### PR TITLE
fix(new): production build is breaking angular child components

### DIFF
--- a/packages/angular-cli/models/webpack-build-production.ts
+++ b/packages/angular-cli/models/webpack-build-production.ts
@@ -57,7 +57,7 @@ export const getWebpackProdConfigPartial = function(projectRoot: string, appConf
         'process.env.NODE_ENV': JSON.stringify('production')
       }),
       new webpack.optimize.UglifyJsPlugin(<any>{
-        mangle: { screw_ie8 : true },
+        mangle: { screw_ie8 : true, keep_fnames: true },
         compress: { screw_ie8: true },
         sourceMap: true
       }),


### PR DESCRIPTION
Set keep_fnames: true fixes the issue.

Similar to the issues found here:
https://github.com/mishoo/UglifyJS2/issues/999
https://github.com/angular/angular/issues/10618#issuecomment-243532360