### PR TITLE
fix(generate): show error when no name is specified

### DIFF
--- a/packages/angular-cli/commands/generate.ts
+++ b/packages/angular-cli/commands/generate.ts
@@ -24,6 +24,11 @@ const GenerateCommand = EmberGenerateCommand.extend({
       SilentError.debugOrThrow('angular-cli/commands/generate', `Invalid blueprint: ${rawArgs[0]}`);
     }
 
+    if (!rawArgs[1]) {
+      SilentError.debugOrThrow('angular-cli/commands/generate',
+        `The \`ng generate ${rawArgs[0]}\` command requires a name to be specified.`);
+    }
+
     // Override default help to hide ember blueprints
     EmberGenerateCommand.prototype.printDetailedHelp = function() {
       const blueprintList = fs.readdirSync(path.join(__dirname, '..', 'blueprints'));

--- a/tests/acceptance/generate-module.spec.js
+++ b/tests/acceptance/generate-module.spec.js
@@ -30,6 +30,12 @@ describe('Acceptance: ng generate module', function () {
     return tmp.teardown('./tmp');
   });
 
+  it('will fail if no name is specified', function () {
+    return ng(['generate', 'module']).catch((error) => {
+      expect(error).to.equal('The `ng generate module` command requires a name to be specified.');
+    });
+  });
+
   it('ng generate module my-module', function () {
     return ng(['generate', 'module', 'my-module']).then(() => {
       expect(existsSync(path.join(testPath, 'my-module', 'my-module.module.ts'))).to.equal(true);


### PR DESCRIPTION
Show custom error when user forgets the name while generating blueprints.
Earlier it would fall to the dynamicPathParser function and throw a TypeError: Path must be a string. Received undefined.

I think it wouldn't make sense to add the same test to all the `generate-*.spec.js` files, but not sure if `generate-module.spec.js` is the best place either.