### PR TITLE
fix(@angular-devkit/build-angular): error when both `baseUrl` and `devServerTarget` are used in protractor

### DIFF
--- a/packages/angular_devkit/build_angular/src/browser/index.ts
+++ b/packages/angular_devkit/build_angular/src/browser/index.ts
@@ -113,7 +113,7 @@ export class BrowserBuilder implements Builder<BrowserBuilderSchema> {
   ) {
     // Ensure Build Optimizer is only used with AOT.
     if (options.buildOptimizer && !options.aot) {
-      throw new Error('The `--build-optimizer` option cannot be used without `--aot`.');
+      throw new Error(`The 'buildOptimizer' option cannot be used without 'aot'.`);
     }
 
     let wco: WebpackConfigOptions<NormalizedBrowserBuilderSchema>;

--- a/packages/angular_devkit/build_angular/src/protractor/index.ts
+++ b/packages/angular_devkit/build_angular/src/protractor/index.ts
@@ -44,7 +44,14 @@ export class ProtractorBuilder implements Builder<ProtractorBuilderOptions> {
     const options = builderConfig.options;
     const root = this.context.workspace.root;
     const projectRoot = resolve(root, builderConfig.root);
-    // const projectSystemRoot = getSystemPath(projectRoot);
+
+    // ensure that either one of this option is used
+    if (options.devServerTarget && options.baseUrl) {
+      throw new Error(tags.stripIndents`
+      The 'baseUrl' option cannot be used with 'devServerTarget'.
+      When present, 'devServerTarget' will be used to automatically setup 'baseUrl' for Protractor.
+      `);
+    }
 
     // TODO: verify using of(null) to kickstart things is a pattern.
     return of(null).pipe(
@@ -81,7 +88,7 @@ export class ProtractorBuilder implements Builder<ProtractorBuilderOptions> {
         }
 
         // Compute baseUrl from devServerOptions.
-        if (options.devServerTarget && builderConfig.options.publicHost) {
+        if (builderConfig.options.publicHost) {
           let publicHost = builderConfig.options.publicHost;
           if (!/^\w+:\/\//.test(publicHost)) {
             publicHost = `${builderConfig.options.ssl
@@ -90,7 +97,7 @@ export class ProtractorBuilder implements Builder<ProtractorBuilderOptions> {
           }
           const clientUrl = url.parse(publicHost);
           baseUrl = url.format(clientUrl);
-        } else if (options.devServerTarget) {
+        } else {
           const result: DevServerResult | undefined = buildEvent.result;
 
           baseUrl = url.format({

--- a/packages/angular_devkit/build_angular/src/protractor/schema.json
+++ b/packages/angular_devkit/build_angular/src/protractor/schema.json
@@ -45,7 +45,8 @@
     },
     "baseUrl": {
       "type": "string",
-      "description": "Base URL for protractor to connect to."
+      "description": "Base URL for protractor to connect to.",
+      "x-deprecated": "Use \"baseUrl\" in the Protractor config file instead."
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
fix(@angular-devkit/build-angular): error when both `baseUrl` and `devServerTarget` are used in protractor

Users cannot use both baseUrl and devServerTarget, and the later superseeds the baseUrl.

Fixes #13611