### PR TITLE
fix(@angular/cli): check package manager existance before installing packages

### DIFF
--- a/packages/@angular/cli/tasks/npm-install.ts
+++ b/packages/@angular/cli/tasks/npm-install.ts
@@ -1,6 +1,7 @@
 const Task = require('../ember-cli/lib/models/task');
 import * as chalk from 'chalk';
 import {exec} from 'child_process';
+import {checkYarnOrCNPM} from '../utilities/check-package-manager';
 
 
 export default Task.extend({
@@ -11,7 +12,7 @@ export default Task.extend({
       packageManager = 'npm';
     }
 
-    return new Promise(function(resolve, reject) {
+    return checkYarnOrCNPM().then(function () {
       ui.writeLine(chalk.green(`Installing packages for tooling via ${packageManager}.`));
       let installCommand = `${packageManager} install`;
       if (packageManager === 'npm') {
@@ -21,11 +22,11 @@ export default Task.extend({
         (err: NodeJS.ErrnoException, _stdout: string, stderr: string) => {
         if (err) {
           ui.writeLine(stderr);
-          ui.writeLine(chalk.red('Package install failed, see above.'));
-          reject();
+          const message = 'Package install failed, see above.';
+          ui.writeLine(chalk.red(message));
+          throw new Error(message);
         } else {
           ui.writeLine(chalk.green(`Installed packages for tooling via ${packageManager}.`));
-          resolve();
         }
       });
     });

--- a/packages/@angular/cli/utilities/check-package-manager.ts
+++ b/packages/@angular/cli/utilities/check-package-manager.ts
@@ -8,10 +8,6 @@ const packageManager = CliConfig.fromGlobal().get('packageManager');
 
 
 export function checkYarnOrCNPM() {
-  if (packageManager !== 'default') {
-    return Promise.resolve();
-  }
-
   return Promise
       .all([checkYarn(), checkCNPM()])
       .then((data: Array<boolean>) => {
@@ -23,6 +19,11 @@ export function checkYarnOrCNPM() {
           console.log(chalk.yellow('You can `ng set --global packageManager=yarn`.'));
         } else if (isCNPMInstalled) {
           console.log(chalk.yellow('You can `ng set --global packageManager=cnpm`.'));
+        } else  {
+          if (packageManager !== 'default' && packageManager !== 'npm') {
+            console.log(chalk.yellow(`Seems that ${packageManager} is not installed.`));
+            console.log(chalk.yellow('You can `ng set --global packageManager=npm`.'));
+          }
         }
       });
 }


### PR DESCRIPTION
If for some reason there is a wrong package manager in global config
user should be notified about this with example of how to set default
one

Closes #6635

Unwanted promise removed as @Brocco asks