### PR TITLE
refactor(@schematics/angular): remove hardcoded default values

### DIFF
--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -306,11 +306,6 @@ export default function (options: ApplicationOptions): Rule {
       throw new SchematicsException(`Invalid options, "name" is required.`);
     }
     validateProjectName(options.name);
-    options.prefix = options.prefix || 'app';
-    // This line and the one above shouldn't be needed, but at the moment they are.
-    // This is because the default value defined in the schema.json file is not
-    // correctly set when this schematic is run from another schematic.
-    options.style = options.style || Style.Css;
     const appRootSelector = `${options.prefix}-root`;
     const componentOptions: Partial<ComponentOptions> = !options.minimal ?
       {

--- a/packages/schematics/angular/library/index.ts
+++ b/packages/schematics/angular/library/index.ts
@@ -139,7 +139,7 @@ function addAppToWorkspaceFile(
       root: projectRoot,
       sourceRoot: `${projectRoot}/src`,
       projectType: ProjectType.Library,
-      prefix: options.prefix || 'lib',
+      prefix: options.prefix,
       targets: {
         build: {
           builder: Builders.NgPackagr,
@@ -178,7 +178,7 @@ export default function (options: LibraryOptions): Rule {
     if (!options.name) {
       throw new SchematicsException(`Invalid options, "name" is required.`);
     }
-    const prefix = options.prefix || 'lib';
+    const prefix = options.prefix;
 
     validateProjectName(options.name);
 


### PR DESCRIPTION
Defaults in code are no longer required as the root issue was solved by https://github.com/angular/angular-cli/pull/15222