### PR TITLE
fix(@angular-devkit/schematics): fix declaring multiple aliases

### DIFF
--- a/packages/angular_devkit/schematics/tools/file-system-engine-host-base.ts
+++ b/packages/angular_devkit/schematics/tools/file-system-engine-host-base.ts
@@ -165,8 +165,9 @@ export abstract class FileSystemEngineHostBase implements
         if (allNames.indexOf(alias) != -1) {
           throw new SchematicNameCollisionException(alias);
         }
-        allNames.push(...aliases);
       }
+
+      allNames.push(...aliases);
     }
 
     return description;

--- a/packages/angular_devkit/schematics/tools/file-system-engine-host_spec.ts
+++ b/packages/angular_devkit/schematics/tools/file-system-engine-host_spec.ts
@@ -42,6 +42,45 @@ describe('FileSystemEngineHost', () => {
     expect(schematic1.description.name).toBe('schematic1');
   });
 
+  it('understands multiple aliases for a single schematic', () => {
+    const engineHost = new FileSystemEngineHost(root);
+    const engine = new SchematicEngine(engineHost);
+
+    const testCollection = engine.createCollection('aliases-many');
+
+    const schematic1 = engine.createSchematic('alias1', testCollection);
+    expect(schematic1).not.toBeNull();
+    expect(schematic1.description.name).toBe('schematic1');
+
+    const schematic2 = engine.createSchematic('alias2', testCollection);
+    expect(schematic2).not.toBeNull();
+    expect(schematic2.description.name).toBe('schematic1');
+
+    const schematic3 = engine.createSchematic('alias3', testCollection);
+    expect(schematic3).not.toBeNull();
+    expect(schematic3.description.name).toBe('schematic1');
+  });
+
+
+  it('allows dupe aliases for a single schematic', () => {
+    const engineHost = new FileSystemEngineHost(root);
+    const engine = new SchematicEngine(engineHost);
+
+    const testCollection = engine.createCollection('aliases-dupe');
+
+    const schematic1 = engine.createSchematic('alias1', testCollection);
+    expect(schematic1).not.toBeNull();
+    expect(schematic1.description.name).toBe('schematic1');
+
+    const schematic2 = engine.createSchematic('alias2', testCollection);
+    expect(schematic2).not.toBeNull();
+    expect(schematic2.description.name).toBe('schematic1');
+
+    const schematic3 = engine.createSchematic('alias3', testCollection);
+    expect(schematic3).not.toBeNull();
+    expect(schematic3.description.name).toBe('schematic1');
+  });
+
   it('lists schematics but not aliases', () => {
     const engineHost = new FileSystemEngineHost(root);
     const engine = new SchematicEngine(engineHost);

--- a/tests/@angular_devkit/schematics/tools/file-system-engine-host/aliases-dupe/collection.json
+++ b/tests/@angular_devkit/schematics/tools/file-system-engine-host/aliases-dupe/collection.json
@@ -1,0 +1,14 @@
+{
+  "name": "aliases-dupe",
+  "schematics": {
+    "schematic1": {
+      "aliases": ["alias1", "alias2", "alias3", "alias1", "alias2"],
+      "description": "1",
+      "factory": "../null-factory"
+    },
+    "schematic2": {
+      "description": "2",
+      "factory": "../null-factory"
+    }
+  }
+}

--- a/tests/@angular_devkit/schematics/tools/file-system-engine-host/aliases-many/collection.json
+++ b/tests/@angular_devkit/schematics/tools/file-system-engine-host/aliases-many/collection.json
@@ -1,0 +1,14 @@
+{
+  "name": "aliases-many",
+  "schematics": {
+    "schematic1": {
+      "aliases": ["alias1", "alias2", "alias3"],
+      "description": "1",
+      "factory": "../null-factory"
+    },
+    "schematic2": {
+      "description": "2",
+      "factory": "../null-factory"
+    }
+  }
+}


### PR DESCRIPTION
Fix #11389