### PR TITLE
[chore] improve test fixture

### DIFF
--- a/tests/e2e/setup/010-build.ts
+++ b/tests/e2e/setup/010-build.ts
@@ -24,9 +24,9 @@ export default function() {
             json['devDependencies'] = {};
           }
           if (json['dependencies'] && pkgName in json['dependencies']) {
-            json['dependencies'][pkgName] = packages[pkgName].dist;
+            json['dependencies'][pkgName] = 'file:' + packages[pkgName].dist;
           } else if (json['devDependencies'] && pkgName in json['devDependencies']) {
-            json['devDependencies'][pkgName] = packages[pkgName].dist;
+            json['devDependencies'][pkgName] = 'file:' + packages[pkgName].dist;
           }
         });
       });

--- a/tests/e2e/setup/500-create-project.ts
+++ b/tests/e2e/setup/500-create-project.ts
@@ -19,7 +19,7 @@ export default function() {
   } else if (argv.reuse) {
     // If we're set to reuse an existing project, just chdir to it and clean it.
     createProject = Promise.resolve()
-      .then(() => process.chdir(argv.reuse))
+      .then(() => process.chdir(join(argv.reuse, 'test-project')))
       .then(() => gitClean());
   } else {
     // Otherwise create a project from scratch.

--- a/tests/e2e/setup/500-create-project.ts
+++ b/tests/e2e/setup/500-create-project.ts
@@ -11,7 +11,7 @@ let packages = require('../../../lib/packages').packages;
 
 export default function() {
   const argv = getGlobalVariable('argv');
-  let createProject = null;
+  let createProject: Promise<any> = null;
 
   // This is a dangerous flag, but is useful for testing packages only.
   if (argv.noproject) {
@@ -19,7 +19,10 @@ export default function() {
   } else if (argv.reuse) {
     // If we're set to reuse an existing project, just chdir to it and clean it.
     createProject = Promise.resolve()
-      .then(() => process.chdir(join(argv.reuse, 'test-project')))
+      .then(() => expectFileToExist(join(process.cwd(), 'test-project')))
+      .then(() => Promise.resolve(),
+        () => ng('new', 'test-project', '--skip-install', ...(argv['ng4'] ? ['--ng4'] : [])))
+      .then(() => process.chdir('./test-project'))
       .then(() => gitClean());
   } else {
     // Otherwise create a project from scratch.

--- a/tests/e2e/tests/commands/new/new-routing.ts
+++ b/tests/e2e/tests/commands/new/new-routing.ts
@@ -1,9 +1,14 @@
 import {ng} from '../../../utils/process';
 import {createProject} from '../../../utils/project';
+import {getGlobalVariable} from '../../../utils/env';
+import {join} from 'path';
 
+const denodeify = require('denodeify');
+const rimraf = denodeify(require('rimraf'));
 
 export default function() {
   return Promise.resolve()
+    .then(() => rimraf(join(getGlobalVariable('tmp-root'), 'routing-project')))
     .then(() => createProject('routing-project', '--routing'))
 
     // Try to run the unit tests.

--- a/tests/e2e/utils/utils.ts
+++ b/tests/e2e/utils/utils.ts
@@ -1,5 +1,8 @@
+import {yellow, bold} from 'chalk';
 
 export function expectToFail(fn: () => Promise<any>, errorMessage?: string): Promise<void> {
+  console.log(bold(yellow('This test is expected to fail, Don\'t worry.')));
+
   return fn()
     .then(() => {
       const functionSource = fn.name || (<any>fn).source || fn.toString();

--- a/tools/publish/src/build.ts
+++ b/tools/publish/src/build.ts
@@ -65,7 +65,12 @@ export default function build(packagesToBuild: string[], _opts: any,
     .then(() => logger.info('Deleting dist folder...'))
     .then(() => {
       if (willBuildEverything) {
-        return rimraf(dist);
+        return rimraf(dist + '/**', {
+          glob: {
+            ignore: ['**/node_modules/**'],
+            nodir: true
+          }
+        });
       }
     })
     .then(() => logger.info('Creating schema.d.ts...'))


### PR DESCRIPTION
Here make several improvements for test fixture and develop experience.

1. avoid to delete node_modules folder in dist, as it's very slow every time running e2e tests which will reinstall all dependencies at `npm link`.
2. ~add skip command option to skip some setup step or test cases.~
3. fix the related logic for `reuse` command option, **it changes the previous behavior**.

see the commit messages for more details.