### PR TITLE
docs: fix links to https://webpack.github.io/analyse

### DIFF
--- a/docs/documentation/build.md
+++ b/docs/documentation/build.md
@@ -450,7 +450,7 @@ See https://github.com/angular/angular-cli/issues/7797 for details.
     <code>--stats-json</code>
   </p>
   <p>
-    Generates a 'stats.json' file which can be analyzed using tools such as: #webpack-bundle-analyzer' or https: //webpack.github.io/analyse.
+    Generates a 'stats.json' file which can be analyzed using tools such as: <a href="https://github.com/webpack-contrib/webpack-bundle-analyzer">webpack-bundle-analyzer</a> or <a href="https://webpack.github.io/analyse">webpack.github.io/analyse</a>.
   </p>
 </details>
 <details>

--- a/packages/@angular/cli/lib/config/schema.json
+++ b/packages/@angular/cli/lib/config/schema.json
@@ -725,7 +725,7 @@
             },
             "statsJson": {
               "type": "boolean",
-              "description": "Generates a 'stats.json' file which can be analyzed using tools such as: #webpack-bundle-analyzer' or https: //webpack.github.io/analyse.",
+              "description": "Generates a 'stats.json' file which can be analyzed using tools such as: #webpack-bundle-analyzer' or https://webpack.github.io/analyse .",
               "default": false
             },
             "forkTypeChecker": {
@@ -1458,7 +1458,7 @@
             },
             "statsJson": {
               "type": "boolean",
-              "description": "Generates a 'stats.json' file which can be analyzed using tools such as: #webpack-bundle-analyzer' or https: //webpack.github.io/analyse.",
+              "description": "Generates a 'stats.json' file which can be analyzed using tools such as: #webpack-bundle-analyzer' or https://webpack.github.io/analyse .",
               "default": false
             },
             "forkTypeChecker": {


### PR DESCRIPTION
This patch fixes some links to the WebPack Analyzer