### PR TITLE
docs: adding autoprefixer config story to list

### DIFF
--- a/docs/documentation/stories.md
+++ b/docs/documentation/stories.md
@@ -24,3 +24,4 @@
  - [Serve from Disk](stories/disk-serve)
  - [Code Coverage](stories/code-coverage)
  - [Application Environments](stories/application-environments)
+ - [Autoprefixer Configuration](stories/autoprefixer)


### PR DESCRIPTION
This change adds the autoprefixer config ([PR#5975](https://github.com/angular/angular-cli/pull/5975)) story to the story list.