### PR TITLE
refactor(@angular-devkit/build-angular): compare the target with ScriptTarget

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
@@ -295,7 +295,8 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
     );
   }
 
-  if (wco.tsConfig.options.target === 4) {
+  if (wco.tsConfig.options.target !== undefined &&
+      wco.tsConfig.options.target >= ts.ScriptTarget.ES2017) {
     wco.logger.warn(tags.stripIndent`
       WARNING: Zone.js does not support native async/await in ES2017.
       These blocks are not intercepted by zone.js and will not triggering change detection.


### PR DESCRIPTION
Compare with ScriptTarget and consider ES2017 and newer.