### PR TITLE
feat: use es2018 lib in tsconfig.json files

### DIFF
--- a/packages/schematics/angular/library/files/__projectRoot__/tsconfig.lib.json
+++ b/packages/schematics/angular/library/files/__projectRoot__/tsconfig.lib.json
@@ -14,7 +14,7 @@
     "types": [],
     "lib": [
       "dom",
-      "es2015"
+      "es2018"
     ]
   },
   "angularCompilerOptions": {

--- a/packages/schematics/angular/workspace/files/tsconfig.json
+++ b/packages/schematics/angular/workspace/files/tsconfig.json
@@ -14,7 +14,7 @@
       "node_modules/@types"
     ],
     "lib": [
-      "es2017",
+      "es2018",
       "dom"
     ]
   }

--- a/packages/schematics/schematics/blank/project-files/tsconfig.json
+++ b/packages/schematics/schematics/blank/project-files/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": "tsconfig",
     "lib": [
-      "es2017",
+      "es2018",
       "dom"
     ],
     "declaration": true,

--- a/packages/schematics/schematics/schematic/files/tsconfig.json
+++ b/packages/schematics/schematics/schematic/files/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": "tsconfig",
     "lib": [
-      "es2017",
+      "es2018",
       "dom"
     ],
     "module": "commonjs",


### PR DESCRIPTION
Update the `lib` property in `tsconfig.json` files of both schematics and the DevKit package to 
`es2018`.

The ECMAScript 2018 feature set was finalized in January, so it seems reasonable to upgrade the libs as well. This is specifically interesting for the new Angular libs that are stuck at ECMAScript 2015 (!).

Rescued over from https://github.com/angular/devkit/pull/869.