### PR TITLE
fix(@ngtools/webpack): replace bootstrap code under Ivy unless running in JIT mode

### DIFF
--- a/packages/ngtools/webpack/src/angular_compiler_plugin.ts
+++ b/packages/ngtools/webpack/src/angular_compiler_plugin.ts
@@ -948,13 +948,13 @@ export class AngularCompilerPlugin {
             this._normalizedLocale));
         }
 
-        if (this._useFactories) {
-          // Replace bootstrap in browser AOT.
+        if (!this._JitMode) {
+          // Replace bootstrap in browser non JIT Mode.
           this._transformers.push(replaceBootstrap(
             isAppPath,
             getEntryModule,
             getTypeChecker,
-            !!this._compilerOptions.enableIvy,
+            this._useFactories,
           ));
         }
       } else if (this._platform === PLATFORM.Server) {

--- a/packages/ngtools/webpack/src/transformers/replace_bootstrap.ts
+++ b/packages/ngtools/webpack/src/transformers/replace_bootstrap.ts
@@ -17,7 +17,7 @@ export function replaceBootstrap(
   shouldTransform: (fileName: string) => boolean,
   getEntryModule: () => { path: string, className: string } | null,
   getTypeChecker: () => ts.TypeChecker,
-  enableIvy?: boolean,
+  useFactories = true,
 ): ts.TransformerFactory<ts.SourceFile> {
 
   const standardTransform: StandardTransform = function (sourceFile: ts.SourceFile) {
@@ -82,7 +82,7 @@ export function replaceBootstrap(
       let modulePath = `./${relativeEntryModulePath}`.replace(/\\/g, '/');
       let bootstrapIdentifier = 'bootstrapModule';
 
-      if (!enableIvy) {
+      if (useFactories) {
         className += 'NgFactory';
         modulePath += '.ngfactory';
         bootstrapIdentifier = 'bootstrapModuleFactory';

--- a/packages/ngtools/webpack/src/transformers/replace_bootstrap_spec.ts
+++ b/packages/ngtools/webpack/src/transformers/replace_bootstrap_spec.ts
@@ -52,7 +52,7 @@ describe('@ngtools/webpack transformers', () => {
       expect(tags.oneLine`${result}`).toEqual(tags.oneLine`${output}`);
     });
 
-    it('should replace bootstrap for Ivy without referencing ngFactory', () => {
+    it('should replace bootstrap without referencing ngFactory when useFactories is false', () => {
       const input = tags.stripIndent`
         import { enableProdMode } from '@angular/core';
         import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
@@ -87,7 +87,7 @@ describe('@ngtools/webpack transformers', () => {
         () => true,
         () => ({ path: '/project/src/app/app.module', className: 'AppModule' }),
         () => program.getTypeChecker(),
-        true,
+        false,
       );
       const result = transformTypescript(undefined, [transformer], program, compilerHost);
 

--- a/tests/legacy-cli/e2e/tests/build/prod-build.ts
+++ b/tests/legacy-cli/e2e/tests/build/prod-build.ts
@@ -1,30 +1,37 @@
-import {join} from 'path';
-import {readdirSync} from 'fs';
-import {expectFileToExist, expectFileToMatch} from '../../utils/fs';
-import {ng} from '../../utils/process';
-import {expectGitToBeClean} from '../../utils/git';
+import { readdirSync } from 'fs';
+import { join } from 'path';
+import { getGlobalVariable } from '../../utils/env';
+import { expectFileToExist, expectFileToMatch } from '../../utils/fs';
+import { expectGitToBeClean } from '../../utils/git';
+import { ng } from '../../utils/process';
 
 
-export default function() {
+export default async function () {
   // TODO(architect): Delete this test. It is now in devkit/build-angular.
 
   // Can't use the `ng` helper because somewhere the environment gets
   // stuck to the first build done
-  return ng('build', '--prod')
-    .then(() => expectFileToExist(join(process.cwd(), 'dist')))
-    // Check for cache busting hash script src
-    .then(() => expectFileToMatch('dist/test-project/index.html', /main-es5\.[0-9a-f]{20}\.js/))
-    .then(() => expectFileToMatch('dist/test-project/index.html', /main-es2015\.[0-9a-f]{20}\.js/))
-    .then(() => expectFileToMatch('dist/test-project/index.html', /styles\.[0-9a-f]{20}\.css/))
-    .then(() => expectFileToMatch('dist/test-project/3rdpartylicenses.txt', /MIT/))
-    // Defaults to AoT
-    .then(() => {
-      const mainES5 = readdirSync('./dist/test-project').find(name => !!name.match(/main-es5.[a-z0-9]+\.js/));
-      expectFileToMatch(`dist/test-project/${mainES5}`, /bootstrapModuleFactory\(/);
+  const argv = getGlobalVariable('argv');
+  const ivyProject = argv['ivy'];
+  const bootstrapRegExp = ivyProject
+    ? /bootstrapModule\([a-zA-Z]+\)\./
+    : /bootstrapModuleFactory\([a-zA-Z]+\)\./;
 
-      const mainES2015 = readdirSync('./dist/test-project').find(name => !!name.match(/main-es2015.[a-z0-9]+\.js/));
-      expectFileToMatch(`dist/test-project/${mainES5}`, /bootstrapModuleFactory\(/);
-    })
-    // Check that the process didn't change local files.
-    .then(() => expectGitToBeClean());
+  await ng('build', '--prod');
+  await expectFileToExist(join(process.cwd(), 'dist'));
+  // Check for cache busting hash script src
+  await expectFileToMatch('dist/test-project/index.html', /main-es5\.[0-9a-f]{20}\.js/);
+  await expectFileToMatch('dist/test-project/index.html', /main-es2015\.[0-9a-f]{20}\.js/);
+  await expectFileToMatch('dist/test-project/index.html', /styles\.[0-9a-f]{20}\.css/);
+  await expectFileToMatch('dist/test-project/3rdpartylicenses.txt', /MIT/);
+
+  const dirContents = readdirSync('./dist/test-project');
+  const mainES5 = dirContents.find(name => /main-es5.[a-z0-9]+\.js/.test(name));
+  await expectFileToMatch(`dist/test-project/${mainES5}`, bootstrapRegExp);
+
+  const mainES2015 = dirContents.find(name => /main-es2015.[a-z0-9]+\.js/.test(name));
+  await expectFileToMatch(`dist/test-project/${mainES2015}`, bootstrapRegExp);
+
+  // Check that the process didn't change local files.
+  await expectGitToBeClean();
 }


### PR DESCRIPTION
fix(@ngtools/webpack): replace bootstrap code under Ivy unless running in JIT mode

The bootstrap code always needs to be replaced if not running in JIT mode as other wise the entire compiler will be pulled in because we will not replace the bootstrapping code to use `platform-browser` instead of `platform-browser-dynamic`.