### PR TITLE
feat(@angular/cli): add schema to the config

### DIFF
--- a/packages/@angular/cli/blueprints/ng2/files/angular-cli.json
+++ b/packages/@angular/cli/blueprints/ng2/files/angular-cli.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
   "project": {
     "version": "<%= version %>",
     "name": "<%= htmlComponentName %>"


### PR DESCRIPTION
So IDEs can actually use auto-completion, for example. This uses the installed
@angular/cli in node_modules, so versions are updated correctly.