### PR TITLE
Add install instructions to pull a snapshot build

### DIFF
--- a/docs/documentation/home.md
+++ b/docs/documentation/home.md
@@ -2,7 +2,7 @@
 
 # Angular CLI
 
-NOTE: this documentation is for Angular CLI 6. For Angular CLI 1.x go [here](1-x/home) instead.
+NOTE: this documentation is for Angular CLI 6. For Angular CLI 1.x go [here](1-x-home) instead.
 
 ### Overview
 The Angular CLI is a tool to initialize, develop, scaffold  and maintain [Angular](https://angular.io) applications
@@ -12,6 +12,10 @@ To install the Angular CLI:
 ```
 npm install -g @angular/cli
 ```
+
+> If you get an error installing the CLI, this is an issue with your local npm setup on your machine, not a problem in Angular CLI.
+> Please have a look at the [fixing npm permissions page](https://docs.npmjs.com/getting-started/fixing-npm-permissions), [common errors page](https://docs.npmjs.com/troubleshooting/common-errors), [npm issue tracker](https://github.com/npm/npm/issues), or open a new issue if the problem you are experiencing isn't known.
+> To install a different version, see below.
 
 Generating and serving an Angular project via a development server
 [Create](new) and [run](serve) a new project:
@@ -63,3 +67,12 @@ End-to-end tests are run via [Protractor](http://www.protractortest.org/).
 ### Additional Information
 There are several [stories](stories) which will walk you through setting up
 additional aspects of Angular applications.
+
+### Installing a specific version
+The CLI is installed both globally (the command above with the `-g` argument to `npm install`) and also within the project. To install a different version of the CLI, you can just update the version locally within your project. The globally installed package will always delegate to the local one.
+
+There are several different versions available at any time:
+- Install a previous version, maybe because of a bug in the latest version. For example to get 6.0.2: `npm install @angular/cli@6.0.2`
+- Install the pre-release of a newer minor/major version, to try new features. For example to get 7.0.0-beta.3: `npm install @angular/cli@next`. Note that the `@next` version is only useful during beta periods.
+- Install a snapshot build from the latest passing run of our CI (angular-cli/master). This is useful if an issue was just fixed or a new feature just landed on master, but is not yet released: `npm install @angular/cli@github:angular/cli-builds` (or maybe better, find the particular SHA that you want to try: 
+`npm install @angular/cli@github:angular/cli-builds#0123456789abcdef`)


### PR DESCRIPTION
Would like to point users here when they ask why their bug was closed but the problem is still visible in `@latest`