### PR TITLE
docs: point users to the Releases page

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ npm install
 
 If you are updating to 1.0 from a beta or RC version, check out our [1.0 Update Guide](https://github.com/angular/angular-cli/wiki/stories-1.0-update).
 
-You can find more details about changes between versions in [CHANGELOG.md](https://github.com/angular/angular-cli/blob/master/CHANGELOG.md).
+You can find more details about changes between versions on the [Releases](https://github.com/angular/angular-cli/releases) page.
 
 
 ## Development Hints for working on Angular CLI


### PR DESCRIPTION
[CHANGELOG.md](https://github.com/angular/angular-cli/blob/ec287158d68bf0a59e9c083ffb6d69d70e6b9edd/CHANGELOG.md) is deprecated

Relates to #6850