### PR TITLE
fix(@angular-devkit/build-angular): re-order reporters to set code coverage at the very end

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/karma.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/karma.ts
@@ -70,17 +70,15 @@ const init: any = (config: any, emitter: any, customFileHandlers: any) => {
   successCb = config.buildWebpack.successCb;
   failureCb = config.buildWebpack.failureCb;
 
-  config.reporters.unshift('@angular-devkit/build-angular--event-reporter');
-
   // When using code-coverage, auto-add coverage-istanbul.
   config.reporters = config.reporters || [];
   if (options.codeCoverage && config.reporters.indexOf('coverage-istanbul') === -1) {
-    config.reporters.unshift('coverage-istanbul');
+    config.reporters.push('coverage-istanbul');
   }
 
   // Add a reporter that fixes sourcemap urls.
   if (normalizeSourceMaps(options.sourceMap).scripts) {
-    config.reporters.unshift('@angular-devkit/build-angular--sourcemap-reporter');
+    config.reporters.push('@angular-devkit/build-angular--sourcemap-reporter');
 
     // Code taken from https://github.com/tschaub/karma-source-map-support.
     // We can't use it directly because we need to add it conditionally in this file, and karma
@@ -93,6 +91,8 @@ const init: any = (config: any, emitter: any, customFileHandlers: any) => {
       { pattern: path.join(ksmsPath, 'client.js'), watched: false }
     ], true);
   }
+
+  config.reporters.push('@angular-devkit/build-angular--event-reporter');
 
   // Add webpack config.
   const webpackConfig = config.buildWebpack.webpackConfig;

--- a/packages/angular_devkit/build_angular/test/karma/code-coverage_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/karma/code-coverage_spec_large.ts
@@ -110,4 +110,21 @@ describe('Karma Builder code coverage', () => {
       expect(content).not.toContain('my-lib');
     }
   }, 120000);
+
+  it(`should fail when coverage is below threhold and 'emitWarning' is false`, async () => {
+    host.replaceInFile('karma.conf.js', 'fixWebpackSourcePaths: true',
+      `
+      fixWebpackSourcePaths: true,
+      thresholds: {
+        emitWarning: false,
+        global: {
+          statements: 200
+        }
+      }`,
+    );
+
+    const run = await architect.scheduleTarget(karmaTargetSpec, { codeCoverage: true });
+    await expectAsync(run.result).toBeResolvedTo(jasmine.objectContaining({ success: false }));
+    await run.stop();
+  }, 120000);
 });


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/17563226/59829646-394b4380-933e-11e9-804f-32d78e1d6c21.png)


After
![image](https://user-images.githubusercontent.com/17563226/59829593-1456d080-933e-11e9-8a43-85f9427d0186.png)

