### PR TITLE
docs(@angular/cli): update links to generate blueprints

### DIFF
--- a/docs/documentation/generate.md
+++ b/docs/documentation/generate.md
@@ -6,15 +6,15 @@
 `ng generate [name]` generates the specified blueprint
 
 ## Available blueprints:
- - [class](generate/class)
- - [component](generate/component)
- - [directive](generate/directive)
- - [enum](generate/enum)
- - [guard](generate/guard)
- - [interface](generate/interface)
- - [module](generate/module)
- - [pipe](generate/pipe)
- - [service](generate/service)
+ - [class](generate/class.md)
+ - [component](generate/component.md)
+ - [directive](generate/directive.md)
+ - [enum](generate/enum.md)
+ - [guard](generate/guard.md)
+ - [interface](generate/interface.md)
+ - [module](generate/module.md)
+ - [pipe](generate/pipe.md)
+ - [service](generate/service.md)
 
 ## Options
 <details>


### PR DESCRIPTION
[docs/documentation/generate.md](https://github.com/angular/angular-cli/blob/master/docs/documentation/generate.md) links to blueprints results in page not found. 