### PR TITLE
fix(@angular/cli): @bazel/* are not shown in `ng version`

### DIFF
--- a/packages/angular/cli/commands/version-impl.ts
+++ b/packages/angular/cli/commands/version-impl.ts
@@ -29,6 +29,7 @@ export class VersionCommand extends Command<VersionCommandSchema> {
     const patterns = [
       /^@angular\/.*/,
       /^@angular-devkit\/.*/,
+      /^@bazel\/.*/,
       /^@ngtools\/.*/,
       /^@nguniversal\/.*/,
       /^@schematics\/.*/,


### PR DESCRIPTION
Update `ng version` to show versions for @bazel/* packages to help users
report meaningful errors when they opt in to Bazel.