### PR TITLE
fix(@angular-devkit/core): support writing an empty object workspace

### DIFF
--- a/packages/angular_devkit/core/src/workspace/core_spec.ts
+++ b/packages/angular_devkit/core/src/workspace/core_spec.ts
@@ -289,7 +289,7 @@ describe('readWorkspace', () => {
 });
 
 describe('writeWorkspace', () => {
-  xit('attempts to write to specified file path', async (done) => {
+  it('attempts to write to specified file path', async (done) => {
     const requestedPath = '/path/to/workspace/angular.json';
 
     let writtenPath: string | undefined;

--- a/packages/angular_devkit/core/src/workspace/json/writer.ts
+++ b/packages/angular_devkit/core/src/workspace/json/writer.ts
@@ -55,7 +55,7 @@ function convertJsonWorkspace(workspace: WorkspaceDefinition, schema?: string): 
     $schema: schema || './node_modules/@angular/cli/lib/config/schema.json',
     version: 1,
     ...workspace.extensions,
-    projects: convertJsonProjectCollection(workspace.projects),
+    projects: workspace.projects ? convertJsonProjectCollection(workspace.projects) : {},
   };
 
   return obj;


### PR DESCRIPTION
Minor cleanup of workspace functionality (and enabling of an errantly disabled unit test).