### PR TITLE
feat(@angular/cli): don't use config file version

### DIFF
--- a/packages/@angular/cli/blueprints/ng2/files/angular-cli.json
+++ b/packages/@angular/cli/blueprints/ng2/files/angular-cli.json
@@ -1,7 +1,6 @@
 {
   "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
   "project": {
-    "version": "<%= version %>",
     "name": "<%= htmlComponentName %>"
   },
   "apps": [

--- a/packages/@angular/cli/commands/version.ts
+++ b/packages/@angular/cli/commands/version.ts
@@ -44,9 +44,6 @@ const VersionCommand = Command.extend({
     }
     const config = CliConfig.fromProject();
     if (config && config.config && config.config.project) {
-      if (config.config.project.version !== pkg.version) {
-        ngCliVersion += ` [${config.config.project.version}]`;
-      }
       if (config.config.project.ejected) {
         ngCliVersion += ' (e)';
       }

--- a/packages/@angular/cli/upgrade/version.ts
+++ b/packages/@angular/cli/upgrade/version.ts
@@ -76,7 +76,7 @@ export class Version {
 
     try {
       const json = JSON.parse(configJson);
-      return new Version(json.project && json.project.version);
+      return new Version(json.project);
     } catch (e) {
       return new Version(null);
     }


### PR DESCRIPTION
We're not updating this number anymore since ng init/update is gone, so at
best it's useless and at worst it's confusing since it appears on ng
version.