### PR TITLE
fix(angularCompilerPlugin): respect noEmitOnError compiler's option when checking for typescript errors

### DIFF
--- a/packages/ngtools/webpack/src/angular_compiler_plugin.ts
+++ b/packages/ngtools/webpack/src/angular_compiler_plugin.ts
@@ -1284,7 +1284,7 @@ export class AngularCompilerPlugin {
         allDiagnostics.push(...gatherDiagnostics(tsProgram, this._JitMode,
           'AngularCompilerPlugin._emit.ts', diagMode));
 
-        if (!hasErrors(allDiagnostics)) {
+        if (!this._compilerOptions.noEmitOnError || !hasErrors(allDiagnostics)) {
           if (this._firstRun || changedTsFiles.size > 20 || !this._hadFullJitEmit) {
             emitResult = tsProgram.emit(
               undefined,


### PR DESCRIPTION


Currently noEmitOnError compiler's option is not respected when executing typescript program. In case when noEmitOnError is false and there are compilation errors in project, no .js files are emitted. However, in this case .js files should be emitted.
In case when noEmitOnError is true and there are compilation errors in project, `.js` files should not be emitted.