### PR TITLE
feat(@angular/cli): add build defaults to config

### DIFF
--- a/packages/@angular/cli/commands/build.ts
+++ b/packages/@angular/cli/commands/build.ts
@@ -5,8 +5,12 @@ import { oneLine } from 'common-tags';
 
 const Command = require('../ember-cli/lib/models/command');
 
+
 const config = CliConfig.fromProject() || CliConfig.fromGlobal();
-const pollDefault = config.config.defaults && config.config.defaults.poll;
+const buildConfigDefaults = config.getPaths('defaults.build', [
+  'sourcemaps', 'baseHref', 'progress', 'poll', 'deleteOutputPath', 'preserveSymlinks',
+  'showCircularDependencies'
+]);
 
 // defaults for BuildOptions
 export const baseBuildCommandOptions: any = [
@@ -20,7 +24,7 @@ export const baseBuildCommandOptions: any = [
   {
     name: 'environment',
     type: String,
-    aliases: ['e'] ,
+    aliases: ['e'],
     description: 'Defines the build environment.'
   },
   {
@@ -38,7 +42,8 @@ export const baseBuildCommandOptions: any = [
     name: 'sourcemaps',
     type: Boolean,
     aliases: ['sm', 'sourcemap'],
-    description: 'Output sourcemaps.'
+    description: 'Output sourcemaps.',
+    default: buildConfigDefaults['sourcemaps']
   },
   {
     name: 'vendor-chunk',
@@ -51,7 +56,8 @@ export const baseBuildCommandOptions: any = [
     name: 'base-href',
     type: String,
     aliases: ['bh'],
-    description: 'Base url for the application being built.'
+    description: 'Base url for the application being built.',
+    default: buildConfigDefaults['base-href']
   },
   {
     name: 'deploy-url',
@@ -69,9 +75,9 @@ export const baseBuildCommandOptions: any = [
   {
     name: 'progress',
     type: Boolean,
-    default: true,
     aliases: ['pr'],
-    description: 'Log progress to the console while building.'
+    description: 'Log progress to the console while building.',
+    default: buildConfigDefaults['progress']
   },
   {
     name: 'i18n-file',
@@ -111,8 +117,8 @@ export const baseBuildCommandOptions: any = [
   {
     name: 'poll',
     type: Number,
-    default: pollDefault,
-    description: 'Enable and define the file watching poll time period (milliseconds).'
+    description: 'Enable and define the file watching poll time period (milliseconds).',
+    default: buildConfigDefaults['poll']
   },
   {
     name: 'app',
@@ -123,15 +129,15 @@ export const baseBuildCommandOptions: any = [
   {
     name: 'delete-output-path',
     type: Boolean,
-    default: true,
     aliases: ['dop'],
-    description: 'Delete output path before build.'
+    description: 'Delete output path before build.',
+    default: buildConfigDefaults['deleteOutputPath'],
   },
   {
     name: 'preserve-symlinks',
     type: Boolean,
-    default: false,
-    description: 'Do not use the real path when resolving modules.'
+    description: 'Do not use the real path when resolving modules.',
+    default: buildConfigDefaults['preserveSymlinks']
   },
   {
     name: 'extract-licenses',
@@ -143,7 +149,8 @@ export const baseBuildCommandOptions: any = [
     name: 'show-circular-dependencies',
     type: Boolean,
     aliases: ['scd'],
-    description: 'Show circular dependency warnings on builds.'
+    description: 'Show circular dependency warnings on builds.',
+    default: buildConfigDefaults['showCircularDependencies']
   }
 ];
 
@@ -158,12 +165,12 @@ const BuildCommand = Command.extend({
 
   availableOptions: baseBuildCommandOptions.concat([
     {
-       name: 'stats-json',
-       type: Boolean,
-       default: false,
-       description: oneLine`Generates a \`stats.json\` file which can be analyzed using tools
+      name: 'stats-json',
+      type: Boolean,
+      default: false,
+      description: oneLine`Generates a \`stats.json\` file which can be analyzed using tools
        such as: \`webpack-bundle-analyzer\` or https://webpack.github.io/analyse.`
-      }
+    }
   ]),
 
   run: function (commandOptions: BuildTaskOptions) {

--- a/packages/@angular/cli/commands/serve.ts
+++ b/packages/@angular/cli/commands/serve.ts
@@ -9,12 +9,10 @@ import { overrideOptions } from '../utilities/override-options';
 const Command = require('../ember-cli/lib/models/command');
 
 const config = CliConfig.fromProject() || CliConfig.fromGlobal();
-const defaultPort = process.env.PORT || config.get('defaults.serve.port');
-const defaultHost = config.get('defaults.serve.host');
-const defaultSsl = config.get('defaults.serve.ssl');
-const defaultSslKey = config.get('defaults.serve.sslKey');
-const defaultSslCert = config.get('defaults.serve.sslCert');
-const defaultProxyConfig = config.get('defaults.serve.proxyConfig');
+const serveConfigDefaults = config.getPaths('defaults.serve', [
+  'port', 'host', 'ssl', 'sslKey', 'sslCert', 'proxyConfig'
+]);
+const defaultPort = process.env.PORT || serveConfigDefaults['port'];
 
 export interface ServeTaskOptions extends BuildOptions {
   port?: number;
@@ -43,33 +41,33 @@ export const baseServeCommandOptions: any = overrideOptions([
   {
     name: 'host',
     type: String,
-    default: defaultHost,
+    default: serveConfigDefaults['host'],
     aliases: ['H'],
-    description: `Listens only on ${defaultHost} by default.`
+    description: `Listens only on ${serveConfigDefaults['host']} by default.`
   },
   {
     name: 'proxy-config',
     type: 'Path',
-    default: defaultProxyConfig,
+    default: serveConfigDefaults['proxyConfig'],
     aliases: ['pc'],
     description: 'Proxy configuration file.'
   },
   {
     name: 'ssl',
     type: Boolean,
-    default: defaultSsl,
+    default: serveConfigDefaults['ssl'],
     description: 'Serve using HTTPS.'
   },
   {
     name: 'ssl-key',
     type: String,
-    default: defaultSslKey,
+    default: serveConfigDefaults['sslKey'],
     description: 'SSL key to use for serving HTTPS.'
   },
   {
     name: 'ssl-cert',
     type: String,
-    default: defaultSslCert,
+    default: serveConfigDefaults['sslCert'],
     description: 'SSL certificate to use for serving HTTPS.'
   },
   {

--- a/packages/@angular/cli/lib/config/schema.json
+++ b/packages/@angular/cli/lib/config/schema.json
@@ -118,11 +118,6 @@
             "type": "boolean",
             "default": false
           },
-          "showCircularDependencies": {
-            "description": "Show circular dependency warnings on builds.",
-            "type": "boolean",
-            "default": true
-          },
           "styles": {
             "description": "Global styles to be included in the build.",
             "type": "array",
@@ -446,6 +441,44 @@
             },
             "spec": {
               "description": "Specifies if a spec file is generated.",
+              "type": "boolean",
+              "default": true
+            }
+          }
+        },
+        "build": {
+          "description": "Properties to be passed to the build command.",
+          "type": "object",
+          "properties": {
+            "sourcemaps": {
+              "description": "Output sourcemaps.",
+              "type": "boolean"
+            },
+            "baseHref": {
+              "description": "Base url for the application being built.",
+              "type": "string"
+            },
+            "progress": {
+              "description": "The ssl key used by the server.",
+              "type": "boolean",
+              "default": true
+            },
+            "poll": {
+              "description": "Enable and define the file watching poll time period (milliseconds).",
+              "type": "number"
+            },
+            "deleteOutputPath": {
+              "description": "Delete output path before build.",
+              "type": "boolean",
+              "default": true
+            },
+            "preserveSymlinks": {
+              "description": "Do not use the real path when resolving modules.",
+              "type": "boolean",
+              "default": false
+            },
+            "showCircularDependencies": {
+              "description": "Show circular dependency warnings on builds.",
               "type": "boolean",
               "default": true
             }

--- a/packages/@angular/cli/models/config.ts
+++ b/packages/@angular/cli/models/config.ts
@@ -65,31 +65,7 @@ export class CliConfig extends CliConfigBase<ConfigInterface> {
 
     const cliConfig = CliConfigBase.fromConfigPath<ConfigInterface>(globalConfigPath);
 
-    const aliases = [
-      cliConfig.alias('apps.0.root', 'defaults.sourceDir'),
-      cliConfig.alias('apps.0.prefix', 'defaults.prefix')
-    ];
-
-    // Additional aliases which do not emit any messages.
-    cliConfig.alias('defaults.interface.prefix', 'defaults.inline.prefixInterfaces');
-    cliConfig.alias('defaults.component.inlineStyle', 'defaults.inline.style');
-    cliConfig.alias('defaults.component.inlineTemplate', 'defaults.inline.template');
-    cliConfig.alias('defaults.component.spec', 'defaults.spec.component');
-    cliConfig.alias('defaults.class.spec', 'defaults.spec.class');
-    cliConfig.alias('defaults.component.directive', 'defaults.spec.directive');
-    cliConfig.alias('defaults.component.module', 'defaults.spec.module');
-    cliConfig.alias('defaults.component.pipe', 'defaults.spec.pipe');
-    cliConfig.alias('defaults.component.service', 'defaults.spec.service');
-
-    // If any of them returned true, output a deprecation warning.
-    if (aliases.some(x => x)) {
-      console.error(chalk.yellow(oneLine`
-        The "defaults.prefix" and "defaults.sourceDir" properties of .angular-cli.json
-        are deprecated in favor of "apps[0].root" and "apps[0].prefix".\n
-        Please update in order to avoid errors in future versions of Angular CLI.
-      `));
-    }
-
+    CliConfig.addAliases(cliConfig);
     configCacheMap.set(globalConfigPath, cliConfig);
     return cliConfig;
   }
@@ -108,10 +84,27 @@ export class CliConfig extends CliConfigBase<ConfigInterface> {
     const globalConfigPath = CliConfig.globalConfigFilePath();
     const cliConfig = CliConfigBase.fromConfigPath<ConfigInterface>(configPath, [globalConfigPath]);
 
+    CliConfig.addAliases(cliConfig);
+    configCacheMap.set(configPath, cliConfig);
+    return cliConfig as CliConfig;
+  }
+
+  static addAliases(cliConfig: CliConfigBase<ConfigInterface>) {
+
+    // Aliases with deprecation messages.
     const aliases = [
       cliConfig.alias('apps.0.root', 'defaults.sourceDir'),
       cliConfig.alias('apps.0.prefix', 'defaults.prefix')
     ];
+
+    // If any of them returned true, output a deprecation warning.
+    if (aliases.some(x => x)) {
+      console.error(chalk.yellow(oneLine`
+        The "defaults.prefix" and "defaults.sourceDir" properties of .angular-cli.json
+        are deprecated in favor of "apps[0].root" and "apps[0].prefix".\n
+        Please update in order to avoid errors in future versions of Angular CLI.
+      `));
+    }
 
     // Additional aliases which do not emit any messages.
     cliConfig.alias('defaults.interface.prefix', 'defaults.inline.prefixInterfaces');
@@ -123,17 +116,6 @@ export class CliConfig extends CliConfigBase<ConfigInterface> {
     cliConfig.alias('defaults.component.module', 'defaults.spec.module');
     cliConfig.alias('defaults.component.pipe', 'defaults.spec.pipe');
     cliConfig.alias('defaults.component.service', 'defaults.spec.service');
-
-    // If any of them returned true, output a deprecation warning.
-    if (aliases.some(x => x)) {
-      console.error(chalk.yellow(oneLine`
-        The "defaults.prefix" and "defaults.sourceDir" properties of .angular-cli.json
-        are deprecated in favor of "apps[0].root" and "apps[0].prefix".\n
-        Please update in order to avoid errors in future versions of Angular CLI.
-      `));
-    }
-
-    configCacheMap.set(configPath, cliConfig);
-    return cliConfig as CliConfig;
+    cliConfig.alias('defaults.build.poll', 'defaults.poll');
   }
 }

--- a/packages/@angular/cli/models/config/config.ts
+++ b/packages/@angular/cli/models/config/config.ts
@@ -61,6 +61,12 @@ export class CliConfig<JsonType> {
     this._config.$$set(jsonPath, value);
   }
 
+  getPaths(baseJsonPath: string, keys: string[]) {
+    const ret: { [k: string]: any } = {};
+    keys.forEach(key => ret[key] = this.get(`${baseJsonPath}.${key}`));
+    return ret;
+  }
+
   static fromJson<ConfigType>(content: ConfigType, ...global: ConfigType[]) {
     const schemaContent = fs.readFileSync(DEFAULT_CONFIG_SCHEMA_PATH, 'utf-8');
     let schema: Object;

--- a/packages/@angular/cli/models/webpack-config.ts
+++ b/packages/@angular/cli/models/webpack-config.ts
@@ -98,8 +98,7 @@ export class NgCliWebpackConfig {
     const mergeableOptions = {
       outputPath: appConfig.outDir,
       deployUrl: appConfig.deployUrl,
-      baseHref: appConfig.baseHref,
-      showCircularDependencies: appConfig.showCircularDependencies
+      baseHref: appConfig.baseHref
     };
 
     return Object.assign({}, mergeableOptions, buildOptions);

--- a/tests/e2e/tests/misc/circular-dependency.ts
+++ b/tests/e2e/tests/misc/circular-dependency.ts
@@ -10,7 +10,7 @@ export default async function () {
     throw new Error('Expected to have circular dependency warning in output.');
   }
 
-  await ng('set', 'apps.0.showCircularDependencies=false');
+  await ng('set', 'defaults.build.showCircularDependencies=false');
   output = await ng('build');
   if (output.stdout.match(/WARNING in Circular dependency detected/)) {
     throw new Error('Expected to not have circular dependency warning in output.');


### PR DESCRIPTION
Adds following defaults to `.angular-cli.json` under `defaults`: `sourcemaps`, `baseHref`, `progress`, `poll`, `deleteOutputPath`, `preserveSymlinks`, `showCircularDependencies`.

They can be set via `ng set defaults.build.KEY = VALUE`.

Also removes `apps.0.showCircularDependencies`. This is not a breaking chance since it was only added in 1.3.0-beta.0.

Followup to https://github.com/angular/angular-cli/pull/6884#discussion_r125533830.