### PR TITLE
Deprecate Old Architect

### DIFF
--- a/packages/angular_devkit/architect/src/architect-legacy.ts
+++ b/packages/angular_devkit/architect/src/architect-legacy.ts
@@ -24,18 +24,27 @@ import { resolve as nodeResolve } from '@angular-devkit/core/node';
 import { Observable, forkJoin, of, throwError } from 'rxjs';
 import { concatMap, map, tap } from 'rxjs/operators';
 
+/**
+ * @deprecated
+ */
 export class ProjectNotFoundException extends BaseException {
   constructor(projectName: string) {
     super(`Project '${projectName}' could not be found in Workspace.`);
   }
 }
 
+/**
+ * @deprecated
+ */
 export class TargetNotFoundException extends BaseException {
   constructor(projectName: string, targetName: string) {
     super(`Target '${targetName}' could not be found in project '${projectName}'.`);
   }
 }
 
+/**
+ * @deprecated
+ */
 export class ConfigurationNotFoundException extends BaseException {
   constructor(projectName: string, configurationName: string) {
     super(`Configuration '${configurationName}' could not be found in project '${projectName}'.`);
@@ -43,22 +52,34 @@ export class ConfigurationNotFoundException extends BaseException {
 }
 
 // TODO: break this exception apart into more granular ones.
+/**
+ * @deprecated
+ */
 export class BuilderCannotBeResolvedException extends BaseException {
   constructor(builder: string) {
     super(`Builder '${builder}' cannot be resolved.`);
   }
 }
 
+/**
+ * @deprecated
+ */
 export class ArchitectNotYetLoadedException extends BaseException {
   constructor() { super(`Architect needs to be loaded before Architect is used.`); }
 }
 
+/**
+ * @deprecated
+ */
 export class BuilderNotFoundException extends BaseException {
   constructor(builder: string) {
     super(`Builder ${builder} could not be found.`);
   }
 }
 
+/**
+ * @deprecated
+ */
 export interface BuilderContext {
   logger: logging.Logger;
   host: virtualFs.Host<{}>;
@@ -70,37 +91,57 @@ export interface BuilderContext {
 // TODO: use Build Event Protocol
 // https://docs.bazel.build/versions/master/build-event-protocol.html
 // https://github.com/googleapis/googleapis/tree/master/google/devtools/build/v1
-// TODO: use unknown
-// tslint:disable-next-line:no-any
-export interface BuildEvent<BuildResultT = any> {
+/**
+ * TODO: use unknown
+ * @deprecated
+ */
+export interface BuildEvent<BuildResultT = any> {  // tslint:disable-line:no-any
   success: boolean;
   result?: BuildResultT;
 }
 
+/**
+ * @deprecated
+ */
 export interface Builder<OptionsT> {
   run(builderConfig: BuilderConfiguration<Partial<OptionsT>>): Observable<BuildEvent>;
 }
 
+/**
+ * @deprecated
+ */
 export interface BuilderPathsMap {
   builders: { [k: string]: BuilderPaths };
 }
 
+/**
+ * @deprecated
+ */
 export interface BuilderPaths {
   class: Path;
   schema: Path;
   description: string;
 }
 
+/**
+ * @deprecated
+ */
 export interface BuilderDescription {
   name: string;
   schema: JsonObject;
   description: string;
 }
 
+/**
+ * @deprecated
+ */
 export interface BuilderConstructor<OptionsT> {
   new(context: BuilderContext): Builder<OptionsT>;
 }
 
+/**
+ * @deprecated
+ */
 export interface BuilderConfiguration<OptionsT = {}> {
   root: Path;
   sourceRoot?: Path;
@@ -109,6 +150,9 @@ export interface BuilderConfiguration<OptionsT = {}> {
   options: OptionsT;
 }
 
+/**
+ * @deprecated
+ */
 export interface TargetSpecifier<OptionsT = {}> {
   project: string;
   target: string;
@@ -116,6 +160,9 @@ export interface TargetSpecifier<OptionsT = {}> {
   overrides?: Partial<OptionsT>;
 }
 
+/**
+ * @deprecated
+ */
 export interface TargetMap {
   [k: string]: Target;
 }
@@ -123,12 +170,18 @@ export interface TargetMap {
 export declare type TargetOptions<T = JsonObject> = T;
 export declare type TargetConfiguration<T = JsonObject> = Partial<T>;
 
+/**
+ * @deprecated
+ */
 export interface Target<T = JsonObject> {
   builder: string;
   options: TargetOptions<T>;
   configurations?: { [k: string]: TargetConfiguration<T> };
 }
 
+/**
+ * @deprecated
+ */
 export class Architect {
   private readonly _targetsSchemaPath = join(normalize(__dirname), 'targets-schema.json');
   private readonly _buildersSchemaPath = join(normalize(__dirname), 'builders-schema.json');

--- a/packages/angular_devkit/architect/src/architect_spec.ts
+++ b/packages/angular_devkit/architect/src/architect_spec.ts
@@ -15,7 +15,7 @@ import {
   BuilderCannotBeResolvedException,
   ConfigurationNotFoundException,
   TargetNotFoundException,
-} from './architect';
+} from './architect-legacy';
 
 
 describe('Architect', () => {

--- a/packages/angular_devkit/architect/src/index.ts
+++ b/packages/angular_devkit/architect/src/index.ts
@@ -5,5 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-
-export * from './architect';
+/**
+ * @deprecated
+ */
+export * from './architect-legacy';

--- a/packages/angular_devkit/architect/testing/request.ts
+++ b/packages/angular_devkit/architect/testing/request.ts
@@ -9,6 +9,9 @@ import * as http from 'http';
 import * as https from 'https';
 import * as Url from 'url';
 
+/**
+ * @deprecated
+ */
 export function request(url: string, headers = {}): Promise<string> {
   return new Promise((resolve, reject) => {
     const u = Url.parse(url);

--- a/packages/angular_devkit/architect/testing/run-target-spec.ts
+++ b/packages/angular_devkit/architect/testing/run-target-spec.ts
@@ -12,8 +12,14 @@ import { concatMap, concatMapTo, finalize, takeUntil } from 'rxjs/operators';
 import { Architect, BuildEvent, BuilderContext, TargetSpecifier } from '../src';
 import { TestProjectHost } from './test-project-host';
 
+/**
+ * @deprecated
+ */
 export const DefaultTimeout = 45000;
 
+/**
+ * @deprecated
+ */
 export function runTargetSpec(
   host: TestProjectHost,
   targetSpec: TargetSpecifier,

--- a/packages/angular_devkit/architect/testing/test-logger.ts
+++ b/packages/angular_devkit/architect/testing/test-logger.ts
@@ -9,6 +9,9 @@
 import { logging } from '@angular-devkit/core';
 
 
+/**
+ * @deprecated
+ */
 export class TestLogger extends logging.Logger {
   private _latestEntries: logging.LogEntry[] = [];
   constructor(name: string, parent: logging.Logger | null = null) {

--- a/packages/angular_devkit/architect/testing/test-project-host.ts
+++ b/packages/angular_devkit/architect/testing/test-project-host.ts
@@ -22,6 +22,9 @@ import { EMPTY, Observable, from, of } from 'rxjs';
 import { concatMap, delay, finalize, map, mergeMap, retry, tap } from 'rxjs/operators';
 
 
+/**
+ * @deprecated
+ */
 export class TestProjectHost extends NodeJsSyncHost {
   private _currentRoot: Path | null = null;
   private _scopedSyncHost: virtualFs.SyncDelegateHost<Stats> | null = null;


### PR DESCRIPTION
This is a PR that should go in 7.3 when the new Architect API is accepted.

The new API should probably go in 8.x (or at least 7.4).