### PR TITLE
feat(@schematics/angular): Update rxjs to 6.4.0

### DIFF
--- a/packages/schematics/angular/utility/latest-versions.ts
+++ b/packages/schematics/angular/utility/latest-versions.ts
@@ -9,7 +9,7 @@
 export const latestVersions = {
   // These versions should be kept up to date with latest Angular peer dependencies.
   Angular: '~8.0.0-beta.0',
-  RxJs: '~6.3.3',
+  RxJs: '~6.4.0',
   ZoneJs: '~0.8.26',
   TypeScript: '~3.2.2',
   TsLib: '^1.9.0',


### PR DESCRIPTION
6.4.0 is needed so that Bazel does not have to build rxjs from source

See https://github.com/angular/angular/pull/28720