### PR TITLE
fix(@angular/cli): restore e2e blueprint

### DIFF
--- a/packages/@angular/cli/blueprints/ng/files/e2e/app.e2e-spec.ts
+++ b/packages/@angular/cli/blueprints/ng/files/e2e/app.e2e-spec.ts
@@ -7,10 +7,8 @@ describe('<%= htmlComponentName %> App', () => {
     page = new <%= jsComponentName %>Page();
   });
 
-  it('should display welcome message', done => {
+  it('should display welcome message', () => {
     page.navigateTo();
-    page.getParagraphText()
-      .then(msg => expect(msg).toEqual('Welcome to <%= prefix %>!!'))
-      .then(done, done.fail);
+    expect(page.getParagraphText()).toEqual('Welcome to <%= prefix %>!!');
   });
 });


### PR DESCRIPTION
This reverts commit ba15605fc3ef2e9a117b25b8fbc05b6817b3d27d.

The commit introduced non idiomatic Protractor code as I was pointing out in https://github.com/angular/angular-cli/pull/6361#issuecomment-303857900.

The issue that the commit was trying to fix is unrelated to the test itself. It is related to the typings of Jasmine that have evolved (see https://github.com/angular/protractor/issues/4176). Pinning the typings to 2.5.45 (as it is right now in the blueprint) is enough to not encounter the issue, while we wait for a fix from either Jasmine typings or Protractor.