### PR TITLE
fix: removed travis-specific configuration from karma.conf.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,11 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew tap caskroom/cask; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew cask install google-chrome --force; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then mkdir ~/.config && echo "--no-sandbox" > ~/.config/chrome-flags.conf; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export DISPLAY=:99.0; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sh -e /etc/init.d/xvfb start; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export CHROME_BIN=chromium-browser; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then echo "--no-sandbox" > ~/.config/chromium-flags.conf; fi
   - if [[ "$TARGET" == "mobile" ]]; then export MOBILE_TEST=true; fi
   - npm config set spin false
   - npm config set progress false

--- a/addon/ng2/blueprints/ng2/files/karma.conf.js
+++ b/addon/ng2/blueprints/ng2/files/karma.conf.js
@@ -11,13 +11,6 @@ module.exports = function (config) {
       require('karma-remap-istanbul'),
       require('angular-cli/plugins/karma')
     ],
-    customLaunchers: {
-      // chrome setup for travis CI using chromium
-      Chrome_travis_ci: {
-        base: 'Chrome',
-        flags: ['--no-sandbox']
-      }
-    },
     files: [
       { pattern: './<%= sourceDir %>/test.ts', watched: false }
     ],

--- a/tests/e2e/e2e_workflow.spec.js
+++ b/tests/e2e/e2e_workflow.spec.js
@@ -35,13 +35,6 @@ describe('Basic end-to-end Workflow', function () {
 
   var testArgs = ['test', '--watch', 'false'];
 
-  // In travis CI only run tests in Chrome_travis_ci
-  if (process.env.TRAVIS) {
-    testArgs.push('--browsers');
-    testArgs.push('Chrome_travis_ci');
-  }
-
-
   it('Installs angular-cli correctly', function () {
     this.timeout(300000);
 
@@ -492,7 +485,7 @@ describe('Basic end-to-end Workflow', function () {
     let stylesPath = path.join(process.cwd(), 'src', 'styles.css');
     let testStyle = 'body { background-color: blue; }';
     fs.writeFileSync(stylesPath, testStyle, 'utf8');
-    
+
     sh.exec(`${ngBin} build`);
 
     var stylesBundlePath = path.join(process.cwd(), 'dist', 'styles.bundle.js');
@@ -548,7 +541,7 @@ describe('Basic end-to-end Workflow', function () {
     expect(stylesBundleContent).to.include('* Bootstrap ');
 
     const scriptsBundlePath = path.join(process.cwd(), 'dist', 'scripts.bundle.js');
-    const scriptsBundleContent = fs.readFileSync(scriptsBundlePath, { encoding: 'utf8' });    
+    const scriptsBundleContent = fs.readFileSync(scriptsBundlePath, { encoding: 'utf8' });
     expect(scriptsBundleContent).to.include('* jQuery JavaScript');
     expect(scriptsBundleContent).to.include('/*! tether ');
     expect(scriptsBundleContent).to.include('* Bootstrap ');
@@ -556,7 +549,7 @@ describe('Basic end-to-end Workflow', function () {
     // check the scripts are loaded in the correct order
     const indexPath = path.join(process.cwd(), 'dist', 'index.html');
     const indexContent = fs.readFileSync(indexPath, { encoding: 'utf8' });
-    let scriptTags = '<script type="text/javascript" src="inline.js"></script>' + 
+    let scriptTags = '<script type="text/javascript" src="inline.js"></script>' +
                     '<script type="text/javascript" src="styles.bundle.js"></script>' +
                     '<script type="text/javascript" src="scripts.bundle.js"></script>' +
                     '<script type="text/javascript" src="main.bundle.js"></script>'


### PR DESCRIPTION
The pull request removes the travis-specific custom launcher from karma.conf.js as per discussed in #1738.

Hopefully there will be a follow-up PR, allowing the user to successfully run their karma test cases in their CI tools, without having to change the `karma.conf.js` generated by angular-cli, but it still needs some investigations and decisions to be made about the approach.