### PR TITLE
fix(@ngtools/webpack): support AngularCompilerPlugin compilerOptions

### DIFF
--- a/packages/@ngtools/webpack/src/angular_compiler_plugin.ts
+++ b/packages/@ngtools/webpack/src/angular_compiler_plugin.ts
@@ -174,7 +174,7 @@ export class AngularCompilerPlugin implements Tapable {
     }
 
     this._rootNames = config.rootNames.concat(...this._singleFileIncludes);
-    this._compilerOptions = config.options;
+    this._compilerOptions = { ...config.options, ...options.compilerOptions };
     this._basePath = config.options.basePath;
 
     // Overwrite outDir so we can find generated files next to their .ts origin in compilerHost.


### PR DESCRIPTION
Fixes https://github.com/angular/angular-cli/issues/8430