### PR TITLE
 fix(@angular/cli): errors and warnings are hard to read in windows cmd

### DIFF
--- a/packages/angular/cli/lib/cli/index.ts
+++ b/packages/angular/cli/lib/cli/index.ts
@@ -81,18 +81,16 @@ function initializeLogging(logger: logging.Logger) {
           color = terminal.white;
           break;
         case 'warn':
-          color = terminal.yellow;
-          output = process.stderr;
-          break;
-        case 'error':
-          color = terminal.red;
+          color = (x: string) => terminal.bold(terminal.yellow(x));
           output = process.stderr;
           break;
         case 'fatal':
-          color = (x) => terminal.bold(terminal.red(x));
+        case 'error':
+          color = (x: string) => terminal.bold(terminal.red(x));
           output = process.stderr;
           break;
       }
+
 
       // If we do console.log(message) or process.stdout.write(message + '\n'), the process might
       // stop before the whole message is written and the stream is flushed. This happens when

--- a/packages/angular_devkit/core/node/cli-logger.ts
+++ b/packages/angular_devkit/core/node/cli-logger.ts
@@ -32,13 +32,10 @@ export function createConsoleLogger(
           color = terminal.white;
           break;
         case 'warn':
-          color = terminal.yellow;
-          break;
-        case 'error':
-          color = terminal.red;
-          output = stderr;
+          color = (x: string) => terminal.bold(terminal.yellow(x));
           break;
         case 'fatal':
+        case 'error':
           color = (x: string) => terminal.bold(terminal.red(x));
           output = stderr;
           break;


### PR DESCRIPTION
Closes #12755

Win Before
![before-windows-colors](https://user-images.githubusercontent.com/17563226/47563068-e2ad7700-d920-11e8-9e59-4f01e5157ae6.png)

Win After
![after-windows-colors](https://user-images.githubusercontent.com/17563226/47563082-eb05b200-d920-11e8-9328-372a3bdc5b0e.png)


Ios Before
<img width="819" alt="screenshot 2018-10-26 at 17 43 12" src="https://user-images.githubusercontent.com/17563226/47577318-d89e6f00-d946-11e8-9b55-e443f8820506.png">


Ios After
<img width="795" alt="screenshot 2018-10-26 at 17 44 27" src="https://user-images.githubusercontent.com/17563226/47577315-d76d4200-d946-11e8-81b7-3238bc0d619b.png">