### PR TITLE
fix(@ngtools/webpack): improve fallbacking for path mapping

### DIFF
--- a/packages/ngtools/webpack/src/paths-plugin.ts
+++ b/packages/ngtools/webpack/src/paths-plugin.ts
@@ -154,14 +154,21 @@ export function resolveWithPaths(
 
   // If TypeScript gives us a `.d.ts`, it is probably a node module
   if (moduleFilePath.endsWith('.d.ts')) {
-    // If in a package, let webpack resolve the package
-    const packageRootPath = path.join(path.dirname(moduleFilePath), 'package.json');
-    if (!host.fileExists(packageRootPath)) {
-      // Otherwise, if there is a file with a .js extension use that
-      const jsFilePath = moduleFilePath.slice(0, -5) + '.js';
-      if (host.fileExists(jsFilePath)) {
+    const pathNoExtension = moduleFilePath.slice(0, -5);
+    const pathDirName = path.dirname(moduleFilePath);
+    const packageRootPath = path.join(pathDirName, 'package.json');
+    const jsFilePath = `${pathNoExtension}.js`;
+
+    if (host.fileExists(pathNoExtension)) {
+        // This is mainly for secondary entry points
+        // ex: 'node_modules/@angular/core/testing.d.ts' -> 'node_modules/@angular/core/testing'
+        request.request = pathNoExtension;
+    } else if (host.fileExists(packageRootPath)) {
+        // Let webpack resolve the correct module format
+        request.request = pathDirName;
+    } else if (host.fileExists(jsFilePath)) {
+        // Otherwise, if there is a file with a .js extension use that
         request.request = jsFilePath;
-      }
     }
 
     callback(null, request);


### PR DESCRIPTION
This is following https://github.com/angular/angular-cli/pull/11351#discussion_r197549766

TypeScript tries to resolve modules as follows;
```
    // /node_modules/moduleB.ts
    // /node_modules/moduleB.tsx
    // /node_modules/moduleB.d.ts
    // /node_modules/moduleB/package.json (if it specifies a "types" property)
    // /node_modules/moduleB/index.ts
    // /node_modules/moduleB/index.tsx
    // /node_modules/moduleB/index.d.ts
```


//cc @clydin 

Not sure for I can add E2E that triggers the fallback