### PR TITLE
build: add missing @ngtools/webpack devDep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,14 +5,14 @@
   "requires": true,
   "dependencies": {
     "@angular-devkit/architect": {
-      "version": "github:angular/angular-devkit-architect-builds#08c81d9cd50fc944edb7da644b57c0d642f57634",
+      "version": "github:angular/angular-devkit-architect-builds#c41f0aa41254900e5e2a1f0fbc20eaf33b17c451",
       "requires": {
-        "@angular-devkit/core": "github:angular/angular-devkit-core-builds#4e5378fef09c674e3f3fe425e0cd21cca70dd0f9",
+        "@angular-devkit/core": "github:angular/angular-devkit-core-builds#7933a579c0ec16fd8d6c08adf16970ec7af1fe5b",
         "rxjs": "6.0.0"
       },
       "dependencies": {
         "@angular-devkit/core": {
-          "version": "github:angular/angular-devkit-core-builds#4e5378fef09c674e3f3fe425e0cd21cca70dd0f9",
+          "version": "github:angular/angular-devkit-core-builds#7933a579c0ec16fd8d6c08adf16970ec7af1fe5b",
           "requires": {
             "ajv": "6.4.0",
             "chokidar": "1.7.0",
@@ -23,7 +23,7 @@
       }
     },
     "@angular-devkit/core": {
-      "version": "github:angular/angular-devkit-core-builds#4e5378fef09c674e3f3fe425e0cd21cca70dd0f9",
+      "version": "github:angular/angular-devkit-core-builds#7933a579c0ec16fd8d6c08adf16970ec7af1fe5b",
       "requires": {
         "ajv": "6.4.0",
         "chokidar": "1.7.0",
@@ -32,15 +32,14 @@
       }
     },
     "@angular-devkit/schematics": {
-      "version": "github:angular/angular-devkit-schematics-builds#a10bd8bf76032b1e258cfbb063a9ae2525dcbd2b",
+      "version": "github:angular/angular-devkit-schematics-builds#6dbe0ac74abe4890f8b8aedd9353e91bbc300c90",
       "requires": {
-        "@angular-devkit/core": "github:angular/angular-devkit-core-builds#4e5378fef09c674e3f3fe425e0cd21cca70dd0f9",
-        "@ngtools/json-schema": "1.1.0",
+        "@angular-devkit/core": "github:angular/angular-devkit-core-builds#7933a579c0ec16fd8d6c08adf16970ec7af1fe5b",
         "rxjs": "6.0.0"
       },
       "dependencies": {
         "@angular-devkit/core": {
-          "version": "github:angular/angular-devkit-core-builds#4e5378fef09c674e3f3fe425e0cd21cca70dd0f9",
+          "version": "github:angular/angular-devkit-core-builds#7933a579c0ec16fd8d6c08adf16970ec7af1fe5b",
           "requires": {
             "ajv": "6.4.0",
             "chokidar": "1.7.0",
@@ -53,18 +52,19 @@
     "@ngtools/json-schema": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@ngtools/json-schema/-/json-schema-1.1.0.tgz",
-      "integrity": "sha1-w6DFRNYjkqzCgTpCyKDcb1j4aSI="
+      "integrity": "sha1-w6DFRNYjkqzCgTpCyKDcb1j4aSI=",
+      "dev": true
     },
     "@schematics/angular": {
-      "version": "github:angular/schematics-angular-builds#584e9b5f0f4f434db5a8b67cba0ba144219a62bc",
+      "version": "github:angular/schematics-angular-builds#930cf95d7cb794799f3c1f54266860a4fde2e5b3",
       "requires": {
-        "@angular-devkit/core": "github:angular/angular-devkit-core-builds#4e5378fef09c674e3f3fe425e0cd21cca70dd0f9",
-        "@angular-devkit/schematics": "github:angular/angular-devkit-schematics-builds#a10bd8bf76032b1e258cfbb063a9ae2525dcbd2b",
+        "@angular-devkit/core": "github:angular/angular-devkit-core-builds#7933a579c0ec16fd8d6c08adf16970ec7af1fe5b",
+        "@angular-devkit/schematics": "github:angular/angular-devkit-schematics-builds#6dbe0ac74abe4890f8b8aedd9353e91bbc300c90",
         "typescript": "2.7.2"
       },
       "dependencies": {
         "@angular-devkit/core": {
-          "version": "github:angular/angular-devkit-core-builds#4e5378fef09c674e3f3fe425e0cd21cca70dd0f9",
+          "version": "github:angular/angular-devkit-core-builds#7933a579c0ec16fd8d6c08adf16970ec7af1fe5b",
           "requires": {
             "ajv": "6.4.0",
             "chokidar": "1.7.0",
@@ -73,10 +73,9 @@
           }
         },
         "@angular-devkit/schematics": {
-          "version": "github:angular/angular-devkit-schematics-builds#a10bd8bf76032b1e258cfbb063a9ae2525dcbd2b",
+          "version": "github:angular/angular-devkit-schematics-builds#6dbe0ac74abe4890f8b8aedd9353e91bbc300c90",
           "requires": {
-            "@angular-devkit/core": "github:angular/angular-devkit-core-builds#4e5378fef09c674e3f3fe425e0cd21cca70dd0f9",
-            "@ngtools/json-schema": "1.1.0",
+            "@angular-devkit/core": "github:angular/angular-devkit-core-builds#7933a579c0ec16fd8d6c08adf16970ec7af1fe5b",
             "rxjs": "6.0.0"
           }
         },
@@ -88,10 +87,10 @@
       }
     },
     "@schematics/update": {
-      "version": "github:angular/schematics-update-builds#ea95f8ef5eaa53caf49b091b11eef7f7c70c8d7a",
+      "version": "github:angular/schematics-update-builds#8e9b9aede9fd5e42d29b65b3f576e9d0cb079679",
       "requires": {
-        "@angular-devkit/core": "github:angular/angular-devkit-core-builds#4e5378fef09c674e3f3fe425e0cd21cca70dd0f9",
-        "@angular-devkit/schematics": "github:angular/angular-devkit-schematics-builds#a10bd8bf76032b1e258cfbb063a9ae2525dcbd2b",
+        "@angular-devkit/core": "github:angular/angular-devkit-core-builds#7933a579c0ec16fd8d6c08adf16970ec7af1fe5b",
+        "@angular-devkit/schematics": "github:angular/angular-devkit-schematics-builds#6dbe0ac74abe4890f8b8aedd9353e91bbc300c90",
         "npm-registry-client": "8.5.1",
         "rxjs": "6.0.0",
         "semver": "5.5.0",
@@ -99,7 +98,7 @@
       },
       "dependencies": {
         "@angular-devkit/core": {
-          "version": "github:angular/angular-devkit-core-builds#4e5378fef09c674e3f3fe425e0cd21cca70dd0f9",
+          "version": "github:angular/angular-devkit-core-builds#7933a579c0ec16fd8d6c08adf16970ec7af1fe5b",
           "requires": {
             "ajv": "6.4.0",
             "chokidar": "1.7.0",
@@ -108,10 +107,9 @@
           }
         },
         "@angular-devkit/schematics": {
-          "version": "github:angular/angular-devkit-schematics-builds#a10bd8bf76032b1e258cfbb063a9ae2525dcbd2b",
+          "version": "github:angular/angular-devkit-schematics-builds#6dbe0ac74abe4890f8b8aedd9353e91bbc300c90",
           "requires": {
-            "@angular-devkit/core": "github:angular/angular-devkit-core-builds#4e5378fef09c674e3f3fe425e0cd21cca70dd0f9",
-            "@ngtools/json-schema": "1.1.0",
+            "@angular-devkit/core": "github:angular/angular-devkit-core-builds#7933a579c0ec16fd8d6c08adf16970ec7af1fe5b",
             "rxjs": "6.0.0"
           }
         }

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "yargs-parser": "^9.0.2"
   },
   "devDependencies": {
+    "@ngtools/json-schema": "^1.1.0",
     "@types/common-tags": "^1.2.4",
     "@types/express": "^4.0.32",
     "@types/fs-extra": "^4.0.0",


### PR DESCRIPTION
It is used by the publishing script, and was previously being added transitively via schematics (removed in https://github.com/angular/devkit/pull/810).