### PR TITLE
fix(less):Add exclude path options to less plugin.

### DIFF
--- a/lib/broccoli/angular-broccoli-less.js
+++ b/lib/broccoli/angular-broccoli-less.js
@@ -7,6 +7,7 @@ const fs            = require('fs');
 const fse           = require('fs-extra');
 const path          = require('path');
 const Funnel        = require('broccoli-funnel');
+const Minimatch     = require('minimatch').Minimatch;
 
 let less = requireOrNull('less');
 if (!less) {
@@ -14,7 +15,7 @@ if (!less) {
 }
 
 class LESSPlugin extends Plugin {
-  constructor(inputNodes, options) {
+  constructor(inputNodes, lessExclude, options) {
     super(inputNodes, {});
 
     options = options || {};
@@ -22,22 +23,40 @@ class LESSPlugin extends Plugin {
       cacheInclude: [/\.less$/]
     });
     this.options = options;
+    this.lessExclude = lessExclude;
   }
 
   build() {
-    return Promise.all(this.listEntries().map(e => {
+    return Promise.all(this.listEntries().filter(e => {
+      return !this.shouldExclude(e.relativePath);
+    }).map(e => {
       let fileName = path.resolve(e.basePath, e.relativePath);
-      return this.compile(fileName, this.inputPaths[0], this.outputPath);
+      return this.compile(fileName, this.inputPaths[0], this.outputPath, e.relativePath);
     }));
   }
 
-  compile(fileName, inputPath, outputPath) {
+  shouldExclude(path) {
+    if (this.lessExclude) {
+      for (var i = 0; i < this.lessExclude.length; i++) {
+        if (this.lessExclude[i].match(path)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  compile(fileName, inputPath, outputPath, relativePath) {
     let content = fs.readFileSync(fileName, 'utf8');
 
     return less.render(content, this.options)
       .then(output => {
         let filePath = fileName.replace(inputPath, outputPath).replace(/\.less$/, '.css');
         fse.outputFileSync(filePath, output.css, 'utf8');
+      }).catch(e => {
+        if (e && e.message) {
+          throw new Error('Error compiling less file: ' + relativePath + ' with message: "' + e.message + '"');
+        }
       });
   }
 }
@@ -48,7 +67,12 @@ exports.makeBroccoliTree = (sourceDir, options) => {
       include: ['**/*.less'],
       allowEmpty: true
     });
-
-    return new LESSPlugin([lessSrcTree], options);
+    var lessExclude = undefined;
+    if (options['exclude-paths']) {
+      lessExclude = options['exclude-paths'].map(e => {
+        return new Minimatch(e);
+      }); 
+    }
+    return new LESSPlugin([lessSrcTree], lessExclude, options);
   }
 };


### PR DESCRIPTION
Allow users to configure a less exclude paths so that all the less files can be inside the src/app directory, triggering the build on changes on any less file inside src/app. Throw an error message so that broccoli show a more useful message to the user when less compile fails.

This is how the options will look like:

```lessCompiler: { 'paths': ['src/app/less', 'node_modules/bootstrap-less' ], 'exclude-targets' : [ 'src/app/less/**/*.+(less)'] } }); }```