### PR TITLE
fix(@angular-devkit/build-angular): support inline javascript in less

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/styles.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/styles.ts
@@ -220,6 +220,7 @@ export function getStylesConfig(wco: WebpackConfigOptions) {
         loader: 'less-loader',
         options: {
           sourceMap: cssSourceMap,
+          javascriptEnabled: true,
           ...lessPathOptions,
         }
       }]

--- a/packages/angular_devkit/build_angular/test/browser/styles_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/browser/styles_spec_large.ts
@@ -529,4 +529,22 @@ describe('Browser Builder styles', () => {
       tap((buildEvent) => expect(buildEvent.success).toBe(true)),
     ).toPromise().then(done, done.fail);
   });
+
+  it(`supports inline javascript in less`, (done) => {
+    const overrides = { styles: [`src/styles.less`] };
+    host.writeMultipleFiles({
+      'src/styles.less': `
+        .myFunction() {
+          @functions: ~\`(function () {
+            return '';
+          })()\`;
+        }
+        .myFunction();
+      `,
+    });
+
+    runTargetSpec(host, browserTargetSpec, overrides).pipe(
+      tap((buildEvent) => expect(buildEvent.success).toBe(true)),
+    ).toPromise().then(done, done.fail);
+  });
 });


### PR DESCRIPTION
Based on https://github.com/angular/devkit/pull/866
Fix https://github.com/angular/angular-cli/issues/10430