### PR TITLE
docs: fix grammar error

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -307,6 +307,6 @@ import * as foo from './foo';
 export { foo };
 ```
 There are currently not supported by the API guardian. 
-To overcome this limitiation we created `_golden-api.ts` in certain packages.
+To overcome this limitation we created `_golden-api.ts` in certain packages.
 
 When adding a new API, it might be the case that you need to add it to `_golden-api.ts`.

--- a/scripts/templates/contributing.ejs
+++ b/scripts/templates/contributing.ejs
@@ -296,6 +296,6 @@ import * as foo from './foo';
 export { foo };
 ```
 There are currently not supported by the API guardian. 
-To overcome this limitiation we created `_golden-api.ts` in certain packages.
+To overcome this limitation we created `_golden-api.ts` in certain packages.
 
 When adding a new API, it might be the case that you need to add it to `_golden-api.ts`.


### PR DESCRIPTION
Fix the "limitation" word

Was going to be fixed in 
https://github.com/angular/angular-cli/pull/13336 but was closed.