### PR TITLE
Fix URL for tour of heroes tutorial

### DIFF
--- a/packages/@angular/cli/blueprints/ng/files/__path__/app/app.component.html
+++ b/packages/@angular/cli/blueprints/ng/files/__path__/app/app.component.html
@@ -8,7 +8,7 @@
 <h2>Here are some links to help you start: </h2>
 <ul>
   <li>
-    <h2><a target="_blank" href="https://angular.io/docs/ts/latest/tutorial/">Tour of Heroes</a></h2>
+    <h2><a target="_blank" href="https://angular.io/tutorial">Tour of Heroes</a></h2>
   </li>
   <li>
     <h2><a target="_blank" href="https://github.com/angular/angular-cli/wiki">CLI Documentation</a></h2>


### PR DESCRIPTION
Existing URL that is generated in the scaffold gives a 404. Updating this to the correct version.