### PR TITLE
fix(@schematics/angular): enable lazy loading with ivy

### DIFF
--- a/packages/schematics/angular/application/files/root/tsconfig.app.json.template
+++ b/packages/schematics/angular/application/files/root/tsconfig.app.json.template
@@ -9,6 +9,7 @@
     "**/*.spec.ts"
   ]<% if (experimentalIvy) { %>,
   "angularCompilerOptions": {
-    "enableIvy": "ngtsc"
+    "enableIvy": "ngtsc",
+    "allowEmptyCodegenFiles": true
   }<% } %>
 }


### PR DESCRIPTION
Angular `8.0.0-beta.1` supports lazy loading with Ivy (at least a partial support), but currently the CLI needs `"allowEmptyCodegenFiles": true` to avoid errors like:

```
ERROR in ./src/$$_lazy_route_resource lazy namespace object
Module not found: Error: Can't resolve '/src/app/races/races.module.ngfactory.js' in '/src/$$_lazy_route_resource'
```

As discussed with @gkalpak this might be a temporary workaround, but it might help users giving a try to Ivy (as the workaround is not really trivial ^^) .