### PR TITLE
feat(@angular/cli): specify multiple default collections

### DIFF
--- a/packages/@angular/cli/lib/config/schema.json
+++ b/packages/@angular/cli/lib/config/schema.json
@@ -565,9 +565,17 @@
           "type": "object",
           "properties": {
             "collection": {
-              "description": "The schematics collection to use.",
+              "description": "The base schematics collection to use.",
               "type": "string",
               "default": "@schematics/angular"
+            },
+            "collections": {
+              "description": "The additional schematics collections to use.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": []
             },
             "newApp": {
               "description": "The new app schematic.",

--- a/packages/@angular/cli/tasks/init.ts
+++ b/packages/@angular/cli/tasks/init.ts
@@ -72,7 +72,6 @@ export default Task.extend({
     });
 
     const cwd = this.project.root;
-    const schematicName = CliConfig.fromGlobal().get('defaults.schematics.newApp');
     commandOptions.version = packageJson.version;
 
     const runOptions = {
@@ -80,7 +79,7 @@ export default Task.extend({
       workingDir: cwd,
       emptyHost: true,
       collectionName: commandOptions.collectionName,
-      schematicName
+      schematicName: commandOptions.schematicName
     };
 
     return schematicRunTask.run(runOptions)

--- a/packages/@angular/cli/tasks/schematic-get-options.ts
+++ b/packages/@angular/cli/tasks/schematic-get-options.ts
@@ -1,6 +1,5 @@
 const Task = require('../ember-cli/lib/models/task');
 const stringUtils = require('ember-cli-string-utils');
-import { CliConfig } from '../models/config';
 import { getCollection, getSchematic } from '../utilities/schematics';
 
 export interface SchematicGetOptions {
@@ -19,10 +18,7 @@ export interface SchematicAvailableOptions {
 
 export default Task.extend({
   run: function (options: SchematicGetOptions): Promise<SchematicAvailableOptions[]> {
-    const collectionName = options.collectionName ||
-      CliConfig.getValue('defaults.schematics.collection');
-
-    const collection = getCollection(collectionName);
+    const collection = getCollection(options.collectionName);
 
     const schematic = getSchematic(collection, options.schematicName);
 

--- a/packages/@angular/cli/utilities/schematics.ts
+++ b/packages/@angular/cli/utilities/schematics.ts
@@ -20,6 +20,7 @@ import { SchemaClassFactory } from '@ngtools/json-schema';
 import 'rxjs/add/operator/concatMap';
 import 'rxjs/add/operator/map';
 
+import { CliConfig } from '../models/config';
 const SilentError = require('silent-error');
 
 const engineHost = new NodeModulesEngineHost();
@@ -60,4 +61,26 @@ export function getCollection(collectionName: string): Collection<any, any> {
 export function getSchematic(collection: Collection<any, any>,
                              schematicName: string): Schematic<any, any> {
   return collection.createSchematic(schematicName);
+}
+
+export function getCollectionNames() {
+  const collectionNames = [CliConfig.getValue('defaults.schematics.collection')];
+  const additionalCollections = CliConfig.getValue('defaults.schematics.collections');
+  if (additionalCollections && additionalCollections.length) {
+    collectionNames.unshift(...additionalCollections);
+  }
+  return collectionNames;
+}
+
+export function getCollectionNameForSchematicName(collectionNames: string[],
+                                                  schematicName: string): string {
+  return collectionNames.filter((collectionName: string) => {
+    let schematic;
+    try {
+      schematic = getSchematic(getCollection(collectionName), schematicName);
+    } catch (e) {
+      // it's OK, schematic doesn't exists in collection
+    }
+    return !!schematic;
+  })[0];
 }

--- a/tests/collections/@custom-other/application/collection.json
+++ b/tests/collections/@custom-other/application/collection.json
@@ -1,0 +1,11 @@
+{
+  "name": "@custom-other/application",
+  "version": "0.1",
+  "schematics": {
+    "application": {
+      "factory": "./index.js",
+      "schema": "./schema.json",
+      "description": "Create an very empty application"
+    }
+  }
+}

--- a/tests/collections/@custom-other/application/index.js
+++ b/tests/collections/@custom-other/application/index.js
@@ -1,0 +1,6 @@
+const s = require('@angular-devkit/schematics');
+
+exports.default = function(options) {
+  return s.chain([s.mergeWith(s.apply(
+    s.url('./files'), [s.template({}), s.move(options.name)]))]);
+};

--- a/tests/collections/@custom-other/application/package.json
+++ b/tests/collections/@custom-other/application/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "very-empty-app",
+  "schematics": "./collection.json"
+}

--- a/tests/collections/@custom-other/application/schema.json
+++ b/tests/collections/@custom-other/application/schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "id": "VeryEmptyApp",
+  "title": "Angular Bazel Workspace Options Schema",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    }
+  },
+  "required": [
+  ]
+}


### PR DESCRIPTION
Hi 😉

This PR is related to [issue](https://github.com/angular/devkit/issues/249) posted on `angular/devkit` repository by @jeffbcross . It looks like the whole implementation of executing schematics belongs to `@angular/cli` itself so that's the reason for creating PR against this repo.

The proposed solution adds possibility to specify additional `collections` property in defaults of `schematics` in `angular-cli.json`. That way app has base collection which defaults to `@schematics/angular` (but could be overridden too) and potential to add unlimited additional collections. Execution priority is that the first collection containing requested schematics wins.
the additional `collections` property should make this solution backwards compatible.

This is initial working implementation. Review of someone who knows that part would be highly appreciated. Also some guidance on how to test this is very welcome.

Check out screenshot of working solutions.

![schema1](https://user-images.githubusercontent.com/3764868/33516222-4dd92318-d7c3-11e7-8a8f-91f8c63a8593.png)
![schema2](https://user-images.githubusercontent.com/3764868/33516223-4f1ea9fa-d7c3-11e7-954a-50349828bb9a.png)
![schema3](https://user-images.githubusercontent.com/3764868/33516224-5030f2c6-d7c3-11e7-93ee-fac2b337089e.png)
