### PR TITLE
Fix for #3847

### DIFF
--- a/packages/@ngtools/webpack/src/compiler_host.ts
+++ b/packages/@ngtools/webpack/src/compiler_host.ts
@@ -117,14 +117,18 @@ export class WebpackCompilerHost implements ts.CompilerHost {
   private _resolve(path: string) {
     path = this._normalizePath(path);
     if (path[0] == '.') {
-      return join(this.getCurrentDirectory(), path);
+      path = join(this.getCurrentDirectory(), path);
     } else if (path[0] == '/' || path.match(/^\w:\//)) {
-      return path;
+      // return path;
     } else {
-      return join(this._basePath, path);
+      path = join(this._basePath, path);
     }
+    // FIX symlink duplication in npm linked modules (#3875)
+    if (fs.existsSync(path)) {
+      path = fs.realpathSync(path);
+    }
+    return path;
   }
-
   private _setFileContent(fileName: string, content: string) {
     this._files[fileName] = new VirtualFileStats(fileName, content);
 


### PR DESCRIPTION
The problem: duplication of symlinked source files (npm linked sources) in CompilerHost's stats.
The solution: resolve these paths before of all
Gift of jdavidls

Exact same as: #3877 but with a new master.

(I remade this because Travis CI build was failing see: #4354)