### PR TITLE
fix(blueprint): remove typescript as a dev dependency of the generate…

### DIFF
--- a/addon/ng2/blueprints/ng2/files/package.json
+++ b/addon/ng2/blueprints/ng2/files/package.json
@@ -34,7 +34,6 @@
     "protractor": "^3.0.0",
     "ts-node": "^0.5.5",
     "tslint": "^3.3.0",
-    "typescript": "^1.8.7",
     "typings": "^0.6.6"
   }
 }


### PR DESCRIPTION
…d project

typescript is already provided by angular-cli and the dependency doesn't need to be listed directly in the project.