### PR TITLE
feat(@schematics/angular): update Angular and TS versions

### DIFF
--- a/packages/schematics/angular/utility/latest-versions.ts
+++ b/packages/schematics/angular/utility/latest-versions.ts
@@ -8,10 +8,10 @@
 
 export const latestVersions = {
   // These versions should be kept up to date with latest Angular peer dependencies.
-  Angular: '~7.0.0-beta.5',
+  Angular: '~7.0.0-rc.0',
   RxJs: '~6.3.3',
   ZoneJs: '~0.8.26',
-  TypeScript: '~3.0.1',
+  TypeScript: '>=3.1.1 <3.2',
   // The versions below must be manually updated when making a new devkit release.
   DevkitBuildAngular: '~0.9.0-beta.1',
   DevkitBuildNgPackagr: '~0.9.0-beta.1',


### PR DESCRIPTION
The CLI legacy e2e tests where failing because Angular 7.0.0-rc.0 embed
https://github.com/angular/angular/pull/26151/, and TS version 3.0 wasn't
right for this. This commit fix this error as reported in #12423, but isn't enought
to support TS 3.1 (see #12416 for more commits on this).

Close #12413