### PR TITLE
remove the trailing folder slash, enhance editor syntax highlight by removing unresolved modules path

### DIFF
--- a/addon/ng2/blueprints/ng2/files/__path__/main.ts
+++ b/addon/ng2/blueprints/ng2/files/__path__/main.ts
@@ -1,6 +1,6 @@
 import { bootstrap } from '@angular/platform-browser-dynamic';
 import { enableProdMode } from '@angular/core';
-import { <%= jsComponentName %>AppComponent, environment } from './app/';<% if(isMobile) { %>
+import { <%= jsComponentName %>AppComponent, environment } from './app';<% if(isMobile) { %>
 import { APP_SHELL_RUNTIME_PROVIDERS } from '@angular/app-shell';<% } %>
 
 if (environment.production) {


### PR DESCRIPTION
In **WebStorm** editor, with trailing slash, cannot resolve the path

![screen shot 2016-05-30 at 6 08 41 pm](https://cloud.githubusercontent.com/assets/1148428/15660461/adcad6f2-2691-11e6-8313-9889d3db3422.png)

See the error curve line on *src* and *main.ts*

![screen shot 2016-05-30 at 6 10 42 pm](https://cloud.githubusercontent.com/assets/1148428/15660476/e67dd3dc-2691-11e6-9360-6856c960e8f2.png)


After remove the trailing slash

![screen shot 2016-05-30 at 6 09 07 pm](https://cloud.githubusercontent.com/assets/1148428/15660464/bd545b16-2691-11e6-85a4-863bbfcf09c7.png)

