### PR TITLE
fix(@schematics/angular): remove indentation in component html 

### DIFF
--- a/packages/schematics/angular/component/files/__name@dasherize@if-flat__/__name@dasherize__.component.html.template
+++ b/packages/schematics/angular/component/files/__name@dasherize@if-flat__/__name@dasherize__.component.html.template
@@ -1,3 +1,1 @@
-<p>
-  <%= dasherize(name) %> works!
-</p>
+<p><%= dasherize(name) %> works!</p>


### PR DESCRIPTION
Most editors remember the indentation, even if you remove all code. This way, there is no
indentation thus there is nothing for the editor to remember and there will be no need for
a HTML lint fix.

Fixes #14816