### PR TITLE
feat(@angular/cli): set loaders to minimize

### DIFF
--- a/packages/@angular/cli/models/webpack-configs/production.ts
+++ b/packages/@angular/cli/models/webpack-configs/production.ts
@@ -97,8 +97,13 @@ export const getProdConfig = function (wco: WebpackConfigOptions) {
       new webpack.EnvironmentPlugin({
         'NODE_ENV': 'production'
       }),
+      new webpack.LoaderOptionsPlugin({
+        minimize: true,
+        debug: false
+      }),
       new (<any>webpack).HashedModuleIdsPlugin(),
       new webpack.optimize.UglifyJsPlugin(<any>{
+        beautify: false,
         mangle: { screw_ie8: true },
         compress: { screw_ie8: true, warnings: buildOptions.verbose },
         sourceMap: buildOptions.sourcemaps,


### PR DESCRIPTION
Loaders weren't being set to minimize in prod mode, as per https://webpack.js.org/guides/production/#the-manual-way.