### PR TITLE
fix(@schematics/angular): ensure non-evergreen IE browsers are excluded

### DIFF
--- a/packages/schematics/angular/application/files/root/browserslist
+++ b/packages/schematics/angular/application/files/root/browserslist
@@ -1,9 +1,11 @@
 # This file is currently used by autoprefixer to adjust CSS to support the below specified browsers
 # For additional information regarding the format and rule options, please see:
 # https://github.com/browserslist/browserslist#queries
-# For IE 9-11 support, please uncomment the last line of the file and adjust as needed
+#
+# For IE 9-11 support, please remove 'not' from the last line of the file and adjust as needed
+
 > 0.5%
 last 2 versions
 Firefox ESR
 not dead
-# IE 9-11
+not IE 9-11


### PR DESCRIPTION
Fixes #11333