### PR TITLE
fix(angular-devkit/build-angular): fix check for absolute paths in wi…

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/server.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/server.ts
@@ -5,6 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import { isAbsolute } from 'path';
 import { Configuration } from 'webpack';
 import { WebpackConfigOptions } from '../build-options';
 import { getSourceMapDevTool } from './utils';
@@ -38,7 +39,7 @@ export function getServerConfig(wco: WebpackConfigOptions) {
       /^@angular/,
       (context: string, request: string, callback: (error?: null, result?: string) => void) => {
         // Absolute & Relative paths are not externals
-        if (request.match(/^\.{0,2}\//)) {
+        if (/^\.{0,2}\//.test(request) || isAbsolute(request)) {
           return callback();
         }
 


### PR DESCRIPTION
…ndows in server config

This changes fixes `Error: You must pass in a NgModule or NgModuleFactory to be bootstrapped`.

At the moment the check for absolute path is not correct for windows.

Fixes #13865 and fixes https://github.com/angular/universal/issues/1139