### PR TITLE
fix: Change CLI exit code to 1 when quitting for unknown options #10759

### DIFF
--- a/packages/@angular/cli/models/architect-command.ts
+++ b/packages/@angular/cli/models/architect-command.ts
@@ -172,6 +172,7 @@ export abstract class ArchitectCommand extends Command<ArchitectCommandOptions> 
     } catch (e) {
       if (e instanceof schema.SchemaValidationException) {
         const newErrors: schema.SchemaValidatorError[] = [];
+        let fatalErrors = 0;
         e.errors.forEach(schemaError => {
           if (schemaError.keyword === 'additionalProperties') {
             const unknownProperty = schemaError.params.additionalProperty;
@@ -179,11 +180,15 @@ export abstract class ArchitectCommand extends Command<ArchitectCommandOptions> 
               const dashes = unknownProperty.length === 1 ? '-' : '--';
               this.logger.fatal(`Unknown option: '${dashes}${unknownProperty}'`);
 
-              return 1;
+              fatalErrors++;
             }
           }
           newErrors.push(schemaError);
         });
+
+        if (fatalErrors > 0) {
+          return 1;
+        }
 
         if (newErrors.length > 0) {
           this.logger.error(new schema.SchemaValidationException(newErrors).message);


### PR DESCRIPTION
This is a proposal based on my vague understanding of what's going on.

One of the various flag changes broke our integration when someone upgraded us to Angular 6.

Our build system assumed that commands would exit 0 when they did their job, or exit non zero when they failed.

Instead, the ng command exited 0, and didn't do its job. Unfortunately, we didn't have enough test coverage to recognize this, and thus a package was created that didn't include its package...