### PR TITLE
fix(@angular-devkit/build-angular): exclude map files from 'bundle' budgets

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/bundle-calculator.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/bundle-calculator.ts
@@ -48,6 +48,7 @@ class BundleCalculator extends Calculator {
     const size: number = this.compilation.chunks
       .filter(chunk => chunk.name === this.budget.name)
       .reduce((files, chunk) => [...files, ...chunk.files], [])
+      .filter((file: string) => !file.endsWith('.map'))
       .map((file: string) => this.compilation.assets[file].size())
       .reduce((total: number, size: number) => total + size, 0);
 

--- a/packages/angular_devkit/build_angular/test/browser/bundle-budgets_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/browser/bundle-budgets_spec_large.ts
@@ -65,6 +65,18 @@ describe('Browser Builder bundle budgets', () => {
   });
 
   describe(`should ignore '.map' files`, () => {
+    it(`when 'bundle' budget`, async () => {
+      const overrides = {
+        optimization: true,
+        budgets: [{ type: 'bundle', name: 'main', maximumError: '3Kb' }],
+      };
+
+      const run = await architect.scheduleTarget(targetSpec, overrides);
+      const output = await run.result;
+      expect(output.success).toBe(true);
+      await run.stop();
+    });
+
     it(`when 'intial' budget`, async () => {
       const overrides = {
         optimization: true,


### PR DESCRIPTION
#11999 raised the issue of bundle budgets for the `initial` type including source maps. That issue was fixed in #12012. However, as was noted by @Tonio31, source maps should also be excluded from `bundle`-type budgets.