### PR TITLE
added support for a new `sass-files` option

### DIFF
--- a/lib/broccoli/angular-broccoli-sass.js
+++ b/lib/broccoli/angular-broccoli-sass.js
@@ -25,12 +25,22 @@ class SASSPlugin extends Plugin {
   }
 
   build() {
+    let sassFileEndings = this.options['sass-files'] || ['.sass', '.scss'];
+
     this.listFiles().forEach(fileName => {
       // Normalize is necessary for changing `\`s into `/`s on windows.
-      this.compile(path.normalize(fileName),
-                   path.normalize(this.inputPaths[0]),
-                   path.normalize(this.outputPath));
+      let found = false;
+      sassFileEndings.forEach(ending => {
+        found = found || fileName.endsWith(ending);
+      });
+
+      if (found) {
+        this.compile(path.normalize(fileName),
+          path.normalize(this.inputPaths[0]),
+          path.normalize(this.outputPath));
+      }
     });
+
   }
 
   compile(fileName, inputPath, outputPath) {


### PR DESCRIPTION
Projects that have a large number of sass files but only a few that need to be compiled because of `@import`s can have a hard time with the CLI because of the automatic compilation included in the current implementation of the sass plugin.

This pull request adds the capability to provide a list of 'sass-files' that restrict the compiler to only compile files that end with the given name(s) or extensions. ends-with was the chosen solution so we can support the default configuration of compiling everything that ends with `.scss` or `.sass`

In use this looks like:
```
  return new Angular2App(defaults, {
    vendorNpmFiles: [],
    sassCompiler:{
      "sass-files":["main.scss"]
    }
  });
```

addresses [Issue 831](https://github.com/angular/angular-cli/issues/831)