### PR TITLE
docs(polyfills.ts): Clarify about reflect API and when it is needed

### DIFF
--- a/tests/angular_devkit/build_webpack/angular-app/src/polyfills.ts
+++ b/tests/angular_devkit/build_webpack/angular-app/src/polyfills.ts
@@ -44,7 +44,11 @@
 /** IE10 and IE11 requires the following for NgClass support on SVG elements */
 // import 'classlist.js';  // Run `npm install --save classlist.js`.
 
-/** IE10 and IE11 requires the following for the Reflect API. */
+/**
+ * IE10 and IE11 requires the following for the Reflect API.
+ * `es6/reflect` is needed, if you use any of these features in your application, to work in IE10 and IE11.
+ * `es7/reflect` is required by Angular when running JIT Compilation (`--aot=false`) but this will be imported by default.
+ */
 // import 'core-js/es6/reflect';
 
 


### PR DESCRIPTION
I found it very confusing if we needed `es6/reflect` or not when looking at `polyfills.ts` and https://angular.io/guide/browser-support#mandatory-polyfills 

I Think that this might clarify it somewhat. I also created a PR to try to clarify the docs (https://github.com/angular/angular/pull/28238) 

I don't know if the wording was the greatest, please poke me about any improvements I can do