### PR TITLE
fix(@angular-devkit/build-optimizer): don't wrap classes which static…

### DIFF
--- a/packages/angular_devkit/build_optimizer/src/build-optimizer/build-optimizer.ts
+++ b/packages/angular_devkit/build_optimizer/src/build-optimizer/build-optimizer.ts
@@ -149,7 +149,7 @@ export function buildOptimizer(options: BuildOptimizerOptions): TransformJavascr
     getTransforms.unshift(getImportTslibTransformer);
   }
 
-  getTransforms.unshift(getWrapEnumsTransformer);
+  getTransforms.push(getWrapEnumsTransformer);
 
   const transformJavascriptOpts: TransformJavascriptOptions = {
     content: content,

--- a/packages/angular_devkit/build_optimizer/src/build-optimizer/build-optimizer_spec.ts
+++ b/packages/angular_devkit/build_optimizer/src/build-optimizer/build-optimizer_spec.ts
@@ -99,6 +99,35 @@ describe('build-optimizer', () => {
       expect(tags.oneLine`${boOutput.content}`).toEqual(output);
       expect(boOutput.emitSkipped).toEqual(false);
     });
+
+    it('should not wrap classes which had all static properties dropped in IIFE', () => {
+      const classDeclaration = tags.oneLine`
+        import { Injectable } from '@angular/core';
+
+        class Platform {
+          constructor(_doc) {
+          }
+          init() {
+          }
+        }
+      `;
+      const input = tags.oneLine`
+        ${classDeclaration}
+
+        Platform.decorators = [
+            { type: Injectable }
+        ];
+
+        /** @nocollapse */
+        Platform.ctorParameters = () => [
+            { type: undefined, decorators: [{ type: Inject, args: [DOCUMENT] }] }
+        ];
+      `;
+
+      const boOutput = buildOptimizer({ content: input, isSideEffectFree: true });
+      expect(tags.oneLine`${boOutput.content}`).toEqual(classDeclaration);
+      expect(boOutput.emitSkipped).toEqual(false);
+    });
   });
 
 


### PR DESCRIPTION
… properties have been removed

At the moment the `wrap-enums` transfomers is being run prior to `scrub-file` and this is resulting classes which all static properties have been dropped to be wrapped in IIFE.