### PR TITLE
fix(@ngtools/webpack): allow path mapping to resolve in JS files

### DIFF
--- a/packages/@ngtools/webpack/src/paths-plugin.ts
+++ b/packages/@ngtools/webpack/src/paths-plugin.ts
@@ -124,7 +124,7 @@ export class PathsPlugin implements Tapable {
     this._nmf.plugin('before-resolve', (request: NormalModuleFactoryRequest,
                                         callback: Callback<any>) => {
       // Only work on TypeScript issuers.
-      if (!request.contextInfo.issuer || !request.contextInfo.issuer.endsWith('.ts')) {
+      if (!request.contextInfo.issuer || !request.contextInfo.issuer.match(/\.[jt]s$/)) {
         return callback(null, request);
       }
 


### PR DESCRIPTION
Previously we filtered our path mapping resolver to only be used on typescript.
The correct behaviour is unclear; tsc does not resolve JS files, only TS. But
there is a lot of value to use path mapping to resolve JavaScript files, and
it replaces the webpack alias configuration option. Because of that value it
was decided to fix this.

Fixes #8117.