### PR TITLE
fix(test): fix test coverage when testing linked libs

### DIFF
--- a/packages/@angular/cli/models/webpack-configs/test.ts
+++ b/packages/@angular/cli/models/webpack-configs/test.ts
@@ -42,6 +42,7 @@ export function getTestConfig(testConfig: WebpackTestOptions) {
 
     extraRules.push({
       test: /\.(js|ts)$/, loader: 'istanbul-instrumenter-loader',
+      options: { esModules: true },
       enforce: 'post',
       exclude
     });


### PR DESCRIPTION
Hey

As you may know,  angular-cli is used for testing and deploying doc pages for ngx-bootstrap
Several days ago code coverage just stopped to work, with log you can see above.

@hansl I will really appreciate if you can consider this PR for nearest release 

```
- [x] bug report -> please search issues before submitting
```

### Versions.
```
@angular/cli: 1.3.1
node: 7.10.0
os: darwin x64
@angular/cli: 1.3.1
@angular/common: 2.4.10
@angular/compiler: 2.4.10
@angular/compiler-cli: 2.4.10
@angular/core: 2.4.10
@angular/forms: 2.4.10
@angular/http: 2.4.10
@angular/language-service: 2.4.10
@angular/platform-browser: 2.4.10
@angular/platform-browser-dynamic: 2.4.10
@angular/router: 3.4.10
@angular/tsc-wrapped: 0.5.1
```
same for angular v4.3+

### Repro steps.
1. git clone git@github.com:valor-software/ngx-bootstrap.git
2. npm i 
3. ng test -sr -cc

### The log given by the failure.
```
20 08 2017 18:34:49.664:ERROR [karma]: Error: Module build failed: SyntaxError: 'import' and 'export' may appear only with 'sourceType: module' (1:0)
    at Parser.pp$5.raise (/Users/valorkin/work/open-source/ngx-bootstrap/node_modules/babylon/lib/index.js:4454:13)
    at Parser.pp$1.parseStatement (/Users/valorkin/work/open-source/ngx-bootstrap/node_modules/babylon/lib/index.js:1881:16)
    at Parser.parseStatement (/Users/valorkin/work/open-source/ngx-bootstrap/node_modules/babylon/lib/index.js:5835:22)
    at Parser.pp$1.parseBlockBody (/Users/valorkin/work/open-source/ngx-bootstrap/node_modules/babylon/lib/index.js:2268:21)
    at Parser.pp$1.parseTopLevel (/Users/valorkin/work/open-source/ngx-bootstrap/node_modules/babylon/lib/index.js:1778:8)
    at Parser.parse (/Users/valorkin/work/open-source/ngx-bootstrap/node_modules/babylon/lib/index.js:1673:17)
    at Object.parse (/Users/valorkin/work/open-source/ngx-bootstrap/node_modules/babylon/lib/index.js:7221:37)
    at Instrumenter.instrumentSync (/Users/valorkin/work/open-source/ngx-bootstrap/node_modules/istanbul-lib-instrument/dist/instrumenter.js:121:31)
    at Instrumenter.instrument (/Users/valorkin/work/open-source/ngx-bootstrap/node_modules/istanbul-lib-instrument/dist/instrumenter.js:176:32)
    at Object.module.exports (/Users/valorkin/work/open-source/ngx-bootstrap/node_modules/istanbul-instrumenter-loader/index.js:25:25),Module build failed: SyntaxError: 'import' and 'export' may appear only with 'sourceType: module' (1:0)
    at Parser.pp$5.raise (/Users/valorkin/work/open-source/ngx-bootstrap/node_modules/babylon/lib/index.js:4454:13)
    at Parser.pp$1.parseStatement (/Users/valorkin/work/open-source/ngx-bootstrap/node_modules/babylon/lib/index.js:1881:16)
    at Parser.parseStatement (/Users/valorkin/work/open-source/ngx-bootstrap/node_modules/babylon/lib/index.js:5835:22)
    at Parser.pp$1.parseBlockBody (/Users/valorkin/work/open-source/ngx-bootstrap/node_modules/babylon/lib/index.js:2268:21)
    at Parser.pp$1.parseTopLevel (/Users/valorkin/work/open-source/ngx-bootstrap/node_modules/babylon/lib/index.js:1778:8)
    at Parser.parse (/Users/valorkin/work/open-source/ngx-bootstrap/node_modules/babylon/lib/index.js:1673:17)
    at Object.parse (/Users/valorkin/work/open-source/ngx-bootstrap/node_modules/babylon/lib/index.js:7221:37)
    at Instrumenter.instrumentSync (/Users/valorkin/work/open-source/ngx-bootstrap/node_modules/istanbul-lib-instrument/dist/instrumenter.js:121:31)
    at Instrumenter.instrument (/Users/valorkin/work/open-source/ngx-bootstrap/node_modules/istanbul-lib-instrument/dist/instrumenter.js:176:32)
    at Object.module.exports (/Users/valorkin/work/open-source/ngx-bootstrap/node_modules/istanbul-instrumenter-loader/index.js:25:25),Module build failed: SyntaxError: 'import' and 'export' may appear only with 'sourceType: module' (1:0)
```


### Desired functionality.
Code coverage should work as expected

### Mention any other details that might be useful.
For some reason `.tmp` folder files got included in test coverage report

