### PR TITLE
fix(@angular-devkit/build-angular): IE11 errors when using scripts an…

### DIFF
--- a/packages/angular_devkit/build_angular/src/browser/index.ts
+++ b/packages/angular_devkit/build_angular/src/browser/index.ts
@@ -236,8 +236,8 @@ export function buildWebpackBrowser(
             const [firstBuild, secondBuild] = buildEvents;
 
             if (buildEvents.length === 2) {
-              noModuleFiles = firstBuild.emittedFiles;
-              moduleFiles = secondBuild.emittedFiles || [];
+              moduleFiles = firstBuild.emittedFiles || [];
+              noModuleFiles = secondBuild.emittedFiles;
               files = moduleFiles.filter(x => x.extension === '.css');
             } else if (options.watch && isDifferentialLoadingNeeded) {
               // differential loading is not enabled in watch mode

--- a/packages/angular_devkit/build_angular/src/utils/webpack-browser-config.ts
+++ b/packages/angular_devkit/build_angular/src/utils/webpack-browser-config.ts
@@ -62,7 +62,7 @@ export async function generateWebpackConfig(
   const scriptTargets = [scriptTarget];
 
   if (differentialLoading) {
-    scriptTargets.unshift(ts.ScriptTarget.ES5);
+    scriptTargets.push(ts.ScriptTarget.ES5);
   }
 
   // For differential loading, we can have several targets


### PR DESCRIPTION
…d differential loading

Invert the builds so that es2015 scripts output don't override the es5 version.

Fixes #14777