### PR TITLE
fix(@schematics/angular): Handle Windows paths for generate names

### DIFF
--- a/packages/schematics/angular/utility/parse-name.ts
+++ b/packages/schematics/angular/utility/parse-name.ts
@@ -7,7 +7,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 // import { relative, Path } from "../../../angular_devkit/core/src/virtual-fs";
-import { Path, basename, dirname, normalize } from '@angular-devkit/core';
+import { Path, basename, dirname, join, normalize } from '@angular-devkit/core';
 
 export interface Location {
   name: string;
@@ -15,8 +15,8 @@ export interface Location {
 }
 
 export function parseName(path: string, name: string): Location {
-  const nameWithoutPath = basename(name as Path);
-  const namePath = dirname((path + '/' + name) as Path);
+  const nameWithoutPath = basename(normalize(name));
+  const namePath = dirname(join(normalize(path), name) as Path);
 
   return {
     name: nameWithoutPath,

--- a/packages/schematics/angular/utility/parse-name_spec.ts
+++ b/packages/schematics/angular/utility/parse-name_spec.ts
@@ -36,4 +36,10 @@ describe('parse-name', () => {
   it('should handle name has a higher path above root', () => {
     expect(() => parseName('src/app', '../../../foo')).toThrow();
   });
+
+  it('should handle Windows paths', () => {
+    const result = parseName('', 'foo\\bar\\baz');
+    expect(result.name).toEqual('baz');
+    expect(result.path).toEqual('/foo/bar');
+  });
 });


### PR DESCRIPTION
fixes #11501