### PR TITLE
chore: update typescript version for development.

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
   },
   "homepage": "https://github.com/angular/angular-cli",
   "dependencies": {
-    "@angular-cli/ast-tools": "^1.0.0",
     "@angular/compiler": "^2.3.1",
     "@angular/compiler-cli": "^2.3.1",
     "@angular/core": "^2.3.1",

--- a/packages/@angular-cli/ast-tools/src/ast-utils.spec.ts
+++ b/packages/@angular-cli/ast-tools/src/ast-utils.spec.ts
@@ -296,5 +296,5 @@ function getNodesOfKind(kind: ts.SyntaxKind, sourceFile: string) {
 
 function getRootNode(sourceFile: string) {
   return ts.createSourceFile(sourceFile, fs.readFileSync(sourceFile).toString(),
-    ts.ScriptTarget.ES6, true);
+    ts.ScriptTarget.Latest, true);
 }

--- a/packages/@angular-cli/ast-tools/src/ast-utils.ts
+++ b/packages/@angular-cli/ast-tools/src/ast-utils.ts
@@ -29,7 +29,7 @@ import 'rxjs/add/operator/toPromise';
 */
 export function getSource(filePath: string): ts.SourceFile {
   return ts.createSourceFile(filePath, fs.readFileSync(filePath).toString(),
-    ts.ScriptTarget.ES6, true);
+    ts.ScriptTarget.Latest, true);
 }
 
 

--- a/packages/@angular-cli/ast-tools/src/change.ts
+++ b/packages/@angular-cli/ast-tools/src/change.ts
@@ -1,8 +1,8 @@
 import fs = require('fs');
 import denodeify = require('denodeify');
 
-const readFile = (denodeify(fs.readFile) as (...args: any[]) => Promise<string>);
-const writeFile = (denodeify(fs.writeFile) as (...args: any[]) => Promise<string>);
+const readFile = (denodeify(fs.readFile) as (...args: any[]) => Promise<any>);
+const writeFile = (denodeify(fs.writeFile) as (...args: any[]) => Promise<any>);
 
 export interface Host {
   write(path: string, content: string): Promise<void>;

--- a/packages/@angular-cli/ast-tools/src/route-utils.spec.ts
+++ b/packages/@angular-cli/ast-tools/src/route-utils.spec.ts
@@ -7,7 +7,7 @@ import denodeify = require('denodeify');
 import * as _ from 'lodash';
 import {it} from './spec-utils';
 
-const readFile = (denodeify(fs.readFile) as (...args: any[]) => Promise<string>);
+const readFile = (denodeify(fs.readFile) as (...args: any[]) => Promise<any>);
 
 
 describe('route utils', () => {

--- a/packages/@angular-cli/ast-tools/src/route-utils.ts
+++ b/packages/@angular-cli/ast-tools/src/route-utils.ts
@@ -553,5 +553,5 @@ function getValueForKey(objectLiteralNode: ts.Node, key: string) {
  * @param file
  */
 function getRootNode(file: string) {
-  return ts.createSourceFile(file, fs.readFileSync(file).toString(), ts.ScriptTarget.ES6, true);
+  return ts.createSourceFile(file, fs.readFileSync(file).toString(), ts.ScriptTarget.Latest, true);
 }

--- a/packages/angular-cli/commands/get.ts
+++ b/packages/angular-cli/commands/get.ts
@@ -11,7 +11,7 @@ const GetCommand = Command.extend({
   availableOptions: [],
 
   run: function (commandOptions: any, rawArgs: string[]): Promise<void> {
-    return new Promise(resolve => {
+    return new Promise<void>(resolve => {
       const config = CliConfig.fromProject();
       const value = config.get(rawArgs[0]);
 

--- a/packages/angular-cli/commands/set.ts
+++ b/packages/angular-cli/commands/set.ts
@@ -29,7 +29,7 @@ const SetCommand = Command.extend({
   },
 
   run: function (commandOptions: any, rawArgs: string[]): Promise<void> {
-    return new Promise(resolve => {
+    return new Promise<void>(resolve => {
       const [jsonPath, rawValue] = rawArgs;
       const config = CliConfig.fromProject();
       const type = config.typeOf(jsonPath);

--- a/packages/angular-cli/utilities/get-dependent-files.ts
+++ b/packages/angular-cli/utilities/get-dependent-files.ts
@@ -32,7 +32,7 @@ export interface ModuleMap {
 export function createTsSourceFile(fileName: string): Promise<ts.SourceFile> {
   return readFile(fileName, 'utf8')
     .then((contents: string) => {
-      return ts.createSourceFile(fileName, contents, ts.ScriptTarget.ES6, true);
+      return ts.createSourceFile(fileName, contents, ts.ScriptTarget.Latest, true);
     });
 }
 


### PR DESCRIPTION
We still support typescript >= 2.0, but this allows us to build using TS 2.1. It's a first step towards moving the repo to 2.1; next step is making sure our `d.ts` is backward compatible..