### PR TITLE
(fix) `ng complete`: Suggest different way to capture output to .bashrc/.zshrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,19 +274,19 @@ To turn on auto completion use the following commands:
 
 For bash:
 ```bash
-ng completion >> ~/.bashrc
+ng completion 1>> ~/.bashrc 2>>&1
 source ~/.bashrc
 ```
 
 For zsh:
 ```bash
-ng completion >> ~/.zshrc
+ng completion 1>> ~/.zshrc 2>>&1
 source ~/.zshrc
 ```
 
 Windows users using gitbash:
 ```bash
-ng completion >> ~/.bash_profile
+ng completion 1>> ~/.bash_profile 2>>&1
 source ~/.bash_profile
 ```
 
@@ -344,7 +344,7 @@ npm install d3 --save
 npm install @types/d3 --save-dev
 ```
 
-If the library doesn't have typings available at `@types/`, you can still use it by 
+If the library doesn't have typings available at `@types/`, you can still use it by
 manually adding typings for it:
 ```
 // in src/typings.d.ts

--- a/packages/angular-cli/models/webpack-build-common.ts
+++ b/packages/angular-cli/models/webpack-build-common.ts
@@ -33,7 +33,8 @@ export function getWebpackCommonConfig(
   return {
     devtool: 'source-map',
     resolve: {
-      extensions: ['.ts', '.js']
+      extensions: ['.ts', '.js'],
+      modules: [path.resolve(projectRoot, 'node_modules')]
     },
     context: path.resolve(__dirname, './'),
     entry: entry,

--- a/packages/angular-cli/utilities/completion.sh
+++ b/packages/angular-cli/utilities/completion.sh
@@ -2,7 +2,8 @@
 #
 # ng command completion script
 #
-# Installation: ng completion >> ~/.bashrc (or ~/.zshrc)
+# Installation: ng completion 1>> ~/.bashrc 2>>&1
+#           or  ng completion 1>> ~/.zshrc 2>>&1
 #
 
 ng_opts='b build completion doc e2e g generate get github-pages:deploy gh-pages:deploy h help i init install lint make-this-awesome new s serve server set t test v version -h --help'


### PR DESCRIPTION
At long last, the output of `ng completion` can all be fed to your favourite shell startup file.
The discussion took place in issue #2253, the reasoning behind this PR is at https://github.com/angular/angular-cli/issues/2253#issuecomment-252726299.