### PR TITLE
chore: delete .clang-format  from ng2 blueprint

### DIFF
--- a/addon/ng2/blueprints/ng2/files/.clang-format
+++ b/addon/ng2/blueprints/ng2/files/.clang-format
@@ -1,3 +1,0 @@
-Language:        JavaScript
-BasedOnStyle:    Google
-ColumnLimit:     100


### PR DESCRIPTION
related to #765  #798