### PR TITLE
fix(build): fix sourcemap in prod

### DIFF
--- a/packages/angular-cli/models/webpack-build-production.ts
+++ b/packages/angular-cli/models/webpack-build-production.ts
@@ -16,7 +16,8 @@ export const getWebpackProdConfigPartial = function(projectRoot: string, appConf
       new WebpackMd5Hash(),
       new webpack.optimize.UglifyJsPlugin(<any>{
         mangle: { screw_ie8 : true },
-        compress: { screw_ie8: true }
+        compress: { screw_ie8: true },
+        sourceMap: true
       }),
       new CompressionPlugin({
           asset: '[path].gz[query]',


### PR DESCRIPTION
Currently, `ng build --prod` cannot emit source map files. UglifyJSPlugin with Webpack2 requires `sourceMap: true` option to solve it.

Fix https://github.com/angular/angular-cli/issues/2533