### PR TITLE
feat(pipe) the args parameter should be an array

### DIFF
--- a/addon/ng2/blueprints/pipe/files/__path__/__name__.pipe.ts
+++ b/addon/ng2/blueprints/pipe/files/__path__/__name__.pipe.ts
@@ -5,7 +5,7 @@ import { Pipe, PipeTransform } from '@angular/core';
 })
 export class <%= classifiedModuleName %>Pipe implements PipeTransform {
 
-  transform(value: any, args?: any): any {
+  transform(value: any, ...args:any[]): any {
     return null;
   }
 


### PR DESCRIPTION
If we name the second parameter of a pipe `args`, it should be an array containing all parameters of the pipe