### PR TITLE
docs: add SUPPORT.md

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,16 @@
+# Got a Question or Problem?
+
+Please, do not open issues for the general support questions as we want to keep GitHub issues for bug reports and feature requests. You've got much better chances of getting your question answered on [StackOverflow](https://stackoverflow.com/questions/tagged/angular-cli) where the questions should be tagged with tag `angular-cli`.
+
+StackOverflow is a much better place to ask questions since:
+
+- there are thousands of people willing to help on StackOverflow
+- questions and answers stay available for public viewing so your question / answer might help someone else
+- StackOverflow's voting system assures that the best answers are prominently visible.
+
+To save your and our time we will be systematically closing all the issues that are requests for general support and redirecting people to StackOverflow.
+
+If you would like to chat about the question in real-time, you can reach out via [our gitter channel][gitter].
+
+
+[gitter]: https://gitter.im/angular/angular-cli


### PR DESCRIPTION
Just contains the `Got a Question or Problem?` section of `CONTRIBUTING.md`.

See https://github.com/blog/2400-support-file-support for github support.

Didn't add it to `.github` folder because it's more visible outside, like `CONTRIBUTING.md`.