### PR TITLE
feat(@angular/cli): include empty 'exports' property in 'ng g module'

### DIFF
--- a/packages/@angular/cli/blueprints/module/files/__path__/__name__.module.ts
+++ b/packages/@angular/cli/blueprints/module/files/__path__/__name__.module.ts
@@ -8,6 +8,7 @@ import { <%= classifiedModuleName %>RoutingModule } from './<%= dasherizedModule
     CommonModule<% if (routing) { %>,
     <%= classifiedModuleName %>RoutingModule<% } %>
   ],
-  declarations: []
+  declarations: [],
+  exports: []
 })
 export class <%= classifiedModuleName %>Module { }


### PR DESCRIPTION
fixes #6312 