### PR TITLE
tests: update AoTPlugin test

### DIFF
--- a/tests/e2e/tests/packages/webpack/weird.ts
+++ b/tests/e2e/tests/packages/webpack/weird.ts
@@ -15,7 +15,12 @@ export default function(skipCleaning: () => void) {
     .then(() => expectFileToExist('dist/0.app.main.js'))
     .then(() => expectFileToExist('dist/1.app.main.js'))
     .then(() => expectFileToExist('dist/2.app.main.js'))
-    .then(() => expectFileSizeToBeUnder('dist/app.main.js', 410000))
+    // 4.0.0-beta.8 added roughly 80kb extra size (401kb to 480kb).
+    // For now we have fixed the test below, but when the size drops down again replace the
+    // two lines below with the commented one.
+    .then(() => expectFileSizeToBeUnder('dist/app.main.js', 481000))
+    .then(() => expectToFail(() => expectFileSizeToBeUnder('dist/app.main.js', 410000)))
+    // .then(() => expectFileSizeToBeUnder('dist/app.main.js', 410000))
     .then(() => expectFileSizeToBeUnder('dist/0.app.main.js', 40000))
 
     // Skip code generation and rebuild.


### PR DESCRIPTION
This fix should be removed once the bundle size drops down, which will cause the test to fail.

/cc @hansl