### PR TITLE
fix(mobile): don't import system-config in system-import.js

### DIFF
--- a/addon/ng2/blueprints/mobile/files/__path__/system-import.js
+++ b/addon/ng2/blueprints/mobile/files/__path__/system-import.js
@@ -1,3 +1,2 @@
-System.import('system-config.js').then(function () {
-  System.import('main');
-}).catch(console.error.bind(console));
+System.import('main')
+  .catch(console.error.bind(console));


### PR DESCRIPTION
It's not necessary since all modules have already been added
to app-concat.js.