### PR TITLE
fix(@angular-devkit/build-optimizer): support object literal methods

### DIFF
--- a/packages/angular_devkit/build_optimizer/src/transforms/prefix-functions.ts
+++ b/packages/angular_devkit/build_optimizer/src/transforms/prefix-functions.ts
@@ -63,6 +63,7 @@ export function findTopLevelFunctions(parentNode: ts.Node): Set<ts.Node> {
       || ts.isFunctionExpression(node)
       || ts.isClassDeclaration(node)
       || ts.isArrowFunction(node)
+      || ts.isMethodDeclaration(node)
     ) {
       return;
     }

--- a/packages/angular_devkit/build_optimizer/src/transforms/prefix-functions_spec.ts
+++ b/packages/angular_devkit/build_optimizer/src/transforms/prefix-functions_spec.ts
@@ -162,5 +162,21 @@ describe('prefix-functions', () => {
 
       expect(tags.oneLine`${transform(input)}`).toEqual(tags.oneLine`${output}`);
     });
+
+    it('doesn\'t add comment when inside object literal method', () => {
+      const input = tags.stripIndent`
+        const literal = {
+          method() {
+            var newClazz = new Clazz();
+          }
+        };
+      `;
+      const output = tags.stripIndent`
+        ${emptyImportsComment}
+        ${input}
+      `;
+
+      expect(tags.oneLine`${transform(input)}`).toEqual(tags.oneLine`${output}`);
+    });
   });
 });


### PR DESCRIPTION
Fixes: #11399