### PR TITLE
feat(@ngtools/webpack): improved TypeScript diagnostic reporting

### DIFF
--- a/packages/ngtools/webpack/src/angular_compiler_plugin.ts
+++ b/packages/ngtools/webpack/src/angular_compiler_plugin.ts
@@ -28,6 +28,7 @@ import {
   createCompilerHost,
   createProgram,
   formatDiagnostics,
+  isNgDiagnostic,
   readConfiguration,
 } from '@angular/compiler-cli';
 import { ChildProcess, ForkOptions, fork } from 'child_process';
@@ -1007,19 +1008,57 @@ export class AngularCompilerPlugin {
     const { emitResult, diagnostics } = this._emit();
     timeEnd('AngularCompilerPlugin._update._emit');
 
-    // Report diagnostics.
-    const errors = diagnostics
-      .filter((diag) => diag.category === ts.DiagnosticCategory.Error);
-    const warnings = diagnostics
-      .filter((diag) => diag.category === ts.DiagnosticCategory.Warning);
+    // Report Diagnostics
+    const tsErrors = [];
+    const tsWarnings = [];
+    const ngErrors = [];
+    const ngWarnings = [];
 
-    if (errors.length > 0) {
-      const message = formatDiagnostics(errors);
+    for (const diagnostic of diagnostics) {
+      switch (diagnostic.category) {
+        case ts.DiagnosticCategory.Error:
+          if (isNgDiagnostic(diagnostic)) {
+            ngErrors.push(diagnostic);
+          } else {
+            tsErrors.push(diagnostic);
+          }
+          break;
+        case ts.DiagnosticCategory.Message:
+        case ts.DiagnosticCategory.Suggestion:
+          // Warnings?
+        case ts.DiagnosticCategory.Warning:
+          if (isNgDiagnostic(diagnostic)) {
+            ngWarnings.push(diagnostic);
+          } else {
+            tsWarnings.push(diagnostic);
+          }
+          break;
+      }
+    }
+
+    if (tsErrors.length > 0) {
+      const message = ts.formatDiagnosticsWithColorAndContext(
+        tsErrors,
+        this._compilerHost,
+      );
       this._errors.push(new Error(message));
     }
 
-    if (warnings.length > 0) {
-      const message = formatDiagnostics(warnings);
+    if (tsWarnings.length > 0) {
+      const message = ts.formatDiagnosticsWithColorAndContext(
+        tsWarnings,
+        this._compilerHost,
+      );
+      this._warnings.push(message);
+    }
+
+    if (ngErrors.length > 0) {
+      const message = formatDiagnostics(ngErrors);
+      this._errors.push(new Error(message));
+    }
+
+    if (ngWarnings.length > 0) {
+      const message = formatDiagnostics(ngWarnings);
       this._warnings.push(message);
     }
 


### PR DESCRIPTION
By leveraging the built-in TS error formatting, additional context related to errors and warnings will now be shown.  This includes a segment of the code that caused the diagnostic message.

Before:
![image](https://user-images.githubusercontent.com/19598772/59555692-4b1a9880-8f84-11e9-8050-a9c54cdc4d26.png)

After:
![image](https://user-images.githubusercontent.com/19598772/59555685-3807c880-8f84-11e9-9ee5-e60d23704f72.png)
