### PR TITLE
docs(readme): update ng --help to ng help in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This project is very much still a work in progress.
 The CLI is now in beta.
 If you wish to collaborate while the project is still young, check out [our issue list](https://github.com/angular/angular-cli/issues).
 
-Before submitting new issues, have a look at [issues marked with the `type: faq` label](https://github.com/angular/angular-cli/issues?utf8=%E2%9C%93&q=is%3Aissue%20label%3A%22type%3A%20faq%22%20).  
+Before submitting new issues, have a look at [issues marked with the `type: faq` label](https://github.com/angular/angular-cli/issues?utf8=%E2%9C%93&q=is%3Aissue%20label%3A%22type%3A%20faq%22%20).
 
 ## Webpack update
 
@@ -67,7 +67,7 @@ npm install -g angular-cli
 ## Usage
 
 ```bash
-ng --help
+ng help
 ```
 
 ### Generating and serving an Angular2 project via a development server


### PR DESCRIPTION
![screen shot 2016-11-16 at 13 40 39](https://cloud.githubusercontent.com/assets/472453/20347917/821b6a6a-ac03-11e6-99c5-1ae6aa3bb123.png)

As you can see above, `ng --help` doesn't work, we have to use `ng help` instead, and the command specified in the [readme](https://github.com/angular/angular-cli#usage) is the wrong one

Fix https://github.com/angular/angular-cli/issues/3168