### PR TITLE
feat(@angular-devkit/build-angular): remove Closure compiler i18n code for ivy

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
@@ -237,10 +237,11 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
       },
 
       // On server, we don't want to compress anything. We still set the ngDevMode = false for it
-      // to remove dev code.
+      // to remove dev code, and ngI18nClosureMode to remove Closure compiler i18n code
       compress: (buildOptions.platform == 'server' ? {
         global_defs: {
           ngDevMode: false,
+          ngI18nClosureMode: false,
         },
       } : {
           pure_getters: buildOptions.buildOptimizer,
@@ -249,6 +250,7 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
           passes: buildOptions.buildOptimizer ? 3 : 1,
           global_defs: {
             ngDevMode: false,
+            ngI18nClosureMode: false,
           },
         }),
       // We also want to avoid mangling on server.


### PR DESCRIPTION
For runtime i18n with ivy we generate code for both Closure compiler (used at Google) and for external people that don't use Closure compiler.
We added a new global flag named `ngI18nClosureMode` that allows uglify (and Closure compiler) to effectively tree-shake all of the code that isn't used in the current setup.
By default we remove all of the Closure compiler code because we assume that it won't be used.

Required for https://github.com/angular/angular/pull/28689.