### PR TITLE
fix(@angular/cli): show warning on TypeScript 2.5

### DIFF
--- a/packages/@angular/cli/upgrade/version.ts
+++ b/packages/@angular/cli/upgrade/version.ts
@@ -167,7 +167,7 @@ export class Version {
     const versionCombos = [
       { compiler: '>=2.3.1 <3.0.0', typescript: '>=2.0.2 <2.3.0' },
       { compiler: '>=4.0.0 <5.0.0', typescript: '>=2.1.0 <2.4.0' },
-      { compiler: '>=5.0.0 <6.0.0', typescript: '>=2.4.0 <2.6.0' }
+      { compiler: '>=5.0.0 <6.0.0', typescript: '>=2.4.0 <2.5.0' }
     ];
 
     const currentCombo = versionCombos.find((combo) => satisfies(compilerVersion, combo.compiler));


### PR DESCRIPTION
It is not officially supported by Angular 5. Might be in 5.1 or above,
and will revisit then.

Fixes #8093 