### PR TITLE
test: add --nobuild flag

### DIFF
--- a/tests/e2e/setup/010-build.ts
+++ b/tests/e2e/setup/010-build.ts
@@ -8,6 +8,10 @@ const packages = require('../../../lib/packages');
 export default function() {
   const argv = getGlobalVariable('argv');
 
+  if (argv.nobuild) {
+    return;
+  }
+
   return npm('run', 'build')
     .then(() => console.log('Updating package.json from dist...'))
     .then(() => Promise.all(Object.keys(packages).map(pkgName => {

--- a/tests/e2e_runner.ts
+++ b/tests/e2e_runner.ts
@@ -25,6 +25,8 @@ Error.stackTraceLimit = Infinity;
  * Here's a short description of those flags:
  *   --debug          If a test fails, block the thread so the temporary directory isn't deleted.
  *   --noproject      Skip creating a project or using one.
+ *   --nobuild        Skip building the packages. Use with --nolink and --reuse to quickly
+ *                    rerun tests.
  *   --nolink         Skip linking your local @angular/cli directory. Can save a few seconds.
  *   --ng-sha=SHA     Use a specific ng-sha. Similar to nightly but point to a master SHA instead
  *                    of using the latest.


### PR DESCRIPTION
Cuts down rerunning just tests from some 150secs to 15secs.

Example usage:

```
# run once normally to build CLI, link CLI and build project
kamik@T460p MINGW64 /D/work/angular-cli (fast-retest)
$ node tests/run_e2e.js tests/e2e/tests/build/poll.ts
# ...
# add in --no-link --nobuild --reuse flags to quickly re-run the e2e test
kamik@T460p MINGW64 /D/work/angular-cli (fast-retest)
$ node tests/run_e2e.js --nolink --nobuild --reuse=/c/Users/kamik/AppData/Local/Temp/angular-cli-e2e-117115-8500-3fbczu.64p5019k9/test-project tests/e2e/tests/build/poll.ts
```