### PR TITLE
fix(@ngtools/webpack): remove message handler on main process 

### DIFF
--- a/packages/@ngtools/webpack/src/angular_compiler_plugin.ts
+++ b/packages/@ngtools/webpack/src/angular_compiler_plugin.ts
@@ -27,7 +27,7 @@ import {
   replaceResources,
 } from './transformers';
 import { time, timeEnd } from './benchmark';
-import { InitMessage, UpdateMessage } from './type_checker';
+import { InitMessage, UpdateMessage, AUTO_START_ARG } from './type_checker';
 import { gatherDiagnostics, hasErrors } from './gather_diagnostics';
 import {
   CompilerCliIsSupported,
@@ -466,7 +466,7 @@ export class AngularCompilerPlugin implements Tapable {
     const g: any = global;
     const typeCheckerFile: string = g['angularCliIsLocal']
       ? './type_checker_bootstrap.js'
-      : './type_checker.js';
+      : './type_checker_worker.js';
 
     const debugArgRegex = /--inspect(?:-brk|-port)?|--debug(?:-brk|-port)/;
 
@@ -475,10 +475,15 @@ export class AngularCompilerPlugin implements Tapable {
       // Workaround for https://github.com/nodejs/node/issues/9435
       return !debugArgRegex.test(arg);
     });
-
+    // Signal the process to start listening for messages
+    // Solves https://github.com/angular/angular-cli/issues/9071
+    const forkArgs = [AUTO_START_ARG];
     const forkOptions: ForkOptions = { execArgv };
 
-    this._typeCheckerProcess = fork(path.resolve(__dirname, typeCheckerFile), [], forkOptions);
+    this._typeCheckerProcess = fork(
+      path.resolve(__dirname, typeCheckerFile),
+      forkArgs,
+      forkOptions);
     this._typeCheckerProcess.send(new InitMessage(this._compilerOptions, this._basePath,
       this._JitMode, this._rootNames));
 

--- a/packages/@ngtools/webpack/src/type_checker_bootstrap.js
+++ b/packages/@ngtools/webpack/src/type_checker_bootstrap.js
@@ -1,2 +1,2 @@
 require('../../../../lib/bootstrap-local');
-require('./type_checker.ts');
+require('./type_checker_worker.ts');

--- a/packages/@ngtools/webpack/src/type_checker_worker.ts
+++ b/packages/@ngtools/webpack/src/type_checker_worker.ts
@@ -1,0 +1,53 @@
+import * as process from 'process';
+
+import { time, timeEnd } from './benchmark';
+import { CancellationToken } from './gather_diagnostics';
+
+import {
+  AUTO_START_ARG,
+  TypeCheckerMessage,
+  InitMessage,
+  MESSAGE_KIND,
+  UpdateMessage,
+  TypeChecker
+} from './type_checker';
+
+let typeChecker: TypeChecker;
+let lastCancellationToken: CancellationToken;
+
+// only listen to messages if started from the AngularCompilerPlugin
+if (process.argv.indexOf(AUTO_START_ARG) >= 0) {
+  process.on('message', (message: TypeCheckerMessage) => {
+    time('TypeChecker.message');
+    switch (message.kind) {
+      case MESSAGE_KIND.Init:
+        const initMessage = message as InitMessage;
+        typeChecker = new TypeChecker(
+          initMessage.compilerOptions,
+          initMessage.basePath,
+          initMessage.jitMode,
+          initMessage.rootNames,
+        );
+        break;
+      case MESSAGE_KIND.Update:
+        if (!typeChecker) {
+          throw new Error('TypeChecker: update message received before initialization');
+        }
+        if (lastCancellationToken) {
+          // This cancellation token doesn't seem to do much, messages don't seem to be processed
+          // before the diagnostics finish.
+          lastCancellationToken.requestCancellation();
+        }
+        const updateMessage = message as UpdateMessage;
+        lastCancellationToken = new CancellationToken();
+        typeChecker.update(updateMessage.rootNames, updateMessage.changedCompilationFiles,
+          lastCancellationToken);
+        break;
+      default:
+        throw new Error(`TypeChecker: Unexpected message received: ${message}.`);
+    }
+    timeEnd('TypeChecker.message');
+  });
+}
+
+


### PR DESCRIPTION
Move the listening to messages from the type_checker.ts to a seperate
type_checker_worker.ts file. Only start listening to messages when a
magic 'auto start' argument is present in in the argument list,
preventing undesired eaves dropping on other processes.

Fixes #9071
  