### PR TITLE
fix(@angular-devkit/build-angular): avoid defer attribute for Safari nomodule polyfill

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/index-file/augment-index-html.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/index-file/augment-index-html.ts
@@ -150,7 +150,10 @@ export async function augmentIndexHtml(params: AugmentIndexHtmlOptions): Promise
       const isModuleType = moduleFiles.some(scriptPredictor);
 
       if (isNoModuleType && !isModuleType) {
-        attrs.push({ name: 'nomodule', value: null }, { name: 'defer', value: null });
+        attrs.push({ name: 'nomodule', value: null });
+        if (!script.startsWith('polyfills-nomodule-es5')) {
+          attrs.push({ name: 'defer', value: null });
+        }
       } else if (isModuleType && !isNoModuleType) {
         attrs.push({ name: 'type', value: 'module' });
       } else {

--- a/tests/legacy-cli/e2e/tests/misc/support-safari-10.1.ts
+++ b/tests/legacy-cli/e2e/tests/misc/support-safari-10.1.ts
@@ -27,7 +27,7 @@ export default async function () {
   await ng('build');
   await expectFileToExist('dist/test-project/polyfills-nomodule-es5.js');
   await expectFileToMatch('dist/test-project/index.html', oneLineTrim`
-    <script src="polyfills-nomodule-es5.js" nomodule defer></script>
+    <script src="polyfills-nomodule-es5.js" nomodule></script>
     <script src="runtime-es2015.js" type="module"></script>
     <script src="polyfills-es2015.js" type="module"></script>
     <script src="runtime-es5.js" nomodule defer></script>


### PR DESCRIPTION
The polyfill will not function properly if the defer attribute is present.