### PR TITLE
fix(@angular/cli): change serve fallback config to support Accept header wildcard

### DIFF
--- a/packages/@angular/cli/tasks/serve.ts
+++ b/packages/@angular/cli/tasks/serve.ts
@@ -220,7 +220,7 @@ export default Task.extend({
       historyApiFallback: {
         index: `${servePath}/${appConfig.index}`,
         disableDotRule: true,
-        htmlAcceptHeaders: ['text/html', 'application/xhtml+xml']
+        htmlAcceptHeaders: ['text/html', 'application/xhtml+xml', '*/*']
       },
       stats: serveTaskOptions.verbose ? statsConfig : 'none',
       inline: true,


### PR DESCRIPTION
If a resource request is not present on the server and the Accept header only contains the wildcard / to accept all content, the server responds with a 404 instead of the index.html content.

Testing:
Execute a GET request against any resource not available on the local dev server with the following Accept header:
Accept: */*
The server will return a 404 instead of a 200 with the index.html content