### PR TITLE
feat(aot):export default routes array to work with AoT compiler

### DIFF
--- a/packages/angular-cli/blueprints/module/files/__path__/__name__-routing.module.ts
+++ b/packages/angular-cli/blueprints/module/files/__path__/__name__-routing.module.ts
@@ -1,7 +1,7 @@
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 
-const routes: Routes = [];
+export const routes: Routes = [];
 
 @NgModule({
   imports: [RouterModule.forChild(routes)],


### PR DESCRIPTION
The AoT compiler needs the variables used in the `@NgModule` declaration to be exported as well.

This doesn't fail when the array is empty (come compiler optimization magic maybe?), but as soon as the user enters their first route into the array, their first experience with AoT becomes an error. So, this improves the default to be compatible with AoT compiler from the beginning.