### PR TITLE
fix(@angular-devkit/architect): support all observable types as build results

### DIFF
--- a/etc/api/angular_devkit/architect/src/index.d.ts
+++ b/etc/api/angular_devkit/architect/src/index.d.ts
@@ -38,7 +38,7 @@ export declare type BuilderInput = json.JsonObject & RealBuilderInput;
 
 export declare type BuilderOutput = json.JsonObject & RealBuilderOutput;
 
-export declare type BuilderOutputLike = Observable<BuilderOutput> | Promise<BuilderOutput> | BuilderOutput;
+export declare type BuilderOutputLike = SubscribableOrPromise<BuilderOutput> | BuilderOutput;
 
 export declare type BuilderProgress = json.JsonObject & RealBuilderProgress & TypedBuilderProgress;
 
@@ -59,6 +59,8 @@ export interface BuilderRun {
 }
 
 export declare function createBuilder<OptT extends json.JsonObject, OutT extends BuilderOutput = BuilderOutput>(fn: BuilderHandlerFn<OptT>): Builder<OptT>;
+
+export declare function isBuilderOutput(obj: any): obj is BuilderOutput;
 
 export interface ScheduleOptions {
     analytics?: analytics.Analytics;

--- a/packages/angular_devkit/architect/src/api.ts
+++ b/packages/angular_devkit/architect/src/api.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import { analytics, experimental, json, logging } from '@angular-devkit/core';
-import { Observable, from } from 'rxjs';
+import { Observable, SubscribableOrPromise, from } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
 import { Schema as RealBuilderInput, Target as RealTarget } from './input-schema';
 import { Schema as RealBuilderOutput } from './output-schema';
@@ -250,8 +250,16 @@ export interface BuilderContext {
 /**
  * An accepted return value from a builder. Can be either an Observable, a Promise or a vector.
  */
-export type BuilderOutputLike = Observable<BuilderOutput> | Promise<BuilderOutput> | BuilderOutput;
+export type BuilderOutputLike = SubscribableOrPromise<BuilderOutput> | BuilderOutput;
 
+// tslint:disable-next-line:no-any
+export function isBuilderOutput(obj: any): obj is BuilderOutput {
+  if (!obj || typeof obj.then === 'function' || typeof obj.subscribe === 'function') {
+    return false;
+  }
+
+  return typeof obj.success === 'boolean';
+}
 
 /**
  * A builder handler function. The function signature passed to `createBuilder()`.

--- a/packages/angular_devkit/architect/src/create-builder.ts
+++ b/packages/angular_devkit/architect/src/create-builder.ts
@@ -5,8 +5,8 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import { analytics, experimental, isPromise, json, logging } from '@angular-devkit/core';
-import { Observable, Subscription, from, isObservable, of, throwError } from 'rxjs';
+import { analytics, experimental, json, logging } from '@angular-devkit/core';
+import { Observable, Subscription, from, of, throwError } from 'rxjs';
 import { tap } from 'rxjs/operators';
 import {
   BuilderContext,
@@ -14,11 +14,11 @@ import {
   BuilderInfo,
   BuilderInput,
   BuilderOutput,
-  BuilderOutputLike,
   BuilderProgressState,
   ScheduleOptions,
   Target,
   TypedBuilderProgress,
+  isBuilderOutput,
   targetStringFromTarget,
 } from './api';
 import { Builder, BuilderSymbol, BuilderVersionSymbol } from './internal';
@@ -189,17 +189,16 @@ export function createBuilder<
         };
 
         context.reportRunning();
-        let result: BuilderOutputLike;
+        let result;
         try {
           result = fn(i.options as OptT, context);
+          if (isBuilderOutput(result)) {
+            result = of(result);
+          } else {
+            result = from(result);
+          }
         } catch (e) {
           result = throwError(e);
-        }
-
-        if (isPromise(result)) {
-          result = from(result);
-        } else if (!isObservable(result)) {
-          result = of(result);
         }
 
         // Manage some state automatically.


### PR DESCRIPTION
The `from` operator allows for the normalization of observables, obervable-like objects, and promises.

Fixes #14579