### PR TITLE
fix(@angular/cli): remove redundant period in deprecation warning

### DIFF
--- a/packages/angular/cli/models/parser.ts
+++ b/packages/angular/cli/models/parser.ts
@@ -206,7 +206,7 @@ function _assignOption(
 
         if (option.deprecated !== undefined && option.deprecated !== false) {
           warnings.push(`Option ${JSON.stringify(option.name)} is deprecated${
-            typeof option.deprecated == 'string' ? ': ' + option.deprecated : ''}.`);
+            typeof option.deprecated == 'string' ? ': ' + option.deprecated : '.'}`);
         }
       }
     } else {


### PR DESCRIPTION
As `parser.ts` currently always adds a period at the end of the warning message and the `x-deprecated` messages also have one, this removes the always added one to avoid a double period in the warning message.

Fixes:

    Option "styleext" is deprecated: Use "style" instead..

to:

    Option "styleext" is deprecated: Use "style" instead.