### PR TITLE
Load zone.js long-stack-trace in debug mode

### DIFF
--- a/packages/angular-cli/blueprints/ng2/files/__path__/main.ts
+++ b/packages/angular-cli/blueprints/ng2/files/__path__/main.ts
@@ -7,6 +7,8 @@ import { AppModule } from './app/app.module';
 
 if (environment.production) {
   enableProdMode();
+} else {
+  require('zone.js/dist/long-stack-trace-zone');
 }
 
 platformBrowserDynamic().bootstrapModule(AppModule);


### PR DESCRIPTION
[dist/long-stack-trace-zone.min.js](https://github.com/angular/zone.js/blob/master/dist/long-stack-trace-zone.min.js) should be loaded in the development environment to give more meaningful stack traces.

Without this script, only the last VM turn is logged. When this script is loaded the stack will contain all VM turns from the point the async operation was initiated.

fixes #2233