### PR TITLE
Fixed typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ First install Bootstrap from `npm`:
 npm install bootstrap@next
 ```
 
-Then add the needed script files to to `apps[0].scripts`.
+Then add the needed script files to `apps[0].scripts`:
 
 ```
 "scripts": [


### PR DESCRIPTION
Fixed typo (removed extra 'to') and added colon to match other steps in global installation instructions.