### PR TITLE
fix(command options): throw an error on invalid argument.

### DIFF
--- a/packages/angular-cli/commands/completion.ts
+++ b/packages/angular-cli/commands/completion.ts
@@ -7,7 +7,7 @@ const CompletionCommand = Command.extend({
   name: 'completion',
   description: 'Adds autocomplete functionality to `ng` commands and subcommands',
   works: 'everywhere',
-  run: function() {
+  run: function(options: any, rawArgs: any[]) {
     const scriptPath = path.resolve(__dirname, '..', 'utilities', 'completion.sh');
     const scriptOutput = fs.readFileSync(scriptPath, 'utf8');
 

--- a/packages/angular-cli/commands/new.ts
+++ b/packages/angular-cli/commands/new.ts
@@ -13,6 +13,10 @@ const NewCommand = Command.extend({
   description: `Creates a new directory and runs ${chalk.green('ng init')} in it.`,
   works: 'outsideProject',
 
+  anonymousOptions: [
+    '<project-name>'
+  ],
+
   availableOptions: [
     { name: 'dry-run', type: Boolean, default: false, aliases: ['d'] },
     { name: 'verbose', type: Boolean, default: false, aliases: ['v'] },
@@ -31,6 +35,12 @@ const NewCommand = Command.extend({
   ],
 
   run: function (commandOptions: any, rawArgs: string[]) {
+    if (rawArgs.length != 1) {
+      throw new SilentError(oneLine`
+        The ${this.name} command expected 1 arguments, received ${rawArgs.length}.
+      `);
+    }
+
     const packageName = rawArgs.shift();
 
     if (!packageName) {

--- a/packages/angular-cli/ember-cli/lib/models/command.js
+++ b/packages/angular-cli/ember-cli/lib/models/command.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var oneLine             = require('common-tags').oneLine;
 var nopt                = require('nopt');
 var chalk               = require('chalk');
 var path                = require('path');
@@ -137,6 +138,13 @@ Command.prototype.validateAndRun = function(args) {
     if (!this.project.hasDependencies()) {
       throw new SilentError('node_modules appears empty, you may need to run `npm install`');
     }
+  }
+
+  if (commandOptions.args.length > this.anonymousOptions.length) {
+    throw new SilentError(oneLine`
+        The ${this.name} command expected at most ${this.anonymousOptions.length} arguments, 
+        received ${commandOptions.args.length}.
+      `);
   }
 
   return Watcher.detectWatcher(this.ui, commandOptions.options).then(function(options) {


### PR DESCRIPTION
When the amount of anonymous arguments is over the amount of expected ones, throw an error. The most common case would be something like "ng build prod" when the user actually means "ng build -prod".

Fix #5935