### PR TITLE
feat(build): pass environment variables to index template

### DIFF
--- a/packages/angular-cli/models/webpack-build-common.ts
+++ b/packages/angular-cli/models/webpack-build-common.ts
@@ -88,7 +88,9 @@ export function getWebpackCommonConfig(
       new HtmlWebpackPlugin({
         template: path.resolve(appRoot, appConfig.index),
         filename: path.resolve(appConfig.outDir, appConfig.index),
-        chunksSortMode: 'dependency'
+        chunksSortMode: 'dependency',
+        environment: require(path.resolve(appRoot, appConfig.environments[environment]))
+          .environment
       }),
       new BaseHrefWebpackPlugin({
         baseHref: baseHref

--- a/tests/e2e/tests/build/env-variables-in-template.ts
+++ b/tests/e2e/tests/build/env-variables-in-template.ts
@@ -1,0 +1,18 @@
+import {writeFile, expectFileToMatch} from '../../utils/fs';
+import {ng} from '../../utils/process';
+import {updateJsonFile} from '../../utils/project';
+
+
+export default function() {
+  return updateJsonFile('angular-cli.json', configJson => {
+    const app = configJson['apps'][0];
+    app['index'] = 'index.ejs';
+  })
+  .then(() => writeFile('index.ejs', `
+    is production? <%= htmlWebpackPlugin.options.environment.production ? 'YES' : 'NO' %>!
+  `))
+  .then(() => ng('build', '--env=prod'))
+  .then(() => expectFileToMatch('dist/index.html', /is production? YES!/))
+  .then(() => ng('build', '--env=dev'))
+  .then(() => expectFileToMatch('dist/index.html', /is production? NO!/));
+}


### PR DESCRIPTION
we can use environment variables in index template, thanks to [html-webpack-plugin](https://github.com/ampedandwired/html-webpack-plugin#writing-your-own-templates).

for example, using different GA codes in different environments.

``` js
// angular-cli.json

{
  // ...
  "apps": [
      // ...
      "index": "index.ejs",
      // ...
   ]
  // ...
}
```

``` js
// environment.ts

export const environment = {
   // ...
   ga_code: 'UA-XXXXX-Y'
};

```

``` js
// environment.prod.ts

export const environment = {
   // ...
   ga_code: 'UA-XXXXX-X'
};

```

``` ejs
<!-- index.ejs -->

<!-- Google Analytics -->
<script>
(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');

ga('create', '<%= htmlWebpackPlugin.options.environment.ga_code %>', 'auto');
ga('send', 'pageview');
</script>
<!-- End Google Analytics -->
```
