### PR TITLE
test: update development tslint version

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "through": "^2.3.6",
     "tree-kill": "^1.0.0",
     "ts-node": "^2.0.0",
-    "tslint": "^4.0.2"
+    "tslint": "^5.1.0"
   },
   "optionalDependencies": {
     "node-sass": "^4.3.0"

--- a/packages/@angular/cli/lib/ast-tools/route-utils.ts
+++ b/packages/@angular/cli/lib/ast-tools/route-utils.ts
@@ -143,7 +143,7 @@ export function insertImport(fileToEdit: string, symbolName: string,
     fallbackPos,
     ts.SyntaxKind.StringLiteral
   );
-};
+}
 
 /**
  * Inserts a path to the new route into src/routes.ts if it doesn't exist

--- a/packages/@angular/cli/models/webpack-configs/typescript.ts
+++ b/packages/@angular/cli/models/webpack-configs/typescript.ts
@@ -95,7 +95,7 @@ export const getAotConfig = function(wco: WebpackConfigOptions) {
   // Fallback to exclude spec files from AoT compilation on projects using a shared tsconfig.
   if (testTsConfigPath === tsConfigPath) {
     let exclude = [ '**/*.spec.ts' ];
-    if (appConfig.test) { exclude.push(path.join(projectRoot, appConfig.root, appConfig.test)); };
+    if (appConfig.test) { exclude.push(path.join(projectRoot, appConfig.root, appConfig.test)); }
     pluginOptions.exclude = exclude;
   }
 

--- a/packages/@angular/cli/utilities/app-utils.ts
+++ b/packages/@angular/cli/utilities/app-utils.ts
@@ -25,6 +25,8 @@ export function getAppFromConfig(nameOrIndex?: String) {
   } else {
     return apps[0];
   }
-  throw new SilentError(chalk.red(oneLine`Unable to find app with name or index. 
-    Make you have proper apps configuration in \`.angular-cli.json\``));
+  throw new SilentError(chalk.red(oneLine`
+    Unable to find app with name or index.
+    Verify the configuration in \`.angular-cli.json\`
+  `));
 }

--- a/packages/@angular/cli/utilities/dynamic-path-parser.ts
+++ b/packages/@angular/cli/utilities/dynamic-path-parser.ts
@@ -61,4 +61,4 @@ export function dynamicPathParser(project: any, entityName: string, appConfig: a
   parsedPath.dir = parsedPath.dir === path.sep ? '' : parsedPath.dir;
 
   return { ...parsedPath, appRoot, sourceDir };
-};
+}

--- a/packages/@angular/cli/utilities/find-parent-module.ts
+++ b/packages/@angular/cli/utilities/find-parent-module.ts
@@ -34,4 +34,4 @@ export default function findParentModule(
   }
 
   throw new SilentError('No module files found');
-};
+}

--- a/packages/@angular/cli/utilities/get-dependent-files.ts
+++ b/packages/@angular/cli/utilities/get-dependent-files.ts
@@ -142,7 +142,7 @@ export function getDependentFiles(fileName: string, rootPath: string): Promise<M
           });
         if (tempModuleSpecifiers.length > 0) {
           relevantFiles[filePath] = tempModuleSpecifiers;
-        };
+        }
       });
       return relevantFiles;
     }));

--- a/packages/@angular/cli/utilities/module-resolver.ts
+++ b/packages/@angular/cli/utilities/module-resolver.ts
@@ -73,7 +73,7 @@ export class ModuleResolver {
               let changeText = path.relative(fileDir, path.join(this.newFilePath, componentName));
               if (changeText.length > 0 && changeText.charAt(0) !== '.') {
                 changeText = `.${path.sep}${changeText}`;
-              };
+              }
               let position = specifier.end - specifier.specifierText.length;
               return new ReplaceChange(file, position - 1, specifier.specifierText, changeText);
             });

--- a/packages/@angular/cli/utilities/prerender-webpack-plugin.ts
+++ b/packages/@angular/cli/utilities/prerender-webpack-plugin.ts
@@ -53,4 +53,4 @@ export class PrerenderWebpackPlugin {
         delete require.cache[key];
       });
   }
-};
+}

--- a/packages/@ngtools/json-schema/src/schema-tree.spec.ts
+++ b/packages/@ngtools/json-schema/src/schema-tree.spec.ts
@@ -15,6 +15,7 @@ describe('@ngtools/json-schema', () => {
 
     it('works', () => {
       const proto: any = Object.create(null);
+      // tslint:disable-next-line
       new RootSchemaTreeNode(proto, {
         value: valueJson,
         schema: schemaJson
@@ -47,6 +48,7 @@ describe('@ngtools/json-schema', () => {
 
     it('works', () => {
       const proto: any = Object.create(null);
+      // tslint:disable-next-line
       new RootSchemaTreeNode(proto, {
         value: valueJson,
         schema: schemaJson

--- a/packages/@ngtools/json-schema/src/schema-tree.ts
+++ b/packages/@ngtools/json-schema/src/schema-tree.ts
@@ -102,7 +102,7 @@ export abstract class SchemaTreeNode<T> implements SchemaNode {
       throw new MissingImplementationError();
     }
     throw new SettingReadOnlyPropertyError();
-  };
+  }
   isCompatible(_v: any) { return false; }
 
   abstract serialize(serializer: Serializer): void;


### PR DESCRIPTION
Also fixes any encountered errors.

This only changes the version used for the CLI's development.  The project template version of tslint cannot be updated until codelyzer supports the latest version. ([codelyzer tracking issue](https://github.com/mgechev/codelyzer/issues/281))