### PR TITLE
fix(@angular/cli): typo in console output

### DIFF
--- a/packages/@angular/cli/tasks/serve.ts
+++ b/packages/@angular/cli/tasks/serve.ts
@@ -246,7 +246,7 @@ export default Task.extend({
         This is a simple server for use in testing or debugging Angular applications locally.
         It hasn't been reviewed for security issues.
 
-        DON'T USE IT FOR PRODUCTION USE!
+        DON'T USE IT FOR PRODUCTION!
         ****************************************************************************************
       `));
     }


### PR DESCRIPTION
Fix the typo in `DON'T USE IT FOR PRODUCTION USE!`.
It is now `DON'T USE IT FOR PRODUCTION!`.