### PR TITLE
feature: Allow for absolute TypeScript imports.

### DIFF
--- a/packages/angular-cli/blueprints/ng2/files/__path__/tsconfig.json
+++ b/packages/angular-cli/blueprints/ng2/files/__path__/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "declaration": false,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,

--- a/packages/angular-cli/models/webpack-build-common.ts
+++ b/packages/angular-cli/models/webpack-build-common.ts
@@ -35,11 +35,11 @@ export function getWebpackCommonConfig(
     resolve: {
       extensions: ['.ts', '.js'],
       modules: [
-        path.resolve(projectRoot, 'src'),
-        path.resolve(projectRoot, 'node_modules')
+        path.resolve(projectRoot, appConfig.root),
+        'node_modules'
       ]
     },
-    context: path.resolve(projectRoot, 'src'),
+    context: path.resolve(projectRoot, appConfig.root),
     entry: entry,
     output: {
       path: path.resolve(projectRoot, appConfig.outDir),

--- a/packages/angular-cli/models/webpack-build-common.ts
+++ b/packages/angular-cli/models/webpack-build-common.ts
@@ -33,9 +33,13 @@ export function getWebpackCommonConfig(
   return {
     devtool: 'source-map',
     resolve: {
-      extensions: ['.ts', '.js']
+      extensions: ['.ts', '.js'],
+      modules: [
+        path.resolve(projectRoot, 'src'),
+        path.resolve(projectRoot, 'node_modules')
+      ]
     },
-    context: path.resolve(__dirname, './'),
+    context: path.resolve(projectRoot, 'src'),
     entry: entry,
     output: {
       path: path.resolve(projectRoot, appConfig.outDir),

--- a/packages/angular-cli/models/webpack-build-test.js
+++ b/packages/angular-cli/models/webpack-build-test.js
@@ -9,12 +9,12 @@ const getWebpackTestConfig = function (projectRoot, environment, appConfig) {
 
   return {
     devtool: 'inline-source-map',
-    context: path.resolve(projectRoot, 'src'),
+    context: path.resolve(projectRoot, appConfig.root),
     resolve: {
       extensions: ['.ts', '.js'],
       modules: [
-        path.resolve(projectRoot, 'src'),
-        path.resolve(projectRoot, 'node_modules')
+        path.resolve(projectRoot, appConfig.root),
+        'node_modules'
       ]
     },
     entry: {

--- a/packages/angular-cli/models/webpack-build-test.js
+++ b/packages/angular-cli/models/webpack-build-test.js
@@ -9,9 +9,13 @@ const getWebpackTestConfig = function (projectRoot, environment, appConfig) {
 
   return {
     devtool: 'inline-source-map',
-    context: path.resolve(__dirname, './'),
+    context: path.resolve(projectRoot, 'src'),
     resolve: {
-      extensions: ['.ts', '.js']
+      extensions: ['.ts', '.js'],
+      modules: [
+        path.resolve(projectRoot, 'src'),
+        path.resolve(projectRoot, 'node_modules')
+      ]
     },
     entry: {
       test: path.resolve(appRoot, appConfig.test)


### PR DESCRIPTION
By defining:
- context and resolve.modules for webpack
- base url for TypeScript compiler
we can achieve working absolute imports.

For example, for standard ng project:
- app/app.module.ts
- app/layout/header/header.component.ts

We cen define app module with imports like:
- import { AppComponent } from 'app/app.component';
- import { HeaderComponent } from 'app/layout/header/header.component';
- import { FooterComponent } from 'app/layout/footer/footer.component';

Sample project: https://github.com/glipecki/angular-cli-absolute-sample