### PR TITLE
fix(@angular-devkit/architect): fix for newest version of rxjs

### DIFF
--- a/packages/angular_devkit/architect/src/architect.ts
+++ b/packages/angular_devkit/architect/src/architect.ts
@@ -61,7 +61,8 @@ function _createJobHandlerFromBuilderInfo(
           // Validate v against the options schema.
           return registry.compile(info.optionSchema).pipe(
             concatMap(validation => validation(options)),
-            map(({ data, success, errors }) => {
+            map((validationResult: json.schema.SchemaValidatorResult) => {
+              const { data, success, errors } = validationResult;
               if (success) {
                 return { ...v, options: data } as BuilderInput;
               }


### PR DESCRIPTION
Only Line 64 matters.

Prettier seems to be auto-formatting the other lines.

This was needed because rxjs version inside Google is being updated.