### PR TITLE
fix(@angular/cli): update to webpack-concat-plugin@2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "uglifyjs-webpack-plugin": "~1.1.2",
     "url-loader": "^0.6.2",
     "webpack": "~3.10.0",
-    "webpack-concat-plugin": "^1.4.2",
+    "webpack-concat-plugin": "^2.0.0",
     "webpack-dev-middleware": "~1.12.0",
     "webpack-dev-server": "~2.9.3",
     "webpack-merge": "^4.1.0",


### PR DESCRIPTION
Fixes #8561

To enable using es2015 in scripts.