### PR TITLE
fix(@angular/cli): Module name support for generate component

### DIFF
--- a/docs/documentation/generate/component.md
+++ b/docs/documentation/generate/component.md
@@ -73,6 +73,11 @@
   </p>
   <p>
     Allows specification of the declaring module's file name (e.g `app.module.ts`).
+
+    For any submodules, e.g. in `app/profile/bar-mod/bar-mod.module.ts`, specify either of following:
+    * --module ./profile/bar-mod/bar-mod.module.ts
+    * --module ./profile/bar-mod/bar-mod
+    * --module ./profile/bar-mod/BarMod
   </p>
 </details>
 

--- a/packages/@angular/cli/commands/generate.ts
+++ b/packages/@angular/cli/commands/generate.ts
@@ -173,8 +173,15 @@ export default Command.extend({
     const collectionName = commandOptions.collection ||
       CliConfig.getValue('defaults.schematics.collection');
 
-    if (collectionName === '@schematics/angular' && schematicName === 'interface' && rawArgs[2]) {
-      commandOptions.type = rawArgs[2];
+    if (collectionName === '@schematics/angular' ) {
+      if (['interface', 'i'].indexOf(schematicName) !== -1 && rawArgs[2] ) {
+        commandOptions.type = rawArgs[2];
+      }
+      if (commandOptions.module && commandOptions.module !== '') {
+        commandOptions.module = stringUtils.dasherize(
+          commandOptions.module
+        );
+      }
     }
 
     return schematicRunTask.run({

--- a/tests/acceptance/generate-component.spec.ts
+++ b/tests/acceptance/generate-component.spec.ts
@@ -300,6 +300,21 @@ describe('Acceptance: ng generate component', () => {
         .then(done, done.fail);
     });
 
+    it('when given a submodule with module name', (done) => {
+      const appRoot = path.join(root, 'tmp/foo');
+      const modulePath = path.join(appRoot, 'src/app/foo-test/foo-test.module.ts');
+
+      return Promise.resolve()
+        .then(() => ng(['generate', 'module', 'FooTest']))
+        .then(() => ng(['generate', 'component', 'baz', '--module', path.join('foo-test', 'FooTest')]))
+        .then(() => readFile(modulePath, 'utf-8'))
+        .then(content => {
+          expect(content).toMatch(/import.*BazComponent.*from '..\/baz\/baz.component';/);
+          expect(content).toMatch(/declarations:\s+\[BazComponent]/m);
+        })
+        .then(done, done.fail);
+    });
+
     it('when given a submodule with missing module.ts suffix', (done) => {
       const appRoot = path.join(root, 'tmp/foo');
       const modulePath = path.join(appRoot, 'src/app/foo/foo.module.ts');
@@ -338,6 +353,22 @@ describe('Acceptance: ng generate component', () => {
         .then(() => ng(['generate', 'module', 'foo']))
         .then(() => ng(['generate', 'module', path.join('foo', 'bar')]))
         .then(() => ng(['generate', 'component', 'baz', '--module', path.join('foo', 'bar')]))
+        .then(() => readFile(modulePath, 'utf-8'))
+        .then(content => {
+          expect(content).toMatch(/import.*BazComponent.*from '..\/..\/baz\/baz.component';/);
+          expect(content).toMatch(/declarations:\s+\[BazComponent]/m);
+        })
+        .then(done, done.fail);
+    });
+
+    it('when given deep submodule folder module name only', (done) => {
+      const appRoot = path.join(root, 'tmp/foo');
+      const modulePath = path.join(appRoot, 'src/app/foo/bar-mod/bar-mod.module.ts');
+
+      return Promise.resolve()
+        .then(() => ng(['generate', 'module', 'foo']))
+        .then(() => ng(['generate', 'module', path.join('foo', 'BarMod')]))
+        .then(() => ng(['generate', 'component', 'baz', '--module', path.join('foo', 'bar-mod/BarMod')]))
         .then(() => readFile(modulePath, 'utf-8'))
         .then(content => {
           expect(content).toMatch(/import.*BazComponent.*from '..\/..\/baz\/baz.component';/);


### PR DESCRIPTION
Added support of specifying module name (with path) when generating components
Added some examples of current usage in the docs
Added tests for the module name support

Fixes #7968