### PR TITLE
refactor(@ngtools/webpack): simplify paths module resolution

### DIFF
--- a/packages/@angular/cli/models/webpack-configs/common.ts
+++ b/packages/@angular/cli/models/webpack-configs/common.ts
@@ -207,6 +207,7 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
     resolve: {
       extensions: ['.ts', '.js'],
       symlinks: !buildOptions.preserveSymlinks,
+      modules: [appRoot, 'node_modules'],
       alias
     },
     resolveLoader: {

--- a/packages/@angular/cli/tasks/eject.ts
+++ b/packages/@angular/cli/tasks/eject.ts
@@ -288,7 +288,9 @@ class JsonWebpackSerializer {
   private _resolveReplacer(value: any) {
     this.variableImports['rxjs/_esm5/path-mapping'] = 'rxPaths';
     return Object.assign({}, value, {
-      alias: this._escape('rxPaths()')
+      alias: this._escape('rxPaths()'),
+      modules: value.modules
+               && value.modules.map((x: string) => './' + path.relative(this._root, x)),
     });
   }
 


### PR DESCRIPTION
This performs an initial check and if a request would not be affected by any path mapping, then fallback to Webpack immediately.

Fixes: #9575

target: 1.7.x