### PR TITLE
feat(@ngtools/webpack): show warning when large CSS are included in c…

### DIFF
--- a/packages/ngtools/webpack/src/transformers/find_resources.ts
+++ b/packages/ngtools/webpack/src/transformers/find_resources.ts
@@ -9,9 +9,10 @@ import * as ts from 'typescript';
 import { collectDeepNodes } from './ast_helpers';
 import { getResourceUrl } from './replace_resources';
 
-export function findResources(sourceFile: ts.SourceFile): string[] {
-  const resources: string[] = [];
+export function findResources(sourceFile: ts.SourceFile): { templates: string[]; styles: string[]} {
   const decorators = collectDeepNodes<ts.Decorator>(sourceFile, ts.SyntaxKind.Decorator);
+  const templates: string[] = [];
+  const styles: string[] = [];
 
   for (const node of decorators) {
     if (!ts.isCallExpression(node.expression)) {
@@ -38,7 +39,7 @@ export function findResources(sourceFile: ts.SourceFile): string[] {
             const url = getResourceUrl(node.initializer);
 
             if (url) {
-              resources.push(url);
+              templates.push(url);
             }
             break;
 
@@ -51,7 +52,7 @@ export function findResources(sourceFile: ts.SourceFile): string[] {
               const url = getResourceUrl(node);
 
               if (url) {
-                resources.push(url);
+                styles.push(url);
               }
 
               return node;
@@ -64,5 +65,5 @@ export function findResources(sourceFile: ts.SourceFile): string[] {
     );
   }
 
-  return resources;
+  return { templates, styles };
 }

--- a/packages/ngtools/webpack/src/transformers/find_resources_spec.ts
+++ b/packages/ngtools/webpack/src/transformers/find_resources_spec.ts
@@ -27,10 +27,12 @@ describe('@ngtools/webpack transformers', () => {
       `;
 
       const result = findResources(ts.createSourceFile('temp.ts', input, ts.ScriptTarget.ES2015));
-      expect(result).toEqual([
-        './app.component.html',
+      expect(result.styles).toEqual([
         './app.component.css',
         './app.component.2.css',
+      ]);
+      expect(result.templates).toEqual([
+        './app.component.html',
       ]);
     });
 
@@ -43,7 +45,8 @@ describe('@ngtools/webpack transformers', () => {
       `;
 
       const result = findResources(ts.createSourceFile('temp.ts', input, ts.ScriptTarget.ES2015));
-      expect(result).toEqual([]);
+      expect(result.styles).toEqual([]);
+      expect(result.templates).toEqual([]);
     });
   });
 });

--- a/packages/ngtools/webpack/src/utils.ts
+++ b/packages/ngtools/webpack/src/utils.ts
@@ -23,3 +23,13 @@ export function flattenArray<T>(value: Array<T | T[]>): T[] {
 export function forwardSlashPath(path: string) {
   return path.replace(/\\/g, '/');
 }
+
+export function formatSize(size: number): string {
+  if (size <= 0) {
+      return '0 bytes';
+  }
+  const abbreviations = ['bytes', 'kB', 'MB', 'GB'];
+  const index = Math.floor(Math.log(size) / Math.log(1024));
+
+  return `${+(size / Math.pow(1024, index)).toPrecision(3)} ${abbreviations[index]}`;
+}


### PR DESCRIPTION
…omponents

It’s very easy to inadvertently import toplevel css in component styles. Since component css is standalone and self-contained, it will never be shared between components and remains as a single large bundle for each component. This in turn adds a large amount of code that must be processed and increases bundle size.

Related to: TOOL-949