### PR TITLE
fix: check for old version of the CLI on empty project

### DIFF
--- a/packages/angular-cli/upgrade/version.ts
+++ b/packages/angular-cli/upgrade/version.ts
@@ -76,6 +76,11 @@ export class Version {
 
 
     const configPath = CliConfig.configFilePath();
+
+    if (configPath === null) {
+      return new Version(null);
+    }
+
     const configJson = readFileSync(configPath, 'utf8');
 
     try {


### PR DESCRIPTION
On empty project, when config files are not exists `CliConfig.configFilePath` will return `null`.
`null` is not valid argument for `readFileSync`
There was `TypeError: path must be a string or Buffer`

#2135 