### PR TITLE
fix(@ngtools/webpack): update error message to reference templateUrl

### DIFF
--- a/packages/ngtools/webpack/src/resource_loader.ts
+++ b/packages/ngtools/webpack/src/resource_loader.ts
@@ -49,7 +49,7 @@ export class WebpackResourceLoader {
 
     // Simple sanity check.
     if (filePath.match(/\.[jt]s$/)) {
-      return Promise.reject('Cannot use a JavaScript or TypeScript file for styleUrl.');
+      return Promise.reject('Cannot use a JavaScript or TypeScript file for styleUrl or templateUrl.');
     }
 
     const outputOptions = { filename: filePath };


### PR DESCRIPTION
The error message for a `.ts` typo in `templateUrl` currently says that the issue is with `styleUrl`. Change the error message to reference both `styleUrl` and `templateUrl`.

fixes #12693