### PR TITLE
build: unpin zone.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "webpack-dev-middleware": "^1.11.0",
     "webpack-dev-server": "~2.5.1",
     "webpack-merge": "^2.4.0",
-    "zone.js": "0.8.12"
+    "zone.js": "^0.8.14"
   },
   "devDependencies": {
     "@angular/compiler": "^4.0.0",

--- a/packages/@angular/cli/blueprints/ng/files/package.json
+++ b/packages/@angular/cli/blueprints/ng/files/package.json
@@ -26,7 +26,7 @@
     "@angular/router": "^4.2.4",
     "core-js": "^2.4.1",
     "rxjs": "^5.4.1",
-    "zone.js": "0.8.12"
+    "zone.js": "^0.8.14"
   },
   "devDependencies": {
     "@angular/cli": "<%= version %>",

--- a/packages/@angular/cli/package.json
+++ b/packages/@angular/cli/package.json
@@ -86,7 +86,7 @@
     "webpack-dev-middleware": "^1.11.0",
     "webpack-dev-server": "~2.4.5",
     "webpack-merge": "^2.4.0",
-    "zone.js": "0.8.12"
+    "zone.js": "^0.8.14"
   },
   "optionalDependencies": {
     "node-sass": "^4.3.0"

--- a/tests/e2e/assets/1.0.0-proj/package.json
+++ b/tests/e2e/assets/1.0.0-proj/package.json
@@ -22,7 +22,7 @@
     "@angular/router": "^4.0.0",
     "core-js": "^2.4.1",
     "rxjs": "^5.1.0",
-    "zone.js": "0.8.12"
+    "zone.js": "^0.8.14"
   },
   "devDependencies": {
     "@angular/cli": "1.0.0",

--- a/tests/e2e/assets/webpack/test-app-weird/package.json
+++ b/tests/e2e/assets/webpack/test-app-weird/package.json
@@ -14,7 +14,7 @@
     "@ngtools/webpack": "0.0.0",
     "core-js": "^2.4.1",
     "rxjs": "^5.0.1",
-    "zone.js": "0.8.12"
+    "zone.js": "^0.8.14"
   },
   "devDependencies": {
     "node-sass": "^3.7.0",

--- a/tests/e2e/assets/webpack/test-app/package.json
+++ b/tests/e2e/assets/webpack/test-app/package.json
@@ -14,7 +14,7 @@
     "@ngtools/webpack": "0.0.0",
     "core-js": "^2.4.1",
     "rxjs": "^5.0.1",
-    "zone.js": "0.8.12"
+    "zone.js": "^0.8.14"
   },
   "devDependencies": {
     "node-sass": "^3.7.0",

--- a/tests/e2e/assets/webpack/test-server-app/package.json
+++ b/tests/e2e/assets/webpack/test-server-app/package.json
@@ -15,7 +15,7 @@
     "@ngtools/webpack": "0.0.0",
     "core-js": "^2.4.1",
     "rxjs": "^5.3.1",
-    "zone.js": "0.8.12"
+    "zone.js": "^0.8.14"
   },
   "devDependencies": {
     "node-sass": "^4.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5655,6 +5655,6 @@ yn@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/yn/-/yn-2.0.0.tgz#e5adabc8acf408f6385fc76495684c88e6af689a"
 
-zone.js@0.8.12:
-  version "0.8.12"
-  resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.8.12.tgz#86ff5053c98aec291a0bf4bbac501d694a05cfbb"
+zone.js@^0.8.14:
+  version "0.8.14"
+  resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.8.14.tgz#0c4db24b178232274ccb43f78c99db7f3642b6cf"


### PR DESCRIPTION
Followup to #6971. `zone.js@0.8.14` has been released and we should unpin it.