### PR TITLE
refactor(@angular/cli): standardize color handling and support checking

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "@types/webpack-sources": "^0.1.5",
     "@yarnpkg/lockfile": "1.1.0",
     "ajv": "6.10.0",
+    "ansi-colors": "3.2.4",
     "common-tags": "^1.8.0",
     "conventional-changelog": "^1.1.0",
     "conventional-commits-parser": "^3.0.0",

--- a/packages/angular/cli/BUILD
+++ b/packages/angular/cli/BUILD
@@ -41,6 +41,7 @@ ts_library(
         "@npm//@types/semver",
         "@npm//@types/universal-analytics",
         "@npm//@types/uuid",
+        "@npm//ansi-colors",
         "@npm//rxjs",
     ],
 )

--- a/packages/angular/cli/package.json
+++ b/packages/angular/cli/package.json
@@ -31,6 +31,7 @@
     "@schematics/angular": "0.0.0",
     "@schematics/update": "0.0.0",
     "@yarnpkg/lockfile": "1.1.0",
+    "ansi-colors": "3.2.4",
     "debug": "^4.1.1",
     "ini": "1.3.5",
     "inquirer": "6.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -988,6 +988,11 @@ ansi-align@^2.0.0:
   dependencies:
     string-width "^2.0.0"
 
+ansi-colors@3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.2.4.tgz#e3a3da4bfbae6c86a9c285625de124a234026fbf"
+  integrity sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==
+
 ansi-colors@^3.0.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.2.1.tgz#9638047e4213f3428a11944a7d4b31cba0a3ff95"


### PR DESCRIPTION
Node.js 10+ provides built-in functionality to test for color support based on chalk's `supports-color` package as well as several others. This alleviates the need for custom code or third-party packages to determine color support.  In addition for this PR, the `ansi-colors` package is added to the CLI which provides color, cross-platform symbol, and style/color removal support.  The package is light-weight (~150 SLOC), contains typings, and has no dependencies. The removal support is leveraged to remove all styling from logger messages when color is not supported.  This removes a current defect in which color/styling is still displayed if generated manually or via methods that do not perform supportability checks.  This is very relevant for third-party code/packages.  Finally, the typically used console functions are overriden to leverage the logger to ensure that the color processing is applied to third-party code (e.g., webpack internally as well as some of its loaders and plugins) which output to the console directly.

The color removal capabilities will be leveraged to support improved TypeScript diagnostic reporting which will use TypeScript's built-in functionality that while providing improved messaging and context also includes color.