### PR TITLE
fix(@angular-devkit/build-optimizer): update typescript to 3.1.6

### DIFF
--- a/packages/angular_devkit/build_optimizer/package.json
+++ b/packages/angular_devkit/build_optimizer/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "loader-utils": "1.1.0",
     "source-map": "0.5.6",
-    "typescript": "3.1.5",
+    "typescript": "3.1.6",
     "webpack-sources": "1.2.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9908,6 +9908,11 @@ typescript@3.1.5, typescript@~3.1.5:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.5.tgz#93d8b6864375325a91177372cb370ae0ae3a0703"
   integrity sha512-muYNWV9j5+3mXoKD6oPONKuGUmYiFX14gfo9lWm9ZXRHOqVDQiB4q1CzFPbF4QLV2E9TZXH6oK55oQ94rn3PpA==
 
+typescript@3.1.6:
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.6.tgz#b6543a83cfc8c2befb3f4c8fba6896f5b0c9be68"
+  integrity sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==
+
 uglify-es@^3.3.4:
   version "3.3.9"
   resolved "https://registry.yarnpkg.com/uglify-es/-/uglify-es-3.3.9.tgz#0c1c4f0700bed8dbc124cdb304d2592ca203e677"


### PR DESCRIPTION
The build optimiser is still stuck on ts 3.1.5 so all our builds still take way longer on angular 7, hopefully this should be the last thing to solve the ng 7 perf issues 🎉 