### PR TITLE
fix(@angular/cli) : Improve error message for create component with -…

### DIFF
--- a/packages/@angular/cli/blueprints/component/index.ts
+++ b/packages/@angular/cli/blueprints/component/index.ts
@@ -231,7 +231,17 @@ export default Blueprint.extend({
           path.relative(this.project.root, this.pathToModule));
         return;
       }
-      const preChange = fs.readFileSync(this.pathToModule, 'utf8');
+
+      let preChange: any;
+      try {
+         preChange = fs.readFileSync(this.pathToModule, 'utf8');
+      } catch (err) {
+        if (err.code === 'EISDIR') {
+          throw 'Module specified should be a file, not a directory';
+        } else {
+          throw err;
+        }
+      }
 
       returns.push(
         astUtils.addDeclarationToModule(this.pathToModule, className, importPath)


### PR DESCRIPTION
…m option

Suppose we have created a module with command : `ng g m moduleA'. Now, we would like to create a component cmpA in this module...

When we create this component with : `ng g c cmpA -m moduleA`, we have this error : 

> Error: EISDIR: illegal operation on a directory, read
    at Error (native)
    at Object.fs.readSync (fs.js:731:19)
    at tryReadSync (fs.js:486:20)
    at Object.fs.readFileSync (fs.js:534:19)
    at getSource (/Users/william/learn-angular.fr/prj-lazy-loading/node_modules/@angular/cli/lib/ast-tools/ast-utils.js:24:45)
    at _addSymbolToNgModuleMetadata (/Users/william/learn-angular.fr/prj-lazy-loading/node_modules/@angular/cli/lib/ast-tools/ast-utils.js:175:20)
    at Object.addDeclarationToModule (/Users/william/learn-angular.fr/prj-lazy-loading/node_modules/@angular/cli/lib/ast-tools/ast-utils.js:278:12)
    at Class.afterInstall (/Users/william/learn-angular.fr/prj-lazy-loading/node_modules/@angular/cli/blueprints/component/index.js:227:35)
    at tryCatch (/Users/william/learn-angular.fr/prj-lazy-loading/node_modules/rsvp/dist/rsvp.js:539:12)
    at invokeCallback (/Users/william/learn-angular.fr/prj-lazy-loading/node_modules/rsvp/dist/rsvp.js:554:13)


Now, with this fix, we have this error : 

> Module specified should be a file, not a directory

