### PR TITLE
docs: get rid of remaining angular-cli references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to angular-cli
+# Contributing to Angular CLI
 
 We would love for you to contribute to angular-cli and help make it even better
 than it is today! As a contributor, here are the guidelines we would like you
@@ -18,7 +18,7 @@ Help us keep Angular open and inclusive. Please read and follow our [Code of Con
 
 ## <a name="question"></a> Got a Question or Problem?
 
-If you have questions about how to *use* Angular CLI, please direct them to [StackOverflow][stackoverflow]. Please note that angular-cli is still in early developer preview, and the core team's capacity to answer usage questions is limited. We are also available on [Gitter][gitter].
+If you have questions about how to *use* Angular CLI, please direct them to [StackOverflow][stackoverflow]. Please note that Angular CLI is still in early developer preview, and the core team's capacity to answer usage questions is limited. We are also available on [Gitter][gitter].
 
 ## <a name="issue"></a> Found an Issue?
 If you find a bug in the source code or a mistake in the documentation, you can help us by

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ with NPM 3 or higher.
 * [CSS preprocessor integration](#css-preprocessor-integration)
 * [3rd Party Library Installation](#3rd-party-library-installation)
 * [Global Library Installation](#global-library-installation)
-* [Updating angular-cli](#updating-angular-cli)
-* [Development Hints for hacking on angular-cli](#development-hints-for-hacking-on-angular-cli)
+* [Updating Angular CLI](#updating-angular-cli)
+* [Development Hints for hacking on Angular CLI](#development-hints-for-hacking-on-angular-cli)
 
 ## Installation
 
@@ -392,21 +392,21 @@ your app.
 
 <!-- DeleteSection2 End here -->
 
-### Updating angular-cli
+### Updating Angular CLI
 
-To update `angular-cli` to a new version, you must update both the global package and your project's local package.
+To update Angular CLI to a new version, you must update both the global package and your project's local package.
 
 Global package:
 ```bash
-npm uninstall -g angular-cli
+npm uninstall -g angular-cli @angular/cli
 npm cache clean
-npm install -g angular-cli@latest
+npm install -g @angular/cli@latest
 ```
 
 Local project package:
 ```bash
 rm -rf node_modules dist # use rmdir on Windows
-npm install --save-dev angular-cli@latest
+npm install --save-dev @angular/cli@latest
 npm install
 ng update
 ```
@@ -420,7 +420,7 @@ Carefully read the diffs for each code file, and either accept the changes or in
 You can find more details about changes between versions in [CHANGELOG.md](https://github.com/angular/angular-cli/blob/master/CHANGELOG.md).
 
 
-## Development Hints for hacking on angular-cli
+## Development Hints for hacking on Angular CLI
 
 ### Working with master
 
@@ -432,25 +432,25 @@ npm link
 
 `npm link` is very similar to `npm install -g` except that instead of downloading the package
 from the repo, the just cloned `angular-cli/` folder becomes the global package.
-Any changes to the files in the `angular-cli/` folder will immediately affect the global `angular-cli` package,
+Any changes to the files in the `angular-cli/` folder will immediately affect the global `@angular/cli` package,
 allowing you to quickly test any changes you make to the cli project.
 
-Now you can use `angular-cli` via the command line:
+Now you can use `@angular/cli` via the command line:
 
 ```bash
 ng new foo
 cd foo
-npm link angular-cli
+npm link @angular/cli
 ng serve
 ```
 
-`npm link angular-cli` is needed because by default the globally installed `angular-cli` just loads
-the local `angular-cli` from the project which was fetched remotely from npm.
-`npm link angular-cli` symlinks the global `angular-cli` package to the local `angular-cli` package.
+`npm link @angular/cli` is needed because by default the globally installed `@angular/cli` just loads
+the local `@angular/cli` from the project which was fetched remotely from npm.
+`npm link @angular/cli` symlinks the global `@angular/cli` package to the local `@angular/cli` package.
 Now the `angular-cli` you cloned before is in three places:
-The folder you cloned it into, npm's folder where it stores global packages and the `angular-cli` project you just created.
+The folder you cloned it into, npm's folder where it stores global packages and the Angular CLI project you just created.
 
-You can also use `ng new foo --link-cli` to automatically link the `angular-cli` package.
+You can also use `ng new foo --link-cli` to automatically link the `@angular/cli` package.
 
 Please read the official [npm-link documentation](https://www.npmjs.org/doc/cli/npm-link.html)
 and the [npm-link cheatsheet](http://browsenpm.org/help#linkinganynpmpackagelocally) for more information.

--- a/docs/documentation/overview.md
+++ b/docs/documentation/overview.md
@@ -6,9 +6,9 @@
 The Angular CLI is a tool to initialize, develop, scaffold  and maintain [Angular](https://angular.io) applications
 
 ### Getting Started
-To install the angular-cli:
+To install the Angular CLI:
 ```
-npm install -g angular-cli
+npm install -g @angular/cli
 ```
 
 Generating and serving an Angular project via a development server

--- a/packages/@angular/cli/blueprints/ng2/files/README.md
+++ b/packages/@angular/cli/blueprints/ng2/files/README.md
@@ -1,6 +1,6 @@
 # <%= jsComponentName %>
 
-This project was generated with [angular-cli](https://github.com/angular/angular-cli) version <%= version %>.
+This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version <%= version %>.
 
 ## Development server
 Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The app will automatically reload if you change any of the source files.
@@ -24,4 +24,4 @@ Before running the tests make sure you are serving the app via `ng serve`.
 
 ## Further help
 
-To get more help on the `angular-cli` use `ng help` or go check out the [Angular-CLI README](https://github.com/angular/angular-cli/blob/master/README.md).
+To get more help on the Angular CLI use `ng help` or go check out the [Angular-CLI README](https://github.com/angular/angular-cli/blob/master/README.md).

--- a/packages/@angular/cli/commands/init.ts
+++ b/packages/@angular/cli/commands/init.ts
@@ -2,7 +2,7 @@ const Command = require('../ember-cli/lib/models/command');
 
 const InitCommand: any = Command.extend({
   name: 'init',
-  description: 'Creates a new angular-cli project in the current folder.',
+  description: 'Creates a new Angular CLI project in the current folder.',
   aliases: ['u', 'update', 'i'],
   works: 'everywhere',
 

--- a/packages/@angular/cli/commands/version.ts
+++ b/packages/@angular/cli/commands/version.ts
@@ -5,7 +5,7 @@ import * as chalk from 'chalk';
 
 const VersionCommand = Command.extend({
   name: 'version',
-  description: 'outputs angular-cli version',
+  description: 'outputs Angular CLI version',
   aliases: ['v', '--version', '-v'],
   works: 'everywhere',
 

--- a/packages/@angular/cli/models/config.ts
+++ b/packages/@angular/cli/models/config.ts
@@ -57,7 +57,7 @@ export class CliConfig extends CliConfigBase<ConfigInterface> {
       console.error(chalk.yellow(oneLine`
         The "defaults.prefix" and "defaults.sourceDir" properties of angular-cli.json
         are deprecated in favor of "apps[0].root" and "apps[0].prefix".\n
-        Please update in order to avoid errors in future versions of angular-cli.
+        Please update in order to avoid errors in future versions of Angular CLI.
       `));
     }
 
@@ -85,7 +85,7 @@ export class CliConfig extends CliConfigBase<ConfigInterface> {
       console.error(chalk.yellow(oneLine`
         The "defaults.prefix" and "defaults.sourceDir" properties of angular-cli.json
         are deprecated in favor of "apps[0].root" and "apps[0].prefix".\n
-        Please update in order to avoid errors in future versions of angular-cli.
+        Please update in order to avoid errors in future versions of Angular CLI.
       `));
     }
 

--- a/packages/@angular/cli/plugins/karma.js
+++ b/packages/@angular/cli/plugins/karma.js
@@ -61,7 +61,7 @@ const init = (config) => {
   config.webpack = Object.assign(webpackConfig, config.webpack);
   config.webpackMiddleware = Object.assign(webpackMiddlewareConfig, config.webpackMiddleware);
 
-  // replace the angular-cli preprocessor with webpack+sourcemap
+  // replace the @angular/cli preprocessor with webpack+sourcemap
   Object.keys(config.preprocessors)
     .filter((file) => config.preprocessors[file].indexOf('@angular/cli') !== -1)
     .map((file) => config.preprocessors[file])

--- a/plugins/karma.js
+++ b/plugins/karma.js
@@ -1,4 +1,4 @@
 // This file is necessary when using a linked angular-cli to this repo, meaning that
-// require('angular-cli/plugins/karma') will load this file, and we just forward to
+// require('@angular/cli/plugins/karma') will load this file, and we just forward to
 // the actual published file.
 module.exports = require('../packages/@angular/cli/plugins/karma');


### PR DESCRIPTION
This commit changes 2 things:
1. Changes remaining angular-cli package references to @angular/cli.
2. Where angular-cli was mentioned as a project name, it's been changed
   to Angular CLI.

Where angular-cli was meant to mean the repository name, it's been left
unchanged.