### PR TITLE
fix(docs): don't reference next.angular.io

### DIFF
--- a/docs/documentation/stories/multiple-projects.md
+++ b/docs/documentation/stories/multiple-projects.md
@@ -1,4 +1,4 @@
-**Documentation below is deprecated and we no longer accept PRs to improve this. The new documentation is available [here](https://next.angular.io/guide/build)**.
+**Documentation below is deprecated and we no longer accept PRs to improve this. The new documentation is available [here](https://angular.io/guide/build)**.
 
 # Multiple Projects
 

--- a/docs/documentation/stories/third-party-lib.md
+++ b/docs/documentation/stories/third-party-lib.md
@@ -1,4 +1,4 @@
-**Documentation below is deprecated and we no longer accept PRs to improve this. The new documentation is available [here](https://next.angular.io/guide/build)**.
+**Documentation below is deprecated and we no longer accept PRs to improve this. The new documentation is available [here](https://angular.io/guide/build)**.
 
 # 3rd Party Library Installation
 

--- a/packages/angular/cli/commands/analytics.json
+++ b/packages/angular/cli/commands/analytics.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/schema",
   "$id": "ng-cli://commands/analytics.json",
-  "description": "Configures the gathering of Angular CLI usage metrics. See https://next.angular.io/cli/usage-analytics-gathering.",
+  "description": "Configures the gathering of Angular CLI usage metrics. See https://v8.angular.io/cli/usage-analytics-gathering.",
   "$longDescription": "",
 
   "$aliases": [],

--- a/packages/ngtools/webpack/src/transformers/import_factory.ts
+++ b/packages/ngtools/webpack/src/transformers/import_factory.ts
@@ -66,7 +66,7 @@ loadChildren: () => import('IMPORT_STRING').then(M => M.EXPORT_NAME)
 
 Please note that only IMPORT_STRING, M, and EXPORT_NAME can be replaced in this format.
 
-Visit https://next.angular.io/guide/ivy for more information on using Ivy.
+Visit https://v8.angular.io/guide/ivy for more information on using Ivy.
 `;
 
       const emitWarning = () => warningCb(warning);


### PR DESCRIPTION
When we cut a release, this moves to angular.io.
Use v8.angular.io in places where angular.io is currently a 404.

Fixes https://github.com/angular/angular/issues/30407