### PR TITLE
fix(commands): throw when init command is called with mobile flag

### DIFF
--- a/packages/angular-cli/commands/init.ts
+++ b/packages/angular-cli/commands/init.ts
@@ -114,6 +114,13 @@ const InitCommand: any = Command.extend({
         new SilentError('We currently do not support a name of `' + packageName + '`.'));
     }
 
+    if (commandOptions.mobile) {
+      return Promise.reject(new SilentError(
+        'The --mobile flag has been disabled temporarily while we await an update of ' +
+        'angular-universal for supporting NgModule. Sorry for the inconvenience.'
+      ));
+    }
+
     blueprintOpts.blueprint = normalizeBlueprint(blueprintOpts.blueprint);
 
     return installBlueprint.run(blueprintOpts)

--- a/tests/acceptance/init.spec.js
+++ b/tests/acceptance/init.spec.js
@@ -117,13 +117,8 @@ describe('Acceptance: ng init', function () {
     ]).then(confirmBlueprinted);
   });
 
-  it('ng init --mobile', () => {
-    return ng([
-      'init',
-      '--skip-npm',
-      '--skip-bower',
-      '--mobile'
-    ]).then(() => confirmBlueprinted(true));
+  it('ng init with mobile flag does throw exception', function () {
+    expect(ng(['init', '--mobile'])).to.throw;
   });
 
   it('ng init can run in created folder', function () {


### PR DESCRIPTION
Show error message when user uses the mobile flag in conjunction with the init command.

Closes #2679

A bit uncertain if the acceptance test is the correct place to test this, as I assume re-enabling the mobile flag is in progress.