### PR TITLE
Do NOT allow variables in lambda expressions to shadow variables already defined in scope

### DIFF
--- a/addon/ng2/utilities/get-dependent-files.ts
+++ b/addon/ng2/utilities/get-dependent-files.ts
@@ -25,7 +25,7 @@ export interface ModuleMap {
 /**
  * Create a SourceFile as defined by Typescript Compiler API.
  * Generate a AST structure from a source file.
- * 
+ *
  * @param fileName source file for which AST is to be extracted
  */
 export function createTsSourceFile(fileName: string): Promise<ts.SourceFile> {
@@ -38,18 +38,18 @@ export function createTsSourceFile(fileName: string): Promise<ts.SourceFile> {
 
 /**
  * Traverses through AST of a given file of kind 'ts.SourceFile', filters out child
- * nodes of the kind 'ts.SyntaxKind.ImportDeclaration' and returns import clauses as 
+ * nodes of the kind 'ts.SyntaxKind.ImportDeclaration' and returns import clauses as
  * ModuleImport[]
- * 
+ *
  * @param {ts.SourceFile} node: Typescript Node of whose AST is being traversed
- * 
+ *
  * @return {ModuleImport[]} traverses through ts.Node and returns an array of moduleSpecifiers.
  */
 export function getImportClauses(node: ts.SourceFile): ModuleImport[] {
   return node.statements
-    .filter(node => node.kind === ts.SyntaxKind.ImportDeclaration)  // Only Imports.
-    .map((node: ts.ImportDeclaration) => {
-      let moduleSpecifier = node.moduleSpecifier;
+    .filter(aNode => aNode.kind === ts.SyntaxKind.ImportDeclaration)  // Only Imports.
+    .map((aNode: ts.ImportDeclaration) => {
+      let moduleSpecifier = aNode.moduleSpecifier;
       return {
         specifierText: moduleSpecifier.getText().slice(1, -1),
         pos: moduleSpecifier.pos,
@@ -58,12 +58,12 @@ export function getImportClauses(node: ts.SourceFile): ModuleImport[] {
     });
 }
 
-/** 
+/**
  * Find the file, 'index.ts' given the directory name and return boolean value
  * based on its findings.
- * 
+ *
  * @param dirPath
- * 
+ *
  * @return a boolean value after it searches for a barrel (index.ts by convention) in a given path
  */
 export function hasIndexFile(dirPath: string): Promise<Boolean> {
@@ -80,13 +80,13 @@ export function hasIndexFile(dirPath: string): Promise<Boolean> {
  *   creating associated files with the name of the generated unit. So, there are two
  *   assumptions made:
  *   a. the function only returns associated files that have names matching to the given unit.
- *   b. the function only looks for the associated files in the directory where the given unit 
+ *   b. the function only looks for the associated files in the directory where the given unit
  *      exists.
- *  
+ *
  * @todo read the metadata to look for the associated files of a given file.
- * 
- * @param fileName 
- * 
+ *
+ * @param fileName
+ *
  * @return absolute paths of '.html/.css/.sass/.spec.ts' files associated with the given file.
  *
  */
@@ -105,12 +105,12 @@ export function getAllAssociatedFiles(fileName: string): Promise<string[]> {
 /**
  * Returns a map of all dependent file/s' path with their moduleSpecifier object
  * (specifierText, pos, end).
- * 
- * @param fileName file upon which other files depend 
+ *
+ * @param fileName file upon which other files depend
  * @param rootPath root of the project
- * 
+ *
  * @return {Promise<ModuleMap>} ModuleMap of all dependent file/s (specifierText, pos, end)
- * 
+ *
  */
 export function getDependentFiles(fileName: string, rootPath: string): Promise<ModuleMap> {
   const globSearch = denodeify(glob);

--- a/packages/ast-tools/src/node.ts
+++ b/packages/ast-tools/src/node.ts
@@ -21,9 +21,9 @@ export function findNodes(node: ts.Node, kind: ts.SyntaxKind, max: number = Infi
   }
   if (max > 0) {
     for (const child of node.getChildren()) {
-      findNodes(child, kind, max).forEach(node => {
+      findNodes(child, kind, max).forEach(aNode => {
         if (max > 0) {
-          arr.push(node);
+          arr.push(aNode);
         }
         max--;
       });

--- a/packages/ast-tools/src/route-utils.spec.ts
+++ b/packages/ast-tools/src/route-utils.spec.ts
@@ -124,7 +124,7 @@ describe('route utils', () => {
         .then(content => {
           expect(content).toEqual(
             `import routes from './routes';
-  import { provideRouter } from '@angular/router'; 
+  import { provideRouter } from '@angular/router';
   bootstrap(AppComponent, [ provideRouter(routes) ]);`);
         });
     });
@@ -299,7 +299,7 @@ export default [
     children: [
       { path: 'about', component: AboutComponent,
         children: [
-          { path: 'details', component: DetailsComponent }, 
+          { path: 'details', component: DetailsComponent },
           { path: 'more', component: MoreComponent }
         ]
       }
@@ -327,7 +327,7 @@ export default [
         children: [
           { path: 'more', component: MoreComponent,
             children: [
-              { path: 'sections', component: SectionsComponent } 
+              { path: 'sections', component: SectionsComponent }
             ]
           }
         ]
@@ -359,7 +359,7 @@ export default [
   { path: 'main', component: MainComponent }
   { path: 'home', component: HomeComponent,
     children: [
-      { path: 'about/:id', component: AboutComponent_1 }, 
+      { path: 'about/:id', component: AboutComponent_1 },
       { path: 'about', component: AboutComponent }
     ]
   }
@@ -447,7 +447,7 @@ export default [
 export default [
   { path: 'home', component: HomeComponent,
     children: [
-      { path: 'trap-queen', component: TrapQueenComponent }, 
+      { path: 'trap-queen', component: TrapQueenComponent },
       { path: 'about', component: AboutComponent,
         children: [
           { path: 'more', component: MoreComponent }
@@ -462,9 +462,9 @@ export default [
       let editedFile = new InsertChange(routesFile, 16,
         `\n  { path: 'home', component: HomeComponent }\n`);
       return editedFile.apply().then(() => {
-        let editedFile = new InsertChange(routesFile, 0,
+        let editedFile2 = new InsertChange(routesFile, 0,
           `import { HomeComponent } from './app/home/home.component';\n`);
-        return editedFile.apply();
+        return editedFile2.apply();
       })
         .then(() => {
           options.dasherizedName = 'home';
@@ -478,7 +478,7 @@ import { HomeComponent as HomeComponent_1 } from './app/home/home/home.component
 export default [
   { path: 'home', component: HomeComponent,
     children: [
-      { path: 'home', component: HomeComponent_1 } 
+      { path: 'home', component: HomeComponent_1 }
     ]
   }
 ];`;
@@ -487,18 +487,18 @@ export default [
     });
     it('throws error if components collide and there is repitition', () => {
       let editedFile = new InsertChange(routesFile, 16,
-        `\n  { path: 'about', component: AboutComponent, 
+        `\n  { path: 'about', component: AboutComponent,
     children: [
       { path: 'details/:id', component: DetailsComponent_1 },
       { path: 'details', component: DetailsComponent }
     ]
   }`);
       return editedFile.apply().then(() => {
-        let editedFile = new InsertChange(routesFile, 0,
+        let editedFile3 = new InsertChange(routesFile, 0,
           `import { AboutComponent } from './app/about/about.component';
 import { DetailsComponent } from './app/about/details/details.component';
 import { DetailsComponent as DetailsComponent_1 } from './app/about/description/details.component;\n`); // tslint:disable-line
-        return editedFile.apply();
+        return editedFile3.apply();
       }).then(() => {
         options.dasherizedName = 'details';
         options.component = 'DetailsComponent';
@@ -543,7 +543,7 @@ import { DetailsComponent as DetailsComponent_1 } from './app/about/description/
 export default [
   { path: 'home', component: HomeComponent,
     children: [
-      { path: 'more', component: MoreComponent, canDeactivate: [ MyGuard ], useAsDefault: true } 
+      { path: 'more', component: MoreComponent, canDeactivate: [ MyGuard ], useAsDefault: true }
     ]
   }
 ];`

--- a/tslint.json
+++ b/tslint.json
@@ -18,6 +18,7 @@
     "no-internal-module": true,
     "no-trailing-whitespace": true,
     "no-bitwise": true,
+    "no-shadowed-variable": true,
     "no-unused-expression": true,
     "no-unused-variable": true,
     "no-var-keyword": true,


### PR DESCRIPTION
Eliminate a class of bugs.
Rename lambda variables different from scoped ones.
This PR addresses issue #1844.
