### PR TITLE
docs(@angular-cli): update README as per #6070

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,9 @@ Navigate to `http://localhost:4200/`. The app will automatically reload if you c
 You can configure the default HTTP host and port used by the development server with two command-line options :
 
 ```bash
-ng serve --host 0.0.0.0 --port 4201
+ng serve --host <public ip or valid domain> --port 4201
 ```
+You have to use exactly the same `<public ip>` or `<domain` when opening the app or you will get "Invalid Host header".
 
 ### Generating Components, Directives, Pipes and Services
 


### PR DESCRIPTION
The 0.0.0.0 host format will never work with current webpack version and will always show "invalid host header". Instead, a valid domain or public IP has to be specified. See #6070 .