### PR TITLE
fix(build): fix infinite loop on ng serve

### DIFF
--- a/lib/broccoli/broccoli-handlebars.js
+++ b/lib/broccoli/broccoli-handlebars.js
@@ -22,6 +22,7 @@ class HandlebarReplace extends BroccoliCacheWriter {
 
   build() {
     this.listFiles().forEach((filePath) => {
+      filePath = path.normalize(filePath);
       const destPath = filePath.replace(this.inputPaths[0], this.outputPath);
       const content = fs.readFileSync(filePath, 'utf-8');
       const template = Handlebars.compile(content);


### PR DESCRIPTION
Close #773

In windows, `filePath` seems to not be normalized and has the wrong separations, resulting in incorrect calculation of `destPath`.