### PR TITLE
fix(@ngtools/webpack): remove default type checker memory limit

### DIFF
--- a/packages/@ngtools/webpack/src/angular_compiler_plugin.ts
+++ b/packages/@ngtools/webpack/src/angular_compiler_plugin.ts
@@ -464,25 +464,13 @@ export class AngularCompilerPlugin implements Tapable {
       ? './type_checker_bootstrap.js'
       : './type_checker.js';
 
-    let hasMemoryFlag = false;
-    const memoryFlagRegex = /--max-old-space-size/;
     const debugArgRegex = /--inspect(?:-brk|-port)?|--debug(?:-brk|-port)/;
 
     const execArgv = process.execArgv.filter((arg) => {
-      // Check if memory is being set by parent process.
-      if (memoryFlagRegex.test(arg)) {
-        hasMemoryFlag = true;
-      }
-
       // Remove debug args.
       // Workaround for https://github.com/nodejs/node/issues/9435
       return !debugArgRegex.test(arg);
     });
-
-    if (!hasMemoryFlag) {
-      // Force max 8gb ram.
-      execArgv.push('--max-old-space-size=8192');
-    }
 
     const forkOptions: ForkOptions = { execArgv };
 


### PR DESCRIPTION
Seems to be causing trouble on Appveyor and we use the parent one anyway.