### PR TITLE
docs: add jsdoc instead of comments

### DIFF
--- a/packages/angular_devkit/benchmark/src/interfaces.ts
+++ b/packages/angular_devkit/benchmark/src/interfaces.ts
@@ -9,14 +9,22 @@ import { Observable } from 'rxjs';
 import { Command } from './command';
 
 export interface AggregatedProcessStats {
-  processes: number;      // number of processes
-  cpu: number;            // percentage (from 0 to 100*vcore)
-  memory: number;         // bytes
-  ppid: number;           // PPID
-  pid: number;            // PID
-  ctime: number;          // ms user + system time
-  elapsed: number;        // ms since the start of the process
-  timestamp: number;      // ms since epoch
+  /** Number of processes */
+  processes: number;
+  /** Percentage (from 0 to 100 * vcore) */
+  cpu: number;
+  /** Bytes */
+  memory: number;
+  /** Parent Process ID */
+  ppid: number;
+  /** Process ID */
+  pid: number;
+  /** Ms user + system time */
+  ctime: number;
+  /** Ms since the start of the process */
+  elapsed: number;
+  /** Ms since epoch */
+  timestamp: number;
 }
 
 export interface MonitoredProcess {


### PR DESCRIPTION
This changes was originally required for the API guardian as it was not liking the comments as they were. But I am going to land it separately.

- Use `jsdocs` / `tsdocs` instead of comments
- rename file from `.d.ts` to `.ts`. This is due that `d.ts` don't get typechecked because we have `skipLibCheck` enabled which might result in invalid declarations. Referenced `dts` files don’t get emitted by tsc, which means there should be a separate build process to copy this dts file to dist. And finally I'd very much like to avoid issues like this #11294 just because we use d.ts instead of .ts