### PR TITLE
Architect qol

### DIFF
--- a/packages/angular_devkit/architect/builders/false.ts
+++ b/packages/angular_devkit/architect/builders/false.ts
@@ -5,10 +5,9 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import { of } from 'rxjs';
 import { createBuilder } from '../src/index2';
 
-export default createBuilder(() => of({
+export default createBuilder(() => ({
   success: false,
   error: 'False builder always errors.',
 }));

--- a/packages/angular_devkit/architect/builders/true.ts
+++ b/packages/angular_devkit/architect/builders/true.ts
@@ -5,7 +5,6 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import { of } from 'rxjs';
 import { createBuilder } from '../src/index2';
 
-export default createBuilder(() => of({ success: true }));
+export default createBuilder(() => ({ success: true }));

--- a/packages/angular_devkit/architect/src/api.ts
+++ b/packages/angular_devkit/architect/src/api.ts
@@ -100,6 +100,17 @@ export interface BuilderRun {
 }
 
 /**
+ * Additional optional scheduling options.
+ */
+export interface ScheduleOptions {
+  /**
+   * Logger to pass to the builder. Note that messages will stop being forwarded, and if you want
+   * to log a builder scheduled from your builder you should forward log events yourself.
+   */
+  logger?: logging.Logger;
+}
+
+/**
  * The context received as a second argument in your builder.
  */
 export interface BuilderContext {
@@ -148,11 +159,13 @@ export interface BuilderContext {
    * Targets are considered the same if the project, the target AND the configuration are the same.
    * @param target The target to schedule.
    * @param overrides A set of options to override the workspace set of options.
+   * @param scheduleOptions Additional optional scheduling options.
    * @return A promise of a run. It will resolve when all the members of the run are available.
    */
   scheduleTarget(
     target: Target,
     overrides?: json.JsonObject,
+    scheduleOptions?: ScheduleOptions,
   ): Promise<BuilderRun>;
 
   /**
@@ -160,12 +173,23 @@ export interface BuilderContext {
    * @param builderName The name of the builder, ie. its `packageName:builderName` tuple.
    * @param options All options to use for the builder (by default empty object). There is no
    *     additional options added, e.g. from the workspace.
+   * @param scheduleOptions Additional optional scheduling options.
    * @return A promise of a run. It will resolve when all the members of the run are available.
    */
   scheduleBuilder(
     builderName: string,
     options?: json.JsonObject,
+    scheduleOptions?: ScheduleOptions,
   ): Promise<BuilderRun>;
+
+  /**
+   * Resolve and return options for a specified target. If the target isn't defined in the
+   * workspace this will reject the promise. This object will be read directly from the workspace
+   * but not validated against the builder of the target.
+   * @param target The target to resolve the options of.
+   * @return A non-validated object resolved from the workspace.
+   */
+  getTargetOptions(target: Target): Promise<json.JsonObject>;
 
   /**
    * Set the builder to running. This should be used if an external event triggered a re-run,

--- a/packages/angular_devkit/build_angular/src/tslint/index2.ts
+++ b/packages/angular_devkit/build_angular/src/tslint/index2.ts
@@ -37,15 +37,17 @@ async function _loadTslint() {
 }
 
 
-async function _run(config: TslintBuilderOptions, context: BuilderContext): Promise<BuilderOutput> {
+async function _run(
+  options: TslintBuilderOptions,
+  context: BuilderContext,
+): Promise<BuilderOutput> {
   const systemRoot = context.workspaceRoot;
   process.chdir(context.currentDirectory);
-  const options = config;
-  const projectName = context.target && context.target.project || '<???>';
+  const projectName = (context.target && context.target.project) || '<???>';
 
   // Print formatter output only for non human-readable formats.
-  const printInfo = ['prose', 'verbose', 'stylish'].includes(options.format || '')
-                    && !options.silent;
+  const printInfo =
+    ['prose', 'verbose', 'stylish'].includes(options.format || '') && !options.silent;
 
   context.reportStatus(`Linting ${JSON.stringify(projectName)}...`);
   if (printInfo) {
@@ -72,8 +74,14 @@ async function _run(config: TslintBuilderOptions, context: BuilderContext): Prom
 
     let i = 0;
     for (const program of allPrograms) {
-      const partial
-        = await _lint(projectTslint, systemRoot, tslintConfigPath, options, program, allPrograms);
+      const partial = await _lint(
+        projectTslint,
+        systemRoot,
+        tslintConfigPath,
+        options,
+        program,
+        allPrograms,
+      );
       if (result === undefined) {
         result = partial;
       } else {


### PR DESCRIPTION
Add a scheduling options to scheduleTarget and Builder on the context so
builders can schedule sub-builds and override the logger.

Add a getTargetOptions() for builders to get access to options from the
host for a specific target. This allows builders to get options, override
some, then scheduleBuilder with those new options, for example.
