### PR TITLE
--inline-asset-max-size Maximum size (in Kb) of assets to be inlined

### DIFF
--- a/docs/documentation/build.md
+++ b/docs/documentation/build.md
@@ -73,15 +73,15 @@ dead code elimination via UglifyJS.
 Both `--dev`/`--target=development` and `--prod`/`--target=production` are 'meta' flags, that set other flags.
 If you do not specify either you will get the `--dev` defaults.
 
-Flag                | `--dev` | `--prod`
----                 | ---     | ---
-`--aot`             | `false` | `true`
-`--environment`     | `dev`   | `prod`
-`--output-hashing`  | `media` | `all`
-`--sourcemaps`      | `true`  | `false`
-`--extract-css`     | `false` | `true`
-`--named-chunks`    | `true`  | `false`
-`--build-optimizer` | `false` | `true` with AOT and Angular 5
+Flag                      | `--dev` | `--prod`
+---                       | ---     | ---
+`--aot`                   | `false` | `true`
+`--environment`           | `dev`   | `prod`
+`--output-hashing`        | `media` | `all`
+`--sourcemaps`            | `true`  | `false`
+`--extract-css`           | `false` | `true`
+`--named-chunks`          | `true`  | `false`
+`--build-optimizer`       | `false` | `true` with AOT and Angular 5
 
 `--prod` also sets the following non-flaggable settings:
 - Adds service worker if configured in `.angular-cli.json`.
@@ -100,7 +100,11 @@ code.
 ### CSS resources
 
 Resources in CSS, such as images and fonts, will be copied over automatically as part of a build.
-If a resource is less than 10kb it will also be inlined.
+If a resource is less than 10kb it will also be inlined by default.
+
+By using flaf `--inline-asset-max-size` it's possible to define the max size of the
+assets that have to be inlined. Negative values will result in no assets to be inlined.
+
 
 You'll see these resources be outputted and fingerprinted at the root of `dist/`.
 
@@ -117,6 +121,16 @@ On `--prod` builds a service worker manifest will be created and loaded automati
 Remember to disable the service worker while developing to avoid stale code.
 
 Note: service worker support is experimental and subject to change.
+
+### ES2015 support
+
+To build in ES2015 mode, edit `./tsconfig.json` to use `"target": "es2015"` (instead of `es5`).
+
+This will cause application TypeScript and Uglify be output as ES2015, and third party libraries
+to be loaded through the `es2015` entry in `package.json` if available.
+
+Be aware that JIT does not support ES2015 and so you should build/serve your app with `--aot`.
+See https://github.com/angular/angular-cli/issues/7797 for details.
 
 ## Options
 <details>
@@ -176,6 +190,19 @@ Note: service worker support is experimental and subject to change.
   </p>
   <p>
     Extract css from global styles onto css files instead of js ones.
+  </p>
+</details>
+
+<details>
+  <summary>inline-asset-max-size</summary>
+  <p>
+    <code>--inline-asset-max-size</code>
+  </p>
+  <p>
+    Maximum size (in Kb) of assets to be inlined
+  </p>
+  <p>
+    Values: <code>-1</code> - must not inline any assets, <code>positive integer</code> - size in Kb of assets to inline
   </p>
 </details>
 

--- a/packages/@angular/cli/models/build-options.ts
+++ b/packages/@angular/cli/models/build-options.ts
@@ -18,6 +18,7 @@ export interface BuildOptions {
   locale?: string;
   missingTranslation?: string;
   extractCss?: boolean;
+  inlineAssetMaxSize?: number;
   bundleDependencies?: 'none' | 'all';
   watch?: boolean;
   outputHashing?: string;

--- a/tests/e2e/tests/build/styles/inline-asset-max-size.ts
+++ b/tests/e2e/tests/build/styles/inline-asset-max-size.ts
@@ -1,0 +1,51 @@
+import { ng } from '../../../utils/process';
+import {
+  expectFileToMatch,
+  expectFileMatchToExist,
+  writeMultipleFiles
+} from '../../../utils/fs';
+import { copyProjectAsset } from '../../../utils/assets';
+import { expectToFail } from '../../../utils/utils';
+
+const imgSvg = `
+  <svg width="100" height="100" xmlns="http://www.w3.org/2000/svg">
+    <circle cx="50" cy="50" r="40" stroke="green" stroke-width="4" fill="yellow" />
+  </svg>
+`;
+
+export default function () {
+  return Promise.resolve()
+    .then(() => writeMultipleFiles({
+      'src/styles.css': `
+        h1 { background: url('./assets/large.png'); }
+        h2 { background: url('./assets/small.svg'); }
+        p  { background: url('./assets/small-id.svg#testID'); }
+      `,
+      'src/app/app.component.css': `
+        h3 { background: url('../assets/small.svg'); }
+        h4 { background: url('../assets/large.png'); }
+      `,
+      'src/assets/small.svg': imgSvg,
+      'src/assets/small-id.svg': imgSvg
+    }))
+    .then(() => copyProjectAsset('images/spectrum.png', './assets/large.png'))
+    .then(() => ng('build', '--extract-css', '--inline-asset-max-size=-1', '--aot'))
+    // Check paths are correctly generated.
+    .then(() => expectFileToMatch('dist/styles.bundle.css',
+      /url\([\'"]?large\.[0-9a-f]{20}\.png[\'"]?\)/))
+    .then(() => expectFileToMatch('dist/styles.bundle.css',
+      /url\([\'"]?small\.[0-9a-f]{20}\.svg[\'"]?\)/))
+    .then(() => expectFileToMatch('dist/styles.bundle.css',
+      /url\([\'"]?small-id\.[0-9a-f]{20}\.svg#testID[\'"]?\)/))
+    .then(() => expectFileToMatch('dist/main.bundle.js',
+      /url\([\'"]?small\.[0-9a-f]{20}\.svg[\'"]?\)/))
+    .then(() => expectFileToMatch('dist/main.bundle.js',
+      /url\([\'"]?large\.[0-9a-f]{20}\.png[\'"]?\)/))
+    // Check if no inline images have been generated
+    .then(() => expectToFail(() => expectFileToMatch('dist/styles.bundle.css',
+      /url\(\\?[\'"]data:image\/svg\+xml/)))
+    // Check files are correctly created.
+    .then(() => expectFileMatchToExist('./dist', /large\.[0-9a-f]{20}\.png/))
+    .then(() => expectFileMatchToExist('./dist', /small\.[0-9a-f]{20}\.svg/))
+    .then(() => expectFileMatchToExist('./dist', /small-id\.[0-9a-f]{20}\.svg/));
+}


### PR DESCRIPTION
When building an Angular app with Angular CLI, resources in CSS, e.g. svg images, less than 10kb in size will be inlined.

This sounds like a good concept from the performance point of view, however, it violates very strict Content Security Policies in an app, which has to satisfy stricter security requirements. https://github.com/angular/angular-cli/issues/8945

```
data: Allows data: URIs to be used as a content source. This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts.
```
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/img-src


Instead of ejecting webpack, this PR adds a new build flag
`--inline-asset-max-size` that instructs Angular CLI NOT to inline any assets, e.g. images, in CSS due to strict CSP requirements.

* Added build flag `--inline-asset-max-size` - Maximum size (in Kb) of assets to be inlined
* Positive integer defines the max number of assets to be inlined
* Negative integer - no assets to be inlined.
