### PR TITLE
refactor(@angular-devkit/build-angular): cleanup compatible Angular version check

### DIFF
--- a/packages/angular_devkit/build_angular/src/browser/index.ts
+++ b/packages/angular_devkit/build_angular/src/browser/index.ts
@@ -58,7 +58,7 @@ import {
 } from '../angular-cli-files/utilities/stats';
 import { ExecutionTransformer } from '../transforms';
 import { BuildBrowserFeatures, deleteOutputDir } from '../utils';
-import { Version } from '../utils/version';
+import { assertCompatibleAngularVersion } from '../utils/version';
 import { generateBrowserWebpackConfigFromContext } from '../utils/webpack-browser-config';
 import { Schema as BrowserBuilderSchema } from './schema';
 
@@ -180,7 +180,7 @@ export function buildWebpackBrowser(
   const root = normalize(context.workspaceRoot);
 
   // Check Angular version.
-  Version.assertCompatibleAngularVersion(context.workspaceRoot);
+  assertCompatibleAngularVersion(context.workspaceRoot, context.logger);
 
   const loggingFn = transforms.logging
     || createBrowserLoggingCallback(!!options.verbose, context.logger);

--- a/packages/angular_devkit/build_angular/src/dev-server/index.ts
+++ b/packages/angular_devkit/build_angular/src/dev-server/index.ts
@@ -36,7 +36,7 @@ import {
 import { Schema as BrowserBuilderSchema } from '../browser/schema';
 import { ExecutionTransformer } from '../transforms';
 import { normalizeOptimization } from '../utils';
-import { Version } from '../utils/version';
+import { assertCompatibleAngularVersion } from '../utils/version';
 import { Schema } from './schema';
 const open = require('open');
 
@@ -80,7 +80,7 @@ export function serveWebpackBrowser(
   } = {},
 ): Observable<DevServerBuilderOutput> {
   // Check Angular version.
-  Version.assertCompatibleAngularVersion(context.workspaceRoot);
+  assertCompatibleAngularVersion(context.workspaceRoot, context.logger);
 
   const browserTarget = targetFromTargetString(options.browserTarget);
   const root = context.workspaceRoot;

--- a/packages/angular_devkit/build_angular/src/extract-i18n/index.ts
+++ b/packages/angular_devkit/build_angular/src/extract-i18n/index.ts
@@ -23,7 +23,7 @@ import {
 import { readTsconfig } from '../angular-cli-files/utilities/read-tsconfig';
 import { statsErrorsToString, statsWarningsToString } from '../angular-cli-files/utilities/stats';
 import { Schema as BrowserBuilderOptions } from '../browser/schema';
-import { Version } from '../utils/version';
+import { assertCompatibleAngularVersion } from '../utils/version';
 import { generateBrowserWebpackConfigFromContext } from '../utils/webpack-browser-config';
 import { Schema as ExtractI18nBuilderOptions } from './schema';
 
@@ -51,7 +51,7 @@ class InMemoryOutputPlugin {
 
 async function execute(options: ExtractI18nBuilderOptions, context: BuilderContext) {
   // Check Angular version.
-  Version.assertCompatibleAngularVersion(context.workspaceRoot);
+  assertCompatibleAngularVersion(context.workspaceRoot, context.logger);
 
   const browserTarget = targetFromTargetString(options.browserTarget);
   const browserOptions = await context.validateOptions<JsonObject & BrowserBuilderOptions>(

--- a/packages/angular_devkit/build_angular/src/karma/index.ts
+++ b/packages/angular_devkit/build_angular/src/karma/index.ts
@@ -19,7 +19,7 @@ import {
 } from '../angular-cli-files/models/webpack-configs';
 import { Schema as BrowserBuilderOptions } from '../browser/schema';
 import { ExecutionTransformer } from '../transforms';
-import { Version } from '../utils/version';
+import { assertCompatibleAngularVersion } from '../utils/version';
 import { generateBrowserWebpackConfigFromContext } from '../utils/webpack-browser-config';
 import { Schema as KarmaBuilderOptions } from './schema';
 
@@ -69,7 +69,7 @@ export function execute(
   } = {},
 ): Observable<BuilderOutput> {
   // Check Angular version.
-  Version.assertCompatibleAngularVersion(context.workspaceRoot);
+  assertCompatibleAngularVersion(context.workspaceRoot, context.logger);
 
   return from(initialize(options, context, transforms.webpackConfiguration)).pipe(
     switchMap(([karma, webpackConfig]) => new Observable<BuilderOutput>(subscriber => {

--- a/packages/angular_devkit/build_angular/src/server/index.ts
+++ b/packages/angular_devkit/build_angular/src/server/index.ts
@@ -24,7 +24,7 @@ import {
 } from '../angular-cli-files/models/webpack-configs';
 import { ExecutionTransformer } from '../transforms';
 import { NormalizedBrowserBuilderSchema, deleteOutputDir } from '../utils';
-import { Version } from '../utils/version';
+import { assertCompatibleAngularVersion } from '../utils/version';
 import { generateBrowserWebpackConfigFromContext } from '../utils/webpack-browser-config';
 import { Schema as ServerBuilderOptions } from './schema';
 
@@ -46,7 +46,7 @@ export function execute(
   const root = context.workspaceRoot;
 
   // Check Angular version.
-  Version.assertCompatibleAngularVersion(context.workspaceRoot);
+  assertCompatibleAngularVersion(context.workspaceRoot, context.logger);
 
   return from(buildServerWebpackConfig(options, context)).pipe(
     concatMap(async v => transforms.webpackConfiguration ? transforms.webpackConfiguration(v) : v),

--- a/packages/angular_devkit/build_angular/src/utils/version.ts
+++ b/packages/angular_devkit/build_angular/src/utils/version.ts
@@ -5,136 +5,103 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import { logging, tags } from '@angular-devkit/core';
+import { SemVer, gte, satisfies } from 'semver';
 
-import { tags, terminal } from '@angular-devkit/core';
-import * as path from 'path';
-import { SemVer, satisfies } from 'semver';
+export function assertCompatibleAngularVersion(projectRoot: string, logger: logging.LoggerApi) {
+  let angularCliPkgJson;
+  let angularPkgJson;
+  let rxjsPkgJson;
+  const resolveOptions = { paths: [projectRoot] };
 
+  try {
+    const angularPackagePath = require.resolve('@angular/core/package.json', resolveOptions);
+    const rxjsPackagePath = require.resolve('rxjs/package.json', resolveOptions);
 
-export class Version {
-  private _semver: SemVer | null = null;
-  constructor(private _version: string | null = null) {
-    this._semver = _version ? new SemVer(_version) : null;
+    angularPkgJson = require(angularPackagePath);
+    rxjsPkgJson = require(rxjsPackagePath);
+  } catch {
+    logger.error(tags.stripIndents`
+      You seem to not be depending on "@angular/core" and/or "rxjs". This is an error.
+    `);
+
+    process.exit(2);
   }
 
-  isAlpha() { return this.qualifier == 'alpha'; }
-  isBeta() { return this.qualifier == 'beta'; }
-  isReleaseCandidate() { return this.qualifier == 'rc'; }
-  isKnown() { return this._version !== null; }
+  if (!(angularPkgJson && angularPkgJson['version'] && rxjsPkgJson && rxjsPkgJson['version'])) {
+    logger.error(tags.stripIndents`
+      Cannot determine versions of "@angular/core" and/or "rxjs".
+      This likely means your local installation is broken. Please reinstall your packages.
+    `);
 
-  isLocal() { return this.isKnown() && this._version && path.isAbsolute(this._version); }
-  isGreaterThanOrEqualTo(other: SemVer) {
-    return this._semver !== null && this._semver.compare(other) >= 0;
-  }
-  satisfies(other: string) {
-    // This comparison includes pre-releases (like betas and rcs), and considers them to be
-    // before the release proper.
-    // e.g. '9.0.0-beta.1' will satisfy '>=7.0.0 <9.0.0', but '9.0.0' will not.
-    return this._semver !== null && satisfies(this._semver, other, { includePrerelease: true });
+    process.exit(2);
   }
 
-  get major() { return this._semver ? this._semver.major : 0; }
-  get minor() { return this._semver ? this._semver.minor : 0; }
-  get patch() { return this._semver ? this._semver.patch : 0; }
-  get qualifier() { return this._semver ? this._semver.prerelease[0] : ''; }
-  get extra() { return this._semver ? this._semver.prerelease[1] : ''; }
-
-  toString() { return this._version; }
-
-  static assertCompatibleAngularVersion(projectRoot: string) {
-    let angularCliPkgJson;
-    let angularPkgJson;
-    let rxjsPkgJson;
-    const resolveOptions = { paths: [projectRoot] };
-
-    try {
-      const angularPackagePath = require.resolve('@angular/core/package.json', resolveOptions);
-      const rxjsPackagePath = require.resolve('rxjs/package.json', resolveOptions);
-
-      angularPkgJson = require(angularPackagePath);
-      rxjsPkgJson = require(rxjsPackagePath);
-    } catch {
-      console.error(terminal.bold(terminal.red(tags.stripIndents`
-        You seem to not be depending on "@angular/core" and/or "rxjs". This is an error.
-      `)));
-      process.exit(2);
+  try {
+    const angularCliPkgPath = require.resolve('@angular/cli/package.json', resolveOptions);
+    angularCliPkgJson = require(angularCliPkgPath);
+    if (!(angularCliPkgJson && angularCliPkgJson['version'])) {
+      throw new Error();
     }
+  } catch {
+    logger.error(tags.stripIndents`
+      Cannot determine versions of "@angular/cli".
+      This likely means your local installation is broken. Please reinstall your packages.
+    `);
 
-    if (!(angularPkgJson && angularPkgJson['version'] && rxjsPkgJson && rxjsPkgJson['version'])) {
-      console.error(terminal.bold(terminal.red(tags.stripIndents`
-        Cannot determine versions of "@angular/core" and/or "rxjs".
-        This likely means your local installation is broken. Please reinstall your packages.
-      `)));
-      process.exit(2);
-    }
-
-    try {
-      const angularCliPkgPath = require.resolve('@angular/cli/package.json', resolveOptions);
-      angularCliPkgJson = require(angularCliPkgPath);
-      if (!(angularCliPkgJson && angularCliPkgJson['version'])) {
-        throw new Error();
-      }
-    } catch (error) {
-      console.error(terminal.bold(terminal.red(tags.stripIndents`
-        Cannot determine versions of "@angular/cli".
-        This likely means your local installation is broken. Please reinstall your packages.
-      `)));
-      process.exit(2);
-    }
-
-    if (angularCliPkgJson['version'] === '0.0.0') {
-      // Internal testing version
-      return;
-    }
-
-    const cliMajor = new Version(angularCliPkgJson['version']).major;
-    // e.g. CLI 8.0 supports '>=8.0.0 <9.0.0', including pre-releases (betas, rcs, snapshots)
-    // of both 8 and 9.
-    const supportedAngularSemver = `^${cliMajor}.0.0-beta || ` +
-      `>=${cliMajor}.0.0 <${cliMajor + 1}.0.0`;
-
-    const angularVersion = new Version(angularPkgJson['version']);
-    const rxjsVersion = new Version(rxjsPkgJson['version']);
-
-    if (angularVersion.isLocal()) {
-      console.error(terminal.yellow('Using a local version of angular. Proceeding with care...'));
-
-      return;
-    }
-
-    if (!angularVersion.satisfies(supportedAngularSemver)) {
-      console.error(terminal.bold(terminal.red(tags.stripIndents`
-          This version of CLI is only compatible with Angular versions ${supportedAngularSemver},
-          but Angular version ${angularVersion} was found instead.
-
-          Please visit the link below to find instructions on how to update Angular.
-          https://angular-update-guide.firebaseapp.com/
-        ` + '\n')));
-      process.exit(3);
-    } else if (
-      angularVersion.isGreaterThanOrEqualTo(new SemVer('6.0.0-rc.0'))
-      && !rxjsVersion.isGreaterThanOrEqualTo(new SemVer('5.6.0-forward-compat.0'))
-      && !rxjsVersion.isGreaterThanOrEqualTo(new SemVer('6.0.0-beta.0'))
-    ) {
-      console.error(terminal.bold(terminal.red(tags.stripIndents`
-          This project uses version ${rxjsVersion} of RxJs, which is not supported by Angular v6+.
-          The official RxJs version that is supported is 5.6.0-forward-compat.0 and greater.
-
-          Please visit the link below to find instructions on how to update RxJs.
-          https://docs.google.com/document/d/12nlLt71VLKb-z3YaSGzUfx6mJbc34nsMXtByPUN35cg/edit#
-        ` + '\n')));
-      process.exit(3);
-    } else if (
-      angularVersion.isGreaterThanOrEqualTo(new SemVer('6.0.0-rc.0'))
-      && !rxjsVersion.isGreaterThanOrEqualTo(new SemVer('6.0.0-beta.0'))
-    ) {
-      console.warn(terminal.bold(terminal.red(tags.stripIndents`
-          This project uses a temporary compatibility version of RxJs (${rxjsVersion}).
-
-          Please visit the link below to find instructions on how to update RxJs.
-          https://docs.google.com/document/d/12nlLt71VLKb-z3YaSGzUfx6mJbc34nsMXtByPUN35cg/edit#
-        ` + '\n')));
-    }
+    process.exit(2);
   }
 
+  if (angularCliPkgJson['version'] === '0.0.0') {
+    // Internal testing version
+    return;
+  }
+
+  const cliMajor = new SemVer(angularCliPkgJson['version']).major;
+  // e.g. CLI 8.0 supports '>=8.0.0 <9.0.0', including pre-releases (betas, rcs, snapshots)
+  // of both 8 and 9.
+  const supportedAngularSemver =
+    `^${cliMajor}.0.0-beta || ` + `>=${cliMajor}.0.0 <${cliMajor + 1}.0.0`;
+
+  const angularVersion = new SemVer(angularPkgJson['version']);
+  const rxjsVersion = new SemVer(rxjsPkgJson['version']);
+
+  if (!satisfies(angularVersion, supportedAngularSemver, { includePrerelease: true })) {
+    logger.error(
+      tags.stripIndents`
+        This version of CLI is only compatible with Angular versions ${supportedAngularSemver},
+        but Angular version ${angularVersion} was found instead.
+
+        Please visit the link below to find instructions on how to update Angular.
+        https://angular-update-guide.firebaseapp.com/
+      ` + '\n',
+    );
+
+    process.exit(3);
+  } else if (
+    gte(angularVersion, '6.0.0-rc.0') &&
+    !gte(rxjsVersion, '5.6.0-forward-compat.0') &&
+    !gte(rxjsVersion, '6.0.0-beta.0')
+  ) {
+    logger.error(
+      tags.stripIndents`
+        This project uses version ${rxjsVersion} of RxJs, which is not supported by Angular v6+.
+        The official RxJs version that is supported is 5.6.0-forward-compat.0 and greater.
+
+        Please visit the link below to find instructions on how to update RxJs.
+        https://docs.google.com/document/d/12nlLt71VLKb-z3YaSGzUfx6mJbc34nsMXtByPUN35cg/edit#
+      ` + '\n',
+    );
+
+    process.exit(3);
+  } else if (gte(angularVersion, '6.0.0-rc.0') && !gte(rxjsVersion, '6.0.0-beta.0')) {
+    logger.warn(
+      tags.stripIndents`
+        This project uses a temporary compatibility version of RxJs (${rxjsVersion}).
+
+        Please visit the link below to find instructions on how to update RxJs.
+        https://docs.google.com/document/d/12nlLt71VLKb-z3YaSGzUfx6mJbc34nsMXtByPUN35cg/edit#
+      ` + '\n',
+    );
+  }
 }


### PR DESCRIPTION
This code has been mainly untouched (but moved around) since CLI 1.x.  This change leverages the logging framework as well as removes unused code.