### PR TITLE
chore(npm): update systemjs builder

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "shelljs": "^0.7.0",
     "silent-error": "^1.0.0",
     "symlink-or-copy": "^1.0.3",
-    "systemjs-builder": "0.15.17",
+    "systemjs-builder": "0.15.20",
     "typescript": "^1.8.10",
     "typings": "^0.8.1"
   },


### PR DESCRIPTION
The latest SystemJS builder version no longer fails when source maps are missing. This is helpful when upgrading projects generated before beta.5.

See https://github.com/systemjs/builder/releases/tag/0.15.20