### PR TITLE
refactor(deps): remove unused dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "postcss-loader": "^0.9.1",
     "quick-temp": "0.1.5",
     "raw-loader": "^0.5.1",
-    "readline2": "0.1.1",
     "reflect-metadata": "^0.1.8",
     "remap-istanbul": "^0.6.4",
     "resolve": "^1.1.7",

--- a/packages/angular-cli/ember-cli/lib/ui/index.js
+++ b/packages/angular-cli/ember-cli/lib/ui/index.js
@@ -35,7 +35,6 @@ function UI(options) {
   var spinner = this.spinner = ora({ color: 'green' });
 
   this.through  = require('through');
-  this.readline = require('readline2');
 
   // Output stream
   this.actualOutputStream = options.outputStream;

--- a/packages/angular-cli/package.json
+++ b/packages/angular-cli/package.json
@@ -75,7 +75,6 @@
     "postcss-loader": "^0.9.1",
     "quick-temp": "0.1.5",
     "raw-loader": "^0.5.1",
-    "readline2": "0.1.1",
     "remap-istanbul": "^0.6.4",
     "resolve": "^1.1.7",
     "rimraf": "^2.5.3",


### PR DESCRIPTION
Removes `readline2` which is required but never actually used.