### PR TITLE
fix(@angular-devkit/build-angular): ensure failure with disabled AOT and enabled build optimizer

### DIFF
--- a/packages/angular_devkit/build_angular/src/browser/index.ts
+++ b/packages/angular_devkit/build_angular/src/browser/index.ts
@@ -71,11 +71,6 @@ export class BrowserBuilder implements Builder<BrowserBuilderSchema> {
       // Replace the assets in options with the normalized version.
       tap((assetPatternObjects => options.assets = assetPatternObjects)),
       concatMap(() => {
-        // Ensure Build Optimizer is only used with AOT.
-        if (options.buildOptimizer && !options.aot) {
-          throw new Error('The `--build-optimizer` option cannot be used without `--aot`.');
-        }
-
         let webpackConfig;
         try {
           webpackConfig = this.buildWebpackConfig(root, projectRoot, host,
@@ -119,6 +114,11 @@ export class BrowserBuilder implements Builder<BrowserBuilderSchema> {
     host: virtualFs.Host<fs.Stats>,
     options: NormalizedBrowserBuilderSchema,
   ) {
+    // Ensure Build Optimizer is only used with AOT.
+    if (options.buildOptimizer && !options.aot) {
+      throw new Error('The `--build-optimizer` option cannot be used without `--aot`.');
+    }
+
     let wco: WebpackConfigOptions<NormalizedBrowserBuilderSchema>;
 
     const tsConfigPath = getSystemPath(normalize(resolve(root, normalize(options.tsConfig))));

--- a/packages/angular_devkit/build_angular/test/browser/build-optimizer_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/browser/build-optimizer_spec_large.ts
@@ -30,6 +30,12 @@ describe('Browser Builder build optimizer', () => {
     ).toPromise().then(done, done.fail);
   });
 
+  it('fails if AOT is disabled', (done) => {
+    const overrides = { aot: false, buildOptimizer: true };
+    runTargetSpec(host, browserTargetSpec, overrides)
+      .toPromise().then(() => done.fail(), () => done());
+  });
+
   it('reduces bundle size', (done) => {
     const noBoOverrides = { aot: true, optimization: true, vendorChunk: false };
     const boOverrides = { ...noBoOverrides, buildOptimizer: true };

--- a/tests/legacy-cli/e2e/tests/build/build-optimizer.ts
+++ b/tests/legacy-cli/e2e/tests/build/build-optimizer.ts
@@ -10,5 +10,6 @@ export default function () {
     .then(() => expectToFail(() => expectFileToMatch('dist/test-project/main.js', /\.decorators =/)))
     .then(() => ng('build', '--prod'))
     .then(() => expectToFail(() => expectFileToExist('dist/vendor.js')))
-    .then(() => expectToFail(() => expectFileToMatch('dist/test-project/main.js', /\.decorators =/)));
+    .then(() => expectToFail(() => expectFileToMatch('dist/test-project/main.js', /\.decorators =/)))
+    .then(() => expectToFail(() => ng('build', '--aot=false', '--build-optimizer')));
 }


### PR DESCRIPTION
Fixes #11157