### PR TITLE
fix: fix BUILD file filter for npm package to include both BUILD and BUILD.bazel file

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -264,7 +264,7 @@ export default async function(
         }
 
         // Remove Bazel files from NPM.
-        if (fileName.endsWith('BUILD')) {
+        if (fileName === 'BUILD' || fileName === 'BUILD.bazel') {
           return false;
         }
 


### PR DESCRIPTION
This removes the file https://github.com/angular/angular-cli/blob/master/packages/schematics/angular/third_party/github.com/Microsoft/TypeScript/BUILD.bazel which currently makes it into the npm dist at `@schematics/angular/third_party/github.com/Microsoft/TypeScript/BUILD.bazel`.
