### PR TITLE
redirect to index.html if root is called directly

### DIFF
--- a/packages/angular_devkit/build_angular/src/dev-server/index.ts
+++ b/packages/angular_devkit/build_angular/src/dev-server/index.ts
@@ -324,7 +324,14 @@ export function buildServerConfig(
         rewrites: [
           {
             from: new RegExp(`^(?!${servePath})/.*`),
-            to: context => url.format(context.parsedUrl),
+            to: context => {
+              // redirect to index.html if root is called directly
+              if (context.parsedUrl.href === '/') {
+                return `${servePath}/${path.basename(browserOptions.index)}`;
+              }
+
+              return url.format(context.parsedUrl),
+            }
           },
         ],
       } as WebpackDevServer.HistoryApiFallbackConfig),


### PR DESCRIPTION
Followup for https://github.com/angular/angular-cli/commit/01247c9339d928cac1291f268ad17ee3a153c057#diff-6c0b312b8bd33db747e50549a66f7ab1

Restores the old behavior, if anyone calls the root directly it redirects to the index.html.

/cc @ajafff