### PR TITLE
fix(@angular/cli): fix xi18n command typo

### DIFF
--- a/packages/@angular/cli/commands/xi18n.ts
+++ b/packages/@angular/cli/commands/xi18n.ts
@@ -7,7 +7,7 @@ export interface Options {
 }
 
 export default class Xi18nCommand extends ArchitectCommand {
-  public readonly name = 'xi81n';
+  public readonly name = 'xi18n';
   public readonly target = 'extract-i18n';
   public readonly description = 'Extracts i18n messages from source code.';
   public readonly scope = CommandScope.inProject;


### PR DESCRIPTION
Change the command to extract i18n messages to xi18n instead of xi81n.