### PR TITLE
fix(find-lazy-modules): JSON parse error for loadChildren

### DIFF
--- a/addon/ng2/models/find-lazy-modules.ts
+++ b/addon/ng2/models/find-lazy-modules.ts
@@ -35,7 +35,8 @@ export function findLoadChildren(tsFilePath: string): string[] {
       })
       // Get the full text of the initializer.
       .map((node: ts.PropertyAssignment) => {
-        return JSON.parse(node.initializer.getText(source)); // tslint:disable-line
+        let text = node.initializer.getText(source).replace(/'/g, '"');
+        return JSON.parse(text);
       });
 
   return nodes


### PR DESCRIPTION
Fixes #1891, #1960.

cc @filipesilva @ericjim - was failing for ng2.io, but this fixes the issue.