### PR TITLE
fix(@schematics/angular): enable tsc `downlevelIteration`

### DIFF
--- a/packages/schematics/angular/migrations/update-8/differential-loading.ts
+++ b/packages/schematics/angular/migrations/update-8/differential-loading.ts
@@ -131,7 +131,16 @@ function updateTsConfig(tree: Tree, tsConfigPath: string): void {
   if (isExtendedConfig) {
     removePropertyInAstObject(recorder, compilerOptions, 'target');
     removePropertyInAstObject(recorder, compilerOptions, 'module');
+    removePropertyInAstObject(recorder, compilerOptions, 'downlevelIteration');
   } else {
+    const downlevelIteration = findPropertyInAstObject(compilerOptions, 'downlevelIteration');
+    if (!downlevelIteration) {
+      insertPropertyInAstObjectInOrder(recorder, compilerOptions, 'downlevelIteration', true, 4);
+    } else if (!downlevelIteration.value) {
+      const { start, end } = downlevelIteration;
+      recorder.remove(start.offset, end.offset - start.offset);
+      recorder.insertLeft(start.offset, 'true');
+    }
     const scriptTarget = findPropertyInAstObject(compilerOptions, 'target');
     if (!scriptTarget) {
       insertPropertyInAstObjectInOrder(recorder, compilerOptions, 'target', 'es2015', 4);

--- a/packages/schematics/angular/migrations/update-8/differential-loading_spec.ts
+++ b/packages/schematics/angular/migrations/update-8/differential-loading_spec.ts
@@ -80,6 +80,29 @@ describe('Migration to version 8', () => {
       expect(module).toBe('esnext');
     });
 
+    it(`should create 'downlevelIteration' property when doesn't exists`, () => {
+      const tree2 = schematicRunner.runSchematic('migration-07', {}, tree.branch());
+      const compilerOptions = {
+        ...oldTsConfig.compilerOptions,
+      };
+
+      tree.overwrite(tsConfigPath, JSON.stringify({ compilerOptions }, null, 2));
+      const { downlevelIteration } = JSON.parse(tree2.readContent(tsConfigPath)).compilerOptions;
+      expect(downlevelIteration).toBe(true);
+    });
+
+    it(`should update 'downlevelIteration' to true when it's false`, () => {
+      const tree2 = schematicRunner.runSchematic('migration-07', {}, tree.branch());
+      const compilerOptions = {
+        ...oldTsConfig.compilerOptions,
+        downlevelIteration: false,
+      };
+
+      tree.overwrite(tsConfigPath, JSON.stringify({ compilerOptions }, null, 2));
+      const { downlevelIteration } = JSON.parse(tree2.readContent(tsConfigPath)).compilerOptions;
+      expect(downlevelIteration).toBe(true);
+    });
+
     it(`should create browserslist file if it doesn't exist`, () => {
       tree.delete('/browserslist');
       const tree2 = schematicRunner.runSchematic('migration-07', {}, tree.branch());

--- a/packages/schematics/angular/workspace/files/tsconfig.json.template
+++ b/packages/schematics/angular/workspace/files/tsconfig.json.template
@@ -5,10 +5,11 @@
     "outDir": "./dist/out-tsc",
     "sourceMap": true,
     "declaration": false,
-    "module": "esnext",
-    "moduleResolution": "node",
+    "downlevelIteration": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
+    "module": "esnext",
+    "moduleResolution": "node",
     "importHelpers": true,
     "target": "es2015",
     "typeRoots": [


### PR DESCRIPTION
We by default now use ES2015. Users can use ES2015 iterations however the ES5 build will fail.

Fixes #14697

Patch version of https://github.com/angular/angular-cli/pull/14698