### PR TITLE
fix(@schematics/angular): set `optimization` and `sourceMap` in universal production config

### DIFF
--- a/packages/schematics/angular/universal/index.ts
+++ b/packages/schematics/angular/universal/index.ts
@@ -67,6 +67,11 @@ function updateConfigFile(options: UniversalOptions, tsConfigDirectory: Path): R
       configurations: {
         production: {
           fileReplacements: getFileReplacements(projectTargets),
+          sourceMap: false,
+          optimization: {
+            scripts: false,
+            styles: true,
+          },
         },
       },
     };

--- a/packages/schematics/angular/utility/workspace-models.ts
+++ b/packages/schematics/angular/utility/workspace-models.ts
@@ -74,6 +74,11 @@ export interface ServerBuilderOptions {
     tsConfig: string;
     main: string;
     fileReplacements?: FileReplacements[];
+    optimization?: {
+        scripts?: boolean;
+        styles?: boolean;
+    };
+    sourceMap?: boolean;
 }
 
 export interface AppShellBuilderOptions {


### PR DESCRIPTION

- When using Universal sourceMaps should not be enabled or at least `styles` sourceMaps should be disabled as these will otherwise be inlined and will be set as apart of the server side rendered page.

- While there is no benefit to optimize the scripts at server level, styles should always be minified so that the server side rendered page is smaller.

Fixes #12541 and Fixes #12940

Depends on https://github.com/angular/angular-cli/pull/13116