### PR TITLE
fix(@angular/cli): change blog link to international one

### DIFF
--- a/packages/@angular/cli/blueprints/ng/files/__path__/app/app.component.html
+++ b/packages/@angular/cli/blueprints/ng/files/__path__/app/app.component.html
@@ -14,7 +14,7 @@
     <h2><a target="_blank" href="https://github.com/angular/angular-cli/wiki">CLI Documentation</a></h2>
   </li>
   <li>
-    <h2><a target="_blank" href="http://angularjs.blogspot.ca/">Angular blog</a></h2>
+    <h2><a target="_blank" href="http://angularjs.blogspot.com/">Angular blog</a></h2>
   </li>
 </ul>
 <% if (routing) { %>


### PR DESCRIPTION
Just a really minor, tiny fix that changes the official Angular blog to the international url, using the `.com` domain. This way it applies blogger.com's country-specific redirect rather than showing the `.ca` domain for everyone. :smile: 