### PR TITLE
fix(schematics/angular): assert no error logs in e2e

### DIFF
--- a/packages/schematics/angular/e2e/files/src/app.e2e-spec.ts
+++ b/packages/schematics/angular/e2e/files/src/app.e2e-spec.ts
@@ -1,4 +1,5 @@
 import { AppPage } from './app.po';
+import { browser, logging } from 'protractor';
 
 describe('workspace-project App', () => {
   let page: AppPage;
@@ -10,5 +11,13 @@ describe('workspace-project App', () => {
   it('should display welcome message', () => {
     page.navigateTo();
     expect(page.getTitleText()).toEqual('Welcome to <%= relatedAppName %>!');
+  });
+
+  afterEach(async () => {
+    // Assert that there are no errors emitted from the browser
+    const logs = await browser.manage().logs().get(logging.Type.BROWSER);
+    expect(logs).not.toContain(jasmine.objectContaining({
+      level: logging.Level.SEVERE,
+    }));
   });
 });


### PR DESCRIPTION
This commit adds an assertion to the e2e test to make sure there are
no error logs emitted by the browser.