### PR TITLE
fix(@angular/cli): karma config is default for test command

### DIFF
--- a/packages/@angular/cli/commands/test.ts
+++ b/packages/@angular/cli/commands/test.ts
@@ -45,7 +45,7 @@ const TestCommand = EmberTestCommand.extend({
       type: String,
       aliases: ['c'],
       description: oneLine`Use a specific config file.
-        Defaults to the protractor config file in angular-cli.json.`
+        Defaults to the karma config file in .angular-cli.json.`
     },
     {
       name: 'single-run',


### PR DESCRIPTION
`ng help test` says _protractor_ config is used by default, but it should be karma config instead.