### PR TITLE
Add graphql-tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "file-loader": "^1.1.11",
     "font-awesome": "^4.7.0",
     "glob": "^7.0.3",
+    "graphql-tag": "^2.9.2",
     "html-webpack-plugin": "^3.0.6",
     "husky": "^0.14.3",
     "istanbul": "^0.4.5",

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
@@ -280,6 +280,11 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
           }
         },
         {
+          test: /\.(graphql|gql)$/,
+          exclude: /node_modules/,
+          loader: 'graphql-tag/loader'
+        },
+        {
           // Mark files inside `@angular/core` as using SystemJS style dynamic imports.
           // Removing this will cause deprecation warnings to appear.
           test: /[\/\\]@angular[\/\\]core[\/\\].+\.js$/,


### PR DESCRIPTION
graphql-tag isn't added as a feature and this is an easy solution that would sidestep many of the issues brought up by https://github.com/angular/angular-cli/issues/1656 