### PR TITLE
feat(ng2 blueprint): add test script entry to package.json

### DIFF
--- a/addon/ng2/blueprints/ng2/files/package.json
+++ b/addon/ng2/blueprints/ng2/files/package.json
@@ -8,6 +8,7 @@
     "postinstall": "typings install",
     "lint": "tslint \"src/**/*.ts\"",
     "format": "clang-format -i -style=file --glob=src/**/*.ts",
+    "test": "ng test",
     "pree2e": "webdriver-manager update",
     "e2e": "protractor"
   },


### PR DESCRIPTION
Add a test script (that executes ng test) to the scripts contained in the package.json blueprint.

Users are commonly used to typing `npm test` to test projects via the command line. Adding an alias via the scripts property of the package.json would be helpful users that are new to angular-cli.