### PR TITLE
fix(generator): load polyfills before zone.js

### DIFF
--- a/addon/ng2/blueprints/ng2/files/config/karma.conf.js
+++ b/addon/ng2/blueprints/ng2/files/config/karma.conf.js
@@ -15,9 +15,9 @@ module.exports = function (config) {
     },
     files: [
       { pattern: 'dist/vendor/es6-shim/es6-shim.js', included: true, watched: false },
+      { pattern: 'dist/vendor/systemjs/dist/system-polyfills.js', included: true, watched: false },
       { pattern: 'dist/vendor/zone.js/dist/zone.js', included: true, watched: false },
       { pattern: 'dist/vendor/reflect-metadata/Reflect.js', included: true, watched: false },
-      { pattern: 'dist/vendor/systemjs/dist/system-polyfills.js', included: true, watched: false },
       { pattern: 'dist/vendor/systemjs/dist/system.src.js', included: true, watched: false },
       { pattern: 'dist/vendor/zone.js/dist/async-test.js', included: true, watched: false },
       { pattern: 'dist/vendor/zone.js/dist/fake-async-test.js', included: true, watched: false },


### PR DESCRIPTION
My very limited understanding is that systemjs polyfills include a Promise polyfill that allows `zone.js` to intercept asynchronous task scheduling. The polyfill must be loaded before `zone.js` so that testing functions like [`flushMicrotasks`](https://angular.io/docs/ts/latest/api/testing/flushMicrotasks-function.html) work correctly with promises.

This test only passes when the polyfills are loaded first:

```typescript
import {
  describe,
  expect,
  fakeAsync,
  flushMicrotasks,
  it
} from '@angular/core/testing';

describe('flushMicrotasks', () => {
  it('flushes pending async tasks', fakeAsync(() => {
    let isResolved = false;
    Promise.resolve().then(() => {
      isResolved = true;
    });
    flushMicrotasks();
    expect(isResolved).toBe(true);
  }));
});
```