### PR TITLE
fix(@angular-devkit/build-angular): downgrade sass-loader to 6.0.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9414,9 +9414,9 @@
       }
     },
     "sass-loader": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-7.0.2.tgz",
-      "integrity": "sha512-HfoUBjcBf56u7+Qb6/15OmfL4nymtACwAYXRuhgaSUJI3QF0ndID76SiTlwxDYgNYLtvP5s3xVSYMZISezsuKQ==",
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-6.0.7.tgz",
+      "integrity": "sha512-JoiyD00Yo1o61OJsoP2s2kb19L1/Y2p3QFcCdWdF6oomBGKVYuZyqHWemRBfQ2uGYsk+CH3eCguXNfpjzlcpaA==",
       "requires": {
         "clone-deep": "^2.0.1",
         "loader-utils": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "raw-loader": "^0.5.1",
     "rc": "^1.2.8",
     "rxjs": "^6.0.0",
-    "sass-loader": "^7.0.2",
+    "sass-loader": "~6.0.7",
     "semver": "^5.3.0",
     "semver-intersect": "^1.1.2",
     "source-map": "^0.5.6",

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -39,7 +39,7 @@
     "postcss-url": "^7.3.2",
     "raw-loader": "^0.5.1",
     "rxjs": "^6.0.0",
-    "sass-loader": "^7.0.2",
+    "sass-loader": "~6.0.7",
     "source-map-support": "^0.5.0",
     "source-map-loader": "^0.2.3",
     "stats-webpack-plugin": "^0.6.2",


### PR DESCRIPTION
Avoid the following issue (pending a fix): webpack-contrib/sass-loader/issues/556

Fixes: #10535