### PR TITLE
feat(@schematics/angular): Added multiselect guard implements option

### DIFF
--- a/packages/schematics/angular/guard/files/__name@dasherize__.guard.ts
+++ b/packages/schematics/angular/guard/files/__name@dasherize__.guard.ts
@@ -1,14 +1,24 @@
 import { Injectable } from '@angular/core';
-import { CanActivate, ActivatedRouteSnapshot, RouterStateSnapshot, UrlTree } from '@angular/router';
+import { <%= implementationImports %>ActivatedRouteSnapshot, RouterStateSnapshot, UrlTree } from '@angular/router';
 import { Observable } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
 })
-export class <%= classify(name) %>Guard implements CanActivate {
-  canActivate(
+export class <%= classify(name) %>Guard implements <%= implementations %> {
+  <% if (implements.includes('CanActivate')) { %>canActivate(
     next: ActivatedRouteSnapshot,
     state: RouterStateSnapshot): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
     return true;
   }
+  <% } %><% if (implements.includes('CanActivateChild')) { %>canActivateChild(
+    next: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
+    return true;
+  }
+  <% } %><% if (implements.includes('CanLoad')) { %>canLoad(
+    route: Route,
+    segments: UrlSegment[]): Observable<boolean> | Promise<boolean> | boolean {
+    return true;
+  }<% } %>
 }

--- a/packages/schematics/angular/guard/index.ts
+++ b/packages/schematics/angular/guard/index.ts
@@ -36,6 +36,20 @@ export default function (options: GuardOptions): Rule {
     if (options.path === undefined) {
       options.path = buildDefaultPath(project);
     }
+    if (options.implements === undefined) {
+      options.implements = [];
+    }
+
+    let implementations = '';
+    let implementationImports = '';
+    if (options.implements.length > 0) {
+      implementations = options.implements.join(', ');
+      implementationImports = `${implementations}, `;
+      // As long as we aren't in IE... ;)
+      if (options.implements.includes('CanLoad')) {
+        implementationImports = `${implementationImports}Route, UrlSegment, `;
+      }
+    }
 
     const parsedPath = parseName(options.path, options.name);
     options.name = parsedPath.name;
@@ -47,6 +61,8 @@ export default function (options: GuardOptions): Rule {
     const templateSource = apply(url('./files'), [
       options.skipTests ? filter(path => !path.endsWith('.spec.ts')) : noop(),
       template({
+        implementations,
+        implementationImports,
         ...strings,
         ...options,
       }),

--- a/packages/schematics/angular/guard/index_spec.ts
+++ b/packages/schematics/angular/guard/index_spec.ts
@@ -10,7 +10,6 @@ import { Schema as ApplicationOptions } from '../application/schema';
 import { Schema as WorkspaceOptions } from '../workspace/schema';
 import { Schema as GuardOptions } from './schema';
 
-
 describe('Guard Schematic', () => {
   const schematicRunner = new SchematicTestRunner(
     '@schematics/angular',
@@ -63,5 +62,31 @@ describe('Guard Schematic', () => {
     appTree.overwrite('/angular.json', JSON.stringify(config, null, 2));
     appTree = schematicRunner.runSchematic('guard', defaultOptions, appTree);
     expect(appTree.files).toContain('/projects/bar/custom/app/foo.guard.ts');
+  });
+
+  it('should respect the implements value', () => {
+    const options = { ...defaultOptions, implements: ['CanActivate']};
+    const tree = schematicRunner.runSchematic('guard', options, appTree);
+    const fileString = tree.readContent('/projects/bar/src/app/foo.guard.ts');
+    expect(fileString).toContain('CanActivate');
+    expect(fileString).toContain('canActivate');
+    expect(fileString).not.toContain('CanActivateChild');
+    expect(fileString).not.toContain('canActivateChild');
+    expect(fileString).not.toContain('CanLoad');
+    expect(fileString).not.toContain('canLoad');
+  });
+
+  it('should respect the implements values', () => {
+    const implementationOptions = ['CanActivate', 'CanLoad', 'CanActivateChild'];
+    const options = { ...defaultOptions, implements: implementationOptions};
+    const tree = schematicRunner.runSchematic('guard', options, appTree);
+    const fileString = tree.readContent('/projects/bar/src/app/foo.guard.ts');
+
+    // Should contain all implementations
+    implementationOptions.forEach((implementation: string) => {
+      expect(fileString).toContain(implementation);
+      const functionName = `${implementation.charAt(0).toLowerCase()}${implementation.slice(1)}`;
+      expect(fileString).toContain(functionName);
+    });
   });
 });

--- a/packages/schematics/angular/guard/schema.json
+++ b/packages/schematics/angular/guard/schema.json
@@ -47,6 +47,24 @@
       "type": "boolean",
       "default": false,
       "description": "When true, applies lint fixes after generating the guard."
+    },
+    "implements": {
+      "type": "array",
+      "description": "Specifies which interfaces to implement.",
+      "uniqueItems": true,
+      "items": {
+        "type": "string"
+      },
+      "x-prompt": {
+        "message": "Which interfaces would you like to implement?",
+        "type": "list",
+        "multiselect": true,
+        "items": [
+          "CanActivate",
+          "CanActivateChild",
+          "CanLoad"
+        ]
+      }
     }
   },
   "required": [


### PR DESCRIPTION
Follow up to https://github.com/angular/angular-cli/pull/13031, using the multiselect option for the guard schematic to ask the user which methods they would like to implement. I purposefully left out CanDeactivate because of the need to tie in a component. This would be a good candidate for a future PR though!

Fixes #13400

Thanks,

Michael