### PR TITLE
Differentiate lib build from app build in reference doc

### DIFF
--- a/packages/angular/cli/commands/build-long.md
+++ b/packages/angular/cli/commands/build-long.md
@@ -1,14 +1,18 @@
-Uses the [webpack](https://webpack.js.org/) build tool, with default configuration options specified in the workspace configuration file (`angular.json`) or with a named alternative configuration. 
-A "production" configuration is created by default when you use the CLI to create the project, and you can use that configuration by specifying the `--prod` option.
+The command can be used to build a project of type "application" or "library".
+When used to build a library, a different builder is invoked, and only the `ts-config`, `configuration`, and `watch` options are applied.
+All other options apply only to building applications.
+
+The application builder uses the [webpack](https://webpack.js.org/) build tool, with default configuration options specified in the workspace configuration file (`angular.json`) or with a named alternative configuration.
+A "production" configuration is created by default when you use the CLI to create the project, and you can use that configuration by specifying the `--configuration="production"` or the `--prod="true"` option.
 
 The configuration options generally correspond to the command options.
-You can override individual configuration defaults by specifying the corresponding options on the command line. 
+You can override individual configuration defaults by specifying the corresponding options on the command line.
 The command can accept option names given in either dash-case or camelCase.
 Note that in the configuration file, you must specify names in camelCase.
 
 Some additional options can only be set through the configuration file,
 either by direct editing or with the `ng config` command.
-These include `assets`, `styles`, and `scripts` objects that provide runtime-global resources to include in the project. 
+These include `assets`, `styles`, and `scripts` objects that provide runtime-global resources to include in the project.
 Resources in CSS, such as images and fonts, are automatically written and fingerprinted at the root of the output folder.
 
 For further details, see [Workspace Configuration](guide/workspace-config).

--- a/packages/angular_devkit/build_ng_packagr/src/build/schema.json
+++ b/packages/angular_devkit/build_ng_packagr/src/build/schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "title": "ng-packagr Target",
-  "description": "ng-packagr target options for Build Architect.",
+  "description": "ng-packagr target options for Build Architect. Use to build library projects.",
   "type": "object",
   "properties": {
     "project": {
@@ -10,11 +10,11 @@
     },
     "tsConfig": {
       "type": "string",
-      "description": "The full path for the TypeScript configuration file, relative to the current workspace. Applies to both libraries and applications."
+      "description": "The full path for the TypeScript configuration file, relative to the current workspace."
     },
     "watch": {
       "type": "boolean",
-      "description": "Run build when files change. Applies to both libraries and applications.",
+      "description": "Run build when files change.",
       "default": false
     }
   },

--- a/packages/angular_devkit/build_ng_packagr/src/build/schema.json
+++ b/packages/angular_devkit/build_ng_packagr/src/build/schema.json
@@ -10,11 +10,11 @@
     },
     "tsConfig": {
       "type": "string",
-      "description": "The file path of the TypeScript configuration file."
+      "description": "The full path for the TypeScript configuration file, relative to the current workspace. Applies to both libraries and applications."
     },
     "watch": {
       "type": "boolean",
-      "description": "Run build when files change.",
+      "description": "Run build when files change. Applies to both libraries and applications.",
       "default": false
     }
   },


### PR DESCRIPTION
Explain that `ng build` command invokes different builders for apps and libs, and that only two options apply to libs.
Issue https://github.com/angular/angular/issues/26569

This is a stop-gap doc fix - it points out that `ng build app-project` uses a different builder than `ng build lib-project`, and that most options doc'd here apply only to apps. This can keep readers from trying to apply options to libs, but we really need a separate doc page for the lib builder.