### PR TITLE
Allow partially overriding webpack config

### DIFF
--- a/packages/@angular/cli/models/webpack-config.ts
+++ b/packages/@angular/cli/models/webpack-config.ts
@@ -8,7 +8,8 @@ import {
   getProdConfig,
   getStylesConfig,
   getNonAotConfig,
-  getAotConfig
+  getAotConfig,
+  getCustomConfig
 } from './webpack-configs';
 
 const path = require('path');
@@ -50,6 +51,8 @@ export class NgCliWebpackConfig {
         : getNonAotConfig(this.wco);
       webpackConfigs.push(typescriptConfigPartial);
     }
+
+    webpackConfigs.push(getCustomConfig(this.wco));
 
     this.config = webpackMerge(webpackConfigs);
     return this.config;

--- a/packages/@angular/cli/models/webpack-configs/custom.ts
+++ b/packages/@angular/cli/models/webpack-configs/custom.ts
@@ -1,0 +1,16 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { WebpackConfigOptions } from '../webpack-config';
+
+export const getCustomConfig = function (_wco: WebpackConfigOptions) {
+  const customConfigPath = path.join(_wco.projectRoot, 'webpack.config.js');
+
+  console.log('checking for webpack custom config in', customConfigPath);
+  if (fs.statSync(customConfigPath)) {
+    console.log('Found! Loading...');
+    return require(customConfigPath);
+  }
+
+  return {};
+};

--- a/packages/@angular/cli/models/webpack-configs/custom.ts
+++ b/packages/@angular/cli/models/webpack-configs/custom.ts
@@ -6,9 +6,7 @@ import { WebpackConfigOptions } from '../webpack-config';
 export const getCustomConfig = function (_wco: WebpackConfigOptions) {
   const customConfigPath = path.join(_wco.projectRoot, 'webpack.config.js');
 
-  console.log('checking for webpack custom config in', customConfigPath);
-  if (fs.statSync(customConfigPath)) {
-    console.log('Found! Loading...');
+  if (fs.existsSync(customConfigPath)) {
     return require(customConfigPath);
   }
 

--- a/packages/@angular/cli/models/webpack-configs/index.ts
+++ b/packages/@angular/cli/models/webpack-configs/index.ts
@@ -1,5 +1,6 @@
 export * from './browser';
 export * from './common';
+export * from './custom';
 export * from './development';
 export * from './production';
 export * from './styles';


### PR DESCRIPTION
If a webpack.config.js file is found in the project root, it's loaded after all other configs so configuration can be overriden.

I need to compile pug (jade) but didn't want to eject the cli. So I implemented this. I think I ready somewhere you guys didn't it, but I'm not sure. Please, let me know if this will make into the cli. If not, I'll publish another package.

Thanks for the hard work, guys! You are awesome, I'm loving the cli!!