### PR TITLE
fix(@angular/cli): Fixing duplicate aliases issue

### DIFF
--- a/packages/@angular/cli/ember-cli/lib/models/command.js
+++ b/packages/@angular/cli/ember-cli/lib/models/command.js
@@ -183,7 +183,10 @@ Command.prototype.mergeDuplicateOption = function(key) {
 */
 Command.prototype.normalizeOption = function(option) {
   option.key = camelize(option.name);
-  option.aliases = (option.aliases || []).concat(camelize(option.name));
+  option.aliases = (option.aliases || []);
+  if (option.aliases.indexOf(camelize(option.name)) === -1) {
+    option.aliases = option.aliases.concat(camelize(option.name));
+  }
   option.required = option.required || false;
   return option;
 };


### PR DESCRIPTION
`ng —help` calls `validateAndRun` twice once to check if `callHelp` function is to be triggered and once actually for command lookup and mutates the state of aliases. `normalizeOption` is what is mutating the aliases which is called from `parseArgs` from `validateAndRun`. 

The current fix is to check for aliases in the list of aliases and only add it if it's not previously present else continue as usual.

Fixes: https://github.com/angular/angular-cli/issues/4979