### PR TITLE
fix(@angular/cli): ng-update migrations not running with --migrate-only

### DIFF
--- a/packages/angular_devkit/schematics/tools/node-module-engine-host.ts
+++ b/packages/angular_devkit/schematics/tools/node-module-engine-host.ts
@@ -79,7 +79,7 @@ export class NodeModulesEngineHost extends FileSystemEngineHostBase {
   protected _resolveCollectionPath(name: string): string {
     let collectionPath: string | undefined = undefined;
 
-    if (name.replace(/\\/, '/').split('/').length > (name[0] == '@' ? 2 : 1)) {
+    if (name.replace(/\\/g, '/').split('/').length > (name[0] == '@' ? 2 : 1)) {
       try {
         collectionPath = this._resolvePath(name, process.cwd());
       } catch {

--- a/packages/angular_devkit/schematics/tools/node-module-engine-host_spec.ts
+++ b/packages/angular_devkit/schematics/tools/node-module-engine-host_spec.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+// tslint:disable:no-implicit-dependencies
+
+import { SchematicEngine } from '@angular-devkit/schematics';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { NodeModulesEngineHost } from './node-module-engine-host';
+
+const TMP_DIR = process.env['$TEST_TMPDIR'] || os.tmpdir();
+
+describe('NodeModulesEngineHost', () => {
+  let tmpDir!: string;
+  let previousDir!: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(TMP_DIR,
+        'angular-devkit-schematics-tools-node-module-engine-host'));
+    previousDir = process.cwd();
+    process.chdir(tmpDir);
+  });
+
+  afterEach(() => process.chdir(previousDir));
+
+  /** Creates a fake NPM module that can be used to test the node module engine host. */
+  function createFakeNpmModule() {
+    fs.mkdirSync(path.join(tmpDir, 'node_modules'));
+    fs.mkdirSync(path.join(tmpDir, 'node_modules/@angular/'));
+    fs.mkdirSync(path.join(tmpDir, 'node_modules/@angular/core'));
+    fs.mkdirSync(path.join(tmpDir, 'node_modules/@angular/core/schematics'));
+    fs.writeFileSync(path.join(tmpDir, 'node_modules/@angular/core/package.json'),
+      JSON.stringify({name: '@angular/core'}));
+    fs.writeFileSync(path.join(tmpDir, 'node_modules/@angular/core/schematics/migrations.json'),
+      JSON.stringify({schematics: {}}));
+  }
+
+  it('should properly create collections with explicit collection path', () => {
+    createFakeNpmModule();
+
+    const engineHost = new NodeModulesEngineHost();
+    const engine = new SchematicEngine(engineHost);
+
+    expect(() => {
+      engine.createCollection(path.join('@angular/core', './schematics/migrations.json'));
+    }).not.toThrow();
+  });
+});


### PR DESCRIPTION
With Angular CLI version 8, migrations cannot be re-run with the
`--migrate-only` flag as there was a recent regression introduced
in https://github.com/angular/angular-cli/commit/e406f00909a72dff70cbaaff52a5495258ee77c3#diff-0d0a748fb9a38a7ccde08d9b42e70bce as it now passes
a normalized platform path to the `engine.createCollection` call.

This breaks as there is incorrect logic within
`node-modules-engine-host` that causes the schematic collection to be
searched within the `package.json#schematics` entry. This is incorrect
as migration schematics specify their migration schematics in a separate
schematic collection file which is part of `package.json#ng-update`.

Fixes #14565