### PR TITLE
test: fix failing prod build snapshots

### DIFF
--- a/tests/legacy-cli/e2e/tests/build/prod-build.ts
+++ b/tests/legacy-cli/e2e/tests/build/prod-build.ts
@@ -33,8 +33,8 @@ export default async function () {
   const argv = getGlobalVariable('argv');
   const ivyProject = argv['ivy'];
   const bootstrapRegExp = ivyProject
-    ? /bootstrapModule\([a-zA-Z]+\)\./
-    : /bootstrapModuleFactory\([a-zA-Z]+\)\./;
+    ? /bootstrapModule\([$]?[a-zA-Z]+\)\./
+    : /bootstrapModuleFactory\([$]?[a-zA-Z]+\)\./;
 
   await ng('build', '--prod');
   await expectFileToExist(join(process.cwd(), 'dist'));


### PR DESCRIPTION
The output of a prod build contains now:
```
bootstrapModuleFactory($l).catch(e=>console.error(e))}
```

Which is not being matched with the previously defined RegExp