### PR TITLE
fix(@schematics/angular): add migration to update `web-animations-js`…

### DIFF
--- a/packages/schematics/angular/migrations/update-8/index.ts
+++ b/packages/schematics/angular/migrations/update-8/index.ts
@@ -12,7 +12,7 @@ import { updatePackageJson, updateTsLintConfig } from './codelyzer-5';
 import { updateES5Projects } from './differential-loading';
 import { dropES2015Polyfills } from './drop-es6-polyfills';
 import { removeAngularHttp } from './remove-angular-http';
-import { updateBuilders } from './update-builders';
+import { updateDependencies } from './update-dependencies';
 
 export { updateLazyModulePaths } from './update-lazy-module-paths';
 
@@ -23,7 +23,7 @@ export default function(): Rule {
       updatePackageJson(),
       dropES2015Polyfills(),
       updateES5Projects(),
-      updateBuilders(),
+      updateDependencies(),
       removeAngularHttp(),
       (tree, context) => {
         const packageChanges = tree.actions.some(a => a.path.endsWith('/package.json'));

--- a/packages/schematics/angular/migrations/update-8/update-dependencies.ts
+++ b/packages/schematics/angular/migrations/update-8/update-dependencies.ts
@@ -9,7 +9,7 @@ import { Tree } from '@angular-devkit/schematics';
 import { addPackageJsonDependency, getPackageJsonDependency } from '../../utility/dependencies';
 import { latestVersions } from '../../utility/latest-versions';
 
-export function updateBuilders() {
+export function updateDependencies() {
   return (host: Tree) => {
     let current = getPackageJsonDependency(host, '@angular-devkit/build-angular');
     if (current && current.version !== latestVersions.DevkitBuildAngular) {
@@ -45,6 +45,21 @@ export function updateBuilders() {
           type: current.type,
           name: 'zone.js',
           version: latestVersions.ZoneJs,
+          overwrite: true,
+        },
+      );
+    }
+
+    // FIXME: change to ^2.3.2 as soon as it's released with the pr208 fix
+    const webAnimationsJsVersion = 'github:angular/web-animations-js#release_pr208';
+    current = getPackageJsonDependency(host, 'web-animations-js');
+    if (current && current.version !== webAnimationsJsVersion) {
+      addPackageJsonDependency(
+        host,
+        {
+          type: current.type,
+          name: 'web-animations-js',
+          version: webAnimationsJsVersion,
           overwrite: true,
         },
       );


### PR DESCRIPTION
… polyfill

Previous versions rely on `this` which breaks differential loading since it's `undefined` when using script tags with type module.