### PR TITLE
fix(@angular/cli): allow ts 2.2

### DIFF
--- a/packages/@angular/cli/package.json
+++ b/packages/@angular/cli/package.json
@@ -77,7 +77,7 @@
     "stylus": "^0.54.5",
     "stylus-loader": "^2.4.0",
     "temp": "0.8.3",
-    "typescript": ">=2.0.0 <2.2.0",
+    "typescript": ">=2.0.0 <2.3.0",
     "url-loader": "^0.5.7",
     "walk-sync": "^0.3.1",
     "webpack": "~2.2.0",


### PR DESCRIPTION
The CLI itself was locked to TS2.0/2.1, but that could case it to not use the project TS when users updated to 2.2.

Fix #5548

/cc @hansl 