### PR TITLE
chore: exclude tsconfig.json from being copied to dist/

### DIFF
--- a/lib/broccoli/angular2-app.js
+++ b/lib/broccoli/angular2-app.js
@@ -333,7 +333,8 @@ class Angular2App extends BroccoliPlugin {
         '**/*.scss',
         '**/*.sass',
         '**/*.less',
-        '**/*.styl'
+        '**/*.styl',
+        '**/tsconfig.json'
       ],
       allowEmpty: true
     });


### PR DESCRIPTION
The tsconfig.json located at src/ is being copied to dist/ even though there are no ts files in dist/. This is breaking builds in Visual Studio 2015. 

It seems that it is unintential getting copied across in _getAssetsTree(), there is an exclusion for it in _getTsTree already.