### PR TITLE
chore(@angular/cli): bump jasmine and add jasminewd2 types

### DIFF
--- a/packages/@angular/cli/blueprints/ng/files/e2e/tsconfig.e2e.json
+++ b/packages/@angular/cli/blueprints/ng/files/e2e/tsconfig.e2e.json
@@ -6,6 +6,7 @@
     "target": "es5",
     "types": [
       "jasmine",
+      "jasminewd2",
       "node"
     ]
   }

--- a/packages/@angular/cli/blueprints/ng/files/package.json
+++ b/packages/@angular/cli/blueprints/ng/files/package.json
@@ -32,7 +32,8 @@
     "@angular/cli": "<%= version %>",
     "@angular/compiler-cli": "^4.0.0",
     "@angular/language-service": "^4.0.0",<% if (!minimal) { %>
-    "@types/jasmine": "2.5.45",
+    "@types/jasmine": "~2.5.53",
+    "@types/jasminewd2": "~2.0.2",
     "@types/node": "~6.0.60",
     "codelyzer": "~3.0.1",
     "jasmine-core": "~2.6.2",


### PR DESCRIPTION
This bumps jasmine types to 2.5.53.
The version was previously pinned down to 2.5.45, because more recent versions weren't playing nice with Protractor
and lead to errors like https://github.com/angular/protractor/issues/4176

The proper fix appears to be the one mentioned in the Protractor issue: add `@types/jasminewd2` typings, and add these typings to the tsconfig for e2e tests.

[jasminewd](https://github.com/angular/jasminewd) is the adapter used by Protractor to handle the async part.