### PR TITLE
feat(@angular/cli): add publicPath support via command for webpack-dev-server

### DIFF
--- a/packages/@angular/cli/tasks/serve.ts
+++ b/packages/@angular/cli/tasks/serve.ts
@@ -159,6 +159,11 @@ export default Task.extend({
 
     webpackDevServerConfiguration.hot = serveTaskOptions.hmr;
 
+    // set publicPath property to be sent on webpack server config
+    if (serveTaskOptions.deployUrl) {
+      webpackDevServerConfiguration.publicPath = serveTaskOptions.deployUrl;
+    }
+
     if (serveTaskOptions.target === 'production') {
       ui.writeLine(chalk.red(stripIndents`
         ****************************************************************************************

--- a/tests/e2e/tests/misc/deploy-url.ts
+++ b/tests/e2e/tests/misc/deploy-url.ts
@@ -1,0 +1,18 @@
+import { killAllProcesses } from '../../utils/process';
+import { request } from '../../utils/http';
+import { expectToFail } from '../../utils/utils';
+import { ngServe } from '../../utils/project';
+
+export default function () {
+  return Promise.resolve()
+    // check when setup through command line arguments
+    .then(() => ngServe('--deploy-url', '/deployurl', '--base-href', '/deployurl'))
+    .then(() => expectToFail(() => request('http://localhost:4200')))
+    .then(() => request('http://localhost:4200/deployurl'))
+    .then(body => {
+      if (!body.match(/<app-root>Loading...<\/app-root>/)) {
+        throw new Error('Response does not match expected value.');
+      }
+    })
+    .then(() => killAllProcesses(), (err) => { killAllProcesses(); throw err; });
+}


### PR DESCRIPTION
This adds support for publicPath to webpack-dev-server via ng serve
The server would have to be started like ng serve --deploy-url /deploypath --base-href /deploypath.
The app will be served from http://localhost:4200/deploypath

Should fix #2727