### PR TITLE
test: fix tslint failure test after update

### DIFF
--- a/tests/e2e/tests/lint/lint-with-type-check-fail.ts
+++ b/tests/e2e/tests/lint/lint-with-type-check-fail.ts
@@ -24,8 +24,8 @@ const c = {
 
 function check(val: any, fxState: any) {
   if (typeof val === "string" && val.indexOf(" ") < 0) {
-    let r = val.match(ANIMATION_CSS_VALUE_REGEX);
-    let num = parseFloat(r[1]);
+    var r = val.match(ANIMATION_CSS_VALUE_REGEX);
+    var num = parseFloat(r[1]);
 
     if (!isNaN(num)) {
       fxState.num = num + "";


### PR DESCRIPTION
The latest tslint (minor version) does not return an error status code
when linting errors were fixed (using --fix). Only if there are more
linting errors, which is what were adding here.