### PR TITLE
fix: Respect build assets allowOutsideOutdir

### DIFF
--- a/packages/@angular/cli/models/webpack-configs/common.ts
+++ b/packages/@angular/cli/models/webpack-configs/common.ts
@@ -96,13 +96,6 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
       const outputRelativeOutput = path.relative(absoluteOutputPath, absoluteAssetOutput);
 
       if (outputRelativeOutput.startsWith('..') || path.isAbsolute(outputRelativeOutput)) {
-
-        const projectRelativeOutput = path.relative(projectRoot, absoluteAssetOutput);
-        if (projectRelativeOutput.startsWith('..') || path.isAbsolute(projectRelativeOutput)) {
-          const message = 'An asset cannot be written to a location outside the project.';
-          throw new SilentError(message);
-        }
-
         if (!asset.allowOutsideOutDir) {
           const message = 'An asset cannot be written to a location outside of the output path. '
                         + 'You can override this message by setting the `allowOutsideOutDir` '


### PR DESCRIPTION
The old check should be removed so assets are allowed outside the project folder if allowOutsideOutdir is configured.
Fixes #9363