### PR TITLE
fix(@angular-devkit/build-angular): relax typescript peerDep

### DIFF
--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -87,6 +87,6 @@
     "zone.js": "^0.9.0"
   },
   "peerDependencies": {
-    "typescript": ">=3.4 < 3.5"
+    "typescript": ">=3.1 < 3.5"
   }
 }

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/build-options.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/build-options.ts
@@ -9,7 +9,7 @@
 // TODO: cleanup this file, it's copied as is from Angular CLI.
 
 import { logging } from '@angular-devkit/core';
-import * as ts from 'typescript'; // tslint:disable-line:no-implicit-dependencies
+import { ParsedCommandLine, ScriptTarget } from 'typescript';
 import {
   AssetPatternClass,
   Budget,
@@ -79,7 +79,7 @@ export interface BuildOptions {
   esVersionInFileName?: boolean;
 
   /* When specified it will be used instead of the script target in the tsconfig.json. */
-  scriptTargetOverride?: ts.ScriptTarget;
+  scriptTargetOverride?: ScriptTarget;
 }
 
 export interface WebpackTestOptions extends BuildOptions {
@@ -93,7 +93,7 @@ export interface WebpackConfigOptions<T = BuildOptions> {
   projectRoot: string;
   sourceRoot?: string;
   buildOptions: T;
-  tsConfig: ts.ParsedCommandLine;
+  tsConfig: ParsedCommandLine;
   tsConfigPath: string;
   supportES2015: boolean;
 }

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
@@ -8,7 +8,7 @@
 import { tags } from '@angular-devkit/core';
 import * as CopyWebpackPlugin from 'copy-webpack-plugin';
 import * as path from 'path';
-import * as ts from 'typescript';
+import { ScriptTarget } from 'typescript';
 import {
   Configuration,
   ContextReplacementPlugin,
@@ -71,7 +71,7 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
 
   if (targetInFileName) {
     // For differential loading we don't need to have 2 polyfill bundles
-    if (buildOptions.scriptTargetOverride === ts.ScriptTarget.ES2015) {
+    if (buildOptions.scriptTargetOverride === ScriptTarget.ES2015) {
       entryPoints['polyfills'] = [path.join(__dirname, '..', 'safari-nomodule.js')];
     } else {
       entryPoints['polyfills'] = [es5Polyfills];
@@ -305,7 +305,7 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
   }
 
   if (wco.tsConfig.options.target !== undefined &&
-    wco.tsConfig.options.target >= ts.ScriptTarget.ES2017) {
+    wco.tsConfig.options.target >= ScriptTarget.ES2017) {
     wco.logger.warn(tags.stripIndent`
       WARNING: Zone.js does not support native async/await in ES2017.
       These blocks are not intercepted by zone.js and will not triggering change detection.

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/utils.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/utils.ts
@@ -12,7 +12,7 @@ import * as path from 'path';
 import { basename, normalize } from '@angular-devkit/core';
 import { ExtraEntryPoint, ExtraEntryPointClass } from '../../../browser/schema';
 import { SourceMapDevToolPlugin } from 'webpack';
-import * as ts from 'typescript';
+import { ScriptTarget } from 'typescript';
 
 export const ngAppResolve = (resolvePath: string): string => {
   return path.resolve(process.cwd(), resolvePath);
@@ -95,9 +95,9 @@ export function getSourceMapDevTool(
  * Returns an ES version file suffix to differentiate between various builds.
  */
 export function getEsVersionForFileName(
-  scriptTargetOverride: ts.ScriptTarget | undefined,
+  scriptTargetOverride: ScriptTarget | undefined,
   esVersionInFileName = false,
 ): string {
   return scriptTargetOverride && esVersionInFileName ?
-    '-' + ts.ScriptTarget[scriptTargetOverride].toLowerCase() : '';
+    '-' + ScriptTarget[scriptTargetOverride].toLowerCase() : '';
 }

--- a/packages/angular_devkit/build_angular/src/browser/index.ts
+++ b/packages/angular_devkit/build_angular/src/browser/index.ts
@@ -27,7 +27,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { from, of } from 'rxjs';
 import { bufferCount, catchError, concatMap, map, mergeScan, switchMap } from 'rxjs/operators';
-import * as ts from 'typescript';
+import { ScriptTarget } from 'typescript';
 import * as webpack from 'webpack';
 import { NgBuildAnalyticsPlugin } from '../../plugins/webpack/analytics';
 import { WebpackConfigOptions } from '../angular-cli-files/models/build-options';
@@ -194,8 +194,8 @@ export function buildWebpackBrowser(
       const tsConfig = readTsconfig(tsConfigPath);
 
       if (isEs5SupportNeeded(projectRoot) &&
-          tsConfig.options.target !== ts.ScriptTarget.ES5 &&
-          tsConfig.options.target !== ts.ScriptTarget.ES2015) {
+          tsConfig.options.target !== ScriptTarget.ES5 &&
+          tsConfig.options.target !== ScriptTarget.ES2015) {
         context.logger.warn(tags.stripIndent`
           WARNING: Using differential loading with targets ES5 and ES2016 or higher may
           cause problems. Browsers with support for ES2015 will load the ES2016+ scripts

--- a/packages/angular_devkit/build_angular/src/tslint/index.ts
+++ b/packages/angular_devkit/build_angular/src/tslint/index.ts
@@ -12,7 +12,7 @@ import * as glob from 'glob';
 import { Minimatch } from 'minimatch';
 import * as path from 'path';
 import * as tslint from 'tslint'; // tslint:disable-line:no-implicit-dependencies
-import * as ts from 'typescript'; // tslint:disable-line:no-implicit-dependencies
+import { Program } from 'typescript';
 import { stripBom } from '../angular-cli-files/utilities/strip-bom';
 import { Schema as RealTslintBuilderOptions } from './schema';
 
@@ -153,8 +153,8 @@ async function _lint(
   systemRoot: string,
   tslintConfigPath: string | null,
   options: TslintBuilderOptions,
-  program?: ts.Program,
-  allPrograms?: ts.Program[],
+  program?: Program,
+  allPrograms?: Program[],
 ): Promise<LintResult> {
   const Linter = projectTslint.Linter;
   const Configuration = projectTslint.Configuration;
@@ -210,7 +210,7 @@ function getFilesToLint(
   root: string,
   options: TslintBuilderOptions,
   linter: typeof tslint.Linter,
-  program?: ts.Program,
+  program?: Program,
 ): string[] {
   const ignore = options.exclude;
   const files = options.files || [];

--- a/packages/angular_devkit/build_angular/src/utils/differential-loading.ts
+++ b/packages/angular_devkit/build_angular/src/utils/differential-loading.ts
@@ -8,14 +8,14 @@
 
 import * as browserslist from 'browserslist';
 import * as caniuse from 'caniuse-api';
-import * as ts from 'typescript';
+import { ScriptTarget } from 'typescript';
 
 
 export function isDifferentialLoadingNeeded(
   projectRoot: string,
-  target: ts.ScriptTarget = ts.ScriptTarget.ES5): boolean {
+  target: ScriptTarget = ScriptTarget.ES5): boolean {
 
-  const supportES2015 = target !== ts.ScriptTarget.ES3 && target !== ts.ScriptTarget.ES5;
+  const supportES2015 = target !== ScriptTarget.ES3 && target !== ScriptTarget.ES5;
 
   return supportES2015 && isEs5SupportNeeded(projectRoot);
 }

--- a/tests/legacy-cli/e2e/tests/basic/update-7.0.ts
+++ b/tests/legacy-cli/e2e/tests/basic/update-7.0.ts
@@ -8,7 +8,7 @@ import { expectToFail } from '../../utils/utils';
 
 
 export default async function () {
-  const extraUpdateArgs = await isPrereleaseCli() ? ['--next', '--force'] : [];
+  const extraUpdateArgs = await isPrereleaseCli() ? ['--next'] : [];
 
   // Create new project from previous version files.
   // We must use the original NPM packages to force a real update.


### PR DESCRIPTION
We only use it for a few things but have a strict peerdep.

This strictness causes errors when updating the CLI from 7.x to 8.x projects:
```
Package "@angular/compiler-cli" has an incompatible peer dependency to "typescript" (requires ">=3.1.1 <3.2", would install "3.4.5").
```
`build-angular` did not have a peerdep in 7.x so this never was a problem.

This PR relaxes the peerdep to `">=3.1 < 3.5"`, which covers the 3.1 used in initial CLI 7.0 projects.