### PR TITLE
Fix typos in command descriptions

### DIFF
--- a/packages/angular/cli/commands/run-long.md
+++ b/packages/angular/cli/commands/run-long.md
@@ -3,7 +3,7 @@ The CLI commands run Architect targets such as `build`, `serve`, `test`, and `li
 Each named target has a default configuration, specified by an "options" object,
 and an optional set of named alternate configurations in the "configurations" object.
 
-For example, the "server" target for a newly generated app has a predefined
+For example, the "serve" target for a newly generated app has a predefined
 alternate configuration named "production".
 
 You can define new targets and their configuration options in the "architect" section

--- a/packages/angular/cli/commands/update-long.md
+++ b/packages/angular/cli/commands/update-long.md
@@ -1,1 +1,7 @@
-Before running this command, see the interactive [Angular Update Guide](https://update.angular.io/).
+Perform a basic update to v7 of the core framework and CLI by running the following command.
+
+```
+ng update @angular/cli @angular/core‌
+```
+
+For detailed information and guidance on updating your application, see the interactive [Angular Update Guide](https://update.angular.io/).

--- a/packages/schematics/angular/library/library-long.md
+++ b/packages/schematics/angular/library/library-long.md
@@ -1,5 +1,5 @@
 A library is a type of project that does not run independently.
 The library skeleton created by this command is placed by default in the `/projects` folder, and has `type` of "library".
 
-You can build a new library using the `ng build` command, run unit test for it using the `ng test` command,
-and lint it using the `ng lint` command.
+You can build a new library using the `ng build` command, run unit tests for it using the `ng test` command,
+and lint it using  and the `ng lint` command.


### PR DESCRIPTION
Fixes typos reported in long descriptions of run cmd and library schematic.