### PR TITLE
fix(@schematics/angular): codeCoverage exclude is not being migrated

### DIFF
--- a/packages/schematics/angular/migrations/update-6/index.ts
+++ b/packages/schematics/angular/migrations/update-6/index.ts
@@ -472,7 +472,16 @@ function extractProjectsConfig(
 
       if (app.testTsconfig) {
           testOptions.tsConfig = appRoot + '/' + app.testTsconfig;
-        }
+      }
+
+      const codeCoverageExclude = config.test
+        && config.test.codeCoverage
+        && config.test.codeCoverage.exclude;
+
+      if (codeCoverageExclude) {
+        testOptions.codeCoverageExclude = codeCoverageExclude;
+      }
+
       testOptions.scripts = (app.scripts || []).map(_extraEntryMapper);
       testOptions.styles = (app.styles || []).map(_extraEntryMapper);
       testOptions.assets = (app.assets || []).map(_mapAssets).filter(x => !!x);

--- a/packages/schematics/angular/migrations/update-6/index_spec.ts
+++ b/packages/schematics/angular/migrations/update-6/index_spec.ts
@@ -93,6 +93,11 @@ describe('Migration to v6', () => {
         karma: {
           config: './karma.conf.js',
         },
+        codeCoverage: {
+          exclude: [
+            './excluded.spec.ts',
+          ],
+        },
       },
       defaults: {
         styleExt: 'css',
@@ -657,6 +662,7 @@ describe('Migration to v6', () => {
         expect(test.options.polyfills).toEqual('src/polyfills.ts');
         expect(test.options.tsConfig).toEqual('src/tsconfig.spec.json');
         expect(test.options.karmaConfig).toEqual('./karma.conf.js');
+        expect(test.options.codeCoverageExclude).toEqual(['./excluded.spec.ts']);
         expect(test.options.scripts).toEqual([]);
         expect(test.options.styles).toEqual(['src/styles.css']);
         expect(test.options.assets).toEqual([


### PR DESCRIPTION
Fixes #10936