### PR TITLE
Revert "chore(build): use cheap-module-source-map for dev"

### DIFF
--- a/packages/angular-cli/models/webpack-build-development.ts
+++ b/packages/angular-cli/models/webpack-build-development.ts
@@ -2,7 +2,7 @@ const path = require('path');
 
 export const getWebpackDevConfigPartial = function(projectRoot: string, appConfig: any) {
   return {
-    devtool: 'cheap-module-source-map',
+    devtool: 'source-map',
     output: {
       path: path.resolve(projectRoot, appConfig.outDir),
       filename: '[name].bundle.js',


### PR DESCRIPTION
Reverts angular/angular-cli#2619

Fix https://github.com/angular/angular-cli/issues/2811