### PR TITLE
fix(@angular/cli): add '@angular/pwa' in the 'packageGroup'

### DIFF
--- a/packages/angular/cli/package.json
+++ b/packages/angular/cli/package.json
@@ -38,6 +38,9 @@
     "symbol-observable": "1.2.0"
   },
   "ng-update": {
-    "migrations": "@schematics/angular/migrations/migration-collection.json"
+    "migrations": "@schematics/angular/migrations/migration-collection.json",
+    "packageGroup": [
+      "@angular/pwa"
+    ]
   }
 }


### PR DESCRIPTION
When using `ng update @angular/cli`  to update from v6 to v7 with `@angular/pwa` and `npm`, even though the `@angular/cli` can be update to v7 correctly, but the dependencies like `@schematics/angular` cannot be updated correctly as the old `@angular/pwa` v0.8.6 still requires 
```
"@angular-devkit/core": "0.8.6",
"@angular-devkit/schematics": "0.8.6",
"@schematics/angular": "0.8.6",
```
So here add `@angular/pwa` in the `packageGroup` to make sure the update is correctly when using with  `@angular/pwa`