### PR TITLE
fix(serve): allow relevant live-reload options to function

### DIFF
--- a/docs/documentation/serve.md
+++ b/docs/documentation/serve.md
@@ -16,13 +16,7 @@
 
 `--live-reload` (`-lr`) flag to turn off live reloading
 
-`--live-reload-host` (`-lrh`) specify the host for live reloading
-
-`--live-reload-base-url` (`-lrbu`) specify the base URL for live reloading
-
-`--live-reload-port` (`-lrp`) port for live reloading
-
-`--live-reload-live-css` flag to live reload CSS
+`--live-reload-client` specify the URL that the live reload browser client will use
 
 `--ssl` flag to turn on SSL
 

--- a/packages/@angular/cli/utilities/check-port.ts
+++ b/packages/@angular/cli/utilities/check-port.ts
@@ -2,14 +2,12 @@ import * as denodeify from 'denodeify';
 
 const SilentError = require('silent-error');
 const PortFinder = require('portfinder');
-const getPort = <any>denodeify(PortFinder.getPort);
+const getPort = denodeify<{host: string, port: number}, number>(PortFinder.getPort);
 
-PortFinder.basePort = 49152;
-
-
-export function checkPort(port: number, host: string) {
+export function checkPort(port: number, host: string, basePort = 49152): Promise<number> {
+  PortFinder.basePort = basePort;
   return getPort({ port, host })
-    .then((foundPort: number) => {
+    .then(foundPort => {
 
       // If the port isn't available and we weren't looking for any port, throw error.
       if (port !== foundPort && port !== 0) {


### PR DESCRIPTION
This provides implementations for the following `serve` command options:

- `live-reload` [boolean; default: true] -- flag to control the browser live reload capability
- `live-reload-client` [URL; default: `ssl`/`host`/`port` command options] -- specify the URL that the live reload browser client will use

Closes #3361