### PR TITLE
fix(@angular/cli): allow private schematics on ng add

### DIFF
--- a/packages/@angular/cli/models/schematic-command.ts
+++ b/packages/@angular/cli/models/schematic-command.ts
@@ -201,7 +201,7 @@ export abstract class SchematicCommand extends Command {
 
     const collection = getCollection(collectionName);
 
-    const schematic = getSchematic(collection, options.schematicName);
+    const schematic = getSchematic(collection, options.schematicName, this.allowPrivateSchematics);
     this._deAliasedName = schematic.description.name;
 
     if (!schematic.description.schemaJson) {


### PR DESCRIPTION
The execution was changed in #10184, but the getOptions() method was forgotten.