### PR TITLE
fix: update to awesome-typescript-loader 2.1.0

### DIFF
--- a/addon/ng2/blueprints/ng2/files/__path__/tsconfig.json
+++ b/addon/ng2/blueprints/ng2/files/__path__/tsconfig.json
@@ -3,6 +3,7 @@
     "declaration": false,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
+    "lib": ["es6", "dom"],
     "mapRoot": "./",
     "module": "es6",
     "moduleResolution": "node",

--- a/addon/ng2/blueprints/ng2/files/__path__/typings.d.ts
+++ b/addon/ng2/blueprints/ng2/files/__path__/typings.d.ts
@@ -3,10 +3,6 @@
 // https://www.typescriptlang.org/docs/handbook/writing-declaration-files.html
 
 /// <reference path="<%= refToTypings %>/typings/index.d.ts" />
-/// <reference path="../node_modules/typescript/lib/lib.es2015.core.d.ts" />
-/// <reference path="../node_modules/typescript/lib/lib.es2015.collection.d.ts" />
-/// <reference path="../node_modules/typescript/lib/lib.es2015.promise.d.ts" />
-
 <% if(!isMobile) { %>
 declare var System: any;
 <% if(!isMobile) { %>declare var module: { id: string };<% } %>

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@types/rimraf": "0.0.25-alpha",
     "@types/webpack": "^1.12.22-alpha",
     "angular2-template-loader": "^0.4.0",
-    "awesome-typescript-loader": "^2.0.1",
+    "awesome-typescript-loader": "^2.1.0",
     "chalk": "^1.1.3",
     "compression-webpack-plugin": "^0.3.1",
     "copy-webpack-plugin": "^3.0.1",


### PR DESCRIPTION
Also remove typings references for es6 and dom libs that were needed to support windows. 