### PR TITLE
feat(generate): specify class type via dot notation

### DIFF
--- a/packages/angular-cli/blueprints/class/index.js
+++ b/packages/angular-cli/blueprints/class/index.js
@@ -6,26 +6,26 @@ const getFiles = Blueprint.prototype.files;
 module.exports = {
   description: '',
 
-  anonymousOptions: [
-    '<class-type>'
-  ],
-
   availableOptions: [
     { name: 'spec', type: Boolean }
   ],
 
   normalizeEntityName: function (entityName) {
-    var parsedPath = dynamicPathParser(this.project, entityName);
+    var parsedPath = dynamicPathParser(this.project, entityName.split('.')[0]);
 
     this.dynamicPath = parsedPath;
     return parsedPath.name;
   },
 
   locals: function (options) {
-    var classType = options.args [2]
+    const rawName = options.args[1];
+    const nameParts = rawName.split('.')
+      .filter(part => part.length !== 0);
+
+    const classType = nameParts[1];
     this.fileName = stringUtils.dasherize(options.entity.name);
     if (classType) {
-      this.fileName += '.' + classType;
+      this.fileName += '.' + classType.toLowerCase();
     }
 
     options.spec = options.spec !== undefined ?

--- a/tests/acceptance/generate-class.spec.js
+++ b/tests/acceptance/generate-class.spec.js
@@ -43,8 +43,8 @@ describe('Acceptance: ng generate class', function () {
     });
   });
 
-  it('ng generate class my-class model', function () {
-    return ng(['generate', 'class', 'my-class', 'model']).then(() => {
+  it('ng generate class my-class.model', function () {
+    return ng(['generate', 'class', 'my-class.model']).then(() => {
       expect(existsSync(path.join(testPath, 'my-class.model.ts'))).to.equal(true);
     });
   });
@@ -55,8 +55,8 @@ describe('Acceptance: ng generate class', function () {
     });
   });
 
-  it(`ng generate class shared${path.sep}my-class model`, function () {
-    return ng(['generate', 'class', 'shared/my-class', 'model']).then(() => {
+  it(`ng generate class shared${path.sep}my-class.model`, function () {
+    return ng(['generate', 'class', 'shared/my-class.model']).then(() => {
       expect(existsSync(path.join(testPath, 'shared', 'my-class.model.ts'))).to.equal(true);
     });
   });


### PR DESCRIPTION
Closes #2155

BREAKING CHANGE: The ability to specify a class type via an additional arg has been replaced by combining the name and type args separated by a dot