### PR TITLE
fix(@schematics/angular): app shell schematic does not use production configuration

### DIFF
--- a/packages/schematics/angular/app-shell/index.ts
+++ b/packages/schematics/angular/app-shell/index.ts
@@ -196,6 +196,11 @@ function addAppShellConfigToWorkspace(options: AppShellOptions): Rule {
         serverTarget: `${options.clientProject}:server`,
         route: options.route,
       },
+      configurations: {
+        production: {
+          browserTarget: `${options.clientProject}:build:production`,
+        },
+      },
     };
 
     if (!workspace.projects[options.clientProject]) {

--- a/packages/schematics/angular/app-shell/index_spec.ts
+++ b/packages/schematics/angular/app-shell/index_spec.ts
@@ -68,6 +68,7 @@ describe('App Shell Schematic', () => {
     expect(target.options.browserTarget).toEqual('bar:build');
     expect(target.options.serverTarget).toEqual('bar:server');
     expect(target.options.route).toEqual('shell');
+    expect(target.configurations.production.browserTarget).toEqual('bar:build:production');
   });
 
   it('should add router module to client app module', () => {


### PR DESCRIPTION
app shell schematic does not use production configuration

Closes: #11578