### PR TITLE
fix(@angular/cli): put vendor ngfactory in vendor chunk

### DIFF
--- a/packages/@angular/cli/models/webpack-configs/browser.ts
+++ b/packages/@angular/cli/models/webpack-configs/browser.ts
@@ -12,7 +12,6 @@ export function getBrowserConfig(wco: WebpackConfigOptions) {
   const { projectRoot, buildOptions, appConfig } = wco;
 
   const appRoot = path.resolve(projectRoot, appConfig.root);
-  const nodeModules = path.resolve(projectRoot, 'node_modules');
 
   let extraPlugins: any[] = [];
 
@@ -23,10 +22,16 @@ export function getBrowserConfig(wco: WebpackConfigOptions) {
   ]);
 
   if (buildOptions.vendorChunk) {
+    // Separate modules from node_modules into a vendor chunk.
+    const nodeModules = path.resolve(projectRoot, 'node_modules');
+    // --aot puts the generated *.ngfactory.ts in src/$$_gendir/node_modules.
+    const genDirNodeModules = path.resolve(appRoot, '$$_gendir', 'node_modules');
+
     extraPlugins.push(new webpack.optimize.CommonsChunkPlugin({
       name: 'vendor',
       chunks: ['main'],
-      minChunks: (module: any) => module.resource && module.resource.startsWith(nodeModules)
+      minChunks: (module: any) => module.resource &&
+        (module.resource.startsWith(nodeModules) || module.resource.startsWith(genDirNodeModules))
     }));
   }
 

--- a/packages/@angular/cli/tasks/eject.ts
+++ b/packages/@angular/cli/tasks/eject.ts
@@ -39,11 +39,13 @@ class JsonWebpackSerializer {
   };
   public variables: {[name: string]: string} = {
     'nodeModules': `path.join(process.cwd(), 'node_modules')`,
+    'genDirNodeModules':
+      `path.join(process.cwd(), '${this._appRoot}', '$$_gendir', 'node_modules')`,
   };
   private _postcssProcessed = false;
 
 
-  constructor(private _root: string, private _dist: string) {}
+  constructor(private _root: string, private _dist: string, private _appRoot: string) {}
 
   private _escape(str: string) {
     return '\uFF01' + str + '\uFF01';
@@ -398,7 +400,7 @@ export default Task.extend({
     }
 
     const webpackConfig = new NgCliWebpackConfig(runTaskOptions, appConfig).buildConfig();
-    const serializer = new JsonWebpackSerializer(process.cwd(), outputPath);
+    const serializer = new JsonWebpackSerializer(process.cwd(), outputPath, appConfig.root);
     const output = serializer.serialize(webpackConfig);
     const webpackConfigStr = `${serializer.generateVariables()}\n\nmodule.exports = ${output};\n`;
 


### PR DESCRIPTION
Currently vendor Angular libraries will have their *.ngfactory.ts in main.ts when building with `--aot`.

The easiest way to see this is with `source-map-explorer.

This PR correctly puts them in vendor.ts.

/cc @clydin @johnpapa