### PR TITLE
build: re-add name and version field so npm link works

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,6 @@
 {
+  "name": "@angular/devkit-repo",
+  "version": "0.0.0",
   "private": true,
   "description": "Software Development Kit for Angular",
   "bin": {

--- a/scripts/validate-licenses.ts
+++ b/scripts/validate-licenses.ts
@@ -61,6 +61,8 @@ const licenseReplacements: { [key: string]: string } = {
 
 // Specific packages to ignore, add a reason in a comment. Format: package-name@version.
 const ignoredPackages = [
+  // Us.
+  '@angular/devkit-repo@0.0.0',  // Hey, that's us!
   // * Development only
   'spdx-license-ids@3.0.0',  // CC0 but it's content only (index.json, no code) and not distributed.
   'tslint-sonarts@1.7.0', // LGPL-3.0 but only used as a tool, not linked in the build.


### PR DESCRIPTION
It was removed by https://github.com/angular/angular-cli/pull/11766 but that was clearly a mistake.