### PR TITLE
feat(@angular/cli): update standard library to es2017

### DIFF
--- a/docs/documentation/stories/1.0-update.md
+++ b/docs/documentation/stories/1.0-update.md
@@ -215,7 +215,7 @@ CLI projects now use one tsconfig per app ([#4924](https://github.com/angular/an
     "experimentalDecorators": true,
     "target": "es5",
     "lib": [
-      "es2016",
+      "es2017",
       "dom"
     ],
     "outDir": "../out-tsc/app",
@@ -239,7 +239,7 @@ CLI projects now use one tsconfig per app ([#4924](https://github.com/angular/an
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "lib": [
-      "es2016",
+      "es2017",
       "dom"
     ],
     "outDir": "../out-tsc/spec",
@@ -271,7 +271,7 @@ CLI projects now use one tsconfig per app ([#4924](https://github.com/angular/an
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "lib": [
-      "es2016"
+      "es2017"
     ],
     "outDir": "../out-tsc/e2e",
     "module": "commonjs",
@@ -302,7 +302,7 @@ There is an additional root-level `tsconfig.json` that is used for IDE integrati
       "node_modules/@types"
     ],
     "lib": [
-      "es2016",
+      "es2017",
       "dom"
     ]
   }

--- a/packages/@angular/cli/blueprints/ng/files/tsconfig.json
+++ b/packages/@angular/cli/blueprints/ng/files/tsconfig.json
@@ -12,7 +12,7 @@
       "node_modules/@types"
     ],
     "lib": [
-      "es2016",
+      "es2017",
       "dom"
     ]
   }

--- a/tests/e2e/assets/1.0.0-proj/tsconfig.json
+++ b/tests/e2e/assets/1.0.0-proj/tsconfig.json
@@ -13,7 +13,7 @@
       "node_modules/@types"
     ],
     "lib": [
-      "es2016",
+      "es2017",
       "dom"
     ]
   }

--- a/tests/e2e/assets/webpack/test-app-weird/not/so/source/tsconfig.json
+++ b/tests/e2e/assets/webpack/test-app-weird/not/so/source/tsconfig.json
@@ -9,7 +9,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "lib": [
-      "es2016",
+      "es2017",
       "dom"
     ],
     "outDir": "lib",

--- a/tests/e2e/assets/webpack/test-app/tsconfig.json
+++ b/tests/e2e/assets/webpack/test-app/tsconfig.json
@@ -11,7 +11,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "lib": [
-      "es2016",
+      "es2017",
       "dom"
     ],
     "outDir": "lib",

--- a/tests/e2e/assets/webpack/test-server-app/tsconfig.json
+++ b/tests/e2e/assets/webpack/test-server-app/tsconfig.json
@@ -10,7 +10,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "lib": [
-      "es2016",
+      "es2017",
       "dom"
     ],
     "outDir": "lib",

--- a/tests/e2e/utils/project.ts
+++ b/tests/e2e/utils/project.ts
@@ -108,7 +108,7 @@ export function useNg2() {
       'experimentalDecorators': true,
       'target': 'es5',
       'lib': [
-        'es2016',
+        'es2017',
         'dom'
       ],
       'outDir': '../out-tsc/app',
@@ -130,7 +130,7 @@ export function useNg2() {
       'emitDecoratorMetadata': true,
       'experimentalDecorators': true,
       'lib': [
-        'es2016',
+        'es2017',
         'dom'
       ],
       'outDir': '../out-tsc/spec',
@@ -159,7 +159,7 @@ export function useNg2() {
       'emitDecoratorMetadata': true,
       'experimentalDecorators': true,
       'lib': [
-        'es2016'
+        'es2017'
       ],
       'outDir': '../out-tsc/e2e',
       'module': 'commonjs',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,8 +17,6 @@
     "sourceRoot": "",
     "target": "es6",
     "lib": [
-      "es2015",
-      "es2016",
       "es2017"
     ],
     "baseUrl": "",


### PR DESCRIPTION
ECMAScript 2017 was released at the end of June. Standard library support for ES 2017 is around in TypeScript for quite a while now. Even `typescript@~2.0.0` which is used by the Angular 2 template supports a subset of ES 2017. Hence, it seems reasonable to update to the latest standard library version.