### PR TITLE
fix(build): don't inline sourcemaps

### DIFF
--- a/packages/angular-cli/models/webpack-build-common.ts
+++ b/packages/angular-cli/models/webpack-build-common.ts
@@ -33,7 +33,7 @@ export function getWebpackCommonConfig(
   if (appConfig.scripts.length > 0) { entry['scripts'] = scripts; }
 
   return {
-    devtool: sourcemap ? 'source-map' : 'eval',
+    devtool: sourcemap ? 'source-map' : false,
     resolve: {
       extensions: ['.ts', '.js'],
       modules: [path.resolve(projectRoot, 'node_modules')]


### PR DESCRIPTION
Don't inline sourcemaps when using `--no-sourcemap` option.

Follow up from https://github.com/angular/angular-cli/pull/3113.