### PR TITLE
fix(build): Missing css in CompressionPlugin

### DIFF
--- a/packages/angular-cli/models/webpack-build-production.ts
+++ b/packages/angular-cli/models/webpack-build-production.ts
@@ -63,7 +63,7 @@ export const getWebpackProdConfigPartial = function(projectRoot: string, appConf
       new CompressionPlugin({
           asset: '[path].gz[query]',
           algorithm: 'gzip',
-          test: /\.js$|\.html$/,
+          test: /\.js$|\.html$|\.css$/,
           threshold: 10240,
           minRatio: 0.8
       }),


### PR DESCRIPTION
CompressionPlugin does not compress css as of #2646.

Fixes #3298 