### PR TITLE
style(@angular/cli): fix INITIAL_COMMIT_MESSAGE

### DIFF
--- a/packages/@angular/cli/utilities/INITIAL_COMMIT_MESSAGE.txt
+++ b/packages/@angular/cli/utilities/INITIAL_COMMIT_MESSAGE.txt
@@ -1,4 +1,5 @@
 chore: initial commit from @angular/cli
+
                           _                      _ _ 
    __ _ _ __   __ _ _   _| | __ _ _ __       ___| (_)
   / _  |  _ \ / _  | | | | |/ _  |  __|____ / __| | |


### PR DESCRIPTION
Git commit messages should always have a blank line after the title.