### PR TITLE
refactor: remove redundant `await`'s

### DIFF
--- a/packages/angular/cli/commands/e2e.ts
+++ b/packages/angular/cli/commands/e2e.ts
@@ -22,7 +22,7 @@ export default class E2eCommand extends ArchitectCommand {
     this.configurationOption,
   ];
 
-  public run(options: ArchitectCommandOptions) {
+  public async run(options: ArchitectCommandOptions) {
     return this.runArchitectTarget(options);
   }
 }

--- a/packages/angular/cli/models/architect-command.ts
+++ b/packages/angular/cli/models/architect-command.ts
@@ -177,7 +177,9 @@ export abstract class ArchitectCommand extends Command<ArchitectCommandOptions> 
         return await from(this.getProjectNamesByTarget(this.target)).pipe(
           concatMap(project => runSingleTarget({ ...targetSpec, project })),
           toArray(),
-        ).toPromise().then(results => results.every(res => res === 0) ? 0 : 1);
+          map(results => results.every(res => res === 0) ? 0 : 1),
+        )
+        .toPromise();
       } else {
         return await runSingleTarget(targetSpec).toPromise();
       }

--- a/packages/angular/cli/models/command-runner.ts
+++ b/packages/angular/cli/models/command-runner.ts
@@ -169,7 +169,7 @@ export async function runCommand(commandMap: CommandMap,
       return 1;
     }
 
-    return await command.run(options);
+    return command.run(options);
   }
 }
 


### PR DESCRIPTION
An async function always wraps the return value in a Promise. Using return await just adds extra time before the overreaching promise is resolved without changing the semantics.
