### PR TITLE
Dependency reference used incorrect github syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "awesome-typescript-loader": "^2.2.3",
     "chalk": "^1.1.3",
     "common-tags": "^1.3.1",
-    "compression-webpack-plugin": "github:webpack/compression-webpack-plugin#7e55907cd54a2e91b96d25a660acc6a2a6453f54",
+    "compression-webpack-plugin": "webpack/compression-webpack-plugin#7e55907cd54a2e91b96d25a660acc6a2a6453f54",
     "copy-webpack-plugin": "^3.0.1",
     "core-js": "^2.4.0",
     "css-loader": "^0.23.1",


### PR DESCRIPTION
`npm install -g angular-cli` fails on OSX 10.11.6 with node v4.2.6 (npm v2.1.11), giving the following error:

```
npm ERR! Darwin 15.6.0
npm ERR! argv "/Users/clov3r/.nvm/versions/node/v4.2.6/bin/node" "/Users/clov3r/.nvm/versions/node/v4.2.6/bin/npm" "install" "-g" "angular-cli"
npm ERR! node v4.2.6
npm ERR! npm  v2.1.11

npm ERR! Unsupported URL Type: github:webpack/compression-webpack-plugin#7e55907cd54a2e91b96d25a660acc6a2a6453f54
```


> As of version 1.1.65, you can refer to GitHub urls as just "foo": "user/foo-project". Just as with git URLs, a commit-ish suffix can be included.

[Source](https://docs.npmjs.com/files/package.json#github-urls)