### PR TITLE
feat(test): extend karma.conf.js w/ kjhtml reporter

### DIFF
--- a/packages/@angular/cli/blueprints/ng2/files/karma.conf.js
+++ b/packages/@angular/cli/blueprints/ng2/files/karma.conf.js
@@ -8,9 +8,13 @@ module.exports = function (config) {
     plugins: [
       require('karma-jasmine'),
       require('karma-chrome-launcher'),
+      require('karma-jasmine-html-reporter'),
       require('karma-coverage-istanbul-reporter'),
       require('@angular/cli/plugins/karma')
     ],
+    client:{
+      clearContext: false // leave Jasmine Spec Runner output visible in browser
+    },
     files: [
       { pattern: './<%= sourceDir %>/test.ts', watched: false }
     ],
@@ -30,7 +34,7 @@ module.exports = function (config) {
     },
     reporters: config.angularCli && config.angularCli.codeCoverage
               ? ['progress', 'coverage-istanbul']
-              : ['progress'],
+              : ['progress', 'kjhtml'],
     port: 9876,
     colors: true,
     logLevel: config.LOG_INFO,

--- a/packages/@angular/cli/blueprints/ng2/files/package.json
+++ b/packages/@angular/cli/blueprints/ng2/files/package.json
@@ -36,6 +36,7 @@
     "karma-chrome-launcher": "~2.0.0",
     "karma-cli": "~1.0.1",
     "karma-jasmine": "~1.1.0",
+    "karma-jasmine-html-reporter": "^0.2.2",
     "karma-coverage-istanbul-reporter": "^0.2.0",
     "protractor": "~5.1.0",
     "ts-node": "~2.0.0",


### PR DESCRIPTION
Add karma-jasmine-html-reporter (kjhtml) which displays Jasmine test runner in the test browser.

We use this in docs testing chapter so users can visualize their tests in the test browser rather than see a blank page.  Convenient for exploring broken tests and re-running certain specific tests.

![image](https://cloud.githubusercontent.com/assets/129061/22795866/07dd5dca-eead-11e6-9d05-98edc37209dd.png)

Has no apparent ill-effects on CI. We run these tests with this config in docs CI.

Deliberately excluded from the test/code-coverage combo ... for no great reason other than I thought someone who was running with code-coverage wouldn't want it.