### PR TITLE
Fixes to serve path

### DIFF
--- a/packages/angular_devkit/build_angular/src/dev-server/index.ts
+++ b/packages/angular_devkit/build_angular/src/dev-server/index.ts
@@ -107,6 +107,12 @@ export function serveWebpackBrowser(
     // In dev server we should not have budgets because of extra libs such as socks-js
     overrides.budgets = undefined;
 
+    // When having a serve path we need to change the
+    // baseHref from '/' as otherwise resources won't be found.
+    if (options.servePath && !(rawBrowserOptions.baseHref || options.baseHref)) {
+      overrides.baseHref = '';
+    }
+
     const browserName = await context.getBuilderNameForTarget(browserTarget);
     const browserOptions = await context.validateOptions<json.JsonObject & BrowserBuilderSchema>(
       { ...rawBrowserOptions, ...overrides },
@@ -276,7 +282,7 @@ export function buildServerConfig(
     },
     public: serverOptions.publicHost,
     disableHostCheck: serverOptions.disableHostCheck,
-    publicPath: servePath,
+    publicPath: servePath.endsWith('/') ? servePath : `${servePath}/`,
     hot: serverOptions.hmr,
     contentBase: false,
   };

--- a/packages/angular_devkit/build_angular/src/protractor/index.ts
+++ b/packages/angular_devkit/build_angular/src/protractor/index.ts
@@ -130,9 +130,16 @@ async function execute(
       const clientUrl = url.parse(publicHost);
       baseUrl = url.format(clientUrl);
     } else if (typeof result.port === 'number') {
+      let pathname = undefined;
+      if (typeof serverOptions.servePath === 'string') {
+        pathname = serverOptions.servePath;
+        pathname = pathname.endsWith('/') ? pathname : `${pathname}/`;
+      }
+
       baseUrl = url.format({
         protocol: serverOptions.ssl ? 'https' : 'http',
         hostname: options.host,
+        pathname,
         port: result.port.toString(),
       });
     }

--- a/packages/angular_devkit/build_angular/test/dev-server/deploy-url_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/dev-server/deploy-url_spec_large.ts
@@ -31,9 +31,9 @@ describe('Dev Server Deploy Url', () => {
     runs.push(run);
     const output = await run.result as DevServerBuilderOutput;
     expect(output.success).toBe(true);
-    expect(output.baseUrl).toBe('http://localhost:4200/test');
+    expect(output.baseUrl).toBe('http://localhost:4200/test/');
 
-    const response = await fetch(`${output.baseUrl}/polyfills.js`);
+    const response = await fetch(`${output.baseUrl}polyfills.js`);
     expect(await response.text()).toContain('window["webpackJsonp"]');
   }, 30000);
 });

--- a/packages/angular_devkit/build_angular/test/dev-server/serve-path_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/dev-server/serve-path_spec_large.ts
@@ -32,9 +32,9 @@ describe('Dev Server Builder serve path', () => {
     runs.push(run);
     const output = await run.result as DevServerBuilderOutput;
     expect(output.success).toBe(true);
-    expect(output.baseUrl).toBe('http://localhost:4200/test');
+    expect(output.baseUrl).toBe('http://localhost:4200/test/');
 
-    const response = await fetch(`${output.baseUrl}/polyfills.js`);
+    const response = await fetch(`${output.baseUrl}polyfills.js`);
     expect(await response.text()).toContain('window["webpackJsonp"]');
   }, 30000);
 });

--- a/tests/legacy-cli/e2e/tests/commands/e2e/serve-path.ts
+++ b/tests/legacy-cli/e2e/tests/commands/e2e/serve-path.ts
@@ -1,0 +1,15 @@
+import { killAllProcesses, ng } from '../../../utils/process';
+import { updateJsonFile } from '../../../utils/project';
+
+export default async function () {
+  try {
+    await updateJsonFile('angular.json', workspaceJson => {
+      const appArchitect = workspaceJson.projects['test-project'].architect;
+      appArchitect.serve.options.servePath = 'test/';
+    });
+
+    await ng('e2e');
+  } finally {
+    await killAllProcesses();
+  }
+}


### PR DESCRIPTION
fix(@angular-devkit/build-angular): using `servePath` results in resources not being found

At the moment the default baseHref is `/`, which means resources won't be found when using the `servePath`. Because the later only effect the serving of the file and doesn't change the paths in the script tag (rightly so). However having the baseHref as `/` will cause the resources to be loaded from root.


fix(@angular-devkit/build-angular): `servePath` is not respected in protractor
