### PR TITLE
fix(@angular/cli): code scaffolding examples / to |

### DIFF
--- a/packages/@angular/cli/blueprints/ng/files/README.md
+++ b/packages/@angular/cli/blueprints/ng/files/README.md
@@ -8,7 +8,7 @@ Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The app w
 
 ## Code scaffolding
 
-Run `ng generate component component-name` to generate a new component. You can also use `ng generate directive/pipe/service/class/module`.
+Run `ng generate component component-name` to generate a new component. You can also use `ng generate directive|pipe|service|class|module`.
 
 ## Build
 


### PR DESCRIPTION
Alternatives in the `ng generate` examples in the generated `README.md` are confusing. These should use the pipe character `|` as opposed to forward slash `/` to avoid appearing as a directory structure.