### PR TITLE
fix(deploy): fix file copy, index tag rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The generated project has dependencies that require **Node 4 or greater**.
 * [Running Unit Tests](#running-unit-tests)
 * [Running End-to-End Tests](#running-end-to-end-tests)
 * [Deploying the App via GitHub Pages](#deploying-the-app-via-github-pages)
+* [Linting and formatting code](#linting-and-formatting-code)
 * [Support for offline applications](#support-for-offline-applications)
 * [Commands autocompletion](#commands-autocompletion)
 * [CSS preprocessor integration](#css-preprocessor-integration)
@@ -163,7 +164,7 @@ ng github-pages:deploy --message "Optional commit message"
 This will do the following:
 
 - creates GitHub repo for the current project if one doesn't exist
-- rebuilds the app at the current `HEAD`
+- rebuilds the app in production mode at the current `HEAD`
 - creates a local `gh-pages` branch if one doesn't exist
 - moves your app to the `gh-pages` branch and creates a commit
 - edit the base tag in index.html to support github pages
@@ -173,6 +174,16 @@ This will do the following:
 Creating the repo requires a token from github, and the remaining functionality
 relies on ssh authentication for all git operations that communicate with github.com.
 To simplify the authentication, be sure to [setup your ssh keys](https://help.github.com/articles/generating-ssh-keys/).
+
+If you are deploying a [user or organization page](https://help.github.com/articles/user-organization-and-project-pages/), you can instead use the following command:
+
+```
+ng github-pages:deploy --user-page --message "Optional commit message"
+```
+
+This command pushes the app to the `master` branch on the github repo instead
+of pushing to `gh-pages`, since user and organization pages require this.
+
 
 ### Linting and formatting code
 

--- a/addon/ng2/commands/github-pages-deploy.ts
+++ b/addon/ng2/commands/github-pages-deploy.ts
@@ -149,13 +149,19 @@ module.exports = Command.extend({
 
     function copyFiles() {
       return fsReadDir('dist')
-        .then((files) => Promise.all(files.map((file) => fsCopy(path.join('dist', file), path.join('.', file)))))
+        .then((files) => Promise.all(files.map((file) => {
+          if (file === '.gitignore'){
+            // don't overwrite the .gitignore file
+            return Promise.resolve();
+          } 
+          return fsCopy(path.join('dist', file), path.join('.', file))
+        })));
     }
 
     function updateBaseHref() {
       let indexHtml = path.join(root, 'index.html');
       return fsReadFile(indexHtml, 'utf8')
-        .then((data) => data.replace(/<base href="\/">/g, `<base href="/${projectName}/>"`))
+        .then((data) => data.replace(/<base href="\/">/g, `<base href="/${projectName}/">`))
         .then((data) => fsWriteFile(indexHtml, data, 'utf8'));
     }
 

--- a/addon/ng2/commands/github-pages-deploy.ts
+++ b/addon/ng2/commands/github-pages-deploy.ts
@@ -33,10 +33,10 @@ module.exports = Command.extend({
       default: 'production',
       description: 'The Angular environment to create a build for'
     }, {
-      name: 'branch',
-      type: String,
-      default: 'gh-pages',
-      description: 'The git branch to push your pages to'
+      name: 'user-page',
+      type: Boolean,
+      default: false,
+      description: 'Deploy as a user/org page'
     }, {
       name: 'skip-build',
       type: Boolean,
@@ -62,6 +62,8 @@ module.exports = Command.extend({
     };
     var projectName = this.project.pkg.name;
 
+    let ghPagesBranch = 'gh-pages';
+    let destinationBranch = options.userPage ? 'master' : ghPagesBranch;
     let initialBranch;
 
     // declared here so that tests can stub exec
@@ -129,22 +131,29 @@ module.exports = Command.extend({
         .then(function(stdout) {
           if (!/origin\s+(https:\/\/|git@)github\.com/m.test(stdout)) {
             return createGithubRepoTask.run(createGithubRepoOptions)
-              .then(() => execPromise(`git push -u origin ${initialBranch}`));
+              .then(() => {
+                // only push starting branch if it's not the destinationBranch
+                // this happens commonly when using github user pages, since
+                // they require the destination branch to be 'master'
+                if (destinationBranch !== initialBranch) {
+                  execPromise(`git push -u origin ${initialBranch}`);
+                }
+              });
           }
         });
     }
 
     function checkoutGhPages() {
-      return execPromise(`git checkout ${options.branch}`)
+      return execPromise(`git checkout ${ghPagesBranch}`)
         .catch(createGhPagesBranch)
     }
 
     function createGhPagesBranch() {
-      return execPromise(`git checkout --orphan ${options.branch}`)
+      return execPromise(`git checkout --orphan ${ghPagesBranch}`)
         .then(() => execPromise('git rm --cached -r .', execOptions))
         .then(() => execPromise('git add .gitignore', execOptions))
         .then(() => execPromise('git clean -f -d', execOptions))
-        .then(() => execPromise(`git commit -m \"initial ${options.branch} commit\"`));
+        .then(() => execPromise(`git commit -m \"initial ${ghPagesBranch} commit\"`));
     }
 
     function copyFiles() {
@@ -175,8 +184,8 @@ module.exports = Command.extend({
       return execPromise(`git checkout ${initialBranch}`);
     }
 
-    function pushToGitRepo(committed) {
-      return execPromise(`git push origin ${options.branch}`);
+    function pushToGitRepo() {
+      return execPromise(`git push origin ${ghPagesBranch}:${destinationBranch}`);
     }
 
     function printProjectUrl() {

--- a/tests/acceptance/github-pages-deploy.spec.js
+++ b/tests/acceptance/github-pages-deploy.spec.js
@@ -22,7 +22,7 @@ describe('Acceptance: ng github-pages:deploy', function() {
   let execStub;
   let project = 'foo',
     initialBranch = 'master',
-    branch = 'gh-pages',
+    ghPagesBranch = 'gh-pages',
     message = 'new gh-pages version',
     remote = 'origin  git@github.com:username/project.git (fetch)';
 
@@ -71,11 +71,11 @@ describe('Acceptance: ng github-pages:deploy', function() {
     execStub.addExecSuccess('git status --porcelain')
       .addExecSuccess('git rev-parse --abbrev-ref HEAD', initialBranch)
       .addExecSuccess('git remote -v', remote)
-      .addExecSuccess(`git checkout ${branch}`)
+      .addExecSuccess(`git checkout ${ghPagesBranch}`)
       .addExecSuccess('git add .')
       .addExecSuccess(`git commit -m "${message}"`)
       .addExecSuccess(`git checkout ${initialBranch}`)
-      .addExecSuccess(`git push origin ${branch}`)
+      .addExecSuccess(`git push origin ${ghPagesBranch}:${ghPagesBranch}`)
       .addExecSuccess('git remote -v', remote);
 
     return ng(['github-pages:deploy', '--skip-build'])
@@ -87,21 +87,21 @@ describe('Acceptance: ng github-pages:deploy', function() {
   });
 
   it('should deploy with changed defaults', function() {
-    let branch = 'not-gh-pages',
+    let userPageBranch = 'master',
       message = 'not new gh-pages version';
 
     execStub.addExecSuccess('git status --porcelain')
       .addExecSuccess('git rev-parse --abbrev-ref HEAD', initialBranch)
       .addExecSuccess('git remote -v', remote)
-      .addExecSuccess(`git checkout ${branch}`)
+      .addExecSuccess(`git checkout ${ghPagesBranch}`)
       .addExecSuccess('git add .')
       .addExecSuccess(`git commit -m "${message}"`)
       .addExecSuccess(`git checkout ${initialBranch}`)
-      .addExecSuccess(`git push origin ${branch}`)
+      .addExecSuccess(`git push origin ${ghPagesBranch}:${userPageBranch}`)
       .addExecSuccess('git remote -v', remote);
 
     return ng(['github-pages:deploy', '--skip-build', `--message=${message}`,
-                `--branch=${branch}`])
+                '--user-page'])
       .then(() => {
         let indexHtml = path.join(process.cwd(), 'index.html');
         return fsReadFile(indexHtml, 'utf8');
@@ -113,16 +113,16 @@ describe('Acceptance: ng github-pages:deploy', function() {
     execStub.addExecSuccess('git status --porcelain')
       .addExecSuccess('git rev-parse --abbrev-ref HEAD', initialBranch)
       .addExecSuccess('git remote -v', remote)
-      .addExecError(`git checkout ${branch}`)
-      .addExecSuccess(`git checkout --orphan ${branch}`)
+      .addExecError(`git checkout ${ghPagesBranch}`)
+      .addExecSuccess(`git checkout --orphan ${ghPagesBranch}`)
       .addExecSuccess('git rm --cached -r .')
       .addExecSuccess('git add .gitignore')
       .addExecSuccess('git clean -f -d')
-      .addExecSuccess(`git commit -m \"initial ${branch} commit\"`)
+      .addExecSuccess(`git commit -m \"initial ${ghPagesBranch} commit\"`)
       .addExecSuccess('git add .')
       .addExecSuccess(`git commit -m "${message}"`)
       .addExecSuccess(`git checkout ${initialBranch}`)
-      .addExecSuccess(`git push origin ${branch}`)
+      .addExecSuccess(`git push origin ${ghPagesBranch}:${ghPagesBranch}`)
       .addExecSuccess('git remote -v', remote);
 
     return ng(['github-pages:deploy', '--skip-build'])
@@ -143,11 +143,11 @@ describe('Acceptance: ng github-pages:deploy', function() {
       .addExecSuccess('git remote -v', noRemote)
       .addExecSuccess(`git remote add origin git@github.com:${username}/${project}.git`)
       .addExecSuccess(`git push -u origin ${initialBranch}`)
-      .addExecSuccess(`git checkout ${branch}`)
+      .addExecSuccess(`git checkout ${ghPagesBranch}`)
       .addExecSuccess('git add .')
       .addExecSuccess(`git commit -m "${message}"`)
       .addExecSuccess(`git checkout ${initialBranch}`)
-      .addExecSuccess(`git push origin ${branch}`)
+      .addExecSuccess(`git push origin ${ghPagesBranch}:${ghPagesBranch}`)
       .addExecSuccess('git remote -v', remote);
 
     var httpsStub = sinon.stub(https, 'request', httpsRequestStubFunc);
@@ -246,7 +246,7 @@ describe('Acceptance: ng github-pages:deploy', function() {
     execStub.addExecSuccess('git status --porcelain')
       .addExecSuccess('git rev-parse --abbrev-ref HEAD', initialBranch)
       .addExecSuccess('git remote -v', remote)
-      .addExecSuccess(`git checkout ${branch}`)
+      .addExecSuccess(`git checkout ${ghPagesBranch}`)
       .addExecSuccess('git add .')
       .addExecSuccess(`git commit -m "${message}"`)
       .addExecError(`git checkout ${initialBranch}`, 'error: cannot stat \'src/client\': Permission denied');

--- a/tests/acceptance/github-pages-deploy.spec.js
+++ b/tests/acceptance/github-pages-deploy.spec.js
@@ -83,7 +83,7 @@ describe('Acceptance: ng github-pages:deploy', function() {
         let indexHtml = path.join(process.cwd(), 'index.html');
         return fsReadFile(indexHtml, 'utf8');
       })
-      .then((data) => expect(data.search(`<base href="/${project}/>"`)).to.not.equal(-1));
+      .then((data) => expect(data.search(`<base href="/${project}/">`)).to.not.equal(-1));
   });
 
   it('should deploy with changed defaults', function() {
@@ -106,7 +106,7 @@ describe('Acceptance: ng github-pages:deploy', function() {
         let indexHtml = path.join(process.cwd(), 'index.html');
         return fsReadFile(indexHtml, 'utf8');
       })
-      .then((data) => expect(data.search(`<base href="/${project}/>"`)).to.not.equal(-1));
+      .then((data) => expect(data.search(`<base href="/${project}/">`)).to.not.equal(-1));
   });
 
   it('should create branch if needed', function() {
@@ -130,7 +130,7 @@ describe('Acceptance: ng github-pages:deploy', function() {
         let indexHtml = path.join(process.cwd(), 'index.html');
         return fsReadFile(indexHtml, 'utf8');
       })
-      .then((data) => expect(data.search(`<base href="/${project}/>"`)).to.not.equal(-1));
+      .then((data) => expect(data.search(`<base href="/${project}/">`)).to.not.equal(-1));
   });
 
   it('should create repo if needed', function() {
@@ -187,7 +187,7 @@ describe('Acceptance: ng github-pages:deploy', function() {
         let indexHtml = path.join(process.cwd(), 'index.html');
         return fsReadFile(indexHtml, 'utf8');
       })
-      .then((data) => expect(data.search(`<base href="/${project}/>"`)).to.not.equal(-1))
+      .then((data) => expect(data.search(`<base href="/${project}/">`)).to.not.equal(-1))
       .then(() => httpsStub.restore());
   });
 


### PR DESCRIPTION
Deployment to github was broken due to a new `.gitignore` file that is now present in the `dist/` folder. This PR fixes that issue, and also fixes a broken rewrite of the base tag.

The second commit allows users to push to [user/organization pages](https://help.github.com/articles/user-organization-and-project-pages/), which require the generated project to go into the master branch in the repo (closes https://github.com/angular/angular-cli/issues/720).