### PR TITLE
fix(@schematics/angular): `findModuleFromOptions` not handling proper…

### DIFF
--- a/packages/schematics/angular/utility/find-module.ts
+++ b/packages/schematics/angular/utility/find-module.ts
@@ -12,7 +12,6 @@ import {
   join,
   normalize,
   relative,
-  strings,
 } from '@angular-devkit/core';
 import { DirEntry, Tree } from '@angular-devkit/schematics';
 
@@ -25,7 +24,6 @@ export interface ModuleOptions {
   skipImport?: boolean;
   moduleExt?: string;
   routingModuleExt?: string;
-  nameFormatter?: (str: string) => string;
 }
 
 const MODULE_EXT = '.module.ts';
@@ -43,8 +41,7 @@ export function findModuleFromOptions(host: Tree, options: ModuleOptions): Path 
   const routingModuleExt = options.routingModuleExt || ROUTING_MODULE_EXT;
 
   if (!options.module) {
-    options.nameFormatter = options.nameFormatter || strings.dasherize;
-    const pathToCheck = (options.path || '') + '/' + options.nameFormatter(options.name);
+    const pathToCheck = (options.path || '') + '/' + options.name;
 
     return normalize(findModule(host, pathToCheck, moduleExt, routingModuleExt));
   } else {

--- a/packages/schematics/angular/utility/find-module_spec.ts
+++ b/packages/schematics/angular/utility/find-module_spec.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import { Path, strings } from '@angular-devkit/core';
+import { Path } from '@angular-devkit/core';
 import { EmptyTree, Tree } from '@angular-devkit/schematics';
 import { ModuleOptions, findModule, findModuleFromOptions } from './find-module';
 
@@ -111,12 +111,20 @@ describe('find-module', () => {
       expect(modPath).toEqual('/projects/my-proj/src/app.module.ts' as Path);
     });
 
-    it('should find a module if nameFormatter is provided', () => {
-      tree.create('/projects/my-proj/src/app_test.module.ts', '');
+    it('should find a module when name has underscore', () => {
+      tree.create('/projects/my-proj/src/feature_module/app_test.module.ts', '');
       options.path = '/projects/my-proj/src';
-      options.nameFormatter = strings.underscore;
+      options.name = 'feature_module/new_component';
       const modPath = findModuleFromOptions(tree, options);
-      expect(modPath).toEqual('/projects/my-proj/src/app_test.module.ts' as Path);
+      expect(modPath).toEqual('/projects/my-proj/src/feature_module/app_test.module.ts' as Path);
+    });
+
+    it('should find a module when name has uppercase', () => {
+      tree.create('/projects/my-proj/src/featureModule/appTest.module.ts', '');
+      options.path = '/projects/my-proj/src';
+      options.name = 'featureModule/newComponent';
+      const modPath = findModuleFromOptions(tree, options);
+      expect(modPath).toEqual('/projects/my-proj/src/featureModule/appTest.module.ts' as Path);
     });
 
     it('should find a module if flat is true', () => {


### PR DESCRIPTION
…ly different casing in name

At the moment users can have various casing and separators in paths, we should not always dasherize the name when resolving modules.

As for example when providing something like:

```
/module/SubModule/feature
```

It won't be able to resolve the modules properly as `sub-module` does't exist.

This PR also updates the test for underscore as previously it was not properly testing this usercase, since the formatter was used on name and not th path.

Fixes #13714