### PR TITLE
fix(build): enable chunkhash in inline.js

### DIFF
--- a/packages/angular-cli/models/webpack-build-common.ts
+++ b/packages/angular-cli/models/webpack-build-common.ts
@@ -124,9 +124,7 @@ export function getWebpackCommonConfig(
       }),
       new webpack.optimize.CommonsChunkPlugin({
         minChunks: Infinity,
-        name: 'inline',
-        filename: 'inline.js',
-        sourceMapFilename: 'inline.map'
+        name: 'inline'
       }),
       new GlobCopyWebpackPlugin({
         patterns: appConfig.assets,

--- a/tests/e2e/tests/third-party/bootstrap.ts
+++ b/tests/e2e/tests/third-party/bootstrap.ts
@@ -22,7 +22,7 @@ export default function() {
     .then(() => expectFileToMatch('dist/scripts.bundle.js', '/*!\\n * Bootstrap'))
     .then(() => expectFileToMatch('dist/styles.bundle.js', '/*!\\n * Bootstrap'))
     .then(() => expectFileToMatch('dist/index.html', oneLineTrim`
-      <script type="text/javascript" src="inline.js"></script>
+      <script type="text/javascript" src="inline.bundle.js"></script>
       <script type="text/javascript" src="styles.bundle.js"></script>
       <script type="text/javascript" src="scripts.bundle.js"></script>
       <script type="text/javascript" src="main.bundle.js"></script>


### PR DESCRIPTION
We had CommonsChunkPlugin misconfigured to remove the chunkhash in inline.js.

Partially address #2307