### PR TITLE
fix(@schematics/angular): use proper project root for e2e

### DIFF
--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -279,7 +279,7 @@ export default function (options: ApplicationOptions): Rule {
       name: `${options.name}-e2e`,
       relatedAppName: options.name,
       rootSelector: appRootSelector,
-      projectRoot: newProjectRoot ? `${newProjectRoot}/e2e` : 'e2e',
+      projectRoot: newProjectRoot ? `${newProjectRoot}/${options.name}-e2e` : 'e2e',
     };
 
     return chain([


### PR DESCRIPTION
When creating an application, the project root was always "projects/e2e". This
is undesired as it leads to conflicts when creating another app.

Fix #12491.