### PR TITLE
fix(@angular-devkit/build-angular): tslint exclude for relative paths

### DIFF
--- a/packages/angular_devkit/build_angular/src/tslint/index.ts
+++ b/packages/angular_devkit/build_angular/src/tslint/index.ts
@@ -201,10 +201,12 @@ function getFilesToLint(
   let programFiles = linter.getFileNames(program);
 
   if (ignore && ignore.length > 0) {
-    const ignoreMatchers = ignore.map(pattern => new Minimatch(pattern, { dot: true }));
+    // normalize to support ./ paths
+    const ignoreMatchers = ignore
+      .map(pattern => new Minimatch(path.normalize(pattern), { dot: true }));
 
     programFiles = programFiles
-      .filter(file => !ignoreMatchers.some(matcher => matcher.match(file)));
+      .filter(file => !ignoreMatchers.some(matcher => matcher.match(path.relative(root, file))));
   }
 
   return programFiles;

--- a/packages/angular_devkit/build_angular/test/tslint/works_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/tslint/works_spec_large.ts
@@ -41,9 +41,27 @@ describe('Tslint Target', () => {
     ).toPromise().then(done, done.fail);
   }, 30000);
 
-  it('supports exclude', (done) => {
+  it('supports exclude with glob', (done) => {
     host.writeMultipleFiles(filesWithErrors);
     const overrides: Partial<TslintBuilderOptions> = { exclude: ['**/foo.ts'] };
+
+    runTargetSpec(host, tslintTargetSpec, overrides).pipe(
+      tap((buildEvent) => expect(buildEvent.success).toBe(true)),
+    ).toPromise().then(done, done.fail);
+  }, 30000);
+
+  it('supports exclude with relative paths', (done) => {
+    host.writeMultipleFiles(filesWithErrors);
+    const overrides: Partial<TslintBuilderOptions> = { exclude: ['src/foo.ts'] };
+
+    runTargetSpec(host, tslintTargetSpec, overrides).pipe(
+      tap((buildEvent) => expect(buildEvent.success).toBe(true)),
+    ).toPromise().then(done, done.fail);
+  }, 30000);
+
+  it(`supports exclude with paths starting with './'`, (done) => {
+    host.writeMultipleFiles(filesWithErrors);
+    const overrides: Partial<TslintBuilderOptions> = { exclude: ['./src/foo.ts'] };
 
     runTargetSpec(host, tslintTargetSpec, overrides).pipe(
       tap((buildEvent) => expect(buildEvent.success).toBe(true)),


### PR DESCRIPTION
Closes #11773, Closes #11951