### PR TITLE
Update karma-debug.html with <base href="/"> tag, as in the karma-context.html

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/karma-debug.html
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/karma-debug.html
@@ -9,6 +9,7 @@ just for immediate execution, without reporting to Karma server.
 <head>
 %X_UA_COMPATIBLE%
   <title>Karma DEBUG RUNNER</title>
+  <base href="/">
   <link href="favicon.ico" rel="icon" type="image/x-icon" />
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />


### PR DESCRIPTION
same fix as in https://github.com/angular/angular-cli/pull/12889 , but for the karma debug context.
Issue described in the above PR happens again, if you switch to the karma debug runner. Karma will now use the karma-debug.html instead of the karma-context.html, rendering the initial fix useless.