### PR TITLE
Ref #7197 - Increase keepAliveTimeout for Webpack Dev Server

### DIFF
--- a/packages/@angular/cli/tasks/serve.ts
+++ b/packages/@angular/cli/tasks/serve.ts
@@ -273,14 +273,27 @@ export default Task.extend({
     }
 
     return new Promise((_resolve, reject) => {
-      server.listen(serveTaskOptions.port, serveTaskOptions.host, (err: any, _stats: any) => {
-        if (err) {
-          return reject(err);
-        }
-        if (serveTaskOptions.open) {
-          opn(serverAddress);
-        }
-      });
+      const httpServer = server.listen(
+        serveTaskOptions.port,
+        serveTaskOptions.host,
+        (err: any, _stats: any) => {
+          if (err) {
+            return reject(err);
+          }
+          if (serveTaskOptions.open) {
+            opn(serverAddress);
+          }
+        });
+      // Node 8.0 - 8.4 has a keepAliveTimeout bug which doesn't respect active connections.
+      // Connections will end after ~5 seconds (arbitrary), often not letting the full download
+      // of large pieces of content, such as a vendor javascript file.  This results in browsers
+      // throwing a "net::ERR_CONTENT_LENGTH_MISMATCH" error.
+      // https://github.com/angular/angular-cli/issues/7197
+      // https://github.com/nodejs/node/issues/13391
+      // https://github.com/nodejs/node/commit/2cb6f2b281eb96a7abe16d58af6ebc9ce23d2e96
+      if (/^v8.[0-4].\d+$/.test(process.version)) {
+        httpServer.keepAliveTimeout = 30000; // 30 seconds
+      }
     })
     .catch((err: Error) => {
       if (err) {


### PR DESCRIPTION
Fixes #7197 

This resolves an issue with browsers throwing `net::ERR_CONTENT_LENGTH_MISMATCH` for large files or slow connections, when using Webpack Dev Server.  Large files, such as a vendor javascript bundle, are susceptible to this bug which is tracked all the way back to the NodeJS http module.  A change in NodeJS 8.0 broke the `keepAliveTimeout` handling where active requests don't reset the timeout timer.  This is fixed in NodeJS 8.5.

The `keepAliveTimeout` defaults to 5 seconds, which may be too short.  This change increases that `keepAliveTimeout` to 30 seconds, but only if the Node process has versions between 8.0 - 8.4.

I'd like to mention, I don't use Angular CLI and haven't tried this fix with Angular CLI specifically.  I have however verified it works when using Webpack Dev Server standalone.