### PR TITLE
Direct component template loading in AOT

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/typescript.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/typescript.ts
@@ -82,6 +82,7 @@ function _createAotPlugin(
     forkTypeChecker: buildOptions.forkTypeChecker,
     contextElementDependencyConstructor: require('webpack/lib/dependencies/ContextElementDependency'),
     logger: wco.logger,
+    directTemplateLoading: true,
     ...options,
   };
   return new AngularCompilerPlugin(pluginOptions);

--- a/packages/ngtools/webpack/README.md
+++ b/packages/ngtools/webpack/README.md
@@ -43,6 +43,7 @@ The loader works with webpack plugin to compile your TypeScript. It's important 
 * `sourceMap`. Optional. Include sourcemaps.
 * `compilerOptions`. Optional. Override options in `tsconfig.json`.
 * `contextElementDependencyConstructor`. Optional. Set to `require('webpack/lib/dependencies/ContextElementDependency')` if you are having `No module factory available for dependency type: ContextElementDependency` errors.
+* `directTemplateLoading`. Optional. Causes the plugin to load component templates (HTML) directly from the filesystem.  This is more efficient if only using the `raw-loader` to load component templates.  Do not enable this option if additional loaders are configured for component templates.
 
 ## Features
 The benefits and ability of using [`@ngtools/webpack`](https://www.npmjs.com/~ngtools) standalone from the Angular CLI as presented in [Stephen Fluin's Angular CLI talk](https://youtu.be/uBRK6cTr4Vk?t=6m45s) at Angular Connect 2016:

--- a/packages/ngtools/webpack/src/angular_compiler_plugin.ts
+++ b/packages/ngtools/webpack/src/angular_compiler_plugin.ts
@@ -103,6 +103,7 @@ export interface AngularCompilerPluginOptions {
   platform?: PLATFORM;
   nameLazyFiles?: boolean;
   logger?: logging.Logger;
+  directTemplateLoading?: boolean;
 
   // added to the list of lazy routes
   additionalLazyModules?: { [module: string]: string };
@@ -627,6 +628,7 @@ export class AngularCompilerPlugin {
         this._basePath,
         host,
         watchMode,
+        this._options.directTemplateLoading,
       );
 
       // Create and set a new WebpackResourceLoader.

--- a/packages/ngtools/webpack/src/compiler_host.ts
+++ b/packages/ngtools/webpack/src/compiler_host.ts
@@ -46,6 +46,7 @@ export class WebpackCompilerHost implements ts.CompilerHost {
     basePath: string,
     host: virtualFs.Host,
     private readonly cacheSourceFiles: boolean,
+    private readonly directTemplateLoading = false,
   ) {
     this._syncHost = new virtualFs.SyncDelegateHost(host);
     this._memoryHost = new virtualFs.SyncDelegateHost(new virtualFs.SimpleMemoryHost());
@@ -326,6 +327,10 @@ export class WebpackCompilerHost implements ts.CompilerHost {
   }
 
   readResource(fileName: string) {
+    if (this.directTemplateLoading && fileName.endsWith('.html')) {
+      return this.readFile(fileName);
+    }
+
     if (this._resourceLoader) {
       // These paths are meant to be used by the loader so we must denormalize them.
       const denormalizedFileName = this.denormalizePath(normalize(fileName));


### PR DESCRIPTION
Currently within the CLI, a full webpack child compilation is created and executed to load a template via the `raw-loader` in AOT.  The end result is equivalent to reading the file directly.  This PR eliminates the overhead of the extra webpack compilation for the CLI by adding an option to the `@ngtools/webpack` plugin (defaulting to false to retain existing behavior) that reads the HTML component templates directly from the compiler host if enabled.  This option is then enabled for the CLI.