### PR TITLE
fix(@schematics/angular): remove extra comma in component schematic

### DIFF
--- a/packages/schematics/angular/application/other-files/app.component.ts.template
+++ b/packages/schematics/angular/application/other-files/app.component.ts.template
@@ -28,7 +28,7 @@ import { Component<% if(!!viewEncapsulation) { %>, ViewEncapsulation<% }%> } fro
   `,<% } else { %>
   templateUrl: './app.component.html',<% } if(inlineStyle) { %>
   styles: []<% } else { %>
-  styleUrls: ['./app.component.<%= styleExt %>']<% } %>,<% if(!!viewEncapsulation) { %>,
+  styleUrls: ['./app.component.<%= styleExt %>']<% } %><% if(!!viewEncapsulation) { %>,
   encapsulation: ViewEncapsulation.<%= viewEncapsulation %><% } %>
 })
 export class AppComponent {

--- a/packages/schematics/angular/application/other-files/app.component.ts.template
+++ b/packages/schematics/angular/application/other-files/app.component.ts.template
@@ -1,4 +1,4 @@
-import { Component<% if(!!viewEncapsulation) { %>, ViewEncapsulation<% }%> } from '@angular/core';
+import { Component } from '@angular/core';
 
 @Component({
   selector: '<%= selector %>',<% if(inlineTemplate) { %>
@@ -28,8 +28,7 @@ import { Component<% if(!!viewEncapsulation) { %>, ViewEncapsulation<% }%> } fro
   `,<% } else { %>
   templateUrl: './app.component.html',<% } if(inlineStyle) { %>
   styles: []<% } else { %>
-  styleUrls: ['./app.component.<%= styleExt %>']<% } %><% if(!!viewEncapsulation) { %>,
-  encapsulation: ViewEncapsulation.<%= viewEncapsulation %><% } %>
+  styleUrls: ['./app.component.<%= styleExt %>']<% } %>
 })
 export class AppComponent {
   title = '<%= name %>';


### PR DESCRIPTION
This was introduced by #13690

Previously to this commit, a trailing comma was always added after styles/styleUrls
The `viewEncapsulation` also adds one, so there is an extra one.

Fixes: #13742