### PR TITLE
docs: correct target in run command docs

### DIFF
--- a/packages/angular/cli/commands/run-long.md
+++ b/packages/angular/cli/commands/run-long.md
@@ -3,7 +3,7 @@ The CLI commands run Architect targets such as `build`, `serve`, `test`, and `li
 Each named target has a default configuration, specified by an "options" object,
 and an optional set of named alternate configurations in the "configurations" object.
 
-For example, the "server" target for a newly generated app has a predefined
+For example, the "serve" target for a newly generated app has a predefined
 alternate configuration named "production".
 
 You can define new targets and their configuration options in the "architect" section


### PR DESCRIPTION
@jbogarthyde I think this commit https://github.com/angular/angular-cli/commit/1c39f54a24eb0893735d3cf87e8f3d6403bf8ae2 recently merged references a target "server" that doesn't exist instead of the "serve" target.