### PR TITLE
feat(@angular-devkit/build-angular): add bundle budget for component styles

### DIFF
--- a/packages/angular/cli/lib/config/schema.json
+++ b/packages/angular/cli/lib/config/schema.json
@@ -1024,6 +1024,7 @@
                     "allScript",
                     "any",
                     "anyScript",
+                    "anyComponentStyle",
                     "bundle",
                     "initial"
                   ]

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/bundle-calculator.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/bundle-calculator.ts
@@ -25,9 +25,11 @@ export function calculateSizes(budget: Budget, compilation: Compilation): Size[]
     allScript: AllScriptCalculator,
     any: AnyCalculator,
     anyScript: AnyScriptCalculator,
+    anyComponentStyle: AnyComponentStyleCalculator,
     bundle: BundleCalculator,
     initial: InitialCalculator,
   };
+
   const ctor = calculatorMap[budget.type];
   const calculator = new ctor(budget, compilation);
 
@@ -98,6 +100,20 @@ class AllCalculator extends Calculator {
       .reduce((total: number, size: number) => total + size, 0);
 
     return [{size, label: 'total'}];
+  }
+}
+
+/**
+ * Any components styles
+ */
+class AnyComponentStyleCalculator extends Calculator {
+  calculate() {
+    return Object.keys(this.compilation.assets)
+      .filter(key => key.endsWith('.css'))
+      .map(key => ({
+        size: this.compilation.assets[key].size(),
+        label: key,
+      }));
   }
 }
 

--- a/packages/angular_devkit/build_angular/src/browser/schema.json
+++ b/packages/angular_devkit/build_angular/src/browser/schema.json
@@ -482,6 +482,7 @@
             "allScript",
             "any",
             "anyScript",
+            "anyComponentStyle",
             "bundle",
             "initial"
           ]

--- a/packages/angular_devkit/build_angular/test/browser/aot_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/browser/aot_spec_large.ts
@@ -7,7 +7,7 @@
  */
 
 import { Architect } from '@angular-devkit/architect';
-import { join, normalize, virtualFs } from '@angular-devkit/core';
+import { join, logging, normalize, virtualFs } from '@angular-devkit/core';
 import { BrowserBuilderOutput } from '../../src/browser';
 import { createArchitect, host, ivyEnabled } from '../utils';
 
@@ -37,6 +37,30 @@ describe('Browser Builder AOT', () => {
       expect(content).toMatch(/platformBrowser.*bootstrapModuleFactory.*AppModuleNgFactory/);
     }
 
+    await run.stop();
+  });
+
+  it('shows warnings for component styles', async () => {
+    const overrides = {
+      aot: true,
+      optimization: true,
+    };
+
+    host.writeMultipleFiles({
+      'src/app/app.component.css': `
+        .foo { color: white; padding: 1px; };
+        .buz { color: white; padding: 2px; };
+      `,
+    });
+
+    const logger = new logging.Logger('');
+    const logs: string[] = [];
+    logger.subscribe(e => logs.push(e.message));
+
+    const run = await architect.scheduleTarget(targetSpec, overrides, { logger });
+    const output = await run.result;
+    expect(output.success).toBe(true);
+    expect(logs.join()).toContain('WARNING in Invalid selector');
     await run.stop();
   });
 });

--- a/packages/ngtools/webpack/src/resource_loader.ts
+++ b/packages/ngtools/webpack/src/resource_loader.ts
@@ -100,10 +100,19 @@ export class WebpackResourceLoader {
     return new Promise((resolve, reject) => {
       childCompiler.compile((err: Error, childCompilation: any) => {
         // Resolve / reject the promise
-        if (childCompilation && childCompilation.errors && childCompilation.errors.length) {
-          const errorDetails = childCompilation.errors.map(function (error: any) {
-            return error.message + (error.error ? ':\n' + error.error : '');
-          }).join('\n');
+        const { warnings, errors } = childCompilation;
+
+        if (warnings && warnings.length) {
+          this._parentCompilation.warnings.push(...warnings);
+        }
+
+        if (errors && errors.length) {
+          this._parentCompilation.errors.push(...errors);
+
+          const errorDetails = errors
+            .map((error: any) => error.message + (error.error ? ':\n' + error.error : ''))
+            .join('\n');
+
           reject(new Error('Child compilation failed:\n' + errorDetails));
         } else if (err) {
           reject(err);

--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -223,6 +223,11 @@ function addAppToWorkspaceFile(options: ApplicationOptions, appDir: string): Rul
               type: 'initial',
               maximumWarning: '2mb',
               maximumError: '5mb',
+            },
+            {
+              type: 'anyComponentStyle',
+              maximumWarning: '6kb',
+              maximumError: '10kb',
             }],
           },
         },

--- a/packages/schematics/angular/utility/config.ts
+++ b/packages/schematics/angular/utility/config.ts
@@ -130,7 +130,7 @@ export interface AppConfig {
     /**
      * The type of budget
      */
-    type?: ('bundle' | 'initial' | 'allScript' | 'all' | 'anyScript' | 'any');
+    type?: ('bundle' | 'initial' | 'allScript' | 'all' | 'anyScript' | 'any' | 'anyComponentStyle');
     /**
      * The name of the bundle
      */

--- a/packages/schematics/angular/utility/json-utils.ts
+++ b/packages/schematics/angular/utility/json-utils.ts
@@ -31,7 +31,7 @@ export function appendPropertyInAstObject(
     recorder.insertRight(commaIndex, ',');
     index = end.offset;
   }
-  const content = JSON.stringify(value, null, indent).replace(/\n/g, indentStr);
+  const content = _stringifyContent(value, indentStr);
   recorder.insertRight(
     index,
     (node.properties.length === 0 && indent ? '\n' : '')
@@ -84,7 +84,7 @@ export function insertPropertyInAstObjectInOrder(
   const insertIndex = insertAfterProp === null
     ? node.start.offset + 1
     : insertAfterProp.end.offset + 1;
-  const content = JSON.stringify(value, null, indent).replace(/\n/g, indentStr);
+  const content = _stringifyContent(value, indentStr);
   recorder.insertRight(
     insertIndex,
     indentStr
@@ -168,7 +168,7 @@ export function appendValueInAstArray(
     index,
     (node.elements.length === 0 && indent ? '\n' : '')
     + ' '.repeat(indent)
-    + JSON.stringify(value, null, indent).replace(/\n/g, indentStr)
+    + _stringifyContent(value, indentStr)
     + indentStr.slice(0, -indent),
   );
 }
@@ -190,4 +190,25 @@ export function findPropertyInAstObject(
 
 function _buildIndent(count: number): string {
   return count ? '\n' + ' '.repeat(count) : '';
+}
+
+function _stringifyContent(value: JsonValue, indentStr: string): string {
+  // TODO: Add snapshot tests
+  
+  // The 'space' value is 2, because we want to add 2 additional
+  // indents from the 'key' node.
+
+  // If we use the indent provided we will have double indents: 
+  // "budgets": [
+  //   {
+  //     "type": "initial",
+  //     "maximumWarning": "2mb",
+  //     "maximumError": "5mb"
+  //   },
+  //   {
+  //       "type": "anyComponentStyle",
+  //       'maximumWarning": "5kb"
+  //   }
+  // ]
+  return JSON.stringify(value, null, 2).replace(/\n/g, indentStr);
 }

--- a/packages/schematics/angular/utility/workspace-models.ts
+++ b/packages/schematics/angular/utility/workspace-models.ts
@@ -38,8 +38,8 @@ export interface BrowserBuilderBaseOptions {
     index?: string;
     polyfills: string;
     assets?: (object|string)[];
-    styles?: string[];
-    scripts?: string[];
+    styles?: (object|string)[];
+    scripts?: (object|string)[];
     sourceMap?: boolean;
 }
 


### PR DESCRIPTION

It’s very easy to inadvertently import toplevel css in component styles. Since component css is standalone and self-contained, it will never be shared between components and remains as a single large bundle for each component. This in turn adds a large amount of code that must be processed and increases bundle size.

Note: this will only work for AOT compilations

Related to: TOOL-949