### PR TITLE
added section on difference between building with or without prod flag

### DIFF
--- a/docs/documentation/build.md
+++ b/docs/documentation/build.md
@@ -64,6 +64,30 @@ ng build --bh /myUrl/
 All builds make use of bundling, and using the `--prod` flag in  `ng build --prod`
 or `ng serve --prod` will also make use of uglifying and tree-shaking functionality.
 
+**Note:** It is not recommended using `[class].constructor.name` while using the
+`--prod` build flag. Since the name of the class will be uglified.
+#### Example
+```js
+// Outputing router events to log
+router.events.map(event => console.log(event.constructor.name));
+
+// Output without --prod flag:
+// NavigationStart
+// RoutesRecognized
+// NavigationEnd
+
+// With --prod flag:
+// t
+// v
+// c
+```
+
+#### Difference between building with or without `---prod` flag
+|              | With | Without |
+|--------------|:----:|:-------:|
+| Tree-shaking |  x   |    x    |
+| Uglifying    |  x   |         |
+
 ## Options
 `--watch` (`-w`) rebuild when files change
 

--- a/docs/documentation/build.md
+++ b/docs/documentation/build.md
@@ -83,10 +83,14 @@ router.events.map(event => console.log(event.constructor.name));
 ```
 
 #### Difference between building with or without `---prod` flag
+The functionality that does not have * after it, are by default added to the workflow.
+
 |              | With | Without |
 |--------------|:----:|:-------:|
-| Tree-shaking |  x   |    x    |
+| Tree-shaking |  x   |    x*   |
 | Uglifying    |  x   |         |
+
+*The flag must specifically be added.
 
 ## Options
 `--aot` Build using Ahead of Time compilation.


### PR DESCRIPTION
My team spent a long time figuring out why our code broke when building our project with the `--prod` flag compared to when we did not.

Since we don't know much about the build process in angular-cli we did not know what the real difference was when using the flag.

We finally found out that `constructor.name` did not work when building prod.

Therefore this pull request contains a warning with example and a "difference" section.
I know that tree shaking is done and uglifying. Is there more that could be added?