### PR TITLE
feat(@angular-devkit/build-angular): change es5BrowserSupport  output filename to `polyfills.es5.js`

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/browser.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/browser.ts
@@ -44,7 +44,7 @@ export function getBrowserConfig(wco: WebpackConfigOptions) {
       entrypoints: generateEntryPoints(buildOptions),
       deployUrl: buildOptions.deployUrl,
       sri: buildOptions.subresourceIntegrity,
-      noModuleEntrypoints: ['es2015-polyfills'],
+      noModuleEntrypoints: ['polyfills.es5'],
     }));
   }
 
@@ -113,7 +113,7 @@ export function getBrowserConfig(wco: WebpackConfigOptions) {
               const moduleName = module.nameForCondition ? module.nameForCondition() : '';
 
               return /[\\/]node_modules[\\/]/.test(moduleName)
-                && !chunks.some(({ name }) => name === 'polyfills' || name === 'es2015-polyfills'
+                && !chunks.some(({ name }) => name === 'polyfills' || name === 'polyfills.es5'
                   || globalStylesBundleNames.includes(name));
             },
           },

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
@@ -54,7 +54,7 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
   }
 
   if (buildOptions.es5BrowserSupport) {
-    entryPoints['es2015-polyfills'] = [path.join(__dirname, '..', 'es2015-polyfills.js')];
+    entryPoints['polyfills.es5'] = [path.join(__dirname, '..', 'es2015-polyfills.js')];
   }
 
   if (buildOptions.polyfills) {
@@ -68,8 +68,8 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
     ];
 
     if (buildOptions.es5BrowserSupport) {
-      entryPoints['es2015-polyfills'] = [
-        ...entryPoints['es2015-polyfills'],
+      entryPoints['polyfills.es5'] = [
+        ...entryPoints['polyfills.es5'],
         path.join(__dirname, '..', 'es2015-jit-polyfills.js'),
       ];
     }

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/package-chunk-sort.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/package-chunk-sort.ts
@@ -26,7 +26,7 @@ export function generateEntryPoints(
   };
 
   const entryPoints = [
-    'es2015-polyfills',
+    'polyfills.es5',
     'polyfills',
     'sw-register',
     ...extraEntryPoints(appConfig.styles, 'styles'),

--- a/tests/legacy-cli/e2e/tests/basic/scripts-array.ts
+++ b/tests/legacy-cli/e2e/tests/basic/scripts-array.ts
@@ -54,7 +54,7 @@ export default function () {
     // index.html lists the right bundles
     .then(() => expectFileToMatch('dist/test-project/index.html', oneLineTrim`
       <script src="runtime.js"></script>
-      <script src="es2015-polyfills.js" nomodule></script>
+      <script src="polyfills.es5.js" nomodule></script>
       <script src="polyfills.js"></script>
       <script src="scripts.js"></script>
       <script src="renamed-script.js"></script>

--- a/tests/legacy-cli/e2e/tests/basic/styles-array.ts
+++ b/tests/legacy-cli/e2e/tests/basic/styles-array.ts
@@ -43,7 +43,7 @@ export default function () {
     `))
     .then(() => expectFileToMatch('dist/test-project/index.html', oneLineTrim`
       <script src="runtime.js"></script>
-      <script src="es2015-polyfills.js" nomodule></script>
+      <script src="polyfills.es5.js" nomodule></script>
       <script src="polyfills.js"></script>
       <script src="vendor.js"></script>
       <script src="main.js"></script>

--- a/tests/legacy-cli/e2e/tests/build/polyfills.ts
+++ b/tests/legacy-cli/e2e/tests/build/polyfills.ts
@@ -15,7 +15,7 @@ export default async function () {
     await expectFileToMatch('dist/test-project/polyfills.js', 'zone.js');
     expectFileToMatch('dist/test-project/index.html', oneLineTrim`
       <script src="runtime.js"></script>
-      <script src="es2015-polyfills.js" nomodule></script>
+      <script src="polyfills.es5.js" nomodule></script>
       <script src="polyfills.js"></script>
     `);
     const jitPolyfillSize = await getFileSize('dist/test-project/polyfills.js');
@@ -28,7 +28,7 @@ export default async function () {
     await expectFileToMatch('dist/test-project/polyfills.js', 'zone.js');
     expectFileToMatch('dist/test-project/index.html', oneLineTrim`
       <script src="runtime.js"></script>
-      <script src="es2015-polyfills.js" nomodule></script>
+      <script src="polyfills.es5.js" nomodule></script>
       <script src="polyfills.js"></script>
     `);
 }

--- a/tests/legacy-cli/e2e/tests/build/styles/extract-css.ts
+++ b/tests/legacy-cli/e2e/tests/build/styles/extract-css.ts
@@ -48,7 +48,7 @@ export default function () {
     `)))
     .then(() => expectFileToMatch('dist/test-project/index.html', oneLineTrim`
       <script src="runtime.js"></script>
-      <script src="es2015-polyfills.js" nomodule></script>
+      <script src="polyfills.es5.js" nomodule></script>
       <script src="polyfills.js"></script>
       <script src="vendor.js"></script>
       <script src="main.js"></script>
@@ -64,7 +64,7 @@ export default function () {
     // index.html lists the right bundles
     .then(() => expectFileToMatch('dist/test-project/index.html', oneLineTrim`
       <script src="runtime.js"></script>
-      <script src="es2015-polyfills.js" nomodule></script>
+      <script src="polyfills.es5.js" nomodule></script>
       <script src="polyfills.js"></script>
       <script src="styles.js"></script>
       <script src="renamed-style.js"></script>

--- a/tests/legacy-cli/e2e/tests/misc/support-ie.ts
+++ b/tests/legacy-cli/e2e/tests/misc/support-ie.ts
@@ -10,7 +10,7 @@ export default async function () {
   });
 
   await ng('build');
-  await expectFileNotToExist('dist/test-project/es2015-polyfills.js');
+  await expectFileNotToExist('dist/test-project/polyfills.es5.js');
   await expectFileToMatch('dist/test-project/index.html', oneLineTrim`
     <script src="runtime.js"></script>
     <script src="polyfills.js"></script>
@@ -20,10 +20,10 @@ export default async function () {
   `);
 
   await ng('build', `--es5BrowserSupport`);
-  await expectFileToMatch('dist/test-project/es2015-polyfills.js', 'core-js');
+  await expectFileToMatch('dist/test-project/polyfills.es5.js', 'core-js');
   await expectFileToMatch('dist/test-project/index.html', oneLineTrim`
     <script src="runtime.js"></script>
-    <script src="es2015-polyfills.js" nomodule></script>
+    <script src="polyfills.es5.js" nomodule></script>
     <script src="polyfills.js"></script>
     <script src="styles.js"></script>
     <script src="vendor.js"></script>

--- a/tests/legacy-cli/e2e/tests/third-party/bootstrap.ts
+++ b/tests/legacy-cli/e2e/tests/third-party/bootstrap.ts
@@ -23,7 +23,7 @@ export default function() {
     .then(() => expectFileToMatch('dist/test-project/styles.css', '* Bootstrap'))
     .then(() => expectFileToMatch('dist/test-project/index.html', oneLineTrim`
       <script src="runtime.js"></script>
-      <script src="es2015-polyfills.js" nomodule></script>
+      <script src="polyfills.es5.js" nomodule></script>
       <script src="polyfills.js"></script>
       <script src="scripts.js"></script>
       <script src="vendor.js"></script>
@@ -40,7 +40,7 @@ export default function() {
     .then(() => expectFileToMatch('dist/test-project/styles.css', '* Bootstrap'))
     .then(() => expectFileToMatch('dist/test-project/index.html', oneLineTrim`
       <script src="runtime.js"></script>
-      <script src="es2015-polyfills.js" nomodule></script>
+      <script src="polyfills.es5.js" nomodule></script>
       <script src="polyfills.js"></script>
       <script src="scripts.js"></script>
       <script src="main.js"></script>


### PR DESCRIPTION
Closes #13808

//cc @StephenFluin 