### PR TITLE
docs: css-preprocessors wiki page explains that inline styles must be CSS

### DIFF
--- a/docs/documentation/stories/css-preprocessors.md
+++ b/docs/documentation/stories/css-preprocessors.md
@@ -30,3 +30,5 @@ Or set the default style on an existing project:
 ```bash
 ng set defaults.styleExt scss
 ```
+
+Style strings added to the `@Component.styles` array _must be written in CSS_ because the CLI cannot apply a pre-processor to inline styles.


### PR DESCRIPTION
Cannot write them in less, sass, or stylus
See issue #8472