### PR TITLE
Edit and add doc for CLI usage analytics options

### DIFF
--- a/packages/angular/cli/commands/analytics.json
+++ b/packages/angular/cli/commands/analytics.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/schema",
   "$id": "ng-cli://commands/analytics.json",
-  "description": "Configures usage metric gathering for the Angular CLI. See http://angular.io/MORE_INFO_HERE",
+  "description": "Configures the gathering of Angular CLI usage metrics. See https://next.angular.io/cli/usage-analytics-gathering.",
   "$longDescription": "",
 
   "$aliases": [],
@@ -21,7 +21,7 @@
             "project",
             "prompt"
           ],
-          "description": ".",
+          "description": "Directly enables or disables all usage analytics for the user, or prompts the user to set the status interactively, or sets the default status for the project.",
           "$default": {
             "$source": "argv",
             "index": 0
@@ -33,7 +33,7 @@
             "off",
             "prompt"
           ],
-          "description": ".",
+          "description": "Sets the default analytics enablement status for the project.",
           "$default": {
             "$source": "argv",
             "index": 1

--- a/packages/angular/cli/commands/config-long.md
+++ b/packages/angular/cli/commands/config-long.md
@@ -1,11 +1,13 @@
-A workspace has a single CLI configuration file, `angular.json`, at the top level. 
+A workspace has a single CLI configuration file, `angular.json`, at the top level.
 The `projects` object contains a configuration object for each project in the workspace.
 
-You can edit the configuration directly in a code editor, 
-or indirectly on the command line using this command. 
+You can edit the configuration directly in a code editor,
+or indirectly on the command line using this command.
 
-The configurable property names match command option names, 
-except that in the configuration file, all names must use camelCase, 
+The configurable property names match command option names,
+except that in the configuration file, all names must use camelCase,
 while on the command line options can be given in either camelCase or dash-case.
 
 For further details, see [Workspace Configuration](guide/workspace-config).
+
+For configuration of CLI usage analytics, see [Gathering an Viewing CLI Usage Analytics](./usage-analytics-gathering).


### PR DESCRIPTION
I don't know if the target should be master or master-and-patch. Is `ng analytics` going into version 8?