### PR TITLE
fix(@angular-devkit/build-angular): polyfill URL to support $location

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/es5-polyfills.js
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/es5-polyfills.js
@@ -92,3 +92,5 @@ import 'core-js/modules/es.weak-map';
 import 'core-js/modules/es.set';
 import 'core-js/modules/web.dom-collections.iterator';
 import 'core-js/modules/es.promise';
+
+import 'core-js/modules/web.url';


### PR DESCRIPTION
The `$location` service relies on the URL constructor which is not present in IE9-11.  core-js provides a polyfill which has now been added to the ES5 polyfill set which will be loaded for IE9-11.

Size check failure is expected due to the addition of ES5 polyfills.
Gzipped size change is 38kb -> 44kb