### PR TITLE
fix(@angular/cli): Make generated inline template conform to test case

### DIFF
--- a/packages/@angular/cli/blueprints/ng/files/__path__/app/app.component.ts
+++ b/packages/@angular/cli/blueprints/ng/files/__path__/app/app.component.ts
@@ -4,7 +4,7 @@ import { Component } from '@angular/core';
   selector: '<%= prefix %>-root',<% if (inlineTemplate) { %>
   template: `
     <h1>
-      {{title}}
+      Welcome to {{title}}!!
     </h1><% if (routing) { %>
     <router-outlet></router-outlet><% } %>
   `,<% } else { %>


### PR DESCRIPTION
The generated app component spec checks for the string "Welcome to {{title}}!!", which is only output by the generated `app.component.htm`l file, not the generated inline template in `app.component.ts` when the `--inline-template` option is passed to the `ng new` command. This causes a test failure when generating a new app with `--inline-template`.