### PR TITLE
fix(@angular/cli): allow TS 2.6 for Angular >= 5.2

### DIFF
--- a/packages/@angular/cli/upgrade/version.ts
+++ b/packages/@angular/cli/upgrade/version.ts
@@ -170,7 +170,8 @@ export class Version {
       { compiler: '>=2.3.1 <3.0.0', typescript: '>=2.0.2 <2.3.0' },
       { compiler: '>=4.0.0 <5.0.0', typescript: '>=2.1.0 <2.4.0' },
       { compiler: '>=5.0.0 <5.1.0', typescript: '>=2.4.2 <2.5.0' },
-      { compiler: '>=5.1.0 <6.0.0', typescript: '>=2.4.2 <2.6.0' }
+      { compiler: '>=5.1.0 <5.2.0', typescript: '>=2.4.2 <2.6.0' },
+      { compiler: '>=5.2.0 <6.0.0', typescript: '>=2.4.2 <2.7.0' }
     ];
 
     const currentCombo = versionCombos.find((combo) => satisfies(compilerVersion, combo.compiler));

--- a/tests/e2e/tests/misc/typescript-warning.ts
+++ b/tests/e2e/tests/misc/typescript-warning.ts
@@ -3,9 +3,8 @@ import { getGlobalVariable } from '../../utils/env';
 
 
 export default function () {
-  // typescript@2.6 is not part of the officially supported range in latest stable.
-  // Update as needed.
-  let unsupportedTsVersion = '2.6';
+  // typescript@2.7.0-dev.20180104 is not part of the officially supported range in latest stable.
+  let unsupportedTsVersion = '2.7.0-dev.20180104';
 
   // Skip this test in Angular 2/4.
   if (getGlobalVariable('argv').ng2 || getGlobalVariable('argv').ng4) {


### PR DESCRIPTION
Although it is not (yet?) mentioned in the [changelog](https://github.com/angular/angular/blob/master/CHANGELOG.md#520-rc0-2018-01-04) looks like 5.2.0-rc.0 added support for TypeScript 2.6 (https://github.com/angular/angular/commit/83d207d0a795bc1945c4661cb5ab73d2e671c1ce). Opening a PR, so CLI won't show a warning once 5.2.0 stable goes live.

I tried to serve and build my project with TypeScript 2.6.2 + CLI 1.6.3 and it worked fine. So probably no other changes on the CLI side are needed.

Fixes #9162