### PR TITLE
fix(@angular/cli): open app with servePath

### DIFF
--- a/packages/@angular/cli/tasks/serve.ts
+++ b/packages/@angular/cli/tasks/serve.ts
@@ -281,7 +281,7 @@ export default Task.extend({
             return reject(err);
           }
           if (serveTaskOptions.open) {
-            opn(serverAddress);
+            opn(serverAddress + servePath);
           }
         });
       // Node 8 has a keepAliveTimeout bug which doesn't respect active connections.


### PR DESCRIPTION
### Current behavior

Currently when I execute `ng serve --base-href /foo/ --open`,  a browser tab is opened in `localhost:4200`. 

### Expected behavior

`ng serve --base-href /foo/ --open` opens a tab in `localhost:4200/foo/`

### Note

How should I write a test for this? 🤔 