### PR TITLE
Fix(@schematics/angular): support `Fetch as Google`（Google bot)

### DIFF
--- a/packages/schematics/angular/application/files/src/polyfills.ts
+++ b/packages/schematics/angular/application/files/src/polyfills.ts
@@ -28,11 +28,18 @@
 // import 'core-js/es6/math';
 // import 'core-js/es6/string';
 // import 'core-js/es6/date';
-// import 'core-js/es6/array';
 // import 'core-js/es6/regexp';
 // import 'core-js/es6/map';
 // import 'core-js/es6/weak-map';
 // import 'core-js/es6/set';
+
+/**
+ * If your app need to indexed by Google Search, your app require polyfills 'core-js/es6/array'
+ * Google bot use ES5.
+ * FYI: Googlebot uses a renderer following the similar spec to Chrome 41.
+ * https://developers.google.com/search/docs/guides/rendering
+ **/
+// import 'core-js/es6/array';
 
 /** IE10 and IE11 requires the following for NgClass support on SVG elements */
 // import 'classlist.js';  // Run `npm install --save classlist.js`.


### PR DESCRIPTION
Fetch as Google (Google's bot checker) use ES5. So ES5 require polyfills (`Fetch as Google` need `core-js/es6/array` only ).
I think that Angular needs a response to Google in order to become a PWA. 

thanks.