### PR TITLE
fix(@angular-devkit/build-angular): remove `skipAppShell` as it has no effect in browser builder

### DIFF
--- a/packages/angular/cli/lib/config/schema.json
+++ b/packages/angular/cli/lib/config/schema.json
@@ -752,11 +752,6 @@
               "description": "Generates a service worker config for production builds.",
               "default": false
             },
-            "skipAppShell": {
-              "type": "boolean",
-              "description": "Flag to prevent building an app shell.",
-              "default": false
-            },
             "index": {
               "type": "string",
               "description": "The name of the index HTML file."

--- a/packages/angular_devkit/build_angular/src/browser/schema.json
+++ b/packages/angular_devkit/build_angular/src/browser/schema.json
@@ -203,11 +203,6 @@
       "type": "string",
       "description": "Path to ngsw-config.json."
     },
-    "skipAppShell": {
-      "type": "boolean",
-      "description": "Flag to prevent building an app shell.",
-      "default": false
-    },
     "index": {
       "type": "string",
       "description": "The name of the index HTML file."


### PR DESCRIPTION
Was not sure, if to deprecate and show a warning when using this options. But based on Filipe's comment. It should error out.

Closes #11478