### PR TITLE
docs: clarify ng e2e project parameter format

### DIFF
--- a/docs/documentation/e2e.md
+++ b/docs/documentation/e2e.md
@@ -15,6 +15,12 @@ ng e2e [project]
 ng e2e
 ```
 
+Add '-e2e' extension to project names.
+
+```bash
+ng e2e myproject-e2e
+```
+
 End-to-end tests are run via [Protractor](https://angular.github.io/protractor/).
 
 ## Options


### PR DESCRIPTION
The `ng e2e [project]` command requires an `-e2e` extension after the project name.
Let us document this.

https://github.com/angular/angular-cli/issues/11533