### PR TITLE
fix(@ngtools/webpack): provide a TS-like path to ngProgram.listLazyRo…

### DIFF
--- a/packages/ngtools/webpack/src/angular_compiler_plugin.ts
+++ b/packages/ngtools/webpack/src/angular_compiler_plugin.ts
@@ -454,7 +454,7 @@ export class AngularCompilerPlugin {
       });
       timeEnd('AngularCompilerPlugin._listLazyRoutesFromProgram.createProgram');
 
-      entryRoute = this.entryModule.path + '#' + this.entryModule.className;
+      entryRoute = workaroundResolve(this.entryModule.path) + '#' + this.entryModule.className;
     } else {
       ngProgram = this._program as Program;
     }


### PR DESCRIPTION
…utes

The webpack plugin was leaking our internal Path abstraction to the Angular compiler via the `ngProgram.listLazyRoutes` call.

This Path abstraction is provided by `@angular-devkit/core` and shouldn't leak. Instead a TS-like path should be provided to the Angular program.

Fix #13531 