### PR TITLE
fix(deploy): gh-pages deploy fail after repo create

### DIFF
--- a/packages/angular-cli/commands/github-pages-deploy.ts
+++ b/packages/angular-cli/commands/github-pages-deploy.ts
@@ -216,7 +216,10 @@ const githubPagesDeployCommand = Command.extend({
               files = files.concat(`"${f}" `);
             }
           });
-          return execPromise(`git rm -r ${files}`);
+          return execPromise(`git rm -r ${files}`)
+            .catch(() => {
+              // Ignoring errors when trying to erase files.
+            });
         });
     }
 


### PR DESCRIPTION
Catches the error as they are no files to clean up on repo create.

Closes #3385