### PR TITLE
test: partial lint rule upgrade and fixes

### DIFF
--- a/packages/@angular/cli/commands/add.ts
+++ b/packages/@angular/cli/commands/add.ts
@@ -2,9 +2,9 @@ import { tags, terminal } from '@angular-devkit/core';
 import { NodePackageDoesNotSupportSchematics } from '@angular-devkit/schematics/tools';
 import { CommandScope, Option } from '../models/command';
 import { parseOptions } from '../models/command-runner';
-import { getPackageManager } from '../utilities/config';
 import { SchematicCommand } from '../models/schematic-command';
 import { NpmInstall } from '../tasks/npm-install';
+import { getPackageManager } from '../utilities/config';
 
 
 export default class AddCommand extends SchematicCommand {
@@ -33,7 +33,7 @@ export default class AddCommand extends SchematicCommand {
     if (!collectionName) {
       this.logger.fatal(
         `The "ng ${this.name}" command requires a name argument to be specified eg. `
-        + `${terminal.yellow('ng add [name] ')}. For more details, use "ng help".`
+        + `${terminal.yellow('ng add [name] ')}. For more details, use "ng help".`,
       );
 
       return false;
@@ -48,7 +48,7 @@ export default class AddCommand extends SchematicCommand {
     if (!firstArg) {
       this.logger.fatal(
         `The "ng ${this.name}" command requires a name argument to be specified eg. `
-        + `${terminal.yellow('ng add [name] ')}. For more details, use "ng help".`
+        + `${terminal.yellow('ng add [name] ')}. For more details, use "ng help".`,
       );
 
       return 1;

--- a/packages/@angular/cli/commands/build.ts
+++ b/packages/@angular/cli/commands/build.ts
@@ -1,6 +1,6 @@
-import { Option, CommandScope } from '../models/command';
-import { Version } from '../upgrade/version';
 import { ArchitectCommand, ArchitectCommandOptions } from '../models/architect-command';
+import { CommandScope, Option } from '../models/command';
+import { Version } from '../upgrade/version';
 
 export default class BuildCommand extends ArchitectCommand {
   public readonly name = 'build';
@@ -11,7 +11,7 @@ export default class BuildCommand extends ArchitectCommand {
   public scope = CommandScope.inProject;
   public options: Option[] = [
     this.prodOption,
-    this.configurationOption
+    this.configurationOption,
   ];
 
   public validate(options: ArchitectCommandOptions) {

--- a/packages/@angular/cli/commands/config.ts
+++ b/packages/@angular/cli/commands/config.ts
@@ -1,3 +1,12 @@
+import {
+  JsonArray,
+  JsonObject,
+  JsonParseMode,
+  JsonValue,
+  experimental,
+  parseJson,
+  tags,
+} from '@angular-devkit/core';
 import { writeFileSync } from 'fs';
 import { Command, Option } from '../models/command';
 import {
@@ -6,15 +15,6 @@ import {
   migrateLegacyGlobalConfig,
   validateWorkspace,
 } from '../utilities/config';
-import {
-  JsonValue,
-  JsonArray,
-  JsonObject,
-  JsonParseMode,
-  experimental,
-  parseJson,
-  tags,
-} from '@angular-devkit/core';
 
 
 export interface ConfigOptions {
@@ -162,8 +162,8 @@ export default class ConfigCommand extends Command {
       type: Boolean,
       'default': false,
       aliases: ['g'],
-      description: 'Get/set the value in the global configuration (in your home directory).'
-    }
+      description: 'Get/set the value in the global configuration (in your home directory).',
+    },
   ];
 
   public run(options: ConfigOptions) {

--- a/packages/@angular/cli/commands/doc.ts
+++ b/packages/@angular/cli/commands/doc.ts
@@ -17,8 +17,8 @@ export default class DocCommand extends Command {
       aliases: ['s'],
       type: Boolean,
       default: false,
-      description: 'Search whole angular.io instead of just api.'
-    }
+      description: 'Search whole angular.io instead of just api.',
+    },
   ];
 
   public validate(options: Options) {

--- a/packages/@angular/cli/commands/e2e.ts
+++ b/packages/@angular/cli/commands/e2e.ts
@@ -1,5 +1,5 @@
-import { CommandScope, Option } from '../models/command';
 import { ArchitectCommand, ArchitectCommandOptions } from '../models/architect-command';
+import { CommandScope, Option } from '../models/command';
 
 
 export default class E2eCommand extends ArchitectCommand {
@@ -11,7 +11,7 @@ export default class E2eCommand extends ArchitectCommand {
   public readonly multiTarget = true;
   public readonly options: Option[] = [
     this.prodOption,
-    this.configurationOption
+    this.configurationOption,
   ];
 
   public run(options: ArchitectCommandOptions) {

--- a/packages/@angular/cli/commands/easter-egg.ts
+++ b/packages/@angular/cli/commands/easter-egg.ts
@@ -1,5 +1,5 @@
-import { Command, Option } from '../models/command';
 import { terminal } from '@angular-devkit/core';
+import { Command, Option } from '../models/command';
 
 function pickOne(of: string[]): string {
   return of[Math.floor(Math.random() * of.length)];
@@ -21,7 +21,7 @@ export default class AwesomeCommand extends Command {
       `Nothing to do; already awesome. Exiting.`,
       `Error 418: As Awesome As Can Get.`,
       `I spy with my little eye a great developer!`,
-      `Noop... already awesome.`
+      `Noop... already awesome.`,
     ]);
     this.logger.info(terminal.green(phrase));
   }

--- a/packages/@angular/cli/commands/generate.ts
+++ b/packages/@angular/cli/commands/generate.ts
@@ -1,11 +1,11 @@
+import { tags, terminal } from '@angular-devkit/core';
 import { CommandScope, Option } from '../models/command';
+import { SchematicCommand } from '../models/schematic-command';
 import { getDefaultSchematicCollection } from '../utilities/config';
 import {
   getCollection,
-  getEngineHost
+  getEngineHost,
 } from '../utilities/schematics';
-import { tags, terminal } from '@angular-devkit/core';
-import { SchematicCommand } from '../models/schematic-command';
 
 
 export default class GenerateCommand extends SchematicCommand {
@@ -15,7 +15,7 @@ export default class GenerateCommand extends SchematicCommand {
   public readonly scope = CommandScope.inProject;
   public arguments = ['schematic'];
   public options: Option[] = [
-    ...this.coreOptions
+    ...this.coreOptions,
   ];
 
   private initialized = false;

--- a/packages/@angular/cli/commands/help.ts
+++ b/packages/@angular/cli/commands/help.ts
@@ -1,5 +1,5 @@
-import { Command, Option } from '../models/command';
 import { terminal } from '@angular-devkit/core';
+import { Command, Option } from '../models/command';
 
 
 export default class HelpCommand extends Command {
@@ -18,7 +18,7 @@ export default class HelpCommand extends Command {
       .filter(cmd => !cmd.hidden && !cmd.unknown)
       .map(cmd => ({
         name: cmd.name,
-        description: cmd.description
+        description: cmd.description,
       }));
     this.logger.info(`Available Commands:`);
     commands.forEach(cmd => {

--- a/packages/@angular/cli/commands/lint.ts
+++ b/packages/@angular/cli/commands/lint.ts
@@ -1,5 +1,5 @@
-import { CommandScope, Option } from '../models/command';
 import { ArchitectCommand, ArchitectCommandOptions } from '../models/architect-command';
+import { CommandScope, Option } from '../models/command';
 
 
 export default class LintCommand extends ArchitectCommand {
@@ -10,7 +10,7 @@ export default class LintCommand extends ArchitectCommand {
   public readonly scope = CommandScope.inProject;
   public readonly multiTarget = true;
   public readonly options: Option[] = [
-    this.configurationOption
+    this.configurationOption,
   ];
 
   public async run(options: ArchitectCommandOptions) {

--- a/packages/@angular/cli/commands/new.ts
+++ b/packages/@angular/cli/commands/new.ts
@@ -1,6 +1,6 @@
 import { CommandScope, Option } from '../models/command';
-import { getDefaultSchematicCollection } from '../utilities/config';
 import { SchematicCommand } from '../models/schematic-command';
+import { getDefaultSchematicCollection } from '../utilities/config';
 
 
 export default class NewCommand extends SchematicCommand {
@@ -18,14 +18,14 @@ export default class NewCommand extends SchematicCommand {
       type: Boolean,
       default: false,
       aliases: ['v'],
-      description: 'Adds more details to output logging.'
+      description: 'Adds more details to output logging.',
     },
     {
       name: 'collection',
       type: String,
       aliases: ['c'],
-      description: 'Schematics collection to use.'
-    }
+      description: 'Schematics collection to use.',
+    },
   ];
 
   private initialized = false;
@@ -41,7 +41,7 @@ export default class NewCommand extends SchematicCommand {
 
     return this.getOptions({
         schematicName,
-        collectionName
+        collectionName,
       })
       .then((schematicOptions) => {
         this.options = this.options.concat(schematicOptions.options);
@@ -79,7 +79,7 @@ export default class NewCommand extends SchematicCommand {
       schematicOptions: options,
       debug: options.debug,
       dryRun: options.dryRun,
-      force: options.force
+      force: options.force,
     });
   }
 

--- a/packages/@angular/cli/commands/run.ts
+++ b/packages/@angular/cli/commands/run.ts
@@ -1,5 +1,5 @@
-import { CommandScope, Option } from '../models/command';
 import { ArchitectCommand, ArchitectCommandOptions } from '../models/architect-command';
+import { CommandScope, Option } from '../models/command';
 
 
 export default class RunCommand extends ArchitectCommand {
@@ -8,7 +8,7 @@ export default class RunCommand extends ArchitectCommand {
   public readonly scope = CommandScope.inProject;
   public readonly arguments: string[] = ['target'];
   public readonly options: Option[] = [
-    this.configurationOption
+    this.configurationOption,
   ];
 
   public async run(options: ArchitectCommandOptions) {

--- a/packages/@angular/cli/commands/serve.ts
+++ b/packages/@angular/cli/commands/serve.ts
@@ -1,6 +1,6 @@
+import { ArchitectCommand, ArchitectCommandOptions } from '../models/architect-command';
 import { CommandScope, Option } from '../models/command';
 import { Version } from '../upgrade/version';
-import { ArchitectCommand, ArchitectCommandOptions } from '../models/architect-command';
 
 
 export default class ServeCommand extends ArchitectCommand {
@@ -11,7 +11,7 @@ export default class ServeCommand extends ArchitectCommand {
   public readonly scope = CommandScope.inProject;
   public readonly options: Option[] = [
     this.prodOption,
-    this.configurationOption
+    this.configurationOption,
   ];
 
   public validate(_options: ArchitectCommandOptions) {

--- a/packages/@angular/cli/commands/test.ts
+++ b/packages/@angular/cli/commands/test.ts
@@ -1,5 +1,5 @@
-import { CommandScope, Option } from '../models/command';
 import { ArchitectCommand, ArchitectCommandOptions } from '../models/architect-command';
+import { CommandScope, Option } from '../models/command';
 
 
 export default class TestCommand extends ArchitectCommand {
@@ -11,7 +11,7 @@ export default class TestCommand extends ArchitectCommand {
   public readonly multiTarget = true;
   public readonly options: Option[] = [
     this.prodOption,
-    this.configurationOption
+    this.configurationOption,
   ];
 
   public async run(options: ArchitectCommandOptions) {

--- a/packages/@angular/cli/commands/update.ts
+++ b/packages/@angular/cli/commands/update.ts
@@ -1,6 +1,6 @@
 import { normalize } from '@angular-devkit/core';
 import { CommandScope, Option } from '../models/command';
-import { SchematicCommand, CoreSchematicOptions } from '../models/schematic-command';
+import { CoreSchematicOptions, SchematicCommand } from '../models/schematic-command';
 import { findUp } from '../utilities/find-up';
 
 export interface UpdateOptions extends CoreSchematicOptions {

--- a/packages/@angular/cli/commands/version.ts
+++ b/packages/@angular/cli/commands/version.ts
@@ -1,8 +1,8 @@
 import { terminal } from '@angular-devkit/core';
-import { Command, Option } from '../models/command';
+import * as child_process from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
-import * as child_process from 'child_process';
+import { Command, Option } from '../models/command';
 import { findUp } from '../utilities/find-up';
 
 
@@ -15,7 +15,7 @@ export default class VersionCommand extends Command {
 
   public run(_options: any) {
     let angularCoreVersion = '';
-    let angularSameAsCore: string[] = [];
+    const angularSameAsCore: string[] = [];
     const pkg = require(path.resolve(__dirname, '..', 'package.json'));
     let projPkg: any;
     try {
@@ -96,7 +96,7 @@ export default class VersionCommand extends Command {
     }
 
     const namePad = ' '.repeat(
-      Object.keys(versions).sort((a, b) => b.length - a.length)[0].length + 3
+      Object.keys(versions).sort((a, b) => b.length - a.length)[0].length + 3,
     );
     const asciiArt = `
      _                      _                 ____ _     ___

--- a/packages/@angular/cli/commands/xi18n.ts
+++ b/packages/@angular/cli/commands/xi18n.ts
@@ -1,5 +1,5 @@
-import { CommandScope, Option } from '../models/command';
 import { ArchitectCommand, ArchitectCommandOptions } from '../models/architect-command';
+import { CommandScope, Option } from '../models/command';
 
 
 export default class Xi18nCommand extends ArchitectCommand {
@@ -9,7 +9,7 @@ export default class Xi18nCommand extends ArchitectCommand {
   public readonly scope = CommandScope.inProject;
   public readonly multiTarget: true;
   public readonly options: Option[] = [
-    this.configurationOption
+    this.configurationOption,
   ];
 
   public async run(options: ArchitectCommandOptions) {

--- a/packages/@angular/cli/custom-typings.d.ts
+++ b/packages/@angular/cli/custom-typings.d.ts
@@ -32,7 +32,6 @@ declare module 'yargs-parser' {
 }
 
 
-
 declare module 'opn' {
   export default function(url: string, options?: any): Promise<any>;
 }

--- a/packages/@angular/cli/lib/cli/index.ts
+++ b/packages/@angular/cli/lib/cli/index.ts
@@ -1,5 +1,5 @@
-import { filter } from 'rxjs/operators';
 import { logging, terminal } from '@angular-devkit/core';
+import { filter } from 'rxjs/operators';
 import { runCommand } from '../../models/command-runner';
 import { getProjectDetails } from '../../utilities/project';
 
@@ -53,7 +53,7 @@ export default async function(options: any) {
     projectDetails = { root: process.cwd() };
   }
   const context = {
-    project: projectDetails
+    project: projectDetails,
   };
 
   try {

--- a/packages/@angular/cli/lib/init.ts
+++ b/packages/@angular/cli/lib/init.ts
@@ -79,7 +79,7 @@ try {
   }
 
   if (shouldWarn && isWarningEnabled('versionMismatch')) {
-    let warning = yellow(stripIndents`
+    const warning = yellow(stripIndents`
     Your global Angular CLI version (${globalVersion}) is greater than your local
     version (${localVersion}). The local Angular CLI version is used.
 

--- a/packages/@angular/cli/models/architect-command.ts
+++ b/packages/@angular/cli/models/architect-command.ts
@@ -1,14 +1,14 @@
+import {
+  Architect, BuildEvent, BuilderDescription,
+  TargetSpecifier,
+} from '@angular-devkit/architect';
 import { JsonObject, experimental, schema, strings } from '@angular-devkit/core';
 import { NodeJsSyncHost, createConsoleLogger } from '@angular-devkit/core/node';
-import {
-  Architect, BuilderDescription, BuildEvent,
-  TargetSpecifier
-} from '@angular-devkit/architect';
-import { Command, Option } from './command';
 import { of } from 'rxjs';
 import { from } from 'rxjs';
 import { concatMap, map, tap, toArray } from 'rxjs/operators';
 import { WorkspaceLoader } from '../models/workspace-loader';
+import { Command, Option } from './command';
 
 
 export interface ProjectAndConfigurationOptions {
@@ -36,7 +36,7 @@ export abstract class ArchitectCommand extends Command<ArchitectCommandOptions> 
     name: 'configuration',
     description: 'The configuration',
     type: String,
-    aliases: ['c']
+    aliases: ['c'],
   }];
 
   readonly arguments = ['project'];
@@ -68,9 +68,9 @@ export abstract class ArchitectCommand extends Command<ArchitectCommandOptions> 
         const builderConfig = this._architect.getBuilderConfiguration(targetSpec);
 
         return this._architect.getBuilderDescription(builderConfig).pipe(
-          tap<BuilderDescription>(builderDesc => { this.mapArchitectOptions(builderDesc.schema); })
+          tap<BuilderDescription>(builderDesc => { this.mapArchitectOptions(builderDesc.schema); }),
         );
-      })
+      }),
     ).toPromise()
       .then(() => { });
   }
@@ -138,14 +138,14 @@ export abstract class ArchitectCommand extends Command<ArchitectCommandOptions> 
   protected prodOption: Option = {
     name: 'prod',
     description: 'Flag to set configuration to "prod".',
-    type: Boolean
+    type: Boolean,
   };
 
   protected configurationOption: Option = {
     name: 'configuration',
     description: 'Specify the configuration to use.',
     type: String,
-    aliases: ['c']
+    aliases: ['c'],
   };
 
   protected async runArchitectTarget(options: ArchitectCommandOptions): Promise<number> {
@@ -153,9 +153,9 @@ export abstract class ArchitectCommand extends Command<ArchitectCommandOptions> 
 
     const runSingleTarget = (targetSpec: TargetSpecifier) => this._architect.run(
       this._architect.getBuilderConfiguration(targetSpec),
-      { logger: this._logger }
+      { logger: this._logger },
     ).pipe(
-      map((buildEvent: BuildEvent) => buildEvent.success ? 0 : 1)
+      map((buildEvent: BuildEvent) => buildEvent.success ? 0 : 1),
     );
 
     try {
@@ -197,7 +197,7 @@ export abstract class ArchitectCommand extends Command<ArchitectCommandOptions> 
 
   private getProjectNamesByTarget(targetName: string): string[] {
     const allProjectsForTargetName = this._workspace.listProjectNames().map(projectName =>
-      this._architect.listProjectTargets(projectName).includes(targetName) ? projectName : null
+      this._architect.listProjectTargets(projectName).includes(targetName) ? projectName : null,
     ).filter(x => !!x);
 
     if (this.multiTarget) {
@@ -258,7 +258,7 @@ export abstract class ArchitectCommand extends Command<ArchitectCommandOptions> 
       project,
       configuration,
       target,
-      overrides
+      overrides,
     };
   }
 }

--- a/packages/@angular/cli/models/command-runner.ts
+++ b/packages/@angular/cli/models/command-runner.ts
@@ -1,12 +1,12 @@
-import {
-  Option,
-  CommandContext,
-  CommandConstructor,
-  CommandScope,
-  ArgumentStrategy
-} from '../models/command';
 import { logging, tags } from '@angular-devkit/core';
 import { camelize } from '@angular-devkit/core/src/utils/strings';
+import {
+  ArgumentStrategy,
+  CommandConstructor,
+  CommandContext,
+  CommandScope,
+  Option,
+} from '../models/command';
 import { insideProject } from '../utilities/project';
 
 import * as yargsParser from 'yargs-parser';
@@ -207,7 +207,7 @@ export function parseOptions<T = any>(
     boolean: booleans,
     default: defaults,
     string: strings,
-    number: numbers
+    number: numbers,
   };
 
   const parsedOptions = parser(args, yargsOptions);

--- a/packages/@angular/cli/models/command.ts
+++ b/packages/@angular/cli/models/command.ts
@@ -9,12 +9,12 @@ export interface CommandConstructor {
 export enum CommandScope {
   everywhere,
   inProject,
-  outsideProject
+  outsideProject,
 }
 
 export enum ArgumentStrategy {
   MapToOptions,
-  Nothing
+  Nothing,
 }
 
 export abstract class Command<T = any> {

--- a/packages/@angular/cli/models/error.ts
+++ b/packages/@angular/cli/models/error.ts
@@ -5,7 +5,7 @@ export class NgToolkitError extends Error {
     if (message) {
       this.message = message;
     } else {
-      this.message = (<any>this.constructor).name;
+      this.message = (<any> this.constructor).name;
     }
   }
 }

--- a/packages/@angular/cli/models/schematic-command.ts
+++ b/packages/@angular/cli/models/schematic-command.ts
@@ -1,14 +1,14 @@
-import { experimental, JsonObject } from '@angular-devkit/core';
+import { JsonObject, experimental } from '@angular-devkit/core';
 import { normalize, strings, tags, terminal, virtualFs } from '@angular-devkit/core';
 import { NodeJsSyncHost } from '@angular-devkit/core/node';
-import { ArgumentStrategy, Command, Option } from './command';
-import { NodeWorkflow } from '@angular-devkit/schematics/tools';
 import { DryRunEvent, UnsuccessfulWorkflowExecution } from '@angular-devkit/schematics';
-import { getPackageManager, getDefaultSchematicCollection } from '../utilities/config';
-import { getCollection, getSchematic } from '../utilities/schematics';
-import { getSchematicDefaults } from '../utilities/config';
+import { NodeWorkflow } from '@angular-devkit/schematics/tools';
 import { take } from 'rxjs/operators';
 import { WorkspaceLoader } from '../models/workspace-loader';
+import { getDefaultSchematicCollection, getPackageManager } from '../utilities/config';
+import { getSchematicDefaults } from '../utilities/config';
+import { getCollection, getSchematic } from '../utilities/schematics';
+import { ArgumentStrategy, Command, Option } from './command';
 
 export interface CoreSchematicOptions {
   dryRun: boolean;
@@ -50,14 +50,14 @@ export abstract class SchematicCommand extends Command {
       type: Boolean,
       default: false,
       aliases: ['d'],
-      description: 'Run through without making any changes.'
+      description: 'Run through without making any changes.',
     },
     {
       name: 'force',
       type: Boolean,
       default: false,
       aliases: ['f'],
-      description: 'Forces overwriting of files.'
+      description: 'Forces overwriting of files.',
     }];
 
   readonly arguments = ['project'];
@@ -231,7 +231,7 @@ export abstract class SchematicCommand extends Command {
     if (!schematic.description.schemaJson) {
       return Promise.resolve({
         options: [],
-        arguments: []
+        arguments: [],
       });
     }
 
@@ -302,7 +302,7 @@ export abstract class SchematicCommand extends Command {
 
     return Promise.resolve({
       options: schematicOptions,
-      arguments: schematicArguments
+      arguments: schematicArguments,
     });
   }
 
@@ -321,7 +321,7 @@ export abstract class SchematicCommand extends Command {
               // Ignore missing workspace
               throw err;
             }
-          }
+          },
         );
     } catch (err) {
       if (!this.allowMissingWorkspace) {

--- a/packages/@angular/cli/models/workspace-loader.ts
+++ b/packages/@angular/cli/models/workspace-loader.ts
@@ -1,16 +1,16 @@
 import {
   Path,
   basename,
-  experimental,
   dirname,
+  experimental,
   join,
   normalize,
-  virtualFs
+  virtualFs,
 } from '@angular-devkit/core';
-import { Observable, of } from 'rxjs';
-import { concatMap, tap } from 'rxjs/operators';
 import * as fs from 'fs';
 import { homedir } from 'os';
+import { Observable, of } from 'rxjs';
+import { concatMap, tap } from 'rxjs/operators';
 import { findUp } from '../utilities/find-up';
 
 
@@ -26,13 +26,13 @@ export class WorkspaceLoader {
 
   loadGlobalWorkspace(): Observable<experimental.workspace.Workspace | null> {
     return this._getGlobalWorkspaceFilePath().pipe(
-      concatMap(globalWorkspacePath => this._loadWorkspaceFromPath(globalWorkspacePath))
+      concatMap(globalWorkspacePath => this._loadWorkspaceFromPath(globalWorkspacePath)),
     );
   }
 
   loadWorkspace(projectPath?: string): Observable<experimental.workspace.Workspace | null> {
     return this._getProjectWorkspaceFilePath(projectPath).pipe(
-      concatMap(globalWorkspacePath => this._loadWorkspaceFromPath(globalWorkspacePath))
+      concatMap(globalWorkspacePath => this._loadWorkspaceFromPath(globalWorkspacePath)),
     );
   }
 
@@ -78,7 +78,7 @@ export class WorkspaceLoader {
     const workspace = new experimental.workspace.Workspace(workspaceRoot, this._host);
 
     return workspace.loadWorkspaceFromHost(workspaceFileName).pipe(
-      tap(workspace => this._workspaceCacheMap.set(workspacePath, workspace))
+      tap(workspace => this._workspaceCacheMap.set(workspacePath, workspace)),
     );
   }
 }

--- a/packages/@angular/cli/tasks/npm-install.ts
+++ b/packages/@angular/cli/tasks/npm-install.ts
@@ -1,6 +1,6 @@
+import { logging, terminal } from '@angular-devkit/core';
 import { ModuleNotFoundException, resolve } from '@angular-devkit/core/node';
 import { spawn } from 'child_process';
-import { logging, terminal } from '@angular-devkit/core';
 
 
 export type NpmInstall = (packageName: string,
@@ -53,7 +53,7 @@ export default async function (packageName: string,
   }
   const installOptions = {
     stdio: 'inherit',
-    shell: true
+    shell: true,
   };
 
   await new Promise((resolve, reject) => {

--- a/packages/@angular/cli/upgrade/version.ts
+++ b/packages/@angular/cli/upgrade/version.ts
@@ -1,6 +1,6 @@
-import { SemVer, satisfies } from 'semver';
 import { tags, terminal } from '@angular-devkit/core';
 import * as path from 'path';
+import { SemVer, satisfies } from 'semver';
 import { isWarningEnabled } from '../utilities/config';
 import { requireProjectModule } from '../utilities/require-project-module';
 
@@ -50,11 +50,12 @@ export class Version {
       process.exit(2);
     }
 
-    let angularVersion = new Version(angularPkgJson['version']);
-    let rxjsVersion = new Version(rxjsPkgJson['version']);
+    const angularVersion = new Version(angularPkgJson['version']);
+    const rxjsVersion = new Version(rxjsPkgJson['version']);
 
     if (angularVersion.isLocal()) {
       console.warn(terminal.yellow('Using a local version of angular. Proceeding with care...'));
+
       return;
     }
 

--- a/packages/@angular/cli/utilities/bundle-calculator.ts
+++ b/packages/@angular/cli/utilities/bundle-calculator.ts
@@ -143,7 +143,7 @@ class AnyScriptCalculator extends Calculator {
         const asset = this.compilation.assets[key];
         return {
           size: asset.size(),
-          label: key
+          label: key,
         };
       });
   }
@@ -159,7 +159,7 @@ class AnyCalculator extends Calculator {
         const asset = this.compilation.assets[key];
         return {
           size: asset.size(),
-          label: key
+          label: key,
         };
       });
   }

--- a/packages/@angular/cli/utilities/config.ts
+++ b/packages/@angular/cli/utilities/config.ts
@@ -1,8 +1,6 @@
-import { existsSync, readFileSync, writeFileSync } from 'fs';
-import * as os from 'os';
-import * as path from 'path';
 import {
   JsonAstObject,
+  JsonObject,
   JsonParseMode,
   JsonValue,
   experimental,
@@ -10,9 +8,11 @@ import {
   parseJson,
   parseJsonAst,
   virtualFs,
-  JsonObject,
 } from '@angular-devkit/core';
 import { NodeJsSyncHost } from '@angular-devkit/core/node';
+import { existsSync, readFileSync, writeFileSync } from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import { findUp } from './find-up';
 
 function getSchemaLocation(): string {
@@ -56,7 +56,7 @@ export function getWorkspace(
     return cached;
   }
 
-  let configPath = level === 'local' ? projectFilePath() : globalFilePath();
+  const configPath = level === 'local' ? projectFilePath() : globalFilePath();
 
   if (!configPath) {
     cachedWorkspaces.set(level, null);
@@ -195,7 +195,7 @@ export function migrateLegacyGlobalConfig(): boolean {
       if (legacy.warnings && typeof legacy.warnings == 'object'
           && !Array.isArray(legacy.warnings)) {
 
-        let warnings: JsonObject = {};
+        const warnings: JsonObject = {};
         if (typeof legacy.warnings.versionMismatch == 'boolean') {
           warnings['versionMismatch'] = legacy.warnings.versionMismatch;
         }

--- a/packages/@angular/cli/utilities/find-up.ts
+++ b/packages/@angular/cli/utilities/find-up.ts
@@ -1,5 +1,5 @@
-import * as path from 'path';
 import { existsSync } from 'fs';
+import * as path from 'path';
 
 export function findUp(names: string | string[], from: string) {
   if (!Array.isArray(names)) {

--- a/packages/@angular/cli/utilities/project.ts
+++ b/packages/@angular/cli/utilities/project.ts
@@ -1,8 +1,8 @@
+import { normalize } from '@angular-devkit/core';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { findUp } from './find-up';
-import { normalize } from '@angular-devkit/core';
 
 export function insideProject(): boolean {
   return getProjectDetails() !== null;

--- a/packages/@angular/cli/utilities/schematics.ts
+++ b/packages/@angular/cli/utilities/schematics.ts
@@ -17,7 +17,7 @@ import {
   FileSystemCollectionDesc,
   FileSystemSchematicDesc,
   NodeModulesEngineHost,
-  validateOptionsWithSchema
+  validateOptionsWithSchema,
 } from '@angular-devkit/schematics/tools';
 
 export class UnknownCollectionError extends Error {

--- a/tests/e2e_runner.ts
+++ b/tests/e2e_runner.ts
@@ -1,16 +1,16 @@
 // This may seem awkward but we're using Logger in our e2e. At this point the unit tests
 // have run already so it should be "safe", teehee.
 import { logging } from '@angular-devkit/core';
-import { createConsoleLogger } from '@angular-devkit/core/node';
 import { terminal } from '@angular-devkit/core';
-import {gitClean} from './e2e/utils/git';
+import { createConsoleLogger } from '@angular-devkit/core/node';
 import * as glob from 'glob';
 import * as minimist from 'minimist';
 import * as path from 'path';
-import {setGlobalVariable} from './e2e/utils/env';
+import { setGlobalVariable } from './e2e/utils/env';
+import { gitClean } from './e2e/utils/git';
 
 // RxJS
-import {filter} from 'rxjs/operators';
+import { filter } from 'rxjs/operators';
 
 const { blue, bold, green, red, yellow, white } = terminal;
 
@@ -53,7 +53,7 @@ const argv = minimist(process.argv.slice(2), {
     'verbose',
   ],
   'string': ['devkit', 'glob', 'ignore', 'reuse', 'ng-sha', 'tmpdir', 'ng-version'],
-  'number': ['nb-shards', 'shard']
+  'number': ['nb-shards', 'shard'],
 });
 
 

--- a/tools/publish/src/build-schema.ts
+++ b/tools/publish/src/build-schema.ts
@@ -1,6 +1,6 @@
-import * as fs from 'fs';
 import { logging } from '@angular-devkit/core';
 import { SchemaClassFactory } from '@ngtools/json-schema';
+import * as fs from 'fs';
 
 
 export function buildSchema(inFile: string, _logger: logging.Logger): string {

--- a/tools/publish/src/changelog.ts
+++ b/tools/publish/src/changelog.ts
@@ -19,7 +19,7 @@ const changelogStream = fs.createWriteStream('CHANGELOG-delta.md');
 
 const config = {
   preset: 'angular',
-  releaseCount: 1
+  releaseCount: 1,
 };
 
 function prependDelta() {

--- a/tools/publish/src/generate-docs.ts
+++ b/tools/publish/src/generate-docs.ts
@@ -1,11 +1,11 @@
-import * as fs from 'fs';
-import * as path from 'path';
 import { logging, schema, strings, tags } from '@angular-devkit/core';
 import { formats } from '@angular-devkit/schematics';
 import {
   NodeModulesEngineHost,
-  validateOptionsWithSchema
+  validateOptionsWithSchema,
 } from '@angular-devkit/schematics/tools';
+import * as fs from 'fs';
+import * as path from 'path';
 
 export default async function () {
   const commandsPath = __dirname + '/../../../packages/@angular/cli/commands';
@@ -48,7 +48,7 @@ export default async function () {
             name: strings.dasherize(schematicName),
             namePrefix: 'generate ',
             description: schematic.description,
-            path: 'generate'
+            path: 'generate',
           },
         );
       }

--- a/tools/publish/src/main.ts
+++ b/tools/publish/src/main.ts
@@ -1,13 +1,13 @@
 import { logging, terminal } from '@angular-devkit/core';
 import * as minimist from 'minimist';
 
-import {filter} from 'rxjs/operators';
+import { filter } from 'rxjs/operators';
 
 
 const { bold, red, yellow, white } = terminal;
 
 const argv = minimist(process.argv.slice(2), {
-  boolean: ['verbose']
+  boolean: ['verbose'],
 });
 
 const rootLogger = new logging.IndentLogger('cling');

--- a/tools/publish/src/update-version.ts
+++ b/tools/publish/src/update-version.ts
@@ -1,7 +1,7 @@
 import { logging } from '@angular-devkit/core';
 import * as fs from 'fs';
 import * as path from 'path';
-import {SemVer} from 'semver';
+import { SemVer } from 'semver';
 
 export default function patch(args: string[], opts: any, logger: logging.Logger): void {
   const newVersion = args[0];

--- a/tslint.json
+++ b/tslint.json
@@ -1,5 +1,14 @@
 {
   "rules": {
+    "no-implicit-dependencies": false,
+    "no-import-side-effect": [true, {"ignore-module": "^(?!rxjs\/)"}],
+    "align": [
+      true,
+      "elements",
+      "members",
+      "parameters",
+      "statements"
+    ],
     "max-line-length": [true, 100],
     "no-inferrable-types": true,
     "class-name": true,
@@ -12,27 +21,48 @@
       "spaces"
     ],
     "eofline": true,
+    "import-spacing": true,
+    "match-default-export-name": true,
+    "newline-before-return": false,
+    "no-consecutive-blank-lines": [true, 2],
     "no-duplicate-variable": true,
     "no-eval": true,
+    "no-any": false,
     "no-arg": true,
     "no-internal-module": true,
     "no-trailing-whitespace": true,
-    "no-bitwise": true,
     "no-unused-expression": true,
+    "no-unused-variable": [true, {"ignore-pattern": "^_"}],
     "no-var-keyword": true,
     "one-line": [
       true,
       "check-catch",
       "check-else",
+      "check-finally",
       "check-open-brace",
       "check-whitespace"
     ],
+    "ordered-imports": [
+      true,
+      {
+        "import-sources-order": "lowercase-last",
+        "named-imports-order": "lowercase-last"
+      }
+    ],
+    "prefer-const": true,
     "quotemark": [
       true,
       "single",
       "avoid-escape"
     ],
     "semicolon": [true, "always"],
+    "trailing-comma": [
+      true,
+      {
+        "multiline": "always",
+        "singleline": "never"
+      }
+    ],
     "typedef-whitespace": [
       true,
       {
@@ -55,9 +85,12 @@
       true,
       "check-branch",
       "check-decl",
+      "check-module",
+      "check-preblock",
       "check-operator",
       "check-separator",
-      "check-type"
+      "check-type",
+      "check-typecast"
     ]
   }
 }


### PR DESCRIPTION
`no-implicit-dependencies`, `newline-before-return`, and `no-any` are not yet enabled and will be handled in later PRs.