### PR TITLE
fix(paths): fix the determination of execution path

### DIFF
--- a/addon/ng2/blueprints/component/index.js
+++ b/addon/ng2/blueprints/component/index.js
@@ -5,11 +5,7 @@ module.exports = {
   description: '',
 
   normalizeEntityName: function(entityName) {
-    var cwd = this.project.cli.testing
-      ? process.cwd()
-      : process.env.PWD;
-    
-    var parsedPath = dynamicPathParser(cwd, this.project.root, entityName);
+    var parsedPath = dynamicPathParser(this.project, entityName);
     
     this.dynamicPath = parsedPath;
     return parsedPath.name;

--- a/addon/ng2/blueprints/directive/index.js
+++ b/addon/ng2/blueprints/directive/index.js
@@ -5,11 +5,7 @@ module.exports = {
   description: '',
 
   normalizeEntityName: function(entityName) {
-    var cwd = this.project.cli.testing
-      ? process.cwd()
-      : process.env.PWD;
-    
-    var parsedPath = dynamicPathParser(cwd, this.project.root, entityName);
+    var parsedPath = dynamicPathParser(this.project, entityName);
     
     this.dynamicPath = parsedPath;
     return parsedPath.name;

--- a/addon/ng2/blueprints/pipe/index.js
+++ b/addon/ng2/blueprints/pipe/index.js
@@ -5,11 +5,7 @@ module.exports = {
   description: '',
 
   normalizeEntityName: function(entityName) {
-    var cwd = this.project.cli.testing
-      ? process.cwd()
-      : process.env.PWD;
-    
-    var parsedPath = dynamicPathParser(cwd, this.project.root, entityName);
+    var parsedPath = dynamicPathParser(this.project, entityName);
     
     this.dynamicPath = parsedPath;
     return parsedPath.name;

--- a/addon/ng2/blueprints/service/index.js
+++ b/addon/ng2/blueprints/service/index.js
@@ -5,11 +5,7 @@ module.exports = {
   description: '',
 
   normalizeEntityName: function(entityName) {
-    var cwd = this.project.cli.testing
-      ? process.cwd()
-      : process.env.PWD;
-    
-    var parsedPath = dynamicPathParser(cwd, this.project.root, entityName);
+    var parsedPath = dynamicPathParser(this.project, entityName);
     
     this.dynamicPath = parsedPath;
     return parsedPath.name;

--- a/addon/ng2/utilities/dynamic-path-parser.js
+++ b/addon/ng2/utilities/dynamic-path-parser.js
@@ -1,7 +1,10 @@
 var path = require('path');
 var process = require('process');
 
-module.exports = function dynamicPathParser(cwd, projectRoot, entityName) {
+module.exports = function dynamicPathParser(project, entityName) {
+  var projectRoot = project.root;
+  var cwd = process.env.PWD;
+  
   var rootPath = path.join(projectRoot, 'src', 'app');
 
   var outputPath = path.join(rootPath, entityName);

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -61,6 +61,9 @@ module.exports = function(options) {
     root: path.join(__dirname, '..', '..'),
     npmPackage: 'angular-cli'
   };
-    
+  
+  // ensure the environemnt variable for dynamic paths
+  process.env.PWD = process.env.PWD || process.cwd();
+  
   return cli(options);
 }

--- a/tests/acceptance/generate-component.spec.js
+++ b/tests/acceptance/generate-component.spec.js
@@ -87,7 +87,6 @@ describe('Acceptance: ng generate component', function() {
       .then(_ => fs.mkdirsSync('./1'))
       .then(_ => process.chdir('./1'))
       .then(_ => {
-        process.env.CWD = process.cwd();
         return ng([
           'generate',
           'component',
@@ -109,7 +108,6 @@ describe('Acceptance: ng generate component', function() {
       .then(_ => fs.mkdirsSync('./1'))
       .then(_ => process.chdir('./1'))
       .then(_ => {
-        process.env.CWD = process.cwd();
         return ng([
           'generate',
           'component',
@@ -131,7 +129,6 @@ describe('Acceptance: ng generate component', function() {
       .then(_ => fs.mkdirsSync('./1'))
       .then(_ => process.chdir('./1'))
       .then(_ => {
-        process.env.CWD = process.cwd();
         return ng([
           'generate',
           'component',
@@ -153,7 +150,6 @@ describe('Acceptance: ng generate component', function() {
       .then(_ => fs.mkdirsSync('./1'))
       .then(_ => process.chdir('./1'))
       .then(_ => {
-        process.env.CWD = process.cwd();
         return ng([
           'generate',
           'component',

--- a/tests/helpers/ng.js
+++ b/tests/helpers/ng.js
@@ -6,7 +6,9 @@ var Cli           = require('../../lib/cli');
 
 module.exports = function ng(args) {
     var cli;
-
+    
+    process.env.PWD = process.cwd();
+    
     cli = new Cli({
         inputStream:  [],
         outputStream: [],


### PR DESCRIPTION
Windows does not populate  this fix allows for determination
of the directory from which an ng command was executed
Fixes #297