### PR TITLE
chore(build): use cheap-module-source-map for dev

### DIFF
--- a/packages/angular-cli/models/webpack-build-development.ts
+++ b/packages/angular-cli/models/webpack-build-development.ts
@@ -14,7 +14,7 @@ declare module 'webpack' {
 
 export const getWebpackDevConfigPartial = function(projectRoot: string, appConfig: any) {
   return {
-    devtool: 'source-map',
+    devtool: 'cheap-module-source-map',
     output: {
       path: path.resolve(projectRoot, appConfig.outDir),
       filename: '[name].bundle.js',


### PR DESCRIPTION
Allows for faster builds, partially addresses #1980