### PR TITLE
fix: missing dependency @angular-cli/base-href-webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "homepage": "https://github.com/angular/angular-cli",
   "dependencies": {
     "@angular-cli/ast-tools": "^1.0.0",
+    "@angular-cli/base-href-webpack": "^1.0.0",
     "@angular/common": "^2.0.0",
     "@angular/compiler": "^2.0.0",
     "@angular/compiler-cli": "^0.6.0",


### PR DESCRIPTION
`@angular-cli/base-href-webpack` dependency was in `packages/angular-cli/project.json` but not in root `project.json`