### PR TITLE
fix: package.json use sourceDir for new command

### DIFF
--- a/addon/ng2/blueprints/ng2/files/package.json
+++ b/addon/ng2/blueprints/ng2/files/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "start": "ng server",
     "postinstall": "typings install",
-    "lint": "tslint \"src/**/*.ts\"",
-    "format": "clang-format -i -style=file --glob=src/**/*.ts",
+    "lint": "tslint \"<%= sourceDir %>/**/*.ts\"",
+    "format": "clang-format -i -style=file --glob=<%= sourceDir %>/**/*.ts",
     "pree2e": "webdriver-manager update",
     "e2e": "protractor"
   },


### PR DESCRIPTION
When creating a new app using `ng new appName --source-dir sourceDir`, `package.json` was not using the `sourceDir` option.