### PR TITLE
fix(@angular/cli): increase keepAliveTimeout for all Node 8 versions

### DIFF
--- a/packages/@angular/cli/tasks/serve.ts
+++ b/packages/@angular/cli/tasks/serve.ts
@@ -284,14 +284,14 @@ export default Task.extend({
             opn(serverAddress);
           }
         });
-      // Node 8.0 - 8.4 has a keepAliveTimeout bug which doesn't respect active connections.
+      // Node 8 has a keepAliveTimeout bug which doesn't respect active connections.
       // Connections will end after ~5 seconds (arbitrary), often not letting the full download
       // of large pieces of content, such as a vendor javascript file.  This results in browsers
       // throwing a "net::ERR_CONTENT_LENGTH_MISMATCH" error.
       // https://github.com/angular/angular-cli/issues/7197
       // https://github.com/nodejs/node/issues/13391
       // https://github.com/nodejs/node/commit/2cb6f2b281eb96a7abe16d58af6ebc9ce23d2e96
-      if (/^v8.[0-4].\d+$/.test(process.version)) {
+      if (/^v8.\d.\d+$/.test(process.version)) {
         httpServer.keepAliveTimeout = 30000; // 30 seconds
       }
     })


### PR DESCRIPTION
Fixes #7197, in continuation to #7563 

Thanks @mtraynham for the original fix.

This resolves an issue with browsers throwing net::ERR_CONTENT_LENGTH_MISMATCH for large files or slow connections, when using Webpack Dev Server. Large files, such as a vendor javascript bundle, are susceptible to this bug which is tracked all the way back to the NodeJS http module. A change in NodeJS 8.0 broke the keepAliveTimeout handling where active requests don't reset the timeout timer. This is a proposal fix in NodeJS 8.6, but that is what was last time as well.

The keepAliveTimeout defaults to 5 seconds, which may be too short. This change increases that keepAliveTimeout to 30 seconds, but only if the Node process has versions starting with 8