### PR TITLE
fix(@angular-devkit/build-angular): remove deprecated `istanbul` from…

### DIFF
--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -18,7 +18,6 @@
     "copy-webpack-plugin": "4.6.0",
     "file-loader": "3.0.1",
     "glob": "7.1.3",
-    "istanbul": "0.4.5",
     "istanbul-instrumenter-loader": "3.0.1",
     "karma-source-map-support": "1.3.0",
     "less": "3.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5339,7 +5339,7 @@ istanbul-reports@^2.0.1:
   dependencies:
     handlebars "^4.0.11"
 
-istanbul@0.4.5, istanbul@^0.4.5:
+istanbul@^0.4.5:
   version "0.4.5"
   resolved "https://registry.yarnpkg.com/istanbul/-/istanbul-0.4.5.tgz#65c7d73d4c4da84d4f3ac310b918fb0b8033733b"
   integrity sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=


### PR DESCRIPTION
… dependencies

It also seems this package was unused

Fix #13562