### PR TITLE
fix(@ngtools/webpack): ensure references for constructor parameter types

### DIFF
--- a/packages/ngtools/webpack/src/transformers/make_transform.ts
+++ b/packages/ngtools/webpack/src/transformers/make_transform.ts
@@ -16,26 +16,20 @@ import {
   TransformOperation,
 } from './interfaces';
 
-
-// Typescript below 2.7.0 needs a workaround.
-const tsVersionParts = ts.version.split('.').map(p => Number(p));
-const visitEachChild = tsVersionParts[0] <= 2 && tsVersionParts[1] < 7
-  ? visitEachChildWorkaround
-  : ts.visitEachChild;
-
 export function makeTransform(
   standardTransform: StandardTransform,
   getTypeChecker?: () => ts.TypeChecker,
 ): ts.TransformerFactory<ts.SourceFile> {
-
   return (context: ts.TransformationContext): ts.Transformer<ts.SourceFile> => {
     const transformer: ts.Transformer<ts.SourceFile> = (sf: ts.SourceFile) => {
       const ops: TransformOperation[] = standardTransform(sf);
-      const removeOps = ops
-        .filter((op) => op.kind === OPERATION_KIND.Remove) as RemoveNodeOperation[];
-      const addOps = ops.filter((op) => op.kind === OPERATION_KIND.Add) as AddNodeOperation[];
-      const replaceOps = ops
-        .filter((op) => op.kind === OPERATION_KIND.Replace) as ReplaceNodeOperation[];
+      const removeOps = ops.filter(
+        op => op.kind === OPERATION_KIND.Remove,
+      ) as RemoveNodeOperation[];
+      const addOps = ops.filter(op => op.kind === OPERATION_KIND.Add) as AddNodeOperation[];
+      const replaceOps = ops.filter(
+        op => op.kind === OPERATION_KIND.Replace,
+      ) as ReplaceNodeOperation[];
 
       // If nodes are removed, elide the imports as well.
       // Mainly a workaround for https://github.com/Microsoft/TypeScript/issues/17552.
@@ -43,33 +37,33 @@ export function makeTransform(
       // This is currently true for transforms that use replaceOps (replace_bootstrap and
       // replace_resources), but may not be true for new transforms.
       if (getTypeChecker && removeOps.length + replaceOps.length > 0) {
-        const removedNodes = removeOps.concat(replaceOps).map((op) => op.target);
+        const removedNodes = removeOps.concat(replaceOps).map(op => op.target);
         removeOps.push(...elideImports(sf, removedNodes, getTypeChecker));
       }
 
-      const visitor: ts.Visitor = (node) => {
+      const visitor: ts.Visitor = node => {
         let modified = false;
         let modifiedNodes = [node];
         // Check if node should be dropped.
-        if (removeOps.find((op) => op.target === node)) {
+        if (removeOps.find(op => op.target === node)) {
           modifiedNodes = [];
           modified = true;
         }
 
         // Check if node should be replaced (only replaces with first op found).
-        const replace = replaceOps.find((op) => op.target === node);
+        const replace = replaceOps.find(op => op.target === node);
         if (replace) {
           modifiedNodes = [replace.replacement];
           modified = true;
         }
 
         // Check if node should be added to.
-        const add = addOps.filter((op) => op.target === node);
+        const add = addOps.filter(op => op.target === node);
         if (add.length > 0) {
           modifiedNodes = [
-            ...add.filter((op) => op.before).map(((op) => op.before)),
+            ...add.filter(op => op.before).map(op => op.before),
             ...modifiedNodes,
-            ...add.filter((op) => op.after).map(((op) => op.after)),
+            ...add.filter(op => op.after).map(op => op.after),
           ] as ts.Node[];
           modified = true;
         }
@@ -79,7 +73,7 @@ export function makeTransform(
           return modifiedNodes;
         } else {
           // Otherwise return node as is and visit children.
-          return visitEachChild(node, visitor, context);
+          return ts.visitEachChild(node, visitor, context);
         }
       };
 
@@ -91,7 +85,7 @@ export function makeTransform(
       const result = ts.visitNode(sf, visitor);
 
       // If we removed any decorators, we need to clean up the decorator arrays.
-      if (removeOps.some((op) => op.target.kind === ts.SyntaxKind.Decorator)) {
+      if (removeOps.some(op => op.target.kind === ts.SyntaxKind.Decorator)) {
         cleanupDecorators(result);
       }
 
@@ -102,52 +96,11 @@ export function makeTransform(
   };
 }
 
-/**
- * This is a version of `ts.visitEachChild` that works that calls our version
- * of `updateSourceFileNode`, so that typescript doesn't lose type information
- * for property decorators.
- * See https://github.com/Microsoft/TypeScript/issues/17384 (fixed by
- * https://github.com/Microsoft/TypeScript/pull/20314 and released in TS 2.7.0) and
- * https://github.com/Microsoft/TypeScript/issues/17551 (fixed by
- * https://github.com/Microsoft/TypeScript/pull/18051 and released on TS 2.5.0).
- */
-function visitEachChildWorkaround(
-  node: ts.Node,
-  visitor: ts.Visitor,
-  context: ts.TransformationContext,
-) {
-
-  if (node.kind === ts.SyntaxKind.SourceFile) {
-    const sf = node as ts.SourceFile;
-    const statements = ts.visitLexicalEnvironment(sf.statements, visitor, context);
-
-    if (statements === sf.statements) {
-      return sf;
-    }
-    // Note: Need to clone the original file (and not use `ts.updateSourceFileNode`)
-    // as otherwise TS fails when resolving types for decorators.
-    const sfClone = ts.getMutableClone(sf);
-    sfClone.statements = statements;
-
-    return sfClone;
-  }
-
-  return ts.visitEachChild(node, visitor, context);
-}
-
-
-// 1) If TS sees an empty decorator array, it will still emit a `__decorate` call.
+// If TS sees an empty decorator array, it will still emit a `__decorate` call.
 //    This seems to be a TS bug.
-// 2) Also ensure nodes with modified decorators have parents
-//    built in TS transformers assume certain nodes have parents (fixed in TS 2.7+)
 function cleanupDecorators(node: ts.Node) {
-  if (node.decorators) {
-    if (node.decorators.length == 0) {
-      node.decorators = undefined;
-    } else if (node.parent == undefined) {
-      const originalNode = ts.getParseTreeNode(node);
-      node.parent = originalNode.parent;
-    }
+  if (node.decorators && node.decorators.length === 0) {
+    node.decorators = undefined;
   }
 
   ts.forEachChild(node, node => cleanupDecorators(node));

--- a/tests/legacy-cli/e2e/tests/misc/es2015-nometa.ts
+++ b/tests/legacy-cli/e2e/tests/misc/es2015-nometa.ts
@@ -1,0 +1,24 @@
+import { prependToFile, replaceInFile, writeFile } from '../../utils/fs';
+import { ng } from '../../utils/process';
+
+export default async function() {
+  // Ensure an ES2015 build is used in test
+  await writeFile('browserslist', 'Chrome 65');
+
+  await ng('generate', 'service', 'user');
+
+  // Update the application to use the new service
+  await prependToFile(
+    'src/app/app.component.ts',
+    'import { UserService } from \'./user.service\';',
+  );
+
+  await replaceInFile(
+    'src/app/app.component.ts',
+    'export class AppComponent {',
+    'export class AppComponent {\n  constructor(user: UserService) {}',
+  );
+
+  // Execute the application's tests with emitDecoratorMetadata disabled (default)
+  await ng('test', '--no-watch');
+}


### PR DESCRIPTION
By cloning the import specifier for each of the parameter types, TypeScript's import eliding algorithm will skip removal and prevent reference exceptions at runtime.