### PR TITLE
fix(@angular/cli): schematics commands should fail on unknown options

### DIFF
--- a/packages/angular/cli/models/schematic-command.ts
+++ b/packages/angular/cli/models/schematic-command.ts
@@ -437,6 +437,15 @@ export abstract class SchematicCommand<
       args = await this.parseArguments(schematicOptions || [], o);
     }
 
+    // ng-add is special because we don't know all possible options at this point
+    if (args['--'] && schematicName !== 'ng-add') {
+      args['--'].forEach(additional => {
+        this.logger.fatal(`Unknown option: '${additional.split(/=/)[0]}'`);
+      });
+
+      return 1;
+    }
+
     const pathOptions = o ? this.setPathOptions(o, workingDir) : {};
     let input = Object.assign(pathOptions, args);
 

--- a/tests/legacy-cli/e2e/tests/commands/unknown-option.ts
+++ b/tests/legacy-cli/e2e/tests/commands/unknown-option.ts
@@ -15,4 +15,13 @@ export default async function() {
     [ 'build', '--notanoption' ],
     /should NOT have additional properties\(notanoption\)./,
   ));
+
+  const ngGenerateArgs = [ 'generate', 'component', 'component-name', '--notanoption' ];
+  await expectToFail(() => ng(...ngGenerateArgs));
+
+  await execAndWaitForOutputToMatch(
+    'ng',
+    ngGenerateArgs,
+    /Unknown option: '--notanoption'/,
+  );
 }


### PR DESCRIPTION
When an addition argument is parsed the schematic commands should fail with an error.

Fixes #12549