### PR TITLE
fix(@schematics/angular): minimal should not add `test` target

### DIFF
--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -289,7 +289,7 @@ function addAppToWorkspaceFile(options: ApplicationOptions, workspace: Workspace
           browserTarget: `${options.name}:build`,
         },
       },
-      test: {
+      test: options.minimal ? undefined : {
         builder: Builders.Karma,
         options: {
           main: `${sourceRoot}/test.ts`,

--- a/packages/schematics/angular/application/index_spec.ts
+++ b/packages/schematics/angular/application/index_spec.ts
@@ -163,14 +163,13 @@ describe('Application Schematic', () => {
     expect(karmaConf).toContain(`dir: require('path').join(__dirname, '../../coverage/foo')`);
   });
 
-  it('minimal=true should not create e2e project', () => {
+  it('minimal=true should not create e2e and test targets', () => {
     const options = { ...defaultOptions, minimal: true };
-
     const tree = schematicRunner.runSchematic('application', options, workspaceTree);
-    const files = tree.files;
-    expect(files).not.toContain('/projects/foo-e2e');
-    const confContent = JSON.parse(tree.readContent('/angular.json'));
-    expect(confContent.projects['foo-e2e']).toBeUndefined();
+    const config = JSON.parse(tree.readContent('/angular.json'));
+    const architect = config.projects.foo.architect;
+    expect(architect.test).not.toBeDefined();
+    expect(architect.e2e).not.toBeDefined();
   });
 
   it('should create correct files when using minimal', () => {


### PR DESCRIPTION
At the moment when using minimal flag, test targets are being created even though they cannot be used as test setup files are not created nor are testing dependencies

Target: master only as this doesn't apply cleanly on patch