### PR TITLE
Adding default outputPath

### DIFF
--- a/packages/angular-cli/tasks/build-webpack-watch.ts
+++ b/packages/angular-cli/tasks/build-webpack-watch.ts
@@ -6,6 +6,7 @@ const ProgressPlugin = require('webpack/lib/ProgressPlugin');
 import { NgCliWebpackConfig } from '../models/webpack-config';
 import { webpackOutputOptions } from '../models/';
 import { BuildOptions } from '../commands/build';
+import { CliConfig } from '../models/config';
 
 let lastHash: any = null;
 
@@ -14,7 +15,8 @@ export default Task.extend({
 
     const project = this.cliProject;
 
-    rimraf.sync(path.resolve(project.root, runTaskOptions.outputPath));
+    const outputDir = runTaskOptions.outputPath || CliConfig.fromProject().config.apps[0].outDir;
+    rimraf.sync(path.resolve(project.root, outputDir));
 
     const config = new NgCliWebpackConfig(
       project,


### PR DESCRIPTION
ng build -w does not work #2409

Setting the default option for outputPath to the outDir property of angular.cli