### PR TITLE
fix(docs): jasmine-spec-reporter is still used in rc.0

### DIFF
--- a/docs/documentation/stories/rc.0-update.md
+++ b/docs/documentation/stories/rc.0-update.md
@@ -316,7 +316,6 @@ Packages in `dependencies`:
 - `@types/node` was updated to `~6.0.60`
 - `codelyzer` was updated to `~2.0.0`
 - `jasmine-core` was updated to `~2.5.2`
-- `jasmine-spec-reporter` was **removed**
 - `karma` was updated to `~1.4.1`
 - `karma-chrome-launcher` was updated to `~2.0.0`
 - `karma-cli` was updated to `~1.0.1`
@@ -447,5 +446,3 @@ Add these new rules:
 ```
 
 Update `no-inferrable-types` to `"no-inferrable-types": [true, "ignore-params"]`.
-
-


### PR DESCRIPTION
The guide to rc.0 indicates that `jasmine-spec-reporter` has been removed. I may be mistaken but I think it's still necessary (the protractor config file still reference it).