### PR TITLE
fix(@angular-devkit/core): handle drive only paths in windows

### DIFF
--- a/packages/angular_devkit/core/src/virtual-fs/path.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/path.ts
@@ -298,9 +298,11 @@ export type PosixPath = string & {
 };
 
 export function asWindowsPath(path: Path): WindowsPath {
-  const drive = path.match(/^\/(\w)\/(.*)$/);
+  const drive = path.match(/^\/(\w)(?:\/(.*))?$/);
   if (drive) {
-    return `${drive[1]}:\\${drive[2].replace(/\//g, '\\')}` as WindowsPath;
+    const subPath = drive[2] ? drive[2].replace(/\//g, '\\') : '';
+
+    return `${drive[1]}:\\${subPath}` as WindowsPath;
   }
 
   return path.replace(/\//g, '\\') as WindowsPath;

--- a/packages/angular_devkit/core/src/virtual-fs/path_spec.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/path_spec.ts
@@ -8,6 +8,7 @@
 import {
   InvalidPathException,
   Path,
+  asWindowsPath,
   basename,
   dirname,
   join,
@@ -159,4 +160,11 @@ describe('path', () => {
     expect(basename(normalize('.'))).toBe('');
     expect(basename(normalize('./a/b/c'))).toBe('c');
   });
+
+  it('asWindowsPath', () => {
+    expect(asWindowsPath(normalize('c:/'))).toBe('c:\\');
+    expect(asWindowsPath(normalize('c:/b/'))).toBe('c:\\b');
+    expect(asWindowsPath(normalize('c:/b/c'))).toBe('c:\\b\\c');
+  });
+
 });


### PR DESCRIPTION
When normalized path will not have a trailing slash, and at the moment the RegExp for drive needs to match `\c\`

Fixes #12670