### PR TITLE
test(@ngtools/webpack): add source-map-support.

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "silent-error": "^1.0.0",
     "source-map": "^0.5.6",
     "source-map-loader": "^0.2.0",
+    "source-map-support": "^0.4.1",
     "style-loader": "^0.13.1",
     "stylus": "^0.54.5",
     "stylus-loader": "^3.0.1",

--- a/packages/@angular/cli/package.json
+++ b/packages/@angular/cli/package.json
@@ -75,6 +75,7 @@
     "semver": "^5.1.0",
     "silent-error": "^1.0.0",
     "source-map-loader": "^0.2.0",
+    "source-map-support": "^0.4.1",
     "istanbul-instrumenter-loader": "^2.0.0",
     "style-loader": "^0.13.1",
     "stylus": "^0.54.5",

--- a/packages/@angular/cli/plugins/karma.ts
+++ b/packages/@angular/cli/plugins/karma.ts
@@ -12,6 +12,7 @@ import { KarmaWebpackThrowError } from './karma-webpack-throw-error';
  * Enumerate needed (but not require/imported) dependencies from this file
  *  to let the dependency validator know they are used.
  *
+ * require('source-map-support')
  * require('karma-source-map-support')
  */
 


### PR DESCRIPTION
karma plugin relies on source-map-support being a dependency of karma-source-map-support and npm 3+ flat dependency tree.

https://github.com/pnpm/pnpm/issues/863