### PR TITLE
Set of fixes for better npmrc parameters support

### DIFF
--- a/packages/schematics/update/update/npm.ts
+++ b/packages/schematics/update/update/npm.ts
@@ -56,7 +56,7 @@ function _readNpmRc(): Observable<{ [key: string]: string }> {
 
     allOptionsArr.forEach(x => {
       const [key, ...value] = x.split('=');
-      allOptions[key] = value.join('=');
+      allOptions[key.trim()] = value.join('=').trim();
     });
 
     subject.next(allOptions);

--- a/packages/schematics/update/update/npm.ts
+++ b/packages/schematics/update/update/npm.ts
@@ -33,15 +33,21 @@ function _readNpmRc(): Observable<{ [key: string]: string }> {
     // TODO: have a way to read options without using fs directly.
     const path = require('path');
     const fs = require('fs');
+    const perProjectNpmrc = path.resolve('.npmrc');
 
     let npmrc = '';
-    if (process.platform === 'win32') {
-      if (process.env.LOCALAPPDATA) {
-        npmrc = fs.readFileSync(path.join(process.env.LOCALAPPDATA, '.npmrc')).toString('utf-8');
-      }
+
+    if (fs.existsSync(perProjectNpmrc)) {
+      npmrc = fs.readFileSync(perProjectNpmrc).toString('utf-8');
     } else {
-      if (process.env.HOME) {
-        npmrc = fs.readFileSync(path.join(process.env.HOME, '.npmrc')).toString('utf-8');
+      if (process.platform === 'win32') {
+        if (process.env.LOCALAPPDATA) {
+          npmrc = fs.readFileSync(path.join(process.env.LOCALAPPDATA, '.npmrc')).toString('utf-8');
+        }
+      } else {
+        if (process.env.HOME) {
+          npmrc = fs.readFileSync(path.join(process.env.HOME, '.npmrc')).toString('utf-8');
+        }
       }
     }
 


### PR DESCRIPTION
Heavily related to a hot topic #10624. This issue is really annoying for lots of people.

Targets two points:

1. Support for per-project `.npmrc` file. This is done for the projects that include bundled `.npmrc` with readonly permissions, see https://docs.npmjs.com/files/npmrc
2. Support for private repositories like Nexus and Artifactory. I did not test with Artifactory because currently I have none, however Nexus works perfectly with the applied changes. Artifactory has a similar way of authentication, so it should also be covered.

Changes type:
- `alwaysAuth` is changed to `always-auth`, which is a proper name, see https://docs.npmjs.com/misc/config#always-auth
- added email parameter
- `_auth` is normally a base64 encoded `token:password` string => added extracting those credentials from the token and left a fallback token assignment in case something else is stored in `_auth`

Thank you in advance.