### PR TITLE
feat(@angular/cli): add extends app from another apps by name

### DIFF
--- a/docs/documentation/angular-cli.md
+++ b/docs/documentation/angular-cli.md
@@ -11,6 +11,7 @@
 
 - **apps** (`array`): Properties of the different applications in this project.
   - *name* (`string`): Name of the app.
+  - *extends* (`string|array`): Can be used to extend from another apps by name.
   - *root* (`string`): The root directory of the app.
   - *outDir* (`string`): The output directory for build results. Default is `dist/`.
   - *assets* (`array`): List of application assets.

--- a/docs/documentation/stories/multiple-apps.md
+++ b/docs/documentation/stories/multiple-apps.md
@@ -64,3 +64,78 @@ You can also add the `name` property to the app object in `apps` array and then 
 ```
 To serve application by name `ng serve --app=app1` or `ng serve --app app1`.
 
+### Apps inheritance 
+
+If you use multiple applications in the same project so that you do not copy the common configuration for all applications, 
+you can use property `extends` to inherit the configuration from common application:
+
+**Single inheritance:**
+```
+"apps": [
+  {
+    "name": "base",
+    "root": "src",
+    "test": "test.ts",
+    "tsconfig": "tsconfig.app.json",
+    "testTsconfig": "tsconfig.spec.json",
+    ...
+  },
+  {
+    "name": "app1",
+    "extends": "base",
+    "outDir": "dist-app1",
+    "prefix": "app1",
+    "assets": [
+      "assets/app1"
+    ]
+  },
+  {
+    "name": "app2",
+    "extends": "base",
+    "outDir": "dist-app2",
+    "prefix": "app2",
+    "assets": [
+      "assets/app2"
+    ]
+  },
+  ...
+],
+
+```
+
+
+**Multiple inheritance:**
+
+```
+"apps": [
+  {
+    "name": "base",
+    "root": "src",
+    "test": "test.ts",
+    "tsconfig": "tsconfig.app.json",
+    "testTsconfig": "tsconfig.spec.json",
+    ...
+  },
+  {
+    "name": "app1",
+    "outDir": "dist",
+    "prefix": "app1",
+    "index.html"
+    "assets": [
+      "assets/app1"
+    ],
+    ...
+  },
+  {
+    "name": "app2",
+    "extends": ["base", "app1"]
+    "outDir": "dist-app2",
+    "prefix": "app2",
+    "assets": [
+      "assets/app2"
+    ]
+  },
+  ...
+],
+
+```

--- a/packages/@angular/cli/lib/config/schema.json
+++ b/packages/@angular/cli/lib/config/schema.json
@@ -33,6 +33,21 @@
             "type": "string",
             "description": "Name of the app."
           },
+          "extends": {
+            "description": "Can be used to extend from another apps by name",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ],
+            "default": []
+          },
           "appRoot": {
             "type": "string",
             "description": "Directory where app files are placed.",


### PR DESCRIPTION
This feature let you use inheritance of the application configuration.
```
"apps": [
  {
    "name": "base",
    "root": "src",
    "test": "test.ts",
    "tsconfig": "tsconfig.app.json",
    "testTsconfig": "tsconfig.spec.json",
    ...
  },
  {
    "name": "app1",
    "extends": "base",
    "outDir": "dist-app1",
    "prefix": "app1",
    "assets": [
      "assets/app1"
    ]
  },
  {
    "name": "app2",
    "extends": "base",
    "outDir": "dist-app2",
    "prefix": "app2",
    "assets": [
      "assets/app2"
    ]
  },
  ....
],
```
see #6646 
