### PR TITLE
Node v6 engine dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "url": "https://github.com/angular/angular-cli.git"
   },
   "engines": {
-    "node": ">= 4.1.0",
+    "node": ">= 6.9.0",
     "npm": ">= 3.0.0"
   },
   "author": "Angular Authors",


### PR DESCRIPTION
Hi,

Isn't this line making angular cli installable even if node version is not supported ? ("node": ">= 6.9.0",)

ref: https://github.com/angular/angular-cli/issues/4604