### PR TITLE
test: fix flaky rebuild-deps-test

### DIFF
--- a/tests/e2e/tests/build/rebuild-deps-type-check.ts
+++ b/tests/e2e/tests/build/rebuild-deps-type-check.ts
@@ -41,6 +41,7 @@ export default function() {
     // Should trigger a rebuild, no error expected.
     .then(() => execAndWaitForOutputToMatch('ng', ['serve'], doneRe))
     // Make an invalid version of the file.
+    .then(() => wait(2000))
     .then(() => writeFile('src/funky2.ts', `
       export function funky2(value: number): number {
         return value + 1;
@@ -66,6 +67,7 @@ export default function() {
       }
     })
     // Fix the error!
+    .then(() => wait(2000))
     .then(() => writeFile('src/funky2.ts', `
       export function funky2(value: string): string {
         return value + 'hello';


### PR DESCRIPTION
This test is flaky because writing a file right after rebuilds are done can cause webpack to not detect the change.