### PR TITLE
fix(serve): delete dist on serve

### DIFF
--- a/packages/angular-cli/tasks/serve.ts
+++ b/packages/angular-cli/tasks/serve.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as chalk from 'chalk';
+import * as rimraf from 'rimraf';
 const SilentError = require('silent-error');
 const Task = require('../ember-cli/lib/models/task');
 import * as webpack from 'webpack';
@@ -21,6 +22,9 @@ export default Task.extend({
     let webpackCompiler: any;
     const projectConfig = CliConfig.fromProject().config;
     const appConfig = projectConfig.apps[0];
+
+    const outputPath = serveTaskOptions.outputPath || appConfig.outDir;
+    rimraf.sync(path.resolve(this.project.root, outputPath));
 
     const serveDefaults = {
       // default deployUrl to '' on serve to prevent the default from angular-cli.json


### PR DESCRIPTION
`ng serve` will serve the app from memory, but it's easy to think that it just serves what's in `dist/`.

This way, `dist/` is deleted on `ng serve` and users will not have a `dist/` dir where they might think the files are being served from.

Partially address #4290