### PR TITLE
feat(angular_devkit): stop blocking karma after compilation error

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/karma-webpack-failure-cb.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/karma-webpack-failure-cb.ts
@@ -12,12 +12,12 @@
 // Workaround for https://github.com/webpack-contrib/karma-webpack/issues/66
 
 export class KarmaWebpackFailureCb {
-  constructor(private callback: () => void) { }
+  constructor(private callback: (error: string | undefined, errors: string[]) => void) { }
 
   apply(compiler: any): void {
     compiler.hooks.done.tap('KarmaWebpackFailureCb', (stats: any) => {
       if (stats.compilation.errors.length > 0) {
-        this.callback();
+        this.callback(undefined, stats.compilation.errors.map((error: any) => error.message? error.message : error.toString()));
       }
     });
   }


### PR DESCRIPTION
This PR removes the blocking of karma in case of compilation errors. This will not influence regular developer workflows (with `ng test` and `ng test --single-run`), but does help plugin creators relying on `karma run` functionality (with `singleRun: false` and `watch: false`).

Fixes #11170 