### PR TITLE
Enable the ability to configure WebpackDevServer.Configuration.headers

### DIFF
--- a/packages/angular/cli/lib/config/schema.json
+++ b/packages/angular/cli/lib/config/schema.json
@@ -967,6 +967,11 @@
               "description": "Host to listen on.",
               "default": "localhost"
             },
+            "headers": {
+              "type": "object",
+              "default": "{ 'Access-Control-Allow-Origin': '*' }",
+              "description": "Http headers in format of keys-values object. Keys are headers names. Values are headers values."
+            },
             "proxyConfig": {
               "type": "string",
               "description": "Proxy configuration file."

--- a/packages/angular_devkit/build_angular/src/dev-server/index.ts
+++ b/packages/angular_devkit/build_angular/src/dev-server/index.ts
@@ -32,6 +32,7 @@ export interface DevServerBuilderOptions {
   browserTarget: string;
   port: number;
   host: string;
+  headers?: { [key: string]: string; };
   proxyConfig?: string;
   ssl: boolean;
   sslKey?: string;
@@ -207,7 +208,7 @@ export class DevServerBuilder implements Builder<DevServerBuilderOptions> {
     const config: WebpackDevServer.Configuration = {
       host: options.host,
       port: options.port,
-      headers: { 'Access-Control-Allow-Origin': '*' },
+      headers: options.headers ? options.headers : { 'Access-Control-Allow-Origin': '*' },
       historyApiFallback: {
         index: `${servePath}/${path.basename(browserOptions.index)}`,
         disableDotRule: true,


### PR DESCRIPTION
Enable the ability to configure WebpackDevServer.Configuration.headers from angular.json.

I, personally, need it for easier CORS configuring of my angular-ionic application with third-party API.
I believe there are another configuration possibilities with this configuration available.