### PR TITLE
docs(@ngtools/webpack): full file name for mainpath option

### DIFF
--- a/packages/@ngtools/webpack/README.md
+++ b/packages/@ngtools/webpack/README.md
@@ -63,7 +63,7 @@ The loader works with webpack plugin to compile your TypeScript. It's important 
 * `tsConfigPath`. The path to the `tsconfig.json` file. This is required. In your `tsconfig.json`, you can pass options to the Angular Compiler with `angularCompilerOptions`.
 * `basePath`. Optional. The root to use by the compiler to resolve file paths. By default, use the `tsConfigPath` root.
 * `entryModule`. Optional if specified in `angularCompilerOptions`. The path and classname of the main application module. This follows the format `path/to/file#ClassName`.
-* `mainPath`. Optional if `entryModule` is specified. The `main.ts` file containing the bootstrap code. The plugin will use AST to determine the `entryModule`.
+* `mainPath`. Optional if `entryModule` is specified. The `main.ts` file containing the bootstrap code. The plugin will use AST to determine the `entryModule`. NOTE: Provide path and **full file name** - like `<path>/main.ts` - not only `<path>/main` like in module loading import statements (without ".ts")!
 * `skipCodeGeneration`. Optional, defaults to false. Disable code generation and do not refactor the code to bootstrap. This replaces `templateUrl: "string"` with `template: require("string")` (and similar for styles) to allow for webpack to properly link the resources. Only available in `AotPlugin`.
 * `typeChecking`. Optional, defaults to true. Enable type checking through your application. This will slow down compilation, but show syntactic and semantic errors in webpack. Only available in `AotPlugin`.
 * `exclude`. Optional. Extra files to exclude from TypeScript compilation. Not supported with `AngularCompilerPlugin`.


### PR DESCRIPTION
To prevent others from using mainPath option with file name like in a "module import" (without extension), so they won't get "Cannot read type ... errors".