### PR TITLE
chore(travis): cleanup travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,30 @@
 dist: trusty
 sudo: required
+language: node_js
+node_js:
+  - "5"
+  - "6"
+os:
+  - linux
+  - osx
 env:
   global:
     - DBUS_SESSION_BUS_ADDRESS=/dev/null
   matrix:
-    - NODE_VERSION=5 SCRIPT=lint
-    - NODE_VERSION=5 SCRIPT=test
-    - NODE_VERSION=5 TARGET=mobile SCRIPT=mobile_test
-    - NODE_VERSION=6 SCRIPT=test
-    - NODE_VERSION=6 TARGET=mobile SCRIPT=mobile_test
-os:
-  - linux
-  - osx
+    - SCRIPT=lint
+    - SCRIPT=test
+    - TARGET=mobile SCRIPT=mobile_test
 matrix:
   exclude:
+    - node_js: "6"
+      env: SCRIPT=lint
     - os: osx
-      env: NODE_VERSION=5 SCRIPT=lint
+      node_js: "5"
+      env: SCRIPT=lint
     - os: osx
-      env: NODE_VERSION=5 TARGET=mobile SCRIPT=mobile_test
-    - os: osx
-      env: NODE_VERSION=6 TARGET=mobile SCRIPT=mobile_test
-
-script:
-  - npm run-script $SCRIPT
+      env: TARGET=mobile SCRIPT=mobile_test
 
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.30.1/install.sh | bash; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then source ~/.nvm/nvm-exec; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew tap caskroom/cask; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew cask install google-chrome --force; fi
@@ -34,11 +32,11 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sh -e /etc/init.d/xvfb start; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export CHROME_BIN=chromium-browser; fi
   - if [[ "$TARGET" == "mobile" ]]; then export MOBILE_TEST=true; fi
-  - nvm install $NODE_VERSION
   - npm config set spin false
   - npm config set progress false
+
 install:
-  - node --version
-  - npm --version
-  - git --version
   - npm install --no-optional
+
+script:
+  - npm run-script $SCRIPT


### PR DESCRIPTION
This PR cleans up our travis file, fixing the following issues

- set the travis instances to be node_js instead of ruby (default)
- remove duplicated and and exclude matrix entries
- remove unneeded nvm install on osx
- remove unneeded npm install
- remove unneeded npm related prints (node_js instances print it already)

This should lower the average travis build time.