### PR TITLE
Cleanup module resolution

### DIFF
--- a/packages/@angular/cli/models/webpack-configs/common.ts
+++ b/packages/@angular/cli/models/webpack-configs/common.ts
@@ -177,17 +177,23 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
     alias = rxPaths(nodeModules);
   } catch (e) { }
 
+  // Allow loaders to be in a node_modules nested inside the CLI package
+  const loaderNodeModules = ['node_modules'];
+  const potentialNodeModules = path.join(__dirname, '..', '..', 'node_modules');
+  if (isDirectory(potentialNodeModules)) {
+    loaderNodeModules.push(potentialNodeModules);
+  }
+
   return {
     resolve: {
       extensions: ['.ts', '.js'],
-      modules: ['node_modules', nodeModules],
       symlinks: !buildOptions.preserveSymlinks,
       alias
     },
     resolveLoader: {
-      modules: [nodeModules, 'node_modules']
+      modules: loaderNodeModules
     },
-    context: __dirname,
+    context: projectRoot,
     entry: entryPoints,
     output: {
       path: path.resolve(buildOptions.outputPath),

--- a/packages/@angular/cli/tasks/eject.ts
+++ b/packages/@angular/cli/tasks/eject.ts
@@ -274,7 +274,6 @@ class JsonWebpackSerializer {
   private _resolveReplacer(value: any) {
     this.variableImports['rxjs/_esm5/path-mapping'] = 'rxPaths';
     return Object.assign({}, value, {
-      modules: value.modules.map((x: string) => './' + path.relative(this._root, x)),
       alias: this._escape('rxPaths()')
     });
   }

--- a/packages/@ngtools/webpack/src/angular_compiler_plugin.ts
+++ b/packages/@ngtools/webpack/src/angular_compiler_plugin.ts
@@ -10,7 +10,7 @@ const treeKill = require('tree-kill');
 import { WebpackResourceLoader } from './resource_loader';
 import { WebpackCompilerHost } from './compiler_host';
 import { Tapable } from './webpack';
-import { PathsPlugin } from './paths-plugin';
+import { resolveWithPaths } from './paths-plugin';
 import { findLazyRoutes, LazyRouteMap } from './lazy_routes';
 import {
   VirtualFileSystemDecorator,
@@ -258,9 +258,6 @@ export class AngularCompilerPlugin implements Tapable {
       }
     }
 
-    // Use an identity function as all our paths are absolute already.
-    this._moduleResolutionCache = ts.createModuleResolutionCache(this._basePath, x => x);
-
     // Resolve mainPath if provided.
     if (options.mainPath) {
       this._mainPath = this._compilerHost.resolve(options.mainPath);
@@ -313,6 +310,9 @@ export class AngularCompilerPlugin implements Tapable {
         if (this._forkTypeChecker && !this._firstRun) {
           this._updateForkedTypeChecker(this._rootNames, this._getChangedCompilationFiles());
         }
+
+         // Use an identity function as all our paths are absolute already.
+        this._moduleResolutionCache = ts.createModuleResolutionCache(this._basePath, x => x);
 
         if (this._JitMode) {
           // Create the TypeScript program.
@@ -611,12 +611,15 @@ export class AngularCompilerPlugin implements Tapable {
     });
 
     compiler.plugin('normal-module-factory', (nmf: any) => {
-      compiler.resolvers.normal.apply(new PathsPlugin({
-        nmf,
-        tsConfigPath: this._tsConfigPath,
-        compilerOptions: this._compilerOptions,
-        compilerHost: this._compilerHost
-      }));
+      nmf.plugin('before-resolve', (request: any, callback: any) => {
+        resolveWithPaths(
+          request,
+          callback,
+          this._compilerOptions,
+          this._compilerHost,
+          this._moduleResolutionCache,
+        );
+      });
     });
   }
 


### PR DESCRIPTION
This removes some unused code from the paths plugin and uses a cache if available.  Also simplifies the module resolve section of the webpack config.  The project root can be used as the webpack configuration context again.