### PR TITLE
WIP: Add angular-cli.json option to explicitly specify `entryModule` when …

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ with NPM 3 or higher.
 * [Installation](#installation)
 * [Usage](#usage)
 * [Generating a New Project](#generating-and-serving-an-angular2-project-via-a-development-server)
+* [Specifying application entry module](#specifying-application-entry-module)
 * [Generating Components, Directives, Pipes and Services](#generating-components-directives-pipes-and-services)
 * [Generating a Route](#generating-a-route)
 * [Creating a Build](#creating-a-build)
@@ -83,6 +84,17 @@ You can configure the default HTTP port and the one used by the LiveReload serve
 
 ```bash
 ng serve --host 0.0.0.0 --port 4201 --live-reload-port 49153
+```
+
+### Specifying application entry module
+
+In some cases ng-cli is unable to resolve the application entry module automatically. You can specify it explicitly in `angular-cli.json`:
+
+```json
+...
+"main": "main.ts",
+"entryModule": "app/app.module#AppModule",
+...
 ```
 
 ### Generating Components, Directives, Pipes and Services

--- a/packages/@ngtools/webpack/src/entry_resolver.ts
+++ b/packages/@ngtools/webpack/src/entry_resolver.ts
@@ -124,6 +124,11 @@ function _symbolImportLookup(refactor: TypeScriptFileRefactor,
   return null;
 }
 
+export class ResolveEntryModuleError extends Error {
+  constructor(message: string) {
+    super(message);
+  }
+}
 
 export function resolveEntryModuleFromMain(mainPath: string,
                                            host: ts.CompilerHost,
@@ -143,7 +148,7 @@ export function resolveEntryModuleFromMain(mainPath: string,
     .filter(node => node.kind == ts.SyntaxKind.Identifier);
 
   if (bootstrap.length != 1) {
-    throw new Error('Tried to find bootstrap code, but could not. Specify either '
+    throw new ResolveEntryModuleError('Tried to find bootstrap code, but could not. Specify either '
       + 'statically analyzable bootstrap code or pass in an entryModule '
       + 'to the plugins options.');
   }
@@ -154,7 +159,7 @@ export function resolveEntryModuleFromMain(mainPath: string,
   }
 
   // shrug... something bad happened and we couldn't find the import statement.
-  throw new Error('Tried to find bootstrap code, but could not. Specify either '
+  throw new ResolveEntryModuleError('Tried to find bootstrap code, but could not. Specify either '
     + 'statically analyzable bootstrap code or pass in an entryModule '
     + 'to the plugins options.');
 }

--- a/packages/@ngtools/webpack/src/index.ts
+++ b/packages/@ngtools/webpack/src/index.ts
@@ -1,5 +1,6 @@
 import 'reflect-metadata';
 
 export * from './plugin';
+export {ResolveEntryModuleError} from './entry_resolver';
 export {ngcLoader as default} from './loader';
 export {PathsPlugin} from './paths-plugin';

--- a/packages/angular-cli/lib/config/schema.json
+++ b/packages/angular-cli/lib/config/schema.json
@@ -55,6 +55,9 @@
           "main": {
             "type": "string"
           },
+          "entryModule": {
+            "type": "string"
+          },
           "test": {
             "type": "string"
           },

--- a/packages/angular-cli/models/webpack-build-typescript.ts
+++ b/packages/angular-cli/models/webpack-build-typescript.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import {AotPlugin} from '@ngtools/webpack';
+import {AotPlugin, ResolveEntryModuleError} from '@ngtools/webpack';
 
 
 const g: any = global;
@@ -9,52 +9,78 @@ const webpackLoader: string = g['angularCliIsLocal']
 
 
 export const getWebpackNonAotConfigPartial = function(projectRoot: string, appConfig: any) {
-  let exclude = [ '**/*.spec.ts' ];
-  if (appConfig.test) { exclude.push(path.join(projectRoot, appConfig.root, appConfig.test)); };
-  return {
-    module: {
-      rules: [
-        {
-          test: /\.ts$/,
-          loader: webpackLoader,
-          exclude: [/\.(spec|e2e)\.ts$/]
-        }
+  try {
+    let exclude = [ '**/*.spec.ts' ];
+    if (appConfig.test) { exclude.push(path.join(projectRoot, appConfig.root, appConfig.test)); };
+    let entryModule = appConfig.entryModule &&
+      path.join(projectRoot, appConfig.root, appConfig.entryModule);
+    return {
+      module: {
+        rules: [
+          {
+            test: /\.ts$/,
+            loader: webpackLoader,
+            exclude: [/\.(spec|e2e)\.ts$/]
+          }
+        ]
+      },
+      plugins: [
+        new AotPlugin({
+          tsConfigPath: path.resolve(projectRoot, appConfig.root, appConfig.tsconfig),
+          mainPath: path.join(projectRoot, appConfig.root, appConfig.main),
+          entryModule: entryModule,
+          exclude: exclude,
+          skipCodeGeneration: true
+        }),
       ]
-    },
-    plugins: [
-      new AotPlugin({
-        tsConfigPath: path.resolve(projectRoot, appConfig.root, appConfig.tsconfig),
-        mainPath: path.join(projectRoot, appConfig.root, appConfig.main),
-        exclude: exclude,
-        skipCodeGeneration: true
-      }),
-    ]
-  };
+    };
+  } catch (e) {
+    if (e instanceof ResolveEntryModuleError) {
+      throw new Error('Tried to find bootstrap code, but could not. Either provide '
+                    + 'statically analyzable bootstrap code or specify entryModule '
+                    + 'in angular-cli options.');
+    } else {
+      throw e;
+    }
+  }
 };
 
 export const getWebpackAotConfigPartial = function(projectRoot: string, appConfig: any,
   i18nFile: string, i18nFormat: string, locale: string) {
-  let exclude = [ '**/*.spec.ts' ];
-  if (appConfig.test) { exclude.push(path.join(projectRoot, appConfig.root, appConfig.test)); };
-  return {
-    module: {
-      rules: [
-        {
-          test: /\.ts$/,
-          loader: webpackLoader,
-          exclude: [/\.(spec|e2e)\.ts$/]
-        }
+  try {
+    let exclude = [ '**/*.spec.ts' ];
+    if (appConfig.test) { exclude.push(path.join(projectRoot, appConfig.root, appConfig.test)); };
+    let entryModule = appConfig.entryModule &&
+      path.join(projectRoot, appConfig.root, appConfig.entryModule);
+    return {
+      module: {
+        rules: [
+          {
+            test: /\.ts$/,
+            loader: webpackLoader,
+            exclude: [/\.(spec|e2e)\.ts$/]
+          }
+        ]
+      },
+      plugins: [
+        new AotPlugin({
+          tsConfigPath: path.resolve(projectRoot, appConfig.root, appConfig.tsconfig),
+          mainPath: path.join(projectRoot, appConfig.root, appConfig.main),
+          entryModule: entryModule,
+          i18nFile: i18nFile,
+          i18nFormat: i18nFormat,
+          locale: locale,
+          exclude: exclude
+        })
       ]
-    },
-    plugins: [
-      new AotPlugin({
-        tsConfigPath: path.resolve(projectRoot, appConfig.root, appConfig.tsconfig),
-        mainPath: path.join(projectRoot, appConfig.root, appConfig.main),
-        i18nFile: i18nFile,
-        i18nFormat: i18nFormat,
-        locale: locale,
-        exclude: exclude
-      })
-    ]
-  };
+    };
+  } catch (e) {
+    if (e instanceof ResolveEntryModuleError) {
+      throw new Error('Tried to find bootstrap code, but could not. Either provide '
+                    + 'statically analyzable bootstrap code or specify entryModule '
+                    + 'in angular-cli options.');
+    } else {
+      throw e;
+    }
+  }
 };


### PR DESCRIPTION
…it can’t be inferred from code

In some cases `@ngtools/webpack` is unable to resolve the application entry module automatically.
This commit exposes `entryModule` option of `AotPlugin` in angular-cli.json so that you can specify it by hand.
