### PR TITLE
test: update typescript warning test unsupported version

### DIFF
--- a/tests/legacy-cli/e2e/tests/misc/typescript-warning.ts
+++ b/tests/legacy-cli/e2e/tests/misc/typescript-warning.ts
@@ -2,8 +2,8 @@ import { ng, silentNpm } from '../../utils/process';
 import { updateJsonFile } from '../../utils/project';
 
 export default async function () {
-  // typescript@2.8.0-dev.20180320 is not part of the officially supported range in latest stable.
-  const unsupportedTsVersion = '2.8.0-dev.20180320';
+  // typescript@3.0.1 is not part of the officially supported range in latest stable.
+  const unsupportedTsVersion = '3.0.1';
 
   await updateJsonFile('src/tsconfig.app.json', configJson => {
     // skipLibCheck is required because declerations


### PR DESCRIPTION
The old version was failing to build against @angular/core@7.1.0-beta.1 with the error below:
```
ERROR in node_modules/@angular/core/src/di/injector.d.ts(67,70): error TS1005: ',' expected.
```