### PR TITLE
fix(@angular/cli): Adding more details to documentation

### DIFF
--- a/docs/documentation/build.md
+++ b/docs/documentation/build.md
@@ -65,36 +65,46 @@ All builds make use of bundling, and using the `--prod` flag in  `ng build --pro
 or `ng serve --prod` will also make use of uglifying and tree-shaking functionality.
 
 ## Options
-`--watch` (`-w`) rebuild when files change
+`--aot` Build using Ahead of Time compilation.
 
-`--target` (`-t`) define the build target
+`--app` Specifies app name or index to use.
 
-`--environment` (`-e`) defines the build environment
+`--base-href` (`-bh`) Base url for the application being built.
 
-`--prod` flag to set build target and environment to production
+`--deploy-url` (`-d`) URL where files will be deployed.
 
-`--dev` flag to set build target and environment to development
+`--dev` Build target and environment to development.
 
 `--output-path` (`-op`) path where output will be placed
 
-`--aot` flag whether to build using Ahead of Time compilation
+`--environment` (`-e`) Defines the build environment.
 
-`--sourcemap` (`-sm`) output sourcemaps
+`--extract-css` (`-ec`) Extract css from global styles onto css files instead of js ones.
 
-`--vendor-chunk` (`-vb`) use a separate bundle containing only vendor libraries
+`--i18n-file` Localization file to use for i18n.
 
-`--base-href` (`-bh`) base url for the application being built
+`--i18n-format` Format of the localization file specified with --i18n-file.
 
-`--deploy-url` (`-d`) url where files will be deployed
+`--locale` Locale to use for i18n.
 
-`--verbose` (`-v`) adds more details to output logging
+`--output-hashing` Define the output filename cache-busting hashing mode.
 
-`--progress` (`-pr`) log progress to the console while building
+`--output-path` (`-op`) Path where output will be placed.
 
-`--extract-css` (`-ec`) extract css from global styles onto css files instead of js ones
+`--poll` Enable and define the file watching poll time period (milliseconds).
 
-`--output-hashing` define the output filename cache-busting hashing mode
+`--prod` Build target and environment to production.
 
-`--stats-json` generates a `stats.json` file which can be analyzed using tools such as: `webpack-bundle-analyzer` or https://webpack.github.io/analyse
+`--progress` (`-pr`) Log progress to the console while building.
 
-`--poll` enable and define the file watching poll time period (milliseconds)
+`--sourcemap` (`-sm`) Output sourcemaps.
+
+`--stats-json` Generates a `stats.json` file which can be analyzed using tools such as: `webpack-bundle-analyzer` or https://webpack.github.io/analyse.
+
+`--target` (`-t`) Defines the build target.
+
+`--vendor-chunk` (`-vb`) Use a separate bundle containing only vendor libraries.
+
+`--verbose` (`-v`) Adds more details to output logging.
+
+`--watch` (`-w`) Run build when files change.

--- a/docs/documentation/config.md
+++ b/docs/documentation/config.md
@@ -1,4 +1,18 @@
 <!-- Links in /docs/documentation should NOT have `.md` at the end, because they end up in our wiki at release. -->
 
-`ng get`
-`ng set`
+# ng get
+
+## Overview
+`ng get [key]` Get a value from the configuration.
+
+## Options
+`--global` Get the value in the global configuration (in your home directory).
+
+
+# ng set
+
+## Overview
+`ng set [key]=[value]` Set a value in the configuration.
+
+## Options
+`--global` Set the value in the global configuration rather than in your project's.

--- a/docs/documentation/doc.md
+++ b/docs/documentation/doc.md
@@ -3,4 +3,4 @@
 # ng doc
 
 ## Overview
-`ng doc [search term]` searches documentation on [angular.io](https://angular.io)
+`ng doc [search term]`  Opens the official Angular documentation for a given keyword on [angular.io](https://angular.io).

--- a/docs/documentation/e2e.md
+++ b/docs/documentation/e2e.md
@@ -16,14 +16,10 @@ End-to-end tests are run via [Protractor](https://angular.github.io/protractor/)
 ## Options
 `--config` (`-c`) use a specific config file. Defaults to the protractor config file in `.angular-cli.json`.
 
-`--specs` (`-sp`) override specs in the protractor config.
-Can send in multiple specs by repeating flag (`ng e2e --specs=spec1.ts --specs=spec2.ts`).
+`--element-explorer` (`-ee`) Start Protractor's [Element Explorer](https://github.com/angular/protractor/blob/master/docs/debugging.md#testing-out-protractor-interactively) for debugging.
 
-`--element-explorer` (`-ee`) start Protractor's
-[Element Explorer](https://github.com/angular/protractor/blob/master/docs/debugging.md#testing-out-protractor-interactively)
-for debugging.
+`--serve` Compile and Serve the app. All serve options are also available. The live-reload option defaults to false, and the default port will be random.
 
-`--webdriver-update` (`-wu`) try to update webdriver.
+`--specs` Override specs in the protractor config. Can send in multiple specs by repeating flag (ng e2e --specs=spec1.ts --specs=spec2.ts).
 
-`--serve` (`-s`) compile and serve the app.
-All non-reload related serve options are also available (e.g. `--port=4400`).
+`--webdriver-update` (`-wu`) (Default: true) Try to update webdriver.

--- a/docs/documentation/generate/class.md
+++ b/docs/documentation/generate/class.md
@@ -6,4 +6,6 @@
 `ng generate class [name]` generates a class
 
 ## Options
-`--spec` specifies if a spec file is generated
+`--app` Specifies app name or index to use.
+
+`--spec` Specifies if a spec file is generated.

--- a/docs/documentation/generate/component.md
+++ b/docs/documentation/generate/component.md
@@ -6,22 +6,24 @@
 `ng generate component [name]` generates a component
 
 ## Options
-`--flat` flag to indicate if a dir is created
+`--app` Specifies app name or index to use.
 
-`--inline-template` (`-it`) specifies if the template will be in the ts file
+`--change-detection` (`-cd`) Specifies the change detection strategy.
 
-`--inline-style` (`-is`) specifies if the style will be in the ts file
+`--flat` Flag to indicate if a dir is created.
 
-`--prefix` specifies whether to use the prefix
+`--export` Specifies if declaring module exports the component.
 
-`--spec` specifies if a spec file is generated
+`--inline-style` (`-is`) Specifies if the style will be in the ts file.
 
-`--view-encapsulation` (`-ve`) specifies the view encapsulation strategy
+`--inline-template` (`-it`) Specifies if the template will be in the ts file.
 
-`--change-detection` (`-cd`) specifies the change detection strategy
+`--module` (`-m`) Allows specification of the declaring module.
 
-`--skip-import` allows for skipping the module import
+`--prefix` Specifies whether to use the prefix.
 
-`--module` (`-m`) allows specification of the declaring module
+`--skip-import` Allows for skipping the module import.
 
-`--export` specifies if declaring module exports the component
+`--spec` Specifies if a spec file is generated.
+
+`--view-encapsulation` (`-ve`) Specifies the view encapsulation strategy.

--- a/docs/documentation/generate/directive.md
+++ b/docs/documentation/generate/directive.md
@@ -6,14 +6,16 @@
 `ng generate directive [name]` generates a directive
 
 ## Options
-`--flat` flag to indicate if a dir is created
+`--app` Specifies app name or index to use.
 
-`--prefix` specifies whether to use the prefix
+`--export` Specifies if declaring module exports the component.
 
-`--spec` specifies if a spec file is generated
+`--flat` Flag to indicate if a dir is created.
 
-`--skip-import` allows for skipping the module import
+`--module` (`-m`) Allows specification of the declaring module.
 
-`--module` (`-m`) allows specification of the declaring module
+`--prefix` Specifies whether to use the prefix.
 
-`--export` specifies if declaring module exports the directive
+`--skip-import` Allows for skipping the module import.
+
+`--spec` Specifies if a spec file is generated.

--- a/docs/documentation/generate/enum.md
+++ b/docs/documentation/generate/enum.md
@@ -4,3 +4,6 @@
 
 ## Overview
 `ng generate enum [name]` generates an enumeration
+
+## Options
+`--app` Specifies app name or index to use.

--- a/docs/documentation/generate/guard.md
+++ b/docs/documentation/generate/guard.md
@@ -4,8 +4,10 @@
 `ng generate guard [name]` generates a guard
 
 ## Options
-`--flat` flag to indicate if a dir is created
+`--app` Specifies app name or index to use.
 
-`--spec` specifies if a spec file is generated
+`--flat` Indicate if a dir is created.
 
-`--module` (`-m`) allows specification of the declaring module
+`--module` (`-m`) Allows specification of the declaring module.
+
+`--spec` Specifies if a spec file is generated.

--- a/docs/documentation/generate/interface.md
+++ b/docs/documentation/generate/interface.md
@@ -5,6 +5,7 @@
 ## Overview
 `ng generate interface [name] <type>` generates an interface
 
-## Arguments
+## Options
+`--app` Specifies app name or index to use.
 
-`type` optional string to specify the type of interface
+`type` Pptional String to specify the type of interface.

--- a/docs/documentation/generate/module.md
+++ b/docs/documentation/generate/module.md
@@ -6,9 +6,10 @@
 `ng generate module [name]` generates an NgModule
 
 ## Options
+`--app` Specifies app name or index to use.
 
-`--flat` flag to indicate if a dir is created
+`--flat` Flag to indicate if a dir is created.
 
-`--spec` specifies if a spec file is generated
+`--spec` Specifies if a spec file is generated.
 
-`--routing` specifies if a routing module file should be generated
+`--routing` Specifies if a routing module file should be generated.

--- a/docs/documentation/generate/pipe.md
+++ b/docs/documentation/generate/pipe.md
@@ -6,12 +6,14 @@
 `ng generate pipe [name]` generates a pipe
 
 ## Options
-`--flat` flag to indicate if a dir is created
+`--app` Specifies app name or index to use.
 
-`--spec` specifies if a spec file is generated
+`--export` Specifies if declaring module exports the pipe.
 
-`--skip-import` allows for skipping the module import
+`--flat` Flag to indicate if a dir is created.
 
-`--module` (`-m`) allows specification of the declaring module
+`--module` (`-m`) Allows specification of the declaring module.
 
-`--export` specifies if declaring module exports the pipe
+`--skip-import` Allows for skipping the module import.
+
+`--spec` Specifies if a spec file is generated.

--- a/docs/documentation/generate/service.md
+++ b/docs/documentation/generate/service.md
@@ -6,8 +6,10 @@
 `ng generate service [name]` generates a service
 
 ## Options
-`--flat` flag to indicate if a dir is created
+`--app` Specifies app name or index to use.
 
-`--spec` specifies if a spec file is generated
+`--flat` Flag to indicate if a dir is created.
 
-`--module` (`-m`) allows specification of the declaring module
+`--module` (`-m`) Allows specification of the declaring module.
+
+`--spec` Specifies if a spec file is generated.

--- a/docs/documentation/lint.md
+++ b/docs/documentation/lint.md
@@ -7,8 +7,8 @@
 
 ## Options
 
-`--fix` will attempt to fix lint errors
+`--fix` Fixes linting errors (may overwrite linted files).
 
-`--force` will always return error code 0 even with lint errors
+`--force` Succeeds even if there was linting errors.
 
-`--format` (`-t`) the output formatter to use
+`--format` (`-t`) Output format (prose, json, stylish, verbose, pmd, msbuild, checkstyle, vso, fileslist).

--- a/docs/documentation/new.md
+++ b/docs/documentation/new.md
@@ -8,22 +8,32 @@
 Default applications are created in a directory of the same name, with an initialized Angular application.
 
 ## Options
-`--dry-run` (`-d`) run through without making any changes
+`--directory` (`-dir`) The directory name to create the app in.
 
-`--skip-install` (`-si`) skip installing packages
+`--dry-run` (`-d`) Run through without making any changes.
 
-`--skip-git` (`-sg`) skip initializing a git repository
+`--inline-style` (`is`) Should have an inline style.
 
-`--directory` (`-dir`) the directory name to create the app in
+`--inline-template` (`it`) Should have an inline template.
 
-`--source-dir` (`-sd`) the name of the source directory
+`--link-cli` Automatically link the `@angular/cli` package.
 
-`--style` the style file default extension
+`--ng4` Create a project with Angular 4 in the template.
 
-`--prefix` (`p`) the prefix to use for all component selectors
+`--prefix` (`p`) The prefix to use for all component selectors.
 
-`--routing` flag to indicate whether to generate a routing module
+`--routing` Generate a routing module.
 
-`--inline-style` (`is`) flag to indicate if the app component should have an inline style
+`--skip-commit` Skip committing the first commit to git.
 
-`--inline-template` (`it`) flag to indicate if the app component should have an inline template
+`--skip-git` (`-sg`) Skip initializing a git repository.
+
+`--skip-install` (`-si`) Skip installing packages.
+
+`--skip-tests` Skip creating spec files.
+
+`--source-dir` (`-sd`) The name of the source directory.
+
+`--style` The style file default extension.
+
+`--verbose` Adds more details to output logging.

--- a/docs/documentation/serve.md
+++ b/docs/documentation/serve.md
@@ -5,55 +5,23 @@
 ## Overview
 `ng serve` builds the application and starts a web server
 
+All the build Options are available in serve below are the additional options.
+
 ## Options
-`--watch` (`-w`) rebuild when files change
+`--host` (`-H`) Listens only on localhost by default.
 
-`--port` (`-p`) port to serve the application on
+`--hmr` Enable hot module replacement.
 
-`--host` (`-H`) host where to listen
+`--live-reload` (`-lr`) Whether to reload the page on change, using live-reload.
 
-`--proxy-config` (`-pc`) proxy configuration file
+`--live-reload-client` Specify the URL that the live reload browser client will use.
 
-`--live-reload` (`-lr`) flag to turn off live reloading
+`--open` (`-o`) Opens the url in default browser.
 
-`--live-reload-client` specify the URL that the live reload browser client will use
+`--port` (`-p`) Port to listen to for serving.
 
-`--ssl` flag to turn on SSL
+`--ssl`  Serve using HTTPS.
 
-`--ssl-key` path to the SSL key
+`--ssl-cert` SSL certificate to use for serving HTTPS.
 
-`--ssl-cert` path to the SSL cert
-
-`--open` (`-o`) opens the app in the default browser
-
-`--hmr` use hot module reload
-
-`--target` (`-t`) define the build target
-
-`--environment` (`-e`) defines the build environment
-
-`--prod` flag to set build target and environment to production
-
-`--dev` flag to set build target and environment to development
-
-`--output-path` (`-po`) path where output will be placed
-
-`--aot` flag whether to build using Ahead of Time compilation
-
-`--sourcemap` (`-sm`) output sourcemaps
-
-`--vendor-chunk` (`-vb`) use a separate bundle containing only vendor libraries
-
-`--base-href` (`-bh`) base url for the application being built
-
-`--deploy-url` (`-d`) url where files will be deployed
-
-`--verbose` (`-v`) adds more details to output logging
-
-`--progress` (`-pr`) log progress to the console while building
-
-`--extract-css` (`-ec`) extract css from global styles onto css files instead of js ones
-
-`--output-hashing` define the output filename cache-busting hashing mode
-
-`--poll` enable and define the file watching poll time period (milliseconds)
+`--ssl-key` SSL key to use for serving HTTPS.

--- a/docs/documentation/test.md
+++ b/docs/documentation/test.md
@@ -16,18 +16,30 @@ Tests will execute after a build is executed via [Karma](http://karma-runner.git
 You can run tests with coverage via `--code-coverage`. The coverage report will be in the `coverage/` directory.
 
 ## Options
-`--watch` (`-w`) flag to run builds when files change
+`--app` Specifies app name or index to use.
 
-`--browsers` override which browsers tests are run against
+`--browsers` Override which browsers tests are run against.
 
-`--colors` enable or disable colors in the output (reporters and logs)
+`--build` Build prior to running tests.
 
-`--log-level` level of logging
+`--code-coverage` Coverage report will be in the coverage/ directory.
 
-`--port` port where the web server will be listening
+`--colors` Enable or disable colors in the output (reporters and logs).
 
-`--reporters` list of reporters to use
+`--config` Use a specific config file. Defaults to the protractor config file in angular-cli.json.
 
-`--build` flag to build prior to running tests
+`--log-level` Level of logging.
 
-`--poll` enable and define the file watching poll time period (milliseconds)
+`--poll` Enable and define the file watching poll time period (milliseconds).
+
+`--port` Port where the web server will be listening.
+
+`--progress` Log progress to the console while in progress.
+
+`--reporters` List of reporters to use.
+
+`--single-run` Run tests a single time.
+
+`--sourcemap` Output sourcemaps.
+
+`--watch` (`-w`) Run build when files change.


### PR DESCRIPTION
- Added descriptions to `.md` files now both are similar on `ng help` and docs.
- Ordered options in alphabetical order