### PR TITLE
fix(build): fix sourcemap in prod

### DIFF
--- a/packages/angular-cli/models/webpack-build-production.ts
+++ b/packages/angular-cli/models/webpack-build-production.ts
@@ -16,7 +16,8 @@ export const getWebpackProdConfigPartial = function(projectRoot: string, appConf
       new WebpackMd5Hash(),
       new webpack.optimize.UglifyJsPlugin(<any>{
         mangle: { screw_ie8 : true },
-        compress: { screw_ie8: true }
+        compress: { screw_ie8: true },
+        sourceMap: true
       }),
       new CompressionPlugin({
           asset: '[path].gz[query]',


### PR DESCRIPTION
Currently `--prod` build doesn't emit sourcemap files correctly.

As far as I know, webpack2 with UglifyJsPlugin require `devtool: 'source-map'` and `sourceMap: true` both settings.
