### PR TITLE
fix(@angular/cli): Fix replace('/') to work using Regex.

### DIFF
--- a/packages/@angular/cli/utilities/dynamic-path-parser.ts
+++ b/packages/@angular/cli/utilities/dynamic-path-parser.ts
@@ -12,11 +12,11 @@ export interface DynamicPathOptions {
 
 export function dynamicPathParser(options: DynamicPathOptions) {
   const projectRoot = options.project.root;
-  const sourceDir = options.appConfig.root.replace('/', path.sep);
+  const sourceDir = options.appConfig.root.replace(/\//g, path.sep);
 
   const p = options.appConfig.appRoot === undefined
     ? 'app'
-    : options.appConfig.appRoot.replace('/', path.sep);
+    : options.appConfig.appRoot.replace(/\//g, path.sep);
   const appRoot = path.join(sourceDir, p);
   const cwd = process.env.PWD;
 


### PR DESCRIPTION
To fix the commit message, I made another PR. This is the same as #8669 .

For usage with @nrwl/nx, which nests things more than one level deep, replace('/') is not adequate as it only replaces the first occurrence of '/'. This uses a regex instead, which enables the usage of @nrwl/nx on Windows.