### PR TITLE
fix(@ngtools/webpack): fixes ngcc error when project name is the same…

### DIFF
--- a/packages/ngtools/webpack/src/angular_compiler_plugin.ts
+++ b/packages/ngtools/webpack/src/angular_compiler_plugin.ts
@@ -674,6 +674,7 @@ export class AngularCompilerPlugin {
             compilerWithFileSystems.inputFileSystem,
             this._warnings,
             this._errors,
+            this._basePath,
           );
         }
       }


### PR DESCRIPTION
… or partially the same as a module name

FIxes #14317