### PR TITLE
docs(readme): add ember-cli as part of the initial installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The generated project has dependencies that require **Node 4 or greater**.
 
 ```bash
 npm install -g angular-cli
+npm install -g ember-cli 
 ```
 
 ## Usage


### PR DESCRIPTION
Ember has to be installed globally. We make this dependency explicit so that people
aren't confused.