### PR TITLE
chore(deps): explicitely add @types/node

### DIFF
--- a/packages/angular-cli/blueprints/ng2/files/package.json
+++ b/packages/angular-cli/blueprints/ng2/files/package.json
@@ -34,6 +34,7 @@
     "preboot": "2.1.2",
     "parse5": "1.5.1",<% } %>
     "@types/jasmine": "^2.2.30",
+    "@types/node": "^6.0.42",
     "angular-cli": "<%= version %>",
     "codelyzer": "~0.0.26",
     "jasmine-core": "2.4.1",


### PR DESCRIPTION
Fix https://github.com/angular/angular-cli/issues/2099

We're getting need the `require` typings because of `angular2-template-loader` and are currently getting it transitively via `@types/node` in `protractor`.

We can't just `declare var require:any` because that would conflict with said `@types/node`.

Solutions for this are either to add these typings explicitely (this pr), to remove the requirement for `require` in `angular2-template-loader` (slated to happen in the future when it's moved to AST) or to manually list used typings in `tsconfig.json` (which would make the 3rd party lib journey a tad harder).

This seems the best solution for now, followed by moving `angular2-template-loader` to AST.

/cc @hansl