### PR TITLE
specify where angular-cli reads module name from

### DIFF
--- a/docs/documentation/generate.md
+++ b/docs/documentation/generate.md
@@ -5,6 +5,8 @@
 ## Overview
 `ng generate [name]` generates the specified blueprint
 
+`[name]` is read from the prefix property of an object in the apps array within .angular-cli.json
+
 ## Available blueprints:
  - [class](generate/class)
  - [component](generate/component)


### PR DESCRIPTION
Adding this to the docs would be helpful.

Background:
I renamed the folder containing an initialized module from `app` to `client`. Then I attempted to `ng generate service --module client` I received an error that the module doesn't exist.

So I renamed all the files in the folder. `./client/app.module.ts` -> `./client/client.modules.ts`. Same issue. So I renamed the variables within each file. `AppRoutingModule` -> `ClientRoutingModule`, etc. Issue is still there.

Finally I realized that the name was coming from .angular-cli.json. Let's spare some other folks the time.