### PR TITLE
Patch 1

### DIFF
--- a/packages/@angular/cli/blueprints/ng/files/e2e/tsconfig.e2e.json
+++ b/packages/@angular/cli/blueprints/ng/files/e2e/tsconfig.e2e.json
@@ -10,7 +10,7 @@
     "lib": [
       "es2016"
     ],<% } %>
-    "outDir": "../dist/out-tsc-e2e",
+    "outDir": "../out-tsc/e2e",
     "module": "commonjs",
     "target": "es6",
     "types":[

--- a/packages/@angular/cli/blueprints/ng/files/gitignore
+++ b/packages/@angular/cli/blueprints/ng/files/gitignore
@@ -3,6 +3,7 @@
 # compiled output
 /dist
 /tmp
+/out-tsc
 
 # dependencies
 /node_modules


### PR DESCRIPTION
Added /out-tsc to the .gitignore blueprint. If someone runs tsc -p src/tsconfig.spec.json it outputs to the ../out-tsc folder. These should be ignored.

Also changed https://github.com/angular/angular-cli/blob/master/packages/%40angular/cli/blueprints/ng/files/e2e/tsconfig.e2e.json#L13 to ../out-tsc/e2e so that they all match

cc @filipesilva 



fixing due to issue with CLA from https://github.com/angular/angular-cli/pull/5062