### PR TITLE
feat(github): support usage of gh-token for deployment from external env

### DIFF
--- a/packages/angular-cli/commands/github-pages-deploy.ts
+++ b/packages/angular-cli/commands/github-pages-deploy.ts
@@ -2,71 +2,71 @@ const Command = require('../ember-cli/lib/models/command');
 import { oneLine } from 'common-tags';
 
 export interface GithubPagesDeployOptions {
-  message?: string;
-  target?: string;
-  environment?: string;
-  userPage?: boolean;
-  skipBuild?: boolean;
-  ghToken?: string;
-  ghUsername?: string;
-  baseHref?: string;
+    message?: string;
+    target?: string;
+    environment?: string;
+    userPage?: boolean;
+    skipBuild?: boolean;
+    ghToken?: string;
+    ghUsername?: string;
+    baseHref?: string;
 }
 
 const githubPagesDeployCommand = Command.extend({
-  name: 'github-pages:deploy',
-  aliases: ['gh-pages:deploy'],
-  description: oneLine`
+    name: 'github-pages:deploy',
+    aliases: ['gh-pages:deploy'],
+    description: oneLine`
     Build the test app for production, commit it into a git branch,
     setup GitHub repo and push to it
   `,
-  works: 'insideProject',
+    works: 'insideProject',
 
-  availableOptions: [
-    {
-      name: 'message',
-      type: String,
-      default: 'new gh-pages version',
-      description: 'The commit message to include with the build, must be wrapped in quotes.'
-    }, {
-      name: 'target',
-      type: String,
-      default: 'production',
-      aliases: ['t', { 'dev': 'development' }, { 'prod': 'production' }]
-    }, {
-      name: 'environment',
-      type: String,
-      default: '',
-      aliases: ['e']
-    }, {
-      name: 'user-page',
-      type: Boolean,
-      default: false,
-      description: 'Deploy as a user/org page'
-    }, {
-      name: 'skip-build',
-      type: Boolean,
-      default: false,
-      description: 'Skip building the project before deploying'
-    }, {
-      name: 'gh-token',
-      type: String,
-      default: '',
-      description: 'Github token'
-    }, {
-      name: 'gh-username',
-      type: String,
-      default: '',
-      description: 'Github username'
-    }, {
-      name: 'base-href',
-      type: String,
-      default: null,
-      aliases: ['bh']
-    }],
+    availableOptions: [
+        {
+            name: 'message',
+            type: String,
+            default: 'new gh-pages version',
+            description: 'The commit message to include with the build, must be wrapped in quotes.'
+        }, {
+            name: 'target',
+            type: String,
+            default: 'production',
+            aliases: ['t', { 'dev': 'development' }, { 'prod': 'production' }]
+        }, {
+            name: 'environment',
+            type: String,
+            default: '',
+            aliases: ['e']
+        }, {
+            name: 'user-page',
+            type: Boolean,
+            default: false,
+            description: 'Deploy as a user/org page'
+        }, {
+            name: 'skip-build',
+            type: Boolean,
+            default: false,
+            description: 'Skip building the project before deploying'
+        }, {
+            name: 'gh-token',
+            type: String,
+            default: '',
+            description: 'Github token'
+        }, {
+            name: 'gh-username',
+            type: String,
+            default: '',
+            description: 'Github username'
+        }, {
+            name: 'base-href',
+            type: String,
+            default: null,
+            aliases: ['bh']
+        }],
 
-  run: function(options: GithubPagesDeployOptions, rawArgs: string[]) {
-    return require('./github-pages-deploy.run').default.call(this, options, rawArgs);
-  }
+    run: function(options: GithubPagesDeployOptions, rawArgs: string[]) {
+        return require('./github-pages-deploy.run').default.call(this, options, rawArgs);
+    }
 });
 
 

--- a/tests/acceptance/github-pages-deploy.spec.js
+++ b/tests/acceptance/github-pages-deploy.spec.js
@@ -77,6 +77,44 @@ describe('Acceptance: ng github-pages:deploy', function() {
     return ng(['github-pages:deploy', '--skip-build']);
   });
 
+  it('should deploy with token and username', function () {
+    let token = 'token',
+      username = 'bar';
+
+    execStub.addExecSuccess('git status --porcelain')
+      .addExecSuccess('git rev-parse --abbrev-ref HEAD', initialBranch)
+      .addExecSuccess('git remote -v', remote)
+      .addExecSuccess(`git checkout ${ghPagesBranch}`)
+      .addExecSuccess('git ls-files')
+      .addExecSuccess('git rm -r ')
+      .addExecSuccess('git add .')
+      .addExecSuccess(`git commit -m "${message}"`)
+      .addExecSuccess(`git checkout ${initialBranch}`)
+      .addExecSuccess(`git push https://${token}@github.com/${username}/${project}.git ${ghPagesBranch}:${ghPagesBranch}`)
+      .addExecSuccess('git remote -v', remote);
+
+    return ng(['github-pages:deploy', '--skip-build', `--gh-token=${token}`, `--gh-username=${username}`]);
+  })
+
+  it('should deploy with token only', function () {
+    let token = 'token';
+
+    execStub.addExecSuccess('git status --porcelain')
+      .addExecSuccess('git rev-parse --abbrev-ref HEAD', initialBranch)
+      .addExecSuccess('git remote -v', remote)
+      .addExecSuccess(`git checkout ${ghPagesBranch}`)
+      .addExecSuccess('git ls-files')
+      .addExecSuccess('git rm -r ')
+      .addExecSuccess('git add .')
+      .addExecSuccess(`git commit -m "${message}"`)
+      .addExecSuccess(`git checkout ${initialBranch}`)
+      .addExecSuccess('git remote -v', remote)
+      .addExecSuccess(`git push https://${token}@github.com/username/${project}.git ${ghPagesBranch}:${ghPagesBranch}`)
+      .addExecSuccess('git remote -v', remote);
+
+    return ng(['github-pages:deploy', '--skip-build', `--gh-token=${token}`]);
+  });
+
   it('should deploy with changed defaults', function() {
     let userPageBranch = 'master',
       message = 'not new gh-pages version';
@@ -126,14 +164,14 @@ describe('Acceptance: ng github-pages:deploy', function() {
       .addExecSuccess('git rev-parse --abbrev-ref HEAD', initialBranch)
       .addExecSuccess('git remote -v', noRemote)
       .addExecSuccess(`git remote add origin git@github.com:${username}/${project}.git`)
-      .addExecSuccess(`git push -u origin ${initialBranch}`)
+      .addExecSuccess(`git push -u https://${token}@github.com/${username}/${project}.git ${initialBranch}`)
       .addExecSuccess(`git checkout ${ghPagesBranch}`)
       .addExecSuccess('git ls-files')
       .addExecSuccess('git rm -r ')
       .addExecSuccess('git add .')
       .addExecSuccess(`git commit -m "${message}"`)
       .addExecSuccess(`git checkout ${initialBranch}`)
-      .addExecSuccess(`git push origin ${ghPagesBranch}:${ghPagesBranch}`)
+      .addExecSuccess(`git push https://${token}@github.com/${username}/${project}.git ${ghPagesBranch}:${ghPagesBranch}`)
       .addExecSuccess('git remote -v', remote);
 
     var httpsStub = sinon.stub(https, 'request', httpsRequestStubFunc);


### PR DESCRIPTION
In order to being able to push to github from CI (Travis for example), we should be able to provide a token to the cli, as `--gh-token=XYZ`. This modification allow to use this token in the destination url. This also allow user to push to another github repository if it uses a different `--gh-username` from the one used for the checkout.