### PR TITLE
fix(@angular-devkit/build-angular): verify chunk files exist before a…

### DIFF
--- a/packages/angular_devkit/build_angular/plugins/webpack/analytics.ts
+++ b/packages/angular_devkit/build_angular/plugins/webpack/analytics.ts
@@ -200,7 +200,7 @@ export class NgBuildAnalyticsPlugin {
       }
     }
     for (const chunk of json.chunks) {
-      if (chunk.files[0].endsWith('.css')) {
+      if (chunk.files[0] && chunk.files[0].endsWith('.css')) {
         this._stats.cssSize += chunk.size || 0;
       }
     }


### PR DESCRIPTION
…ccessing

`chunk.files[0]` can be undefined, which caused  `chunk.files[0].endsWith` to fail.