### PR TITLE
fix: check for existing SW manifest should look in project dir

### DIFF
--- a/packages/@angular/cli/models/webpack-configs/production.ts
+++ b/packages/@angular/cli/models/webpack-configs/production.ts
@@ -58,8 +58,12 @@ export const getProdConfig = function (wco: WebpackConfigOptions) {
     }
 
     extraPlugins.push(new GlobCopyWebpackPlugin({
-      patterns: ['ngsw-manifest.json', 'src/ngsw-manifest.json'],
+      patterns: [
+        'ngsw-manifest.json',
+        {glob: 'ngsw-manifest.json', input: path.resolve(projectRoot, appConfig.root), output: ''}
+      ],
       globOptions: {
+        cwd: projectRoot,
         optional: true,
       },
     }));


### PR DESCRIPTION
A previous change broke the logic which brings an application ngsw-manifest.json into the Webpack build for merging with the auto-generated configuration. It caused the GlobCopyWebpackPlugin to look in the wrong directory for the existing manifest. This change sets the working directory for the copy plugin explicitly.

Fixes #6654.