### PR TITLE
fix(test): removed favicon, was breaking re-init unit test

### DIFF
--- a/tests/acceptance/init.spec.js
+++ b/tests/acceptance/init.spec.js
@@ -124,19 +124,22 @@ describe('Acceptance: ng init', function() {
     });
 
     it('init an already init\'d folder', function() {
+      return ng([
+        'init',
+        '--skip-npm',
+        '--skip-bower'
+      ])
+      .then(function(){
+        Blueprint.ignoredFiles.push('favicon.ico');
+      })
+      .then(function() {
         return ng([
-            'init',
-            '--skip-npm',
-            '--skip-bower'
-        ])
-            .then(function() {
-                return ng([
-                    'init',
-                    '--skip-npm',
-                    '--skip-bower'
-                ]);
-            })
-            .then(confirmBlueprinted);
+          'init',
+          '--skip-npm',
+          '--skip-bower'
+        ]);
+      })
+      .then(confirmBlueprinted);
     });
 
     it('init a single file', function() {


### PR DESCRIPTION
fixes #75 

Apparently the binary nature of the favicon.ico file was causing an issue when templates were being processed.