### PR TITLE
feat(@angular/cli): adding option to search docs as well

### DIFF
--- a/packages/@angular/cli/commands/doc.ts
+++ b/packages/@angular/cli/commands/doc.ts
@@ -1,16 +1,29 @@
 const Command = require('../ember-cli/lib/models/command');
 import { DocTask } from '../tasks/doc';
 
+export interface DocOptions {
+  search?: boolean;
+}
+
 const DocCommand = Command.extend({
   name: 'doc',
   description: 'Opens the official Angular documentation for a given keyword.',
   works: 'everywhere',
+  availableOptions: [
+    {
+      name: 'search',
+      aliases: ['s'],
+      type: Boolean,
+      default: false,
+      description: 'Search docs instead of api.'
+    }
+  ],
 
   anonymousOptions: [
     '<keyword>'
   ],
 
-  run: function(_commandOptions: any, rawArgs: Array<string>) {
+  run: function(commandOptions: DocOptions, rawArgs: Array<string>) {
     const keyword = rawArgs[0];
 
     const docTask = new DocTask({
@@ -18,7 +31,7 @@ const DocCommand = Command.extend({
       project: this.project
     });
 
-    return docTask.run(keyword);
+    return docTask.run(keyword, commandOptions.search);
   }
 });
 

--- a/packages/@angular/cli/tasks/doc.ts
+++ b/packages/@angular/cli/tasks/doc.ts
@@ -2,8 +2,10 @@ const Task = require('../ember-cli/lib/models/task');
 const opn = require('opn');
 
 export const DocTask: any = Task.extend({
-  run: function(keyword: string) {
-    const searchUrl = `https://angular.io/docs/ts/latest/api/#!?query=${keyword}`;
+  run: function(keyword: string, search: boolean) {
+    const searchUrl = search ? `https://angular.io/search/#stq=${keyword}&stp=1` :
+     `https://angular.io/docs/ts/latest/api/#!?query=${keyword}`;
+
     return opn(searchUrl, { wait: false });
   }
 });


### PR DESCRIPTION
Adds option to search docs as well.
`ng doc --search service` Should open https://angular.io/search/#stq=service&stp=1

Fixes: https://github.com/angular/angular-cli/issues/5829