### PR TITLE
docs(@angular/cli): Include base-href flag in e2e documentation

### DIFF
--- a/docs/documentation/e2e.md
+++ b/docs/documentation/e2e.md
@@ -11,18 +11,11 @@
 ng e2e
 ```
 
-End-to-end tests are run via [Protractor] (https://angular.github.io/protractor/).
+End-to-end tests are run via [Protractor](https://angular.github.io/protractor/).
 
 ## Options
-<details>
-  <summary>base href</summary>
-  <p>
-    <code>--base-href</code>
-  </p>
-  <p>
-    Override the baseUrl in the protractor config. Defaults to the baseUrl in the protractor config.
-  </p>
-</details>
+
+Please note that options that are supported by `ng serve` are also supported by `ng e2e`
 
 <details>
   <summary>config</summary>

--- a/docs/documentation/e2e.md
+++ b/docs/documentation/e2e.md
@@ -15,6 +15,16 @@ End-to-end tests are run via [Protractor] (https://angular.github.io/protractor/
 
 ## Options
 <details>
+  <summary>base href</summary>
+  <p>
+    <code>--base-href</code>
+  </p>
+  <p>
+    Override the baseUrl in the protractor config. Defaults to the baseUrl in the protractor config.
+  </p>
+</details>
+
+<details>
   <summary>config</summary>
   <p>
     <code>--config</code> (aliases: <code>-c</code>)


### PR DESCRIPTION
Whilst working, I noticed a lot of people wanting to change the baseUrl in the protractor config dynamically. Ended up stumbling across the base-href flags in one of the tests but it did not seem to be documented anywhere.

Thought this might help people as there are quite a few stackoverflow questions asking for similar with varying solutions.