### PR TITLE
build: add external block for tsconfig in test targets

### DIFF
--- a/packages/angular_devkit/benchmark/BUILD
+++ b/packages/angular_devkit/benchmark/BUILD
@@ -55,7 +55,9 @@ ts_library(
         "@npm//@types/jasmine",
     ],
     testonly = True,
+    # @external_begin
     tsconfig = "//:tsconfig-test.json",
+    # @external_end
 )
 
 jasmine_node_test(

--- a/packages/angular_devkit/build_optimizer/BUILD
+++ b/packages/angular_devkit/build_optimizer/BUILD
@@ -47,7 +47,9 @@ ts_library(
         "@npm//@types/source-map",
     ],
     testonly = True,
+    # @external_begin
     tsconfig = "//:tsconfig-test.json",
+    # @external_end
 )
 
 jasmine_node_test(

--- a/packages/angular_devkit/core/BUILD
+++ b/packages/angular_devkit/core/BUILD
@@ -57,7 +57,9 @@ ts_library(
         "src/workspace/test/test-workspace.json"
     ],
     testonly = True,
+    # @external_begin
     tsconfig = "//:tsconfig-test.json",
+    # @external_end
 )
 
 jasmine_node_test(
@@ -111,7 +113,9 @@ ts_library(
         "@npm//@types/jasmine",
     ],
     testonly = True,
+    # @external_begin
     tsconfig = "//:tsconfig-test.json",
+    # @external_end
 )
 
 jasmine_node_test(

--- a/packages/angular_devkit/schematics/BUILD
+++ b/packages/angular_devkit/schematics/BUILD
@@ -51,7 +51,9 @@ ts_library(
         "@npm//@types/jasmine",
     ],
     testonly = True,
+    # @external_begin
     tsconfig = "//:tsconfig-test.json",
+    # @external_end
 )
 
 jasmine_node_test(
@@ -141,7 +143,9 @@ ts_library(
         "@npm//@types/jasmine",
     ],
     testonly = True,
+    # @external_begin
     tsconfig = "//:tsconfig-test.json",
+    # @external_end
 )
 
 
@@ -205,7 +209,9 @@ ts_library(
         "@npm//@types/jasmine",
     ],
     testonly = True,
+    # @external_begin
     tsconfig = "//:tsconfig-test.json",
+    # @external_end
 )
 
 jasmine_node_test(

--- a/packages/schematics/angular/BUILD
+++ b/packages/schematics/angular/BUILD
@@ -84,7 +84,9 @@ ts_library(
         "@npm//typescript",
     ],
     testonly = True,
+    # @external_begin
     tsconfig = "//:tsconfig-test.json",
+    # @external_end
 )
 
 jasmine_node_test(

--- a/packages/schematics/schematics/BUILD
+++ b/packages/schematics/schematics/BUILD
@@ -80,7 +80,9 @@ ts_json_schema(
 #         "@npm//@types/jasmine",
 #     ],
 #     testonly = True,
+#     # @external_begin
 #     tsconfig = "//:tsconfig-test.json",
+#     # @external_end
 # )
 
 # jasmine_node_test(

--- a/packages/schematics/update/BUILD
+++ b/packages/schematics/update/BUILD
@@ -70,7 +70,9 @@ ts_library(
         "@npm//pacote",
     ],
     testonly = True,
+    # @external_begin
     tsconfig = "//:tsconfig-test.json",
+    # @external_end
 )
 
 jasmine_node_test(


### PR DESCRIPTION
internal `ts_library` rule does not require tsconfig attribute.