### PR TITLE
fix(server): configure webpack-dev-server with devServer options

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,14 +221,15 @@ with the content
 
 ```json
 {
-  "/api": {
-    "target": "http://localhost:3000",
-    "secure": false
-  }
+  proxy: {
+        "/api/*": {
+          "target": "http://localhost:3000"
+        }
+    }
 }
 ```
 
-You can read more about what options are available here [webpack-dev-server proxy settings](https://webpack.github.io/docs/webpack-dev-server.html#proxy)
+You can read more about what options are available here [webpack-dev-server proxy settings](https://webpack.js.org/configuration/dev-server/)
 
 and then we edit the `package.json` file's start script to be
 

--- a/packages/angular-cli/tasks/serve-webpack.ts
+++ b/packages/angular-cli/tasks/serve-webpack.ts
@@ -68,7 +68,6 @@ export default Task.extend({
     }
     if (!config.entry.main) { config.entry.main = []; }
     config.entry.main.unshift(...entryPoints);
-    webpackCompiler = webpack(config);
 
     const statsConfig = getWebpackStatsConfig(serveTaskOptions.verbose);
 
@@ -76,12 +75,14 @@ export default Task.extend({
     if (serveTaskOptions.proxyConfig) {
       const proxyPath = path.resolve(this.project.root, serveTaskOptions.proxyConfig);
       if (fs.existsSync(proxyPath)) {
-        proxyConfig = require(proxyPath);
+        config.devServer = require(proxyPath);
       } else {
         const message = 'Proxy config file ' + proxyPath + ' does not exist.';
         return Promise.reject(new SilentError(message));
       }
     }
+
+    webpackCompiler = webpack(config);
 
     let sslKey: string = null;
     let sslCert: string = null;

--- a/tests/e2e/tests/misc/proxy.ts
+++ b/tests/e2e/tests/misc/proxy.ts
@@ -24,8 +24,10 @@ export default function() {
   const proxyServerUrl = `http://${backendHost}:${backendPort}`;
   const proxyConfigFile = 'proxy.config.json';
   const proxyConfig = {
-    '/api/*': {
-      target: proxyServerUrl
+    proxy: {
+      '/api/*': {
+        target: proxyServerUrl
+      }
     }
   };
 


### PR DESCRIPTION
This tries to fix #4117 and take advantage of webpack 2.x dev-server configuration