### PR TITLE
refactor: remove extra `.` in error message

### DIFF
--- a/packages/angular_devkit/schematics_cli/bin/schematics.ts
+++ b/packages/angular_devkit/schematics_cli/bin/schematics.ts
@@ -168,7 +168,7 @@ workflow.reporter.subscribe((event: DryRunEvent) => {
     case 'error':
       error = true;
 
-      const desc = event.description == 'alreadyExist' ? 'already exists' : 'does not exist.';
+      const desc = event.description == 'alreadyExist' ? 'already exists' : 'does not exist';
       logger.warn(`ERROR! ${event.path} ${desc}.`);
       break;
     case 'update':


### PR DESCRIPTION
There is already a full stop in the following line.