### PR TITLE
fix(@schematics/schematics): prefix unused argument with underscore

### DIFF
--- a/packages/schematics/schematics/blank/schematic-files/src/__name@dasherize__/index.ts
+++ b/packages/schematics/schematics/blank/schematic-files/src/__name@dasherize__/index.ts
@@ -3,7 +3,7 @@ import { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
 
 // You don't have to export the function as default. You can also have more than one rule factory
 // per file.
-export function <%= camelize(name) %>(options: any): Rule {
+export function <%= camelize(name) %>(_options: any): Rule {
   return (tree: Tree, _context: SchematicContext) => {
     return tree;
   };


### PR DESCRIPTION
The `options` arguments is not used in the function. This causes the
TypeScript compilation to fail.

fixes #11916