### PR TITLE
chore(gitignore): add .idea to gitignore

### DIFF
--- a/addon/ng2/blueprints/ng2/files/gitignore
+++ b/addon/ng2/blueprints/ng2/files/gitignore
@@ -8,6 +8,9 @@
 /node_modules
 /bower_components
 
+# IDEs and editors
+/.idea
+
 # misc
 /.sass-cache
 /connect.lock


### PR DESCRIPTION
Add `/.idea` to the `.gitignore` under a section "IDEs and editors". Without this, WebStorm WebStorm / IntelliJ will keep prompting you if you want to add project files to git and also show them as "unrevisioned files" in the "Local changes" view.