### PR TITLE
fix(@angular/cli): ignore yarn-error.log file

### DIFF
--- a/packages/@angular/cli/blueprints/ng/files/gitignore
+++ b/packages/@angular/cli/blueprints/ng/files/gitignore
@@ -32,6 +32,7 @@
 npm-debug.log
 testem.log
 /typings
+yarn-error.log
 
 # e2e
 /e2e/*.js


### PR DESCRIPTION
If any errors yarn creating a file `yarn-error.log` needs to be added to `.gitignore` to avoid accidental commit of that file.