### PR TITLE
docs(@angular-cli): update documentation for `ng new`

### DIFF
--- a/docs/documentation/new.md
+++ b/docs/documentation/new.md
@@ -24,7 +24,7 @@ Default applications are created in a directory of the same name, with an initia
     <code>--dry-run</code> (alias: <code>-d</code>) <em>default value: false</em>
   </p>
   <p>
-    Run through without making any changes.
+    Run through without making any changes. Will list all files that would have been created when running <code>ng new</code>.
   </p>
 </details>
 
@@ -65,6 +65,9 @@ Default applications are created in a directory of the same name, with an initia
   </p>
   <p>
     The prefix to use for all component selectors.
+  </p>
+  <p>
+    You can later change the value in <em>.angular-cli.json</em> (<code>apps[0].prefix</code>).
   </p>
 </details>
 
@@ -129,6 +132,9 @@ Default applications are created in a directory of the same name, with an initia
   <p>
     The name of the source directory.
   </p>
+  <p>
+    You can later change the value in <em>.angular-cli.json</em> (<code>apps[0].root</code>).
+  </p>
 </details>
 
 <details>
@@ -136,8 +142,18 @@ Default applications are created in a directory of the same name, with an initia
   <p>
     <code>--style</code> <em>default value: css</em>
   </p>
+  <div>
+    The style file default extension. Possible values:
+    <ul>
+      <li>css</li>
+      <li>scss</li>
+      <li>less</li>
+      <li>sass</li>
+      <li>styl (<code>stylus</code>)<li>
+    </ul>
+  </div>
   <p>
-    The style file default extension.
+    You can later change the value in <em>.angular-cli.json</em> (<code>defaults.styleExt</code>).
   </p>
 </details>
 

--- a/packages/@angular/cli/commands/new.ts
+++ b/packages/@angular/cli/commands/new.ts
@@ -13,6 +13,8 @@ const Project = require('../ember-cli/lib/models/project');
 const SilentError = require('silent-error');
 const mkdir = denodeify(fs.mkdir);
 
+const configFile = '.angular-cli.json';
+const changeLater = (path: string) => `You can later change the value in "${configFile}" (${path})`;
 
 const NewCommand = Command.extend({
   name: 'new',
@@ -26,7 +28,10 @@ const NewCommand = Command.extend({
       type: Boolean,
       default: false,
       aliases: ['d'],
-      description: 'Run through without making any changes.'
+      description: oneLine`
+        Run through without making any changes.
+        Will list all files that would have been created when running "ng new".
+      `
     },
     {
       name: 'verbose',
@@ -82,20 +87,26 @@ const NewCommand = Command.extend({
       type: String,
       default: 'src',
       aliases: ['sd'],
-      description: 'The name of the source directory.'
+      description: `The name of the source directory. ${changeLater('apps[0].root')}.`
     },
     {
       name: 'style',
       type: String,
       default: 'css',
-      description: 'The style file default extension.'
+      description: oneLine`The style file default extension.
+        Possible values: css, scss, less, sass, styl(stylus).
+        ${changeLater('defaults.styleExt')}.
+      `
     },
     {
       name: 'prefix',
       type: String,
       default: 'app',
       aliases: ['p'],
-      description: 'The prefix to use for all component selectors.'
+      description: oneLine`
+        The prefix to use for all component selectors.
+        ${changeLater('apps[0].prefix')}.
+      `
     },
     {
       name: 'routing',


### PR DESCRIPTION
* for several options that are saved in `.angular-cli.json`, I've added an explanation of what setting in the json file controls that options.  
* added an explanation about what `--dry-run` will output.
* added possible values for `--style` option

The motivation for this change is that sometimes people would want to change some of the settings set by the `cli` durig `ng new`, that they might have not known or cared about, for example, `prefix`.