### PR TITLE
feat(@angular/cli): user defined webpack configuration per build target

### DIFF
--- a/packages/@angular/cli/lib/config/schema.json
+++ b/packages/@angular/cli/lib/config/schema.json
@@ -216,6 +216,20 @@
             "description": "Name and corresponding file for environment config.",
             "type": "object",
             "additionalProperties": true
+          },
+          "extraWebpack": {
+            "description": "Experimental support for custom webpack configuration per build target in commonjs format. Paths will be resolved to project root.",
+            "type": "object",
+            "properties": {
+              "development": {
+                "description": "Path to development webpack configuration file.",
+                "type": "string"
+              },
+              "production": {
+                "description": "Path to production webpack configuration file.",
+                "type": "string"
+              }
+            }
           }
         },
         "additionalProperties": false

--- a/packages/@angular/cli/models/webpack-test-config.ts
+++ b/packages/@angular/cli/models/webpack-test-config.ts
@@ -22,8 +22,9 @@ export class WebpackTestConfig extends NgCliWebpackConfig<WebpackTestOptions> {
       getCommonConfig(this.wco),
       getStylesConfig(this.wco),
       this.getTargetConfig(this.wco),
+      this.getTargetConfigCustom(this.wco),
       getNonAotTestConfig(this.wco),
-      getTestConfig(this.wco)
+      getTestConfig(this.wco),
     ];
 
     this.config = webpackMerge(webpackConfigs);


### PR DESCRIPTION
Fixes #3879 

Similar request here #8824

This PR provides developers a way to add custom webpack configuration to their development and production build targets on a per app basis. The custom webpack configuration is loaded if the user provides the paths to their custom configurations.

We have a usecase where we are automatically generating documentation from various file formats and we needed a way to load files without relying on any backend or heavy frontend rendering. We also did not want to eject from @angular/cli as the generated webpack file is quite unwieldy as well and we lose all the generator benefits of @angular/cli.

Sample repo at:
https://github.com/admosity/angular-cli-custom-webpack

The configuration is added after `getTargetConfig` so these configurations are merged after that.

.angular-cli.json schema is updated with an `extraWebpack` property under an app and accepts `development` and `production` paths to custom webpack files. I believe this functionality should be provided as experimental as it is unknown what the behavior may be when combined with @angular/cli defined webpack configurations. 

From the sample repo:
```json
      "extraWebpack": {
        "production": "../webpack-custom.js",
        "development": "../webpack-custom.js"
      }
```

Below is a sample file that can be loaded (follows webpack config schema). In this usecase, I am loading prerendered markdown to be loaded directly into the app.
```javascript

module.exports = {
  module: {
    rules: [
      {
        test: /\.md$/,
        use: [
          {
            loader: 'raw-loader',
          },
          {
            loader: 'markdown-loader'
          }
        ]
      },
    ]
  },
  plugins: [

  ]
 };
```

I was able to run this successfully, but after fast forwarding to the latest 1.7.0-beta.0 on master, I've been getting: 
`TypeError: querystring.unescape is not a function` being thrown from various files. I think this is due to ambiguity between loading the querystring library or loading node's querystring library.