### PR TITLE
refactor(@angular-devkit/schematics): remove optimize from host-tree

### DIFF
--- a/etc/api/angular_devkit/schematics/src/_golden-api.d.ts
+++ b/etc/api/angular_devkit/schematics/src/_golden-api.d.ts
@@ -316,7 +316,6 @@ export declare class HostTree implements Tree {
     get(path: string): FileEntry | null;
     getDir(path: string): DirEntry;
     merge(other: Tree, strategy?: MergeStrategy): void;
-    optimize(): this;
     overwrite(path: string, content: Buffer | string): void;
     read(path: string): Buffer | null;
     rename(from: string, to: string): void;

--- a/packages/angular_devkit/schematics/src/tree/host-tree.ts
+++ b/packages/angular_devkit/schematics/src/tree/host-tree.ts
@@ -148,12 +148,6 @@ export class HostTree implements Tree {
     return this._record.willRename(path);
   }
 
-  // This can be used by old Schematics library with new Trees in some corner cases.
-  // TODO: remove this for 7.0
-  optimize() {
-    return this;
-  }
-
   branch(): Tree {
     const branchedTree = new HostTree(this._backend);
     branchedTree._record = this._record.clone();


### PR DESCRIPTION
Remove unused optimize method marked for removal in version 7.0