### PR TITLE
fix(@angular/cli): add a dependency to RXJS

### DIFF
--- a/packages/@angular/cli/lib/cli/index.js
+++ b/packages/@angular/cli/lib/cli/index.js
@@ -1,8 +1,9 @@
 /*eslint-disable no-console */
 
-// Prevent the dependency validation from tripping because we don't import zone.js. We need
+// Prevent the dependency validation from tripping because we don't import these. We need
 // it as a peer dependency of @angular/core.
 // require('zone.js')
+// require('rxjs')
 
 
 // This file hooks up on require calls to transpile TypeScript.

--- a/packages/@angular/cli/package.json
+++ b/packages/@angular/cli/package.json
@@ -74,6 +74,7 @@
     "resolve": "^1.1.7",
     "rimraf": "^2.5.3",
     "rsvp": "^3.0.17",
+    "rxjs": "^5.0.1",
     "sass-loader": "^4.1.1",
     "script-loader": "^0.7.0",
     "semver": "^5.1.0",


### PR DESCRIPTION
Projects dont have a problem with it because they have that dependency directly, but
global installs dont have rxjs and will error out.