### PR TITLE
fix(autoprefixer): Added autoprefixer to prod

### DIFF
--- a/packages/angular-cli/models/webpack-build-common.ts
+++ b/packages/angular-cli/models/webpack-build-common.ts
@@ -4,8 +4,6 @@ import {GlobCopyWebpackPlugin} from '../plugins/glob-copy-webpack-plugin';
 import {BaseHrefWebpackPlugin} from '@angular-cli/base-href-webpack';
 
 const HtmlWebpackPlugin = require('html-webpack-plugin');
-const autoprefixer = require('autoprefixer');
-
 
 export function getWebpackCommonConfig(
   projectRoot: string,
@@ -116,7 +114,9 @@ export function getWebpackCommonConfig(
       new webpack.LoaderOptionsPlugin({
         test: /\.(css|scss|sass|less|styl)$/,
         options: {
-          postcss: [ autoprefixer() ]
+          postcss: [
+            require('autoprefixer')
+          ]
         },
       }),
     ],

--- a/packages/angular-cli/models/webpack-build-production.ts
+++ b/packages/angular-cli/models/webpack-build-production.ts
@@ -69,8 +69,10 @@ export const getWebpackProdConfigPartial = function(projectRoot: string, appConf
           minRatio: 0.8
       }),
       new webpack.LoaderOptionsPlugin({
+        test: /\.(css|scss|sass|less|styl)$/,
         options: {
           postcss: [
+            require('autoprefixer'),
             require('postcss-discard-comments')
           ]
         }


### PR DESCRIPTION
There does not seem to be any webpack plugin available to merge webpack.LoaderOptionsPlugin().

Instead we could define all postcss-plugins we want to use per environment as there might be some plugins in the future which we only want in dev.

Does anyone know if the `test: /\.(css|scss|sass|less|styl)$/` is actually needed? My postcss-discard-comments did not have it while autoprefixer did.

Fixes #3156