### PR TITLE
Highlight creating workspace without initial app in doc

### DIFF
--- a/packages/angular/cli/commands/new.md
+++ b/packages/angular/cli/commands/new.md
@@ -3,8 +3,14 @@ Creates and initializes a new Angular app that is the default project for a new 
 Provides interactive prompts for optional configuration, such as adding routing support.
 All prompts can safely be allowed to default.
 
-* The new workspace folder is given the specified project name, and contains configuration files at the top level. 
+* The new workspace folder is given the specified project name, and contains configuration files at the top level.
 
-* The new app files are placed in the `src/` subfolder. A corresponding end-to-end test app is placed in the `e2e/` subfolder.
+* By default, the files for a new initial app (with the same name as the workspace) are placed in the `src/` subfolder. A corresponding end-to-end test app is placed in the `e2e/` subfolder.
 
 * The new app's configuration appears in the `projects` section of the `angular.json` workspace configuration file, under its project name.
+
+* Subsequent apps that you generate in the workspace reside in the `projects/` subfolder.
+
+If you plan to have multiple apps in the workspace, you can create an empty workspace by setting the `--createApplication` option to false.
+You can then use `ng generate application` to create an initial app.
+This allows a workspace name different from the initial app name, and ensures that all apps reside in the `/projects` subfolder, matching the structure of the configuration file.

--- a/packages/schematics/angular/application/schema.json
+++ b/packages/schematics/angular/application/schema.json
@@ -70,7 +70,7 @@
       "description": "When true, does not add dependencies to the \"package.json\" file."
     },
     "minimal": {
-      "description": "When true, creates a bare-bones project without any testing frameworks and should be used for learning purposes.",
+      "description": "When true, creates a bare-bones project without any testing frameworks. (Use for learning purposes only.)",
       "type": "boolean",
       "default": false
     },

--- a/packages/schematics/angular/ng-new/schema.json
+++ b/packages/schematics/angular/ng-new/schema.json
@@ -132,12 +132,12 @@
       "alias": "S"
     },
     "createApplication": {
-      "description": "When true (the default), creates a new initial app project in the new workspace.",
+      "description": "When true (the default), creates a new initial app project in the src folder of the new workspace. When false, creates an empty workspace with no initial app. You can then use the generate application command so that all apps are created in the projects folder.",
       "type": "boolean",
       "default": true
     },
     "minimal": {
-      "description": "When true, creates a project without any testing frameworks and should be used for learning purposes only.",
+      "description": "When true, creates a project without any testing frameworks. (Use for learning purposes only).",
       "type": "boolean",
       "default": false
     }

--- a/packages/schematics/angular/ng-new/schema.json
+++ b/packages/schematics/angular/ng-new/schema.json
@@ -137,7 +137,7 @@
       "default": true
     },
     "minimal": {
-      "description": "When true, creates a project without any testing frameworks. (Use for learning purposes only).",
+      "description": "When true, creates a project without any testing frameworks. (Use for learning purposes only.)",
       "type": "boolean",
       "default": false
     }

--- a/packages/schematics/angular/workspace/schema.json
+++ b/packages/schematics/angular/workspace/schema.json
@@ -70,7 +70,7 @@
       }
     },
     "minimal": {
-      "description": "When true, creates a workspace without any testing frameworks and should be used for learning.",
+      "description": "When true, creates a workspace without any testing frameworks. (Use for learning purposes only.)",
       "type": "boolean",
       "default": false
     }


### PR DESCRIPTION
I just learned that you can create a workspace without the anomalous initial app in /src, and then populate it with apps using `ng g a`, so that multiple apps are all in /projects (with libs).  This is much more desirable for a workspace with multiple apps.

I think `--createApplication==false` should be the default in future to avoid confusion and awkwardness for new users -- but for now, I'm proposing that we point out the benefits in the API doc for `ng new`.