### PR TITLE
test: remove debounce as it's causing flakes

### DIFF
--- a/packages/angular_devkit/build_angular/test/browser/allow-js_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/browser/allow-js_spec_large.ts
@@ -8,7 +8,7 @@
 
 import { runTargetSpec } from '@angular-devkit/architect/testing';
 import { join, virtualFs } from '@angular-devkit/core';
-import { debounceTime, take, tap } from 'rxjs/operators';
+import { take, tap } from 'rxjs/operators';
 import { browserTargetSpec, host, outputPath } from '../utils';
 
 
@@ -82,7 +82,6 @@ describe('Browser Builder allow js', () => {
 
     let buildCount = 1;
     runTargetSpec(host, browserTargetSpec, overrides).pipe(
-      debounceTime(1000),
       tap(() => {
         const content = virtualFs.fileBufferToString(
           host.scopedSync().read(join(outputPath, 'main.js')),

--- a/packages/angular_devkit/build_angular/test/browser/resolve-json-module_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/browser/resolve-json-module_spec_large.ts
@@ -8,7 +8,7 @@
 
 import { runTargetSpec } from '@angular-devkit/architect/testing';
 import { join, virtualFs } from '@angular-devkit/core';
-import { debounceTime, take, tap } from 'rxjs/operators';
+import { take, tap } from 'rxjs/operators';
 import { browserTargetSpec, host, outputPath } from '../utils';
 
 
@@ -32,7 +32,6 @@ describe('Browser Builder resolve json module', () => {
 
     let buildCount = 1;
     runTargetSpec(host, browserTargetSpec, overrides).pipe(
-      debounceTime(1000),
       tap(() => {
         const content = virtualFs.fileBufferToString(
           host.scopedSync().read(join(outputPath, 'main.js')),


### PR DESCRIPTION
It looks like the debounceTime is causing flakes when the both compilations happen faster than 1000ms.

Thus, when debouncing only the last rebuild is taken into consideration.

Error
```
**************************************************
*                    Failures                    *
**************************************************

1) Browser Builder allow js works with watch
  - Expected '(window["webpackJsonp"] = window["webpackJsonp"] || []).push([["main"],{

  /***/ "./main.ts":
  /*!*****************!*\
    !*** ./main.ts ***!
    \*****************/
  /*! no exports provided */
  /***/ (function(module, __webpack_exports__, __webpack_require__) {

  "use strict";
  __webpack_require__.r(__webpack_exports__);
  /* harmony import */ var _my_js_file__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./my-js-file */ "./my-js-file.js");

  console.log(_my_js_file__WEBPACK_IMPORTED_MODULE_0__["a"]);


  /***/ }),

  /***/ "./my-js-file.js":
  /*!***********************!*\
    !*** ./my-js-file.js ***!
    \***********************/
  /*! exports provided: a */
  /***/ (function(module, __webpack_exports__, __webpack_require__) {

  "use strict";
  __webpack_require__.r(__webpack_exports__);
  /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return a; });
  console.log(1);
  var a = 2;
  //# sourceMappingURL=my-js-file.js.map

  /***/ }),

  /***/ 0:
  /*!***************** ... to contain 'var a = 1'.
  Error: Expected '(window["webpackJsonp"] = window["webpackJsonp"] || []).push([["main"],{

  /***/ "./main.ts":
  /*!*****************!*\
    !*** ./main.ts ***!
    \*****************/
  /*! no exports provided */
  /***/ (function(module, __webpack_exports__, __webpack_require__) {

  "use strict";
  __webpack_require__.r(__webpack_exports__);
  /* harmony import */ var _my_js_file__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./my-js-file */ "./my-js-file.js");

  console.log(_my_js_file__WEBPACK_IMPORTED_MODULE_0__["a"]);


  /***/ }),

  /***/ "./my-js-file.js":
  /*!***********************!*\
    !*** ./my-js-file.js ***!
    \***********************/
  /*! exports provided: a */
  /***/ (function(module, __webpack_exports__, __webpack_require__) {

  "use strict";
  __webpack_require__.r(__webpack_exports__);
  /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "a", function() { return a; });
  console.log(1);
  var a = 2;
  //# sourceMappingURL=my-js-file.js.map

  /***/ }),

  /***/ 0:
  /*!***************** ... to contain 'var a = 1'.
      at stack (/home/circleci/ng/node_modules/jasmine/node_modules/jasmine-core/lib/jasmine-core/jasmine.js:2455:17)
      at buildExpectationResult (/home/circleci/ng/node_modules/jasmine/node_modules/jasmine-core/lib/jasmine-core/jasmine.js:2425:14)
      at Spec.expectationResultFactory (/home/circleci/ng/node_modules/jasmine/node_modules/jasmine-core/lib/jasmine-core/jasmine.js:901:18)
      at Spec.addExpectationResult (/home/circleci/ng/node_modules/jasmine/node_modules/jasmine-core/lib/jasmine-core/jasmine.js:524:34)
      at Expectation.addExpectationResult (/home/circleci/ng/node_modules/jasmine/node_modules/jasmine-core/lib/jasmine-core/jasmine.js:845:21)
      at Expectation.toContain (/home/circleci/ng/node_modules/jasmine/node_modules/jasmine-core/lib/jasmine-core/jasmine.js:2369:12)
      at TapSubscriber.testing_1.runTargetSpec.pipe.operators_1.tap [as _tapNext] (/home/circleci/ng/packages/angular_devkit/build_angular/test/browser/file:/home/circleci/ng/packages/angular_devkit/build_angular/test/browser/allow-js_spec_large.ts:99:29)
      at TapSubscriber._next (/home/circleci/ng/node_modules/rxjs/src/internal/operators/tap.ts:111:21)
      at TapSubscriber.Subscriber.next (/home/circleci/ng/node_modules/rxjs/src/internal/Subscriber.ts:101:12)
      at DebounceTimeSubscriber.debouncedNext (/home/circleci/ng/node_modules/rxjs/src/internal/operators/debounceTime.ts:110:24)
      at AsyncAction.dispatchNext (/home/circleci/ng/node_modules/rxjs/src/internal/operators/debounceTime.ts:126:14)
      at AsyncAction._execute (/home/circleci/ng/node_modules/rxjs/src/internal/scheduler/AsyncAction.ts:121:12)
      at AsyncAction.execute (/home/circleci/ng/node_modules/rxjs/src/internal/scheduler/AsyncAction.ts:96:24)
      at AsyncScheduler.flush (/home/circleci/ng/node_modules/rxjs/src/internal/scheduler/AsyncScheduler.ts:58:26)
      at ontimeout (timers.js:424:11)

**************************************************
*                    Pending                     *
**************************************************

```