### PR TITLE
fix: remove `vendorSourceMap` warning that `vendorSourceMap` is not a…

### DIFF
--- a/docs/documentation/serve.md
+++ b/docs/documentation/serve.md
@@ -209,6 +209,15 @@ ng serve [project]
   </p>
 </details>
 <details>
+  <summary>vendor-source-map</summary>
+  <p>
+    <code>--vendor-source-map</code>
+  </p>
+  <p>
+    Resolve vendor packages sourcemaps.
+  </p>
+</details>
+<details>
   <summary>vendor-chunk</summary>
   <p>
     <code>--vendor-chunk</code>

--- a/packages/angular/cli/lib/config/schema.json
+++ b/packages/angular/cli/lib/config/schema.json
@@ -605,6 +605,11 @@
               "description": "Output sourcemaps.",
               "default": true
             },
+            "vendorSourceMap": {
+              "type": "boolean",
+              "description": "Resolve vendor packages sourcemaps.",
+              "default": false
+            },
             "evalSourceMap": {
               "type": "boolean",
               "description": "Output in-file eval sourcemaps.",
@@ -1000,6 +1005,11 @@
               "type": "boolean",
               "description": "Output sourcemaps."
             },
+            "vendorSourceMap": {
+              "type": "boolean",
+              "description": "Resolve vendor packages sourcemaps.",
+              "default": false
+            },
             "evalSourceMap": {
               "type": "boolean",
               "description": "Output in-file eval sourcemaps."
@@ -1382,6 +1392,11 @@
               "type": "boolean",
               "description": "Output sourcemaps.",
               "default": true
+            },
+            "vendorSourceMap": {
+              "type": "boolean",
+              "description": "Resolve vendor packages sourcemaps.",
+              "default": false
             },
             "evalSourceMap": {
               "type": "boolean",

--- a/packages/angular_devkit/build_angular/src/dev-server/index.ts
+++ b/packages/angular_devkit/build_angular/src/dev-server/index.ts
@@ -51,6 +51,7 @@ export interface DevServerBuilderOptions {
   optimization?: boolean;
   aot?: boolean;
   sourceMap?: boolean;
+  vendorSourceMap?: boolean;
   evalSourceMap?: boolean;
   vendorChunk?: boolean;
   commonChunk?: boolean;
@@ -399,6 +400,8 @@ export class DevServerBuilder implements Builder<DevServerBuilderOptions> {
       ...(options.optimization !== undefined ? { optimization: options.optimization } : {}),
       ...(options.aot !== undefined ? { aot: options.aot } : {}),
       ...(options.sourceMap !== undefined ? { sourceMap: options.sourceMap } : {}),
+      ...(options.vendorSourceMap !== undefined ?
+         { vendorSourceMap: options.vendorSourceMap } : {}),
       ...(options.evalSourceMap !== undefined ? { evalSourceMap: options.evalSourceMap } : {}),
       ...(options.vendorChunk !== undefined ? { vendorChunk: options.vendorChunk } : {}),
       ...(options.commonChunk !== undefined ? { commonChunk: options.commonChunk } : {}),


### PR DESCRIPTION
fixes: remove `vendorSourceMap` warning that `vendorSourceMap` is not allowed
fixes: `--vendor-source-map` doesn't work when used as a command argument of `ng-serve`

While the build works and there are no error, at the moment you will have a warning in `angular.json`

Closes #11715