### PR TITLE
fix(@angular-devkit/build-angular): fix extractLicenses default

### DIFF
--- a/packages/angular_devkit/build_angular/src/browser/schema.json
+++ b/packages/angular_devkit/build_angular/src/browser/schema.json
@@ -171,8 +171,8 @@
     },
     "extractLicenses": {
       "type": "boolean",
-      "description": "Extract all licenses in a separate file, in the case of production builds only.",
-      "default": true
+      "description": "Extract all licenses in a separate file.",
+      "default": false
     },
     "showCircularDependencies": {
       "type": "boolean",


### PR DESCRIPTION
It should be false so that it doesn't affect dev builds. The default production config has it set to true already.

Partially address #12432.