### PR TITLE
fix(@ngtools/webpack): fixed relative path for AoT.

### DIFF
--- a/packages/angular-cli/blueprints/ng2/files/__path__/tsconfig.json
+++ b/packages/angular-cli/blueprints/ng2/files/__path__/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "baseUrl": "",
     "declaration": false,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,

--- a/packages/webpack/src/plugin.ts
+++ b/packages/webpack/src/plugin.ts
@@ -282,7 +282,7 @@ export class AotPlugin {
       .map(route => {
         const mr = ModuleRoute.fromString(route);
         const relativePath = this._resolveModulePath(mr, relativeModulePath);
-        const absolutePath = path.join(this.genDir, relativePath);
+        const absolutePath = path.resolve(this.genDir, relativePath);
         return {
           moduleRoute: mr,
           moduleRelativePath: relativePath,

--- a/tests/e2e/tests/misc/lazy-module.ts
+++ b/tests/e2e/tests/misc/lazy-module.ts
@@ -6,18 +6,14 @@ import {addImportToModule} from '../../utils/ast';
 
 
 export default function(argv: any) {
-  /** This test is disabled when not on nightly. */
-  if (!argv.nightly) {
-    return Promise.resolve();
-  }
-
   let oldNumberOfFiles = 0;
   return Promise.resolve()
     .then(() => ng('build'))
     .then(() => oldNumberOfFiles = readdirSync('dist').length)
     .then(() => ng('generate', 'module', 'lazy', '--routing'))
     .then(() => addImportToModule('src/app/app.module.ts', oneLine`
-      RouterModule.forRoot([{ path: "lazy", loadChildren: "app/lazy/lazy.module#LazyModule" }])
+      RouterModule.forRoot([{ path: "lazy", loadChildren: "app/lazy/lazy.module#LazyModule" }]),
+      RouterModule.forRoot([{ path: "lazy1", loadChildren: "./lazy/lazy.module#LazyModule" }])
       `, '@angular/router'))
     .then(() => ng('build'))
     .then(() => readdirSync('dist').length)


### PR DESCRIPTION
Re-enabled test for all. Also added the baseUrl option as it makes most sense.