### PR TITLE
feat(@angular-devkit/build-angular): enable webpack profile when usin…

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
@@ -280,6 +280,7 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
       ? 'production'
       : 'development',
     devtool: false,
+    profile: buildOptions.statsJson,
     resolve: {
       extensions: ['.ts', '.tsx', '.mjs', '.js'],
       symlinks: !buildOptions.preserveSymlinks,

--- a/packages/angular_devkit/build_angular/test/browser/stats-json_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/browser/stats-json_spec_large.ts
@@ -23,4 +23,11 @@ describe('Browser Builder stats json', () => {
     const { files } = await browserBuild(architect, host, target, { statsJson: true });
     expect('stats.json' in files).toBe(true);
   });
+
+  it('works with profile flag', async () => {
+    const { files } = await browserBuild(architect, host, target, { statsJson: true });
+    expect('stats.json' in files).toBe(true);
+    const stats = await files['stats.json'];
+    expect(stats).toMatch(/profile.+building/);
+  });
 });


### PR DESCRIPTION
…g stats-json flag

More information about what `profile` does can be found here: https://webpack.js.org/api/stats

Closes #13907