### PR TITLE
fix(new): fix relativeRootPath for typeRoots

### DIFF
--- a/packages/angular-cli/blueprints/ng2/files/__path__/tsconfig.json
+++ b/packages/angular-cli/blueprints/ng2/files/__path__/tsconfig.json
@@ -11,7 +11,7 @@
     "sourceMap": true,
     "target": "es5",
     "typeRoots": [
-      "../node_modules/@types"
+      "<%= relativeRootPath %>/node_modules/@types"
     ]
   }
 }

--- a/packages/angular-cli/blueprints/ng2/index.js
+++ b/packages/angular-cli/blueprints/ng2/index.js
@@ -26,8 +26,8 @@ module.exports = {
     this.styleExt = options.style;
     this.version = require(path.resolve(__dirname, '../../package.json')).version;
 
-    // Join with / not path.sep as reference to typings require forward slashes.
-    const relativeRootPath = options.sourceDir.split(path.sep).map(() => '..').join('/');
+    // Split/join with / not path.sep as reference to typings require forward slashes.
+    const relativeRootPath = options.sourceDir.split('/').map(() => '..').join('/');
     const fullAppName = stringUtils.dasherize(options.entity.name)
       .replace(/-(.)/g, (_, l) => ' ' + l.toUpperCase())
       .replace(/^./, (l) => l.toUpperCase());


### PR DESCRIPTION
Fix #2206 

Opted to only allow `/` as path separator since that's the direction we're taking with generators overall.