### PR TITLE
docs: fix typo in index.html

### DIFF
--- a/etc/cli.angular.io/index.html
+++ b/etc/cli.angular.io/index.html
@@ -102,7 +102,7 @@
 
     <div class="features-list">
         <h4>Test, Lint, Format</h4>
-        <p>Make your code really shine. Run your unittests or your end-to-end tests with the breeze of a command. Execute the official Angular linter and run clang format.</p>
+        <p>Make your code really shine. Run your unit tests or your end-to-end tests with the breeze of a command. Execute the official Angular linter and run clang format.</p>
     </div>
 
 


### PR DESCRIPTION
Fix "unittest" typo in index.html