### PR TITLE
fix(generate): normalize pwd before using it

### DIFF
--- a/packages/angular-cli/lib/cli/index.js
+++ b/packages/angular-cli/lib/cli/index.js
@@ -32,7 +32,7 @@ module.exports = function(options) {
   };
 
   // ensure the environemnt variable for dynamic paths
-  process.env.PWD = process.env.PWD || process.cwd();
+  process.env.PWD = path.normalize(process.env.PWD || process.cwd());
   process.env.CLI_ROOT = process.env.CLI_ROOT || path.resolve(__dirname, '..', '..');
 
   return cli(options);


### PR DESCRIPTION
`process.env.PWD` is different between gitbash and cmd
- gitbash: `D:/sandbox/master-project/src/app/other`
- cmd: `D:\sandbox\master-project\src\app\other`

Normalizing it via `path.normalize` solves the problem.

Fix #1639