### PR TITLE
Update proxy.md with Correct Path

### DIFF
--- a/docs/documentation/stories/proxy.md
+++ b/docs/documentation/stories/proxy.md
@@ -26,7 +26,7 @@ We can then add the `proxyConfig` option to the serve target:
     "builder": "@angular-devkit/build-angular:dev-server",
     "options": {
       "browserTarget": "your-application-name:build",
-      "proxyConfig": "src/proxy.conf.json"
+      "proxyConfig": "proxy.conf.json"
     },
 ```
 


### PR DESCRIPTION
When adding proxy configuration in angular.json, it appears to be incorrect to keep 'src/' as part of the path to the proxy file.  The documentation says to create a proxy.conf.json file "next to", which I interpret as "in the same directory", the package.json file which resides in the root directory.  Therefore, by including'src/' in the path to the newly proxy file I get an error.  It seems the correct configuration is just 'proxyConfig": "proxy.conf.json"'.