### PR TITLE
feat(@angular/cli): ng doc uses angular core version by default

### DIFF
--- a/packages/angular/cli/commands/doc-impl.ts
+++ b/packages/angular/cli/commands/doc-impl.ts
@@ -26,7 +26,7 @@ export class DocCommand extends Command<DocCommandSchema> {
       // version can either be a string containing "next"
       if (options.version == 'next') {
         domain = 'next.angular.io';
-      // or a number where version must be a valid Angular version (i.e. not 0, 1 or 3)
+        // or a number where version must be a valid Angular version (i.e. not 0, 1 or 3)
       } else if (!isNaN(+options.version) && ![0, 1, 3].includes(+options.version)) {
         domain = `v${options.version}.angular.io`;
       } else {
@@ -34,6 +34,14 @@ export class DocCommand extends Command<DocCommandSchema> {
 
         return 0;
       }
+    } else {
+      // we try to get the current Angular version of the project
+      // and use it if we can find it
+      try {
+        /* tslint:disable-next-line:no-implicit-dependencies */
+        const currentNgVersion = require('@angular/core').VERSION.major;
+        domain = `v${currentNgVersion}.angular.io`;
+      } catch (e) {}
     }
 
     let searchUrl = `https://${domain}/api?query=${options.keyword}`;

--- a/packages/angular/cli/commands/doc.json
+++ b/packages/angular/cli/commands/doc.json
@@ -36,7 +36,7 @@
               "enum": [2, "next"]
             }
           ],
-          "description": "Contains the version of Angular to use for the documentation."
+          "description": "Contains the version of Angular to use for the documentation. If not provided, the command uses your current Angular core version."
         }
       },
       "required": [


### PR DESCRIPTION
Follow-up to #14788 that allowed `ng doc --version 6`.
This commit enhances the doc command to use the current Angular version of the project by default, if no version is provided explicitely.

Fixes #12365