### PR TITLE
feat(@schematics/angular): extend tslint:recommended

### DIFF
--- a/packages/schematics/angular/workspace/files/tslint.json
+++ b/packages/schematics/angular/workspace/files/tslint.json
@@ -1,32 +1,25 @@
 {
+  "extends": "tslint:recommended",
   "rulesDirectory": [
     "codelyzer"
   ],
   "rules": {
-    "arrow-return-shorthand": true,
-    "callable-types": true,
-    "class-name": true,
-    "comment-format": [
-      true,
-      "check-space"
-    ],
-    "curly": true,
+    "adjacent-overload-signatures": false,
+    "align": false,
+    "array-type": false,
+    "arrow-parens": false,
+    "ban-types": false,
     "deprecation": {
       "severity": "warn"
     },
-    "eofline": true,
-    "forin": true,
+    "function-constructor": false,
     "import-blacklist": [
       true,
       "rxjs/Rx"
     ],
-    "import-spacing": true,
-    "indent": [
-      true,
-      "spaces"
-    ],
-    "interface-over-type-literal": true,
-    "label-position": true,
+    "interface-name": false,
+    "jsdoc-format": false,
+    "max-classes-per-file": false,
     "max-line-length": [
       true,
       140
@@ -43,8 +36,10 @@
         ]
       }
     ],
-    "no-arg": true,
-    "no-bitwise": true,
+    "new-parens": false,
+    "no-angle-bracket-type-assertion": false,
+    "no-conditional-assignment": false,
+    "no-consecutive-blank-lines": false,
     "no-console": [
       true,
       "debug",
@@ -53,28 +48,23 @@
       "timeEnd",
       "trace"
     ],
-    "no-construct": true,
-    "no-debugger": true,
-    "no-duplicate-super": true,
     "no-empty": false,
-    "no-empty-interface": true,
-    "no-eval": true,
     "no-inferrable-types": [
       true,
       "ignore-params"
     ],
-    "no-misused-new": true,
+    "no-namespace": false,
     "no-non-null-assertion": true,
     "no-redundant-jsdoc": true,
-    "no-shadowed-variable": true,
+    "no-reference": false,
+    "no-reference-import": false,
     "no-string-literal": false,
-    "no-string-throw": true,
     "no-switch-case-fall-through": true,
-    "no-trailing-whitespace": true,
-    "no-unnecessary-initializer": true,
-    "no-unused-expression": true,
+    "no-unsafe-finally": false,
     "no-use-before-declare": true,
-    "no-var-keyword": true,
+    "no-var-requires": false,
+    "object-literal-key-quotes": false,
+    "object-literal-shorthand": false,
     "object-literal-sort-keys": false,
     "one-line": [
       true,
@@ -83,20 +73,16 @@
       "check-else",
       "check-whitespace"
     ],
-    "prefer-const": true,
+    "one-variable-per-declaration": false,
+    "only-arrow-functions": false,
+    "ordered-imports": false,
+    "prefer-for-of": false,
     "quotemark": [
       true,
       "single"
     ],
-    "radix": true,
-    "semicolon": [
-      true,
-      "always"
-    ],
-    "triple-equals": [
-      true,
-      "allow-null-check"
-    ],
+    "space-before-function-paren": false,
+    "trailing-comma": false,
     "typedef-whitespace": [
       true,
       {
@@ -107,7 +93,7 @@
         "variable-declaration": "nospace"
       }
     ],
-    "unified-signatures": true,
+    "use-isnan": false,
     "variable-name": false,
     "whitespace": [
       true,


### PR DESCRIPTION
Updates the `tslint.json` file to extend to the `tslint:recommended` set.
Removes the rules that have the same value as the recommended one and explicitely deactivates some rules that are activated in the recommended set, but were not in ours.

Fixes #6179 

cc @mgechev this is to start the discussion, feedback welcome