### PR TITLE
feat(@angular/cli): import TypeScript helpers instead of inlining

### DIFF
--- a/packages/@angular/cli/blueprints/ng/files/__path__/tsconfig.app.json
+++ b/packages/@angular/cli/blueprints/ng/files/__path__/tsconfig.app.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "outDir": "<%= relativeRootPath %>/out-tsc/app",
     "module": "es2015",
+    "importHelpers": true,
     "baseUrl": "",
     "types": []
   },

--- a/packages/@angular/cli/blueprints/ng/files/package.json
+++ b/packages/@angular/cli/blueprints/ng/files/package.json
@@ -26,6 +26,7 @@
     "@angular/router": "^4.2.4",
     "core-js": "^2.4.1",
     "rxjs": "^5.4.1",
+    "tslib": "~1.7.1",
     "zone.js": "^0.8.12"
   },
   "devDependencies": {


### PR DESCRIPTION
This should reduce overall bundle sizes by eliminating the repeated inlining of various typescript helpers within each source module.