### PR TITLE
fix(@schematics/angular): add differential loading profiling file to gi…

### DIFF
--- a/packages/schematics/angular/workspace/files/__dot__gitignore.template
+++ b/packages/schematics/angular/workspace/files/__dot__gitignore.template
@@ -11,8 +11,8 @@
 /node_modules
 
 # profiling files
-chrome-profiler-events.json
-speed-measure-plugin.json
+chrome-profiler-events*.json
+speed-measure-plugin*.json
 
 # IDEs and editors
 /.idea


### PR DESCRIPTION

When differential loading enabled we will have different profiling files for every build target

Ex:
```
chrome-profiler-events-es2015.json
speed-measure-plugin-es2015.json
chrome-profiler-events-es5.json
speed-measure-plugin-es5.json
```