### PR TITLE
Changed scss to css extension fro app.component.scss

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ To use these prepocessors simply add the file to your component's `styleUrls`:
   moduleId: module.id,
   selector: 'app-root',
   templateUrl: 'app.component.html',
-  styleUrls: ['app.component.scss']
+  styleUrls: ['app.component.css']
 })
 export class AppComponent {
   title = 'app works!';


### PR DESCRIPTION
According to the project created by `ng new sassy-project --style=sass` you dont need to change the extension in the component to `scss`