### PR TITLE
fix(@angular-devkit/build-angular): revert performance optimization causing regression

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/webpack-browser-config.ts
+++ b/packages/angular_devkit/build_angular/src/utils/webpack-browser-config.ts
@@ -68,29 +68,20 @@ export async function generateWebpackConfig(
   // For differential loading, we can have several targets
   return scriptTargets.map(scriptTarget => {
     let buildOptions: NormalizedBrowserBuilderSchema = { ...options };
-    const supportES2015
-      = scriptTarget !== ts.ScriptTarget.ES3 && scriptTarget !== ts.ScriptTarget.ES5;
-
     if (differentialLoading) {
+      // For differential loading, the builder needs to created the index.html by itself
+      // without using a webpack plugin.
       buildOptions = {
         ...options,
-        ...(
-          // FIXME: we do create better webpack config composition to achieve the below
-          // When DL is enabled and supportES2015 is true it means that we are on the second build
-          // This also means that we don't need to include styles and assets multiple times
-          supportES2015
-            ? {}
-            : {
-              styles: options.extractCss ? [] : options.styles,
-              assets: [],
-            }
-        ),
         es5BrowserSupport: undefined,
         index: '',
         esVersionInFileName: true,
         scriptTargetOverride: scriptTarget,
       };
     }
+
+    const supportES2015
+      = scriptTarget !== ts.ScriptTarget.ES3 && scriptTarget !== ts.ScriptTarget.ES5;
 
     const wco: BrowserWebpackConfigOptions = {
       root: workspaceRoot,


### PR DESCRIPTION
This reverts commit 10200f1395229032caebf98d92a32ba4c975a96f.

The optimization was causing regression because we didn't cherry-pick https://github.com/angular/angular-cli/pull/14419 in patch.