### PR TITLE
docs(@angular/cli): Add specific key example for ng get [key].

### DIFF
--- a/docs/documentation/config.md
+++ b/docs/documentation/config.md
@@ -4,6 +4,7 @@
 
 ## Overview
 `ng get [key]` Get a value from the configuration.
+`[key]` should be in JSON path format. Example: `a[3].foo.bar[2]`.
 
 ## Options
 <details>
@@ -21,6 +22,7 @@
 
 ## Overview
 `ng set [key]=[value]` Set a value in the configuration.
+`[key]` should be in JSON path format. Example: `a[3].foo.bar[2]`.
 
 ## Options
 <details>


### PR DESCRIPTION
Add a JSON path example for `ng get` docs.

Related issue: #5886