### PR TITLE
feat(@angular-devkit/build-angular): add support for port 0 when using protractor

### DIFF
--- a/etc/api/angular_devkit/architect/src/index.d.ts
+++ b/etc/api/angular_devkit/architect/src/index.d.ts
@@ -63,7 +63,8 @@ export interface BuilderPathsMap {
     };
 }
 
-export interface BuildEvent {
+export interface BuildEvent<BuildResultT = any> {
+    result?: BuildResultT;
     success: boolean;
 }
 

--- a/packages/angular_devkit/architect/src/architect.ts
+++ b/packages/angular_devkit/architect/src/architect.ts
@@ -70,8 +70,11 @@ export interface BuilderContext {
 // TODO: use Build Event Protocol
 // https://docs.bazel.build/versions/master/build-event-protocol.html
 // https://github.com/googleapis/googleapis/tree/master/google/devtools/build/v1
-export interface BuildEvent {
+// TODO: use unknown
+// tslint:disable-next-line:no-any
+export interface BuildEvent<BuildResultT = any> {
   success: boolean;
+  result?: BuildResultT;
 }
 
 export interface Builder<OptionsT> {

--- a/packages/angular_devkit/build_angular/test/protractor/works_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/protractor/works_spec_large.ts
@@ -60,6 +60,12 @@ describe('Protractor Builder', () => {
     ).toPromise().then(done, done.fail);
   }, 60000);
 
+  it('works with port 0', (done) => {
+    runTargetSpec(host, protractorTargetSpec, { port: 0 }).pipe(
+      retry(3),
+    ).toPromise().then(done, done.fail);
+  }, 30000);
+
   // TODO: test `element-explorer` when the protractor builder emits build events with text.
   // .then(() => execAndWaitForOutputToMatch('ng', ['e2e', '--element-explorer'],
   // /Element Explorer/))


### PR DESCRIPTION
Fixes #13129

Depends on https://github.com/angular/angular-cli/pull/13292 since `checkPort` was changed to return a Promise instead of Observable.
