### PR TITLE
refactor(@angular/cli): remove webpack nodeJS globals shimming

### DIFF
--- a/packages/@angular/cli/models/webpack-configs/browser.ts
+++ b/packages/@angular/cli/models/webpack-configs/browser.ts
@@ -124,16 +124,6 @@ export function getBrowserConfig(wco: WebpackConfigOptions) {
         deployUrl: buildOptions.deployUrl,
       }),
     ]),
-    node: {
-      fs: 'empty',
-      global: true,
-      crypto: 'empty',
-      tls: 'empty',
-      net: 'empty',
-      process: true,
-      module: false,
-      clearImmediate: false,
-      setImmediate: false
-    }
+    node: false,
   };
 }

--- a/packages/@angular/cli/models/webpack-configs/common.ts
+++ b/packages/@angular/cli/models/webpack-configs/common.ts
@@ -268,11 +268,6 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
             warnings: buildOptions.verbose,
             safari10: true,
             compress: {
-              // Disabled because of an issue with Mapbox GL when using the Webpack node global:
-              // https://github.com/mapbox/mapbox-gl-js/issues/4359#issuecomment-303880888
-              // https://github.com/angular/angular-cli/issues/5804
-              // https://github.com/angular/angular-cli/pull/7931
-              typeofs : false,
               pure_getters: buildOptions.buildOptimizer,
               // PURE comments work best with 3 passes.
               // See https://github.com/webpack/webpack/issues/2899#issuecomment-317425926.


### PR DESCRIPTION
BREAKING CHANGE:
Libraries/Packages must contain a web version if not web specific.