### PR TITLE
feat(blueprints): add enum blueprint.

### DIFF
--- a/addon/ng2/blueprints/enum/files/__path__/__name__.enum.ts
+++ b/addon/ng2/blueprints/enum/files/__path__/__name__.enum.ts
@@ -1,0 +1,3 @@
+export enum <%= classifiedModuleName %> {
+
+}

--- a/addon/ng2/blueprints/enum/index.js
+++ b/addon/ng2/blueprints/enum/index.js
@@ -1,0 +1,44 @@
+const stringUtils = require('ember-cli-string-utils');
+var dynamicPathParser = require('../../utilities/dynamic-path-parser');
+var addBarrelRegistration = require('../../utilities/barrel-management');
+
+module.exports = {
+  description: '',
+
+  normalizeEntityName: function (entityName) {
+    var parsedPath = dynamicPathParser(this.project, entityName);
+
+    this.dynamicPath = parsedPath;
+    return parsedPath.name;
+  },
+
+  locals: function (options) {
+    this.fileName = stringUtils.dasherize(options.entity.name);
+
+    return {
+      dynamicPath: this.dynamicPath.dir,
+      flat: options.flat,
+      fileName: this.fileName
+    };
+  },
+
+  fileMapTokens: function () {
+    // Return custom template variables here.
+    return {
+      __path__: () => {
+        this.generatePath = this.dynamicPath.dir;
+        return this.generatePath;
+      },
+      __name__: () => {
+        return this.fileName;
+      }
+    };
+  },
+
+  afterInstall: function() {
+    return addBarrelRegistration(
+      this,
+      this.generatePath,
+      this.fileName);
+  }
+};

--- a/addon/ng2/commands/generate.ts
+++ b/addon/ng2/commands/generate.ts
@@ -52,6 +52,7 @@ const aliasMap = {
   'cl': 'class',
   'c': 'component',
   'd': 'directive',
+  'e': 'enum',
   'p': 'pipe',
   'r': 'route',
   's': 'service'


### PR DESCRIPTION
* Adds a basic blueprint for a typescript enum.

Not sure, whether the test is a good approach. 
It would be better to check for a valid enum value, but I didn't do that - because all other blueprints didn't have values inside of a blueprint.

Closes #707