### PR TITLE
Revert "build: limit rxjs to 6.2.x due to a defect in 6.3.0 (#12048)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "license-checker": "^20.1.0",
     "minimatch": "^3.0.4",
     "minimist": "^1.2.0",
-    "rxjs": "~6.2.0",
+    "rxjs": "^6.0.0",
     "semver": "^5.3.0",
     "source-map": "^0.5.6",
     "source-map-support": "^0.5.0",
@@ -107,6 +107,6 @@
   "resolutions": {
     "@types/webpack": "4.4.0",
     "@types/webpack-dev-server": "2.9.4",
-    "rxjs": "~6.2.0"
+    "rxjs": "6.0.0"
   }
 }

--- a/packages/angular/cli/package.json
+++ b/packages/angular/cli/package.json
@@ -38,7 +38,7 @@
     "inquirer": "^6.1.0",
     "json-schema-traverse": "^0.4.1",
     "opn": "^5.3.0",
-    "rxjs": "~6.2.0",
+    "rxjs": "^6.0.0",
     "semver": "^5.1.0",
     "symbol-observable": "^1.2.0",
     "yargs-parser": "^10.0.0"

--- a/packages/angular_devkit/architect/package.json
+++ b/packages/angular_devkit/architect/package.json
@@ -6,6 +6,6 @@
   "typings": "src/index.d.ts",
   "dependencies": {
     "@angular-devkit/core": "0.0.0",
-    "rxjs": "~6.2.0"
+    "rxjs": "^6.0.0"
   }
 }

--- a/packages/angular_devkit/architect/test/package.json
+++ b/packages/angular_devkit/architect/test/package.json
@@ -1,6 +1,6 @@
 {
   "builders": "builders.json",
   "dependencies": {
-    "rxjs": "~6.2.0"
+    "rxjs": "^6.0.0"
   }
 }

--- a/packages/angular_devkit/architect_cli/package.json
+++ b/packages/angular_devkit/architect_cli/package.json
@@ -16,6 +16,6 @@
     "@angular-devkit/architect": "0.0.0",
     "minimist": "^1.2.0",
     "symbol-observable": "^1.2.0",
-    "rxjs": "~6.2.0"
+    "rxjs": "^6.0.0"
   }
 }

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -36,7 +36,7 @@
     "postcss-loader": "^2.1.5",
     "postcss-url": "^7.3.2",
     "raw-loader": "^0.5.1",
-    "rxjs": "~6.2.0",
+    "rxjs": "^6.0.0",
     "sass-loader": "^7.1.0",
     "semver": "^5.5.0",
     "source-map-support": "^0.5.0",

--- a/packages/angular_devkit/build_ng_packagr/package.json
+++ b/packages/angular_devkit/build_ng_packagr/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "@angular-devkit/architect": "0.0.0",
     "@angular-devkit/core": "0.0.0",
-    "rxjs": "~6.2.0",
+    "rxjs": "^6.0.0",
     "semver": "^5.3.0"
   },
   "peerDependencies": {

--- a/packages/angular_devkit/build_webpack/package.json
+++ b/packages/angular_devkit/build_webpack/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "@angular-devkit/architect": "0.0.0",
     "@angular-devkit/core": "0.0.0",
-    "rxjs": "~6.2.0"
+    "rxjs": "^6.0.0"
   },
   "peerDependencies": {
     "webpack": "^4.6.0",

--- a/packages/angular_devkit/core/package.json
+++ b/packages/angular_devkit/core/package.json
@@ -12,6 +12,6 @@
     "chokidar": "^2.0.3",
     "fast-json-stable-stringify": "^2.0.0",
     "source-map": "^0.5.6",
-    "rxjs": "~6.2.0"
+    "rxjs": "^6.0.0"
   }
 }

--- a/packages/angular_devkit/schematics/package.json
+++ b/packages/angular_devkit/schematics/package.json
@@ -14,6 +14,6 @@
   ],
   "dependencies": {
     "@angular-devkit/core": "0.0.0",
-    "rxjs": "~6.2.0"
+    "rxjs": "^6.0.0"
   }
 }

--- a/packages/angular_devkit/schematics_cli/package.json
+++ b/packages/angular_devkit/schematics_cli/package.json
@@ -23,6 +23,6 @@
     "@schematics/schematics": "0.0.0",
     "minimist": "^1.2.0",
     "symbol-observable": "^1.2.0",
-    "rxjs": "~6.2.0"
+    "rxjs": "^6.0.0"
   }
 }

--- a/packages/ngtools/webpack/package.json
+++ b/packages/ngtools/webpack/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@angular-devkit/core": "0.0.0",
-    "rxjs": "~6.2.0",
+    "rxjs": "^6.0.0",
     "tree-kill": "^1.0.0",
     "webpack-sources": "^1.1.0"
   },

--- a/packages/schematics/angular/utility/latest-versions.ts
+++ b/packages/schematics/angular/utility/latest-versions.ts
@@ -9,7 +9,7 @@
 export const latestVersions = {
   // These versions should be kept up to date with latest Angular peer dependencies.
   Angular: '^6.1.0',
-  RxJs: '~6.2.0',
+  RxJs: '^6.0.0',
   ZoneJs: '~0.8.26',
   TypeScript: '~2.9.2',
   // The versions below must be manually updated when making a new devkit release.

--- a/packages/schematics/update/package.json
+++ b/packages/schematics/update/package.json
@@ -15,6 +15,6 @@
     "npm-registry-client": "^8.5.1",
     "semver": "^5.3.0",
     "semver-intersect": "^1.1.2",
-    "rxjs": "~6.2.0"
+    "rxjs": "^6.0.0"
   }
 }

--- a/tests/angular_devkit/build_angular/hello-world-app/package.json
+++ b/tests/angular_devkit/build_angular/hello-world-app/package.json
@@ -22,7 +22,7 @@
     "@angular/platform-browser-dynamic": "^6.0.0-rc.0",
     "@angular/router": "^6.0.0-rc.0",
     "core-js": "^2.4.1",
-    "rxjs": "~6.2.0",
+    "rxjs": "^6.0.0",
     "zone.js": "^0.8.19"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6371,9 +6371,9 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   dependencies:
     aproba "^1.1.1"
 
-rxjs@^6.0.0, rxjs@^6.1.0, rxjs@~6.2.0:
-  version "6.2.2"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.2.2.tgz#eb75fa3c186ff5289907d06483a77884586e1cf9"
+rxjs@6.0.0, rxjs@^6.0.0, rxjs@^6.1.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.0.0.tgz#d647e029b5854617f994c82fe57a4c6747b352da"
   dependencies:
     tslib "^1.9.0"
 


### PR DESCRIPTION
This reverts commit 7e63dd791b67ad49de4b0b2f55ecc386e4cad20e.

Verifying that `rxjs 6.1.3` doesn't throw an error