### PR TITLE
chore(docs): fix ng completion command syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,19 +276,19 @@ To turn on auto completion use the following commands:
 
 For bash:
 ```bash
-ng completion 1>> ~/.bashrc 2>>&1
+ng completion 1>> ~/.bashrc 2>&1
 source ~/.bashrc
 ```
 
 For zsh:
 ```bash
-ng completion 1>> ~/.zshrc 2>>&1
+ng completion 1>> ~/.zshrc 2>&1
 source ~/.zshrc
 ```
 
 Windows users using gitbash:
 ```bash
-ng completion 1>> ~/.bash_profile 2>>&1
+ng completion 1>> ~/.bash_profile 2>&1
 source ~/.bash_profile
 ```
 

--- a/packages/angular-cli/utilities/completion.sh
+++ b/packages/angular-cli/utilities/completion.sh
@@ -2,8 +2,8 @@
 #
 # ng command completion script
 #
-# Installation: ng completion 1>> ~/.bashrc 2>>&1
-#           or  ng completion 1>> ~/.zshrc 2>>&1
+# Installation: ng completion 1>> ~/.bashrc 2>&1
+#           or  ng completion 1>> ~/.zshrc 2>&1
 #
 
 ng_opts='b build completion doc e2e g generate get github-pages:deploy gh-pages:deploy h help i init install lint make-this-awesome new s serve server set t test v version -h --help'


### PR DESCRIPTION
Unbreak by using single angle bracket for redirecting sderr to stdout