### PR TITLE
Exclude dist/ from [et]slint npm script tasks

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,3 +5,5 @@ typings/
 
 # Ignore all blueprint files. We e2e tests those later on.
 addon/ng2/blueprints/*/files/
+
+dist/

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:packages": "node scripts/run-packages-spec.js",
     "build-config-interface": "dtsgen lib/config/schema.json --out lib/config/schema.d.ts",
     "eslint": "eslint .",
-    "tslint": "tslint \"**/*.ts\" -c tslint.json -e \"**/blueprints/*/files/**/*.ts\" -e \"node_modules/**\" -e \"tmp/**\"",
+    "tslint": "tslint \"**/*.ts\" -c tslint.json -e \"**/blueprints/*/files/**/*.ts\" -e \"node_modules/**\" -e \"tmp/**\" -e \"dist/**\"",
     "lint": "npm-run-all -c eslint tslint"
   },
   "repository": {


### PR DESCRIPTION
See issue #1862, where linting fails because the generated .js and .ts files in dist/ are not conforming to the linting rules.

This PR takes care of it.
