### PR TITLE
refactor: remove support for '.ember-cli' file

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,6 @@
     "webpack-dev-server": "2.2.0-rc.0",
     "webpack-merge": "^0.14.0",
     "webpack-sources": "^0.1.3",
-    "yam": "0.0.18",
     "zone.js": "^0.7.2"
   },
   "ember-addon": {

--- a/packages/angular-cli/ember-cli/lib/cli/index.js
+++ b/packages/angular-cli/ember-cli/lib/cli/index.js
@@ -7,13 +7,11 @@ var commands      = require('../commands');
 var tasks         = require('../tasks');
 var CLI           = require('./cli');
 var debug         = require('debug')('ember-cli:cli/index');
-var merge         = require('lodash/merge');
 
 
 // Options: Array cliArgs, Stream inputStream, Stream outputStream
 module.exports = function(options) {
   var UI = options.UI || require('../ui');
-  var Yam = options.Yam || require('yam');
 
   // TODO: one UI (lib/models/project.js also has one for now...)
   var ui = new UI({
@@ -25,9 +23,6 @@ module.exports = function(options) {
     writeLevel:   ~process.argv.indexOf('--silent') ? 'ERROR' : undefined
   });
 
-  var config = new Yam('ember-cli', {
-    primary: Project.getProjectRoot()
-  });
 
   var defaultUpdateCheckerOptions = {
     checkForUpdates: false
@@ -49,7 +44,7 @@ module.exports = function(options) {
     cliArgs:  options.cliArgs,
     commands: commands,
     project:  project,
-    settings: merge(defaultUpdateCheckerOptions, config.getAll())
+    settings: defaultUpdateCheckerOptions
   };
 
   return cli.run(environment);

--- a/packages/angular-cli/package.json
+++ b/packages/angular-cli/package.json
@@ -100,7 +100,6 @@
     "webpack-dev-server": "2.2.0-rc.0",
     "webpack-merge": "^0.14.0",
     "webpack-sources": "^0.1.3",
-    "yam": "0.0.18",
     "zone.js": "^0.7.2"
   },
   "ember-addon": {


### PR DESCRIPTION
This eliminates the current dependency on `yam`.