### PR TITLE
fix(@schematics/angular): remove leading comments when removing `core…

### DIFF
--- a/packages/schematics/angular/migrations/update-7/polyfill-metadata.ts
+++ b/packages/schematics/angular/migrations/update-7/polyfill-metadata.ts
@@ -29,18 +29,15 @@ function _removeReflectFromPolyfills(tree: Tree, path: string) {
   const recorder = tree.beginUpdate(path);
 
   const sourceFile = ts.createSourceFile(path, source.toString(), ts.ScriptTarget.Latest);
-  const imports = (
-    sourceFile.statements
-      .filter(s => s.kind === ts.SyntaxKind.ImportDeclaration) as ts.ImportDeclaration[]
-  );
+  const imports = sourceFile.statements
+      .filter(s => s.kind === ts.SyntaxKind.ImportDeclaration) as ts.ImportDeclaration[];
 
   for (const i of imports) {
-    const module = i.moduleSpecifier.kind == ts.SyntaxKind.StringLiteral
-      && (i.moduleSpecifier as ts.StringLiteral).text;
+    const module = ts.isStringLiteral(i.moduleSpecifier) && i.moduleSpecifier.text;
 
     switch (module) {
       case 'core-js/es7/reflect':
-        recorder.remove(i.getStart(sourceFile), i.getWidth(sourceFile));
+        recorder.remove(i.getFullStart(), i.getFullWidth());
         break;
     }
   }

--- a/packages/schematics/angular/migrations/update-7/polyfill-metadata_spec.ts
+++ b/packages/schematics/angular/migrations/update-7/polyfill-metadata_spec.ts
@@ -42,6 +42,34 @@ import 'web-animations-js';  // Run \`npm install --save web-animations-js\`.
 import 'zone.js/dist/zone';  // Included with Angular CLI.
 `;
 
+const newPolyfills = `
+/** IE9, IE10 and IE11 requires all of the following polyfills. **/
+// import 'core-js/es6/symbol';
+// import 'core-js/es6/object';
+import 'core-js/es6/function';
+import 'core-js/es6/parse-int';
+// import 'core-js/es6/parse-float';
+import 'core-js/es6/number';
+// import 'core-js/es6/math';
+// import 'core-js/es6/string';
+import 'core-js/es6/date';
+// import 'core-js/es6/array';
+// import 'core-js/es6/regexp';
+
+/** IE10 and IE11 requires the following for the Reflect API. */
+import 'core-js/es6/reflect';
+
+import 'web-animations-js';  // Run \`npm install --save web-animations-js\`.
+
+ (window as any).__Zone_disable_requestAnimationFrame = true; // disable patch requestAnimationFrame
+ (window as any).__Zone_disable_on_property = true; // disable patch onProperty such as onclick
+
+/***************************************************************************************************
+ * Zone JS is required by default for Angular itself.
+ */
+import 'zone.js/dist/zone';  // Included with Angular CLI.
+`;
+
 
 describe('polyfillMetadataRule', () => {
   const schematicRunner = new SchematicTestRunner(
@@ -84,7 +112,7 @@ describe('polyfillMetadataRule', () => {
     const tree2 = await schematicRunner.runSchematicAsync('migration-03', {}, tree.branch())
       .toPromise();
 
-    expect(tree2.readContent(polyfillPath)).not.toMatch(/import .*es7.*reflect.*;/);
+    expect(tree2.readContent(polyfillPath)).toBe(newPolyfills);
   });
 
   it('should work as expected for a project with a root', async () => {
@@ -96,6 +124,6 @@ describe('polyfillMetadataRule', () => {
     const tree2 = await schematicRunner.runSchematicAsync('migration-03', {}, tree.branch())
       .toPromise();
 
-    expect(tree2.readContent(polyfillPath)).not.toMatch(/import .*es7.*reflect.*;/);
+    expect(tree2.readContent(polyfillPath)).toBe(newPolyfills);
   });
 });


### PR DESCRIPTION
…-js/es7/reflect`

Fixes #13491