### PR TITLE
fix(help): remove match of *.run.ts files

### DIFF
--- a/packages/angular-cli/commands/help.ts
+++ b/packages/angular-cli/commands/help.ts
@@ -23,7 +23,7 @@ const HelpCommand = Command.extend({
   run: function (commandOptions: any, rawArgs: any) {
     let commandFiles = fs.readdirSync(__dirname)
       // Remove files that are not JavaScript or Typescript
-      .filter(file => file.match(/\.(j|t)s$/) && !file.match(/\.d.ts$/))
+      .filter(file => file.match(/\.(j|t)s$/) && !file.match(/\.d.ts$/) && !file.match(/\.run.ts$/))
       .map(file => path.parse(file).name)
       .map(file => file.toLowerCase());
 


### PR DESCRIPTION
The recently added *.run.ts files are being picked up by the filter and therefore are leading to errors when executing `ng help`

Fixes #3976.