### PR TITLE
removed npm install step from upgrade process

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,7 +405,6 @@ Local project package:
 ```bash
 rm -rf node_modules dist # use rmdir on Windows
 npm install --save-dev @angular/cli@latest
-npm install
 ng update
 ```
 


### PR DESCRIPTION
Because npm install is running as part of `ng update`.
And also, if someone updates their package.json as part of `ng update`, one might wanna npm install only after that.