### PR TITLE
chore(dependencies): bump typescript and related dependency versions...

### DIFF
--- a/addon/ng2/blueprints/ng2/files/package.json
+++ b/addon/ng2/blueprints/ng2/files/package.json
@@ -14,12 +14,13 @@
   },
   "private": true,
   "dependencies": {
-    "angular2": "2.0.0-beta.6",
+    "angular2": "2.0.0-beta.8",
     "es6-promise": "^3.0.2",
     "es6-shim": "^0.33.3",
     "reflect-metadata": "0.1.2",
-    "rxjs": "5.0.0-beta.0",
-    "systemjs": "0.19.20"
+    "rxjs": "5.0.0-beta.2",
+    "systemjs": "0.19.20",
+    "zone.js": "0.5.15"
   },
   "devDependencies": {
     "angular-cli": "0.0.*",
@@ -32,7 +33,8 @@
     "karma-firefox-launcher": "^0.1.7",
     "karma-jasmine": "^0.3.6",
     "protractor": "^3.0.0",
-    "typescript": "^1.7.3",
+    "silent-error": "^1.0.0",
+    "typescript": "^1.8.7",
     "typings": "^0.6.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,10 +42,10 @@
     "lodash": "^3.10.0",
     "node-notifier": "^4.4.0",
     "resolve": "^1.0.0",
-    "silent-error": "^1.0.0",
     "shelljs": "^0.5.3",
+    "silent-error": "^1.0.0",
     "symlink-or-copy": "^1.0.1",
-    "typescript": "~1.7.3",
+    "typescript": "^1.8.7",
     "typings": "^0.6.2"
   },
   "ember-addon": {


### PR DESCRIPTION
chore(dependencies): bump typescript and related dependency versions to support string literals

the current cli does not support string literals and is using an beta7. Bumping versions for typescript as well as the beta.

Fixes #279