### PR TITLE
fix(@ngtools/webpack): when an error happens rediagnose the file

### DIFF
--- a/packages/@ngtools/webpack/src/plugin.ts
+++ b/packages/@ngtools/webpack/src/plugin.ts
@@ -411,6 +411,11 @@ export class AotPlugin implements Tapable {
           this._rootFilePath, this._compilerOptions, this._compilerHost, this._program);
       })
       .then(() => {
+        // Re-diagnose changed files.
+        const changedFilePaths = this._compilerHost.getChangedFilePaths();
+        changedFilePaths.forEach(filePath => this.diagnose(filePath));
+      })
+      .then(() => {
         if (this._typeCheck) {
           const diagnostics = this._program.getGlobalDiagnostics();
           if (diagnostics.length > 0) {
@@ -461,7 +466,9 @@ export class AotPlugin implements Tapable {
           });
       })
       .then(() => {
-        this._compilerHost.resetChangedFileTracker();
+        if (this._compilation.errors == 0) {
+          this._compilerHost.resetChangedFileTracker();
+        }
 
         cb();
       }, (err: any) => {

--- a/tests/e2e/tests/build/rebuild-deps-type-check.ts
+++ b/tests/e2e/tests/build/rebuild-deps-type-check.ts
@@ -40,12 +40,24 @@ export default function() {
     `))
     // Should trigger a rebuild, no error expected.
     .then(() => waitForAnyProcessOutputToMatch(doneRe, 10000))
-    // Create and import files.
+    // Make an invalid version of the file.
     .then(() => wait(2000))
     .then(() => writeFile('src/funky2.ts', `
       export function funky(value: number): number {
         return value + 1;
       }
+    `))
+    // Should trigger a rebuild, this time an error is expected.
+    .then(() => waitForAnyProcessOutputToMatch(doneRe, 10000))
+    .then(({ stdout }) => {
+      if (!/ERROR in .*\/src\/main\.ts \(/.test(stdout)) {
+        throw new Error('Expected an error but none happened.');
+      }
+    })
+    // Change an UNRELATED file and the error should still happen.
+    .then(() => wait(2000))
+    .then(() => appendToFile('src/app/app.module.ts', `
+      function anything(): number {}
     `))
     // Should trigger a rebuild, this time an error is expected.
     .then(() => waitForAnyProcessOutputToMatch(doneRe, 10000))


### PR DESCRIPTION
Before there was a bug that the file wasnt forced to rediagnose.

If the file changed, we wont diagnose it twice because we keep a hash table per compilation anyway.

Fixes #4810
Fixes #5404