### PR TITLE
fix(serve): added accept html headers option to webpack-dev-server

### DIFF
--- a/packages/angular-cli/custom-typings.d.ts
+++ b/packages/angular-cli/custom-typings.d.ts
@@ -1,7 +1,7 @@
 interface IWebpackDevServerConfigurationOptions {
   contentBase?: string;
   hot?: boolean;
-  historyApiFallback?: {[key: string]: boolean} | boolean;
+  historyApiFallback?: {[key: string]: any} | boolean;
   compress?: boolean;
   proxy?: {[key: string]: string};
   staticOptions?: any;

--- a/packages/angular-cli/tasks/serve-webpack.ts
+++ b/packages/angular-cli/tasks/serve-webpack.ts
@@ -72,6 +72,7 @@ export default Task.extend({
       ),
       historyApiFallback: {
         disableDotRule: true,
+        htmlAcceptHeaders: ['text/html', 'application/xhtml+xml']
       },
       stats: webpackDevServerOutputOptions,
       inline: true,


### PR DESCRIPTION
fixes #2989