### PR TITLE
fix: autoprefixer suppress existing prefix

### DIFF
--- a/packages/@angular/cli/models/webpack-configs/styles.ts
+++ b/packages/@angular/cli/models/webpack-configs/styles.ts
@@ -66,7 +66,7 @@ export function getStylesConfig(wco: WebpackConfigOptions) {
   urlPlugin[postcssArgs] = postcssUrlOptions;
 
   // PostCSS plugins.
-  const postCssPlugins = [autoprefixer(), urlPlugin].concat(
+  const postCssPlugins = [autoprefixer({remove: false}), urlPlugin].concat(
     buildOptions.target === 'production' ? [cssnanoPlugin] : []
   );
 


### PR DESCRIPTION
The previous behavior was that in webpack config, autoprefixer uses the
default config. There is a config in autoprefixer that supress outdated
prefixes. This mean that is a prefix is not use in the default
BrowserList, they will remove it. So, if in a css of a component, a user
wrote prefix for iOS (-webkit-), they will remove it.
This fix is made for not remove prefixes in css code. So, in adding
'remove = false' in autoprefixer config, all css will stay there, which
is fantastic.