### PR TITLE
Change npm install to yarn to install dependencies

### DIFF
--- a/packages/angular/cli/README.md
+++ b/packages/angular/cli/README.md
@@ -162,7 +162,7 @@ You can find more details about changes between versions in [the Releases tab on
 
 ```bash
 git clone https://github.com/angular/angular-cli.git
-npm install
+yarn
 npm run build
 cd dist/@angular/cli
 npm link

--- a/yarn.lock
+++ b/yarn.lock
@@ -7541,6 +7541,7 @@ scss-tokenizer@^0.2.3:
 seedrandom@^2.4.4:
   version "2.4.4"
   resolved "https://registry.yarnpkg.com/seedrandom/-/seedrandom-2.4.4.tgz#b25ea98632c73e45f58b77cfaa931678df01f9ba"
+  integrity sha512-9A+PDmgm+2du77B5i0Ip2cxOqqHjgNxnBgglxLcX78A2D6c2rTo61z4jnVABpF4cKeDMDG+cmXXvdnqse2VqMA==
 
 select-hose@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
On cloning angular-cli and running `npm install`
I got the error message :
```
 npm install                                                                                                  angular-cli/git/master 

> @angular/devkit-repo@0.0.0 preinstall /home/rohit/Projects/angular-cli
> node ./tools/yarn/check-yarn.js

/home/rohit/Projects/angular-cli/tools/yarn/check-yarn.js:12
  throw new Error(
  ^

Error: Please use Yarn instead of NPM to install dependencies. See: https://yarnpkg.com/lang/en/docs/install/
    at Object.<anonymous> (/home/rohit/Projects/angular-cli/tools/yarn/check-yarn.js:12:9)
    at Module._compile (internal/modules/cjs/loader.js:689:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
    at Module.load (internal/modules/cjs/loader.js:599:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
    at Function.Module._load (internal/modules/cjs/loader.js:530:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:742:12)
    at startup (internal/bootstrap/node.js:279:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:752:3)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! @angular/devkit-repo@0.0.0 preinstall: `node ./tools/yarn/check-yarn.js`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the @angular/devkit-repo@0.0.0 preinstall script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/rohit/.npm/_logs/2018-10-05T18_18_04_521Z-debug.log
```

The solution was to instead run `yarn`.