### PR TITLE
fix(@angular-devkit/build-angular): fixes cors issues with karma

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/karma.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/karma.ts
@@ -144,6 +144,7 @@ const init: any = (config: any, emitter: any, customFileHandlers: any) => {
   // Files need to be served from a custom path for Karma.
   webpackConfig.output.path = '/_karma_webpack_/';
   webpackConfig.output.publicPath = '/_karma_webpack_/';
+  webpackConfig.output.devtoolModuleFilenameTemplate = '[namespace]/[resource-path]?[loaders]';
 
   let compiler: any;
   try {


### PR DESCRIPTION
Checking the stack trace in the issue one can noticed that the paths for the components are being served via the `webpack://` protocol which is causing a `cors` issue between `http` and `webpack` protocol

This PR removed the `webpack` protocol from the `devtoolModuleFilenameTemplate`

Closes #11966