### PR TITLE
fix() Change 'ember help' to 'ng help'

### DIFF
--- a/packages/angular-cli/ember-cli/lib/commands/unknown.js
+++ b/packages/angular-cli/ember-cli/lib/commands/unknown.js
@@ -15,6 +15,6 @@ module.exports = Command.extend({
   validateAndRun: function() {
     throw new SilentError('The specified command ' + this.name +
                           ' is invalid. For available options, see' +
-                          ' `ember help`.');
+                          ' `ng help`.');
   }
 });


### PR DESCRIPTION
An invalid `$ ng <command>` will render the follow error to the terminal:
> The specified command `<command>` is invalid. For available options, see \`ember help`\.

This PR changes `ember help`   to   `ng help`.