### PR TITLE
fix(build): add `root` option for css-loader

### DIFF
--- a/packages/@angular/cli/models/webpack-configs/styles.ts
+++ b/packages/@angular/cli/models/webpack-configs/styles.ts
@@ -163,6 +163,7 @@ export function getStylesConfig(wco: WebpackConfigOptions) {
       loader: 'css-loader',
       options: {
         sourceMap: cssSourceMap,
+        root: appRoot,
         importLoaders: 1
       }
     },


### PR DESCRIPTION
So that I can use absolute path (`@import "/app/styles/common"`) to import css files instead of relative path `@import "../../../styles/common"`.

See <https://github.com/webpack-contrib/css-loader#root>.

P.S. My english is not so good, feel free to edit my commit message please.