### PR TITLE
fix(@angular/cli): fix css url processing 

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "opn": "4.0.2",
     "portfinder": "~1.0.12",
     "postcss-loader": "^0.13.0",
+    "postcss-url": "^5.1.2",
     "raw-loader": "^0.5.1",
     "resolve": "^1.1.7",
     "rimraf": "^2.5.3",

--- a/packages/@angular/cli/models/webpack-configs/styles.ts
+++ b/packages/@angular/cli/models/webpack-configs/styles.ts
@@ -1,13 +1,15 @@
 import * as webpack from 'webpack';
 import * as path from 'path';
+import { oneLineTrim } from 'common-tags';
 import {
   SuppressExtractedTextChunksWebpackPlugin
 } from '../../plugins/suppress-entry-chunks-webpack-plugin';
 import { extraEntryParser, getOutputHashFormat } from './utils';
 import { WebpackConfigOptions } from '../webpack-config';
-import { pluginArgs } from '../../tasks/eject';
+import { pluginArgs, postcssArgs } from '../../tasks/eject';
 
 const cssnano = require('cssnano');
+const postcssUrl = require('postcss-url');
 const autoprefixer = require('autoprefixer');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 
@@ -39,11 +41,35 @@ export function getStylesConfig(wco: WebpackConfigOptions) {
   // https://github.com/webpack-contrib/style-loader#recommended-configuration
   const cssSourceMap = buildOptions.extractCss && buildOptions.sourcemap;
 
-  // minify/optimize css in production
-  // autoprefixer is always run separately so disable here
-  const extraPostCssPlugins = buildOptions.target === 'production'
-    ? [cssnano({ safe: true, autoprefixer: false })]
-    : [];
+  // Minify/optimize css in production.
+  const cssnanoPlugin = cssnano({ safe: true, autoprefixer: false });
+
+  // Convert absolute resource URLs to account for base-href and deploy-url.
+  const baseHref = wco.buildOptions.baseHref;
+  const deployUrl = wco.buildOptions.deployUrl;
+  const postcssUrlOptions = {
+    url: (URL: string) => {
+      // Only convert absolute URLs, which CSS-Loader won't process into require().
+      if (!URL.startsWith('/')) {
+        return URL;
+      }
+      // Join together base-href, deploy-url and the original URL.
+      // Also dedupe multiple slashes into single ones.
+      return `/${baseHref || ''}/${deployUrl || ''}/${URL}`.replace(/\/\/+/g, '/');
+    }
+  };
+  const urlPlugin = postcssUrl(postcssUrlOptions);
+  // We need to save baseHref and deployUrl for the Ejected webpack config to work (we reuse
+  //  the function defined above).
+  (postcssUrlOptions as any).baseHref = baseHref;
+  (postcssUrlOptions as any).deployUrl = deployUrl;
+  // Save the original options as arguments for eject.
+  urlPlugin[postcssArgs] = postcssUrlOptions;
+
+  // PostCSS plugins.
+  const postCssPlugins = [autoprefixer(), urlPlugin].concat(
+    buildOptions.target === 'production' ? [cssnanoPlugin] : []
+  );
 
   // determine hashing format
   const hashFormat = getOutputHashFormat(buildOptions.outputHashing);
@@ -141,7 +167,7 @@ export function getStylesConfig(wco: WebpackConfigOptions) {
       new webpack.LoaderOptionsPlugin({
         sourceMap: cssSourceMap,
         options: {
-          postcss: [autoprefixer()].concat(extraPostCssPlugins),
+          postcss: postCssPlugins,
           // css-loader, stylus-loader don't support LoaderOptionsPlugin properly
           // options are in query instead
           sassLoader: { sourceMap: cssSourceMap, includePaths },

--- a/packages/@angular/cli/package.json
+++ b/packages/@angular/cli/package.json
@@ -66,6 +66,7 @@
     "opn": "4.0.2",
     "portfinder": "~1.0.12",
     "postcss-loader": "^0.13.0",
+    "postcss-url": "^5.1.2",
     "raw-loader": "^0.5.1",
     "resolve": "^1.1.7",
     "rimraf": "^2.5.3",

--- a/packages/@ngtools/webpack/src/resource_loader.ts
+++ b/packages/@ngtools/webpack/src/resource_loader.ts
@@ -70,10 +70,12 @@ export class WebpackResourceLoader implements ResourceLoader {
 
           // Restore the parent compilation to the state like it was before the child compilation.
           Object.keys(childCompilation.assets).forEach((fileName) => {
-            this._parentCompilation.assets[fileName] = assetsBeforeCompilation[fileName];
-            if (assetsBeforeCompilation[fileName] === undefined) {
-              // If it wasn't there - delete it.
+            // If it wasn't there and it's a source file (absolute path) - delete it.
+            if (assetsBeforeCompilation[fileName] === undefined && path.isAbsolute(fileName)) {
               delete this._parentCompilation.assets[fileName];
+            } else {
+              // Otherwise, add it to the parent compilation.
+              this._parentCompilation.assets[fileName] = childCompilation.assets[fileName];
             }
           });
 

--- a/scripts/test-licenses.js
+++ b/scripts/test-licenses.js
@@ -64,6 +64,7 @@ const licenseReplacements = [
 // TODO(hansl): review these
 const ignoredPackages = [
   'async-foreach@0.1.3', // MIT, but doesn't list it in package.json
+  'directory-encoder@0.7.2', // MIT, but doesn't list it in package.json
   'domelementtype@1.1.3', // Looks like MIT
   'domelementtype@1.3.0', // Looks like MIT
   'domhandler@2.1.0', // Looks like MIT
@@ -79,8 +80,10 @@ const ignoredPackages = [
   'progress@1.1.8', // MIT, but doesn't list it in package.json
   'samsam@1.1.2', // BSD, but doesn't list it in package.json
   'stdout-stream@1.4.0', // MIT, but doesn't list it in package.json
+  'uglify-js@2.3.6', // BSD, but doesn't list it in package.json
   'undefined@undefined', // Test package with no name nor version.
-  'verror@1.3.6' // Looks like MIT
+  'verror@1.3.6', // Looks like MIT
+  'xmldom@0.1.27' // LGPL,MIT but has a broken licenses array
 ];
 
 const root = path.resolve(__dirname, '../');

--- a/tests/e2e/tests/build/css-urls.ts
+++ b/tests/e2e/tests/build/css-urls.ts
@@ -1,0 +1,55 @@
+import { ng } from '../../utils/process';
+import {
+  expectFileToMatch,
+  expectFileToExist,
+  writeMultipleFiles
+} from '../../utils/fs';
+import { expectToFail } from '../../utils/utils';
+
+const imgSvg = `
+  <svg width="100" height="100" xmlns="http://www.w3.org/2000/svg">
+    <circle cx="50" cy="50" r="40" stroke="green" stroke-width="4" fill="yellow" />
+  </svg>
+`;
+
+export default function () {
+  return Promise.resolve()
+    // Verify absolute/relative paths in global/component css.
+    .then(() => writeMultipleFiles({
+      'src/styles.css': `
+        h1 { background: url('/assets/global-img-absolute.svg'); }
+        h2 { background: url('./assets/global-img-relative.svg'); }
+      `,
+      'src/app/app.component.css': `
+        h3 { background: url('/assets/component-img-absolute.svg'); }
+        h4 { background: url('../assets/component-img-relative.svg'); }
+      `,
+      // Using SVGs because they are loaded via file-loader and thus never inlined.
+      'src/assets/global-img-absolute.svg': imgSvg,
+      'src/assets/global-img-relative.svg': imgSvg,
+      'src/assets/component-img-absolute.svg': imgSvg,
+      'src/assets/component-img-relative.svg': imgSvg
+    }))
+    .then(() => ng('build', '--extract-css', '--aot'))
+    // Check paths are correctly generated.
+    .then(() => expectFileToMatch('dist/styles.bundle.css',
+      `url\('\/assets\/global-img-absolute\.svg'\)`))
+    .then(() => expectFileToMatch('dist/styles.bundle.css', 'url\(global-img-relative.svg\)'))
+    .then(() => expectFileToMatch('dist/main.bundle.js',
+      `url\('\/assets\/component-img-absolute\.svg'\)`))
+    .then(() => expectFileToMatch('dist/main.bundle.js', 'background: url\(" \+ __webpack_require'))
+    // Check files are correctly created.
+    .then(() => expectToFail(() => expectFileToExist('global-img-absolute.svg')))
+    .then(() => expectFileToExist('global-img-relative.svg'))
+    .then(() => expectToFail(() => expectFileToExist('component-img-absolute.svg')))
+    .then(() => expectFileToExist('component-img-relative.svg'))
+    // Also check with base-href and deploy-url flags.
+    .then(() => ng('build', '--base-href=/base/', '--deploy-url=/deploy/', '--extract-css'))
+    .then(() => expectFileToMatch('dist/styles.bundle.css',
+      `url\('\/base\/deploy\/assets\/global-img-absolute\.svg'\)`))
+    .then(() => expectFileToMatch('dist/styles.bundle.css', 'url\(global-img-relative.svg\)'))
+    .then(() => expectFileToMatch('dist/main.bundle.js',
+      `url\('\/base\/deploy\/assets\/component-img-absolute\.svg'\)`))
+    .then(() => expectFileToMatch('dist/main.bundle.js',
+      'background: url\(" \+ __webpack_require'));
+}

--- a/tests/e2e/tests/build/css-urls.ts
+++ b/tests/e2e/tests/build/css-urls.ts
@@ -36,20 +36,21 @@ export default function () {
       `url\('\/assets\/global-img-absolute\.svg'\)`))
     .then(() => expectFileToMatch('dist/styles.bundle.css', 'url\(global-img-relative.svg\)'))
     .then(() => expectFileToMatch('dist/main.bundle.js',
-      `url\('\/assets\/component-img-absolute\.svg'\)`))
-    .then(() => expectFileToMatch('dist/main.bundle.js', 'background: url\(" \+ __webpack_require'))
+      `url\(\\'\/assets\/component-img-absolute\.svg\\'\)`))
+    .then(() => expectFileToMatch('dist/main.bundle.js', 'url\(component-img-relative\.svg\)'))
     // Check files are correctly created.
-    .then(() => expectToFail(() => expectFileToExist('global-img-absolute.svg')))
-    .then(() => expectFileToExist('global-img-relative.svg'))
-    .then(() => expectToFail(() => expectFileToExist('component-img-absolute.svg')))
-    .then(() => expectFileToExist('component-img-relative.svg'))
+    .then(() => expectToFail(() => expectFileToExist('dist/global-img-absolute.svg')))
+    .then(() => expectFileToExist('dist/global-img-relative.svg'))
+    .then(() => expectToFail(() => expectFileToExist('dist/component-img-absolute.svg')))
+    .then(() => expectFileToExist('dist/component-img-relative.svg'))
     // Also check with base-href and deploy-url flags.
-    .then(() => ng('build', '--base-href=/base/', '--deploy-url=/deploy/', '--extract-css'))
+    .then(() => ng('build', '--base-href=/base/', '--deploy-url=deploy/',
+      '--extract-css', '--aot'))
     .then(() => expectFileToMatch('dist/styles.bundle.css',
       `url\('\/base\/deploy\/assets\/global-img-absolute\.svg'\)`))
     .then(() => expectFileToMatch('dist/styles.bundle.css', 'url\(global-img-relative.svg\)'))
     .then(() => expectFileToMatch('dist/main.bundle.js',
-      `url\('\/base\/deploy\/assets\/component-img-absolute\.svg'\)`))
+      `url\(\\'\/base\/deploy\/assets\/component-img-absolute\.svg\\'\)`))
     .then(() => expectFileToMatch('dist/main.bundle.js',
-      'background: url\(" \+ __webpack_require'));
+      'url\(deploy/component-img-relative\.svg\)'));
 }


### PR DESCRIPTION
Fixing component css in #4667 uncovered errors in CSS url processing.

This PR correctly composes absolute urls when using `--base-href` and/or `--deploy-url`.

It also fixes asset output on `--aot` mode. Thanks to @clydin for finding out assets were being dropped in the child compiler.

Fix #4778
Fix #4782
Fix #4806