### PR TITLE
fix(generate): use prefix when initializing app (#2046)

### DIFF
--- a/packages/angular-cli/blueprints/ng2/files/__path__/app/app.component.spec.ts
+++ b/packages/angular-cli/blueprints/ng2/files/__path__/app/app.component.spec.ts
@@ -21,13 +21,13 @@ describe('App: <%= jsComponentName %>', () => {
   it(`should have as title 'app works!'`, async(() => {
     let fixture = TestBed.createComponent(AppComponent);
     let app = fixture.debugElement.componentInstance;
-    expect(app.title).toEqual('app works!');
+    expect(app.title).toEqual('<%= prefix %> works!');
   }));
 
   it('should render title in a h1 tag', async(() => {
     let fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     let compiled = fixture.debugElement.nativeElement;
-    expect(compiled.querySelector('h1').textContent).toContain('app works!');
+    expect(compiled.querySelector('h1').textContent).toContain('<%= prefix %> works!');
   }));
 });

--- a/packages/angular-cli/blueprints/ng2/files/__path__/app/app.component.ts
+++ b/packages/angular-cli/blueprints/ng2/files/__path__/app/app.component.ts
@@ -13,5 +13,5 @@ import { APP_SHELL_DIRECTIVES } from '@angular/app-shell';<% } %>
   styleUrls: ['./app.component.<%= styleExt %>']<% } %>
 })
 export class AppComponent {
-  title = 'app works!';
+  title = '<%= prefix %> works!';
 }


### PR DESCRIPTION
E2E test would fail when using a prefix to generate the app.
I've updated the initial component generator to take prefix into account.

Fixes issue #2046