### PR TITLE
fix(@angular-devkit/schematics-cli): dryRun is not set by default when using a local collection

### DIFF
--- a/packages/angular_devkit/schematics_cli/bin/schematics.ts
+++ b/packages/angular_devkit/schematics_cli/bin/schematics.ts
@@ -305,7 +305,7 @@ function parseArgs(args: string[] | undefined): minimist.ParsedArgs {
       },
       default: {
         'debug': null,
-        'dry-run': null,
+        'dryRun': null,
       },
       '--': true,
     });

--- a/packages/angular_devkit/schematics_cli/bin/schematics_spec.ts
+++ b/packages/angular_devkit/schematics_cli/bin/schematics_spec.ts
@@ -53,6 +53,16 @@ describe('schematics-cli binary', () => {
     expect(res).toEqual(0);
   });
 
+  it('dry-run is default when debug mode', async () => {
+    const args = ['blank', 'foo', '--debug'];
+    const res = await main({ args, stdout, stderr });
+    expect(stdout.lines).toMatch(/CREATE \/foo\/README.md/);
+    expect(stdout.lines).toMatch(/CREATE \/foo\/.gitignore/);
+    expect(stdout.lines).toMatch(/CREATE \/foo\/src\/foo\/index.ts/);
+    expect(stdout.lines).toMatch(/CREATE \/foo\/src\/foo\/index_spec.ts/);
+    expect(res).toEqual(0);
+  });
+
   it('error when no name is provided', async () => {
     const args = ['blank'];
     const res = await main({ args, stdout, stderr });


### PR DESCRIPTION
Fixes #12815