### PR TITLE
docs(@angular/cli): fixes wrong link on corporate proxy story

### DIFF
--- a/docs/documentation/stories/using-corporate-proxy.md
+++ b/docs/documentation/stories/using-corporate-proxy.md
@@ -2,7 +2,7 @@
 
 # Using corporate proxy
 
-If you work behind a corporate proxy, the regular [backend proxy](http://github.com/angular/angular-cli#proxy-to-backend) configuration will not work if you try to proxy calls to any URL outside your local network.
+If you work behind a corporate proxy, the regular [backend proxy](https://github.com/angular/angular-cli/wiki/stories-proxy) configuration will not work if you try to proxy calls to any URL outside your local network.
 
 In this case, you can configure the backend proxy to redirect calls through your corporate proxy using an agent:
 


### PR DESCRIPTION
I think this link might be outdated.