### PR TITLE
refactor: replace karma jasmine html reporter with karma material rep…

### DIFF
--- a/packages/schematics/angular/application/files/root/karma.conf.js
+++ b/packages/schematics/angular/application/files/root/karma.conf.js
@@ -8,7 +8,7 @@ module.exports = function (config) {
     plugins: [
       require('karma-jasmine'),
       require('karma-chrome-launcher'),
-      require('karma-jasmine-html-reporter'),
+      require('karma-material-reporter'),
       require('karma-coverage-istanbul-reporter'),
       require('@angular-devkit/build-angular/plugins/karma')
     ],
@@ -20,7 +20,7 @@ module.exports = function (config) {
       reports: ['html', 'lcovonly', 'text-summary'],
       fixWebpackSourcePaths: true
     },
-    reporters: ['progress', 'kjhtml'],
+    reporters: ['progress', 'material'],
     port: 9876,
     colors: true,
     logLevel: config.LOG_INFO,

--- a/packages/schematics/angular/workspace/files/package.json
+++ b/packages/schematics/angular/workspace/files/package.json
@@ -38,7 +38,7 @@
     "karma-chrome-launcher": "~2.2.0",
     "karma-coverage-istanbul-reporter": "~2.0.1",
     "karma-jasmine": "~1.1.2",
-    "karma-jasmine-html-reporter": "^0.2.2",
+    "karma-material-reporter": "^1.1.0",
     "protractor": "~5.4.0",<% } %>
     "ts-node": "~7.0.0",
     "tslint": "~5.11.0",


### PR DESCRIPTION
Replace the karma-jasmine-html reporter with [karma-material-reporter](https://github.com/ameerthehacker/karma-material-reporter) as may have following advantages

* Realtime test result reporting
* Good automated test coverage for the package itself
* Built with material design