### PR TITLE
fix(@angular/cli): support codeFrame format with ng lint

### DIFF
--- a/docs/documentation/1-x/lint.md
+++ b/docs/documentation/1-x/lint.md
@@ -42,6 +42,6 @@
     <code>--format</code> (aliases: <code>-t</code>) <em>default value: prose</em>
   </p>
   <p>
-    Output format (prose, json, stylish, verbose, pmd, msbuild, checkstyle, vso, fileslist).
+    Output format (prose, json, stylish, verbose, pmd, msbuild, checkstyle, vso, fileslist, codeFrame).
   </p>
 </details>

--- a/docs/documentation/lint.md
+++ b/docs/documentation/lint.md
@@ -70,6 +70,6 @@ ng lint [project]
     <code>--format</code>
   </p>
   <p>
-    Output format (prose, json, stylish, verbose, pmd, msbuild, checkstyle, vso, fileslist).
+    Output format (prose, json, stylish, verbose, pmd, msbuild, checkstyle, vso, fileslist, codeFrame).
   </p>
 </details>

--- a/packages/@angular/cli/lib/config/schema.json
+++ b/packages/@angular/cli/lib/config/schema.json
@@ -1566,7 +1566,7 @@
             },
             "format": {
               "type": "string",
-              "description": "Output format (prose, json, stylish, verbose, pmd, msbuild, checkstyle, vso, fileslist).",
+              "description": "Output format (prose, json, stylish, verbose, pmd, msbuild, checkstyle, vso, fileslist, codeFrame).",
               "default": "prose",
               "enum": [
                 "prose",
@@ -1577,7 +1577,8 @@
                 "msbuild",
                 "checkstyle",
                 "vso",
-                "fileslist"
+                "fileslist",
+                "codeFrame"
               ]
             },
             "exclude": {


### PR DESCRIPTION
After upgrading to v6 I was not able to run ng lint on my project with the format option set to `codeFrame`.

I believe it's just been forgotten has it's a [valid option on TSLint](https://github.com/palantir/tslint/blob/7199227d683a2c275681a551341c8dfa5d1cdc6e/docs/usage/cli/index.md#cli-usage).

