### PR TITLE
fix(@angular/cli): Allow service-workers package to be installed in parent node_modules

### DIFF
--- a/packages/@angular/cli/utilities/require-project-module.ts
+++ b/packages/@angular/cli/utilities/require-project-module.ts
@@ -1,6 +1,11 @@
 const resolve = require('resolve');
 
+// resolve dependencies within the target project
+export function resolveProjectModule(root: string, moduleName: string) {
+  return resolve.sync(moduleName, { basedir: root });
+}
+
 // require dependencies within the target project
 export function requireProjectModule(root: string, moduleName: string) {
-  return require(resolve.sync(moduleName, { basedir: root }));
+  return require(resolveProjectModule(root, moduleName));
 }


### PR DESCRIPTION
The checks on existence of @angular/service-worker used the node_modules relative to the
project root directly, but those don't exist when using yarn workspaces or lerna. Use
resolve.sync instead, which looks up the tree to parent node_modules folders.

A similar change is required when loading the service worker script from the
@angular/service-worker package. Switch to require.resolve here as well.

Fixes #8300