### PR TITLE
fix(@ngtools/webpack): don't invalidate cache after first run

### DIFF
--- a/packages/ngtools/webpack/src/transformers/replace_resources.ts
+++ b/packages/ngtools/webpack/src/transformers/replace_resources.ts
@@ -18,9 +18,21 @@ export function replaceResources(
 
     const visitNode: ts.Visitor = (node: ts.Decorator) => {
       if (ts.isClassDeclaration(node)) {
-        node.decorators = ts.visitNodes(
+        const decorators = ts.visitNodes(
           node.decorators,
           (node: ts.Decorator) => visitDecorator(node, typeChecker, directTemplateLoading),
+        );
+
+        // todo: we need to investigate and confirm that using
+        //  `updateClassDeclaration` has no regressions
+        return ts.updateClassDeclaration(
+          node,
+          decorators,
+          node.modifiers,
+          node.name,
+          node.typeParameters,
+          node.heritageClauses,
+          node.members,
         );
       }
 


### PR DESCRIPTION
- fix(@ngtools/webpack): don't invalidate cache after first run
At the moment, since there are no old files in the compilation it will cause all source files to be invalidate after the first run. This shouldn't be done as it will slow down the 2nd recompilation.

- fix(@ngtools/webpack): replace resources should not return class node when modified
This is also the root cause of spec large fail occasionally as we keep checking the child class nodes