### PR TITLE
fix(@angular-devkit/build-angular): use sourcemap object in karma plugin

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/karma.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/karma.ts
@@ -18,6 +18,7 @@ import { statsErrorsToString } from '../utilities/stats';
 import { getWebpackStatsConfig } from '../models/webpack-configs/stats';
 import { createConsoleLogger } from '@angular-devkit/core/node';
 import { logging } from '@angular-devkit/core';
+import { WebpackTestOptions } from '../models/build-options';
 
 /**
  * Enumerate needed (but not require/imported) dependencies from this file
@@ -63,7 +64,7 @@ const init: any = (config: any, emitter: any, customFileHandlers: any) => {
     ` be used from within Angular CLI and will not work correctly outside of it.`
     )
   }
-  const options = config.buildWebpack.options;
+  const options = config.buildWebpack.options as WebpackTestOptions;
   const logger: logging.Logger = config.buildWebpack.logger || createConsoleLogger();
   successCb = config.buildWebpack.successCb;
   failureCb = config.buildWebpack.failureCb;
@@ -77,7 +78,7 @@ const init: any = (config: any, emitter: any, customFileHandlers: any) => {
   }
 
   // Add a reporter that fixes sourcemap urls.
-  if (options.sourceMap) {
+  if (options.sourceMap.scripts) {
     config.reporters.unshift('@angular-devkit/build-angular--sourcemap-reporter');
 
     // Code taken from https://github.com/tschaub/karma-source-map-support.


### PR DESCRIPTION
Followup to https://github.com/angular/angular-cli/pull/13062

Fix https://github.com/angular/angular-cli/issues/13580