### PR TITLE
fix(@ngtools/webpack): initialize type checker with initial files

### DIFF
--- a/packages/@ngtools/webpack/src/type_checker.ts
+++ b/packages/@ngtools/webpack/src/type_checker.ts
@@ -97,7 +97,6 @@ class TypeChecker {
       options: this._angularCompilerOptions,
       tsHost: compilerHost
     }) as CompilerHost & WebpackCompilerHost;
-    this._tsFilenames = [];
     timeEnd('TypeChecker.constructor');
   }
 


### PR DESCRIPTION
Fix #7986