### PR TITLE
fix(@angular-devkit/schematics): implement optimize() for HostTree

### DIFF
--- a/packages/angular_devkit/schematics/src/tree/host-tree.ts
+++ b/packages/angular_devkit/schematics/src/tree/host-tree.ts
@@ -134,6 +134,12 @@ export class HostTree implements Tree {
     return this._record.willRename(path);
   }
 
+  // This can be used by old Schematics library with new Trees in some corner cases.
+  // TODO: remove this for 7.0
+  optimize() {
+    return this;
+  }
+
   branch(): Tree {
     const branchedTree = new HostTree(this._backend);
     branchedTree._record = this._record.clone();


### PR DESCRIPTION
Its only used by old Schematics library, which can end up in there. Since optimization
is only a thing for VirtualTree, HostTree returns itself.

Fixes #11688