### PR TITLE
feat(@schematics/angular): add `text-summary` to code coverage reporters

### DIFF
--- a/packages/schematics/angular/application/files/root/karma.conf.js
+++ b/packages/schematics/angular/application/files/root/karma.conf.js
@@ -17,7 +17,7 @@ module.exports = function (config) {
     },
     coverageIstanbulReporter: {
       dir: require('path').join(__dirname, '<%= relativePathToWorkspaceRoot %>/coverage'),
-      reports: ['html', 'lcovonly'],
+      reports: ['html', 'lcovonly', 'text-summary'],
       fixWebpackSourcePaths: true
     },
     reporters: ['progress', 'kjhtml'],

--- a/tests/legacy-cli/e2e/tests/misc/coverage.ts
+++ b/tests/legacy-cli/e2e/tests/misc/coverage.ts
@@ -10,6 +10,7 @@ export default function () {
   return;
 
   return ng('test', '--watch=false', '--code-coverage')
+    .then(output => expect(output.stdout).toContain('Coverage summary'))
     .then(() => expectFileToExist('coverage/src/app'))
     .then(() => expectFileToExist('coverage/lcov.info'))
     // Verify code coverage exclude work


### PR DESCRIPTION
Fixes: #3602

![image](https://user-images.githubusercontent.com/17563226/46733257-0e2d3200-cc90-11e8-8d5f-01307a736f4d.png)

