### PR TITLE
fix(@ngtools/webpack): fix no real error information.

### DIFF
--- a/packages/@ngtools/webpack/src/index.ts
+++ b/packages/@ngtools/webpack/src/index.ts
@@ -7,7 +7,8 @@ let version;
 try {
   version = require('@angular/compiler-cli').VERSION;
 } catch (e) {
-  throw new Error('The "@angular/compiler-cli" package was not properly installed.');
+  e.message += ' The "@angular/compiler-cli" package was not properly installed.'
+  throw e;
 }
 
 // Check that Angular is also not part of this module's node_modules (it should be the project's).


### PR DESCRIPTION
When node want to resolve module rxjs but he was not installed this try catch hide real error and throw not very useful error message.