### PR TITLE
docs: removed outdated notice

### DIFF
--- a/docs/documentation/stories/routing.md
+++ b/docs/documentation/stories/routing.md
@@ -8,6 +8,4 @@ The CLI supports routing in several ways:
 
   The file includes an empty `Routes` object that you can fill with routes to different components and/or modules.
 
-  The `--routing` option also generates a default component with the same name as the module.
-
 - You can use the `--routing` option with `ng new` to create a `app-routing.module.ts` file when you create or initialize a project.


### PR DESCRIPTION
from https://github.com/angular/angular-cli/blob/master/CHANGELOG.md#breaking-changes-1

> 1.0.0-beta.32 (2017-02-17)
> ...
> BREAKING CHANGES
> ...
> @angular/cli: Generating a module with routing will no longer generate an associated component.

But the user story still metions it.