### PR TITLE
fix(@angular/cli): Add missing aliases into help output

### DIFF
--- a/packages/@angular/cli/blueprints/class/index.ts
+++ b/packages/@angular/cli/blueprints/class/index.ts
@@ -14,6 +14,7 @@ export default Blueprint.extend({
     {
       name: 'spec',
       type: Boolean,
+      aliases: ['sp'],
       description: 'Specifies if a spec file is generated.'
     },
     {

--- a/packages/@angular/cli/blueprints/component/index.ts
+++ b/packages/@angular/cli/blueprints/component/index.ts
@@ -42,6 +42,7 @@ export default Blueprint.extend({
     {
       name: 'flat',
       type: Boolean,
+      aliases: ['f'],
       description: 'Flag to indicate if a dir is created.'
     },
     {
@@ -60,11 +61,13 @@ export default Blueprint.extend({
       name: 'prefix',
       type: String,
       default: null,
+      aliases: ['p'],
       description: 'Specifies whether to use the prefix.'
     },
     {
       name: 'spec',
       type: Boolean,
+      aliases: ['sp'],
       description: 'Specifies if a spec file is generated.'
     },
     {
@@ -83,6 +86,7 @@ export default Blueprint.extend({
       name: 'skip-import',
       type: Boolean,
       default: false,
+      aliases: ['ski'],
       description: 'Allows for skipping the module import.'
     },
     {
@@ -95,6 +99,7 @@ export default Blueprint.extend({
       name: 'export',
       type: Boolean,
       default: false,
+      aliases: ['e'],
       description: 'Specifies if declaring module exports the component.'
     },
     {

--- a/packages/@angular/cli/blueprints/directive/index.ts
+++ b/packages/@angular/cli/blueprints/directive/index.ts
@@ -20,34 +20,40 @@ export default Blueprint.extend({
     {
       name: 'flat',
       type: Boolean,
+      aliases: ['f'],
       description: 'Flag to indicate if a dir is created.'
     },
     {
       name: 'prefix',
       type: String,
       default: null,
+      aliases: ['p'],
       description: 'Specifies whether to use the prefix.'
     },
     {
       name: 'spec',
       type: Boolean,
+      aliases: ['sp'],
       description: 'Specifies if a spec file is generated.'
     },
     {
       name: 'skip-import',
       type: Boolean,
       default: false,
+      aliases: ['ski'],
       description: 'Allows for skipping the module import.'
     },
     {
       name: 'module',
-      type: String, aliases: ['m'],
+      type: String,
+      aliases: ['m'],
       description: 'Allows specification of the declaring module.'
     },
     {
       name: 'export',
       type: Boolean,
       default: false,
+      aliases: ['e'],
       description: 'Specifies if declaring module exports the component.'
     },
     {

--- a/packages/@angular/cli/blueprints/guard/index.ts
+++ b/packages/@angular/cli/blueprints/guard/index.ts
@@ -20,11 +20,13 @@ export default Blueprint.extend({
     {
       name: 'flat',
       type: Boolean,
+      aliases: ['f'],
       description: 'Indicate if a dir is created.'
     },
     {
       name: 'spec',
       type: Boolean,
+      aliases: ['sp'],
       description: 'Specifies if a spec file is generated.'
     },
     {

--- a/packages/@angular/cli/blueprints/module/index.ts
+++ b/packages/@angular/cli/blueprints/module/index.ts
@@ -14,17 +14,20 @@ export default Blueprint.extend({
     {
       name: 'spec',
       type: Boolean,
+      aliases: ['sp'],
       description: 'Specifies if a spec file is generated.'
     },
     {
       name: 'flat',
       type: Boolean,
+      aliases: ['f'],
       description: 'Flag to indicate if a dir is created.'
     },
     {
       name: 'routing',
       type: Boolean,
       default: false,
+      aliases: ['r'],
       description: 'Specifies if a routing module file should be generated.'
     },
     {

--- a/packages/@angular/cli/blueprints/ng/index.ts
+++ b/packages/@angular/cli/blueprints/ng/index.ts
@@ -12,7 +12,7 @@ export default Blueprint.extend({
     { name: 'source-dir', type: String, default: 'src', aliases: ['sd'] },
     { name: 'prefix', type: String, default: 'app', aliases: ['p'] },
     { name: 'style', type: String },
-    { name: 'routing', type: Boolean, default: false },
+    { name: 'routing', type: Boolean, default: false, aliases: ['r'] },
     { name: 'inline-style', type: Boolean, default: false, aliases: ['is'] },
     { name: 'inline-template', type: Boolean, default: false, aliases: ['it'] },
     { name: 'skip-git', type: Boolean, default: false, aliases: ['sg'] }

--- a/packages/@angular/cli/blueprints/pipe/index.ts
+++ b/packages/@angular/cli/blueprints/pipe/index.ts
@@ -20,17 +20,20 @@ export default Blueprint.extend({
     {
       name: 'flat',
       type: Boolean,
+      aliases: ['f'],
       description: 'Flag to indicate if a dir is created.'
     },
     {
       name: 'spec',
       type: Boolean,
+      aliases: ['sp'],
       description: 'Specifies if a spec file is generated.'
     },
     {
       name: 'skip-import',
       type: Boolean,
       default: false,
+      aliases: ['ski'],
       description: 'Allows for skipping the module import.'
     },
     {
@@ -43,6 +46,7 @@ export default Blueprint.extend({
       name: 'export',
       type: Boolean,
       default: false,
+      aliases: ['e'],
       description: 'Specifies if declaring module exports the pipe.'
     },
     {

--- a/packages/@angular/cli/blueprints/service/index.ts
+++ b/packages/@angular/cli/blueprints/service/index.ts
@@ -20,16 +20,19 @@ export default Blueprint.extend({
     {
       name: 'flat',
       type: Boolean,
+      aliases: ['f'],
       description: 'Flag to indicate if a dir is created.'
     },
     {
       name: 'spec',
       type: Boolean,
+      aliases: ['sp'],
       description: 'Specifies if a spec file is generated.'
     },
     {
       name: 'module',
-      type: String, aliases: ['m'],
+      type: String,
+      aliases: ['m'],
       description: 'Specifies where the service should be provided.'
     },
     {


### PR DESCRIPTION
This is a proposition to include some missing aliases :

  - `--flat` -> `-f`
  - `--prefix` -> `-p`
  - `--spec` -> `-sp`
  - `--skip-import` -> `-ski`
  - `--export` -> `-e`
  - `--routing` -> `-r`

into the help output of blueprints creation