### PR TITLE
fix(@ngtools/webpack): use outDir for i18n extraction in Angular v5

### DIFF
--- a/packages/@ngtools/webpack/src/extract_i18n_plugin.ts
+++ b/packages/@ngtools/webpack/src/extract_i18n_plugin.ts
@@ -106,10 +106,11 @@ export class ExtractI18nPlugin implements Tapable {
 
     this._compilerOptions = tsConfig.options;
     this._angularCompilerOptions = Object.assign(
+      // kept for compatibility with Angular <v5.0.0-beta.7+
       { genDir },
       this._compilerOptions,
       tsConfig.raw['angularCompilerOptions'],
-      { basePath }
+      { basePath, outDir: genDir }
     );
 
     this._basePath = basePath;


### PR DESCRIPTION
From Angular v5 beta 7, the extraction script uses the new pipeline and genDir has been replaced by outDir. This fix ensures the compatibility with previous versions of Angular as well, which is why I haven't renamed the plugin parameter genDir to outDir (genDir was never related to the "genDir" option from the tsconfig file anyway since it uses the value from the cli parameter `outputPath` instead, or the app config root value by default).

Fixes https://github.com/angular/angular/issues/19198