### PR TITLE
fix(eject): start webpack-dev-server with e2e & sync its port with protractor default config port

### DIFF
--- a/packages/@angular/cli/tasks/eject.ts
+++ b/packages/@angular/cli/tasks/eject.ts
@@ -439,6 +439,12 @@ export default Task.extend({
             Your package.json scripts needs to not contain a start script as it will be overwritten.
           `);
         }
+        if (scripts['pree2e'] && scripts['prepree2e'] !== 'npm start' && !force) {
+          throw new SilentError(oneLine`
+            Your package.json scripts needs to not contain a prepree2e script as it will be
+            overwritten.
+          `);
+        }
         if (scripts['pree2e'] && scripts['pree2e'] !== pree2eNpmScript && !force) {
           throw new SilentError(oneLine`
             Your package.json scripts needs to not contain a pree2e script as it will be
@@ -457,8 +463,9 @@ export default Task.extend({
         }
 
         packageJson['scripts']['build'] = 'webpack';
-        packageJson['scripts']['start'] = 'webpack-dev-server';
+        packageJson['scripts']['start'] = 'webpack-dev-server --port=4200';
         packageJson['scripts']['test'] = 'karma start ./karma.conf.js';
+        packageJson['scripts']['prepree2e'] = 'npm start';
         packageJson['scripts']['pree2e'] = pree2eNpmScript;
         packageJson['scripts']['e2e'] = 'protractor ./protractor.conf.js';
 


### PR DESCRIPTION
This only handles default port for now as we don't seem to change protractor config in `eject`.

In the future we can provide something that takes the default `serve` task port or the `.angular-cli.json` override default, but for now, this should do.

It also starts the dev server with e2e by default because that's what the current version of the CLI does for non-ejected projects. It uses a `pre``pre` script for that, which is a bit weird, but it gives the app more time to compile etc.