### PR TITLE
fix(@angular/cli): `e2e` no longer supports specifying a project name

### DIFF
--- a/packages/angular/cli/commands/e2e.json
+++ b/packages/angular/cli/commands/e2e.json
@@ -11,6 +11,14 @@
 
   "type": "object",
   "properties": {
+    "project": {
+      "type": "string",
+      "description": "The name of the project to build.",
+      "$default": {
+        "$source": "argv",
+        "index": 0
+      }
+    },
     "configuration": {
       "description": "Specify the configuration to use.",
       "type": "string",


### PR DESCRIPTION
Closes: #12417

On master it has been solved already with some other updates