### PR TITLE
fix: override ui write level

### DIFF
--- a/packages/angular-cli/lib/cli/index.js
+++ b/packages/angular-cli/lib/cli/index.js
@@ -2,17 +2,19 @@
 
 // This file hooks up on require calls to transpile TypeScript.
 const cli = require('ember-cli/lib/cli');
+const UI = require('ember-cli/lib/ui');
 const path = require('path');
 
 Error.stackTraceLimit = Infinity;
 
 module.exports = function(options) {
+
+  // patch UI to not print Ember-CLI warnings (which don't apply to Angular-CLI)
+  UI.prototype.writeWarnLine = function () { }
+
   const oldStdoutWrite = process.stdout.write;
   process.stdout.write = function (line) {
     line = line.toString();
-    if (line.match(/version:|WARNING:/)) {
-      return;
-    }
     if (line.match(/ember-cli-(inject-)?live-reload/)) {
       // don't replace 'ember-cli-live-reload' on ng init diffs
       return oldStdoutWrite.apply(process.stdout, arguments);
@@ -38,8 +40,6 @@ module.exports = function(options) {
 
   // ensure the environemnt variable for dynamic paths
   process.env.PWD = process.env.PWD || process.cwd();
-
-
   process.env.CLI_ROOT = process.env.CLI_ROOT || path.resolve(__dirname, '..', '..');
 
   return cli(options);


### PR DESCRIPTION
This method is more reliable than using regexes on
the input/output streams.

Fix #2540