### PR TITLE
fix(@angular-devkit/build-angular): never use component css sourcemap…

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/styles.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/styles.ts
@@ -193,7 +193,13 @@ export function getStylesConfig(wco: WebpackConfigOptions) {
         options: {
           ident: 'embedded',
           plugins: postcssPluginCreator,
-          sourceMap: cssSourceMap && !buildOptions.sourceMap.hidden ? 'inline' : false,
+          sourceMap: cssSourceMap
+            // Never use component css sourcemap when style optimizations are on.
+            // It will just increase bundle size without offering good debug experience.
+            && !buildOptions.optimization.styles
+            // Inline all sourcemap types except hidden ones, which are the same as no sourcemaps
+            // for component css.
+            && !buildOptions.sourceMap.hidden ? 'inline' : false,
         },
       },
       ...(use as webpack.Loader[]),


### PR DESCRIPTION
… when optimizations are on.

It will just increase bundle size without offering good debug experience.