### PR TITLE
fix(@angular-devkit/build-angular): consider local decl in angular co…

### DIFF
--- a/packages/angular_devkit/build_optimizer/src/transforms/scrub-file.ts
+++ b/packages/angular_devkit/build_optimizer/src/transforms/scrub-file.ts
@@ -93,7 +93,7 @@ export function expect<T extends ts.Node>(node: ts.Node, kind: ts.SyntaxKind): T
 }
 
 function findAngularMetadata(node: ts.Node, isAngularCoreFile: boolean): ts.Node[] {
-  const specs: ts.Node[] = [];
+  let specs: ts.Node[] = [];
   // Find all specifiers from imports of `@angular/core`.
   ts.forEachChild(node, (child) => {
     if (child.kind === ts.SyntaxKind.ImportDeclaration) {
@@ -103,6 +103,13 @@ function findAngularMetadata(node: ts.Node, isAngularCoreFile: boolean): ts.Node
       }
     }
   });
+
+  // If the current module is a Angular core file, we also consider all declarations in it to
+  // potentially be Angular metadata.
+  if (isAngularCoreFile) {
+    const localDecl = findAllDeclarations(node);
+    specs = specs.concat(localDecl);
+  }
 
   return specs;
 }


### PR DESCRIPTION
…re files to be metadata too

Followup to https://github.com/angular/angular-cli/pull/15239, fixes a 6kb size regression in new apps, potentially more in larger apps.

Local declarations inside `@angular/core` files should also be considered metadata and scrubbed.