### PR TITLE
fix(@schematics/angular): add `text-summary` to code coverage reporter

### DIFF
--- a/packages/schematics/angular/library/files/karma.conf.js.template
+++ b/packages/schematics/angular/library/files/karma.conf.js.template
@@ -17,7 +17,7 @@ module.exports = function (config) {
     },
     coverageIstanbulReporter: {
       dir: require('path').join(__dirname, '<%= relativePathToWorkspaceRoot %>/coverage/<%= folderName %>'),
-      reports: ['html', 'lcovonly'],
+      reports: ['html', 'lcovonly', 'text-summary'],
       fixWebpackSourcePaths: true
     },
     reporters: ['progress', 'kjhtml'],


### PR DESCRIPTION
Code Coverage doesn't print to log when the project is generated with projectType **library**.

## Version
- Angular CLI : 8.1.0

## To Reproduce

- `$ ng new sample-app`
- `$ yarn ng g library sample-lib`
- `$ yarn ng test sample-lib --watch false --code-coverage --no-progress`

```
yarn ng test sample-lib --watch false --code-coverage --no-progress
yarn run v1.16.0
$ ng test sample-lib --watch false --code-coverage --no-progress
07 07 2019 18:32:20.750:INFO [karma-server]: Karma v4.1.0 server started at http://0.0.0.0:9876/
07 07 2019 18:32:20.755:INFO [launcher]: Launching browsers Chrome with concurrency unlimited
07 07 2019 18:32:20.761:INFO [launcher]: Starting browser Chrome
07 07 2019 18:32:28.657:INFO [Chrome 75.0.3770 (Mac OS X 10.14.5)]: Connected on socket 69o4bbRYREg2PJ9rAAAA with id 5385819
Chrome 75.0.3770 (Mac OS X 10.14.5): Executed 2 of 2 SUCCESS (0.299 secs / 0.238 secs)
TOTAL: 2 SUCCESS
TOTAL: 2 SUCCESS
TOTAL: 2 SUCCESS
✨  Done in 24.26s.
```

## Supplement
- Print code coverage summary if the project is generated with projectType **application**.

```
yarn ng test --watch false --code-coverage --no-progress
yarn run v1.16.0
$ ng test --watch false --code-coverage --no-progress
07 07 2019 18:33:53.595:INFO [karma-server]: Karma v4.1.0 server started at http://0.0.0.0:9876/
07 07 2019 18:33:53.607:INFO [launcher]: Launching browsers Chrome with concurrency unlimited
07 07 2019 18:33:53.611:INFO [launcher]: Starting browser Chrome
07 07 2019 18:34:01.758:INFO [Chrome 75.0.3770 (Mac OS X 10.14.5)]: Connected on socket IZRX727fPFWBSpoZAAAA with id 91122663
Chrome 75.0.3770 (Mac OS X 10.14.5): Executed 3 of 3 SUCCESS (0.397 secs / 0.312 secs)
TOTAL: 3 SUCCESS
TOTAL: 3 SUCCESS
TOTAL: 3 SUCCESS

=============================== Coverage summary ===============================
Statements   : 100% ( 6/6 )
Branches     : 100% ( 0/0 )
Functions    : 100% ( 1/1 )
Lines        : 100% ( 5/5 )
================================================================================
07 07 2019 18:34:09.325:INFO [karma-server]: Karma v4.1.0 server started at http://0.0.0.0:9876/
07 07 2019 18:34:09.326:INFO [launcher]: Launching browsers Chrome with concurrency unlimited
07 07 2019 18:34:09.330:INFO [launcher]: Starting browser Chrome
07 07 2019 18:34:17.019:INFO [Chrome 75.0.3770 (Mac OS X 10.14.5)]: Connected on socket bh9n-zG7ngDh6pZYAAAB with id 75219490
Chrome 75.0.3770 (Mac OS X 10.14.5): Executed 2 of 2 SUCCESS (0.295 secs / 0.243 secs)
TOTAL: 2 SUCCESS
TOTAL: 2 SUCCESS
TOTAL: 2 SUCCESS
✨  Done in 40.78s.
```

- Similar to #12542