### PR TITLE
feat(@angular-devkit/build-angular): add `ignore` option to `assets` …

### DIFF
--- a/docs/documentation/stories/asset-configuration.md
+++ b/docs/documentation/stories/asset-configuration.md
@@ -1,7 +1,8 @@
 # Project assets
 
 You use the `assets` array inside the build target in `angular.json` to list files or folders
-you want to copy as-is when building your project.
+you want to copy as-is when building your project. if you think you need to exclude files, 
+consider not putting that thing in the assets
 
 By default, the `src/assets/` folder and `src/favicon.ico` are copied over.
 
@@ -23,7 +24,7 @@ The array below does the same as the default one:
 ]
 ```
 
-- `glob` is the a [node-glob](https://github.com/isaacs/node-glob) using `input` as base directory.
+- `glob` is a [node-glob](https://github.com/isaacs/node-glob) using `input` as base directory.
 - `input` is relative to the workspace root.
 - `ignore` is a list of globs to ignore from copying.
 - `output` is relative to `outDir` (`dist/project-name` default).

--- a/docs/documentation/stories/asset-configuration.md
+++ b/docs/documentation/stories/asset-configuration.md
@@ -23,9 +23,10 @@ The array below does the same as the default one:
 ]
 ```
 
-`glob` is the a [node-glob](https://github.com/isaacs/node-glob) using `input` as base directory.
-`input` is relative to the workspace root, while `output` is relative to `outDir`
-(`dist/project-name` default).
+- `glob` is the a [node-glob](https://github.com/isaacs/node-glob) using `input` as base directory.
+- `input` is relative to the workspace root.
+- `ignore` is a list of globs to ignore from copying.
+- `output` is relative to `outDir` (`dist/project-name` default).
 
  You can use this extended configuration to copy assets from outside your project.
  For instance, you can copy assets from a node package:
@@ -36,7 +37,14 @@ The array below does the same as the default one:
 ]
 ```
 
-The contents of `node_modules/some-package/images/` will be available in `dist/some-package/`.
+You can ignore certain files from copying by using the `ignore` option:
+ ```json
+"assets": [
+  { "glob": "**/*", "input": "src/assets/", "ignore": ["**/*.svg"], "output": "/assets/" },
+]
+```
+
+The contents of `node_modules/some-package/images/` will be available in `dist/some-package/`. 
 
 ## Writing assets outside of `dist/`
 

--- a/packages/angular/cli/lib/config/schema.json
+++ b/packages/angular/cli/lib/config/schema.json
@@ -108,7 +108,7 @@
               "default": false,
               "alias": "t"
             },
-            "module":  {
+            "module": {
               "type": "string",
               "description": "Allows specification of the declaring module.",
               "alias": "m"
@@ -160,7 +160,7 @@
               "description": "Flag to indicate if a dir is created.",
               "default": true
             },
-            "module":  {
+            "module": {
               "type": "string",
               "description": "Allows specification of the declaring module.",
               "alias": "m"
@@ -219,7 +219,7 @@
               "default": true,
               "visible": false
             },
-            "module":  {
+            "module": {
               "type": "string",
               "description": "Allows specification of the declaring module.",
               "alias": "m"
@@ -778,6 +778,13 @@
                     "output": {
                       "type": "string",
                       "description": "Absolute path within the output."
+                    },
+                    "ignore": {
+                      "description": "An array of globs to ignore.",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
                     }
                   },
                   "additionalProperties": false,
@@ -1241,6 +1248,13 @@
                     "output": {
                       "type": "string",
                       "description": "Absolute path within the output."
+                    },
+                    "ignore": {
+                      "description": "An array of globs to ignore.",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
                     }
                   },
                   "additionalProperties": false,
@@ -1541,7 +1555,6 @@
                 }
               ]
             }
-
           }
         },
         "tslint": {

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
@@ -125,6 +125,7 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
         context: asset.input,
         // Now we remove starting slash to make Webpack place it from the output root.
         to: asset.output.replace(/^\//, ''),
+        ignore: asset.ignore,
         from: {
           glob: asset.glob,
           dot: true

--- a/packages/angular_devkit/build_angular/src/browser/schema.d.ts
+++ b/packages/angular_devkit/build_angular/src/browser/schema.d.ts
@@ -238,6 +238,11 @@ export interface AssetPatternObject {
   input: string;
 
   /**
+   * 	An array of globs to ignore.
+   */
+  ignore?: string[];
+
+  /**
    * Absolute path within the output.
    */
   output: string;

--- a/packages/angular_devkit/build_angular/src/browser/schema.json
+++ b/packages/angular_devkit/build_angular/src/browser/schema.json
@@ -259,6 +259,13 @@
               "type": "string",
               "description": "The input path dir in which to apply 'glob'. Defaults to the project root."
             },
+            "ignore": {
+              "description": "An array of globs to ignore.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
             "output": {
               "type": "string",
               "description": "Absolute path within the output."

--- a/packages/angular_devkit/build_angular/src/karma/schema.json
+++ b/packages/angular_devkit/build_angular/src/karma/schema.json
@@ -174,6 +174,13 @@
             "output": {
               "type": "string",
               "description": "Absolute path within the output."
+            },
+            "ignore": {
+              "description": "An array of globs to ignore.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           },
           "additionalProperties": false,

--- a/packages/angular_devkit/build_angular/test/browser/assets_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/browser/assets_spec_large.ts
@@ -59,6 +59,36 @@ describe('Browser Builder assets', () => {
     ).toPromise().then(done, done.fail);
   });
 
+  it('works with ignored patterns', (done) => {
+    const assets: { [path: string]: string } = {
+      './src/folder/.gitkeep': '',
+      './src/folder/asset-ignored.txt': '',
+      './src/folder/asset.txt': '',
+    };
+
+    host.writeMultipleFiles(assets);
+
+    const overrides = {
+      assets: [
+        {
+          glob: '**/*',
+          ignore: ['asset-ignored.txt'],
+          input: 'src/folder',
+          output: '/folder',
+        },
+      ],
+    };
+
+    runTargetSpec(host, browserTargetSpec, overrides).pipe(
+      tap((buildEvent) => expect(buildEvent.success).toBe(true)),
+      tap(() => {
+        expect(host.scopedSync().exists(normalize('./dist/folder/asset.txt'))).toBe(true);
+        expect(host.scopedSync().exists(normalize('./dist/folder/asset-ignored.txt'))).toBe(false);
+        expect(host.scopedSync().exists(normalize('./dist/folder/.gitkeep'))).toBe(false);
+      }),
+    ).toPromise().then(done, done.fail);
+  });
+
   it('fails with non-absolute output path', (done) => {
     const assets: { [path: string]: string } = {
       './node_modules/some-package/node_modules-asset.txt': 'node_modules-asset.txt',


### PR DESCRIPTION
add `ignore` option to `assets` object

You can now provide an array of globs to `ignore` from copying.

Closes #11850