### PR TITLE
refactor: remove redundant `error` in catch

### DIFF
--- a/packages/angular/cli/commands/version.ts
+++ b/packages/angular/cli/commands/version.ts
@@ -90,7 +90,7 @@ export default class VersionCommand extends Command {
       try {
         const gitRefName = '' + child_process.execSync('git symbolic-ref HEAD', {cwd: __dirname});
         gitBranch = path.basename(gitRefName.replace('\n', ''));
-      } catch (e) {
+      } catch {
       }
 
       ngCliVersion = `local (v${pkg.version}, branch: ${gitBranch})`;
@@ -172,7 +172,7 @@ export default class VersionCommand extends Command {
 
         return modulePkg.version + ' (cli-only)';
       }
-    } catch (e) {
+    } catch {
     }
 
     return '<error>';

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
@@ -203,7 +203,7 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
       : 'rxjs/_esm5/path-mapping';
     const rxPaths = requireProjectModule(projectRoot, rxjsPathMappingImport);
     alias = rxPaths(nodeModules);
-  } catch (e) { }
+  } catch { }
 
   const uglifyOptions = {
     ecma: wco.supportES2015 ? 6 : 5,

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/server.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/server.ts
@@ -50,7 +50,7 @@ export function getServerConfig(wco: WebpackConfigOptions) {
             // It's a system thing (.ie util, fs...)
             callback();
           }
-        } catch (e) {
+        } catch {
           // Node couldn't find it, so it must be user-aliased
           callback();
         }

--- a/packages/angular_devkit/build_angular/src/protractor/index.ts
+++ b/packages/angular_devkit/build_angular/src/protractor/index.ts
@@ -106,11 +106,11 @@ export class ProtractorBuilder implements Builder<ProtractorBuilderOptions> {
       // When using npm, webdriver is within protractor/node_modules.
       webdriverUpdate = requireProjectModule(getSystemPath(projectRoot),
         `protractor/node_modules/${webdriverDeepImport}`);
-    } catch (e) {
+    } catch {
       try {
         // When using yarn, webdriver is found as a root module.
         webdriverUpdate = requireProjectModule(getSystemPath(projectRoot), webdriverDeepImport);
-      } catch (e) {
+      } catch {
         throw new Error(tags.stripIndents`
           Cannot automatically find webdriver-manager to update.
           Update webdriver-manager manually and run 'ng e2e --no-webdriver-update' instead.

--- a/packages/angular_devkit/build_angular/src/tslint/index.ts
+++ b/packages/angular_devkit/build_angular/src/tslint/index.ts
@@ -224,7 +224,7 @@ function getFileContents(
   // NOTE: The tslint CLI checks for and excludes MPEG transport streams; this does not.
   try {
     return stripBom(readFileSync(file, 'utf-8'));
-  } catch (e) {
+  } catch {
     throw new Error(`Could not read file '${file}'.`);
   }
 }

--- a/packages/angular_devkit/core/node/resolve.ts
+++ b/packages/angular_devkit/core/node/resolve.ts
@@ -236,7 +236,7 @@ export function resolve(x: string, options: ResolveOptions): string {
             return n;
           }
         }
-      } catch (e) {}
+      } catch {}
     }
 
     return loadAsFileSync(path.join(x, '/index'));

--- a/packages/angular_devkit/core/src/virtual-fs/host/alias_spec.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/host/alias_spec.ts
@@ -28,7 +28,7 @@ describe('AliasHost', () => {
         .subscribe(undefined, err => {
           expect(err.message).toMatch(/does not exist/);
         });
-    } catch (e) {
+    } catch {
       // Ignore it. RxJS <6 still throw errors when they happen synchronously.
     }
   });
@@ -49,7 +49,7 @@ describe('AliasHost', () => {
     try {
       aHost.read(normalize('/some/folder/file'))
         .subscribe(undefined, err => expect(err.message).toMatch(/does not exist/));
-    } catch (e) {}
+    } catch {}
 
     // Create the file with new content and verify that this has the new content.
     aHost.write(normalize('/other/folder/file'), content2).subscribe();

--- a/packages/angular_devkit/core/src/virtual-fs/host/pattern_spec.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/host/pattern_spec.ts
@@ -32,7 +32,7 @@ describe('PatternMatchingHost', () => {
         .subscribe(undefined, err => {
           expect(err.message).toMatch(/does not exist/);
         });
-    } catch (e) {
+    } catch {
       // Ignore it. RxJS <6 still throw errors when they happen synchronously.
     }
 

--- a/packages/angular_devkit/schematics/tasks/tslint-fix/executor.ts
+++ b/packages/angular_devkit/schematics/tasks/tslint-fix/executor.ts
@@ -62,7 +62,7 @@ function _getFileContent(
     // Strip BOM from file data.
     // https://stackoverflow.com/questions/24356713
     return fs.readFileSync(file, 'utf-8').replace(/^\uFEFF/, '');
-  } catch (e) {
+  } catch {
     throw new Error(`Could not read file '${file}'.`);
   }
 }

--- a/packages/ngtools/webpack/src/compiler_host.ts
+++ b/packages/ngtools/webpack/src/compiler_host.ts
@@ -283,7 +283,7 @@ export class WebpackCompilerHost implements ts.CompilerHost {
 
         return stats;
       }
-    } catch (e) {
+    } catch {
       return undefined;
     }
   }
@@ -318,11 +318,11 @@ export class WebpackCompilerHost implements ts.CompilerHost {
       delegated = this._syncHost.list(p).filter((x: string) => {
         try {
           return this._syncHost.isFile(_join(p, x));
-        } catch (e) {
+        } catch {
           return false;
         }
       });
-    } catch (e) {
+    } catch {
       delegated = [];
     }
 
@@ -340,11 +340,11 @@ export class WebpackCompilerHost implements ts.CompilerHost {
       delegated = this._syncHost.list(p).filter((x: string) => {
         try {
           return this._syncHost.isDirectory(_join(p, x));
-        } catch (e) {
+        } catch {
           return false;
         }
       });
-    } catch (e) {
+    } catch {
       delegated = [];
     }
 

--- a/packages/schematics/angular/migrations/update-6/index.ts
+++ b/packages/schematics/angular/migrations/update-6/index.ts
@@ -90,7 +90,7 @@ function migrateKarmaConfiguration(config: CliConfig): Rule {
           `dir: require('path').join(__dirname, 'coverage'), reports`);
         host.overwrite(karmaPath, content);
       }
-    } catch (e) { }
+    } catch { }
 
     return host;
   };

--- a/scripts/snapshots.ts
+++ b/scripts/snapshots.ts
@@ -100,7 +100,7 @@ export default function(opts: SnapshotsOptions, logger: logging.Logger) {
     // Clear snapshot directory before publishing to remove deleted build files.
     try {
       _exec('git', ['rm', '-rf', './'], {cwd: destPath}, publishLogger);
-    } catch (e) {
+    } catch {
       // Ignore errors on delete. :shrug:
     }
     _copy(pkg.dist, destPath);

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/shared/location.service.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/shared/location.service.ts
@@ -72,8 +72,9 @@ export class LocationService {
               search[decodeURIComponent(pair[0])] = pair[1] && decodeURIComponent(pair[1]);
             }
           });
-      } catch (e) { /* don't care */ }
+        } catch (e) { /* don't care */ }
     }
+
     return search;
   }
 


### PR DESCRIPTION
not sure if this is your style, but error parameter is not needed if it's unused