### PR TITLE
refactor: deprecate `evalSourceMap`

### DIFF
--- a/packages/angular_devkit/build_angular/src/browser/schema.json
+++ b/packages/angular_devkit/build_angular/src/browser/schema.json
@@ -94,7 +94,8 @@
     "evalSourceMap": {
       "type": "boolean",
       "description": "Output in-file eval sourcemaps.",
-      "default": false
+      "default": false,
+      "x-deprecated": true
     },
     "vendorChunk": {
       "type": "boolean",

--- a/packages/angular_devkit/build_angular/src/server/schema.d.ts
+++ b/packages/angular_devkit/build_angular/src/server/schema.d.ts
@@ -43,6 +43,7 @@ export interface BuildWebpackServerSchema {
   vendorSourceMap?: boolean;
   /**
    * Output in-file eval sourcemaps.
+   * @deprecated
    */
   evalSourceMap?: boolean;
   /**


### PR DESCRIPTION
Missed a couple in https://github.com/angular/angular-cli/pull/12966