### PR TITLE
feat(@schematics/angular): add several prompts to ng-new

### DIFF
--- a/packages/schematics/angular/ng-new/schema.json
+++ b/packages/schematics/angular/ng-new/schema.json
@@ -15,7 +15,8 @@
       "$default": {
         "$source": "argv",
         "index": 0
-      }
+      },
+      "x-prompt": "What name would you like to use for the project?"
     },
     "experimentalIvy": {
       "description": "EXPERIMENTAL: Specifies whether to create a new application which uses the Ivy rendering engine.",
@@ -95,19 +96,32 @@
     "routing": {
       "type": "boolean",
       "description": "Generates a routing module.",
-      "default": false
+      "default": false,
+      "x-prompt": "Would you like to generate a routing module?"
     },
     "prefix": {
       "type": "string",
       "format": "html-selector",
       "description": "The prefix to apply to generated selectors.",
+      "minLength": 1,
       "default": "app",
       "alias": "p"
     },
     "style": {
       "description": "The file extension to be used for style files.",
       "type": "string",
-      "default": "css"
+      "default": "css",
+      "x-prompt": {
+        "message": "Which stylesheet format would you like to use?",
+        "type": "list",
+        "items": [
+          { "value": "css", "label": "CSS" },
+          { "value": "scss", "label": "SCSS   [ http://sass-lang.com   ]" },
+          { "value": "sass", "label": "SASS   [ http://sass-lang.com   ]" },
+          { "value": "less", "label": "LESS   [ http://lesscss.org     ]" },
+          { "value": "styl", "label": "Stylus [ http://stylus-lang.com ]" }
+        ]
+      }
     },
     "skipTests": {
       "description": "Skip creating spec files.",


### PR DESCRIPTION
Initial prompt usage when executing `ng new` for 7.0.

When executing `ng new` (no options are required now), the user will be prompted for the following:
* name of the project
* selector prefix for components
* whether they will use Angular routing
* stylesheet format (css, scss, etc.)

If the user provides the option on the command line (e.g., `--style scss`), the prompt for that option will not be displayed.