### PR TITLE
docs(@ngtools/webpack): update `skipCodeGeneration` section

### DIFF
--- a/packages/@ngtools/webpack/README.md
+++ b/packages/@ngtools/webpack/README.md
@@ -64,7 +64,7 @@ The loader works with webpack plugin to compile your TypeScript. It's important 
 * `basePath`. Optional. The root to use by the compiler to resolve file paths. By default, use the `tsConfigPath` root.
 * `entryModule`. Optional if specified in `angularCompilerOptions`. The path and classname of the main application module. This follows the format `path/to/file#ClassName`.
 * `mainPath`. Optional if `entryModule` is specified. The `main.ts` file containing the bootstrap code. The plugin will use AST to determine the `entryModule`.
-* `skipCodeGeneration`. Optional, defaults to false. Disable code generation and do not refactor the code to bootstrap. This replaces `templateUrl: "string"` with `template: require("string")` (and similar for styles) to allow for webpack to properly link the resources. Only available in `AotPlugin`.
+* `skipCodeGeneration`. Optional, defaults to false. Disable code generation and do not refactor the code to bootstrap. This replaces `templateUrl: "string"` with `template: require("string")` (and similar for styles) to allow for webpack to properly link the resources.
 * `typeChecking`. Optional, defaults to true. Enable type checking through your application. This will slow down compilation, but show syntactic and semantic errors in webpack. Only available in `AotPlugin`.
 * `exclude`. Optional. Extra files to exclude from TypeScript compilation. Not supported with `AngularCompilerPlugin`.
 * `sourceMap`. Optional. Include sourcemaps.


### PR DESCRIPTION
Seems like it's still widely used in https://github.com/angular/angular-cli/blob/master/packages/%40ngtools/webpack/src/angular_compiler_plugin.ts