### PR TITLE
fix(@angular/cli): fix doc command to work with new angular.io

### DIFF
--- a/docs/documentation/doc.md
+++ b/docs/documentation/doc.md
@@ -3,4 +3,16 @@
 # ng doc
 
 ## Overview
-`ng doc [search term]` Opens the official Angular documentation for a given keyword on [angular.io](https://angular.io).
+`ng doc [search term]` Opens the official Angular API documentation for a given keyword on [angular.io](https://angular.io).
+
+## Options
+
+<details>
+  <summary>search</summary>
+  <p>
+    <code>--search</code> (alias: <code>-s</code>) <em>default value: false</em>
+  </p>
+  <p>
+    Search for the keyword in the whole [angular.io](https://angular.io) documentation instead of just the API.
+  </p>
+</details>

--- a/packages/@angular/cli/commands/doc.ts
+++ b/packages/@angular/cli/commands/doc.ts
@@ -7,7 +7,7 @@ export interface DocOptions {
 
 const DocCommand = Command.extend({
   name: 'doc',
-  description: 'Opens the official Angular documentation for a given keyword.',
+  description: 'Opens the official Angular API documentation for a given keyword.',
   works: 'everywhere',
   availableOptions: [
     {
@@ -15,7 +15,7 @@ const DocCommand = Command.extend({
       aliases: ['s'],
       type: Boolean,
       default: false,
-      description: 'Search docs instead of api.'
+      description: 'Search whole angular.io instead of just api.'
     }
   ],
 

--- a/packages/@angular/cli/tasks/doc.ts
+++ b/packages/@angular/cli/tasks/doc.ts
@@ -3,8 +3,8 @@ const opn = require('opn');
 
 export const DocTask: any = Task.extend({
   run: function(keyword: string, search: boolean) {
-    const searchUrl = search ? `https://angular.io/search/#stq=${keyword}&stp=1` :
-     `https://angular.io/docs/ts/latest/api/#!?query=${keyword}`;
+    const searchUrl = search ? `https://www.google.com/search?q=site%3Aangular.io+${keyword}` :
+     `https://angular.io/api?query=${keyword}`;
 
     return opn(searchUrl, { wait: false });
   }


### PR DESCRIPTION
- change the URL for the API search
- use google search when --search option is true, since angular.io doesn't have a search page anymore
- improve the help and doc of the doc command