### PR TITLE
chore(docs): fix typos in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ ng build
 
 You can also add your own env files other than `dev` and `prod` by doing the following:
 - create a `src/environments/environment.NAME.ts`
-- add `{ "NAME": 'src/environments/environment.NAME.ts' }` to the the `apps[0].environments` object in `angular-cli.json`
+- add `{ "NAME": 'src/environments/environment.NAME.ts' }` to the `apps[0].environments` object in `angular-cli.json`
 - use them via the `--env=NAME` flag on the build/serve commands.
 
 ### Base tag handling in index.html
@@ -319,7 +319,7 @@ Angular-CLI supports all major CSS preprocessors:
 - less ([http://lesscss.org/](http://lesscss.org/))
 - stylus ([http://stylus-lang.com/](http://stylus-lang.com/))
 
-To use these prepocessors simply add the file to your component's `styleUrls`:
+To use these preprocessors simply add the file to your component's `styleUrls`:
 
 ```javascript
 @Component({


### PR DESCRIPTION
Fix two typos in the readme.md.

"GitHub" vs "github" is also inconsistent throughout the readme, but I kept that out of this PR.