### PR TITLE
chore(dev-feature): add support to profile the CLI.

### DIFF
--- a/packages/angular-cli/bin/ng
+++ b/packages/angular-cli/bin/ng
@@ -36,6 +36,29 @@ function _fromPackageJson(cwd) {
 }
 
 
+// Check if we need to profile this CLI run.
+let profiler = null;
+if (process.env['NG_CLI_PROFILING']) {
+  profiler = require('v8-profiler');
+  profiler.startProfiling();
+  function exitHandler(options, err) {
+    if (options.cleanup) {
+      const cpuProfile = profiler.stopProfiling();
+      fs.writeFileSync(path.resolve(process.cwd(), process.env.NG_CLI_PROFILING) + '.cpuprofile',
+        JSON.stringify(cpuProfile));
+    }
+
+    if (options.exit) {
+      process.exit();
+    }
+  }
+
+  process.on('exit', exitHandler.bind(null, { cleanup: true }));
+  process.on('SIGINT', exitHandler.bind(null, { exit: true }));
+  process.on('uncaughtException', exitHandler.bind(null, { exit: true }));
+}
+
+
 resolve('angular-cli', { basedir: process.cwd() },
   function (error, projectLocalCli) {
     var cli;


### PR DESCRIPTION
This requires that one "npm install v8-profiler" where the CLI lives (not going to add it as a dev dependency), and run with something like "NG_CLI_PROFILING=serve ng serve". This will create a "serve.cpuprofile" that can be opened in Chrome.