### PR TITLE
Extensions

### DIFF
--- a/packages/schematics/angular/migrations/migration-collection.json
+++ b/packages/schematics/angular/migrations/migration-collection.json
@@ -29,6 +29,11 @@
       "version": "7.0.3",
       "factory": "./update-7/index#updateDevkitBuildNgPackagr",
       "description": "Update an Angular CLI project to version 7."
+    },
+    "migration-07": {
+      "version": "8.0.0",
+      "factory": "./update-vscode-recommendations/update-8.0.0",
+      "description": "Update an Angular CLI project to version 8.0.0"
     }
   }
 }

--- a/packages/schematics/angular/migrations/update-vscode-recommendations/ast-utils.ts
+++ b/packages/schematics/angular/migrations/update-vscode-recommendations/ast-utils.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { Rule, Tree } from '@angular-devkit/schematics';
+
+export function readJsonInTree<T>(host: Tree, path: string): T {
+  if (!host.exists(path)) {
+    throw new Error(`Cannot find ${path}`);
+  }
+
+  const json = host.read(path);
+  if (!json) {
+    throw new Error(`Cannot read ${path}`);
+  }
+
+  return JSON.parse(json.toString('utf-8'));
+}
+
+export function serializeJson<T>(json: T): string {
+  return `${JSON.stringify(json, null, 2)}\n`;
+}
+
+export function updateJsonInTree<T, O = T>(
+  path: string,
+  callback: (json: T) => O,
+): Rule {
+  return (host: Tree): Tree => {
+    if (!host.exists(path)) {
+      host.create(path, serializeJson(callback({} as T)));
+
+      return host;
+    }
+    host.overwrite(path, serializeJson(callback(readJsonInTree(host, path))));
+
+    return host;
+  };
+}

--- a/packages/schematics/angular/migrations/update-vscode-recommendations/update-8.0.0.ts
+++ b/packages/schematics/angular/migrations/update-vscode-recommendations/update-8.0.0.ts
@@ -1,0 +1,27 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { Rule, chain } from '@angular-devkit/schematics';
+import { updateJsonInTree } from './ast-utils';
+
+export default function (): Rule {
+  return chain([addExtensionRecommendations]);
+}
+
+const addExtensionRecommendations = updateJsonInTree(
+  '.vscode/extensions.json',
+  (json: { recommendations?: string[] }) => {
+    ['angular.ng-template', 'ms-vscode.vscode-typescript-tslint-plugin'].forEach(extension => {
+      json.recommendations = json.recommendations || [];
+      if (!json.recommendations.includes(extension)) {
+        json.recommendations.push(extension);
+      }
+    });
+
+    return json;
+  },
+);

--- a/packages/schematics/angular/migrations/update-vscode-recommendations/update-8.0.0.ts
+++ b/packages/schematics/angular/migrations/update-vscode-recommendations/update-8.0.0.ts
@@ -15,12 +15,15 @@ export default function (): Rule {
 const addExtensionRecommendations = updateJsonInTree(
   '.vscode/extensions.json',
   (json: { recommendations?: string[] }) => {
-    ['angular.ng-template', 'ms-vscode.vscode-typescript-tslint-plugin'].forEach(extension => {
-      json.recommendations = json.recommendations || [];
-      if (!json.recommendations.includes(extension)) {
-        json.recommendations.push(extension);
-      }
-    });
+    [
+      'angular.ng-template',
+      'nrwl.angular-console',
+      'ms-vscode.vscode-typescript-tslint-plugin'].forEach(extension => {
+        json.recommendations = json.recommendations || [];
+        if (!json.recommendations.includes(extension)) {
+          json.recommendations.push(extension);
+        }
+      });
 
     return json;
   },

--- a/packages/schematics/angular/migrations/update-vscode-recommendations/update-8.0.0_spec.ts
+++ b/packages/schematics/angular/migrations/update-vscode-recommendations/update-8.0.0_spec.ts
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { Tree } from '@angular-devkit/schematics';
+import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
+import { readJsonInTree, serializeJson, updateJsonInTree } from './ast-utils';
+
+describe('Update 8.0.0', () => {
+  let initialTree: Tree;
+  let schematicRunner: SchematicTestRunner;
+
+  beforeEach(() => {
+    initialTree = Tree.empty();
+
+    initialTree.create(
+      'package.json',
+      serializeJson({
+        devDependencies: { '@angular/cli': '7.1.0', typescript: '~3.1.0' },
+      }),
+    );
+
+    schematicRunner = new SchematicTestRunner(
+      'migrations',
+      require.resolve('../migration-collection.json'),
+    );
+  });
+
+  it('should add vscode extension recommendations', async () => {
+    const result = await schematicRunner
+      .runSchematicAsync('migration-07', {}, initialTree)
+      .toPromise();
+
+    expect(readJsonInTree(result, '.vscode/extensions.json')).toEqual({
+      recommendations: ['angular.ng-template', 'ms-vscode.vscode-typescript-tslint-plugin'],
+    });
+  });
+
+  it('should add to existing vscode extension recommendations', async () => {
+    initialTree = await schematicRunner
+      .callRule(
+        updateJsonInTree('.vscode/extensions.json', () => ({
+          recommendations: [
+            'eamodio.gitlens', 'angular.ng-template', 'ms-vscode.vscode-typescript-tslint-plugin'],
+        })),
+        initialTree,
+      )
+      .toPromise();
+
+    const result = await schematicRunner
+      .runSchematicAsync('migration-07', {}, initialTree)
+      .toPromise();
+
+    expect(readJsonInTree(result, '.vscode/extensions.json')).toEqual({
+      recommendations: [
+        'eamodio.gitlens', 'angular.ng-template', 'ms-vscode.vscode-typescript-tslint-plugin'],
+    });
+  });
+});

--- a/packages/schematics/angular/migrations/update-vscode-recommendations/update-8.0.0_spec.ts
+++ b/packages/schematics/angular/migrations/update-vscode-recommendations/update-8.0.0_spec.ts
@@ -35,7 +35,8 @@ describe('Update 8.0.0', () => {
       .toPromise();
 
     expect(readJsonInTree(result, '.vscode/extensions.json')).toEqual({
-      recommendations: ['angular.ng-template', 'ms-vscode.vscode-typescript-tslint-plugin'],
+      recommendations: [
+        'angular.ng-template', 'nrwl.angular-console', 'ms-vscode.vscode-typescript-tslint-plugin'],
     });
   });
 
@@ -44,7 +45,10 @@ describe('Update 8.0.0', () => {
       .callRule(
         updateJsonInTree('.vscode/extensions.json', () => ({
           recommendations: [
-            'eamodio.gitlens', 'angular.ng-template', 'ms-vscode.vscode-typescript-tslint-plugin'],
+            'eamodio.gitlens',
+            'angular.ng-template',
+            'nrwl.angular-console',
+            'ms-vscode.vscode-typescript-tslint-plugin'],
         })),
         initialTree,
       )
@@ -56,7 +60,10 @@ describe('Update 8.0.0', () => {
 
     expect(readJsonInTree(result, '.vscode/extensions.json')).toEqual({
       recommendations: [
-        'eamodio.gitlens', 'angular.ng-template', 'ms-vscode.vscode-typescript-tslint-plugin'],
+        'eamodio.gitlens',
+        'angular.ng-template',
+        'nrwl.angular-console',
+        'ms-vscode.vscode-typescript-tslint-plugin'],
     });
   });
 });

--- a/packages/schematics/angular/workspace/files/__dot__vscode/README.md
+++ b/packages/schematics/angular/workspace/files/__dot__vscode/README.md
@@ -1,0 +1,23 @@
+# VSCode extensions recommended by Angular CLI
+
+Extensions that appear in `extensions.json` will be suggested to CLI users in the extensions panel in VSCode.
+
+The extensions are not installed automatically; it's up to users to accept a suggestion and install it themselves.
+
+Similarly, if we remove a recommended extension, it remains installed.
+We don't have a mechanism yet to alert users that we no longer recommend an extension.
+
+## Current extensions
+
+We recommend "official, first-party" extensions.
+
+This means they are authored and governed by either the Angular or VSCode teams.
+We do this because our recommendations carry an obligation for us to address some issues, especially privacy or security vulnerabilities.
+Extensions that we don't control could have problems, and we are not in a position to mediate these.
+
+## Criteria for adding new recommendations
+
+The Angular team loves the great work of the community in making VSCode more useful for Angular development.
+We would like to highlight community-developed extensions by recommending them, but this requires that we develop consistent criteria for choosing which to recommend.
+We are working to develop unbiased criteria in the future which are fair to the community.
+The biggest challenge is that we could easily recommend dozens of extensions, with overlapping feature sets, which makes it more confusing for developers to get a reasonable setup.

--- a/packages/schematics/angular/workspace/files/__dot__vscode/README.md
+++ b/packages/schematics/angular/workspace/files/__dot__vscode/README.md
@@ -15,6 +15,8 @@ This means they are authored and governed by either the Angular or VSCode teams.
 We do this because our recommendations carry an obligation for us to address some issues, especially privacy or security vulnerabilities.
 Extensions that we don't control could have problems, and we are not in a position to mediate these.
 
+(Note that the Angular Console extension from Nrwl is a joint effort with the Angular team, who has final governance control.)
+
 ## Criteria for adding new recommendations
 
 The Angular team loves the great work of the community in making VSCode more useful for Angular development.

--- a/packages/schematics/angular/workspace/files/__dot__vscode/extensions.json.template
+++ b/packages/schematics/angular/workspace/files/__dot__vscode/extensions.json.template
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "angular.ng-template",
+    "ms-vscode.vscode-typescript-tslint-plugin
+  ]
+}

--- a/packages/schematics/angular/workspace/files/__dot__vscode/extensions.json.template
+++ b/packages/schematics/angular/workspace/files/__dot__vscode/extensions.json.template
@@ -1,6 +1,7 @@
 {
   "recommendations": [
     "angular.ng-template",
-    "ms-vscode.vscode-typescript-tslint-plugin
+    "nrwl.angular-console",
+    "ms-vscode.vscode-typescript-tslint-plugin"
   ]
 }


### PR DESCRIPTION
Rolling this forward with a README explaining our agreed-on policy.

@cyrilletuzi we want to find a fair way to include extensions from the community, including yours. We are stuck on how to do this without confusing users with a set of overlapping extensions - we assume that many users will install all of our recommendations. That forces us to pick winners and that's not a good position for us to be in.
The governance constraint is the primary one we'll use for guidance in version 8. So the easiest path to get your code in front of users is to make it first-party.
Happy to discuss further.

/fyi @mrmeku  