### PR TITLE
fix(@angular/cli): fix ng lint formatted output

### DIFF
--- a/packages/@angular/cli/tasks/lint.ts
+++ b/packages/@angular/cli/tasks/lint.ts
@@ -62,7 +62,7 @@ export default Task.extend({
       });
 
     // print formatter output directly for non human-readable formats
-    if (['prose', 'verbose'].indexOf(commandOptions.format) == -1) {
+    if (['prose', 'verbose', 'stylish'].indexOf(commandOptions.format) == -1) {
       ui.writeLine(results.trim());
       return (errors == 0 || commandOptions.force) ? Promise.resolve(0) : Promise.resolve(2);
     }

--- a/packages/@angular/cli/tasks/lint.ts
+++ b/packages/@angular/cli/tasks/lint.ts
@@ -61,6 +61,12 @@ export default Task.extend({
         results = results.concat(result.output.trim().concat('\n'));
       });
 
+    // print formatter output directly for non human-readable formats
+    if (['prose', 'verbose'].indexOf(commandOptions.format) == -1) {
+      ui.writeLine(results.trim());
+      return (errors == 0 || commandOptions.force) ? Promise.resolve(0) : Promise.resolve(2);
+    }
+
     if (errors > 0) {
       ui.writeLine(results.trim());
       ui.writeLine(chalk.red('Lint errors found in the listed files.'));


### PR DESCRIPTION
Print linting result only for human-readable formats, to not mess up xml, json, ... output.

Fix #4791

Some previous discussion was here: https://github.com/angular/angular-cli/pull/4853
Human-readable formatters are according to this list: https://palantir.github.io/tslint/formatters/