### PR TITLE
chore(e2e): bump protractor to 4.0.5

### DIFF
--- a/addon/ng2/blueprints/ng2/files/__path__/test.ts
+++ b/addon/ng2/blueprints/ng2/files/__path__/test.ts
@@ -9,6 +9,7 @@ import 'zone.js/dist/fake-async-test';
 
 // Unfortunately there's no typing for the `__karma__` variable. Just declare it as any.
 declare var __karma__: any;
+declare var require: any;
 
 // Prevent Karma from running prematurely.
 __karma__.loaded = function () {};

--- a/addon/ng2/blueprints/ng2/files/__path__/typings.d.ts
+++ b/addon/ng2/blueprints/ng2/files/__path__/typings.d.ts
@@ -3,6 +3,3 @@
 // https://www.typescriptlang.org/docs/handbook/writing-declaration-files.html
 
 declare var System: any;
-declare var module: { id: string };
-declare var require: any;
-

--- a/addon/ng2/blueprints/ng2/files/package.json
+++ b/addon/ng2/blueprints/ng2/files/package.json
@@ -43,7 +43,7 @@
     "karma-cli": "^1.0.1",
     "karma-jasmine": "^1.0.2",
     "karma-remap-istanbul": "^0.2.1",
-    "protractor": "4.0.3",
+    "protractor": "4.0.5",
     "ts-node": "1.2.1",
     "tslint": "3.13.0",
     "typescript": "2.0.2"


### PR DESCRIPTION
Fixes #1977 

Protractor 4.0.3 has a critical bug, and will return a success code even if the tests are failing or if there is no `ng serve` running... (see the related https://github.com/angular/protractor/issues/3505)

4.0.5 fixes it, but it now relies on `@types/node` (as stated in the changelog https://github.com/angular/protractor/blob/master/CHANGELOG.md#405), which conflicts with the declarations in the `typings.d.ts` file. As they are now duplicated, removing them from the `typings.d.ts` file solves the problem.

`declare var require: any;`  has to be added to the `test.ts` file because this is not the same `NodeRequire` that `@types/node` declares, but a `WebpackRequire` with the `context` field.

There is probably a more elegant solution to solve this, but at least this one unblocked us.