### PR TITLE
feat(build) use appConfig.index to set output index file

### DIFF
--- a/packages/angular-cli/models/webpack-build-common.ts
+++ b/packages/angular-cli/models/webpack-build-common.ts
@@ -105,6 +105,7 @@ export function getWebpackCommonConfig(
     plugins: [
       new HtmlWebpackPlugin({
         template: path.resolve(appRoot, appConfig.index),
+        filename: path.resolve(appConfig.outDir, appConfig.index),
         chunksSortMode: 'dependency'
       }),
       new BaseHrefWebpackPlugin({

--- a/tests/e2e/tests/build/filename.ts
+++ b/tests/e2e/tests/build/filename.ts
@@ -1,0 +1,15 @@
+import {ng} from '../../utils/process';
+import {expectFileToExist} from '../../utils/fs';
+import {updateJsonFile} from '../../utils/project';
+
+
+export default function() {
+  return Promise.resolve()
+    .then(() => updateJsonFile('angular-cli.json', configJson => {
+      const app = configJson['apps'][0];
+      app['outDir'] = 'config-build-output';
+      app['index'] = 'config-index.html';
+    }))
+    .then(() => ng('build'))
+    .then(() => expectFileToExist('./config-build-output/config-index.html'));
+}


### PR DESCRIPTION
Pass appConfig.index to the HtmlWebpackPlugin’s filename property.

Closes #2241 
