### PR TITLE
fix(@ngtools/webpack): invalidate all the files changed

### DIFF
--- a/packages/@ngtools/webpack/src/plugin.ts
+++ b/packages/@ngtools/webpack/src/plugin.ts
@@ -237,12 +237,14 @@ export class AotPlugin implements Tapable {
   apply(compiler: any) {
     this._compiler = compiler;
 
-    compiler.plugin('invalid', (fileName: string) => {
+    compiler.plugin('invalid', () => {
       // Turn this off as soon as a file becomes invalid and we're about to start a rebuild.
       this._firstRun = false;
       this._diagnoseFiles = {};
 
-      this._compilerHost.invalidate(fileName);
+      compiler.watchFileSystem.watcher.once('aggregated', (changes: string[]) => {
+        changes.forEach((fileName: string) => this._compilerHost.invalidate(fileName));
+      });
     });
 
     // Add lazy modules to the context module for @angular/core/src/linker

--- a/tests/e2e/utils/fs.ts
+++ b/tests/e2e/utils/fs.ts
@@ -82,11 +82,8 @@ export function copyFile(from: string, to: string) {
 }
 
 
-export function writeMultipleFiles(fs: any) {
-  return Object.keys(fs)
-    .reduce((previous, curr) => {
-      return previous.then(() => writeFile(curr, fs[curr]));
-    }, Promise.resolve());
+export function writeMultipleFiles(fs: { [path: string]: string }) {
+  return Promise.all(Object.keys(fs).map(fileName => writeFile(fileName, fs[fileName])));
 }
 
 


### PR DESCRIPTION
Webpack only passes the first file that was changed. If there are multiple,
we need to validate all of them. For that we result to listening to Watchpack
directly.

Fixes #4453 
Fixes #4511 
