### PR TITLE
chore: upgrade to 2.0.0-alpha52

### DIFF
--- a/addon/ng2/blueprints/ng2/files/package.json
+++ b/addon/ng2/blueprints/ng2/files/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "systemjs": "0.19.4",
-    "angular2": "2.0.0-alpha.48"
+    "angular2": "2.0.0-alpha.52"
   },
   "devDependencies": {
     "angular-cli": "0.0.*",


### PR DESCRIPTION
After bumping Angular version I'm having this TypeScript issue in the generated project:

![screen shot 2015-12-10 at 8 42 21 am](https://cloud.githubusercontent.com/assets/469908/11713399/4f37a68c-9f1a-11e5-8644-087ba69e0efd.png)

Even after trying to reference the manual typings the issue persists.

https://github.com/angular/angular/issues/5596 should be related.
