### PR TITLE
chore(webpack): fixes webpack to 2.1.0-beta.22 to avoid broken CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "typedoc": "^0.4.2",
     "typescript": "2.0.2",
     "url-loader": "^0.5.7",
-    "webpack": "^2.1.0-beta.22",
+    "webpack": "2.1.0-beta.22",
     "webpack-dev-server": "^2.1.0-beta.3",
     "webpack-md5-hash": "0.0.5",
     "webpack-merge": "^0.14.0",


### PR DESCRIPTION
Please pin the webpack version to v2.1.0-beta.22.
Beta-23 of webpack has breaking changes: https://github.com/webpack/webpack/releases/tag/v2.1.0-beta.23

see https://github.com/angular/angular-cli/issues/2234 for error log
The evil `^` was introduced in https://github.com/angular/angular-cli/pull/2011