### PR TITLE
feat(ng new): Make CLI available without install

### DIFF
--- a/packages/angular-cli/blueprints/ng2/files/package.json
+++ b/packages/angular-cli/blueprints/ng2/files/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "angular-cli": {},
   "scripts": {
+    "ng": "ng",
     "start": "ng serve",
     "lint": "tslint \"<%= sourceDir %>/**/*.ts\"",
     "test": "ng test",


### PR DESCRIPTION
This small change will allow consumers of the CLI to have their projects shared with anyone, even if they don't have the CLI installed.

They just clone, and run `npm install`, and then they can all interesting stuff they want directly from the CLI by using `npm run ng -- ` instead of `ng`.

It also helps people who may have multiple projects created by the CLI not all upgraded to the latest version, matching their global install.