### PR TITLE
docs: Changed sass-test-variable - $brand-primary

### DIFF
--- a/docs/documentation/stories/include-bootstrap.md
+++ b/docs/documentation/stories/include-bootstrap.md
@@ -117,7 +117,7 @@ Verify the bootstrap styled button appears.
 To ensure your variables are used open `_variables.scss` and add the following:
 
 ```sass
-$brand-primary: red;
+$blue: #dc3545;
 ```
 
 Return the browser to see the font color changed.


### PR DESCRIPTION
$brand-primary is no longer available. Instead of setting the whole schema $theme-colors(...), the blue-part is set to red.