### PR TITLE
fix(@angular/cli): sync webpack stats file content options

### DIFF
--- a/packages/@angular/cli/tasks/build.ts
+++ b/packages/@angular/cli/tasks/build.ts
@@ -59,7 +59,7 @@ export default Task.extend({
         } else if (runTaskOptions.statsJson) {
           fs.writeFileSync(
             path.resolve(this.project.root, outputPath, 'stats.json'),
-            JSON.stringify(json, null, 2)
+            JSON.stringify(stats.toJson(), null, 2)
           );
         }
 


### PR DESCRIPTION
This synchronizes the webpack output options for the stats JSON file output with the default usage of the webpack CLI's `--json` option.

Fixes #7057