### PR TITLE
fix(@angular/cli): fix problem of SuppressPlugin in case entryFiles type is string

### DIFF
--- a/packages/@angular/cli/plugins/suppress-entry-chunks-webpack-plugin.ts
+++ b/packages/@angular/cli/plugins/suppress-entry-chunks-webpack-plugin.ts
@@ -11,8 +11,11 @@ export class SuppressExtractedTextChunksWebpackPlugin {
         const entryPoints = compilation.options.entry;
         // determine which entry points are composed entirely of css files
         for (let entryPoint of Object.keys(entryPoints)) {
-          if (entryPoints[entryPoint].every((el: string) =>
-            el.match(/\.(css|scss|sass|less|styl)$/))) {
+          let entryFiles: string[]|string = entryPoints[entryPoint]
+          // when type of entryFiles is not array, make it as an array
+          entryFiles = entryFiles instanceof Array ? entryFiles : [entryFiles]
+          if (entryFiles.every((el: string) =>
+            el.match(/\.(css|scss|sass|less|styl)$/) !== null)) {
               cssOnlyChunks.push(entryPoint);
           }
         }

--- a/packages/@angular/cli/plugins/suppress-entry-chunks-webpack-plugin.ts
+++ b/packages/@angular/cli/plugins/suppress-entry-chunks-webpack-plugin.ts
@@ -8,17 +8,17 @@ export class SuppressExtractedTextChunksWebpackPlugin {
     compiler.plugin('compilation', function (compilation: any) {
       // find which chunks have css only entry points
       const cssOnlyChunks: string[] = [];
-        const entryPoints = compilation.options.entry;
-        // determine which entry points are composed entirely of css files
-        for (let entryPoint of Object.keys(entryPoints)) {
-          let entryFiles: string[]|string = entryPoints[entryPoint]
-          // when type of entryFiles is not array, make it as an array
-          entryFiles = entryFiles instanceof Array ? entryFiles : [entryFiles]
-          if (entryFiles.every((el: string) =>
-            el.match(/\.(css|scss|sass|less|styl)$/) !== null)) {
-              cssOnlyChunks.push(entryPoint);
-          }
+      const entryPoints = compilation.options.entry;
+      // determine which entry points are composed entirely of css files
+      for (let entryPoint of Object.keys(entryPoints)) {
+        let entryFiles: string[]|string = entryPoints[entryPoint];
+        // when type of entryFiles is not array, make it as an array
+        entryFiles = entryFiles instanceof Array ? entryFiles : [entryFiles];
+        if (entryFiles.every((el: string) =>
+          el.match(/\.(css|scss|sass|less|styl)$/) !== null)) {
+            cssOnlyChunks.push(entryPoint);
         }
+      }
       // Remove the js file for supressed chunks
       compilation.plugin('after-seal', (callback: any) => {
         compilation.chunks


### PR DESCRIPTION
The type of entryFiles from entryPoint is **array** in webpack official suggested, **but actually it could be string**. default entryPonit seems like: 
```
entry: {
  app: [__dirname + '/app.js']
}
```

but actually, entryPoint could be this: 
```
entry: {
  app: __dirname + '/app.js'
}
```

This moment, our SuppressPlugin doesn't work. The error caused by `every` method which is only invoked by array, however entryFiles type is a string now. 

**Solution is, if entryFile is not array, make it as an array which includes just a single string element(itself).**