### PR TITLE
ci: don't install chrome on appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,7 +9,6 @@ install:
   - ps: Install-Product node $env:nodejs_version
   - npm install -g npm@~5.6.0
   - npm install
-  - choco install googlechrome
 
 test_script:
   - node --version

--- a/tests/e2e/tests/basic/update.ts
+++ b/tests/e2e/tests/basic/update.ts
@@ -1,26 +1,31 @@
-import { ng } from '../../utils/process';
-import { readFile } from '../../utils/fs';
+import { ng, silentNpm } from '../../utils/process';
+import { readFile, writeFile } from '../../utils/fs';
 import { updateJsonFile } from '../../utils/project';
 
-function updateVersions(obj: any) {
-  const keys = Object.keys(obj);
-  keys.forEach(key => {
-    if (key.startsWith('@angular/')) {
-      obj[key] = '2.0.0';
-    }
-  });
-}
 
 export default function () {
+  let origPackageJson: string;
   let origCoreVersion: string;
   let origCliVersion: string;
-  return updateJsonFile('package.json', obj => {
-    origCoreVersion = obj.dependencies['@angular/core'];
-    origCliVersion = obj.devDependencies['@angular/cli'];
-    updateVersions(obj.dependencies);
-    updateVersions(obj.devDependencies);
-    obj.devDependencies['@angular/cli'] = '1.6.5';
-    })
+
+  function updateVersions(obj: any) {
+    const keys = Object.keys(obj);
+    keys.forEach(key => {
+      if (key.startsWith('@angular/')) {
+        obj[key] = '2.0.0';
+      }
+    });
+  }
+
+  return readFile('package.json')
+    .then((content) => origPackageJson = content)
+    .then(() => updateJsonFile('package.json', obj => {
+      origCoreVersion = obj.dependencies['@angular/core'];
+      origCliVersion = obj.devDependencies['@angular/cli'];
+      updateVersions(obj.dependencies);
+      updateVersions(obj.devDependencies);
+      obj.devDependencies['@angular/cli'] = '1.6.5';
+    }))
     .then(() => ng('update'))
     .then(() => readFile('package.json'))
     .then(s => {
@@ -30,5 +35,7 @@ export default function () {
       if (origCoreVersion === version || origCliVersion === cliVersion) {
         throw new Error('Versions not updated');
       }
-    });
+    })
+    .then(() => writeFile('package.json', origPackageJson))
+    .then(() => silentNpm('install'));
 }


### PR DESCRIPTION
See https://github.com/appveyor/ci/issues/2089.

We should be able to not install it via choco and just use the latest that comes with AppVeyor.