### PR TITLE
feat(@angular/cli): build static libs

### DIFF
--- a/docs/documentation/stories/static-libs.md
+++ b/docs/documentation/stories/static-libs.md
@@ -1,0 +1,11 @@
+# Static libraries
+
+Under some circumstances, you may need to build static libraries without code splitting.
+
+This is especially useful for legacy libraries or background scripts.
+
+```json
+"libs": [
+  "background.ts"
+],
+```

--- a/packages/@angular/cli/blueprints/ng2/files/angular-cli.json
+++ b/packages/@angular/cli/blueprints/ng2/files/angular-cli.json
@@ -21,6 +21,7 @@
         "styles.<%= styleExt %>"
       ],
       "scripts": [],
+      "libs": [],
       "environmentSource": "environments/environment.ts",
       "environments": {
         "dev": "environments/environment.ts",

--- a/packages/@angular/cli/lib/config/schema.json
+++ b/packages/@angular/cli/lib/config/schema.json
@@ -166,6 +166,30 @@
             },
             "additionalProperties": false
           },
+          "libs": {
+            "description": "Static libraries to be included in the build.",
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "input": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": true,
+                  "required": [
+                    "input"
+                  ]
+                }
+              ]
+            },
+            "additionalProperties": false
+          },
           "environmentSource":{
             "description": "Source file for environment config.",
             "type": "string"

--- a/packages/@angular/cli/models/webpack-config.ts
+++ b/packages/@angular/cli/models/webpack-config.ts
@@ -101,6 +101,7 @@ export class NgCliWebpackConfig {
   private addAppConfigDefaults(appConfig: any) {
     const appConfigDefaults: any = {
       scripts: [],
+      libs: [],
       styles: []
     };
 


### PR DESCRIPTION
By default,  it is not possible to build static libraries without code splitting.

A common need for apps and web extensions is to maintain long-term state or perform long-term operations independently of the lifetime of any particular web page or browser window.

Web extension manifest (see [Google Chrome: Background Pages](https://developer.chrome.com/extensions/background_pages))
```js
{
  "name": "My extension",
  ...
  "background": {
    "scripts": ["process.js"]
  },
  ...
}
```

Example usage
```js
{
  "project": {
    "version": "1.0.0-beta.32.3",
    "name": "extension"
  },
  "apps": [
    {
      "root": "src",
      "outDir": "dist",
      ...
      "libs": [
        {
          "input": "process.ts",
          "output": "process.js"
        }
      ]
    }
  ]
}
```


Basic Implementation

We simply filter the inline chunks and register the processed libraries as lazy.