### PR TITLE
fix(tsconfig): `app.ts` is `main.ts` now

### DIFF
--- a/addon/ng2/blueprints/ng2/files/src/client/tsconfig.json
+++ b/addon/ng2/blueprints/ng2/files/src/client/tsconfig.json
@@ -17,7 +17,7 @@
   },
 
   "files": [
-    "app.ts",
+    "main.ts",
     "typings.d.ts"
   ]
 }


### PR DESCRIPTION
fixes TSError `file not included in the typescript compilation context`