### PR TITLE
fix(@schematics/angular): update codelyzer for new projects

### DIFF
--- a/packages/schematics/angular/workspace/files/package.json
+++ b/packages/schematics/angular/workspace/files/package.json
@@ -30,7 +30,7 @@
     "@types/node": "~8.9.4",
     <% if (!minimal) { %>"@types/jasmine": "~2.8.8",
     "@types/jasminewd2": "~2.0.3",
-    "codelyzer": "~4.3.0",
+    "codelyzer": "~4.5.0",
     "jasmine-core": "~2.99.1",
     "jasmine-spec-reporter": "~4.2.1",
     "karma": "~3.0.0",


### PR DESCRIPTION
codelyzer@4.5.0 adds support for Angular 7.0 and removes peer dep warnings on new project install.