### PR TITLE
tests(deploy): increase timeout for long test

### DIFF
--- a/tests/acceptance/github-pages-deploy.spec.js
+++ b/tests/acceptance/github-pages-deploy.spec.js
@@ -51,6 +51,7 @@ describe('Acceptance: ng github-pages:deploy', function() {
   });
 
   it('should fail with uncommited changes', function() {
+    this.timeout(10000);
     execStub.addExecSuccess('git status --porcelain', 'M dir/file.ext');
     return ng(['github-pages:deploy', '--skip-build'])
       .then(() => {


### PR DESCRIPTION
The `should fail with uncommited changes` test is slower than the others and sometimes causes flakes on CI.