### PR TITLE
fix(@schematics/angular): handle newline after `@` of a decorator

### DIFF
--- a/packages/schematics/angular/utility/ast-utils.ts
+++ b/packages/schematics/angular/utility/ast-utils.ts
@@ -290,8 +290,7 @@ export function getDecoratorMetadata(source: ts.SourceFile, identifier: string,
       if (expr.expression.kind == ts.SyntaxKind.Identifier) {
         const id = expr.expression as ts.Identifier;
 
-        return id.getFullText(source) == identifier
-          && angularImports[id.getFullText(source)] === module;
+        return id.text == identifier && angularImports[id.text] === module;
       } else if (expr.expression.kind == ts.SyntaxKind.PropertyAccessExpression) {
         // This covers foo.NgModule when importing * as foo.
         const paExpr = expr.expression as ts.PropertyAccessExpression;
@@ -301,7 +300,7 @@ export function getDecoratorMetadata(source: ts.SourceFile, identifier: string,
         }
 
         const id = paExpr.name.text;
-        const moduleId = (paExpr.expression as ts.Identifier).getText(source);
+        const moduleId = (paExpr.expression as ts.Identifier).text;
 
         return id === identifier && (angularImports[moduleId + '.'] === module);
       }

--- a/packages/schematics/angular/utility/ast-utils_spec.ts
+++ b/packages/schematics/angular/utility/ast-utils_spec.ts
@@ -169,6 +169,22 @@ describe('ast utils', () => {
     expect(output).toMatch(/imports: \[HelloWorld],\r?\n/m);
   });
 
+  it(`should handle NgModule with newline after '@'`, () => {
+    const moduleContent = `
+      import { BrowserModule } from '@angular/platform-browser';
+      import { NgModule } from '@angular/core';
+
+      @
+      NgModule({imports: [BrowserModule], declarations: []})
+      export class AppModule { }
+    `;
+    const source = getTsSource(modulePath, moduleContent);
+    const changes = addExportToModule(source, modulePath, 'FooComponent', './foo.component');
+    const output = applyChanges(modulePath, moduleContent, changes);
+    expect(output).toMatch(/import { FooComponent } from '.\/foo.component';/);
+    expect(output).toMatch(/exports: \[FooComponent\]/);
+  });
+
   it('should handle NgModule with no newlines', () => {
     const moduleContent = `
       import { BrowserModule } from '@angular/platform-browser';


### PR DESCRIPTION
Fixes #14490