### PR TITLE
fix(tsconfig): use inheritance for ng4

### DIFF
--- a/packages/@angular/cli/blueprints/ng/files/__path__/tsconfig.app.json
+++ b/packages/@angular/cli/blueprints/ng/files/__path__/tsconfig.app.json
@@ -1,22 +1,18 @@
 {<% if (ng4) { %>
   "extends": "<%= relativeRootPath %>/tsconfig.json",
-  "compilerOptions": {
-  "lib": [
-    "es2016",
-    "dom"
-  ],<% } else { %>
+  "compilerOptions": {<% } else { %>
   "compilerOptions": {
     "sourceMap": true,
     "declaration": false,
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
+    "target": "es5",
     "lib": [
       "es2016",
       "dom"
     ],<% } %>
     "outDir": "<%= relativeRootPath %>/out-tsc/app",
-    "target": "es5",
     "module": "es2015",
     "baseUrl": "",
     "types": []


### PR DESCRIPTION
Now that #5060 added the dom library and es5 target to the base tsconfig, it can be removed in other ones.