### PR TITLE
Patching 1.3 branch with ng build breaking on uglify per 1.5 branch

### DIFF
--- a/packages/@angular/cli/models/webpack-configs/production.ts
+++ b/packages/@angular/cli/models/webpack-configs/production.ts
@@ -92,7 +92,7 @@ export const getProdConfig = function (wco: WebpackConfigOptions) {
     }));
   }
 
-  const uglifyCompressOptions: any = { screw_ie8: true, warnings: buildOptions.verbose };
+  const uglifyCompressOptions: any = { screw_ie8: true, warnings: buildOptions.verbose, comparisons: false };
 
   if (buildOptions.buildOptimizer) {
     // This plugin must be before webpack.optimize.UglifyJsPlugin.


### PR DESCRIPTION
Whilst I'm aware we probably should be upgrading, we've got a lot of applications that are only being built with 1.3.x - until we're able to get through and test all the breakages, it'd be great if we could get this merged in (as it has been for some other branches/versions).