### PR TITLE
fix(@schematics/angular): --minimal should prevent generating e2e

### DIFF
--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -372,7 +372,7 @@ export default function (options: ApplicationOptions): Rule {
           }),
           move(sourceDir),
         ]), MergeStrategy.Overwrite),
-      !options.minimal ? schematic('e2e', e2eOptions) : noop(),
+      options.minimal ? noop() : schematic('e2e', e2eOptions),
       options.skipPackageJson ? noop() : addDependenciesToPackageJson(options),
     ]);
   };

--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -372,7 +372,7 @@ export default function (options: ApplicationOptions): Rule {
           }),
           move(sourceDir),
         ]), MergeStrategy.Overwrite),
-      schematic('e2e', e2eOptions),
+      !options.minimal ? schematic('e2e', e2eOptions) : noop(),
       options.skipPackageJson ? noop() : addDependenciesToPackageJson(options),
     ]);
   };

--- a/packages/schematics/angular/application/index_spec.ts
+++ b/packages/schematics/angular/application/index_spec.ts
@@ -136,6 +136,16 @@ describe('Application Schematic', () => {
     expect(content.rules['component-selector'][2]).toMatch('app');
   });
 
+  it('minimal=true should not create e2e project', () => {
+    const options = { ...defaultOptions, minimal: true };
+
+    const tree = schematicRunner.runSchematic('application', options, workspaceTree);
+    const files = tree.files;
+    expect(files.indexOf('/projects/foo-e2e')).toEqual(-1);
+    const confContent = JSON.parse(tree.readContent('/angular.json'));
+    expect(confContent.projects['foo-e2e']).toBeUndefined();
+  });
+
   describe(`update package.json`, () => {
     it(`should add build-angular to devDependencies`, () => {
       const tree = schematicRunner.runSchematic('application', defaultOptions, workspaceTree);

--- a/packages/schematics/angular/ng-new/index.ts
+++ b/packages/schematics/angular/ng-new/index.ts
@@ -57,6 +57,7 @@ export default function (options: NgNewOptions): Rule {
     skipPackageJson: false,
     // always 'skipInstall' here, so that we do it after the move
     skipInstall: true,
+    minimal: options.minimal,
   };
 
   return chain([

--- a/packages/schematics/angular/ng-new/index_spec.ts
+++ b/packages/schematics/angular/ng-new/index_spec.ts
@@ -65,4 +65,14 @@ describe('Ng New Schematic', () => {
     expect(files.indexOf('/bar/angular.json')).toBeGreaterThanOrEqual(0);
     expect(files.indexOf('/bar/src')).toBe(-1);
   });
+
+  it('minimal=true should not create e2e project', () => {
+    const options = { ...defaultOptions, minimal: true };
+
+    const tree = schematicRunner.runSchematic('ng-new', options);
+    const files = tree.files;
+    expect(files.indexOf('/bar/e2e')).toEqual(-1);
+    const confContent = JSON.parse(tree.readContent('/bar/angular.json'));
+    expect(confContent.projects['foo-e2e']).toBeUndefined();
+  });
 });


### PR DESCRIPTION
Don't run the e2e schematic when using application or ng-new schematics
with option.minimal set to true.

fix #12739 

Couldn't test it works with ng new, let me know if I should write a test for that.