### PR TITLE
Disable inline sourcemaps for builds & increase target to ES2018 (Node.js 10.3+)

### DIFF
--- a/lib/bootstrap-local.js
+++ b/lib/bootstrap-local.js
@@ -23,9 +23,12 @@ const tmpRoot = temp.mkdirSync('angular-devkit-');
 
 debugLocal('starting bootstrap local');
 
-const compilerOptions = ts.readConfigFile(path.join(__dirname, '../tsconfig.json'), p => {
-  return fs.readFileSync(p, 'utf-8');
-}).config;
+// This processes any extended configs
+const compilerOptions = ts.getParsedCommandLineOfConfigFile(
+  path.join(__dirname, '../tsconfig-test.json'),
+  { },
+  ts.sys,
+).options;
 
 let _istanbulRequireHook = null;
 if (process.env['CODE_COVERAGE'] || process.argv.indexOf('--code-coverage') !== -1) {
@@ -33,7 +36,7 @@ if (process.env['CODE_COVERAGE'] || process.argv.indexOf('--code-coverage') !== 
   _istanbulRequireHook = require('./istanbul-local').istanbulRequireHook;
   // async keyword isn't supported by the Esprima version used by Istanbul version used by us.
   // TODO: update istanbul to istanbul-lib-* (see http://istanbul.js.org/) and remove this hack.
-  compilerOptions.compilerOptions.target = 'es2016';
+  compilerOptions.target = 'es2016';
 }
 
 
@@ -98,7 +101,7 @@ require.extensions['.ts'] = function (m, filename) {
   const source = fs.readFileSync(filename).toString();
 
   try {
-    let result = ts.transpile(source, compilerOptions['compilerOptions'], filename);
+    let result = ts.transpile(source, compilerOptions, filename);
 
     if (_istanbulRequireHook) {
       result = _istanbulRequireHook(result, filename);

--- a/tsconfig-test.json
+++ b/tsconfig-test.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "inlineSourceMap": true,
+    "sourceRoot": ".",
+    // Inline sources are necessary for our tests to show the proper sources, since we are using
+    // Istanbul (not Constantinople) as well, and applying both source maps to get the original
+    // source in devtools.
+    "inlineSources": true,
     "types": [
       "node",
       "jasmine"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,12 +15,6 @@
     "rootDir": ".",
     "skipDefaultLibCheck": true,
     "skipLibCheck": true,
-    "inlineSourceMap": true,
-    "sourceRoot": ".",
-    // Inline sources are necessary for our tests to show the proper sources, since we are using
-    // Istanbul (not Constantinople) as well, and applying both source maps to get the original
-    // source in devtools.
-    "inlineSources": true,
     "strictNullChecks": true,
     "target": "es2017",
     "lib": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,9 +16,9 @@
     "skipDefaultLibCheck": true,
     "skipLibCheck": true,
     "strictNullChecks": true,
-    "target": "es2017",
+    "target": "es2018",
     "lib": [
-      "es2017"
+      "es2018"
     ],
     "baseUrl": "",
     "rootDirs": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "emitDecoratorMetadata": true,
-    "experimentalDecorators": true,
     "module": "commonjs",
     "moduleResolution": "node",
     "noEmitOnError": true,
@@ -13,7 +11,6 @@
     "noUnusedLocals": false,  // The linter is used for these.
     "outDir": "./dist",
     "rootDir": ".",
-    "skipDefaultLibCheck": true,
     "skipLibCheck": true,
     "strictNullChecks": true,
     "target": "es2018",


### PR DESCRIPTION
This also includes separate commits for increasing the target version to ES2018 which is supported by Node.js 10.3.0+ ([reference](https://node.green/#ES2018)) and some minor cleanup to the tsconfig file.