### PR TITLE
feat(@schematics/angular): use Karma 3.0.0 by default

### DIFF
--- a/packages/schematics/angular/workspace/files/package.json
+++ b/packages/schematics/angular/workspace/files/package.json
@@ -34,7 +34,7 @@
     "codelyzer": "~4.3.0",
     "jasmine-core": "~2.99.1",
     "jasmine-spec-reporter": "~4.2.1",
-    "karma": "~1.7.1",
+    "karma": "~3.0.0",
     "karma-chrome-launcher": "~2.2.0",
     "karma-coverage-istanbul-reporter": "~2.0.1",
     "karma-jasmine": "~1.1.2",


### PR DESCRIPTION
This *may be* a BREAKING CHANGE. (Or it may not, please review.)

I reviewed the change log of Karma and the only breaking change of Karma is dropping support for Node 4.

Since the CLI does not support Node 4 anyway, I don't think this is a breaking change. (Plus, I did a test on my personal projects and it worked!)

Close #10963