### PR TITLE
chore(new): prevent generation of .gitignore when using --skip-git

### DIFF
--- a/packages/angular-cli/blueprints/ng2/index.js
+++ b/packages/angular-cli/blueprints/ng2/index.js
@@ -13,7 +13,8 @@ module.exports = {
     { name: 'mobile', type: Boolean, default: false },
     { name: 'routing', type: Boolean, default: false },
     { name: 'inline-style', type: Boolean, default: false, aliases: ['is'] },
-    { name: 'inline-template', type: Boolean, default: false, aliases: ['it'] }
+    { name: 'inline-template', type: Boolean, default: false, aliases: ['it'] },
+    { name: 'skip-git', type: Boolean, default: false, aliases: ['sg'] }
   ],
 
   beforeInstall: function(options) {
@@ -71,6 +72,9 @@ module.exports = {
     }
     if (this.options && this.options.inlineStyle) {
       fileList = fileList.filter(p => p.indexOf('app.component.__styleext__') < 0);
+    }
+    if (this.options && this.options.skipGit) {
+      fileList = fileList.filter(p => p.indexOf('gitignore') < 0);
     }
 
     return fileList;

--- a/packages/angular-cli/commands/init.ts
+++ b/packages/angular-cli/commands/init.ts
@@ -92,7 +92,8 @@ const InitCommand: any = Command.extend({
       routing: commandOptions.routing,
       inlineStyle: commandOptions.inlineStyle,
       inlineTemplate: commandOptions.inlineTemplate,
-      ignoredUpdateFiles: ['favicon.ico']
+      ignoredUpdateFiles: ['favicon.ico'],
+      skipGit: commandOptions.skipGit
     };
 
     if (!validProjectName(packageName)) {


### PR DESCRIPTION
Generating a new project when using `--skip-git` a `.gitignore` file is still created, this PR will prevent that file from being generated hence reducing app clutter.