### PR TITLE
fix(@schematics/angular): conserve canonical doctype declaration case

### DIFF
--- a/etc/cli.angular.io/index.html
+++ b/etc/cli.angular.io/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="">
 <head>
     <meta charset="utf-8">

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/karma-debug.html
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/karma-debug.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <!--
 This file is almost the same as context.html - loads all source files,
 but its purpose is to be loaded in the main frame (not within an iframe),

--- a/packages/schematics/angular/application/files/src/index.html.template
+++ b/packages/schematics/angular/application/files/src/index.html.template
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="utf-8">

--- a/tests/angular_devkit/build_angular/hello-world-app/src/index.html
+++ b/tests/angular_devkit/build_angular/hello-world-app/src/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="utf-8">

--- a/tests/legacy-cli/e2e/assets/1.0-project/src/index.html
+++ b/tests/legacy-cli/e2e/assets/1.0-project/src/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
 <head>
   <meta charset="utf-8">

--- a/tests/legacy-cli/e2e/assets/1.7-project/src/index.html
+++ b/tests/legacy-cli/e2e/assets/1.7-project/src/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="utf-8">

--- a/tests/legacy-cli/e2e/assets/7.0-project/src/index.html
+++ b/tests/legacy-cli/e2e/assets/7.0-project/src/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="utf-8">


### PR DESCRIPTION
Use the HTML5 doctype declaration as defined by W3C, as is, conserving its case.

https://dev.w3.org/html5/html-author/#doctype-declaration
https://developer.mozilla.org/en-US/docs/Glossary/Doctype