### PR TITLE
fix(@angular/cli): allow RCs and betas for @angular/service-worker

### DIFF
--- a/packages/@angular/cli/models/webpack-configs/production.ts
+++ b/packages/@angular/cli/models/webpack-configs/production.ts
@@ -47,7 +47,7 @@ export function getProdConfig(wco: WebpackConfigOptions) {
     const swVersion = JSON.parse(swPackageJson)['version'];
 
     const isLegacySw = semver.satisfies(swVersion, OLD_SW_VERSION);
-    const isModernSw = semver.satisfies(swVersion, NEW_SW_VERSION);
+    const isModernSw = semver.gte(swVersion, NEW_SW_VERSION);
 
     if (!isLegacySw && !isModernSw) {
       throw new Error(stripIndent`

--- a/packages/@angular/cli/utilities/service-worker/index.ts
+++ b/packages/@angular/cli/utilities/service-worker/index.ts
@@ -5,7 +5,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as semver from 'semver';
 
-export const NEW_SW_VERSION = '>= 5.0.0-rc.0';
+export const NEW_SW_VERSION = '5.0.0-rc.0';
 
 class CliFilesystem implements Filesystem {
   constructor(private base: string) {}
@@ -58,7 +58,7 @@ export function usesServiceWorker(projectRoot: string): boolean {
   const swPackageJson = fs.readFileSync(`${swModule}/package.json`).toString();
   const swVersion = JSON.parse(swPackageJson)['version'];
 
-  return semver.satisfies(swVersion, NEW_SW_VERSION);
+  return semver.gte(swVersion, NEW_SW_VERSION);
 }
 
 export function augmentAppWithServiceWorker(projectRoot: string, appRoot: string,


### PR DESCRIPTION
It was not possible to use `5.1.0-rc.1` previously (see https://github.com/angular/angular-cli/issues/8247#issuecomment-348722905),
because of how `semver.satisfies()` works (see https://github.com/npm/node-semver#prerelease-tags).
This relaxes the check by using `semver.gte()`.

Related to #8247 