### PR TITLE
test: replace silent exec with just exec

### DIFF
--- a/tests/e2e/tests/build/poll.ts
+++ b/tests/e2e/tests/build/poll.ts
@@ -1,7 +1,7 @@
 import {
   killAllProcesses,
   waitForAnyProcessOutputToMatch,
-  silentExecAndWaitForOutputToMatch
+  execAndWaitForOutputToMatch
 } from '../../utils/process';
 import {appendToFile} from '../../utils/fs';
 import {expectToFail, wait} from '../../utils/utils';
@@ -19,7 +19,7 @@ export default function() {
   }
 
 
-  return silentExecAndWaitForOutputToMatch('ng', ['serve', '--poll=10000'], webpackGoodRegEx)
+  return execAndWaitForOutputToMatch('ng', ['serve', '--poll=10000'], webpackGoodRegEx)
     // Wait before editing a file.
     // Editing too soon seems to trigger a rebuild and throw polling out of whack.
     .then(() => wait(2000))

--- a/tests/e2e/tests/build/rebuild-css-change.ts
+++ b/tests/e2e/tests/build/rebuild-css-change.ts
@@ -2,7 +2,7 @@ import {
   killAllProcesses,
   exec,
   waitForAnyProcessOutputToMatch,
-  silentExecAndWaitForOutputToMatch
+  execAndWaitForOutputToMatch
 } from '../../utils/process';
 import {appendToFile} from '../../utils/fs';
 import {getGlobalVariable} from '../../utils/env';
@@ -19,7 +19,7 @@ export default function() {
   }
 
 
-  return silentExecAndWaitForOutputToMatch('ng', ['serve'], webpackGoodRegEx)
+  return execAndWaitForOutputToMatch('ng', ['serve'], webpackGoodRegEx)
     // Should trigger a rebuild.
     .then(() => exec('touch', 'src/main.ts'))
     .then(() => waitForAnyProcessOutputToMatch(webpackGoodRegEx, 10000))

--- a/tests/e2e/tests/build/rebuild-deps-type-check.ts
+++ b/tests/e2e/tests/build/rebuild-deps-type-check.ts
@@ -1,7 +1,7 @@
 import {
   killAllProcesses,
   waitForAnyProcessOutputToMatch,
-  silentExecAndWaitForOutputToMatch,
+  execAndWaitForOutputToMatch,
 } from '../../utils/process';
 import {writeFile, prependToFile, appendToFile} from '../../utils/fs';
 import {wait} from '../../utils/utils';
@@ -39,7 +39,7 @@ export default function() {
     `))
     .then(() => wait(2000))
     // Should trigger a rebuild, no error expected.
-    .then(() => silentExecAndWaitForOutputToMatch('ng', ['serve'], doneRe))
+    .then(() => execAndWaitForOutputToMatch('ng', ['serve'], doneRe))
     // Make an invalid version of the file.
     .then(() => writeFile('src/funky2.ts', `
       export function funky2(value: number): number {

--- a/tests/e2e/tests/build/rebuild.ts
+++ b/tests/e2e/tests/build/rebuild.ts
@@ -2,7 +2,7 @@ import {
   killAllProcesses,
   exec,
   waitForAnyProcessOutputToMatch,
-  silentExecAndWaitForOutputToMatch,
+  execAndWaitForOutputToMatch,
   ng,
 } from '../../utils/process';
 import {writeFile, writeMultipleFiles} from '../../utils/fs';
@@ -25,7 +25,7 @@ export default function() {
   let oldNumberOfChunks = 0;
   const chunkRegExp = /chunk\s+\{/g;
 
-  return silentExecAndWaitForOutputToMatch('ng', ['serve'], validBundleRegEx)
+  return execAndWaitForOutputToMatch('ng', ['serve'], validBundleRegEx)
     // Should trigger a rebuild.
     .then(() => exec('touch', 'src/main.ts'))
     .then(() => waitForAnyProcessOutputToMatch(invalidBundleRegEx, 10000))

--- a/tests/e2e/tests/build/watch.ts
+++ b/tests/e2e/tests/build/watch.ts
@@ -2,7 +2,7 @@ import {
   killAllProcesses,
   exec,
   waitForAnyProcessOutputToMatch,
-  silentExecAndWaitForOutputToMatch
+  execAndWaitForOutputToMatch
 } from '../../utils/process';
 import { expectToFail } from '../../utils/utils';
 
@@ -14,7 +14,7 @@ export default function () {
     return Promise.resolve();
   }
 
-  return silentExecAndWaitForOutputToMatch('ng', ['serve'], webpackGoodRegEx)
+  return execAndWaitForOutputToMatch('ng', ['serve'], webpackGoodRegEx)
     // Should trigger a rebuild.
     .then(() => exec('touch', 'src/main.ts'))
     .then(() => waitForAnyProcessOutputToMatch(webpackGoodRegEx, 5000))
@@ -22,7 +22,7 @@ export default function () {
       killAllProcesses();
       throw err;
     })
-    .then(() => silentExecAndWaitForOutputToMatch('ng', ['serve', '--no-watch'], webpackGoodRegEx))
+    .then(() => execAndWaitForOutputToMatch('ng', ['serve', '--no-watch'], webpackGoodRegEx))
     // Should not trigger a rebuild when not watching files.
     .then(() => exec('touch', 'src/main.ts'))
     .then(() => expectToFail(() => waitForAnyProcessOutputToMatch(webpackGoodRegEx, 5000)))

--- a/tests/e2e/tests/misc/live-reload.ts
+++ b/tests/e2e/tests/misc/live-reload.ts
@@ -6,7 +6,7 @@ import * as http from 'http';
 import {appendToFile, writeMultipleFiles, writeFile} from '../../utils/fs';
 import {
   killAllProcesses,
-  silentExecAndWaitForOutputToMatch,
+  execAndWaitForOutputToMatch,
   waitForAnyProcessOutputToMatch
 } from '../../utils/process';
 import { wait } from '../../utils/utils';
@@ -96,7 +96,7 @@ export default function () {
         }
       `
     }))
-    .then(_ => silentExecAndWaitForOutputToMatch(
+    .then(_ => execAndWaitForOutputToMatch(
       'ng',
       ['e2e', '--watch', '--live-reload'],
       protractorGoodRegEx
@@ -116,7 +116,7 @@ export default function () {
     .then(_ => killAllProcesses(), (err) => { killAllProcesses(); throw err; })
     .then(_ => resetApiVars())
     // Serve with live reload off should call api only once.
-    .then(_ => silentExecAndWaitForOutputToMatch(
+    .then(_ => execAndWaitForOutputToMatch(
       'ng',
       ['e2e', '--watch', '--no-live-reload'],
       protractorGoodRegEx
@@ -150,7 +150,7 @@ export default function () {
             http.get('http://${publicHost + '/live-reload-count'}').subscribe(res => null);
           }
         }`))
-    .then(_ => silentExecAndWaitForOutputToMatch(
+    .then(_ => execAndWaitForOutputToMatch(
       'ng',
       ['e2e', '--watch', '--host=0.0.0.0', '--port=4200', `--public-host=${publicHost}`, '--proxy', proxyConfigFile],
       protractorGoodRegEx

--- a/tests/e2e/tests/test/e2e.ts
+++ b/tests/e2e/tests/test/e2e.ts
@@ -2,7 +2,6 @@ import {
   ng,
   npm,
   execAndWaitForOutputToMatch,
-  silentExecAndWaitForOutputToMatch,
   killAllProcesses
 } from '../../utils/process';
 import { updateJsonFile } from '../../utils/project';
@@ -43,7 +42,7 @@ export default function () {
       throw err;
     })
     // Should run side-by-side with `ng serve`
-    .then(() => silentExecAndWaitForOutputToMatch('ng', ['serve'],
+    .then(() => execAndWaitForOutputToMatch('ng', ['serve'],
       /webpack: Compiled successfully./))
     .then(() => ng('e2e'));
 }

--- a/tests/e2e/tests/test/test-fail-watch.ts
+++ b/tests/e2e/tests/test/test-fail-watch.ts
@@ -1,7 +1,7 @@
 import {
   killAllProcesses,
   waitForAnyProcessOutputToMatch,
-  silentExecAndWaitForOutputToMatch
+  execAndWaitForOutputToMatch
 } from '../../utils/process';
 import { expectToFail } from '../../utils/utils';
 import { readFile, writeFile } from '../../utils/fs';
@@ -12,7 +12,7 @@ const karmaGoodRegEx = /Executed 3 of 3 SUCCESS \(\d+\.\d+ secs/;
 
 export default function () {
   let originalSpec: string;
-  return silentExecAndWaitForOutputToMatch('ng', ['test'], karmaGoodRegEx)
+  return execAndWaitForOutputToMatch('ng', ['test'], karmaGoodRegEx)
     .then(() => readFile('src/app/app.component.spec.ts'))
     .then((data) => originalSpec = data)
     // Trigger a failed rebuild, which shouldn't run tests again.

--- a/tests/e2e/utils/project.ts
+++ b/tests/e2e/utils/project.ts
@@ -1,5 +1,5 @@
 import {readFile, writeFile} from './fs';
-import {silentExecAndWaitForOutputToMatch, silentNpm, ng} from './process';
+import {execAndWaitForOutputToMatch, silentNpm, ng} from './process';
 import {getGlobalVariable} from './env';
 
 const packages = require('../../../lib/packages').packages;
@@ -25,7 +25,7 @@ export function updateTsConfig(fn: (json: any) => any | void) {
 
 
 export function ngServe(...args: string[]) {
-  return silentExecAndWaitForOutputToMatch('ng',
+  return execAndWaitForOutputToMatch('ng',
     ['serve', ...args],
     /webpack: bundle is now VALID|webpack: Compiled successfully./);
 }


### PR DESCRIPTION
This will make the tests more verbose, but also easier to see the steps previous to the ones that error out.

Should be merged with #6985 to reduce some of the spam.