### PR TITLE
fix(@schematics/angular): avoid double header/comments in es6 polyfill migration

### DIFF
--- a/packages/schematics/angular/migrations/update-8/drop-es6-polyfills_spec.ts
+++ b/packages/schematics/angular/migrations/update-8/drop-es6-polyfills_spec.ts
@@ -88,7 +88,6 @@ import 'zone.js/dist/zone'; // Included with Angular CLI.
       expect(polyfills).toContain('core-js/es6/reflect');
       expect(polyfills).toContain('core-js/es7/reflect');
       expect(polyfills).toContain('BROWSER POLYFILLS');
-      expect(polyfills).toContain('core-js/es6/weak-map');
     });
 
     it('should work as expected for a project with a root', async () => {
@@ -113,7 +112,6 @@ import 'zone.js/dist/zone'; // Included with Angular CLI.
       expect(newPolyfills).toContain('core-js/es6/reflect');
       expect(newPolyfills).toContain('core-js/es7/reflect');
       expect(newPolyfills).toContain('BROWSER POLYFILLS');
-      expect(newPolyfills).toContain('core-js/es6/weak-map');
     });
   });
 });


### PR DESCRIPTION
If a polyfills file is original, then replace completely with latest version of the file.  This removes the need to deeply analyze the file as well as ensuring all comments are up to date.  Also skips analysis if there is no mention of `core-js` of any form in the file.
The header re-addition check is also reduced in scope to account for varying versions of the header content.
The WeakMap polyfill was also removed as it is automatically included at build time.