### PR TITLE
Revert "refactor: deprecate protractor baseUrl option from builder"

### DIFF
--- a/packages/angular_devkit/build_angular/src/protractor/schema.json
+++ b/packages/angular_devkit/build_angular/src/protractor/schema.json
@@ -46,8 +46,7 @@
     },
     "baseUrl": {
       "type": "string",
-      "description": "Base URL for protractor to connect to.",
-      "x-deprecated": "Use \"baseUrl\" in the Protractor config file instead."
+      "description": "Base URL for protractor to connect to."
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
This reverts commit 5415bcc6f872b181b6b05b2a5c718a9146ea3113.

Right now, this is flagged as "Deprecated" in the CLI, which isn't actually the case. As per the new protractor implementation in https://github.com/angular/angular-cli/commit/a49d278baa8561a39566dffd5c947bcc79b485c0 , `baseUrl` is supported as long as `devServerTarget` is not included.

This patch reverts the deprecation note.

Resolves #13952