### PR TITLE
fix(@angular-devkit/build-angular): disable by default stylesheet root relative URL rebasing

### DIFF
--- a/packages/angular/cli/lib/config/schema.json
+++ b/packages/angular/cli/lib/config/schema.json
@@ -875,6 +875,12 @@
               "description": "Enables conditionally loaded ES2015 polyfills.",
               "type": "boolean",
               "default": false
+            },
+            "rebaseRootRelativeCssUrls": {
+              "description": "Change root relative URLs in stylesheets to include base HREF and deploy URL. Use only for compatibility and transition. The behavior of this option is non-standard and will be removed in the next major release.",
+              "type": "boolean",
+              "default": false,
+              "x-deprecated": true
             }
           },
           "additionalProperties": false,

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/build-options.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/build-options.ts
@@ -71,6 +71,8 @@ export interface BuildOptions {
   lazyModules: string[];
   platform?: 'browser' | 'server';
   fileReplacements: CurrentFileReplacement[];
+    /** @deprecated use only for compatibility in 8.x; will be removed in 9.0 */
+  rebaseRootRelativeCssUrls?: boolean;
 }
 
 export interface WebpackTestOptions extends BuildOptions {

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/styles.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/styles.ts
@@ -45,10 +45,6 @@ export function getStylesConfig(wco: WebpackConfigOptions) {
 
   // Determine hashing format.
   const hashFormat = getOutputHashFormat(buildOptions.outputHashing as string);
-  // Convert absolute resource URLs to account for base-href and deploy-url.
-  const baseHref = buildOptions.baseHref || '';
-  const deployUrl = buildOptions.deployUrl || '';
-  const resourcesOutputPath = buildOptions.resourcesOutputPath || '';
 
   const postcssPluginCreator = function (loader: webpack.loader.LoaderContext) {
     return [
@@ -70,10 +66,11 @@ export function getStylesConfig(wco: WebpackConfigOptions) {
         },
       }),
       PostcssCliResources({
-        baseHref,
-        deployUrl,
-        resourcesOutputPath,
+        baseHref: buildOptions.baseHref,
+        deployUrl: buildOptions.deployUrl,
+        resourcesOutputPath: buildOptions.resourcesOutputPath,
         loader,
+        rebaseRootRelative: buildOptions.rebaseRootRelativeCssUrls,
         filename: `[name]${hashFormat.file}.[ext]`,
       }),
       autoprefixer(),

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/postcss-cli-resources.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/postcss-cli-resources.ts
@@ -28,6 +28,7 @@ export interface PostcssCliResourcesOptions {
   baseHref?: string;
   deployUrl?: string;
   resourcesOutputPath?: string;
+  rebaseRootRelative?: boolean;
   filename: string;
   loader: webpack.loader.LoaderContext;
 }
@@ -49,6 +50,7 @@ export default postcss.plugin('postcss-cli-resources', (options: PostcssCliResou
     deployUrl = '',
     baseHref = '',
     resourcesOutputPath = '',
+    rebaseRootRelative = false,
     filename,
     loader,
   } = options;
@@ -58,6 +60,10 @@ export default postcss.plugin('postcss-cli-resources', (options: PostcssCliResou
   const process = async (inputUrl: string, context: string, resourceCache: Map<string, string>) => {
     // If root-relative, absolute or protocol relative url, leave as is
     if (/^((?:\w+:)?\/\/|data:|chrome:|#)/.test(inputUrl)) {
+      return inputUrl;
+    }
+
+    if (!rebaseRootRelative && /^\//.test(inputUrl)) {
       return inputUrl;
     }
 

--- a/packages/angular_devkit/build_angular/src/browser/schema.d.ts
+++ b/packages/angular_devkit/build_angular/src/browser/schema.d.ts
@@ -241,6 +241,14 @@ export interface BrowserBuilderSchema {
    * Enables conditionally loaded IE9-11 polyfills.
    */
   es5BrowserSupport: boolean;
+
+  /**
+   * @deprecated
+   * Change root relative URLs in stylesheets to include base HREF and deploy URL.
+   * Use only for compatibility and transition.
+   * The behavior of this option is non-standard and will be removed in the next major release.
+   */
+  rebaseRootRelativeCssUrls: boolean;
 }
 
 export type OptimizationOptions = boolean | OptimizationObject;

--- a/packages/angular_devkit/build_angular/src/browser/schema.json
+++ b/packages/angular_devkit/build_angular/src/browser/schema.json
@@ -304,6 +304,12 @@
       "description": "Enables conditionally loaded ES2015 polyfills.",
       "type": "boolean",
       "default": false
+    },
+    "rebaseRootRelativeCssUrls": {
+      "description": "Change root relative URLs in stylesheets to include base HREF and deploy URL. Use only for compatibility and transition. The behavior of this option is non-standard and will be removed in the next major release.",
+      "type": "boolean",
+      "default": false,
+      "x-deprecated": true
     }
   },
   "additionalProperties": false,

--- a/tests/legacy-cli/e2e/tests/build/css-urls.ts
+++ b/tests/legacy-cli/e2e/tests/build/css-urls.ts
@@ -29,7 +29,6 @@ export default function () {
       'src/assets/global-img-absolute.svg': imgSvg,
       'src/assets/component-img-absolute.svg': imgSvg
     }))
-    // use image with file size >10KB to prevent inlining
     .then(() => copyProjectAsset('images/spectrum.png', './src/assets/global-img-relative.png'))
     .then(() => copyProjectAsset('images/spectrum.png', './src/assets/component-img-relative.png'))
     .then(() => ng('build', '--extract-css', '--aot'))
@@ -52,54 +51,54 @@ export default function () {
     .then(() => ng('build', '--base-href=/base/', '--deploy-url=http://deploy.url/',
       '--extract-css'))
     .then(() => expectFileToMatch('dist/test-project/styles.css',
-      /url\(\'http:\/\/deploy\.url\/assets\/global-img-absolute\.svg\'\)/))
+      /url\(\'\/assets\/global-img-absolute\.svg\'\)/))
     .then(() => expectFileToMatch('dist/test-project/main.js',
-      /url\(\'http:\/\/deploy\.url\/assets\/component-img-absolute\.svg\'\)/))
+      /url\(\'\/assets\/component-img-absolute\.svg\'\)/))
     // Check urls with base-href scheme are used as is (with deploy-url).
     .then(() => ng('build', '--base-href=http://base.url/', '--deploy-url=deploy/',
       '--extract-css'))
     .then(() => expectFileToMatch('dist/test-project/styles.css',
-      /url\(\'http:\/\/base\.url\/deploy\/assets\/global-img-absolute\.svg\'\)/))
+      /url\(\'\/assets\/global-img-absolute\.svg\'\)/))
     .then(() => expectFileToMatch('dist/test-project/main.js',
-      /url\(\'http:\/\/base\.url\/deploy\/assets\/component-img-absolute\.svg\'\)/))
+      /url\(\'\/assets\/component-img-absolute\.svg\'\)/))
     // Check urls with deploy-url and base-href scheme only use deploy-url.
     .then(() => ng('build', '--base-href=http://base.url/', '--deploy-url=http://deploy.url/',
       '--extract-css'))
     .then(() => expectFileToMatch('dist/test-project/styles.css',
-      /url\(\'http:\/\/deploy\.url\/assets\/global-img-absolute\.svg\'\)/))
+      /url\(\'\/assets\/global-img-absolute\.svg\'\)/))
     .then(() => expectFileToMatch('dist/test-project/main.js',
-      /url\(\'http:\/\/deploy\.url\/assets\/component-img-absolute\.svg\'\)/))
+      /url\(\'\/assets\/component-img-absolute\.svg\'\)/))
     // Check with base-href and deploy-url flags.
     .then(() => ng('build', '--base-href=/base/', '--deploy-url=deploy/',
       '--extract-css', '--aot'))
     .then(() => expectFileToMatch('dist/test-project/styles.css',
-      '/base/deploy/assets/global-img-absolute.svg'))
+      '/assets/global-img-absolute.svg'))
     .then(() => expectFileToMatch('dist/test-project/styles.css',
       /global-img-relative\.png/))
     .then(() => expectFileToMatch('dist/test-project/main.js',
-      '/base/deploy/assets/component-img-absolute.svg'))
+      '/assets/component-img-absolute.svg'))
     .then(() => expectFileToMatch('dist/test-project/main.js',
       /deploy\/component-img-relative\.png/))
     // Check with identical base-href and deploy-url flags.
     .then(() => ng('build', '--base-href=/base/', '--deploy-url=/base/',
       '--extract-css', '--aot'))
     .then(() => expectFileToMatch('dist/test-project/styles.css',
-      '/base/assets/global-img-absolute.svg'))
+      '/assets/global-img-absolute.svg'))
     .then(() => expectFileToMatch('dist/test-project/styles.css',
       /global-img-relative\.png/))
     .then(() => expectFileToMatch('dist/test-project/main.js',
-      '/base/assets/component-img-absolute.svg'))
+      '/assets/component-img-absolute.svg'))
     .then(() => expectFileToMatch('dist/test-project/main.js',
       /\/base\/component-img-relative\.png/))
     // Check with only base-href flag.
     .then(() => ng('build', '--base-href=/base/',
       '--extract-css', '--aot'))
     .then(() => expectFileToMatch('dist/test-project/styles.css',
-      '/base/assets/global-img-absolute.svg'))
+      '/assets/global-img-absolute.svg'))
     .then(() => expectFileToMatch('dist/test-project/styles.css',
       /global-img-relative\.png/))
     .then(() => expectFileToMatch('dist/test-project/main.js',
-      '/base/assets/component-img-absolute.svg'))
+      '/assets/component-img-absolute.svg'))
     .then(() => expectFileToMatch('dist/test-project/main.js',
       /component-img-relative\.png/));
 }


### PR DESCRIPTION
BREAKING CHANGE:
Root relative URLs are a standardized method to reference a resource path from the root of a host.  The previous behavior of the Angular CLI prevented this from occuring and resulted in an inability to reference stylesheet assets in this manner.  The initial reason for this behavior is no longer present in the internal implementation of the Angular CLI.  Therefore, this now unnecessary and non-standard behavior is being phased out.  If an application currently relies on this behavior, a compatibility option `rebaseRootRelativeCssUrls` has been provided for the 8.x release cycle to facilitate transition away from this non-standard and limiting behavior.  The recommended method to transition is to use relative paths within the source stylesheet.  This allows the build system to process and generate a full URL for the asset.

This change also aligns the CLI behavior with other commonly used tools including Webpack's css-loader. The compatibility option will only be needed for projects that used root relative URLs within stylesheets and also used either a custom HTML base HREF and/or deploy URL option.
This option is a new option for the `build` target of an application (using the default `@angular-devkit/build-angular:browser` builder).  For example:
```
"build": {
    "builder": "@angular-devkit/build-angular:browser",
    "options": {
        ...
        "rebaseRootRelativeCssUrls": true,
        ...
    },
    ...
}
```

To further demonstrate the behavioral differences, assuming that a stylesheet has a `url()` containing `/image.jpg`.  The URL would be transformed as follows.  Note that in the behavior prior to 8.0, referencing an asset from the root of the origin is not present when providing the HTML base HREF or deploy URL options.

|  | Prior to 8.0 | 8.0 and later |
|:-:|:-:|:-:|
| Base HREF of `/base/` |`/base/image.jpg`|`/image.jpg`|
| Deploy URL of `deployed/` |`deployed/image.jpg`|`/image.jpg`|
| Both of the above | `/base/deployed/image.jpg` | `/image.jpg` |
| **Deploy URL of `/deployed/` |`/deployed/image.jpg`|`/image.jpg`|

** -- For prior behavior, the base HREF will be ignored when the deploy URL is root relative.