### PR TITLE
fix(@schematics/angular): buildRelativePath handles files in root

### DIFF
--- a/packages/angular_devkit/core/src/virtual-fs/path.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/path.ts
@@ -144,8 +144,8 @@ export function relative(from: Path, to: Path): Path {
   if (from == to) {
     p = '';
   } else {
-    const splitFrom = from.split(NormalizedSep);
-    const splitTo = to.split(NormalizedSep);
+    const splitFrom = split(from);
+    const splitTo = split(to);
 
     while (splitFrom.length > 0 && splitTo.length > 0 && splitFrom[0] == splitTo[0]) {
       splitFrom.shift();

--- a/packages/angular_devkit/core/src/virtual-fs/path_spec.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/path_spec.ts
@@ -133,6 +133,8 @@ describe('path', () => {
         '/src/app/sub1/test1', '/src/app/sub2/test2',
         '../../sub2/test2',
       ],
+      ['/', '/a/b/c', 'a/b/c'],
+      ['/a/b/c', '/d', '../../../d'],
     ];
 
     for (const [from, to, result] of tests) {
@@ -141,6 +143,7 @@ describe('path', () => {
         const t = normalize(to);
 
         expect(relative(f, t)).toBe(result);
+        expect(join(f, relative(f, t))).toBe(t);
       });
     }
   });

--- a/packages/schematics/angular/utility/find-module.ts
+++ b/packages/schematics/angular/utility/find-module.ts
@@ -130,7 +130,8 @@ export function buildRelativePath(from: string, to: string): string {
   fromParts.pop();
   const toFileName = toParts.pop();
 
-  const relativePath = relative(normalize(fromParts.join('/')), normalize(toParts.join('/')));
+  const relativePath = relative(normalize(fromParts.join('/') || '/'),
+   normalize(toParts.join('/') || '/'));
   let pathPrefix = '';
 
   // Set the path prefix for same dir or child dir, parent dir starts with `..`

--- a/packages/schematics/angular/utility/find-module_spec.ts
+++ b/packages/schematics/angular/utility/find-module_spec.ts
@@ -7,7 +7,7 @@
  */
 import { Path } from '@angular-devkit/core';
 import { EmptyTree, Tree } from '@angular-devkit/schematics';
-import { ModuleOptions, findModule, findModuleFromOptions } from './find-module';
+import { ModuleOptions, buildRelativePath, findModule, findModuleFromOptions } from './find-module';
 
 
 describe('find-module', () => {
@@ -187,6 +187,19 @@ describe('find-module', () => {
       options.module = 'app.module';
       modPath = findModuleFromOptions(tree, options);
       expect(modPath).toBe('/projects/my-proj/src/app.module.ts' as Path);
+    });
+  });
+
+  describe('buildRelativePath', () => {
+    it('works', () => {
+      expect(buildRelativePath('/test/module', '/test/service'))
+          .toEqual('./service');
+      expect(buildRelativePath('/test/module', '/other/service'))
+          .toEqual('../other/service');
+      expect(buildRelativePath('/module', '/test/service'))
+          .toEqual('./test/service');
+      expect(buildRelativePath('/test/service', '/module'))
+          .toEqual('../module');
     });
   });
 });


### PR DESCRIPTION
Before, if one of the arguments was a file in root (eg "/module")
code would fail with: "" must be an absolute path.