### PR TITLE
fix(@ngtools/webpack): always strip BOM when reading files

### DIFF
--- a/packages/ngtools/webpack/src/compiler_host.ts
+++ b/packages/ngtools/webpack/src/compiler_host.ts
@@ -147,13 +147,15 @@ export class WebpackCompilerHost implements ts.CompilerHost {
     const filePath = this.resolve(fileName);
 
     try {
+      let content: ArrayBuffer;
       if (this._memoryHost.isFile(filePath)) {
-        return virtualFs.fileBufferToString(this._memoryHost.read(filePath));
+        content = this._memoryHost.read(filePath);
       } else {
-        const content = this._syncHost.read(filePath);
-
-        return virtualFs.fileBufferToString(content);
+        content = this._syncHost.read(filePath);
       }
+
+      // strip BOM
+      return virtualFs.fileBufferToString(content).replace(/^\uFEFF/, '');
     } catch {
       return undefined;
     }


### PR DESCRIPTION
This is to align with the tsc readFile logic https://github.com/microsoft/TypeScript/blob/9da05243ff7ba9a2776d5a52118d680348b1454d/src/compiler/sys.ts#L1067