### PR TITLE
style: remove redundant async in tests

### DIFF
--- a/packages/schematics/angular/application/other-files/app.component.spec.ts
+++ b/packages/schematics/angular/application/other-files/app.component.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed, async } from '@angular/core/testing';<% if (routing) { %>
 import { RouterTestingModule } from '@angular/router/testing';<% } %>
 import { AppComponent } from './app.component';
-                                                                        
+
 describe('AppComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({<% if (routing) { %>
@@ -14,22 +14,22 @@ describe('AppComponent', () => {
     }).compileComponents();
   }));
 
-  it('should create the app', async(() => {
+  it('should create the app', () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.debugElement.componentInstance;
     expect(app).toBeTruthy();
-  }));
+  });
 
-  it(`should have as title '<%= name %>'`, async(() => {
+  it(`should have as title '<%= name %>'`, () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.debugElement.componentInstance;
     expect(app.title).toEqual('<%= name %>');
-  }));
+  });
 
-  it('should render title in a h1 tag', async(() => {
+  it('should render title in a h1 tag', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const compiled = fixture.debugElement.nativeElement;
     expect(compiled.querySelector('h1').textContent).toContain('Welcome to <%= name %>!');
-  }));
+  });
 });

--- a/packages/schematics/angular/application/other-files/app.component.spec.ts
+++ b/packages/schematics/angular/application/other-files/app.component.spec.ts
@@ -1,6 +1,7 @@
 import { TestBed, async } from '@angular/core/testing';<% if (routing) { %>
 import { RouterTestingModule } from '@angular/router/testing';<% } %>
 import { AppComponent } from './app.component';
+                                                                        
 describe('AppComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({<% if (routing) { %>
@@ -12,16 +13,19 @@ describe('AppComponent', () => {
       ],
     }).compileComponents();
   }));
+
   it('should create the app', async(() => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.debugElement.componentInstance;
     expect(app).toBeTruthy();
   }));
+
   it(`should have as title '<%= name %>'`, async(() => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.debugElement.componentInstance;
     expect(app.title).toEqual('<%= name %>');
   }));
+
   it('should render title in a h1 tag', async(() => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();


### PR DESCRIPTION
style: improve formatting of spec file

style: remove redundant async in tests
In component specs only the compileComponents is async thus the async on it are redundant

Closes #12161