### PR TITLE
fix(@angular/cli): do not run e2e task if build fails

### DIFF
--- a/docs/documentation/e2e.md
+++ b/docs/documentation/e2e.md
@@ -42,6 +42,9 @@ End-to-end tests are run via [Protractor] (https://angular.github.io/protractor/
   <p>
     Compile and Serve the app. All serve options are also available. The live-reload option defaults to false, and the default port will be random.
   </p>
+  <p>
+    NOTE: Build failure will not launch the e2e task. You must first fix error(s) and run e2e again.
+  </p>
 </details>
 
 <details>

--- a/packages/@angular/cli/commands/e2e.ts
+++ b/packages/@angular/cli/commands/e2e.ts
@@ -107,11 +107,14 @@ const E2eCommand = Command.extend({
       // Protractor will end the proccess, so we don't need to kill the dev server
       return new Promise((resolve, reject) => {
         let firstRebuild = true;
-        function rebuildCb() {
+        function rebuildCb(stats: any) {
           // don't run re-run tests on subsequent rebuilds
-          if (firstRebuild) {
+          const cleanBuild = !!!stats.compilation.errors.length;
+          if (firstRebuild && cleanBuild) {
             firstRebuild = false;
             return resolve(e2eTask.run(commandOptions));
+          } else {
+            return reject('Build did not succeed. Please fix errors before running e2e task');
           }
         }
 


### PR DESCRIPTION
when ng e2e --serve=true is run and the build is not successful e2e task
should not be run

previously the e2e task was run even if build was a failure which will
obviously result in failure of test cases
now if errors are detected in build the e2e task will not be run
update docs as well to reflect this behaviour

Closes #7567