### PR TITLE
docs: change proxyConfig folder path to root directory

### DIFF
--- a/docs/documentation/stories/proxy.md
+++ b/docs/documentation/stories/proxy.md
@@ -26,7 +26,7 @@ We can then add the `proxyConfig` option to the serve target:
     "builder": "@angular-devkit/build-angular:dev-server",
     "options": {
       "browserTarget": "your-application-name:build",
-      "proxyConfig": "src/proxy.conf.json"
+      "proxyConfig": "proxy.conf.json"
     },
 ```
 


### PR DESCRIPTION
The directions on line 8 require the creation of the proxy.conf.json file next to the packages.json file which is in the root folder. The error on line 29 pointed the proxyConfig to the src/proxy.conf.json file which does not exist, as that file was placed in the root folder.