### PR TITLE
fix json schema for angular.json to allow 'targets' property

### DIFF
--- a/packages/angular/cli/lib/config/schema.json
+++ b/packages/angular/cli/lib/config/schema.json
@@ -327,6 +327,12 @@
           "additionalProperties": {
             "$ref": "#/definitions/project/definitions/target"
           }
+        },
+        "targets": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/project/definitions/target"
+          }
         }
       },
       "required": [


### PR DESCRIPTION
Currently a newly created angular-cli project contains angular.json not passing checks with the json schema bundled with corresponding package:
![image](https://user-images.githubusercontent.com/4499495/45311329-0d866c00-b529-11e8-8312-6e3d4dac5fcd.png)

The issue was reported by WebStorm QA as https://youtrack.jetbrains.com/issue/WEB-34738.

This PR fixes the issue, allowing 'targets' property.