### PR TITLE
feat(build): add `--poll` option to build/serve/test commands

### DIFF
--- a/docs/documentation/build.md
+++ b/docs/documentation/build.md
@@ -96,3 +96,5 @@ or `ng serve --prod` will also make use of uglifying and tree-shaking functional
 `--output-hashing` define the output filename cache-busting hashing mode
 
 `--stats-json` generates a `stats.json` file which can be analyzed using tools such as: `webpack-bundle-analyzer` or https://webpack.github.io/analyse
+
+`--poll` enable and define the file watching poll time period (milliseconds)

--- a/docs/documentation/serve.md
+++ b/docs/documentation/serve.md
@@ -59,3 +59,5 @@
 `--extract-css` (`-ec`) extract css from global styles onto css files instead of js ones
 
 `--output-hashing` define the output filename cache-busting hashing mode
+
+`--poll` enable and define the file watching poll time period (milliseconds)

--- a/docs/documentation/test.md
+++ b/docs/documentation/test.md
@@ -29,3 +29,5 @@ You can run tests with coverage via `--code-coverage`. The coverage report will 
 `--reporters` list of reporters to use
 
 `--build` flag to build prior to running tests
+
+`--poll` enable and define the file watching poll time period (milliseconds)

--- a/packages/@angular/cli/commands/build.ts
+++ b/packages/@angular/cli/commands/build.ts
@@ -1,7 +1,11 @@
+import { CliConfig } from '../models/config';
 import { BuildOptions } from '../models/build-options';
 import { Version } from '../upgrade/version';
 
 const Command = require('../ember-cli/lib/models/command');
+
+const config = CliConfig.fromProject() || CliConfig.fromGlobal();
+const pollDefault = config.config.defaults && config.config.defaults.poll;
 
 // defaults for BuildOptions
 export const baseBuildCommandOptions: any = [
@@ -32,6 +36,12 @@ export const baseBuildCommandOptions: any = [
     aliases: ['oh']
   },
   { name: 'stats-json', type: Boolean, default: false },
+  {
+    name: 'poll',
+    type: Number,
+    default: pollDefault,
+    description: 'enable and define the file watching poll time period (milliseconds)'
+  }
 ];
 
 export interface BuildTaskOptions extends BuildOptions {

--- a/packages/@angular/cli/commands/test.ts
+++ b/packages/@angular/cli/commands/test.ts
@@ -2,6 +2,9 @@ const EmberTestCommand = require('../ember-cli/lib/commands/test');
 import TestTask from '../tasks/test';
 import {CliConfig} from '../models/config';
 
+const config = CliConfig.fromProject() || CliConfig.fromGlobal();
+const pollDefault = config.config.defaults && config.config.defaults.poll;
+
 export interface TestOptions {
   watch?: boolean;
   codeCoverage?: boolean;
@@ -15,6 +18,7 @@ export interface TestOptions {
   sourcemap?: boolean;
   progress?: boolean;
   config: string;
+  poll?: number;
 }
 
 
@@ -31,7 +35,13 @@ const TestCommand = EmberTestCommand.extend({
     { name: 'port', type: Number },
     { name: 'reporters', type: String },
     { name: 'build', type: Boolean, default: true },
-    { name: 'sourcemap', type: Boolean, default: true, aliases: ['sm'] }
+    { name: 'sourcemap', type: Boolean, default: true, aliases: ['sm'] },
+    {
+      name: 'poll',
+      type: Number,
+      default: pollDefault,
+      description: 'enable and define the file watching poll time period (milliseconds)'
+    }
   ],
 
   run: function(commandOptions: TestOptions) {

--- a/packages/@angular/cli/models/build-options.ts
+++ b/packages/@angular/cli/models/build-options.ts
@@ -14,4 +14,5 @@ export interface BuildOptions {
   locale?: string;
   extractCss?: boolean;
   outputHashing?: string;
+  poll?: number;
 }

--- a/packages/@angular/cli/plugins/karma.js
+++ b/packages/@angular/cli/plugins/karma.js
@@ -2,7 +2,6 @@ const path = require('path');
 const fs = require('fs');
 
 const getTestConfig = require('../models/webpack-configs/test').getTestConfig;
-const CliConfig = require('../models/config').CliConfig;
 
 function isDirectory(path) {
   try {
@@ -81,7 +80,7 @@ const init = (config) => {
       chunkModules: false
     },
     watchOptions: {
-      poll: CliConfig.fromProject().config.defaults.poll
+      poll: config.angularCli.poll
     }
   };
 

--- a/packages/@angular/cli/tasks/build.ts
+++ b/packages/@angular/cli/tasks/build.ts
@@ -54,7 +54,7 @@ export default Task.extend({
       };
 
       if (runTaskOptions.watch) {
-        webpackCompiler.watch({}, callback);
+        webpackCompiler.watch({ poll: runTaskOptions.poll }, callback);
       } else {
         webpackCompiler.run(callback);
       }

--- a/packages/@angular/cli/tasks/serve.ts
+++ b/packages/@angular/cli/tasks/serve.ts
@@ -109,7 +109,7 @@ export default Task.extend({
       proxy: proxyConfig,
       compress: serveTaskOptions.target === 'production',
       watchOptions: {
-        poll: projectConfig.defaults && projectConfig.defaults.poll
+        poll: serveTaskOptions.poll
       },
       https: serveTaskOptions.ssl,
       overlay: serveTaskOptions.target === 'development'

--- a/packages/@angular/cli/tasks/test.ts
+++ b/packages/@angular/cli/tasks/test.ts
@@ -21,7 +21,8 @@ export default Task.extend({
       karmaOptions.angularCli = {
         codeCoverage: options.codeCoverage,
         sourcemap: options.sourcemap,
-        progress: options.progress
+        progress: options.progress,
+        poll: options.poll
       };
 
       // Assign additional karmaConfig options to the local ngapp config

--- a/tests/e2e/tests/build/poll.ts
+++ b/tests/e2e/tests/build/poll.ts
@@ -1,0 +1,27 @@
+import { appendToFile } from '../../utils/fs';
+import {
+  killAllProcesses,
+  waitForAnyProcessOutputToMatch,
+  silentExecAndWaitForOutputToMatch
+} from '../../utils/process';
+import {expectToFail, wait} from '../../utils/utils';
+
+const webpackGoodRegEx = /webpack: Compiled successfully./;
+
+export default function() {
+  return silentExecAndWaitForOutputToMatch('ng', ['serve', '--poll=10000'], webpackGoodRegEx)
+    // Wait before editing a file.
+    // Editing too soon seems to trigger a rebuild and throw polling out of whack.
+    // .then(() => wait(1000))
+    // .then(() => appendToFile('src/main.ts', 'console.log(1);'))
+    .then(() => waitForAnyProcessOutputToMatch(webpackGoodRegEx, 12000))
+    .then(() => appendToFile('src/main.ts', 'console.log(1);'))
+    // No rebuilds should occur for a while
+    .then(() => expectToFail(() => waitForAnyProcessOutputToMatch(webpackGoodRegEx, 6000)))
+    // But a rebuild should happen roughly within the 10 second window.
+    .then(() => waitForAnyProcessOutputToMatch(webpackGoodRegEx, 12000))
+    .then(() => killAllProcesses(), (err: any) => {
+      killAllProcesses();
+      throw err;
+    });
+}


### PR DESCRIPTION
This also updates `build --watch` to use the poll setting if present.

Closes #4255