### PR TITLE
style(@schematics/angular): format jsdoc in polyfills.ts

### DIFF
--- a/packages/schematics/angular/application/files/src/polyfills.ts
+++ b/packages/schematics/angular/application/files/src/polyfills.ts
@@ -47,7 +47,7 @@
  * Web Animations `@angular/platform-browser/animations`
  * Only required if AnimationBuilder is used within the application and using IE/Edge or Safari.
  * Standard animation support in Angular DOES NOT require any polyfills (as of Angular 6.0).
- **/
+ */
 // import 'web-animations-js';  // Run `npm install --save web-animations-js`.
 
 /**


### PR DESCRIPTION
This line makes the `jsdoc-format` tslint rule fails if activated as it is not a correct JSDoc formating.