### PR TITLE
fix(@angular/cli): ng generate --help shows the wrong collection

### DIFF
--- a/packages/angular/cli/commands/generate-impl.ts
+++ b/packages/angular/cli/commands/generate-impl.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-// tslint:disable:no-global-tslint-disable no-any
 import { terminal } from '@angular-devkit/core';
 import { Arguments, SubCommandDescription } from '../models/interface';
 import { SchematicCommand } from '../models/schematic-command';
@@ -18,10 +17,12 @@ export class GenerateCommand extends SchematicCommand<GenerateCommandSchema> {
   longSchematicName: string|undefined;
 
   async initialize(options: GenerateCommandSchema & Arguments) {
-    await super.initialize(options);
-
     // Fill up the schematics property of the command description.
     const [collectionName, schematicName] = this.parseSchematicInfo(options);
+    this.collectionName = collectionName;
+    this.schematicName = schematicName;
+
+    await super.initialize(options);
 
     const collection = this.getCollection(collectionName);
     const subcommands: { [name: string]: SubCommandDescription } = {};
@@ -60,15 +61,13 @@ export class GenerateCommand extends SchematicCommand<GenerateCommandSchema> {
   }
 
   public async run(options: GenerateCommandSchema & Arguments) {
-    const [collectionName, schematicName] = this.parseSchematicInfo(options);
-
-    if (!schematicName || !collectionName) {
+    if (!this.schematicName || !this.collectionName) {
       return this.printHelp(options);
     }
 
     return this.runSchematic({
-      collectionName,
-      schematicName,
+      collectionName: this.collectionName,
+      schematicName: this.schematicName,
       schematicOptions: options['--'] || [],
       debug: !!options.debug || false,
       dryRun: !!options.dryRun || false,

--- a/packages/angular/cli/commands/new-impl.ts
+++ b/packages/angular/cli/commands/new-impl.ts
@@ -16,14 +16,17 @@ export class NewCommand extends SchematicCommand<NewCommandSchema> {
   public readonly allowMissingWorkspace = true;
   schematicName = 'ng-new';
 
-  public async run(options: NewCommandSchema & Arguments) {
-    let collectionName: string;
+  async initialize(options: NewCommandSchema & Arguments) {
     if (options.collection) {
-      collectionName = options.collection;
+      this.collectionName = options.collection;
     } else {
-      collectionName = this.parseCollectionName(options);
+      this.collectionName = this.parseCollectionName(options);
     }
 
+    return super.initialize(options);
+  }
+
+  public async run(options: NewCommandSchema & Arguments) {
     // Register the version of the CLI in the registry.
     const packageJson = require('../package.json');
     const version = packageJson.version;
@@ -31,7 +34,7 @@ export class NewCommand extends SchematicCommand<NewCommandSchema> {
     this._workflow.registry.addSmartDefaultProvider('ng-cli-version', () => version);
 
     return this.runSchematic({
-      collectionName: collectionName,
+      collectionName: this.collectionName,
       schematicName: this.schematicName,
       schematicOptions: options['--'] || [],
       debug: !!options.debug,

--- a/packages/angular/cli/models/schematic-command.ts
+++ b/packages/angular/cli/models/schematic-command.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {
-  analytics,
   experimental,
   json,
   logging,
@@ -76,7 +75,8 @@ export abstract class SchematicCommand<
   private _workspace: experimental.workspace.Workspace;
   protected _workflow: NodeWorkflow;
 
-  protected collectionName = '@schematics/angular';
+  private readonly defaultCollectionName = '@schematics/angular';
+  protected collectionName = this.defaultCollectionName;
   protected schematicName?: string;
 
   constructor(
@@ -373,7 +373,7 @@ export abstract class SchematicCommand<
       }
     }
 
-    return this.collectionName;
+    return this.defaultCollectionName;
   }
 
   protected async runSchematic(options: RunSchematicOptions) {
@@ -400,7 +400,7 @@ export abstract class SchematicCommand<
     schematicName = schematic.description.name;
 
     // TODO: Remove warning check when 'targets' is default
-    if (collectionName !== this.collectionName) {
+    if (collectionName !== this.defaultCollectionName) {
       const [ast, configPath] = getWorkspaceRaw('local');
       if (ast) {
         const projectsKeyValue = ast.properties.find(p => p.key.value === 'projects');

--- a/tests/legacy-cli/e2e/tests/generate/help-output.ts
+++ b/tests/legacy-cli/e2e/tests/generate/help-output.ts
@@ -22,7 +22,7 @@ export default function() {
             "factory": "./fake",
             "description": "Fake schematic",
             "schema": "./fake-schema.json"
-          }
+          },
         }
       }`,
       [join(genRoot, 'fake-schema.json')]: `
@@ -93,6 +93,33 @@ export default function() {
       }
       if (!/opt-a[\s\S]*opt-b[\s\S]*opt-c/.test(stdout)) {
         throw new Error('Help signature options are incorrect.');
+      }
+    })
+
+    // should print all the available schematics in a collection
+    // when a collection has more than 1 schematic
+    .then(() => writeMultipleFiles({
+      [join(genRoot, 'collection.json')]: `
+      {
+        "schematics": {
+          "fake": {
+            "factory": "./fake",
+            "description": "Fake schematic",
+            "schema": "./fake-schema.json"
+          },
+          "fake-two": {
+            "factory": "./fake",
+            "description": "Fake schematic",
+            "schema": "./fake-schema.json"
+          },
+        }
+      }`,
+    }))
+    .then(() => ng('generate', '--help'))
+    .then(({stdout}) => {
+      if (!/Collection \"fake-schematics\" \(default\):[\s\S]*fake[\s\S]*fake-two/.test(stdout)) {
+        throw new Error(
+          `Help result is wrong, it didn't contain all the schematics.`);
       }
     });
 


### PR DESCRIPTION
At the moment, collectionName and schematicCollections are not set in various schematics command which result in fallbacking to the hardcoded default collectionName https://github.com/angular/angular-cli/blob/master/packages/angular/cli/models/schematic-command.ts#L79

Hence, this will result in incorrect information being present when using the `--help`, `--list`.

Fixes #14519