### PR TITLE
Allow specifying different styling per environment 

### DIFF
--- a/packages/@angular/cli/lib/config/schema.json
+++ b/packages/@angular/cli/lib/config/schema.json
@@ -125,40 +125,10 @@
             "default": false
           },
           "styles": {
-            "description": "Global styles to be included in the build.",
-            "type": "array",
-            "items": {
-              "oneOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "object",
-                  "properties": {
-                    "input": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": true
-                }
-              ]
-            },
-            "additionalProperties": false
+            "$ref": "#/definitions/styles"
           },
           "stylePreprocessorOptions": {
-            "description": "Options to pass to style preprocessors",
-            "type": "object",
-            "properties": {
-              "includePaths": {
-                "description": "Paths to include. Paths will be resolved to project root.",
-                "type": "array",
-                "items": {
-                  "type": "string"
-                },
-                "default": []
-              }
-            },
-            "additionalProperties": false
+            "$ref": "#/definitions/stylePreprocessorOptions"
           },
           "scripts": {
             "description": "Global scripts to be included in the build.",
@@ -191,7 +161,27 @@
           "environments": {
             "description": "Name and corresponding file for environment config.",
             "type": "object",
-            "additionalProperties": true
+            "additionalProperties": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "config": {
+                      "type": "string"
+                    },
+                    "styles": {
+                      "$ref": "#/definitions/styles"
+                    },
+                    "stylePreprocessorOptions": {
+                      "$ref": "#/definitions/stylePreprocessorOptions"
+                    }
+                  }
+                }
+              ]
+            }
           }
         },
         "additionalProperties": false
@@ -573,5 +563,43 @@
       }
     }
   },
-  "additionalProperties": false
+  "additionalProperties": false,
+  "definitions": {
+    "styles": {
+      "description": "Global styles to be included in the build.",
+      "type": "array",
+      "items": {
+        "oneOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "input": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": true
+          }
+        ]
+      },
+      "additionalProperties": false
+    },
+    "stylePreprocessorOptions": {
+      "description": "Options to pass to style preprocessors",
+      "type": "object",
+      "properties": {
+        "includePaths": {
+          "description": "Paths to include. Paths will be resolved to project root.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        }
+      },
+      "additionalProperties": false
+    }
+  }
 }


### PR DESCRIPTION
Starting a PR to fix #5803 / #6331

The plan is to update https://github.com/angular/angular-cli/blob/master/packages/%40angular/cli/models/webpack-configs/styles.ts to read this option, and if there is an environment with the `styles` / `stylePreprocessorOptions` set, use that instead of the values at the top level. This will also involve updating https://github.com/angular/angular-cli/blob/master/packages/%40angular/cli/models/webpack-configs/typescript.ts to properly interpret the object instead of just the string, and use the `config` key for the environment ts file.

NOT READY TO MERGE

Seeking feedback on the options structure.