### PR TITLE
Fix generated class.spec testing import

### DIFF
--- a/addon/ng2/blueprints/class/files/__path__/__name__.spec.ts
+++ b/addon/ng2/blueprints/class/files/__path__/__name__.spec.ts
@@ -4,7 +4,7 @@ import {
   expect,
   iit,
   it
-} from '@angular/testing';
+} from '@angular/core/testing';
 import {<%= classifiedModuleName %>} from './<%= fileName %>';
 
 describe('<%= classifiedModuleName %>', () => {


### PR DESCRIPTION
Class specs generated by ng via the `ng generate class` command include
an incorrect import - it should import from `@angular/core/testing`, but
it currently imports from `@angular/testing`. This commit corrects the
import location.