### PR TITLE
chore(package): Set uglify plugin minimum to 1.1.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -930,9 +930,9 @@
       "integrity": "sha1-TJQj6i0lLCcMQbK97+/5u2tiwGo="
     },
     "cacache": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.0.tgz",
-      "integrity": "sha512-s9h6I9NY3KcBjfuS28K6XNmrv/HNFSzlpVD6eYMXugZg3Y8jjI1lUzTeUMa0oKByCDtHfsIy5Ec7KgWRnC5gtg==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.1.tgz",
+      "integrity": "sha512-dRHYcs9LvG9cHgdPzjiI+/eS7e1xRhULrcyOx04RZQsszNJXU2SL9CyG60yLnge282Qq5nwTv+ieK2fH+WPZmA==",
       "requires": {
         "bluebird": "3.5.1",
         "chownr": "1.0.1",
@@ -2888,7 +2888,7 @@
       "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
       "requires": {
         "commondir": "1.0.1",
-        "make-dir": "1.0.0",
+        "make-dir": "1.1.0",
         "pkg-dir": "2.0.0"
       }
     },
@@ -5321,11 +5321,18 @@
       }
     },
     "make-dir": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.0.0.tgz",
-      "integrity": "sha1-l6ARdR6R3YfPre9Ygy67BJNt6Xg=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.1.0.tgz",
+      "integrity": "sha512-0Pkui4wLJ7rxvmfUvs87skoEaxmu0hCUApF8nonzpl7q//FWp9zu8W61Scz4sd/kUiqDxvUhtoam2efDyiBzcA==",
       "requires": {
-        "pify": "2.3.0"
+        "pify": "3.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+        }
       }
     },
     "make-error": {
@@ -5552,9 +5559,9 @@
         "flush-write-stream": "1.0.2",
         "from2": "2.3.0",
         "parallel-transform": "1.1.0",
-        "pump": "1.0.2",
+        "pump": "1.0.3",
         "pumpify": "1.3.5",
-        "stream-each": "1.2.0",
+        "stream-each": "1.2.2",
         "through2": "2.0.3"
       }
     },
@@ -7118,9 +7125,9 @@
       }
     },
     "pump": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.2.tgz",
-      "integrity": "sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
+      "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
       "requires": {
         "end-of-stream": "1.4.0",
         "once": "1.4.0"
@@ -7133,7 +7140,7 @@
       "requires": {
         "duplexify": "3.5.1",
         "inherits": "2.0.3",
-        "pump": "1.0.2"
+        "pump": "1.0.3"
       }
     },
     "punycode": {
@@ -7747,6 +7754,11 @@
         }
       }
     },
+    "serialize-javascript": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.4.0.tgz",
+      "integrity": "sha1-fJWFFNtqwkQ6irwGLcn3iGp/YAU="
+    },
     "serializerr": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/serializerr/-/serializerr-1.0.3.tgz",
@@ -8172,9 +8184,9 @@
       }
     },
     "stream-each": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.0.tgz",
-      "integrity": "sha1-HpXUdXP1gNgU3A/4zQ9m8c5TyZE=",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz",
+      "integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
       "requires": {
         "end-of-stream": "1.4.0",
         "stream-shift": "1.0.0"
@@ -8747,23 +8759,24 @@
       "optional": true
     },
     "uglifyjs-webpack-plugin": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.1.2.tgz",
-      "integrity": "sha512-k07cmJTj+8vZMSc3BaQ9uW7qVl2MqDts4ti4KaNACXEcXSw2vQM2S8olSk/CODxvcSFGvUHzNSqA8JQlhgUJPw==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.1.5.tgz",
+      "integrity": "sha512-YBGc9G7dv12Vjx8vUQs54DZgAXVf04LlG6dNNiEbTZjL3PbUqiY4uPB9Kv+fUJaqRskEGva/lS7sh08yJr7jnA==",
       "requires": {
-        "cacache": "10.0.0",
+        "cacache": "10.0.1",
         "find-cache-dir": "1.0.0",
         "schema-utils": "0.3.0",
+        "serialize-javascript": "1.4.0",
         "source-map": "0.6.1",
-        "uglify-es": "3.2.0",
+        "uglify-es": "3.2.2",
         "webpack-sources": "1.0.1",
-        "worker-farm": "1.4.1"
+        "worker-farm": "1.5.2"
       },
       "dependencies": {
         "commander": {
-          "version": "2.12.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.1.tgz",
-          "integrity": "sha512-PCNLExLlI5HiPdaJs4pMXwOTHkSCpNQ1QJH9ykZLKtKEyKu3p9HgmH5l97vM8c0IUz6d54l+xEu2GG9yuYrFzA=="
+          "version": "2.12.2",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+          "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA=="
         },
         "source-map": {
           "version": "0.6.1",
@@ -8771,11 +8784,11 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "uglify-es": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.2.0.tgz",
-          "integrity": "sha512-eD4rjK4o6rzrvE1SMZJLQFEVMnWRUyIu6phJ0BXk5TIthMmP5B4QP0HI8o3bkQB5wf1N4WHA0leZAQyQBAd+Jg==",
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.2.2.tgz",
+          "integrity": "sha512-l+s5VLzFwGJfS+fbqaGf/Dfwo1MF13jLOF2ekL0PytzqEqQ6cVppvHf4jquqFok+35USMpKjqkYxy6pQyUcuug==",
           "requires": {
-            "commander": "2.12.1",
+            "commander": "2.12.2",
             "source-map": "0.6.1"
           }
         }
@@ -9468,9 +9481,9 @@
       "dev": true
     },
     "worker-farm": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.4.1.tgz",
-      "integrity": "sha512-tgFAtgOYLPutkAyzgpS6VJFL5HY+0ui1Tvua+fITgz8ByaJTMFGtazR6xxQfwfiAcbwE+2fLG/K49wc2TfwCNw==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.5.2.tgz",
+      "integrity": "sha512-XxiQ9kZN5n6mmnW+mFJ+wXjNNI/Nx4DIdaAKLX1Bn6LYBWlN/zaBhu34DQYPZ1AJobQuu67S2OfDdNSVULvXkQ==",
       "requires": {
         "errno": "0.1.4",
         "xtend": "4.0.1"

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "stylus-loader": "^3.0.1",
     "tree-kill": "^1.0.0",
     "typescript": "~2.4.2",
-    "uglifyjs-webpack-plugin": "~1.1.2",
+    "uglifyjs-webpack-plugin": "^1.1.5",
     "url-loader": "^0.6.2",
     "webpack": "~3.10.0",
     "webpack-dev-middleware": "~1.12.0",


### PR DESCRIPTION
 - Pins uglify-es dependency version on the Webpack side for #8997 


Fixes #8997