### PR TITLE
Update Node.js version minimum to 10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,6 @@
 # See https://circleci.com/docs/2.0/caching/#restoring-cache for how prefixes work in CircleCI.
 var_1: &docker_image angular/ngcontainer:0.10.0
 var_2: &cache_key angular_devkit-0.10.0-{{ checksum "yarn.lock" }}
-var_3: &node_8_docker_image angular/ngcontainer:0.3.3
 
 # Settings common to each job
 anchor_1: &defaults
@@ -114,20 +113,6 @@ jobs:
           path: /tmp/dist
           destination: cli/new-production
 
-  e2e-node-8:
-    <<: *defaults
-    # Overwrite docker image to node 8.
-    docker:
-      - image: *node_8_docker_image
-    environment:
-      BASH_ENV: ~/.profile
-    resource_class: xlarge
-    parallelism: 2
-    steps:
-      - attach_workspace: *attach_options
-      - run: npm install --global npm@6
-      - run: xvfb-run -a node ./tests/legacy-cli/run_e2e --glob=tests/basic/* --nb-shards=${CIRCLE_NODE_TOTAL} --shard=${CIRCLE_NODE_INDEX}
-
   e2e-cli-ng-snapshots:
     <<: *defaults
     environment:
@@ -216,9 +201,6 @@ workflows:
           requires:
             - build
       - e2e-cli:
-          requires:
-            - build
-      - e2e-node-8:
           requires:
             - build
       - snapshot_publish_docs:

--- a/lib/packages.ts
+++ b/lib/packages.ts
@@ -117,8 +117,8 @@ function loadPackageJson(p: string) {
       // Overwrite engines to a common default.
       case 'engines':
         pkg['engines'] = {
-          'node': '>= 8.9.0',
-          'npm': '>= 5.5.1',
+          'node': '>= 10.9.0',
+          'npm': '>= 6.2.0',
         };
         break;
 

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@types/jasmine": "^3.3.8",
     "@types/loader-utils": "^1.1.3",
     "@types/minimist": "^1.2.0",
-    "@types/node": "8.10.10",
+    "@types/node": "10.9.4",
     "@types/request": "^2.47.1",
     "@types/semver": "^5.5.0",
     "@types/source-map": "0.5.2",

--- a/packages/angular/cli/bin/ng
+++ b/packages/angular/cli/bin/ng
@@ -12,10 +12,10 @@ try {
 
 // Some older versions of Node do not support let or const.
 var version = process.version.substr(1).split('.');
-if (Number(version[0]) < 8 || (Number(version[0]) === 8 && Number(version[1]) < 9)) {
+if (Number(version[0]) < 10 || (Number(version[0]) === 10 && Number(version[1]) < 9)) {
   process.stderr.write(
-    'You are running version ' + process.version + ' of Node.js, which is not supported by Angular CLI v6.\n' +
-    'The official Node.js version that is supported is 8.9 and greater.\n\n' +
+    'You are running version ' + process.version + ' of Node.js, which is not supported by Angular CLI 8.0+.\n' +
+    'The official Node.js version that is supported is 10.9 or greater.\n\n' +
     'Please visit https://nodejs.org/en/ to find instructions on how to update Node.js.\n'
   );
 

--- a/packages/angular/cli/tasks/npm-install.ts
+++ b/packages/angular/cli/tasks/npm-install.ts
@@ -48,13 +48,9 @@ export default async function (packageName: string,
   if (!save) {
     installArgs.push('--no-save');
   }
-  const installOptions = {
-    stdio: 'inherit',
-    shell: true,
-  };
 
   await new Promise((resolve, reject) => {
-    spawn(packageManager, installArgs, installOptions)
+    spawn(packageManager, installArgs, { stdio: 'inherit', shell: true })
       .on('close', (code: number) => {
         if (code === 0) {
           logger.info(terminal.green(`Installed packages for tooling via ${packageManager}.`));

--- a/packages/angular_devkit/benchmark/package.json
+++ b/packages/angular_devkit/benchmark/package.json
@@ -10,8 +10,8 @@
     "benchmark"
   ],
   "engines": {
-    "node": ">= 8.9.0",
-    "npm": ">= 5.5.1"
+    "node": ">= 10.9.0",
+    "npm": ">= 6.2.0"
   },
   "dependencies": {
     "@angular-devkit/core": "0.0.0",

--- a/packages/angular_devkit/build_angular/test/dev-server/proxy_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/dev-server/proxy_spec_large.ts
@@ -9,11 +9,11 @@
 import { request, runTargetSpec } from '@angular-devkit/architect/testing';
 import * as express from 'express'; // tslint:disable-line:no-implicit-dependencies
 import * as http from 'http';
+import { AddressInfo } from 'net';
 import { from } from 'rxjs';
 import { concatMap, take, tap } from 'rxjs/operators';
 import { Schema as DevServerBuilderOptions } from '../../src/dev-server/schema';
 import { devServerTargetSpec, host } from '../utils';
-
 
 describe('Dev Server Builder proxy', () => {
   beforeEach(done => host.initialize().toPromise().then(done, done.fail));
@@ -25,13 +25,15 @@ describe('Dev Server Builder proxy', () => {
     const server = http.createServer(app);
     server.listen(0);
 
-    app.set('port', server.address().port);
+    // cast is safe, the HTTP server is not using a pipe or UNIX domain socket
+    app.set('port', (server.address() as AddressInfo).port);
     app.get('/api/test', function (_req, res) {
       res.send('TEST_API_RETURN');
     });
 
     const backendHost = 'localhost';
-    const backendPort = server.address().port;
+    // cast is safe, the HTTP server is not using a pipe or UNIX domain socket
+    const backendPort = (server.address() as AddressInfo).port;
     const proxyServerUrl = `http://${backendHost}:${backendPort}`;
 
     host.writeMultipleFiles({

--- a/packages/angular_devkit/build_webpack/src/webpack-dev-server/index2.ts
+++ b/packages/angular_devkit/build_webpack/src/webpack-dev-server/index2.ts
@@ -73,11 +73,12 @@ export function runWebpackDevServer(
           if (err) {
             obs.error(err);
           } else {
+            const address = this.address();
             result = {
               success: true,
-              port: this.address().port,
-              family: this.address().family,
-              address: this.address().address,
+              port: typeof address === 'string' ? 0 : address.port,
+              family: typeof address === 'string' ? '' : address.family,
+              address: typeof address === 'string' ? address : address.address,
             };
           }
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -407,15 +407,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node@*":
+"@types/node@*", "@types/node@10.9.4":
   version "10.9.4"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.9.4.tgz#0f4cb2dc7c1de6096055357f70179043c33e9897"
   integrity sha512-fCHV45gS+m3hH17zgkgADUSi2RR1Vht6wOZ0jyHP8rjiQra9f+mIcgwPQHllmDocYOstIEbKlxbFDYlgrTPYqw==
-
-"@types/node@8.10.10":
-  version "8.10.10"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.10.tgz#fec07bc2ad549d9e6d2f7aa0fb0be3491b83163a"
-  integrity sha512-p3W/hFzQs76RlYRIZsZc5a9bht6m0TspmWYYbKhRswmLnwj9fsE40EbuGifeu/XWR/c0UJQ1DDbvTxIsm/OOAA==
 
 "@types/node@^6.0.46":
   version "6.14.0"


### PR DESCRIPTION
Node.js 8 is now in maintenance LTS status and will be EOL in December 2019.  Node.js 10 is now the active LTS version with Node.js 12 due for arrival in April 2019.  Node.js 10+ provides an improved performance baseline as well as access to newer Node.js APIs and Javascript language features which the Angular CLI will now be able to leverage.

ref: https://nodejs.org/en/about/releases/

The minimum npm version was also synchronized with the version bundled with the new minimum Node.js version.
Also fixes several type issues related to the updated Node.js API.