### PR TITLE
fix(linter): tslint always exits nicely

### DIFF
--- a/addon/ng2/blueprints/ng2/files/package.json
+++ b/addon/ng2/blueprints/ng2/files/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "ng serve",
     "postinstall": "typings install",
-    "lint": "tslint \"<%= sourceDir %>/**/*.ts\"",
+    "lint": "tslint \"<%= sourceDir %>/**/*.ts\" --force",
     "test": "ng test",
     "pree2e": "webdriver-manager update",
     "e2e": "protractor"


### PR DESCRIPTION
This uses the `--force` flag of tslint to always exit the command in success,
even if violations are detected. It changes the current behaviour where the command
exits in error. See https://github.com/palantir/tslint#usage

Fixes #967 