### PR TITLE
fix: Enforce loglevel warn for npm-install

### DIFF
--- a/packages/@angular/cli/tasks/npm-install.ts
+++ b/packages/@angular/cli/tasks/npm-install.ts
@@ -13,7 +13,7 @@ export default Task.extend({
 
     return new Promise(function(resolve, reject) {
       ui.writeLine(chalk.green(`Installing packages for tooling via ${packageManager}.`));
-      exec(`${packageManager} install`,
+      exec(`${packageManager} --quiet install`,
         (err: NodeJS.ErrnoException, _stdout: string, stderr: string) => {
         if (err) {
           ui.writeLine(stderr);


### PR DESCRIPTION
The npm call uses the node exec() call which has a default limit
of 200kb after which the process is terminated.
When the user has set the info loglevel ng new terminates without
any helpful error message. When using --quiet the loglevel is
set to warning in any case resulting in a successful build.
This is especially important for users of docker since the current
node base image sets the loglevel to info.