### PR TITLE
chore(build): remove html-loader options

### DIFF
--- a/packages/angular-cli/models/webpack-build-production.ts
+++ b/packages/angular-cli/models/webpack-build-production.ts
@@ -41,17 +41,6 @@ export const getWebpackProdConfigPartial = function(projectRoot: string, appConf
       }),
       new webpack.LoaderOptionsPlugin({
         options: {
-          htmlLoader: {
-            minimize: true,
-            removeAttributeQuotes: false,
-            caseSensitive: true,
-            customAttrSurround: [
-              [/#/, /(?:)/],
-              [/\*/, /(?:)/],
-              [/\[?\(?/, /(?:)/]
-            ],
-            customAttrAssign: [/\)?\]?=/]
-          },
           postcss: [
             require('postcss-discard-comments')
           ]


### PR DESCRIPTION
Follow-up from #2537, these options still remained.
