### PR TITLE
fix(@angular-devkit/build-angular): various breakpoints issues

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/utils.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/utils.ts
@@ -93,6 +93,11 @@ export function getSourceMapDevTool(
   return new SourceMapDevToolPlugin({
     filename: inlineSourceMap ? undefined : '[file].map',
     include,
+    // We want to set sourceRoot to  `webpack:///` for non
+    // inline sourcemaps as otherwise paths to sourcemaps will be broken in browser
+    // `webpack:///` is needed for Visual Studio breakpoints to work properly as currently
+    // there is no way to set the 'webRoot'
+    sourceRoot: inlineSourceMap ? '' : 'webpack:///',
     moduleFilenameTemplate: '[resource-path]',
     append: hiddenSourceMap ? false : undefined,
   });


### PR DESCRIPTION
With this change we address 2 main issues related to unbound breakpoints:
1) in VS code when having a `baseHref` set.
2) Visual Studio when using an SPA inside a ASP.NET project

For the latter, it seems that there is no way to set a `webRoot`. However, `webpack:///` seems to be handled internally and will be mapped to the `SpaRoot` ie `ClientApp` folder.

Fixes: #15211