### PR TITLE
fix(@angular/cli): `ng lint` option format not work properly if using alias

### DIFF
--- a/packages/@angular/cli/commands/lint.ts
+++ b/packages/@angular/cli/commands/lint.ts
@@ -37,7 +37,7 @@ export default Command.extend({
     },
     {
       name: 'format',
-      alias: 't',
+      aliases: ['t'],
       type: String,
       default: 'prose',
       description: oneLine`

--- a/tests/e2e/tests/lint/lint-with-format-by-aliases.ts
+++ b/tests/e2e/tests/lint/lint-with-format-by-aliases.ts
@@ -1,0 +1,25 @@
+import { ng } from '../../utils/process';
+import { writeFile } from '../../utils/fs';
+import { getGlobalVariable } from '../../utils/env';
+import { oneLine } from 'common-tags';
+
+export default function () {
+  // Skip this in Appveyor tests.
+  if (getGlobalVariable('argv').appveyor) {
+    return Promise.resolve();
+  }
+
+  const fileName = 'src/app/foo.ts';
+
+  return Promise.resolve()
+    .then(() => writeFile(fileName, 'const foo = "";\n'))
+    .then(() => ng('lint', '-t=stylish', '--force'))
+    .then(({ stdout }) => {
+      if (!stdout.match(/1:13  quotemark  " should be '/)) {
+        throw new Error(oneLine`
+          Expected to match "1:13  quotemark  " should be '"
+          in ${stdout}.
+        `);
+      }
+    });
+}


### PR DESCRIPTION
`ng lint` keeps produce output with default format even though it is already using option -t=stylish