### PR TITLE
chore(loaders): update angular2-template-loader dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@types/lodash": "^4.0.25-alpha",
     "@types/rimraf": "0.0.25-alpha",
     "@types/webpack": "^1.12.22-alpha",
-    "angular2-template-loader": "^0.4.0",
+    "angular2-template-loader": "^0.5.0",
     "awesome-typescript-loader": "^2.2.1",
     "chalk": "^1.1.3",
     "compression-webpack-plugin": "^0.3.1",


### PR DESCRIPTION
* Update angular2-template-loader dependency to v0.5.0 which includes small fixes for those using unorthodox spacing between properties in `@Component` decorators

Closes https://github.com/angular/angular-cli/issues/1501