### PR TITLE
node-uuid -> uuid

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "mkdirp": "^0.5.1",
     "node-modules-path": "^1.0.0",
     "node-sass": "^3.10.1",
-    "node-uuid": "^1.4.3",
+    "uuid": "^3.0.0",
     "nopt": "^3.0.1",
     "npm-run-all": "^3.0.0",
     "offline-plugin": "^3.4.1",

--- a/packages/angular-cli/ember-cli/lib/cli/index.js
+++ b/packages/angular-cli/ember-cli/lib/cli/index.js
@@ -25,7 +25,7 @@ function clientId() {
   if (id) {
     return id;
   } else {
-    id = require('node-uuid').v4().toString();
+    id = require('uuid').v4().toString();
     configStore.set('client-id', id);
     return id;
   }


### PR DESCRIPTION
fixes npm warning: `warning angular-cli > node-uuid@1.4.7: use uuid module instead`
node-uuid is now maintained under uuid.
can find more information on node-uuid being renamed kelektiv/node-uuid#116