### PR TITLE
feat(@angular-devkit/build-angular): enable sourcemaps by default when using karma

### DIFF
--- a/packages/angular_devkit/build_angular/src/karma/schema.json
+++ b/packages/angular_devkit/build_angular/src/karma/schema.json
@@ -64,7 +64,8 @@
     },
     "sourceMap": {
       "type": "boolean",
-      "description": "Output sourcemaps."
+      "description": "Output sourcemaps.",
+      "default": true
     },
     "vendorSourceMap": {
       "type": "boolean",


### PR DESCRIPTION

I tried to do a regression tests like @filipesilva suggested
```ts
  it('sourcemaps are enabled by default', (done) => {
    host.writeMultipleFiles({
      'src/app/app.component.spec.ts': 'console.log(new Error())',
    });

    const logger = new TestLogger('karma-sourcemaps');

    runTargetSpec(host, karmaTargetSpec, undefined, DefaultTimeout, logger).pipe(
      tap((buildEvent) => expect(buildEvent.success).toBe(false)),
      tap(() => {
        console.log(logger);
        expect(logger.includes('/app/app.component.spec.ts')).toBe(true)
      }),
    ).toPromise().then(done, done.fail);
  });
```

However the problem is that the stacktrace always contains `ts` paths. The only difference when enabling sourcemaps is the contents of the files, as shown below;

Sourcemaps enabled
![image](https://user-images.githubusercontent.com/17563226/45669838-86855500-bb21-11e8-95f9-b36ad60a8892.png)

No sourcemaps
![image](https://user-images.githubusercontent.com/17563226/45669872-99982500-bb21-11e8-99b2-31f9f0d26bc4.png)

Closes #12282 and Potentially fixes #11672