### PR TITLE
Fix Protractor test so 'ng e2e' succeeds after 'ng new'

### DIFF
--- a/addon/ng2/blueprints/ng2/files/e2e/app.po.ts
+++ b/addon/ng2/blueprints/ng2/files/e2e/app.po.ts
@@ -2,8 +2,8 @@ export class <%= jsComponentName %>Page {
   navigateTo() {
     return browser.get('/');
   }
-  
+
   getParagraphText() {
-    return element(by.css('<%= jsComponentName %>-app p')).getText();
+    return element(by.css('<%= htmlComponentName %>-app p')).getText();
   }
 }


### PR DESCRIPTION
Fix Protractor test so `ng e2e` succeeds after `ng new`.