### PR TITLE
fix(@angular/cli): `ng completion` inside of ng app folders behave again

### DIFF
--- a/packages/@angular/cli/bin/ng
+++ b/packages/@angular/cli/bin/ng
@@ -155,20 +155,20 @@ resolve('@angular/cli', { basedir: process.cwd() },
       }
 
       if (shouldWarn && CliConfig.fromGlobal().get('warnings.versionMismatch')) {
-        let warning = stripIndents`
+        let warning = yellow(stripIndents`
           Your global Angular CLI version (${globalVersion}) is greater than your local
           version (${localVersion}). The local Angular CLI version is used.
 
           To disable this warning use "ng set --global warnings.versionMismatch=false".
-        `;
+        `);
          // Don't show warning colorised on `ng completion`
          if (process.argv[2] !== 'completion') {
            // eslint-disable no-console
-           console.log(yellow(warning));
-         } else {
-           warning = warning.replace(/^/gm, '# ');
-           // eslint-disable no-console
            console.log(warning);
+         } else {
+           // eslint-disable no-console
+           console.error(warning);
+           process.exit(1);
          }
       }
 

--- a/packages/@angular/cli/bin/ng
+++ b/packages/@angular/cli/bin/ng
@@ -155,13 +155,21 @@ resolve('@angular/cli', { basedir: process.cwd() },
       }
 
       if (shouldWarn && CliConfig.fromGlobal().get('warnings.versionMismatch')) {
-        // eslint-disable no-console
-        console.log(yellow(stripIndents`
+        let warning = stripIndents`
           Your global Angular CLI version (${globalVersion}) is greater than your local
           version (${localVersion}). The local Angular CLI version is used.
 
           To disable this warning use "ng set --global warnings.versionMismatch=false".
-        `));
+        `;
+         // Don't show warning colorised on `ng completion`
+         if (process.argv[2] !== 'completion') {
+           // eslint-disable no-console
+           console.log(yellow(warning));
+         } else {
+           warning = warning.replace(/^/gm, '# ');
+           // eslint-disable no-console
+           console.log(warning);
+         }
       }
 
       // No error implies a projectLocalCli, which will load whatever

--- a/packages/@angular/cli/commands/completion.ts
+++ b/packages/@angular/cli/commands/completion.ts
@@ -43,7 +43,7 @@ const optsNg: string[] = [];
 const CompletionCommand = Command.extend({
   name: 'completion',
   description: 'Adds autocomplete functionality to `ng` commands and subcommands.',
-  works: 'everywhere',
+  works: 'outsideProject',
   availableOptions: [
     {
       name: 'all',

--- a/packages/@angular/cli/commands/completion.ts
+++ b/packages/@angular/cli/commands/completion.ts
@@ -43,7 +43,7 @@ const optsNg: string[] = [];
 const CompletionCommand = Command.extend({
   name: 'completion',
   description: 'Adds autocomplete functionality to `ng` commands and subcommands.',
-  works: 'outsideProject',
+  works: 'everywhere',
   availableOptions: [
     {
       name: 'all',


### PR DESCRIPTION
If an ng app folder was created with an **older** ng CLI version, and the ng CLI is upgraded globally, one cannot perform `ng completion` INSIDE that app folder.
Thus it is advisable to only allow `ng completion` in places
such as shell start-up code, for which the completion is meant in the first place.
`ng completion` performed in an ng app folder generated with an **older** version
issues a warning, which the shell cannot ignore, but tries to interpret as genuine
shell commands, miserably failing.  This warning must be prepended with shell comment characters.
The PR fixes #6343.

The change does not introduce a breaking change, it prevents the warning from being erroneously
interpreted by the shell.
