### PR TITLE
docs(i18n story): fixed link to xi18n commands

### DIFF
--- a/docs/documentation/stories/internationalization.md
+++ b/docs/documentation/stories/internationalization.md
@@ -13,7 +13,7 @@ When your app is ready, you can extract the strings to translate from your templ
 `ng xi18n` command.
 
 By default it will create a file named `messages.xlf` in your `src` folder.
-You can use [parameters from the xi18n command](../xi18n) to change the format,
+You can use [parameters from the xi18n command](./xi18n) to change the format,
 the name, the location and the source locale of the extracted file.
 
 For example to create a file in the `src/locale` folder you would use:


### PR DESCRIPTION
Fixed the link for the i18n story to point to the correct commands page instead of a 404 (I already edited the wiki for now)