### PR TITLE
feat(@angular-devkit/build-angular): code coverage for ng build, ng serve and ng e2e

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/build-options.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/build-options.ts
@@ -69,12 +69,12 @@ export interface BuildOptions {
   lazyModules: string[];
   platform?: 'browser' | 'server';
   fileReplacements: CurrentFileReplacement[];
-}
 
-export interface WebpackTestOptions extends BuildOptions {
   codeCoverage?: boolean;
   codeCoverageExclude?: string[];
 }
+
+export interface WebpackTestOptions extends BuildOptions {}
 
 export interface WebpackConfigOptions<T = BuildOptions> {
   root: string;

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
@@ -6,8 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import * as CopyWebpackPlugin from 'copy-webpack-plugin';
+import * as glob from 'glob';
 import * as path from 'path';
-import { HashedModuleIdsPlugin, debug } from 'webpack';
+import { HashedModuleIdsPlugin, Rule, debug } from 'webpack';
 import { AssetPatternObject } from '../../../browser/schema';
 import { BundleBudgetPlugin } from '../../plugins/bundle-budget';
 import { CleanCssWebpackPlugin } from '../../plugins/cleancss-webpack-plugin';
@@ -32,7 +33,7 @@ export const buildOptimizerLoader: string = g['_DevKitIsLocal']
 
 // tslint:disable-next-line:no-big-function
 export function getCommonConfig(wco: WebpackConfigOptions) {
-  const { root, projectRoot, buildOptions } = wco;
+  const { root, projectRoot, buildOptions, sourceRoot: include } = wco;
   const { styles: stylesOptimization, scripts: scriptsOptimization } = buildOptions.optimization;
   const {
     styles: stylesSouceMap,
@@ -261,6 +262,35 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
     );
   }
 
+  const extraRules: Rule[] = [];
+
+  // if (buildOptions.codeCoverage && CliConfig.fromProject()) {
+  if (buildOptions.codeCoverage) {
+    const codeCoverageExclude = buildOptions.codeCoverageExclude;
+    const exclude: (string | RegExp)[] = [
+      /\.(e2e|spec)\.ts$/,
+      /node_modules/,
+    ];
+
+    if (codeCoverageExclude) {
+      codeCoverageExclude.forEach((excludeGlob: string) => {
+        const excludeFiles = glob
+          .sync(path.join(root, excludeGlob), { nodir: true })
+          .map(file => path.normalize(file));
+        exclude.push(...excludeFiles);
+      });
+    }
+
+    extraRules.push({
+      test: /\.(js|ts)$/,
+      loader: 'istanbul-instrumenter-loader',
+      options: { esModules: true },
+      enforce: 'post',
+      exclude,
+      include,
+    });
+  }
+
   return {
     mode: scriptsOptimization || stylesOptimization
       ? 'production'
@@ -294,6 +324,7 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
     },
     module: {
       rules: [
+        ...extraRules,
         { test: /\.html$/, loader: 'raw-loader' },
         {
           test: /\.(eot|svg|cur|jpg|png|webp|gif|otf|ttf|woff|woff2|ani)$/,

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/test.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/test.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import * as glob from 'glob';
 import * as path from 'path';
 import * as webpack from 'webpack';
 import { WebpackConfigOptions, WebpackTestOptions } from '../build-options';
@@ -24,37 +23,9 @@ import { getSourceMapDevTool } from './utils';
 export function getTestConfig(
   wco: WebpackConfigOptions<WebpackTestOptions>,
 ): webpack.Configuration {
-  const { root, buildOptions, sourceRoot: include } = wco;
+  const { root, buildOptions } = wco;
 
-  const extraRules: webpack.Rule[] = [];
   const extraPlugins: webpack.Plugin[] = [];
-
-  // if (buildOptions.codeCoverage && CliConfig.fromProject()) {
-  if (buildOptions.codeCoverage) {
-    const codeCoverageExclude = buildOptions.codeCoverageExclude;
-    const exclude: (string | RegExp)[] = [
-      /\.(e2e|spec)\.ts$/,
-      /node_modules/,
-    ];
-
-    if (codeCoverageExclude) {
-      codeCoverageExclude.forEach((excludeGlob: string) => {
-        const excludeFiles = glob
-          .sync(path.join(root, excludeGlob), { nodir: true })
-          .map(file => path.normalize(file));
-        exclude.push(...excludeFiles);
-      });
-    }
-
-    extraRules.push({
-      test: /\.(js|ts)$/,
-      loader: 'istanbul-instrumenter-loader',
-      options: { esModules: true },
-      enforce: 'post',
-      exclude,
-      include,
-    });
-  }
 
   if (wco.buildOptions.sourceMap) {
     const { styles, scripts } = wco.buildOptions.sourceMap;
@@ -78,9 +49,6 @@ export function getTestConfig(
     devtool: buildOptions.sourceMap ? false : 'eval',
     entry: {
       main: path.resolve(root, buildOptions.main),
-    },
-    module: {
-      rules: extraRules,
     },
     plugins: extraPlugins,
     optimization: {

--- a/packages/angular_devkit/build_angular/src/browser/schema.d.ts
+++ b/packages/angular_devkit/build_angular/src/browser/schema.d.ts
@@ -235,6 +235,16 @@ export interface BrowserBuilderSchema {
    * Output profile events for Chrome profiler.
    */
   profile: boolean;
+
+  /**
+   * Instruments the code for coverage.
+   */
+  codeCoverage: boolean;
+
+  /**
+   * Globs to exclude from code coverage.
+   */
+  codeCoverageExclude: string[];
 }
 
 export type OptimizationOptions = boolean | OptimizationObject;

--- a/packages/angular_devkit/build_angular/src/browser/schema.json
+++ b/packages/angular_devkit/build_angular/src/browser/schema.json
@@ -299,6 +299,19 @@
       "type": "boolean",
       "description": "Output profile events for Chrome profiler.",
       "default": false
+    },
+    "codeCoverage": {
+      "type": "boolean",
+      "description": "Instruments the code for coverage.",
+      "default": false
+    },
+    "codeCoverageExclude": {
+      "type": "array",
+      "description": "Globs to exclude from code coverage.",
+      "items": {
+        "type": "string"
+      },
+      "default": []
     }
   },
   "additionalProperties": false,

--- a/packages/angular_devkit/build_angular/src/dev-server/index.ts
+++ b/packages/angular_devkit/build_angular/src/dev-server/index.ts
@@ -49,6 +49,8 @@ export interface DevServerBuilderOptions extends Pick<BrowserBuilderSchema,
   watch: boolean;
   hmrWarning: boolean;
   servePathDefaultWarning: boolean;
+  codeCoverage?: boolean;
+  codeCoverageExclude?: string[];
 }
 
 type DevServerBuilderOptionsKeys = Extract<keyof DevServerBuilderOptions, string>;
@@ -403,6 +405,8 @@ export class DevServerBuilder implements Builder<DevServerBuilderOptions> {
       'poll',
       'verbose',
       'deployUrl',
+      'codeCoverage',
+      'codeCoverageExclude',
     ];
 
     // remove options that are undefined or not to be overrriden

--- a/packages/angular_devkit/build_angular/src/dev-server/schema.json
+++ b/packages/angular_devkit/build_angular/src/dev-server/schema.json
@@ -180,6 +180,19 @@
     "poll": {
       "type": "number",
       "description": "Enable and define the file watching poll time period in milliseconds."
+    },
+    "codeCoverage": {
+      "type": "boolean",
+      "description": "Instruments the code for coverage.",
+      "default": false
+    },
+    "codeCoverageExclude": {
+      "type": "array",
+      "description": "Globs to exclude from code coverage.",
+      "items": {
+        "type": "string"
+      },
+      "default": []
     }
   },
   "additionalProperties": false,

--- a/packages/angular_devkit/build_angular/src/karma/schema.d.ts
+++ b/packages/angular_devkit/build_angular/src/karma/schema.d.ts
@@ -9,7 +9,8 @@ import { BrowserBuilderSchema } from '../browser/schema';
 
 export interface KarmaBuilderSchema extends Pick<BrowserBuilderSchema,
   'assets' | 'main' | 'polyfills' | 'tsConfig' | 'scripts' | 'styles' | 'stylePreprocessorOptions'
-  | 'fileReplacements' | 'poll' | 'preserveSymlinks' | 'watch' | 'vendorSourceMap'
+  | 'fileReplacements' | 'poll' | 'preserveSymlinks' | 'watch' | 'vendorSourceMap' | 'codeCoverage'
+  | 'codeCoverageExclude'
   > {
   /**
    * The name of the Karma configuration file..
@@ -25,16 +26,6 @@ export interface KarmaBuilderSchema extends Pick<BrowserBuilderSchema,
    * Override which browsers tests are run against.
    */
   browsers: string;
-
-  /**
-   * Output a code coverage report.
-   */
-  codeCoverage: boolean;
-
-  /**
-   * Globs to exclude from code coverage.
-   */
-  codeCoverageExclude: string[];
 
   /**
    * Karma reporters to use. Directly passed to the karma runner.

--- a/packages/angular_devkit/build_angular/src/protractor/index.ts
+++ b/packages/angular_devkit/build_angular/src/protractor/index.ts
@@ -32,6 +32,8 @@ export interface ProtractorBuilderOptions {
   port?: number;
   host: string;
   baseUrl: string;
+  codeCoverage?: boolean;
+  codeCoverageExclude?: string[];
 }
 
 export class ProtractorBuilder implements Builder<ProtractorBuilderOptions> {
@@ -63,6 +65,10 @@ export class ProtractorBuilder implements Builder<ProtractorBuilderOptions> {
     // Also override the port and host if they are defined in protractor options.
     if (options.host !== undefined) { overrides.host = options.host; }
     if (options.port !== undefined) { overrides.port = options.port; }
+    if (options.codeCoverage !== undefined) { overrides.codeCoverage = options.codeCoverage; }
+    if (options.codeCoverageExclude !== undefined) {
+      overrides.codeCoverageExclude = options.codeCoverageExclude;
+    }
     const targetSpec = { project, target: targetName, configuration, overrides };
     const builderConfig = architect.getBuilderConfiguration<DevServerBuilderOptions>(targetSpec);
     let devServerDescription: BuilderDescription;

--- a/packages/angular_devkit/build_angular/src/protractor/schema.json
+++ b/packages/angular_devkit/build_angular/src/protractor/schema.json
@@ -46,6 +46,19 @@
     "baseUrl": {
       "type": "string",
       "description": "Base URL for protractor to connect to."
+    },
+    "codeCoverage": {
+      "type": "boolean",
+      "description": "Instruments the code for coverage.",
+      "default": false
+    },
+    "codeCoverageExclude": {
+      "type": "array",
+      "description": "Globs to exclude from code coverage.",
+      "items": {
+        "type": "string"
+      },
+      "default": []
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
This PR is related to #6286 and allows `--code-coverage` and `--code-coverage-exclude` options to be used with `ng build`, `ng serve` and `ng e2e`, so that it is easy to instrument the code for coverage.

When used with these commands, the `--code-coverage` switch does not automatically create a file with the report but allows the developers to access the `__coverage__` variable from Istanbul.js inside the browser to get coverage data.
That object can then be used to generate a report as described in https://istanbul.js.org/docs/advanced/coverage-object-report/
