### PR TITLE
fix(@angular-devkit/build-angular) changing order of event and coverage reporters

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/karma.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/karma.ts
@@ -67,6 +67,13 @@ const init: any = (config: any, emitter: any, customFileHandlers: any) => {
   failureCb = config.buildWebpack.failureCb;
 
   config.reporters.unshift('@angular-devkit/build-angular--event-reporter');
+  
+  // When using code-coverage, auto-add coverage-istanbul.
+  config.reporters = config.reporters || [];
+  if (options.codeCoverage && config.reporters.indexOf('coverage-istanbul') === -1) {
+    config.reporters.unshift('coverage-istanbul');
+  }
+  
   // Add a reporter that fixes sourcemap urls.
   if (options.sourceMap) {
     config.reporters.unshift('@angular-devkit/build-angular--sourcemap-reporter');
@@ -106,12 +113,6 @@ const init: any = (config: any, emitter: any, customFileHandlers: any) => {
   // Use existing config if any.
   config.webpack = Object.assign(webpackConfig, config.webpack);
   config.webpackMiddleware = Object.assign(webpackMiddlewareConfig, config.webpackMiddleware);
-
-  // When using code-coverage, auto-add coverage-istanbul.
-  config.reporters = config.reporters || [];
-  if (options.codeCoverage && config.reporters.indexOf('coverage-istanbul') === -1) {
-    config.reporters.push('coverage-istanbul');
-  }
 
   // Our custom context and debug files list the webpack bundles directly instead of using
   // the karma files array.


### PR DESCRIPTION
Fixing an issue when event reporter is executed before coverage reporter, which was causing the test command to pass even though unit testing coverage thresholds were not met. Closes https://github.com/angular/angular-cli/issues/10940