### PR TITLE
feature: disable --mobile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
   matrix:
     - SCRIPT=lint
     - SCRIPT=test
-    - TARGET=mobile SCRIPT=mobile_test
+#    - TARGET=mobile SCRIPT=mobile_test
 matrix:
   exclude:
     - node_js: "6"
@@ -21,8 +21,8 @@ matrix:
     - os: osx
       node_js: "5"
       env: SCRIPT=lint
-    - os: osx
-      env: TARGET=mobile SCRIPT=mobile_test
+#    - os: osx
+#      env: TARGET=mobile SCRIPT=mobile_test
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi

--- a/README.md
+++ b/README.md
@@ -212,7 +212,9 @@ You can modify the these scripts in `package.json` to run whatever tool you pref
 
 ### Support for offline applications
 
-Angular-CLI includes support for offline applications via the `--mobile` flag on `ng new`. Support is experimental, please see the angular/mobile-toolkit project and https://mobile.angular.io/ for documentation on how to make use of this functionality.
+**The `--mobile` flag has been disabled temporarily. Sorry for the inconvenience.**
+
+~~Angular-CLI includes support for offline applications via the `--` flag on `ng new`. Support is experimental, please see the angular/mobile-toolkit project and https://mobile.angular.io/ for documentation on how to make use of this functionality.~~
 
 ### Commands autocompletion
 

--- a/addon/ng2/commands/new.ts
+++ b/addon/ng2/commands/new.ts
@@ -52,6 +52,13 @@ const NewCommand = Command.extend({
         new SilentError(`We currently do not support a name of "${packageName}".`));
     }
 
+    if (commandOptions.mobile) {
+      return Promise.reject(new SilentError(
+        'The --mobile flag has been disabled temporarily while we await an update of ' +
+        'angular-universal for supporting NgModule. Sorry for the inconvenience.'
+      ));
+    }
+
     commandOptions.blueprint = normalizeBlueprint(commandOptions.blueprint);
 
     if (!commandOptions.directory) {


### PR DESCRIPTION
The `--mobile` flag need the angular-universal package and it has yet to be updated for Angular RC5. Since we'll generate apps that are compatible with Angular RC5 soon, we don't want to block a CLI release on angular-universal. The mobile team is aware and they're okay with this decision.