### PR TITLE
Removed ember-cli references in comments

### DIFF
--- a/bin/ng
+++ b/bin/ng
@@ -13,14 +13,14 @@ resolve('angular-cli', { basedir: process.cwd() },
   function (error, projectLocalCli) {
     var cli;
     if (error) {
-      // If there is an error, resolve could not find the ember-cli
+      // If there is an error, resolve could not find the ng-cli
       // library from a package.json. Instead, include it from a relative
       // path to this script file (which is likely a globally installed
-      // npm package). Most common cause for hitting this is `ember new`
+      // npm package). Most common cause for hitting this is `ng new`
       cli = require('../lib/cli');
     } else {
       // No error implies a projectLocalCli, which will load whatever
-      // version of ember-cli you have installed in a local package.json
+      // version of ng-cli you have installed in a local package.json
       cli = require(projectLocalCli);
     }
 


### PR DESCRIPTION
in this project, there are 117 references to `ember`.  Most of those are valid.

4 of those are `remember` and `member`. 
Most of the rest are references to the ember-cli  lib or utils that are used in the project.

The three I fixed here are in comments and I if I understand it correctly, they would be valid to change since they point to the ng-cli


(my counts are based on rev 901bad0af1fb9c90a9a93c0353a80a1c92e47f5e and counted with:
```
$ git grep -i ember |wc -l
     117
$ git grep -i '\bember\b' |wc -l
     105
```