### PR TITLE
fix(@angular/cli): add missing WeakMap polyfill

### DIFF
--- a/packages/@angular/cli/blueprints/ng/files/__path__/polyfills.ts
+++ b/packages/@angular/cli/blueprints/ng/files/__path__/polyfills.ts
@@ -31,6 +31,7 @@
 // import 'core-js/es6/array';
 // import 'core-js/es6/regexp';
 // import 'core-js/es6/map';
+// import 'core-js/es6/weak-map';
 // import 'core-js/es6/set';
 
 /** IE10 and IE11 requires the following for NgClass support on SVG elements */


### PR DESCRIPTION
The `WeakMap` feature in ES2015 is used by the **View Engine** in [angular/packages/core/src/view/util.ts](https://github.com/angular/angular/blob/39b92f7e546b8bdecc0e08c915d36717358c122b/packages/core/src/view/util.ts#L237):

```typescript
const DEFINITION_CACHE = new WeakMap<any, Definition<any>>();
```

Since IE9 & IE10 does not provide that by default, it should be consider part of IE polyfills.
