### PR TITLE
feat(mobile): add app shell to mobile blueprint

### DIFF
--- a/addon/ng2/blueprints/mobile/files/__path__/main-app-shell.ts
+++ b/addon/ng2/blueprints/mobile/files/__path__/main-app-shell.ts
@@ -1,6 +1,7 @@
-import {provide} from '@angular/core';
-import {APP_BASE_HREF} from '@angular/common';
-import {<%= jsComponentName %>AppComponent} from './app/';
+import { provide } from '@angular/core';
+import { APP_BASE_HREF } from '@angular/common';
+import { APP_SHELL_BUILD_PROVIDERS } from '@angular/app-shell';
+import { <%= jsComponentName %>AppComponent } from './app/';
 import {
   REQUEST_URL,
   ORIGIN_URL
@@ -12,6 +13,7 @@ export const options = {
     <%= jsComponentName %>AppComponent
   ],
   platformProviders: [
+    APP_SHELL_BUILD_PROVIDERS,
     provide(ORIGIN_URL, {
       useValue: ''
     })

--- a/addon/ng2/blueprints/ng2/files/__path__/app/__name__.component.ts
+++ b/addon/ng2/blueprints/ng2/files/__path__/app/__name__.component.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component } from '@angular/core';<% if (isMobile) { %>
+import { APP_SHELL_DIRECTIVES } from '@angular/app-shell';<% } %>
 
 @Component({
   moduleId: module.id,
@@ -8,7 +9,8 @@ import { Component } from '@angular/core';
     {{title}}
   </h1>
   `,
-  styles: []<% } else { %>templateUrl: '<%= htmlComponentName %>.component.html',
+  styles: [],
+  directives: [APP_SHELL_DIRECTIVES]<% } else { %>templateUrl: '<%= htmlComponentName %>.component.html',
   styleUrls: ['<%= dasherizedModuleName %>.component.css']<% } %>
 })
 export class <%= jsComponentName %>AppComponent {

--- a/addon/ng2/blueprints/ng2/files/__path__/main.ts
+++ b/addon/ng2/blueprints/ng2/files/__path__/main.ts
@@ -1,9 +1,11 @@
 import { bootstrap } from '@angular/platform-browser-dynamic';
 import { enableProdMode } from '@angular/core';
-import { <%= jsComponentName %>AppComponent, environment } from './app/';
+import { <%= jsComponentName %>AppComponent, environment } from './app/';<% if(isMobile) { %>
+import { APP_SHELL_RUNTIME_PROVIDERS } from '@angular/app-shell';<% } %>
 
 if (environment.production) {
   enableProdMode();
 }
 
-bootstrap(<%= jsComponentName %>AppComponent);
+bootstrap(<%= jsComponentName %>AppComponent<% if(isMobile) { %>, [ APP_SHELL_RUNTIME_PROVIDERS ]<% } %>);
+

--- a/addon/ng2/blueprints/ng2/files/__path__/system-config.ts
+++ b/addon/ng2/blueprints/ng2/files/__path__/system-config.ts
@@ -21,7 +21,8 @@ const barrels: string[] = [
   '@angular/http',
   '@angular/router',
   '@angular/platform-browser',
-  '@angular/platform-browser-dynamic',
+  '@angular/platform-browser-dynamic',<% if(isMobile) { %>
+  '@angular/app-shell', <% } %>
 
   // Thirdparty barrels.
   'rxjs',

--- a/addon/ng2/blueprints/ng2/files/package.json
+++ b/addon/ng2/blueprints/ng2/files/package.json
@@ -30,6 +30,7 @@
     "@angular/platform-server": "2.0.0-rc.1",
     "@angular/router-deprecated": "2.0.0-rc.1",
     "@angular/service-worker": "^0.2.0",
+    "@angular/app-shell": "^0.0.0",
     "angular2-broccoli-prerender": "^0.11.0",
     "angular2-universal":"^0.100.3",
     "angular2-universal-polyfills": "^0.4.1",


### PR DESCRIPTION
This PR adds `@angular/app-shell` functionality out of the box if you are using the `--mobile` flag.