### PR TITLE
feat(@ngtools/webpack): expose TS TypeChecker from ng compiler plugin

### DIFF
--- a/packages/ngtools/webpack/src/angular_compiler_plugin.ts
+++ b/packages/ngtools/webpack/src/angular_compiler_plugin.ts
@@ -174,6 +174,12 @@ export class AngularCompilerPlugin {
     return { path, className };
   }
 
+  get typeChecker(): ts.TypeChecker | null {
+    const tsProgram = this._getTsProgram();
+
+    return tsProgram ? tsProgram.getTypeChecker() : null;
+  }
+
   static isSupported() {
     return VERSION && parseInt(VERSION.major) >= 5;
   }
@@ -351,7 +357,7 @@ export class AngularCompilerPlugin {
           this._updateForkedTypeChecker(this._rootNames, this._getChangedCompilationFiles());
         }
 
-         // Use an identity function as all our paths are absolute already.
+        // Use an identity function as all our paths are absolute already.
         this._moduleResolutionCache = ts.createModuleResolutionCache(this._basePath, x => x);
 
         if (this._JitMode) {
@@ -1020,7 +1026,7 @@ export class AngularCompilerPlugin {
       .map((resourcePath) => resolve(dirname(resolvedFileName), normalize(resourcePath)));
 
     // These paths are meant to be used by the loader so we must denormalize them.
-    const uniqueDependencies =  new Set([
+    const uniqueDependencies = new Set([
       ...esImports,
       ...resourceImports,
       ...this.getResourceDependencies(this._compilerHost.denormalizePath(resolvedFileName)),


### PR DESCRIPTION
Expose the TypeScript Program created by the plugin, so that it can be used in custom platform transformers.This will allow to define custom [`platformTransformers`](https://github.com/angular/angular-cli/blob/master/packages/ngtools/webpack/src/angular_compiler_plugin.ts#L105) similar to [`replace_bootstrap`](https://github.com/angular/angular-cli/blob/master/packages/ngtools/webpack/src/transformers/replace_bootstrap.ts). They will need some way to get access to the TS program created by the plugin to make transformations.

We discussed this with @filipesilva in slack and he suggested to open a proper PR exposing the TS program and continue any discussions here.