### PR TITLE
docs: remove mention of the Angular CLI depending on Node 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ To get started locally, follow these instructions:
 
 1. If you haven't done it already, [make a fork of this repo](https://github.com/angular/angular-cli/fork).
 1. Clone to your local computer using `git`.
-1. Make sure that you have Node 10.9 or later installed. See instructions [here](https://nodejs.org/en/download/). The Angular CLI requires Node 8, but development requires Node 10.
+1. Make sure that you have Node 10.9 or later installed. See instructions [here](https://nodejs.org/en/download/).
 1. Make sure that you have `yarn` installed; see instructions [here](https://yarnpkg.com/lang/en/docs/install/).
 1. Run `yarn` (no arguments) from the root of your clone of this project.
 1. Run `yarn link` to add all custom scripts we use to your global install.


### PR DESCRIPTION
The official Angular documentation states that Angular requires Node.js version 10.9.0 or later. The README should align with that