### PR TITLE
fix(@ngtools/webpack): set output locale for ng xi18n

### DIFF
--- a/packages/@ngtools/webpack/src/angular_compiler_plugin.ts
+++ b/packages/@ngtools/webpack/src/angular_compiler_plugin.ts
@@ -227,6 +227,7 @@ export class AngularCompilerPlugin implements Tapable {
     }
     if (options.locale !== undefined) {
       this._compilerOptions.i18nInLocale = options.locale;
+      this._compilerOptions.i18nOutLocale = options.locale;
       this._normalizedLocale = this._validateLocale(options.locale);
     }
     if (options.missingTranslation !== undefined) {

--- a/tests/e2e/tests/i18n/extract-locale.ts
+++ b/tests/e2e/tests/i18n/extract-locale.ts
@@ -1,9 +1,6 @@
 import { join } from 'path';
 import { ng } from '../../utils/process';
-import {
-  expectFileToExist, writeFile,
-  expectFileToMatch
-} from '../../utils/fs';
+import { writeFile, expectFileToMatch } from '../../utils/fs';
 
 
 export default function() {
@@ -14,8 +11,7 @@ export default function() {
     .then(() => ng('xi18n', '--locale', 'fr'))
     .then((output) => {
       if (!output.stdout.match(/starting from Angular v4/)) {
-        expectFileToExist(join('src', 'messages.xlf'));
-        expectFileToMatch(join('src', 'messages.xlf'), /source-language="fr"/);
+        return expectFileToMatch(join('src', 'messages.xlf'), 'source-language="fr"');
       }
     });
 }

--- a/tests/e2e/tests/i18n/extract-outfile.ts
+++ b/tests/e2e/tests/i18n/extract-outfile.ts
@@ -1,9 +1,6 @@
 import {join} from 'path';
 import {ng} from '../../utils/process';
-import {
-  expectFileToExist, writeFile,
-  expectFileToMatch
-} from '../../utils/fs';
+import { writeFile, expectFileToMatch } from '../../utils/fs';
 
 
 export default function() {
@@ -14,8 +11,7 @@ export default function() {
     .then(() => ng('xi18n', '--out-file', 'messages.fr.xlf'))
     .then((output) => {
       if (!output.stdout.match(/starting from Angular v4/)) {
-        expectFileToExist(join('src', 'messages.fr.xlf'));
-        expectFileToMatch(join('src', 'messages.fr.xlf'), /Hello world/);
+        return expectFileToMatch(join('src', 'messages.fr.xlf'), 'Hello world');
       }
     });
 }


### PR DESCRIPTION
The output locale was not defined when extracting the files using `ng xi18n`, which means that the locale was not set in the extracted file.
We had a test for that, but the test was not working... Fixed it along with another test that had the same problem.

Fixes #8680