### PR TITLE
chore: Fixing the test in webpack by waiting for the platform to be initialized

### DIFF
--- a/addon/ng2/blueprints/ng2/files/__path__/test.ts
+++ b/addon/ng2/blueprints/ng2/files/__path__/test.ts
@@ -1,5 +1,3 @@
-
-/*global jasmine, __karma__, window*/
 import 'core-js/es6';
 import 'core-js/es7/reflect';
 
@@ -16,22 +14,27 @@ import 'zone.js/dist/sync-test';
 // RxJS
 import 'rxjs/Rx';
 
-Promise.all([
-    System.import('@angular/core/testing'),
-    System.import('@angular/platform-browser-dynamic/testing')
-  ]).then(function (providers) {
-    let testing = providers[0];
-    let testingBrowser = providers[1];
+// Unfortunately there's no typing for the `__karma__` variable. Just declare it as any.
+declare var __karma__: any;
 
+// Prevent Karma from running prematurely.
+__karma__.loaded = function () {};
+
+
+Promise.all([
+  System.import('@angular/core/testing'),
+  System.import('@angular/platform-browser-dynamic/testing')
+])
+  // First, initialize the Angular testing environment.
+  .then(([testing, testingBrowser]) => {
     testing.setBaseTestProviders(
       testingBrowser.TEST_BROWSER_DYNAMIC_PLATFORM_PROVIDERS,
       testingBrowser.TEST_BROWSER_DYNAMIC_APPLICATION_PROVIDERS
     );
-});
-
-let testContext: any = require.context('./', true, /\.spec\.ts/);
-function requireAll(requireContext: any) {
-  return requireContext.keys().map(requireContext);
-}
-
-requireAll(testContext);
+  })
+  // Then we find all the tests.
+  .then(() => require.context('./', true, /\.spec\.ts/))
+  // And load the modules.
+  .then(context => context.keys().map(context))
+  // Finally, start Karma to run the tests.
+  .then(__karma__.start, __karma__.error);


### PR DESCRIPTION
This properly waits for the tests to be loaded and ready before starting Karma.