### PR TITLE
docs: Improve "updating angular cli" steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,11 +392,17 @@ your app.
 
 ### Updating Angular CLI
 
+If you're using Angular CLI `beta.28` or less, you need to uninstall `angular-cli` package. It should be done due to changing of package's name and scope from `angular-cli` to `@angular/cli`:
+```bash
+npm uninstall -g angular-cli
+npm uninstall --save-dev angular-cli
+```
+
 To update Angular CLI to a new version, you must update both the global package and your project's local package.
 
 Global package:
 ```bash
-npm uninstall -g angular-cli @angular/cli
+npm uninstall -g @angular/cli
 npm cache clean
 npm install -g @angular/cli@latest
 ```


### PR DESCRIPTION
Add step that removes "angular-cli" from "package.json" to make sure that after
upgrading from "angular-cli" to "@angular/cli" only "@angular/cli" is installed
into "node_modules".

It's needed to avoid problems with npm run scripts that uses "ng" command.

Otherwise, there will be an error ("You have to be inside an angular-cli project in
order to use the test command.") when running "npm start", "npm test" or
"npm run ng -- ..." commands.

Here are related issues: #4463, #4439