### PR TITLE
fix(@angular-devkit/build-angular): remove inline style soucemaps in server output

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/styles.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/styles.ts
@@ -45,8 +45,8 @@ export function getStylesConfig(wco: WebpackConfigOptions) {
   // Determine hashing format.
   const hashFormat = getOutputHashFormat(buildOptions.outputHashing as string);
   // Convert absolute resource URLs to account for base-href and deploy-url.
-  const baseHref = wco.buildOptions.baseHref || '';
-  const deployUrl = wco.buildOptions.deployUrl || '';
+  const baseHref = buildOptions.baseHref || '';
+  const deployUrl = buildOptions.deployUrl || '';
 
   const postcssPluginCreator = function (loader: webpack.loader.LoaderContext) {
     return [
@@ -185,7 +185,7 @@ export function getStylesConfig(wco: WebpackConfigOptions) {
         options: {
           ident: 'embedded',
           plugins: postcssPluginCreator,
-          sourceMap: cssSourceMap ? 'inline' : false,
+          sourceMap: cssSourceMap && buildOptions.platform !== 'server' ? 'inline' : false,
         },
       },
       ...(use as webpack.Loader[]),


### PR DESCRIPTION
Fixes #12940