### PR TITLE
docs: update project description to full application instead of app

### DIFF
--- a/packages/angular/cli/commands/definitions.json
+++ b/packages/angular/cli/commands/definitions.json
@@ -7,7 +7,7 @@
       "properties": {
         "project": {
           "type": "string",
-          "description": "The name of the project to build. Can be an app or a library.",
+          "description": "The name of the project to build. Can be an application or a library.",
           "$default": {
             "$source": "argv",
             "index": 0


### PR DESCRIPTION
Use full word instead of an acronym 