### PR TITLE
fix(@angular/cli): work around npm peerdep issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -400,14 +400,13 @@
       }
     },
     "ajv": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.2.tgz",
-      "integrity": "sha1-R8aNaehvXZUxA7AHSpQw3GPaXjk=",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.1.1.tgz",
+      "integrity": "sha1-l41Zf7wrfQ5aXD3esUmmgvKr+g4=",
       "requires": {
-        "co": "4.6.0",
         "fast-deep-equal": "1.0.0",
-        "json-schema-traverse": "0.3.1",
-        "json-stable-stringify": "1.0.1"
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
       }
     },
     "ajv-keywords": {
@@ -1154,9 +1153,22 @@
           "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.2.tgz",
           "integrity": "sha512-LCuuUj7L43TbSIqeERp+/Z2FH/NxSA48mqcWlGTSYUUKsevGafj2SpyaFVTxyWWFLkIAS3p7jDTLpNsrU7PXoA==",
           "requires": {
-            "ajv": "5.2.2",
+            "ajv": "5.5.2",
             "ajv-keywords": "2.1.0",
             "chalk": "2.3.0"
+          },
+          "dependencies": {
+            "ajv": {
+              "version": "5.5.2",
+              "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+              "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+              "requires": {
+                "co": "4.6.0",
+                "fast-deep-equal": "1.0.0",
+                "fast-json-stable-stringify": "2.0.0",
+                "json-schema-traverse": "0.3.1"
+              }
+            }
           }
         },
         "supports-color": {
@@ -4288,8 +4300,21 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "requires": {
-        "ajv": "5.2.2",
+        "ajv": "5.5.2",
         "har-schema": "2.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "requires": {
+            "co": "4.6.0",
+            "fast-deep-equal": "1.0.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
+          }
+        }
       }
     },
     "has": {
@@ -5144,6 +5169,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "dev": true,
       "requires": {
         "jsonify": "0.0.0"
       }
@@ -5166,7 +5192,8 @@
     "jsonify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "dev": true
     },
     "jsonparse": {
       "version": "1.3.1",
@@ -7835,7 +7862,20 @@
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
       "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
       "requires": {
-        "ajv": "5.2.2"
+        "ajv": "5.5.2"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "requires": {
+            "co": "4.6.0",
+            "fast-deep-equal": "1.0.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
+          }
+        }
       }
     },
     "scss-tokenizer": {
@@ -9283,9 +9323,22 @@
           "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.2.tgz",
           "integrity": "sha512-LCuuUj7L43TbSIqeERp+/Z2FH/NxSA48mqcWlGTSYUUKsevGafj2SpyaFVTxyWWFLkIAS3p7jDTLpNsrU7PXoA==",
           "requires": {
-            "ajv": "5.2.2",
+            "ajv": "5.5.2",
             "ajv-keywords": "2.1.0",
             "chalk": "2.3.0"
+          },
+          "dependencies": {
+            "ajv": {
+              "version": "5.5.2",
+              "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+              "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+              "requires": {
+                "co": "4.6.0",
+                "fast-deep-equal": "1.0.0",
+                "fast-json-stable-stringify": "2.0.0",
+                "json-schema-traverse": "0.3.1"
+              }
+            }
           }
         },
         "source-map": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@angular-devkit/schematics": "0.3.1",
     "@schematics/angular": "0.3.1",
     "@schematics/package-update": "0.3.1",
+    "ajv": "^6.1.1",
     "autoprefixer": "^7.2.3",
     "cache-loader": "^1.2.0",
     "chalk": "~2.2.0",

--- a/packages/@angular/cli/lib/cli/index.ts
+++ b/packages/@angular/cli/lib/cli/index.ts
@@ -1,3 +1,10 @@
+// TODO: remove this commented AJV require.
+// We don't actually require AJV, but there is a bug with NPM and peer dependencies that is
+// whose workaround is to depend on AJV.
+// See https://github.com/angular/angular-cli/issues/9691#issuecomment-367322703 for details.
+// We need to add a require here to satisfy the dependency checker.
+// require('ajv');
+
 import * as path from 'path';
 
 const cli = require('../../ember-cli/lib/cli');

--- a/packages/@angular/cli/package.json
+++ b/packages/@angular/cli/package.json
@@ -34,6 +34,7 @@
     "@ngtools/webpack": "1.10.0-rc.0",
     "@schematics/angular": "0.3.1",
     "@schematics/package-update": "0.3.1",
+    "ajv": "^6.1.1",
     "autoprefixer": "^7.2.3",
     "cache-loader": "^1.2.0",
     "chalk": "~2.2.0",


### PR DESCRIPTION
NPM hoists dependencies with peerDeps of their own, leading to unmet peer dependencies.

This workaround should be safe for now since the only two packages that depend on `ajv-keywords@3.1.0` are `webpack` and `schema-utils`.

See https://github.com/angular/angular-cli/issues/9691#issuecomment-367322703 and https://github.com/npm/npm/issues/19877 for more information.

Fix https://github.com/angular/angular-cli/issues/9691.