### PR TITLE
fix(@schematics/angular): use TS 3.0+ for experimentalAngularNext

### DIFF
--- a/packages/schematics/angular/workspace/files/package.json
+++ b/packages/schematics/angular/workspace/files/package.json
@@ -42,6 +42,6 @@
     "protractor": "~5.4.0",
     "ts-node": "~7.0.0",
     "tslint": "~5.11.0",
-    "typescript": "<%= latestVersions.TypeScript %>"
+    "typescript": "<%= experimentalAngularNext ? '~3.0.3' : latestVersions.TypeScript %>"
   }
 }


### PR DESCRIPTION
Sets the TypeScript version to `~3.0.3` if the option `experimentalAngularNext` (or `experimentalIvy`) is set.

Currently the generated app uses TS ~2.9.2 and throws if the `next` version of Angular is used:

    Error: The Angular Compiler requires TypeScript >=3.0.1 and <3.1.0 but 2.9.2 was found instead.