### PR TITLE
fix(@ngtools/webpack): don't use src dir as a resource

### DIFF
--- a/packages/@ngtools/webpack/src/plugin.ts
+++ b/packages/@ngtools/webpack/src/plugin.ts
@@ -334,8 +334,7 @@ export class AotPlugin implements Tapable {
         }
 
         this.done.then(() => {
-          result.resource = this.skipCodeGeneration ? this.basePath : this.genDir;
-          result.recursive = true;
+          result.resource = this.genDir;
           result.dependencies.forEach((d: any) => d.critical = false);
           result.resolveDependencies = (_fs: any, _resource: any, _recursive: any,
             _regExp: RegExp, cb: any) => {


### PR DESCRIPTION
We add either `src/` or `src/$$_gendir/` directories as the lazy route resource, which causes rebuilds whenever anything changes there.

This PR makes it always use the `src/$$_gendir/` special directory.

@brocco this should also fix your local failing poll test.

Fix #6238
Close #6959