### PR TITLE
refactor: deprecate `evalSourceMap`

### DIFF
--- a/packages/angular_devkit/build_angular/src/browser/schema.d.ts
+++ b/packages/angular_devkit/build_angular/src/browser/schema.d.ts
@@ -72,6 +72,7 @@ export interface BrowserBuilderSchema {
   vendorSourceMap?: boolean;
 
   /**
+    @deprecated
    * Output in-file eval sourcemaps.
    */
   evalSourceMap: boolean;

--- a/packages/angular_devkit/build_angular/src/dev-server/index.ts
+++ b/packages/angular_devkit/build_angular/src/dev-server/index.ts
@@ -51,6 +51,7 @@ export interface DevServerBuilderOptions {
   aot?: boolean;
   sourceMap?: boolean;
   vendorSourceMap?: boolean;
+  /**@deprecated */
   evalSourceMap?: boolean;
   vendorChunk?: boolean;
   commonChunk?: boolean;

--- a/packages/angular_devkit/build_angular/src/dev-server/schema.json
+++ b/packages/angular_devkit/build_angular/src/dev-server/schema.json
@@ -102,7 +102,8 @@
     },
     "evalSourceMap": {
       "type": "boolean",
-      "description": "Output in-file eval sourcemaps."
+      "description": "Output in-file eval sourcemaps.",
+      "x-deprecated": true
     },
     "vendorChunk": {
       "type": "boolean",

--- a/packages/angular_devkit/build_angular/src/karma/schema.json
+++ b/packages/angular_devkit/build_angular/src/karma/schema.json
@@ -74,7 +74,8 @@
     },
     "evalSourceMap": {
       "type": "boolean",
-      "description": "Output in-file eval sourcemaps."
+      "description": "Output in-file eval sourcemaps.",
+      "x-deprecated": true
     },
     "progress": {
       "type": "boolean",

--- a/packages/angular_devkit/build_angular/src/server/schema.json
+++ b/packages/angular_devkit/build_angular/src/server/schema.json
@@ -57,7 +57,8 @@
     "evalSourceMap": {
       "type": "boolean",
       "description": "Output in-file eval sourcemaps.",
-      "default": false
+      "default": false,
+      "x-deprecated": true
     },
     "vendorChunk": {
       "type": "boolean",


### PR DESCRIPTION
This was previously done for build performance, however this is no needed anymore