### PR TITLE
fix(@angular/cli): only show postinstall prompt when global analytics not configured

### DIFF
--- a/packages/angular/cli/bin/postinstall/analytics-prompt.js
+++ b/packages/angular/cli/bin/postinstall/analytics-prompt.js
@@ -1,10 +1,14 @@
 'use strict';
 // This file is ES6 because it needs to be executed as is.
 
+if ('NG_CLI_ANALYTICS' in process.env) {
+  return;
+}
+
 try {
   const analytics = require('../../models/analytics');
 
-  if (analytics.getGlobalAnalytics() === undefined) {
+  if (!analytics.hasGlobalAnalyticsConfiguration()) {
     analytics.promptGlobalAnalytics();
   }
 } catch (_) {}

--- a/packages/angular/cli/models/analytics.ts
+++ b/packages/angular/cli/models/analytics.ts
@@ -441,6 +441,20 @@ export async function promptProjectAnalytics(force = false): Promise<boolean> {
   return false;
 }
 
+export function hasGlobalAnalyticsConfiguration(): boolean {
+  try {
+    const globalWorkspace = getWorkspace('global');
+    const analyticsConfig: string | undefined | null | { uid?: string } = globalWorkspace
+      && globalWorkspace.getCli()
+      && globalWorkspace.getCli()['analytics'];
+
+    if (analyticsConfig !== undefined) {
+      return true;
+    }
+  } catch {}
+
+  return false;
+}
 
 /**
  * Get the global analytics object for the user. This returns an instance of UniversalAnalytics,


### PR DESCRIPTION
Partially addresses #14011 