### PR TITLE
Adds handlebar plugin to webpack build

### DIFF
--- a/addon/ng2/models/webpack-build-common.ts
+++ b/addon/ng2/models/webpack-build-common.ts
@@ -4,8 +4,9 @@ import * as HtmlWebpackPlugin from 'html-webpack-plugin';
 import * as webpack from 'webpack';
 import { ForkCheckerPlugin } from 'awesome-typescript-loader';
 import { CliConfig } from './config';
+import {HandlebarsWebpackPlugin} from '../utilities/handlebars-webpack-plugin';
 
-export function getWebpackCommonConfig(projectRoot: string, sourceDir: string) {
+export function getWebpackCommonConfig(projectRoot: string, sourceDir: string, environment: any) {
   return {
     devtool: 'inline-source-map',
     resolve: {
@@ -63,6 +64,10 @@ export function getWebpackCommonConfig(projectRoot: string, sourceDir: string) {
       new HtmlWebpackPlugin({
         template: path.resolve(projectRoot, `./${sourceDir}/index.html`),
         chunksSortMode: 'dependency'
+      }),
+      new HandlebarsWebpackPlugin({
+        assetName: 'index.html',
+        data: environment,
       }),
       new webpack.optimize.CommonsChunkPlugin({
         name: ['polyfills']

--- a/addon/ng2/models/webpack-config.ts
+++ b/addon/ng2/models/webpack-config.ts
@@ -26,9 +26,10 @@ export class NgCliWebpackConfig {
   constructor(public ngCliProject: any, public target: string, public environment: string) {
     const sourceDir = CliConfig.fromProject().defaults.sourceDir;
 
-    const environmentPath = `./${sourceDir}/app/environments/environment.${environment}.ts`;
+    const environmentPath = path.resolve(this.ngCliProject.root, `./${sourceDir}/app/environments/environment.${environment}.ts`);
+    const environmentData = require(environmentPath);
 
-    this.webpackBaseConfig = getWebpackCommonConfig(this.ngCliProject.root, sourceDir);
+    this.webpackBaseConfig = getWebpackCommonConfig(this.ngCliProject.root, sourceDir, environmentData);
     this.webpackDevConfigPartial = getWebpackDevConfigPartial(this.ngCliProject.root, sourceDir);
     this.webpackProdConfigPartial = getWebpackProdConfigPartial(this.ngCliProject.root, sourceDir);
 

--- a/addon/ng2/utilities/handlebars-webpack-plugin.ts
+++ b/addon/ng2/utilities/handlebars-webpack-plugin.ts
@@ -1,0 +1,44 @@
+var Handlebars = require('handlebars');
+
+export interface IHandlebarsPluginOptions {
+  assetName:string
+  data:any
+}
+
+export class HandlebarsWebpackPlugin {
+  private data:any;
+  private assetName:string;
+
+  constructor(private options:IHandlebarsPluginOptions) {
+    this.data = options.data || {};
+    this.assetName = options.assetName;
+    if(this.assetName == "") {
+      this.assetName = "index.html";
+    }
+  }
+
+  apply(compiler:any) {
+    var data = this.data;
+    var assetName = this.assetName;
+
+    compiler.plugin("emit", function(compilation:any, callback:Function) {
+      let asset = compilation.assets[assetName];
+      // This will be undefined if there is a build error
+      if(asset != undefined) {
+        let templateContent = compilation.assets[assetName].source();
+        let template = Handlebars.compile(templateContent);
+        let result = template(data);
+        compilation.assets[assetName] = {
+          source: function() {
+            return result;
+          },
+          size: function() {
+            return result.length;
+          }
+        };
+      }
+
+      callback();
+    });
+  }
+}


### PR DESCRIPTION

This pull request is in reference to #1544. If we bring back the ability to access environment variables, we have two main benefits.

**Easier Upgrade Path**
Users upgrading to the webpack version will have less difficulty if they are already taking advantage of the handlebar template logic.

**Environment Specific index.html**
Users can take advantage of multiple environments. I believe these are examples of typical needs for environment specific logic.
```
<base href={{environment.baseURL}} />

...

{{#if environment.production}}
  <script type="text/javascript">
    // Google Analytics
    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');

    ga('create', 'UA-########-#', 'auto');
  </script>
{{/if}}

...

  <script type="text/javascript">
    // Load Facebook SDK for JS
    window.fbAsyncInit = function () {
      FB.init({
        appId: "{{environment.facebookAppId}}", // Test app vs Production app
        cookie: true,
        xfbml: false,
        version: "v2.7"
      });
    };
    (function (d, s, id) {
      var js, fjs = d.getElementsByTagName(s)[0];
      if (d.getElementById(id)) {
        return;
      }
      js = d.createElement(s);
      js.id = id;
      js.src = "//connect.facebook.net/en_US/sdk.js";
      fjs.parentNode.insertBefore(js, fjs);
    }(document, "script", "facebook-jssdk"));
  </script>
```
**Webpack Dev Server Base URL**
Webpack Dev Server has an issue with baseURL: https://github.com/webpack/webpack-dev-server/issues/288 By making this environment specific, users who need a nested directory structure for their SPA can use a baseURL of / for local testing using webpack dev server, but have a different value for production. 

**Build System Independent**
There is actually a way to use variables from the HTML Plugin currently used in the form <%= htmlWebpackPlugin.options.title %>. However, this makes the templates build system specific. If you wanted to change away from Webpack later, these would not longer apply. By using handlebars, you can move between build systems.

This can also help address the following issues:
#1509
#1460
#1064

