### PR TITLE
fix(@schematics/angular): module is not being located correctly when using `flat`

### DIFF
--- a/packages/schematics/angular/utility/find-module.ts
+++ b/packages/schematics/angular/utility/find-module.ts
@@ -44,8 +44,7 @@ export function findModuleFromOptions(host: Tree, options: ModuleOptions): Path 
 
   if (!options.module) {
     options.nameFormatter = options.nameFormatter || strings.dasherize;
-    const pathToCheck = (options.path || '')
-      + (options.flat ? '' : '/' + options.nameFormatter(options.name));
+    const pathToCheck = (options.path || '') + '/' + options.nameFormatter(options.name);
 
     return normalize(findModule(host, pathToCheck, moduleExt, routingModuleExt));
   } else {

--- a/packages/schematics/angular/utility/find-module_spec.ts
+++ b/packages/schematics/angular/utility/find-module_spec.ts
@@ -119,6 +119,15 @@ describe('find-module', () => {
       expect(modPath).toEqual('/projects/my-proj/src/app_test.module.ts' as Path);
     });
 
+    it('should find a module if flat is true', () => {
+      tree.create('/projects/my-proj/src/module/app_test.module.ts', '');
+      options.path = '/projects/my-proj/src';
+      options.flat = true;
+      options.name = '/module/directive';
+      const modPath = findModuleFromOptions(tree, options);
+      expect(modPath).toEqual('/projects/my-proj/src/module/app_test.module.ts' as Path);
+    });
+
     it('should find a module in a sub dir', () => {
       tree.create('/projects/my-proj/src/admin/foo.module.ts', '');
       options.name = 'other/test';


### PR DESCRIPTION


Fixes #12614