### PR TITLE
fix(@angular/cli): add $schema as a schema prop

### DIFF
--- a/packages/@angular/cli/lib/config/schema.json
+++ b/packages/@angular/cli/lib/config/schema.json
@@ -4,6 +4,9 @@
   "title": "Angular CLI Config Schema",
   "type": "object",
   "properties": {
+    "$schema": {
+      "type": "string"
+    },
     "project": {
       "description": "The global configuration of the project.",
       "type": "object",


### PR DESCRIPTION
Fixes "Property $schema is not allowed" error on editors.

![image](https://cloud.githubusercontent.com/assets/4172079/23064215/8fd865ee-f506-11e6-9ecd-d1b3ca4f4f49.png)
