### PR TITLE
feat(@schematics/angular): add `lintFix` to several other schematics

### DIFF
--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -31,6 +31,7 @@ import {
 } from '../utility/config';
 import { NodeDependencyType, addPackageJsonDependency } from '../utility/dependencies';
 import { latestVersions } from '../utility/latest-versions';
+import { applyLintFix } from '../utility/lint-fix';
 import { validateProjectName } from '../utility/validation';
 import {
   Builders,
@@ -372,6 +373,7 @@ export default function (options: ApplicationOptions): Rule {
         ]), MergeStrategy.Overwrite),
       options.minimal ? noop() : schematic('e2e', e2eOptions),
       options.skipPackageJson ? noop() : addDependenciesToPackageJson(options),
+      options.lintFix ? applyLintFix(sourceDir) : noop(),
     ]);
   };
 }

--- a/packages/schematics/angular/application/schema.json
+++ b/packages/schematics/angular/application/schema.json
@@ -78,6 +78,11 @@
       "description": "Skip installing dependency packages.",
       "type": "boolean",
       "default": false
+    },
+    "lintFix": {
+      "type": "boolean",
+      "default": false,
+      "description": "When true, applies lint fixes after generating the application."
     }
   },
   "required": [

--- a/packages/schematics/angular/class/index.ts
+++ b/packages/schematics/angular/class/index.ts
@@ -13,6 +13,7 @@ import {
   Tree,
   apply,
   branchAndMerge,
+  chain,
   filter,
   mergeWith,
   move,
@@ -20,6 +21,7 @@ import {
   template,
   url,
 } from '@angular-devkit/schematics';
+import { applyLintFix } from '../utility/lint-fix';
 import { parseName } from '../utility/parse-name';
 import { buildDefaultPath, getProject } from '../utility/project';
 import { Schema as ClassOptions } from './schema';
@@ -51,6 +53,9 @@ export default function (options: ClassOptions): Rule {
       move(parsedPath.path),
     ]);
 
-    return branchAndMerge(mergeWith(templateSource));
+    return chain([
+      branchAndMerge(mergeWith(templateSource)),
+      options.lintFix ? applyLintFix(options.path) : noop(),
+    ]);
   };
 }

--- a/packages/schematics/angular/class/schema.json
+++ b/packages/schematics/angular/class/schema.json
@@ -36,6 +36,11 @@
       "type": "string",
       "description": "Adds a developer-defined type to the filename, in the format \"name.type.ts\".",
       "default": ""
+    },
+    "lintFix": {
+      "type": "boolean",
+      "default": false,
+      "description": "When true, applies lint fixes after generating the class."
     }
   },
   "required": [

--- a/packages/schematics/angular/library/index.ts
+++ b/packages/schematics/angular/library/index.ts
@@ -27,6 +27,7 @@ import {
 } from '../utility/config';
 import { NodeDependencyType, addPackageJsonDependency } from '../utility/dependencies';
 import { latestVersions } from '../utility/latest-versions';
+import { applyLintFix } from '../utility/lint-fix';
 import { validateProjectName } from '../utility/validation';
 import {
   Builders,
@@ -246,6 +247,7 @@ export default function (options: LibraryOptions): Rule {
         path: sourceDir,
         project: options.name,
       }),
+      options.lintFix ? applyLintFix(sourceDir) : noop(),
       (_tree: Tree, context: SchematicContext) => {
         if (!options.skipPackageJson && !options.skipInstall) {
           context.addTask(new NodePackageInstallTask());

--- a/packages/schematics/angular/library/schema.json
+++ b/packages/schematics/angular/library/schema.json
@@ -42,6 +42,11 @@
       "type": "boolean",
       "default": false,
       "description": "When true, does not update \"tsconfig.json\" to add a path mapping for the new library. The path mapping is needed to use the library in an app, but can be disabled here to simplify development."
+    },
+    "lintFix": {
+      "type": "boolean",
+      "default": false,
+      "description": "When true, applies lint fixes after generating the library."
     }
   },
   "required": []

--- a/packages/schematics/angular/module/index.ts
+++ b/packages/schematics/angular/module/index.ts
@@ -24,6 +24,7 @@ import * as ts from 'typescript';
 import { addImportToModule } from '../utility/ast-utils';
 import { InsertChange } from '../utility/change';
 import { buildRelativePath, findModuleFromOptions } from '../utility/find-module';
+import { applyLintFix } from '../utility/lint-fix';
 import { parseName } from '../utility/parse-name';
 import { buildDefaultPath, getProject } from '../utility/project';
 import { Schema as ModuleOptions } from './schema';
@@ -102,6 +103,7 @@ export default function (options: ModuleOptions): Rule {
         addDeclarationToNgModule(options),
         mergeWith(templateSource),
       ])),
+      options.lintFix ? applyLintFix(options.path) : noop(),
     ]);
   };
 }

--- a/packages/schematics/angular/module/schema.json
+++ b/packages/schematics/angular/module/schema.json
@@ -53,6 +53,11 @@
       "type": "string",
       "description": "The declaring NgModule.",
       "alias": "m"
+    },
+    "lintFix": {
+      "type": "boolean",
+      "default": false,
+      "description": "When true, applies lint fixes after generating the module."
     }
   },
   "required": [


### PR DESCRIPTION
At the moment some schematics contain this options for instance the `guard`, `component` etc.. But some others don't such as `module`

Fixes #12894 and Fixes #6272