### PR TITLE
refactor(@ngtools/webpack): refactor bootstrap refactoring

### DIFF
--- a/tests/e2e/assets/webpack/test-server-app/app/app.module.ts
+++ b/tests/e2e/assets/webpack/test-server-app/app/app.module.ts
@@ -24,4 +24,6 @@ export class HomeView {}
   ],
   bootstrap: [AppComponent]
 })
-export class AppModule { }
+export class AppModule {
+  static testProp: string;
+}

--- a/tests/e2e/assets/webpack/test-server-app/app/main.ts
+++ b/tests/e2e/assets/webpack/test-server-app/app/main.ts
@@ -1,7 +1,11 @@
 import 'core-js/es7/reflect';
-import {platformDynamicServer} from '@angular/platform-server';
+import {platformDynamicServer, renderModule} from '@angular/platform-server';
 import {AppModule} from './app.module';
 
 AppModule.testProp = 'testing';
 
 platformDynamicServer().bootstrapModule(AppModule);
+renderModule(AppModule, {
+  document: '<app-root></app-root>',
+  url: '/'
+});

--- a/tests/e2e/assets/webpack/test-server-app/app/main.ts
+++ b/tests/e2e/assets/webpack/test-server-app/app/main.ts
@@ -2,4 +2,6 @@ import 'core-js/es7/reflect';
 import {platformDynamicServer} from '@angular/platform-server';
 import {AppModule} from './app.module';
 
+AppModule.testProp = 'testing';
+
 platformDynamicServer().bootstrapModule(AppModule);

--- a/tests/e2e/tests/packages/webpack/server.ts
+++ b/tests/e2e/tests/packages/webpack/server.ts
@@ -17,6 +17,8 @@ export default function(skipCleaning: () => void) {
     .then(() => expectFileToMatch('dist/app.main.js',
       new RegExp('AppComponent.ctorParameters = .*MyInjectable'))
     .then(() => expectFileToMatch('dist/app.main.js',
-      /AppModule.*\.testProp = \'testing\'/)
+      /AppModule \*\/\].*\.testProp = \'testing\'/))
+    .then(() => expectFileToMatch('dist/app.main.js',
+      /renderModuleFactory \*\/\].*\/\* AppModuleNgFactory \*\/\]/))
     .then(() => skipCleaning());
 }

--- a/tests/e2e/tests/packages/webpack/server.ts
+++ b/tests/e2e/tests/packages/webpack/server.ts
@@ -16,5 +16,7 @@ export default function(skipCleaning: () => void) {
                + 'type: undefined, decorators.*Inject.*args: .*DOCUMENT.*'))
     .then(() => expectFileToMatch('dist/app.main.js',
       new RegExp('AppComponent.ctorParameters = .*MyInjectable'))
+    .then(() => expectFileToMatch('dist/app.main.js',
+      /AppModule.*\.testProp = \'testing\'/)
     .then(() => skipCleaning());
 }


### PR DESCRIPTION
Refactor _replaceBootstrap() so that it finds and replaces all references to the entry module.

Bonuses:
* Skips the gendir, the bootstrap is not going to be in there
* Switches out any mention of the entry module such as `@nguniversal/express-engine`
* Broke up code into more digestible bits and mitigates eventual complication of this function

Part 2:
Enable replacement of renderModule with renderModuleFactory