### PR TITLE
feat(ng test) add option to inlcude unused files in code coverage

### DIFF
--- a/packages/angular-cli/blueprints/ng2/files/__path__/test.ts
+++ b/packages/angular-cli/blueprints/ng2/files/__path__/test.ts
@@ -14,6 +14,8 @@ declare var require: any;
 // Prevent Karma from running prematurely.
 __karma__.loaded = function () {};
 
+// Flag for loading all files to include them in code coverage.
+declare var FULL_CODE_COVERAGE: boolean;
 
 Promise.all([
   System.import('@angular/core/testing'),
@@ -26,8 +28,15 @@ Promise.all([
       testingBrowser.platformBrowserDynamicTesting()
     );
   })
-  // Then we find all the tests.
-  .then(() => require.context('./', true, /\.spec\.ts/))
+  .then(() => {
+    if (FULL_CODE_COVERAGE) {
+      // Then require all files in ./app for code coverage including unused files.
+      return require.context('./', true, /\/app\/.*\.ts/);
+    } else {
+      // Then we find all the tests.
+      return require.context('./', true, /\.spec\.ts/);
+    }
+  })
   // And load the modules.
   .then(context => {
     try {

--- a/packages/angular-cli/commands/test.ts
+++ b/packages/angular-cli/commands/test.ts
@@ -6,6 +6,7 @@ const NgCliTestCommand = TestCommand.extend({
   availableOptions: [
     { name: 'watch', type: Boolean, default: true, aliases: ['w'] },
     { name: 'code-coverage', type: Boolean, default: false, aliases: ['cc'] },
+    { name: 'full-code-coverage', type: Boolean, default: false, aliases: ['fcc'] },
     { name: 'lint', type: Boolean, default: false, aliases: ['l'] },
     { name: 'browsers', type: String },
     { name: 'colors', type: Boolean },

--- a/packages/angular-cli/models/webpack-build-test.js
+++ b/packages/angular-cli/models/webpack-build-test.js
@@ -113,7 +113,10 @@ const getWebpackTestConfig = function (projectRoot, environment, appConfig, test
       new webpack.ContextReplacementPlugin(
         /angular(\\|\/)core(\\|\/)(esm(\\|\/)src|src)(\\|\/)linker/,
         appRoot
-      )
+      ),
+      new webpack.DefinePlugin({
+        FULL_CODE_COVERAGE: testConfig.fullCodeCoverage
+      })
     ].concat(extraPlugins),
     node: {
       fs: 'empty',

--- a/packages/angular-cli/plugins/karma.js
+++ b/packages/angular-cli/plugins/karma.js
@@ -12,6 +12,7 @@ const init = (config) => {
   const environment = config.angularCli.environment || 'dev';
   const testConfig = {
     codeCoverage: config.angularCli.codeCoverage || false,
+    fullCodeCoverage: config.angularCli.fullCodeCoverage || false,
     lint: config.angularCli.lint || false
   }
 

--- a/packages/angular-cli/tasks/test.ts
+++ b/packages/angular-cli/tasks/test.ts
@@ -21,7 +21,8 @@ export default Task.extend({
       }
 
       options.angularCli = {
-        codeCoverage: options.codeCoverage,
+        codeCoverage: options.codeCoverage || options.fullCodeCoverage,
+        fullCodeCoverage: options.fullCodeCoverage,
         lint: options.lint,
       };
 


### PR DESCRIPTION
Code coverage does not include files not imported in any test file.
This new options for `ng test` includes all source files in the `app`
directory in the coverage report. To enable this option use
`--full-code-coverage` or `-fcc`.

Closes #1735