### PR TITLE
fix(mobile): prevent already-bundled JS from getting cached by Servic…

### DIFF
--- a/lib/broccoli/angular2-app.js
+++ b/lib/broccoli/angular2-app.js
@@ -159,14 +159,6 @@ class Angular2App extends BroccoliPlugin {
       merged = this._getBundleTree(merged);
     }
 
-    if (this.ngConfig.apps[0].mobile) {
-      var ServiceWorkerPlugin = require('@angular/service-worker').ServiceWorkerPlugin;
-      var swTree = new ServiceWorkerPlugin(merged);
-      merged = BroccoliMergeTrees([merged, swTree], {
-        overwrite: true
-      });
-    }
-
     return new BroccoliFunnel(merged, {
       destDir: this._destDir,
       overwrite: true
@@ -416,6 +408,7 @@ class Angular2App extends BroccoliPlugin {
     var indexContent = fs.readFileSync(indexFile, 'utf8');
     var scriptTagVendorFiles = indexContent.match(/vendor\/[^"']*\.js/gi);
     var vendorTree = this._getVendorNpmTree();
+    var assetsTree = this._getAssetsTree();
 
     var scriptTree = new BroccoliFunnel(preBundleTree, {
       include: scriptTagVendorFiles
@@ -452,9 +445,28 @@ class Angular2App extends BroccoliPlugin {
       bundleTree = uglify(bundleTree, {
         mangle: false
       });
+
+      // Required here since the package isn't installed for non-mobile apps.
+      var ServiceWorkerPlugin = require('@angular/service-worker').ServiceWorkerPlugin;
+      // worker.js is needed so it can be copied to dist
+      var workerJsTree = new BroccoliFunnel(jsTree, {
+        include: ['vendor/@angular/service-worker/dist/worker.js']
+      });
+      /**
+       * ServiceWorkerPlugin will automatically pre-fetch and cache every file
+       * in the tree it receives, so it should only receive the app bundle,
+       * and non-JS static files from the app. The plugin also needs to have
+       * the worker.js file available so it can copy it to dist.
+       **/
+      var swTree = new ServiceWorkerPlugin(BroccoliMergeTrees([
+        bundleTree,
+        assetsTree,
+        workerJsTree
+      ]));
+      bundleTree = BroccoliMergeTrees([bundleTree, swTree], {
+        overwrite: true
+      });
     }
-
-
 
     return BroccoliMergeTrees([nonJsTree, scriptTree, bundleTree], { overwrite: true });
   }


### PR DESCRIPTION
…e Worker

This change excludes all JS files, except for the production-ready bundle,
from the tree that the ServiceWorkerPlugin receives.