### PR TITLE
fix(@angular/cli): fix templates not being updated when using pug

### DIFF
--- a/packages/@ngtools/webpack/src/angular_compiler_plugin.ts
+++ b/packages/@ngtools/webpack/src/angular_compiler_plugin.ts
@@ -294,7 +294,7 @@ export class AngularCompilerPlugin implements Tapable {
 
   private _getChangedCompilationFiles() {
     return this._compilerHost.getChangedFilePaths()
-      .filter(k => /\.(?:ts|html|css|scss|sass|less|styl)$/.test(k));
+      .filter(k => /\.(?:ts|html|css|scss|sass|less|styl|pug)$/.test(k));
   }
 
   private _createOrUpdateProgram() {


### PR DESCRIPTION
include .pug files in output of `_getChangedCompilationFiles()`

Fixes #8509