### PR TITLE
fix(@angular/cli): maintain autoprefixer backward compatibility

### DIFF
--- a/packages/@angular/cli/models/webpack-configs/styles.ts
+++ b/packages/@angular/cli/models/webpack-configs/styles.ts
@@ -122,7 +122,7 @@ export function getStylesConfig(wco: WebpackConfigOptions) {
         },
         { url: 'rebase' },
       ]),
-      autoprefixer(),
+      autoprefixer({ grid: true }),
     ];
   };
   (postcssPluginCreator as any)[postcssArgs] = {


### PR DESCRIPTION
Autoprefixer 7+ changed the default for `grid` to false which causes different behavior for CLI end users.