### PR TITLE
docs: add Guard generator option in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Directive | `ng g directive my-new-directive`
 Pipe      | `ng g pipe my-new-pipe`
 Service   | `ng g service my-new-service`
 Class     | `ng g class my-new-class`
+Guard     | `ng g guard my-new-guard`
 Interface | `ng g interface my-new-interface`
 Enum      | `ng g enum my-new-enum`
 Module    | `ng g module my-module`


### PR DESCRIPTION
Add the Guard param on the options table of the generator in the README.
It was implemented by #4055.