### PR TITLE
fix(@angular-devkit/build-angular): fix base href insertion when HTML…

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/index-html-webpack-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/index-html-webpack-plugin.ts
@@ -200,7 +200,7 @@ export class IndexHtmlWebpackPlugin {
 
           treeAdapter.appendChild(baseFragment, baseElement);
           indexSource.insert(
-            headElement.__location.startTag.endOffset + 1,
+            headElement.__location.startTag.endOffset,
             parse5.serialize(baseFragment, { treeAdapter }),
           );
         } else {


### PR DESCRIPTION
… is in a single line

When HTML is in a single line using offset + 1 will cause the insertion of the base href tag in the wrong possition.

Fixes #13851