### PR TITLE
fix(@ngtools/webpack): fix locale refactoring code for commonjs

### DIFF
--- a/packages/@ngtools/webpack/src/transformers/insert_import.ts
+++ b/packages/@ngtools/webpack/src/transformers/insert_import.ts
@@ -9,6 +9,8 @@ export function insertStarImport(
   sourceFile: ts.SourceFile,
   identifier: ts.Identifier,
   modulePath: string,
+  target?: ts.Node,
+  before = false,
 ): TransformOperation[] {
   const ops: TransformOperation[] = [];
   const allImports = findAstNodes(null, sourceFile, ts.SyntaxKind.ImportDeclaration);
@@ -21,7 +23,14 @@ export function insertStarImport(
   const newImport = ts.createImportDeclaration(undefined, undefined, importClause,
     ts.createLiteral(modulePath));
 
-  if (allImports.length > 0) {
+  if (target) {
+    ops.push(new AddNodeOperation(
+      sourceFile,
+      target,
+      before ? newImport : undefined,
+      before ? undefined : newImport
+    ));
+  } else if (allImports.length > 0) {
     // Find the last import and insert after.
     ops.push(new AddNodeOperation(
       sourceFile,

--- a/packages/@ngtools/webpack/src/transformers/register_locale_data.spec.ts
+++ b/packages/@ngtools/webpack/src/transformers/register_locale_data.spec.ts
@@ -21,9 +21,9 @@ describe('@ngtools/webpack transformers', () => {
         platformBrowserDynamic().bootstrapModule(AppModule);
       `;
       const output = stripIndent`
-        import __locale_fr__ from "@angular/common/locales/fr";
-        import { registerLocaleData } from "@angular/common";
-        registerLocaleData(__locale_fr__);
+        import * as __NgCli_locale_1 from "@angular/common/locales/fr";
+        import * as __NgCli_locale_2 from "@angular/common";
+        __NgCli_locale_2.registerLocaleData(__NgCli_locale_1.default);
 
         import { enableProdMode } from '@angular/core';
         import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';


### PR DESCRIPTION
And just general be right (since nothing prevents TypeScript from renaming
imports).