### PR TITLE
chore(test): wrap it statements in describe to group tests

### DIFF
--- a/packages/angular-cli/blueprints/class/files/__path__/__name__.spec.ts
+++ b/packages/angular-cli/blueprints/class/files/__path__/__name__.spec.ts
@@ -1,7 +1,9 @@
 import {<%= classifiedModuleName %>} from './<%= fileName %>';
 
 describe('<%= classifiedModuleName %>', () => {
-  it('should create an instance', () => {
-    expect(new <%= classifiedModuleName %>()).toBeTruthy();
+  describe('.constructor()', () => {
+    it('should create an instance', () => {
+      expect(new <%= classifiedModuleName %>()).toBeTruthy();
+    });
   });
 });

--- a/packages/angular-cli/blueprints/component/files/__path__/__name__.component.spec.ts
+++ b/packages/angular-cli/blueprints/component/files/__path__/__name__.component.spec.ts
@@ -22,7 +22,9 @@ describe('<%= classifiedModuleName %>Component', () => {
     fixture.detectChanges();
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  describe('.constructor()', () => {
+    it('should create', () => {
+      expect(component).toBeTruthy();
+    });
   });
 });

--- a/packages/angular-cli/blueprints/directive/files/__path__/__name__.directive.spec.ts
+++ b/packages/angular-cli/blueprints/directive/files/__path__/__name__.directive.spec.ts
@@ -4,8 +4,10 @@ import { TestBed, async } from '@angular/core/testing';
 import { <%= classifiedModuleName %>Directive } from './<%= dasherizedModuleName %>.directive';
 
 describe('<%= classifiedModuleName %>Directive', () => {
-  it('should create an instance', () => {
-    let directive = new <%= classifiedModuleName %>Directive();
-    expect(directive).toBeTruthy();
+  describe('.constructor()', () => {
+    it('should create an instance', () => {
+      let directive = new <%= classifiedModuleName %>Directive();
+      expect(directive).toBeTruthy();
+    });
   });
 });

--- a/packages/angular-cli/blueprints/module/files/__path__/__name__.module.spec.ts
+++ b/packages/angular-cli/blueprints/module/files/__path__/__name__.module.spec.ts
@@ -10,7 +10,9 @@ describe('<%= classifiedModuleName %>Module', () => {
     <%= camelizedModuleName %>Module = new <%= classifiedModuleName %>Module();
   });
 
-  it('should create an instance', () => {
-    expect(<%= camelizedModuleName %>Module).toBeTruthy();
-  })
+  describe('.constructor()', () => {
+    it('should create an instance', () => {
+      expect(<%= camelizedModuleName %>Module).toBeTruthy();
+    });
+  });
 });

--- a/packages/angular-cli/blueprints/ng2/files/__path__/app/app.component.spec.ts
+++ b/packages/angular-cli/blueprints/ng2/files/__path__/app/app.component.spec.ts
@@ -12,22 +12,24 @@ describe('AppComponent', () => {
     });
   });
 
-  it('should create the app', async(() => {
-    let fixture = TestBed.createComponent(AppComponent);
-    let app = fixture.debugElement.componentInstance;
-    expect(app).toBeTruthy();
-  }));
+  describe('.constructor()', () => {
+    it('should create the app', async(() => {
+      let fixture = TestBed.createComponent(AppComponent);
+      let app = fixture.debugElement.componentInstance;
+      expect(app).toBeTruthy();
+    }));
 
-  it(`should have as title '<%= prefix %> works!'`, async(() => {
-    let fixture = TestBed.createComponent(AppComponent);
-    let app = fixture.debugElement.componentInstance;
-    expect(app.title).toEqual('<%= prefix %> works!');
-  }));
+    it(`should have as title '<%= prefix %> works!'`, async(() => {
+      let fixture = TestBed.createComponent(AppComponent);
+      let app = fixture.debugElement.componentInstance;
+      expect(app.title).toEqual('<%= prefix %> works!');
+    }));
 
-  it('should render title in a h1 tag', async(() => {
-    let fixture = TestBed.createComponent(AppComponent);
-    fixture.detectChanges();
-    let compiled = fixture.debugElement.nativeElement;
-    expect(compiled.querySelector('h1').textContent).toContain('<%= prefix %> works!');
-  }));
+    it('should render title in a h1 tag', async(() => {
+      let fixture = TestBed.createComponent(AppComponent);
+      fixture.detectChanges();
+      let compiled = fixture.debugElement.nativeElement;
+      expect(compiled.querySelector('h1').textContent).toContain('<%= prefix %> works!');
+    }));
+  });
 });

--- a/packages/angular-cli/blueprints/pipe/files/__path__/__name__.pipe.spec.ts
+++ b/packages/angular-cli/blueprints/pipe/files/__path__/__name__.pipe.spec.ts
@@ -4,8 +4,10 @@ import { TestBed, async } from '@angular/core/testing';
 import { <%= classifiedModuleName %>Pipe } from './<%= dasherizedModuleName %>.pipe';
 
 describe('<%= classifiedModuleName %>Pipe', () => {
-  it('create an instance', () => {
-    let pipe = new <%= classifiedModuleName %>Pipe();
-    expect(pipe).toBeTruthy();
+  describe('.constructor()', () => {
+    it('create an instance', () => {
+      let pipe = new <%= classifiedModuleName %>Pipe();
+      expect(pipe).toBeTruthy();
+    });
   });
 });

--- a/packages/angular-cli/blueprints/service/files/__path__/__name__.service.spec.ts
+++ b/packages/angular-cli/blueprints/service/files/__path__/__name__.service.spec.ts
@@ -10,7 +10,10 @@ describe('<%= classifiedModuleName %>Service', () => {
     });
   });
 
-  it('should ...', inject([<%= classifiedModuleName %>Service], (service: <%= classifiedModuleName %>Service) => {
-    expect(service).toBeTruthy();
-  }));
+  describe('.constructor()', () => {
+    it('should ...',
+      inject([<%= classifiedModuleName %>Service], (service: <%= classifiedModuleName %>Service) => {
+        expect(service).toBeTruthy();
+      }));
+  });
 });


### PR DESCRIPTION
As per discussion: https://github.com/angular/angular-cli/pull/3112

I think it makes tests a little more organised and easier to read. I got the idea from reading the Http specs within angular/angular: https://github.com/angular/angular/blob/master/modules/%40angular/http/test/http_spec.ts#L108