### PR TITLE
@fix(@schematics/angular): add prod serverTarget to appShell prod config

### DIFF
--- a/packages/schematics/angular/app-shell/index.ts
+++ b/packages/schematics/angular/app-shell/index.ts
@@ -194,6 +194,7 @@ function addAppShellConfigToWorkspace(options: AppShellOptions): Rule {
       configurations: {
         production: {
           browserTarget: `${options.clientProject}:build:production`,
+          serverTarget: `${options.clientProject}:server:production`,
         },
       },
     };

--- a/packages/schematics/angular/app-shell/index_spec.ts
+++ b/packages/schematics/angular/app-shell/index_spec.ts
@@ -69,6 +69,7 @@ describe('App Shell Schematic', () => {
     expect(target.options.serverTarget).toEqual('bar:server');
     expect(target.options.route).toEqual('shell');
     expect(target.configurations.production.browserTarget).toEqual('bar:build:production');
+    expect(target.configurations.production.serverTarget).toEqual('bar:server:production');
   });
 
   it('should add router module to client app module', () => {


### PR DESCRIPTION
Any builds with the appShell schema would only build the app in production but not the universal server. This was due to the `serverTarget` field missing from the appShell production configuration in `angular.json`. Some outcomes of this bug are that Service Workers will not work due to not being built in production.

Could not find any issues related to this fix.