### PR TITLE
feat(@schematics/angular): consistent naming of options and arguments that do the same thing

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   "dependencies": {
     "glob": "^7.0.3",
     "node-fetch": "^2.2.0",
-    "quicktype-core": "^5.0.41",
+    "quicktype-core": "^6.0.15",
     "temp": "^0.8.3",
     "tslint": "^5.11.0",
     "typescript": "~3.1.6",

--- a/packages/angular/cli/lib/config/schema.json
+++ b/packages/angular/cli/lib/config/schema.json
@@ -139,6 +139,11 @@
               "type": "string",
               "default": "css"
             },
+            "style": {
+              "description": "The file extension to use for style files.",
+              "type": "string",
+              "default": "css"
+            },
             "viewEncapsulation": {
               "description": "Specifies the view encapsulation strategy.",
               "enum": ["Emulated", "Native", "None", "ShadowDom"],
@@ -186,6 +191,11 @@
               "type": "boolean",
               "description": "Specifies if a spec file is generated.",
               "default": true
+            },
+            "skipTests": {
+              "type": "boolean",
+              "description": "When true, does not create test files.",
+              "default": false
             }
           }
         },
@@ -202,11 +212,6 @@
               "type": "string",
               "description": "The scope for the generated routing.",
               "default": "Child"
-            },
-            "spec": {
-              "type": "boolean",
-              "description": "Specifies if a spec file is generated.",
-              "default": true
             },
             "flat": {
               "type": "boolean",
@@ -236,8 +241,13 @@
             },
             "spec": {
               "type": "boolean",
-              "default": true,
-              "description": "Specifies if a spec file is generated."
+              "description": "Specifies if a spec file is generated.",
+              "default": true
+            },
+            "skipTests": {
+              "type": "boolean",
+              "description": "When true, does not create test files.",
+              "default": false
             }
           }
         },
@@ -251,8 +261,13 @@
             },
             "spec": {
               "type": "boolean",
-              "default": true,
-              "description": "Specifies if a spec file is generated."
+              "description": "Specifies if a spec file is generated.",
+              "default": true
+            },
+            "skipTests": {
+              "type": "boolean",
+              "description": "When true, does not create test files.",
+              "default": false
             },
             "skipImport": {
               "type": "boolean",
@@ -277,8 +292,13 @@
           "properties": {
             "spec": {
               "type": "boolean",
-              "default": true,
-              "description": "Specifies if a spec file is generated."
+              "description": "Specifies if a spec file is generated.",
+              "default": true
+            },
+            "skipTests": {
+              "type": "boolean",
+              "description": "When true, does not create test files.",
+              "default": false
             }
           }
         }

--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -136,7 +136,7 @@ function addAppToWorkspaceFile(options: ApplicationOptions, workspace: Workspace
       if (!(`@schematics/angular:${type}` in schematics)) {
         schematics[`@schematics/angular:${type}`] = {};
       }
-      (schematics[`@schematics/angular:${type}`] as JsonObject).spec = false;
+      (schematics[`@schematics/angular:${type}`] as JsonObject).skipTests = true;
     });
   }
 
@@ -264,15 +264,15 @@ export default function (options: ApplicationOptions): Rule {
       {
         inlineStyle: options.inlineStyle,
         inlineTemplate: options.inlineTemplate,
-        spec: !options.skipTests,
-        styleext: options.style,
+        skipTests: options.skipTests,
+        style: options.style,
         viewEncapsulation: options.viewEncapsulation,
       } :
       {
         inlineStyle: true,
         inlineTemplate: true,
-        spec: false,
-        styleext: options.style,
+        skipTests: true,
+        style: options.style,
       };
 
     const workspace = getWorkspace(host);
@@ -361,7 +361,7 @@ export default function (options: ApplicationOptions): Rule {
       mergeWith(
         apply(url('./other-files'), [
           componentOptions.inlineTemplate ? filter(path => !path.endsWith('.html')) : noop(),
-          !componentOptions.spec ? filter(path => !path.endsWith('.spec.ts')) : noop(),
+          componentOptions.skipTests ? filter(path => !/[.|-]spec.ts$/.test(path)) : noop(),
           template({
             utils: strings,
             ...options as any,  // tslint:disable-line:no-any

--- a/packages/schematics/angular/application/index_spec.ts
+++ b/packages/schematics/angular/application/index_spec.ts
@@ -29,8 +29,6 @@ describe('Application Schematic', () => {
     inlineStyle: false,
     inlineTemplate: false,
     routing: false,
-    style: 'css',
-    skipTests: false,
     skipPackageJson: false,
   };
 

--- a/packages/schematics/angular/application/other-files/app.component.ts
+++ b/packages/schematics/angular/application/other-files/app.component.ts
@@ -28,7 +28,7 @@ import { Component } from '@angular/core';
   `,<% } else { %>
   templateUrl: './app.component.html',<% } if(inlineStyle) { %>
   styles: []<% } else { %>
-  styleUrls: ['./app.component.<%= styleext %>']<% } %>
+  styleUrls: ['./app.component.<%= style %>']<% } %>
 })
 export class AppComponent {
   title = '<%= name %>';

--- a/packages/schematics/angular/class/index.ts
+++ b/packages/schematics/angular/class/index.ts
@@ -42,8 +42,11 @@ export default function (options: ClassOptions): Rule {
     options.name = parsedPath.name;
     options.path = parsedPath.path;
 
+    // todo remove these when we remove the deprecations
+    options.skipTests = options.skipTests || !options.spec;
+
     const templateSource = apply(url('./files'), [
-      options.spec ? noop() : filter(path => !path.endsWith('.spec.ts')),
+      options.skipTests ? filter(path => !path.endsWith('.spec.ts')) : noop(),
       template({
         ...strings,
         ...options,

--- a/packages/schematics/angular/class/schema.json
+++ b/packages/schematics/angular/class/schema.json
@@ -29,7 +29,13 @@
     },
     "spec": {
       "type": "boolean",
-      "description": "When true, generates a \"spec.ts\" test file for the new class.",
+      "description": "When true (the default), generates a  \"spec.ts\" test file for the new class.",
+      "default": true,
+      "x-deprecated": "Use \"skipTests\" instead."
+    },
+    "skipTests": {
+      "type": "boolean",
+      "description": "When true, does not create \"spec.ts\" test files for the new class.",
       "default": false
     },
     "type": {

--- a/packages/schematics/angular/component/files/__name@dasherize@if-flat__/__name@dasherize__.component.ts
+++ b/packages/schematics/angular/component/files/__name@dasherize@if-flat__/__name@dasherize__.component.ts
@@ -9,7 +9,7 @@ import { Component, OnInit<% if(!!viewEncapsulation) { %>, ViewEncapsulation<% }
   `,<% } else { %>
   templateUrl: './<%= dasherize(name) %>.component.html',<% } if(inlineStyle) { %>
   styles: []<% } else { %>
-  styleUrls: ['./<%= dasherize(name) %>.component.<%= styleext %>']<% } %><% if(!!viewEncapsulation) { %>,
+  styleUrls: ['./<%= dasherize(name) %>.component.<%= style %>']<% } %><% if(!!viewEncapsulation) { %>,
   encapsulation: ViewEncapsulation.<%= viewEncapsulation %><% } if (changeDetection !== 'Default') { %>,
   changeDetection: ChangeDetectionStrategy.<%= changeDetection %><% } %>
 })

--- a/packages/schematics/angular/component/index.ts
+++ b/packages/schematics/angular/component/index.ts
@@ -125,7 +125,7 @@ function buildSelector(options: ComponentOptions, projectPrefix: string) {
 }
 
 
-export default function(options: ComponentOptions): Rule {
+export default function (options: ComponentOptions): Rule {
   return (host: Tree) => {
     if (!options.project) {
       throw new SchematicsException('Option (project) is required.');
@@ -143,12 +143,19 @@ export default function(options: ComponentOptions): Rule {
     options.path = parsedPath.path;
     options.selector = options.selector || buildSelector(options, project.prefix);
 
+    // todo remove these when we remove the deprecations
+    options.style = (
+      options.style && options.style !== 'css'
+        ? options.style : options.styleext
+    ) || 'css';
+    options.skipTests = options.skipTests || !options.spec;
+
     validateName(options.name);
     validateHtmlSelector(options.selector);
 
     const templateSource = apply(url('./files'), [
-      options.spec ? noop() : filter(path => !path.endsWith('.spec.ts')),
-      options.inlineStyle ? filter(path => !path.endsWith('.__styleext__')) : noop(),
+      options.skipTests ? filter(path => !path.endsWith('.spec.ts')) : noop(),
+      options.inlineStyle ? filter(path => !path.endsWith('.__style__')) : noop(),
       options.inlineTemplate ? filter(path => !path.endsWith('.html')) : noop(),
       template({
         ...strings,

--- a/packages/schematics/angular/component/index_spec.ts
+++ b/packages/schematics/angular/component/index_spec.ts
@@ -24,8 +24,8 @@ describe('Component Schematic', () => {
     inlineStyle: false,
     inlineTemplate: false,
     changeDetection: ChangeDetection.Default,
-    styleext: 'css',
-    spec: true,
+    style: 'css',
+    skipTests: false,
     module: undefined,
     export: false,
     project: 'bar',
@@ -249,8 +249,8 @@ describe('Component Schematic', () => {
     expect(tree.files).not.toContain('/projects/bar/src/app/foo/foo.component.css');
   });
 
-  it('should respect the styleext option', () => {
-    const options = { ...defaultOptions, styleext: 'scss' };
+  it('should respect the style option', () => {
+    const options = { ...defaultOptions, style: 'scss' };
     const tree = schematicRunner.runSchematic('component', options, appTree);
     const content = tree.readContent('/projects/bar/src/app/foo/foo.component.ts');
     expect(content).toMatch(/styleUrls: \['.\/foo.component.scss/);
@@ -310,4 +310,34 @@ describe('Component Schematic', () => {
     appTree = schematicRunner.runSchematic('component', defaultOptions, appTree);
     expect(appTree.files).toContain('/projects/bar/custom/app/foo/foo.component.ts');
   });
+
+  // testing deprecating options don't cause conflicts
+  it('should respect the deprecated styleext (scss) option', () => {
+    const options = { ...defaultOptions, style: undefined, styleext: 'scss' };
+    const tree = schematicRunner.runSchematic('component', options, appTree);
+    const files = tree.files;
+    expect(files).toContain('/projects/bar/src/app/foo/foo.component.scss');
+  });
+
+  it('should respect the deprecated styleext (css) option', () => {
+    const options = { ...defaultOptions, style: undefined, styleext: 'css' };
+    const tree = schematicRunner.runSchematic('component', options, appTree);
+    const files = tree.files;
+    expect(files).toContain('/projects/bar/src/app/foo/foo.component.css');
+  });
+
+  it('should respect the deprecated spec option when false', () => {
+    const options = { ...defaultOptions, skipTests: undefined, spec: false };
+    const tree = schematicRunner.runSchematic('component', options, appTree);
+    const files = tree.files;
+    expect(files).not.toContain('/projects/bar/src/app/foo/foo.component.spec.ts');
+  });
+
+  it('should respect the deprecated spec option when true', () => {
+    const options = { ...defaultOptions, skipTests: false, spec: true };
+    const tree = schematicRunner.runSchematic('component', options, appTree);
+    const files = tree.files;
+    expect(files).toContain('/projects/bar/src/app/foo/foo.component.spec.ts');
+  });
+
 });

--- a/packages/schematics/angular/component/schema.json
+++ b/packages/schematics/angular/component/schema.json
@@ -69,12 +69,24 @@
     "styleext": {
       "description": "The file extension to use for style files.",
       "type": "string",
+      "default": "css",
+      "x-deprecated": "Use \"style\" instead."
+    },
+    "style": {
+      "description": "The file extension to use for style files.",
+      "type": "string",
       "default": "css"
     },
     "spec": {
       "type": "boolean",
       "description": "When true (the default), generates a  \"spec.ts\" test file for the new component.",
-      "default": true
+      "default": true,
+      "x-deprecated": "Use \"skipTests\" instead."
+    },
+    "skipTests": {
+      "type": "boolean",
+      "description": "When true, does not create \"spec.ts\" test files for the new component.",
+      "default": false
     },
     "flat": {
       "type": "boolean",

--- a/packages/schematics/angular/directive/index.ts
+++ b/packages/schematics/angular/directive/index.ts
@@ -121,8 +121,11 @@ export default function (options: DirectiveOptions): Rule {
 
     validateHtmlSelector(options.selector);
 
+    // todo remove these when we remove the deprecations
+    options.skipTests = options.skipTests || !options.spec;
+
     const templateSource = apply(url('./files'), [
-      options.spec ? noop() : filter(path => !path.endsWith('.spec.ts')),
+      options.skipTests ? filter(path => !path.endsWith('.spec.ts')) : noop(),
       template({
         ...strings,
         'if-flat': (s: string) => options.flat ? '' : s,

--- a/packages/schematics/angular/directive/index_spec.ts
+++ b/packages/schematics/angular/directive/index_spec.ts
@@ -18,7 +18,6 @@ describe('Directive Schematic', () => {
   );
   const defaultOptions: DirectiveOptions = {
     name: 'foo',
-    spec: true,
     module: undefined,
     export: false,
     prefix: 'app',
@@ -37,7 +36,6 @@ describe('Directive Schematic', () => {
     inlineStyle: false,
     inlineTemplate: false,
     routing: false,
-    style: 'css',
     skipTests: false,
     skipPackageJson: false,
   };

--- a/packages/schematics/angular/directive/schema.json
+++ b/packages/schematics/angular/directive/schema.json
@@ -44,7 +44,13 @@
     "spec": {
       "type": "boolean",
       "description": "When true (the default), generates a  \"spec.ts\" test file for the new directive.",
-      "default": true
+      "default": true,
+      "x-deprecated": "Use \"skipTests\" instead."
+    },
+    "skipTests": {
+      "type": "boolean",
+      "description": "When true, does not create \"spec.ts\" test files for the new class.",
+      "default": false
     },
     "skipImport": {
       "type": "boolean",
@@ -61,7 +67,7 @@
       "description": "When true (the default), creates the new files at the top level of the current project.",
       "default": true
     },
-    "module":  {
+    "module": {
       "type": "string",
       "description": "The declaring NgModule.",
       "alias": "m"

--- a/packages/schematics/angular/guard/index.ts
+++ b/packages/schematics/angular/guard/index.ts
@@ -41,8 +41,11 @@ export default function (options: GuardOptions): Rule {
     options.name = parsedPath.name;
     options.path = parsedPath.path;
 
+    // todo remove these when we remove the deprecations
+    options.skipTests = options.skipTests || !options.spec;
+
     const templateSource = apply(url('./files'), [
-      options.spec ? noop() : filter(path => !path.endsWith('.spec.ts')),
+      options.skipTests ? filter(path => !path.endsWith('.spec.ts')) : noop(),
       template({
         ...strings,
         ...options,

--- a/packages/schematics/angular/guard/index_spec.ts
+++ b/packages/schematics/angular/guard/index_spec.ts
@@ -18,7 +18,6 @@ describe('Guard Schematic', () => {
   );
   const defaultOptions: GuardOptions = {
     name: 'foo',
-    spec: true,
     flat: true,
     project: 'bar',
   };
@@ -33,7 +32,6 @@ describe('Guard Schematic', () => {
     inlineStyle: false,
     inlineTemplate: false,
     routing: false,
-    style: 'css',
     skipTests: false,
     skipPackageJson: false,
   };
@@ -50,8 +48,8 @@ describe('Guard Schematic', () => {
     expect(files).toContain('/projects/bar/src/app/foo.guard.ts');
   });
 
-  it('should respect the spec flag', () => {
-    const options = { ...defaultOptions, spec: false };
+  it('should respect the skipTests flag', () => {
+    const options = { ...defaultOptions, skipTests: true };
 
     const tree = schematicRunner.runSchematic('guard', options, appTree);
     const files = tree.files;

--- a/packages/schematics/angular/guard/schema.json
+++ b/packages/schematics/angular/guard/schema.json
@@ -17,7 +17,13 @@
     "spec": {
       "type": "boolean",
       "description": "When true (the default), generates a  \"spec.ts\" test file for the new guard.",
-      "default": true
+      "default": true,
+      "x-deprecated": "Use \"skipTests\" instead."
+    },
+    "skipTests": {
+      "type": "boolean",
+      "description": "When true, does not create \"spec.ts\" test files for the new guard.",
+      "default": false
     },
     "flat": {
       "type": "boolean",

--- a/packages/schematics/angular/pipe/index.ts
+++ b/packages/schematics/angular/pipe/index.ts
@@ -102,8 +102,11 @@ export default function (options: PipeOptions): Rule {
 
     options.module = findModuleFromOptions(host, options);
 
+    // todo remove these when we remove the deprecations
+    options.skipTests = options.skipTests || !options.spec;
+
     const templateSource = apply(url('./files'), [
-      options.spec ? noop() : filter(path => !path.endsWith('.spec.ts')),
+      options.skipTests ? filter(path => !path.endsWith('.spec.ts')) : noop(),
       template({
         ...strings,
         'if-flat': (s: string) => options.flat ? '' : s,

--- a/packages/schematics/angular/pipe/schema.json
+++ b/packages/schematics/angular/pipe/schema.json
@@ -35,7 +35,13 @@
     "spec": {
       "type": "boolean",
       "default": true,
-      "description": "When true (the default), generates a  \"spec.ts\" test file for the new pipe."
+      "description": "When true (the default), generates a  \"spec.ts\" test file for the new pipe.",
+      "x-deprecated": "Use \"skipTests\" instead."
+    },
+    "skipTests": {
+      "type": "boolean",
+      "description": "When true, does not create \"spec.ts\" test files for the new pipe.",
+      "default": false
     },
     "skipImport": {
       "type": "boolean",

--- a/packages/schematics/angular/service/index.ts
+++ b/packages/schematics/angular/service/index.ts
@@ -39,8 +39,11 @@ export default function (options: ServiceOptions): Rule {
     options.name = parsedPath.name;
     options.path = parsedPath.path;
 
+    // todo remove these when we remove the deprecations
+    options.skipTests = options.skipTests || !options.spec;
+
     const templateSource = apply(url('./files'), [
-      options.spec ? noop() : filter(path => !path.endsWith('.spec.ts')),
+      options.skipTests ? filter(path => !path.endsWith('.spec.ts')) : noop(),
       template({
         ...strings,
         'if-flat': (s: string) => options.flat ? '' : s,

--- a/packages/schematics/angular/service/index_spec.ts
+++ b/packages/schematics/angular/service/index_spec.ts
@@ -18,7 +18,6 @@ describe('Service Schematic', () => {
   );
   const defaultOptions: ServiceOptions = {
     name: 'foo',
-    spec: true,
     flat: false,
     project: 'bar',
   };
@@ -34,8 +33,6 @@ describe('Service Schematic', () => {
     inlineStyle: false,
     inlineTemplate: false,
     routing: false,
-    style: 'css',
-    skipTests: false,
     skipPackageJson: false,
   };
   let appTree: UnitTestTree;
@@ -61,8 +58,8 @@ describe('Service Schematic', () => {
     expect(content).toMatch(/providedIn: 'root'/);
   });
 
-  it('should respect the spec flag', () => {
-    const options = { ...defaultOptions, spec: false };
+  it('should respect the skipTests flag', () => {
+    const options = { ...defaultOptions, skipTests: true };
 
     const tree = schematicRunner.runSchematic('service', options, appTree);
     const files = tree.files;

--- a/packages/schematics/angular/service/schema.json
+++ b/packages/schematics/angular/service/schema.json
@@ -35,7 +35,13 @@
     "spec": {
       "type": "boolean",
       "default": true,
-      "description": "When true (the default), generates a  \"spec.ts\" test file for the new service."
+      "description": "When true (the default), generates a  \"spec.ts\" test file for the new service.",
+      "x-deprecated": "Use \"skipTests\" instead."
+    },
+    "skipTests": {
+      "type": "boolean",
+      "description": "When true, does not create \"spec.ts\" test files for the new service.",
+      "default": false
     },
     "lintFix": {
       "type": "boolean",

--- a/tests/legacy-cli/e2e/tests/generate/class.ts
+++ b/tests/legacy-cli/e2e/tests/generate/class.ts
@@ -6,7 +6,7 @@ import {expectFileToExist} from '../../utils/fs';
 export default function() {
   const projectDir = join('src', 'app');
 
-  return ng('generate', 'class', 'test-class', '--spec')
+  return ng('generate', 'class', 'test-class')
     .then(() => expectFileToExist(projectDir))
     .then(() => expectFileToExist(join(projectDir, 'test-class.ts')))
     .then(() => expectFileToExist(join(projectDir, 'test-class.spec.ts')))

--- a/tools/quicktype_runner.js
+++ b/tools/quicktype_runner.js
@@ -131,6 +131,7 @@ async function generate(inPath) {
     rendererOptions: {
       'just-types': 'true',
       'explicit-unions': 'true',
+      'acronym-style': 'camel',
     },
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2032,10 +2032,10 @@ codelyzer@^4.2.1:
     source-map "^0.5.7"
     sprintf-js "^1.1.1"
 
-collection-utils@0.0.15:
-  version "0.0.15"
-  resolved "https://registry.yarnpkg.com/collection-utils/-/collection-utils-0.0.15.tgz#70f4c54299621699b3f38c66577c9d4284825125"
-  integrity sha512-eLGXa67rSilE5dNCcx2wenWcmmgl4QdlwUj1Z5idKkIBOhZh6PghEZFC3wP3AHH8xnMbIDsky0pR/+1epJBymQ==
+collection-utils@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/collection-utils/-/collection-utils-1.0.1.tgz#31d14336488674f27aefc0a7c5eccacf6df78044"
+  integrity sha512-LA2YTIlR7biSpXkKYwwuzGjwL5rjWEZVOSnvdUc7gObvWe4WkjxOpfrdhoP7Hs09YWDVfg0Mal9BpAqLfVEzQg==
 
 collection-visit@^1.0.0:
   version "1.0.0"
@@ -7314,11 +7314,6 @@ parseqs@0.0.5:
   dependencies:
     better-assert "~1.0.0"
 
-parser-toolkit@>=0.0.3:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/parser-toolkit/-/parser-toolkit-0.0.5.tgz#ec4b61729c86318b56ea971bfba6b3c672d62c01"
-  integrity sha1-7EthcpyGMYtW6pcb+6azxnLWLAE=
-
 parseuri@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/parseuri/-/parseuri-0.0.5.tgz#80204a50d4dbb779bfdc6ebe2778d90e4bce320a"
@@ -7819,18 +7814,16 @@ quick-lru@^1.0.0:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-1.1.0.tgz#4360b17c61136ad38078397ff11416e186dcfbb8"
   integrity sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=
 
-quicktype-core@^5.0.41:
-  version "5.0.41"
-  resolved "https://registry.yarnpkg.com/quicktype-core/-/quicktype-core-5.0.41.tgz#83f090b1bddeefcff0581e0d9c754d83410ed453"
-  integrity sha512-CImdVo4M4TlDs0McPSql9HnaoG5/Z3w1bQIlAhc95qekxBx+jJ2HNIqXzEkIsvx7W7sIPZhOuCug9fvmqNkMKQ==
+quicktype-core@^6.0.15:
+  version "6.0.15"
+  resolved "https://registry.yarnpkg.com/quicktype-core/-/quicktype-core-6.0.15.tgz#44fddfa7ae00fcc06e2eb43829870341be12a34b"
+  integrity sha512-m8GHNFsd2yL9eZmIy0FoZCDuoxfKnvfQHCpcBTvV0760AV9kSNRAk8e2uRs2eYcgj/VUSx0qcUUqm/40CrwYOQ==
   dependencies:
     "@types/urijs" "github:quicktype/types-urijs"
-    collection-utils "0.0.15"
+    collection-utils "^1.0.1"
     js-base64 "^2.4.3"
     pako "^1.0.6"
     pluralize "^7.0.0"
-    stream-json "0.5.2"
-    string-to-stream "^1.1.0"
     unicode-properties "github:quicktype/unicode-properties#dist"
     urijs "^1.19.1"
     wordwrap "^1.0.0"
@@ -7990,7 +7983,7 @@ read-pkg@^3.0.0:
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
 
-"readable-stream@1 || 2", readable-stream@2, readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.0, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.2.9, readable-stream@^2.3.0, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6, readable-stream@~2.3.3:
+"readable-stream@1 || 2", readable-stream@2, readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.2.9, readable-stream@^2.3.0, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6, readable-stream@~2.3.3:
   version "2.3.6"
   resolved "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   integrity sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==
@@ -9317,13 +9310,6 @@ stream-http@^2.7.2:
     to-arraybuffer "^1.0.0"
     xtend "^4.0.0"
 
-stream-json@0.5.2:
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/stream-json/-/stream-json-0.5.2.tgz#f4256c0ef1a905f2ef2d473706b4b3ff827653cf"
-  integrity sha512-/QlOLybrc6LkH/oVgXo1lJ8oemRIze/grdpfssLn1Pm8nZVhW4VMOqDDYGaORPodQFxiDEUquQJER5LiBu8Ehg==
-  dependencies:
-    parser-toolkit ">=0.0.3"
-
 stream-shift@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.0.tgz#d5c752825e5367e786f78e18e445ea223a155952"
@@ -9343,14 +9329,6 @@ strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
   integrity sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=
-
-string-to-stream@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/string-to-stream/-/string-to-stream-1.1.1.tgz#aba78f73e70661b130ee3e1c0192be4fef6cb599"
-  integrity sha512-QySF2+3Rwq0SdO3s7BAp4x+c3qsClpPQ6abAmb0DGViiSBAkT5kL6JT2iyzEVP+T1SmzHrQD1TwlP9QAHCc+Sw==
-  dependencies:
-    inherits "^2.0.1"
-    readable-stream "^2.1.0"
 
 string-width@^1.0.1, string-width@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
feat(@schematics/angular): consistent naming of options and arguments that do the same thing

This aligns options that do the same thing:
1) `skipSpecs` and `spec` has been deprecated in favor of `skipTests`.
2) `styleext` has been deprecated in favor of `style` since the latest is two words.

Fixes #12784

