### PR TITLE
fix(@angular/cli): validate version in doc command

### DIFF
--- a/packages/angular/cli/commands/doc-impl.ts
+++ b/packages/angular/cli/commands/doc-impl.ts
@@ -23,10 +23,16 @@ export class DocCommand extends Command<DocCommandSchema> {
     let domain = 'angular.io';
 
     if (options.version) {
+      // version can either be a string containing "next"
       if (options.version == 'next') {
         domain = 'next.angular.io';
-      } else {
+      // or a number where version must be a valid Angular version (i.e. not 0, 1 or 3)
+      } else if (!isNaN(+options.version) && ![0, 1, 3].includes(+options.version)) {
         domain = `v${options.version}.angular.io`;
+      } else {
+        this.logger.error('Version should either be a number (2, 4, 5, 6...) or "next"');
+
+        return 0;
       }
     }
 

--- a/packages/angular/cli/commands/doc.json
+++ b/packages/angular/cli/commands/doc.json
@@ -27,16 +27,13 @@
           "description": "When true, searches all of angular.io. Otherwise, searches only API reference documentation."
         },
         "version" : {
-          "anyOf": [
+          "oneOf": [
             {
-              "const" : 2
-            },
-            {
-              "type" : "integer",
+              "type": "number",
               "minimum": 4
             },
             {
-              "const": "next"
+              "enum": [2, "next"]
             }
           ],
           "description": "Contains the version of Angular to use for the documentation."

--- a/packages/angular/cli/models/parser.ts
+++ b/packages/angular/cli/models/parser.ts
@@ -16,7 +16,7 @@ export class ParseArgumentException extends BaseException {
     public readonly parsed: Arguments,
     public readonly ignored: string[],
   ) {
-    super(`One or more errors occured while parsing arguments:\n  ${comments.join('\n  ')}`);
+    super(`One or more errors occurred while parsing arguments:\n  ${comments.join('\n  ')}`);
   }
 }
 


### PR DESCRIPTION
As the JSON Schema validation is minimum in the CLI, we have to also validate in code.
This PR:
- updates the JSON Schema to use `number` and `enum` instead of `integer` and `const` that are not supported.
- adds validation in the doc command implementation
- adds error reporting if the version is not valid
- fixes a typo in an error message in the parser