### PR TITLE
Add NETWORK section to cache manifest

### DIFF
--- a/lib/broccoli/service-worker-manifest.js
+++ b/lib/broccoli/service-worker-manifest.js
@@ -65,7 +65,10 @@ class DiffingSWManifest extends Plugin {
     return 'CACHE MANIFEST\n'
          + '# sw.bundle: ng-cli\n'
          + `# sw.version: ${bundleHash}\n`
-         + `${contents}\n`;
+         + `${contents}\n`
+         + '\n'
+         + 'NETWORK:'
+         + '*\n';
   }
 
   // Read the manifest from the cache and split it out into a dict of files to hashes.


### PR DESCRIPTION
This PR adds a wildcard NETWORK section to the manifest.appcache file to allow files that are not explicitly listed in the manifest to be loaded from the server. 

This allows files such as `ember-cli-live-reload.js` to be loaded from the network, fixing live reload in development. If using the application cache during development, the ember live reload will cause the cache to be updated, but in order to display the updated content, a second refresh is required. This can be easily forced programmatically within your app:

```Javascript
if (window.applicationCache.status == window.applicationCache.UPDATEREADY) {
  window.location.reload();
}
```