### PR TITLE
refactor(@angular/cli): avoid aggressive eager command loading

### DIFF
--- a/packages/angular/cli/commands/help-impl.ts
+++ b/packages/angular/cli/commands/help-impl.ts
@@ -13,9 +13,7 @@ export class HelpCommand extends Command<HelpCommandSchema> {
   async run() {
     this.logger.info(`Available Commands:`);
 
-    for (const name of Object.keys(Command.commandMap)) {
-      const cmd = Command.commandMap[name];
-
+    for (const cmd of Object.values(await Command.commandMap())) {
       if (cmd.hidden) {
         continue;
       }

--- a/packages/angular/cli/models/command.ts
+++ b/packages/angular/cli/models/command.ts
@@ -29,8 +29,8 @@ export abstract class Command<T extends BaseCommandOptions = BaseCommandOptions>
   public workspace: CommandWorkspace;
   public analytics: analytics.Analytics;
 
-  protected static commandMap: CommandDescriptionMap;
-  static setCommandMap(map: CommandDescriptionMap) {
+  protected static commandMap: () => Promise<CommandDescriptionMap>;
+  static setCommandMap(map: () => Promise<CommandDescriptionMap>) {
     this.commandMap = map;
   }
 


### PR DESCRIPTION
Currently, upon execution `ng` will load all description files and code for all available commands.  This requires a large amount of unnecessary file access and processing since only at most one command will be executed.  This change limits the loading to only the command being executed in the common case and a subset of commands in the event an alias is used.  The help command now loads all commands during its execution which is needed to gather command description information.  Further improvements are possible by only loading the necessary metadata instead of the execution code (and its dependencies) as well.
This change allows for savings of ~250ms per execution and reduces memory consumption by 10-20 MBs depending on the command.

Examples:
Before -- `./node_modules/.bin/ng version  0.99s user 0.17s system 113% cpu 1.020 total`
After -- `./node_modules/.bin/ng version  0.70s user 0.13s system 110% cpu 0.749 total`

Before -- `./node_modules/.bin/ng g c a  1.91s user 0.30s system 111% cpu 1.996 total`
After -- `./node_modules/.bin/ng g c a  1.62s user 0.27s system 110% cpu 1.715 total`