### PR TITLE
Add missing semicolon to e2e template

### DIFF
--- a/addon/ng2/blueprints/ng2/files/e2e/app.e2e.ts
+++ b/addon/ng2/blueprints/ng2/files/e2e/app.e2e.ts
@@ -5,7 +5,7 @@ describe('<%= htmlComponentName %> App', function() {
 
   beforeEach(() => {
     page = new <%= jsComponentName %>Page();
-  })
+  });
 
   it('should display message saying app works', () => {
     page.navigateTo();


### PR DESCRIPTION
Very small change to add a missing semicolon after the beforeEach() call in app.e2e.ts