### PR TITLE
feat(@angular/cli) override suite in the protractor config

### DIFF
--- a/docs/documentation/e2e.md
+++ b/docs/documentation/e2e.md
@@ -61,6 +61,16 @@ Please note that options that are supported by `ng serve` are also supported by 
 </details>
 
 <details>
+  <summary>suite</summary>
+  <p>
+    <code>--suite</code> (aliases: <code>-su</code>)
+  </p>
+  <p>
+    Override suite in the protractor config. Can send in multiple suite by comma separated values (<code>ng e2e --suite=suiteA,suiteB</code>).
+  </p>
+</details>
+
+<details>
   <summary>webdriver-update</summary>
   <p>
     <code>--webdriver-update</code> (aliases: <code>-wu</code>) <em>default value: true</em>

--- a/packages/@angular/cli/commands/e2e.ts
+++ b/packages/@angular/cli/commands/e2e.ts
@@ -13,6 +13,7 @@ export interface E2eTaskOptions extends ServeTaskOptions {
   serve: boolean;
   webdriverUpdate: boolean;
   specs: string[];
+  suite: string;
   elementExplorer: boolean;
 }
 
@@ -40,6 +41,15 @@ const E2eCommand = Command.extend({
       description: oneLine`
         Override specs in the protractor config.
         Can send in multiple specs by repeating flag (ng e2e --specs=spec1.ts --specs=spec2.ts).
+      `
+    },
+    {
+      name: 'suite',
+      type: String,
+      aliases: ['su'],
+      description: oneLine`
+        Override suite in the protractor config.
+        Can send in multiple suite by comma separated values (ng e2e --suite=suiteA,suiteB).
       `
     },
     {

--- a/packages/@angular/cli/tasks/e2e.ts
+++ b/packages/@angular/cli/tasks/e2e.ts
@@ -59,6 +59,10 @@ export const E2eTask = Task.extend({
         additionalProtractorConfig['specs'] = e2eTaskOptions.specs;
       }
 
+      if (e2eTaskOptions.suite && e2eTaskOptions.suite.length !== 0) {
+        additionalProtractorConfig['suite'] = e2eTaskOptions.suite;
+      }
+
       if (e2eTaskOptions.webdriverUpdate) {
         // The webdriver-manager update command can only be accessed via a deep import.
         const webdriverDeepImport = 'webdriver-manager/built/lib/cmds/update';

--- a/tests/e2e/tests/basic/e2e.ts
+++ b/tests/e2e/tests/basic/e2e.ts
@@ -4,9 +4,9 @@ import {
   execAndWaitForOutputToMatch,
   killAllProcesses
 } from '../../utils/process';
-import { updateJsonFile } from '../../utils/project';
-import { expectToFail } from '../../utils/utils';
-import { moveFile, copyFile } from '../../utils/fs';
+import {updateJsonFile} from '../../utils/project';
+import {expectToFail} from '../../utils/utils';
+import {moveFile, copyFile, replaceInFile} from '../../utils/fs';
 
 
 export default function () {
@@ -34,6 +34,21 @@ export default function () {
     .then(() => copyFile('./e2e/renamed-app.e2e-spec.ts', './e2e/another-app.e2e-spec.ts'))
     .then(() => ng('e2e', '--specs', './e2e/renamed-app.e2e-spec.ts',
       '--specs', './e2e/another-app.e2e-spec.ts'))
+    // Suites block need to be added in the protractor.conf.js file to test suites
+    .then(() => replaceInFile('protractor.conf.js', `allScriptsTimeout: 11000,`,
+      `allScriptsTimeout: 11000,
+          suites: {
+            app: './e2e/app.e2e-spec.ts'
+          },
+    `))
+    .then(() => ng('e2e', '--suite=app'))
+    // remove suites block from protractor.conf.js file after testing suites
+    .then(() => replaceInFile('protractor.conf.js', `allScriptsTimeout: 11000,
+          suites: {
+            app: './e2e/app.e2e-spec.ts'
+          },
+    `, `allScriptsTimeout: 11000,`
+    ))
     // Should start up Element Explorer
     .then(() => execAndWaitForOutputToMatch('ng', ['e2e', '--element-explorer'],
       /Element Explorer/))


### PR DESCRIPTION
feat(@angular/cli) override suite in the protractor config

resolves: 807
Override suite in the protractor config.
Can send in multiple suite by comma seperated values (ng e2e --suite=suite1.ts, suite2.ts).

Issue link
 github.com/angular/angular-cli/issues/807
 github.com/angular/angular-cli/pull/3551