### PR TITLE
Deprecate redundant isObservable function

### DIFF
--- a/packages/angular_devkit/core/src/json/schema/registry.ts
+++ b/packages/angular_devkit/core/src/json/schema/registry.ts
@@ -7,11 +7,11 @@
  */
 import * as ajv from 'ajv';
 import * as http from 'http';
-import { Observable, from, of, throwError } from 'rxjs';
+import { Observable, from, isObservable, of, throwError } from 'rxjs';
 import { concatMap, map, switchMap, tap } from 'rxjs/operators';
 import * as Url from 'url';
 import { BaseException } from '../../exception/exception';
-import { PartiallyOrderedSet, deepCopy, isObservable } from '../../utils';
+import { PartiallyOrderedSet, deepCopy } from '../../utils';
 import { JsonArray, JsonObject, JsonValue, isJsonObject } from '../interface';
 import {
   JsonPointer,

--- a/packages/angular_devkit/core/src/json/schema/visitor.ts
+++ b/packages/angular_devkit/core/src/json/schema/visitor.ts
@@ -5,14 +5,12 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import { Observable, concat, from, of as observableOf } from 'rxjs';
+import { Observable, concat, from, isObservable, of as observableOf } from 'rxjs';
 import { concatMap, ignoreElements, mergeMap, tap } from 'rxjs/operators';
-import { isObservable } from '../../utils';
 import { JsonArray, JsonObject, JsonValue } from '../interface';
 import { JsonPointer, JsonSchemaVisitor, JsonVisitor } from './interface';
 import { buildJsonPointer, joinJsonPointer } from './pointer';
 import { JsonSchema } from './schema';
-
 
 export interface ReferenceResolver<ContextT> {
   (ref: string, context?: ContextT): { context?: ContextT, schema?: JsonObject };
@@ -70,11 +68,8 @@ function _visitJsonRecursive<ContextT>(
 
   const value = visitor(json, ptr, schema, root);
 
-  return (isObservable(value)
-      ? value as Observable<JsonValue>
-      : observableOf(value as JsonValue)
-  ).pipe(
-    concatMap((value: JsonValue) => {
+  return (isObservable<JsonValue>(value) ? value : observableOf(value)).pipe(
+    concatMap(value => {
       if (Array.isArray(value)) {
         return concat(
           from(value).pipe(

--- a/packages/angular_devkit/core/src/utils/lang.ts
+++ b/packages/angular_devkit/core/src/utils/lang.ts
@@ -20,6 +20,7 @@ export function isPromise(obj: any): obj is Promise<any> {
 
 /**
  * Determine if the argument is an Observable
+ * @deprecated as of 8.0; use rxjs' built-in version
  */
 // tslint:disable-next-line:no-any
 export function isObservable(obj: any | Observable<any>): obj is Observable<any> {

--- a/packages/angular_devkit/schematics/tools/file-system-engine-host-base.ts
+++ b/packages/angular_devkit/schematics/tools/file-system-engine-host-base.ts
@@ -10,7 +10,6 @@ import {
   InvalidJsonCharacterException,
   JsonObject,
   UnexpectedEndOfInputException,
-  isObservable,
   isPromise,
   normalize,
   virtualFs,
@@ -21,6 +20,7 @@ import { dirname, isAbsolute, join, resolve } from 'path';
 import {
   Observable,
   from as observableFrom,
+  isObservable,
   of as observableOf,
   throwError,
 } from 'rxjs';


### PR DESCRIPTION
rxjs provides a canonical version of the helper function.  Internal usage has also been changed to use this version.