### PR TITLE
fix(@angular/cli): support `--version` option

### DIFF
--- a/packages/angular/cli/models/command-runner.ts
+++ b/packages/angular/cli/models/command-runner.ts
@@ -115,7 +115,11 @@ export async function runCommand(
 
   // if no commands were found, use `help`.
   if (commandName === undefined) {
-    commandName = 'help';
+    if (args.length === 1 && args[0] === '--version') {
+      commandName = 'version';
+    } else {
+      commandName = 'help';
+    }
   }
 
   let description: CommandDescription | null = null;

--- a/tests/legacy-cli/e2e/tests/misc/version.ts
+++ b/tests/legacy-cli/e2e/tests/misc/version.ts
@@ -1,13 +1,22 @@
-import {deleteFile} from '../../utils/fs';
-import {ng} from '../../utils/process';
+import { deleteFile } from '../../utils/fs';
+import { ng } from '../../utils/process';
 
 
-export default function() {
-  return ng('version')
-    .then(() => deleteFile('angular.json'))
-    // doesn't fail on a project with missing angular.json
-    .then(() => ng('version'))
-    // Doesn't fail outside a project.
-    .then(() => process.chdir('/'))
-    .then(() => ng('version'));
+export default async function() {
+  const { stdout: commandOutput } = await ng('version');
+  const { stdout: optionOutput } = await ng('--version');
+  if (!optionOutput.includes('Angular CLI:')) {
+    throw new Error('version not displayed');
+  }
+  if (commandOutput !== optionOutput) {
+    throw new Error('version variants have differing output');
+  }
+
+  // doesn't fail on a project with missing angular.json
+  await deleteFile('angular.json');
+  await ng('version');
+
+  // Doesn't fail outside a project.
+  await process.chdir('/');
+  await ng('version');
 }


### PR DESCRIPTION
It was supported in 6.x and appears to have been lost in the 7.0 betas.