### PR TITLE
Add project source dir as a module solution

### DIFF
--- a/packages/angular-cli/models/webpack-build-common.ts
+++ b/packages/angular-cli/models/webpack-build-common.ts
@@ -37,7 +37,12 @@ export function getWebpackCommonConfig(
     devtool: 'source-map',
     resolve: {
       extensions: ['', '.ts', '.js'],
-      root: appRoot
+       root: appRoot,
+       plugins: [
+         new atl.TsConfigPathsPlugin({
+           tsconfig: path.resolve(appRoot, appConfig.tsconfig)
+         })
+       ]
     },
     context: path.resolve(__dirname, './'),
     entry: entry,

--- a/packages/angular-cli/models/webpack-build-test.js
+++ b/packages/angular-cli/models/webpack-build-test.js
@@ -2,6 +2,7 @@
 
 const path = require('path');
 const webpack = require('webpack');
+const atl = require('awesome-typescript-loader');
 
 const getWebpackTestConfig = function (projectRoot, environment, appConfig) {
 
@@ -12,7 +13,12 @@ const getWebpackTestConfig = function (projectRoot, environment, appConfig) {
     context: path.resolve(__dirname, './'),
     resolve: {
       extensions: ['', '.ts', '.js'],
-      root: appRoot
+      root: appRoot,
+      plugins: [
+        new atl.TsConfigPathsPlugin({
+          tsconfig: path.resolve(appRoot, appConfig.tsconfig)
+        })
+      ]
     },
     entry: {
       test: path.resolve(appRoot, appConfig.test)


### PR DESCRIPTION
Adding resolve alias `@prefix` and `app` to webpack config and adding `paths` `@prefix` and `app` to tsconfig.json. I think it fixes #1465

This allows to import app modules using 

```typescript
import '@app/app.component'
```

or 

```typescript
import 'app/app.component';
```