### PR TITLE
chore(build): map dev env to environment.ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,13 +125,19 @@ The build artifacts will be stored in the `dist/` directory.
 
 ### Build Targets and Environment Files
 
-A build can specify both a build target (`development` or `production`) and an 
-environment file to be used with that build. By default, the development build 
-target is used.
+`ng build` can specify both a build target (`--target=production` or `--target=development`) and an 
+environment file to be used with that build (`--environment=dev` or `--environment=prod`). 
+By default, the development build target and environment are used.
 
-At build time, `src/environments/environment.ts` will be replaced by
-`src/environments/environment.NAME.ts` where `NAME` is the argument 
-provided to the `--environment` flag.
+The mapping used to determine which environment file is used can be found in `angular-cli.json`:
+
+```
+"environments": {
+  "source": "environments/environment.ts",
+  "dev": "environments/environment.ts",
+  "prod": "environments/environment.prod.ts"
+}
+```
 
 These options also apply to the serve command. If you do not pass a value for `environment`,
 it will default to `dev` for `development` and `prod` for `production`.
@@ -150,8 +156,8 @@ ng build
 
 You can also add your own env files other than `dev` and `prod` by doing the following:
 - create a `src/environments/environment.NAME.ts`
-- add `{ NAME: 'src/environments/environment.NAME.ts' }` to the the `apps[0].environments` object in `angular-cli.json` 
-- use them by using the `--env=NAME` flag on the build/serve commands.
+- add `{ "NAME": 'src/environments/environment.NAME.ts' }` to the the `apps[0].environments` object in `angular-cli.json` 
+- use them via the `--env=NAME` flag on the build/serve commands.
 
 ### Base tag handling in index.html
 

--- a/packages/angular-cli/blueprints/ng2/files/__path__/environments/environment.dev.ts
+++ b/packages/angular-cli/blueprints/ng2/files/__path__/environments/environment.dev.ts
@@ -1,3 +1,0 @@
-export const environment = {
-  production: false
-};

--- a/packages/angular-cli/blueprints/ng2/files/__path__/environments/environment.ts
+++ b/packages/angular-cli/blueprints/ng2/files/__path__/environments/environment.ts
@@ -1,7 +1,7 @@
-// The file for the current environment will overwrite this one during build.
-// Different environments can be found in ./environment.{dev|prod}.ts, and
-// you can create your own and use it with the --env flag.
-// The build system defaults to the dev environment.
+// The file contents for the current environment will overwrite these during build.
+// The build system defaults to the dev environment which uses `environment.ts`, but if you do
+// `ng build --env=prod` then `environment.prod.ts` will be used instead.
+// The list of which env maps to which file can be found in `angular-cli.json`.
 
 export const environment = {
   production: false

--- a/packages/angular-cli/blueprints/ng2/files/angular-cli.json
+++ b/packages/angular-cli/blueprints/ng2/files/angular-cli.json
@@ -20,8 +20,8 @@
       "scripts": [],
       "environments": {
         "source": "environments/environment.ts",
-        "prod": "environments/environment.prod.ts",
-        "dev": "environments/environment.dev.ts"
+        "dev": "environments/environment.ts",
+        "prod": "environments/environment.prod.ts"
       }
     }
   ],


### PR DESCRIPTION
By mapping `--env=dev` directly to `environment.ts` we can avoid having an extra file that is never really used.