### PR TITLE
Fix(version): allow Angular major version other than 2

### DIFF
--- a/packages/angular-cli/upgrade/version.ts
+++ b/packages/angular-cli/upgrade/version.ts
@@ -105,11 +105,13 @@ export class Version {
       if (v.isLocal()) {
         console.warn(yellow('Using a local version of angular. Proceeding with care...'));
       } else {
-        if (v.major != 2 || ((v.minor == 3 && v.patch == 0) || v.minor < 3)) {
+        if (v.major < 2
+          || (v.major < 2 && v.minor < 3)
+          || (v.major < 2 && v.minor < 3 && v.patch < 1)) {
           console.error(bold(red(stripIndents`
             This version of CLI is only compatible with angular version 2.3.1 or better. Please
             upgrade your angular version, e.g. by running:
-            
+
             npm install @angular/core@latest
           ` + '\n')));
           process.exit(3);
@@ -129,7 +131,7 @@ export class Version {
         It seems like you're using a project generated using an old version of the Angular CLI.
         The latest CLI now uses webpack and has a lot of improvements including a simpler
         workflow, a faster build, and smaller bundles.
-        
+
         To get more info, including a step-by-step guide to upgrade the CLI, follow this link:
         https://github.com/angular/angular-cli/wiki/Upgrading-from-Beta.10-to-Beta.14
       ` + '\n')));


### PR DESCRIPTION
I am not sure if other changes are required, but using angular v4 was blocked because of this strict version check. See this issue: https://github.com/angular/angular-cli/issues/3720