### PR TITLE
fix(commands): ember-cli branding leaks through many error messages a…

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,6 @@ This project is currently a prototype so there are many known issues. Just to me
 - On Windows you need to run the `build` and `serve` commands with Admin permissions, otherwise the performance is not good.
 - [Protractor](https://angular.github.io/protractor/) integration is missing.
 - The initial installation as well as `ng new` take too long because of lots of npm dependencies.
-- "ember" branding leaks through many error messages and help text.
 - Many existing ember addons are not compatible with Angular apps built via angular-cli.
 
 

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -3,10 +3,30 @@ var path = require('path');
 var fs   = require('fs');
 
 module.exports = function (options) {
-    options.cli = {
-        name: 'ng',
-        root: path.join(__dirname, '..', '..'),
-        npmPackage: 'angular-cli'
-    };
-    return cli(options);
+  process.stdout.write = (function(write) {
+    return function(string, encoding, fd) {
+      if (/version:/.test(string) || /warning:/.test(string)) {
+        return;
+      }
+      string = string.replace(/ember-cli/g, 'angular-cli');
+      string = string.replace(/ember/g, 'ng');
+      write.apply(process.stdout, arguments)
+    }
+  })(process.stdout.write);
+
+  process.stderr.write = (function(write) {
+    return function(string, encoding, fd) {
+      string = string.replace(/ember-cli/g, 'angular-cli');
+      string = string.replace(/ember/g, 'ng');
+      write.apply(process.stdout, arguments)
+    }
+  })(process.stderr.write);
+    
+  options.cli = {
+    name: 'ng',
+    root: path.join(__dirname, '..', '..'),
+    npmPackage: 'angular-cli'
+  };
+    
+  return cli(options);
 };


### PR DESCRIPTION
Prevent `ember-cli` version message on every executed command. Also applies on warning when overriding core `ember-cli` commands and replaces all `ember` output strings with `ng`. 
That was a known issue and I removed it from README.md.