### PR TITLE
Factory Methods for BrowserBuilder and WebpackBuilder

### DIFF
--- a/packages/angular_devkit/build_webpack/src/webpack/index.ts
+++ b/packages/angular_devkit/build_webpack/src/webpack/index.ts
@@ -42,11 +42,15 @@ export class WebpackBuilder implements Builder<WebpackBuilderSchema> {
     return from(import(webpackConfigPath));
   }
 
+  protected createWebpackCompiler(config: webpack.Configuration): webpack.Compiler {
+    return webpack(config);
+  }
+
   public runWebpack(
     config: webpack.Configuration, loggingCb = defaultLoggingCb,
   ): Observable<BuildEvent> {
     return new Observable(obs => {
-      const webpackCompiler = webpack(config);
+      const webpackCompiler = this.createWebpackCompiler(config);
 
       const callback: webpack.compiler.CompilerCallback = (err, stats) => {
         if (err) {


### PR DESCRIPTION
These factory methods create the WebpackBuilder, the getBrowserLoggingCb function and the WebpackCompiler to use. This PR doesn't change the current behavior but provides hooks for extensions which inherit the existing Builders.