### PR TITLE
feat(unit-tests): add systemjs TS compilation

### DIFF
--- a/addon/ng2/blueprints/ng2/files/karma-test-shim.js
+++ b/addon/ng2/blueprints/ng2/files/karma-test-shim.js
@@ -5,43 +5,46 @@ jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000;
 __karma__.loaded = function() {};
 
 System.config({
+  transpiler: 'typescript',
+  typescriptOptions: {
+    emitDecoratorMetadata: true
+  },
   packages: {
-    'base/dist/app': {
-      defaultExtension: false,
-      format: 'register',
-      map: Object.keys(window.__karma__.files)
-        .filter(onlyAppFiles)
-        .reduce(function(pathsMapping, appPath) {
-          var moduleName = appPath.replace(/^\/base\/dist\/app\//, './').replace(/\.js$/, '');
-          pathsMapping[moduleName] = appPath + '?' + window.__karma__.files[appPath]
-        return pathsMapping;
-      }, {})
+    'app/': {
+      defaultExtension: 'ts'
     }
   }
 });
 
-System.import('angular2/testing').then(function(testing) {
-  return System.import('angular2/platform/testing/browser').then(function(providers) {
-    testing.setBaseTestProviders(providers.TEST_BROWSER_PLATFORM_PROVIDERS,
-                                 providers.TEST_BROWSER_APPLICATION_PROVIDERS);
-  });
-}).then(function() {
-  return Promise.all(
-    Object.keys(window.__karma__.files)
+System.import('angular2/testing')
+  .then(function(testing) {
+    return System.import('angular2/platform/testing/browser')
+      .then(function(providers) {
+        testing.setBaseTestProviders(providers.TEST_BROWSER_PLATFORM_PROVIDERS,
+          providers.TEST_BROWSER_APPLICATION_PROVIDERS);
+      });
+  })
+  .then(function() {
+    return Promise.all(
+      Object.keys(window.__karma__.files)
       .filter(onlySpecFiles)
+      .map(removePathPrefix)
       .map(function(moduleName) {
-        return System.import(moduleName);
+        return System.import(moduleName)
+          .catch(console.error.bind(console));
       }));
-}).then(function() {
-  __karma__.start();
-}, function(error) {
-  __karma__.error(error.stack || error);
-});
-
-function onlyAppFiles(filePath) {
-  return /^\/base\/dist\/app\/(?!.*\.spec\.js$)([a-z0-9-_\.\/]+)\.js$/.test(filePath);
-}
+  })
+  .then(function() {
+    __karma__.start();
+  })
+  .catch(function() {
+    __karma__.error(error.stack || error);
+  });
 
 function onlySpecFiles(path) {
-  return /\.spec\.js$/.test(path);
+  return /\.spec\.ts$/.test(path);
+}
+
+function removePathPrefix(path) {
+  return path.replace(/\/base\/src\/app/, '/app');
 }

--- a/addon/ng2/blueprints/ng2/files/karma.conf.js
+++ b/addon/ng2/blueprints/ng2/files/karma.conf.js
@@ -14,34 +14,26 @@ module.exports = function(config) {
       },
     },
     files: [
-      {pattern: 'node_modules/systemjs/dist/system-polyfills.js', included: true, watched: true},
-      {pattern: 'node_modules/systemjs/dist/system.src.js', included: true, watched: true},
       {pattern: 'node_modules/es6-shim/es6-shim.js', included: true, watched: true},
+      {pattern: 'node_modules/systemjs/dist/system-polyfills.js', included: true, watched: true},
       {pattern: 'node_modules/angular2/bundles/angular2-polyfills.js', included: true, watched: true},
+      {pattern: 'node_modules/systemjs/dist/system.src.js', included: true, watched: true},
       {pattern: 'node_modules/rxjs/bundles/Rx.js', included: true, watched: true},
       {pattern: 'node_modules/angular2/bundles/angular2.js', included: true, watched: true},
       {pattern: 'node_modules/angular2/bundles/http.dev.js', included: true, watched: true},
       {pattern: 'node_modules/angular2/bundles/router.dev.js', included: true, watched: true},
       {pattern: 'node_modules/angular2/bundles/testing.dev.js', included: true, watched: true},
 
-
+      {pattern: 'node_modules/typescript/lib/typescript.js', included: true, watched: true},
       {pattern: 'karma-test-shim.js', included: true, watched: true},
 
-      // paths loaded via module imports
-      {pattern: 'dist/**/*.js', included: false, watched: true},
-
-      // paths loaded via Angular's component compiler
-      // (these paths need to be rewritten, see proxies section)
-      {pattern: 'dist/**/*.html', included: false, watched: true},
-      {pattern: 'dist/**/*.css', included: false, watched: true},
-
-      // paths to support debugging with source maps in dev tools
-      {pattern: 'dist/**/*.ts', included: false, watched: false},
-      {pattern: 'dist/**/*.js.map', included: false, watched: false}
+      {pattern: 'src/app/**/*.ts', included: false, watched: true},
+      {pattern: 'src/app/**/*.html', included: false, watched: true},
+      {pattern: 'src/app/**/*.css', included: false, watched: true},
     ],
     proxies: {
       // required for component assets fetched by Angular's compiler
-      "/app/": "/base/dist/app/"
+      "/app": "/base/src/app"
     },
     exclude: [],
     preprocessors: {},


### PR DESCRIPTION
Do not merge this PR, it needs discussion.

This change enables karma to run unit tests without needing `ng build`, thus being able to run at the same time as `ng serve`.

It uses in-browser TS compilation via SystemJS. This also means that tested files will be recompiled whenever tests are re-run. This is a bad thing for bigger projects.

There might be a way around this limitation, but that needs further investigation.