### PR TITLE
fix(@angular/cli): fixing lint error issue added flag `--type-check`

### DIFF
--- a/docs/documentation/lint.md
+++ b/docs/documentation/lint.md
@@ -27,6 +27,16 @@
 </details>
 
 <details>
+  <summary>type-check</summary>
+  <p>
+    `--type-check` _default value: false_
+  </p>
+  <p>
+    Controls the type check for linting.
+  </p>
+</details>
+
+<details>
   <summary>format</summary>
   <p>
     `--format` (alias: `-t`) _default value: prose_

--- a/packages/@angular/cli/commands/lint.ts
+++ b/packages/@angular/cli/commands/lint.ts
@@ -5,6 +5,7 @@ const Command = require('../ember-cli/lib/models/command');
 
 export interface LintCommandOptions {
   fix?: boolean;
+  typeCheck?: boolean;
   format?: string;
   force?: boolean;
 }
@@ -20,6 +21,12 @@ export default Command.extend({
       type: Boolean,
       default: false,
       description: 'Fixes linting errors (may overwrite linted files).'
+    },
+    {
+      name: 'type-check',
+      type: Boolean,
+      default: false,
+      description: 'Controls the type check for linting.'
     },
     {
       name: 'force',

--- a/packages/@angular/cli/tasks/lint.ts
+++ b/packages/@angular/cli/tasks/lint.ts
@@ -32,11 +32,12 @@ export default Task.extend({
       .map((config) => {
         const program: ts.Program = Linter.createProgram(config.project);
         const files = getFilesToLint(program, config, Linter);
-
-        const linter = new Linter({
+        const lintOptions = {
           fix: commandOptions.fix,
           formatter: commandOptions.format
-        }, program);
+        };
+        const lintProgram = commandOptions.typeCheck ? program : undefined;
+        const linter = new Linter(lintOptions, lintProgram);
 
         files.forEach((file) => {
           const sourceFile = program.getSourceFile(file);
@@ -75,7 +76,7 @@ export default Task.extend({
     // print formatter output directly for non human-readable formats
     if (['prose', 'verbose', 'stylish'].indexOf(commandOptions.format) == -1) {
       return (result.failures.length == 0 || commandOptions.force)
-            ? Promise.resolve(0) : Promise.resolve(2);
+        ? Promise.resolve(0) : Promise.resolve(2);
     }
 
     if (result.failures.length > 0) {

--- a/tests/e2e/tests/lint/lint-with-type-check-fail.ts
+++ b/tests/e2e/tests/lint/lint-with-type-check-fail.ts
@@ -1,0 +1,39 @@
+import { ng } from '../../utils/process';
+import { expectToFail } from '../../utils/utils';
+import { writeFile } from '../../utils/fs';
+
+export default function () {
+  const fileName = 'src/app/foo.ts';
+  const fileContents = `
+const ANIMATION_CSS_VALUE_REGEX = 'asda';
+const a = ["asda", 'asda', 'asdasd', "ASDASDAS"];
+const b = "asdasd";
+const c = {
+  a: "sadas",
+  b: {
+    v: "asdasda",
+    s: ["asda", "asdas", 10, true, "asda"],
+  }
+};
+
+function check(val: any, fxState: any) {
+  if (typeof val === "string" && val.indexOf(" ") < 0) {
+    let r = val.match(ANIMATION_CSS_VALUE_REGEX);
+    let num = parseFloat(r[1]);
+
+    if (!isNaN(num)) {
+      fxState.num = num + "";
+    }
+    fxState.unit = (r[0] !== r[2] ? r[2] : "");
+
+  } else if (typeof val === "number") {
+    fxState.num = val + "";
+  }
+}
+
+  `;
+
+  return Promise.resolve()
+    .then(() => writeFile(fileName, fileContents))
+    .then(() => expectToFail(() => ng('lint', '--fix', '--type-check')));
+}

--- a/tests/e2e/tests/lint/lint-with-type-check.ts
+++ b/tests/e2e/tests/lint/lint-with-type-check.ts
@@ -1,0 +1,44 @@
+import { ng } from '../../utils/process';
+import { writeFile } from '../../utils/fs';
+
+export default function () {
+  const fileName = 'src/app/foo.ts';
+  const fileContents = `
+const ANIMATION_CSS_VALUE_REGEX = 'asda';
+const a = ["asda", 'asda', 'asdasd', "ASDASDAS"];
+const b = "asdasd";
+const c = {
+  a: "sadas",
+  b: {
+    v: "asdasda",
+    s: ["asda", "asdas", 10, true, "asda"],
+  }
+};
+
+function check(val: any, fxState: any) {
+  if (typeof val === "string" && val.indexOf(" ") < 0) {
+    let r = val.match(ANIMATION_CSS_VALUE_REGEX);
+    let num = parseFloat(r[1]);
+
+    if (!isNaN(num)) {
+      fxState.num = num + "";
+    }
+    fxState.unit = (r[0] !== r[2] ? r[2] : "");
+
+  } else if (typeof val === "number") {
+    fxState.num = val + "";
+  }
+}
+
+  `;
+
+  return Promise.resolve()
+    .then(() => writeFile(fileName, fileContents))
+    .then(() => ng('lint', '--fix'))
+    .then(() => ng('lint'))
+    .then(({ stdout }) => {
+      if (!stdout.match(/All files pass linting./)) {
+        throw new Error('All files pass linting.');
+      }
+    });
+}


### PR DESCRIPTION
Fixes: https://github.com/angular/angular-cli/issues/5406
Fix #5520

BREAKING CHANGE: `ng lint` will not type check by default.