### PR TITLE
fix(@angular-devkit/build-angular): only add module script types to actual module scripts

### DIFF
--- a/packages/angular_devkit/build_angular/src/dev-server/index.ts
+++ b/packages/angular_devkit/build_angular/src/dev-server/index.ts
@@ -209,7 +209,7 @@ export function serveWebpackBrowser(
 
         const entrypoints = generateEntryPoints({ scripts, styles });
         const moduleEntrypoints = buildBrowserFeatures.isDifferentialLoadingNeeded()
-          ? entrypoints
+          ? generateEntryPoints({ scripts: [], styles })
           : [];
 
         webpackConfig.plugins.push(

--- a/packages/angular_devkit/build_angular/test/dev-server/index_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/dev-server/index_spec_large.ts
@@ -5,6 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import { workspaces } from '@angular-devkit/core';
 import fetch from 'node-fetch'; // tslint:disable-line:no-implicit-dependencies
 import { DevServerBuilderOutput } from '../../src/dev-server/index';
 import { createArchitect, host } from '../utils';
@@ -32,6 +33,50 @@ describe('Dev Server Builder index', () => {
       '<script src="runtime.js" type="module"></script>' +
         '<script src="polyfills.js" type="module"></script>' +
         '<script src="styles.js" type="module"></script>' +
+        '<script src="vendor.js" type="module"></script>' +
+        '<script src="main.js" type="module"></script>',
+    );
+    await run.stop();
+  });
+
+  it(`does not add 'type="module"' to custom scripts when differential loading is needed`, async () => {
+    host.writeMultipleFiles({
+      browserslist: `
+        last 1 chrome version
+        IE 10
+      `,
+      'test.js': 'console.log("test");',
+    });
+
+    const { workspace } = await workspaces.readWorkspace(host.root(), workspaces.createWorkspaceHost(host));
+    const app = workspace.projects.get('app');
+    if (!app) {
+      fail('Test application "app" not found.');
+
+      return;
+    }
+    const target = app.targets.get('build');
+    if (!target) {
+      fail('Test application "app" target "build" not found.');
+
+      return;
+    }
+    if (!target.options) {
+      target.options = {};
+    }
+    target.options.scripts = ['test.js'];
+    await workspaces.writeWorkspace(workspace, workspaces.createWorkspaceHost(host));
+
+    const architect = (await createArchitect(host.root())).architect;
+    const run = await architect.scheduleTarget(targetSpec);
+    const output = (await run.result) as DevServerBuilderOutput;
+    expect(output.success).toBe(true);
+    const response = await fetch('http://localhost:4200/index.html');
+    expect(await response.text()).toContain(
+      '<script src="runtime.js" type="module"></script>' +
+        '<script src="polyfills.js" type="module"></script>' +
+        '<script src="styles.js" type="module"></script>' +
+        '<script src="scripts.js"></script>' +
         '<script src="vendor.js" type="module"></script>' +
         '<script src="main.js" type="module"></script>',
     );


### PR DESCRIPTION
`ng serve` was errantly adding a module type to custom script bundles.  These scripts may contain ES5 and non-strict compatible code and can therefore not be marked as module scripts.  `ng build` already correctly operates in this fashion.

Fixes #14952