### PR TITLE
feat: docker init

### DIFF
--- a/docs/documentation/docker.md
+++ b/docs/documentation/docker.md
@@ -1,0 +1,29 @@
+<!-- Links in /docs/documentation should NOT have `.md` at the end, because they end up in our wiki at release. -->
+
+# ng docker
+
+## Overview
+`ng docker <action> [options]` Creates/modifes docker files.
+
+## Available Commands:
+ - [init](docker/init)
+
+## Options
+<details>
+  <summary>dry-run</summary>
+  <p>
+    <code>--dry-run</code> (alias: <code>-d</code>)
+  </p>
+  <p>
+    Run through without making any changes.
+  </p>
+</details>
+<details>
+  <summary>force</summary>
+  <p>
+    <code>--force</code> (alias: <code>-f</code>)
+  </p>
+  <p>
+    Forces overwriting of files.
+  </p>
+</details>

--- a/docs/documentation/docker/init.md
+++ b/docs/documentation/docker/init.md
@@ -1,0 +1,98 @@
+<!-- Links in /docs/documentation should NOT have \`.md\` at the end, because they end up in our wiki at release. -->
+
+# ng docker init
+
+## Overview
+Create default docker files for an application.
+
+## Options
+<details>
+  <summary>dry-run</summary>
+  <p>
+    <code>--dry-run</code> (alias: <code>-d</code>)
+  </p>
+  <p>
+    Run through without making any changes.
+  </p>
+</details>
+<details>
+  <summary>force</summary>
+  <p>
+    <code>--force</code> (alias: <code>-f</code>)
+  </p>
+  <p>
+    Forces overwriting of files.
+  </p>
+</details>
+<details>
+  <summary>image-name</summary>
+  <p>
+    <code>--image-name</code>
+  </p>
+  <p>
+    The image name to use for image pushes.
+  </p>
+</details>
+<details>
+  <summary>image-org</summary>
+  <p>
+    <code>--image-org</code>
+  </p>
+  <p>
+    The organization name to use for image pushes.
+  </p>
+</details>
+<details>
+  <summary>image-registry</summary>
+  <p>
+    <code>--image-registry</code>
+  </p>
+  <p>
+    The registry address to use for image pushes.
+  </p>
+</details>
+<details>
+  <summary>machine-name</summary>
+  <p>
+    <code>--machine-name</code>
+  </p>
+  <p>
+    The name of the machine.
+  </p>
+</details>
+<details>
+  <summary>project</summary>
+  <p>
+    <code>--project</code>
+  </p>
+  <p>
+    The name of the project.
+  </p>
+</details>
+<details>
+  <summary>service-name</summary>
+  <p>
+    <code>--service-name</code>
+  </p>
+  <p>
+    The name of the service.
+  </p>
+</details>
+<details>
+  <summary>service-port</summary>
+  <p>
+    <code>--service-port</code>
+  </p>
+  <p>
+    The port of the computer service.
+  </p>
+</details>
+<details>
+  <summary>use-image</summary>
+  <p>
+    <code>--use-image</code>
+  </p>
+  <p>
+    Initializes the environment for deploying with an image, rather than performing a build.
+  </p>
+</details>

--- a/packages/angular/cli/BUILD
+++ b/packages/angular/cli/BUILD
@@ -46,6 +46,7 @@ ts_library(
         ":config_schema",
         ":deprecated_schema",
         ":doc_schema",
+        ":docker_schema",
         ":e2e_schema",
         ":easter_egg_schema",
         ":eject_schema",
@@ -97,6 +98,14 @@ ts_json_schema(
 ts_json_schema(
     name = "doc_schema",
     src = "commands/doc.json",
+    data = [
+        "commands/definitions.json",
+    ],
+)
+
+ts_json_schema(
+    name = "docker_schema",
+    src = "commands/docker.json",
     data = [
         "commands/definitions.json",
     ],

--- a/packages/angular/cli/commands.json
+++ b/packages/angular/cli/commands.json
@@ -3,6 +3,7 @@
   "build": "./commands/build.json",
   "config": "./commands/config.json",
   "doc": "./commands/doc.json",
+  "docker": "./commands/docker.json",
   "e2e": "./commands/e2e.json",
   "make-this-awesome": "./commands/easter-egg.json",
   "eject": "./commands/eject.json",

--- a/packages/angular/cli/commands/docker-impl.ts
+++ b/packages/angular/cli/commands/docker-impl.ts
@@ -1,0 +1,80 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+// tslint:disable:no-global-tslint-disable no-any
+import { execSync } from 'child_process';
+import { Arguments } from '../models/interface';
+import { SchematicCommand } from '../models/schematic-command';
+import { parseJsonSchemaToSubCommandDescription } from '../utilities/json-schema';
+import { Action, Schema as DockerCommandSchema } from './docker';
+
+export class DockerCommand extends SchematicCommand<DockerCommandSchema> {
+
+  public async initialize(options: DockerCommandSchema & Arguments) {
+    await super.initialize(options);
+
+    this.schematicName = 'docker';
+
+    if (options.action === Action.Init && options.help) {
+      const collection = this.getCollection(this.collectionName);
+      const schematic = this.getSchematic(collection, this.schematicName, true);
+
+      if (schematic.description.schemaJson) {
+        const subcommand = await parseJsonSchemaToSubCommandDescription(
+          this.schematicName,
+          schematic.description.path,
+          this._workflow.registry,
+          schematic.description.schemaJson,
+          this.logger,
+        );
+
+        if (subcommand) {
+          subcommand.options.sort();
+          this.description.options = [...this.description.options, ...subcommand.options];
+        }
+      }
+    }
+
+    this.dockerCliExistChecker();
+  }
+
+  public async run(options: DockerCommandSchema & Arguments) {
+
+    if (!this.schematicName) {
+      throw Error('Schematic name is required but is it empty!');
+    }
+
+    switch (options.action) {
+      case  Action.Init:
+        return await this.runSchematic({
+          collectionName: this.collectionName,
+          schematicName: this.schematicName,
+          schematicOptions: options['--'] || [],
+          debug: !!options.debug || false,
+          dryRun: !!options.dryRun || false,
+          force: !!options.force || false,
+        });
+      default:
+        await this.printHelp(options);
+    }
+  }
+
+  private dockerCliExistChecker() {
+    try {
+      /**
+       * Checking for the default docker-cli existance in the machine.
+       * Stdio removes all the output
+       */
+      execSync('docker', { stdio: [] });
+    } catch (err) {
+      this.logger.info('');
+      this.logger.warn('Docker-CLI is available on https://docs.docker.com/install/');
+      throw Error('Docker-CLI is missing!');
+    }
+  }
+}

--- a/packages/angular/cli/commands/docker.json
+++ b/packages/angular/cli/commands/docker.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "$id": "ng-cli://commands/docker.json",
+  "description": "Add/Modify docker files",
+  "$longDescription": "",
+
+  "$scope": "in",
+  "$impl": "./docker-impl#DockerCommand",
+
+  "type": "object",
+  "allOf": [
+    {
+      "properties": {
+        "action": {
+          "type": "string",
+          "description": "The specific action to be executed.",
+          "enum": [
+            "init",
+            "deploy",
+            "push"
+          ],
+          "$default": {
+            "$source": "argv",
+            "index": 0
+          }
+        }
+      },
+      "required": [
+        "action"
+      ]
+    },
+    { "$ref": "./definitions.json#/definitions/base" },
+    { "$ref": "./definitions.json#/definitions/schematic" }
+  ]
+}

--- a/packages/schematics/angular/collection.json
+++ b/packages/schematics/angular/collection.json
@@ -48,6 +48,12 @@
       "description": "Create an Angular directive.",
       "schema": "./directive/schema.json"
     },
+    "docker": {
+      "aliases": [ "dock" ],
+      "factory": "./docker",
+      "description": "Create docker default files.",
+      "schema": "./docker/schema.json"
+    },
     "enum": {
       "aliases": [ "e" ],
       "factory": "./enum",

--- a/packages/schematics/angular/docker/files/.dockerignore
+++ b/packages/schematics/angular/docker/files/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.gitignore
+.env*
+node_modules
+docker-compose*.yml

--- a/packages/schematics/angular/docker/files/Dockerfile
+++ b/packages/schematics/angular/docker/files/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:latest as build-stage
+ARG environment
+
+WORKDIR /app
+
+COPY package*.json /app/
+
+RUN npm install --quiet
+
+COPY ./ /app/
+
+RUN npm run build -- --output-path=./dist/out --configuration=$environment --build-optimizer
+
+FROM nginx:latest
+
+COPY --from=build-stage /app/dist/out/ /usr/share/nginx/html
+
+COPY ./nginx.conf /etc/nginx/conf.d/default.conf

--- a/packages/schematics/angular/docker/files/docker-compose.__environment__.yml
+++ b/packages/schematics/angular/docker/files/docker-compose.__environment__.yml
@@ -1,0 +1,15 @@
+version: "2"
+services:
+  <%= name %>:
+    <% if (!imageName) { %>
+    build:
+        context: ./
+        dockerfile: Dockerfile
+        args:
+          environment: "<%= environment %>"
+    <% } %>
+    <% if (imageName) { %>
+    image: <%= imageName %>
+    <% } %>
+    ports:
+      - "<%= servicePort %>:80"

--- a/packages/schematics/angular/docker/files/docker-compose.yml
+++ b/packages/schematics/angular/docker/files/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "2"
+services:
+  application:
+    <% if (!imageName) { %>
+    build:
+        context: ./
+        dockerfile: Dockerfile
+        args:
+          environment: "<%= environment %>"
+    <% } %>
+    <% if (imageName) { %>
+    image: <%= imageName %>
+    <% } %>
+    ports:
+      - "8000:80"

--- a/packages/schematics/angular/docker/files/nginx.conf
+++ b/packages/schematics/angular/docker/files/nginx.conf
@@ -1,0 +1,8 @@
+server {
+  listen 80;
+  location / {
+    root /usr/share/nginx/html;
+    index index.html index.htm;
+    try_files $uri $uri/ /index.html =404;
+  }
+}

--- a/packages/schematics/angular/docker/index.ts
+++ b/packages/schematics/angular/docker/index.ts
@@ -1,0 +1,124 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {
+  Rule,
+  SchematicContext,
+  SchematicsException,
+  Tree,
+  apply,
+  chain,
+  mergeWith,
+  move,
+  template,
+  url,
+} from '@angular-devkit/schematics';
+import { getWorkspace } from '../utility/config';
+import { NodeScript, addPackageJsonScript } from '../utility/dependencies';
+import { getProjectTargets } from '../utility/project-targets';
+import { WorkspaceTool } from './../../../angular_devkit/core/src/workspace/workspace-schema';
+import { Schema as DockerOptions } from './schema';
+
+// tslint:disable-next-line:max-line-length
+const applyDockerOptions = (projectTargets: WorkspaceTool, dockerOptions: DockerOptions, environmentOptions: { machineName: string | undefined, isImageDeploy: boolean, serviceName: string | undefined }) => {
+  if (!projectTargets || !dockerOptions || !environmentOptions || !dockerOptions.environment) {
+    return;
+  }
+
+  if (projectTargets.build
+    && projectTargets.build.configurations
+    && projectTargets.build.configurations.docker) {
+    const dockerConfiguration = projectTargets.build.configurations.docker;
+    dockerConfiguration.environments[dockerOptions.environment] = environmentOptions;
+
+    return dockerConfiguration;
+  }
+
+  return {
+    imageName: dockerOptions.imageName,
+    registryAddress: dockerOptions.imageRegistry,
+    environments: {
+      [dockerOptions.environment]: environmentOptions,
+    },
+  };
+
+};
+
+function updateConfigFile(options: DockerOptions): Rule {
+  return (host: Tree, context: SchematicContext) => {
+    context.logger.debug('updating config file.');
+
+    const environmentOptions = {
+      machineName: options.machineName,
+      isImageDeploy: false,
+      serviceName: options.serviceName,
+    };
+
+    const workspace = getWorkspace(host);
+
+    if (!options.project) {
+      throw new SchematicsException('Option (project) is required.');
+    }
+
+    const projectTargets = getProjectTargets(workspace, options.project);
+
+    const target = projectTargets.build;
+
+    if (!target || !target.configurations) {
+      throw Error('Build configurations are missing!');
+    }
+
+    const applyTo = target.configurations;
+
+    if (!options.machineName || !options.serviceName) {
+        throw new SchematicsException('Option (machineName) and (serviceName) are required.');
+    }
+
+    applyTo.docker = applyDockerOptions(projectTargets, options, environmentOptions);
+
+    return host;
+  };
+}
+
+function addDockerScript(): Rule {
+  return (host: Tree, context: SchematicContext) => {
+
+    const dockerScript: NodeScript = {
+      name: 'docker',
+      value: 'docker-compose up -d --build',
+    };
+
+    return addPackageJsonScript(host, dockerScript);
+  };
+}
+
+export default function (options: DockerOptions): Rule {
+  return (host: Tree) => {
+    const workspace = getWorkspace(host);
+
+    if (!options.project) {
+      throw new SchematicsException('Option (project) is required.');
+    }
+
+    const project = workspace.projects[options.project];
+
+    if (project.projectType !== 'application') {
+      throw new SchematicsException(`Docker requires a project type of "application".`);
+    }
+
+    const templateSource = apply(url('./files'), [
+      template({...options}),
+      move(project.root),
+    ]);
+
+    return chain([
+      mergeWith(templateSource),
+      updateConfigFile(options),
+      addDockerScript(),
+    ]);
+  };
+}

--- a/packages/schematics/angular/docker/index_spec.ts
+++ b/packages/schematics/angular/docker/index_spec.ts
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';
+import * as path from 'path';
+import { Schema as ApplicationOptions } from '../application/schema';
+import { Schema as WorkspaceOptions } from '../workspace/schema';
+import { Schema as DockerOptions } from './schema';
+
+
+// tslint:disable:max-line-length
+describe('Docker Schematic', () => {
+  const schematicRunner = new SchematicTestRunner(
+    '@schematics/angular',
+    path.join(__dirname, '../collection.json'),
+  );
+
+  const defaultOptions: DockerOptions = {
+    project: 'bar',
+    name: 'foo',
+    environment: 'prod',
+    imageName: 'null',
+    useImage: false,
+    imageOrg: 'temp',
+    imageRegistry: 'registry.hub.docker.com',
+    servicePort: 8000,
+    serviceName: 'bar',
+    machineName: 'my-machine',
+  };
+
+  const workspaceOptions: WorkspaceOptions = {
+    name: 'workspace',
+    newProjectRoot: 'projects',
+    version: '6.0.0',
+  };
+
+  const appOptions: ApplicationOptions = {
+    name: 'bar',
+    inlineStyle: false,
+    inlineTemplate: false,
+    routing: false,
+    style: 'css',
+    skipTests: false,
+    skipPackageJson: false,
+  };
+
+  const initialWorkspaceAppOptions: ApplicationOptions = {
+    name: 'workspace',
+    projectRoot: '',
+    inlineStyle: false,
+    inlineTemplate: false,
+    routing: false,
+    style: 'css',
+    skipTests: false,
+    skipPackageJson: false,
+  };
+
+  let appTree: UnitTestTree;
+
+  beforeEach(() => {
+    appTree = schematicRunner.runSchematic('workspace', workspaceOptions);
+    appTree = schematicRunner.runSchematic('application', initialWorkspaceAppOptions, appTree);
+    appTree = schematicRunner.runSchematic('application', appOptions, appTree);
+  });
+
+  it('should create docker default files', () => {
+    const options = { ...defaultOptions };
+    const tree = schematicRunner.runSchematic('docker', options, appTree);
+    const files = tree.files;
+    const path = '/projects/bar';
+
+    expect(files.indexOf(`${path}/.dockerignore`)).toBeGreaterThanOrEqual(0);
+    expect(files.indexOf(`${path}/Dockerfile`)).toBeGreaterThanOrEqual(0);
+    expect(files.indexOf(`${path}/docker-compose.yml`)).toBeGreaterThanOrEqual(0);
+    expect(files.indexOf(`${path}/docker-compose.${options.environment}.yml`)).toBeGreaterThanOrEqual(0);
+    expect(files.indexOf(`${path}/nginx.conf`)).toBeGreaterThanOrEqual(0);
+  });
+
+});

--- a/packages/schematics/angular/docker/schema.json
+++ b/packages/schematics/angular/docker/schema.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "id": "SchematicsAngularDocker",
+  "title": "Angular Docker schema",
+  "type": "object",
+  "properties": {
+    "project": {
+      "type": "string",
+      "description": "The name of the project.",
+      "$default": {
+        "$source": "projectName"
+      }
+    },
+    "name": {
+      "type": "string",
+      "description": "[Deprecated] The name of the project.",
+      "$default": {
+        "$source": "projectName"
+      },
+      "visible": false
+    },
+    "environment": {
+      "description": "Initialize for a particular environment.",
+      "alias": "env",
+      "type": "string",
+      "default": "production"
+    },
+    "imageName": {
+      "description": "The image name to use for image pushes.",
+      "type": "string"
+    },
+    "useImage": {
+      "description": "Initializes the environment for deploying with an image, rather than performing a build.",
+      "type": "boolean",
+      "default": false
+    },
+    "imageOrg": {
+      "description": "The org name to use for image pushes.",
+      "type": "string",
+      "default": "temp"
+    },
+    "imageRegistry": {
+      "description": "The registry address to use for image pushes.",
+      "type": "string",
+      "default": "registry.hub.docker.com"
+    },  
+    "servicePort": {
+      "description": "The port of the computer service.",
+      "type": "number",
+      "default": 8000
+    },
+    "serviceName": {
+      "description": "The name of the service.",
+      "type": "string",
+      "$default": {
+        "$source": "projectName"
+      }
+    },
+    "machineName": {
+      "description": "The name of the machine.",
+      "alias": "machine",
+      "type": "string",
+      "default": "my-machine"
+    }
+  },
+  "required": [],
+  "additionalProperties": false
+}

--- a/packages/schematics/angular/utility/workspace-models.ts
+++ b/packages/schematics/angular/utility/workspace-models.ts
@@ -30,6 +30,19 @@ export interface FileReplacements {
     with: string;
 }
 
+export interface DockerOptions {
+    orgName: string;
+    imageName: string;
+    registryAddress: string;
+    environments: {
+        [key: string]: {
+            machineName: string,
+            isImageDeploy: boolean,
+            serviceName: string,
+        },
+    };
+}
+
 export interface BrowserBuilderBaseOptions {
     main: string;
     tsConfig: string;
@@ -101,6 +114,7 @@ export interface BuilderTarget<TBuilder extends Builders, TOptions> {
         production: Partial<TOptions>;
         [key: string]: Partial<TOptions>;
     };
+    docker?: DockerOptions;
 }
 
 export type LibraryBuilderTarget = BuilderTarget<Builders.NgPackagr, LibraryBuilderOptions>;


### PR DESCRIPTION
Introducing only the **init** action. 

Tested with a brand new application generated with the latest cli.

Also tested with angular-cli@1.6.5 generated app with the following required actions:
- rm -rf node_modules
- npm link @angular/cli
- ng update --all
- yarn