### PR TITLE
fix: use symLinkSync

### DIFF
--- a/lib/broccoli/broccoli-typescript.js
+++ b/lib/broccoli/broccoli-typescript.js
@@ -78,7 +78,7 @@ class BroccoliTypeScriptCompiler extends Plugin {
         this._fileRegistry[tsFilePath].outputs.forEach(absoluteFilePath => {
           const outputFilePath = absoluteFilePath.replace(this.cachePath, this.outputPath);
           fse.mkdirsSync(path.dirname(outputFilePath));
-          fs.linkSync(absoluteFilePath, outputFilePath);
+          fs.symlinkSync(absoluteFilePath, outputFilePath);
         });
       } else {
         this._fileRegistry[tsFilePath].version = entry.mtime;
@@ -202,7 +202,7 @@ class BroccoliTypeScriptCompiler extends Plugin {
     fs.writeFileSync(absoluteFilePath, content, FS_OPTS);
 
     fse.mkdirsSync(path.dirname(outputFilePath));
-    fs.linkSync(absoluteFilePath, outputFilePath);
+    fs.symlinkSync(absoluteFilePath, outputFilePath);
   }
 
   _addNewFileEntry(entry, checkDuplicates /* = true */) {
@@ -314,7 +314,7 @@ class CustomLanguageServiceHost {
   getCurrentDirectory() {
     return this.currentDirectory;
   }
-  
+
   getCompilationSettings() {
     return this.compilerOptions;
   }


### PR DESCRIPTION
Using the latest releases of angular-cli (up to 0.0.30), I've been running into an issue when the build is in a VM/docker container and using a shared file system with the host (`EPERM: operation not permitted` for BroccoliTypeScriptPlugin).

After some research, it looks like it's not a new problem in the Broccoli/Ember-cli world, and that it is recommended to use `fs.symlinkSync` instead of `fs.linkSync`.

See https://github.com/ember-cli/broccoli-caching-writer/issues/2 for example and the related links.

It does appear to solve the problem, so here is a humble PR to (hopefully) fix it.