### PR TITLE
feat(@angular-devkit/core): ng help/--help in JSON format

### DIFF
--- a/tests/legacy-cli/e2e/tests/commands/help/help-option-command.ts
+++ b/tests/legacy-cli/e2e/tests/commands/help/help-option-command.ts
@@ -3,5 +3,6 @@ import {silentNg} from '../../../utils/process';
 
 export default function() {
   return Promise.resolve()
-    .then(() => silentNg('--help', 'build'));
+    .then(() => silentNg('--help', 'build'))
+    .then(() => silentNg('--help', '--json'));
 }

--- a/tests/legacy-cli/e2e/tests/commands/help/help-option.ts
+++ b/tests/legacy-cli/e2e/tests/commands/help/help-option.ts
@@ -5,5 +5,7 @@ export default function() {
   return Promise.resolve()
     .then(() => silentNg('--help'))
     .then(() => process.chdir('/'))
-    .then(() => silentNg('--help'));
+    .then(() => silentNg('--help'))
+    .then(() => process.chdir('/'))
+    .then(() => silentNg('--help', '--json'));
 }


### PR DESCRIPTION
This change prints out the help texts in JSON format.

It is meant for CLI tools to process the output, e.g. to transform it into bash or zsh completion instructions.

In other words, this is the precondition for `ng` completion 2.0.
