### PR TITLE
fix(@ngtools/webpack): HTML and style changes in libraries is not ref…

### DIFF
--- a/packages/ngtools/webpack/src/loader.ts
+++ b/packages/ngtools/webpack/src/loader.ts
@@ -88,6 +88,10 @@ export function ngcLoader(this: loader.LoaderContext) {
         this.addDependency(originalFile);
         const origDependencies = plugin.getDependencies(originalFile);
         origDependencies.forEach(dep => this.addDependency(dep));
+
+        // When having a library we need to add a dependency to the .metadata.json
+        // In case it changes overtime.
+        this.addDependency(sourceFileName.replace(ngFactoryRe, '.metadata.json'));
       }
 
       // NgStyle files depend on the style file they represent.


### PR DESCRIPTION
…lected in applications during VE AOT

During AOT compilations, apart from the `d.ts` and `.js` changes we need to handle summary changes and metadata depedencies for libraries.

NGC compiler doesn't allow us to purge known changed summaries, this change implements a workaround for this, which allows us to have incrementality for component resources in libraries.

Fixes #13588