### PR TITLE
docs: fix path of CircleCI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 <!-- Badges section here. -->
 [![Build Status](https://img.shields.io/travis/angular/angular-cli/master.svg?label=travis)][travis-badge-url]
-[![CircleCI branch](https://img.shields.io/circleci/project/github/RedSparr0w/node-csgo-parser/master.svg?label=circleci)](https://circleci.com/gh/angular/angular-cli)
+[![CircleCI branch](https://img.shields.io/circleci/project/github/angular/angular-cli/master.svg?label=circleci)](https://circleci.com/gh/angular/angular-cli)
 [![Dependency Status][david-badge]][david-badge-url]
 [![devDependency Status][david-dev-badge]][david-dev-badge-url]
 


### PR DESCRIPTION
Replace the example path from shields.io (RedSparr0w/node-csgo-parser) with the angular-cli path in order to display the right badge.