### PR TITLE
fix(@angular-devkit/build-angular): keep hash equal

### DIFF
--- a/packages/ngtools/webpack/src/angular_compiler_plugin.ts
+++ b/packages/ngtools/webpack/src/angular_compiler_plugin.ts
@@ -224,7 +224,7 @@ export class AngularCompilerPlugin {
 
     // Overwrite outDir so we can find generated files next to their .ts origin in compilerHost.
     this._compilerOptions.outDir = '';
-    this._compilerOptions.suppressOutputPathCheck = true;
+    this._compilerOptions.suppressOutputPathCheck = false;
 
     // Default plugin sourceMap to compiler options setting.
     if (!options.hasOwnProperty('sourceMap')) {


### PR DESCRIPTION
Keep hashes equal with/without sourcemaps. 

Closes: #8981