### PR TITLE
Updating misleading build target documentation

### DIFF
--- a/docs/documentation/build.md
+++ b/docs/documentation/build.md
@@ -4,7 +4,7 @@
 `ng build` compiles the application into an output directory
 
 ## Options
-`--target` (`-t`, `-dev`, `prod`) define the build target
+`--target` (`-t`, `-dev`, `-prod`) define the build target
 
 `--environment` (`-e`)
 

--- a/docs/documentation/build.md
+++ b/docs/documentation/build.md
@@ -4,9 +4,25 @@
 `ng build` compiles the application into an output directory
 
 ## Options
-`--target` (`-t`, `-dev`, `-prod`) define the build target
+`--target` (`-t`) define the build target
 
-`--environment` (`-e`)
+`--environment` (`-e`) defines the build environment
+
+`--prod` flag to set build target and environment to production
+
+`--dev` flag to set build target and environment to development
+
+```bash
+# these are equivalent
+--target=production --environment=prod
+--prod --env=prod
+--prod
+# and so are these
+--target=development --environment=dev
+--dev --e=dev
+--dev
+ng build
+```
 
 `--output-path` (`-o`) path where output will be placed
 


### PR DESCRIPTION
The old build documentation stated that prod was a valid target command which is incorrect.

The working and valid production commands are:

--prod
-prod

Not:
prod