### PR TITLE
fix(@angular/cli): remove deprecated json-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "inquirer": "^3.0.0",
     "isbinaryfile": "^3.0.0",
     "istanbul-instrumenter-loader": "^2.0.0",
-    "json-loader": "^0.5.4",
     "karma-source-map-support": "^1.2.0",
     "less": "^2.7.2",
     "less-loader": "^4.0.5",

--- a/packages/@angular/cli/models/webpack-configs/common.ts
+++ b/packages/@angular/cli/models/webpack-configs/common.ts
@@ -16,7 +16,6 @@ const CircularDependencyPlugin = require('circular-dependency-plugin');
  * require('source-map-loader')
  * require('raw-loader')
  * require('script-loader')
- * require('json-loader')
  * require('url-loader')
  * require('file-loader')
  * require('@angular-devkit/build-optimizer')
@@ -106,7 +105,6 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
     module: {
       rules: [
         { enforce: 'pre', test: /\.js$/, loader: 'source-map-loader', exclude: [nodeModules] },
-        { test: /\.json$/, loader: 'json-loader' },
         { test: /\.html$/, loader: 'raw-loader' },
         { test: /\.(eot|svg)$/, loader: `file-loader?name=[name]${hashFormat.file}.[ext]` },
         {

--- a/packages/@angular/cli/package.json
+++ b/packages/@angular/cli/package.json
@@ -53,7 +53,6 @@
     "inflection": "^1.7.0",
     "inquirer": "^3.0.0",
     "isbinaryfile": "^3.0.0",
-    "json-loader": "^0.5.4",
     "karma-source-map-support": "^1.2.0",
     "less": "^2.7.2",
     "less-loader": "^4.0.5",

--- a/packages/@angular/cli/tasks/eject.ts
+++ b/packages/@angular/cli/tasks/eject.ts
@@ -507,7 +507,6 @@ export default Task.extend({
           'cssnano',
           'exports-loader',
           'file-loader',
-          'json-loader',
           'karma-sourcemap-loader',
           'less-loader',
           'postcss-loader',


### PR DESCRIPTION
JSON support is built into Webpack 2+.  Use of the loader causes a warning for each use of a JSON file.
Ref: https://webpack.js.org/guides/migrating/#json-loader-is-not-required-anymore

Fixes #7095