### PR TITLE
revert: fix(@ngtools/webpack): fix paths-plugin to allow '*' as alias

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "diff": "^3.1.0",
     "ember-cli-normalize-entity-name": "^1.0.0",
     "ember-cli-string-utils": "^1.0.0",
+    "enhanced-resolve": "^3.1.0",
     "exports-loader": "^0.6.3",
     "extract-text-webpack-plugin": "^2.1.0",
     "file-loader": "^0.10.0",

--- a/packages/@ngtools/webpack/package.json
+++ b/packages/@ngtools/webpack/package.json
@@ -25,6 +25,7 @@
     "npm": ">= 3.0.0"
   },
   "dependencies": {
+    "enhanced-resolve": "^3.1.0",
     "loader-utils": "^1.0.2",
     "magic-string": "^0.19.0",
     "source-map": "^0.5.6"

--- a/packages/@ngtools/webpack/src/plugin.ts
+++ b/packages/@ngtools/webpack/src/plugin.ts
@@ -341,11 +341,7 @@ export class AotPlugin implements Tapable {
           cb();
         }
       });
-    });
-
-    compiler.plugin('normal-module-factory', (nmf: any) => {
       compiler.resolvers.normal.apply(new PathsPlugin({
-        nmf,
         tsConfigPath: this._tsConfigPath,
         compilerOptions: this._compilerOptions,
         compilerHost: this._compilerHost

--- a/packages/@ngtools/webpack/src/webpack.ts
+++ b/packages/@ngtools/webpack/src/webpack.ts
@@ -39,18 +39,6 @@ export interface NormalModule {
   resource: string;
 }
 
-export interface NormalModuleFactory {
-  plugin(
-    event: string,
-    callback: (data: NormalModuleFactoryRequest, callback: Callback<any>) => void
-  ): any;
-}
-
-export interface NormalModuleFactoryRequest {
-  request: string;
-  contextInfo: { issuer: string };
-}
-
 export interface LoaderContext {
   _module: NormalModule;
 

--- a/tests/e2e/tests/build/ts-paths.ts
+++ b/tests/e2e/tests/build/ts-paths.ts
@@ -13,10 +13,6 @@ export default function() {
       ],
       '@shared/*': [
         'app/shared/*'
-      ],
-      '*': [
-        '*',
-        'app/shared/*'
       ]
     };
   })
@@ -29,14 +25,12 @@ export default function() {
     import { meaning } from 'app/shared/meaning';
     import { meaning as meaning2 } from '@shared';
     import { meaning as meaning3 } from '@shared/meaning';
-    import { meaning as meaning4 } from 'meaning';
 
     // need to use imports otherwise they are ignored and
     // no error is outputted, even if baseUrl/paths don't work
     console.log(meaning)
     console.log(meaning2)
     console.log(meaning3)
-    console.log(meaning4)
   `))
   .then(() => ng('build'));
 }


### PR DESCRIPTION
This reverts commit 6da95cdca7b7049ddb1386b3396867afedb78d2b from PR #5033.

See #6451.

Fixes #6455 
Fixes #6451 