### PR TITLE
perf(@angular/cli): Add ModuleConcatenationPlugin

### DIFF
--- a/packages/@angular/cli/models/webpack-configs/common.ts
+++ b/packages/@angular/cli/models/webpack-configs/common.ts
@@ -208,6 +208,7 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
       ].concat(extraRules)
     },
     plugins: [
+      new webpack.optimize.ModuleConcatenationPlugin(),
       new webpack.NoEmitOnErrorsPlugin()
     ].concat(extraPlugins)
   };


### PR DESCRIPTION
Add ModuleConcatenationPlugin to avoid larger bundles with rxjs lettables operators