### PR TITLE
fix(ng2 blueprint): fix ordering in devDependencies of package.json blueprint

### DIFF
--- a/addon/ng2/blueprints/ng2/files/package.json
+++ b/addon/ng2/blueprints/ng2/files/package.json
@@ -34,9 +34,9 @@
     "karma-jasmine": "^0.3.6",
     "protractor": "^3.0.0",
     "silent-error": "^1.0.0",
+    "ts-node": "^0.5.5",
     "tslint": "^3.3.0",
     "typescript": "^1.8.7",
-    "typings": "^0.6.6",
-    "ts-node": "^0.5.5"
+    "typings": "^0.6.6"
   }
 }


### PR DESCRIPTION
Fixed the ordering of the devDependencies in the package.json so they
are in correct alphabetical order.

This fixes the minor annoyance (when looking at file diffs) of the
ts-node property having its location changed whenever a new module is
added using npm install.