### PR TITLE
ci: packages now can list version numbers too

### DIFF
--- a/scripts/packages.ts
+++ b/scripts/packages.ts
@@ -12,10 +12,20 @@ import { logging } from '@angular-devkit/core';
 const { packages } = require('../lib/packages');
 
 
-export default function(args: { json: boolean }, logger: logging.Logger) {
+export default function(args: { json: boolean, version: boolean }, logger: logging.Logger) {
   if (args.json) {
     logger.info(JSON.stringify(packages, null, 2));
   } else {
-    logger.info(Object.keys(packages).filter(name => !packages[name].private).join('\n'));
+    logger.info(
+      Object.keys(packages)
+        .filter(name => !packages[name].private)
+        .map(name => {
+          if (args.version) {
+            return `${name}@${packages[name].version}`;
+          } else {
+            return name;
+          }
+        })
+        .join('\n'));
   }
 }


### PR DESCRIPTION
Useful for mapping to npm commands like dist-tag.