### PR TITLE
refactor(@angular/cli): remove unneeded dependency on RSVP

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "postcss-url": "^5.1.2",
     "raw-loader": "^0.5.1",
     "resolve": "^1.1.7",
-    "rsvp": "^3.0.17",
     "rxjs": "^5.4.2",
     "sass-loader": "^6.0.3",
     "script-loader": "^0.7.0",

--- a/packages/@angular/cli/ember-cli/lib/cli/cli.js
+++ b/packages/@angular/cli/ember-cli/lib/cli/cli.js
@@ -1,14 +1,11 @@
 'use strict';
 
-const RSVP = require('rsvp');
-
 const lookupCommand = require('./lookup-command');
 const getOptionArgs = require('../utilities/get-option-args');
 let logger = require('heimdalljs-logger')('ember-cli:cli');
 let loggerTesting = require('heimdalljs-logger')('ember-cli:testing');
 const heimdall = require('heimdalljs');
 
-const Promise = RSVP.Promise;
 // Disabled until e2e and serve command can be evaluated/corrected -- require('../utilities/will-interrupt-process');
 const onProcessInterrupt = { addHandler: (_handler) => { }, removeHandler: (_handler) => { } };
 
@@ -86,7 +83,7 @@ class CLI {
   run(environment) {
     let shutdownOnExit = null;
 
-    return RSVP.hash(environment).then(environment => {
+    return Promise.resolve().then(() => {
       let args = environment.cliArgs.slice();
 
       if (args.length === 0) {
@@ -161,11 +158,6 @@ class CLI {
         onProcessInterrupt.removeHandler(onCommandInterrupt);
 
         return result;
-      }).finally(() => {
-        instrumentation.start('shutdown');
-        shutdownOnExit = function() {
-          instrumentation.stopAndReport('shutdown');
-        };
       }).then(result => {
         // if the help option was passed, call the help command
         if (result === 'callHelp') {
@@ -200,11 +192,6 @@ class CLI {
           .then(() => runPromise);
 
       return runPromise;
-    })
-    .finally(() => {
-      if (shutdownOnExit) {
-        shutdownOnExit();
-      }
     })
     .catch(this.logError.bind(this));
   }

--- a/packages/@angular/cli/package.json
+++ b/packages/@angular/cli/package.json
@@ -65,7 +65,6 @@
     "postcss-url": "^5.1.2",
     "raw-loader": "^0.5.1",
     "resolve": "^1.1.7",
-    "rsvp": "^3.0.17",
     "rxjs": "^5.4.2",
     "sass-loader": "^6.0.3",
     "script-loader": "^0.7.0",


### PR DESCRIPTION
The changes here to `ember-cli/lib/cli/cli.js` have no actual effect on behavior.  The CLI doesn't pass an environment object containing promises to the run function and the ember-cli instrumentation is completely stubbed out.