### PR TITLE
feat(@angular/cli): use tslint language service

### DIFF
--- a/packages/@angular/cli/blueprints/ng/files/package.json
+++ b/packages/@angular/cli/blueprints/ng/files/package.json
@@ -46,7 +46,8 @@
     "karma-jasmine-html-reporter": "^0.2.2",
     "protractor": "~5.1.2",
     "ts-node": "~3.2.0",
-    "tslint": "~5.3.2",<% } %>
+    "tslint": "~5.3.2",
+    "tslint-language-service": "^0.9.6",<% } %>
     "typescript": "~2.3.3"
   }
 }

--- a/packages/@angular/cli/blueprints/ng/files/tsconfig.json
+++ b/packages/@angular/cli/blueprints/ng/files/tsconfig.json
@@ -14,6 +14,11 @@
     "lib": [
       "es2017",
       "dom"
-    ]
+    ]<% if (!minimal) { %>,
+    "plugins": [
+      {
+        "name": "tslint-language-service"
+      }
+    ]<% } %>
   }
 }

--- a/tests/e2e/tests/commands/new/new-minimal.ts
+++ b/tests/e2e/tests/commands/new/new-minimal.ts
@@ -22,6 +22,7 @@ export default function() {
     .then(() => expectToFail(() => expectFileToMatch('package.json', '"protractor":')))
     .then(() => expectToFail(() => expectFileToMatch('package.json', '"karma":')))
     .then(() => expectToFail(() => expectFileToMatch('package.json', '"jasmine-core":')))
+    .then(() => expectToFail(() => expectFileToMatch('package.json', '"tslint-language-service":')))
 
     // Try to run a build.
     .then(() => ng('build'));


### PR DESCRIPTION
tslint-language-service can support tslint rules that require the type checker
share program representation with TypeScript (no need to reanalyze)

Fixes: #6125