### PR TITLE
feat(@angular/cli): ng doc accepts a version flag

### DIFF
--- a/packages/angular/cli/commands/doc-impl.ts
+++ b/packages/angular/cli/commands/doc-impl.ts
@@ -19,9 +19,21 @@ export class DocCommand extends Command<DocCommandSchema> {
 
       return 0;
     }
-    let searchUrl = `https://angular.io/api?query=${options.keyword}`;
+
+    let domain = 'angular.io';
+
+    if (options.version) {
+      if (options.version == 'next') {
+        domain = 'next.angular.io';
+      } else {
+        domain = `v${options.version}.angular.io`;
+      }
+    }
+
+    let searchUrl = `https://${domain}/api?query=${options.keyword}`;
+
     if (options.search) {
-      searchUrl = `https://www.google.com/search?q=site%3Aangular.io+${options.keyword}`;
+      searchUrl = `https://www.google.com/search?q=site%3A${domain}+${options.keyword}`;
     }
 
     // We should wrap `open` in a new Promise because `open` is already resolved

--- a/packages/angular/cli/commands/doc.json
+++ b/packages/angular/cli/commands/doc.json
@@ -25,6 +25,21 @@
           "type": "boolean",
           "default": false,
           "description": "When true, searches all of angular.io. Otherwise, searches only API reference documentation."
+        },
+        "version" : {
+          "anyOf": [
+            {
+              "const" : 2
+            },
+            {
+              "type" : "integer",
+              "minimum": 4
+            },
+            {
+              "const": "next"
+            }
+          ],
+          "description": "Contains the version of Angular to use for the documentation."
         }
       },
       "required": [


### PR DESCRIPTION
With this commit, we can now specify a `version`
for the `ng doc` command

    ng doc --version 6
    ng doc -v 6

and this will open `v6.angular.io` instead of `angular.io`.
The default domain is still used
if no version is specified.

Refs #12365