### PR TITLE
fix(@angular-devkit/core): remove unimplemented prompt priority

### DIFF
--- a/etc/api/angular_devkit/core/src/_golden-api.d.ts
+++ b/etc/api/angular_devkit/core/src/_golden-api.d.ts
@@ -796,7 +796,6 @@ export interface PromptDefinition {
     }>;
     message: string;
     multiselect?: boolean;
-    priority: number;
     raw?: string | JsonObject;
     type: string;
     validator?: (value: string) => boolean | string | Promise<boolean | string>;

--- a/packages/angular_devkit/core/src/json/schema/interface.ts
+++ b/packages/angular_devkit/core/src/json/schema/interface.ts
@@ -100,7 +100,6 @@ export interface PromptDefinition {
   type: string;
   message: string;
   default?: string | string[] | number | boolean | null;
-  priority: number;
   validator?: (value: string) => boolean | string | Promise<boolean | string>;
 
   items?: Array<string | { value: JsonValue, label: string }>;

--- a/packages/angular_devkit/core/src/json/schema/registry.ts
+++ b/packages/angular_devkit/core/src/json/schema/registry.ts
@@ -569,7 +569,6 @@ export class CoreSchemaRegistry implements SchemaRegistry {
           id: path,
           type,
           message,
-          priority: 0,
           raw: schema,
           items,
           multiselect: type === 'list' ? schema.multiselect : false,
@@ -624,8 +623,6 @@ export class CoreSchemaRegistry implements SchemaRegistry {
     if (!provider) {
       return of(data);
     }
-
-    prompts.sort((a, b) => b.priority - a.priority);
 
     return from(provider(prompts)).pipe(
       map(answers => {


### PR DESCRIPTION
Node.js versions prior to 11 used an unstable sort for arrays with a length greater than 10.  This caused the prompt order of a schematic with more than 10 prompts to be inconsistent with the content of the file and the same schematic with several of the prompts removed.  Since priorities were never fully implemented and property dependencies will most likely be used at a higher level instead, the underlying elements have been removed with this change.

Fixes #14402