### PR TITLE
docs: Add command for angular-cli-ghpages and change repo URL

### DIFF
--- a/docs/documentation/stories/github-pages.md
+++ b/docs/documentation/stories/github-pages.md
@@ -17,5 +17,12 @@ Commit your changes and push. On the GitHub project page, configure it to
 And that's all you need to do! Now you can see your page at
 `https://USER_NAME.github.io/PROJECT_NAME/`.
 
-You can also use [angular-cli-ghpages](https://github.com/angular-buch/angular-cli-ghpages), a full
+You can also use [angular-cli-ghpages](https://github.com/angular-schule/angular-cli-ghpages), a full
 featured package that does this all this for you and has extra functionality.
+All you need is a single command:
+
+```bash
+ngh --dir=dist/docs
+```
+
+It takes care of pushing to the `gh-pages` branch and copying your `index.html` to `404.html`.


### PR DESCRIPTION
For the ghpages story:
I added the specific command needed to run `angular-cli-ghpages` / `ngh` as a teaser.
Also, we moved the repo from angular-buch to angular-schule, so I changed the repo URL.

// CC https://github.com/angular/angular-cli/issues/11169