### PR TITLE
fix(@angular/cli): do not check if node_modules are inside sources dir

### DIFF
--- a/packages/angular/cli/upgrade/version.ts
+++ b/packages/angular/cli/upgrade/version.ts
@@ -41,17 +41,6 @@ export class Version {
     let angularPkgJson;
     let rxjsPkgJson;
 
-    const isInside = (base: string, potential: string): boolean => {
-      const absoluteBase = path.resolve(base);
-      const absolutePotential = path.resolve(potential);
-      const relativePotential = path.relative(absoluteBase, absolutePotential);
-      if (!relativePotential.startsWith('..') && !path.isAbsolute(relativePotential)) {
-        return true;
-      }
-
-      return false;
-    };
-
     try {
       const resolveOptions = {
         basedir: projectRoot,
@@ -60,11 +49,6 @@ export class Version {
       };
       const angularPackagePath = resolve('@angular/core/package.json', resolveOptions);
       const rxjsPackagePath = resolve('rxjs/package.json', resolveOptions);
-
-      if (!isInside(projectRoot, angularPackagePath)
-          || !isInside(projectRoot, rxjsPackagePath)) {
-        throw new Error();
-      }
 
       angularPkgJson = require(angularPackagePath);
       rxjsPkgJson = require(rxjsPackagePath);


### PR DESCRIPTION
It should not verify that angular and rxjs packages are inside project
directory. To correctly resolve packages is enough.

Close #11685

Signed-off-by: Nicolas Geniteau <nicolas.geniteau@gmail.com>