### PR TITLE
fix(@angular-devkit/build-angular): resolve fonts with space in filename

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/cleancss-webpack-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/cleancss-webpack-plugin.ts
@@ -52,7 +52,10 @@ export class CleanCssWebpackPlugin {
         compatibility: 'ie9',
         level: {
           2: {
-            skipProperties: ['transition'] // Fixes #12408
+            skipProperties: [
+              'transition', // Fixes #12408
+              'font', // Fixes #9648
+            ] 
           }
         },
         inline: false,

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/postcss-cli-resources.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/postcss-cli-resources.ts
@@ -103,7 +103,7 @@ export default postcss.plugin('postcss-cli-resources', (options: PostcssCliResou
 
     const { pathname, hash, search } = url.parse(inputUrl.replace(/\\/g, '/'));
     const resolver = (file: string, base: string) => new Promise<string>((resolve, reject) => {
-      loader.resolve(base, file, (err, result) => {
+      loader.resolve(base, decodeURI(file), (err, result) => {
         if (err) {
           reject(err);
 

--- a/packages/angular_devkit/build_angular/test/browser/styles2_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/browser/styles2_spec_large.ts
@@ -8,7 +8,7 @@
 // tslint:disable:no-big-function
 
 import { Architect } from '@angular-devkit/architect/src/index2';
-import { normalize, tags } from '@angular-devkit/core';
+import { logging, normalize, tags } from '@angular-devkit/core';
 import { browserBuild, createArchitect, host } from '../utils';
 
 
@@ -594,5 +594,24 @@ describe('Browser Builder styles', () => {
     const overrides = { extractCss: true };
     const { output } = await browserBuild(architect, host, target, overrides);
     expect(output.success).toBe(true);
+  });
+
+  it('supports font names with spaces', async () => {
+    host.writeMultipleFiles({
+      'src/styles.css': `
+        body {
+          font: 10px "Font Awesome";
+        }
+      `,
+    });
+
+    const overrides = { extractCss: true, optimization: true };
+    const logger = new logging.Logger('font-name-spaces');
+    const logs: string[] = [];
+    logger.subscribe(e => logs.push(e.message));
+
+    const { output } = await browserBuild(architect, host, target, overrides, { logger });
+    expect(output.success).toBe(true);
+    expect(logs.join()).not.toContain('WARNING in Invalid font values ');
   });
 });

--- a/packages/angular_devkit/build_angular/test/browser/styles2_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/browser/styles2_spec_large.ts
@@ -575,4 +575,24 @@ describe('Browser Builder styles', () => {
     const { files } = await browserBuild(architect, host, target, overrides);
     expect(await files['styles.css']).toContain('background-image:url(//cdn.com/classic-bg.jpg)');
   });
+
+  it('supports fonts with space in filename', async () => {
+    host.writeMultipleFiles({
+      'src/styles.css': `
+        @font-face {
+          font-family: "Font Awesome";
+          src: url("./assets/fa solid-900.woff2") format("woff2");
+        }
+
+        body {
+          font-family: "Font Awesome";
+        }
+      `,
+      'src/assets/fa solid-900.woff2': '',
+    });
+
+    const overrides = { extractCss: true };
+    const { output } = await browserBuild(architect, host, target, overrides);
+    expect(output.success).toBe(true);
+  });
 });


### PR DESCRIPTION
At the moment the uri of the font instead of spaced it will be `%20`, hence we need to decode it first before trying to resolve it.

Fixes #9648