### PR TITLE
fix(@angular/cli): guard against scripts without a src attribute

### DIFF
--- a/packages/@angular/cli/plugins/suppress-entry-chunks-webpack-plugin.ts
+++ b/packages/@angular/cli/plugins/suppress-entry-chunks-webpack-plugin.ts
@@ -42,7 +42,7 @@ export class SuppressExtractedTextChunksWebpackPlugin {
       compilation.plugin('html-webpack-plugin-alter-asset-tags',
         (htmlPluginData: any, callback: any) => {
           const filterFn = (tag: any) =>
-            !(tag.tagName === 'script' && tag.attributes.src.match(/\.css$/));
+            !(tag.tagName === 'script' && tag.attributes.src && tag.attributes.src.match(/\.css$/));
           htmlPluginData.head = htmlPluginData.head.filter(filterFn);
           htmlPluginData.body = htmlPluginData.body.filter(filterFn);
           callback(null, htmlPluginData);


### PR DESCRIPTION
If a script is inline it has no src attribute. The build should not
fail on looking for CSS scripts due to inline scripts.

This fixes #9448 