### PR TITLE
docs(serve): fix webpack links

### DIFF
--- a/docs/documentation/stories/configure-hmr.md
+++ b/docs/documentation/stories/configure-hmr.md
@@ -3,7 +3,7 @@
 Hot Module Replacement (HMR) is a WebPack feature to update code in a running app without rebuilding it.
 This results in faster updates and less full page-reloads.
 
-You can read more about HMR by visiting [this page](https://webpack.github.io/docs/hot-module-replacement.html).
+You can read more about HMR by visiting [this page](https://webpack.js.org/guides/hot-module-replacement).
 
 In order to get HMR working with Angular CLI we first need to add a new environment and enable it.
 

--- a/docs/documentation/stories/proxy.md
+++ b/docs/documentation/stories/proxy.md
@@ -1,6 +1,6 @@
 # Proxy To Backend
 
-Using the [proxying support](https://webpack.github.io/docs/webpack-dev-server.html#proxy) in webpack's dev server we can highjack certain URLs and send them to a backend server.
+Using the [proxying support](https://webpack.js.org/configuration/dev-server/#devserver-proxy) in webpack's dev server we can highjack certain URLs and send them to a backend server.
 We do this by passing a file to `--proxy-config`
 
 Say we have a server running on `http://localhost:3000/api` and we want all calls to `http://localhost:4200/api` to go to that server.
@@ -16,7 +16,7 @@ We create a file next to our project's `package.json` called `proxy.conf.json` w
 }
 ```
 
-You can read more about what options are available [here](https://webpack.github.io/docs/webpack-dev-server.html#proxy).
+You can read more about what options are available [here](https://webpack.js.org/configuration/dev-server/#devserver-proxy).
 
 We can then edit the `package.json` file's start script to be
 

--- a/packages/@angular/cli/tasks/serve.ts
+++ b/packages/@angular/cli/tasks/serve.ts
@@ -108,12 +108,12 @@ export default Task.extend({
 
     if (serveTaskOptions.liveReload) {
       // This allows for live reload of page when changes are made to repo.
-      // https://webpack.github.io/docs/webpack-dev-server.html#inline-mode
+      // https://webpack.js.org/configuration/dev-server/#devserver-inline
       let entryPoints = [
         `webpack-dev-server/client?${clientAddress}`
       ];
       if (serveTaskOptions.hmr) {
-        const webpackHmrLink = 'https://webpack.github.io/docs/hot-module-replacement.html';
+        const webpackHmrLink = 'https://webpack.js.org/guides/hot-module-replacement';
 
         ui.writeLine(oneLine`
           ${yellow('NOTICE')} Hot Module Replacement (HMR) is enabled for the dev server.


### PR DESCRIPTION
Fix some links to old webpack’s website that doesn’t work anymore.