### PR TITLE
feature(config): improved error message for invalid angular-cli.json

### DIFF
--- a/packages/angular-cli/models/config/config.ts
+++ b/packages/angular-cli/models/config/config.ts
@@ -6,10 +6,11 @@ import {SchemaClass, SchemaClassFactory} from '../json-schema/schema-class-facto
 
 const DEFAULT_CONFIG_SCHEMA_PATH = path.join(__dirname, '../../lib/config/schema.json');
 
-
-export class InvalidConfigError extends Error {
-  constructor(err: Error) {
-    super(err.message);
+class InvalidConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.message = message;
+    this.name = 'InvalidConfigError';
   }
 }
 
@@ -61,7 +62,7 @@ export class CliConfig<JsonType> {
     try {
       schema = JSON.parse(schemaContent);
     } catch (err) {
-      throw new InvalidConfigError(err);
+      throw new InvalidConfigError(err.message);
     }
 
     return new CliConfig<ConfigType>(null, schema, content, global);
@@ -80,10 +81,20 @@ export class CliConfig<JsonType> {
 
     try {
       content = JSON.parse(configContent);
+    } catch (err) {
+      throw new InvalidConfigError(
+        'Parsing angular-cli.json failed. Please make sure your angular-cli.json'
+        + ' is valid JSON. Error:\n' + err
+      );
+    }
+
+    try {
       schema = JSON.parse(schemaContent);
       others = otherContents.map(otherContent => JSON.parse(otherContent));
     } catch (err) {
-      throw new InvalidConfigError(err);
+      throw new InvalidConfigError(
+        `Parsing Angular CLI schema or other configuration files failed. Error:\n${err}`
+      );
     }
 
     return new CliConfig<T>(configPath, schema, content, others);


### PR DESCRIPTION
Earlier invalid angular-cli.json yielded only "Error". Now it prints something like:

Parsing angular-cli.json failed. Please make sure your angular-cli.json is valid JSON. Error:
SyntaxError: Unexpected token s in JSON at position 2

Almost the same message is now also used for the other configuration files (schema and other). 

This fixes https://github.com/angular/angular-cli/issues/2526