### PR TITLE
fix: add @angular-cli/base-href-webpack@1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "homepage": "https://github.com/angular/angular-cli",
   "dependencies": {
     "@angular-cli/ast-tools": "^1.0.0",
+    "@angular-cli/base-href-webpack": "^1.0.0",
     "@angular/compiler": "^2.0.0-rc.7",
     "@angular/compiler-cli": "^0.6.0",
     "@angular/core": "^2.0.0-rc.7",


### PR DESCRIPTION
The current 1.0.0-beta.11-webpack.9 doesn't include @angular-cli/base-href-webpack@1.0.0 causing an error when running ng commands