### PR TITLE
fix(@schematics/angular): move browserslist even when no sourceRoot i…

### DIFF
--- a/packages/schematics/angular/migrations/update-8/differential-loading.ts
+++ b/packages/schematics/angular/migrations/update-8/differential-loading.ts
@@ -88,26 +88,16 @@ export function updateES5Projects(): Rule {
       }
 
       const browserslistPath = join(normalize(project.root), 'browserslist');
-      if (typeof project.sourceRoot === 'string') {
-        // Move the CLI 7 style browserlist to root if it's there.
-        const srcBrowsersList = join(normalize(project.sourceRoot), 'browserslist');
-        if (tree.exists(srcBrowsersList) && !tree.exists(browserslistPath)) {
-          // TODO: use rename instead.
-          // This is a hacky workaround. We should be able to just rename it.
-          // On unit tests the rename works fine but on real projects it fails with
-          //     ERROR! browserslist does not exist..
-          // This seems to happen because we are both renaming and then commiting an update.
-          // But it's fine if we read/create/delete. There's a bug somewhere.
-          // tree.rename(srcBrowsersList, browserslistPath);
-          const content = tree.read(srcBrowsersList);
-          if (content) {
-            tree.create(browserslistPath, content);
-            tree.delete(srcBrowsersList);
-          }
-        }
-      }
 
-      if (!tree.exists(browserslistPath)) {
+      // Move the CLI 7 style browserlist to root if it's there.
+      const sourceRoot = project.sourceRoot === 'string'
+        ? project.sourceRoot
+        : join(normalize(project.root), 'src');
+      const srcBrowsersList = join(normalize(sourceRoot), 'browserslist');
+
+      if (tree.exists(srcBrowsersList)) {
+        tree.rename(srcBrowsersList, browserslistPath);
+      } else if (!tree.exists(browserslistPath)) {
         tree.create(browserslistPath, browserslistContent);
       }
     }

--- a/packages/schematics/angular/migrations/update-8/differential-loading_spec.ts
+++ b/packages/schematics/angular/migrations/update-8/differential-loading_spec.ts
@@ -166,5 +166,18 @@ describe('Migration to version 8', () => {
       const tree2 = schematicRunner.runSchematic('migration-07', {}, tree.branch());
       expect(tree2.exists('/browserslist')).toBe(false);
     });
+
+    it(`should move 'browserslist' to root when 'sourceRoot' is not defined`, () => {
+      tree.rename('/browserslist', '/src/browserslist');
+      expect(tree.exists('/src/browserslist')).toBe(true);
+
+      const config = JSON.parse(tree.readContent('angular.json'));
+      config.projects['migration-test'].sourceRoot = undefined;
+
+      tree.overwrite('angular.json', JSON.stringify(config));
+      const tree2 = schematicRunner.runSchematic('migration-07', {}, tree.branch());
+      expect(tree2.exists('/src/browserslist')).toBe(false);
+      expect(tree2.exists('/browserslist')).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
…s available

```
Using package manager: 'npm'
Collecting installed dependencies...
Found 36 dependencies.
    ** Executing migrations for package '@angular/cli' **
RENAME src/browserslist => /browserslist
UPDATE tslint.json (2800 bytes)
UPDATE package.json (1396 bytes)
UPDATE tsconfig.json (460 bytes)
UPDATE tsconfig.app.json (282 bytes)
UPDATE tsconfig.spec.json (256 bytes)
```

Fixes #14660