### PR TITLE
Build-optimizer fixes for FESM/ESM bundles

### DIFF
--- a/etc/api/angular_devkit/build_optimizer/src/_golden-api.d.ts
+++ b/etc/api/angular_devkit/build_optimizer/src/_golden-api.d.ts
@@ -12,6 +12,8 @@ export declare function getPrefixFunctionsTransformer(): ts.TransformerFactory<t
 
 export declare function getScrubFileTransformer(program: ts.Program): ts.TransformerFactory<ts.SourceFile>;
 
+export declare function getScrubFileTransformerForCore(program: ts.Program): ts.TransformerFactory<ts.SourceFile>;
+
 export declare function getWrapEnumsTransformer(): ts.TransformerFactory<ts.SourceFile>;
 
 export declare function testImportTslib(content: string): boolean;

--- a/packages/angular_devkit/build_optimizer/src/build-optimizer/build-optimizer.ts
+++ b/packages/angular_devkit/build_optimizer/src/build-optimizer/build-optimizer.ts
@@ -15,7 +15,11 @@ import { getFoldFileTransformer } from '../transforms/class-fold';
 import { getImportTslibTransformer, testImportTslib } from '../transforms/import-tslib';
 import { getPrefixClassesTransformer, testPrefixClasses } from '../transforms/prefix-classes';
 import { getPrefixFunctionsTransformer } from '../transforms/prefix-functions';
-import { getScrubFileTransformer, testScrubFile } from '../transforms/scrub-file';
+import {
+  getScrubFileTransformer,
+  getScrubFileTransformerForCore,
+  testScrubFile,
+} from '../transforms/scrub-file';
 import { getWrapEnumsTransformer } from '../transforms/wrap-enums';
 
 
@@ -44,6 +48,18 @@ const ngFactories = [
   /\.ngstyle\.[jt]s/,
 ];
 
+// Known locations for the source files of @angular/core.
+const coreFilesRegex = [
+  /[\\/]node_modules[\\/]@angular[\\/]core[\\/]esm5[\\/]/,
+  /[\\/]node_modules[\\/]@angular[\\/]core[\\/]fesm5[\\/]/,
+  /[\\/]node_modules[\\/]@angular[\\/]core[\\/]esm2015[\\/]/,
+  /[\\/]node_modules[\\/]@angular[\\/]core[\\/]fesm2015[\\/]/,
+];
+
+function isKnownCoreFile(filePath: string) {
+  return coreFilesRegex.some(re => re.test(filePath));
+}
+
 function isKnownSideEffectFree(filePath: string) {
   return ngFactories.some((re) => re.test(filePath)) ||
     whitelistedAngularModules.some((re) => re.test(filePath));
@@ -57,11 +73,12 @@ export interface BuildOptimizerOptions {
   emitSourceMap?: boolean;
   strict?: boolean;
   isSideEffectFree?: boolean;
+  isAngularCoreFile?: boolean;
 }
 
 export function buildOptimizer(options: BuildOptimizerOptions): TransformJavascriptOutput {
 
-  const { inputFilePath } = options;
+  const { inputFilePath, isAngularCoreFile } = options;
   let { originalFilePath, content } = options;
 
   if (!originalFilePath && inputFilePath) {
@@ -84,6 +101,15 @@ export function buildOptimizer(options: BuildOptimizerOptions): TransformJavascr
     };
   }
 
+  let selectedGetScrubFileTransformer = getScrubFileTransformer;
+
+  if (
+    isAngularCoreFile === true ||
+    (isAngularCoreFile === undefined && originalFilePath && isKnownCoreFile(originalFilePath))
+  ) {
+    selectedGetScrubFileTransformer = getScrubFileTransformerForCore;
+  }
+
   const isWebpackBundle = content.indexOf('__webpack_require__') !== -1;
 
   // Determine which transforms to apply.
@@ -97,14 +123,14 @@ export function buildOptimizer(options: BuildOptimizerOptions): TransformJavascr
       // We only apply it to whitelisted modules, since we know they are safe.
       // getPrefixFunctionsTransformer needs to be before getFoldFileTransformer.
       getPrefixFunctionsTransformer,
-      getScrubFileTransformer,
+      selectedGetScrubFileTransformer,
       getFoldFileTransformer,
     );
     typeCheck = true;
   } else if (testScrubFile(content)) {
     // Always test as these require the type checker
     getTransforms.push(
-      getScrubFileTransformer,
+      selectedGetScrubFileTransformer,
       getFoldFileTransformer,
     );
     typeCheck = true;

--- a/packages/angular_devkit/build_optimizer/src/build-optimizer/rollup-plugin.ts
+++ b/packages/angular_devkit/build_optimizer/src/build-optimizer/rollup-plugin.ts
@@ -20,6 +20,7 @@ const DEBUG = false;
 
 export interface Options {
   sideEffectFreeModules?: string[];
+  angularCoreModules?: string[];
 }
 
 export default function optimizer(options: Options) {
@@ -34,8 +35,10 @@ export default function optimizer(options: Options) {
       const normalizedId = id.replace(/\\/g, '/');
       const isSideEffectFree = options.sideEffectFreeModules &&
         options.sideEffectFreeModules.some(m => normalizedId.indexOf(m) >= 0);
+      const isAngularCoreFile = options.angularCoreModules &&
+        options.angularCoreModules.some(m => normalizedId.indexOf(m) >= 0);
       const { content: code, sourceMap: map } = buildOptimizer({
-        content, inputFilePath: id, emitSourceMap: true, isSideEffectFree,
+        content, inputFilePath: id, emitSourceMap: true, isSideEffectFree, isAngularCoreFile,
       });
       if (!code) {
         if (DEBUG) {

--- a/packages/angular_devkit/build_optimizer/src/index.ts
+++ b/packages/angular_devkit/build_optimizer/src/index.ts
@@ -14,5 +14,9 @@ export { getFoldFileTransformer } from './transforms/class-fold';
 export { getImportTslibTransformer, testImportTslib } from './transforms/import-tslib';
 export { getPrefixClassesTransformer, testPrefixClasses } from './transforms/prefix-classes';
 export { getPrefixFunctionsTransformer } from './transforms/prefix-functions';
-export { getScrubFileTransformer, testScrubFile } from './transforms/scrub-file';
+export {
+  getScrubFileTransformer,
+  getScrubFileTransformerForCore,
+  testScrubFile,
+} from './transforms/scrub-file';
 export { getWrapEnumsTransformer } from './transforms/wrap-enums';

--- a/packages/angular_devkit/build_optimizer/src/transforms/prefix-classes.ts
+++ b/packages/angular_devkit/build_optimizer/src/transforms/prefix-classes.ts
@@ -11,7 +11,7 @@ import * as ts from 'typescript';
  * @deprecated From 0.9.0
  */
 export function testPrefixClasses(content: string) {
-  const exportVarSetter = /(?:export )?(?:var|const)\s+(\S+)\s*=\s*/;
+  const exportVarSetter = /(?:export )?(?:var|const)\s+(?:\S+)\s*=\s*/;
   const multiLineComment = /\s*(?:\/\*[\s\S]*?\*\/)?\s*/;
   const newLine = /\s*\r?\n\s*/;
 
@@ -22,7 +22,7 @@ export function testPrefixClasses(content: string) {
       /\(/, multiLineComment,
       /\s*function \(\) {/, newLine,
       multiLineComment,
-      /function \1\([^\)]*\) \{/, newLine,
+      /function (?:\S+)\([^\)]*\) \{/, newLine,
     ],
     [
       /^/,
@@ -142,9 +142,6 @@ function isDownleveledClass(node: ts.Node): boolean {
     return false;
   }
 
-  // The variable name should be the class name.
-  const className = variableDeclaration.name.text;
-
   const firstStatement = functionStatements[0];
 
   // find return statement - may not be last statement
@@ -166,7 +163,6 @@ function isDownleveledClass(node: ts.Node): boolean {
     // potential non-extended class or wrapped es2015 class
     return (ts.isFunctionDeclaration(firstStatement) || ts.isClassDeclaration(firstStatement))
            && firstStatement.name !== undefined
-           && firstStatement.name.text === className
            && returnStatement.expression.text === firstStatement.name.text;
   } else if (functionExpression.parameters.length !== 1) {
     return false;
@@ -216,6 +212,5 @@ function isDownleveledClass(node: ts.Node): boolean {
 
   return ts.isFunctionDeclaration(secondStatement)
          && secondStatement.name !== undefined
-         && className.endsWith(secondStatement.name.text)
          && returnStatement.expression.text === secondStatement.name.text;
 }

--- a/packages/angular_devkit/build_optimizer/src/transforms/prefix-classes_spec.ts
+++ b/packages/angular_devkit/build_optimizer/src/transforms/prefix-classes_spec.ts
@@ -173,6 +173,26 @@ describe('prefix-classes', () => {
     expect(tags.oneLine`${transform(input)}`).toEqual(tags.oneLine`${output}`);
   });
 
+  it('prefix TS 2.5 - 2.6 renamed downlevel class', () => {
+    const input = tags.stripIndent`
+      var ComponentFactoryResolver$1 = /** @class */ (function () {
+        function ComponentFactoryResolver$$1() {
+        }
+        return ComponentFactoryResolver$$1;
+      }());
+    `;
+    const output = tags.stripIndent`
+      var ComponentFactoryResolver$1 = /** @class */ /*@__PURE__*/ (function () {
+        function ComponentFactoryResolver$$1() {
+        }
+        return ComponentFactoryResolver$$1;
+      }());
+    `;
+
+    expect(testPrefixClasses(input)).toBeTruthy();
+    expect(tags.oneLine`${transform(input)}`).toEqual(tags.oneLine`${output}`);
+  });
+
   it('prefix TS 2.5 - 2.6 downlevel class with static variable', () => {
     const input = tags.stripIndent`
       var StaticTestCase = /** @class */ (function () {

--- a/packages/angular_devkit/build_optimizer/src/transforms/scrub-file_spec.ts
+++ b/packages/angular_devkit/build_optimizer/src/transforms/scrub-file_spec.ts
@@ -9,11 +9,17 @@
 // tslint:disable-next-line:no-implicit-dependencies
 import { tags } from '@angular-devkit/core';
 import { transformJavascript } from '../helpers/transform-javascript';
-import { getScrubFileTransformer, testScrubFile } from './scrub-file';
+import {
+  getScrubFileTransformer,
+  getScrubFileTransformerForCore,
+  testScrubFile,
+} from './scrub-file';
 
 
 const transform = (content: string) => transformJavascript(
   { content, getTransforms: [getScrubFileTransformer], typeCheck: true }).content;
+const transformCore = (content: string) => transformJavascript(
+  { content, getTransforms: [getScrubFileTransformerForCore], typeCheck: true }).content;
 
 describe('scrub-file', () => {
   const clazz = 'var Clazz = (function () { function Clazz() { } return Clazz; }());';
@@ -288,6 +294,47 @@ describe('scrub-file', () => {
 
       expect(testScrubFile(input)).toBeTruthy();
       expect(tags.oneLine`${transform(input)}`).toEqual(tags.oneLine`${output}`);
+    });
+
+    it('recognizes decorator imports in Angular core', () => {
+      const input = tags.stripIndent`
+        import * as tslib_1 from "tslib";
+        import { Injectable } from './di';
+        var Console = /** @class */ (function () {
+            function Console() {
+            }
+            Console.prototype.log = function (message) {
+                console.log(message);
+            };
+            Console.prototype.warn = function (message) {
+                console.warn(message);
+            };
+            Console = tslib_1.__decorate([
+                Injectable()
+            ], Console);
+            return Console;
+        }());
+        export { Console };
+      `;
+      const output = tags.stripIndent`
+        import * as tslib_1 from "tslib";
+        import { Injectable } from './di';
+        var Console = /** @class */ (function () {
+            function Console() {
+            }
+            Console.prototype.log = function (message) {
+                console.log(message);
+            };
+            Console.prototype.warn = function (message) {
+                console.warn(message);
+            };
+            return Console;
+        }());
+        export { Console };
+      `;
+
+      expect(testScrubFile(input)).toBeTruthy();
+      expect(tags.oneLine`${transformCore(input)}`).toEqual(tags.oneLine`${output}`);
     });
   });
 


### PR DESCRIPTION
fix(@angular-devkit/build-optimizer): prefix renamed classes
Module concatenation may rename classes with the same name. The renaming logic is specific to the bundler so we can't really foresee it.

But the fact remains that the inner function declaration doesn't need to have the same name as the outer one.

---

fix(@angular-devkit/build-optimizer): identify relative imports in angular core

Build optimizer was broken for non-FESM files inside @angular/core because it couldn't identify relative imports were still inside core.

This change adds a known list of angular core files as a default, and also allows passing in a override.