### PR TITLE
docs: No more cache clean on NPM 5

### DIFF
--- a/docs/documentation/stories/1.0-update.md
+++ b/docs/documentation/stories/1.0-update.md
@@ -46,7 +46,7 @@ npm uninstall --save-dev @angular/cli # Remove from package.json
 Also purge the cache and local packages:
 ```
 rm -rf node_modules dist # Use rmdir on Windows
-npm cache clean
+npm cache clean          # Not necessary with NPM 5 or higher
 ```
 
 At this point, you should not have Angular CLI on your system anymore. If invoking Angular CLI at the commandline reveals that it still exists on your system, you will have to manually remove it. See _Manually removing residual Angular CLI_.


### PR DESCRIPTION
`npm cache verify` is possible, but not necessary.