### PR TITLE
fix(@ngtools/webpack): prevent relative request path mapping

### DIFF
--- a/tests/e2e/tests/misc/module-resolution.ts
+++ b/tests/e2e/tests/misc/module-resolution.ts
@@ -5,6 +5,13 @@ import { expectToFail } from '../../utils/utils';
 
 
 export default async function () {
+  await updateJsonFile('src/tsconfig.app.json', tsconfig => {
+    tsconfig.compilerOptions.paths = {
+      '*': [ '../node_modules/*' ],
+    };
+  });
+  await ng('build');
+
   await createDir('xyz');
   await moveFile(
     'node_modules/@angular/common',


### PR DESCRIPTION
Fixes #9727