### PR TITLE
fix(generate): revert change to component dir in generate module

### DIFF
--- a/packages/angular-cli/blueprints/module/index.js
+++ b/packages/angular-cli/blueprints/module/index.js
@@ -58,8 +58,12 @@ module.exports = {
   },
 
   afterInstall: function (options) {
-    options.entity.name = path.relative(this.dynamicPath.appRoot, this.generatePath);
-    options.flat = false;
+    // Note that `this.generatePath` already contains `this.dasherizedModuleName`
+    // So, the path will end like `name/name`, 
+    //  which is correct for `name.component.ts` created in module `name`
+    var componentPath = path.join(this.generatePath, this.dasherizedModuleName);
+    options.entity.name = path.relative(this.dynamicPath.appRoot, componentPath);
+    options.flat = true;
     options.route = false;
     options.inlineTemplate = false;
     options.inlineStyle = false;

--- a/tests/e2e/tests/generate/module/module-basic.ts
+++ b/tests/e2e/tests/generate/module/module-basic.ts
@@ -1,6 +1,6 @@
 import {join} from 'path';
 import {ng} from '../../../utils/process';
-import {expectFileToExist} from '../../../utils/fs';
+import {expectFileToExist, expectFileToMatch} from '../../../utils/fs';
 import {expectToFail} from '../../../utils/utils';
 
 
@@ -15,6 +15,7 @@ export default function() {
     .then(() => expectFileToExist(join(moduleDir, 'test-module.component.spec.ts')))
     .then(() => expectFileToExist(join(moduleDir, 'test-module.component.html')))
     .then(() => expectFileToExist(join(moduleDir, 'test-module.component.css')))
+    .then(() => expectFileToMatch(join(moduleDir, 'test-module.module.ts'), 'TestModuleComponent'))
 
     // Try to run the unit tests.
     .then(() => ng('test', '--single-run'));


### PR DESCRIPTION
fix(generate): revert change to component dir in generate module, as it caused component declaration to go to parent module

This fixes regression introduced in the code-review of PR #3066. The PR deals with `generate module` command, and the component generated with the module.

In the code review, it was requested to change the way component was created as `flat`. I did that, but this is causing the following problem:

If you run:

```
ng new cli-project
cd cli-project
ng g module test
```

The files are created in `src/app/test` correctly (and hence the tests pass), but the component `src/app/test/test.component.ts` is added to the `NgModule` `declarations` of `AppModule`, not `TestModule`.

This is because with switching `flat` false and giving the module folder as the component folder, the CLI looks for a module to add declarations ABOVE the module folder.

So, now I reverted the code to the original code in #3066 before the code review.