### PR TITLE
Listen on Host 0.0.0.0 by default

### DIFF
--- a/addon/ng2/commands/serve.ts
+++ b/addon/ng2/commands/serve.ts
@@ -37,7 +37,7 @@ module.exports = Command.extend({
 
   availableOptions: [
     { name: 'port',                 type: Number,  default: defaultPort,   aliases: ['p'] },
-    { name: 'host',                 type: String,  default: 'localhost',   aliases: ['H'],     description: 'Listens on all interfaces by default' },
+    { name: 'host',                 type: String,  default: '0.0.0.0',     aliases: ['H'],     description: 'Listens on all interfaces by default' },
     { name: 'proxy',                type: String,                          aliases: ['pr', 'pxy'] },
     { name: 'insecure-proxy',       type: Boolean, default: false,         aliases: ['inspr'], description: 'Set false to proxy self-signed SSL certificates' },
     { name: 'watcher',              type: String,  default: 'events',      aliases: ['w'] },


### PR DESCRIPTION
Before webpack, the server used to bind to 0.0.0.0 by default to allow connecting via network IPs like 192.168.5.1.
This makes it easier to develop mobile applications as you can just connect to the same network and access via IP.