### PR TITLE
chore(lint): bump to tslint 4.5.0

### DIFF
--- a/packages/@angular/cli/blueprints/ng/files/package.json
+++ b/packages/@angular/cli/blueprints/ng/files/package.json
@@ -40,7 +40,7 @@
     "karma-coverage-istanbul-reporter": "^0.2.0",
     "protractor": "~5.1.0",
     "ts-node": "~2.0.0",
-    "tslint": "~4.4.2",
+    "tslint": "~4.5.0",
     "typescript": "<%= ng4 ? '~2.1.0' : '~2.0.0' %>"
   }
 }


### PR DESCRIPTION
Update: the new rules are pushed back after 1.0 release, this PR now only contains the bump to tslint 4.5

Adds a few rules introduced by tslint 4.4 and 4.5

- [arrow-return-shorthand](https://palantir.github.io/tslint/rules/arrow-return-shorthand/)
- [no-duplicate-super](https://palantir.github.io/tslint/rules/no-duplicate-super/)
- [no-import-side-effect](https://palantir.github.io/tslint/rules/no-import-side-effect/)
- [no-misused-new](https://palantir.github.io/tslint/rules/no-misused-new/)
- [no-non-null-assertion](https://palantir.github.io/tslint/rules/no-non-null-assertion/)
- [no-unnecessary-initializer](https://palantir.github.io/tslint/rules/no-unnecessary-initializer/)

This introduces the new rule `no-import-side-effect` from @mgechev referenced in #3904.
I deliberately relaxed the rule to authorize RxJS imports and avoid tons of warnings on existing apps, but I think it's nice to have it in the tslint config, so people who want to add constraints to these imports will learn about this rule and can easily do it.