### PR TITLE
fix(new): include routing in spec and inline template when called with `--routing`

### DIFF
--- a/packages/angular-cli/blueprints/ng2/files/__path__/app/app.component.spec.ts
+++ b/packages/angular-cli/blueprints/ng2/files/__path__/app/app.component.spec.ts
@@ -14,6 +14,7 @@ describe('AppComponent', () => {
         AppComponent
       ],
     });
+    TestBed.compileComponents();
   });
 
   it('should create the app', async(() => {

--- a/packages/angular-cli/blueprints/ng2/files/__path__/app/app.component.spec.ts
+++ b/packages/angular-cli/blueprints/ng2/files/__path__/app/app.component.spec.ts
@@ -1,11 +1,15 @@
 /* tslint:disable:no-unused-variable */
 
-import { TestBed, async } from '@angular/core/testing';
+import { TestBed, async } from '@angular/core/testing';<% if (routing) { %>
+import { RouterTestingModule } from '@angular/router/testing';<% } %>
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
   beforeEach(() => {
-    TestBed.configureTestingModule({
+    TestBed.configureTestingModule({<% if (routing) { %>
+      imports: [
+        RouterTestingModule
+      ],<% } %>
       declarations: [
         AppComponent
       ],

--- a/packages/angular-cli/blueprints/ng2/files/__path__/app/app.component.ts
+++ b/packages/angular-cli/blueprints/ng2/files/__path__/app/app.component.ts
@@ -6,7 +6,8 @@ import { APP_SHELL_DIRECTIVES } from '@angular/app-shell';<% } %>
   template: `
   <h1>
     {{title}}
-  </h1>
+  </h1><% if (routing) { %>
+  <router-outlet></router-outlet><% } %>
   `,<% } else { %>
   templateUrl: './app.component.html',<% } %><% if (inlineStyle) { %>
   styles: []<% } else { %>

--- a/tests/e2e/tests/commands/new/new-routing.ts
+++ b/tests/e2e/tests/commands/new/new-routing.ts
@@ -1,0 +1,13 @@
+import * as path from 'path';
+import {ng} from '../../../utils/process';
+import {getGlobalVariable} from '../../../utils/env';
+
+export default function() {
+  return Promise.resolve()
+    .then(() => process.chdir(getGlobalVariable('tmp-root')))
+    .then(() => ng('new', 'routing-project', '--routing'))
+    .then(() => process.chdir(path.join('routing-project')))
+
+    // Try to run the unit tests.
+    .then(() => ng('test', '--single-run'));
+}


### PR DESCRIPTION
Closes #3331

This is kind-of missed work from #2794.

In that other PR, we prevented a browser error that happens when a user just runs:

```
ng new sample --routing
cd sample
ng serve
```

This works great now after #2794 was cherry picked.
However, there were 2 missing items:

- `ng test` fails
  Because the `app.component` has `<router-outlet>`, but the test does not import a routing module
- The browser error still comes if you use `--inline-template` with `ng new --routing`
  Because we only fixed `app.component.html`, but not the actual `template` in `app.component.ts`

This PR addresses these 2 issues.

### Tests

<strike>I am really keen to add some tests to this PR. 
Acceptance tests are not applicable here because they only check created files not file content, and I could not find any E2E tests for `ng new` that I could use for inspiration, or I could extend to cover this scenario.</strike>

**Update:** Thanks Hans for guidance. Tests were added.