### PR TITLE
fix(test): allow dash/underscore separated names

### DIFF
--- a/addon/ng2/blueprints/ng2/files/karma-test-shim.js
+++ b/addon/ng2/blueprints/ng2/files/karma-test-shim.js
@@ -37,7 +37,7 @@ System.import('angular2/src/core/dom/browser_adapter').then(function(browser_ada
 });
 
 function onlyAppFiles(filePath) {
-  return /^\/base\/dist\/app\/(?!spec)([a-z0-9]+)\.js$/.test(filePath);
+  return /^\/base\/dist\/app\/(?!spec)([a-z0-9-_]+)\.js$/.test(filePath);
 }
 
 function onlySpecFiles(path) {


### PR DESCRIPTION
issue was found whenever creating projects with names like: 'project-2' or
'project_2' Karma weren't able to find the app files.

@IgorMinar can you review?