### PR TITLE
 fix(@schematics/angular): the `ng-new` schematic should not prompt for style nor for routing

### DIFF
--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -307,6 +307,10 @@ export default function (options: ApplicationOptions): Rule {
     }
     validateProjectName(options.name);
     options.prefix = options.prefix || 'app';
+    // This line and the one above shouldn't be needed, but at the moment they are.
+    // This is because the default value defined in the schema.json file is not
+    // correctly set when this schematic is run from another schematic.
+    options.style = options.style || Style.Css;
     const appRootSelector = `${options.prefix}-root`;
     const componentOptions: Partial<ComponentOptions> = !options.minimal ?
       {

--- a/packages/schematics/angular/ng-new/schema.json
+++ b/packages/schematics/angular/ng-new/schema.json
@@ -112,31 +112,7 @@
     "style": {
       "description": "The file extension or preprocessor to use for style files.",
       "type": "string",
-      "default": "css",
       "enum": ["css", "scss", "sass", "less", "styl"],
-      "x-prompt": {
-        "message": "Which stylesheet format would you like to use?",
-        "type": "list",
-        "items": [
-          { "value": "css", "label": "CSS" },
-          {
-            "value": "scss",
-            "label": "SCSS   [ https://sass-lang.com/documentation/syntax#scss                ]"
-          },
-          {
-            "value": "sass",
-            "label": "Sass   [ https://sass-lang.com/documentation/syntax#the-indented-syntax ]"
-          },
-          {
-            "value": "less",
-            "label": "Less   [ http://lesscss.org                                             ]"
-          },
-          {
-            "value": "styl",
-            "label": "Stylus [ http://stylus-lang.com                                         ]"
-          }
-        ]
-      },
       "x-user-analytics": 5
     },
     "skipTests": {

--- a/packages/schematics/angular/ng-new/schema.json
+++ b/packages/schematics/angular/ng-new/schema.json
@@ -58,10 +58,7 @@
               "type": "string"
             }
           },
-          "required": [
-            "name",
-            "email"
-          ]
+          "required": ["name", "email"]
         }
       ],
       "default": true
@@ -102,8 +99,6 @@
     "routing": {
       "type": "boolean",
       "description": "When true, generates a routing module for the initial project.",
-      "default": false,
-      "x-prompt": "Would you like to add Angular routing?",
       "x-user-analytics": 17
     },
     "prefix": {
@@ -118,22 +113,28 @@
       "description": "The file extension or preprocessor to use for style files.",
       "type": "string",
       "default": "css",
-      "enum": [
-        "css",
-        "scss",
-        "sass",
-        "less",
-        "styl"
-      ],
+      "enum": ["css", "scss", "sass", "less", "styl"],
       "x-prompt": {
         "message": "Which stylesheet format would you like to use?",
         "type": "list",
         "items": [
-          { "value": "css",  "label": "CSS" },
-          { "value": "scss", "label": "SCSS   [ https://sass-lang.com/documentation/syntax#scss                ]" },
-          { "value": "sass", "label": "Sass   [ https://sass-lang.com/documentation/syntax#the-indented-syntax ]" },
-          { "value": "less", "label": "Less   [ http://lesscss.org                                             ]" },
-          { "value": "styl", "label": "Stylus [ http://stylus-lang.com                                         ]" }
+          { "value": "css", "label": "CSS" },
+          {
+            "value": "scss",
+            "label": "SCSS   [ https://sass-lang.com/documentation/syntax#scss                ]"
+          },
+          {
+            "value": "sass",
+            "label": "Sass   [ https://sass-lang.com/documentation/syntax#the-indented-syntax ]"
+          },
+          {
+            "value": "less",
+            "label": "Less   [ http://lesscss.org                                             ]"
+          },
+          {
+            "value": "styl",
+            "label": "Stylus [ http://stylus-lang.com                                         ]"
+          }
         ]
       },
       "x-user-analytics": 5
@@ -157,8 +158,5 @@
       "x-user-analytics": 14
     }
   },
-  "required": [
-    "name",
-    "version"
-  ]
+  "required": ["name", "version"]
 }


### PR DESCRIPTION
closes #13383 