### PR TITLE
fix(service blueprint): Prevent unwanted ember service test generation

### DIFF
--- a/addon/ng2/blueprints/route-test/index.js
+++ b/addon/ng2/blueprints/route-test/index.js
@@ -1,0 +1,14 @@
+var stringUtils = require('ember-cli/lib/utilities/string');
+
+module.exports = {
+  description: '',
+  
+  // ******************************************************
+  // ******************************************************
+  // LEAVE THIS HERE
+  // Must override install to prevent ember's route tests
+  // ******************************************************
+  // ******************************************************
+  
+  install: function(options){}
+};

--- a/addon/ng2/blueprints/service-test/index.js
+++ b/addon/ng2/blueprints/service-test/index.js
@@ -1,0 +1,14 @@
+var stringUtils = require('ember-cli/lib/utilities/string');
+
+module.exports = {
+  description: '',
+  
+  // ******************************************************
+  // ******************************************************
+  // LEAVE THIS HERE
+  // Must override install to prevent ember's service tests
+  // ******************************************************
+  // ******************************************************
+  
+  install: function(options){}
+};


### PR DESCRIPTION
The ember-cli generates blueprints for  when generating a new
By overriding  in  it prevents the ember service test generation
Fixes #202