### PR TITLE
Add a toggle to disable ProgressPlugin

### DIFF
--- a/packages/angular-cli/commands/serve.ts
+++ b/packages/angular-cli/commands/serve.ts
@@ -22,6 +22,7 @@ export interface ServeTaskOptions {
   liveReloadLiveCss?: boolean;
   target?: string;
   environment?: string;
+  showProgress: boolean;
   ssl?: boolean;
   sslKey?: string;
   sslCert?: string;
@@ -78,6 +79,13 @@ const ServeCommand = Command.extend({
       aliases: ['t', { 'dev': 'development' }, { 'prod': 'production' }]
     },
     { name: 'environment',          type: String,  default: '', aliases: ['e'] },
+    {
+      name: 'show-progress',
+      type: Boolean,
+      default: true,
+      description: 'Whether to show the Webpack build progress (default true)',
+      aliases: ['sp']
+    },
     { name: 'ssl',                  type: Boolean, default: false },
     { name: 'ssl-key',              type: String,  default: 'ssl/server.key' },
     { name: 'ssl-cert',             type: String,  default: 'ssl/server.crt' },

--- a/packages/angular-cli/tasks/serve-webpack.ts
+++ b/packages/angular-cli/tasks/serve-webpack.ts
@@ -37,10 +37,12 @@ export default Task.extend({
     );
     webpackCompiler = webpack(config);
 
-    webpackCompiler.apply(new ProgressPlugin({
-      profile: true,
-      colors: true
-    }));
+    if (commandOptions.showProgress) {
+      webpackCompiler.apply(new ProgressPlugin({
+        profile: false,
+        colors: false
+      }));
+    }
 
     let proxyConfig = {};
     if (commandOptions.proxyConfig) {


### PR DESCRIPTION
This patch adds a command line option that can disable the Webpack ProgressPlugin, keeping it enabled by default.

Disabling this progress speeds up the initial build that `ng serve` does quite significantly in our setup, where we use [pm2](https://github.com/Unitech/pm2) to start `ng serve`.

The build process of our app went down from about 25 to 11 seconds.

Please let me know if it needs any adjustments to get merged.