### PR TITLE
test: fix flaky profile flag test large

### DIFF
--- a/packages/angular_devkit/build_angular/test/browser/stats-json_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/browser/stats-json_spec_large.ts
@@ -27,7 +27,7 @@ describe('Browser Builder stats json', () => {
   it('works with profile flag', async () => {
     const { files } = await browserBuild(architect, host, target, { statsJson: true });
     expect('stats.json' in files).toBe(true);
-    const stats = await files['stats.json'];
-    expect(stats).toMatch(/profile.+building/);
+    const stats = JSON.parse(await files['stats.json']);
+    expect(stats.chunks[0].modules[0].profile.building).toBeDefined();
   });
 });


### PR DESCRIPTION
This change addresses the flaky profile flag test large that sometimes caused `RangeError Maximum call stack size exceeded` inside regex