### PR TITLE
fix(@angular-devkit/build-angular): improve bundle size value displaying

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/stats.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/stats.ts
@@ -18,9 +18,9 @@ export function formatSize(size: number): string {
   }
 
   const abbreviations = ['bytes', 'kB', 'MB', 'GB'];
-  const index = Math.floor(Math.log(size) / Math.log(1000));
+  const index = Math.floor(Math.log(size) / Math.log(1024));
 
-  return `${+(size / Math.pow(1000, index)).toPrecision(3)} ${abbreviations[index]}`;
+  return `${+(size / Math.pow(1024, index)).toPrecision(3)} ${abbreviations[index]}`;
 }
 
 


### PR DESCRIPTION
**Case:**
When adding `budgets` like this:
```
"budgets": [
	{
	  "type": "initial",
	  "maximumWarning": "2mb",
	  "maximumError": "5mb"
	}
],
```
When got the warning for exceeding the maximum, the warning like this: 
`WARNING in budgets, maximum exceeded for initial. Budget 2.1 MB was exceeded by 590 kB.`
So there's a difference here (2mb <---> 2.1 MB) between the configuration and the warning, which can cause confusion.

Because when parsing the value it uses [1024 as the basis](https://github.com/angular/angular-cli/blob/master/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/bundle-calculator.ts#L155), while when displaying in the output, uses 1000 as the basis.

So here the change is to change 1000 to 1024 to make the basis same again.
After this change, warning is like this:
`WARNING in budgets, maximum exceeded for initial. Budget 2 MB was exceeded by 576 kB.`

Also this change will also affect the displaying of the chunk size after build, but I think this is acceptable.