### PR TITLE
feat(@schematics/angular): add generator for interceptor

### DIFF
--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -169,7 +169,7 @@ function addAppToWorkspaceFile(options: ApplicationOptions, appDir: string): Rul
   }
 
   if (options.skipTests || options.minimal) {
-    ['class', 'component', 'directive', 'guard', 'module', 'pipe', 'service'].forEach((type) => {
+    ['class', 'component', 'directive', 'guard', 'interceptor', 'module', 'pipe', 'service'].forEach((type) => {
       if (!(`@schematics/angular:${type}` in schematics)) {
         schematics[`@schematics/angular:${type}`] = {};
       }

--- a/packages/schematics/angular/collection.json
+++ b/packages/schematics/angular/collection.json
@@ -60,6 +60,11 @@
       "description": "Create a guard.",
       "schema": "./guard/schema.json"
     },
+    "interceptor": {
+      "factory": "./interceptor",
+      "description": "Create an interceptor.",
+      "schema": "./interceptor/schema.json"
+    },
     "interface": {
       "aliases": [ "i" ],
       "factory": "./interface",

--- a/packages/schematics/angular/interceptor/files/__name@dasherize@if-flat__/__name@dasherize__.interceptor.spec.ts.template
+++ b/packages/schematics/angular/interceptor/files/__name@dasherize@if-flat__/__name@dasherize__.interceptor.spec.ts.template
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { <%= classify(name) %>Interceptor } from './<%= dasherize(name) %>.interceptor';
+
+describe('<%= classify(name) %>Interceptor', () => {
+  beforeEach(() => TestBed.configureTestingModule({
+    providers: [
+      <%= classify(name) %>Interceptor
+      ]
+  }));
+
+  it('should be created', () => {
+    const interceptor: <%= classify(name) %>Interceptor = TestBed.inject(<%= classify(name) %>Interceptor);
+    expect(interceptor).toBeTruthy();
+  });
+});

--- a/packages/schematics/angular/interceptor/files/__name@dasherize@if-flat__/__name@dasherize__.interceptor.ts.template
+++ b/packages/schematics/angular/interceptor/files/__name@dasherize@if-flat__/__name@dasherize__.interceptor.ts.template
@@ -1,0 +1,18 @@
+import { Injectable } from '@angular/core';
+import {
+  HttpRequest,
+  HttpHandler,
+  HttpEvent,
+  HttpInterceptor
+} from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+@Injectable()
+export class <%= classify(name) %>Interceptor implements HttpInterceptor {
+
+  constructor() {}
+
+  intercept(request: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
+    return next.handle(request);
+  }
+}

--- a/packages/schematics/angular/interceptor/index.ts
+++ b/packages/schematics/angular/interceptor/index.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { strings } from '@angular-devkit/core';
+import {
+  Rule,
+  Tree,
+  apply,
+  applyTemplates,
+  chain,
+  filter,
+  mergeWith,
+  move,
+  noop,
+  url,
+} from '@angular-devkit/schematics';
+import { applyLintFix } from '../utility/lint-fix';
+import { parseName } from '../utility/parse-name';
+import { createDefaultPath } from '../utility/workspace';
+import { Schema as InterceptorOptions } from './schema';
+
+export default function (options: InterceptorOptions): Rule {
+  return async (host: Tree) => {
+    if (options.path === undefined) {
+      options.path = await createDefaultPath(host, options.project as string);
+    }
+
+    const parsedPath = parseName(options.path, options.name);
+    options.name = parsedPath.name;
+    options.path = parsedPath.path;
+
+    const templateSource = apply(url('./files'), [
+      options.skipTests ? filter(path => !path.endsWith('.spec.ts.template')) : noop(),
+      applyTemplates({
+        ...strings,
+        'if-flat': (s: string) => options.flat ? '' : s,
+        ...options,
+      }),
+      move(parsedPath.path),
+    ]);
+
+    return chain([
+      mergeWith(templateSource),
+      options.lintFix ? applyLintFix(options.path) : noop(),
+    ]);
+  };
+}

--- a/packages/schematics/angular/interceptor/index_spec.ts
+++ b/packages/schematics/angular/interceptor/index_spec.ts
@@ -1,0 +1,71 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';
+import { Schema as ApplicationOptions } from '../application/schema';
+import { Schema as WorkspaceOptions } from '../workspace/schema';
+import { Schema as ServiceOptions } from './schema';
+
+describe('Interceptor Schematic', () => {
+  const schematicRunner = new SchematicTestRunner(
+    '@schematics/angular',
+    require.resolve('../collection.json'),
+  );
+  const defaultOptions: ServiceOptions = {
+    name: 'foo',
+    flat: false,
+    project: 'bar',
+  };
+
+  const workspaceOptions: WorkspaceOptions = {
+    name: 'workspace',
+    newProjectRoot: 'projects',
+    version: '6.0.0',
+  };
+
+  const appOptions: ApplicationOptions = {
+    name: 'bar',
+    inlineStyle: false,
+    inlineTemplate: false,
+    routing: false,
+    skipPackageJson: false,
+  };
+  let appTree: UnitTestTree;
+  beforeEach(async () => {
+    appTree = schematicRunner.runSchematic('workspace', workspaceOptions);
+    appTree = await schematicRunner.runSchematicAsync('application', appOptions, appTree).toPromise();
+  });
+
+  it('should create an interceptor', async () => {
+    const options = { ...defaultOptions };
+
+    const tree = await schematicRunner.runSchematicAsync('interceptor', options, appTree)
+      .toPromise();
+    const files = tree.files;
+    expect(files).toContain('/projects/bar/src/app/foo/foo.interceptor.spec.ts');
+    expect(files).toContain('/projects/bar/src/app/foo/foo.interceptor.ts');
+  });
+
+  it('should respect the skipTests flag', async () => {
+    const options = { ...defaultOptions, skipTests: true };
+
+    const tree = await schematicRunner.runSchematicAsync('interceptor', options, appTree)
+      .toPromise();
+    const files = tree.files;
+    expect(files).toContain('/projects/bar/src/app/foo/foo.interceptor.ts');
+    expect(files).not.toContain('/projects/bar/src/app/foo/foo.interceptor.spec.ts');
+  });
+
+  it('should respect the sourceRoot value', async () => {
+    const config = JSON.parse(appTree.readContent('/angular.json'));
+    config.projects.bar.sourceRoot = 'projects/bar/custom';
+    appTree.overwrite('/angular.json', JSON.stringify(config, null, 2));
+    appTree = await schematicRunner.runSchematicAsync('interceptor', defaultOptions, appTree)
+      .toPromise();
+    expect(appTree.files).toContain('/projects/bar/custom/app/foo/foo.interceptor.ts');
+  });
+});

--- a/packages/schematics/angular/interceptor/schema.json
+++ b/packages/schematics/angular/interceptor/schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "id": "SchematicsAngularInterceptor",
+  "title": "Angular Interceptor Options Schema",
+  "type": "object",
+  "description": "Creates a new, generic interceptor definition in the given or default project.",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "The name of the interceptor.",
+      "$default": {
+        "$source": "argv",
+        "index": 0
+      },
+      "x-prompt": "What name would you like to use for the interceptor?"
+    },
+    "path": {
+      "type": "string",
+      "format": "path",
+      "description": "The path at which to create the interceptor, relative to the workspace root.",
+      "visible": false
+    },
+    "project": {
+      "type": "string",
+      "description": "The name of the project.",
+      "$default": {
+        "$source": "projectName"
+      }
+    },
+    "flat": {
+      "type": "boolean",
+      "default": true,
+      "description": "When true (the default), creates files at the top level of the project."
+    },
+    "skipTests": {
+      "type": "boolean",
+      "description": "When true, does not create \"spec.ts\" test files for the new interceptor.",
+      "default": false,
+      "x-user-analytics": 12
+    },
+    "lintFix": {
+      "type": "boolean",
+      "default": false,
+      "description": "When true, applies lint fixes after generating the interceptor.",
+      "x-user-analytics": 15
+    }
+  },
+  "required": ["name"]
+}

--- a/tests/legacy-cli/e2e/tests/generate/interceptor/interceptor-basic.ts
+++ b/tests/legacy-cli/e2e/tests/generate/interceptor/interceptor-basic.ts
@@ -1,0 +1,17 @@
+import {join} from 'path';
+import {ng} from '../../../utils/process';
+import {expectFileToExist} from '../../../utils/fs';
+
+
+export default function() {
+  // Does not create a sub directory.
+  const interceptorDir = join('src', 'app');
+
+  return ng('generate', 'interceptor', 'test-interceptor')
+    .then(() => expectFileToExist(interceptorDir))
+    .then(() => expectFileToExist(join(interceptorDir, 'test-interceptor.interceptor.ts')))
+    .then(() => expectFileToExist(join(interceptorDir, 'test-interceptor.interceptor.spec.ts')))
+
+    // Try to run the unit tests.
+    .then(() => ng('test', '--watch=false'));
+}


### PR DESCRIPTION
It is now possible to generate interceptors using the angular-cli (see #6937):

`$ ng g interceptor(ic) test`

Result:
```
CREATE src/app/test.interceptor.spec.ts (417 bytes)
CREATE src/app/test.interceptor.ts (419 bytes)
```

Is master the correct one to merge into? The documentation says devkit:master but there's no such branch. devkit is too far behind I guess.