### PR TITLE
chore: update typings version to ^0.7.12

### DIFF
--- a/addon/ng2/blueprints/ng2/files/package.json
+++ b/addon/ng2/blueprints/ng2/files/package.json
@@ -34,6 +34,6 @@
     "ts-node": "^0.5.5",
     "tslint": "^3.6.0",
     "typescript": "^1.8.7",
-    "typings": "^0.6.6"
+    "typings": "^0.7.12"
   }
 }


### PR DESCRIPTION
The current version of typings (0.6.6) is outdated. It does not know about the "registry" prefix. 
typings install redux --save
...
"dependencies": {
    "redux": "registry:npm/redux#3.0.6+20160214194820"
  }
...
