### PR TITLE
add missing npmignore in schematics example

### DIFF
--- a/packages/schematics/schematics/schematic/files/__dot__npmignore
+++ b/packages/schematics/schematics/schematic/files/__dot__npmignore
@@ -1,0 +1,3 @@
+# Ignores TypeScript files, but keeps definitions.
+*.ts
+!*.d.ts


### PR DESCRIPTION
Hi!
I tried schematics examples.

In the example of `schematic`, js file was not included in the npm package by published referring to this [README.md](https://github.com/angular/angular-cli/tree/master/packages/schematics/schematics/schematic/files).

 Therefore, I added npmignore referring to the example of `blank`.

