### PR TITLE
feat(generate): Enable route generation for @angular/router v3

### DIFF
--- a/addon/ng2/blueprints/guard/files/__path__/__name__.guard.spec.ts
+++ b/addon/ng2/blueprints/guard/files/__path__/__name__.guard.spec.ts
@@ -1,0 +1,16 @@
+/* tslint:disable:no-unused-variable */
+
+import { addProviders, async, inject } from '@angular/core/testing';
+import { <%= classifiedModuleName %>Guard } from './<%= dasherizedModuleName %>.guard';
+
+describe('Guard: <%= classifiedModuleName %>', () => {
+  beforeEach(() => {
+    addProviders([<%= classifiedModuleName %>Guard]);
+  });
+
+  it('should ...',
+    inject([<%= classifiedModuleName %>Guard],
+      (guard: <%= classifiedModuleName %>Guard) => {
+        expect(guard).toBeTruthy();
+      }));
+});

--- a/addon/ng2/blueprints/guard/files/__path__/__name__.guard.ts
+++ b/addon/ng2/blueprints/guard/files/__path__/__name__.guard.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@angular/core';
+import { CanActivate, ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+
+@Injectable()
+export class <%= classifiedModuleName %>Guard implements CanActivate {
+  canActivate(
+    next:  ActivatedRouteSnapshot,
+    state: RouterStateSnapshot) : Observable<boolean> | boolean {
+    return true;
+  }
+}

--- a/addon/ng2/blueprints/guard/files/__path__/index.ts
+++ b/addon/ng2/blueprints/guard/files/__path__/index.ts
@@ -1,0 +1,1 @@
+export * from './<%= dasherizedModuleName %>.guard';

--- a/addon/ng2/blueprints/guard/index.js
+++ b/addon/ng2/blueprints/guard/index.js
@@ -1,11 +1,13 @@
-var path = require('path');
+'use strict';
+
+const dynamicPathParser = require('../../utilities/dynamic-path-parser');
+const addBarrelRegistration = require('../../utilities/barrel-management');
+const path = require('path');
 var Blueprint = require('ember-cli/lib/models/blueprint');
-var dynamicPathParser = require('../../utilities/dynamic-path-parser');
-var addBarrelRegistration = require('../../utilities/barrel-management');
 var getFiles = Blueprint.prototype.files;
 
 module.exports = {
-  description: '',
+  description: 'Generates a guard to be used in routing.',
 
   availableOptions: [
     { name: 'flat', type: Boolean, default: true }
@@ -58,7 +60,7 @@ module.exports = {
       return addBarrelRegistration(
         this,
         this.generatePath,
-        options.entity.name + '.service');
+        options.entity.name + '.guard');
     }
   }
 };

--- a/addon/ng2/blueprints/ng2/files/__path__/app/app.routes.ts
+++ b/addon/ng2/blueprints/ng2/files/__path__/app/app.routes.ts
@@ -1,0 +1,8 @@
+import { provideRouter, RouterConfig } from '@angular/router';
+
+const appRoutes: RouterConfig = [
+];
+
+export const APP_ROUTER_PROVIDERS = [
+  provideRouter(appRoutes)
+];

--- a/addon/ng2/blueprints/ng2/files/__path__/app/index.ts
+++ b/addon/ng2/blueprints/ng2/files/__path__/app/index.ts
@@ -1,2 +1,3 @@
 export * from './environment';
 export * from './app.component';
+export * from './app.routes';

--- a/addon/ng2/blueprints/ng2/files/__path__/main.ts
+++ b/addon/ng2/blueprints/ng2/files/__path__/main.ts
@@ -1,10 +1,13 @@
 import { bootstrap } from '@angular/platform-browser-dynamic';
 import { enableProdMode } from '@angular/core';
-import { AppComponent, environment } from './app/';<% if(isMobile) { %>
+import { APP_ROUTER_PROVIDERS, AppComponent, environment } from './app/';<% if(isMobile) { %>
 import { APP_SHELL_RUNTIME_PROVIDERS } from '@angular/app-shell';<% } %>
 
 if (environment.production) {
   enableProdMode();
 }
 
-bootstrap(AppComponent<% if(isMobile) { %>, [ APP_SHELL_RUNTIME_PROVIDERS ]<% } %>);
+bootstrap(AppComponent, [
+  APP_ROUTER_PROVIDERS<% if(isMobile) { %>,
+  APP_SHELL_RUNTIME_PROVIDERS<% } %>
+]);

--- a/addon/ng2/blueprints/route/files/__path__/__name__.routes.ts
+++ b/addon/ng2/blueprints/route/files/__path__/__name__.routes.ts
@@ -1,0 +1,7 @@
+import { RouterConfig } from '@angular/router';
+import { <%= classifiedModuleName %>Component } from './';
+
+export const <%= screamingSnakeCaseModuleName %>_ROUTES: RouterConfig = [{
+  path: '<%= dasherizedModuleName %>', component: <%= classifiedModuleName %>Component,
+  children: [ ]
+}];

--- a/addon/ng2/blueprints/route/index.js
+++ b/addon/ng2/blueprints/route/index.js
@@ -1,7 +1,74 @@
-module.exports = {
-  description: '',
+'use strict';
 
-  install: function () {
-    throw 'Due to changes in the router, route generation has been temporarily disabled. You can find more information about the new router here: http://victorsavkin.com/post/145672529346/angular-router';
+const Blueprint = require('ember-cli/lib/models/blueprint');
+const path = require('path');
+const dynamicPathParser = require('../../utilities/dynamic-path-parser');
+const stringUtils = require('ember-cli-string-utils');
+
+function getRoutePrefix(project) {
+  if (project.ngConfig &&
+      project.ngConfig.defaults &&
+      project.ngConfig.defaults.lazyRoutePrefix !== undefined) {
+    return project.ngConfig.defaults.lazyRoutePrefix;
+  }
+
+  return '+';
+}
+
+module.exports = {
+  description: 'Generates a route and a corresponding component.',
+
+  availableOptions: [
+    { name: 'lazy', type: Boolean, default: true },
+    { name: 'inline-template', type: Boolean, default: false, aliases: ['it'] },
+    { name: 'inline-style', type: Boolean, default: false, aliases: ['is'] },
+    { name: 'prefix', type: Boolean, default: true }
+  ],
+
+  beforeInstall: function(options) {
+    options.route = true;
+
+    if (options.lazy) {
+      options.isLazyRoute = true;
+    }
+
+    return Blueprint.load(path.join(__dirname, '..', 'component')).install(options);
+  },
+
+  normalizeEntityName: function (entityName) {
+    var parsedPath = dynamicPathParser(this.project, entityName);
+
+    if (parsedPath.name[0] === getRoutePrefix(this.project)) {
+      var index = entityName.lastIndexOf(parsedPath.name);
+      entityName = entityName.substr(0, index) + entityName.substr(index + 1);
+    }
+
+    this.dynamicPath = parsedPath;
+
+    //leave the entity name intact for component generation
+    return entityName;
+  },
+
+  locals: function (options) {
+    return {
+      dynamicPath: this.dynamicPath.dir.replace(this.dynamicPath.appRoot, ''),
+      screamingSnakeCaseModuleName: stringUtils.underscore(stringUtils.dasherize(options.entity.name)).toUpperCase()
+    };
+  },
+
+  fileMapTokens: function (options) {
+    // Return custom template variables here.
+    return {
+      __path__: () => {
+        var dir = this.dynamicPath.dir;
+        var lazyPrefix = this.options.lazy ? getRoutePrefix(this.project) : '';
+
+        if (!options.locals.flat) {
+          dir += path.sep + lazyPrefix + options.dasherizedModuleName;
+        }
+
+        return dir;
+      }
+    };
   }
 };

--- a/addon/ng2/commands/generate.ts
+++ b/addon/ng2/commands/generate.ts
@@ -21,7 +21,7 @@ const GenerateCommand = EmberGenerateCommand.extend({
       !fs.existsSync(path.join(__dirname, '..', 'blueprints', rawArgs[0]))) {
       SilentError.debugOrThrow('angular-cli/commands/generate', `Invalid blueprint: ${rawArgs[0]}`);
     }
-    
+
     // Override default help to hide ember blueprints
     EmberGenerateCommand.prototype.printDetailedHelp = function (options) {
       var blueprintList = fs.readdirSync(path.join(__dirname, '..', 'blueprints'));
@@ -29,7 +29,7 @@ const GenerateCommand = EmberGenerateCommand.extend({
         .filter(bp => bp.indexOf('-test') === -1)
         .filter(bp => bp !== 'ng2')
         .map(bp => Blueprint.load(path.join(__dirname, '..', 'blueprints', bp)));
-      
+
       var output = '';
       blueprints
         .forEach(function (bp) {
@@ -38,7 +38,7 @@ const GenerateCommand = EmberGenerateCommand.extend({
       this.ui.writeLine(chalk.cyan('  Available blueprints'));
       this.ui.writeLine(output);
     };
-    
+
     return EmberGenerateCommand.prototype.beforeRun.apply(this, arguments);
   }
 });
@@ -53,6 +53,7 @@ const aliasMap = {
   'c': 'component',
   'd': 'directive',
   'e': 'enum',
+  'g': 'guard',
   'p': 'pipe',
   'r': 'route',
   's': 'service'

--- a/tests/acceptance/generate-guard.spec.js
+++ b/tests/acceptance/generate-guard.spec.js
@@ -1,0 +1,141 @@
+/*eslint-disable no-console */
+'use strict';
+
+var fs = require('fs-extra');
+var ng = require('../helpers/ng');
+var existsSync = require('exists-sync');
+var expect = require('chai').expect;
+var path = require('path');
+var tmp = require('../helpers/tmp');
+var root = process.cwd();
+var conf = require('ember-cli/tests/helpers/conf');
+var Promise = require('ember-cli/lib/ext/promise');
+var SilentError = require('silent-error');
+
+describe('Acceptance: ng generate guard', function () {
+  before(conf.setup);
+
+  after(conf.restore);
+
+  beforeEach(function () {
+    return tmp.setup('./tmp').then(function () {
+      process.chdir('./tmp');
+    }).then(function () {
+      return ng(['new', 'foo', '--skip-npm', '--skip-bower']);
+    });
+  });
+
+  afterEach(function () {
+    this.timeout(10000);
+
+    return tmp.teardown('./tmp');
+  });
+
+  it('ng generate guard my-guard', function () {
+    return ng(['generate', 'guard', 'my-guard']).then(() => {
+      var testPath = path.join(root, 'tmp', 'foo', 'src', 'app', 'my-guard.guard.ts');
+      expect(existsSync(testPath)).to.equal(true);
+    });
+  });
+
+  it('ng generate guard test' + path.sep + 'my-guard', function () {
+    fs.mkdirsSync(path.join(root, 'tmp', 'foo', 'src', 'app', 'test'));
+    return ng(['generate', 'guard', 'test' + path.sep + 'my-guard']).then(() => {
+      var testPath = path.join(root, 'tmp', 'foo', 'src', 'app', 'test', 'my-guard.guard.ts');
+      expect(existsSync(testPath)).to.equal(true);
+    });
+  });
+
+  it('ng generate guard test' + path.sep + '..' + path.sep + 'my-guard', function () {
+    return ng(['generate', 'guard', 'test' + path.sep + '..' + path.sep + 'my-guard']).then(() => {
+      var testPath = path.join(root, 'tmp', 'foo', 'src', 'app', 'my-guard.guard.ts');
+      expect(existsSync(testPath)).to.equal(true);
+    });
+  });
+
+  it('ng generate guard my-guard from a child dir', () => {
+    fs.mkdirsSync(path.join(root, 'tmp', 'foo', 'src', 'app', '1'));
+    return new Promise(function (resolve) {
+      process.chdir('./src');
+      resolve();
+    })
+      .then(() => process.chdir('./app'))
+      .then(() => process.chdir('./1'))
+      .then(() => {
+        process.env.CWD = process.cwd();
+        return ng(['generate', 'guard', 'my-guard'])
+      })
+      .then(() => {
+        var testPath = path.join(root, 'tmp', 'foo', 'src', 'app', '1', 'my-guard.guard.ts');
+        expect(existsSync(testPath)).to.equal(true);
+      }, err => console.log('ERR: ', err));
+  });
+
+  it('ng generate guard child-dir' + path.sep + 'my-guard from a child dir', () => {
+    fs.mkdirsSync(path.join(root, 'tmp', 'foo', 'src', 'app', '1', 'child-dir'));
+    return new Promise(function (resolve) {
+      process.chdir('./src');
+      resolve();
+    })
+      .then(() => process.chdir('./app'))
+      .then(() => process.chdir('./1'))
+      .then(() => {
+        process.env.CWD = process.cwd();
+        return ng(['generate', 'guard', 'child-dir' + path.sep + 'my-guard'])
+      })
+      .then(() => {
+        var testPath = path.join(
+          root, 'tmp', 'foo', 'src', 'app', '1', 'child-dir', 'my-guard.guard.ts');
+        expect(existsSync(testPath)).to.equal(true);
+      }, err => console.log('ERR: ', err));
+  });
+
+  it('ng generate guard child-dir' + path.sep + '..' + path.sep + 'my-guard from a child dir',
+    () => {
+      fs.mkdirsSync(path.join(root, 'tmp', 'foo', 'src', 'app', '1'));
+      return new Promise(function (resolve) {
+        process.chdir('./src');
+        resolve();
+      })
+        .then(() => process.chdir('./app'))
+        .then(() => process.chdir('./1'))
+        .then(() => {
+          process.env.CWD = process.cwd();
+          return ng(
+            ['generate', 'guard', 'child-dir' + path.sep + '..' + path.sep + 'my-guard'])
+        })
+        .then(() => {
+          var testPath =
+            path.join(root, 'tmp', 'foo', 'src', 'app', '1', 'my-guard.guard.ts');
+          expect(existsSync(testPath)).to.equal(true);
+        }, err => console.log('ERR: ', err));
+    });
+
+  it('ng generate guard ' + path.sep + 'my-guard from a child dir, gens under ' +
+    path.join('src', 'app'),
+    () => {
+      fs.mkdirsSync(path.join(root, 'tmp', 'foo', 'src', 'app', '1'));
+      return new Promise(function (resolve) {
+        process.chdir('./src');
+        resolve();
+      })
+        .then(() => process.chdir('./app'))
+        .then(() => process.chdir('./1'))
+        .then(() => {
+          process.env.CWD = process.cwd();
+          return ng(['generate', 'guard', path.sep + 'my-guard'])
+        })
+        .then(() => {
+          var testPath = path.join(root, 'tmp', 'foo', 'src', 'app', 'my-guard.guard.ts');
+          expect(existsSync(testPath)).to.equal(true);
+        }, err => console.log('ERR: ', err));
+    });
+
+  it('ng generate guard ..' + path.sep + 'my-guard from root dir will fail', () => {
+    return ng(['generate', 'guard', '..' + path.sep + 'my-guard']).then(() => {
+      throw new SilentError(`ng generate guard ..${path.sep}my-guard from root dir should fail.`);
+    }, (err) => {
+      expect(err).to.equal(`Invalid path: "..${path.sep}my-guard" cannot be above the "src${path.sep}app" directory`);
+    });
+  });
+});

--- a/tests/acceptance/generate-route.spec.js
+++ b/tests/acceptance/generate-route.spec.js
@@ -12,13 +12,7 @@ const root = process.cwd();
 
 const testPath = path.join(root, 'tmp', 'foo', 'src', 'app');
 
-function fileExpectations(lazy, expectation) {
-  const lazyPrefix = lazy ? '+' : '';
-  const dir = `${lazyPrefix}my-route`;
-  expect(existsSync(path.join(testPath, dir, 'my-route.component.ts'))).to.equal(expectation);
-}
-
-xdescribe('Acceptance: ng generate route', function () {
+describe('Acceptance: ng generate route', function () {
   before(conf.setup);
 
   after(conf.restore);
@@ -39,23 +33,23 @@ xdescribe('Acceptance: ng generate route', function () {
 
   it('ng generate route my-route', function () {
     return ng(['generate', 'route', 'my-route']).then(() => {
-      fileExpectations(true, true);
-    });
-  });
-
-  it('ng generate route my-route --lazy false', function () {
-    return ng(['generate', 'route', 'my-route', '--lazy', 'false']).then(() => {
-      fileExpectations(false, true);
+      expect(existsSync(path.join(testPath, '+my-route', 'my-route.routes.ts'))).to.be.true;
     });
   });
 
   it('ng generate route +my-route', function () {
     return ng(['generate', 'route', '+my-route']).then(() => {
-      fileExpectations(true, true);
+      expect(existsSync(path.join(testPath, '+my-route', 'my-route.routes.ts'))).to.be.true;
     });
   });
 
-  it('ng generate route +my-route/my-other', () => {
+  it('ng generate route my-route --lazy false', function () {
+    return ng(['generate', 'route', 'my-route', '--lazy', 'false']).then(() => {
+      expect(existsSync(path.join(testPath, 'my-route', 'my-route.routes.ts'))).to.be.true;
+    });
+  });
+
+  it.skip('ng generate route +my-route/my-other', () => {
     return ng(['generate', 'route', '+my-route'])
       .then(() => ng(['generate', 'route', '+my-route/my-other', '--default']))
       .then(() => ng(['generate', 'route', '+my-route/+my-other/my-third', '--default']))
@@ -79,7 +73,7 @@ xdescribe('Acceptance: ng generate route', function () {
       });
   });
 
-  it('ng generate route details --path /details/:id', () => {
+  it.skip('ng generate route details --path /details/:id', () => {
     return ng(['generate', 'route', 'details', '--path', '/details/:id'])
       .then(() => {
         const appContent = fs.readFileSync(path.join(testPath, 'foo.component.ts'), 'utf-8');
@@ -87,7 +81,7 @@ xdescribe('Acceptance: ng generate route', function () {
       });
   });
 
-  it('ng generate route my-route --dry-run does not modify files', () => {
+  it.skip('ng generate route my-route --dry-run does not modify files', () => {
     var parentComponentPath = path.join(testPath, 'foo.component.ts');
     var parentComponentHtmlPath = path.join(testPath, 'foo.component.html')
 
@@ -102,14 +96,13 @@ xdescribe('Acceptance: ng generate route', function () {
       expect(afterGenerateParentHtml).to.equal(unmodifiedParentComponentHtml);
     });
   });
-  
+
   it('lazy route prefix', () => {
     return ng(['set', 'defaults.lazyRoutePrefix', 'myprefix'])
       .then(() => ng(['generate', 'route', 'prefix-test']))
       .then(() => {
-        var folderPath = path.join(testPath, 'myprefixprefix-test', 'prefix-test.component.ts');
-        expect(existsSync(folderPath))
-          .to.equal(true);
+        var folderPath = path.join(testPath, 'myprefixprefix-test', 'prefix-test.routes.ts');
+        expect(existsSync(folderPath)).to.equal(true);
       });
   });
 });

--- a/tests/acceptance/init.spec.js
+++ b/tests/acceptance/init.spec.js
@@ -59,7 +59,7 @@ describe('Acceptance: ng init', function () {
       expected[index] = expected[index].replace(/__styleext__/g, 'css');
       expected[index] = expected[index].replace(/__path__/g, 'src');
     });
-    
+
     if (isMobile) {
       expected = expected.filter(p => p.indexOf('tmp.component.html') < 0);
       expected = expected.filter(p => p.indexOf('tmp.component.css') < 0);


### PR DESCRIPTION
Eventually will fix https://github.com/angular/angular-cli/issues/1093

Route generation checklist:
- [x] Recreate `ng generate route`
- [x] Create `ng generate guard` and spec file
- [x] Create `app.routes.ts` boilerplate
- [x] Export `./app.routes` in app barrel
- [x] Import and bootstrap `APP_ROUTER_PROVIDERS`
- [x] Create blueprint for routes file
- [x] Allow `--lazy` to be set
- [ ] Allow custom `--path` to be set
- [ ] Modify parent `{component}.routes.ts`

If I am missing anything, please let me know and I will add it to the list.