### PR TITLE
feat(webpackDevServer): Add watchOptions for webpackDevServer

### DIFF
--- a/packages/angular-cli/lib/config/schema.d.ts
+++ b/packages/angular-cli/lib/config/schema.d.ts
@@ -59,5 +59,6 @@ export interface CliConfig {
     defaults?: {
         styleExt?: string;
         prefixInterfaces?: boolean;
+        poll?: number;
     };
 }

--- a/packages/angular-cli/lib/config/schema.json
+++ b/packages/angular-cli/lib/config/schema.json
@@ -135,6 +135,9 @@
         },
         "prefixInterfaces": {
           "type": "boolean"
+        },
+        "poll": {
+          "type": "number"
         }
       },
       "additionalProperties": false

--- a/packages/angular-cli/tasks/serve-webpack.ts
+++ b/packages/angular-cli/tasks/serve-webpack.ts
@@ -54,7 +54,10 @@ export default Task.extend({
       historyApiFallback: true,
       stats: webpackDevServerOutputOptions,
       inline: true,
-      proxy: proxyConfig
+      proxy: proxyConfig,
+      watchOptions: {
+        poll: CliConfig.fromProject().config.defaults.poll
+      }
     };
 
     ui.writeLine(chalk.green(oneLine`


### PR DESCRIPTION
Add watchOptions to webpackDevServerConfiguration to conditionally enable polling option in watchpack
Remove additional blank lines from end of serve-watchpack.ts so that only one is remaining