### PR TITLE
Properly use STDERR

### DIFF
--- a/packages/angular/cli/lib/init.ts
+++ b/packages/angular/cli/lib/init.ts
@@ -99,7 +99,7 @@ try {
     // Don't show warning colorised on `ng completion`
     if (process.argv[2] !== 'completion') {
         // eslint-disable-next-line no-console
-      console.log(warning);
+      console.error(warning);
     } else {
         // eslint-disable-next-line no-console
       console.error(warning);
@@ -141,6 +141,6 @@ cli({
     process.exit(exitCode);
   })
   .catch((err: Error) => {
-    console.log('Unknown error: ' + err.toString());
+    console.error('Unknown error: ' + err.toString());
     process.exit(127);
   });

--- a/packages/angular/cli/upgrade/version.ts
+++ b/packages/angular/cli/upgrade/version.ts
@@ -87,7 +87,7 @@ export class Version {
     const rxjsVersion = new Version(rxjsPkgJson['version']);
 
     if (angularVersion.isLocal()) {
-      console.warn(terminal.yellow('Using a local version of angular. Proceeding with care...'));
+      console.error(terminal.yellow('Using a local version of angular. Proceeding with care...'));
 
       return;
     }
@@ -175,7 +175,7 @@ export class Version {
 
     if (currentCombo && !satisfies(tsVersion, currentCombo.typescript)) {
       // First line of warning looks weird being split in two, disable tslint for it.
-      console.log((terminal.yellow('\n' + tags.stripIndent`
+      console.error((terminal.yellow('\n' + tags.stripIndent`
         @angular/compiler-cli@${compilerVersion} requires typescript@'${
         currentCombo.typescript}' but ${tsVersion} was found instead.
         Using this version can result in undefined behaviour and difficult to debug problems.

--- a/packages/angular/cli/utilities/check-package-manager.ts
+++ b/packages/angular/cli/utilities/check-package-manager.ts
@@ -27,16 +27,16 @@ export function checkYarnOrCNPM() {
       .then((data: Array<boolean>) => {
         const [isYarnInstalled, isCNPMInstalled] = data;
         if (isYarnInstalled && isCNPMInstalled) {
-          console.log(terminal.yellow('You can `ng config -g cli.packageManager yarn` '
+          console.error(terminal.yellow('You can `ng config -g cli.packageManager yarn` '
             + 'or `ng config -g cli.packageManager cnpm`.'));
         } else if (isYarnInstalled) {
-          console.log(terminal.yellow('You can `ng config -g cli.packageManager yarn`.'));
+          console.error(terminal.yellow('You can `ng config -g cli.packageManager yarn`.'));
         } else if (isCNPMInstalled) {
-          console.log(terminal.yellow('You can `ng config -g cli.packageManager cnpm`.'));
+          console.error(terminal.yellow('You can `ng config -g cli.packageManager cnpm`.'));
         } else  {
           if (packageManager !== 'default' && packageManager !== 'npm') {
-            console.log(terminal.yellow(`Seems that ${packageManager} is not installed.`));
-            console.log(terminal.yellow('You can `ng config -g cli.packageManager npm`.'));
+            console.error(terminal.yellow(`Seems that ${packageManager} is not installed.`));
+            console.error(terminal.yellow('You can `ng config -g cli.packageManager npm`.'));
           }
         }
       });

--- a/packages/ngtools/webpack/src/transformers/ast_helpers.ts
+++ b/packages/ngtools/webpack/src/transformers/ast_helpers.ts
@@ -91,7 +91,7 @@ export function transformTypescript(
 
   // Log diagnostics if emit wasn't successfull.
   if (emitSkipped) {
-    console.log(diagnostics);
+    console.error(diagnostics);
 
     return null;
   }

--- a/packages/ngtools/webpack/src/type_checker.ts
+++ b/packages/ngtools/webpack/src/type_checker.ts
@@ -128,7 +128,7 @@ export class TypeChecker {
 
       if (warnings.length > 0) {
         const message = formatDiagnostics(warnings);
-        console.log(terminal.bold(terminal.yellow('WARNING in ' + message)));
+        console.error(terminal.bold(terminal.yellow('WARNING in ' + message)));
       }
     }
   }

--- a/packages/schematics/angular/utility/ast-utils.ts
+++ b/packages/schematics/angular/utility/ast-utils.ts
@@ -426,7 +426,7 @@ export function addSymbolToNgModuleMetadata(
   }
 
   if (!node) {
-    console.log('No app module found. Please add your new class to your component.');
+    console.error('No app module found. Please add your new class to your component.');
 
     return [];
   }

--- a/tests/legacy-cli/e2e/tests/i18n/extract-locale.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/extract-locale.ts
@@ -12,7 +12,7 @@ export default function() {
       '<p i18n>Hello world</p>'))
     .then(() => ng('xi18n', '--i18n-locale', 'fr'))
     .then((output) => {
-      if (!output.stdout.match(/starting from Angular v4/)) {
+      if (!output.stderr.match(/starting from Angular v4/)) {
         return expectFileToMatch('src/messages.xlf', 'source-language="fr"');
       }
     });

--- a/tests/legacy-cli/e2e/tests/misc/typescript-warning.ts
+++ b/tests/legacy-cli/e2e/tests/misc/typescript-warning.ts
@@ -17,7 +17,7 @@ export default async function () {
     .then(() => silentNpm('install', `typescript@${unsupportedTsVersion}`, '--no-save'))
     .then(() => ng('build'))
     .then((output) => {
-      if (!output.stdout.match('Using this version can result in undefined behaviour')) {
+      if (!output.stderr.match('Using this version can result in undefined behaviour')) {
         throw new Error('Expected to have typescript version mismatch warning in output.');
       }
     });


### PR DESCRIPTION
Normally STDOUT should be used for output, and STDERR for everything else (including warnings). We were using STDOUT for warnings and errors throughout.

Tagged as master only as this is technically changing the default behaviour.


Fix #11802 