### PR TITLE
fix(@angular/cli): exclude nodejs built-ins from process.cwd() resolve

### DIFF
--- a/lib/bootstrap-local.js
+++ b/lib/bootstrap-local.js
@@ -4,6 +4,7 @@
 const fs = require('fs');
 const path = require('path');
 const ts = require('typescript');
+const builtinModules = require('builtin-modules');
 
 
 Error.stackTraceLimit = Infinity;
@@ -79,12 +80,14 @@ if (!__dirname.match(new RegExp(`\\${path.sep}node_modules\\${path.sep}`))) {
         const p = path.join(packages[match].root, request.substr(match.length));
         return oldLoad.call(this, p, parent);
       } else {
-        try {
-          if (isAngularProject) {
-            return oldLoad.call(this, resolve.sync(request, { basedir: process.cwd() }), parent);
+        if (!(builtinModules.indexOf(request) > -1)) {        
+          try {
+            if (isAngularProject) {
+              return oldLoad.call(this, resolve.sync(request, { basedir: process.cwd() }), parent);
+            }
+          } catch (e) {
+            // Do nothing. Fallback to the old method.
           }
-        } catch (e) {
-          // Do nothing. Fallback to the old method.
         }
 
         return oldLoad.apply(this, arguments);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1053,9 +1053,10 @@
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
     },
     "builtin-modules": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-2.0.0.tgz",
+      "integrity": "sha512-3U5kUA5VPsRUA3nofm/BXX7GVHKfxz0hOBAPxXrIvHzlDRkQVqEn6yi8QJegxl4LzOHLdvb7XF5dVawa/VVYBg==",
+      "dev": true
     },
     "builtin-status-codes": {
       "version": "3.0.0",
@@ -4931,6 +4932,13 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "requires": {
         "builtin-modules": "1.1.1"
+      },
+      "dependencies": {
+        "builtin-modules": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+          "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+        }
       }
     },
     "is-callable": {

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "@types/source-map": "^0.5.0",
     "@types/webpack": "^3.0.5",
     "@types/webpack-sources": "^0.1.3",
+    "builtin-modules": "2.0.0",
     "conventional-changelog": "1.1.0",
     "dtsgenerator": "^0.9.1",
     "eslint": "^3.11.0",


### PR DESCRIPTION
Subsequent to commit dd9e69e, bootstrap-local.js attempts to resolve packages using process.cwd() when @angular/cli is linked locally. The nodejs built-in modules are among the packages being evaluated. Unfortunately, if a built-in module is matched in the local node_modules structure, the replacement is more likely to be an older, or customized, version of that module. Issue #9229 documents the type of error that can be caused by this replacement process.

This pull request refines the replacement logic by excluding nodejs built-ins from process.cwd() resolves during a local bootstrap.