### PR TITLE
docs(@angular/cli): fixed typos

### DIFF
--- a/docs/documentation/stories/internationalization.md
+++ b/docs/documentation/stories/internationalization.md
@@ -47,14 +47,14 @@ your bootstrap file yourself.
 To build your application with a specific locale you can use the exact same commands
 that you used for `serve`:
 ```sh
-ng build --aot --locale fr --i18n-format xlf --i18n-file src/i18n/messages.fr.xlf --missing-translation error
+ng build --aot --locale fr --i18n-format xlf --i18n-file src/locale/messages.fr.xlf --missing-translation error
 ```
 
 When you build your application for a specific locale, it is probably a good idea to change
 the output path with the command `--output-path` in order to save the files to a different location.
 
 ```sh
-ng build --aot --output-path dist/fr --locale fr --i18n-format xlf --i18n-file src/i18n/messages.fr.xlf --missing-translation error
+ng build --aot --output-path dist/fr --locale fr --i18n-format xlf --i18n-file src/locale/messages.fr.xlf --missing-translation error
 ```
 
 If you end up serving this specific version from a subdirectory, you can also change
@@ -64,7 +64,7 @@ For example if the french version of your application is served from https://mya
 then you would build the french version like this:
 
 ```sh
-ng build --aot --output-path dist/fr --base-href fr --locale fr --i18n-format xlf --i18n-file src/i18n/messages.fr.xlf --missing-translation error
+ng build --aot --output-path dist/fr --base-href fr --locale fr --i18n-format xlf --i18n-file src/locale/messages.fr.xlf --missing-translation error
 ```
 
 If you need more details about how to create scripts to generate the app in multiple

--- a/docs/documentation/xi18n.md
+++ b/docs/documentation/xi18n.md
@@ -37,7 +37,7 @@
 </details>
 
 <details>
-  <summary>outfile</summary>
+  <summary>out-file</summary>
   <p>
     <code>--out-file</code> (aliases: <code>-of</code>)
   </p>


### PR DESCRIPTION
Just a few typos and inconsistencies from the i18n docs