### PR TITLE
fix(@angular/cli): check package manager existance before installing packages

### DIFF
--- a/packages/@angular/cli/models/webpack-configs/production.ts
+++ b/packages/@angular/cli/models/webpack-configs/production.ts
@@ -58,8 +58,12 @@ export const getProdConfig = function (wco: WebpackConfigOptions) {
     }
 
     extraPlugins.push(new GlobCopyWebpackPlugin({
-      patterns: ['ngsw-manifest.json', 'src/ngsw-manifest.json'],
+      patterns: [
+        'ngsw-manifest.json',
+        {glob: 'ngsw-manifest.json', input: path.resolve(projectRoot, appConfig.root), output: ''}
+      ],
       globOptions: {
+        cwd: projectRoot,
         optional: true,
       },
     }));

--- a/packages/@angular/cli/tasks/npm-install.ts
+++ b/packages/@angular/cli/tasks/npm-install.ts
@@ -1,6 +1,7 @@
 const Task = require('../ember-cli/lib/models/task');
 import * as chalk from 'chalk';
 import {exec} from 'child_process';
+import {checkYarnOrCNPM} from '../utilities/check-package-manager';
 
 
 export default Task.extend({
@@ -11,7 +12,7 @@ export default Task.extend({
       packageManager = 'npm';
     }
 
-    return new Promise(function(resolve, reject) {
+    return checkYarnOrCNPM().then(function () {
       ui.writeLine(chalk.green(`Installing packages for tooling via ${packageManager}.`));
       let installCommand = `${packageManager} install`;
       if (packageManager === 'npm') {
@@ -21,11 +22,11 @@ export default Task.extend({
         (err: NodeJS.ErrnoException, _stdout: string, stderr: string) => {
         if (err) {
           ui.writeLine(stderr);
-          ui.writeLine(chalk.red('Package install failed, see above.'));
-          reject();
+          const message = 'Package install failed, see above.';
+          ui.writeLine(chalk.red(message));
+          throw new Error(message);
         } else {
           ui.writeLine(chalk.green(`Installed packages for tooling via ${packageManager}.`));
-          resolve();
         }
       });
     });

--- a/packages/@angular/cli/utilities/check-package-manager.ts
+++ b/packages/@angular/cli/utilities/check-package-manager.ts
@@ -8,10 +8,6 @@ const packageManager = CliConfig.fromGlobal().get('packageManager');
 
 
 export function checkYarnOrCNPM() {
-  if (packageManager !== 'default') {
-    return Promise.resolve();
-  }
-
   return Promise
       .all([checkYarn(), checkCNPM()])
       .then((data: Array<boolean>) => {
@@ -23,6 +19,11 @@ export function checkYarnOrCNPM() {
           console.log(chalk.yellow('You can `ng set --global packageManager=yarn`.'));
         } else if (isCNPMInstalled) {
           console.log(chalk.yellow('You can `ng set --global packageManager=cnpm`.'));
+        } else  {
+          if (packageManager !== 'default' && packageManager !== 'npm') {
+            console.log(chalk.yellow(`Seems that ${packageManager} is not installed.`));
+            console.log(chalk.yellow('You can `ng set --global packageManager=npm`.'));
+          }
         }
       });
 }

--- a/tests/e2e/assets/webpack/test-app-weird/not/so/source/app/app.component.html
+++ b/tests/e2e/assets/webpack/test-app-weird/not/so/source/app/app.component.html
@@ -3,3 +3,11 @@
   <a [routerLink]="['lazy']">lazy</a>
   <router-outlet></router-outlet>
 </div>
+
+<!-- @ifdef DEBUG -->
+<p>DEBUG_ONLY</p>
+<!-- @endif -->
+
+<!-- @ifndef DEBUG -->
+<p>PRODUCTION_ONLY</p>
+<!-- @endif -->

--- a/tests/e2e/assets/webpack/test-app-weird/not/so/source/app/app.component.scss
+++ b/tests/e2e/assets/webpack/test-app-weird/not/so/source/app/app.component.scss
@@ -1,3 +1,15 @@
 :host {
   background-color: blue;
 }
+
+// @ifdef DEBUG
+:host::before {
+  content: 'DEBUG_ONLY';
+}
+// @endif
+
+// @ifndef DEBUG
+:host::before {
+  content: 'PRODUCTION_ONLY';
+}
+// @endif

--- a/tests/e2e/assets/webpack/test-app-weird/not/so/source/app/app.module.ts
+++ b/tests/e2e/assets/webpack/test-app-weird/not/so/source/app/app.module.ts
@@ -10,6 +10,15 @@ import { AppComponent } from './app.component';
 export class HomeView {}
 
 
+// @ifdef DEBUG
+console.log("DEBUG_ONLY");
+// @endif
+
+// @ifndef DEBUG
+console.log("PRODUCTION_ONLY");
+// @endif
+
+
 @NgModule({
   declarations: [
     AppComponent,

--- a/tests/e2e/assets/webpack/test-app-weird/package.json
+++ b/tests/e2e/assets/webpack/test-app-weird/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "node-sass": "^3.7.0",
     "performance-now": "^0.2.0",
+    "preprocess-loader": "^0.2.2",
     "raw-loader": "^0.5.1",
     "sass-loader": "^3.2.0",
     "typescript": "~2.1.0",

--- a/tests/e2e/assets/webpack/test-app-weird/webpack.config.js
+++ b/tests/e2e/assets/webpack/test-app-weird/webpack.config.js
@@ -1,5 +1,10 @@
 const ngToolsWebpack = require('@ngtools/webpack');
 
+const flags = require('./webpack.flags.json');
+
+const preprocessLoader = 'preprocess-loader' + (flags.DEBUG ? '?+DEBUG' : '');
+
+
 module.exports = {
   resolve: {
     extensions: ['.ts', '.js']
@@ -15,10 +20,14 @@ module.exports = {
   ],
   module: {
     loaders: [
-      { test: /\.scss$/, loaders: ['raw-loader', 'sass-loader'] },
+      { test: /\.scss$/, loaders: ['raw-loader', 'sass-loader', preprocessLoader] },
       { test: /\.css$/, loader: 'raw-loader' },
-      { test: /\.html$/, loader: 'raw-loader' },
-      { test: /\.ts$/, loader: '@ngtools/webpack' }
+      { test: /\.html$/, loaders: ['raw-loader', preprocessLoader] },
+      // Use preprocess to remove DEBUG only code.
+      { test: /\.ts$/, use: [
+        { loader: '@ngtools/webpack' },
+        { loader: preprocessLoader }
+      ] }
     ]
   },
   devServer: {

--- a/tests/e2e/assets/webpack/test-app-weird/webpack.flags.json
+++ b/tests/e2e/assets/webpack/test-app-weird/webpack.flags.json
@@ -1,0 +1,3 @@
+{
+  "DEBUG": false
+}

--- a/tests/e2e/tests/misc/live-reload.ts
+++ b/tests/e2e/tests/misc/live-reload.ts
@@ -11,7 +11,7 @@ import { wait } from '../../utils/utils';
 
 
 export default function () {
-  const protractorGoodRegEx = /Spec started/;
+  const protractorGoodRegEx = /Jasmine started/;
   const webpackGoodRegEx = /webpack: Compiled successfully./;
 
   // Create an express api for the Angular app to call.

--- a/tests/e2e/tests/packages/webpack/weird.ts
+++ b/tests/e2e/tests/packages/webpack/weird.ts
@@ -1,9 +1,9 @@
 import {normalize} from 'path';
 
 import {createProjectFromAsset} from '../../../utils/assets';
-import {exec} from '../../../utils/process';
+import {exec, execWithEnv} from '../../../utils/process';
 import {updateJsonFile} from '../../../utils/project';
-import {expectFileSizeToBeUnder, expectFileToExist} from '../../../utils/fs';
+import {expectFileSizeToBeUnder, expectFileToExist, expectFileToMatch} from '../../../utils/fs';
 import {expectToFail} from '../../../utils/utils';
 
 
@@ -18,9 +18,16 @@ export default function(skipCleaning: () => void) {
     .then(() => expectFileSizeToBeUnder('dist/app.main.js', 410000))
     .then(() => expectFileSizeToBeUnder('dist/0.app.main.js', 40000))
 
+    // Verify that we're using the production environment.
+    .then(() => expectFileToMatch('dist/app.main.js', /PRODUCTION_ONLY/))
+    .then(() => expectToFail(() => expectFileToMatch('dist/app.main.js', /DEBUG_ONLY/)))
+
     // Skip code generation and rebuild.
     .then(() => updateJsonFile('aotplugin.config.json', json => {
       json['skipCodeGeneration'] = true;
+    }))
+    .then(() => updateJsonFile('webpack.flags.json', json => {
+      json['DEBUG'] = true;
     }))
     .then(() => exec(normalize('node_modules/.bin/webpack'), '-p'))
     .then(() => expectFileToExist('dist/app.main.js'))
@@ -29,5 +36,10 @@ export default function(skipCleaning: () => void) {
     .then(() => expectFileToExist('dist/2.app.main.js'))
     .then(() => expectToFail(() => expectFileSizeToBeUnder('dist/app.main.js', 410000)))
     .then(() => expectFileSizeToBeUnder('dist/0.app.main.js', 40000))
+
+    // Verify that we're using the debug environment now.
+    .then(() => expectFileToMatch('dist/app.main.js', /DEBUG_ONLY/))
+    .then(() => expectToFail(() => expectFileToMatch('dist/app.main.js', /PRODUCTION_ONLY/)))
+
     .then(() => skipCleaning());
 }


### PR DESCRIPTION
If for some reason there is a wrong package manager in global config
user should be notified about this with example of how to set default
one

Closes #6635

Unwanted promise removed as @Brocco asks