### PR TITLE
Updated blueprint for git ignore with VS Code

### DIFF
--- a/packages/angular-cli/blueprints/ng2/files/gitignore
+++ b/packages/angular-cli/blueprints/ng2/files/gitignore
@@ -10,12 +10,18 @@
 
 # IDEs and editors
 /.idea
-/.vscode
 .project
 .classpath
 .c9/
 *.launch
 .settings/
+
+# IDE - VSCode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
 
 # misc
 /.sass-cache


### PR DESCRIPTION
https://github.com/github/gitignore/blob/a0df192f5271ad4d35a36c163d768e2db656b9fe/Global/VisualStudioCode.gitignore

Updated the git ignore template for VS Code Editor to not ignore the work-space settings.

Was trying to workout why everyone was having different indentation at work until I realised the default git ignore for vscode is really wrong :(

