### PR TITLE
fix(@schematics/angular): update Angular to 6.1 for new projects

### DIFF
--- a/packages/angular/cli/upgrade/version.ts
+++ b/packages/angular/cli/upgrade/version.ts
@@ -151,6 +151,8 @@ export class Version {
       { compiler: '>=5.1.0-beta.0 <5.2.0', typescript: '>=2.4.2 <2.6.0' },
       { compiler: '>=5.2.0-beta.0 <6.0.0', typescript: '>=2.4.2 <2.7.0' },
       { compiler: '>=6.0.0-beta.0 <7.0.0', typescript: '>=2.7.0 <2.8.0' },
+      { compiler: '>=6.1.0-beta.0 <6.1.0-rc.0', typescript: '>=2.7.2 <2.9.0' },
+      { compiler: '>=6.1.0-rc.0 <7.0.0', typescript: '>=2.7.2 <2.10.0' },
     ];
 
     const currentCombo = versionCombos.find((combo) => satisfies(compilerVersion, combo.compiler));

--- a/packages/schematics/angular/utility/latest-versions.ts
+++ b/packages/schematics/angular/utility/latest-versions.ts
@@ -10,7 +10,7 @@ export const latestVersions = {
   // These versions should be kept up to date with latest Angular peer dependencies.
   Angular: '^6.1.0',
   RxJs: '^6.0.0',
-  ZoneJs: '^0.8.26',
+  ZoneJs: '~0.8.26',
   TypeScript: '~2.7.2',
   // The versions below must be manually updated when making a new devkit release.
   DevkitBuildAngular: '~0.7.0',


### PR DESCRIPTION
Blocked on an Angular 6.1 final release