### PR TITLE
feat(@angular/cli): option to build and run only specified spec files

### DIFF
--- a/packages/angular_devkit/build_angular/src/karma/index.ts
+++ b/packages/angular_devkit/build_angular/src/karma/index.ts
@@ -87,6 +87,7 @@ export class KarmaBuilder implements Builder<KarmaBuilderSchema> {
         karmaOptions.buildWebpack = {
           root: getSystemPath(root),
           projectRoot: getSystemPath(projectRoot),
+          sourceRoot: builderConfig.sourceRoot,
           options: options as NormalizedKarmaBuilderSchema,
           webpackConfig: this.buildWebpackConfig(root, projectRoot, sourceRoot, host,
             options as NormalizedKarmaBuilderSchema),

--- a/packages/angular_devkit/build_angular/src/karma/schema.json
+++ b/packages/angular_devkit/build_angular/src/karma/schema.json
@@ -62,6 +62,15 @@
       "type": "string",
       "description": "Defines the build environment."
     },
+    "spec": {
+      "type": "string",
+      "description": "Glob of files to include"
+    },
+    "specUpdate": {
+      "type": "boolean",
+      "description": "Should this only update generated test file?",
+      "default": false
+    },
     "sourceMap": {
       "type": "boolean",
       "description": "Output sourcemaps.",


### PR DESCRIPTION
A new `--spec` option is added. It is a glob/pattern that specifies which specs should be included in the build.
e.g. `ng test --spec=app/services/auth*` (`.spec.ts` is added automatically if missing)

When karma is already running, selected spec can be updated by running `ng test --spec=app/login* --spec-update`

With such option it is also trivial to add custom vscode task to be able to run currently open spec file.

Behind the scenes a new `test.generated.ts` (could be temp?) is saved next to original `test.ts` which instead of using `require.context` imports all matching files. This gives quite a big boost in the project at work (at least 10s on each iterative build!)

Fixes #3603

Motivation: It is a pain in a big application to wait until entire app is rebuilt just to run single `fit` block. Takes almost a minute with 4000+ tests and barely works when code coverage is enabled. 

Missing: docs(?) and tests 

Disclaimer: this is quick and dirty solution that can be improved a lot but some feedback before making it nice would be great!

