### PR TITLE
docs(@angular/flex-layout): changed @angular/flex-layout

### DIFF
--- a/docs/documentation/stories/include-angular-flex.md
+++ b/docs/documentation/stories/include-angular-flex.md
@@ -17,7 +17,7 @@ import { FlexLayoutModule } from '@angular/flex-layout';
 @NgModule({
   imports: [
     ...
-    FlexLayoutModule.forRoot()
+    FlexLayoutModule
   ],
   ...
 })


### PR DESCRIPTION
changed @angular/flex-layout documentation to rmeove reference of
deprecated method

changed @angular/flex-layout