### PR TITLE
fix(@angular/cli): resolve dev server entrypoint

### DIFF
--- a/packages/@angular/cli/tasks/serve.ts
+++ b/packages/@angular/cli/tasks/serve.ts
@@ -109,8 +109,14 @@ export default Task.extend({
     if (serveTaskOptions.liveReload) {
       // This allows for live reload of page when changes are made to repo.
       // https://webpack.js.org/configuration/dev-server/#devserver-inline
+      let webpackDevServerPath;
+      try {
+        webpackDevServerPath = require.resolve('webpack-dev-server/client');
+      } catch {
+        throw new SilentError('The "webpack-dev-server" package could not be found.');
+      }
       let entryPoints = [
-        `webpack-dev-server/client?${clientAddress}`
+        `${webpackDevServerPath}?${clientAddress}`
       ];
       if (serveTaskOptions.hmr) {
         const webpackHmrLink = 'https://webpack.js.org/guides/hot-module-replacement';


### PR DESCRIPTION
This PR removes the assumption that the `webpack-dev-server` package will be hoisted by the package manager.  It also will now fail fast if the package cannot be found.

Fixes #9644