### PR TITLE
fix(@angular-devkit/build-angular): remove unneeded script element type

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/index-html-webpack-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/index-html-webpack-plugin.ts
@@ -154,7 +154,6 @@ export class IndexHtmlWebpackPlugin {
       let scriptElements = '';
       for (const script of scripts) {
         const attrs: { name: string, value: string | null }[] = [
-          { name: 'type', value: 'text/javascript' },
           { name: 'src', value: (this._options.deployUrl || '') + script },
         ];
 

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/karma-context.html
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/karma-context.html
@@ -27,14 +27,14 @@ Reloaded before every execution run.
     // All served files with the latest timestamps
     %MAPPINGS%
   </script>
-  <script type="text/javascript" src="_karma_webpack_/runtime.js" crossorigin="anonymous"></script>
-  <script type="text/javascript" src="_karma_webpack_/polyfills.js" crossorigin="anonymous"></script>
+  <script src="_karma_webpack_/runtime.js" crossorigin="anonymous"></script>
+  <script src="_karma_webpack_/polyfills.js" crossorigin="anonymous"></script>
   <!-- Dynamically replaced with <script> tags -->
   %SCRIPTS%
-  <script type="text/javascript" src="_karma_webpack_/styles.js" crossorigin="anonymous"></script>
-  <script type="text/javascript" src="_karma_webpack_/scripts.js" crossorigin="anonymous"></script>
-  <script type="text/javascript" src="_karma_webpack_/vendor.js" crossorigin="anonymous"></script>
-  <script type="text/javascript" src="_karma_webpack_/main.js" crossorigin="anonymous"></script>
+  <script src="_karma_webpack_/styles.js" crossorigin="anonymous"></script>
+  <script src="_karma_webpack_/scripts.js" crossorigin="anonymous"></script>
+  <script src="_karma_webpack_/vendor.js" crossorigin="anonymous"></script>
+  <script src="_karma_webpack_/main.js" crossorigin="anonymous"></script>
   <script type="text/javascript">
       window.__karma__.loaded();
   </script>

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/karma-debug.html
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/karma-debug.html
@@ -28,14 +28,14 @@ just for immediate execution, without reporting to Karma server.
     // All served files with the latest timestamps
     %MAPPINGS%
   </script>
-  <script type="text/javascript" src="_karma_webpack_/runtime.js" crossorigin="anonymous"></script>
-  <script type="text/javascript" src="_karma_webpack_/polyfills.js" crossorigin="anonymous"></script>
+  <script src="_karma_webpack_/runtime.js" crossorigin="anonymous"></script>
+  <script src="_karma_webpack_/polyfills.js" crossorigin="anonymous"></script>
   <!-- Dynamically replaced with <script> tags -->
   %SCRIPTS%
-  <script type="text/javascript" src="_karma_webpack_/styles.js" crossorigin="anonymous"></script>
-  <script type="text/javascript" src="_karma_webpack_/scripts.js" crossorigin="anonymous"></script>
-  <script type="text/javascript" src="_karma_webpack_/vendor.js" crossorigin="anonymous"></script>
-  <script type="text/javascript" src="_karma_webpack_/main.js" crossorigin="anonymous"></script>
+  <script src="_karma_webpack_/styles.js" crossorigin="anonymous"></script>
+  <script src="_karma_webpack_/scripts.js" crossorigin="anonymous"></script>
+  <script src="_karma_webpack_/vendor.js" crossorigin="anonymous"></script>
+  <script src="_karma_webpack_/main.js" crossorigin="anonymous"></script>
   <script type="text/javascript">
       window.__karma__.loaded();
   </script>

--- a/packages/angular_devkit/build_angular/test/browser/index_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/browser/index_spec_large.ts
@@ -31,7 +31,7 @@ describe('Browser Builder works with BOM index.html', () => {
         const fileName = join(outputPath, 'index.html');
         const content = virtualFs.fileBufferToString(host.scopedSync().read(normalize(fileName)));
         // tslint:disable-next-line:max-line-length
-        expect(content).toBe(`<html><head><base href="/"></head><body><app-root></app-root><script type="text/javascript" src="runtime.js"></script><script type="text/javascript" src="polyfills.js"></script><script type="text/javascript" src="styles.js"></script><script type="text/javascript" src="vendor.js"></script><script type="text/javascript" src="main.js"></script></body></html>`);
+        expect(content).toBe(`<html><head><base href="/"></head><body><app-root></app-root><script src="runtime.js"></script><script src="polyfills.js"></script><script src="styles.js"></script><script src="vendor.js"></script><script src="main.js"></script></body></html>`);
       }),
     ).toPromise().then(done, done.fail);
   });
@@ -49,7 +49,7 @@ describe('Browser Builder works with BOM index.html', () => {
         const fileName = join(outputPath, 'index.html');
         const content = virtualFs.fileBufferToString(host.scopedSync().read(normalize(fileName)));
         // tslint:disable-next-line:max-line-length
-        expect(content).toBe(`<html><head><base href="/"></head><body><app-root></app-root><script type="text/javascript" src="runtime.js"></script><script type="text/javascript" src="polyfills.js"></script><script type="text/javascript" src="styles.js"></script><script type="text/javascript" src="vendor.js"></script><script type="text/javascript" src="main.js"></script></body></html>`);
+        expect(content).toBe(`<html><head><base href="/"></head><body><app-root></app-root><script src="runtime.js"></script><script src="polyfills.js"></script><script src="styles.js"></script><script src="vendor.js"></script><script src="main.js"></script></body></html>`);
       }),
     ).toPromise().then(done, done.fail);
   });
@@ -68,7 +68,7 @@ describe('Browser Builder works with BOM index.html', () => {
         const fileName = join(outputPath, 'index.html');
         const content = virtualFs.fileBufferToString(host.scopedSync().read(normalize(fileName)));
         // tslint:disable-next-line:max-line-length
-        expect(content).toBe(`<html><head><title>&iacute;</title><base href="/"></head> <body><app-root></app-root><script type="text/javascript" src="runtime.js"></script><script type="text/javascript" src="polyfills.js"></script><script type="text/javascript" src="styles.js"></script><script type="text/javascript" src="vendor.js"></script><script type="text/javascript" src="main.js"></script></body></html>`);
+        expect(content).toBe(`<html><head><title>&iacute;</title><base href="/"></head> <body><app-root></app-root><script src="runtime.js"></script><script src="polyfills.js"></script><script src="styles.js"></script><script src="vendor.js"></script><script src="main.js"></script></body></html>`);
       }),
     ).toPromise().then(done, done.fail);
   });
@@ -87,7 +87,7 @@ describe('Browser Builder works with BOM index.html', () => {
         const fileName = join(outputPath, 'index.html');
         const content = virtualFs.fileBufferToString(host.scopedSync().read(normalize(fileName)));
         // tslint:disable-next-line:max-line-length
-        expect(content).toBe(`<html><head><base href="/"><%= csrf_meta_tags %></head> <body><app-root></app-root><script type="text/javascript" src="runtime.js"></script><script type="text/javascript" src="polyfills.js"></script><script type="text/javascript" src="styles.js"></script><script type="text/javascript" src="vendor.js"></script><script type="text/javascript" src="main.js"></script></body></html>`);
+        expect(content).toBe(`<html><head><base href="/"><%= csrf_meta_tags %></head> <body><app-root></app-root><script src="runtime.js"></script><script src="polyfills.js"></script><script src="styles.js"></script><script src="vendor.js"></script><script src="main.js"></script></body></html>`);
       }),
     ).toPromise().then(done, done.fail);
   });

--- a/packages/angular_devkit/build_angular/test/browser/scripts-array_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/browser/scripts-array_spec_large.ts
@@ -50,12 +50,12 @@ describe('Browser Builder scripts array', () => {
       './dist/renamed-script.js': 'pre-rename-script',
       './dist/renamed-lazy-script.js': 'pre-rename-lazy-script',
       './dist/main.js': 'input-script',
-      './dist/index.html': '<script type="text/javascript" src="runtime.js"></script>'
-        + '<script type="text/javascript" src="polyfills.js"></script>'
-        + '<script type="text/javascript" src="scripts.js"></script>'
-        + '<script type="text/javascript" src="renamed-script.js"></script>'
-        + '<script type="text/javascript" src="vendor.js"></script>'
-        + '<script type="text/javascript" src="main.js"></script>',
+      './dist/index.html': '<script src="runtime.js"></script>'
+        + '<script src="polyfills.js"></script>'
+        + '<script src="scripts.js"></script>'
+        + '<script src="renamed-script.js"></script>'
+        + '<script src="vendor.js"></script>'
+        + '<script src="main.js"></script>',
     };
 
     host.writeMultipleFiles(scripts);

--- a/packages/angular_devkit/build_angular/test/browser/service-worker_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/browser/service-worker_spec_large.ts
@@ -105,7 +105,7 @@ describe('Browser Builder service worker', () => {
           hashTable: {
             '/favicon.ico': '84161b857f5c547e3699ddfbffc6d8d737542e01',
             '/assets/folder-asset.txt': '617f202968a6a81050aa617c2e28e1dca11ce8d4',
-            '/index.html': '843c96f0aeadc8f093b1b2203c08891ecd8f7425',
+            '/index.html': '1bcafd53046ffb270ac5e6f3cab23e0442f95c4f',
             '/spectrum.png': '8d048ece46c0f3af4b598a95fd8e4709b631c3c0',
           },
         });
@@ -161,7 +161,7 @@ describe('Browser Builder service worker', () => {
           hashTable: {
             '/foo/bar/favicon.ico': '84161b857f5c547e3699ddfbffc6d8d737542e01',
             '/foo/bar/assets/folder-asset.txt': '617f202968a6a81050aa617c2e28e1dca11ce8d4',
-            '/foo/bar/index.html': '9ef50361678004b3b197c12cbc74962e5a15b844',
+            '/foo/bar/index.html': '925d80777b6ba64b526b0be79761d254dfe94c65',
           },
         });
       }),

--- a/packages/angular_devkit/build_angular/test/browser/styles_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/browser/styles_spec_large.ts
@@ -56,12 +56,12 @@ describe('Browser Builder styles', () => {
       './dist/renamed-lazy-style.js': '.pre-rename-lazy-style',
     };
     const jsIndexMatches: { [path: string]: string } = {
-      './dist/index.html': '<script type="text/javascript" src="runtime.js"></script>'
-        + '<script type="text/javascript" src="polyfills.js"></script>'
-        + '<script type="text/javascript" src="styles.js"></script>'
-        + '<script type="text/javascript" src="renamed-style.js"></script>'
-        + '<script type="text/javascript" src="vendor.js"></script>'
-        + '<script type="text/javascript" src="main.js"></script>',
+      './dist/index.html': '<script src="runtime.js"></script>'
+        + '<script src="polyfills.js"></script>'
+        + '<script src="styles.js"></script>'
+        + '<script src="renamed-style.js"></script>'
+        + '<script src="vendor.js"></script>'
+        + '<script src="main.js"></script>',
     };
 
     host.writeMultipleFiles(styles);

--- a/tests/legacy-cli/e2e/tests/basic/scripts-array.ts
+++ b/tests/legacy-cli/e2e/tests/basic/scripts-array.ts
@@ -53,13 +53,13 @@ export default function () {
     .then(() => expectFileToMatch('dist/test-project/renamed-lazy-script.js', 'pre-rename-lazy-script'))
     // index.html lists the right bundles
     .then(() => expectFileToMatch('dist/test-project/index.html', oneLineTrim`
-      <script type="text/javascript" src="runtime.js"></script>
-      <script type="text/javascript" src="es2015-polyfills.js" nomodule></script>
-      <script type="text/javascript" src="polyfills.js"></script>
-      <script type="text/javascript" src="scripts.js"></script>
-      <script type="text/javascript" src="renamed-script.js"></script>
-      <script type="text/javascript" src="vendor.js"></script>
-      <script type="text/javascript" src="main.js"></script>
+      <script src="runtime.js"></script>
+      <script src="es2015-polyfills.js" nomodule></script>
+      <script src="polyfills.js"></script>
+      <script src="scripts.js"></script>
+      <script src="renamed-script.js"></script>
+      <script src="vendor.js"></script>
+      <script src="main.js"></script>
     `))
     // Ensure scripts can be separately imported from the app.
     .then(() => expectFileToMatch('dist/test-project/main.js', 'console.log(\'string-script\');'));

--- a/tests/legacy-cli/e2e/tests/basic/styles-array.ts
+++ b/tests/legacy-cli/e2e/tests/basic/styles-array.ts
@@ -42,10 +42,10 @@ export default function () {
       <link rel="stylesheet" href="renamed-style.css">
     `))
     .then(() => expectFileToMatch('dist/test-project/index.html', oneLineTrim`
-      <script type="text/javascript" src="runtime.js"></script>
-      <script type="text/javascript" src="es2015-polyfills.js" nomodule></script>
-      <script type="text/javascript" src="polyfills.js"></script>
-      <script type="text/javascript" src="vendor.js"></script>
-      <script type="text/javascript" src="main.js"></script>
+      <script src="runtime.js"></script>
+      <script src="es2015-polyfills.js" nomodule></script>
+      <script src="polyfills.js"></script>
+      <script src="vendor.js"></script>
+      <script src="main.js"></script>
     `));
 }

--- a/tests/legacy-cli/e2e/tests/build/polyfills.ts
+++ b/tests/legacy-cli/e2e/tests/build/polyfills.ts
@@ -14,9 +14,9 @@ export default async function () {
     await expectFileToMatch('dist/test-project/polyfills.js', 'core-js/es7/reflect');
     await expectFileToMatch('dist/test-project/polyfills.js', 'zone.js');
     expectFileToMatch('dist/test-project/index.html', oneLineTrim`
-      <script type="text/javascript" src="runtime.js"></script>
-      <script type="text/javascript" src="es2015-polyfills.js" nomodule></script>
-      <script type="text/javascript" src="polyfills.js"></script>
+      <script src="runtime.js"></script>
+      <script src="es2015-polyfills.js" nomodule></script>
+      <script src="polyfills.js"></script>
     `);
     const jitPolyfillSize = await getFileSize('dist/test-project/polyfills.js');
 
@@ -27,8 +27,8 @@ export default async function () {
     await expectToFail(() => expectFileToMatch('dist/test-project/polyfills.js', 'core-js/es7/reflect'));
     await expectFileToMatch('dist/test-project/polyfills.js', 'zone.js');
     expectFileToMatch('dist/test-project/index.html', oneLineTrim`
-      <script type="text/javascript" src="runtime.js"></script>
-      <script type="text/javascript" src="es2015-polyfills.js" nomodule></script>
-      <script type="text/javascript" src="polyfills.js"></script>
+      <script src="runtime.js"></script>
+      <script src="es2015-polyfills.js" nomodule></script>
+      <script src="polyfills.js"></script>
     `);
 }

--- a/tests/legacy-cli/e2e/tests/build/styles/extract-css.ts
+++ b/tests/legacy-cli/e2e/tests/build/styles/extract-css.ts
@@ -47,11 +47,11 @@ export default function () {
       <link rel="stylesheet" href="renamed-style\.css"/?>
     `)))
     .then(() => expectFileToMatch('dist/test-project/index.html', oneLineTrim`
-      <script type="text/javascript" src="runtime.js"></script>
-      <script type="text/javascript" src="es2015-polyfills.js" nomodule></script>
-      <script type="text/javascript" src="polyfills.js"></script>
-      <script type="text/javascript" src="vendor.js"></script>
-      <script type="text/javascript" src="main.js"></script>
+      <script src="runtime.js"></script>
+      <script src="es2015-polyfills.js" nomodule></script>
+      <script src="polyfills.js"></script>
+      <script src="vendor.js"></script>
+      <script src="main.js"></script>
     `))
     // also check when css isn't extracted
     .then(() => ng('build', '--no-extract-css'))
@@ -63,12 +63,12 @@ export default function () {
     .then(() => expectFileToMatch('dist/test-project/renamed-lazy-style.js', '.pre-rename-lazy-style'))
     // index.html lists the right bundles
     .then(() => expectFileToMatch('dist/test-project/index.html', oneLineTrim`
-      <script type="text/javascript" src="runtime.js"></script>
-      <script type="text/javascript" src="es2015-polyfills.js" nomodule></script>
-      <script type="text/javascript" src="polyfills.js"></script>
-      <script type="text/javascript" src="styles.js"></script>
-      <script type="text/javascript" src="renamed-style.js"></script>
-      <script type="text/javascript" src="vendor.js"></script>
-      <script type="text/javascript" src="main.js"></script>
+      <script src="runtime.js"></script>
+      <script src="es2015-polyfills.js" nomodule></script>
+      <script src="polyfills.js"></script>
+      <script src="styles.js"></script>
+      <script src="renamed-style.js"></script>
+      <script src="vendor.js"></script>
+      <script src="main.js"></script>
     `));
 }

--- a/tests/legacy-cli/e2e/tests/misc/support-ie.ts
+++ b/tests/legacy-cli/e2e/tests/misc/support-ie.ts
@@ -12,21 +12,21 @@ export default async function () {
   await ng('build');
   await expectFileNotToExist('dist/test-project/es2015-polyfills.js');
   await expectFileToMatch('dist/test-project/index.html', oneLineTrim`
-    <script type="text/javascript" src="runtime.js"></script>
-    <script type="text/javascript" src="polyfills.js"></script>
-    <script type="text/javascript" src="styles.js"></script>
-    <script type="text/javascript" src="vendor.js"></script>
-    <script type="text/javascript" src="main.js"></script>
+    <script src="runtime.js"></script>
+    <script src="polyfills.js"></script>
+    <script src="styles.js"></script>
+    <script src="vendor.js"></script>
+    <script src="main.js"></script>
   `);
 
   await ng('build', `--es5BrowserSupport`);
   await expectFileToMatch('dist/test-project/es2015-polyfills.js', 'core-js');
   await expectFileToMatch('dist/test-project/index.html', oneLineTrim`
-    <script type="text/javascript" src="runtime.js"></script>
-    <script type="text/javascript" src="es2015-polyfills.js" nomodule></script>
-    <script type="text/javascript" src="polyfills.js"></script>
-    <script type="text/javascript" src="styles.js"></script>
-    <script type="text/javascript" src="vendor.js"></script>
-    <script type="text/javascript" src="main.js"></script>
+    <script src="runtime.js"></script>
+    <script src="es2015-polyfills.js" nomodule></script>
+    <script src="polyfills.js"></script>
+    <script src="styles.js"></script>
+    <script src="vendor.js"></script>
+    <script src="main.js"></script>
   `);
 }

--- a/tests/legacy-cli/e2e/tests/third-party/bootstrap.ts
+++ b/tests/legacy-cli/e2e/tests/third-party/bootstrap.ts
@@ -22,12 +22,12 @@ export default function() {
     .then(() => expectFileToMatch('dist/test-project/scripts.js', '* Bootstrap'))
     .then(() => expectFileToMatch('dist/test-project/styles.css', '* Bootstrap'))
     .then(() => expectFileToMatch('dist/test-project/index.html', oneLineTrim`
-      <script type="text/javascript" src="runtime.js"></script>
-      <script type="text/javascript" src="es2015-polyfills.js" nomodule></script>
-      <script type="text/javascript" src="polyfills.js"></script>
-      <script type="text/javascript" src="scripts.js"></script>
-      <script type="text/javascript" src="vendor.js"></script>
-      <script type="text/javascript" src="main.js"></script>
+      <script src="runtime.js"></script>
+      <script src="es2015-polyfills.js" nomodule></script>
+      <script src="polyfills.js"></script>
+      <script src="scripts.js"></script>
+      <script src="vendor.js"></script>
+      <script src="main.js"></script>
     `))
     .then(() => ng(
       'build',
@@ -39,10 +39,10 @@ export default function() {
     .then(() => expectFileToMatch('dist/test-project/scripts.js', 'jQuery'))
     .then(() => expectFileToMatch('dist/test-project/styles.css', '* Bootstrap'))
     .then(() => expectFileToMatch('dist/test-project/index.html', oneLineTrim`
-      <script type="text/javascript" src="runtime.js"></script>
-      <script type="text/javascript" src="es2015-polyfills.js" nomodule></script>
-      <script type="text/javascript" src="polyfills.js"></script>
-      <script type="text/javascript" src="scripts.js"></script>
-      <script type="text/javascript" src="main.js"></script>
+      <script src="runtime.js"></script>
+      <script src="es2015-polyfills.js" nomodule></script>
+      <script src="polyfills.js"></script>
+      <script src="scripts.js"></script>
+      <script src="main.js"></script>
     `));
 }


### PR DESCRIPTION
The `type` attribute for `script` elements is not required for HTML5.