### PR TITLE
prompt support for value type number

### DIFF
--- a/packages/angular_devkit/core/src/json/schema/registry.ts
+++ b/packages/angular_devkit/core/src/json/schema/registry.ts
@@ -540,6 +540,8 @@ export class CoreSchemaRegistry implements SchemaRegistry {
             type = 'confirmation';
           } else if (Array.isArray(parentSchema.enum)) {
             type = 'list';
+          } else if (parentSchema.type === 'number') {
+            type = 'number';
           } else {
             type = 'input';
           }
@@ -570,7 +572,12 @@ export class CoreSchemaRegistry implements SchemaRegistry {
           items,
           default: typeof parentSchema.default == 'object' ? undefined : parentSchema.default,
           async validator(data: string) {
-            const result = it.self.validate(parentSchema, data);
+            let convertedData: string | number = data;
+            if (parentSchema.type === 'number') {
+              const parsed = parseInt(data);
+              convertedData = isNaN(parsed) ? '' : parsed;
+            }
+            const result = it.self.validate(parentSchema, convertedData);
             if (typeof result === 'boolean') {
               return result;
             } else {


### PR DESCRIPTION
Permit to support x-prompt for a schematic parameter definition if its type is set to number.

Previously, if used with type 'number', the prompt was trap in a loop as input never was considered correct.

The part on the cli will also need to be reproduced on schematics-cli after #12814.

Related to #12163.

## Root causes

### angular-devkit/core & ajv
Type number wasn't set, and the value wasn't converted to a number if needed in the prompt validator.

### angular-devkit/cli & inquirer
Inquirer doesn't convert it result to a number even if definition type is set to 'number' following https://github.com/SBoudrias/Inquirer.js/pull/663

## Reproduction steps

You can reproduce the previous behavior by using the @angular-buddies/prettier@1.0.0-alpha.2:prettier-config schematic.

https://github.com/angular-buddies/angular-buddies/blob/v1.0.0-alpha.2/packages/prettier/src/config/schema.json#L14-L19