### PR TITLE
fix(@ngtools/webpack) rename deprecated magicString.insertLeft() to appendLeft()

### DIFF
--- a/packages/@ngtools/webpack/src/refactor.ts
+++ b/packages/@ngtools/webpack/src/refactor.ts
@@ -128,11 +128,11 @@ export class TypeScriptFileRefactor {
     this._sourceString.appendRight(node.getEnd(), text);
   }
   append(node: ts.Node, text: string): void {
-    this._sourceString.insertLeft(node.getEnd(), text);
+    this._sourceString.appendLeft(node.getEnd(), text);
   }
 
   prependBefore(node: ts.Node, text: string) {
-    this._sourceString.insertLeft(node.getStart(), text);
+    this._sourceString.appendLeft(node.getStart(), text);
   }
 
   insertImport(symbolName: string, modulePath: string): void {


### PR DESCRIPTION
Fixes #4581