### PR TITLE
chore(readme) Use ng help instead of flag --help

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ npm install -g angular-cli
 ## Usage
 
 ```bash
-ng --help
+ng help
 ```
 
 ### Generating and serving an Angular2 project via a development server

--- a/packages/angular-cli/blueprints/ng2/files/README.md
+++ b/packages/angular-cli/blueprints/ng2/files/README.md
@@ -28,4 +28,4 @@ Run `ng github-pages:deploy` to deploy to Github Pages.
 
 ## Further help
 
-To get more help on the `angular-cli` use `ng --help` or go check out the [Angular-CLI README](https://github.com/angular/angular-cli/blob/master/README.md).
+To get more help on the `angular-cli` use `ng help` or go check out the [Angular-CLI README](https://github.com/angular/angular-cli/blob/master/README.md).


### PR DESCRIPTION
Got the following error using `ng --help`:

```
The specified command --help is invalid. For available options, see `ng help`.
```