### PR TITLE
fix(@angular/cli): throw xi18n errors

### DIFF
--- a/tests/e2e/tests/i18n/extract-errors.ts
+++ b/tests/e2e/tests/i18n/extract-errors.ts
@@ -1,0 +1,18 @@
+import { ng } from '../../utils/process';
+import { writeFile } from '../../utils/fs';
+import { expectToFail } from '../../utils/utils';
+import { join } from 'path';
+
+export default function() {
+  return ng('generate', 'component', 'i18n-test')
+    .then(() => writeFile(
+      join('src/app/i18n-test', 'i18n-test.component.html'),
+      '<p i18n>Hello world <span i18n>inner</span></p>'))
+    .then(() => expectToFail(() => ng('xi18n')))
+    .then(({ message }) => {
+      if (!message.includes('Could not mark an element as' +
+          ' translatable inside a translatable section')) {
+        throw new Error(`Expected i18n extraction error, got this instead:\n${message}`);
+      }
+    });
+}


### PR DESCRIPTION
Correctly throw xi18n errors (and print warnings) instead of ignoring them.
I've also removed the catch so that the extraction really fails when there is an error.

Fixes #8065 