### PR TITLE
feat(@angular/cli): enable parallel javascript minification

### DIFF
--- a/packages/@angular/cli/models/webpack-configs/production.ts
+++ b/packages/@angular/cli/models/webpack-configs/production.ts
@@ -146,6 +146,7 @@ export function getProdConfig(wco: WebpackConfigOptions) {
       // Uglify should be the last plugin as PurifyPlugin needs to be before it.
       new UglifyJSPlugin({
         sourceMap: buildOptions.sourcemaps,
+        parallel: true,
         uglifyOptions: {
           ecma: wco.supportES2015 ? 6 : 5,
           warnings: buildOptions.verbose,


### PR DESCRIPTION
Tests on a quad-core system resulted in a 10% time reduction for a production build of a stock project.  Using a large test project with multiple lazy loaded modules, a production build saw a ~50% reduction.