### PR TITLE
docs(readme): repairs cannot find module error

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,7 @@ Local project package:
 ```bash
 rm -rf node_modules dist tmp
 npm install --save-dev angular-cli@latest
+npm install
 ng init
 ```
 


### PR DESCRIPTION
After deleting all node_modules, and trying to run `ng init`, it search for @angular/core and don't find it.
This is what it returns:
```bash
Cannot find module '@angular/core'
```
Because of that, we need to install all that modules at some point :)