### PR TITLE
fix(@ngtools/webpack): fixes module resolution when using `*` token

### DIFF
--- a/packages/ngtools/webpack/src/angular_compiler_plugin.ts
+++ b/packages/ngtools/webpack/src/angular_compiler_plugin.ts
@@ -115,6 +115,7 @@ export class AngularCompilerPlugin {
   private _program: (ts.Program | Program) | null;
   private _compilerHost: WebpackCompilerHost & CompilerHost;
   private _moduleResolutionCache: ts.ModuleResolutionCache;
+  private _dtsModuleResolutionCache: Map<string, string>;
   private _resourceLoader: WebpackResourceLoader;
   // Contains `moduleImportPath#exportName` => `fullModulePath`.
   private _lazyRoutes: LazyRouteMap = Object.create(null);
@@ -382,6 +383,9 @@ export class AngularCompilerPlugin {
 
          // Use an identity function as all our paths are absolute already.
         this._moduleResolutionCache = ts.createModuleResolutionCache(this._basePath, x => x);
+
+        // Used to cache '.d.ts.' to module directory or .js file
+        this._dtsModuleResolutionCache = new Map<string, string>();
 
         if (this._JitMode) {
           // Create the TypeScript program.
@@ -723,6 +727,7 @@ export class AngularCompilerPlugin {
           this._compilerOptions,
           this._compilerHost,
           this._moduleResolutionCache,
+          this._dtsModuleResolutionCache,
         );
       });
     });

--- a/packages/ngtools/webpack/src/paths-plugin.ts
+++ b/packages/ngtools/webpack/src/paths-plugin.ts
@@ -12,15 +12,15 @@ import {
   NormalModuleFactoryRequest,
 } from './webpack';
 
-
 export function resolveWithPaths(
   request: NormalModuleFactoryRequest,
   callback: Callback<NormalModuleFactoryRequest>,
   compilerOptions: ts.CompilerOptions,
   host: ts.CompilerHost,
   cache?: ts.ModuleResolutionCache,
+  dtsModuleResolutionCache?: Map<string, string>,
 ) {
-  if (!request || !request.request || !compilerOptions.paths) {
+  if (!request || !request.request) {
     callback(null, request);
 
     return;
@@ -49,69 +49,9 @@ export function resolveWithPaths(
     return;
   }
 
-  // check if any path mapping rules are relevant
-  const pathMapOptions = [];
-  for (const pattern in compilerOptions.paths) {
-      // can only contain zero or one
-      const starIndex = pattern.indexOf('*');
-      if (starIndex === -1) {
-        if (pattern === originalRequest) {
-          pathMapOptions.push({
-            partial: '',
-            potentials: compilerOptions.paths[pattern],
-          });
-        }
-      } else if (starIndex === 0 && pattern.length === 1) {
-        pathMapOptions.push({
-          partial: originalRequest,
-          potentials: compilerOptions.paths[pattern],
-        });
-      } else if (starIndex === pattern.length - 1) {
-        if (originalRequest.startsWith(pattern.slice(0, -1))) {
-          pathMapOptions.push({
-            partial: originalRequest.slice(pattern.length - 1),
-            potentials: compilerOptions.paths[pattern],
-          });
-        }
-      } else {
-        const [prefix, suffix] = pattern.split('*');
-        if (originalRequest.startsWith(prefix) && originalRequest.endsWith(suffix)) {
-          pathMapOptions.push({
-            partial: originalRequest.slice(prefix.length).slice(0, -suffix.length),
-            potentials: compilerOptions.paths[pattern],
-          });
-        }
-      }
-  }
-
-  if (pathMapOptions.length === 0) {
-    callback(null, request);
-
-    return;
-  }
-
-  if (pathMapOptions.length === 1 && pathMapOptions[0].potentials.length === 1) {
-    const onlyPotential = pathMapOptions[0].potentials[0];
-    let replacement;
-    const starIndex = onlyPotential.indexOf('*');
-    if (starIndex === -1) {
-      replacement = onlyPotential;
-    } else if (starIndex === onlyPotential.length - 1) {
-      replacement = onlyPotential.slice(0, -1) + pathMapOptions[0].partial;
-    } else {
-      const [prefix, suffix] = onlyPotential.split('*');
-      replacement = prefix + pathMapOptions[0].partial + suffix;
-    }
-
-    request.request = path.resolve(compilerOptions.baseUrl || '', replacement);
-    callback(null, request);
-
-    return;
-  }
-
   const moduleResolver = ts.resolveModuleName(
     originalRequest,
-    request.contextInfo.issuer,
+    request.contextInfo.issuer.replace(/\\/g, '/'),
     compilerOptions,
     host,
     cache,
@@ -122,21 +62,66 @@ export function resolveWithPaths(
 
   // If there is no result, let webpack try to resolve
   if (!moduleFilePath) {
-    callback(null, request);
-
     return;
   }
 
   // If TypeScript gives us a `.d.ts`, it is probably a node module
   if (moduleFilePath.endsWith('.d.ts')) {
-    // If in a package, let webpack resolve the package
-    const packageRootPath = path.join(path.dirname(moduleFilePath), 'package.json');
-    if (!host.fileExists(packageRootPath)) {
+    // if it was already resolved return it from cache, so we avoid extra IO operations.
+    const cachedResolution = dtsModuleResolutionCache
+      && dtsModuleResolutionCache.get(moduleFilePath);
+
+    if (cachedResolution) {
+      request.request = cachedResolution;
+      callback(null, request);
+
+      return;
+    }
+
+    // TypeScript resolutions are as follow:
+    // /node_modules/moduleB.ts
+    // /node_modules/moduleB.tsx
+    // /node_modules/moduleB.d.ts
+    // /node_modules/moduleB/package.json (if it specifies a "types" property)
+    // /node_modules/moduleB/index.ts
+    // /node_modules/moduleB/index.tsx
+    // /node_modules/moduleB/index.d.ts
+    const pathNoExtension = moduleFilePath.slice(0, -5);
+    const pathDirName = path.dirname(moduleFilePath);
+    const packageRootPath = path.join(pathDirName, 'package.json');
+    const jsFilePath = `${pathNoExtension}.js`;
+    let resolvedPath: string | undefined;
+
+    if (host.fileExists(pathNoExtension)) {
+        // this is mainly for secondary entry point
+        // such as 'node_modules/@angular/core/testing.d.ts'
+        resolvedPath = pathNoExtension;
+    }
+
+    if (!resolvedPath && host.fileExists(packageRootPath)) {
+        const content = ts.sys.readFile(packageRootPath);
+        if (content) {
+          const { main, module, es2015, browser } = JSON.parse(content);
+          // If a package doesn't have entryfields like '@angular/common/locales'
+          // this cannot be resolved by webpack from the 'package.json'.
+          if (main || module || es2015 || browser) {
+            resolvedPath = pathDirName;
+          }
+        }
+    }
+
+    if (!resolvedPath && host.fileExists(jsFilePath)) {
       // Otherwise, if there is a file with a .js extension use that
-      const jsFilePath = moduleFilePath.slice(0, -5) + '.js';
-      if (host.fileExists(jsFilePath)) {
-        request.request = jsFilePath;
-      }
+      resolvedPath = jsFilePath;
+    }
+
+    if (resolvedPath) {
+      request.request = resolvedPath;
+    }
+
+    if (dtsModuleResolutionCache) {
+      // store the resolved request path in cache, so we avoid doing extra future IO operations
+      dtsModuleResolutionCache.set(moduleFilePath, request.request);
     }
 
     callback(null, request);

--- a/tests/legacy-cli/e2e/tests/i18n/build-locale.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/build-locale.ts
@@ -21,5 +21,5 @@ export default function () {
     .then(() => ng('build', '--aot', '--i18n-locale=fr_FR'))
     .then(() => expectFileToMatch('dist/test-project/main.js', /registerLocaleData/))
     .then(() => expectFileToMatch('dist/test-project/main.js', /angular_common_locales_fr/))
-    .then(() => rimraf('dist'))
+    .then(() => rimraf('dist'));
 }

--- a/tests/legacy-cli/e2e/tests/misc/module-resolution.ts
+++ b/tests/legacy-cli/e2e/tests/misc/module-resolution.ts
@@ -15,7 +15,7 @@ export default async function () {
   await createDir('xyz');
   await moveFile(
     'node_modules/@angular/common',
-    'xyz/common'
+    'xyz/common',
   );
 
   await expectToFail(() => ng('build'));
@@ -23,6 +23,14 @@ export default async function () {
   await updateJsonFile('tsconfig.json', tsconfig => {
     tsconfig.compilerOptions.paths = {
       '@angular/common': [ './xyz/common' ],
+    };
+  });
+  await ng('build');
+
+  await updateJsonFile('tsconfig.json', tsconfig => {
+    tsconfig.compilerOptions.paths = {
+      '@angular/common': [ './xyz/common' ],
+      '*': ['./node_modules/*'],
     };
   });
   await ng('build');
@@ -38,7 +46,7 @@ export default async function () {
   await ng('build', '--aot');
   await ng('test', '--watch=false');
 
-  await silentNpm('install', 'firebase@4.9.0');
+  await silentNpm('install', 'firebase@4.13.1');
   await ng('build', '--aot');
   await ng('test', '--watch=false');
 
@@ -60,12 +68,12 @@ export default async function () {
       '@firebase/polyfill': ['@firebase/polyfill/index.ts'],
     };
   });
-  await expectToFail(() => ng('build'));
+  await ng('build');
 
   await updateJsonFile('tsconfig.json', tsconfig => {
     tsconfig.compilerOptions.paths = {
       '@firebase/polyfill*': ['@firebase/polyfill/index.ts'],
     };
   });
-  await expectToFail(() => ng('build'));
+  await ng('build');
 }


### PR DESCRIPTION
At the moment module resolution is done via typescript when there is a single `*` token. For maintainability purposes it's best to resolve paths via typescript module resolution strategy. 

Module resolution now is solely done via typescript when there are paths in tsconfig .

Closes: #11301

//cc @filipesilva, I know you usually working in this, can you help me out please, where do you usually add the tests, I cannot find any :(