### PR TITLE
Lint cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "lodash": "^4.11.1",
     "magic-string": "^0.22.3",
     "memory-fs": "^0.4.1",
+    "minimatch": "^3.0.4",
     "node-modules-path": "^1.0.0",
     "nopt": "^4.0.1",
     "opn": "~5.1.0",

--- a/packages/@angular/cli/package.json
+++ b/packages/@angular/cli/package.json
@@ -54,6 +54,7 @@
     "license-webpack-plugin": "^1.0.0",
     "lodash": "^4.11.1",
     "memory-fs": "^0.4.1",
+    "minimatch": "^3.0.4",
     "node-modules-path": "^1.0.0",
     "nopt": "^4.0.1",
     "opn": "~5.1.0",

--- a/packages/@angular/cli/tasks/lint.ts
+++ b/packages/@angular/cli/tasks/lint.ts
@@ -9,6 +9,7 @@ import * as ts from 'typescript';
 // @ignoreDep tslint - used only for type information
 import * as tslint from 'tslint';
 import { requireProjectModule } from '../utilities/require-project-module';
+import { stripBom } from '../utilities/strip-bom';
 
 const SilentError = require('silent-error');
 const Task = require('../ember-cli/lib/models/task');
@@ -167,14 +168,10 @@ function getFilesToLint(
 }
 
 function getFileContents(file: string): string {
-  let contents: string;
-
   // NOTE: The tslint CLI checks for and excludes MPEG transport streams; this does not.
   try {
-    contents = fs.readFileSync(file, 'utf8');
+    return stripBom(fs.readFileSync(file, 'utf-8'));
   } catch (e) {
     throw new SilentError(`Could not read file "${file}".`);
   }
-
-  return contents;
 }

--- a/tests/e2e/tests/lint/lint-with-non-project.ts
+++ b/tests/e2e/tests/lint/lint-with-non-project.ts
@@ -1,0 +1,8 @@
+import { ng } from '../../utils/process';
+import { expectToFail } from '../../utils/utils';
+
+export default function () {
+  return Promise.resolve()
+    .then(() => ng('set', 'lint.0.files', '"src/app/**/*.ts"'))
+    .then(() => expectToFail(() => ng('lint')));
+}


### PR DESCRIPTION
Includes some general code quality improvements as well as supporting non-UTF8 file reading, eliminating the need to use glob (and re-walk the filesystem) if only a project option is provided, and providing a clearer message when the `files` option includes a file not present within the supplied program. 