### PR TITLE
Remove the restriction of additionalProperties from Angular schematics

### DIFF
--- a/packages/angular/pwa/pwa/schema.json
+++ b/packages/angular/pwa/pwa/schema.json
@@ -26,6 +26,5 @@
       "description": "The title of the application."
     }
   },
-  "required": [],
-  "additionalProperties": false
+  "required": []
 }

--- a/packages/schematics/angular/app-shell/schema.json
+++ b/packages/schematics/angular/app-shell/schema.json
@@ -98,6 +98,5 @@
   "required": [
     "clientProject",
     "universalProject"
-  ],
-  "additionalProperties": false
+  ]
 }

--- a/packages/schematics/angular/application/schema.json
+++ b/packages/schematics/angular/application/schema.json
@@ -63,6 +63,5 @@
       "description": "Do not add dependencies to package.json."
     }
   },
-  "required": [],
-  "additionalProperties": false
+  "required": []
 }

--- a/packages/schematics/angular/class/schema.json
+++ b/packages/schematics/angular/class/schema.json
@@ -36,6 +36,5 @@
       "default": ""
     }
   },
-  "required": [],
-  "additionalProperties": false
+  "required": []
 }

--- a/packages/schematics/angular/component/schema.json
+++ b/packages/schematics/angular/component/schema.json
@@ -110,6 +110,5 @@
       "description": "Specifies whether to apply lint fixes after generating the component."
     }
   },
-  "required": [],
-  "additionalProperties": false
+  "required": []
 }

--- a/packages/schematics/angular/directive/schema.json
+++ b/packages/schematics/angular/directive/schema.json
@@ -75,6 +75,5 @@
       "description": "Specifies whether to apply lint fixes after generating the directive."
     }
   },
-  "required": [],
-  "additionalProperties": false
+  "required": []
 }

--- a/packages/schematics/angular/e2e/schema.json
+++ b/packages/schematics/angular/e2e/schema.json
@@ -30,6 +30,5 @@
   },
   "required": [
     "relatedAppName"
-  ],
-  "additionalProperties": false
+  ]
 }

--- a/packages/schematics/angular/enum/schema.json
+++ b/packages/schematics/angular/enum/schema.json
@@ -31,6 +31,5 @@
       "description": "Specifies whether to apply lint fixes after generating the enum."
     }
   },
-  "required": [],
-  "additionalProperties": false
+  "required": []
 }

--- a/packages/schematics/angular/guard/schema.json
+++ b/packages/schematics/angular/guard/schema.json
@@ -41,6 +41,5 @@
       "description": "Specifies whether to apply lint fixes after generating the guard."
     }
   },
-  "required": [],
-  "additionalProperties": false
+  "required": []
 }

--- a/packages/schematics/angular/interface/schema.json
+++ b/packages/schematics/angular/interface/schema.json
@@ -44,6 +44,5 @@
       "description": "Specifies whether to apply lint fixes after generating the directive."
     }
   },
-  "required": [],
-  "additionalProperties": false
+  "required": []
 }

--- a/packages/schematics/angular/library/schema.json
+++ b/packages/schematics/angular/library/schema.json
@@ -36,6 +36,5 @@
       "description": "Do not update tsconfig.json for development experience."
     }
   },
-  "required": [],
-  "additionalProperties": false
+  "required": []
 }

--- a/packages/schematics/angular/module/schema.json
+++ b/packages/schematics/angular/module/schema.json
@@ -58,6 +58,5 @@
       "alias": "m"
     }
   },
-  "required": [],
-  "additionalProperties": false
+  "required": []
 }

--- a/packages/schematics/angular/ng-new/schema.json
+++ b/packages/schematics/angular/ng-new/schema.json
@@ -113,6 +113,5 @@
   },
   "required": [
     "version"
-  ],
-  "additionalProperties": false
+  ]
 }

--- a/packages/schematics/angular/pipe/schema.json
+++ b/packages/schematics/angular/pipe/schema.json
@@ -57,6 +57,5 @@
       "description": "Specifies whether to apply lint fixes after generating the pipe."
     }
   },
-  "required": [],
-  "additionalProperties": false
+  "required": []
 }

--- a/packages/schematics/angular/service-worker/schema.json
+++ b/packages/schematics/angular/service-worker/schema.json
@@ -22,6 +22,5 @@
       "default": "production"
     }
   },
-  "required": [],
-  "additionalProperties": false
+  "required": []
 }

--- a/packages/schematics/angular/service/schema.json
+++ b/packages/schematics/angular/service/schema.json
@@ -41,6 +41,5 @@
       "description": "Specifies whether to apply lint fixes after generating the pipe."
     }
   },
-  "required": [],
-  "additionalProperties": false
+  "required": []
 }

--- a/packages/schematics/angular/universal/schema.json
+++ b/packages/schematics/angular/universal/schema.json
@@ -61,6 +61,5 @@
   },
   "required": [
     "clientProject"
-  ],
-  "additionalProperties": false
+  ]
 }

--- a/packages/schematics/angular/workspace/schema.json
+++ b/packages/schematics/angular/workspace/schema.json
@@ -70,6 +70,5 @@
   "required": [
     "name",
     "version"
-  ],
-  "additionalProperties": false
+  ]
 }


### PR DESCRIPTION
When they were added it caused breakages, so this restriction should be re-added at the next major release.