### PR TITLE
fix(@angular/cli): Angular compiler CLI v5.1 allows TypeScript >= 2.5.0

### DIFF
--- a/packages/@angular/cli/upgrade/version.ts
+++ b/packages/@angular/cli/upgrade/version.ts
@@ -169,7 +169,8 @@ export class Version {
     const versionCombos = [
       { compiler: '>=2.3.1 <3.0.0', typescript: '>=2.0.2 <2.3.0' },
       { compiler: '>=4.0.0 <5.0.0', typescript: '>=2.1.0 <2.4.0' },
-      { compiler: '>=5.0.0 <6.0.0', typescript: '>=2.4.2 <2.5.0' }
+      { compiler: '>=5.0.0 <5.1.0', typescript: '>=2.4.2 <2.5.0' },
+      { compiler: '>=5.1.0 <6.0.0', typescript: '>=2.4.2 <2.6.0' }
     ];
 
     const currentCombo = versionCombos.find((combo) => satisfies(compilerVersion, combo.compiler));


### PR DESCRIPTION
Fixes #8769

This is a very naive attempt to fix #8769 . I'm open to suggestions if that's not the way to go.