### PR TITLE
test(@schematics/angular): no matching version found for `@angular-dev`

### DIFF
--- a/packages/schematics/angular/utility/latest-versions.ts
+++ b/packages/schematics/angular/utility/latest-versions.ts
@@ -13,6 +13,6 @@ export const latestVersions = {
   ZoneJs: '~0.8.26',
   TypeScript: '~2.9.2',
   // The versions below must be manually updated when making a new devkit release.
-  DevkitBuildAngular: '~0.8.0',
-  DevkitBuildNgPackagr: '~0.8.0',
+  DevkitBuildAngular: '~0.8.0-beta.0',
+  DevkitBuildNgPackagr: '~0.8.0-beta.0',
 };


### PR DESCRIPTION
During the last release the versions have been set incorrectly.

This is also the cause why E2E tests in CI are failing

Relates to #11746