### PR TITLE
fix(mobile): make app-shell compilation synchronous

### DIFF
--- a/addon/ng2/blueprints/mobile/files/__path__/main-app-shell.ts
+++ b/addon/ng2/blueprints/mobile/files/__path__/main-app-shell.ts
@@ -21,7 +21,7 @@ export const options = {
     provide(APP_BASE_HREF, {useValue: '/'}),
     provide(REQUEST_URL, {useValue: '/'})
   ],
-  async: true,
+  async: false,
   preboot: false
 };
 


### PR DESCRIPTION
App Shell should generally not require any async information in
order to render.