### PR TITLE
refactor(@schematics/angular): move codelyzer rules to app & lib schematics

### DIFF
--- a/packages/schematics/angular/application/files/tslint.json.template
+++ b/packages/schematics/angular/application/files/tslint.json.template
@@ -1,6 +1,9 @@
 {<% if (!isRootApp) { %>
   "extends": "<%= relativePathToWorkspaceRoot %>/tslint.json",<%
   } %>
+  "rulesDirectory": [
+    "codelyzer"
+  ],
   "rules": {
     "directive-selector": [
       true,
@@ -13,6 +16,21 @@
       "element",
       "<%= utils.dasherize(prefix) %>",
       "kebab-case"
-    ]
+    ],
+    "component-class-suffix": true,
+    "contextual-lifecycle": true,
+    "directive-class-suffix": true,
+    "no-conflicting-lifecycle": true,
+    "no-host-metadata-property": true,
+    "no-input-rename": true,
+    "no-inputs-metadata-property": true,
+    "no-output-native": true,
+    "no-output-on-prefix": true,
+    "no-output-rename": true,
+    "no-outputs-metadata-property": true,
+    "template-banana-in-box": true,
+    "template-no-negated-async": true,
+    "use-lifecycle-interface": true,
+    "use-pipe-transform-interface": true
   }
 }

--- a/packages/schematics/angular/library/files/tslint.json.template
+++ b/packages/schematics/angular/library/files/tslint.json.template
@@ -1,5 +1,8 @@
 {
   "extends": "<%= relativePathToWorkspaceRoot %>/tslint.json",
+  "rulesDirectory": [
+    "codelyzer"
+  ],
   "rules": {
     "directive-selector": [
       true,
@@ -12,6 +15,21 @@
       "element",
       "<%= dasherize(prefix) %>",
       "kebab-case"
-    ]
+    ],
+    "component-class-suffix": true,
+    "contextual-lifecycle": true,
+    "directive-class-suffix": true,
+    "no-conflicting-lifecycle": true,
+    "no-host-metadata-property": true,
+    "no-input-rename": true,
+    "no-inputs-metadata-property": true,
+    "no-output-native": true,
+    "no-output-on-prefix": true,
+    "no-output-rename": true,
+    "no-outputs-metadata-property": true,
+    "template-banana-in-box": true,
+    "template-no-negated-async": true,
+    "use-lifecycle-interface": true,
+    "use-pipe-transform-interface": true
   }
 }

--- a/packages/schematics/angular/workspace/files/tslint.json.template
+++ b/packages/schematics/angular/workspace/files/tslint.json.template
@@ -1,8 +1,5 @@
 {
   "extends": "tslint:recommended",
-  "rulesDirectory": [
-    "codelyzer"
-  ],
   "rules": {
     "array-type": false,
     "arrow-parens": false,
@@ -60,21 +57,6 @@
       true,
       "single"
     ],
-    "trailing-comma": false,
-    "component-class-suffix": true,
-    "contextual-lifecycle": true,
-    "directive-class-suffix": true,
-    "no-conflicting-lifecycle": true,
-    "no-host-metadata-property": true,
-    "no-input-rename": true,
-    "no-inputs-metadata-property": true,
-    "no-output-native": true,
-    "no-output-on-prefix": true,
-    "no-output-rename": true,
-    "no-outputs-metadata-property": true,
-    "template-banana-in-box": true,
-    "template-no-negated-async": true,
-    "use-lifecycle-interface": true,
-    "use-pipe-transform-interface": true
+    "trailing-comma": false
   }
 }


### PR DESCRIPTION
Proposed solution for #14130 
Relocated codelyzer recommended rules to the `tslint.json.template` in the application and library schematics.

Open to suggestions on how to create a covering spec for this kind of change.