### PR TITLE
feat: swap out raw-loader for html-loader for html files

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "fs.realpath": "^1.0.0",
     "glob": "^7.0.3",
     "handlebars": "^4.0.5",
+    "html-loader": "^0.4.4",
     "html-webpack-plugin": "^2.19.0",
     "istanbul-instrumenter-loader": "^0.2.0",
     "json-loader": "^0.5.4",

--- a/packages/angular-cli/models/webpack-build-common.ts
+++ b/packages/angular-cli/models/webpack-build-common.ts
@@ -115,7 +115,7 @@ export function getWebpackCommonConfig(
 
         { test: /\.json$/, loader: 'json-loader' },
         { test: /\.(jpg|png|gif)$/, loader: 'url-loader?limit=10000' },
-        { test: /\.html$/, loader: 'raw-loader' },
+        { test: /\.html$/, loader: 'html-loader' },
 
         { test: /\.(otf|woff|ttf|svg)$/, loader: 'url?limit=10000' },
         { test: /\.woff2$/, loader: 'url?limit=10000&mimetype=font/woff2' },

--- a/packages/angular-cli/models/webpack-build-test.js
+++ b/packages/angular-cli/models/webpack-build-test.js
@@ -64,7 +64,7 @@ const getWebpackTestConfig = function (projectRoot, environment, appConfig) {
         { test: /\.less$/, loaders: ['raw-loader', 'postcss-loader', 'less-loader'] },
         { test: /\.scss$|\.sass$/, loaders: ['raw-loader', 'postcss-loader', 'sass-loader'] },
         { test: /\.(jpg|png)$/, loader: 'url-loader?limit=128000' },
-        { test: /\.html$/, loader: 'raw-loader', exclude: [path.resolve(appRoot, appConfig.index)] }
+        { test: /\.html$/, loader: 'html-loader', exclude: [path.resolve(appRoot, appConfig.index)] }
       ],
       postLoaders: [
         {


### PR DESCRIPTION
#* angular html components as well as index.html now have the benefits of [html-loader](https://github.com/webpack/html-loader)
* Fixes #2231 