### PR TITLE
fix(@ngtools/webpack): prevent emitting sourcemaps

### DIFF
--- a/packages/@ngtools/webpack/src/resource_loader.ts
+++ b/packages/@ngtools/webpack/src/resource_loader.ts
@@ -69,11 +69,13 @@ export class WebpackResourceLoader implements ResourceLoader {
           });
 
           // Restore the parent compilation to the state like it was before the child compilation.
-          this._parentCompilation.assets[outputName] = assetsBeforeCompilation[outputName];
-          if (assetsBeforeCompilation[outputName] === undefined) {
-            // If it wasn't there - delete it.
-            delete this._parentCompilation.assets[outputName];
-          }
+          Object.keys(childCompilation.assets).forEach((fileName) => {
+            this._parentCompilation.assets[fileName] = assetsBeforeCompilation[fileName];
+            if (assetsBeforeCompilation[fileName] === undefined) {
+              // If it wasn't there - delete it.
+              delete this._parentCompilation.assets[fileName];
+            }
+          });
 
           resolve({
             // Hash of the template entry point.


### PR DESCRIPTION
In some cases compilation of a component style generates a sourcemap and it's not deleted from assets.
This would cause hangs in Windows and make unnecessary outputs in other platform.

may fix #3019