### PR TITLE
chore(generator): Update template barrels to use 'export *'

### DIFF
--- a/addon/ng2/blueprints/component/files/__path__/index.ts
+++ b/addon/ng2/blueprints/component/files/__path__/index.ts
@@ -1,1 +1,1 @@
-export { <%= classifiedModuleName %>Component } from './<%= dasherizedModuleName %>.component';
+export * from './<%= dasherizedModuleName %>.component';

--- a/addon/ng2/blueprints/directive/files/__path__/index.ts
+++ b/addon/ng2/blueprints/directive/files/__path__/index.ts
@@ -1,1 +1,1 @@
-export {<%= classifiedModuleName %>} from './<%= dasherizedModuleName %>.directive';
+export * from './<%= dasherizedModuleName %>.directive';

--- a/addon/ng2/blueprints/pipe/files/__path__/index.ts
+++ b/addon/ng2/blueprints/pipe/files/__path__/index.ts
@@ -1,1 +1,1 @@
-export { <%= classifiedModuleName %> } from './<%= dasherizedModuleName %>.pipe';
+export * from './<%= dasherizedModuleName %>.pipe';

--- a/addon/ng2/blueprints/service/files/__path__/index.ts
+++ b/addon/ng2/blueprints/service/files/__path__/index.ts
@@ -1,1 +1,1 @@
-export {<%= classifiedModuleName %>Service} from './<%= dasherizedModuleName %>.service';
+export * from './<%= dasherizedModuleName %>.service';


### PR DESCRIPTION
This is in addition to #823. 

In https://github.com/angular/angular-cli/issues/820#issuecomment-220053064, @johnpapa suggested that we use `export *` for all barrels. This fixes all templates that have a barrel.