### PR TITLE
Fix: Updated module generation @NgModule order (issue #12509)

### DIFF
--- a/packages/schematics/angular/module/files/__name@dasherize@if-flat__/__name@dasherize__.module.ts
+++ b/packages/schematics/angular/module/files/__name@dasherize@if-flat__/__name@dasherize__.module.ts
@@ -4,10 +4,10 @@ import { CommonModule } from '@angular/common';<% } %><% if (routing) { %>
 import { <%= classify(name) %>RoutingModule } from './<%= dasherize(name) %>-routing.module';<% } %>
 
 @NgModule({
+  declarations: [],
   imports: [<% if (commonModule) { %>
     CommonModule<%= routing ? ',' : '' %><% } %><% if (routing) { %>
     <%= classify(name) %>RoutingModule<% } %>
-  ],
-  declarations: []
+  ]
 })
 export class <%= classify(name) %>Module { }


### PR DESCRIPTION
Moved declarations prior to that of imports so that it matches original CLI module generation order. In reference to issue, [#12509](https://github.com/angular/angular-cli/issues/12509). (https://github.com/angular/angular-cli/blob/master/packages/schematics/angular/application/other-files/app.module.ts)