### PR TITLE
refactor(@angular/cli): remove rxjs direct dependency

### DIFF
--- a/packages/angular/cli/BUILD
+++ b/packages/angular/cli/BUILD
@@ -28,8 +28,6 @@ ts_library(
         "//packages/angular_devkit/core:node",
         "//packages/angular_devkit/schematics",
         "//packages/angular_devkit/schematics:tools",
-        "@rxjs",
-        "@rxjs//operators",
         # @typings: es2017.object
         # @typings: inquirer
         # @typings: node

--- a/packages/angular/cli/lib/cli/index.ts
+++ b/packages/angular/cli/lib/cli/index.ts
@@ -7,7 +7,6 @@
  */
 
 import { logging, terminal } from '@angular-devkit/core';
-import { filter } from 'rxjs/operators';
 import { runCommand } from '../../models/command-runner';
 import { getWorkspaceRaw } from '../../utilities/config';
 import { getWorkspaceDetails } from '../../utilities/project';
@@ -72,11 +71,12 @@ export default async function(options: { testing?: boolean, cliArgs: string[] })
 // Initialize logging.
 function initializeLogging(logger: logging.Logger) {
   return logger
-    .pipe(filter(entry => (entry.level != 'debug')))
     .subscribe(entry => {
       let color = (x: string) => terminal.dim(terminal.white(x));
       let output = process.stdout;
       switch (entry.level) {
+        case 'debug':
+          return;
         case 'info':
           color = terminal.white;
           break;

--- a/packages/angular/cli/models/architect-command.ts
+++ b/packages/angular/cli/models/architect-command.ts
@@ -7,14 +7,11 @@
  */
 import {
   Architect,
-  BuildEvent,
   BuilderConfiguration,
   TargetSpecifier,
 } from '@angular-devkit/architect';
 import { experimental, json, schema, tags } from '@angular-devkit/core';
 import { NodeJsSyncHost, createConsoleLogger } from '@angular-devkit/core/node';
-import { from } from 'rxjs';
-import { concatMap, map, tap, toArray } from 'rxjs/operators';
 import { parseJsonSchemaToOptions } from '../utilities/json-schema';
 import { BaseCommandOptions, Command } from './command';
 import { Arguments } from './interface';
@@ -49,7 +46,7 @@ export abstract class ArchitectCommand<
     this._registry = new json.schema.CoreSchemaRegistry();
     this._registry.addPostTransform(json.schema.transforms.addUndefinedDefaults);
 
-    await this._loadWorkspaceAndArchitect().toPromise();
+    await this._loadWorkspaceAndArchitect();
 
     if (!options.project && this.target) {
       const projectNames = this.getProjectNamesByTarget(this.target);
@@ -153,9 +150,9 @@ export abstract class ArchitectCommand<
     }
     const realBuilderConf = this._architect.getBuilderConfiguration({ ...targetSpec, overrides });
 
-    return this._architect.run(realBuilderConf, { logger: this._logger }).pipe(
-      map((buildEvent: BuildEvent) => buildEvent.success ? 0 : 1),
-    ).toPromise();
+    const result = await this._architect.run(realBuilderConf, { logger: this._logger }).toPromise();
+
+    return result.success ? 0 : 1;
   }
 
   protected async runArchitectTarget(
@@ -168,12 +165,12 @@ export abstract class ArchitectCommand<
       if (!targetSpec.project && this.target) {
         // This runs each target sequentially.
         // Running them in parallel would jumble the log messages.
-        return await from(this.getProjectNamesByTarget(this.target)).pipe(
-          concatMap(project => from(this.runSingleTarget({ ...targetSpec, project }, extra))),
-          toArray(),
-          map(results => results.every(res => res === 0) ? 0 : 1),
-        )
-        .toPromise();
+        let result = 0;
+        for (const project of this.getProjectNamesByTarget(this.target)) {
+          result |= await this.runSingleTarget({ ...targetSpec, project }, extra);
+        }
+
+        return result;
       } else {
         return await this.runSingleTarget(targetSpec, extra);
       }
@@ -227,16 +224,13 @@ export abstract class ArchitectCommand<
     }
   }
 
-  private _loadWorkspaceAndArchitect() {
+  private async _loadWorkspaceAndArchitect() {
     const workspaceLoader = new WorkspaceLoader(this._host);
 
-    return workspaceLoader.loadWorkspace(this.workspace.root).pipe(
-      tap((workspace: experimental.workspace.Workspace) => this._workspace = workspace),
-      concatMap((workspace: experimental.workspace.Workspace) => {
-        return new Architect(workspace).loadArchitect();
-      }),
-      tap((architect: Architect) => this._architect = architect),
-    );
+    const workspace = await workspaceLoader.loadWorkspace(this.workspace.root);
+
+    this._workspace = workspace;
+    this._architect = await new Architect(workspace).loadArchitect().toPromise();
   }
 
   private _makeTargetSpecifier(commandOptions: ArchitectCommandOptions): TargetSpecifier {

--- a/packages/angular/cli/models/command-runner.ts
+++ b/packages/angular/cli/models/command-runner.ts
@@ -16,7 +16,6 @@ import {
 } from '@angular-devkit/core';
 import { readFileSync } from 'fs';
 import { dirname, join, resolve } from 'path';
-import { of } from 'rxjs';
 import { findUp } from '../utilities/find-up';
 import { parseJsonSchemaToCommandDescription } from '../utilities/json-schema';
 import { Command } from './command';
@@ -76,7 +75,7 @@ export async function runCommand(
     if (uri.startsWith('ng-cli://')) {
       const content = readFileSync(join(__dirname, '..', uri.substr('ng-cli://'.length)), 'utf-8');
 
-      return of(JSON.parse(content));
+      return Promise.resolve(JSON.parse(content));
     } else {
       return null;
     }

--- a/packages/angular/cli/models/workspace-loader.ts
+++ b/packages/angular/cli/models/workspace-loader.ts
@@ -11,20 +11,13 @@ import {
   basename,
   dirname,
   experimental,
-  join,
   normalize,
   virtualFs,
 } from '@angular-devkit/core';
-import * as fs from 'fs';
-import { homedir } from 'os';
-import { Observable, of } from 'rxjs';
-import { concatMap, tap } from 'rxjs/operators';
 import { findUp } from '../utilities/find-up';
 
 
-// TODO: error out instead of returning null when workspace cannot be found.
 export class WorkspaceLoader {
-  private _workspaceCacheMap = new Map<string, experimental.workspace.Workspace>();
   // TODO: add remaining fallbacks.
   private _configFileNames = [
     normalize('.angular.json'),
@@ -32,20 +25,12 @@ export class WorkspaceLoader {
   ];
   constructor(private _host: virtualFs.Host) { }
 
-  loadGlobalWorkspace(): Observable<experimental.workspace.Workspace | null> {
-    return this._getGlobalWorkspaceFilePath().pipe(
-      concatMap(globalWorkspacePath => this._loadWorkspaceFromPath(globalWorkspacePath)),
-    );
-  }
-
-  loadWorkspace(projectPath?: string): Observable<experimental.workspace.Workspace | null> {
-    return this._getProjectWorkspaceFilePath(projectPath).pipe(
-      concatMap(globalWorkspacePath => this._loadWorkspaceFromPath(globalWorkspacePath)),
-    );
+  loadWorkspace(projectPath?: string): Promise<experimental.workspace.Workspace> {
+    return this._loadWorkspaceFromPath(this._getProjectWorkspaceFilePath(projectPath));
   }
 
   // TODO: do this with the host instead of fs.
-  private _getProjectWorkspaceFilePath(projectPath?: string): Observable<Path | null> {
+  private _getProjectWorkspaceFilePath(projectPath?: string): Path {
     // Find the workspace file, either where specified, in the Angular CLI project
     // (if it's in node_modules) or from the current process.
     const workspaceFilePath = (projectPath && findUp(this._configFileNames, projectPath))
@@ -53,40 +38,17 @@ export class WorkspaceLoader {
       || findUp(this._configFileNames, __dirname);
 
     if (workspaceFilePath) {
-      return of(normalize(workspaceFilePath));
+      return normalize(workspaceFilePath);
     } else {
       throw new Error(`Local workspace file ('angular.json') could not be found.`);
     }
   }
 
-  // TODO: do this with the host instead of fs.
-  private _getGlobalWorkspaceFilePath(): Observable<Path | null> {
-    for (const fileName of this._configFileNames) {
-      const workspaceFilePath = join(normalize(homedir()), fileName);
-
-      if (fs.existsSync(workspaceFilePath)) {
-        return of(normalize(workspaceFilePath));
-      }
-    }
-
-    return of(null);
-  }
-
-  private _loadWorkspaceFromPath(workspacePath: Path | null) {
-    if (!workspacePath) {
-      return of(null);
-    }
-
-    if (this._workspaceCacheMap.has(workspacePath)) {
-      return of(this._workspaceCacheMap.get(workspacePath) || null);
-    }
-
+  private _loadWorkspaceFromPath(workspacePath: Path) {
     const workspaceRoot = dirname(workspacePath);
     const workspaceFileName = basename(workspacePath);
     const workspace = new experimental.workspace.Workspace(workspaceRoot, this._host);
 
-    return workspace.loadWorkspaceFromHost(workspaceFileName).pipe(
-      tap(workspace => this._workspaceCacheMap.set(workspacePath, workspace)),
-    );
+    return workspace.loadWorkspaceFromHost(workspaceFileName).toPromise();
   }
 }

--- a/packages/angular/cli/package.json
+++ b/packages/angular/cli/package.json
@@ -33,7 +33,6 @@
     "@schematics/update": "0.0.0",
     "inquirer": "6.2.0",
     "opn": "5.3.0",
-    "rxjs": "6.3.3",
     "semver": "5.5.1",
     "symbol-observable": "1.2.0"
   },

--- a/packages/angular_devkit/core/src/json/schema/registry.ts
+++ b/packages/angular_devkit/core/src/json/schema/registry.ts
@@ -43,7 +43,8 @@ interface AjvRefMap {
   schema: JsonObject;
 }
 
-export type UriHandler = (uri: string) => Observable<JsonObject> | null | undefined;
+export type UriHandler = (uri: string) =>
+  Observable<JsonObject> | Promise<JsonObject> | null | undefined;
 
 export class SchemaValidationException extends BaseException {
   public readonly errors: SchemaValidatorError[];
@@ -133,7 +134,7 @@ export class CoreSchemaRegistry implements SchemaRegistry {
       const handler = maybeHandler(uri);
       if (handler) {
         // The AJV API only understands Promises.
-        return handler.pipe(
+        return from(handler).pipe(
           tap(json => this._uriCache.set(uri, json)),
         ).toPromise();
       }


### PR DESCRIPTION
It was barely being used and in most cases where it was being used, the observables were being converted into promises anyway.