### PR TITLE
feat(@angular/cli): add platform: server

### DIFF
--- a/packages/@angular/cli/lib/config/schema.json
+++ b/packages/@angular/cli/lib/config/schema.json
@@ -42,6 +42,10 @@
             "default": "dist/",
             "description": "The output directory for build results."
           },
+          "platform": {
+            "type": "string",
+            "description": "The destination platform of app."
+          },
           "assets": {
             "type": "array",
             "description": "List of application assets.",

--- a/packages/@angular/cli/models/webpack-config.ts
+++ b/packages/@angular/cli/models/webpack-config.ts
@@ -3,6 +3,7 @@ import { CliConfig } from './config';
 import { BuildOptions } from './build-options';
 import {
   getBrowserConfig,
+  getServerConfig,
   getCommonConfig,
   getDevConfig,
   getProdConfig,
@@ -37,12 +38,22 @@ export class NgCliWebpackConfig {
   }
 
   public buildConfig() {
-    let webpackConfigs = [
-      getCommonConfig(this.wco),
-      getBrowserConfig(this.wco),
-      getStylesConfig(this.wco),
-      this.getTargetConfig(this.wco)
+    let webpackConfigs: any[] = [
+      getCommonConfig(this.wco)
     ];
+
+    switch (this.wco.appConfig.platform) {
+      case 'browser':
+        webpackConfigs.push(getBrowserConfig(this.wco), getStylesConfig(this.wco));
+        break;
+      case 'server':
+        webpackConfigs.push(getServerConfig());
+        break;
+      default:
+        throw new Error('Only browser and server platforms are supported');
+    }
+
+    webpackConfigs.push(this.getTargetConfig(this.wco));
 
     if (this.wco.appConfig.main || this.wco.appConfig.polyfills) {
       const typescriptConfigPartial = this.wco.buildOptions.aot
@@ -106,6 +117,7 @@ export class NgCliWebpackConfig {
   public addAppConfigDefaults(appConfig: any) {
     const appConfigDefaults: any = {
       testTsconfig: appConfig.tsconfig,
+      platform: 'browser',
       scripts: [],
       styles: []
     };

--- a/packages/@angular/cli/models/webpack-configs/browser.ts
+++ b/packages/@angular/cli/models/webpack-configs/browser.ts
@@ -13,6 +13,7 @@ export function getBrowserConfig(wco: WebpackConfigOptions) {
 
   const appRoot = path.resolve(projectRoot, appConfig.root);
   const nodeModules = path.resolve(projectRoot, 'node_modules');
+  const entryPoints: { [key: string]: string[] } = {};
 
   let extraPlugins: any[] = [];
 
@@ -21,6 +22,10 @@ export function getBrowserConfig(wco: WebpackConfigOptions) {
     ...extraEntryParser(appConfig.scripts, appRoot, 'scripts'),
     ...extraEntryParser(appConfig.styles, appRoot, 'styles')
   ]);
+
+  if (appConfig.polyfills) {
+    entryPoints['polyfills'] = [path.resolve(appRoot, appConfig.polyfills)];
+  }
 
   if (buildOptions.vendorChunk) {
     extraPlugins.push(new webpack.optimize.CommonsChunkPlugin({
@@ -31,6 +36,7 @@ export function getBrowserConfig(wco: WebpackConfigOptions) {
   }
 
   return {
+    entry: entryPoints,
     plugins: [
       new HtmlWebpackPlugin({
         template: path.resolve(appRoot, appConfig.index),

--- a/packages/@angular/cli/models/webpack-configs/common.ts
+++ b/packages/@angular/cli/models/webpack-configs/common.ts
@@ -33,10 +33,6 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
     entryPoints['main'] = [path.resolve(appRoot, appConfig.main)];
   }
 
-  if (appConfig.polyfills) {
-    entryPoints['polyfills'] = [path.resolve(appRoot, appConfig.polyfills)];
-  }
-
   // determine hashing format
   const hashFormat = getOutputHashFormat(buildOptions.outputHashing);
 

--- a/packages/@angular/cli/models/webpack-configs/index.ts
+++ b/packages/@angular/cli/models/webpack-configs/index.ts
@@ -1,4 +1,5 @@
 export * from './browser';
+export * from './server';
 export * from './common';
 export * from './development';
 export * from './production';

--- a/packages/@angular/cli/models/webpack-configs/server.ts
+++ b/packages/@angular/cli/models/webpack-configs/server.ts
@@ -1,0 +1,6 @@
+export function getServerConfig() {
+
+  return {
+    target: 'node'
+  };
+}


### PR DESCRIPTION
This adds the platform field to the cli config.

```"browser"``` is by default and ```"server"``` is also allowed.

passing server will generate a bundle meant for the server via ng build