### PR TITLE
Bail out if output path is the root folder

### DIFF
--- a/packages/@angular/cli/tasks/serve.ts
+++ b/packages/@angular/cli/tasks/serve.ts
@@ -24,6 +24,9 @@ export default Task.extend({
     const appConfig = projectConfig.apps[0];
 
     const outputPath = serveTaskOptions.outputPath || appConfig.outDir;
+    if (this.project.root === outputPath) {
+      throw new SilentError ('Output path MUST not be project root directory!');
+    }
     rimraf.sync(path.resolve(this.project.root, outputPath));
 
     const serveDefaults = {


### PR DESCRIPTION
`ng serve --output-path=.` would wipe out the entire root folder otherwise.
This PR prevent issue #4481 from occurring, this closes #4481.