### PR TITLE
docs: add module.id removal to moving doc

### DIFF
--- a/docs/documentation/stories/moving-into-the-cli.md
+++ b/docs/documentation/stories/moving-into-the-cli.md
@@ -44,6 +44,7 @@ Adjust paths on your app to use this folder e.g. `<img src='assets/my-image.jpg>
 There are a few adjustments you need to do to use the CLI build system.
 - Change any absolute paths you have for `templateUrl`, `styleUrls` or lazy loaded NgModules to
 relative paths instead.
+- Remove any `module.id` that you have in `@Component` metadata. They aren't needed in the CLI.
 - Polyfills are listed in `./src/polyfills.ts` so remove `core-js` and `zone.js` from `index.html`.
 - SystemJS is not needed anymore, so remove it from `index.html` as well.
 - Instead of using `<script>` and `<link>` tags directly in `index.html`, use


### PR DESCRIPTION
CLI projects don't need it, and soon Quickstart projects won't need it either so we might as well remove it.