### PR TITLE
fix(@angular/cli): use correct version for dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@angular/cli",
-  "version": "1.0.0-rc.2",
+  "version": "1.0.0-rc.4",
   "description": "CLI tool for Angular",
   "main": "packages/@angular/cli/lib/cli/index.js",
   "trackingCode": "UA-8594346-19",

--- a/packages/@angular/cli/package.json
+++ b/packages/@angular/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@angular/cli",
-  "version": "1.0.0-rc.2",
+  "version": "1.0.0-rc.4",
   "description": "CLI tool for Angular",
   "main": "lib/cli/index.js",
   "trackingCode": "UA-8594346-19",


### PR DESCRIPTION
This causes new projects generated with master to use rc.2 instead of rc.4.