### PR TITLE
chore(@ngtools/webpack): allow JSON files to be cacheable

### DIFF
--- a/packages/@angular/cli/models/webpack-configs/common.ts
+++ b/packages/@angular/cli/models/webpack-configs/common.ts
@@ -137,7 +137,7 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
         { test: /\.html$/, loader: 'raw-loader' },
         { test: /\.(eot|svg|cur)$/, loader: `file-loader?name=[name]${hashFormat.file}.[ext]` },
         {
-          test: /\.(jpg|png|webp|gif|otf|ttf|woff|woff2|ani)$/,
+          test: /\.(jpg|png|webp|gif|otf|ttf|woff|woff2|ani|json)$/,
           loader: `url-loader?name=[name]${hashFormat.file}.[ext]&limit=10000`
         }
       ].concat(extraRules)


### PR DESCRIPTION
#### Reason
Static JSON files put in the assets folder are not currently cacheable because they are ignore by the Webpack `url-loader`.