### PR TITLE
fix(@schematics/angular): Include bazel-out in .gitignore

### DIFF
--- a/packages/schematics/angular/workspace/files/__dot__gitignore.template
+++ b/packages/schematics/angular/workspace/files/__dot__gitignore.template
@@ -4,6 +4,8 @@
 /dist
 /tmp
 /out-tsc
+# Only exists if Bazel was run
+/bazel-out
 
 # dependencies
 /node_modules


### PR DESCRIPTION
We could do this only when we know the user has opted into using Bazel, like in the @angular/bazel schematics.
However, the complexity of amending new lines to the .gitignore isn't worth it, when we can just add one line here.

Fixes #13636