### PR TITLE
chore(ng blueprint): update tslint dependency in package.json blueprint

### DIFF
--- a/addon/ng2/blueprints/ng2/files/package.json
+++ b/addon/ng2/blueprints/ng2/files/package.json
@@ -32,7 +32,7 @@
     "karma-jasmine": "^0.3.6",
     "protractor": "^3.0.0",
     "ts-node": "^0.5.5",
-    "tslint": "^3.3.0",
+    "tslint": "^3.6.0",
     "typescript": "^1.8.7",
     "typings": "^0.6.6"
   }

--- a/addon/ng2/blueprints/ng2/files/tslint.json
+++ b/addon/ng2/blueprints/ng2/files/tslint.json
@@ -33,7 +33,7 @@
       "single",
       "avoid-escape"
     ],
-    "semicolon": true,
+    "semicolon": [true, "always"],
     "typedef-whitespace": [
       true,
       {


### PR DESCRIPTION
Update tslint dev dependency in the package.json blueprint to use
^3.6.0.
Allows additional tslint rules to be implemented.
Update tslint.json to use the updated semicolon rule config setting.
See http://palantir.github.io/tslint/rules/semicolon/