### PR TITLE
feat(@angular-devkit/build-angular): add crossorigin options

### DIFF
--- a/packages/angular/cli/lib/config/schema.json
+++ b/packages/angular/cli/lib/config/schema.json
@@ -890,6 +890,16 @@
             "webWorkerTsConfig": {
               "type": "string",
               "description": "TypeScript configuration for Web Worker modules."
+            },
+            "crossOrigin": {
+              "type": "string",
+              "description": "Define the crossorigin attribute setting of elements that provide CORS support.",
+              "default": "none",
+              "enum": [
+                "none",
+                "anonymous",
+                "use-credentials"
+              ]
             }
           },
           "additionalProperties": false,

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/index-html-webpack-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/index-html-webpack-plugin.ts
@@ -8,7 +8,11 @@
 import * as path from 'path';
 import { Compiler, compilation } from 'webpack';
 import { RawSource } from 'webpack-sources';
-import { FileInfo, augmentIndexHtml } from '../utilities/index-file/augment-index-html';
+import {
+  CrossOriginValue,
+  FileInfo,
+  augmentIndexHtml,
+} from '../utilities/index-file/augment-index-html';
 import { IndexHtmlTransform } from '../utilities/index-file/write-index-html';
 import { stripBom } from '../utilities/strip-bom';
 
@@ -22,6 +26,7 @@ export interface IndexHtmlWebpackPluginOptions {
   noModuleEntrypoints: string[];
   moduleEntrypoints: string[];
   postTransform?: IndexHtmlTransform;
+  crossOrigin?: CrossOriginValue;
 }
 
 function readFile(filename: string, compilation: compilation.Compilation): Promise<string> {
@@ -91,6 +96,7 @@ export class IndexHtmlWebpackPlugin {
         baseHref: this._options.baseHref,
         deployUrl: this._options.deployUrl,
         sri: this._options.sri,
+        crossOrigin: this._options.crossOrigin,
         files,
         noModuleFiles,
         loadOutputFile,

--- a/packages/angular_devkit/build_angular/src/browser/index.ts
+++ b/packages/angular_devkit/build_angular/src/browser/index.ts
@@ -115,9 +115,8 @@ function getAnalyticsConfig(
     let category = 'build';
     if (context.builder) {
       // We already vetted that this is a "safe" package, otherwise the analytics would be noop.
-      category = context.builder.builderName.split(':')[1]
-              || context.builder.builderName
-              || 'build';
+      category =
+        context.builder.builderName.split(':')[1] || context.builder.builderName || 'build';
     }
 
     // The category is the builder name if it's an angular builder.
@@ -264,6 +263,7 @@ export function buildWebpackBrowser(
               scripts: options.scripts,
               styles: options.styles,
               postTransform: transforms.indexHtml,
+              crossOrigin: options.crossOrigin,
             }).pipe(
               map(() => ({ success: true })),
               catchError(error => of({ success: false, error: mapErrorToMessage(error) })),

--- a/packages/angular_devkit/build_angular/src/browser/schema.json
+++ b/packages/angular_devkit/build_angular/src/browser/schema.json
@@ -319,6 +319,16 @@
     "webWorkerTsConfig": {
       "type": "string",
       "description": "TypeScript configuration for Web Worker modules."
+    },
+    "crossOrigin": {
+      "type": "string",
+      "description": "Define the crossorigin attribute setting of elements that provide CORS support.",
+      "default": "none",
+      "enum": [
+        "none",
+        "anonymous",
+        "use-credentials"
+      ]
     }
   },
   "additionalProperties": false,

--- a/packages/angular_devkit/build_angular/src/dev-server/index.ts
+++ b/packages/angular_devkit/build_angular/src/dev-server/index.ts
@@ -223,6 +223,7 @@ export function serveWebpackBrowser(
             sri: browserOptions.subresourceIntegrity,
             noModuleEntrypoints: ['polyfills-es5'],
             postTransform: transforms.indexHtml,
+            crossOrigin: browserOptions.crossOrigin,
           }),
         );
       }

--- a/packages/angular_devkit/build_angular/test/browser/cross-origin_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/browser/cross-origin_spec_large.ts
@@ -1,0 +1,89 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { Architect } from '@angular-devkit/architect';
+import { join, normalize, virtualFs } from '@angular-devkit/core';
+import { BrowserBuilderOutput } from '../../src/browser/index';
+import { CrossOrigin } from '../../src/browser/schema';
+import { createArchitect, host } from '../utils';
+
+describe('Browser Builder crossOrigin', () => {
+  const targetSpec = { project: 'app', target: 'build' };
+  let architect: Architect;
+
+  beforeEach(async () => {
+    await host.initialize().toPromise();
+    architect = (await createArchitect(host.root())).architect;
+
+    host.writeMultipleFiles({
+      'src/index.html': Buffer.from(
+        '\ufeff<html><head><base href="/"></head><body><app-root></app-root></body></html>',
+        'utf8',
+      ),
+    });
+  });
+
+  afterEach(async () => host.restore().toPromise());
+
+  it('works with use-credentials', async () => {
+    const overrides = { crossOrigin: CrossOrigin.UseCredentials };
+    const run = await architect.scheduleTarget(targetSpec, overrides);
+    const output = (await run.result) as BrowserBuilderOutput;
+    expect(output.success).toBe(true);
+    const fileName = join(normalize(output.outputPath), 'index.html');
+    const content = virtualFs.fileBufferToString(await host.read(normalize(fileName)).toPromise());
+    expect(content).toBe(
+      `<html><head><base href="/"></head>` +
+        `<body><app-root></app-root>` +
+        `<script src="runtime.js" crossorigin="use-credentials"></script>` +
+        `<script src="polyfills.js" crossorigin="use-credentials"></script>` +
+        `<script src="styles.js" crossorigin="use-credentials"></script>` +
+        `<script src="vendor.js" crossorigin="use-credentials"></script>` +
+        `<script src="main.js" crossorigin="use-credentials"></script></body></html>`,
+    );
+    await run.stop();
+  });
+
+  it('works with anonymous', async () => {
+    const overrides = { crossOrigin: CrossOrigin.Anonymous };
+    const run = await architect.scheduleTarget(targetSpec, overrides);
+    const output = (await run.result) as BrowserBuilderOutput;
+    expect(output.success).toBe(true);
+    const fileName = join(normalize(output.outputPath), 'index.html');
+    const content = virtualFs.fileBufferToString(await host.read(normalize(fileName)).toPromise());
+    expect(content).toBe(
+      `<html><head><base href="/"></head>` +
+        `<body><app-root></app-root>` +
+        `<script src="runtime.js" crossorigin="anonymous"></script>` +
+        `<script src="polyfills.js" crossorigin="anonymous"></script>` +
+        `<script src="styles.js" crossorigin="anonymous"></script>` +
+        `<script src="vendor.js" crossorigin="anonymous"></script>` +
+        `<script src="main.js" crossorigin="anonymous"></script></body></html>`,
+    );
+    await run.stop();
+  });
+
+  it('works with none', async () => {
+    const overrides = { crossOrigin: CrossOrigin.None };
+    const run = await architect.scheduleTarget(targetSpec, overrides);
+    const output = (await run.result) as BrowserBuilderOutput;
+    expect(output.success).toBe(true);
+    const fileName = join(normalize(output.outputPath), 'index.html');
+    const content = virtualFs.fileBufferToString(await host.read(normalize(fileName)).toPromise());
+    expect(content).toBe(
+      `<html><head><base href="/"></head>` +
+        `<body><app-root></app-root>` +
+        `<script src="runtime.js"></script>` +
+        `<script src="polyfills.js"></script>` +
+        `<script src="styles.js"></script>` +
+        `<script src="vendor.js"></script>` +
+        `<script src="main.js"></script></body></html>`,
+    );
+    await run.stop();
+  });
+});


### PR DESCRIPTION
This options allows to define the crossorigin attribute setting of elements that provide CORS support

By default we set the value to `anonymous`.

Closes #14743
