### PR TITLE
refactor(test): remove lint option from test command

### DIFF
--- a/docs/documentation/test.md
+++ b/docs/documentation/test.md
@@ -15,8 +15,6 @@ Tests will execute after a build is executed via [Karma](http://karma-runner.git
 
 You can run tests with coverage via `--code-coverage`. The coverage report will be in the `coverage/` directory.
 
-Linting during tests is also available via the `--lint` flag. See [Linting and formatting code](#linting-and-formatting-code) chapter for more informations.
-
 ## Options
 `--watch` (`-w`) flag to run builds when files change
 

--- a/package.json
+++ b/package.json
@@ -105,8 +105,6 @@
     "stylus-loader": "^2.4.0",
     "temp": "0.8.3",
     "through": "^2.3.6",
-    "tslint": "^4.0.2",
-    "tslint-loader": "^3.3.0",
     "typescript": "~2.0.3",
     "url-loader": "^0.5.7",
     "walk-sync": "^0.2.6",
@@ -156,6 +154,7 @@
     "rewire": "^2.5.1",
     "sinon": "^1.17.3",
     "tree-kill": "^1.0.0",
-    "ts-node": "^1.3.0"
+    "ts-node": "^1.3.0",
+    "tslint": "^4.0.2"
   }
 }

--- a/packages/angular-cli/commands/test.ts
+++ b/packages/angular-cli/commands/test.ts
@@ -5,7 +5,6 @@ import {CliConfig} from '../models/config';
 export interface TestOptions {
   watch?: boolean;
   codeCoverage?: boolean;
-  lint?: boolean;
   singleRun?: boolean;
   browsers?: string;
   colors?: boolean;
@@ -22,7 +21,6 @@ const TestCommand = EmberTestCommand.extend({
   availableOptions: [
     { name: 'watch', type: Boolean, default: true, aliases: ['w'] },
     { name: 'code-coverage', type: Boolean, default: false, aliases: ['cc'] },
-    { name: 'lint', type: Boolean, default: false, aliases: ['l'] },
     { name: 'single-run', type: Boolean, default: false, aliases: ['sr'] },
     { name: 'progress', type: Boolean, default: true},
     { name: 'browsers', type: String },

--- a/packages/angular-cli/models/webpack-configs/test.js
+++ b/packages/angular-cli/models/webpack-configs/test.js
@@ -17,12 +17,10 @@ const ProgressPlugin  = require('webpack/lib/ProgressPlugin');
  * Enumerate loaders and their dependencies from this file to let the dependency validator
  * know they are used.
  *
- * require('tslint-loader')
  * require('source-map-loader')
  * require('sourcemap-istanbul-instrumenter-loader')
  *
  * require('remap-istanbul')
- * require('tslint')
  */
 
 
@@ -42,27 +40,6 @@ const getTestConfig = function (projectRoot, environment, appConfig, testConfig)
       ],
       query: { 'force-sourcemap': true }
     });
-  }
-
-  if (testConfig.lint) {
-    extraRules.push({
-      test: /\.ts$/,
-      enforce: 'pre',
-      loader: 'tslint-loader',
-      exclude: [
-        path.resolve(projectRoot, 'node_modules')
-      ]
-    });
-    extraPlugins.push(new webpack.LoaderOptionsPlugin({
-      options: {
-        tslint: {
-          emitErrors: false,
-          failOnHint: false,
-          resourcePath: `./${appConfig.root}`,
-          typeCheck: true
-        }
-      }
-    }))
   }
 
   if (testConfig.progress) {

--- a/packages/angular-cli/package.json
+++ b/packages/angular-cli/package.json
@@ -89,8 +89,6 @@
     "stylus-loader": "^2.4.0",
     "temp": "0.8.3",
     "through": "^2.3.6",
-    "tslint": "^4.0.2",
-    "tslint-loader": "^3.3.0",
     "typescript": "~2.0.3",
     "url-loader": "^0.5.7",
     "walk-sync": "^0.2.6",

--- a/packages/angular-cli/plugins/karma.js
+++ b/packages/angular-cli/plugins/karma.js
@@ -15,7 +15,6 @@ const init = (config) => {
   const environment = config.angularCli.environment || 'dev';
   const testConfig = {
     codeCoverage: config.angularCli.codeCoverage || false,
-    lint: config.angularCli.lint || false,
     sourcemap: config.angularCli.sourcemap,
     progress: config.angularCli.progress
   }

--- a/packages/angular-cli/tasks/test.ts
+++ b/packages/angular-cli/tasks/test.ts
@@ -25,7 +25,6 @@ export default Task.extend({
 
       karmaOptions.angularCli = {
         codeCoverage: options.codeCoverage,
-        lint: options.lint,
         sourcemap: options.sourcemap,
         progress: options.progress
       };


### PR DESCRIPTION
As discussed in #4114.

Closes #4114 
Closes #3317

BREAKING CHANGE: `ng test` no longer has the `--lint` flag available.
