### PR TITLE
feat(@angular/cli): Add option to preserve symlinks for module resolution in test task

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@angular/cli",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -256,6 +256,16 @@
         "@types/node": "6.0.87",
         "@types/tapable": "0.2.3",
         "@types/uglify-js": "2.6.29"
+      }
+    },
+    "JSONStream": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
+      "dev": true,
+      "requires": {
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
       }
     },
     "abbrev": {
@@ -1603,8 +1613,8 @@
       "integrity": "sha1-4ye1MZThp61dxjR57pCZpSsCSGU=",
       "dev": true,
       "requires": {
-        "is-text-path": "1.0.1",
         "JSONStream": "1.3.1",
+        "is-text-path": "1.0.1",
         "lodash": "4.17.4",
         "meow": "3.7.0",
         "split2": "2.1.1",
@@ -4225,16 +4235,6 @@
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
-    },
-    "JSONStream": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
-      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
-      "dev": true,
-      "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
-      }
     },
     "jsprim": {
       "version": "1.4.1",
@@ -6993,14 +6993,6 @@
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -7034,6 +7026,14 @@
         "define-properties": "1.1.2",
         "es-abstract": "1.8.0",
         "function-bind": "1.1.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/packages/@angular/cli/commands/test.ts
+++ b/packages/@angular/cli/commands/test.ts
@@ -23,6 +23,7 @@ export interface TestOptions {
   poll?: number;
   environment?: string;
   app?: string;
+  preserveSymlinks?:boolean;
 }
 
 
@@ -114,6 +115,12 @@ const TestCommand = Command.extend({
       type: String,
       aliases: ['a'],
       description: 'Specifies app name to use.'
+    },
+    {
+      name: 'preserve-symlinks',
+      type: Boolean,
+      description: 'Do not use the real path when resolving modules.',
+      default: false
     }
   ],
 

--- a/packages/@angular/cli/commands/test.ts
+++ b/packages/@angular/cli/commands/test.ts
@@ -23,7 +23,7 @@ export interface TestOptions {
   poll?: number;
   environment?: string;
   app?: string;
-  preserveSymlinks?:boolean;
+  preserveSymlinks?: boolean;
 }
 
 

--- a/packages/@angular/cli/tasks/test.ts
+++ b/packages/@angular/cli/tasks/test.ts
@@ -40,7 +40,8 @@ export default Task.extend({
         progress: options.progress,
         poll: options.poll,
         environment: options.environment,
-        app: options.app
+        app: options.app,
+        preserveSymlinks: options.preserveSymlinks
       };
 
       // Assign additional karmaConfig options to the local ngapp config


### PR DESCRIPTION
The PR https://github.com/angular/angular-cli/pull/6460 added *build* support for linked packages and peer dependency usage scenarios.

This PR adds equivalent support for tests by adding the preserveSymlinks parameter to the test task and command.
