### PR TITLE
fix(webpack-copy): preserves directory references from /public

### DIFF
--- a/addon/ng2/models/webpack-build-common.ts
+++ b/addon/ng2/models/webpack-build-common.ts
@@ -73,7 +73,11 @@ export function getWebpackCommonConfig(projectRoot: string, sourceDir: string) {
         filename: 'inline.js',
         sourceMapFilename: 'inline.map'
       }),
-      new CopyWebpackPlugin([{from: path.resolve(projectRoot, './public'), to: path.resolve(projectRoot, './dist')}])
+      new CopyWebpackPlugin([{
+        context: path.resolve(projectRoot, './public'),
+        from: '**/*', 
+        to: path.resolve(projectRoot, './dist')
+      }])
     ],
     node: {
       global: 'window',


### PR DESCRIPTION
Close https://github.com/angular/angular-cli/issues/1503