### PR TITLE
Add possibility to pass i18n options to Webpack Aot Plugin

### DIFF
--- a/packages/webpack/README.md
+++ b/packages/webpack/README.md
@@ -37,3 +37,4 @@ The loader works with the webpack plugin to compile your TypeScript. It's import
 * `mainPath`. Optional if `entryModule` is specified. The `main.ts` file containing the bootstrap code. The plugin will use AST to determine the `entryModule`.
 * `genDir`. Optional. The output directory of the offline compiler. The files created by the offline compiler will be in a virtual file system, but the import paths might change. This can also be specified in `angularCompilerOptions`, and by default will be the same as `basePath`.
 * `typeChecking`. Optional, defaults to true. Enable type checking through your application. This will slow down compilation, but show syntactic and semantic errors in webpack.
+* `i18nOptions`. Optional. Pass an object of type NgcCliOptions.

--- a/packages/webpack/src/plugin.ts
+++ b/packages/webpack/src/plugin.ts
@@ -23,6 +23,7 @@ export interface AotPluginOptions {
   entryModule?: string;
   mainPath?: string;
   typeChecking?: boolean;
+  i18nOptions?: ngCompiler.NgcCliOptions
 }
 
 
@@ -71,7 +72,7 @@ export class AotPlugin {
   private _typeCheck: boolean = true;
   private _basePath: string;
   private _genDir: string;
-
+  private _i18nOptions: ngCompiler.NgcCliOptions;
 
   constructor(options: AotPluginOptions) {
     this._setupOptions(options);
@@ -110,6 +111,7 @@ export class AotPlugin {
       genDir = tsConfig.ngOptions.genDir;
     }
 
+    this._i18nOptions = options.i18nOptions;
     this._compilerOptions = tsConfig.parsed.options;
 
     if (options.entryModule) {
@@ -201,12 +203,13 @@ export class AotPlugin {
 
     this._resourceLoader = new WebpackResourceLoader(compilation);
 
-    const i18nOptions: ngCompiler.NgcCliOptions = {
+    const i18nOptions: ngCompiler.NgcCliOptions = this._i18nOptions || {
       i18nFile: undefined,
       i18nFormat: undefined,
-      locale: undefined,
-      basePath: this.basePath
+      locale: undefined
     };
+
+    i18nOptions.basePath = this.basePath;
 
     // Create the Code Generator.
     const codeGenerator = ngCompiler.CodeGenerator.create(


### PR DESCRIPTION
Hi,

since angular-cli does not support the following combination as of now, we needed a workaround:
- AOT with Webpack + I18N

We are now using webpack (raw) with the AotPlugin, though we needed to pass through the i18n options, which was not possible before. 

I'm not sure if this is relevant or interesting, just in case, here are my changes - feel free to reject if you don't think this will benefit anyone else :)
