### PR TITLE
Analytics for Builds, and other fixes

### DIFF
--- a/docs/design/analytics.md
+++ b/docs/design/analytics.md
@@ -8,22 +8,19 @@ Each command creates a pageview with the path `/command/${commandName}/${subcomm
 `ng generate component my-component --dryRun` would create a page view with the path
 `/command/generate/@schematics_angular/component`.
 
-Additionally, only the Architect configuration of `default`, `production` and `staging` will be
-logged. The project name will be removed, and if the configuration is different than the three
-basic ones, it will be replaced with `_`. 
+We use page views to keep track of sessions more effectively, and to tag events to a page.
+
+Project names and target names will be removed. 
 The command `ng run some-project:lint:some-configuration` will create a page view with the path
-`/command/run/_:lint:_`. Configurations are only used when actually mentioned on the command
-line, thus the command `ng build some-project --prod` will create a page view of
-`/command/build/_:default` (with the `prod` flag), while `ng build some-project:some-conf` will log
-`/command/build/_:_`.
+`/command/run`.
 
 # Dimensions
-Google Analytics Custom Dimensions are used to track flag values. These dimensions are aggregated
-automatically on the backend.
+Google Analytics Custom Dimensions are used to track system values and flag values. These
+dimensions are aggregated automatically on the backend.
 
 One dimension per flag, and although technically there can be an overlap between 2 commands, for
-simplicity it should remain unique across all CLI commands. These are numbers added to our own
-`schema.json` files. Dimensions are not to be used for anything else.
+simplicity it should remain unique across all CLI commands. The dimension is the value of the
+`x-user-analytics` field in the `schema.json` files.
 
 To create a new dimension (tracking a new flag):
 
@@ -41,42 +38,59 @@ PROJECT NAME TO BUILD OR A MODULE NAME.**
 Note: There's a limit of 20 custom dimensions.
 
 ### List Of All Dimensions
-| Id | Category | Flag | Type | File / Description |
-|:---:|:---|:---|:---|---:|
-| 1 | `generate`, `new` | `--dryRun`      | `Boolean` | |
-| 2 | `generate`, `new` | `--force`       | `Boolean` | |
-| 3 | `generate`, `new` | `--interactive` | `Boolean` | |
-| 4 | `generate` | `--skipInstall` | `Boolean` | |
-| 5 | `generate` | `--style` | `String` | |
-| 6 | `add` | `--collection` | `String` | Only for packages that we control (see safelist in `add-impl.ts`). |
-| 7 | `build`, `serve` | `--buildEventLog` | `Boolean` | If the flag was used (does not report its value). See `build-impl.ts`. |
-| 8 | `generate`, `new` | `--enableIvy` | `Boolean` | |
-| 9 | `generate` | `--inlineStyle` | `Boolean` | |
-| 10 | `generate` | `--inlineTemplate` | `Boolean` | |
-| 11 | `generate` | `--viewEncapsulation` | `String` | |
-| 12 | `generate` | `--skipTests` | `Boolean` | |
-| 13 | `build` | `--aot` | `Boolean` | |
-| 14 | `generate` | `--minimal` | `Boolean` | |
-| 15 | `generate` | `--lintFix` | `Boolean` | |
-| 16 | `build` | `--optimization` | `Boolean` | |
-| 17 | `generate` | `--routing` | `Boolean` | |
-| 18 | `generate` | `--skipImport` | `Boolean` | |
-| 19 | `generate` | `--export` | `Boolean` | |
-| 20 | `generate` | `--entryComponent` | `Boolean` | |
+<!--DIMENSIONS_TABLE_BEGIN-->
+| Id | Flag | Type |
+|:---:|:---|:---|
+| 1 | `CPU Count` | `number` |
+| 2 | `CPU Speed` | `number` |
+| 3 | `RAM (In MB)` | `number` |
+| 4 | `Node Version` | `number` |
+| 5 | `Flag: --style` | `string` |
+| 6 | `--collection` | `string` |
+| 7 | `--buildEventLog` | `boolean` |
+| 8 | `Flag: --enableIvy` | `boolean` |
+| 9 | `Flag: --inlineStyle` | `boolean` |
+| 10 | `Flag: --inlineTemplate` | `boolean` |
+| 11 | `Flag: --viewEncapsulation` | `string` |
+| 12 | `Flag: --skipTests` | `boolean` |
+| 13 | `Flag: --aot` | `boolean` |
+| 14 | `Flag: --minimal` | `boolean` |
+| 15 | `Flag: --lintFix` | `boolean` |
+| 16 | `Flag: --optimization` | `boolean` |
+| 17 | `Flag: --routing` | `boolean` |
+| 18 | `Flag: --skipImport` | `boolean` |
+| 19 | `Flag: --export` | `boolean` |
+| 20 | `Build Errors (comma separated)` | `string` |
+<!--DIMENSIONS_TABLE_END-->
 
 # Metrics
 
 ### List of All Metrics
-| Id  | Type | Description |
-|:---:|:-----|-------------|
-| 1 | `Number` | CPU count |
-| 2 | `Number` | Average CPU speed |
-| 3 | `Number` | RAM Count |
-| 4 | `Number` | Node Version (Major.Minor) |
+<!--METRICS_TABLE_BEGIN-->
+| Id | Flag | Type |
+|:---:|:---|:---|
+| 1 | `UNUSED_1` | `none` |
+| 2 | `UNUSED_2` | `none` |
+| 3 | `UNUSED_3` | `none` |
+| 4 | `UNUSED_4` | `none` |
+| 5 | `Build Time` | `number` |
+| 6 | `NgOnInit Count` | `number` |
+| 7 | `Initial Chunk Size` | `number` |
+| 8 | `Total Chunk Count` | `number` |
+| 9 | `Total Chunk Size` | `number` |
+| 10 | `Lazy Chunk Count` | `number` |
+| 11 | `Lazy Chunk Size` | `number` |
+| 12 | `Asset Count` | `number` |
+| 13 | `Asset Size` | `number` |
+| 14 | ` Polyfill Size` | `number` |
+| 15 | ` Css Size` | `number` |
+<!--METRICS_TABLE_END-->
 
 # Operating System and Node Version
 A User Agent string is built to "fool" Google Analytics into reading the Operating System and
 version fields from it. The base dimensions are used for those.
+
+Node version is our App ID, but a dimension is also used to get the numeric MAJOR.MINOR of node.
 
 # Debugging
 Using `DEBUG=universal-analytics` will report all calls to the universal-analytics library,

--- a/packages/angular/cli/commands/add-impl.ts
+++ b/packages/angular/cli/commands/add-impl.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import { tags, terminal } from '@angular-devkit/core';
+import { analytics, tags, terminal } from '@angular-devkit/core';
 import { ModuleNotFoundException, resolve } from '@angular-devkit/core/node';
 import { NodePackageDoesNotSupportSchematics } from '@angular-devkit/schematics/tools';
 import { dirname } from 'path';
@@ -150,7 +150,7 @@ export class AddCommand extends SchematicCommand<AddCommandSchema> {
 
     // Add the collection if it's safe listed.
     if (collection && isPackageNameSafeForAnalytics(collection)) {
-      dimensions[AnalyticsDimensions.NgAddCollection] = collection;
+      dimensions[analytics.NgCliAnalyticsDimensions.NgAddCollection] = collection;
     } else {
       delete dimensions[AnalyticsDimensions.NgAddCollection];
     }

--- a/packages/angular/cli/commands/add-impl.ts
+++ b/packages/angular/cli/commands/add-impl.ts
@@ -10,7 +10,7 @@ import { ModuleNotFoundException, resolve } from '@angular-devkit/core/node';
 import { NodePackageDoesNotSupportSchematics } from '@angular-devkit/schematics/tools';
 import { dirname } from 'path';
 import { intersects, prerelease, rcompare, satisfies, valid, validRange } from 'semver';
-import { AnalyticsDimensions, isPackageNameSafeForAnalytics } from '../models/analytics';
+import { isPackageNameSafeForAnalytics } from '../models/analytics';
 import { Arguments } from '../models/interface';
 import { SchematicCommand } from '../models/schematic-command';
 import npmInstall from '../tasks/npm-install';
@@ -152,7 +152,7 @@ export class AddCommand extends SchematicCommand<AddCommandSchema> {
     if (collection && isPackageNameSafeForAnalytics(collection)) {
       dimensions[analytics.NgCliAnalyticsDimensions.NgAddCollection] = collection;
     } else {
-      delete dimensions[AnalyticsDimensions.NgAddCollection];
+      delete dimensions[analytics.NgCliAnalyticsDimensions.NgAddCollection];
     }
 
     return super.reportAnalytics(paths, options, dimensions, metrics);

--- a/packages/angular/cli/commands/build-impl.ts
+++ b/packages/angular/cli/commands/build-impl.ts
@@ -5,8 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-
-import { AnalyticsDimensions } from '../models/analytics';
+import { analytics } from '@angular-devkit/core';
 import { ArchitectCommand, ArchitectCommandOptions } from '../models/architect-command';
 import { Arguments } from '../models/interface';
 import { Version } from '../upgrade/version';
@@ -29,7 +28,7 @@ export class BuildCommand extends ArchitectCommand<BuildCommandSchema> {
     metrics: (boolean | number | string)[] = [],
   ): Promise<void> {
     if (options.buildEventLog !== undefined) {
-      dimensions[AnalyticsDimensions.NgBuildBuildEventLog] = true;
+      dimensions[analytics.NgCliAnalyticsDimensions.NgBuildBuildEventLog] = true;
     }
 
     return super.reportAnalytics(paths, options, dimensions, metrics);

--- a/packages/angular/cli/commands/definitions.json
+++ b/packages/angular/cli/commands/definitions.json
@@ -42,15 +42,13 @@
           "type": "boolean",
           "default": false,
           "aliases": [ "d" ],
-          "description": "When true, runs through and reports activity without writing out results.",
-          "x-user-analytics": 1
+          "description": "When true, runs through and reports activity without writing out results."
         },
         "force": {
           "type": "boolean",
           "default": false,
           "aliases": [ "f" ],
-          "description": "When true, forces overwriting of existing files.",
-          "x-user-analytics": 2
+          "description": "When true, forces overwriting of existing files."
         }
       }
     },
@@ -59,8 +57,7 @@
         "interactive": {
           "type": "boolean",
           "default": "true",
-          "description": "When false, disables interactive input prompts.",
-          "x-user-analytics": 3
+          "description": "When false, disables interactive input prompts."
         },
         "defaults": {
           "type": "boolean",

--- a/packages/angular/cli/commands/serve-impl.ts
+++ b/packages/angular/cli/commands/serve-impl.ts
@@ -5,8 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-
-import { AnalyticsDimensions } from '../models/analytics';
+import { analytics } from '@angular-devkit/core';
 import { ArchitectCommand, ArchitectCommandOptions } from '../models/architect-command';
 import { Arguments } from '../models/interface';
 import { Version } from '../upgrade/version';
@@ -34,7 +33,7 @@ export class ServeCommand extends ArchitectCommand<ServeCommandSchema> {
     metrics: (boolean | number | string)[] = [],
   ): Promise<void> {
     if (options.buildEventLog !== undefined) {
-      dimensions[AnalyticsDimensions.NgBuildBuildEventLog] = true;
+      dimensions[analytics.NgCliAnalyticsDimensions.NgBuildBuildEventLog] = true;
     }
 
     return super.reportAnalytics(paths, options, dimensions, metrics);

--- a/packages/angular/cli/models/analytics.ts
+++ b/packages/angular/cli/models/analytics.ts
@@ -241,6 +241,7 @@ function _buildUserAgentString() {
 export class UniversalAnalytics implements analytics.Analytics {
   private _ua: ua.Visitor;
   private _dirty = false;
+  private _metrics: (string | number)[] = [];
 
   /**
    * @param trackingId The Google Analytics ID.
@@ -266,10 +267,10 @@ export class UniversalAnalytics implements analytics.Analytics {
     this._ua.set('aid', _getNodeVersion());
 
     // We set custom metrics for values we care about.
-    this._ua.set('cm1', _getCpuCount());
-    this._ua.set('cm2', _getCpuSpeed());
-    this._ua.set('cm3', _getRamSize());
-    this._ua.set('cm4', _getNumericNodeVersion());
+    this._metrics[analytics.NgCliAnalyticsMetrics.CpuCount] = _getCpuCount();
+    this._metrics[analytics.NgCliAnalyticsMetrics.CpuSpeed] = _getCpuSpeed();
+    this._metrics[analytics.NgCliAnalyticsMetrics.RamInMegabytes] = _getRamSize();
+    this._metrics[analytics.NgCliAnalyticsMetrics.NodeVersion] = _getNumericNodeVersion();
   }
 
   /**
@@ -278,6 +279,7 @@ export class UniversalAnalytics implements analytics.Analytics {
    */
   private _customVariables(options: analytics.CustomDimensionsAndMetricsOptions) {
     const additionals: { [key: string]: boolean | number | string } = {};
+    this._metrics.forEach((v, i) => additionals['cm' + i] = v);
     (options.dimensions || []).forEach((v, i) => additionals['cd' + i] = v);
     (options.metrics || []).forEach((v, i) => additionals['cm' + i] = v);
 

--- a/packages/angular/cli/models/analytics.ts
+++ b/packages/angular/cli/models/analytics.ts
@@ -42,15 +42,6 @@ export function isPackageNameSafeForAnalytics(name: string) {
   });
 }
 
-  /**
- * MAKE SURE TO KEEP THIS IN SYNC WITH THE TABLE AND CONTENT IN `/docs/design/analytics.md`.
- * WE LIST THOSE DIMENSIONS (AND MORE).
- */
-export enum AnalyticsDimensions {
-  NgAddCollection = 6,
-  NgBuildBuildEventLog = 7,
-}
-
 
 /**
  * Attempt to get the Windows Language Code string.

--- a/packages/angular/cli/models/analytics.ts
+++ b/packages/angular/cli/models/analytics.ts
@@ -242,6 +242,7 @@ export class UniversalAnalytics implements analytics.Analytics {
   private _ua: ua.Visitor;
   private _dirty = false;
   private _metrics: (string | number)[] = [];
+  private _dimensions: (string | number)[] = [];
 
   /**
    * @param trackingId The Google Analytics ID.
@@ -267,10 +268,10 @@ export class UniversalAnalytics implements analytics.Analytics {
     this._ua.set('aid', _getNodeVersion());
 
     // We set custom metrics for values we care about.
-    this._metrics[analytics.NgCliAnalyticsMetrics.CpuCount] = _getCpuCount();
-    this._metrics[analytics.NgCliAnalyticsMetrics.CpuSpeed] = _getCpuSpeed();
-    this._metrics[analytics.NgCliAnalyticsMetrics.RamInMegabytes] = _getRamSize();
-    this._metrics[analytics.NgCliAnalyticsMetrics.NodeVersion] = _getNumericNodeVersion();
+    this._dimensions[analytics.NgCliAnalyticsDimensions.CpuCount] = _getCpuCount();
+    this._dimensions[analytics.NgCliAnalyticsDimensions.CpuSpeed] = _getCpuSpeed();
+    this._dimensions[analytics.NgCliAnalyticsDimensions.RamInMegabytes] = _getRamSize();
+    this._dimensions[analytics.NgCliAnalyticsDimensions.NodeVersion] = _getNumericNodeVersion();
   }
 
   /**
@@ -279,8 +280,9 @@ export class UniversalAnalytics implements analytics.Analytics {
    */
   private _customVariables(options: analytics.CustomDimensionsAndMetricsOptions) {
     const additionals: { [key: string]: boolean | number | string } = {};
-    this._metrics.forEach((v, i) => additionals['cm' + i] = v);
+    this._dimensions.forEach((v, i) => additionals['cd' + i] = v);
     (options.dimensions || []).forEach((v, i) => additionals['cd' + i] = v);
+    this._metrics.forEach((v, i) => additionals['cm' + i] = v);
     (options.metrics || []).forEach((v, i) => additionals['cm' + i] = v);
 
     return additionals;

--- a/packages/angular/cli/models/command.ts
+++ b/packages/angular/cli/models/command.ts
@@ -180,9 +180,14 @@ export abstract class Command<T extends BaseCommandOptions = BaseCommandOptions>
     } else if (options.help === 'json' || options.help === 'JSON') {
       return this.printJsonHelp(options);
     } else {
+      const startTime = +new Date();
       await this.reportAnalytics([this.description.name], options);
+      const result = await this.run(options);
+      const endTime = +new Date();
 
-      return await this.run(options);
+      this.analytics.timing(this.description.name, 'duration', endTime - startTime);
+
+      return result;
     }
   }
 }

--- a/packages/angular_devkit/architect/src/api.ts
+++ b/packages/angular_devkit/architect/src/api.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import { experimental, json, logging } from '@angular-devkit/core';
+import { analytics, experimental, json, logging } from '@angular-devkit/core';
 import { Observable, from } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
 import { Schema as RealBuilderInput, Target as RealTarget } from './input-schema';
@@ -233,6 +233,12 @@ export interface BuilderContext {
    * @param status Update the status string. If omitted the status string is not modified.
    */
   reportProgress(current: number, total?: number, status?: string): void;
+
+  /**
+   * API to report analytics. This might be undefined if the feature is unsupported. This might
+   * not be undefined, but the backend could also not report anything.
+   */
+  readonly analytics: analytics.Analytics;
 
   /**
    * Add teardown logic to this Context, so that when it's being stopped it will execute teardown.

--- a/packages/angular_devkit/architect/src/architect.ts
+++ b/packages/angular_devkit/architect/src/architect.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import { experimental, json, logging } from '@angular-devkit/core';
+import { analytics, experimental, json, logging } from '@angular-devkit/core';
 import { Observable, from, of } from 'rxjs';
 import { concatMap, first, map, shareReplay, switchMap } from 'rxjs/operators';
 import {
@@ -102,6 +102,7 @@ function _createJobHandlerFromBuilderInfo(
 
 export interface ScheduleOptions {
   logger?: logging.Logger;
+  analytics?: analytics.Analytics;
 }
 
 
@@ -347,6 +348,7 @@ export class Architect {
       logger: scheduleOptions.logger || new logging.NullLogger(),
       currentDirectory: this._host.getCurrentDirectory(),
       workspaceRoot: this._host.getWorkspaceRoot(),
+      analytics: scheduleOptions.analytics,
     });
   }
   scheduleTarget(
@@ -359,6 +361,7 @@ export class Architect {
       logger: scheduleOptions.logger || new logging.NullLogger(),
       currentDirectory: this._host.getCurrentDirectory(),
       workspaceRoot: this._host.getWorkspaceRoot(),
+      analytics: scheduleOptions.analytics,
     });
   }
 }

--- a/packages/angular_devkit/architect/src/create-builder.ts
+++ b/packages/angular_devkit/architect/src/create-builder.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import { experimental, isPromise, json, logging } from '@angular-devkit/core';
+import { analytics, experimental, isPromise, json, logging } from '@angular-devkit/core';
 import { Observable, Subscription, from, isObservable, of, throwError } from 'rxjs';
 import { tap } from 'rxjs/operators';
 import {
@@ -36,6 +36,7 @@ export function createBuilder<
     const scheduler = context.scheduler;
     const progressChannel = context.createChannel('progress');
     const logChannel = context.createChannel('log');
+    const analyticsChannel = context.createChannel('analytics');
     let currentState: BuilderProgressState = BuilderProgressState.Stopped;
     const teardownLogics: Array<() => (PromiseLike<void> | void)> = [];
     let tearingDown = false;
@@ -181,6 +182,7 @@ export function createBuilder<
                 progress({ state: currentState, current, total, status }, context);
             }
           },
+          analytics: new analytics.ForwardingAnalytics(report => analyticsChannel.next(report)),
           addTeardown(teardown: () => (Promise<void> | void)): void {
             teardownLogics.push(teardown);
           },

--- a/packages/angular_devkit/architect/src/schedule-by-name.ts
+++ b/packages/angular_devkit/architect/src/schedule-by-name.ts
@@ -8,6 +8,7 @@
 import { experimental, json, logging } from '@angular-devkit/core';
 import { EMPTY, Subscription } from 'rxjs';
 import { catchError, first, ignoreElements, map, share, shareReplay, tap } from 'rxjs/operators';
+import { Analytics, AnalyticsReport, AnalyticsReporter } from '../../core/src/analytics';
 import {
   BuilderInfo,
   BuilderInput,
@@ -31,6 +32,7 @@ export async function scheduleByName(
     logger: logging.LoggerApi,
     workspaceRoot: string | Promise<string>,
     currentDirectory: string | Promise<string>,
+    analytics?: Analytics,
   },
 ): Promise<BuilderRun> {
   const childLoggerName = options.target ? `{${targetStringFromTarget(options.target)}}` : name;
@@ -88,6 +90,12 @@ export async function scheduleByName(
     shareReplay(),
   );
 
+  // If there's an analytics object, take the job channel and report it to the analytics.
+  if (options.analytics) {
+    const reporter = new AnalyticsReporter(options.analytics);
+    job.getChannel<AnalyticsReport>('analytics')
+      .subscribe(report => reporter.report(report));
+  }
   // Start the builder.
   output.pipe(first()).subscribe({
     error() {},
@@ -121,6 +129,7 @@ export async function scheduleByTarget(
     logger: logging.LoggerApi,
     workspaceRoot: string | Promise<string>,
     currentDirectory: string | Promise<string>,
+    analytics?: Analytics,
   },
 ): Promise<BuilderRun> {
   return scheduleByName(`{${targetStringFromTarget(target)}}`, overrides, {

--- a/packages/angular_devkit/build_angular/plugins/webpack/analytics.ts
+++ b/packages/angular_devkit/build_angular/plugins/webpack/analytics.ts
@@ -42,14 +42,23 @@ export function countOccurrences(source: string, match: string, wordBreak = fals
   // We condition here so branch prediction happens out of the loop, not in it.
   if (wordBreak) {
     const re = /\w/;
-    for (let pos = source.lastIndexOf(match); pos >= 0; pos = source.lastIndexOf(match, pos - 1)) {
-      if (!(re.test(source[pos - 1]) || re.test(source[pos + match.length]))) {
+    for (let pos = source.lastIndexOf(match); pos >= 0; pos = source.lastIndexOf(match, pos)) {
+      if (!(re.test(source[pos - 1] || '') || re.test(source[pos + match.length] || ''))) {
         count++;  // 1 match, AH! AH! AH! 2 matches, AH! AH! AH!
+      }
+
+      pos -= match.length;
+      if (pos < 0) {
+        break;
       }
     }
   } else {
-    for (let pos = source.lastIndexOf(match); pos >= 0; pos = source.lastIndexOf(match, pos - 1)) {
+    for (let pos = source.lastIndexOf(match); pos >= 0; pos = source.lastIndexOf(match, pos)) {
       count++;  // 1 match, AH! AH! AH! 2 matches, AH! AH! AH!
+      pos -= match.length;
+      if (pos < 0) {
+        break;
+      }
     }
   }
 

--- a/packages/angular_devkit/build_angular/plugins/webpack/analytics.ts
+++ b/packages/angular_devkit/build_angular/plugins/webpack/analytics.ts
@@ -1,0 +1,256 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { analytics } from '@angular-devkit/core';
+import {
+  Compiler,
+  Module,
+  Stats,
+  compilation,
+} from 'webpack';
+import { Source } from 'webpack-sources';
+import Compilation = compilation.Compilation;
+
+const NormalModule = require('webpack/lib/NormalModule');
+
+interface NormalModule extends Module {
+  _source?: Source | null;
+  resource?: string;
+}
+
+const webpackAllErrorMessageRe = /^([^(]+)\(\d+,\d\): (.*)$/gm;
+const webpackTsErrorMessageRe = /^[^(]+\(\d+,\d\): error (TS\d+):/;
+
+/**
+ * Faster than using a RegExp, so we use this to count occurences in source code.
+ * @param source The source to look into.
+ * @param match The match string to look for.
+ * @param wordBreak Whether to check for word break before and after a match was found.
+ * @return The number of matches found.
+ * @private
+ */
+export function countOccurrences(source: string, match: string, wordBreak = false): number {
+  if (match.length == 0) {
+    return source.length + 1;
+  }
+
+  let count = 0;
+  // We condition here so branch prediction happens out of the loop, not in it.
+  if (wordBreak) {
+    const re = /\w/;
+    for (let pos = source.lastIndexOf(match); pos >= 0; pos = source.lastIndexOf(match, pos - 1)) {
+      if (!(re.test(source[pos - 1]) || re.test(source[pos + match.length]))) {
+        count++;  // 1 match, AH! AH! AH! 2 matches, AH! AH! AH!
+      }
+    }
+  } else {
+    for (let pos = source.lastIndexOf(match); pos >= 0; pos = source.lastIndexOf(match, pos - 1)) {
+      count++;  // 1 match, AH! AH! AH! 2 matches, AH! AH! AH!
+    }
+  }
+
+  return count;
+}
+
+
+/**
+ * Holder of statistics related to the build.
+ */
+class AnalyticsBuildStats {
+  public errors: string[] = [];
+  public numberOfNgOnInit = 0;
+  public initialChunkSize = 0;
+  public totalChunkCount = 0;
+  public totalChunkSize = 0;
+  public lazyChunkCount = 0;
+  public lazyChunkSize = 0;
+  public assetCount = 0;
+  public assetSize = 0;
+  public polyfillSize = 0;
+  public cssSize = 0;
+}
+
+
+/**
+ * Analytics plugin that reports the analytics we want from the CLI.
+ */
+export class NgBuildAnalyticsPlugin {
+  protected _built = false;
+  protected _stats = new AnalyticsBuildStats();
+
+  constructor(
+    protected _projectRoot: string,
+    protected _analytics: analytics.Analytics,
+    protected _category: string,
+  ) {}
+
+  protected _reset() {
+    this._stats = new AnalyticsBuildStats();
+  }
+
+  protected _getMetrics(stats: Stats) {
+    const startTime = +(stats.startTime || 0);
+    const endTime = +(stats.endTime || 0);
+    const metrics: (string | number)[] = [];
+    metrics[analytics.NgCliAnalyticsMetrics.BuildTime] = (endTime - startTime);
+    metrics[analytics.NgCliAnalyticsMetrics.NgOnInitCount] = this._stats.numberOfNgOnInit;
+    metrics[analytics.NgCliAnalyticsMetrics.InitialChunkSize] = this._stats.initialChunkSize;
+    metrics[analytics.NgCliAnalyticsMetrics.TotalChunkCount] = this._stats.totalChunkCount;
+    metrics[analytics.NgCliAnalyticsMetrics.TotalChunkSize] = this._stats.totalChunkSize;
+    metrics[analytics.NgCliAnalyticsMetrics.LazyChunkCount] = this._stats.lazyChunkCount;
+    metrics[analytics.NgCliAnalyticsMetrics.LazyChunkSize] = this._stats.lazyChunkSize;
+    metrics[analytics.NgCliAnalyticsMetrics.AssetCount] = this._stats.assetCount;
+    metrics[analytics.NgCliAnalyticsMetrics.AssetSize] = this._stats.assetSize;
+    metrics[analytics.NgCliAnalyticsMetrics.PolyfillSize] = this._stats.polyfillSize;
+    metrics[analytics.NgCliAnalyticsMetrics.CssSize] = this._stats.cssSize;
+
+    return metrics;
+  }
+  protected _getDimensions(stats: Stats) {
+    const dimensions: (string | number)[] = [];
+    // Adding commas before and after so the regex are easier to define.
+    dimensions[analytics.NgCliAnalyticsDimensions.BuildErrors] = `,${this._stats.errors.join()},`;
+
+    return dimensions;
+  }
+
+  protected _reportBuildMetrics(stats: Stats) {
+    const dimensions = this._getDimensions(stats);
+    const metrics = this._getMetrics(stats);
+    this._analytics.event(this._category, 'build', { dimensions, metrics });
+  }
+
+  protected _reportRebuildMetrics(stats: Stats) {
+    const dimensions = this._getDimensions(stats);
+    const metrics = this._getMetrics(stats);
+    this._analytics.event(this._category, 'rebuild', { dimensions, metrics });
+  }
+
+  protected _checkTsNormalModule(module: NormalModule) {
+    if (module._source) {
+      // We're dealing with ES5 _or_ ES2015 JavaScript at this point (we don't know for sure).
+      // Just count the ngOnInit occurences. Comments/Strings/calls occurences should be sparse
+      // so we just consider them within the margin of error. We do break on word break though.
+      this._stats.numberOfNgOnInit += countOccurrences(module._source.source(), 'ngOnInit', true);
+    }
+  }
+
+  protected _collectErrors(stats: Stats) {
+    if (stats.hasErrors()) {
+      for (const errObject of stats.compilation.errors) {
+        if (errObject instanceof Error) {
+          const allErrors = errObject.message.match(webpackAllErrorMessageRe);
+          for (const err of [...allErrors || []].slice(1)) {
+            const message = (err.match(webpackTsErrorMessageRe) || [])[1];
+            if (message) {
+              // At this point this should be a TS1234.
+              this._stats.errors.push(message);
+            }
+          }
+          // console.log(allErrors);
+        }
+        console.log(errObject.message);
+        console.log('------');
+      }
+    }
+  }
+
+  // We can safely disable no any here since we know the format of the JSON output from webpack.
+  // tslint:disable-next-line:no-any
+  protected _collectBundleStats(json: any) {
+    json.chunks
+      .filter((chunk: { rendered?: boolean }) => chunk.rendered)
+      .forEach((chunk: { files: string[], initial?: boolean, entry?: boolean }) => {
+        const asset = json.assets.find((x: { name: string }) => x.name == chunk.files[0]);
+        const size = asset ? asset.size : 0;
+
+        if (chunk.entry || chunk.initial) {
+          this._stats.initialChunkSize += size;
+        } else {
+          this._stats.lazyChunkCount++;
+          this._stats.lazyChunkSize += size;
+        }
+        this._stats.totalChunkCount++;
+        this._stats.totalChunkSize += size;
+      });
+
+    json.assets
+      // Filter out chunks. We only count assets that are not JS.
+      .filter((a: { name: string }) => {
+        return json.chunks.every((chunk: { files: string[] }) => chunk.files[0] != a.name);
+      })
+      .forEach((a: { size?: number }) => {
+        this._stats.assetSize += (a.size || 0);
+        this._stats.assetCount++;
+      });
+
+    for (const asset of json.assets) {
+      if (asset.name == 'polyfill') {
+        this._stats.polyfillSize += asset.size || 0;
+      }
+    }
+    for (const chunk of json.chunks) {
+      if (chunk.files[0].endsWith('.css')) {
+        this._stats.cssSize += chunk.size || 0;
+      }
+    }
+  }
+
+  /************************************************************************************************
+   * The next section is all the different Webpack hooks for this plugin.
+   */
+
+  /**
+   * Reports a succeed module.
+   * @private
+   */
+  protected _succeedModule(mod: Module) {
+    // Only report NormalModule instances.
+    if (mod.constructor !== NormalModule) {
+      return;
+    }
+    const module = mod as {} as NormalModule;
+
+    // Only reports modules that are part of the user's project. We also don't do node_modules.
+    // There is a chance that someone name a file path `hello_node_modules` or something and we
+    // will ignore that file for the purpose of gathering, but we're willing to take the risk.
+    if (!module.resource
+        || !module.resource.startsWith(this._projectRoot)
+        || module.resource.indexOf('node_modules') >= 0) {
+      return;
+    }
+
+    // Check that it's a source file from the project.
+    if (module.constructor === NormalModule && module.resource.endsWith('.ts')) {
+      this._checkTsNormalModule(module as {} as NormalModule);
+    }
+  }
+
+  protected _compilation(compiler: Compiler, compilation: Compilation) {
+    this._reset();
+    compilation.hooks.succeedModule.tap('NgBuildAnalyticsPlugin', this._succeedModule.bind(this));
+  }
+
+  protected _done(stats: Stats) {
+    this._collectErrors(stats);
+    this._collectBundleStats(stats.toJson());
+    if (this._built) {
+      this._reportRebuildMetrics(stats);
+    } else {
+      this._reportBuildMetrics(stats);
+      this._built = true;
+    }
+  }
+
+  apply(compiler: Compiler): void {
+    compiler.hooks.compilation.tap(
+      'NgBuildAnalyticsPlugin',
+      this._compilation.bind(this, compiler),
+    );
+    compiler.hooks.done.tap('NgBuildAnalyticsPlugin', this._done.bind(this));
+  }
+}

--- a/packages/angular_devkit/build_angular/plugins/webpack/analytics_spec.ts
+++ b/packages/angular_devkit/build_angular/plugins/webpack/analytics_spec.ts
@@ -1,0 +1,95 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { countOccurrences } from './analytics';
+
+
+function _randomString(len: number) {
+  const charSpace = `0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ`;
+
+  let s = '';
+  for (let i = 0; i < len; i++) {
+    s += charSpace[Math.floor(Math.random() * charSpace.length)];
+  }
+
+  return s;
+}
+
+describe('countOccurrences', () => {
+  // Every use cases is a text, search, word break or not, and expected result.
+  const useCases: [string, string, boolean, number][] = [
+    ['abc1def1ghi1jkl1mno1pqrs1tuvw1xyz', '1', false, 7],  // 0
+    ['abc1def12ghi1jkl1mno12pqrs12tuvw1xyz12', '12', false, 4],  // 1
+    ['abc', 'abc', false, 1],  // 2
+    ['abc', 'abc', true, 1],  // 3
+    ['aaaaa', 'aaa', false, 1],  // 4
+    ['aa aaa', 'aaa', true, 1],  // 5
+    ['aaaaaa', 'aaa', false, 2],  // 6
+    ['aaa aaa', 'aaa', true, 2],  // 7
+    ['a', 'a', false, 1],  // 8
+    ['a', 'a', true, 1],  // 9
+  ];
+
+  useCases.forEach(([text, search, wordBreak, expected], i) => {
+    it(`works (${i})`, () => {
+      expect(countOccurrences(text, search, wordBreak)).toBe(expected);
+    });
+  });
+
+  // Random testing.
+  it('can count (random, wordBreak=false)', () => {
+    // Generate a random string with injected search strings in it.
+    let text = _randomString(10000);
+    const search = _randomString(100).toLowerCase();
+    const nb = Math.floor(Math.random() * 200 + 100);
+
+    // Insert nb search string in.
+    new Array(nb).fill(0)
+      // Map it with a random position.
+      .map(() => Math.floor(Math.random() * text.length))
+      // Sort from highest to lowest.
+      .sort((a, b) => b - a)
+      // Insert the search string for each position created this way.
+      .forEach(pos => {
+        text = text.slice(0, pos) + search + text.slice(pos);
+      });
+
+    expect(countOccurrences(text, search, false)).toBe(nb);
+    expect(countOccurrences(text, search, true)).toBe(0);
+  });
+
+  it('can count (random, wordBreak=true)', () => {
+    // Generate a random string with injected search strings in it.
+    let text = _randomString(10000);
+    const search = _randomString(100).toLowerCase();
+    let nb = Math.floor(Math.random() * 200 + 100);
+
+    // Insert nb search string in.
+    new Array(nb).fill(0)
+    // Map it with a random position.
+      .map(() => Math.floor(Math.random() * text.length))
+      // Sort from highest to lowest.
+      .sort((a, b) => b - a)
+      // Insert the search string for each position created this way.
+      .forEach(pos => {
+        switch (Math.floor(Math.random() * 5)) {
+          case 0:
+            // Do not insert a wordbreak.
+            text = text.slice(0, pos) + search + text.slice(pos);
+            nb--;
+            break;
+
+          case 1: text = text.slice(0, pos) + ' ' + search + ' ' + text.slice(pos); break;
+          case 2: text = text.slice(0, pos) + '(' + search + '$' + text.slice(pos); break;
+          case 3: text = text.slice(0, pos) + '|' + search + ')' + text.slice(pos); break;
+          case 4: text = text.slice(0, pos) + '-' + search + '.' + text.slice(pos); break;
+        }
+      });
+
+    expect(countOccurrences(text, search, true)).toBe(nb);
+  });
+});

--- a/packages/angular_devkit/core/src/analytics/index.ts
+++ b/packages/angular_devkit/core/src/analytics/index.ts
@@ -15,6 +15,10 @@ export * from './noop';
 /**
  * MAKE SURE TO KEEP THIS IN SYNC WITH THE TABLE AND CONTENT IN `/docs/design/analytics.md`.
  * WE LIST THOSE DIMENSIONS (AND MORE).
+ *
+ * These cannot be in their respective schema.json file because we either change the type
+ * (e.g. --buildEventLog is string, but we want to know the usage of it, not its value), or
+ * some validation needs to be done (we cannot record ng add --collection if it's not whitelisted).
  */
 export enum NgCliAnalyticsDimensions {
   CpuCount = 1,
@@ -40,6 +44,38 @@ export enum NgCliAnalyticsMetrics {
   LazyChunkSize = 11,
   AssetCount = 12,
   AssetSize = 13,
-  PolyfillSize = 12,
-  CssSize = 13,
+  PolyfillSize = 14,
+  CssSize = 15,
 }
+
+// This table is used when generating the analytics.md file. It should match the enum above
+// or the validate-user-analytics script will fail.
+export const NgCliAnalyticsDimensionsFlagInfo: { [name: string]: [string, string] } = {
+  CpuCount: ['CPU Count', 'number'],
+  CpuSpeed: ['CPU Speed', 'number'],
+  RamInMegabytes: ['RAM (In MB)', 'number'],
+  NodeVersion: ['Node Version', 'number'],
+  NgAddCollection: ['--collection', 'string'],
+  NgBuildBuildEventLog: ['--buildEventLog', 'boolean'],
+  BuildErrors: ['Build Errors (comma separated)', 'string'],
+};
+
+// This table is used when generating the analytics.md file. It should match the enum above
+// or the validate-user-analytics script will fail.
+export const NgCliAnalyticsMetricsFlagInfo: { [name: string]: [string, string] } = {
+  UNUSED_1: ['UNUSED_1', 'none'],
+  UNUSED_2: ['UNUSED_2', 'none'],
+  UNUSED_3: ['UNUSED_3', 'none'],
+  UNUSED_4: ['UNUSED_4', 'none'],
+  BuildTime: ['Build Time', 'number'],
+  NgOnInitCount: ['NgOnInit Count', 'number'],
+  InitialChunkSize: ['Initial Chunk Size', 'number'],
+  TotalChunkCount: ['Total Chunk Count', 'number'],
+  TotalChunkSize: ['Total Chunk Size', 'number'],
+  LazyChunkCount: ['Lazy Chunk Count', 'number'],
+  LazyChunkSize: ['Lazy Chunk Size', 'number'],
+  AssetCount: ['Asset Count', 'number'],
+  AssetSize: ['Asset Size', 'number'],
+  PolyfillSize: [' Polyfill Size', 'number'],
+  CssSize: [' Css Size', 'number'],
+};

--- a/packages/angular_devkit/core/src/analytics/index.ts
+++ b/packages/angular_devkit/core/src/analytics/index.ts
@@ -10,3 +10,32 @@ export * from './forwarder';
 export * from './logging';
 export * from './multi';
 export * from './noop';
+
+
+/**
+ * MAKE SURE TO KEEP THIS IN SYNC WITH THE TABLE AND CONTENT IN `/docs/design/analytics.md`.
+ * WE LIST THOSE DIMENSIONS (AND MORE).
+ */
+export enum NgCliAnalyticsDimensions {
+  NgAddCollection = 6,
+  NgBuildBuildEventLog = 7,
+  BuildErrors = 20,
+}
+
+export enum NgCliAnalyticsMetrics {
+  CpuCount = 1,
+  CpuSpeed = 2,
+  RamInMegabytes = 3,
+  NodeVersion = 4,
+  BuildTime = 5,
+  NgOnInitCount = 6,
+  InitialChunkSize = 7,
+  TotalChunkCount = 8,
+  TotalChunkSize = 9,
+  LazyChunkCount = 10,
+  LazyChunkSize = 11,
+  AssetCount = 12,
+  AssetSize = 13,
+  PolyfillSize = 12,
+  CssSize = 13,
+}

--- a/packages/angular_devkit/core/src/analytics/index.ts
+++ b/packages/angular_devkit/core/src/analytics/index.ts
@@ -17,16 +17,20 @@ export * from './noop';
  * WE LIST THOSE DIMENSIONS (AND MORE).
  */
 export enum NgCliAnalyticsDimensions {
+  CpuCount = 1,
+  CpuSpeed = 2,
+  RamInMegabytes = 3,
+  NodeVersion = 4,
   NgAddCollection = 6,
   NgBuildBuildEventLog = 7,
   BuildErrors = 20,
 }
 
 export enum NgCliAnalyticsMetrics {
-  CpuCount = 1,
-  CpuSpeed = 2,
-  RamInMegabytes = 3,
-  NodeVersion = 4,
+  UNUSED_1 = 1,
+  UNUSED_2 = 2,
+  UNUSED_3 = 3,
+  UNUSED_4 = 4,
   BuildTime = 5,
   NgOnInitCount = 6,
   InitialChunkSize = 7,

--- a/packages/schematics/angular/application/schema.json
+++ b/packages/schematics/angular/application/schema.json
@@ -80,8 +80,7 @@
     "skipPackageJson": {
       "type": "boolean",
       "default": false,
-      "description": "When true, does not add dependencies to the \"package.json\" file.",
-      "x-user-analytics": 13
+      "description": "When true, does not add dependencies to the \"package.json\" file."
     },
     "minimal": {
       "description": "When true, creates a bare-bones project without any testing frameworks. (Use for learning purposes only.)",

--- a/packages/schematics/angular/application/schema.json
+++ b/packages/schematics/angular/application/schema.json
@@ -92,8 +92,7 @@
     "skipInstall": {
       "description": "Skip installing dependency packages.",
       "type": "boolean",
-      "default": false,
-      "x-user-analytics": 4
+      "default": false
     },
     "lintFix": {
       "type": "boolean",

--- a/packages/schematics/angular/component/schema.json
+++ b/packages/schematics/angular/component/schema.json
@@ -130,8 +130,7 @@
     "entryComponent": {
       "type": "boolean",
       "default": false,
-      "description": "When true, the new component is the entry component of the declaring NgModule.",
-      "x-user-analytics": 20
+      "description": "When true, the new component is the entry component of the declaring NgModule."
     },
     "lintFix": {
       "type": "boolean",

--- a/packages/schematics/angular/library/schema.json
+++ b/packages/schematics/angular/library/schema.json
@@ -31,8 +31,7 @@
     "skipPackageJson": {
       "type": "boolean",
       "default": false,
-      "description": "When true, does not add dependencies to the \"package.json\" file. ",
-      "x-user-analytics": 13
+      "description": "When true, does not add dependencies to the \"package.json\" file. "
     },
     "skipInstall": {
       "description": "When true, does not install dependency packages.",

--- a/packages/schematics/angular/library/schema.json
+++ b/packages/schematics/angular/library/schema.json
@@ -37,8 +37,7 @@
     "skipInstall": {
       "description": "When true, does not install dependency packages.",
       "type": "boolean",
-      "default": false,
-      "x-user-analytics": 4
+      "default": false
     },
     "skipTsConfig": {
       "type": "boolean",

--- a/packages/schematics/angular/ng-new/schema.json
+++ b/packages/schematics/angular/ng-new/schema.json
@@ -26,8 +26,7 @@
     "skipInstall": {
       "description": "When true, does not install dependency packages.",
       "type": "boolean",
-      "default": false,
-      "x-user-analytics": 4
+      "default": false
     },
     "linkCli": {
       "description": "When true, links the CLI to the global version (internal development only).",

--- a/packages/schematics/angular/universal/schema.json
+++ b/packages/schematics/angular/universal/schema.json
@@ -57,8 +57,7 @@
     "skipInstall": {
       "description": "When true, does not install packages for dependencies.",
       "type": "boolean",
-      "default": false,
-      "x-user-analytics": 4
+      "default": false
     }
   },
   "required": [

--- a/packages/schematics/angular/workspace/schema.json
+++ b/packages/schematics/angular/workspace/schema.json
@@ -21,8 +21,7 @@
     "skipInstall": {
       "description": "When true, does not install packages for dependencies.",
       "type": "boolean",
-      "default": false,
-      "x-user-analytics": 4
+      "default": false
     },
     "linkCli": {
       "description": "When true, links the CLI to the global version (internal development only).",

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -397,8 +397,10 @@ export default async function(
   const tarLogger = logger.createChild('license');
   Object.keys(packages).forEach(pkgName => {
     const pkg = packages[pkgName];
-    tarLogger.info(`${pkgName} => ${pkg.tar}`);
-    _tar(pkg.tar, pkg.dist);
+    if (!pkg.private) {
+      tarLogger.info(`${pkgName} => ${pkg.tar}`);
+      _tar(pkg.tar, pkg.dist);
+    }
   });
 
   logger.info(`Done.`);

--- a/scripts/templates/user-analytics-table.ejs
+++ b/scripts/templates/user-analytics-table.ejs
@@ -1,0 +1,9 @@
+<%
+%>| Id | Flag | Type |
+|:---:|:---|:---|
+<% for (const flag of flags) {
+  if (flag === undefined) {
+    continue;
+  }
+%>| <%= flag.userAnalytics %> | `<%= flag.name %>` | `<%= flag.type %>` |
+<%}%>

--- a/scripts/validate-user-analytics.ts
+++ b/scripts/validate-user-analytics.ts
@@ -1,0 +1,218 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+// tslint:disable:no-implicit-dependencies
+import { analytics, logging, tags } from '@angular-devkit/core';
+import { spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { CommandDescriptionMap, Option } from '../packages/angular/cli/models/interface';
+import create from './create';
+
+const userAnalyticsTable = require('./templates/user-analytics-table').default;
+
+const dimensionsTableRe = /<!--DIMENSIONS_TABLE_BEGIN-->([\s\S]*)<!--DIMENSIONS_TABLE_END-->/m;
+const metricsTableRe = /<!--METRICS_TABLE_BEGIN-->([\s\S]*)<!--METRICS_TABLE_END-->/m;
+
+/**
+ * Execute a command.
+ * @private
+ */
+function _exec(command: string, args: string[], opts: { cwd?: string }, logger: logging.Logger) {
+  const { status, error, stdout } = spawnSync(command, args, {
+    stdio: ['ignore', 'pipe', 'inherit'],
+    ...opts,
+  });
+
+  if (status != 0) {
+    logger.error(`Command failed: ${command} ${args.map(x => JSON.stringify(x)).join(', ')}`);
+    throw error;
+  }
+
+  return stdout.toString('utf-8');
+}
+
+async function _checkDimensions(dimensionsTable: string, logger: logging.Logger) {
+  const data: { userAnalytics: number, type: string, name: string }[] = new Array(200);
+
+  function _updateData(userAnalytics: number, name: string, type: string) {
+    if (data[userAnalytics]) {
+      if (data[userAnalytics].name !== name) {
+        logger.error(tags.stripIndents`
+            User analytics clash with the same name: ${data[userAnalytics].name} and
+            ${name} both have userAnalytics of ${userAnalytics}
+          `);
+
+        return 2;
+      }
+    } else {
+      data[userAnalytics] = { userAnalytics, name, type };
+    }
+  }
+
+  logger.info('Gathering fixed dimension from @angular-devkit/core...');
+
+  // Create the data with dimensions missing from schema.json:
+  const allFixedDimensions = Object.keys(analytics.NgCliAnalyticsDimensions)
+  // tslint:disable-next-line:no-any
+    .filter(x => typeof analytics.NgCliAnalyticsDimensions[x as any] === 'number');
+
+  for (const name of allFixedDimensions) {
+    // tslint:disable-next-line:no-any
+    const userAnalytics = analytics.NgCliAnalyticsDimensions[name as any];
+    if (!(name in analytics.NgCliAnalyticsDimensionsFlagInfo)) {
+      throw new Error(
+        `Flag ${name} is in NgCliAnalyticsDimensions but not NgCliAnalyticsDimensionsFlagInfo`,
+      );
+    }
+
+    const [flagName, type] = analytics.NgCliAnalyticsDimensionsFlagInfo[name];
+    if (typeof userAnalytics !== 'number') {
+      throw new Error(
+        `Invalid value found in enum AnalyticsDimensions: ${JSON.stringify(userAnalytics)}`,
+      );
+    }
+    _updateData(userAnalytics, flagName, type);
+  }
+
+
+  // Creating a new project and reading the help.
+  logger.info('Creating temporary project for gathering help...');
+
+  const newProjectTempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'angular-cli-create-'));
+  const newProjectName = 'help-project';
+  const newProjectRoot = path.join(newProjectTempRoot, newProjectName);
+  await create({ _: [newProjectName] }, logger.createChild('create'), newProjectTempRoot);
+
+  const commandDescription: CommandDescriptionMap = {};
+
+  logger.info('Gathering options...');
+
+  const commands = require('../packages/angular/cli/commands.json');
+  const ngPath = path.join(newProjectRoot, 'node_modules/.bin/ng');
+  for (const commandName of Object.keys(commands)) {
+    const options = { cwd: newProjectRoot };
+    const childLogger = logger.createChild(commandName);
+    const stdout = _exec(ngPath, [commandName, '--help=json'], options, childLogger);
+    commandDescription[commandName] = JSON.parse(stdout.trim());
+  }
+
+  function _checkOptionsForAnalytics(options: Option[]) {
+    for (const option of options) {
+      if (option.subcommands) {
+        for (const subcommand of Object.values(option.subcommands)) {
+          _checkOptionsForAnalytics(subcommand.options);
+        }
+      }
+
+      if (option.userAnalytics === undefined) {
+        continue;
+      }
+      _updateData(option.userAnalytics, 'Flag: --' + option.name, option.type);
+    }
+  }
+
+  for (const commandName of Object.keys(commandDescription)) {
+    _checkOptionsForAnalytics(commandDescription[commandName].options);
+  }
+
+  const generatedTable = userAnalyticsTable({ flags: data }).trim();
+  if (dimensionsTable !== generatedTable) {
+    logger.error('Expected dimensions table to be the same as generated. Copy the lines below:');
+    logger.error(generatedTable);
+
+    return 3;
+  }
+
+  return 0;
+}
+
+async function _checkMetrics(metricsTable: string, logger: logging.Logger) {
+  const data: { userAnalytics: number, type: string, name: string }[] = new Array(200);
+
+  function _updateData(userAnalytics: number, name: string, type: string) {
+    if (data[userAnalytics]) {
+      if (data[userAnalytics].name !== name) {
+        logger.error(tags.stripIndents`
+            User analytics clash with the same name: ${data[userAnalytics].name} and
+            ${name} both have userAnalytics of ${userAnalytics}
+          `);
+
+        return 2;
+      }
+    } else {
+      data[userAnalytics] = { userAnalytics, name, type };
+    }
+  }
+
+  logger.info('Gathering fixed metrics from @angular-devkit/core...');
+
+  // Create the data with dimensions missing from schema.json:
+  const allFixedMetrics = Object.keys(analytics.NgCliAnalyticsMetrics)
+  // tslint:disable-next-line:no-any
+    .filter(x => typeof analytics.NgCliAnalyticsMetrics[x as any] === 'number');
+
+  for (const name of allFixedMetrics) {
+    // tslint:disable-next-line:no-any
+    const userAnalytics = analytics.NgCliAnalyticsMetrics[name as any];
+    if (!(name in analytics.NgCliAnalyticsMetricsFlagInfo)) {
+      throw new Error(
+        `Flag ${name} is in NgCliAnalyticsMetrics but not NgCliAnalyticsMetricsFlagInfo`,
+      );
+    }
+
+    const [flagName, type] = analytics.NgCliAnalyticsMetricsFlagInfo[name];
+    if (typeof userAnalytics !== 'number') {
+      throw new Error(
+        `Invalid value found in enum NgCliAnalyticsMetrics: ${JSON.stringify(userAnalytics)}`,
+      );
+    }
+    _updateData(userAnalytics, flagName, type);
+  }
+
+  const generatedTable = userAnalyticsTable({ flags: data }).trim();
+  if (metricsTable !== generatedTable) {
+    logger.error('Expected metrics table to be the same as generated. Copy the lines below:');
+    logger.error(generatedTable);
+
+    return 4;
+  }
+
+  return 0;
+}
+
+/**
+ * Validate that the table of analytics from the analytics.md document is the same as expected /
+ * generated.
+ */
+export default async function (_options: {}, logger: logging.Logger): Promise<number> {
+  const analyticsMarkdownPath = path.join(__dirname, '../docs/design/analytics.md');
+  const analyticsMarkdown = fs.readFileSync(analyticsMarkdownPath, 'utf8');
+  const dimensionsMatch = analyticsMarkdown.match(dimensionsTableRe);
+  const metricsMatch = analyticsMarkdown.match(metricsTableRe);
+
+  if (!dimensionsMatch || !metricsMatch) {
+    logger.fatal('Could not find dimensions or metrics table in analytics.md');
+
+    return 1;
+  }
+
+  const metricsTable = metricsMatch[1].trim();
+  let maybeError = await _checkMetrics(metricsTable, logger);
+  if (maybeError) {
+    return maybeError;
+  }
+
+  const dimensionsTable = dimensionsMatch[1].trim();
+  maybeError = await _checkDimensions(dimensionsTable, logger);
+  if (maybeError) {
+    return maybeError;
+  }
+
+  return 0;
+}

--- a/scripts/validate.ts
+++ b/scripts/validate.ts
@@ -13,6 +13,7 @@ import validateBuildFiles from './validate-build-files';
 import validateCommits from './validate-commits';
 import validateDoNotSubmit from './validate-do-not-submit';
 import validateLicenses from './validate-licenses';
+import validateUserAnalytics from './validate-user-analytics';
 
 export default async function (options: { verbose: boolean }, logger: logging.Logger) {
   let error = false;
@@ -58,6 +59,11 @@ export default async function (options: { verbose: boolean }, logger: logging.Lo
   logger.info('Running BUILD files validation...');
   error = await validateBuildFiles({}, logger.createChild('validate-build-files')) != 0
        || error;
+
+  logger.info('');
+  logger.info('Running User Analytics validation...');
+  error = await validateUserAnalytics({}, logger.createChild('validate-user-analytics')) != 0
+    || error;
 
   if (error) {
     return 101;


### PR DESCRIPTION
Multiple changes:

1. Builder stats for every build. This was tested using logging and Architect CLI.  
    The only missing piece is for the Angular CLI to pass an instance of `Analytics` interface.
1. Validation script for the user analytics, to make sure the document is kept up to date.
1. Rework some metrics into dimensions, which lets us make better reports.
1. adding duration tracking for all commands.