### PR TITLE
fix(@angular-devkit/build-angular): `ng test` without `reporters` no …

### DIFF
--- a/packages/angular_devkit/build_angular/src/karma/index.ts
+++ b/packages/angular_devkit/build_angular/src/karma/index.ts
@@ -73,9 +73,13 @@ export class KarmaBuilder implements Builder<KarmaBuilderSchema> {
 
         if (options.reporters) {
           // Split along commas to make it more natural, and remove empty strings.
-          karmaOptions.reporters = options.reporters
+          const reporters = options.reporters
             .reduce<string[]>((acc, curr) => acc.concat(curr.split(/,/)), [])
             .filter(x => !!x);
+
+          if (reporters.length > 0) {
+            karmaOptions.reporters = reporters;
+          }
         }
 
         const sourceRoot = builderConfig.sourceRoot && resolve(root, builderConfig.sourceRoot);


### PR DESCRIPTION
…longer print error

Closes #12455


Karma is not using our logger yet so it's not easy to create a spec large