### PR TITLE
fix(@ngtools/webpack): don't load ngfactories for lazy routes with Ivy

### DIFF
--- a/packages/ngtools/webpack/src/angular_compiler_plugin.ts
+++ b/packages/ngtools/webpack/src/angular_compiler_plugin.ts
@@ -500,10 +500,14 @@ export class AngularCompilerPlugin {
         const lazyRouteTSFile = discoveredLazyRoutes[lazyRouteKey].replace(/\\/g, '/');
         let modulePath: string, moduleKey: string;
 
-        if (this._JitMode) {
+        if (this._JitMode ||
+          // When using Ivy and not using allowEmptyCodegenFiles, factories are not generated.
+          (this._compilerOptions.enableIvy && !this._compilerOptions.allowEmptyCodegenFiles)
+        ) {
           modulePath = lazyRouteTSFile;
           moduleKey = `${lazyRouteModule}${moduleName ? '#' + moduleName : ''}`;
         } else {
+          // NgFactories are only used with AOT on ngc (legacy) mode.
           modulePath = lazyRouteTSFile.replace(/(\.d)?\.tsx?$/, '');
           modulePath += '.ngfactory.js';
           const factoryModuleName = moduleName ? `#${moduleName}NgFactory` : '';

--- a/tests/legacy-cli/e2e/tests/experimental/ivy-lazy-load.ts
+++ b/tests/legacy-cli/e2e/tests/experimental/ivy-lazy-load.ts
@@ -1,0 +1,27 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { readdirSync } from 'fs';
+import { prependToFile, replaceInFile } from '../../utils/fs';
+import { ng } from '../../utils/process';
+import { createProject } from '../../utils/project';
+
+export default async function() {
+  await createProject('ivy-project', '--experimental-ivy');
+
+  await ng('generate', 'module', 'lazy', '--routing');
+  await prependToFile('src/app/app.module.ts', `import { RouterModule } from '@angular/router';`);
+  await replaceInFile('src/app/app.module.ts', 'imports: [', `imports: [
+    RouterModule.forRoot([{ path: "lazy", loadChildren: "src/app/lazy/lazy.module#LazyModule" }]),
+  `);
+  await ng('build', '--named-chunks', '--aot');
+  const distFiles = await readdirSync('dist/ivy-project');
+  if (!distFiles.includes('lazy-lazy-module.js')
+    || distFiles.includes('lazy-lazy-module-ngfactory.js')) {
+    throw new Error('The lazy module chunk should not be a ngfactory.');
+  }
+}

--- a/tests/legacy-cli/e2e_runner.ts
+++ b/tests/legacy-cli/e2e_runner.ts
@@ -130,7 +130,9 @@ allTests = allTests
   // NEEDS devkit change
   .filter(name => !name.endsWith('/existing-directory.ts'))
   // Disabled on rc.0 due to needed sync with devkit for changes.
-  .filter(name => !name.endsWith('/service-worker.ts'));
+  .filter(name => !name.endsWith('/service-worker.ts'))
+  // Lazy load support is WIP https://github.com/angular/angular/pull/28685
+  .filter(name => !name.endsWith('tests/experimental/ivy-lazy-load.ts'));
 
 if (argv.ivy) {
   // These tests are disabled on the Ivy-only CI job because:
@@ -143,7 +145,7 @@ if (argv.ivy) {
     // Ivy doesn't support i18n externally at the moment.
     .filter(name => !name.includes('tests/i18n/'))
     .filter(name => !name.endsWith('tests/build/aot/aot-i18n.ts'))
-    // Lazy load support is WIP https://github.com/angular/angular-cli/pull/13524
+    // Lazy load support is WIP https://github.com/angular/angular/pull/28685
     .filter(name => !name.endsWith('tests/misc/lazy-module.ts'))
     // We don't have a library consumption story yet for Ivy.
     .filter(name => !name.endsWith('tests/generate/library/library-consumption.ts'));


### PR DESCRIPTION
Supersedes https://github.com/angular/angular-cli/pull/13524