### PR TITLE
fix(@ngtools/webpack): fix elide removing whole imports on single match

### DIFF
--- a/packages/@ngtools/webpack/src/transformers/elide_imports.ts
+++ b/packages/@ngtools/webpack/src/transformers/elide_imports.ts
@@ -113,7 +113,7 @@ export function elideImports(
     })
     .forEach((symbol) => {
       // Remove the whole declaration if it's a single import.
-      const nodeToRemove = symbol.singleImport ? symbol.importSpec : symbol.importDecl;
+      const nodeToRemove = symbol.singleImport ? symbol.importDecl : symbol.importSpec;
       ops.push(new RemoveNodeOperation(sourceFile, nodeToRemove));
     });
 


### PR DESCRIPTION
If an import imports multiple symbols, the previous condition meant that the whole
import statement was removed, instead of only the symbol.

Fixes #8518.