### PR TITLE
fix(tests): link package in e2e tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.30.1/install.sh | bash; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then source ~/.nvm/nvm-exec; fi
   - nvm install $NODE_VERSION
-  - npm link npm
   - npm config set spin false
 install:
   - node --version

--- a/addon/ng2/utilities/shell-promise.js
+++ b/addon/ng2/utilities/shell-promise.js
@@ -1,0 +1,16 @@
+/* jshint node: true */
+'use strict';
+
+var Promise = require('ember-cli/lib/ext/promise');
+var sh = require('shelljs');
+
+module.exports = function shellPromise(command) {
+  return new Promise(function(resolve, reject) {
+    return sh.exec(command, {
+      silent: true
+    }, function(code, stdout, stderr) {
+      if (code !== 0) reject(stderr);
+      else resolve(stdout);
+    });
+  });
+};

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "node-notifier": "^4.4.0",
     "resolve": "^1.0.0",
     "silent-error": "^1.0.0",
+    "shelljs": "^0.5.3",
     "symlink-or-copy": "^1.0.1",
     "typescript": "~1.7.3",
     "typings": "^0.6.2"
@@ -60,7 +61,6 @@
     "minimatch": "^2.0.10",
     "mocha": "^2.2.5",
     "rewire": "^2.3.4",
-    "shelljs": "^0.5.3",
     "through": "^2.3.8",
     "walk-sync": "^0.2.6"
   }

--- a/tests/e2e/e2e_workflow.spec.js
+++ b/tests/e2e/e2e_workflow.spec.js
@@ -18,11 +18,10 @@ describe('Basic end-to-end Workflow', function () {
   it('Installs angular-cli correctly', function() {
     this.timeout(300000);
 
+    sh.exec('npm link', {silent: true});
     return tmp.setup('./tmp')
       .then(function () {
         process.chdir('./tmp');
-
-        sh.exec('npm i angular-cli -g -C ' + process.cwd(), { silent: true });
         expect(fs.existsSync(path.join(process.cwd(), 'bin', 'ng')));
       });
   });
@@ -40,7 +39,9 @@ describe('Basic end-to-end Workflow', function () {
   });
 
   it('Can change current working directory to `test-project`', function() {
+    this.timeout(300000);
     process.chdir(path.join(root, 'test-project'));
+    sh.exec('npm link angular-cli', {silent: true});
     expect(path.basename(process.cwd())).to.equal('test-project');
   });
 


### PR DESCRIPTION
Close #194

This issue proved to be harder to fix than it initially looked like.

Running `npm link` did not seem to work, due to `npm` itself being local as per the `npm link npm` command in `.travis.yml`.

Removing `npm link npm` caused the tests to file in a [spectacular fashion](https://travis-ci.org/angular/angular-cli/builds/108998425). 

`npm4` builds fail because `ng install` tests report a missing package - `npm` itself. This seems to have been what originated the inclusion of `npm link npm` in `.travis.yml`. Also related, https://github.com/angular/angular-cli/issues/185#issuecomment-182635747.

`npm5` builds fail in a much more confusing way. 

Linking `angular-cli` shows a couple of warnings about npm packages that aren't part of `angular-cli` nor are present in npm4 builds:

```
npm WARN prefer global marked@0.3.5 should be installed with -g
npm WARN prefer global npm@2.14.10 should be installed with -g
```

There is also a weird stray error during the `ng new` test, that seems to be responsible for for `ng new` failing:

```
Error: ENOENT: no such file or directory, open '/home/travis/build/angular/angular-cli/tmp/foo/package.json'
    at Error (native)
```

The e2e build tests fail with missing core packages that should have been installed in in the initial `ng new test-project` (that seems to fail):

```
  app.ts (1, 25): Cannot find module 'angular2/platform/browser'.
  app.ts (3, 32): Cannot find module 'angular2/router'.
  app/test-project.spec.ts (1, 65): Cannot find module 'angular2/testing'.
  app/test-project.ts (1, 25): Cannot find module 'angular2/core'.
  app/test-project.ts (2, 46): Cannot find module 'angular2/router'.
```

I tried removing the acceptance tests for `ng install` and `ng uninstall` and the [resulting build](https://travis-ci.org/angular/angular-cli/builds/109000126) seems to pass every test, correctly linking the existing `angular-cli` and succeding and bulding the generated project, typings included.

This seems to indicate that either the `ng install` and `ng uninstall` acceptance tests or the commands themselves break subsequent tests.

I found two references to the instability of using the `npm` module programatically: [one on stack overflow](http://stackoverflow.com/questions/15957529/can-i-install-a-npm-package-from-javascript-running-in-node-js) and [one on ember-cli](https://github.com/ember-cli/ember-cli/blob/master/lib/utilities/npm.js#L10-L12).

This prompted me to change the `ng install` and `ng uninstall` code to use `shelljs` to run `npm install/uninstall` commands instead using npm programatically as before. That seems to have fixed the weird interactions between their acceptance tests and the e2e tests.

/cc @hansl @jkuri @Brocco 