### PR TITLE
fix(@angular/cli): remove component generation from module generation

### DIFF
--- a/packages/@angular/cli/blueprints/module/index.ts
+++ b/packages/@angular/cli/blueprints/module/index.ts
@@ -61,29 +61,5 @@ export default Blueprint.extend({
         return this.generatePath;
       }
     };
-  },
-
-  afterInstall: function (options: any) {
-    if (this.options && this.options.routing) {
-
-      // Component folder needs to be `/{moduleName}/{ComponentName}`
-      // Note that we are using `flat`, so no extra dir will be created
-      // We need the leading `/` so the component path resolution work for both cases below:
-      // 1. If module name has no path (no `/`), that's going to be `/mod-name/mod-name`
-      //      as `this.dynamicPath.dir` will be the same as `this.dynamicPath.appRoot`
-      // 2. If it does have `/` (like `parent/mod-name`), it'll be `/parent/mod-name/mod-name`
-      //      as `this.dynamicPath.dir` minus `this.dynamicPath.appRoot` will be `/parent`
-      const moduleDir = this.dynamicPath.dir.replace(this.dynamicPath.appRoot, '')
-                      + path.sep + this.dasherizedModuleName;
-      options.entity.name = moduleDir + path.sep + this.dasherizedModuleName;
-      options.flat = true;
-
-      options.route = false;
-      options.inlineTemplate = false;
-      options.inlineStyle = false;
-      options.prefix = null;
-      options.spec = true;
-      return Blueprint.load(path.join(__dirname, '../component')).install(options);
-    }
   }
 });

--- a/tests/acceptance/generate-module.spec.js
+++ b/tests/acceptance/generate-module.spec.js
@@ -36,16 +36,14 @@ describe('Acceptance: ng generate module', function () {
     return ng(['generate', 'module', 'my-module']).then(() => {
       expect(existsSync(path.join(testPath, 'my-module', 'my-module.module.ts'))).to.equal(true);
       expect(existsSync(path.join(testPath, 'my-module', 'my-module.module.spec.ts'))).to.equal(false);
-      expect(existsSync(path.join(testPath, 'my-module', 'my-module.component.ts'))).to.equal(false);
     });
   });
 
-  it('ng generate module  generate routing and component files when passed flag --routing', function () {
+  it('ng generate module  generate routing file when passed flag --routing', function () {
     return ng(['generate', 'module', 'my-module', '--routing']).then(() => {
       expect(existsSync(path.join(testPath, 'my-module', 'my-module.module.ts'))).to.equal(true);
       expect(existsSync(path.join(testPath, 'my-module', 'my-module-routing.module.ts'))).to.equal(true);
       expect(existsSync(path.join(testPath, 'my-module', 'my-module.module.spec.ts'))).to.equal(false);
-      expect(existsSync(path.join(testPath, 'my-module', 'my-module.component.ts'))).to.equal(true);
     })
   });
 
@@ -68,7 +66,6 @@ describe('Acceptance: ng generate module', function () {
       ng(['generate', 'module', 'parent/child']).then(() => {
         expect(existsSync(path.join(testPath, 'parent/child', 'child.module.ts'))).to.equal(true);
         expect(existsSync(path.join(testPath, 'parent/child', 'child.module.spec.ts'))).to.equal(false);
-        expect(existsSync(path.join(testPath, 'parent/child', 'child.component.ts'))).to.equal(false);
       })
     );
   });
@@ -82,12 +79,11 @@ describe('Acceptance: ng generate module', function () {
       ng(['generate', 'module', 'child']).then(() => {
         expect(existsSync(path.join(testPath, 'sub-dir/child', 'child.module.ts'))).to.equal(true);
         expect(existsSync(path.join(testPath, 'sub-dir/child', 'child.module.spec.ts'))).to.equal(false);
-        expect(existsSync(path.join(testPath, 'sub-dir/child', 'child.component.ts'))).to.equal(false);
       })
     );
   });
 
-  it('ng generate module child should work in sub-dir with routing and component files when passed --routing flag', function () {
+  it('ng generate module child should work in sub-dir with routing file when passed --routing flag', function () {
     fs.mkdirSync(path.join(testPath, './sub-dir'));
     return new Promise(resolve => {
       process.chdir(path.join(testPath, './sub-dir'));
@@ -97,18 +93,16 @@ describe('Acceptance: ng generate module', function () {
         expect(existsSync(path.join(testPath, 'sub-dir/child', 'child.module.ts'))).to.equal(true);
         expect(existsSync(path.join(testPath, 'sub-dir/child', 'child-routing.module.ts'))).to.equal(true);
         expect(existsSync(path.join(testPath, 'sub-dir/child', 'child.module.spec.ts'))).to.equal(false);
-        expect(existsSync(path.join(testPath, 'sub-dir/child', 'child.component.ts'))).to.equal(true);
       })
     );
   });
 
-  it('ng generate module should generate parent/child module with routing and component files when passed --routing flag', function () {
+  it('ng generate module should generate parent/child module with routing file when passed --routing flag', function () {
     return ng(['generate', 'module', 'parent']).then(() =>
       ng(['generate', 'module', 'parent/child', '--routing']).then(() => {
         expect(existsSync(path.join(testPath, 'parent/child', 'child.module.ts'))).to.equal(true);
         expect(existsSync(path.join(testPath, 'parent/child', 'child-routing.module.ts'))).to.equal(true);
         expect(existsSync(path.join(testPath, 'parent/child', 'child.module.spec.ts'))).to.equal(false);
-        expect(existsSync(path.join(testPath, 'parent/child', 'child.component.ts'))).to.equal(true);
       })
     );
   });

--- a/tests/e2e/tests/generate/module/module-basic.ts
+++ b/tests/e2e/tests/generate/module/module-basic.ts
@@ -11,7 +11,6 @@ export default function() {
     .then(() => expectFileToExist(moduleDir))
     .then(() => expectFileToExist(join(moduleDir, 'test.module.ts')))
     .then(() => expectToFail(() => expectFileToExist(join(moduleDir, 'test-routing.module.ts'))))
-    .then(() => expectToFail(() => expectFileToExist(join(moduleDir, 'test.component.ts'))))
     .then(() => expectToFail(() => expectFileToExist(join(moduleDir, 'test.spec.ts'))))
     .then(() => expectFileToMatch(join(moduleDir, 'test.module.ts'), 'TestModule'))
 

--- a/tests/e2e/tests/generate/module/module-routing-child-folder.ts
+++ b/tests/e2e/tests/generate/module/module-routing-child-folder.ts
@@ -20,10 +20,6 @@ export default function () {
         .then(() => expectFileToExist(join(testPath, 'sub-dir/child')))
         .then(() => expectFileToExist(join(testPath, 'sub-dir/child', 'child.module.ts')))
         .then(() => expectFileToExist(join(testPath, 'sub-dir/child', 'child-routing.module.ts')))
-        .then(() => expectFileToExist(join(testPath, 'sub-dir/child', 'child.component.ts')))
-        .then(() => expectFileToExist(join(testPath, 'sub-dir/child', 'child.component.spec.ts')))
-        .then(() => expectFileToExist(join(testPath, 'sub-dir/child', 'child.component.html')))
-        .then(() => expectFileToExist(join(testPath, 'sub-dir/child', 'child.component.css')))
         .then(() => expectToFail(() =>
           expectFileToExist(join(testPath, 'sub-dir/child', 'child.spec.ts'))
         ))

--- a/tests/e2e/tests/generate/module/module-routing.ts
+++ b/tests/e2e/tests/generate/module/module-routing.ts
@@ -11,10 +11,6 @@ export default function() {
     .then(() => expectFileToExist(moduleDir))
     .then(() => expectFileToExist(join(moduleDir, 'test.module.ts')))
     .then(() => expectFileToExist(join(moduleDir, 'test-routing.module.ts')))
-    .then(() => expectFileToExist(join(moduleDir, 'test.component.ts')))
-    .then(() => expectFileToExist(join(moduleDir, 'test.component.spec.ts')))
-    .then(() => expectFileToExist(join(moduleDir, 'test.component.html')))
-    .then(() => expectFileToExist(join(moduleDir, 'test.component.css')))
     .then(() => expectToFail(() => expectFileToExist(join(moduleDir, 'test.spec.ts'))))
     // Try to run the unit tests.
     .then(() => ng('test', '--single-run'));


### PR DESCRIPTION
Fixes #4209

BREAKING CHANGE: Generating a module with routing will no longer generate an associated component.