### PR TITLE
feat(@schematics/angular): set use-host-property-decorator to false in new apps

### DIFF
--- a/packages/schematics/angular/workspace/files/tslint.json
+++ b/packages/schematics/angular/workspace/files/tslint.json
@@ -120,7 +120,7 @@
     "no-output-on-prefix": true,
     "use-input-property-decorator": true,
     "use-output-property-decorator": true,
-    "use-host-property-decorator": true,
+    "use-host-property-decorator": false,
     "no-input-rename": true,
     "no-output-rename": true,
     "use-life-cycle-interface": true,


### PR DESCRIPTION
Inspired by [this twitter thread](https://twitter.com/aaronfrost/status/1070389114959097856), this PR changes the default setting for the `use-host-property-decorator` codelyzer rule. 

The rule gives the developer the impression that the `host` property in the `Component` decorator is deprecated, which is not the case. 

In fact, the [angular/material2](https://github.com/angular/material2) project maintained by the Angular team uses it more than 140 times throughout the project.

Personally I've spend a few hours over the years to work around this warning, refactoring `host` properties to `@HostBinding` as I thought it was deprecated. The Twitter thread above thought me it's not, which is why I think it should be disabled.

Here we can see other people [agree on this](https://twitter.com/aaronfrost/status/1070389114959097856), and have been [for a while](https://github.com/angular/angular.io/issues/1763#issuecomment-264036519). 