### PR TITLE
fix(test): add build environment to karma

### DIFF
--- a/packages/angular-cli/blueprints/ng2/files/karma.conf.js
+++ b/packages/angular-cli/blueprints/ng2/files/karma.conf.js
@@ -23,7 +23,10 @@ module.exports = function (config) {
         lcovonly: './coverage/coverage.lcov'
       }
     },
-    angularCliConfig: './angular-cli.json',
+    angularCli: {
+      config: './angular-cli.json',
+      environment: 'dev'
+    },
     reporters: ['progress', 'karma-remap-istanbul'],
     port: 9876,
     colors: true,

--- a/packages/angular-cli/models/webpack-build-test.js
+++ b/packages/angular-cli/models/webpack-build-test.js
@@ -3,8 +3,8 @@
 const path = require('path');
 const webpack = require('webpack');
 
-const getWebpackTestConfig = function(projectRoot, appConfig) {
-  
+const getWebpackTestConfig = function (projectRoot, environment, appConfig) {
+
   const appRoot = path.resolve(projectRoot, appConfig.root);
 
   return {
@@ -81,7 +81,15 @@ const getWebpackTestConfig = function(projectRoot, appConfig) {
       new webpack.SourceMapDevToolPlugin({
         filename: null, // if no value is provided the sourcemap is inlined
         test: /\.(ts|js)($|\?)/i // process .js and .ts files only
-      })
+      }),
+      new webpack.NormalModuleReplacementPlugin(
+        // This plugin is responsible for swapping the environment files.
+        // Since it takes a RegExp as first parameter, we need to escape the path.
+        // See https://webpack.github.io/docs/list-of-plugins.html#normalmodulereplacementplugin
+        new RegExp(path.resolve(appRoot, appConfig.environments['source'])
+          .replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&')),
+        path.resolve(appRoot, appConfig.environments[environment])
+      ),
     ],
     tslint: {
       emitErrors: false,

--- a/packages/angular-cli/plugins/karma.js
+++ b/packages/angular-cli/plugins/karma.js
@@ -4,12 +4,15 @@ const getWebpackTestConfig = require('../models/webpack-build-test').getWebpackT
 const init = (config) => {
 
   // load Angular CLI config
-  if (!config.angularCliConfig) throw new Error('Missing \'angularCliConfig\' entry in Karma config');
-  const angularCliConfig = require(path.join(config.basePath, config.angularCliConfig));
+  if (!config.angularCli && !config.angularCli.config) {
+    throw new Error('Missing \'angularCliConfig\' entry in Karma config');
+  }
+  const angularCliConfig = require(path.join(config.basePath, config.config.angularCli.config));
   const appConfig = angularCliConfig.apps[0];
+  const environment = config.angularCli.environment || 'dev';
 
   // add webpack config
-  config.webpack = getWebpackTestConfig(config.basePath, appConfig);
+  config.webpack = getWebpackTestConfig(config.basePath, environment, appConfig);
   config.webpackMiddleware = {
     noInfo: true, // Hide webpack output because its noisy.
     stats: { // Also prevent chunk and module display output, cleaner look. Only emit errors.


### PR DESCRIPTION
Karma was not using environment file replacement in it's build step. This PR fixes that, defaulting to `dev`.

Fix https://github.com/angular/angular-cli/issues/1718
Partially fix https://github.com/angular/angular-cli/issues/1419 