### PR TITLE
fix(eject): set ejected project to run `webdriver-manager update` as part of `e2e` npm script

### DIFF
--- a/packages/@angular/cli/tasks/e2e.ts
+++ b/packages/@angular/cli/tasks/e2e.ts
@@ -43,6 +43,7 @@ export const E2eTask = Task.extend({
         const webdriverUpdate = requireProjectModule(projectRoot,
           'protractor/node_modules/webdriver-manager/built/lib/cmds/update');
         // run `webdriver-manager update --standalone false --gecko false --quiet`
+        // if you change this, update the command comment in prev line, and in `eject` task
         promise = promise.then(() => webdriverUpdate.program.run({
           standalone: false,
           gecko: false,

--- a/packages/@angular/cli/tasks/eject.ts
+++ b/packages/@angular/cli/tasks/eject.ts
@@ -31,6 +31,8 @@ const ProgressPlugin = require('webpack/lib/ProgressPlugin');
 export const pluginArgs = Symbol('plugin-args');
 export const postcssArgs = Symbol('postcss-args');
 
+const pree2eNpmScript = `webdriver-manager update --standalone false --gecko false --quiet`;
+
 
 class JsonWebpackSerializer {
   public imports: {[name: string]: string[]} = {};
@@ -434,6 +436,13 @@ export default Task.extend({
             Your package.json scripts needs to not contain a start script as it will be overwritten.
           `);
         }
+        if (scripts['pree2e'] && scripts['pree2e'] !== pree2eNpmScript && !force) {
+          // tslint:disable-next-line:max-line-length
+          throw new SilentError(oneLine`
+            Your package.json scripts needs to not contain a pree2e script as it will be overwritten.
+          `);
+          // tslint:enable-next-line:max-line-length
+        }
         if (scripts['e2e'] && scripts['e2e'] !== 'ng e2e' && !force) {
           throw new SilentError(oneLine`
             Your package.json scripts needs to not contain a e2e script as it will be overwritten.
@@ -448,6 +457,7 @@ export default Task.extend({
         packageJson['scripts']['build'] = 'webpack';
         packageJson['scripts']['start'] = 'webpack-dev-server';
         packageJson['scripts']['test'] = 'karma start ./karma.conf.js';
+        packageJson['scripts']['pree2e'] = pree2eNpmScript;
         packageJson['scripts']['e2e'] = 'protractor ./protractor.conf.js';
 
         // Add new dependencies based on our dependencies.


### PR DESCRIPTION
Fixes an error you get with:

```
ng new awesome
cd awesome
ng eject
npm run e2e
```

Because `webdriver-manager update` never ran.

--

This is based on old NPM `pree2e` way.