### PR TITLE
fix(@angular/cli): Generating component considers default style ext

### DIFF
--- a/packages/@angular/cli/commands/generate.ts
+++ b/packages/@angular/cli/commands/generate.ts
@@ -145,9 +145,15 @@ export default Command.extend({
     const cwd = this.project.root;
     const schematicName = rawArgs[0];
 
-    if (schematicName === 'component' || schematicName === 'directive') {
+    if (['component', 'c', 'directive', 'd'].indexOf(schematicName) !== -1) {
       if (commandOptions.prefix === undefined) {
         commandOptions.prefix = appConfig.prefix;
+      }
+
+      if (schematicName === 'component' || schematicName === 'c') {
+        if (commandOptions.styleext === undefined) {
+          commandOptions.styleext = CliConfig.getValue('defaults.styleExt');
+        }
       }
     }
 

--- a/packages/@angular/cli/tasks/schematic-run.ts
+++ b/packages/@angular/cli/tasks/schematic-run.ts
@@ -177,8 +177,7 @@ function prepOptions(schematic: Schematic<{}, {}>, options: SchematicOptions): S
 
   const properties = (<any>schematic.description).schemaJson.properties;
   const keys = Object.keys(properties);
-
-  if (schematic.description.name === 'component') {
+  if (['component', 'c', 'directive', 'd'].indexOf(schematic.description.name) !== -1) {
     options.prefix = (options.prefix === 'false' || options.prefix === '')
       ? '' : options.prefix;
   }

--- a/tests/acceptance/generate-component.spec.ts
+++ b/tests/acceptance/generate-component.spec.ts
@@ -73,6 +73,22 @@ describe('Acceptance: ng generate component', () => {
       .then(done, done.fail);
   });
 
+  it('mycomp should use styleExt from the angular-cli.json for style file', (done) => {
+    return ng(['generate', 'component', 'mycomp']).then(() => {
+      const cliJson = JSON.parse(readFileSync('.angular-cli.json', 'utf8'));
+      const styleExt = cliJson.defaults.styleExt;
+      expect(styleExt).toBe('css');
+      const scssFilePath =
+        path.join(root, 'tmp', 'foo', 'src', 'app', 'mycomp', `mycomp.component.${styleExt}`);
+      const compPath =
+        path.join(root, 'tmp', 'foo', 'src', 'app', 'mycomp', 'mycomp.component.ts');
+      expect(pathExistsSync(scssFilePath)).toBe(true);
+      const contents = readFileSync(compPath, 'utf8');
+      expect(contents.indexOf(`styleUrls: [\'./mycomp.component.${styleExt}\']`) === -1).toBe(false);
+    })
+    .then(done, done.fail);
+  });
+
   it('child-dir' + path.sep + 'my-comp from a child dir', (done) => {
     mkdirsSync(path.join(root, 'tmp', 'foo', 'src', 'app', '1', 'child-dir'));
     return new Promise(function (resolve) {


### PR DESCRIPTION
Fixes #7624, #7644, #7647, #7708, #7715, #7719, #7721 & #7522