### PR TITLE
chore(test): simplify test file

### DIFF
--- a/packages/angular-cli/blueprints/ng2/files/__path__/test.ts
+++ b/packages/angular-cli/blueprints/ng2/files/__path__/test.ts
@@ -6,6 +6,11 @@ import 'zone.js/dist/sync-test';
 import 'zone.js/dist/jasmine-patch';
 import 'zone.js/dist/async-test';
 import 'zone.js/dist/fake-async-test';
+import { getTestBed } from '@angular/core/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting
+} from '@angular/platform-browser-dynamic/testing';
 
 // Unfortunately there's no typing for the `__karma__` variable. Just declare it as any.
 declare var __karma__: any;
@@ -14,30 +19,14 @@ declare var require: any;
 // Prevent Karma from running prematurely.
 __karma__.loaded = function () {};
 
-
-Promise.all([
-  System.import('@angular/core/testing'),
-  System.import('@angular/platform-browser-dynamic/testing')
-])
-  // First, initialize the Angular testing environment.
-  .then(([testing, testingBrowser]) => {
-    testing.getTestBed().initTestEnvironment(
-      testingBrowser.BrowserDynamicTestingModule,
-      testingBrowser.platformBrowserDynamicTesting()
-    );
-  })
-  // Then we find all the tests.
-  .then(() => require.context('./', true, /\.spec\.ts/))
-  // And load the modules.
-  .then(context => {
-    try {
-      return context.keys().map(context);
-    } catch (e) {
-      if (console) {
-        console.error(e.message, e.stack);
-      }
-      throw e;
-    }
-  })
-  // Finally, start Karma to run the tests.
-  .then(__karma__.start, __karma__.error);
+// First, initialize the Angular testing environment.
+getTestBed().initTestEnvironment(
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting()
+);
+// Then we find all the tests.
+let context = require.context('./', true, /\.spec\.ts/);
+// And load the modules.
+context.keys().map(context);
+// Finally, start Karma to run the tests.
+__karma__.start();

--- a/packages/angular-cli/blueprints/ng2/files/__path__/typings.d.ts
+++ b/packages/angular-cli/blueprints/ng2/files/__path__/typings.d.ts
@@ -1,4 +1,2 @@
 // Typings reference file, you can add your own global typings here
 // https://www.typescriptlang.org/docs/handbook/writing-declaration-files.html
-
-declare var System: any;


### PR DESCRIPTION
There is no need to have System typings or asynchronously load
the testing modules.
