### PR TITLE
fix(@angular/cli): flatten index.html config during output

### DIFF
--- a/packages/@angular/cli/models/webpack-configs/browser.ts
+++ b/packages/@angular/cli/models/webpack-configs/browser.ts
@@ -60,11 +60,13 @@ export function getBrowserConfig(wco: WebpackConfigOptions) {
     }));
   }
 
+  const flatIndex = appConfig.index.substr(appConfig.index.lastIndexOf('/') + 1);
+
   return {
     plugins: [
       new HtmlWebpackPlugin({
         template: path.resolve(appRoot, appConfig.index),
-        filename: path.resolve(buildOptions.outputPath, appConfig.index),
+        filename: path.resolve(buildOptions.outputPath, flatIndex),
         chunksSortMode: packageChunkSort(appConfig),
         excludeChunks: lazyChunks,
         xhtml: true,


### PR DESCRIPTION
We're attempting to re-use common library code within the same CLI codebase. To achieve this we're putting apps in separate folders like:
```
/coca-cola
    /app
        app.module.ts
    styles.scss
    index.html
/pepsi
    /app
        app.module.ts
    styles.scss
    index.html
/shared
    /components
    /services
```

index.html has it's own brand specific things, like a unique `<title>` for instance. This means we need to separate them and point to them using appConfig like:
```
"index": "coca-cola/index.html",
```

When you run an `ng build` though, the index.html is still inside the branded folder, referencing JS that is up a directory. This PR flattens the `appConfig.index` property, as it should always be in the root directory with the JS files anyway

Fixes: #7309