### PR TITLE
Use baseUrl for default e2e test

### DIFF
--- a/packages/schematics/angular/e2e/files/src/app.po.ts.template
+++ b/packages/schematics/angular/e2e/files/src/app.po.ts.template
@@ -2,7 +2,7 @@ import { browser, by, element } from 'protractor';
 
 export class AppPage {
   navigateTo() {
-    return browser.get('/') as Promise<any>;
+    return browser.get(browser.baseUrl) as Promise<any>;
   }
 
   getTitleText() {

--- a/tests/angular_devkit/build_angular/hello-world-app/e2e/app.po.ts
+++ b/tests/angular_devkit/build_angular/hello-world-app/e2e/app.po.ts
@@ -9,7 +9,7 @@ import { browser, by, element } from 'protractor';
 
 export class AppPage {
   navigateTo() {
-    return browser.get('/');
+    return browser.get(browser.baseUrl);
   }
 
   getTitleText() {


### PR DESCRIPTION
Replace usage of `'/'` for default end-to-end test by `browser.baseUrl` to take into account any accesspath and rely on provided setting.

Notes:

* I have changed `tests/angular_devkit/build_angular/hello-world-app/e2e/app.po.ts` but not sure its required.
* I haven't touched `tests/legacy-cli` as I suppose they are used to check project managed by old `@angular/cli`
* I have tested to generate new project. However, something seems to be already broken on `master` branch as using Sass styling make project fails because `src/styles.sass` file is missing
* I tried `node ./tests/legacy-cli/run_e2e`. However, something seems to be already broken on `master` branch (or my environment) as it fails with:

```
Running `ng "version"`...
CWD: /tmp/angular-cli-e2e-2019025-8745-1lrsyky.w7xd
ENV: undefined
events.js:167
      throw er; // Unhandled 'error' event
      ^

Error: spawn ng ENOENT
    at Process.ChildProcess._handle.onexit (internal/child_process.js:232:19)
    at onErrorNT (internal/child_process.js:407:16)
    at process._tickCallback (internal/process/next_tick.js:63:19)
Emitted 'error' event at:
    at Process.ChildProcess._handle.onexit (internal/child_process.js:238:12)
    at onErrorNT (internal/child_process.js:407:16)
    at process._tickCallback (internal/process/next_tick.js:63:19)
```
