### PR TITLE
fix(@angular/cli): ignore system files in assets

### DIFF
--- a/packages/@angular/cli/models/webpack-configs/common.ts
+++ b/packages/@angular/cli/models/webpack-configs/common.ts
@@ -121,7 +121,7 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
         }
       };
     });
-    const copyWebpackPluginOptions = { ignore: ['.gitkeep'] };
+    const copyWebpackPluginOptions = { ignore: ['.gitkeep', '**/.DS_Store', '**/Thumbs.db'] };
 
     const copyWebpackPluginInstance = new CopyWebpackPlugin(copyWebpackPluginPatterns,
       copyWebpackPluginOptions);


### PR DESCRIPTION
Replaces angular/devkit#263

When copying the assets during build, the CLI must not include system files (e.g. `.DS_Store` and `Thumbs.db`).

It is very important for service worker to work : if presents, these files will be included in the service worker manifest as files to cache (according to [this schematic](https://github.com/angular/devkit/blob/master/packages/schematics/angular/application/files/__path__/ngsw-config.json)). But such files may (and should) not be deployed to the server. Then on the client, files will be missing, then the service worker installation will fail and so all the offline feature won't work.

@hansl @filipesilva @Brocco @alxhub 