### PR TITLE
feat: add logic to filter out spec file associated with the given com…

### DIFF
--- a/addon/ng2/utilities/module-resolver.ts
+++ b/addon/ng2/utilities/module-resolver.ts
@@ -7,16 +7,13 @@ import * as dependentFilesUtils from './get-dependent-files';
 import { Promise } from 'es6-promise';
 import { Change, ReplaceChange } from './change';
 
-// The root directory of Angular Project.
-const ROOT_PATH = path.resolve('src/app');
-
 /** 
  * Rewrites import module of dependent files when the file is moved. 
  * Also, rewrites export module of related index file of the given file.
  */
 export class ModuleResolver {
 
-  constructor(public oldFilePath: string, public newFilePath: string) {}
+  constructor(public oldFilePath: string, public newFilePath: string, public rootPath) {}
 
   /**
    * Changes are applied from the bottom of a file to the top.
@@ -54,7 +51,7 @@ export class ModuleResolver {
    * @return {Promise<Change[]>} 
    */
   resolveDependentFiles(): Promise<Change[]> {
-    return dependentFilesUtils.getDependentFiles(this.oldFilePath, ROOT_PATH)
+    return dependentFilesUtils.getDependentFiles(this.oldFilePath, this.rootPath)
       .then((files:  dependentFilesUtils.ModuleMap) => {
         let changes: Change[] = [];
         Object.keys(files).forEach(file => {

--- a/tests/acceptance/get-dependent-files.spec.ts
+++ b/tests/acceptance/get-dependent-files.spec.ts
@@ -24,10 +24,12 @@ describe('Get Dependent Files: ', () => {
             'baz.html': '<h1> Hello </h1>'
           },
           'bar.component.ts': `import * from './baz/baz.component'
-                               import * from '../foo'`
+                               import * from '../foo'`,
+          'bar.component.spec.ts': ''
         },
         'foo-baz': {
-          'no-module.component.ts': ''
+          'no-module.component.ts': '',
+          'no-module.component.spec.ts': 'import * from "../bar/bar.component";'
         },
         'empty-dir': {}
       }
@@ -109,6 +111,7 @@ describe('Get Dependent Files: ', () => {
         .then((contents: dependentFilesUtils.ModuleMap) => {
           let bazFile = path.join(rootPath, 'bar/baz/baz.component.ts');
           let fooFile = path.join(rootPath, 'foo/foo.component.ts');
+          let noModuleSpecFile = path.join(rootPath, 'foo-baz/no-module.component.spec.ts');
           let expectedContents: dependentFilesUtils.ModuleMap = {};
           expectedContents[bazFile] = [{
               specifierText: '../bar.component',
@@ -119,6 +122,11 @@ describe('Get Dependent Files: ', () => {
             specifierText: '../bar/bar.component',
             pos: 85,
             end: 108
+          }];
+          expectedContents[noModuleSpecFile] = [{
+            specifierText: '../bar/bar.component',
+            pos: 13,
+            end: 36
           }];
           assert.deepEqual(contents, expectedContents);
         });


### PR DESCRIPTION
  add logic to filter out spec file associated with the given component unit while getting all dependent files
  add utlity function to get all the files (`.html`/`stylesheets`/`.spec.ts`) associated with the given component unit
   change the constructor method of the class ModuleResolver (add `rootPath` as an additional parameter)