### PR TITLE
feat(@schematics/angular): use es2015 modules overall

### DIFF
--- a/packages/schematics/angular/application/files/root/tsconfig.app.json
+++ b/packages/schematics/angular/application/files/root/tsconfig.app.json
@@ -2,7 +2,6 @@
   "extends": "<%= relativePathToWorkspaceRoot %>/tsconfig.json",
   "compilerOptions": {
     "outDir": "<%= relativePathToWorkspaceRoot %>/out-tsc/app",
-    "module": "es2015",
     "types": []
   },
   "exclude": [

--- a/packages/schematics/angular/application/files/root/tsconfig.spec.json
+++ b/packages/schematics/angular/application/files/root/tsconfig.spec.json
@@ -2,7 +2,6 @@
   "extends": "<%= relativePathToWorkspaceRoot %>/tsconfig.json",
   "compilerOptions": {
     "outDir": "<%= relativePathToWorkspaceRoot %>/out-tsc/spec",
-    "module": "commonjs",
     "types": [
       "jasmine",
       "node"

--- a/packages/schematics/angular/library/files/__projectRoot__/tsconfig.lib.json
+++ b/packages/schematics/angular/library/files/__projectRoot__/tsconfig.lib.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "outDir": "<%= relativePathToWorkspaceRoot %>/out-tsc/lib",
     "target": "es2015",
-    "module": "es2015",
     "moduleResolution": "node",
     "declaration": true,
     "sourceMap": true,

--- a/packages/schematics/angular/universal/files/root/__tsconfigFileName__.json
+++ b/packages/schematics/angular/universal/files/root/__tsconfigFileName__.json
@@ -2,8 +2,7 @@
   "extends": "./<%= tsConfigExtends %>",
   "compilerOptions": {
     "outDir": "<%= outDir %>-server",
-    "baseUrl": ".",
-    "module": "commonjs"
+    "baseUrl": "."
   },
   "angularCompilerOptions": {
     "entryModule": "<%= rootInSrc ? '' : 'src/' %><%= appDir %>/<%= stripTsExtension(rootModuleFileName) %>#<%= rootModuleClassName %>"

--- a/packages/schematics/angular/universal/index_spec.ts
+++ b/packages/schematics/angular/universal/index_spec.ts
@@ -82,7 +82,6 @@ describe('Universal Schematic', () => {
       compilerOptions: {
         outDir: '../out-tsc/app-server',
         baseUrl: '.',
-        module: 'commonjs',
       },
       angularCompilerOptions: {
         entryModule: 'app/app.server.module#AppServerModule',
@@ -103,7 +102,6 @@ describe('Universal Schematic', () => {
       compilerOptions: {
         outDir: '../../out-tsc/app-server',
         baseUrl: '.',
-        module: 'commonjs',
       },
       angularCompilerOptions: {
         entryModule: 'src/app/app.server.module#AppServerModule',

--- a/packages/schematics/angular/workspace/files/tsconfig.json
+++ b/packages/schematics/angular/workspace/files/tsconfig.json
@@ -5,6 +5,7 @@
     "outDir": "./dist/out-tsc",
     "sourceMap": true,
     "declaration": false,
+    "module": "es2015",
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,


### PR DESCRIPTION
This change helps to keep the behaviour of build/serve/test consistent by using the same import semantics in all of them.