### PR TITLE
docs(@angular/cli): add the missing autocompletion.md

### DIFF
--- a/docs/documentation/stories/autocompletion.md
+++ b/docs/documentation/stories/autocompletion.md
@@ -1,0 +1,21 @@
+# Autocompletion
+
+To turn on auto completion use the following commands:
+
+For bash:
+```bash
+ng completion --bash >> ~/.bashrc
+source ~/.bashrc
+```
+
+For zsh:
+```bash
+ng completion --zsh >> ~/.zshrc
+source ~/.zshrc
+```
+
+Windows users using gitbash:
+```bash
+ng completion --bash >> ~/.bash_profile
+source ~/.bash_profile
+```


### PR DESCRIPTION
Referring to Issue #11792 ,
The autocompletion link points to autocompletion.md which was missing from docs/documentation/stories.

The stories of 1.x wiki had the file, thus the links were working fine.

autocompletion.md added to docs/documentation/stories making the link to point to correct file.