### PR TITLE
feat(cli): allows webpack alias configuration via angular-cli.json

### DIFF
--- a/addon/ng2/models/webpack-build-common.ts
+++ b/addon/ng2/models/webpack-build-common.ts
@@ -7,6 +7,17 @@ const atl = require('awesome-typescript-loader');
 import { BaseHrefWebpackPlugin } from '@angular-cli/base-href-webpack';
 import { findLazyModules } from './find-lazy-modules';
 
+const getWebpackAlias = function (appRoot: string, alias: any) {
+  if (! alias) {
+    return {};
+  }
+  // resolve the appRoot path into the aliases
+  Object.keys(alias).map(item =>
+    alias[item] = path.resolve(appRoot, alias[item])
+  );
+
+  return alias;
+};
 
 export function getWebpackCommonConfig(
   projectRoot: string,
@@ -37,7 +48,8 @@ export function getWebpackCommonConfig(
     devtool: 'source-map',
     resolve: {
       extensions: ['', '.ts', '.js'],
-      root: appRoot
+      root: appRoot,
+      alias: getWebpackAlias(appRoot, appConfig.alias)
     },
     context: path.resolve(__dirname, './'),
     entry: entry,

--- a/addon/ng2/models/webpack-build-test.js
+++ b/addon/ng2/models/webpack-build-test.js
@@ -3,8 +3,20 @@
 const path = require('path');
 const webpack = require('webpack');
 
+const getWebpackAlias = function (appRoot, alias) {
+  if (! alias) {
+    return {};
+  }
+  // resolve the appRoot path into the aliases
+  Object.keys(alias).map(item =>
+    alias[item] = path.resolve(appRoot, alias[item])
+  );
+
+  return alias;
+}
+
 const getWebpackTestConfig = function(projectRoot, appConfig) {
-  
+
   const appRoot = path.resolve(projectRoot, appConfig.root);
 
   return {
@@ -12,7 +24,8 @@ const getWebpackTestConfig = function(projectRoot, appConfig) {
     context: path.resolve(__dirname, './'),
     resolve: {
       extensions: ['', '.ts', '.js'],
-      root: appRoot
+      root: appRoot,
+      alias: getWebpackAlias(appRoot, appConfig.alias)
     },
     entry: {
       test: path.resolve(appRoot, appConfig.test)
@@ -98,6 +111,6 @@ const getWebpackTestConfig = function(projectRoot, appConfig) {
       setImmediate: false
     }
   };
-}
+};
 
 module.exports.getWebpackTestConfig = getWebpackTestConfig;

--- a/lib/config/schema.d.ts
+++ b/lib/config/schema.d.ts
@@ -33,6 +33,12 @@ export interface CliConfig {
         environments?: {
             [name: string]: any;
         };
+        /**
+         * Alias to resolve by webpack.
+         */
+        alias?: {
+            [name: string]: any;
+        };
     }[];
     /**
      * Configuration reserved for installed third party addons.

--- a/lib/config/schema.json
+++ b/lib/config/schema.json
@@ -73,6 +73,11 @@
             "description": "Name and corresponding file for environment config.",
             "type": "object",
             "additionalProperties": true
+          },
+          "alias": {
+            "description": "Paths to be resolved by webpack in the build.",
+            "type": "object",
+            "additionalProperties": true
           }
         },
         "additionalProperties": false


### PR DESCRIPTION
Allows webpack alias configuration, this feature allows relative paths to be resolved more elegantly.

angular-cli.json example
```
"apps": [
    {
      "root": "src",
      "outDir": "dist",
      "assets": "assets",
      "index": "index.html",
      "main": "main.ts",
      "test": "test.ts",
      "tsconfig": "tsconfig.json",
      "prefix": "app",
      "mobile": false,
      "styles": [
        "styles.css"
      ],
      "scripts": [],
      "environments": {
        "source": "environments/environment.ts",
        "prod": "environments/environment.prod.ts",
        "dev": "environments/environment.dev.ts"
      },
      "alias": {  <---------------------------------- new property
        "app": "app"  <---------------------------------- relativet to "root"
      }
    }
```

you can now import files using
import {Component} from 'app/path/to/component'
