### PR TITLE
fix(@angular-devkit/build-angular): should not log duplicate messages

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/karma.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/karma.ts
@@ -240,6 +240,9 @@ const eventReporter: any = function (this: any, baseReporterDecorator: any) {
       failureCb && failureCb();
     }
   }
+
+  // avoid duplicate failure message
+  this.specFailure = () => {};
 };
 
 eventReporter.$inject = ['baseReporterDecorator'];
@@ -271,6 +274,12 @@ const sourceMapReporter: any = function (this: any, baseReporterDecorator: any, 
       });
     }
   };
+
+  // avoid duplicate complete message
+  this.onRunComplete = () => {};
+
+  // avoid duplicate failure message
+  this.specFailure = () => {};
 };
 
 sourceMapReporter.$inject = ['baseReporterDecorator', 'config'];


### PR DESCRIPTION
Should not log duplicate messages for `specFailure` and `onRunComplete`, as they all have been handled by the `baseReporter`