### PR TITLE
fix(@ngtools/webpack): performance improvement.

### DIFF
--- a/packages/webpack/src/plugin.ts
+++ b/packages/webpack/src/plugin.ts
@@ -160,12 +160,6 @@ export class AotPlugin implements Tapable {
     this._compiler = compiler;
 
     compiler.plugin('context-module-factory', (cmf: any) => {
-      cmf.resolvers.normal.apply(new PathsPlugin({
-        tsConfigPath: this._tsConfigPath,
-        compilerOptions: this._compilerOptions,
-        compilerHost: this._compilerHost
-      }));
-
       cmf.plugin('before-resolve', (request: any, callback: (err?: any, request?: any) => void) => {
         if (!request) {
           return callback();
@@ -209,6 +203,11 @@ export class AotPlugin implements Tapable {
         cb();
       }
     });
+    compiler.resolvers.normal.apply(new PathsPlugin({
+      tsConfigPath: this._tsConfigPath,
+      compilerOptions: this._compilerOptions,
+      compilerHost: this._compilerHost
+    }));
   }
 
   private _make(compilation: any, cb: (err?: any, request?: any) => void) {

--- a/packages/webpack/src/refactor.ts
+++ b/packages/webpack/src/refactor.ts
@@ -172,16 +172,14 @@ export class TypeScriptFileRefactor {
   }
 
   transpile(compilerOptions: ts.CompilerOptions): TranspileOutput {
-    compilerOptions = Object.assign({}, compilerOptions, {
-      sourceMap: true,
-      inlineSources: false,
-      inlineSourceMap: false,
-      sourceRoot: ''
-    });
-
     const source = this.sourceText;
     const result = ts.transpileModule(source, {
-      compilerOptions,
+      compilerOptions: Object.assign({}, compilerOptions, {
+        sourceMap: true,
+        inlineSources: false,
+        inlineSourceMap: false,
+        sourceRoot: ''
+      }),
       fileName: this._fileName
     });
 

--- a/tests/e2e/setup/100-npm-link.ts
+++ b/tests/e2e/setup/100-npm-link.ts
@@ -1,13 +1,15 @@
 import {join} from 'path';
 import {npm, exec} from '../utils/process';
 import {updateJsonFile} from '../utils/project';
+import {getGlobalVariable} from '../utils/env';
 
 const packages = require('../../../lib/packages');
 
 
-export default function (argv: any) {
+export default function () {
   return Promise.resolve()
     .then(() => {
+      const argv = getGlobalVariable('argv');
       if (argv.nolink) {
         return;
       }

--- a/tests/e2e/setup/200-create-tmp-dir.ts
+++ b/tests/e2e/setup/200-create-tmp-dir.ts
@@ -1,9 +1,11 @@
-import {setGlobalVariable} from '../utils/env';
+import {setGlobalVariable, getGlobalVariable} from '../utils/env';
 
 
 const temp = require('temp');
 
-export default function(argv: any) {
+export default function() {
+  const argv = getGlobalVariable('argv');
+
   // Get to a temporary directory.
   let tempRoot = argv.reuse || temp.mkdirSync('angular-cli-e2e-');
   console.log(`  Using "${tempRoot}" as temporary directory for a new project.`);

--- a/tests/e2e/setup/500-create-project.ts
+++ b/tests/e2e/setup/500-create-project.ts
@@ -4,12 +4,14 @@ import {isMobileTest} from '../utils/utils';
 import {expectFileToExist} from '../utils/fs';
 import {updateTsConfig, updateJsonFile} from '../utils/project';
 import {gitClean, gitCommit} from '../utils/git';
+import {getGlobalVariable} from '../utils/env';
 
 
 let packages = require('../../../lib/packages');
 
 
-export default function(argv: any) {
+export default function() {
+  const argv = getGlobalVariable('argv');
   let createProject = null;
 
   // This is a dangerous flag, but is useful for testing packages only.

--- a/tests/e2e/tests/commands/new/new-routing.ts
+++ b/tests/e2e/tests/commands/new/new-routing.ts
@@ -1,12 +1,10 @@
-import * as path from 'path';
 import {ng} from '../../../utils/process';
-import {getGlobalVariable} from '../../../utils/env';
+import {createProject} from '../../../utils/project';
+
 
 export default function() {
   return Promise.resolve()
-    .then(() => process.chdir(getGlobalVariable('tmp-root')))
-    .then(() => ng('new', 'routing-project', '--routing'))
-    .then(() => process.chdir(path.join('routing-project')))
+    .then(() => createProject('routing-project', '--routing'))
 
     // Try to run the unit tests.
     .then(() => ng('test', '--single-run'));

--- a/tests/e2e/tests/misc/lazy-module.ts
+++ b/tests/e2e/tests/misc/lazy-module.ts
@@ -5,7 +5,7 @@ import {ng} from '../../utils/process';
 import {addImportToModule} from '../../utils/ast';
 
 
-export default function(argv: any) {
+export default function() {
   let oldNumberOfFiles = 0;
   return Promise.resolve()
     .then(() => ng('build'))

--- a/tests/e2e/tests/packages/webpack/test.ts
+++ b/tests/e2e/tests/packages/webpack/test.ts
@@ -5,7 +5,7 @@ import {join} from 'path';
 import {expectFileSizeToBeUnder} from '../../../utils/fs';
 
 
-export default function(argv: any, skipCleaning: () => void) {
+export default function(skipCleaning: () => void) {
   if (process.platform.startsWith('win')) {
     // Disable the test on Windows.
     return Promise.resolve();

--- a/tests/e2e/tests/packages/webpack/weird.ts
+++ b/tests/e2e/tests/packages/webpack/weird.ts
@@ -6,7 +6,7 @@ import {expectFileSizeToBeUnder, expectFileToExist} from '../../../utils/fs';
 import {expectToFail} from '../../../utils/utils';
 
 
-export default function(argv: any, skipCleaning: () => void) {
+export default function(skipCleaning: () => void) {
   if (process.platform.startsWith('win')) {
     // Disable the test on Windows.
     return Promise.resolve();

--- a/tests/e2e_runner.js
+++ b/tests/e2e_runner.js
@@ -18,6 +18,8 @@ const green = chalk.green;
 const red = chalk.red;
 const white = chalk.white;
 
+const setGlobalVariable = require('./e2e/utils/env').setGlobalVariable;
+
 
 /**
  * Here's a short description of those flags:
@@ -73,6 +75,8 @@ if (testsToRun.length == allTests.length) {
   console.log(`Running ${testsToRun.length} tests (${allTests.length + allSetups.length} total)`);
 }
 
+setGlobalVariable('argv', argv);
+
 testsToRun.reduce((previous, relativeName) => {
   // Make sure this is a windows compatible path.
   let absoluteName = path.join(e2eRoot, relativeName);
@@ -96,7 +100,7 @@ testsToRun.reduce((previous, relativeName) => {
     return Promise.resolve()
       .then(() => printHeader(currentFileName))
       .then(() => previousDir = process.cwd())
-      .then(() => fn(argv, () => clean = false))
+      .then(() => fn(() => clean = false))
       .then(() => console.log('  ----'))
       .then(() => {
         // If we're not in a setup, change the directory back to where it was before the test.


### PR DESCRIPTION
Bringing it back to 1.1.7 levels. Turns out I was reading files for every require() calls resolving steps. Which is a bad thing.