### PR TITLE
refactor(@angular/cli): add missing defaults to update schema

### DIFF
--- a/packages/angular/cli/commands/update.json
+++ b/packages/angular/cli/commands/update.json
@@ -44,6 +44,7 @@
         },
         "migrateOnly": {
           "description": "Only perform a migration, does not update the installed version.",
+          "default": false,
           "type": "boolean"
         },
         "from": {
@@ -56,6 +57,7 @@
         },
         "allowDirty": {
           "description": "Whether to allow updating when the repository contains modified or untracked files.",
+          "default": false,
           "type": "boolean"
         }
       }


### PR DESCRIPTION
It's useful to indicate the defaults in the docs.
Currently `migrateOnly` and `allowDirty` don't list their defaults in the docs.
This addresses that.

![Screen Shot 2019-06-20 at 21 14 16](https://user-images.githubusercontent.com/3506071/59890760-6d575080-93a0-11e9-93a8-1b1a95c2da31.png)
