### PR TITLE
feature(generate): give possibility to generate custom blueprint defined in project

### DIFF
--- a/packages/angular-cli/commands/generate.ts
+++ b/packages/angular-cli/commands/generate.ts
@@ -20,7 +20,8 @@ const GenerateCommand = EmberGenerateCommand.extend({
     rawArgs[0] = mapBlueprintName(rawArgs[0]);
 
     if (rawArgs[0] !== '--help' &&
-      !fs.existsSync(path.join(__dirname, '..', 'blueprints', rawArgs[0]))) {
+      !fs.existsSync(path.join(__dirname, '..', 'blueprints', rawArgs[0])) &&
+      !fs.existsSync(path.join(this.project.root, 'blueprints'), rawArgs[0])) {
       SilentError.debugOrThrow('angular-cli/commands/generate', `Invalid blueprint: ${rawArgs[0]}`);
     }
 

--- a/packages/angular-cli/commands/generate.ts
+++ b/packages/angular-cli/commands/generate.ts
@@ -21,7 +21,7 @@ const GenerateCommand = EmberGenerateCommand.extend({
 
     if (rawArgs[0] !== '--help' &&
       !fs.existsSync(path.join(__dirname, '..', 'blueprints', rawArgs[0])) &&
-      !fs.existsSync(path.join(this.project.root, 'blueprints'), rawArgs[0])) {
+      !fs.existsSync(path.join(this.project.root, 'blueprints', rawArgs[0]))) {
       SilentError.debugOrThrow('angular-cli/commands/generate', `Invalid blueprint: ${rawArgs[0]}`);
     }
 


### PR DESCRIPTION
References #2377 

Here is a patch that should give back the possibility to use custom blueprints from an angular-cli project.

I've created a demo app using this functionnality: https://github.com/feloy/angular-cli-custom-blueprints-demo
