### PR TITLE
fix(@angular-devkit/build-angular): shim node events builtin for dev server

### DIFF
--- a/packages/angular_devkit/build_angular/src/dev-server/index.ts
+++ b/packages/angular_devkit/build_angular/src/dev-server/index.ts
@@ -290,6 +290,19 @@ export class DevServerBuilder implements Builder<DevServerBuilderOptions> {
     }
     if (!webpackConfig.entry.main) { webpackConfig.entry.main = []; }
     webpackConfig.entry.main.unshift(...entryPoints);
+
+    // The dev server live reload requires a node 'events' builtin shim to function.
+    // The dev server as written only currently works with package managers
+    // that hoist the `events` shim package to an accessible location.
+    // Hoisting is unfortunately not standardized and the assumption within
+    // the dev server will not hold true for all package managers.
+    // The actual code is only accessed when hmr is enabled which allows
+    // the 'events' import to be ignored in the non-hmr case.
+    if (!webpackConfig.node) {
+      webpackConfig.node = { events: options.hmr || false };
+    } else if (typeof webpackConfig.node === 'object') {
+      webpackConfig.node.events = webpackConfig.node.events || options.hmr || false;
+    }
   }
 
   private _addSslConfig(


### PR DESCRIPTION
The dev server requires a node 'events' builtin shim to function.  The dev server as written only currently works with package managers that hoist the `events` shim package to an accessible location.  Hoisting is unfortunately not standardized and the assumption within the dev server will not hold true for all package managers. The actual code is only accessed when hmr is enabled which allows the 'events' import to be ignored in the non-hmr case.

Closes #13680