### PR TITLE
feat(@angular/cli): expose test include list

### DIFF
--- a/packages/@angular/cli/blueprints/ng2/files/angular-cli.json
+++ b/packages/@angular/cli/blueprints/ng2/files/angular-cli.json
@@ -46,7 +46,11 @@
   "test": {
     "karma": {
       "config": "./karma.conf.js"
-    }
+    },
+    "include": [
+      "**/*.spec.ts",
+      "test.ts"
+    ]
   },
   "defaults": {
     "styleExt": "<%= styleExt %>",

--- a/packages/@angular/cli/lib/config/schema.json
+++ b/packages/@angular/cli/lib/config/schema.json
@@ -262,6 +262,17 @@
             }
           },
           "additionalProperties": false
+        },
+        "include":{
+          "description": "Test files to include in the TypeScript compilation.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "**/*.spec.ts",
+            "test.ts"
+          ]
         }
       },
       "additionalProperties": false

--- a/packages/@angular/cli/models/webpack-configs/typescript.ts
+++ b/packages/@angular/cli/models/webpack-configs/typescript.ts
@@ -2,6 +2,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { stripIndent } from 'common-tags';
 import {AotPlugin, AotPluginOptions} from '@ngtools/webpack';
+
+import { CliConfig } from '../config';
 import { WebpackConfigOptions } from '../webpack-config';
 
 const SilentError = require('silent-error');
@@ -13,8 +15,11 @@ const webpackLoader: string = g['angularCliIsLocal']
   : '@ngtools/webpack';
 
 
-function _createAotPlugin(wco: WebpackConfigOptions, options: any) {
+function _createAotPlugin(wco: WebpackConfigOptions, options: any = {}) {
   const { appConfig, projectRoot, buildOptions } = wco;
+
+  // Exclude test files by default.
+  options.exclude = CliConfig.fromProject().config.test.include;
 
   // Read the environment, and set it in the compiler host.
   let hostReplacementPaths: any = {};
@@ -76,12 +81,6 @@ function _createAotPlugin(wco: WebpackConfigOptions, options: any) {
 
 
 export const getNonAotConfig = function(wco: WebpackConfigOptions) {
-  const { projectRoot, appConfig } = wco;
-  let exclude = [ '**/*.spec.ts' ];
-  if (appConfig.test) {
-    exclude.push(path.join(projectRoot, appConfig.root, appConfig.test));
-  }
-
   return {
     module: {
       rules: [
@@ -93,15 +92,12 @@ export const getNonAotConfig = function(wco: WebpackConfigOptions) {
       ]
     },
     plugins: [
-      _createAotPlugin(wco, { exclude, skipCodeGeneration: true }),
+      _createAotPlugin(wco, { skipCodeGeneration: true }),
     ]
   };
 };
 
 export const getAotConfig = function(wco: WebpackConfigOptions) {
-  const { projectRoot, appConfig } = wco;
-  let exclude = [ '**/*.spec.ts' ];
-  if (appConfig.test) { exclude.push(path.join(projectRoot, appConfig.root, appConfig.test)); };
   return {
     module: {
       rules: [
@@ -113,7 +109,7 @@ export const getAotConfig = function(wco: WebpackConfigOptions) {
       ]
     },
     plugins: [
-      _createAotPlugin(wco, { exclude })
+      _createAotPlugin(wco)
     ]
   };
 };

--- a/packages/@angular/cli/models/webpack-configs/typescript.ts
+++ b/packages/@angular/cli/models/webpack-configs/typescript.ts
@@ -19,7 +19,11 @@ function _createAotPlugin(wco: WebpackConfigOptions, options: any = {}) {
   const { appConfig, projectRoot, buildOptions } = wco;
 
   // Exclude test files by default.
-  options.exclude = CliConfig.fromProject().config.test.include;
+  const testConfig = CliConfig.fromProject().config.test;
+  options.exclude = (testConfig && testConfig.include) || [
+    '**/*.spec.ts',
+    'test.ts'
+  ];
 
   // Read the environment, and set it in the compiler host.
   let hostReplacementPaths: any = {};

--- a/tests/e2e/tests/build/aot/aot.ts
+++ b/tests/e2e/tests/build/aot/aot.ts
@@ -1,14 +1,8 @@
 import {ng} from '../../../utils/process';
-import {expectFileToMatch, writeFile, createDir} from '../../../utils/fs';
+import {expectFileToMatch} from '../../../utils/fs';
 
 export default function() {
   return ng('build', '--aot')
     .then(() => expectFileToMatch('dist/main.bundle.js',
-      /bootstrapModuleFactory.*\/\* AppModuleNgFactory \*\//))
-    // Check if **/*.spec.ts files are excluded by default. This import will cause aot to fail.
-    .then(() => createDir('./src/much/deep/folder'))
-    .then(() => writeFile('./src/much/deep/folder/unit-test.spec.ts', `
-      import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/testing';
-    `))
-    .then(() => ng('build', '--aot'));
+      /bootstrapModuleFactory.*\/\* AppModuleNgFactory \*\//));
 }

--- a/tests/e2e/tests/build/aot/aot.ts
+++ b/tests/e2e/tests/build/aot/aot.ts
@@ -1,8 +1,14 @@
 import {ng} from '../../../utils/process';
-import {expectFileToMatch} from '../../../utils/fs';
+import {expectFileToMatch, writeFile, createDir} from '../../../utils/fs';
 
 export default function() {
   return ng('build', '--aot')
     .then(() => expectFileToMatch('dist/main.bundle.js',
-      /bootstrapModuleFactory.*\/\* AppModuleNgFactory \*\//));
+      /bootstrapModuleFactory.*\/\* AppModuleNgFactory \*\//))
+    // Check if **/*.spec.ts files are excluded by default. This import will cause aot to fail.
+    .then(() => createDir('./src/much/deep/folder'))
+    .then(() => writeFile('./src/much/deep/folder/unit-test.spec.ts', `
+      import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/testing';
+    `))
+    .then(() => ng('build', '--aot'));
 }

--- a/tests/e2e/tests/build/aot/exclude.ts
+++ b/tests/e2e/tests/build/aot/exclude.ts
@@ -1,0 +1,17 @@
+import { ng } from '../../../utils/process';
+import { writeFile } from '../../../utils/fs';
+import { updateJsonFile } from '../../../utils/project';
+
+export default function () {
+  // Check if **/*.spec.ts files are excluded by default.
+  return Promise.resolve()
+    .then(() => updateJsonFile('.angular-cli.json', configJson => {
+      const test = configJson['test'];
+      delete test['include'];
+    }))
+    // This import would cause aot to fail.
+    .then(() => writeFile('src/app.component.spec.ts', `
+      import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/testing';
+    `))
+    .then(() => ng('build', '--aot'));
+}


### PR DESCRIPTION
The `karma` entry in `.angular-cli.json` now supports an `include` property, listing the test specific files to be included in the TypeScript compilation:

```
  "test": {
    "karma": {
      "config": "./karma.conf.js"
    },
    "include": [
      "**/*.spec.ts",
      "test.ts"
    ]
  },
```

Existing projects will default to the list abose.

This list will also be used as an exclude list for AoT Compilations.

Fix #3973