### PR TITLE
feat(@angular/cli): adding skip e2e test option

### DIFF
--- a/docs/documentation/new.md
+++ b/docs/documentation/new.md
@@ -114,7 +114,7 @@ Default applications are created in a directory of the same name, with an initia
     `--skip-e2e` (alias: `-se`) _default value: false_
   </p>
   <p>
-    Skip creating e2e spec files.
+    Skip including e2e functionality.
   </p>
 </details>
 

--- a/docs/documentation/new.md
+++ b/docs/documentation/new.md
@@ -109,6 +109,16 @@ Default applications are created in a directory of the same name, with an initia
 </details>
 
 <details>
+  <summary>skip-e2e</summary>
+  <p>
+    `--skip-e2e` (alias: `-se`) _default value: false_
+  </p>
+  <p>
+    Skip creating e2e spec files.
+  </p>
+</details>
+
+<details>
   <summary>source-dir</summary>
   <p>
     `--source-dir` (alias: `-sd`) _default value: src_

--- a/packages/@angular/cli/blueprints/ng/files/package.json
+++ b/packages/@angular/cli/blueprints/ng/files/package.json
@@ -37,9 +37,9 @@
     "karma-cli": "~1.0.1",
     "karma-jasmine": "~1.1.0",
     "karma-jasmine-html-reporter": "^0.2.2",
-    "karma-coverage-istanbul-reporter": "^0.2.0",
+    "karma-coverage-istanbul-reporter": "^0.2.0",<% if(e2e) { %>
     "protractor": "~5.1.0",
-    "ts-node": "~2.0.0",
+    "ts-node": "~2.0.0",<% } %>
     "tslint": "~4.5.0",
     "typescript": "~2.2.0"
   }

--- a/packages/@angular/cli/blueprints/ng/index.ts
+++ b/packages/@angular/cli/blueprints/ng/index.ts
@@ -35,6 +35,7 @@ export default Blueprint.extend({
     // set this.tests to opposite of skipTest options,
     // meaning if tests are being skipped then the default.spec.BLUEPRINT will be false
     this.tests = options.skipTests ? false : true;
+    this.e2e = options.skipE2e ? false : true;
 
     // Split/join with / not path.sep as reference to typings require forward slashes.
     const relativeRootPath = options.sourceDir.split('/').map(() => '..').join('/');
@@ -54,7 +55,8 @@ export default Blueprint.extend({
       routing: options.routing,
       inlineStyle: options.inlineStyle,
       inlineTemplate: options.inlineTemplate,
-      tests: this.tests
+      tests: this.tests,
+      e2e: this.e2e,
     };
   },
 
@@ -76,6 +78,13 @@ export default Blueprint.extend({
 
     if (this.options && this.options.skipTests) {
       fileList = fileList.filter(p => p.indexOf('app.component.spec.ts') < 0);
+    }
+
+    if (this.options && this.options.skipE2e) {
+      fileList = fileList
+        .filter(p => p.indexOf('protractor.conf.js') < 0)
+        .filter(p => p.indexOf('app.po.ts') < 0)
+        .filter(p => p.indexOf('app.e2e-spec.ts') < 0);
     }
 
     const cliConfig = CliConfig.fromProject();

--- a/packages/@angular/cli/commands/new.ts
+++ b/packages/@angular/cli/commands/new.ts
@@ -63,6 +63,13 @@ const NewCommand = Command.extend({
       description: 'Skip creating spec files.'
     },
     {
+      name: 'skip-e2e',
+      type: Boolean,
+      default: false,
+      aliases: ['s2'],
+      description: 'Skip creating e2e files.'
+    },
+    {
       name: 'skip-commit',
       type: Boolean,
       default: false,

--- a/packages/@angular/cli/tasks/init.ts
+++ b/packages/@angular/cli/tasks/init.ts
@@ -78,7 +78,8 @@ export default Task.extend({
       inlineTemplate: commandOptions.inlineTemplate,
       ignoredUpdateFiles: ['favicon.ico'],
       skipGit: commandOptions.skipGit,
-      skipTests: commandOptions.skipTests
+      skipTests: commandOptions.skipTests,
+      skipE2e: commandOptions.skipE2e
     };
 
     validateProjectName(packageName);

--- a/tests/e2e/tests/commands/new/new-skip-e2e.ts
+++ b/tests/e2e/tests/commands/new/new-skip-e2e.ts
@@ -1,0 +1,11 @@
+import {createProject} from '../../../utils/project';
+import {expectFileNotToExist} from '../../../utils/fs';
+
+
+export default function() {
+  return Promise.resolve()
+    .then(() => createProject('new-project-skip-e2e', '--skip-e2e'))
+    .then(() => expectFileNotToExist('e2e/app.e2e-spec.ts'))
+    .then(() => expectFileNotToExist('e2e/app.po.ts'))
+    .then(() => expectFileNotToExist('protractor.conf.js'));
+}

--- a/tests/e2e/tests/commands/new/new-skip-tests.ts
+++ b/tests/e2e/tests/commands/new/new-skip-tests.ts
@@ -1,0 +1,9 @@
+import {createProject} from '../../../utils/project';
+import {expectFileNotToExist} from '../../../utils/fs';
+
+
+export default function() {
+  return Promise.resolve()
+    .then(() => createProject('new-project-skip-tests', '--skip-tests'))
+    .then(() => expectFileNotToExist('src/app/app.component.spec.ts'));
+}

--- a/tests/e2e/utils/fs.ts
+++ b/tests/e2e/utils/fs.ts
@@ -130,6 +130,18 @@ export function expectFileMatchToExist(dir: string, regex: RegExp) {
   });
 }
 
+export function expectFileNotToExist(fileName: string) {
+  return new Promise((resolve, reject) => {
+    fs.exists(fileName, (exist) => {
+      if (exist) {
+        reject(new Error(`File ${fileName} was expected not to exist but found...`));
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
 export function expectFileToExist(fileName: string) {
   return new Promise((resolve, reject) => {
     fs.exists(fileName, (exist) => {


### PR DESCRIPTION
Adds another option to skip e2e tests
```
--skip-e2e (Boolean) (Default: false) Skip creating e2e files.
```
Fixes: https://github.com/angular/angular-cli/issues/5724