### PR TITLE
fix(@ngtools/webpack): support invalidating compiler-host with a directory

### DIFF
--- a/packages/@ngtools/webpack/src/compiler_host.ts
+++ b/packages/@ngtools/webpack/src/compiler_host.ts
@@ -173,12 +173,20 @@ export class WebpackCompilerHost implements ts.CompilerHost {
       .map((path) => this.denormalizePath(path));
   }
 
-  invalidate(fileName: string): void {
-    fileName = this.resolve(fileName);
-    if (fileName in this._files) {
-      this._files[fileName] = null;
+  invalidate(path: string): void {
+    const fullPath = this.resolve(path);
+    if (fullPath in this._files) {
+      this._files[fullPath] = null;
+    } else {
+      for (const file in this._files) {
+        if (file.startsWith(fullPath + '/')) {
+          this._files[file] = null;
+        }
+      }
     }
-    this._changedFiles[fileName] = true;
+    if (this.fileExists(fullPath)) {
+      this._changedFiles[fullPath] = true;
+    }
   }
 
   fileExists(fileName: string, delegate = true): boolean {

--- a/packages/@ngtools/webpack/src/lazy_routes.ts
+++ b/packages/@ngtools/webpack/src/lazy_routes.ts
@@ -33,7 +33,7 @@ export function findLazyRoutes(
   if (program) {
     sourceFile = program.getSourceFile(fileName);
   }
-  if (!sourceFile) {
+  if (!sourceFile && host.fileExists(fileName)) {
     sourceFile = ts.createSourceFile(
       fileName,
       host.readFile(fileName),


### PR DESCRIPTION
`invalidate` is called from the Webpack `InputFileSystem.purge` method which can be passed a file or directory.