### PR TITLE
fix(@angular/cli): correct blog link to blog.angular.io

### DIFF
--- a/packages/@angular/cli/blueprints/ng/files/__path__/app/app.component.html
+++ b/packages/@angular/cli/blueprints/ng/files/__path__/app/app.component.html
@@ -14,7 +14,7 @@
     <h2><a target="_blank" href="https://github.com/angular/angular-cli/wiki">CLI Documentation</a></h2>
   </li>
   <li>
-    <h2><a target="_blank" href="https://blog.angular.io//">Angular blog</a></h2>
+    <h2><a target="_blank" href="https://blog.angular.io/">Angular blog</a></h2>
   </li>
 </ul>
 <% if (routing) { %>


### PR DESCRIPTION
<img width="1680" alt="screen shot 2017-08-15 at 10 00 07 pm" src="https://user-images.githubusercontent.com/1016365/29347985-2143085a-8205-11e7-9eb5-0a9ff76be8bc.png">
