### PR TITLE
fix(@angular-devkit/build_angular): add loader-utils as dependency

### DIFF
--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -28,6 +28,7 @@
     "less": "^3.0.4",
     "less-loader": "^4.1.0",
     "license-webpack-plugin": "^1.3.1",
+    "loader-utils": "^1.1.0",
     "mini-css-extract-plugin": "~0.4.0",
     "minimatch": "^3.0.4",
     "parse5": "^4.0.0",


### PR DESCRIPTION
* The `loader-utils` package is actively used in the `@angular-devkit/build_angular` package, and should therefore also list `loader-utils` as dependency. It might work for most package managers that do flatten the node modules, but if not (e.g. pnpm) this will fail *correctly*.

cc. @filipesilva 