### PR TITLE
fix(@schematics/angular): use `scss` file extension instead of `sass` for `styles.scss`

### DIFF
--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -205,7 +205,7 @@ function addAppToWorkspaceFile(options: ApplicationOptions, workspace: Workspace
             join(normalize(projectRoot), 'src', 'assets'),
           ],
           styles: [
-            `${projectRoot}src/styles.${options.style}`,
+            `${projectRoot}src/styles.${styleToFileExtention(options.style)}`,
           ],
           scripts: [],
           es5BrowserSupport: true,
@@ -258,7 +258,7 @@ function addAppToWorkspaceFile(options: ApplicationOptions, workspace: Workspace
           tsConfig: `${rootFilesRoot}tsconfig.spec.json`,
           karmaConfig: `${rootFilesRoot}karma.conf.js`,
           styles: [
-            `${projectRoot}src/styles.${options.style}`,
+            `${projectRoot}src/styles.${styleToFileExtention(options.style)}`,
           ],
           scripts: [],
           assets: [

--- a/packages/schematics/angular/application/index_spec.ts
+++ b/packages/schematics/angular/application/index_spec.ts
@@ -295,5 +295,17 @@ describe('Application Schematic', () => {
       expect(content.rules['directive-selector'][2]).toMatch('app');
       expect(content.rules['component-selector'][2]).toMatch('app');
     });
+
+    it('should use `scss` file extension instead of `sass` for `styles.scss`', () => {
+      const options = { ...defaultOptions, style: 'sass' };
+
+      const tree = schematicRunner.runSchematic('application', options, workspaceTree);
+      const config = JSON.parse(tree.readContent('/angular.json'));
+      const project = config.projects.foo;
+      const projectArchitect = config.projects.foo.architect;
+      expect(projectArchitect.build.options.styles).toEqual(['projects/foo/src/styles.scss']);
+      expect(projectArchitect.test.options.styles).toEqual(['projects/foo/src/styles.scss']);
+    });
+
   });
 });


### PR DESCRIPTION
When using `ng new --style=sass`, `ng-new` schematic generates a `styles.scss` file but in `build` and `test` architects in `angular.json` references `src/styles.sass`.

This fix solves the mismatch issue for users generating an application with `style` option set to `sass`.