### PR TITLE
fix(test): fix tsconfig paths resolver

### DIFF
--- a/packages/@ngtools/webpack/src/paths-plugin.ts
+++ b/packages/@ngtools/webpack/src/paths-plugin.ts
@@ -54,7 +54,7 @@ export class PathsPlugin implements Tapable {
     if (tsConfig.error) {
       throw tsConfig.error;
     }
-    return tsConfig.config;
+    return tsConfig.config.compilerOptions;
   }
 
   constructor(options: PathsPluginOptions) {
@@ -110,7 +110,7 @@ export class PathsPlugin implements Tapable {
   }
 
   apply(resolver: ResolverPlugin): void {
-    let { baseUrl } = this._compilerOptions;
+    let baseUrl = this._compilerOptions.baseUrl || '.';
 
     if (baseUrl) {
       resolver.apply(new ModulesInRootPlugin('module', this._absoluteBaseUrl, 'resolve'));


### PR DESCRIPTION
Fixes #3586

There were two issues with this:
- Someone missed `compilerOptions` property when reading `tsconfig.json`;
- Dunno why and what it does but `resolver.apply(new ModulesInRootPlugin('module', this._absoluteBaseUrl, 'resolve'))` is needed when running tests. Temporary I've added [` || '.'`](https://github.com/angular/angular-cli/blob/da0c09fe25b5aeaae65af39cd28a083aff14c73a/packages/%40ngtools/webpack/src/paths-plugin.ts#L113) to solve the issue. But then the following `if (baseUrl)` clause doesn't make sense. So tell me how it should be and I'll change that.