### PR TITLE
docs(@angular/cli): add note to configuration flag

### DIFF
--- a/docs/documentation/build.md
+++ b/docs/documentation/build.md
@@ -78,6 +78,7 @@ See https://github.com/angular/angular-cli/issues/7797 for details.
   </p>
   <p>
     Specify the configuration to use.
+    Note: Prior to version 6.0.0 this flag was --env
   </p>
 </details>
 <details>

--- a/docs/documentation/serve.md
+++ b/docs/documentation/serve.md
@@ -26,6 +26,7 @@ ng serve [project]
   </p>
   <p>
     Specify the configuration to use.
+    Note: Prior to version 6.0.0 this flag was --env
   </p>
 </details>
 <details>

--- a/docs/documentation/test.md
+++ b/docs/documentation/test.md
@@ -32,6 +32,7 @@ You can run tests with coverage via `--code-coverage`. The coverage report will 
   </p>
   <p>
     Specify the configuration to use.
+    Note: Prior to version 6.0.0 this flag was --env
   </p>
 </details>
 <details>


### PR DESCRIPTION
Added a note to the configuration flag description in the build, serve
and test wiki pages that mentions that the flag was previously named env