### PR TITLE
feat(@angular/cli): add option to set dev server's base serve path

### DIFF
--- a/packages/@angular/cli/commands/serve.ts
+++ b/packages/@angular/cli/commands/serve.ts
@@ -26,6 +26,7 @@ export interface ServeTaskOptions extends BuildOptions {
   sslCert?: string;
   open?: boolean;
   hmr?: boolean;
+  servePath?: string;
 }
 
 // Expose options unrelated to live-reload to other commands that need to run serve
@@ -95,6 +96,11 @@ export const baseServeCommandOptions: any = overrideOptions([
     type: Boolean,
     default: false,
     description: 'Don\'t verify connected clients are part of allowed hosts.',
+  },
+  {
+    name: 'serve-path',
+    type: String,
+    description: 'The pathname where the app will be served.'
   },
   {
     name: 'hmr',

--- a/tests/e2e/tests/commands/serve/serve-path.ts
+++ b/tests/e2e/tests/commands/serve/serve-path.ts
@@ -1,0 +1,29 @@
+import { request } from '../../../utils/http';
+import { killAllProcesses } from '../../../utils/process';
+import { ngServe } from '../../../utils/project';
+
+export default function () {
+  return Promise.resolve()
+    .then(() => ngServe('--serve-path', 'test/'))
+    .then(() => request('http://localhost:4200/test'))
+    .then(body => {
+      if (!body.match(/<app-root><\/app-root>/)) {
+        throw new Error('Response does not match expected value.');
+      }
+    })
+    .then(() => request('http://localhost:4200/test/abc'))
+    .then(body => {
+      if (!body.match(/<app-root><\/app-root>/)) {
+        throw new Error('Response does not match expected value.');
+      }
+    })
+    .then(() => killAllProcesses(), (err) => { killAllProcesses(); throw err; })
+    .then(() => ngServe('--base-href', 'test/'))
+    .then(() => request('http://localhost:4200/test'))
+    .then(body => {
+      if (!body.match(/<app-root><\/app-root>/)) {
+        throw new Error('Response does not match expected value.');
+      }
+    })
+    .then(() => killAllProcesses(), (err) => { killAllProcesses(); throw err; });
+}


### PR DESCRIPTION
Allows `ng serve` to be configured to serve the application at a path other than the root via a new `--serve-path` option.  The option will default to a combination of the `--base-href` and `--deploy-url`, if present.

Closes #6289