### PR TITLE
Minor update to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ npm-debug.log*
 # IDEs
 .idea/
 jsconfig.json
-.vscode/launch.json
+.vscode/
 
 # Typings file.
 typings/

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,11 @@
 dist/
 node_modules/
-npm-debug.log
+npm-debug.log*
 
 # IDEs
 .idea/
 jsconfig.json
+.vscode/launch.json
 
 # Typings file.
 typings/


### PR DESCRIPTION
1. node does not only create `npm-debug.log` files, also files in the format `npm-debug.log.NUMBER` are possible
2. for all those people that have to debug the CLI