### PR TITLE
refactor: Change ejection message

### DIFF
--- a/packages/@angular/cli/tasks/eject.ts
+++ b/packages/@angular/cli/tasks/eject.ts
@@ -549,7 +549,7 @@ export default Task.extend({
 
           To run your builds, you now need to do the following commands:
              - "npm run build" to build.
-             - "npm run test" to run unit tests.
+             - "npm test" to run unit tests.
              - "npm start" to serve the app using webpack-dev-server.
              - "npm run e2e" to run protractor.
 


### PR DESCRIPTION
Before:

    - "npm run test" to run unit tests.
    - "npm start" to serve the app using webpack-dev-server.

After:

    - "npm test" to run unit tests.
    - "npm start" to serve the app using webpack-dev-server.

because `test` is a build in script just like `start`.
