### PR TITLE
feat(@schematic/angular): enable ivy in tests

### DIFF
--- a/packages/schematics/angular/application/files/tsconfig.spec.json.template
+++ b/packages/schematics/angular/application/files/tsconfig.spec.json.template
@@ -14,5 +14,8 @@
   "include": [
     "src/**/*.spec.ts",
     "src/**/*.d.ts"
-  ]
+  ]<% if (enableIvy) { %>,
+  "angularCompilerOptions": {
+    "enableIvy": true
+  }<% } %>
 }


### PR DESCRIPTION
If a project is generated with `enableIvy`, this commit adds the necessary configuration to `tsconfig.spec.json` to then run the tests with Ivy. Note that the CLI already does the correct work (runs `ngcc` and then runs the tests).

cc @filipesilva as we talked about it on Slack