### PR TITLE
chore(readme): fix path in CSS Preprocessor

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,8 +328,8 @@ To use these preprocessors simply add the file to your component's `styleUrls`:
 ```javascript
 @Component({
   selector: 'app-root',
-  templateUrl: 'app.component.html',
-  styleUrls: ['app.component.scss']
+  templateUrl: './app.component.html',
+  styleUrls: ['./app.component.scss']
 })
 export class AppComponent {
   title = 'app works!';


### PR DESCRIPTION
current README says

```javascript 
@Component({
  selector: 'app-root',
  templateUrl: 'app.component.html',
  styleUrls: ['app.component.scss']
})
```
this code causes `Module not found: Error: Can't resolve`.

I updated README to use `./app.component.html` and `./app.component.scss`.