### PR TITLE
fix(@angular-devkit/build-angular): add Symbol.iterator polyfill for legacy browsers

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/es5-polyfills.js
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/es5-polyfills.js
@@ -8,6 +8,7 @@
 
 // ES2015 symbol capabilities
 import 'core-js/modules/es.symbol';
+import 'core-js/modules/es.symbol.iterator';
 
 // ES2015 function capabilities
 import 'core-js/modules/es.function.bind';


### PR DESCRIPTION
Fix #14916 