### PR TITLE
feat(@angular-devkit/build-angular): deprecate `es5BrowserSupport` op…

### DIFF
--- a/packages/angular_devkit/build_angular/src/browser/schema.json
+++ b/packages/angular_devkit/build_angular/src/browser/schema.json
@@ -308,7 +308,7 @@
     "es5BrowserSupport": {
       "description": "Enables conditionally loaded ES2015 polyfills.",
       "type": "boolean",
-      "default": false
+      "x-deprecated": "This will be determined from the list of supported browsers specified in the 'browserslist' file."
     },
     "rebaseRootRelativeCssUrls": {
       "description": "Change root relative URLs in stylesheets to include base HREF and deploy URL. Use only for compatibility and transition. The behavior of this option is non-standard and will be removed in the next major release.",

--- a/packages/angular_devkit/build_angular/src/utils/index.ts
+++ b/packages/angular_devkit/build_angular/src/utils/index.ts
@@ -8,6 +8,7 @@
 
 export * from './default-progress';
 export * from './delete-output-dir';
+export * from './differential-loading';
 export * from './run-module-as-observable-fork';
 export * from './normalize-file-replacements';
 export * from './normalize-asset-patterns';

--- a/tests/legacy-cli/e2e/tests/misc/support-ie.ts
+++ b/tests/legacy-cli/e2e/tests/misc/support-ie.ts
@@ -1,5 +1,5 @@
 import { oneLineTrim } from 'common-tags';
-import { expectFileNotToExist, expectFileToMatch } from '../../utils/fs';
+import { expectFileNotToExist, expectFileToMatch, writeFile } from '../../utils/fs';
 import { ng } from '../../utils/process';
 import { updateJsonFile } from '../../utils/project';
 
@@ -14,6 +14,7 @@ export default async function () {
       appArchitect.build.options.es5BrowserSupport = false;
   });
 
+  await writeFile('browserslist', 'last 2 Chrome versions');
   await ng('build');
   await expectFileNotToExist('dist/test-project/polyfills.es5.js');
   await expectFileToMatch('dist/test-project/index.html', oneLineTrim`
@@ -24,6 +25,7 @@ export default async function () {
     <script src="main.js"></script>
   `);
 
+  await writeFile('browserslist', 'IE 10');
   await ng('build', `--es5BrowserSupport`);
   await expectFileToMatch('dist/test-project/polyfills.es5.js', 'core-js');
   await expectFileToMatch('dist/test-project/index.html', oneLineTrim`


### PR DESCRIPTION
…tion in browser builder

In future, this will be determined from the list of supported browsers specified in the 'browserslist' file.