### PR TITLE
fix(@angular/cli): explicitly disable warning overlays

### DIFF
--- a/packages/@angular/cli/custom-typings.d.ts
+++ b/packages/@angular/cli/custom-typings.d.ts
@@ -20,5 +20,5 @@ interface IWebpackDevServerConfigurationOptions {
   https?: boolean;
   key?: string;
   cert?: string;
-  overlay?: boolean;
+  overlay?: boolean | { errors: boolean, warnings: boolean };
 }

--- a/packages/@angular/cli/tasks/serve.ts
+++ b/packages/@angular/cli/tasks/serve.ts
@@ -148,7 +148,10 @@ export default Task.extend({
         poll: serveTaskOptions.poll
       },
       https: serveTaskOptions.ssl,
-      overlay: serveTaskOptions.target === 'development',
+      overlay: {
+        errors: serveTaskOptions.target === 'development',
+        warnings: false
+      },
       contentBase: false
     };
 


### PR DESCRIPTION
Fixes #6150 
Fixes #6100