### PR TITLE
refactor(@angular/cli): cleanup unused dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2305,12 +2305,6 @@
         "tapable": "0.2.8"
       }
     },
-    "ensure-posix-path": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/ensure-posix-path/-/ensure-posix-path-1.0.2.tgz",
-      "integrity": "sha1-pls+QtC3HPxYXrd0+ZQ8jZuRsMI=",
-      "dev": true
-    },
     "entities": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
@@ -5307,15 +5301,6 @@
       "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
       "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
       "dev": true
-    },
-    "matcher-collection": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.5.tgz",
-      "integrity": "sha512-nUCmzKipcJEwYsBVAFh5P+d7JBuhJaW1xs85Hara9xuMLqtCVUrW6DSC0JVIkluxEH2W45nPBM/wjHtBXa/tYA==",
-      "dev": true,
-      "requires": {
-        "minimatch": "3.0.4"
-      }
     },
     "math-expression-evaluator": {
       "version": "1.2.17",
@@ -8971,16 +8956,6 @@
         "indexof": "0.0.1"
       }
     },
-    "walk-sync": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.2.tgz",
-      "integrity": "sha512-FMB5VqpLqOCcqrzA9okZFc0wq0Qbmdm396qJxvQZhDpyu0W95G9JCmp74tx7iyYnyOcBtUuKJsgIKAqjozvmmQ==",
-      "dev": true,
-      "requires": {
-        "ensure-posix-path": "1.0.2",
-        "matcher-collection": "1.0.5"
-      }
-    },
     "watchpack": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.4.0.tgz",
@@ -9625,9 +9600,10 @@
       "dev": true
     },
     "zone.js": {
-      "version": "0.8.17",
-      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.8.17.tgz",
-      "integrity": "sha1-TF5RhahX2o2nk9rzkZNxxaNrKgs="
+      "version": "0.8.18",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.8.18.tgz",
+      "integrity": "sha512-knKOBQM0oea3/x9pdyDuDi7RhxDlJhOIkeixXSiTKWLgs4LpK37iBc+1HaHwzlciHUKT172CymJFKo8Xgh+44Q==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -142,8 +142,7 @@
     "temp": "0.8.3",
     "through": "^2.3.6",
     "ts-node": "^3.2.0",
-    "tslint": "^5.1.0",
-    "walk-sync": "^0.3.1"
+    "tslint": "^5.1.0"
   },
   "optionalDependencies": {
     "node-sass": "^4.3.0"

--- a/packages/@angular/cli/lib/cli/index.ts
+++ b/packages/@angular/cli/lib/cli/index.ts
@@ -1,7 +1,3 @@
-// Prevent the dependency validation from tripping because we don't import these. We need
-// it as a peer dependency of @angular/core.
-// require('zone.js')
-
 import * as path from 'path';
 
 const cli = require('../../ember-cli/lib/cli');


### PR DESCRIPTION
Minor cleanup.  `walk-sync` is no longer used.  And the `zone.js` require comment no longer applies.  It's currently used directly in https://github.com/angular/angular-cli/blob/master/packages/%40angular/cli/tasks/render-universal.ts#L16