### PR TITLE
fix(webpack): Added ContextReplacementPlugin to remove ng test warning

### DIFF
--- a/packages/angular-cli/models/webpack-build-test.js
+++ b/packages/angular-cli/models/webpack-build-test.js
@@ -102,7 +102,11 @@ const getWebpackTestConfig = function (projectRoot, environment, appConfig) {
             resourcePath: `./${appConfig.root}`
           }
         }
-      })
+      }),
+      new webpack.ContextReplacementPlugin(
+        /angular(\\|\/)core(\\|\/)(esm(\\|\/)src|src)(\\|\/)linker/,
+        appRoot
+      )
     ],
     node: {
       fs: 'empty',


### PR DESCRIPTION
Fixes #2359

@TheLarkInn: This is my first time working with webpack. Please let me know if there is anything else I need to do. It appears to have fixed the issue I was seeing with my project.