### PR TITLE
feat(@angular/cli): always use named webpack modules in dev builds

### DIFF
--- a/packages/@angular/cli/models/webpack-configs/development.ts
+++ b/packages/@angular/cli/models/webpack-configs/development.ts
@@ -1,5 +1,9 @@
+import { NamedModulesPlugin } from 'webpack';
+
 import { WebpackConfigOptions } from '../webpack-config';
 
 export const getDevConfig = function (_wco: WebpackConfigOptions) {
-  return {};
+  return {
+    plugins: [new NamedModulesPlugin()]
+  };
 };

--- a/packages/@angular/cli/tasks/eject.ts
+++ b/packages/@angular/cli/tasks/eject.ts
@@ -141,6 +141,9 @@ class JsonWebpackSerializer {
         case webpack.NoEmitOnErrorsPlugin:
           this._addImport('webpack', 'NoEmitOnErrorsPlugin');
           break;
+        case webpack.NamedModulesPlugin:
+          this._addImport('webpack', 'NamedModulesPlugin');
+          break;
         case (<any>webpack).HashedModuleIdsPlugin:
           this._addImport('webpack', 'HashedModuleIdsPlugin');
           break;

--- a/packages/@angular/cli/tasks/serve.ts
+++ b/packages/@angular/cli/tasks/serve.ts
@@ -75,7 +75,6 @@ export default Task.extend({
         ui.writeLine('  for information on working with HMR for Webpack.');
         entryPoints.push('webpack/hot/dev-server');
         webpackConfig.plugins.push(new webpack.HotModuleReplacementPlugin());
-        webpackConfig.plugins.push(new webpack.NamedModulesPlugin());
         if (serveTaskOptions.extractCss) {
           ui.writeLine(oneLine`
             ${chalk.yellow('NOTICE')} (HMR) does not allow for CSS hot reload when used


### PR DESCRIPTION
This should provide a small rebuild performance improvement for certain cases by limiting the number of bundles required to be rebuilt due to webpack module ID changes.