### PR TITLE
fix(@ngtools/webpack): fix #7615, check if this.done is defined before delaying resolvers

### DIFF
--- a/packages/@ngtools/webpack/src/plugin.ts
+++ b/packages/@ngtools/webpack/src/plugin.ts
@@ -390,9 +390,9 @@ export class AotPlugin implements Tapable {
       // Wait for the plugin to be done when requesting `.ts` files directly (entry points), or
       // when the issuer is a `.ts` file.
       compiler.resolvers.normal.plugin('before-resolve', (request: any, cb: () => void) => {
-        if (request.request.endsWith('.ts')
-          || (request.context.issuer && request.context.issuer.endsWith('.ts'))) {
-          this.done!.then(() => cb(), () => cb());
+        if (this.done && (request.request.endsWith('.ts')
+          || (request.context.issuer && request.context.issuer.endsWith('.ts')))) {
+          this.done.then(() => cb(), () => cb());
         } else {
           cb();
         }


### PR DESCRIPTION
Resolves #7615