### PR TITLE
fix(@angular-devkit/build-angular): don't override missing options in…

### DIFF
--- a/packages/angular_devkit/build_angular/src/protractor/index.ts
+++ b/packages/angular_devkit/build_angular/src/protractor/index.ts
@@ -58,8 +58,11 @@ export class ProtractorBuilder implements Builder<ProtractorBuilderOptions> {
   private _startDevServer(options: ProtractorBuilderOptions) {
     const architect = this.context.architect;
     const [project, targetName, configuration] = (options.devServerTarget as string).split(':');
-    // Override browser build watch setting.
-    const overrides = { watch: false, host: options.host, port: options.port };
+    // Override dev server watch setting.
+    const overrides: Partial<DevServerBuilderOptions> = { watch: false };
+    // Also override the port and host if they are defined in protractor options.
+    if (options.host !== undefined) { overrides.host = options.host; }
+    if (options.port !== undefined) { overrides.port = options.port; }
     const targetSpec = { project, target: targetName, configuration, overrides };
     const builderConfig = architect.getBuilderConfiguration<DevServerBuilderOptions>(targetSpec);
     let devServerDescription: BuilderDescription;


### PR DESCRIPTION
… protractor

Fix #10697