### PR TITLE
chore: revert "explicitely add node typings"

### DIFF
--- a/addon/ng2/blueprints/ng2/files/package.json
+++ b/addon/ng2/blueprints/ng2/files/package.json
@@ -34,7 +34,6 @@
     "preboot": "2.1.2",
     "parse5": "1.5.1",<% } %>
     "@types/jasmine": "^2.2.30",
-    "@types/node": "^6.0.38",
     "angular-cli": "<%= version %>",
     "codelyzer": "~0.0.26",
     "jasmine-core": "2.4.1",


### PR DESCRIPTION
Reverts angular/angular-cli#2059

I didn't notice but @cexbrayat had already added the explicit declaration for `require` in https://github.com/angular/angular-cli/pull/2054/files#diff-ae97f17abc1aa7fc3f20519d8da9b628, making it unnecessary to have typings for node.