### PR TITLE
fix(@angular/cli): ensure asset output is within the output path

### DIFF
--- a/packages/@angular/cli/models/webpack-configs/common.ts
+++ b/packages/@angular/cli/models/webpack-configs/common.ts
@@ -12,6 +12,7 @@ import { readTsconfig } from '../../utilities/read-tsconfig';
 const ConcatPlugin = require('webpack-concat-plugin');
 const ProgressPlugin = require('webpack/lib/ProgressPlugin');
 const CircularDependencyPlugin = require('circular-dependency-plugin');
+const SilentError = require('silent-error');
 
 
 /**
@@ -95,6 +96,13 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
       asset.input = path.resolve(appRoot, asset.input || '');
       asset.output = asset.output || '';
       asset.glob = asset.glob || '';
+
+      // Prevent asset configurations from writing outside of the output path
+      const fullOutputPath = path.resolve(buildOptions.outputPath, asset.output);
+      if (!fullOutputPath.startsWith(path.resolve(buildOptions.outputPath))) {
+        const message = 'An asset cannot be written to a location outside of the output path.';
+        throw new SilentError(message);
+      }
 
       // Ensure trailing slash.
       if (isDirectory(path.resolve(asset.input))) {

--- a/tests/e2e/tests/build/assets.ts
+++ b/tests/e2e/tests/build/assets.ts
@@ -26,6 +26,14 @@ export default function () {
       './src/output-asset.txt': 'output-asset.txt',
       './node_modules/some-package/node_modules-asset.txt': 'node_modules-asset.txt',
     }))
+    // Add invalid asset config in .angular-cli.json.
+    .then(() => updateJsonFile('.angular-cli.json', configJson => {
+      const app = configJson['apps'][0];
+      app['assets'] = [
+        { 'glob': '**/*', 'input': '../node_modules/some-package/', 'output': '../package-folder' }
+      ];
+    }))
+    .then(() => expectToFail(() => ng('build')))
     // Add asset config in .angular-cli.json.
     .then(() => updateJsonFile('.angular-cli.json', configJson => {
       const app = configJson['apps'][0];


### PR DESCRIPTION
Build output should be sandboxed within the specified output path.  It's currently quite easy to unintentionally (or the remote chance of maliciously) cause an asset or assets to be written to a location on the filesystem outside the project itself.