### PR TITLE
fix(entry_resolver): search recursively for entry module

### DIFF
--- a/packages/@ngtools/webpack/src/entry_resolver.ts
+++ b/packages/@ngtools/webpack/src/entry_resolver.ts
@@ -130,7 +130,7 @@ export function resolveEntryModuleFromMain(mainPath: string,
                                            program: ts.Program) {
   const source = new TypeScriptFileRefactor(mainPath, host, program);
 
-  const bootstrap = source.findAstNodes(source.sourceFile, ts.SyntaxKind.CallExpression, false)
+  const bootstrap = source.findAstNodes(source.sourceFile, ts.SyntaxKind.CallExpression, true)
     .map(node => node as ts.CallExpression)
     .filter(call => {
       const access = call.expression as ts.PropertyAccessExpression;


### PR DESCRIPTION
The entry module wasn't detected properly when the standard bootstrapping instruction

```javascript
platformBrowserDynamic().bootstrapModule(AppModule);
```

is changed to something like

```javascript
platformBrowserDynamic().bootstrapModule(AppModule).then(() => console.log('...'));
```

Then the CLI doesn't execute the build with the error mentioned in #2887.

AFAIK, the problem was that in the 2nd case, the `bootstrapModule` instruction is nested more deep in the AST wherefore it wasn't found. I changed it to search recursively which fixes the issue.

Fixes #2887 