### PR TITLE
chore: remove codelyzer rules

### DIFF
--- a/tests/e2e/assets/1.0.0-proj/tslint.json
+++ b/tests/e2e/assets/1.0.0-proj/tslint.json
@@ -109,8 +109,6 @@
     "use-pipe-transform-interface": true,
     "component-class-suffix": true,
     "directive-class-suffix": true,
-    "no-access-missing-member": true,
-    "templates-use-public": true,
     "invoke-injectable": true
   }
 }


### PR DESCRIPTION
Few codelyzer rules report warnings which are also compile-time errors caught by the
Angular compiler and reported by the language service.

Since codelyzer doesn't aim to provide type checking and deep analysis
of the entire project, it'll be better if these two rules are removed.

Btw, soon more rules will follow https://github.com/mgechev/codelyzer/issues/314.