### PR TITLE
fix(@ngtools/webpack): show error stack on plugin

### DIFF
--- a/packages/@ngtools/webpack/src/plugin.ts
+++ b/packages/@ngtools/webpack/src/plugin.ts
@@ -579,7 +579,7 @@ export class AotPlugin implements Tapable {
 
         cb();
       }, (err: any) => {
-        compilation.errors.push(err);
+        compilation.errors.push(err.stack);
         cb();
       });
   }


### PR DESCRIPTION
Plugin errors do not show the stack, just the message. This makes it harder to debug errors as the single line message blends into loader errors.