### PR TITLE
fix(config): allow minimal config for build/serve

### DIFF
--- a/packages/angular-cli/lib/config/schema.json
+++ b/packages/angular-cli/lib/config/schema.json
@@ -59,7 +59,8 @@
             "type": "string"
           },
           "tsconfig": {
-            "type": "string"
+            "type": "string",
+            "default": "tsconfig.json"
           },
           "prefix": {
             "type": "string"

--- a/packages/angular-cli/models/json-schema/schema-tree.ts
+++ b/packages/angular-cli/models/json-schema/schema-tree.ts
@@ -134,9 +134,11 @@ export abstract class NonLeafSchemaTreeNode<T> extends SchemaTreeNode<T> {
     if (!schema['oneOf']) {
       type = schema['type'];
     } else {
+      let testValue = value || schema['default'];
+      // Match existing value to one of the schema types
       for (let testSchema of schema['oneOf']) {
-        if ((testSchema['type'] === 'array' && Array.isArray(value))
-            || typeof value === testSchema['type']) {
+        if ((testSchema['type'] === 'array' && Array.isArray(testValue))
+            || typeof testValue === testSchema['type']) {
           type = testSchema['type'];
           schema = testSchema;
           break;

--- a/packages/angular-cli/models/webpack-build-typescript.ts
+++ b/packages/angular-cli/models/webpack-build-typescript.ts
@@ -9,6 +9,8 @@ const webpackLoader: string = g['angularCliIsLocal']
 
 
 export const getWebpackNonAotConfigPartial = function(projectRoot: string, appConfig: any) {
+  let exclude = [ '**/*.spec.ts' ];
+  if (appConfig.test) { exclude.push(path.join(projectRoot, appConfig.root, appConfig.test)); };
   return {
     module: {
       rules: [
@@ -23,10 +25,7 @@ export const getWebpackNonAotConfigPartial = function(projectRoot: string, appCo
       new AotPlugin({
         tsConfigPath: path.resolve(projectRoot, appConfig.root, appConfig.tsconfig),
         mainPath: path.join(projectRoot, appConfig.root, appConfig.main),
-        exclude: [
-          path.join(projectRoot, appConfig.root, appConfig.test),
-          '**/*.spec.ts'
-        ],
+        exclude: exclude,
         skipCodeGeneration: true
       }),
     ]
@@ -35,6 +34,8 @@ export const getWebpackNonAotConfigPartial = function(projectRoot: string, appCo
 
 export const getWebpackAotConfigPartial = function(projectRoot: string, appConfig: any,
   i18nFile: string, i18nFormat: string, locale: string) {
+  let exclude = [ '**/*.spec.ts' ];
+  if (appConfig.test) { exclude.push(path.join(projectRoot, appConfig.root, appConfig.test)); };
   return {
     module: {
       rules: [
@@ -52,10 +53,7 @@ export const getWebpackAotConfigPartial = function(projectRoot: string, appConfi
         i18nFile: i18nFile,
         i18nFormat: i18nFormat,
         locale: locale,
-        exclude: [
-          path.join(projectRoot, appConfig.root, appConfig.test),
-          '**/*.spec.ts'
-        ]
+        exclude: exclude
       })
     ]
   };

--- a/packages/angular-cli/tasks/serve-webpack.ts
+++ b/packages/angular-cli/tasks/serve-webpack.ts
@@ -98,7 +98,8 @@ export default Task.extend({
       proxy: proxyConfig,
       compress: serveTaskOptions.target === 'production',
       watchOptions: {
-        poll: CliConfig.fromProject().config.defaults.poll
+        poll: CliConfig.fromProject().config.defaults &&
+          CliConfig.fromProject().config.defaults.poll
       },
       https: serveTaskOptions.ssl
     };

--- a/tests/e2e/tests/misc/minimal-config.ts
+++ b/tests/e2e/tests/misc/minimal-config.ts
@@ -1,0 +1,14 @@
+import { writeFile } from '../../utils/fs';
+import { ng } from '../../utils/process';
+
+
+export default function () {
+  return Promise.resolve()
+    .then(() => writeFile('angular-cli.json', JSON.stringify({
+      apps: [{
+        root: 'src',
+        main: 'main.ts'
+      }]
+    })))
+    .then(() => ng('build'));
+}


### PR DESCRIPTION
This PR fixes a lot of errors that would show up when `angular-cli.json` was missing some entries.

A config as small as the following now works for `ng build/serve`:

```
{
  "apps": [
    {
      "root": "src",
      "main": "main.ts"
    }
  ]
}
```

In future PRs we should verify the rest of the commands work correctly with minimal configs (i.e. throw correct errors instead of just dying because of an undefined).