### PR TITLE
fix(@schematics/angular): add file extensions to style prompt

### DIFF
--- a/packages/schematics/angular/ng-new/schema.json
+++ b/packages/schematics/angular/ng-new/schema.json
@@ -125,10 +125,10 @@
         "message": "Which stylesheet format would you like to use?",
         "type": "list",
         "items": [
-          { "value": "css", "label": "CSS" },
-          { "value": "sass", "label": "Sass   [ http://sass-lang.com   ]" },
-          { "value": "less", "label": "Less   [ http://lesscss.org     ]" },
-          { "value": "styl", "label": "Stylus [ http://stylus-lang.com ]" }
+          { "value": "css",  "label": "CSS    (.css )" },
+          { "value": "sass", "label": "Sass   (.scss) [ http://sass-lang.com   ]" },
+          { "value": "less", "label": "Less   (.less) [ http://lesscss.org     ]" },
+          { "value": "styl", "label": "Stylus (.styl) [ http://stylus-lang.com ]" }
         ]
       }
     },


### PR DESCRIPTION
This is causing major confusion as users are not aware that choosing `sass` will generate files with `scss` extension.

Another reason for this confusion is that in other schematics, `style` accepts either a preprocessor or file extension while in this prompt only a preprocessor is provided.