### PR TITLE
docs(readme): Add missing npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,7 @@ Local project package:
 ```
 rm -rf node_modules dist tmp
 npm install --save-dev angular-cli@latest
+npm install
 ng init
 ```
 


### PR DESCRIPTION
Since the first line is to remove the whole node_modules folder, it is helpful for users to also tell to re-install them. This way there isn't some cryptic error message shown for the user trying to run ng init command.