### PR TITLE
fix(@angular/cli): change blog link to blog.angular.io

### DIFF
--- a/packages/@angular/cli/blueprints/ng/files/__path__/app/app.component.html
+++ b/packages/@angular/cli/blueprints/ng/files/__path__/app/app.component.html
@@ -14,7 +14,7 @@
     <h2><a target="_blank" href="https://github.com/angular/angular-cli/wiki">CLI Documentation</a></h2>
   </li>
   <li>
-    <h2><a target="_blank" href="http://angularjs.blogspot.com/">Angular blog</a></h2>
+    <h2><a target="_blank" href="https://blog.angular.io//">Angular blog</a></h2>
   </li>
 </ul>
 <% if (routing) { %>


### PR DESCRIPTION
Following #6781 to set the URL to the new Angular blog https://blog.angular.io