### PR TITLE
feat(command): add output option to ng lint command

### DIFF
--- a/packages/@angular/cli/commands/lint.ts
+++ b/packages/@angular/cli/commands/lint.ts
@@ -4,6 +4,7 @@ export interface LintCommandOptions {
   fix?: boolean;
   format?: string;
   force?: boolean;
+  output?: string;
 }
 
 export default Command.extend({
@@ -14,7 +15,8 @@ export default Command.extend({
   availableOptions: [
     { name: 'fix', type: Boolean, default: false },
     { name: 'force', type: Boolean, default: false },
-    { name: 'format', alias: 't', type: String, default: 'prose' }
+    { name: 'format', alias: 't', type: String, default: 'prose' },
+    { name: 'output', alias: 'o', type: String, default: '' }
   ],
   run: function (commandOptions: LintCommandOptions) {
     const LintTask = require('../tasks/lint').default;

--- a/packages/@angular/cli/tasks/lint.ts
+++ b/packages/@angular/cli/tasks/lint.ts
@@ -7,6 +7,7 @@ import { requireProjectModule } from '../utilities/require-project-module';
 import { CliConfig } from '../models/config';
 import { LintCommandOptions } from '../commands/lint';
 import { oneLine } from 'common-tags';
+const fs = require('fs');
 
 interface CliLintConfig {
   files?: (string | string[]);
@@ -62,8 +63,14 @@ export default Task.extend({
         results = results.concat(result.output.trim().concat('\n'));
       });
 
-    if (errors > 0) {
+    if (commandOptions.output === '') {
       ui.writeLine(results.trim());
+    } else {
+      fs.writeFileSync(commandOptions.output, results.trim());
+      ui.writeLine('Saved lint results to ' + commandOptions.output + '.');
+    }
+
+    if (errors > 0) {
       ui.writeLine(chalk.red('Lint errors found in the listed files.'));
       return commandOptions.force ? Promise.resolve(0) : Promise.resolve(2);
     }


### PR DESCRIPTION
Add output option to ng lint command to redirect lint result to file.

Fix #4791