### PR TITLE
fix(mobile): add `icons/` path in front of icon `src` values

### DIFF
--- a/addon/ng2/blueprints/mobile/files/__path__/manifest.webapp
+++ b/addon/ng2/blueprints/mobile/files/__path__/manifest.webapp
@@ -3,37 +3,37 @@
   "short_name": "<%= fullAppName %>",
   "icons": [
     {
-			"src": "/android-chrome-36x36.png",
+			"src": "icons/android-chrome-36x36.png",
 			"sizes": "36x36",
 			"type": "image/png",
 			"density": 0.75
 		},
 		{
-			"src": "/android-chrome-48x48.png",
+			"src": "icons/android-chrome-48x48.png",
 			"sizes": "48x48",
 			"type": "image/png",
 			"density": 1
 		},
 		{
-			"src": "/android-chrome-72x72.png",
+			"src": "icons/android-chrome-72x72.png",
 			"sizes": "72x72",
 			"type": "image/png",
 			"density": 1.5
 		},
 		{
-			"src": "/android-chrome-96x96.png",
+			"src": "icons/android-chrome-96x96.png",
 			"sizes": "96x96",
 			"type": "image/png",
 			"density": 2
 		},
 		{
-			"src": "/android-chrome-144x144.png",
+			"src": "icons/android-chrome-144x144.png",
 			"sizes": "144x144",
 			"type": "image/png",
 			"density": 3
 		},
 		{
-			"src": "/android-chrome-192x192.png",
+			"src": "icons/android-chrome-192x192.png",
 			"sizes": "192x192",
 			"type": "image/png",
 			"density": 4


### PR DESCRIPTION
fix 'Add to Homescreen' on mobile not finding icons in `dist/icons`
seen when running `ng build --prod`

Fixes #1179