### PR TITLE
Fixed dev dependencies badge link url

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,6 +470,6 @@ MIT
 [david-badge]: https://david-dm.org/angular/angular-cli.svg
 [david-badge-url]: https://david-dm.org/angular/angular-cli
 [david-dev-badge]: https://david-dm.org/angular/angular-cli/dev-status.svg
-[david-dev-badge-url]: https://david-dm.org/angular/angular-cli#info=devDependencies
+[david-dev-badge-url]: https://david-dm.org/angular/angular-cli?type=dev
 [npm-badge]: https://img.shields.io/npm/v/angular-cli.svg
 [npm-badge-url]: https://www.npmjs.com/package/angular-cli


### PR DESCRIPTION
Added the 'type=dev' parameter will point the link to the Dev Dependencies  tab in david-dm.org site. Removed the part of the url which is not needed anymore.