### PR TITLE
docs(@angular/cli): add commented `Object.setPrototypeOf` polyfills

### DIFF
--- a/packages/schematics/angular/application/files/src/polyfills.ts
+++ b/packages/schematics/angular/application/files/src/polyfills.ts
@@ -40,6 +40,25 @@
 /** IE10 and IE11 requires the following for the Reflect API. */
 // import 'core-js/es6/reflect';
 
+/** IE9 and IE10 requires the following polyfill for using rxjs 6.0 */
+// (function() {
+//   Object.setPrototypeOf = Object.setPrototypeOf || ({__proto__: []} instanceof Array ? setProtoOf : mixinProperties);
+//
+//   function setProtoOf(obj, proto) {
+//     obj.__proto__ = proto;
+//     return obj;
+//   }
+//
+//   function mixinProperties(obj, proto) {
+//     for (const prop in proto) {
+//       if (!obj.hasOwnProperty(prop)) {
+//         obj[prop] = proto[prop];
+//       }
+//     }
+//     return obj;
+//   }
+// })();
+
 
 /** Evergreen browsers require these. **/
 // Used for reflect-metadata in JIT. If you use AOT (and only Angular decorators), you can remove.

--- a/tests/@angular_devkit/build_angular/hello-world-app/src/polyfills.ts
+++ b/tests/@angular_devkit/build_angular/hello-world-app/src/polyfills.ts
@@ -47,6 +47,25 @@
 /** IE10 and IE11 requires the following for the Reflect API. */
 // import 'core-js/es6/reflect';
 
+/** IE9 and IE10 requires the following polyfill for using rxjs 6.0 */
+// (function() {
+//   Object.setPrototypeOf = Object.setPrototypeOf || ({__proto__: []} instanceof Array ? setProtoOf : mixinProperties);
+//
+//   function setProtoOf(obj, proto) {
+//     obj.__proto__ = proto;
+//     return obj;
+//   }
+//
+//   function mixinProperties(obj, proto) {
+//     for (const prop in proto) {
+//       if (!obj.hasOwnProperty(prop)) {
+//         obj[prop] = proto[prop];
+//       }
+//     }
+//     return obj;
+//   }
+// })();
+
 
 /** Evergreen browsers require these. **/
 // Used for reflect-metadata in JIT. If you use AOT (and only Angular decorators), you can remove.

--- a/tests/@angular_devkit/build_webpack/angular-app/src/polyfills.ts
+++ b/tests/@angular_devkit/build_webpack/angular-app/src/polyfills.ts
@@ -47,6 +47,25 @@
 /** IE10 and IE11 requires the following for the Reflect API. */
 // import 'core-js/es6/reflect';
 
+/** IE9 and IE10 requires the following polyfill for using rxjs 6.0 */
+// (function() {
+//   Object.setPrototypeOf = Object.setPrototypeOf || ({__proto__: []} instanceof Array ? setProtoOf : mixinProperties);
+//
+//   function setProtoOf(obj, proto) {
+//     obj.__proto__ = proto;
+//     return obj;
+//   }
+//
+//   function mixinProperties(obj, proto) {
+//     for (const prop in proto) {
+//       if (!obj.hasOwnProperty(prop)) {
+//         obj[prop] = proto[prop];
+//       }
+//     }
+//     return obj;
+//   }
+// })();
+
 
 /** Evergreen browsers require these. **/
 // Used for reflect-metadata in JIT. If you use AOT (and only Angular decorators), you can remove.

--- a/tests/legacy-cli/e2e/assets/1.0-project/src/polyfills.ts
+++ b/tests/legacy-cli/e2e/assets/1.0-project/src/polyfills.ts
@@ -39,6 +39,25 @@
 /** IE10 and IE11 requires the following to support `@angular/animation`. */
 // import 'web-animations-js';  // Run `npm install --save web-animations-js`.
 
+/** IE9 and IE10 requires the following polyfill for using rxjs 6.0 */
+// (function() {
+//   Object.setPrototypeOf = Object.setPrototypeOf || ({__proto__: []} instanceof Array ? setProtoOf : mixinProperties);
+//
+//   function setProtoOf(obj, proto) {
+//     obj.__proto__ = proto;
+//     return obj;
+//   }
+//
+//   function mixinProperties(obj, proto) {
+//     for (const prop in proto) {
+//       if (!obj.hasOwnProperty(prop)) {
+//         obj[prop] = proto[prop];
+//       }
+//     }
+//     return obj;
+//   }
+// })();
+
 
 /** Evergreen browsers require these. **/
 import 'core-js/es6/reflect';

--- a/tests/legacy-cli/e2e/assets/1.7-project/src/polyfills.ts
+++ b/tests/legacy-cli/e2e/assets/1.7-project/src/polyfills.ts
@@ -40,6 +40,25 @@
 /** IE10 and IE11 requires the following for the Reflect API. */
 // import 'core-js/es6/reflect';
 
+/** IE9 and IE10 requires the following polyfill for using rxjs 6.0 */
+// (function() {
+//   Object.setPrototypeOf = Object.setPrototypeOf || ({__proto__: []} instanceof Array ? setProtoOf : mixinProperties);
+//
+//   function setProtoOf(obj, proto) {
+//     obj.__proto__ = proto;
+//     return obj;
+//   }
+//
+//   function mixinProperties(obj, proto) {
+//     for (const prop in proto) {
+//       if (!obj.hasOwnProperty(prop)) {
+//         obj[prop] = proto[prop];
+//       }
+//     }
+//     return obj;
+//   }
+// })();
+
 
 /** Evergreen browsers require these. **/
 // Used for reflect-metadata in JIT. If you use AOT (and only Angular decorators), you can remove.


### PR DESCRIPTION
since rxjs v6.0.0-alpha.1 IE10 and below need `Object.setPrototypeOf` polyfill.
change polyfill.ts for that.

related issue: https://github.com/angular/angular/issues/24488