### PR TITLE
refactor: remove usage of Buffer constructor

### DIFF
--- a/packages/angular_devkit/core/src/utils/template.ts
+++ b/packages/angular_devkit/core/src/utils/template.ts
@@ -334,7 +334,7 @@ function templateWithSourceMap(ast: TemplateAst, options?: TemplateOptions): str
 
   return code.code
        + '\n//# sourceMappingURL=data:application/json;base64,'
-       + new Buffer(code.map.toString()).toString('base64');
+       + Buffer.from(code.map.toString()).toString('base64');
 }
 
 

--- a/packages/angular_devkit/core/src/virtual-fs/host/buffer.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/host/buffer.ts
@@ -56,7 +56,7 @@ export function fileBufferToString(fileBuffer: FileBuffer): string {
   if (fileBuffer.toString.length == 1) {
     return (fileBuffer.toString as (enc: string) => string)('utf-8');
   } else if (typeof Buffer !== 'undefined') {
-    return new Buffer(fileBuffer).toString('utf-8');
+    return Buffer.from(fileBuffer).toString('utf-8');
   } else if (typeof TextDecoder !== 'undefined') {
     // Modern browsers implement TextEncode.
     return new TextDecoder('utf-8').decode(new Uint8Array(fileBuffer));

--- a/packages/angular_devkit/schematics/src/rules/template.ts
+++ b/packages/angular_devkit/schematics/src/rules/template.ts
@@ -47,7 +47,7 @@ export function applyContentTemplate<T extends TemplateOptions>(options: T): Fil
 
     return {
       path: path,
-      content: new Buffer(templateImpl(content.toString('utf-8'), {})(options)),
+      content: Buffer.from(templateImpl(content.toString('utf-8'), {})(options)),
     };
   };
 }

--- a/packages/angular_devkit/schematics/src/rules/template_spec.ts
+++ b/packages/angular_devkit/schematics/src/rules/template_spec.ts
@@ -26,7 +26,7 @@ function _entry(path?: string, content?: string): FileEntry {
 
   return {
     path: normalize(path),
-    content: new Buffer(content),
+    content: Buffer.from(content),
   };
 }
 

--- a/packages/angular_devkit/schematics/src/tree/action_spec.ts
+++ b/packages/angular_devkit/schematics/src/tree/action_spec.ts
@@ -14,9 +14,9 @@ describe('Action', () => {
     it('works with create', () => {
       const actions = new ActionList;
 
-      actions.create(normalize('/a/b'), new Buffer('1'));
-      actions.create(normalize('/a/c'), new Buffer('2'));
-      actions.create(normalize('/a/c'), new Buffer('3'));
+      actions.create(normalize('/a/b'), Buffer.from('1'));
+      actions.create(normalize('/a/c'), Buffer.from('2'));
+      actions.create(normalize('/a/c'), Buffer.from('3'));
 
       expect(actions.length).toBe(3);
       actions.optimize();
@@ -25,10 +25,10 @@ describe('Action', () => {
     it('works with overwrite', () => {
       const actions = new ActionList;
 
-      actions.create(normalize('/a/b'), new Buffer('1'));
-      actions.create(normalize('/a/c'), new Buffer('2'));
-      actions.overwrite(normalize('/a/c'), new Buffer('3'));
-      actions.overwrite(normalize('/a/b'), new Buffer('4'));
+      actions.create(normalize('/a/b'), Buffer.from('1'));
+      actions.create(normalize('/a/c'), Buffer.from('2'));
+      actions.overwrite(normalize('/a/c'), Buffer.from('3'));
+      actions.overwrite(normalize('/a/b'), Buffer.from('4'));
 
       expect(actions.length).toBe(4);
       actions.optimize();
@@ -38,11 +38,11 @@ describe('Action', () => {
     it('works with cloning a list', () => {
       const actions = new ActionList;
 
-      actions.create(normalize('/a/b'), new Buffer('1'));
-      actions.create(normalize('/a/c'), new Buffer('2'));
-      actions.overwrite(normalize('/a/c'), new Buffer('3'));
-      actions.overwrite(normalize('/a/b'), new Buffer('4'));
-      actions.create(normalize('/a/d'), new Buffer('5'));
+      actions.create(normalize('/a/b'), Buffer.from('1'));
+      actions.create(normalize('/a/c'), Buffer.from('2'));
+      actions.overwrite(normalize('/a/c'), Buffer.from('3'));
+      actions.overwrite(normalize('/a/b'), Buffer.from('4'));
+      actions.create(normalize('/a/d'), Buffer.from('5'));
 
       const actions2 = new ActionList;
       actions.forEach(x => actions2.push(x));
@@ -59,10 +59,10 @@ describe('Action', () => {
     it('handles edge cases (1)', () => {
       const actions = new ActionList;
 
-      actions.create(normalize('/test'), new Buffer('1'));
-      actions.overwrite(normalize('/test'), new Buffer('3'));
-      actions.overwrite(normalize('/hello'), new Buffer('2'));
-      actions.overwrite(normalize('/test'), new Buffer('4'));
+      actions.create(normalize('/test'), Buffer.from('1'));
+      actions.overwrite(normalize('/test'), Buffer.from('3'));
+      actions.overwrite(normalize('/hello'), Buffer.from('2'));
+      actions.overwrite(normalize('/test'), Buffer.from('4'));
 
       const actions2 = new ActionList;
       actions.forEach(x => actions2.push(x));
@@ -79,9 +79,9 @@ describe('Action', () => {
     it('handles edge cases (2)', () => {
       const actions = new ActionList;
 
-      actions.create(normalize('/test'), new Buffer('1'));
+      actions.create(normalize('/test'), Buffer.from('1'));
       actions.rename(normalize('/test'), normalize('/test1'));
-      actions.overwrite(normalize('/test1'), new Buffer('2'));
+      actions.overwrite(normalize('/test1'), Buffer.from('2'));
       actions.rename(normalize('/test1'), normalize('/test2'));
 
       actions.optimize();
@@ -95,7 +95,7 @@ describe('Action', () => {
       const actions = new ActionList;
 
       actions.rename(normalize('/test'), normalize('/test1'));
-      actions.overwrite(normalize('/test1'), new Buffer('2'));
+      actions.overwrite(normalize('/test1'), Buffer.from('2'));
       actions.rename(normalize('/test1'), normalize('/test2'));
 
       actions.optimize();

--- a/packages/angular_devkit/schematics/src/tree/filesystem.ts
+++ b/packages/angular_devkit/schematics/src/tree/filesystem.ts
@@ -102,7 +102,7 @@ export class FileSystemTree extends VirtualTree {
       this._initialized = true;
       this._recursiveFileList().forEach(path => {
         this._tree.set(path, new LazyFileEntry(path, () => {
-          return new Buffer(host.read(path));
+          return Buffer.from(host.read(path));
         }));
       });
     }
@@ -121,7 +121,7 @@ export class FileSystemTree extends VirtualTree {
 
       if (fileExists) {
         const host = this._host;
-        entry = new LazyFileEntry(normalizedPath, () => new Buffer(host.read(systemPath)));
+        entry = new LazyFileEntry(normalizedPath, () => Buffer.from(host.read(systemPath)));
         this._tree.set(normalizedPath, entry);
       }
     }
@@ -178,7 +178,7 @@ export class FileSystemCreateTree extends FileSystemTree {
     super(host);
 
     this._recursiveFileList().forEach(path => {
-      this.create(path, new Buffer(this._host.read(path)));
+      this.create(path, Buffer.from(this._host.read(path)));
     });
     this._initialized = true;
   }

--- a/packages/angular_devkit/schematics/src/tree/host-tree.ts
+++ b/packages/angular_devkit/schematics/src/tree/host-tree.ts
@@ -287,7 +287,7 @@ export class HostTree implements Tree {
       return null;
     }
 
-    return new LazyFileEntry(p, () => new Buffer(this._recordSync.read(p)));
+    return new LazyFileEntry(p, () => Buffer.from(this._recordSync.read(p)));
   }
 
   getDir(path: string): DirEntry {
@@ -324,7 +324,7 @@ export class HostTree implements Tree {
     if (!this._recordSync.exists(p)) {
       throw new FileDoesNotExistException(p);
     }
-    const c = typeof content == 'string' ? new Buffer(content) : content;
+    const c = typeof content == 'string' ? Buffer.from(content) : content;
     this._record.overwrite(p, c as {} as virtualFs.FileBuffer).subscribe();
   }
   beginUpdate(path: string): UpdateRecorder {
@@ -356,7 +356,7 @@ export class HostTree implements Tree {
     if (this._recordSync.exists(p)) {
       throw new FileAlreadyExistException(p);
     }
-    const c = typeof content == 'string' ? new Buffer(content) : content;
+    const c = typeof content == 'string' ? Buffer.from(content) : content;
     this._record.create(p, c as {} as virtualFs.FileBuffer).subscribe();
   }
   delete(path: string): void {
@@ -393,7 +393,7 @@ export class HostTree implements Tree {
                 parent: 0,
                 kind: 'c',
                 path: record.path,
-                content: new Buffer(record.content),
+                content: Buffer.from(record.content),
               } as CreateFileAction;
             case 'overwrite':
               return {
@@ -401,7 +401,7 @@ export class HostTree implements Tree {
                 parent: 0,
                 kind: 'o',
                 path: record.path,
-                content: new Buffer(record.content),
+                content: Buffer.from(record.content),
               } as OverwriteFileAction;
             case 'rename':
               return {

--- a/packages/angular_devkit/schematics/src/tree/recorder.ts
+++ b/packages/angular_devkit/schematics/src/tree/recorder.ts
@@ -16,7 +16,7 @@ export class UpdateRecorderBase implements UpdateRecorder {
   protected _content: UpdateBuffer;
 
   constructor(entry: FileEntry) {
-    this._original = new Buffer(entry.content);
+    this._original = Buffer.from(entry.content);
     this._content = new UpdateBuffer(entry.content);
     this._path = entry.path;
   }
@@ -42,13 +42,13 @@ export class UpdateRecorderBase implements UpdateRecorder {
 
   // These just record changes.
   insertLeft(index: number, content: Buffer | string): UpdateRecorder {
-    this._content.insertLeft(index, typeof content == 'string' ? new Buffer(content) : content);
+    this._content.insertLeft(index, typeof content == 'string' ? Buffer.from(content) : content);
 
     return this;
   }
 
   insertRight(index: number, content: Buffer | string): UpdateRecorder {
-    this._content.insertRight(index, typeof content == 'string' ? new Buffer(content) : content);
+    this._content.insertRight(index, typeof content == 'string' ? Buffer.from(content) : content);
 
     return this;
   }

--- a/packages/angular_devkit/schematics/src/tree/recorder_spec.ts
+++ b/packages/angular_devkit/schematics/src/tree/recorder_spec.ts
@@ -11,7 +11,7 @@ import { UpdateRecorderBase, UpdateRecorderBom } from './recorder';
 
 describe('UpdateRecorderBase', () => {
   it('works for simple files', () => {
-    const buffer = new Buffer('Hello World');
+    const buffer = Buffer.from('Hello World');
     const entry = new SimpleFileEntry(normalize('/some/path'), buffer);
 
     const recorder = new UpdateRecorderBase(entry);
@@ -21,7 +21,7 @@ describe('UpdateRecorderBase', () => {
   });
 
   it('works for simple files (2)', () => {
-    const buffer = new Buffer('Hello World');
+    const buffer = Buffer.from('Hello World');
     const entry = new SimpleFileEntry(normalize('/some/path'), buffer);
 
     const recorder = new UpdateRecorderBase(entry);
@@ -31,31 +31,31 @@ describe('UpdateRecorderBase', () => {
   });
 
   it('can create the proper recorder', () => {
-    const e = new SimpleFileEntry(normalize('/some/path'),  new Buffer('hello'));
+    const e = new SimpleFileEntry(normalize('/some/path'),  Buffer.from('hello'));
     expect(UpdateRecorderBase.createFromFileEntry(e) instanceof UpdateRecorderBase).toBe(true);
     expect(UpdateRecorderBase.createFromFileEntry(e) instanceof UpdateRecorderBom).toBe(false);
   });
 
   it('can create the proper recorder (bom)', () => {
-    const eBom = new SimpleFileEntry(normalize('/some/path'), new Buffer('\uFEFFhello'));
+    const eBom = new SimpleFileEntry(normalize('/some/path'), Buffer.from('\uFEFFhello'));
     expect(UpdateRecorderBase.createFromFileEntry(eBom) instanceof UpdateRecorderBase).toBe(true);
     expect(UpdateRecorderBase.createFromFileEntry(eBom) instanceof UpdateRecorderBom).toBe(true);
   });
 
   it('supports empty files', () => {
-    const e = new SimpleFileEntry(normalize('/some/path'),  new Buffer(''));
+    const e = new SimpleFileEntry(normalize('/some/path'),  Buffer.from(''));
     expect(UpdateRecorderBase.createFromFileEntry(e) instanceof UpdateRecorderBase).toBe(true);
   });
 
   it('supports empty files (bom)', () => {
-    const eBom = new SimpleFileEntry(normalize('/some/path'), new Buffer('\uFEFF'));
+    const eBom = new SimpleFileEntry(normalize('/some/path'), Buffer.from('\uFEFF'));
     expect(UpdateRecorderBase.createFromFileEntry(eBom) instanceof UpdateRecorderBase).toBe(true);
   });
 });
 
 describe('UpdateRecorderBom', () => {
   it('works for simple files', () => {
-    const buffer = new Buffer('\uFEFFHello World');
+    const buffer = Buffer.from('\uFEFFHello World');
     const entry = new SimpleFileEntry(normalize('/some/path'), buffer);
 
     const recorder = new UpdateRecorderBom(entry);

--- a/packages/angular_devkit/schematics/src/tree/virtual.ts
+++ b/packages/angular_devkit/schematics/src/tree/virtual.ts
@@ -207,7 +207,7 @@ export class VirtualTree implements Tree {
   overwrite(path: string, content: Buffer | string) {
     const normalizedTo = this._normalizePath(path);
     if (typeof content == 'string') {
-      content = new Buffer(content, 'utf-8');
+      content = Buffer.from(content, 'utf-8');
     }
     const maybeEntry = this.get(normalizedTo);
     if (maybeEntry && maybeEntry.content.equals(content)) {
@@ -218,7 +218,7 @@ export class VirtualTree implements Tree {
   create(path: string, content: Buffer | string): void {
     const normalizedTo = this._normalizePath(path);
     if (typeof content == 'string') {
-      content = new Buffer(content);
+      content = Buffer.from(content);
     }
     this._create(normalizedTo, content);
   }

--- a/packages/angular_devkit/schematics/src/utility/update-buffer_spec.ts
+++ b/packages/angular_devkit/schematics/src/utility/update-buffer_spec.ts
@@ -10,52 +10,52 @@ import { UpdateBuffer } from './update-buffer';
 describe('UpdateBuffer', () => {
   describe('inserts', () => {
     it('works', () => {
-      const mb = new UpdateBuffer(new Buffer('Hello World'));
+      const mb = new UpdateBuffer(Buffer.from('Hello World'));
 
-      mb.insertRight(6, new Buffer('Beautiful '));
+      mb.insertRight(6, Buffer.from('Beautiful '));
       expect(mb.toString()).toBe('Hello Beautiful World');
 
-      mb.insertRight(6, new Buffer('Great '));
+      mb.insertRight(6, Buffer.from('Great '));
       expect(mb.toString()).toBe('Hello Beautiful Great World');
 
-      mb.insertRight(0, new Buffer('1 '));
+      mb.insertRight(0, Buffer.from('1 '));
       expect(mb.toString()).toBe('1 Hello Beautiful Great World');
 
-      mb.insertRight(5, new Buffer('2 '));
+      mb.insertRight(5, Buffer.from('2 '));
       expect(mb.toString()).toBe('1 Hello2  Beautiful Great World');
 
-      mb.insertRight(8, new Buffer('3 '));
+      mb.insertRight(8, Buffer.from('3 '));
       expect(mb.toString()).toBe('1 Hello2  Beautiful Great Wo3 rld');
 
-      mb.insertRight(0, new Buffer('4 '));
+      mb.insertRight(0, Buffer.from('4 '));
       expect(mb.toString()).toBe('1 4 Hello2  Beautiful Great Wo3 rld');
 
-      mb.insertRight(8, new Buffer('5 '));
+      mb.insertRight(8, Buffer.from('5 '));
       expect(mb.toString()).toBe('1 4 Hello2  Beautiful Great Wo3 5 rld');
 
-      mb.insertRight(1, new Buffer('a '));
+      mb.insertRight(1, Buffer.from('a '));
       expect(mb.toString()).toBe('1 4 Ha ello2  Beautiful Great Wo3 5 rld');
 
-      mb.insertRight(2, new Buffer('b '));
+      mb.insertRight(2, Buffer.from('b '));
       expect(mb.toString()).toBe('1 4 Ha eb llo2  Beautiful Great Wo3 5 rld');
 
-      mb.insertRight(7, new Buffer('c '));
+      mb.insertRight(7, Buffer.from('c '));
       expect(mb.toString()).toBe('1 4 Ha eb llo2  Beautiful Great Wc o3 5 rld');
 
-      mb.insertRight(11, new Buffer('d '));
+      mb.insertRight(11, Buffer.from('d '));
       expect(mb.toString()).toBe('1 4 Ha eb llo2  Beautiful Great Wc o3 5 rldd ');
     });
 
     it('works _left and _right', () => {
-      const mb = new UpdateBuffer(new Buffer('Hello World'));
+      const mb = new UpdateBuffer(Buffer.from('Hello World'));
 
-      mb.insertRight(6, new Buffer('Beautiful '));
+      mb.insertRight(6, Buffer.from('Beautiful '));
       expect(mb.toString()).toBe('Hello Beautiful World');
 
-      mb.insertLeft(6, new Buffer('Great '));
+      mb.insertLeft(6, Buffer.from('Great '));
       expect(mb.toString()).toBe('Hello Great Beautiful World');
 
-      mb.insertLeft(6, new Buffer('Awesome '));
+      mb.insertLeft(6, Buffer.from('Awesome '));
       expect(mb.toString()).toBe('Hello Great Awesome Beautiful World');
     });
   });
@@ -64,7 +64,7 @@ describe('UpdateBuffer', () => {
     it('works for non-overlapping ranges', () => {
       //                                                111111111122222222223333333333444444
       //                                      0123456789012345678901234567890123456789012345
-      const mb = new UpdateBuffer(new Buffer('1 4 Ha eb llo2  Beautiful Great Wc o3 5 rldd '));
+      const mb = new UpdateBuffer(Buffer.from('1 4 Ha eb llo2  Beautiful Great Wc o3 5 rldd '));
 
       mb.remove(43, 2);
       expect(mb.toString()).toBe('1 4 Ha eb llo2  Beautiful Great Wc o3 5 rld');
@@ -92,7 +92,7 @@ describe('UpdateBuffer', () => {
 
     it('handles overlapping ranges', () => {
       //                                      0123456789012
-      const mb = new UpdateBuffer(new Buffer('ABCDEFGHIJKLM'));
+      const mb = new UpdateBuffer(Buffer.from('ABCDEFGHIJKLM'));
 
       // Overlapping.
       mb.remove(2, 5);
@@ -114,16 +114,16 @@ describe('UpdateBuffer', () => {
     it('works for non-overlapping indices', () => {
       //                                                1
       //                                      01234567890
-      const mb = new UpdateBuffer(new Buffer('01234567890'));
+      const mb = new UpdateBuffer(Buffer.from('01234567890'));
 
-      mb.insertRight(6, new Buffer('A'));
+      mb.insertRight(6, Buffer.from('A'));
       expect(mb.toString()).toBe('012345A67890');
-      mb.insertRight(2, new Buffer('B'));
+      mb.insertRight(2, Buffer.from('B'));
       expect(mb.toString()).toBe('01B2345A67890');
 
       mb.remove(3, 4);
       expect(mb.toString()).toBe('01B27890');
-      mb.insertRight(4, new Buffer('C'));
+      mb.insertRight(4, Buffer.from('C'));
       expect(mb.toString()).toBe('01B27890');
 
       mb.remove(2, 6);
@@ -132,13 +132,13 @@ describe('UpdateBuffer', () => {
 
     it('works for _left/_right inserts', () => {
       //                                      0123456789
-      const mb = new UpdateBuffer(new Buffer('0123456789'));
+      const mb = new UpdateBuffer(Buffer.from('0123456789'));
 
-      mb.insertLeft(5, new Buffer('A'));
+      mb.insertLeft(5, Buffer.from('A'));
       expect(mb.toString()).toBe('01234A56789');
-      mb.insertRight(5, new Buffer('B'));
+      mb.insertRight(5, Buffer.from('B'));
       expect(mb.toString()).toBe('01234AB56789');
-      mb.insertRight(10, new Buffer('C'));
+      mb.insertRight(10, Buffer.from('C'));
       expect(mb.toString()).toBe('01234AB56789C');
       mb.remove(5, 5);
       expect(mb.toString()).toBe('01234AB');
@@ -147,23 +147,23 @@ describe('UpdateBuffer', () => {
     });
 
     it('supports essential', () => {
-      const mb = new UpdateBuffer(new Buffer('0123456789'));
+      const mb = new UpdateBuffer(Buffer.from('0123456789'));
 
-      mb.insertLeft(5, new Buffer('A'), true);
+      mb.insertLeft(5, Buffer.from('A'), true);
       expect(mb.toString()).toBe('01234A56789');
       mb.remove(5, 5);
       expect(mb.toString()).toBe('01234A');
       expect(() => mb.remove(0, 5)).toThrow();
       expect(mb.toString()).toBe('01234A');
 
-      expect(() => mb.insertRight(6, new Buffer('B'), true)).toThrow();
+      expect(() => mb.insertRight(6, Buffer.from('B'), true)).toThrow();
       expect(mb.toString()).toBe('01234A');
     });
 
     it('works for content at start/end of buffer', () => {
-      const buffer = new UpdateBuffer(new Buffer('012345'));
-      buffer.insertLeft(0, new Buffer('ABC'));
-      buffer.insertRight(6, new Buffer('DEF'));
+      const buffer = new UpdateBuffer(Buffer.from('012345'));
+      buffer.insertLeft(0, Buffer.from('ABC'));
+      buffer.insertRight(6, Buffer.from('DEF'));
       buffer.remove(0, 6);
       expect(buffer.toString()).toBe('ABC');
     });
@@ -172,9 +172,9 @@ describe('UpdateBuffer', () => {
   describe('generate', () => {
     it('works', () => {
       //                                      0123456789
-      const mb = new UpdateBuffer(new Buffer('0123456789'));
+      const mb = new UpdateBuffer(Buffer.from('0123456789'));
 
-      mb.insertLeft(5, new Buffer('A'));
+      mb.insertLeft(5, Buffer.from('A'));
       expect(mb.toString()).toBe('01234A56789');
       mb.remove(5, 5);
       expect(mb.toString()).toBe('01234A');


### PR DESCRIPTION
Its being deprecated in Node 10.4. The replacements are available in Node 8 so
its all good.