### PR TITLE
fix(@angular/cli): pin ts-node in generated projects

### DIFF
--- a/packages/@angular/cli/blueprints/ng/files/package.json
+++ b/packages/@angular/cli/blueprints/ng/files/package.json
@@ -41,7 +41,7 @@
     "karma-jasmine-html-reporter": "^0.2.2",
     "karma-coverage-istanbul-reporter": "^1.2.1",
     "protractor": "~5.1.2",
-    "ts-node": "~3.0.4",
+    "ts-node": "3.0.4",
     "tslint": "~5.3.2",
     "typescript": "~2.3.3"
   }


### PR DESCRIPTION
CI is breaking with some errors related to `ts-node@3.0.5`.

We should unpin once https://github.com/TypeStrong/ts-node/issues/344 clears.