### PR TITLE
fix(@angular/cli): Organize the help output

### DIFF
--- a/packages/@angular/cli/commands/add.ts
+++ b/packages/@angular/cli/commands/add.ts
@@ -16,14 +16,15 @@ export default class AddCommand extends SchematicCommand {
   options: Option[] = [];
 
   private async _parseSchematicOptions(collectionName: string): Promise<any> {
-    const availableOptions: Option[] = await this.getOptions({
+    const schematicOptions = await this.getOptions({
       schematicName: 'ng-add',
       collectionName,
     });
 
-    const options = this.options.concat(availableOptions || []);
+    const options = this.options.concat(schematicOptions.options);
+    const args = schematicOptions.arguments.map(arg => arg.name);
 
-    return parseOptions(this._rawArgs, options, [], this.argStrategy);
+    return parseOptions(this._rawArgs, options, args, this.argStrategy);
   }
 
   validate(options: any) {

--- a/packages/@angular/cli/commands/generate.ts
+++ b/packages/@angular/cli/commands/generate.ts
@@ -31,11 +31,12 @@ export default class GenerateCommand extends SchematicCommand {
     const [collectionName, schematicName] = this.parseSchematicInfo(options);
 
     if (!!schematicName) {
-      const availableOptions: Option[] = await this.getOptions({
+      const schematicOptions = await this.getOptions({
         schematicName,
         collectionName,
       });
-      this.options = this.options.concat( availableOptions || []);
+      this.options = this.options.concat(schematicOptions.options);
+      this.arguments = this.arguments.concat(schematicOptions.arguments.map(a => a.name));
     }
   }
 
@@ -83,8 +84,16 @@ export default class GenerateCommand extends SchematicCommand {
   }
 
   public printHelp(options: any) {
-    if (options.schematic) {
-      super.printHelp(options);
+    const schematicName = options._[0];
+    if (schematicName) {
+      const argDisplay = this.arguments && this.arguments.length > 0
+        ? ' ' + this.arguments.filter(a => a !== 'schematic').map(a => `<${a}>`).join(' ')
+        : '';
+      const optionsDisplay = this.options && this.options.length > 0
+        ? ' [options]'
+        : '';
+      this.logger.info(`usage: ng generate ${schematicName}${argDisplay}${optionsDisplay}`);
+      this.printHelpOptions(options);
     } else {
       this.printHelpUsage(this.name, this.arguments, this.options);
       const engineHost = getEngineHost();

--- a/packages/@angular/cli/commands/new.ts
+++ b/packages/@angular/cli/commands/new.ts
@@ -9,6 +9,7 @@ export default class NewCommand extends SchematicCommand {
     'Creates a new directory and a new Angular app.';
   public static aliases = ['n'];
   public scope = CommandScope.outsideProject;
+  public arguments: string[] = [];
   public options: Option[] = [
     ...this.coreOptions,
     {
@@ -41,12 +42,10 @@ export default class NewCommand extends SchematicCommand {
         schematicName,
         collectionName
       })
-      .then((availableOptions: Option[]) => {
-        // if (availableOptions) {
-        //   availableOptions = availableOptions.filter(opt => opt.name !== 'name');
-        // }
-
-        this.options = this.options.concat( availableOptions || []);
+      .then((schematicOptions) => {
+        this.options = this.options.concat(schematicOptions.options);
+        const args = schematicOptions.arguments.map(arg => arg.name);
+        this.arguments = this.arguments.concat(args);
       });
   }
 

--- a/packages/@angular/cli/commands/update.ts
+++ b/packages/@angular/cli/commands/update.ts
@@ -12,7 +12,7 @@ export default class UpdateCommand extends SchematicCommand {
   public readonly description = 'Updates your application and its dependencies.';
   public static aliases: string[] = [];
   public readonly scope = CommandScope.inProject;
-  public readonly arguments: string[] = [ 'packages' ];
+  public arguments: string[] = [ 'packages' ];
   public options: Option[] = [
     ...this.coreOptions,
   ];
@@ -29,11 +29,12 @@ export default class UpdateCommand extends SchematicCommand {
     super.initialize(options);
     this.initialized = true;
 
-    const availableOptions: Option[] = await this.getOptions({
+    const schematicOptions = await this.getOptions({
       schematicName: this.schematicName,
       collectionName: this.collectionName,
     });
-    this.options = this.options.concat( availableOptions || []);
+    this.options = this.options.concat(schematicOptions.options);
+    this.arguments = this.arguments.concat(schematicOptions.arguments.map(a => a.name));
   }
 
   public async run(options: UpdateOptions) {

--- a/packages/@angular/cli/models/command.ts
+++ b/packages/@angular/cli/models/command.ts
@@ -62,11 +62,12 @@ export abstract class Command {
       this.logger.info(`options:`);
       this.options
         .filter(o => !o.hidden)
+        .sort((a, b) => a.name >= b.name ? 1 : -1)
         .forEach(o => {
         const aliases = o.aliases && o.aliases.length > 0
           ? '(' + o.aliases.map(a => `-${a}`).join(' ') + ')'
           : '';
-        this.logger.info(`  ${cyan(o.name)} ${aliases}`);
+        this.logger.info(`  ${cyan('--' + o.name)} ${aliases}`);
         this.logger.info(`    ${o.description}`);
       });
     }

--- a/tests/e2e/tests/generate/help-output.ts
+++ b/tests/e2e/tests/generate/help-output.ts
@@ -1,0 +1,86 @@
+import {join} from 'path';
+import {ng} from '../../utils/process';
+import {writeMultipleFiles, createDir} from '../../utils/fs';
+
+
+export default function() {
+  // setup temp collection
+  const genRoot = join('node_modules/fake-schematics/');
+
+  return Promise.resolve()
+    .then(() => createDir(genRoot))
+    .then(() => writeMultipleFiles({
+      [join(genRoot, 'package.json')]: `
+      {
+        "schematics": "./collection.json"
+      }`,
+      [join(genRoot, 'collection.json')]: `
+      {
+        "schematics": {
+          "fake": {
+            "factory": "./fake",
+            "description": "Fake schematic",
+            "schema": "./fake-schema.json"
+          }
+        }
+      }`,
+      [join(genRoot, 'fake-schema.json')]: `
+      {
+        "id": "FakeSchema",
+        "title": "Fake Schema",
+        "type": "object",
+        "properties": {
+          "b": {
+            "type": "string",
+            "description": "b.",
+            "$default": {
+              "$source": "argv",
+              "index": 1
+            }
+          },
+          "a": {
+            "type": "string",
+            "description": "a.",
+            "$default": {
+              "$source": "argv",
+              "index": 0
+            }
+          },
+          "optC": {
+            "type": "string",
+            "description": "optC"
+          },
+          "optA": {
+            "type": "string",
+            "description": "optA"
+          },
+          "optB": {
+            "type": "string",
+            "description": "optB"
+          }
+        },
+        "required": []
+      }`,
+      [join(genRoot, 'fake.js')]: `
+      function def(options) {
+        return (host, context) => {
+          return host;
+        };
+      }
+      exports.default = def;
+      `},
+    ))
+    .then(() => ng('generate', 'fake-schematics:fake', '--help'))
+    .then(({stdout}) => {
+      console.warn('stdout start');
+      console.error(stdout);
+      console.warn('stdout end');
+      if (!/ng generate fake-schematics:fake <a> <b> \[options\]/.test(stdout)) {
+        throw new Error('Help signature is wrong.');
+      }
+      if (!/opt-a[\s\S]*opt-b[\s\S]*opt-c/.test(stdout)) {
+        throw new Error('Help signature options are incorrect.');
+      }
+    });
+
+}


### PR DESCRIPTION
The new output shows the options in alphabetic order and will show any options the schematic will parse as arguments dynamically, sample output for running `ng generate directive --help`...

![image](https://user-images.githubusercontent.com/1565117/38337860-207c1d80-3835-11e8-9d97-0b3fb9edf808.png)
