### PR TITLE
Turning on strict mode in system-config.ts. Fixes angular/angular-cli…

### DIFF
--- a/addon/ng2/blueprints/ng2/files/__path__/system-config.ts
+++ b/addon/ng2/blueprints/ng2/files/__path__/system-config.ts
@@ -1,3 +1,5 @@
+"use strict";
+
 // SystemJS configuration file, see links for more information
 // https://github.com/systemjs/systemjs
 // https://github.com/systemjs/systemjs/blob/master/docs/config-api.md


### PR DESCRIPTION
Fixes #758. 

V8 implementation seems to have a problem with `const` in sloppy mode. Latest Firefox does not have this problem. Rather than "downgrading" `const` to `var`, `system-config.ts` should have`"use strict";` at the beginning. This way in Chrome (version 51), `const` statement can work properly. Plus it's a good practice too to enable strict mode in newer projects such as angular2.

