### PR TITLE
fix(@schematics/angular): stop offering SASS option for ng new

### DIFF
--- a/packages/ngtools/webpack/README.md
+++ b/packages/ngtools/webpack/README.md
@@ -48,7 +48,7 @@ The loader works with webpack plugin to compile your TypeScript. It's important 
 ## Features
 The benefits and ability of using [`@ngtools/webpack`](https://www.npmjs.com/~ngtools) standalone from the Angular CLI as presented in [Stephen Fluin's Angular CLI talk](https://youtu.be/uBRK6cTr4Vk?t=6m45s) at Angular Connect 2016:
 
-* Compiles SCSS/LESS
+* Compiles Sass/Less into CSS
 * TypeScript transpilation
 * Bundles JavaScript, CSS
 * Asset optimization

--- a/packages/schematics/angular/ng-new/schema.json
+++ b/packages/schematics/angular/ng-new/schema.json
@@ -119,9 +119,8 @@
         "type": "list",
         "items": [
           { "value": "css", "label": "CSS" },
-          { "value": "scss", "label": "SCSS   [ http://sass-lang.com   ]" },
-          { "value": "sass", "label": "SASS   [ http://sass-lang.com   ]" },
-          { "value": "less", "label": "LESS   [ http://lesscss.org     ]" },
+          { "value": "scss", "label": "Sass   [ http://sass-lang.com   ]" },
+          { "value": "less", "label": "Less   [ http://lesscss.org     ]" },
           { "value": "styl", "label": "Stylus [ http://stylus-lang.com ]" }
         ]
       }


### PR DESCRIPTION
The old Sass language referred to as "SASS" here is no longer relevant. This was denoted with the file extension ".sass"
Any new projects should use the modern Sass language which is expressed in ".scss" files.
This change does not remove any support for projects which were already created with ".sass" files, we simply stop offering
this option when creating new projects.

Also correct the capitalization of Less based on how they spell it on their website.