### PR TITLE
chore(e2e): create repo pushes master branch

### DIFF
--- a/addon/ng2/commands/github-pages-deploy.ts
+++ b/addon/ng2/commands/github-pages-deploy.ts
@@ -128,7 +128,8 @@ module.exports = Command.extend({
       return execPromise('git remote -v')
         .then(function(stdout) {
           if (!/origin\s+(https:\/\/|git@)github\.com/m.test(stdout)) {
-            return createGithubRepoTask.run(createGithubRepoOptions);
+            return createGithubRepoTask.run(createGithubRepoOptions)
+              .then(() => execPromise(`git push -u origin ${initialBranch}`));
           }
         });
     }
@@ -175,7 +176,6 @@ module.exports = Command.extend({
     function printProjectUrl() {
       return execPromise('git remote -v')
         .then((stdout) => {
-
           let userName = stdout.match(/origin\s+(?:https:\/\/|git@)github\.com(?:\:|\/)([^\/]+)/m)[1].toLowerCase();
           ui.writeLine(chalk.green(`Deployed! Visit https://${userName}.github.io/${projectName}/`));
           ui.writeLine('Github pages might take a few minutes to show the deployed site.');
@@ -184,6 +184,7 @@ module.exports = Command.extend({
 
     function failGracefully(error) {
       if (error && (/git clean/.test(error.message) || /Permission denied/.test(error.message))) {
+        ui.writeLine(error.message);
         let msg = 'There was a permissions error during git file operations, please close any open project files/folders and try again.';
         msg += `\nYou might also need to return to the ${initialBranch} branch manually.`;
         return Promise.reject(new SilentError(msg));

--- a/tests/acceptance/github-pages-deploy.spec.js
+++ b/tests/acceptance/github-pages-deploy.spec.js
@@ -142,6 +142,7 @@ describe('Acceptance: ng github-pages:deploy', function() {
       .addExecSuccess('git rev-parse --abbrev-ref HEAD', initialBranch)
       .addExecSuccess('git remote -v', noRemote)
       .addExecSuccess(`git remote add origin git@github.com:${username}/${project}.git`)
+      .addExecSuccess(`git push -u origin ${initialBranch}`)
       .addExecSuccess(`git checkout ${branch}`)
       .addExecSuccess('git add .')
       .addExecSuccess(`git commit -m "${message}"`)


### PR DESCRIPTION
Currently, the github deploy command doesn't push the initial (master) branch on repo creation, which causes the `gh-pages` branch to become the default branch.

This PR makes the command push the `master` branch before the `gh-pages` branch, so that `master` is the default branch.