### PR TITLE
fix(blueprint): fix routing module import

### DIFF
--- a/packages/angular-cli/blueprints/ng2/files/__path__/app/app.module.ts
+++ b/packages/angular-cli/blueprints/ng2/files/__path__/app/app.module.ts
@@ -2,7 +2,7 @@ import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { HttpModule } from '@angular/http';<% if (routing) { %>
-import { <%= classifiedModuleName %>RoutingModule } from './<%= dasherizedModuleName %>-routing.module';<% } %>
+import { <%= classifiedModuleName %>RoutingModule } from './app-routing.module';<% } %>
 
 import { AppComponent } from './app.component';
 


### PR DESCRIPTION
This fixes an issue when generate a new app with `--prefix` and `--routing` options.