### PR TITLE
docs: remove RC mentions in 1.0 guide

### DIFF
--- a/docs/documentation/stories/1.0-update.md
+++ b/docs/documentation/stories/1.0-update.md
@@ -1,4 +1,4 @@
-# Angular CLI RC migration guide
+# Angular CLI migration guide
 
 In this migration guide we'll be looking at some of the major changes to CLI projects in the
 last two months.
@@ -8,18 +8,12 @@ Most of these changes were not breaking changes and your project should work fin
 But if you've been waiting for the perfect time to update, this is it!
 Along with major rebuild speed increases, we've been busy adding a lot of features.
 
-RC means release candidate and we intend to stick to it.
-Unless there is a major breaking bug, we will not change the public surface of the API and
-its generated projects.
-
-This means that a project upgraded now should need no more code changes all the way to 1.0.
-
 Documentation has also completely moved to [the wiki](https://github.com/angular/angular-cli/wiki).
 The new [Stories](https://github.com/angular/angular-cli/wiki/stories) section covers common usage
 scenarios, so be sure to have a look!
 
 Below are the changes between a project generated two months ago, with `1.0.0-beta.24` and
-a `1.0.0-rc.1` project.
+a `1.0.0` project.
 If you kept your project up to date you might have a lot of these already.
 
 You can find more details about changes between versions in [CHANGELOG.md](https://github.com/angular/angular-cli/blob/master/CHANGELOG.md).


### PR DESCRIPTION
I already added these edits on live wiki manually, but we need them in for the next wiki release.