### PR TITLE
feat(@angular-devkit/schematics): support basic promise/async based rules

### DIFF
--- a/etc/api/angular_devkit/schematics/src/_golden-api.d.ts
+++ b/etc/api/angular_devkit/schematics/src/_golden-api.d.ts
@@ -424,7 +424,7 @@ export interface RequiredWorkflowExecutionContext {
     schematic: string;
 }
 
-export declare type Rule = (tree: Tree, context: SchematicContext) => Tree | Observable<Tree> | Rule | void;
+export declare type Rule = (tree: Tree, context: SchematicContext) => Tree | Observable<Tree> | Rule | Promise<void> | void;
 
 export declare type RuleFactory<T extends object> = (options: T) => Rule;
 

--- a/packages/angular_devkit/schematics/src/engine/interface.ts
+++ b/packages/angular_devkit/schematics/src/engine/interface.ts
@@ -227,4 +227,5 @@ export type AsyncFileOperator = (tree: FileEntry) => Observable<FileEntry | null
  * know which types is the schematic or collection metadata, as they are both tooling specific.
  */
 export type Source = (context: SchematicContext) => Tree | Observable<Tree>;
-export type Rule = (tree: Tree, context: SchematicContext) => Tree | Observable<Tree> | Rule | void;
+export type Rule = (tree: Tree, context: SchematicContext) =>
+  Tree | Observable<Tree> | Rule | Promise<void> | void;

--- a/packages/angular_devkit/schematics/src/rules/call.ts
+++ b/packages/angular_devkit/schematics/src/rules/call.ts
@@ -5,9 +5,9 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import { BaseException, isObservable } from '@angular-devkit/core';
-import { Observable, of as observableOf, throwError } from 'rxjs';
-import { defaultIfEmpty, last, mergeMap, tap } from 'rxjs/operators';
+import { BaseException, isObservable, isPromise } from '@angular-devkit/core';
+import { Observable, from, of as observableOf, throwError } from 'rxjs';
+import { defaultIfEmpty, last, map, mergeMap, tap } from 'rxjs/operators';
 import { Rule, SchematicContext, Source } from '../engine/interface';
 import { Tree, TreeSymbol } from '../tree/interface';
 
@@ -96,6 +96,8 @@ export function callRule(
           }
         }),
       );
+    } else if (isPromise(result)) {
+      return from(result).pipe(map(() => inputTree));
     } else if (TreeSymbol in result) {
       return observableOf(result);
     } else {


### PR DESCRIPTION
Currently, all third-party schematic developers are forced to use and directly depend on `rxjs` if any logic is asynchronous.   Doing so can can also add overhead and unneeded complexity for organizations that have chosen to standardize on async/await usage. This change allows such parties to rely on native promise support if desired.