### PR TITLE
chore(tests): fix filename test

### DIFF
--- a/tests/e2e/tests/build/filename.ts
+++ b/tests/e2e/tests/build/filename.ts
@@ -1,10 +1,12 @@
 import {ng} from '../../utils/process';
 import {expectFileToExist} from '../../utils/fs';
 import {updateJsonFile} from '../../utils/project';
+import {copyFile} from '../../utils/fs';
 
 
 export default function() {
   return Promise.resolve()
+    .then(() => copyFile('src/index.html', 'src/config-index.html'))
     .then(() => updateJsonFile('angular-cli.json', configJson => {
       const app = configJson['apps'][0];
       app['outDir'] = 'config-build-output';


### PR DESCRIPTION
The current `e2e/tests/build/filename.ts` errors out because of a missing index file.