### PR TITLE
refactor: Add explict type to allow RxJS to be updated

### DIFF
--- a/packages/angular_devkit/core/src/experimental/workspace/workspace.ts
+++ b/packages/angular_devkit/core/src/experimental/workspace/workspace.ts
@@ -17,6 +17,7 @@ import {
   parseJson,
   schema,
 } from '../../json';
+import { SchemaValidatorResult } from '../../json/schema/interface';
 import {
   Path,
   basename,
@@ -342,7 +343,7 @@ export class Workspace {
 
     return this._registry.compile(schemaJson).pipe(
       concatMap(validator => validator(contentJsonCopy)),
-      concatMap(validatorResult => {
+      concatMap((validatorResult: SchemaValidatorResult) => {
         if (validatorResult.success) {
           return of(contentJsonCopy as T);
         } else {


### PR DESCRIPTION
While trying to sync RxJS into google3 an issue came up around the code in question, where TypeScript is unable to properly infer the type. Adding this explicit type resolves the issue.