### PR TITLE
Fix "ng help" typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ npm install -g angular-cli
 ## Usage
 
 ```bash
-ng --help
+ng help
 ```
 
 ### Generating and serving an Angular2 project via a development server


### PR DESCRIPTION
Documentation says "`ng --help`", but the actual command is "`ng help`".