### PR TITLE
feat(@angular/cli): add in-browser development error overlay

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "url-loader": "^0.5.7",
     "walk-sync": "^0.3.1",
     "webpack": "~2.2.0",
-    "webpack-dev-server": "~2.2.0",
+    "webpack-dev-server": "~2.3.0",
     "webpack-merge": "^2.4.0",
     "webpack-sources": "^0.1.3",
     "zone.js": "^0.7.2"

--- a/packages/@angular/cli/custom-typings.d.ts
+++ b/packages/@angular/cli/custom-typings.d.ts
@@ -20,6 +20,7 @@ interface IWebpackDevServerConfigurationOptions {
   https?: boolean;
   key?: string;
   cert?: string;
+  overlay?: boolean;
 }
 
 interface WebpackProgressPluginOutputOptions {

--- a/packages/@angular/cli/package.json
+++ b/packages/@angular/cli/package.json
@@ -81,7 +81,7 @@
     "url-loader": "^0.5.7",
     "walk-sync": "^0.3.1",
     "webpack": "~2.2.0",
-    "webpack-dev-server": "~2.2.0",
+    "webpack-dev-server": "~2.3.0",
     "webpack-merge": "^2.4.0",
     "webpack-sources": "^0.1.3",
     "zone.js": "^0.7.2"

--- a/packages/@angular/cli/tasks/serve.ts
+++ b/packages/@angular/cli/tasks/serve.ts
@@ -112,7 +112,8 @@ export default Task.extend({
       watchOptions: {
         poll: projectConfig.defaults && projectConfig.defaults.poll
       },
-      https: serveTaskOptions.ssl
+      https: serveTaskOptions.ssl,
+      overlay: serveTaskOptions.target === 'development'
     };
 
     if (sslKey != null && sslCert != null) {


### PR DESCRIPTION
Implements the feature described in #3502 by leveraging the new capability in webpack-dev-server 2.3.0.

Closes #3502