### PR TITLE
chore(readme): update Bootstrap CSS inclusion example

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,8 +342,8 @@ Then add the needed script files to to `apps[0].scripts`.
 Finally add the Bootstrap CSS to the `apps[0].styles` array:
 ```
 "styles": [
-  "styles.css",
-  "../node_modules/bootstrap/dist/css/bootstrap.css"
+  "../node_modules/bootstrap/dist/css/bootstrap.css",
+  "styles.css"
 ],
 ```
 


### PR DESCRIPTION
This commit changes README example of including Bootstrap dependency
in generated project in that way that Bootstrap CSS dependency is
moved up - to be the first in build bundle.
The reason behind this change is that Bootstrap comes with reset
CSS code and globals that are intended to be global unless reset
and changed by cascading file - here style.css.

Order of CSS styles inclusion:
Before:
```
- style.css
- bootstrap.css
```
after:
```
- bootstrap.css
- style.css
```

Thanks!