### PR TITLE
feat(@schematics/update) import user-agent config from NPM

### DIFF
--- a/packages/schematics/update/update/npm.ts
+++ b/packages/schematics/update/update/npm.ts
@@ -277,7 +277,7 @@ export function getNpmPackageJson(
           const params = {
             timeout: 30000,
             auth,
-          }; 
+          };
 
           client.get(
             fullUrl.toString(),

--- a/packages/schematics/update/update/npm.ts
+++ b/packages/schematics/update/update/npm.ts
@@ -195,6 +195,7 @@ export function getNpmPackageJson(
         getNpmConfigOption('strict-ssl'),
         getNpmConfigOption('cafile'),
         getNpmConfigOption('_auth'),
+        getNpmConfigOption('user-agent'),
         getNpmConfigOption('_authToken', registryKey),
         getNpmConfigOption('username', registryKey, true),
         getNpmConfigOption('password', registryKey, true),
@@ -209,6 +210,7 @@ export function getNpmPackageJson(
             strictSsl,
             cafile,
             token,
+            userAgent,
             authToken,
             username,
             password,
@@ -261,15 +263,21 @@ export function getNpmPackageJson(
             auth.password = password;
           }
 
-          const client = new RegistryClient({
+          const clientOptions = {
             proxy: { http, https },
             ssl: sslOptions,
-          });
+          };
+
+          if (userAgent) {
+            clientOptions.userAgent = userAgent;
+          }
+
+          const client = new RegistryClient(clientOptions);
           client.log.level = 'silent';
           const params = {
             timeout: 30000,
             auth,
-          };
+          }; 
 
           client.get(
             fullUrl.toString(),


### PR DESCRIPTION
Configuration of the user-agent header in requests is a commonly available feature; previous versions of angular-cli do not pull this value from NPM.