### PR TITLE
style: remove todo comment from `updateClassDeclaration`

### DIFF
--- a/packages/ngtools/webpack/src/transformers/replace_resources.ts
+++ b/packages/ngtools/webpack/src/transformers/replace_resources.ts
@@ -23,8 +23,6 @@ export function replaceResources(
           (node: ts.Decorator) => visitDecorator(node, typeChecker, directTemplateLoading),
         );
 
-        // todo: we need to investigate and confirm that using
-        //  `updateClassDeclaration` has no regressions
         return ts.updateClassDeclaration(
           node,
           decorators,


### PR DESCRIPTION
A transformer should not mutate existing nodes, ever. If you intend to modify some part of the node, the `ts.update*` methods are correct. Or you can replace a node entirely via `ts.create*` operations, but there are cases where introducing entirely synthetic nodes will break TS output.

Hence using the `updateClassDeclaration` in this case is the correct approach.

This has also been raised in the slack #ts-core channel as TypeScript have been looking to get to the bottom of this https://github.com/Microsoft/TypeScript/issues/29365#issuecomment-479230994, which seemed to have been caused by mutating the node.

Also confirmed with @alxhub.