### PR TITLE
fix(@schematics/angular): add commonjs module to universal tsconfig

### DIFF
--- a/packages/schematics/angular/universal/files/root/__tsconfigFileName__.json.template
+++ b/packages/schematics/angular/universal/files/root/__tsconfigFileName__.json.template
@@ -1,7 +1,8 @@
 {
   "extends": "./<%= tsConfigExtends %>",
   "compilerOptions": {
-    "outDir": "<%= outDir %>-server"
+    "outDir": "<%= outDir %>-server",
+    "module": "commonjs"
   },
   "angularCompilerOptions": {
     "entryModule": "./<%= rootInSrc ? '' : 'src/' %><%= appDir %>/<%= stripTsExtension(rootModuleFileName) %>#<%= rootModuleClassName %>"

--- a/packages/schematics/angular/universal/index_spec.ts
+++ b/packages/schematics/angular/universal/index_spec.ts
@@ -90,6 +90,7 @@ describe('Universal Schematic', () => {
       extends: './tsconfig.app.json',
       compilerOptions: {
         outDir: './out-tsc/app-server',
+        module: 'commonjs',
       },
       angularCompilerOptions: {
         entryModule: './src/app/app.server.module#AppServerModule',
@@ -110,6 +111,7 @@ describe('Universal Schematic', () => {
       extends: './tsconfig.app.json',
       compilerOptions: {
         outDir: '../../out-tsc/app-server',
+        module: 'commonjs',
       },
       angularCompilerOptions: {
         entryModule: './src/app/app.server.module#AppServerModule',


### PR DESCRIPTION
The universal tsconfig extends the application tsconfig which by default it's module format is ES2015. While NodeJS 12 does support this, older versions of Node don't