### PR TITLE
Add loader support for custom cursors

### DIFF
--- a/packages/angular-cli/models/webpack-build-common.ts
+++ b/packages/angular-cli/models/webpack-build-common.ts
@@ -93,7 +93,7 @@ export function getWebpackCommonConfig(
         { include: scripts, test: /\.js$/, loader: 'script-loader' },
 
         { test: /\.json$/, loader: 'json-loader' },
-        { test: /\.(jpg|png|gif)$/, loader: 'url-loader?limit=10000' },
+        { test: /\.(jpg|png|gif|cur)$/, loader: 'url-loader?limit=10000' },
         { test: /\.html$/, loader: 'html-loader' },
 
         { test: /\.(otf|woff|ttf|svg)$/, loader: 'url?limit=10000' },


### PR DESCRIPTION
We rely on a framework that references custom cursors. Without this trivial change, we are unable to serve the app:

> ERROR in ./~/@coralui/coralui/build/resources/cursors/Cur_Fist_11_11.cur
> Module parse failed: /Users/.../node_modules/@coralui/coralui/build/resources/cursors/Cur_Fist_11_11.cur Unexpected character '' (1:0)
> You may need an appropriate loader to handle this file type.