### PR TITLE
fix(@angular/cli): multiline help descriptions are not aligned

### DIFF
--- a/packages/angular/cli/models/command.ts
+++ b/packages/angular/cli/models/command.ts
@@ -85,12 +85,15 @@ export abstract class Command<T extends BaseCommandOptions = BaseCommandOptions>
     const args = options.filter(opt => opt.positional !== undefined);
     const opts = options.filter(opt => opt.positional === undefined);
 
+    const formatDescription = (description: string) =>
+      `    ${description.replace(/\n/g, '\n    ')}`;
+
     if (args.length > 0) {
       this.logger.info(`arguments:`);
       args.forEach(o => {
         this.logger.info(`  ${terminal.cyan(o.name)}`);
         if (o.description) {
-          this.logger.info(`    ${o.description}`);
+          this.logger.info(formatDescription(o.description));
         }
       });
     }
@@ -108,7 +111,7 @@ export abstract class Command<T extends BaseCommandOptions = BaseCommandOptions>
             : '';
           this.logger.info(`  ${terminal.cyan('--' + strings.dasherize(o.name))} ${aliases}`);
           if (o.description) {
-            this.logger.info(`    ${o.description}`);
+            this.logger.info(formatDescription(o.description));
           }
         });
     }


### PR DESCRIPTION
Before

<img width="962" alt="screen shot 2018-10-22 at 08 17 56" src="https://user-images.githubusercontent.com/17563226/47280303-fb8ef300-d5d5-11e8-8be8-bb3d0b525ba9.png">

After

<img width="905" alt="screen shot 2018-10-22 at 08 23 23" src="https://user-images.githubusercontent.com/17563226/47280301-fa5dc600-d5d5-11e8-8f60-d5f8e186c8d3.png">
