### PR TITLE
fix(@angular/cli): Use the appropriate packageManager for linking

### DIFF
--- a/packages/@angular/cli/tasks/init.ts
+++ b/packages/@angular/cli/tasks/init.ts
@@ -33,9 +33,10 @@ export default Task.extend({
       });
     }
 
+    const packageManager = CliConfig.fromGlobal().get('packageManager');
+
     let npmInstall: any;
     if (!commandOptions.skipInstall) {
-      const packageManager = CliConfig.fromGlobal().get('packageManager');
       npmInstall = new NpmInstall({
         ui: this.ui,
         project: this.project,
@@ -47,7 +48,8 @@ export default Task.extend({
     if (commandOptions.linkCli) {
       linkCli = new LinkCli({
         ui: this.ui,
-        project: this.project
+        project: this.project,
+        packageManager
       });
     }
 
@@ -106,4 +108,3 @@ export default Task.extend({
       });
   }
 });
-

--- a/packages/@angular/cli/tasks/link-cli.ts
+++ b/packages/@angular/cli/tasks/link-cli.ts
@@ -6,10 +6,15 @@ export default Task.extend({
   run: function() {
     const ui = this.ui;
 
+    let packageManager = this.packageManager;
+    if (packageManager === 'default') {
+      packageManager = 'npm';
+    }
+
     return new Promise(function(resolve, reject) {
-      exec('npm link @angular/cli', (err) => {
+      exec(`${packageManager} link @angular/cli`, (err) => {
         if (err) {
-          ui.writeLine(chalk.red('Couldn\'t do \'npm link @angular/cli\'.'));
+          ui.writeLine(chalk.red(`Couldn't do '${packageManager} link @angular/cli'.`));
           reject();
         } else {
           ui.writeLine(chalk.green('Successfully linked to @angular/cli.'));


### PR DESCRIPTION
When creating a new project using the `--link-cli` option, the
linking command was hard-coded to use `npm link @angular/cli`.
This commit replicates the behaviour of `npm-install` where the
package manager is obtained from the global config and is then
used for linking.