### PR TITLE
chore: update rxjs to beta.12 in ast-tools

### DIFF
--- a/packages/ast-tools/package.json
+++ b/packages/ast-tools/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@angular/tsc-wrapped": "^0.3.0",
-    "rxjs": "5.0.0-beta.11",
+    "rxjs": "5.0.0-beta.12",
     "denodeify": "^1.2.1",
     "typescript": "~2.0.3"
   }


### PR DESCRIPTION
By using the same `rxjs` version as elsewhere it will save some extra space (~3.3mb).
