### PR TITLE
fix(@angular-devkit/architect): set proper name in TestingArchitectHost

### DIFF
--- a/packages/angular_devkit/architect/testing/testing-architect-host.ts
+++ b/packages/angular_devkit/architect/testing/testing-architect-host.ts
@@ -41,6 +41,10 @@ export class TestingArchitectHost implements ArchitectHost {
       throw new Error('Invalid package.json, builders key not found.');
     }
 
+    if (!packageJson.name) {
+      throw new Error('Invalid package name');
+    }
+
     const builderJsonPath = packageName + '/' + packageJson['builders'];
     const builderJson = await import(builderJsonPath);
     const builders = builderJson['builders'];
@@ -54,7 +58,7 @@ export class TestingArchitectHost implements ArchitectHost {
       if (!b.implementation) { continue; }
       const handler = await import(builderJsonPath + '/../' + b.implementation);
       const optionsSchema = await import(builderJsonPath + '/../' + b.schema);
-      this.addBuilder(builderName, handler, b.description, optionsSchema);
+      this.addBuilder(`${packageJson.name}:${builderName}`, handler, b.description, optionsSchema);
     }
   }
   addTarget(target: Target, builderName: string, options: json.JsonObject = {}) {


### PR DESCRIPTION
The TestingArchitectHost registers the builders only using their name,
ignoring the package name. Later, when Architect looks up the builder
using the host, it's unable to find it.

You can find a reproduction
[here](https://github.com/mgechev/cli-builders-demo).