### PR TITLE
fix(@schematics/angular): default interface for guard

### DIFF
--- a/packages/schematics/angular/guard/index.ts
+++ b/packages/schematics/angular/guard/index.ts
@@ -22,7 +22,7 @@ import {
 import { applyLintFix } from '../utility/lint-fix';
 import { parseName } from '../utility/parse-name';
 import { createDefaultPath } from '../utility/workspace';
-import { Schema as GuardOptions } from './schema';
+import { Implement as GuardInterface, Schema as GuardOptions } from './schema';
 
 
 export default function (options: GuardOptions): Rule {
@@ -31,19 +31,15 @@ export default function (options: GuardOptions): Rule {
       options.path = await createDefaultPath(host, options.project as string);
     }
 
-    if (options.implements === undefined) {
-      options.implements = [];
+    if (!options.implements) {
+      throw new SchematicsException('Option "implements" is required.');
     }
 
-    let implementations = '';
-    let implementationImports = '';
-    if (options.implements.length > 0) {
-      implementations = options.implements.join(', ');
-      implementationImports = `${implementations}, `;
-      // As long as we aren't in IE... ;)
-      if (options.implements.includes('CanLoad')) {
-        implementationImports = `${implementationImports}Route, UrlSegment, `;
-      }
+    const implementations = options.implements.join(', ');
+    let implementationImports = `${implementations}, `;
+    // As long as we aren't in IE... ;)
+    if (options.implements.includes(GuardInterface.CanLoad)) {
+      implementationImports = `${implementationImports}Route, UrlSegment, `;
     }
 
     const parsedPath = parseName(options.path, options.name);

--- a/packages/schematics/angular/guard/index_spec.ts
+++ b/packages/schematics/angular/guard/index_spec.ts
@@ -105,4 +105,17 @@ describe('Guard Schematic', () => {
       expect(fileString).toContain(functionName);
     });
   });
+
+  it('should use CanActivate if no implements value', async () => {
+    const options = { ...defaultOptions, implements: undefined };
+    const tree = await schematicRunner.runSchematicAsync('guard', options, appTree)
+      .toPromise();
+    const fileString = tree.readContent('/projects/bar/src/app/foo.guard.ts');
+    expect(fileString).toContain('CanActivate');
+    expect(fileString).toContain('canActivate');
+    expect(fileString).not.toContain('CanActivateChild');
+    expect(fileString).not.toContain('canActivateChild');
+    expect(fileString).not.toContain('CanLoad');
+    expect(fileString).not.toContain('canLoad');
+  });
 });

--- a/packages/schematics/angular/guard/schema.json
+++ b/packages/schematics/angular/guard/schema.json
@@ -55,8 +55,16 @@
       "description": "Specifies which interfaces to implement.",
       "uniqueItems": true,
       "items": {
-        "type": "string"
+        "enum": [
+          "CanActivate",
+          "CanActivateChild",
+          "CanLoad"
+        ]
       },
+      "default": [
+        "CanActivate"
+      ],
+      "minItems": 1,
       "x-prompt": {
         "message": "Which interfaces would you like to implement?",
         "type": "list",


### PR DESCRIPTION
Currently, if the user hits `<Enter>` before selecting an interface to implement, the CLI will generate a broken guard that implements no interface. With this commit, the CLI generates a `CanActivate` guard by default.