### PR TITLE
Enable fine grain optimization settings

### DIFF
--- a/packages/angular/cli/lib/config/schema.json
+++ b/packages/angular/cli/lib/config/schema.json
@@ -607,9 +607,28 @@
               "additionalProperties": false
             },
             "optimization": {
-              "type": "boolean",
               "description": "Enables optimization of the build output.",
-              "default": false
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "scripts": {
+                      "type": "boolean",
+                      "description": "Enables optimization of the scripts output.",
+                      "default": true
+                    },
+                    "styles": {
+                      "type": "boolean",
+                      "description": "Enables optimization of the styles output.",
+                      "default": true
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "boolean"
+                }
+              ]
             },
             "fileReplacements": {
               "description": "Replace files with other files in the build.",
@@ -1067,8 +1086,28 @@
               "default": true
             },
             "optimization": {
-              "type": "boolean",
-              "description": "Enables optimization of the build output."
+              "description": "Enables optimization of the build output.",
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "scripts": {
+                      "type": "boolean",
+                      "description": "Enables optimization of the scripts output.",
+                      "default": true
+                    },
+                    "styles": {
+                      "type": "boolean",
+                      "description": "Enables optimization of the styles output.",
+                      "default": true
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "boolean"
+                }
+              ]
             },
             "aot": {
               "type": "boolean",
@@ -1515,9 +1554,28 @@
               "additionalProperties": false
             },
             "optimization": {
-              "type": "boolean",
               "description": "Enables optimization of the build output.",
-              "default": false
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "scripts": {
+                      "type": "boolean",
+                      "description": "Enables optimization of the scripts output.",
+                      "default": true
+                    },
+                    "styles": {
+                      "type": "boolean",
+                      "description": "Enables optimization of the styles output.",
+                      "default": true
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "boolean"
+                }
+              ]
             },
             "fileReplacements": {
               "description": "Replace files with other files in the build.",

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/build-options.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/build-options.ts
@@ -16,7 +16,7 @@ import {
   CurrentFileReplacement,
   ExtraEntryPoint,
 } from '../../browser/schema';
-import { NormalizedOptimization } from '../../utils/index';
+import { NormalizedOptimization, NormalizedSourceMaps } from '../../utils/index';
 
 export interface BuildOptions {
   optimization: NormalizedOptimization;
@@ -24,11 +24,10 @@ export interface BuildOptions {
   outputPath: string;
   resourcesOutputPath?: string;
   aot?: boolean;
-  sourceMap?: boolean;
-  scriptsSourceMap?: boolean;
-  stylesSourceMap?: boolean;
-  hiddenSourceMap?: boolean;
+  sourceMap: NormalizedSourceMaps;
+  /** @deprecated use sourceMap instead */
   vendorSourceMap?: boolean;
+  /** @deprecated  */
   evalSourceMap?: boolean;
   vendorChunk?: boolean;
   commonChunk?: boolean;

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/build-options.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/build-options.ts
@@ -16,9 +16,10 @@ import {
   CurrentFileReplacement,
   ExtraEntryPoint,
 } from '../../browser/schema';
+import { NormalizedOptimization } from '../../utils/index';
 
 export interface BuildOptions {
-  optimization: boolean;
+  optimization: NormalizedOptimization;
   environment?: string;
   outputPath: string;
   resourcesOutputPath?: string;

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/browser.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/browser.ts
@@ -20,8 +20,12 @@ export function getBrowserConfig(wco: WebpackConfigOptions) {
   const extraPlugins = [];
 
   let isEval = false;
+  const { styles: stylesOptimization, scripts: scriptsOptimization } = buildOptions.optimization;
   // See https://webpack.js.org/configuration/devtool/ for sourcemap types.
-  if (buildOptions.sourceMap && buildOptions.evalSourceMap && !buildOptions.optimization) {
+  if (buildOptions.sourceMap &&
+    buildOptions.evalSourceMap &&
+    !stylesOptimization &&
+    !scriptsOptimization) {
     // Produce eval sourcemaps for development with serve, which are faster.
     isEval = true;
   }

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/browser.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/browser.ts
@@ -21,8 +21,14 @@ export function getBrowserConfig(wco: WebpackConfigOptions) {
 
   let isEval = false;
   const { styles: stylesOptimization, scripts: scriptsOptimization } = buildOptions.optimization;
+  const {
+    styles: stylesSouceMap,
+    scripts: scriptsSourceMap,
+    hidden: hiddenSourceMap,
+  } = buildOptions.sourceMap;
+
   // See https://webpack.js.org/configuration/devtool/ for sourcemap types.
-  if (buildOptions.sourceMap &&
+  if ((stylesSouceMap || scriptsSourceMap) &&
     buildOptions.evalSourceMap &&
     !stylesOptimization &&
     !scriptsOptimization) {
@@ -58,16 +64,10 @@ export function getBrowserConfig(wco: WebpackConfigOptions) {
     }));
   }
 
-  if (!isEval && buildOptions.sourceMap) {
-    const {
-      scriptsSourceMap = false,
-      stylesSourceMap = false,
-      hiddenSourceMap = false,
-    } = buildOptions;
-
+  if (!isEval && (scriptsSourceMap || stylesSouceMap)) {
     extraPlugins.push(getSourceMapDevTool(
       scriptsSourceMap,
-      stylesSourceMap,
+      stylesSouceMap,
       hiddenSourceMap,
     ));
   }

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
@@ -34,6 +34,11 @@ export const buildOptimizerLoader: string = g['_DevKitIsLocal']
 export function getCommonConfig(wco: WebpackConfigOptions) {
   const { root, projectRoot, buildOptions } = wco;
   const { styles: stylesOptimization, scripts: scriptsOptimization } = buildOptions.optimization;
+  const {
+    styles: stylesSouceMap,
+    scripts: scriptsSourceMap,
+    vendor: vendorSourceMap,
+  } = buildOptions.sourceMap;
 
   const nodeModules = findUp('node_modules', projectRoot);
   if (!nodeModules) {
@@ -103,7 +108,7 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
 
       extraPlugins.push(new ScriptsWebpackPlugin({
         name: bundleName,
-        sourceMap: buildOptions.scriptsSourceMap,
+        sourceMap: scriptsSourceMap,
         filename: `${path.basename(bundleName)}${hash}.js`,
         scripts: script.paths,
         basePath: projectRoot,
@@ -159,7 +164,7 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
   }
 
   let sourceMapUseRule;
-  if (buildOptions.sourceMap && buildOptions.vendorSourceMap) {
+  if ((scriptsSourceMap || stylesSouceMap) && vendorSourceMap) {
     sourceMapUseRule = {
       use: [
         {
@@ -175,7 +180,7 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
       use: [
         {
           loader: buildOptimizerLoader,
-          options: { sourceMap: buildOptions.scriptsSourceMap },
+          options: { sourceMap: scriptsSourceMap },
         },
       ],
     };
@@ -209,7 +214,7 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
   if (stylesOptimization) {
     extraMinimizers.push(
       new CleanCssWebpackPlugin({
-        sourceMap: buildOptions.stylesSourceMap,
+        sourceMap: stylesSouceMap,
         // component styles retain their original file name
         test: (file) => /\.(?:css|scss|sass|less|styl)$/.test(file),
       }),
@@ -248,7 +253,7 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
 
     extraMinimizers.push(
       new TerserPlugin({
-        sourceMap: buildOptions.scriptsSourceMap,
+        sourceMap: scriptsSourceMap,
         parallel: true,
         cache: true,
         terserOptions,

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
@@ -33,6 +33,7 @@ export const buildOptimizerLoader: string = g['_DevKitIsLocal']
 // tslint:disable-next-line:no-big-function
 export function getCommonConfig(wco: WebpackConfigOptions) {
   const { root, projectRoot, buildOptions } = wco;
+  const { styles: stylesOptimization, scripts: scriptsOptimization } = buildOptions.optimization;
 
   const nodeModules = findUp('node_modules', projectRoot);
   if (!nodeModules) {
@@ -204,37 +205,61 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
     alias = rxPaths(nodeModules);
   } catch { }
 
-  const terserOptions = {
-    ecma: wco.supportES2015 ? 6 : 5,
-    warnings: !!buildOptions.verbose,
-    safari10: true,
-    output: {
-      ascii_only: true,
-      comments: false,
-      webkit: true,
-    },
+  const extraMinimizers = [];
+  if (stylesOptimization) {
+    extraMinimizers.push(
+      new CleanCssWebpackPlugin({
+        sourceMap: buildOptions.stylesSourceMap,
+        // component styles retain their original file name
+        test: (file) => /\.(?:css|scss|sass|less|styl)$/.test(file),
+      }),
+    );
+  }
 
-    // On server, we don't want to compress anything. We still set the ngDevMode = false for it
-    // to remove dev code.
-    compress: (buildOptions.platform == 'server' ? {
-      global_defs: {
-        ngDevMode: false,
+  if (scriptsOptimization) {
+    const terserOptions = {
+      ecma: wco.supportES2015 ? 6 : 5,
+      warnings: !!buildOptions.verbose,
+      safari10: true,
+      output: {
+        ascii_only: true,
+        comments: false,
+        webkit: true,
       },
-    } : {
-      pure_getters: buildOptions.buildOptimizer,
-      // PURE comments work best with 3 passes.
-      // See https://github.com/webpack/webpack/issues/2899#issuecomment-317425926.
-      passes: buildOptions.buildOptimizer ? 3 : 1,
-      global_defs: {
-        ngDevMode: false,
-      },
-    }),
-    // We also want to avoid mangling on server.
-    ...(buildOptions.platform == 'server' ? { mangle: false } : {}),
-  };
+
+      // On server, we don't want to compress anything. We still set the ngDevMode = false for it
+      // to remove dev code.
+      compress: (buildOptions.platform == 'server' ? {
+        global_defs: {
+          ngDevMode: false,
+        },
+      } : {
+          pure_getters: buildOptions.buildOptimizer,
+          // PURE comments work best with 3 passes.
+          // See https://github.com/webpack/webpack/issues/2899#issuecomment-317425926.
+          passes: buildOptions.buildOptimizer ? 3 : 1,
+          global_defs: {
+            ngDevMode: false,
+          },
+        }),
+      // We also want to avoid mangling on server.
+      ...(buildOptions.platform == 'server' ? { mangle: false } : {}),
+    };
+
+    extraMinimizers.push(
+      new TerserPlugin({
+        sourceMap: buildOptions.scriptsSourceMap,
+        parallel: true,
+        cache: true,
+        terserOptions,
+      }),
+    );
+  }
 
   return {
-    mode: buildOptions.optimization ? 'production' : 'development',
+    mode: scriptsOptimization || stylesOptimization
+      ? 'production'
+      : 'development',
     devtool: false,
     resolve: {
       extensions: ['.ts', '.tsx', '.mjs', '.js'],
@@ -296,17 +321,7 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
         new HashedModuleIdsPlugin(),
         // TODO: check with Mike what this feature needs.
         new BundleBudgetPlugin({ budgets: buildOptions.budgets }),
-        new CleanCssWebpackPlugin({
-          sourceMap: buildOptions.stylesSourceMap,
-          // component styles retain their original file name
-          test: (file) => /\.(?:css|scss|sass|less|styl)$/.test(file),
-        }),
-        new TerserPlugin({
-          sourceMap: buildOptions.scriptsSourceMap,
-          parallel: true,
-          cache: true,
-          terserOptions,
-        }),
+        ...extraMinimizers,
       ],
     },
     plugins: extraPlugins,

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/server.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/server.ts
@@ -18,16 +18,12 @@ export function getServerConfig(wco: WebpackConfigOptions) {
 
   const extraPlugins = [];
   if (wco.buildOptions.sourceMap) {
-    const {
-      scriptsSourceMap = false,
-      stylesSourceMap = false,
-      hiddenSourceMap = false,
-    } = wco.buildOptions;
+    const { scripts, styles, hidden } = wco.buildOptions.sourceMap;
 
     extraPlugins.push(getSourceMapDevTool(
-      scriptsSourceMap,
-      stylesSourceMap,
-      hiddenSourceMap,
+      scripts,
+      styles,
+      hidden,
     ));
   }
 

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/styles.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/styles.ts
@@ -41,7 +41,7 @@ export function getStylesConfig(wco: WebpackConfigOptions) {
   const globalStylePaths: string[] = [];
   const extraPlugins = [];
 
-  const cssSourceMap = buildOptions.stylesSourceMap;
+  const cssSourceMap = buildOptions.sourceMap.styles;
 
   // Determine hashing format.
   const hashFormat = getOutputHashFormat(buildOptions.outputHashing as string);
@@ -188,7 +188,7 @@ export function getStylesConfig(wco: WebpackConfigOptions) {
         options: {
           ident: 'embedded',
           plugins: postcssPluginCreator,
-          sourceMap: cssSourceMap && !buildOptions.hiddenSourceMap ? 'inline' : false,
+          sourceMap: cssSourceMap && !buildOptions.sourceMap.hidden ? 'inline' : false,
         },
       },
       ...(use as webpack.Loader[]),
@@ -211,7 +211,7 @@ export function getStylesConfig(wco: WebpackConfigOptions) {
               plugins: postcssPluginCreator,
               sourceMap: cssSourceMap
                 && !buildOptions.extractCss
-                && !buildOptions.hiddenSourceMap
+                && !buildOptions.sourceMap.hidden
                 ? 'inline' : cssSourceMap,
             },
           },

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/test.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/test.ts
@@ -57,14 +57,11 @@ export function getTestConfig(
   }
 
   if (wco.buildOptions.sourceMap) {
-    const {
-      scriptsSourceMap = false,
-      stylesSourceMap = false,
-    } = wco.buildOptions;
+    const { styles, scripts } = wco.buildOptions.sourceMap;
 
     extraPlugins.push(getSourceMapDevTool(
-      scriptsSourceMap,
-      stylesSourceMap,
+      styles,
+      scripts,
       false,
       true,
     ));

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/typescript.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/typescript.ts
@@ -75,7 +75,7 @@ function _createAotPlugin(
     locale: buildOptions.i18nLocale,
     platform: buildOptions.platform === 'server' ? PLATFORM.Server : PLATFORM.Browser,
     missingTranslation: buildOptions.i18nMissingTranslation,
-    sourceMap: buildOptions.scriptsSourceMap,
+    sourceMap: buildOptions.sourceMap.scripts,
     additionalLazyModules,
     hostReplacementPaths,
     nameLazyFiles: buildOptions.namedChunks,
@@ -108,7 +108,7 @@ export function getAotConfig(
   if (buildOptions.buildOptimizer) {
     loaders.unshift({
       loader: buildOptimizerLoader,
-      options: { sourceMap: buildOptions.scriptsSourceMap }
+      options: { sourceMap: buildOptions.sourceMap.scripts }
     });
   }
 

--- a/packages/angular_devkit/build_angular/src/browser/index.ts
+++ b/packages/angular_devkit/build_angular/src/browser/index.ts
@@ -35,10 +35,12 @@ import {
   statsWarningsToString,
 } from '../angular-cli-files/utilities/stats';
 import {
+  NormalizedOptimization,
   NormalizedSourceMaps,
   defaultProgress,
   normalizeAssetPatterns,
   normalizeFileReplacements,
+  normalizeOptimization,
   normalizeSourceMaps,
 } from '../utils';
 import {
@@ -56,10 +58,14 @@ const webpackMerge = require('webpack-merge');
 // BrowserBuildSchema and BrowserBuilder.buildWebpackConfig.
 // It would really help if it happens during architect.validateBuilderOptions, or similar.
 export interface NormalizedBrowserBuilderSchema extends
-  Pick<BrowserBuilderSchema, Exclude<keyof BrowserBuilderSchema, 'sourceMap' | 'vendorSourceMap'>>,
+  Pick<
+  BrowserBuilderSchema,
+  Exclude<keyof BrowserBuilderSchema, 'sourceMap' | 'vendorSourceMap' | 'optimization'>
+  >,
   NormalizedSourceMaps {
   assets: AssetPatternObject[];
   fileReplacements: CurrentFileReplacement[];
+  optimization: NormalizedOptimization;
 }
 
 export class BrowserBuilder implements Builder<BrowserBuilderSchema> {
@@ -92,13 +98,18 @@ export class BrowserBuilder implements Builder<BrowserBuilderSchema> {
         options = {
           ...options,
           ...normalizedOptions,
+          // tslint:disable-next-line:no-any
+          optimization: normalizeOptimization(options.optimization) as any,
         };
       }),
       concatMap(() => {
         let webpackConfig;
         try {
           webpackConfig = this.buildWebpackConfig(root, projectRoot, host,
-            options as NormalizedBrowserBuilderSchema);
+            // todo replace with unknown
+            // we need to find a clear way to create this options
+            // tslint:disable-next-line:no-any
+            options as any as NormalizedBrowserBuilderSchema);
         } catch (e) {
           return throwError(e);
         }

--- a/packages/angular_devkit/build_angular/src/browser/index.ts
+++ b/packages/angular_devkit/build_angular/src/browser/index.ts
@@ -34,18 +34,8 @@ import {
   statsToString,
   statsWarningsToString,
 } from '../angular-cli-files/utilities/stats';
-import {
-  NormalizedOptimization,
-  NormalizedSourceMaps,
-  defaultProgress,
-  normalizeBuilderSchema,
-} from '../utils';
-import {
-  AssetPatternObject,
-  BrowserBuilderSchema,
-  CurrentFileReplacement,
-  NormalizedBrowserBuilderSchema,
-} from './schema';
+import { defaultProgress, normalizeBuilderSchema } from '../utils';
+import { BrowserBuilderSchema, NormalizedBrowserBuilderSchema } from './schema';
 const SpeedMeasurePlugin = require('speed-measure-webpack-plugin');
 const webpackMerge = require('webpack-merge');
 
@@ -54,19 +44,18 @@ export class BrowserBuilder implements Builder<BrowserBuilderSchema> {
   constructor(public context: BuilderContext) { }
 
   run(builderConfig: BuilderConfiguration<BrowserBuilderSchema>): Observable<BuildEvent> {
-    let options: NormalizedBrowserBuilderSchema;
     const root = this.context.workspace.root;
     const projectRoot = resolve(root, builderConfig.root);
     const host = new virtualFs.AliasHost(this.context.host as virtualFs.Host<fs.Stats>);
     const webpackBuilder = new WebpackBuilder({ ...this.context, host });
 
+    const options = normalizeBuilderSchema(
+      host,
+      root,
+      builderConfig,
+    );
+
     return of(null).pipe(
-      concatMap(() => normalizeBuilderSchema(
-        host,
-        root,
-        builderConfig,
-      )),
-      tap(normalizedOptions => options = normalizedOptions),
       concatMap(() => options.deleteOutputPath
         ? this._deleteOutputDir(root, normalize(options.outputPath), this.context.host)
         : of(null)),

--- a/packages/angular_devkit/build_angular/src/browser/schema.d.ts
+++ b/packages/angular_devkit/build_angular/src/browser/schema.d.ts
@@ -403,3 +403,19 @@ export enum BudgetType {
   AnyScript = 'anyScript',
   Bundle = 'bundle',
 }
+
+// TODO: figure out a better way to normalize assets, extra entry points, file replacements,
+// and whatever else needs to be normalized, while keeping type safety.
+// Right now this normalization has to be done in all other builders that make use of the
+// BrowserBuildSchema and BrowserBuilder.buildWebpackConfig.
+// It would really help if it happens during architect.validateBuilderOptions, or similar.
+export interface NormalizedBrowserBuilderSchema extends
+  Pick<
+  BrowserBuilderSchema,
+  Exclude<keyof BrowserBuilderSchema, 'sourceMap' | 'vendorSourceMap' | 'optimization'>
+  > {
+  sourceMap: NormalizedSourceMaps;
+  assets: AssetPatternObject[];
+  fileReplacements: CurrentFileReplacement[];
+  optimization: NormalizedOptimization;
+}

--- a/packages/angular_devkit/build_angular/src/browser/schema.d.ts
+++ b/packages/angular_devkit/build_angular/src/browser/schema.d.ts
@@ -44,7 +44,7 @@ export interface BrowserBuilderSchema {
   /**
    * Enables optimization of the build output.
    */
-  optimization: boolean;
+  optimization: OptimizationOptions;
 
   /**
    * Replace files with other files in the build.
@@ -235,6 +235,15 @@ export interface BrowserBuilderSchema {
    * Output profile events for Chrome profiler.
    */
   profile: boolean;
+}
+
+export type OptimizationOptions = boolean | OptimizationObject;
+
+export interface OptimizationObject {
+  /** Enables optimization of the scripts output. */
+  scripts?: boolean;
+  /** Enables optimization of the styles output. */
+  styles?: boolean;
 }
 
 export type SourceMapOptions = boolean | SourceMapObject;

--- a/packages/angular_devkit/build_angular/src/browser/schema.json
+++ b/packages/angular_devkit/build_angular/src/browser/schema.json
@@ -56,7 +56,6 @@
     },
     "optimization": {
       "description": "Enables optimization of the build output.",
-      "default": false,
       "oneOf": [
         {
           "type": "object",

--- a/packages/angular_devkit/build_angular/src/browser/schema.json
+++ b/packages/angular_devkit/build_angular/src/browser/schema.json
@@ -55,9 +55,29 @@
       "additionalProperties": false
     },
     "optimization": {
-      "type": "boolean",
-      "description": "When true, uses optimization for the app build.",
-      "default": false
+      "description": "Enables optimization of the build output.",
+      "default": false,
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "scripts": {
+              "type": "boolean",
+              "description": "Enables optimization of the scripts output.",
+              "default": true
+            },
+            "styles": {
+              "type": "boolean",
+              "description": "Enables optimization of the styles output.",
+              "default": true
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "boolean"
+        }
+      ]
     },
     "fileReplacements": {
       "description": "Replace files with other files in the build.",

--- a/packages/angular_devkit/build_angular/src/dev-server/index.ts
+++ b/packages/angular_devkit/build_angular/src/dev-server/index.ts
@@ -70,12 +70,11 @@ export class DevServerBuilder implements Builder<DevServerBuilderOptions> {
     return checkPort(options.port, options.host).pipe(
       tap((port) => options.port = port),
       concatMap(() => this._getBrowserOptions(options)),
-      concatMap((opts) => normalizeBuilderSchema(
+      tap(opts => browserOptions = normalizeBuilderSchema(
         host,
         root,
         opts,
       )),
-      tap(normalizedOptions => browserOptions = normalizedOptions),
       concatMap(() => {
         const webpackConfig = this.buildWebpackConfig(root, projectRoot, host, browserOptions);
 
@@ -162,7 +161,7 @@ export class DevServerBuilder implements Builder<DevServerBuilderOptions> {
 
         return buildEvent;
       }),
-     // using more than 10 operators will cause rxjs to loose the types
+      // using more than 10 operators will cause rxjs to loose the types
     ) as Observable<BuildEvent>;
   }
 

--- a/packages/angular_devkit/build_angular/src/dev-server/index.ts
+++ b/packages/angular_devkit/build_angular/src/dev-server/index.ts
@@ -24,7 +24,12 @@ import * as WebpackDevServer from 'webpack-dev-server';
 import { checkPort } from '../angular-cli-files/utilities/check-port';
 import { BrowserBuilder, NormalizedBrowserBuilderSchema, getBrowserLoggingCb } from '../browser/';
 import { BrowserBuilderSchema } from '../browser/schema';
-import { normalizeAssetPatterns, normalizeFileReplacements, normalizeSourceMaps } from '../utils';
+import {
+  normalizeAssetPatterns,
+  normalizeFileReplacements,
+  normalizeOptimization,
+  normalizeSourceMaps,
+} from '../utils';
 const opn = require('opn');
 
 
@@ -86,15 +91,26 @@ export class DevServerBuilder implements Builder<DevServerBuilderOptions> {
         browserOptions = {
           ...browserOptions,
           ...normalizedOptions,
+          // tslint:disable-next-line:no-any
+          optimization: normalizeOptimization(options.optimization) as any,
         };
       }),
       concatMap(() => {
         const webpackConfig = this.buildWebpackConfig(
-          root, projectRoot, host, browserOptions as NormalizedBrowserBuilderSchema);
+          // todo should be unknown
+          // tslint:disable-next-line:no-any
+          root, projectRoot, host, browserOptions as any as NormalizedBrowserBuilderSchema,
+        );
 
         let webpackDevServerConfig: WebpackDevServer.Configuration;
         try {
-          webpackDevServerConfig = this._buildServerConfig(root, options, browserOptions);
+          webpackDevServerConfig = this._buildServerConfig(
+            root,
+            options,
+            // todo should be unknown
+            // tslint:disable-next-line:no-any
+            browserOptions as any as NormalizedBrowserBuilderSchema,
+          );
         } catch (err) {
           return throwError(err);
         }
@@ -179,11 +195,11 @@ export class DevServerBuilder implements Builder<DevServerBuilderOptions> {
     root: Path,
     projectRoot: Path,
     host: virtualFs.Host<Stats>,
-    browserOptions: BrowserBuilderSchema,
+    browserOptions: NormalizedBrowserBuilderSchema,
   ) {
     const browserBuilder = new BrowserBuilder(this.context);
     const webpackConfig = browserBuilder.buildWebpackConfig(
-      root, projectRoot, host, browserOptions as NormalizedBrowserBuilderSchema);
+      root, projectRoot, host, browserOptions);
 
     return webpackConfig;
   }
@@ -191,7 +207,7 @@ export class DevServerBuilder implements Builder<DevServerBuilderOptions> {
   private _buildServerConfig(
     root: Path,
     options: DevServerBuilderOptions,
-    browserOptions: BrowserBuilderSchema,
+    browserOptions: NormalizedBrowserBuilderSchema,
   ) {
     const systemRoot = getSystemPath(root);
     if (options.disableHostCheck) {
@@ -203,6 +219,7 @@ export class DevServerBuilder implements Builder<DevServerBuilderOptions> {
     }
 
     const servePath = this._buildServePath(options, browserOptions);
+    const { styles, scripts } = browserOptions.optimization;
 
     const config: WebpackDevServer.Configuration = {
       host: options.host,
@@ -214,13 +231,13 @@ export class DevServerBuilder implements Builder<DevServerBuilderOptions> {
         htmlAcceptHeaders: ['text/html', 'application/xhtml+xml'],
       } as WebpackDevServer.HistoryApiFallbackConfig,
       stats: false,
-      compress: browserOptions.optimization,
+      compress: styles || scripts,
       watchOptions: {
         poll: browserOptions.poll,
       },
       https: options.ssl,
       overlay: {
-        errors: !browserOptions.optimization,
+        errors: !(styles || scripts),
         warnings: false,
       },
       public: options.publicHost,
@@ -332,7 +349,10 @@ export class DevServerBuilder implements Builder<DevServerBuilderOptions> {
     config.proxy = proxyConfig;
   }
 
-  private _buildServePath(options: DevServerBuilderOptions, browserOptions: BrowserBuilderSchema) {
+  private _buildServePath(
+    options: DevServerBuilderOptions,
+    browserOptions: NormalizedBrowserBuilderSchema,
+  ) {
     let servePath = options.servePath;
     if (!servePath && servePath !== '') {
       const defaultServePath =

--- a/packages/angular_devkit/build_angular/src/dev-server/schema.json
+++ b/packages/angular_devkit/build_angular/src/dev-server/schema.json
@@ -84,8 +84,29 @@
       "default": true
     },
     "optimization": {
-      "type": "boolean",
-      "description": "Enables optimization of the build output."
+      "description": "Enables optimization of the build output.",
+      "default": false,
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "scripts": {
+              "type": "boolean",
+              "description": "Enables optimization of the scripts output.",
+              "default": true
+            },
+            "styles": {
+              "type": "boolean",
+              "description": "Enables optimization of the styles output.",
+              "default": true
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "boolean"
+        }
+      ]
     },
     "aot": {
       "type": "boolean",

--- a/packages/angular_devkit/build_angular/src/dev-server/schema.json
+++ b/packages/angular_devkit/build_angular/src/dev-server/schema.json
@@ -85,7 +85,6 @@
     },
     "optimization": {
       "description": "Enables optimization of the build output.",
-      "default": false,
       "oneOf": [
         {
           "type": "object",

--- a/packages/angular_devkit/build_angular/src/extract-i18n/index.ts
+++ b/packages/angular_devkit/build_angular/src/extract-i18n/index.ts
@@ -27,8 +27,7 @@ import {
 } from '../angular-cli-files/models/webpack-configs';
 import { readTsconfig } from '../angular-cli-files/utilities/read-tsconfig';
 import { statsErrorsToString, statsWarningsToString } from '../angular-cli-files/utilities/stats';
-import { NormalizedBrowserBuilderSchema } from '../browser';
-import { BrowserBuilderSchema } from '../browser/schema';
+import { BrowserBuilderSchema, NormalizedBrowserBuilderSchema } from '../browser/schema';
 const webpackMerge = require('webpack-merge');
 
 
@@ -88,7 +87,10 @@ export class ExtractI18nBuilder implements Builder<ExtractI18nBuilderOptions> {
         const webpackConfig = this.buildWebpackConfig(root, projectRoot, {
           // todo: remove this casting when 'CurrentFileReplacement' is changed to 'FileReplacement'
           ...(browserOptions as NormalizedBrowserBuilderSchema),
-          optimization: false,
+          optimization: {
+            scripts: false,
+            styles: false,
+          },
           i18nLocale: options.i18nLocale,
           i18nFormat: options.i18nFormat,
           i18nFile: outFile,

--- a/packages/angular_devkit/build_angular/src/karma/index.ts
+++ b/packages/angular_devkit/build_angular/src/karma/index.ts
@@ -15,7 +15,7 @@ import {
 import { Path, getSystemPath, normalize, resolve, virtualFs } from '@angular-devkit/core';
 import * as fs from 'fs';
 import { Observable, of } from 'rxjs';
-import { concatMap, tap } from 'rxjs/operators';
+import { concatMap } from 'rxjs/operators';
 import * as ts from 'typescript'; // tslint:disable-line:no-implicit-dependencies
 import { WebpackConfigOptions } from '../angular-cli-files/models/build-options';
 import {
@@ -26,8 +26,7 @@ import {
 } from '../angular-cli-files/models/webpack-configs';
 import { readTsconfig } from '../angular-cli-files/utilities/read-tsconfig';
 import { requireProjectModule } from '../angular-cli-files/utilities/require-project-module';
-import { AssetPatternObject, CurrentFileReplacement } from '../browser/schema';
-import { NormalizedSourceMaps, defaultProgress, normalizeBuilderSchema } from '../utils';
+import { defaultProgress, normalizeBuilderSchema } from '../utils';
 import { KarmaBuilderSchema, NormalizedKarmaBuilderSchema } from './schema';
 const webpackMerge = require('webpack-merge');
 
@@ -36,18 +35,17 @@ export class KarmaBuilder implements Builder<KarmaBuilderSchema> {
   constructor(public context: BuilderContext) { }
 
   run(builderConfig: BuilderConfiguration<KarmaBuilderSchema>): Observable<BuildEvent> {
-    let options: NormalizedKarmaBuilderSchema;
     const root = this.context.workspace.root;
     const projectRoot = resolve(root, builderConfig.root);
     const host = new virtualFs.AliasHost(this.context.host as virtualFs.Host<fs.Stats>);
 
+    const options = normalizeBuilderSchema(
+      host,
+      root,
+      builderConfig,
+    );
+
     return of(null).pipe(
-      concatMap((opts) => normalizeBuilderSchema(
-        host,
-        root,
-        builderConfig,
-      )),
-      tap(normalizedOptions => options = normalizedOptions),
       concatMap(() => new Observable(obs => {
         const karma = requireProjectModule(getSystemPath(projectRoot), 'karma');
         const karmaConfig = getSystemPath(resolve(root, normalize(options.karmaConfig)));

--- a/packages/angular_devkit/build_angular/src/karma/index.ts
+++ b/packages/angular_devkit/build_angular/src/karma/index.ts
@@ -27,48 +27,27 @@ import {
 import { readTsconfig } from '../angular-cli-files/utilities/read-tsconfig';
 import { requireProjectModule } from '../angular-cli-files/utilities/require-project-module';
 import { AssetPatternObject, CurrentFileReplacement } from '../browser/schema';
-import {
-  defaultProgress,
-  normalizeAssetPatterns,
-  normalizeFileReplacements,
-  normalizeSourceMaps,
-} from '../utils';
-import { KarmaBuilderSchema } from './schema';
+import { NormalizedSourceMaps, defaultProgress, normalizeBuilderSchema } from '../utils';
+import { KarmaBuilderSchema, NormalizedKarmaBuilderSchema } from './schema';
 const webpackMerge = require('webpack-merge');
 
-
-export interface NormalizedKarmaBuilderSchema extends KarmaBuilderSchema {
-  assets: AssetPatternObject[];
-  fileReplacements: CurrentFileReplacement[];
-}
 
 export class KarmaBuilder implements Builder<KarmaBuilderSchema> {
   constructor(public context: BuilderContext) { }
 
   run(builderConfig: BuilderConfiguration<KarmaBuilderSchema>): Observable<BuildEvent> {
-    let options = builderConfig.options;
+    let options: NormalizedKarmaBuilderSchema;
     const root = this.context.workspace.root;
     const projectRoot = resolve(root, builderConfig.root);
     const host = new virtualFs.AliasHost(this.context.host as virtualFs.Host<fs.Stats>);
 
     return of(null).pipe(
-      concatMap(() => normalizeFileReplacements(options.fileReplacements, host, root)),
-      tap(fileReplacements => options.fileReplacements = fileReplacements),
-      concatMap(() => normalizeAssetPatterns(
-        options.assets, host, root, projectRoot, builderConfig.sourceRoot)),
-      // Replace the assets in options with the normalized version.
-      tap((assetPatternObjects => options.assets = assetPatternObjects)),
-      tap(() => {
-        const normalizedOptions = normalizeSourceMaps(options.sourceMap);
-        // todo: remove when removing the deprecations
-        normalizedOptions.vendorSourceMap
-          = normalizedOptions.vendorSourceMap || !!options.vendorSourceMap;
-
-        options = {
-          ...options,
-          ...normalizedOptions,
-        };
-      }),
+      concatMap((opts) => normalizeBuilderSchema(
+        host,
+        root,
+        builderConfig,
+      )),
+      tap(normalizedOptions => options = normalizedOptions),
       concatMap(() => new Observable(obs => {
         const karma = requireProjectModule(getSystemPath(projectRoot), 'karma');
         const karmaConfig = getSystemPath(resolve(root, normalize(options.karmaConfig)));
@@ -103,9 +82,8 @@ export class KarmaBuilder implements Builder<KarmaBuilderSchema> {
         karmaOptions.buildWebpack = {
           root: getSystemPath(root),
           projectRoot: getSystemPath(projectRoot),
-          options: options as NormalizedKarmaBuilderSchema,
-          webpackConfig: this.buildWebpackConfig(root, projectRoot, sourceRoot, host,
-            options as NormalizedKarmaBuilderSchema),
+          options,
+          webpackConfig: this.buildWebpackConfig(root, projectRoot, sourceRoot, host, options),
           // Pass onto Karma to emit BuildEvents.
           successCb: () => obs.next({ success: true }),
           failureCb: () => obs.next({ success: false }),

--- a/packages/angular_devkit/build_angular/src/karma/schema.d.ts
+++ b/packages/angular_devkit/build_angular/src/karma/schema.d.ts
@@ -52,3 +52,13 @@ export interface KarmaSourceMapObject {
   /** Output sourcemaps for all styles. */
   styles?: boolean;
 }
+
+
+export interface NormalizedKarmaBuilderSchema extends Pick<
+  KarmaBuilderSchema,
+  Exclude<keyof KarmaBuilderSchema, 'sourceMap' | 'vendorSourceMap'>
+  > {
+  assets: AssetPatternObject[];
+  fileReplacements: CurrentFileReplacement[];
+  sourceMap: NormalizedSourceMaps;
+}

--- a/packages/angular_devkit/build_angular/src/server/index.ts
+++ b/packages/angular_devkit/build_angular/src/server/index.ts
@@ -30,7 +30,12 @@ import {
 import { readTsconfig } from '../angular-cli-files/utilities/read-tsconfig';
 import { requireProjectModule } from '../angular-cli-files/utilities/require-project-module';
 import { getBrowserLoggingCb } from '../browser';
-import { defaultProgress, normalizeFileReplacements, normalizeSourceMaps } from '../utils';
+import {
+  defaultProgress,
+  normalizeFileReplacements,
+  normalizeOptimization,
+  normalizeSourceMaps,
+} from '../utils';
 import { BuildWebpackServerSchema } from './schema';
 const webpackMerge = require('webpack-merge');
 
@@ -62,6 +67,8 @@ export class ServerBuilder implements Builder<BuildWebpackServerSchema> {
         options = {
           ...options,
           ...normalizedOptions,
+          // tslint:disable-next-line:no-any
+          optimization: normalizeOptimization(options.optimization || {}) as any,
         };
       }),
       concatMap(() => {

--- a/packages/angular_devkit/build_angular/src/server/schema.d.ts
+++ b/packages/angular_devkit/build_angular/src/server/schema.d.ts
@@ -6,7 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { BrowserBuilderSchema, FileReplacement, SourceMapOptions } from '../browser/schema';
+import {
+  BrowserBuilderSchema,
+  FileReplacement,
+  OptimizationObject,
+  SourceMapOptions,
+} from '../browser/schema';
 
 export interface BuildWebpackServerSchema {
   /**
@@ -72,7 +77,7 @@ export interface BuildWebpackServerSchema {
   /**
    * Enables optimization of the build output.
    */
-  optimization?: boolean;
+  optimization?: OptimizationObject;
   /**
    * Log progress to the console while building.
    */

--- a/packages/angular_devkit/build_angular/src/server/schema.d.ts
+++ b/packages/angular_devkit/build_angular/src/server/schema.d.ts
@@ -173,3 +173,12 @@ export interface StylePreprocessorOptions {
    */
   includePaths?: string[];
 }
+
+export interface NormalizedServerBuilderServerSchema extends Pick<
+  BuildWebpackServerSchema,
+  Exclude<keyof BuildWebpackServerSchema, 'sourceMap' | 'optimization'>
+  > {
+  fileReplacements: CurrentFileReplacement[];
+  sourceMap: NormalizedSourceMaps;
+  optimization: NormalizedOptimization;
+}

--- a/packages/angular_devkit/build_angular/src/server/schema.json
+++ b/packages/angular_devkit/build_angular/src/server/schema.json
@@ -29,7 +29,6 @@
     },
     "optimization": {
       "description": "Enables optimization of the build output.",
-      "default": false,
       "oneOf": [
         {
           "type": "object",

--- a/packages/angular_devkit/build_angular/src/server/schema.json
+++ b/packages/angular_devkit/build_angular/src/server/schema.json
@@ -28,9 +28,29 @@
       "additionalProperties": false
     },
     "optimization": {
-      "type": "boolean",
       "description": "Enables optimization of the build output.",
-      "default": false
+      "default": false,
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "scripts": {
+              "type": "boolean",
+              "description": "Enables optimization of the scripts output.",
+              "default": true
+            },
+            "styles": {
+              "type": "boolean",
+              "description": "Enables optimization of the styles output.",
+              "default": true
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "boolean"
+        }
+      ]
     },
     "fileReplacements": {
       "description": "Replace files with other files in the build.",

--- a/packages/angular_devkit/build_angular/src/utils/index.ts
+++ b/packages/angular_devkit/build_angular/src/utils/index.ts
@@ -11,3 +11,4 @@ export * from './run-module-as-observable-fork';
 export * from './normalize-file-replacements';
 export * from './normalize-asset-patterns';
 export * from './normalize-source-maps';
+export * from './normalize-optimization';

--- a/packages/angular_devkit/build_angular/src/utils/index.ts
+++ b/packages/angular_devkit/build_angular/src/utils/index.ts
@@ -12,3 +12,4 @@ export * from './normalize-file-replacements';
 export * from './normalize-asset-patterns';
 export * from './normalize-source-maps';
 export * from './normalize-optimization';
+export * from './normalize-builder-schema';

--- a/packages/angular_devkit/build_angular/src/utils/normalize-builder-schema.ts
+++ b/packages/angular_devkit/build_angular/src/utils/normalize-builder-schema.ts
@@ -1,0 +1,85 @@
+
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+
+import { BuilderConfiguration } from '@angular-devkit/architect';
+import { Path, resolve, virtualFs } from '@angular-devkit/core';
+import { Observable, combineLatest, of } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { BrowserBuilderSchema, NormalizedBrowserBuilderSchema } from '../browser/schema';
+import { KarmaBuilderSchema, NormalizedKarmaBuilderSchema } from '../karma/schema';
+import { BuildWebpackServerSchema, NormalizedServerBuilderServerSchema } from '../server/schema';
+import { normalizeAssetPatterns } from './normalize-asset-patterns';
+import { normalizeFileReplacements } from './normalize-file-replacements';
+import { normalizeOptimization } from './normalize-optimization';
+import { normalizeSourceMaps } from './normalize-source-maps';
+
+export function normalizeBuilderSchema<BuilderConfigurationT extends
+    BuilderConfiguration<BrowserBuilderSchema | BuildWebpackServerSchema | KarmaBuilderSchema>,
+    OptionsT = BuilderConfigurationT['options']>(
+        host: virtualFs.Host<{}>,
+        root: Path,
+        builderConfig: BuilderConfigurationT,
+): Observable<
+OptionsT extends BrowserBuilderSchema ? NormalizedBrowserBuilderSchema :
+OptionsT extends BuildWebpackServerSchema ? NormalizedServerBuilderServerSchema :
+// todo should be unknown
+// tslint:disable-next-line:no-any
+OptionsT extends KarmaBuilderSchema ? NormalizedKarmaBuilderSchema : any> {
+    const { options } = builderConfig;
+    const projectRoot = resolve(root, builderConfig.root);
+
+    // todo: this should be unknown
+    // tslint:disable-next-line:no-any
+    const isKarmaBuilderSchema = (options: any): options is KarmaBuilderSchema =>
+        !options.hasOwnProperty('optimization');
+
+    // todo: this should be unknown
+    // tslint:disable-next-line:no-any
+    const isBuildWebpackServerSchema = (options: any): options is BuildWebpackServerSchema =>
+        !options.hasOwnProperty('assets');
+
+    return combineLatest(
+        isBuildWebpackServerSchema(options)
+            ? of(null)
+            : normalizeAssetPatterns(
+                options.assets,
+                host,
+                root,
+                projectRoot,
+                builderConfig.sourceRoot,
+            ),
+        normalizeFileReplacements(options.fileReplacements, host, root),
+    ).pipe(
+        map(([assetPatternObjects, fileReplacements]) => {
+            const normalizedSourceMapOptions = normalizeSourceMaps(options.sourceMap);
+            // todo: remove when removing the deprecations
+            normalizedSourceMapOptions.vendor
+                = normalizedSourceMapOptions.vendor || !!options.vendorSourceMap;
+
+            const optimization = isKarmaBuilderSchema(options)
+                ? {}
+                : options.optimization || {};
+
+            const assets = isBuildWebpackServerSchema(options)
+                ? {}
+                : { assets: assetPatternObjects };
+
+            return {
+                // todo remove any casing when using typescript 3.2
+                // tslint:disable-next-line:no-any
+                ...options as any,
+                ...assets,
+                fileReplacements,
+                optimization: normalizeOptimization(optimization),
+                sourceMap: normalizeSourceMaps(options.sourceMap),
+            };
+        }),
+    );
+}

--- a/packages/angular_devkit/build_angular/src/utils/normalize-optimization.ts
+++ b/packages/angular_devkit/build_angular/src/utils/normalize-optimization.ts
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { OptimizationOptions, SourceMapOptions } from '../browser/schema';
+
+export interface NormalizedOptimization {
+  scripts: boolean;
+  styles: boolean;
+}
+
+export function normalizeOptimization(optimization: OptimizationOptions): NormalizedOptimization {
+  const scripts = !!(typeof optimization === 'object' ? optimization.scripts : optimization);
+  const styles = !!(typeof optimization === 'object' ? optimization.styles : optimization);
+
+  return {
+    scripts,
+    styles,
+  };
+}

--- a/packages/angular_devkit/build_angular/src/utils/normalize-source-maps.ts
+++ b/packages/angular_devkit/build_angular/src/utils/normalize-source-maps.ts
@@ -9,24 +9,22 @@
 import { SourceMapOptions } from '../browser/schema';
 
 export interface NormalizedSourceMaps {
-  sourceMap: boolean;
-  scriptsSourceMap: boolean;
-  stylesSourceMap: boolean;
-  hiddenSourceMap: boolean;
-  vendorSourceMap: boolean;
+  scripts: boolean;
+  styles: boolean;
+  hidden: boolean;
+  vendor: boolean;
 }
 
 export function normalizeSourceMaps(sourceMap: SourceMapOptions): NormalizedSourceMaps {
-  const scriptsSourceMap = !!(typeof sourceMap === 'object' ? sourceMap.scripts : sourceMap);
-  const stylesSourceMap = !!(typeof sourceMap === 'object' ? sourceMap.styles : sourceMap);
-  const hiddenSourceMap = typeof sourceMap === 'object' && !!sourceMap.hidden;
-  const vendorSourceMap = typeof sourceMap === 'object' && !!sourceMap.vendor;
+  const scripts = !!(typeof sourceMap === 'object' ? sourceMap.scripts : sourceMap);
+  const styles = !!(typeof sourceMap === 'object' ? sourceMap.styles : sourceMap);
+  const hidden = typeof sourceMap === 'object' && !!sourceMap.hidden;
+  const vendor = typeof sourceMap === 'object' && !!sourceMap.vendor;
 
   return {
-    sourceMap: stylesSourceMap || scriptsSourceMap,
-    vendorSourceMap,
-    hiddenSourceMap,
-    scriptsSourceMap,
-    stylesSourceMap,
+    vendor,
+    hidden,
+    scripts,
+    styles,
   };
 }


### PR DESCRIPTION


While doing the sourceMaps and optimisations flags, there were several places that had duplicate logic, and options were not really type safety as in most cases a castings was used.

This tried to improve how we normalize options and also improves type safety or at least it unifies the logic into a common method.

We can now enabled/disabled optimisations for scripts and styles.

Ex: 
```
 optimization: {
   scripts: true,
   styles: false,
 },
```

Following a suggestion from @filipesilva, I combined these 2 PRs togather.