### PR TITLE
fix(@schematics/angular): update latest version of devkit

### DIFF
--- a/packages/schematics/angular/utility/latest-versions.ts
+++ b/packages/schematics/angular/utility/latest-versions.ts
@@ -14,6 +14,6 @@ export const latestVersions = {
   TypeScript: '~3.2.2',
   TsLib: '^1.9.0',
   // The versions below must be manually updated when making a new devkit release.
-  DevkitBuildAngular: '~0.13.0-beta.0',
-  DevkitBuildNgPackagr: '~0.13.0-beta.0',
+  DevkitBuildAngular: '~0.13.0-rc.0',
+  DevkitBuildNgPackagr: '~0.13.0-rc.0',
 };


### PR DESCRIPTION
Same thing that happened in the `beta.0` relase: devkit has not been updated when releasing `rc.0`.

Installing the CLI `7.3.0-rc.0` brings devkit in version `0.13.0-beta.0`