### PR TITLE
fix(@angular-devkit/core): remove colors for info messages

### DIFF
--- a/packages/angular_devkit/benchmark/src/main.ts
+++ b/packages/angular_devkit/benchmark/src/main.ts
@@ -98,10 +98,11 @@ export async function main({
       let output = stdout;
       switch (entry.level) {
         case 'info':
-          color = terminal.white;
+          color = s => s;
           break;
         case 'warn':
           color = terminal.yellow;
+          output = stderr;
           break;
         case 'error':
           color = terminal.red;

--- a/packages/angular_devkit/core/node/cli-logger.ts
+++ b/packages/angular_devkit/core/node/cli-logger.ts
@@ -29,7 +29,7 @@ export function createConsoleLogger(
       let output = stdout;
       switch (entry.level) {
         case 'info':
-          color = terminal.reset;
+          color = s => s;
           break;
         case 'warn':
           color = (s: string) => terminal.bold(terminal.yellow(s));


### PR DESCRIPTION
Rely on the terminal to provide the color for info messages

fixes #13497