### PR TITLE
fix(template): add missing parameter to protractor

### DIFF
--- a/addon/ng2/blueprints/ng2/files/package.json
+++ b/addon/ng2/blueprints/ng2/files/package.json
@@ -9,7 +9,7 @@
     "lint": "tslint \"<%= sourceDir %>/**/*.ts\"",
     "test": "ng test",
     "pree2e": "webdriver-manager update",
-    "e2e": "protractor"
+    "e2e": "protractor config/protractor.conf.js"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
Config file path parameter to protractor is missing in the generated
package.json which leads to failure of npm run e2e. Fix template to add
one.