### PR TITLE
refactor(@angular-devkit/build-angular): improve check port

### DIFF
--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -29,7 +29,6 @@
     "minimatch": "3.0.4",
     "parse5": "4.0.0",
     "opn": "5.4.0",
-    "portfinder": "1.0.20",
     "postcss": "7.0.7",
     "postcss-import": "12.0.1",
     "postcss-loader": "3.0.0",

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/check-port.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/check-port.ts
@@ -5,26 +5,36 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import * as net from 'net';
 
-import { Observable } from 'rxjs';
-const portfinder = require('portfinder');
-
-
-export function checkPort(port: number, host: string, basePort = 49152): Observable<number> {
-  return new Observable(obs => {
-    portfinder.basePort = basePort;
-    // tslint:disable:no-any
-    portfinder.getPort({ port, host }, (err: any, foundPort: number) => {
-      if (err) {
-        obs.error(err);
-      } else if (port !== foundPort && port !== 0) {
-        // If the port isn't available and we weren't looking for any port, throw error.
-        obs.error(`Port ${port} is already in use. Use '--port' to specify a different port.`);
-      } else {
-        // Otherwise, our found port is good.
-        obs.next(foundPort);
-        obs.complete();
+export function checkPort(port: number, host: string, basePort = 49152): Promise<number> {
+  return new Promise<number>((resolve, reject) => {
+    function _getPort(portNumber: number) {
+      if (portNumber > 65535) {
+        reject(new Error(`There is no port available.`));
       }
-    });
+
+      const server = net.createServer();
+
+      server.once('error', (err: Error & {code: string}) => {
+        if (err.code !== 'EADDRINUSE') {
+          reject(err);
+        } else if (port === 0) {
+          _getPort(portNumber + 1);
+        } else {
+          // If the port isn't available and we weren't looking for any port, throw error.
+          reject(
+            new Error(`Port ${port} is already in use. Use '--port' to specify a different port.`),
+          );
+        }
+      })
+      .once('listening', () => {
+        server.close();
+        resolve(portNumber);
+      })
+      .listen(portNumber, host);
+    }
+
+    _getPort(port || basePort);
   });
 }

--- a/packages/angular_devkit/build_angular/src/dev-server/index.ts
+++ b/packages/angular_devkit/build_angular/src/dev-server/index.ts
@@ -16,7 +16,7 @@ import { WebpackDevServerBuilder } from '@angular-devkit/build-webpack';
 import { Path, getSystemPath, resolve, tags, virtualFs } from '@angular-devkit/core';
 import { Stats, existsSync, readFileSync } from 'fs';
 import * as path from 'path';
-import { Observable, throwError } from 'rxjs';
+import { Observable, from, throwError } from 'rxjs';
 import { concatMap, map, tap } from 'rxjs/operators';
 import * as url from 'url';
 import * as webpack from 'webpack';
@@ -67,7 +67,7 @@ export class DevServerBuilder implements Builder<DevServerBuilderOptions> {
     let first = true;
     let opnAddress: string;
 
-    return checkPort(options.port, options.host).pipe(
+    return from(checkPort(options.port, options.host)).pipe(
       tap((port) => options.port = port),
       concatMap(() => this._getBrowserOptions(options)),
       tap(opts => browserOptions = normalizeBuilderSchema(

--- a/yarn.lock
+++ b/yarn.lock
@@ -7464,15 +7464,6 @@ popper.js@^1.14.1:
   resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.14.4.tgz#8eec1d8ff02a5a3a152dd43414a15c7b79fd69b6"
   integrity sha1-juwdj/AqWjoVLdQ0FKFce3n9abY=
 
-portfinder@1.0.20:
-  version "1.0.20"
-  resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.20.tgz#bea68632e54b2e13ab7b0c4775e9b41bf270e44a"
-  integrity sha512-Yxe4mTyDzTd59PZJY4ojZR8F+E5e97iq2ZOHPz3HDgSvYC5siNad2tLooQ5y5QHyQhc3xVqvyk/eNA3wuoa7Sw==
-  dependencies:
-    async "^1.5.2"
-    debug "^2.2.0"
-    mkdirp "0.5.x"
-
 portfinder@^1.0.9:
   version "1.0.19"
   resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.19.tgz#07e87914a55242dcda5b833d42f018d6875b595f"


### PR DESCRIPTION
@hansl I have checked the usage of ```checkPort``` function, and the param ```basePort``` was never passed.
I also read the code of portfinder and saw that, when we set the port option, basePort will not be used.
Instead of that, I think set the highestPort to the same as the port we are looking for can improve the time to check if the port is opened.

What do you think?