### PR TITLE
fix: Set fs building/polyfill empty for better package support

### DIFF
--- a/addon/ng2/models/webpack-build-common.ts
+++ b/addon/ng2/models/webpack-build-common.ts
@@ -75,11 +75,12 @@ export function getWebpackCommonConfig(projectRoot: string, sourceDir: string) {
       }),
       new CopyWebpackPlugin([{
         context: path.resolve(projectRoot, './public'),
-        from: '**/*', 
+        from: '**/*',
         to: path.resolve(projectRoot, './dist')
       }])
     ],
     node: {
+      fs: 'empty',
       global: 'window',
       crypto: 'empty',
       module: false,

--- a/addon/ng2/models/webpack-build-development.ts
+++ b/addon/ng2/models/webpack-build-development.ts
@@ -17,6 +17,7 @@ export const getWebpackDevConfigPartial = function(projectRoot: string, sourceDi
       resourcePath: path.resolve(projectRoot, `./${sourceDir}`)
     },
     node: {
+      fs: 'empty',
       global: 'window',
       crypto: 'empty',
       process: true,

--- a/addon/ng2/models/webpack-build-production.ts
+++ b/addon/ng2/models/webpack-build-production.ts
@@ -50,6 +50,7 @@ export const getWebpackProdConfigPartial = function(projectRoot: string, sourceD
       customAttrAssign: [/\)?\]?=/]
     },
     node: {
+      fs: 'empty',
       global: 'window',
       crypto: 'empty',
       process: true,

--- a/addon/ng2/models/webpack-build-test.js
+++ b/addon/ng2/models/webpack-build-test.js
@@ -86,6 +86,7 @@ const getWebpackTestConfig = function(projectRoot, sourceDir) {
       resourcePath: `./${sourceDir}`
     },
     node: {
+      fs: 'empty',
       global: 'window',
       process: false,
       crypto: 'empty',


### PR DESCRIPTION
Fixes #1583. 

Certain packages have issues with the default webpack node build-ins. `fs` specifically. Setting this to empty fixes this problem.