### PR TITLE
refactor(@angular/cli): use project's zone.js when needed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9750,9 +9750,10 @@
       "dev": true
     },
     "zone.js": {
-      "version": "0.8.18",
-      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.8.18.tgz",
-      "integrity": "sha512-knKOBQM0oea3/x9pdyDuDi7RhxDlJhOIkeixXSiTKWLgs4LpK37iBc+1HaHwzlciHUKT172CymJFKo8Xgh+44Q=="
+      "version": "0.8.20",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.8.20.tgz",
+      "integrity": "sha512-FXlA37ErSXCMy5RNBcGFgCI/Zivqzr0D19GuvDxhcYIJc7xkFp6c29DKyODJu0Zo+EMyur/WPPgcBh1EHjB9jA==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -99,8 +99,7 @@
     "webpack-dev-server": "~2.9.3",
     "webpack-merge": "^4.1.0",
     "webpack-sources": "^1.0.0",
-    "webpack-subresource-integrity": "^1.0.1",
-    "zone.js": "^0.8.14"
+    "webpack-subresource-integrity": "^1.0.1"
   },
   "devDependencies": {
     "@angular/compiler": "^5.0.0",
@@ -142,7 +141,8 @@
     "temp": "0.8.3",
     "through": "^2.3.6",
     "ts-node": "^3.2.0",
-    "tslint": "^5.1.0"
+    "tslint": "^5.1.0",
+    "zone.js": "^0.8.20"
   },
   "optionalDependencies": {
     "node-sass": "^4.3.0"

--- a/packages/@angular/cli/package.json
+++ b/packages/@angular/cli/package.json
@@ -82,8 +82,7 @@
     "webpack-dev-server": "~2.9.3",
     "webpack-merge": "^4.1.0",
     "webpack-sources": "^1.0.0",
-    "webpack-subresource-integrity": "^1.0.1",
-    "zone.js": "^0.8.14"
+    "webpack-subresource-integrity": "^1.0.1"
   },
   "optionalDependencies": {
     "node-sass": "^4.3.0"

--- a/packages/@angular/cli/tasks/render-universal.ts
+++ b/packages/@angular/cli/tasks/render-universal.ts
@@ -13,7 +13,7 @@ export interface RenderUniversalTaskOptions {
 
 export default Task.extend({
   run: function(options: RenderUniversalTaskOptions): Promise<any> {
-    require('zone.js/dist/zone-node');
+    requireProjectModule(this.project.root, 'zone.js/dist/zone-node');
 
     const renderModuleFactory =
       requireProjectModule(this.project.root, '@angular/platform-server').renderModuleFactory;


### PR DESCRIPTION
Moves the CLI's dependency on `zone.js` to a dev dependency.