### PR TITLE
Several 8.0 Migration fixes

### DIFF
--- a/packages/schematics/angular/migrations/update-8/differential-loading.ts
+++ b/packages/schematics/angular/migrations/update-8/differential-loading.ts
@@ -88,12 +88,15 @@ function updateBrowserlist(): Rule {
     }
 
     // For all projects
-    for (const projectName of Object.keys(angularJson.projects)) {
-      const project = angularJson.projects[projectName];
+    for (const [name, project] of Object.entries(angularJson.projects)) {
       if (!isJsonObject(project)) {
         continue;
       }
       if (typeof project.root != 'string' || project.projectType !== 'application') {
+        continue;
+      }
+      if (name.endsWith('-e2e')) {
+        // Skip existing separate E2E projects
         continue;
       }
 

--- a/packages/schematics/angular/migrations/update-8/index.ts
+++ b/packages/schematics/angular/migrations/update-8/index.ts
@@ -13,6 +13,7 @@ import {
 import { updatePackageJson, updateTsLintConfig } from './codelyzer-5';
 import { updateES5Projects } from './differential-loading';
 import { dropES2015Polyfills } from './drop-es6-polyfills';
+import { updateBuilders } from './update-builders';
 
 export { updateLazyModulePaths } from './update-lazy-module-paths';
 
@@ -23,6 +24,7 @@ export default function(): Rule {
       updatePackageJson(),
       dropES2015Polyfills(),
       updateES5Projects(),
+      updateBuilders(),
     ]);
   };
 }

--- a/packages/schematics/angular/migrations/update-8/update-builders.ts
+++ b/packages/schematics/angular/migrations/update-8/update-builders.ts
@@ -1,0 +1,49 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { SchematicContext, Tree } from '@angular-devkit/schematics';
+import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
+import { addPackageJsonDependency, getPackageJsonDependency } from '../../utility/dependencies';
+import { latestVersions } from '../../utility/latest-versions';
+
+export function updateBuilders() {
+  return (host: Tree, context: SchematicContext) => {
+    let updates = false;
+
+    let current = getPackageJsonDependency(host, '@angular-devkit/build-angular');
+    if (current && current.version !== latestVersions.DevkitBuildAngular) {
+      updates = true;
+      addPackageJsonDependency(
+        host,
+        {
+          type: current.type,
+          name: '@angular-devkit/build-angular',
+          version: latestVersions.DevkitBuildAngular,
+          overwrite: true,
+        },
+      );
+    }
+
+    current = getPackageJsonDependency(host, '@angular-devkit/build-ng-packagr');
+    if (current && current.version !== latestVersions.DevkitBuildNgPackagr) {
+      updates = true;
+      addPackageJsonDependency(
+        host,
+        {
+          type: current.type,
+          name: '@angular-devkit/build-ng-packagr',
+          version: latestVersions.DevkitBuildNgPackagr,
+          overwrite: true,
+        },
+      );
+    }
+
+    if (updates) {
+      context.addTask(new NodePackageInstallTask());
+    }
+  };
+}


### PR DESCRIPTION
* The package group format required to automatically update the builder packages was not supported until CLI 7.2.  For older CLI versions performing the update, this new migration will update the builders instead.  Once the CLI is updated to at least 7.2, the update algorithm itself will handle the update.

* Skip E2E projects when migrating browserslist.  These projects are not actual applications.

Fixes #14233
Fixes #14229