### PR TITLE
fix(@angular/cli): support minified JS on safari 10

### DIFF
--- a/packages/@angular/cli/models/webpack-configs/production.ts
+++ b/packages/@angular/cli/models/webpack-configs/production.ts
@@ -144,11 +144,14 @@ export function getProdConfig(wco: WebpackConfigOptions) {
           ecma: wco.supportES2015 ? 6 : 5,
           warnings: buildOptions.verbose,
           ie8: false,
-          mangle: true,
+          mangle: {
+            safari10: true,
+          },
           compress: uglifyCompressOptions,
           output: {
             ascii_only: true,
-            comments: false
+            comments: false,
+            webkit: true,
           },
         }
       }),


### PR DESCRIPTION
This enables several UglifyJS options which prevent minification issues with Safari.

Partially addresses https://github.com/angular/angular-cli/issues/8546