### PR TITLE
Json namespace

### DIFF
--- a/packages/angular/cli/models/json-schema.ts
+++ b/packages/angular/cli/models/json-schema.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import { JsonObject, JsonValue, parseJson } from '@angular-devkit/core';
+import { JsonObject, isJsonObject, parseJson } from '@angular-devkit/core';
 import * as jsonSchemaTraverse from 'json-schema-traverse';
 import { Option, OptionSmartDefault } from './command';
 
@@ -42,7 +42,7 @@ function getOptions(schemaText: string, onlyRootProperties = true): Promise<Opti
           }
         }
         let $default: OptionSmartDefault | undefined = undefined;
-        if (schema.$default !== null && JsonValue.isJsonObject(schema.$default)) {
+        if (schema.$default !== null && isJsonObject(schema.$default)) {
           $default = <OptionSmartDefault> schema.$default;
         }
         let required = false;
@@ -98,7 +98,7 @@ function isPropertyNested(jsonPath: string): boolean {
 
 export function parseSchema(schema: string): JsonObject | null {
   const parsedSchema = parseJson(schema);
-  if (parsedSchema === null || !JsonValue.isJsonObject(parsedSchema)) {
+  if (parsedSchema === null || !isJsonObject(parsedSchema)) {
     return null;
   }
 

--- a/packages/angular_devkit/core/src/index.ts
+++ b/packages/angular_devkit/core/src/index.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import * as experimental from './experimental';
+import * as json from './json';
 import * as logging from './logger';
 import * as terminal from './terminal';
 
@@ -16,6 +17,7 @@ export * from './virtual-fs';
 
 export {
   experimental,
+  json,
   logging,
   terminal,
 };

--- a/packages/angular_devkit/core/src/json/interface.ts
+++ b/packages/angular_devkit/core/src/json/interface.ts
@@ -110,8 +110,10 @@ export interface JsonAstComment extends JsonAstNodeBase {
 
 export type JsonValue = JsonAstNode['value'];
 
-export const JsonValue = {
-  isJsonObject(value: JsonValue): value is JsonObject {
-    return value != null && typeof value === 'object' && !Array.isArray(value);
-  },
-};
+export function isJsonObject(value: JsonValue): value is JsonObject {
+  return value != null && typeof value === 'object' && !Array.isArray(value);
+}
+
+export function isJsonArray(value: JsonValue): value is JsonArray {
+  return Array.isArray(value);
+}

--- a/packages/angular_devkit/core/src/json/schema/transforms.ts
+++ b/packages/angular_devkit/core/src/json/schema/transforms.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import { JsonObject, JsonValue } from '../interface';
+import { JsonObject, JsonValue, isJsonObject } from '../interface';
 import { JsonPointer } from './interface';
 
 const allTypes = ['string', 'integer', 'number', 'object', 'array', 'boolean', 'null'];
@@ -24,7 +24,7 @@ function findTypes(schema: JsonObject): Set<string> {
     potentials = new Set(allTypes);
   }
 
-  if (JsonValue.isJsonObject(schema.not)) {
+  if (isJsonObject(schema.not)) {
     const notTypes = findTypes(schema.not);
     potentials = new Set([...potentials].filter(p => !notTypes.has(p)));
   }
@@ -97,13 +97,13 @@ export function addUndefinedDefaults(
     let newValue;
     if (value == undefined) {
       newValue = {} as JsonObject;
-    } else if (JsonValue.isJsonObject(value)) {
+    } else if (isJsonObject(value)) {
       newValue = value;
     } else {
       return value;
     }
 
-    if (!JsonValue.isJsonObject(schema.properties)) {
+    if (!isJsonObject(schema.properties)) {
       return newValue;
     }
 


### PR DESCRIPTION
Just a bit of backward compatible refactor. We should consider removing the direct functions in 7 (along with the other non-namespaced exports).