### PR TITLE
fix(@schematics/angular): `addSymbolToNgModuleMetadata` metadata with…

### DIFF
--- a/packages/schematics/angular/utility/ast-utils.ts
+++ b/packages/schematics/angular/utility/ast-utils.ts
@@ -455,8 +455,8 @@ export function addSymbolToNgModuleMetadata(
       position = node.getEnd();
       // Get the indentation of the last element, if any.
       const text = node.getFullText(source);
-      if (text.match('^\r?\r?\n')) {
-        toInsert = `,${text.match(/^\r?\n\s+/)[0]}${metadataField}: [${symbolName}]`;
+      if (text.match(/^\r?\r?\n/)) {
+        toInsert = `,${text.match(/^\r?\n\s*/)[0]}${metadataField}: [${symbolName}]`;
       } else {
         toInsert = `, ${metadataField}: [${symbolName}]`;
       }
@@ -469,7 +469,7 @@ export function addSymbolToNgModuleMetadata(
     // Get the indentation of the last element, if any.
     const text = node.getFullText(source);
     if (text.match(/^\r?\n/)) {
-      toInsert = `,${text.match(/^\r?\n(\r?)\s+/)[0]}${symbolName}`;
+      toInsert = `,${text.match(/^\r?\n(\r?)\s*/)[0]}${symbolName}`;
     } else {
       toInsert = `, ${symbolName}`;
     }

--- a/packages/schematics/angular/utility/ast-utils_spec.ts
+++ b/packages/schematics/angular/utility/ast-utils_spec.ts
@@ -11,7 +11,11 @@ import { HostTree } from '@angular-devkit/schematics';
 import * as ts from 'typescript';
 import { Change, InsertChange } from '../utility/change';
 import { getFileContent } from '../utility/test';
-import { addExportToModule, addSymbolToNgModuleMetadata } from './ast-utils';
+import {
+  addDeclarationToModule,
+  addExportToModule,
+  addSymbolToNgModuleMetadata,
+} from './ast-utils';
 
 
 function getTsSource(path: string, content: string): ts.SourceFile {
@@ -71,6 +75,15 @@ describe('ast utils', () => {
     const output = applyChanges(modulePath, moduleContent, changes);
     expect(output).toMatch(/import { FooComponent } from '.\/foo.component';/);
     expect(output).toMatch(/exports: \[FooComponent\]/);
+  });
+
+  it('should add declarations to module if not indented', () => {
+    moduleContent = tags.stripIndents`${moduleContent}`;
+    const source = getTsSource(modulePath, moduleContent);
+    const changes = addDeclarationToModule(source, modulePath, 'FooComponent', './foo.component');
+    const output = applyChanges(modulePath, moduleContent, changes);
+    expect(output).toMatch(/import { FooComponent } from '.\/foo.component';/);
+    expect(output).toMatch(/declarations: \[\nAppComponent,\nFooComponent\n\]/);
   });
 
   it('should add metadata', () => {


### PR DESCRIPTION
…out indent

At the moment, at least a single whitespace is required as otherwise the following error `Cannot read property '0' of null ` will be thrown

Fixes #12950 and possible fixes #12073