### PR TITLE
release: 1.7.0-beta.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@angular/cli",
-  "version": "1.6.3",
+  "version": "1.7.0-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@angular-devkit/build-optimizer": {
-      "version": "0.0.36",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-optimizer/-/build-optimizer-0.0.36.tgz",
-      "integrity": "sha512-EFFF7hBbVoTOzYfXuSlGhcDr8neafmwuBAIkzAekEjzik7OaTLq7LPG7As+ebed9ll+3DAGypnrpdIE1Tp/H/A==",
+      "version": "0.0.37",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-optimizer/-/build-optimizer-0.0.37.tgz",
+      "integrity": "sha512-446XvQosYWGG7OJGTqkXg39pHwqywLv03X+sewHOfqYqlTYD4/A7PxHCDB9qnLSwVz1DBRCbY0FJCfx5aYGakA==",
       "requires": {
         "loader-utils": "1.1.0",
         "source-map": "0.5.7",
@@ -23,30 +23,35 @@
       }
     },
     "@angular-devkit/core": {
-      "version": "0.0.22",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-0.0.22.tgz",
-      "integrity": "sha512-zxrNtTiv60liye/GGeRMnnGgLgAWoqlMTfPLMW0D1qJ4bbrPHtme010mpxS3QL4edcDtQseyXSFCnEkuo2MrRw==",
+      "version": "0.0.24",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-0.0.24.tgz",
+      "integrity": "sha512-abYk+YbDGnt/LSCDDI2CvJpIPaQGbvHjQc9hqK9KLZP5ZoxoRAqVV4K3POjatrE6l1ok83x3dVlt7Habxm6+Xg==",
       "requires": {
+        "ajv": "5.5.2",
+        "chokidar": "1.7.0",
         "source-map": "0.5.7"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "requires": {
+            "co": "4.6.0",
+            "fast-deep-equal": "1.0.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
+          }
+        }
       }
     },
     "@angular-devkit/schematics": {
-      "version": "0.0.42",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-0.0.42.tgz",
-      "integrity": "sha512-elTiNL0Nx9oin2pfZTvMBU/d9sgutXaZe8n3xm2p7jfqQZry5MYYFES4hq+WIJjtV/X9gAniafncEpxuF7ikYw==",
+      "version": "0.0.45",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-0.0.45.tgz",
+      "integrity": "sha512-lcuOEwfwN8zqH4lf3pmGa9NIWlvADuINjxDCtXIRwQc9PieeGmN56AMVTjFGk7SN+Wu+gPDMbL9wrBFM/u9z9g==",
       "requires": {
-        "@angular-devkit/core": "0.0.22",
-        "@ngtools/json-schema": "1.1.0",
-        "@schematics/schematics": "0.0.11",
-        "minimist": "1.2.0",
-        "rxjs": "5.5.2"
-      },
-      "dependencies": {
-        "@schematics/schematics": {
-          "version": "0.0.11",
-          "resolved": "https://registry.npmjs.org/@schematics/schematics/-/schematics-0.0.11.tgz",
-          "integrity": "sha512-HAXgAIuuAGjiIKohGlRUkmUTWYtNmclR12KHlQQxT9pHFdEb2OrpHjUp2YoV32jiU6jIZm4pf3ODwlPA0VbwnA=="
-        }
+        "@angular-devkit/core": "0.0.24",
+        "@ngtools/json-schema": "1.1.0"
       }
     },
     "@angular/compiler": {
@@ -94,11 +99,34 @@
       "integrity": "sha1-w6DFRNYjkqzCgTpCyKDcb1j4aSI="
     },
     "@schematics/angular": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-0.1.11.tgz",
-      "integrity": "sha512-jYTantZjdYeDjxh9ZLYvGbDI0VeUxgSrcBjHvnHqMNe+YGJenY988ifWCwzjmOowj57maLrQQGrdoO7oUeNdyw==",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-0.1.12.tgz",
+      "integrity": "sha512-ETBjNR1gJZQvUgmpVhk4jDxVvpyOXzGFhX4SkDvmrJdQSOThQFZRL2+TdUNtT+PAtPx583i+ixxsjuK53tU5Ew==",
       "requires": {
-        "@angular-devkit/core": "0.0.22"
+        "@angular-devkit/core": "0.0.24"
+      },
+      "dependencies": {
+        "@angular-devkit/core": {
+          "version": "0.0.24",
+          "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-0.0.24.tgz",
+          "integrity": "sha512-abYk+YbDGnt/LSCDDI2CvJpIPaQGbvHjQc9hqK9KLZP5ZoxoRAqVV4K3POjatrE6l1ok83x3dVlt7Habxm6+Xg==",
+          "requires": {
+            "ajv": "5.5.2",
+            "chokidar": "1.7.0",
+            "source-map": "0.5.7"
+          }
+        },
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "requires": {
+            "co": "4.6.0",
+            "fast-deep-equal": "1.0.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
+          }
+        }
       }
     },
     "@types/common-tags": {
@@ -2876,6 +2904,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
       "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fast-levenshtein": {
       "version": "2.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@angular/cli",
-  "version": "1.6.3",
+  "version": "1.7.0-beta.0",
   "description": "CLI tool for Angular",
   "main": "packages/@angular/cli/lib/cli/index.js",
   "trackingCode": "UA-8594346-19",
@@ -41,9 +41,9 @@
   },
   "homepage": "https://github.com/angular/angular-cli",
   "dependencies": {
-    "@angular-devkit/build-optimizer": "~0.0.36",
-    "@angular-devkit/schematics": "~0.0.42",
-    "@schematics/angular": "~0.1.11",
+    "@angular-devkit/build-optimizer": "~0.0.37",
+    "@angular-devkit/schematics": "~0.0.45",
+    "@schematics/angular": "~0.1.12",
     "autoprefixer": "^7.2.3",
     "chalk": "~2.2.0",
     "circular-dependency-plugin": "^4.2.1",

--- a/packages/@angular/cli/package.json
+++ b/packages/@angular/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@angular/cli",
-  "version": "1.6.3",
+  "version": "1.7.0-beta.0",
   "description": "CLI tool for Angular",
   "main": "lib/cli/index.js",
   "trackingCode": "UA-8594346-19",
@@ -27,11 +27,11 @@
   },
   "homepage": "https://github.com/angular/angular-cli",
   "dependencies": {
-    "@angular-devkit/build-optimizer": "~0.0.36",
-    "@angular-devkit/schematics": "~0.0.42",
+    "@angular-devkit/build-optimizer": "~0.0.37",
+    "@angular-devkit/schematics": "~0.0.45",
     "@ngtools/json-schema": "1.1.0",
-    "@ngtools/webpack": "1.9.3",
-    "@schematics/angular": "~0.1.11",
+    "@ngtools/webpack": "1.10.0-beta.0",
+    "@schematics/angular": "~0.1.12",
     "autoprefixer": "^7.2.3",
     "chalk": "~2.2.0",
     "circular-dependency-plugin": "^4.2.1",

--- a/packages/@ngtools/webpack/package.json
+++ b/packages/@ngtools/webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngtools/webpack",
-  "version": "1.9.3",
+  "version": "1.10.0-beta.0",
   "description": "Webpack plugin that AoT compiles your Angular components and modules.",
   "main": "./src/index.js",
   "typings": "src/index.d.ts",


### PR DESCRIPTION
angular@6.0.0-beta.0 ng -aot error

// Throw if we're neither 2.3.1 or more, nor 4.x.y, nor 5.x.y.
// add version.major == '6'
  if (
    !(
      version.major == '6' || 
      version.major == '5' ||
      version.major == '4' ||
      (version.major == '2' &&
        (version.minor == '4' ||
          (version.minor == '3' && version.patch == '1')))
    )
  ) {
    throw new Error(
      'Version of @angular/compiler-cli needs to be 2.3.1 or greater. ' +
        `Current version is "${version.full}".`
    );
  }