### PR TITLE
fix spelling of 'position'

### DIFF
--- a/packages/angular-cli/utilities/get-dependent-files.ts
+++ b/packages/angular-cli/utilities/get-dependent-files.ts
@@ -11,7 +11,7 @@ const globSearch = <any>denodeify(glob);
 
 /**
  * Interface that represents a module specifier and its position in the source file.
- * Use for storing a string literal, start position and end posittion of ImportClause node kinds.
+ * Use for storing a string literal, start position and end position of ImportClause node kinds.
  */
 export interface ModuleImport {
   specifierText: string;


### PR DESCRIPTION
style(utilities): Fix spelling of 'posittion' to 'position'.

Fix spelling of 'posittion' to 'position'.  Might benefit the pedantic.

