### PR TITLE
fix(@schematics/angular): project name option in the library schematic index

### DIFF
--- a/packages/schematics/angular/library/index.ts
+++ b/packages/schematics/angular/library/index.ts
@@ -222,7 +222,7 @@ export default function (options: LibraryOptions): Rule {
         commonModule: false,
         flat: true,
         path: sourceDir,
-        project: options.name,
+        project: projectName,
       }),
       schematic('component', {
         name: options.name,
@@ -232,13 +232,13 @@ export default function (options: LibraryOptions): Rule {
         flat: true,
         path: sourceDir,
         export: true,
-        project: options.name,
+        project: projectName,
       }),
       schematic('service', {
         name: options.name,
         flat: true,
         path: sourceDir,
-        project: options.name,
+        project: projectName,
       }),
       options.lintFix ? applyLintFix(sourceDir) : noop(),
       (_tree: Tree, context: SchematicContext) => {


### PR DESCRIPTION
The change fixes the passed `project` option to the module, component, and service schematics used in the library schematic (`schematics/angular/library/index.ts`). Originally, `options.name` used to be passed to the respective schematics. In the case of a scoped project, however, the passed `project` option will be incorrect/incomplete due to the stripped scope from `option.name` performed earlier during the execution (https://github.com/angular/angular-cli/blob/master/packages/schematics/angular/library/index.ts#L184).