### PR TITLE
fix(@angular/cli): when a schematic fails on commit errors fail the command

### DIFF
--- a/packages/@angular/cli/tasks/schematic-run.ts
+++ b/packages/@angular/cli/tasks/schematic-run.ts
@@ -17,6 +17,7 @@ import { concat, concatMap, ignoreElements, map } from 'rxjs/operators';
 import { getCollection, getSchematic, getEngineHost, getEngine } from '../utilities/schematics';
 
 const { green, red, yellow } = chalk;
+const SilentError = require('silent-error');
 const Task = require('../ember-cli/lib/models/task');
 
 export interface SchematicRunOptions {
@@ -135,9 +136,11 @@ export default Task.extend({
         if (!error) {
           // Output the logging queue.
           loggingQueue.forEach(log => ui.writeLine(`  ${log.color(log.keyword)} ${log.message}`));
+        } else {
+          throw new SilentError();
         }
 
-        if (opts.dryRun || error) {
+        if (opts.dryRun) {
           return observableOf(tree);
         }
         return fsSink.commit(tree).pipe(

--- a/tests/e2e/tests/generate/component/component-duplicate.ts
+++ b/tests/e2e/tests/generate/component/component-duplicate.ts
@@ -1,4 +1,5 @@
 import { ng } from '../../../utils/process';
+import { expectToFail } from "../../../utils/utils";
 import { oneLine } from 'common-tags';
 
 export default function () {
@@ -11,13 +12,5 @@ export default function () {
           in ${output.stdout}.`);
       }
     })
-    .then(() => ng('generate', 'component', 'test-component'))
-    .then((output) => {
-      if (!output.stdout.match(/error! src[\\|\/]app[\\|\/]test-component[\\|\/]test-component.component.ts already exists./)) {
-        throw new Error(oneLine`
-          Expected to match
-          "ERROR! src/app/test-component/test-component.ts"
-          in ${output.stdout}.`);
-      }
-    });
+    .then(() => expectToFail(() => ng('generate', 'component', 'test-component')));
 }


### PR DESCRIPTION
Before the only way it could fail was to have the schematic throw, but that does
not happen when the schematic creates files that already exist (e.g.). This fixes
that.