### PR TITLE
Ignore SASS/SCSS files starting with "_"

### DIFF
--- a/lib/broccoli/angular-broccoli-sass.js
+++ b/lib/broccoli/angular-broccoli-sass.js
@@ -63,6 +63,7 @@ exports.makeBroccoliTree = (sourceDir, options) => {
   if (sass && !compass) {
     let sassSrcTree = new Funnel(sourceDir, {
       include: ['**/*.sass', '**/*.scss'],
+      exclude: ['**/_*.sass', '**/_*.scss'],
       allowEmpty: true
     });
 


### PR DESCRIPTION
Ignore SASS or SCSS partial files starting with "_" as required in the SASS convention