### PR TITLE
fix(@angular/cli): fix TS2.2 typeroots

### DIFF
--- a/docs/documentation/stories/rc-update.md
+++ b/docs/documentation/stories/rc-update.md
@@ -273,6 +273,9 @@ There is an additional root-level `tsconfig.json` that is used for IDE integrati
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "target": "es5",
+    "typeRoots": [
+      "node_modules/@types"
+    ],
     "lib": [
       "es2016",
       "dom"

--- a/packages/@angular/cli/blueprints/ng/files/tsconfig.json
+++ b/packages/@angular/cli/blueprints/ng/files/tsconfig.json
@@ -8,6 +8,9 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "target": "es5",
+    "typeRoots": [
+      "node_modules/@types"
+    ],
     "lib": [
       "es2016",
       "dom"


### PR DESCRIPTION
TS-Node with TypeScript 2.2 does not infer `typeRoots`, so we need to list them explicitely in the root tsconfig.

Issue for TS-Node: https://github.com/TypeStrong/ts-node/issues/283

Fix #5082