### PR TITLE
Add classlist to differential polyfills

### DIFF
--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -14,6 +14,7 @@
     "ajv": "6.8.1",
     "autoprefixer": "9.4.7",
     "circular-dependency-plugin": "5.0.2",
+    "classlist.js": "1.1.20150312",
     "clean-css": "4.2.1",
     "copy-webpack-plugin": "4.6.0",
     "file-loader": "3.0.1",

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/es2015-polyfills.js
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/es2015-polyfills.js
@@ -19,3 +19,5 @@ import 'core-js/es6/regexp';
 import 'core-js/es6/map';
 import 'core-js/es6/weak-map';
 import 'core-js/es6/set';
+
+import 'classlist.js';

--- a/packages/schematics/angular/application/files/src/polyfills.ts.template
+++ b/packages/schematics/angular/application/files/src/polyfills.ts.template
@@ -18,9 +18,6 @@
  * BROWSER POLYFILLS
  */
 
-/** IE10 and IE11 requires the following for NgClass support on SVG elements */
-// import 'classlist.js';  // Run `npm install --save classlist.js`.
-
 /**
  * Web Animations `@angular/platform-browser/animations`
  * Only required if AnimationBuilder is used within the application and using IE/Edge or Safari.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2081,6 +2081,11 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
+classlist.js@1.1.20150312:
+  version "1.1.20150312"
+  resolved "https://registry.yarnpkg.com/classlist.js/-/classlist.js-1.1.20150312.tgz#1d70842f7022f08d9ac086ce69e5b250f2c57789"
+  integrity sha1-HXCEL3Ai8I2awIbOaeWyUPLFd4k=
+
 clean-css@4.2.1, clean-css@^4.1.11:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.2.1.tgz#2d411ef76b8569b6d0c84068dabe85b0aa5e5c17"


### PR DESCRIPTION
The polyfill is only required on IE10/11 which are ES5 only browsers.