### PR TITLE
fix(@angular/pwa): properly write closing body tag when modifying index

### DIFF
--- a/packages/angular/pwa/pwa/index.ts
+++ b/packages/angular/pwa/pwa/index.ts
@@ -93,7 +93,7 @@ function updateIndexFile(options: PwaOptions): Rule {
       ...itemsToAddToHead.map(line => headIndent + line),
       ...lines.slice(closingHeadTagLineIndex, closingBodyTagLineIndex),
       ...itemsToAddToBody.map(line => bodyIndent + line),
-      ...lines.slice(closingHeadTagLineIndex),
+      ...lines.slice(closingBodyTagLineIndex),
     ].join('\n');
 
     host.overwrite(path, updatedIndex);


### PR DESCRIPTION
Fixes #11543
Fixes #11942