### PR TITLE
fix(@angular/cli): ensure only in-memory output is served

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "url-loader": "^0.5.7",
     "walk-sync": "^0.3.1",
     "webpack": "~2.2.0",
-    "webpack-dev-server": "~2.3.0",
+    "webpack-dev-server": "~2.4.2",
     "webpack-merge": "^2.4.0",
     "zone.js": "^0.8.4"
   },

--- a/packages/@angular/cli/custom-typings.d.ts
+++ b/packages/@angular/cli/custom-typings.d.ts
@@ -1,5 +1,5 @@
 interface IWebpackDevServerConfigurationOptions {
-  contentBase?: string;
+  contentBase?: boolean | string | string[];
   hot?: boolean;
   historyApiFallback?: {[key: string]: any} | boolean;
   compress?: boolean;

--- a/packages/@angular/cli/package.json
+++ b/packages/@angular/cli/package.json
@@ -81,7 +81,7 @@
     "url-loader": "^0.5.7",
     "walk-sync": "^0.3.1",
     "webpack": "~2.2.0",
-    "webpack-dev-server": "~2.3.0",
+    "webpack-dev-server": "~2.4.2",
     "webpack-merge": "^2.4.0",
     "zone.js": "^0.8.4"
   },

--- a/packages/@angular/cli/tasks/serve.ts
+++ b/packages/@angular/cli/tasks/serve.ts
@@ -148,7 +148,8 @@ export default Task.extend({
         poll: serveTaskOptions.poll
       },
       https: serveTaskOptions.ssl,
-      overlay: serveTaskOptions.target === 'development'
+      overlay: serveTaskOptions.target === 'development',
+      contentBase: false
     };
 
     if (sslKey != null && sslCert != null) {


### PR DESCRIPTION
The default setup for webpack-dev-server is to use the current working directory as the content base.  This resulted in additional files (most likely unexpectedly) being served during development that would not exist after a build is deployed.