### PR TITLE
Introduce tslint npm script task

### DIFF
--- a/addon/ng2/commands/build.ts
+++ b/addon/ng2/commands/build.ts
@@ -17,8 +17,13 @@ module.exports = Command.extend({
   aliases: ['b'],
 
   availableOptions: [
-    { name: 'target',         type: String,  default: 'development', aliases: ['t', { 'dev': 'development' }, { 'prod': 'production' }] },
-    { name: 'environment',    type: String,  default: '', aliases: ['e'] },
+    { name: 'target',         type: String,  default: 'development', aliases: [
+          't',
+        { 'dev': 'development' },
+        { 'prod': 'production' }
+      ]
+    },
+    { name: 'environment',    type: String,  default: '',            aliases: ['e'] },
     { name: 'output-path',    type: 'Path',  default: 'dist/',       aliases: ['o'] },
     { name: 'watch',          type: Boolean, default: false,         aliases: ['w'] },
     { name: 'watcher',        type: String },
@@ -26,13 +31,13 @@ module.exports = Command.extend({
   ],
 
   run: function (commandOptions: BuildOptions) {
-    if (commandOptions.environment === ''){
+    if (commandOptions.environment === '') {
       if (commandOptions.target === 'development') {
         commandOptions.environment = 'dev';
       }
       if (commandOptions.target === 'production') {
         commandOptions.environment = 'prod';
-      } 
+      }
     }
 
     var project = this.project;

--- a/addon/ng2/commands/doc.ts
+++ b/addon/ng2/commands/doc.ts
@@ -10,9 +10,9 @@ const DocCommand = Command.extend({
     '<keyword>'
   ],
 
-  run: function(commandOptions, rawArgs:Array<string>) {
+  run: function(commandOptions, rawArgs: Array<string>) {
     var keyword = rawArgs[0];
-    
+
     var docTask = new DocTask({
       ui: this.ui,
       analytics: this.analytics,

--- a/addon/ng2/commands/generate.ts
+++ b/addon/ng2/commands/generate.ts
@@ -21,7 +21,7 @@ const GenerateCommand = EmberGenerateCommand.extend({
       !fs.existsSync(path.join(__dirname, '..', 'blueprints', rawArgs[0]))) {
       SilentError.debugOrThrow('angular-cli/commands/generate', `Invalid blueprint: ${rawArgs[0]}`);
     }
-    
+
     // Override default help to hide ember blueprints
     EmberGenerateCommand.prototype.printDetailedHelp = function (options) {
       var blueprintList = fs.readdirSync(path.join(__dirname, '..', 'blueprints'));
@@ -29,7 +29,7 @@ const GenerateCommand = EmberGenerateCommand.extend({
         .filter(bp => bp.indexOf('-test') === -1)
         .filter(bp => bp !== 'ng2')
         .map(bp => Blueprint.load(path.join(__dirname, '..', 'blueprints', bp)));
-      
+
       var output = '';
       blueprints
         .forEach(function (bp) {
@@ -38,7 +38,7 @@ const GenerateCommand = EmberGenerateCommand.extend({
       this.ui.writeLine(chalk.cyan('  Available blueprints'));
       this.ui.writeLine(output);
     };
-    
+
     return EmberGenerateCommand.prototype.beforeRun.apply(this, arguments);
   }
 });

--- a/addon/ng2/commands/github-pages-deploy.ts
+++ b/addon/ng2/commands/github-pages-deploy.ts
@@ -18,7 +18,8 @@ const fsCopy = Promise.denodeify(fse.copy);
 module.exports = Command.extend({
   name: 'github-pages:deploy',
   aliases: ['gh-pages:deploy'],
-  description: 'Build the test app for production, commit it into a git branch, setup GitHub repo and push to it',
+  description: 'Build the test app for production, \
+  commit it into a git branch, setup GitHub repo and push to it',
   works: 'insideProject',
 
   availableOptions: [
@@ -66,7 +67,7 @@ module.exports = Command.extend({
       cwd: root
     };
 
-    if (options.environment === ''){
+    if (options.environment === '') {
       if (options.target === 'development') {
         options.environment = 'dev';
       }
@@ -137,7 +138,9 @@ module.exports = Command.extend({
     }
 
     function build() {
-      if (options.skipBuild) return Promise.resolve();
+      if (options.skipBuild) {
+        return Promise.resolve();
+      }
       return buildTask.run(buildOptions);
     }
 
@@ -165,7 +168,7 @@ module.exports = Command.extend({
 
     function checkoutGhPages() {
       return execPromise(`git checkout ${ghPagesBranch}`)
-        .catch(createGhPagesBranch)
+        .catch(createGhPagesBranch);
     }
 
     function createGhPagesBranch() {
@@ -179,16 +182,18 @@ module.exports = Command.extend({
     function copyFiles() {
       return fsReadDir(outDir)
         .then((files) => Promise.all(files.map((file) => {
-          if (file === '.gitignore'){
+          if (file === '.gitignore') {
             // don't overwrite the .gitignore file
             return Promise.resolve();
           }
-          return fsCopy(path.join(outDir, file), path.join('.', file))
+          return fsCopy(path.join(outDir, file), path.join('.', file));
         })));
     }
 
     function updateBaseHref() {
-      if (options.userPage) return Promise.resolve();
+      if (options.userPage) {
+        return Promise.resolve();
+      }
       let indexHtml = path.join(root, 'index.html');
       return fsReadFile(indexHtml, 'utf8')
         .then((data) => data.replace(/<base href="\/">/g, `<base href="/${projectName}/">`))
@@ -215,7 +220,8 @@ module.exports = Command.extend({
     function printProjectUrl() {
       return execPromise('git remote -v')
         .then((stdout) => {
-          let userName = stdout.match(/origin\s+(?:https:\/\/|git@)github\.com(?:\:|\/)([^\/]+)/m)[1].toLowerCase();
+          let userName = stdout.match(/origin\s+(?:https:\/\/|git@)github\.com(?:\:|\/)([^\/]+)/m)
+            [1].toLowerCase();
           let url = `https://${userName}.github.io/${options.userPage ? '' : (projectName + '/')}`;
           ui.writeLine(chalk.green(`Deployed! Visit ${url}`));
           ui.writeLine('Github pages might take a few minutes to show the deployed site.');
@@ -225,7 +231,8 @@ module.exports = Command.extend({
     function failGracefully(error) {
       if (error && (/git clean/.test(error.message) || /Permission denied/.test(error.message))) {
         ui.writeLine(error.message);
-        let msg = 'There was a permissions error during git file operations, please close any open project files/folders and try again.';
+        let msg = 'There was a permissions error during git file operations, \
+ please close any open project files/folders and try again.';
         msg += `\nYou might also need to return to the ${initialBranch} branch manually.`;
         return Promise.reject(new SilentError(msg));
       } else {

--- a/addon/ng2/commands/serve.ts
+++ b/addon/ng2/commands/serve.ts
@@ -36,15 +36,24 @@ module.exports = Command.extend({
 
   availableOptions: [
     { name: 'port',                 type: Number,  default: defaultPort,   aliases: ['p'] },
-    { name: 'host',                 type: String,  default: 'localhost',   aliases: ['H'],     description: 'Listens on all interfaces by default' },
+    { name: 'host',                 type: String,  default: 'localhost',   aliases: ['H'],
+      description: 'Listens on all interfaces by default' },
     { name: 'proxy-config',         type: 'Path',                          aliases: ['pc'] },
     { name: 'watcher',              type: String,  default: 'events',      aliases: ['w'] },
     { name: 'live-reload',          type: Boolean, default: true,          aliases: ['lr'] },
-    { name: 'live-reload-host',     type: String,                          aliases: ['lrh'],   description: 'Defaults to host' },
-    { name: 'live-reload-base-url', type: String,                          aliases: ['lrbu'],  description: 'Defaults to baseURL' },
-    { name: 'live-reload-port',     type: Number,                          aliases: ['lrp'],   description: '(Defaults to port number within [49152...65535])' },
-    { name: 'live-reload-live-css', type: Boolean, default: true,                              description: 'Whether to live reload CSS (default true)' },
-    { name: 'target',               type: String,  default: 'development', aliases: ['t', { 'dev': 'development' }, { 'prod': 'production' }] },
+    { name: 'live-reload-host',     type: String,                          aliases: ['lrh'],
+      description: 'Defaults to host' },
+    { name: 'live-reload-base-url', type: String,                          aliases: ['lrbu'],
+      description: 'Defaults to baseURL' },
+    { name: 'live-reload-port',     type: Number,                          aliases: ['lrp'],
+      description: '(Defaults to port number within [49152...65535])' },
+    { name: 'live-reload-live-css', type: Boolean, default: true,
+      description: 'Whether to live reload CSS (default true)' },
+    { name: 'target',               type: String,  default: 'development', aliases: [
+            't',
+          { 'dev': 'development' },
+          { 'prod': 'production' }
+        ] },
     { name: 'environment',          type: String,  default: '', aliases: ['e'] },
     { name: 'ssl',                  type: Boolean, default: false },
     { name: 'ssl-key',              type: String,  default: 'ssl/server.key' },
@@ -52,7 +61,7 @@ module.exports = Command.extend({
   ],
 
   run: function(commandOptions: ServeTaskOptions) {
-    if (commandOptions.environment === ''){
+    if (commandOptions.environment === '') {
       if (commandOptions.target === 'development') {
         commandOptions.environment = 'dev';
       }
@@ -65,14 +74,15 @@ module.exports = Command.extend({
 
     return this._checkExpressPort(commandOptions)
       .then(this._autoFindLiveReloadPort.bind(this))
-      .then((commandOptions: ServeTaskOptions) => {
-        commandOptions = assign({}, commandOptions, {
-          baseURL: this.project.config(commandOptions.target).baseURL || '/'
+      .then((options: ServeTaskOptions) => {
+        commandOptions = assign({}, options, {
+          baseURL: this.project.config(options.target).baseURL || '/'
         });
 
         if (commandOptions.proxy) {
           if (!commandOptions.proxy.match(/^(http:|https:)/)) {
-            var message = 'You need to include a protocol with the proxy URL.' + EOL + 'Try --proxy http://' + commandOptions.proxy;
+            var message = 'You need to include a protocol with the proxy URL.' + EOL +
+              'Try --proxy http://' + commandOptions.proxy;
 
             return Promise.reject(new SilentError(message));
           }

--- a/addon/ng2/custom-typings.d.ts
+++ b/addon/ng2/custom-typings.d.ts
@@ -3,7 +3,7 @@ interface IWebpackDevServerConfigurationOptions {
   hot?: boolean;
   historyApiFallback?: boolean;
   compress?: boolean;
-  proxy?: {[key: string] : string};
+  proxy?: {[key: string]: string};
   staticOptions?: any;
   quiet?: boolean;
   noInfo?: boolean;
@@ -14,8 +14,8 @@ interface IWebpackDevServerConfigurationOptions {
     poll?: number;
   };
   publicPath?: string;
-  headers?: { [key:string]: string };
-  stats?: { [key:string]: boolean };
+  headers?: { [key: string]: string };
+  stats?: { [key: string]: boolean };
   inline: boolean;
 }
 

--- a/addon/ng2/models/config.ts
+++ b/addon/ng2/models/config.ts
@@ -4,8 +4,8 @@ import * as chalk from 'chalk';
 import * as fs from 'fs';
 import * as path from 'path';
 
-const schemaPath = path.resolve(process.env.CLI_ROOT, 'lib/config/schema.json');
-const schema = require(schemaPath);
+// const schemaPath = path.resolve(process.env.CLI_ROOT, 'lib/config/schema.json');
+// const schema = require(schemaPath);
 
 export const CLI_CONFIG_FILE_NAME = 'angular-cli.json';
 

--- a/addon/ng2/models/config/config.ts
+++ b/addon/ng2/models/config/config.ts
@@ -29,7 +29,7 @@ export class CliConfig<Config> {
   save(path: string = this._configPath) {
     return fs.writeFileSync(path, this.serialize(), 'utf-8');
   }
-  serialize(mimetype: string = 'application/json'): string {
+  serialize(mimetype = 'application/json'): string {
     return this._config.$$serialize(mimetype);
   }
 
@@ -73,7 +73,7 @@ export class CliConfig<Config> {
     try {
       content = JSON.parse(configContent);
       schema = JSON.parse(schemaContent);
-      others = otherContents.map(content => JSON.parse(content));
+      others = otherContents.map(content_ => JSON.parse(content_));
     } catch (err) {
       throw new InvalidConfigError(err);
     }

--- a/addon/ng2/models/find-lazy-modules.ts
+++ b/addon/ng2/models/find-lazy-modules.ts
@@ -3,11 +3,12 @@ import * as glob from 'glob';
 import * as path from 'path';
 import * as ts from 'typescript';
 
-import {Observable} from 'rxjs/Observable';
+// import {Observable} from 'rxjs/Observable';
 import {getSource, findNodes, getContentOfKeyLiteral} from '../utilities/ast-utils';
 
 
-const loadChildrenRegex = /(\{[^{}]+?(loadChildren|['"]loadChildren['"])\s*:\s*)('[^']+'|"[^"]+")/gm;
+// const loadChildrenRegex =
+//  /(\{[^{}]+?(loadChildren|['"]loadChildren['"])\s*:\s*)('[^']+'|"[^"]+")/gm;
 
 
 interface Array<T> {
@@ -37,7 +38,7 @@ export function findLoadChildren(tsFilePath: string): string[] {
         // key is an expression, can't do anything.
         return false;
       }
-      return key == 'loadChildren'
+      return key == 'loadChildren';
     })
     // Remove initializers that are not files.
     .filter((node: ts.PropertyAssignment) => {

--- a/addon/ng2/models/json-schema/schema-class-factory.ts
+++ b/addon/ng2/models/json-schema/schema-class-factory.ts
@@ -108,7 +108,7 @@ class SchemaClassBase<T> implements SchemaClass<T> {
   $$set(path: string, value: any) {
     const node = _getSchemaNodeForPath(this[kSchemaNode], path);
     if (node) {
-      node.set(value)
+      node.set(value);
     } else {
       // This might be inside an object that can have additionalProperties, so
       // a TreeNode would not exist.
@@ -137,7 +137,7 @@ class SchemaClassBase<T> implements SchemaClass<T> {
     return node ? node.defined : false;
   }
 
-  $$delete(path: string){
+  $$delete(path: string) {
     const node = _getSchemaNodeForPath(this[kSchemaNode], path);
     if (node) {
       node.destroy();
@@ -145,7 +145,7 @@ class SchemaClassBase<T> implements SchemaClass<T> {
   }
 
   /** Serialize into a string. */
-  $$serialize(mimetype: string = 'application/json', ...options: any[]): string {
+  $$serialize(mimetype = 'application/json', ...options: any[]): string {
     let str = '';
     const serializer = Serializer.fromMimetype(mimetype, (s) => str += s, ...options);
 

--- a/addon/ng2/models/json-schema/schema-tree.ts
+++ b/addon/ng2/models/json-schema/schema-tree.ts
@@ -75,7 +75,7 @@ export abstract class SchemaTreeNode<T> {
   get parent<ParentType>(): SchemaTreeNode<ParentType> { return this._parent; }
   get children<ChildType>(): { [key: string]: SchemaTreeNode<ChildType>} { return null; }
 
-  abstract get() : T;
+  abstract get(): T;
   set(v: T) {
     if (!this.readOnly) {
       throw new MissingImplementationError();
@@ -130,22 +130,22 @@ abstract class NonLeafSchemaTreeNode<T> extends SchemaTreeNode<T> {
   protected _createChildProperty<T>(name: string, value: T, forward: SchemaTreeNode<T>,
                                     schema: Object, define = true): SchemaTreeNode<T> {
     const type = schema['type'];
-    let Klass: TreeNodeConstructor = null;
+    let klass: TreeNodeConstructor = null;
 
-    switch(type) {
-      case 'object': Klass = ObjectSchemaTreeNode; break;
-      case 'array': Klass = ArraySchemaTreeNode; break;
-      case 'string': Klass = StringSchemaTreeNode; break;
-      case 'boolean': Klass = BooleanSchemaTreeNode; break;
-      case 'number': Klass = NumberSchemaTreeNode; break;
-      case 'integer': Klass = IntegerSchemaTreeNode; break;
+    switch (type) {
+      case 'object': klass = ObjectSchemaTreeNode; break;
+      case 'array': klass = ArraySchemaTreeNode; break;
+      case 'string': klass = StringSchemaTreeNode; break;
+      case 'boolean': klass = BooleanSchemaTreeNode; break;
+      case 'number': klass = NumberSchemaTreeNode; break;
+      case 'integer': klass = IntegerSchemaTreeNode; break;
 
       default:
         console.error('Type ' + type + ' not understood by SchemaClassFactory.');
         return null;
     }
 
-    const metaData = new Klass({ parent: this, forward, value, schema, name });
+    const metaData = new klass({ parent: this, forward, value, schema, name });
     if (define) {
       SchemaTreeNode._defineProperty(this._value, metaData);
     }

--- a/addon/ng2/models/json-schema/serializer.ts
+++ b/addon/ng2/models/json-schema/serializer.ts
@@ -60,9 +60,9 @@ class JsonSerializer implements Serializer {
   private _top() {
     return this._state[this._state.length - 1] || {};
   }
-  private _topIsArray() {
-    return this._top().type == 'array';
-  }
+  // private _topIsArray() {
+  //   return this._top().type == 'array';
+  // }
 
   private _indent(): string {
     if (this._indentDelta == 0) {

--- a/addon/ng2/models/webpack-build-common.ts
+++ b/addon/ng2/models/webpack-build-common.ts
@@ -14,13 +14,17 @@ export function getWebpackCommonConfig(projectRoot: string, environment: string,
   const scripts = appConfig.scripts.map(script => path.resolve(appRoot, script));
   const lazyModules = findLazyModules(appRoot);
 
-  let entry = { 
+  let entry = {
     main: [appMain]
   };
 
   // Only add styles/scripts if there's actually entries there
-  if (appConfig.styles.length > 0) entry.styles = styles;
-  if (appConfig.scripts.length > 0) entry.scripts = scripts;
+  if (appConfig.styles.length > 0) {
+    entry.styles = styles;
+  }
+  if (appConfig.scripts.length > 0) {
+    entry.scripts = scripts;
+  }
 
   return {
     devtool: 'source-map',
@@ -63,15 +67,22 @@ export function getWebpackCommonConfig(projectRoot: string, environment: string,
 
         // in main, load css as raw text
         { exclude: styles, test: /\.css$/, loaders: ['raw-loader', 'postcss-loader'] },
-        { exclude: styles, test: /\.styl$/, loaders: ['raw-loader', 'postcss-loader', 'stylus-loader'] },
-        { exclude: styles, test: /\.less$/, loaders: ['raw-loader', 'postcss-loader', 'less-loader'] },
-        { exclude: styles, test: /\.scss$|\.sass$/, loaders: ['raw-loader', 'postcss-loader', 'sass-loader'] },
+        { exclude: styles, test: /\.styl$/, loaders: ['raw-loader', 'postcss-loader',
+          'stylus-loader'] },
+        { exclude: styles, test: /\.less$/, loaders: ['raw-loader', 'postcss-loader',
+          'less-loader'] },
+        { exclude: styles, test: /\.scss$|\.sass$/, loaders: ['raw-loader', 'postcss-loader',
+          'sass-loader'] },
 
         // outside of main, load it via style-loader
-        { include: styles, test: /\.css$/, loaders: ['style-loader', 'css-loader', 'postcss-loader'] },
-        { include: styles, test: /\.styl$/, loaders: ['style-loader', 'css-loader', 'postcss-loader', 'stylus-loader'] },
-        { include: styles, test: /\.less$/, loaders: ['style-loader', 'css-loader', 'postcss-loader', 'less-loader'] },
-        { include: styles, test: /\.scss$|\.sass$/, loaders: ['style-loader', 'css-loader', 'postcss-loader', 'sass-loader'] },
+        { include: styles, test: /\.css$/, loaders: ['style-loader', 'css-loader',
+          'postcss-loader'] },
+        { include: styles, test: /\.styl$/, loaders: ['style-loader', 'css-loader',
+          'postcss-loader', 'stylus-loader'] },
+        { include: styles, test: /\.less$/, loaders: ['style-loader', 'css-loader',
+          'postcss-loader', 'less-loader'] },
+        { include: styles, test: /\.scss$|\.sass$/, loaders: ['style-loader', 'css-loader',
+          'postcss-loader', 'sass-loader'] },
 
         // load global scripts using script-loader
         { include: scripts, test: /\.js$/, loader: 'script-loader' },
@@ -97,7 +108,7 @@ export function getWebpackCommonConfig(projectRoot: string, environment: string,
         // Since it takes a RegExp as first parameter, we need to escape the path.
         // See https://webpack.github.io/docs/list-of-plugins.html#normalmodulereplacementplugin
         new RegExp(path.resolve(appRoot, appConfig.environments['source'])
-          .replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&")),
+          .replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&')),
         path.resolve(appRoot, appConfig.environments[environment])
       ),
       new webpack.optimize.CommonsChunkPlugin({
@@ -124,5 +135,5 @@ export function getWebpackCommonConfig(projectRoot: string, environment: string,
       clearImmediate: false,
       setImmediate: false
     }
-  }
+  };
 }

--- a/addon/ng2/models/webpack-build-development.ts
+++ b/addon/ng2/models/webpack-build-development.ts
@@ -1,4 +1,4 @@
-const path = require('path')
+const path = require('path');
 
 export const getWebpackDevConfigPartial = function(projectRoot: string, appConfig: any) {
   return {
@@ -24,4 +24,4 @@ export const getWebpackDevConfigPartial = function(projectRoot: string, appConfi
       setImmediate: false
     }
   };
-}
+};

--- a/addon/ng2/models/webpack-build-mobile.ts
+++ b/addon/ng2/models/webpack-build-mobile.ts
@@ -1,4 +1,4 @@
-import * as webpack from 'webpack';
+// import * as webpack from 'webpack';
 import * as path from 'path';
 import * as OfflinePlugin from 'offline-plugin';
 import * as CopyWebpackPlugin from 'copy-webpack-plugin';
@@ -10,8 +10,10 @@ export const getWebpackMobileConfigPartial = function (projectRoot: string, appC
   return {
     plugins: [
       new CopyWebpackPlugin([
-        {from: path.resolve(projectRoot, appConfig.root, 'icons'), to: path.resolve(projectRoot, appConfig.outDir, 'icons')},
-        {from: path.resolve(projectRoot, appConfig.root, 'manifest.webapp'), to: path.resolve(projectRoot, appConfig.outDir)}
+        {from: path.resolve(projectRoot, appConfig.root, 'icons'), to: path.resolve(projectRoot,
+          appConfig.outDir, 'icons')},
+        {from: path.resolve(projectRoot, appConfig.root, 'manifest.webapp'), to: path.resolve(
+          projectRoot, appConfig.outDir)}
       ]),
       new PrerenderWebpackPlugin({
         templatePath: 'index.html',
@@ -19,7 +21,7 @@ export const getWebpackMobileConfigPartial = function (projectRoot: string, appC
         appPath: path.resolve(projectRoot, appConfig.root)
       })
     ]
-  }
+  };
 };
 
 export const getWebpackMobileProdConfigPartial = function (projectRoot: string, appConfig: any) {
@@ -30,5 +32,5 @@ export const getWebpackMobileProdConfigPartial = function (projectRoot: string, 
     plugins: [
       new OfflinePlugin()
     ]
-  }
+  };
 };

--- a/addon/ng2/models/webpack-build-production.ts
+++ b/addon/ng2/models/webpack-build-production.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import * as webpackMerge from 'webpack-merge'; // used to merge webpack configs
+// import * as webpackMerge from 'webpack-merge'; // used to merge webpack configs
 import * as WebpackMd5Hash from 'webpack-md5-hash';
 import * as CompressionPlugin from 'compression-webpack-plugin';
 import * as webpack from 'webpack';
@@ -19,10 +19,10 @@ export const getWebpackProdConfigPartial = function(projectRoot: string, appConf
       new webpack.optimize.DedupePlugin(),
       // ~107kb
       new webpack.optimize.UglifyJsPlugin({
-        beautify: false, //prod
-        mangle: { screw_ie8 : true, keep_fnames: true }, //prod
-        compress: { screw_ie8: true }, //prod
-        comments: false //prod
+        beautify: false, // prod
+        mangle: { screw_ie8 : true, keep_fnames: true }, // prod
+        compress: { screw_ie8: true }, // prod
+        comments: false // prod
       }),
       new CompressionPlugin({
           asset: '[path].gz[query]',
@@ -57,5 +57,5 @@ export const getWebpackProdConfigPartial = function(projectRoot: string, appConf
       clearImmediate: false,
       setImmediate: false
     }
-  }
+  };
 };

--- a/addon/ng2/models/webpack-build-utils.ts
+++ b/addon/ng2/models/webpack-build-utils.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 
 export const ngAppResolve = (resolvePath: string): string => {
   return path.resolve(process.cwd(), resolvePath);
-}
+};
 
 export const webpackOutputOptions: WebpackProgressPluginOutputOptions = {
   colors: true,
@@ -10,7 +10,7 @@ export const webpackOutputOptions: WebpackProgressPluginOutputOptions = {
   modules: false,
   reasons: false,
   chunkModules: false
-}
+};
 
 export const webpackDevServerOutputOptions = {
   assets: true,
@@ -20,4 +20,4 @@ export const webpackDevServerOutputOptions = {
   timings: true,
   chunks: false,
   chunkModules: false
-}
+};

--- a/addon/ng2/models/webpack-config.ts
+++ b/addon/ng2/models/webpack-config.ts
@@ -18,7 +18,8 @@ export class NgCliWebpackConfig {
   private webpackMobileConfigPartial: any;
   private webpackMobileProdConfigPartial: any;
 
-  constructor(public ngCliProject: any, public target: string, public environment: string, outputDir?: string) {
+  constructor(public ngCliProject: any, public target: string, public environment: string,
+    outputDir?: string) {
     const config: CliConfig = CliConfig.fromProject();
     const appConfig = config.config.apps[0];
 
@@ -28,11 +29,15 @@ export class NgCliWebpackConfig {
     this.webpackDevConfigPartial = getWebpackDevConfigPartial(this.ngCliProject.root, appConfig);
     this.webpackProdConfigPartial = getWebpackProdConfigPartial(this.ngCliProject.root, appConfig);
 
-    if (appConfig.mobile){
-      this.webpackMobileConfigPartial = getWebpackMobileConfigPartial(this.ngCliProject.root, appConfig);
-      this.webpackMobileProdConfigPartial = getWebpackMobileProdConfigPartial(this.ngCliProject.root, appConfig);
-      this.webpackBaseConfig = webpackMerge(this.webpackBaseConfig, this.webpackMobileConfigPartial);
-      this.webpackProdConfigPartial = webpackMerge(this.webpackProdConfigPartial, this.webpackMobileProdConfigPartial);
+    if (appConfig.mobile) {
+      this.webpackMobileConfigPartial = getWebpackMobileConfigPartial(this.ngCliProject.root,
+        appConfig);
+      this.webpackMobileProdConfigPartial = getWebpackMobileProdConfigPartial(
+        this.ngCliProject.root, appConfig);
+      this.webpackBaseConfig = webpackMerge(this.webpackBaseConfig,
+        this.webpackMobileConfigPartial);
+      this.webpackProdConfigPartial = webpackMerge(this.webpackProdConfigPartial,
+        this.webpackMobileProdConfigPartial);
     }
 
     this.generateConfig();
@@ -40,15 +45,14 @@ export class NgCliWebpackConfig {
 
   generateConfig(): void {
     switch (this.target) {
-      case "development":
+      case 'development':
         this.config = webpackMerge(this.webpackBaseConfig, this.webpackDevConfigPartial);
         break;
-      case "production":
+      case 'production':
         this.config = webpackMerge(this.webpackBaseConfig, this.webpackProdConfigPartial);
         break;
       default:
         throw new Error("Invalid build target. Only 'development' and 'production' are available.");
-        break;
     }
   }
 }

--- a/addon/ng2/tasks/build-webpack-watch.ts
+++ b/addon/ng2/tasks/build-webpack-watch.ts
@@ -16,7 +16,8 @@ module.exports = Task.extend({
 
     rimraf.sync(path.resolve(project.root, runTaskOptions.outputPath));
 
-    const config = new NgCliWebpackConfig(project, runTaskOptions.target, runTaskOptions.environment, runTaskOptions.outputPath).config;
+    const config = new NgCliWebpackConfig(project, runTaskOptions.target,
+      runTaskOptions.environment, runTaskOptions.outputPath).config;
     const webpackCompiler = webpack(config);
 
     webpackCompiler.apply(new ProgressPlugin({
@@ -28,15 +29,17 @@ module.exports = Task.extend({
         if (err) {
           lastHash = null;
           console.error(err.stack || err);
-          if(err.details) console.error(err.details);
-            reject(err.details);
+          if (err.details) {
+            console.error(err.details);
+          }
+          reject(err.details);
         }
 
-        if(stats.hash !== lastHash) {
+        if (stats.hash !== lastHash) {
           lastHash = stats.hash;
-          process.stdout.write(stats.toString(webpackOutputOptions) + "\n");
+          process.stdout.write(stats.toString(webpackOutputOptions) + '\n');
         }
-      })
-    })
+      });
+    });
   }
 });

--- a/addon/ng2/tasks/build-webpack.ts
+++ b/addon/ng2/tasks/build-webpack.ts
@@ -16,8 +16,9 @@ module.exports = Task.extend({
     var project = this.cliProject;
 
     rimraf.sync(path.resolve(project.root, runTaskOptions.outputPath));
-    var config = new NgCliWebpackConfig(project, runTaskOptions.target, runTaskOptions.environment, runTaskOptions.outputPath).config;
-    
+    var config = new NgCliWebpackConfig(project, runTaskOptions.target, runTaskOptions.environment,
+      runTaskOptions.outputPath).config;
+
     const webpackCompiler = webpack(config);
 
     const ProgressPlugin  = require('webpack/lib/ProgressPlugin');
@@ -32,16 +33,18 @@ module.exports = Task.extend({
         // TODO: Make conditional if using --watch
         webpackCompiler.purgeInputFileSystem();
 
-        if(err) {
+        if (err) {
           lastHash = null;
           console.error(err.stack || err);
-          if(err.details) console.error(err.details);
-            reject(err.details);
+          if (err.details) {
+            console.error(err.details);
+          }
+          reject(err.details);
         }
 
-        if(stats.hash !== lastHash) {
+        if (stats.hash !== lastHash) {
           lastHash = stats.hash;
-          process.stdout.write(stats.toString(webpackOutputOptions) + "\n");
+          process.stdout.write(stats.toString(webpackOutputOptions) + '\n');
         }
         resolve();
       });

--- a/addon/ng2/tasks/create-github-repo.ts
+++ b/addon/ng2/tasks/create-github-repo.ts
@@ -18,16 +18,19 @@ module.exports = Task.extend({
         ghUsername: commandOptions.ghUsername
       });
     } else {
-      ui.writeLine("\nIn order to deploy this project via GitHub Pages, we must first create a repository for it.");
-      ui.writeLine("It's safer to use a token than to use a password, so you will need to create one.\n");
-      ui.writeLine("Go to the following page and click 'Generate new token'.");
-      ui.writeLine("https://github.com/settings/tokens\n");
-      ui.writeLine("Choose 'public_repo' as scope and then click 'Generate token'.\n");
+      ui.writeLine('\nIn order to deploy this project via GitHub Pages, we must first create a\
+ repository for it.');
+      ui.writeLine('It\'s safer to use a token than to use a password, so you will need to create\
+ one.\n');
+      ui.writeLine('Go to the following page and click "Generate new token".');
+      ui.writeLine('https://github.com/settings/tokens\n');
+      ui.writeLine('Choose "public_repo" as scope and then click "Generate token".\n');
       promise = ui.prompt([
         {
           name: 'ghToken',
           type: 'input',
-          message: 'Please enter GitHub token you just created (used only once to create the repo):',
+          message: 'Please enter GitHub token you just created (used only once to create the\
+ repo):',
           validate: function(token) {
             return /.+/.test(token);
           }
@@ -63,9 +66,11 @@ module.exports = Task.extend({
 
         req.on('response', function(response) {
           if (response.statusCode === 201) {
-            resolve(execPromise(`git remote add origin git@github.com:${answers.ghUsername}/${commandOptions.projectName}.git`))
+            resolve(execPromise(
+   `git remote add origin git@github.com:${answers.ghUsername}/${commandOptions.projectName}.git`));
           } else {
-            reject(new SilentError(`Failed to create GitHub repo. Error: ${response.statusCode} ${response.statusMessage}`));
+            reject(new SilentError(
+          `Failed to create GitHub repo. Error: ${response.statusCode} ${response.statusMessage}`));
           }
         });
 

--- a/addon/ng2/tasks/doc.ts
+++ b/addon/ng2/tasks/doc.ts
@@ -3,7 +3,7 @@ import * as opn from 'opn';
 
 const DocTask = Task.extend({
   run: function(keyword: string) {
-    var searchUrl = `https://angular.io/docs/ts/latest/api/#!?apiFilter=${keyword}`; 
+    var searchUrl = `https://angular.io/docs/ts/latest/api/#!?apiFilter=${keyword}`;
     return opn(searchUrl, { wait: false });
   }
 });

--- a/addon/ng2/tasks/e2e.ts
+++ b/addon/ng2/tasks/e2e.ts
@@ -9,7 +9,8 @@ module.exports = Task.extend({
     var exitCode = 0;
 
     return new Promise((resolve) => {
-      exec(`npm run e2e -- ${this.project.ngConfig.config.e2e.protractor.config}`, (err, stdout, stderr) => {
+      exec(`npm run e2e -- ${this.project.ngConfig.config.e2e.protractor.config}`,
+      (err, stdout, stderr) => {
         ui.writeLine(stdout);
         if (err) {
           ui.writeLine(stderr);

--- a/addon/ng2/tasks/serve-webpack.ts
+++ b/addon/ng2/tasks/serve-webpack.ts
@@ -17,11 +17,13 @@ module.exports = Task.extend({
     let lastHash = null;
     let webpackCompiler: any;
 
-    var config = new NgCliWebpackConfig(this.project, commandOptions.target, commandOptions.environment).config;
+    var config = new NgCliWebpackConfig(this.project, commandOptions.target,
+      commandOptions.environment).config;
 
     // This allows for live reload of page when changes are made to repo.
     // https://webpack.github.io/docs/webpack-dev-server.html#inline-mode
-    config.entry.main.unshift(`webpack-dev-server/client?http://${commandOptions.host}:${commandOptions.port}/`);
+    config.entry.main.unshift(
+      `webpack-dev-server/client?http://${commandOptions.host}:${commandOptions.port}/`);
     webpackCompiler = webpack(config);
 
     webpackCompiler.apply(new ProgressPlugin({
@@ -41,36 +43,36 @@ module.exports = Task.extend({
     }
 
     const webpackDevServerConfiguration: IWebpackDevServerConfigurationOptions = {
-      contentBase: path.resolve(this.project.root, `./${CliConfig.fromProject().config.apps[0].root}`),
+      contentBase: path.resolve(this.project.root,
+        `./${CliConfig.fromProject().config.apps[0].root}`),
       historyApiFallback: true,
       stats: webpackDevServerOutputOptions,
       inline: true,
       proxy: proxyConfig
     };
 
-    const serveMessage:string = chalk.green(`\n*\n*\n NG Live Development Server is running on http://${commandOptions.host}:${commandOptions.port}.\n*\n*`);
+    const serveMessage: string = chalk.green(`\n*\n*\n NG Live Development Server is running on\
+ http://${commandOptions.host}:${commandOptions.port}.\n*\n*`);
     const server = new WebpackDevServer(webpackCompiler, webpackDevServerConfiguration);
 
     return new Promise((resolve, reject) => {
       server.listen(commandOptions.port, `${commandOptions.host}`, function(err, stats) {
-        if(err) {
+        if (err) {
           lastHash = null;
           console.error(err.stack || err);
-          if(err.details) console.error(err.details);
-            reject(err.details);
+          if (err.details) {
+            console.error(err.details);
+          }
+          reject(err.details);
         }
 
-        if(stats && stats.hash && stats.hash !== lastHash) {
+        if (stats && stats.hash && stats.hash !== lastHash) {
           lastHash = stats.hash;
           process.stdout.write(stats.toString(webpackOutputOptions) + '\n' + serveMessage + '\n');
         }
 
         process.stdout.write(serveMessage);
       });
-    })
+    });
   }
 });
-
-
-
-

--- a/addon/ng2/tasks/test.ts
+++ b/addon/ng2/tasks/test.ts
@@ -1,7 +1,7 @@
 import * as Promise from 'ember-cli/lib/ext/promise';
 import * as Task from 'ember-cli/lib/models/task';
 import * as path from 'path';
-import { getWebpackTestConfig } from '../models/webpack-build-test';
+// import { getWebpackTestConfig } from '../models/webpack-build-test';
 
 // require dependencies within the target project
 function requireDependency(root, moduleName) {
@@ -10,7 +10,7 @@ function requireDependency(root, moduleName) {
   return require(path.join(root, 'node_modules', moduleName, main));
 }
 
-module.exports = Task.extend({ 
+module.exports = Task.extend({
   run: function (options) {
     const projectRoot = this.project.root;
     return new Promise((resolve) => {

--- a/addon/ng2/utilities/get-dependent-files.ts
+++ b/addon/ng2/utilities/get-dependent-files.ts
@@ -25,7 +25,7 @@ export interface ModuleMap {
 /**
  * Create a SourceFile as defined by Typescript Compiler API.
  * Generate a AST structure from a source file.
- * 
+ *
  * @param fileName source file for which AST is to be extracted
  */
 export function createTsSourceFile(fileName: string): Promise<ts.SourceFile> {
@@ -38,18 +38,18 @@ export function createTsSourceFile(fileName: string): Promise<ts.SourceFile> {
 
 /**
  * Traverses through AST of a given file of kind 'ts.SourceFile', filters out child
- * nodes of the kind 'ts.SyntaxKind.ImportDeclaration' and returns import clauses as 
+ * nodes of the kind 'ts.SyntaxKind.ImportDeclaration' and returns import clauses as
  * ModuleImport[]
- * 
+ *
  * @param {ts.SourceFile} node: Typescript Node of whose AST is being traversed
- * 
+ *
  * @return {ModuleImport[]} traverses through ts.Node and returns an array of moduleSpecifiers.
  */
 export function getImportClauses(node: ts.SourceFile): ModuleImport[] {
   return node.statements
-    .filter(node => node.kind === ts.SyntaxKind.ImportDeclaration)  // Only Imports.
-    .map((node: ts.ImportDeclaration) => {
-      let moduleSpecifier = node.moduleSpecifier;
+    .filter(node_ => node_.kind === ts.SyntaxKind.ImportDeclaration)  // Only Imports.
+    .map((node_: ts.ImportDeclaration) => {
+      let moduleSpecifier = node_.moduleSpecifier;
       return {
         specifierText: moduleSpecifier.getText().slice(1, -1),
         pos: moduleSpecifier.pos,
@@ -58,12 +58,12 @@ export function getImportClauses(node: ts.SourceFile): ModuleImport[] {
     });
 }
 
-/** 
+/**
  * Find the file, 'index.ts' given the directory name and return boolean value
  * based on its findings.
- * 
+ *
  * @param dirPath
- * 
+ *
  * @return a boolean value after it searches for a barrel (index.ts by convention) in a given path
  */
 export function hasIndexFile(dirPath: string): Promise<Boolean> {
@@ -80,13 +80,13 @@ export function hasIndexFile(dirPath: string): Promise<Boolean> {
  *   creating associated files with the name of the generated unit. So, there are two
  *   assumptions made:
  *   a. the function only returns associated files that have names matching to the given unit.
- *   b. the function only looks for the associated files in the directory where the given unit 
+ *   b. the function only looks for the associated files in the directory where the given unit
  *      exists.
- *  
+ *
  * @todo read the metadata to look for the associated files of a given file.
- * 
- * @param fileName 
- * 
+ *
+ * @param fileName
+ *
  * @return absolute paths of '.html/.css/.sass/.spec.ts' files associated with the given file.
  *
  */
@@ -105,12 +105,12 @@ export function getAllAssociatedFiles(fileName: string): Promise<string[]> {
 /**
  * Returns a map of all dependent file/s' path with their moduleSpecifier object
  * (specifierText, pos, end).
- * 
- * @param fileName file upon which other files depend 
+ *
+ * @param fileName file upon which other files depend
  * @param rootPath root of the project
- * 
+ *
  * @return {Promise<ModuleMap>} ModuleMap of all dependent file/s (specifierText, pos, end)
- * 
+ *
  */
 export function getDependentFiles(fileName: string, rootPath: string): Promise<ModuleMap> {
   const globSearch = denodeify(glob);

--- a/addon/ng2/utilities/prerender-webpack-plugin.ts
+++ b/addon/ng2/utilities/prerender-webpack-plugin.ts
@@ -10,7 +10,7 @@ interface IWebpackPrerender {
 export class PrerenderWebpackPlugin {
 
   private bootloader: any;
-  private cachedTemplate: string
+  private cachedTemplate: string;
 
   constructor(private options: IWebpackPrerender) {
     // maintain your platform instance
@@ -53,4 +53,4 @@ export class PrerenderWebpackPlugin {
         delete require.cache[key];
       });
   }
-}
+};

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:inspect": "node --inspect --debug-brk tests/runner",
     "test:packages": "node scripts/run-packages-spec.js",
     "lint": "eslint .",
+    "tslint": "node_modules/.bin/tslint addon/**/*.ts -e 'addon/ng2/blueprints/**/*' -t verbose",
     "build-config-interface": "dtsgen lib/config/schema.json --out lib/config/schema.d.ts"
   },
   "repository": {


### PR DESCRIPTION
Since `tslint` is a dev dependency, we might as well make use of it.

This PR introduces an `npm` script task names `tslint`.

Running it reveals a flood of rather trivial "typos".
I corrected most of them, they are included in this PR.

After applying this PR, the output of `npm run tslint` is 25 cases of camelcase/uppercase and one usage of evil `eval` (down from 147 cases):

```log
(variable-name) addon/ng2/commands/doc.ts[4, 7]: variable name must be in camelcase or uppercase
(variable-name) addon/ng2/commands/generate.ts[9, 7]: variable name must be in camelcase or uppercase
(variable-name) addon/ng2/commands/get.ts[6, 7]: variable name must be in camelcase or uppercase
(variable-name) addon/ng2/commands/new.ts[8, 7]: variable name must be in camelcase or uppercase
(variable-name) addon/ng2/commands/new.ts[10, 7]: variable name must be in camelcase or uppercase
(variable-name) addon/ng2/commands/set.ts[6, 7]: variable name must be in camelcase or uppercase
(variable-name) addon/ng2/commands/version.ts[5, 7]: variable name must be in camelcase or uppercase
(variable-name) addon/ng2/models/config/config.ts[18, 11]: variable name must be in camelcase or uppercase
(variable-name) addon/ng2/models/config/config.ts[20, 31]: variable name must be in camelcase or uppercase
(no-eval) addon/ng2/models/find-lazy-modules.ts[49, 14]: forbidden eval
(variable-name) addon/ng2/models/json-schema/schema-tree.ts[32, 13]: variable name must be in camelcase or uppercase
(variable-name) addon/ng2/models/json-schema/schema-tree.ts[34, 13]: variable name must be in camelcase or uppercase
(variable-name) addon/ng2/models/json-schema/schema-tree.ts[35, 13]: variable name must be in camelcase or uppercase
(variable-name) addon/ng2/models/json-schema/schema-tree.ts[37, 13]: variable name must be in camelcase or uppercase
(variable-name) addon/ng2/models/json-schema/schema-tree.ts[38, 13]: variable name must be in camelcase or uppercase
(variable-name) addon/ng2/models/json-schema/schema-tree.ts[40, 13]: variable name must be in camelcase or uppercase
(variable-name) addon/ng2/models/json-schema/schema-tree.ts[41, 13]: variable name must be in camelcase or uppercase
(variable-name) addon/ng2/models/json-schema/schema-tree.ts[160, 13]: variable name must be in camelcase or uppercase
(variable-name) addon/ng2/models/json-schema/schema-tree.ts[221, 13]: variable name must be in camelcase or uppercase
(variable-name) addon/ng2/models/json-schema/schema-tree.ts[281, 11]: variable name must be in camelcase or uppercase
(variable-name) addon/ng2/models/json-schema/serializer.ts[27, 9]: variable name must be in camelcase or uppercase
(variable-name) addon/ng2/models/json-schema/serializer.ts[40, 11]: variable name must be in camelcase or uppercase
(variable-name) addon/ng2/models/json-schema/serializer.ts[42, 23]: variable name must be in camelcase or uppercase
(variable-name) addon/ng2/models/json-schema/serializer.ts[42, 50]: variable name must be in camelcase or uppercase
(variable-name) addon/ng2/tasks/build-webpack.ts[24, 11]: variable name must be in camelcase or uppercase
(variable-name) addon/ng2/tasks/doc.ts[4, 7]: variable name must be in camelcase or uppercase
```
