### PR TITLE
ci: add cache and match with nvmrc on appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,13 +1,12 @@
 environment:
   matrix:
-  - nodejs_version: "6.9"
+    - nodejs_version: "6"
 
 matrix:
   fast_finish: true
 
 install:
   - ps: Install-Product node $env:nodejs_version
-  - npm install -g yarn
   - yarn install
 
 test_script:
@@ -17,3 +16,7 @@ test_script:
   - node tests\run_e2e.js
 
 build: off
+
+cache:
+  - node_modules
+  - "%LOCALAPPDATA%/Yarn"


### PR DESCRIPTION
No need to install yarn, it's already included in appveyor.

Add cache to take advantage of Yarn and match node version with nvmrc, so tests on AppVeyor will be executed on the latest version of 6.