### PR TITLE
docs(README): add required rmdir options for update on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ npm install -g @angular/cli@latest
 
 Local project package:
 ```bash
-rm -rf node_modules dist # use rmdir on Windows
+rm -rf node_modules dist # use rmdir /S/Q on Windows
 npm install --save-dev @angular/cli@latest
 npm install
 ```


### PR DESCRIPTION
Add required Windows `rmdir` options in Angular CLI update instructions to match `bash` `rm -rf` command.