### PR TITLE
fix(@schematics/angular): e2e test fails strict TS config

### DIFF
--- a/packages/schematics/angular/e2e/files/src/app.e2e-spec.ts.template
+++ b/packages/schematics/angular/e2e/files/src/app.e2e-spec.ts.template
@@ -18,6 +18,6 @@ describe('workspace-project App', () => {
     const logs = await browser.manage().logs().get(logging.Type.BROWSER);
     expect(logs).not.toContain(jasmine.objectContaining({
       level: logging.Level.SEVERE,
-    }));
+    } as logging.Entry));
   });
 });


### PR DESCRIPTION
If using `strictFunctionTypes: true` in `tsconfig.json`, the default e2e test introduced in `7.3.0-beta.0` is failing compilation with:

```
error TS2345: Argument of type 'ObjectContaining<{ level: Level; }>' is not assignable to parameter of type 'Expected<Entry>'.
  Type 'ObjectContaining<{ level: Level; }>' is not assignable to type 'ObjectContaining<Entry>'.
    Type 'Partial<{ level: Level; }>' is not assignable to type 'Partial<Entry>'.
     Type '{ level: Level; }' is not assignable to type 'Entry'.
```

Explictely using `as logging.Entry` fixes the issue.