### PR TITLE
fix(routes): fix providers for route unit tests

### DIFF
--- a/addon/ng2/blueprints/route/files/src/app/__name__/__name__-detail.component.spec.ts
+++ b/addon/ng2/blueprints/route/files/src/app/__name__/__name__-detail.component.spec.ts
@@ -9,12 +9,30 @@ import {
   TestComponentBuilder,
   beforeEachProviders
 } from 'angular2/testing';
-import {provide} from 'angular2/core';
+import {bind} from 'angular2/core';
 import {<%= classifiedModuleName %>DetailComponent} from './<%= dasherizedModuleName %>-detail.component';
+import {Router, RouteParams} from 'angular2/router';
+import {<%= classifiedModuleName %>, <%= classifiedModuleName %>Service} from './<%= dasherizedModuleName %>.service';
+
+class Mock<%= classifiedModuleName %>Service {
+  get() { return Promise.resolve(new <%= classifiedModuleName %>(1, 'one')); }
+}
+
+class MockRouter {
+  navigate() { }
+}
+
+class MockRouteParams {
+  get() { return 1; }
+}
 
 describe('<%= classifiedModuleName %>DetailComponent', () => {
 
-  beforeEachProviders(() => []);
+  beforeEachProviders(() => [
+    bind(<%= classifiedModuleName %>Service).toValue(new Mock<%= classifiedModuleName %>Service()),
+    bind(Router).toValue(new MockRouter()),
+    bind(RouteParams).toValue(new MockRouteParams()),
+  ]);
 
   it('should ...', injectAsync([TestComponentBuilder], (tcb:TestComponentBuilder) => {
     return tcb.createAsync(<%= classifiedModuleName %>DetailComponent).then((fixture) => {

--- a/addon/ng2/blueprints/route/files/src/app/__name__/__name__-list.component.spec.ts
+++ b/addon/ng2/blueprints/route/files/src/app/__name__/__name__-list.component.spec.ts
@@ -9,12 +9,19 @@ import {
   TestComponentBuilder,
   beforeEachProviders
 } from 'angular2/testing';
-import {provide} from 'angular2/core';
+import {bind} from 'angular2/core';
 import {<%= classifiedModuleName %>ListComponent} from './<%= dasherizedModuleName %>-list.component';
+import {<%= classifiedModuleName %>, <%= classifiedModuleName %>Service} from './<%= dasherizedModuleName %>.service';
+
+class Mock<%= classifiedModuleName %>Service {
+  getAll() { return Promise.resolve([new <%= classifiedModuleName %>(1, 'one')]); }
+}
 
 describe('<%= classifiedModuleName %>ListComponent', () => {
 
-  beforeEachProviders(() => []);
+  beforeEachProviders(() => [
+    bind(<%= classifiedModuleName %>Service).toValue(new Mock<%= classifiedModuleName %>Service()),
+  ]);
 
   it('should ...', injectAsync([TestComponentBuilder], (tcb:TestComponentBuilder) => {
     return tcb.createAsync(<%= classifiedModuleName %>ListComponent).then((fixture) => {


### PR DESCRIPTION
Fix broken providers in unit tests for generated routes.

/cc @Brocco 