### PR TITLE
Remove ember-addon keyword from package.json

### DIFF
--- a/packages/angular-cli/package.json
+++ b/packages/angular-cli/package.json
@@ -8,7 +8,8 @@
     "ng": "./bin/ng"
   },
   "keywords": [
-    "ember-addon"
+    "angular",
+    "angular-cli"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
Searching for "ember-addon" on npmjs.org shows the `angular-cli` package due to it being declared in the `keywords`.

<img width="1440" alt="screen shot 2017-01-20 at 14 44 35" src="https://cloud.githubusercontent.com/assets/7525670/22151653/42caf7be-df1f-11e6-9715-bb1543d76836.png">

This PR changes the keywords to be Angular specific so this stops happening. Cheers!