### PR TITLE
feat(@angular-devkit/build-angular): deprecate `profile` option in build

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
@@ -75,7 +75,7 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
     }
   }
 
-  if (buildOptions.profile) {
+  if (buildOptions.profile || process.env['NG_BUILD_PROFILING']) {
     extraPlugins.push(new debug.ProfilingPlugin({
       outputPath: path.resolve(root, 'chrome-profiler-events.json'),
     }));

--- a/packages/angular_devkit/build_angular/src/browser/index.ts
+++ b/packages/angular_devkit/build_angular/src/browser/index.ts
@@ -156,7 +156,7 @@ export class BrowserBuilder implements Builder<BrowserBuilderSchema> {
 
     const webpackConfig = webpackMerge(webpackConfigs);
 
-    if (options.profile) {
+    if (options.profile || process.env['NG_BUILD_PROFILING']) {
       const smp = new SpeedMeasurePlugin({
         outputFormat: 'json',
         outputTarget: getSystemPath(join(root, 'speed-measure-plugin.json')),

--- a/packages/angular_devkit/build_angular/src/browser/index2.ts
+++ b/packages/angular_devkit/build_angular/src/browser/index2.ts
@@ -141,7 +141,7 @@ export function buildWebpackConfig(
 
   const webpackConfig = webpackMerge(webpackConfigs);
 
-  if (options.profile) {
+  if (options.profile || process.env['NG_BUILD_PROFILING']) {
     const smp = new SpeedMeasurePlugin({
       outputFormat: 'json',
       outputTarget: getSystemPath(join(root, 'speed-measure-plugin.json')),

--- a/packages/angular_devkit/build_angular/src/browser/schema.json
+++ b/packages/angular_devkit/build_angular/src/browser/schema.json
@@ -300,7 +300,8 @@
     "profile": {
       "type": "boolean",
       "description": "Output profile events for Chrome profiler.",
-      "default": false
+      "default": false,
+      "x-deprecated": "Use \"NG_BUILD_PROFILING\" environment variable instead."
     },
     "es5BrowserSupport": {
       "description": "Enables conditionally loaded ES2015 polyfills.",


### PR DESCRIPTION
This flag has been deprecated in favor of the `NG_BUILD_PROFILING`  environment variable. This is mainly due not to expose debugging flag in our API.