### PR TITLE
feat(@angular-devkit/schematics): add .template as an extension

### DIFF
--- a/packages/angular_devkit/schematics/BUILD
+++ b/packages/angular_devkit/schematics/BUILD
@@ -99,6 +99,7 @@ ts_library(
     ),
     deps = [
         ":schematics",
+        ":testing",
         "//packages/angular_devkit/core",
         "@rxjs",
         "@rxjs//operators",

--- a/packages/angular_devkit/schematics/src/rules/base.ts
+++ b/packages/angular_devkit/schematics/src/rules/base.ts
@@ -185,3 +185,20 @@ export function forEach(operator: FileOperator): Rule {
     return tree;
   };
 }
+
+
+export function composeFileOperators(operators: FileOperator[]): FileOperator {
+  return (entry: FileEntry) => {
+    let current: FileEntry | null = entry;
+    for (const op of operators) {
+      current = op(current);
+
+      if (current === null) {
+        // Deleted, just return.
+        return null;
+      }
+    }
+
+    return current;
+  };
+}

--- a/packages/angular_devkit/schematics/src/rules/rename.ts
+++ b/packages/angular_devkit/schematics/src/rules/rename.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { normalize } from '@angular-devkit/core';
+import { Rule } from '../engine/interface';
+import { FilePredicate } from '../tree/interface';
+import { forEach } from './base';
+
+
+export function rename(match: FilePredicate<boolean>, to: FilePredicate<string>): Rule {
+  return forEach(entry => {
+    if (match(entry.path, entry)) {
+      return {
+        content: entry.content,
+        path: normalize(to(entry.path, entry)),
+      };
+    } else {
+      return entry;
+    }
+  });
+}

--- a/packages/angular_devkit/schematics/src/rules/rename_spec.ts
+++ b/packages/angular_devkit/schematics/src/rules/rename_spec.ts
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+// tslint:disable:non-null-operator
+import { of as observableOf } from 'rxjs';
+import { SchematicContext } from '../engine/interface';
+import { HostTree } from '../tree/host-tree';
+import { callRule } from './call';
+import { rename } from './rename';
+
+
+const context: SchematicContext = null !;
+
+
+describe('rename', () => {
+  it('works', done => {
+    const tree = new HostTree();
+    tree.create('a/b/file1', 'hello world');
+    tree.create('a/b/file2', 'hello world');
+    tree.create('a/c/file3', 'hello world');
+
+    let i = 0;
+
+    // Rename all files that contain 'b' to 'hello'.
+    callRule(rename(x => !!x.match(/b/), () => 'hello' + (i++)), observableOf(tree), context)
+      .toPromise()
+      .then(result => {
+        expect(result.exists('a/b/file1')).toBe(false);
+        expect(result.exists('a/b/file2')).toBe(false);
+        expect(result.exists('hello0')).toBe(true);
+        expect(result.exists('hello1')).toBe(true);
+        expect(result.exists('a/c/file3')).toBe(true);
+      })
+      .then(done, done.fail);
+  });
+
+  it('works (2)', done => {
+    const tree = new HostTree();
+    tree.create('a/b/file1', 'hello world');
+    tree.create('a/b/file2', 'hello world');
+    tree.create('a/c/file3', 'hello world');
+
+    let i = 0;
+
+    // Rename all files that contain 'b' to 'hello'.
+    callRule(rename(x => !!x.match(/b/), x => x + (i++)), observableOf(tree), context)
+      .toPromise()
+      .then(result => {
+        expect(result.exists('a/b/file1')).toBe(false);
+        expect(result.exists('a/b/file2')).toBe(false);
+        expect(result.exists('a/b/file10')).toBe(true);
+        expect(result.exists('a/b/file21')).toBe(true);
+        expect(result.exists('a/c/file3')).toBe(true);
+      })
+      .then(done, done.fail);
+  });
+});


### PR DESCRIPTION
New rules to deal with templates using a .template extension. Apply the template only
to those files, then remove the .template suffix.

Also added a new rename() rule that takes a matcher and a renamer. Nothing big there.

Also added a new composeFileOperator() that compose operators one after the other.

Fixes #11605.