### PR TITLE
Simplify user configuration

### DIFF
--- a/addon/ng2/blueprints/ng2/files/__path__/system-config.ts
+++ b/addon/ng2/blueprints/ng2/files/__path__/system-config.ts
@@ -51,4 +51,4 @@ System.config({
 });
 
 // Apply the user's configuration.
-System.config({ map, packages });
+System.config({ map: map, packages: packages });


### PR DESCRIPTION
Simplify user configuration by already pre-setting `map` and `packages` properties in `System.config` call argument.

User configuration is now easier, redundant calls like this are a thing of the past: 
```
const map:any = {
  map: {
    'key': 'val'
  }
};
```

Here's how to use it now:
```
const map:any = {
  'key': 'val'
};
```
 Same goes for `packages`.

ps: PRing this because it took me a while to figure out why my configuration wasn't working. This small improvement may help beginners!