### PR TITLE
feat(@angular-devkit/build-angular): add --reporters option to test

### DIFF
--- a/packages/angular/cli/lib/config/schema.json
+++ b/packages/angular/cli/lib/config/schema.json
@@ -1261,6 +1261,13 @@
                 ]
               },
               "default": []
+            },
+            "reporters": {
+              "type": "array",
+              "description": "Karma reporters to use. Directly passed to the karma runner.",
+              "items": {
+                "type": "string"
+              }
             }
           },
           "additionalProperties": false,

--- a/packages/angular_devkit/build_angular/src/karma/index.ts
+++ b/packages/angular_devkit/build_angular/src/karma/index.ts
@@ -71,6 +71,13 @@ export class KarmaBuilder implements Builder<KarmaBuilderSchema> {
           karmaOptions.browsers = options.browsers.split(',');
         }
 
+        if (options.reporters) {
+          // Split along commas to make it more natural, and remove empty strings.
+          karmaOptions.reporters = options.reporters
+            .reduce<string[]>((acc, curr) => acc.concat(curr.split(/,/)), [])
+            .filter(x => !!x);
+        }
+
         const sourceRoot = builderConfig.sourceRoot && resolve(root, builderConfig.sourceRoot);
 
         karmaOptions.buildWebpack = {

--- a/packages/angular_devkit/build_angular/src/karma/schema.d.ts
+++ b/packages/angular_devkit/build_angular/src/karma/schema.d.ts
@@ -32,4 +32,9 @@ export interface KarmaBuilderSchema extends Pick<BrowserBuilderSchema,
    * Globs to exclude from code coverage.
    */
   codeCoverageExclude: string[];
+
+  /**
+   * Karma reporters to use. Directly passed to the karma runner.
+   */
+  reporters?: string[];
 }

--- a/packages/angular_devkit/build_angular/src/karma/schema.json
+++ b/packages/angular_devkit/build_angular/src/karma/schema.json
@@ -150,6 +150,13 @@
         ]
       },
       "default": []
+    },
+    "reporters": {
+      "type": "array",
+      "description": "Karma reporters to use. Directly passed to the karma runner.",
+      "items": {
+        "type": "string"
+      }
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
It was a regression, and used by enough people on CI. No reason it should be
omitted and karma.conf.js only.

Fixes #11376