### PR TITLE
feat(@ngtools/webpack):  prevent build failure in case of custom locale

### DIFF
--- a/packages/@ngtools/webpack/src/angular_compiler_plugin.ts
+++ b/packages/@ngtools/webpack/src/angular_compiler_plugin.ts
@@ -331,7 +331,7 @@ export class AngularCompilerPlugin {
           this._updateForkedTypeChecker(this._rootNames, this._getChangedCompilationFiles());
         }
 
-        // Use an identity function as all our paths are absolute already.
+         // Use an identity function as all our paths are absolute already.
         this._moduleResolutionCache = ts.createModuleResolutionCache(this._basePath, x => x);
 
         if (this._JitMode) {
@@ -640,7 +640,7 @@ export class AngularCompilerPlugin {
         // when the issuer is a `.ts` or `.ngfactory.js` file.
         nmf.plugin('before-resolve', (request: any, callback: any) => {
           if (this.done && (request.request.endsWith('.ts')
-            || (request.context.issuer && /\.ts|ngfactory\.js$/.test(request.context.issuer)))) {
+              || (request.context.issuer && /\.ts|ngfactory\.js$/.test(request.context.issuer)))) {
             this.done.then(() => callback(null, request), () => callback(null, request));
           } else {
             callback(null, request);
@@ -911,7 +911,7 @@ export class AngularCompilerPlugin {
       .map((resourcePath) => path.resolve(path.dirname(resolvedFileName), resourcePath));
 
     // These paths are meant to be used by the loader so we must denormalize them.
-    const uniqueDependencies = new Set([
+    const uniqueDependencies =  new Set([
       ...esImports,
       ...resourceImports,
       ...this.getResourceDependencies(resolvedFileName)
@@ -1060,6 +1060,7 @@ export class AngularCompilerPlugin {
             `please check that "${locale}" is a valid locale id.
             Proceeding with default locale data registration i.e. 'en'.
             If needed, localeData can be registered against custom locale in application module.`);
+          locale = 'en';
         }
       }
     }

--- a/packages/@ngtools/webpack/src/angular_compiler_plugin.ts
+++ b/packages/@ngtools/webpack/src/angular_compiler_plugin.ts
@@ -111,7 +111,7 @@ export class AngularCompilerPlugin {
   // Webpack plugin.
   private _firstRun = true;
   private _donePromise: Promise<void> | null;
-  private _normalizedLocale: string;
+  private _normalizedLocale: string | null;
   private _warnings: (string | Error)[] = [];
   private _errors: (string | Error)[] = [];
 
@@ -1029,7 +1029,7 @@ export class AngularCompilerPlugin {
     return { program, emitResult, diagnostics: allDiagnostics };
   }
 
-  private _validateLocale(locale: string) {
+  private _validateLocale(locale: string): string | null {
     // Get the path of the common module.
     const commonPath = path.dirname(require.resolve('@angular/common/package.json'));
     // Check if the locale file exists
@@ -1056,11 +1056,12 @@ export class AngularCompilerPlugin {
         if (locales.indexOf(parentLocale) !== -1) {
           locale = parentLocale;
         } else {
-          console.log(`Unable to load the locale data file "@angular/common/locales/${locale}", ` +
+          this._warnings.push(`AngularCompilerPlugin: Unable to load the locale data file ` +
+            `"@angular/common/locales/${locale}", ` +
             `please check that "${locale}" is a valid locale id.
             Proceeding with default locale data registration i.e. 'en'.
             If needed, localeData can be registered against custom locale in application module.`);
-          locale = 'en';
+          return null;
         }
       }
     }

--- a/packages/@ngtools/webpack/src/angular_compiler_plugin.ts
+++ b/packages/@ngtools/webpack/src/angular_compiler_plugin.ts
@@ -1057,8 +1057,9 @@ export class AngularCompilerPlugin {
           locale = parentLocale;
         } else {
           console.log(`Unable to load the locale data file "@angular/common/locales/${locale}", ` +
-            `please check that "${locale}" is a valid locale id. Proceeding with default locale data registration i.e. 'en'. If needed, localeData can be registered against custom locale in application module.`);
-          locale = 'en';
+            `please check that "${locale}" is a valid locale id.
+            Proceeding with default locale data registration i.e. 'en'.
+            If needed, localeData can be registered against custom locale in application module.`);
         }
       }
     }

--- a/packages/@ngtools/webpack/src/angular_compiler_plugin.ts
+++ b/packages/@ngtools/webpack/src/angular_compiler_plugin.ts
@@ -1059,7 +1059,6 @@ export class AngularCompilerPlugin {
           this._warnings.push(`AngularCompilerPlugin: Unable to load the locale data file ` +
             `"@angular/common/locales/${locale}", ` +
             `please check that "${locale}" is a valid locale id.
-            Proceeding with default locale data registration i.e. 'en'.
             If needed, localeData can be registered against custom locale in application module.`);
           return null;
         }

--- a/packages/@ngtools/webpack/src/angular_compiler_plugin.ts
+++ b/packages/@ngtools/webpack/src/angular_compiler_plugin.ts
@@ -331,7 +331,7 @@ export class AngularCompilerPlugin {
           this._updateForkedTypeChecker(this._rootNames, this._getChangedCompilationFiles());
         }
 
-         // Use an identity function as all our paths are absolute already.
+        // Use an identity function as all our paths are absolute already.
         this._moduleResolutionCache = ts.createModuleResolutionCache(this._basePath, x => x);
 
         if (this._JitMode) {
@@ -640,7 +640,7 @@ export class AngularCompilerPlugin {
         // when the issuer is a `.ts` or `.ngfactory.js` file.
         nmf.plugin('before-resolve', (request: any, callback: any) => {
           if (this.done && (request.request.endsWith('.ts')
-              || (request.context.issuer && /\.ts|ngfactory\.js$/.test(request.context.issuer)))) {
+            || (request.context.issuer && /\.ts|ngfactory\.js$/.test(request.context.issuer)))) {
             this.done.then(() => callback(null, request), () => callback(null, request));
           } else {
             callback(null, request);
@@ -911,7 +911,7 @@ export class AngularCompilerPlugin {
       .map((resourcePath) => path.resolve(path.dirname(resolvedFileName), resourcePath));
 
     // These paths are meant to be used by the loader so we must denormalize them.
-    const uniqueDependencies =  new Set([
+    const uniqueDependencies = new Set([
       ...esImports,
       ...resourceImports,
       ...this.getResourceDependencies(resolvedFileName)
@@ -1056,9 +1056,9 @@ export class AngularCompilerPlugin {
         if (locales.indexOf(parentLocale) !== -1) {
           locale = parentLocale;
         } else {
-          throw new Error(
-            `Unable to load the locale data file "@angular/common/locales/${locale}", ` +
-            `please check that "${locale}" is a valid locale id.`);
+          console.log(`Unable to load the locale data file "@angular/common/locales/${locale}", ` +
+            `please check that "${locale}" is a valid locale id. Proceeding with default locale data registration i.e. 'en'. If needed, localeData can be registered against custom locale in application module.`);
+          locale = 'en';
         }
       }
     }

--- a/packages/@ngtools/webpack/src/angular_compiler_plugin.ts
+++ b/packages/@ngtools/webpack/src/angular_compiler_plugin.ts
@@ -1059,7 +1059,7 @@ export class AngularCompilerPlugin {
           this._warnings.push(`AngularCompilerPlugin: Unable to load the locale data file ` +
             `"@angular/common/locales/${locale}", ` +
             `please check that "${locale}" is a valid locale id.
-            If needed, localeData can be registered against custom locale in application module.`);
+            If needed, you can use "registerLocaleData" manually.`);
           return null;
         }
       }

--- a/tests/e2e/tests/i18n/build-locale.ts
+++ b/tests/e2e/tests/i18n/build-locale.ts
@@ -1,7 +1,6 @@
 import { ng } from '../../utils/process';
 import { expectFileToMatch, rimraf } from '../../utils/fs';
 import { getGlobalVariable } from '../../utils/env';
-import { expectToFail } from '../../utils/utils';
 
 
 export default function () {
@@ -21,5 +20,4 @@ export default function () {
     .then(() => expectFileToMatch('dist/main.js', /registerLocaleData/))
     .then(() => expectFileToMatch('dist/main.js', /angular_common_locales_fr/))
     .then(() => rimraf('dist'))
-    .then(() => expectToFail(() => ng('build', '--aot', '--locale=no-locale')));
 }


### PR DESCRIPTION
Fix for the issue #9772 . It will allow to use custom locale at build time. Locale data corresponding to custom locale can be registered using registerLocaleData in application module.