### PR TITLE
chore(tests): Auto run tests after builds

### DIFF
--- a/addon/ng2/commands/build.js
+++ b/addon/ng2/commands/build.js
@@ -1,0 +1,63 @@
+'use strict';
+
+var path    = require('path');
+var Command      = require('ember-cli/lib/models/command');
+var win = require('ember-cli/lib/utilities/windows-admin');
+var BuildCommand = require('ember-cli/lib/commands/build');
+var BuildTask = require('ember-cli/lib/tasks/build');
+var BuildWatchTask = require('ember-cli/lib/tasks/build-watch');
+var TestTask = require('../tasks/test');
+
+module.exports = BuildCommand.extend({
+  name: 'build',
+  description: 'Builds your app and places it into the output path (dist/ by default).',
+  aliases: ['b'],
+
+  availableOptions: [
+    { name: 'environment', type: String,  default: 'development', aliases: ['e', { 'dev': 'development' }, { 'prod': 'production' }] },
+    { name: 'watch',       type: Boolean, default: false,         aliases: ['w'] },
+    { name: 'watcher',     type: String },
+    { name: 'no-test',     type: Boolean, default: false}
+  ],
+  
+  run: function(commandOptions){
+    // outputPath was removed from the avaiableOptions
+    // so it must be set internally
+    commandOptions.outputPath = 'dist/';
+    
+    var BuildTask = this.tasks.Build;
+    var buildTask = new BuildTask({
+      ui: this.ui,
+      analytics: this.analytics,
+      project: this.project
+    });
+    var BuildWatchTask = this.tasks.BuildWatch;
+    var buildWatchTask = new BuildWatchTask({
+      ui: this.ui,
+      analytics: this.analytics,
+      project: this.project
+    });
+    var testTask = new TestTask({
+      ui: this.ui,
+      analytics: this.analytics,
+      project: this.project
+    });
+    
+    if (!commandOptions.noTest) {
+      commandOptions.buildCompleted = function(){
+        return testTask.run({singleRun: true});
+      };
+    }
+    
+    var buildTaskToRun = commandOptions.watch
+      ? buildWatchTask
+      : buildTask;
+    
+    return win.checkWindowsElevation(this.ui)
+      .then(function() {
+        return buildTaskToRun.run(commandOptions);
+      });
+  }
+});
+
+module.exports.overrideCore = true;

--- a/addon/ng2/index.js
+++ b/addon/ng2/index.js
@@ -5,12 +5,13 @@ module.exports = {
   name: 'ng2',
   includedCommands: function() {
     return {
+      'build'     : require('./commands/build'),
       'new'       : require('./commands/new'),
       'init'      : require('./commands/init'),
       'install'   : require('./commands/install'),
       'uninstall' : require('./commands/uninstall'),
       'test'      : require('./commands/test'),
-      'e2e'      : require('./commands/e2e'),
+      'e2e'       : require('./commands/e2e'),
       'lint'      : require('./commands/lint'),
       'format'    : require('./commands/format')
     };


### PR DESCRIPTION
When running `ng build` or `ng build --watch` karma tests are run after builds
`--no-test` swtich to turn it off