### PR TITLE
feat(@angular-devkit/build-webpack): report emitted files

### DIFF
--- a/packages/angular_devkit/build_webpack/src/index.ts
+++ b/packages/angular_devkit/build_webpack/src/index.ts
@@ -10,3 +10,5 @@ export * from './webpack';
 export * from './webpack-dev-server';
 
 export * from './plugins/architect';
+
+export { EmittedFiles } from './utils';

--- a/packages/angular_devkit/build_webpack/src/utils.ts
+++ b/packages/angular_devkit/build_webpack/src/utils.ts
@@ -1,0 +1,47 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as webpack from 'webpack';
+
+export interface EmittedFiles {
+  name?: string;
+  file: string;
+  initial: boolean;
+  extension: string;
+}
+
+export function getEmittedFiles(compilation: webpack.compilation.Compilation): EmittedFiles[] {
+  const getExtension = (file: string) => file.split('.').reverse()[0];
+  const files: EmittedFiles[] = [];
+
+  for (const chunk of Object.values(compilation.chunks)) {
+    const entry: Partial<EmittedFiles> = {
+      name: chunk.name,
+      initial: chunk.isOnlyInitial(),
+    };
+
+    for (const file of chunk.files) {
+      files.push({ ...entry, file, extension: getExtension(file) } as EmittedFiles);
+    }
+  }
+
+  for (const file of Object.keys(compilation.assets)) {
+    if (files.some(e => e.file === file)) {
+      // skip as this already exists
+      continue;
+    }
+
+    files.push({
+      file,
+      extension: getExtension(file),
+      initial: false,
+    });
+  }
+
+  return files;
+}

--- a/packages/angular_devkit/build_webpack/src/webpack-dev-server/index2_spec_large.ts
+++ b/packages/angular_devkit/build_webpack/src/webpack-dev-server/index2_spec_large.ts
@@ -7,7 +7,7 @@
  */
 import { Architect } from '@angular-devkit/architect/src/index2';
 import { TestingArchitectHost } from '@angular-devkit/architect/testing/index2';
-import { experimental, join, normalize, schema } from '@angular-devkit/core';
+import { experimental, normalize, schema } from '@angular-devkit/core';
 import { NodeJsSyncHost } from '@angular-devkit/core/node';
 import * as fs from 'fs';
 import fetch from 'node-fetch';  // tslint:disable-line:no-implicit-dependencies
@@ -15,7 +15,7 @@ import * as path from 'path';
 import { WorkspaceNodeModulesArchitectHost } from '../../../architect/node';
 import { DevServerBuildOutput } from './index2';
 
-const devkitRoot = normalize((global as any)._DevKitRoot); // tslint:disable-line:no-any
+const devkitRoot = (global as any)._DevKitRoot; // tslint:disable-line:no-any
 
 
 describe('Dev Server Builder', () => {
@@ -42,7 +42,7 @@ describe('Dev Server Builder', () => {
   }
 
   beforeEach(async () => {
-    await createArchitect(join(devkitRoot, 'tests/angular_devkit/build_webpack/basic-app/'));
+    await createArchitect(path.join(devkitRoot, 'tests/angular_devkit/build_webpack/basic-app/'));
   });
 
   it('works', async () => {
@@ -53,6 +53,20 @@ describe('Dev Server Builder', () => {
     const response = await fetch(`http://${output.address}:${output.port}/bundle.js`);
     expect(await response.text()).toContain(`console.log('hello world')`);
 
+    await run.stop();
+  }, 30000);
+
+  it('works and returns emitted files', async () => {
+    const run = await architect.scheduleTarget(webpackTargetSpec);
+    const output = await run.result as DevServerBuildOutput;
+
+    expect(output.success).toBe(true);
+    expect(output.emittedFiles).toContain({
+      name: 'main',
+      initial: true,
+      file: 'bundle.js',
+      extension: 'js',
+    });
     await run.stop();
   }, 30000);
 });


### PR DESCRIPTION
With this change the builder will report the emitted chunks and assets after the compilation, this is needed for deferential loading so that we can build an index from the outputs of multiple builds