### PR TITLE
refactor: ignore vscode history folder in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ dist-schema/
 .idea/
 jsconfig.json
 .vscode/
+.history/
 
 # Typings file.
 typings/


### PR DESCRIPTION
**Ignore .history/ directory in git.**

After using Visual Studio Code to work with this repository, many files remain in the .history directory that git show as "new" but all should be ignored. Based on this, a .gitignore file is updated.

_this is a small change_