### PR TITLE
refactor(@angular-devkit/build-angular): remove unnecessary stylus-lo…

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/styles.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/styles.ts
@@ -300,8 +300,6 @@ export function getStylesConfig(wco: WebpackConfigOptions) {
   }
 
   return {
-    // Workaround stylus-loader defect: https://github.com/shama/stylus-loader/issues/189
-    loader: { stylus: {} },
     entry: entryPoints,
     module: { rules },
     plugins: [].concat(extraPlugins as any)


### PR DESCRIPTION
…ader workaround

Remove unnecessary stylus-loader workaround. 
Issue, from which this workaround originates, is resolved. 
Link to issue in stylus-loader: https://github.com/shama/stylus-loader/issues/189