### PR TITLE
fix(upgrade): missing parenthesis in RxJs compat warning

### DIFF
--- a/packages/@angular/cli/upgrade/version.ts
+++ b/packages/@angular/cli/upgrade/version.ts
@@ -112,7 +112,7 @@ export class Version {
       && !rxjsVersion.isGreaterThanOrEqualTo(new SemVer('6.0.0-beta.0'))
     ) {
       console.warn(bold(red(tags.stripIndents`
-          This project uses a temporary compatibility version of RxJs (${rxjsVersion}.
+          This project uses a temporary compatibility version of RxJs (${rxjsVersion}).
 
           Please visit the link below to find instructions on how to update RxJs.
           https://docs.google.com/document/d/12nlLt71VLKb-z3YaSGzUfx6mJbc34nsMXtByPUN35cg/edit#


### PR DESCRIPTION
Fixes
```
This project uses a temporary compatibility version of RxJs (5.6.0-forward-compat.4.

Please visit the link below to find instructions on how to update RxJs.
https://docs.google.com/document/d/12nlLt71VLKb-z3YaSGzUfx6mJbc34nsMXtByPUN35cg/edit#
```