### PR TITLE
fix(@angular-devkit/build_angular): use webpack 4 hooks for single run in karma plugin

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/karma.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/karma.ts
@@ -67,13 +67,13 @@ const init: any = (config: any, emitter: any, customFileHandlers: any) => {
   failureCb = config.buildWebpack.failureCb;
 
   config.reporters.unshift('@angular-devkit/build-angular--event-reporter');
-  
+
   // When using code-coverage, auto-add coverage-istanbul.
   config.reporters = config.reporters || [];
   if (options.codeCoverage && config.reporters.indexOf('coverage-istanbul') === -1) {
     config.reporters.unshift('coverage-istanbul');
   }
-  
+
   // Add a reporter that fixes sourcemap urls.
   if (options.sourceMap) {
     config.reporters.unshift('@angular-devkit/build-angular--sourcemap-reporter');
@@ -135,7 +135,7 @@ const init: any = (config: any, emitter: any, customFileHandlers: any) => {
     // we can override the file watcher instead.
     webpackConfig.plugins.unshift({
       apply: (compiler: any) => { // tslint:disable-line:no-any
-        compiler.plugin('after-environment', () => {
+        compiler.hooks.afterEnvironment.tap('karma', () => {
           compiler.watchFileSystem = { watch: () => { } };
         });
       },


### PR DESCRIPTION
Right now, `ng test --watch=false` command will get the warning `(node:15240) DeprecationWarning: Tapable.plugin is deprecated. Use new API on '.hooks' instead`
And as angular-cli uses the webpack 4 right now, I just refactor the code to use the new `hooks` api.