### PR TITLE
feat(@ngtools/webpack) support of single file component

### DIFF
--- a/packages/@angular/cli/lib/config/schema.json
+++ b/packages/@angular/cli/lib/config/schema.json
@@ -197,6 +197,10 @@
             "description": "Name and corresponding file for environment config.",
             "type": "object",
             "additionalProperties": true
+          },
+          "defaultStyleType": {
+            "description": "Default file type for inline styles.",
+            "type": "string"
           }
         },
         "additionalProperties": false

--- a/packages/@angular/cli/models/webpack-configs/typescript.ts
+++ b/packages/@angular/cli/models/webpack-configs/typescript.ts
@@ -95,6 +95,8 @@ function _createAotPlugin(wco: WebpackConfigOptions, options: any) {
       // If we don't explicitely list excludes, it will default to `['**/*.spec.ts']`.
       exclude: [],
       include: options.include,
+
+      defaultStyleType: appConfig.defaultStyleType
     }, options);
     return new AngularCompilerPlugin(pluginOptions);
   } else {
@@ -108,7 +110,9 @@ function _createAotPlugin(wco: WebpackConfigOptions, options: any) {
       hostReplacementPaths,
       sourceMap: buildOptions.sourcemaps,
       // If we don't explicitely list excludes, it will default to `['**/*.spec.ts']`.
-      exclude: []
+      exclude: [],
+
+      defaultStyleType: appConfig.defaultStyleType
     }, options);
     return new AotPlugin(pluginOptions);
   }

--- a/packages/@ngtools/webpack/src/angular_compiler_plugin.ts
+++ b/packages/@ngtools/webpack/src/angular_compiler_plugin.ts
@@ -69,6 +69,9 @@ export interface AngularCompilerPluginOptions {
   missingTranslation?: string;
   platform?: PLATFORM;
 
+  defaultTemplateType?: string;
+  defaultStyleType?: string;
+
   // Use tsconfig to include path globs.
   exclude?: string | string[];
   include?: string[];
@@ -278,7 +281,12 @@ export class AngularCompilerPlugin implements Tapable {
     }
 
     // Create the webpack compiler host.
-    this._compilerHost = new WebpackCompilerHost(this._compilerOptions, this._basePath);
+    this._compilerHost = new WebpackCompilerHost(
+      this._compilerOptions,
+      this._basePath,
+      this._options.defaultTemplateType,
+      this._options.defaultStyleType
+    );
     this._compilerHost.enableCaching();
 
     // Create and set a new WebpackResourceLoader.

--- a/packages/@ngtools/webpack/src/plugin.ts
+++ b/packages/@ngtools/webpack/src/plugin.ts
@@ -36,6 +36,9 @@ export interface AotPluginOptions {
   locale?: string;
   missingTranslation?: string;
 
+  defaultTemplateType?: string;
+  defaultStyleType?: string;
+
   // Use tsconfig to include path globs.
   exclude?: string | string[];
   compilerOptions?: ts.CompilerOptions;
@@ -232,7 +235,12 @@ export class AotPlugin implements Tapable {
       this._skipCodeGeneration = options.skipCodeGeneration;
     }
 
-    this._compilerHost = new WebpackCompilerHost(this._compilerOptions, this._basePath);
+    this._compilerHost = new WebpackCompilerHost(
+      this._compilerOptions,
+      this._basePath,
+      options.defaultTemplateType,
+      options.defaultStyleType
+    );
 
     // Override some files in the FileSystem.
     if (options.hostOverrideFileSystem) {

--- a/packages/@ngtools/webpack/src/virtual_file_system_decorator.ts
+++ b/packages/@ngtools/webpack/src/virtual_file_system_decorator.ts
@@ -37,7 +37,7 @@ export class VirtualFileSystemDecorator implements InputFileSystem {
 
   stat(path: string, callback: Callback<any>): void {
     const result = this._statSync(path);
-    if (result) {
+    if (result != null) {
       callback(null, result);
     } else {
       this._inputFileSystem.stat(path, callback);
@@ -50,7 +50,7 @@ export class VirtualFileSystemDecorator implements InputFileSystem {
 
   readFile(path: string, callback: Callback<any>): void {
     const result = this._readFileSync(path);
-    if (result) {
+    if (result != null) {
       callback(null, result);
     } else {
       this._inputFileSystem.readFile(path, callback);


### PR DESCRIPTION
## Intro
This pr add the possibility to use inline template and styles with any types. So it allows us to effectively use single file component with Angular.

You can for example do the following : 
```js
template: `!md!
## This template is written in markdown
`,
styles: [`!scss!
  @import 'var';
  :host {
    div {
      color: $red;
    }
  }
`]
```

While using markdown to write angular templates doesn't seem like a great idea (but it's fun!) most people use scss for their styles. And you can even drop the type `!scss!` if you set scss as the default for styles.

## API
I've added `defaultStyleType` option to the cli and `defaultTemplateType` + `defaultStyleType` to AOTPlugin and AngularCompilerPlugin to define default types so you don't have to set it every time.
The syntax to add type is simple it's the file extension you're expecting (e.g. the one define on your loader rule) surrounded by `!`. It must be at the very start without any spacing or newlines like on the example above.

## Known bug
If you serve your app on aot and edit the type you"ll get an error. But this is not related to this PR and the same can be done with resources urls. The problem is that we feed the angular compiler with the previous ts program containing the compiled files *before* the change. So it end up asking for a file that doesn't exist anymore.

## Discussion
The idea was to make it work without changing Angular at first. So we can see how this goes and then optimize it with changes to the compiler. For example this requires all components to be compiled by ts twice. That's why I don't think this pr is acceptable to merge like that, maybe we could add an experimental flag to enable it or just use this as a POC to get a feeling before implementing it on the compiler.
The good news here is that all the complex/hacky part of this PR can be easily done by the angular compiler.

So as I just said, for the moment this should be treated as a POC but I think it would be great if we could remove all those .html and .scss files and use clean single file component. The sooner the better :).

## Example
I've created a repo with an example at https://github.com/ghetolay/TestAngularSFC
There is both a cli and a custom webpack build so you can play with it using any types you want, you just need to drop a loader to the config.


So what do you guys think ?