### PR TITLE
feat(@angular/cli): missing bootstrap code should not error

### DIFF
--- a/packages/@ngtools/webpack/src/angular_compiler_plugin.ts
+++ b/packages/@ngtools/webpack/src/angular_compiler_plugin.ts
@@ -96,7 +96,7 @@ export class AngularCompilerPlugin implements Tapable {
   // Contains `moduleImportPath#exportName` => `fullModulePath`.
   private _lazyRoutes: LazyRouteMap = Object.create(null);
   private _tsConfigPath: string;
-  private _entryModule: string;
+  private _entryModule: string | null;
   private _mainPath: string | undefined;
   private _basePath: string;
   private _transformers: ts.TransformerFactory<ts.SourceFile>[] = [];

--- a/packages/@ngtools/webpack/src/entry_resolver.ts
+++ b/packages/@ngtools/webpack/src/entry_resolver.ts
@@ -130,7 +130,7 @@ function _symbolImportLookup(refactor: TypeScriptFileRefactor,
 
 export function resolveEntryModuleFromMain(mainPath: string,
                                            host: ts.CompilerHost,
-                                           program: ts.Program) {
+                                           program: ts.Program): string | null {
   const source = new TypeScriptFileRefactor(mainPath, host, program);
 
   const bootstrap = source.findAstNodes(source.sourceFile, ts.SyntaxKind.CallExpression, true)
@@ -146,9 +146,7 @@ export function resolveEntryModuleFromMain(mainPath: string,
     .filter(node => node.kind == ts.SyntaxKind.Identifier);
 
   if (bootstrap.length != 1) {
-    throw new Error('Tried to find bootstrap code, but could not. Specify either '
-      + 'statically analyzable bootstrap code or pass in an entryModule '
-      + 'to the plugins options.');
+    return null;
   }
   const bootstrapSymbolName = bootstrap[0].text;
   const module = _symbolImportLookup(source, bootstrapSymbolName, host, program);

--- a/tests/e2e/tests/build/no-entry-module.ts
+++ b/tests/e2e/tests/build/no-entry-module.ts
@@ -1,0 +1,15 @@
+import { AppModule } from '../../assets/1.0.0-proj/src/app/app.module';
+import { readFile, writeFile } from '../../utils/fs';
+import { ng } from '../../utils/process';
+
+
+export default async function() {
+  const mainTs = await readFile('src/main.ts');
+
+  const newMainTs = mainTs
+    .replace(/platformBrowserDynamic.*?bootstrapModule.*?;/, '')
+    + 'console.log(AppModule);';  // Use AppModule to make sure it's imported properly.
+
+  await writeFile('src/main.ts', newMainTs);
+  await ng('build');
+}


### PR DESCRIPTION
It is totally valid now to have a different bootstrapping process. By removing
the error in resolveEntryModuleFromMain we allow the compilation to work.