### PR TITLE
Fix: directive compiler error for ComponentFixture

### DIFF
--- a/addon/ng2/blueprints/directive/files/__path__/__name__.directive.spec.ts
+++ b/addon/ng2/blueprints/directive/files/__path__/__name__.directive.spec.ts
@@ -22,7 +22,7 @@ describe('<%= classifiedModuleName %> Directive', () => {
   beforeEachProviders((): any[] => []);
 
   it('should ...', async(inject([TestComponentBuilder], (tcb:TestComponentBuilder) => {
-    return tcb.createAsync(TestComponent).then((fixture: ComponentFixture) => {
+    return tcb.createAsync(TestComponent).then((fixture: ComponentFixture<any>) => {
       fixture.detectChanges();
     });
   })));


### PR DESCRIPTION
close #654

## Problem
compiler error -> Generic type 'ComponentFixture<T>' requires 1 type argument(s)

## Solution
add `<any>` to ComponentFixture