### PR TITLE
fix(@angular/cli): generating service dry run fix

### DIFF
--- a/packages/@angular/cli/blueprints/service/index.ts
+++ b/packages/@angular/cli/blueprints/service/index.ts
@@ -103,6 +103,13 @@ export default Blueprint.extend({
       `;
       this._writeStatusToUI(chalk.yellow, 'WARNING', warningMessage);
     } else {
+      if (options.dryRun) {
+        this._writeStatusToUI(chalk.yellow,
+          'update',
+          path.relative(this.project.root, this.pathToModule));
+        return;
+      }
+
       const className = stringUtils.classify(`${options.entity.name}Service`);
       const fileName = stringUtils.dasherize(`${options.entity.name}.service`);
       const fullGeneratePath = path.join(this.project.root, this.generatePath);

--- a/tests/e2e/tests/generate/service/service-dry-run.ts
+++ b/tests/e2e/tests/generate/service/service-dry-run.ts
@@ -1,0 +1,9 @@
+import {join} from 'path';
+import {ng} from '../../../utils/process';
+import {expectGitToBeClean} from '../../../utils/git';
+
+
+export default function() {
+  return ng('generate', 'service', 'test-service', '--module', 'app.module.ts', '--dry-run')
+    .then(() => expectGitToBeClean());
+}


### PR DESCRIPTION
Before, generating a service and providing it in a module, the dry run flag was
ignored for the providing part. We dont provide the module now if its a dry-run.

Fixes #5862.