### PR TITLE
feat(@angular-devkit/core): respect FORCE_COLOR env var behavior

### DIFF
--- a/packages/angular_devkit/core/src/terminal/caps.ts
+++ b/packages/angular_devkit/core/src/terminal/caps.ts
@@ -75,8 +75,15 @@ export interface StreamCapabilities {
 
 const ciVars = ['TRAVIS', 'CIRCLECI', 'APPVEYOR', 'GITLAB_CI'];
 
+function _getColorLevel(stream: Socket): 0 | 1 | 2 | 3 {
+  if ('FORCE_COLOR' in _env) {
+    if (_env.FORCE_COLOR === '1') {
+      return 3;
+    } else if (_env.FORCE_COLOR === '0') {
+      return 0;
+    }
+  }
 
-function _getColorLevel(stream: Socket): number {
   if (stream && !stream.isTTY) {
     return 0;
   }


### PR DESCRIPTION
Currently, there is no mechanism in the Angular tooling to forcefully output colors regardless of detected terminal capabilities. This commit adds an override via an environment variable: `FORCE_COLOR`. The behavior in this commit is the same as the behavior in a commonly used module, `supports-color` (https://github.com/chalk/supports-color#info). This is especially useful when piping output from the Angular CLI, which would automatically and irreversibly disable colors before this commit.