### PR TITLE
fix(deps): explicitely add portfinder

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "offline-plugin": "^3.4.1",
     "opn": "4.0.1",
     "parse5": "^2.1.5",
+    "portfinder": "1.0.9",
     "postcss-discard-comments": "^2.0.4",
     "postcss-loader": "^0.9.1",
     "protractor": "^3.3.0",

--- a/packages/angular-cli/package.json
+++ b/packages/angular-cli/package.json
@@ -68,6 +68,7 @@
     "offline-plugin": "^3.4.1",
     "opn": "4.0.1",
     "parse5": "^2.1.5",
+    "portfinder": "1.0.9",
     "postcss-loader": "^0.9.1",
     "protractor": "^3.3.0",
     "raw-loader": "^0.5.1",


### PR DESCRIPTION
This PR explicitely adds portfinder as a dependency.

We're using portfinder in the serve command but getting it transitively as a ember-cli dependency.

Fix #2769
