### PR TITLE
chore(version): `ng version` outputs the right version

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -1,16 +1,16 @@
-var cli  = require('ember-cli/lib/cli');
-var path = require('path');
-var fs   = require('fs');
+var cli   = require('ember-cli/lib/cli');
+var path  = require('path');
+var fs    = require('fs');
 
 module.exports = function (options) {
   process.stdout.write = (function(write) {
     return function(string, encoding, fd) {
-      if (/version:/.test(string) || /warning:/.test(string)) {
+      if ((/version:/.test(string) || /warning:/.test(string)) && !/angular-cli/.test(string)) {
         return;
       }
       string = string.replace(/ember-cli(?!.com)/g, 'angular-cli');
       string = string.replace(/ember(?!-cli.com)/g, 'ng');
-      write.apply(process.stdout, arguments)
+      write.apply(process.stdout, arguments);
     }
   })(process.stdout.write);
 
@@ -18,9 +18,14 @@ module.exports = function (options) {
     return function(string, encoding, fd) {
       string = string.replace(/ember-cli(?!.com)/g, 'angular-cli');
       string = string.replace(/ember(?!-cli.com)/g, 'ng');
-      write.apply(process.stdout, arguments)
+      write.apply(process.stdout, arguments);
     }
   })(process.stderr.write);
+
+  if (process.argv[2] === '--version' || process.argv[2] === '-v' || process.argv[2] === 'version') {
+    var version = require(path.join(__dirname, '..', '..', 'package.json'), 'utf8').version;
+    console.log('angular-cli version:', version);
+  }
     
   options.cli = {
     name: 'ng',


### PR DESCRIPTION
This fix outputs the current version of `angular-cli`.
Example:
```
[~]$ ng version
angular-cli version: 0.0.23
node: 5.6.0
npm: 2.14.10
os: darwin x64
```