### PR TITLE
fix(ng2 blueprint): fix tslint warning in service spec

### DIFF
--- a/addon/ng2/blueprints/service/files/src/app/__path__/__name__/__name__.spec.ts
+++ b/addon/ng2/blueprints/service/files/src/app/__path__/__name__/__name__.spec.ts
@@ -18,7 +18,7 @@ describe('<%= classifiedModuleName %> Service', () => {
   beforeEachProviders(() => [<%= classifiedModuleName %>]);
 
 
-  it('should ...', inject([<%= classifiedModuleName %>], (service:<%= classifiedModuleName %>) => {
+  it('should ...', inject([<%= classifiedModuleName %>], (service: <%= classifiedModuleName %>) => {
 
   }));
 


### PR DESCRIPTION
Add a space character in the inject statement within the blueprint of
the service spec to remove tslint whitespace missing warning