### PR TITLE
feat(@angular/cli): known command version shortcut

### DIFF
--- a/packages/angular/cli/commands/version-impl.ts
+++ b/packages/angular/cli/commands/version-impl.ts
@@ -14,7 +14,7 @@ import { findUp } from '../utilities/find-up';
 import { Schema as VersionCommandSchema } from './version';
 
 export class VersionCommand extends Command<VersionCommandSchema> {
-  public static aliases = ['v'];
+  public static aliases = ['v', '-v'];
 
   async run() {
     const pkg = require(path.resolve(__dirname, '..', 'package.json'));

--- a/packages/angular/cli/commands/version.json
+++ b/packages/angular/cli/commands/version.json
@@ -4,7 +4,7 @@
   "description": "Outputs Angular CLI version.",
   "$longDescription": "",
 
-  "$aliases": [ "v" ],
+  "$aliases": [ "v", "-v" ],
   "$scope": "all",
   "$impl": "./version-impl#VersionCommand",
 


### PR DESCRIPTION
just to make it possible to run 

`$ ng -v` (with `-`)

that everybody got used to for all other tools

