### PR TITLE
fix(@angular/cli): change the title of the process

### DIFF
--- a/bin/ng
+++ b/bin/ng
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 'use strict';
 
-// Provide a title to the process in `ps`
-process.title = '@angular/cli';
+// Provide a title to the process in `ps`.
+// Due to an obscure Mac bug, do not start this title with any symbol.
+process.title = 'ng';
 
 require('../lib/bootstrap-local');
 require('../packages/@angular/cli/bin/ng');

--- a/packages/@angular/cli/bin/ng
+++ b/packages/@angular/cli/bin/ng
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 'use strict';
 
-// Provide a title to the process in `ps`
-process.title = '@angular/cli';
+// Provide a title to the process in `ps`.
+// Due to an obscure Mac bug, do not start this title with any symbol.
+process.title = 'ng';
 
 const CliConfig = require('../models/config').CliConfig;
 const Version = require('../upgrade/version').Version;


### PR DESCRIPTION
This fixes an obscure Mac bug where VoiceOver would crash when listing
processes.

Fixes #6034.