### PR TITLE
feat(@angular-devkit/build-angular): add defer attributes to classic scripts

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/index-file/augment-index-html.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/index-file/augment-index-html.ts
@@ -150,10 +150,14 @@ export async function augmentIndexHtml(params: AugmentIndexHtmlOptions): Promise
       const isModuleType = moduleFiles.some(scriptPredictor);
 
       if (isNoModuleType && !isModuleType) {
-        attrs.push({ name: 'nomodule', value: null });
+        attrs.push({ name: 'nomodule', value: null }, { name: 'defer', value: null });
       } else if (isModuleType && !isNoModuleType) {
         attrs.push({ name: 'type', value: 'module' });
+      } else {
+        attrs.push({ name: 'defer', value: null });
       }
+    } else {
+      attrs.push({ name: 'defer', value: null });
     }
 
     if (params.sri) {

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/index-file/augment-index-html_spec.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/index-file/augment-index-html_spec.ts
@@ -41,9 +41,9 @@ describe('augment-index-html', () => {
           <link rel="stylesheet" href="styles.css">
         </head>
         <body>
-          <script src="runtime.js"></script>
-          <script src="polyfills.js"></script>
-          <script src="main.js"></script>
+          <script src="runtime.js" defer></script>
+          <script src="polyfills.js" defer></script>
+          <script src="main.js" defer></script>
         </body>
       </html>
     `);
@@ -84,10 +84,10 @@ describe('augment-index-html', () => {
         <body>
           <script src="runtime-es2015.js" type="module"></script>
           <script src="polyfills-es2015.js" type="module"></script>
-          <script src="runtime-es5.js" nomodule></script>
-          <script src="polyfills-es5.js" nomodule></script>
+          <script src="runtime-es5.js" nomodule defer></script>
+          <script src="polyfills-es5.js" nomodule defer></script>
           <script src="main-es2015.js" type="module"></script>
-          <script src="main-es5.js" nomodule></script>
+          <script src="main-es5.js" nomodule defer></script>
         </body>
       </html>
     `);
@@ -124,9 +124,9 @@ describe('augment-index-html', () => {
           <link rel="stylesheet" href="styles.css">
         </head>
         <body>
-          <script src="scripts.js"></script>
+          <script src="scripts.js" defer></script>
           <script src="main-es2015.js" type="module"></script>
-          <script src="main-es5.js" nomodule></script>
+          <script src="main-es5.js" nomodule defer></script>
         </body>
       </html>
     `);

--- a/packages/angular_devkit/build_angular/test/browser/cross-origin_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/browser/cross-origin_spec_large.ts
@@ -40,11 +40,11 @@ describe('Browser Builder crossOrigin', () => {
     expect(content).toBe(
       `<html><head><base href="/"></head>` +
         `<body><app-root></app-root>` +
-        `<script src="runtime.js" crossorigin="use-credentials"></script>` +
-        `<script src="polyfills.js" crossorigin="use-credentials"></script>` +
-        `<script src="styles.js" crossorigin="use-credentials"></script>` +
-        `<script src="vendor.js" crossorigin="use-credentials"></script>` +
-        `<script src="main.js" crossorigin="use-credentials"></script></body></html>`,
+        `<script src="runtime.js" crossorigin="use-credentials" defer></script>` +
+        `<script src="polyfills.js" crossorigin="use-credentials" defer></script>` +
+        `<script src="styles.js" crossorigin="use-credentials" defer></script>` +
+        `<script src="vendor.js" crossorigin="use-credentials" defer></script>` +
+        `<script src="main.js" crossorigin="use-credentials" defer></script></body></html>`,
     );
     await run.stop();
   });
@@ -59,11 +59,11 @@ describe('Browser Builder crossOrigin', () => {
     expect(content).toBe(
       `<html><head><base href="/"></head>` +
         `<body><app-root></app-root>` +
-        `<script src="runtime.js" crossorigin="anonymous"></script>` +
-        `<script src="polyfills.js" crossorigin="anonymous"></script>` +
-        `<script src="styles.js" crossorigin="anonymous"></script>` +
-        `<script src="vendor.js" crossorigin="anonymous"></script>` +
-        `<script src="main.js" crossorigin="anonymous"></script></body></html>`,
+        `<script src="runtime.js" crossorigin="anonymous" defer></script>` +
+        `<script src="polyfills.js" crossorigin="anonymous" defer></script>` +
+        `<script src="styles.js" crossorigin="anonymous" defer></script>` +
+        `<script src="vendor.js" crossorigin="anonymous" defer></script>` +
+        `<script src="main.js" crossorigin="anonymous" defer></script></body></html>`,
     );
     await run.stop();
   });
@@ -78,11 +78,11 @@ describe('Browser Builder crossOrigin', () => {
     expect(content).toBe(
       `<html><head><base href="/"></head>` +
         `<body><app-root></app-root>` +
-        `<script src="runtime.js"></script>` +
-        `<script src="polyfills.js"></script>` +
-        `<script src="styles.js"></script>` +
-        `<script src="vendor.js"></script>` +
-        `<script src="main.js"></script></body></html>`,
+        `<script src="runtime.js" defer></script>` +
+        `<script src="polyfills.js" defer></script>` +
+        `<script src="styles.js" defer></script>` +
+        `<script src="vendor.js" defer></script>` +
+        `<script src="main.js" defer></script></body></html>`,
     );
     await run.stop();
   });

--- a/packages/angular_devkit/build_angular/test/browser/index_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/browser/index_spec_large.ts
@@ -35,9 +35,9 @@ describe('Browser Builder index HTML processing', () => {
     const content = virtualFs.fileBufferToString(await host.read(normalize(fileName)).toPromise());
     expect(content).toBe(
       `<html><head><base href="/"></head>`
-      + `<body><app-root></app-root><script src="runtime.js"></script>`
-      + `<script src="polyfills.js"></script><script src="styles.js"></script>`
-      + `<script src="vendor.js"></script><script src="main.js"></script></body></html>`,
+      + `<body><app-root></app-root><script src="runtime.js" defer></script>`
+      + `<script src="polyfills.js" defer></script><script src="styles.js" defer></script>`
+      + `<script src="vendor.js" defer></script><script src="main.js" defer></script></body></html>`,
     );
     await run.stop();
   });
@@ -57,9 +57,9 @@ describe('Browser Builder index HTML processing', () => {
     const content = virtualFs.fileBufferToString(await host.read(normalize(fileName)).toPromise());
     expect(content).toBe(
       `<html><head><base href="/"></head><body><app-root></app-root>`
-      + `<script src="runtime.js"></script><script src="polyfills.js"></script>`
-      + `<script src="styles.js"></script><script src="vendor.js"></script>`
-      + `<script src="main.js"></script></body></html>`,
+      + `<script src="runtime.js" defer></script><script src="polyfills.js" defer></script>`
+      + `<script src="styles.js" defer></script><script src="vendor.js" defer></script>`
+      + `<script src="main.js" defer></script></body></html>`,
     );
     await run.stop();
   });
@@ -79,9 +79,9 @@ describe('Browser Builder index HTML processing', () => {
     const content = virtualFs.fileBufferToString(await host.read(normalize(fileName)).toPromise());
     expect(content).toBe(
       `<html><head><title>&iacute;</title><base href="/"></head> `
-      + `<body><app-root></app-root><script src="runtime.js"></script>`
-      + `<script src="polyfills.js"></script><script src="styles.js"></script>`
-      + `<script src="vendor.js"></script><script src="main.js"></script></body></html>`,
+      + `<body><app-root></app-root><script src="runtime.js" defer></script>`
+      + `<script src="polyfills.js" defer></script><script src="styles.js" defer></script>`
+      + `<script src="vendor.js" defer></script><script src="main.js" defer></script></body></html>`,
     );
     await run.stop();
   });
@@ -101,9 +101,9 @@ describe('Browser Builder index HTML processing', () => {
     const content = virtualFs.fileBufferToString(await host.read(normalize(fileName)).toPromise());
     expect(content).toBe(
       `<html><head><base href="/"><%= csrf_meta_tags %></head> `
-      + `<body><app-root></app-root><script src="runtime.js"></script>`
-      + `<script src="polyfills.js"></script><script src="styles.js"></script>`
-      + `<script src="vendor.js"></script><script src="main.js"></script></body></html>`,
+      + `<body><app-root></app-root><script src="runtime.js" defer></script>`
+      + `<script src="polyfills.js" defer></script><script src="styles.js" defer></script>`
+      + `<script src="vendor.js" defer></script><script src="main.js" defer></script></body></html>`,
     );
     await run.stop();
   });
@@ -146,9 +146,9 @@ describe('Browser Builder index HTML processing', () => {
     const content = await host.read(normalize(outputIndexPath)).toPromise();
     expect(virtualFs.fileBufferToString(content)).toBe(
       `<html><head><base href="/"><%= csrf_meta_tags %></head> `
-      + `<body><app-root></app-root><script src="runtime.js"></script>`
-      + `<script src="polyfills.js"></script><script src="styles.js"></script>`
-      + `<script src="vendor.js"></script><script src="main.js"></script></body></html>`,
+      + `<body><app-root></app-root><script src="runtime.js" defer></script>`
+      + `<script src="polyfills.js" defer></script><script src="styles.js" defer></script>`
+      + `<script src="vendor.js" defer></script><script src="main.js" defer></script></body></html>`,
     );
   });
 
@@ -189,9 +189,9 @@ describe('Browser Builder index HTML processing', () => {
     const content = await host.read(normalize(outputIndexPath)).toPromise();
     expect(virtualFs.fileBufferToString(content)).toBe(
       `<html><head><base href="/"></head> `
-      + `<body><app-root></app-root><script src="runtime.js"></script>`
-      + `<script src="polyfills.js"></script><script src="styles.js"></script>`
-      + `<script src="vendor.js"></script><script src="main.js"></script></body></html>`,
+      + `<body><app-root></app-root><script src="runtime.js" defer></script>`
+      + `<script src="polyfills.js" defer></script><script src="styles.js" defer></script>`
+      + `<script src="vendor.js" defer></script><script src="main.js" defer></script></body></html>`,
     );
   });
 
@@ -232,9 +232,9 @@ describe('Browser Builder index HTML processing', () => {
     const content = await host.read(normalize(outputIndexPath)).toPromise();
     expect(virtualFs.fileBufferToString(content)).toBe(
       `<html><head><base href="/"></head> `
-      + `<body><app-root></app-root><script src="runtime.js"></script>`
-      + `<script src="polyfills.js"></script><script src="styles.js"></script>`
-      + `<script src="vendor.js"></script><script src="main.js"></script></body></html>`,
+      + `<body><app-root></app-root><script src="runtime.js" defer></script>`
+      + `<script src="polyfills.js" defer></script><script src="styles.js" defer></script>`
+      + `<script src="vendor.js" defer></script><script src="main.js" defer></script></body></html>`,
     );
   });
 });

--- a/packages/angular_devkit/build_angular/test/browser/scripts-array_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/browser/scripts-array_spec_large.ts
@@ -54,12 +54,12 @@ describe('Browser Builder scripts array', () => {
       'renamed-script.js': 'pre-rename-script',
       'renamed-lazy-script.js': 'pre-rename-lazy-script',
       'main.js': 'input-script',
-      'index.html': '<script src="runtime.js"></script>'
-        + '<script src="polyfills.js"></script>'
-        + '<script src="scripts.js"></script>'
-        + '<script src="renamed-script.js"></script>'
-        + '<script src="vendor.js"></script>'
-        + '<script src="main.js"></script>',
+      'index.html': '<script src="runtime.js" defer></script>'
+        + '<script src="polyfills.js" defer></script>'
+        + '<script src="scripts.js" defer></script>'
+        + '<script src="renamed-script.js" defer></script>'
+        + '<script src="vendor.js" defer></script>'
+        + '<script src="main.js" defer></script>',
     };
 
     host.writeMultipleFiles(scripts);

--- a/packages/angular_devkit/build_angular/test/browser/service-worker_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/browser/service-worker_spec_large.ts
@@ -110,7 +110,7 @@ describe('Browser Builder service worker', () => {
       hashTable: {
         '/favicon.ico': '84161b857f5c547e3699ddfbffc6d8d737542e01',
         '/assets/folder-asset.txt': '617f202968a6a81050aa617c2e28e1dca11ce8d4',
-        '/index.html': '1bcafd53046ffb270ac5e6f3cab23e0442f95c4f',
+        '/index.html': 'f95e7a84949070c4984069b592be7969bc3187a0',
         '/spectrum.png': '8d048ece46c0f3af4b598a95fd8e4709b631c3c0',
       },
     }));
@@ -167,7 +167,7 @@ describe('Browser Builder service worker', () => {
       hashTable: {
         '/foo/bar/favicon.ico': '84161b857f5c547e3699ddfbffc6d8d737542e01',
         '/foo/bar/assets/folder-asset.txt': '617f202968a6a81050aa617c2e28e1dca11ce8d4',
-        '/foo/bar/index.html': '925d80777b6ba64b526b0be79761d254dfe94c65',
+        '/foo/bar/index.html': 'a5359e8e1a516683b32bbb2f9e8bf402dae4738e',
       },
     }));
 

--- a/packages/angular_devkit/build_angular/test/browser/styles_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/browser/styles_spec_large.ts
@@ -54,12 +54,12 @@ describe('Browser Builder styles', () => {
     };
     const jsIndexMatches: { [path: string]: string } = {
       'index.html':
-        '<script src="runtime.js"></script>' +
-        '<script src="polyfills.js"></script>' +
-        '<script src="styles.js"></script>' +
-        '<script src="renamed-style.js"></script>' +
-        '<script src="vendor.js"></script>' +
-        '<script src="main.js"></script>',
+        '<script src="runtime.js" defer></script>' +
+        '<script src="polyfills.js" defer></script>' +
+        '<script src="styles.js" defer></script>' +
+        '<script src="renamed-style.js" defer></script>' +
+        '<script src="vendor.js" defer></script>' +
+        '<script src="main.js" defer></script>',
     };
 
     host.writeMultipleFiles({

--- a/packages/angular_devkit/build_angular/test/dev-server/index_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/dev-server/index_spec_large.ts
@@ -76,7 +76,7 @@ describe('Dev Server Builder index', () => {
       '<script src="runtime.js" type="module"></script>' +
         '<script src="polyfills.js" type="module"></script>' +
         '<script src="styles.js" type="module"></script>' +
-        '<script src="scripts.js"></script>' +
+        '<script src="scripts.js" defer></script>' +
         '<script src="vendor.js" type="module"></script>' +
         '<script src="main.js" type="module"></script>',
     );
@@ -96,11 +96,11 @@ describe('Dev Server Builder index', () => {
     expect(output.success).toBe(true);
     const response = await fetch('http://localhost:4200/index.html');
     expect(await response.text()).toContain(
-      '<script src="runtime.js"></script>' +
-        '<script src="polyfills.js"></script>' +
-        '<script src="styles.js"></script>' +
-        '<script src="vendor.js"></script>' +
-        '<script src="main.js"></script>',
+      '<script src="runtime.js" defer></script>' +
+        '<script src="polyfills.js" defer></script>' +
+        '<script src="styles.js" defer></script>' +
+        '<script src="vendor.js" defer></script>' +
+        '<script src="main.js" defer></script>',
     );
     await run.stop();
   });

--- a/tests/legacy-cli/e2e/tests/basic/scripts-array.ts
+++ b/tests/legacy-cli/e2e/tests/basic/scripts-array.ts
@@ -67,14 +67,14 @@ export default function() {
           oneLineTrim`
       <script src="runtime-es2015.js" type="module"></script>
       <script src="polyfills-es2015.js" type="module"></script>
-      <script src="runtime-es5.js" nomodule></script>
-      <script src="polyfills-es5.js" nomodule></script>
-      <script src="scripts.js"></script>
-      <script src="renamed-script.js"></script>
+      <script src="runtime-es5.js" nomodule defer></script>
+      <script src="polyfills-es5.js" nomodule defer></script>
+      <script src="scripts.js" defer></script>
+      <script src="renamed-script.js" defer></script>
       <script src="vendor-es2015.js" type="module"></script>
       <script src="main-es2015.js" type="module"></script>
-      <script src="vendor-es5.js" nomodule></script>
-      <script src="main-es5.js" nomodule></script>
+      <script src="vendor-es5.js" nomodule defer></script>
+      <script src="main-es5.js" nomodule defer></script>
     `,
         ),
       )

--- a/tests/legacy-cli/e2e/tests/basic/styles-array.ts
+++ b/tests/legacy-cli/e2e/tests/basic/styles-array.ts
@@ -55,12 +55,12 @@ export default function() {
           oneLineTrim`
       <script src="runtime-es2015.js" type="module"></script>
       <script src="polyfills-es2015.js" type="module"></script>
-      <script src="runtime-es5.js" nomodule></script>
-      <script src="polyfills-es5.js" nomodule></script>
+      <script src="runtime-es5.js" nomodule defer></script>
+      <script src="polyfills-es5.js" nomodule defer></script>
       <script src="vendor-es2015.js" type="module"></script>
       <script src="main-es2015.js" type="module"></script>
-      <script src="vendor-es5.js" nomodule></script>
-      <script src="main-es5.js" nomodule></script>
+      <script src="vendor-es5.js" nomodule defer></script>
+      <script src="main-es5.js" nomodule defer></script>
     `,
         ),
       )

--- a/tests/legacy-cli/e2e/tests/build/polyfills.ts
+++ b/tests/legacy-cli/e2e/tests/build/polyfills.ts
@@ -16,8 +16,8 @@ export default async function () {
     await expectFileToMatch('dist/test-project/index.html', oneLineTrim`
       <script src="runtime-es2015.js" type="module"></script>
       <script src="polyfills-es2015.js" type="module"></script>
-      <script src="runtime-es5.js" nomodule></script>
-      <script src="polyfills-es5.js" nomodule></script>
+      <script src="runtime-es5.js" nomodule defer></script>
+      <script src="polyfills-es5.js" nomodule defer></script>
     `);
     const jitPolyfillSize = await getFileSize('dist/test-project/polyfills-es5.js');
 
@@ -30,7 +30,7 @@ export default async function () {
     await expectFileToMatch('dist/test-project/index.html', oneLineTrim`
       <script src="runtime-es2015.js" type="module"></script>
       <script src="polyfills-es2015.js" type="module"></script>
-      <script src="runtime-es5.js" nomodule></script>
-      <script src="polyfills-es5.js" nomodule></script>
+      <script src="runtime-es5.js" nomodule defer></script>
+      <script src="polyfills-es5.js" nomodule defer></script>
     `);
 }

--- a/tests/legacy-cli/e2e/tests/build/styles/extract-css.ts
+++ b/tests/legacy-cli/e2e/tests/build/styles/extract-css.ts
@@ -74,12 +74,12 @@ export default function() {
           oneLineTrim`
     <script src="runtime-es2015.js" type="module"></script>
     <script src="polyfills-es2015.js" type="module"></script>
-    <script src="runtime-es5.js" nomodule></script>
-    <script src="polyfills-es5.js" nomodule></script>
+    <script src="runtime-es5.js" nomodule defer></script>
+    <script src="polyfills-es5.js" nomodule defer></script>
     <script src="vendor-es2015.js" type="module"></script>
     <script src="main-es2015.js" type="module"></script>
-    <script src="vendor-es5.js" nomodule></script>
-    <script src="main-es5.js" nomodule></script>
+    <script src="vendor-es5.js" nomodule defer></script>
+    <script src="main-es5.js" nomodule defer></script>
     `,
         ),
       )
@@ -112,16 +112,16 @@ export default function() {
           oneLineTrim`
     <script src="runtime-es2015.js" type="module"></script>
     <script src="polyfills-es2015.js" type="module"></script>
-    <script src="runtime-es5.js" nomodule></script>
-    <script src="polyfills-es5.js" nomodule></script>
+    <script src="runtime-es5.js" nomodule defer></script>
+    <script src="polyfills-es5.js" nomodule defer></script>
     <script src="styles-es2015.js" type="module"></script>
-    <script src="styles-es5.js" nomodule></script>
+    <script src="styles-es5.js" nomodule defer></script>
     <script src="renamed-style-es2015.js" type="module"></script>
-    <script src="renamed-style-es5.js" nomodule></script>
+    <script src="renamed-style-es5.js" nomodule defer></script>
     <script src="vendor-es2015.js" type="module"></script>
     <script src="main-es2015.js" type="module"></script>
-    <script src="vendor-es5.js" nomodule></script>
-    <script src="main-es5.js" nomodule></script>
+    <script src="vendor-es5.js" nomodule defer></script>
+    <script src="main-es5.js" nomodule defer></script>
     `,
         ),
       )

--- a/tests/legacy-cli/e2e/tests/misc/support-ie.ts
+++ b/tests/legacy-cli/e2e/tests/misc/support-ie.ts
@@ -18,22 +18,22 @@ export default async function () {
   await ng('build');
   await expectFileNotToExist('dist/test-project/polyfills-es5.js');
   await expectFileToMatch('dist/test-project/index.html', oneLineTrim`
-    <script src="runtime.js"></script>
-    <script src="polyfills.js"></script>
-    <script src="styles.js"></script>
-    <script src="vendor.js"></script>
-    <script src="main.js"></script>
+    <script src="runtime.js" defer></script>
+    <script src="polyfills.js" defer></script>
+    <script src="styles.js" defer></script>
+    <script src="vendor.js" defer></script>
+    <script src="main.js" defer></script>
   `);
 
   await ng('build', `--es5BrowserSupport`);
   await expectFileToMatch('dist/test-project/polyfills-es5.js', 'core-js');
   await expectFileToMatch('dist/test-project/index.html', oneLineTrim`
-    <script src="runtime.js"></script>
-    <script src="polyfills-es5.js" nomodule></script>
-    <script src="polyfills.js"></script>
-    <script src="styles.js"></script>
-    <script src="vendor.js"></script>
-    <script src="main.js"></script>
+    <script src="runtime.js" defer></script>
+    <script src="polyfills-es5.js" nomodule defer></script>
+    <script src="polyfills.js" defer></script>
+    <script src="styles.js" defer></script>
+    <script src="vendor.js" defer></script>
+    <script src="main.js" defer></script>
   `);
 
   await updateJsonFile('angular.json', workspaceJson => {
@@ -44,11 +44,11 @@ export default async function () {
   await ng('build');
   await expectFileToMatch('dist/test-project/polyfills-es5.js', 'core-js');
   await expectFileToMatch('dist/test-project/index.html', oneLineTrim`
-    <script src="runtime.js"></script>
-    <script src="polyfills-es5.js" nomodule></script>
-    <script src="polyfills.js"></script>
-    <script src="styles.js"></script>
-    <script src="vendor.js"></script>
-    <script src="main.js"></script>
+    <script src="runtime.js" defer></script>
+    <script src="polyfills-es5.js" nomodule defer></script>
+    <script src="polyfills.js" defer></script>
+    <script src="styles.js" defer></script>
+    <script src="vendor.js" defer></script>
+    <script src="main.js" defer></script>
   `);
 }

--- a/tests/legacy-cli/e2e/tests/misc/support-safari-10.1.ts
+++ b/tests/legacy-cli/e2e/tests/misc/support-safari-10.1.ts
@@ -13,11 +13,11 @@ export default async function () {
   await expectFileNotToExist('dist/test-project/polyfills-es5.js');
   await expectFileNotToExist('dist/test-project/polyfills-nomodule-es5.js');
   await expectFileToMatch('dist/test-project/index.html', oneLineTrim`
-    <script src="runtime.js"></script>
-    <script src="polyfills.js"></script>
-    <script src="styles.js"></script>
-    <script src="vendor.js"></script>
-    <script src="main.js"></script>
+    <script src="runtime.js" defer></script>
+    <script src="polyfills.js" defer></script>
+    <script src="styles.js" defer></script>
+    <script src="vendor.js" defer></script>
+    <script src="main.js" defer></script>
   `);
 
   await writeFile('browserslist', `
@@ -27,16 +27,16 @@ export default async function () {
   await ng('build');
   await expectFileToExist('dist/test-project/polyfills-nomodule-es5.js');
   await expectFileToMatch('dist/test-project/index.html', oneLineTrim`
-    <script src="polyfills-nomodule-es5.js" nomodule></script>
+    <script src="polyfills-nomodule-es5.js" nomodule defer></script>
     <script src="runtime-es2015.js" type="module"></script>
     <script src="polyfills-es2015.js" type="module"></script>
-    <script src="runtime-es5.js" nomodule></script>
-    <script src="polyfills-es5.js" nomodule></script>
+    <script src="runtime-es5.js" nomodule defer></script>
+    <script src="polyfills-es5.js" nomodule defer></script>
     <script src="styles-es2015.js" type="module"></script>
-    <script src="styles-es5.js" nomodule></script>
+    <script src="styles-es5.js" nomodule defer></script>
     <script src="vendor-es2015.js" type="module"></script>
     <script src="main-es2015.js" type="module"></script>
-    <script src="vendor-es5.js" nomodule></script>
-    <script src="main-es5.js" nomodule></script>
+    <script src="vendor-es5.js" nomodule defer></script>
+    <script src="main-es5.js" nomodule defer></script>
   `);
 }

--- a/tests/legacy-cli/e2e/tests/third-party/bootstrap.ts
+++ b/tests/legacy-cli/e2e/tests/third-party/bootstrap.ts
@@ -24,13 +24,13 @@ export default function() {
     .then(() => expectFileToMatch('dist/test-project/index.html', oneLineTrim`
       <script src="runtime-es2015.js" type="module"></script>
       <script src="polyfills-es2015.js" type="module"></script>
-      <script src="runtime-es5.js" nomodule></script>
-      <script src="polyfills-es5.js" nomodule></script>
-      <script src="scripts.js"></script>
+      <script src="runtime-es5.js" nomodule defer></script>
+      <script src="polyfills-es5.js" nomodule defer></script>
+      <script src="scripts.js" defer></script>
       <script src="vendor-es2015.js" type="module"></script>
       <script src="main-es2015.js" type="module"></script>
-      <script src="vendor-es5.js" nomodule></script>
-      <script src="main-es5.js" nomodule></script>
+      <script src="vendor-es5.js" nomodule defer></script>
+      <script src="main-es5.js" nomodule defer></script>
     `))
     .then(() => ng(
       'build',
@@ -44,10 +44,10 @@ export default function() {
     .then(() => expectFileToMatch('dist/test-project/index.html', oneLineTrim`
     <script src="runtime-es2015.js" type="module"></script>
     <script src="polyfills-es2015.js" type="module"></script>
-    <script src="runtime-es5.js" nomodule></script>
-    <script src="polyfills-es5.js" nomodule></script>
-    <script src="scripts.js"></script>
+    <script src="runtime-es5.js" nomodule defer></script>
+    <script src="polyfills-es5.js" nomodule defer></script>
+    <script src="scripts.js" defer></script>
     <script src="main-es2015.js" type="module"></script>
-    <script src="main-es5.js" nomodule></script>
+    <script src="main-es5.js" nomodule defer></script>
     `));
 }


### PR DESCRIPTION
This change synchronizes the behavior of classic scripts and module scripts (`type="module"`).  Module scripts are deferred by default.  Also, certain injected scripts are not considered module scripts even in a ES2015+ build due to the strict mode behavior of module scripts.  Deferring such scripts also ensures consistent execution in those scenarios.