### PR TITLE
docs(@angular/cli): services are provided, not declared

### DIFF
--- a/docs/documentation/generate/service.md
+++ b/docs/documentation/generate/service.md
@@ -10,6 +10,6 @@
 
 `--flat` Flag to indicate if a dir is created.
 
-`--module` (`-m`) Allows specification of the declaring module.
+`--module` (`-m`) Allows you to specify the module where the service should be provided
 
 `--spec` Specifies if a spec file is generated.


### PR DESCRIPTION
docs(@angular/cli): services are provided, not declared