### PR TITLE
ci: enable snapshot e2e for renovate PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ executors:
 # https://circleci.com/docs/2.0/reusing-config/#authoring-reusable-commands
 commands:
   setup_windows:
-    steps:     
+    steps:
       - checkout
       - run:
           # Need to install node and yarn before, as the base windows image doesn't have anything.
@@ -358,9 +358,16 @@ workflows:
       - e2e-cli:
           name: e2e-cli-ng-snapshots
           snapshots: true
-          <<: *ignore_pull_requests
           requires:
             - e2e-cli
+          pre-steps:
+            - run:
+                name: Don't run expensive e2e snapshots tests for forks other than renovate-bot and angular
+                command: >
+                  if [[ "$CIRCLE_PR_USERNAME" != "renovate-bot" ]] &&
+                    [[ "$CIRCLE_PROJECT_USERNAME" != "angular" || $CIRCLE_BRANCH != "master" ]]; then
+                    circleci step halt
+                  fi
       - e2e-cli-node-10:
           <<: *ignore_pull_requests
           requires:


### PR DESCRIPTION


snapshots builds are required to be run when the PR is created by renovate. This is because we have renovate jobs that update the snapshots commit SHA and we want to verify that these are green prior to merging them.

Related to: https://github.com/angular/angular-cli/pull/14687