### PR TITLE
fix(@angular-devkit/build-angular): use the internal buildWebpackConf…

### DIFF
--- a/packages/angular_devkit/build_angular/src/dev-server/index.ts
+++ b/packages/angular_devkit/build_angular/src/dev-server/index.ts
@@ -84,8 +84,7 @@ export class DevServerBuilder implements Builder<DevServerBuilderOptions> {
       // Replace the assets in options with the normalized version.
       tap((assetPatternObjects => browserOptions.assets = assetPatternObjects)),
       concatMap(() => {
-        const browserBuilder = new BrowserBuilder(this.context);
-        const webpackConfig = browserBuilder.buildWebpackConfig(
+        const webpackConfig = this.buildWebpackConfig(
           root, projectRoot, host, browserOptions as NormalizedBrowserBuilderSchema);
 
         let webpackDevServerConfig: WebpackDevServer.Configuration;


### PR DESCRIPTION
…ig method

Instead of directly calling the browser builder. This means it can be overridden by
subclasses.