### PR TITLE
ci: run e2e snapshots for renovate user

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,7 @@ jobs:
       - run:
           name: Don't run expensive e2e tests for forks other than renovate-bot and angular
           command: >
-            if [[ "$CIRCLE_PROJECT_USERNAME" != "renovate-bot" ]] &&
+            if [[ "$CIRCLE_PR_USERNAME" != "renovate-bot" ]] &&
                [[ "$CIRCLE_PROJECT_USERNAME" != "angular" || $CIRCLE_BRANCH != "master" ]]; then
               circleci step halt
             fi
@@ -133,7 +133,7 @@ jobs:
       - run:
           name: Don't run expensive e2e tests for forks other than renovate-bot and angular
           command: >
-            if [[ "$CIRCLE_PROJECT_USERNAME" != "renovate-bot" ]] &&
+            if [[ "$CIRCLE_PR_USERNAME" != "renovate-bot" ]] &&
                [[ "$CIRCLE_PROJECT_USERNAME" != "angular" || $CIRCLE_BRANCH != "master" ]]; then
               circleci step halt
             fi


### PR DESCRIPTION
When a PR is opened by an upstream user, the username value will be available in `CIRCLE_PR_USERNAME` environment variable and not `CIRCLE_PROJECT_USERNAME`

```
  CIRCLE_PROJECT_REPONAME=angular-cli
  CIRCLE_PROJECT_USERNAME=angular
  CIRCLE_PR_NUMBER=13923
  CIRCLE_PR_REPONAME=angular-cli
  CIRCLE_PR_USERNAME=renovate-bot
```

see https://circleci.com/gh/angular/angular-cli/45116#tests/containers/0