### PR TITLE
docs: new GitHub Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,56 +1,10 @@
-<!--
-IF YOU DON'T FILL OUT THE FOLLOWING INFORMATION YOUR ISSUE MIGHT BE CLOSED WITHOUT INVESTIGATING
--->
-### Bug Report or Feature Request (mark with an `x`)
-```
-- [ ] bug report -> please search issues before submitting
-- [ ] feature request
-```
+🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑
 
-### Command (mark with an `x`)
-```
-- [ ] new
-- [ ] build
-- [ ] serve
-- [ ] test
-- [ ] e2e
-- [ ] generate
-- [ ] add
-- [ ] update
-- [ ] lint
-- [ ] xi18n
-- [ ] run
-- [ ] config
-- [ ] help
-- [ ] version
-- [ ] doc
-```
+Please help us process issues more efficiently by filing an
+issue using one of the following templates:
 
-### Versions
-<!--
-Output from: `node --version`, `npm --version` and `ng --version`.
-  Windows (7/8/10). Linux (incl. distribution). macOS (El Capitan? Sierra? High Sierra?)
--->
+https://github.com/angular/angular-cli/issues/new/choose
 
+Thank you!
 
-### Repro steps
-<!--
-Simple steps to reproduce this bug.
-Please include: commands run (incl args), packages added, related code changes.
-A link to a sample repo would help too.
--->
-
-
-### The log given by the failure
-<!-- Normally this include a stack trace and some more information. -->
-
-
-### Desired functionality
-<!--
-What would like to see implemented?
-What is the usecase?
--->
-
-
-### Mention any other details that might be useful
-<!-- Please include a link to the repo if this is related to an OSS project. -->
+🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑

--- a/.github/ISSUE_TEMPLATE/1-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.md
@@ -1,0 +1,80 @@
+---
+name: "\U0001F41EBug report"
+about: Report a bug in Angular CLI
+---
+<!--🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅
+
+Oh hi there! 😄
+
+To expedite issue processing please search open and closed issues before submitting a new one.
+Existing issues often contain information about workarounds, resolution, or progress updates.
+
+🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅-->
+
+
+# 🐞 Bug report
+
+### Command (mark with an `x`)
+<!-- Can you pin-point the command or commands that are effected by this bug? -->
+<!-- ✍️edit: -->
+```
+- [ ] new
+- [ ] build
+- [ ] serve
+- [ ] test
+- [ ] e2e
+- [ ] generate
+- [ ] add
+- [ ] update
+- [ ] lint
+- [ ] xi18n
+- [ ] run
+- [ ] config
+- [ ] help
+- [ ] version
+- [ ] doc
+```
+
+### Is this a regression?
+
+<!-- Did this behavior use to work in the previous version? -->
+<!-- ✍️--> Yes, the previous version in which this bug was not present was: ....
+
+
+### Description
+
+<!-- ✍️--> A clear and concise description of the problem...
+
+
+## 🔬 Minimal Reproduction
+<!--
+Simple steps to reproduce this bug.
+
+Please include: commands run (including args), packages added, related code changes.
+
+If reproduction steps are not enough for reproduction of your issue, please create a minimal GitHub repository with the reproduction of the issue. Share the link to the repo below along with step-by-step instructions to reproduce the problem, as well as expected and actual behavior.
+
+Issues that don't have enough info and can't be reproduced will be closed.
+
+You can read more about issue submission guidelines here: https://github.com/angular/angular-cli/blob/master/CONTRIBUTING.md#-submitting-an-issue
+-->
+
+## 🔥 Exception or Error
+<pre><code>
+<!-- If the issue is accompanied by an exception or an error, please share it below: -->
+<!-- ✍️-->
+
+</code></pre>
+
+
+## 🌍 Your Environment
+<pre><code>
+<!-- run `ng version` and paste output below -->
+<!-- ✍️-->
+
+</code></pre>
+
+**Anything else relevant?**
+<!-- ✍️Is this a browser specific issue? If so, please specify the browser and version. -->
+
+<!-- ✍️Do any of these matter: operating system, IDE, package manager, HTTP server, ...? If so, please mention it below. -->

--- a/.github/ISSUE_TEMPLATE/2-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.md
@@ -1,0 +1,49 @@
+---
+name: "\U0001F680Feature request"
+about: Suggest a feature for Angular CLI
+
+---
+<!--🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅
+
+Oh hi there! 😄
+
+To expedite issue processing please search open and closed issues before submitting a new one.
+Existing issues often contain information about workarounds, resolution, or progress updates.
+
+🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅🔅-->
+
+
+# 🚀 Feature request
+
+
+### Command (mark with an `x`)
+<!-- Can you pin-point the command or commands that are relevant for this feature request? -->
+<!-- ✍️edit: -->
+```
+- [ ] new
+- [ ] build
+- [ ] serve
+- [ ] test
+- [ ] e2e
+- [ ] generate
+- [ ] add
+- [ ] update
+- [ ] lint
+- [ ] xi18n
+- [ ] run
+- [ ] config
+- [ ] help
+- [ ] version
+- [ ] doc
+```
+
+### Description
+<!-- ✍️--> A clear and concise description of the problem or missing capability...
+
+
+### Describe the solution you'd like
+<!-- ✍️--> If you have a solution in mind, please describe it.
+
+
+### Describe alternatives you've considered
+<!-- ✍️--> Have you considered any alternative solutions or workarounds?

--- a/.github/ISSUE_TEMPLATE/3-docs-bug.md
+++ b/.github/ISSUE_TEMPLATE/3-docs-bug.md
@@ -1,0 +1,13 @@
+---
+name: "📚 Docs or angular.io issue report"
+about: Report an issue in Angular's documentation or angular.io application
+
+---
+
+🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑
+
+Please file any Docs or angular.io issues at: https://github.com/angular/angular/issues/new/choose
+
+For the time being, we keep Angular AIO issues in a separate repository.
+
+🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑

--- a/.github/ISSUE_TEMPLATE/4-security-issue-disclosure.md
+++ b/.github/ISSUE_TEMPLATE/4-security-issue-disclosure.md
@@ -1,0 +1,11 @@
+---
+name: ⚠️Security issue disclosure
+about: Report a security issue in Angular Framework, Material, or CLI
+
+---
+
+🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑
+
+Please read https://angular.io/guide/security#report-issues on how to disclose security related issues.
+
+🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑

--- a/.github/ISSUE_TEMPLATE/5-support-request.md
+++ b/.github/ISSUE_TEMPLATE/5-support-request.md
@@ -1,0 +1,16 @@
+---
+name: "❓Support request"
+about: Questions and requests for support
+
+---
+
+🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑
+
+Please do not file questions or support requests on the GitHub issues tracker.
+
+You can get your questions answered using other communication channels. Please see: 
+https://github.com/angular/angular-cli/blob/master/CONTRIBUTING.md#question
+
+Thank you!
+
+🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑

--- a/.github/ISSUE_TEMPLATE/6-angular-framework.md
+++ b/.github/ISSUE_TEMPLATE/6-angular-framework.md
@@ -1,0 +1,13 @@
+---
+name: "⚡Angular Framework"
+about: Issues and feature requests for Angular Framework
+
+---
+
+🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑
+
+Please file any Angular Framework issues at: https://github.com/angular/angular/issues/new/choose
+
+For the time being, we keep Angular issues in a separate repository.
+
+🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑

--- a/.github/ISSUE_TEMPLATE/7-angular-material.md
+++ b/.github/ISSUE_TEMPLATE/7-angular-material.md
@@ -1,0 +1,13 @@
+---
+name: "\U0001F48EAngular Material"
+about: Issues and feature requests for Angular Material
+
+---
+
+🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑
+
+Please file any Angular Material issues at: https://github.com/angular/material2/issues/new
+
+For the time being, we keep Angular Material issues in a separate repository.
+
+🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑🛑


### PR DESCRIPTION
These templates take advatange of github's feature that allows
us to define multiple templates anand whyd which the UI presents to the
user similar to the one in Angular/Angular.

Can be viewed https://github.com/alan-agius4/renovate-playground-git/issues/new/choose