### PR TITLE
ng command failed on no devDependencies in package.json

### DIFF
--- a/packages/@angular/cli/bin/ng
+++ b/packages/@angular/cli/bin/ng
@@ -91,9 +91,9 @@ if (require('../package.json')['name'] == 'angular-cli'
 const packageJsonProjectPath = findUp('package.json', process.cwd(), true);
 if (packageJsonProjectPath && fs.existsSync(packageJsonProjectPath)) {
   const packageJsonProject = require(packageJsonProjectPath);
-  const hasOldDep = !!packageJsonProject.dependencies['angular-cli'];
-  const hasOldDevDep = !!packageJsonProject.devDependencies['angular-cli'];
-  const hasDevDep = !!packageJsonProject.devDependencies['@angular/cli'];
+  const hasOldDep = !!(packageJsonProject.dependencies && packageJsonProject.dependencies['angular-cli']);
+  const hasOldDevDep = !!(packageJsonProject.devDependencies && packageJsonProject.devDependencies['angular-cli']);
+  const hasDevDep = !!(packageJsonProject.devDependencies && packageJsonProject.devDependencies['@angular/cli']);
 
   if (hasOldDep || hasOldDevDep || !hasDevDep) {
     const warnings = [


### PR DESCRIPTION
```
$ cat package.json
{
  "name": "nodevdep",
  "version": "0.0.0",
  "license": "MIT",
  "scripts": {
    "ng": "ng",
    "start": "ng serve",
    "build": "ng build",
    "test": "ng test",
    "lint": "ng lint",
    "e2e": "ng e2e"
  },
  "private": true,
  "dependencies": {
    "@angular/common": "^2.4.0",
    "@angular/compiler": "^2.4.0",
    "@angular/core": "^2.4.0",
    "@angular/forms": "^2.4.0",
    "@angular/http": "^2.4.0",
    "@angular/platform-browser": "^2.4.0",
    "@angular/platform-browser-dynamic": "^2.4.0",
    "@angular/router": "^3.4.0",
    "core-js": "^2.4.1",
    "rxjs": "^5.1.0",
    "zone.js": "^0.7.6",
    "@angular/cli": "1.0.0-rc.0",
    "@angular/compiler-cli": "^2.4.0",
    "@types/jasmine": "2.5.38",
    "@types/node": "~6.0.60",
    "codelyzer": "~2.0.0",
    "jasmine-core": "~2.5.2",
    "jasmine-spec-reporter": "~3.2.0",
    "karma": "~1.4.1",
    "karma-chrome-launcher": "~2.0.0",
    "karma-cli": "~1.0.1",
    "karma-jasmine": "~1.1.0",
    "karma-jasmine-html-reporter": "^0.2.2",
    "karma-coverage-istanbul-reporter": "^0.2.0",
    "protractor": "~5.1.0",
    "ts-node": "~2.0.0",
    "tslint": "~4.4.2",
    "typescript": "~2.0.0"
  }
}
```

```
$ ng --version
/usr/local/lib/node_modules/@angular/cli/bin/ng:95
  const hasOldDevDep = !!packageJsonProject.devDependencies['angular-cli'];
                                                           ^

TypeError: Cannot read property 'angular-cli' of undefined
    at Object.<anonymous> (/usr/local/lib/node_modules/@angular/cli/bin/ng:95:60)
    at Module._compile (module.js:571:32)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:488:32)
    at tryModuleLoad (module.js:447:12)
    at Function.Module._load (module.js:439:3)
    at Module.runMain (module.js:605:10)
    at run (bootstrap_node.js:422:7)
    at startup (bootstrap_node.js:143:9)
    at bootstrap_node.js:537:3


```