### PR TITLE
git feat(serve): add option to serve app from dist folder

### DIFF
--- a/packages/@angular/cli/commands/e2e.ts
+++ b/packages/@angular/cli/commands/e2e.ts
@@ -14,6 +14,7 @@ export interface E2eTaskOptions extends ServeTaskOptions {
   webdriverUpdate: boolean;
   specs: string[];
   elementExplorer: boolean;
+  useDist: boolean;
 }
 
 const E2eCommand = Command.extend({
@@ -65,7 +66,14 @@ const E2eCommand = Command.extend({
         Compile and Serve the app.
         All non-reload related serve options are also available (e.g. --port=4400).
       `
-    }
+    },
+    {
+      name: 'use-dist',
+      type: Boolean,
+      default: false,
+      aliases: ['ud'],
+      description: 'Uses the files in the dist folder to run tests instead of serving from memory.',
+    },
   ], [
     {
       name: 'port',

--- a/packages/@angular/cli/commands/serve.ts
+++ b/packages/@angular/cli/commands/serve.ts
@@ -26,6 +26,7 @@ export interface ServeTaskOptions extends BuildOptions {
   sslCert?: string;
   open?: boolean;
   hmr?: boolean;
+  useDist?: boolean;
 }
 
 // Expose options unrelated to live-reload to other commands that need to run serve
@@ -93,14 +94,21 @@ export const baseServeCommandOptions: any = overrideOptions([
     type: Boolean,
     default: false,
     description: 'Enable hot module replacement.',
-  }
-], [
+  },
   {
-    name: 'watch',
-    default: true,
-    description: 'Rebuild on change.'
-  }
-]);
+    name: 'use-dist',
+    type: Boolean,
+    default: false,
+    aliases: ['ud'],
+    description: 'Uses the files in the dist folder to run tests instead of re-building.',
+  },
+], [
+    {
+      name: 'watch',
+      default: true,
+      description: 'Rebuild on change.'
+    }
+  ]);
 
 const ServeCommand = Command.extend({
   name: 'serve',

--- a/packages/@angular/cli/tasks/serve.ts
+++ b/packages/@angular/cli/tasks/serve.ts
@@ -31,7 +31,15 @@ export default Task.extend({
     if (projectConfig.project && projectConfig.project.ejected) {
       throw new SilentError('An ejected project cannot use the build command anymore.');
     }
-    rimraf.sync(path.resolve(this.project.root, outputPath));
+
+    const contentBase = path.resolve(this.project.root, outputPath);
+    if (serveTaskOptions.useDist) {
+      if(!fs.existsSync(contentBase)) {
+        throw new SilentError('Dist directory not found');
+      }
+    } else {
+      rimraf.sync(contentBase);
+    }
 
     const serveDefaults = {
       // default deployUrl to '' on serve to prevent the default from .angular-cli.json
@@ -151,6 +159,12 @@ export default Task.extend({
       overlay: serveTaskOptions.target === 'development'
     };
 
+    if (serveTaskOptions.useDist) {
+      webpackDevServerConfiguration.contentBase = contentBase;
+      webpackDevServerConfiguration.lazy = true;
+      webpackDevServerConfiguration.filename = appConfig.main;
+    }
+
     if (sslKey != null && sslCert != null) {
       webpackDevServerConfiguration.key = sslKey;
       webpackDevServerConfiguration.cert = sslCert;
@@ -182,7 +196,10 @@ export default Task.extend({
           return reject(err);
         }
         if (serveTaskOptions.open) {
-            opn(serverAddress);
+          opn(serverAddress);
+        }
+        if(serveTaskOptions.useDist && rebuildDoneCb) {
+          rebuildDoneCb();
         }
       });
     })


### PR DESCRIPTION
Add a flag to allow serving the app from the dist folder.

This allows users to run `ng build` and then run `ng serve --use-dist` to serve from the dist folder. This is also enabled for `ng e2e` which allows running `ng build` with the appropriate environment / target and then running e2e tests against the build (without `ng serve` rebuilding). This is especially useful for continuous deployment scenarios.

This should resolve: #4293, #4722, and #4830 
