### PR TITLE
fix(@ngtools/webpack): allow # in paths

### DIFF
--- a/packages/@ngtools/webpack/src/angular_compiler_plugin.ts
+++ b/packages/@ngtools/webpack/src/angular_compiler_plugin.ts
@@ -134,9 +134,13 @@ export class AngularCompilerPlugin implements Tapable {
     if (!this._entryModule) {
       return undefined;
     }
-    const splitted = this._entryModule.split('#');
+    const splitted = this._entryModule.split(/(#[a-zA-Z]+)/);
     const path = splitted[0];
-    const className = splitted[1] || 'default';
+    let className = splitted[1] || 'default';
+    if (splitted.length >= 3) {
+      className = splitted[splitted.length - 2];
+    }
+
     return { path, className };
   }
 


### PR DESCRIPTION
Possible fix for #9100 by only splitting on # when it's followed by a valid classname

(This time commits are done with the correct email address)