### PR TITLE
fix: change inline-source-map to source-map for dev and common builds.

### DIFF
--- a/addon/ng2/models/webpack-build-common.ts
+++ b/addon/ng2/models/webpack-build-common.ts
@@ -7,7 +7,7 @@ import { CliConfig } from './config';
 
 export function getWebpackCommonConfig(projectRoot: string, sourceDir: string) {
   return {
-    devtool: 'inline-source-map',
+    devtool: 'source-map',
     resolve: {
       extensions: ['', '.ts', '.js'],
       root: path.resolve(projectRoot, `./${sourceDir}`)

--- a/addon/ng2/models/webpack-build-development.ts
+++ b/addon/ng2/models/webpack-build-development.ts
@@ -4,7 +4,7 @@ const path = require('path')
 export const getWebpackDevConfigPartial = function(projectRoot: string, sourceDir: string) {
   return {
     debug: true,
-    devtool: 'cheap-module-source-map',
+    devtool: 'source-map',
     output: {
       path: path.resolve(projectRoot, './dist'),
       filename: '[name].bundle.js',


### PR DESCRIPTION
Fixes #1519 where either a chrome or webpack issue is causing inline-source-map and cheap-module-source-map to display inaccurately for development and production mode (in some cases).