### PR TITLE
feat(build): add ability to disable webpack's cache busting mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,14 @@ ng build --base-href /myUrl/
 ng build --bh /myUrl/
 ```
 
+### Disable cache busting
+
+You can disable webpack's caching mechanism in prod build with the `--disable-cache-bust` / `-dcb` flag.
+
+```bash
+ng build -dcb
+```
+
 ### Bundling
 
 All builds make use of bundling, and using the `--prod` flag in  `ng build --prod`

--- a/packages/angular-cli/commands/build.ts
+++ b/packages/angular-cli/commands/build.ts
@@ -17,6 +17,7 @@ export interface BuildOptions {
   i18nFormat?: string;
   locale?: string;
   deployUrl?: string;
+  disableCacheBust?: boolean;
 }
 
 const BuildCommand = Command.extend({
@@ -45,7 +46,9 @@ const BuildCommand = Command.extend({
     { name: 'i18n-file',      type: String, default: null },
     { name: 'i18n-format',    type: String, default: null },
     { name: 'locale',         type: String, default: null },
-    { name: 'deploy-url',     type: String,  default: null, aliases: ['d'] }
+    { name: 'deploy-url',     type: String,  default: null, aliases: ['d'] },
+    { name: 'disable-cache-bust', type: Boolean, default: false, aliases: ['dcb'],
+      description: 'Disable webpack\'s caching mechanism.' }
   ],
 
   run: function (commandOptions: BuildOptions) {

--- a/packages/angular-cli/models/webpack-build-production.ts
+++ b/packages/angular-cli/models/webpack-build-production.ts
@@ -18,17 +18,18 @@ declare module 'webpack' {
 export const getWebpackProdConfigPartial = function(projectRoot: string,
                                                     appConfig: any,
                                                     sourcemap: boolean,
-                                                    verbose: any) {
+                                                    verbose: any,
+                                                    disableCacheBust: boolean) {
   const appRoot = path.resolve(projectRoot, appConfig.root);
 
   return {
     output: {
-      filename: '[name].[chunkhash].bundle.js',
-      sourceMapFilename: '[name].[chunkhash].bundle.map',
-      chunkFilename: '[id].[chunkhash].chunk.js'
+      filename: disableCacheBust ? '[name].bundle.js' : '[name].[chunkhash].bundle.js',
+      sourceMapFilename: disableCacheBust ? '[name].bundle.map' : '[name].[chunkhash].bundle.map',
+      chunkFilename: disableCacheBust ? '[id].chunk.js' : '[id].[chunkhash].chunk.js'
     },
     plugins: [
-      new ExtractTextPlugin('[name].[chunkhash].bundle.css'),
+      new ExtractTextPlugin(disableCacheBust ? '[name].bundle.css' : '[name].[chunkhash].bundle.css'),
       new webpack.DefinePlugin({
         'process.env.NODE_ENV': JSON.stringify('production')
       }),

--- a/packages/angular-cli/models/webpack-config.ts
+++ b/packages/angular-cli/models/webpack-config.ts
@@ -32,7 +32,8 @@ export class NgCliWebpackConfig {
     vendorChunk = false,
     verbose = false,
     progress = true,
-    deployUrl?: string
+    deployUrl?: string,
+    disableCacheBust = false
   ) {
     const config: CliConfig = CliConfig.fromProject();
     const appConfig = config.config.apps[0];
@@ -51,7 +52,7 @@ export class NgCliWebpackConfig {
       progress
     );
     let targetConfigPartial = this.getTargetConfig(
-      this.ngCliProject.root, appConfig, sourcemap, verbose
+      this.ngCliProject.root, appConfig, sourcemap, verbose, disableCacheBust
     );
     const typescriptConfigPartial = isAoT
       ? getWebpackAotConfigPartial(this.ngCliProject.root, appConfig, i18nFile, i18nFormat, locale)
@@ -74,12 +75,12 @@ export class NgCliWebpackConfig {
     );
   }
 
-  getTargetConfig(projectRoot: string, appConfig: any, sourcemap: boolean, verbose: boolean): any {
+  getTargetConfig(projectRoot: string, appConfig: any, sourcemap: boolean, verbose: boolean, disableCacheBust: boolean): any {
     switch (this.target) {
       case 'development':
         return getWebpackDevConfigPartial(projectRoot, appConfig);
       case 'production':
-        return getWebpackProdConfigPartial(projectRoot, appConfig, sourcemap, verbose);
+        return getWebpackProdConfigPartial(projectRoot, appConfig, sourcemap, verbose, disableCacheBust);
       default:
         throw new Error("Invalid build target. Only 'development' and 'production' are available.");
     }

--- a/packages/angular-cli/tasks/build-webpack.ts
+++ b/packages/angular-cli/tasks/build-webpack.ts
@@ -34,7 +34,8 @@ export default <any>Task.extend({
       runTaskOptions.vendorChunk,
       runTaskOptions.verbose,
       runTaskOptions.progress,
-      deployUrl
+      deployUrl,
+      runTaskOptions.disableCacheBust
     ).config;
 
     const webpackCompiler: any = webpack(config);


### PR DESCRIPTION
Optionally disable webpack's caching mechanism with the `-dcb` flag. 

Usecase: You want to solve cache busting of the generated bundles with a different strategy.

closes https://github.com/angular/angular-cli/issues/3853