### PR TITLE
chore: update tslint and codelyzer

### DIFF
--- a/packages/angular-cli/blueprints/ng2/files/package.json
+++ b/packages/angular-cli/blueprints/ng2/files/package.json
@@ -37,7 +37,7 @@
     "@types/jasmine": "2.5.38",
     "@types/node": "^6.0.42",
     "angular-cli": "<%= version %>",
-    "codelyzer": "~1.0.0-beta.3",
+    "codelyzer": "~2.0.0-beta.1",
     "jasmine-core": "2.5.2",
     "jasmine-spec-reporter": "2.5.0",
     "karma": "1.2.0",
@@ -47,7 +47,7 @@
     "karma-remap-istanbul": "^0.2.1",
     "protractor": "4.0.9",
     "ts-node": "1.2.1",
-    "tslint": "3.13.0",
+    "tslint": "^4.0.2",
     "typescript": "~2.0.3",
     "webdriver-manager": "10.2.5"
   }

--- a/packages/angular-cli/blueprints/ng2/files/tslint.json
+++ b/packages/angular-cli/blueprints/ng2/files/tslint.json
@@ -16,7 +16,6 @@
       "spaces"
     ],
     "label-position": true,
-    "label-undefined": true,
     "max-line-length": [
       true,
       140
@@ -39,7 +38,6 @@
     ],
     "no-construct": true,
     "no-debugger": true,
-    "no-duplicate-key": true,
     "no-duplicate-variable": true,
     "no-empty": false,
     "no-eval": true,
@@ -49,8 +47,6 @@
     "no-switch-case-fall-through": true,
     "no-trailing-whitespace": true,
     "no-unused-expression": true,
-    "no-unused-variable": true,
-    "no-unreachable": true,
     "no-use-before-declare": true,
     "no-var-keyword": true,
     "object-literal-sort-keys": false,
@@ -93,12 +89,8 @@
       "check-type"
     ],
 
-    "directive-selector-prefix": [true, "<%= prefix %>"],
-    "component-selector-prefix": [true, "<%= prefix %>"],
-    "directive-selector-name": [true, "camelCase"],
-    "component-selector-name": [true, "kebab-case"],
-    "directive-selector-type": [true, "attribute"],
-    "component-selector-type": [true, "element"],
+    "directive-selector": [true, "attribute", "<%= prefix %>", "camelCase"],
+    "component-selector": [true, "element", "<%= prefix %>", "kebab-case"],
     "use-input-property-decorator": true,
     "use-output-property-decorator": true,
     "use-host-property-decorator": true,
@@ -108,6 +100,7 @@
     "use-pipe-transform-interface": true,
     "component-class-suffix": true,
     "directive-class-suffix": true,
+    "no-access-missing-member": true,
     "templates-use-public": true,
     "invoke-injectable": true
   }


### PR DESCRIPTION
1. Update to tslint ^4.0.2.
2. Update to codelyzer 2.0.0-beta.1 which includes external templates & styles support.
3. Drop deprecated tslint rules.
4. Update to the latest rule changes in codelyzer.