### PR TITLE
Add `@angular/compiler-cli` version `8.1.0-next.0` as `peerDependency`

### DIFF
--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -86,7 +86,7 @@
     "zone.js": "^0.9.1"
   },
   "peerDependencies": {
-    "@angular/compiler-cli": ">=8.0.0-beta.0 < 9.0.0",
+    "@angular/compiler-cli": "^8.0.0-beta.0 || ^8.1.0-beta.0 || ^8.2.0-beta.0 || ^8.3.0-beta.0 || ^8.4.0-beta.0 || >=9.0.0-beta < 9",
     "typescript": ">=3.1 < 3.5"
   }
 }

--- a/packages/ngtools/webpack/package.json
+++ b/packages/ngtools/webpack/package.json
@@ -28,7 +28,7 @@
     "webpack-sources": "1.3.0"
   },
   "peerDependencies": {
-    "@angular/compiler-cli": ">=8.0.0-beta.0 < 9.0.0",
+    "@angular/compiler-cli": "^8.0.0-beta.0 || ^8.1.0-beta.0 || ^8.2.0-beta.0 || ^8.3.0-beta.0 || ^8.4.0-beta.0 || >=9.0.0-beta < 9",
     "typescript": ">=3.4 < 3.5",
     "webpack": "^4.0.0"
   },

--- a/tests/legacy-cli/e2e/tests/update/update-7.0.ts
+++ b/tests/legacy-cli/e2e/tests/update/update-7.0.ts
@@ -1,14 +1,11 @@
 import { createProjectFromAsset } from '../../utils/assets';
 import { expectFileMatchToExist, expectFileToExist, expectFileToMatch } from '../../utils/fs';
 import { ng, noSilentNg, silentNpm } from '../../utils/process';
-import {
-  isPrereleaseCli, useBuiltPackages, useCIChrome, useCIDefaults,
-} from '../../utils/project';
+import { isPrereleaseCli, useBuiltPackages, useCIChrome, useCIDefaults } from '../../utils/project';
 import { expectToFail } from '../../utils/utils';
 
-
-export default async function () {
-  const extraUpdateArgs = await isPrereleaseCli() ? ['--next'] : [];
+export default async function() {
+  const extraUpdateArgs = (await isPrereleaseCli()) ? ['--next', '--force'] : [];
 
   // Create new project from previous version files.
   // We must use the original NPM packages to force a real update.
@@ -23,8 +20,10 @@ export default async function () {
 
   // Test CLI migrations.
   // Should update the lazy route syntax via update-lazy-module-paths.
-  await expectFileToMatch('src/app/app-routing.module.ts',
-    `loadChildren: () => import('./lazy/lazy.module').then(m => m.LazyModule)`);
+  await expectFileToMatch(
+    'src/app/app-routing.module.ts',
+    `loadChildren: () => import('./lazy/lazy.module').then(m => m.LazyModule)`,
+  );
   // Should update tsconfig and src/browserslist via differential-loading.
   await expectFileToMatch('tsconfig.json', `"target": "es2015",`);
   await expectToFail(() => expectFileToExist('e2e/browserlist'));
@@ -33,8 +32,7 @@ export default async function () {
   // Should rename codelyzer rules.
   await expectFileToMatch('tslint.json', `use-lifecycle-interface`);
   // Unnecessary es6 polyfills should be removed via drop-es6-polyfills.
-  await expectToFail(() => expectFileToMatch('src/polyfills.ts',
-   `import 'core-js/es6/symbol';`));
+  await expectToFail(() => expectFileToMatch('src/polyfills.ts', `import 'core-js/es6/symbol';`));
   await expectToFail(() => expectFileToMatch('src/polyfills.ts', `import 'core-js/es6/set';`));
 
   // Use the packages we are building in this commit, and CI Chrome.


### PR DESCRIPTION
**fix(@angular-devkit/build-angular): add `@angular/compiler-cli` version `8.1.0-next.0` as `peerDependency`**
 
**fix(@ngtools/webpack): add `@angular/compiler-cli` version `8.1.0-next.0` as `peerDependency`**
 
**test: add `--force` to version 7 migration when updating prerelease versions**

We only use it for a few things but have a strict peerdep.

This strictness causes errors when updating the CLI from 7.x to 8.1 next projects:

Package "@angular-devkit/build-angular" has an incompatible peer dependency to "@angular/compiler-cli" (requires ">=8.0.0-beta.0 < 9.0.0" (extended), would install "8.1.0-next.3").
`build-angular` didn't have a peerdep on `@angular/compiler-cli` that supported `8.1.0-next`

This PR relaxes this requirement.

After the other commits get merged and released, we should to revert this commit.