### PR TITLE
chore(lint): bump to tslint 4.3.0 and add a few new rules

### DIFF
--- a/packages/angular-cli/blueprints/directive/files/__path__/__name__.directive.spec.ts
+++ b/packages/angular-cli/blueprints/directive/files/__path__/__name__.directive.spec.ts
@@ -5,7 +5,7 @@ import { <%= classifiedModuleName %>Directive } from './<%= dasherizedModuleName
 
 describe('<%= classifiedModuleName %>Directive', () => {
   it('should create an instance', () => {
-    let directive = new <%= classifiedModuleName %>Directive();
+    const directive = new <%= classifiedModuleName %>Directive();
     expect(directive).toBeTruthy();
   });
 });

--- a/packages/angular-cli/blueprints/ng2/files/__path__/app/app.component.spec.ts
+++ b/packages/angular-cli/blueprints/ng2/files/__path__/app/app.component.spec.ts
@@ -18,21 +18,21 @@ describe('AppComponent', () => {
   });
 
   it('should create the app', async(() => {
-    let fixture = TestBed.createComponent(AppComponent);
-    let app = fixture.debugElement.componentInstance;
+    const fixture = TestBed.createComponent(AppComponent);
+    const app = fixture.debugElement.componentInstance;
     expect(app).toBeTruthy();
   }));
 
   it(`should have as title '<%= prefix %> works!'`, async(() => {
-    let fixture = TestBed.createComponent(AppComponent);
-    let app = fixture.debugElement.componentInstance;
+    const fixture = TestBed.createComponent(AppComponent);
+    const app = fixture.debugElement.componentInstance;
     expect(app.title).toEqual('<%= prefix %> works!');
   }));
 
   it('should render title in a h1 tag', async(() => {
-    let fixture = TestBed.createComponent(AppComponent);
+    const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
-    let compiled = fixture.debugElement.nativeElement;
+    const compiled = fixture.debugElement.nativeElement;
     expect(compiled.querySelector('h1').textContent).toContain('<%= prefix %> works!');
   }));
 });

--- a/packages/angular-cli/blueprints/ng2/files/__path__/test.ts
+++ b/packages/angular-cli/blueprints/ng2/files/__path__/test.ts
@@ -25,7 +25,7 @@ getTestBed().initTestEnvironment(
   platformBrowserDynamicTesting()
 );
 // Then we find all the tests.
-let context = require.context('./', true, /\.spec\.ts$/);
+const context = require.context('./', true, /\.spec\.ts$/);
 // And load the modules.
 context.keys().map(context);
 // Finally, start Karma to run the tests.

--- a/packages/angular-cli/blueprints/ng2/files/package.json
+++ b/packages/angular-cli/blueprints/ng2/files/package.json
@@ -41,7 +41,7 @@
     "karma-remap-istanbul": "^0.2.1",
     "protractor": "~4.0.13",
     "ts-node": "1.2.1",
-    "tslint": "^4.2.0",
+    "tslint": "^4.3.0",
     "typescript": "~2.0.3"
   }
 }

--- a/packages/angular-cli/blueprints/ng2/files/tslint.json
+++ b/packages/angular-cli/blueprints/ng2/files/tslint.json
@@ -13,6 +13,7 @@
     "eofline": true,
     "forin": true,
     "import-blacklist": [true, "rxjs"],
+    "import-spacing": true,
     "indent": [
       true,
       "spaces"
@@ -62,6 +63,7 @@
       "check-else",
       "check-whitespace"
     ],
+    "prefer-const": true,
     "quotemark": [
       true,
       "single"
@@ -84,6 +86,8 @@
         "variable-declaration": "nospace"
       }
     ],
+    "typeof-compare": true,
+    "unified-signatures": true,
     "variable-name": false,
     "whitespace": [
       true,
@@ -105,7 +109,6 @@
     "use-pipe-transform-interface": true,
     "component-class-suffix": true,
     "directive-class-suffix": true,
-    "import-destructuring-spacing": true,
     "no-access-missing-member": true,
     "templates-use-public": true,
     "invoke-injectable": true

--- a/packages/angular-cli/blueprints/pipe/files/__path__/__name__.pipe.spec.ts
+++ b/packages/angular-cli/blueprints/pipe/files/__path__/__name__.pipe.spec.ts
@@ -5,7 +5,7 @@ import { <%= classifiedModuleName %>Pipe } from './<%= dasherizedModuleName %>.p
 
 describe('<%= classifiedModuleName %>Pipe', () => {
   it('create an instance', () => {
-    let pipe = new <%= classifiedModuleName %>Pipe();
+    const pipe = new <%= classifiedModuleName %>Pipe();
     expect(pipe).toBeTruthy();
   });
 });


### PR DESCRIPTION
Adds a few rules introduced or fixed by tslint 4.3

- [import-spacing](https://palantir.github.io/tslint/rules/import-spacing/)
- [unified-signature](https://palantir.github.io/tslint/rules/unified-signatures/)
- [prefer-const](https://palantir.github.io/tslint/rules/prefer-const/)
- [typeof-compare](https://palantir.github.io/tslint/rules/typeof-compare/)

and removes a rule for codelyzer (now handled by tslint directly):

- import-destructuring-spacing

Fixes `test.ts` to use `const` instead of `let`.