### PR TITLE
fix(@angular/cli): add `verbose` option to `update` and `add`

### DIFF
--- a/packages/angular/cli/commands/add-impl.ts
+++ b/packages/angular/cli/commands/add-impl.ts
@@ -11,7 +11,7 @@ import { dirname, join } from 'path';
 import { intersects, prerelease, rcompare, satisfies, valid, validRange } from 'semver';
 import { isPackageNameSafeForAnalytics } from '../models/analytics';
 import { Arguments } from '../models/interface';
-import { SchematicCommand } from '../models/schematic-command';
+import { RunSchematicOptions, SchematicCommand } from '../models/schematic-command';
 import npmInstall from '../tasks/npm-install';
 import { colors } from '../utilities/color';
 import { getPackageManager } from '../utilities/package-manager';
@@ -65,6 +65,7 @@ export class AddCommand extends SchematicCommand<AddCommandSchema> {
         packageMetadata = await fetchPackageMetadata(packageIdentifier.name, this.logger, {
           registry: options.registry,
           usingYarn,
+          verbose: options.verbose,
         });
       } catch (e) {
         this.logger.error('Unable to fetch package metadata: ' + e.message);
@@ -116,6 +117,7 @@ export class AddCommand extends SchematicCommand<AddCommandSchema> {
       try {
         const manifest = await fetchPackageManifest(packageIdentifier, this.logger, {
           registry: options.registry,
+          verbose: options.verbose,
           usingYarn,
         });
 
@@ -174,12 +176,10 @@ export class AddCommand extends SchematicCommand<AddCommandSchema> {
     collectionName: string,
     options: string[] = [],
   ): Promise<number | void> {
-    const runOptions = {
+    const runOptions: RunSchematicOptions = {
       schematicOptions: options,
-      workingDir: this.workspace.root,
       collectionName,
       schematicName: 'ng-add',
-      allowPrivate: true,
       dryRun: false,
       force: false,
     };

--- a/packages/angular/cli/commands/add.json
+++ b/packages/angular/cli/commands/add.json
@@ -30,6 +30,11 @@
               "format": "hostname"
             }
           ]
+        },
+        "verbose": {
+          "description": "Display additional details about internal operations during execution.",
+          "type": "boolean",
+          "default": false
         }
       },
       "required": [

--- a/packages/angular/cli/commands/update-impl.ts
+++ b/packages/angular/cli/commands/update-impl.ts
@@ -11,7 +11,6 @@ import * as path from 'path';
 import * as semver from 'semver';
 import { Arguments, Option } from '../models/interface';
 import { SchematicCommand } from '../models/schematic-command';
-import { findUp } from '../utilities/find-up';
 import { getPackageManager } from '../utilities/package-manager';
 import {
   PackageIdentifier,
@@ -134,6 +133,7 @@ export class UpdateCommand extends SchematicCommand<UpdateCommandSchema> {
         additionalOptions: {
           force: options.force || false,
           next: options.next || false,
+          verbose: options.verbose || false,
           packageManager,
           packages: options.all ? Object.keys(rootDependencies) : [],
         },
@@ -240,6 +240,7 @@ export class UpdateCommand extends SchematicCommand<UpdateCommandSchema> {
           package: packageName,
           collection: migrations,
           from: options.from,
+          verbose: options.verbose || false,
           to: options.to || packageNode.package.version,
         },
       });
@@ -286,7 +287,7 @@ export class UpdateCommand extends SchematicCommand<UpdateCommandSchema> {
       try {
         // Metadata requests are internally cached; multiple requests for same name
         // does not result in additional network traffic
-        metadata = await fetchPackageMetadata(packageName, this.logger);
+        metadata = await fetchPackageMetadata(packageName, this.logger, { verbose: options.verbose });
       } catch (e) {
         this.logger.error(`Error fetching metadata for '${packageName}': ` + e.message);
 
@@ -339,6 +340,7 @@ export class UpdateCommand extends SchematicCommand<UpdateCommandSchema> {
       dryRun: !!options.dryRun,
       showNothingDone: false,
       additionalOptions: {
+        verbose: options.verbose || false,
         force: options.force || false,
         packageManager,
         packages: packagesToUpdate,

--- a/packages/angular/cli/commands/update.json
+++ b/packages/angular/cli/commands/update.json
@@ -57,6 +57,11 @@
         "allowDirty": {
           "description": "Whether to allow updating when the repository contains modified or untracked files.",
           "type": "boolean"
+        },
+        "verbose": {
+          "description": "Display additional details about internal operations during execution.",
+          "type": "boolean",
+          "default": false
         }
       }
     }


### PR DESCRIPTION
At the moment there is no way to turn on the verbose logging for `ng update` and `ng add`. This is useful for use so that when users report issues such as npmrc is not read we can see the lookup locations.

This also removes some reduncant that were being provided in `executeSchematic`.

Related to https://github.com/angular/angular-cli/issues/14993