### PR TITLE
fix(@angular/cli): standardize output path behavior

### DIFF
--- a/packages/@angular/cli/models/webpack-config.ts
+++ b/packages/@angular/cli/models/webpack-config.ts
@@ -11,8 +11,7 @@ import {
   getNonAotConfig,
   getAotConfig
 } from './webpack-configs';
-
-const path = require('path');
+import * as path from 'path';
 
 export interface WebpackConfigOptions {
   projectRoot: string;
@@ -32,7 +31,7 @@ export class NgCliWebpackConfig {
 
     appConfig = this.addAppConfigDefaults(appConfig);
     buildOptions = this.addTargetDefaults(buildOptions);
-    buildOptions = this.mergeConfigs(buildOptions, appConfig);
+    buildOptions = this.mergeConfigs(buildOptions, appConfig, projectRoot);
 
     this.wco = { projectRoot, buildOptions, appConfig };
   }
@@ -106,9 +105,9 @@ export class NgCliWebpackConfig {
   }
 
   // Fill in defaults from .angular-cli.json
-  public mergeConfigs(buildOptions: BuildOptions, appConfig: any) {
+  public mergeConfigs(buildOptions: BuildOptions, appConfig: any, projectRoot: string) {
     const mergeableOptions = {
-      outputPath: appConfig.outDir,
+      outputPath: path.resolve(projectRoot, appConfig.outDir),
       deployUrl: appConfig.deployUrl,
       baseHref: appConfig.baseHref
     };

--- a/packages/@angular/cli/models/webpack-configs/common.ts
+++ b/packages/@angular/cli/models/webpack-configs/common.ts
@@ -97,7 +97,7 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
     context: __dirname,
     entry: entryPoints,
     output: {
-      path: path.resolve(projectRoot, buildOptions.outputPath),
+      path: path.resolve(buildOptions.outputPath),
       publicPath: buildOptions.deployUrl,
       filename: `[name]${hashFormat.chunk}.bundle.js`,
       chunkFilename: `[id]${hashFormat.chunk}.chunk.js`


### PR DESCRIPTION
This ensures that a relative output path specified from the config will be relative to the project root and that a relative output path specified from the command line will be relative to the current working directory.

Currently, executing `ng build` below the project root would create a defective project output.

Fixes #7208