### PR TITLE
feat(@angular/cli): enable to specify UNIX domain socket

### DIFF
--- a/packages/@angular/cli/commands/serve.ts
+++ b/packages/@angular/cli/commands/serve.ts
@@ -16,7 +16,7 @@ const defaultSslKey = config.get('defaults.serve.sslKey');
 const defaultSslCert = config.get('defaults.serve.sslCert');
 
 export interface ServeTaskOptions extends BuildOptions {
-  port?: number;
+  port?: string;
   host?: string;
   proxyConfig?: string;
   liveReload?: boolean;
@@ -33,7 +33,7 @@ export const baseServeCommandOptions: any = overrideOptions([
   ...baseBuildCommandOptions,
   {
     name: 'port',
-    type: Number,
+    type: String,
     default: defaultPort,
     aliases: ['p'],
     description: 'Port to listen to for serving.'

--- a/packages/@angular/cli/tasks/serve.ts
+++ b/packages/@angular/cli/tasks/serve.ts
@@ -177,14 +177,19 @@ export default Task.extend({
 
     const server = new WebpackDevServer(webpackCompiler, webpackDevServerConfiguration);
     return new Promise((_resolve, reject) => {
-      server.listen(serveTaskOptions.port, serveTaskOptions.host, (err: any, _stats: any) => {
+      let callback = (err, _stats) => {
         if (err) {
           return reject(err);
         }
         if (serveTaskOptions.open) {
-            opn(serverAddress);
+          opn(serverAddress);
         }
-      });
+      };
+      serveTaskOptions.port
+               ?
+      server.listen(serveTaskOptions.port, serveTaskOptions.host,callback)
+               :
+      server.listen(serveTaskOptions.host,callback);
     })
     .catch((err: Error) => {
       if (err) {

--- a/packages/@angular/cli/utilities/check-port.ts
+++ b/packages/@angular/cli/utilities/check-port.ts
@@ -7,10 +7,11 @@ const getPort = denodeify<{host: string, port: number}, number>(PortFinder.getPo
 export function checkPort(port: number, host: string, basePort = 49152): Promise<number> {
   PortFinder.basePort = basePort;
   return getPort({ port, host })
+    .then(port =>{return port === "unix" ? "" : port;})
     .then(foundPort => {
 
       // If the port isn't available and we weren't looking for any port, throw error.
-      if (port !== foundPort && port !== 0) {
+      if (port !== foundPort && port !== 0 && foundPort) {
         throw new SilentError(
           `Port ${port} is already in use. Use '--port' to specify a different port.`
         );


### PR DESCRIPTION
how to use
$ ng serve --host ./test.sock --port unix
./test.sock :  socket name
unix        :  it's a special argument for using UNIX domain socket

BREAKING CHANGE: the type owned by port has changed from Number to String
Before:
{
  port?: number;
  .....
}
After:
{
  port?: string;
  .....
}
Before:
{
  name: 'port',
  type: Number,
  .....
}
After:
{
  name: 'port',
  type: String,
  .....
}