### PR TITLE
feat(@schematics/angular): add new projectRoot flag for initial project

### DIFF
--- a/packages/schematics/angular/ng-new/index.ts
+++ b/packages/schematics/angular/ng-new/index.ts
@@ -44,7 +44,7 @@ export default function (options: NgNewOptions): Rule {
     newProjectRoot: options.newProjectRoot || 'projects',
   };
   const applicationOptions: ApplicationOptions = {
-    projectRoot: '',
+    projectRoot: options.projectRoot,
     name: options.name,
     experimentalIvy: options.experimentalIvy,
     inlineStyle: options.inlineStyle,

--- a/packages/schematics/angular/ng-new/index_spec.ts
+++ b/packages/schematics/angular/ng-new/index_spec.ts
@@ -38,6 +38,19 @@ describe('Ng New Schematic', () => {
     expect(files.indexOf('/bar/src/app/app.module.ts')).toBeGreaterThanOrEqual(0);
   });
 
+  it('should create files in the project root', () => {
+    const options = { ...defaultOptions, projectRoot: 'new-project' };
+
+    const tree = schematicRunner.runSchematic('ng-new', options);
+    const files = tree.files;
+    expect(files).toContain('/bar/new-project/src/tsconfig.app.json');
+    expect(files).toContain('/bar/new-project/src/main.ts');
+    expect(files).toContain('/bar/new-project/src/app/app.module.ts');
+
+    const content = tree.readContent('/bar/angular.json');
+    expect(content).toMatch(/"sourceRoot": "new-project\/src"/);
+  });
+
   it('should should set the prefix in angular.json and in app.component.ts', () => {
     const options = { ...defaultOptions, prefix: 'pre' };
 

--- a/packages/schematics/angular/ng-new/schema.json
+++ b/packages/schematics/angular/ng-new/schema.json
@@ -71,6 +71,11 @@
       "type": "string",
       "default": "projects"
     },
+    "projectRoot": {
+      "description": "The root for the initial project.",
+      "type": "string",
+      "default": ""
+    },
     "inlineStyle": {
       "description": "Specifies if the style will be in the ts file.",
       "type": "boolean",


### PR DESCRIPTION
We used to support it. See #8112