### PR TITLE
build: return promise on changelog script

### DIFF
--- a/scripts/changelog.ts
+++ b/scripts/changelog.ts
@@ -39,7 +39,7 @@ export default function(args: ChangelogOptions, logger: logging.Logger) {
     || ''
   ).trim();
 
-  new Promise((resolve) => {
+  return new Promise((resolve) => {
     (gitRawCommits({
       from: args.from,
       to: args.to || 'HEAD',


### PR DESCRIPTION
The changelog function makes a promise but doesn't return it, causing a race condition between the process exiting and the promise finishing.

On a repository with bigger git history the promise took longer to execute and the process exited first.