### PR TITLE
feat(migration): copying JS files when created in cli generated app,

### DIFF
--- a/lib/broccoli/angular2-app.js
+++ b/lib/broccoli/angular2-app.js
@@ -56,6 +56,7 @@ class Angular2App extends BroccoliPlugin {
   read(readTree) {
     return this._tree.read(readTree);
   }
+
   /**
    * @override
    */
@@ -247,34 +248,6 @@ class Angular2App extends BroccoliPlugin {
   }
 
   /**
-   * Returns the source root dir tree.
-   *
-   * @private
-   * @method _getSourceTree
-   * @return {Tree} Tree for the src dir.
-   */
-  _getSourceTree() {
-    return new BroccoliFunnel(this._inputNode, {
-      include: ['*.ts', '**/*.ts', '**/*.d.ts'],
-      destDir: this._sourceDir
-    });
-  }
-
-  /**
-   * Returns the typings tree.
-   *
-   * @private
-   * @method _getTypingsTree
-   * @return {Tree} Tree for the src dir.
-   */
-  _getTypingsTree() {
-    return new BroccoliFunnel('typings', {
-      include: ['browser.d.ts', 'browser/**'],
-      destDir: 'typings'
-    });
-  }
-
-  /**
    * Returns the TS tree.
    *
    * @private
@@ -345,7 +318,6 @@ class Angular2App extends BroccoliPlugin {
       include: [path.join(this._sourceDir, '**/*')],
       exclude: [
         '**/*.ts',
-        '**/*.js',
         '**/*.scss',
         '**/*.sass',
         '**/*.less',


### PR DESCRIPTION
feat(migration): copying JS files when created in cli generated app, removing dead code

One of the paths for migration is to generate a cli project and move your existing code base into it and migrate piece by piece.  Currently JS files that are created in App are not copied over.  This PR treats them like a common asset.  Also there were two functions unused in the angualr2-app.js file and they were removed. 