### PR TITLE
fix(@ngtools/webpack): Fix cache invalidation error when watching

### DIFF
--- a/packages/@ngtools/webpack/src/plugin.ts
+++ b/packages/@ngtools/webpack/src/plugin.ts
@@ -388,6 +388,13 @@ export class AotPlugin implements Tapable {
           return;
         }
 
+        // Create a new Program before compiling to invalidate source
+        // cache. Fixes error when watching for changes where the
+        // pre-save version of the file is used.
+        this._program = ts.createProgram(
+            this._rootFilePath, this._compilerOptions, this._compilerHost, this._program
+        );
+
         // Create the Code Generator.
         return __NGTOOLS_PRIVATE_API_2.codeGen({
           basePath: this._basePath,


### PR DESCRIPTION
  Update of #4009 by @rynclark to latest version of codebase.

  TypeScript caches the contents of source files within the program
  to minimize redundant compilation of non-changing code. This cache
  is not invalidated in @ngtools/webpack, causing two issues:
    1. When the watcher is triggered, the old version of the source
       is used. A second save is necessary for changes to take effect.
    2. When a change would result in a compilation error, the initial
       save will pass without errors. Subsequent saves, even saves
       containing fixes to the original error, will continue to fail
       with the original error. This is likely caused by TypeScript
       trying to compare any new programs against an invalid prior
       program state.

  Possibly also addresses #4566.

Signed-off-by: RandomBK <david@david-li.com>