### PR TITLE
chore: remove spec files from vendors

### DIFF
--- a/addon/ng2/blueprints/ng2/files/karma.conf.js
+++ b/addon/ng2/blueprints/ng2/files/karma.conf.js
@@ -43,7 +43,10 @@ module.exports = function (config) {
       // required for component assets fetched by Angular's compiler
       '/app/': '/base/dist/app/'
     },
-    exclude: [],
+    exclude: [
+      // Vendor packages might include spec files. We don't want to use those.
+      'dist/vendor/**/*.spec.js'
+    ],
     preprocessors: {},
     reporters: ['progress'],
     port: 9876,


### PR DESCRIPTION
Because we run every spec files, we need to remove those from vendors.