### PR TITLE
fix(@schematics/angular): use peerDependency on typescript

### DIFF
--- a/packages/schematics/angular/package.json
+++ b/packages/schematics/angular/package.json
@@ -10,7 +10,9 @@
   "schematics": "./collection.json",
   "dependencies": {
     "@angular-devkit/core": "0.0.0",
-    "@angular-devkit/schematics": "0.0.0",
-    "typescript": "3.2.4"
+    "@angular-devkit/schematics": "0.0.0"
+  },
+  "peerDependencies": {
+    "typescript": ">=3.1.1 <3.4"
   }
 }


### PR DESCRIPTION
This saves 7MB in the initial install of @angular/cli which depends on this package