### PR TITLE
feat(@angular/cli): load reflect only on dev

### DIFF
--- a/packages/@angular/cli/blueprints/ng/files/__path__/environments/environment.ts
+++ b/packages/@angular/cli/blueprints/ng/files/__path__/environments/environment.ts
@@ -3,6 +3,11 @@
 // `ng build --env=prod` then `environment.prod.ts` will be used instead.
 // The list of which env maps to which file can be found in `.angular-cli.json`.
 
+// Evergreen browsers require these polyfills on non-aot builds.
+// If you need to use `--prod --no-aot` you should transfer these over to `polyfills.ts`.
+import 'core-js/es6/reflect';
+import 'core-js/es7/reflect';
+
 export const environment = {
   production: false
 };

--- a/packages/@angular/cli/blueprints/ng/files/__path__/polyfills.ts
+++ b/packages/@angular/cli/blueprints/ng/files/__path__/polyfills.ts
@@ -37,10 +37,6 @@
 /** IE10 and IE11 requires the following for NgClass support on SVG elements */
 // import 'classlist.js';  // Run `npm install --save classlist.js`.
 
-/** Evergreen browsers require these. **/
-import 'core-js/es6/reflect';
-import 'core-js/es7/reflect';
-
 
 /**
  * Required to support Web Animations `@angular/animation`.
@@ -70,3 +66,6 @@ import 'zone.js/dist/zone';  // Included with Angular CLI.
  * Need to import at least one locale-data with intl.
  */
 // import 'intl/locale-data/jsonp/en';
+
+// Each environment can have different polyfills as well.
+import './environments/environment';


### PR DESCRIPTION
`reflect-metadata` is not needed in AOT builds. It's the biggest polyfill and the cause for a significant startup time increase.

Note: this will make `ng build --prod --no-aot` builds for new projects not work. The workaround is to move `reflect-metadata` back into the common polyfills. We should discuss if this is ok.

Fix https://github.com/angular/angular-cli/issues/6325