### PR TITLE
feat(angular-cli): Add a postinstall warning for Node 4 deprecation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,6 @@ matrix:
     - node_js: "6"
       os: linux
       env: SCRIPT=build
-    - node_js: "4"
-      os: linux
-      env: NODE_SCRIPT=tests/run_e2e.js
     - node_js: "6"
       os: linux
       env: SCRIPT=test

--- a/packages/angular-cli/bin/ng
+++ b/packages/angular-cli/bin/ng
@@ -4,13 +4,16 @@
 // Provide a title to the process in `ps`
 process.title = 'angular-cli';
 
-const resolve = require('resolve');
-const packageJson = require('../package.json');
+const CliConfig = require('../models/config').CliConfig;
 const Version = require('../upgrade/version').Version;
+
+const fs = require('fs');
+const packageJson = require('../package.json');
+const path = require('path');
+const resolve = require('resolve');
+const stripIndents = require('common-tags').stripIndents;
 const yellow = require('chalk').yellow;
 const SemVer = require('semver').SemVer;
-const fs = require('fs');
-const path = require('path');
 
 
 function _fromPackageJson(cwd) {
@@ -59,6 +62,31 @@ if (process.env['NG_CLI_PROFILING']) {
 }
 
 
+// Show the warnings due to package and version deprecation.
+const version = new SemVer(process.version);
+if (version.compare(new SemVer('6.9.0')) < 0
+    && CliConfig.fromGlobal().get('warnings.nodeDeprecation')) {
+  process.stderr.write(yellow(stripIndents`
+    You are running version ${version.version} of Node, which will not be supported in future
+    versions of the CLI. The official Node version that will be supported is 6.9 and greater.
+
+    To disable this warning use "ng set --global warnings.nodeDeprecation=false".
+  `));
+}
+
+
+if (require('../package.json')['name'] == 'angular-cli'
+  && CliConfig.fromGlobal().get('warnings.packageDeprecation')) {
+  process.stderr.write(yellow(stripIndents`
+    As a forewarning, we are moving the CLI npm package to "@angular/cli" with the next release,
+    which will only support Node 6.9 and greater. This package will be officially deprecated
+    shortly after.
+
+    To disable this warning use "ng set --global warnings.packageDeprecation=false".
+  `));
+}
+
+
 resolve('angular-cli', { basedir: process.cwd() },
   function (error, projectLocalCli) {
     var cli;
@@ -85,10 +113,14 @@ resolve('angular-cli', { basedir: process.cwd() },
         shouldWarn = true;
       }
 
-      if (shouldWarn) {
+      if (shouldWarn && CliConfig.fromGlobal().get('warnings.versionMismatch')) {
         // eslint-disable no-console
-        console.log(yellow(`Your global Angular CLI version (${globalVersion}) is greater than `
-          + `your local version (${localVersion}). The local Angular CLI version is used.`));
+        console.log(yellow(stripIndents`
+          Your global Angular CLI version (${globalVersion}) is greater than your local
+          version (${localVersion}). The local Angular CLI version is used.
+  
+          To disable this warning use "ng set --global warnings.versionMismatch=false".
+        `));
       }
 
       // No error implies a projectLocalCli, which will load whatever

--- a/packages/angular-cli/lib/config/schema.json
+++ b/packages/angular-cli/lib/config/schema.json
@@ -292,6 +292,27 @@
         }
       },
       "additionalProperties": false
+    },
+    "warnings": {
+      "description": "Allow people to disable console warnings.",
+      "type": "object",
+      "properties": {
+        "nodeDeprecation": {
+          "description": "Show a warning when the node version is incompatible.",
+          "type": "boolean",
+          "default": true
+        },
+        "packageDeprecation": {
+          "description": "Show a warning when the user installed angular-cli.",
+          "type": "boolean",
+          "default": true
+        },
+        "versionMismatch": {
+          "description": "Show a warning when the global version is newer than the local one.",
+          "type": "boolean",
+          "default": true
+        }
+      }
     }
   },
   "additionalProperties": false


### PR DESCRIPTION
BREAKING CHANGE: Node < 6.9 will be deprecated soon, and this will show a warning to users. Moving forward, that warning will be moved to an error with the next release.