### PR TITLE
feat(@angular/cli): support inline source maps with defined charset

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "semver": "^5.3.0",
     "silent-error": "^1.0.0",
     "source-map": "^0.5.6",
-    "source-map-loader": "^0.1.5",
+    "source-map-loader": "^0.2.0",
     "style-loader": "^0.13.1",
     "stylus": "^0.54.5",
     "stylus-loader": "^3.0.1",

--- a/packages/@angular/cli/package.json
+++ b/packages/@angular/cli/package.json
@@ -71,7 +71,7 @@
     "script-loader": "^0.7.0",
     "semver": "^5.1.0",
     "silent-error": "^1.0.0",
-    "source-map-loader": "^0.1.5",
+    "source-map-loader": "^0.2.0",
     "istanbul-instrumenter-loader": "^2.0.0",
     "style-loader": "^0.13.1",
     "stylus": "^0.54.5",


### PR DESCRIPTION
Latest version of `source-map-loader` added support for the charset option of inline source maps.