### PR TITLE
fix(@angular/cli): with no overrides dont throw

### DIFF
--- a/packages/angular/cli/models/architect-command.ts
+++ b/packages/angular/cli/models/architect-command.ts
@@ -296,6 +296,12 @@ export abstract class ArchitectCommand extends Command<ArchitectCommandOptions> 
       delete overrides.project;
     }
 
+    // For some reason, latest of yargs-parser with our configuration returns `{ _: [] }` if
+    // there's nothing to parse.
+    if (overrides._ && Array.isArray(overrides._) && overrides._.length == 0) {
+      delete overrides._;
+    }
+
     if (!project) {
       project = '';
     }


### PR DESCRIPTION
Configuration for yargs made it so the return value is different
now and triggers our logic to have extra overrides.

Fixes #12344.