### PR TITLE
fix(@angular/cli): update e2e config in 1.0 update guide

### DIFF
--- a/docs/documentation/stories/1.0-update.md
+++ b/docs/documentation/stories/1.0-update.md
@@ -302,7 +302,7 @@ Then update `protractor.conf.js` to use the e2e config as well:
 ```
 beforeLaunch: function() {
   require('ts-node').register({
-    project: 'e2e'
+    project: 'e2e/tsconfig.e2e.json'
   });
 },
 ```
@@ -450,7 +450,7 @@ Update `beforeLaunch` as described in [One tsconfig per app](#one-tsconfig-per-a
 ```
 beforeLaunch: function() {
   require('ts-node').register({
-    project: 'e2e'
+    project: 'e2e/tsconfig.e2e.json'
   });
 },
 ```


### PR DESCRIPTION
The current e2e config is incorrect with the new 'one tsconfig per app'.