### PR TITLE
feat(build): added postcss-discard-comments

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "offline-plugin": "^3.4.1",
     "opn": "4.0.1",
     "parse5": "^2.1.5",
+    "postcss-discard-comments": "^2.0.4",
     "postcss-loader": "^0.9.1",
     "protractor": "^3.3.0",
     "raw-loader": "^0.5.1",

--- a/packages/angular-cli/models/webpack-build-production.ts
+++ b/packages/angular-cli/models/webpack-build-production.ts
@@ -45,7 +45,7 @@ export const getWebpackProdConfigPartial = function(projectRoot: string, appConf
           },
           postcss: [
             require('postcss-discard-comments')
-          ],
+          ]
         }
       })
     ],

--- a/packages/angular-cli/models/webpack-build-production.ts
+++ b/packages/angular-cli/models/webpack-build-production.ts
@@ -42,7 +42,10 @@ export const getWebpackProdConfigPartial = function(projectRoot: string, appConf
               [/\[?\(?/, /(?:)/]
             ],
             customAttrAssign: [/\)?\]?=/]
-          }
+          },
+          postcss: [
+            require('postcss-discard-comments')
+          ],
         }
       })
     ],


### PR DESCRIPTION
Not sure if this is something that will be accepted or if we should wait for #1656.

I've got a single `@import "~material-design-lite/src/material-design-lite";` in my `./src/style.scss` which results in 31 copies of each comment used in `~material-design-lite/src/variables` aswell as a lot of other comments.

Simply removing all CSS comments makes a huge difference in final bundle size as seen below.

# Before
```
                                   Asset       Size  Chunks             Chunk Names
     main.6fbac24ca5132af329fe.bundle.js    1.22 MB    0, 2  [emitted]  main
   styles.b90aa540ebff7287c650.bundle.js     355 kB    1, 2  [emitted]  styles
                               inline.js    1.39 kB       2  [emitted]  inline
styles.b90aa540ebff7287c650.bundle.js.gz    31.7 kB          [emitted]  
  main.6fbac24ca5132af329fe.bundle.js.gz     283 kB          [emitted]  
                              index.html  977 bytes          [emitted]  
```

# After
```
                                   Asset       Size  Chunks             Chunk Names
     main.8d1026f789bf4650316e.bundle.js    1.22 MB    0, 2  [emitted]  main
   styles.149e785c053377a80361.bundle.js     161 kB    1, 2  [emitted]  styles
                               inline.js    1.39 kB       2  [emitted]  inline
styles.149e785c053377a80361.bundle.js.gz    22.8 kB          [emitted]  
  main.8d1026f789bf4650316e.bundle.js.gz     282 kB          [emitted]  
                              index.html  977 bytes          [emitted]  
```