### PR TITLE
fix(@angular/cli): remove broken script after eject

### DIFF
--- a/packages/@angular/cli/tasks/eject.ts
+++ b/packages/@angular/cli/tasks/eject.ts
@@ -427,12 +427,6 @@ export default Task.extend({
             Your package.json scripts must not contain a start script as it will be overwritten.
           `);
         }
-        if (scripts['pree2e'] && scripts['prepree2e'] !== 'npm start' && !force) {
-          throw new SilentError(oneLine`
-            Your package.json scripts needs to not contain a prepree2e script as it will be
-            overwritten.
-          `);
-        }
         if (scripts['pree2e'] && scripts['pree2e'] !== pree2eNpmScript && !force) {
           throw new SilentError(oneLine`
             Your package.json scripts must not contain a pree2e script as it will be
@@ -453,7 +447,6 @@ export default Task.extend({
         packageJson['scripts']['build'] = 'webpack';
         packageJson['scripts']['start'] = 'webpack-dev-server --port=4200';
         packageJson['scripts']['test'] = 'karma start ./karma.conf.js';
-        packageJson['scripts']['prepree2e'] = 'npm start';
         packageJson['scripts']['pree2e'] = pree2eNpmScript;
         packageJson['scripts']['e2e'] = 'protractor ./protractor.conf.js';
 


### PR DESCRIPTION
`prepree2e` doesn't run because it's a lifecycle script for a lifecycle script, but even if it did it would not work because there is nothing coordinating the serve and e2e processes.

Users must manually initialize the server prior to running e2e tests after ejecting.

Related to https://github.com/angular/angular-cli/issues/6171