### PR TITLE
fix(@angular-devkit/build-angular): output non human readable lint re…

### DIFF
--- a/packages/angular_devkit/build_angular/src/tslint/index.ts
+++ b/packages/angular_devkit/build_angular/src/tslint/index.ts
@@ -63,12 +63,11 @@ export default class TslintBuilder implements Builder<TslintBuilderOptions> {
     const targetSpecifier = this.context.targetSpecifier;
     const projectName = targetSpecifier && targetSpecifier.project || '';
 
-    // Print formatter output directly for non human-readable formats.
-    if (!['prose', 'verbose', 'stylish'].includes(options.format)) {
-      options.silent = true;
-    }
+    // Print formatter output only for non human-readable formats.
+    const printInfo = ['prose', 'verbose', 'stylish'].includes(options.format)
+      && !options.silent;
 
-    if (!options.silent) {
+    if (printInfo) {
       this.context.logger.info(`Linting ${JSON.stringify(projectName)}...`);
     }
 
@@ -127,15 +126,15 @@ export default class TslintBuilder implements Builder<TslintBuilderOptions> {
         }
       }
 
-      if (result.warningCount > 0 && !options.silent) {
+      if (result.warningCount > 0 && printInfo) {
         this.context.logger.warn('Lint warnings found in the listed files.');
       }
 
-      if (result.errorCount > 0 && !options.silent) {
+      if (result.errorCount > 0 && printInfo) {
         this.context.logger.error('Lint errors found in the listed files.');
       }
 
-      if (result.warningCount === 0 && result.errorCount === 0 && !options.silent) {
+      if (result.warningCount === 0 && result.errorCount === 0 && printInfo) {
         this.context.logger.info('All files pass linting.');
       }
 

--- a/packages/angular_devkit/build_angular/test/tslint/works_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/tslint/works_spec_large.ts
@@ -43,6 +43,7 @@ describe('Tslint Target', () => {
       tap((buildEvent) => expect(buildEvent.success).toBe(true)),
       tap(() => {
         expect(logger.includes('Linting "app"...')).toBe(false);
+        expect(logger.includes('<checkstyle')).toBe(true);
       }),
     ).toPromise().then(done, done.fail);
   }, 30000);


### PR DESCRIPTION
…sult

At the moment, when the tslint formatted is non human readable, it is being fully silenced.

This changes this behaviour and only emit the formatted result.

Originally reported in #tools-cli-discuss

//cc @FrozenPandaz 

Fixes #13173