### PR TITLE
fix(@angular-devkit/build-angular): passing `specs` to protractor builder has no effect

### DIFF
--- a/packages/angular_devkit/build_angular/src/protractor/index.ts
+++ b/packages/angular_devkit/build_angular/src/protractor/index.ts
@@ -128,10 +128,10 @@ export class ProtractorBuilder implements Builder<ProtractorBuilderOptions> {
   }
 
   private _runProtractor(root: Path, options: ProtractorBuilderOptions): Observable<BuildEvent> {
-    const additionalProtractorConfig = {
+    const additionalProtractorConfig: Partial<ProtractorBuilderOptions> = {
       elementExplorer: options.elementExplorer,
       baseUrl: options.baseUrl,
-      spec: options.specs.length ? options.specs : undefined,
+      specs: options.specs.length ? options.specs : undefined,
       suite: options.suite,
     };
 

--- a/packages/angular_devkit/build_angular/test/protractor/works_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/protractor/works_spec_large.ts
@@ -32,9 +32,9 @@ describe('Protractor Builder', () => {
 
   it('overrides protractor specs', (done) => {
     host.scopedSync().rename(normalize('./e2e/app.e2e-spec.ts'),
-      normalize('./e2e/renamed-app.e2e-spec.ts'));
+      normalize('./e2e/renamed-app.e2e.spec.ts'));
 
-    const overrides = { specs: ['./e2e/renamed-app.e2e-spec.ts'] };
+    const overrides = { specs: ['./e2e/renamed-app.e2e.spec.ts'] };
 
     runTargetSpec(host, protractorTargetSpec, overrides).pipe(
       retry(3),


### PR DESCRIPTION


Fixes #12510