### PR TITLE
refactor (build): refactor the logic to set publicPath

### DIFF
--- a/packages/angular-cli/models/webpack-build-common.ts
+++ b/packages/angular-cli/models/webpack-build-common.ts
@@ -35,6 +35,7 @@ export function getWebpackCommonConfig(
   progress: boolean,
   outputHashing: string,
   extractCss: boolean,
+  deployUrl: string
 ) {
 
   const appRoot = path.resolve(projectRoot, appConfig.root);
@@ -149,7 +150,7 @@ export function getWebpackCommonConfig(
     entry: entryPoints,
     output: {
       path: path.resolve(projectRoot, appConfig.outDir),
-      publicPath: appConfig.deployUrl,
+      publicPath: deployUrl,
       filename: `[name]${hashFormat.chunk}.bundle.js`,
       sourceMapFilename: `[name]${hashFormat.chunk}.bundle.map`,
       chunkFilename: `[id]${hashFormat.chunk}.chunk.js`

--- a/packages/angular-cli/models/webpack-config.ts
+++ b/packages/angular-cli/models/webpack-config.ts
@@ -40,7 +40,6 @@ export class NgCliWebpackConfig {
     const projectRoot = this.ngCliProject.root;
 
     appConfig.outDir = outputDir || appConfig.outDir;
-    appConfig.deployUrl = deployUrl || appConfig.deployUrl;
 
     let baseConfig = getWebpackCommonConfig(
       projectRoot,
@@ -53,6 +52,7 @@ export class NgCliWebpackConfig {
       progress,
       outputHashing,
       extractCss,
+      deployUrl
     );
     let targetConfigPartial = this.getTargetConfig(projectRoot, appConfig, sourcemap, verbose);
 


### PR DESCRIPTION
If we set ```deployUrl``` via the ```angular-cli.json```, the ```ng serve``` will be affected as well because we set ```publicPath``` via ```appConfig.deployUrl``` in the ```webpack-build-common.ts```

This PR can solve above issue and also remove duplicated logic ```deployUrl || appConfig.deployUrl;``` which already exists in ```build-webpack.ts```