### PR TITLE
Small all round refactoring

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/typescript.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/typescript.ts
@@ -49,9 +49,8 @@ function _pluginOptionsOverrides(
 
 function _createAotPlugin(
   wco: WebpackConfigOptions,
-  options: any,
-  useMain = true,
-  extract = false,
+  options: AngularCompilerPluginOptions,
+  i18nExtract = false,
 ) {
   const { root, buildOptions } = wco;
 
@@ -59,7 +58,7 @@ function _createAotPlugin(
     ? path.resolve(root, buildOptions.i18nFile)
     : undefined;
 
-  const i18nFileAndFormat = extract
+  const i18nFileAndFormat = i18nExtract
     ? {
       i18nOutFile: buildOptions.i18nFile,
       i18nOutFormat: buildOptions.i18nFormat,
@@ -79,7 +78,7 @@ function _createAotPlugin(
   }
 
   let pluginOptions: AngularCompilerPluginOptions = {
-    mainPath: useMain ? path.join(root, buildOptions.main) : undefined,
+    mainPath: path.join(root, buildOptions.main),
     ...i18nFileAndFormat,
     locale: buildOptions.i18nLocale,
     platform: buildOptions.platform === 'server' ? PLATFORM.Server : PLATFORM.Browser,
@@ -108,7 +107,7 @@ export function getNonAotConfig(wco: WebpackConfigOptions) {
   };
 }
 
-export function getAotConfig(wco: WebpackConfigOptions, extract = false) {
+export function getAotConfig(wco: WebpackConfigOptions, i18nExtract = false) {
   const { tsConfigPath, buildOptions } = wco;
 
   const loaders: any[] = [NgToolsLoader];
@@ -123,7 +122,7 @@ export function getAotConfig(wco: WebpackConfigOptions, extract = false) {
 
   return {
     module: { rules: [{ test, use: loaders }] },
-    plugins: [_createAotPlugin(wco, { tsConfigPath }, true, extract)]
+    plugins: [_createAotPlugin(wco, { tsConfigPath }, i18nExtract)]
   };
 }
 

--- a/packages/angular_devkit/build_angular/src/extract-i18n/index.ts
+++ b/packages/angular_devkit/build_angular/src/extract-i18n/index.ts
@@ -72,6 +72,7 @@ async function execute(options: ExtractI18nBuilderOptions, context: BuilderConte
         scripts: false,
         styles: false,
       },
+      buildOptimizer: false,
       i18nLocale: options.i18nLocale,
       i18nFormat: options.i18nFormat,
       i18nFile: outFile,

--- a/packages/ngtools/webpack/src/interfaces.ts
+++ b/packages/ngtools/webpack/src/interfaces.ts
@@ -7,6 +7,7 @@
  */
 
 import { logging, virtualFs } from '@angular-devkit/core';
+import { CompilerOptions } from '@angular/compiler-cli';
 import * as fs from 'fs';
 import * as ts from 'typescript';
 
@@ -59,7 +60,7 @@ export interface AngularCompilerPluginOptions {
   contextElementDependencyConstructor?: ContextElementDependencyConstructor;
 
   // Use tsconfig to include path globs.
-  compilerOptions?: ts.CompilerOptions;
+  compilerOptions?: CompilerOptions;
 
   host?: virtualFs.Host<fs.Stats>;
   platformTransformers?: ts.TransformerFactory<ts.SourceFile>[];


### PR DESCRIPTION
refactor: update `compilerOptions` to NG `CompilerOptions`

refactor: small refactor in AOT plugin file

fix(@angular-devkit/build-angular): always disable `buildOptimizer` when extracting i18n
