### PR TITLE
chore(config): remove addons/packages entries

### DIFF
--- a/packages/angular-cli/blueprints/ng2/files/angular-cli.json
+++ b/packages/angular-cli/blueprints/ng2/files/angular-cli.json
@@ -28,8 +28,6 @@
       }
     }
   ],
-  "addons": [],
-  "packages": [],
   "e2e": {
     "protractor": {
       "config": "./protractor.conf.js"


### PR DESCRIPTION
We don't really use these two entries and people sometimes ask about them. Better to not have them as defaults.

https://github.com/angular/angular-cli/issues/3901