### PR TITLE
ci: disable TypeScript patch updates for different major and minor versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -53,7 +53,17 @@
       "packageNames": [
         "typescript"
       ],
-      "updateTypes": "patch"
+      "separateMinorPatch": true
+    },
+    {
+      "packageNames": [
+        "typescript"
+      ],
+      "updateTypes": [
+        "minor",
+        "major"
+      ],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
At the moment, we get patch updates for different major and minor versions than the current version of TypeScript installed.

```json
{
  "packageRules": [
    {
      "packageNames": [
        "typescript"
      ],
      "separateMinorPatch": true
    },
    {
      "packageNames": [
        "typescript"
      ],
      "updateTypes": [
        "minor",
        "major"
      ],
      "enabled": false
    }
  ]
}
```

What the first rule does is override Renovate's results so that if TypeScript has both a minor update as well as a patch update then you get both PRs. Renovate's default otherwise is to just give you the latest minor or squash. So for example if the current TypeScript is `3.4.4` then the default behaviour is just to PR you for `3.5.1`. With this rule, we get both `3.4.5` and `3.5.1`.

The second rule then disables major and minor updates for TypeScript, which has the effect of them suppressing the minor `3.5.1` update.

For more context see: https://github.com/renovatebot/config-help/issues/260