### PR TITLE
fix(@schematics/angular): generate workspace tslint and .editorconfig…

### DIFF
--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -205,30 +205,38 @@ function addAppToWorkspaceFile(options: ApplicationOptions, workspace: Workspace
           browserTarget: `${options.name}:build`,
         },
       },
-      test: {
-        builder: Builders.Karma,
-        options: {
-          main: `${projectRoot}src/test.ts`,
-          polyfills: `${projectRoot}src/polyfills.ts`,
-          tsConfig: `${rootFilesRoot}tsconfig.spec.json`,
-          karmaConfig: `${rootFilesRoot}karma.conf.js`,
-          styles: [
-            `${projectRoot}src/styles.${options.style}`,
-          ],
-          scripts: [],
-          assets: [
-            join(normalize(projectRoot), 'src', 'favicon.ico'),
-            join(normalize(projectRoot), 'src', 'assets'),
-          ],
-        },
-      },
+      ...(
+        options.minimal ? {} : {
+          test: {
+            builder: Builders.Karma,
+            options: {
+              main: `${projectRoot}src/test.ts`,
+              polyfills: `${projectRoot}src/polyfills.ts`,
+              tsConfig: `${rootFilesRoot}tsconfig.spec.json`,
+              karmaConfig: `${rootFilesRoot}karma.conf.js`,
+              styles: [
+                `${projectRoot}src/styles.${options.style}`,
+              ],
+              scripts: [],
+              assets: [
+                join(normalize(projectRoot), 'src', 'favicon.ico'),
+                join(normalize(projectRoot), 'src', 'assets'),
+              ],
+            },
+          },
+        }
+      ),
       lint: {
         builder: Builders.TsLint,
         options: {
-          tsConfig: [
-            `${rootFilesRoot}tsconfig.app.json`,
-            `${rootFilesRoot}tsconfig.spec.json`,
-          ],
+          tsConfig: options.minimal
+            ? [
+              `${rootFilesRoot}tsconfig.app.json`,
+            ]
+            : [
+              `${rootFilesRoot}tsconfig.app.json`,
+              `${rootFilesRoot}tsconfig.spec.json`,
+            ],
           exclude: [
             '**/node_modules/**',
           ],

--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -327,7 +327,7 @@ export default function (options: ApplicationOptions): Rule {
           }),
           move(appDir),
         ])),
-      options.minimal ? noop() : mergeWith(
+      mergeWith(
         apply(url('./files/lint'), [
           template({
             utils: strings,

--- a/packages/schematics/angular/application/index_spec.ts
+++ b/packages/schematics/angular/application/index_spec.ts
@@ -152,7 +152,6 @@ describe('Application Schematic', () => {
     const files = tree.files;
     [
       '/projects/foo/tsconfig.spec.json',
-      '/projects/foo/tslint.json',
       '/projects/foo/karma.conf.js',
       '/projects/foo/src/test.ts',
       '/projects/foo/src/app/app.component.css',

--- a/packages/schematics/angular/workspace/files/package.json
+++ b/packages/schematics/angular/workspace/files/package.json
@@ -39,8 +39,8 @@
     "karma-coverage-istanbul-reporter": "~2.0.1",
     "karma-jasmine": "~1.1.2",
     "karma-jasmine-html-reporter": "^0.2.2",
-    "protractor": "~5.4.0",<% } %>
-    "ts-node": "~7.0.0",
+    "protractor": "~5.4.0",
+    "ts-node": "~7.0.0",<% } %>
     "tslint": "~5.11.0",
     "typescript": "<%= latestVersions.TypeScript %>"
   }

--- a/packages/schematics/angular/workspace/index.ts
+++ b/packages/schematics/angular/workspace/index.ts
@@ -9,9 +9,7 @@ import { strings } from '@angular-devkit/core';
 import {
   Rule,
   apply,
-  filter,
   mergeWith,
-  noop,
   template,
   url,
 } from '@angular-devkit/schematics';
@@ -20,10 +18,8 @@ import { Schema as WorkspaceOptions } from './schema';
 
 
 export default function (options: WorkspaceOptions): Rule {
-  const minimalFilesRegExp = /(.editorconfig|tslint.json)$/;
 
   return mergeWith(apply(url('./files'), [
-    options.minimal ? filter(path => !minimalFilesRegExp.test(path)) : noop(),
     template({
       utils: strings,
       ...options,

--- a/packages/schematics/angular/workspace/index_spec.ts
+++ b/packages/schematics/angular/workspace/index_spec.ts
@@ -66,9 +66,8 @@ describe('Workspace Schematic', () => {
       '/package.json',
       '/README.md',
       '/tsconfig.json',
+      '/tslint.json',
+      '/.editorconfig',
     ]));
-
-    expect(files).not.toContain('/tslint.json');
-    expect(files).not.toContain('/.editorconfig');
   });
 });


### PR DESCRIPTION
… in minimal workspaces and applications

When in minimal, tslint does get installed thus the tslint config should also be created, as this will break

The minimal flags definition stats that the project will be created without any testing frameworks.

Fixes #13054