### PR TITLE
fix(@angular/cli): use correct property names for build config defaults

### DIFF
--- a/packages/@angular/cli/commands/build.ts
+++ b/packages/@angular/cli/commands/build.ts
@@ -54,8 +54,7 @@ export const baseBuildCommandOptions: any = [
   {
     name: 'common-chunk',
     type: Boolean,
-    default: buildConfigDefaults['common-chunk'] === undefined ?
-      true : buildConfigDefaults['common-chunk'],
+    default: buildConfigDefaults['commonChunk'],
     aliases: ['cc'],
     description: 'Use a separate bundle containing code used across multiple bundles.'
   },
@@ -64,7 +63,7 @@ export const baseBuildCommandOptions: any = [
     type: String,
     aliases: ['bh'],
     description: 'Base url for the application being built.',
-    default: buildConfigDefaults['base-href']
+    default: buildConfigDefaults['baseHref']
   },
   {
     name: 'deploy-url',


### PR DESCRIPTION
`commonChunk` and `baseHref` are not being to passed the build from the `.angular-cli.json` correctly.