### PR TITLE
bug(binary): version comparison message is incorrect

### DIFF
--- a/packages/angular-cli/bin/ng
+++ b/packages/angular-cli/bin/ng
@@ -87,7 +87,7 @@ resolve('angular-cli', { basedir: process.cwd() },
 
       if (shouldWarn) {
         // eslint-disable no-console
-        console.log(yellow(`Your global Angular CLI version (${globalVersion}) is greater than `
+        console.log(yellow(`Your global Angular CLI version (${globalVersion}) is lower than `
           + `your local version (${localVersion}). The local Angular CLI version is used.`));
       }
 


### PR DESCRIPTION
The messaging provided is a little confusing.  Adjusting it to say lower rather than greater. 

`Your global Angular CLI version (1.0.0-beta.25.5) is greater than your local version (1.0.0-beta.26). The local Angular CLI version is used.`