### PR TITLE
fix(): remove node6 deprecation warnings

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -85,7 +85,13 @@ module.exports = function(options) {
 
   const oldStderrWrite = process.stderr.write;
   process.stderr.write = function (line) {
-    line = line.toString()
+    line = line.toString();
+
+    if (line.match(/\(node\:(.*)/)) {
+      return;
+    }
+
+    line
       .replace(/ember-cli(?!.com)/g, 'angular-cli')
       .replace(/ember(?!-cli.com)/g, 'ng');
     return oldStderrWrite.apply(process.stdout, arguments);


### PR DESCRIPTION
This fix removes the `node6` deprecation warning that appears on every executed `ng` command.
Removed appearing message:
`(node:14774) fs: re-evaluating native module sources is not supported. If you are using the graceful-fs module, please update it to a more recent version.`