### PR TITLE
chore: update index.html to reflect alpha router changes. 

### DIFF
--- a/addon/ng2/blueprints/ng2/files/__path__/index.html
+++ b/addon/ng2/blueprints/ng2/files/__path__/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title><%= jsComponentName %></title>
-  <base href="/">
+  <base href=".">
 
   {{#unless environment.production}}
   <script src="/ember-cli-live-reload.js" type="text/javascript"></script>


### PR DESCRIPTION
Base href has not been updated; it continues to show the deprecated "/" which should be <base href="."> as per official docs.
This change might also prevent possible issues with certain file:// protocol.