### PR TITLE
test: Add missing peer dependency

### DIFF
--- a/packages/@angular/cli/package.json
+++ b/packages/@angular/cli/package.json
@@ -41,6 +41,7 @@
     "diff": "^3.1.0",
     "ember-cli-normalize-entity-name": "^1.0.0",
     "ember-cli-string-utils": "^1.0.0",
+    "enhanced-resolve": "^3.1.0",
     "exports-loader": "^0.6.3",
     "extract-text-webpack-plugin": "3.0.0",
     "file-loader": "^0.10.0",

--- a/packages/@angular/cli/package.json
+++ b/packages/@angular/cli/package.json
@@ -41,7 +41,6 @@
     "diff": "^3.1.0",
     "ember-cli-normalize-entity-name": "^1.0.0",
     "ember-cli-string-utils": "^1.0.0",
-    "enhanced-resolve": "^3.1.0",
     "exports-loader": "^0.6.3",
     "extract-text-webpack-plugin": "3.0.0",
     "file-loader": "^0.10.0",

--- a/packages/@ngtools/webpack/package.json
+++ b/packages/@ngtools/webpack/package.json
@@ -26,11 +26,11 @@
   },
   "dependencies": {
     "loader-utils": "^1.0.2",
+    "enhanced-resolve": "^3.1.0",
     "magic-string": "^0.22.3",
     "source-map": "^0.5.6"
   },
   "peerDependencies": {
-    "enhanced-resolve": "^3.1.0",
     "typescript": "^2.0.2",
     "webpack": "^2.2.0 || ^3.0.0"
   }


### PR DESCRIPTION
`@ngtools/webpack` requires a peer dependency of `enhanced-resolve@^3.1.0`. It currently relies on `webpack` providing this dependency and on `NPM 3+` flat tree installation. `Webpack` could remove this dependency or `NPM` change the tree structure. This change also removes a NPM warning about missing peer dependency.