### PR TITLE
Improve handling of nomodules and modules in index generation

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/generate-index-html_spec.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/generate-index-html_spec.ts
@@ -5,32 +5,92 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import { generateIndexHtml } from './generate-index-html';
+import { tags } from '@angular-devkit/core';
+import { FileInfo, GenerateIndexHtmlOptions, generateIndexHtml } from './generate-index-html';
 
 describe('index-html-webpack-plugin', () => {
+  const indexGeneratorOptions: GenerateIndexHtmlOptions = {
+    input: 'index.html',
+    inputContent: '<html><head></head><body></body></html>',
+    baseHref: '/',
+    sri: false,
+    files: [],
+    loadOutputFile: async (_fileName: string) => '',
+    entrypoints: ['polyfills', 'main', 'styles'],
+  };
 
-  it('can generate index.html', () => {
+  const oneLineHtml = (html: TemplateStringsArray) =>
+     tags.stripIndents`${html}`.replace(/(\>\s+)/g, '>');
 
+  it('can generate index.html', async () => {
     const source = generateIndexHtml({
-      input: 'index.html',
-      inputContent: '<html><head></head><body></body></html>',
-      baseHref: '/',
-      sri: false,
-      loadOutputFile: (fileName: string) => '',
-      unfilteredSortedFiles: [
-        {file: 'a.js', type: 'module'},
-        {file: 'b.js', type: 'nomodule'},
-        {file: 'c.js', type: 'none'},
+      ...indexGeneratorOptions,
+      files: [
+        { fileName: 'styles.css', extension: '.css', name: 'styles' },
+        { fileName: 'runtime.js', extension: '.js', name: 'main' },
+        { fileName: 'main.js', extension: '.js', name: 'main' },
+        { fileName: 'runtime.js', extension: '.js', name: 'polyfills' },
+        { fileName: 'polyfills.js', extension: '.js', name: 'polyfills' },
       ],
-      noModuleFiles: new Set<string>(),
     });
 
-    const html = source.source();
+    const html = (await source).source();
+    expect(html).toEqual(oneLineHtml`
+      <html>
+        <head><base href="/">
+          <link rel="stylesheet" href="styles.css">
+        </head>
+        <body>
+          <script src="runtime.js"></script>
+          <script src="polyfills.js"></script>
+          <script src="main.js"></script>
+        </body>
+      </html>
+    `);
+  });
 
-    expect(html).toContain('<script src="a.js" type="module"></script>');
-    expect(html).toContain('<script src="b.js" nomodule></script>');
-    expect(html).toContain('<script src="c.js"></script>');
+  it('should emit correct script tags when having module and non-module js', async () => {
+    const es2015JsFiles: FileInfo[] = [
+      { fileName: 'runtime-es2015.js', extension: '.js', name: 'main' },
+      { fileName: 'main-es2015.js', extension: '.js', name: 'main' },
+      { fileName: 'runtime-es2015.js', extension: '.js', name: 'polyfills' },
+      { fileName: 'polyfills-es2015.js', extension: '.js', name: 'polyfills' },
+    ];
 
+    const es5JsFiles: FileInfo[] = [
+      { fileName: 'runtime-es5.js', extension: '.js', name: 'main' },
+      { fileName: 'main-es5.js', extension: '.js', name: 'main' },
+      { fileName: 'runtime-es5.js', extension: '.js', name: 'polyfills' },
+      { fileName: 'polyfills-es5.js', extension: '.js', name: 'polyfills' },
+    ];
+
+    const source = generateIndexHtml({
+      ...indexGeneratorOptions,
+      files: [
+        { fileName: 'styles.css', extension: '.css', name: 'styles' },
+        { fileName: 'styles.css', extension: '.css', name: 'styles' },
+      ],
+      moduleFiles: es2015JsFiles,
+      noModuleFiles: es5JsFiles,
+    });
+
+    const html = (await source).source();
+    expect(html).toEqual(oneLineHtml`
+      <html>
+        <head>
+          <base href="/">
+          <link rel="stylesheet" href="styles.css">
+        </head>
+        <body>
+          <script src="runtime-es5.js" nomodule></script>
+          <script src="polyfills-es5.js" nomodule></script>
+          <script src="runtime-es2015.js" type="module"></script>
+          <script src="polyfills-es2015.js" type="module"></script>
+          <script src="main-es5.js" nomodule></script>
+          <script src="main-es2015.js" type="module"></script>
+        </body>
+      </html>
+    `);
   });
 
 });

--- a/packages/angular_devkit/build_webpack/src/utils.ts
+++ b/packages/angular_devkit/build_webpack/src/utils.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import * as path from 'path';
 import * as webpack from 'webpack';
 
 export interface EmittedFiles {
@@ -16,7 +17,6 @@ export interface EmittedFiles {
 }
 
 export function getEmittedFiles(compilation: webpack.compilation.Compilation): EmittedFiles[] {
-  const getExtension = (file: string) => file.split('.').reverse()[0];
   const files: EmittedFiles[] = [];
 
   for (const chunk of Object.values(compilation.chunks)) {
@@ -26,7 +26,7 @@ export function getEmittedFiles(compilation: webpack.compilation.Compilation): E
     };
 
     for (const file of chunk.files) {
-      files.push({ ...entry, file, extension: getExtension(file) } as EmittedFiles);
+      files.push({ ...entry, file, extension: path.extname(file) } as EmittedFiles);
     }
   }
 
@@ -38,7 +38,7 @@ export function getEmittedFiles(compilation: webpack.compilation.Compilation): E
 
     files.push({
       file,
-      extension: getExtension(file),
+      extension: path.extname(file),
       initial: false,
     });
   }

--- a/packages/angular_devkit/build_webpack/src/utils.ts
+++ b/packages/angular_devkit/build_webpack/src/utils.ts
@@ -19,29 +19,32 @@ export interface EmittedFiles {
 export function getEmittedFiles(compilation: webpack.compilation.Compilation): EmittedFiles[] {
   const files: EmittedFiles[] = [];
 
+  // entrypoints might have multiple outputs
+  // such as runtime.js
+  for (const [name, entrypoint] of compilation.entrypoints) {
+    const entryFiles: string[] = (entrypoint && entrypoint.getFiles()) || [];
+    for (const file of entryFiles) {
+      files.push({ name, file, extension: path.extname(file), initial: true });
+    }
+  }
+
+  // adds all chunks to the list of emitted files such as lazy loaded modules
   for (const chunk of Object.values(compilation.chunks)) {
-    const entry: Partial<EmittedFiles> = {
-      name: chunk.name,
-      initial: chunk.isOnlyInitial(),
-    };
-
-    for (const file of chunk.files) {
-      files.push({ ...entry, file, extension: path.extname(file) } as EmittedFiles);
+    for (const file of chunk.files as string[]) {
+      files.push({
+        name: chunk.name,
+        file,
+        extension: path.extname(file),
+        initial: chunk.isOnlyInitial(),
+      });
     }
   }
 
+  // other all files
   for (const file of Object.keys(compilation.assets)) {
-    if (files.some(e => e.file === file)) {
-      // skip as this already exists
-      continue;
-    }
-
-    files.push({
-      file,
-      extension: path.extname(file),
-      initial: false,
-    });
+    files.push({ file, extension: path.extname(file), initial: false });
   }
 
-  return files;
+  // dedupe
+  return files.filter(({ file }, index) => files.findIndex(f => f.file === file) === index);
 }

--- a/packages/angular_devkit/build_webpack/src/webpack-dev-server/index_spec_large.ts
+++ b/packages/angular_devkit/build_webpack/src/webpack-dev-server/index_spec_large.ts
@@ -65,7 +65,7 @@ describe('Dev Server Builder', () => {
       name: 'main',
       initial: true,
       file: 'bundle.js',
-      extension: 'js',
+      extension: '.js',
     });
     await run.stop();
   }, 30000);

--- a/packages/angular_devkit/build_webpack/src/webpack/index_spec_large.ts
+++ b/packages/angular_devkit/build_webpack/src/webpack/index_spec_large.ts
@@ -64,7 +64,7 @@ describe('Webpack Builder basic test', () => {
         name: 'main',
         initial: true,
         file: 'bundle.js',
-        extension: 'js',
+        extension: '.js',
       });
 
       await run.stop();
@@ -95,8 +95,8 @@ describe('Webpack Builder basic test', () => {
 
       expect(output.success).toBe(true);
       expect(output.emittedFiles).toContain(
-        { name: 'main', initial: true, file: 'main.js', extension: 'js' },
-        { name: 'polyfills', initial: true, file: 'polyfills.js', extension: 'js' },
+        { name: 'main', initial: true, file: 'main.js', extension: '.js' },
+        { name: 'polyfills', initial: true, file: 'polyfills.js', extension: '.js' },
       );
 
       await run.stop();


### PR DESCRIPTION
**fix(@angular-devkit/build-webpack): add dot to file extension in emitted files**

**feat(@angular-devkit/build-webpack): include entrypoints in emitted files**
Entrypoints might have other files associate with them such as runtime.js, it is is paramount to keep the relation between them especially when this result is needed to generate an index file

 **feat(@angular-devkit/build-angular): improve handling of nomodules and modules in index generation**

Since when having differential loading we already know which files originated from which build. We shouldn't need to merge and transform this data.

With this change, the index generator accepts a couple of new inputs.
1. `files` - used for Js and CSS files which require nomodule nor module attributes
2. `moduleFiles` - Js files that need to have a `module` attribute
3. `noModuleFiles`  - Js files that need to have a `nomodule` attribute
4. `entrypoints` - used to sort the insertion of files in the HTML file