### PR TITLE
docs: add directory removal options in README for update on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ npm install -g @angular/cli@latest
 
 Local project package:
 ```bash
-rm -rf node_modules dist # use rmdir on Windows
+rm -rf node_modules dist # use rmdir /S/Q node_modules dist in Windows Command Prompt; use rm -r -fo node_modules,dist in Windows PowerShell
 npm install --save-dev @angular/cli@latest
 npm install
 ```


### PR DESCRIPTION
Add required Windows `rmdir` options for `Windows Command Prompt` and `rm` options for `Windows PowerShell` in Angular CLI README update instructions to match `bash` `rm -rf` command.