### PR TITLE
docs: typo in library command docs

### DIFF
--- a/packages/schematics/angular/library/library-long.md
+++ b/packages/schematics/angular/library/library-long.md
@@ -2,4 +2,4 @@ A library is a type of project that does not run independently.
 The library skeleton created by this command is placed by default in the `/projects` folder, and has `type` of "library".
 
 You can build a new library using the `ng build` command, run unit test for it using the `ng test` command,
-and lint it using  and the `ng lint` command.
+and lint it using the `ng lint` command.


### PR DESCRIPTION
@jbogarthyde introduced by the recently merged commit https://github.com/angular/angular-cli/commit/cf75a6401a8c4ffbb9e6e0ae93edb1b1c3ec97f3