### PR TITLE
feat(@angular/cli): expose setup hook so the user can access the Express app object and apply custom middleware

### DIFF
--- a/packages/@angular/cli/commands/serve.ts
+++ b/packages/@angular/cli/commands/serve.ts
@@ -19,6 +19,7 @@ export interface ServeTaskOptions extends BuildOptions {
   port?: number;
   host?: string;
   proxyConfig?: string;
+  setupScript?: string;
   liveReload?: boolean;
   liveReloadClient?: string;
   ssl?: boolean;
@@ -50,6 +51,12 @@ export const baseServeCommandOptions: any = overrideOptions([
     type: 'Path',
     aliases: ['pc'],
     description: 'Proxy configuration file.'
+  },
+  {
+    name: 'setup-script',
+    type: 'Path',
+    aliases: ['su'],
+    description: 'Setup script file.'
   },
   {
     name: 'ssl',

--- a/packages/@angular/cli/custom-typings.d.ts
+++ b/packages/@angular/cli/custom-typings.d.ts
@@ -4,6 +4,7 @@ interface IWebpackDevServerConfigurationOptions {
   historyApiFallback?: {[key: string]: any} | boolean;
   compress?: boolean;
   proxy?: {[key: string]: string};
+  setup?: Function;
   staticOptions?: any;
   quiet?: boolean;
   noInfo?: boolean;

--- a/packages/@angular/cli/tasks/serve.ts
+++ b/packages/@angular/cli/tasks/serve.ts
@@ -120,6 +120,17 @@ export default Task.extend({
       }
     }
 
+    let setupScript = undefined;
+    if (serveTaskOptions.setupScript) {
+      const setupPath = path.resolve(this.project.root, serveTaskOptions.setupScript);
+      if (fs.existsSync(setupPath)) {
+        setupScript = require(setupPath);
+      } else {
+        const message = 'Setup script file ' + setupPath + ' does not exist.';
+        return Promise.reject(new SilentError(message));
+      }
+    }
+
     let sslKey: string = null;
     let sslCert: string = null;
     if (serveTaskOptions.ssl) {
@@ -142,6 +153,7 @@ export default Task.extend({
       },
       stats: statsConfig,
       inline: true,
+      setup: setupScript,
       proxy: proxyConfig,
       compress: serveTaskOptions.target === 'production',
       watchOptions: {


### PR DESCRIPTION
In some cases its useful to do some custom routing on the server.
webpack-dev-server covers this use case by exposing the express app instance trough the "setup hook" on the config. With this pull request this feature is exposed to the user.

From the webpack-dev-server [docs](https://webpack.github.io/docs/webpack-dev-server.html#api):
```
...
setup: function(app) {
    // Here you can access the Express app object and add your own custom middleware to it.
    // For example, to define custom handlers for some paths:
    // app.get('/some/path', function(req, res) {
    //   res.json({ custom: 'response' });
    // });
  },
...
```
An example of a setup-script:
```
var cookieParser = require('cookie-parser')

module.exports = function(app) {
  app.use(cookieParser())

  app.get('/', function(req, res, next) {
    if (!req.cookies['connect.sid']) {
      res.redirect('http://localhost:4200/oauth/authorize')
    }

    next()
  })
}
```

How to run:
```
ng serve --setup-script setup-script.js
```
