### PR TITLE
feat(@schematics/angular): remove useless import for Ivy

### DIFF
--- a/packages/schematics/angular/application/other-files/app.module.ts
+++ b/packages/schematics/angular/application/other-files/app.module.ts
@@ -1,6 +1,6 @@
-import { BrowserModule } from '@angular/platform-browser';
+<% if (!experimentalIvy) { %>import { BrowserModule } from '@angular/platform-browser';<% } %>
 import { NgModule } from '@angular/core';
-<% if (routing) { %>
+<% if (routing && !experimentalIvy) { %>
 import { AppRoutingModule } from './app-routing.module';<% } %>
 import { AppComponent } from './app.component';
 


### PR DESCRIPTION
Using cli `6.2.0-beta.2` with the new `experimentalIvy` flag leads to:

    ERROR in src/app/app.module.ts(1,1): error TS6133: 'BrowserModule' is declared but its value is never read.