### PR TITLE
build(broccoli): Expose `options` property of `Angular2App` 

### DIFF
--- a/lib/broccoli/angular2-app.js
+++ b/lib/broccoli/angular2-app.js
@@ -54,6 +54,14 @@ class Angular2App extends BroccoliPlugin {
   }
 
   /**
+   * For compatibility with Ember addons
+   * @returns {*|{}}
+   */
+  get options(){
+    return this._options;
+  }
+
+  /**
    * For backward compatibility.
    * @public
    * @method toTree


### PR DESCRIPTION
Expose `options` property of `Angular2App` to be (more) compatible with existing ember addons.

Motivation: allow angular-cli builds to take advantage of other brocolli plugins that do double duty as ember-cli addons. Specifically, `broccoli-asset-rev`
Expose the `_options` property as a public getter through `options` to allow the ember addon to query for options without throwing fatal build errors

Closes #1226