### PR TITLE
fix(@angular/cli): always ignore node_modules for lint

### DIFF
--- a/packages/@angular/cli/blueprints/ng/files/angular-cli.json
+++ b/packages/@angular/cli/blueprints/ng/files/angular-cli.json
@@ -36,13 +36,16 @@
   },
   "lint": [
     {
-      "project": "<%= sourceDir %>/tsconfig.app.json"
+      "project": "<%= sourceDir %>/tsconfig.app.json",
+      "exclude": "**/node_modules/**"
     },
     {
-      "project": "<%= sourceDir %>/tsconfig.spec.json"
+      "project": "<%= sourceDir %>/tsconfig.spec.json",
+      "exclude": "**/node_modules/**"
     },
     {
-      "project": "e2e/tsconfig.e2e.json"
+      "project": "e2e/tsconfig.e2e.json",
+      "exclude": "**/node_modules/**"
     }
   ],
   "test": {


### PR DESCRIPTION
Fix #6626