### PR TITLE
Add option to adjust generated files via lint fix

### DIFF
--- a/packages/@angular/cli/blueprints/class/index.ts
+++ b/packages/@angular/cli/blueprints/class/index.ts
@@ -7,6 +7,7 @@ const Blueprint = require('../../ember-cli/lib/models/blueprint');
 const getFiles = Blueprint.prototype.files;
 
 export default Blueprint.extend({
+  name: 'class',
   description: '',
   aliases: ['cl'],
 

--- a/packages/@angular/cli/blueprints/component/index.ts
+++ b/packages/@angular/cli/blueprints/component/index.ts
@@ -272,6 +272,7 @@ export default Blueprint.extend({
             this._writeStatusToUI(chalk.yellow,
               moduleStatus,
               path.relative(this.project.root, this.pathToModule));
+            this.addModifiedFile(this.pathToModule);
           }));
     }
 

--- a/packages/@angular/cli/blueprints/component/index.ts
+++ b/packages/@angular/cli/blueprints/component/index.ts
@@ -36,6 +36,7 @@ function correctCase(options: any) {
 }
 
 export default Blueprint.extend({
+  name: 'component',
   description: '',
   aliases: ['c'],
 

--- a/packages/@angular/cli/blueprints/directive/index.ts
+++ b/packages/@angular/cli/blueprints/directive/index.ts
@@ -14,6 +14,7 @@ const Blueprint = require('../../ember-cli/lib/models/blueprint');
 const getFiles = Blueprint.prototype.files;
 
 export default Blueprint.extend({
+  name: 'directive',
   description: '',
   aliases: ['d'],
 

--- a/packages/@angular/cli/blueprints/directive/index.ts
+++ b/packages/@angular/cli/blueprints/directive/index.ts
@@ -166,6 +166,7 @@ export default Blueprint.extend({
       this._writeStatusToUI(chalk.yellow,
         'update',
         path.relative(this.project.root, this.pathToModule));
+      this.addModifiedFile(this.pathToModule);
     }
 
     return Promise.all(returns);

--- a/packages/@angular/cli/blueprints/enum/index.ts
+++ b/packages/@angular/cli/blueprints/enum/index.ts
@@ -5,6 +5,7 @@ const stringUtils = require('ember-cli-string-utils');
 const Blueprint = require('../../ember-cli/lib/models/blueprint');
 
 export default Blueprint.extend({
+  name: 'enum',
   description: '',
   aliases: ['e'],
 

--- a/packages/@angular/cli/blueprints/guard/index.ts
+++ b/packages/@angular/cli/blueprints/guard/index.ts
@@ -111,6 +111,7 @@ export default Blueprint.extend({
       this._writeStatusToUI(chalk.yellow,
         'update',
         path.relative(this.project.root, this.pathToModule));
+      this.addModifiedFile(this.pathToModule);
     }
 
     return Promise.all(returns);

--- a/packages/@angular/cli/blueprints/guard/index.ts
+++ b/packages/@angular/cli/blueprints/guard/index.ts
@@ -13,6 +13,7 @@ const astUtils = require('../../utilities/ast-utils');
 const getFiles = Blueprint.prototype.files;
 
 export default Blueprint.extend({
+  name: 'guard',
   description: '',
   aliases: ['g'],
 

--- a/packages/@angular/cli/blueprints/interface/index.ts
+++ b/packages/@angular/cli/blueprints/interface/index.ts
@@ -6,6 +6,7 @@ const stringUtils = require('ember-cli-string-utils');
 const Blueprint = require('../../ember-cli/lib/models/blueprint');
 
 export default Blueprint.extend({
+  name: 'interface',
   description: '',
   aliases: ['i'],
 

--- a/packages/@angular/cli/blueprints/module/index.ts
+++ b/packages/@angular/cli/blueprints/module/index.ts
@@ -7,6 +7,7 @@ const Blueprint   = require('../../ember-cli/lib/models/blueprint');
 const getFiles = Blueprint.prototype.files;
 
 export default Blueprint.extend({
+  name: 'module',
   description: '',
   aliases: ['m'],
 

--- a/packages/@angular/cli/blueprints/pipe/index.ts
+++ b/packages/@angular/cli/blueprints/pipe/index.ts
@@ -144,6 +144,7 @@ export default Blueprint.extend({
         this._writeStatusToUI(chalk.yellow,
           'update',
           path.relative(this.project.root, this.pathToModule));
+        this.addModifiedFile(this.pathToModule);
     }
 
     return Promise.all(returns);

--- a/packages/@angular/cli/blueprints/pipe/index.ts
+++ b/packages/@angular/cli/blueprints/pipe/index.ts
@@ -13,6 +13,7 @@ const Blueprint = require('../../ember-cli/lib/models/blueprint');
 const getFiles = Blueprint.prototype.files;
 
 export default Blueprint.extend({
+  name: 'pipe',
   description: '',
   aliases: ['p'],
 

--- a/packages/@angular/cli/blueprints/service/index.ts
+++ b/packages/@angular/cli/blueprints/service/index.ts
@@ -123,6 +123,7 @@ export default Blueprint.extend({
       this._writeStatusToUI(chalk.yellow,
         'update',
         path.relative(this.project.root, this.pathToModule));
+      this.addModifiedFile(this.pathToModule);
     }
 
     return Promise.all(returns);

--- a/packages/@angular/cli/blueprints/service/index.ts
+++ b/packages/@angular/cli/blueprints/service/index.ts
@@ -13,6 +13,7 @@ const astUtils = require('../../utilities/ast-utils');
 const getFiles = Blueprint.prototype.files;
 
 export default Blueprint.extend({
+  name: 'service',
   description: '',
   aliases: ['s'],
 

--- a/packages/@angular/cli/commands/lint.ts
+++ b/packages/@angular/cli/commands/lint.ts
@@ -1,4 +1,5 @@
-import {oneLine} from 'common-tags';
+import { oneLine } from 'common-tags';
+import { CliConfig } from '../models/config';
 
 const Command = require('../ember-cli/lib/models/command');
 
@@ -52,6 +53,9 @@ export default Command.extend({
       project: this.project
     });
 
-    return lintTask.run(commandOptions);
+    return lintTask.run({
+      ...commandOptions,
+      configs: CliConfig.fromProject().config.lint
+    });
   }
 });

--- a/packages/@angular/cli/ember-cli/lib/models/blueprint.js
+++ b/packages/@angular/cli/ember-cli/lib/models/blueprint.js
@@ -364,6 +364,13 @@ Blueprint.prototype._writeStatusToUI = function(chalkColor, keyword, message) {
   }
 };
 
+Blueprint.prototype.addModifiedFile = function(file) {
+  if (!this.modifiedFiles) {
+    this.modifiedFiles = [];
+  }
+  this.modifiedFiles.push(file);
+}
+
 /**
   @private
   @method _writeFile
@@ -372,6 +379,7 @@ Blueprint.prototype._writeStatusToUI = function(chalkColor, keyword, message) {
 */
 Blueprint.prototype._writeFile = function(info) {
   if (!this.dryRun) {
+    this.addModifiedFile(info.outputPath);
     return writeFile(info.outputPath, info.render());
   }
 };

--- a/packages/@angular/cli/lib/config/schema.json
+++ b/packages/@angular/cli/lib/config/schema.json
@@ -299,6 +299,11 @@
           "description": "How often to check for file updates.",
           "type": "number"
         },
+        "lintFix": {
+          "description": "Use lint to fix files after generation",
+          "type": "boolean",
+          "default": false
+        },
         "class": {
           "description": "Options for generating a class.",
           "type": "object",

--- a/packages/@angular/cli/tasks/lint.ts
+++ b/packages/@angular/cli/tasks/lint.ts
@@ -4,27 +4,37 @@ import * as glob from 'glob';
 import * as path from 'path';
 import * as ts from 'typescript';
 import { requireProjectModule } from '../utilities/require-project-module';
-import { CliConfig } from '../models/config';
-import { LintCommandOptions } from '../commands/lint';
 
 const SilentError = require('silent-error');
 const Task = require('../ember-cli/lib/models/task');
 
-interface CliLintConfig {
+export interface CliLintConfig {
   files?: (string | string[]);
   project?: string;
   tslintConfig?: string;
   exclude?: (string | string[]);
 }
 
+export class LintTaskOptions {
+  fix: boolean;
+  force: boolean;
+  format? = 'prose';
+  silent? = false;
+  typeCheck? = false;
+  configs: Array<CliLintConfig>;
+}
+
 export default Task.extend({
-  run: function (commandOptions: LintCommandOptions) {
+  run: function (options: LintTaskOptions) {
+    options = { ...new LintTaskOptions(), ...options };
     const ui = this.ui;
     const projectRoot = this.project.root;
-    const lintConfigs: CliLintConfig[] = CliConfig.fromProject().config.lint || [];
+    const lintConfigs = options.configs || [];
 
     if (lintConfigs.length === 0) {
-      ui.writeLine(chalk.yellow('No lint configuration(s) found.'));
+      if (!options.silent) {
+        ui.writeLine(chalk.yellow('No lint configuration(s) found.'));
+      }
       return Promise.resolve(0);
     }
 
@@ -37,15 +47,17 @@ export default Task.extend({
         let program: ts.Program;
         if (config.project) {
           program = Linter.createProgram(config.project);
-        } else if (commandOptions.typeCheck) {
-          ui.writeLine(chalk.yellow('A "project" must be specified to enable type checking.'));
+        } else if (options.typeCheck) {
+          if (!options.silent) {
+            ui.writeLine(chalk.yellow('A "project" must be specified to enable type checking.'));
+          }
         }
         const files = getFilesToLint(program, config, Linter);
         const lintOptions = {
-          fix: commandOptions.fix,
-          formatter: commandOptions.format
+          fix: options.fix,
+          formatter: options.format
         };
-        const lintProgram = commandOptions.typeCheck ? program : undefined;
+        const lintProgram = options.typeCheck ? program : undefined;
         const linter = new Linter(lintOptions, lintProgram);
 
         let lastDirectory: string;
@@ -82,26 +94,35 @@ export default Task.extend({
         fixes: undefined
       });
 
-    const Formatter = tslint.findFormatter(commandOptions.format);
-    const formatter = new Formatter();
+    if (!options.silent) {
+      const Formatter = tslint.findFormatter(options.format);
+      if (!Formatter) {
+        throw new SilentError(chalk.red(`Invalid lint format "${options.format}".`));
+      }
+      const formatter = new Formatter();
 
-    const output = formatter.format(result.failures, result.fixes);
-    if (output) {
-      ui.writeLine(output);
+      const output = formatter.format(result.failures, result.fixes);
+      if (output) {
+        ui.writeLine(output);
+      }
     }
 
     // print formatter output directly for non human-readable formats
-    if (['prose', 'verbose', 'stylish'].indexOf(commandOptions.format) == -1) {
-      return (result.failures.length == 0 || commandOptions.force)
+    if (['prose', 'verbose', 'stylish'].indexOf(options.format) == -1) {
+      return (result.failures.length == 0 || options.force)
         ? Promise.resolve(0) : Promise.resolve(2);
     }
 
     if (result.failures.length > 0) {
-      ui.writeLine(chalk.red('Lint errors found in the listed files.'));
-      return commandOptions.force ? Promise.resolve(0) : Promise.resolve(2);
+      if (!options.silent) {
+        ui.writeLine(chalk.red('Lint errors found in the listed files.'));
+      }
+      return options.force ? Promise.resolve(0) : Promise.resolve(2);
     }
 
-    ui.writeLine(chalk.green('All files pass linting.'));
+    if (!options.silent) {
+      ui.writeLine(chalk.green('All files pass linting.'));
+    }
     return Promise.resolve(0);
   }
 });
@@ -109,7 +130,7 @@ export default Task.extend({
 function getFilesToLint(program: ts.Program, lintConfig: CliLintConfig, Linter: any): string[] {
   let files: string[] = [];
 
-  if (lintConfig.files !== null) {
+  if (lintConfig.files) {
     files = Array.isArray(lintConfig.files) ? lintConfig.files : [lintConfig.files];
   } else if (program) {
     files = Linter.getFileNames(program);
@@ -117,7 +138,7 @@ function getFilesToLint(program: ts.Program, lintConfig: CliLintConfig, Linter: 
 
   let globOptions = {};
 
-  if (lintConfig.exclude !== null) {
+  if (lintConfig.exclude) {
     const excludePatterns = Array.isArray(lintConfig.exclude)
       ? lintConfig.exclude
       : [lintConfig.exclude];

--- a/tests/e2e/tests/generate/lint-fix.ts
+++ b/tests/e2e/tests/generate/lint-fix.ts
@@ -1,0 +1,37 @@
+import { ng } from '../../utils/process';
+import { writeFile } from '../../utils/fs';
+import { expectToFail } from '../../utils/utils';
+
+export default function () {
+  const nestedConfigContent = `
+  {
+    "rules": {
+      "quotemark": [
+        true,
+        "double",
+        "avoid-escape"
+      ]
+    }
+  }`;
+
+  return Promise.resolve()
+    // setup a double-quote tslint config
+    .then(() => writeFile('src/app/tslint.json', nestedConfigContent))
+
+    // Generate a fixed new component but don't fix rest of app
+    .then(() => ng('generate', 'component', 'test-component1', '--lint-fix'))
+    .then(() => expectToFail(() => ng('lint')))
+
+    // Fix rest of app and generate new component
+    .then(() => ng('lint', '--fix'))
+    .then(() => ng('generate', 'component', 'test-component2', '--lint-fix'))
+    .then(() => ng('lint'))
+
+    // Enable default option and generate all other module related blueprints
+    .then(() => ng('set', 'defaults.lintFix', 'true'))
+    .then(() => ng('generate', 'directive', 'test-directive'))
+    .then(() => ng('generate', 'service', 'test-service', '--module', 'app.module.ts'))
+    .then(() => ng('generate', 'pipe', 'test-pipe'))
+    .then(() => ng('generate', 'guard', 'test-guard', '--module', 'app.module.ts'))
+    .then(() => ng('lint'));
+}

--- a/tests/e2e/tests/lint/lint-no-project.ts
+++ b/tests/e2e/tests/lint/lint-no-project.ts
@@ -1,0 +1,26 @@
+import { ng } from '../../utils/process';
+import { writeFile } from '../../utils/fs';
+import { expectToFail } from '../../utils/utils';
+import { oneLine } from 'common-tags';
+
+export default function () {
+  return Promise.resolve()
+    .then(() => ng('set', 'lint.0.project', ''))
+    .then(() => ng('lint', '--type-check'))
+    .then(({ stdout }) => {
+      if (!stdout.match(/A "project" must be specified to enable type checking./)) {
+        throw new Error(oneLine`
+          Expected to match "A "project" must be specified to enable type checking."
+          in ${stdout}.
+        `);
+      }
+
+      return stdout;
+    })
+    .then(() => ng('set', 'lint.0.files', '"**/baz.ts"'))
+    .then(() => writeFile('src/app/foo.ts', 'const foo = "";\n'))
+    .then(() => writeFile('src/app/baz.ts', 'const baz = \'\';\n'))
+    .then(() => ng('lint'))
+    .then(() => ng('set', 'lint.0.files', '"**/foo.ts"'))
+    .then(() => expectToFail(() => ng('lint')));
+}


### PR DESCRIPTION
This adds the `--lint-fix` option to all generate commands which will execute a lint fix task on (and only on) the modified files resulting from the generate command.  There is also an `.angular-cli.json` option `defaults.lintFix` to enable the option for the project or globally.

This feature was created via several commits due to several foundational changes that were required.  As a bonus, the lint configuration now also allows the `files` option to be used without the `project` option.

Closes #6192