### PR TITLE
fix(@angular-devkit/build-webpack): skip transition property optimization

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/cleancss-webpack-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/cleancss-webpack-plugin.ts
@@ -63,7 +63,11 @@ export class CleanCssWebpackPlugin {
     hook(compiler, (compilation: compilation.Compilation, chunks: Array<Chunk>) => {
       const cleancss = new CleanCSS({
         compatibility: 'ie9',
-        level: 2,
+        level: {
+          2: {
+            skipProperties: ['transition'] // Fixes #12408
+          }
+        },
         inline: false,
         returnPromise: true,
         sourceMap: this._options.sourceMap,


### PR DESCRIPTION
jakubpawlowicz/clean-css#1050 to be fixed before removing this option.

Fix #12408