### PR TITLE
docs: remove space for webpack-bundle-analyzer url

### DIFF
--- a/docs/documentation/build.md
+++ b/docs/documentation/build.md
@@ -394,7 +394,7 @@ See https://github.com/angular/angular-cli/issues/7797 for details.
     <code>--stats-json</code>
   </p>
   <p>
-    Generates a 'stats.json' file which can be analyzed using tools such as: #webpack-bundle-analyzer' or https: //webpack.github.io/analyse.
+    Generates a 'stats.json' file which can be analyzed using tools such as: #webpack-bundle-analyzer' or https://webpack.github.io/analyse.
   </p>
 </details>
 <details>

--- a/packages/angular_devkit/build_angular/src/browser/schema.d.ts
+++ b/packages/angular_devkit/build_angular/src/browser/schema.d.ts
@@ -211,7 +211,7 @@ export interface BrowserBuilderSchema {
 
   /**
    * Generates a 'stats.json' file which can be analyzed using tools
-   * such as: #webpack-bundle-analyzer' or https: //webpack.github.io/analyse.
+   * such as: #webpack-bundle-analyzer' or https://webpack.github.io/analyse.
    */
   statsJson: boolean;
 

--- a/packages/angular_devkit/build_angular/src/browser/schema.json
+++ b/packages/angular_devkit/build_angular/src/browser/schema.json
@@ -271,7 +271,7 @@
     },
     "statsJson": {
       "type": "boolean",
-      "description": "Generates a 'stats.json' file which can be analyzed using tools such as: 'webpack-bundle-analyzer' or https: //webpack.github.io/analyse.",
+      "description": "Generates a 'stats.json' file which can be analyzed using tools such as: 'webpack-bundle-analyzer' or https://webpack.github.io/analyse.",
       "default": false
     },
     "forkTypeChecker": {

--- a/packages/angular_devkit/build_angular/src/server/schema.d.ts
+++ b/packages/angular_devkit/build_angular/src/server/schema.d.ts
@@ -62,7 +62,7 @@ export interface BuildWebpackServerSchema {
   resourcesOutputPath: string;
   /**
    * Generates a 'stats.json' file which can be analyzed using tools such as:
-   * #webpack-bundle-analyzer' or https: //webpack.github.io/analyse.
+   * #webpack-bundle-analyzer' or https://webpack.github.io/analyse.
    */
   statsJson?: boolean;
   /**

--- a/packages/angular_devkit/build_angular/src/server/schema.json
+++ b/packages/angular_devkit/build_angular/src/server/schema.json
@@ -201,7 +201,7 @@
     },
     "statsJson": {
       "type": "boolean",
-      "description": "Generates a 'stats.json' file which can be analyzed using tools such as: 'webpack-bundle-analyzer' or https: //webpack.github.io/analyse.",
+      "description": "Generates a 'stats.json' file which can be analyzed using tools such as: 'webpack-bundle-analyzer' or https://webpack.github.io/analyse.",
       "default": false
     },
     "forkTypeChecker": {


### PR DESCRIPTION
The url to the webpack-bundle-analyzer website had a space in it and was therefore not a valid url. Removing the space makes the url valid (and easily clickable).