### PR TITLE
Windows 10 Bash bug fix for issue #3028

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "nopt": "^3.0.1",
     "opn": "4.0.1",
     "ora": "^0.2.0",
-    "portfinder": "1.0.9",
+    "portfinder": "1.0.12",
     "postcss-discard-comments": "^2.0.4",
     "postcss-loader": "^0.9.1",
     "quick-temp": "0.1.5",


### PR DESCRIPTION
Updating portfinder dependency from @1.0.9 to @1.0.12 to fix windows 10 bash bug. Look at issue #3028 for more information.

https://github.com/angular/angular-cli/issues/3028

