### PR TITLE
fix(@angular/cli): remove mangle and compress from server build

### DIFF
--- a/packages/@angular/cli/models/webpack-config.ts
+++ b/packages/@angular/cli/models/webpack-config.ts
@@ -37,7 +37,7 @@ export class NgCliWebpackConfig<T extends BuildOptions = BuildOptions> {
     const projectRoot = path.dirname(configPath);
 
     appConfig = this.addAppConfigDefaults(appConfig);
-    buildOptions = this.addTargetDefaults(buildOptions);
+    buildOptions = this.addTargetDefaults(buildOptions, appConfig);
     buildOptions = this.mergeConfigs(buildOptions, appConfig, projectRoot);
 
     const tsconfigPath = path.resolve(projectRoot, appConfig.root, appConfig.tsconfig);
@@ -101,7 +101,7 @@ export class NgCliWebpackConfig<T extends BuildOptions = BuildOptions> {
   }
 
   // Fill in defaults for build targets
-  public addTargetDefaults(buildOptions: T): T {
+  public addTargetDefaults(buildOptions: T, appConfig: any): T {
     const targetDefaults: { [target: string]: Partial<BuildOptions> } = {
       development: {
         environment: 'dev',
@@ -126,8 +126,10 @@ export class NgCliWebpackConfig<T extends BuildOptions = BuildOptions> {
 
     // Use Build Optimizer on prod AOT builds by default when AngularCompilerPlugin is supported.
     const buildOptimizerDefault = {
-      buildOptimizer: buildOptions.target == 'production' && buildOptions.aot !== false
+      buildOptimizer: buildOptions.target == 'production'
+        && buildOptions.aot !== false
         && AngularCompilerPlugin.isSupported()
+        && appConfig.platform != 'server'
     };
 
     merged = Object.assign({}, buildOptimizerDefault, merged);

--- a/packages/@angular/cli/models/webpack-configs/production.ts
+++ b/packages/@angular/cli/models/webpack-configs/production.ts
@@ -165,10 +165,10 @@ export function getProdConfig(wco: WebpackConfigOptions) {
           ecma: wco.supportES2015 ? 6 : 5,
           warnings: buildOptions.verbose,
           ie8: false,
-          mangle: {
+          mangle: buildOptions.platform == 'server' ? false : {
             safari10: true,
           },
-          compress: uglifyCompressOptions,
+          compress: buildOptions.platform == 'server' ? false : uglifyCompressOptions,
           output: {
             ascii_only: true,
             comments: false,


### PR DESCRIPTION
Using those for server might break the runtime, and since it all runs on the server
we dont need to compress, local name mangling works fine. Also remove the build
optimizer pass on server optimized builds.

Fixes #8616