### PR TITLE
feat(update): Ignore spaces and EOLs when comparing files

### DIFF
--- a/docs/documentation/update.md
+++ b/docs/documentation/update.md
@@ -8,6 +8,8 @@
 Initialization is done in-place, meaning that the generated application is initialized in the current directory.
 
 ## Options
+`--compare-spaces` (`-cs`) flag to indicate whether to compare spaces when comparing files
+
 `--dry-run` (`-d`) run through without making any changes
 
 `--skip-npm` (`-sn`) skip installing npm packages

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "cssnano": "^3.10.0",
     "debug": "^2.1.3",
     "denodeify": "^1.2.1",
-    "diff": "^2.2.2",
+    "diff": "^3.2.0",
     "ember-cli-normalize-entity-name": "^1.0.0",
     "ember-cli-string-utils": "^1.0.0",
     "enhanced-resolve": "^2.3.0",

--- a/packages/@angular/cli/commands/init.run.ts
+++ b/packages/@angular/cli/commands/init.run.ts
@@ -57,6 +57,7 @@ export default function initRun(commandOptions: any, rawArgs: string[]) {
   }
 
   const blueprintOpts = {
+    compareSpaces: commandOptions.compareSpaces,
     dryRun: commandOptions.dryRun,
     blueprint: 'ng2',
     rawName: packageName,

--- a/packages/@angular/cli/commands/init.ts
+++ b/packages/@angular/cli/commands/init.ts
@@ -7,6 +7,7 @@ const InitCommand: any = Command.extend({
   works: 'everywhere',
 
   availableOptions: [
+    { name: 'compare-spaces', type: Boolean, default: false, aliases: ['cs'] },
     { name: 'dry-run', type: Boolean, default: false, aliases: ['d'] },
     { name: 'verbose', type: Boolean, default: false, aliases: ['v'] },
     { name: 'link-cli', type: Boolean, default: false, aliases: ['lc'] },

--- a/packages/@angular/cli/ember-cli/lib/models/blueprint.js
+++ b/packages/@angular/cli/ember-cli/lib/models/blueprint.js
@@ -673,6 +673,7 @@ Blueprint.prototype.buildFileInfo = function(destPath, templateVariables, file) 
     displayPath: path.normalize(mappedPath),
     inputPath: this.srcPath(file),
     templateVariables: templateVariables,
+    compareSpaces: this.options.compareSpaces,
     ui: this.ui
   });
 };


### PR DESCRIPTION
* Update `diff` dependency to `v3.2.0`.
* Add `normalizeEOL` and `stringsAreEqual` helper functions in `file-info.js`.
* Always normalize EOL when comparing files and creating diff patch.
* Add `--compare-spaces` option to `update` command.
* `update` command now ignores spaces when comparing, by default.

Closes #2083