### PR TITLE
fix(@angular/cli): set sass precision to bootstrap required value

### DIFF
--- a/packages/@angular/cli/models/webpack-configs/styles.ts
+++ b/packages/@angular/cli/models/webpack-configs/styles.ts
@@ -117,6 +117,8 @@ export function getStylesConfig(wco: WebpackConfigOptions) {
         loader: 'sass-loader',
         options: {
           sourceMap: cssSourceMap,
+          // bootstrap-sass requires a minimum precision of 8
+          precision: 8,
           includePaths
         }
       }]


### PR DESCRIPTION
To avoid graphical glitches a minimum precision of 8 is required.
See: https://github.com/twbs/bootstrap-sass/blob/master/README.md

Fixes #5807