### PR TITLE
refactor(@angular/cli): exclude builtin modules

### DIFF
--- a/lib/bootstrap-local.js
+++ b/lib/bootstrap-local.js
@@ -4,7 +4,6 @@
 const fs = require('fs');
 const path = require('path');
 const ts = require('typescript');
-const builtinModules = require('builtin-modules');
 
 
 Error.stackTraceLimit = Infinity;
@@ -49,6 +48,7 @@ require.extensions['.ts'] = function (m, filename) {
 
 const resolve = require('resolve');
 
+const builtinModules = Object.keys(process.binding('natives'));
 
 // Look if there's a .angular-cli.json file, and if so toggle process.cwd() resolution.
 const isAngularProject = fs.existsSync(path.join(process.cwd(), '.angular-cli.json'))
@@ -80,7 +80,7 @@ if (!__dirname.match(new RegExp(`\\${path.sep}node_modules\\${path.sep}`))) {
         const p = path.join(packages[match].root, request.substr(match.length));
         return oldLoad.call(this, p, parent);
       } else {
-        if (!(builtinModules.indexOf(request) > -1)) {        
+        if (!builtinModules.includes(request)) {
           try {
             if (isAngularProject) {
               return oldLoad.call(this, resolve.sync(request, { basedir: process.cwd() }), parent);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1048,12 +1048,6 @@
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
     },
-    "builtin-modules": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-2.0.0.tgz",
-      "integrity": "sha512-3U5kUA5VPsRUA3nofm/BXX7GVHKfxz0hOBAPxXrIvHzlDRkQVqEn6yi8QJegxl4LzOHLdvb7XF5dVawa/VVYBg==",
-      "dev": true
-    },
     "builtin-status-codes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -125,7 +125,6 @@
     "@types/source-map": "0.5.2",
     "@types/webpack": "^3.8.2",
     "@types/webpack-sources": "^0.1.3",
-    "builtin-modules": "2.0.0",
     "conventional-changelog": "1.1.0",
     "dtsgenerator": "^0.9.1",
     "eslint": "^3.11.0",


### PR DESCRIPTION
This pull request is a refactor of PR #9302 which was my original submission to resolve issue #9229. Since that time, @hansl and @filipesilva have resolved similar issues (commits ea22589, 6585ddb, 20860cc) with cleaner code that doesn't require the 'builtin-modules' package.

Other than the "!", this is not my contribution; it is @hansl 's.  I would prefer to see his solution implemented at this location.

If this PR needs to be closed and reopened under @hansl, I will be in full agreement.