### PR TITLE
fix(@schematics/angular): incorrect `exclude` path for `test.ts`

### DIFF
--- a/packages/schematics/angular/application/files/root/tsconfig.app.json
+++ b/packages/schematics/angular/application/files/root/tsconfig.app.json
@@ -5,7 +5,7 @@
     "types": []
   },
   "exclude": [
-    "src/test.ts",
+    "test.ts",
     "**/*.spec.ts"
   ]<% if (experimentalIvy) { %>,
   "angularCompilerOptions": {


### PR DESCRIPTION
Closes #11829