### PR TITLE
docs: add 1.0 upgrade guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ CLI for Angular applications based on the [ember-cli](http://www.ember-cli.com/)
 
 ## Note
 
-The CLI is now in Release Candidate (RC).
-If you are updating from a beta version, check out our [RC Update Guide]
-(https://github.com/angular/angular-cli/wiki/stories-rc-update).
+The CLI is now in 1.0.
+If you are updating from a beta or RC version, check out our [1.0 Update Guide]
+(https://github.com/angular/angular-cli/wiki/stories-1.0-update).
 
 If you wish to collaborate, check out [our issue list](https://github.com/angular/angular-cli/issues).
 

--- a/docs/documentation/stories/1.0-update.md
+++ b/docs/documentation/stories/1.0-update.md
@@ -193,12 +193,12 @@ CLI projects now use one tsconfig per app ([#4924](https://github.com/angular/an
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
+    "target": "es5",
     "lib": [
       "es2016",
       "dom"
     ],
     "outDir": "../out-tsc/app",
-    "target": "es5",
     "module": "es2015",
     "baseUrl": "",
     "types": []
@@ -219,11 +219,12 @@ CLI projects now use one tsconfig per app ([#4924](https://github.com/angular/an
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "lib": [
-      "es2016"
+      "es2016",
+      "dom"
     ],
     "outDir": "../out-tsc/spec",
     "module": "commonjs",
-    "target": "es6",
+    "target": "es5",
     "baseUrl": "",
     "types": [
       "jasmine",
@@ -234,9 +235,11 @@ CLI projects now use one tsconfig per app ([#4924](https://github.com/angular/an
     "test.ts"
   ],
   "include": [
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "**/*.d.ts"
   ]
 }
+
 ```
 - `e2e/tsconfig.e2e.json`: configuration for the e2e tests.
 ```
@@ -250,15 +253,16 @@ CLI projects now use one tsconfig per app ([#4924](https://github.com/angular/an
     "lib": [
       "es2016"
     ],
-    "outDir": "../dist/out-tsc-e2e",
+    "outDir": "../out-tsc/e2e",
     "module": "commonjs",
-    "target": "es6",
+    "target": "es5",
     "types":[
       "jasmine",
       "node"
     ]
   }
 }
+
 ```
 
 There is an additional root-level `tsconfig.json` that is used for IDE integration.
@@ -267,6 +271,7 @@ There is an additional root-level `tsconfig.json` that is used for IDE integrati
   "compileOnSave": false,
   "compilerOptions": {
     "outDir": "./dist/out-tsc",
+    "baseUrl": "src",
     "sourceMap": true,
     "declaration": false,
     "moduleResolution": "node",
@@ -310,6 +315,20 @@ For instance, the unit test `tsconfig` has `jasmine` and `node`, which correspon
 `@types/jasmine` and `@types/node`.
 Add any typings you've installed to the appropriate `tsconfig` as well.
 
+## typings.d.ts
+
+There's a new `src/typings.d.ts` file that serves two purposes:
+- provides a centralized place for users to add their own custom typings
+- makes it easy to use components that use `module.id`, present in the documentation and in snippets
+
+```
+/* SystemJS module definition */
+declare var module: NodeModule;
+interface NodeModule {
+  id: string;
+}
+```
+
 ## package.json
 
 We've updated a lot of packages over the last months in order to keep projects up to date.
@@ -317,15 +336,15 @@ We've updated a lot of packages over the last months in order to keep projects u
 Additions or removals are found in bold below.
 
 Packages in `dependencies`:
-- `@angular/*` packages now have a `^2.4.0` minimum (`^3.4.0` for router)
+- `@angular/*` packages now have a `^4.0.0` minimum
 - `core-js` remains unchanged at `^2.4.1`
-- `rxjs` to `^5.1.0`
+- `rxjs` was updated to `^5.1.0`
 - `ts-helpers` was **removed**
-- `zone.js` to `^0.7.6`
+- `zone.js` was updated to `^0.8.4`
 
 Packages in `devDependencies`:
-- `@angular/cli` at `1.0.0-rc.0` replaces `angular-cli`
-- `@angular/compiler-cli` is also at `^2.4.0`
+- `@angular/cli` at `1.0.0` replaces `angular-cli`
+- `@angular/compiler-cli` is also at `^4.0.0`
 - `@types/jasmine` remains unchanged and pinned at `2.5.38`
 - `@types/node` was updated to `~6.0.60`
 - `codelyzer` was updated to `~2.0.0`
@@ -340,8 +359,8 @@ Packages in `devDependencies`:
 - `karma-remap-istanbul` was **removed**
 - `protractor` was updated to `~5.1.0`
 - `ts-node` was updated to `~2.0.0`
-- `tslint` was updated to `~4.4.2`
-- `typescript` was updated to `~2.0.0`
+- `tslint` was updated to `~4.5.0`
+- `typescript` was updated to `~2.1.0`
 
 See the [karma](#karma.conf.js) and [protractor](#protractor.conf.js) sections below for more
 information on changed packages.


### PR DESCRIPTION
Fix #5484 

Should only be merged immediately prior to 1.0 release. 

Also double check any version changes in https://github.com/angular/angular-cli/blob/master/packages/@angular/cli/blueprints/ng/files/package.json.