### PR TITLE
docs(@angular/cli): fix typo with service schema

### DIFF
--- a/packages/schematics/angular/service/schema.json
+++ b/packages/schematics/angular/service/schema.json
@@ -47,11 +47,9 @@
     "lintFix": {
       "type": "boolean",
       "default": false,
-      "description": "When true, applies lint fixes after generating the pipe.",
+      "description": "When true, applies lint fixes after generating the service.",
       "x-user-analytics": 15
     }
   },
-  "required": [
-    "name"
-  ]
+  "required": ["name"]
 }


### PR DESCRIPTION
change the typo "pipe" to "service" in the service schema