### PR TITLE
feat(@angular/cli): hide error/warning build output stacktraces

### DIFF
--- a/packages/@angular/cli/models/webpack-configs/utils.ts
+++ b/packages/@angular/cli/models/webpack-configs/utils.ts
@@ -6,16 +6,19 @@ export const ngAppResolve = (resolvePath: string): string => {
 
 const webpackOutputOptions = {
   colors: true,
-  hash: true,
-  timings: true,
-  chunks: true,
+  hash: true, // required by custom stat output
+  timings: true, // required by custom stat output
+  chunks: true, // required by custom stat output
   chunkModules: false,
   children: false, // listing all children is very noisy in AOT and hides warnings/errors
   modules: false,
   reasons: false,
   warnings: true,
-  assets: false, // listing all assets is very noisy when using assets directories
-  version: false
+  errors: true,
+  assets: true, // required by custom stat output
+  version: false,
+  errorDetails: false,
+  moduleTrace: false,
 };
 
 const verboseWebpackOutputOptions = {
@@ -23,7 +26,9 @@ const verboseWebpackOutputOptions = {
   assets: true,
   version: true,
   reasons: true,
-  chunkModules: false // TODO: set to true when console to file output is fixed
+  chunkModules: false, // TODO: set to true when console to file output is fixed
+  errorDetails: true,
+  moduleTrace: true,
 };
 
 export function getWebpackStatsConfig(verbose = false) {

--- a/packages/@angular/cli/tasks/build.ts
+++ b/packages/@angular/cli/tasks/build.ts
@@ -44,7 +44,7 @@ export default Task.extend({
           return reject(err);
         }
 
-        const json = stats.toJson('verbose');
+        const json = stats.toJson(statsConfig);
         if (runTaskOptions.verbose) {
           this.ui.writeLine(stats.toString(statsConfig));
         } else {

--- a/packages/@angular/cli/tasks/serve.ts
+++ b/packages/@angular/cli/tasks/serve.ts
@@ -262,7 +262,7 @@ export default Task.extend({
     const server = new WebpackDevServer(webpackCompiler, webpackDevServerConfiguration);
     if (!serveTaskOptions.verbose) {
       webpackCompiler.plugin('done', (stats: any) => {
-        const json = stats.toJson('verbose');
+        const json = stats.toJson(statsConfig);
         this.ui.writeLine(statsToString(json, statsConfig));
         if (stats.hasWarnings()) {
           this.ui.writeLine(statsWarningsToString(json, statsConfig));


### PR DESCRIPTION
Internal Webpack stack traces are not very useful for standard build errors.  They are now hidden behind the verbose option.  This drastically reduces the verbiage when build errors or warnings are present.