### PR TITLE
feat(): add typings to the blueprints.

### DIFF
--- a/addon/ng2/blueprints/ng2/files/gitignore
+++ b/addon/ng2/blueprints/ng2/files/gitignore
@@ -18,7 +18,9 @@
 /libpeerconnection.log
 npm-debug.log
 testem.log
+/typings/
 
 # e2e
 /e2e/*.js
 /e2e/*.map
+

--- a/addon/ng2/blueprints/ng2/files/package.json
+++ b/addon/ng2/blueprints/ng2/files/package.json
@@ -8,25 +8,31 @@
       "playSound": false
     }
   },
+  "scripts": {
+    "start": "ng server",
+    "postinstall": "typings install --ambient"
+  },
   "private": true,
   "dependencies": {
-    "angular2": "2.0.0-beta.0",
+    "angular2": "2.0.0-beta.3",
     "es6-promise": "^3.0.2",
     "es6-shim": "^0.33.3",
     "reflect-metadata": "0.1.2",
     "rxjs": "5.0.0-beta.0",
     "systemjs": "0.19.4",
-    "zone.js": "0.5.10"
+    "zone.js": "0.5.11"
   },
   "devDependencies": {
     "angular-cli": "0.0.*",
     "angular-cli-github-pages": "^0.2.0",
     "ember-cli-inject-live-reload": "^1.3.0",
+    "glob": "^6.0.4",
     "jasmine-core": "^2.3.4",
     "karma": "^0.13.15",
     "karma-chrome-launcher": "^0.2.1",
     "karma-jasmine": "^0.3.6",
     "protractor": "^3.0.0",
-    "typescript": "^1.7.3"
+    "typescript": "^1.7.3",
+    "typings": "^0.6.6"
   }
 }

--- a/addon/ng2/blueprints/ng2/files/src/tsconfig.json
+++ b/addon/ng2/blueprints/ng2/files/src/tsconfig.json
@@ -1,16 +1,1 @@
-{
-  "compilerOptions": {
-    "declaration": false,
-    "emitDecoratorMetadata": true,
-    "experimentalDecorators": true,
-    "mapRoot": "",
-    "module": "system",
-    "moduleResolution": "node",
-    "noEmitOnError": true,
-    "noImplicitAny": false,
-    "rootDir": ".",
-    "sourceMap": true,
-    "sourceRoot": "/",
-    "target": "es5"
-  }
-}
+../tsconfig.json

--- a/addon/ng2/blueprints/ng2/files/tsconfig.json
+++ b/addon/ng2/blueprints/ng2/files/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "declaration": false,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "mapRoot": "",
+    "module": "system",
+    "moduleResolution": "node",
+    "noEmitOnError": true,
+    "noImplicitAny": false,
+    "outDir": "../dist/",
+    "rootDir": ".",
+    "sourceMap": true,
+    "sourceRoot": "/",
+    "target": "es5"
+  },
+  "exclude": [
+    "e2e/",
+    "node_modules/",
+    "typings/main",
+    "typings/main.d.ts"
+  ]
+}

--- a/addon/ng2/blueprints/ng2/files/typings.json
+++ b/addon/ng2/blueprints/ng2/files/typings.json
@@ -1,0 +1,10 @@
+{
+  "dependencies": {},
+  "devDependencies": {
+  },
+  "ambientDevDependencies": {
+    "jasmine": "github:DefinitelyTyped/DefinitelyTyped/jasmine/jasmine.d.ts#26c98c8a9530c44f8c801ccc3b2057e2101187ee"
+  },
+  "ambientDependencies": {
+  }
+}

--- a/lib/broccoli/angular2-app.js
+++ b/lib/broccoli/angular2-app.js
@@ -1,7 +1,9 @@
+var path = require('path');
 var Concat = require('broccoli-concat');
 var configReplace = require('./broccoli-config-replace');
 var compileWithTypescript = require('./broccoli-typescript').default;
 var fs = require('fs');
+var glob = require('glob');
 var Funnel = require('broccoli-funnel');
 var mergeTrees = require('broccoli-merge-trees');
 var Project = require('ember-cli/lib/models/project');
@@ -32,7 +34,25 @@ Angular2App.prototype.toTree = function() {
       vendorNpmFiles = vendorNpmFiles.concat(this.options.vendorNpmFiles);
     }
 
-    var tsConfigCompilerOptions = JSON.parse(fs.readFileSync('src/tsconfig.json', 'utf-8')).compilerOptions;
+    var tsConfig = JSON.parse(fs.readFileSync('tsconfig.json', 'utf-8'));
+    var tsConfigCompilerOptions = tsConfig.compilerOptions;
+
+    // `rootFilesPath` is used by the broccoli-typescript to add files to the compilation.
+    // It is _not_ part of the `tsconfig.json` spec, so it won't be found in
+    // tsConfigCompilerOptions. This adds the typings manually to the compilation step.
+    // We pass in all files except those that matches excluded paths.
+    var exclude = tsConfig.exclude || [];
+    var files = glob.sync('**/*.ts');
+    tsConfigCompilerOptions.rootFilePaths = files
+      .filter(function(x) {
+        // Remove those who start with paths in the tsconfig exclude list.
+        return !exclude.some(function(y) { return x.startsWith(y); });
+      })
+      .map((function(x) {
+        // Map them around the current working directory.
+        return path.join(process.cwd(), x);
+      }));
+
     var tsTree = compileWithTypescript(sourceTree, tsConfigCompilerOptions);
     var tsSrcTree = new Funnel(sourceTree, {
       include: ['**/*.ts'],
@@ -46,7 +66,7 @@ Angular2App.prototype.toTree = function() {
 
     var assetTree = new Funnel(sourceTree, {
         include: ['**/*.*'],
-        exclude: ['**/*.ts', '**/*.js', 'src/tsconfig.json'],
+        exclude: ['**/*.ts', '**/*.js'],
         allowEmpty: true
     });
 


### PR DESCRIPTION
Simply add typings to the blueprints, and use the browser ones in `tsconfig`.

This should get the upgrade to angular beta.2 unblocked.