### PR TITLE
fix(@ngtools/webpack): rebuilding project with errors reports cannot …

### DIFF
--- a/packages/ngtools/webpack/src/angular_compiler_plugin.ts
+++ b/packages/ngtools/webpack/src/angular_compiler_plugin.ts
@@ -1195,7 +1195,7 @@ export class AngularCompilerPlugin {
           'AngularCompilerPlugin._emit.ts', diagMode));
 
         if (!hasErrors(allDiagnostics)) {
-          if (this._firstRun || changedTsFiles.size > 20) {
+          if (this._firstRun || changedTsFiles.size > 20 || this._emitSkipped) {
             emitResult = tsProgram.emit(
               undefined,
               undefined,


### PR DESCRIPTION


When the first build in JIT has an error we are not emitting files. This ends up causing an issue because subsequent builds only trigger partial emits of files and only emits the full set of files if the number of files changed is greater than 20.

This logic adds the behavior that we only enter the 'only 20 files' part when the previous build was successful.

Fixes #14644