### PR TITLE
fix(@angular-devkit/build-angular): live reload cannot be disabled

### DIFF
--- a/packages/angular_devkit/build_angular/src/dev-server/index.ts
+++ b/packages/angular_devkit/build_angular/src/dev-server/index.ts
@@ -274,6 +274,8 @@ export function buildServerConfig(
       errors: !(styles || scripts),
       warnings: false,
     },
+    // inline is always false, because we add live reloading scripts in _addLiveReload when needed
+    inline: false,
     public: serverOptions.publicHost,
     disableHostCheck: serverOptions.disableHostCheck,
     publicPath: servePath,


### PR DESCRIPTION
By default the application will be served with inline mode enabled. This means that a script will be inserted in your bundle to take care of live reloading.

However at the moment we are already adding these scripts in `_addLiveReload` method.

With this change we always disable this behaviour and only add it when needed via the `_addLiveReload` logic.

Eventually we should try to remove the logic and rely on webpack-dev-server interals.

Fixes #14300