### PR TITLE
fix(@angular/cli): exclude node_modules while take account for os specific path separators (#6870)

### DIFF
--- a/packages/@angular/cli/tasks/eject.ts
+++ b/packages/@angular/cli/tasks/eject.ts
@@ -287,7 +287,7 @@ class JsonWebpackSerializer {
         return v;
       } else if (typeof v == 'string') {
         if (v === path.join(this._root, 'node_modules')) {
-          return this._serializeRegExp(/\/node_modules\//);
+          return this._relativePath('process.cwd()', 'node_modules');
         }
         return this._relativePath('process.cwd()', path.relative(this._root, v));
       } else {

--- a/packages/@angular/cli/tasks/eject.ts
+++ b/packages/@angular/cli/tasks/eject.ts
@@ -287,7 +287,7 @@ class JsonWebpackSerializer {
         return v;
       } else if (typeof v == 'string') {
         if (v === path.join(this._root, 'node_modules')) {
-          return this._relativePath('process.cwd()', 'node_modules');
+          return this._serializeRegExp(/(\\|\/)node_modules(\\|\/)/);
         }
         return this._relativePath('process.cwd()', path.relative(this._root, v));
       } else {


### PR DESCRIPTION
fix(@angular/cli): use relativ path instead of regex to exclude node_modules (#6870)