### PR TITLE
Ivy backwards compatible bootstrap

### DIFF
--- a/packages/ngtools/webpack/src/angular_compiler_plugin.ts
+++ b/packages/ngtools/webpack/src/angular_compiler_plugin.ts
@@ -406,12 +406,12 @@ export class AngularCompilerPlugin {
     }
 
     // If there's still no entryModule try to resolve from mainPath.
-    if (!this._entryModule && this._mainPath && !this._compilerOptions.enableIvy) {
+    if (!this._entryModule && this._mainPath) {
       time('AngularCompilerPlugin._make.resolveEntryModuleFromMain');
       this._entryModule = resolveEntryModuleFromMain(
         this._mainPath, this._compilerHost, this._getTsProgram() as ts.Program);
 
-      if (!this.entryModule) {
+      if (!this.entryModule && !this._compilerOptions.enableIvy) {
         this._warnings.push('Lazy routes discovery is not enabled. '
           + 'Because there is neither an entryModule nor a '
           + 'statically analyzable bootstrap code in the main file.',
@@ -863,7 +863,12 @@ export class AngularCompilerPlugin {
 
         if (!this._JitMode) {
           // Replace bootstrap in browser AOT.
-          this._transformers.push(replaceBootstrap(isAppPath, getEntryModule, getTypeChecker));
+          this._transformers.push(replaceBootstrap(
+            isAppPath,
+            getEntryModule,
+            getTypeChecker,
+            !!this._compilerOptions.enableIvy,
+          ));
         }
       } else if (this._platform === PLATFORM.Server) {
         this._transformers.push(exportLazyModuleMap(isMainPath, getLazyRoutes));

--- a/packages/ngtools/webpack/src/transformers/replace_bootstrap_spec.ts
+++ b/packages/ngtools/webpack/src/transformers/replace_bootstrap_spec.ts
@@ -52,6 +52,48 @@ describe('@ngtools/webpack transformers', () => {
       expect(tags.oneLine`${result}`).toEqual(tags.oneLine`${output}`);
     });
 
+    it('should replace bootstrap for Ivy without referencing ngFactory', () => {
+      const input = tags.stripIndent`
+        import { enableProdMode } from '@angular/core';
+        import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+
+        import { AppModule } from './app/app.module';
+        import { environment } from './environments/environment';
+
+        if (environment.production) {
+          enableProdMode();
+        }
+
+        platformBrowserDynamic().bootstrapModule(AppModule);
+      `;
+
+      // tslint:disable:max-line-length
+      const output = tags.stripIndent`
+        import { enableProdMode } from '@angular/core';
+        import { environment } from './environments/environment';
+
+        import * as __NgCli_bootstrap_1 from "./app/app.module";
+        import * as __NgCli_bootstrap_2 from "@angular/platform-browser";
+
+        if (environment.production) {
+          enableProdMode();
+        }
+        __NgCli_bootstrap_2.platformBrowser().bootstrapModule(__NgCli_bootstrap_1.AppModule);
+      `;
+      // tslint:enable:max-line-length
+
+      const { program, compilerHost } = createTypescriptContext(input);
+      const transformer = replaceBootstrap(
+        () => true,
+        () => ({ path: '/project/src/app/app.module', className: 'AppModule' }),
+        () => program.getTypeChecker(),
+        true,
+      );
+      const result = transformTypescript(undefined, [transformer], program, compilerHost);
+
+      expect(tags.oneLine`${result}`).toEqual(tags.oneLine`${output}`);
+    });
+
     it('should replace bootstrap when barrel files are used', () => {
       const input = tags.stripIndent`
         import { enableProdMode } from '@angular/core';

--- a/packages/schematics/angular/application/files/src/main.ts
+++ b/packages/schematics/angular/application/files/src/main.ts
@@ -1,19 +1,12 @@
-<%= experimentalIvy ? '// ' : '' %>import { enableProdMode } from '@angular/core';
-<%= experimentalIvy ? '// ' : '' %>import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
-<%= experimentalIvy ? '// ' : '' %>
-<%= experimentalIvy ? '// ' : '' %>import { AppModule } from './app/app.module';
-<%= experimentalIvy ? '// ' : '' %>import { environment } from './environments/environment';
-<%= experimentalIvy ? '// ' : '' %>
-<%= experimentalIvy ? '// ' : '' %>if (environment.production) {
-<%= experimentalIvy ? '// ' : '' %>  enableProdMode();
-<%= experimentalIvy ? '// ' : '' %>}
-<%= experimentalIvy ? '// ' : '' %>
-<%= experimentalIvy ? '// ' : '' %>platformBrowserDynamic().bootstrapModule(AppModule)
-<%= experimentalIvy ? '// ' : '' %>  .catch(err => console.error(err));
-<% if (experimentalIvy) { %>
-import { AppComponent } from './app/app.component';
-import { ɵrenderComponent as renderComponent } from '@angular/core';
+import { enableProdMode } from '@angular/core';
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 
-renderComponent(AppComponent);
+import { AppModule } from './app/app.module';
+import { environment } from './environments/environment';
 
-<% } %>
+if (environment.production) {
+  enableProdMode();
+}
+
+platformBrowserDynamic().bootstrapModule(AppModule)
+  .catch(err => console.error(err));

--- a/packages/schematics/angular/application/index_spec.ts
+++ b/packages/schematics/angular/application/index_spec.ts
@@ -190,6 +190,12 @@ describe('Application Schematic', () => {
       expect(pkg.devDependencies['typescript']).toEqual(latestVersions.TypeScript);
     });
 
+    it(`should add a postinstall in package.json when 'experimentalIvy'`, () => {
+      const tree = schematicRunner.runSchematic('application', { ...defaultOptions, experimentalIvy: true }, workspaceTree);
+      const pkg = JSON.parse(tree.readContent('/package.json'));
+      expect(pkg.scripts.postinstall).toEqual('ivy-ngcc');
+    });
+
     it(`should not override existing users dependencies`, () => {
       const oldPackageJson = workspaceTree.readContent('package.json');
       workspaceTree.overwrite('package.json', oldPackageJson.replace(

--- a/packages/schematics/angular/application/other-files/app.module.ts
+++ b/packages/schematics/angular/application/other-files/app.module.ts
@@ -1,6 +1,6 @@
-<% if (!experimentalIvy) { %>import { BrowserModule } from '@angular/platform-browser';<% } %>
+import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
-<% if (routing && !experimentalIvy) { %>
+<% if (routing) { %>
 import { AppRoutingModule } from './app-routing.module';<% } %>
 import { AppComponent } from './app.component';
 
@@ -8,10 +8,10 @@ import { AppComponent } from './app.component';
   declarations: [
     AppComponent
   ],
-  imports: [<% if (!experimentalIvy) { %>
+  imports: [
     BrowserModule<% if (routing) { %>,
     AppRoutingModule<% } %>
-  <% } %>],
+  ],
   providers: [],
   bootstrap: [AppComponent]
 })


### PR DESCRIPTION
feat(@schematics/angular): `experimentalIvy` should generates backwards compatible solution

Usage:
```
ng new foo --experimentalIvy
```

Users will need to use `ngcc` so to process code coming from NPM and produce the equivalent Ivy version. This needs to be done once after installing the node packages.

```
node_modules/.bin/ivy-ngcc
```

`ngtsc` compilter will then be used when building using the `--aot` or `--prod` flag.


feat(@ngtools/webpack): add support for Ivy compatible solution
Ivy compatible solution still uses the 'standard' bootstrapping code, however the difference is that there are no factories.

Using a similar approach for `ngc` but without factories and instead of `bootstrapModuleFactory` it uses `bootstrapModule`.


More context: https://github.com/angular/angular-cli/issues/13024#issuecomment-449146917


TODO check with Framework: 

- [x] Confirm that using `bootstrapModule` is the right approach
- [x] How to retrieve lazy loaded modules as it seems that `listLazyRoutes` is not returning anything, - https://github.com/angular/angular/pull/27697
- [x] TBD - Should we add `ivy-ngcc` as a post install script
- [x] TBD - Should we turn on factory shimming by default in tsconfig via `allowEmptyCodegenFiles`

Fixes: #13024 