### PR TITLE
chore(protractor): update protractor to ~4.0.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,10 +49,14 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew tap caskroom/cask; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew cask install google-chrome --force; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then mkdir ~/.config && echo "--no-sandbox" > ~/.config/chrome-flags.conf; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then CHROME_BIN=/usr/bin/google-chrome; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export DISPLAY=:99.0; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sh -e /etc/init.d/xvfb start; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export CHROME_BIN=chromium-browser; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then echo "--no-sandbox" > ~/.config/chromium-flags.conf; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y libappindicator1 fonts-liberation; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo dpkg -i google-chrome*.deb; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then echo "--no-sandbox" > ~/.config/chrome-flags.conf; fi
   - if [[ "$TARGET" == "mobile" ]]; then export MOBILE_TEST=true; fi
   - npm install -g npm
   - npm config set spin false

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,14 +49,10 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew tap caskroom/cask; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew cask install google-chrome --force; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then mkdir ~/.config && echo "--no-sandbox" > ~/.config/chrome-flags.conf; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then CHROME_BIN=/usr/bin/google-chrome; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export DISPLAY=:99.0; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sh -e /etc/init.d/xvfb start; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y libappindicator1 fonts-liberation; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo dpkg -i google-chrome*.deb; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then echo "--no-sandbox" > ~/.config/chrome-flags.conf; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export CHROME_BIN=chromium-browser; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then echo "--no-sandbox" > ~/.config/chromium-flags.conf; fi
   - if [[ "$TARGET" == "mobile" ]]; then export MOBILE_TEST=true; fi
   - npm install -g npm
   - npm config set spin false

--- a/packages/angular-cli/blueprints/ng2/files/package.json
+++ b/packages/angular-cli/blueprints/ng2/files/package.json
@@ -8,7 +8,7 @@
     "start": "ng serve",
     "lint": "tslint \"<%= sourceDir %>/**/*.ts\"",
     "test": "ng test",
-    "pree2e": "webdriver-manager update",
+    "pree2e": "webdriver-manager update --standalone false --gecko false",
     "e2e": "protractor"
   },
   "private": true,
@@ -39,10 +39,9 @@
     "karma-cli": "^1.0.1",
     "karma-jasmine": "^1.0.2",
     "karma-remap-istanbul": "^0.2.1",
-    "protractor": "4.0.9",
+    "protractor": "~4.0.13",
     "ts-node": "1.2.1",
     "tslint": "^4.0.2",
-    "typescript": "~2.0.3",
-    "webdriver-manager": "10.2.5"
+    "typescript": "~2.0.3"
   }
 }


### PR DESCRIPTION
package.json
- Removed Protractor. `npm test` does not appear to be using Protractor.

packages/angular-cli/blueprints/ng2/files/package.json
- Update to protractor 4.0.13. see [changelog](https://github.com/angular/protractor/blob/master/CHANGELOG.md)
- Remove webdriver-manager as a dependency.  Protractor includes
  webdriver-manager as a dependency.
- Since packages/angular-cli/blueprints/ng2/files/protractor.conf.js uses
  directConnect with chrome, the pree2e step does not need to download
  the selenium standalone server or gecko driver.

updated Travis
- test linux to use chrome per http://blog.500tech.com/setting-up-travis-ci-to-run-tests-on-latest-google-chrome-version/