### PR TITLE
docs: remove non existing format command

### DIFF
--- a/etc/cli.angular.io/index.html
+++ b/etc/cli.angular.io/index.html
@@ -101,8 +101,8 @@
     </div>
 
     <div class="features-list">
-        <h4>Test, Lint, Format</h4>
-        <p>Make your code really shine. Run your unit tests or your end-to-end tests with the breeze of a command. Execute the official Angular linter and run clang format.</p>
+        <h4>Test, Lint</h4>
+        <p>Make your code really shine. Run your unit tests, your end-to-end tests, or execute the official Angular linter with the breeze of a command.</p>
     </div>
 
 


### PR DESCRIPTION
This dc page has been mentionning clang format for a long time but this is not available out of the box.