### PR TITLE
test: disable strict TS version check for TS2.7 test

### DIFF
--- a/tests/e2e/tests/build/typescript/typescript-2_7.ts
+++ b/tests/e2e/tests/build/typescript/typescript-2_7.ts
@@ -1,6 +1,15 @@
 import { ng, npm } from '../../../utils/process';
+import { updateJsonFile } from '../../../utils/project';
 
 export default async function () {
+  // Disable the strict TS version check for nightly
+  await updateJsonFile('src/tsconfig.app.json', configJson => {
+    configJson.angularCompilerOptions = {
+      ...configJson.angularCompilerOptions,
+      disableTypeScriptVersionCheck: true,
+    };
+  });
+
   await npm('install', 'typescript@2.7');
   await ng('build');
   await ng('build', '--prod');


### PR DESCRIPTION
Latest version of `@angular/compiler-cli` produces an error when the TypeScript version is out of the supported range.