### PR TITLE
fix(@angular-devkit/core): coerce properties when validating

### DIFF
--- a/packages/angular/cli/lib/config/schema.json
+++ b/packages/angular/cli/lib/config/schema.json
@@ -1607,7 +1607,7 @@
             },
             "tsConfig": {
               "description": "The name of the TypeScript configuration file.",
-              "oneOf": [
+              "anyOf": [
                 { "type": "string" },
                 {
                   "type": "array",

--- a/packages/angular_devkit/build_angular/src/tslint/schema.json
+++ b/packages/angular_devkit/build_angular/src/tslint/schema.json
@@ -10,7 +10,7 @@
     },
     "tsConfig": {
       "description": "The name of the TypeScript configuration file.",
-      "oneOf": [
+      "anyOf": [
         { "type": "string" },
         {
           "type": "array",

--- a/packages/angular_devkit/core/src/json/schema/registry.ts
+++ b/packages/angular_devkit/core/src/json/schema/registry.ts
@@ -115,6 +115,7 @@ export class CoreSchemaRegistry implements SchemaRegistry {
       loadSchema: (uri: string) => this._fetch(uri),
       schemaId: 'auto',
       passContext: true,
+      coerceTypes: 'array',
     });
 
     this._ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-04.json'));

--- a/packages/angular_devkit/core/src/json/schema/registry_spec.ts
+++ b/packages/angular_devkit/core/src/json/schema/registry_spec.ts
@@ -433,4 +433,29 @@ describe('CoreSchemaRegistry', () => {
       .toPromise().then(done, done.fail);
   });
 
+  it('coerces properties', done => {
+    const registry = new CoreSchemaRegistry();
+    registry.addPostTransform(addUndefinedDefaults);
+    const data: any = { bool: 'true', num: '10', ary: 'foo' };
+
+    registry
+      .compile({
+        properties: {
+          bool: { type: 'boolean' },
+          ary: { type: 'array' },
+          num: { type: 'number' },
+        },
+      })
+      .pipe(
+        mergeMap(validator => validator(data)),
+        map(result => {
+          expect(result.success).toBe(true);
+          expect(data.bool).toBe(true);
+          expect(data.num).toBe(10);
+          expect(data.ary).toEqual(['foo']);
+        }),
+      )
+      .toPromise().then(done, done.fail);
+  });
+
 });


### PR DESCRIPTION
Closes #12150

> Application of these rules can have some unexpected consequences. Ajv may coerce the same value multiple times (this is why coercion reversibility is required) as needed at different points in the schema. This is particularly evident when using oneOf, which must test all of the subschemas. Ajv will coerce the type for each subschema, possibly resulting in unexpected failure if it can coerce to match more than one of the subschemas. Even if it succeeds, Ajv will not backtrack, so you'll get the type of the final coercion even if that's not the one that allowed the data to pass validation. If possible, structure your schema with anyOf, which won't validate subsequent subschemas as soon as it encounters one subschema that matches.

https://github.com/epoberezkin/ajv/blob/master/COERCION.md