### PR TITLE
WIP: refactor(@angular/cli): directly add pure hints to imports

### DIFF
--- a/packages/@angular/cli/models/webpack-configs/common.ts
+++ b/packages/@angular/cli/models/webpack-configs/common.ts
@@ -4,6 +4,7 @@ import { GlobCopyWebpackPlugin } from '../../plugins/glob-copy-webpack-plugin';
 import { NamedLazyChunksWebpackPlugin } from '../../plugins/named-lazy-chunks-webpack-plugin';
 import { extraEntryParser, getOutputHashFormat } from './utils';
 import { WebpackConfigOptions } from '../webpack-config';
+import { SafeImportsPlugin } from '../../plugins/safe-imports';
 
 const ProgressPlugin = require('webpack/lib/ProgressPlugin');
 const CircularDependencyPlugin = require('circular-dependency-plugin');
@@ -114,7 +115,8 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
       ].concat(extraRules)
     },
     plugins: [
-      new webpack.NoEmitOnErrorsPlugin()
+      new webpack.NoEmitOnErrorsPlugin(),
+      new SafeImportsPlugin()
     ].concat(extraPlugins),
     node: {
       fs: 'empty',

--- a/packages/@angular/cli/plugins/safe-imports.ts
+++ b/packages/@angular/cli/plugins/safe-imports.ts
@@ -1,0 +1,83 @@
+import * as webpack from 'webpack';
+const HarmonyImportDependency = require('webpack/lib/dependencies/HarmonyImportDependency');
+const HarmonyImportSpecifierDependency =
+  require('webpack/lib/dependencies/HarmonyImportSpecifierDependency');
+
+export interface SafeImportsPluginOptions {
+  hintText?: string;
+  include?: (dep: any) => boolean;
+  exclude?: (dep: any) => boolean;
+}
+
+export class SafeImportDependencyTemplate {
+  constructor(private options: SafeImportsPluginOptions) {}
+
+  apply(dep: any, source: any, outputOptions: any, requestShortener: any) {
+    let content: string = HarmonyImportDependency
+      .makeImportStatement(true, dep, outputOptions, requestShortener);
+
+    if (content && this.shouldAddHint(dep)) {
+      content = content.split('=').reduce((prev, cur) => {
+        return prev + `= /*${this.options.hintText}*/` + cur;
+      });
+    }
+
+    source.replace(dep.range[0], dep.range[1] - 1, '');
+    source.insert(-1, content);
+  }
+
+  private shouldAddHint(dep: any): boolean {
+    if (!dep.module) {
+      return false;
+    }
+    if (this.options.exclude
+      && this.options.exclude(dep)) {
+      return false;
+    }
+    if (this.options.include
+      && this.options.include(dep)) {
+      return true;
+    }
+    return false;
+  }
+}
+
+export class SafeImportSpecifierDependencyTemplate {
+  constructor(private options?: SafeImportsPluginOptions) {}
+
+  apply(dep: any, source: any) {
+    const originalTemplate = new HarmonyImportSpecifierDependency.Template();
+
+    let content = originalTemplate.getContent(dep);
+    if (dep.id === 'ɵccf' || dep.id === 'ɵcmf') {
+      content = `/*${this.options.hintText}*/ ` + content;
+    }
+
+    source.replace(dep.range[0], dep.range[1] - 1, content);
+  }
+}
+
+export class SafeImportsPlugin {
+  private options: SafeImportsPluginOptions;
+
+  constructor(options?: SafeImportsPluginOptions) {
+    const optionDefaults: SafeImportsPluginOptions = {
+      hintText: '@__PURE__',
+      include: (dep) => /@angular/.test(dep.module.id)
+      // || /[\\/]\$\$_gendir[\\/]/.test(dep.module.id)
+    };
+    this.options = { ...optionDefaults, ...options };
+  }
+
+  apply(compiler: webpack.Compiler): void {
+    compiler.plugin('after-plugins', () => {
+      compiler.plugin('compilation', (compilation: any) => {
+        compilation.dependencyTemplates
+          .set(HarmonyImportDependency, new SafeImportDependencyTemplate(this.options));
+        compilation.dependencyTemplates
+          .set(HarmonyImportSpecifierDependency,
+            new SafeImportSpecifierDependencyTemplate(this.options));
+      });
+    });
+  }
+}

--- a/packages/@angular/cli/plugins/webpack.js
+++ b/packages/@angular/cli/plugins/webpack.js
@@ -8,5 +8,7 @@ module.exports = {
     require('../plugins/suppress-entry-chunks-webpack-plugin')
       .SuppressExtractedTextChunksWebpackPlugin,
   NamedLazyChunksWebpackPlugin:
-    require('../plugins/named-lazy-chunks-webpack-plugin').NamedLazyChunksWebpackPlugin
+    require('../plugins/named-lazy-chunks-webpack-plugin').NamedLazyChunksWebpackPlugin,
+  SafeImportsPlugin:
+    require('../plugins/safe-imports').SafeImportsPlugin
 };

--- a/packages/@angular/cli/tasks/eject.ts
+++ b/packages/@angular/cli/tasks/eject.ts
@@ -180,6 +180,7 @@ class JsonWebpackSerializer {
         case angularCliPlugins.BaseHrefWebpackPlugin:
         case angularCliPlugins.NamedLazyChunksWebpackPlugin:
         case angularCliPlugins.SuppressExtractedTextChunksWebpackPlugin:
+        case angularCliPlugins.SafeImportsPlugin:
           this._addImport('@angular/cli/plugins/webpack', plugin.constructor.name);
           break;
         case angularCliPlugins.GlobCopyWebpackPlugin:


### PR DESCRIPTION
This updates the webpack dependency template to add the uglifyjs pure hint to imports with an import clause.  This eliminates the need to analyze the imports via a transform and then add the hints via a plugin.