### PR TITLE
fix(@schematics/angular): normalize differing TS AST versions in lazy module migration

### DIFF
--- a/packages/schematics/angular/migrations/update-8/rules/noLazyModulePathsRule.ts
+++ b/packages/schematics/angular/migrations/update-8/rules/noLazyModulePathsRule.ts
@@ -21,7 +21,16 @@ export class Rule extends Rules.AbstractRule {
     const ruleName = this.ruleName;
     const changes: RuleFailure[] = [];
 
-    ts.forEachChild(ast, function analyze(node) {
+    // NOTE: This should ideally be excluded at a higher level to avoid parsing
+    if (ast.isDeclarationFile || /[\\\/]node_modules[\\\/]/.test(ast.fileName)) {
+      return [];
+    }
+
+    // Workaround mismatched tslint TS version and vendored TS version
+    // The TS SyntaxKind enum numeric values change between versions
+    const sourceFile = ts.createSourceFile(ast.fileName, ast.text, ast.languageVersion, true);
+
+    ts.forEachChild(sourceFile, function analyze(node) {
       if (ts.isPropertyAssignment(node) &&
           (ts.isIdentifier(node.name) || ts.isStringLiteral(node.name)) &&
           node.name.text === 'loadChildren' &&


### PR DESCRIPTION
The version of TypeScript used by TSLint and the vendored version may not match.  This is especially likely during an update.  Since the TypeScript `SyntaxKind` enum numeric values change between versions, a version mismatch can cause invalid analysis of the AST.  This change normalizes the AST to the vendored version.

Since the update tests pull versions from the npm registry, CI will fail until this change has been published.  This fix was tested manually by installing the locally built packages in a 7.0.7 project and running the migrations.