### PR TITLE
fix(@angular/cli): avoid defaulting base-href to an empty string

### DIFF
--- a/packages/@angular/cli/tasks/serve.ts
+++ b/packages/@angular/cli/tasks/serve.ts
@@ -74,7 +74,7 @@ export default Task.extend({
 
     const serveDefaults = {
       deployUrl: appConfig.deployUrl || '',
-      baseHref: appConfig.baseHref || '',
+      baseHref: appConfig.baseHref,
     };
 
     serveTaskOptions = Object.assign({}, serveDefaults, serveTaskOptions);


### PR DESCRIPTION
Fixes #9401
Fixes #9297