### PR TITLE
feat(@angular/cli): allow code coverage excludes

### DIFF
--- a/packages/@angular/cli/lib/config/schema.json
+++ b/packages/@angular/cli/lib/config/schema.json
@@ -32,7 +32,7 @@
           "name": {
             "type": "string",
             "description": "Name of the app."
-          },          
+          },
           "root": {
             "type": "string",
             "description": "The root directory of the app."
@@ -270,6 +270,20 @@
             }
           },
           "additionalProperties": false
+        },
+        "codeCoverage": {
+          "type": "object",
+          "properties": {
+            "exclude": {
+              "description": "Globs to exclude from code coverage.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": []
+            }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -435,19 +449,19 @@
               "description": "The host the application will be served on",
               "type": "string",
               "default": "localhost"
-            
+
             },
             "ssl": {
               "description": "Enables ssl for the application",
               "type": "boolean",
               "default": false
-            
+
             },
             "sslKey": {
               "description": "The ssl key used by the server",
               "type": "string",
               "default": "ssl/server.key"
-            
+
             },
             "sslCert": {
               "description": "The ssl certificate used by the server",

--- a/tests/e2e/tests/misc/coverage.ts
+++ b/tests/e2e/tests/misc/coverage.ts
@@ -1,9 +1,26 @@
-import {expectFileToExist} from '../../utils/fs';
+import {expectFileToExist, expectFileToMatch} from '../../utils/fs';
+import {updateJsonFile} from '../../utils/project';
+import {expectToFail} from '../../utils/utils';
 import {ng} from '../../utils/process';
 
 
-export default function() {
+export default function () {
   return ng('test', '--single-run', '--code-coverage')
     .then(() => expectFileToExist('coverage/src/app'))
-    .then(() => expectFileToExist('coverage/lcov.info'));
+    .then(() => expectFileToExist('coverage/lcov.info'))
+    // Verify code coverage exclude work
+    .then(() => expectFileToMatch('coverage/lcov.info', 'polyfills.ts'))
+    .then(() => expectFileToMatch('coverage/lcov.info', 'test.ts'))
+    .then(() => updateJsonFile('.angular-cli.json', configJson => {
+      const test = configJson['test'];
+      test['codeCoverage'] = {
+        exclude: [
+          'src/polyfills.ts',
+          '**/test.ts'
+        ]
+      };
+    }))
+    .then(() => ng('test', '--single-run', '--code-coverage'))
+    .then(() => expectToFail(() => expectFileToMatch('coverage/lcov.info', 'polyfills.ts')))
+    .then(() => expectToFail(() => expectFileToMatch('coverage/lcov.info', 'test.ts')));
 }


### PR DESCRIPTION
A new CLI config entry under `test` allows you to list exclude globs for code coverage:

```
  "test": {
    "codeCoverage": {
      "exclude": [
        "src/polyfills.ts",
        "**/test.ts"
      ]
    },
    "karma": {
      "config": "./karma.conf.js"
    }
  },
```

/cc @delasteve 