### PR TITLE
fix(@schematics/angular): remove baseUrl from universal tsconfig

### DIFF
--- a/packages/schematics/angular/universal/files/root/__tsconfigFileName__.json.template
+++ b/packages/schematics/angular/universal/files/root/__tsconfigFileName__.json.template
@@ -1,10 +1,9 @@
 {
   "extends": "./<%= tsConfigExtends %>",
   "compilerOptions": {
-    "outDir": "<%= outDir %>-server",
-    "baseUrl": "."
+    "outDir": "<%= outDir %>-server"
   },
   "angularCompilerOptions": {
-    "entryModule": "<%= rootInSrc ? '' : 'src/' %><%= appDir %>/<%= stripTsExtension(rootModuleFileName) %>#<%= rootModuleClassName %>"
+    "entryModule": "./<%= rootInSrc ? '' : 'src/' %><%= appDir %>/<%= stripTsExtension(rootModuleFileName) %>#<%= rootModuleClassName %>"
   }
 }

--- a/packages/schematics/angular/universal/index_spec.ts
+++ b/packages/schematics/angular/universal/index_spec.ts
@@ -80,10 +80,9 @@ describe('Universal Schematic', () => {
       extends: './tsconfig.app.json',
       compilerOptions: {
         outDir: './out-tsc/app-server',
-        baseUrl: '.',
       },
       angularCompilerOptions: {
-        entryModule: 'src/app/app.server.module#AppServerModule',
+        entryModule: './src/app/app.server.module#AppServerModule',
       },
     });
     const angularConfig = JSON.parse(tree.readContent('angular.json'));
@@ -100,10 +99,9 @@ describe('Universal Schematic', () => {
       extends: './tsconfig.app.json',
       compilerOptions: {
         outDir: '../../out-tsc/app-server',
-        baseUrl: '.',
       },
       angularCompilerOptions: {
-        entryModule: 'src/app/app.server.module#AppServerModule',
+        entryModule: './src/app/app.server.module#AppServerModule',
       },
     });
     const angularConfig = JSON.parse(tree.readContent('angular.json'));


### PR DESCRIPTION
The baseUrl is used for non relative module imports, and we should always use the baseUrl set in the workspace tsconfig. When having path mappings set at workspace level and setting a `baseUrl` in the server tsconfig, this paths will no longer work as paths mapping as relative to the baseUrl.

Fixes #13935