### PR TITLE
fix(@angular-devkit/build-angular): use process TTY as progress default

### DIFF
--- a/packages/angular_devkit/build_angular/src/browser/index.ts
+++ b/packages/angular_devkit/build_angular/src/browser/index.ts
@@ -34,7 +34,7 @@ import {
   statsToString,
   statsWarningsToString,
 } from '../angular-cli-files/utilities/stats';
-import { normalizeAssetPatterns, normalizeFileReplacements } from '../utils';
+import { defaultProgress, normalizeAssetPatterns, normalizeFileReplacements } from '../utils';
 import { AssetPatternObject, BrowserBuilderSchema, CurrentFileReplacement } from './schema';
 const webpackMerge = require('webpack-merge');
 
@@ -137,6 +137,8 @@ export class BrowserBuilder implements Builder<BrowserBuilderSchema> {
       tsConfigPath,
       supportES2015,
     };
+
+    wco.buildOptions.progress = defaultProgress(wco.buildOptions.progress);
 
     const webpackConfigs: {}[] = [
       getCommonConfig(wco),

--- a/packages/angular_devkit/build_angular/src/browser/schema.d.ts
+++ b/packages/angular_devkit/build_angular/src/browser/schema.d.ts
@@ -104,7 +104,7 @@ export interface BrowserBuilderSchema {
   /**
    * Log progress to the console while building.
    */
-  progress: boolean;
+  progress?: boolean;
 
   /**
    * Localization file to use for i18n.

--- a/packages/angular_devkit/build_angular/src/browser/schema.json
+++ b/packages/angular_devkit/build_angular/src/browser/schema.json
@@ -115,8 +115,7 @@
     },
     "progress": {
       "type": "boolean",
-      "description": "Log progress to the console while building.",
-      "default": true
+      "description": "Log progress to the console while building."
     },
     "i18nFile": {
       "type": "string",

--- a/packages/angular_devkit/build_angular/src/karma/index.ts
+++ b/packages/angular_devkit/build_angular/src/karma/index.ts
@@ -27,7 +27,7 @@ import {
 import { readTsconfig } from '../angular-cli-files/utilities/read-tsconfig';
 import { requireProjectModule } from '../angular-cli-files/utilities/require-project-module';
 import { AssetPatternObject, CurrentFileReplacement } from '../browser/schema';
-import { normalizeAssetPatterns, normalizeFileReplacements } from '../utils';
+import { defaultProgress, normalizeAssetPatterns, normalizeFileReplacements } from '../utils';
 import { KarmaBuilderSchema } from './schema';
 const webpackMerge = require('webpack-merge');
 
@@ -136,6 +136,8 @@ export class KarmaBuilder implements Builder<KarmaBuilderSchema> {
       tsConfigPath,
       supportES2015,
     };
+
+    wco.buildOptions.progress = defaultProgress(wco.buildOptions.progress);
 
     const webpackConfigs: {}[] = [
       getCommonConfig(wco),

--- a/packages/angular_devkit/build_angular/src/karma/schema.json
+++ b/packages/angular_devkit/build_angular/src/karma/schema.json
@@ -77,8 +77,7 @@
     },
     "progress": {
       "type": "boolean",
-      "description": "Log progress to the console while building.",
-      "default": true
+      "description": "Log progress to the console while building."
     },
     "watch": {
       "type": "boolean",

--- a/packages/angular_devkit/build_angular/src/server/index.ts
+++ b/packages/angular_devkit/build_angular/src/server/index.ts
@@ -30,7 +30,7 @@ import {
 import { readTsconfig } from '../angular-cli-files/utilities/read-tsconfig';
 import { requireProjectModule } from '../angular-cli-files/utilities/require-project-module';
 import { getBrowserLoggingCb } from '../browser';
-import { normalizeFileReplacements } from '../utils';
+import { defaultProgress, normalizeFileReplacements } from '../utils';
 import { BuildWebpackServerSchema } from './schema';
 const webpackMerge = require('webpack-merge');
 
@@ -97,6 +97,8 @@ export class ServerBuilder implements Builder<BuildWebpackServerSchema> {
       tsConfigPath,
       supportES2015,
     };
+
+    wco.buildOptions.progress = defaultProgress(wco.buildOptions.progress);
 
     const webpackConfigs: {}[] = [
       getCommonConfig(wco),

--- a/packages/angular_devkit/build_angular/src/server/schema.json
+++ b/packages/angular_devkit/build_angular/src/server/schema.json
@@ -80,8 +80,7 @@
     },
     "progress": {
       "type": "boolean",
-      "description": "Log progress to the console while building.",
-      "default": true
+      "description": "Log progress to the console while building."
     },
     "i18nFile": {
       "type": "string",

--- a/packages/angular_devkit/build_angular/src/utils/default-progress.ts
+++ b/packages/angular_devkit/build_angular/src/utils/default-progress.ts
@@ -6,7 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export * from './default-progress';
-export * from './run-module-as-observable-fork';
-export * from './normalize-file-replacements';
-export * from './normalize-asset-patterns';
+export function defaultProgress(progress: boolean | undefined): boolean {
+  if (progress === undefined) {
+    return process.stdout.isTTY === true;
+  }
+
+  return progress;
+}


### PR DESCRIPTION
Fix #11195