### PR TITLE
fix(@angular/core): properly replace an added value in workspace API

### DIFF
--- a/packages/angular_devkit/core/src/workspace/json/metadata.ts
+++ b/packages/angular_devkit/core/src/workspace/json/metadata.ts
@@ -60,6 +60,9 @@ export class JsonWorkspaceMetadata {
       for (let i = this.changes.length - 1; i >= 0; --i) {
         const currentPath = this.changes[i].path;
         if (currentPath === path || currentPath.startsWith(path + '/')) {
+          if (op === 'replace' && currentPath === path && this.changes[i].op === 'add') {
+            op = 'add';
+          }
           this.changes.splice(i, 1);
         }
       }


### PR DESCRIPTION
Replacing a previous added value in the same session should cause the replace operation to become an add operation with the original add operation elided.