### PR TITLE
fix(@angular/cli): fix url-loader filename formatting

### DIFF
--- a/packages/@angular/cli/models/webpack-configs/common.ts
+++ b/packages/@angular/cli/models/webpack-configs/common.ts
@@ -191,7 +191,7 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
           test: /\.(jpg|png|webp|gif|otf|ttf|woff|woff2|ani)$/,
           loader: 'url-loader',
           options: {
-            name: `[name]${hashFormat.file}`,
+            name: `[name]${hashFormat.file}.[ext]`,
             limit: 10000
           }
         }


### PR DESCRIPTION
Fix file loading by readding the extension indicator.

Broken in commit 776af8617bb867197c2c385a939940ff3960080d .