### PR TITLE
docs(@angular-devkit/schematics): extended Schematics README regarding templating

### DIFF
--- a/packages/angular_devkit/schematics/README.md
+++ b/packages/angular_devkit/schematics/README.md
@@ -105,7 +105,7 @@ The system operates on placeholders defined inside files or their paths as loade
 | Placeholder | Description |
 |---|---|
 | __variable__ | Replaced with the value of `variable`. |
-| __varaiable@function__ | Replaced with the result of the call `function(variable)`. Can be chained to the left (`__variable@function1@function2__ ` etc).  |
+| __variable@function__ | Replaced with the result of the call `function(variable)`. Can be chained to the left (`__variable@function1@function2__ ` etc).  |
 
 ## Content Templating
 | Placeholder | Description |


### PR DESCRIPTION
Extended the README of `@angular-devkit/schematics` to include basic info and an example about the templating functionality.

Prior, multiple places in the README (i.e. the [`template` Rule](https://github.com/angular/angular-cli/tree/master/packages/schematics/angular/class)) referenced a non-existent section about templating.

The content is based on the source of [`@angular_devkit/core/utils/template`](https://github.com/angular/angular-cli/blob/master/packages/angular_devkit/core/src/utils/template.ts) and the [referenced blog post](https://johnresig.com/blog/javascript-micro-templating/) as well as using the existing [`@angular/cli` `class` schematic](https://github.com/angular/angular-cli/tree/master/packages/schematics/angular/class) for the example code.

Additionally, some small changes to the remaining text are also included. They aim at making the text nicer to read and I can remove them if desired.