### PR TITLE
chore(ci): temporarily allow osx to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ env:
     - SCRIPT=test
 #    - TARGET=mobile SCRIPT=mobile_test
 matrix:
+  fast_finish: true
+  allow_failures:
+    - os: osx
   exclude:
     - node_js: "6"
       env: SCRIPT=lint


### PR DESCRIPTION
Travis has been having trouble with OSX builds for the past few days. 

This PR allows OSX builds to fail, and for us to merge PRs without waiting for them to start/finish.