### PR TITLE
Refactor/Cleanup browser builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/browser.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/browser.ts
@@ -7,6 +7,7 @@
  */
 import { LicenseWebpackPlugin } from 'license-webpack-plugin';
 import * as path from 'path';
+import * as webpack from 'webpack';
 import { IndexHtmlWebpackPlugin } from '../../plugins/index-html-webpack-plugin';
 import { generateEntryPoints } from '../../utilities/package-chunk-sort';
 import { WebpackConfigOptions } from '../build-options';
@@ -15,7 +16,7 @@ import { getSourceMapDevTool, normalizeExtraEntryPoints } from './utils';
 const SubresourceIntegrityPlugin = require('webpack-subresource-integrity');
 
 
-export function getBrowserConfig(wco: WebpackConfigOptions) {
+export function getBrowserConfig(wco: WebpackConfigOptions): webpack.Configuration {
   const { root, buildOptions } = wco;
   const extraPlugins = [];
 
@@ -119,7 +120,7 @@ export function getBrowserConfig(wco: WebpackConfigOptions) {
           },
         },
       },
-    },
+    } as webpack.Options.Optimization,
     plugins: extraPlugins,
     node: false,
   };

--- a/packages/angular_devkit/build_angular/src/extract-i18n/index.ts
+++ b/packages/angular_devkit/build_angular/src/extract-i18n/index.ts
@@ -87,7 +87,7 @@ async function execute(options: ExtractI18nBuilderOptions, context: BuilderConte
     ],
   );
 
-  return runWebpack(config, context).toPromise();
+  return runWebpack(config[0], context).toPromise();
 }
 
 export default createBuilder<JsonObject & ExtractI18nBuilderOptions>(execute);

--- a/packages/angular_devkit/build_angular/src/karma/index.ts
+++ b/packages/angular_devkit/build_angular/src/karma/index.ts
@@ -52,7 +52,7 @@ async function initialize(
   // tslint:disable-next-line:no-implicit-dependencies
   const karma = await import('karma');
 
-  return [karma, config];
+  return [karma, config[0]];
 }
 
 export function execute(


### PR DESCRIPTION
Switches the browser builder to use the existing Webpack configuration generation utility functions.  Also, provides improved and centralized parsing of the tsconfig file.