### PR TITLE
fix(@angular-debkit/architect): consume the default export in Testing…

### DIFF
--- a/packages/angular_devkit/architect/testing/testing-architect-host.ts
+++ b/packages/angular_devkit/architect/testing/testing-architect-host.ts
@@ -52,7 +52,7 @@ export class TestingArchitectHost implements ArchitectHost {
       const b = builders[builderName];
       // TODO: remove this check as v1 is not supported anymore.
       if (!b.implementation) { continue; }
-      const handler = await import(builderJsonPath + '/../' + b.implementation);
+      const handler = (await import(builderJsonPath + '/../' + b.implementation)).default;
       const optionsSchema = await import(builderJsonPath + '/../' + b.schema);
       this.addBuilder(builderName, handler, b.description, optionsSchema);
     }


### PR DESCRIPTION
…ArchitectHost

Using the TestingArchitectHost architect is unable to execute the
handler of the builder since it needs to access its `default` property.