### PR TITLE
feat(@angular-cli): remove `server` alias for `serve`

### DIFF
--- a/packages/@angular/cli/commands/serve.ts
+++ b/packages/@angular/cli/commands/serve.ts
@@ -12,7 +12,7 @@ export default class ServeCommand extends ArchitectCommand {
   public readonly name = 'serve';
   public readonly target = 'serve';
   public readonly description = 'Builds and serves your app, rebuilding on file changes.';
-  public static aliases = ['server', 's'];
+  public static aliases = ['s'];
   public readonly scope = CommandScope.inProject;
   public readonly options: Option[] = [
     this.prodOption,


### PR DESCRIPTION
The alias has been removed as it's quite confusing as one might expect that `ng server` will trigger a server build 

Closes: #10334