### PR TITLE
fix(@angular/cli): use default .map filename

### DIFF
--- a/packages/@angular/cli/models/webpack-configs/common.ts
+++ b/packages/@angular/cli/models/webpack-configs/common.ts
@@ -97,7 +97,6 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
       path: path.resolve(projectRoot, buildOptions.outputPath),
       publicPath: buildOptions.deployUrl,
       filename: `[name]${hashFormat.chunk}.bundle.js`,
-      sourceMapFilename: `[name]${hashFormat.chunk}.bundle.map`,
       chunkFilename: `[id]${hashFormat.chunk}.chunk.js`
     },
     module: {

--- a/packages/@angular/cli/plugins/suppress-entry-chunks-webpack-plugin.ts
+++ b/packages/@angular/cli/plugins/suppress-entry-chunks-webpack-plugin.ts
@@ -23,7 +23,7 @@ export class SuppressExtractedTextChunksWebpackPlugin {
           .forEach((chunk: any) => {
             let newFiles: string[] = [];
             chunk.files.forEach((file: string) => {
-              if (file.match(/\.js$/)) {
+              if (file.match(/\.js(\.map)?$/)) {
                 // remove js files
                 delete compilation.assets[file];
               } else {

--- a/tests/e2e/tests/build/sourcemap.ts
+++ b/tests/e2e/tests/build/sourcemap.ts
@@ -5,14 +5,14 @@ import {expectToFail} from '../../utils/utils';
 
 export default function() {
   return ng('build')
-    .then(() => expectFileToExist('dist/main.bundle.map'))
+    .then(() => expectFileToExist('dist/main.bundle.js.map'))
 
     .then(() => ng('build', '--no-sourcemap'))
-    .then(() => expectToFail(() => expectFileToExist('dist/main.bundle.map')))
+    .then(() => expectToFail(() => expectFileToExist('dist/main.bundle.js.map')))
 
     .then(() => ng('build', '--prod', '--output-hashing=none'))
-    .then(() => expectToFail(() => expectFileToExist('dist/main.bundle.map')))
+    .then(() => expectToFail(() => expectFileToExist('dist/main.bundle.js.map')))
 
     .then(() => ng('build', '--prod', '--output-hashing=none', '--sourcemap'))
-    .then(() => expectFileToExist('dist/main.bundle.map'));
+    .then(() => expectFileToExist('dist/main.bundle.js.map'));
 }


### PR DESCRIPTION
Fix #4741

BREAKING CHANGE: sourcemaps now are always [filename].map (e.g `main.bundle.js.map` instead of `main.bundle.map`).