### PR TITLE
Update JSON schema references

### DIFF
--- a/packages/_/devkit/package/schema.json
+++ b/packages/_/devkit/package/schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "id": "SchematicsSchematicSchema",
   "title": "DevKit Package Schematic Schema",
   "type": "object",

--- a/packages/angular/cli/commands/add.json
+++ b/packages/angular/cli/commands/add.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "ng-cli://commands/add.json",
   "description": "Adds support for an external library to your project.",
   "$longDescription": "./add.md",

--- a/packages/angular/cli/commands/build.json
+++ b/packages/angular/cli/commands/build.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "ng-cli://commands/build.json",
   "description": "Compiles an Angular app into an output directory named dist/ at the given output path. Must be executed from within a workspace directory.",
   "$longDescription": "./build-long.md",

--- a/packages/angular/cli/commands/config.json
+++ b/packages/angular/cli/commands/config.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "ng-cli://commands/config.json",
   "description": "Retrieves or sets Angular configuration values in the angular.json file for the workspace.",
   "$longDescription": "",

--- a/packages/angular/cli/commands/definitions.json
+++ b/packages/angular/cli/commands/definitions.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "ng-cli://commands/definitions.json",
 
   "definitions": {

--- a/packages/angular/cli/commands/deprecated.json
+++ b/packages/angular/cli/commands/deprecated.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "ng-cli://commands/deprecated.json",
   "description": "Deprecated in favor of config command.",
   "$longDescription": "",

--- a/packages/angular/cli/commands/doc.json
+++ b/packages/angular/cli/commands/doc.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "ng-cli://commands/doc.json",
   "description": "Opens the official Angular documentation (angular.io) in a browser, and searches for a given keyword.",
   "$longDescription": "",

--- a/packages/angular/cli/commands/e2e.json
+++ b/packages/angular/cli/commands/e2e.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "ng-cli://commands/e2e.json",
   "description": "Builds and serves an Angular app, then runs end-to-end tests using Protractor.",
   "$longDescription": "./e2e-long.md",

--- a/packages/angular/cli/commands/easter-egg.json
+++ b/packages/angular/cli/commands/easter-egg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "ng-cli://commands/easter-egg.json",
   "description": "",
   "$longDescription": "",

--- a/packages/angular/cli/commands/generate.json
+++ b/packages/angular/cli/commands/generate.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "ng-cli://commands/generate.json",
   "description": "Generates and/or modifies files based on a schematic.",
   "$longDescription": "",

--- a/packages/angular/cli/commands/help.json
+++ b/packages/angular/cli/commands/help.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "ng-cli://commands/help.json",
   "description": "Lists available commands and their short descriptions.",
   "$longDescription": "./help-long.md",

--- a/packages/angular/cli/commands/lint.json
+++ b/packages/angular/cli/commands/lint.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "ng-cli://commands/lint.json",
   "description": "Runs linting tools on Angular app code in a given project folder.",
   "$longDescription": "./lint-long.md",

--- a/packages/angular/cli/commands/new.json
+++ b/packages/angular/cli/commands/new.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "ng-cli://commands/new.json",
   "description": "Creates a new workspace and an initial Angular app.",
   "$longDescription": "./new.md",

--- a/packages/angular/cli/commands/run.json
+++ b/packages/angular/cli/commands/run.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "ng-cli://commands/run.json",
   "description": "Runs an Architect target with an optional custom builder configuration defined in your project.",
   "$longDescription": "./run-long.md",

--- a/packages/angular/cli/commands/serve.json
+++ b/packages/angular/cli/commands/serve.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "ng-cli://commands/serve.json",
   "description": "Builds and serves your app, rebuilding on file changes.",
   "$longDescription": "",

--- a/packages/angular/cli/commands/test.json
+++ b/packages/angular/cli/commands/test.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "ng-cli://commands/test.json",
   "description": "Runs unit tests in a project.",
   "$longDescription": "./test-long.md",

--- a/packages/angular/cli/commands/update.json
+++ b/packages/angular/cli/commands/update.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "ng-cli://commands/update.json",
   "description": "Updates your application and its dependencies. See https://update.angular.io/",
   "$longDescription": "./update-long.md",

--- a/packages/angular/cli/commands/version.json
+++ b/packages/angular/cli/commands/version.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "ng-cli://commands/version.json",
   "description": "Outputs Angular CLI version.",
   "$longDescription": "",

--- a/packages/angular/cli/commands/xi18n.json
+++ b/packages/angular/cli/commands/xi18n.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "ng-cli://commands/xi18n.json",
   "description": "Extracts i18n messages from source code.",
   "$longDescription": "",

--- a/packages/angular/pwa/pwa/schema.json
+++ b/packages/angular/pwa/pwa/schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "id": "SchematicsAngularPWA",
   "title": "Angular PWA Options Schema",
   "type": "object",

--- a/packages/angular_devkit/architect/builders/noop-schema.json
+++ b/packages/angular_devkit/architect/builders/noop-schema.json
@@ -1,4 +1,4 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "type": "object"
 }

--- a/packages/angular_devkit/architect/builders/operator-schema.json
+++ b/packages/angular_devkit/architect/builders/operator-schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "description": "All input types of builders that perform operations on one or multiple sub-builders.",
   "type": "object",
   "properties": {

--- a/packages/angular_devkit/architect/src/builders-schema.json
+++ b/packages/angular_devkit/architect/src/builders-schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "id": "BuildersSchema",
   "title": "Builders schema for validating a list of builders.",
   "type": "object",

--- a/packages/angular_devkit/architect/src/input-schema.json
+++ b/packages/angular_devkit/architect/src/input-schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "id": "BuilderInputSchema",
   "title": "Input schema for builders.",
   "type": "object",

--- a/packages/angular_devkit/architect/src/output-schema.json
+++ b/packages/angular_devkit/architect/src/output-schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "id": "BuilderOutputSchema",
   "title": "Output schema for builders.",
   "type": "object",

--- a/packages/angular_devkit/architect/src/progress-schema.json
+++ b/packages/angular_devkit/architect/src/progress-schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "id": "BuilderProgressSchema",
   "title": "Progress schema for builders.",
   "type": "object",

--- a/packages/angular_devkit/architect/src/targets-schema.json
+++ b/packages/angular_devkit/architect/src/targets-schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "id": "ArchitectTargets",
   "title": "Targets schema for validating Architect targets configuration.",
   "type": "object",

--- a/packages/angular_devkit/build_angular/src/browser/schema.json
+++ b/packages/angular_devkit/build_angular/src/browser/schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "title": "Webpack browser schema for Build Facade.",
   "description": "Browser target options",
   "type": "object",

--- a/packages/angular_devkit/build_angular/src/dev-server/schema.json
+++ b/packages/angular_devkit/build_angular/src/dev-server/schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "title": "Dev Server Target",
   "description": "Dev Server target options for Build Facade.",
   "type": "object",

--- a/packages/angular_devkit/build_angular/src/server/schema.json
+++ b/packages/angular_devkit/build_angular/src/server/schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "id": "BuildAngularWebpackServerSchema",
   "title": "Universal Target",
   "type": "object",

--- a/packages/angular_devkit/build_webpack/src/webpack-dev-server/schema.json
+++ b/packages/angular_devkit/build_webpack/src/webpack-dev-server/schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "title": "Webpack Dev-Server Builder",
   "description": "Webpack Dev-Server Builder schema for Architect.",
   "type": "object",

--- a/packages/angular_devkit/build_webpack/src/webpack/schema.json
+++ b/packages/angular_devkit/build_webpack/src/webpack/schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "title": "Webpack Builder.",
   "description": "Webpack Builder schema for Architect.",
   "type": "object",

--- a/packages/angular_devkit/core/src/experimental/workspace/workspace-schema.json
+++ b/packages/angular_devkit/core/src/experimental/workspace/workspace-schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "id": "AngularDevkitWorkspaceSchema",
   "title": "Angular Devkit Workspace Schema for validating workspace JSON.",
   "type": "object",

--- a/packages/angular_devkit/schematics/collection-schema.json
+++ b/packages/angular_devkit/schematics/collection-schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "id": "SchematicsCollectionSchema",
   "title": "Collection Schema for validating a 'collection.json'.",
   "type": "object",

--- a/packages/schematics/angular/app-shell/schema.json
+++ b/packages/schematics/angular/app-shell/schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "id": "SchematicsAngularAppShell",
   "title": "Angular AppShell Options Schema",
   "type": "object",

--- a/packages/schematics/angular/application/schema.json
+++ b/packages/schematics/angular/application/schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "id": "SchematicsAngularApp",
   "title": "Angular Application Options Schema",
   "type": "object",

--- a/packages/schematics/angular/class/schema.json
+++ b/packages/schematics/angular/class/schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "id": "SchematicsAngularClass",
   "title": "Angular Class Options Schema",
   "type": "object",

--- a/packages/schematics/angular/component/schema.json
+++ b/packages/schematics/angular/component/schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "id": "SchematicsAngularComponent",
   "title": "Angular Component Options Schema",
   "type": "object",

--- a/packages/schematics/angular/directive/schema.json
+++ b/packages/schematics/angular/directive/schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "id": "SchematicsAngularDirective",
   "title": "Angular Directive Options Schema",
   "type": "object",

--- a/packages/schematics/angular/e2e/schema.json
+++ b/packages/schematics/angular/e2e/schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "id": "SchematicsAngularE2eApp",
   "title": "Angular e2e Application Options Schema",
   "type": "object",

--- a/packages/schematics/angular/enum/schema.json
+++ b/packages/schematics/angular/enum/schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "id": "SchematicsAngularEnum",
   "title": "Angular Enum Options Schema",
   "type": "object",

--- a/packages/schematics/angular/guard/schema.json
+++ b/packages/schematics/angular/guard/schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "id": "SchematicsAngularGuard",
   "title": "Angular Guard Options Schema",
   "type": "object",

--- a/packages/schematics/angular/interface/schema.json
+++ b/packages/schematics/angular/interface/schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "id": "SchematicsAngularInterface",
   "title": "Angular Interface Options Schema",
   "type": "object",

--- a/packages/schematics/angular/library/schema.json
+++ b/packages/schematics/angular/library/schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "id": "SchematicsLibrary",
   "title": "Library Options Schema",
   "type": "object",

--- a/packages/schematics/angular/module/schema.json
+++ b/packages/schematics/angular/module/schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "id": "SchematicsAngularModule",
   "title": "Angular Module Options Schema",
   "type": "object",

--- a/packages/schematics/angular/ng-new/schema.json
+++ b/packages/schematics/angular/ng-new/schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "id": "SchematicsAngularNgNew",
   "title": "Angular Ng New Options Schema",
   "type": "object",

--- a/packages/schematics/angular/pipe/schema.json
+++ b/packages/schematics/angular/pipe/schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "id": "SchematicsAngularPipe",
   "title": "Angular Pipe Options Schema",
   "type": "object",

--- a/packages/schematics/angular/service-worker/schema.json
+++ b/packages/schematics/angular/service-worker/schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "id": "SchematicsAngularServiceWorker",
   "title": "Angular Service Worker Options Schema",
   "type": "object",

--- a/packages/schematics/angular/service/schema.json
+++ b/packages/schematics/angular/service/schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "id": "SchematicsAngularService",
   "title": "Angular Service Options Schema",
   "type": "object",

--- a/packages/schematics/angular/universal/schema.json
+++ b/packages/schematics/angular/universal/schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "id": "SchematicsAngularUniversalApp",
   "title": "Angular Universal App Options Schema",
   "type": "object",

--- a/packages/schematics/angular/workspace/schema.json
+++ b/packages/schematics/angular/workspace/schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "id": "SchematicsAngularWorkspace",
   "title": "Angular Workspace Options Schema",
   "type": "object",

--- a/packages/schematics/schematics/blank/schema.json
+++ b/packages/schematics/schematics/blank/schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "id": "SchematicsSchematicSchema",
   "title": "Schematic Options Schema",
   "type": "object",

--- a/packages/schematics/schematics/schematic/files/src/my-full-schematic/schema.json
+++ b/packages/schematics/schematics/schematic/files/src/my-full-schematic/schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "id": "MyFullSchematicsSchema",
   "title": "My Full Schematics Schema",
   "type": "object",

--- a/packages/schematics/schematics/schematic/schema.json
+++ b/packages/schematics/schematics/schematic/schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "id": "SchematicsSchematicSchema",
   "title": "Schematic Options Schema",
   "type": "object",

--- a/packages/schematics/update/migrate/schema.json
+++ b/packages/schematics/update/migrate/schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "id": "PostUpdateSchema",
   "type": "object",
   "properties": {

--- a/packages/schematics/update/update/schema.json
+++ b/packages/schematics/update/update/schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "id": "SchematicsUpdateSchema",
   "title": "Schematic Options Schema",
   "type": "object",

--- a/tests/angular_devkit/core/json/schema/serializers/schema_benchmark.json
+++ b/tests/angular_devkit/core/json/schema/serializers/schema_benchmark.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "id": "https://github.com/angular/angular-cli/blob/master/packages/@angular/cli/lib/config/schema.json#CliConfig",
   "title": "Angular CLI Config Schema",
   "type": "object",


### PR DESCRIPTION
Currently many of the schemas reference `http://json-schema.org/schema` which points to the latest version of the schema and will change over time.  It currently points to the `draft-07` version which allows everything to work for now.  However, there is no guarantee that the latest version will be supported by the CLI nor that the file will conform to the latest version.  By specifying a specific version, the `$schema` identifier can be used as both a version identifier for the format of the file and as the location of the schema.  This allows processors to use the specified version/format of the specification when parsing and processing the file.  (ref: http://json-schema.org/draft-07/json-schema-core.html#rfc.section.7)