### PR TITLE
docs(@angular/cli): up node version for ci tools

### DIFF
--- a/docs/documentation/stories/continuous-integration.md
+++ b/docs/documentation/stories/continuous-integration.md
@@ -76,7 +76,7 @@ jobs:
   build:
     working_directory: ~/my-project
     docker:
-      - image: circleci/node:6-browsers
+      - image: circleci/node:8-browsers
     steps:
       - checkout
       - restore_cache:
@@ -118,7 +118,7 @@ sudo: false
 
 language: node_js
 node_js:
-  - "6"
+  - "8"
   
 addons:
   apt:


### PR DESCRIPTION
- Add node_js v 8 instead of v 6 for travis config 
- Add node v 8 instead of v 6 for docker image in circleci config