### PR TITLE
fix(@angular/cli): resolve in all available node_modules

### DIFF
--- a/packages/@angular/cli/models/webpack-configs/common.ts
+++ b/packages/@angular/cli/models/webpack-configs/common.ts
@@ -70,9 +70,9 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
       modules: ['node_modules', nodeModules],
     },
     resolveLoader: {
-      modules: [nodeModules]
+      modules: [nodeModules, 'node_modules']
     },
-    context: projectRoot,
+    context: __dirname,
     entry: entryPoints,
     output: {
       path: path.resolve(projectRoot, buildOptions.outputPath),

--- a/tests/e2e/tests/misc/loaders-resolution.ts
+++ b/tests/e2e/tests/misc/loaders-resolution.ts
@@ -1,0 +1,12 @@
+import { createDir, moveFile } from '../../utils/fs';
+import { ng } from '../../utils/process';
+
+export default async function () {
+  await createDir('node_modules/@angular/cli/node_modules');
+  await moveFile(
+    'node_modules/@ngtools',
+    'node_modules/@angular/cli/node_modules/@ngtools'
+  );
+
+  await ng('build');
+}


### PR DESCRIPTION
When @angular/cli dependencies (like @ngtool/webpack for example) are installed in its node_modules (as node_modules/@angular/cli/node_modules for example) webpack isn't seeing them.

Actually I experienced it when trying to use [lerna](https://github.com/lerna/lerna) with [ng-cli](https://github.com/angular/angular-cli). As Lerna try to be smart about how the node_modules are shared between different packages, it's installing the `@angular/cli` dependencies in the `@angular/cli/node_modules`

```
/packages/my-ng-app
├── dist
├── e2e
├── node_modules
│   ├── @angular
│   │   ├── animations
│   │   ├── cli
│   │   │   ├── ...
│   │   │   ├── node_modules
│   │   │   │   ├── ...
│   │   │   │   ├── css-loader
│   │   │   │   ├── extract-text-webpack-plugin
│   │   │   │   ├── file-loader
│   │   │   │   ├── html-webpack-plugin
│   │   │   │   ├── istanbul-instrumenter-loader
│   │   │   │   ├── karma-sourcemap-loader
│   │   │   │   ├── less-loader
│   │   │   │   ├── @ngtools
│   │   │   │   ├── sass-loader
│   │   │   │   ├── script-loader
│   │   │   │   ├── source-map-loader
│   │   │   │   ├── style-loader
│   │   │   │   ├── stylus-loader
│   │   │   │   ├── supports-color
│   │   │   │   ├── url-loader
│   │   │   │   ├── webpack
│   │   │   │   └── ...
```