### PR TITLE
feat(@angular/cli): allow disabling warning when --hmr flag is enabled

### DIFF
--- a/packages/@angular/cli/lib/config/schema.json
+++ b/packages/@angular/cli/lib/config/schema.json
@@ -493,6 +493,11 @@
       "description": "Allow people to disable console warnings.",
       "type": "object",
       "properties": {
+        "hmrWarning": {
+          "description": "Show a warning when the user enabled the --hmr option.",
+          "type": "boolean",
+          "default": true
+        },
         "nodeDeprecation": {
           "description": "Show a warning when the node version is incompatible.",
           "type": "boolean",

--- a/packages/@angular/cli/tasks/serve.ts
+++ b/packages/@angular/cli/tasks/serve.ts
@@ -15,6 +15,7 @@ const WebpackDevServer = require('webpack-dev-server');
 const Task = require('../ember-cli/lib/models/task');
 const SilentError = require('silent-error');
 const opn = require('opn');
+const yellow = require('chalk').yellow;
 
 export default Task.extend({
   run: function (serveTaskOptions: ServeTaskOptions, rebuildDoneCb: any) {
@@ -52,7 +53,7 @@ export default Task.extend({
 
     if (serveTaskOptions.disableHostCheck) {
       ui.writeLine(oneLine`
-          ${chalk.yellow('WARNING')} Running a server with --disable-host-check is a security risk.
+          ${yellow('WARNING')} Running a server with --disable-host-check is a security risk.
           See https://medium.com/webpack/webpack-dev-server-middleware-security-issues-1489d950874a
           for more information.
         `);
@@ -77,19 +78,27 @@ export default Task.extend({
       ];
       if (serveTaskOptions.hmr) {
         const webpackHmrLink = 'https://webpack.github.io/docs/hot-module-replacement.html';
+
         ui.writeLine(oneLine`
-          ${chalk.yellow('NOTICE')} Hot Module Replacement (HMR) is enabled for the dev server.
+          ${yellow('NOTICE')} Hot Module Replacement (HMR) is enabled for the dev server.
         `);
-        ui.writeLine('  The project will still live reload when HMR is enabled,');
-        ui.writeLine('  but to take advantage of HMR additional application code is required');
-        ui.writeLine('  (not included in an Angular CLI project by default).');
-        ui.writeLine(`  See ${chalk.blue(webpackHmrLink)}`);
-        ui.writeLine('  for information on working with HMR for Webpack.');
+
+        const showWarning = CliConfig.fromGlobal().get('warnings.hmrWarning');
+        if (showWarning) {
+          ui.writeLine('  The project will still live reload when HMR is enabled,');
+          ui.writeLine('  but to take advantage of HMR additional application code is required');
+          ui.writeLine('  (not included in an Angular CLI project by default).');
+          ui.writeLine(`  See ${chalk.blue(webpackHmrLink)}`);
+          ui.writeLine('  for information on working with HMR for Webpack.');
+          ui.writeLine(oneLine`
+            ${yellow('To disable this warning use "ng set --global warnings.hmrWarning=false"')}
+          `);
+        }
         entryPoints.push('webpack/hot/dev-server');
         webpackConfig.plugins.push(new webpack.HotModuleReplacementPlugin());
         if (serveTaskOptions.extractCss) {
           ui.writeLine(oneLine`
-            ${chalk.yellow('NOTICE')} (HMR) does not allow for CSS hot reload when used
+            ${yellow('NOTICE')} (HMR) does not allow for CSS hot reload when used
             together with '--extract-css'.
           `);
         }
@@ -97,7 +106,7 @@ export default Task.extend({
       if (!webpackConfig.entry.main) { webpackConfig.entry.main = []; }
       webpackConfig.entry.main.unshift(...entryPoints);
     } else if (serveTaskOptions.hmr) {
-      ui.writeLine(chalk.yellow('Live reload is disabled. HMR option ignored.'));
+      ui.writeLine(yellow('Live reload is disabled. HMR option ignored.'));
     }
 
     if (!serveTaskOptions.watch) {


### PR DESCRIPTION
This allows toggling the 6-line warning for enabling HRM by running:

`ng set --global warnings.hmrWarning=false`

and activate it again with:

`ng set --global warnings.hmrWarning=true`
