### PR TITLE
Work with typescript files without content

### DIFF
--- a/packages/@ngtools/webpack/src/virtual_file_system_decorator.ts
+++ b/packages/@ngtools/webpack/src/virtual_file_system_decorator.ts
@@ -35,7 +35,7 @@ export class VirtualFileSystemDecorator implements InputFileSystem {
 
   stat(path: string, callback: Callback<any>): void {
     const result = this._statSync(path);
-    if (result) {
+    if (result != undefined) {
       callback(null, result);
     } else {
       this._inputFileSystem.stat(path, callback);
@@ -48,7 +48,7 @@ export class VirtualFileSystemDecorator implements InputFileSystem {
 
   readFile(path: string, callback: Callback<any>): void {
     const result = this._readFileSync(path);
-    if (result) {
+    if (result != undefined) {
       callback(null, result);
     } else {
       this._inputFileSystem.readFile(path, callback);


### PR DESCRIPTION
Too bad we have empty typescript files and their content is "" which is a false-y value.
On the other hand:
```
> null != undefined
false
> undefined != undefined
false
> "" != undefined
true
```
I am not sure this is a proper "fix" but please mind it should work with empty string. Usually we won't have empty files but on few occasions we use a mechanism to do a preprocessor kind of stuff that will output some TypeScript code for some builds but have none for others. Then web pack running uglify will strip comments and compress whitespace leading to "".