### PR TITLE
fix(@angular-devkit/build-angular): use query option to set sockJS path in dev-server

### DIFF
--- a/packages/angular_devkit/build_angular/src/dev-server/index.ts
+++ b/packages/angular_devkit/build_angular/src/dev-server/index.ts
@@ -417,11 +417,13 @@ function _addLiveReload(
 
   // If a custom path is provided the webpack dev server client drops the sockjs-node segment.
   // This adds it back so that behavior is consistent when using a custom URL path
+  let sockjsPath = '';
   if (clientAddress.pathname) {
-    clientAddress.pathname = path.posix.join(clientAddress.pathname, 'sockjs-node');
+      clientAddress.pathname = path.posix.join(clientAddress.pathname, 'sockjs-node');
+      sockjsPath = '&sockPath=' + clientAddress.pathname;
   }
 
-  const entryPoints = [`${webpackDevServerPath}?${url.format(clientAddress)}`];
+  const entryPoints = [`${webpackDevServerPath}?${url.format(clientAddress)}${sockjsPath}`];
   if (options.hmr) {
     const webpackHmrLink = 'https://webpack.js.org/guides/hot-module-replacement';
 


### PR DESCRIPTION
Newer versions of `webpack-dev-server` do not honor the path segment of the passed URL and requires the query option to be used to configure the sockjs path of the reload client code.  This only affects 8.1+ as the version of `webpack-dev-server` used in 8.0.x does not have this requirement.

Fixes #15002