### PR TITLE
feat(deploy): add custom-domain support for gh-pages deployment (#1781)

### DIFF
--- a/packages/angular-cli/utilities/completion.sh
+++ b/packages/angular-cli/utilities/completion.sh
@@ -10,7 +10,7 @@ ng_opts='b build completion doc e2e g generate get github-pages:deploy gh-pages:
 
 build_opts='--aot --base-href --environment --output-path --suppress-sizes --target --watch --watcher -bh -dev -e -o -prod -t -w'
 generate_opts='class component directive enum module pipe route service c cl d e m p r s --help'
-github_pages_deploy_opts='--base-href --environment --gh-token --gh-username --message --skip-build --target --user-page -bh -e -t'
+github_pages_deploy_opts='--base-href --environment --gh-token --gh-username --message --skip-build --target --user-page --custom-domain -bh -e -t'
 help_opts='--json --verbose -v'
 init_opts='--dry-run inline-style inline-template --link-cli --mobile --name --prefix --routing --skip-bower --skip-npm --source-dir --style --verbose -d -is -it -lc -n -p -sb -sd -sn -v'
 new_opts='--directory --dry-run inline-style inline-template --link-cli --mobile --prefix --routing --skip-bower --skip-git --skip-npm --source-dir --style --verbose -d -dir -is -it -lc -p -sb -sd -sg -sn -v'


### PR DESCRIPTION
feature for (#1781)

This PR adds the new `--custom-domain` flag to the `github-pages:deploy` command to create a CNAME file to support Github Pages custom domains.

I am looking for some guidance on the testing for this since `github-pages-deploy.spec.js` doesn't contain any logic/acceptance criteria to ensure that certain files are created.  It is only checking 
git related commands and http requests.

Currently the similar method `createNotFoundPage()` is not tested either.  Either way, all tests and linting pass.  I also have some spare domains and tested that Github's DNS picks the CNAME up with a new branch correctly.


