### PR TITLE
Allow less-loader to use webpack resolver when no includePaths are given

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/styles.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/styles.ts
@@ -158,7 +158,7 @@ export function getStylesConfig(wco: WebpackConfigOptions) {
 
   // use includePaths from appConfig
   const includePaths: string[] = [];
-  let lessPathOptions: { paths: string[] } = { paths: [] };
+  let lessPathOptions: { paths?: string[] } = { };
 
   if (buildOptions.stylePreprocessorOptions
     && buildOptions.stylePreprocessorOptions.includePaths


### PR DESCRIPTION
- If you look at https://github.com/webpack-contrib/less-loader#less-resolver, it states that
if you provide paths, it will use the less resolver. We should only use the less-resolver when
stylePreprocessorOptions.includePaths are actually given.
- This fixes issues where if in your less file you `@import "~@dependency/less-file";` it actually
resolves correct and when you import something like `@import "some-local-file";` it actually
recompiles when `ng build --watch` is ran.