### PR TITLE
fix(@angular/cli): add missing alias for guard blueprint

### DIFF
--- a/packages/@angular/cli/commands/generate.ts
+++ b/packages/@angular/cli/commands/generate.ts
@@ -57,6 +57,7 @@ const aliasMap: { [alias: string]: string } = {
   'c': 'component',
   'd': 'directive',
   'e': 'enum',
+  'g': 'guard',
   'i': 'interface',
   'm': 'module',
   'p': 'pipe',


### PR DESCRIPTION
Fixes #5336