### PR TITLE
feat(@angular/cli): support bundle preloading and execution deferral

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "rsvp": "^3.0.17",
     "rxjs": "^5.0.1",
     "sass-loader": "^6.0.3",
+    "script-ext-html-webpack-plugin": "^1.8.1",
     "script-loader": "^0.7.0",
     "semver": "^5.3.0",
     "silent-error": "^1.0.0",

--- a/packages/@angular/cli/commands/build.ts
+++ b/packages/@angular/cli/commands/build.ts
@@ -9,7 +9,7 @@ const Command = require('../ember-cli/lib/models/command');
 const config = CliConfig.fromProject() || CliConfig.fromGlobal();
 const buildConfigDefaults = config.getPaths('defaults.build', [
   'sourcemaps', 'baseHref', 'progress', 'poll', 'deleteOutputPath', 'preserveSymlinks',
-  'showCircularDependencies'
+  'showCircularDependencies', 'preloadBundles'
 ]);
 
 // defaults for BuildOptions
@@ -144,6 +144,12 @@ export const baseBuildCommandOptions: any = [
     type: Boolean,
     default: true,
     description: 'Extract all licenses in a separate file, in the case of production builds only.'
+  },
+  {
+    name: 'preload-bundles',
+    type: Boolean,
+    description: 'Add preload hints for initial bundles; does not include `scripts` bundles.',
+    default: buildConfigDefaults['preloadBundles']
   },
   {
     name: 'show-circular-dependencies',

--- a/packages/@angular/cli/lib/config/schema.json
+++ b/packages/@angular/cli/lib/config/schema.json
@@ -477,6 +477,11 @@
               "type": "boolean",
               "default": false
             },
+            "preloadBundles": {
+              "description": "Add preload hints for initial bundles; does not include `scripts` bundles.",
+              "type": "boolean",
+              "default": false
+            },
             "showCircularDependencies": {
               "description": "Show circular dependency warnings on builds.",
               "type": "boolean",

--- a/packages/@angular/cli/models/build-options.ts
+++ b/packages/@angular/cli/models/build-options.ts
@@ -20,5 +20,6 @@ export interface BuildOptions {
   deleteOutputPath?: boolean;
   preserveSymlinks?: boolean;
   extractLicenses?: boolean;
+  preloadBundles?: boolean;
   showCircularDependencies?: boolean;
 }

--- a/packages/@angular/cli/models/webpack-configs/browser.ts
+++ b/packages/@angular/cli/models/webpack-configs/browser.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as webpack from 'webpack';
 import * as path from 'path';
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const ScriptExtHtmlWebpackPlugin = require('script-ext-html-webpack-plugin');
 
 import { packageChunkSort } from '../../utilities/package-chunk-sort';
 import { BaseHrefWebpackPlugin } from '../../lib/base-href-webpack';
@@ -51,6 +52,15 @@ export function getBrowserConfig(wco: WebpackConfigOptions) {
     }));
   }
 
+  let deferBundles;
+  let preloadBundles;
+  if (buildOptions.preloadBundles) {
+    deferBundles = appConfig.scripts.length > 0 ?
+          ['vendor', 'main'] :
+          ['inline', 'polyfills', 'vendor', 'main'];
+    preloadBundles = ['inline', 'polyfills', 'vendor', 'main'];
+  }
+
   return {
     plugins: [
       new HtmlWebpackPlugin({
@@ -67,6 +77,10 @@ export function getBrowserConfig(wco: WebpackConfigOptions) {
       }),
       new BaseHrefWebpackPlugin({
         baseHref: buildOptions.baseHref
+      }),
+      new ScriptExtHtmlWebpackPlugin({
+        defer: deferBundles || [],
+        preload: preloadBundles || []
       }),
       new webpack.optimize.CommonsChunkPlugin({
         name: 'main',

--- a/packages/@angular/cli/package.json
+++ b/packages/@angular/cli/package.json
@@ -70,6 +70,7 @@
     "rsvp": "^3.0.17",
     "rxjs": "^5.0.1",
     "sass-loader": "^6.0.3",
+    "script-ext-html-webpack-plugin": "^1.8.1",
     "script-loader": "^0.7.0",
     "semver": "^5.1.0",
     "silent-error": "^1.0.0",

--- a/packages/@angular/cli/tasks/eject.ts
+++ b/packages/@angular/cli/tasks/eject.ts
@@ -20,6 +20,7 @@ const angularCliPlugins = require('../plugins/webpack');
 
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const ScriptExtHtmlWebpackPlugin = require('script-ext-html-webpack-plugin');
 const SilentError = require('silent-error');
 const licensePlugin = require('license-webpack-plugin');
 const CircularDependencyPlugin = require('circular-dependency-plugin');
@@ -204,6 +205,9 @@ class JsonWebpackSerializer {
         case HtmlWebpackPlugin:
           args = this._htmlWebpackPlugin(plugin);
           this.variableImports['html-webpack-plugin'] = 'HtmlWebpackPlugin';
+          break;
+        case ScriptExtHtmlWebpackPlugin:
+          this.variableImports['script-ext-html-webpack-plugin'] = 'ScriptExtHtmlWebpackPlugin';
           break;
         case webpack.EnvironmentPlugin:
           args = this._environmentPlugin(plugin);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4568,6 +4568,12 @@ schema-utils@^0.3.0:
   dependencies:
     ajv "^5.0.0"
 
+script-ext-html-webpack-plugin@^1.8.1:
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/script-ext-html-webpack-plugin/-/script-ext-html-webpack-plugin-1.8.3.tgz#04c77e68eb45eb6358bf36554a1a358ca60ca2ed"
+  dependencies:
+    debug "^2.6.8"
+
 script-loader@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/script-loader/-/script-loader-0.7.0.tgz#685dc7e7069e0dee7a92674f0ebc5b0f55baa5ec"


### PR DESCRIPTION
This adds preload hints to `index.html` for the required initial javascript bundles.  If no scripts are defined within the configuration then these bundles are deferred as well.  Otherwise, only the `main` and `vendor` bundle execution is deferred until after the document is parsed.  The behavior and expectations of the contents of any script bundles is unknown and therefore cannot be safely deferred.  As the `inline` and `polyfills` bundles are currently dependents of any script bundles, they also must follow suit.