### PR TITLE
fix(lint): Update rule names for codelyzer 0.0.19

### DIFF
--- a/addon/ng2/blueprints/ng2/files/tslint.json
+++ b/addon/ng2/blueprints/ng2/files/tslint.json
@@ -62,11 +62,11 @@
     ],
     "component-selector-name": [true, "kebab-case"],
     "component-selector-type": [true, "element"],
-    "host-parameter-decorator": true,
-    "input-parameter-decorator": true,
-    "output-parameter-decorator": true,
-    "attribute-parameter-decorator": true,
-    "input-property-directive": true,
-    "output-property-directive": true
+    "use-host-property-decorator": true,
+    "use-input-property-decorator": true,
+    "use-output-property-decorator": true,
+    "no-attribute-parameter-decorator": true,
+    "no-input-rename": true,
+    "no-output-rename": true
   }
 }


### PR DESCRIPTION
Updated rules based on changes: https://github.com/mgechev/codelyzer/commit/6f985f9e84865e383d7d88ef54f1d96dc929c9c2
and https://github.com/mgechev/codelyzer/commit/ceaefa6b7c0d488e2f621343875e692770a57664

Currently running `ng lint` gives the message:

``` 
> tslint "src/**/*.ts"

Lint errors found in the listed files.
```

This fixes the errors because lint rules were not found because of name changes.