### PR TITLE
fix(@schematics/update): fix strict ssl always as true bug

### DIFF
--- a/packages/schematics/update/update/npm.ts
+++ b/packages/schematics/update/update/npm.ts
@@ -63,18 +63,18 @@ function getNpmConfigOption(
 
 function getNpmClientSslOptions(
   strictSsl?: string | boolean | undefined,
-  cafile?: string | boolean | undefined
+  cafile?: string | boolean | undefined,
 ) {
   const sslOptions: { strict?: boolean; ca?: Buffer } = {};
 
   if (strictSsl === undefined) {
     sslOptions.strict = true;
   } else {
-    sslOptions.strict = <boolean>strictSsl;
+    sslOptions.strict = <boolean> strictSsl;
   }
 
   if (cafile) {
-    sslOptions.ca = readFileSync(<string>cafile);
+    sslOptions.ca = readFileSync(<string> cafile);
   }
 
   return sslOptions;

--- a/packages/schematics/update/update/npm.ts
+++ b/packages/schematics/update/update/npm.ts
@@ -62,15 +62,15 @@ function getNpmConfigOption(
 }
 
 function getNpmClientSslOptions(
-  strictSsl?: string | boolean | undefined,
-  cafile?: string | boolean | undefined,
+  strictSsl?: boolean,
+  cafile?: string,
 ) {
   const sslOptions: { strict?: boolean; ca?: Buffer } = {};
 
-  sslOptions.strict = <boolean> strictSsl;
+  sslOptions.strict = strictSsl;
 
   if (cafile) {
-    sslOptions.ca = readFileSync(<string> cafile);
+    sslOptions.ca = readFileSync(cafile);
   }
 
   return sslOptions;

--- a/packages/schematics/update/update/npm.ts
+++ b/packages/schematics/update/update/npm.ts
@@ -62,12 +62,12 @@ function getNpmConfigOption(
 }
 
 function getNpmClientSslOptions(
-  strictSsl?: boolean,
+  strictSsl?: string | boolean,
   cafile?: string,
 ) {
   const sslOptions: { strict?: boolean; ca?: Buffer } = {};
 
-  sslOptions.strict = strictSsl;
+  sslOptions.strict = <boolean> strictSsl;
 
   if (cafile) {
     sslOptions.ca = readFileSync(cafile);

--- a/packages/schematics/update/update/npm.ts
+++ b/packages/schematics/update/update/npm.ts
@@ -67,11 +67,7 @@ function getNpmClientSslOptions(
 ) {
   const sslOptions: { strict?: boolean; ca?: Buffer } = {};
 
-  if (strictSsl === undefined) {
-    sslOptions.strict = true;
-  } else {
-    sslOptions.strict = <boolean> strictSsl;
-  }
+  sslOptions.strict = <boolean> strictSsl;
 
   if (cafile) {
     sslOptions.ca = readFileSync(<string> cafile);

--- a/packages/schematics/update/update/npm.ts
+++ b/packages/schematics/update/update/npm.ts
@@ -61,17 +61,20 @@ function getNpmConfigOption(
   return value;
 }
 
-function getNpmClientSslOptions(strictSsl?: string, cafile?: string) {
-  const sslOptions: { strict?: boolean, ca?: Buffer } = {};
+function getNpmClientSslOptions(
+  strictSsl?: string | boolean | undefined,
+  cafile?: string | boolean | undefined
+) {
+  const sslOptions: { strict?: boolean; ca?: Buffer } = {};
 
-  if (strictSsl === 'false') {
-    sslOptions.strict = false;
-  } else if (strictSsl === 'true') {
+  if (strictSsl === undefined) {
     sslOptions.strict = true;
+  } else {
+    sslOptions.strict = <boolean>strictSsl;
   }
 
   if (cafile) {
-    sslOptions.ca = readFileSync(cafile);
+    sslOptions.ca = readFileSync(<string>cafile);
   }
 
   return sslOptions;


### PR DESCRIPTION
The last release fixes an auth token issue on #10624 However, it doesn't get the correct **strict-ssl** option, since it uses package **rc** - boolean options comes as either boolean or undefined.