### PR TITLE
refactor(@angular/cli): remove unnecessary use of ember-cli promise wrapper

### DIFF
--- a/packages/@angular/cli/lib/ast-tools/change.spec.ts
+++ b/packages/@angular/cli/lib/ast-tools/change.spec.ts
@@ -1,16 +1,11 @@
-'use strict';
-
 // This needs to be first so fs module can be mocked correctly.
-let mockFs = require('mock-fs');
+import mockFs = require('mock-fs');
 
-import {it} from './spec-utils';
-import {InsertChange, NodeHost, RemoveChange, ReplaceChange} from './change';
-import fs = require('fs');
+import { it } from './spec-utils';
+import { InsertChange, NodeHost, RemoveChange, ReplaceChange } from './change';
+import { readFile } from 'fs-extra';
+import * as path from 'path';
 
-let path = require('path');
-let Promise = require('@angular/cli/ember-cli/lib/ext/promise');
-
-const readFile =  Promise.denodeify(fs.readFile);
 
 describe('Change', () => {
   let sourcePath = 'src/app/my-component';

--- a/packages/@angular/cli/tasks/git-init.ts
+++ b/packages/@angular/cli/tasks/git-init.ts
@@ -1,7 +1,7 @@
 import { oneLine } from 'common-tags';
+import denodeify = require('denodeify');
 
-const Promise = require('../ember-cli/lib/ext/promise');
-const exec = Promise.denodeify(require('child_process').exec);
+const exec: any = denodeify(require('child_process').exec);
 const path = require('path');
 const pkg = require('../package.json');
 const fs = require('fs');

--- a/packages/@angular/cli/utilities/check-package-manager.ts
+++ b/packages/@angular/cli/utilities/check-package-manager.ts
@@ -1,9 +1,9 @@
 import * as chalk from 'chalk';
 import {exec} from 'child_process';
 import {CliConfig} from '../models/config';
+import denodeify = require('denodeify');
 
-const Promise = require('../ember-cli/lib/ext/promise');
-const execPromise = Promise.denodeify(exec);
+const execPromise = denodeify(exec);
 const packageManager = CliConfig.fromGlobal().get('packageManager');
 
 

--- a/tests/e2e/tests/generate/module/module-routing-child-folder.ts
+++ b/tests/e2e/tests/generate/module/module-routing-child-folder.ts
@@ -5,8 +5,6 @@ import { expectFileToExist } from '../../../utils/fs';
 import { expectToFail } from '../../../utils/utils';
 
 
-const Promise = require('@angular/cli/ember-cli/lib/ext/promise');
-
 export default function () {
   const root = process.cwd();
   const testPath = join(root, 'src', 'app');


### PR DESCRIPTION
Also some very minor import cleanup to the ast-tools change spec.