### PR TITLE
fix(@ngtools/webpack): update engine to node 6.9 minumum

### DIFF
--- a/packages/@ngtools/webpack/package.json
+++ b/packages/@ngtools/webpack/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/angular/angular-cli/tree/master/packages/@ngtools/webpack",
   "engines": {
-    "node": ">= 4.1.0",
+    "node": ">= 6.9.0",
     "npm": ">= 3.0.0"
   },
   "dependencies": {


### PR DESCRIPTION
Fix #6608