### PR TITLE
fix(@angular/cli): remove inexistent tslint override

### DIFF
--- a/packages/@angular/cli/blueprints/component/files/__path__/__name__.component.spec.ts
+++ b/packages/@angular/cli/blueprints/component/files/__path__/__name__.component.spec.ts
@@ -1,7 +1,4 @@
-/* tslint:disable:no-unused-variable */
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { By } from '@angular/platform-browser';
-import { DebugElement } from '@angular/core';
 
 import { <%= classifiedModuleName %>Component } from './<%= dasherizedModuleName %>.component';
 

--- a/packages/@angular/cli/blueprints/directive/files/__path__/__name__.directive.spec.ts
+++ b/packages/@angular/cli/blueprints/directive/files/__path__/__name__.directive.spec.ts
@@ -1,6 +1,3 @@
-/* tslint:disable:no-unused-variable */
-
-import { TestBed, async } from '@angular/core/testing';
 import { <%= classifiedModuleName %>Directive } from './<%= dasherizedModuleName %>.directive';
 
 describe('<%= classifiedModuleName %>Directive', () => {

--- a/packages/@angular/cli/blueprints/module/files/__path__/__name__.module.spec.ts
+++ b/packages/@angular/cli/blueprints/module/files/__path__/__name__.module.spec.ts
@@ -1,6 +1,3 @@
-/* tslint:disable:no-unused-variable */
-
-import { TestBed, async } from '@angular/core/testing';
 import <%= classifiedModuleName %>Module from './<%= dasherizedModuleName %>.module';
 
 describe('<%= classifiedModuleName %>Module', () => {

--- a/packages/@angular/cli/blueprints/ng2/files/__path__/app/app.component.spec.ts
+++ b/packages/@angular/cli/blueprints/ng2/files/__path__/app/app.component.spec.ts
@@ -1,5 +1,3 @@
-/* tslint:disable:no-unused-variable */
-
 import { TestBed, async } from '@angular/core/testing';<% if (routing) { %>
 import { RouterTestingModule } from '@angular/router/testing';<% } %>
 import { AppComponent } from './app.component';

--- a/packages/@angular/cli/blueprints/pipe/files/__path__/__name__.pipe.spec.ts
+++ b/packages/@angular/cli/blueprints/pipe/files/__path__/__name__.pipe.spec.ts
@@ -1,6 +1,3 @@
-/* tslint:disable:no-unused-variable */
-
-import { TestBed, async } from '@angular/core/testing';
 import { <%= classifiedModuleName %>Pipe } from './<%= dasherizedModuleName %>.pipe';
 
 describe('<%= classifiedModuleName %>Pipe', () => {

--- a/packages/@angular/cli/blueprints/service/files/__path__/__name__.service.spec.ts
+++ b/packages/@angular/cli/blueprints/service/files/__path__/__name__.service.spec.ts
@@ -1,6 +1,4 @@
-/* tslint:disable:no-unused-variable */
-
-import { TestBed, async, inject } from '@angular/core/testing';
+import { TestBed, inject } from '@angular/core/testing';
 import { <%= classifiedModuleName %>Service } from './<%= dasherizedModuleName %>.service';
 
 describe('<%= classifiedModuleName %>Service', () => {


### PR DESCRIPTION
`no-unused-variable` doesn't exist anymore, so these disables aren't doing anything. Also removed the unused vars.