### PR TITLE
chore: explicitely add node typings

### DIFF
--- a/addon/ng2/blueprints/ng2/files/package.json
+++ b/addon/ng2/blueprints/ng2/files/package.json
@@ -34,6 +34,7 @@
     "preboot": "2.1.2",
     "parse5": "1.5.1",<% } %>
     "@types/jasmine": "^2.2.30",
+    "@types/node": "^6.0.38",
     "angular-cli": "<%= version %>",
     "codelyzer": "~0.0.26",
     "jasmine-core": "2.4.1",


### PR DESCRIPTION
Followup from https://github.com/angular/angular-cli/pull/2054

Now our files depend on the node typings, so we should have it as an explicit dependency.