### PR TITLE
test(@angular/cli): disable sourcemaps by default in test suite

### DIFF
--- a/tests/e2e/setup/500-create-project.ts
+++ b/tests/e2e/setup/500-create-project.ts
@@ -66,6 +66,18 @@ export default function() {
         });
       }
     })
+    .then(() => updateJsonFile('.angular-cli.json', configJson => {
+      // Auto-add some flags to ng commands that build or test the app.
+      // --no-progress disables progress logging, which in CI logs thousands of lines.
+      // --no-sourcemaps disables sourcemaps, making builds faster.
+      // We add these flags before other args so that they can be overriden.
+      // e.g. `--no-sourcemaps --sourcemaps` will still generate sourcemaps.
+      const defaults = configJson.defaults;
+      defaults.build = {
+        sourcemaps: false,
+        progress: false
+      };
+    }))
     .then(() => silentNpm('install'))
     // Force sourcemaps to be from the root of the filesystem.
     .then(() => updateTsConfig(json => {

--- a/tests/e2e/tests/build/sourcemap.ts
+++ b/tests/e2e/tests/build/sourcemap.ts
@@ -10,7 +10,7 @@ export default function() {
     return Promise.resolve();
   }
 
-  return ng('build')
+  return ng('build', '--sourcemaps')
     .then(() => expectFileToExist('dist/main.bundle.js.map'))
 
     .then(() => ng('build', '--no-sourcemap'))

--- a/tests/e2e/tests/build/vendor-chunk-symlink-node-module.ts
+++ b/tests/e2e/tests/build/vendor-chunk-symlink-node-module.ts
@@ -9,7 +9,6 @@ export default function() {
     .then(() => symlinkFile('../node_modules', 'node_modules', 'dir'))
     .then(() => ng('build'))
     .then(() => expectFileToExist('dist/vendor.bundle.js'))
-    .then(() => expectFileToExist('dist/vendor.bundle.js.map'))
     // Cleanup
     .then(() => {
       return deleteFile('node_modules')

--- a/tests/e2e/tests/test/test-fail-watch.ts
+++ b/tests/e2e/tests/test/test-fail-watch.ts
@@ -12,7 +12,7 @@ const karmaGoodRegEx = /Executed 3 of 3 SUCCESS \(\d+\.\d+ secs/;
 
 export default function () {
   let originalSpec: string;
-  return silentExecAndWaitForOutputToMatch('ng', ['test', '--no-progress'], karmaGoodRegEx)
+  return silentExecAndWaitForOutputToMatch('ng', ['test'], karmaGoodRegEx)
     .then(() => readFile('src/app/app.component.spec.ts'))
     .then((data) => originalSpec = data)
     // Trigger a failed rebuild, which shouldn't run tests again.

--- a/tests/e2e/utils/process.ts
+++ b/tests/e2e/utils/process.ts
@@ -139,7 +139,6 @@ export function silentExecAndWaitForOutputToMatch(cmd: string, args: string[], m
 
 let npmInstalledEject = false;
 export function ng(...args: string[]) {
-  // Auto-add --no-progress to commands that build the app, otherwise we get thousands of lines.
   if (['build', 'serve', 'test', 'e2e', 'xi18n'].indexOf(args[0]) != -1) {
     // If we have the --eject, use webpack for the test.
     const argv = getGlobalVariable('argv');
@@ -156,7 +155,7 @@ export function ng(...args: string[]) {
         .then(() => _exec({silent: true}, 'node_modules/.bin/webpack', []));
     }
 
-    return silentNg(...args, '--no-progress');
+    return silentNg(...args);
   } else {
     return _exec({}, 'ng', args);
   }

--- a/tests/e2e/utils/project.ts
+++ b/tests/e2e/utils/project.ts
@@ -26,7 +26,7 @@ export function updateTsConfig(fn: (json: any) => any | void) {
 
 export function ngServe(...args: string[]) {
   return silentExecAndWaitForOutputToMatch('ng',
-    ['serve', '--no-progress', ...args],
+    ['serve', ...args],
     /webpack: bundle is now VALID|webpack: Compiled successfully./);
 }
 


### PR DESCRIPTION
Note: this PR is for the repository test suite, not for project commands like `ng test`.