### PR TITLE
fix(@schematics/update): check if replace is a function

### DIFF
--- a/packages/schematics/update/update/npm.ts
+++ b/packages/schematics/update/update/npm.ts
@@ -84,7 +84,9 @@ function readOptions(
 
   // Substitute any environment variable references
   for (const key in options) {
-    options[key] = options[key].replace(/\$\{([^\}]+)\}/, (_, name) => process.env[name] || '');
+    if (typeof options[key] === 'string') {
+      options[key] = options[key].replace(/\$\{([^\}]+)\}/, (_, name) => process.env[name] || '');
+    }
   }
 
   return options;


### PR DESCRIPTION
When substituting environment variables in npmrc options, string replace was also applied on boolean values. This caused the ng update process to fail #10624 