### PR TITLE
build(@angular/cli): Enable crypto

### DIFF
--- a/packages/@angular/cli/models/webpack-configs/common.ts
+++ b/packages/@angular/cli/models/webpack-configs/common.ts
@@ -98,7 +98,7 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
     node: {
       fs: 'empty',
       global: true,
-      crypto: 'empty',
+      crypto: true,
       tls: 'empty',
       net: 'empty',
       process: true,


### PR DESCRIPTION
Webpack uses `crypto-browserify` to make this work on the browser. Furthermore, a [Web Crypto API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API) is coming. 


Fix: https://github.com/angular/angular-cli/issues/1548