### PR TITLE
refactor(check-port): return found port

### DIFF
--- a/packages/@angular/cli/utilities/check-port.ts
+++ b/packages/@angular/cli/utilities/check-port.ts
@@ -1,22 +1,19 @@
 import * as denodeify from 'denodeify';
 
-const SilentError = require('silent-error');
 const PortFinder = require('portfinder');
 const getPort = denodeify<{host: string, port: number}, number>(PortFinder.getPort);
 
 export function checkPort(port: number, host: string, basePort = 49152): Promise<number> {
   PortFinder.basePort = basePort;
+
   return getPort({ port, host })
     .then(foundPort => {
 
-      // If the port isn't available and we weren't looking for any port, throw error.
+      // If the port isn't available we will simply warn the user about it
       if (port !== foundPort && port !== 0) {
-        throw new SilentError(
-          `Port ${port} is already in use. Use '--port' to specify a different port.`
-        );
+        console.log( `Port ${port} is already in use. Using port ${foundPort} instead` );
       }
 
-      // Otherwise, our found port is good.
       return foundPort;
     });
 }


### PR DESCRIPTION
This will allow the angular cli to simply run on a different port in case the current port is occupied. This is super way more useful than receiving a warning from the `angular-cli` the port is in use.