### PR TITLE
fix(init): ignore favicon

### DIFF
--- a/packages/angular-cli/blueprints/ng2/index.js
+++ b/packages/angular-cli/blueprints/ng2/index.js
@@ -16,6 +16,12 @@ module.exports = {
     { name: 'inline-template', type: Boolean, default: false, aliases: ['it'] }
   ],
 
+  beforeInstall: function(options) {
+    if (options.ignoredUpdateFiles && options.ignoredUpdateFiles.length > 0) {
+      return Blueprint.ignoredUpdateFiles = Blueprint.ignoredUpdateFiles.concat(options.ignoredUpdateFiles);
+    }
+  },
+
   afterInstall: function (options) {
     if (options.mobile) {
       return Blueprint.load(path.join(__dirname, '../mobile')).install(options);

--- a/packages/angular-cli/commands/init.ts
+++ b/packages/angular-cli/commands/init.ts
@@ -105,7 +105,8 @@ const InitCommand: any = Command.extend({
       mobile: commandOptions.mobile,
       routing: commandOptions.routing,
       inlineStyle: commandOptions.inlineStyle,
-      inlineTemplate: commandOptions.inlineTemplate
+      inlineTemplate: commandOptions.inlineTemplate,
+      ignoredUpdateFiles: ['favicon.ico']
     };
 
     if (!validProjectName(packageName)) {

--- a/tests/acceptance/init.spec.js
+++ b/tests/acceptance/init.spec.js
@@ -149,11 +149,6 @@ describe('Acceptance: ng init', function () {
   it('init an already init\'d folder', function () {
     return ng(['init', '--skip-npm', '--skip-bower'])
       .then(function () {
-        // ignore the favicon file for the the unit test since it breaks at ember-cli level
-        // when trying to re-init
-        Blueprint.ignoredFiles.push('favicon.ico');
-      })
-      .then(function () {
         return ng(['init', '--skip-npm', '--skip-bower']);
       })
       .then(confirmBlueprinted);


### PR DESCRIPTION
Avoid crashes when choosing to diff the favicon.ico during overwrite.

Closes #2274 

I'm assuming people would either want to keep their favicon or the default one, but as the option to overwrite would be there anyway... who doesn't want to diff a favicon.ico? So I think to avoid the crashes is better to ignore it when updating the cli.