### PR TITLE
fix(@angular/cli): obey the flat option when generating modules

### DIFF
--- a/packages/@angular/cli/blueprints/module/index.ts
+++ b/packages/@angular/cli/blueprints/module/index.ts
@@ -53,6 +53,7 @@ export default Blueprint.extend({
 
     return {
       dynamicPath: this.dynamicPath.dir,
+      flat: options.flat,
       spec: options.spec,
       routing: options.routing
     };


### PR DESCRIPTION
Fixes #5373