### PR TITLE
chore(blueprints): remove config folder

### DIFF
--- a/addon/ng2/blueprints/ng2/files/angular-cli.json
+++ b/addon/ng2/blueprints/ng2/files/angular-cli.json
@@ -26,12 +26,12 @@
   "packages": [],
   "e2e": {
     "protractor": {
-      "config": "config/protractor.conf.js"
+      "config": "./protractor.conf.js"
     }
   },
   "test": {
     "karma": {
-      "config": "config/karma.conf.js"
+      "config": "./karma.conf.js"
     }
   },
   "defaults": {

--- a/addon/ng2/blueprints/ng2/files/karma.conf.js
+++ b/addon/ng2/blueprints/ng2/files/karma.conf.js
@@ -3,7 +3,7 @@
 
 module.exports = function (config) {
   config.set({
-    basePath: '..',
+    basePath: './',
     frameworks: ['jasmine', 'angular-cli'],
     plugins: [
       require('karma-jasmine'),

--- a/addon/ng2/blueprints/ng2/files/protractor.conf.js
+++ b/addon/ng2/blueprints/ng2/files/protractor.conf.js
@@ -7,7 +7,7 @@ var SpecReporter = require('jasmine-spec-reporter');
 exports.config = {
   allScriptsTimeout: 11000,
   specs: [
-    '../e2e/**/*.e2e-spec.ts'
+    './e2e/**/*.e2e-spec.ts'
   ],
   capabilities: {
     'browserName': 'chrome'


### PR DESCRIPTION
The config folder currently only has two files: `karma.conf.js` and `protractor.conf.js`.

It's somewhat unnecessary to have only these two files in that folder given the the remaining config-like files are at root: `.editorconfig`, `angular-cli.json` and `tslint.json`.