### PR TITLE
chore: update codelyzer and add rules

### DIFF
--- a/tests/e2e/assets/1.0.0-proj/package.json
+++ b/tests/e2e/assets/1.0.0-proj/package.json
@@ -29,7 +29,7 @@
     "@angular/compiler-cli": "^4.0.0",
     "@types/jasmine": "2.5.38",
     "@types/node": "~6.0.60",
-    "codelyzer": "~2.0.0",
+    "codelyzer": "^4.0.0",
     "jasmine-core": "~2.5.2",
     "jasmine-spec-reporter": "~3.2.0",
     "karma": "~1.4.1",

--- a/tests/e2e/assets/1.0.0-proj/tslint.json
+++ b/tests/e2e/assets/1.0.0-proj/tslint.json
@@ -100,6 +100,8 @@
 
     "directive-selector": [true, "attribute", "app", "camelCase"],
     "component-selector": [true, "element", "app", "kebab-case"],
+    "angular-whitespace": [true, "check-interpolation"],
+    "no-on-prefix-output-name": true,
     "use-input-property-decorator": true,
     "use-output-property-decorator": true,
     "use-host-property-decorator": true,


### PR DESCRIPTION
codelyzer@^4.0.0 works with Angular version 5. The PR also introduces
two rules, which we can discuss further:

- `no-on-prefix-output-name` - Follows the style recommending to not
  prefix
  https://angular.io/guide/styleguide#dont-prefix-output-properties
- `angular-whitespace` - Makes sure an expression within interpolation
  is surrounded with whitespace. This rule has a fix as well.

So, in case the code looks like:

```
{{foo + bar}}
```

codelyzer will suggest to add whitespace like:

```
{{ foo + bar }}
```
The fix flag will automatically update the template.

There are few more rules in beta which I will introduce with a PR later.