### PR TITLE
tests: increase delay on flaky tests

### DIFF
--- a/tests/e2e/tests/build/rebuild.ts
+++ b/tests/e2e/tests/build/rebuild.ts
@@ -76,7 +76,7 @@ export default function() {
         throw new Error('Expected webpack to create a new chunk, but did not.');
       }
     })
-    .then(() => wait(1000))
+    .then(() => wait(2000))
     // Change multiple files and check that all of them are invalidated and recompiled.
     .then(() => writeMultipleFiles({
       'src/app/app.module.ts': `
@@ -91,6 +91,7 @@ export default function() {
     }))
     .then(() => waitForAnyProcessOutputToMatch(
       /webpack: bundle is now VALID|webpack: Compiled successfully./, 10000))
+    .then(() => wait(2000))
     .then(() => request('http://localhost:4200/main.bundle.js'))
     .then((body) => {
       if (!body.match(/\$\$_E2E_GOLDEN_VALUE_1/)) {

--- a/tests/e2e/tests/misc/live-reload.ts
+++ b/tests/e2e/tests/misc/live-reload.ts
@@ -69,10 +69,10 @@ export default function () {
       protractorGoodRegEx
     ))
     // Let app run.
-    .then(_ => wait(1000))
+    .then(_ => wait(2000))
     .then(_ => appendToFile('src/main.ts', 'console.log(1);'))
     .then(_ => waitForAnyProcessOutputToMatch(webpackGoodRegEx, 5000))
-    .then(_ => wait(1000))
+    .then(_ => wait(2000))
     .then(_ => {
       if (liveReloadCount != 2) {
         throw new Error(
@@ -88,10 +88,10 @@ export default function () {
       ['e2e', '--watch', '--no-live-reload'],
       protractorGoodRegEx
     ))
-    .then(_ => wait(1000))
+    .then(_ => wait(2000))
     .then(_ => appendToFile('src/main.ts', 'console.log(1);'))
     .then(_ => waitForAnyProcessOutputToMatch(webpackGoodRegEx, 5000))
-    .then(_ => wait(1000))
+    .then(_ => wait(2000))
     .then(_ => {
       if (liveReloadCount != 1) {
         throw new Error(


### PR DESCRIPTION
The rebuild and live-reload tests have been flaky lately. This might fix them. It might also not.