### PR TITLE
feat(build): Make __GITVERSION__ available to source

### DIFF
--- a/docs/documentation/build.md
+++ b/docs/documentation/build.md
@@ -33,3 +33,11 @@ ng build
 `--base-href` (`-bh`) base url for the application being built
 
 `--aot` flag whether to build using Ahead of Time compilation
+
+## Defined variables
+The source code of the application can access extra information about the
+environment. As of today, only one is avaible:
+
+`__GITVERSION__` gives the string describing the git commit, such as `"v1.0.2"`
+or `"v1.0.0-beta.23-52-g979e4f9"`. If not available, `__GITVERSION__` is
+undefined.

--- a/packages/angular-cli/models/webpack-build-common.ts
+++ b/packages/angular-cli/models/webpack-build-common.ts
@@ -1,5 +1,6 @@
 import * as webpack from 'webpack';
 import * as path from 'path';
+import * as childProcess from 'child_process';
 import { GlobCopyWebpackPlugin } from '../plugins/glob-copy-webpack-plugin';
 import { SuppressEntryChunksWebpackPlugin } from '../plugins/suppress-entry-chunks-webpack-plugin';
 import { packageChunkSort } from '../utilities/package-chunk-sort';
@@ -128,6 +129,18 @@ export function getWebpackCommonConfig(
   }
 
   if (progress) { extraPlugins.push(new ProgressPlugin({ profile: verbose, colors: true })); }
+
+  // Define __GITVERSION__ in source code. If available, it will be something
+  // like "v1.0.2" or "v1.0.0-beta.23-52-g979e4f9". Otherwise it is undefined.
+  let gitVersion: string;
+  try {
+    gitVersion = childProcess.execSync(
+      'git describe --tags --always', { encoding: 'utf8' }).trim();
+  } catch (e) { }
+
+  extraPlugins.push(new webpack.DefinePlugin({
+    '__GITVERSION__': JSON.stringify(gitVersion),
+  }));
 
   return {
     devtool: sourcemap ? 'source-map' : false,


### PR DESCRIPTION
Allow web application source code to access the git version (if available) through the `__GITVERSION__` variable. It will give the string describing the git commit, such as `"v1.0.2"` or `"v1.0.0-beta.23-52-g979e4f9"`. If not available, `__GITVERSION__` is undefined.

For instance, an Angular app could use it like this:

```js
console.log('Starting web app version' + __GITVERSION__);
platformBrowserDynamic().bootstrapModule(AppModule);
```

or:

```html
<button (click)="alert('version ' + __GITVERSION__)">
  about
</button>
```