### PR TITLE
Set correct peerDependencies for TypeScript and Angular Compiler CLI

### DIFF
--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -87,6 +87,6 @@
     "zone.js": "^0.9.0"
   },
   "peerDependencies": {
-    "typescript": ">=2.7 < 3.5"
+    "typescript": ">=3.4 < 3.5"
   }
 }

--- a/packages/ngtools/webpack/package.json
+++ b/packages/ngtools/webpack/package.json
@@ -28,8 +28,8 @@
     "webpack-sources": "1.3.0"
   },
   "peerDependencies": {
-    "@angular/compiler-cli": ">=6.0.0 <9.0.0 || ^8.0.0-beta.0",
-    "typescript": ">=2.7 < 3.5",
+    "@angular/compiler-cli": ">=8.0.0-beta.0 < 9.0.0",
+    "typescript": ">=3.4 < 3.5",
     "webpack": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
In version 8, we support only Angular 8+ which only supports TypeScript >=3.4 < 3.5