### PR TITLE
fix(@angular/cli): add error message when missing config env variable

### DIFF
--- a/packages/@angular/cli/models/config.ts
+++ b/packages/@angular/cli/models/config.ts
@@ -13,7 +13,12 @@ const CLI_CONFIG_FILE_NAME_ALT = 'angular-cli.json';
 
 
 function getUserHome() {
-  return process.env[(process.platform.startsWith('win')) ? 'USERPROFILE' : 'HOME'];
+  const envHomeName = (process.platform.startsWith('win')) ? 'USERPROFILE' : 'HOME';
+  const env = process.env[envHomeName];
+  if (env == null) {
+    throw new Error('Missing environment variable ' + envHomeName);
+  }
+  return env;
 }
 
 


### PR DESCRIPTION
I tried to implement a continuous integration system on my VPS. I have a PHP script that runs ng build. However in my default PHP configuration no environment variable HOME or USERPROFILE was set. I had this error : `Path must be a string. Received undefined`.

I had to take some time to see where the problem came from so I made a pull request to clarify the error.

Now it is : `Error: Missing environment variable HOME` which does not require to look at the code. This message would have saved me some time.