### PR TITLE
fix(@angular/cli): add analytics option to options schema

### DIFF
--- a/packages/angular/cli/lib/config/schema.json
+++ b/packages/angular/cli/lib/config/schema.json
@@ -65,6 +65,10 @@
               "x-deprecated": true
             }
           }
+        },
+        "analytics": {
+          "type": "boolean",
+          "description": "Share anonymous usage data with the Angular Team at Google."
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
When following the instructions at https://angular.io/analytics (`ng analytics project off`) to disable analytics at the project level, the cli won't recognise the option:

![image](https://user-images.githubusercontent.com/6425649/58658232-0d641180-82ee-11e9-8396-a4037527f5d9.png)
