### PR TITLE
fix(generate): missing string-utils and empty test

### DIFF
--- a/addon/ng2/blueprints/component/index.js
+++ b/addon/ng2/blueprints/component/index.js
@@ -1,14 +1,14 @@
 var path = require('path');
-var stringUtils = require('ember-cli-string-utils');
 var chalk = require('chalk');
 var Blueprint = require('ember-cli/lib/models/blueprint');
 var dynamicPathParser = require('../../utilities/dynamic-path-parser');
 var addBarrelRegistration = require('../../utilities/barrel-management');
 var getFiles = Blueprint.prototype.files;
+const stringUtils = require('ember-cli/lib/utilities/string');
 
 module.exports = {
   description: '',
-  
+
   availableOptions: [
     { name: 'flat', type: Boolean, default: false },
     { name: 'route', type: Boolean, default: false },
@@ -21,27 +21,27 @@ module.exports = {
     var parsedPath = dynamicPathParser(this.project, entityName);
 
     this.dynamicPath = parsedPath;
-    
+
     var defaultPrefix = '';
-    if (this.project.ngConfig && 
+    if (this.project.ngConfig &&
         this.project.ngConfig.defaults &&
         this.project.ngConfig.defaults.prefix) {
       defaultPrefix = this.project.ngConfig.defaults.prefix + '-';
     }
     var prefix = this.options.prefix ? defaultPrefix : '';
     this.selector = stringUtils.dasherize(prefix + parsedPath.name);
-    
+
     if (this.selector.indexOf('-') === -1) {
       this._writeStatusToUI(chalk.yellow, 'WARNING', 'selectors should contain a dash');
     }
-    
+
     return parsedPath.name;
   },
 
   locals: function (options) {
     //TODO: pull value from config
     this.styleExt = 'css';
-    
+
     return {
       dynamicPath: this.dynamicPath.dir.replace(this.dynamicPath.appRoot, ''),
       flat: options.flat,
@@ -54,10 +54,10 @@ module.exports = {
       selector: this.selector
     };
   },
-  
+
   files: function() {
     var fileList = getFiles.call(this);
-    
+
     if (this.options && this.options.flat) {
       fileList = fileList.filter(p => p.indexOf('index.ts') <= 0);
     }
@@ -73,7 +73,7 @@ module.exports = {
 
     return fileList;
   },
-  
+
   fileMapTokens: function (options) {
     // Return custom template variables here.
     return {
@@ -81,7 +81,7 @@ module.exports = {
         var dir = this.dynamicPath.dir;
         if (!options.locals.flat) {
           dir += path.sep + options.dasherizedModuleName;
-          
+
           if (options.locals.isLazyRoute) {
             var dirParts = dir.split(path.sep);
             dirParts[dirParts.length - 1] = `+${dirParts[dirParts.length - 1]}`;
@@ -97,12 +97,12 @@ module.exports = {
       }
     };
   },
-  
+
   afterInstall: function(options) {
     if (!options.flat) {
       var filePath = path.join('src', 'client', 'system-config.ts');
       var barrelUrl = this.appDir.replace(path.sep, '/');
-      
+
       return addBarrelRegistration(this, this.generatePath)
         .then(() => {
           return this.insertIntoFile(
@@ -113,7 +113,7 @@ module.exports = {
         })
     } else {
       return addBarrelRegistration(
-        this, 
+        this,
         this.generatePath,
         options.entity.name + '.component');
     }

--- a/tests/acceptance/generate-component.spec.js
+++ b/tests/acceptance/generate-component.spec.js
@@ -138,7 +138,7 @@ describe('Acceptance: ng generate component', function () {
       expect(existsSync(testPath)).to.equal(false);
     });
   });
-  
+
   it('ng generate component mycomp will prefix selector', () => {
     return ng(['generate', 'component', 'mycomp'])
       .then(() => {
@@ -148,7 +148,7 @@ describe('Acceptance: ng generate component', function () {
         expect(contents.indexOf('selector: \'app-mycomp\'') === -1).to.equal(false);
       });
   });
-  
+
   it('ng generate component mycomp --no-prefix will not prefix selector', () => {
     return ng(['generate', 'component', 'mycomp', '--no-prefix'])
       .then(() => {
@@ -158,7 +158,7 @@ describe('Acceptance: ng generate component', function () {
         expect(contents.indexOf('selector: \'mycomp\'') === -1).to.equal(false);
       });
   });
-  
+
   it('ng generate component myComp will succeed', () => {
     return ng(['generate', 'component', 'myComp'])
       .then(() => {
@@ -166,21 +166,19 @@ describe('Acceptance: ng generate component', function () {
         expect(existsSync(testPath)).to.equal(true);
       });
   });
-  
+
   it('ng generate component my-comp --inline-template', function () {
     return ng(['generate', 'component', 'my-comp', '--inline-template']).then(() => {
       var testPath = path.join(root, 'tmp', 'foo', 'src', 'client', 'app', 'my-comp', 'my-comp.component.html');
       expect(existsSync(testPath)).to.equal(false);
     });
   });
-  
+
   it('ng generate component my-comp --inline-style', function () {
     return ng(['generate', 'component', 'my-comp', '--inline-style']).then(() => {
       var testPath = path.join(root, 'tmp', 'foo', 'src', 'client', 'app', 'my-comp', 'my-comp.component.css');
       expect(existsSync(testPath)).to.equal(false);
     });
   });
-  
-  it('should ', () => {
-  });
+
 });


### PR DESCRIPTION
When running tests from latest master, seeing following error:
```
Cannot find module 'angular-cli-string-utils'
Error: Cannot find module 'angular-cli-string-utils'
    at Function.Module._resolveFilename (module.js:325:15)
    at Function.Module._load (module.js:276:25)
    at Module.require (module.js:353:17)
    at require (internal/module.js:12:17)
    at Object.<anonymous> (/Users/cmartin/Src/angular2-sandbox/angular-cli/addon/ng2/blueprints/component/index.js:2:19)
    at Module._compile (module.js:409:26)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Module.require (module.js:353:17)
```

Also removes empty test.