### PR TITLE
fix(@angular-devkit/build-angular): fix sourcemaps paths

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/utils.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/utils.ts
@@ -82,6 +82,7 @@ export function getSourceMapDevTool(
   return new SourceMapDevToolPlugin({
     filename: inlineSourceMap ? undefined : '[file].map',
     include,
+    moduleFilenameTemplate: '[namespace]/[resource-path]',
     append: hiddenSourceMap ? false : undefined,
   });
 }

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/karma.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/karma.ts
@@ -147,7 +147,6 @@ const init: any = (config: any, emitter: any, customFileHandlers: any) => {
   // Files need to be served from a custom path for Karma.
   webpackConfig.output.path = '/_karma_webpack_/';
   webpackConfig.output.publicPath = '/_karma_webpack_/';
-  webpackConfig.output.devtoolModuleFilenameTemplate = '[namespace]/[resource-path]?[loaders]';
 
   let compiler: any;
   try {


### PR DESCRIPTION
`output.devtoolModuleFilenameTemplate` is not used when `SourceMapDevToolPlugin`

https://github.com/webpack/webpack/blob/671cb184e34e748e7c3e1d724ee24263c18c19e9/lib/SourceMapDevToolPlugin.js#L77

Current stacktraces are not properly formatted
```
http://localhost:9876/_karma_webpack_/webpack:/src/app/dummy.component.spec.ts:36:76
```

With this change we wil change this to
```
http://localhost:9876/src/app/validation-directive.ts:13:23
```

This also allows users to click on the stacktrace in the browser and go to source.