### PR TITLE
fix(@angular-devkit/build-angular): update speed-measure-webpack-plug…

### DIFF
--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -38,7 +38,7 @@
     "semver": "5.6.0",
     "source-map-support": "0.5.11",
     "source-map-loader": "0.2.4",
-    "speed-measure-webpack-plugin": "1.3.0",
+    "speed-measure-webpack-plugin": "1.3.1",
     "stats-webpack-plugin": "0.7.0",
     "style-loader": "0.23.1",
     "stylus": "0.54.5",

--- a/packages/angular_devkit/build_angular/test/browser/profile_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/browser/profile_spec_large.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import { Architect } from '@angular-devkit/architect/src/index2';
-import { join, normalize } from '@angular-devkit/core';
+import { join, normalize, virtualFs } from '@angular-devkit/core';
 import { BrowserBuilderOutput } from '../../src/browser/index2';
 import { browserBuild, createArchitect, host } from '../utils';
 
@@ -26,9 +26,13 @@ describe('Browser Builder profile', () => {
     const output = await run.result as BrowserBuilderOutput;
 
     expect(output.success).toBe(true);
-    expect(host.scopedSync().exists(normalize('chrome-profiler-events.json'))).toBe(true);
-    expect(host.scopedSync().exists(normalize('speed-measure-plugin.json'))).toBe(true);
 
+    const speedMeasureLogPath = normalize('speed-measure-plugin.json');
+    expect(host.scopedSync().exists(normalize('chrome-profiler-events.json'))).toBe(true);
+    expect(host.scopedSync().exists(speedMeasureLogPath)).toBe(true);
+
+    const content = virtualFs.fileBufferToString(host.scopedSync().read(speedMeasureLogPath));
+    expect(content).toContain('plugins');
     await run.stop();
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -8700,10 +8700,10 @@ spdy@^4.0.0:
     select-hose "^2.0.0"
     spdy-transport "^3.0.0"
 
-speed-measure-webpack-plugin@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/speed-measure-webpack-plugin/-/speed-measure-webpack-plugin-1.3.0.tgz#c7ffafef513df3d63d5d546c8fc1986dfc4969aa"
-  integrity sha512-b9Yd0TrzceMVYSbuamM1sFsGM1oVfyFTM22gOoyLhymNvBVApuYpkdFOgYkKJpN/KhTpcCYcTGHg7X+FJ33Vvw==
+speed-measure-webpack-plugin@1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/speed-measure-webpack-plugin/-/speed-measure-webpack-plugin-1.3.1.tgz#69840a5cdc08b4638697dac7db037f595d7f36a0"
+  integrity sha512-qVIkJvbtS9j/UeZumbdfz0vg+QfG/zxonAjzefZrqzkr7xOncLVXkeGbTpzd1gjCBM4PmVNkWlkeTVhgskAGSQ==
   dependencies:
     chalk "^2.0.1"
 


### PR DESCRIPTION
…in to 1.3.1

This fixes the issue of it generating an empty `speed-measure-plugin.json`.

Fixes #12763