### PR TITLE
chore(test): add --single-run option

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ or `ng serve --prod` will also make use of uglifying and tree-shaking functional
 ng test
 ```
 
-Tests will execute after a build is executed via [Karma](http://karma-runner.github.io/0.13/index.html), and it will automatically watch your files for changes. You can run tests a single time via `--watch=false`.
+Tests will execute after a build is executed via [Karma](http://karma-runner.github.io/0.13/index.html), and it will automatically watch your files for changes. You can run tests a single time via `--watch=false` or `--single-run`.
 
 ### Running end-to-end tests
 

--- a/packages/angular-cli/commands/test.ts
+++ b/packages/angular-cli/commands/test.ts
@@ -7,6 +7,7 @@ const NgCliTestCommand = TestCommand.extend({
     { name: 'watch', type: Boolean, default: true, aliases: ['w'] },
     { name: 'code-coverage', type: Boolean, default: false, aliases: ['cc'] },
     { name: 'lint', type: Boolean, default: false, aliases: ['l'] },
+    { name: 'single-run', type: Boolean, default: false, aliases: ['sr'] },
     { name: 'browsers', type: String },
     { name: 'colors', type: Boolean },
     { name: 'log-level', type: String },

--- a/tests/e2e/tests/generate/class.ts
+++ b/tests/e2e/tests/generate/class.ts
@@ -12,5 +12,5 @@ export default function() {
     .then(() => expectFileToExist(join(classDir, 'test-class.spec.ts')))
 
     // Try to run the unit tests.
-    .then(() => ng('test', '--watch=false'));
+    .then(() => ng('test', '--single-run'));
 }

--- a/tests/e2e/tests/generate/component/component-basic.ts
+++ b/tests/e2e/tests/generate/component/component-basic.ts
@@ -14,5 +14,5 @@ export default function() {
     .then(() => expectFileToExist(join(componentDir, 'test-component.component.css')))
 
     // Try to run the unit tests.
-    .then(() => ng('test', '--watch=false'));
+    .then(() => ng('test', '--single-run'));
 }

--- a/tests/e2e/tests/generate/interface.ts
+++ b/tests/e2e/tests/generate/interface.ts
@@ -11,5 +11,5 @@ export default function() {
     .then(() => expectFileToExist(join(interfaceDir, 'test-interface.model.ts')))
 
     // Try to run the unit tests.
-    .then(() => ng('test', '--watch=false'));
+    .then(() => ng('test', '--single-run'));
 }

--- a/tests/e2e/tests/generate/module/module-basic.ts
+++ b/tests/e2e/tests/generate/module/module-basic.ts
@@ -17,5 +17,5 @@ export default function() {
     .then(() => expectFileToExist(join(moduleDir, 'test-module.component.css')))
 
     // Try to run the unit tests.
-    .then(() => ng('test', '--watch=false'));
+    .then(() => ng('test', '--single-run'));
 }

--- a/tests/e2e/tests/generate/module/module-routing.ts
+++ b/tests/e2e/tests/generate/module/module-routing.ts
@@ -16,5 +16,5 @@ export default function() {
     .then(() => expectFileToExist(join(moduleDir, 'test-module.component.css')))
 
     // Try to run the unit tests.
-    .then(() => ng('test', '--watch=false'));
+    .then(() => ng('test', '--single-run'));
 }

--- a/tests/e2e/tests/generate/pipe.ts
+++ b/tests/e2e/tests/generate/pipe.ts
@@ -13,5 +13,5 @@ export default function() {
     .then(() => expectFileToExist(join(pipeDir, 'test-pipe.pipe.spec.ts')))
 
     // Try to run the unit tests.
-    .then(() => ng('test', '--watch=false'));
+    .then(() => ng('test', '--single-run'));
 }

--- a/tests/e2e/tests/generate/service.ts
+++ b/tests/e2e/tests/generate/service.ts
@@ -13,5 +13,5 @@ export default function() {
     .then(() => expectFileToExist(join(serviceDir, 'test-service.service.spec.ts')))
 
     // Try to run the unit tests.
-    .then(() => ng('test', '--watch=false'));
+    .then(() => ng('test', '--single-run'));
 }

--- a/tests/e2e/tests/misc/coverage.ts
+++ b/tests/e2e/tests/misc/coverage.ts
@@ -3,7 +3,7 @@ import {ng} from '../../utils/process';
 
 
 export default function() {
-  return ng('test', '--watch=false', '--code-coverage')
+  return ng('test', '--single-run', '--code-coverage')
     .then(() => expectFileToExist('coverage/src/app'))
     .then(() => expectFileToExist('coverage/coverage.lcov'));
 }

--- a/tests/e2e/tests/test/test.ts
+++ b/tests/e2e/tests/test/test.ts
@@ -2,5 +2,7 @@ import {ng} from '../../utils/process';
 
 
 export default function() {
-  return ng('test', '--watch=false');
+  // make sure both --watch=false and --single-run work
+  return ng('test', '--single-run')
+    .then(() => ng('test', '--watch=false'));
 }


### PR DESCRIPTION
Doing `ng test --single-run` always worked but outputted a ember-cli warning about a missing option.

This PR allows using the option without warning. It's overall better than `--watch=false` because it better aligns with Karma's options.

`--watch=false` still works though.
