### PR TITLE
build: use the tar files for dependencies for e2e

### DIFF
--- a/lib/packages.js
+++ b/lib/packages.js
@@ -25,6 +25,7 @@ const packages =
       packages[name] = {
         dist: path.join(distRoot, pkg.name),
         packageJson: path.join(pkg.root, 'package.json'),
+        distPackageJson: path.join(distRoot, pkg.name, 'package.json'),
         root: pkg.root,
         relative: path.relative(path.dirname(__dirname), pkg.root),
         main: path.resolve(pkg.root, 'src/index.ts'),

--- a/tests/e2e/setup/010-build.ts
+++ b/tests/e2e/setup/010-build.ts
@@ -12,7 +12,7 @@ export default function() {
     return;
   }
 
-  return npm('run', 'build')
+  return npm('run', 'build', '--', '--local')
     .then(() => console.log('Updating package.json from dist...'))
     .then(() => Promise.all(Object.keys(packages).map(pkgName => {
       return updateJsonFile(join(packages[pkgName].dist, 'package.json'), json => {


### PR DESCRIPTION
This adds a new flag to the build script that sets the tar files path as dependencies inside the package.json before tarring the files.