### PR TITLE
build(@angular/cli): update webpack-dev-server to satisfy peer depend…

### DIFF
--- a/packages/@angular/cli/package.json
+++ b/packages/@angular/cli/package.json
@@ -84,7 +84,7 @@
     "walk-sync": "^0.3.1",
     "webpack": "~3.2.0",
     "webpack-dev-middleware": "^1.11.0",
-    "webpack-dev-server": "~2.4.5",
+    "webpack-dev-server": "~2.5.1",
     "webpack-merge": "^2.4.0",
     "zone.js": "0.8.12"
   },


### PR DESCRIPTION
…ency

Before when creating new project with CLI there was a warning about not satisfied peer dependency.

    npm WARN webpack-dev-server@2.4.5 requires a peer of webpack@^2.2.0 but none was installed.

Now it uses version of `webpack-dev-server`, which allows Webpack 3+ as a peer dependency.