### PR TITLE
fix(@angular/cli): properly check the project status

### DIFF
--- a/packages/@angular/cli/ember-cli/lib/models/command.js
+++ b/packages/@angular/cli/ember-cli/lib/models/command.js
@@ -109,14 +109,14 @@ Command.prototype.validateAndRun = function(args) {
 
   if (this.works === 'insideProject' && !this.isWithinProject) {
     return Promise.reject(new SilentError(
-      'You have to be inside an angular-cli project in order to use ' +
+      'You have to be inside an Angular CLI project in order to use ' +
       'the ' + chalk.green(this.name) + ' command.'
     ));
   }
 
   if (this.works === 'outsideProject' && this.isWithinProject) {
     return Promise.reject(new SilentError(
-      'You cannot use the ' + chalk.green(this.name) + ' command inside an angular-cli project.'
+      'You cannot use the ' + chalk.green(this.name) + ' command inside an Angular CLI project.'
     ));
   }
 

--- a/packages/@angular/cli/ember-cli/lib/models/project.js
+++ b/packages/@angular/cli/ember-cli/lib/models/project.js
@@ -106,7 +106,8 @@ Project.prototype.name = function() {
   @return {Boolean} Whether this is an Ember CLI project
  */
 Project.prototype.isEmberCLIProject = function() {
-  return (this.cli ? this.cli.npmPackage : 'ember-cli') in this.dependencies();
+  return 'angular-cli' in this.dependencies()
+      || '@angular/cli' in this.dependencies();
 };
 
 /**


### PR DESCRIPTION
Check for either angular-cli or @angular/cli in the dependencies of the current project.

Fixes #4379