### PR TITLE
fix(@ngtools/webpack): don't elide identifiers that are still exported

### DIFF
--- a/packages/@ngtools/webpack/src/transformers/elide_imports.ts
+++ b/packages/@ngtools/webpack/src/transformers/elide_imports.ts
@@ -99,7 +99,11 @@ export function elideImports(
     .forEach((id) => {
       if (removedSymbolMap.has(id.text)) {
         const symbol = removedSymbolMap.get(id.text);
-        if (typeChecker.getSymbolAtLocation(id) === symbol.symbol) {
+
+        // Check if the symbol is the same or if it is a named export.
+        // Named exports don't have the same symbol but will have the same name.
+        if ((id.parent && id.parent.kind === ts.SyntaxKind.ExportSpecifier)
+          || typeChecker.getSymbolAtLocation(id) === symbol.symbol) {
           symbol.all.push(id);
         }
       }

--- a/packages/@ngtools/webpack/src/transformers/remove_decorators.spec.ts
+++ b/packages/@ngtools/webpack/src/transformers/remove_decorators.spec.ts
@@ -111,7 +111,7 @@ describe('@ngtools/webpack transformers', () => {
 
     it('should not remove imports from types that are still used', () => {
       const input = stripIndent`
-        import { Component, EventEmitter } from '@angular/core';
+        import { Component, ChangeDetectionStrategy, EventEmitter } from '@angular/core';
 
         @Component({
           selector: 'app-root',
@@ -123,9 +123,11 @@ describe('@ngtools/webpack transformers', () => {
           notify: EventEmitter<string> = new EventEmitter<string>();
           title = 'app';
         }
+
+        export { ChangeDetectionStrategy };
       `;
       const output = stripIndent`
-        import { EventEmitter } from '@angular/core';
+        import { ChangeDetectionStrategy, EventEmitter } from '@angular/core';
 
         export class AppComponent {
           constructor() {
@@ -133,6 +135,8 @@ describe('@ngtools/webpack transformers', () => {
             this.title = 'app';
           }
         }
+
+        export { ChangeDetectionStrategy };
       `;
 
       const { program, compilerHost } = createTypescriptContext(input);


### PR DESCRIPTION
Fix #9180