### PR TITLE
fix(@angular-devkit/build-angular): serve option merging is being overridden by defaults in schema

### DIFF
--- a/packages/angular_devkit/build_angular/src/dev-server/index.ts
+++ b/packages/angular_devkit/build_angular/src/dev-server/index.ts
@@ -46,7 +46,7 @@ const open = require('open');
 
 export type DevServerBuilderOptions = Schema & json.JsonObject;
 
-export const devServerBuildOverriddenKeys: (keyof DevServerBuilderOptions)[] = [
+const devServerBuildOverriddenKeys: (keyof DevServerBuilderOptions)[] = [
   'watch',
   'optimization',
   'aot',

--- a/packages/angular_devkit/build_angular/src/dev-server/schema.json
+++ b/packages/angular_devkit/build_angular/src/dev-server/schema.json
@@ -44,8 +44,7 @@
     },
     "verbose": {
       "type": "boolean",
-      "description": "Adds more details to output logging.",
-      "default": false
+      "description": "Adds more details to output logging."
     },
     "liveReload": {
       "type": "boolean",
@@ -117,7 +116,6 @@
     },
     "sourceMap": {
       "description": "Output sourcemaps.",
-      "default": true,
       "oneOf": [
         {
           "type": "object",
@@ -153,8 +151,7 @@
     "vendorSourceMap": {
       "type": "boolean",
       "description": "Resolve vendor packages sourcemaps.",
-      "x-deprecated": true,
-      "default": false
+      "x-deprecated": true
     },
     "evalSourceMap": {
       "type": "boolean",

--- a/packages/angular_devkit/build_angular/test/dev-server/works_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/dev-server/works_spec_large.ts
@@ -92,4 +92,14 @@ describe('Dev Server Builder', () => {
     expect(await response.text()).toContain('<title>HelloWorldApp</title>');
   });
 
+  it('should not generate sourcemaps when running prod build', async () => {
+    // Production builds have sourcemaps turned off.
+    const run = await architect.scheduleTarget({ ...target, configuration: 'production' });
+    runs.push(run);
+    const output = await run.result as DevServerBuilderOutput;
+    expect(output.success).toBe(true);
+    const hasSourceMaps = output.emittedFiles && output.emittedFiles.some(f => f.extension === '.map');
+    expect(hasSourceMaps).toBe(false, `Expected emitted files not to contain '.map' files.`);
+  });
+
 });


### PR DESCRIPTION


We have a number of browser options that we allow the dev-server to merge. However, this only happens when such as options are undefined from the dev-server builder. At the moment these option have defaults inside their schema which results in them never being `undefined`, and hence the overridden logic is bypassed.

See: https://github.com/angular/angular-cli/blob/6dd5b186d4dc0ed750cc195d9ebe1aaa282bb640/packages/angular_devkit/build_angular/src/dev-server/index.ts#L49-L63 and https://github.com/angular/angular-cli/blob/6dd5b186d4dc0ed750cc195d9ebe1aaa282bb640/packages/angular_devkit/build_angular/src/dev-server/index.ts#L107-L115

Fixes #15273 and fixes #15064