### PR TITLE
fix(doc): update search url for documentation

### DIFF
--- a/packages/angular-cli/tasks/doc.ts
+++ b/packages/angular-cli/tasks/doc.ts
@@ -3,7 +3,7 @@ const opn = require('opn');
 
 export const DocTask: any = Task.extend({
   run: function(keyword: string) {
-    const searchUrl = `https://angular.io/docs/ts/latest/api/#!?apiFilter=${keyword}`;
+    const searchUrl = `https://angular.io/docs/ts/latest/api/#!?query=${keyword}`;
     return opn(searchUrl, { wait: false });
   }
 });


### PR DESCRIPTION
Passes wrong query parameter when open documentation.

Fixes #2731