### PR TITLE
feat(cli): Adding support for custom uglify options in .angular-cli.json

### DIFF
--- a/packages/@angular/cli/lib/config/schema.json
+++ b/packages/@angular/cli/lib/config/schema.json
@@ -46,8 +46,7 @@
             "type": "array",
             "description": "List of application assets.",
             "items": {
-              "oneOf": [
-                {
+              "oneOf": [{
                   "type": "string"
                 },
                 {
@@ -118,8 +117,7 @@
             "description": "Global styles to be included in the build.",
             "type": "array",
             "items": {
-              "oneOf": [
-                {
+              "oneOf": [{
                   "type": "string"
                 },
                 {
@@ -150,12 +148,16 @@
             },
             "additionalProperties": false
           },
+          "uglifyOptions": {
+            "description": "Options to pass to the Uglify plugin",
+            "type": "object",
+            "additionalProperties": true
+          },
           "scripts": {
             "description": "Global scripts to be included in the build.",
             "type": "array",
             "items": {
-              "oneOf": [
-                {
+              "oneOf": [{
                   "type": "string"
                 },
                 {
@@ -174,7 +176,7 @@
             },
             "additionalProperties": false
           },
-          "environmentSource":{
+          "environmentSource": {
             "description": "Source file for environment config.",
             "type": "string"
           },
@@ -213,8 +215,7 @@
         "properties": {
           "files": {
             "description": "File glob(s) to lint.",
-            "oneOf": [
-              {
+            "oneOf": [{
                 "type": "string"
               },
               {
@@ -237,8 +238,7 @@
           },
           "exclude": {
             "description": "File glob(s) to ignore.",
-            "oneOf": [
-              {
+            "oneOf": [{
                 "type": "string"
               },
               {
@@ -475,7 +475,7 @@
     },
     "packageManager": {
       "description": "Specify which package manager tool to use.",
-      "enum": [ "npm", "cnpm", "yarn", "default" ],
+      "enum": ["npm", "cnpm", "yarn", "default"],
       "default": "default",
       "type": "string"
     },

--- a/packages/@angular/cli/models/webpack-configs/production.ts
+++ b/packages/@angular/cli/models/webpack-configs/production.ts
@@ -11,7 +11,12 @@ export const getProdConfig = function (wco: WebpackConfigOptions) {
   const { projectRoot, buildOptions, appConfig } = wco;
 
   let extraPlugins: any[] = [];
-  let entryPoints: {[key: string]: string[]} = {};
+  let entryPoints: { [key: string]: string[] } = {};
+  let appUglifyOptions = appConfig.uglifyOptions || {};
+  let baseUglifyOptions = {
+    mangle: { screw_ie8: true },
+    compress: { screw_ie8: true, warnings: buildOptions.verbose }
+  };
 
   if (appConfig.serviceWorker) {
     const nodeModules = path.resolve(projectRoot, 'node_modules');
@@ -51,7 +56,7 @@ export const getProdConfig = function (wco: WebpackConfigOptions) {
 
     // Load the Webpack plugin for manifest generation and install it.
     const AngularServiceWorkerPlugin = require('@angular/service-worker/build/webpack')
-        .AngularServiceWorkerPlugin;
+      .AngularServiceWorkerPlugin;
     extraPlugins.push(new AngularServiceWorkerPlugin());
 
     // Copy the worker script into assets.
@@ -71,8 +76,8 @@ export const getProdConfig = function (wco: WebpackConfigOptions) {
       }),
       new (<any>webpack).HashedModuleIdsPlugin(),
       new webpack.optimize.UglifyJsPlugin(<any>{
-        mangle: { screw_ie8: true },
-        compress: { screw_ie8: true, warnings: buildOptions.verbose },
+        mangle: Object.assign(baseUglifyOptions.mangle, appUglifyOptions.mangle),
+        compress: Object.assign(baseUglifyOptions.compress, appUglifyOptions.compress),
         sourceMap: buildOptions.sourcemap
       })
     ].concat(extraPlugins)


### PR DESCRIPTION
### Description

Adding an option into the `.angular-cli.json` to provide custom options to the UglifyJsPlugin that is used for production builds.

### Why?

We are using some older libraries inside our Angular application that when we build for production we require the `compress: { keep_fnames: true }` on the UglifyJsPlugin plugin. The CLI does not currently support this, so I added a way to pass any options to the UglifyJsPlugin.

The `.angular-cli.json` can now have the following property:

```
"apps": [{
    "uglifyOptions": {
        "mangle": {
            "keep_fnames": true
        }
    }
}]
```

Then this will just merge the already defaulted options that were there with any new options that the user needs or wants.

This issue was brought up and closed in a few PRs and tickets, but there was never a solution. (https://github.com/angular/angular-cli/pull/1662 & https://github.com/angular/angular-cli/pull/3167)