### PR TITLE
feat: Add LCOV reporting by default in karma remap instanbul reporter

### DIFF
--- a/addon/ng2/blueprints/ng2/files/config/karma.conf.js
+++ b/addon/ng2/blueprints/ng2/files/config/karma.conf.js
@@ -26,7 +26,8 @@ module.exports = function (config) {
     },
     remapIstanbulReporter: {
       reports: {
-        html: 'coverage'
+        html: 'coverage',
+        lcovonly: './coverage/coverage.lcov'
       }
     },
     angularCliConfig: './angular-cli.json',

--- a/tests/e2e/e2e_workflow.spec.js
+++ b/tests/e2e/e2e_workflow.spec.js
@@ -289,6 +289,12 @@ describe('Basic end-to-end Workflow', function () {
     expect(existsSync(coverageReport)).to.be.equal(true);
   });
 
+  it('Make sure that LCOV file is generated inside coverage folder', function() {
+    const lcovReport = path.join(process.cwd(), 'coverage', 'coverage.lcov');
+
+    expect(existsSync(lcovReport)).to.be.equal(true);
+  });
+
   it('moves all files that live inside `public` into `dist`', function () {
     this.timeout(420000);
 
@@ -375,8 +381,8 @@ describe('Basic end-to-end Workflow', function () {
     let lessFile = path.join(componentPath, lessFilename);
     let lessExample = '.outer {\n  .inner { background: #fff; }\n }';
     let componentContents = fs.readFileSync(componentFile, 'utf8');
-    
-    sh.mv(cssFile, lessFile);      
+
+    sh.mv(cssFile, lessFile);
     fs.writeFileSync(lessFile, lessExample, 'utf8');
     fs.writeFileSync(componentFile, componentContents.replace(new RegExp(cssFilename, 'g'), lessFilename), 'utf8');
 
@@ -402,8 +408,8 @@ describe('Basic end-to-end Workflow', function () {
     let stylusFile = path.join(componentPath, stylusFilename);
     let stylusExample = '.outer {\n  .inner { background: #fff; }\n }';
     let componentContents = fs.readFileSync(componentFile, 'utf8');
-    
-    sh.mv(cssFile, stylusFile);      
+
+    sh.mv(cssFile, stylusFile);
     fs.writeFileSync(stylusFile, stylusExample, 'utf8');
     fs.writeFileSync(componentFile, componentContents.replace(new RegExp(cssFilename, 'g'), stylusFilename), 'utf8');
 


### PR DESCRIPTION
Adds by default also a `coverage.lcov` coverage file by default when running `ng test`. It can be found in the `coverage` folder in the root directory when generated. 

Fixes #1620