### PR TITLE
docs(stories): update proxy.md with correct path

### DIFF
--- a/docs/documentation/stories/proxy.md
+++ b/docs/documentation/stories/proxy.md
@@ -26,7 +26,7 @@ We can then add the `proxyConfig` option to the serve target:
     "builder": "@angular-devkit/build-angular:dev-server",
     "options": {
       "browserTarget": "your-application-name:build",
-      "proxyConfig": "src/proxy.conf.json"
+      "proxyConfig": "proxy.conf.json"
     },
 ```
 
@@ -119,7 +119,7 @@ Make sure to point to the right file (`.js` instead of `.json`):
     "builder": "@angular-devkit/build-angular:dev-server",
     "options": {
       "browserTarget": "your-application-name:build",
-      "proxyConfig": "src/proxy.conf.js"
+      "proxyConfig": "proxy.conf.js"
     },
 ```
 


### PR DESCRIPTION
Since it is stated;
> We create a file next to our project's package.json called proxy.conf.json with the content

Then paths to `proxy.conf.json` in `angular.json` are not prefixed with `src/`.