### PR TITLE
feat(e2e): Added --config-file flag to e2e command

### DIFF
--- a/packages/angular-cli/commands/e2e.ts
+++ b/packages/angular-cli/commands/e2e.ts
@@ -6,7 +6,10 @@ const E2eCommand = Command.extend({
   name: 'e2e',
   description: 'Run e2e tests in existing project',
   works: 'insideProject',
-  run: function () {
+  availableOptions: [
+    { name: 'config', type: String, aliases: ['c', 'cf'] },
+  ],
+  run: function (commandOptions: any) {
     this.project.ngConfig = this.project.ngConfig || CliConfig.fromProject();
 
     const e2eTask = new E2eTask({
@@ -15,7 +18,7 @@ const E2eCommand = Command.extend({
       project: this.project
     });
 
-    return e2eTask.run();
+    return e2eTask.run(commandOptions);
   }
 });
 

--- a/packages/angular-cli/tasks/e2e.ts
+++ b/packages/angular-cli/tasks/e2e.ts
@@ -4,12 +4,16 @@ import {exec} from 'child_process';
 
 
 export const E2eTask = Task.extend({
-  run: function () {
+  run: function (options: any) {
     const ui = this.ui;
     let exitCode = 0;
 
+    let protractorConfig = (options.config) ?
+      this.project.ngConfig.config.e2e.protractor[options.config] :
+      this.project.ngConfig.config.e2e.protractor.config;
+
     return new Promise((resolve) => {
-      exec(`npm run e2e -- ${this.project.ngConfig.config.e2e.protractor.config}`,
+      exec(`npm run e2e -- ${protractorConfig}`,
         (err: NodeJS.ErrnoException, stdout: string, stderr: string) => {
           ui.writeLine(stdout);
           if (err) {

--- a/tests/e2e/tests/test/e2e.ts
+++ b/tests/e2e/tests/test/e2e.ts
@@ -19,5 +19,6 @@ export default function() {
     .then(() => _runServeAndE2e())
     .then(() => _runServeAndE2e('--prod'))
     .then(() => _runServeAndE2e('--aot'))
-    .then(() => _runServeAndE2e('--aot', '--prod'));
+    .then(() => _runServeAndE2e('--aot', '--prod'))
+    .then(() => _runServeAndE2e('--config', 'config'));
 }


### PR DESCRIPTION
This change will allow for a user to pass in a different config-file for e2e testing through the --config-file flag

Fix #976 
