### PR TITLE
fix(@ngtools/webpack): continue past invalid imports

### DIFF
--- a/packages/@ngtools/webpack/src/entry_resolver.ts
+++ b/packages/@ngtools/webpack/src/entry_resolver.ts
@@ -97,7 +97,7 @@ function _symbolImportLookup(refactor: TypeScriptFileRefactor,
       (decl.moduleSpecifier as ts.StringLiteral).text,
       refactor.fileName, program.getCompilerOptions(), host);
     if (!resolvedModule.resolvedModule || !resolvedModule.resolvedModule.resolvedFileName) {
-      return null;
+      continue;
     }
 
     const module = resolvedModule.resolvedModule.resolvedFileName;


### PR DESCRIPTION
Small change to continue instead of bail.

This happens when for some reason Typescript cant locate a module in an import statement.

This WILL be necessary for supporting fs for platform-server

Example:
main.ts
```ts
import * as fs from 'fs'; // Yeah this will probably never be the actual use case but to have it is good to be able to skip over this
import { enableProdMode } from '@angular/core';
import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';

import { AppBrowserModule } from './app/app.browser.module';
import { environment } from './environments/environment';

if (environment.production) {
  enableProdMode();
}

platformBrowserDynamic().bootstrapModule(AppBrowserModule);
```
To test, import this before your MainModule
```ts
import * as fs from 'fs';
```