### PR TITLE
Fix for issue 1876: noImplicitAny means make them explicite

### DIFF
--- a/addon/ng2/commands/init.ts
+++ b/addon/ng2/commands/init.ts
@@ -55,7 +55,8 @@ const InitCommand: any = Command.extend({
 
     // needs an explicit check in case it's just 'undefined'
     // due to passing of options from 'new' and 'addon'
-    let gitInit;
+    debugger;
+    let gitInit: any;
     if (commandOptions.skipGit === false) {
       gitInit = new GitInit({
         ui: this.ui,
@@ -63,7 +64,7 @@ const InitCommand: any = Command.extend({
       });
     }
 
-    let linkCli;
+    let linkCli: any;
     if (commandOptions.linkCli) {
       linkCli = new LinkCli({
         ui: this.ui,
@@ -72,7 +73,7 @@ const InitCommand: any = Command.extend({
       });
     }
 
-    let npmInstall;
+    let npmInstall: any;
     if (!commandOptions.skipNpm) {
       npmInstall = new NpmInstall({
         ui: this.ui,
@@ -81,7 +82,7 @@ const InitCommand: any = Command.extend({
       });
     }
 
-    let bowerInstall;
+    let bowerInstall: any;
     if (!commandOptions.skipBower) {
       bowerInstall = new this.tasks.BowerInstall({
         ui: this.ui,

--- a/addon/ng2/commands/init.ts
+++ b/addon/ng2/commands/init.ts
@@ -55,7 +55,6 @@ const InitCommand: any = Command.extend({
 
     // needs an explicit check in case it's just 'undefined'
     // due to passing of options from 'new' and 'addon'
-    debugger;
     let gitInit: any;
     if (commandOptions.skipGit === false) {
       gitInit = new GitInit({


### PR DESCRIPTION
`npm run build` has the TypeScript compiler configured to not allow implicit any references.
A build fails currently with - see issue #1876.

```log
npm run build

> angular-cli@1.0.0-beta.11-webpack.8 build angular-cli.git
> npm-run-all -c build:main build:packages


> angular-cli@1.0.0-beta.11-webpack.8 build:main angular-cli.git
> tsc -p addon/ng2

addon/ng2/commands/init.ts(58,9): error TS7005: Variable 'gitInit' implicitly has an 'any' type.
addon/ng2/commands/init.ts(66,9): error TS7005: Variable 'linkCli' implicitly has an 'any' type.
addon/ng2/commands/init.ts(75,9): error TS7005: Variable 'npmInstall' implicitly has an 'any' type.
addon/ng2/commands/init.ts(84,9): error TS7005: Variable 'bowerInstall' implicitly has an 'any' type.
```

This PR fixes the compilation errors.