### PR TITLE
feat(new): include app level import paths for style preprocessors

### DIFF
--- a/packages/angular-cli/lib/config/schema.d.ts
+++ b/packages/angular-cli/lib/config/schema.d.ts
@@ -1,0 +1,94 @@
+export interface CliConfig {
+    /**
+     * The global configuration of the project.
+     */
+    project?: {
+        version?: string;
+        name?: string;
+    };
+    /**
+     * Properties of the different applications in this project.
+     */
+    apps?: {
+        root?: string;
+        outDir?: string;
+        assets?: string | string[];
+        deployUrl?: string;
+        index?: string;
+        main?: string;
+        test?: string;
+        tsconfig?: string;
+        prefix?: string;
+        mobile?: boolean;
+        /**
+         * Global styles to be included in the build.
+         */
+        styles?: (string | {
+            [name: string]: any;
+            input?: string;
+        })[];
+        /**
+         * Global scripts to be included in the build.
+         */
+        scripts?: (string | {
+            [name: string]: any;
+            input?: string;
+        })[];
+        /**
+         * Name and corresponding file for environment config.
+         */
+        environments?: {
+            [name: string]: any;
+        };
+        /**
+         * Options to pass to style loaders in webpack.
+         */
+        webpackStyleLoaderOptions?: {
+            /**
+             * Paths to include. Paths will be resolved to project root.
+             */
+            includePaths?: string[];
+        };
+    }[];
+    /**
+     * Configuration reserved for installed third party addons.
+     */
+    addons?: {
+        [name: string]: any;
+    }[];
+    /**
+     * Configuration reserved for installed third party packages.
+     */
+    packages?: {
+        [name: string]: any;
+    }[];
+    e2e?: {
+        protractor?: {
+            config?: string;
+        };
+    };
+    test?: {
+        karma?: {
+            config?: string;
+        };
+    };
+    defaults?: {
+        styleExt?: string;
+        prefixInterfaces?: boolean;
+        poll?: number;
+        viewEncapsulation?: string;
+        changeDetection?: string;
+        inline?: {
+            style?: boolean;
+            template?: boolean;
+        };
+        spec?: {
+            class?: boolean;
+            component?: boolean;
+            directive?: boolean;
+            module?: boolean;
+            pipe?: boolean;
+            service?: boolean;
+        };
+    };
+}

--- a/packages/angular-cli/lib/config/schema.json
+++ b/packages/angular-cli/lib/config/schema.json
@@ -115,6 +115,21 @@
             "description": "Name and corresponding file for environment config.",
             "type": "object",
             "additionalProperties": true
+          },
+          "webpackStyleLoaderOptions": {
+            "description": "Options to pass to style loaders in webpack.",
+            "type": "object",
+            "properties": {
+              "includePaths": {
+                "description": "Paths to include. Paths will be resolved to project root.",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "default": []
+              }
+            },
+            "additionalProperties": false
           }
         },
         "additionalProperties": false

--- a/packages/angular-cli/models/webpack-build-production.ts
+++ b/packages/angular-cli/models/webpack-build-production.ts
@@ -1,8 +1,6 @@
 import * as path from 'path';
 import * as webpack from 'webpack';
 import {CompressionPlugin} from '../lib/webpack/compression-plugin';
-const autoprefixer = require('autoprefixer');
-const postcssDiscardComments = require('postcss-discard-comments');
 
 declare module 'webpack' {
   export interface LoaderOptionsPlugin {}
@@ -37,22 +35,6 @@ export const getWebpackProdConfigPartial = function(projectRoot: string,
           test: /\.js$|\.html$|\.css$/,
           threshold: 10240
       }),
-      // LoaderOptionsPlugin needs to be fully duplicated because webpackMerge will replace it.
-      new webpack.LoaderOptionsPlugin({
-        test: /\.(css|scss|sass|less|styl)$/,
-        options: {
-          postcss: [
-            autoprefixer(),
-            postcssDiscardComments
-          ],
-          cssLoader: { sourceMap: sourcemap },
-          sassLoader: { sourceMap: sourcemap },
-          lessLoader: { sourceMap: sourcemap },
-          stylusLoader: { sourceMap: sourcemap },
-          // context needed as a workaround https://github.com/jtangelder/sass-loader/issues/285
-          context: projectRoot,
-        }
-      })
     ]
   };
 };

--- a/packages/angular-cli/models/webpack-config.ts
+++ b/packages/angular-cli/models/webpack-config.ts
@@ -35,7 +35,8 @@ export class NgCliWebpackConfig {
     deployUrl?: string,
     outputHashing?: string
   ) {
-    const appConfig = CliConfig.fromProject().config.apps[0];
+    const cliConfig = CliConfig.fromProject().config;
+    const appConfig = cliConfig.apps[0];
     const projectRoot = this.ngCliProject.root;
 
     appConfig.outDir = outputDir || appConfig.outDir;
@@ -45,6 +46,7 @@ export class NgCliWebpackConfig {
       projectRoot,
       environment,
       appConfig,
+      cliConfig,
       baseHref,
       sourcemap,
       vendorChunk,


### PR DESCRIPTION
Fixes #2747 and #3683.

Added a possible solution for sass, less, and I think stylus? (uses `paths` instead of `includePaths`).

Added a new configuration property to apps `webpackStyleLoaderOptions` that only supports one property at the moment `includePaths`.

Sample Config:

```json
      "webpackStyleLoaderOptions": {
        "includePaths": [
          "node_modules",
          "src/global-css-example"
        ]
      }
```

Other notable changes:
Removed the plugin `webpack.LoaderOptionsPlugin` definition in the prod build and added a condition in common for including the css stripping plugin. Seems more DRY.

Updated the schema, but it looks like it generated differently for:

![image](https://cloud.githubusercontent.com/assets/4655972/21462788/2b34584a-c92e-11e6-96b1-98f887dda3a4.png)

Not sure if that's going to be an issue.
