### PR TITLE
Removed moduleId property

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,6 @@ To use these prepocessors simply add the file to your component's `styleUrls`:
 
 ```
 @Component({
-  moduleId: module.id,
   selector: 'app-root',
   templateUrl: 'app.component.html',
   styleUrls: ['app.component.scss']


### PR DESCRIPTION
Removed moduleId property from @Component decorator object.

Reason:
https://github.com/angular/angular-cli/blob/master/WEBPACK_UPDATE.md
1. Updated Files
./src/app/app.component.ts (and all other components) - removed module.id, sass/less/stylus preprocessing now uses the real extension in styleUrls instead of .css.