### PR TITLE
feat (webpack): build version for production

### DIFF
--- a/packages/angular-cli/models/webpack-configs/production.ts
+++ b/packages/angular-cli/models/webpack-configs/production.ts
@@ -11,7 +11,8 @@ export const getProdConfig = function (wco: WebpackConfigOptions) {
   return {
     plugins: [
       new webpack.DefinePlugin({
-        'process.env.NODE_ENV': JSON.stringify('production')
+        'process.env.NODE_ENV': JSON.stringify('production'),
+        'process.env.BUILD_VERSION': JSON.stringify(Date.now())
       }),
       new webpack.optimize.UglifyJsPlugin(<any>{
         mangle: { screw_ie8: true },


### PR DESCRIPTION
- [x] Feature Request

Nice feature for production environment. process.env.BUILD_VERSION will be updated on every production build and developers will be able to use this value for many purposes (logging etc.)