### PR TITLE
A small update in the SCSS integration section of README.md #1593

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ To use these prepocessors simply add the file to your component's `styleUrls`:
   moduleId: module.id,
   selector: 'app-root',
   templateUrl: 'app.component.html',
-  styleUrls: ['app.component.scss']
+  styleUrls: ['app.component.css']
 })
 export class AppComponent {
   title = 'app works!';


### PR DESCRIPTION
using ```styleUrls: ['app.component.scss']``` will result in 404 when loaded in the web browser #1593 