### PR TITLE
feat(@angular-devkit/build-angular): expose webpack-dev-server's allowedHosts option

### DIFF
--- a/packages/angular/cli/lib/config/schema.json
+++ b/packages/angular/cli/lib/config/schema.json
@@ -1119,6 +1119,14 @@
               "type": "string",
               "description": "The URL that the browser client (or live-reload client, if enabled) should use to connect to the development server. Use for a complex dev server setup, such as one with reverse proxies."
             },
+            "allowedHosts": {
+              "type": "array",
+              "description": "Whitelist of hosts that are allowed to access the dev server.",
+              "default": [],
+              "items": {
+                "type": "string"
+              }
+            },
             "servePath": {
               "type": "string",
               "description": "The pathname where the app will be served."

--- a/packages/angular_devkit/build_angular/src/dev-server/index.ts
+++ b/packages/angular_devkit/build_angular/src/dev-server/index.ts
@@ -342,6 +342,7 @@ export function buildServerConfig(
     // inline is always false, because we add live reloading scripts in _addLiveReload when needed
     inline: false,
     public: serverOptions.publicHost,
+    allowedHosts: serverOptions.allowedHosts,
     disableHostCheck: serverOptions.disableHostCheck,
     publicPath: servePath,
     hot: serverOptions.hmr,

--- a/packages/angular_devkit/build_angular/src/dev-server/schema.json
+++ b/packages/angular_devkit/build_angular/src/dev-server/schema.json
@@ -55,6 +55,14 @@
       "type": "string",
       "description": "The URL that the browser client (or live-reload client, if enabled) should use to connect to the development server. Use for a complex dev server setup, such as one with reverse proxies."
     },
+    "allowedHosts": {
+      "type": "array",
+      "description": "Whitelist of hosts that are allowed to access the dev server.",
+      "default": [],
+      "items": {
+        "type": "string"
+      }
+    },
     "servePath": {
       "type": "string",
       "description": "The pathname where the app will be served."

--- a/packages/angular_devkit/build_angular/test/dev-server/allowed-hosts_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/dev-server/allowed-hosts_spec_large.ts
@@ -11,7 +11,7 @@ import { DevServerBuilderOutput } from '../../src/dev-server';
 import { createArchitect, host } from '../utils';
 
 
-describe('Dev Server Builder public host', () => {
+describe('Dev Server Builder allowed host', () => {
   // We have to spoof the host to a non-numeric one because Webpack Dev Server does not
   // check the hosts anymore when requests come from numeric IP addresses.
   const headers = { host: 'spoofy.mcspoofface' };
@@ -31,30 +31,8 @@ describe('Dev Server Builder public host', () => {
     await Promise.all(runs.map(r => r.stop()));
   });
 
-  it('works', async () => {
-    const run = await architect.scheduleTarget(target);
-    runs.push(run);
-    const output = await run.result as DevServerBuilderOutput;
-    expect(output.success).toBe(true);
-    expect(output.baseUrl).toBe('http://localhost:4200/');
-
-    const response = await fetch(`${output.baseUrl}`, { headers });
-    expect(await response.text()).toContain('Invalid Host header');
-  }, 30000);
-
   it('works',  async () => {
-    const run = await architect.scheduleTarget(target, { publicHost: headers.host });
-    runs.push(run);
-    const output = await run.result as DevServerBuilderOutput;
-    expect(output.success).toBe(true);
-    expect(output.baseUrl).toBe('http://localhost:4200/');
-
-    const response = await fetch(`${output.baseUrl}`, { headers });
-    expect(await response.text()).toContain('<title>HelloWorldApp</title>');
-  }, 30000);
-
-  it('works', async () => {
-    const run = await architect.scheduleTarget(target, { disableHostCheck: true });
+    const run = await architect.scheduleTarget(target, { allowedHosts: ['spoofy.mcspoofface'] });
     runs.push(run);
     const output = await run.result as DevServerBuilderOutput;
     expect(output.success).toBe(true);


### PR DESCRIPTION
This PR adds `allowedHosts` as option and passes it along to the dev server. Issue #13656 describes a use-case for this. My use-case is slightly different, as I'm working on a multi-tenant application that derives the tenant from the host name. Having access to `allowedHosts` makes it possible to define multiple hosts pointing to 127.0.0.1 and using them to access the dev server (during development).

A test was added, but I'm not entirely happy with the end result. The `beforeEach` and `afterEach` are duplicate with `public-host_spec_large.ts` (although more spec files have the exact same code). It might also be better to combine it with the public-host spec file, as some test cases in there (no options specified, or with `disableHostCheck`) also apply to the `allowedHosts` option.