### PR TITLE
docs(@angular/cli): update rc update guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ CLI for Angular applications based on the [ember-cli](http://www.ember-cli.com/)
 ## Note
 
 The CLI is now in Release Candidate (RC).
-If you are updating from a beta version, check out our [RC.0 Update Guide]
-(https://github.com/angular/angular-cli/wiki/stories-rc.0-update).
+If you are updating from a beta version, check out our [RC Update Guide]
+(https://github.com/angular/angular-cli/wiki/stories-rc-update).
 
 If you wish to collaborate, check out [our issue list](https://github.com/angular/angular-cli/issues).
 

--- a/docs/documentation/stories.md
+++ b/docs/documentation/stories.md
@@ -2,7 +2,7 @@
 
 # Stories describing how to do more with the CLI
 
- - [RC.0 Update](stories/rc.0-update)
+ - [RC Update](stories/rc-update)
  - [Asset Configuration](stories/asset-configuration)
  - [Autocompletion](stories/autocompletion)
  - [CSS Preprocessors](stories/css-preprocessors)

--- a/docs/documentation/stories/rc-update.md
+++ b/docs/documentation/stories/rc-update.md
@@ -1,4 +1,4 @@
-# Angular CLI RC.0 migration guide
+# Angular CLI RC migration guide
 
 In this migration guide we'll be looking at some of the major changes to CLI projects in the
 last two months.
@@ -19,7 +19,7 @@ The new [Stories](https://github.com/angular/angular-cli/wiki/stories) section c
 scenarios, so be sure to have a look!
 
 Below are the changes between a project generated two months ago, with `1.0.0-beta.24` and
-a `1.0.0-rc.0` project.
+a `1.0.0-rc.1` project.
 If you kept your project up to date you might have a lot of these already.
 
 You can find more details about changes between versions in [CHANGELOG.md](https://github.com/angular/angular-cli/blob/master/CHANGELOG.md).
@@ -272,8 +272,10 @@ There is an additional root-level `tsconfig.json` that is used for IDE integrati
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
+    "target": "es5",
     "lib": [
-      "es2016"
+      "es2016",
+      "dom"
     ]
   }
 }
@@ -455,5 +457,3 @@ Add these new rules:
 ```
 
 Update `no-inferrable-types` to `"no-inferrable-types": [true, "ignore-params"]`.
-
-


### PR DESCRIPTION
Make it still relevant for the current rc.1 release and future ones, as a lot of people I see are using this guide as reference.

This include the change made on `tsconfig.json` in rc.1.

This should be merged after #5041 (which fixes a few issues in the current rc.0 guide).