### PR TITLE
feat(@angular-devkit/build-angular): use evergreen version of zone.js with ES2015

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/webpack-browser-config.ts
+++ b/packages/angular_devkit/build_angular/src/utils/webpack-browser-config.ts
@@ -95,7 +95,17 @@ export async function generateWebpackConfig(
     wco.buildOptions.progress = defaultProgress(wco.buildOptions.progress);
 
     const partials = webpackPartialGenerator(wco);
-    const webpackConfig = webpackMerge(partials);
+    const webpackConfig = webpackMerge(partials) as webpack.Configuration;
+
+    if (supportES2015) {
+      if (!webpackConfig.resolve) {
+        webpackConfig.resolve = {};
+      }
+      if (!webpackConfig.resolve.alias) {
+        webpackConfig.resolve.alias = {};
+      }
+      webpackConfig.resolve.alias['zone.js/dist/zone'] = 'zone.js/dist/zone-evergreen';
+    }
 
     if (options.profile || process.env['NG_BUILD_PROFILING']) {
       const esVersionInFileName = getEsVersionForFileName(

--- a/packages/angular_devkit/build_angular/test/browser/differential_loading_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/browser/differential_loading_spec_large.ts
@@ -98,4 +98,13 @@ describe('Browser Builder with differential loading', () => {
     expect(await files['main-es5.js']).not.toContain('class');
     expect(await files['main-es2015.js']).toContain('class');
   });
+
+  it('uses the right zone.js variant', async () => {
+    const { files } = await browserBuild(architect, host, target, { optimization: false });
+    expect(await files['polyfills-es5.js']).toContain('zone.js/dist/zone');
+    expect(await files['polyfills-es5.js']).not.toContain('zone.js/dist/zone-evergreen');
+    expect(await files['polyfills-es5.js']).toContain('registerElementPatch');
+    expect(await files['polyfills-es2015.js']).toContain('zone.js/dist/zone-evergreen');
+    expect(await files['polyfills-es2015.js']).not.toContain('registerElementPatch');
+  });
 });


### PR DESCRIPTION
When generating an application targeting browsers which support ES2015, zone.js (if included) will  only include code relevant to ES2015+ browsers.
By leveraging differential loading, a more optimized method can be used to include the different variants.