### PR TITLE
fix(blueprints): remove 'glob' dependency

### DIFF
--- a/addon/ng2/blueprints/ng2/files/package.json
+++ b/addon/ng2/blueprints/ng2/files/package.json
@@ -14,7 +14,6 @@
   "private": true,
   "dependencies": {
     "angular2": "2.0.0-beta.9",
-    "clang-format": "^1.0.35",
     "es6-promise": "^3.0.2",
     "es6-shim": "^0.33.3",
     "reflect-metadata": "0.1.2",
@@ -25,6 +24,7 @@
   "devDependencies": {
     "angular-cli": "0.0.*",
     "angular-cli-github-pages": "^0.2.0",
+    "clang-format": "^1.0.35",
     "ember-cli-inject-live-reload": "^1.3.0",
     "jasmine-core": "^2.3.4",
     "jasmine-spec-reporter": "^2.4.0",

--- a/addon/ng2/blueprints/ng2/files/package.json
+++ b/addon/ng2/blueprints/ng2/files/package.json
@@ -32,7 +32,6 @@
     "karma-chrome-launcher": "^0.2.1",
     "karma-jasmine": "^0.3.6",
     "protractor": "^3.0.0",
-    "silent-error": "^1.0.0",
     "ts-node": "^0.5.5",
     "tslint": "^3.3.0",
     "typescript": "^1.8.7",

--- a/addon/ng2/blueprints/ng2/files/package.json
+++ b/addon/ng2/blueprints/ng2/files/package.json
@@ -26,7 +26,6 @@
     "angular-cli": "0.0.*",
     "angular-cli-github-pages": "^0.2.0",
     "ember-cli-inject-live-reload": "^1.3.0",
-    "glob": "^6.0.4",
     "jasmine-core": "^2.3.4",
     "jasmine-spec-reporter": "^2.4.0",
     "karma": "^0.13.15",


### PR DESCRIPTION
it seems that it was introduced by error in https://github.com/angular/angular-cli/commit/e238e328f7e0e8d8119dec45679ef2837f58fb1e