### PR TITLE
fix(@schematics/update): only set registry option when used

### DIFF
--- a/packages/schematics/update/update/npm.ts
+++ b/packages/schematics/update/update/npm.ts
@@ -112,7 +112,7 @@ export function getNpmPackageJson(
     {
       'full-metadata': true,
       ...npmrc,
-      registry: registryUrl,
+      ...(registryUrl ? { registry: registryUrl } : {}),
     },
   );
 


### PR DESCRIPTION
7.1.x version of https://github.com/angular/angular-cli/pull/13106