### PR TITLE
ci: trim the appveyor tests

### DIFF
--- a/appveyor-e2e.bat
+++ b/appveyor-e2e.bat
@@ -2,7 +2,7 @@
 IF not defined APPVEYOR_PULL_REQUEST_NUMBER (
   IF not defined BUILDKITE_PULL_REQUEST (
     REM Run full test suite if not on a Appveyor/Buildkite PR.
-    node tests\legacy-cli\run_e2e.js --appveyor "--glob=tests/{basic,commands,generate,build/styles,ivy}/**"
+    node tests\legacy-cli\run_e2e.js --appveyor "--glob=tests/{basic,commands,generate,ivy}/**"
     exit
   )
 ) 


### PR DESCRIPTION
Removing the `build/styles` tests because they can take a while and others are more important.

Fix #14451