### PR TITLE
fix for #14457 - fix(@angular-devkit/build-angular): normalize sourceMap options in ka…

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/karma.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/karma.ts
@@ -19,6 +19,7 @@ import { getWebpackStatsConfig } from '../models/webpack-configs/stats';
 import { createConsoleLogger } from '@angular-devkit/core/node';
 import { logging } from '@angular-devkit/core';
 import { WebpackTestOptions } from '../models/build-options';
+import { normalizeSourceMaps } from '../../utils/index';
 
 /**
  * Enumerate needed (but not require/imported) dependencies from this file
@@ -78,7 +79,7 @@ const init: any = (config: any, emitter: any, customFileHandlers: any) => {
   }
 
   // Add a reporter that fixes sourcemap urls.
-  if (options.sourceMap.scripts) {
+  if (normalizeSourceMaps(options.sourceMap).scripts) {
     config.reporters.unshift('@angular-devkit/build-angular--sourcemap-reporter');
 
     // Code taken from https://github.com/tschaub/karma-source-map-support.

--- a/tests/legacy-cli/e2e/tests/test/test-sourcemap.ts
+++ b/tests/legacy-cli/e2e/tests/test/test-sourcemap.ts
@@ -1,8 +1,14 @@
 import { writeFile } from '../../utils/fs';
-import { execAndWaitForOutputToMatch, killAllProcesses } from '../../utils/process';
+import { ng } from '../../utils/process';
 import { updateJsonFile } from '../../utils/project';
 
 export default async function () {
+  await writeFile('src/app/app.component.spec.ts', `
+      it('show fail', () => {
+        expect(undefined).toBeTruthy();
+      });
+    `);
+
   await updateJsonFile('angular.json', configJson => {
     const appArchitect = configJson.projects['test-project'].architect;
     appArchitect.test.options.sourceMap = {
@@ -10,20 +16,43 @@ export default async function () {
     };
   });
 
-  await writeFile('src/app/app.component.spec.ts', `
-      it('show fail', () => {
-        expect(undefined).toBeTruthy();
-      });
-    `);
-
-  // when sourcemaps are not working the stacktrace won't point to the spec.ts file.
+  // when sourcemaps are 'on' the stacktrace will point to the spec.ts file.
   try {
-    await execAndWaitForOutputToMatch(
-      'ng',
-      ['test', '--watch', 'false'],
-      /app\.component\.spec\.ts/,
-    );
-  } finally {
-    killAllProcesses();
+    await ng('test', '--watch', 'false');
+    throw new Error('ng test should have failed.');
+  } catch (error) {
+    if (!error.message.includes('app.component.spec.ts')) {
+      throw error;
+    };
+  }
+
+  await updateJsonFile('angular.json', configJson => {
+    const appArchitect = configJson.projects['test-project'].architect;
+    appArchitect.test.options.sourceMap = true;
+  });
+
+  // when sourcemaps are 'on' the stacktrace will point to the spec.ts file.
+  try {
+    await ng('test', '--watch', 'false');
+    throw new Error('ng test should have failed.');
+  } catch (error) {
+    if (!error.message.includes('app.component.spec.ts')) {
+      throw error;
+    };
+  }
+
+  await updateJsonFile('angular.json', configJson => {
+    const appArchitect = configJson.projects['test-project'].architect;
+    appArchitect.test.options.sourceMap = false;
+  });
+
+  // when sourcemaps are 'off' the stacktrace won't point to the spec.ts file.
+  try {
+    await ng('test', '--watch', 'false');
+    throw new Error('ng test should have failed.');
+  } catch (error) {
+    if (!error.message.includes('main.js')) {
+      throw error;
+    };
   }
 }


### PR DESCRIPTION
…rma webpack plugin

`sourceMap` option can be either a boolean or an object,we need to normalize it before trying to get the `script` value.

Fixes #14457