### PR TITLE
fix(build) use custom index value when copying to 404.html during github deploy

### DIFF
--- a/packages/angular-cli/commands/github-pages-deploy.ts
+++ b/packages/angular-cli/commands/github-pages-deploy.ts
@@ -216,7 +216,7 @@ const githubPagesDeployCommand = Command.extend({
     }
 
     function createNotFoundPage() {
-      const indexHtml = path.join(root, 'index.html');
+      const indexHtml = path.join(root, this.project.index);
       const notFoundPage = path.join(root, '404.html');
       return fsCopy(indexHtml, notFoundPage);
     }

--- a/packages/angular-cli/commands/github-pages-deploy.ts
+++ b/packages/angular-cli/commands/github-pages-deploy.ts
@@ -97,6 +97,7 @@ const githubPagesDeployCommand = Command.extend({
     const projectName = this.project.pkg.name;
 
     const outDir = CliConfig.fromProject().config.apps[0].outDir;
+    const indexFilename = CliConfig.fromProject().config.apps[0].index;
 
     let ghPagesBranch = 'gh-pages';
     let destinationBranch = options.userPage ? 'master' : ghPagesBranch;
@@ -216,7 +217,7 @@ const githubPagesDeployCommand = Command.extend({
     }
 
     function createNotFoundPage() {
-      const indexHtml = path.join(root, this.project.index);
+      const indexHtml = path.join(root, indexFilename);
       const notFoundPage = path.join(root, '404.html');
       return fsCopy(indexHtml, notFoundPage);
     }


### PR DESCRIPTION
related to fix in #2767 
There is no guarantee that there will be an `index.html` file, as the developer may specify a custom index file. 
When a developer uses a custom index file, use that file name when copying to the 404.html file.