### PR TITLE
fix(@angular-devkit/architect): one more fix for newest version of rxjs

### DIFF
--- a/packages/angular_devkit/core/src/experimental/jobs/simple-scheduler.ts
+++ b/packages/angular_devkit/core/src/experimental/jobs/simple-scheduler.ts
@@ -509,7 +509,8 @@ export class SimpleScheduler<
       waitable,
 
       from(handler).pipe(
-        switchMap(handler => new Observable((subscriber: Observer<JobOutboundMessage<O>>) => {
+        switchMap(handler => new Observable<JobOutboundMessage<O>>(
+                      (subscriber: Observer<JobOutboundMessage<O>>) => {
           if (!handler) {
             throw new JobDoesNotExistException(name);
           }


### PR DESCRIPTION
Provide explicit generics type to `new Observable()`