### PR TITLE
fix(@ngtools/webpack): output consistent filename

### DIFF
--- a/packages/angular_devkit/build_angular/test/browser/lazy-module_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/browser/lazy-module_spec_large.ts
@@ -97,7 +97,7 @@ describe('Browser Builder lazy modules', () => {
       tap((buildEvent) => expect(buildEvent.success).toBe(true)),
       tap(() => {
         expect(host.scopedSync()
-          .exists(join(outputPath, 'lazy-lazy-module-ngfactory.js'))).toBe(true);
+          .exists(join(outputPath, 'lazy-lazy-module.js'))).toBe(true);
       }),
     ).toPromise().then(done, done.fail);
   });
@@ -256,7 +256,7 @@ describe('Browser Builder lazy modules', () => {
     runTargetSpec(host, browserTargetSpec, overrides, DefaultTimeout * 2).pipe(
       tap((buildEvent) => expect(buildEvent.success).toBe(true)),
       tap(() => expect(host.scopedSync()
-        .exists(join(outputPath, 'src-app-lazy-lazy-module-ngfactory.js')))
+        .exists(join(outputPath, 'src-app-lazy-lazy-module.js')))
         .toBe(true)),
     ).toPromise().then(done, done.fail);
   });

--- a/packages/ngtools/webpack/src/angular_compiler_plugin.ts
+++ b/packages/ngtools/webpack/src/angular_compiler_plugin.ts
@@ -721,7 +721,7 @@ export class AngularCompilerPlugin {
                   const modulePath = this._lazyRoutes[key];
                   const importPath = key.split('#')[0];
                   if (modulePath !== null) {
-                    const name = importPath.replace(/(\.ngfactory)?\.(js|ts)$/, '');
+                    const name = importPath.replace(/(\.ngfactory)?(\.(js|ts))?$/, '');
 
                     return new this._contextElementDependencyConstructor(modulePath, name);
                   } else {


### PR DESCRIPTION
At the moment when having namedChunks file names are different between JIT and AOT builds .

AOT will will output something like
```
customers-customers-module-ngfactory.9b8b989df2e32e5cadac.js
```
while JIT will output

```
customers-customers-module.js
```

This PR aligns the output file name

Found this will debugging another issue.

Closes https://github.com/angular/angular-cli/issues/9900