### PR TITLE
feat(@angular/cli): add convenience aliases to the eject command

### DIFF
--- a/packages/@angular/cli/commands/eject.ts
+++ b/packages/@angular/cli/commands/eject.ts
@@ -28,6 +28,7 @@ export interface EjectTaskOptions extends BuildOptions {
 const EjectCommand = Command.extend({
   name: 'eject',
   description: 'Ejects your app and output the proper webpack configuration and scripts.',
+  aliases: ['webpack', 'larkin'],
 
   availableOptions: baseEjectCommandOptions,
 


### PR DESCRIPTION
Add the webpack alias
Add the larkin alias

This feature has been requested by @geddski on stage during ng conf 2017