### PR TITLE
feat(@angular/cli): add ability to use custom blueprint templates whe…

### DIFF
--- a/packages/@angular/cli/blueprints/class/index.ts
+++ b/packages/@angular/cli/blueprints/class/index.ts
@@ -1,6 +1,7 @@
 import {getAppFromConfig} from '../../utilities/app-utils';
 import {dynamicPathParser} from '../../utilities/dynamic-path-parser';
 import {CliConfig} from '../../models/config';
+import {getBlueprintFilesPathFor} from '../../utilities/get-blueprint-files-path-for';
 
 const stringUtils = require('ember-cli-string-utils');
 const Blueprint = require('../../ember-cli/lib/models/blueprint');
@@ -61,6 +62,10 @@ export default Blueprint.extend({
     }
 
     return fileList;
+  },
+
+  filesPath: function () {
+    return getBlueprintFilesPathFor.call(this, 'class');
   },
 
   fileMapTokens: function () {

--- a/packages/@angular/cli/blueprints/component/index.ts
+++ b/packages/@angular/cli/blueprints/component/index.ts
@@ -6,6 +6,7 @@ import { CliConfig } from '../../models/config';
 import { getAppFromConfig } from '../../utilities/app-utils';
 import { dynamicPathParser } from '../../utilities/dynamic-path-parser';
 import { resolveModulePath } from '../../utilities/resolve-module-file';
+import { getBlueprintFilesPathFor } from '../../utilities/get-blueprint-files-path-for';
 
 const Blueprint = require('../../ember-cli/lib/models/blueprint');
 const findParentModule = require('../../utilities/find-parent-module').default;
@@ -143,6 +144,7 @@ export default Blueprint.extend({
   },
 
   locals: function (options: any) {
+
     this.styleExt = CliConfig.getValue('defaults.styleExt') || 'css';
 
     options.inlineStyle = options.inlineStyle !== undefined ?
@@ -194,6 +196,10 @@ export default Blueprint.extend({
     }
 
     return fileList;
+  },
+
+  filesPath: function () {
+    return getBlueprintFilesPathFor.call(this, 'component');
   },
 
   fileMapTokens: function (options: any) {

--- a/packages/@angular/cli/blueprints/directive/index.ts
+++ b/packages/@angular/cli/blueprints/directive/index.ts
@@ -5,6 +5,7 @@ import { CliConfig } from '../../models/config';
 import { getAppFromConfig } from '../../utilities/app-utils';
 import { resolveModulePath } from '../../utilities/resolve-module-file';
 import { dynamicPathParser } from '../../utilities/dynamic-path-parser';
+import { getBlueprintFilesPathFor } from '../../utilities/get-blueprint-files-path-for';
 
 const stringUtils = require('ember-cli-string-utils');
 const astUtils = require('../../utilities/ast-utils');
@@ -113,6 +114,9 @@ export default Blueprint.extend({
     }
 
     return fileList;
+  },
+  filesPath: function () {
+    return getBlueprintFilesPathFor.call(this, 'directive');
   },
 
   fileMapTokens: function (options: any) {

--- a/packages/@angular/cli/blueprints/enum/index.ts
+++ b/packages/@angular/cli/blueprints/enum/index.ts
@@ -1,5 +1,6 @@
 import {getAppFromConfig} from '../../utilities/app-utils';
 import {dynamicPathParser} from '../../utilities/dynamic-path-parser';
+import { getBlueprintFilesPathFor } from '../../utilities/get-blueprint-files-path-for';
 
 const stringUtils = require('ember-cli-string-utils');
 const Blueprint = require('../../ember-cli/lib/models/blueprint');
@@ -33,6 +34,10 @@ export default Blueprint.extend({
       flat: options.flat,
       fileName: this.fileName
     };
+  },
+
+  filesList: function () {
+    return getBlueprintFilesPathFor.call(this, 'enum');
   },
 
   fileMapTokens: function () {

--- a/packages/@angular/cli/blueprints/guard/index.ts
+++ b/packages/@angular/cli/blueprints/guard/index.ts
@@ -6,6 +6,7 @@ import { CliConfig } from '../../models/config';
 import { dynamicPathParser } from '../../utilities/dynamic-path-parser';
 import { getAppFromConfig } from '../../utilities/app-utils';
 import { resolveModulePath } from '../../utilities/resolve-module-file';
+import { getBlueprintFilesPathFor } from '../../utilities/get-blueprint-files-path-for';
 
 const Blueprint = require('../../ember-cli/lib/models/blueprint');
 const stringUtils = require('ember-cli-string-utils');
@@ -72,6 +73,10 @@ export default Blueprint.extend({
     }
 
     return fileList;
+  },
+
+  filesList: function () {
+    return getBlueprintFilesPathFor.call(this, 'guard');
   },
 
   fileMapTokens: function (options: any) {

--- a/packages/@angular/cli/blueprints/interface/index.ts
+++ b/packages/@angular/cli/blueprints/interface/index.ts
@@ -1,6 +1,7 @@
 import {CliConfig} from '../../models/config';
 import {getAppFromConfig} from '../../utilities/app-utils';
 import {dynamicPathParser} from '../../utilities/dynamic-path-parser';
+import { getBlueprintFilesPathFor } from '../../utilities/get-blueprint-files-path-for';
 
 const stringUtils = require('ember-cli-string-utils');
 const Blueprint = require('../../ember-cli/lib/models/blueprint');
@@ -43,6 +44,10 @@ export default Blueprint.extend({
       fileName: this.fileName,
       prefix: prefix
     };
+  },
+
+  filesPath: function () {
+    return getBlueprintFilesPathFor.call(this, 'interface');
   },
 
   fileMapTokens: function () {

--- a/packages/@angular/cli/blueprints/pipe/index.ts
+++ b/packages/@angular/cli/blueprints/pipe/index.ts
@@ -5,6 +5,7 @@ import { CliConfig } from '../../models/config';
 import { dynamicPathParser } from '../../utilities/dynamic-path-parser';
 import { getAppFromConfig } from '../../utilities/app-utils';
 import { resolveModulePath } from '../../utilities/resolve-module-file';
+import { getBlueprintFilesPathFor } from '../../utilities/get-blueprint-files-path-for';
 
 const stringUtils = require('ember-cli-string-utils');
 const astUtils = require('../../utilities/ast-utils');
@@ -98,6 +99,10 @@ export default Blueprint.extend({
     }
 
     return fileList;
+  },
+
+  filesPath: function () {
+    return getBlueprintFilesPathFor.call(this, 'pipe');
   },
 
   fileMapTokens: function (options: any) {

--- a/packages/@angular/cli/blueprints/service/index.ts
+++ b/packages/@angular/cli/blueprints/service/index.ts
@@ -6,6 +6,7 @@ import { CliConfig } from '../../models/config';
 import { dynamicPathParser } from '../../utilities/dynamic-path-parser';
 import { getAppFromConfig } from '../../utilities/app-utils';
 import { resolveModulePath } from '../../utilities/resolve-module-file';
+import { getBlueprintFilesPathFor } from '../../utilities/get-blueprint-files-path-for';
 
 const Blueprint = require('../../ember-cli/lib/models/blueprint');
 const stringUtils = require('ember-cli-string-utils');
@@ -75,8 +76,11 @@ export default Blueprint.extend({
     if (this.options && !this.options.spec) {
       fileList = fileList.filter(p => p.indexOf('__name__.service.spec.ts') < 0);
     }
-
     return fileList;
+  },
+
+  filesPath: function () {
+    return getBlueprintFilesPathFor.call(this, 'service');
   },
 
   fileMapTokens: function (options: any) {

--- a/packages/@angular/cli/lib/config/schema.json
+++ b/packages/@angular/cli/lib/config/schema.json
@@ -33,6 +33,43 @@
             "type": "string",
             "description": "Name of the app."
           },
+          "blueprints": {
+            "type": "object",
+            "properties": {
+              "class": {
+                "type": "string",
+                "description": "Path to a directory that contains blueprint files for the class generator."
+              },
+              "component": {
+                "type": "string",
+                "description": "Path to a directory that contains blueprint files for the component generator."
+              },
+              "directive": {
+                "type": "string",
+                "description": "Path to a directory that contains blueprint files for the directive generator."
+              },
+              "enum": {
+                "type": "string",
+                "description": "Path to a directory that contains blueprint files for the enum generator."
+              },
+              "guard": {
+                "type": "string",
+                "description": "Path to a directory that contains blueprint files for the guard generator."
+              },
+              "interface": {
+                "type": "string",
+                "description": "Path to a directory that contains blueprint files for the interface generator."
+              },
+              "pipe": {
+                "type": "string",
+                "description": "Path to a directory that contains blueprint files for the pipe generator."
+              },
+              "service": {
+                "type": "string",
+                "description": "Path to a directory that contains blueprint files for the service generator."
+              }
+            }
+          },
           "root": {
             "type": "string",
             "description": "The root directory of the app."

--- a/packages/@angular/cli/utilities/get-blueprint-files-path-for.ts
+++ b/packages/@angular/cli/utilities/get-blueprint-files-path-for.ts
@@ -1,0 +1,14 @@
+import * as path from 'path';
+import { getAppFromConfig } from './app-utils';
+const Blueprint = require('../ember-cli/lib/models/blueprint');
+
+export function getBlueprintFilesPathFor(blueprintName: string) {
+  const app = this.options && this.options.app;
+  const appConfig = getAppFromConfig(app);
+
+  if (appConfig.blueprints && appConfig.blueprints[blueprintName]) {
+    return path.join(process.cwd(), appConfig.blueprints[blueprintName]);
+  } else {
+    return Blueprint.prototype.filesPath.apply(this);
+  }
+}


### PR DESCRIPTION
This type of feature was mentioned in Issue #3549

It allows a user of the cli to define their own blueprints to be used by the generate command. This is probably a little rough around the edges but I wanted to get it out there for feedback and see if anyone has suggestions how to make this nicer.

Currently this implementation would allow a developer to define the locations of their blueprints in the .angular-cli.json config file
```
{
  "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
  "project": {
    "name": "ng2-custom-blueprints"
  },
  "apps": [
    {
      "blueprints": {
        "component": "./blueprints/component"
      },
      "root": "src",
      "outDir": "dist"

      // ... more config 

    }
  ]
}
```

With the above config the user could have a directory structure like this in their project
```
├── blueprints
│   └── component
│       └── __path__
│           ├── __name__.component.__styleext__
│           ├── __name__.component.html
│           ├── __name__.component.spec.ts
│           └── __name__.component.ts
```

The only blueprint that wouldn't be customizable here would be the module. I'm not sure on the implications of the cli being able to automatically register a component with a module if the blueprint were customized.

feedback / suggestions?