### PR TITLE
feat(@angular-devkit/build-optimizer): add support for es2015 enums e…

### DIFF
--- a/packages/angular_devkit/build_optimizer/src/transforms/wrap-enums.ts
+++ b/packages/angular_devkit/build_optimizer/src/transforms/wrap-enums.ts
@@ -120,6 +120,14 @@ function visitBlockStatements(
         } else if (ts.isObjectLiteralExpression(variableDeclaration.initializer)
           && variableDeclaration.initializer.properties.length !== 0) {
           const literalPropertyCount = variableDeclaration.initializer.properties.length;
+
+          // tsickle es2015 enums first statement is an export declaration
+          const isPotentialEnumExport = ts.isExportDeclaration(statements[oIndex + 1]);
+          if (isPotentialEnumExport) {
+            // skip the export
+            oIndex ++;
+          }
+
           const enumStatements = findEnumNameStatements(name, statements, oIndex + 1);
           if (enumStatements.length === literalPropertyCount) {
             // found an enum
@@ -127,11 +135,13 @@ function visitBlockStatements(
               updatedStatements = statements.slice();
             }
             // create wrapper and replace variable statement and enum member statements
-            updatedStatements.splice(uIndex, enumStatements.length + 1, createWrappedEnum(
+            const deleteCount = enumStatements.length + (isPotentialEnumExport ? 2 : 1);
+            updatedStatements.splice(uIndex, deleteCount, createWrappedEnum(
               name,
               currentStatement,
               enumStatements,
               variableDeclaration.initializer,
+              isPotentialEnumExport,
             ));
             // skip enum member declarations
             oIndex += enumStatements.length;
@@ -475,8 +485,18 @@ function createWrappedEnum(
   hostNode: ts.VariableStatement,
   statements: Array<ts.Statement>,
   literalInitializer: ts.ObjectLiteralExpression | undefined,
+  addExportModifier = false,
 ): ts.Statement {
   literalInitializer = literalInitializer || ts.createObjectLiteral();
+
+  const node = addExportModifier
+    ? ts.updateVariableStatement(
+      hostNode,
+      [ts.createToken(ts.SyntaxKind.ExportKeyword)],
+      hostNode.declarationList,
+    )
+    : hostNode;
+
   const innerVarStmt = ts.createVariableStatement(
     undefined,
     ts.createVariableDeclarationList([
@@ -492,5 +512,5 @@ function createWrappedEnum(
     innerReturn,
   ]);
 
-  return updateHostNode(hostNode, addPureComment(ts.createParen(iife)));
+  return updateHostNode(node, addPureComment(ts.createParen(iife)));
 }

--- a/packages/angular_devkit/build_optimizer/src/transforms/wrap-enums_spec.ts
+++ b/packages/angular_devkit/build_optimizer/src/transforms/wrap-enums_spec.ts
@@ -38,6 +38,64 @@ describe('wrap-enums', () => {
     expect(tags.oneLine`${transform(input)}`).toEqual(tags.oneLine`${output}`);
   });
 
+  it('wraps ES2015 tsickle enums in IIFE', () => {
+    const input = tags.stripIndent`
+      const ChangeDetectionStrategy = {
+          OnPush: 0,
+          Default: 1,
+      };
+      export { ChangeDetectionStrategy };
+      ChangeDetectionStrategy[ChangeDetectionStrategy.OnPush] = 'OnPush';
+      ChangeDetectionStrategy[ChangeDetectionStrategy.Default] = 'Default';
+    `;
+
+    const output = tags.stripIndent`
+      export const ChangeDetectionStrategy = /*@__PURE__*/ (function () {
+          var ChangeDetectionStrategy = { OnPush: 0, Default: 1, };
+
+          ChangeDetectionStrategy[ChangeDetectionStrategy.OnPush] = 'OnPush';
+          ChangeDetectionStrategy[ChangeDetectionStrategy.Default] = 'Default';
+          return ChangeDetectionStrategy;
+      }());
+    `;
+
+    expect(tags.oneLine`${transform(input)}`).toEqual(tags.oneLine`${output}`);
+  });
+
+  it('wraps only ES2015 tsickle enums in IIFE', () => {
+    const input = tags.stripIndent`
+      const RendererStyleFlags3 = {
+          Important: 1,
+          DashCase: 2,
+      };
+      export { RendererStyleFlags3 };
+      RendererStyleFlags3[RendererStyleFlags3.Important] = 'Important';
+      RendererStyleFlags3[RendererStyleFlags3.DashCase] = 'DashCase';
+
+      export const domRendererFactory3 = {
+          createRenderer: (hostElement, rendererType) => { return document; }
+      };
+
+      export const unusedValueExportToPlacateAjd = 1;
+    `;
+    const output = tags.stripIndent`
+      export const RendererStyleFlags3 = /*@__PURE__*/ (function () {
+        var RendererStyleFlags3 = { Important: 1, DashCase: 2, };
+        RendererStyleFlags3[RendererStyleFlags3.Important] = 'Important';
+        RendererStyleFlags3[RendererStyleFlags3.DashCase] = 'DashCase';
+        return RendererStyleFlags3;
+      }());
+
+      export const domRendererFactory3 = {
+        createRenderer: (hostElement, rendererType) => { return document; }
+      };
+
+      export const unusedValueExportToPlacateAjd = 1;
+    `;
+
+    expect(tags.oneLine`${transform(input)}`).toEqual(tags.oneLine`${output}`);
+  });
+
   it('wraps ts >2.3 enums in IIFE', () => {
     const input = tags.stripIndent`
       export var ChangeDetectionStrategy;


### PR DESCRIPTION
…mitted by tsickle

tsickle emits es2015 enums with an object literal followed by an export declaration

Example:
```
      const RendererStyleFlags3 = {
          Important: 1,
          DashCase: 2,
      };
      export { RendererStyleFlags3 };
      RendererStyleFlags3[RendererStyleFlags3.Important] = 'Important';
      RendererStyleFlags3[RendererStyleFlags3.DashCase] = 'DashCase';
```

This PR adds support for the enums to be optimized by wrapping them in an iife and marks them as pure.

Fixes #13488