### PR TITLE
feat(@angular-devkit/build-optimizer): also fold ES2015 classes

### DIFF
--- a/packages/angular_devkit/build_optimizer/src/transforms/class-fold_spec.ts
+++ b/packages/angular_devkit/build_optimizer/src/transforms/class-fold_spec.ts
@@ -15,33 +15,80 @@ const transform = (content: string) => transformJavascript(
   { content, getTransforms: [getFoldFileTransformer], typeCheck: true }).content;
 
 describe('class-fold', () => {
-  it('folds static properties into class', () => {
-    const staticProperty = 'Clazz.prop = 1;';
-    const input = tags.stripIndent`
+  describe('es5', () => {
+    it('folds static properties into class', () => {
+      const staticProperty = 'Clazz.prop = 1;';
+      const input = tags.stripIndent`
       var Clazz = (function () { function Clazz() { } return Clazz; }());
       ${staticProperty}
     `;
-    const output = tags.stripIndent`
+      const output = tags.stripIndent`
       var Clazz = (function () { function Clazz() { }
       ${staticProperty} return Clazz; }());
     `;
 
-    expect(tags.oneLine`${transform(input)}`).toEqual(tags.oneLine`${output}`);
-  });
+      expect(tags.oneLine`${transform(input)}`).toEqual(tags.oneLine`${output}`);
+    });
 
-  it('folds multiple static properties into class', () => {
-    const staticProperty = 'Clazz.prop = 1;';
-    const anotherStaticProperty = 'Clazz.anotherProp = 2;';
-    const input = tags.stripIndent`
+    it('folds multiple static properties into class', () => {
+      const staticProperty = 'Clazz.prop = 1;';
+      const anotherStaticProperty = 'Clazz.anotherProp = 2;';
+      const input = tags.stripIndent`
       var Clazz = (function () { function Clazz() { } return Clazz; }());
       ${staticProperty}
       ${anotherStaticProperty}
     `;
-    const output = tags.stripIndent`
+      const output = tags.stripIndent`
       var Clazz = (function () { function Clazz() { }
       ${staticProperty} ${anotherStaticProperty} return Clazz; }());
     `;
 
-    expect(tags.oneLine`${transform(input)}`).toEqual(tags.oneLine`${output}`);
+      expect(tags.oneLine`${transform(input)}`).toEqual(tags.oneLine`${output}`);
+    });
+  });
+
+  describe('es2015', () => {
+    it('folds static properties in IIFE', () => {
+      const input = tags.stripIndent`
+      export class TemplateRef { }
+      TemplateRef.__NG_ELEMENT_ID__ = () => SWITCH_TEMPLATE_REF_FACTORY(TemplateRef, ElementRef);
+    `;
+      const output = tags.stripIndent`
+      export const TemplateRef = /*@__PURE__*/ function () {
+        class TemplateRef { }
+        TemplateRef.__NG_ELEMENT_ID__ = () => SWITCH_TEMPLATE_REF_FACTORY(TemplateRef, ElementRef);
+        return TemplateRef;
+      }();
+    `;
+
+      expect(tags.oneLine`${transform(input)}`).toEqual(tags.oneLine`${output}`);
+    });
+
+    it('folds multiple static properties into class', () => {
+      const input = tags.stripIndent`
+      export class TemplateRef { }
+      TemplateRef.__NG_ELEMENT_ID__ = () => SWITCH_TEMPLATE_REF_FACTORY(TemplateRef, ElementRef);
+      TemplateRef.somethingElse = true;
+    `;
+      const output = tags.stripIndent`
+      export const TemplateRef = /*@__PURE__*/ function () {
+        class TemplateRef {
+        }
+        TemplateRef.__NG_ELEMENT_ID__ = () => SWITCH_TEMPLATE_REF_FACTORY(TemplateRef, ElementRef);
+        TemplateRef.somethingElse = true;
+        return TemplateRef;
+      }();
+    `;
+
+      expect(tags.oneLine`${transform(input)}`).toEqual(tags.oneLine`${output}`);
+    });
+
+    it(`doesn't wrap classes without static properties in IIFE`, () => {
+      const input = tags.stripIndent`
+        export class TemplateRef { }
+      `;
+
+      expect(tags.oneLine`${transform(input)}`).toEqual(tags.oneLine`${input}`);
+    });
   });
 });


### PR DESCRIPTION
Although ES5 classes had their static properties folded in, ES2015 ones did not.

This PR adds that new functionality.

It should also make this particular transform a bit faster since it will stop early.

Fix https://github.com/angular/angular-cli/issues/13487