### PR TITLE
fix(@schematics/angular): reduce package installs for 8.0 migrations

### DIFF
--- a/packages/schematics/angular/migrations/update-8/codelyzer-5.ts
+++ b/packages/schematics/angular/migrations/update-8/codelyzer-5.ts
@@ -9,10 +9,8 @@
 import { JsonParseMode, parseJsonAst } from '@angular-devkit/core';
 import {
   Rule,
-  SchematicContext,
   Tree,
 } from '@angular-devkit/schematics';
-import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
 import {
   NodeDependency,
   NodeDependencyType,
@@ -78,7 +76,7 @@ export const updateTsLintConfig = (): Rule => {
 };
 
 export const updatePackageJson = () => {
-  return (host: Tree, context: SchematicContext) => {
+  return (host: Tree) => {
     const dependency: NodeDependency = {
       type: NodeDependencyType.Dev,
       name: 'codelyzer',
@@ -87,8 +85,5 @@ export const updatePackageJson = () => {
     };
 
     addPackageJsonDependency(host, dependency);
-    context.addTask(new NodePackageInstallTask());
-
-    return host;
   };
 };

--- a/packages/schematics/angular/migrations/update-8/index.ts
+++ b/packages/schematics/angular/migrations/update-8/index.ts
@@ -6,10 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {
-  Rule,
-  chain,
-} from '@angular-devkit/schematics';
+import { Rule, chain } from '@angular-devkit/schematics';
+import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
 import { updatePackageJson, updateTsLintConfig } from './codelyzer-5';
 import { updateES5Projects } from './differential-loading';
 import { dropES2015Polyfills } from './drop-es6-polyfills';
@@ -27,6 +25,12 @@ export default function(): Rule {
       updateES5Projects(),
       updateBuilders(),
       removeAngularHttp(),
+      (tree, context) => {
+        const packageChanges = tree.actions.some(a => a.path.endsWith('/package.json'));
+        if (packageChanges) {
+          context.addTask(new NodePackageInstallTask());
+        }
+      },
     ]);
   };
 }

--- a/packages/schematics/angular/migrations/update-8/remove-angular-http.ts
+++ b/packages/schematics/angular/migrations/update-8/remove-angular-http.ts
@@ -6,15 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { SchematicContext, Tree } from '@angular-devkit/schematics';
-import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
+import { Tree } from '@angular-devkit/schematics';
 import { removePackageJsonDependency } from '../../utility/dependencies';
 
 export const removeAngularHttp = () => {
-  return (host: Tree, context: SchematicContext) => {
+  return (host: Tree) => {
     removePackageJsonDependency(host, '@angular/http');
-    context.addTask(new NodePackageInstallTask());
-
-    return host;
   };
 };

--- a/packages/schematics/angular/migrations/update-8/update-builders.ts
+++ b/packages/schematics/angular/migrations/update-8/update-builders.ts
@@ -5,18 +5,14 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import { SchematicContext, Tree } from '@angular-devkit/schematics';
-import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
+import { Tree } from '@angular-devkit/schematics';
 import { addPackageJsonDependency, getPackageJsonDependency } from '../../utility/dependencies';
 import { latestVersions } from '../../utility/latest-versions';
 
 export function updateBuilders() {
-  return (host: Tree, context: SchematicContext) => {
-    let updates = false;
-
+  return (host: Tree) => {
     let current = getPackageJsonDependency(host, '@angular-devkit/build-angular');
     if (current && current.version !== latestVersions.DevkitBuildAngular) {
-      updates = true;
       addPackageJsonDependency(
         host,
         {
@@ -30,7 +26,6 @@ export function updateBuilders() {
 
     current = getPackageJsonDependency(host, '@angular-devkit/build-ng-packagr');
     if (current && current.version !== latestVersions.DevkitBuildNgPackagr) {
-      updates = true;
       addPackageJsonDependency(
         host,
         {
@@ -44,7 +39,6 @@ export function updateBuilders() {
 
     current = getPackageJsonDependency(host, 'zone.js');
     if (current && current.version !== latestVersions.ZoneJs) {
-      updates = true;
       addPackageJsonDependency(
         host,
         {
@@ -54,10 +48,6 @@ export function updateBuilders() {
           overwrite: true,
         },
       );
-    }
-
-    if (updates) {
-      context.addTask(new NodePackageInstallTask());
     }
   };
 }


### PR DESCRIPTION
At most one package manager install will now be executed for 8.0 migrations.  This provides a ~30% performance improvement for a hello world project.