### PR TITLE
feat(@angular/cli): make the common chunk optional

### DIFF
--- a/docs/documentation/build.md
+++ b/docs/documentation/build.md
@@ -294,6 +294,16 @@ Note: service worker support is experimental and subject to change.
 </details>
 
 <details>
+  <summary>common-chunk</summary>
+  <p>
+    <code>--common-chunk</code> (aliases: <code>-cc</code>) <em>default value: true</em>
+  </p>
+  <p>
+    Use a separate bundle containing code used across multiple bundles.
+  </p>
+</details>
+
+<details>
   <summary>verbose</summary>
   <p>
     <code>--verbose</code> (aliases: <code>-v</code>) <em>default value: false</em>

--- a/docs/documentation/eject.md
+++ b/docs/documentation/eject.md
@@ -183,6 +183,16 @@ ng eject
 </details>
 
 <details>
+  <summary>common-chunk</summary>
+  <p>
+    <code>--common-chunk</code> (aliases: <code>-cc</code>) <em>default value: true</em>
+  </p>
+  <p>
+    Use a separate bundle containing code used across multiple bundles.
+  </p>
+</details>
+
+<details>
   <summary>verbose</summary>
   <p>
     <code>--verbose</code> (aliases: <code>-v</code>) <em>default value: false</em>

--- a/docs/documentation/serve.md
+++ b/docs/documentation/serve.md
@@ -259,6 +259,16 @@ All the build Options are available in serve, below are the additional options.
 </details>
 
 <details>
+  <summary>common-chunk</summary>
+  <p>
+    <code>--common-chunk</code> (aliases: <code>-cc</code>) <em>default value: true</em>
+  </p>
+  <p>
+    Use a separate bundle containing code used across multiple bundles.
+  </p>
+</details>
+
+<details>
   <summary>verbose</summary>
   <p>
     <code>--verbose</code> (aliases: <code>-v</code>) <em>default value: false</em>

--- a/packages/@angular/cli/commands/build.ts
+++ b/packages/@angular/cli/commands/build.ts
@@ -9,7 +9,7 @@ const Command = require('../ember-cli/lib/models/command');
 const config = CliConfig.fromProject() || CliConfig.fromGlobal();
 const buildConfigDefaults = config.getPaths('defaults.build', [
   'sourcemaps', 'baseHref', 'progress', 'poll', 'deleteOutputPath', 'preserveSymlinks',
-  'showCircularDependencies'
+  'showCircularDependencies', 'commonChunk'
 ]);
 
 // defaults for BuildOptions
@@ -51,6 +51,14 @@ export const baseBuildCommandOptions: any = [
     default: true,
     aliases: ['vc'],
     description: 'Use a separate bundle containing only vendor libraries.'
+  },
+  {
+    name: 'common-chunk',
+    type: Boolean,
+    default: buildConfigDefaults['common-chunk'] === undefined ?
+      true : buildConfigDefaults['common-chunk'],
+    aliases: ['cc'],
+    description: 'Use a separate bundle containing code used across multiple bundles.'
   },
   {
     name: 'base-href',

--- a/packages/@angular/cli/lib/config/schema.json
+++ b/packages/@angular/cli/lib/config/schema.json
@@ -481,6 +481,11 @@
               "description": "Show circular dependency warnings on builds.",
               "type": "boolean",
               "default": true
+            },
+            "commonChunk": {
+              "description": "Use a separate bundle containing code used across multiple bundles.",
+              "type": "boolean",
+              "default": true
             }
           }
         },

--- a/packages/@angular/cli/models/build-options.ts
+++ b/packages/@angular/cli/models/build-options.ts
@@ -5,6 +5,7 @@ export interface BuildOptions {
   aot?: boolean;
   sourcemaps?: boolean;
   vendorChunk?: boolean;
+  commonChunk?: boolean;
   baseHref?: string;
   deployUrl?: string;
   verbose?: boolean;

--- a/packages/@angular/cli/models/webpack-configs/browser.ts
+++ b/packages/@angular/cli/models/webpack-configs/browser.ts
@@ -51,6 +51,15 @@ export function getBrowserConfig(wco: WebpackConfigOptions) {
     }));
   }
 
+  if (buildOptions.commonChunk) {
+    extraPlugins.push(new webpack.optimize.CommonsChunkPlugin({
+      name: 'main',
+      async: 'common',
+      children: true,
+      minChunks: 2
+    }));
+  }
+
   return {
     plugins: [
       new HtmlWebpackPlugin({
@@ -67,12 +76,6 @@ export function getBrowserConfig(wco: WebpackConfigOptions) {
       }),
       new BaseHrefWebpackPlugin({
         baseHref: buildOptions.baseHref
-      }),
-      new webpack.optimize.CommonsChunkPlugin({
-        name: 'main',
-        async: 'common',
-        children: true,
-        minChunks: 2
       }),
       new webpack.optimize.CommonsChunkPlugin({
         minChunks: Infinity,


### PR DESCRIPTION
- Add a "--no-common-chunk" build option for disabling the common async chunk.
- The existing behavior is maintained by default.

closes #7021