### PR TITLE
feat(@angular/cli): use standard stackTraceLimit

### DIFF
--- a/lib/bootstrap-local.js
+++ b/lib/bootstrap-local.js
@@ -6,6 +6,8 @@ const path = require('path');
 const ts = require('typescript');
 
 
+Error.stackTraceLimit = Infinity;
+
 global.angularCliIsLocal = true;
 global.angularCliPackages = require('./packages');
 

--- a/packages/@angular/cli/lib/cli/index.js
+++ b/packages/@angular/cli/lib/cli/index.js
@@ -12,7 +12,6 @@ const UI = require('../../ember-cli/lib/ui');
 const Watcher = require('../../ember-cli/lib/models/watcher');
 const path = require('path');
 
-Error.stackTraceLimit = Infinity;
 
 module.exports = function(options) {
 


### PR DESCRIPTION
Sometime very long ago we set infinite stack traces and never took them out.

This PR sets infinite stack traces only on dev setups.