### PR TITLE
fix(@angular-devkit/build-angular): re-order ES5 polyfills in karma H…

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/karma-context.html
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/karma-context.html
@@ -28,8 +28,8 @@ Reloaded before every execution run.
     %MAPPINGS%
   </script>
   <script src="_karma_webpack_/runtime.js" crossorigin="anonymous"></script>
-  <script src="_karma_webpack_/polyfills.js" crossorigin="anonymous"></script>
   <script src="_karma_webpack_/polyfills-es5.js" crossorigin="anonymous" nomodule></script>
+  <script src="_karma_webpack_/polyfills.js" crossorigin="anonymous"></script>
   <!-- Dynamically replaced with <script> tags -->
   %SCRIPTS%
   <script src="_karma_webpack_/styles.js" crossorigin="anonymous"></script>

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/karma-debug.html
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/karma-debug.html
@@ -29,8 +29,8 @@ just for immediate execution, without reporting to Karma server.
     %MAPPINGS%
   </script>
   <script src="_karma_webpack_/runtime.js" crossorigin="anonymous"></script>
-  <script src="_karma_webpack_/polyfills.js" crossorigin="anonymous"></script>
   <script src="_karma_webpack_/polyfills-es5.js" crossorigin="anonymous" nomodule></script>
+  <script src="_karma_webpack_/polyfills.js" crossorigin="anonymous"></script>
   <!-- Dynamically replaced with <script> tags -->
   %SCRIPTS%
   <script src="_karma_webpack_/styles.js" crossorigin="anonymous"></script>


### PR DESCRIPTION
…TMLs

Similar to the index HTML page (https://github.com/angular/angular-cli/blob/6ec09919b5c2695dee784ce0c3accee7f9754bb0/tests/legacy-cli/e2e/tests/misc/support-ie.ts#L30-L37) ES5 polyfills should be loaded prior to the other polyfills. This is because other polyfills such as `zone.js` require these for example `Symbol` and `Object.isFrozen`

Fixes #14618