### PR TITLE
docs: fix proxy config paths

### DIFF
--- a/docs/documentation/stories/proxy.md
+++ b/docs/documentation/stories/proxy.md
@@ -26,7 +26,7 @@ We can then add the `proxyConfig` option to the serve target:
     "builder": "@angular-devkit/build-angular:dev-server",
     "options": {
       "browserTarget": "your-application-name:build",
-      "proxyConfig": "src/proxy.conf.json"
+      "proxyConfig": "proxy.conf.json"
     },
 ```
 
@@ -119,7 +119,7 @@ Make sure to point to the right file (`.js` instead of `.json`):
     "builder": "@angular-devkit/build-angular:dev-server",
     "options": {
       "browserTarget": "your-application-name:build",
-      "proxyConfig": "src/proxy.conf.js"
+      "proxyConfig": "proxy.conf.js"
     },
 ```
 


### PR DESCRIPTION
Fixed serve proxy.conf.json path. The documentation wants us to create the config file next to the package.json (project root), not the src subdirectory. So, the proxyConfig needs that path.