### PR TITLE
fix(build): use html-loader to figureprint images (#3415)

### DIFF
--- a/packages/@angular/cli/models/webpack-configs/common.ts
+++ b/packages/@angular/cli/models/webpack-configs/common.ts
@@ -18,7 +18,7 @@ const SilentError = require('silent-error');
  * know they are used.
  *
  * require('source-map-loader')
- * require('raw-loader')
+ * require('html-loader')
  * require('url-loader')
  * require('file-loader')
  * require('@angular-devkit/build-optimizer')
@@ -188,7 +188,13 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
     },
     module: {
       rules: [
-        { test: /\.html$/, loader: 'raw-loader' },
+        {
+          test: /\.html$/,
+          loader: 'html-loader',
+          options: {
+            root: appRoot,
+          }
+        },
         {
           test: /\.(eot|svg|cur)$/,
           loader: 'file-loader',

--- a/packages/@angular/cli/package.json
+++ b/packages/@angular/cli/package.json
@@ -61,7 +61,7 @@
     "postcss-custom-properties": "^6.1.0",
     "postcss-loader": "^1.3.3",
     "postcss-url": "^5.1.2",
-    "raw-loader": "^0.5.1",
+    "html-loader": "^0.5.1",
     "resolve": "^1.1.7",
     "rxjs": "^5.4.2",
     "sass-loader": "^6.0.3",


### PR DESCRIPTION
A quick and dirty PR about using html-loader's "root-relative" urls to figureprint images in assets

demo: <https://github.com/asnowwolf/test-ng-cli>
see <https://github.com/webpack-contrib/html-loader#root-relative-urls>

Fix https://github.com/angular/angular-cli/issues/3415