### PR TITLE
fix:  check path for 'ng get'

### DIFF
--- a/addon/ng2/models/config.ts
+++ b/addon/ng2/models/config.ts
@@ -108,6 +108,9 @@ export class CliConfig {
   }
 
   private _validatePath(jsonPath: string) {
+    if (!jsonPath) {
+      throw 'Config path is missing.';
+    }
     if (!jsonPath.match(/^(?:[-_\w\d]+(?:\[\d+\])*\.)*(?:[-_\w\d]+(?:\[\d+\])*)$/)) {
       throw `Invalid JSON path: "${jsonPath}"`;
     }


### PR DESCRIPTION
if user doesn't provide path for `ng get`,
cli throws exception `Cannot read property 'match' of undefined`.

this small PR allow to catch it and show more friendly message.