### PR TITLE
feat(@angular/cli): automatically detect the live-reload client connection address

### DIFF
--- a/packages/@angular/cli/tasks/serve.ts
+++ b/packages/@angular/cli/tasks/serve.ts
@@ -95,7 +95,7 @@ export default Task.extend({
         `);
     }
 
-    let clientAddress = serverAddress;
+    let clientAddress = `${serveTaskOptions.ssl ? 'https' : 'http'}://0.0.0.0:0`;
     if (serveTaskOptions.publicHost) {
       let publicHost = serveTaskOptions.publicHost;
       if (!/^\w+:\/\//.test(publicHost)) {


### PR DESCRIPTION
Can still be manually specified with the `--public-host` option.