### PR TITLE
fix(@angular-devkit/schematics): enable sourceMap for coverage mapping

### DIFF
--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -204,6 +204,7 @@ function addAppToWorkspaceFile(options: ApplicationOptions, workspace: Workspace
             join(normalize(projectRoot), 'src', 'favicon.ico'),
             join(normalize(projectRoot), 'src', 'assets'),
           ],
+          sourceMap: true,
         },
       },
       lint: {

--- a/packages/schematics/angular/library/index.ts
+++ b/packages/schematics/angular/library/index.ts
@@ -151,6 +151,7 @@ function addAppToWorkspaceFile(options: LibraryOptions, workspace: WorkspaceSche
           main: `${projectRoot}/src/test.ts`,
           tsConfig: `${projectRoot}/tsconfig.spec.json`,
           karmaConfig: `${projectRoot}/karma.conf.js`,
+          sourceMap: true,
         },
       },
       lint: {

--- a/packages/schematics/angular/migrations/update-6/index.ts
+++ b/packages/schematics/angular/migrations/update-6/index.ts
@@ -476,6 +476,7 @@ function extractProjectsConfig(
       testOptions.scripts = (app.scripts || []).map(_extraEntryMapper);
       testOptions.styles = (app.styles || []).map(_extraEntryMapper);
       testOptions.assets = (app.assets || []).map(_mapAssets).filter(x => !!x);
+      testOptions.sourceMap = true;
 
       if (karmaConfig) {
         targets.test = {

--- a/packages/schematics/angular/migrations/update-6/index_spec.ts
+++ b/packages/schematics/angular/migrations/update-6/index_spec.ts
@@ -661,6 +661,7 @@ describe('Migration to v6', () => {
           { glob: '**/*', input: 'src/assets', output: '/assets' },
           { glob: 'favicon.ico', input: 'src', output: '/' },
         ]);
+        expect(test.options.sourceMap).toEqual(true);
       });
 
       it('should set the extract i18n target', () => {


### PR DESCRIPTION
Fixes #11672 