### PR TITLE
fix(@angular/cli): pass arguments to all targets

### DIFF
--- a/packages/angular/cli/models/parser_spec.ts
+++ b/packages/angular/cli/models/parser_spec.ts
@@ -150,10 +150,14 @@ describe('parseArguments', () => {
   Object.entries(tests).forEach(([str, expected]) => {
     it(`works for ${str}`, () => {
       try {
-        const actual = parseArguments(str.split(' '), options);
+        const originalArgs = str.split(' ');
+        const args = originalArgs.slice();
+
+        const actual = parseArguments(args, options);
 
         expect(Array.isArray(expected)).toBe(false);
         expect(actual).toEqual(expected as Arguments);
+        expect(args).toEqual(originalArgs);
       } catch (e) {
         if (!(e instanceof ParseArgumentException)) {
           throw e;


### PR DESCRIPTION
When running a command with args against multiple targets, all targets should be given the args. As parseArguments was mutating the passed args array this wasn't the case. 

Fix by making a shallow clone of the array. This was especially noticeable when using the `ng lint --fix` command on a newly generated project, as files in the app target would be fixed, but e2e target would be only be linted (with no fix).

Possibly closes #10657, #10656, #11005