### PR TITLE
fix(@angular-devkit/build-angular): add progress option to xi18n

### DIFF
--- a/packages/angular/cli/lib/config/schema.json
+++ b/packages/angular/cli/lib/config/schema.json
@@ -1101,6 +1101,11 @@
               "type": "string",
               "description": "Specifies the source language of the application."
             },
+            "progress": {
+              "type": "boolean",
+              "description": "Log progress to the console.",
+              "default": true
+            },
             "outputPath": {
               "type": "string",
               "description": "Path where output will be placed."

--- a/packages/angular_devkit/build_angular/src/extract-i18n/index.ts
+++ b/packages/angular_devkit/build_angular/src/extract-i18n/index.ts
@@ -38,6 +38,7 @@ export interface ExtractI18nBuilderOptions {
   i18nLocale: string;
   outputPath?: string;
   outFile?: string;
+  progress?: boolean;
 }
 
 export class ExtractI18nBuilder implements Builder<ExtractI18nBuilderOptions> {
@@ -92,6 +93,7 @@ export class ExtractI18nBuilder implements Builder<ExtractI18nBuilderOptions> {
           i18nFormat: options.i18nFormat,
           i18nFile: outFile,
           aot: true,
+          progress: options.progress,
           assets: [],
           scripts: [],
           styles: [],

--- a/packages/angular_devkit/build_angular/src/extract-i18n/schema.json
+++ b/packages/angular_devkit/build_angular/src/extract-i18n/schema.json
@@ -24,6 +24,11 @@
       "type": "string",
       "description": "Specifies the source language of the application."
     },
+    "progress": {
+      "type": "boolean",
+      "description": "Log progress to the console.",
+      "default": true
+    },
     "outputPath": {
       "type": "string",
       "description": "Path where output will be placed."


### PR DESCRIPTION
Add progress option to xi18n. It is passed to the webpack builder.

Fixes #11667.