### PR TITLE
fix(@ngtools/logger): add typings and other information to logger package.json

### DIFF
--- a/packages/@ngtools/logger/package.json
+++ b/packages/@ngtools/logger/package.json
@@ -3,7 +3,28 @@
   "version": "1.0.1",
   "description": "",
   "main": "./src/index.js",
+  "typings": "./src/index.d.ts",
   "license": "MIT",
+  "keywords": [
+    "reporter",
+    "logger",
+    "rxjs",
+    "typescript",
+    "log"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/angular/angular-cli.git"
+  },
+  "author": "angular",
+  "bugs": {
+    "url": "https://github.com/angular/angular-cli/issues"
+  },
+  "homepage": "https://github.com/angular/angular-cli/tree/master/packages/@ngtools/logger",
+  "engines": {
+    "node": ">= 6.9.0",
+    "npm": ">= 3.0.0"
+  },
   "dependencies": {
     "rxjs": "^5.0.1"
   }


### PR DESCRIPTION
Missing that information means that typescript doesn't find typings. Also it's harder to find on npm without keywords.