### PR TITLE
fix(@angular/cli): add missing webpack-sources dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "webpack-dev-middleware": "~1.12.0",
     "webpack-dev-server": "~2.7.1",
     "webpack-merge": "^4.1.0",
+    "webpack-sources": "^1.0.0",
     "webpack-subresource-integrity": "^1.0.1",
     "zone.js": "^0.8.14"
   },

--- a/packages/@angular/cli/models/webpack-configs/production.ts
+++ b/packages/@angular/cli/models/webpack-configs/production.ts
@@ -13,6 +13,13 @@ import { readTsconfig } from '../../utilities/read-tsconfig';
 
 const UglifyJSPlugin = require('uglifyjs-webpack-plugin');
 
+/**
+ * license-webpack-plugin has a peer dependency on webpack-sources, list it in a comment to
+ * let the dependency validator know it is used.
+ *
+ * require('webpack-sources')
+ */
+
 
 export function getProdConfig(wco: WebpackConfigOptions) {
   const { projectRoot, buildOptions, appConfig } = wco;

--- a/packages/@angular/cli/package.json
+++ b/packages/@angular/cli/package.json
@@ -81,6 +81,7 @@
     "webpack-dev-middleware": "~1.12.0",
     "webpack-dev-server": "~2.7.1",
     "webpack-merge": "^4.1.0",
+    "webpack-sources": "^1.0.0",
     "webpack-subresource-integrity": "^1.0.1",
     "zone.js": "^0.8.14"
   },


### PR DESCRIPTION
`license-webpack-plugin` has a peer dependency on `webpack-sources` that was being satisfied via hoisting.

Fix #8075