### PR TITLE
feat(@angular/cli): Add typings.d.ts to types in TS config

### DIFF
--- a/packages/@angular/cli/blueprints/ng/files/__path__/tsconfig.app.json
+++ b/packages/@angular/cli/blueprints/ng/files/__path__/tsconfig.app.json
@@ -15,7 +15,9 @@
     "outDir": "<%= relativeRootPath %>/out-tsc/app",
     "module": "es2015",
     "baseUrl": "",
-    "types": []
+    "types": [
+      "src/typings.d.ts"
+    ]
   },
   "exclude": [
     "test.ts",

--- a/packages/@angular/cli/blueprints/ng/files/__path__/tsconfig.spec.json
+++ b/packages/@angular/cli/blueprints/ng/files/__path__/tsconfig.spec.json
@@ -17,7 +17,8 @@
     "baseUrl": "",
     "types": [
       "jasmine",
-      "node"
+      "node",
+      "src/typings.d.ts"
     ]
   },
   "files": [

--- a/packages/@angular/cli/blueprints/ng/files/tsconfig.json
+++ b/packages/@angular/cli/blueprints/ng/files/tsconfig.json
@@ -12,6 +12,9 @@
     "typeRoots": [
       "node_modules/@types"
     ],
+    "types": [
+      "src/typings.d.ts"
+    ],
     "lib": [
       "es2016",
       "dom"


### PR DESCRIPTION
Previously adding anything to typings file `typings.d.ts`
had no effect because the file is not referenced by the
TS compiler. This add the `typings.d.ts` to the `types`
array in the generated `tsconfig.ts` files (app and spec).