### PR TITLE
README.md License section changed to MIT

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ and the [npm-link cheatsheet](http://browsenpm.org/help#linkinganynpmpackageloca
 
 ## License
 
-Apache v2
+MIT
 
 
 [travis-badge]: https://travis-ci.org/angular/angular-cli.svg?branch=master


### PR DESCRIPTION
Small change, @naomiblack switched the license to MIT in 849698d369d71a5674bdca042fbec9de0c2ecac4 but the README said Apache 2.0