### PR TITLE
feat(@angular/cli): improve error messages for apps that do not have 'main' defined

### DIFF
--- a/packages/@angular/cli/tasks/build.ts
+++ b/packages/@angular/cli/tasks/build.ts
@@ -26,6 +26,9 @@ export default Task.extend({
     if (config.project && config.project.ejected) {
       throw new SilentError('An ejected project cannot use the build command anymore.');
     }
+    if (! app.main) {
+      throw new SilentError(`An app without 'main' cannot use the build command.`);
+    }
     if (runTaskOptions.deleteOutputPath) {
       fs.removeSync(path.resolve(this.project.root, outputPath));
     }

--- a/packages/@angular/cli/tasks/test.ts
+++ b/packages/@angular/cli/tasks/test.ts
@@ -21,6 +21,9 @@ export default Task.extend({
     if (appConfig.platform === 'server') {
       throw new SilentError('ng test for platform server applications is coming soon!');
     }
+    if (! appConfig.main) {
+      throw new SilentError(`An app without 'main' cannot use the test command.`);
+    }
 
     return new Promise((resolve) => {
       const karma = requireProjectModule(projectRoot, 'karma');


### PR DESCRIPTION
It's not uncommon for large CLI projects with multiple CLI apps to have apps that are only used in the context of other apps, so they cannot be built or tested independently, and they do not have main defined.

Currently, this setup works, except that the user will get cryptic error messages when trying run build or test it. This PR makes it nicer by providing better error messages.

 