### PR TITLE
style: enable tslint rules that were removed due to prettier

### DIFF
--- a/packages/angular/cli/lib/cli/index.ts
+++ b/packages/angular/cli/lib/cli/index.ts
@@ -72,7 +72,7 @@ export default async function(options: { testing?: boolean; cliArgs: string[] })
 
         logger.fatal(
           `An unhandled exception occurred: ${err.message}\n` +
-            `See "${logPath}" for further details.`
+            `See "${logPath}" for further details.`,
         );
       } catch (e) {
         logger.fatal(

--- a/packages/angular/cli/utilities/config.ts
+++ b/packages/angular/cli/utilities/config.ts
@@ -86,8 +86,8 @@ export function getWorkspace(
   if (error) {
     throw new Error(
       `Workspace config file cannot le loaded: ${configPath}`
-      + `\n${error instanceof Error ? error.message : error}`
-    )
+      + `\n${error instanceof Error ? error.message : error}`,
+    );
   }
 
   cachedWorkspaces.set(level, workspace);

--- a/packages/angular/pwa/pwa/index_spec.ts
+++ b/packages/angular/pwa/pwa/index_spec.ts
@@ -9,8 +9,6 @@ import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/te
 import * as path from 'path';
 import { Schema as PwaOptions } from './schema';
 
-
-// tslint:disable:max-line-length
 describe('PWA Schematic', () => {
   const schematicRunner = new SchematicTestRunner(
     '@angular/pwa',

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/utils.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/utils.ts
@@ -21,7 +21,6 @@ export interface HashFormat {
 }
 
 export function getOutputHashFormat(option: string, length = 20): HashFormat {
-  /* tslint:disable:max-line-length */
   const hashFormats: { [option: string]: HashFormat } = {
     none: { chunk: '', extract: '', file: '', script: '' },
     media: { chunk: '', extract: '', file: `.[hash:${length}]`, script: '' },
@@ -38,7 +37,6 @@ export function getOutputHashFormat(option: string, length = 20): HashFormat {
       script: `.[hash:${length}]`,
     },
   };
-  /* tslint:enable:max-line-length */
   return hashFormats[option] || hashFormats['none'];
 }
 

--- a/packages/angular_devkit/build_optimizer/src/build-optimizer/build-optimizer_spec.ts
+++ b/packages/angular_devkit/build_optimizer/src/build-optimizer/build-optimizer_spec.ts
@@ -54,7 +54,6 @@ describe('build-optimizer', () => {
         }());
         var RenderType_MdOption = ɵcrt({ encapsulation: 2, styles: styles_MdOption});
       `;
-      // tslint:disable:max-line-length
       const output = tags.oneLine`
         import { __extends } from "tslib";
         ${imports}

--- a/packages/angular_devkit/build_optimizer/src/build-optimizer/webpack-plugin.ts
+++ b/packages/angular_devkit/build_optimizer/src/build-optimizer/webpack-plugin.ts
@@ -10,8 +10,8 @@ import { Compiler } from 'webpack';  // tslint:disable-line:no-implicit-dependen
 
 export class BuildOptimizerWebpackPlugin {
   apply(compiler: Compiler) {
-    compiler.hooks.normalModuleFactory.tap("BuildOptimizerWebpackPlugin", nmf => {
-      nmf.hooks.module.tap("BuildOptimizerWebpackPlugin", (module, data) => {
+    compiler.hooks.normalModuleFactory.tap('BuildOptimizerWebpackPlugin', nmf => {
+      nmf.hooks.module.tap('BuildOptimizerWebpackPlugin', (module, data) => {
         const resolveData = data.resourceResolveData;
         if (resolveData && resolveData.descriptionFileData) {
           // Only TS packages should use Build Optimizer.

--- a/packages/angular_devkit/build_optimizer/src/transforms/import-tslib_spec.ts
+++ b/packages/angular_devkit/build_optimizer/src/transforms/import-tslib_spec.ts
@@ -32,7 +32,6 @@ describe('import-tslib', () => {
   });
 
   it('replaces wrapped __extends', () => {
-    // tslint:disable:max-line-length
     const input = tags.stripIndent`
     export default function appGlobal() {
         var __extends = (this && this.__extends) || function (d, b) {
@@ -61,7 +60,6 @@ describe('import-tslib', () => {
           return c > 3 && r && Object.defineProperty(target, key, r), r;
       };
     `;
-    // tslint:enable:max-line-length
     const output = tags.stripIndent`
       import { __decorate } from "tslib";
     `;
@@ -71,13 +69,11 @@ describe('import-tslib', () => {
   });
 
   it('replaces __metadata', () => {
-    // tslint:disable:max-line-length
     const input = tags.stripIndent`
       var __metadata = (this && this.__metadata) || function (k, v) {
           if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
       };
     `;
-    // tslint:enable:max-line-length
     const output = tags.stripIndent`
       import { __metadata } from "tslib";
     `;

--- a/packages/angular_devkit/build_optimizer/src/transforms/wrap-enums.ts
+++ b/packages/angular_devkit/build_optimizer/src/transforms/wrap-enums.ts
@@ -262,7 +262,7 @@ function findTs2_3EnumIife(
       || !ts.isBinaryExpression(statement.expression)
       || !ts.isElementAccessExpression(statement.expression.left)
     ) {
-      return null
+      return null;
     }
 
     const leftExpression = statement.expression.left.expression;

--- a/packages/angular_devkit/schematics/tools/workflow/node-workflow.ts
+++ b/packages/angular_devkit/schematics/tools/workflow/node-workflow.ts
@@ -34,7 +34,7 @@ export class NodeWorkflow extends workflow.BaseWorkflow {
 
       force: options.force,
       dryRun: options.dryRun,
-      registry: options.registry
+      registry: options.registry,
     });
 
     engineHost.registerTaskExecutor(

--- a/packages/angular_devkit/schematics_cli/bin/schematics.ts
+++ b/packages/angular_devkit/schematics_cli/bin/schematics.ts
@@ -24,7 +24,7 @@ import {
   DryRunEvent,
   SchematicEngine,
   UnsuccessfulWorkflowExecution,
-  formats
+  formats,
 } from '@angular-devkit/schematics';
 import { NodeModulesEngineHost, NodeWorkflow, validateOptionsWithSchema } from '@angular-devkit/schematics/tools';
 import * as inquirer from 'inquirer';

--- a/packages/ngtools/webpack/src/transformers/ctor-parameters.ts
+++ b/packages/ngtools/webpack/src/transformers/ctor-parameters.ts
@@ -19,7 +19,6 @@ export function downlevelConstructorParameters(
 
 // The following is sourced from tsickle with local modifications
 // Only the creation of `ctorParameters` is retained
-// tslint:disable-next-line:max-line-length
 // https://github.com/angular/tsickle/blob/0ceb7d6bc47f6945a6c4c09689f1388eb48f5c07/src/decorator_downlevel_transformer.ts
 //
 

--- a/packages/ngtools/webpack/src/transformers/ctor-parameters_spec.ts
+++ b/packages/ngtools/webpack/src/transformers/ctor-parameters_spec.ts
@@ -52,12 +52,14 @@ describe('Constructor Parameter Transformer', () => {
       }
     `;
 
+    // tslint:disable:max-line-length
     const output = `
       import * as tslib_1 from "tslib";
       let RootProvidedService = class RootProvidedService { constructor() { } };
       RootProvidedService = tslib_1.__decorate([ Injectable({ providedIn: 'root' }) ], RootProvidedService);
       export { RootProvidedService }; export class MyService { constructor(v) { } } MyService.ctorParameters = () => [ { type: RootProvidedService } ];
     `;
+    // tslint:enable:max-line-length
 
     const result = transform(input);
 

--- a/packages/ngtools/webpack/src/transformers/import_factory_spec.ts
+++ b/packages/ngtools/webpack/src/transformers/import_factory_spec.ts
@@ -81,7 +81,6 @@ describe('@ngtools/webpack transformers', () => {
         }];
       `;
 
-      // tslint:disable: max-line-length
       const output = tags.stripIndent`
         const ɵ0 = () => import("./shared/path/to/lazy/lazy.module.ngfactory").then(m => m.LazyModuleNgFactory);
         const routes = [{
@@ -89,7 +88,6 @@ describe('@ngtools/webpack transformers', () => {
           loadChildren: ɵ0
         }];
       `;
-      // tslint:enable: max-line-length
 
       const { program, compilerHost } = createTypescriptContext(input, additionalFiles, true);
       const transformer = importFactory(() => { }, () => program.getTypeChecker());

--- a/packages/ngtools/webpack/src/transformers/replace_bootstrap_spec.ts
+++ b/packages/ngtools/webpack/src/transformers/replace_bootstrap_spec.ts
@@ -26,7 +26,6 @@ describe('@ngtools/webpack transformers', () => {
         platformBrowserDynamic().bootstrapModule(AppModule);
       `;
 
-      // tslint:disable:max-line-length
       const output = tags.stripIndent`
         import { enableProdMode } from '@angular/core';
         import { environment } from './environments/environment';
@@ -39,7 +38,6 @@ describe('@ngtools/webpack transformers', () => {
         }
         __NgCli_bootstrap_2.platformBrowser().bootstrapModuleFactory(__NgCli_bootstrap_1.AppModuleNgFactory);
       `;
-      // tslint:enable:max-line-length
 
       const { program, compilerHost } = createTypescriptContext(input);
       const transformer = replaceBootstrap(

--- a/packages/ngtools/webpack/src/transformers/replace_server_bootstrap_spec.ts
+++ b/packages/ngtools/webpack/src/transformers/replace_server_bootstrap_spec.ts
@@ -27,7 +27,6 @@ describe('@ngtools/webpack transformers', () => {
         platformDynamicServer().bootstrapModule(AppModule);
       `;
 
-      // tslint:disable:max-line-length
       const output = tags.stripIndent`
         import { enableProdMode } from '@angular/core';
         import { environment } from './environments/environment';
@@ -40,7 +39,6 @@ describe('@ngtools/webpack transformers', () => {
         }
         __NgCli_bootstrap_2.platformServer().bootstrapModuleFactory(__NgCli_bootstrap_1.AppModuleNgFactory);
       `;
-      // tslint:enable:max-line-length
 
       const { program, compilerHost } = createTypescriptContext(input);
       const transformer = replaceServerBootstrap(
@@ -71,7 +69,6 @@ describe('@ngtools/webpack transformers', () => {
         });
       `;
 
-      // tslint:disable:max-line-length
       const output = tags.stripIndent`
         import { enableProdMode } from '@angular/core';
         import { environment } from './environments/environment';
@@ -87,7 +84,6 @@ describe('@ngtools/webpack transformers', () => {
             url: '/'
           });
       `;
-      // tslint:enable:max-line-length
 
       const { program, compilerHost } = createTypescriptContext(input);
       const transformer = replaceServerBootstrap(
@@ -120,7 +116,6 @@ describe('@ngtools/webpack transformers', () => {
         }));
       `;
 
-      // tslint:disable:max-line-length
       const output = tags.stripIndent`
         import * as express from 'express';
 
@@ -140,7 +135,6 @@ describe('@ngtools/webpack transformers', () => {
           bootstrap: __NgCli_bootstrap_1.AppModuleNgFactory
         }));
       `;
-      // tslint:enable:max-line-length
 
       const { program, compilerHost } = createTypescriptContext(input);
       const transformer = replaceServerBootstrap(
@@ -168,7 +162,6 @@ describe('@ngtools/webpack transformers', () => {
         platformDynamicServer().bootstrapModule(AppModule);
       `;
 
-      // tslint:disable:max-line-length
       const output = tags.stripIndent`
         import { enableProdMode } from '@angular/core';
         import { environment } from './environments/environment';
@@ -181,7 +174,6 @@ describe('@ngtools/webpack transformers', () => {
         }
         __NgCli_bootstrap_2.platformServer().bootstrapModuleFactory(__NgCli_bootstrap_1.AppModuleNgFactory);
       `;
-      // tslint:enable:max-line-length
 
       const { program, compilerHost } = createTypescriptContext(input);
       const transformer = replaceServerBootstrap(

--- a/packages/schematics/angular/application/index_spec.ts
+++ b/packages/schematics/angular/application/index_spec.ts
@@ -12,7 +12,6 @@ import { getFileContent } from '../utility/test';
 import { Schema as WorkspaceOptions } from '../workspace/schema';
 import { Schema as ApplicationOptions, Style, ViewEncapsulation } from './schema';
 
-// tslint:disable:max-line-length
 describe('Application Schematic', () => {
   const schematicRunner = new SchematicTestRunner(
     '@schematics/angular',

--- a/packages/schematics/angular/component/index_spec.ts
+++ b/packages/schematics/angular/component/index_spec.ts
@@ -12,7 +12,6 @@ import { createAppModule } from '../utility/test';
 import { Schema as WorkspaceOptions } from '../workspace/schema';
 import { ChangeDetection, Schema as ComponentOptions, Style } from './schema';
 
-// tslint:disable:max-line-length
 describe('Component Schematic', () => {
   const schematicRunner = new SchematicTestRunner(
     '@schematics/angular',
@@ -273,7 +272,6 @@ describe('Component Schematic', () => {
     const tree = await schematicRunner.runSchematicAsync('component', options, appTree).toPromise();
     const content = tree.readContent('/projects/bar/src/app/app.module.ts');
     expect(content).toMatch(
-      // tslint:disable-next-line:max-line-length
       /import { TestComponentComponent } from '\.\/dir\/test-component\/test-component.component'/,
     );
   });
@@ -288,7 +286,6 @@ describe('Component Schematic', () => {
 
     const content = appTree.readContent('/projects/bar/src/app/admin/module/module.module.ts');
     expect(content).toMatch(
-      // tslint:disable-next-line:max-line-length
       /import { TestComponentComponent } from '..\/..\/other\/test-component\/test-component.component'/,
     );
   });

--- a/packages/schematics/angular/directive/index_spec.ts
+++ b/packages/schematics/angular/directive/index_spec.ts
@@ -10,7 +10,6 @@ import { Schema as ApplicationOptions } from '../application/schema';
 import { Schema as WorkspaceOptions } from '../workspace/schema';
 import { Schema as DirectiveOptions } from './schema';
 
-// tslint:disable:max-line-length
 describe('Directive Schematic', () => {
   const schematicRunner = new SchematicTestRunner(
     '@schematics/angular',

--- a/packages/schematics/angular/library/index_spec.ts
+++ b/packages/schematics/angular/library/index_spec.ts
@@ -17,7 +17,6 @@ function getJsonFileContent(tree: UnitTestTree, path: string) {
   return JSON.parse(tree.readContent(path));
 }
 
-// tslint:disable:max-line-length
 describe('Library Schematic', () => {
   const schematicRunner = new SchematicTestRunner(
     '@schematics/ng_packagr',

--- a/packages/schematics/angular/migrations/update-6/index.ts
+++ b/packages/schematics/angular/migrations/update-6/index.ts
@@ -556,7 +556,6 @@ function extractProjectsConfig(
 
       const e2eTargets: JsonObject = {};
 
-      // tslint:disable-next-line:max-line-length
       const protractorConfig = config && config.e2e && config.e2e.protractor && config.e2e.protractor.config
         ? config.e2e.protractor.config
         : '';

--- a/packages/schematics/angular/migrations/update-8/differential-loading.ts
+++ b/packages/schematics/angular/migrations/update-8/differential-loading.ts
@@ -20,7 +20,6 @@ import {
   removePropertyInAstObject,
 } from '../../utility/json-utils';
 
-// tslint:disable-next-line:max-line-length
 const browserslistContent = `# This file is used by the build system to adjust CSS and JS output to support the specified browsers below.
 # For additional information regarding the format and rule options, please see:
 # https://github.com/browserslist/browserslist#queries

--- a/packages/schematics/angular/migrations/update-9/update-workspace-config_spec.ts
+++ b/packages/schematics/angular/migrations/update-9/update-workspace-config_spec.ts
@@ -18,28 +18,28 @@ const scriptsWithLazy = [
   { bundleName: 'two', input: 'two.js', lazy: true },
   { bundleName: 'tree', input: 'tree.js' },
   'four.js',
-]
+];
 
 const scriptsExpectWithLazy = [
   { bundleName: 'one', input: 'one.js' },
   { bundleName: 'two', inject: false, input: 'two.js' },
   { bundleName: 'tree', input: 'tree.js' },
   'four.js',
-]
+];
 
 const stylesWithLazy = [
   { bundleName: 'one', input: 'one.css', lazy: false },
   { bundleName: 'two', input: 'two.css', lazy: true },
   { bundleName: 'tree', input: 'tree.css' },
   'four.css',
-]
+];
 
 const stylesExpectWithLazy = [
   { bundleName: 'one', input: 'one.css' },
   { bundleName: 'two', inject: false, input: 'two.css' },
   { bundleName: 'tree', input: 'tree.css' },
   'four.css',
-]
+];
 
 const workspacePath = '/angular.json';
 

--- a/packages/schematics/angular/module/index_spec.ts
+++ b/packages/schematics/angular/module/index_spec.ts
@@ -10,7 +10,6 @@ import { Schema as ApplicationOptions } from '../application/schema';
 import { Schema as WorkspaceOptions } from '../workspace/schema';
 import { Schema as ModuleOptions } from './schema';
 
-// tslint:disable:max-line-length
 describe('Module Schematic', () => {
   const schematicRunner = new SchematicTestRunner(
     '@schematics/angular',

--- a/packages/schematics/angular/service-worker/index_spec.ts
+++ b/packages/schematics/angular/service-worker/index_spec.ts
@@ -93,7 +93,6 @@ describe('Service Worker Schematic', () => {
     const tree = await schematicRunner.runSchematicAsync('service-worker', defaultOptions, appTree)
       .toPromise();
     const pkgText = tree.readContent('/projects/bar/src/app/app.module.ts');
-    // tslint:disable-next-line:max-line-length
     const expectedText = 'ServiceWorkerModule.register(\'ngsw-worker.js\', { enabled: environment.production })';
     expect(pkgText).toContain(expectedText);
   });

--- a/packages/schematics/angular/service/index_spec.ts
+++ b/packages/schematics/angular/service/index_spec.ts
@@ -10,7 +10,6 @@ import { Schema as ApplicationOptions } from '../application/schema';
 import { Schema as WorkspaceOptions } from '../workspace/schema';
 import { Schema as ServiceOptions } from './schema';
 
-// tslint:disable:max-line-length
 describe('Service Schematic', () => {
   const schematicRunner = new SchematicTestRunner(
     '@schematics/angular',

--- a/packages/schematics/angular/universal/index_spec.ts
+++ b/packages/schematics/angular/universal/index_spec.ts
@@ -93,7 +93,7 @@ describe('Universal Schematic', () => {
         module: 'commonjs',
       },
       files: [
-        "src/main.server.ts"
+        'src/main.server.ts',
       ],
       angularCompilerOptions: {
         entryModule: './src/app/app.server.module#AppServerModule',
@@ -117,7 +117,7 @@ describe('Universal Schematic', () => {
         module: 'commonjs',
       },
       files: [
-        "src/main.server.ts"
+        'src/main.server.ts',
       ],
       angularCompilerOptions: {
         entryModule: './src/app/app.server.module#AppServerModule',

--- a/packages/schematics/angular/utility/ast-utils_spec.ts
+++ b/packages/schematics/angular/utility/ast-utils_spec.ts
@@ -344,12 +344,10 @@ describe('ast utils', () => {
       const source = getTsSource(modulePath, moduleContent);
       const change = () => addRouteDeclarationToModule(source, './src/app', '');
       expect(change).toThrowError(
-        // tslint:disable-next-line:max-line-length
         `No route declaration array was found that corresponds to router module at line 11 in ./src/app`,
       );
     });
 
-    // tslint:disable-next-line:max-line-length
     it(`should throw an error, if the provided first argument of router module is not an identifier`, () => {
       const moduleContent = `
         import { BrowserModule } from '@angular/platform-browser';
@@ -372,7 +370,6 @@ describe('ast utils', () => {
       const source = getTsSource(modulePath, moduleContent);
       const change = () => addRouteDeclarationToModule(source, './src/app', '');
       expect(change).toThrowError(
-        // tslint:disable-next-line:max-line-length
         `No route declaration array was found that corresponds to router module at line 11 in ./src/app`,
       );
     });
@@ -439,7 +436,6 @@ describe('ast utils', () => {
       const output = applyChanges(modulePath, moduleContent, [changes]);
 
       expect(output).toMatch(
-        // tslint:disable-next-line:max-line-length
         /const routes = \[\r?\n?\s*{ path: 'foo', component: FooComponent },\r?\n?\s*{ path: 'bar', component: BarComponent }\r?\n?\s*\]/,
       );
     });
@@ -473,10 +469,11 @@ describe('ast utils', () => {
         './src/app', `{ path: 'bar', component: BarComponent }`,
       );
       const output = applyChanges(modulePath, moduleContent, [changes]);
+      // tslint:disable:max-line-length
       expect(output).toMatch(
-        // tslint:disable-next-line:max-line-length
         /const routes = \[\r?\n?\s*{ path: 'foo', component: FooComponent, canLoad: \[Guard\] },\r?\n?\s*{ path: 'bar', component: BarComponent }\r?\n?\s*\]/,
       );
+      // tslint:enable:max-line-length
     });
 
     it('should add a route to the routes argument of RouteModule', () => {

--- a/packages/schematics/update/update/index.ts
+++ b/packages/schematics/update/update/index.ts
@@ -213,14 +213,12 @@ function _validateUpdatePackages(
       || peerErrors;
   });
 
-  // tslint:disable:max-line-length
   if (!force && peerErrors) {
     throw new SchematicsException(tags.stripIndents
       `Incompatible peer dependencies found.
       Peer dependency warnings when installing dependencies means that those dependencies might not work correctly together.
       You can use the '--force' option to ignore incompatible peer dependencies and instead address these warnings later.`);
   }
-  // tslint:enable:max-line-length
 }
 
 

--- a/tests/legacy-cli/e2e/tests/basic/e2e.ts
+++ b/tests/legacy-cli/e2e/tests/basic/e2e.ts
@@ -10,7 +10,6 @@ import {updateJsonFile} from '../../utils/project';
 import {expectToFail} from '../../utils/utils';
 import {moveFile, copyFile, replaceInFile} from '../../utils/fs';
 
-// tslint:disable:max-line-length
 export default function () {
   // Should fail without updated webdriver
   return updateJsonFile('package.json', packageJson => {

--- a/tests/legacy-cli/e2e/tests/basic/test.ts
+++ b/tests/legacy-cli/e2e/tests/basic/test.ts
@@ -1,7 +1,6 @@
 import { ng } from '../../utils/process';
 import { moveFile } from '../../utils/fs';
 
-// tslint:disable:max-line-length
 export default function () {
   // make sure both --watch=false work
   return ng('test', '--watch=false')

--- a/tests/legacy-cli/e2e/tests/build/build-errors.ts
+++ b/tests/legacy-cli/e2e/tests/build/build-errors.ts
@@ -4,8 +4,6 @@ import { writeFile, appendToFile, readFile, replaceInFile } from '../../utils/fs
 import { getGlobalVariable } from '../../utils/env';
 import { expectToFail } from '../../utils/utils';
 
-// tslint:disable:max-line-length
-
 const extraErrors = [
   `Final loader didn't return a Buffer or String`,
   `doesn't contain a valid alias configuration`,

--- a/tests/legacy-cli/e2e/tests/generate/component/component-duplicate.ts
+++ b/tests/legacy-cli/e2e/tests/generate/component/component-duplicate.ts
@@ -5,7 +5,6 @@ import { oneLine } from 'common-tags';
 export default function () {
   return ng('generate', 'component', 'test-component')
     .then((output) => {
-      // tslint:disable-next-line:max-line-length
       if (!output.stdout.match(/UPDATE src[\\|\/]app[\\|\/]app.module.ts/)) {
         throw new Error(oneLine`
           Expected to match

--- a/tests/legacy-cli/e2e/tests/generate/module/module-import.ts
+++ b/tests/legacy-cli/e2e/tests/generate/module/module-import.ts
@@ -2,7 +2,6 @@ import { join } from 'path';
 import { ng } from '../../../utils/process';
 import { expectFileToMatch } from '../../../utils/fs';
 
-// tslint:disable:max-line-length
 export default function () {
   const root = process.cwd();
   const modulePath = join(root, 'src', 'app', 'app.module.ts');

--- a/tslint.json
+++ b/tslint.json
@@ -15,6 +15,7 @@
     "defocus": true,
     "import-groups": true,
     "no-global-tslint-disable": true,
+    "single-eof-line": true,
     // ==================================================================================================
     // tslint-sonarts rules. See https://github.com/SonarSource/SonarTS
     // These rules are part of the bug detection section of tslint-sonarts
@@ -51,14 +52,29 @@
     "no-floating-promises": true,
     "no-implicit-dependencies": true,
     "no-import-side-effect": [true, {"ignore-module": "^(?!rxjs\/)"}],
+    "align": [
+      true,
+      "elements",
+      "members",
+      "parameters",
+      "statements"
+    ],
+    "max-line-length": [true, 140],
     "no-inferrable-types": true,
     "class-name": true,
     "comment-format": [
       true,
       "check-space"
     ],
+    "indent": [
+      true,
+      "spaces"
+    ],
+    "eofline": true,
+    "import-spacing": true,
     "match-default-export-name": true,
     "newline-before-return": true,
+    "no-consecutive-blank-lines": [true, 2],
     "no-duplicate-variable": true,
     "no-eval": true,
     "no-any": true,
@@ -66,8 +82,17 @@
     "no-debugger": true,
     "no-console": true,
     "no-internal-module": true,
+    "no-trailing-whitespace": true,
     "no-unused-expression": true,
     "no-var-keyword": true,
+    "one-line": [
+      true,
+      "check-catch",
+      "check-else",
+      "check-finally",
+      "check-open-brace",
+      "check-whitespace"
+    ],
     "ordered-imports": [
       true,
       {
@@ -76,6 +101,29 @@
       }
     ],
     "prefer-const": true,
+    "quotemark": [
+      true,
+      "single",
+      "avoid-escape"
+    ],
+    "semicolon": [true, "always"],
+    "trailing-comma": [
+      true,
+      {
+        "multiline": "always",
+        "singleline": "never"
+      }
+    ],
+    "typedef-whitespace": [
+      true,
+      {
+        "call-signature": "nospace",
+        "index-signature": "nospace",
+        "parameter": "nospace",
+        "property-declaration": "nospace",
+        "variable-declaration": "nospace"
+      }
+    ],
     "curly": true,
     "file-header": [
       true,
@@ -87,6 +135,17 @@
       "check-format",
       "allow-leading-underscore",
       "allow-pascal-case"
+    ],
+    "whitespace": [
+      true,
+      "check-branch",
+      "check-decl",
+      "check-module",
+      "check-preblock",
+      "check-operator",
+      "check-separator",
+      "check-type",
+      "check-typecast"
     ]
   }
 }


### PR DESCRIPTION
Prettier was disabled in this PR https://github.com/angular/angular-cli/pull/14940

Until we re-introduce it again, we should re-introduce certain lint rules to maintaince a coding standards.

Also, this increases the `max-line-length` to `140` instead of `100`.