### PR TITLE
chore(schematics): remove surplus space

### DIFF
--- a/packages/schematics/angular/collection.json
+++ b/packages/schematics/angular/collection.json
@@ -105,7 +105,7 @@
       "aliases": ["web-worker", "worker"],
       "factory": "./web-worker",
       "schema": "./web-worker/schema.json",
-      "description": "Create a Web Worker ."
+      "description": "Create a Web Worker."
     }
   }
 }


### PR DESCRIPTION
Remove surplus space from web worker description in Angular schematic collection.