### PR TITLE
Jasmine types and jasmine-core are out of sync

### DIFF
--- a/packages/angular-cli/blueprints/ng2/files/package.json
+++ b/packages/angular-cli/blueprints/ng2/files/package.json
@@ -34,11 +34,11 @@
     "preboot": "2.1.2",
     "parse5": "1.5.1",<% } %>
     "@angular/compiler-cli": "^2.1.0",
-    "@types/jasmine": "^2.2.30",
+    "@types/jasmine": "2.5.38",
     "@types/node": "^6.0.42",
     "angular-cli": "<%= version %>",
     "codelyzer": "~1.0.0-beta.3",
-    "jasmine-core": "2.4.1",
+    "jasmine-core": "2.5.2",
     "jasmine-spec-reporter": "2.5.0",
     "karma": "1.2.0",
     "karma-chrome-launcher": "^2.0.0",


### PR DESCRIPTION
Jasmine-types are right now on latest version and have the new matchers
`toBeGreaterThanOrEqual` and `toBeLessThanOrEqual` (see https://github.com/jasmine/jasmine/commit/b7d8b0de713b5a123b73d026a03849d3f5dffb0d / https://github.com/jasmine/jasmine/issues/1013 )

Unfortunately current jasmine is pinned to `2.4.1`, so promised matchers are not available and lead to following errors:

```
 TypeError: expect(...).toBeGreaterThanOrEqual is not a function
 TypeError: expect(...).toBeLessThanOrEqual is not a function
```