### PR TITLE
fix(@schematics/angular): update latest version of devkit

### DIFF
--- a/packages/schematics/angular/utility/latest-versions.ts
+++ b/packages/schematics/angular/utility/latest-versions.ts
@@ -14,6 +14,6 @@ export const latestVersions = {
   TypeScript: '~3.2.2',
   TsLib: '^1.9.0',
   // The versions below must be manually updated when making a new devkit release.
-  DevkitBuildAngular: '~0.13.0-beta.0',
-  DevkitBuildNgPackagr: '~0.13.0-beta.0',
+  DevkitBuildAngular: '~0.14.0-beta.0',
+  DevkitBuildNgPackagr: '~0.14.0-beta.0',
 };


### PR DESCRIPTION
It looks like the latest release `8.0.0-beta.0` is fetching devkit `~0.13.0-beta.0` instead of `~0.14.0-beta.0`.