### PR TITLE
feat(@angular/cli): add --compress option

### DIFF
--- a/docs/documentation/build.md
+++ b/docs/documentation/build.md
@@ -93,4 +93,6 @@ or `ng serve --prod` will also make use of uglifying and tree-shaking functional
 
 `--extract-css` (`-ec`) extract css from global styles onto css files instead of js ones
 
+`--compress` use gzip compression in production mode
+
 `--output-hashing` define the output filename cache-busting hashing mode

--- a/docs/documentation/serve.md
+++ b/docs/documentation/serve.md
@@ -58,4 +58,6 @@
 
 `--extract-css` (`-ec`) extract css from global styles onto css files instead of js ones
 
+`--compress` use gzip compression in production mode
+
 `--output-hashing` define the output filename cache-busting hashing mode

--- a/packages/@angular/cli/commands/build.ts
+++ b/packages/@angular/cli/commands/build.ts
@@ -25,6 +25,12 @@ export const baseBuildCommandOptions: any = [
   { name: 'locale', type: String },
   { name: 'extract-css', type: Boolean, aliases: ['ec'] },
   {
+    name: 'compress',
+    type: Boolean,
+    default: true,
+    description: 'use gzip compression in production mode'
+  },
+  {
     name: 'output-hashing',
     type: String,
     values: ['none', 'all', 'media', 'bundles'],

--- a/packages/@angular/cli/models/build-options.ts
+++ b/packages/@angular/cli/models/build-options.ts
@@ -13,5 +13,6 @@ export interface BuildOptions {
   i18nFormat?: string;
   locale?: string;
   extractCss?: boolean;
+  compress?: boolean;
   outputHashing?: string;
 }

--- a/packages/@angular/cli/models/webpack-config.ts
+++ b/packages/@angular/cli/models/webpack-config.ts
@@ -81,6 +81,7 @@ export class NgCliWebpackConfig {
         outputHashing: 'all',
         sourcemap: false,
         extractCss: true,
+        compress: true,
         aot: true
       }
     };

--- a/packages/@angular/cli/models/webpack-configs/production.ts
+++ b/packages/@angular/cli/models/webpack-configs/production.ts
@@ -76,12 +76,13 @@ export const getProdConfig = function (wco: WebpackConfigOptions) {
         compress: { screw_ie8: true, warnings: buildOptions.verbose },
         sourceMap: buildOptions.sourcemap
       }),
-      new CompressionPlugin({
-        asset: '[path].gz[query]',
-        algorithm: 'gzip',
-        test: /\.js$|\.html$|\.css$/,
-        threshold: 10240
-      })
+      buildOptions.compress ?
+        new CompressionPlugin({
+          asset: '[path].gz[query]',
+          algorithm: 'gzip',
+          test: /\.js$|\.html$|\.css$/,
+          threshold: 10240
+        }) : (): void => null
     ].concat(extraPlugins)
   };
 };

--- a/packages/@angular/cli/tasks/serve.ts
+++ b/packages/@angular/cli/tasks/serve.ts
@@ -108,7 +108,7 @@ export default Task.extend({
       stats: statsConfig,
       inline: true,
       proxy: proxyConfig,
-      compress: serveTaskOptions.target === 'production',
+      compress: serveTaskOptions.target === 'production' && serveTaskOptions.compress,
       watchOptions: {
         poll: projectConfig.defaults && projectConfig.defaults.poll
       },


### PR DESCRIPTION
By default, gzip compression is enabled in `production` mode. There are several use cases, where gzip compression might not be supported and/or required

- [x] Environments where gzip compression is not required
  - App frameworks using native WebViews (eg. [Apache Cordova](https://cordova.apache.org/), [Phonegap](http://phonegap.com/))
  - Web Extensions (eg. [Mozilla Firefox](https://developer.mozilla.org/en-US/Add-ons/WebExtensions), [Google Chrome](https://developer.chrome.com/extensions) and [Microsoft Edge](https://docs.microsoft.com/en-us/microsoft-edge/extensions))
- [x] Environments where a server-side compression method is preferred

Usage

```sh
$ ng build --prod --compress=false
```

or

```sh
$ ng serve --prod --compress=false
```

Example Output

```sh
$ ng --help
ng build <options...>
  Builds your app and places it into the output path (dist/ by default).
  aliases: b
  --target (String) (Default: development)
    aliases: -t <value>, -dev (--target=development), -prod (--target=production)
  ...
  --compress (Boolean) (Default: true) use gzip compression in production mode
  ...
```

Basic Implementation

We simply wrap the plugin with a conditional operator and void the output, if the expression evaluates to `false`

```ts
  plugins: [
    ...
    buildOptions.compress ? new CompressionPlugin({...}) : (): void => null
  ]
```

This is perfectly fine, since Webpack installs a plugin by calling its `apply` method, passing a reference to the Webpack compiler object.

Related Issues

- https://github.com/angular/angular-cli/pull/2621#issuecomment-253851611
- https://github.com/angular/angular-cli/issues/2028

Related Pull Requests
- https://github.com/angular/angular-cli/pull/2621