### PR TITLE
fix(@angular/cli): eject now remove all hardcoded paths

### DIFF
--- a/tests/e2e/tests/commands/eject/eject.ts
+++ b/tests/e2e/tests/commands/eject/eject.ts
@@ -1,4 +1,5 @@
 import * as path from 'path';
+import { expectFileToMatch, readFile } from '../../../utils/fs';
 
 import {ng, silentNpm, exec} from '../../../utils/process';
 import {expectToFail} from '../../../utils/utils';
@@ -12,6 +13,10 @@ export default function() {
     .then(() => expectToFail(() => ng('e2e')))
     .then(() => expectToFail(() => ng('serve')))
     .then(() => expectToFail(() => expectGitToBeClean()))
+
+    // Check that no path appears anymore.
+    .then(() => expectToFail(() => expectFileToMatch('webpack.config.js', process.cwd())))
+
     .then(() => silentNpm('install'))
     .then(() => exec(path.join('node_modules', '.bin', 'webpack')));
 }


### PR DESCRIPTION
In favor of process.cwd(). Also added a new eject e2e test that verifies
the webpack.config.js does NOT have the project path in it at any place.

Fixed #9335.