### PR TITLE
fix(webpack): allow webpack to resolve in all available node_modules

### DIFF
--- a/packages/@angular/cli/custom-typings.d.ts
+++ b/packages/@angular/cli/custom-typings.d.ts
@@ -24,3 +24,8 @@ interface IWebpackDevServerConfigurationOptions {
   public?: string;
   disableHostCheck?: boolean;
 }
+
+
+interface NodeModule {
+  paths: string[];
+}

--- a/packages/@angular/cli/models/webpack-configs/common.ts
+++ b/packages/@angular/cli/models/webpack-configs/common.ts
@@ -23,7 +23,8 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
   const { projectRoot, buildOptions, appConfig } = wco;
 
   const appRoot = path.resolve(projectRoot, appConfig.root);
-  const nodeModules = path.resolve(projectRoot, 'node_modules');
+  const projectRootNodeModules = path.resolve(projectRoot, 'node_modules');
+  const nodeModules = module.paths.slice(0, module.paths.indexOf(projectRootNodeModules) + 1)
 
   let extraPlugins: any[] = [];
   let extraRules: any[] = [];
@@ -67,10 +68,10 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
     devtool: buildOptions.sourcemaps ? 'source-map' : false,
     resolve: {
       extensions: ['.ts', '.js'],
-      modules: ['node_modules', nodeModules],
+      modules: [appRoot].concat(nodeModules),
     },
     resolveLoader: {
-      modules: [nodeModules]
+      modules: nodeModules
     },
     context: projectRoot,
     entry: entryPoints,
@@ -82,7 +83,7 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
     },
     module: {
       rules: [
-        { enforce: 'pre', test: /\.js$/, loader: 'source-map-loader', exclude: [nodeModules] },
+        { enforce: 'pre', test: /\.js$/, loader: 'source-map-loader', exclude: nodeModules },
         { test: /\.json$/, loader: 'json-loader' },
         { test: /\.html$/, loader: 'raw-loader' },
         { test: /\.(eot|svg)$/, loader: `file-loader?name=[name]${hashFormat.file}.[ext]` },


### PR DESCRIPTION
When @angular/cli dependencies (like @ngtool/webpack for example) are installed in its node_modules (as node_modules/@angular/cli/node_modules for example) webpack isn't seeing them.
By using a subset of the current `module.paths`, containing all the node_modules from the current file to the root, we always webpack to discover those modules.