### PR TITLE
feat(@angular/cli): Implement request 7141 - Short list of cli commands

### DIFF
--- a/packages/@angular/cli/commands/help.ts
+++ b/packages/@angular/cli/commands/help.ts
@@ -10,7 +10,15 @@ const HelpCommand = Command.extend({
   description: 'Shows help for the CLI.',
   works: 'everywhere',
 
-  availableOptions: [],
+  availableOptions: [
+    {
+      name: 'short',
+      type: Boolean,
+      default: false,
+      aliases: ['s'],
+      description: 'Display command name and description only.'
+    },
+  ],
 
   anonymousOptions: ['command-name (Default: all)'],
 
@@ -56,14 +64,20 @@ const HelpCommand = Command.extend({
         }
 
         if (cmd === commandInput) {
-          if (command.printDetailedHelp(commandOptions)) {
+          if (commandOptions.short) {
+            this.ui.writeLine(command.printShortHelp(commandOptions));
+          } else if (command.printDetailedHelp(commandOptions)) {
             this.ui.writeLine(command.printDetailedHelp(commandOptions));
           } else {
             this.ui.writeLine(command.printBasicHelp(commandOptions));
           }
         }
       } else {
-        this.ui.writeLine(command.printBasicHelp(commandOptions));
+        if (commandOptions.short) {
+          this.ui.writeLine(command.printShortHelp(commandOptions));
+        } else {
+          this.ui.writeLine(command.printBasicHelp(commandOptions));
+        }
       }
 
     });

--- a/packages/@angular/cli/ember-cli/lib/models/command.js
+++ b/packages/@angular/cli/ember-cli/lib/models/command.js
@@ -551,6 +551,32 @@ let Command = CoreObject.extend({
   _printCommand: printCommand,
 
   /**
+    Prints short help for the command.
+    Short help looks like this:
+        ng generate <blueprint> <options...>
+          Generates new code from blueprints
+          aliases: g
+    The default implementation is designed to cover all bases
+    but may be overridden if necessary.
+    @method printShortHelp
+  */
+  printShortHelp() {
+    // ng command-name
+    let output;
+    if (this.isRoot) {
+      output = `Usage: ${this.name}`;
+    } else {
+      output = `ng ${this.name}`;
+    }
+
+    output += EOL;
+    output += `   ${this.description}`;
+    output += EOL;
+
+    return output;
+  },
+
+  /**
     Prints basic help for the command.
     Basic help looks like this:
         ng generate <blueprint> <options...>
@@ -559,7 +585,7 @@ let Command = CoreObject.extend({
           --dry-run (Default: false)
           --verbose (Default: false)
     The default implementation is designed to cover all bases
-    but may be overriden if necessary.
+    but may be overridden if necessary.
     @method printBasicHelp
   */
   printBasicHelp() {


### PR DESCRIPTION
When calling  ng help -s / --short  one gets a shorter output; basically only ng + command, followed by the command's description.  Implements and closes #7141.

No breaking change, as it introduces a new flag.
