### PR TITLE
fix: 'ember' is replaced with 'ng' a bit too eagerly in log output

### DIFF
--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -17,7 +17,7 @@ module.exports = function(options) {
       return oldStdoutWrite.apply(process.stdout, arguments);
     }
     line = line.replace(/ember-cli(?!.com)/g, 'angular-cli')
-      .replace(/ember(?!-cli.com)/g, 'ng');
+      .replace(/\bember\b(?!-cli.com)/g, 'ng');
     return oldStdoutWrite.apply(process.stdout, arguments);
   };
 
@@ -25,7 +25,7 @@ module.exports = function(options) {
   process.stderr.write = function (line) {
     line = line.toString()
       .replace(/ember-cli(?!.com)/g, 'angular-cli')
-      .replace(/ember(?!-cli.com)/g, 'ng');
+      .replace(/\bember\b(?!-cli.com)/g, 'ng');
     return oldStderrWrite.apply(process.stdout, arguments);
   };
 


### PR DESCRIPTION
#1405

before: `ng g c member-list` output `create src/app/ng-list/ng-list.component.scss`.

after: `ng g c member-list` output ` create src/app/member-list/member-list.component.scss`.