### PR TITLE
fix(@ngtools/webpack): report a warning when lazy route discovery is disabled

### DIFF
--- a/packages/angular_devkit/build_angular/test/browser/no-entry-module_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/browser/no-entry-module_spec_large.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { runTargetSpec } from '@angular-devkit/architect/testing';
+import { TestLogger, runTargetSpec } from '@angular-devkit/architect/testing';
 import { tap } from 'rxjs/operators';
 import { browserTargetSpec, host } from '../utils';
 
@@ -23,6 +23,17 @@ describe('Browser Builder no entry module', () => {
     const overrides = { baseHref: '/myUrl' };
 
     runTargetSpec(host, browserTargetSpec, overrides).pipe(
+      tap((buildEvent) => expect(buildEvent.success).toBe(true)),
+    ).toPromise().then(done, done.fail);
+  });
+
+  it('reports warning when no bootstrap code', (done) => {
+    host.replaceInFile('src/main.ts', /./g, '');
+    host.appendToFile('src/main.ts', `import './app/app.module';`);
+
+    const logger = new TestLogger('no-bootstrap');
+    runTargetSpec(host, browserTargetSpec, undefined, undefined, logger).pipe(
+      tap(() => expect(logger.includes('Lazy routes discovery is not enabled')).toBe(true)),
       tap((buildEvent) => expect(buildEvent.success).toBe(true)),
     ).toPromise().then(done, done.fail);
   });

--- a/packages/ngtools/webpack/src/angular_compiler_plugin.ts
+++ b/packages/ngtools/webpack/src/angular_compiler_plugin.ts
@@ -418,10 +418,17 @@ export class AngularCompilerPlugin {
     }
 
     // If there's still no entryModule try to resolve from mainPath.
-    if (!this._entryModule && this._mainPath) {
+    if (!this._entryModule && this._mainPath && !this._compilerOptions.enableIvy) {
       time('AngularCompilerPlugin._make.resolveEntryModuleFromMain');
       this._entryModule = resolveEntryModuleFromMain(
         this._mainPath, this._compilerHost, this._getTsProgram() as ts.Program);
+
+      if (!this.entryModule) {
+        this._warnings.push('Lazy routes discovery is not enabled. '
+          + 'Because there is neither an entryModule nor a '
+          + 'statically analyzable bootstrap code in the main file.',
+        );
+      }
       timeEnd('AngularCompilerPlugin._make.resolveEntryModuleFromMain');
     }
   }

--- a/packages/ngtools/webpack/src/entry_resolver.ts
+++ b/packages/ngtools/webpack/src/entry_resolver.ts
@@ -152,17 +152,13 @@ export function resolveEntryModuleFromMain(mainPath: string,
     .map(node => node.arguments[0] as ts.Identifier)
     .filter(node => node.kind == ts.SyntaxKind.Identifier);
 
-  if (bootstrap.length != 1) {
-    return null;
-  }
-  const bootstrapSymbolName = bootstrap[0].text;
-  const module = _symbolImportLookup(source, bootstrapSymbolName, host, program);
-  if (module) {
-    return `${module.replace(/\.ts$/, '')}#${bootstrapSymbolName}`;
+  if (bootstrap.length === 1) {
+    const bootstrapSymbolName = bootstrap[0].text;
+    const module = _symbolImportLookup(source, bootstrapSymbolName, host, program);
+    if (module) {
+      return `${module.replace(/\.ts$/, '')}#${bootstrapSymbolName}`;
+    }
   }
 
-  // shrug... something bad happened and we couldn't find the import statement.
-  throw new Error('Tried to find bootstrap code, but could not. Specify either '
-    + 'statically analyzable bootstrap code or pass in an entryModule '
-    + 'to the plugins options.');
+  return null;
 }


### PR DESCRIPTION


At the moment this will cause a runtime error instead. With this change the error is thrown during the build.

Closes #12238 and Closes #12025