### PR TITLE
build: Update Bazel workspace

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,7 @@
 workspace(name = "angular_cli")
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 # This is required by Angular Workspace
 http_archive(
     name = "bazel_skylib",
@@ -19,8 +21,9 @@ http_archive(
 # Load the TypeScript rules, its dependencies, and setup the workspace.
 http_archive(
     name = "build_bazel_rules_typescript",
-    url = "https://github.com/bazelbuild/rules_typescript/archive/8ea1a55cf5cf8be84ddfeefc0940769b80da792f.zip",
-    strip_prefix = "rules_typescript-8ea1a55cf5cf8be84ddfeefc0940769b80da792f",
+    url = "https://github.com/bazelbuild/rules_typescript/archive/0.22.1.zip",
+    strip_prefix = "rules_typescript-0.22.1",
+    sha256 = "351abe89b291a3b3d6af38d9d04c6270f5d2ed8781e2fda25bc65fd12db25e66",
 )
 
 load("@build_bazel_rules_typescript//:package.bzl", "rules_typescript_dependencies")
@@ -37,9 +40,9 @@ go_register_toolchains()
 # TS API Guardian resides in Angular
 http_archive(
     name = "angular",
-    url = "https://github.com/angular/angular/archive/7.1.0-rc.0.zip",
-    strip_prefix = "angular-7.1.0-rc.0",
-    sha256 = "dbf3ae2d60b5384715bc002c695be0141f8c9219396ac1edbdc7023bd400c8a1",
+    url = "https://github.com/angular/angular/archive/7.2.0.zip",
+    strip_prefix = "angular-7.2.0",
+    sha256 = "8a4915a524f3fed17424da4b77cd7a943fbbddba44275f06671493339713914b",
 )
 
 load("@angular//:index.bzl", "ng_setup_workspace")

--- a/etc/api/angular_devkit/schematics/src/_golden-api.d.ts
+++ b/etc/api/angular_devkit/schematics/src/_golden-api.d.ts
@@ -566,7 +566,7 @@ export declare function template<T>(options: T): Rule;
 
 export declare const TEMPLATE_FILENAME_RE: RegExp;
 
-export declare const Tree: TreeConstructor;
+export declare type Tree = TreeInterface;
 
 export interface TreeConstructor {
     branch(tree: TreeInterface): TreeInterface;

--- a/package.json
+++ b/package.json
@@ -74,8 +74,8 @@
   "devDependencies": {
     "@angular/compiler": "^7.2.0-rc.0",
     "@angular/compiler-cli": "^7.2.0-rc.0",
-    "@bazel/karma": "^0.20.3",
-    "@bazel/typescript": "0.20.3",
+    "@bazel/karma": "^0.22.1",
+    "@bazel/typescript": "0.22.1",
     "@ngtools/json-schema": "^1.1.0",
     "@types/copy-webpack-plugin": "^4.4.1",
     "@types/express": "^4.16.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -195,10 +195,10 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
-"@bazel/karma@^0.20.3":
-  version "0.20.3"
-  resolved "https://registry.yarnpkg.com/@bazel/karma/-/karma-0.20.3.tgz#a63bb82b4887ae8c0d01f3028c6fa4764470851d"
-  integrity sha512-IgWfTpK9XLEI977DS2kHIEO1QfFTEOBxeNDDjHtd1onmzyMCLROphTOBZ/g42ybUIWyJhS9DK4U3bLSMQE0Bng==
+"@bazel/karma@^0.22.1":
+  version "0.22.1"
+  resolved "https://registry.yarnpkg.com/@bazel/karma/-/karma-0.22.1.tgz#1bd7028b7939e19d67a94a95ea8e7afada679a16"
+  integrity sha512-QPJbvCvxpQF4Wvcrl8efQY095+5OMh/uCPB7REGD728KmFKCPz0R/RhaU5dyNOoaZlR7yTGPkvVcN0nNUKqKKQ==
   dependencies:
     jasmine-core "2.8.0"
     karma alexeagle/karma#fa1a84ac881485b5657cb669e9b4e5da77b79f0a
@@ -209,16 +209,17 @@
     karma-sauce-launcher "1.2.0"
     karma-sourcemap-loader "0.3.7"
     requirejs "2.3.5"
+    semver "5.6.0"
     tmp "0.0.33"
 
-"@bazel/typescript@0.20.3":
-  version "0.20.3"
-  resolved "https://registry.yarnpkg.com/@bazel/typescript/-/typescript-0.20.3.tgz#51dcc369c2af0d7f2311d6e692d07776492060f4"
-  integrity sha512-BZmfzaNkgS++53CGEUk5p9FXOG+k8FNWCDbxzYljoIGP60aIkw4UgRQ24ReBwhCMg6M6KW609yje7AvDZkA6bg==
+"@bazel/typescript@0.22.1":
+  version "0.22.1"
+  resolved "https://registry.yarnpkg.com/@bazel/typescript/-/typescript-0.22.1.tgz#b52c00e8560019e2f9d273d45c04785e0ec9d9bd"
+  integrity sha512-88DaCCnNg8rPlKP0eAQEZuoiJkEPeiItpUS3oBR1sFQNBRJb56D25ahK8+N6LJk4qaH+ZQ1/AHOPDhfEEWvDzA==
   dependencies:
     protobufjs "5.0.3"
+    semver "5.6.0"
     source-map-support "0.5.9"
-    tsickle "0.28.0"
     tsutils "2.27.2"
 
 "@ngtools/json-schema@^1.1.0":
@@ -5597,7 +5598,7 @@ karma-sourcemap-loader@0.3.7:
   dependencies:
     graceful-fs "^4.1.2"
 
-karma@alexeagle/karma#fa1a84ac881485b5657cb669e9b4e5da77b79f0a:
+"karma@github:alexeagle/karma#fa1a84ac881485b5657cb669e9b4e5da77b79f0a":
   version "1.7.1"
   resolved "https://codeload.github.com/alexeagle/karma/tar.gz/fa1a84ac881485b5657cb669e9b4e5da77b79f0a"
   dependencies:
@@ -9953,16 +9954,6 @@ ts-node@^5.0.0:
     mkdirp "^0.5.1"
     source-map-support "^0.5.3"
     yn "^2.0.0"
-
-tsickle@0.28.0:
-  version "0.28.0"
-  resolved "https://registry.yarnpkg.com/tsickle/-/tsickle-0.28.0.tgz#6cd6fa004766c6ad9261b599c83866ee97cc7875"
-  integrity sha512-cb/Z4NlKMPGiIIbgmklfBJIxDl4EQoYqC+0/BnPxZWzWcUvikeOHFkkkEmabJVqKh47jUqOwU/uMAu6UvhicZg==
-  dependencies:
-    minimist "^1.2.0"
-    mkdirp "^0.5.1"
-    source-map "^0.6.0"
-    source-map-support "^0.5.0"
 
 tsickle@>=0.34.0:
   version "0.34.0"


### PR DESCRIPTION
While doing a Bazel query using Bazel 0.21.0, Bazel complains that
`http_archive` must now be an explicit rule. This commit fixes that.

In addition, versions for rules_typescript and angular have also
been updated.