### PR TITLE
fix(@angular/cli): fix schema error Property `targets` is not allowed

### DIFF
--- a/packages/angular/cli/lib/config/schema.json
+++ b/packages/angular/cli/lib/config/schema.json
@@ -327,11 +327,39 @@
           "additionalProperties": {
             "$ref": "#/definitions/project/definitions/target"
           }
+        },
+        "targets": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/project/definitions/target"
+          }
         }
       },
       "required": [
         "root",
         "projectType"
+      ],
+      "anyOf": [
+        {
+          "required": ["architect"],
+          "not": {
+            "required": ["targets"]
+          }
+        },
+        {
+          "required": ["targets"],
+          "not": {
+            "required": ["architect"]
+          }
+        },
+        {
+          "not": {
+            "required": [
+              "targets",
+              "architect"
+            ]
+          }
+        }
       ],
       "additionalProperties": false,
       "patternProperties": {


### PR DESCRIPTION
Closes #12192