### PR TITLE
Upgrade ts 3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "quicktype-core": "^5.0.41",
     "temp": "^0.8.3",
     "tslint": "^5.11.0",
-    "typescript": "~3.0.1"
+    "typescript": "~3.1.1"
   },
   "devDependencies": {
     "@angular/compiler": "^7.0.0-beta.4",

--- a/packages/angular/cli/utilities/json-schema.ts
+++ b/packages/angular/cli/utilities/json-schema.ts
@@ -205,7 +205,7 @@ export async function parseJsonSchemaToOptions(
 
     let defaultValue: string | number | boolean | undefined = undefined;
     if (current.default !== undefined) {
-      switch (types[0]) {
+      switch (types[0] as string) {
         case 'string':
           if (typeof current.default == 'string') {
             defaultValue = current.default;

--- a/packages/angular_devkit/build_optimizer/package.json
+++ b/packages/angular_devkit/build_optimizer/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "loader-utils": "1.1.0",
     "source-map": "0.5.6",
-    "typescript": "3.0.1",
+    "typescript": "3.1.1",
     "webpack-sources": "1.2.0"
   }
 }

--- a/packages/ngtools/webpack/package.json
+++ b/packages/ngtools/webpack/package.json
@@ -29,13 +29,13 @@
   },
   "peerDependencies": {
     "@angular/compiler-cli": ">=5.0.0 <8.0.0 || ^7.0.0-beta.0",
-    "typescript": ">=2.4.0 < 3.1",
+    "typescript": ">=2.4.0 < 3.2",
     "webpack": "^4.0.0"
   },
   "devDependencies": {
     "@angular/compiler": "^7.0.0-beta.4",
     "@angular/compiler-cli": "^7.0.0-beta.4",
-    "typescript": "~3.0.1",
+    "typescript": "~3.1.1",
     "webpack": "^4.0.0"
   }
 }

--- a/packages/schematics/angular/package.json
+++ b/packages/schematics/angular/package.json
@@ -11,6 +11,6 @@
   "dependencies": {
     "@angular-devkit/core": "0.0.0",
     "@angular-devkit/schematics": "0.0.0",
-    "typescript": "3.0.1"
+    "typescript": "3.1.1"
   }
 }

--- a/packages/schematics/angular/utility/latest-versions.ts
+++ b/packages/schematics/angular/utility/latest-versions.ts
@@ -8,10 +8,10 @@
 
 export const latestVersions = {
   // These versions should be kept up to date with latest Angular peer dependencies.
-  Angular: '~7.0.0-beta.5',
+  Angular: '~7.0.0-rc.0',
   RxJs: '~6.3.3',
   ZoneJs: '~0.8.26',
-  TypeScript: '~3.0.1',
+  TypeScript: '>=3.1.1 <3.2',
   // The versions below must be manually updated when making a new devkit release.
   DevkitBuildAngular: '~0.9.0-beta.1',
   DevkitBuildNgPackagr: '~0.9.0-beta.1',

--- a/yarn.lock
+++ b/yarn.lock
@@ -7672,13 +7672,9 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.1.tgz#43738f29585d3a87575520a4b93ab6026ef11fdb"
-
-typescript@~3.0.1:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.3.tgz#4853b3e275ecdaa27f78fda46dc273a7eb7fc1c8"
+typescript@3.1.1, typescript@~3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.1.tgz#3362ba9dd1e482ebb2355b02dfe8bcd19a2c7c96"
 
 uglify-es@^3.3.4:
   version "3.3.9"


### PR DESCRIPTION
Use TS 3.1 as Angular now requires it (see https://github.com/angular/angular/pull/26151).

You can find a more simple solution to this in #12415. :warning: this PR embed the commit from this other PR.