### PR TITLE
build(@angular/cli): add option to ignore files

### DIFF
--- a/docs/documentation/angular-cli.md
+++ b/docs/documentation/angular-cli.md
@@ -82,6 +82,7 @@
     - *baseHref* (`string`): Base url for the application being built.
     - *progress* (`boolean`): Log progress to the console while building. Default is `true`.
     - *poll* (`number`): Enable and define the file watching poll time period (milliseconds).
+    - *ignored* (`string|array`): Avoid rebuilding files when files matching this [anymatch](https://github.com/es128/anymatch) pattern fails.
     - *deleteOutputPath* (`boolean`): Delete output path before build. Default is `true`.
     - *preserveSymlinks* (`boolean`): Do not use the real path when resolving modules. Default is `false`.
     - *showCircularDependencies* (`boolean`): Show circular dependency warnings on builds. Default is `true`.

--- a/packages/@angular/cli/commands/build.ts
+++ b/packages/@angular/cli/commands/build.ts
@@ -9,7 +9,7 @@ const Command = require('../ember-cli/lib/models/command');
 const config = CliConfig.fromProject() || CliConfig.fromGlobal();
 const buildConfigDefaults = config.getPaths('defaults.build', [
   'sourcemaps', 'baseHref', 'progress', 'poll', 'deleteOutputPath', 'preserveSymlinks',
-  'showCircularDependencies', 'commonChunk', 'namedChunks'
+  'showCircularDependencies', 'commonChunk', 'namedChunks', 'ignored'
 ]);
 
 // defaults for BuildOptions
@@ -130,6 +130,12 @@ export const baseBuildCommandOptions: any = [
     type: Number,
     description: 'Enable and define the file watching poll time period (milliseconds).',
     default: buildConfigDefaults['poll']
+  },
+  {
+    name: 'ignored',
+    type: String,
+    description: 'Avoid rebuilding files when files matching this anymatch pattern fails.',
+    default: buildConfigDefaults['ignored']
   },
   {
     name: 'app',

--- a/packages/@angular/cli/custom-typings.d.ts
+++ b/packages/@angular/cli/custom-typings.d.ts
@@ -11,6 +11,7 @@ interface IWebpackDevServerConfigurationOptions {
   filename?: string;
   watchOptions?: {
     aggregateTimeout?: number;
+    ignored?: string | string[];
     poll?: number;
   };
   publicPath?: string;

--- a/packages/@angular/cli/lib/config/schema.json
+++ b/packages/@angular/cli/lib/config/schema.json
@@ -473,6 +473,20 @@
               "description": "Enable and define the file watching poll time period (milliseconds).",
               "type": "number"
             },
+            "ignored": {
+              "description": "Avoid rebuilding files when files matching this anymatch pattern fails.",
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ]
+            },
             "deleteOutputPath": {
               "description": "Delete output path before build.",
               "type": "boolean",

--- a/packages/@angular/cli/models/build-options.ts
+++ b/packages/@angular/cli/models/build-options.ts
@@ -17,6 +17,7 @@ export interface BuildOptions {
   extractCss?: boolean;
   watch?: boolean;
   outputHashing?: string;
+  ignored?: string | string[];
   poll?: number;
   app?: string;
   deleteOutputPath?: boolean;

--- a/packages/@angular/cli/tasks/serve.ts
+++ b/packages/@angular/cli/tasks/serve.ts
@@ -220,6 +220,7 @@ export default Task.extend({
       proxy: proxyConfig,
       compress: serveTaskOptions.target === 'production',
       watchOptions: {
+        ignored: serveTaskOptions.ignored,
         poll: serveTaskOptions.poll
       },
       https: serveTaskOptions.ssl,

--- a/tests/e2e/tests/build/ignored.ts
+++ b/tests/e2e/tests/build/ignored.ts
@@ -1,0 +1,72 @@
+import {
+  killAllProcesses,
+  waitForAnyProcessOutputToMatch
+} from '../../utils/process';
+import { readFile, writeFile } from '../../utils/fs';
+import { expectToFail } from '../../utils/utils';
+import { ngServe, updateJsonFile, useCIDefaults } from '../../utils/project';
+
+const webpackGoodRegEx = /webpack: Compiled successfully./;
+const shouldCompile = () => waitForAnyProcessOutputToMatch(webpackGoodRegEx, 10000);
+const shouldNotCompile = () => expectToFail(shouldCompile);
+
+const touch = (fileName: string) => readFile(fileName)
+  .then(
+    (content: string) => writeFile(fileName, content.concat('console.log(1);')),
+    error => writeFile(fileName, 'console.log(1);')
+  );
+
+const updateIgnoredConfig = (ignored: string | string[]) => updateJsonFile(
+  '.angular-cli.json',
+  ({ defaults }) => {
+    const { build = {} } = defaults;
+    defaults.build = { ...build, ignored };
+  }
+);
+
+export default function() {
+  return Promise.resolve()
+    // Can specify an array of  ignored options via the config
+    .then(() => updateIgnoredConfig([ '**/*~', '**/.*.sw[pon]' ])
+    .then(() => ngServe())
+    .then(() => touch('src/main.ts')).then(shouldCompile)
+    .then(() => touch('src/main.ts~')).then(shouldNotCompile)
+    .then(() => touch('src/.main.ts.swp')).then(shouldNotCompile)
+    .then(() => touch('src/.main.ts.swo')).then(shouldNotCompile)
+    .then(() => touch('src/.main.ts.swn')).then(shouldNotCompile)
+    .then(() => touch('src/main.ts')).then(shouldCompile)
+    .then(() => killAllProcesses())
+
+    // Can specify a single ignored option via the config
+    .then(() => updateIgnoredConfig('**/*~')
+    .then(() => ngServe())
+    .then(() => touch('src/main.ts')).then(shouldCompile)
+    .then(() => touch('src/main.ts~')).then(shouldNotCompile)
+    .then(() => touch('src/.main.ts.swp')).then(shouldCompile)
+    .then(() => touch('src/.main.ts.swo')).then(shouldCompile)
+    .then(() => touch('src/.main.ts.swn')).then(shouldCompile)
+    .then(() => touch('src/main.ts')).then(shouldCompile)
+    .then(() => killAllProcesses())
+
+    // Can specify a single ignored option via the command line
+    .then(() => useCIDefaults())
+    .then(() => ngServe('--ignored', '**/.*.sw[po]'))
+    .then(() => touch('src/main.ts')).then(shouldCompile)
+    .then(() => touch('src/main.ts~')).then(shouldCompile)
+    .then(() => touch('src/.main.ts.swp')).then(shouldNotCompile)
+    .then(() => touch('src/.main.ts.swo')).then(shouldNotCompile)
+    .then(() => touch('src/.main.ts.swn')).then(shouldCompile)
+    .then(() => touch('src/main.ts')).then(shouldCompile)
+    .then(() => killAllProcesses())
+
+    // Compiles on every file change by default
+    .then(() => useCIDefaults())
+    .then(() => ngServe())
+    .then(() => touch('src/main.ts')).then(shouldCompile)
+    .then(() => touch('src/main.ts~')).then(shouldCompile)
+    .then(() => touch('src/.main.ts.swp')).then(shouldCompile)
+    .then(() => touch('src/.main.ts.swo')).then(shouldCompile)
+    .then(() => touch('src/.main.ts.swn')).then(shouldCompile)
+    .then(() => touch('src/main.ts')).then(shouldCompile)
+    .then(() => killAllProcesses(), err => { killAllProcesses(); throw err; });
+}


### PR DESCRIPTION
Let the webpack dev server ignore files specified by the user
as either the `--ignored` command line option or through the
`defaults.build.ignored` option in the configuration file

This fixes #2425 and allows for a way to fix #4593.

TODO:
* [ ] Fix e2e test. The built code seems to work in practice, but not in the test environment.