### PR TITLE
fix(@angular/cli): wait for install to finish before exiting

### DIFF
--- a/packages/@angular/cli/tasks/init.ts
+++ b/packages/@angular/cli/tasks/init.ts
@@ -89,7 +89,7 @@ export default Task.extend({
     return installBlueprint.run(blueprintOpts)
       .then(function () {
         if (!commandOptions.skipInstall) {
-          return npmInstall.run();
+          return checkYarnOrCNPM().then(() => npmInstall.run());
         }
       })
       .then(function () {
@@ -100,11 +100,6 @@ export default Task.extend({
       .then(function () {
         if (commandOptions.linkCli) {
           return linkCli.run();
-        }
-      })
-      .then(() => {
-        if (!commandOptions.skipInstall || commandOptions.linkCli) {
-          return checkYarnOrCNPM();
         }
       })
       .then(() => {

--- a/packages/@angular/cli/tasks/npm-install.ts
+++ b/packages/@angular/cli/tasks/npm-install.ts
@@ -1,34 +1,35 @@
 const Task = require('../ember-cli/lib/models/task');
 import * as chalk from 'chalk';
-import {exec} from 'child_process';
-import {checkYarnOrCNPM} from '../utilities/check-package-manager';
+import { exec } from 'child_process';
 
 
 export default Task.extend({
-  run: function() {
+  run: function () {
     const ui = this.ui;
     let packageManager = this.packageManager;
     if (packageManager === 'default') {
       packageManager = 'npm';
     }
 
-    return checkYarnOrCNPM().then(function () {
-      ui.writeLine(chalk.green(`Installing packages for tooling via ${packageManager}.`));
-      let installCommand = `${packageManager} install`;
-      if (packageManager === 'npm') {
-        installCommand = `${packageManager} --quiet install`;
-      }
+    ui.writeLine(chalk.green(`Installing packages for tooling via ${packageManager}.`));
+    let installCommand = `${packageManager} install`;
+    if (packageManager === 'npm') {
+      installCommand = `${packageManager} --quiet install`;
+    }
+
+    return new Promise((resolve, reject) => {
       exec(installCommand,
         (err: NodeJS.ErrnoException, _stdout: string, stderr: string) => {
-        if (err) {
-          ui.writeLine(stderr);
-          const message = 'Package install failed, see above.';
-          ui.writeLine(chalk.red(message));
-          throw new Error(message);
-        } else {
-          ui.writeLine(chalk.green(`Installed packages for tooling via ${packageManager}.`));
-        }
-      });
+          if (err) {
+            ui.writeLine(stderr);
+            const message = 'Package install failed, see above.';
+            ui.writeLine(chalk.red(message));
+            reject(message);
+          } else {
+            ui.writeLine(chalk.green(`Installed packages for tooling via ${packageManager}.`));
+            resolve();
+          }
+        });
     });
   }
 });

--- a/packages/@angular/cli/utilities/check-package-manager.ts
+++ b/packages/@angular/cli/utilities/check-package-manager.ts
@@ -8,6 +8,12 @@ const packageManager = CliConfig.fromGlobal().get('packageManager');
 
 
 export function checkYarnOrCNPM() {
+
+  // Don't show messages if user has already changed the default.
+  if (packageManager !== 'default') {
+    return Promise.resolve();
+  }
+
   return Promise
       .all([checkYarn(), checkCNPM()])
       .then((data: Array<boolean>) => {


### PR DESCRIPTION
Should also fix the duplicate `ng set` messages, and not show them at all if the default has been changed.