### PR TITLE
fix(e2e): add typings detection

### DIFF
--- a/addon/ng2/blueprints/ng2/files/e2e/app.e2e.ts
+++ b/addon/ng2/blueprints/ng2/files/e2e/app.e2e.ts
@@ -1,5 +1,3 @@
-/// <reference path="../typings/main.d.ts" />
-
 import { <%= jsComponentName %>Page } from './app.po';
 
 describe('<%= htmlComponentName %> App', function() {

--- a/addon/ng2/blueprints/ng2/files/e2e/tsconfig.json
+++ b/addon/ng2/blueprints/ng2/files/e2e/tsconfig.json
@@ -4,7 +4,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "mapRoot": "",
-    "module": "system",
+    "module": "commonjs",
     "moduleResolution": "node",
     "noEmitOnError": true,
     "noImplicitAny": false,

--- a/addon/ng2/blueprints/ng2/files/e2e/typings.d.ts
+++ b/addon/ng2/blueprints/ng2/files/e2e/typings.d.ts
@@ -1,0 +1,1 @@
+/// <reference path="../typings/main.d.ts" />

--- a/addon/ng2/blueprints/ng2/files/protractor.conf.js
+++ b/addon/ng2/blueprints/ng2/files/protractor.conf.js
@@ -18,7 +18,9 @@ exports.config = {
   },
   useAllAngular2AppRoots: true,
   beforeLaunch: function() {
-    require('ts-node/register');
+    require('ts-node').register({
+      project: 'e2e'
+    });
   },
   onPrepare: function() {
     jasmine.getEnv().addReporter(new SpecReporter());


### PR DESCRIPTION
By configuring `ts-node` with the project location, it is no
longer necessary to reference typings at the top of files.