### PR TITLE
docs(@schematics/angular): fix typo in web worker schematics ("service worker" --> "web worker")

### DIFF
--- a/packages/schematics/angular/web-worker/schema.json
+++ b/packages/schematics/angular/web-worker/schema.json
@@ -3,14 +3,14 @@
   "id": "SchematicsAngularWebWorker",
   "title": "Angular Web Worker Options Schema",
   "type": "object",
-  "description": "Pass this schematic to the \"run\" command to create a Web Worker",
+  "description": "Creates a new generic web worker definition in the given or default project.",
   "properties": {
     "path": {
       "type": "string",
       "format": "path",
       "description": "The path at which to create the worker file, relative to the current workspace.",
       "visible": false
-    },    
+    },
     "project": {
       "type": "string",
       "description": "The name of the project.",
@@ -20,7 +20,7 @@
     },
     "target": {
       "type": "string",
-      "description": "The target to apply service worker to.",
+      "description": "The target to apply web worker to.",
       "default": "build"
     },
     "name": {
@@ -36,7 +36,7 @@
       "type": "boolean",
       "default": true,
       "description": "Add a worker creation snippet in a sibling file of the same name."
-    }    
+    }
   },
   "required": [
     "name",


### PR DESCRIPTION
☝️ 