### PR TITLE
feat(angular2-app): allow to easily add vendor files

### DIFF
--- a/addon/ng2/blueprints/ng2/files/ember-cli-build.js
+++ b/addon/ng2/blueprints/ng2/files/ember-cli-build.js
@@ -3,6 +3,8 @@
 var Angular2App = require('angular-cli/lib/broccoli/angular2-app');
 
 module.exports = function(defaults) {
-  var app = new Angular2App(defaults);
+  var app = new Angular2App(defaults, {
+    vendorFiles: []
+  });
   return app.toTree();
 }

--- a/lib/broccoli/angular2-app.js
+++ b/lib/broccoli/angular2-app.js
@@ -11,10 +11,26 @@ module.exports = Angular2App;
 function Angular2App(defaults, options) {
     this._initProject();
     this._notifyAddonIncluded();
+    this.options = options;
 }
 
-Angular2App.prototype.toTree = function () {
+Angular2App.prototype.toTree = function() {
     var sourceTree = 'src';
+    var vendorNpmFiles = [
+      'angular2/bundles/angular2-polyfills.js',
+      'angular2/bundles/angular2.dev.js',
+      'angular2/bundles/http.dev.js',
+      'angular2/bundles/router.dev.js',
+      'angular2/bundles/upgrade.dev.js',
+      'es6-shim/es6-shim.js',
+      'rxjs/bundles/Rx.js',
+      'systemjs/dist/system.src.js',
+      'systemjs/dist/system-polyfills.js'
+    ];
+    
+    if (this.options.vendorNpmFiles) {
+      vendorNpmFiles = vendorNpmFiles.concat(this.options.vendorNpmFiles);
+    }
 
     var tsConfigCompilerOptions = JSON.parse(fs.readFileSync('src/tsconfig.json', 'utf-8')).compilerOptions;
     var tsTree = compileWithTypescript(sourceTree, tsConfigCompilerOptions);
@@ -33,19 +49,9 @@ Angular2App.prototype.toTree = function () {
         exclude: ['**/*.ts', '**/*.js', 'src/tsconfig.json'],
         allowEmpty: true
     });
-
-    var vendorJsTree = new Funnel('node_modules', {
-      files: [
-        'angular2/bundles/angular2-polyfills.js',
-        'angular2/bundles/angular2.dev.js',
-        'angular2/bundles/http.dev.js',
-        'angular2/bundles/router.dev.js',
-        'angular2/bundles/upgrade.dev.js',
-        'es6-shim/es6-shim.js',
-        'rxjs/bundles/Rx.js',
-        'systemjs/dist/system.src.js',
-        'systemjs/dist/system-polyfills.js'
-      ],
+    
+    var vendorNpmTree = new Funnel('node_modules', {
+      files: vendorNpmFiles,
       destDir: 'vendor'
     });
 
@@ -73,7 +79,7 @@ Angular2App.prototype.toTree = function () {
       tsTree, 
       jsTree, 
       this.index(), 
-      vendorJsTree,
+      vendorNpmTree,
       thirdPartyJs
     ], { overwrite: true });
 };


### PR DESCRIPTION
to be able to easily add vendor files in generated projects:

```js
var Angular2App = require('angular-cli/lib/broccoli/angular2-app');

module.exports = function(defaults) {
  var app = new Angular2App(defaults, {
    vendorFiles: ['material-design-lite/material.css']
  });
  return app.toTree();
}
```