### PR TITLE
fix(readme): point npm badges to @angular/cli instead of angular-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,5 +467,5 @@ MIT
 [david-badge-url]: https://david-dm.org/angular/angular-cli
 [david-dev-badge]: https://david-dm.org/angular/angular-cli/dev-status.svg
 [david-dev-badge-url]: https://david-dm.org/angular/angular-cli?type=dev
-[npm-badge]: https://img.shields.io/npm/v/angular-cli.svg
-[npm-badge-url]: https://www.npmjs.com/package/angular-cli
+[npm-badge]: https://img.shields.io/npm/v/@angular/cli.svg
+[npm-badge-url]: https://www.npmjs.com/package/@angular/cli


### PR DESCRIPTION
The badges were still pointing to the old package.