### PR TITLE
chore(protractor): adjust link to docs in comment

### DIFF
--- a/packages/angular-cli/blueprints/ng2/files/protractor.conf.js
+++ b/packages/angular-cli/blueprints/ng2/files/protractor.conf.js
@@ -1,5 +1,5 @@
 // Protractor configuration file, see link for more information
-// https://github.com/angular/protractor/blob/master/docs/referenceConf.js
+// https://github.com/angular/protractor/blob/master/lib/config.ts
 
 /*global jasmine */
 var SpecReporter = require('jasmine-spec-reporter');


### PR DESCRIPTION
Just a minor thing 😄 (gotta start somewhere 😉). I noticed the link to the protractor reference configuration changed.