### PR TITLE
test: disable max line length linting for constructor parameters transformer unit tests

### DIFF
--- a/packages/ngtools/webpack/src/transformers/ctor-parameters_spec.ts
+++ b/packages/ngtools/webpack/src/transformers/ctor-parameters_spec.ts
@@ -5,6 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+// tslint:disable:max-line-length
 import { tags } from '@angular-devkit/core'; // tslint:disable-line:no-implicit-dependencies
 import { createTypescriptContext, transformTypescript } from './ast_helpers';
 import { downlevelConstructorParameters } from './ctor-parameters';


### PR DESCRIPTION
Makes patch branch green; several of the output code strings are lengthy.