### PR TITLE
feat(@angular-devkit/build-angular): move milliseconds time audit at …

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/stats.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/stats.ts
@@ -50,16 +50,15 @@ export function statsToString(json: any, statsConfig: any) {
 
   if (unchangedChunkNumber > 0) {
     return '\n' + rs(tags.stripIndents`
-      Date: ${w(new Date().toISOString())} - Hash: ${w(json.hash)} - Time: ${w('' + json.time)}ms
+      Date: ${w(new Date().toISOString())} - Hash: ${w(json.hash)}
       ${unchangedChunkNumber} unchanged chunks
       ${changedChunksStats.join('\n')}
+      Time: ${w('' + json.time)}ms
       `);
   } else {
     return '\n' + rs(tags.stripIndents`
-      Date: ${w(new Date().toISOString())}
-      Hash: ${w(json.hash)}
-      Time: ${w('' + json.time)}ms
       ${changedChunksStats.join('\n')}
+      Date: ${w(new Date().toISOString())} - Hash: ${w(json.hash)} - Time: ${w('' + json.time)}ms
       `);
   }
 }


### PR DESCRIPTION
…the end of console

In a project with a lot of lazy modules we need scroll console window to see Date - Hash - Time audit message.

This PR should keep Date - Hash - Time at the end on first `ng s` or `ng b` to see if first build just happend or not. On rebuild only Time is at the end which is most valuable

Before:
```
$ ng s
Date: 2019-06-04T14:41:49.775Z
Hash: 998791a06c755186a7dc
Time: 37700ms
chunk {0} 0.205d3a05f39f54abaf98.js () 26.3 kB  [rendered]
chunk {1} 1.78ebb349f1f621ecc6dd.js () 85.3 kB  [rendered]
chunk {2} 2.6999dce3fa088a3aa465.js () 33.9 kB  [rendered]
chunk {3} 3.5532acdb300ef6741a51.js () 49.2 kB  [rendered]
chunk {4} 4.2add4f56d22ab59d79c6.js () 56.9 kB  [rendered]
...
chunk {137} 137.a15fd611c1c4b96d409a.js () 3.26 kB  [rendered]
chunk {138} 138.c9e103d1056bb9d070e3.js () 2.94 kB  [rendered]
chunk {139} 139.455c4ac2d85c520f1254.js () 3.17 kB  [rendered]
chunk {140} 140.4ca3e4f5eccec58809be.js () 4.29 kB  [rendered]
chunk {141} 141.c27def44603508d8df52.js () 2.37 kB  [rendered]
chunk {common} common.b74eca2038a9b1b5f3e4.js (common) 39.7 kB  [rendered]
chunk {main} main.db063f94924f162703a2.js (main) 163 kB [initial] [rendered]
chunk {polyfills} polyfills.4ac5e2c02b432e50dfda.js (polyfills) 295 kB [initial] [rendered]
chunk {polyfills-es5} polyfills-es5.5468c4e590607eea5bd4.js (polyfills-es5) 462 kB [initial] [rendered]
chunk {runtime} runtime.7381db3f14ba80dfec8f.js (runtime) 12.7 kB [entry] [rendered]
chunk {scripts} scripts.9a46a0e28dae0f11bffb.js (scripts) 20.3 kB [entry] [rendered]
chunk {styles} styles.e8c91b6de63cbd1ef1be.js (styles) 624 kB [initial] [rendered]
chunk {vendor} vendor.eccdafeabbb649d68877.js (vendor) 4.77 MB [initial] [rendered]
** Angular Live Development Server is listening on 0.0.0.0:80, open your browser on http://localhost:80/ **
i ｢wdm｣: Compiled successfully.
i ｢wdm｣: Compiling...

Date: 2019-06-04T14:41:54.313Z - Hash: 41c1ac04e7ee47d1f385 - Time: 1463ms
148 unchanged chunks
chunk {64} 64.ca3cef05dbfd71b73683.js () 36.2 kB  [rendered]
chunk {runtime} runtime.629babcdb3b730464fa1.js (runtime) 12.7 kB [entry] [rendered]
i ｢wdm｣: Compiled successfully.
```

After:
```
$ ng serve
chunk {0} 0.205d3a05f39f54abaf98.js () 26.3 kB  [rendered]
chunk {1} 1.78ebb349f1f621ecc6dd.js () 85.3 kB  [rendered]
chunk {2} 2.6999dce3fa088a3aa465.js () 33.9 kB  [rendered]
chunk {3} 3.5532acdb300ef6741a51.js () 49.2 kB  [rendered]
chunk {4} 4.2add4f56d22ab59d79c6.js () 56.9 kB  [rendered]
...
chunk {137} 137.a15fd611c1c4b96d409a.js () 3.26 kB  [rendered]
chunk {138} 138.c9e103d1056bb9d070e3.js () 2.94 kB  [rendered]
chunk {139} 139.455c4ac2d85c520f1254.js () 3.17 kB  [rendered]
chunk {140} 140.4ca3e4f5eccec58809be.js () 4.29 kB  [rendered]
chunk {141} 141.c27def44603508d8df52.js () 2.37 kB  [rendered]
chunk {common} common.b74eca2038a9b1b5f3e4.js (common) 39.7 kB  [rendered]
chunk {main} main.db063f94924f162703a2.js (main) 163 kB [initial] [rendered]
chunk {polyfills} polyfills.4ac5e2c02b432e50dfda.js (polyfills) 295 kB [initial] [rendered]
chunk {polyfills-es5} polyfills-es5.5468c4e590607eea5bd4.js (polyfills-es5) 462 kB [initial] [rendered]
chunk {runtime} runtime.b9d205421cbb4e61db70.js (runtime) 12.7 kB [entry] [rendered]
chunk {scripts} scripts.9a46a0e28dae0f11bffb.js (scripts) 20.3 kB [entry] [rendered]
chunk {styles} styles.e8c91b6de63cbd1ef1be.js (styles) 624 kB [initial] [rendered]
chunk {vendor} vendor.eccdafeabbb649d68877.js (vendor) 4.77 MB [initial] [rendered]
Date: 2019-06-04T14:14:33.560Z - Hash: 1690109f67cb887a6d5d - Time: 34676ms
** Angular Live Development Server is listening on 0.0.0.0:80, open your browser on http://localhost:80/ **
i ｢wdm｣: Compiled successfully.
i ｢wdm｣: Compiling...

Date: 2019-06-04T14:14:53.336Z - Hash: 998791a06c755186a7dc
148 unchanged chunks
chunk {64} 64.0bf728d7fbcbba217b53.js () 36.2 kB  [rendered]
chunk {runtime} runtime.7381db3f14ba80dfec8f.js (runtime) 12.7 kB [entry] [rendered]
Time: 1411ms
i ｢wdm｣: Compiled successfully.
```