### PR TITLE
refactor(@schematics/angular): optimize insertAfterLastOccurrence AST util

### DIFF
--- a/packages/schematics/angular/utility/ast-utils.ts
+++ b/packages/schematics/angular/utility/ast-utils.ts
@@ -189,8 +189,12 @@ export function insertAfterLastOccurrence(nodes: ts.Node[],
                                           file: string,
                                           fallbackPos: number,
                                           syntaxKind?: ts.SyntaxKind): Change {
-  // sort() has a side effect, so make a copy so that we won't overwrite the parent's object.
-  let lastItem = [...nodes].sort(nodesByPosition).pop();
+  let lastItem: ts.Node | undefined;
+  for (const node of nodes) {
+    if (!lastItem || lastItem.getStart() < node.getStart()) {
+      lastItem = node;
+    }
+  }
   if (syntaxKind && lastItem) {
     lastItem = findNodes(lastItem, syntaxKind).sort(nodesByPosition).pop();
   }


### PR DESCRIPTION
The change was suggested by @clydin (ref: https://github.com/angular/angular-cli/pull/14329#discussion_r282095904)

Eliminates the need of array creation (copying) and sorting when determining the last node in the provided `nodes: ts.Node[]` argument of the `insertAfterLastOccurrence` AST util.