### PR TITLE
feat: direct ngc compilation with a webpack compiler host

### DIFF
--- a/packages/@ngtools/webpack/src/index.ts
+++ b/packages/@ngtools/webpack/src/index.ts
@@ -15,6 +15,7 @@ try {
     + e);
 }
 
+export * from './ngc_bridge';
 export * from './plugin';
 export * from './angular_compiler_plugin';
 export * from './extract_i18n_plugin';

--- a/packages/@ngtools/webpack/src/ngc_bridge/index.ts
+++ b/packages/@ngtools/webpack/src/ngc_bridge/index.ts
@@ -1,0 +1,1 @@
+export { compile, CompilationResult } from './run';

--- a/packages/@ngtools/webpack/src/ngc_bridge/inline_metadata.ts
+++ b/packages/@ngtools/webpack/src/ngc_bridge/inline_metadata.ts
@@ -1,3 +1,4 @@
+// @ignoreDep @angular/core
 import * as Path from 'path';
 
 import { Component } from '@angular/core';

--- a/packages/@ngtools/webpack/src/ngc_bridge/inline_metadata.ts
+++ b/packages/@ngtools/webpack/src/ngc_bridge/inline_metadata.ts
@@ -1,0 +1,67 @@
+import * as Path from 'path';
+
+import { Component } from '@angular/core';
+import {
+  ModuleMetadata,
+  MetadataSymbolicCallExpression,
+  isClassMetadata,
+  isMetadataSymbolicCallExpression,
+  isMetadataImportedSymbolReferenceExpression
+} from '@angular/compiler-cli';
+
+
+function hasResources(obj: any): obj is Component {
+  return obj.hasOwnProperty('templateUrl') || obj.hasOwnProperty('styleUrls');
+}
+
+function findComponentDecoratorMetadata(decorators: any[]): MetadataSymbolicCallExpression {
+  return decorators
+    .find( entry => {
+      if (isMetadataSymbolicCallExpression(entry)) {
+        const exp = entry.expression;
+        if (isMetadataImportedSymbolReferenceExpression(exp) && exp.module === '@angular/core'
+          && exp.name === 'Component') {
+          return true;
+        }
+      }
+      return false;
+    });
+}
+
+export function inlineMetadataBundle(
+  relativeTo: string,
+  metadataBundle: ModuleMetadata,
+  getResource: (resourcePath: string) => string | undefined
+): void {
+  const { metadata, origins } = metadataBundle;
+
+  Object.keys(metadata).forEach( key => {
+    const entry = metadata[key];
+    if (isClassMetadata(entry) && entry.decorators) {
+      const exp = findComponentDecoratorMetadata(entry.decorators);
+      const componentMetadata = exp && exp.arguments && exp.arguments[0];
+
+      if (componentMetadata && hasResources(componentMetadata)) {
+        // when no "origins" it is metadata json for specific module, if origins it's flat mode.
+        const origin = origins
+          ? Path.dirname(Path.resolve(relativeTo, origins[key]))
+          : relativeTo
+        ;
+
+        if (componentMetadata.templateUrl) {
+          const template = getResource(Path.resolve(origin, componentMetadata.templateUrl));
+          if (template) {
+            delete componentMetadata.templateUrl;
+            componentMetadata.template = template;
+          }
+        }
+
+        if (componentMetadata.styleUrls) {
+          componentMetadata.styles = componentMetadata.styleUrls
+            .map( stylePath => getResource(Path.resolve(origin, stylePath)) );
+          delete componentMetadata.styleUrls;
+        }
+      }
+    }
+  });
+}

--- a/packages/@ngtools/webpack/src/ngc_bridge/ngc_compilation_context.ts
+++ b/packages/@ngtools/webpack/src/ngc_bridge/ngc_compilation_context.ts
@@ -1,0 +1,135 @@
+import * as FS from 'fs';
+import * as Path from 'path';
+import * as ts from 'typescript';
+import { ParsedConfiguration, TsEmitArguments } from '@angular/compiler-cli';
+
+import { WebpackResourceLoader } from '../resource_loader';
+import { createEmitCallback } from './perform_compile_async';
+import { inlineResources } from '../transformers/inline_resources';
+import { inlineMetadataBundle } from './inline_metadata';
+import { NgcCompilerHost } from './ngc_compiler_host';
+import { createSrcToOutPathMapper } from './util';
+
+export function createContext(config: ParsedConfiguration) {
+  let sourceToOutMapper: (srcFileName: string, reverse?: boolean) => string;
+
+  const compilerHost = new NgcCompilerHost(config.options, new WebpackResourceLoader());
+  const getResource = (resourcePath: string) => compilerHost.getResource(resourcePath);
+  const realEmitCallback = createEmitCallback(config.options);
+
+  /**
+   * Inline a single metadata.json module (not flat module)
+   */
+  const inlineMetadataModule = (fileName: string, data: string): string => {
+    const metadataBundle = JSON.parse(data);
+
+    let relativeTo = Path.dirname(fileName);
+    if (sourceToOutMapper) {
+      relativeTo = sourceToOutMapper(relativeTo, true);
+    }
+
+    // process the metadata bundle and inline resources
+    // we send the source location as the relative folder (not the dest) so matching resource paths
+    // with compilerHost will work.
+    metadataBundle.forEach( (m: any) => inlineMetadataBundle(relativeTo, m, getResource) );
+
+    return JSON.stringify(metadataBundle);
+  };
+
+  /**
+   * A wrapper around the actual emit callback that allow creating a file system path mapper
+   * between source and destination.
+   */
+  const emitCallback = (emitArgs: TsEmitArguments) => {
+    const writeFile = (...args: any[]) => {
+      // we don't need to collect all source files mappings, we need only 1 so it's a bit different
+      // from angular's code
+      if (!sourceToOutMapper) {
+        const outFileName: string = args[0];
+        const sourceFiles: ts.SourceFile[] = args[4];
+        if (sourceFiles && sourceFiles.length == 1) {
+          sourceToOutMapper = createSrcToOutPathMapper(
+            config.options.outDir,
+            sourceFiles[0].fileName,
+            outFileName
+          );
+        }
+      }
+      return emitArgs.writeFile.apply(null, args);
+    };
+    return realEmitCallback(Object.create(emitArgs, { writeFile: { value: writeFile } }));
+  };
+
+  return {
+    compilerHost,
+
+    /**
+     * Returns the source file to destination file mapper used to map source files to dest files.
+     * The mapper is available after after the compilation is done.
+     */
+    getSourceToOutMapper(): ( (srcFileName: string, reverse?: boolean) => string ) | undefined {
+      return sourceToOutMapper;
+    },
+
+    createCompilation(compiler: any) {
+      const compilation = compiler.createCompilation();
+      compilerHost.resourceLoader.update(compilation);
+      return compilation;
+    },
+
+    getResource,
+
+    createInlineResourcesTransformer() {
+      return inlineResources(
+        getResource,
+        (fName: string) => !fName.endsWith('.ngfactory.ts') && !fName.endsWith('.ngstyle.ts')
+      );
+    },
+
+    emitCallback,
+
+    /**
+     * Returns a compilerHost instance that inline all resources (templateUrl, styleUrls)
+     * inside metadata files that was created for a specific module
+     * (i.e. not a flat metadata bundle module)
+     */
+    resourceInliningCompilerHost() {
+      return Object.create(compilerHost, {
+        writeFile: {
+          writable: true,
+          value: (fileName: string, data: string, ...args: any[]): void => {
+            if (/\.metadata\.json$/.test(fileName)) {
+              data = inlineMetadataModule(fileName, data);
+            }
+            return compilerHost.writeFile(fileName, data, args[0], args[1], args[2]);
+          }
+        }
+      });
+    },
+
+    inlineFlatModuleMetadataBundle(relativeTo: string, flatModuleOutFile: string): void {
+      let metadataPath = Path.resolve(
+        relativeTo,
+        flatModuleOutFile.replace(/\.js$/, '.metadata.json')
+      );
+
+      if (sourceToOutMapper) {
+        metadataPath = sourceToOutMapper(metadataPath);
+      }
+
+      if (!FS.existsSync(metadataPath)) {
+        throw new Error(`Could not find flat module "metadata.json" output at ${metadataPath}`);
+      }
+
+      const metadataBundle = JSON.parse(FS.readFileSync(metadataPath, { encoding: 'utf8' }));
+
+      // process the metadata bundle and inline resources.
+      // We set the relative base folder to be the source code and not destination
+      // because the cached resources in the compiler host are id'ed by
+      // the source path.
+      inlineMetadataBundle(relativeTo, metadataBundle, getResource);
+
+      FS.writeFileSync(metadataPath, JSON.stringify(metadataBundle), { encoding: 'utf8' });
+    }
+  };
+}

--- a/packages/@ngtools/webpack/src/ngc_bridge/ngc_compiler_host.ts
+++ b/packages/@ngtools/webpack/src/ngc_bridge/ngc_compiler_host.ts
@@ -1,0 +1,89 @@
+import * as ts from 'typescript';
+import { sep } from 'path';
+import { WebpackResourceLoader } from '../resource_loader';
+
+function denormalizePath(path: string): string {
+  return path.replace(/\//g, sep);
+}
+
+export interface OnErrorFn {
+  (message: string): void;
+}
+
+export class NgcCompilerHost implements ts.CompilerHost {
+  private resourceCache = new Map<string, string>();
+  private host: ts.CompilerHost;
+
+  constructor(private options: ts.CompilerOptions, public resourceLoader?: WebpackResourceLoader) {
+    this.host = ts.createCompilerHost(this.options, true);
+  }
+
+  fileExists(fileName: string): boolean {
+    return this.host.fileExists(fileName);
+  }
+
+  readFile(fileName: string): string {
+    return this.host.readFile(fileName);
+  }
+
+  getDirectories(path: string): string[] {
+    return this.host.getDirectories(path);
+  }
+
+  getSourceFile(fileName: string, languageVersion: ts.ScriptTarget, _onError?: OnErrorFn) {
+    return this.host.getSourceFile(fileName, languageVersion, _onError);
+  }
+
+  getCancellationToken() {
+    return this.host.getCancellationToken!();
+  }
+
+  getDefaultLibFileName(options: ts.CompilerOptions) {
+    return this.host.getDefaultLibFileName(options);
+  }
+
+  writeFile(fileName: string, data: string, _writeByteOrderMark: boolean,
+            _onError?: (message: string) => void, _sourceFiles?: ts.SourceFile[]) {
+    return this.host.writeFile(fileName, data, _writeByteOrderMark, _onError, _sourceFiles);
+  }
+
+  getCurrentDirectory(): string {
+    return this.host.getCurrentDirectory();
+  }
+
+  getCanonicalFileName(fileName: string): string {
+    return this.host.getCanonicalFileName(fileName);
+  }
+
+  useCaseSensitiveFileNames(): boolean {
+    return this.host.useCaseSensitiveFileNames();
+  }
+
+  getNewLine(): string {
+    return this.host.getNewLine();
+  }
+
+  readResource(fileName: string): Promise<string> | string {
+    if (this.resourceLoader) {
+      // These paths are meant to be used by the loader so we must denormalize them.
+      const denormalizedFileName = denormalizePath(fileName);
+      return this.resourceLoader.get(denormalizedFileName)
+        .then( content => {
+          this.resourceCache.set(denormalizedFileName, content);
+          return content;
+        });
+    } else {
+      return this.readFile(fileName);
+    }
+  }
+
+  /**
+   * Returns a cached resource, if the resource is not cached returns undefined.
+   * Will not try to get the resource if it does not exists.
+   * @param {string} fileName
+   * @returns {string}
+   */
+  getResource(fileName: string): string | undefined {
+    return this.resourceCache.get(fileName);
+  }
+}

--- a/packages/@ngtools/webpack/src/ngc_bridge/perform_compile_async.ts
+++ b/packages/@ngtools/webpack/src/ngc_bridge/perform_compile_async.ts
@@ -11,6 +11,8 @@ Additional code copied per need (e.g. `createEmitCallback`).
 This code should also get removed once async is implemented in compiler-cli.
 */
 
+// @ignoreDep tsickle
+// @ignoreDep @angular/compiler
 import * as ts from 'typescript';
 import * as tsickle from 'tsickle';
 import {isSyntaxError} from '@angular/compiler';

--- a/packages/@ngtools/webpack/src/ngc_bridge/perform_compile_async.ts
+++ b/packages/@ngtools/webpack/src/ngc_bridge/perform_compile_async.ts
@@ -1,0 +1,196 @@
+/*
+An async version of `performCompilation`
+https://github.com/angular/angular/blob/master/packages/compiler-cli/src/perform_compile.ts
+
+This implementation will invoke `program.loadNgStructureAsync()` before moving on with
+compilation, allowing resources to load async an so enabling webpack integration.
+
+TODO: Move to native implementation when/if https://github.com/angular/angular/issues/20130
+
+Additional code copied per need (e.g. `createEmitCallback`).
+This code should also get removed once async is implemented in compiler-cli.
+*/
+
+import * as ts from 'typescript';
+import * as tsickle from 'tsickle';
+import {isSyntaxError} from '@angular/compiler';
+import {
+  Program,
+  CompilerHost,
+  CompilerOptions,
+  TsEmitCallback,
+  CustomTransformers,
+  PerformCompilationResult,
+  createCompilerHost,
+  createProgram,
+  Diagnostic,
+  Diagnostics,
+  EmitFlags,
+  DEFAULT_ERROR_CODE,
+  UNKNOWN_ERROR_CODE,
+  SOURCE
+} from '@angular/compiler-cli';
+
+export function performCompilationAsync({
+                                          rootNames, options, host, oldProgram, emitCallback,
+                                          gatherDiagnostics = asyncDiagnostics,
+                                          customTransformers, emitFlags = EmitFlags.Default
+                                        }: {
+  rootNames: string[],
+  options: CompilerOptions,
+  host?: CompilerHost,
+  oldProgram?: Program,
+  emitCallback?: TsEmitCallback,
+  gatherDiagnostics?: (program: Program) => Diagnostics,
+  customTransformers?: CustomTransformers,
+  emitFlags?: EmitFlags
+}): Promise<PerformCompilationResult> {
+  let program: Program | undefined;
+  let emitResult: ts.EmitResult | undefined;
+  let allDiagnostics: Diagnostics = [];
+
+  return Promise.resolve()
+    .then(() => {
+      if (!host) {
+        host = createCompilerHost({options});
+      }
+      program = createProgram({rootNames, host, options, oldProgram});
+      return program.loadNgStructureAsync();
+    })
+    .then(() => {
+      const beforeDiags = Date.now();
+      allDiagnostics.push(...gatherDiagnostics(program !));
+      if (options.diagnostics) {
+        const afterDiags = Date.now();
+        allDiagnostics.push(
+          createMessageDiagnostic(`Time for diagnostics: ${afterDiags - beforeDiags}ms.`));
+      }
+
+      if (!hasErrors(allDiagnostics)) {
+        emitResult = program !.emit({emitCallback, customTransformers, emitFlags});
+        allDiagnostics.push(...emitResult.diagnostics);
+        return {diagnostics: allDiagnostics, program, emitResult};
+      }
+      return {diagnostics: allDiagnostics, program};
+    })
+    .catch(e => {
+      let errMsg: string;
+      let code: number;
+      if (isSyntaxError(e)) {
+        // don't report the stack for syntax errors as they are well known errors.
+        errMsg = e.message;
+        code = DEFAULT_ERROR_CODE;
+      } else {
+        errMsg = e.stack;
+        // It is not a syntax error we might have a program with unknown state, discard it.
+        program = undefined;
+        code = UNKNOWN_ERROR_CODE;
+      }
+      allDiagnostics.push(
+        {category: ts.DiagnosticCategory.Error, messageText: errMsg, code, source: SOURCE});
+      return {diagnostics: allDiagnostics, program};
+    });
+}
+
+function asyncDiagnostics(angularProgram: Program): Diagnostics {
+  const allDiagnostics: Diagnostics = [];
+
+  // Check Angular structural diagnostics.
+  allDiagnostics.push(...angularProgram.getNgStructuralDiagnostics());
+
+  // Check TypeScript parameter diagnostics.
+  allDiagnostics.push(...angularProgram.getTsOptionDiagnostics());
+
+  // Check Angular parameter diagnostics.
+  allDiagnostics.push(...angularProgram.getNgOptionDiagnostics());
+
+
+  function checkDiagnostics(diags: Diagnostics | undefined) {
+    if (diags) {
+      allDiagnostics.push(...diags);
+      return !hasErrors(diags);
+    }
+    return true;
+  }
+
+  let checkOtherDiagnostics = true;
+  // Check TypeScript syntactic diagnostics.
+  checkOtherDiagnostics = checkOtherDiagnostics &&
+    checkDiagnostics(angularProgram.getTsSyntacticDiagnostics(undefined));
+
+  // Check TypeScript semantic and Angular structure diagnostics.
+  checkOtherDiagnostics = checkOtherDiagnostics &&
+    checkDiagnostics(angularProgram.getTsSemanticDiagnostics(undefined));
+
+  // Check Angular semantic diagnostics
+  if (checkOtherDiagnostics) {
+    checkDiagnostics(angularProgram.getNgSemanticDiagnostics(undefined));
+  }
+
+  return allDiagnostics;
+}
+
+export const GENERATED_FILES = /(.*?)\.(ngfactory|shim\.ngstyle|ngstyle|ngsummary)\.(js|d\.ts|ts)$/;
+export const DTS = /\.d\.ts$/;
+export function createEmitCallback(options: CompilerOptions): TsEmitCallback | undefined {
+  const transformDecorators = options.annotationsAs !== 'decorators';
+  const transformTypesToClosure = options.annotateForClosureCompiler;
+  if (!transformDecorators && !transformTypesToClosure) {
+    return undefined;
+  }
+  if (transformDecorators) {
+    // This is needed as a workaround for https://github.com/angular/tsickle/issues/635
+    // Otherwise tsickle might emit references to non imported values
+    // as TypeScript elided the import.
+    options.emitDecoratorMetadata = true;
+  }
+  const tsickleHost: tsickle.TsickleHost = {
+    shouldSkipTsickleProcessing: fileName => DTS.test(fileName) || GENERATED_FILES.test(fileName),
+    pathToModuleName: () => '',
+    shouldIgnoreWarningsForPath: () => false,
+    fileNameToModuleId: (fileName) => fileName,
+    googmodule: false,
+    untyped: true,
+    convertIndexImportShorthand: false, transformDecorators, transformTypesToClosure,
+  };
+
+  return ({
+            program,
+            targetSourceFile,
+            writeFile,
+            cancellationToken,
+            emitOnlyDtsFiles,
+            customTransformers = {},
+            host,
+            options
+          }) =>
+    tsickle.emitWithTsickle(
+      program,
+      tsickleHost,
+      host,
+      options,
+      targetSourceFile,
+      writeFile,
+      cancellationToken,
+      emitOnlyDtsFiles,
+      {
+        beforeTs: customTransformers.before,
+        afterTs: customTransformers.after,
+      }
+    );
+}
+
+function hasErrors(diags: Diagnostics) {
+  return diags.some(d => d.category === ts.DiagnosticCategory.Error);
+}
+
+function createMessageDiagnostic(messageText: string): ts.Diagnostic & Diagnostic {
+  return {
+    file: undefined,
+    start: undefined,
+    length: undefined,
+    category: ts.DiagnosticCategory.Message, messageText,
+    code: DEFAULT_ERROR_CODE,
+    source: SOURCE,
+  };
+}

--- a/packages/@ngtools/webpack/src/ngc_bridge/run.ts
+++ b/packages/@ngtools/webpack/src/ngc_bridge/run.ts
@@ -1,0 +1,179 @@
+import * as Path from 'path';
+import * as webpack from 'webpack';
+import * as ts from 'typescript';
+import { CompilerOptions, ParsedConfiguration, readConfiguration } from '@angular/compiler-cli';
+
+import { createContext } from './ngc_compilation_context';
+import { performCompilationAsync } from './perform_compile_async';
+import { parseDiagnostics } from './util';
+
+export interface CompilationResult {
+  errors?: Error[];
+  emitResult?: ts.EmitResult;
+}
+
+/**
+ * Perform AOT compilation with all resources (templateUrl / styleUrls) compiled
+ * by webpack using the loader chain configuration supplied.
+ *
+ * Inlining is automatically set on based on the typescript configuration.
+ */
+export function executeCompilation(
+  webpackConfig: webpack.Configuration,
+  config: ParsedConfiguration
+): Promise<CompilationResult> {
+  const compiler = webpack(webpackConfig);
+  const inline = config.options.skipTemplateCodegen;
+  workaroundSkipTemplateCodegen(config);
+
+  const ctx = createContext(config);
+  const { compilerHost } = ctx;
+
+  const compilation = ctx.createCompilation(compiler);
+  const rootNames = config.rootNames.slice();
+
+  return performCompilationAsync({
+    rootNames,
+    options: config.options,
+
+    /*
+        The compiler host "writeFile" is wrapped with a handler that will
+        inline all resources into metadata modules (non flat bundle modules)
+     */
+    host: (inline && !config.options.skipMetadataEmit && !config.options.flatModuleOutFile)
+      ? ctx.resourceInliningCompilerHost()
+      : compilerHost
+    ,
+    emitFlags: config.emitFlags,
+    emitCallback: ctx.emitCallback,
+    customTransformers: {
+      beforeTs: inline ? [ ctx.createInlineResourcesTransformer() ] : []
+    }
+  })
+    .then( result => {
+      const parsedDiagnostics = parseDiagnostics(result.diagnostics, config.options);
+      if (parsedDiagnostics.exitCode !== 0) {
+        const error = parsedDiagnostics.error || new Error(parsedDiagnostics.exitCode.toString());
+        compilation.errors.push(error);
+      }
+
+      if (compilation.errors.length === 0) {
+        // inline resources into the flat metadata json file, if exists.
+        if (config.options.flatModuleOutFile) {
+          // we assume the last rootName is the flatModuleOutFile JS added by the compiler
+          // TODO: check that it exists
+          const flatModulePath = rootNames[rootNames.length - 1];
+          ctx.inlineFlatModuleMetadataBundle(
+            Path.dirname(flatModulePath),
+            config.options.flatModuleOutFile
+          );
+        }
+
+        return { emitResult: result.emitResult };
+      } else {
+        return { errors: compilation.errors };
+      }
+    });
+}
+
+/**
+ * Perform AOT compilation with all resources (templateUrl / styleUrls) compiled
+ * by webpack using the loader chain configuration supplied.
+ *
+ * Inlining is automatically set on based on the typescript configuration.
+ *
+ * > Note that `extOptions` has 2 properties that extend the configuration.
+ * `compilerOptions` is applied before parsing the configuration and does not
+ * accept values from `angularCompilerOptions`, if set they are overriden.
+ * `existingOptions` is applied after parsing which means it can not effect
+ * rootName, emit flags, etc...
+ * @param webpackConfig Webpack configuration module, object or string,
+ * @param tsConfigPath path to the tsconfig file, relative to process.cwd()
+ * @param extOptions Optional TS/AOT options that extend the options loaded from file.
+ * @param extOptions.compilerOptions - Optional TS compiler options set BEFORE parsing
+ * @param extOptions.existingOptions - Optional compiler options set AFTER parsing
+ */
+export function compile(
+  webpackConfig: string | webpack.Configuration,
+  tsConfigPath: string,
+  extOptions: { compilerOptions?: ts.CompilerOptions, existingOptions?: CompilerOptions } = {}
+): Promise<CompilationResult> {
+
+  // load tsconfig
+  const config = readConfiguration(tsConfigPath, extOptions.compilerOptions);
+  if (config.errors && config.errors.length > 0) {
+    const parsed = parseDiagnostics(config.errors, undefined);
+    return Promise.resolve({ errors: [parsed.error] });
+  }
+  const existingOptions = extOptions.existingOptions || <any> {};
+  const options = {...config.options, ...existingOptions};
+
+  // normalize webpackConfig input
+  if (typeof webpackConfig === 'string') {
+    let configPath = Path.isAbsolute(webpackConfig)
+      ? webpackConfig
+      : Path.join(process.cwd(), webpackConfig)
+    ;
+    webpackConfig = require(configPath);
+  }
+
+  return executeCompilation(resolveConfig(webpackConfig), {
+    project: tsConfigPath,
+    rootNames: config.rootNames,
+    options,
+    errors: config.errors,
+    emitFlags: config.emitFlags
+  });
+}
+
+/**
+ * Resolve the config to an object.
+ * If it's a fn, invoke.
+ *
+ * Also check if it's a mocked ES6 Module in cases where TS file is used that uses "export default"
+ * @param config
+ * @returns {any}
+ */
+function resolveConfig(config: any): webpack.Configuration {
+  if (typeof config === 'function') {
+    return config();
+  } else if (config.__esModule === true && !!config.default) {
+    return resolveConfig(config.default);
+  } else {
+    return config;
+  }
+}
+
+/**
+ * `compiler-cli`s compiler host will not generate metadata if skipping template codegen
+ * or no full template typescheck.
+ *
+ * https://github.com/angular/angular/blob/master/
+ * packages/compiler-cli/src/transformers/compiler_host.ts#L440
+ *
+ * This is required if we want to inline the resources while compiling and not post-compiling.
+ *
+ * To solve this we need to can force `fullTemplateTypeCheck`...
+ * This is strict and might cause issues to some devs and also has an issue:
+ * https://github.com/angular/angular/issues/19905
+ * which has pending PR to fix: https://github.com/angular/angular/pull/20490
+ *
+ * Another options is to disable skipTemplateCodegen.
+ * It looks counter-intuitive because we want it on... but, at this point we already have
+ * a calcualted `emitFlags` which has the flag `Codegen` OFF !!!
+ * OFF reflects config.options.skipTemplateCodegen = true.
+ *
+ * Setting `config.options.skipTemplateCodegen` to false, at this point, will not change the
+ * emitFlags. The compiler will NOT emit template code gen but
+ * the `isSourceFile` method will return true!
+ *
+ * This is a weak workaround and a more solid one is required.
+ *
+ * TODO: refactor workaround to a writeFile wrapper that will not write generated files.
+ */
+function workaroundSkipTemplateCodegen(config: ParsedConfiguration): void {
+  if (config.options.skipTemplateCodegen && !config.options.fullTemplateTypeCheck) {
+    // options.fullTemplateTypeCheck = true;
+    config.options.skipTemplateCodegen = false;
+  }
+}

--- a/packages/@ngtools/webpack/src/ngc_bridge/util.ts
+++ b/packages/@ngtools/webpack/src/ngc_bridge/util.ts
@@ -1,0 +1,86 @@
+import * as Path from 'path';
+import * as ts from 'typescript';
+import {
+  CompilerOptions,
+  exitCodeFromResult,
+  formatDiagnostics,
+  Diagnostics,
+  filterErrorsAndWarnings
+} from '@angular/compiler-cli';
+
+
+function normalizeSeparators(path: string): string {
+  return path.replace(/\\/g, '/');
+}
+
+/* COPIED FROM `@angular/compiler-cli` */
+/**
+ * Returns a function that can adjust a path from source path to out path,
+ * based on an existing mapping from source to out path.
+ *
+ * TODO(tbosch): talk to the TypeScript team to expose their logic for calculating the `rootDir`
+ * if none was specified.
+ *
+ * Note: This function works on normalized paths from typescript.
+ */
+export function createSrcToOutPathMapper(outDir: string | undefined,
+                                         sampleSrcFileName: string | undefined,
+                                         sampleOutFileName: string | undefined,
+                                         host: {
+                                           dirname: typeof Path.dirname,
+                                           resolve: typeof Path.resolve,
+                                           relative: typeof Path.relative
+                                         } = Path
+): (srcFileName: string, reverse?: boolean) => string {
+  let srcToOutPath: (srcFileName: string) => string;
+  if (outDir) {
+    // let Path: {} = {};  // Ensure we error if we use `path` instead of `host`.
+    if (sampleSrcFileName == null || sampleOutFileName == null) {
+      throw new Error(`Can't calculate the rootDir without a sample srcFileName / outFileName. `);
+    }
+    const srcFileDir = normalizeSeparators(host.dirname(sampleSrcFileName));
+    const outFileDir = normalizeSeparators(host.dirname(sampleOutFileName));
+    if (srcFileDir === outFileDir) {
+      return (srcFileName) => srcFileName;
+    }
+    // calculate the common suffix, stopping
+    // at `outDir`.
+    const srcDirParts = srcFileDir.split('/');
+    const outDirParts = normalizeSeparators(host.relative(outDir, outFileDir)).split('/');
+    let i = 0;
+    while (i < Math.min(srcDirParts.length, outDirParts.length) &&
+    srcDirParts[srcDirParts.length - 1 - i] === outDirParts[outDirParts.length - 1 - i]) {
+      i++;
+    }
+    const rootDir = srcDirParts.slice(0, srcDirParts.length - i).join('/');
+    srcToOutPath = (srcFileName, reverse?) => reverse
+      ? host.resolve(rootDir, host.relative(outDir, srcFileName))
+      : host.resolve(outDir, host.relative(rootDir, srcFileName))
+    ;
+  } else {
+    srcToOutPath = (srcFileName) => srcFileName;
+  }
+  return srcToOutPath;
+}
+
+export interface ParsedDiagnostics {
+  exitCode: number;
+  error?: Error;
+}
+
+export function parseDiagnostics(allDiagnostics: Diagnostics,
+                                 options?: CompilerOptions): ParsedDiagnostics {
+  const result: ParsedDiagnostics = { exitCode: exitCodeFromResult(allDiagnostics) };
+
+  const errorsAndWarnings = filterErrorsAndWarnings(allDiagnostics);
+  if (errorsAndWarnings.length) {
+    let currentDir = options ? options.basePath : undefined;
+    const formatHost: ts.FormatDiagnosticsHost = {
+      getCurrentDirectory: () => currentDir || ts.sys.getCurrentDirectory(),
+      getCanonicalFileName: fileName => fileName,
+      getNewLine: () => ts.sys.newLine
+    };
+    result.error = new Error(formatDiagnostics(errorsAndWarnings, formatHost));
+  }
+  return result;
+}

--- a/packages/@ngtools/webpack/src/transformers/inline_resources.ts
+++ b/packages/@ngtools/webpack/src/transformers/inline_resources.ts
@@ -1,0 +1,145 @@
+// @ignoreDep typescript
+import * as Path from 'path';
+import * as ts from 'typescript';
+
+import { collectDeepNodes } from './ast_helpers';
+import { makeTransform } from './make_transform';
+import { StandardTransform, ReplaceNodeOperation } from './interfaces';
+
+function errorMsg(type: 'templateUrl' | 'styleUrl', exp: string, fileName: string): string {
+  return `Could not find ${type} expression "${exp}" in "${fileName}"`;
+}
+
+/**
+ * Transform `templateUrl` and `styleUrls` expressions to `template` and `styles` expression
+ * using a store that gets the a resource from it's url.
+ */
+export function inlineResources(
+  getResource: (resourcePath: string) => string | undefined,
+  shouldTransform: (fileName: string) => boolean
+): ts.TransformerFactory<ts.SourceFile> {
+  const createInlineLiteral = createInlineLiteralFactory(getResource);
+  const standardTransform: StandardTransform = function (sourceFile: ts.SourceFile) {
+    if (!shouldTransform(sourceFile.fileName)) {
+      return [];
+    }
+    const replacements: ReplaceNodeOperation[] = [];
+    const propAssignments = findResources(sourceFile);
+    // Replace templateUrl/styleUrls key with template/styles, and and paths with require('path').
+    propAssignments.forEach((node: ts.PropertyAssignment) => {
+      const key = _getContentOfKeyLiteral(node.name);
+
+      if (key == 'templateUrl') {
+        const resourcePath = _getResourceRequest(node.initializer, sourceFile);
+        const inlineLiteral = createInlineLiteral(resourcePath.resolved);
+
+        if (!inlineLiteral) {
+          const fileName = Path.relative(process.cwd(), sourceFile.fileName);
+          throw new Error(errorMsg('templateUrl', resourcePath.raw, fileName));
+        }
+
+        const propAssign = ts.createPropertyAssignment('template', inlineLiteral);
+        replacements.push(new ReplaceNodeOperation(sourceFile, node, propAssign));
+      } else if (key == 'styleUrls') {
+        const arr = collectDeepNodes<ts.ArrayLiteralExpression>(
+          node,
+          ts.SyntaxKind.ArrayLiteralExpression
+        );
+
+        if (!arr || arr.length == 0 || arr[0].elements.length == 0) {
+          return;
+        }
+
+        const styleLiterals: ts.Expression[] = [];
+        arr[0].elements.forEach((element: ts.Expression) => {
+          const resourcePath = _getResourceRequest(element, sourceFile);
+          const inlineLiteral = createInlineLiteral(resourcePath.resolved);
+
+          if (!inlineLiteral) {
+            const fileName = Path.relative(process.cwd(), sourceFile.fileName);
+            throw new Error(errorMsg('styleUrl', resourcePath.raw, fileName));
+          }
+
+          styleLiterals.push(inlineLiteral);
+        });
+
+        const propAssign = ts.createPropertyAssignment(
+          'styles',
+          ts.createArrayLiteral(styleLiterals)
+        );
+        replacements.push(new ReplaceNodeOperation(sourceFile, node, propAssign));
+      }
+    });
+    return replacements;
+  };
+
+  return makeTransform(standardTransform);
+}
+
+export function findResources(sourceFile: ts.SourceFile): ts.PropertyAssignment[] {
+  // Find all object literals.
+  return collectDeepNodes<ts.ObjectLiteralExpression>(
+    sourceFile,
+    ts.SyntaxKind.ObjectLiteralExpression
+  )
+  // Get all their property assignments.
+    .map(node => collectDeepNodes<ts.PropertyAssignment>(node, ts.SyntaxKind.PropertyAssignment))
+    // Flatten into a single array (from an array of array<property assignments>).
+    .reduce((prev, curr) => curr ? prev.concat(curr) : prev, [])
+    // We only want property assignments for the templateUrl/styleUrls keys.
+    .filter((node: ts.PropertyAssignment) => {
+      const key = _getContentOfKeyLiteral(node.name);
+      if (!key) {
+        // key is an expression, can't do anything.
+        return false;
+      }
+      return key == 'templateUrl' || key == 'styleUrls';
+    });
+}
+
+function _getContentOfKeyLiteral(node?: ts.Node): string | null {
+  if (!node) {
+    return null;
+  } else if (node.kind == ts.SyntaxKind.Identifier) {
+    return (node as ts.Identifier).text;
+  } else if (node.kind == ts.SyntaxKind.StringLiteral) {
+    return (node as ts.StringLiteral).text;
+  } else {
+    return null;
+  }
+}
+
+function _getResourceRequest(
+  element: ts.Expression,
+  sourceFile: ts.SourceFile
+): { raw: string, resolved: string } {
+  if (element.kind == ts.SyntaxKind.StringLiteral) {
+    let url = (element as ts.StringLiteral).text;
+    // If the URL does not start with / OR ./ OR ../, prepends ./ to it.
+    if (! (/(^\.?\.\/)|(^\/)/.test(url)) ) {
+      url = './' + url;
+    }
+    return {
+      raw: (element as ts.StringLiteral).text,
+      resolved: resolveResourcePath(url, sourceFile)
+    };
+  } else {
+    throw new Error('Expressions are not supported when inlining resources.');
+  }
+}
+
+function resolveResourcePath(fileName: string, sourceFile: ts.SourceFile): string {
+  if (fileName[0] === '/') {
+    return fileName;
+  } else {
+    const dir = Path.dirname(sourceFile.fileName);
+    return Path.resolve(dir, fileName);
+  }
+}
+
+function createInlineLiteralFactory(getResource: (resourcePath: string) => string | undefined) {
+  return (resourcePath: string): ts.LiteralExpression | undefined => {
+    const inlineContent = getResource(resourcePath);
+    return inlineContent ? ts.createLiteral(inlineContent) : undefined;
+  };
+}

--- a/tests/e2e/assets/webpack/test-lib-ng5/index.ts
+++ b/tests/e2e/assets/webpack/test-lib-ng5/index.ts
@@ -1,0 +1,3 @@
+export * from './lib-service.service';
+export * from './lib-component/lib-component.component';
+export * from './lib-module.module';

--- a/tests/e2e/assets/webpack/test-lib-ng5/lib-component/lib-component.component.html
+++ b/tests/e2e/assets/webpack/test-lib-ng5/lib-component/lib-component.component.html
@@ -1,0 +1,1 @@
+<h1>Hello World</h1>

--- a/tests/e2e/assets/webpack/test-lib-ng5/lib-component/lib-component.component.scss
+++ b/tests/e2e/assets/webpack/test-lib-ng5/lib-component/lib-component.component.scss
@@ -1,0 +1,5 @@
+$scss-value: 15px;
+
+h1 {
+  border: $scss-value black solid;
+}

--- a/tests/e2e/assets/webpack/test-lib-ng5/lib-component/lib-component.component.ts
+++ b/tests/e2e/assets/webpack/test-lib-ng5/lib-component/lib-component.component.ts
@@ -1,0 +1,14 @@
+import { Component } from '@angular/core';
+import { LibServiceService } from '../lib-service.service';
+
+
+@Component({
+  selector: 'lib-component',
+  templateUrl: './lib-component.component.html',
+  styleUrls: [
+    './lib-component.component.scss'
+  ]
+})
+export class LibComponentComponent {
+  constructor(public libService: LibServiceService) { }
+}

--- a/tests/e2e/assets/webpack/test-lib-ng5/lib-module.module.ts
+++ b/tests/e2e/assets/webpack/test-lib-ng5/lib-module.module.ts
@@ -1,0 +1,27 @@
+import { NgModule, ModuleWithProviders } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { LibServiceService } from './lib-service.service';
+import { LibComponentComponent } from './lib-component/lib-component.component';
+
+@NgModule({
+  declarations: [
+    LibComponentComponent
+  ],
+  imports: [ // import Angular's modules
+    CommonModule
+  ],
+  exports: [ LibComponentComponent ]
+})
+export class MyLibraryModule {
+
+  static fromRoot(): ModuleWithProviders {
+    return {
+      ngModule: MyLibraryModule,
+      providers: [
+        LibServiceService
+      ]
+    }
+  }
+}
+

--- a/tests/e2e/assets/webpack/test-lib-ng5/lib-service.service.ts
+++ b/tests/e2e/assets/webpack/test-lib-ng5/lib-service.service.ts
@@ -1,0 +1,9 @@
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export class LibServiceService {
+
+  doSomething(): void {
+
+  }
+}

--- a/tests/e2e/assets/webpack/test-lib-ng5/package.json
+++ b/tests/e2e/assets/webpack/test-lib-ng5/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "test",
+  "license": "MIT",
+  "dependencies": {
+    "@angular/common": "^5.0.0-rc.8",
+    "@angular/compiler": "^5.0.0-rc.8",
+    "@angular/compiler-cli": "^5.0.0-rc.8",
+    "@angular/core": "^5.0.0-rc.8",
+    "@angular/http": "^5.0.0-rc.8",
+    "@angular/platform-browser": "^5.0.0-rc.8",
+    "@angular/platform-browser-dynamic": "^5.0.0-rc.8",
+    "@angular/platform-server": "^5.0.0-rc.8",
+    "@angular/router": "^5.0.0-rc.8",
+    "@angular/forms": "^5.0.0-rc.8",
+    "@ngtools/webpack": "0.0.0",
+    "core-js": "^2.4.1",
+    "rxjs": "^5.5.0",
+    "zone.js": "^0.8.14"
+  },
+  "devDependencies": {
+    "node-sass": "^3.7.0",
+    "performance-now": "^0.2.0",
+    "raw-loader": "^0.5.1",
+    "sass-loader": "^3.2.0",
+    "typescript": "~2.4.2",
+    "webpack": "2.2.0"
+  }
+}

--- a/tests/e2e/assets/webpack/test-lib-ng5/tsconfig.json
+++ b/tests/e2e/assets/webpack/test-lib-ng5/tsconfig.json
@@ -1,0 +1,33 @@
+{
+  // Test comment
+  "compilerOptions": {
+    "baseUrl": "",
+    "module": "es2015",
+    "moduleResolution": "node",
+    "target": "es5",
+    "noImplicitAny": false,
+    "sourceMap": true,
+    "declaration": true,
+    "noEmitHelpers": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "lib": [
+      "es2017",
+      "dom"
+    ],
+    "outDir": "lib",
+    "skipLibCheck": true,
+    "rootDir": "."
+  },
+  "files": [
+    "index.ts"
+  ],
+  "angularCompilerOptions": {
+    "annotateForClosureCompiler": true,
+    "skipMetadataEmit": false,
+    "skipTemplateCodegen": true,
+    "strictMetadataEmit": true,
+    "flatModuleOutFile": "my-lib.js",
+    "flatModuleId": "my-lib"
+  }
+}

--- a/tests/e2e/assets/webpack/test-lib-ng5/webpack.config.js
+++ b/tests/e2e/assets/webpack/test-lib-ng5/webpack.config.js
@@ -1,0 +1,34 @@
+const ngToolsWebpack = require('@ngtools/webpack');
+
+/*
+  When compiling through `ngc` most options have no effect.
+  only loader configuration for resources in templateUrl / styleUrls
+  have effect.
+ */
+module.exports = {
+  resolve: {
+    extensions: ['.ts', '.js']
+  },
+  entry: './app/main.ts',
+  output: {
+    path: './dist',
+    publicPath: 'dist/',
+    filename: 'app.main.js'
+  },
+  plugins: [
+    new ngToolsWebpack.AngularCompilerPlugin({
+      tsConfigPath: './tsconfig.json'
+    })
+  ],
+  module: {
+    loaders: [
+      { test: /\.scss$/, loaders: ['raw-loader', 'sass-loader'] },
+      { test: /\.css$/, loader: 'raw-loader' },
+      { test: /\.html$/, loader: 'raw-loader' },
+      { test: /\.ts$/, loader: '@ngtools/webpack' }
+    ]
+  },
+  devServer: {
+    historyApiFallback: true
+  }
+};

--- a/tests/e2e/tests/packages/webpack/lib-ng5.ts
+++ b/tests/e2e/tests/packages/webpack/lib-ng5.ts
@@ -1,0 +1,50 @@
+import {stripIndents} from 'common-tags';
+import {createProjectFromAsset} from '../../../utils/assets';
+import {node} from '../../../utils/process';
+import {expectFileToMatch, writeFile, readFile} from '../../../utils/fs';
+
+
+export default function(skipCleaning: () => void) {
+  return Promise.resolve()
+    .then(() => createProjectFromAsset('webpack/test-lib-ng5'))
+    .then(() => writeFile('run.js', `
+    require('@ngtools/webpack')
+      .compile('webpack.config.js', 'tsconfig.json')
+      .then( () => process.exit() )
+      .catch( err => {
+        process.exit(99);
+        console.error(err);
+      });
+    `))
+    .then(() => node('run.js'))
+    .then(() => expectFileToMatch('lib/lib-component/lib-component.component.js',
+      `template: "<h1>Hello World</h1>"`))
+    .then(() => expectFileToMatch('lib/lib-component/lib-component.component.js',
+      `styles: ["h1 {\\n  border: 15px black solid; }\\n"]`) )
+    .then(() => readFile('lib/my-lib.metadata.json'))
+    .then( data => JSON.parse(data) )
+    .then( metaBundle => {
+      const srcMeta: any = metaBundle.metadata.LibComponentComponent.decorators[0].arguments[0];
+      const matchMeta: any = {
+        selector: 'lib-component',
+        template: '<h1>Hello World</h1>',
+        styles: [ 'h1 {\n  border: 15px black solid; }\n' ]
+      };
+      ['selector', 'template'].forEach( k => {
+        if (matchMeta[k] !== srcMeta[k]) {
+          throw new Error(stripIndents`File "my-lib.metadata.json" did not match expected format...
+            Field ${k} should be "${matchMeta[k]}" but found "${srcMeta[k]}"
+            ------
+          `);
+        }
+      });
+
+      if (matchMeta.styles[0] !== srcMeta.styles[0]) {
+        throw new Error(stripIndents`File "my-lib.metadata.json" did not match expected format...
+            Field styles[0] should be "${matchMeta.styles[0]}" but found "${srcMeta.styles[0]}"
+            ------
+          `);
+      }
+     })
+    .then(() => skipCleaning() );
+}


### PR DESCRIPTION
This PR add's the missing bridge to `ngc` with a wepack compiler host.

Now it is possible to execute a compilation (not bundling) process similar to `ngc -p ...` but with a webpack enabled resource loader, no more gulp process, scss, postcss... just provide a webpack config and a tsconfig.

The process will inline resources when skipping template codegen. Inline is supported for JS files and metadata.json files (including flat bundle)

webpack is not used to run any bundling, just to compile resources on demand.

This is the first step for providing library support, it completes the "angular" gap of dealing with AOT resources.

The PR does not include cli interface, just node API, I guess CLI should go elsewhere using this node API.

Usage is simple:

```js
    require('@ngtools/webpack')
      .compile('webpack.config.js', 'tsconfig.json')
      .then( () => process.exit() )
      .catch( err => {
        process.exit(99);
        console.error(err);
      });
```

No change to the current code base, only additions.

Also, once angular/angular#20130 is added some code can be removed