### PR TITLE
Remove dependency from @angular-devkit/core to chokidar

### DIFF
--- a/packages/angular_devkit/core/BUILD
+++ b/packages/angular_devkit/core/BUILD
@@ -72,7 +72,6 @@ jasmine_node_test(
     deps = [
         "@npm//jasmine",
         "@npm//source-map",
-        "@npm//chokidar",
     ],
 )
 

--- a/packages/angular_devkit/core/package.json
+++ b/packages/angular_devkit/core/package.json
@@ -9,7 +9,6 @@
   ],
   "dependencies": {
     "ajv": "6.10.0",
-    "chokidar": "2.1.2",
     "fast-json-stable-stringify": "2.0.0",
     "rxjs": "6.4.0",
     "source-map": "0.7.3"

--- a/packages/angular_devkit/schematics/BUILD
+++ b/packages/angular_devkit/schematics/BUILD
@@ -61,7 +61,6 @@ jasmine_node_test(
     name = "schematics_test",
     srcs = [":schematics_test_lib"],
     deps = [
-        "@npm//chokidar",
         "@npm//jasmine",
         "@npm//source-map",
     ],
@@ -159,7 +158,6 @@ jasmine_node_test(
     deps = [
         "@npm//jasmine",
         "@npm//source-map",
-        "@npm//chokidar",
     ],
 )
 
@@ -225,7 +223,6 @@ jasmine_node_test(
     deps = [
         "@npm//jasmine",
         "@npm//source-map",
-        "@npm//chokidar",
     ],
 )
 

--- a/packages/schematics/angular/BUILD
+++ b/packages/schematics/angular/BUILD
@@ -102,7 +102,6 @@ jasmine_node_test(
     deps = [
         "@npm//jasmine",
         "@npm//source-map",
-        "@npm//chokidar",
         "//packages/schematics/angular/third_party/github.com/Microsoft/TypeScript",
     ],
 )

--- a/packages/schematics/update/BUILD
+++ b/packages/schematics/update/BUILD
@@ -83,7 +83,6 @@ jasmine_node_test(
     deps = [
         "@npm//jasmine",
         "@npm//source-map",
-        "@npm//chokidar",
         "@npm//npm-registry-client",
     ],
 )


### PR DESCRIPTION
It is unused within our code, as webpack will do the file watching.

BREAKING CHANGE:
Users who rely on angular-devkit/core to do the file watching must add chokidar to their devDependencies.