### PR TITLE
 feat(jsonpFunction): allow overriding jsonpFunction for multiple webpack builds on the same pag

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/build-options.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/build-options.ts
@@ -48,6 +48,7 @@ export interface BuildOptions {
   buildOptimizer?: boolean;
   namedChunks?: boolean;
   subresourceIntegrity?: boolean;
+  jsonpFunction?: string;
   serviceWorker?: boolean;
   skipAppShell?: boolean;
   statsJson: boolean;

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/browser.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/browser.ts
@@ -71,7 +71,8 @@ export function getBrowserConfig(wco: WebpackConfigOptions) {
       ],
     },
     output: {
-      crossOriginLoading: buildOptions.subresourceIntegrity ? 'anonymous' : false,
+      jsonpFunction: buildOptions.jsonpFunction ? buildOptions.jsonpFunction : undefined,
+      crossOriginLoading: buildOptions.subresourceIntegrity ? 'anonymous' : false
     },
     optimization: {
       runtimeChunk: 'single',

--- a/packages/angular_devkit/build_angular/src/browser/schema.d.ts
+++ b/packages/angular_devkit/build_angular/src/browser/schema.d.ts
@@ -182,6 +182,12 @@ export interface BrowserBuilderSchema {
   subresourceIntegrity: boolean;
 
   /**
+   * Enables the ability to run multiple instances of webpack runtimes on the same page for loading
+   * on-demand chunks from different builds on the same page.
+   */
+  jsonpFunction?: string;
+
+  /**
    * Generates a service worker config for production builds.
    */
   serviceWorker: boolean;

--- a/packages/angular_devkit/build_angular/src/browser/schema.json
+++ b/packages/angular_devkit/build_angular/src/browser/schema.json
@@ -194,6 +194,10 @@
       "description": "Enables the use of subresource integrity validation.",
       "default": false
     },
+    "jsonpFunction": {
+      "type": "string",
+      "description": "The name of JSONP function for loading on-demand chunks."
+    },
     "serviceWorker": {
       "type": "boolean",
       "description": "Generates a service worker config for production builds.",

--- a/packages/angular_devkit/build_angular/test/browser/webpack_jsonp_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/browser/webpack_jsonp_spec_large.ts
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { runTargetSpec } from '@angular-devkit/architect/testing';
+import { join, normalize, virtualFs } from '@angular-devkit/core';
+import { tap } from 'rxjs/operators';
+import { browserTargetSpec, host } from '../utils';
+
+
+describe('Browser Builder webpack jsonp', () => {
+  const outputPath = normalize('dist');
+
+  beforeEach(done => host.initialize().toPromise().then(done, done.fail));
+  afterEach(done => host.restore().toPromise().then(done, done.fail));
+
+  it('allows overriding the jsonp function', (done) => {
+    host.writeMultipleFiles({
+      'src/my-js-file.js': `console.log(1); export const a = 2;`,
+      'src/main.ts': `import { a } from './my-js-file'; console.log(a);`,
+    });
+
+    const overrides = { outputHashing: 'none', jsonpFunction: 'fooAppWebpackJsonp' };
+
+    runTargetSpec(host, browserTargetSpec, overrides).pipe(
+      tap((buildEvent) => expect(buildEvent.success).toBe(true)),
+      tap(() => {
+        const fileName = join(outputPath, 'main.js');
+        const content = virtualFs.fileBufferToString(host.scopedSync().read(fileName));
+        expect(content).toMatch(/window\["fooAppWebpackJsonp"\]/);
+      }),
+    ).toPromise().then(done, done.fail);
+  });
+
+  it('allows for default webpackJsonp', (done) => {
+    host.writeMultipleFiles({
+      'src/my-js-file.js': `console.log(1); export const a = 2;`,
+      'src/main.ts': `import { a } from './my-js-file'; console.log(a);`,
+    });
+
+    const overrides = { outputHashing: 'none' };
+
+    runTargetSpec(host, browserTargetSpec, overrides).pipe(
+      tap((buildEvent) => expect(buildEvent.success).toBe(true)),
+      tap(() => {
+        const fileName = join(outputPath, 'main.js');
+        const content = virtualFs.fileBufferToString(host.scopedSync().read(fileName));
+        expect(content).toMatch(/window\["webpackJsonp"\]/);
+      }),
+    ).toPromise().then(done, done.fail);
+  });
+});
+


### PR DESCRIPTION
This PR will allow for many code split builds (ex: many angular elements builds) to live on the same page and work correctly without clashing the default webpackJsonp global.