### PR TITLE
fix(@angular/cli): pass sourceMap to postcss

### DIFF
--- a/packages/@angular/cli/models/webpack-configs/styles.ts
+++ b/packages/@angular/cli/models/webpack-configs/styles.ts
@@ -172,7 +172,8 @@ export function getStylesConfig(wco: WebpackConfigOptions) {
       options: {
         // A non-function property is required to workaround a webpack option handling bug
         ident: 'postcss',
-        plugins: postcssPluginCreator
+        plugins: postcssPluginCreator,
+        sourceMap: cssSourceMap
       }
     }
   ];


### PR DESCRIPTION
This is required per https://github.com/postcss/postcss-loader#sourcemap

Closes #8588