### PR TITLE
chore(build): update node-zopfli

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "awesome-typescript-loader": "^2.2.3",
     "chalk": "^1.1.3",
     "common-tags": "^1.3.1",
-    "compression-webpack-plugin": "^0.3.1",
+    "compression-webpack-plugin": "github:webpack/compression-webpack-plugin#7e55907cd54a2e91b96d25a660acc6a2a6453f54",
     "copy-webpack-plugin": "^3.0.1",
     "core-js": "^2.4.0",
     "css-loader": "^0.23.1",

--- a/packages/angular-cli/package.json
+++ b/packages/angular-cli/package.json
@@ -37,7 +37,7 @@
     "awesome-typescript-loader": "^2.2.3",
     "chalk": "^1.1.3",
     "common-tags": "^1.3.1",
-    "compression-webpack-plugin": "^0.3.1",
+    "compression-webpack-plugin": "github:webpack/compression-webpack-plugin#7e55907cd54a2e91b96d25a660acc6a2a6453f54",
     "copy-webpack-plugin": "^3.0.1",
     "core-js": "^2.4.0",
     "css-loader": "^0.23.1",


### PR DESCRIPTION
Update `compression-webpack-plugin` to a (yet) unreleased version that fixed the `node-zopfli` gyp errors on windows.

See https://github.com/webpack/compression-webpack-plugin/pull/34
Close https://github.com/angular/angular-cli/issues/1991