### PR TITLE
feat(@ngtools/webpack): allow ts to be transformed before loading

### DIFF
--- a/packages/@ngtools/webpack/src/plugin.ts
+++ b/packages/@ngtools/webpack/src/plugin.ts
@@ -9,7 +9,7 @@ const ContextElementDependency = require('webpack/lib/dependencies/ContextElemen
 const NodeWatchFileSystem = require('webpack/lib/node/NodeWatchFileSystem');
 
 import {WebpackResourceLoader} from './resource_loader';
-import {WebpackCompilerHost} from './compiler_host';
+import {FileTransform, WebpackCompilerHost} from './compiler_host';
 import {resolveEntryModuleFromMain} from './entry_resolver';
 import {Tapable} from './webpack';
 import {PathsPlugin} from './paths-plugin';
@@ -34,6 +34,7 @@ export interface AotPluginOptions {
   i18nFormat?: string;
   locale?: string;
   missingTranslation?: string;
+  transform?: FileTransform;
 
   // Use tsconfig to include path globs.
   exclude?: string | string[];
@@ -205,7 +206,7 @@ export class AotPlugin implements Tapable {
       this._skipCodeGeneration = options.skipCodeGeneration;
     }
 
-    this._compilerHost = new WebpackCompilerHost(this._compilerOptions, this._basePath);
+    this._compilerHost = new WebpackCompilerHost(this._compilerOptions, this._basePath, this._options.transform);
 
     // Override some files in the FileSystem.
     if (options.hostOverrideFileSystem) {


### PR DESCRIPTION
This allows defining a transformation function that can be run on Typescript sources before they're loaded into the compilation.

Our use case is that we output multiple application bundles, which involves some [preprocess](https://www.npmjs.com/package/preprocess) flags depending on the build target. Previously we could not have used preprocess flags in constructor vars, since the metadata extraction happens before the normal TypeScript loader chain is executed (where we had a [loader](https://github.com/mixer/preprocessor-loader) to take care of preprocessing).