### PR TITLE
fix(@angular/cli): add kjhtml reporter when testing with code coverage

### DIFF
--- a/packages/@angular/cli/blueprints/ng/files/karma.conf.js
+++ b/packages/@angular/cli/blueprints/ng/files/karma.conf.js
@@ -32,7 +32,7 @@ module.exports = function (config) {
       environment: 'dev'
     },
     reporters: config.angularCli && config.angularCli.codeCoverage
-              ? ['progress', 'coverage-istanbul']
+              ? ['progress', 'kjhtml', 'coverage-istanbul']
               : ['progress', 'kjhtml'],
     port: 9876,
     colors: true,


### PR DESCRIPTION
As per the linked issue, the jasmine html report is now shown when testing with code coverage

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/angular/angular-cli/5146)
<!-- Reviewable:end -->
