### PR TITLE
feat(@angular/cli): add baseHref property to appConfig

### DIFF
--- a/packages/@angular/cli/lib/config/schema.json
+++ b/packages/@angular/cli/lib/config/schema.json
@@ -79,6 +79,10 @@
             "type": "string",
             "description": "URL where files will be deployed."
           },
+          "baseHref": {
+            "type": "string",
+            "description": "Base url for the application being built."
+          },
           "index": {
             "type": "string",
             "default": "index.html",

--- a/packages/@angular/cli/models/webpack-config.ts
+++ b/packages/@angular/cli/models/webpack-config.ts
@@ -97,7 +97,8 @@ export class NgCliWebpackConfig {
   public mergeConfigs(buildOptions: BuildOptions, appConfig: any) {
     const mergeableOptions = {
       outputPath: appConfig.outDir,
-      deployUrl: appConfig.deployUrl
+      deployUrl: appConfig.deployUrl,
+      baseHref: appConfig.baseHref
     };
 
     return Object.assign({}, mergeableOptions, buildOptions);

--- a/tests/e2e/tests/build/base-href.ts
+++ b/tests/e2e/tests/build/base-href.ts
@@ -1,6 +1,7 @@
 import {ng} from '../../utils/process';
 import {expectFileToMatch} from '../../utils/fs';
 import {getGlobalVariable} from '../../utils/env';
+import {updateJsonFile} from '../../utils/project';
 
 
 export default function() {
@@ -10,5 +11,11 @@ export default function() {
   }
 
   return ng('build', '--base-href', '/myUrl')
-    .then(() => expectFileToMatch('dist/index.html', /<base href="\/myUrl">/));
+    .then(() => expectFileToMatch('dist/index.html', /<base href="\/myUrl">/))
+    .then(() => updateJsonFile('.angular-cli.json', configJson => {
+      const app = configJson['apps'][0];
+      app['baseHref'] = '/myUrl';
+    }))
+    .then(() => ng('build'))
+    .then(() => expectFileToMatch('dist/index.html', /<base href="\/myUrl">/))
 }


### PR DESCRIPTION
Allows `baseHref` to be defined in .angular-cli.json.