### PR TITLE
fix(@ngtools/webpack): resolve file name before invalidating cached files

### DIFF
--- a/packages/@ngtools/webpack/src/compiler_host.ts
+++ b/packages/@ngtools/webpack/src/compiler_host.ts
@@ -187,6 +187,7 @@ export class WebpackCompilerHost implements ts.CompilerHost {
   }
 
   invalidate(fileName: string): void {
+    fileName = this._resolve(fileName);
     if (fileName in this._files) {
       this._files[fileName] = null;
       this._changedFiles[fileName] = true;


### PR DESCRIPTION
Fix `WebpackCompilerHost` cache invalidation behavior on Windows systems. Previously, `invalidate` made no call to `_resolve`, causing paths with backslashes not to match the file cache. This caused a watch build to continuously emit the same result.

Fixes #4422
Fixes #4345
Fixes #4338