### PR TITLE
fix(@angular/cli): enhances & improves project name validation

### DIFF
--- a/packages/@angular/cli/utilities/validate-project-name.ts
+++ b/packages/@angular/cli/utilities/validate-project-name.ts
@@ -2,30 +2,33 @@ import {oneLine, stripIndent} from 'common-tags';
 
 const SilentError = require('silent-error');
 
-const projectNameRegexp = /^[a-zA-Z][.0-9a-zA-Z]*(-[.0-9a-zA-Z]*)*$/;
+const projectNameRegexp = /^[a-zA-Z][0-9a-zA-Z]*([-. ][a-zA-Z][0-9a-zA-Z]*)*$/;
 const unsupportedProjectNames = ['test', 'ember', 'ember-cli', 'vendor', 'app'];
 
-function getRegExpFailPosition(str: string): number | null {
+function getRegExpFailPosition(str: string): number {
+  if (projectNameRegexp.test(str)) { return -1; }
+
   const parts = str.split('-');
   const matched: string[] = [];
 
   parts.forEach(part => {
-    if (part.match(projectNameRegexp)) {
+    if (projectNameRegexp.test(part)) {
       matched.push(part);
     }
   });
 
   const compare = matched.join('-');
-  return (str !== compare) ? compare.length : null;
+  return (str !== compare) ? compare.length : -1;
 }
 
 export function validateProjectName(projectName: string) {
   const errorIndex = getRegExpFailPosition(projectName);
-  if (errorIndex !== null) {
+  if (errorIndex !== -1) {
     const firstMessage = oneLine`
       Project name "${projectName}" is not valid. New project names must
-      start with a letter, and must contain only alphanumeric characters or dashes.
-      When adding a dash the segment after the dash must also start with a letter.
+      start with a letter, and must contain only alphanumeric characters, spaces, dots or dashes.
+      New project name must end with alphanumeric characters.
+      When adding a dash, space or dot the segment after the it must also start with a letter.
     `;
     const msg = stripIndent`
       ${firstMessage}

--- a/tests/acceptance/new.spec.ts
+++ b/tests/acceptance/new.spec.ts
@@ -59,6 +59,10 @@ describe('Acceptance: ng new', function () {
     return ng(['new', '!', '--skip-install', '--skip-git', '--inline-template'])
       .then(() => done.fail(), () => done());
   });
+  it('requires a valid name (123)', (done) => {
+    return ng(['new', '123', '--skip-install', '--skip-git', '--inline-template'])
+      .then(() => done.fail(), () => done());
+  });
   it('requires a valid name (abc-.)', (done) => {
     return ng(['new', 'abc-.', '--skip-install', '--skip-git', '--inline-template'])
       .then(() => done.fail(), () => done());
@@ -67,20 +71,97 @@ describe('Acceptance: ng new', function () {
     return ng(['new', 'abc-', '--skip-install', '--skip-git', '--inline-template'])
       .then(() => done.fail(), () => done());
   });
-  it('requires a valid name (abc-def-)', (done) => {
-    return ng(['new', 'abc-def-', '--skip-install', '--skip-git', '--inline-template'])
+  it('requires a valid name ( abc)', (done) => {
+    return ng(['new', ' abc', '--skip-install', '--skip-git', '--inline-template'])
+      .then(() => done.fail(), () => done());
+  });
+  it('requires a valid name (abc )', (done) => {
+    return ng(['new', 'abc ', '--skip-install', '--skip-git', '--inline-template'])
+      .then(() => done.fail(), () => done());
+  });
+  it('requires a valid name (.abc)', (done) => {
+    return ng(['new', '.abc', '--skip-install', '--skip-git', '--inline-template'])
+      .then(() => done.fail(), () => done());
+  });
+  it('requires a valid name (abc.)', (done) => {
+    return ng(['new', 'abc.', '--skip-install', '--skip-git', '--inline-template'])
       .then(() => done.fail(), () => done());
   });
   it('requires a valid name (abc-123)', (done) => {
     return ng(['new', 'abc-123', '--skip-install', '--skip-git', '--inline-template'])
       .then(() => done.fail(), () => done());
   });
+  it('requires a valid name (abc 123)', (done) => {
+    return ng(['new', 'abc 123', '--skip-install', '--skip-git', '--inline-template'])
+      .then(() => done.fail(), () => done());
+  });
+  it('requires a valid name (abc.123)', (done) => {
+    return ng(['new', 'abc.123', '--skip-install', '--skip-git', '--inline-template'])
+      .then(() => done.fail(), () => done());
+  });
+  it('requires a valid name (abc-def-)', (done) => {
+    return ng(['new', 'abc-def-', '--skip-install', '--skip-git', '--inline-template'])
+      .then(() => done.fail(), () => done());
+  });
+  it('requires a valid name (abc-def--)', (done) => {
+    return ng(['new', 'abc-def--', '--skip-install', '--skip-git', '--inline-template'])
+      .then(() => done.fail(), () => done());
+  });
+  it('requires a valid name (abc--def)', (done) => {
+    return ng(['new', 'abc--def', '--skip-install', '--skip-git', '--inline-template'])
+      .then(() => done.fail(), () => done());
+  });
+  it('requires a valid name (abc.def.)', (done) => {
+    return ng(['new', 'abc.def.', '--skip-install', '--skip-git', '--inline-template'])
+      .then(() => done.fail(), () => done());
+  });
+  it('requires a valid name (abc.def..)', (done) => {
+    return ng(['new', 'abc.def..', '--skip-install', '--skip-git', '--inline-template'])
+      .then(() => done.fail(), () => done());
+  });
+  it('requires a valid name (abc..def)', (done) => {
+    return ng(['new', 'abc..def', '--skip-install', '--skip-git', '--inline-template'])
+      .then(() => done.fail(), () => done());
+  });
+  it('requires a valid name (abc def )', (done) => {
+    return ng(['new', 'abc def ', '--skip-install', '--skip-git', '--inline-template'])
+      .then(() => done.fail(), () => done());
+  });
+  it('requires a valid name (abc  def)', (done) => {
+    return ng(['new', 'abc  def', '--skip-install', '--skip-git', '--inline-template'])
+      .then(() => done.fail(), () => done());
+  });
+
   it('requires a valid name (abc)', (done) => {
     return ng(['new', 'abc', '--skip-install', '--skip-git', '--inline-template'])
       .then(() => done(), () => done.fail());
   });
   it('requires a valid name (abc-def)', (done) => {
     return ng(['new', 'abc-def', '--skip-install', '--skip-git', '--inline-template'])
+      .then(() => done(), () => done.fail());
+  });
+  it('requires a valid name (abc-def123)', (done) => {
+    return ng(['new', 'abc-def123', '--skip-install', '--skip-git', '--inline-template'])
+      .then(() => done(), () => done.fail());
+  });
+  it('requires a valid name (abc def)', (done) => {
+    return ng(['new', 'abc def', '--skip-install', '--skip-git', '--inline-template'])
+      .then(() => done(), () => done.fail());
+  });
+  it('requires a valid name (abc def123)', (done) => {
+    return ng(['new', 'abc def123', '--skip-install', '--skip-git', '--inline-template'])
+      .then(() => done(), () => done.fail());
+  });
+  it('requires a valid name (abc.def)', (done) => {
+    return ng(['new', 'abc.def', '--skip-install', '--skip-git', '--inline-template'])
+      .then(() => done(), () => done.fail());
+  });
+  it('requires a valid name (abc.def123)', (done) => {
+    return ng(['new', 'abc.def123', '--skip-install', '--skip-git', '--inline-template'])
+      .then(() => done(), () => done.fail());
+  });
+  it('requires a valid name (abc-def hello.app)', (done) => {
+    return ng(['new', 'abc-def hello.app', '--skip-install', '--skip-git', '--inline-template'])
       .then(() => done(), () => done.fail());
   });
 


### PR DESCRIPTION
- added support for accepting spaces in project name (i.e., just like dashes and dots)
- improved bit of regex and now according to changed regex the package name **must**:
    - start with a letter (`[a-zA-Z]`)
    - end with alphanumeric characters (`[0-9a-zA-Z]`)
    - start with letter after adding dash, dot or space (`[-. ][a-zA-Z]`)
    - contain exactly one (i.e., either dash, dot or a space) between two segments.
 
Some of the example names are below:

**Valid names:**
- foo
- foo bar
- foo-bar
- foo.bar
- foo123
- foo-bar123
- foo.bar123 test-app

**Invalid names:**
- empty
- space / dot / dash at the starts or ends of the name.
- foo-
- -foo
- foo.
- foo..bar
- foo--bar
- foo123
- foo-123
- foo 123

Fyi. 
`$ yarn test:cli` - All tests are passing..
```
>  yarn test:cli
yarn test:cli v0.24.5
$ node tests/runner
Started
........................................................................................................................................................................


168 specs, 0 failures
Finished in 153.667 seconds

✨  Done in 155.91s.
```