### PR TITLE
Protractor builder should use dev server supplied baseUrl when available

### DIFF
--- a/packages/angular_devkit/build_angular/src/protractor/index.ts
+++ b/packages/angular_devkit/build_angular/src/protractor/index.ts
@@ -140,6 +140,8 @@ async function execute(
       }
       const clientUrl = url.parse(publicHost);
       baseUrl = url.format(clientUrl);
+    } else if (typeof result.baseUrl === 'string') {
+      baseUrl = result.baseUrl;
     } else if (typeof result.port === 'number') {
       baseUrl = url.format({
         protocol: serverOptions.ssl ? 'https' : 'http',

--- a/packages/angular_devkit/build_angular/test/protractor/works_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/protractor/works_spec_large.ts
@@ -81,4 +81,20 @@ describe('Protractor Builder', () => {
     await run.stop();
   }, 30000);
 
+  it('supports dev server builder with browser builder base HREF option', async () => {
+    host.replaceInFile(
+      'angular.json',
+      '"main": "src/main.ts",',
+      '"main": "src/main.ts", "baseHref": "/base/",',
+    );
+    // Need to reset architect to use the modified config
+    architect = (await createArchitect(host.root())).architect;
+
+    const run = await architect.scheduleTarget(protractorTargetSpec);
+
+    await expectAsync(run.result).toBeResolvedTo(jasmine.objectContaining({ success: true }));
+
+    await run.stop();
+  }, 30000);
+
 });


### PR DESCRIPTION
The Angular dev server builder provides a full URL accounting for the deploy URL, base HREF, and serve path options in its result output.  This provides the necessary information for protractor to properly connect in the even any of those options are used.

The dev serve was also not properly accounting for dynamic ports (port = 0) within the result output base URL.  This has also been corrected.