### PR TITLE
refactor(build): replace `source` in environments with `environmentDe…

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,11 +144,12 @@ By default, the development build target and environment are used.
 The mapping used to determine which environment file is used can be found in `angular-cli.json`:
 
 ```json
+"environmentSource": "environments/environment.ts",
 "environments": {
-  "source": "environments/environment.ts",
   "dev": "environments/environment.ts",
   "prod": "environments/environment.prod.ts"
 }
+
 ```
 
 These options also apply to the serve command. If you do not pass a value for `environment`,

--- a/docs/documentation/overview.md
+++ b/docs/documentation/overview.md
@@ -29,8 +29,8 @@ By default, the development build target and environment are used.
 The mapping used to determine which environment file is used can be found in `angular-cli.json`:
 
 ```json
+"environmentSource": "environments/environment.ts",
 "environments": {
-  "source": "environments/environment.ts",
   "dev": "environments/environment.ts",
   "prod": "environments/environment.prod.ts"
 }

--- a/packages/@angular/cli/blueprints/ng2/files/angular-cli.json
+++ b/packages/@angular/cli/blueprints/ng2/files/angular-cli.json
@@ -21,8 +21,8 @@
         "styles.<%= styleExt %>"
       ],
       "scripts": [],
+      "environmentSource": "environments/environment.ts",
       "environments": {
-        "source": "environments/environment.ts",
         "dev": "environments/environment.ts",
         "prod": "environments/environment.prod.ts"
       }

--- a/packages/@angular/cli/lib/config/schema.json
+++ b/packages/@angular/cli/lib/config/schema.json
@@ -131,6 +131,11 @@
             },
             "additionalProperties": false
           },
+          "environmentSource": {
+            "description": "Source file for environment config.",
+            "type": "string",
+            "additionalProperties": true
+          },
           "environments": {
             "description": "Name and corresponding file for environment config.",
             "type": "object",

--- a/packages/@angular/cli/models/webpack-configs/common.ts
+++ b/packages/@angular/cli/models/webpack-configs/common.ts
@@ -74,7 +74,8 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
   // process environment file replacement
   if (appConfig.environments) {
     if (!('source' in appConfig.environmentSource)) {
-      throw new SilentError(`Environment configuration does not contain "environmentSource" entry.`);
+      throw new SilentError(`Environment configuration does not contain
+        "environmentSource" entry.`);
     }
     if (!(buildOptions.environment in appConfig.environments)) {
       throw new SilentError(`Environment "${buildOptions.environment}" does not exist.`);

--- a/packages/@angular/cli/models/webpack-configs/common.ts
+++ b/packages/@angular/cli/models/webpack-configs/common.ts
@@ -73,8 +73,8 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
 
   // process environment file replacement
   if (appConfig.environments) {
-    if (!('source' in appConfig.environments)) {
-      throw new SilentError(`Environment configuration does not contain "source" entry.`);
+    if (!('source' in appConfig.environmentSource)) {
+      throw new SilentError(`Environment configuration does not contain "environmentSource" entry.`);
     }
     if (!(buildOptions.environment in appConfig.environments)) {
       throw new SilentError(`Environment "${buildOptions.environment}" does not exist.`);
@@ -84,7 +84,7 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
       // This plugin is responsible for swapping the environment files.
       // Since it takes a RegExp as first parameter, we need to escape the path.
       // See https://webpack.github.io/docs/list-of-plugins.html#normalmodulereplacementplugin
-      new RegExp(path.resolve(appRoot, appConfig.environments['source'])
+      new RegExp(path.resolve(appRoot, appConfig['environmentSource'])
         .replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&')),
       path.resolve(appRoot, appConfig.environments[buildOptions.environment])
     ));

--- a/packages/@angular/cli/models/webpack-configs/test.js
+++ b/packages/@angular/cli/models/webpack-configs/test.js
@@ -104,7 +104,7 @@ const getTestConfig = function (projectRoot, environment, appConfig, testConfig)
         // This plugin is responsible for swapping the environment files.
         // Since it takes a RegExp as first parameter, we need to escape the path.
         // See https://webpack.github.io/docs/list-of-plugins.html#normalmodulereplacementplugin
-        new RegExp(path.resolve(appRoot, appConfig.environments['source'])
+        new RegExp(path.resolve(appRoot, appConfig['source'])
           .replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&')),
         path.resolve(appRoot, appConfig.environments[environment])
       ),


### PR DESCRIPTION
…fault` entry

Replace source in environments with separate environmentDefault entry and updated docs to reflect this change

BREAKING CHANGE: angular-cli.json has changed. A new environmentDefault entry replaces the previous source entry inside environments.

To migrate the code follow the example below:

Before:

"environments": {
"source": "environments/environment.ts",
	"dev": "environments/environment.ts",
	"prod": "environments/environment.prod.ts"
}

After:

"environmentSource": "environments/environment.ts",
"environments": {
	"dev": "environments/environment.ts",
	"prod": "environments/environment.prod.ts"
}

Closes #3857