### PR TITLE
fix(@angular/cli): don't add leftovers when there are none

### DIFF
--- a/packages/angular/cli/models/parser.ts
+++ b/packages/angular/cli/models/parser.ts
@@ -269,7 +269,9 @@ export function parseFreeFormArguments(args: string[]): Arguments {
     }
   }
 
-  parsedOptions['--'] = leftovers;
+  if (leftovers.length) {
+    parsedOptions['--'] = leftovers;
+  }
 
   return parsedOptions;
 }


### PR DESCRIPTION
At the moment we are adding leftover args to `--` even when it's an empty array, this causes schematics without arguments to fail silently, because of https://github.com/angular/angular-cli/blob/07780b9272d985606d318da16d732dd28a41d592/packages/angular/cli/models/schematic-command.ts#L463

Fixes: #15156