### PR TITLE
feat(webpack): support merging loader options

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "walk-sync": "^0.2.6",
     "webpack": "2.2.0-rc.3",
     "webpack-dev-server": "2.2.0-rc.0",
-    "webpack-merge": "^0.14.0",
+    "webpack-merge": "^2.1.0",
     "webpack-sources": "^0.1.3",
     "yam": "0.0.18",
     "zone.js": "^0.7.2"

--- a/packages/angular-cli/models/webpack-build-common.ts
+++ b/packages/angular-cli/models/webpack-build-common.ts
@@ -173,7 +173,6 @@ export function getWebpackCommonConfig(
         name: 'inline'
       }),
       new webpack.LoaderOptionsPlugin({
-        test: /\.(css|scss|sass|less|styl)$/,
         options: {
           postcss: [autoprefixer()],
           cssLoader: { sourceMap: sourcemap },

--- a/packages/angular-cli/models/webpack-build-production.ts
+++ b/packages/angular-cli/models/webpack-build-production.ts
@@ -2,7 +2,6 @@ import * as path from 'path';
 import * as webpack from 'webpack';
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 import {CompressionPlugin} from '../lib/webpack/compression-plugin';
-const autoprefixer = require('autoprefixer');
 const postcssDiscardComments = require('postcss-discard-comments');
 
 declare module 'webpack' {
@@ -32,7 +31,6 @@ export const getWebpackProdConfigPartial = function(projectRoot: string,
       new webpack.DefinePlugin({
         'process.env.NODE_ENV': JSON.stringify('production')
       }),
-      new webpack.LoaderOptionsPlugin({ minimize: true }),
       new webpack.optimize.UglifyJsPlugin(<any>{
         mangle: { screw_ie8 : true },
         compress: { screw_ie8: true, warnings: verbose },
@@ -44,20 +42,12 @@ export const getWebpackProdConfigPartial = function(projectRoot: string,
           test: /\.js$|\.html$|\.css$/,
           threshold: 10240
       }),
-      // LoaderOptionsPlugin needs to be fully duplicated because webpackMerge will replace it.
       new webpack.LoaderOptionsPlugin({
-        test: /\.(css|scss|sass|less|styl)$/,
+        minimize: true,
         options: {
           postcss: [
-            autoprefixer(),
             postcssDiscardComments
-          ],
-          cssLoader: { sourceMap: sourcemap },
-          sassLoader: { sourceMap: sourcemap },
-          lessLoader: { sourceMap: sourcemap },
-          stylusLoader: { sourceMap: sourcemap },
-          // context needed as a workaround https://github.com/jtangelder/sass-loader/issues/285
-          context: projectRoot,
+          ]
         }
       })
     ]

--- a/packages/angular-cli/models/webpack-config.ts
+++ b/packages/angular-cli/models/webpack-config.ts
@@ -40,6 +40,8 @@ export class NgCliWebpackConfig {
     appConfig.outDir = outputDir || appConfig.outDir;
     appConfig.deployUrl = deployUrl || appConfig.deployUrl;
 
+    const merge = webpackMerge.smartStrategy({}, ['LoaderOptionsPlugin']);
+
     let baseConfig = getWebpackCommonConfig(
       this.ngCliProject.root,
       environment,
@@ -61,13 +63,13 @@ export class NgCliWebpackConfig {
       let mobileConfigPartial = getWebpackMobileConfigPartial(this.ngCliProject.root, appConfig);
       let mobileProdConfigPartial = getWebpackMobileProdConfigPartial(this.ngCliProject.root,
                                                                       appConfig);
-      baseConfig = webpackMerge(baseConfig, mobileConfigPartial);
+      baseConfig = merge(baseConfig, mobileConfigPartial);
       if (this.target == 'production') {
-        targetConfigPartial = webpackMerge(targetConfigPartial, mobileProdConfigPartial);
+        targetConfigPartial = merge(targetConfigPartial, mobileProdConfigPartial);
       }
     }
 
-    this.config = webpackMerge(
+    this.config = merge(
       baseConfig,
       targetConfigPartial,
       typescriptConfigPartial

--- a/packages/angular-cli/package.json
+++ b/packages/angular-cli/package.json
@@ -97,7 +97,7 @@
     "walk-sync": "^0.2.6",
     "webpack": "2.2.0-rc.3",
     "webpack-dev-server": "2.2.0-rc.0",
-    "webpack-merge": "^0.14.0",
+    "webpack-merge": "^2.1.0",
     "webpack-sources": "^0.1.3",
     "yam": "0.0.18",
     "zone.js": "^0.7.2"


### PR DESCRIPTION
This simplifies and removes the redundancy in the production webpack config.