### PR TITLE
fix: update webpack-dev-server (ng serve) support for `prod` target

### DIFF
--- a/addon/ng2/models/webpack-build-production.ts
+++ b/addon/ng2/models/webpack-build-production.ts
@@ -53,7 +53,7 @@ export const getWebpackProdConfigPartial = function(projectRoot: string, sourceD
     node: {
       global: 'window',
       crypto: 'empty',
-      process: false,
+      process: true,
       module: false,
       clearImmediate: false,
       setImmediate: false


### PR DESCRIPTION
Setting process to true for prod so that dev server can be used 