### PR TITLE
fix(@ngtools/webpack): fix error in compiler CLI when i18nFormat is undefined

### DIFF
--- a/packages/@ngtools/webpack/src/extract_i18n_plugin.ts
+++ b/packages/@ngtools/webpack/src/extract_i18n_plugin.ts
@@ -175,7 +175,7 @@ export class ExtractI18nPlugin implements Tapable {
           program: this._program,
           host: this._compilerHost,
           angularCompilerOptions: this._angularCompilerOptions,
-          i18nFormat: this._i18nFormat,
+          i18nFormat: this._i18nFormat || '',
           locale: this._locale,
           outFile: this._outFile,
 


### PR DESCRIPTION
```
TypeError: Cannot read property 'toLowerCase' of undefined
    at Extractor.serialize (/node_modules/@angular/compiler-cli/src/extractor.js:45:32)
    at /node_modules/@angular/compiler-cli/src/extractor.js:32:33
    at process._tickCallback (internal/process/next_tick.js:103:7)
```