### PR TITLE
Removed invalid option of ProgressPlugin

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
@@ -150,7 +150,7 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
   }
 
   if (buildOptions.progress) {
-    extraPlugins.push(new ProgressPlugin({ profile: buildOptions.verbose, colors: true }));
+    extraPlugins.push(new ProgressPlugin({ profile: buildOptions.verbose }));
   }
 
   if (buildOptions.showCircularDependencies) {


### PR DESCRIPTION
Remove invalid colors option of ProgressPlugin

ProgressPlugin has no option colors https://github.com/webpack/webpack/issues/8487
ng serve fails if progress is shown