### PR TITLE
fix(@angular/cli): use recommended TTY check logic

### DIFF
--- a/packages/angular/cli/utilities/tty.ts
+++ b/packages/angular/cli/utilities/tty.ts
@@ -11,5 +11,7 @@ export function isTTY(): boolean {
     return !(force === '0' || force.toUpperCase() === 'FALSE');
   }
 
-  return !!process.stdout.isTTY && !!process.stdin.isTTY && !('CI' in process.env);
+  const ci = process.env['CI'];
+
+  return !!process.stdout.isTTY && (!ci || ci === '0' || ci.toUpperCase() === 'FALSE');
 }


### PR DESCRIPTION
`stdin` can be redirected/piped by various shells but still be interactive.  Node.js recommends only testing `stdout`: https://nodejs.org/api/tty.html#tty_tty
Also cleans up the `CI` environment variable logic for the false case.

Fixes #14640