### PR TITLE
fix(generated-project): adding router-deprecated module

### DIFF
--- a/addon/ng2/blueprints/ng2/files/__path__/system-config.ts
+++ b/addon/ng2/blueprints/ng2/files/__path__/system-config.ts
@@ -20,6 +20,7 @@ const barrels: string[] = [
   '@angular/compiler',
   '@angular/http',
   '@angular/router',
+  '@angular/router-deprecated',
   '@angular/platform-browser',
   '@angular/platform-browser-dynamic',
 

--- a/addon/ng2/blueprints/ng2/files/package.json
+++ b/addon/ng2/blueprints/ng2/files/package.json
@@ -19,6 +19,7 @@
     "@angular/platform-browser": "2.0.0-rc.1",
     "@angular/platform-browser-dynamic": "2.0.0-rc.1",
     "@angular/router": "2.0.0-rc.1",
+    "@angular/router-deprecated": "2.0.0-rc.1",
     "es6-shim": "^0.35.0",
     "reflect-metadata": "0.1.3",
     "rxjs": "5.0.0-beta.6",


### PR DESCRIPTION
In order to use the `@angular/router-deprecated`, we have to include this dependency in `package.json` and import it to `system-config.ts`. here https://github.com/angular/angular-cli/issues/651