### PR TITLE
feat(@angular-devkit/build-angular): differential loading

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,8 @@
     "@bazel/karma": "~0.26.0",
     "@bazel/typescript": "~0.26.0",
     "@ngtools/json-schema": "^1.1.0",
+    "@types/browserslist": "^4.4.0",
+    "@types/caniuse-api": "^3.0.0",
     "@types/copy-webpack-plugin": "^4.4.1",
     "@types/express": "^4.16.0",
     "@types/glob": "^7.0.0",

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -14,6 +14,8 @@
     "@ngtools/webpack": "0.0.0",
     "ajv": "6.10.0",
     "autoprefixer": "9.5.1",
+    "browserslist": "4.5.2",
+    "caniuse-api": "3.0.0",
     "circular-dependency-plugin": "5.0.2",
     "clean-css": "4.2.1",
     "copy-webpack-plugin": "5.0.2",
@@ -83,5 +85,8 @@
     "popper.js": "^1.14.1",
     "protractor": "~5.4.0",
     "zone.js": "^0.9.0"
+  },
+  "peerDependencies": {
+    "typescript": ">=2.7 < 3.4"
   }
 }

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/build-options.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/build-options.ts
@@ -73,8 +73,14 @@ export interface BuildOptions {
   lazyModules: string[];
   platform?: 'browser' | 'server';
   fileReplacements: NormalizedFileReplacement[];
-    /** @deprecated use only for compatibility in 8.x; will be removed in 9.0 */
+  /** @deprecated use only for compatibility in 8.x; will be removed in 9.0 */
   rebaseRootRelativeCssUrls?: boolean;
+
+  /* Append script target version to filename. */
+  esVersionInFileName?: boolean;
+
+  /* When specified it will be used instead of the script target in the tsconfig.json. */
+  scriptTargetOverride?: ts.ScriptTarget;
 }
 
 export interface WebpackTestOptions extends BuildOptions {

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/utils.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/utils.ts
@@ -12,6 +12,7 @@ import * as path from 'path';
 import { basename, normalize } from '@angular-devkit/core';
 import { ExtraEntryPoint, ExtraEntryPointClass } from '../../../browser/schema';
 import { SourceMapDevToolPlugin } from 'webpack';
+import * as ts from 'typescript';
 
 export const ngAppResolve = (resolvePath: string): string => {
   return path.resolve(process.cwd(), resolvePath);
@@ -88,4 +89,15 @@ export function getSourceMapDevTool(
     include,
     append: hiddenSourceMap ? false : undefined,
   });
+}
+
+/**
+ * Returns an ES version file suffix to differentiate between various builds.
+ */
+export function getEsVersionForFileName(
+  scriptTargetOverride: ts.ScriptTarget | undefined,
+  esVersionInFileName = false,
+): string {
+  return scriptTargetOverride && esVersionInFileName ?
+    '-' + ts.ScriptTarget[scriptTargetOverride].toLowerCase() : '';
 }

--- a/packages/angular_devkit/build_angular/src/browser/index.ts
+++ b/packages/angular_devkit/build_angular/src/browser/index.ts
@@ -5,16 +5,14 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+
 import {
   BuilderContext,
   BuilderInfo,
   BuilderOutput,
   createBuilder,
 } from '@angular-devkit/architect';
-import {
-  WebpackLoggingCallback,
-  runWebpack,
-} from '@angular-devkit/build-webpack';
+import { WebpackLoggingCallback, runWebpack } from '@angular-devkit/build-webpack';
 import {
   Path,
   analytics,
@@ -25,27 +23,27 @@ import {
   logging,
   normalize,
   resolve,
-  schema,
-  virtualFs,
+  schema, virtualFs,
 } from '@angular-devkit/core';
 import { NodeJsSyncHost } from '@angular-devkit/core/node';
 import * as fs from 'fs';
-import { Observable, from, of } from 'rxjs';
+import { Observable, combineLatest, from, of } from 'rxjs';
 import { concatMap, map, switchMap } from 'rxjs/operators';
-import * as ts from 'typescript'; // tslint:disable-line:no-implicit-dependencies
+import * as ts from 'typescript';
+import * as webpack from 'webpack';
 import { NgBuildAnalyticsPlugin } from '../../plugins/webpack/analytics';
 import { WebpackConfigOptions } from '../angular-cli-files/models/build-options';
 import {
   getAotConfig,
   getBrowserConfig,
   getCommonConfig,
+  getEsVersionForFileName,
   getNonAotConfig,
   getStatsConfig,
   getStylesConfig,
   getWorkerConfig,
 } from '../angular-cli-files/models/webpack-configs';
 import { readTsconfig } from '../angular-cli-files/utilities/read-tsconfig';
-import { requireProjectModule } from '../angular-cli-files/utilities/require-project-module';
 import { augmentAppWithServiceWorker } from '../angular-cli-files/utilities/service-worker';
 import {
   statsErrorsToString,
@@ -60,7 +58,7 @@ import {
 } from '../utils';
 import { Schema as BrowserBuilderSchema } from './schema';
 
-import webpack = require('webpack');
+
 const SpeedMeasurePlugin = require('speed-measure-webpack-plugin');
 const webpackMerge = require('webpack-merge');
 
@@ -68,7 +66,6 @@ const webpackMerge = require('webpack-merge');
 export type BrowserBuilderOutput = json.JsonObject & BuilderOutput & {
   outputPath: string;
 };
-
 
 export function createBrowserLoggingCallback(
   verbose: boolean,
@@ -101,7 +98,7 @@ export function buildWebpackConfig(
     analytics?: analytics.Analytics,
     builderInfo?: BuilderInfo,
   } = {},
-): webpack.Configuration {
+): webpack.Configuration[] {
   // Ensure Build Optimizer is only used with AOT.
   if (options.buildOptimizer && !options.aot) {
     throw new Error(`The 'buildOptimizer' option cannot be used without 'aot'.`);
@@ -112,74 +109,100 @@ export function buildWebpackConfig(
   const tsConfigPath = getSystemPath(normalize(resolve(root, normalize(options.tsConfig))));
   const tsConfig = readTsconfig(tsConfigPath);
 
-  const projectTs = requireProjectModule(getSystemPath(projectRoot), 'typescript') as typeof ts;
-
-  const supportES2015 = tsConfig.options.target !== projectTs.ScriptTarget.ES3
-    && tsConfig.options.target !== projectTs.ScriptTarget.ES5;
-
   const logger = additionalOptions.logger
     ? additionalOptions.logger.createChild('webpackConfigOptions')
     : new logging.NullLogger();
 
-  wco = {
-    root: getSystemPath(root),
-    logger,
-    projectRoot: getSystemPath(projectRoot),
-    buildOptions: options,
-    tsConfig,
-    tsConfigPath,
-    supportES2015,
-  };
+  const scriptTarget = tsConfig.options.target;
+  // todo enabe when differential loading is complete
+  // const differentialLoading = isDifferentialLoadingNeeded(projectRoot, scriptTarget);
+  const differentialLoading = false;
 
-  wco.buildOptions.progress = defaultProgress(wco.buildOptions.progress);
+  const scriptTargets = differentialLoading ? [ts.ScriptTarget.ES5, scriptTarget] : [scriptTarget];
 
-  const webpackConfigs: {}[] = [
-    getCommonConfig(wco),
-    getBrowserConfig(wco),
-    getStylesConfig(wco),
-    getStatsConfig(wco),
-  ];
-
-  if (additionalOptions.analytics) {
-    // If there's analytics, add our plugin. Otherwise no need to slow down the build.
-    let category = 'build';
-    if (additionalOptions.builderInfo) {
-      // We already vetted that this is a "safe" package, otherwise the analytics would be noop.
-      category = additionalOptions.builderInfo.builderName.split(':')[1];
+  // For differential loading, we can have several targets
+  return scriptTargets.map(scriptTarget => {
+    let buildOptions: NormalizedBrowserBuilderSchema = { ...options };
+    if (differentialLoading) {
+      // For differential loading, the builder needs to created the index.html by itself
+      // without using a webpack plugin.
+      buildOptions = {
+        ...options,
+        es5BrowserSupport: undefined,
+        index: '',
+        esVersionInFileName: true,
+        scriptTargetOverride: scriptTarget,
+      };
     }
-    // The category is the builder name if it's an angular builder.
-    webpackConfigs.push({
-      plugins: [
-        new NgBuildAnalyticsPlugin(wco.projectRoot, additionalOptions.analytics, category),
-      ],
-    });
-  }
 
-  if (wco.buildOptions.main || wco.buildOptions.polyfills) {
-    const typescriptConfigPartial = wco.buildOptions.aot
-      ? getAotConfig(wco)
-      : getNonAotConfig(wco);
-    webpackConfigs.push(typescriptConfigPartial);
-  }
+    const supportES2015
+      = scriptTarget !== ts.ScriptTarget.ES3 && scriptTarget !== ts.ScriptTarget.ES5;
 
-  if (wco.buildOptions.webWorkerTsConfig) {
-    webpackConfigs.push(getWorkerConfig(wco));
-  }
+    wco = {
+      root: getSystemPath(root),
+      logger,
+      projectRoot: getSystemPath(projectRoot),
+      buildOptions: buildOptions,
+      tsConfig,
+      tsConfigPath,
+      supportES2015,
+    };
 
-  const webpackConfig = webpackMerge(webpackConfigs);
+    wco.buildOptions.progress = defaultProgress(wco.buildOptions.progress);
 
-  if (options.profile || process.env['NG_BUILD_PROFILING']) {
-    const smp = new SpeedMeasurePlugin({
-      outputFormat: 'json',
-      outputTarget: getSystemPath(join(root, 'speed-measure-plugin.json')),
-    });
+    const webpackConfigs: {}[] = [
+      getCommonConfig(wco),
+      getBrowserConfig(wco),
+      getStylesConfig(wco),
+      getStatsConfig(wco),
+    ];
 
-    return smp.wrap(webpackConfig);
-  }
+    if (wco.buildOptions.main || wco.buildOptions.polyfills) {
+      const typescriptConfigPartial = wco.buildOptions.aot
+        ? getAotConfig(wco)
+        : getNonAotConfig(wco);
+      webpackConfigs.push(typescriptConfigPartial);
+    }
 
-  return webpackConfig;
+    if (additionalOptions.analytics) {
+      // If there's analytics, add our plugin. Otherwise no need to slow down the build.
+      let category = 'build';
+      if (additionalOptions.builderInfo) {
+        // We already vetted that this is a "safe" package, otherwise the analytics would be noop.
+        category = additionalOptions.builderInfo.builderName.split(':')[1];
+      }
+      // The category is the builder name if it's an angular builder.
+      webpackConfigs.push({
+        plugins: [
+          new NgBuildAnalyticsPlugin(wco.projectRoot, additionalOptions.analytics, category),
+        ],
+      });
+    }
+
+    if (wco.buildOptions.webWorkerTsConfig) {
+      webpackConfigs.push(getWorkerConfig(wco));
+    }
+
+    const webpackConfig = webpackMerge(webpackConfigs);
+
+    if (options.profile || process.env['NG_BUILD_PROFILING']) {
+      const esVersionInFileName = getEsVersionForFileName(
+        wco.buildOptions.scriptTargetOverride,
+        wco.buildOptions.esVersionInFileName,
+      );
+
+      const smp = new SpeedMeasurePlugin({
+        outputFormat: 'json',
+        outputTarget: getSystemPath(join(root,
+          `speed-measure-plugin${esVersionInFileName}.json`)),
+      });
+
+      return smp.wrap(webpackConfig);
+    }
+
+    return webpackConfig;
+  });
 }
-
 
 export async function buildBrowserWebpackConfigFromWorkspace(
   options: BrowserBuilderSchema,
@@ -191,7 +214,7 @@ export async function buildBrowserWebpackConfigFromWorkspace(
     analytics?: analytics.Analytics,
     builderInfo?: BuilderInfo,
   } = {},
-): Promise<webpack.Configuration> {
+): Promise<webpack.Configuration[]> {
   // TODO: Use a better interface for workspace access.
   const projectRoot = resolve(workspace.root, normalize(workspace.getProject(projectName).root));
   const sourceRoot = workspace.getProject(projectName).sourceRoot;
@@ -212,7 +235,7 @@ export async function buildBrowserWebpackConfigFromContext(
   options: BrowserBuilderSchema,
   context: BuilderContext,
   host: virtualFs.Host<fs.Stats>,
-): Promise<{ workspace: experimental.workspace.Workspace, config: webpack.Configuration }> {
+): Promise<{ workspace: experimental.workspace.Workspace, config: webpack.Configuration[] }> {
   const registry = new schema.CoreSchemaRegistry();
   registry.addPostTransform(schema.transforms.addUndefinedDefaults);
 
@@ -249,6 +272,7 @@ export type BrowserConfigTransformFn = (
   config: webpack.Configuration,
 ) => Observable<webpack.Configuration>;
 
+
 export function buildWebpackBrowser(
   options: BrowserBuilderSchema,
   context: BuilderContext,
@@ -264,7 +288,7 @@ export function buildWebpackBrowser(
   const configFn = transforms.config;
   const outputFn = transforms.output;
   const loggingFn = transforms.logging
-      || createBrowserLoggingCallback(!!options.verbose, context.logger);
+    || createBrowserLoggingCallback(!!options.verbose, context.logger);
 
   // This makes a host observable into a cold one. This is because we want to wait until
   // subscription before calling buildBrowserWebpackConfigFromContext, which can throw.
@@ -272,14 +296,14 @@ export function buildWebpackBrowser(
     switchMap(() => from(buildBrowserWebpackConfigFromContext(options, context, host))),
     switchMap(({ workspace, config }) => {
       if (configFn) {
-        return configFn(workspace, config).pipe(
+        return combineLatest(config.map(config => configFn(workspace, config))).pipe(
           map(config => ({ workspace, config })),
         );
       } else {
         return of({ workspace, config });
       }
     }),
-    switchMap(({workspace, config}) => {
+    switchMap(({ workspace, config }) => {
       if (options.deleteOutputPath) {
         return deleteOutputDir(
           normalize(context.workspaceRoot),
@@ -290,7 +314,7 @@ export function buildWebpackBrowser(
         return of({ workspace, config });
       }
     }),
-    switchMap(({ workspace, config }) => {
+    switchMap(({ workspace, config: configs }) => {
       const projectName = context.target
         ? context.target.project : workspace.getDefaultProjectName();
 
@@ -303,7 +327,18 @@ export function buildWebpackBrowser(
         normalize(workspace.getProject(projectName).root),
       );
 
-      return runWebpack(config, context, { logging: loggingFn }).pipe(
+      return combineLatest(
+        configs.map(config => runWebpack(config, context, { logging: loggingFn })),
+      )
+      .pipe(
+        switchMap(buildEvents => {
+          if (buildEvents.length === 2) {
+            // todo implement writing index.html for differential loading in another PR
+          }
+
+          return of(buildEvents);
+        }),
+        map(buildEvents => ({ success: buildEvents.every(r => r.success) })),
         concatMap(buildEvent => {
           if (buildEvent.success && !options.watch && options.serviceWorker) {
             return from(augmentAppWithServiceWorker(
@@ -320,7 +355,8 @@ export function buildWebpackBrowser(
         }),
         map(event => ({
           ...event,
-          outputPath: config.output && config.output.path || '',
+          // If we use differential loading, both configs have the same outputs
+          outputPath: getSystemPath(join(normalize(context.workspaceRoot), options.outputPath)),
         } as BrowserBuilderOutput)),
         concatMap(output => outputFn ? outputFn(output) : of(output)),
       );

--- a/packages/angular_devkit/build_angular/src/browser/utils.ts
+++ b/packages/angular_devkit/build_angular/src/browser/utils.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { Path, getSystemPath } from '@angular-devkit/core';
+import * as browserslist from 'browserslist';
+import * as caniuse from 'caniuse-api';
+import * as ts from 'typescript';
+
+
+export function isDifferentialLoadingNeeded(
+  projectRoot: Path,
+  target: ts.ScriptTarget = ts.ScriptTarget.ES5): boolean {
+
+  const supportES2015 = target !== ts.ScriptTarget.ES3 && target !== ts.ScriptTarget.ES5;
+
+  return supportES2015 && isEs5SupportNeeded(projectRoot);
+}
+
+export function isEs5SupportNeeded(projectRoot: Path): boolean {
+  const browsersList: string[] = browserslist(
+    undefined, {
+      path: getSystemPath(projectRoot),
+    });
+
+  return !caniuse.isSupported('es6-module', browsersList.join(', '));
+}

--- a/packages/angular_devkit/build_angular/src/browser/utils_spec.ts
+++ b/packages/angular_devkit/build_angular/src/browser/utils_spec.ts
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+
+import { TestProjectHost } from '@angular-devkit/architect/testing';
+import { join } from '@angular-devkit/core';
+import { ScriptTarget } from 'typescript';
+import { isDifferentialLoadingNeeded } from './utils';
+
+const devkitRoot = (global as any)._DevKitRoot; // tslint:disable-line:no-any
+const workspaceRoot = join(
+  devkitRoot,
+  'tests/angular_devkit/build_angular/hello-world-app/');
+
+const host = new TestProjectHost(workspaceRoot);
+
+
+describe('differential loading', () => {
+
+  beforeEach(async () => host.initialize().toPromise());
+  afterEach(async () => host.restore().toPromise());
+
+  it('detects the need for differential loading for IE 9-11 and ES2015', () => {
+    host.writeMultipleFiles({
+      'browserslist': 'IE 9-11',
+    });
+
+    const needed = isDifferentialLoadingNeeded(host.root(), ScriptTarget.ES2015);
+    expect(needed).toBe(true);
+  });
+
+  it('detects no need for differential loading for Chrome and ES2015', () => {
+    host.writeMultipleFiles({
+      'browserslist': 'last 1 chrome version',
+    });
+
+    const needed = isDifferentialLoadingNeeded(host.root(), ScriptTarget.ES2015);
+
+    expect(needed).toBe(false);
+  });
+
+  it('detects no need for differential loading for target is ES5', () => {
+    host.writeMultipleFiles({
+      'browserslist': 'last 1 chrome version',
+    });
+
+    const needed = isDifferentialLoadingNeeded(host.root(), ScriptTarget.ES5);
+
+    expect(needed).toBe(false);
+  });
+});

--- a/packages/angular_devkit/build_angular/src/dev-server/index.ts
+++ b/packages/angular_devkit/build_angular/src/dev-server/index.ts
@@ -117,7 +117,9 @@ export function serveWebpackBrowser(
       context,
       host,
     );
-    let webpackConfig = webpackConfigResult.config;
+
+    // No differential loading for dev-server, hence there is just one config
+    let webpackConfig = webpackConfigResult.config[0];
     const workspace = webpackConfigResult.workspace;
 
     if (transforms.browserConfig) {

--- a/packages/angular_devkit/build_angular/test/browser/differential_loading_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/browser/differential_loading_spec_large.ts
@@ -1,0 +1,80 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { Architect } from '@angular-devkit/architect/src/index';
+import { PathFragment } from '@angular-devkit/core';
+import { browserBuild, createArchitect, host } from '../utils';
+
+// This feature is currently hidden behind a flag
+xdescribe('Browser Builder with differential loading', () => {
+  const target = { project: 'app', target: 'build' };
+  let architect: Architect;
+
+  beforeEach(async () => {
+    await host.initialize().toPromise();
+    architect = (await createArchitect(host.root())).architect;
+  });
+
+  afterEach(async () => host.restore().toPromise());
+
+  it('emits all the neccessary files', async () => {
+    host.replaceInFile(
+      'tsconfig.json',
+      '"target": "es5"',
+      '"target": "es2015"',
+    );
+
+    const { files } = await browserBuild(architect, host, target);
+
+    const expectedOutputs = [
+      'favicon.ico',
+      'index.html',
+
+      'main-es2015.js',
+      'main-es2015.js.map',
+      'main-es5.js',
+      'main-es5.js.map',
+
+      'polyfills-es2015.js',
+      'polyfills-es2015.js.map',
+      'polyfills-es5.js',
+      'polyfills-es5.js.map',
+
+      'runtime-es2015.js',
+      'runtime-es2015.js.map',
+      'runtime-es5.js',
+      'runtime-es5.js.map',
+
+      'styles-es2015.js',
+      'styles-es2015.js.map',
+      'styles-es5.js',
+      'styles-es5.js.map',
+
+      'vendor-es2015.js',
+      'vendor-es2015.js.map',
+      'vendor-es5.js',
+      'vendor-es5.js.map',
+    ] as PathFragment[];
+
+    expect(Object.keys(files))
+      .toEqual(jasmine.arrayWithExactContents(expectedOutputs));
+  });
+
+  it('emits the right ES formats', async () => {
+    host.replaceInFile(
+      'tsconfig.json',
+      '"target": "es5"',
+      '"target": "es2015"',
+    );
+
+    const { files } = await browserBuild(architect, host, target, { optimization: true });
+    expect(await files['main-es5.js']).not.toContain('class');
+    expect(await files['main-es2015.js']).toContain('class');
+  });
+
+});

--- a/packages/angular_devkit/build_angular/test/browser/works_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/browser/works_spec_large.ts
@@ -19,6 +19,7 @@ describe('Browser Builder basic test', () => {
     await host.initialize().toPromise();
     architect = (await createArchitect(host.root())).architect;
   });
+
   afterEach(async () => host.restore().toPromise());
 
   it('works', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -246,6 +246,16 @@
     "@types/connect" "*"
     "@types/node" "*"
 
+"@types/browserslist@^4.4.0":
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/@types/browserslist/-/browserslist-4.4.0.tgz#e2a5f7f8c7e97afb39f50812a77e5230d3ca2353"
+  integrity sha512-hrIjWSu7Hh96/rKlpChe58qHEwIZ0+F5Zf4QNdvSVP5LUXbaJM04g9tBjo702VTNqPZr5znEJeqNR3nAV3vJPg==
+
+"@types/caniuse-api@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/caniuse-api/-/caniuse-api-3.0.0.tgz#af31cc52062be0ab24583be072fd49b634dcc2fe"
+  integrity sha512-wT1VfnScjAftZsvLYaefu/UuwYJdYBwD2JDL2OQd01plGmuAoir5V6HnVHgrfh7zEwcasoiyO2wQ+W58sNh2sw==
+
 "@types/caseless@*":
   version "0.12.1"
   resolved "https://registry.yarnpkg.com/@types/caseless/-/caseless-0.12.1.tgz#9794c69c8385d0192acc471a540d1f8e0d16218a"
@@ -1575,6 +1585,15 @@ browserify-zlib@^0.2.0:
   dependencies:
     pako "~1.0.5"
 
+browserslist@4.5.2:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.5.2.tgz#36ad281f040af684555a23c780f5c2081c752df0"
+  integrity sha512-zmJVLiKLrzko0iszd/V4SsjTaomFeoVzQGYYOYgRgsbh7WNh95RgDB0CmBdFWYs/3MyFSt69NypjL/h3iaddKQ==
+  dependencies:
+    caniuse-lite "^1.0.30000951"
+    electron-to-chromium "^1.3.116"
+    node-releases "^1.1.11"
+
 browserslist@^4.0.0, browserslist@^4.3.3:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.3.4.tgz#4477b737db6a1b07077275b24791e680d4300425"
@@ -1797,6 +1816,21 @@ camelcase@^4.0.0, camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
   integrity sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
+
+caniuse-api@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/caniuse-api/-/caniuse-api-3.0.0.tgz#5e4d90e2274961d46291997df599e3ed008ee4c0"
+  integrity sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==
+  dependencies:
+    browserslist "^4.0.0"
+    caniuse-lite "^1.0.0"
+    lodash.memoize "^4.1.2"
+    lodash.uniq "^4.5.0"
+
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000951:
+  version "1.0.30000955"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000955.tgz#360fdb9a1e41d6dd996130411334e44a39e4446d"
+  integrity sha512-6AwmIKgqCYfDWWadRkAuZSHMQP4Mmy96xAXEdRBlN/luQhlRYOKgwOlZ9plpCOsVbBuqbTmGqDK3JUM/nlr8CA==
 
 caniuse-lite@^1.0.30000898, caniuse-lite@^1.0.30000899:
   version "1.0.30000903"
@@ -3031,6 +3065,11 @@ ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
+
+electron-to-chromium@^1.3.116:
+  version "1.3.121"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.121.tgz#761aaec1ec947b8ed3e9538177598d8f6ca3b5bd"
+  integrity sha512-ALxUkgrnQ6zg2SN9zHnwDcDRy577haGT9dqsbq8lfeAgmEUPC+58SrrU8vIHpGRf7SEyyBYy4mlfonDnoKxONw==
 
 electron-to-chromium@^1.3.122:
   version "1.3.124"
@@ -5624,6 +5663,11 @@ lodash.get@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
 
+lodash.memoize@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
+  integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
+
 lodash.tail@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.tail/-/lodash.tail-4.1.1.tgz#d2333a36d9e7717c8ad2f7cacafec7c32b444664"
@@ -5643,6 +5687,11 @@ lodash.templatesettings@^4.0.0:
   integrity sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=
   dependencies:
     lodash._reinterpolate "~3.0.0"
+
+lodash.uniq@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
+  integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
 lodash@^4.16.6, lodash@^4.17.11, lodash@^4.17.5:
   version "4.17.11"
@@ -6319,7 +6368,7 @@ node-releases@^1.0.1:
   dependencies:
     semver "^5.3.0"
 
-node-releases@^1.1.13:
+node-releases@^1.1.11, node-releases@^1.1.13:
   version "1.1.13"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.13.tgz#8c03296b5ae60c08e2ff4f8f22ae45bd2f210083"
   integrity sha512-fKZGviSXR6YvVPyc011NHuJDSD8gFQvLPmc2d2V3BS4gr52ycyQ1Xzs7a8B+Ax3Ni/W+5h1h4SqmzeoA8WZRmA==


### PR DESCRIPTION
This PR adds differential loading to the browser builder. First, it checks if differential loading is needed. This is the case if the compilation target is ES2015 while the browserslist points to ES5 browsers.

For providing differential loading, it calls the methods for creating the webpack config for each compilation target (e. g. ES5 and ES2015). The needed differences between those configurations are defined using parameters also added by this PR. Then it calls webpack for each of them, merges the results and writes the index.html.

This feature is currently hidden behind a flag. To activate it, set the ENABLE_DIFFERENTIAL_LOADING flag in packages/angular_devkit/build_angular/src/browser/index.ts.