### PR TITLE
test: remove material-design-icons package as a development dependency

### DIFF
--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -80,7 +80,6 @@
     "karma-coverage-istanbul-reporter": "~2.0.0",
     "karma-jasmine": "~2.0.1",
     "karma-jasmine-html-reporter": "^1.4.0",
-    "material-design-icons": "^3.0.1",
     "popper.js": "^1.14.1",
     "protractor": "~5.4.0",
     "zone.js": "^0.9.1"

--- a/packages/angular_devkit/build_angular/test/browser/styles_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/browser/styles_spec_large.ts
@@ -203,18 +203,6 @@ describe('Browser Builder styles', () => {
     });
   });
 
-  it(`supports material icons`, async () => {
-    const overrides = {
-      extractCss: true,
-      optimization: true,
-      styles: [
-        { input: '../../../../node_modules/material-design-icons/iconfont/material-icons.css' },
-      ],
-    };
-
-    await browserBuild(architect, host, target, overrides);
-  });
-
   extensionsWithVariableSupport.forEach(ext => {
     it(`supports ${ext} includePaths`, async () => {
       let variableAssignment = '';

--- a/tests/legacy-cli/e2e/tests/third-party/material-icons.ts
+++ b/tests/legacy-cli/e2e/tests/third-party/material-icons.ts
@@ -1,26 +1,28 @@
-import {silentNpm, ng} from '../../utils/process';
-import {updateJsonFile} from '../../utils/project';
-import {expectFileToMatch} from '../../utils/fs';
+import { expectFileToMatch } from '../../utils/fs';
+import { ng, silentNpm } from '../../utils/process';
+import { updateJsonFile } from '../../utils/project';
 
+export default async function() {
+  // Install material design icons
+  await silentNpm('install', 'material-design-icons@3.0.1');
 
-export default function() {
-  // TODO(architect): Delete this test. It is now in devkit/build-angular.
+  // Add icon stylesheet to application
+  await updateJsonFile('angular.json', workspaceJson => {
+    const appArchitect = workspaceJson.projects['test-project'].architect;
+    appArchitect.build.options.styles = [
+      { input: 'node_modules/material-design-icons/iconfont/material-icons.css' },
+    ];
+  });
 
-  return Promise.resolve()
-    .then(() => silentNpm('install', 'material-design-icons@3.0.1'))
-    .then(() => updateJsonFile('angular.json', workspaceJson => {
-      const appArchitect = workspaceJson.projects['test-project'].architect;
-      appArchitect.build.options.styles = [
-        { input: 'node_modules/material-design-icons/iconfont/material-icons.css' },
-      ];
-    }))
-    .then(() => ng('build', '--extract-css'))
-    .then(() => expectFileToMatch('dist/test-project/styles.css', 'Material Icons'))
-    .then(() => ng(
-      'build',
-      '--prod',
-      '--extract-css',
-      '--output-hashing=none'
-    ))
-    .then(() => expectFileToMatch('dist/test-project/styles.css', 'Material Icons'));
+  // Build dev application
+  await ng('build', '--extract-css');
+
+  // Ensure icons are included
+  await expectFileToMatch('dist/test-project/styles.css', 'Material Icons')
+
+  // Build prod application
+  await ng('build', '--prod', '--extract-css', '--output-hashing=none');
+
+  // Ensure icons are included
+  await expectFileToMatch('dist/test-project/styles.css', 'Material Icons')
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6632,11 +6632,6 @@ marked@0.7.0:
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.7.0.tgz#b64201f051d271b1edc10a04d1ae9b74bb8e5c0e"
   integrity sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==
 
-material-design-icons@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/material-design-icons/-/material-design-icons-3.0.1.tgz#9a71c48747218ebca51e51a66da682038cdcb7bf"
-  integrity sha1-mnHEh0chjrylHlGmbaaCA4zct78=
-
 math-random@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/math-random/-/math-random-1.0.1.tgz#8b3aac588b8a66e4975e3cdea67f7bb329601fac"


### PR DESCRIPTION
The package is quite large at 33MB (46MB on disk).  The package is also only used in one test that is already covered by an E2E test.  The E2E test does not require the package to be present for development as the test installs it within a generated project during execution.  This also has the benefit of testing the icons package in a more real world use case; as well as allowing the test to serve as a guide for a user to add the package to their own application.