### PR TITLE
fix(@angular/cli): Changed init order to make sure all files gets committed

### DIFF
--- a/packages/@angular/cli/tasks/init.ts
+++ b/packages/@angular/cli/tasks/init.ts
@@ -88,13 +88,13 @@ export default Task.extend({
 
     return installBlueprint.run(blueprintOpts)
       .then(function () {
-        if (commandOptions.skipGit === false) {
-          return gitInit.run(commandOptions, rawArgs);
+        if (!commandOptions.skipInstall) {
+          return npmInstall.run();
         }
       })
       .then(function () {
-        if (!commandOptions.skipInstall) {
-          return npmInstall.run();
+        if (commandOptions.skipGit === false) {
+          return gitInit.run(commandOptions, rawArgs);
         }
       })
       .then(function () {


### PR DESCRIPTION
With the update of npm 5 and the introduction of package-lock.json all files weren't
committed into the first commit.

And since [npm recommend](https://docs.npmjs.com/files/package-lock.json) that the package-lock.json gets committed into the repository it make sense to do it as default. Thus promoting users to use lock files.