### PR TITLE
fix(new): exclude non spec files from test.ts

### DIFF
--- a/packages/angular-cli/blueprints/ng2/files/__path__/test.ts
+++ b/packages/angular-cli/blueprints/ng2/files/__path__/test.ts
@@ -25,7 +25,7 @@ getTestBed().initTestEnvironment(
   platformBrowserDynamicTesting()
 );
 // Then we find all the tests.
-let context = require.context('./', true, /\.spec\.ts/);
+let context = require.context('./', true, /\.spec\.ts$/);
 // And load the modules.
 context.keys().map(context);
 // Finally, start Karma to run the tests.


### PR DESCRIPTION
At the moment if you have a merge conflict, and it leaves you with `blah.spec.ts.orig` files (file used by git for diff checking), you can just add it to gitignore (might add it in another PR), but when you run `ng test` the next time, you get the error:

```
Module parse failed: <SOME_PROJECT_APP_FOLDER_PATH>\blah.spec.ts.orig Unexpected token (xx:xx)
You may need an appropriate loader to handle this file type.
```

This PR excludes these false positives.