### PR TITLE
fix(mobile): remove icon `density` field from manifest

### DIFF
--- a/addon/ng2/blueprints/mobile/files/__path__/manifest.webapp
+++ b/addon/ng2/blueprints/mobile/files/__path__/manifest.webapp
@@ -5,38 +5,32 @@
     {
 			"src": "/android-chrome-36x36.png",
 			"sizes": "36x36",
-			"type": "image/png",
-			"density": 0.75
+			"type": "image/png"
 		},
 		{
 			"src": "/android-chrome-48x48.png",
 			"sizes": "48x48",
-			"type": "image/png",
-			"density": 1
+			"type": "image/png"
 		},
 		{
 			"src": "/android-chrome-72x72.png",
 			"sizes": "72x72",
-			"type": "image/png",
-			"density": 1.5
+			"type": "image/png"
 		},
 		{
 			"src": "/android-chrome-96x96.png",
 			"sizes": "96x96",
-			"type": "image/png",
-			"density": 2
+			"type": "image/png"
 		},
 		{
 			"src": "/android-chrome-144x144.png",
 			"sizes": "144x144",
-			"type": "image/png",
-			"density": 3
+			"type": "image/png"
 		},
 		{
 			"src": "/android-chrome-192x192.png",
 			"sizes": "192x192",
-			"type": "image/png",
-			"density": 4
+			"type": "image/png"
 		}
   ],
   "theme_color": "#000000",


### PR DESCRIPTION
`density` was deprecated
see: https://developers.google.com/web/updates/2014/11/Support-for-installable-web-apps-with-webapp-manifest-in-chrome-38-for-Android?hl=en
see: https://developer.mozilla.org/en-US/docs/Web/Manifest

Fixes #1178