### PR TITLE
fix(@angular/cli): proper generation when the target dir exists

### DIFF
--- a/packages/@angular/cli/utilities/dynamic-path-parser.ts
+++ b/packages/@angular/cli/utilities/dynamic-path-parser.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import * as process from 'process';
-import * as fs from 'fs';
+import * as fs from 'fs-extra';
 const stringUtils = require('ember-cli-string-utils');
 
 export function dynamicPathParser(project: any, entityName: string, appConfig: any) {
@@ -38,7 +38,7 @@ export function dynamicPathParser(project: any, entityName: string, appConfig: a
       // Folder not found, create it, and return it
       const dasherizedPart = stringUtils.dasherize(part);
       const dasherizedDirName = path.join(tempPath, dasherizedPart);
-      fs.mkdirSync(dasherizedDirName);
+      fs.mkdirpSync(dasherizedDirName);
       return dasherizedDirName;
 
     }, parsedOutputPath.root);


### PR DESCRIPTION
This allows generating nested components or other blurprint outputs.