### PR TITLE
Change warning suppression case

### DIFF
--- a/packages/@angular/cli/bin/ng
+++ b/packages/@angular/cli/bin/ng
@@ -95,9 +95,9 @@ if (packageJsonProjectPath && fs.existsSync(packageJsonProjectPath)) {
   const devDeps = packageJsonProject['devDependencies'] || {};
   const hasOldDep = !!deps['angular-cli'];
   const hasOldDevDep = !!devDeps['angular-cli'];
-  const hasDevDep = !!devDeps['@angular/cli'];
+  const hasDep = !!(devDeps['@angular/cli'] || deps['@angular/cli']);
 
-  if (hasOldDep || hasOldDevDep || !hasDevDep) {
+  if (hasOldDep || hasOldDevDep || !hasDep) {
     const warnings = [
       'The package "angular-cli" has been renamed to "@angular/cli". The old package will be '
       + 'deprecated soon.',


### PR DESCRIPTION
Suppress the warning if they have installed `"@angular/cli"` in either `"devDependencies"` OR `"dependencies"`

Fixes #5443