### PR TITLE
fix(main): match styleguide catch callback

### DIFF
--- a/packages/schematics/angular/application/files/src/main.ts
+++ b/packages/schematics/angular/application/files/src/main.ts
@@ -9,7 +9,7 @@
 <%= experimentalIvy ? '// ' : '' %>}
 <%= experimentalIvy ? '// ' : '' %>
 <%= experimentalIvy ? '// ' : '' %>platformBrowserDynamic().bootstrapModule(AppModule)
-<%= experimentalIvy ? '// ' : '' %>  .catch(err => console.log(err));
+<%= experimentalIvy ? '// ' : '' %>  .catch(err => console.error(err));
 <% if (experimentalIvy) { %>
 import { AppComponent } from './app/app.component';
 import { ɵrenderComponent as renderComponent } from '@angular/core';


### PR DESCRIPTION
Referencing the original PR here https://github.com/angular/devkit/pull/422

https://angular.io/guide/styleguide#style-02-05

In the styleguide rule above the catch callback uses console.error when the app boostrapping fails. I am updating the template to match.

I wasn't sure if the success console.log should also be included but that seems a bit too opinionated.