### PR TITLE
fix(@angular/cli): do not limit arguments of schematics

### DIFF
--- a/packages/@angular/cli/tasks/schematic-get-options.ts
+++ b/packages/@angular/cli/tasks/schematic-get-options.ts
@@ -37,6 +37,14 @@ export default Task.extend({
           case 'boolean':
             type = Boolean;
             break;
+          case 'integer':
+          case 'number':
+            type = Number;
+            break;
+
+          // Ignore arrays / objects.
+          default:
+            return null;
         }
         let aliases: string[] = [];
         if (opt.alias) {
@@ -52,7 +60,8 @@ export default Task.extend({
           type,
           default: undefined // do not carry over schematics defaults
         };
-      });
+      })
+      .filter(x => x);
 
     return Promise.resolve(availableOptions);
   }

--- a/packages/@angular/cli/utilities/schematics.ts
+++ b/packages/@angular/cli/utilities/schematics.ts
@@ -7,10 +7,12 @@
 
 import {
   Collection,
+  Engine,
   Schematic,
   SchematicEngine,
 } from '@angular-devkit/schematics';
 import {
+  FileSystemCollectionDesc,
   FileSystemSchematicDesc,
   NodeModulesEngineHost
 } from '@angular-devkit/schematics/tools';
@@ -20,14 +22,22 @@ import 'rxjs/add/operator/map';
 
 const SilentError = require('silent-error');
 
+const engineHost = new NodeModulesEngineHost();
+const engine: Engine<FileSystemCollectionDesc, FileSystemSchematicDesc>
+  = new SchematicEngine(engineHost);
+
+
 export function getEngineHost() {
-  const engineHost = new NodeModulesEngineHost();
   return engineHost;
 }
+export function getEngine(): Engine<FileSystemCollectionDesc, FileSystemSchematicDesc> {
+  return engine;
+}
+
 
 export function getCollection(collectionName: string): Collection<any, any> {
   const engineHost = getEngineHost();
-  const engine = new SchematicEngine(engineHost);
+  const engine = getEngine();
 
   // Add support for schemaJson.
   engineHost.registerOptionsTransform((schematic: FileSystemSchematicDesc, options: any) => {


### PR DESCRIPTION
The schema of a Schematic can be any valid schema. The CLI was erroring if
it included anything else than strings or booleans.