### PR TITLE
fix(@angular/cli): show error when using x18n command on Node.js 12.0

### DIFF
--- a/packages/angular/cli/commands/xi18n-impl.ts
+++ b/packages/angular/cli/commands/xi18n-impl.ts
@@ -15,6 +15,15 @@ export class Xi18nCommand extends ArchitectCommand<Xi18nCommandSchema> {
   public readonly multiTarget: true;
 
   public async run(options: Xi18nCommandSchema & Arguments) {
+    const version = process.version.substr(1).split('.');
+    if (Number(version[0]) === 12 && Number(version[1]) === 0) {
+      this.logger.error(
+        'Due to a defect in Node.js 12.0, the command is not supported on this Node.js version. '
+        + 'Please upgrade to Node.js 12.1 or later.');
+
+      return 1;
+    }
+
     return this.runArchitectTarget(options);
   }
 }


### PR DESCRIPTION
Node.js 12.0 contains a defect which will cause the command to crash.  This is due to the locale support in Node.js 12.0 (ICU).  ref: https://github.com/nodejs/node/issues/27379

Related: #14351