### PR TITLE
chore(blueprints): update codelyzer

### DIFF
--- a/packages/angular-cli/blueprints/ng2/files/package.json
+++ b/packages/angular-cli/blueprints/ng2/files/package.json
@@ -36,7 +36,7 @@
     "@types/jasmine": "^2.2.30",
     "@types/node": "^6.0.42",
     "angular-cli": "<%= version %>",
-    "codelyzer": "~0.0.26",
+    "codelyzer": "1.0.0-beta.1",
     "jasmine-core": "2.4.1",
     "jasmine-spec-reporter": "2.5.0",
     "karma": "1.2.0",

--- a/packages/angular-cli/blueprints/ng2/files/tslint.json
+++ b/packages/angular-cli/blueprints/ng2/files/tslint.json
@@ -107,6 +107,8 @@
     "use-life-cycle-interface": true,
     "use-pipe-transform-interface": true,
     "component-class-suffix": true,
-    "directive-class-suffix": true
+    "directive-class-suffix": true,
+    "templates-use-public": true,
+    "invoke-injectable": true
   }
 }


### PR DESCRIPTION
This version includes template support and is compatible with the latest changes in the `TemplateParser` introduced by Angular 2.0.2.

The following new rules are introduced:

```
// Does not allow access to private & protected
// in inline templates
"templates-use-public": true,

// Makes sure `@Injectable()` is invoked and not
// used as `@Injectable`.
"invoke-injectable": true
```

There's one more rule which verifies if all members accessed in templates are defined in the component's controller but doesn't check the inheritance chain so I'll open a PR for it once we have the entire functionality implemented.