### PR TITLE
fix(@schematics/angular): move and update existing `src/browserslist`

### DIFF
--- a/packages/schematics/angular/migrations/update-8/differential-loading.ts
+++ b/packages/schematics/angular/migrations/update-8/differential-loading.ts
@@ -97,11 +97,18 @@ function updateBrowserlist(): Rule {
         continue;
       }
 
-      const browserslistPath = join(normalize(project.root), '/browserslist');
+      const browserslistPath = join(normalize(project.root), 'browserslist');
+      if (typeof project.sourceRoot === 'string') {
+        const srcBrowsersList = join(normalize(project.sourceRoot), 'browserslist');
+        if (tree.exists(srcBrowsersList)) {
+          tree.rename(srcBrowsersList, browserslistPath);
+        }
+      }
+
       const source = tree.read(browserslistPath);
       if (!source) {
         tree.create(browserslistPath, browserslistContent);
-      } else {
+      } else if (!source.toString().toLowerCase().includes('chrome 41')) {
         const recorder = tree.beginUpdate(browserslistPath);
         recorder.insertRight(source.length, '\nChrome 41 # Googlebot');
         tree.commitUpdate(recorder);

--- a/packages/schematics/angular/migrations/update-8/differential-loading_spec.ts
+++ b/packages/schematics/angular/migrations/update-8/differential-loading_spec.ts
@@ -74,5 +74,15 @@ describe('Migration to version 8', () => {
       expect(tree2.readContent('/browserslist'))
         .toContain('Googlebot support');
     });
+
+    it('should move browserslist file if it exists in the sourceRoot', () => {
+      tree.create('/src/browserslist', 'last 2 Chrome versions');
+      tree.delete('/browserslist');
+      const tree2 = schematicRunner.runSchematic('migration-07', {}, tree.branch());
+      expect(tree2.exists('/browserslist')).toBe(true);
+      const content = tree2.readContent('/browserslist');
+      expect(content).toContain('Chrome 41');
+      expect(content).toContain('last 2 Chrome versions');
+    });
   });
 });


### PR DESCRIPTION
Older projects have their `browserslist` file under the `src` folder.

Fixes #14232