### PR TITLE
fix(lint): change " to '

### DIFF
--- a/addon/ng2/blueprints/ng2/files/__path__/test.ts
+++ b/addon/ng2/blueprints/ng2/files/__path__/test.ts
@@ -1,4 +1,4 @@
-import "./polyfills.ts";
+import './polyfills.ts';
 
 import 'zone.js/dist/long-stack-trace-zone';
 import 'zone.js/dist/jasmine-patch';


### PR DESCRIPTION
This was causing a warning on unit tests.