### PR TITLE
feat(@angular/cli): build only the projects of a certain type

### DIFF
--- a/packages/@angular/cli/commands/build.ts
+++ b/packages/@angular/cli/commands/build.ts
@@ -1,12 +1,15 @@
 import { ArchitectCommand } from '../models/architect-command';
 import { Option, CommandScope } from '../models/command';
 import { Version } from '../upgrade/version';
+import { experimental } from '@angular-devkit/core';
 
 export interface Options {
   project?: string;
   configuration?: string;
+  projectType?: string;
   prod: boolean;
 }
+
 
 export default class BuildCommand extends ArchitectCommand {
   public readonly name = 'build';
@@ -38,9 +41,13 @@ export default class BuildCommand extends ArchitectCommand {
     delete overrides.configuration;
     delete overrides.prod;
 
+    const filter: experimental.workspace.projectFilter = options.projectType
+      && ((project) => project.projectType === options.projectType);
+
     return this.runArchitectTarget({
       project: options.project,
       target: this.target,
+      projectFilter: filter,
       configuration,
       overrides
     }, options);

--- a/packages/@angular/cli/models/architect-command.ts
+++ b/packages/@angular/cli/models/architect-command.ts
@@ -10,6 +10,8 @@ import { from } from 'rxjs';
 import { concatMap, map, tap, toArray } from 'rxjs/operators';
 import { WorkspaceLoader } from '../models/workspace-loader';
 
+type projectFilter = experimental.workspace.projectFilter;
+
 
 export abstract class ArchitectCommand<T = any> extends Command<T> {
   private _host = new NodeJsSyncHost();
@@ -161,7 +163,7 @@ export abstract class ArchitectCommand<T = any> extends Command<T> {
       if (!targetSpec.project && this.target) {
         // This runs each target sequentially.
         // Running them in parallel would jumble the log messages.
-        return await from(this.getProjectNamesByTarget(this.target)).pipe(
+        return await from(this.getProjectNamesByTarget(this.target, targetSpec.projectFilter)).pipe(
           concatMap(project => runSingleTarget({ ...targetSpec, project })),
           toArray(),
         ).toPromise().then(results => results.every(res => res === 0) ? 0 : 1);
@@ -194,8 +196,8 @@ export abstract class ArchitectCommand<T = any> extends Command<T> {
     }
   }
 
-  private getProjectNamesByTarget(targetName: string): string[] {
-    const allProjectsForTargetName = this._workspace.listProjectNames().map(projectName =>
+  private getProjectNamesByTarget(targetName: string, filter?: projectFilter): string[] {
+    const allProjectsForTargetName = this._workspace.listProjectNames(filter).map(projectName =>
       this._architect.listProjectTargets(projectName).includes(targetName) ? projectName : null
     ).filter(x => !!x);
 


### PR DESCRIPTION
## Goal feature

Permit to run some architect commands only on projects with a specific projectType.

For example, this will only build the libraries : 
```
ng build --project-type=library
```
angular/devkit#739 would be needed for filtering project names.

## Purpose

Applications and libraries doesn't share the same use-cases : where applications are built (thanks to the build-angular build architect) in order to be served through HTTP, libraries, on the other hand, are bundled by ng-packagr in order to be published to a npm repository. Therefore, deployment / publication processes diverged between the two, so is the CI.

This PR is also a first example of angular/devkit#739 use.