### PR TITLE
Adding --history-api-fallback CLI option to `ng serve`

### DIFF
--- a/docs/documentation/serve.md
+++ b/docs/documentation/serve.md
@@ -59,6 +59,16 @@ All the build Options are available in serve, below are the additional options.
 </details>
 
 <details>
+  <summary>history-api-fallback</summary>
+  <p>
+    <code>--history-api-fallback</code> <em>default value: true</em>
+  </p>
+  <p>
+    Serves the index page instead of HTTP 404 "Not Found" errors (but only when the `Accept` HTTP header includes "html" content-types).
+  </p>
+</details>
+
+<details>
   <summary>open</summary>
   <p>
     <code>--open</code> (aliases: <code>-o</code>) <em>default value: false</em>

--- a/packages/@angular/cli/commands/serve.ts
+++ b/packages/@angular/cli/commands/serve.ts
@@ -21,6 +21,7 @@ export interface ServeTaskOptions extends BuildOptions {
   liveReload?: boolean;
   publicHost?: string;
   disableHostCheck?: boolean;
+  historyApiFallback?: boolean;
   ssl?: boolean;
   sslKey?: string;
   sslCert?: string;
@@ -96,6 +97,12 @@ export const baseServeCommandOptions: any = overrideOptions([
     type: Boolean,
     default: false,
     description: 'Don\'t verify connected clients are part of allowed hosts.',
+  },
+  {
+    name: 'history-api-fallback',
+    type: Boolean,
+    default: true,
+    description: 'Serves the index page instead of HTTP 404 "Not Found" errors',
   },
   {
     name: 'serve-path',

--- a/packages/@angular/cli/tasks/serve.ts
+++ b/packages/@angular/cli/tasks/serve.ts
@@ -211,11 +211,11 @@ export default Task.extend({
     }
     const webpackDevServerConfiguration: IWebpackDevServerConfigurationOptions = {
       headers: { 'Access-Control-Allow-Origin': '*' },
-      historyApiFallback: {
+      historyApiFallback: !!serveTaskOptions.historyApiFallback ? {
         index: `${servePath}/${appConfig.index}`,
         disableDotRule: true,
         htmlAcceptHeaders: ['text/html', 'application/xhtml+xml']
-      },
+      } : false,
       stats: serveTaskOptions.verbose ? statsConfig : 'none',
       inline: true,
       proxy: proxyConfig,


### PR DESCRIPTION
Fixes #9640 by adding a CLI option (defaults to current behavior).

While it would be swell to pull the correct behavior from each app's router configuration, that's a little outside my area of expertise. This doesn't feel important enough to polluting the .angular-cli.json schema over, either. In the end, just a CLI option is enough for my needs.

Feedback/edits welcome.