### PR TITLE
fix(@ngtools/webpack): remove tsc-wrapped from peerDependencies

### DIFF
--- a/packages/@ngtools/webpack/package.json
+++ b/packages/@ngtools/webpack/package.json
@@ -34,7 +34,6 @@
     "@angular/compiler": "^2.3.1 || >=4.0.0-beta <5.0.0",
     "@angular/compiler-cli": "^2.3.1 || >=4.0.0-beta <5.0.0",
     "@angular/core": "^2.3.1 || >=4.0.0-beta <5.0.0",
-    "@angular/tsc-wrapped": "^0.5.0 || >=4.0.0-beta <5.0.0",
     "typescript": "^2.0.2",
     "webpack": "^2.2.0"
   }


### PR DESCRIPTION
`tsc-wrapped` is a explicit dependency of `@angular/compiler-cli`, so it should be enough to have `@angular/compiler-cli` in peerDependecies.

I use `@ngtools/webpack` in a standalone project and this will fix a yarn / npm warning about a missing peerDependency cause i don't have `tsc-wrapped` defined in my dependcies.