### PR TITLE
chore(lint): bump to tslint 4.2.0 and add a few new rules

### DIFF
--- a/packages/angular-cli/blueprints/ng2/files/package.json
+++ b/packages/angular-cli/blueprints/ng2/files/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "lint": "tslint \"<%= sourceDir %>/**/*.ts\"",
+    "lint": "tslint \"<%= sourceDir %>/**/*.ts\" --project src/tsconfig.json --type-check",
     "test": "ng test",
     "pree2e": "webdriver-manager update --standalone false --gecko false",
     "e2e": "protractor"
@@ -41,7 +41,7 @@
     "karma-remap-istanbul": "^0.2.1",
     "protractor": "~4.0.13",
     "ts-node": "1.2.1",
-    "tslint": "^4.0.2",
+    "tslint": "^4.2.0",
     "typescript": "~2.0.3"
   }
 }

--- a/packages/angular-cli/blueprints/ng2/files/tslint.json
+++ b/packages/angular-cli/blueprints/ng2/files/tslint.json
@@ -3,6 +3,7 @@
     "node_modules/codelyzer"
   ],
   "rules": {
+    "callable-types": true,
     "class-name": true,
     "comment-format": [
       true,
@@ -11,10 +12,12 @@
     "curly": true,
     "eofline": true,
     "forin": true,
+    "import-blacklist": [true, "rxjs"],
     "indent": [
       true,
       "spaces"
     ],
+    "interface-over-type-literal": true,
     "label-position": true,
     "max-line-length": [
       true,
@@ -40,10 +43,13 @@
     "no-debugger": true,
     "no-duplicate-variable": true,
     "no-empty": false,
+    "no-empty-interface": true,
     "no-eval": true,
     "no-inferrable-types": true,
+    "no-inferred-empty-object-type": true,
     "no-shadowed-variable": true,
     "no-string-literal": false,
+    "no-string-throw": true,
     "no-switch-case-fall-through": true,
     "no-trailing-whitespace": true,
     "no-unused-expression": true,
@@ -100,6 +106,7 @@
     "use-pipe-transform-interface": true,
     "component-class-suffix": true,
     "directive-class-suffix": true,
+    "import-destructuring-spacing": true,
     "no-access-missing-member": true,
     "templates-use-public": true,
     "invoke-injectable": true

--- a/packages/angular-cli/models/webpack-build-test.js
+++ b/packages/angular-cli/models/webpack-build-test.js
@@ -58,7 +58,8 @@ const getWebpackTestConfig = function (projectRoot, environment, appConfig, test
         tslint: {
           emitErrors: false,
           failOnHint: false,
-          resourcePath: `./${appConfig.root}`
+          resourcePath: `./${appConfig.root}`,
+          typeCheck: true
         }
       }
     }))


### PR DESCRIPTION
Adds a few rules introduced by tslint [4.1](https://github.com/palantir/tslint/releases/tag/4.1.0) and [4.2](https://github.com/palantir/tslint/releases/tag/4.2.0).

This bumps tslint to `^4.2.0` and activates a few rules in `tslint.json`.
Some of these rules need to have [type info to run](https://github.com/palantir/tslint#type-checking), hence the modification of the `lint` task in `package.json`.

- [callable-types](https://palantir.github.io/tslint/rules/callable-types/)
- [import-blacklist](https://palantir.github.io/tslint/rules/import-blacklist/)
- [interface-over-type-literal](https://palantir.github.io/tslint/rules/interface-over-type-literal/)
- [no-empty-interface](https://palantir.github.io/tslint/rules/no-empty-interface/)
- [no-inferred-empty-object-type](https://palantir.github.io/tslint/rules/no-inferred-empty-object-type/)
- [no-string-throw](https://palantir.github.io/tslint/rules/no-string-throw/)

and a rule for codelyzer:

- import-destructuring-spacing

I'd like to also introduce the [prefer-const](https://palantir.github.io/tslint/rules/prefer-const/) rule, but it's currently [buggy](https://github.com/palantir/tslint/issues/1936).