### PR TITLE
test: disable rebuild replacements when running ivy e2e

### DIFF
--- a/tests/legacy-cli/e2e/tests/build/rebuild-replacements.ts
+++ b/tests/legacy-cli/e2e/tests/build/rebuild-replacements.ts
@@ -10,6 +10,14 @@ import { wait } from '../../utils/utils';
 const webpackGoodRegEx = /: Compiled successfully./;
 
 export default async function() {
+  const argv = getGlobalVariable('argv');
+  if (argv['ivy']) {
+    // todo: enable when the below is solved
+    // rebuilds under ivy are broken at the moment
+    // https://github.com/angular/angular/issues/30079
+    return;
+  }
+
   if (process.platform.startsWith('win')) {
     return;
   }


### PR DESCRIPTION
Rebuilds under ivy are broken at the moment

See: https://github.com/angular/angular/issues/30079