### PR TITLE
fix(@schematics/angular): add non deprecated `style` as default

### DIFF
--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -172,7 +172,7 @@ function addAppToWorkspaceFile(options: ApplicationOptions, workspace: Workspace
       (schematics['@schematics/angular:component'] as JsonObject).inlineStyle = true;
     }
     if (options.style && options.style !== Style.Css) {
-      (schematics['@schematics/angular:component'] as JsonObject).styleext = options.style;
+      (schematics['@schematics/angular:component'] as JsonObject).style = options.style;
     }
   }
 


### PR DESCRIPTION
When adding default in the application schematics we should use the non deprecated `style` option.

Originally reported in https://github.com/angular/angular-cli/issues/12784#issuecomment-452486436