### PR TITLE
Ivy workspaces

### DIFF
--- a/docs/design/analytics.md
+++ b/docs/design/analytics.md
@@ -48,7 +48,6 @@ Note: There's a limit of 20 custom dimensions.
 | 5 | `Flag: --style` | `string` |
 | 6 | `--collection` | `string` |
 | 7 | `--buildEventLog` | `boolean` |
-| 8 | `Flag: --enableIvy` | `boolean` |
 | 9 | `Flag: --inlineStyle` | `boolean` |
 | 10 | `Flag: --inlineTemplate` | `boolean` |
 | 11 | `Flag: --viewEncapsulation` | `string` |

--- a/packages/schematics/angular/application/files/tsconfig.app.json.template
+++ b/packages/schematics/angular/application/files/tsconfig.app.json.template
@@ -7,18 +7,8 @@
   "files": [
     "src/main.ts",
     "src/polyfills.ts"
-  ],<% if (!enableIvy) { %>
-  "include": [
-    "src/**/*.ts"
   ],
-  "exclude": [
-    "src/test.ts",
-    "src/**/*.spec.ts"
-  ]<% } %><% if (enableIvy) { %>
   "include": [
     "src/**/*.d.ts"
-  ],
-  "angularCompilerOptions": {
-    "enableIvy": true
-  }<% } %>
+  ]
 }

--- a/packages/schematics/angular/application/files/tsconfig.spec.json.template
+++ b/packages/schematics/angular/application/files/tsconfig.spec.json.template
@@ -14,8 +14,5 @@
   "include": [
     "src/**/*.spec.ts",
     "src/**/*.d.ts"
-  ]<% if (enableIvy) { %>,
-  "angularCompilerOptions": {
-    "enableIvy": true
-  }<% } %>
+  ]
 }

--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -194,7 +194,7 @@ function addAppToWorkspaceFile(options: ApplicationOptions, appDir: string): Rul
           main: `${sourceRoot}/main.ts`,
           polyfills: `${sourceRoot}/polyfills.ts`,
           tsConfig: `${projectRoot}tsconfig.app.json`,
-          aot: !!options.enableIvy,
+          aot: true,
           assets: [
             `${sourceRoot}/favicon.ico`,
             `${sourceRoot}/assets`,

--- a/packages/schematics/angular/application/index_spec.ts
+++ b/packages/schematics/angular/application/index_spec.ts
@@ -213,45 +213,6 @@ describe('Application Schematic', () => {
     ]));
   });
 
-  it('should set AOT option to false for VE projects', async () => {
-    const options = { ...defaultOptions };
-
-    const tree = await schematicRunner.runSchematicAsync('application', options, workspaceTree)
-      .toPromise();
-    const workspace = JSON.parse(tree.readContent('/angular.json'));
-    expect(workspace.projects.foo.architect.build.options.aot).toEqual(false);
-  });
-
-  it('should set AOT option to true for Ivy projects', async () => {
-    const options = { ...defaultOptions, enableIvy: true };
-
-    const tree = await schematicRunner.runSchematicAsync('application', options, workspaceTree)
-      .toPromise();
-    const workspace = JSON.parse(tree.readContent('/angular.json'));
-    expect(workspace.projects.foo.architect.build.options.aot).toEqual(true);
-  });
-
-  it('should set the right files, exclude, include in the tsconfig for VE projects', async () => {
-    const tree = await schematicRunner.runSchematicAsync('application', defaultOptions, workspaceTree)
-      .toPromise();
-    const path = '/projects/foo/tsconfig.app.json';
-    const tsConfig = JSON.parse(tree.readContent(path));
-    expect(tsConfig.files).toEqual(['src/main.ts', 'src/polyfills.ts']);
-    expect(tsConfig.exclude).toEqual(['src/test.ts', 'src/**/*.spec.ts']);
-    expect(tsConfig.include).toEqual(['src/**/*.ts']);
-  });
-
-  it('should set the right files, exclude, include in the tsconfig for Ivy projects', async () => {
-    const options = { ...defaultOptions, enableIvy: true };
-    const tree = await schematicRunner.runSchematicAsync('application', options, workspaceTree)
-      .toPromise();
-    const path = '/projects/foo/tsconfig.app.json';
-    const tsConfig = JSON.parse(tree.readContent(path));
-    expect(tsConfig.files).toEqual(['src/main.ts', 'src/polyfills.ts']);
-    expect(tsConfig.exclude).toBeUndefined();
-    expect(tsConfig.include).toEqual(['src/**/*.d.ts']);
-  });
-
   describe(`update package.json`, () => {
     it(`should add build-angular to devDependencies`, async () => {
       const tree = await schematicRunner.runSchematicAsync('application', defaultOptions, workspaceTree)

--- a/packages/schematics/angular/application/schema.json
+++ b/packages/schematics/angular/application/schema.json
@@ -19,12 +19,6 @@
       },
       "x-prompt": "What name would you like to use for the application?"
     },
-    "enableIvy": {
-      "description": "**EXPERIMENTAL** True to create a new app that uses the Ivy rendering engine.",
-      "type": "boolean",
-      "default": false,
-      "x-user-analytics": 8
-    },
     "inlineStyle": {
       "description": "When true, includes styles inline in the root component.ts file. Only CSS styles can be included inline. Default is false, meaning that an external styles file is created and referenced in the root component.ts file.",
       "type": "boolean",

--- a/packages/schematics/angular/library/files/tsconfig.lib.json.template
+++ b/packages/schematics/angular/library/files/tsconfig.lib.json.template
@@ -15,8 +15,6 @@
     "annotateForClosureCompiler": true,
     "skipTemplateCodegen": true,
     "strictMetadataEmit": true,
-    "fullTemplateTypeCheck": true,
-    "strictInjectionParameters": true,
     "enableResourceInlining": true
   },
   "exclude": [

--- a/packages/schematics/angular/library/files/tsconfig.lib.prod.json.template
+++ b/packages/schematics/angular/library/files/tsconfig.lib.prod.json.template
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.lib.json",
+  "angularCompilerOptions": {
+    "enableIvy": false
+  }
+}

--- a/packages/schematics/angular/library/index.ts
+++ b/packages/schematics/angular/library/index.ts
@@ -124,7 +124,7 @@ function addDependenciesToPackageJson() {
   };
 }
 
-function addAppToWorkspaceFile(
+function addLibToWorkspaceFile(
   options: LibraryOptions,
   projectRoot: string,
   projectName: string,
@@ -146,6 +146,11 @@ function addAppToWorkspaceFile(
           options: {
             tsConfig: `${projectRoot}/tsconfig.lib.json`,
             project: `${projectRoot}/ng-package.json`,
+          },
+          configurations: {
+            production: {
+              tsConfig: `${projectRoot}/tsconfig.lib.prod.json`,
+            },
           },
         },
         test: {
@@ -199,7 +204,6 @@ export default function (options: LibraryOptions): Rule {
     const folderName = `${scopeFolder}${strings.dasherize(options.name)}`;
     const projectRoot = join(normalize(newProjectRoot), folderName);
     const distRoot = `dist/${folderName}`;
-
     const sourceDir = `${projectRoot}/src/lib`;
 
     const templateSource = apply(url('./files'), [
@@ -219,7 +223,7 @@ export default function (options: LibraryOptions): Rule {
 
     return chain([
       mergeWith(templateSource),
-      addAppToWorkspaceFile(options, projectRoot, projectName),
+      addLibToWorkspaceFile(options, projectRoot, projectName),
       options.skipPackageJson ? noop() : addDependenciesToPackageJson(),
       options.skipTsConfig ? noop() : updateTsConfig(packageName, distRoot),
       schematic('module', {

--- a/packages/schematics/angular/library/index_spec.ts
+++ b/packages/schematics/angular/library/index_spec.ts
@@ -49,6 +49,8 @@ describe('Library Schematic', () => {
       '/projects/foo/package.json',
       '/projects/foo/README.md',
       '/projects/foo/tslint.json',
+      '/projects/foo/tsconfig.lib.json',
+      '/projects/foo/tsconfig.lib.prod.json',
       '/projects/foo/src/test.ts',
       '/projects/foo/src/my-index.ts',
       '/projects/foo/src/lib/foo.module.ts',
@@ -132,7 +134,7 @@ describe('Library Schematic', () => {
   });
 
   it('should handle a pascalCasedName', async () => {
-    const options = {...defaultOptions, name: 'pascalCasedName'};
+    const options = { ...defaultOptions, name: 'pascalCasedName' };
     const tree = await schematicRunner.runSchematicAsync('library', options, workspaceTree).toPromise();
     const config = getJsonFileContent(tree, '/angular.json');
     const project = config.projects.pascalCasedName;
@@ -316,5 +318,13 @@ describe('Library Schematic', () => {
     expect(appTsConfig.extends).toEqual('../tsconfig.json');
     const specTsConfig = JSON.parse(tree.readContent('/foo/tsconfig.spec.json'));
     expect(specTsConfig.extends).toEqual('../tsconfig.json');
+  });
+
+  it(`should add 'production' configuration`, async () => {
+    const tree = await schematicRunner.runSchematicAsync('library', defaultOptions, workspaceTree)
+      .toPromise();
+
+    const workspace = JSON.parse(tree.readContent('/angular.json'));
+    expect(workspace.projects.foo.architect.build.configurations.production).toBeDefined();
   });
 });

--- a/packages/schematics/angular/ng-new/index.ts
+++ b/packages/schematics/angular/ng-new/index.ts
@@ -46,7 +46,6 @@ export default function (options: NgNewOptions): Rule {
   const applicationOptions: ApplicationOptions = {
     projectRoot: '',
     name: options.name,
-    enableIvy: options.enableIvy,
     inlineStyle: options.inlineStyle,
     inlineTemplate: options.inlineTemplate,
     prefix: options.prefix,

--- a/packages/schematics/angular/ng-new/schema.json
+++ b/packages/schematics/angular/ng-new/schema.json
@@ -18,11 +18,6 @@
       },
       "x-prompt": "What name would you like to use for the new workspace and initial project?"
     },
-    "enableIvy": {
-      "description": "When true, creates a new app that uses the Ivy rendering engine.",
-      "type": "boolean",
-      "default": false
-    },
     "skipInstall": {
       "description": "When true, does not install dependency packages.",
       "type": "boolean",

--- a/packages/schematics/angular/web-worker/index_spec.ts
+++ b/packages/schematics/angular/web-worker/index_spec.ts
@@ -72,6 +72,18 @@ describe('Web Worker Schematic', () => {
   });
 
   it('should add exclusions to tsconfig.app.json', async () => {
+    const oldTsConfig = {
+      extends: '../../tsconfig.json',
+      include: [
+        'src/**/*.ts',
+      ],
+      exclude: [
+        'src/test.ts',
+        'src/**/*.spec.ts',
+      ],
+    };
+    appTree.overwrite('projects/bar/tsconfig.app.json', JSON.stringify(oldTsConfig, undefined, 2));
+
     const tree = await schematicRunner.runSchematicAsync('web-worker', defaultOptions, appTree)
       .toPromise();
     const { exclude } = JSON.parse(tree.readContent('/projects/bar/tsconfig.app.json'));
@@ -120,7 +132,18 @@ describe('Web Worker Schematic', () => {
     const tsConfigPath = '/projects/bar/src/tsconfig.app.json';
     workspace.projects.bar.architect.build.options.tsConfig = tsConfigPath;
     appTree.overwrite('/angular.json', JSON.stringify(workspace));
-    appTree.rename('projects/bar/tsconfig.app.json', tsConfigPath);
+
+    const oldTsConfig = {
+      extends: '../../../tsconfig.json',
+      include: [
+        '**/*.ts',
+      ],
+      exclude: [
+        'test.ts',
+        '**/*.spec.ts',
+      ],
+    };
+    appTree.create('projects/bar/src/tsconfig.app.json', JSON.stringify(oldTsConfig, undefined, 2));
 
     const tree = await schematicRunner.runSchematicAsync('web-worker', defaultOptions, appTree)
       .toPromise();

--- a/packages/schematics/angular/workspace/files/tsconfig.json.template
+++ b/packages/schematics/angular/workspace/files/tsconfig.json.template
@@ -20,6 +20,7 @@
     ]
   },
   "angularCompilerOptions": {
+    "enableIvy": true,
     "fullTemplateTypeCheck": true,
     "strictInjectionParameters": true
   }

--- a/tests/angular_devkit/build_angular/hello-world-app-ivy/src/tsconfig.app.json
+++ b/tests/angular_devkit/build_angular/hello-world-app-ivy/src/tsconfig.app.json
@@ -10,8 +10,5 @@
   ],
   "include": [
     "**/*.d.ts"
-  ],
-  "angularCompilerOptions": {
-    "enableIvy": true
-  }
+  ]
 }

--- a/tests/angular_devkit/build_angular/hello-world-app-ivy/src/tsconfig.server.json
+++ b/tests/angular_devkit/build_angular/hello-world-app-ivy/src/tsconfig.server.json
@@ -10,7 +10,6 @@
     "main.server.ts"
   ],
   "angularCompilerOptions": {
-    "entryModule": "app/app.server.module#AppServerModule",
-    "enableIvy": true
+    "entryModule": "app/app.server.module#AppServerModule"
   }
 }

--- a/tests/angular_devkit/build_angular/hello-world-app-ivy/src/tsconfig.spec.json
+++ b/tests/angular_devkit/build_angular/hello-world-app-ivy/src/tsconfig.spec.json
@@ -14,8 +14,5 @@
   "include": [
     "**/*.spec.ts",
     "**/*.d.ts"
-  ],
-  "angularCompilerOptions": {
-    "enableIvy": true
-  }
+  ]
 }

--- a/tests/angular_devkit/build_angular/hello-world-app-ivy/tsconfig.json
+++ b/tests/angular_devkit/build_angular/hello-world-app-ivy/tsconfig.json
@@ -17,5 +17,8 @@
       "es2017",
       "dom"
     ]
+  },
+  "angularCompilerOptions": {
+    "enableIvy": true
   }
 }

--- a/tests/angular_devkit/build_angular/hello-world-app-ivy/tsconfig.json
+++ b/tests/angular_devkit/build_angular/hello-world-app-ivy/tsconfig.json
@@ -17,8 +17,5 @@
       "es2017",
       "dom"
     ]
-  },
-  "angularCompilerOptions": {
-    "enableIvy": true
   }
 }

--- a/tests/angular_devkit/build_angular/hello-world-app/tsconfig.json
+++ b/tests/angular_devkit/build_angular/hello-world-app/tsconfig.json
@@ -17,5 +17,8 @@
       "es2017",
       "dom"
     ]
+  },
+  "angularCompilerOptions": {
+    "enableIvy": false
   }
 }

--- a/tests/angular_devkit/build_ng_packagr/ng-packaged-ivy/tsconfig.json
+++ b/tests/angular_devkit/build_ng_packagr/ng-packaged-ivy/tsconfig.json
@@ -16,8 +16,5 @@
       "es2017",
       "dom"
     ]
-  },
-  "angularCompilerOptions": {
-    "enableIvy": true
   }
 }

--- a/tests/angular_devkit/build_ng_packagr/ng-packaged-ivy/tsconfig.json
+++ b/tests/angular_devkit/build_ng_packagr/ng-packaged-ivy/tsconfig.json
@@ -16,5 +16,8 @@
       "es2017",
       "dom"
     ]
+  },
+  "angularCompilerOptions": {
+    "enableIvy": true
   }
 }

--- a/tests/angular_devkit/build_ng_packagr/ng-packaged/tsconfig.json
+++ b/tests/angular_devkit/build_ng_packagr/ng-packaged/tsconfig.json
@@ -16,5 +16,8 @@
       "es2017",
       "dom"
     ]
+  },
+  "angularCompilerOptions": {
+    "enableIvy": false
   }
 }

--- a/tests/legacy-cli/e2e/tests/build/lazy-load-syntax.ts
+++ b/tests/legacy-cli/e2e/tests/build/lazy-load-syntax.ts
@@ -9,11 +9,8 @@ import { getGlobalVariable } from '../../utils/env';
 import { appendToFile, prependToFile, readFile, replaceInFile, writeFile } from '../../utils/fs';
 import { ng } from '../../utils/process';
 import { updateJsonFile } from '../../utils/project';
-import { expectToFail } from '../../utils/utils';
 
 export default async function () {
-  const argv = getGlobalVariable('argv');
-  const ivyProject = argv['ivy'];
   const projectName = 'test-project';
   const appRoutingModulePath = 'src/app/app-routing.module.ts';
 

--- a/tests/legacy-cli/e2e/tests/generate/library/library-consumption.ts
+++ b/tests/legacy-cli/e2e/tests/generate/library/library-consumption.ts
@@ -3,8 +3,6 @@ import { ng } from '../../../utils/process';
 
 export default async function () {
   await ng('generate', 'library', 'my-lib');
-  await ng('build', 'my-lib');
-
   await writeFile('./src/app/app.module.ts', `
       import { BrowserModule } from '@angular/platform-browser';
       import { NgModule } from '@angular/core';
@@ -68,6 +66,18 @@ export default async function () {
       });
     });
   `);
+
+  await runLibraryTests();
+  await runLibraryTests(true);
+}
+
+async function runLibraryTests(prodMode = false): Promise<void> {
+  const args = ['build', 'my-lib'];
+  if (prodMode) {
+    args.push('--prod');
+  }
+
+  await ng(...args);
 
   // Check that the tests succeeds both with named project, unnammed (should test app), and prod.
   await ng('e2e');

--- a/tests/legacy-cli/e2e/tests/ivy/ivy-opt-out.ts
+++ b/tests/legacy-cli/e2e/tests/ivy/ivy-opt-out.ts
@@ -5,19 +5,20 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import { replaceInFile } from '../../utils/fs';
 import { request } from '../../utils/http';
 import { killAllProcesses, ng } from '../../utils/process';
-import { createProject, ngServe } from '../../utils/project';
+import { createProject, ngServe, updateJsonFile } from '../../utils/project';
 
 export default async function() {
   try {
-    await createProject('ivy-project-opt-out', '--enable-ivy');
+    await createProject('ivy-project-opt-out');
     // trigger an Ivy builds to process packages with NGCC
     await ng('e2e', '--prod');
 
     // View Engine (NGC) compilation should work after running NGCC from Webpack
-    await replaceInFile('tsconfig.app.json', '"enableIvy": true', '"enableIvy": false');
+    await updateJsonFile('tsconfig.json', config => {
+      config.angularCompilerOptions.enableIvy = false;
+    });
 
     // verify that VE compilation works during runtime
     await ng('e2e', '--prod');

--- a/tests/legacy-cli/e2e/tests/ivy/ivy.ts
+++ b/tests/legacy-cli/e2e/tests/ivy/ivy.ts
@@ -12,7 +12,7 @@ import { createProject, ngServe } from '../../utils/project';
 
 export default async function() {
   try {
-    await createProject('ivy-project', '--enable-ivy');
+    await createProject('ivy-project');
 
     // Add in a reference to a secondary entry-point to check that ngcc processes it correctly
     await replaceInFile(

--- a/tests/legacy-cli/e2e/tests/ivy/ngcc-es2015-only.ts
+++ b/tests/legacy-cli/e2e/tests/ivy/ngcc-es2015-only.ts
@@ -4,7 +4,7 @@ import { createProject } from '../../utils/project';
 
 export default async function() {
   // Create a new project to avoid polluting node modules for other tests
-  await createProject('ivy-project-ngcc', '--enable-ivy');
+  await createProject('ivy-project-ngcc');
 
   const { stderr, stdout } = await ng('build', '--prod');
 

--- a/tests/legacy-cli/e2e/utils/project.ts
+++ b/tests/legacy-cli/e2e/utils/project.ts
@@ -33,16 +33,12 @@ export function ngServe(...args: string[]) {
 
 
 export async function createProject(name: string, ...args: string[]) {
-  const argv: string[] = getGlobalVariable('argv');
   const extraArgs = [];
-
-  if (argv['ivy']) {
-    extraArgs.push('--enableIvy');
-  }
 
   process.chdir(getGlobalVariable('tmp-root'));
   await ng('new', name, '--skip-install', ...extraArgs, ...args);
   process.chdir(name);
+
   await prepareProjectForE2e(name);
 }
 


### PR DESCRIPTION
**feat(@schematics/angular): introduce Ivy libraries for development**  

Since `NGCC` is non incremental and in library projects we have the original TS sources
we don't need to build a library using the `VE` and transform it using `NGCC`. Instead we can build the library using `NGTSC` (Ivy) directly
 as this enables faster incremental compilations and a better development experience.

 Libraries now have a `production` configuration, which enabled `VE` compilations. As it is not recommended to publish NGTSC (Ivy)
 built libraries to NPM repositories, since Ivy libraries are not backwards compatible with the legacy View Engine.

**feat(@schematics/angular): remove enableIvy option** 
 With this change we remove the enableIvy option as now we only support generating Ivy application. Users who want to create a VE applications should follow the opt-out guide