### PR TITLE
feat(@angular/cli): add `--defaults` option to `ng new`

### DIFF
--- a/packages/angular/cli/commands/definitions.json
+++ b/packages/angular/cli/commands/definitions.json
@@ -57,6 +57,11 @@
           "type": "boolean",
           "default": "true",
           "description": "Disables interactive inputs (i.e., prompts)."
+        },
+        "defaults": {
+          "type": "boolean",
+          "default": "false",
+          "description": "Disables interactive inputs (i.e., prompts) for options with a default."
         }
       }
     }

--- a/packages/angular/cli/models/schematic-command.ts
+++ b/packages/angular/cli/models/schematic-command.ts
@@ -53,6 +53,7 @@ export interface BaseSchematicOptions extends BaseCommandOptions {
   dryRun?: boolean;
   force?: boolean;
   interactive?: boolean;
+  defaults?: boolean;
 }
 
 export interface RunSchematicOptions {
@@ -234,7 +235,11 @@ export abstract class SchematicCommand<
 
     this._engineHost.registerOptionsTransform(validateOptionsWithSchema(workflow.registry));
 
-    workflow.registry.addPostTransform(schema.transforms.addUndefinedDefaults);
+    if (options.defaults) {
+      workflow.registry.addPreTransform(schema.transforms.addUndefinedDefaults);
+    } else {
+      workflow.registry.addPostTransform(schema.transforms.addUndefinedDefaults);
+    }
 
     workflow.registry.addSmartDefaultProvider('projectName', () => {
       if (this._workspace) {


### PR DESCRIPTION
Any option with a default value will not be prompted (if a prompt is defined) and the default will be used instead.

Closes #12084