### PR TITLE
fix(@angular-devkit/build-angular): stop dev server fallback outside of serve path

### DIFF
--- a/packages/angular_devkit/build_angular/src/dev-server/index.ts
+++ b/packages/angular_devkit/build_angular/src/dev-server/index.ts
@@ -259,10 +259,16 @@ export function buildServerConfig(
     host: serverOptions.host,
     port: serverOptions.port,
     headers: { 'Access-Control-Allow-Origin': '*' },
-    historyApiFallback: {
+    historyApiFallback: !!browserOptions.index && {
       index: `${servePath}/${path.basename(browserOptions.index)}`,
       disableDotRule: true,
       htmlAcceptHeaders: ['text/html', 'application/xhtml+xml'],
+      rewrites: [
+        {
+          from: new RegExp(`^(?!${servePath})/.*`),
+          to: context => url.format(context.parsedUrl),
+        },
+      ],
     } as WebpackDevServer.HistoryApiFallbackConfig,
     stats: false,
     compress: styles || scripts,


### PR DESCRIPTION
The serve path represents the base of the application.  Accessing a different path (`/api/` for instance) should not cause the application to load if the application's base is `/test/`