### PR TITLE
fix(@angular-devkit/schematics): fix use `install` subcommand when override package manager to yarn

### DIFF
--- a/packages/angular_devkit/schematics/tasks/node-package/executor.ts
+++ b/packages/angular_devkit/schematics/tasks/node-package/executor.ts
@@ -88,11 +88,11 @@ export default function(
 
     if (options.packageName) {
       if (options.command === 'install') {
-        args.push(packageManagerProfile.commands.installPackage);
+        args.push(taskPackageManagerProfile.commands.installPackage);
       }
       args.push(options.packageName);
-    } else if (options.command === 'install' && packageManagerProfile.commands.installAll) {
-      args.push(packageManagerProfile.commands.installAll);
+    } else if (options.command === 'install' && taskPackageManagerProfile.commands.installAll) {
+      args.push(taskPackageManagerProfile.commands.installAll);
     }
 
     if (options.quiet && taskPackageManagerProfile.quietArgument) {


### PR DESCRIPTION
Currently, when I running code:

```js
context.addTask(
  new NodePackageInstallTask({
    packageManager: 'yarn',
    packageName: 'typescript',
    workingDirectory: options.name,
  }),
)
```

and use command `schematics` to generate project, I get error:

```js
error `install` has been replaced with `add` to add new dependencies. Run "yarn add typescript" instead.
Error: Package install failed, see above.
    at ChildProcess.<anonymous> (/xxxx/node_modules/@angular-devkit/schematics/tasks/node-packa
ge/executor.js:94:31)
    at ChildProcess.emit (events.js:196:13)
    at maybeClose (internal/child_process.js:1000:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:267:5)
```

PS. I didn't find the `_spec.ts` file in `packages/angular_devkit/schematics/tasks/node-package/`, can anyone give me some advice about how to write unit test?