### PR TITLE
docs: updated Environments section to reflect current behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,16 +132,16 @@ The build artifacts will be stored in the `dist/` directory.
 
 ### Environments
 
-At build time, the `src/client/app/environment.ts` will be replaced by either
+At build time, the `src/app/environment.ts` will be replaced by either
 `config/environment.dev.ts` or `config/environment.prod.ts`, depending on the
-current cli environment.
+current cli environment. The resulting file will be `dist/app/environment.ts`.
 
 Environment defaults to `dev`, but you can generate a production build via
 the `-prod` flag in either `ng build -prod` or `ng serve -prod`.
 
-You can also add your own env files other than `dev` and `prod` by creating a 
-`src/client/app/environment.{NAME}.ts` and use them by using the `--env=NAME` 
-flag on the build/serve commands. 
+You can also add your own env files other than `dev` and `prod` by creating a
+`config/environment.{NAME}.ts` and use them by using the `--env=NAME`
+flag on the build/serve commands.
 
 ### Bundling
 


### PR DESCRIPTION
The current documentation states that the `src/client/app/environment.ts` file will be replaced by the config/etc... removed `client` from the path.

Also, the section implies that a src/client/app/environment.{NAME}.ts will be used with the --env=NAME flag. Changed to reflect that it's actually `config/environment.{NAME}.ts`.