### PR TITLE
docs: remove --single-run as it is no more valid

### DIFF
--- a/docs/documentation/home.md
+++ b/docs/documentation/home.md
@@ -33,7 +33,7 @@ or `ng serve --prod` will also make use of uglifying and tree-shaking functional
 ng test
 ```
 
-Tests will execute after a build is executed via [Karma](http://karma-runner.github.io/0.13/index.html), and it will automatically watch your files for changes. You can run tests a single time via `--watch=false` or `--single-run`.
+Tests will execute after a build is executed via [Karma](http://karma-runner.github.io/0.13/index.html), and it will automatically watch your files for changes. You can run tests a single time via `--watch=false`.
 
 ### Running end-to-end tests
 


### PR DESCRIPTION
Running the CLI v6 with `--single-run` returns an error `Unkown option: '--singleRun'`. Since in the [ng test](https://github.com/angular/angular-cli/wiki/test) command wiki page also doesn't mention it, I guess it's an obsolete command.