### PR TITLE
fix(@angular/cli): Add an error message when we call `ng doc` without…

### DIFF
--- a/packages/angular/cli/commands/doc-impl.ts
+++ b/packages/angular/cli/commands/doc-impl.ts
@@ -14,6 +14,11 @@ const opn = require('opn');
 
 export class DocCommand extends Command<DocCommandSchema> {
   public async run(options: DocCommandSchema & Arguments) {
+    if (!options.keyword) {
+      this.logger.error('You should specify a keyword, for instance, `ng doc ActivatedRoute`.');
+
+      return 0;
+    }
     let searchUrl = `https://angular.io/api?query=${options.keyword}`;
     if (options.search) {
       searchUrl = `https://www.google.com/search?q=site%3Aangular.io+${options.keyword}`;


### PR DESCRIPTION
… keyword. Currently, we open a page with the keyword `undefined`.