### PR TITLE
fix(build): fix broken sourcemaps

### DIFF
--- a/addon/ng2/blueprints/ng2/files/__path__/tsconfig.json
+++ b/addon/ng2/blueprints/ng2/files/__path__/tsconfig.json
@@ -4,7 +4,6 @@
     "declaration": false,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "mapRoot": "",
     "module": "commonjs",
     "moduleResolution": "node",
     "noEmitOnError": true,

--- a/addon/ng2/blueprints/ng2/files/angular-cli-build.js
+++ b/addon/ng2/blueprints/ng2/files/angular-cli-build.js
@@ -7,11 +7,11 @@ module.exports = function(defaults) {
     vendorNpmFiles: [
       'systemjs/dist/system-polyfills.js',
       'systemjs/dist/system.src.js',
-      'zone.js/dist/*.js',
+      'zone.js/dist/**/*.+(js|js.map)',
       'es6-shim/es6-shim.js',
-      'reflect-metadata/*.js',
-      'rxjs/**/*.js',
-      '@angular/**/*.js'
+      'reflect-metadata/**/*.+(js|js.map)',
+      'rxjs/**/*.+(js|js.map)',
+      '@angular/**/*.+(js|js.map)'
     ]
   });
 };

--- a/lib/broccoli/angular2-app.js
+++ b/lib/broccoli/angular2-app.js
@@ -404,21 +404,18 @@ class Angular2App extends BroccoliPlugin {
   }
 
   _getBundleTree(preBundleTree){
-    var indexFile = path.join(this._sourceDir, 'index.html');
-    var indexContent = fs.readFileSync(indexFile, 'utf8');
-    var scriptTagVendorFiles = indexContent.match(/vendor\/[^"']*\.js/gi);
     var vendorTree = this._getVendorNpmTree();
     var assetsTree = this._getAssetsTree();
 
     var scriptTree = new BroccoliFunnel(preBundleTree, {
-      include: scriptTagVendorFiles
+      include: this._options.polyfills
     });
 
     var nonJsTree = new BroccoliFunnel(preBundleTree, {
       exclude: ['**/*.js', '**/*.js.map']
     });
     var jsTree = new BroccoliFunnel(preBundleTree, {
-      include: ['**/*.js']
+      include: ['**/*.js', '**/*.js.map']
     });
 
     var bundleTree = new BundlePlugin([jsTree]);

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "shelljs": "^0.7.0",
     "silent-error": "^1.0.0",
     "symlink-or-copy": "^1.0.3",
-    "systemjs-builder": "^0.15.16",
+    "systemjs-builder": "0.15.17",
     "typescript": "^1.8.10",
     "typings": "^0.8.1"
   },


### PR DESCRIPTION
The [latest version of SystemJS](https://github.com/systemjs/systemjs/releases/tag/0.19.28) fixed their support for sourcemaps, which caused our production builds to fail since our source maps weren't being generated/copied properly down the build pipeline.

This PR fixes that. Also closes https://github.com/angular/angular-cli/issues/829.