### PR TITLE
changed base ref from project name to full repository name for deploy to github pages [change in wiki]

### DIFF
--- a/docs/documentation/stories/github-pages.md
+++ b/docs/documentation/stories/github-pages.md
@@ -7,8 +7,8 @@ The first step is to [create a GitHub account](https://github.com/join), and the
 [create a repository](https://help.github.com/articles/create-a-repo/) for your project.
 Make a note of the user name and project name in GitHub.
 
-Then all you need to do is run `ng build --prod --output-path docs --base-href PROJECT_NAME`, where
-`PROJECT_NAME` is the name of your project in GitHub.
+Then all you need to do is run `ng build --prod --output-path docs --base-href https://USER_NAME.github.io/PROJECT_NAME/`, where
+`https://USER_NAME.github.io/PROJECT_NAME/` is the name of your project in GitHub.
 Make a copy of `docs/index.html` and name it `docs/404.html`.
 
 Commit your changes and push. On the GitHub project page, configure it to


### PR DESCRIPTION
Github pages publishing was resolved here https://stackoverflow.com/questions/48436223/angular-cli-deploy-to-github-pages-issue-error-error-uncaught-in-promise-er/48461805#48461805. 

changed baseref from project name to complete repository name. 