### PR TITLE
Backwards warning that global CLI is greater version than local CLI #…

### DIFF
--- a/packages/@angular/cli/bin/ng
+++ b/packages/@angular/cli/bin/ng
@@ -107,7 +107,7 @@ resolve('@angular/cli', { basedir: process.cwd() },
 
       try {
         localVersion = _fromPackageJson();
-        shouldWarn = localVersion && globalVersion.compare(localVersion) < 0;
+        shouldWarn = localVersion && globalVersion.compare(localVersion) > 0;
       } catch (e) {
         console.error(e);
         shouldWarn = true;


### PR DESCRIPTION
Fixed comparation of versions (inverse).
Fixes https://github.com/angular/angular-cli/issues/4337
