### PR TITLE
fix(@schematics/angular): generate coverage for libs in their own folder

### DIFF
--- a/packages/schematics/angular/application/files/root/karma.conf.js
+++ b/packages/schematics/angular/application/files/root/karma.conf.js
@@ -16,7 +16,7 @@ module.exports = function (config) {
       clearContext: false // leave Jasmine Spec Runner output visible in browser
     },
     coverageIstanbulReporter: {
-      dir: require('path').join(__dirname, '<%= relativePathToWorkspaceRoot %>/coverage'),
+      dir: require('path').join(__dirname, '<%= relativePathToWorkspaceRoot %>/coverage/<%= appName%>'),
       reports: ['html', 'lcovonly', 'text-summary'],
       fixWebpackSourcePaths: true
     },

--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -324,6 +324,7 @@ export default function (options: ApplicationOptions): Rule {
             'dot': '.',
             relativePathToWorkspaceRoot,
             rootInSrc,
+            appName: options.name,
           }),
           move(appDir),
         ])),

--- a/packages/schematics/angular/application/index_spec.ts
+++ b/packages/schematics/angular/application/index_spec.ts
@@ -8,6 +8,7 @@
 // tslint:disable:no-big-function
 import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';
 import { latestVersions } from '../utility/latest-versions';
+import { getFileContent } from '../utility/test';
 import { Schema as WorkspaceOptions } from '../workspace/schema';
 import { Schema as ApplicationOptions } from './schema';
 
@@ -134,6 +135,12 @@ describe('Application Schematic', () => {
     expect(content.extends).toMatch('../../tslint.json');
     expect(content.rules['directive-selector'][2]).toMatch('app');
     expect(content.rules['component-selector'][2]).toMatch('app');
+  });
+
+  it('should set the right coverage folder in the karma.json file', () => {
+    const tree = schematicRunner.runSchematic('application', defaultOptions, workspaceTree);
+    const karmaConf = getFileContent(tree, '/projects/foo/karma.conf.js');
+    expect(karmaConf).toContain(`dir: require('path').join(__dirname, '../../coverage/foo')`);
   });
 
   it('minimal=true should not create e2e project', () => {

--- a/packages/schematics/angular/library/files/__projectRoot__/karma.conf.js
+++ b/packages/schematics/angular/library/files/__projectRoot__/karma.conf.js
@@ -16,7 +16,7 @@ module.exports = function (config) {
       clearContext: false // leave Jasmine Spec Runner output visible in browser
     },
     coverageIstanbulReporter: {
-      dir: require('path').join(__dirname, '<%= relativePathToWorkspaceRoot %>/coverage'),
+      dir: require('path').join(__dirname, '<%= relativePathToWorkspaceRoot %>/coverage/<%= folderName %>'),
       reports: ['html', 'lcovonly'],
       fixWebpackSourcePaths: true
     },

--- a/packages/schematics/angular/library/index.ts
+++ b/packages/schematics/angular/library/index.ts
@@ -213,6 +213,7 @@ export default function (options: LibraryOptions): Rule {
         relativePathToWorkspaceRoot,
         prefix,
         angularLatestVersion: latestVersions.Angular.replace('~', '').replace('^', ''),
+        folderName,
       }),
       // TODO: Moving inside `branchAndMerge` should work but is bugged right now.
       // The __projectRoot__ is being used meanwhile.

--- a/packages/schematics/angular/library/index_spec.ts
+++ b/packages/schematics/angular/library/index_spec.ts
@@ -255,6 +255,9 @@ describe('Library Schematic', () => {
 
     const rootTsCfg = JSON.parse(tree.readContent('/tsconfig.json'));
     expect(rootTsCfg.compilerOptions.paths['@myscope/mylib']).toEqual(['dist/myscope/mylib']);
+
+    const karmaConf = getFileContent(tree, '/projects/myscope/mylib/karma.conf.js');
+    expect(karmaConf).toContain(`dir: require('path').join(__dirname, '../../../coverage/myscope/mylib')`);
   });
 
   it(`should dasherize scoped libraries`, () => {
@@ -275,5 +278,11 @@ describe('Library Schematic', () => {
 
     const cfg = JSON.parse(tree.readContent('/angular.json'));
     expect(cfg.projects['@myScope/myLib']).toBeDefined();
+  });
+
+  it(`should set coverage folder to "coverage/foo"`, () => {
+    const tree = schematicRunner.runSchematic('library', defaultOptions, workspaceTree);
+    const karmaConf = getFileContent(tree, '/projects/foo/karma.conf.js');
+    expect(karmaConf).toContain(`dir: require('path').join(__dirname, '../../coverage/foo')`);
   });
 });


### PR DESCRIPTION
BEFORE:
`ng test foo --code-coverage` would generate the code coverage in the `coverage` folder and would overwrite the code coverage folder of the main app.

AFTER:
Now the code coverage resides in its own folder (`coverage/foo`).

This mimic the behaviour of the `ng build` command and adds more consistency.