### PR TITLE
feat(build): concat all src files into app.js and transpile them as SystemJS

### DIFF
--- a/addon/ng2/blueprints/ng2/files/src/index.html
+++ b/addon/ng2/blueprints/ng2/files/src/index.html
@@ -10,6 +10,7 @@
 </head>
 <body>
 <<%= htmlComponentName %>-app>Loading...</<%= htmlComponentName %>-app>
+<script src="app.js"></script>
 <script>
     System.import('<%= htmlComponentName %>');
 </script>

--- a/lib/broccoli/angular2-app.js
+++ b/lib/broccoli/angular2-app.js
@@ -3,6 +3,7 @@ var configReplace = require('./broccoli-config-replace');
 var mergeTrees = require('broccoli-merge-trees');
 var Funnel = require('broccoli-funnel');
 var Project = require('ember-cli/lib//models/project');
+var Concat = require('broccoli-concat');
 
 module.exports = Angular2App;
 
@@ -25,7 +26,7 @@ Angular2App.prototype.toTree = function () {
         sourceMap: true,
         sourceRoot: '.',
         target: 'ES5',
-        module: 'commonjs'
+        module: 4 /* System */
     });
 
     var jsTree = new Funnel(sourceTree, {
@@ -43,7 +44,15 @@ Angular2App.prototype.toTree = function () {
         allowEmpty: true
     });
 
-    return mergeTrees([tsTree, jsTree, cssTree, htmlTree, this.index()], { overwrite: true });
+    var appJs = new Concat(mergeTrees([tsTree, jsTree]), {
+        inputFiles: [
+            '*.js',
+            '**/*.js'
+        ],
+        outputFile: '/app.js'
+    });
+
+    return mergeTrees([appJs, cssTree, htmlTree, this.index()], { overwrite: true });
 };
 
 /**

--- a/lib/broccoli/broccoli-typescript.js
+++ b/lib/broccoli/broccoli-typescript.js
@@ -33,6 +33,11 @@ var DiffingTSCompiler = (function () {
         this.tsServiceHost = new CustomLanguageServiceHost(this.tsOpts, this.rootFilePaths, this.fileRegistry, this.inputPath);
         this.tsService = ts.createLanguageService(this.tsServiceHost, ts.createDocumentRegistry());
     }
+    DiffingTSCompiler.prototype.addSystemJsModule = function (name, content) {
+        name = name.split('.tmp').pop().substring(1);
+        name = name.substring(0, name.length - 3);
+        return content.replace('System.register(', 'System.register("' + name + '", ');
+    };
     DiffingTSCompiler.prototype.rebuild = function (treeDiff) {
         var _this = this;
         var pathsToEmit = [];
@@ -61,7 +66,7 @@ var DiffingTSCompiler = (function () {
         }
         else {
             pathsToEmit.forEach(function (tsFilePath) {
-                var output = _this.tsService.getEmitOutput(tsFilePath);
+                var output = _this.tsService.getEmitOutput(tsFilePath); // System.register
                 if (output.emitSkipped) {
                     var errorFound = _this.collectErrors(tsFilePath);
                     if (errorFound) {
@@ -73,7 +78,8 @@ var DiffingTSCompiler = (function () {
                     output.outputFiles.forEach(function (o) {
                         var destDirPath = path.dirname(o.name);
                         fse.mkdirsSync(destDirPath);
-                        fs.writeFileSync(o.name, o.text, FS_OPTS);
+                        //console.log(o.name, o.text)
+                        fs.writeFileSync(o.name, _this.addSystemJsModule(o.name, o.text), FS_OPTS);
                     });
                 }
             });
@@ -108,10 +114,12 @@ var DiffingTSCompiler = (function () {
         }
     };
     DiffingTSCompiler.prototype.doFullBuild = function () {
+        var _this = this;
         var program = this.tsService.getProgram();
         var emitResult = program.emit(undefined, function (absoluteFilePath, fileContent) {
+            //console.log('absoluteFilePath', absoluteFilePath, fileContent);
             fse.mkdirsSync(path.dirname(absoluteFilePath));
-            fs.writeFileSync(absoluteFilePath, fileContent, FS_OPTS);
+            fs.writeFileSync(absoluteFilePath, _this.addSystemJsModule(absoluteFilePath, fileContent), FS_OPTS);
         });
         if (emitResult.emitSkipped) {
             var allDiagnostics = ts.getPreEmitDiagnostics(program).concat(emitResult.diagnostics);

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "resolve": "^1.0.0",
     "silent-error": "^1.0.0",
     "symlink-or-copy": "^1.0.1",
-    "typescript": "^1.5.0-beta"
+    "typescript": "^1.5.3"
   },
   "ember-addon": {
     "paths": [


### PR DESCRIPTION
Now, source files all get concatenated as `app.js` in the dist folder, and that gets loaded in the index.html.

We will do the same thing for vendors, concatenated as `vendor.js`.