### PR TITLE
Fix readme help command text

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ npm install -g angular-cli
 ## Usage
 
 ```bash
-ng --help
+ng help
 ```
 
 ### Generating and serving an Angular2 project via a development server


### PR DESCRIPTION
`ng --help` in the readme should be changed to `ng help`.

Thanks,
Dan