### PR TITLE
Feature/silence sourcemap warnings for vendors

### DIFF
--- a/addon/ng2/models/webpack-build-common.ts
+++ b/addon/ng2/models/webpack-build-common.ts
@@ -22,16 +22,6 @@ export function getWebpackCommonConfig(projectRoot: string, sourceDir: string) {
       filename: '[name].bundle.js'
     },
     module: {
-      preLoaders: [
-        {
-          test: /\.js$/,
-          loader: 'source-map-loader',
-          exclude: [
-            path.resolve(projectRoot, 'node_modules/rxjs'),
-            path.resolve(projectRoot, 'node_modules/@angular'),
-          ]
-        }
-      ],
       loaders: [
         {
           test: /\.ts$/,

--- a/addon/ng2/models/webpack-build-development.ts
+++ b/addon/ng2/models/webpack-build-development.ts
@@ -11,6 +11,14 @@ export const getWebpackDevConfigPartial = function(projectRoot: string, sourceDi
       sourceMapFilename: '[name].map',
       chunkFilename: '[id].chunk.js'
     },
+    module: {
+      preLoaders: [
+        {
+          test: /\.js$/,
+          loader: 'source-map-loader'
+        }
+      ]
+    },
     tslint: {
       emitErrors: false,
       failOnHint: false,

--- a/addon/ng2/models/webpack-build-production.ts
+++ b/addon/ng2/models/webpack-build-production.ts
@@ -15,6 +15,17 @@ export const getWebpackProdConfigPartial = function(projectRoot: string, sourceD
       sourceMapFilename: '[name].[chunkhash].bundle.map',
       chunkFilename: '[id].[chunkhash].chunk.js'
     },
+    module: {
+      preLoaders: [
+        {
+          test: /\.js$/,
+          loader: 'source-map-loader',
+          exclude: [
+            /node_modules/ // don't pull in vendor sourcemaps for production builds, increased speed for build
+          ]
+        }
+      ]
+    },
     plugins: [
       new WebpackMd5Hash(),
       new webpack.optimize.DedupePlugin(),

--- a/addon/ng2/models/webpack-build-utils.ts
+++ b/addon/ng2/models/webpack-build-utils.ts
@@ -19,5 +19,6 @@ export const webpackDevServerOutputOptions = {
   hash: true,
   timings: true,
   chunks: false,
-  chunkModules: false
+  chunkModules: false,
+  warning: false
 }

--- a/addon/ng2/models/webpack-build-utils.ts
+++ b/addon/ng2/models/webpack-build-utils.ts
@@ -20,5 +20,5 @@ export const webpackDevServerOutputOptions = {
   timings: true,
   chunks: false,
   chunkModules: false,
-  warning: false
+  warnings: false
 }


### PR DESCRIPTION
Remove sourcemap for vendors if in prod, but in develop we will allow it. If a sourcemap isn't properly exposed/inlined  (IE: @ngrx/core), the typical warning should be surpressed. 

This will also result in faster prod builds

Fixes #1578