### PR TITLE
The whole "coverage" directory must be ignored. 

### DIFF
--- a/packages/@angular/cli/blueprints/ng/files/gitignore
+++ b/packages/@angular/cli/blueprints/ng/files/gitignore
@@ -27,7 +27,7 @@
 # misc
 /.sass-cache
 /connect.lock
-/coverage/*
+/coverage
 /libpeerconnection.log
 npm-debug.log
 testem.log


### PR DESCRIPTION
Then IDE highlights this directory as "Out of git" (Gray for IntelliJ products).