### PR TITLE
Fix lazy loading

### DIFF
--- a/packages/angular_devkit/build_angular/test/browser/lazy-module_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/browser/lazy-module_spec_large.ts
@@ -142,7 +142,7 @@ describe('Browser Builder lazy modules', () => {
       tap((buildEvent) => expect(buildEvent.success).toBe(true)),
       tap(() => {
         expect(host.scopedSync()
-          .exists(join(outputPath, 'lazy-lazy-module.js'))).toBe(true);
+          .exists(join(outputPath, 'lazy-lazy-module-ngfactory.js'))).toBe(true);
       }),
     ).toPromise().then(done, done.fail);
   });
@@ -301,7 +301,7 @@ describe('Browser Builder lazy modules', () => {
     runTargetSpec(host, browserTargetSpec, overrides, DefaultTimeout * 2).pipe(
       tap((buildEvent) => expect(buildEvent.success).toBe(true)),
       tap(() => expect(host.scopedSync()
-        .exists(join(outputPath, 'src-app-lazy-lazy-module.js')))
+        .exists(join(outputPath, 'src-app-lazy-lazy-module-ngfactory.js')))
         .toBe(true)),
     ).toPromise().then(done, done.fail);
   });

--- a/packages/ngtools/webpack/src/angular_compiler_plugin.ts
+++ b/packages/ngtools/webpack/src/angular_compiler_plugin.ts
@@ -696,9 +696,8 @@ export class AngularCompilerPlugin {
               const dependencies = Object.keys(this._lazyRoutes)
                 .map((key) => {
                   const modulePath = this._lazyRoutes[key];
-                  const importPath = key.split('#')[0];
                   if (modulePath !== null) {
-                    const name = importPath.replace(/(\.ngfactory)?\.(js|ts)$/, '');
+                    const name = key.split('#')[0];
 
                     return new this._contextElementDependencyConstructor(modulePath, name);
                   } else {

--- a/packages/ngtools/webpack/src/angular_compiler_plugin.ts
+++ b/packages/ngtools/webpack/src/angular_compiler_plugin.ts
@@ -698,7 +698,7 @@ export class AngularCompilerPlugin {
                   const modulePath = this._lazyRoutes[key];
                   const importPath = key.split('#')[0];
                   if (modulePath !== null) {
-                    const name = importPath.replace(/(\.ngfactory)?(\.(js|ts))?$/, '');
+                    const name = importPath.replace(/(\.ngfactory)?\.(js|ts)$/, '');
 
                     return new this._contextElementDependencyConstructor(modulePath, name);
                   } else {


### PR DESCRIPTION
revert: fix(@ngtools/webpack): output consistent filename
refactor(@ngtools/webpack): remove RegExp for ngfactory 

This RegExp is not needed as if it actually works it will break lazy loading as in case of AOT, the name should always be suffixed with ngfactory

https://github.com/angular/angular/blob/4c2ce4e8ba4c5ac5ce8754d67bc6603eaad4564a/packages/core/src/linker/system_js_ng_module_factory_loader.ts#L83

Fixes #12944

Not sure how we can actually test this better.