### PR TITLE
feat(@angular/cli): minify inline CSS, JS in prod

### DIFF
--- a/packages/@angular/cli/models/webpack-configs/browser.ts
+++ b/packages/@angular/cli/models/webpack-configs/browser.ts
@@ -41,7 +41,9 @@ export function getBrowserConfig(wco: WebpackConfigOptions) {
         minify: buildOptions.target === 'production' ? {
           caseSensitive: true,
           collapseWhitespace: true,
-          keepClosingSlash: true
+          keepClosingSlash: true,
+          minifyCSS: true,
+          minifyJS: true
         } : false
     }));
     extraPlugins.push(new BaseHrefWebpackPlugin({


### PR DESCRIPTION
This PR enables `minifyCSS` and `minifyJS` in `html-webpack-plugin` (prod build).

Angular app preloading screen can be styled in the index.html inside the `<app-root></app-root>` tag (with inline style for performance).

Sample: https://medium.com/@tomastrajan/how-to-style-angular-application-loading-with-angular-cli-like-a-boss-cdd4f5358554

Another example for JS is GTM code in index.html.

```html
<!doctype html>
<html lang="en">
  <head>
    <meta charset="utf-8">
    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
    <title>Angular</title>
  </head>
  <body>
    <!-- Google Tag Manager (noscript) -->
    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-XXXX" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
    <!-- End Google Tag Manager (noscript) -->
    <app-root>
      <style>
        .pre-loader {
          font-weight: 700;
        }
      </style>
      <div class="pre-loader">Loading...</div>
    </app-root>
    <!-- Google Tag Manager -->
    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
    })(window,document,'script','dataLayer','GTM-XXXX');</script>
    <!-- End Google Tag Manager -->
  </body>
</html>
```