### PR TITLE
fix(@angular/cli) pin webpack to 3.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "typescript": "~2.4.2",
     "url-loader": "^0.5.7",
     "walk-sync": "^0.3.1",
-    "webpack": "~3.3.0",
+    "webpack": "3.3.0",
     "webpack-dev-middleware": "^1.11.0",
     "webpack-dev-server": "~2.5.1",
     "webpack-merge": "^4.1.0",

--- a/packages/@angular/cli/package.json
+++ b/packages/@angular/cli/package.json
@@ -84,7 +84,7 @@
     "typescript": ">=2.0.0 <2.5.0",
     "url-loader": "^0.5.7",
     "walk-sync": "^0.3.1",
-    "webpack": "~3.3.0",
+    "webpack": "3.3.0",
     "webpack-dev-middleware": "^1.11.0",
     "webpack-dev-server": "~2.5.1",
     "webpack-merge": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5526,7 +5526,7 @@ webpack-sources@^1.0.1:
     source-list-map "^2.0.0"
     source-map "~0.5.3"
 
-webpack@~3.3.0:
+webpack@3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-3.3.0.tgz#ce2f9e076566aba91f74887133a883fd7da187bc"
   dependencies:


### PR DESCRIPTION
Webpack is updating to `enhanced-resolve@3.4.0` (https://github.com/webpack/webpack/commit/16bf0b6f26b23df682433ddefcbff5278a6fac2c) but the CLI cannot do so yet (see #7123).

This PR pins `webpack@3.3.0` until we are able to update to `enhanced-resolve@^3.4.0`.