### PR TITLE
feat(@schematics/angular): tslint migration for 8

### DIFF
--- a/packages/schematics/angular/migrations/migration-collection.json
+++ b/packages/schematics/angular/migrations/migration-collection.json
@@ -29,6 +29,11 @@
       "version": "7.0.3",
       "factory": "./update-7/index#updateDevkitBuildNgPackagr",
       "description": "Update an Angular CLI project to version 7."
+    },
+    "migration-07": {
+      "version": "8.0.0",
+      "factory": "./update-8",
+      "description": "Update an Angular CLI project to version 8."
     }
   }
 }

--- a/packages/schematics/angular/migrations/update-8/index.ts
+++ b/packages/schematics/angular/migrations/update-8/index.ts
@@ -1,0 +1,103 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { JsonParseMode, parseJsonAst } from '@angular-devkit/core';
+import {
+  Rule,
+  SchematicContext,
+  Tree,
+  chain,
+} from '@angular-devkit/schematics';
+import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
+import {
+  NodeDependency,
+  NodeDependencyType,
+  addPackageJsonDependency,
+} from '../../utility/dependencies';
+import { findPropertyInAstObject } from '../../utility/json-utils';
+
+const ruleMapping: {[key: string]: string} = {
+  'contextual-life-cycle': 'contextual-lifecycle',
+  'no-conflicting-life-cycle-hooks': 'no-conflicting-lifecycle',
+  'no-life-cycle-call': 'no-lifecycle-call',
+  'use-life-cycle-interface': 'use-lifecycle-interface',
+  'decorator-not-allowed': 'contextual-decorator',
+  'enforce-component-selector': 'use-component-selector',
+  'no-output-named-after-standard-event': 'no-output-native',
+  'use-host-property-decorator': 'no-host-metadata-property',
+  'use-input-property-decorator': 'no-inputs-metadata-property',
+  'use-output-property-decorator': 'no-outputs-metadata-property',
+  'no-queries-parameter': 'no-queries-metadata-property',
+  'pipe-impure': 'no-pipe-impure',
+  'use-view-encapsulation': 'use-component-view-encapsulation',
+  i18n: 'template-i18n',
+  'banana-in-box': 'template-banana-in-box',
+  'no-template-call-expression': 'template-no-call-expression',
+  'templates-no-negated-async': 'template-no-negated-async',
+  'trackBy-function': 'template-use-track-by-function',
+  'no-attribute-parameter-decorator': 'no-attribute-decorator',
+  'max-inline-declarations': 'component-max-inline-declarations',
+};
+
+function updateTsLintConfig(): Rule {
+  return (host: Tree) => {
+    const tsLintPath = '/tslint.json';
+    const buffer = host.read(tsLintPath);
+    if (!buffer) {
+      return host;
+    }
+    const tsCfgAst = parseJsonAst(buffer.toString(), JsonParseMode.Loose);
+
+    if (tsCfgAst.kind != 'object') {
+      return host;
+    }
+
+    const rulesNode = findPropertyInAstObject(tsCfgAst, 'rules');
+    if (!rulesNode || rulesNode.kind != 'object') {
+      return host;
+    }
+
+    const recorder = host.beginUpdate(tsLintPath);
+
+    rulesNode.properties.forEach(prop => {
+      const mapping = ruleMapping[prop.key.value];
+      if (mapping) {
+        recorder.remove(prop.key.start.offset + 1, prop.key.value.length);
+        recorder.insertLeft(prop.key.start.offset + 1, mapping);
+      }
+    });
+
+    host.commitUpdate(recorder);
+
+    return host;
+  };
+}
+
+function updatePackageJson() {
+  return (host: Tree, context: SchematicContext) => {
+    const dependency: NodeDependency = {
+      type: NodeDependencyType.Dev,
+      name: 'codelyzer',
+      version: '^5.0.0',
+      overwrite: true,
+    };
+
+    addPackageJsonDependency(host, dependency);
+    context.addTask(new NodePackageInstallTask());
+
+    return host;
+  };
+}
+
+export default function(): Rule {
+  return () => {
+    return chain([
+      updateTsLintConfig(),
+      updatePackageJson(),
+    ]);
+  };
+}

--- a/packages/schematics/angular/migrations/update-8/index_spec.ts
+++ b/packages/schematics/angular/migrations/update-8/index_spec.ts
@@ -1,0 +1,85 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+// tslint:disable:no-big-function
+import { EmptyTree } from '@angular-devkit/schematics';
+import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';
+
+const renames = [
+  'use-lifecycle-interface',
+  'no-host-metadata-property',
+  'no-outputs-metadata-property',
+  'no-inputs-metadata-property',
+];
+
+describe('Migration to version 8', () => {
+  const schematicRunner = new SchematicTestRunner(
+    'migrations',
+    require.resolve('../migration-collection.json'),
+  );
+
+  let tree: UnitTestTree;
+  const tslintPath = '/tslint.json';
+  const packageJsonPath = '/package.json';
+  const baseConfig = {};
+  const defaultOptions = {};
+  const configPath = `/angular-cli.json`;
+  const tslintConfig = {
+    rules: {
+      'directive-selector': [
+        true,
+        'attribute',
+        'app',
+        'camelCase',
+      ],
+      'component-selector': [
+        true,
+        'element',
+        'app',
+        'kebab-case',
+      ],
+      'no-output-on-prefix': true,
+      'use-input-property-decorator': true,
+      'use-output-property-decorator': true,
+      'use-host-property-decorator': true,
+      'no-input-rename': true,
+      'no-output-rename': true,
+      'use-life-cycle-interface': true,
+      'use-pipe-transform-interface': true,
+      'component-class-suffix': true,
+      'directive-class-suffix': true,
+    },
+  };
+  const packageJson = {
+    devDependencies: {
+      codelyzer: '^4.5.0',
+    },
+  };
+
+  describe('Migration of codelyzer to version 5', () => {
+    beforeEach(() => {
+      tree = new UnitTestTree(new EmptyTree());
+      tree.create(configPath, JSON.stringify(baseConfig, null, 2));
+      tree.create(packageJsonPath, JSON.stringify(packageJson, null, 2));
+      tree.create(tslintPath, JSON.stringify(tslintConfig, null, 2));
+    });
+
+    it('should rename all previous rules', () => {
+      tree = schematicRunner.runSchematic('migration-07', defaultOptions, tree);
+      const tslint = JSON.parse(tree.readContent(tslintPath));
+      for (const rule of renames) {
+        expect(rule in tslint.rules).toBeTruthy(`Rule ${rule} not renamed`);
+      }
+    });
+
+    it('should update codelyzer\'s version', () => {
+      tree = schematicRunner.runSchematic('migration-07', defaultOptions, tree);
+      const packageJson = JSON.parse(tree.readContent(packageJsonPath));
+      expect(packageJson.devDependencies.codelyzer).toBe('^5.0.0');
+    });
+  });
+});


### PR DESCRIPTION
Migration of the `tslint.json` file required by the refactoring of
codelyzer. For more information check this PR
https://github.com/mgechev/codelyzer/pull/754.

// cc @rafaelss95, would you check if I've missed anything?