### PR TITLE
docs(@angular/cli): fix reference to prod and dev build flags

### DIFF
--- a/docs/documentation/build.md
+++ b/docs/documentation/build.md
@@ -35,12 +35,12 @@ it will default to `dev` for `development` and `prod` for `production`.
 ```bash
 # these are equivalent
 ng build --target=production --environment=prod
-ng build --prod --env=prod
-ng build --prod
+ng build -prod --env=prod
+ng build -prod
 # and so are these
 ng build --target=development --environment=dev
-ng build --dev --e=dev
-ng build --dev
+ng build -dev --e=dev
+ng build -dev
 ng build
 ```
 
@@ -61,15 +61,15 @@ ng build --bh /myUrl/
 
 ### Bundling & Tree-Shaking
 
-All builds make use of bundling and limited tree-shaking, while `--prod` builds also run limited
+All builds make use of bundling and limited tree-shaking, while `-prod` builds also run limited
 dead code elimination via UglifyJS.
 
-### `--dev` vs `--prod` builds
+### `-dev` vs `-prod` builds
 
-Both `--dev`/`--target=development` and `--prod`/`--target=production` are 'meta' flags, that set other flags.
-If you do not specify either you will get the `--dev` defaults.
+Both `-dev`/`--target=development` and `-prod`/`--target=production` are 'meta' flags, that set other flags.
+If you do not specify either you will get the `-dev` defaults.
 
-Flag                | `--dev` | `--prod`
+Flag                | `-dev` | `-prod`
 ---                 | ---     | ---
 `--aot`             | `false` | `true`
 `--environment`     | `dev`   | `prod`
@@ -77,7 +77,7 @@ Flag                | `--dev` | `--prod`
 `--sourcemaps`      | `true`  | `false`
 `--extract-css`     | `false` | `true`
 
-`--prod` also sets the following non-flaggable settings:
+`-prod` also sets the following non-flaggable settings:
 - Adds service worker if configured in `.angular-cli.json`.
 - Replaces `process.env.NODE_ENV` in modules with the `production` value (this is needed for some libraries, like react).
 - Runs UglifyJS on the code.
@@ -98,7 +98,7 @@ npm install @angular/service-worker --save
 ng set apps.0.serviceWorker=true
 ```
 
-On `--prod` builds a service worker manifest will be created and loaded automatically.
+On `-prod` builds a service worker manifest will be created and loaded automatically.
 Remember to disable the service worker while developing to avoid stale code.
 
 Note: service worker support is experimental and subject to change.


### PR DESCRIPTION
This should be a fix for #6383 which requests that the -prod and -dev flags all be called by their single-hyphen syntax.