### PR TITLE
fix(@schematics/angular):  cannot create pipe in sub-directory if mod…

### DIFF
--- a/packages/schematics/angular/pipe/index.ts
+++ b/packages/schematics/angular/pipe/index.ts
@@ -96,11 +96,11 @@ export default function (options: PipeOptions): Rule {
       options.path = buildDefaultPath(project);
     }
 
+    options.module = findModuleFromOptions(host, options);
+
     const parsedPath = parseName(options.path, options.name);
     options.name = parsedPath.name;
     options.path = parsedPath.path;
-
-    options.module = findModuleFromOptions(host, options);
 
     // todo remove these when we remove the deprecations
     options.skipTests = options.skipTests || !options.spec;

--- a/packages/schematics/angular/pipe/index_spec.ts
+++ b/packages/schematics/angular/pipe/index_spec.ts
@@ -79,6 +79,20 @@ describe('Pipe Schematic', () => {
     expect(thrownError).toBeDefined();
   });
 
+  it('should handle a path in the name and module options', () => {
+    appTree = schematicRunner.runSchematic(
+      'module',
+      { name: 'admin/module', project: 'bar' },
+      appTree,
+    );
+
+    const options = { ...defaultOptions, module: 'admin/module' };
+    appTree = schematicRunner.runSchematic('pipe', options, appTree);
+
+    const content = appTree.readContent('/projects/bar/src/app/admin/module/module.module.ts');
+    expect(content).toMatch(/import { FooPipe } from '\.\.\/\.\.\/foo.pipe'/);
+  });
+
   it('should export the pipe', () => {
     const options = { ...defaultOptions, export: true };
 


### PR DESCRIPTION
…ule is in different sub-directory

Similar to other schematics, `findModuleFromOptions` should happen prior to `parseName` that modifies the name and path.

Fixes #13182