### PR TITLE
fix(@schematics/angular): use correct file extension for SASS (.scss)

### DIFF
--- a/packages/schematics/angular/ng-new/schema.json
+++ b/packages/schematics/angular/ng-new/schema.json
@@ -126,7 +126,7 @@
         "type": "list",
         "items": [
           { "value": "css", "label": "CSS" },
-          { "value": "sass", "label": "Sass   [ http://sass-lang.com   ]" },
+          { "value": "scss", "label": "Sass   [ http://sass-lang.com   ]" },
           { "value": "less", "label": "Less   [ http://lesscss.org     ]" },
           { "value": "styl", "label": "Stylus [ http://stylus-lang.com ]" }
         ]


### PR DESCRIPTION
The ng new command sets the incorrect file extension for SASS files in the angular.json. The configuration expects styles.sass, whereas it should be styles.scss. This is due to the fact that the pull request that dropped support for creating new angular applicaplications with the .sass extension (#13444) conflicted with the pull request to only support known style extensions (#13470).

This pull request changes the referenced extension for the sass language to the correct '.scss' ending.

closes #13574