### PR TITLE
fix(@angular/cli): fix ide import errors

### DIFF
--- a/packages/@angular/cli/blueprints/ng/files/tsconfig.json
+++ b/packages/@angular/cli/blueprints/ng/files/tsconfig.json
@@ -2,6 +2,7 @@
   "compileOnSave": false,
   "compilerOptions": {
     "outDir": "./dist/out-tsc",
+    "baseUrl": "src",
     "sourceMap": true,
     "declaration": false,
     "moduleResolution": "node",


### PR DESCRIPTION
**VSC**: 1.10.2
**CLI**: rc.1 with --ng4

When you're in VSC and write code like: `import { environment } from 'environments/environment'`, it's flagged as being incorrect because the IDE doesn't know about tsconfig.app.json