### PR TITLE
fix(@schematics/angular): undefined is used as newProjectRoot when no…

### DIFF
--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -324,7 +324,7 @@ export default function (options: ApplicationOptions): Rule {
       };
 
     const workspace = getWorkspace(host);
-    let newProjectRoot = workspace.newProjectRoot;
+    let newProjectRoot = workspace.newProjectRoot || 'projects';
     let appDir = `${newProjectRoot}/${options.name}`;
     let sourceRoot = `${appDir}/src`;
     let sourceDir = `${sourceRoot}/app`;

--- a/packages/schematics/angular/library/index.ts
+++ b/packages/schematics/angular/library/index.ts
@@ -193,7 +193,7 @@ export default function (options: LibraryOptions): Rule {
     }
 
     const workspace = getWorkspace(host);
-    const newProjectRoot = workspace.newProjectRoot;
+    const newProjectRoot = workspace.newProjectRoot || 'projects';
 
     const scopeFolder = scopeName ? strings.dasherize(scopeName) + '/' : '';
     const folderName = `${scopeFolder}${strings.dasherize(options.name)}`;


### PR DESCRIPTION
…ne is set

Fixes #13703