### PR TITLE
feat(@angular/cli): specify browser to open url instead of default one

### DIFF
--- a/docs/documentation/serve.md
+++ b/docs/documentation/serve.md
@@ -64,7 +64,17 @@ All the build Options are available in serve, below are the additional options.
     <code>--open</code> (aliases: <code>-o</code>) <em>default value: false</em>
   </p>
   <p>
-    Opens the url in default browser.
+    Opens the url in default browser. 
+  </p>
+</details>
+
+<details>
+  <summary>browser</summary>
+  <p>
+    `--browser` (alias: `-b`)
+  </p>
+  <p>
+    Opens the url in specified browser instead of default. The browser name is platform dependent. For example, Chrome is google chrome on macOS, google-chrome on Linux and chrome on Windows.
   </p>
 </details>
 

--- a/packages/@angular/cli/commands/serve.ts
+++ b/packages/@angular/cli/commands/serve.ts
@@ -27,6 +27,7 @@ export interface ServeTaskOptions extends BuildOptions {
   sslCert?: string;
   open?: boolean;
   hmr?: boolean;
+  browser?: string;
 }
 
 // Expose options unrelated to live-reload to other commands that need to run serve
@@ -76,6 +77,12 @@ export const baseServeCommandOptions: any = overrideOptions([
     default: false,
     aliases: ['o'],
     description: 'Opens the url in default browser.',
+  },
+  {
+    name: 'browser',
+    type: String,
+    aliases: ['b'],
+    description: 'Opens the url in specified browser instead of default.',
   },
   {
     name: 'live-reload',

--- a/packages/@angular/cli/tasks/serve.ts
+++ b/packages/@angular/cli/tasks/serve.ts
@@ -204,7 +204,11 @@ export default Task.extend({
           return reject(err);
         }
         if (serveTaskOptions.open) {
-          opn(serverAddress);
+           if (serveTaskOptions.browser) {
+            opn(serverAddress, { app: serveTaskOptions.browser });
+           } else {
+             opn(serverAddress);
+           }
         }
       });
     })


### PR DESCRIPTION
Allows you to specify the browser to open.
`ng serve --open --browser=safari` or `ng s -o -b=safari`

Fixes: https://github.com/angular/angular-cli/issues/5508