### PR TITLE
fix: Set awesome-typescript-loader version to 2.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@angular/core": "^2.0.0-rc.6",
     "@angular/tsc-wrapped": "^0.2.2",
     "angular2-template-loader": "^0.5.0",
-    "awesome-typescript-loader": "^2.2.1",
+    "awesome-typescript-loader": "2.2.1",
     "chalk": "^1.1.3",
     "common-tags": "^1.3.1",
     "compression-webpack-plugin": "^0.3.1",


### PR DESCRIPTION
New builds are breaking with the most recent awesome-typescript-loader update