### PR TITLE
fix(@angular/cli) 1st project consuming arguments to a multiTarget command

### DIFF
--- a/packages/angular/cli/models/architect-command.ts
+++ b/packages/angular/cli/models/architect-command.ts
@@ -165,7 +165,7 @@ export abstract class ArchitectCommand<
         // Running them in parallel would jumble the log messages.
         let result = 0;
         for (const project of this.getProjectNamesByTarget(this.target)) {
-          result |= await this.runSingleTarget({ ...targetSpec, project }, extra);
+          result |= await this.runSingleTarget({ ...targetSpec, project }, [...extra]);
         }
 
         return result;


### PR DESCRIPTION
- Angular CLI version latest (tested on 7.1.0-beta.1 & master 4059fe83b485edcf42b8a795ea74289f1531688e)
- use case angular.json w/ 2 projects and command (i.e. karma w/ `{singleRun: false}` and command line `ng test --no-progress --no-watch` which will only send the options to the first project and the second one will hang (because of `--no-watch` not be given  to the second project). Visibly you can notice that the first will not show any build progress (as expected from `--no-progress`), but the second one will.