### PR TITLE
feat:(support unit tests in folders outside of app)

### DIFF
--- a/addon/ng2/blueprints/ng2/files/config/karma-test-shim.js
+++ b/addon/ng2/blueprints/ng2/files/config/karma-test-shim.js
@@ -6,7 +6,7 @@ __karma__.loaded = function () {
 };
 
 var distPath = '/base/dist/';
-var appPath = distPath + 'app/';
+var appPaths = ['app']; //Add all valid source code folders here
 
 function isJsFile(path) {
   return path.slice(-3) == '.js';
@@ -17,7 +17,10 @@ function isSpecFile(path) {
 }
 
 function isAppFile(path) {
-  return isJsFile(path) && (path.substr(0, appPath.length) == appPath);
+  return isJsFile(path) && appPaths.some(function(appPath) {
+    var fullAppPath = distPath + appPath + '/';
+    return path.substr(0, fullAppPath.length) == fullAppPath;
+  });
 }
 
 var allSpecFiles = Object.keys(window.__karma__.files)


### PR DESCRIPTION
@hansl @Brocco @IgorMinar 
I am making a PR with a simple idea for supporting unit testing of code that lives outside the CLI 'app' folder.

We are currently working on a control suite where we are creating npm packages for individual components in a shared CLI project. We are using the app folder for a demo app/test bed for the components, but we would like to put the actual components in their own folders to mimic the npm scoped package structure in Angular material. 

It is currently possible to put components outside the app folder, but the unit test runner will skip any tests defined outside of app.  

My proposal is to make this more configurable by allowing us to specify all valid folders in an array in karma-test-shim.js

Anyway, it's just an idea that I had based on needing some more flexibility wrt folder structure.



