### PR TITLE
feat(@angular/cli): add vrsource-tslint-rules

### DIFF
--- a/packages/@angular/cli/blueprints/ng/files/package.json
+++ b/packages/@angular/cli/blueprints/ng/files/package.json
@@ -42,6 +42,7 @@
     "protractor": "~5.1.0",
     "ts-node": "~2.0.0",
     "tslint": "~5.1.0",
-    "typescript": "~2.2.0"
+    "typescript": "~2.2.0",
+    "vrsource-tslint-rules": "4.0.1"
   }
 }

--- a/packages/@angular/cli/blueprints/ng/files/tslint.json
+++ b/packages/@angular/cli/blueprints/ng/files/tslint.json
@@ -1,6 +1,7 @@
 {
   "rulesDirectory": [
-    "node_modules/codelyzer"
+    "node_modules/codelyzer",
+    "node_modules/vrsource-tslint-rules/rules"
   ],
   "rules": {
     "callable-types": true,
@@ -42,11 +43,13 @@
     ],
     "no-construct": true,
     "no-debugger": true,
+    "no-duplicate-imports": true,
     "no-duplicate-variable": true,
     "no-empty": false,
     "no-empty-interface": true,
     "no-eval": true,
     "no-inferrable-types": [true, "ignore-params"],
+    "no-jasmine-focus": true,
     "no-shadowed-variable": true,
     "no-string-literal": false,
     "no-string-throw": true,
@@ -64,6 +67,12 @@
       "check-whitespace"
     ],
     "prefer-const": true,
+    "prefer-literal": [
+      true,
+      "object",
+      "function",
+      "array"
+    ],    
     "quotemark": [
       true,
       "single"


### PR DESCRIPTION
This is a proposition to include a few interesting rules from [vrsource-tslint-rules](https://www.npmjs.com/package/vrsource-tslint-rules).

It adds:
- `no-duplicate-imports` (see [docs](https://www.npmjs.com/package/vrsource-tslint-rules#no-duplicate-imports))
- `no-jasmine-focus` (see [docs](https://www.npmjs.com/package/vrsource-tslint-rules#no-jasmine-focus))
- `prefer-literal` (see [docs](https://www.npmjs.com/package/vrsource-tslint-rules#prefer-literal))