### PR TITLE
fix(@schematics/angular): remove properties which are set by default …

### DIFF
--- a/packages/schematics/angular/service-worker/schema.json
+++ b/packages/schematics/angular/service-worker/schema.json
@@ -24,8 +24,6 @@
     }
   },
   "required": [
-    "project",
-    "target",
-    "configuration"
+    "project"
   ]
 }


### PR DESCRIPTION
…from required

At the moment, these would end up being required to be passed even though a default is provided.

Fixes #13010