### PR TITLE
fix(@schematics/angular): remove SCSS from ng-new prompt

### DIFF
--- a/packages/schematics/angular/ng-new/schema.json
+++ b/packages/schematics/angular/ng-new/schema.json
@@ -119,8 +119,7 @@
         "type": "list",
         "items": [
           { "value": "css", "label": "CSS" },
-          { "value": "scss", "label": "SCSS   [ http://sass-lang.com   ]" },
-          { "value": "sass", "label": "SASS   [ http://sass-lang.com   ]" },
+          { "value": "scss", "label": "SASS   [ http://sass-lang.com   ]" },
           { "value": "less", "label": "LESS   [ http://lesscss.org     ]" },
           { "value": "styl", "label": "Stylus [ http://stylus-lang.com ]" }
         ]


### PR DESCRIPTION
The stylesheet extension `.sass` should be deprecated in favor of `.scss`.
See SASS documentation [here](http://sass-lang.com/guide).

In `ng new`, the **value** `scss` generates stylesheets with `.scss`
extension whereas the **value** `sass` generates stylesheets with
`.sass` extension. 
We want `.scss` extension. However, the **label** for `.scss` extension should
be SASS.

This is a non-breaking change since it only affect new CLI projects.