### PR TITLE
use compileComponents() is not required with webpack

### DIFF
--- a/packages/@angular/cli/blueprints/component/files/__path__/__name__.component.spec.ts
+++ b/packages/@angular/cli/blueprints/component/files/__path__/__name__.component.spec.ts
@@ -9,8 +9,7 @@ describe('<%= classifiedModuleName %>Component', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ <%= classifiedModuleName %>Component ]
-    })
-    .compileComponents();
+    });
   }));
 
   beforeEach(() => {

--- a/packages/@angular/cli/blueprints/ng2/files/__path__/app/app.component.spec.ts
+++ b/packages/@angular/cli/blueprints/ng2/files/__path__/app/app.component.spec.ts
@@ -12,7 +12,6 @@ describe('AppComponent', () => {
         AppComponent
       ],
     });
-    TestBed.compileComponents();
   });
 
   it('should create the app', async(() => {


### PR DESCRIPTION
Since we use webpack, we don't have to use compileComponents(). Webpack transforms html and css file to inline template.