### PR TITLE
chore(systemjs): load all dependencies via systemjs

### DIFF
--- a/addon/ng2/blueprints/ng2/files/angular-cli-build.js
+++ b/addon/ng2/blueprints/ng2/files/angular-cli-build.js
@@ -4,6 +4,13 @@ var Angular2App = require('angular-cli/lib/broccoli/angular2-app');
 
 module.exports = function(defaults) {
   return new Angular2App(defaults, {
-    vendorNpmFiles: []
+    vendorNpmFiles: [
+      'reflect-metadata/**/*.js',
+      'zone.js/**/*.js',
+      'systemjs/**/*.js',
+      'es6-shim/**/*.js',
+      'angular2/**/*.js',
+      'rxjs/**/*.js'
+    ]
   });
 };

--- a/addon/ng2/blueprints/ng2/files/karma-test-shim.js
+++ b/addon/ng2/blueprints/ng2/files/karma-test-shim.js
@@ -26,16 +26,9 @@ var allSpecFiles = Object.keys(window.__karma__.files)
 
 // Load our SystemJS configuration.
 System.import('base/dist/system-config.js').then(function(systemJsConfig) {
-  // We need to add the distPrefix to our system config packages.
   var config = systemJsConfig.config;
-  Object.keys(config.packages).forEach(function(pkgName) {
-    if (pkgName[0] != '/' && pkgName[0] != '.') {
-      var pkg = config.packages[pkgName];
-      delete config.packages[pkgName];
-      config.packages[distPath + pkgName] = pkg;
-    }
-  });
-
+  // We need to add the distPath to our system config.
+  config.baseURL = distPath;
   System.config(config);
 }).then(function() {
   // Load and configure the TestComponentBuilder.

--- a/addon/ng2/blueprints/ng2/files/karma.conf.js
+++ b/addon/ng2/blueprints/ng2/files/karma.conf.js
@@ -14,18 +14,12 @@ module.exports = function (config) {
       }
     },
     files: [
-      { pattern: 'node_modules/systemjs/dist/system-polyfills.js', included: true, watched: true },
-      { pattern: 'node_modules/systemjs/dist/system.src.js', included: true, watched: true },
-      { pattern: 'node_modules/es6-shim/es6-shim.js', included: true, watched: true },
-      { pattern: 'node_modules/angular2/bundles/angular2-polyfills.js', included: true, watched: true },
+      { pattern: 'node_modules/es6-shim/es6-shim.js', included: true, watched: false },
+      { pattern: 'node_modules/systemjs/dist/system-polyfills.js', included: true, watched: false },
+      { pattern: 'node_modules/systemjs/dist/system.src.js', included: true, watched: false },
+      { pattern: 'node_modules/angular2/bundles/angular2-polyfills.js', included: true, watched: false },
       { pattern: 'node_modules/zone.js/dist/async-test.js', included: true, watched: true },
       { pattern: 'node_modules/zone.js/dist/fake-async-test.js', included: true, watched: true },
-      { pattern: 'node_modules/rxjs/bundles/Rx.js', included: true, watched: true },
-      { pattern: 'node_modules/angular2/bundles/angular2.js', included: true, watched: true },
-      { pattern: 'node_modules/angular2/bundles/http.dev.js', included: true, watched: true },
-      { pattern: 'node_modules/angular2/bundles/router.dev.js', included: true, watched: true },
-      { pattern: 'node_modules/angular2/bundles/testing.dev.js', included: true, watched: true },
-
 
       { pattern: 'karma-test-shim.js', included: true, watched: true },
 
@@ -41,10 +35,6 @@ module.exports = function (config) {
       { pattern: 'dist/**/*.ts', included: false, watched: false },
       { pattern: 'dist/**/*.js.map', included: false, watched: false }
     ],
-    proxies: {
-      // required for component assets fetched by Angular's compiler
-      '/': '/base/dist/'
-    },
     exclude: [
       // Vendor packages might include spec files. We don't want to use those.
       'dist/vendor/**/*.spec.js'

--- a/addon/ng2/blueprints/ng2/files/src/client/app/index.ts
+++ b/addon/ng2/blueprints/ng2/files/src/client/app/index.ts
@@ -1,0 +1,2 @@
+export {environment} from './environment';
+export {<%= jsComponentName %>App} from './<%= htmlComponentName %>.component';

--- a/addon/ng2/blueprints/ng2/files/src/client/index.html
+++ b/addon/ng2/blueprints/ng2/files/src/client/index.html
@@ -24,19 +24,14 @@
 
   <script src="vendor/es6-shim/es6-shim.js"></script>
   <script src="vendor/systemjs/dist/system-polyfills.js"></script>
-  <script src="vendor/angular2/bundles/angular2-polyfills.js"></script>
   <script src="vendor/systemjs/dist/system.src.js"></script>
-  <script src="vendor/rxjs/bundles/Rx.js"></script>
+  <script src="vendor/angular2/bundles/angular2-polyfills.js"></script>
 
-  <script src="vendor/angular2/bundles/angular2.dev.js"></script>
-  <script src="vendor/angular2/bundles/http.dev.js"></script>
-  <script src="vendor/angular2/bundles/router.dev.js"></script>
-  
   <script>
     System.import('system-config.js').then(function(systemConfig) {
       System.config(systemConfig.config);
     }).then(function () {
-      System.import('main.js')
+      System.import('main')
     }).catch(console.error.bind(console));
   </script>
 </body>

--- a/addon/ng2/blueprints/ng2/files/src/client/main.ts
+++ b/addon/ng2/blueprints/ng2/files/src/client/main.ts
@@ -1,7 +1,6 @@
 import {bootstrap} from 'angular2/platform/browser';
 import {enableProdMode} from 'angular2/core';
-import {environment} from './app/environment';
-import {<%= jsComponentName %>App} from './app/<%= htmlComponentName %>.component';
+import {<%= jsComponentName %>App, environment} from './app/';
 
 if (environment.production) {
   enableProdMode();

--- a/addon/ng2/blueprints/ng2/files/src/client/system-config.ts
+++ b/addon/ng2/blueprints/ng2/files/src/client/system-config.ts
@@ -7,8 +7,6 @@ const barrels: string[] = [
 function createPackageConfig(barrelList: string[]): any {
   return barrelList.reduce((barrelConfig: any, barrelName: string) => {
     barrelConfig[barrelName] = {
-      format: 'register',
-      defaultExtension: 'js',
       main: 'index'
     };
     return barrelConfig;
@@ -18,7 +16,14 @@ function createPackageConfig(barrelList: string[]): any {
 
 // Add your custom SystemJS configuration here.
 export const config: any = {
+  map: {
+    main: 'main.js',
+    angular2: 'vendor/angular2',
+    rxjs: 'vendor/rxjs'
+  },
   packages: Object.assign({
     // Add your custom SystemJS packages here.
+    angular2: {},
+    rxjs: {},
   }, createPackageConfig(barrels))
 };

--- a/addon/ng2/blueprints/ng2/files/src/client/tsconfig.json
+++ b/addon/ng2/blueprints/ng2/files/src/client/tsconfig.json
@@ -18,6 +18,7 @@
 
   "files": [
     "main.ts",
-    "typings.d.ts"
+    "typings.d.ts",
+    "system-config.ts"
   ]
 }

--- a/lib/broccoli/angular2-app.js
+++ b/lib/broccoli/angular2-app.js
@@ -9,6 +9,8 @@ const BroccoliSwManifest = require('./service-worker-manifest').default;
 const BroccoliFunnel = require('broccoli-funnel');
 const BroccoliMergeTrees = require('broccoli-merge-trees');
 const BroccoliUglify = require('broccoli-uglify-js');
+const BroccoliSource = require('broccoli-source');
+const UnwatchedDir = BroccoliSource.UnwatchedDir;
 const Project = require('ember-cli/lib/models/project');
 
 
@@ -115,7 +117,9 @@ class Angular2App extends BroccoliPlugin {
     }
 
     var merged = new BroccoliMergeTrees(buildTrees, { overwrite: true });
-    merged = new BroccoliMergeTrees([merged, new BroccoliSwManifest([merged])]);
+    if (isProduction){
+      merged = new BroccoliMergeTrees([merged, new BroccoliSwManifest([merged])]);
+    }
     return new BroccoliFunnel(merged, {
       destDir: this._destDir
     });
@@ -284,23 +288,13 @@ class Angular2App extends BroccoliPlugin {
    * @return {Tree} The NPM tree.
    */
   _getVendorNpmTree() {
-    var vendorNpmFiles = [
-      'systemjs/dist/system-polyfills.js',
-      'systemjs/dist/system.src.js',
-      'es6-shim/es6-shim.js',
-      'angular2/bundles/angular2-polyfills.js',
-      'rxjs/bundles/Rx.js',
-      'angular2/bundles/angular2.dev.js',
-      'angular2/bundles/http.dev.js',
-      'angular2/bundles/router.dev.js',
-      'angular2/bundles/upgrade.dev.js'
-    ];
+    var vendorNpmFiles = [];
 
     if (this._options.vendorNpmFiles) {
       vendorNpmFiles = vendorNpmFiles.concat(this._options.vendorNpmFiles);
     }
 
-    return new BroccoliFunnel('node_modules', {
+    return new BroccoliFunnel(new UnwatchedDir('node_modules'), {
       include: vendorNpmFiles,
       destDir: 'vendor'
     });

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "broccoli-concat": "^2.2.0",
     "broccoli-funnel": "^1.0.1",
     "broccoli-merge-trees": "^1.1.1",
+    "broccoli-source": "^1.1.0",
     "broccoli-uglify-js": "^0.1.3",
     "broccoli-writer": "^0.1.1",
     "chalk": "^1.1.1",

--- a/tests/e2e/e2e_workflow.spec.js
+++ b/tests/e2e/e2e_workflow.spec.js
@@ -71,6 +71,17 @@ describe('Basic end-to-end Workflow', function () {
     expect(sh.exec('git status --porcelain').output).to.be.equal('');
   });
 
+  it('Produces a service worker manifest after production build', function () {
+    var manifestPath = path.join(process.cwd(), 'dist', 'manifest.appcache');
+    expect(existsSync(manifestPath)).to.be.equal(true);
+    // Read the worker.
+    //TODO: Commenting this out because it makes eslint fail(need to figure out why this expect was commented out)
+    // var lines = fse.readFileSync(manifestPath, {encoding: 'utf8'}).trim().split('\n');
+
+    // Check that a few critical files have been detected.
+    // expect(lines).to.include(`${path.sep}index.html`);
+  });
+
   it('Can run `ng build` in created project', function () {
     this.timeout(420000);
 
@@ -85,17 +96,6 @@ describe('Basic end-to-end Workflow', function () {
       .catch(() => {
         throw new Error('Build failed.');
       });
-  });
-
-  it('Produces a service worker manifest after initial build', function () {
-    var manifestPath = path.join(process.cwd(), 'dist', 'manifest.appcache');
-    expect(existsSync(manifestPath)).to.be.equal(true);
-    // Read the worker.
-    //TODO: Commenting this out because it makes eslint fail(need to figure out why this expect was commented out)
-    // var lines = fse.readFileSync(manifestPath, {encoding: 'utf8'}).trim().split('\n');
-
-    // Check that a few critical files have been detected.
-    // expect(lines).to.include(`${path.sep}index.html`);
   });
 
   it('Perform `ng test` after initial build', function () {


### PR DESCRIPTION
This PR loads all app dependencies via SystemJS instead of script tags. This is necessary for production builds so that these dependencies can be traced and built around.

It also adds `system-config.ts` to the `files` entry `tsconfig.json` so that it doesn't have the 'not included in project' error.

`vendorNpmFiles` were also fully moved into `angular-cli-build` to give more control over dependencies (for instance, allowing the user to not use the dev packages of angular 2).

Closes #517
Closes #400