### PR TITLE
chore: add the angular2-dependencies-graph tool

### DIFF
--- a/packages/angular-cli/addon/index.js
+++ b/packages/angular-cli/addon/index.js
@@ -31,6 +31,7 @@ module.exports = {
       'completion': require('../commands/completion').default,
       'doc': require('../commands/doc').default,
       'github-pages-deploy': require('../commands/github-pages-deploy').default,
+      'deps': require('../commands/deps').default,
 
       // Easter eggs.
       'make-this-awesome': require('../commands/easter-egg').default,

--- a/packages/angular-cli/blueprints/ng2/files/package.json
+++ b/packages/angular-cli/blueprints/ng2/files/package.json
@@ -8,7 +8,8 @@
     "lint": "tslint \"<%= sourceDir %>/**/*.ts\"",
     "test": "ng test",
     "pree2e": "webdriver-manager update",
-    "e2e": "protractor"
+    "e2e": "protractor",
+    "deps": "ngd -f src/main.ts -d ./documentation/dependencies/"
   },
   "private": true,
   "dependencies": {
@@ -46,6 +47,7 @@
     "protractor": "4.0.9",
     "ts-node": "1.2.1",
     "tslint": "3.13.0",
-    "typescript": "2.0.2"
+    "typescript": "2.0.2",
+    "angular2-dependencies-graph": "1.0.0-alpha.1"
   }
 }

--- a/packages/angular-cli/commands/deps.ts
+++ b/packages/angular-cli/commands/deps.ts
@@ -1,0 +1,19 @@
+const Command = require('ember-cli/lib/models/command');
+import { DepsTask } from  '../tasks/deps';
+
+const DepsCommand = Command.extend({
+  name: 'deps',
+  description: 'Generate a visual representation of dependenecies',
+  works: 'insideProject',
+  run: function () {
+    const depsTask = new DepsTask({
+      ui: this.ui,
+      analytics: this.analytics,
+      project: this.project
+    });
+
+    return depsTask.run();
+  }
+});
+
+export default DepsCommand;

--- a/packages/angular-cli/tasks/deps.ts
+++ b/packages/angular-cli/tasks/deps.ts
@@ -1,0 +1,23 @@
+const Task = require('ember-cli/lib/models/task');
+import * as Promise from 'ember-cli/lib/ext/promise';
+import * as chalk from 'chalk';
+import {exec} from 'child_process';
+
+export const DepsTask: any = Task.extend({
+  run: function () {
+    const ui = this.ui;
+
+    return new Promise(function(resolve, reject) {
+      exec('npm run deps', (err, stdout) => {
+        ui.writeLine(stdout);
+        if (err) {
+          ui.writeLine(chalk.red('Can not generate the graph dependencies.'));
+          reject();
+        } else {
+          ui.writeLine(chalk.green('Graph dependencies generated.'));
+          resolve();
+        }
+      });
+    });
+  }
+});


### PR DESCRIPTION
This is an attempt to integrate the the [angular2-dependencies-graph](http://manekinekko.github.io/angular2-dependencies-graph/) into the cli. See https://github.com/angular/angular-cli/issues/934 for more details.