### PR TITLE
fix(@angular/cli): ignore system files in service worker

### DIFF
--- a/packages/@angular/cli/models/webpack-configs/production.ts
+++ b/packages/@angular/cli/models/webpack-configs/production.ts
@@ -72,8 +72,11 @@ export const getProdConfig = function (wco: WebpackConfigOptions) {
     // Load the Webpack plugin for manifest generation and install it.
     const AngularServiceWorkerPlugin = require('@angular/service-worker/build/webpack')
       .AngularServiceWorkerPlugin;
+    
+    // Add baseHref in manifest and ignore system files
     extraPlugins.push(new AngularServiceWorkerPlugin({
       baseHref: buildOptions.baseHref || '/',
+      'static.ignore': ['^\\.DS_Store$', '^Thumbs\\.db$'],
     }));
 
     // Copy the worker script into assets.

--- a/packages/@angular/cli/models/webpack-configs/production.ts
+++ b/packages/@angular/cli/models/webpack-configs/production.ts
@@ -72,7 +72,7 @@ export const getProdConfig = function (wco: WebpackConfigOptions) {
     // Load the Webpack plugin for manifest generation and install it.
     const AngularServiceWorkerPlugin = require('@angular/service-worker/build/webpack')
       .AngularServiceWorkerPlugin;
-    
+
     // Add baseHref in manifest and ignore system files
     extraPlugins.push(new AngularServiceWorkerPlugin({
       baseHref: buildOptions.baseHref || '/',


### PR DESCRIPTION
Related to angular/mobile-toolkit#180

When copying the assets, the CLI includes system files (e.g. .DS_Store and Thumbs.db). As a consequence, they are included in the service worker manifest as files to cache. But such file may (and should) not be deployed to the server, then a file will be missing, then the service worker installation will fail and so all the offline feature won't work.

This PR makes the CLI ensure the service worker will ignore these system files.