### PR TITLE
feat(@schematics/angular): renove `annotateForClosureCompiler` in libraries tsconfig

### DIFF
--- a/packages/schematics/angular/library/files/__projectRoot__/tsconfig.lib.json.template
+++ b/packages/schematics/angular/library/files/__projectRoot__/tsconfig.lib.json.template
@@ -18,7 +18,6 @@
     ]
   },
   "angularCompilerOptions": {
-    "annotateForClosureCompiler": true,
     "skipTemplateCodegen": true,
     "strictMetadataEmit": true,
     "fullTemplateTypeCheck": true,

--- a/tests/angular_devkit/build_ng_packagr/ng-packaged/projects/lib/tsconfig.lib.json
+++ b/tests/angular_devkit/build_ng_packagr/ng-packaged/projects/lib/tsconfig.lib.json
@@ -16,7 +16,6 @@
     ]
   },
   "angularCompilerOptions": {
-    "annotateForClosureCompiler": true,
     "skipTemplateCodegen": true,
     "strictMetadataEmit": true,
     "fullTemplateTypeCheck": true,


### PR DESCRIPTION
Users outside of Google don't usually need closure annotations.

We should also follow up with ng-packagr so that tsickle is not required as a peerDependency and afterwards, we be able to remove tsickle as a dependency when generating.

//cc @alexeagle and @vikerman 
