### PR TITLE
feat(@angular/cli): add option to preserve symlinks for module resolution

### DIFF
--- a/packages/@angular/cli/commands/build.ts
+++ b/packages/@angular/cli/commands/build.ts
@@ -125,6 +125,12 @@ export const baseBuildCommandOptions: any = [
     default: true,
     aliases: ['dop'],
     description: 'Delete output path before build.'
+  },
+  {
+    name: 'preserve-symlinks',
+    type: Boolean,
+    default: false,
+    description: 'Do not use the real path when resolving modules.'
   }
 ];
 

--- a/packages/@angular/cli/models/build-options.ts
+++ b/packages/@angular/cli/models/build-options.ts
@@ -18,4 +18,5 @@ export interface BuildOptions {
   poll?: number;
   app?: string;
   deleteOutputPath?: boolean;
+  preserveSymlinks?: boolean;
 }

--- a/packages/@angular/cli/models/webpack-configs/common.ts
+++ b/packages/@angular/cli/models/webpack-configs/common.ts
@@ -68,6 +68,7 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
     resolve: {
       extensions: ['.ts', '.js'],
       modules: ['node_modules', nodeModules],
+      symlinks: !buildOptions.preserveSymlinks
     },
     resolveLoader: {
       modules: [nodeModules]


### PR DESCRIPTION
Similar to the [NodeJS option](https://nodejs.org/api/cli.html#cli_preserve_symlinks) of the same name.

This provides additional support for linked packages and peer dependency usage scenarios.