### PR TITLE
fix(@angular/cli): use correct schematic defaults considering workspace

### DIFF
--- a/etc/api/angular_devkit/schematics/tools/index.d.ts
+++ b/etc/api/angular_devkit/schematics/tools/index.d.ts
@@ -28,6 +28,7 @@ export declare type FileSystemCollection = Collection<FileSystemCollectionDescri
 export declare type FileSystemCollectionDesc = CollectionDescription<FileSystemCollectionDescription>;
 
 export interface FileSystemCollectionDescription {
+    readonly name: string;
     readonly path: string;
     readonly schematics: {
         [name: string]: FileSystemSchematicDesc;
@@ -92,9 +93,11 @@ export interface FileSystemSchematicDescription extends FileSystemSchematicJsonD
 
 export interface FileSystemSchematicJsonDescription {
     readonly aliases?: string[];
+    readonly collection: FileSystemCollectionDescription;
     readonly description: string;
     readonly extends?: string;
     readonly factory: string;
+    readonly name: string;
     readonly schema?: string;
 }
 
@@ -135,6 +138,7 @@ export declare class NodeWorkflow extends workflow.BaseWorkflow {
         dryRun?: boolean;
         root?: Path;
         packageManager?: string;
+        registry?: schema.CoreSchemaRegistry;
     });
 }
 

--- a/packages/angular_devkit/schematics/tools/description.ts
+++ b/packages/angular_devkit/schematics/tools/description.ts
@@ -19,6 +19,7 @@ import {
 
 
 export interface FileSystemCollectionDescription {
+  readonly name: string;
   readonly path: string;
   readonly version?: string;
   readonly schematics: { [name: string]: FileSystemSchematicDesc };
@@ -28,6 +29,8 @@ export interface FileSystemCollectionDescription {
 export interface FileSystemSchematicJsonDescription {
   readonly aliases?: string[];
   readonly factory: string;
+  readonly name: string;
+  readonly collection: FileSystemCollectionDescription;
   readonly description: string;
   readonly schema?: string;
   readonly extends?: string;

--- a/packages/angular_devkit/schematics/tools/workflow/node-workflow.ts
+++ b/packages/angular_devkit/schematics/tools/workflow/node-workflow.ts
@@ -5,14 +5,13 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import { Path, getSystemPath, virtualFs } from '@angular-devkit/core';
+import { Path, getSystemPath, schema, virtualFs } from '@angular-devkit/core';
 import {
   workflow,
 } from '@angular-devkit/schematics';  // tslint:disable-line:no-implicit-dependencies
 import { BuiltinTaskExecutor } from '../../tasks/node';
 import { FileSystemEngine } from '../description';
 import { NodeModulesEngineHost } from '../node-module-engine-host';
-import { validateOptionsWithSchema } from '../schema-option-transform';
 
 /**
  * A workflow specifically for Node tools.
@@ -23,8 +22,9 @@ export class NodeWorkflow extends workflow.BaseWorkflow {
     options: {
       force?: boolean;
       dryRun?: boolean;
-      root?: Path,
+      root?: Path;
       packageManager?: string;
+      registry?: schema.CoreSchemaRegistry;
     },
   ) {
     const engineHost = new NodeModulesEngineHost();
@@ -34,9 +34,9 @@ export class NodeWorkflow extends workflow.BaseWorkflow {
 
       force: options.force,
       dryRun: options.dryRun,
+      registry: options.registry
     });
 
-    engineHost.registerOptionsTransform(validateOptionsWithSchema(this._registry));
     engineHost.registerTaskExecutor(
       BuiltinTaskExecutor.NodePackage,
       {

--- a/packages/angular_devkit/schematics/tools/workflow/node-workflow_spec.ts
+++ b/packages/angular_devkit/schematics/tools/workflow/node-workflow_spec.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 // tslint:disable:no-implicit-dependencies
+import { schema } from '@angular-devkit/core';
 import { NodeJsSyncHost } from '@angular-devkit/core/node';
 import { NodeWorkflow } from '@angular-devkit/schematics/tools';
 import * as path from 'path';


### PR DESCRIPTION
Fix #14986

This PR includes some refactoring to simplify the interaction of the `NodeWorkflow` and the `BaseWorkflow` with the registry.

We were registering redundant `addPostTransform`s. Some of them in the constructor of the `BaseWorkflow`, which did not allow us to intercept `addUndefinedDefaults`.

Additionally, we were setting the `validateOptionsWithSchema` transform multiple times unnecessarily.

An issue left to fix is support for the `--project` option in schematic commands. Currently, `getProjectName` does not know about this option, since `createWorkflow` does not know how to parse the command line arguments. The parsing logic is implemented partially by the concrete implementation of the `SchematicCommand` template method.