### PR TITLE
feat(@schematics/angular): add `no-redundant-jsdoc` tslint rule

### DIFF
--- a/packages/schematics/angular/workspace/files/tslint.json
+++ b/packages/schematics/angular/workspace/files/tslint.json
@@ -65,6 +65,7 @@
     ],
     "no-misused-new": true,
     "no-non-null-assertion": true,
+    "no-redundant-jsdoc": true,
     "no-shadowed-variable": true,
     "no-string-literal": false,
     "no-string-throw": true,


### PR DESCRIPTION
When building a library, `tsickle` is used as the `annotateForClosureCompiler` option is `true`. tsickle warns when redundant jsdocs are used.

https://github.com/angular/tsickle/blob/d24b139b71a3f86bf25d6eecf4d4dcdad3b379e4/src/jsdoc.ts#L170-L178

These diagnostics are later passed to Angular Compiler and are treated as errors.

Seeing this: https://github.com/angular/angular/issues/19969#issuecomment-343318361 it looks like it is expected that warnings will fail the build.

Closes: #11282