### PR TITLE
fix(@angular/cli): `ng completion` inside of ng app folders warns but does not produce output 

### DIFF
--- a/packages/@angular/cli/bin/ng
+++ b/packages/@angular/cli/bin/ng
@@ -155,13 +155,21 @@ resolve('@angular/cli', { basedir: process.cwd() },
       }
 
       if (shouldWarn && CliConfig.fromGlobal().get('warnings.versionMismatch')) {
-        // eslint-disable no-console
-        console.log(yellow(stripIndents`
-          Your global Angular CLI version (${globalVersion}) is greater than your local
-          version (${localVersion}). The local Angular CLI version is used.
+        let warning = yellow(stripIndents`
+        Your global Angular CLI version (${globalVersion}) is greater than your local
+        version (${localVersion}). The local Angular CLI version is used.
 
-          To disable this warning use "ng set --global warnings.versionMismatch=false".
-        `));
+        To disable this warning use "ng set --global warnings.versionMismatch=false".
+        `);
+        // Don't show warning colorised on `ng completion`
+         if (process.argv[2] !== 'completion') {
+           // eslint-disable no-console
+           console.log(warning);
+         } else {
+           // eslint-disable no-console
+           console.error(warning);
+           process.exit(1);
+         }
       }
 
       // No error implies a projectLocalCli, which will load whatever


### PR DESCRIPTION
If an ng app folder was created with an older ng CLI version, while the global ng CLI is more recent, one cannot perform ng completion INSIDE that app folder.
This is due to the warning being written to stdout, which if appended to ~/.bashrc causes the shell to fail to process the English text as commands.
The solution is to display the warning to stderr without producing the completion output.
Also, an error code 1 is returned.
This PR fixes #6343.

The change introduces a breaking change, the warning is written to stderr - if the call is
 `ng completion` in an ng app folder.
