### PR TITLE
fix(deps): pin lodash types

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "@types/fs-extra": "^0.0.31",
     "@types/glob": "^5.0.29",
     "@types/jasmine": "^2.2.32",
-    "@types/lodash": "^4.14.43",
+    "@types/lodash": "4.14.50",
     "@types/mock-fs": "^3.6.30",
     "@types/node": "^6.0.36",
     "@types/request": "0.0.30",


### PR DESCRIPTION
Pinned to latest version that does not require TS2.1+.
Fixes build failures.