### PR TITLE
Print detailed help, so as blueprint help is displayed again.

### DIFF
--- a/packages/@angular/cli/commands/help.ts
+++ b/packages/@angular/cli/commands/help.ts
@@ -55,7 +55,7 @@ const HelpCommand = Command.extend({
 
       if (rawArgs.length > 0) {
         if (cmd === rawArgs[0]) {
-          this.ui.writeLine(command.printBasicHelp(commandOptions));
+          this.ui.writeLine(command.printDetailedHelp(commandOptions));
         }
       } else {
         this.ui.writeLine(command.printBasicHelp(commandOptions));


### PR DESCRIPTION
This logic was present in beta.20, as pointed out in the issue #3699.

Consequently, this PR re-introduces the logic, and thus fixes issue #3699, closes #3699.