### PR TITLE
fix(@angular-devkit/build-optimizer): don't add pure comments in call…

### DIFF
--- a/packages/angular_devkit/build_optimizer/src/transforms/prefix-functions.ts
+++ b/packages/angular_devkit/build_optimizer/src/transforms/prefix-functions.ts
@@ -47,6 +47,7 @@ export function findTopLevelFunctions(parentNode: ts.Node): Set<ts.Node> {
     if (ts.isFunctionDeclaration(node)
       || ts.isFunctionExpression(node)
       || ts.isClassDeclaration(node)
+      || ts.isClassExpression(node)
       || ts.isArrowFunction(node)
       || ts.isMethodDeclaration(node)
     ) {

--- a/packages/angular_devkit/build_optimizer/src/transforms/prefix-functions_spec.ts
+++ b/packages/angular_devkit/build_optimizer/src/transforms/prefix-functions_spec.ts
@@ -167,4 +167,23 @@ describe('prefix-functions', () => {
 
     expect(tags.oneLine`${transform(input)}`).toEqual(tags.oneLine`${output}`);
   });
+
+  it('doesn\'t add comment when inside class expression', () => {
+    const input = tags.stripIndent`
+      let Foo = class Foo {
+        constructor() {
+          this.isExpandedChange = new EventEmitter();
+        }
+
+        set isExpanded(value) {
+          this.isExpandedChange.emit(value);
+        }
+      };
+    `;
+    const output = tags.stripIndent`
+      ${input}
+    `;
+
+    expect(tags.oneLine`${transform(input)}`).toEqual(tags.oneLine`${output}`);
+  });
 });


### PR DESCRIPTION
… expressions

When we removed tsickle from the library compilation pipeline the emitted JS changes for Classes.

With tsc a class can be of kind CallExpression because of this syntax
```
let Foo = class Foo {
	constructor() {
		this.isExpandedChange = new EventEmitter();
	}

	set isExpanded(value) {
		this.isExpandedChange.emit(value);
	}
};
```

In such case we shall not add `/*@__PURE__*/` inside this class

Fixes #14084