### PR TITLE
fix(@ngtools/webpack): redo #7619 in angular_compiler_plugin

### DIFF
--- a/packages/@ngtools/webpack/src/angular_compiler_plugin.ts
+++ b/packages/@ngtools/webpack/src/angular_compiler_plugin.ts
@@ -601,9 +601,9 @@ export class AngularCompilerPlugin implements Tapable {
       // Wait for the plugin to be done when requesting `.ts` files directly (entry points), or
       // when the issuer is a `.ts` or `.ngfactory.js` file.
       compiler.resolvers.normal.plugin('before-resolve', (request: any, cb: () => void) => {
-        if (request.request.endsWith('.ts')
-          || (request.context.issuer && /\.ts|ngfactory\.js$/.test(request.context.issuer))) {
-          this.done!.then(() => cb(), () => cb());
+        if (this.done && (request.request.endsWith('.ts')
+          || (request.context.issuer && /\.ts|ngfactory\.js$/.test(request.context.issuer)))) {
+          this.done.then(() => cb(), () => cb());
         } else {
           cb();
         }


### PR DESCRIPTION
The issue fixed in #7619, is still in [`angular_compiler_plugin.ts`](https://github.com/angular/angular-cli/blob/5eea7faf5a320e5f18c7dbef79105046819e32ea/packages/%40ngtools/webpack/src/angular_compiler_plugin.ts#L604) 
With my current webpack production setup I keep hitting this problem, that `this.done` is not defined. 
As a quick fix I was able to just edit the file in the node_modules. However as a permanent solution I would like this PR to be merged.