### PR TITLE
Pass target to a builder called through `context.scheduleBuilder`

### DIFF
--- a/packages/angular_devkit/architect/src/api.ts
+++ b/packages/angular_devkit/architect/src/api.ts
@@ -109,6 +109,11 @@ export interface ScheduleOptions {
    * to log a builder scheduled from your builder you should forward log events yourself.
    */
   logger?: logging.Logger;
+
+  /**
+   * Target to pass to the builder.
+   */
+  target?: Target;
 }
 
 /**

--- a/packages/angular_devkit/architect/src/create-builder.ts
+++ b/packages/angular_devkit/architect/src/create-builder.ts
@@ -129,6 +129,7 @@ export function createBuilder<
           ) {
             const run = await scheduleByName(builderName, options, {
               scheduler,
+              target: scheduleOptions.target,
               logger: scheduleOptions.logger || logger.createChild(''),
               workspaceRoot: i.workspaceRoot,
               currentDirectory: i.currentDirectory,


### PR DESCRIPTION
A custom builder can call `context.scheduleBuilder` to call another builder.
However, the following call will fail with `Must either have a target from
the context or a default project.` exception because `scheduleBuilder` does
not pass `target` to the called builder.

```typescript
import { JsonObject } from '@angular-devkit/core'
import { BuilderContext, BuilderOutput, BuilderRun, createBuilder } from '@angular-devkit/architect';
import { Observable, from } from 'rxjs';
import { concatMap, map } from 'rxjs/operators';

export default createBuilder(_customBuilder);

function _customBuilder(options: JsonObject, context: BuilderContext): Observable<BuilderOutput> {
    const builder = '@angular-devkit/build-angular:browser';

    return from(context.scheduleBuilder(builder, options)).pipe(
        concatMap(run => run.result)
    );
}
```

This patch makes sure that parent target is passed to the called builder.

Resolves:
https://github.com/angular/angular-cli/issues/15053