### PR TITLE
fix(command options): allow to use camelCase for options.

### DIFF
--- a/packages/@angular/cli/ember-cli/lib/models/command.js
+++ b/packages/@angular/cli/ember-cli/lib/models/command.js
@@ -183,6 +183,7 @@ Command.prototype.mergeDuplicateOption = function(key) {
 */
 Command.prototype.normalizeOption = function(option) {
   option.key = camelize(option.name);
+  option.aliases = (option.aliases || []).concat(camelize(option.name));
   option.required = option.required || false;
   return option;
 };

--- a/tests/e2e/tests/build/aot/aot-i18n.ts
+++ b/tests/e2e/tests/build/aot/aot-i18n.ts
@@ -22,6 +22,8 @@ export default function() {
       '<h1 i18n="An introduction header for this sample">Hello i18n!</h1>'))
     .then(() => ng('build', '--aot', '--i18n-file', 'src/locale/messages.fr.xlf', '--i18n-format',
       'xlf', '--locale', 'fr'))
+    .then(() => ng('build', '--aot', '--i18nFile', 'src/locale/messages.fr.xlf', '--i18nFormat',
+      'xlf', '--locale', 'fr'))
     .then(() => expectFileToMatch('dist/main.bundle.js', /Bonjour i18n!/))
     .then(() => ng('build', '--aot'))
     .then(() => expectToFail(() => expectFileToMatch('dist/main.bundle.js', /Bonjour i18n!/)))


### PR DESCRIPTION
Previously this resulted in weird behaviour, now we automatically add an alias for the camelize version of the flag name.

Fixes #3625.