### PR TITLE
chore(e2e): bump to protractor 4.0.9

### DIFF
--- a/packages/angular-cli/blueprints/ng2/files/e2e/app.po.ts
+++ b/packages/angular-cli/blueprints/ng2/files/e2e/app.po.ts
@@ -1,4 +1,4 @@
-import { browser, element, by } from 'protractor/globals';
+import { browser, element, by } from 'protractor';
 
 export class <%= jsComponentName %>Page {
   navigateTo() {

--- a/packages/angular-cli/blueprints/ng2/files/package.json
+++ b/packages/angular-cli/blueprints/ng2/files/package.json
@@ -43,7 +43,7 @@
     "karma-cli": "^1.0.1",
     "karma-jasmine": "^1.0.2",
     "karma-remap-istanbul": "^0.2.1",
-    "protractor": "4.0.5",
+    "protractor": "4.0.9",
     "ts-node": "1.2.1",
     "tslint": "3.13.0",
     "typescript": "2.0.2"


### PR DESCRIPTION
Last protractor release has a breaking change on the import needed (see https://github.com/angular/protractor/blob/master/CHANGELOG.md#409).