### PR TITLE
(fix) error when project name is dir

### DIFF
--- a/packages/angular/cli/lib/config/schema.json
+++ b/packages/angular/cli/lib/config/schema.json
@@ -27,7 +27,7 @@
     "projects": {
       "type": "object",
       "patternProperties": {
-        "^[a-zA-Z][.0-9a-zA-Z]*(-[.0-9a-zA-Z]*)*$": {
+        "\\w*": {
           "$ref": "#/definitions/project"
         }
       },


### PR DESCRIPTION
sometimes, I want named a project or library like "@superme/angular", it work, but angular.json report an schema error: "@superme/angular is not allowed". So I suggest changing pattern properties to \\w* to match any words.