### PR TITLE
feat(@angular/cli): support schematics generating new apps

### DIFF
--- a/packages/@angular/cli/commands/generate.ts
+++ b/packages/@angular/cli/commands/generate.ts
@@ -126,41 +126,42 @@ export default Command.extend({
       throw 'The `ng generate module` command requires a name to be specified.';
     }
 
+    const cwd = this.project.root;
+    const schematicName = rawArgs[0];
     const entityName = rawArgs[1];
     commandOptions.name = stringUtils.dasherize(entityName.split(separatorRegEx).pop());
 
-    const appConfig = getAppFromConfig(commandOptions.app);
-    const dynamicPathOptions: DynamicPathOptions = {
-      project: this.project,
-      entityName: entityName,
-      appConfig: appConfig,
-      dryRun: commandOptions.dryRun
-    };
-    const parsedPath = dynamicPathParser(dynamicPathOptions);
-    commandOptions.sourceDir = appConfig.root;
-    const root = appConfig.root + path.sep;
-    commandOptions.appRoot = parsedPath.appRoot === appConfig.root ? '' :
-      parsedPath.appRoot.startsWith(root)
-        ? parsedPath.appRoot.substr(root.length)
-        : parsedPath.appRoot;
+    const newProject = CliConfig.getValue('defaults.schematics.newProject');
+    if (!newProject || newProject.indexOf(schematicName) === -1) {
+      const appConfig = getAppFromConfig(commandOptions.app);
+      const dynamicPathOptions: DynamicPathOptions = {
+        project: this.project,
+        entityName: entityName,
+        appConfig: appConfig,
+        dryRun: commandOptions.dryRun
+      };
+      const parsedPath = dynamicPathParser(dynamicPathOptions);
+      commandOptions.sourceDir = appConfig.root;
+      const root = appConfig.root + path.sep;
+      commandOptions.appRoot = parsedPath.appRoot === appConfig.root ? '' :
+        parsedPath.appRoot.startsWith(root)
+          ? parsedPath.appRoot.substr(root.length)
+          : parsedPath.appRoot;
+      commandOptions.path = parsedPath.dir.replace(separatorRegEx, '/');
+      commandOptions.path = parsedPath.dir === appConfig.root ? '' :
+          parsedPath.dir.startsWith(root)
+            ? commandOptions.path.substr(root.length)
+            : commandOptions.path;
 
-    commandOptions.path = parsedPath.dir.replace(separatorRegEx, '/');
-    commandOptions.path = parsedPath.dir === appConfig.root ? '' :
-      parsedPath.dir.startsWith(root)
-        ? commandOptions.path.substr(root.length)
-        : commandOptions.path;
+      if (['component', 'c', 'directive', 'd'].indexOf(schematicName) !== -1) {
+        if (commandOptions.prefix === undefined) {
+          commandOptions.prefix = appConfig.prefix;
+        }
 
-    const cwd = this.project.root;
-    const schematicName = rawArgs[0];
-
-    if (['component', 'c', 'directive', 'd'].indexOf(schematicName) !== -1) {
-      if (commandOptions.prefix === undefined) {
-        commandOptions.prefix = appConfig.prefix;
-      }
-
-      if (schematicName === 'component' || schematicName === 'c') {
-        if (commandOptions.styleext === undefined) {
-          commandOptions.styleext = CliConfig.getValue('defaults.styleExt');
+        if (schematicName === 'component' || schematicName === 'c') {
+          if (commandOptions.styleext === undefined) {
+            commandOptions.styleext = CliConfig.getValue('defaults.styleExt');
+          }
         }
       }
     }

--- a/packages/@angular/cli/lib/config/schema.json
+++ b/packages/@angular/cli/lib/config/schema.json
@@ -555,6 +555,13 @@
               "description": "The new app schematic.",
               "type": "string",
               "default": "application"
+            },
+            "newProject": {
+              "description": "The new project schematic.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           },
           "additionalProperties": false

--- a/tests/acceptance/generate-app.spec.ts
+++ b/tests/acceptance/generate-app.spec.ts
@@ -1,0 +1,46 @@
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import { ng } from '../helpers';
+const tmp = require('../helpers/tmp');
+
+describe('Acceptance: ng generate applications', () => {
+  beforeEach((done) => {
+    spyOn(console, 'error');
+
+    fs.symlinkSync(`${process.cwd()}/tests/collections/@custom`, `./node_modules/@custom`, 'dir');
+
+    tmp.setup('./tmp')
+      .then(() => process.chdir('./tmp'))
+      .then(() => ng(['new', 'empty', '--skip-install']))
+      .then(() => removeAllApps())
+      .then(done, done.fail);
+  }, 10000);
+
+  afterEach((done) => {
+    tmp.teardown('./tmp').then(done, done.fail);
+    fs.unlinkSync(path.join(__dirname, '/../../node_modules/@custom'));
+  });
+
+  it('ng generate app myapp', (done) => {
+    return ng(['generate', 'app', 'myapp', '--collection', '@custom/app']).then(() => {
+      expect(() => fs.readFileSync(`myapp/emptyapp`, 'utf8')).not.toThrow();
+    })
+    .then(done, done.fail);
+  });
+});
+
+function removeAllApps(): Promise<any> {
+  const cliJson = path.join(path.join(process.cwd()), '.angular-cli.json');
+  return fs.readFile(cliJson, 'utf-8').then(content => {
+    const json = JSON.parse(content);
+    json.apps = [];
+    json.defaults = {
+      schematics: {
+        newProject: ['app']
+      }
+    };
+    return json;
+  }).then(json => {
+    return fs.writeFile(cliJson, JSON.stringify(json, null, 2));
+  });
+}

--- a/tests/collections/@custom/app/collection.json
+++ b/tests/collections/@custom/app/collection.json
@@ -1,0 +1,11 @@
+{
+  "name": "@custom/app",
+  "version": "0.1",
+  "schematics": {
+    "app": {
+      "factory": "./index.js",
+      "schema": "./schema.json",
+      "description": "Create an empty app"
+    }
+  }
+}

--- a/tests/collections/@custom/app/index.js
+++ b/tests/collections/@custom/app/index.js
@@ -1,0 +1,6 @@
+const s = require('@angular-devkit/schematics');
+
+exports.default = function (options) {
+  return s.chain([s.mergeWith(s.apply(
+    s.url('./files'), [s.template({ name: options.name })]))]);
+};

--- a/tests/collections/@custom/app/package.json
+++ b/tests/collections/@custom/app/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "empty-app",
+  "schematics": "./collection.json"
+}

--- a/tests/collections/@custom/app/schema.json
+++ b/tests/collections/@custom/app/schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "id": "EmptyApp",
+  "title": "EmptyApp",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "name"
+  ]
+}


### PR DESCRIPTION
AngularCLI supports having multiple apps (== projects within the same "workspace"), but there is no way to generate them. The generate commands requires an already existing app. 

This PR enhances the generate command to support this use case.