### PR TITLE
fix(@schematics/angular): improve pipe signature

### DIFF
--- a/packages/schematics/angular/pipe/files/__name@dasherize@if-flat__/__name@dasherize__.pipe.ts.template
+++ b/packages/schematics/angular/pipe/files/__name@dasherize@if-flat__/__name@dasherize__.pipe.ts.template
@@ -5,7 +5,7 @@ import { Pipe, PipeTransform } from '@angular/core';
 })
 export class <%= classify(name) %>Pipe implements PipeTransform {
 
-  transform(value: any, args?: any): any {
+  transform(value: any, ...args: any[]): any {
     return null;
   }
 

--- a/packages/schematics/angular/pipe/index_spec.ts
+++ b/packages/schematics/angular/pipe/index_spec.ts
@@ -57,6 +57,8 @@ describe('Pipe Schematic', () => {
     const moduleContent = getFileContent(tree, '/projects/bar/src/app/app.module.ts');
     expect(moduleContent).toMatch(/import.*Foo.*from '.\/foo.pipe'/);
     expect(moduleContent).toMatch(/declarations:\s*\[[^\]]+?,\r?\n\s+FooPipe\r?\n/m);
+    const fileContent = tree.readContent('/projects/bar/src/app/foo.pipe.ts');
+    expect(fileContent).toContain('transform(value: any, ...args: any[])');
   });
 
   it('should import into a specified module', async () => {


### PR DESCRIPTION
Currently , the CLI generates :

```typescript

transform(value: any , args?: any)

```

With this commit , it generate :

```typescript

transform(value: any, ...args?: any[])

```

Which conforms to the official doc

Fixes #12602