### PR TITLE
feat(build): disable sourcemaps for production

### DIFF
--- a/packages/angular-cli/commands/build.run.ts
+++ b/packages/angular-cli/commands/build.run.ts
@@ -22,7 +22,7 @@ export default function buildRun(commandOptions: BuildOptions) {
     }
   }
 
-  if (!commandOptions.sourcemap) {
+  if (typeof commandOptions.sourcemap === 'undefined') {
     if (commandOptions.target == 'development') {
       commandOptions.sourcemap = true;
     }

--- a/packages/angular-cli/commands/build.run.ts
+++ b/packages/angular-cli/commands/build.run.ts
@@ -22,6 +22,15 @@ export default function buildRun(commandOptions: BuildOptions) {
     }
   }
 
+  if (!commandOptions.sourcemap) {
+    if (commandOptions.target == 'development') {
+      commandOptions.sourcemap = true;
+    }
+    if (commandOptions.target == 'production') {
+      commandOptions.sourcemap = false;
+    }
+  }
+
   const project = this.project;
 
   // Check angular version.

--- a/packages/angular-cli/commands/build.ts
+++ b/packages/angular-cli/commands/build.ts
@@ -39,7 +39,7 @@ const BuildCommand = Command.extend({
     { name: 'suppress-sizes', type: Boolean, default: false },
     { name: 'base-href',      type: String,  default: null, aliases: ['bh'] },
     { name: 'aot',            type: Boolean, default: false },
-    { name: 'sourcemap',      type: Boolean, default: true, aliases: ['sm'] },
+    { name: 'sourcemap',      type: Boolean, aliases: ['sm'] },
     { name: 'vendor-chunk',   type: Boolean, default: true },
     { name: 'verbose',        type: Boolean, default: false },
     { name: 'progress',       type: Boolean, default: true },

--- a/tests/e2e/tests/build/sourcemap.ts
+++ b/tests/e2e/tests/build/sourcemap.ts
@@ -6,6 +6,13 @@ import {expectToFail} from '../../utils/utils';
 export default function() {
   return ng('build')
     .then(() => expectFileToExist('dist/main.bundle.map'))
+
     .then(() => ng('build', '--no-sourcemap'))
-    .then(() => expectToFail(() => expectFileToExist('dist/main.bundle.map')));
+    .then(() => expectToFail(() => expectFileToExist('dist/main.bundle.map')))
+
+    .then(() => ng('build', '--prod', '--output-hashing=none'))
+    .then(() => expectToFail(() => expectFileToExist('dist/main.bundle.map')))
+
+    .then(() => ng('build', '--prod', '--output-hashing=none', '--sourcemap'))
+    .then(() => expectFileToExist('dist/main.bundle.map'));
 }


### PR DESCRIPTION
sourcemaps can be enabled using the `--sourcemap` option, if desired.

Closes #3958