### PR TITLE
fix: remove tslint rule that requires type info

### DIFF
--- a/packages/angular-cli/blueprints/ng2/files/tslint.json
+++ b/packages/angular-cli/blueprints/ng2/files/tslint.json
@@ -46,7 +46,6 @@
     "no-empty-interface": true,
     "no-eval": true,
     "no-inferrable-types": true,
-    "no-inferred-empty-object-type": true,
     "no-shadowed-variable": true,
     "no-string-literal": false,
     "no-string-throw": true,


### PR DESCRIPTION
tslint rules that require type info can cause problems in editors (vscode in particular).  See https://github.com/Microsoft/vscode-tslint/issues/70