### PR TITLE
Added a custom hash option

### DIFF
--- a/packages/@angular/cli/commands/build.ts
+++ b/packages/@angular/cli/commands/build.ts
@@ -108,6 +108,12 @@ export const baseBuildCommandOptions: any = [
     aliases: ['oh']
   },
   {
+    name: 'custom-hash',
+    type: String,
+    description: 'Define a custom hash for cache-busting',
+    aliases: ['ch']
+  },
+  {
     name: 'poll',
     type: Number,
     default: pollDefault,

--- a/packages/@angular/cli/models/build-options.ts
+++ b/packages/@angular/cli/models/build-options.ts
@@ -15,6 +15,7 @@ export interface BuildOptions {
   extractCss?: boolean;
   watch?: boolean;
   outputHashing?: string;
+  customHash?: string;
   poll?: number;
   app?: string;
   deleteOutputPath?: boolean;

--- a/packages/@angular/cli/models/webpack-configs/common.ts
+++ b/packages/@angular/cli/models/webpack-configs/common.ts
@@ -38,7 +38,7 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
   }
 
   // determine hashing format
-  const hashFormat = getOutputHashFormat(buildOptions.outputHashing);
+  const hashFormat = getOutputHashFormat(buildOptions.outputHashing, buildOptions.customHash);
 
   // process global scripts
   if (appConfig.scripts.length > 0) {

--- a/packages/@angular/cli/models/webpack-configs/styles.ts
+++ b/packages/@angular/cli/models/webpack-configs/styles.ts
@@ -93,7 +93,7 @@ export function getStylesConfig(wco: WebpackConfigOptions) {
   };
 
   // determine hashing format
-  const hashFormat = getOutputHashFormat(buildOptions.outputHashing);
+  const hashFormat = getOutputHashFormat(buildOptions.outputHashing, buildOptions.customHash);
 
   // use includePaths from appConfig
   const includePaths: string[] = [];

--- a/packages/@angular/cli/models/webpack-configs/utils.ts
+++ b/packages/@angular/cli/models/webpack-configs/utils.ts
@@ -75,12 +75,12 @@ export interface HashFormat {
   file: string;
 }
 
-export function getOutputHashFormat(option: string, hash='', length = 20): HashFormat {
+export function getOutputHashFormat(option: string, hash= '', length = 20): HashFormat {
   /* tslint:disable:max-line-length */
   let chunkHash = hash || `[chunkhash:${length}]`;
   let contentHash = hash || `[contenthash:${length}]`;
   let fileHash = hash || `[hash:${length}]`;
-  let customHash = hash ? `.${hash}`: '';
+  let customHash = hash ? `.${hash}` : '';
   const hashFormats: { [option: string]: HashFormat } = {
     none: { chunk: customHash, extract: customHash, file: customHash},
     media: { chunk: customHash, extract: customHash, file: `.${fileHash}`},

--- a/packages/@angular/cli/models/webpack-configs/utils.ts
+++ b/packages/@angular/cli/models/webpack-configs/utils.ts
@@ -75,16 +75,17 @@ export interface HashFormat {
   file: string;
 }
 
-export function getOutputHashFormat(option: string, hash: string, length = 20): HashFormat {
+export function getOutputHashFormat(option: string, hash='', length = 20): HashFormat {
   /* tslint:disable:max-line-length */
   let chunkHash = hash || `[chunkhash:${length}]`;
   let contentHash = hash || `[contenthash:${length}]`;
   let fileHash = hash || `[hash:${length}]`;
+  let customHash = hash ? `.${hash}`: '';
   const hashFormats: { [option: string]: HashFormat } = {
-    none:    { chunk: '',                       extract: '',                         file: ''                  },
-    media:   { chunk: '',                       extract: '',                         file: `.${fileHash}` },
-    bundles: { chunk: `.${chunkHash}`, extract: `.${contentHash}`, file: ''                  },
-    all:     { chunk: `.${chunkHash}`, extract: `.${contentHash}`, file: `.${fileHash}` },
+    none: { chunk: customHash, extract: customHash, file: customHash},
+    media: { chunk: customHash, extract: customHash, file: `.${fileHash}`},
+    bundles: { chunk: `.${chunkHash}`, extract: `.${contentHash}`, file: customHash},
+    all: { chunk: `.${chunkHash}`, extract: `.${contentHash}`, file: `.${fileHash}`},
   };
   /* tslint:enable:max-line-length */
   return hashFormats[option] || hashFormats['none'];

--- a/packages/@angular/cli/models/webpack-configs/utils.ts
+++ b/packages/@angular/cli/models/webpack-configs/utils.ts
@@ -75,13 +75,16 @@ export interface HashFormat {
   file: string;
 }
 
-export function getOutputHashFormat(option: string, length = 20): HashFormat {
+export function getOutputHashFormat(option: string, hash: string, length = 20): HashFormat {
   /* tslint:disable:max-line-length */
+  let chunkHash = hash || `[chunkhash:${length}]`;
+  let contentHash = hash || `[contenthash:${length}]`;
+  let fileHash = hash || `[hash:${length}]`;
   const hashFormats: { [option: string]: HashFormat } = {
     none:    { chunk: '',                       extract: '',                         file: ''                  },
-    media:   { chunk: '',                       extract: '',                         file: `.[hash:${length}]` },
-    bundles: { chunk: `.[chunkhash:${length}]`, extract: `.[contenthash:${length}]`, file: ''                  },
-    all:     { chunk: `.[chunkhash:${length}]`, extract: `.[contenthash:${length}]`, file: `.[hash:${length}]` },
+    media:   { chunk: '',                       extract: '',                         file: `.${fileHash}` },
+    bundles: { chunk: `.${chunkHash}`, extract: `.${contentHash}`, file: ''                  },
+    all:     { chunk: `.${chunkHash}`, extract: `.${contentHash}`, file: `.${fileHash}` },
   };
   /* tslint:enable:max-line-length */
   return hashFormats[option] || hashFormats['none'];

--- a/tests/e2e/tests/build/output-hashing.ts
+++ b/tests/e2e/tests/build/output-hashing.ts
@@ -21,7 +21,19 @@ export default function() {
     .then(() => expectFileToMatch('dist/index.html', /styles\.[0-9a-f]{20}\.bundle\.(css|js)/))
     .then(() => verifyMedia(/styles\.[0-9a-f]{20}\.bundle\.(css|js)/, /image\.[0-9a-f]{20}\.svg/))
 
+    .then(() => ng('build', '--dev', '--output-hashing=all --custom-hash=someHash'))//custom hash can be any string
+    .then(() => expectFileToMatch('dist/index.html', /inline\.someHash\.bundle\.js/))
+    .then(() => expectFileToMatch('dist/index.html', /main\.someHash\.bundle\.js/))
+    .then(() => expectFileToMatch('dist/index.html', /styles\.someHash\.bundle\.(css|js)/))
+    .then(() => verifyMedia(/styles\.someHash\.bundle\.(css|js)/, /image\.someHash\.svg/))
+
     .then(() => ng('build', '--prod', '--output-hashing=none'))
+    .then(() => expectFileToMatch('dist/index.html', /inline\.bundle\.js/))
+    .then(() => expectFileToMatch('dist/index.html', /main\.bundle\.js/))
+    .then(() => expectFileToMatch('dist/index.html', /styles\.bundle\.(css|js)/))
+    .then(() => verifyMedia(/styles\.bundle\.(css|js)/, /image\.svg/))
+
+    .then(() => ng('build', '--prod', '--output-hashing=none --custom-hash=someHash'))
     .then(() => expectFileToMatch('dist/index.html', /inline\.bundle\.js/))
     .then(() => expectFileToMatch('dist/index.html', /main\.bundle\.js/))
     .then(() => expectFileToMatch('dist/index.html', /styles\.bundle\.(css|js)/))
@@ -33,9 +45,21 @@ export default function() {
     .then(() => expectFileToMatch('dist/index.html', /styles\.bundle\.(css|js)/))
     .then(() => verifyMedia(/styles\.bundle\.(css|js)/, /image\.[0-9a-f]{20}\.svg/))
 
+    .then(() => ng('build', '--dev', '--output-hashing=media --custom-hash=someHash'))
+    .then(() => expectFileToMatch('dist/index.html', /inline\.bundle\.js/))
+    .then(() => expectFileToMatch('dist/index.html', /main\.bundle\.js/))
+    .then(() => expectFileToMatch('dist/index.html', /styles\.bundle\.(css|js)/))
+    .then(() => verifyMedia(/styles\.bundle\.(css|js)/, /image\.someHash\.svg/))
+
     .then(() => ng('build', '--dev', '--output-hashing=bundles'))
     .then(() => expectFileToMatch('dist/index.html', /inline\.[0-9a-f]{20}\.bundle\.js/))
     .then(() => expectFileToMatch('dist/index.html', /main\.[0-9a-f]{20}\.bundle\.js/))
     .then(() => expectFileToMatch('dist/index.html', /styles\.[0-9a-f]{20}\.bundle\.(css|js)/))
-    .then(() => verifyMedia(/styles\.[0-9a-f]{20}\.bundle\.(css|js)/, /image\.svg/));
+    .then(() => verifyMedia(/styles\.[0-9a-f]{20}\.bundle\.(css|js)/, /image\.svg/))
+
+    .then(() => ng('build', '--dev', '--output-hashing=bundles --custom-hash=someHash'))
+    .then(() => expectFileToMatch('dist/index.html', /inline\.someHash\.bundle\.js/))
+    .then(() => expectFileToMatch('dist/index.html', /main\.someHash\.bundle\.js/))
+    .then(() => expectFileToMatch('dist/index.html', /styles\.someHash\.bundle\.(css|js)/))
+    .then(() => verifyMedia(/styles\.someHash\.bundle\.(css|js)/, /image\.svg/));
 }


### PR DESCRIPTION
What was needed is custom hash support in angular cli cache busting. I have added an option `customHash` and other of its dependent things.
