### PR TITLE
ci: make ng4 optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
   allow_failures:
     - node_js: "7"
     - env: NODE_SCRIPT="tests/run_e2e.js --nightly"
+    - env: NODE_SCRIPT="tests/run_e2e.js --ng4"
   include:
     - node_js: "6"
       os: linux


### PR DESCRIPTION
The ng4 job was in the optional section but wasn't added to the allowed failures.