### PR TITLE
feat(test): Add --config-file flag option to `ng test` command

### DIFF
--- a/packages/angular-cli/commands/test.ts
+++ b/packages/angular-cli/commands/test.ts
@@ -13,7 +13,8 @@ const NgCliTestCommand = TestCommand.extend({
     { name: 'log-level', type: String },
     { name: 'port', type: Number },
     { name: 'reporters', type: String },
-    { name: 'build', type: Boolean, default: true }
+    { name: 'build', type: Boolean, default: true },
+    { name: 'config', type: String, aliases: ['c', 'cf']}
   ],
 
   run: function(commandOptions: any) {

--- a/packages/angular-cli/tasks/test.ts
+++ b/packages/angular-cli/tasks/test.ts
@@ -13,7 +13,9 @@ export default Task.extend({
     const projectRoot = this.project.root;
     return new Promise((resolve) => {
       const karma = requireDependency(projectRoot, 'karma');
-      const karmaConfig = path.join(projectRoot, this.project.ngConfig.config.test.karma.config);
+      const karmaConfig = (options.config) ?
+        options.config :
+        path.join(projectRoot, this.project.ngConfig.config.test.karma.config);
 
       // Convert browsers from a string to an array
       if (options.browsers) {

--- a/tests/e2e/tests/test/test.ts
+++ b/tests/e2e/tests/test/test.ts
@@ -1,8 +1,12 @@
 import {ng} from '../../utils/process';
+import * as path from 'path';
 
 
 export default function() {
   // make sure both --watch=false and --single-run work
+  const karmaConfigPath = path.join(process.cwd(), './karma.conf.js');
+
   return ng('test', '--single-run')
-    .then(() => ng('test', '--watch=false'));
+    .then(() => ng('test', '--watch=false'))
+    .then(() => ng('test', '--watch=false', `--config=${karmaConfigPath}`));
 }


### PR DESCRIPTION
Allow for users to optionally specify a path to a karma config file on the `ng test` command which
will allow for the usage of a karma config file different from that set as the default in the
angular-cli.json file

Fixes: #976 
