### PR TITLE
refactor(@angular/schematics): Add an extra option to not use dasheri…

### DIFF
--- a/packages/schematics/angular/utility/find-module.ts
+++ b/packages/schematics/angular/utility/find-module.ts
@@ -25,6 +25,7 @@ export interface ModuleOptions {
   skipImport?: boolean;
   moduleExt?: string;
   routingModuleExt?: string;
+  nameFormatter?: (str: string) => string;
 }
 
 const MODULE_EXT = '.module.ts';
@@ -42,8 +43,9 @@ export function findModuleFromOptions(host: Tree, options: ModuleOptions): Path 
   const routingModuleExt = options.routingModuleExt || ROUTING_MODULE_EXT;
 
   if (!options.module) {
+    options.nameFormatter = options.nameFormatter || strings.dasherize;
     const pathToCheck = (options.path || '')
-      + (options.flat ? '' : '/' + strings.dasherize(options.name));
+      + (options.flat ? '' : '/' + options.nameFormatter(options.name));
 
     return normalize(findModule(host, pathToCheck, moduleExt, routingModuleExt));
   } else {

--- a/packages/schematics/angular/utility/find-module_spec.ts
+++ b/packages/schematics/angular/utility/find-module_spec.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import { Path } from '@angular-devkit/core';
+import { Path, strings } from '@angular-devkit/core';
 import { EmptyTree, Tree } from '@angular-devkit/schematics';
 import { ModuleOptions, findModule, findModuleFromOptions } from './find-module';
 
@@ -109,6 +109,14 @@ describe('find-module', () => {
       options.path = '/projects/my-proj/src';
       const modPath = findModuleFromOptions(tree, options);
       expect(modPath).toEqual('/projects/my-proj/src/app.module.ts' as Path);
+    });
+
+    it('should find a module if nameFormatter is provided', () => {
+      tree.create('/projects/my-proj/src/app_test.module.ts', '');
+      options.path = '/projects/my-proj/src';
+      options.nameFormatter = strings.underscore;
+      const modPath = findModuleFromOptions(tree, options);
+      expect(modPath).toEqual('/projects/my-proj/src/app_test.module.ts' as Path);
     });
 
     it('should find a module in a sub dir', () => {


### PR DESCRIPTION
…ze in findModuleFromOptions

In Google we prefer underscore instead of dashes. So this option is useful there.