### PR TITLE
ignore .directory files

### DIFF
--- a/packages/@angular/cli/blueprints/ng/files/gitignore
+++ b/packages/@angular/cli/blueprints/ng/files/gitignore
@@ -41,3 +41,4 @@ yarn-error.log
 # System Files
 .DS_Store
 Thumbs.db
+.directory


### PR DESCRIPTION
ignore .directory files (the KDE dolphin pendant of macOS' .DS_Store)