### PR TITLE
feat(@schematics/angular): simplify service test

### DIFF
--- a/packages/schematics/angular/service/files/__name@dasherize@if-flat__/__name@dasherize__.service.spec.ts
+++ b/packages/schematics/angular/service/files/__name@dasherize@if-flat__/__name@dasherize__.service.spec.ts
@@ -1,15 +1,12 @@
-import { TestBed, inject } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 
 import { <%= classify(name) %>Service } from './<%= dasherize(name) %>.service';
 
 describe('<%= classify(name) %>Service', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [<%= classify(name) %>Service]
-    });
-  });
+  beforeEach(() => TestBed.configureTestingModule({}));
 
-  it('should be created', inject([<%= classify(name) %>Service], (service: <%= classify(name) %>Service) => {
+  it('should be created', () => {
+    const service: <%= classify(name) %>Service = TestBed.get(<%= classify(name) %>Service);
     expect(service).toBeTruthy();
-  }));
+  });
 });


### PR DESCRIPTION
Note: this is PR https://github.com/angular/devkit/pull/654 from devkit now that the package has moved.

Now that the service schematic uses `providedIn` by default,
we can simplify the test to use `TestBed.configureTestingModule({})`.

Also use `TestBed.get()` instead of the `inject` wrapper.