### PR TITLE
fix(webpack): fix some problems with errors not reported.

### DIFF
--- a/packages/angular-cli/tasks/build-webpack.ts
+++ b/packages/angular-cli/tasks/build-webpack.ts
@@ -7,6 +7,7 @@ import { NgCliWebpackConfig } from '../models/webpack-config';
 import { getWebpackStatsConfig } from '../models/';
 import { CliConfig } from '../models/config';
 
+
 // Configure build and output;
 let lastHash: any = null;
 
@@ -36,7 +37,9 @@ export default <any>Task.extend({
 
     return new Promise((resolve, reject) => {
       webpackCompiler.run((err: any, stats: any) => {
-        if (err) { return reject(err); }
+        if (err) {
+          return reject(err);
+        }
 
         // Don't keep cache
         // TODO: Make conditional if using --watch
@@ -47,8 +50,18 @@ export default <any>Task.extend({
           process.stdout.write(stats.toString(statsConfig) + '\n');
         }
 
-        return stats.hasErrors() ? reject() : resolve();
+        if (stats.hasErrors()) {
+          reject();
+        } else {
+          resolve();
+        }
       });
+    })
+    .catch((err: Error) => {
+      if (err) {
+        this.ui.writeError('\nAn error occured during the build:\n' + ((err && err.stack) || err));
+      }
+      throw err;
     });
   }
 });

--- a/packages/angular-cli/tasks/serve-webpack.ts
+++ b/packages/angular-cli/tasks/serve-webpack.ts
@@ -115,9 +115,7 @@ export default Task.extend({
 
     const server = new WebpackDevServer(webpackCompiler, webpackDevServerConfiguration);
     return new Promise((resolve, reject) => {
-      server.listen(serveTaskOptions.port,
-                    `${serveTaskOptions.host}`,
-                    function(err: any, stats: any) {
+      server.listen(serveTaskOptions.port, `${serveTaskOptions.host}`, (err: any, stats: any) => {
         if (err) {
           console.error(err.stack || err);
           if (err.details) { console.error(err.details); }


### PR DESCRIPTION
When analyzing the program or generating code AoT, the plugin was sometimes missing errors. On build, nothing was outputted. Now it will show the error encountered before leaving the process.

On serve, hte problem is in webpack-dev-server which does not give us a way to report the error. It seems like webpack-dev-server is not compatible with async plugins, which the @ngtools/webpack is. This is a problem with webpack-dev-server itself.