### PR TITLE
fix(Help): fixing the help command aliases

### DIFF
--- a/packages/@angular/cli/commands/help.ts
+++ b/packages/@angular/cli/commands/help.ts
@@ -55,7 +55,13 @@ const HelpCommand = Command.extend({
       });
 
       if (rawArgs.length > 0) {
-        if (cmd === rawArgs[0]) {
+        let commandInput = rawArgs[0];
+        const aliases = Command.prototype.aliases;
+        if (aliases && aliases.indexOf(commandInput) > -1) {
+          commandInput = Command.prototype.name;
+        }
+
+        if (cmd === commandInput) {
           if (command.printDetailedHelp(commandOptions)) {
             this.ui.writeLine(command.printDetailedHelp(commandOptions));
           } else {


### PR DESCRIPTION
Did mapping of aliases to commands in help 
Fixes: https://github.com/angular/angular-cli/issues/4802