### PR TITLE
WIP: feat(@angular-devkit/schematics): add support for jobs as tasks 

### DIFF
--- a/lib/bootstrap-local.js
+++ b/lib/bootstrap-local.js
@@ -16,9 +16,16 @@ const ts = require('typescript');
 
 const tmpRoot = temp.mkdirSync('angular-devkit-');
 
+const compilerOptions = ts.readConfigFile(path.join(__dirname, '../tsconfig.json'), p => {
+  return fs.readFileSync(p, 'utf-8');
+}).config;
+
 let _istanbulRequireHook = null;
 if (process.env['CODE_COVERAGE'] || process.argv.indexOf('--code-coverage') !== -1) {
   _istanbulRequireHook = require('./istanbul-local').istanbulRequireHook;
+  // async keyword isn't supported by the Esprima version used by Istanbul version used by us.
+  // TODO: update istanbul to istanbul-lib-* (see http://istanbul.js.org/) and remove this hack.
+  compilerOptions.compilerOptions.target = 'es2016';
 }
 
 
@@ -60,11 +67,6 @@ if (process.env['DEVKIT_LONG_STACK_TRACE']) {
 
 global._DevKitIsLocal = true;
 global._DevKitRoot = path.resolve(__dirname, '..');
-
-
-const compilerOptions = ts.readConfigFile(path.join(__dirname, '../tsconfig.json'), p => {
-  return fs.readFileSync(p, 'utf-8');
-}).config;
 
 
 const oldRequireTs = require.extensions['.ts'];

--- a/lib/istanbul-local.js
+++ b/lib/istanbul-local.js
@@ -46,7 +46,7 @@ exports.istanbulRequireHook = function(code, filename) {
 
     instrumentedCode = instrumentedCode.replace(inlineSourceMapRe, '')
       + '//# sourceMappingURL=data:application/json;base64,'
-      + new Buffer(sourceMapGenerator.toString()).toString('base64');
+      + Buffer.from(sourceMapGenerator.toString()).toString('base64');
 
     // Keep the consumer from the original source map, because the reports from Istanbul (not
     // Constantinople) are already mapped against the code.

--- a/packages/angular_devkit/core/BUILD
+++ b/packages/angular_devkit/core/BUILD
@@ -109,6 +109,7 @@ ts_library(
     deps = [
         ":core",
         ":node",
+        "//tests/angular_devkit/core/node/jobs:jobs_test_lib",
         "@rxjs",
         "@rxjs//operators",
         "@npm//@types/node",

--- a/packages/angular_devkit/core/node/index.ts
+++ b/packages/angular_devkit/core/node/index.ts
@@ -10,5 +10,6 @@ import * as fs from './fs';
 export * from './cli-logger';
 export * from './host';
 export { ModuleNotFoundException, ResolveOptions, resolve } from './resolve';
+export * from './scheduler';
 
 export { fs };

--- a/packages/angular_devkit/core/node/scheduler.ts
+++ b/packages/angular_devkit/core/node/scheduler.ts
@@ -1,0 +1,73 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { jobs, schema } from '../src';
+import { ModuleNotFoundException, resolve } from './resolve';
+
+export class NodeModuleJobScheduler extends jobs.SimpleScheduler {
+  public constructor(
+    _schemaRegistry?: schema.SchemaRegistry,
+    private _resolveLocal = true,
+    private _resolveGlobal = false,
+  ) {
+    super(_schemaRegistry);
+  }
+
+  _resolve(name: string): string | null {
+    try {
+      return resolve(name, {
+        checkLocal: this._resolveLocal,
+        checkGlobal: this._resolveGlobal,
+        basedir: __dirname,
+      });
+    } catch (e) {
+      if (e instanceof ModuleNotFoundException) {
+        return null;
+      }
+      throw e;
+    }
+  }
+
+  /**
+   * Get a job description for a named job.
+   *
+   * @param name The name of the job.
+   * @returns A description, or null if the job is not registered.
+   */
+  protected _createDescription(name: jobs.JobName): jobs.SimpleSchedulerJobDescription | null {
+    const [moduleName, exportName] = name.split(/#/, 2);
+
+    const resolvedPath = this._resolve(moduleName);
+    if (!resolvedPath) {
+      return null;
+    }
+
+    const pkg = require(resolvedPath);
+    const handler = pkg[exportName || 'default'];
+    if (!handler) {
+      return null;
+    }
+
+    const input = ['boolean', 'object'].includes(typeof pkg.input)
+      ? pkg.input : handler.input !== undefined ? handler.input : true;
+    const output = ['boolean', 'object'].includes(typeof pkg.output)
+      ? pkg.output : handler.output !== undefined ? handler.output : true;
+    const channels = ['boolean', 'object'].includes(typeof pkg.channels)
+      ? pkg.channels : handler.channels !== undefined ? handler.channels : true;
+
+    return {
+      description: {
+        input,
+        output,
+        name,
+        channels,
+        inputChannel: true,
+      },
+      handler: pkg['default'],
+    };
+  }
+}

--- a/packages/angular_devkit/core/node/scheduler_spec.ts
+++ b/packages/angular_devkit/core/node/scheduler_spec.ts
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import * as path from 'path';
+import { NodeModuleJobScheduler } from './scheduler';
+
+const root = path.join(
+  path.dirname(require.resolve(__filename)),
+  '../../../../tests/angular_devkit/core/node/jobs',
+);
+
+
+describe('NodeModuleJobScheduler', () => {
+  it('works', async () => {
+    const scheduler = new NodeModuleJobScheduler();
+
+    const job = scheduler.schedule(path.join(root, 'add'), [1, 2, 3]);
+    expect(await job.promise).toBe(6);
+  });
+});

--- a/packages/angular_devkit/core/src/exception/exception.ts
+++ b/packages/angular_devkit/core/src/exception/exception.ts
@@ -13,7 +13,7 @@ export class BaseException extends Error {
 }
 
 
-export class UnknownException extends Error {
+export class UnknownException extends BaseException {
   constructor(message: string) { super(message); }
 }
 

--- a/packages/angular_devkit/core/src/index.ts
+++ b/packages/angular_devkit/core/src/index.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import * as experimental from './experimental';
+import * as jobs from './jobs';
 import * as json from './json';
 import * as logging from './logger';
 import * as terminal from './terminal';
@@ -17,6 +18,7 @@ export * from './virtual-fs';
 
 export {
   experimental,
+  jobs,
   json,
   logging,
   terminal,

--- a/packages/angular_devkit/core/src/jobs/README.md
+++ b/packages/angular_devkit/core/src/jobs/README.md
@@ -1,0 +1,205 @@
+# Jobs
+
+Jobs is the Angular DevKit subsystem for scheduling and running generic functions with clearly 
+typed inputs and outputs. A Job is 
+
+The whole API is serializable, allowing someone to use a Node Stream or message channel to 
+communicate between the job and the job scheduler.
+
+## Input, Output and Channels
+Jobs can emit multiple outputs, and receives an input when first started. In addition, jobs can
+listen to an input channel, and multiple output channels. Those channels are asynchronous
+JSON messages that can be typed.
+
+If a Job was an executable, the input would be the arguments on the command line, the input 
+channel would be STDIN, the output channel would be STDOUT and STDERR (through Observable errors),
+and the channels would be additional pipes out.
+
+# Creating Jobs
+
+A job is at its core a function with a Schema associated to it;
+
+```typescript
+import { Observable } from 'rxjs';
+import { jobs } from '@angular-devkit/core';
+
+const input = {
+  type: 'array', items: { type: 'number' },
+};
+const output = {
+  type: 'number',
+};
+
+export function add(input: number[]): Observable<jobs.JobEvent<number>> {
+  return new Observable(o => {
+    o.next({ kind: jobs.JobEventKind.Start });
+    o.next({
+      kind: jobs.JobEventKind.Output,
+      output: input.reduce((total, curr) => total + curr, 0),
+    });
+    o.next({ kind: jobs.JobEventKind.End });
+  });
+}
+
+// Register the job in a SimpleJobRegistry. Different registries have different API.
+declare const registry: SimpleJobRegistry;
+registry.register('add', add, {
+  input: input,
+  output: output,
+});
+
+// Calling the job, and logging its output.
+declare const scheduler: jobs.Scheduler;
+scheduler.schedule('add', [1, 2, 3, 4])
+    .output.subscribe(x => console.log(x));  // Will output 10.
+```
+
+This is a lot of boilerplate, so we made some helpers to improve readability and manage input 
+and output automatically;
+
+```typescript
+// Add is a JobHandler function, like the above.
+export const add = jobs.createJob<number[], number>(
+  input => input.reduce((total, curr) => total + curr, 0),
+);
+
+// Schedule like above.
+```
+
+You can also return a Promise or an Observable, as jobs are asynchronous. This helper will set 
+progress to 0, start and end events appropriately, and will pass in a logger. It will also manage
+channels automatically (see below).
+
+A more complex job can be declared like this:
+
+```typescript
+import { Observable } from 'rxjs';
+import { JobRegistry } from './api'
+
+// Show progress with each count. Output "more" in a channel.
+export const count = jobs.createJob<number, number>(
+  // Receive a context that contains additional methods, like progress, logger and channels.
+  (input: number, { progress, channels }) => new Observable<number>(o => {
+    let i = 0;
+    function doCount() {
+      o.next(i++);
+      progress(i / input);
+      channels['side'].next('more');
+  
+      if (i < input) {
+        setTimeout(doCount, 100);
+      } else {
+        o.complete();
+      }
+    }
+    setTimeout(doCount, 100);
+  }),
+  {
+      input: { type: 'number' },
+      output: { type: 'number' },
+      channels: {
+        'side': { type: 'string', const: 'more' },
+      },
+  },
+);
+
+declare const registry: JobRegistry;
+// Register this job with `registry.register('count', count)`.
+
+const job = registry.schedule('count');
+job.channels['side'] && job.channels['side'].subscribe((x: json.JsonValue) => console.log(x));
+const c = job.getChannel<string>('side', { type: 'string' });
+if (c) {
+  c.subscribe((x: string) => console.log(x));
+}
+```
+
+## Job Extension
+A Job can extend other jobs, meaning their inputs and outputs have to be a superset of the job 
+extended. This is useful for making compatible jobs that can be replaced by others.
+
+## Job Groups
+Groups are an additional way to synchronize and execute logic on scheduling the job, from the 
+side of the scheduler. This logic will always apply in the thread the job is scheduled, and not
+where the job is created/registered.
+
+Job groups are a job helper that redirect to different jobs. To create a job group, use the
+`createGroup()` function:
+
+```typescript
+import { jobs } from '@angular-devkit/core';
+
+// A group that installs node modules.
+const group = jobs.createGroup({
+  name: 'node-install',
+  input: {
+    properties: {
+      moduleName: { type: 'string' },
+    },
+  },
+  output: { type: 'boolean' },
+});
+
+// Extending makes sure the input and output matches the group.
+const npmInstall = jobs.createJob(/* ... */, { name: 'npm-install', extends: group });
+const yarnInstall = jobs.createJob(/* ... */, { name: 'yarn-install', extends: group });
+const pnpmInstall = jobs.createJob(/* ... */, { name: 'pnpm-install', extends: group });
+
+declare const registry: jobs.SimpleJobRegistry;
+registry.register(group);
+registry.register(npmInstall);
+registry.register(yarnInstall);
+registry.register(pnpmInstall);
+
+// Default to npm.
+group.setDefaultDelegate(npmInstall.name);
+// If the user is asking for yarn over npm, uses it.
+group.addConditionalDelegate(() => userWantsYarn, yarnInstall.name);
+```
+
+## Execution Strategy
+
+Jobs are always run in parallel and will always start, but many helper functions are provided 
+when creating a job to help you control the execution strategy;
+
+1. `serialize()`. Multiple runs of this job will be queued with each others.
+1. `reuse(replayEvents = false)`. Jobs with this strategy will reuse an already running job. If 
+`replayEvents` is true, all events will be replayed in the same order.
+1. `memoize(replayEvents = false)` will create a job, or reuse the same job  when inputs are 
+matching. If the inputs don't match, a new job will be started and its outputs will be stored.
+
+These strategies can be used when creating the job:
+
+```typescript
+// Same input and output as above.
+
+export const add = jobs.strategy.memoize()(
+  jobs.createJob<number[], number>(
+      input => input.reduce((total, curr) => total + curr, 0),
+  ),
+);
+```
+
+Strategies can be reused to synchronize between jobs. For example, given jobs `jobA` and `jobB`, 
+you can reuse the strategy to serialize both jobs together;
+
+```typescript
+const strategy = jobs.strategy.serialize();
+const jobA = strategy(jobs.createJob(...));
+const jobB = strategy(jobs.createJob(...));
+```
+
+# Executing Jobs
+
+## SimpleJobRegistry
+A registry that accept job registration, and can also schedule jobs.
+
+## NodeModuleJobScheduler
+A scheduler that loads jobs using their node package names. These jobs need to use the
+`createJob()` helper and report their input/output schemas that way.
+
+```javascript
+declare const scheduler: NodeModuleJobScheduler;
+
+scheduler.schedule('some-node-package#someExport', 'input');
+```

--- a/packages/angular_devkit/core/src/jobs/api.ts
+++ b/packages/angular_devkit/core/src/jobs/api.ts
@@ -1,0 +1,421 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { Observable, Observer } from 'rxjs';
+import { JsonObject, JsonValue, schema } from '../json';
+import { LogEntry, LoggerApi } from '../logger';
+import { DeepReadonly } from '../utils';
+
+/**
+ * Job Name is just a string (needs to be serializable).
+ */
+export type JobName = string;
+
+/**
+ * Metadata associated with a job.
+ */
+export interface JobDescription extends JsonObject {
+  readonly name: JobName;
+  readonly input: DeepReadonly<schema.JsonSchema>;
+  readonly output: DeepReadonly<schema.JsonSchema>;
+
+  readonly channels: { [name: string]: DeepReadonly<schema.JsonSchema> };
+  readonly inputChannel: DeepReadonly<schema.JsonSchema>;
+}
+
+/**
+ * Events that can be sent TO a job. The job needs to listen to those.
+ */
+export enum JobInputKind {
+  Ping = 0,
+  Stop = 1,
+
+  // Channel specific events.
+  ChannelMessage = 100,
+  ChannelError,
+  ChannelComplete,
+}
+
+/** Base interface for the all job input events. */
+export interface JobInputBase extends JsonObject {
+  /**
+   * The kind of event this is.
+   */
+  readonly kind: JobInputKind;
+}
+
+/**
+ * A ping to the job. The job should reply with a pong as soon as possible.
+ */
+export interface JobInputPing extends JobInputBase {
+  readonly kind: JobInputKind.Ping;
+}
+
+/**
+ * Stop the job. This is handled by the job itself and jobs might not handle it.
+ * This is equivalent to SIGTERM.
+ */
+export interface JobInputStop extends JobInputBase {
+  readonly kind: JobInputKind.Stop;
+}
+
+
+/**
+ * Base interface for all job event related to channels.
+ */
+export interface JobInputChannelBase extends JobInputBase {
+  // There's only 1 input channel.
+}
+
+/**
+ * A Job wants to send a message to a channel. This can be marshaled, and the Job object
+ * has helpers to transform this into an observable. The context also can create RxJS subjects that
+ * marshall events through a channel.
+ */
+export interface JobInputChannelMessage extends JobInputChannelBase {
+  readonly kind: JobInputKind.ChannelMessage;
+
+  /**
+   * The message being sent to the channel.
+   */
+  readonly message: JsonValue;
+}
+
+/**
+ * A Job wants to send an error to one of its channel. This is the equivalent of throwing through
+ * an Observable. The side channel will not receive any more messages after this, and will not
+ * complete.
+ */
+export interface JobInputChannelError extends JobInputChannelBase {
+  readonly kind: JobInputKind.ChannelError;
+
+  /**
+   * The error message being sent to the channel.
+   */
+  readonly error: JsonValue;
+}
+
+/**
+ * A Job wants to close the channel, as completed. This is done automatically when the job ends,
+ * or can be done from the job to close it. A closed channel cannot be reopened.
+ */
+export interface JobInputChannelComplete extends JobInputChannelBase {
+  readonly kind: JobInputKind.ChannelComplete;
+}
+
+export type JobInput =
+  JobInputPing
+  | JobInputStop
+  | JobInputChannelMessage
+  | JobInputChannelError
+  | JobInputChannelComplete;
+
+/**
+ * Kind of events that can be outputted from a job.
+ */
+export enum JobEventKind {
+  // Lifecycle specific events.
+  Create = 0,
+  Start,
+  End,
+  Pong,
+
+  // Feedback events.
+  Progress,
+  Log,
+  Output,
+
+  // Channel specific events.
+  ChannelMessage = 100,
+  ChannelError,
+  ChannelComplete,
+}
+
+/** Base interface for the all job events. */
+export interface JobEventBase extends JsonObject {
+  /**
+   * The Job Description.
+   */
+  readonly description: JobDescription;
+
+  /**
+   * The kind of event this is.
+   */
+  readonly kind: JobEventKind;
+}
+
+/**
+ * The Job has been created and will validate its input.
+ */
+export interface JobEventCreate extends JobEventBase {
+  readonly kind: JobEventKind.Create;
+}
+
+/**
+ * The Job started. This is done by the job itself.
+ */
+export interface JobEventStart extends JobEventBase {
+  readonly kind: JobEventKind.Start;
+}
+
+/**
+ * A logging event, supporting the logging.LogEntry.
+ */
+export interface JobEventLog extends JobEventBase {
+  readonly kind: JobEventKind.Log;
+  readonly entry: LogEntry;
+}
+
+/**
+ * Progress notification.
+ */
+export interface JobEventProgress extends JobEventBase {
+  readonly kind: JobEventKind.Progress;
+  /**
+   * Clamped between 0 and 1. 1 is considered 100% done.
+   */
+  readonly progress: number;
+}
+
+/**
+ * An output value is available.
+ */
+export interface JobEventOutput<OutputT extends JsonValue> extends JobEventBase {
+  readonly kind: JobEventKind.Output;
+  readonly output: OutputT;
+}
+
+
+/**
+ * Base interface for all job event related to channels.
+ */
+export interface JobEventChannelBase extends JobEventBase {
+  /**
+   * The name of the channel.
+   */
+  readonly name: string;
+}
+
+/**
+ * A Job wants to send a message to a channel. This can be marshaled, and the Job object
+ * has helpers to transform this into an observable. The context also can create RxJS subjects that
+ * marshall events through a channel.
+ */
+export interface JobEventChannelMessage extends JobEventChannelBase {
+  readonly kind: JobEventKind.ChannelMessage;
+
+  /**
+   * The message being sent to the channel.
+   */
+  readonly message: JsonValue;
+}
+
+/**
+ * A Job wants to send an error to one of its channel. This is the equivalent of throwing through
+ * an Observable. The side channel will not receive any more messages after this, and will not
+ * complete.
+ */
+export interface JobEventChannelError extends JobEventChannelBase {
+  readonly kind: JobEventKind.ChannelError;
+
+  /**
+   * The error message being sent to the channel.
+   */
+  readonly error: JsonValue;
+}
+
+/**
+ * A Job wants to close the channel, as completed. This is done automatically when the job ends,
+ * or can be done from the job to close it. A closed channel cannot be reopened.
+ */
+export interface JobEventChannelComplete extends JobEventChannelBase {
+  readonly kind: JobEventKind.ChannelComplete;
+}
+
+/**
+ * End of the job run.
+ */
+export interface JobEventEnd extends JobEventBase {
+  readonly kind: JobEventKind.End;
+}
+
+/**
+ * The Job has been created and will validate its input.
+ */
+export interface JobEventPong extends JobEventBase {
+  readonly kind: JobEventKind.Pong;
+}
+
+/**
+ * Generic event type.
+ */
+export type JobEvent<OutputT extends JsonValue> =
+  JobEventCreate
+  | JobEventStart
+  | JobEventLog
+  | JobEventProgress
+  | JobEventOutput<OutputT>
+  | JobEventChannelMessage
+  | JobEventChannelError
+  | JobEventChannelComplete
+  | JobEventEnd
+  | JobEventPong;
+
+/**
+ * The context in which the job is run.
+ */
+export interface JobHandlerContext<
+  MinimumInputValueT extends JsonValue = JsonValue,
+  MinimumOutputValueT extends JsonValue = JsonValue,
+> {
+  readonly description: JobDescription;
+  readonly scheduler: Scheduler<MinimumInputValueT, MinimumOutputValueT>;
+  readonly dependencies: Job<{}>[];
+
+  readonly input: Observable<JobInput>;
+}
+
+/**
+ * The Job Handler, which is a method that's executed for the job.
+ */
+export interface JobHandler<InputT extends JsonValue, OutputT extends JsonValue> {
+  (
+    input: InputT,
+    context: JobHandlerContext,
+  ): Observable<JobEvent<OutputT>>;
+}
+
+
+/**
+ * The state of a job. These are changed as the job reports a new state through its events.
+ */
+export enum JobState {
+  Queued = 0,
+  Created = 1,
+  Started = 2,
+  Ended = 4,
+}
+
+
+/**
+ * A Job instance, returned from scheduling a job. A Job Instance is _not_ serializable.
+ */
+export interface Job<O extends JsonValue> {
+  /**
+   * The unique ID of the job.
+   */
+  readonly id: symbol;
+
+  /**
+   * Description of the job.
+   */
+  readonly description: JobDescription;
+
+  /**
+   * The input to the job. This goes through the input channel as messages.
+   */
+  readonly input: Observer<JsonValue>;
+
+  /**
+   * Outputs of this Job. This is sugar for
+   * `this.pipe(filter(x => x.kind == JobEventKind.Output), map(x => x.output))`.
+   */
+  readonly output: Observable<O>;
+
+  /**
+   * Last output for this Job. This is sugar for `output.pipe(last()).toPromise()`.
+   */
+  readonly promise: Promise<O | undefined>;
+
+  /**
+   * The current state of the job.
+   */
+  readonly state: JobState;
+
+  /**
+   * A progress indication of the job, between 0 and 1. While the job is Started, this will be the
+   * last value reported by a JobEventProgress event. If the job has ended this will be 1.
+   */
+  readonly progress: number;
+
+  /**
+   * All channels available.
+   */
+  readonly channels: { [name: string]: Observable<JsonValue> };
+
+  /**
+   * The JobInput events TO the job.
+   */
+  readonly inputChannel: Observer<JobInput>;
+
+  /**
+   * The JobEvent FROM the job.
+   */
+  readonly outputChannel: Observable<JobEvent<O>>;
+}
+
+/**
+ * Options for scheduling jobs.
+ */
+export interface ScheduleJobOptions {
+  /**
+   * Where should logging be passed in. By default logging will be dropped.
+   */
+  logger?: LoggerApi;
+
+  /**
+   * Jobs that need to finish before scheduling this job. These dependencies will not be passed
+   * to the job itself.
+   */
+  dependencies?: Job<{}> | Job<{}>[];
+}
+
+/**
+ * An interface that can schedule jobs.
+ */
+export interface Scheduler<
+  MinimumInputValueT extends JsonValue = JsonValue,
+  MinimumOutputValueT extends JsonValue = JsonValue,
+> {
+  /**
+   * Get a job description for a named job.
+   *
+   * @param name The name of the job.
+   * @returns A description, or null if the job is not registered.
+   */
+  getDescription(name: JobName): JobDescription | null;
+
+  /**
+   * Returns true if the job name has been registered.
+   * @param name The name of the job.
+   * @returns True if the job exists, false otherwise.
+   */
+  has(name: JobName): boolean;
+
+  /**
+   * Pause the scheduler, temporary queueing _new_ jobs. Returns a resume function that should be
+   * used to resume execution. If multiple `pause()` were called, all their resume functions must
+   * be called before the Scheduler actually starts new jobs. Additional calls to the same resume
+   * function will have no effect.
+   *
+   * Jobs already running are NOT paused. This is pausing the scheduler only.
+   */
+  pause(): () => void;
+
+  /**
+   * Schedule a job to be run, using its name.
+   * @param name The name of job to be run.
+   * @param input
+   * @param options
+   * @returns The Job being run.
+   */
+  schedule<I extends MinimumInputValueT, O extends MinimumOutputValueT>(
+    name: JobName,
+    input: I,
+    options?: ScheduleJobOptions,
+  ): Job<O>;
+}

--- a/packages/angular_devkit/core/src/jobs/api.ts
+++ b/packages/angular_devkit/core/src/jobs/api.ts
@@ -419,3 +419,15 @@ export interface Scheduler<
     options?: ScheduleJobOptions,
   ): Job<O>;
 }
+
+
+/**
+ * Returns true if the passed in value is a JobHandler<>.
+ */
+export function isJobHandler<InputT extends JsonValue, OutputT extends JsonValue>(
+  // TODO: this should be unknown
+  // tslint:disable-next-line:no-any
+  value: any,
+): value is JobHandler<InputT, OutputT> {
+  return typeof value == 'function' && value.length < 3;
+}

--- a/packages/angular_devkit/core/src/jobs/create-job.ts
+++ b/packages/angular_devkit/core/src/jobs/create-job.ts
@@ -72,28 +72,6 @@ export interface JobHandlerWithExtra<
 }
 
 
-export function renameJob<I extends JsonValue, O extends JsonValue>(
-  handler: JobHandlerWithExtra<I, O>,
-  options: RegisterJobOptions,
-): JobHandlerWithExtra<I, O>;
-export function renameJob<I extends JsonValue, O extends JsonValue>(
-  handler: JobHandlerWithExtra<I, O>,
-  options: RegisterJobOptions & { jobName: JobName },
-): JobHandlerWithExtra<I, O> & { jobName: JobName };
-
-/**
- * Allows you to override options of another job. This can be used to rename the job for example.
- * @param handler The other job.
- * @param options Additional information to add.
- */
-export function renameJob<I extends JsonValue, O extends JsonValue>(
-  handler: JobHandlerWithExtra<I, O>,
-  options: RegisterJobOptions,
-): JobHandlerWithExtra<I, O> {
-  return Object.assign(handler, options);
-}
-
-
 export function createJob<I extends JsonValue, O extends JsonValue>(
   fn: SimpleJobHandlerFn<I, O>,
   options: Partial<RegisterJobOptions> & { jobName: JobName },
@@ -222,6 +200,27 @@ export function createJob<I extends JsonValue, O extends JsonValue>(
     });
   };
 
+  return Object.assign(handler, options);
+}
+
+export function renameJob<I extends JsonValue, O extends JsonValue>(
+  handler: JobHandlerWithExtra<I, O>,
+  options: RegisterJobOptions,
+): JobHandlerWithExtra<I, O>;
+export function renameJob<I extends JsonValue, O extends JsonValue>(
+  handler: JobHandlerWithExtra<I, O>,
+  options: RegisterJobOptions & { jobName: JobName },
+): JobHandlerWithExtra<I, O> & { jobName: JobName };
+
+/**
+ * Allows you to override options of another job. This can be used to rename the job for example.
+ * @param handler The other job.
+ * @param options Additional information to add.
+ */
+export function renameJob<I extends JsonValue, O extends JsonValue>(
+  handler: JobHandlerWithExtra<I, O>,
+  options: RegisterJobOptions,
+): JobHandlerWithExtra<I, O> {
   return Object.assign(handler, options);
 }
 

--- a/packages/angular_devkit/core/src/jobs/create-job.ts
+++ b/packages/angular_devkit/core/src/jobs/create-job.ts
@@ -1,0 +1,204 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ *
+ */
+import { Observable, Observer, Subject, SubscriptionLike, isObservable } from 'rxjs';
+import { JsonValue, schema } from '../json';
+import { Logger, LoggerApi } from '../logger';
+import { isPromise, mapObject } from '../utils';
+import {
+  JobEvent,
+  JobEventKind,
+  JobHandler,
+  JobHandlerContext,
+  JobInputKind,
+  JobName,
+} from './api';
+import { RegisterJobOptions } from './simple-registry';
+
+
+export interface SimpleJobHandlerContext extends JobHandlerContext {
+  logger: LoggerApi;
+  progress: (p: number) => void;
+  channels: { [name: string]: Observer<JsonValue> };
+  inputChannel: Observable<JsonValue>;
+}
+
+
+/**
+ * A simple version of the JobHandler. This simplifies a lot of the interaction with the job
+ * scheduler and registry. For example, instead of returning a JobEvent observable, you can
+ * directly return an output.
+ */
+export type SimpleJobHandlerFn<I extends JsonValue, O extends JsonValue> = (
+  input: I,
+  context: SimpleJobHandlerContext,
+) => O | Promise<O> | Observable<O>;
+
+
+/**
+ * A Job Handler with extra information associated with it.
+ */
+export interface JobHandlerWithExtra<
+  InputT extends JsonValue,
+  OutputT extends JsonValue,
+> extends JobHandler<InputT, OutputT> {
+  /**
+   * The name of the job for the handler.
+   */
+  readonly jobName?: JobName;
+
+  /**
+   * All the channel names supported by this job, and their schemas. This must be known in
+   * advance, but can be omitted if no channel is supported.
+   */
+  readonly channels?: {
+    readonly [name: string]: schema.JsonSchema;
+  };
+
+  /**
+   * The input schema of the job. If unspecified, use the smallest intersection of all extends.
+   */
+  readonly input?: schema.JsonSchema;
+
+  /**
+   * The output schema of the job. If unspecified, use the smallest intersection of all extends.
+   */
+  readonly output?: schema.JsonSchema;
+}
+
+
+export function createJob<I extends JsonValue, O extends JsonValue>(
+  fn: SimpleJobHandlerFn<I, O>,
+  options: Partial<RegisterJobOptions> & { jobName: JobName },
+): JobHandlerWithExtra<I, O> & { jobName: JobName };
+export function createJob<I extends JsonValue, O extends JsonValue>(
+  fn: SimpleJobHandlerFn<I, O>,
+  options?: Partial<RegisterJobOptions>,
+): JobHandlerWithExtra<I, O>;
+
+/**
+ * Make a simple job handler that sets start, progress and end from a function that's synchronous
+ * or does not report progress.
+ *
+ * @param fn The function to create a handler for.
+ * @param options An optional set of properties to set on the handler. Some fields might be
+ *   required by registry or schedulers.
+ */
+export function createJob<I extends JsonValue, O extends JsonValue>(
+  fn: SimpleJobHandlerFn<I, O>,
+  options: RegisterJobOptions = {},
+): JobHandlerWithExtra<I, O> {
+  const handler: JobHandlerWithExtra<I, O> = (input: I, context) => {
+    const description = context.description;
+    const inputStream = context.input;
+    const inputChannel = new Subject<JsonValue>();
+    let subscription: SubscriptionLike | null = null;
+
+    return new Observable<JobEvent<O>>(subject => {
+      subject.next({ kind: JobEventKind.Start, description });
+
+      // Handle input.
+      inputStream.subscribe(event => {
+        switch (event.kind) {
+          case JobInputKind.Ping:
+            subject.next({ kind: JobEventKind.Pong, description });
+            break;
+
+          case JobInputKind.Stop:
+            // There's no way to cancel a promise or a synchronous function, but we do cancel
+            // observables where possible.
+            if (subscription) {
+              subscription.unsubscribe();
+            }
+            subject.complete();
+            break;
+
+          case JobInputKind.ChannelComplete:
+            inputChannel.complete();
+            break;
+          case JobInputKind.ChannelError:
+            inputChannel.error(event.error);
+            break;
+          case JobInputKind.ChannelMessage:
+            inputChannel.next(event.message);
+            break;
+        }
+      });
+
+      // Configure a logger to pass in as additional context.
+      const logger = new Logger('job');
+      logger.subscribe(entry => {
+        subject.next({
+          kind: JobEventKind.Log,
+          description,
+          entry,
+        });
+      });
+
+      function progress(progress: number) {
+        subject.next({ kind: JobEventKind.Progress, description, progress });
+      }
+
+      // Execute the function with the additional context.
+      subject.next({ kind: JobEventKind.Progress, description, progress: 0 });
+      const result = fn(input, {
+        ...context,
+        channels: mapObject(context.description.channels, name => {
+          const s = new Subject<JsonValue>();
+          s.asObservable().subscribe(
+            message => subject.next({
+              kind: JobEventKind.ChannelMessage, description, message, name,
+            }),
+            error => subject.next({
+              kind: JobEventKind.ChannelError, description, error, name,
+            }),
+            () => subject.next({
+              kind: JobEventKind.ChannelComplete, description, name,
+            }),
+          );
+
+          return s;
+        }),
+        inputChannel: inputChannel.asObservable(),
+        logger,
+        progress,
+    });
+
+      // If the result is a promise, simply wait for it to complete before reporting full progress
+      // and the result.
+      if (isPromise(result)) {
+        result.then(result => {
+          progress(1);
+          subject.next({ kind: JobEventKind.Output, description, output: result });
+          subject.next({ kind: JobEventKind.End, description });
+          subject.complete();
+        }, err => subject.error(err));
+      } else if (isObservable(result)) {
+        subscription = (result as Observable<O>).subscribe(
+          (output: O) => subject.next({ kind: JobEventKind.Output, description, output }),
+          error => subject.error(error),
+          () => {
+            progress(1);
+            subject.next({ kind: JobEventKind.End, description });
+            subject.complete();
+          },
+        );
+
+        return subscription;
+      } else {
+        // If it's a scalar value, report it synchronously.
+        progress(1);
+        subject.next({ kind: JobEventKind.Output, description, output: result as O });
+        subject.next({ kind: JobEventKind.End, description });
+        subject.complete();
+      }
+    });
+  };
+
+  return Object.assign(handler, options);
+}

--- a/packages/angular_devkit/core/src/jobs/exception.ts
+++ b/packages/angular_devkit/core/src/jobs/exception.ts
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { BaseException } from '../exception';
+import { JobName } from './api';
+
+export class JobNameAlreadyRegisteredException extends BaseException {
+  constructor(name: JobName) {
+    super(`Job named ${JSON.stringify(name)} already exists.`);
+  }
+}
+
+export class JobDoesNotExistException extends BaseException {
+  constructor(name: JobName) {
+    super(`Job name ${JSON.stringify(name)} does not exist.`);
+  }
+}

--- a/packages/angular_devkit/core/src/jobs/group.ts
+++ b/packages/angular_devkit/core/src/jobs/group.ts
@@ -1,0 +1,95 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ *
+ */
+import { Observable } from 'rxjs';
+import { JsonValue, schema } from '../json';
+import { Readwrite } from '../utils';
+import { JobDescription, JobEvent, JobHandler, JobName } from './api';
+import { JobDoesNotExistException } from './exception';
+
+/**
+ * A JobGroup can be used to
+ */
+export interface JobGroup<I extends JsonValue, O extends JsonValue> extends JobHandler<I, O> {
+  /**
+   * the name of the job.
+   */
+  readonly jobName?: string;
+
+  /**
+   * All the channel names supported by this job, and their schemas. This must be known in
+   * advance, but can be omitted if no channel is supported.
+   */
+  readonly channels?: {
+    readonly [name: string]: schema.JsonSchema;
+  };
+
+  /**
+   * The input schema of the job. If unspecified, use the smallest intersection of all extends.
+   */
+  readonly input?: schema.JsonSchema;
+
+  /**
+   * The output schema of the job. If unspecified, use the smallest intersection of all extends.
+   */
+  readonly output?: schema.JsonSchema;
+
+  /**
+   * Set the default job if all conditionals failed.
+   * @param jobName
+   */
+  setDefaultJob(jobName: string | null | { jobName: string }): void;
+
+  /**
+   * Add a conditional job that will be selected if the input fits a predicate.
+   * @param predicate
+   * @param jobName
+   */
+  addConditionalJob(predicate: (args: I) => boolean, jobName: string): void;
+}
+
+
+/**
+ * Create a group that can dispatch to a sub job, depending on conditions.
+ * @param options
+ */
+export function createGroup<I extends JsonValue, O extends JsonValue>(
+  options: Partial<Readwrite<JobDescription>> & { jobName?: string } = {},
+): JobGroup<I, O> {
+  let defaultDelegate: JobName | null = null;
+  const conditionalDelegateList: [(args: I) => boolean, JobName][] = [];
+
+  const job: JobHandler<I, O> = (input, context) => {
+    const maybeDelegate = conditionalDelegateList.find(([predicate]) => predicate(input));
+
+    if (maybeDelegate) {
+      return context.scheduler
+        .schedule(maybeDelegate[1], input).outputChannel as Observable<JobEvent<O>>;
+    } else if (defaultDelegate) {
+      return context.scheduler
+        .schedule(defaultDelegate, input).outputChannel as Observable<JobEvent<O>>;
+    } else {
+      throw new JobDoesNotExistException('<null>');
+    }
+  };
+
+  return Object.assign(job, {
+    ...options,
+
+    setDefaultJob(jobName: string | null | { jobName: string }) {
+      if (jobName && typeof jobName !== 'string') {
+        jobName = jobName.jobName;
+      }
+
+      defaultDelegate = jobName;
+    },
+    addConditionalJob(predicate: (args: I) => boolean, jobName: string) {
+      conditionalDelegateList.push([predicate, jobName]);
+    },
+  });
+}

--- a/packages/angular_devkit/core/src/jobs/group_spec.ts
+++ b/packages/angular_devkit/core/src/jobs/group_spec.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { createJob } from './create-job';
+import { createGroup } from './group';
+import { SimpleJobRegistry } from './simple-registry';
+
+describe('createGroup', () => {
+  it('works', async () => {
+    const registry = new SimpleJobRegistry();
+
+    const group = createGroup({
+      jobName: 'add',
+      input: { items: { type: 'number' } },
+      output: { type: 'number' },
+    });
+    const add0 = createJob((input: number[]) => input.reduce((a, c) => a + c, 0), {
+      jobName: 'add0',
+      extends: 'add',
+    });
+    const add100 = createJob((input: number[]) => input.reduce((a, c) => a + c, 100), {
+      jobName: 'add100',
+      extends: 'add',
+    });
+
+    registry.register(group);
+    registry.register(add0);
+    registry.register(add100);
+
+    group.setDefaultJob(add0);
+    const sum = await registry.schedule('add', [1, 2, 3, 4]).promise;
+    expect(sum).toBe(10);
+  });
+});

--- a/packages/angular_devkit/core/src/jobs/index.ts
+++ b/packages/angular_devkit/core/src/jobs/index.ts
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import * as strategy from './strategy';
+
+export * from './api';
+export * from './create-job';
+export * from './exception';
+export * from './group';
+export * from './simple-registry';
+export * from './simple-scheduler';
+
+export { strategy };

--- a/packages/angular_devkit/core/src/jobs/simple-registry.ts
+++ b/packages/angular_devkit/core/src/jobs/simple-registry.ts
@@ -1,0 +1,195 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { JsonValue, schema } from '../json';
+import { JobDescription, JobHandler, JobName } from './api';
+import { JobDoesNotExistException, JobNameAlreadyRegisteredException } from './exception';
+import { SimpleScheduler, SimpleSchedulerJobDescription } from './simple-scheduler';
+
+
+/**
+ * SimpleJobRegistry job registration options.
+ */
+export interface RegisterJobOptions {
+  /**
+   * The input schema.
+   */
+  input?: schema.JsonSchema;
+  /**
+   * The output schema.
+   */
+  output?: schema.JsonSchema;
+
+  /**
+   * Schemas of all channels.
+   */
+  channels?: { [name: string]: schema.JsonSchema };
+
+  /**
+   * Schema of the input channel.
+   */
+  inputChannel?: schema.JsonSchema;
+
+  /**
+   * The name of the job to register. This can be used to override the JobHandler's information.
+   */
+  jobName?: JobName;
+
+  /**
+   * Compatible jobs to this one, ie. jobs that have an input and output schema that is a subset
+   * of this one. Inputs and Outputs will be validated against this job as well.
+   */
+  extends?: JobName;
+}
+
+/**
+ * A simple job registry that executes jobs in the current process as they come.
+ */
+export class SimpleJobRegistry extends SimpleScheduler {
+  private _jobNames = new Map<JobName, SimpleSchedulerJobDescription>();
+
+  protected _createDescription(name: JobName): SimpleSchedulerJobDescription | null {
+    return this._jobNames.get(name) || null;
+  }
+
+  /**
+   * Register a job handler. The name must be unique.
+   *
+   * @param name The name of the job.
+   * @param handler The function that will be called for the job.
+   * @param options An optional list of options to override the handler. {@see RegisterJobOptions}
+   */
+  register<InputT extends JsonValue, OutputT extends JsonValue>(
+    name: JobName,
+    handler: JobHandler<InputT, OutputT> & RegisterJobOptions,
+    options?: RegisterJobOptions,
+  ): void;
+
+  /**
+   * Register a job handler. The name must be unique.
+   *
+   * @param handler The function that will be called for the job.
+   * @param options An optional list of options to override the handler. {@see RegisterJobOptions}
+   */
+  register<InputT extends JsonValue, OutputT extends JsonValue>(
+    handler: JobHandler<InputT, OutputT> & RegisterJobOptions,
+    // This version MUST contain a name.
+    options?: RegisterJobOptions,
+  ): void;
+
+  /**
+   * Register a job handler. The name must be unique.
+   *
+   * @param name The name of the job.
+   * @param handler The function that will be called for the job.
+   * @param options A list of options. {@see RegisterJobOptions}
+   */
+  register<InputT extends JsonValue, OutputT extends JsonValue>(
+    name: JobName,
+    handler: JobHandler<InputT, OutputT>,
+    options: RegisterJobOptions,
+  ): void;
+
+  register<InputT extends JsonValue, OutputT extends JsonValue>(
+    nameOrHandler: JobName | (JobHandler<InputT, OutputT> & RegisterJobOptions),
+    handlerOrOptions: JobHandler<InputT, OutputT>
+        | (JobHandler<InputT, OutputT> & RegisterJobOptions)
+        | RegisterJobOptions = {},
+    options: RegisterJobOptions = {},
+  ): void {
+    // Switch on the input.
+    if (typeof nameOrHandler == 'string') {
+      if (typeof handlerOrOptions === 'object') {
+        // This is an error.
+        throw new TypeError('Expected function as the handler.');
+      }
+
+      this._register(nameOrHandler, handlerOrOptions, { ...options, ...handlerOrOptions });
+    } else if (typeof handlerOrOptions == 'function') {
+      if (typeof handlerOrOptions === 'function') {
+        // This is an error.
+        throw new TypeError('Expected object as the handler.');
+      }
+
+      const name = nameOrHandler.jobName || handlerOrOptions.jobName;
+      if (name === undefined) {
+        throw new TypeError('Expected name to be a string.');
+      }
+
+      this._register(name, handlerOrOptions, { ...handlerOrOptions, ...options });
+    } else {
+      const name = nameOrHandler.jobName || handlerOrOptions.jobName;
+      if (name === undefined) {
+        throw new TypeError('Expected name to be a string.');
+      }
+
+      this._register(name, nameOrHandler, { ...nameOrHandler, ...handlerOrOptions });
+    }
+  }
+
+  protected _register<InputT extends JsonValue, OutputT extends JsonValue>(
+    name: JobName,
+    handler: JobHandler<InputT, OutputT>,
+    options: RegisterJobOptions,
+  ): void {
+    if (this.has(name)) {
+      // We shouldn't allow conflicts.
+      throw new JobNameAlreadyRegisteredException(name);
+    }
+
+    let { input, output } = options;
+    let extendsInternalDesc: SimpleSchedulerJobDescription | undefined = undefined;
+
+    if (options.extends) {
+      const x = this._jobNames.get(options.extends);
+      if (!x) {
+        throw new JobDoesNotExistException(options.extends);
+      }
+      extendsInternalDesc = x;
+    }
+
+    // Default to `any`.
+    if (!input) {
+      input = true;
+    }
+    if (!output) {
+      output = true;
+    }
+
+    // Create the job description.
+    const description: JobDescription = {
+      name,
+      input,
+      output,
+      inputChannel: options.inputChannel || true,
+      channels: options.channels || {},
+    };
+
+    this._jobNames.set(name, {
+      description,
+      handler,
+      extends: extendsInternalDesc,
+    });
+  }
+
+  /**
+   * Returns a list of jobs that extends the job passed in.
+   * @param name The job to look for.
+   */
+  getJobsExtending(name: JobName): JobDescription[] {
+    return [...this._jobNames.values()]
+      .filter(x => x.extends && x.extends.description.name === name)
+      .map(x => x.description);
+  }
+
+  /**
+   * Returns the job names of all jobs.
+   */
+  getJobNames(): JobName[] {
+    return [...this._jobNames.keys()];
+  }
+}

--- a/packages/angular_devkit/core/src/jobs/simple-registry_spec.ts
+++ b/packages/angular_devkit/core/src/jobs/simple-registry_spec.ts
@@ -1,0 +1,268 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+// tslint:disable:no-big-function
+import { Observable } from 'rxjs';
+import { createJob } from './create-job';
+import { SimpleJobRegistry } from './simple-registry';
+
+describe('SimpleJobRegistry', () => {
+  it('works for a simple case', async () => {
+    const registry = new SimpleJobRegistry();
+
+    registry.register(
+      'add', createJob((input: number[]) => input.reduce((a, c) => a + c, 0)), {
+        input: { items: { type: 'number' } },
+        output: { type: 'number' },
+      },
+    );
+
+    const sum = await registry.schedule('add', [1, 2, 3, 4]).promise;
+    expect(sum).toBe(10);
+  });
+
+  it('calls jobs in parallel', async () => {
+    const registry = new SimpleJobRegistry();
+
+    let started = 0;
+    let finished = 0;
+
+    registry.register(
+      'add',
+      createJob((input: number[]) => {
+        started++;
+
+        return new Promise<number>(
+          resolve => setTimeout(() => {
+            finished++;
+            resolve(input.reduce((a, c) => a + c, 0));
+          }, 10),
+        );
+      }),
+      {
+        input: { items: { type: 'number' } },
+        output: { type: 'number' },
+      },
+    );
+
+    const job1 = registry.schedule('add', [1, 2, 3, 4]);
+    const job2 = registry.schedule('add', [1, 2, 3, 4, 5]);
+    expect(started).toBe(0);
+
+    const p1 = job1.promise;
+    expect(started).toBe(1);
+
+    const p2 = job2.promise;
+    expect(started).toBe(2);
+    expect(finished).toBe(0);
+
+    const [sum, sum2] = await Promise.all([p1, p2]);
+    expect(started).toBe(2);
+    expect(finished).toBe(2);
+
+    expect(sum).toBe(10);
+    expect(sum2).toBe(15);
+  });
+
+  it('validates inputs', async () => {
+    const registry = new SimpleJobRegistry();
+
+    registry.register(
+      'add', createJob((input: number[]) => input.reduce((a, c) => a + c, 0)), {
+        input: { items: { type: 'number' } },
+        output: { type: 'number' },
+      },
+    );
+
+    await registry.schedule('add', [1, 2, 3, 4]).promise;
+    try {
+      await registry.schedule('add', ['1', 2, 3, 4]).promise;
+      expect(true).toBe(false);
+    } catch {}
+  });
+
+  it('validates outputs', async () => {
+    const registry = new SimpleJobRegistry();
+
+    registry.register(
+      'add', createJob(() => 'hello world'), {
+        input: true,
+        output: { type: 'number' },
+      },
+    );
+
+    try {
+      await registry.schedule('add', [1, 2, 3, 4]).promise;
+      expect(true).toBe(false);
+    } catch {}
+  });
+
+  it('allows extensions', async () => {
+    const registry = new SimpleJobRegistry();
+
+    registry.register(
+      'add', createJob((input: number[]) => input.reduce((a, c) => a + c, 0)), {
+        input: { items: { type: 'number' } },
+        output: { type: 'number' },
+      },
+    );
+    registry.register(
+      'add1', createJob((input: number[]) => input.reduce((a, c) => a + c + 1, 0)), {
+        extends: 'add',
+      },
+    );
+
+    expect(await registry.schedule('add', [1, 2, 3, 4]).promise).toBe(10);
+    expect(await registry.schedule('add1', [1, 2, 3, 4]).promise).toBe(14);
+  });
+
+  it('validates inputs with extensions', async () => {
+    const registry = new SimpleJobRegistry();
+
+    registry.register(
+      'add', createJob((input: number[]) => input.reduce((a, c) => a + c, 0)), {
+        input: { items: { type: 'number' } },
+        output: { type: 'number' },
+      },
+    );
+    registry.register(
+      'add1', createJob((input: number[]) => input.reduce((a, c) => a + c + 1, 0)), {
+        extends: 'add',
+      },
+    );
+
+    await registry.schedule('add1', [1, 2, 3, 4]).promise;
+    try {
+      await registry.schedule('add1', ['1', 2, 3, 4]).promise;
+      expect(true).toBe(false);
+    } catch {}
+  });
+
+  it('validates outputs with extensions', async () => {
+    const registry = new SimpleJobRegistry();
+
+    registry.register(
+      'add', createJob((input: number[]) => input.reduce((a, c) => a + c, 0)), {
+        input: { items: { type: 'number' } },
+        output: { type: 'number' },
+      },
+    );
+    registry.register(
+      'add1', createJob(() => 'hello world'), {
+        extends: 'add',
+      },
+    );
+
+    await registry.schedule('add', [1, 2, 3, 4]).promise;
+    try {
+      await registry.schedule('add1', [1, 2, 3, 4]).promise;
+      expect(true).toBe(false);
+    } catch {}
+  });
+
+  describe('channels', () => {
+    it('works', async () => {
+      const registry = new SimpleJobRegistry();
+
+      registry.register(
+        'job',
+        createJob<number, number>((input, context) => {
+          context.channels['any'].next('hello world');
+
+          return 0;
+        }), {
+          input: true,
+          output: true,
+          channels: {
+            'any': true,
+          },
+        },
+      );
+
+      const job = registry.schedule('job', 0);
+      let sideValue = '';
+      const c = job.channels['any'] as Observable<string>;
+      expect(c).toBeDefined(null);
+
+      if (c) {
+        c.subscribe(x => sideValue = x);
+      }
+
+      expect(await job.promise).toBe(0);
+      expect(sideValue).toBe('hello world');
+    });
+
+    // Disabling this test as this logic is not implemented in simple registry yet.
+    xit('validates', async () => {
+      const registry = new SimpleJobRegistry();
+
+      registry.register(
+        'job',
+        createJob<number, number>((input, context) => {
+          context.channels['any'].next('hello world');
+
+          return 0;
+        }), {
+          input: true,
+          output: true,
+          channels: {
+            'any': { type: 'number' },
+          },
+        },
+      );
+
+      const job = registry.schedule('job', 0);
+      let sideValue = '';
+      const c = job.channels['any'] as Observable<string>;
+      expect(c).toBeDefined(null);
+
+      if (c) {
+        c.subscribe(x => sideValue = x);
+      }
+
+      expect(await job.promise).toBe(0);
+      expect(sideValue).not.toBe('hello world');
+    });
+  });
+
+  describe('inputChannel', () => {
+    it('works', async () => {
+      const registry = new SimpleJobRegistry();
+
+      registry.register(
+        'job',
+        createJob<number, number>((input, context) => {
+          return new Observable<number>(subscriber => {
+            context.inputChannel.subscribe(x => {
+              if (x === null) {
+                subscriber.complete();
+              } else {
+                subscriber.next(parseInt('' + x) + input);
+              }
+            });
+          });
+        }), {
+          input: true,
+          output: true,
+        },
+      );
+
+      const job = registry.schedule<number, number>('job', 100);
+      const outputs: number[] = [];
+
+      job.output.subscribe(x => outputs.push(x));
+
+      job.input.next(1);
+      job.input.next(2);
+      job.input.next(3);
+      job.input.next(null);
+
+      expect(await job.promise).toBe(103);
+      expect(outputs).toEqual([101, 102, 103]);
+    });
+  });
+});

--- a/packages/angular_devkit/core/src/jobs/simple-scheduler.ts
+++ b/packages/angular_devkit/core/src/jobs/simple-scheduler.ts
@@ -1,0 +1,373 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { EMPTY, Observable, Observer, Subject, concat, of } from 'rxjs';
+import {
+  concatMap,
+  filter,
+  ignoreElements,
+  last,
+  map,
+  shareReplay,
+  switchMap,
+  tap,
+} from 'rxjs/operators';
+import { JsonValue, schema } from '../json';
+import { deepCopy } from '../utils';
+import {
+  Job,
+  JobDescription,
+  JobEvent,
+  JobEventKind,
+  JobEventOutput,
+  JobHandler,
+  JobHandlerContext,
+  JobInput,
+  JobInputKind,
+  JobName,
+  JobState,
+  ScheduleJobOptions,
+  Scheduler,
+} from './api';
+import { JobDoesNotExistException } from './exception';
+
+
+export class JobInputSchemaValidationError extends schema.SchemaValidationException {
+  constructor(errors?: schema.SchemaValidatorError[]) {
+    super(errors, 'Job Input failed to validate. Errors: ');
+  }
+}
+export class JobOutputSchemaValidationError extends schema.SchemaValidationException {
+  constructor(errors?: schema.SchemaValidatorError[]) {
+    super(errors, 'Job Output failed to validate. Errors: ');
+  }
+}
+
+
+// Internal structure.
+export interface SimpleSchedulerJobDescription {
+  description: JobDescription;
+  handler: JobHandler<JsonValue, JsonValue>;
+  extends?: SimpleSchedulerJobDescription;
+}
+
+
+interface InternalJobDescription extends SimpleSchedulerJobDescription {
+  inputV: Observable<schema.SchemaValidator>;
+  outputV: Observable<schema.SchemaValidator>;
+  extendsInternal: InternalJobDescription | null;
+}
+
+
+/**
+ * Simple scheduler. Should be the base of all registries and schedulers.
+ */
+export abstract class SimpleScheduler<
+  MinimumInputValueT extends JsonValue = JsonValue,
+  MinimumOutputValueT extends JsonValue = JsonValue,
+> implements Scheduler<MinimumInputValueT, MinimumOutputValueT> {
+  private _internalJobDescriptionMap = new Map<JobName, InternalJobDescription | null>();
+  private _queue: (() => void)[] = [];
+  private _pauseCounter = 0;
+
+  constructor(
+    protected _schemaRegistry: schema.SchemaRegistry = new schema.CoreSchemaRegistry(),
+  ) {}
+
+  /**
+   * The only method that needs to be overridden for this.
+   * @param name
+   * @private
+   */
+  protected abstract _createDescription(name: JobName): SimpleSchedulerJobDescription | null;
+
+  private _getInternalDescription(name: JobName): InternalJobDescription | null {
+    let maybeDescription = this._internalJobDescriptionMap.get(name);
+    if (!maybeDescription) {
+      const desc = this._createDescription(name);
+
+      if (desc !== null) {
+        maybeDescription = {
+          ...desc,
+          inputV: this._schemaRegistry.compile(desc.description.input).pipe(shareReplay()),
+          outputV: this._schemaRegistry.compile(desc.description.output).pipe(shareReplay()),
+          extendsInternal: desc.extends
+            ? this._getInternalDescription(desc.extends.description.name) : null,
+        };
+      } else {
+        maybeDescription = null;
+      }
+      this._internalJobDescriptionMap.set(name, maybeDescription);
+    }
+
+    return maybeDescription;
+  }
+
+  /**
+   * Get a job description for a named job.
+   *
+   * @param name The name of the job.
+   * @returns A description, or null if the job is not registered.
+   */
+  getDescription(name: JobName): JobDescription | null {
+    const maybeDescription = this._getInternalDescription(name);
+
+    return maybeDescription && maybeDescription.description;
+  }
+
+  /**
+   * Returns true if the job name has been registered.
+   * @param name The name of the job.
+   * @returns True if the job exists, false otherwise.
+   */
+  has(name: JobName): boolean {
+    return this._getInternalDescription(name) !== null;
+  }
+
+  /**
+   * Pause the scheduler, temporary queueing _new_ jobs. Returns a resume function that should be
+   * used to resume execution. If multiple `pause()` were called, all their resume functions must
+   * be called before the Scheduler actually starts new jobs. Additional calls to the same resume
+   * function will have no effect.
+   *
+   * Jobs already running are NOT paused. This is pausing the scheduler only.
+   */
+  pause() {
+    let called = false;
+
+    return () => {
+      if (!called) {
+        called = true;
+        if (--this._pauseCounter == 0) {
+          // Resume the queue.
+          const q = this._queue;
+          this._queue = [];
+          q.forEach(fn => fn());
+        }
+      }
+    };
+  }
+
+  /**
+   * Schedule a job to be run, using its name.
+   * @param name The name of job to be run.
+   * @param input
+   * @param options
+   * @returns The Job being run.
+   */
+  schedule<I extends MinimumInputValueT, O extends MinimumOutputValueT>(
+    name: JobName,
+    input: I,
+    options?: ScheduleJobOptions,
+  ): Job<O> {
+    if (this._pauseCounter > 0) {
+      const waitable = new Subject<never>();
+      this._queue.push(() => waitable.complete());
+
+      return this._scheduleJob(name, input, options, waitable);
+    }
+
+    return this._scheduleJob(name, input, options);
+  }
+
+  protected _scheduleJob<I extends JsonValue, O extends JsonValue>(
+    name: JobName,
+    input: I,
+    options?: ScheduleJobOptions,
+    waitable: Observable<never> = EMPTY,
+  ): Job<O> {
+    const internalDesc = this._getInternalDescription(name);
+    if (!internalDesc) {
+      throw new JobDoesNotExistException(name);
+    }
+
+    const { description, handler, inputV, outputV } = internalDesc;
+    const id: unique symbol = Symbol();
+    const inputCopy = deepCopy(input);
+    const optionsDeps = (options && options.dependencies) || [];
+    const dependencies = Array.isArray(optionsDeps) ? optionsDeps : [optionsDeps];
+
+    const channelsSubject: { [name: string]: Observer<JsonValue> } = {};
+    const channels: { [name: string]: Observable<JsonValue> } = {};
+
+    const inputChannel = new Subject<JobInput>();
+    const inputMessageChannel = new Subject<JsonValue>();
+    inputMessageChannel.subscribe(
+      message => inputChannel.next({ kind: JobInputKind.ChannelMessage, message }),
+      error => inputChannel.next({ kind: JobInputKind.ChannelError, error }),
+      () => inputChannel.next({ kind: JobInputKind.ChannelComplete }),
+    );
+
+    Object.keys(description.channels)
+      .forEach(channelName => {
+        const subject = new Subject<JsonValue>();
+        channelsSubject[channelName] = subject;
+        channels[channelName] = subject.asObservable();
+      });
+
+    let state = JobState.Created;
+    let progress = 0;
+
+    // We create a proxy observable to make sure we queue the job on subscription.
+    const outputChannel = concat(
+      // Wait for pause() to clear (if necessary).
+      waitable,
+
+      // Wait for dependencies, make sure to not report events from dependencies.
+      ...dependencies.map(x => x.outputChannel.pipe(ignoreElements())),
+
+      // The main job. We wait until we're subscribed to before queueing the job. This makes every
+      // job a cold Observable, by design.
+      new Observable<JobEvent<O>>((subject: Observer<JobEvent<O>>) => {
+        subject.next({ kind: JobEventKind.Create, description });
+
+        // First off, validate the input.
+        const subscription = inputV.pipe(
+          switchMap(validate => {
+            let result = validate(inputCopy);
+            let currentExtend = internalDesc.extendsInternal;
+            while (currentExtend) {
+              const v = currentExtend.inputV;
+              result = result.pipe(switchMap(x => {
+                return x.success
+                  ? v.pipe(switchMap(v => v(inputCopy)))
+                  : of(x);
+              }));
+              currentExtend = currentExtend.extendsInternal;
+            }
+
+            return result;
+          }),
+          switchMap(output => {
+            if (!output.success) {
+              throw new JobInputSchemaValidationError(output.errors);
+            }
+
+            state = JobState.Queued;
+            const context: JobHandlerContext<MinimumInputValueT, MinimumOutputValueT> = {
+              description,
+              dependencies,
+              input: inputChannel.asObservable(),
+              scheduler: this,
+            };
+
+            return handler(output.data, context).pipe(
+              tap(event => {
+                // Update the internal state.
+                switch (event.kind) {
+                  case JobEventKind.Log:
+                    if (options && options.logger) {
+                      options.logger.next(event.entry);
+                    }
+                    break;
+
+                  case JobEventKind.Progress:
+                    // Clamp between 0 and 1.
+                    progress = Math.max(0, Math.min(1, event.progress));
+                    break;
+                  case JobEventKind.Start:
+                    state = JobState.Started;
+                    break;
+                  case JobEventKind.End:
+                    state = JobState.Ended;
+                    break;
+
+                  case JobEventKind.ChannelMessage:
+                    if (event.name in channelsSubject) {
+                      channelsSubject[event.name].next(event.message);
+                    }
+                    break;
+                  case JobEventKind.ChannelComplete:
+                    if (event.name in channelsSubject) {
+                      channelsSubject[event.name].complete();
+                    }
+                    break;
+                  case JobEventKind.ChannelError:
+                    if (event.name in channelsSubject) {
+                      channelsSubject[event.name].error(event.error);
+                    }
+                    break;
+                }
+              }),
+
+              // Do output validation (might include default values so this might have side
+              // effects). We keep all events in order.
+              concatMap(event => {
+                if (event.kind !== JobEventKind.Output) {
+                  return of(event);
+                }
+                const outputCopy = deepCopy(event.output);
+
+                return outputV.pipe(
+                  switchMap(validate => {
+                    let result = validate(outputCopy);
+                    let currentExtend = internalDesc.extendsInternal;
+                    while (currentExtend) {
+                      const v = currentExtend.outputV;
+                      result = result.pipe(
+                        switchMap(x => {
+                          if (x.success) {
+                            return v.pipe(switchMap(v => v(x.data)));
+                          } else {
+                            return of(x);
+                          }
+                        }),
+                      );
+                      currentExtend = currentExtend.extendsInternal;
+                    }
+
+                    return result;
+                  }),
+                  switchMap(output => {
+                    if (!output.success) {
+                      throw new JobOutputSchemaValidationError(output.errors);
+                    }
+
+                    return of({
+                      ...event,
+                      output: output.data as O,
+                    } as JobEventOutput<O>);
+                  }),
+                ) as Observable<JobEvent<O>>;
+              }),
+            );
+          }),
+        ).subscribe(subject);
+
+        return () => subscription.unsubscribe();
+      }).pipe(shareReplay()),
+    );
+
+    let promise: Promise<O> | null = null;
+    const output = outputChannel.pipe(
+      filter(x => x.kind == JobEventKind.Output),
+      map((x: JobEventOutput<O>) => x.output),
+    );
+
+    // Return the Job.
+    return {
+      get progress() { return progress; },
+      get promise() {
+        // Cache the promise.
+        if (!promise) {
+          promise = output.pipe(last()).toPromise();
+        }
+
+        return promise;
+      },
+      get state() { return state; },
+      id,
+      description,
+      output,
+      channels,
+      input: inputMessageChannel,
+      inputChannel,
+      outputChannel,
+    };
+  }
+
+}

--- a/packages/angular_devkit/core/src/jobs/strategy.ts
+++ b/packages/angular_devkit/core/src/jobs/strategy.ts
@@ -1,0 +1,74 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { Observable, of } from 'rxjs';
+import { share, shareReplay } from 'rxjs/operators';
+import { JsonValue, stableStringify } from '../json';
+import { JobDescription, JobEvent, JobHandlerContext } from './api';
+import { JobHandlerWithExtra } from './create-job';
+
+type JobStrategy<I extends JsonValue, O extends JsonValue> = (
+  handler: JobHandlerWithExtra<I, O>,
+  options?: Partial<Readonly<JobDescription>>,
+) => JobHandlerWithExtra<I, O>;
+
+/**
+ * Creates a JobStrategy that serializes every call. This strategy can be mixed between jobs.
+ */
+export function serialize<
+  I extends JsonValue = JsonValue,
+  O extends JsonValue = JsonValue,
+>(): JobStrategy<I, O> {
+  let latest: Observable<JobEvent<O>> = of();
+
+  return (handler, options) => {
+    const newHandler = (input: I, context: JobHandlerContext) => {
+      const previous = latest;
+      latest = new Observable<JobEvent<O>>(subject => {
+        previous.subscribe(undefined, undefined, () => handler(input, context).subscribe(subject));
+      }).pipe(
+        shareReplay(),
+      );
+
+      return latest;
+    };
+
+    return Object.assign(newHandler, handler, options || {});
+  };
+}
+
+
+/**
+ * Creates a JobStrategy that will reuse a running job if the input matches.
+ * @param replayEvents Replay ALL events if a job is reused, otherwise just hook up where it is.
+ */
+export function memoize<
+  I extends JsonValue = JsonValue,
+  O extends JsonValue = JsonValue,
+>(replayEvents = false): JobStrategy<I, O> {
+  const runs = new Map<string, Observable<JobEvent<O>>>();
+
+  return (handler, options) => {
+    const newHandler = (input: I, context: JobHandlerContext) => {
+      const inputJson = stableStringify(input);
+      const maybeJob = runs.get(inputJson);
+
+      if (maybeJob) {
+        return maybeJob;
+      }
+
+      const run = handler(input, context).pipe(
+        replayEvents ? shareReplay() : share(),
+      );
+      runs.set(inputJson, run);
+
+      return run;
+    };
+
+    return Object.assign(newHandler, handler, options || {});
+  };
+}

--- a/packages/angular_devkit/core/src/jobs/strategy_spec.ts
+++ b/packages/angular_devkit/core/src/jobs/strategy_spec.ts
@@ -1,0 +1,202 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { JobState } from './api';
+import { createJob } from './create-job';
+import { SimpleJobRegistry } from './simple-registry';
+import { memoize, serialize } from './strategy';
+
+describe('strategy.serialize()', () => {
+  it('works', async () => {
+    const registry = new SimpleJobRegistry();
+
+    let started = 0;
+    let finished = 0;
+
+    registry.register(serialize()(createJob((input: number[]) => {
+      started++;
+
+      return new Promise<number>(
+        resolve => setTimeout(() => {
+          finished++;
+          resolve(input.reduce((a, c) => a + c, 0));
+        }, 10),
+      );
+    })), {
+      input: { items: { type: 'number' } },
+      output: { type: 'number' },
+      jobName: 'add',
+    });
+
+    const job1 = registry.schedule('add', [1, 2, 3, 4]);
+    const job2 = registry.schedule('add', [1, 2, 3, 4, 5]);
+    expect(started).toBe(0);
+    expect(finished).toBe(0);
+
+    job1.output.subscribe();
+    expect(started).toBe(1);
+
+    job2.output.subscribe();
+    expect(started).toBe(1);  // Job2 starts when Job1 ends.
+
+    expect(finished).toBe(0);
+
+    await Promise.all([
+      job1.promise.then(s => {
+        expect(finished).toBe(1);
+        expect(s).toBe(10);
+      }),
+      job2.promise.then(s => {
+        expect(finished).toBe(2);
+        expect(s).toBe(15);
+      }),
+    ]);
+
+    expect(started).toBe(2);
+    expect(finished).toBe(2);
+  });
+
+  it('works across jobs', async () => {
+    const registry = new SimpleJobRegistry();
+
+    let started = 0;
+    let finished = 0;
+
+    const strategy = serialize();
+
+    registry.register(strategy(createJob((input: number[]) => {
+      started++;
+
+      return new Promise<number>(
+        resolve => setTimeout(() => {
+          finished++;
+          resolve(input.reduce((a, c) => a + c, 0));
+        }, 10),
+      );
+    })), {
+      input: { items: { type: 'number' } },
+      output: { type: 'number' },
+      jobName: 'add',
+    });
+    registry.register(strategy(createJob((input: number[]) => {
+      started++;
+
+      return new Promise<number>(
+        resolve => setTimeout(() => {
+          finished++;
+          resolve(input.reduce((a, c) => a + c, 100));
+        }, 10),
+      );
+    })), {
+      input: { items: { type: 'number' } },
+      output: { type: 'number' },
+      jobName: 'add100',
+    });
+
+    const job1 = registry.schedule('add', [1, 2, 3, 4]);
+    const job2 = registry.schedule('add100', [1, 2, 3, 4, 5]);
+    expect(started).toBe(0);
+    expect(finished).toBe(0);
+
+    job1.output.subscribe();
+    expect(started).toBe(1);
+
+    job2.output.subscribe();
+    expect(started).toBe(1);  // Job2 starts when Job1 ends.
+
+    expect(finished).toBe(0);
+
+    await Promise.all([
+      job1.promise.then(s => {
+        expect(finished).toBe(1);
+        expect(s).toBe(10);
+      }),
+      job2.promise.then(s => {
+        expect(finished).toBe(2);
+        expect(s).toBe(115);
+      }),
+    ]);
+
+    expect(started).toBe(2);
+    expect(finished).toBe(2);
+  });
+});
+
+describe('strategy.memoize()', () => {
+  it('works', async () => {
+    const registry = new SimpleJobRegistry();
+
+    let started = 0;
+    let finished = 0;
+
+    registry.register(memoize()(createJob((input: number[]) => {
+      started++;
+
+      return new Promise<number>(
+        resolve => setTimeout(() => {
+          finished++;
+          resolve(input.reduce((a, c) => a + c, 0));
+        }, 10),
+      );
+    })), {
+      input: { items: { type: 'number' } },
+      output: { type: 'number' },
+      jobName: 'add',
+    });
+
+    const job1 = registry.schedule('add', [1, 2, 3, 4]);
+    const job2 = registry.schedule('add', [1, 2, 3, 4]);
+    const job3 = registry.schedule('add', [1, 2, 3, 4, 5]);
+    const job4 = registry.schedule('add', [1, 2, 3, 4, 5]);
+    expect(started).toBe(0);
+    expect(finished).toBe(0);
+
+    job1.output.subscribe();
+    expect(started).toBe(1);
+    expect(finished).toBe(0);
+
+    job2.output.subscribe();
+    expect(started).toBe(1);  // job2 is reusing job1.
+    expect(finished).toBe(0);
+
+    job3.output.subscribe();
+    expect(started).toBe(2);
+    expect(finished).toBe(0);
+
+    job4.output.subscribe();
+    expect(started).toBe(2);  // job4 is reusing job3.
+    expect(finished).toBe(0);
+
+    await Promise.all([
+      job1.promise.then(s => {
+        // This is hard since job3 and job1 might finish out of order.
+        expect(finished).toBeGreaterThanOrEqual(1);
+        expect(s).toBe(10);
+      }),
+      job2.promise.then(s => {
+        // This is hard since job3 and job1 might finish out of order.
+        expect(finished).toBeGreaterThanOrEqual(1);
+        expect(job1.state).toBe(JobState.Ended);
+        expect(s).toBe(10);
+      }),
+      job3.promise.then(s => {
+        // This is hard since job3 and job1 might finish out of order.
+        expect(finished).toBeGreaterThanOrEqual(1);
+        expect(s).toBe(15);
+      }),
+      job4.promise.then(s => {
+        expect(job3.state).toBe(JobState.Ended);
+        // This is hard since job3 and job1 might finish out of order.
+        expect(finished).toBeGreaterThanOrEqual(1);
+        expect(s).toBe(15);
+      }),
+    ]);
+
+    expect(started).toBe(2);
+    expect(finished).toBe(2);
+  });
+});

--- a/packages/angular_devkit/core/src/json/index.ts
+++ b/packages/angular_devkit/core/src/json/index.ts
@@ -7,6 +7,7 @@
  */
 export * from './interface';
 export * from './parser';
+export * from './stringify';
 
 import * as schema from './schema';
 export { schema };

--- a/packages/angular_devkit/core/src/json/interface.ts
+++ b/packages/angular_devkit/core/src/json/interface.ts
@@ -110,10 +110,14 @@ export interface JsonAstComment extends JsonAstNodeBase {
 
 export type JsonValue = JsonAstNode['value'];
 
-export function isJsonObject(value: JsonValue): value is JsonObject {
+// TODO: this should be unknown
+// tslint:disable-next-line:no-any
+export function isJsonObject(value: any): value is JsonObject {
   return value != null && typeof value === 'object' && !Array.isArray(value);
 }
 
-export function isJsonArray(value: JsonValue): value is JsonArray {
+// TODO: this should be unknown
+// tslint:disable-next-line:no-any
+export function isJsonArray(value: any): value is JsonArray {
   return Array.isArray(value);
 }

--- a/packages/angular_devkit/core/src/json/schema/index.ts
+++ b/packages/angular_devkit/core/src/json/schema/index.ts
@@ -8,6 +8,7 @@
 export * from './interface';
 export * from './pointer';
 export * from './registry';
+export * from './schema';
 export * from './visitor';
 export * from './utility';
 

--- a/packages/angular_devkit/core/src/json/schema/registry.ts
+++ b/packages/angular_devkit/core/src/json/schema/registry.ts
@@ -27,6 +27,7 @@ import {
   SchemaValidatorResult,
   SmartDefaultProvider,
 } from './interface';
+import { JsonSchema } from './schema';
 import { visitJson, visitJsonSchema } from './visitor';
 
 // This interface should be exported from ajv, but they only export the class and not the type.
@@ -299,7 +300,7 @@ export class CoreSchemaRegistry implements SchemaRegistry {
    * (using schema as a URI).
    * @returns An Observable of the Validation function.
    */
-  compile(schema: JsonObject): Observable<SchemaValidator> {
+  compile(schema: JsonSchema): Observable<SchemaValidator> {
     const schemaInfo: SchemaInfo = {
       smartDefaultRecord: new Map<string, JsonObject>(),
       promptDefinitions: [],
@@ -346,6 +347,10 @@ export class CoreSchemaRegistry implements SchemaRegistry {
             // tslint:disable-next-line:no-any https://github.com/ReactiveX/rxjs/issues/3989
             result = (result as any).pipe(
               ...[...this._pre].map(visitor => concatMap((data: JsonValue) => {
+                if (schema === false || schema === true) {
+                  return of(data);
+                }
+
                 return visitJson(data, visitor, schema, this._resolver, validate);
               })),
             );
@@ -368,6 +373,9 @@ export class CoreSchemaRegistry implements SchemaRegistry {
 
                 return value;
               };
+              if (schema === false || schema === true) {
+                return of(updatedData);
+              }
 
               return visitJson(updatedData, visitor, schema, this._resolver, validate);
             }),
@@ -410,6 +418,10 @@ export class CoreSchemaRegistry implements SchemaRegistry {
                   // tslint:disable-next-line:no-any https://github.com/ReactiveX/rxjs/issues/3989
                   result = (result as any).pipe(
                     ...[...this._post].map(visitor => concatMap((data: JsonValue) => {
+                      if (schema === false || schema === true) {
+                        return of(schema);
+                      }
+
                       return visitJson(data, visitor, schema, this._resolver, validate);
                     })),
                   );

--- a/packages/angular_devkit/core/src/json/schema/schema.ts
+++ b/packages/angular_devkit/core/src/json/schema/schema.ts
@@ -1,0 +1,15 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { JsonObject } from '../interface';
+
+/**
+ * A specialized interface for JsonSchema (to come). JsonSchemas are also JsonObject.
+ *
+ * @public
+ */
+export type JsonSchema = JsonObject | boolean;

--- a/packages/angular_devkit/core/src/json/schema/utility.ts
+++ b/packages/angular_devkit/core/src/json/schema/utility.ts
@@ -6,11 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import { JsonObject, isJsonArray, isJsonObject } from '../interface';
+import { JsonSchema } from './schema';
 
 
 const allTypes = ['string', 'integer', 'number', 'object', 'array', 'boolean', 'null'];
 
-export function getTypesOfSchema(schema: JsonObject | true): Set<string> {
+export function getTypesOfSchema(schema: JsonSchema): Set<string> {
   if (!schema) {
     return new Set();
   }

--- a/packages/angular_devkit/core/src/json/schema/visitor.ts
+++ b/packages/angular_devkit/core/src/json/schema/visitor.ts
@@ -11,6 +11,7 @@ import { isObservable } from '../../utils';
 import { JsonArray, JsonObject, JsonValue } from '../interface';
 import { JsonPointer, JsonSchemaVisitor, JsonVisitor } from './interface';
 import { buildJsonPointer, joinJsonPointer } from './pointer';
+import { JsonSchema } from './schema';
 
 
 export interface ReferenceResolver<ContextT> {
@@ -139,7 +140,12 @@ export function visitJson<ContextT>(
 }
 
 
-export function visitJsonSchema(schema: JsonObject, visitor: JsonSchemaVisitor) {
+export function visitJsonSchema(schema: JsonSchema, visitor: JsonSchemaVisitor) {
+  if (schema === false || schema === true) {
+    // Nothing to visit.
+    return;
+  }
+
   const keywords = {
     additionalItems: true,
     items: true,

--- a/packages/angular_devkit/core/src/json/stringify.ts
+++ b/packages/angular_devkit/core/src/json/stringify.ts
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ *
+ */
+import { JsonValue } from './interface';
+
+export function stableStringify<T extends JsonValue>(data: T): string {
+  const seen: {}[] = [];
+
+  function recursive(node: JsonValue): string {
+    if (typeof node == 'object'
+      && !Array.isArray(node)
+      && node
+      && node.toJSON
+      && typeof node.toJSON === 'function') {
+      node = (node as {} as { toJSON: Function }).toJSON();
+    }
+
+    if (node === undefined) {
+      return '';
+    }
+    if (typeof node == 'number') {
+      return isFinite(node) ? '' + node : 'null';
+    }
+    if (typeof node !== 'object') {
+      return JSON.stringify(node);
+    }
+
+    if (Array.isArray(node)) {
+      return `[${node.map(x => recursive(x) || 'null').join(',')}]`;
+    }
+
+    if (node === null) {
+      return 'null';
+    }
+
+    if (seen.indexOf(node) !== -1) {
+      throw new TypeError('Converting circular structure to JSON');
+    }
+
+    const seenIndex = seen.push(node) - 1;
+    const keys = Object.keys(node).sort();
+
+    let out = '';
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i];
+      const value = recursive(node[key]);
+
+      if (!value) {
+        continue;
+      }
+      if (out) {
+        out += ',';
+      }
+      out += JSON.stringify(key) + ':' + value;
+    }
+    seen.splice(seenIndex, 1);
+
+    return '{' + out + '}';
+  }
+
+  return recursive(data);
+}

--- a/packages/angular_devkit/core/src/logger/logger.ts
+++ b/packages/angular_devkit/core/src/logger/logger.ts
@@ -21,6 +21,7 @@ export interface LogEntry extends LoggerMetadata {
 export interface LoggerApi {
   createChild(name: string): Logger;
   log(level: LogLevel, message: string, metadata?: JsonObject): void;
+  next(entry: LogEntry): void;
   debug(message: string, metadata?: JsonObject): void;
   info(message: string, metadata?: JsonObject): void;
   warn(message: string, metadata?: JsonObject): void;
@@ -85,6 +86,7 @@ export class Logger extends Observable<LogEntry> implements LoggerApi {
       log: (level: LogLevel, message: string, metadata?: JsonObject) => {
         return this.log(level, message, metadata);
       },
+      next: (entry: LogEntry) => this.next(entry),
       debug: (message: string, metadata?: JsonObject) => this.debug(message, metadata),
       info: (message: string, metadata?: JsonObject) => this.info(message, metadata),
       warn: (message: string, metadata?: JsonObject) => this.warn(message, metadata),
@@ -105,6 +107,9 @@ export class Logger extends Observable<LogEntry> implements LoggerApi {
     const entry: LogEntry = Object.assign({}, this._metadata, metadata, {
       level, message, timestamp: +Date.now(),
     });
+    this._subject.next(entry);
+  }
+  next(entry: LogEntry): void {
     this._subject.next(entry);
   }
 

--- a/packages/angular_devkit/core/src/logger/null-logger.ts
+++ b/packages/angular_devkit/core/src/logger/null-logger.ts
@@ -18,6 +18,7 @@ export class NullLogger extends Logger {
   asApi(): LoggerApi {
     return {
       createChild: () => new NullLogger(this),
+      next() {},
       log() {},
       debug() {},
       info() {},

--- a/packages/angular_devkit/core/src/utils/index.ts
+++ b/packages/angular_devkit/core/src/utils/index.ts
@@ -16,3 +16,20 @@ export * from './priority-queue';
 export * from './lang';
 
 export { tags, strings };
+
+export type DeepReadonly<T> =
+  T extends (infer R)[] ? DeepReadonlyArray<R> :
+    T extends Function ? T :
+      T extends object ? DeepReadonlyObject<T> :
+        T;
+
+// This should be ReadonlyArray but it has implications.
+export interface DeepReadonlyArray<T> extends Array<DeepReadonly<T>> {}
+
+export type DeepReadonlyObject<T> = {
+  readonly [P in keyof T]: DeepReadonly<T[P]>;
+};
+
+export type Readwrite<T> = {
+  -readonly [P in keyof T]: T[P];
+};

--- a/packages/angular_devkit/schematics/tasks/node/index.ts
+++ b/packages/angular_devkit/schematics/tasks/node/index.ts
@@ -5,6 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import { jobs } from '@angular-devkit/core';
 import { TaskExecutorFactory } from '../../src';
 import { NodePackageName, NodePackageTaskFactoryOptions } from '../node-package/options';
 import {
@@ -28,8 +29,11 @@ export class BuiltinTaskExecutor {
     name: RunSchematicName,
     create: () => import('../run-schematic/executor').then(mod => mod.default()),
   };
-  static readonly TslintFix: TaskExecutorFactory<{}> = {
-    name: TslintFixName,
-    create: () => import('../tslint-fix/executor').then(mod => mod.default()),
-  };
+  static readonly TslintFix = jobs.lazyLoadJob(() => {
+    return import('../tslint-fix/executor').then(mod => mod.default);
+  }, {
+    jobName: TslintFixName,
+    input: {},
+    output: {},
+  });
 }

--- a/packages/angular_devkit/schematics/tasks/tslint-fix/executor.ts
+++ b/packages/angular_devkit/schematics/tasks/tslint-fix/executor.ts
@@ -5,6 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import { jobs, json } from '@angular-devkit/core';
 import { resolve } from '@angular-devkit/core/node';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -14,7 +15,6 @@ import {
   Linter as LinterNS,
 } from 'tslint';  // tslint:disable-line:no-implicit-dependencies
 import * as ts from 'typescript';  // tslint:disable-line:no-implicit-dependencies
-import { SchematicContext, TaskExecutor } from '../../src';
 import { TslintFixTaskOptions } from './options';
 
 
@@ -89,8 +89,8 @@ function _listAllFiles(root: string): string[] {
 }
 
 
-export default function(): TaskExecutor<TslintFixTaskOptions> {
-  return (options: TslintFixTaskOptions, context: SchematicContext) => {
+export default jobs.createJob<TslintFixTaskOptions, json.JsonValue>(
+  (options: TslintFixTaskOptions, context: jobs.SimpleJobHandlerContext) => {
     return new Observable(obs => {
       const root = process.cwd();
       const tslint = require(resolve('tslint', {
@@ -198,5 +198,10 @@ export default function(): TaskExecutor<TslintFixTaskOptions> {
         obs.complete();
       }
     });
-  };
-}
+  },
+  {
+    jobName: 'tslint-fix',
+    input: {},
+    output: {},
+  },
+);

--- a/packages/angular_devkit/schematics/tasks/tslint-fix/options.ts
+++ b/packages/angular_devkit/schematics/tasks/tslint-fix/options.ts
@@ -23,4 +23,4 @@ export interface TslintFixTaskOptionsBase {
   tslintConfig?: JsonObject;
 }
 
-export type TslintFixTaskOptions = TslintFixTaskOptionsBase;
+export type TslintFixTaskOptions = TslintFixTaskOptionsBase & JsonObject;

--- a/packages/angular_devkit/schematics/tasks/tslint-fix/task.ts
+++ b/packages/angular_devkit/schematics/tasks/tslint-fix/task.ts
@@ -35,11 +35,12 @@ export class TslintFixTask implements TaskConfigurationGenerator<TslintFixTaskOp
     const config = typeof this._configOrPath == 'object' && this._configOrPath !== null
                  ? { tslintConfig: this._configOrPath }
                  : {};
+
     const options = {
       ...this._options,
       ...path,
       ...config,
-    };
+    } as TslintFixTaskOptions;
 
     return { name: TslintFixName, options };
   }

--- a/scripts/changelog.ts
+++ b/scripts/changelog.ts
@@ -55,7 +55,7 @@ export default function(args: ChangelogOptions, logger: logging.Logger) {
         const commit = chunk.toString('utf-8')
           .replace(/https?:\/\/github.com\/(.*?)\/issues\/(\d+)/g, '@$1#$2');
 
-        callback(undefined, new Buffer(commit));
+        callback(undefined, Buffer.from(commit));
       }))
       .pipe(conventionalCommitsParser({
         headerPattern: /^(\w*)(?:\(([^)]*)\))?: (.*)$/,

--- a/tests/angular_devkit/core/node/jobs/BUILD
+++ b/tests/angular_devkit/core/node/jobs/BUILD
@@ -1,0 +1,22 @@
+# Copyright Google Inc. All Rights Reserved.
+#
+# Use of this source code is governed by an MIT-style license that can be
+# found in the LICENSE file at https://angular.io/license
+package(default_visibility = ["//visibility:public"])
+
+load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
+
+licenses(["notice"])  # MIT License
+
+ts_library(
+    name = "jobs_test_lib",
+    srcs = glob(
+        include = [
+            "**/*.ts",
+        ],
+    ),
+    deps = [
+        "//packages/angular_devkit/core",
+        "@npm//@types/node",
+    ],
+)

--- a/tests/angular_devkit/core/node/jobs/add.ts
+++ b/tests/angular_devkit/core/node/jobs/add.ts
@@ -1,0 +1,16 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+// tslint:disable:no-global-tslint-disable
+// tslint:disable:no-implicit-dependencies
+import { jobs } from '@angular-devkit/core';
+
+// Export the job using a createJob. We use our own spec file here to do the job.
+export default jobs.createJob<number[], number>(input => input.reduce((a, c) => a + c, 0), {
+  input: { items: { type: 'number' } },
+  output: { type: 'number' },
+});


### PR DESCRIPTION

The FileSystemEngineHostBase now has an adapter that understands Jobs as
if they were tasks. This keep the current API but allow tools to register
jobs as tasks. In 8.0 we will have to take the breaking change and clean
up tasks.
28cd458