### PR TITLE
fix(#1875): Support npm linked libraries

### DIFF
--- a/packages/angular-cli/models/webpack-build-common.ts
+++ b/packages/angular-cli/models/webpack-build-common.ts
@@ -33,7 +33,8 @@ export function getWebpackCommonConfig(
   return {
     devtool: 'source-map',
     resolve: {
-      extensions: ['.ts', '.js']
+      extensions: ['.ts', '.js'],
+      modules: [path.resolve(projectRoot, 'node_modules')]
     },
     context: path.resolve(__dirname, './'),
     entry: entry,


### PR DESCRIPTION
This PR fixes the problem with linked packages (https://github.com/angular/angular-cli/issues/1875). 

Originally I've used http://webpack.github.io/docs/troubleshooting.html#npm-linked-modules-doesn-t-find-their-dependencies official documentation. But for webpack2 the team has changed also configuration object, which doesn't work like described in the article.

So I've found another release note related to configuration object - https://gist.github.com/sokra/27b24881210b56bbaff7#resolving-options

The most important is ```Resolving options ``` section.

So we have to change our configuration object from:
```
module.exports = {
  resolve: { fallback: path.join(__dirname, "node_modules") },
  resolveLoader: { fallback: path.join(__dirname, "node_modules") }
};
```
to:
```
module.exports = {
  resolve: { 
    modules: [ path.join(__dirname, "node_modules") ]
  }
};
```

Closes https://github.com/angular/angular-cli/issues/1875