### PR TITLE
fix(@schematics/angular): remove ngoninit from default component

### DIFF
--- a/packages/schematics/angular/component/files/__name@dasherize@if-flat__/__name@dasherize__.component.ts
+++ b/packages/schematics/angular/component/files/__name@dasherize@if-flat__/__name@dasherize__.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit<% if(!!viewEncapsulation) { %>, ViewEncapsulation<% }%><% if(changeDetection !== 'Default') { %>, ChangeDetectionStrategy<% }%> } from '@angular/core';
+import { Component<% if(!!viewEncapsulation) { %>, ViewEncapsulation<% }%><% if(changeDetection !== 'Default') { %>, ChangeDetectionStrategy<% }%> } from '@angular/core';
 
 @Component({
   selector: '<%= selector %>',<% if(inlineTemplate) { %>
@@ -13,11 +13,8 @@ import { Component, OnInit<% if(!!viewEncapsulation) { %>, ViewEncapsulation<% }
   encapsulation: ViewEncapsulation.<%= viewEncapsulation %><% } if (changeDetection !== 'Default') { %>,
   changeDetection: ChangeDetectionStrategy.<%= changeDetection %><% } %>
 })
-export class <%= classify(name) %>Component implements OnInit {
+export class <%= classify(name) %>Component {
 
   constructor() { }
-
-  ngOnInit() {
-  }
 
 }


### PR DESCRIPTION
With the challenges and misconceptions around ngOnInit, I feel like it would be better to remove it from components by default.

1. initializations provided by ngOnInit are not seen by the type system and may cause the user to fail `strictPropertyInitialization` checks from typescript
1. The best practice is for data flows (such as observables) to be defined in the constructor
1. Users seem to get think they should access Inputs in the ngOnInit, but instead they should be using ngOnChanges

Thoughts? @hansl @robwormald 

