### PR TITLE
update @angular-devkit/core version to fix prod build TypeError

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "homepage": "https://github.com/angular/angular-cli",
   "dependencies": {
     "@angular-devkit/build-optimizer": "0.3.2",
-    "@angular-devkit/core": "0.3.2",
+    "@angular-devkit/core": "0.4.3",
     "@angular-devkit/schematics": "0.3.2",
     "@schematics/angular": "0.3.2",
     "@schematics/package-update": "0.3.2",


### PR DESCRIPTION
In order to fix: https://github.com/angular/angular-cli/issues/9820 we need to update the @angular-devkit/core module