### PR TITLE
feat(@angular/cli): added option to override default path 'app'

### DIFF
--- a/packages/@angular/cli/blueprints/component/index.ts
+++ b/packages/@angular/cli/blueprints/component/index.ts
@@ -114,7 +114,8 @@ export default Blueprint.extend({
         resolveModulePath(options.module, this.project, this.project.root, appConfig);
     } else {
       try {
-        this.pathToModule = findParentModule(this.project.root, appConfig.root, this.generatePath);
+        this.pathToModule = findParentModule(this.project.root, appConfig.root, appConfig.directory,
+          this.generatePath);
       } catch (e) {
         if (!options.skipImport) {
           throw `Error locating module for declaration\n\t${e}`;

--- a/packages/@angular/cli/blueprints/directive/index.ts
+++ b/packages/@angular/cli/blueprints/directive/index.ts
@@ -67,7 +67,8 @@ export default Blueprint.extend({
         resolveModulePath(options.module, this.project, this.project.root, appConfig);
     } else {
       try {
-        this.pathToModule = findParentModule(this.project.root, appConfig.root, this.generatePath);
+        this.pathToModule = findParentModule(this.project.root, appConfig.root, appConfig.directory,
+          this.generatePath);
       } catch (e) {
         if (!options.skipImport) {
           throw `Error locating module for declaration\n\t${e}`;

--- a/packages/@angular/cli/blueprints/pipe/index.ts
+++ b/packages/@angular/cli/blueprints/pipe/index.ts
@@ -61,7 +61,8 @@ export default Blueprint.extend({
         resolveModulePath(options.module, this.project, this.project.root, appConfig);
     } else {
       try {
-        this.pathToModule = findParentModule(this.project.root, appConfig.root, this.generatePath);
+        this.pathToModule = findParentModule(this.project.root, appConfig.root, appConfig.directory,
+          this.generatePath);
       } catch (e) {
         if (!options.skipImport) {
           throw `Error locating module for declaration\n\t${e}`;

--- a/packages/@angular/cli/lib/ast-tools/route-utils.spec.ts
+++ b/packages/@angular/cli/lib/ast-tools/route-utils.spec.ts
@@ -587,19 +587,19 @@ export default [
     });
 
     it('accepts component name without \'component\' suffix: resolveComponentPath', () => {
-      let fileName = nru.resolveComponentPath(projectRoot, 'src/app', 'about');
+      let fileName = nru.resolveComponentPath(projectRoot, '', 'src/app', 'about');
       expect(fileName).toEqual(componentFile);
     });
     it('accepts component name with \'component\' suffix: resolveComponentPath', () => {
-      let fileName = nru.resolveComponentPath(projectRoot, 'src/app', 'about.component');
+      let fileName = nru.resolveComponentPath(projectRoot, '', 'src/app', 'about.component');
       expect(fileName).toEqual(componentFile);
     });
     it('accepts path absolute from project root: resolveComponentPath', () => {
-      let fileName = nru.resolveComponentPath(projectRoot, '', `${path.sep}about`);
+      let fileName = nru.resolveComponentPath(projectRoot, '', '', `${path.sep}about`);
       expect(fileName).toEqual(componentFile);
     });
     it('accept component with directory name: resolveComponentPath', () => {
-      let fileName = nru.resolveComponentPath(projectRoot, 'src/app', 'about/about.component');
+      let fileName = nru.resolveComponentPath(projectRoot, '', 'src/app', 'about/about.component');
       expect(fileName).toEqual(componentFile);
     });
 

--- a/packages/@angular/cli/lib/ast-tools/route-utils.ts
+++ b/packages/@angular/cli/lib/ast-tools/route-utils.ts
@@ -334,7 +334,10 @@ function resolveImportName (importName: string, importPath: string, fileName: st
  * @return component file name
  * @throw Error if component file referenced by path is not found
  */
-export function resolveComponentPath(projectRoot: string, currentDir: string, filePath: string) {
+export function resolveComponentPath(projectRoot: string, appDir: string,
+  currentDir: string, filePath: string) {
+
+  appDir = appDir || 'app';
 
   let parsedPath = path.parse(filePath);
   let componentName = parsedPath.base.split('.')[0];
@@ -349,14 +352,14 @@ export function resolveComponentPath(projectRoot: string, currentDir: string, fi
     filePath = componentName;
   }
   let directory = filePath[0] === path.sep ?
-    path.resolve(path.join(projectRoot, 'src', 'app', filePath)) :
+    path.resolve(path.join(projectRoot, 'src', appDir, filePath)) :
     path.resolve(currentDir, filePath);
 
   if (!fs.existsSync(directory)) {
     throw new Error(`path '${filePath}' must be relative to current directory` +
                     ` or absolute from project root`);
   }
-  if (directory.indexOf('src' + path.sep + 'app') === -1) {
+  if (directory.indexOf('src' + path.sep + appDir) === -1) {
     throw new Error('Route must be within app');
   }
   let componentFile = path.join(directory, `${componentName}.component.ts`);

--- a/packages/@angular/cli/lib/ast-tools/route-utils.ts
+++ b/packages/@angular/cli/lib/ast-tools/route-utils.ts
@@ -329,6 +329,7 @@ function resolveImportName (importName: string, importPath: string, fileName: st
  * Resolve a path to a component file. If the path begins with path.sep, it is treated to be
  * absolute from the app/ directory. Otherwise, it is relative to currDir
  * @param projectRoot
+ * @param appDir
  * @param currentDir
  * @param filePath componentName or path to componentName
  * @return component file name

--- a/packages/@angular/cli/lib/config/schema.json
+++ b/packages/@angular/cli/lib/config/schema.json
@@ -37,6 +37,11 @@
             "type": "string",
             "description": "The root directory of the app."
           },
+          "directory": {
+            "type": "string",
+            "default": "app",
+            "description": "The directory under root for the app."
+          },
           "outDir": {
             "type": "string",
             "default": "dist/",

--- a/packages/@angular/cli/utilities/dynamic-path-parser.ts
+++ b/packages/@angular/cli/utilities/dynamic-path-parser.ts
@@ -13,7 +13,8 @@ export interface DynamicPathOptions {
 export function dynamicPathParser(options: DynamicPathOptions) {
   const projectRoot = options.project.root;
   const sourceDir = options.appConfig.root;
-  const appRoot = path.join(sourceDir, 'app');
+  const appDir = options.appConfig.directory || 'app';
+  const appRoot = path.join(sourceDir, appDir);
   const cwd = process.env.PWD;
 
   const rootPath = path.join(projectRoot, appRoot);

--- a/packages/@angular/cli/utilities/find-parent-module.ts
+++ b/packages/@angular/cli/utilities/find-parent-module.ts
@@ -3,12 +3,14 @@ import * as path from 'path';
 const SilentError = require('silent-error');
 
 export default function findParentModule(
-  projectRoot: string, appRoot: string, currentDir: string): string {
+  projectRoot: string, appRoot: string, appDir: string, currentDir: string): string {
 
-  const sourceRoot = path.join(projectRoot, appRoot, 'app');
+  appDir = appDir || 'app';
+
+  const sourceRoot = path.join(projectRoot, appRoot, appDir);
 
   // trim currentDir
-  currentDir = currentDir.replace(path.join(appRoot, 'app'), '');
+  currentDir = currentDir.replace(path.join(appRoot, appDir), '');
 
   let pathToCheck = path.join(sourceRoot, currentDir);
 


### PR DESCRIPTION
Added option 'directory' to .angular-cli.json which allow the default app path to be overridden. The default remains  'src/app' but this allows the use of angular-cli also for projects containing many apps with identical root (see: https://yakovfain.com/2017/04/06/angular-cli-multiple-apps-in-the-same-project/).

For discussion, see issue #3095.