### PR TITLE
ci: fast track docs-preview snapshot

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,6 +168,10 @@ workflows:
       - build:
           requires:
             - install
+          filters:
+            branches:
+              ignore:
+              - /docs-preview/
       - build-bazel:
           requires:
             - build
@@ -183,6 +187,13 @@ workflows:
       - e2e-node-8:
           requires:
             - build
+      - snapshot_publish_docs:
+          requires:
+          - install
+          filters:
+            branches:
+              only:
+              - /docs-preview/
       - e2e-cli-ng-snapshots:
           requires:
             - build


### PR DESCRIPTION
Remove all jobs from the docs-preview branch, and only do `publish_snapshot`