### PR TITLE
feat(@angular-devkit/build-angular): fine grain settings for sourceMaps

### DIFF
--- a/packages/angular/cli/lib/config/schema.json
+++ b/packages/angular/cli/lib/config/schema.json
@@ -633,9 +633,39 @@
               "default": false
             },
             "sourceMap": {
-              "type": "boolean",
               "description": "Output sourcemaps.",
-              "default": true
+              "default": true,
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "scripts": {
+                      "type": "boolean",
+                      "description": "Output sourcemaps for all scripts.",
+                      "default": true
+                    },
+                    "styles": {
+                      "type": "boolean",
+                      "description": "Output sourcemaps for all styles.",
+                      "default": true
+                    },
+                    "hidden": {
+                      "type": "boolean",
+                      "description": "Output sourcemaps used for error reporting tools.",
+                      "default": false
+                    },
+                    "vendor": {
+                      "type": "boolean",
+                      "description": "Resolve vendor packages sourcemaps.",
+                      "default": false
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "boolean"
+                }
+              ]
             },
             "vendorSourceMap": {
               "type": "boolean",
@@ -1045,8 +1075,34 @@
               "description": "Build using Ahead of Time compilation."
             },
             "sourceMap": {
-              "type": "boolean",
-              "description": "Output sourcemaps."
+              "description": "Output sourcemaps.",
+              "default": true,
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "scripts": {
+                      "type": "boolean",
+                      "description": "Output sourcemaps for all scripts.",
+                      "default": true
+                    },
+                    "styles": {
+                      "type": "boolean",
+                      "description": "Output sourcemaps for all styles.",
+                      "default": true
+                    },
+                    "vendor": {
+                      "type": "boolean",
+                      "description": "Resolve vendor packages sourcemaps.",
+                      "default": false
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "boolean"
+                }
+              ]
             },
             "vendorSourceMap": {
               "type": "boolean",
@@ -1189,9 +1245,34 @@
               "description": "Defines the build environment."
             },
             "sourceMap": {
-              "type": "boolean",
               "description": "Output sourcemaps.",
-              "default": true
+              "default": true,
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "scripts": {
+                      "type": "boolean",
+                      "description": "Output sourcemaps for all scripts.",
+                      "default": true
+                    },
+                    "styles": {
+                      "type": "boolean",
+                      "description": "Output sourcemaps for all styles.",
+                      "default": true
+                    },
+                    "vendor": {
+                      "type": "boolean",
+                      "description": "Resolve vendor packages sourcemaps.",
+                      "default": false
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "boolean"
+                }
+              ]
             },
             "progress": {
               "type": "boolean",
@@ -1455,9 +1536,39 @@
               "description": "The path where style resources will be placed, relative to outputPath."
             },
             "sourceMap": {
-              "type": "boolean",
               "description": "Output sourcemaps.",
-              "default": true
+              "default": true,
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "scripts": {
+                      "type": "boolean",
+                      "description": "Output sourcemaps for all scripts.",
+                      "default": true
+                    },
+                    "styles": {
+                      "type": "boolean",
+                      "description": "Output sourcemaps for all styles.",
+                      "default": true
+                    },
+                    "hidden": {
+                      "type": "boolean",
+                      "description": "Output sourcemaps used for error reporting tools.",
+                      "default": false
+                    },
+                    "vendor": {
+                      "type": "boolean",
+                      "description": "Resolve vendor packages sourcemaps.",
+                      "default": false
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "boolean"
+                }
+              ]
             },
             "vendorSourceMap": {
               "type": "boolean",

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/build-options.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/build-options.ts
@@ -24,6 +24,9 @@ export interface BuildOptions {
   resourcesOutputPath?: string;
   aot?: boolean;
   sourceMap?: boolean;
+  scriptsSourceMap?: boolean;
+  stylesSourceMap?: boolean;
+  hiddenSourceMap?: boolean;
   vendorSourceMap?: boolean;
   evalSourceMap?: boolean;
   vendorChunk?: boolean;

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
@@ -15,7 +15,7 @@ import { ScriptsWebpackPlugin } from '../../plugins/scripts-webpack-plugin';
 import { findUp } from '../../utilities/find-up';
 import { isDirectory } from '../../utilities/is-directory';
 import { requireProjectModule } from '../../utilities/require-project-module';
-import { WebpackConfigOptions } from '../build-options';
+import { BuildOptions, WebpackConfigOptions } from '../build-options';
 import { getOutputHashFormat, normalizeExtraEntryPoints } from './utils';
 
 const ProgressPlugin = require('webpack/lib/ProgressPlugin');
@@ -102,7 +102,7 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
 
       extraPlugins.push(new ScriptsWebpackPlugin({
         name: bundleName,
-        sourceMap: buildOptions.sourceMap,
+        sourceMap: buildOptions.scriptsSourceMap,
         filename: `${path.basename(bundleName)}${hash}.js`,
         scripts: script.paths,
         basePath: projectRoot,
@@ -174,7 +174,7 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
       use: [
         {
           loader: buildOptimizerLoader,
-          options: { sourceMap: buildOptions.sourceMap },
+          options: { sourceMap: buildOptions.scriptsSourceMap },
         },
       ],
     };
@@ -297,12 +297,12 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
         // TODO: check with Mike what this feature needs.
         new BundleBudgetPlugin({ budgets: buildOptions.budgets }),
         new CleanCssWebpackPlugin({
-          sourceMap: buildOptions.sourceMap,
+          sourceMap: buildOptions.stylesSourceMap,
           // component styles retain their original file name
           test: (file) => /\.(?:css|scss|sass|less|styl)$/.test(file),
         }),
         new TerserPlugin({
-          sourceMap: buildOptions.sourceMap,
+          sourceMap: buildOptions.scriptsSourceMap,
           parallel: true,
           cache: true,
           terserOptions,

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/server.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/server.ts
@@ -7,6 +7,7 @@
  */
 import { Configuration } from 'webpack';
 import { WebpackConfigOptions } from '../build-options';
+import { getSourceMapDevTool } from './utils';
 
 
 /**
@@ -15,8 +16,22 @@ import { WebpackConfigOptions } from '../build-options';
  */
 export function getServerConfig(wco: WebpackConfigOptions) {
 
+  const extraPlugins = [];
+  if (wco.buildOptions.sourceMap) {
+    const {
+      scriptsSourceMap = false,
+      stylesSourceMap = false,
+      hiddenSourceMap = false,
+    } = wco.buildOptions;
+
+    extraPlugins.push(getSourceMapDevTool(
+      scriptsSourceMap,
+      stylesSourceMap,
+      hiddenSourceMap,
+    ));
+  }
+
   const config: Configuration = {
-    devtool: wco.buildOptions.sourceMap ? 'source-map' : false,
     resolve: {
       mainFields: [
         ...(wco.supportES2015 ? ['es2015'] : []),
@@ -27,6 +42,7 @@ export function getServerConfig(wco: WebpackConfigOptions) {
     output: {
       libraryTarget: 'commonjs',
     },
+    plugins: extraPlugins,
     node: false,
   };
 

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/styles.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/styles.ts
@@ -40,7 +40,8 @@ export function getStylesConfig(wco: WebpackConfigOptions) {
   const entryPoints: { [key: string]: string[] } = {};
   const globalStylePaths: string[] = [];
   const extraPlugins = [];
-  const cssSourceMap = buildOptions.sourceMap;
+
+  const cssSourceMap = buildOptions.stylesSourceMap;
 
   // Determine hashing format.
   const hashFormat = getOutputHashFormat(buildOptions.outputHashing as string);
@@ -187,7 +188,7 @@ export function getStylesConfig(wco: WebpackConfigOptions) {
         options: {
           ident: 'embedded',
           plugins: postcssPluginCreator,
-          sourceMap: cssSourceMap ? 'inline' : false,
+          sourceMap: cssSourceMap && !buildOptions.hiddenSourceMap ? 'inline' : false,
         },
       },
       ...(use as webpack.Loader[]),
@@ -208,7 +209,10 @@ export function getStylesConfig(wco: WebpackConfigOptions) {
             options: {
               ident: buildOptions.extractCss ? 'extracted' : 'embedded',
               plugins: postcssPluginCreator,
-              sourceMap: cssSourceMap && !buildOptions.extractCss ? 'inline' : cssSourceMap,
+              sourceMap: cssSourceMap
+                && !buildOptions.extractCss
+                && !buildOptions.hiddenSourceMap
+                ? 'inline' : cssSourceMap,
             },
           },
           ...(use as webpack.Loader[]),

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/test.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/test.ts
@@ -10,6 +10,7 @@ import * as glob from 'glob';
 import * as path from 'path';
 import * as webpack from 'webpack';
 import { WebpackConfigOptions, WebpackTestOptions } from '../build-options';
+import { getSourceMapDevTool } from './utils';
 
 
 /**
@@ -55,6 +56,20 @@ export function getTestConfig(
     });
   }
 
+  if (wco.buildOptions.sourceMap) {
+    const {
+      scriptsSourceMap = false,
+      stylesSourceMap = false,
+    } = wco.buildOptions;
+
+    extraPlugins.push(getSourceMapDevTool(
+      scriptsSourceMap,
+      stylesSourceMap,
+      false,
+      true,
+    ));
+  }
+
   return {
     mode: 'development',
     resolve: {
@@ -63,7 +78,7 @@ export function getTestConfig(
         'browser', 'module', 'main',
       ],
     },
-    devtool: buildOptions.sourceMap ? 'inline-source-map' : 'eval',
+    devtool: buildOptions.sourceMap ? false : 'eval',
     entry: {
       main: path.resolve(root, buildOptions.main),
     },

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/typescript.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/typescript.ts
@@ -75,7 +75,7 @@ function _createAotPlugin(
     locale: buildOptions.i18nLocale,
     platform: buildOptions.platform === 'server' ? PLATFORM.Server : PLATFORM.Browser,
     missingTranslation: buildOptions.i18nMissingTranslation,
-    sourceMap: buildOptions.sourceMap,
+    sourceMap: buildOptions.scriptsSourceMap,
     additionalLazyModules,
     hostReplacementPaths,
     nameLazyFiles: buildOptions.namedChunks,
@@ -108,7 +108,7 @@ export function getAotConfig(
   if (buildOptions.buildOptimizer) {
     loaders.unshift({
       loader: buildOptimizerLoader,
-      options: { sourceMap: buildOptions.sourceMap }
+      options: { sourceMap: buildOptions.scriptsSourceMap }
     });
   }
 

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/utils.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/utils.ts
@@ -11,6 +11,7 @@
 import * as path from 'path';
 import { basename, normalize } from '@angular-devkit/core';
 import { ExtraEntryPoint, ExtraEntryPointObject } from '../../../browser/schema';
+import { SourceMapDevToolPlugin } from 'webpack';
 
 export const ngAppResolve = (resolvePath: string): string => {
   return path.resolve(process.cwd(), resolvePath);
@@ -65,4 +66,26 @@ export function normalizeExtraEntryPoints(
 
     return normalizedEntry;
   })
+}
+
+export function getSourceMapDevTool(
+  scriptsSourceMap: boolean,
+  stylesSourceMap: boolean,
+  hiddenSourceMap = false,
+  inlineSourceMap = false,
+): SourceMapDevToolPlugin {
+  const include = [];
+  if (scriptsSourceMap) {
+    include.push(/js$/);
+  }
+
+  if (stylesSourceMap) {
+    include.push(/css$/);
+  }
+
+  return new SourceMapDevToolPlugin({
+    filename: inlineSourceMap ? undefined : '[file].map',
+    include,
+    append: hiddenSourceMap ? false : undefined,
+  });
 }

--- a/packages/angular_devkit/build_angular/src/browser/schema.d.ts
+++ b/packages/angular_devkit/build_angular/src/browser/schema.d.ts
@@ -69,10 +69,11 @@ export interface BrowserBuilderSchema {
   /**
    * Output sourcemaps.
    */
-  sourceMap: boolean;
+  sourceMap: SourceMapOptions;
 
   /**
    * Resolve vendor packages sourcemaps.
+   * @deprecated - use `sourceMap.vendor` instead
    */
   vendorSourceMap?: boolean;
 
@@ -234,6 +235,19 @@ export interface BrowserBuilderSchema {
    * Output profile events for Chrome profiler.
    */
   profile: boolean;
+}
+
+export type SourceMapOptions = boolean | SourceMapObject;
+
+export interface SourceMapObject {
+  /** Output sourcemaps used for error reports. */
+  hidden?: boolean;
+  /** Resolve vendor packages sourcemaps */
+  vendor?: boolean;
+  /** Output sourcemaps for all scripts */
+  scripts?: boolean;
+  /** Output sourcemaps for all styles. */
+  styles?: boolean;
 }
 
 export type AssetPattern = string | AssetPatternObject;

--- a/packages/angular_devkit/build_angular/src/browser/schema.json
+++ b/packages/angular_devkit/build_angular/src/browser/schema.json
@@ -82,13 +82,44 @@
       "default": false
     },
     "sourceMap": {
-      "type": "boolean",
       "description": "Output sourcemaps.",
-      "default": true
+      "default": true,
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "scripts": {
+              "type": "boolean",
+              "description": "Output sourcemaps for all scripts.",
+              "default": true
+            },
+            "styles": {
+              "type": "boolean",
+              "description": "Output sourcemaps for all styles.",
+              "default": true
+            },
+            "hidden": {
+              "type": "boolean",
+              "description": "Output sourcemaps used for error reporting tools.",
+              "default": false
+            },
+            "vendor": {
+              "type": "boolean",
+              "description": "Resolve vendor packages sourcemaps.",
+              "default": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "boolean"
+        }
+      ]
     },
     "vendorSourceMap": {
       "type": "boolean",
       "description": "Resolve vendor packages sourcemaps.",
+      "x-deprecated": true,
       "default": false
     },
     "evalSourceMap": {

--- a/packages/angular_devkit/build_angular/src/dev-server/schema.json
+++ b/packages/angular_devkit/build_angular/src/dev-server/schema.json
@@ -92,12 +92,44 @@
       "description": "Build using Ahead of Time compilation."
     },
     "sourceMap": {
-      "type": "boolean",
-      "description": "Output sourcemaps."
+      "description": "Output sourcemaps.",
+      "default": true,
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "scripts": {
+              "type": "boolean",
+              "description": "Output sourcemaps for all scripts.",
+              "default": true
+            },
+            "styles": {
+              "type": "boolean",
+              "description": "Output sourcemaps for all styles.",
+              "default": true
+            },
+            "hidden": {
+              "type": "boolean",
+              "description": "Output sourcemaps used for error reporting tools.",
+              "default": false
+            },
+            "vendor": {
+              "type": "boolean",
+              "description": "Resolve vendor packages sourcemaps.",
+              "default": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "boolean"
+        }
+      ]
     },
     "vendorSourceMap": {
       "type": "boolean",
       "description": "Resolve vendor packages sourcemaps.",
+      "x-deprecated": true,
       "default": false
     },
     "evalSourceMap": {

--- a/packages/angular_devkit/build_angular/src/karma/schema.d.ts
+++ b/packages/angular_devkit/build_angular/src/karma/schema.d.ts
@@ -7,16 +7,19 @@
  */
 import { BrowserBuilderSchema } from '../browser/schema';
 
-
-// TODO: in TS 2.8 use Extract instead of Pick to make a subset of another type.
 export interface KarmaBuilderSchema extends Pick<BrowserBuilderSchema,
   'assets' | 'main' | 'polyfills' | 'tsConfig' | 'scripts' | 'styles' | 'stylePreprocessorOptions'
-  | 'fileReplacements' | 'sourceMap' | 'poll' | 'preserveSymlinks' | 'watch'
+  | 'fileReplacements' | 'poll' | 'preserveSymlinks' | 'watch' | 'vendorSourceMap'
   > {
   /**
    * The name of the Karma configuration file..
    */
   karmaConfig: string;
+
+  /**
+   * Output sourcemaps.
+   */
+  sourceMap: KarmaSourceMapOptions;
 
   /**
    * Override which browsers tests are run against.
@@ -37,4 +40,15 @@ export interface KarmaBuilderSchema extends Pick<BrowserBuilderSchema,
    * Karma reporters to use. Directly passed to the karma runner.
    */
   reporters?: string[];
+}
+
+export type KarmaSourceMapOptions = boolean | KarmaSourceMapObject;
+
+export interface KarmaSourceMapObject {
+  /** Resolve vendor packages sourcemaps */
+  vendor?: boolean;
+  /** Output sourcemaps for all scripts */
+  scripts?: boolean;
+  /** Output sourcemaps for all styles. */
+  styles?: boolean;
 }

--- a/packages/angular_devkit/build_angular/src/karma/schema.json
+++ b/packages/angular_devkit/build_angular/src/karma/schema.json
@@ -63,13 +63,39 @@
       "description": "Defines the build environment."
     },
     "sourceMap": {
-      "type": "boolean",
       "description": "Output sourcemaps.",
-      "default": true
+      "default": true,
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "scripts": {
+              "type": "boolean",
+              "description": "Output sourcemaps for all scripts.",
+              "default": true
+            },
+            "styles": {
+              "type": "boolean",
+              "description": "Output sourcemaps for all styles.",
+              "default": true
+            },
+            "vendor": {
+              "type": "boolean",
+              "description": "Resolve vendor packages sourcemaps.",
+              "default": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "boolean"
+        }
+      ]
     },
     "vendorSourceMap": {
       "type": "boolean",
       "description": "Resolve vendor packages sourcemaps.",
+      "x-deprecated": true,
       "default": false
     },
     "evalSourceMap": {

--- a/packages/angular_devkit/build_angular/src/server/schema.d.ts
+++ b/packages/angular_devkit/build_angular/src/server/schema.d.ts
@@ -6,17 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { FileReplacement } from '../browser/schema';
+import { BrowserBuilderSchema, FileReplacement, SourceMapOptions } from '../browser/schema';
 
 export interface BuildWebpackServerSchema {
   /**
    * The name of the TypeScript configuration file.
    */
   tsConfig: string;
-  /**
-   * Output sourcemaps.
-   */
-  sourceMap?: boolean;
   /**
    * Adds more details to output logging.
    */
@@ -38,7 +34,12 @@ export interface BuildWebpackServerSchema {
    */
   vendorChunk?: boolean;
   /**
+   * Output sourcemaps.
+   */
+  sourceMap: SourceMapOptions;
+  /**
    * Resolve vendor packages sourcemaps.
+   * @deprecated use sourceMap.vendor
    */
   vendorSourceMap?: boolean;
   /**

--- a/packages/angular_devkit/build_angular/src/server/schema.json
+++ b/packages/angular_devkit/build_angular/src/server/schema.json
@@ -50,13 +50,44 @@
       "default": ""
     },
     "sourceMap": {
-      "type": "boolean",
       "description": "Output sourcemaps.",
-      "default": true
+      "default": true,
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "scripts": {
+              "type": "boolean",
+              "description": "Output sourcemaps for all scripts.",
+              "default": true
+            },
+            "styles": {
+              "type": "boolean",
+              "description": "Output sourcemaps for all styles.",
+              "default": true
+            },
+            "hidden": {
+              "type": "boolean",
+              "description": "Output sourcemaps used for error reporting tools.",
+              "default": false
+            },
+            "vendor": {
+              "type": "boolean",
+              "description": "Resolve vendor packages sourcemaps.",
+              "default": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "boolean"
+        }
+      ]
     },
     "vendorSourceMap": {
       "type": "boolean",
       "description": "Resolve vendor packages sourcemaps.",
+      "x-deprecated": true,
       "default": false
     },
     "evalSourceMap": {
@@ -220,6 +251,5 @@
         }
       ]
     }
-
   }
 }

--- a/packages/angular_devkit/build_angular/src/utils/index.ts
+++ b/packages/angular_devkit/build_angular/src/utils/index.ts
@@ -10,3 +10,4 @@ export * from './default-progress';
 export * from './run-module-as-observable-fork';
 export * from './normalize-file-replacements';
 export * from './normalize-asset-patterns';
+export * from './normalize-source-maps';

--- a/packages/angular_devkit/build_angular/src/utils/normalize-source-maps.ts
+++ b/packages/angular_devkit/build_angular/src/utils/normalize-source-maps.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { SourceMapOptions } from '../browser/schema';
+
+export interface NormalizedSourceMaps {
+  sourceMap: boolean;
+  scriptsSourceMap: boolean;
+  stylesSourceMap: boolean;
+  hiddenSourceMap: boolean;
+  vendorSourceMap: boolean;
+}
+
+export function normalizeSourceMaps(sourceMap: SourceMapOptions): NormalizedSourceMaps {
+  const scriptsSourceMap = !!(typeof sourceMap === 'object' ? sourceMap.scripts : sourceMap);
+  const stylesSourceMap = !!(typeof sourceMap === 'object' ? sourceMap.styles : sourceMap);
+  const hiddenSourceMap = typeof sourceMap === 'object' && !!sourceMap.hidden;
+  const vendorSourceMap = typeof sourceMap === 'object' && !!sourceMap.vendor;
+
+  return {
+    sourceMap: stylesSourceMap || scriptsSourceMap,
+    vendorSourceMap,
+    hiddenSourceMap,
+    scriptsSourceMap,
+    stylesSourceMap,
+  };
+}

--- a/packages/angular_devkit/build_angular/test/browser/source-map_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/browser/source-map_spec_large.ts
@@ -9,9 +9,10 @@
 import { runTargetSpec } from '@angular-devkit/architect/testing';
 import { join, normalize, virtualFs } from '@angular-devkit/core';
 import { tap } from 'rxjs/operators';
+import { BrowserBuilderSchema, OutputHashing } from '../../src';
 import { browserTargetSpec, host } from '../utils';
 
-
+// tslint:disable-next-line:no-big-function
 describe('Browser Builder source map', () => {
   const outputPath = normalize('dist');
 
@@ -19,13 +20,38 @@ describe('Browser Builder source map', () => {
   afterEach(done => host.restore().toPromise().then(done, done.fail));
 
   it('works', (done) => {
-    const overrides = { sourceMap: true };
+    const overrides: Partial<BrowserBuilderSchema> = {
+      sourceMap: true,
+      extractCss: true,
+      styles: ['src/styles.css'],
+    };
+
+    host.writeMultipleFiles({
+      'src/styles.css': `div { flex: 1 }`,
+    });
 
     runTargetSpec(host, browserTargetSpec, overrides).pipe(
       tap((buildEvent) => expect(buildEvent.success).toBe(true)),
       tap(() => {
-        const fileName = join(outputPath, 'main.js.map');
-        expect(host.scopedSync().exists(fileName)).toBe(true);
+        const scriptsFileName = join(outputPath, 'main.js.map');
+        expect(host.scopedSync().exists(scriptsFileName)).toBe(true);
+
+        const stylesFileName = join(outputPath, 'styles.css.map');
+        expect(host.scopedSync().exists(stylesFileName)).toBe(true);
+      }),
+    ).toPromise().then(done, done.fail);
+  });
+
+  it('works with outputHashing', (done) => {
+    const overrides: Partial<BrowserBuilderSchema> = {
+      sourceMap: true,
+      outputHashing: OutputHashing.All,
+    };
+
+    runTargetSpec(host, browserTargetSpec, overrides).pipe(
+      tap((buildEvent) => expect(buildEvent.success).toBe(true)),
+      tap(() => {
+        expect(host.fileMatchExists(outputPath, /main\.[0-9a-f]{20}\.js.map/)).toBeTruthy();
       }),
     ).toPromise().then(done, done.fail);
   });
@@ -52,6 +78,145 @@ describe('Browser Builder source map', () => {
         const fileName = join(outputPath, 'main.js');
         const content = virtualFs.fileBufferToString(host.scopedSync().read(fileName));
         expect(content).toContain('eval("function webpackEmptyAsyncContext');
+      }),
+    ).toPromise().then(done, done.fail);
+  });
+
+  it('supports hidden sourcemaps', (done) => {
+    const overrides: Partial<BrowserBuilderSchema> = {
+      sourceMap: {
+        hidden: true,
+        styles: true,
+        scripts: true,
+      },
+      extractCss: true,
+      styles: ['src/styles.scss'],
+    };
+
+    host.writeMultipleFiles({
+      'src/styles.scss': `div { flex: 1 }`,
+    });
+
+
+    runTargetSpec(host, browserTargetSpec, overrides).pipe(
+      tap((buildEvent) => expect(buildEvent.success).toBe(true)),
+      tap(() => {
+        expect(host.scopedSync().exists(join(outputPath, 'main.js.map'))).toBe(true);
+        expect(host.scopedSync().exists(join(outputPath, 'styles.css.map'))).toBe(true);
+
+        const scriptContent = virtualFs.fileBufferToString(
+          host.scopedSync().read(join(outputPath, 'main.js')),
+        );
+        expect(scriptContent).not.toContain('sourceMappingURL=main.js.map');
+
+        const styleContent = virtualFs.fileBufferToString(
+          host.scopedSync().read(join(outputPath, 'styles.css')),
+        );
+        expect(styleContent).not.toContain('sourceMappingURL=styles.css.map');
+      }),
+    ).toPromise().then(done, done.fail);
+  });
+
+  it('supports styles only sourcemaps', (done) => {
+    const overrides: Partial<BrowserBuilderSchema> = {
+      sourceMap: {
+        styles: true,
+        scripts: false,
+      },
+      extractCss: true,
+      styles: ['src/styles.scss'],
+    };
+
+    host.writeMultipleFiles({
+      'src/styles.scss': `div { flex: 1 }`,
+    });
+
+    runTargetSpec(host, browserTargetSpec, overrides).pipe(
+      tap((buildEvent) => expect(buildEvent.success).toBe(true)),
+      tap(() => {
+        expect(host.scopedSync().exists(join(outputPath, 'main.js.map'))).toBe(false);
+        expect(host.scopedSync().exists(join(outputPath, 'styles.css.map'))).toBe(true);
+
+        const scriptContent = virtualFs.fileBufferToString(
+          host.scopedSync().read(join(outputPath, 'main.js')),
+        );
+        expect(scriptContent).not.toContain('sourceMappingURL=main.js.map');
+
+        const styleContent = virtualFs.fileBufferToString(
+          host.scopedSync().read(join(outputPath, 'styles.css')),
+        );
+
+        expect(styleContent).toContain('sourceMappingURL=styles.css.map');
+      }),
+    ).toPromise().then(done, done.fail);
+  });
+
+  it('supports scripts only sourcemaps', (done) => {
+    const overrides: Partial<BrowserBuilderSchema> = {
+      sourceMap: {
+        styles: false,
+        scripts: true,
+      },
+      extractCss: true,
+      styles: ['src/styles.scss'],
+    };
+
+    host.writeMultipleFiles({
+      'src/styles.scss': `div { flex: 1 }`,
+    });
+
+    runTargetSpec(host, browserTargetSpec, overrides).pipe(
+      tap((buildEvent) => expect(buildEvent.success).toBe(true)),
+      tap(() => {
+        expect(host.scopedSync().exists(join(outputPath, 'main.js.map'))).toBe(true);
+        expect(host.scopedSync().exists(join(outputPath, 'styles.css.map'))).toBe(false);
+
+        const scriptContent = virtualFs.fileBufferToString(
+          host.scopedSync().read(join(outputPath, 'main.js')),
+        );
+        expect(scriptContent).toContain('sourceMappingURL=main.js.map');
+
+        const styleContent = virtualFs.fileBufferToString(
+          host.scopedSync().read(join(outputPath, 'styles.css')),
+        );
+        expect(styleContent).not.toContain('sourceMappingURL=styles.css.map');
+      }),
+    ).toPromise().then(done, done.fail);
+  });
+
+  it('should not inline component styles sourcemaps when hidden', (done) => {
+    const overrides: Partial<BrowserBuilderSchema> = {
+      sourceMap: {
+        hidden: true,
+        styles: true,
+        scripts: true,
+      },
+      extractCss: true,
+      styles: ['src/styles.scss'],
+    };
+
+    host.writeMultipleFiles({
+      'src/styles.scss': `div { flex: 1 }`,
+      'src/app/app.component.css': `p { color: red; }`,
+    });
+
+    runTargetSpec(host, browserTargetSpec, overrides).pipe(
+      tap((buildEvent) => expect(buildEvent.success).toBe(true)),
+      tap(() => {
+        expect(host.scopedSync().exists(join(outputPath, 'main.js.map'))).toBe(true);
+        expect(host.scopedSync().exists(join(outputPath, 'styles.css.map'))).toBe(true);
+
+        const scriptContent = virtualFs.fileBufferToString(
+          host.scopedSync().read(join(outputPath, 'main.js')),
+        );
+
+        expect(scriptContent).not.toContain('sourceMappingURL=main.js.map');
+        expect(scriptContent).not.toContain('sourceMappingURL=data:application/json');
+
+        const styleContent = virtualFs.fileBufferToString(
+          host.scopedSync().read(join(outputPath, 'styles.css')),
+        );
+        expect(styleContent).not.toContain('sourceMappingURL=styles.css.map');
       }),
     ).toPromise().then(done, done.fail);
   });

--- a/packages/angular_devkit/build_angular/test/browser/vendor-source-map_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/browser/vendor-source-map_spec_large.ts
@@ -10,6 +10,7 @@ import { runTargetSpec } from '@angular-devkit/architect/testing';
 import { join, normalize, virtualFs } from '@angular-devkit/core';
 import * as path from 'path';
 import { tap } from 'rxjs/operators';
+import { BrowserBuilderSchema } from '../../src/browser/schema';
 import { browserTargetSpec, host } from '../utils';
 
 describe('Browser Builder external source map', () => {
@@ -19,7 +20,13 @@ describe('Browser Builder external source map', () => {
   afterEach(done => host.restore().toPromise().then(done, done.fail));
 
   it('works', (done) => {
-    const overrides = { sourceMap: true, vendorSourceMap: true };
+    const overrides: Partial<BrowserBuilderSchema> = {
+      sourceMap: {
+        scripts: true,
+        styles: true,
+        vendor: true,
+      },
+    };
 
     runTargetSpec(host, browserTargetSpec, overrides).pipe(
       tap((buildEvent) => expect(buildEvent.success).toBe(true)),
@@ -35,7 +42,13 @@ describe('Browser Builder external source map', () => {
   });
 
   it('does not map sourcemaps from external library when disabled', (done) => {
-    const overrides = { sourceMap: true, vendorSourceMap: false };
+    const overrides: Partial<BrowserBuilderSchema> = {
+      sourceMap: {
+        scripts: true,
+        styles: true,
+        vendor: false,
+      },
+    };
 
     runTargetSpec(host, browserTargetSpec, overrides).pipe(
       tap((buildEvent) => expect(buildEvent.success).toBe(true)),


### PR DESCRIPTION
This PR add more control over which sourceMaps you want, Now you can enable sourceMaps for scripts only, styles only or both. Also we added another functionality which are hidden sourcemaps. These are normally used for error reporting tools.

Fixes #7527