### PR TITLE
fix(@schematics/angular): generate application failing when projectRoot is provided

### DIFF
--- a/docs/documentation/generate/application.md
+++ b/docs/documentation/generate/application.md
@@ -96,3 +96,12 @@ Create an Angular application.
     Do not add dependencies to package.json.
   </p>
 </details>
+<details>
+  <summary>project-root</summary>
+  <p>
+    <code>--project-root</code>
+  </p>
+  <p>
+    Specify root folder for new application and e2e tests
+  </p>
+</details>

--- a/docs/documentation/stories/multiple-projects.md
+++ b/docs/documentation/stories/multiple-projects.md
@@ -7,7 +7,7 @@ To create another app you can use the following command:
 ng generate application my-other-app
 ```
 
-The new application will be generated inside `projects/my-other-app`.
+The new application will be generated inside `projects/my-other-app`. If you wish to override root folder specify `--project-root applicationPath`
 
 Now we can `serve`, `build` etc. both the apps by passing the project name with the commands:
 

--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -270,10 +270,8 @@ export default function (options: ApplicationOptions): Rule {
       name: `${options.name}-e2e`,
       relatedAppName: options.name,
       rootSelector: appRootSelector,
+      projectRoot: `${newProjectRoot}/e2e`,
     };
-    if (options.projectRoot !== undefined) {
-      e2eOptions.projectRoot = 'e2e';
-    }
 
     return chain([
       addAppToWorkspaceFile(options, workspace),

--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -270,7 +270,7 @@ export default function (options: ApplicationOptions): Rule {
       name: `${options.name}-e2e`,
       relatedAppName: options.name,
       rootSelector: appRootSelector,
-      projectRoot: `${newProjectRoot}/e2e`,
+      projectRoot: newProjectRoot ? `${newProjectRoot}/e2e` : 'e2e',
     };
 
     return chain([


### PR DESCRIPTION
Right now generate application will be written to projects folder same as  libraries, but its possible to provide location by projectRoot. 

Problem is that e2e tests path is wrong and tasks fails.

This PR is to fix it and allow to use projectRoot parameter as it was designed