### PR TITLE
PostCSS handling of absolute deployUrl paths

### DIFF
--- a/packages/@angular/cli/plugins/postcss-cli-resources.ts
+++ b/packages/@angular/cli/plugins/postcss-cli-resources.ts
@@ -95,7 +95,11 @@ export default postcss.plugin('postcss-cli-resources', (options: PostcssCliResou
         }
 
         if (deployUrl) {
-          outputUrl = url.resolve(deployUrl, outputUrl);
+          if (deployUrl.startsWith('/')) {
+            outputUrl = deployUrl + outputUrl;
+          } else {
+            outputUrl = url.resolve(deployUrl, outputUrl);
+          }
         }
 
         resourceCache.set(inputUrl, outputUrl);


### PR DESCRIPTION
When a `deployUrl` consists of an absolute path, it needs to be prepended to the `outputUrl` since `url.resolve` will just ignore it. The proposed patch simply checks for an absolute path to perform a prepend, falling back to the existing logic otherwise.

Without this patch resources within stylesheets do not get their paths prefixed with the `deployUrl` if for example that `deployUrl` is "/static".