### PR TITLE
fix(@angular/cli): correct git branch in ng version

### DIFF
--- a/packages/angular/cli/commands/version-impl.ts
+++ b/packages/angular/cli/commands/version-impl.ts
@@ -84,8 +84,12 @@ export class VersionCommand extends Command<VersionCommandSchema> {
     if (!__dirname.match(/node_modules/)) {
       let gitBranch = '??';
       try {
-        const gitRefName = '' + child_process.execSync('git symbolic-ref HEAD', {cwd: __dirname});
-        gitBranch = path.basename(gitRefName.replace('\n', ''));
+        const gitRefName = child_process.execSync('git rev-parse --abbrev-ref HEAD', {
+          cwd: __dirname,
+          encoding: 'utf8',
+          stdio: 'pipe',
+        });
+        gitBranch = gitRefName.replace('\n', '');
       } catch {
       }
 


### PR DESCRIPTION
When testing a local CLI build with `npm link @angular/cli`, if you run `ng version`,
you currently see:

    Angular CLI: local (v8.1.0-beta.2+24.3bb67d8.with-local-changes, branch: version)

if the Git branch is `fix/version`.

Whit this PR, `ng version` now displays the proper Git branch name:

    Angular CLI: local (v8.1.0-beta.2+24.3bb67d8.with-local-changes, branch: fix/version)