### PR TITLE
Support `import()` syntax for loadChildren in ViewEngine

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,6 +106,16 @@ jobs:
           path: /tmp/dist
           destination: cli/new-production
 
+  e2e-cli-ivy:
+    <<: *defaults
+    environment:
+      BASH_ENV: ~/.profile
+    resource_class: xlarge
+    parallelism: 4
+    steps:
+      - attach_workspace: *attach_options
+      - run: xvfb-run -a node ./tests/legacy-cli/run_e2e --nb-shards=${CIRCLE_NODE_TOTAL} --shard=${CIRCLE_NODE_INDEX} --ivy          
+
   e2e-cli-ng-snapshots:
     <<: *defaults
     environment:
@@ -122,23 +132,6 @@ jobs:
             fi
       - attach_workspace: *attach_options
       - run: xvfb-run -a node ./tests/legacy-cli/run_e2e --nb-shards=${CIRCLE_NODE_TOTAL} --shard=${CIRCLE_NODE_INDEX} --ng-snapshots
-
-  e2e-cli-ivy-snapshots:
-    <<: *defaults
-    environment:
-      BASH_ENV: ~/.profile
-    resource_class: xlarge
-    parallelism: 4
-    steps:
-      - run:
-          name: Don't run expensive e2e tests for forks other than renovate-bot and angular
-          command: >
-            if [[ "$CIRCLE_PR_USERNAME" != "renovate-bot" ]] &&
-               [[ "$CIRCLE_PROJECT_USERNAME" != "angular" || $CIRCLE_BRANCH != "master" ]]; then
-              circleci step halt
-            fi
-      - attach_workspace: *attach_options
-      - run: xvfb-run -a node ./tests/legacy-cli/run_e2e --nb-shards=${CIRCLE_NODE_TOTAL} --shard=${CIRCLE_NODE_INDEX} --ng-snapshots --ivy
 
   build:
     <<: *defaults
@@ -210,6 +203,9 @@ workflows:
       - e2e-cli:
           requires:
             - build
+      - e2e-cli-ivy:
+          requires:
+            - build            
       - snapshot_publish_docs:
           requires:
           - install
@@ -218,9 +214,6 @@ workflows:
               only:
               - /docs-preview/
       - e2e-cli-ng-snapshots:
-          requires:
-            - build
-      - e2e-cli-ivy-snapshots:
           requires:
             - build
       - snapshot_publish:

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/build-options.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/build-options.ts
@@ -59,6 +59,7 @@ export interface BuildOptions {
   forkTypeChecker: boolean;
   profile?: boolean;
   es5BrowserSupport?: boolean;
+  experimentalImportFactories?: boolean;
 
   main: string;
   index: string;

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
@@ -8,7 +8,13 @@
 import { tags } from '@angular-devkit/core';
 import * as CopyWebpackPlugin from 'copy-webpack-plugin';
 import * as path from 'path';
-import { Configuration, HashedModuleIdsPlugin, Output, debug } from 'webpack';
+import {
+  Configuration,
+  ContextReplacementPlugin,
+  HashedModuleIdsPlugin,
+  Output,
+  debug,
+} from 'webpack';
 import { AssetPatternClass } from '../../../browser/schema';
 import { BundleBudgetPlugin } from '../../plugins/bundle-budget';
 import { CleanCssWebpackPlugin } from '../../plugins/cleancss-webpack-plugin';
@@ -345,6 +351,12 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
         ...extraMinimizers,
       ],
     },
-    plugins: extraPlugins,
+    plugins: [
+      // Always replace the context for the System.import in angular/core to prevent warnings.
+      // https://github.com/angular/angular/issues/11580
+      // With VE the correct context is added in @ngtools/webpack, but Ivy doesn't need it at all.
+      new ContextReplacementPlugin(/\@angular(\\|\/)core(\\|\/)/),
+      ...extraPlugins,
+    ],
   };
 }

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/typescript.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/typescript.ts
@@ -75,6 +75,7 @@ function _createAotPlugin(
     contextElementDependencyConstructor: require('webpack/lib/dependencies/ContextElementDependency'),
     logger: wco.logger,
     directTemplateLoading: true,
+    importFactories: buildOptions.experimentalImportFactories,
     ...options,
   };
   return new AngularCompilerPlugin(pluginOptions);

--- a/packages/angular_devkit/build_angular/src/browser/schema.json
+++ b/packages/angular_devkit/build_angular/src/browser/schema.json
@@ -315,6 +315,11 @@
       "type": "boolean",
       "default": false,
       "x-deprecated": true
+    },
+    "experimentalImportFactories": {
+      "description": "**EXPERIMENTAL** Transform import statements for lazy routes to import factories when using View Engine. Should only be used when switching back and forth between View Engine and Ivy. See https://angular.io/guide/ivy for usage information.",
+      "type": "boolean",
+      "default": false
     }
   },
   "additionalProperties": false,

--- a/packages/ngtools/webpack/src/angular_compiler_plugin.ts
+++ b/packages/ngtools/webpack/src/angular_compiler_plugin.ts
@@ -760,39 +760,36 @@ export class AngularCompilerPlugin {
             return result;
           }
 
-          return this.done.then(
-            () => {
-              // This folder does not exist, but we need to give webpack a resource.
-              // TODO: check if we can't just leave it as is (angularCoreModuleDir).
-              result.resource = path.join(this._basePath, '$$_lazy_route_resource');
-              // tslint:disable-next-line:no-any
-              result.dependencies.forEach((d: any) => d.critical = false);
-              // tslint:disable-next-line:no-any
-              result.resolveDependencies = (_fs: any, options: any, callback: Callback) => {
-                const dependencies = Object.keys(this._lazyRoutes)
-                  .map((key) => {
-                    const modulePath = this._lazyRoutes[key];
-                    if (modulePath !== null) {
-                      const name = key.split('#')[0];
+          await this.done;
 
-                      return new this._contextElementDependencyConstructor(modulePath, name);
-                    } else {
-                      return null;
-                    }
-                  })
-                  .filter(x => !!x);
+          // This folder does not exist, but we need to give webpack a resource.
+          // TODO: check if we can't just leave it as is (angularCoreModuleDir).
+          result.resource = path.join(this._basePath, '$$_lazy_route_resource');
+          // tslint:disable-next-line:no-any
+          result.dependencies.forEach((d: any) => d.critical = false);
+          // tslint:disable-next-line:no-any
+          result.resolveDependencies = (_fs: any, options: any, callback: Callback) => {
+            const dependencies = Object.keys(this._lazyRoutes)
+              .map((key) => {
+                const modulePath = this._lazyRoutes[key];
+                if (modulePath !== null) {
+                  const name = key.split('#')[0];
 
-                if (this._options.nameLazyFiles) {
-                  options.chunkName = '[request]';
+                  return new this._contextElementDependencyConstructor(modulePath, name);
+                } else {
+                  return null;
                 }
+              })
+              .filter(x => !!x);
 
-                callback(null, dependencies);
-              };
+            if (this._options.nameLazyFiles) {
+              options.chunkName = '[request]';
+            }
 
-              return result;
-            },
-            () => undefined,
-          );
+            callback(null, dependencies);
+          };
+
+          return result;
         });
       });
     }

--- a/packages/ngtools/webpack/src/transformers/import_factory.ts
+++ b/packages/ngtools/webpack/src/transformers/import_factory.ts
@@ -53,6 +53,7 @@ export function importFactory(
   warningCb: (warning: string) => void,
 ): ts.TransformerFactory<ts.SourceFile> {
   return (context: ts.TransformationContext) => {
+    // TODO(filipesilva): change the link to https://angular.io/guide/ivy once it is out.
     return (sourceFile: ts.SourceFile) => {
       const warning = `
 Found 'loadChildren' with a non-string syntax in ${sourceFile.fileName} but could not transform it.
@@ -60,7 +61,10 @@ Make sure it matches the format below:
 
 loadChildren: () => import('IMPORT_STRING').then(m => m.EXPORT_NAME)
 
-Please note that only IMPORT_STRING and EXPORT_NAME can be replaced in this format.`;
+Please note that only IMPORT_STRING and EXPORT_NAME can be replaced in this format.
+
+Visit https://next.angular.io/guide/ivy for more information on using Ivy.
+`;
 
       const emitWarning = () => warningCb(warning);
       const visitVariableStatement: ts.Visitor = (node: ts.Node) => {

--- a/packages/ngtools/webpack/src/transformers/import_factory.ts
+++ b/packages/ngtools/webpack/src/transformers/import_factory.ts
@@ -1,0 +1,198 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import * as ts from 'typescript';
+
+
+/**
+ * Given this original source code:
+ *
+ * import { NgModule } from '@angular/core';
+ * import { Routes, RouterModule } from '@angular/router';
+ *
+ * const routes: Routes = [{
+ *   path: 'lazy',
+ *   loadChildren: () => import('./lazy/lazy.module').then(m => m.LazyModule).
+ * }];
+ *
+ * @NgModule({
+ *   imports: [RouterModule.forRoot(routes)],
+ *   exports: [RouterModule]
+ * })
+ * export class AppRoutingModule { }
+ *
+ * NGC (View Engine) will process it into:
+ *
+ * import { Routes } from '@angular/router';
+ * const ɵ0 = () => import('./lazy/lazy.module').then(m => m.LazyModule);
+ * const routes: Routes = [{
+ *         path: 'lazy',
+ *         loadChildren: ɵ0
+ *     }];
+ * export class AppRoutingModule {
+ * }
+ * export { ɵ0 };
+ *
+ * The importFactory transformation will only see the AST after it is process by NGC.
+ * You can confirm this with the code below:
+ *
+ * const res = ts.createPrinter().printNode(ts.EmitHint.Unspecified, sourceFile, sourceFile);
+ * console.log(`### Original source: \n${sourceFile.text}\n###`);
+ * console.log(`### Current source: \n${currentText}\n###`);
+ *
+ * At this point it doesn't yet matter what the target (ES5/ES2015/etc) is, so the original
+ * constructs, like `class` and arrow functions, still remain.
+ *
+ */
+
+export function importFactory(
+  warningCb: (warning: string) => void,
+): ts.TransformerFactory<ts.SourceFile> {
+  return (context: ts.TransformationContext) => {
+    return (sourceFile: ts.SourceFile) => {
+      const warning = `
+Found 'loadChildren' with a non-string syntax in ${sourceFile.fileName} but could not transform it.
+Make sure it matches the format below:
+
+loadChildren: () => import('IMPORT_STRING').then(m => m.EXPORT_NAME)
+
+Please note that only IMPORT_STRING and EXPORT_NAME can be replaced in this format.`;
+
+      const emitWarning = () => warningCb(warning);
+      const visitVariableStatement: ts.Visitor = (node: ts.Node) => {
+        if (ts.isVariableDeclaration(node)) {
+          return replaceImport(node, context, emitWarning);
+        }
+
+        return ts.visitEachChild(node, visitVariableStatement, context);
+      };
+
+      const visitToplevelNodes: ts.Visitor = (node: ts.Node) => {
+        // We only care about finding variable declarations, which are found in this structure:
+        // VariableStatement -> VariableDeclarationList -> VariableDeclaration
+        if (ts.isVariableStatement(node)) {
+          return ts.visitEachChild(node, visitVariableStatement, context);
+        }
+
+        // There's no point in recursing into anything but variable statements, so return the node.
+        return node;
+      };
+
+      return ts.visitEachChild(sourceFile, visitToplevelNodes, context);
+    };
+  };
+}
+
+function replaceImport(
+  node: ts.VariableDeclaration,
+  context: ts.TransformationContext,
+  emitWarning: () => void,
+): ts.Node {
+  // This ONLY matches the original source code format below:
+  // loadChildren: () => import('IMPORT_STRING').then(m => m.EXPORT_NAME)
+  // And expects that source code to be transformed by NGC (see comment for importFactory).
+  // It will not match nor alter variations, for instance:
+  // - not using arrow functions
+  // - not using `m` as the module argument
+  // - using `await` instead of `then`
+  // - using a default export (https://github.com/angular/angular/issues/11402)
+  // The only parts that can change are the ones in caps: IMPORT_STRING and EXPORT_NAME.
+
+  // Exit early if the structure is not what we expect.
+
+  // ɵ0 = something
+  const name = node.name;
+  if (!(
+    ts.isIdentifier(name)
+    && /ɵ\d+/.test(name.text)
+  )) {
+    return node;
+  }
+
+  const initializer = node.initializer;
+  if (initializer === undefined) {
+    return node;
+  }
+
+  // ɵ0 = () => something
+  if (!(
+    ts.isArrowFunction(initializer)
+    && initializer.parameters.length === 0
+  )) {
+    return node;
+  }
+
+  // ɵ0 = () => something.then(something)
+  const topArrowFnBody = initializer.body;
+  if (!ts.isCallExpression(topArrowFnBody)) {
+    return node;
+  }
+
+  const topArrowFnBodyExpr = topArrowFnBody.expression;
+  if (!(
+    ts.isPropertyAccessExpression(topArrowFnBodyExpr)
+    && ts.isIdentifier(topArrowFnBodyExpr.name)
+  )) {
+    return node;
+  }
+  if (topArrowFnBodyExpr.name.text != 'then') {
+    return node;
+  }
+
+  // ɵ0 = () => import('IMPORT_STRING').then(something)
+  const importCall = topArrowFnBodyExpr.expression;
+  if (!(
+    ts.isCallExpression(importCall)
+    && importCall.expression.kind === ts.SyntaxKind.ImportKeyword
+    && importCall.arguments.length === 1
+    && ts.isStringLiteral(importCall.arguments[0])
+  )) {
+    return node;
+  }
+
+  // ɵ0 = () => import('IMPORT_STRING').then(m => m.EXPORT_NAME)
+  if (!(
+    topArrowFnBody.arguments.length === 1
+    && ts.isArrowFunction(topArrowFnBody.arguments[0])
+  )) {
+    // Now that we know it's both `ɵ0` (generated by NGC) and a `import()`, start emitting a warning
+    // if the structure isn't as expected to help users identify unusable syntax.
+    emitWarning();
+
+    return node;
+  }
+
+  const thenArrowFn = topArrowFnBody.arguments[0] as ts.ArrowFunction;
+  if (!(
+    thenArrowFn.parameters.length === 1
+    && ts.isPropertyAccessExpression(thenArrowFn.body)
+    && ts.isIdentifier(thenArrowFn.body.name)
+  )) {
+    emitWarning();
+
+    return node;
+  }
+
+  // At this point we know what are the nodes we need to replace.
+  const importStringLit = importCall.arguments[0] as ts.StringLiteral;
+  const exportNameId = thenArrowFn.body.name;
+
+  // The easiest way to alter them is with a simple visitor.
+  const replacementVisitor: ts.Visitor = (node: ts.Node) => {
+    if (node === importStringLit) {
+      // Transform the import string.
+      return ts.createStringLiteral(importStringLit.text + '.ngfactory');
+    } else if (node === exportNameId) {
+      // Transform the export name.
+      return ts.createIdentifier(exportNameId.text + 'NgFactory');
+    }
+
+    return ts.visitEachChild(node, replacementVisitor, context);
+  };
+
+  return ts.visitEachChild(node, replacementVisitor, context);
+}

--- a/packages/ngtools/webpack/src/transformers/import_factory_spec.ts
+++ b/packages/ngtools/webpack/src/transformers/import_factory_spec.ts
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { tags } from '@angular-devkit/core';
+import { transformTypescript } from './ast_helpers';
+import { importFactory } from './import_factory';
+
+describe('@ngtools/webpack transformers', () => {
+  describe('import_factory', () => {
+    it('should support arrow functions', () => {
+      const input = tags.stripIndent`
+        const ɵ0 = () => import('./lazy/lazy.module').then(m => m.LazyModule);
+        const routes = [{
+          path: 'lazy',
+          loadChildren: ɵ0
+        }];
+      `;
+      const output = tags.stripIndent`
+        const ɵ0 = () => import("./lazy/lazy.module.ngfactory").then(m => m.LazyModuleNgFactory);
+        const routes = [{
+          path: 'lazy',
+          loadChildren: ɵ0
+        }];
+      `;
+
+      let warningCalled = false;
+      const transformer = importFactory(() => warningCalled = true);
+      const result = transformTypescript(input, [transformer]);
+
+      expect(tags.oneLine`${result}`).toEqual(tags.oneLine`${output}`);
+      expect(warningCalled).toBeFalsy();
+    });
+
+    it('should not transform if the format is different than expected', () => {
+      const input = tags.stripIndent`
+        const ɵ0 = () => import('./lazy/lazy.module').then(function (m) { return m.LazyModule; });
+        const routes = [{
+          path: 'lazy',
+          loadChildren: ɵ0
+        }];
+      `;
+
+      let warningCalled = false;
+      const transformer = importFactory(() => warningCalled = true);
+      const result = transformTypescript(input, [transformer]);
+
+      expect(tags.oneLine`${result}`).toEqual(tags.oneLine`${input}`);
+      expect(warningCalled).toBeTruthy();
+    });
+  });
+});

--- a/packages/ngtools/webpack/src/transformers/index.ts
+++ b/packages/ngtools/webpack/src/transformers/index.ts
@@ -18,3 +18,4 @@ export * from './register_locale_data';
 export * from './replace_resources';
 export * from './remove_decorators';
 export * from './find_resources';
+export * from './import_factory';

--- a/tests/legacy-cli/e2e_runner.ts
+++ b/tests/legacy-cli/e2e_runner.ts
@@ -144,6 +144,8 @@ if (argv.ivy) {
     .filter(name => !name.endsWith('tests/build/aot/aot-i18n.ts'))
     // We don't have a library consumption story yet for Ivy.
     .filter(name => !name.endsWith('tests/generate/library/library-consumption.ts'))
+    // The additional lazy modules array does not work with Ivy because it's not needed.
+    .filter(name => !name.endsWith('tests/build/dynamic-import.ts'))
     // We don't have a platform-server usage story yet for Ivy.
     // It's contingent on lazy loading and factory shim considerations that are still being
     // discussed.


### PR DESCRIPTION
This feature ONLY matches the format below:
```
loadChildren: () => import('IMPORT_STRING').then(m => m.EXPORT_NAME)
```

It will not match nor alter variations, for instance:
- not using arrow functions
- not using `m` as the module argument
- using `await` instead of `then`
- using a default export (https://github.com/angular/angular/issues/11402)

The only parts that can change are the ones in caps: IMPORT_STRING and EXPORT_NAME.