### PR TITLE
(fix) allow wider webpack versions in @ngtools/webpack

### DIFF
--- a/packages/@ngtools/webpack/package.json
+++ b/packages/@ngtools/webpack/package.json
@@ -36,6 +36,6 @@
     "@angular/core": "^2.3.1",
     "@angular/tsc-wrapped": "^0.5.0",
     "typescript": "^2.0.2",
-    "webpack": "2.2.0"
+    "webpack": "^2.2.0"
   }
 }


### PR DESCRIPTION
Fixes #4524