### PR TITLE
Document possible values of analytics command

### DIFF
--- a/packages/angular/cli/commands/analytics-long.md
+++ b/packages/angular/cli/commands/analytics-long.md
@@ -1,0 +1,6 @@
+The value of *settingOrProject* is one of the following.
+* "on" : Enables analytics gathering for the user.
+* "off" : Disables analytics gathering for the user.
+* "ci" : 
+* "prompt" : Prompts the user to set the status interactively.
+* "project" : Sets the default status for the project to the *projectSetting* value, which can be any of the other values. The *projectSetting* argument is ignored for all other values of *settingOrProject*.

--- a/packages/angular/cli/commands/analytics-long.md
+++ b/packages/angular/cli/commands/analytics-long.md
@@ -1,6 +1,7 @@
 The value of *settingOrProject* is one of the following.
-* "on" : Enables analytics gathering for the user.
-* "off" : Disables analytics gathering for the user.
-* "ci" : 
+* "on" : Enables analytics gathering and reporting for the user.
+* "off" : Disables analytics gathering and reporting for the user.
+* "ci" : Enables analytics and configures reporting for use with Continuous Integration,
+which uses a common CI user.
 * "prompt" : Prompts the user to set the status interactively.
 * "project" : Sets the default status for the project to the *projectSetting* value, which can be any of the other values. The *projectSetting* argument is ignored for all other values of *settingOrProject*.

--- a/packages/angular/cli/commands/analytics.json
+++ b/packages/angular/cli/commands/analytics.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/schema",
   "$id": "ng-cli://commands/analytics.json",
   "description": "Configures the gathering of Angular CLI usage metrics. See https://v8.angular.io/cli/usage-analytics-gathering.",
-  "$longDescription": "",
+  "$longDescription": "./analytics-long.md",
 
   "$aliases": [],
   "$scope": "all",


### PR DESCRIPTION
The possible values are in the JSON (and an error message) but are not mentioned in the doc.

This is probably true of all enum values - in the standard API doc, value types are automatically extracted into the doc, but since these are always strings, we don't do that. We should have a way to automatically include enumerated value descriptions, that would go into the arg description. 

For now, I've put them into a long-description for the command.