### PR TITLE
perf(@ngtools/webpack): reduce rebuild performance by typechecking more

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "@types/rimraf": "0.0.25-alpha",
     "@types/semver": "^5.3.30",
     "@types/source-map": "^0.5.0",
-    "@types/webpack": "^2.2.1",
+    "@types/webpack": "^2.2.4",
     "chai": "^3.5.0",
     "conventional-changelog": "^1.1.0",
     "dtsgenerator": "^0.7.1",

--- a/packages/@ngtools/webpack/src/webpack.ts
+++ b/packages/@ngtools/webpack/src/webpack.ts
@@ -23,3 +23,29 @@ export interface ResolverPlugin extends Tapable {
   join(relativePath: string, innerRequest: Request): Request;
 }
 
+export interface LoaderCallback {
+  (err: Error | null, source?: string, sourceMap?: string): void;
+}
+
+export interface ModuleReason {
+  dependency: any;
+  module: NormalModule;
+}
+
+export interface NormalModule {
+  buildTimestamp: number;
+  built: boolean;
+  reasons: ModuleReason[];
+  resource: string;
+}
+
+export interface LoaderContext {
+  _module: NormalModule;
+
+  async(): LoaderCallback;
+  cacheable(): void;
+
+  readonly resourcePath: string;
+  readonly query: any;
+}
+

--- a/tests/e2e/tests/build/rebuild-deps-type-check.ts
+++ b/tests/e2e/tests/build/rebuild-deps-type-check.ts
@@ -1,0 +1,63 @@
+import {
+  killAllProcesses,
+  waitForAnyProcessOutputToMatch,
+  silentExecAndWaitForOutputToMatch,
+} from '../../utils/process';
+import {writeFile, prependToFile, appendToFile} from '../../utils/fs';
+import {wait} from '../../utils/utils';
+
+
+export default function() {
+  if (process.platform.startsWith('win')) {
+    return Promise.resolve();
+  }
+
+  return silentExecAndWaitForOutputToMatch('ng', ['serve'], /webpack: bundle is now VALID/)
+    // Create and import files.
+    .then(() => writeFile('src/funky2.ts', `
+      export function funky2(value: string): string {
+        return value + 'hello';
+      }
+    `))
+    .then(() => writeFile('src/funky.ts', `
+      export * from './funky2';
+    `))
+    .then(() => prependToFile('src/main.ts', `
+      import { funky } from './funky';
+    `))
+    .then(() => appendToFile('src/main.ts', `
+      console.log(funky('town'));
+    `))
+    // Should trigger a rebuild, no error expected.
+    .then(() => waitForAnyProcessOutputToMatch(/webpack: bundle is now VALID/, 5000))
+    // Create and import files.
+    .then(() => wait(2000))
+    .then(() => writeFile('src/funky2.ts', `
+      export function funky(value: number): number {
+        return value + 1;
+      }
+    `))
+    // Should trigger a rebuild, this time an error is expected.
+    .then(() => waitForAnyProcessOutputToMatch(/webpack: bundle is now VALID/, 5000))
+    .then(({ stdout }) => {
+      if (!/ERROR in .*\/src\/main\.ts \(/.test(stdout)) {
+        throw new Error('Expected an error but none happened.');
+      }
+    })
+    // Fix the error!
+    .then(() => writeFile('src/funky2.ts', `
+      export function funky(value: string): string {
+        return value + 'hello';
+      }
+    `))
+    .then(() => waitForAnyProcessOutputToMatch(/webpack: bundle is now VALID/, 5000))
+    .then(({ stdout }) => {
+      if (/ERROR in .*\/src\/main\.ts \(/.test(stdout)) {
+        throw new Error('Expected no error but an error was shown.');
+      }
+    })
+    .then(() => killAllProcesses(), (err: any) => {
+      killAllProcesses();
+      throw err;
+    });
+}

--- a/tests/e2e/tests/build/rebuild.ts
+++ b/tests/e2e/tests/build/rebuild.ts
@@ -3,7 +3,7 @@ import {
   exec,
   waitForAnyProcessOutputToMatch,
   silentExecAndWaitForOutputToMatch,
-  ng, execAndWaitForOutputToMatch,
+  ng,
 } from '../../utils/process';
 import {writeFile} from '../../utils/fs';
 import {wait} from '../../utils/utils';
@@ -17,18 +17,18 @@ export default function() {
   let oldNumberOfChunks = 0;
   const chunkRegExp = /chunk\s+\{/g;
 
-  return execAndWaitForOutputToMatch('ng', ['serve'], /webpack: bundle is now VALID/)
+  return silentExecAndWaitForOutputToMatch('ng', ['serve'], /webpack: bundle is now VALID/)
     // Should trigger a rebuild.
     .then(() => exec('touch', 'src/main.ts'))
     .then(() => waitForAnyProcessOutputToMatch(/webpack: bundle is now INVALID/, 1000))
     .then(() => waitForAnyProcessOutputToMatch(/webpack: bundle is now VALID/, 5000))
     // Count the bundles.
-    .then((stdout: string) => {
+    .then(({ stdout }) => {
       oldNumberOfChunks = stdout.split(chunkRegExp).length;
     })
     // Add a lazy module.
     .then(() => ng('generate', 'module', 'lazy', '--routing'))
-    // Just wait for the rebuild, otherwise we might be validating this build.
+    // Just wait for the rebuild, otherwise we might be validating the last build.
     .then(() => wait(1000))
     .then(() => writeFile('src/app/app.module.ts', `
       import { BrowserModule } from '@angular/platform-browser';
@@ -60,7 +60,7 @@ export default function() {
     .then(() => waitForAnyProcessOutputToMatch(/webpack: bundle is now INVALID/, 1000))
     .then(() => waitForAnyProcessOutputToMatch(/webpack: bundle is now VALID/, 5000))
     // Count the bundles.
-    .then((stdout: string) => {
+    .then(({ stdout }) => {
       let newNumberOfChunks = stdout.split(chunkRegExp).length;
       if (oldNumberOfChunks >= newNumberOfChunks) {
         throw new Error('Expected webpack to create a new chunk, but did not.');

--- a/tests/e2e/utils/fs.ts
+++ b/tests/e2e/utils/fs.ts
@@ -103,6 +103,12 @@ export function appendToFile(filePath: string, text: string) {
 }
 
 
+export function prependToFile(filePath: string, text: string) {
+  return readFile(filePath)
+    .then((content: string) => writeFile(filePath, text.concat(content)));
+}
+
+
 export function expectFileToExist(fileName: string) {
   return new Promise((resolve, reject) => {
     fs.exists(fileName, (exist) => {


### PR DESCRIPTION
We got the TypeScript performance down a lot by not type checking every files on rebuild, but this has an issue where typings can be wrong in files that depends on us. This PR alleviate the problem by type checking all files that depends on the changed file.

Note that even if this PR reduces performance, it's marginal by less than 5% (although it depends on the depth of the change in the dependency graph).