### PR TITLE
fix(@angular-devkit/build-angular): karma cannot read property 'succe…

### DIFF
--- a/packages/angular_devkit/build_angular/src/karma/index.ts
+++ b/packages/angular_devkit/build_angular/src/karma/index.ts
@@ -8,7 +8,7 @@
 import { BuilderContext, BuilderOutput, createBuilder } from '@angular-devkit/architect';
 import { resolve } from 'path';
 import { Observable, from } from 'rxjs';
-import { switchMap } from 'rxjs/operators';
+import { defaultIfEmpty, switchMap } from 'rxjs/operators';
 import * as webpack from 'webpack';
 import {
   getCommonConfig,
@@ -128,6 +128,7 @@ export function execute(
         }
       };
     })),
+    defaultIfEmpty({ success: false }),
   );
 }
 


### PR DESCRIPTION
…ss' of undefined

When an error occures outside of the compilation, the observable gets completed without `success` being set. Which causes `Cannot read property 'success' of undefined`

Related to #14621 and might solve #14118