### PR TITLE
ci: temporarily disable size check comments

### DIFF
--- a/.github/angular-robot.yml
+++ b/.github/angular-robot.yml
@@ -96,4 +96,4 @@ triage:
 size:
   circleCiStatusName: "ci/circleci: e2e-cli"
   maxSizeIncrease: 10000
-  comment: true
+  comment: false


### PR DESCRIPTION
Disabled while double github event notification issue is investigated.