### PR TITLE
fix(@angular-devkit/build-angular): remove index option as required

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/build-options.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/build-options.ts
@@ -62,7 +62,7 @@ export interface BuildOptions {
   es5BrowserSupport?: boolean;
 
   main: string;
-  index: string;
+  index?: string;
   polyfills?: string;
   budgets: Budget[];
   assets: AssetPatternClass[];

--- a/packages/angular_devkit/build_angular/src/browser/schema.json
+++ b/packages/angular_devkit/build_angular/src/browser/schema.json
@@ -324,7 +324,6 @@
   "additionalProperties": false,
   "required": [
     "outputPath",
-    "index",
     "main",
     "tsConfig"
   ],


### PR DESCRIPTION
It is not a required option and is allowed to be undefined ([relevant code](https://github.com/angular/angular-cli/blob/master/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/browser.ts#L39)).  This supports use cases where an index HTML file may not be used directly or is autogenerated in some other manner.

Closes #11816