### PR TITLE
refactor(@schematics/angular): remove non-useful or operator

### DIFF
--- a/packages/schematics/angular/ng-new/index.ts
+++ b/packages/schematics/angular/ng-new/index.ts
@@ -65,7 +65,7 @@ export default function (options: NgNewOptions): Rule {
       apply(empty(), [
         schematic('workspace', workspaceOptions),
         options.createApplication ? schematic('application', applicationOptions) : noop,
-        move(options.directory || options.name),
+        move(options.directory),
       ]),
     ),
     (_host: Tree, context: SchematicContext) => {


### PR DESCRIPTION
There is already the following code that sets `options.directory` to `options.name` if no directory is passed as an option.
```typescript
if (!options.directory) {
    options.directory = options.name;
}
```

So the `options.directory || options.name` is unnecessary