### PR TITLE
fix(@angular/cli): prefix `historyApiFallback.index` with `deployUrl`

### DIFF
--- a/packages/@angular/cli/tasks/serve.ts
+++ b/packages/@angular/cli/tasks/serve.ts
@@ -177,6 +177,8 @@ export default Task.extend({
     // set publicPath property to be sent on webpack server config
     if (serveTaskOptions.deployUrl) {
       webpackDevServerConfiguration.publicPath = serveTaskOptions.deployUrl;
+      (webpackDevServerConfiguration.historyApiFallback as any).index =
+        serveTaskOptions.deployUrl + `/${appConfig.index}`;
     }
 
     if (serveTaskOptions.target === 'production') {

--- a/tests/e2e/tests/misc/deploy-url.ts
+++ b/tests/e2e/tests/misc/deploy-url.ts
@@ -1,14 +1,18 @@
 import { killAllProcesses } from '../../utils/process';
 import { request } from '../../utils/http';
-import { expectToFail } from '../../utils/utils';
 import { ngServe } from '../../utils/project';
 
 export default function () {
   return Promise.resolve()
     // check when setup through command line arguments
-    .then(() => ngServe('--deploy-url', '/deployurl', '--base-href', '/deployurl'))
-    .then(() => expectToFail(() => request('http://localhost:4200')))
-    .then(() => request('http://localhost:4200/deployurl'))
+    .then(() => ngServe('--deploy-url', '/deployurl/', '--base-href', '/deployurl/'))
+    .then(() => request('http://localhost:4200'))
+    .then(body => {
+      if (!body.match(/<app-root><\/app-root>/)) {
+        throw new Error('Response does not match expected value.');
+      }
+    })
+    .then(() => request('http://localhost:4200/deployurl/'))
     .then(body => {
       if (!body.match(/<app-root><\/app-root>/)) {
         throw new Error('Response does not match expected value.');


### PR DESCRIPTION
when implementing i18n following https://angular.io/docs/ts/latest/cookbook/i18n.html
and https://medium.com/@feloy/deploying-an-i18n-angular-app-with-angular-cli-fc788f17e358

when running in `development` to be consistent with `production` I am using

```
ng serve --deploy-url /en/ --base-href /en/ \
--aot --locale en --i18n-file ./src/locale/messages.en.xlf
```

running the app this way, on routes other than `http://localhost:4200/en/`
the `webpack-dev-server` was always saying that the route is not found,
so this commit fixes that