### PR TITLE
docs: add clause that states the `minimal` projects are for learning …

### DIFF
--- a/packages/schematics/angular/application/schema.json
+++ b/packages/schematics/angular/application/schema.json
@@ -70,7 +70,7 @@
       "description": "When true, does not add dependencies to the \"package.json\" file."
     },
     "minimal": {
-      "description": "When true, creates a bare-bones project without any testing frameworks.",
+      "description": "When true, creates a bare-bones project without any testing frameworks and should be used for learning purposes.",
       "type": "boolean",
       "default": false
     },

--- a/packages/schematics/angular/ng-new/schema.json
+++ b/packages/schematics/angular/ng-new/schema.json
@@ -138,7 +138,7 @@
       "default": true
     },
     "minimal": {
-      "description": "When true, creates a project without any testing frameworks.",
+      "description": "When true, creates a project without any testing frameworks and should be used for learning purposes only.",
       "type": "boolean",
       "default": false
     }

--- a/packages/schematics/angular/workspace/schema.json
+++ b/packages/schematics/angular/workspace/schema.json
@@ -70,7 +70,7 @@
       }
     },
     "minimal": {
-      "description": "When true, creates a project without any testing frameworks",
+      "description": "When true, creates a workspace without any testing frameworks and should be used for learning.",
       "type": "boolean",
       "default": false
     }


### PR DESCRIPTION
…purposes.

Minimal projects contains limited functionality and certain commands might not work at all.

This projects should be considered as a throw away.

Fixes #13054