### PR TITLE
fix(@ngtools/webpack): don't show loader errors after compilation fails

### DIFF
--- a/packages/@ngtools/webpack/src/loader.ts
+++ b/packages/@ngtools/webpack/src/loader.ts
@@ -602,7 +602,14 @@ export function ngcLoader(this: LoaderContext & { _compilation: any }, source: s
         });
 
         const result = refactor.transpile(compilerOptions);
-        cb(null, result.outputText, result.sourceMap);
+
+        if (plugin.failedCompilation) {
+          // Return an empty string to prevent extra loader errors (missing imports etc).
+          // Plugin errors were already pushed to the compilation errors.
+          cb(null, '');
+        } else {
+          cb(null, result.outputText, result.sourceMap);
+        }
       })
       .catch(err => cb(err));
   } else {


### PR DESCRIPTION
When compilation fails, the loader can still return broken code. This generates extra stack traces that don't show any useful information and obscure the real error.

This PR cuts down on these extra errors.

Before:
```
kamik@T460p MINGW64 /d/sandbox/master-project (master)
$ ng build --aot --i18n-file src/locale/missing-file.xlf
Date: 2017-09-01T14:16:40.650Z
Hash: ceb93ba6373e5bbe16bb
Time: 3217ms
chunk {inline} inline.bundle.js, inline.bundle.js.map (inline) 5.83 kB [entry] [rendered]
chunk {main} main.bundle.js, main.bundle.js.map (main) 3.6 kB {vendor} [initial] [rendered]
chunk {polyfills} polyfills.bundle.js, polyfills.bundle.js.map (polyfills) 220 kB {inline} [initial] [rendered]
chunk {styles} styles.bundle.js, styles.bundle.js.map (styles) 11.8 kB {inline} [initial] [rendered]
chunk {vendor} vendor.bundle.js, vendor.bundle.js.map (vendor) 883 kB [initial] [rendered]

ERROR in ./src/main.ts
Module not found: Error: Can't resolve './$$_gendir/app/app.module.ngfactory' in 'D:\sandbox\master-project\src'
resolve './$$_gendir/app/app.module.ngfactory' in 'D:\sandbox\master-project\src'
  using description file: D:\sandbox\master-project\package.json (relative path: ./src)
    Field 'browser' doesn't contain a valid alias configuration
  after using description file: D:\sandbox\master-project\package.json (relative path: ./src)
    using description file: D:\sandbox\master-project\package.json (relative path: ./src/$$_gendir/app/app.module.ngfactory)
      no extension
        Field 'browser' doesn't contain a valid alias configuration
        D:\sandbox\master-project\src\$$_gendir\app\app.module.ngfactory doesn't exist
      .ts
        Field 'browser' doesn't contain a valid alias configuration
        D:\sandbox\master-project\src\$$_gendir\app\app.module.ngfactory.ts doesn't exist
      .js
        Field 'browser' doesn't contain a valid alias configuration
        D:\sandbox\master-project\src\$$_gendir\app\app.module.ngfactory.js doesn't exist
      as directory
        D:\sandbox\master-project\src\$$_gendir\app\app.module.ngfactory doesn't exist
[D:\sandbox\master-project\src\$$_gendir\app\app.module.ngfactory]
[D:\sandbox\master-project\src\$$_gendir\app\app.module.ngfactory.ts]
[D:\sandbox\master-project\src\$$_gendir\app\app.module.ngfactory.js]
[D:\sandbox\master-project\src\$$_gendir\app\app.module.ngfactory]
 @ ./src/main.ts 3:0-74
 @ multi ./src/main.ts
ERROR in Error: The translation file (src/locale/missing-file.xlf) locale must be provided. Use the --locale option.
    at Function.CodeGenerator.create (D:\work\cli\node_modules\@angular\compiler-cli\src\codegen.js:61:23)
    at Function.NgTools_InternalApi_NG_2.codeGen (D:\work\cli\node_modules\@angular\compiler-cli\src\ngtools_api.js:72:53)
    at _donePromise.Promise.resolve.then (D:\work\cli\packages\@ngtools\webpack\src\plugin.ts:381:44)
```

After:
```
kamik@T460p MINGW64 /d/sandbox/master-project (master)
$ ng build --aot --i18n-file src/locale/missing-file.xlf
Date: 2017-09-01T14:15:37.863Z
Hash: a7b64550c14d7f9d0d1b
Time: 1059ms
chunk {inline} inline.bundle.js, inline.bundle.js.map (inline) 5.83 kB [entry] [rendered]
chunk {main} main.bundle.js, main.bundle.js.map (main) 361 bytes [initial] [rendered]
chunk {polyfills} polyfills.bundle.js, polyfills.bundle.js.map (polyfills) 381 bytes {inline} [initial] [rendered]
chunk {styles} styles.bundle.js, styles.bundle.js.map (styles) 11.8 kB {inline} [initial] [rendered]

ERROR in Error: The translation file (src/locale/missing-file.xlf) locale must be provided. Use the --locale option.
    at Function.CodeGenerator.create (D:\work\cli\node_modules\@angular\compiler-cli\src\codegen.js:61:23)
    at Function.NgTools_InternalApi_NG_2.codeGen (D:\work\cli\node_modules\@angular\compiler-cli\src\ngtools_api.js:72:53)
    at _donePromise.Promise.resolve.then (D:\work\cli\packages\@ngtools\webpack\src\plugin.ts:386:44)
```
