### PR TITLE
fix(@ngtools/webpack): avoid resetting emit skipped flag before emit

### DIFF
--- a/packages/ngtools/webpack/src/angular_compiler_plugin.ts
+++ b/packages/ngtools/webpack/src/angular_compiler_plugin.ts
@@ -846,7 +846,6 @@ export class AngularCompilerPlugin {
 
   private async _make(compilation: compilation.Compilation) {
     time('AngularCompilerPlugin._make');
-    this._emitSkipped = true;
     // tslint:disable-next-line:no-any
     if ((compilation as any)._ngToolsWebpackPluginInstance) {
       throw new Error('An @ngtools/webpack plugin already exist for this compilation.');


### PR DESCRIPTION
Fixes #14719