### PR TITLE
refactor(@angular/cli): remove magic-string console info message

### DIFF
--- a/packages/@ngtools/webpack/src/refactor.ts
+++ b/packages/@ngtools/webpack/src/refactor.ts
@@ -196,7 +196,7 @@ export class TypeScriptFileRefactor {
     this._sourceString.overwrite(node.getStart(this._sourceFile),
                                  node.getEnd(),
                                  replacement,
-                                 replaceSymbolName);
+                                 { storeName: replaceSymbolName });
     this._changed = true;
   }
 


### PR DESCRIPTION
Followup to #7091 .  magic-string issues a console message when using a deprecated function signature.