### PR TITLE
fix(@angular-devkit/architect): propagate option validation errors

### DIFF
--- a/packages/angular_devkit/architect/src/architect.ts
+++ b/packages/angular_devkit/architect/src/architect.ts
@@ -55,7 +55,7 @@ function _createJobHandlerFromBuilderInfo(
               if (result.success) {
                 return { ...v, options: result.data } as BuilderInput;
               } else if (result.errors) {
-                throw new Error('Options did not validate.' + result.errors.join());
+                throw new json.schema.SchemaValidationException(result.errors);
               } else {
                 return v;
               }
@@ -282,9 +282,7 @@ function _validateOptionsFactory(host: ArchitectHost, registry: json.schema.Sche
           if (success) {
             return of(data as json.JsonObject);
           } else {
-            throw new Error(
-              'Data did not validate: ' + (errors ? errors.join() : 'Unknown error.'),
-            );
+            throw new json.schema.SchemaValidationException(errors);
           }
         }),
       ).toPromise();

--- a/packages/angular_devkit/architect/src/index_spec.ts
+++ b/packages/angular_devkit/architect/src/index_spec.ts
@@ -300,10 +300,9 @@ describe('architect', () => {
     // Should also error.
     const run2 = await architect.scheduleBuilder('package:do-it', {});
 
-    try {
-      await run2.output.toPromise();
-      expect('THE ABOVE LINE SHOULD NOT ERROR').toBe('false');
-    } catch {}
+    await expectAsync(run2.output.toPromise())
+      .toBeRejectedWith(jasmine.objectContaining({ message: jasmine.stringMatching('p1')}));
+
     await run2.stop();
   });
 });


### PR DESCRIPTION
By using the `SchemaValidationException` object, the underlying JSON schema validation errors will be propagated to the consuming code.  This allows for more detailed error reporting of malformed or incorrectly provided options.

Partially addresses #14269