### PR TITLE
fix(@schematics/schematics): should not have test node_modules specs

### DIFF
--- a/packages/schematics/schematics/schematic/files/package.json
+++ b/packages/schematics/schematics/schematic/files/package.json
@@ -4,7 +4,7 @@
   "description": "A schematics",
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "test": "npm run build && jasmine **/*_spec.js"
+    "test": "npm run build && jasmine src/**/*_spec.js"
   },
   "keywords": [
     "schematics"


### PR DESCRIPTION
Fixed the  schematics to not consider node_module specs while running unit tests