### PR TITLE
docs: add local installation and specific version installation instructions for angular-cli

### DIFF
--- a/packages/angular/cli/README.md
+++ b/packages/angular/cli/README.md
@@ -55,7 +55,7 @@ npm install @angular/cli
 
 To run a locally installed version of the angular-cli, you can call `ng` commands directly by adding the `.bin` folder within your local `node_modules` folder to your PATH. The `node_modules` and `.bin` folders are created in the directory where `npm install @angular/cli` was run upon completion of the install command.
 
-Alternatively, you can run `npx ng <command>` within the local directory where `npm install @angular/cli` was run, which will use the locally installed angular-cli.
+Alternatively, you can install [npx](https://www.npmjs.com/package/npx) and run `npx ng <command>` within the local directory where `npm install @angular/cli` was run, which will use the locally installed angular-cli.
 
 ### Install Specific Version (Example: 6.1.1)
 ```bash

--- a/packages/angular/cli/README.md
+++ b/packages/angular/cli/README.md
@@ -53,7 +53,9 @@ npm install -g @angular/cli
 npm install @angular/cli
 ```
 
-To run a locally installed version of the angular-cli, you can call `ng` commands directly using your file path to where the `ng` package is installed locally, or you can use `npm run ng <command>`, which will look for locally installed packages before using a globally installed version.  
+To run a locally installed version of the angular-cli, you can call `ng` commands directly by adding the `.bin` folder within your local `node_modules` folder to your PATH. The `node_modules` and `.bin` folders are created in the directory where `npm install @angular/cli` was run upon completion of the install command.
+
+Alternatively, you can run `npx ng <command>` within the local directory where `npm install @angular/cli` was run, which will use the locally installed angular-cli.
 
 ### Install Specific Version (Example: 6.1.1)
 ```bash

--- a/packages/angular/cli/README.md
+++ b/packages/angular/cli/README.md
@@ -42,8 +42,22 @@ with NPM 5.5.1 or higher.
 ## Installation
 
 **BEFORE YOU INSTALL:** please read the [prerequisites](#prerequisites)
+
+### Install Globablly
 ```bash
 npm install -g @angular/cli
+```
+
+### Install Locally
+```bash
+npm install @angular/cli
+```
+
+To run a locally installed version of the angular-cli, you can call `ng` commands directly using your file path to where the `ng` package is installed locally, or you can use `npm run ng <command>`, which will look for locally installed packages before using a globally installed version.  
+
+### Install Specific Version (Example: 6.1.1)
+```bash
+npm install -g @angular/cli@6.1.1
 ```
 
 ## Usage


### PR DESCRIPTION
This pull request adds documentation on how to locally install and use the angular-cli as well as installation instructions on installing specific versions of the angular-cli.

This addresses issues raised in #11738 and includes advice that came as a result of the issue.