### PR TITLE
(docs): update rc.0 guide to note tsconfig entry change

### DIFF
--- a/docs/documentation/stories/rc.0-update.md
+++ b/docs/documentation/stories/rc.0-update.md
@@ -144,6 +144,14 @@ targets are listed:
 },
 ```
 
+The `tsconfig` entry under `apps` should be changed to `tsconfig.app.json` and a new `testTsconfig`
+was added and should be set to `tsconfig.spec.json`:
+
+```
+"tsconfig": "tsconfig.app.json",
+"testTsconfig": "tsconfig.spec.json",
+```
+
 ### Generator defaults
 
 Now you can list generator defaults per generator ([#4389](https://github.com/angular/angular-cli/pull/4389))


### PR DESCRIPTION
When the tsconfig file names are changed using this guide we also need to update the old `app.tsconfig` entry to reflect the new file names