### PR TITLE
fix(@ngtools/webpack): one star replacement should be preceded by slash

### DIFF
--- a/packages/@ngtools/webpack/src/plugin.ts
+++ b/packages/@ngtools/webpack/src/plugin.ts
@@ -127,7 +127,7 @@ export class AotPlugin implements Tapable {
           // Two stars replacement.
           .replace(/\*\*/g, '(?:.*)')
           // One star replacement.
-          .replace(/\*/g, '(?:[^/]*)')
+          .replace(/\/\*/g, '(?:[^/]*)')
           // Escape characters from the basePath and make sure it's forward slashes.
           .replace(/^/, basePathPattern);
 


### PR DESCRIPTION
When building a project with AoT enabled, I noticed that `.spec.ts` files were not being excluded properly. This was happening because the pattern `**/*.spec.ts` triggered the two-stars replacement:
```
"**/*.spec.ts".replace(/\*\*/g, '(?:.*)')
--> "(?:.*)/*.spec.ts"
```

And then the one star replacement would replace the `*` inserted by the previous replacement:
```
"(?:.*)/*.spec.ts".replace(/\*/g, '(?:[^/]*)')
"(?:.(?:[^/]*))/(?:[^/]*).spec.ts"
```

With this PR, the single-star replacement expects a slash before the star, i.e. `/*.spec.ts`, so:
```
"(?:.*)/*.spec.ts".replace(/\/\*/g, '(?:[^/]*)')
"(?:.*)(?:[^/]*)\.spec\.ts"
```

Which then properly excludes the spec files. This doesn't handle the case where the pattern is in the form of `**/something-*.spec.ts`, but I am not sure that is super common.

Since I am not super familiar with the codebase, If you guys know of a simpler or better way to fix this problem, I'd welcome feedback. Or feel free to implement/refactor yourselves.