### PR TITLE
fix(@angular/cli): allow typescript 2.2.x

### DIFF
--- a/packages/@angular/cli/package.json
+++ b/packages/@angular/cli/package.json
@@ -77,7 +77,7 @@
     "stylus": "^0.54.5",
     "stylus-loader": "^2.4.0",
     "temp": "0.8.3",
-    "typescript": ">=2.0.0 <2.2.0",
+    "typescript": ">=2.0.0 <=2.2.x",
     "url-loader": "^0.5.7",
     "walk-sync": "^0.3.1",
     "webpack": "~2.2.0",


### PR DESCRIPTION
closes #4980 

```javascript
const semver = require('semver')
// current
semver.satisfies('2.2.1', '>=2.0.0 <2.2.0')
false
// new
semver.satisfies('2.2.1', '>=2.0.0 <=2.2.x')
true
```