### PR TITLE
refactor: remove reflect-metadata as a direct dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "portfinder": "1.0.9",
     "postcss-loader": "^0.9.1",
     "raw-loader": "^0.5.1",
-    "reflect-metadata": "^0.1.8",
     "resolve": "^1.1.7",
     "rimraf": "^2.5.3",
     "rsvp": "^3.0.17",

--- a/packages/@ngtools/webpack/package.json
+++ b/packages/@ngtools/webpack/package.json
@@ -36,7 +36,6 @@
     "@angular/core": "^2.3.1",
     "@angular/tsc-wrapped": "^0.5.0",
     "typescript": "^2.0.2",
-    "reflect-metadata": "^0.1.8",
     "webpack": "2.2.0"
   }
 }

--- a/packages/@ngtools/webpack/src/index.ts
+++ b/packages/@ngtools/webpack/src/index.ts
@@ -1,5 +1,3 @@
-import 'reflect-metadata';
-
 export * from './plugin';
 export {ngcLoader as default} from './loader';
 export {PathsPlugin} from './paths-plugin';

--- a/tests/e2e/assets/webpack/test-app-weird/not/so/source/app/main.jit.ts
+++ b/tests/e2e/assets/webpack/test-app-weird/not/so/source/app/main.jit.ts
@@ -1,4 +1,4 @@
-import 'reflect-metadata';
+import 'core-js/es7/reflect';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 import {AppModule} from './app.module';
 

--- a/tests/e2e/assets/webpack/test-app/app/main.jit.ts
+++ b/tests/e2e/assets/webpack/test-app/app/main.jit.ts
@@ -1,4 +1,4 @@
-import 'reflect-metadata';
+import 'core-js/es7/reflect';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 import {AppModule} from './app.module';
 

--- a/tests/e2e/tests/packages/webpack/weird.ts
+++ b/tests/e2e/tests/packages/webpack/weird.ts
@@ -15,7 +15,7 @@ export default function(skipCleaning: () => void) {
     .then(() => expectFileToExist('dist/0.app.main.js'))
     .then(() => expectFileToExist('dist/1.app.main.js'))
     .then(() => expectFileToExist('dist/2.app.main.js'))
-    .then(() => expectFileSizeToBeUnder('dist/app.main.js', 400000))
+    .then(() => expectFileSizeToBeUnder('dist/app.main.js', 410000))
     .then(() => expectFileSizeToBeUnder('dist/0.app.main.js', 40000))
 
     // Skip code generation and rebuild.
@@ -27,7 +27,7 @@ export default function(skipCleaning: () => void) {
     .then(() => expectFileToExist('dist/0.app.main.js'))
     .then(() => expectFileToExist('dist/1.app.main.js'))
     .then(() => expectFileToExist('dist/2.app.main.js'))
-    .then(() => expectToFail(() => expectFileSizeToBeUnder('dist/app.main.js', 400000)))
+    .then(() => expectToFail(() => expectFileSizeToBeUnder('dist/app.main.js', 410000)))
     .then(() => expectFileSizeToBeUnder('dist/0.app.main.js', 40000))
     .then(() => skipCleaning());
 }


### PR DESCRIPTION
With the use of the private API from `@angular/compiler-cli` and the move to use NodeJS 6.9+, the direct use of `reflect-metadata` is no longer be needed.
Several e2e tests were using it as well.  These were changed to standardize on the `core-js` reflect version instead.  The weird webpack test required a slight adjustment to the file size threshold to account for the small size increase of the polyfill.  The original intent of the test remains intact.