### PR TITLE
chore(@angular/cli): bump karma-chrome-launcher

### DIFF
--- a/packages/@angular/cli/blueprints/ng/files/package.json
+++ b/packages/@angular/cli/blueprints/ng/files/package.json
@@ -34,7 +34,7 @@
     "jasmine-core": "~2.5.2",
     "jasmine-spec-reporter": "~3.2.0",
     "karma": "~1.4.1",
-    "karma-chrome-launcher": "~2.0.0",
+    "karma-chrome-launcher": "~2.1.1",
     "karma-cli": "~1.0.1",
     "karma-jasmine": "~1.1.0",
     "karma-jasmine-html-reporter": "^0.2.2",


### PR DESCRIPTION
Bumps to the freshly new released karma-chrome-launcher 2.1.1, which includes the flag we were talking about with @filipesilva an @mgol in https://github.com/angular/angular-cli/pull/6160#issuecomment-299416226

This solves the slowness when running unit-tests in the background on Chrome/macOS.

Also note that karma-chrome-launcher 2.1.0 added the support for Chrome headless, so the move to this newer version is really interesting.