### PR TITLE
feat(@schematics/angular): relocate `ng g service-worker` files

### DIFF
--- a/packages/schematics/angular/service-worker/index.ts
+++ b/packages/schematics/angular/service-worker/index.ts
@@ -60,7 +60,7 @@ function updateConfigFile(options: ServiceWorkerOptions, root: string): Rule {
 
     const config = getProjectConfiguration(workspace, options);
     config.serviceWorker = true;
-    config.ngswConfigPath = `${root.endsWith('/') ? root : root + '/'}ngsw-config.json`;
+    config.ngswConfigPath = `${root && !root.endsWith('/') ? root + '/' : root}ngsw-config.json`;
 
     return updateWorkspace(workspace);
   };
@@ -174,17 +174,16 @@ export default function (options: ServiceWorkerOptions): Rule {
       resourcesOutputPath = '/' + resourcesOutputPath.split('/').filter(x => !!x).join('/');
     }
 
-    const root = project.root || project.sourceRoot || '';
     const templateSource = apply(url('./files'), [
       applyTemplates({ ...options, resourcesOutputPath }),
-      move(root),
+      move(project.root),
     ]);
 
     context.addTask(new NodePackageInstallTask());
 
     return chain([
       mergeWith(templateSource),
-      updateConfigFile(options, root),
+      updateConfigFile(options, project.root),
       addDependencies(),
       updateAppModule(options),
     ]);

--- a/packages/schematics/angular/service-worker/index_spec.ts
+++ b/packages/schematics/angular/service-worker/index_spec.ts
@@ -120,7 +120,7 @@ describe('Service Worker Schematic', () => {
       .toContain('/outDir/*.(eot|svg|cur|jpg|png|webp|gif|otf|ttf|woff|woff2|ani)');
   });
 
-  it('should generate ngsw-config.json in src when the application is at root level', () => {
+  it('should generate ngsw-config.json in root when the application is at root level', () => {
     const name = 'foo';
     const rootAppOptions: ApplicationOptions = {
       ...appOptions,
@@ -134,11 +134,11 @@ describe('Service Worker Schematic', () => {
 
     let tree = schematicRunner.runSchematic('application', rootAppOptions, appTree);
     tree = schematicRunner.runSchematic('service-worker', rootSWOptions, tree);
-    expect(tree.exists('/src/ngsw-config.json')).toBe(true);
+    expect(tree.exists('/ngsw-config.json')).toBe(true);
 
     const { projects } = JSON.parse(tree.readContent('/angular.json'));
     expect(projects.foo.architect.build.configurations.production.ngswConfigPath)
-      .toBe('src/ngsw-config.json');
+      .toBe('ngsw-config.json');
   });
 
 });


### PR DESCRIPTION
This is a follow up on https://github.com/angular/angular-cli/pull/13811, with this now all application have the same structure and hence `ng g service-worker` should follow suit and have the same folder structure if generated in a root app, or an app inside the projects.