### PR TITLE
Ivy libraries and workspace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -340,7 +340,7 @@ workflows:
       - test-large:
           name: test-large-ivy
           ivy: true
-          glob: "packages/angular_devkit/build_angular/test/browser/*_spec_large.ts"
+          glob: "packages/angular_devkit/@(build_angular|build_ng_packagr)/@(src|test)/@(build|browser)/*_spec_large.ts"
           requires:
             - build
       - e2e-cli:

--- a/packages/angular_devkit/build_angular/test/browser/web-worker_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/browser/web-worker_spec_large.ts
@@ -77,11 +77,9 @@ describe('Browser Builder Web Worker support', () => {
           "outDir": "../out-tsc/worker",
           "types": []
         },
-        "exclude": [
-          "test.ts",
-          "**/*.spec.ts",
-          "**/*.worker.ts",
-          "app/dep.ts",
+        "files": [
+          "main.ts",
+          "polyfills.ts"
         ]
       }`,
   };

--- a/packages/angular_devkit/build_ng_packagr/package.json
+++ b/packages/angular_devkit/build_ng_packagr/package.json
@@ -17,7 +17,7 @@
     "@angular/compiler": "~8.2.0-rc.0",
     "@angular/compiler-cli": "~8.2.0-rc.0",
     "@angular-devkit/core": "0.0.0",
-    "ng-packagr": "^5.3.0",
+    "ng-packagr": "^5.4.0",
     "tslib": "^1.10.0"
   }
 }

--- a/packages/angular_devkit/build_ng_packagr/src/build/index_spec_large.ts
+++ b/packages/angular_devkit/build_ng_packagr/src/build/index_spec_large.ts
@@ -9,11 +9,12 @@ import { Architect } from '@angular-devkit/architect';
 import { WorkspaceNodeModulesArchitectHost } from '@angular-devkit/architect/node';
 import { TestProjectHost, TestingArchitectHost } from '@angular-devkit/architect/testing';
 import {
+  experimental,
+  getSystemPath,
   join,
   normalize,
   schema,
   virtualFs,
-  workspaces,
 } from '@angular-devkit/core'; // tslint:disable-line:no-implicit-dependencies
 import { map, take, tap } from 'rxjs/operators';
 
@@ -33,15 +34,14 @@ describe('NgPackagr Builder', () => {
     const registry = new schema.CoreSchemaRegistry();
     registry.addPostTransform(schema.transforms.addUndefinedDefaults);
 
-    const { workspace } = await workspaces.readWorkspace(
-      host.root(),
-      workspaces.createWorkspaceHost(host),
-    );
+    const workspaceSysPath = getSystemPath(host.root());
+    const workspace = await experimental.workspace.Workspace.fromPath(host, host.root(), registry);
     const architectHost = new TestingArchitectHost(
-      host.root(),
-      host.root(),
-      new WorkspaceNodeModulesArchitectHost(workspace, host.root()),
+      workspaceSysPath,
+      workspaceSysPath,
+      new WorkspaceNodeModulesArchitectHost(workspace, workspaceSysPath),
     );
+
     architect = new Architect(architectHost, registry);
   });
 

--- a/packages/angular_devkit/build_ng_packagr/src/build/index_spec_large.ts
+++ b/packages/angular_devkit/build_ng_packagr/src/build/index_spec_large.ts
@@ -18,10 +18,16 @@ import {
 } from '@angular-devkit/core'; // tslint:disable-line:no-implicit-dependencies
 import { map, take, tap } from 'rxjs/operators';
 
+export const ivyEnabled = process.argv.includes('--ivy');
+if (ivyEnabled) {
+  // tslint:disable-next-line:no-console
+  console.warn('********* IVY Enabled ***********');
+}
+
 const devkitRoot = (global as unknown as { _DevKitRoot: string})._DevKitRoot;
 const workspaceRoot = join(
   normalize(devkitRoot),
-  'tests/angular_devkit/build_ng_packagr/ng-packaged/',
+  `tests/angular_devkit/build_ng_packagr/ng-packaged${ivyEnabled ? '-ivy' : ''}/`,
 );
 
 describe('NgPackagr Builder', () => {
@@ -59,6 +65,12 @@ describe('NgPackagr Builder', () => {
       host.scopedSync().read(normalize('./dist/lib/fesm5/lib.js')),
     );
     expect(content).toContain('lib works');
+
+    if (ivyEnabled) {
+      expect(content).toContain('ngComponentDef');
+    } else {
+      expect(content).not.toContain('ngComponentDef');
+    }
   });
 
   it('rebuilds on TS file changes', async () => {

--- a/packages/schematics/angular/application/files/tsconfig.app.json.template
+++ b/packages/schematics/angular/application/files/tsconfig.app.json.template
@@ -17,8 +17,5 @@
   ]<% } %><% if (enableIvy) { %>
   "include": [
     "src/**/*.d.ts"
-  ],
-  "angularCompilerOptions": {
-    "enableIvy": true
-  }<% } %>
+  ]<% } %>
 }

--- a/packages/schematics/angular/application/files/tsconfig.spec.json.template
+++ b/packages/schematics/angular/application/files/tsconfig.spec.json.template
@@ -14,8 +14,5 @@
   "include": [
     "src/**/*.spec.ts",
     "src/**/*.d.ts"
-  ]<% if (enableIvy) { %>,
-  "angularCompilerOptions": {
-    "enableIvy": true
-  }<% } %>
+  ]
 }

--- a/packages/schematics/angular/application/index_spec.ts
+++ b/packages/schematics/angular/application/index_spec.ts
@@ -222,15 +222,6 @@ describe('Application Schematic', () => {
     expect(workspace.projects.foo.architect.build.options.aot).toEqual(false);
   });
 
-  it('should set AOT option to true for Ivy projects', async () => {
-    const options = { ...defaultOptions, enableIvy: true };
-
-    const tree = await schematicRunner.runSchematicAsync('application', options, workspaceTree)
-      .toPromise();
-    const workspace = JSON.parse(tree.readContent('/angular.json'));
-    expect(workspace.projects.foo.architect.build.options.aot).toEqual(true);
-  });
-
   it('should set the right files, exclude, include in the tsconfig for VE projects', async () => {
     const tree = await schematicRunner.runSchematicAsync('application', defaultOptions, workspaceTree)
       .toPromise();
@@ -241,18 +232,7 @@ describe('Application Schematic', () => {
     expect(tsConfig.include).toEqual(['src/**/*.ts']);
   });
 
-  it('should set the right files, exclude, include in the tsconfig for Ivy projects', async () => {
-    const options = { ...defaultOptions, enableIvy: true };
-    const tree = await schematicRunner.runSchematicAsync('application', options, workspaceTree)
-      .toPromise();
-    const path = '/projects/foo/tsconfig.app.json';
-    const tsConfig = JSON.parse(tree.readContent(path));
-    expect(tsConfig.files).toEqual(['src/main.ts', 'src/polyfills.ts']);
-    expect(tsConfig.exclude).toBeUndefined();
-    expect(tsConfig.include).toEqual(['src/**/*.d.ts']);
-  });
-
-  describe(`update package.json`, () => {
+  describe('update package.json', () => {
     it(`should add build-angular to devDependencies`, async () => {
       const tree = await schematicRunner.runSchematicAsync('application', defaultOptions, workspaceTree)
         .toPromise();
@@ -425,6 +405,32 @@ describe('Application Schematic', () => {
       expect(appTsConfig.extends).toEqual('../tsconfig.json');
       const specTsConfig = JSON.parse(tree.readContent('/foo/tsconfig.spec.json'));
       expect(specTsConfig.extends).toEqual('../tsconfig.json');
+    });
+  });
+
+  describe('IVY application', () => {
+    beforeEach(() => {
+      // Enable an Ivy workspace
+      const tsconfig = JSON.parse(workspaceTree.readContent('./tsconfig.json'));
+      tsconfig.angularCompilerOptions.enableIvy = true;
+      workspaceTree.overwrite('./tsconfig.json', JSON.stringify(tsconfig, undefined, 2));
+    });
+
+    it('should set the right files, exclude, include in the tsconfig for Ivy projects', async () => {
+      const tree = await schematicRunner.runSchematicAsync('application', defaultOptions, workspaceTree)
+        .toPromise();
+      const path = '/projects/foo/tsconfig.app.json';
+      const tsConfig = JSON.parse(tree.readContent(path));
+      expect(tsConfig.files).toEqual(['src/main.ts', 'src/polyfills.ts']);
+      expect(tsConfig.exclude).toBeUndefined();
+      expect(tsConfig.include).toEqual(['src/**/*.d.ts']);
+    });
+
+    it('should set AOT option to true for Ivy projects', async () => {
+      const tree = await schematicRunner.runSchematicAsync('application', defaultOptions, workspaceTree)
+        .toPromise();
+      const workspace = JSON.parse(tree.readContent('/angular.json'));
+      expect(workspace.projects.foo.architect.build.options.aot).toEqual(true);
     });
   });
 });

--- a/packages/schematics/angular/application/schema.json
+++ b/packages/schematics/angular/application/schema.json
@@ -19,12 +19,6 @@
       },
       "x-prompt": "What name would you like to use for the application?"
     },
-    "enableIvy": {
-      "description": "**EXPERIMENTAL** True to create a new app that uses the Ivy rendering engine.",
-      "type": "boolean",
-      "default": false,
-      "x-user-analytics": 8
-    },
     "inlineStyle": {
       "description": "When true, includes styles inline in the root component.ts file. Only CSS styles can be included inline. Default is false, meaning that an external styles file is created and referenced in the root component.ts file.",
       "type": "boolean",

--- a/packages/schematics/angular/library/files/tsconfig.lib.json.template
+++ b/packages/schematics/angular/library/files/tsconfig.lib.json.template
@@ -12,12 +12,10 @@
     ]
   },
   "angularCompilerOptions": {
-    "annotateForClosureCompiler": true,
+    "annotateForClosureCompiler": true<% if (!enableIvy) { %>,
     "skipTemplateCodegen": true,
     "strictMetadataEmit": true,
-    "fullTemplateTypeCheck": true,
-    "strictInjectionParameters": true,
-    "enableResourceInlining": true
+    "enableResourceInlining": true<% } %>
   },
   "exclude": [
     "src/test.ts",

--- a/packages/schematics/angular/library/files/tsconfig.lib.prod.json.template
+++ b/packages/schematics/angular/library/files/tsconfig.lib.prod.json.template
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.lib.json",
+  "angularCompilerOptions": {
+    "skipTemplateCodegen": true,
+    "strictMetadataEmit": true,
+    "enableResourceInlining": true,
+    "enableIvy": false
+  }
+}

--- a/packages/schematics/angular/migrations/update-9/index.ts
+++ b/packages/schematics/angular/migrations/update-9/index.ts
@@ -7,12 +7,14 @@
  */
 
 import { Rule, chain } from '@angular-devkit/schematics';
+import { UpdateLibraries } from './ivy-libraries';
 import { UpdateWorkspaceConfig } from './update-workspace-config';
 
 export default function(): Rule {
   return () => {
     return chain([
       UpdateWorkspaceConfig(),
+      UpdateLibraries(),
     ]);
   };
 }

--- a/packages/schematics/angular/migrations/update-9/ivy-libraries.ts
+++ b/packages/schematics/angular/migrations/update-9/ivy-libraries.ts
@@ -1,0 +1,147 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { JsonParseMode, parseJsonAst } from '@angular-devkit/core';
+import { Rule, Tree } from '@angular-devkit/schematics';
+import {
+  appendPropertyInAstObject,
+  findPropertyInAstObject,
+  insertPropertyInAstObjectInOrder,
+} from '../../utility/json-utils';
+
+function createTsConfig(tree: Tree, tsConfigPath: string) {
+  const tsConfigContent = {
+    extends: './tsconfig.lib.json',
+    angularCompilerOptions: {
+      skipTemplateCodegen: true,
+      strictMetadataEmit: true,
+      enableResourceInlining: true,
+      enableIvy: false,
+    },
+  };
+
+  tree.create(tsConfigPath, JSON.stringify(tsConfigContent, undefined, 2));
+}
+
+export function UpdateLibraries(): Rule {
+  return (tree: Tree) => {
+    let workspaceConfigPath = 'angular.json';
+    let angularConfigContent = tree.read(workspaceConfigPath);
+
+    if (!angularConfigContent) {
+      workspaceConfigPath = '.angular.json';
+      angularConfigContent = tree.read(workspaceConfigPath);
+
+      if (!angularConfigContent) {
+        return;
+      }
+    }
+
+    const angularJson = parseJsonAst(angularConfigContent.toString(), JsonParseMode.Loose);
+    if (angularJson.kind !== 'object') {
+      return;
+    }
+
+    const projects = findPropertyInAstObject(angularJson, 'projects');
+    if (!projects || projects.kind !== 'object') {
+      return;
+    }
+
+    // For all projects
+    const recorder = tree.beginUpdate(workspaceConfigPath);
+    for (const project of projects.properties) {
+      const projectConfig = project.value;
+      if (projectConfig.kind !== 'object') {
+        break;
+      }
+
+      const projectRoot = findPropertyInAstObject(projectConfig, 'root');
+      if (!projectRoot || projectRoot.kind !== 'string') {
+        break;
+      }
+
+      const architect = findPropertyInAstObject(projectConfig, 'architect');
+      if (!architect || architect.kind !== 'object') {
+        break;
+      }
+
+      const buildTarget = findPropertyInAstObject(architect, 'build');
+      if (buildTarget && buildTarget.kind === 'object') {
+        const builder = findPropertyInAstObject(buildTarget, 'builder');
+        // Projects who's build builder is @angular-devkit/build-ng-packagr
+        if (builder && builder.kind === 'string' && builder.value === '@angular-devkit/build-ng-packagr:build') {
+          const configurations = findPropertyInAstObject(buildTarget, 'configurations');
+          const tsConfig = `${projectRoot.value}/tsconfig.lib.prod.json`;
+
+          if (!configurations || configurations.kind !== 'object') {
+            // Configurations doesn't exist.
+            appendPropertyInAstObject(recorder, buildTarget, 'configurations', { production: { tsConfig } }, 10);
+            createTsConfig(tree, tsConfig);
+            continue;
+          }
+
+          const prodConfig = findPropertyInAstObject(configurations, 'production');
+          if (!prodConfig || prodConfig.kind !== 'object') {
+            // Production configuration doesn't exist.
+            insertPropertyInAstObjectInOrder(recorder, configurations, 'production', { tsConfig }, 12);
+            createTsConfig(tree, tsConfig);
+            continue;
+          }
+
+          const tsConfigOption = findPropertyInAstObject(prodConfig, 'tsConfig');
+          if (!tsConfigOption || tsConfigOption.kind !== 'string') {
+            // No tsconfig for production has been defined.
+            insertPropertyInAstObjectInOrder(recorder, prodConfig, 'tsConfig', tsConfig, 14);
+            createTsConfig(tree, tsConfig);
+            continue;
+          }
+
+          // ts config for production already exists.
+          const tsConfigContent = tree.read(tsConfigOption.value);
+          if (!tsConfigContent) {
+            continue;
+          }
+
+          const tsConfigAst = parseJsonAst(tsConfigContent.toString(), JsonParseMode.Loose);
+          if (!tsConfigAst || tsConfigAst.kind !== 'object') {
+            continue;
+          }
+
+          const tsConfigRecorder = tree.beginUpdate(tsConfigOption.value);
+          const ngCompilerOptions = findPropertyInAstObject(tsConfigAst, 'angularCompilerOptions');
+          if (!ngCompilerOptions) {
+            // Add angularCompilerOptions
+            appendPropertyInAstObject(tsConfigRecorder, tsConfigAst, 'angularCompilerOptions', { enableIvy: false }, 2);
+            tree.commitUpdate(tsConfigRecorder);
+            continue;
+          }
+
+          if (ngCompilerOptions.kind === 'object') {
+            const enableIvy = findPropertyInAstObject(ngCompilerOptions, 'enableIvy');
+            // Add enableIvy false
+            if (!enableIvy) {
+              appendPropertyInAstObject(tsConfigRecorder, ngCompilerOptions, 'enableIvy', false, 4);
+              tree.commitUpdate(tsConfigRecorder);
+              continue;
+            }
+
+            if (enableIvy.kind !== 'false') {
+              const { start, end } = enableIvy;
+              tsConfigRecorder.remove(start.offset, end.offset - start.offset);
+              tsConfigRecorder.insertLeft(start.offset, 'false');
+              tree.commitUpdate(tsConfigRecorder);
+            }
+          }
+        }
+      }
+    }
+
+    tree.commitUpdate(recorder);
+
+    return tree;
+  };
+}

--- a/packages/schematics/angular/migrations/update-9/ivy-libraries_spec.ts
+++ b/packages/schematics/angular/migrations/update-9/ivy-libraries_spec.ts
@@ -1,0 +1,140 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { EmptyTree } from '@angular-devkit/schematics';
+import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';
+import { WorkspaceTargets } from '../../utility/workspace-models';
+
+// tslint:disable-next-line: no-any
+function getWorkspaceTargets(tree: UnitTestTree): any {
+  return JSON.parse(tree.readContent(workspacePath))
+    .projects['migration-lib'].architect;
+}
+
+function updateWorkspaceTargets(tree: UnitTestTree, workspaceTargets: WorkspaceTargets) {
+  const config = JSON.parse(tree.readContent(workspacePath));
+  config.projects['migration-lib'].architect = workspaceTargets;
+  tree.overwrite(workspacePath, JSON.stringify(config, undefined, 2));
+}
+
+const workspacePath = '/angular.json';
+const libProdTsConfig = 'migration-lib/tsconfig.lib.prod.json';
+
+// tslint:disable:no-big-function
+describe('Migration to version 9', () => {
+  describe('Migrate Ivy Libraries', () => {
+    const schematicRunner = new SchematicTestRunner(
+      'migrations',
+      require.resolve('../migration-collection.json'),
+    );
+
+    let tree: UnitTestTree;
+
+    beforeEach(async () => {
+      tree = new UnitTestTree(new EmptyTree());
+      tree = await schematicRunner
+        .runExternalSchematicAsync(
+          require.resolve('../../collection.json'),
+          'workspace',
+          {
+            name: 'migration-test',
+            version: '1.2.3',
+            directory: '.',
+          },
+          tree,
+        )
+        .toPromise();
+      tree = await schematicRunner
+        .runExternalSchematicAsync(
+          require.resolve('../../collection.json'),
+          'library',
+          {
+            name: 'migration-lib',
+          },
+          tree,
+        )
+        .toPromise();
+    });
+
+    it(`should add 'tsConfig' option in production when configurations doesn't exists`, () => {
+      const tree2 = schematicRunner.runSchematic('migration-09', {}, tree.branch());
+      const config = getWorkspaceTargets(tree2).build;
+      expect(config.configurations.production.tsConfig).toEqual(libProdTsConfig);
+      expect(tree2.exists(libProdTsConfig)).toBeTruthy();
+    });
+
+    it(`should add 'tsConfig' option in production when configurations exists`, () => {
+      let config = getWorkspaceTargets(tree);
+      config.build.configurations = {};
+
+      updateWorkspaceTargets(tree, config);
+
+      const tree2 = schematicRunner.runSchematic('migration-09', {}, tree.branch());
+      config = getWorkspaceTargets(tree2).build;
+      expect(config.configurations.production.tsConfig).toEqual(libProdTsConfig);
+      expect(tree2.exists(libProdTsConfig)).toBeTruthy();
+    });
+
+    it(`should add 'tsConfig' option in production when production configurations exists`, () => {
+      let config = getWorkspaceTargets(tree);
+      config.build.configurations = { production: {} };
+
+      updateWorkspaceTargets(tree, config);
+
+      const tree2 = schematicRunner.runSchematic('migration-09', {}, tree.branch());
+      config = getWorkspaceTargets(tree2).build;
+      expect(config.configurations.production.tsConfig).toEqual(libProdTsConfig);
+      expect(tree2.exists(libProdTsConfig)).toBeTruthy();
+    });
+
+    it(`should add enableIvy false in prod tsconfig if already exists`, () => {
+      let config = getWorkspaceTargets(tree);
+      const prodLibTsConfig = 'migration-lib/tsconfig.library.prod.json';
+      config.build.configurations = { production: { tsConfig: prodLibTsConfig } };
+
+      updateWorkspaceTargets(tree, config);
+
+      const tsconfig = {
+        compilerOptions: {},
+      };
+
+      tree.create(prodLibTsConfig, JSON.stringify(tsconfig, undefined, 2));
+
+      const tree2 = schematicRunner.runSchematic('migration-09', {}, tree.branch());
+      config = getWorkspaceTargets(tree2).build;
+      expect(config.configurations.production.tsConfig).toEqual(prodLibTsConfig);
+
+      const tsConfigContent = tree2.readContent(prodLibTsConfig);
+      expect(JSON.parse(tsConfigContent).angularCompilerOptions).toEqual({ enableIvy: false });
+    });
+
+    it('should set enableIvy to false in prod tsconfig if true', () => {
+      let config = getWorkspaceTargets(tree);
+      const prodLibTsConfig = 'migration-lib/tsconfig.library.prod.json';
+      config.build.configurations = { production: { tsConfig: prodLibTsConfig } };
+
+      updateWorkspaceTargets(tree, config);
+
+      const tsconfig = {
+        compilerOptions: {},
+        angularCompilerOptions: {
+          enableIvy: true,
+        },
+      };
+
+      tree.create(prodLibTsConfig, JSON.stringify(tsconfig, undefined, 2));
+
+      const tree2 = schematicRunner.runSchematic('migration-09', {}, tree.branch());
+      config = getWorkspaceTargets(tree2).build;
+      expect(config.configurations.production.tsConfig).toEqual(prodLibTsConfig);
+
+      const tsConfigContent = tree2.readContent(prodLibTsConfig);
+      expect(JSON.parse(tsConfigContent).angularCompilerOptions).toEqual({ enableIvy: false });
+    });
+  });
+});

--- a/packages/schematics/angular/migrations/update-9/update-workspace-config.ts
+++ b/packages/schematics/angular/migrations/update-9/update-workspace-config.ts
@@ -63,7 +63,7 @@ export function UpdateWorkspaceConfig(): Rule {
       const buildTarget = findPropertyInAstObject(architect, 'build');
       if (buildTarget && buildTarget.kind === 'object') {
         const builder = findPropertyInAstObject(buildTarget, 'builder');
-        // Projects who's build builder is not build-angular:browser
+        // Projects who's build builder is @angular-devkit/build-angular:browser
         if (builder && builder.kind === 'string' && builder.value === '@angular-devkit/build-angular:browser') {
           updateStyleOrScriptOption('styles', recorder, buildTarget);
           updateStyleOrScriptOption('scripts', recorder, buildTarget);
@@ -74,7 +74,7 @@ export function UpdateWorkspaceConfig(): Rule {
       const testTarget = findPropertyInAstObject(architect, 'test');
       if (testTarget && testTarget.kind === 'object') {
         const builder = findPropertyInAstObject(testTarget, 'builder');
-        // Projects who's build builder is not build-angular:browser
+        // Projects who's build builder is @angular-devkit/build-angular:karma
         if (builder && builder.kind === 'string' && builder.value === '@angular-devkit/build-angular:karma') {
           updateStyleOrScriptOption('styles', recorder, testTarget);
           updateStyleOrScriptOption('scripts', recorder, testTarget);

--- a/packages/schematics/angular/ng-new/index.ts
+++ b/packages/schematics/angular/ng-new/index.ts
@@ -40,13 +40,13 @@ export default function (options: NgNewOptions): Rule {
   const workspaceOptions: WorkspaceOptions = {
     name: options.name,
     version: options.version,
+    enableIvy: options.enableIvy,
     newProjectRoot: options.newProjectRoot || 'projects',
     minimal: options.minimal,
   };
   const applicationOptions: ApplicationOptions = {
     projectRoot: '',
     name: options.name,
-    enableIvy: options.enableIvy,
     inlineStyle: options.inlineStyle,
     inlineTemplate: options.inlineTemplate,
     prefix: options.prefix,

--- a/packages/schematics/angular/ng-new/index_spec.ts
+++ b/packages/schematics/angular/ng-new/index_spec.ts
@@ -79,4 +79,11 @@ describe('Ng New Schematic', () => {
     const confContent = JSON.parse(tree.readContent('/bar/angular.json'));
     expect(confContent.projects.foo.e2e).toBeUndefined();
   });
+
+  it('should set AOT option to true for Ivy projects', async () => {
+    const options = { ...defaultOptions, enableIvy: true };
+    const tree = await schematicRunner.runSchematicAsync('ng-new', options).toPromise();
+    const workspace = JSON.parse(tree.readContent('/bar/angular.json'));
+    expect(workspace.projects.foo.architect.build.options.aot).toEqual(true);
+  });
 });

--- a/packages/schematics/angular/ng-new/schema.json
+++ b/packages/schematics/angular/ng-new/schema.json
@@ -21,7 +21,8 @@
     "enableIvy": {
       "description": "When true, creates a new app that uses the Ivy rendering engine.",
       "type": "boolean",
-      "default": false
+      "default": false,
+      "x-user-analytics": 8
     },
     "skipInstall": {
       "description": "When true, does not install dependency packages.",

--- a/packages/schematics/angular/utility/latest-versions.ts
+++ b/packages/schematics/angular/utility/latest-versions.ts
@@ -21,5 +21,5 @@ export const latestVersions = {
   AngularPWA: '~0.802.0-rc.0',
 
   tsickle: '^0.36.0',
-  ngPackagr: '^5.3.0',
+  ngPackagr: '^5.4.0',
 };

--- a/packages/schematics/angular/workspace/files/tsconfig.json.template
+++ b/packages/schematics/angular/workspace/files/tsconfig.json.template
@@ -19,7 +19,8 @@
       "dom"
     ]
   },
-  "angularCompilerOptions": {
+  "angularCompilerOptions": {<% if (enableIvy) { %>
+    "enableIvy": true,<% } %>
     "fullTemplateTypeCheck": true,
     "strictInjectionParameters": true
   }

--- a/packages/schematics/angular/workspace/schema.json
+++ b/packages/schematics/angular/workspace/schema.json
@@ -13,6 +13,11 @@
         "index": 0
       }
     },
+    "enableIvy": {
+      "description": "**EXPERIMENTAL** True to create a new app that uses the Ivy rendering engine.",
+      "type": "boolean",
+      "default": false
+    },
     "newProjectRoot": {
       "description": "The path where new projects will be created.",
       "type": "string",

--- a/tests/angular_devkit/build_angular/hello-world-app-ivy/src/tsconfig.app.json
+++ b/tests/angular_devkit/build_angular/hello-world-app-ivy/src/tsconfig.app.json
@@ -10,8 +10,5 @@
   ],
   "include": [
     "**/*.d.ts"
-  ],
-  "angularCompilerOptions": {
-    "enableIvy": true
-  }
+  ]
 }

--- a/tests/angular_devkit/build_angular/hello-world-app-ivy/src/tsconfig.server.json
+++ b/tests/angular_devkit/build_angular/hello-world-app-ivy/src/tsconfig.server.json
@@ -10,7 +10,6 @@
     "main.server.ts"
   ],
   "angularCompilerOptions": {
-    "entryModule": "app/app.server.module#AppServerModule",
-    "enableIvy": true
+    "entryModule": "app/app.server.module#AppServerModule"
   }
 }

--- a/tests/angular_devkit/build_angular/hello-world-app-ivy/src/tsconfig.spec.json
+++ b/tests/angular_devkit/build_angular/hello-world-app-ivy/src/tsconfig.spec.json
@@ -14,8 +14,5 @@
   "include": [
     "**/*.spec.ts",
     "**/*.d.ts"
-  ],
-  "angularCompilerOptions": {
-    "enableIvy": true
-  }
+  ]
 }

--- a/tests/angular_devkit/build_angular/hello-world-app-ivy/tsconfig.json
+++ b/tests/angular_devkit/build_angular/hello-world-app-ivy/tsconfig.json
@@ -17,5 +17,8 @@
       "es2017",
       "dom"
     ]
+  },
+  "angularCompilerOptions": {
+    "enableIvy": true
   }
 }

--- a/tests/angular_devkit/build_ng_packagr/ng-packaged-ivy/.gitignore
+++ b/tests/angular_devkit/build_ng_packagr/ng-packaged-ivy/.gitignore
@@ -1,0 +1,42 @@
+# See http://help.github.com/ignore-files/ for more about ignoring files.
+
+# compiled output
+/dist
+/tmp
+/out-tsc
+
+# dependencies
+/node_modules
+
+# IDEs and editors
+/.idea
+.project
+.classpath
+.c9/
+*.launch
+.settings/
+*.sublime-workspace
+
+# IDE - VSCode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+
+# misc
+/.sass-cache
+/connect.lock
+/coverage
+/libpeerconnection.log
+npm-debug.log
+testem.log
+/typings
+
+# e2e
+/e2e/*.js
+/e2e/*.map
+
+# System Files
+.DS_Store
+Thumbs.db

--- a/tests/angular_devkit/build_ng_packagr/ng-packaged-ivy/angular.json
+++ b/tests/angular_devkit/build_ng_packagr/ng-packaged-ivy/angular.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "../../../../packages/angular_devkit/core/src/workspace/workspace-schema.json",
+  "version": 1,
+  "projects": {
+    "lib": {
+      "root": "projects/lib",
+      "projectType": "library",
+      "targets": {
+        "build": {
+          "builder": "../../../../packages/angular_devkit/build_ng_packagr:build",
+          "options": {
+            "project": "projects/lib/ng-package.json",
+            "tsConfig": "projects/lib/tsconfig.lib.json"
+          },
+          "configurations": {
+            "production": {
+              "tsConfig": "projects/lib/tsconfig.lib.prod.json"
+            }
+          }
+        },
+        "test": {
+          "builder": "../../../../packages/angular_devkit/build_angular:karma",
+          "options": {
+            "main": "projects/lib/src/test.ts",
+            "tsConfig": "projects/lib/tsconfig.spec.json",
+            "karmaConfig": "projects/lib/karma.conf.js",
+            "browsers": "ChromeHeadlessCI",
+            "progress": false,
+            "watch": false
+          }
+        },
+        "lint": {
+          "builder": "../../../../packages/angular_devkit/build_angular:tslint",
+          "options": {
+            "tsConfig": [
+              "projects/lib/tsconfig.lib.json",
+              "projects/lib/tsconfig.spec.json"
+            ],
+            "exclude": [
+              "**/node_modules/**"
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/angular_devkit/build_ng_packagr/ng-packaged-ivy/projects/lib/karma.conf.js
+++ b/tests/angular_devkit/build_ng_packagr/ng-packaged-ivy/projects/lib/karma.conf.js
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+// Karma configuration file, see link for more information
+// https://karma-runner.github.io/1.0/config/configuration-file.html
+
+module.exports = function (config) {
+  config.set({
+    basePath: '',
+    frameworks: ['jasmine', '@angular-devkit/build-angular'],
+    plugins: [
+      require('karma-jasmine'),
+      require('karma-chrome-launcher'),
+      require('karma-jasmine-html-reporter'),
+      require('karma-coverage-istanbul-reporter'),
+      require('@angular-devkit/build-angular/plugins/karma')
+    ],
+    client: {
+      clearContext: false // leave Jasmine Spec Runner output visible in browser
+    },
+    coverageIstanbulReporter: {
+      dir: require('path').join(__dirname, 'coverage'),
+      reports: ['html', 'lcovonly'],
+      fixWebpackSourcePaths: true
+    },
+    reporters: ['progress', 'kjhtml'],
+    port: 9876,
+    colors: true,
+    logLevel: config.LOG_INFO,
+    autoWatch: true,
+    browsers: ['Chrome'],
+    customLaunchers: {
+      ChromeHeadlessCI: {
+        base: 'ChromeHeadless',
+        flags: ['--disable-gpu']
+      }
+    },
+    singleRun: false
+  });
+};

--- a/tests/angular_devkit/build_ng_packagr/ng-packaged-ivy/projects/lib/ng-package.json
+++ b/tests/angular_devkit/build_ng_packagr/ng-packaged-ivy/projects/lib/ng-package.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "../../../../../../node_modules/ng-packagr/ng-package.schema.json",
+  "dest": "../../dist/lib",
+  "lib": {
+    "entryFile": "src/public-api.ts"
+  }
+}

--- a/tests/angular_devkit/build_ng_packagr/ng-packaged-ivy/projects/lib/package.json
+++ b/tests/angular_devkit/build_ng_packagr/ng-packaged-ivy/projects/lib/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "lib",
+  "version": "0.0.1",
+  "peerDependencies": {
+    "@angular/common": "^6.0.0-rc.0 || ^6.0.0",
+    "@angular/core": "^6.0.0-rc.0 || ^6.0.0"
+  }
+}

--- a/tests/angular_devkit/build_ng_packagr/ng-packaged-ivy/projects/lib/src/lib/lib.component.spec.ts
+++ b/tests/angular_devkit/build_ng_packagr/ng-packaged-ivy/projects/lib/src/lib/lib.component.spec.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LibComponent } from './lib.component';
+
+describe('LibComponent', () => {
+  let component: LibComponent;
+  let fixture: ComponentFixture<LibComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ LibComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(LibComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/tests/angular_devkit/build_ng_packagr/ng-packaged-ivy/projects/lib/src/lib/lib.component.ts
+++ b/tests/angular_devkit/build_ng_packagr/ng-packaged-ivy/projects/lib/src/lib/lib.component.ts
@@ -1,0 +1,26 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'lib',
+  template: `
+    <p>
+      lib works!
+    </p>
+  `,
+  styles: []
+})
+export class LibComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+}

--- a/tests/angular_devkit/build_ng_packagr/ng-packaged-ivy/projects/lib/src/lib/lib.module.ts
+++ b/tests/angular_devkit/build_ng_packagr/ng-packaged-ivy/projects/lib/src/lib/lib.module.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { NgModule } from '@angular/core';
+import { LibComponent } from './lib.component';
+import { LibService } from './lib.service';
+
+@NgModule({
+  imports: [
+  ],
+  declarations: [LibComponent],
+  providers: [LibService]
+})
+export class LibModule { }

--- a/tests/angular_devkit/build_ng_packagr/ng-packaged-ivy/projects/lib/src/lib/lib.service.spec.ts
+++ b/tests/angular_devkit/build_ng_packagr/ng-packaged-ivy/projects/lib/src/lib/lib.service.spec.ts
@@ -1,0 +1,22 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { TestBed, inject } from '@angular/core/testing';
+
+import { LibService } from './lib.service';
+
+describe('LibService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [LibService]
+    });
+  });
+
+  it('should be created', inject([LibService], (service: LibService) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/tests/angular_devkit/build_ng_packagr/ng-packaged-ivy/projects/lib/src/lib/lib.service.ts
+++ b/tests/angular_devkit/build_ng_packagr/ng-packaged-ivy/projects/lib/src/lib/lib.service.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export class LibService {
+
+  constructor() { }
+
+  testEs2016() {
+    return ['foo', 'bar'].includes('foo');
+  }
+
+}

--- a/tests/angular_devkit/build_ng_packagr/ng-packaged-ivy/projects/lib/src/public-api.ts
+++ b/tests/angular_devkit/build_ng_packagr/ng-packaged-ivy/projects/lib/src/public-api.ts
@@ -1,0 +1,14 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+/*
+ * Public API Surface of lib
+ */
+
+export * from './lib/lib.service';
+export * from './lib/lib.component';
+export * from './lib/lib.module';

--- a/tests/angular_devkit/build_ng_packagr/ng-packaged-ivy/projects/lib/src/test.ts
+++ b/tests/angular_devkit/build_ng_packagr/ng-packaged-ivy/projects/lib/src/test.ts
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+// This file is required by karma.conf.js and loads recursively all the .spec and framework files
+
+import 'zone.js/dist/zone';
+import 'zone.js/dist/zone-testing';
+import { getTestBed } from '@angular/core/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting
+} from '@angular/platform-browser-dynamic/testing';
+
+declare const require: any;
+
+// First, initialize the Angular testing environment.
+getTestBed().initTestEnvironment(
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting()
+);
+// Then we find all the tests.
+const context = require.context('./', true, /\.spec\.ts$/);
+// And load the modules.
+context.keys().map(context);

--- a/tests/angular_devkit/build_ng_packagr/ng-packaged-ivy/projects/lib/tsconfig.lib.json
+++ b/tests/angular_devkit/build_ng_packagr/ng-packaged-ivy/projects/lib/tsconfig.lib.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "target": "es2015",
+    "declaration": true,
+    "inlineSources": true,
+    "types": [],
+    "lib": [
+      "dom",
+      "es2018"
+    ]
+  },
+  "exclude": [
+    "src/test.ts",
+    "**/*.spec.ts"
+  ]
+}

--- a/tests/angular_devkit/build_ng_packagr/ng-packaged-ivy/projects/lib/tsconfig.lib.prod.json
+++ b/tests/angular_devkit/build_ng_packagr/ng-packaged-ivy/projects/lib/tsconfig.lib.prod.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.lib.json",
+  "angularCompilerOptions": {
+    "skipTemplateCodegen": true,
+    "strictMetadataEmit": true,
+    "enableResourceInlining": true,
+    "enableIvy": false
+  }
+}

--- a/tests/angular_devkit/build_ng_packagr/ng-packaged-ivy/projects/lib/tsconfig.spec.json
+++ b/tests/angular_devkit/build_ng_packagr/ng-packaged-ivy/projects/lib/tsconfig.spec.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../out-tsc/spec",
+    "types": [
+      "jasmine",
+      "node"
+    ]
+  },
+  "files": [
+    "src/test.ts"
+  ],
+  "include": [
+    "**/*.spec.ts",
+    "**/*.d.ts"
+  ]
+}

--- a/tests/angular_devkit/build_ng_packagr/ng-packaged-ivy/tsconfig.json
+++ b/tests/angular_devkit/build_ng_packagr/ng-packaged-ivy/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "baseUrl": "./",
+    "outDir": "./dist/out-tsc",
+    "sourceMap": true,
+    "declaration": false,
+    "moduleResolution": "node",
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "target": "es5",
+    "typeRoots": [
+      "node_modules/@types"
+    ],
+    "lib": [
+      "es2017",
+      "dom"
+    ]
+  },
+  "angularCompilerOptions": {
+    "enableIvy": true
+  }
+}

--- a/tests/angular_devkit/build_ng_packagr/ng-packaged-ivy/tslint.json
+++ b/tests/angular_devkit/build_ng_packagr/ng-packaged-ivy/tslint.json
@@ -1,0 +1,131 @@
+{
+  "rulesDirectory": [
+    "../../../../node_modules/codelyzer"
+  ],
+  "rules": {
+    "arrow-return-shorthand": true,
+    "callable-types": true,
+    "class-name": true,
+    "comment-format": [
+      true,
+      "check-space"
+    ],
+    "curly": true,
+    "deprecation": {
+      "severity": "warn"
+    },
+    "eofline": true,
+    "forin": true,
+    "import-blacklist": [
+      true,
+      "rxjs",
+      "rxjs/Rx"
+    ],
+    "import-spacing": true,
+    "indent": [
+      true,
+      "spaces"
+    ],
+    "interface-over-type-literal": true,
+    "label-position": true,
+    "max-line-length": [
+      true,
+      140
+    ],
+    "member-access": false,
+    "member-ordering": [
+      true,
+      {
+        "order": [
+          "static-field",
+          "instance-field",
+          "static-method",
+          "instance-method"
+        ]
+      }
+    ],
+    "no-arg": true,
+    "no-bitwise": true,
+    "no-console": [
+      true,
+      "debug",
+      "info",
+      "time",
+      "timeEnd",
+      "trace"
+    ],
+    "no-construct": true,
+    "no-debugger": true,
+    "no-duplicate-super": true,
+    "no-empty": false,
+    "no-empty-interface": true,
+    "no-eval": true,
+    "no-inferrable-types": [
+      true,
+      "ignore-params"
+    ],
+    "no-misused-new": true,
+    "no-non-null-assertion": true,
+    "no-shadowed-variable": true,
+    "no-string-literal": false,
+    "no-string-throw": true,
+    "no-switch-case-fall-through": true,
+    "no-trailing-whitespace": true,
+    "no-unnecessary-initializer": true,
+    "no-unused-expression": true,
+    "no-use-before-declare": true,
+    "no-var-keyword": true,
+    "object-literal-sort-keys": false,
+    "one-line": [
+      true,
+      "check-open-brace",
+      "check-catch",
+      "check-else",
+      "check-whitespace"
+    ],
+    "prefer-const": true,
+    "quotemark": [
+      true,
+      "single"
+    ],
+    "radix": true,
+    "semicolon": [
+      true,
+      "always"
+    ],
+    "triple-equals": [
+      true,
+      "allow-null-check"
+    ],
+    "typedef-whitespace": [
+      true,
+      {
+        "call-signature": "nospace",
+        "index-signature": "nospace",
+        "parameter": "nospace",
+        "property-declaration": "nospace",
+        "variable-declaration": "nospace"
+      }
+    ],
+    "unified-signatures": true,
+    "variable-name": false,
+    "whitespace": [
+      true,
+      "check-branch",
+      "check-decl",
+      "check-operator",
+      "check-separator",
+      "check-type"
+    ],
+    "no-output-on-prefix": true,
+    "use-input-property-decorator": true,
+    "use-output-property-decorator": true,
+    "use-host-property-decorator": true,
+    "no-input-rename": true,
+    "no-output-rename": true,
+    "use-life-cycle-interface": true,
+    "use-pipe-transform-interface": true,
+    "component-class-suffix": true,
+    "directive-class-suffix": true
+  }
+}

--- a/tests/legacy-cli/e2e/tests/build/lazy-load-syntax.ts
+++ b/tests/legacy-cli/e2e/tests/build/lazy-load-syntax.ts
@@ -9,11 +9,8 @@ import { getGlobalVariable } from '../../utils/env';
 import { appendToFile, prependToFile, readFile, replaceInFile, writeFile } from '../../utils/fs';
 import { ng } from '../../utils/process';
 import { updateJsonFile } from '../../utils/project';
-import { expectToFail } from '../../utils/utils';
 
 export default async function () {
-  const argv = getGlobalVariable('argv');
-  const ivyProject = argv['ivy'];
   const projectName = 'test-project';
   const appRoutingModulePath = 'src/app/app-routing.module.ts';
 

--- a/tests/legacy-cli/e2e/tests/ivy/ivy-opt-out.ts
+++ b/tests/legacy-cli/e2e/tests/ivy/ivy-opt-out.ts
@@ -17,7 +17,7 @@ export default async function() {
     await ng('e2e', '--prod');
 
     // View Engine (NGC) compilation should work after running NGCC from Webpack
-    await replaceInFile('tsconfig.app.json', '"enableIvy": true', '"enableIvy": false');
+    await replaceInFile('tsconfig.json', '"enableIvy": true', '"enableIvy": false');
 
     // verify that VE compilation works during runtime
     await ng('e2e', '--prod');

--- a/yarn.lock
+++ b/yarn.lock
@@ -271,11 +271,6 @@
     source-map-support "0.5.9"
     tsutils "2.27.2"
 
-"@ngtools/json-schema@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@ngtools/json-schema/-/json-schema-1.1.0.tgz#c3a0c544d62392acc2813a42c8a0dc6f58f86922"
-  integrity sha1-w6DFRNYjkqzCgTpCyKDcb1j4aSI=
-
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
@@ -1024,7 +1019,7 @@ ajv-keywords@^3.1.0:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.2.0.tgz#e86b819c602cf8821ad637413698f1dec021847a"
   integrity sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=
 
-ajv@6.10.2:
+ajv@6.10.2, ajv@^6.10.2:
   version "6.10.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.2.tgz#d3cea04d6b017b2894ad69040fec8b623eb4bd52"
   integrity sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==
@@ -2451,7 +2446,7 @@ combined-stream@^1.0.6, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@2.20.0, commander@^2.19.0:
+commander@2.20.0, commander@^2.19.0, commander@^2.20.0:
   version "2.20.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
   integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
@@ -7161,12 +7156,12 @@ neo-async@^2.6.0:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
   integrity sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==
 
-ng-packagr@^5.3.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/ng-packagr/-/ng-packagr-5.3.0.tgz#92434ca05ecbd1e01fe961a66c8a9a66b095f6fa"
-  integrity sha512-i+964lzZC7VVzatDCLDZndiXTog1XGozY7K1Bs78+uBF8O1YHNQP9wB9C5fR4uEaSKVhCWEBYekoS69flCugMA==
+ng-packagr@^5.4.0:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/ng-packagr/-/ng-packagr-5.4.1.tgz#fd2f72633fc14b92837bb296d0080baa934d6109"
+  integrity sha512-hXIx8vmI65BP8DGM1tC15JXeXoa4GvK7a4xaVf7GSKENI7grwrW34Q6EhUgEG0G3kL9Ta5clE85RDqkQ1oOybg==
   dependencies:
-    "@ngtools/json-schema" "^1.1.0"
+    ajv "^6.10.2"
     autoprefixer "^9.6.0"
     browserslist "^4.0.0"
     chalk "^2.3.1"
@@ -7191,7 +7186,7 @@ ng-packagr@^5.3.0:
     rxjs "^6.0.0"
     sass "^1.17.3"
     stylus "^0.54.5"
-    terser "^4.0.0"
+    terser "^4.1.2"
     update-notifier "^3.0.0"
 
 nice-try@^1.0.4:
@@ -9693,7 +9688,7 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
-source-map-support@0.5.12, source-map-support@~0.5.10:
+source-map-support@0.5.12, source-map-support@~0.5.10, source-map-support@~0.5.12:
   version "0.5.12"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.12.tgz#b4f3b10d51857a5af0138d3ce8003b201613d599"
   integrity sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==
@@ -10330,6 +10325,15 @@ terser@^4.0.0:
     commander "^2.19.0"
     source-map "~0.6.1"
     source-map-support "~0.5.10"
+
+terser@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-4.1.2.tgz#b2656c8a506f7ce805a3f300a2ff48db022fa391"
+  integrity sha512-jvNoEQSPXJdssFwqPSgWjsOrb+ELoE+ILpHPKXC83tIxOlh2U75F1KuB2luLD/3a6/7K3Vw5pDn+hvu0C4AzSw==
+  dependencies:
+    commander "^2.20.0"
+    source-map "~0.6.1"
+    source-map-support "~0.5.12"
 
 text-extensions@^1.0.0:
   version "1.8.0"


### PR DESCRIPTION
- **feat(@schematics/angular): introduce Ivy workspace concept**

At the moment, to enable Ivy as the view rendering engine we are adding `enableIvy: true` in each of the applications tsconfigs. 
While this works this is not ideal when users want to opt-out, as users will need to modify multiple tsconfig. 

With the introduction of Ivy libraries for development this will be even harder and cumbersome.

We added the `enableIvy` option to the `workspace` schematic and remove the option for the `application` schematic.

`ng new <project-name> --enable-ivy` will pass down down the option the workspace schematic and an Ivy workspace will be created. 
Other schematics such as `application` and `library` will read the workspace (root) tsconfig to verify if a application or library with
 Ivy structure and configuration should be created.

- **feat(@schematics/angular): introduce Ivy libraries for development**

Since `NGCC` is non incremental and in library projects we have the original TS sources
we don't need to build a library using the `VE` and transform it using `NGCC`. Instead we can build the library using `NGTSC` (Ivy) directly
 as this enables faster incremental compilations and a better development experience.

 Libraries now have a `production` configuration, which enabled `VE` compilations. As it is not recommended to publish NGTSC (Ivy) 
 built libraries to NPM repositories, since Ivy libraries are not backwards compatible with the legacy View Engine.

- **feat(@schematics/angular): ivy library migration**

Add a migration to migrate existing libraries to the new library layout considering it will be the default in version 9.