### PR TITLE
refactor: don't drop zone.js from polyfills

### DIFF
--- a/packages/schematics/angular/migrations/update-8/drop-es6-polyfills.ts
+++ b/packages/schematics/angular/migrations/update-8/drop-es6-polyfills.ts
@@ -22,7 +22,6 @@ const toDrop: {[importName: string]: true} = {
   'core-js/es6/array': true,
   'core-js/es6/regexp': true,
   'core-js/es6/map': true,
-  'zone.js/dist/zone': true,
   'core-js/es6/set': true,
 };
 

--- a/packages/schematics/angular/migrations/update-8/drop-es6-polyfills_spec.ts
+++ b/packages/schematics/angular/migrations/update-8/drop-es6-polyfills_spec.ts
@@ -80,8 +80,8 @@ import 'zone.js/dist/zone'; // Included with Angular CLI.
       const polyfills = tree.readContent(polyfillsPath);
       expect(polyfills).not.toContain('core-js/es6/symbol');
       expect(polyfills).not.toContain('core-js/es6/set');
-      expect(polyfills).not.toContain('zone.js');
-      expect(polyfills).not.toContain('Zone');
+      expect(polyfills).toContain('zone.js');
+      expect(polyfills).toContain('Zone');
 
       // We don't want to drop this commented import comments
       expect(polyfills).toContain('core-js/es6/reflect');


### PR DESCRIPTION
We don't know yet if we are going to separate zone.js in a separate file. Hence, we should remove this for the time being and include it only when we remove zone.js from the main polyfills files

Introduced by https://github.com/angular/angular-cli/pull/14004

//cc @mgechev 