### PR TITLE
fix(@ngtools/webpack): fix duplicate LAZY_ROUTE_MAP exports

### DIFF
--- a/packages/@ngtools/webpack/src/loader.ts
+++ b/packages/@ngtools/webpack/src/loader.ts
@@ -443,9 +443,7 @@ export function _getModuleExports(plugin: AotPlugin,
   return exports
     .filter(node => {
 
-      const identifiers = refactor.findAstNodes(node, ts.SyntaxKind.Identifier, false);
-
-      identifiers
+      const identifiers = refactor.findAstNodes(node, ts.SyntaxKind.Identifier, false)
         .filter(node => node.getText() === plugin.entryModule.className);
 
       return identifiers.length > 0;


### PR DESCRIPTION
Corrected incorrect filter of the export nodes which caused exporting LAZY_ROUTE_MAP multiple times in a file

Fixes https://github.com/angular/angular-cli/issues/7116