### PR TITLE
fix(@angular-devkit/schematics): Fix issues for file-syetem-engine running in google3

### DIFF
--- a/packages/angular_devkit/schematics/tools/file-system-engine-host.ts
+++ b/packages/angular_devkit/schematics/tools/file-system-engine-host.ts
@@ -57,7 +57,10 @@ export class FileSystemEngineHost extends FileSystemEngineHostBase {
       throw new CollectionMissingSchematicsMapException(name);
     }
 
-    return desc as FileSystemCollectionDesc;
+    return {
+      ...desc,
+      name,
+    } as FileSystemCollectionDesc;
   }
 
   protected _transformSchematicDescription(


### PR DESCRIPTION
Pass 'name' as part of FileSystemCollectionDesc when creating
collection description.