### PR TITLE
fix(@angular-devkit/build-angular): force event category to be something

### DIFF
--- a/packages/angular_devkit/build_angular/src/browser/index.ts
+++ b/packages/angular_devkit/build_angular/src/browser/index.ts
@@ -118,7 +118,9 @@ function getAnalyticsConfig(
     let category = 'build';
     if (context.builder) {
       // We already vetted that this is a "safe" package, otherwise the analytics would be noop.
-      category = context.builder.builderName.split(':')[1];
+      category = context.builder.builderName.split(':')[1]
+              || context.builder.builderName
+              || 'build';
     }
 
     // The category is the builder name if it's an angular builder.


### PR DESCRIPTION
If it is empty (or undefined), the Universal Analytics package will not send events.