### PR TITLE
fix(@ngtools/webpack): always emit on first build

### DIFF
--- a/packages/@ngtools/webpack/src/loader.ts
+++ b/packages/@ngtools/webpack/src/loader.ts
@@ -557,15 +557,11 @@ export function ngcLoader(this: LoaderContext & { _compilation: any }, source: s
             result.sourceMap = JSON.stringify(sourceMap);
           }
 
-          if (plugin.failedCompilation) {
-            // Return an empty string if there is no result to prevent extra loader errors.
-            // Plugin errors were already pushed to the compilation errors.
-            timeEnd(timeLabel);
-            cb(null, result.outputText || '', result.sourceMap);
-          } else {
-            timeEnd(timeLabel);
-            cb(null, result.outputText, result.sourceMap);
+          timeEnd(timeLabel);
+          if (result.outputText === undefined) {
+            throw new Error('TypeScript compilation failed.');
           }
+          cb(null, result.outputText, result.sourceMap);
         })
         .catch(err => {
           timeEnd(timeLabel + '.ngcLoader.AngularCompilerPlugin');
@@ -658,15 +654,12 @@ export function ngcLoader(this: LoaderContext & { _compilation: any }, source: s
           timeEnd(timeLabel + '.ngcLoader.AotPlugin.transpile');
 
           timeEnd(timeLabel + '.ngcLoader.AotPlugin');
-          if (plugin.failedCompilation && plugin.compilerOptions.noEmitOnError) {
-            // Return an empty string to prevent extra loader errors (missing imports etc).
-            // Plugin errors were already pushed to the compilation errors.
-            timeEnd(timeLabel);
-            cb(null, '');
-          } else {
-            timeEnd(timeLabel);
-            cb(null, result.outputText, result.sourceMap);
+          timeEnd(timeLabel);
+
+          if (result.outputText === undefined) {
+            throw new Error('TypeScript compilation failed.');
           }
+          cb(null, result.outputText, result.sourceMap);
         })
         .catch(err => cb(err));
       }

--- a/packages/@ngtools/webpack/src/plugin.ts
+++ b/packages/@ngtools/webpack/src/plugin.ts
@@ -62,7 +62,6 @@ export class AotPlugin implements Tapable {
   private _donePromise: Promise<void> | null;
   private _compiler: any = null;
   private _compilation: any = null;
-  private _failedCompilation = false;
 
   private _typeCheck = true;
   private _skipCodeGeneration = false;
@@ -90,7 +89,6 @@ export class AotPlugin implements Tapable {
   get compilerHost() { return this._compilerHost; }
   get compilerOptions() { return this._compilerOptions; }
   get done() { return this._donePromise; }
-  get failedCompilation() { return this._failedCompilation; }
   get entryModule() {
     const splitted = this._entryModule.split('#');
     const path = splitted[0];
@@ -428,7 +426,6 @@ export class AotPlugin implements Tapable {
     compiler.plugin('done', () => {
       this._donePromise = null;
       this._compilation = null;
-      this._failedCompilation = false;
     });
 
     compiler.plugin('after-resolvers', (compiler: any) => {
@@ -640,14 +637,11 @@ export class AotPlugin implements Tapable {
       .then(() => {
         if (this._compilation.errors == 0) {
           this._compilerHost.resetChangedFileTracker();
-        } else {
-          this._failedCompilation = true;
         }
 
         timeEnd('AotPlugin._make');
         cb();
       }, (err: any) => {
-        this._failedCompilation = true;
         compilation.errors.push(err.stack);
         timeEnd('AotPlugin._make');
         cb();

--- a/tests/e2e/tests/build/rebuild-error.ts
+++ b/tests/e2e/tests/build/rebuild-error.ts
@@ -1,0 +1,43 @@
+import {
+  killAllProcesses,
+  waitForAnyProcessOutputToMatch,
+  execAndWaitForOutputToMatch,
+} from '../../utils/process';
+import {replaceInFile, appendToFile} from '../../utils/fs';
+import {getGlobalVariable} from '../../utils/env';
+
+
+const failedRe = /webpack: Failed to compile/;
+const successRe = /webpack: Compiled successfully/;
+const errorRe = /ERROR in/;
+
+export default function() {
+  if (process.platform.startsWith('win')) {
+    return Promise.resolve();
+  }
+  // Skip this in ejected tests.
+  if (getGlobalVariable('argv').eject) {
+    return Promise.resolve();
+  }
+
+  return Promise.resolve()
+    // Add an error to a non-main file.
+    .then(() => appendToFile('src/app/app.component.ts', ']]]]]'))
+    // Should have an error.
+    .then(() => execAndWaitForOutputToMatch('ng', ['serve'], failedRe))
+    // Fix the error, should trigger a rebuild.
+    .then(() => Promise.all([
+      waitForAnyProcessOutputToMatch(successRe, 20000),
+      replaceInFile('src/app/app.component.ts', ']]]]]', '')
+    ]))
+    .then((results) => {
+      const stderr = results[0].stderr;
+      if (errorRe.test(stderr)) {
+        throw new Error('Expected no error but an error was shown.');
+      }
+    })
+    .then(() => killAllProcesses(), (err: any) => {
+      killAllProcesses();
+      throw err;
+    });
+}


### PR DESCRIPTION
We want to allow emitting with errors on the first run so that imports can be added to the webpack dependency tree and rebuilds triggered by file edits.

This will not cause webpack to finish the compilation successfully on error, it will just allow it to follow imports.

Fix #7890