### PR TITLE
feat(@schematics/angular): default Ivy apps to AOT true

### DIFF
--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -194,6 +194,7 @@ function addAppToWorkspaceFile(options: ApplicationOptions, appDir: string): Rul
           main: `${sourceRoot}/main.ts`,
           polyfills: `${sourceRoot}/polyfills.ts`,
           tsConfig: `${projectRoot}tsconfig.app.json`,
+          aot: !!options.enableIvy,
           assets: [
             `${sourceRoot}/favicon.ico`,
             `${sourceRoot}/assets`,

--- a/packages/schematics/angular/application/index_spec.ts
+++ b/packages/schematics/angular/application/index_spec.ts
@@ -213,6 +213,24 @@ describe('Application Schematic', () => {
     ]));
   });
 
+  it('should set AOT option to false for VE projects', async () => {
+    const options = { ...defaultOptions };
+
+    const tree = await schematicRunner.runSchematicAsync('application', options, workspaceTree)
+      .toPromise();
+    const workspace = JSON.parse(tree.readContent('/angular.json'));
+    expect(workspace.projects.foo.architect.build.options.aot).toEqual(false);
+  });
+
+  it('should set AOT option to true for Ivy projects', async () => {
+    const options = { ...defaultOptions, enableIvy: true };
+
+    const tree = await schematicRunner.runSchematicAsync('application', options, workspaceTree)
+      .toPromise();
+    const workspace = JSON.parse(tree.readContent('/angular.json'));
+    expect(workspace.projects.foo.architect.build.options.aot).toEqual(true);
+  });
+
   describe(`update package.json`, () => {
     it(`should add build-angular to devDependencies`, async () => {
       const tree = await schematicRunner.runSchematicAsync('application', defaultOptions, workspaceTree)

--- a/tests/legacy-cli/e2e/tests/build/polyfills.ts
+++ b/tests/legacy-cli/e2e/tests/build/polyfills.ts
@@ -9,7 +9,7 @@ import { ng } from '../../utils/process';
 import { expectToFail } from '../../utils/utils';
 
 export default async function () {
-    await ng('build');
+    await ng('build', '--aot=false');
     // files were created successfully
     await expectFileToMatch('dist/test-project/polyfills-es5.js', 'core-js/proposals/reflect-metadata');
     await expectFileToMatch('dist/test-project/polyfills-es5.js', 'zone.js');
@@ -21,7 +21,7 @@ export default async function () {
     `);
     const jitPolyfillSize = await getFileSize('dist/test-project/polyfills-es5.js');
 
-    await ng('build', '--aot');
+    await ng('build', '--aot=true');
     // files were created successfully
     await expectFileToExist('dist/test-project/polyfills-es5.js');
     await expectFileSizeToBeUnder('dist/test-project/polyfills-es5.js', jitPolyfillSize);

--- a/tests/legacy-cli/e2e/tests/build/script-target.ts
+++ b/tests/legacy-cli/e2e/tests/build/script-target.ts
@@ -8,7 +8,7 @@ import { expectToFail } from '../../utils/utils';
 export default function () {
   // TODO(architect): Delete this test. It is now in devkit/build-angular.
 
-  // Skip this test in Angular 2, it had different bundles.	
+  // Skip this test in Angular 2, it had different bundles.
   if (getGlobalVariable('argv')['ng2']) {
     return Promise.resolve();
   }
@@ -19,7 +19,7 @@ export default function () {
       compilerOptions['target'] = 'es2015';
     }))
     .then(() => ng('build', '--optimization', '--output-hashing=none', '--vendor-chunk'))
-    // Check class constructors are present in the vendor output.	
-    .then(() => expectFileToMatch('dist/test-project/vendor-es2015.js', /class \w{constructor\(\){/))
-    .then(() => expectToFail(() => expectFileToMatch('dist/test-project/vendor-es5.js', /class \w{constructor\(\){/)));
+    // Check class constructors are present in the vendor output.
+    .then(() => expectFileToMatch('dist/test-project/vendor-es2015.js', /class \w{constructor\(/))
+    .then(() => expectToFail(() => expectFileToMatch('dist/test-project/vendor-es5.js', /class \w{constructor\(/)));
 }


### PR DESCRIPTION
Testing on AIO with Angular master as of 28/05/2019 I got these results:
JIT ~414ms (369, 378, 408, 323, 593)
AOT using VE ~1383ms (1365, 1185, 1767, 1135, 1467)
AOT using Ivy ~517ms (600, 391, 444, 756, 394)

This is largely due to https://github.com/angular/angular/pull/29380 and https://github.com/angular/angular/pull/30238.

The second PR above was not merged to master, and thus will not be in 8.0.0. This PR should be merged to match it.