### PR TITLE
fix(@angular/cli): disable webpack performance hints

### DIFF
--- a/packages/@angular/cli/models/webpack-configs/common.ts
+++ b/packages/@angular/cli/models/webpack-configs/common.ts
@@ -218,6 +218,9 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
       publicPath: buildOptions.deployUrl,
       filename: `[name]${hashFormat.chunk}.js`,
     },
+    performance: {
+      hints: false,
+    },
     module: {
       rules: [
         { test: /\.html$/, loader: 'raw-loader' },


### PR DESCRIPTION
Webpack 4 now enables performance hint warnings by default in production mode.