### PR TITLE
feat(@angular/cli): support passing files to ng lint, closes #7612

### DIFF
--- a/packages/@angular/cli/commands/lint.ts
+++ b/packages/@angular/cli/commands/lint.ts
@@ -45,7 +45,7 @@ export default Command.extend({
       `
     }
   ],
-  run: function (commandOptions: LintCommandOptions) {
+  run: function (commandOptions: LintCommandOptions, args: string[]) {
     const LintTask = require('../tasks/lint').default;
 
     const lintTask = new LintTask({
@@ -53,9 +53,18 @@ export default Command.extend({
       project: this.project
     });
 
+    const configs = CliConfig.fromProject().config.lint || [];
+
+    if (args.length) {
+      configs.forEach(config => {
+        config.files = args;
+        config.project = '';
+      });
+    }
+
     return lintTask.run({
       ...commandOptions,
-      configs: CliConfig.fromProject().config.lint
+      configs
     });
   }
 });

--- a/tests/e2e/tests/lint/lint-with-files.ts
+++ b/tests/e2e/tests/lint/lint-with-files.ts
@@ -1,0 +1,17 @@
+import { ng } from '../../utils/process';
+import { writeFile } from '../../utils/fs';
+
+export default function () {
+  const fileNameFoo = 'src/app/foo.ts';
+  const fileNameBar = 'src/app/bar.ts';
+
+  return Promise.resolve()
+    .then(() => writeFile(fileNameFoo, 'const foo = \'\';\n'))
+    .then(() => writeFile(fileNameBar, 'const bar = "";\n'))
+    .then(() => ng('lint', 'src/app/foo.ts'))
+    .then(({ stdout }) => {
+      if (!stdout.match(/All files pass linting./)) {
+        throw new Error('All files pass linting.');
+      }
+    });
+}


### PR DESCRIPTION
This works for the described use cases like with `lint-staged` or anything else which expects `ng lint` to accept files as args similarly to tslint. 

ps: my first PR ever so be kind thank you!