### PR TITLE
fix(@angular-devkit/build-angular): fix sourcemaps for vscode breakpo…

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/utils.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/utils.ts
@@ -95,7 +95,7 @@ export function getSourceMapDevTool(
   return new SourceMapDevToolPlugin({
     filename: inlineSourceMap ? undefined : '[file].map',
     include,
-    moduleFilenameTemplate: '[namespace]/[resource-path]',
+    moduleFilenameTemplate: '[resource-path]',
     append: hiddenSourceMap ? false : undefined,
   });
 }

--- a/packages/angular_devkit/build_angular/test/browser/source-map_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/browser/source-map_spec_large.ts
@@ -36,6 +36,23 @@ describe('Browser Builder source map', () => {
     expect(await files['styles.css.map']).not.toBeUndefined();
   });
 
+  it(`sourcemaps sources should not start with '/'`, async () => {
+    // If sourcemaps sources start with a '/' it will break VS code breakpoints
+    // Unless 'sourceMapPathOverrides' are provided
+    const overrides = {
+      sourceMap: true,
+    };
+
+    const { files } = await browserBuild(architect, host, target, overrides);
+    const mainJSMap = await files['main.js.map'];
+    expect(mainJSMap).not.toBeUndefined();
+
+    const sources: string[] = JSON.parse(mainJSMap).sources;
+    for (const source of sources) {
+      expect(source.startsWith('/')).toBe(false, `${source} started with an '/'.`);
+    }
+  });
+
   it('works with outputHashing', async () => {
     const { files } = await browserBuild(architect, host, target, {
       sourceMap: true,


### PR DESCRIPTION
…ints

`namespace` is always empty which is breaking sourcemaps since when sources start with `/` vscode will not be able to resolve them unless users configure `sourceMapPathOverrides`.

Fixes #15116