### PR TITLE
fix(@angular/cli/models): resolve #11186

### DIFF
--- a/packages/angular/cli/models/command-runner.ts
+++ b/packages/angular/cli/models/command-runner.ts
@@ -85,6 +85,8 @@ export async function runCommand(commandMap: CommandMap,
 
   if (!Cmd) {
     const commandsDistance = {} as { [name: string]: number };
+
+    commandName = args[0].replace(/-*/, '');
     const allCommands = listAllCommandNames(commandMap).sort((a, b) => {
       if (!(a in commandsDistance)) {
         commandsDistance[a] = levenshtein(a, commandName);


### PR DESCRIPTION
```ng command breaks with wrong option names```