### PR TITLE
fix(aot): add baseurl and fix module resolution.

### DIFF
--- a/packages/angular-cli/blueprints/ng2/files/__path__/tsconfig.json
+++ b/packages/angular-cli/blueprints/ng2/files/__path__/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "baseUrl": "",
     "declaration": false,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,

--- a/packages/webpack/src/plugin.ts
+++ b/packages/webpack/src/plugin.ts
@@ -28,7 +28,6 @@ export interface AotPluginOptions {
 
 export interface LazyRoute {
   moduleRoute: ModuleRoute;
-  moduleRelativePath: string;
   moduleAbsolutePath: string;
 }
 
@@ -260,10 +259,8 @@ export class AotPlugin {
   }
 
   private _resolveModulePath(module: ModuleRoute, containingFile: string) {
-    if (module.path.startsWith('.')) {
-      return path.join(path.dirname(containingFile), module.path);
-    }
-    return module.path;
+    return this._reflectorHost.findDeclaration(module.path, module.className, containingFile)
+      .filePath;
   }
 
   private _processNgModule(module: ModuleRoute, containingFile: string | null): LazyRouteMap {
@@ -278,14 +275,9 @@ export class AotPlugin {
     const entryNgModuleMetadata = this.getNgModuleMetadata(staticSymbol);
     const loadChildrenRoute: LazyRoute[] = this.extractLoadChildren(entryNgModuleMetadata)
       .map(route => {
-        const mr = ModuleRoute.fromString(route);
-        const relativePath = this._resolveModulePath(mr, relativeModulePath);
-        const absolutePath = path.join(this.genDir, relativePath);
-        return {
-          moduleRoute: mr,
-          moduleRelativePath: relativePath,
-          moduleAbsolutePath: absolutePath
-        };
+        const moduleRoute = ModuleRoute.fromString(route);
+        const moduleAbsolutePath = this._resolveModulePath(moduleRoute, relativeModulePath);
+        return { moduleRoute, moduleAbsolutePath };
       });
     const resultMap: LazyRouteMap = loadChildrenRoute
       .reduce((acc: LazyRouteMap, curr: LazyRoute) => {
@@ -347,7 +339,8 @@ export class AotPlugin {
           }
         })
         // Poor man's flat map.
-        .reduce((acc: any[], i: any) => acc.concat(i), []))
+        .reduce((acc: any[], i: any) => acc.concat(i), [])
+      )
       .filter(x => !!x);
   }
 

--- a/tests/e2e/tests/misc/lazy-module.ts
+++ b/tests/e2e/tests/misc/lazy-module.ts
@@ -16,8 +16,12 @@ export default function(argv: any) {
     .then(() => ng('build'))
     .then(() => oldNumberOfFiles = readdirSync('dist').length)
     .then(() => ng('generate', 'module', 'lazy', '--routing'))
+    // Add 2 lazy routes but they point to the same module so we should have only 1 more module.
     .then(() => addImportToModule('src/app/app.module.ts', oneLine`
-      RouterModule.forRoot([{ path: "lazy", loadChildren: "app/lazy/lazy.module#LazyModule" }])
+      RouterModule.forRoot([
+        { path: "lazy1", loadChildren: "app/lazy/lazy.module#LazyModule" },
+        { path: "lazy2", loadChildren: "./lazy/lazy.module#LazyModule" }
+      ])
       `, '@angular/router'))
     .then(() => ng('build'))
     .then(() => readdirSync('dist').length)


### PR DESCRIPTION
`loadChildren` resolution now uses the same resolution as imports (using the TypeScript language service).