### PR TITLE
fix(@schematics/angular): insertAfterLastOccurrence AST util

### DIFF
--- a/packages/schematics/angular/utility/ast-utils.ts
+++ b/packages/schematics/angular/utility/ast-utils.ts
@@ -191,10 +191,7 @@ export function insertAfterLastOccurrence(nodes: ts.Node[],
                                           syntaxKind?: ts.SyntaxKind): Change {
   // sort() has a side effect, so make a copy so that we won't overwrite the parent's object.
   let lastItem = [...nodes].sort(nodesByPosition).pop();
-  if (!lastItem) {
-    throw new Error();
-  }
-  if (syntaxKind) {
+  if (syntaxKind && lastItem) {
     lastItem = findNodes(lastItem, syntaxKind).sort(nodesByPosition).pop();
   }
   if (!lastItem && fallbackPos == undefined) {

--- a/packages/schematics/angular/utility/ast-utils_spec.ts
+++ b/packages/schematics/angular/utility/ast-utils_spec.ts
@@ -16,8 +16,8 @@ import {
   addExportToModule,
   addProviderToModule,
   addSymbolToNgModuleMetadata,
-  insertAfterLastOccurrence,
   findNodes,
+  insertAfterLastOccurrence,
 } from './ast-utils';
 
 
@@ -39,6 +39,7 @@ function applyChanges(path: string, content: string, changes: Change[]): string 
   return getFileContent(tree, path);
 }
 
+// tslint:disable-next-line:no-big-function
 describe('ast utils', () => {
   let modulePath: string;
   let moduleContent: string;
@@ -209,20 +210,23 @@ describe('ast utils', () => {
   });
 
   describe('insertAfterLastOccurrence', () => {
-    const filePath: string = './src/foo.ts';
+    const filePath = './src/foo.ts';
 
     it('should work for the default scenario', () => {
       const fileContent = `const arr = ['foo'];`;
       const source = getTsSource(filePath, fileContent);
-      const arrayNode = findNodes(source.getChildren().shift() as ts.Node, ts.SyntaxKind.ArrayLiteralExpression);
+      const arrayNode = findNodes(
+        source.getChildren().shift() as ts.Node,
+        ts.SyntaxKind.ArrayLiteralExpression,
+      );
       const elements = (arrayNode.pop() as ts.ArrayLiteralExpression).elements;
 
       const change = insertAfterLastOccurrence(
-        elements as any as ts.Node[],
+        elements as unknown as ts.Node[],
         `, 'bar'`,
         filePath,
         elements.pos,
-        ts.SyntaxKind.StringLiteral
+        ts.SyntaxKind.StringLiteral,
       );
       const output = applyChanges(filePath, fileContent, [change]);
 
@@ -233,15 +237,18 @@ describe('ast utils', () => {
     it('should work without occurrences', () => {
       const fileContent = `const arr = [];`;
       const source = getTsSource(filePath, fileContent);
-      const arrayNode = findNodes(source.getChildren().shift() as ts.Node, ts.SyntaxKind.ArrayLiteralExpression);
+      const arrayNode = findNodes(
+        source.getChildren().shift() as ts.Node,
+        ts.SyntaxKind.ArrayLiteralExpression,
+      );
       const elements = (arrayNode.pop() as ts.ArrayLiteralExpression).elements;
 
       const change = insertAfterLastOccurrence(
-        elements as any as ts.Node[],
+        elements as unknown as ts.Node[],
         `'bar'`,
         filePath,
         elements.pos,
-        ts.SyntaxKind.StringLiteral
+        ts.SyntaxKind.StringLiteral,
       );
       const output = applyChanges(filePath, fileContent, [change]);
 


### PR DESCRIPTION
The introduced change fixes a bug in the `insertAfterLastOccurrence` AST utility function which is part of the `@schematics/angular` package. By design, the function should be able to insert a string in an empty node list, hence the `fallbackPos` argument. However, the check performed in the function implementation itself blocks the user to do so; an error is thrown instead.