### PR TITLE
fix(@angular/cli): pin cosmiconfig dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "opn": "4.0.2",
     "portfinder": "~1.0.12",
     "postcss-loader": "^1.3.3",
+    "cosmiconfig": "2.1.1",
     "postcss-url": "^5.1.2",
     "raw-loader": "^0.5.1",
     "resolve": "^1.1.7",

--- a/packages/@angular/cli/package.json
+++ b/packages/@angular/cli/package.json
@@ -32,6 +32,7 @@
     "autoprefixer": "^6.5.3",
     "chalk": "^1.1.3",
     "common-tags": "^1.3.1",
+    "cosmiconfig": "2.1.1",
     "css-loader": "^0.27.3",
     "cssnano": "^3.10.0",
     "debug": "^2.1.3",


### PR DESCRIPTION
The latest version depends on json-parse-helpfulerror which depends on jju which uses
an invalid license (WTFPL is not a license).