### PR TITLE
fix(@schematics/angular): fix paths when `newProjectRoot` is an empty…

### DIFF
--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -143,12 +143,8 @@ function mergeWithRootTsLint(parentHost: Tree) {
   };
 }
 
-function addAppToWorkspaceFile(options: ApplicationOptions, newProjectRoot: string): Rule {
-  let projectRoot = options.projectRoot !== undefined
-    ? options.projectRoot
-    : `${newProjectRoot}/${options.name}`;
-
-  projectRoot = normalize(projectRoot);
+function addAppToWorkspaceFile(options: ApplicationOptions, appDir: string): Rule {
+  let projectRoot = appDir;
   if (projectRoot) {
     projectRoot += '/';
   }
@@ -184,7 +180,7 @@ function addAppToWorkspaceFile(options: ApplicationOptions, newProjectRoot: stri
   const sourceRoot = join(normalize(projectRoot), 'src');
 
   const project = {
-    root: projectRoot,
+    root: normalize(projectRoot),
     sourceRoot,
     projectType: ProjectType.Application,
     prefix: options.prefix || 'app',
@@ -321,11 +317,11 @@ export default function (options: ApplicationOptions): Rule {
       };
 
     const workspace = await getWorkspace(host);
-    const newProjectRoot = workspace.extensions.newProjectRoot as string || '';
+    const newProjectRoot = workspace.extensions.newProjectRoot as (string | undefined) || '';
     const isRootApp = options.projectRoot !== undefined;
     const appDir = isRootApp
       ? options.projectRoot as string
-      : `${newProjectRoot}/${options.name}`;
+      : join(normalize(newProjectRoot), options.name);
     const sourceDir = `${appDir}/src/app`;
 
     const e2eOptions: E2eOptions = {
@@ -334,7 +330,7 @@ export default function (options: ApplicationOptions): Rule {
     };
 
     return chain([
-      addAppToWorkspaceFile(options, newProjectRoot),
+      addAppToWorkspaceFile(options, appDir),
       mergeWith(
         apply(url('./files'), [
           options.minimal ? filter(minimalPathFilter) : noop(),

--- a/packages/schematics/angular/application/index_spec.ts
+++ b/packages/schematics/angular/application/index_spec.ts
@@ -355,5 +355,25 @@ describe('Application Schematic', () => {
       expect(content.rules['component-selector'][2]).toMatch('app');
       expect(content.rules['trailing-comma']).toBeDefined();
     });
+
+    it(`should create correct paths when 'newProjectRoot' is blank`, async () => {
+      const workspaceTree = schematicRunner.runSchematic('workspace', { ...workspaceOptions, newProjectRoot: '' });
+      const options = { ...defaultOptions, projectRoot: undefined };
+      const tree = await schematicRunner.runSchematicAsync('application', options, workspaceTree)
+        .toPromise();
+      const config = JSON.parse(tree.readContent('/angular.json'));
+      const project = config.projects.foo;
+      expect(project.root).toEqual('foo');
+      const buildOpt = project.architect.build.options;
+      expect(buildOpt.index).toEqual('foo/src/index.html');
+      expect(buildOpt.main).toEqual('foo/src/main.ts');
+      expect(buildOpt.polyfills).toEqual('foo/src/polyfills.ts');
+      expect(buildOpt.tsConfig).toEqual('foo/tsconfig.app.json');
+
+      const appTsConfig = JSON.parse(tree.readContent('/foo/tsconfig.app.json'));
+      expect(appTsConfig.extends).toEqual('../tsconfig.json');
+      const specTsConfig = JSON.parse(tree.readContent('/foo/tsconfig.spec.json'));
+      expect(specTsConfig.extends).toEqual('../tsconfig.json');
+    });
   });
 });

--- a/packages/schematics/angular/library/index.ts
+++ b/packages/schematics/angular/library/index.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import { JsonParseMode, parseJson, strings } from '@angular-devkit/core';
+import { JsonParseMode, join, normalize, parseJson, strings } from '@angular-devkit/core';
 import {
   Rule,
   SchematicContext,
@@ -188,11 +188,11 @@ export default function (options: LibraryOptions): Rule {
     }
 
     const workspace = await getWorkspace(host);
-    const newProjectRoot = workspace.extensions.newProjectRoot || '';
+    const newProjectRoot = workspace.extensions.newProjectRoot as (string | undefined) || '';
 
     const scopeFolder = scopeName ? strings.dasherize(scopeName) + '/' : '';
     const folderName = `${scopeFolder}${strings.dasherize(options.name)}`;
-    const projectRoot = `${newProjectRoot}/${folderName}`;
+    const projectRoot = join(normalize(newProjectRoot), folderName);
     const distRoot = `dist/${folderName}`;
 
     const sourceDir = `${projectRoot}/src/lib`;

--- a/packages/schematics/angular/library/index_spec.ts
+++ b/packages/schematics/angular/library/index_spec.ts
@@ -301,4 +301,21 @@ describe('Library Schematic', () => {
     const karmaConf = getFileContent(tree, '/projects/foo/karma.conf.js');
     expect(karmaConf).toContain(`dir: require('path').join(__dirname, '../../coverage/foo')`);
   });
+
+  it(`should create correct paths when 'newProjectRoot' is blank`, async () => {
+    const workspaceTree = schematicRunner.runSchematic('workspace', { ...workspaceOptions, newProjectRoot: '' });
+    const tree = await schematicRunner.runSchematicAsync('library', defaultOptions, workspaceTree)
+      .toPromise();
+    const config = JSON.parse(tree.readContent('/angular.json'));
+    const project = config.projects.foo;
+    expect(project.root).toEqual('foo');
+    const buildOpt = project.architect.build.options;
+    expect(buildOpt.project).toEqual('foo/ng-package.json');
+    expect(buildOpt.tsConfig).toEqual('foo/tsconfig.lib.json');
+
+    const appTsConfig = JSON.parse(tree.readContent('/foo/tsconfig.lib.json'));
+    expect(appTsConfig.extends).toEqual('../tsconfig.json');
+    const specTsConfig = JSON.parse(tree.readContent('/foo/tsconfig.spec.json'));
+    expect(specTsConfig.extends).toEqual('../tsconfig.json');
+  });
 });

--- a/packages/schematics/angular/universal/index.ts
+++ b/packages/schematics/angular/universal/index.ts
@@ -53,7 +53,7 @@ function updateConfigFile(options: UniversalOptions, tsConfigDirectory: Path): R
         builder: Builders.Server,
         options: {
           outputPath: `dist/${options.clientProject}-server`,
-          main: `${clientProject.root}src/main.server.ts`,
+          main: join(normalize(clientProject.root), 'src/main.server.ts'),
           tsConfig: join(tsConfigDirectory, `${options.tsconfigFileName}.json`),
         },
         configurations: {


### PR DESCRIPTION
… string

When `newProjectRoot` the paths are prefixed with an `/` example `/project-name/tsconfig.lib.json` which results in these being marked as absolute paths, which causes build failures.

Fixes #14108