### PR TITLE
Correct forkChecker ats config option to speed up reloads

### DIFF
--- a/packages/angular-cli/models/webpack-build-test.js
+++ b/packages/angular-cli/models/webpack-build-test.js
@@ -79,7 +79,7 @@ const getWebpackTestConfig = function (projectRoot, environment, appConfig, test
                 tsconfig: path.resolve(appRoot, appConfig.tsconfig),
                 module: 'commonjs',
                 target: 'es5',
-                useForkChecker: true
+                forkChecker: true
               }
             },
             {

--- a/packages/angular-cli/models/webpack-build-typescript.ts
+++ b/packages/angular-cli/models/webpack-build-typescript.ts
@@ -30,7 +30,7 @@ export const getWebpackNonAotConfigPartial = function(projectRoot: string, appCo
           loaders: [{
             loader: 'awesome-typescript-loader',
             query: {
-              useForkChecker: true,
+              forkChecker: true,
               tsconfig: path.resolve(appRoot, appConfig.tsconfig)
             }
           }, {


### PR DESCRIPTION
The option for awesome-typescript-loader to fork the type checker is forkChecker, not useForkChecker. This change forks the type checker, and drastically lowers reload times (from ~4sec to ~1.5sec on a new project on my machine).