### PR TITLE
style(@angular/cli): Alphabetized the keys for the angular:component properties object

### DIFF
--- a/packages/@angular/cli/lib/config/schema.json
+++ b/packages/@angular/cli/lib/config/schema.json
@@ -74,6 +74,23 @@
         "@schematics/angular:component": {
           "type": "object",
           "properties": {
+            "changeDetection": {
+              "description": "Specifies the change detection strategy.",
+              "enum": ["Default", "OnPush"],
+              "type": "string",
+              "default": "Default",
+              "alias": "c"
+            },
+            "export": {
+              "type": "boolean",
+              "default": false,
+              "description": "Specifies if declaring module exports the component."
+            },
+            "flat": {
+              "type": "boolean",
+              "description": "Flag to indicate if a dir is created.",
+              "default": false
+            },
             "inlineStyle": {
               "description": "Specifies if the style will be in the ts file.",
               "type": "boolean",
@@ -86,18 +103,10 @@
               "default": false,
               "alias": "t"
             },
-            "viewEncapsulation": {
-              "description": "Specifies the view encapsulation strategy.",
-              "enum": ["Emulated", "Native", "None"],
+            "module":  {
               "type": "string",
-              "alias": "v"
-            },
-            "changeDetection": {
-              "description": "Specifies the change detection strategy.",
-              "enum": ["Default", "OnPush"],
-              "type": "string",
-              "default": "Default",
-              "alias": "c"
+              "description": "Allows specification of the declaring module.",
+              "alias": "m"
             },
             "prefix": {
               "type": "string",
@@ -105,40 +114,31 @@
               "description": "The prefix to apply to generated selectors.",
               "alias": "p"
             },
-            "styleext": {
-              "description": "The file extension to be used for style files.",
+            "selector": {
               "type": "string",
-              "default": "css"
-            },
-            "spec": {
-              "type": "boolean",
-              "description": "Specifies if a spec file is generated.",
-              "default": true
-            },
-            "flat": {
-              "type": "boolean",
-              "description": "Flag to indicate if a dir is created.",
-              "default": false
+              "format": "html-selector",
+              "description": "The selector to use for the component."
             },
             "skipImport": {
               "type": "boolean",
               "description": "Flag to skip the module import.",
               "default": false
             },
-            "selector": {
-              "type": "string",
-              "format": "html-selector",
-              "description": "The selector to use for the component."
-            },
-            "module":  {
-              "type": "string",
-              "description": "Allows specification of the declaring module.",
-              "alias": "m"
-            },
-            "export": {
+            "spec": {
               "type": "boolean",
-              "default": false,
-              "description": "Specifies if declaring module exports the component."
+              "description": "Specifies if a spec file is generated.",
+              "default": true
+            },
+            "styleext": {
+              "description": "The file extension to be used for style files.",
+              "type": "string",
+              "default": "css"
+            },
+            "viewEncapsulation": {
+              "description": "Specifies the view encapsulation strategy.",
+              "enum": ["Emulated", "Native", "None"],
+              "type": "string",
+              "alias": "v"
             }
           }
         },


### PR DESCRIPTION
style(@angular/cli): Alphabetized the keys for the angular:component properties object

Is there are reason that the keys for the angular:x properties are not alphabetized?

I find it difficult to read when I'm not certain if I should scroll up or down to find a key.

I have alphabetized only the @schematics/angular:component properties' keys to start with on this PR. First, to see if there are objections and second to not make the PR so large that the reviewer can not tell if there is parity.

--Cheers,
Brian
