### PR TITLE
fix(@schematics/angular): TypeScript related migrations should cater …

### DIFF
--- a/packages/schematics/angular/migrations/update-8/drop-es6-polyfills.ts
+++ b/packages/schematics/angular/migrations/update-8/drop-es6-polyfills.ts
@@ -106,7 +106,7 @@ function dropES2015PolyfillsFromFile(polyfillPath: string): Rule {
     }
 
     const sourceFile = ts.createSourceFile(polyfillPath,
-      content,
+      content.replace(/^\uFEFF/, ''),
       ts.ScriptTarget.Latest,
       true,
     );

--- a/packages/schematics/angular/migrations/update-8/update-lazy-module-paths.ts
+++ b/packages/schematics/angular/migrations/update-8/update-lazy-module-paths.ts
@@ -17,7 +17,7 @@ function* visit(directory: DirEntry): IterableIterator<ts.SourceFile> {
         if (content.includes('loadChildren')) {
           const source = ts.createSourceFile(
             entry.path,
-            content.toString(),
+            content.toString().replace(/^\uFEFF/, ''),
             ts.ScriptTarget.Latest,
             true,
           );

--- a/packages/schematics/angular/migrations/update-8/update-lazy-module-paths_spec.ts
+++ b/packages/schematics/angular/migrations/update-8/update-lazy-module-paths_spec.ts
@@ -73,5 +73,19 @@ describe('Migration to version 8', () => {
       expect(routes).toContain(
         `loadChildren: () => import('./lazy/lazy.module').then(m => m.LazyModule)`);
     });
+
+    it('should replace the module path string when file has BOM', async () => {
+      tree.create(lazyRoutePath, '\uFEFF' + Buffer.from(lazyRoute).toString());
+
+      schematicRunner.runSchematic('migration-08', {}, tree);
+      await schematicRunner.engine.executePostTasks().toPromise();
+
+      const routes = tree.readContent(lazyRoutePath);
+
+      expect(routes).not.toContain('./lazy/lazy.module#LazyModule');
+      expect(routes).toContain(
+        `loadChildren: () => import('./lazy/lazy.module').then(m => m.LazyModule)`);
+    });
+
   });
 });


### PR DESCRIPTION
In the CLI `UpdateRecorder` methods such as `insertLeft`, `remove` etc.. accepts positions which are not offset by a BOM. This is because when a file has a BOM a different recorder will be used https://github.com/angular/angular-cli/blob/master/packages/angular_devkit/schematics/src/tree/recorder.ts#L72 which caters for an addition offset/delta.

The main reason for this is that when a developer is writing a schematic they shouldn't need to compute the offset based if a file has a BOM or not and is handled out of the box.

Example
```ts
recorder.insertLeft(5, 'true');
```

However this is unfortunate in the case if a ts SourceFile is used and one uses `getWidth` and `getStart` method they will already be offset by 1, which at the end it results in a double offset and hence the problem.

Fixes #14551