### PR TITLE
build: terminate process with non zero error code when build fails

### DIFF
--- a/bin/devkit-admin
+++ b/bin/devkit-admin
@@ -68,7 +68,7 @@ try {
     .then(() => require(scriptPath).default(args, logger, cwd))
     .then(exitCode => process.exit(exitCode || 0))
     .catch(err => {
-      logger.fatal(err.stack);
+      logger.fatal(err && err.stack);
       process.exit(99);
     });
 } catch (err) {


### PR DESCRIPTION
At the moment, error can be undefined sometimes which is causing the process not to be terminated with a non zero error code.