### PR TITLE
feat(@angular/cli): propagate --preserve-symlinks on TS options

### DIFF
--- a/packages/@angular/cli/models/webpack-configs/typescript.ts
+++ b/packages/@angular/cli/models/webpack-configs/typescript.ts
@@ -14,6 +14,10 @@ const webpackLoader: string = g['angularCliIsLocal']
 
 function _createAotPlugin(wco: WebpackConfigOptions, options: any) {
   const { appConfig, projectRoot, buildOptions } = wco;
+  options.compilerOptions = options.compilerOptions || {};
+  if (wco.buildOptions.preserveSymlinks) {
+    options.compilerOptions.preserveSymlinks = true;
+  }
 
   // Read the environment, and set it in the compiler host.
   let hostReplacementPaths: any = {};


### PR DESCRIPTION
With TypeScript 2.5 supporting the `--preserve-symlinks` option, we should set it on the compiler options when the flag is passed into the CLI (it already works for webpack).

See https://blogs.msdn.microsoft.com/typescript/2017/08/31/announcing-typescript-2-5/#user-content-the---preservesymlinks-compiler-flag for more info.