### PR TITLE
fix(@schematics/angular): add `baseUrl` in root tsconfig when migrating

### DIFF
--- a/packages/schematics/angular/migrations/update-6/index_spec.ts
+++ b/packages/schematics/angular/migrations/update-6/index_spec.ts
@@ -775,6 +775,27 @@ describe('Migration to v6', () => {
     });
   });
 
+  describe('root ts config', () => {
+    const rootTsConfig = '/tsconfig.json';
+    beforeEach(() => {
+      tree.create(rootTsConfig, `
+        {
+          "compilerOptions": {
+            "module": "es2015"
+          }
+        }
+      `);
+    });
+
+    it('should add baseUrl', () => {
+      tree.create(oldConfigPath, JSON.stringify(baseConfig, null, 2));
+      tree = schematicRunner.runSchematic('migration-01', defaultOptions, tree);
+      const content = tree.readContent(rootTsConfig);
+      const config = JSON.parse(content);
+      expect(config.compilerOptions.baseUrl).toEqual('./');
+    });
+  });
+
   describe('package.json', () => {
     it('should add a dev dependency to @angular-devkit/build-angular', () => {
       tree.create(oldConfigPath, JSON.stringify(baseConfig, null, 2));

--- a/packages/schematics/angular/migrations/update-6/index_spec.ts
+++ b/packages/schematics/angular/migrations/update-6/index_spec.ts
@@ -777,22 +777,33 @@ describe('Migration to v6', () => {
 
   describe('root ts config', () => {
     const rootTsConfig = '/tsconfig.json';
+    let compilerOptions: JsonObject;
+
     beforeEach(() => {
       tree.create(rootTsConfig, `
         {
           "compilerOptions": {
-            "module": "es2015"
+            "noEmitOnError": true
           }
         }
       `);
-    });
 
-    it('should add baseUrl', () => {
       tree.create(oldConfigPath, JSON.stringify(baseConfig, null, 2));
       tree = schematicRunner.runSchematic('migration-01', defaultOptions, tree);
       const content = tree.readContent(rootTsConfig);
-      const config = JSON.parse(content);
-      expect(config.compilerOptions.baseUrl).toEqual('./');
+      compilerOptions = JSON.parse(content).compilerOptions;
+    });
+
+    it('should add baseUrl', () => {
+      expect(compilerOptions.baseUrl).toEqual('./');
+    });
+
+    it('should add module', () => {
+      expect(compilerOptions.module).toEqual('es2015');
+    });
+
+    it('should not remove existing options', () => {
+      expect(compilerOptions.noEmitOnError).toBeDefined();
     });
   });
 


### PR DESCRIPTION
Closes: #11258 

The problem is that in Angular CLI 1.X.X the root `tsconfig` didn't have `baseUrl`, and when upgrading to v6 the `baseUrl` option is not added. `baseUrl` is  now mandatory especially when creating a library.

//cc @StephenFluin 