### PR TITLE
feat(deploy): add custom-domain support for gh-pages deployment (#1781)

### DIFF
--- a/packages/angular-cli/commands/github-pages-deploy.run.ts
+++ b/packages/angular-cli/commands/github-pages-deploy.run.ts
@@ -13,6 +13,7 @@ import { GithubPagesDeployOptions } from './github-pages-deploy';
 
 const fsReadDir = <any>denodeify(fs.readdir);
 const fsCopy = <any>denodeify(fse.copy);
+const fsWriteFile = <any>denodeify(fse.writeFile);
 
 export default function githubPagesDeployRun(options: GithubPagesDeployOptions, rawArgs: string[]) {
   const ui = this.ui;
@@ -53,11 +54,15 @@ export default function githubPagesDeployRun(options: GithubPagesDeployOptions, 
 
   /**
    * BaseHref tag setting logic:
-   * First, use --base-href flag value if provided.
+   * First, no value if --custom-domain is provided.
+   * Second, use --base-href flag value if provided.
    * Else if --user-page is true, then keep baseHref default as declared in index.html.
    * Otherwise auto-replace with `/${projectName}/`.
    */
-  const baseHref = options.baseHref || (options.userPage ? null : `/${projectName}/`);
+  let baseHref: String = null;
+  if (!options.customDomain) {
+    baseHref = options.baseHref || (options.userPage ? null : `/${projectName}/`);
+  }
 
   const buildOptions = {
     target: options.target,
@@ -85,6 +90,7 @@ export default function githubPagesDeployRun(options: GithubPagesDeployOptions, 
     .then(cleanGhPagesBranch)
     .then(copyFiles)
     .then(createNotFoundPage)
+    .then(createCustomDomainFile)
     .then(addAndCommit)
     .then(returnStartingBranch)
     .then(pushToGitRepo)
@@ -176,6 +182,15 @@ export default function githubPagesDeployRun(options: GithubPagesDeployOptions, 
     return fsCopy(indexHtml, notFoundPage);
   }
 
+  function createCustomDomainFile() {
+    if (!options.customDomain) {
+      return;
+    }
+
+    const cnameFile = path.join(root, 'CNAME');
+    return fsWriteFile(cnameFile, options.customDomain);
+  }
+
   function addAndCommit() {
     return execPromise('git add .', execOptions)
       .then(() => execPromise(`git commit -m "${options.message}"`))
@@ -203,7 +218,14 @@ export default function githubPagesDeployRun(options: GithubPagesDeployOptions, 
   function printProjectUrl() {
     return getUsernameFromGitOrigin()
         .then((userName) => {
-          let url = `https://${userName}.github.io/${options.userPage ? '' : (baseHref + '/')}`;
+          let url = '';
+
+          if (options.customDomain) {
+            url = `http://${options.customDomain}/`;
+          } else {
+            url = `https://${userName}.github.io/${options.userPage ? '' : (baseHref + '/')}`;
+          }
+
           ui.writeLine(chalk.green(`Deployed! Visit ${url}`));
           ui.writeLine('Github pages might take a few minutes to show the deployed site.');
         });

--- a/packages/angular-cli/commands/github-pages-deploy.ts
+++ b/packages/angular-cli/commands/github-pages-deploy.ts
@@ -10,6 +10,7 @@ export interface GithubPagesDeployOptions {
     ghToken?: string;
     ghUsername?: string;
     baseHref?: string;
+    customDomain?: string;
 }
 
 const githubPagesDeployCommand = Command.extend({
@@ -62,6 +63,12 @@ const githubPagesDeployCommand = Command.extend({
             type: String,
             default: null,
             aliases: ['bh']
+        }, {
+            name: 'custom-domain',
+            type: String,
+            default: null,
+            aliases: ['cd'],
+            description: 'Custom domain for Github Pages'
         }],
 
     run: function(options: GithubPagesDeployOptions, rawArgs: string[]) {

--- a/packages/angular-cli/utilities/completion.sh
+++ b/packages/angular-cli/utilities/completion.sh
@@ -10,7 +10,7 @@ ng_opts='b build completion doc e2e g generate get github-pages:deploy gh-pages:
 
 build_opts='--aot --base-href --environment --i18n-file --i18n-format --locale --output-path --progress --sourcemap --suppress-sizes --target --vendor-chunk --verbose --watch --watcher -bh -dev -e -o -prod -sm -t -w'
 generate_opts='class component directive enum module pipe route service c cl d e m p r s --help'
-github_pages_deploy_opts='--base-href --environment --gh-token --gh-username --message --skip-build --target --user-page -bh -e -t'
+github_pages_deploy_opts='--base-href --environment --gh-token --gh-username --message --skip-build --target --user-page --custom-domain -cd -bh -e -t'
 help_opts='--json --verbose -v'
 init_opts='--dry-run inline-style inline-template --link-cli --mobile --name --prefix --routing --skip-npm --source-dir --style --verbose -d -is -it -lc -n -p -sb -sd -sn -v'
 new_opts='--directory --dry-run inline-style inline-template --link-cli --mobile --prefix --routing --skip-git --skip-npm --source-dir --style --verbose -d -dir -is -it -lc -p -sb -sd -sg -sn -v'


### PR DESCRIPTION
feature for (#1781)

This PR adds the new `--custom-domain` flag to the `github-pages:deploy` command to create a CNAME file to support Github Pages custom domains.

I am looking for some guidance on the testing for this since `github-pages-deploy.spec.js` doesn't contain any logic/acceptance criteria to ensure that certain files are created.  It is only checking 
git related commands and http requests.

Currently the similar method `createNotFoundPage()` is not tested either.  Either way, all tests and linting pass.  I also have some spare domains and tested that Github's DNS picks the CNAME up with a new branch correctly.