### PR TITLE
Telemetry various fix

### DIFF
--- a/lib/packages.ts
+++ b/lib/packages.ts
@@ -59,11 +59,11 @@ function loadPackageJson(p: string) {
       case 'private':
       case 'workspaces':
       case 'resolutions':
+      case 'scripts':
         continue;
 
       // Remove the following keys from the package.json.
       case 'devDependencies':
-      case 'scripts':
         delete pkg[key];
         continue;
 

--- a/packages/angular/cli/bin/postinstall/analytics-prompt.js
+++ b/packages/angular/cli/bin/postinstall/analytics-prompt.js
@@ -5,6 +5,6 @@ try {
   const analytics = require('../../models/analytics');
 
   if (analytics.getGlobalAnalytics() === undefined) {
-    analytics.promptGlobalAnalytics(true);
+    analytics.promptGlobalAnalytics();
   }
 } catch (_) {}

--- a/packages/angular/cli/models/analytics.ts
+++ b/packages/angular/cli/models/analytics.ts
@@ -393,6 +393,8 @@ export async function promptGlobalAnalytics(force = false) {
     }
 
     return true;
+  } else {
+    analyticsDebug('Either STDOUT or STDIN are not TTY and we skipped the prompt.');
   }
 
   return false;

--- a/packages/angular/cli/models/analytics.ts
+++ b/packages/angular/cli/models/analytics.ts
@@ -475,10 +475,14 @@ export function getGlobalAnalytics(): string | boolean | undefined {
     const analyticsConfig = globalWorkspace
       && globalWorkspace.getCli()
       && globalWorkspace.getCli()['analytics'];
+    analyticsDebug('Client Analytics config found: %j', analyticsConfig);
 
     if (analyticsConfig === false) {
       return false;
-    } else if (analyticsConfig === undefined) {
+    } else if (analyticsConfig === undefined || analyticsConfig === null) {
+      // globalWorkspace can be null if there is no file. analyticsConfig would be null in this
+      // case. Since there is no file, the user hasn't answered and the expected return value is
+      // undefined.
       return undefined;
     } else {
       let uid: string | undefined = undefined;
@@ -492,7 +496,9 @@ export function getGlobalAnalytics(): string | boolean | undefined {
 
       return uid;
     }
-  } catch {
+  } catch (err) {
+    analyticsDebug('Error happened during reading of analytics config: %s', err.message);
+
     return false;
   }
 }


### PR DESCRIPTION
The prompt was never shown to the user because of a combination of issues;

1. the "scripts" key in package.json is not kept during building.
1. when a user lack a global configuration file, we return as if the user answered false (because it's `null`, not `undefined`).
1. prompting on non-tty terminals also meant that CI was broken.

This fixes those issues.