### PR TITLE
fix(@angular/cli): publicPath should not be path.join

### DIFF
--- a/packages/@angular/cli/plugins/insert-concat-assets-webpack-plugin.ts
+++ b/packages/@angular/cli/plugins/insert-concat-assets-webpack-plugin.ts
@@ -1,5 +1,5 @@
 // Add assets from `ConcatPlugin` to index.html.
-import * as path from 'path';
+
 
 export class InsertConcatAssetsWebpackPlugin {
   // Priority list of where to insert asset.
@@ -24,7 +24,13 @@ export class InsertConcatAssetsWebpackPlugin {
               throw new Error(`Cannot find file for ${entryName} script.`);
             }
 
-            return path.join(htmlPluginData.assets.publicPath, fileName);
+            if (htmlPluginData.assets.publicPath) {
+              if (htmlPluginData.assets.publicPath.endsWith('/')) {
+                return htmlPluginData.assets.publicPath + fileName;
+              }
+              return htmlPluginData.assets.publicPath + '/' + fileName;
+            }
+            return fileName;
           });
 
           let insertAt = 0;

--- a/tests/e2e/tests/build/deploy-url.ts
+++ b/tests/e2e/tests/build/deploy-url.ts
@@ -24,6 +24,8 @@ export default function () {
     .then(() => expectFileToMatch('dist/index.html', 'deployUrl/main.bundle.js'))
     // verify --deploy-url isn't applied to extracted css urls
     .then(() => expectFileToMatch('dist/styles.bundle.css', /url\(more\.[0-9a-f]{20}\.svg\)/))
+    .then(() => ng('build', '--deploy-url=http://example.com/some/path/', '--extract-css'))
+    .then(() => expectFileToMatch('dist/index.html', 'http://example.com/some/path/main.bundle.js'))
     // verify option also works in config
     .then(() => updateJsonFile('.angular-cli.json', configJson => {
       const app = configJson['apps'][0];


### PR DESCRIPTION
Using path.join removes duplicated slashes, like in https://. This code
is the correct version used in the original html-webpack-plugin.

Fixes #7650