### PR TITLE
Conditional IE Polyfill Concept

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/build-options.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/build-options.ts
@@ -52,6 +52,7 @@ export interface BuildOptions {
   skipAppShell?: boolean;
   statsJson: boolean;
   forkTypeChecker: boolean;
+  supportIE?: boolean;
 
   main: string;
   index: string;

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/ie-jit-support.js
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/ie-jit-support.js
@@ -1,0 +1,8 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import 'core-js/es6/reflect';

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/ie-support.js
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/ie-support.js
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import 'core-js/es6/symbol';
+import 'core-js/es6/object';
+import 'core-js/es6/function';
+import 'core-js/es6/parse-int';
+import 'core-js/es6/parse-float';
+import 'core-js/es6/number';
+import 'core-js/es6/math';
+import 'core-js/es6/string';
+import 'core-js/es6/date';
+import 'core-js/es6/array';
+import 'core-js/es6/regexp';
+import 'core-js/es6/map';
+import 'core-js/es6/weak-map';
+import 'core-js/es6/set';

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/jit-polyfills.js
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/jit-polyfills.js
@@ -1,0 +1,8 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import 'core-js/es7/reflect';

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/browser.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/browser.ts
@@ -125,7 +125,7 @@ export function getBrowserConfig(wco: WebpackConfigOptions) {
             test: (module: any, chunks: Array<{ name: string }>) => {
               const moduleName = module.nameForCondition ? module.nameForCondition() : '';
               return /[\\/]node_modules[\\/]/.test(moduleName)
-                && !chunks.some(({ name }) => name === 'polyfills'
+                && !chunks.some(({ name }) => name === 'polyfills' || name === 'ie-support'
                   || globalStylesBundleNames.includes(name));
             },
           },
@@ -138,6 +138,7 @@ export function getBrowserConfig(wco: WebpackConfigOptions) {
         output: path.basename(buildOptions.index),
         baseHref: buildOptions.baseHref,
         entrypoints: generateEntryPoints(buildOptions),
+        noModuleEntrypoints: ['ie-support'],
         deployUrl: buildOptions.deployUrl,
         sri: buildOptions.subresourceIntegrity,
       }),

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
@@ -62,6 +62,13 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
     entryPoints['polyfills'] = [path.resolve(root, buildOptions.polyfills)];
   }
 
+  if (!buildOptions.aot) {
+    entryPoints['polyfills'] = [
+      ...(entryPoints['polyfills'] || []),
+      path.join(__dirname, '..', 'jit-polyfills.js'),
+    ];
+  }
+
   // determine hashing format
   const hashFormat = getOutputHashFormat(buildOptions.outputHashing as any);
 

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
@@ -58,6 +58,10 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
     entryPoints['main'] = [path.resolve(root, buildOptions.main)];
   }
 
+  if (buildOptions.supportIE) {
+    entryPoints['ie-support'] = [path.join(__dirname, '..', 'ie-support.js')];
+  }
+
   if (buildOptions.polyfills) {
     entryPoints['polyfills'] = [path.resolve(root, buildOptions.polyfills)];
   }
@@ -67,6 +71,13 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
       ...(entryPoints['polyfills'] || []),
       path.join(__dirname, '..', 'jit-polyfills.js'),
     ];
+
+    if (buildOptions.supportIE) {
+      entryPoints['ie-support'] = [
+        ...entryPoints['ie-support'],
+        path.join(__dirname, '..', 'ie-jit-support.js'),
+      ];
+    }
   }
 
   // determine hashing format

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/package-chunk-sort.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/package-chunk-sort.ts
@@ -12,7 +12,7 @@ import { ExtraEntryPoint } from '../../browser/schema';
 import { normalizeExtraEntryPoints } from '../models/webpack-configs/utils';
 
 export function generateEntryPoints(appConfig: any) {
-  let entryPoints = ['polyfills', 'sw-register'];
+  const entryPoints = ['ie-support', 'polyfills', 'sw-register'];
 
   // Add all styles/scripts, except lazy-loaded ones.
   [

--- a/packages/angular_devkit/build_angular/src/browser/schema.d.ts
+++ b/packages/angular_devkit/build_angular/src/browser/schema.d.ts
@@ -222,6 +222,11 @@ export interface BrowserBuilderSchema {
    * Budget thresholds to ensure parts of your application stay within boundaries which you set.
    */
   budgets: Budget[];
+
+  /**
+   * Enables conditionally loaded IE9-11 polyfills.
+   */
+  supportIE: boolean;
 }
 
 export type AssetPattern = string | AssetPatternObject;

--- a/packages/angular_devkit/build_angular/src/browser/schema.json
+++ b/packages/angular_devkit/build_angular/src/browser/schema.json
@@ -236,6 +236,11 @@
         "$ref": "#/definitions/budget"
       },
       "default": []
+    },
+    "supportIE": {
+      "description": "Enables conditionally loaded IE9-11 polyfills",
+      "type": "boolean",
+      "default": false
     }
   },
   "additionalProperties": false,

--- a/packages/schematics/angular/application/files/src/polyfills.ts
+++ b/packages/schematics/angular/application/files/src/polyfills.ts
@@ -40,12 +40,6 @@
 /** IE10 and IE11 requires the following for the Reflect API. */
 // import 'core-js/es6/reflect';
 
-
-/** Evergreen browsers require these. **/
-// Used for reflect-metadata in JIT. If you use AOT (and only Angular decorators), you can remove.
-import 'core-js/es7/reflect';
-
-
 /**
  * Web Animations `@angular/platform-browser/animations`
  * Only required if AnimationBuilder is used within the application and using IE/Edge or Safari.

--- a/packages/schematics/angular/application/files/src/polyfills.ts
+++ b/packages/schematics/angular/application/files/src/polyfills.ts
@@ -18,27 +18,8 @@
  * BROWSER POLYFILLS
  */
 
-/** IE9, IE10 and IE11 requires all of the following polyfills. **/
-// import 'core-js/es6/symbol';
-// import 'core-js/es6/object';
-// import 'core-js/es6/function';
-// import 'core-js/es6/parse-int';
-// import 'core-js/es6/parse-float';
-// import 'core-js/es6/number';
-// import 'core-js/es6/math';
-// import 'core-js/es6/string';
-// import 'core-js/es6/date';
-// import 'core-js/es6/array';
-// import 'core-js/es6/regexp';
-// import 'core-js/es6/map';
-// import 'core-js/es6/weak-map';
-// import 'core-js/es6/set';
-
 /** IE10 and IE11 requires the following for NgClass support on SVG elements */
 // import 'classlist.js';  // Run `npm install --save classlist.js`.
-
-/** IE10 and IE11 requires the following for the Reflect API. */
-// import 'core-js/es6/reflect';
 
 /**
  * Web Animations `@angular/platform-browser/animations`

--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -157,6 +157,7 @@ function addAppToWorkspaceFile(options: ApplicationOptions, workspace: Workspace
             `${projectRoot}src/styles.${options.style}`,
           ],
           scripts: [],
+          supportIE: true,
         },
         configurations: {
           production: {

--- a/packages/schematics/angular/utility/workspace-models.ts
+++ b/packages/schematics/angular/utility/workspace-models.ts
@@ -53,6 +53,7 @@ export interface BrowserBuilderOptions extends BrowserBuilderBaseOptions {
     extractLicenses?: boolean;
     vendorChunk?: boolean;
     buildOptimizer?: boolean;
+    supportIE?: boolean;
 }
 
 export interface ServeBuilderOptions {

--- a/tests/legacy-cli/e2e/tests/basic/scripts-array.ts
+++ b/tests/legacy-cli/e2e/tests/basic/scripts-array.ts
@@ -54,6 +54,7 @@ export default function () {
     // index.html lists the right bundles
     .then(() => expectFileToMatch('dist/test-project/index.html', oneLineTrim`
       <script type="text/javascript" src="runtime.js"></script>
+      <script type="text/javascript" src="ie-support.js" nomodule></script>
       <script type="text/javascript" src="polyfills.js"></script>
       <script type="text/javascript" src="scripts.js"></script>
       <script type="text/javascript" src="renamed-script.js"></script>

--- a/tests/legacy-cli/e2e/tests/basic/styles-array.ts
+++ b/tests/legacy-cli/e2e/tests/basic/styles-array.ts
@@ -43,6 +43,7 @@ export default function () {
     `))
     .then(() => expectFileToMatch('dist/test-project/index.html', oneLineTrim`
       <script type="text/javascript" src="runtime.js"></script>
+      <script type="text/javascript" src="ie-support.js" nomodule></script>
       <script type="text/javascript" src="polyfills.js"></script>
       <script type="text/javascript" src="vendor.js"></script>
       <script type="text/javascript" src="main.js"></script>

--- a/tests/legacy-cli/e2e/tests/build/polyfills.ts
+++ b/tests/legacy-cli/e2e/tests/build/polyfills.ts
@@ -1,19 +1,34 @@
-import { expectFileToMatch } from '../../utils/fs';
-import { ng } from '../../utils/process';
 import { oneLineTrim } from 'common-tags';
+import {
+  expectFileSizeToBeUnder,
+  expectFileToExist,
+  expectFileToMatch,
+  getFileSize,
+} from '../../utils/fs';
+import { ng } from '../../utils/process';
+import { expectToFail } from '../../utils/utils';
 
-export default function () {
-  // TODO(architect): Delete this test. It is now in devkit/build-angular.
-
-  return Promise.resolve()
-    .then(() => ng('build'))
+export default async function () {
+    await ng('build');
     // files were created successfully
-    .then(() => expectFileToMatch('dist/test-project/polyfills.js', 'core-js'))
-    .then(() => expectFileToMatch('dist/test-project/polyfills.js', 'zone.js'))
-    // index.html lists the right bundles
-    .then(() => expectFileToMatch('dist/test-project/index.html', oneLineTrim`
+    await expectFileToMatch('dist/test-project/polyfills.js', 'core-js/es7/reflect');
+    await expectFileToMatch('dist/test-project/polyfills.js', 'zone.js');
+    expectFileToMatch('dist/test-project/index.html', oneLineTrim`
       <script type="text/javascript" src="runtime.js"></script>
       <script type="text/javascript" src="ie-support.js" nomodule></script>
       <script type="text/javascript" src="polyfills.js"></script>
-    `));
+    `);
+    const jitPolyfillSize = await getFileSize('dist/test-project/polyfills.js');
+
+    await ng('build', '--aot');
+    // files were created successfully
+    await expectFileToExist('dist/test-project/polyfills.js');
+    await expectFileSizeToBeUnder('dist/test-project/polyfills.js', jitPolyfillSize);
+    await expectToFail(() => expectFileToMatch('dist/test-project/polyfills.js', 'core-js/es7/reflect'));
+    await expectFileToMatch('dist/test-project/polyfills.js', 'zone.js');
+    expectFileToMatch('dist/test-project/index.html', oneLineTrim`
+      <script type="text/javascript" src="runtime.js"></script>
+      <script type="text/javascript" src="ie-support.js" nomodule></script>
+      <script type="text/javascript" src="polyfills.js"></script>
+    `);
 }

--- a/tests/legacy-cli/e2e/tests/build/polyfills.ts
+++ b/tests/legacy-cli/e2e/tests/build/polyfills.ts
@@ -13,6 +13,7 @@ export default function () {
     // index.html lists the right bundles
     .then(() => expectFileToMatch('dist/test-project/index.html', oneLineTrim`
       <script type="text/javascript" src="runtime.js"></script>
+      <script type="text/javascript" src="ie-support.js" nomodule></script>
       <script type="text/javascript" src="polyfills.js"></script>
     `));
 }

--- a/tests/legacy-cli/e2e/tests/build/styles/extract-css.ts
+++ b/tests/legacy-cli/e2e/tests/build/styles/extract-css.ts
@@ -48,6 +48,7 @@ export default function () {
     `)))
     .then(() => expectFileToMatch('dist/test-project/index.html', oneLineTrim`
       <script type="text/javascript" src="runtime.js"></script>
+      <script type="text/javascript" src="ie-support.js" nomodule></script>
       <script type="text/javascript" src="polyfills.js"></script>
       <script type="text/javascript" src="vendor.js"></script>
       <script type="text/javascript" src="main.js"></script>
@@ -63,6 +64,7 @@ export default function () {
     // index.html lists the right bundles
     .then(() => expectFileToMatch('dist/test-project/index.html', oneLineTrim`
       <script type="text/javascript" src="runtime.js"></script>
+      <script type="text/javascript" src="ie-support.js" nomodule></script>
       <script type="text/javascript" src="polyfills.js"></script>
       <script type="text/javascript" src="styles.js"></script>
       <script type="text/javascript" src="renamed-style.js"></script>

--- a/tests/legacy-cli/e2e/tests/misc/support-ie.ts
+++ b/tests/legacy-cli/e2e/tests/misc/support-ie.ts
@@ -1,0 +1,32 @@
+import { oneLineTrim } from 'common-tags';
+import { expectFileNotToExist, expectFileToMatch } from '../../utils/fs';
+import { ng } from '../../utils/process';
+import { updateJsonFile } from '../../utils/project';
+
+export default async function () {
+  await updateJsonFile('angular.json', workspaceJson => {
+      const appArchitect = workspaceJson.projects['test-project'].architect;
+      appArchitect.build.options.supportIE = false;
+  });
+
+  await ng('build');
+  await expectFileNotToExist('dist/test-project/ie-support.js');
+  await expectFileToMatch('dist/test-project/index.html', oneLineTrim`
+    <script type="text/javascript" src="runtime.js"></script>
+    <script type="text/javascript" src="polyfills.js"></script>
+    <script type="text/javascript" src="styles.js"></script>
+    <script type="text/javascript" src="vendor.js"></script>
+    <script type="text/javascript" src="main.js"></script>
+  `);
+
+  await ng('build', `--supportIE`);
+  await expectFileToMatch('dist/test-project/ie-support.js', 'core-js');
+  await expectFileToMatch('dist/test-project/index.html', oneLineTrim`
+    <script type="text/javascript" src="runtime.js"></script>
+    <script type="text/javascript" src="ie-support.js" nomodule></script>
+    <script type="text/javascript" src="polyfills.js"></script>
+    <script type="text/javascript" src="styles.js"></script>
+    <script type="text/javascript" src="vendor.js"></script>
+    <script type="text/javascript" src="main.js"></script>
+  `);
+}

--- a/tests/legacy-cli/e2e/tests/third-party/bootstrap.ts
+++ b/tests/legacy-cli/e2e/tests/third-party/bootstrap.ts
@@ -23,6 +23,7 @@ export default function() {
     .then(() => expectFileToMatch('dist/test-project/styles.css', '* Bootstrap'))
     .then(() => expectFileToMatch('dist/test-project/index.html', oneLineTrim`
       <script type="text/javascript" src="runtime.js"></script>
+      <script type="text/javascript" src="ie-support.js" nomodule></script>
       <script type="text/javascript" src="polyfills.js"></script>
       <script type="text/javascript" src="scripts.js"></script>
       <script type="text/javascript" src="vendor.js"></script>
@@ -39,6 +40,7 @@ export default function() {
     .then(() => expectFileToMatch('dist/test-project/styles.css', '* Bootstrap'))
     .then(() => expectFileToMatch('dist/test-project/index.html', oneLineTrim`
       <script type="text/javascript" src="runtime.js"></script>
+      <script type="text/javascript" src="ie-support.js" nomodule></script>
       <script type="text/javascript" src="polyfills.js"></script>
       <script type="text/javascript" src="scripts.js"></script>
       <script type="text/javascript" src="main.js"></script>

--- a/tests/legacy-cli/e2e/utils/fs.ts
+++ b/tests/legacy-cli/e2e/utils/fs.ts
@@ -188,11 +188,16 @@ export function expectFileToMatch(fileName: string, regEx: RegExp | string) {
     });
 }
 
-export function expectFileSizeToBeUnder(fileName: string, sizeInBytes: number) {
-  return readFile(fileName)
-    .then(content => {
-      if (content.length > sizeInBytes) {
-        throw new Error(`File "${fileName}" exceeded file size of "${sizeInBytes}".`);
-      }
-    });
+export async function getFileSize(fileName: string) {
+  const stats = await fs.stat(fileName);
+
+  return stats.size;
+}
+
+export async function expectFileSizeToBeUnder(fileName: string, sizeInBytes: number) {
+  const fileSize = await getFileSize(fileName);
+
+  if (fileSize > sizeInBytes) {
+    throw new Error(`File "${fileName}" exceeded file size of "${sizeInBytes}".`);
+  }
 }


### PR DESCRIPTION
* No-Cost IE9-11 support
  - no need to manually import and manage individual IE9-11 polyfills
  - Required ES2015 polyfills are only loaded by browsers that require them
  - Controllable via a new `supportIE` option; no behavior change if option is not enabled
  - `supportIE` is enabled in newly generated projects
  - allows for custom polyfill solutions by not using the new option.
  - works in conjunction with conditional JIT polyfills which will load IE specific JIT polyfills