### PR TITLE
chore(build): remove tslint options

### DIFF
--- a/packages/angular-cli/models/webpack-build-development.ts
+++ b/packages/angular-cli/models/webpack-build-development.ts
@@ -1,17 +1,5 @@
 const path = require('path');
 
-import * as webpack from 'webpack';
-
-declare module 'webpack' {
-    export interface LoaderOptionsPlugin {}
-    export interface LoaderOptionsPluginStatic {
-        new (optionsObject: any): LoaderOptionsPlugin;
-    }
-    interface Webpack {
-        LoaderOptionsPlugin: LoaderOptionsPluginStatic;
-    }
-};
-
 export const getWebpackDevConfigPartial = function(projectRoot: string, appConfig: any) {
   return {
     devtool: 'source-map',
@@ -21,17 +9,6 @@ export const getWebpackDevConfigPartial = function(projectRoot: string, appConfi
       sourceMapFilename: '[name].map',
       chunkFilename: '[id].chunk.js'
     },
-    plugins: [
-      new webpack.LoaderOptionsPlugin({
-        options: {
-          tslint: {
-            emitErrors: false,
-            failOnHint: false,
-            resourcePath: path.resolve(projectRoot, appConfig.root)
-          },
-        }
-      })
-    ],
     node: {
       fs: 'empty',
       global: true,

--- a/packages/angular-cli/models/webpack-build-production.ts
+++ b/packages/angular-cli/models/webpack-build-production.ts
@@ -3,6 +3,16 @@ const WebpackMd5Hash = require('webpack-md5-hash');
 const CompressionPlugin = require('compression-webpack-plugin');
 import * as webpack from 'webpack';
 
+declare module 'webpack' {
+  export interface LoaderOptionsPlugin {}
+  export interface LoaderOptionsPluginStatic {
+    new (optionsObject: any): LoaderOptionsPlugin;
+  }
+  interface Webpack {
+    LoaderOptionsPlugin: LoaderOptionsPluginStatic;
+  }
+}
+
 export const getWebpackProdConfigPartial = function(projectRoot: string, appConfig: any) {
   return {
     devtool: 'source-map',
@@ -27,11 +37,6 @@ export const getWebpackProdConfigPartial = function(projectRoot: string, appConf
       }),
       new webpack.LoaderOptionsPlugin({
         options: {
-          tslint: {
-            emitErrors: true,
-            failOnHint: true,
-            resourcePath: path.resolve(projectRoot, appConfig.root)
-          },
           htmlLoader: {
             minimize: true,
             removeAttributeQuotes: false,


### PR DESCRIPTION
We've removed tslint from build cycles a while ago, but these options remained.