### PR TITLE
feat(new): read GIT_AUTHOR_NAME/_EMAIL from process.ENV for initial commit message

### DIFF
--- a/packages/@angular/cli/tasks/git-init.js
+++ b/packages/@angular/cli/tasks/git-init.js
@@ -9,8 +9,8 @@ var template = require('lodash/template');
 var Task = require('../ember-cli/lib/models/task');
 
 var gitEnvironmentVariables = {
-  GIT_AUTHOR_NAME: 'Angular CLI',
-  GIT_AUTHOR_EMAIL: 'angular-cli@angular.io',
+  GIT_AUTHOR_NAME: process.env.GIT_AUTHOR_NAME || 'Angular CLI',
+  GIT_AUTHOR_EMAIL: process.env.GIT_AUTHOR_EMAIL || 'angular-cli@angular.io',
   get GIT_COMMITTER_NAME() {
     return this.GIT_AUTHOR_NAME;
   },


### PR DESCRIPTION
This PR reads the ENV vars for `GIT_AUTHOR_NAME` and `GIT_AUTHOR_EMAIL` and defaults to `angular-cli`/`angular-cli@angular.io` if these are not set.

This allows the developer to do the initial commit on behalf of it's own user account.