### PR TITLE
fix(@angular-devkit/build-angular): run build steps for differential …

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/webpack-browser-config.ts
+++ b/packages/angular_devkit/build_angular/src/utils/webpack-browser-config.ts
@@ -55,7 +55,8 @@ export async function generateWebpackConfig(
   // However this config generation is used by multiple builders such as dev-server
   const scriptTarget = tsConfig.options.target;
   const differentialLoading = context.builder.builderName === 'browser'
-    && isDifferentialLoadingNeeded(projectRoot, scriptTarget);
+    && isDifferentialLoadingNeeded(projectRoot, scriptTarget) && !options.watch;
+
   const scriptTargets = [scriptTarget];
 
   if (differentialLoading) {

--- a/packages/angular_devkit/build_angular/test/browser/differential_loading_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/browser/differential_loading_spec_large.ts
@@ -63,6 +63,36 @@ describe('Browser Builder with differential loading', () => {
       .toEqual(jasmine.arrayWithExactContents(expectedOutputs));
   });
 
+  it('deactivates differential loading for watch mode', async () => {
+    const { files } = await browserBuild(architect, host, target, { watch: true });
+
+    const expectedOutputs = [
+      'favicon.ico',
+      'index.html',
+
+      'main.js',
+      'main.js.map',
+
+      'polyfills-es5.js',
+      'polyfills-es5.js.map',
+      'polyfills.js',
+      'polyfills.js.map',
+
+      'runtime.js',
+      'runtime.js.map',
+
+      'styles.js',
+      'styles.js.map',
+
+      'vendor.js',
+      'vendor.js.map',
+    ] as PathFragment[];
+
+    expect(Object.keys(files))
+      .toEqual(jasmine.arrayWithExactContents(expectedOutputs));
+  });
+
+
   it('emits the right ES formats', async () => {
     const { files } = await browserBuild(architect, host, target, { optimization: true });
     expect(await files['main-es5.js']).not.toContain('class');


### PR DESCRIPTION
…loading in sequence to avoid confusing progress information

Before, the build tasks run in parallel and so the different webpack
instanced competed over the same lines on the console.

This causes an issue with watch mode. We'll address this with an further
PR.