### PR TITLE
feat(@ngtools/webpack): update `require` statements to work with webp…

### DIFF
--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -32,7 +32,7 @@
     "postcss": "7.0.14",
     "postcss-import": "12.0.1",
     "postcss-loader": "3.0.0",
-    "raw-loader": "1.0.0",
+    "raw-loader": "2.0.0",
     "rxjs": "6.4.0",
     "sass": "1.17.3",
     "sass-loader": "7.1.0",

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/styles.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/styles.ts
@@ -179,7 +179,6 @@ export function getStylesConfig(wco: WebpackConfigOptions) {
     exclude: globalStylePaths,
     test,
     use: [
-      { loader: 'raw-loader' },
       {
         loader: 'postcss-loader',
         options: {

--- a/packages/ngtools/webpack/src/transformers/replace_resources.ts
+++ b/packages/ngtools/webpack/src/transformers/replace_resources.ts
@@ -5,6 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import { tags } from '@angular-devkit/core';
 import * as ts from 'typescript';
 
 export function replaceResources(
@@ -39,11 +40,25 @@ export function replaceResources(
       return ts.visitEachChild(node, visitNode, context);
     };
 
-    return (sourceFile: ts.SourceFile) => (
-      shouldTransform(sourceFile.fileName)
-        ? ts.visitNode(sourceFile, visitNode)
-        : sourceFile
-    );
+    // emit helper for `import Name from "foo"`
+    const importDefaultHelper: ts.EmitHelper = {
+      name: 'typescript:commonjsimportdefault',
+      scoped: false,
+      text: tags.stripIndent`
+      var __importDefault = (this && this.__importDefault) || function (mod) {
+        return (mod && mod.__esModule) ? mod : { "default": mod };
+      };`,
+    };
+
+    return (sourceFile: ts.SourceFile) => {
+      if (shouldTransform(sourceFile.fileName)) {
+        context.requestEmitHelper(importDefaultHelper);
+
+        return ts.visitNode(sourceFile, visitNode);
+      }
+
+      return sourceFile;
+    };
   };
 }
 
@@ -173,16 +188,28 @@ function isComponentDecorator(node: ts.Node, typeChecker: ts.TypeChecker): node 
   return false;
 }
 
-function createRequireExpression(node: ts.Expression, loader = ''): ts.Expression {
+function createRequireExpression(node: ts.Expression, loader?: string): ts.Expression {
   const url = getResourceUrl(node, loader);
   if (!url) {
     return node;
   }
 
-  return ts.createCall(
+  const callExpression = ts.createCall(
     ts.createIdentifier('require'),
     undefined,
     [ts.createLiteral(url)],
+  );
+
+  return ts.createPropertyAccess(
+    ts.createCall(
+      ts.setEmitFlags(
+        ts.createIdentifier('__importDefault'),
+        ts.EmitFlags.HelperName | ts.EmitFlags.AdviseOnEmitNode,
+      ),
+      undefined,
+      [callExpression],
+    ),
+    'default',
   );
 }
 

--- a/packages/ngtools/webpack/src/transformers/replace_resources_spec.ts
+++ b/packages/ngtools/webpack/src/transformers/replace_resources_spec.ts
@@ -20,6 +20,7 @@ function transform(input: string, shouldTransform = true, directTemplateLoading 
 
 // tslint:disable-next-line:no-big-function
 describe('@ngtools/webpack transformers', () => {
+  // tslint:disable:max-line-length
   // tslint:disable-next-line:no-big-function
   describe('find_resources', () => {
     it('should replace resources', () => {
@@ -46,8 +47,11 @@ describe('@ngtools/webpack transformers', () => {
         AppComponent = tslib_1.__decorate([
             Component({
                 selector: 'app-root',
-                template: require("!raw-loader!./app.component.html"),
-                styles: [require("./app.component.css"), require("./app.component.2.css")]
+                template: tslib_1.__importDefault(require("!raw-loader!./app.component.html")).default,
+                styles: [
+                  tslib_1.__importDefault(require("./app.component.css")).default,
+                  tslib_1.__importDefault(require("./app.component.2.css")).default
+                ]
             })
         ], AppComponent);
         export { AppComponent };
@@ -64,7 +68,10 @@ describe('@ngtools/webpack transformers', () => {
           @Component({
             selector: 'app-root',
             templateUrl: './app.component.html',
-            styleUrls: ['./app.component.css', './app.component.2.css']
+            styleUrls: [
+              './app.component.css',
+              './app.component.2.css'
+            ]
           })
           export class AppComponent {
             title = 'app';
@@ -81,8 +88,11 @@ describe('@ngtools/webpack transformers', () => {
           AppComponent = tslib_1.__decorate([
               Component({
                   selector: 'app-root',
-                  template: require("./app.component.html"),
-                  styles: [require("./app.component.css"), require("./app.component.2.css")]
+                  template: tslib_1.__importDefault(require("./app.component.html")).default,
+                  styles: [
+                    tslib_1.__importDefault(require("./app.component.css")).default,
+                    tslib_1.__importDefault(require("./app.component.2.css")).default
+                  ]
               })
           ], AppComponent);
           export { AppComponent };
@@ -116,7 +126,7 @@ describe('@ngtools/webpack transformers', () => {
         AppComponent = tslib_1.__decorate([
             Component({
                 selector: 'app-root',
-                template: require("!raw-loader!./app.component.svg")
+                template: tslib_1.__importDefault(require("!raw-loader!./app.component.svg")).default
             })
         ], AppComponent);
         export { AppComponent };
@@ -151,8 +161,11 @@ describe('@ngtools/webpack transformers', () => {
         AppComponent = tslib_1.__decorate([
             Component({
                 selector: 'app-root',
-                template: require("!raw-loader!./app.component.html"),
-                styles: ["a { color: red }", require("./app.component.css")]
+                template: tslib_1.__importDefault(require("!raw-loader!./app.component.html")).default,
+                styles: [
+                  "a { color: red }",
+                  tslib_1.__importDefault(require("./app.component.css")).default
+                ]
             })
         ], AppComponent);
         export { AppComponent };
@@ -186,8 +199,11 @@ describe('@ngtools/webpack transformers', () => {
         AppComponent = tslib_1.__decorate([
             Component({
                 selector: 'app-root',
-                template: require("!raw-loader!./app.component.html"),
-                styles: [require("./app.component.css"), require("./app.component.2.css")]
+                template: tslib_1.__importDefault(require("!raw-loader!./app.component.html")).default,
+                styles: [
+                  tslib_1.__importDefault(require("./app.component.css")).default,
+                  tslib_1.__importDefault(require("./app.component.2.css")).default
+                ]
             })
         ], AppComponent);
         export { AppComponent };
@@ -221,8 +237,11 @@ describe('@ngtools/webpack transformers', () => {
         AppComponent = tslib_1.__decorate([
           NgComponent({
                 selector: 'app-root',
-                template: require("!raw-loader!./app.component.html"),
-                styles: [require("./app.component.css"), require("./app.component.2.css")]
+                template: tslib_1.__importDefault(require("!raw-loader!./app.component.html")).default,
+                styles: [
+                  tslib_1.__importDefault(require("./app.component.css")).default,
+                  tslib_1.__importDefault(require("./app.component.2.css")).default
+                ]
             })
         ], AppComponent);
         export { AppComponent };
@@ -260,8 +279,11 @@ describe('@ngtools/webpack transformers', () => {
         AppComponent = tslib_1.__decorate([
           ng.Component({
                 selector: 'app-root',
-                template: require("!raw-loader!./app.component.html"),
-                styles: [require("./app.component.css"), require("./app.component.2.css")]
+                template: tslib_1.__importDefault(require("!raw-loader!./app.component.html")).default,
+                styles: [
+                  tslib_1.__importDefault(require("./app.component.css")).default,
+                  tslib_1.__importDefault(require("./app.component.2.css")).default
+                ]
             })
         ], AppComponent);
         export { AppComponent };
@@ -308,8 +330,10 @@ describe('@ngtools/webpack transformers', () => {
         AppComponent = tslib_1.__decorate([
             Component({
                 selector: 'app-root',
-                template: require("!raw-loader!./app.component.html"),
-                styles: [require("./app.component.css")]
+                template: tslib_1.__importDefault(require("!raw-loader!./app.component.html")).default,
+                styles: [
+                  tslib_1.__importDefault(require("./app.component.css")).default
+                ]
             })
         ], AppComponent);
         export { AppComponent };

--- a/yarn.lock
+++ b/yarn.lock
@@ -7468,10 +7468,10 @@ raw-body@2.3.3:
     iconv-lite "0.4.23"
     unpipe "1.0.0"
 
-raw-loader@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/raw-loader/-/raw-loader-1.0.0.tgz#3f9889e73dadbda9a424bce79809b4133ad46405"
-  integrity sha512-Uqy5AqELpytJTRxYT4fhltcKPj0TyaEpzJDcGz7DFJi+pQOOi3GjR/DOdxTkTsF+NzhnldIoG6TORaBlInUuqA==
+raw-loader@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/raw-loader/-/raw-loader-2.0.0.tgz#e2813d9e1e3f80d1bbade5ad082e809679e20c26"
+  integrity sha512-kZnO5MoIyrojfrPWqrhFNLZemIAX8edMOCp++yC5RKxzFB3m92DqKNhKlU6+FvpOhWtvyh3jOaD7J6/9tpdIKg==
   dependencies:
     loader-utils "^1.1.0"
     schema-utils "^1.0.0"


### PR DESCRIPTION
…ack raw-loader v2.

webpack raw-loader released a breaking change https://github.com/webpack-contrib/raw-loader/releases/tag/v2.0.0 and now they use ES Module export instead of CommonJS.

BREAKING CHANGE: we now support only raw-loader version 2+ as the emitted code has changed to support version 2 of the mentioned loader.

Before
```
Component({
    selector: 'app-root',
    template: require("!raw-loader!./app.component.html"),
    styles: [require("./app.component.css")]
})
```

Now
```
Component({
    selector: 'app-root',
    template: require("!raw-loader!./app.component.html").default,
    styles: [require("./app.component.css").default]
})
```