### PR TITLE
docs(@schematics/angular): mention npx browserslist in browserslist

### DIFF
--- a/packages/schematics/angular/application/files/browserslist.template
+++ b/packages/schematics/angular/application/files/browserslist.template
@@ -2,6 +2,9 @@
 # For additional information regarding the format and rule options, please see:
 # https://github.com/browserslist/browserslist#queries
 
+# You can see what browsers were selected by your queries by running:
+#   npx browserslist
+
 # Googlebot uses an older version of Chrome
 # For additional information see: https://developers.google.com/search/docs/guides/rendering
 


### PR DESCRIPTION
Running `npx browserslist` allows to see what browsers are actually selected with the configuration,
which is very handy and not very known.