### PR TITLE
docs: add sass brand variable for bootstrap 4

### DIFF
--- a/docs/documentation/stories/include-bootstrap.md
+++ b/docs/documentation/stories/include-bootstrap.md
@@ -117,7 +117,11 @@ Verify the bootstrap styled button appears.
 To ensure your variables are used open `_variables.scss` and add the following:
 
 ```sass
+// version 3
 $brand-primary: red;
+
+// version 4
+$primary: red;
 ```
 
 Return the browser to see the font color changed.


### PR DESCRIPTION
The **$brand-primary** Sass variable is no longer applicable for Bootstrap 4. Updated doc with new **$primary** variable.