### PR TITLE
fix(@angular-devkit/build-angular): don't add hash to lazy styles

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/remove-hash-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/remove-hash-plugin.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { Compiler, compilation } from 'webpack';
+import { HashFormat } from '../models/webpack-configs/utils';
+
+
+export interface RemoveHashPluginOptions {
+  chunkIds: string[];
+  hashFormat: HashFormat;
+}
+
+export class RemoveHashPlugin {
+
+  constructor(private options: RemoveHashPluginOptions) { }
+
+  apply(compiler: Compiler): void {
+    compiler.hooks.compilation.tap('remove-hash-plugin', compilation => {
+      const mainTemplate = compilation.mainTemplate as compilation.MainTemplate & {
+        hooks: compilation.CompilationHooks;
+      };
+
+      mainTemplate.hooks.assetPath.tap('remove-hash-plugin',
+        (path: string, data: { chunk?: { id: string } }) => {
+          const chunkId = data.chunk && data.chunk.id;
+
+          if (chunkId && this.options.chunkIds.includes(chunkId)) {
+            // Replace hash formats with empty strings.
+            return path
+              .replace(this.options.hashFormat.chunk, '')
+              .replace(this.options.hashFormat.extract, '');
+          }
+
+          return path;
+        },
+      );
+    });
+  }
+}

--- a/packages/angular_devkit/build_angular/test/browser/output-hashing_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/browser/output-hashing_spec_large.ts
@@ -163,4 +163,21 @@ describe('Browser Builder output hashing', () => {
       }),
     ).toPromise().then(done, done.fail);
   });
+
+  it('does not hash lazy styles', (done) => {
+    const overrides = {
+      outputHashing: 'all',
+      extractCss: true,
+      styles: [{ input: 'src/styles.css', lazy: true }],
+    };
+
+    runTargetSpec(host, browserTargetSpec, overrides, DefaultTimeout).pipe(
+      tap(() => {
+        expect(host.fileMatchExists('dist', /styles\.[0-9a-f]{20}\.js/)).toBeFalsy();
+        expect(host.fileMatchExists('dist', /styles\.[0-9a-f]{20}\.js.map/)).toBeFalsy();
+        expect(host.scopedSync().exists(normalize('dist/styles.css'))).toBe(true);
+        expect(host.scopedSync().exists(normalize('dist/styles.css.map'))).toBe(true);
+      }),
+    ).toPromise().then(done, done.fail);
+  });
 });


### PR DESCRIPTION
Fix #11235