### PR TITLE
fix(mobile): remove app/index.js from concatenated bundle

### DIFF
--- a/lib/broccoli/angular2-app.js
+++ b/lib/broccoli/angular2-app.js
@@ -440,8 +440,7 @@ class Angular2App extends BroccoliPlugin {
       }), {
         headerFiles: this._options.polyfills.concat([
           'system-config.js',
-          'main.js',
-          'app/index.js'
+          'main.js'
         ]),
         inputFiles: [
           'system-import.js'


### PR DESCRIPTION
Currently, when building for production with --mobile, there
is a runtime error because require is being called. This is
because the app/index.js file is being concatenated into the
final script, in addition to having already been processed 
by System bundler. Since it's already included in the bundle,
it shouldn't be explicitly added to the concatenated JS file.