### PR TITLE
fix(@angular/cli): don't drop resource extentions

### DIFF
--- a/packages/@angular/cli/models/webpack-configs/common.ts
+++ b/packages/@angular/cli/models/webpack-configs/common.ts
@@ -191,7 +191,7 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
           test: /\.(jpg|png|webp|gif|otf|ttf|woff|woff2|ani)$/,
           loader: 'url-loader',
           options: {
-            name: `[name]${hashFormat.file}`,
+            name: `[name]${hashFormat.file}.[ext]`,
             limit: 10000
           }
         }


### PR DESCRIPTION
Fix #8099