### PR TITLE
fix(@angular-devkit/build-angular): add promise polyfill to --es5BrowserSupport provided polyfills

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/es2015-polyfills.js
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/es2015-polyfills.js
@@ -19,3 +19,4 @@ import 'core-js/es6/regexp';
 import 'core-js/es6/map';
 import 'core-js/es6/weak-map';
 import 'core-js/es6/set';
+import 'core-js/es6/promise';


### PR DESCRIPTION
Since Angular uses Promises, we need to provide a polyfill for it to support ES5 only browsers.

Closes #13735 