### PR TITLE
fix(@ngtools/webpack): replace resources should effect only class dec…

### DIFF
--- a/packages/ngtools/webpack/src/angular_compiler_plugin.ts
+++ b/packages/ngtools/webpack/src/angular_compiler_plugin.ts
@@ -849,7 +849,7 @@ export class AngularCompilerPlugin {
 
     if (this._JitMode) {
       // Replace resources in JIT.
-      this._transformers.push(replaceResources(isAppPath));
+      this._transformers.push(replaceResources(isAppPath, getTypeChecker));
     } else {
       // Remove unneeded angular decorators.
       this._transformers.push(removeDecorators(isAppPath, getTypeChecker));
@@ -1054,9 +1054,7 @@ export class AngularCompilerPlugin {
       .filter(x => x);
 
     const resourceImports = findResources(sourceFile)
-      .map((resourceReplacement) => resourceReplacement.resourcePaths)
-      .reduce((prev, curr) => prev.concat(curr), [])
-      .map((resourcePath) => resolve(dirname(resolvedFileName), normalize(resourcePath)));
+      .map(resourcePath => resolve(dirname(resolvedFileName), normalize(resourcePath)));
 
     // These paths are meant to be used by the loader so we must denormalize them.
     const uniqueDependencies = new Set([

--- a/packages/ngtools/webpack/src/transformers/find_resources.ts
+++ b/packages/ngtools/webpack/src/transformers/find_resources.ts
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import * as ts from 'typescript';
+import { collectDeepNodes } from './ast_helpers';
+import { getResourceUrl } from './replace_resources';
+
+export function findResources(sourceFile: ts.SourceFile): string[] {
+  const resources: string[] = [];
+  const decorators = collectDeepNodes<ts.Decorator>(sourceFile, ts.SyntaxKind.Decorator);
+
+  for (const node of decorators) {
+    if (!ts.isCallExpression(node.expression)) {
+      continue;
+    }
+
+    const decoratorFactory = node.expression;
+    const args = decoratorFactory.arguments;
+    if (args.length !== 1 || !ts.isObjectLiteralExpression(args[0])) {
+      // Unsupported component metadata
+      continue;
+    }
+
+    ts.visitNodes(
+      (args[0] as ts.ObjectLiteralExpression).properties,
+      (node: ts.ObjectLiteralElementLike) => {
+        if (!ts.isPropertyAssignment(node) || ts.isComputedPropertyName(node.name)) {
+          return node;
+        }
+
+        const name = node.name.text;
+        switch (name) {
+          case 'templateUrl':
+            const url = getResourceUrl(node.initializer);
+
+            if (url) {
+              resources.push(url);
+            }
+            break;
+
+          case 'styleUrls':
+            if (!ts.isArrayLiteralExpression(node.initializer)) {
+              return node;
+            }
+
+            ts.visitNodes(node.initializer.elements, (node: ts.Expression) => {
+              const url = getResourceUrl(node);
+
+              if (url) {
+                resources.push(url);
+              }
+
+              return node;
+            });
+            break;
+        }
+
+        return node;
+      },
+    );
+  }
+
+  return resources;
+}

--- a/packages/ngtools/webpack/src/transformers/find_resources_spec.ts
+++ b/packages/ngtools/webpack/src/transformers/find_resources_spec.ts
@@ -1,0 +1,49 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { tags } from '@angular-devkit/core';  // tslint:disable-line:no-implicit-dependencies
+import * as ts from 'typescript';
+import { findResources } from './find_resources';
+
+
+describe('@ngtools/webpack transformers', () => {
+  describe('find_resources', () => {
+    it('should return resources', () => {
+      const input = tags.stripIndent`
+        import { Component } from '@angular/core';
+
+        @Component({
+          selector: 'app-root',
+          templateUrl: './app.component.html',
+          styleUrls: ['./app.component.css', './app.component.2.css']
+        })
+        export class AppComponent {
+          title = 'app';
+        }
+      `;
+
+      const result = findResources(ts.createSourceFile('temp.ts', input, ts.ScriptTarget.ES2015));
+      expect(result).toEqual([
+        './app.component.html',
+        './app.component.css',
+        './app.component.2.css',
+      ]);
+    });
+
+    it('should not return resources if they are not in decorator', () => {
+      const input = tags.stripIndent`
+        const foo = {
+          templateUrl: './app.component.html',
+          styleUrls: ['./app.component.css', './app.component.2.css']
+        }
+      `;
+
+      const result = findResources(ts.createSourceFile('temp.ts', input, ts.ScriptTarget.ES2015));
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/packages/ngtools/webpack/src/transformers/index.ts
+++ b/packages/ngtools/webpack/src/transformers/index.ts
@@ -17,3 +17,4 @@ export * from './export_lazy_module_map';
 export * from './register_locale_data';
 export * from './replace_resources';
 export * from './remove_decorators';
+export * from './find_resources';

--- a/packages/ngtools/webpack/src/transformers/replace_resources_spec.ts
+++ b/packages/ngtools/webpack/src/transformers/replace_resources_spec.ts
@@ -6,11 +6,21 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import { tags } from '@angular-devkit/core';  // tslint:disable-line:no-implicit-dependencies
-import { transformTypescript } from './ast_helpers';
+import { createTypescriptContext, transformTypescript } from './ast_helpers';
 import { replaceResources } from './replace_resources';
 
+function transform(input: string, shouldTransform = true) {
+  const { program } = createTypescriptContext(input);
+  const getTypeChecker = () => program.getTypeChecker();
+  const transformer = replaceResources(() => shouldTransform, getTypeChecker);
+
+  return transformTypescript(input, [transformer]);
+}
+
+// tslint:disable-next-line:no-big-function
 describe('@ngtools/webpack transformers', () => {
-  describe('replace_resources', () => {
+  // tslint:disable-next-line:no-big-function
+  describe('find_resources', () => {
     it('should replace resources', () => {
       const input = tags.stripIndent`
         import { Component } from '@angular/core';
@@ -42,9 +52,43 @@ describe('@ngtools/webpack transformers', () => {
         export { AppComponent };
       `;
 
-      const transformer = replaceResources(() => true);
-      const result = transformTypescript(input, [transformer]);
+      const result = transform(input);
+      expect(tags.oneLine`${result}`).toEqual(tags.oneLine`${output}`);
+    });
 
+    it('should merge styleUrls with styles', () => {
+      const input = tags.stripIndent`
+        import { Component } from '@angular/core';
+
+        @Component({
+          selector: 'app-root',
+          templateUrl: './app.component.html',
+          styles: ['a { color: red }'],
+          styleUrls: ['./app.component.css'],
+        })
+        export class AppComponent {
+          title = 'app';
+        }
+      `;
+      const output = tags.stripIndent`
+        import * as tslib_1 from "tslib";
+        import { Component } from '@angular/core';
+        let AppComponent = class AppComponent {
+            constructor() {
+                this.title = 'app';
+            }
+        };
+        AppComponent = tslib_1.__decorate([
+            Component({
+                selector: 'app-root',
+                template: require("./app.component.html"),
+                styles: ["a { color: red }", require("./app.component.css")]
+            })
+        ], AppComponent);
+        export { AppComponent };
+      `;
+
+      const result = transform(input);
       expect(tags.oneLine`${result}`).toEqual(tags.oneLine`${output}`);
     });
 
@@ -79,9 +123,177 @@ describe('@ngtools/webpack transformers', () => {
         export { AppComponent };
       `;
 
-      const transformer = replaceResources(() => true);
+      const result = transform(input);
+      expect(tags.oneLine`${result}`).toEqual(tags.oneLine`${output}`);
+    });
+
+    it('should replace resources if Component decorator is aliased', () => {
+      const input = tags.stripIndent`
+        import { Component as NgComponent } from '@angular/core';
+
+        @NgComponent({
+          selector: 'app-root',
+          templateUrl: './app.component.html',
+          styleUrls: ['./app.component.css', './app.component.2.css']
+        })
+        export class AppComponent {
+          title = 'app';
+        }
+      `;
+      const output = tags.stripIndent`
+        import * as tslib_1 from "tslib";
+        import { Component as NgComponent } from '@angular/core';
+        let AppComponent = class AppComponent {
+            constructor() {
+                this.title = 'app';
+            }
+        };
+        AppComponent = tslib_1.__decorate([
+          NgComponent({
+                selector: 'app-root',
+                template: require("./app.component.html"),
+                styles: [require("./app.component.css"), require("./app.component.2.css")]
+            })
+        ], AppComponent);
+        export { AppComponent };
+      `;
+
+      const { program } = createTypescriptContext(input);
+      const getTypeChecker = () => program.getTypeChecker();
+      const transformer = replaceResources(() => true, getTypeChecker);
       const result = transformTypescript(input, [transformer]);
 
+      expect(tags.oneLine`${result}`).toEqual(tags.oneLine`${output}`);
+    });
+
+    it('should replace resources if Angular Core import is namespaced', () => {
+      const input = tags.stripIndent`
+        import * as ng from '@angular/core';
+
+        @ng.Component({
+          selector: 'app-root',
+          templateUrl: './app.component.html',
+          styleUrls: ['./app.component.css', './app.component.2.css']
+        })
+        export class AppComponent {
+          title = 'app';
+        }
+      `;
+      const output = tags.stripIndent`
+        import * as tslib_1 from "tslib";
+        import * as ng from '@angular/core';
+        let AppComponent = class AppComponent {
+            constructor() {
+                this.title = 'app';
+            }
+        };
+        AppComponent = tslib_1.__decorate([
+          ng.Component({
+                selector: 'app-root',
+                template: require("./app.component.html"),
+                styles: [require("./app.component.css"), require("./app.component.2.css")]
+            })
+        ], AppComponent);
+        export { AppComponent };
+      `;
+
+      const result = transform(input);
+      expect(tags.oneLine`${result}`).toEqual(tags.oneLine`${output}`);
+    });
+
+    it('should not replace resources if not in Component decorator', () => {
+      const input = tags.stripIndent`
+        import { Component } from '@angular/core';
+
+        @Component({
+          selector: 'app-root',
+          templateUrl: './app.component.html',
+          styleUrls: ['./app.component.css']
+        })
+        export class AppComponent {
+          obj = [
+            {
+              'labels': 'Content',
+              'templateUrl': 'content.html'
+            }
+          ];
+        }
+      `;
+
+      const output = tags.stripIndent`
+        import * as tslib_1 from "tslib";
+        import { Component } from '@angular/core';
+
+        let AppComponent = class AppComponent {
+          constructor() {
+            this.obj = [
+              {
+                'labels': 'Content',
+                'templateUrl': 'content.html'
+              }
+            ];
+          }
+        };
+
+        AppComponent = tslib_1.__decorate([
+            Component({
+                selector: 'app-root',
+                template: require("./app.component.html"),
+                styles: [require("./app.component.css")]
+            })
+        ], AppComponent);
+        export { AppComponent };
+      `;
+
+      const result = transform(input);
+      expect(tags.oneLine`${result}`).toEqual(tags.oneLine`${output}`);
+    });
+
+    it('should not replace resources if not in an NG Component decorator', () => {
+      const input = tags.stripIndent`
+        import { Component } from 'foo';
+
+        @Component({
+          selector: 'app-root',
+          templateUrl: './app.component.html',
+          styleUrls: ['./app.component.css']
+        })
+        export class AppComponent {
+          obj = [
+            {
+              'labels': 'Content',
+              'templateUrl': 'content.html'
+            }
+          ];
+        }
+      `;
+
+      const output = tags.stripIndent`
+        import * as tslib_1 from "tslib";
+        import { Component } from 'foo';
+
+        let AppComponent = class AppComponent {
+          constructor() {
+            this.obj = [
+              {
+                'labels': 'Content',
+                'templateUrl': 'content.html'
+              }
+            ];
+          }
+        };
+
+        AppComponent = tslib_1.__decorate([
+            Component({
+                selector: 'app-root',
+                templateUrl: './app.component.html',
+                styleUrls: ['./app.component.css']
+            })
+        ], AppComponent);
+        export { AppComponent };
+      `;
+
+      const result = transform(input);
       expect(tags.oneLine`${result}`).toEqual(tags.oneLine`${output}`);
     });
 
@@ -116,9 +328,7 @@ describe('@ngtools/webpack transformers', () => {
         export { AppComponent };
       `;
 
-      const transformer = replaceResources(() => false);
-      const result = transformTypescript(input, [transformer]);
-
+      const result = transform(input, false);
       expect(tags.oneLine`${result}`).toEqual(tags.oneLine`${output}`);
     });
   });


### PR DESCRIPTION
Replace resources should effect only class decorators

At the moment we are processing all property assignments in object literals irrespective if they are in a decorator or not. With this change we will process only property assignments found under a class decorator.


Fixes #12488, Fixes #6007, Fixes: #6498 and Fixes: #8295