### PR TITLE
fix(vendor): fixed broccoli concat for vendor files

### DIFF
--- a/addon/ng2/blueprints/ng2/files/ember-cli-build.js
+++ b/addon/ng2/blueprints/ng2/files/ember-cli-build.js
@@ -4,7 +4,7 @@ var Angular2App = require('angular-cli/lib/broccoli/angular2-app');
 
 module.exports = function(defaults) {
   var app = new Angular2App(defaults, {
-    vendorFiles: []
+    vendorNpmFiles: []
   });
   return app.toTree();
 }

--- a/lib/broccoli/angular2-app.js
+++ b/lib/broccoli/angular2-app.js
@@ -4,7 +4,7 @@ var compileWithTypescript = require('./broccoli-typescript').default;
 var fs = require('fs');
 var Funnel = require('broccoli-funnel');
 var mergeTrees = require('broccoli-merge-trees');
-var Project = require('ember-cli/lib//models/project');
+var Project = require('ember-cli/lib/models/project');
 
 module.exports = Angular2App;
 
@@ -17,10 +17,10 @@ function Angular2App(defaults, options) {
 Angular2App.prototype.toTree = function() {
     var sourceTree = 'src';
     var vendorNpmFiles = [
-      'es6-shim/es6-shim.js',
       'systemjs/dist/system-polyfills.js',
-      'angular2/bundles/angular2-polyfills.js',
       'systemjs/dist/system.src.js',
+      'es6-shim/es6-shim.js',
+      'angular2/bundles/angular2-polyfills.js',
       'rxjs/bundles/Rx.js',
       'angular2/bundles/angular2.dev.js',
       'angular2/bundles/http.dev.js',
@@ -55,18 +55,12 @@ Angular2App.prototype.toTree = function() {
       destDir: 'vendor'
     });
 
+    var vendorNpmInputFiles = vendorNpmFiles.map(function(file) {
+      return '**/' + file.substr(file.lastIndexOf('/') + 1);
+    });
+
     var vendorNpmJs = new Concat(vendorNpmTree, {
-      inputFiles: [ //TODO: figure out how to make it a glob that maintains the order of the files
-        '**/system-polyfills.js',
-        '**/system.src.js',
-        '**/es6-shim.js',
-        '**/angular2-polyfills.js',
-        '**/Rx.js',
-        '**/angular2.dev.js',
-        '**/http.dev.js',
-        '**/router.dev.js',
-        '**/upgrade.dev.js'
-      ],
+      inputFiles: vendorNpmInputFiles,
       outputFile: '/thirdparty/vendor.js'
     });
 
@@ -80,14 +74,6 @@ Angular2App.prototype.toTree = function() {
       outputFile: '/thirdparty/libs.js',
       allowNone: true
     });
-
-    // var appJs = new Concat(mergeTrees([tsTree, jsTree]), {
-    //     inputFiles: [
-    //         '*.js',
-    //         '**/*.js'
-    //     ],
-    //     outputFile: '/app.js'
-    // });
 
     return mergeTrees([
       assetTree,


### PR DESCRIPTION
Fixed Broccoli concatenation of vendor files without listing them again. 

Also nice solution from @cironunes to easily add vendor files now works properly. Custom vendor files are added at the bottom of `vendor.js` in th order that we listed them.
Example of adding vendor file in our project
````js
// ember-cli-build.js
vendorNpmFiles: ['moment/moment.js']
````