### PR TITLE
fix(@angular/cli): use JIT by default with ng5

### DIFF
--- a/packages/@angular/cli/models/webpack-config.ts
+++ b/packages/@angular/cli/models/webpack-config.ts
@@ -95,7 +95,7 @@ export class NgCliWebpackConfig<T extends BuildOptions = BuildOptions> {
         sourcemaps: true,
         extractCss: false,
         namedChunks: true,
-        aot: AngularCompilerPlugin.isSupported(),
+        aot: false,
         buildOptimizer: false
       },
       production: {

--- a/tests/e2e/tests/i18n/build-locale.ts
+++ b/tests/e2e/tests/i18n/build-locale.ts
@@ -14,9 +14,9 @@ export default function () {
   // These tests should be moved to the default when we use ng5 in new projects.
   return Promise.resolve()
     // tests for register_locale_data transformer
-    .then(() => ng('build', '--locale=fr'))
+    .then(() => ng('build', '--aot', '--locale=fr'))
     .then(() => expectFileToMatch('dist/main.bundle.js', /registerLocaleData/))
     .then(() => expectFileToMatch('dist/main.bundle.js', /angular_common_locales_fr/))
     .then(() => rimraf('dist'))
-    .then(() => expectToFail(() => ng('build', '--locale=no-locale')))
+    .then(() => expectToFail(() => ng('build', '--aot', '--locale=no-locale')))
 }


### PR DESCRIPTION
Fix #8259