### PR TITLE
fix(@angular/cli): don't fail install due to node-sass 

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "magic-string": "^0.19.0",
     "minimatch": "^3.0.3",
     "node-modules-path": "^1.0.0",
-    "node-sass": "^4.3.0",
     "nopt": "^4.0.1",
     "opn": "4.0.2",
     "portfinder": "~1.0.12",
@@ -151,5 +150,8 @@
     "tree-kill": "^1.0.0",
     "ts-node": "^2.0.0",
     "tslint": "^4.0.2"
+  },
+  "optionalDependencies": {
+    "node-sass": "^4.3.0"
   }
 }

--- a/packages/@angular/cli/package.json
+++ b/packages/@angular/cli/package.json
@@ -61,7 +61,6 @@
     "lodash": "^4.11.1",
     "minimatch": "^3.0.3",
     "node-modules-path": "^1.0.0",
-    "node-sass": "^4.3.0",
     "nopt": "^4.0.1",
     "opn": "4.0.2",
     "portfinder": "~1.0.12",
@@ -89,6 +88,9 @@
     "webpack-dev-server": "~2.3.0",
     "webpack-merge": "^2.4.0",
     "zone.js": "^0.7.2"
+  },
+  "optionalDependencies": {
+    "node-sass": "^4.3.0"
   },
   "ember-addon": {
     "paths": [

--- a/scripts/publish/validate_dependencies.js
+++ b/scripts/publish/validate_dependencies.js
@@ -121,6 +121,7 @@ for (const packageName of Object.keys(packages)) {
   const packageJson = JSON.parse(fs.readFileSync(packages[packageName].packageJson, 'utf8'));
   const allDeps = []
     .concat(Object.keys(packageJson['dependencies'] || {}))
+    .concat(Object.keys(packageJson['optionalDependencies'] || {}))
     .concat(Object.keys(packageJson['devDependencies'] || {}))
     .concat(Object.keys(packageJson['peerDependencies'] || {}));
 
@@ -142,6 +143,7 @@ const rootPackageJson = JSON.parse(fs.readFileSync(rootPackagePath, 'utf8'));
 // devDependencies are ignored
 const allRootDeps = []
     .concat(Object.keys(rootPackageJson['dependencies'] || {}))
+    .concat(Object.keys(rootPackageJson['optionalDependencies'] || {}))
     .concat(Object.keys(rootPackageJson['peerDependencies'] || {}));
 
 const internalPackages = Object.keys(packages);


### PR DESCRIPTION
This change should reduce the amount of problems on npm installs.

It makes the `node-sass` dependency optional, and so install will not fail when it cannot be installed.

For projects that do not use sass, there is no side-effect of an failed node-sass install.

For projects that do use node-sass and the install failed, they should see the following self-explanatory error message:

```
ERROR in ./src/app/app.component.scss
Module build failed: Error: Missing binding D:\sandbox\master-project\node_modules\node-sass\vendor\win32-x64-51\binding.node
Node Sass could not find a binding for your current environment: Windows 64-bit with Node.js 7.x

Found bindings for the following environments:

This usually happens because your environment has changed since running `npm install`.
Run `npm rebuild node-sass` to build the binding for your current environment.
    at module.exports (D:\sandbox\master-project\node_modules\node-sass\lib\binding.js:15:13)
    at Object.<anonymous> (D:\sandbox\master-project\node_modules\node-sass\lib\index.js:14:35)
```

Fix #4429