### PR TITLE
feat(@ngtools/webpack): add support for raw-loader 2 and 3

### DIFF
--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -37,7 +37,7 @@
     "postcss": "7.0.17",
     "postcss-import": "12.0.1",
     "postcss-loader": "3.0.0",
-    "raw-loader": "1.0.0",
+    "raw-loader": "3.1.0",
     "rxjs": "6.4.0",
     "sass": "1.22.9",
     "sass-loader": "7.1.0",

--- a/packages/ngtools/webpack/src/resource_loader.ts
+++ b/packages/ngtools/webpack/src/resource_loader.ts
@@ -159,19 +159,18 @@ export class WebpackResourceLoader {
     });
   }
 
-  private _evaluate({ outputName, source }: CompilationOutput): Promise<string> {
-    try {
+  private async _evaluate({ outputName, source }: CompilationOutput): Promise<string> {
       // Evaluate code
       const evaluatedSource = vm.runInNewContext(source, undefined, { filename: outputName });
-
-      if (typeof evaluatedSource == 'string') {
-        return Promise.resolve(evaluatedSource);
+      if (typeof evaluatedSource === 'object' && typeof evaluatedSource.default === 'string') {
+        return evaluatedSource.default;
       }
 
-      return Promise.reject('The loader "' + outputName + '" didn\'t return a string.');
-    } catch (e) {
-      return Promise.reject(e);
-    }
+      if (typeof evaluatedSource === 'string') {
+        return evaluatedSource;
+      }
+
+      throw new Error(`The loader "${outputName}" didn't return a string.`);
   }
 
   get(filePath: string): Promise<string> {

--- a/packages/ngtools/webpack/src/transformers/replace_resources_spec.ts
+++ b/packages/ngtools/webpack/src/transformers/replace_resources_spec.ts
@@ -20,6 +20,7 @@ function transform(input: string, shouldTransform = true, directTemplateLoading 
 
 // tslint:disable-next-line:no-big-function
 describe('@ngtools/webpack transformers', () => {
+  // tslint:disable:max-line-length
   // tslint:disable-next-line:no-big-function
   describe('find_resources', () => {
     it('should replace resources', () => {
@@ -46,8 +47,8 @@ describe('@ngtools/webpack transformers', () => {
         AppComponent = tslib_1.__decorate([
             Component({
                 selector: 'app-root',
-                template: require("!raw-loader!./app.component.html"),
-                styles: [require("./app.component.css"), require("./app.component.2.css")]
+                template: tslib_1.__importDefault(require("!raw-loader!./app.component.html")).default,
+                styles: [tslib_1.__importDefault(require("./app.component.css")).default, tslib_1.__importDefault(require("./app.component.2.css")).default]
             })
         ], AppComponent);
         export { AppComponent };
@@ -64,7 +65,10 @@ describe('@ngtools/webpack transformers', () => {
           @Component({
             selector: 'app-root',
             templateUrl: './app.component.html',
-            styleUrls: ['./app.component.css', './app.component.2.css']
+            styleUrls: [
+              './app.component.css',
+              './app.component.2.css'
+            ]
           })
           export class AppComponent {
             title = 'app';
@@ -81,8 +85,8 @@ describe('@ngtools/webpack transformers', () => {
           AppComponent = tslib_1.__decorate([
               Component({
                   selector: 'app-root',
-                  template: require("./app.component.html"),
-                  styles: [require("./app.component.css"), require("./app.component.2.css")]
+                  template: tslib_1.__importDefault(require("./app.component.html")).default,
+                  styles: [tslib_1.__importDefault(require("./app.component.css")).default, tslib_1.__importDefault(require("./app.component.2.css")).default]
               })
           ], AppComponent);
           export { AppComponent };
@@ -116,7 +120,7 @@ describe('@ngtools/webpack transformers', () => {
         AppComponent = tslib_1.__decorate([
             Component({
                 selector: 'app-root',
-                template: require("!raw-loader!./app.component.svg")
+                template: tslib_1.__importDefault(require("!raw-loader!./app.component.svg")).default
             })
         ], AppComponent);
         export { AppComponent };
@@ -151,8 +155,8 @@ describe('@ngtools/webpack transformers', () => {
         AppComponent = tslib_1.__decorate([
             Component({
                 selector: 'app-root',
-                template: require("!raw-loader!./app.component.html"),
-                styles: ["a { color: red }", require("./app.component.css")]
+                template: tslib_1.__importDefault(require("!raw-loader!./app.component.html")).default,
+                styles: ["a { color: red }", tslib_1.__importDefault(require("./app.component.css")).default]
             })
         ], AppComponent);
         export { AppComponent };
@@ -186,8 +190,8 @@ describe('@ngtools/webpack transformers', () => {
         AppComponent = tslib_1.__decorate([
             Component({
                 selector: 'app-root',
-                template: require("!raw-loader!./app.component.html"),
-                styles: [require("./app.component.css"), require("./app.component.2.css")]
+                template: tslib_1.__importDefault(require("!raw-loader!./app.component.html")).default,
+                styles: [tslib_1.__importDefault(require("./app.component.css")).default, tslib_1.__importDefault(require("./app.component.2.css")).default]
             })
         ], AppComponent);
         export { AppComponent };
@@ -221,8 +225,8 @@ describe('@ngtools/webpack transformers', () => {
         AppComponent = tslib_1.__decorate([
           NgComponent({
                 selector: 'app-root',
-                template: require("!raw-loader!./app.component.html"),
-                styles: [require("./app.component.css"), require("./app.component.2.css")]
+                template: tslib_1.__importDefault(require("!raw-loader!./app.component.html")).default,
+                styles: [tslib_1.__importDefault(require("./app.component.css")).default, tslib_1.__importDefault(require("./app.component.2.css")).default]
             })
         ], AppComponent);
         export { AppComponent };
@@ -260,8 +264,8 @@ describe('@ngtools/webpack transformers', () => {
         AppComponent = tslib_1.__decorate([
           ng.Component({
                 selector: 'app-root',
-                template: require("!raw-loader!./app.component.html"),
-                styles: [require("./app.component.css"), require("./app.component.2.css")]
+                template: tslib_1.__importDefault(require("!raw-loader!./app.component.html")).default,
+                styles: [tslib_1.__importDefault(require("./app.component.css")).default, tslib_1.__importDefault(require("./app.component.2.css")).default]
             })
         ], AppComponent);
         export { AppComponent };
@@ -308,8 +312,8 @@ describe('@ngtools/webpack transformers', () => {
         AppComponent = tslib_1.__decorate([
             Component({
                 selector: 'app-root',
-                template: require("!raw-loader!./app.component.html"),
-                styles: [require("./app.component.css")]
+                template: tslib_1.__importDefault(require("!raw-loader!./app.component.html")).default,
+                styles: [tslib_1.__importDefault(require("./app.component.css")).default]
             })
         ], AppComponent);
         export { AppComponent };

--- a/yarn.lock
+++ b/yarn.lock
@@ -9141,13 +9141,13 @@ raw-body@2.4.0:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-raw-loader@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/raw-loader/-/raw-loader-1.0.0.tgz#3f9889e73dadbda9a424bce79809b4133ad46405"
-  integrity sha512-Uqy5AqELpytJTRxYT4fhltcKPj0TyaEpzJDcGz7DFJi+pQOOi3GjR/DOdxTkTsF+NzhnldIoG6TORaBlInUuqA==
+raw-loader@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/raw-loader/-/raw-loader-3.1.0.tgz#5e9d399a5a222cc0de18f42c3bc5e49677532b3f"
+  integrity sha512-lzUVMuJ06HF4rYveaz9Tv0WRlUMxJ0Y1hgSkkgg+50iEdaI0TthyEDe08KIHb0XsF6rn8WYTqPCaGTZg3sX+qA==
   dependencies:
     loader-utils "^1.1.0"
-    schema-utils "^1.0.0"
+    schema-utils "^2.0.1"
 
 rc@^1.2.7, rc@^1.2.8:
   version "1.2.8"


### PR DESCRIPTION

With this change we add support for raw-loader 1, 2 and 3.

In version 2 raw-loader released a breaking change https://github.com/webpack-contrib/raw-loader/releases/tag/v2.0.0 and now they use ES Module export instead of CommonJS.

Closes #15286 and closes #15149