### PR TITLE
fix(aot): output the sources in the sourcemap.

### DIFF
--- a/packages/webpack/src/plugin.ts
+++ b/packages/webpack/src/plugin.ts
@@ -79,6 +79,7 @@ export class AotPlugin {
 
   get basePath() { return this._basePath; }
   get compilation() { return this._compilation; }
+  get compilerHost() { return this._compilerHost; }
   get compilerOptions() { return this._compilerOptions; }
   get done() { return this._donePromise; }
   get entryModule() { return this._entryModule; }


### PR DESCRIPTION
This allows browsers to at least debug and breakpoints with `--aot`.
Note that the source will be different than the source on disk, because
we still perform some refactoring and we don't transform the sourcemap.