### PR TITLE
chore(test): Allow running of tests in watch mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,9 @@ ng test
 
 Tests will execute after a build is executed via [Karma](http://karma-runner.github.io/0.13/index.html)
 
+If run with the watch argument `--watch` (shorthand `-w`) builds will run when source files have changed 
+and tests will run after each successful build
+
 
 ### Running end-to-end tests
 

--- a/addon/ng2/tasks/build-watch.js
+++ b/addon/ng2/tasks/build-watch.js
@@ -1,0 +1,39 @@
+'use strict';
+
+var chalk    = require('chalk');
+var Task     = require('ember-cli/lib/models/task');
+var Watcher  = require('ember-cli/lib/models/watcher');
+var Builder  = require('ember-cli/lib/models/builder');
+var Promise  = require('ember-cli/lib/ext/promise');
+
+module.exports = Task.extend({
+  run: function(options) {
+    this.ui.startProgress(
+      chalk.green('Building'), chalk.green('.')
+    );
+    
+    var watcher = new Watcher({
+      ui: this.ui,
+      builder: new Builder({
+        ui: this.ui,
+        outputPath: options.outputPath,
+        environment: options.environment,
+        project: this.project
+      }),
+      analytics: this.analytics,
+      options: options
+    });
+    
+    // return the watcher to enable hooking into the build events
+    // return the completion promise to know when this task has ended
+    
+    return {
+      watcher: watcher,
+      completion: watcher.then(function() {
+        // This has been pulled in from the ember-cli build-watch implementation
+        // https://github.com/ember-cli/ember-cli/blob/3ea0ede89adaf1ac2a8b83036e84e792d367e727/lib/tasks/build-watch.js#L15-L27
+        return new Promise(function () {}); // Run until failure or signal to exit
+      })
+    };
+  }
+});


### PR DESCRIPTION
When running `ng test` or `ng test --watch`
karma tests are run after each successful build