### PR TITLE
feat(@angular/cli): allow flags to have deprecation

### DIFF
--- a/packages/angular/cli/models/architect-command.ts
+++ b/packages/angular/cli/models/architect-command.ts
@@ -137,7 +137,7 @@ export abstract class ArchitectCommand<
     const builderConf = this._architect.getBuilderConfiguration(targetSpec);
     const builderDesc = await this._architect.getBuilderDescription(builderConf).toPromise();
     const targetOptionArray = await parseJsonSchemaToOptions(this._registry, builderDesc.schema);
-    const overrides = parseArguments(options, targetOptionArray);
+    const overrides = parseArguments(options, targetOptionArray, this.logger);
 
     if (overrides['--']) {
       (overrides['--'] || []).forEach(additional => {

--- a/packages/angular/cli/models/command-runner.ts
+++ b/packages/angular/cli/models/command-runner.ts
@@ -182,7 +182,7 @@ export async function runCommand(
   }
 
   try {
-    const parsedOptions = parser.parseArguments(args, description.options);
+    const parsedOptions = parser.parseArguments(args, description.options, logger);
     Command.setCommandMap(commandMap);
     const command = new description.impl({ workspace }, description, logger);
 

--- a/packages/angular/cli/models/interface.ts
+++ b/packages/angular/cli/models/interface.ts
@@ -145,6 +145,12 @@ export interface Option {
   positional?: number;
 
   /**
+   * Deprecation. If this flag is not false a warning will be shown on the console. Either `true`
+   * or a string to show the user as a notice.
+   */
+  deprecated?: boolean | string;
+
+  /**
    * Smart default object.
    */
   $default?: OptionSmartDefault;

--- a/packages/angular/cli/models/schematic-command.ts
+++ b/packages/angular/cli/models/schematic-command.ts
@@ -533,7 +533,7 @@ export abstract class SchematicCommand<
     schematicOptions: string[],
     options: Option[] | null,
   ): Promise<Arguments> {
-    return parseArguments(schematicOptions, options);
+    return parseArguments(schematicOptions, options, this.logger);
   }
 
   private async _loadWorkspace() {

--- a/packages/angular/cli/utilities/json-schema.ts
+++ b/packages/angular/cli/utilities/json-schema.ts
@@ -248,6 +248,11 @@ export async function parseJsonSchemaToOptions(
     const visible = current.visible === undefined || current.visible === true;
     const hidden = !!current.hidden || !visible;
 
+    // Deprecated is set only if it's true or a string.
+    const xDeprecated = current['x-deprecated'];
+    const deprecated = (xDeprecated === true || typeof xDeprecated == 'string')
+      ? xDeprecated : undefined;
+
     const option: Option = {
       name,
       description: '' + (current.description === undefined ? '' : current.description),
@@ -258,6 +263,7 @@ export async function parseJsonSchemaToOptions(
       aliases,
       ...format !== undefined ? { format } : {},
       hidden,
+      ...deprecated !== undefined ? { deprecated } : {},
       ...positional !== undefined ? { positional } : {},
     };
 


### PR DESCRIPTION
The feature comes from the "x-deprecated" field in schemas (any schema that is used
to parse arguments), and can be a boolean or a string.

The parser now takes a logger and will warn users when encountering a deprecated
option. These options will also appear in JSON help.