### PR TITLE
fix: karma configuration in ng2 blueprint updated, allowing unit testing on travis.

### DIFF
--- a/addon/ng2/blueprints/ng2/files/config/karma.conf.js
+++ b/addon/ng2/blueprints/ng2/files/config/karma.conf.js
@@ -39,4 +39,10 @@ module.exports = function (config) {
     browsers: ['Chrome'],
     singleRun: false
   });
+
+  if(process.env.TRAVIS) {
+    config.browsers = ['Chrome_travis_ci'];
+    config.autoWatch = false;
+    config.singleRun = true;
+  }
 };


### PR DESCRIPTION
The original karma configuration contained a custom launcher for travis (for more details, please check out [karma.conf.js](https://github.com/angular/angular-cli/blob/master/addon/ng2/blueprints/ng2/files/config/karma.conf.js#L14)), but it was not used anywhere. 

By extending the configuration, it is now automatically applied if travis is detected, and also enabled single run mode for the CI tool, otherwise karma wouldn't exit at the end of the tests.

I am not sure however, if adding an out-of-box travis support directly to the blueprint was the original intention behind the custom launcher.