### PR TITLE
 test: ignore platform-server tests for ivy

### DIFF
--- a/tests/legacy-cli/e2e_runner.ts
+++ b/tests/legacy-cli/e2e_runner.ts
@@ -143,7 +143,13 @@ if (argv.ivy) {
     .filter(name => !name.includes('tests/i18n/'))
     .filter(name => !name.endsWith('tests/build/aot/aot-i18n.ts'))
     // We don't have a library consumption story yet for Ivy.
-    .filter(name => !name.endsWith('tests/generate/library/library-consumption.ts'));
+    .filter(name => !name.endsWith('tests/generate/library/library-consumption.ts'))
+    // We don't have a platform-server usage story yet for Ivy.
+    // It's contingent on lazy loading and factory shim considerations that are still being
+    // discussed.
+    .filter(name => !name.endsWith('tests/build/platform-server.ts'))
+    .filter(name => !name.endsWith('tests/build/build-app-shell.ts'))
+    .filter(name => !name.endsWith('tests/build/build-app-shell-with-schematic.ts'));
 }
 
 const shardId = ('shard' in argv) ? argv['shard'] : null;


### PR DESCRIPTION
We don't have a platform-server usage story yet for Ivy.
It's contingent on lazy loading and factory shim considerations that are still being discussed.


This job is red on master so we need to remove it for now. The ivy job only runs on master, so to verify the changes make it pass, I ran it with a modified circleci config: https://circleci.com/gh/angular/angular-cli/43439