### PR TITLE
fix(@schematics/angular): remove `lint` target from minimal projects

### DIFF
--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -261,7 +261,7 @@ function addAppToWorkspaceFile(options: ApplicationOptions, appDir: string): Rul
           scripts: [],
         },
       },
-      lint: {
+      lint: options.minimal ? undefined : {
         builder: Builders.TsLint,
         options: {
           tsConfig: [

--- a/packages/schematics/angular/application/index_spec.ts
+++ b/packages/schematics/angular/application/index_spec.ts
@@ -174,13 +174,14 @@ describe('Application Schematic', () => {
     expect(karmaConf).toContain(`dir: require('path').join(__dirname, '../../coverage/foo')`);
   });
 
-  it('minimal=true should not create e2e and test targets', async () => {
+  it('minimal=true should not create e2e, lint and test targets', async () => {
     const options = { ...defaultOptions, minimal: true };
     const tree = await schematicRunner.runSchematicAsync('application', options, workspaceTree)
       .toPromise();
     const config = JSON.parse(tree.readContent('/angular.json'));
     const architect = config.projects.foo.architect;
     expect(architect.test).not.toBeDefined();
+    expect(architect.e2e).not.toBeDefined();
     expect(architect.e2e).not.toBeDefined();
   });
 
@@ -270,6 +271,18 @@ describe('Application Schematic', () => {
 
       const packageJson = JSON.parse(tree.readContent('package.json'));
       expect(packageJson.devDependencies['@angular-devkit/build-angular']).toBeUndefined();
+    });
+
+    it('should set the lint tsConfig option', async () => {
+      const tree = await schematicRunner.runSchematicAsync('application', defaultOptions, workspaceTree)
+        .toPromise();
+      const workspace = JSON.parse(tree.readContent('/angular.json'));
+      const lintOptions = workspace.projects.foo.architect.lint.options;
+      expect(lintOptions.tsConfig).toEqual([
+        'projects/foo/tsconfig.app.json',
+        'projects/foo/tsconfig.spec.json',
+        'projects/foo/e2e/tsconfig.json',
+      ]);
     });
   });
 

--- a/packages/schematics/angular/e2e/index_spec.ts
+++ b/packages/schematics/angular/e2e/index_spec.ts
@@ -98,17 +98,5 @@ describe('Application Schematic', () => {
       expect(e2eOptions.protractorConfig).toEqual('projects/foo/e2e/protractor.conf.js');
       expect(e2eOptions.devServerTarget).toEqual('foo:serve');
     });
-
-    it('should set the lint options', async () => {
-      const tree = await schematicRunner.runSchematicAsync('e2e', defaultOptions, applicationTree)
-        .toPromise();
-      const workspace = JSON.parse(tree.readContent('/angular.json'));
-      const lintOptions = workspace.projects.foo.architect.lint.options;
-      expect(lintOptions.tsConfig).toEqual([
-        'projects/foo/tsconfig.app.json',
-        'projects/foo/tsconfig.spec.json',
-        'projects/foo/e2e/tsconfig.json',
-      ]);
-    });
   });
 });


### PR DESCRIPTION
Minimal projects are considered as throw-away projects and only a small subset of features are supported.

More context #13408 and #13354

Closes #14727