### PR TITLE
fix: suggest windows-compatible typescript install command

### DIFF
--- a/packages/angular/cli/upgrade/version.ts
+++ b/packages/angular/cli/upgrade/version.ts
@@ -164,7 +164,7 @@ export class Version {
 
         Please run the following command to install a compatible version of TypeScript.
 
-            npm install typescript@'${currentCombo.typescript}'
+            npm install typescript@"${currentCombo.typescript}"
 
         To disable this warning run "ng config cli.warnings.typescriptMismatch false".
       ` + '\n')));


### PR DESCRIPTION
Specifying version range in single quote doesn't work in windows CMD and it returns:
> The system cannot find the file specified.