### PR TITLE
feat(@angular/cli): use chrome headless by default

### DIFF
--- a/packages/@angular/cli/blueprints/ng/files/karma.conf.js
+++ b/packages/@angular/cli/blueprints/ng/files/karma.conf.js
@@ -27,7 +27,7 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['Chrome'],
+    browsers: ['ChromeHeadless'],
     singleRun: false
   });
 };


### PR DESCRIPTION
I suggest to make headless chrome the default. karma-chrome-launcher provides a config for that already. Maybe we need to wait until the Chrome 60 release on Windows?

See also

* <https://github.com/angular/angular-cli/pull/6853#issuecomment-313628226>
* <https://developers.google.com/web/updates/2017/04/headless-chrome>