### PR TITLE
docs(readme): add node 4 as a prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ This projects is very much still a work in progress.
 We still have a long way before getting out of our alpha stage.
 If you wish to collaborate while the project is still young, checkout [our list issues](https://github.com/angular/angular-cli/issues).
 
+## Prerequisites
+
+The generated project has dependencies that require **Node 4 or greater**.
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
The cli generates the project properly with older node versions but angular-cli-github-pages needs
node v4 so ng serve fails on older node versions. Make this dependency explicit so that people
aren't confused.

Closes #38