### PR TITLE
fix(@angular-devkit/schematics-cli): fix `list-schematics` is not printing anything

### DIFF
--- a/packages/angular_devkit/benchmark/BUILD
+++ b/packages/angular_devkit/benchmark/BUILD
@@ -24,6 +24,7 @@ ts_library(
     module_root = "src/index.d.ts",
     deps = [
         "//packages/angular_devkit/core",
+        "//packages/angular_devkit/core:node",
         "@rxjs",
         "@rxjs//operators",
         # @typings: node
@@ -46,6 +47,7 @@ ts_library(
     deps = [
         ":benchmark",
         "//packages/angular_devkit/core",
+        "//packages/angular_devkit/core:node",
         "@rxjs",
         "@rxjs//operators",
         # @typings: jasmine

--- a/packages/angular_devkit/benchmark/src/main.ts
+++ b/packages/angular_devkit/benchmark/src/main.ts
@@ -8,6 +8,7 @@
  */
 
 import { logging, tags, terminal } from '@angular-devkit/core';
+import { ProcessOutput } from '@angular-devkit/core/node';
 import { appendFileSync, writeFileSync } from 'fs';
 import * as minimist from 'minimist';
 import { filter, map, toArray } from 'rxjs/operators';
@@ -19,8 +20,8 @@ import { runBenchmark } from '../src/run-benchmark';
 
 export interface MainOptions {
   args: string[];
-  stdout?: { write(buffer: string | Buffer): boolean };
-  stderr?: { write(buffer: string | Buffer): boolean };
+  stdout?: ProcessOutput;
+  stderr?: ProcessOutput;
 }
 
 export async function main({

--- a/packages/angular_devkit/core/node/cli-logger.ts
+++ b/packages/angular_devkit/core/node/cli-logger.ts
@@ -8,18 +8,25 @@
 import { filter } from 'rxjs/operators';
 import { logging, terminal } from '../src';
 
+export interface ProcessOutput {
+  write(buffer: string | Buffer): boolean;
+}
 
 /**
  * A Logger that sends information to STDOUT and STDERR.
  */
-export function createConsoleLogger(verbose = false): logging.Logger {
+export function createConsoleLogger(
+  verbose = false,
+  stdout: ProcessOutput = process.stdout,
+  stderr: ProcessOutput = process.stderr,
+): logging.Logger {
   const logger = new logging.IndentLogger('cling');
 
   logger
     .pipe(filter(entry => (entry.level != 'debug' || verbose)))
     .subscribe(entry => {
       let color: (s: string) => string = x => terminal.dim(terminal.white(x));
-      let output = process.stdout;
+      let output = stdout;
       switch (entry.level) {
         case 'info':
           color = terminal.white;
@@ -29,11 +36,11 @@ export function createConsoleLogger(verbose = false): logging.Logger {
           break;
         case 'error':
           color = terminal.red;
-          output = process.stderr;
+          output = stderr;
           break;
         case 'fatal':
           color = (x: string) => terminal.bold(terminal.red(x));
-          output = process.stderr;
+          output = stderr;
           break;
       }
 

--- a/packages/angular_devkit/schematics/src/engine/engine.ts
+++ b/packages/angular_devkit/schematics/src/engine/engine.ts
@@ -329,7 +329,7 @@ export class SchematicEngine<CollectionT extends object, SchematicT extends obje
     }
 
     // remove duplicates
-    return [...new Set(names)];
+    return [...new Set(names)].sort();
   }
 
   transformOptions<OptionT extends object, ResultT extends object>(

--- a/packages/angular_devkit/schematics_cli/bin/schematics_spec.ts
+++ b/packages/angular_devkit/schematics_cli/bin/schematics_spec.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { main } from './schematics';
+
+// We only care about the write method in these mocks of NodeJS.WriteStream.
+class MockWriteStream {
+  lines: string[] = [];
+  write(str: string) {
+    // Strip color control characters.
+    this.lines.push(str.replace(/[^\x20-\x7F]\[\d+m/g, ''));
+
+    return true;
+  }
+}
+
+describe('schematics-cli binary', () => {
+  let stdout: MockWriteStream, stderr: MockWriteStream;
+
+  beforeEach(() => {
+    stdout = new MockWriteStream();
+    stderr = new MockWriteStream();
+  });
+
+  it('list-schematics works', async () => {
+    const args = ['--list-schematics'];
+    const res = await main({ args, stdout, stderr });
+    expect(stdout.lines).toMatch(/blank/);
+    expect(stdout.lines).toMatch(/schematic/);
+    expect(res).toEqual(0);
+  });
+
+  it('dry-run works', async () => {
+    const args = ['blank', 'foo', '--dry-run'];
+    const res = await main({ args, stdout, stderr });
+    expect(stdout.lines).toMatch(/CREATE \/foo\/README.md/);
+    expect(stdout.lines).toMatch(/CREATE \/foo\/.gitignore/);
+    expect(stdout.lines).toMatch(/CREATE \/foo\/src\/foo\/index.ts/);
+    expect(stdout.lines).toMatch(/CREATE \/foo\/src\/foo\/index_spec.ts/);
+    expect(res).toEqual(0);
+  });
+
+  it('error when no name is provided', async () => {
+    const args = ['blank'];
+    const res = await main({ args, stdout, stderr });
+    expect(stderr.lines).toMatch(/Error: name option is required/);
+    expect(res).toEqual(1);
+  });
+});


### PR DESCRIPTION
fix `list-schematics` is not printing anything

Usage:
```
$  schematics @schematics/angular: --list-schematics
$  schematics --list-schematics
```

When no colon is specified, it means that that you are passing a schematic name to be looked up in the default collection.

Closes #12220