### PR TITLE
fix(@schematics/angular): differential loading migration should run o…

### DIFF
--- a/packages/schematics/angular/migrations/update-8/differential-loading.ts
+++ b/packages/schematics/angular/migrations/update-8/differential-loading.ts
@@ -97,20 +97,26 @@ function updateProjects(): Rule {
       }
 
       // Older projects app and spec ts configs had script and module set in them.
-      const tsConfigs = [];
       const architect = project.architect;
-      if (isJsonObject(architect)
+      if (!(isJsonObject(architect)
         && isJsonObject(architect.build)
-        && isJsonObject(architect.build.options)
-        && typeof architect.build.options.tsConfig === 'string') {
-        tsConfigs.push(architect.build.options.tsConfig);
+        && architect.build.builder === '@angular-devkit/build-angular:browser')
+      ) {
+        // Skip projects who's build builder is not build-angular:browser
+        continue;
       }
 
-      if (isJsonObject(architect)
-        && isJsonObject(architect.test)
-        && isJsonObject(architect.test.options)
-        && typeof architect.test.options.tsConfig === 'string') {
-        tsConfigs.push(architect.test.options.tsConfig);
+      const tsConfigs = [];
+      const buildOptionsConfig = architect.build.options;
+      if (isJsonObject(buildOptionsConfig) && typeof buildOptionsConfig.tsConfig === 'string') {
+        tsConfigs.push(buildOptionsConfig.tsConfig);
+      }
+
+      const testConfig = architect.test;
+      if (isJsonObject(testConfig)
+        && isJsonObject(testConfig.options)
+        && typeof testConfig.options.tsConfig === 'string') {
+        tsConfigs.push(testConfig.options.tsConfig);
       }
 
       for (const tsConfig of tsConfigs) {

--- a/packages/schematics/angular/migrations/update-8/differential-loading_spec.ts
+++ b/packages/schematics/angular/migrations/update-8/differential-loading_spec.ts
@@ -113,5 +113,19 @@ describe('Migration to version 8', () => {
       expect(specsCompilerOptions.target).toBeUndefined();
       expect(specsCompilerOptions.module).toBeUndefined();
     });
+
+    it(`should not update projects which browser builder is not 'build-angular:browser'`, () => {
+      tree.delete('/browserslist');
+      const config = JSON.parse(tree.readContent('angular.json'));
+      config
+        .projects['migration-test']
+        .architect
+        .build
+        .builder = '@dummy/builders:browser';
+
+      tree.overwrite('angular.json', JSON.stringify(config));
+      const tree2 = schematicRunner.runSchematic('migration-07', {}, tree.branch());
+      expect(tree2.exists('/browserslist')).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
…nly for projects using `@angular-devkit/build-angular:browser`

Differential loading migration should run only when the project is using `@angular-devkit/build-angular:browser` as it's browser builder. Otherwise we might break applications that are using different builders.

Fixes #14389