### PR TITLE
chore(test): make test descriptions consistent

### DIFF
--- a/packages/angular-cli/blueprints/directive/files/__path__/__name__.directive.spec.ts
+++ b/packages/angular-cli/blueprints/directive/files/__path__/__name__.directive.spec.ts
@@ -3,7 +3,7 @@
 import { TestBed, async } from '@angular/core/testing';
 import { <%= classifiedModuleName %>Directive } from './<%= dasherizedModuleName %>.directive';
 
-describe('Directive: <%= classifiedModuleName %>', () => {
+describe('<%= classifiedModuleName %>Directive', () => {
   it('should create an instance', () => {
     let directive = new <%= classifiedModuleName %>Directive();
     expect(directive).toBeTruthy();

--- a/packages/angular-cli/blueprints/ng2/files/__path__/app/app.component.spec.ts
+++ b/packages/angular-cli/blueprints/ng2/files/__path__/app/app.component.spec.ts
@@ -3,7 +3,7 @@
 import { TestBed, async } from '@angular/core/testing';
 import { AppComponent } from './app.component';
 
-describe('App: <%= jsComponentName %>', () => {
+describe('AppComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [

--- a/packages/angular-cli/blueprints/pipe/files/__path__/__name__.pipe.spec.ts
+++ b/packages/angular-cli/blueprints/pipe/files/__path__/__name__.pipe.spec.ts
@@ -3,7 +3,7 @@
 import { TestBed, async } from '@angular/core/testing';
 import { <%= classifiedModuleName %>Pipe } from './<%= dasherizedModuleName %>.pipe';
 
-describe('Pipe: <%= classifiedModuleName %>', () => {
+describe('<%= classifiedModuleName %>Pipe', () => {
   it('create an instance', () => {
     let pipe = new <%= classifiedModuleName %>Pipe();
     expect(pipe).toBeTruthy();

--- a/packages/angular-cli/blueprints/service/files/__path__/__name__.service.spec.ts
+++ b/packages/angular-cli/blueprints/service/files/__path__/__name__.service.spec.ts
@@ -3,7 +3,7 @@
 import { TestBed, async, inject } from '@angular/core/testing';
 import { <%= classifiedModuleName %>Service } from './<%= dasherizedModuleName %>.service';
 
-describe('Service: <%= classifiedModuleName %>', () => {
+describe('<%= classifiedModuleName %>Service', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [<%= classifiedModuleName %>Service]


### PR DESCRIPTION
Components are called: `<%= classifiedModuleName %>Directive` and it was bothering me that the rest were like: `Service: <%= classifiedModuleName %>`.

Another change I'd like to make but would like approval first, is to wrap the first generated test in another describe like so:

```js
describe('.constructor()', () => {
  it('should create', () => {
    expect(component).toBeTruthy();
  });
});
```

I think it makes tests a little more organised and easier to read. I got the idea from reading the Http specs within angular/angular: https://github.com/angular/angular/blob/master/modules/%40angular/http/test/http_spec.ts#L108