### PR TITLE
fix(@schematics/angular): Add types annotations to e2e AppPage

### DIFF
--- a/packages/schematics/angular/e2e/files/src/app.po.ts
+++ b/packages/schematics/angular/e2e/files/src/app.po.ts
@@ -2,10 +2,10 @@ import { browser, by, element } from 'protractor';
 
 export class AppPage {
   navigateTo() {
-    return browser.get('/');
+    return browser.get('/') as Promise<any>;
   }
 
   getTitleText() {
-    return element(by.css('<%= rootSelector %> h1')).getText();
+    return element(by.css('<%= rootSelector %> h1')).getText() as Promise<string>;
   }
 }


### PR DESCRIPTION
This is a cherry-pick of dc2e40a100040ad3ff4265a9bc7303fde3d3a800
Original PR: https://github.com/angular/angular-cli/pull/13406

When app.po.ts is compiled under Bazel with Typescript 3.2,
AppPage produces the following error:

e2e/src/app.po.ts:4:3 - error TS2742: The inferred type of 'navigateTo' cannot be named without a reference to '../../external/npm/node_modules/@types/selenium-webdriver/index'. This is likely not portable. A type annotation is necessary.

4 navigateTo() {
~~~~~~~~~~
e2e/src/app.po.ts:8:3 - error TS2742: The inferred type of 'getTitleText' cannot be named without a reference to '../../external/npm/node_modules/@types/selenium-webdriver/index'. This is likely not portable. A type annotation is necessary.

8 getTitleText() {
~~~~~~~~~~~~