### PR TITLE
fix(@angular-devkit/build-angular): remove `skipAppShell` as it has no effect in browser builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/browser/schema.d.ts
+++ b/packages/angular_devkit/build_angular/src/browser/schema.d.ts
@@ -192,6 +192,7 @@ export interface BrowserBuilderSchema {
   ngswConfigPath?: string;
 
   /**
+   * @deprecated
    * Flag to prevent building an app shell.
    */
   skipAppShell: boolean;

--- a/packages/angular_devkit/build_angular/src/browser/schema.json
+++ b/packages/angular_devkit/build_angular/src/browser/schema.json
@@ -206,7 +206,8 @@
     "skipAppShell": {
       "type": "boolean",
       "description": "Flag to prevent building an app shell.",
-      "default": false
+      "default": false,
+      "x-deprecated": true
     },
     "index": {
       "type": "string",


### PR DESCRIPTION

Closes #11478

Followup of https://github.com/angular/angular-cli/pull/12790