### PR TITLE
fix(@angular/cli): Fixed e2e task to respect --publicHost setting as baseUrl for protractor

### DIFF
--- a/packages/@angular/cli/tasks/e2e.ts
+++ b/packages/@angular/cli/tasks/e2e.ts
@@ -26,7 +26,17 @@ export const E2eTask = Task.extend({
       };
 
       // use serve url as override for protractors baseUrl
-      if (e2eTaskOptions.serve) {
+      if (e2eTaskOptions.serve && e2eTaskOptions.publicHost) {
+        const clientUrl = url.parse(e2eTaskOptions.publicHost);
+        if (!clientUrl.host) {
+          return Promise.reject(new SilentError(`'publicHost' must be a full URL.`));
+        }
+        additionalProtractorConfig.baseUrl = url.format({
+          protocol: e2eTaskOptions.ssl ? 'https' : 'http',
+          hostname: clientUrl.host,
+          port: clientUrl.port
+        });
+      } else if (e2eTaskOptions.serve) {
         additionalProtractorConfig.baseUrl = url.format({
           protocol: e2eTaskOptions.ssl ? 'https' : 'http',
           hostname: e2eTaskOptions.host,

--- a/packages/@angular/cli/tasks/e2e.ts
+++ b/packages/@angular/cli/tasks/e2e.ts
@@ -27,13 +27,13 @@ export const E2eTask = Task.extend({
 
       // use serve url as override for protractors baseUrl
       if (e2eTaskOptions.serve && e2eTaskOptions.publicHost) {
-        const clientUrl = url.parse(e2eTaskOptions.publicHost);
-        if (!clientUrl.hostname) {
-          return Promise.reject(new SilentError(`'public-host' must be a full URL.`));
+        let publicHost = e2eTaskOptions.publicHost;
+        if (!/^\w+:\/\//.test(publicHost)) {
+          publicHost = `${e2eTaskOptions.ssl ? 'https' : 'http'}://${publicHost}`;
         }
-
-        const protocol = e2eTaskOptions.ssl ? 'https' : 'http';
-        additionalProtractorConfig.baseUrl = `${protocol}://${clientUrl.href}`;
+        const clientUrl = url.parse(publicHost);
+        e2eTaskOptions.publicHost = clientUrl.host;
+        additionalProtractorConfig.baseUrl = url.format(clientUrl);
       } else if (e2eTaskOptions.serve) {
         additionalProtractorConfig.baseUrl = url.format({
           protocol: e2eTaskOptions.ssl ? 'https' : 'http',

--- a/packages/@angular/cli/tasks/e2e.ts
+++ b/packages/@angular/cli/tasks/e2e.ts
@@ -31,6 +31,7 @@ export const E2eTask = Task.extend({
         if (!clientUrl.hostname) {
           return Promise.reject(new SilentError(`'public-host' must be a full URL.`));
         }
+
         const protocol = e2eTaskOptions.ssl ? 'https' : 'http';
         additionalProtractorConfig.baseUrl = `${protocol}://${clientUrl.href}`;
       } else if (e2eTaskOptions.serve) {

--- a/packages/@angular/cli/tasks/e2e.ts
+++ b/packages/@angular/cli/tasks/e2e.ts
@@ -32,7 +32,7 @@ export const E2eTask = Task.extend({
           return Promise.reject(new SilentError(`'public-host' must be a full URL.`));
         }
         const protocol = e2eTaskOptions.ssl ? 'https' : 'http';
-        additionalProtractorConfig.baseUrl = `${protocol}://${clientUrl.href}`
+        additionalProtractorConfig.baseUrl = `${protocol}://${clientUrl.href}`;
       } else if (e2eTaskOptions.serve) {
         additionalProtractorConfig.baseUrl = url.format({
           protocol: e2eTaskOptions.ssl ? 'https' : 'http',

--- a/packages/@angular/cli/tasks/e2e.ts
+++ b/packages/@angular/cli/tasks/e2e.ts
@@ -28,12 +28,12 @@ export const E2eTask = Task.extend({
       // use serve url as override for protractors baseUrl
       if (e2eTaskOptions.serve && e2eTaskOptions.publicHost) {
         const clientUrl = url.parse(e2eTaskOptions.publicHost);
-        if (!clientUrl.host) {
+        if (!clientUrl.hostname) {
           return Promise.reject(new SilentError(`'publicHost' must be a full URL.`));
         }
         additionalProtractorConfig.baseUrl = url.format({
           protocol: e2eTaskOptions.ssl ? 'https' : 'http',
-          hostname: clientUrl.host,
+          hostname: clientUrl.hostname,
           port: clientUrl.port
         });
       } else if (e2eTaskOptions.serve) {

--- a/packages/@angular/cli/tasks/e2e.ts
+++ b/packages/@angular/cli/tasks/e2e.ts
@@ -29,13 +29,10 @@ export const E2eTask = Task.extend({
       if (e2eTaskOptions.serve && e2eTaskOptions.publicHost) {
         const clientUrl = url.parse(e2eTaskOptions.publicHost);
         if (!clientUrl.hostname) {
-          return Promise.reject(new SilentError(`'publicHost' must be a full URL.`));
+          return Promise.reject(new SilentError(`'public-host' must be a full URL.`));
         }
-        additionalProtractorConfig.baseUrl = url.format({
-          protocol: e2eTaskOptions.ssl ? 'https' : 'http',
-          hostname: clientUrl.hostname,
-          port: clientUrl.port
-        });
+        const protocol = e2eTaskOptions.ssl ? 'https' : 'http';
+        additionalProtractorConfig.baseUrl = `${protocol}://${clientUrl.href}`
       } else if (e2eTaskOptions.serve) {
         additionalProtractorConfig.baseUrl = url.format({
           protocol: e2eTaskOptions.ssl ? 'https' : 'http',

--- a/packages/@angular/cli/tasks/serve.ts
+++ b/packages/@angular/cli/tasks/serve.ts
@@ -67,6 +67,13 @@ export default Task.extend({
       const clientUrl = url.parse(publicHost);
       serveTaskOptions.publicHost = clientUrl.host;
       clientAddress = url.format(clientUrl);
+
+      // if (!clientUrl.href.startsWith('http')) {
+      //   const protocol = serveTaskOptions.ssl ? 'https' : 'http';
+      //   clientAddress = `${protocol}://${clientUrl.href}`;
+      // } else {
+      //   clientAddress = clientUrl.href;
+      // }
     }
 
     if (serveTaskOptions.liveReload) {

--- a/packages/@angular/cli/tasks/serve.ts
+++ b/packages/@angular/cli/tasks/serve.ts
@@ -67,13 +67,6 @@ export default Task.extend({
       const clientUrl = url.parse(publicHost);
       serveTaskOptions.publicHost = clientUrl.host;
       clientAddress = url.format(clientUrl);
-
-      // if (!clientUrl.href.startsWith('http')) {
-      //   const protocol = serveTaskOptions.ssl ? 'https' : 'http';
-      //   clientAddress = `${protocol}://${clientUrl.href}`;
-      // } else {
-      //   clientAddress = clientUrl.href;
-      // }
     }
 
     if (serveTaskOptions.liveReload) {

--- a/tests/e2e/tests/misc/live-reload.ts
+++ b/tests/e2e/tests/misc/live-reload.ts
@@ -1,7 +1,9 @@
+import * as os from 'os';
+import * as _ from 'lodash';
 import * as express from 'express';
 import * as http from 'http';
 
-import { appendToFile, writeMultipleFiles } from '../../utils/fs';
+import {appendToFile, writeMultipleFiles, writeFile} from '../../utils/fs';
 import {
   killAllProcesses,
   silentExecAndWaitForOutputToMatch,
@@ -24,10 +26,26 @@ export default function () {
 
   server.listen(0);
   app.set('port', server.address().port);
+
+  const firstLocalIp = _(os.networkInterfaces())
+    .values()
+    .flatten()
+    .filter({ family: 'IPv4', internal: false })
+    .map('address')
+    .first();
+  const publicHost = `${firstLocalIp}:4200`;
+
   const apiUrl = `http://localhost:${server.address().port}`;
 
   // This endpoint will be pinged by the main app on each reload.
   app.get('/live-reload-count', _ => liveReloadCount++);
+
+  const proxyConfigFile = 'proxy.config.json';
+  const proxyConfig = {
+    '/live-reload-count': {
+      target: apiUrl
+    }
+  };
 
   return Promise.resolve()
     .then(_ => writeMultipleFiles({
@@ -111,6 +129,40 @@ export default function () {
       if (liveReloadCount != 1) {
         throw new Error(
           `Expected API to have been called 1 time but it was called ${liveReloadCount} times.`
+        );
+      }
+    })
+    .then(_ => killAllProcesses(), (err) => { killAllProcesses(); throw err; })
+    .then(_ => resetApiVars())
+    // Serve with live reload client set to api should call api.
+    .then(() => writeFile(proxyConfigFile, JSON.stringify(proxyConfig, null, 2)))
+    // Update the component to call the webserver
+    .then(() => writeFile('./src/app/app.component.ts',
+      `
+        import { Component } from '@angular/core';
+        import { Http } from '@angular/http';
+        @Component({
+          selector: 'app-root',
+          template: '<h1>Live reload test</h1>'
+        })
+        export class AppComponent {
+          constructor(private http: Http) {
+            http.get('http://${publicHost + '/live-reload-count'}').subscribe(res => null);
+          }
+        }`))
+    .then(_ => silentExecAndWaitForOutputToMatch(
+      'ng',
+      ['e2e', '--watch', '--host=0.0.0.0', '--port=4200', `--public-host=${publicHost}`, '--proxy', proxyConfigFile],
+      protractorGoodRegEx
+    ))
+    .then(_ => wait(2000))
+    .then(_ => appendToFile('src/main.ts', 'console.log(1);'))
+    .then(_ => waitForAnyProcessOutputToMatch(webpackGoodRegEx, 5000))
+    .then(_ => wait(2000))
+    .then(_ => {
+      if (liveReloadCount != 2) {
+        throw new Error(
+          `Expected API to have been called 2 times but it was called ${liveReloadCount} times.`
         );
       }
     })

--- a/tests/e2e/tests/misc/live-reload.ts
+++ b/tests/e2e/tests/misc/live-reload.ts
@@ -28,6 +28,10 @@ export default function () {
   app.set('port', server.address().port);
   const apiUrl = `http://localhost:${server.address().port}`;
 
+  // Use a diffrent, but defined port for the webserver
+  const webserverPort = server.address().port + 1;
+  const webserverUrl = `http://localhost:${webserverPort}`;
+
   // This endpoint will be pinged by the main app on each reload.
   app.get('/live-reload-count', _ => liveReloadCount++);
   // This endpoint will be pinged by webpack to check for live reloads.
@@ -124,7 +128,7 @@ export default function () {
     // Serve with live reload client set to api should call api.
     .then(_ => silentExecAndWaitForOutputToMatch(
       'ng',
-      ['e2e', '--watch', `--public-host=${apiUrl}`],
+      ['e2e', '--watch', `--port=${webserverPort}`,`--public-host=${webserverUrl}`],
       protractorGoodRegEx
     ))
     .then(_ => wait(2000))


### PR DESCRIPTION
#6173 added two new settings to the serve task. The --publicHost setting is not respected as baseUrl
for protractor in the e2e-task.

With this fix, if --publicHost is set, it will be used as baseUrl for protrator.

Not sure why 1.1.0-beta.1 is not yet on master, but this fix would be for that revision (https://github.com/angular/angular-cli/tree/v1.1.0-beta.1)