### PR TITLE
fix(build): show full error stats

### DIFF
--- a/packages/angular-cli/tasks/build-webpack.ts
+++ b/packages/angular-cli/tasks/build-webpack.ts
@@ -26,9 +26,6 @@ export default <any>Task.extend({
       runTaskOptions.aot
     ).config;
 
-    // fail on build error
-    config.bail = true;
-
     const webpackCompiler: any = webpack(config);
 
     const ProgressPlugin  = require('webpack/lib/ProgressPlugin');
@@ -39,21 +36,18 @@ export default <any>Task.extend({
 
     return new Promise((resolve, reject) => {
       webpackCompiler.run((err: any, stats: any) => {
+        if (err) { return reject(err); }
+
         // Don't keep cache
         // TODO: Make conditional if using --watch
         webpackCompiler.purgeInputFileSystem();
-
-        if (err) {
-          lastHash = null;
-          console.error(err.details || err);
-          reject(err.details || err);
-        }
 
         if (stats.hash !== lastHash) {
           lastHash = stats.hash;
           process.stdout.write(stats.toString(webpackOutputOptions) + '\n');
         }
-        resolve();
+
+        return stats.hasErrors() ? reject() : resolve();
       });
     });
   }


### PR DESCRIPTION
Currently, running `ng build` error reporting for some classes of errors is not very useful. 

For example, if you have a reference to an missing styles file in `angular-cli.json`, this is the output:

```
kamik@T460p MINGW64 /D/sandbox/master-proj (master)
$ ng build
 10% building modules 2/2 modules 0 activeresolve 'D:\sandbox\master-proj\src\nope.css' in 'D:\work\angular-cli\packages\angular-cli\models'
  using description file: D:\work\angular-cli\packages\angular-cli\package.json (relative path: ./models)
    Field 'browser' doesn't contain a valid alias configuration
  after using description file: D:\work\angular-cli\packages\angular-cli\package.json (relative path: ./models)
    using description file: D:\sandbox\master-proj\package.json (relative path: ./src/nope.css)
      as directory
        D:\sandbox\master-proj\src\nope.css doesn't exist
      no extension
        Field 'browser' doesn't contain a valid alias configuration
        D:\sandbox\master-proj\src\nope.css doesn't exist
      .ts
        Field 'browser' doesn't contain a valid alias configuration
        D:\sandbox\master-proj\src\nope.css.ts doesn't exist
      .js
        Field 'browser' doesn't contain a valid alias configuration
        D:\sandbox\master-proj\src\nope.css.js doesn't exist

D:\work\angular-cli\node_modules\webpack\lib\Compiler.js:220
                                        if(err) return callback(err);
                    ^
TypeError: Cannot read property 'hash' of undefined
    at D:\work\angular-cli\packages\angular-cli\tasks\build-webpack.ts:35:26
    at Compiler.onCompiled (D:\work\angular-cli\node_modules\webpack\lib\Compiler.js:220:21)
    at Compiler.<anonymous> (D:\work\angular-cli\node_modules\webpack\lib\Compiler.js:464:19)
    at D:\work\angular-cli\node_modules\tapable\lib\Tapable.js:148:11
(...)
```

This PR makes the error reporting similar to the output of `ng serve`, but still maintaining the error exit code:

```
kamik@T460p MINGW64 /D/sandbox/master-proj (master)
$ ng build
4800ms building modules
(...)
      index.html  491 bytes          [emitted]
 assets/file.txt    0 bytes          [emitted]
     favicon.ico    5.43 kB          [emitted]
chunk    {0} main.bundle.js, main.map (main) 2 MB {1} [initial] [rendered]
chunk    {1} styles.bundle.js, styles.map (styles) 10.2 kB {2} [initial] [rendered]
chunk    {2} inline.js, inline.map (inline) 0 bytes [entry] [rendered]

ERROR in multi styles
Module not found: Error: Can't resolve 'D:\sandbox\master-proj\src\nope.css' in 'D:\work\angular-cli\packages\angular-cli\models'
 @ multi styles
Child html-webpack-plugin for "index.html":
         Asset     Size  Chunks       Chunk Names
    index.html  2.84 kB       0
    chunk    {0} index.html 372 bytes [entry] [rendered]

kamik@T460p MINGW64 /D/sandbox/master-proj (master)
$ echo $?
1
```
