### PR TITLE
fix(generate): make generated component.spec consistent with AppCompo…

### DIFF
--- a/packages/angular-cli/blueprints/component/files/__path__/__name__.component.spec.ts
+++ b/packages/angular-cli/blueprints/component/files/__path__/__name__.component.spec.ts
@@ -4,8 +4,18 @@ import { TestBed, async } from '@angular/core/testing';
 import { <%= classifiedModuleName %>Component } from './<%= dasherizedModuleName %>.component';
 
 describe('Component: <%= classifiedModuleName %>', () => {
-  it('should create an instance', () => {
-    let component = new <%= classifiedModuleName %>Component();
-    expect(component).toBeTruthy();
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        <%= classifiedModuleName %>Component
+      ],
+    });
   });
+
+  it('should create an instance', async(() => {
+    let fixture = TestBed.createComponent(<%= classifiedModuleName %>Component);
+    let cmp = fixture.debugElement.componentInstance;
+    expect(cmp).toBeTruthy();
+  }));
 });


### PR DESCRIPTION
…nent spec

`ng new` generates a little rich spec file for `AppComponent`

```ts
/* tslint:disable:no-unused-variable */

import { TestBed, async } from '@angular/core/testing';
import { AppComponent } from './app.component';

describe('App: test-app', () => {
  beforeEach(() => {
    TestBed.configureTestingModule({
      declarations: [
        AppComponent
      ],
    });
  });

  it('should create the app', async(() => {
    let fixture = TestBed.createComponent(AppComponent);
    let app = fixture.debugElement.componentInstance;
    expect(app).toBeTruthy();
  }));

  it(`should have as title 'app works!'`, async(() => {
    let fixture = TestBed.createComponent(AppComponent);
    let app = fixture.debugElement.componentInstance;
    expect(app.title).toEqual('app works!');
  }));

  it('should render title in a h1 tag', async(() => {
    let fixture = TestBed.createComponent(AppComponent);
    fixture.detectChanges();
    let compiled = fixture.debugElement.nativeElement;
    expect(compiled.querySelector('h1').textContent).toContain('app works!');
  }));
});
```

But a spec via `ng generate component` is not so. Imperative component instantiation is not a good pattern, I think.

```ts
/* tslint:disable:no-unused-variable */

import { TestBed, async } from '@angular/core/testing';
import { HeroDetailComponent } from './hero-detail.component';

describe('Component: HeroDetail', () => {
  it('should create an instance', () => {
    let component = new HeroDetailComponent();
    expect(component).toBeTruthy();
  });
});
```

At least, I think it should generate a spec using `TestBed`. 