### PR TITLE
feat(htmlhint): add htmlhint-loader

### DIFF
--- a/addon/ng2/blueprints/ng2/files/.htmlhintrc
+++ b/addon/ng2/blueprints/ng2/files/.htmlhintrc
@@ -1,0 +1,4 @@
+{
+  "tagname-lowercase": true,
+  "attr-value-double-quotes": true
+}

--- a/addon/ng2/models/webpack-build-common.ts
+++ b/addon/ng2/models/webpack-build-common.ts
@@ -30,6 +30,11 @@ export function getWebpackCommonConfig(projectRoot: string, sourceDir: string) {
             path.resolve(projectRoot, 'node_modules/rxjs'),
             path.resolve(projectRoot, 'node_modules/@angular'),
           ]
+        },
+        {
+          test: /\.html$/,
+          loader: 'htmlhint-loader',
+          exclude: /node_modules/
         }
       ],
       loaders: [

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "glob": "^7.0.3",
     "handlebars": "^4.0.5",
     "html-webpack-plugin": "^2.19.0",
+    "htmlhint-loader": "^0.1.0",
     "istanbul-instrumenter-loader": "^0.2.0",
     "json-loader": "^0.5.4",
     "karma-sourcemap-loader": "^0.3.7",


### PR DESCRIPTION
Add htmlhint-loader to package.json and common webpack config to enable templateUrl htmlhint validation, along with a sample default .htmlhintrc