### PR TITLE
fix(karma): Add cli config poll option to karma default config

### DIFF
--- a/packages/angular-cli/plugins/karma.js
+++ b/packages/angular-cli/plugins/karma.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const getWebpackTestConfig = require('../models/webpack-build-test').getWebpackTestConfig;
+const CliConfig = require('../models/config').CliConfig;
 
 const init = (config) => {
 
@@ -23,8 +24,12 @@ const init = (config) => {
       timings: false,
       chunks: false,
       chunkModules: false
+    },
+    watchOptions: {
+      poll: CliConfig.fromProject().config.defaults.poll
     }
   };
+
   config.webpack = Object.assign(webpackConfig, config.webpack);
   config.webpackMiddleware = Object.assign(webpackMiddlewareConfig, config.webpackMiddleware);
 


### PR DESCRIPTION
With https://github.com/angular/angular-cli/pull/1814 the `defaults.poll` property was added to angular-cli.json. This configuration setting is currently applies to `ng serve` but not `ng test`. This fix adds the poll value to the karma defaults so that if you set `defaults: { poll: 1000 }` it will apply to both `ng serve` and `ng test`.