### PR TITLE
fix(@angular/cli): use build defaults in test

### DIFF
--- a/packages/@angular/cli/commands/test.ts
+++ b/packages/@angular/cli/commands/test.ts
@@ -4,7 +4,9 @@ import { CliConfig } from '../models/config';
 import { oneLine } from 'common-tags';
 
 const config = CliConfig.fromProject() || CliConfig.fromGlobal();
-const pollDefault = config.config.defaults && config.config.defaults.poll;
+const testConfigDefaults = config.getPaths('defaults.build', [
+  'progress', 'poll'
+]);
 
 export interface TestOptions {
   watch?: boolean;
@@ -60,7 +62,7 @@ const TestCommand = Command.extend({
     {
       name: 'progress',
       type: Boolean,
-      default: true,
+      default: testConfigDefaults['progress'],
       description: 'Log progress to the console while in progress.'
     },
     {
@@ -98,7 +100,7 @@ const TestCommand = Command.extend({
     {
       name: 'poll',
       type: Number,
-      default: pollDefault,
+      default: testConfigDefaults['poll'],
       description: 'Enable and define the file watching poll time period (milliseconds).'
     },
     {


### PR DESCRIPTION
These defaults were added to build/serve/e2e but not to test.