### PR TITLE
fix(@angular/cli): serve --live-reload option

### DIFF
--- a/docs/documentation/serve.md
+++ b/docs/documentation/serve.md
@@ -12,6 +12,8 @@
 
 `--proxy-config` (`-pc`) proxy configuration file
 
+`--watch` (`-w`) flag to turn off watch mode
+
 `--live-reload` (`-lr`) flag to turn off live reloading
 
 `--live-reload-host` (`-lrh`) specify the host for live reloading

--- a/packages/@angular/cli/commands/serve.ts
+++ b/packages/@angular/cli/commands/serve.ts
@@ -17,6 +17,7 @@ const defaultPort = process.env.PORT || config.get('defaults.serve.port');
 const defaultHost = config.get('defaults.serve.host');
 
 export interface ServeTaskOptions extends BuildOptions {
+  watch?: boolean;
   port?: number;
   host?: string;
   proxyConfig?: string;
@@ -43,6 +44,7 @@ export const baseServeCommandOptions: any = baseBuildCommandOptions.concat([
     description: `Listens only on ${defaultHost} by default`
   },
   { name: 'proxy-config', type: 'Path', aliases: ['pc'] },
+  { name: 'watch', type: Boolean, default: true, aliases: ['w'] },
   { name: 'ssl', type: Boolean, default: false },
   { name: 'ssl-key', type: String, default: 'ssl/server.key' },
   { name: 'ssl-cert', type: String, default: 'ssl/server.crt' },
@@ -61,7 +63,12 @@ const ServeCommand = Command.extend({
   aliases: ['server', 's'],
 
   availableOptions: baseServeCommandOptions.concat([
-    { name: 'live-reload', type: Boolean, default: true, aliases: ['lr'] },
+    {
+      name: 'live-reload',
+      type: Boolean,
+      aliases: ['lr'],
+      description: 'Defaults to watch'
+    },
     {
       name: 'live-reload-host',
       type: String,
@@ -99,6 +106,7 @@ const ServeCommand = Command.extend({
 
     Version.assertAngularVersionIs2_3_1OrHigher(this.project.root);
     commandOptions.liveReloadHost = commandOptions.liveReloadHost || commandOptions.host;
+    commandOptions.liveReload = commandOptions.liveReload || commandOptions.watch;
 
     return checkExpressPort(commandOptions)
       .then(() => autoFindLiveReloadPort(commandOptions))

--- a/packages/@angular/cli/custom-typings.d.ts
+++ b/packages/@angular/cli/custom-typings.d.ts
@@ -9,6 +9,7 @@ interface IWebpackDevServerConfigurationOptions {
   noInfo?: boolean;
   lazy?: boolean;
   filename?: string;
+  watch?: boolean;
   watchOptions?: {
     aggregateTimeout?: number;
     poll?: number;

--- a/packages/@angular/cli/tasks/serve.ts
+++ b/packages/@angular/cli/tasks/serve.ts
@@ -109,6 +109,7 @@ export default Task.extend({
       inline: true,
       proxy: proxyConfig,
       compress: serveTaskOptions.target === 'production',
+      watch: serveTaskOptions.liveReload,
       watchOptions: {
         poll: projectConfig.defaults && projectConfig.defaults.poll
       },


### PR DESCRIPTION
Due to the replacement of the broccoli build system with webpack in [v1.0.0-beta.11-webpack](https://github.com/angular/angular-cli/blob/master/CHANGELOG.md#100-beta11-webpack-2016-08-02), the serve `--live-reload` option gets ignored.

We need to extend the black boxed configuration, to control [watch mode](https://webpack.js.org/configuration/watch/#watch) in [webpack-dev-server](https://github.com/webpack/webpack-dev-server).

Related Issues:

- https://github.com/angular/angular-cli/issues/4556

Related Pull Requests:

- https://github.com/angular/angular-cli/pull/1455