### PR TITLE
fix(blueprints): remove app root barrel

### DIFF
--- a/packages/angular-cli/blueprints/ng2/files/__path__/app/index.ts
+++ b/packages/angular-cli/blueprints/ng2/files/__path__/app/index.ts
@@ -1,2 +1,0 @@
-export * from './app.component';
-export * from './app.module';

--- a/packages/angular-cli/blueprints/ng2/files/__path__/main.ts
+++ b/packages/angular-cli/blueprints/ng2/files/__path__/main.ts
@@ -3,7 +3,7 @@ import './polyfills.ts';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 import { enableProdMode } from '@angular/core';
 import { environment } from './environments/environment';
-import { AppModule } from './app/';
+import { AppModule } from './app/app.module';
 
 if (environment.production) {
   enableProdMode();


### PR DESCRIPTION
BREAKING CHANGES:  The app root module and component must now be imported directly. (e.g., use `import { AppModule } from './app/app.module';` instead of `import { AppModule } from './app/';`).  Existing CLI-based projects will not be affected.

Fixes #3369