### PR TITLE
fix(@ngtools/webpack): keep the decorators in.

### DIFF
--- a/packages/@ngtools/webpack/src/loader.ts
+++ b/packages/@ngtools/webpack/src/loader.ts
@@ -17,9 +17,10 @@ function _getContentOfKeyLiteral(source: ts.SourceFile, node: ts.Node): string {
 }
 
 function _removeDecorators(refactor: TypeScriptFileRefactor) {
+  // TODO: replace this by tsickle.
   // Find all decorators.
-  refactor.findAstNodes(refactor.sourceFile, ts.SyntaxKind.Decorator)
-    .forEach(d => refactor.removeNode(d));
+  // refactor.findAstNodes(refactor.sourceFile, ts.SyntaxKind.Decorator)
+  //   .forEach(d => refactor.removeNode(d));
 }
 
 


### PR DESCRIPTION
This is a temporary fix for people using custom decorators. The AOT size will be larger temporarily, but we are working on an actual fix where we rtemove only Angular decorators.