### PR TITLE
fix: fix tsconfig for editors

### DIFF
--- a/addon/ng2/blueprints/ng2/files/__path__/tsconfig.json
+++ b/addon/ng2/blueprints/ng2/files/__path__/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl":"./",
     "declaration": false,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
@@ -9,10 +8,5 @@
     "moduleResolution": "node",
     "sourceMap": true,
     "target": "es5"
-  },
-  "compileOnSave": false,
-  "buildOnSave": false,
-  "includes": [
-    "**.d.ts"
-  ]
+  }
 }


### PR DESCRIPTION
See https://github.com/angular/angular-cli/issues/1356

Removed some unneeded tsconfig options that were causing problems with editors, like squiggly lines indicating that decorator support was missing whereas it's explicit on the tsconfig.