### PR TITLE
docs(@angular/cli): fix typos in options documentation

### DIFF
--- a/docs/documentation/build.md
+++ b/docs/documentation/build.md
@@ -103,7 +103,7 @@ or `ng serve --prod` will also make use of uglifying and tree-shaking functional
 
 `--target` (`-t`) Defines the build target.
 
-`--vendor-chunk` (`-vb`) Use a separate bundle containing only vendor libraries.
+`--vendor-chunk` (`-vc`) Use a separate bundle containing only vendor libraries.
 
 `--verbose` (`-v`) Adds more details to output logging.
 

--- a/docs/documentation/generate/interface.md
+++ b/docs/documentation/generate/interface.md
@@ -8,4 +8,4 @@
 ## Options
 `--app` Specifies app name or index to use.
 
-`type` Pptional String to specify the type of interface.
+`type` Optional String to specify the type of interface.


### PR DESCRIPTION
Fixes a few typos introduced in 8c3a7b86dc368d71bbdf34aefb8999584a600385