### PR TITLE
feat(@schematics/angular): remove `@angular/http` as it's deprecated

### DIFF
--- a/packages/schematics/angular/universal/index.ts
+++ b/packages/schematics/angular/universal/index.ts
@@ -161,7 +161,12 @@ function addDependencies(): Rule {
       ...coreDep,
       name: '@angular/platform-server',
     };
+    const httpDep = {
+      ...coreDep,
+      name: '@angular/http',
+    };
     addPackageJsonDependency(host, platformServerDep);
+    addPackageJsonDependency(host, httpDep);
 
     return host;
   };

--- a/packages/schematics/angular/workspace/files/package.json
+++ b/packages/schematics/angular/workspace/files/package.json
@@ -16,7 +16,6 @@
     "@angular/compiler": "<%= experimentalAngularNext ? 'next' : latestVersions.Angular %>",
     "@angular/core": "<%= experimentalAngularNext ? 'next' : latestVersions.Angular %>",
     "@angular/forms": "<%= experimentalAngularNext ? 'next' : latestVersions.Angular %>",
-    "@angular/http": "<%= experimentalAngularNext ? 'next' : latestVersions.Angular %>",
     "@angular/platform-browser": "<%= experimentalAngularNext ? 'next' : latestVersions.Angular %>",
     "@angular/platform-browser-dynamic": "<%= experimentalAngularNext ? 'next' : latestVersions.Angular %>",
     "@angular/router": "<%= experimentalAngularNext ? 'next' : latestVersions.Angular %>",

--- a/tests/legacy-cli/e2e/tests/basic/rebuild.ts
+++ b/tests/legacy-cli/e2e/tests/basic/rebuild.ts
@@ -34,7 +34,7 @@ export default function() {
         import { BrowserModule } from '@angular/platform-browser';
         import { NgModule } from '@angular/core';
         import { FormsModule } from '@angular/forms';
-        import { HttpModule } from '@angular/http';
+        import { HttpClientModule } from '@angular/common/http';
 
         import { AppComponent } from './app.component';
         import { RouterModule } from '@angular/router';
@@ -46,7 +46,7 @@ export default function() {
           imports: [
             BrowserModule,
             FormsModule,
-            HttpModule,
+            HttpClientModule,
             RouterModule.forRoot([
               { path: 'lazy', loadChildren: './lazy/lazy.module#LazyModule' }
             ])

--- a/tests/legacy-cli/e2e/tests/build/build-app-shell-with-schematic.ts
+++ b/tests/legacy-cli/e2e/tests/build/build-app-shell-with-schematic.ts
@@ -18,9 +18,11 @@ export default function () {
   }
 
   let platformServerVersion = readNgVersion();
+  let httpVersion = readNgVersion();
 
   if (getGlobalVariable('argv')['ng-snapshots']) {
     platformServerVersion = 'github:angular/platform-server-builds';
+    httpVersion = 'github:angular/http-builds';
   }
 
 
@@ -33,6 +35,8 @@ export default function () {
     .then(() => updateJsonFile('package.json', packageJson => {
       const dependencies = packageJson['dependencies'];
       dependencies['@angular/platform-server'] = platformServerVersion;
+      // ServerModule depends on @angular/http regardless the app's dependency.
+      dependencies['@angular/http'] = httpVersion;
     })
     .then(() => npm('install'))
     .then(() => ng('build', '--optimization'))

--- a/tests/legacy-cli/e2e/tests/build/build-app-shell.ts
+++ b/tests/legacy-cli/e2e/tests/build/build-app-shell.ts
@@ -19,9 +19,11 @@ export default function () {
   }
 
   let platformServerVersion = readNgVersion();
+  let httpVersion = readNgVersion();
 
   if (getGlobalVariable('argv')['ng-snapshots']) {
     platformServerVersion = 'github:angular/platform-server-builds';
+    httpVersion = 'github:angular/http-builds';
   }
 
   return Promise.resolve()
@@ -134,6 +136,8 @@ export default function () {
     .then(() => updateJsonFile('package.json', packageJson => {
       const dependencies = packageJson['dependencies'];
       dependencies['@angular/platform-server'] = platformServerVersion;
+      // ServerModule depends on @angular/http regardless the app's dependency.
+      dependencies['@angular/http'] = httpVersion;
     })
     .then(() => npm('install')))
     .then(() => ng('run', 'test-project:app-shell'))

--- a/tests/legacy-cli/e2e/tests/build/platform-server.ts
+++ b/tests/legacy-cli/e2e/tests/build/platform-server.ts
@@ -20,9 +20,11 @@ export default function () {
   }
 
   let platformServerVersion = readNgVersion();
+  let httpVersion = readNgVersion();
 
   if (getGlobalVariable('argv')['ng-snapshots']) {
     platformServerVersion = 'github:angular/platform-server-builds';
+    httpVersion = 'github:angular/http-builds';
   }
 
   // Skip this test in Angular 2/4.
@@ -34,6 +36,8 @@ export default function () {
     .then(() => updateJsonFile('package.json', packageJson => {
       const dependencies = packageJson['dependencies'];
       dependencies['@angular/platform-server'] = platformServerVersion;
+      // ServerModule depends on @angular/http regardless the app's dependency.
+      dependencies['@angular/http'] = httpVersion;
     }))
     .then(() => updateJsonFile('angular.json', workspaceJson => {
       const appArchitect = workspaceJson.projects['test-project'].architect;


### PR DESCRIPTION
@angular/http is no longer recommended to use for a new workspace. This unnecessary dependency increase installation time to getting started Angular.