### PR TITLE
chore(commands): override ng destroy

### DIFF
--- a/packages/angular-cli/addon/index.js
+++ b/packages/angular-cli/addon/index.js
@@ -22,6 +22,7 @@ module.exports = {
       'serve': require('../commands/serve').default,
       'new': require('../commands/new').default,
       'generate': require('../commands/generate').default,
+      'destroy': require('../commands/destroy').default,
       'init': require('../commands/init').default,
       'test': require('../commands/test').default,
       'e2e': require('../commands/e2e').default,

--- a/packages/angular-cli/commands/destroy.ts
+++ b/packages/angular-cli/commands/destroy.ts
@@ -1,0 +1,20 @@
+const Command = require('ember-cli/lib/models/command');
+const SilentError = require('silent-error');
+
+
+const DestroyCommand = Command.extend({
+  name: 'destroy',
+  aliases: ['d'],
+  works: 'insideProject',
+
+  anonymousOptions: [
+    '<blueprint>'
+  ],
+
+  run: function() {
+    return Promise.reject(new SilentError('The destroy command is not supported by Angular-CLI.'));
+  }
+});
+
+export default DestroyCommand;
+DestroyCommand.overrideCore = true;

--- a/packages/angular-cli/commands/help.ts
+++ b/packages/angular-cli/commands/help.ts
@@ -7,6 +7,7 @@ const lookupCommand = require('ember-cli/lib/cli/lookup-command');
 
 const commandsToIgnore = [
   'easter-egg',
+  'destroy',
   'github-pages-deploy' // errors because there is no base github-pages command
 ];
 

--- a/tests/acceptance/destroy.spec.js
+++ b/tests/acceptance/destroy.spec.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const ng = require('../helpers/ng');
+const tmp = require('../helpers/tmp');
+const conf = require('ember-cli/tests/helpers/conf');
+const SilentError = require('silent-error');
+const expect = require('chai').expect;
+
+describe('Acceptance: ng destroy', function () {
+  before(conf.setup);
+
+  after(conf.restore);
+
+  beforeEach(function () {
+    this.timeout(10000);
+    return tmp.setup('./tmp').then(function () {
+      process.chdir('./tmp');
+    }).then(function () {
+      return ng(['new', 'foo', '--skip-npm', '--skip-bower']);
+    });
+  });
+
+  afterEach(function () {
+    return tmp.teardown('./tmp');
+  });
+
+  it('without args should fail', function () {
+    return ng(['destroy']).then(() => {
+      throw new SilentError('ng destroy should fail.');
+    }, (err) => {
+      expect(err.message).to.equal('The destroy command is not supported by Angular-CLI.');
+    });
+  });
+
+  it('with args should fail', function () {
+    return ng(['destroy', 'something']).then(() => {
+      throw new SilentError('ng destroy something should fail.');
+    }, (err) => {
+      expect(err.message).to.equal('The destroy command is not supported by Angular-CLI.');
+    });
+  });
+});


### PR DESCRIPTION
It's common for users to try and do `ng destroy component name` and have
it only partially work.

Since we don't support the command, it's better to not have it do any
partial operations.