### PR TITLE
feat(SASSPlugin): Allow regexes to be passed to include/exclude certain file patterns

### DIFF
--- a/lib/broccoli/angular-broccoli-sass.js
+++ b/lib/broccoli/angular-broccoli-sass.js
@@ -18,7 +18,8 @@ class SASSPlugin extends Plugin {
 
     options = options || {};
     Plugin.call(this, inputNodes, {
-      cacheInclude: [/\.scss$/, /\.sass$/]
+      cacheInclude: options.cacheInclude || [/\.scss$/, /\.sass$/],
+      cacheExclude: options.cacheExclude || undefined
     });
     this.options = options;
   }


### PR DESCRIPTION
Allow passing in cacheInclude and cacheExclude as options to the SASSPlugin, primarily so that filenames beginning with an underscore can be ignored during SASS/SCSS compilation, which is generally accepted to be a standard in SASS (http://sass-lang.com/guide#topic-4). These config values can be set in angular-cli-build.js thus:
```
    "sassCompiler": {
        "cacheExclude": [/\/_[^\/]+$/]
    }
```

This arguably closes issue #558