### PR TITLE
fix(@angular/cli): fix new to work with custom collections

### DIFF
--- a/packages/@angular/cli/commands/new.ts
+++ b/packages/@angular/cli/commands/new.ts
@@ -144,7 +144,11 @@ const NewCommand = Command.extend({
       `);
     }
 
-    commandOptions.collectionName = this.getCollectionName(rawArgs);
+    if (commandOptions.collection) {
+      commandOptions.collectionName = commandOptions.collection;
+    } else {
+      commandOptions.collectionName = this.getCollectionName(rawArgs);
+    }
 
     const initCommand = new InitCommand({
       ui: this.ui,

--- a/tests/acceptance/new.spec.ts
+++ b/tests/acceptance/new.spec.ts
@@ -15,6 +15,9 @@ describe('Acceptance: ng new', function () {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
 
     spyOn(console, 'error');
+    // symlink custom collections to node_modules, so we can use with ng new
+    // it is a bit dirty, but bootstrap-local tricks won't work here
+    fs.symlinkSync(`${process.cwd()}/tests/collections/@custom`, `./node_modules/@custom`, 'dir');
 
     tmp.setup('./tmp')
       .then(() => process.chdir('./tmp'))
@@ -22,6 +25,7 @@ describe('Acceptance: ng new', function () {
   }, 10000);
 
   afterEach((done) => {
+    fs.unlinkSync(path.join(__dirname, '/../../node_modules/@custom'));
     jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
     tmp.teardown('./tmp').then(() => done());
   });
@@ -172,6 +176,12 @@ describe('Acceptance: ng new', function () {
       expect(pkgJson.devDependencies['@angular/cli']).toMatch(/\d+\.\d+\.\d+/);
     })
     .then(done, done.fail);
-  })
+  });
 
+  it('should support passing a custom collection', (done) => {
+    return ng(['new', 'foo', '--collection=@custom/application', '--skip-install', '--skip-git']).then(() => {
+      expect(() => fs.readFileSync('emptyapp', 'utf8')).not.toThrow();
+    })
+    .then(done, done.fail);
+  });
 });

--- a/tests/collections/@custom/application/collection.json
+++ b/tests/collections/@custom/application/collection.json
@@ -1,0 +1,11 @@
+{
+  "name": "@custom/application",
+  "version": "0.1",
+  "schematics": {
+    "application": {
+      "factory": "./index.js",
+      "schema": "./schema.json",
+      "description": "Create an empty application"
+    }
+  }
+}

--- a/tests/collections/@custom/application/index.js
+++ b/tests/collections/@custom/application/index.js
@@ -1,0 +1,6 @@
+const s = require('@angular-devkit/schematics');
+
+exports.default = function(options) {
+  return s.chain([s.mergeWith(s.apply(
+    s.url('./files'), [s.template({}), s.move(options.name)]))]);
+};

--- a/tests/collections/@custom/application/package.json
+++ b/tests/collections/@custom/application/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "empty-app",
+  "schematics": "./collection.json"
+}

--- a/tests/collections/@custom/application/schema.json
+++ b/tests/collections/@custom/application/schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "id": "EmptyApp",
+  "title": "Angular Bazel Workspace Options Schema",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    }
+  },
+  "required": [
+  ]
+}


### PR DESCRIPTION
`ng new proj --collection=custom` throws because collection gets stripped out of `rawArgs`. This is a bug fix for that.