### PR TITLE
fix(@schematics/angular): fix polyfill path resolution

### DIFF
--- a/packages/schematics/angular/migrations/update-7/polyfill-metadata.ts
+++ b/packages/schematics/angular/migrations/update-7/polyfill-metadata.ts
@@ -52,7 +52,7 @@ function _removeReflectFromPolyfills(tree: Tree, path: string) {
  * @param targetObject The target information.
  * @private
  */
-function _updateProjectTarget(root: string, targetObject: json.JsonObject): Rule {
+function _updateProjectTarget(targetObject: json.JsonObject): Rule {
   // Make sure we're using the correct builder.
   if (targetObject.builder !== '@angular-devkit/build-angular:browser'
       || !json.isJsonObject(targetObject.options)) {
@@ -63,7 +63,7 @@ function _updateProjectTarget(root: string, targetObject: json.JsonObject): Rule
     return noop();
   }
 
-  const polyfillsToUpdate = [`${root}/${options.polyfills}`];
+  const polyfillsToUpdate = [options.polyfills];
   const configurations = targetObject.configurations;
   if (json.isJsonObject(configurations)) {
     for (const configName of Object.keys(configurations)) {
@@ -73,7 +73,7 @@ function _updateProjectTarget(root: string, targetObject: json.JsonObject): Rule
       if (json.isJsonObject(config)
           && typeof config.polyfills == 'string'
           && config.aot !== true) {
-        polyfillsToUpdate.push(`${root}/${config.polyfills}`);
+        polyfillsToUpdate.push(config.polyfills);
       }
     }
   }
@@ -125,7 +125,7 @@ export function polyfillMetadataRule(): Rule {
       for (const targetName of Object.keys(targets)) {
         const target = targets[targetName];
         if (json.isJsonObject(target)) {
-          rules.push(_updateProjectTarget(project.root, target));
+          rules.push(_updateProjectTarget(target));
         }
       }
     }

--- a/packages/schematics/angular/migrations/update-7/polyfill-metadata_spec.ts
+++ b/packages/schematics/angular/migrations/update-7/polyfill-metadata_spec.ts
@@ -86,4 +86,16 @@ describe('polyfillMetadataRule', () => {
 
     expect(tree2.readContent(polyfillPath)).not.toMatch(/import .*es7.*reflect.*;/);
   });
+
+  it('should work as expected for a project with a root', async () => {
+    const originalContent = JSON.parse(tree.readContent('angular.json'));
+    originalContent.projects['migration-test'].root = 'src';
+    tree.overwrite('angular.json', JSON.stringify(originalContent));
+    const polyfillPath = '/src/polyfills.ts';
+    tree.overwrite(polyfillPath, oldPolyfills);
+    const tree2 = await schematicRunner.runSchematicAsync('migration-03', {}, tree.branch())
+      .toPromise();
+
+    expect(tree2.readContent(polyfillPath)).not.toMatch(/import .*es7.*reflect.*;/);
+  });
 });


### PR DESCRIPTION
## Current Behavior

Paths to polyfills during the Angular 7 migration were resolved from the root which is incorrect

## Expected Behavior

Paths to the polyfills are used as is during the Angular 7 Migration and are correct.

cc
@hansl