### PR TITLE
feat(@angular/cli): update to zone.js 0.8.19, import new zone-testing.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9717,9 +9717,9 @@
       "dev": true
     },
     "zone.js": {
-      "version": "0.8.18",
-      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.8.18.tgz",
-      "integrity": "sha512-knKOBQM0oea3/x9pdyDuDi7RhxDlJhOIkeixXSiTKWLgs4LpK37iBc+1HaHwzlciHUKT172CymJFKo8Xgh+44Q=="
+      "version": "0.8.19",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.8.19.tgz",
+      "integrity": "sha512-l9rofaOs6a4y1W8zt4pDmnCUCnYG377dG+5SZlXNWrTWYUuXFqcJZiOarhYiRVR0NI9sH/8ooPJiz4uprB/Mkg=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "webpack-merge": "^4.1.0",
     "webpack-sources": "^1.0.0",
     "webpack-subresource-integrity": "^1.0.1",
-    "zone.js": "^0.8.14"
+    "zone.js": "^0.8.19"
   },
   "devDependencies": {
     "@angular/compiler": "^5.0.0",

--- a/tests/e2e/assets/1.0.0-proj/src/test.ts
+++ b/tests/e2e/assets/1.0.0-proj/src/test.ts
@@ -1,11 +1,6 @@
 // This file is required by karma.conf.js and loads recursively all the .spec and framework files
 
-import 'zone.js/dist/long-stack-trace-zone';
-import 'zone.js/dist/proxy.js';
-import 'zone.js/dist/sync-test';
-import 'zone.js/dist/jasmine-patch';
-import 'zone.js/dist/async-test';
-import 'zone.js/dist/fake-async-test';
+import 'zone.js/dist/zone-testing';
 import { getTestBed } from '@angular/core/testing';
 import {
   BrowserDynamicTestingModule,


### PR DESCRIPTION
1. update `zone.js` to `0.8.19`.
2. zone.js 0.8.19 provide a `zone-testing` bundle to import 

```javascript
import '../zone-spec/long-stack-trace';
import '../zone-spec/proxy';
import '../zone-spec/sync-test';
import '../jasmine/jasmine';
import '../zone-spec/async-test';
import '../zone-spec/fake-async-test';
```

so  `angular/cli` only need to import `zone.js/dist/zone-testing`, it will also resolve some 
auto load order change issue.