### PR TITLE
fix(@angular/cli): handle case senstive aliases

### DIFF
--- a/packages/angular/cli/models/parser.ts
+++ b/packages/angular/cli/models/parser.ts
@@ -29,10 +29,10 @@ function _coerceType(str: string | undefined, type: OptionType, v?: Value): Valu
       }
 
       return _coerceType(str, OptionType.Boolean, v) !== undefined
-           ? _coerceType(str, OptionType.Boolean, v)
-           : _coerceType(str, OptionType.Number, v) !== undefined
-           ? _coerceType(str, OptionType.Number, v)
-           : _coerceType(str, OptionType.String, v);
+        ? _coerceType(str, OptionType.Boolean, v)
+        : _coerceType(str, OptionType.Number, v) !== undefined
+          ? _coerceType(str, OptionType.Number, v)
+          : _coerceType(str, OptionType.String, v);
 
     case OptionType.String:
       return str || '';
@@ -93,14 +93,16 @@ function _coerce(str: string | undefined, o: Option | null, v?: Value): Value | 
 
 
 function _getOptionFromName(name: string, options: Option[]): Option | undefined {
-  const cName = strings.camelize(name);
+  const camelName = /(-|_)/.test(name)
+    ? strings.camelize(name)
+    : name;
 
   for (const option of options) {
-    if (option.name == name || option.name == cName) {
+    if (option.name === name || option.name === camelName) {
       return option;
     }
 
-    if (option.aliases.some(x => x == name || x == cName)) {
+    if (option.aliases.some(x => x === name || x === camelName)) {
       return option;
     }
   }
@@ -108,6 +110,11 @@ function _getOptionFromName(name: string, options: Option[]): Option | undefined
   return undefined;
 }
 
+function _removeLeadingDashes(key: string): string {
+  const from = key.startsWith('--') ? 2 : key.startsWith('-') ? 1 : 0;
+
+  return key.substr(from);
+}
 
 function _assignOption(
   arg: string,
@@ -127,16 +134,10 @@ function _assignOption(
 
   // If flag is --no-abc AND there's no equal sign.
   if (i == -1) {
-    if (key.startsWith('no-')) {
+    if (key.startsWith('no')) {
       // Only use this key if the option matching the rest is a boolean.
-      const maybeOption = _getOptionFromName(key.substr(3), options);
-      if (maybeOption && maybeOption.type == 'boolean') {
-        value = 'false';
-        option = maybeOption;
-      }
-    } else if (key.startsWith('no')) {
-      // Only use this key if the option matching the rest is a boolean.
-      const maybeOption = _getOptionFromName(key.substr(2), options);
+      const from = key.startsWith('no-') ? 3 : 2;
+      const maybeOption = _getOptionFromName(strings.camelize(key.substr(from)), options);
       if (maybeOption && maybeOption.type == 'boolean') {
         value = 'false';
         option = maybeOption;
@@ -168,7 +169,7 @@ function _assignOption(
     }
   } else {
     key = arg.substring(0, i);
-    option = _getOptionFromName(key, options) || null;
+    option = _getOptionFromName(_removeLeadingDashes(key), options) || null;
     if (option) {
       value = arg.substring(i + 1);
     }

--- a/packages/angular/cli/models/parser_spec.ts
+++ b/packages/angular/cli/models/parser_spec.ts
@@ -14,6 +14,7 @@ describe('parseArguments', () => {
     { name: 'bool', aliases: [ 'b' ], type: OptionType.Boolean, description: '' },
     { name: 'num', aliases: [ 'n' ], type: OptionType.Number, description: '' },
     { name: 'str', aliases: [ 's' ], type: OptionType.String, description: '' },
+    { name: 'strUpper', aliases: [ 'S' ], type: OptionType.String, description: '' },
     { name: 'helloWorld', aliases: [], type: OptionType.String, description: '' },
     { name: 'helloBool', aliases: [], type: OptionType.Boolean, description: '' },
     { name: 'arr', aliases: [ 'a' ], type: OptionType.Array, description: '' },
@@ -34,6 +35,7 @@ describe('parseArguments', () => {
   ];
 
   const tests: { [test: string]: Partial<Arguments> | ['!!!', Partial<Arguments>, string[]] } = {
+    '-S=b': { strUpper: 'b' },
     '--bool': { bool: true },
     '--bool=1': ['!!!', {}, ['--bool=1']],
     '--bool  ': { bool: true, p1: '' },


### PR DESCRIPTION
Closes #12780

Not sure for we can handle something like `noS` as at the moment this will eventually converted to `s`