### PR TITLE
refactor(@angular/cli): move stats-json to build only

### DIFF
--- a/packages/@angular/cli/commands/build.ts
+++ b/packages/@angular/cli/commands/build.ts
@@ -35,7 +35,6 @@ export const baseBuildCommandOptions: any = [
     description: 'define the output filename cache-busting hashing mode',
     aliases: ['oh']
   },
-  { name: 'stats-json', type: Boolean, default: false },
   {
     name: 'poll',
     type: Number,
@@ -55,7 +54,8 @@ const BuildCommand = Command.extend({
   aliases: ['b'],
 
   availableOptions: baseBuildCommandOptions.concat([
-    { name: 'watch', type: Boolean, default: false, aliases: ['w'] }
+    { name: 'watch', type: Boolean, default: false, aliases: ['w'] },
+    { name: 'stats-json', type: Boolean, default: false }
   ]),
 
   run: function (commandOptions: BuildTaskOptions) {


### PR DESCRIPTION
Other commands (like serve) do not support this option, so it should only be in build.

Followup from https://github.com/angular/angular-cli/pull/4189