### PR TITLE
refactor(new): remove unused git repo logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "html-webpack-plugin": "^2.19.0",
     "inflection": "^1.7.0",
     "inquirer": "^0.12.0",
-    "is-git-url": "^0.2.0",
     "isbinaryfile": "^2.0.3",
     "json-loader": "^0.5.4",
     "karma-sourcemap-loader": "^0.3.7",

--- a/packages/angular-cli/ember-cli/lib/models/command.js
+++ b/packages/angular-cli/ember-cli/lib/models/command.js
@@ -3,7 +3,6 @@
 var nopt                = require('nopt');
 var chalk               = require('chalk');
 var path                = require('path');
-var isGitRepo           = require('is-git-url');
 var camelize            = require('ember-cli-string-utils').camelize;
 var getCallerFile       = require('get-caller-file');
 var printableProperties = require('../utilities/printable-properties').command;
@@ -31,18 +30,6 @@ var allowedWorkOptions = {
 };
 
 path.name = 'Path';
-// extend nopt to recognize 'gitUrl' as a type
-nopt.typeDefs.gitUrl = {
-  type: 'gitUrl',
-  validate: function(data, k, val) {
-    if (isGitRepo(val)) {
-      data[k] = val;
-      return true;
-    } else {
-      return false;
-    }
-  }
-};
 
 module.exports = Command;
 

--- a/packages/angular-cli/ember-cli/lib/tasks/install-blueprint.js
+++ b/packages/angular-cli/ember-cli/lib/tasks/install-blueprint.js
@@ -3,7 +3,6 @@
 var Blueprint     = require('../models/blueprint');
 var Task          = require('../models/task');
 var Promise       = require('../ext/promise');
-var isGitRepo     = require('is-git-url');
 var temp          = require('temp');
 var childProcess  = require('child_process');
 var path          = require('path');
@@ -34,22 +33,10 @@ module.exports = Task.extend({
 
     installOptions = merge(installOptions, options || {});
 
-    if (isGitRepo(blueprintOption)) {
-      return mkdir('ember-cli').then(function(pathName) {
-        var execArgs = ['git', 'clone', blueprintOption, pathName].join(' ');
-        return exec(execArgs).then(function() {
-          return exec('npm install', {cwd: pathName}).then(function() {
-            var blueprint = Blueprint.load(pathName);
-            return blueprint.install(installOptions);
-          });
-        });
-      });
-    } else {
-      var blueprintName = blueprintOption || 'app';
-      var blueprint = Blueprint.lookup(blueprintName, {
-        paths: this.project.blueprintLookupPaths()
-      });
-      return blueprint.install(installOptions);
-    }
+    var blueprintName = blueprintOption || 'app';
+    var blueprint = Blueprint.lookup(blueprintName, {
+      paths: this.project.blueprintLookupPaths()
+    });
+    return blueprint.install(installOptions);
   }
 });

--- a/packages/angular-cli/package.json
+++ b/packages/angular-cli/package.json
@@ -53,7 +53,6 @@
     "html-webpack-plugin": "^2.19.0",
     "inflection": "^1.7.0",
     "inquirer": "^0.12.0",
-    "is-git-url": "^0.2.0",
     "isbinaryfile": "^2.0.3",
     "json-loader": "^0.5.4",
     "karma-sourcemap-loader": "^0.3.7",


### PR DESCRIPTION
The blueprint name is already hardcoded to `ng2`.

Also removes `is-git-url` dependency.