### PR TITLE
refactor(@angular/cli): use memory FS for i18n extraction

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "loader-utils": "^1.0.2",
     "lodash": "^4.11.1",
     "magic-string": "^0.19.0",
+    "memory-fs": "^0.4.1",
     "minimatch": "^3.0.3",
     "node-modules-path": "^1.0.0",
     "nopt": "^4.0.1",

--- a/packages/@angular/cli/package.json
+++ b/packages/@angular/cli/package.json
@@ -53,6 +53,7 @@
     "less": "^2.7.2",
     "less-loader": "^4.0.2",
     "lodash": "^4.11.1",
+    "memory-fs": "^0.4.1",
     "minimatch": "^3.0.3",
     "node-modules-path": "^1.0.0",
     "nopt": "^4.0.1",


### PR DESCRIPTION
Eliminates the need to write and then delete the build output.

`memory-fs` was an existing transitive dependency that was moved to a direct dependency due to its now explicit usage.