### PR TITLE
fix(@ngtools/webpack): allow webpack 3 peer dependency

### DIFF
--- a/packages/@ngtools/webpack/package.json
+++ b/packages/@ngtools/webpack/package.json
@@ -32,6 +32,6 @@
   },
   "peerDependencies": {
     "typescript": "^2.0.2",
-    "webpack": "^2.2.0"
+    "webpack": "^2.2.0 || ^3.0.0"
   }
 }


### PR DESCRIPTION
Webpack 3 stable just dropped: https://medium.com/webpack/webpack-3-official-release-15fd2dd8f07b 

AFAIK there are no breaking changes that affect this plugin, I tested locally and everything seems to work fine in my app.