### PR TITLE
style: add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# Auto detect text files and perform LF normalization
+* text=auto
+
+# JS and TS files must always use LF for tools to work
+*.js eol=lf
+*.ts eol=lf
+*.json eol=lf
+*.css eol=lf
+*.scss eol=lf
+*.less eol=lf
+*.html eol=lf
+*.svg eol=lf


### PR DESCRIPTION
On windows unless otherwise specified when cloning the repo the line ending will be CRLF which will cause some tests large specs to fail