### PR TITLE
fix(@ngtools/webpack): suppress warnings for overwriting files in tsc

### DIFF
--- a/packages/@ngtools/webpack/src/angular_compiler_plugin.ts
+++ b/packages/@ngtools/webpack/src/angular_compiler_plugin.ts
@@ -181,6 +181,7 @@ export class AngularCompilerPlugin implements Tapable {
 
     // Overwrite outDir so we can find generated files next to their .ts origin in compilerHost.
     this._compilerOptions.outDir = '';
+    this._compilerOptions.suppressOutputPathCheck = true;
 
     // Default plugin sourceMap to compiler options setting.
     if (!options.hasOwnProperty('sourceMap')) {

--- a/tests/e2e/tests/build/allow-js.ts
+++ b/tests/e2e/tests/build/allow-js.ts
@@ -1,0 +1,18 @@
+import { ng } from '../../utils/process';
+import { updateTsConfig } from '../../utils/project';
+import { appendToFile, writeFile } from '../../utils/fs';
+
+export default async function() {
+  await writeFile('src/my-js-file.js', 'console.log(1); export const a = 2;');
+  await appendToFile('src/main.ts', `
+    import { a } from './my-js-file';
+    console.log(a);
+  `);
+
+  await updateTsConfig(json => {
+    json['compilerOptions'].allowJs = true;
+  });
+
+  await ng('build');
+  await ng('build', '--aot');
+}


### PR DESCRIPTION
Since we're using a virtual filesystem, overwriting files by tsc does
not affect actual files on the filesystem. This allows us to support
allowJs without changing any configuration quirks.

Fixes https://github.com/angular/angular/issues/21080
Might help with #8371
Fixes #8885