### PR TITLE
fix(@schematics/angular): add `manifest.webmanifest` to the list of p…

### DIFF
--- a/packages/schematics/angular/service-worker/files/ngsw-config.json.template
+++ b/packages/schematics/angular/service-worker/files/ngsw-config.json.template
@@ -9,6 +9,7 @@
         "files": [
           "/favicon.ico",
           "/index.html",
+          "/manifest.webmanifest",
           "/*.css",
           "/*.js"
         ]


### PR DESCRIPTION
In the latest versions of Chrome Version 76.0.3809.100, the `manifest.webmanifest` is being requested when offline and is causing a 504 error.

https://github.com/angular/angular-cli/issues/15259#issuecomment-519047384