### PR TITLE
fix(@ngtools/webpack): Bump loader-utils and use getOptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "karma-webpack": "^2.0.0",
     "less": "^2.7.2",
     "less-loader": "^2.2.3",
-    "loader-utils": "^0.2.16",
+    "loader-utils": "^1.0.2",
     "lodash": "^4.11.1",
     "magic-string": "^0.19.0",
     "minimatch": "^3.0.3",

--- a/packages/@ngtools/webpack/package.json
+++ b/packages/@ngtools/webpack/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "enhanced-resolve": "^3.1.0",
-    "loader-utils": "^0.2.16",
+    "loader-utils": "^1.0.2",
     "magic-string": "^0.19.0",
     "source-map": "^0.5.6"
   },

--- a/packages/@ngtools/webpack/src/loader.ts
+++ b/packages/@ngtools/webpack/src/loader.ts
@@ -374,7 +374,7 @@ export function ngcLoader(this: LoaderContext & { _compilation: any }) {
       })
       .catch(err => cb(err));
   } else {
-    const options = loaderUtils.parseQuery(this.query);
+    const options = loaderUtils.getOptions(this) || {};
     const tsConfigPath = options.tsConfigPath;
     const tsConfig = ts.readConfigFile(tsConfigPath, ts.sys.readFile);
 


### PR DESCRIPTION
fix deprecated warning
![deprecated-warning](https://cloud.githubusercontent.com/assets/10962576/23329782/4b8fd014-fb7a-11e6-8baa-772294351a0f.png)

link: webpack/loader-utils#56