### PR TITLE
docs(@angular/cli): Update xi18n outfile argument string

### DIFF
--- a/docs/documentation/xi18n.md
+++ b/docs/documentation/xi18n.md
@@ -39,7 +39,7 @@
 <details>
   <summary>outfile</summary>
   <p>
-    <code>--outfile</code> (aliases: <code>-of</code>)
+    <code>--out-file</code> (aliases: <code>-of</code>)
   </p>
   <p>
     Name of the file to output.


### PR DESCRIPTION
I noticed when working with the cli that the command to generate the output file is different than what is listed in the wiki. It should be ` --out-file` which is what the cli shows when you use `ng xi18n --help` to list the commands. 

If I try to do `--outfile` I get a message that says `The option '--outfile' is not registered with the xi18n command. Run `ng xi18n --help` for a list of supported options.`.

<img width="946" alt="screen shot 2017-06-20 at 9 40 41 am" src="https://user-images.githubusercontent.com/3654512/27336096-8c8b3ea6-559c-11e7-9a7e-95b49b33d61f.png">
