### PR TITLE
fix(@angular/cli): language-service as devDeps only

### DIFF
--- a/packages/@angular/cli/blueprints/ng/files/package.json
+++ b/packages/@angular/cli/blueprints/ng/files/package.json
@@ -18,7 +18,6 @@
     "@angular/core": "^4.0.0",
     "@angular/forms": "^4.0.0",
     "@angular/http": "^4.0.0",
-    "@angular/language-service": "^4.0.0",
     "@angular/platform-browser": "^4.0.0",
     "@angular/platform-browser-dynamic": "^4.0.0",
     "@angular/router": "^4.0.0",


### PR DESCRIPTION
`@angular/language-service` is listed in both `dependencies` and `devDependencies` in `1.1.0-beta.1`. I think it should only be `devDependencies`.