### PR TITLE
chore(blueprints): update codelyzer

### DIFF
--- a/packages/angular-cli/blueprints/ng2/files/package.json
+++ b/packages/angular-cli/blueprints/ng2/files/package.json
@@ -36,7 +36,7 @@
     "@types/jasmine": "^2.2.30",
     "@types/node": "^6.0.42",
     "angular-cli": "<%= version %>",
-    "codelyzer": "1.0.0-beta.1",
+    "codelyzer": "~1.0.0-beta.3",
     "jasmine-core": "2.4.1",
     "jasmine-spec-reporter": "2.5.0",
     "karma": "1.2.0",


### PR DESCRIPTION
Fix #2812

Feat: add support for unused CSS in components with enabled `ViewEncapsulation`.

It's hard to stay up to date with the changes in the compiler's API so the best option I see is just to keep the version with tilde so I can align to the changes and push new versions of codelyzer on npm.