### PR TITLE
fix(@angular/cli): use the new compiler API for listLazyRoutes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,24 @@ matrix:
       os: linux
       script: node tests/run_e2e.js --nb-shards=4 --shard=3 --nosilent
       env: e2e-3
+
+    - node_js: "6"
+      os: linux
+      script: node tests/run_e2e.js --nb-shards=4 --shard=0 --nosilent --nightly
+      env: nightly-0
+    - node_js: "6"
+      os: linux
+      script: node tests/run_e2e.js --nb-shards=4 --shard=1 --nosilent --nightly
+      env: nightly-1
+    - node_js: "6"
+      os: linux
+      script: node tests/run_e2e.js --nb-shards=4 --shard=2 --nosilent --nightly
+      env: nightly-2
+    - node_js: "6"
+      os: linux
+      script: node tests/run_e2e.js --nb-shards=4 --shard=3 --nosilent --nightly
+      env: nightly-3
+
     - node_js: "6"
       os: linux
       script: node tests/run_e2e.js --eject "--glob=tests/build/**"
@@ -54,11 +72,6 @@ matrix:
       before_script: if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then exit 0; fi
       script: node tests/run_e2e.js --ng2 "--glob=tests/{build,test,misc}/**"
       env: ng2
-    - node_js: "6"
-      os: linux
-      before_script: if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then exit 0; fi
-      script: node tests/run_e2e.js "--nightly --glob=tests/{build,test,misc}/**"
-      env: nightly
     - node_js: "7"
       os: linux
       before_script: if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then exit 0; fi

--- a/lib/bootstrap-local.js
+++ b/lib/bootstrap-local.js
@@ -46,6 +46,14 @@ require.extensions['.ts'] = function (m, filename) {
 //   lazy: true
 // });
 
+const resolve = require('resolve');
+
+
+// Look if there's a .angular-cli.json file, and if so toggle process.cwd() resolution.
+const isAngularProject = fs.existsSync(path.join(process.cwd(), '.angular-cli.json'))
+                      || fs.existsSync(path.join(process.cwd(), 'angular-cli.json'));
+
+
 // If we're running locally, meaning npm linked. This is basically "developer mode".
 if (!__dirname.match(new RegExp(`\\${path.sep}node_modules\\${path.sep}`))) {
   const packages = require('./packages').packages;
@@ -71,6 +79,14 @@ if (!__dirname.match(new RegExp(`\\${path.sep}node_modules\\${path.sep}`))) {
         const p = path.join(packages[match].root, request.substr(match.length));
         return oldLoad.call(this, p, parent);
       } else {
+        try {
+          if (isAngularProject) {
+            return oldLoad.call(this, resolve.sync(request, { basedir: process.cwd() }), parent);
+          }
+        } catch (e) {
+          // Do nothing. Fallback to the old method.
+        }
+
         return oldLoad.apply(this, arguments);
       }
     }

--- a/packages/@angular/cli/models/webpack-configs/typescript.ts
+++ b/packages/@angular/cli/models/webpack-configs/typescript.ts
@@ -134,7 +134,9 @@ export function getAotConfig(wco: WebpackConfigOptions) {
   // Fallback to exclude spec files from AoT compilation on projects using a shared tsconfig.
   if (testTsConfigPath === tsConfigPath) {
     let exclude = [ '**/*.spec.ts' ];
-    if (appConfig.test) { exclude.push(path.join(projectRoot, appConfig.root, appConfig.test)); }
+    if (appConfig.test) {
+      exclude.push(path.join(projectRoot, appConfig.root, appConfig.test));
+    }
     pluginOptions.exclude = exclude;
   }
 
@@ -164,7 +166,10 @@ export function getNonAotTestConfig(wco: WebpackConfigOptions) {
   // Force include main and polyfills.
   // This is needed for AngularCompilerPlugin compatibility with existing projects,
   // since TS compilation there is stricter and tsconfig.spec.ts doesn't include them.
-  const include = [appConfig.main, appConfig.polyfills];
+  const include = [appConfig.main, appConfig.polyfills, '**/*.spec.ts'];
+  if (appConfig.test) {
+    include.push(appConfig.test);
+  }
 
   let pluginOptions: any = { tsConfigPath, skipCodeGeneration: true, include };
 

--- a/packages/@ngtools/webpack/src/ngtools_api.ts
+++ b/packages/@ngtools/webpack/src/ngtools_api.ts
@@ -76,12 +76,19 @@ export interface Program {
   getNgSemanticDiagnostics(fileName?: string, cancellationToken?: ts.CancellationToken):
     Diagnostic[];
   loadNgStructureAsync(): Promise<void>;
+  listLazyRoutes?(): LazyRoute[];
   emit({ emitFlags, cancellationToken, customTransformers, emitCallback }: {
     emitFlags?: any;
     cancellationToken?: ts.CancellationToken;
     customTransformers?: CustomTransformers;
     emitCallback?: TsEmitCallback;
   }): ts.EmitResult;
+}
+
+export interface LazyRoute {
+  route: string;
+  module: { name: string, filePath: string };
+  referencedModule: { name: string, filePath: string };
 }
 
 export declare type Diagnostics = Array<ts.Diagnostic | Diagnostic>;

--- a/packages/@ngtools/webpack/src/transformers/export_lazy_module_map.ts
+++ b/packages/@ngtools/webpack/src/transformers/export_lazy_module_map.ts
@@ -20,7 +20,7 @@ export function exportLazyModuleMap(
       let [, moduleName] = loadChildrenString.split('#');
       let modulePath = lazyRoutes[loadChildrenString];
 
-      if (modulePath.endsWith('.ngfactory.ts')) {
+      if (modulePath.match(/\.ngfactory\.[jt]s$/)) {
         modulePath = modulePath.replace('.ngfactory', '');
         moduleName = moduleName.replace('NgFactory', '');
         loadChildrenString = loadChildrenString


### PR DESCRIPTION
Replacing the old API. We keep the old API because we need it for JIT
(with either --aot=false or unittests).

Depends on https://github.com/angular/angular/pull/19836