### PR TITLE
fix(build): remove non existent bundle and fix RxJS path

### DIFF
--- a/lib/broccoli/angular2-app.js
+++ b/lib/broccoli/angular2-app.js
@@ -40,8 +40,7 @@ Angular2App.prototype.toTree = function () {
         'angular2/bundles/angular2.dev.js',
         'angular2/bundles/http.dev.js',
         'angular2/bundles/router.dev.js',
-        'angular2/bundles/upgrade.dev.js',
-        'rxjs/bundles/Rx.js',
+        'rxjs/Rx.js',
         'systemjs/dist/system.src.js'
       ],
       destDir: 'vendor'


### PR DESCRIPTION
Current build is broken:
![screen shot 2015-12-15 at 12 45 45 pm](https://cloud.githubusercontent.com/assets/469908/11814165/7433941c-a32c-11e5-96e8-ed4eb46fa13b.png)

This PR fixes it.