### PR TITLE
feat(@schematics/angular): add profiling files to gitignore

### DIFF
--- a/packages/schematics/angular/workspace/files/__dot__gitignore
+++ b/packages/schematics/angular/workspace/files/__dot__gitignore
@@ -8,6 +8,10 @@
 # dependencies
 /node_modules
 
+# profiling files
+chrome-profiler-events.json
+speed-measure-plugin.json
+
 # IDEs and editors
 /.idea
 .project


### PR DESCRIPTION
feat(@schematics/angular): add profiling files to gitignore

closes #12811 

I added the files generated by the `--profile` flag to the gitignore file so they get ignore by default.

I chose `profiling files` as a name for the section but feel free to come up with something better !

First PR for Angular, gotta start small !