### PR TITLE
 fix(@angular-devkit/build-angular): escape dot in js extensions to match literally

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
@@ -403,11 +403,11 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
           parser: { system: true },
         },
         {
-          test: /[\/\\]hot[\/\\]emitter.js$/,
+          test: /[\/\\]hot[\/\\]emitter\.js$/,
           parser: { node: { events: true } },
         },
         {
-          test: /[\/\\]webpack-dev-server[\/\\]client[\/\\]utils[\/\\]createSocketUrl.js$/,
+          test: /[\/\\]webpack-dev-server[\/\\]client[\/\\]utils[\/\\]createSocketUrl\.js$/,
           parser: { node: { querystring: true } },
         },
         {
@@ -416,7 +416,7 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
         },
         {
           test: /\.js$/,
-          exclude: /(ngfactory|ngstyle).js$/,
+          exclude: /(ngfactory|ngstyle)\.js$/,
           enforce: 'pre',
           ...sourceMapUseRule,
         },


### PR DESCRIPTION

Closes #15195