### PR TITLE
fix(@schematics/update): fix logic to gather version of arguments

### DIFF
--- a/packages/schematics/update/update/index_spec.ts
+++ b/packages/schematics/update/update/index_spec.ts
@@ -147,8 +147,7 @@ describe('@schematics/update', () => {
     );
 
     schematicRunner.runSchematicAsync('update', {
-      packages: ['@angular/core'],
-      next: true,
+      packages: ['@angular/core@^6.0.0'],
     }, appTree).pipe(
       map(tree => {
         const packageJson = JSON.parse(tree.readContent('/package.json'));
@@ -194,8 +193,7 @@ describe('@schematics/update', () => {
     );
 
     schematicRunner.runSchematicAsync('update', {
-      packages: ['@angular/core'],
-      next: true,
+      packages: ['@angular/core@^6.0.0'],
     }, appTree).pipe(
       map(tree => {
         const packageJson = JSON.parse(tree.readContent('/package.json'));


### PR DESCRIPTION
Before we were blindly looking the version. We need to reuse the package info logic
which properly resolve operators.

Also fixed the tests to not use next but @6. Next is now 7 beta and that does not
work. We just want to test a major above so that is fine.