### PR TITLE
docs: link to angular.io/cli instead of old wiki

### DIFF
--- a/etc/cli.angular.io/index.html
+++ b/etc/cli.angular.io/index.html
@@ -33,7 +33,7 @@
         <label for="site-nav-checkbox">SITE MENU</label>
         <nav class="mdl-navigation">
 
-            <a class="mdl-navigation__link" href="https://github.com/angular/angular-cli/wiki">Documentation</a>
+            <a class="mdl-navigation__link" href="https://angular.io/cli">Documentation</a>
 
             <a class="mdl-navigation__link" href="https://github.com/angular/angular-cli">GitHub</a>
 
@@ -41,7 +41,7 @@
         <div class="mdl-layout-spacer"></div>
         <nav class="mdl-navigation">
             <a class="mdl-navigation__link" href="https://github.com/angular/angular-cli/releases"> Releases </a>
-            <a class="mdl-navigation__link" href="https://github.com/angular/angular-cli/wiki"> Get Started </a>
+            <a class="mdl-navigation__link" href="https://angular.io/cli"> Get Started </a>
         </nav>
     </div>
     </div>
@@ -72,7 +72,7 @@
         <div class="mdl-cell mdl-cell--6-col-desktop mdl-cell--12-col-tablet mdl-cell--12-col-phone">
             <h4 class="">Angular CLI</h4>
             <h5 class="tagline">A command line interface for Angular</h5>
-            <a href="https://github.com/angular/angular-cli/wiki" class="mdl-typography--font-regular cta mdl-button mdl-button--raised mdl-button--primary">
+            <a href="https://angular.io/cli" class="mdl-typography--font-regular cta mdl-button mdl-button--raised mdl-button--primary">
                 Get Started
             </a>
         </div>
@@ -107,7 +107,7 @@
 
 
     <div class="button-container mdl-cell mdl-cell--12-col-desktop center">
-        <a href="https://github.com/angular/angular-cli/wiki" class="cta-button mdl-typography--font-regular mdl-button mdl-button--raised mdl-button--accent">
+        <a href="https://angular.io/cli" class="cta-button mdl-typography--font-regular mdl-button mdl-button--raised mdl-button--accent">
             Get Started
         </a>
     </div>


### PR DESCRIPTION
The page on cli.angular.io still link to the old wiki instead of the new docs.