### PR TITLE
feat(@angular/cli): Add Webpack Performance options in angular-cli.json

### DIFF
--- a/docs/documentation/stories/webpack-performance.md
+++ b/docs/documentation/stories/webpack-performance.md
@@ -1,0 +1,11 @@
+# Webpack Performance
+
+Angular CLI supports the [webpack2's performance plugin](https://webpack.js.org/configuration/performance/#components/sidebar/sidebar.jsx).
+You can set the basic properties in the `.angular-cli.json` file:
+```
+"performance": {
+  "maxAssetSize": 100000,
+  "maxEntrypointSize": 400000,
+  "hints": "error" // false | "error" | "warning"
+}
+```

--- a/packages/@angular/cli/blueprints/ng/files/angular-cli.json
+++ b/packages/@angular/cli/blueprints/ng/files/angular-cli.json
@@ -26,7 +26,8 @@
       "environments": {
         "dev": "environments/environment.ts",
         "prod": "environments/environment.prod.ts"
-      }
+      },
+      "performance": {}
     }
   ],
   "e2e": {

--- a/packages/@angular/cli/lib/config/schema.json
+++ b/packages/@angular/cli/lib/config/schema.json
@@ -182,6 +182,11 @@
             "description": "Name and corresponding file for environment config.",
             "type": "object",
             "additionalProperties": true
+          },
+          "performance": {
+            "description": "Performance Webpack options for bundle and assets size limit.",
+            "type": "object",
+            "additionalProperties": true
           }
         },
         "additionalProperties": false

--- a/packages/@angular/cli/models/webpack-configs/common.ts
+++ b/packages/@angular/cli/models/webpack-configs/common.ts
@@ -28,9 +28,14 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
   let extraPlugins: any[] = [];
   let extraRules: any[] = [];
   let entryPoints: { [key: string]: string[] } = {};
+  let performance: { [key: string]: number|string } = {};
 
   if (appConfig.main) {
     entryPoints['main'] = [path.resolve(appRoot, appConfig.main)];
+  }
+
+  if (appConfig.performance) {
+    performance = appConfig.performance;
   }
 
   if (appConfig.polyfills) {
@@ -80,6 +85,7 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
       filename: `[name]${hashFormat.chunk}.bundle.js`,
       chunkFilename: `[id]${hashFormat.chunk}.chunk.js`
     },
+    performance: performance,
     module: {
       rules: [
         { enforce: 'pre', test: /\.js$/, loader: 'source-map-loader', exclude: [nodeModules] },


### PR DESCRIPTION
Hi!
I needed to monitor my bundle sizes easily so i figured something out.

A new configuration is available in `.angular-cli.json` to set the basic properties of Webpack Performance plugin.
```
"performance": {
    "maxAssetSize": 100000,
      "maxEntrypointSize": 400000,
        "hints": "error" // false | "error" | "warning"
}
```

Tell me if i need to correct something, i will try to be reactive.
Thank you!