### PR TITLE
Revert "fix(@angular-devkit/build-angular): remove pure_getters"

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
@@ -279,13 +279,18 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
         comments: false,
         webkit: true,
       },
-      compress: {
-        // PURE comments work best with 3 passes.
-        // See https://github.com/webpack/webpack/issues/2899#issuecomment-317425926.
-        passes: 3,
+      // On server, we don't want to compress anything. We still set the ngDevMode = false for it
+      // to remove dev code, and ngI18nClosureMode to remove Closure compiler i18n code
+      compress: (buildOptions.platform == 'server' ? {
         global_defs: angularGlobalDefinitions,
-      },
-      // We want to avoid mangling on server.
+      } : {
+          pure_getters: buildOptions.buildOptimizer,
+          // PURE comments work best with 3 passes.
+          // See https://github.com/webpack/webpack/issues/2899#issuecomment-317425926.
+          passes: buildOptions.buildOptimizer ? 3 : 1,
+          global_defs: angularGlobalDefinitions,
+        }),
+      // We also want to avoid mangling on server.
       ...(buildOptions.platform == 'server' ? { mangle: false } : {}),
     };
 


### PR DESCRIPTION
This reverts commit 9a9939fc4eb92f50241bc1e46b6623505a587bc5.

We are temporarily reverting the pure_getters removal because it caused a 2x size
regression in Ivy (non-compatibility mode). We need time to investigate why this
is happening and re-assess how we want to move forward.

See https://github.com/angular/angular/commit/fcacb2a4a2e1ad2197b97d2a194d544556f2dcc5 for size regression.