### PR TITLE
fix(lint): use noUnusedParameters and noUnusedLocals instead of no-unused-variable

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,8 @@
     "moduleResolution": "node",
     "noEmitOnError": true,
     "noImplicitAny": true,
+    "noUnusedParameters": true,
+    "noUnusedLocals": true,
     "outDir": "./dist",
     "rootDir": ".",
     "sourceMap": true,

--- a/tslint.json
+++ b/tslint.json
@@ -19,7 +19,6 @@
     "no-trailing-whitespace": true,
     "no-bitwise": true,
     "no-unused-expression": true,
-    "no-unused-variable": true,
     "no-var-keyword": true,
     "one-line": [
       true,


### PR DESCRIPTION
Running `npm lint` yielded this warning:

`no-unused-variable is deprecated. Use the tsc compiler options --noUnusedParameters and --noUnusedLocals instead.`

This PR fixes it.