### PR TITLE
fix(@ngtools/webpack): avoid checking watchMode in environment hook

### DIFF
--- a/packages/ngtools/webpack/src/angular_compiler_plugin.ts
+++ b/packages/ngtools/webpack/src/angular_compiler_plugin.ts
@@ -633,15 +633,12 @@ export class AngularCompilerPlugin {
         }
       }
 
-      // only present for webpack 4.23.0+, assume true otherwise
-      const watchMode = compiler.watchMode === undefined ? true : compiler.watchMode;
-
       // Create the webpack compiler host.
       const webpackCompilerHost = new WebpackCompilerHost(
         this._compilerOptions,
         this._basePath,
         host,
-        watchMode,
+        true,
         this._options.directTemplateLoading,
       );
 


### PR DESCRIPTION
The `environment`/`afterEnvironment` hooks occur before `watchMode` is valid.

Closes #13102