### PR TITLE
feat: add features in get-dependent-files.ts

### DIFF
--- a/tests/acceptance/module-resolver.spec.ts
+++ b/tests/acceptance/module-resolver.spec.ts
@@ -22,7 +22,8 @@ describe('ModuleResolver', () => {
           'baz': {
             'baz.component.ts': `import * from "../bar.component"
                                  import * from '../../foo-baz/qux/quux/foobar/foobar.component'
-                                 `
+                                 `,
+            'baz.component.spec.ts': 'import * from "./baz.component";'
           },
           'bar.component.ts': `import * from './baz/baz.component'
                                import * from '../foo/foo.component'`,
@@ -64,7 +65,7 @@ describe('ModuleResolver', () => {
     it('when there is no index.ts in oldPath', () => {
       let oldFilePath = path.join(rootPath, 'bar/baz/baz.component.ts');
       let newFilePath = path.join(rootPath, 'foo');
-      let resolver = new ModuleResolver(oldFilePath, newFilePath);
+      let resolver = new ModuleResolver(oldFilePath, newFilePath, rootPath);
       return resolver.resolveDependentFiles()
         .then((changes) => resolver.applySortedChangePromise(changes))
         .then(() => dependentFilesUtils.createTsSourceFile(barFile))
@@ -93,7 +94,7 @@ describe('ModuleResolver', () => {
     it('when no files are importing the given file', () => {
       let oldFilePath = path.join(rootPath, 'foo-baz/foo-baz.component.ts');
       let newFilePath = path.join(rootPath, 'bar');
-      let resolver = new ModuleResolver(oldFilePath, newFilePath);
+      let resolver = new ModuleResolver(oldFilePath, newFilePath, rootPath);
       return resolver.resolveDependentFiles()
         .then((changes) => resolver.applySortedChangePromise(changes))
         .then(() => resolver.resolveOwnImports())
@@ -108,7 +109,7 @@ describe('ModuleResolver', () => {
     it('when oldPath and newPath both do not have index.ts', () => {
       let oldFilePath = path.join(rootPath, 'bar/baz/baz.component.ts');
       let newFilePath = path.join(rootPath, 'foo-baz');
-      let resolver = new ModuleResolver(oldFilePath, newFilePath);
+      let resolver = new ModuleResolver(oldFilePath, newFilePath, rootPath);
       return resolver.resolveDependentFiles()
         .then((changes) => resolver.applySortedChangePromise(changes))
         .then(() => dependentFilesUtils.createTsSourceFile(barFile))
@@ -137,7 +138,7 @@ describe('ModuleResolver', () => {
     it('when there are multiple spaces between symbols and specifier', () => {
       let oldFilePath = path.join(rootPath, 'foo-baz/qux/quux/foobar/foobar.component.ts');
       let newFilePath = path.join(rootPath, 'foo');
-      let resolver = new ModuleResolver(oldFilePath, newFilePath);
+      let resolver = new ModuleResolver(oldFilePath, newFilePath, rootPath);
       return resolver.resolveDependentFiles()
         .then((changes) => resolver.applySortedChangePromise(changes))
         .then(() => dependentFilesUtils.createTsSourceFile(fooQuxFile))


### PR DESCRIPTION
add logic to filter out spec file associated with the given component unit and all index files while getting all dependent files
add utlity function to get all the files (.html/stylesheets/.spec.ts) associated with the given component unit
change the constructor method of the class ModuleResolver (add 'rootPath' as an additional parameter)