### PR TITLE
fix(@angular/cli): use rxjs path mapping helper in ejected config

### DIFF
--- a/packages/@angular/cli/tasks/eject.ts
+++ b/packages/@angular/cli/tasks/eject.ts
@@ -286,8 +286,10 @@ class JsonWebpackSerializer {
   }
 
   private _resolveReplacer(value: any) {
+    this.variableImports['rxjs/_esm5/path-mapping'] = 'rxPaths';
     return Object.assign({}, value, {
-      modules: value.modules.map((x: string) => './' + path.relative(this._root, x))
+      modules: value.modules.map((x: string) => './' + path.relative(this._root, x)),
+      alias: this._escape('rxPaths()')
     });
   }
 


### PR DESCRIPTION
Uses the ES5 version of the helper for simplicity as it is guaranteed to work and can be easily adjusted afterwards.

Fixes #8337 