### PR TITLE
fix(@angular-devkit/build-optimizer): don't wrap enum like nodes whic…

### DIFF
--- a/packages/angular_devkit/build_optimizer/src/transforms/wrap-enums.ts
+++ b/packages/angular_devkit/build_optimizer/src/transforms/wrap-enums.ts
@@ -56,7 +56,7 @@ function visitBlockStatements(
           return node;
       }
     } else {
-      return ts.visitEachChild(node, visitor, context);
+      return node;
     }
   };
 
@@ -112,7 +112,7 @@ function visitBlockStatements(
             oIndex++;
           }
 
-          const enumStatements = findStatements(name, statements, oIndex + 1);
+          const enumStatements = findStatements(name, statements, oIndex, 1);
           if (!enumStatements) {
             continue;
           }
@@ -316,6 +316,7 @@ function findStatements(
   name: string,
   statements: ts.NodeArray<ts.Statement>,
   statementIndex: number,
+  offset = 0,
 ): ts.Statement[] | undefined {
   let count = 1;
 
@@ -369,7 +370,7 @@ function findStatements(
   }
 
   if (count > 1) {
-    return statements.slice(statementIndex, statementIndex + count);
+    return statements.slice(statementIndex + offset, statementIndex + count);
   }
 
   return undefined;


### PR DESCRIPTION
…h are inside of methods.

With this change we stop recursive lookup when the current node is not a BlockLike.

This change should also improve the BO overall speed as it's reduces a lot of recursive lookups.

Fixes #15145

Note: Tested also on AIO to confirm size regression and didn't see any increase in file size in both ES5 and ES2015 builds