### PR TITLE
Various Fixes with Modules

### DIFF
--- a/packages/@ngtools/webpack/src/loader.spec.ts
+++ b/packages/@ngtools/webpack/src/loader.spec.ts
@@ -11,16 +11,28 @@ describe('@ngtools/webpack', () => {
         host.writeFile('/file.ts', `
           export const obj = { moduleId: 123 };
           export const obj2 = { moduleId: 123, otherValue: 1 };
-          export const obj2 = { otherValue: 1, moduleId: 123 };
+          export const obj3 = { otherValue: 1, moduleId: 123 };
+        `, false);
+        host.writeFile('/file2.ts', `
+          @SomeDecorator({ moduleId: 123 }) class CLS {}
+          @SomeDecorator({ moduleId: 123, otherValue1: 1 }) class CLS2 {}
+          @SomeDecorator({ otherValue2: 2, moduleId: 123, otherValue3: 3 }) class CLS3 {}
+          @SomeDecorator({ otherValue4: 4, moduleId: 123 }) class CLS4 {}
         `, false);
 
-        const program = ts.createProgram(['/file.ts'], {}, host);
+        const program = ts.createProgram(['/file.ts', '/file2.ts'], {}, host);
 
         const refactor = new TypeScriptFileRefactor('/file.ts', host, program);
         removeModuleIdOnlyForTesting(refactor);
+        expect(refactor.sourceText).not.toMatch(/obj = \{\s+};/);
+        expect(refactor.sourceText).not.toMatch(/\{\s*otherValue: 1\s*};/);
 
-        expect(refactor.sourceText).toMatch(/obj = \{\s+};/);
-        expect(refactor.sourceText).toMatch(/obj2 = \{\s*otherValue: 1\s*};/);
+        const refactor2 = new TypeScriptFileRefactor('/file2.ts', host, program);
+        removeModuleIdOnlyForTesting(refactor2);
+        expect(refactor2.sourceText).toMatch(/\(\{\s+}\)/);
+        expect(refactor2.sourceText).toMatch(/\(\{\s*otherValue1: 1\s*}\)/);
+        expect(refactor2.sourceText).toMatch(/\(\{\s*otherValue2: 2\s*,\s*otherValue3: 3\s*}\)/);
+        expect(refactor2.sourceText).toMatch(/\(\{\s*otherValue4: 4\s*}\)/);
       });
     });
   });

--- a/packages/@ngtools/webpack/src/loader.spec.ts
+++ b/packages/@ngtools/webpack/src/loader.spec.ts
@@ -34,6 +34,27 @@ describe('@ngtools/webpack', () => {
         expect(refactor2.sourceText).toMatch(/\(\{\s*otherValue2: 2\s*,\s*otherValue3: 3\s*}\)/);
         expect(refactor2.sourceText).toMatch(/\(\{\s*otherValue4: 4\s*}\)/);
       });
+
+      it('should work without a root name', () => {
+        const host = new WebpackCompilerHost({}, '');
+        host.writeFile('/file.ts', `
+          import './file2.ts';
+        `, false);
+        host.writeFile('/file2.ts', `
+          @SomeDecorator({ moduleId: 123 }) class CLS {}
+          @SomeDecorator({ moduleId: 123, otherValue1: 1 }) class CLS2 {}
+          @SomeDecorator({ otherValue2: 2, moduleId: 123, otherValue3: 3 }) class CLS3 {}
+          @SomeDecorator({ otherValue4: 4, moduleId: 123 }) class CLS4 {}
+        `, false);
+
+        const program = ts.createProgram(['/file.ts'], {}, host);
+        const refactor = new TypeScriptFileRefactor('/file2.ts', host, program);
+        removeModuleIdOnlyForTesting(refactor);
+        expect(refactor.sourceText).toMatch(/\(\{\s+}\)/);
+        expect(refactor.sourceText).toMatch(/\(\{\s*otherValue1: 1\s*}\)/);
+        expect(refactor.sourceText).toMatch(/\(\{\s*otherValue2: 2\s*,\s*otherValue3: 3\s*}\)/);
+        expect(refactor.sourceText).toMatch(/\(\{\s*otherValue4: 4\s*}\)/);
+      });
     });
   });
 });

--- a/packages/@ngtools/webpack/src/refactor.ts
+++ b/packages/@ngtools/webpack/src/refactor.ts
@@ -45,9 +45,8 @@ export class TypeScriptFileRefactor {
       this._sourceFile = _program.getSourceFile(fileName);
     }
     if (!this._sourceFile) {
-      this._program = null;
       this._sourceFile = ts.createSourceFile(fileName, _host.readFile(fileName),
-        ts.ScriptTarget.Latest);
+        ts.ScriptTarget.Latest, true);
     }
     this._sourceText = this._sourceFile.getFullText(this._sourceFile);
     this._sourceString = new MagicString(this._sourceText);


### PR DESCRIPTION
fix(@ngtools/webpack): only remove moduleId in decorators  …

Prior to this we were removing all mentions of moduleId, which is invalid if the users want to use it themselves. Now we only removes it if its in a decorator. There might be a slight regression with people using static const objects instead of object literals in their decorators but this shuold not happen often and even less often with moduleId.

Fixes #5509.

----

fix(@ngtools/webpack): add parent nodes and keep program  …

Technically that program should always be the valid one, and is needed in some cases (e.g. diagnostics). Adding parent nodes get rid of the getChildAt error that happens, because the prop.parent is not set.

The issue happened because people are using "files": ["main.ts"] or something similar, and when we load
another file than main we dont set the parent nodes.

Fixes #5143
Fixes #4817 