### PR TITLE
fix(lint): fix new linting errors

### DIFF
--- a/packages/@ngtools/json-schema/src/schema-tree.ts
+++ b/packages/@ngtools/json-schema/src/schema-tree.ts
@@ -31,8 +31,8 @@ export abstract class SchemaTreeNode<T> implements SchemaNode {
   // Hierarchy objects
   protected _parent: SchemaTreeNode<any>;
 
-  protected _defined: boolean = false;
-  protected _dirty: boolean = false;
+  protected _defined = false;
+  protected _dirty = false;
 
   protected _schema: Schema;
   protected _name: string;
@@ -247,7 +247,7 @@ export class OneOfSchemaTreeNode extends NonLeafSchemaTreeNode<any> {
 export class ObjectSchemaTreeNode extends NonLeafSchemaTreeNode<{[key: string]: any}> {
   // The map of all children metadata.
   protected _children: { [key: string]: SchemaTreeNode<any> };
-  protected _frozen: boolean = false;
+  protected _frozen = false;
 
   constructor(metaData: TreeNodeConstructorArgument<any>) {
     super(metaData);

--- a/packages/@ngtools/webpack/src/compiler_host.ts
+++ b/packages/@ngtools/webpack/src/compiler_host.ts
@@ -100,7 +100,7 @@ export class WebpackCompilerHost implements ts.CompilerHost {
   private _basePath: string;
   private _setParentNodes: boolean;
 
-  private _cache: boolean = false;
+  private _cache = false;
 
   constructor(private _options: ts.CompilerOptions, basePath: string) {
     this._setParentNodes = true;

--- a/packages/@ngtools/webpack/src/plugin.ts
+++ b/packages/@ngtools/webpack/src/plugin.ts
@@ -47,8 +47,8 @@ export class AotPlugin implements Tapable {
   private _compiler: any = null;
   private _compilation: any = null;
 
-  private _typeCheck: boolean = true;
-  private _skipCodeGeneration: boolean = false;
+  private _typeCheck = true;
+  private _skipCodeGeneration = false;
   private _basePath: string;
   private _genDir: string;
 

--- a/packages/@ngtools/webpack/src/refactor.ts
+++ b/packages/@ngtools/webpack/src/refactor.ts
@@ -30,7 +30,7 @@ export class TypeScriptFileRefactor {
   private _sourceFile: ts.SourceFile;
   private _sourceString: any;
   private _sourceText: string;
-  private _changed: boolean = false;
+  private _changed = false;
 
   get fileName() { return this._fileName; }
   get sourceFile() { return this._sourceFile; }

--- a/packages/angular-cli/lib/webpack/compression-plugin.ts
+++ b/packages/angular-cli/lib/webpack/compression-plugin.ts
@@ -26,8 +26,8 @@ export class CompressionPlugin {
   private algorithm: Function;
   private compressionOptions: any = {};
   private test: RegExp[];
-  private threshold: number = 0;
-  private minRatio: number = 0.8;
+  private threshold = 0;
+  private minRatio = 0.8;
 
   constructor(options: CompressionPluginOptions = {}) {
     if (options.hasOwnProperty('asset')) {

--- a/tests/acceptance/get-dependent-files.spec.ts
+++ b/tests/acceptance/get-dependent-files.spec.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-// This needs to be first so fs module can be mocked correctly. 
+// This needs to be first so fs module can be mocked correctly.
 let mockFs = require('mock-fs');
 import { expect, assert } from 'chai';
 import * as path from 'path';


### PR DESCRIPTION
The following linting errors appeared on master. I suppose it was due to a `tslint` update.

```
packages/@ngtools/json-schema/src/schema-tree.ts[34, 23]: Type boolean trivially inferred from a boolean literal, remove type annotation
packages/@ngtools/json-schema/src/schema-tree.ts[35, 21]: Type boolean trivially inferred from a boolean literal, remove type annotation
packages/@ngtools/json-schema/src/schema-tree.ts[250, 22]: Type boolean trivially inferred from a boolean literal, remove type annotation
packages/@ngtools/webpack/src/compiler_host.ts[103, 19]: Type boolean trivially inferred from a boolean literal, remove type annotation
packages/@ngtools/webpack/src/plugin.ts[50, 23]: Type boolean trivially inferred from a boolean literal, remove type annotation
packages/@ngtools/webpack/src/plugin.ts[51, 32]: Type boolean trivially inferred from a boolean literal, remove type annotation
packages/@ngtools/webpack/src/refactor.ts[33, 21]: Type boolean trivially inferred from a boolean literal, remove type annotation
packages/angular-cli/lib/webpack/compression-plugin.ts[29, 22]: Type number trivially inferred from a number literal, remove type annotation
packages/angular-cli/lib/webpack/compression-plugin.ts[30, 21]: Type number trivially inferred from a number literal, remove type annotation
tests/acceptance/get-dependent-files.spec.ts[3, 64]: trailing whitespace
```