### PR TITLE
chore(notifications): revert remaining files

### DIFF
--- a/addon/ng2/blueprints/ng2/files/package.json
+++ b/addon/ng2/blueprints/ng2/files/package.json
@@ -2,12 +2,7 @@
   "name": "<%= htmlComponentName %>",
   "version": "0.0.0",
   "license": "Apache-2.0",
-  "angular-cli": {
-    "notifications": {
-      "enabled": true,
-      "playSound": false
-    }
-  },
+  "angular-cli": {},
   "scripts": {
     "start": "ng server",
     "postinstall": "typings install --ambient",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "fs-extra": "^0.18.4",
     "leek": "0.0.19",
     "lodash": "^3.10.0",
-    "node-notifier": "^4.4.0",
     "resolve": "^1.0.0",
     "shelljs": "^0.5.3",
     "silent-error": "^1.0.0",


### PR DESCRIPTION
In #214, the main notification functionality was removed
due to it being in a auto-generated file.

This PR removes the remainder code that was left in from #134.

The `angular-cli` property in generated `package.json` is left in
since that was the place agreed for further configuration.

/cc @jkuri @hansl 