### PR TITLE
docs(@angular/cli): fix font-awesome.css path for angular.json

### DIFF
--- a/docs/documentation/stories/include-font-awesome.md
+++ b/docs/documentation/stories/include-font-awesome.md
@@ -23,7 +23,7 @@ To add Font Awesome CSS icons to your app...
 "build": {
   "options": {
     "styles": [
-      "../node_modules/font-awesome/css/font-awesome.css"
+      "node_modules/font-awesome/css/font-awesome.css"
       "styles.css"
     ],
   }


### PR DESCRIPTION
The path does not need to go to the parent directory because angular.json
and node_modules are siblings.