### PR TITLE
fix(): skips initialization of git if directory is already under version control

### DIFF
--- a/addon/ng2/tasks/git-init.js
+++ b/addon/ng2/tasks/git-init.js
@@ -30,6 +30,19 @@ module.exports = Task.extend({
 
     return exec('git --version')
       .then(function () {
+        // check if we're inside a git repo
+        return exec('git rev-parse --is-inside-work-tree')
+          .then(function () {
+            return true;
+          })
+          .catch(function() {
+            return false;
+          })
+      })    
+      .then(function (insideGitRepo) {
+        if (insideGitRepo) {
+          return ui.writeLine('Directory is already under version control. Skipping initialization of git.');
+        }  
         return exec('git init')
           .then(function () {
             return exec('git add .');


### PR DESCRIPTION
avoids nested git repos, which are probably not what we wanted to have
see also: http://boxysystems.com/index.php/nested-git-repo-gotchas/