### PR TITLE
feat(@angular/cli): use environmentSource key for environments

### DIFF
--- a/docs/documentation/build.md
+++ b/docs/documentation/build.md
@@ -22,8 +22,8 @@ By default, the development build target and environment are used.
 The mapping used to determine which environment file is used can be found in `angular-cli.json`:
 
 ```json
+"environmentSource": "environments/environment.ts",
 "environments": {
-  "source": "environments/environment.ts",
   "dev": "environments/environment.ts",
   "prod": "environments/environment.prod.ts"
 }

--- a/packages/@angular/cli/blueprints/ng2/files/angular-cli.json
+++ b/packages/@angular/cli/blueprints/ng2/files/angular-cli.json
@@ -22,8 +22,8 @@
         "styles.<%= styleExt %>"
       ],
       "scripts": [],
+      "environmentSource": "environments/environment.ts",
       "environments": {
-        "source": "environments/environment.ts",
         "dev": "environments/environment.ts",
         "prod": "environments/environment.prod.ts"
       }

--- a/packages/@angular/cli/lib/config/schema.json
+++ b/packages/@angular/cli/lib/config/schema.json
@@ -147,6 +147,10 @@
             },
             "additionalProperties": false
           },
+          "environmentSource":{
+            "description": "Source file for environment config.",
+            "type": "string"
+          },
           "environments": {
             "description": "Name and corresponding file for environment config.",
             "type": "object",

--- a/packages/@angular/cli/models/webpack-configs/test.js
+++ b/packages/@angular/cli/models/webpack-configs/test.js
@@ -103,7 +103,7 @@ const getTestConfig = function (projectRoot, environment, appConfig, testConfig)
         // This plugin is responsible for swapping the environment files.
         // Since it takes a RegExp as first parameter, we need to escape the path.
         // See https://webpack.github.io/docs/list-of-plugins.html#normalmodulereplacementplugin
-        new RegExp(path.resolve(appRoot, appConfig.environments['source'])
+        new RegExp(path.resolve(appRoot, appConfig.environmentSource)
           .replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&')),
         path.resolve(appRoot, appConfig.environments[environment])
       ),

--- a/packages/@angular/cli/models/webpack-configs/typescript.ts
+++ b/packages/@angular/cli/models/webpack-configs/typescript.ts
@@ -19,15 +19,16 @@ function _createAotPlugin(wco: WebpackConfigOptions, options: any) {
   let hostOverrideFileSystem: any = {};
   // process environment file replacement
   if (appConfig.environments) {
-    if (!('source' in appConfig.environments)) {
-      throw new SilentError(`Environment configuration does not contain "source" entry.`);
+    if (!appConfig.environmentSource) {
+      throw new SilentError(
+        'Environment configuration does not contain "environmentSource" entry.');
     }
     if (!(buildOptions.environment in appConfig.environments)) {
       throw new SilentError(`Environment "${buildOptions.environment}" does not exist.`);
     }
 
     const appRoot = path.resolve(projectRoot, appConfig.root);
-    const sourcePath = appConfig.environments['source'];
+    const sourcePath = appConfig.environmentSource;
     const envFile = appConfig.environments[buildOptions.environment];
     const environmentContent = fs.readFileSync(path.join(appRoot, envFile)).toString();
 

--- a/packages/@angular/cli/models/webpack-configs/typescript.ts
+++ b/packages/@angular/cli/models/webpack-configs/typescript.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import { stripIndent } from 'common-tags';
 import {AotPlugin, AotPluginOptions} from '@ngtools/webpack';
 import { WebpackConfigOptions } from '../webpack-config';
 
@@ -20,8 +21,35 @@ function _createAotPlugin(wco: WebpackConfigOptions, options: any) {
   // process environment file replacement
   if (appConfig.environments) {
     if (!appConfig.environmentSource) {
+      let migrationMessage = '';
+      if ('source' in appConfig.environments) {
+        migrationMessage = '\n\n' + stripIndent`
+          A new environmentSource entry replaces the previous source entry inside environments.
+
+          To migrate angular-cli.json follow the example below:
+
+          Before:
+
+          "environments": {
+            "source": "environments/environment.ts",
+            "dev": "environments/environment.ts",
+            "prod": "environments/environment.prod.ts"
+          }
+
+
+          After:
+
+          "environmentSource": "environments/environment.ts",
+          "environments": {
+            "dev": "environments/environment.ts",
+            "prod": "environments/environment.prod.ts"
+          }
+        `;
+      }
       throw new SilentError(
-        'Environment configuration does not contain "environmentSource" entry.');
+        `Environment configuration does not contain "environmentSource" entry.${migrationMessage}`
+      );
+
     }
     if (!(buildOptions.environment in appConfig.environments)) {
       throw new SilentError(`Environment "${buildOptions.environment}" does not exist.`);


### PR DESCRIPTION
Heavily based on @jsanchezgarcia work in #4476.

Fix #3857

BREAKING CHANGE:

A new `environmentSource` entry replaces the previous `source` entry inside `environments`.

To migrate the code follow the example below:

Before:
```
"environments": {
  "source": "environments/environment.ts",
  "dev": "environments/environment.ts",
  "prod": "environments/environment.prod.ts"
}
```

After:
```
"environmentSource": "environments/environment.ts",
"environments": {
  "dev": "environments/environment.ts",
  "prod": "environments/environment.prod.ts"
}
```