### PR TITLE
fix(@angular/cli): disable progress when running Karma directly outside TTY

### DIFF
--- a/packages/@angular/cli/plugins/karma.ts
+++ b/packages/@angular/cli/plugins/karma.ts
@@ -53,7 +53,7 @@ const init: any = (config: any, emitter: any, customFileHandlers: any) => {
     environment: 'dev',
     codeCoverage: false,
     sourcemaps: true,
-    progress: true,
+    progress: process.stdout.isTTY === true,
     preserveSymlinks: false,
   }, config.angularCli);
 


### PR DESCRIPTION
Fixes a shortcoming of #8501. Apply same logic for setting --progress
flag when running Karma directly (as opposed to running it using
`ng test` command).

Fixes #8148

See https://github.com/angular/angular-cli/issues/8148#issuecomment-351735666 for more context.

Tested manually using:

```
$ ./node_modules/.bin/karma start # progress is printed
$ ./node_modules/.bin/karma start | cat # no progress is printed
```