### PR TITLE
build: pin tslint-sonarts

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "tree-kill": "^1.2.0",
     "ts-node": "^5.0.0",
     "tslint-no-circular-imports": "^0.6.0",
-    "tslint-sonarts": "^1.7.0"
+    "tslint-sonarts": "1.9.0"
   },
   "husky": {
     "hooks": {

--- a/scripts/validate-licenses.ts
+++ b/scripts/validate-licenses.ts
@@ -65,7 +65,7 @@ const ignoredPackages = [
   '@angular/devkit-repo@0.0.0',  // Hey, that's us!
   // * Development only
   'spdx-license-ids@3.0.1',  // CC0 but it's content only (index.json, no code) and not distributed.
-  'tslint-sonarts@1.8.0', // LGPL-3.0 but only used as a tool, not linked in the build.
+  'tslint-sonarts@1.9.0', // LGPL-3.0 but only used as a tool, not linked in the build.
 
   // * Broken license fields
   'bitsyntax@0.0.4', // MIT but no license field in package.json

--- a/yarn.lock
+++ b/yarn.lock
@@ -9267,10 +9267,10 @@ tslint-no-circular-imports@^0.6.0:
   resolved "https://registry.yarnpkg.com/tslint-no-circular-imports/-/tslint-no-circular-imports-0.6.1.tgz#a91358395a81c067bf104a641f269655057715cd"
   integrity sha512-XuRgHZKFu6dv7fm/tuilmvynLHgtCTd63/p3744dYVEpnMExp2Jd9IwTiBOGmy5bUDlpTy117vtBcLd028RsBA==
 
-tslint-sonarts@^1.7.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/tslint-sonarts/-/tslint-sonarts-1.8.0.tgz#80f2e8addd418c3b8807fc0155dec33b5a81e8d1"
-  integrity sha512-tpijO5VR18e+Ny99uMNNov3Hw7diiYQ8KoJkezpHGw9hSFFrO5g2PhwdQQo7O9puhJKMIutLl9g+ICMgg+bh0w==
+tslint-sonarts@1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/tslint-sonarts/-/tslint-sonarts-1.9.0.tgz#feb593e92db328c0328b430b838adbe65d504de9"
+  integrity sha512-CJWt+IiYI8qggb2O/JPkS6CkC5DY1IcqRsm9EHJ+AxoWK70lvtP7jguochyNDMP2vIz/giGdWCfEM39x/I/Vnw==
   dependencies:
     immutable "^3.8.2"
 


### PR DESCRIPTION
Pinning this dependency because given its license and validation mechanism our build will fail on a new release.