### PR TITLE
ci: remove unneeded npm 5.6 install

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,7 +7,6 @@ matrix:
 
 install:
   - ps: Install-Product node $env:nodejs_version
-  - npm install -g npm@~5.6.0
   - npm install
   - choco install googlechrome
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,10 +92,6 @@ matrix:
           tags: true
 
 
-before_install:
-  # Install npm 5.
-  - npm install -g npm@~5.6.0
-
 install:
   - npm install
 


### PR DESCRIPTION
Node 8 comes with the necessary npm version.  Should provide a small CI speed boost.