### PR TITLE
Irritating warning when setting missingTranslation in AotPlugin options

### DIFF
--- a/packages/@ngtools/webpack/src/plugin.ts
+++ b/packages/@ngtools/webpack/src/plugin.ts
@@ -295,7 +295,7 @@ export class AotPlugin implements Tapable {
     }
     if (options.hasOwnProperty('missingTranslation')) {
       const [MAJOR, MINOR, PATCH] = VERSION.full.split('.').map((x: string) => parseInt(x, 10));
-      if (MAJOR < 4 || (MINOR == 2 && PATCH < 2)) {
+      if (MAJOR < 4 || (MAJOR == 4 && (MINOR < 2 || (MINOR == 2 && PATCH < 2)))) {
         console.warn((`The --missing-translation parameter will be ignored because it is only `
           + `compatible with Angular version 4.2.0 or higher. If you want to use it, please `
           + `upgrade your Angular version.\n`));


### PR DESCRIPTION
When using `missingTranslation` in options for `AotPlugin` constructor the plugin will print a confusing warning when angular (and CLI) is already at version 5 or higher:

    The --missing-translation parameter will be ignored because is only with Angular version 4.2.0 or higher.
    If you want to use it, please your Angular version.

Example in `webpack.config.js`:

```javascript
    ...
    const aotOptions = {
        tsConfigPath: './tsconfig.json',
        entryModule: ...
        exclude: [...],
        locale: 'en',
        i18nFile: 'messages.en.xlf',
        i18nFormat: 'xlf',
        missingTranslation: 'warning', // <<< this will produce the warning
    }
    new AotPlugin(aotOptions);
```