### PR TITLE
feat(@schematics/angular): hide universal schematic

### DIFF
--- a/packages/schematics/angular/collection.json
+++ b/packages/schematics/angular/collection.json
@@ -87,7 +87,8 @@
     "universal": {
       "factory": "./universal",
       "description": "Create an Angular universal app.",
-      "schema": "./universal/schema.json"
+      "schema": "./universal/schema.json",
+      "hidden": true
     },
     "appShell": {
       "aliases": [ "app-shell" ],

--- a/tests/legacy-cli/e2e/tests/build/platform-server.ts
+++ b/tests/legacy-cli/e2e/tests/build/platform-server.ts
@@ -1,192 +1,48 @@
 import { normalize } from 'path';
 import { getGlobalVariable } from '../../utils/env';
-import { appendToFile, expectFileToMatch, prependToFile, writeFile } from '../../utils/fs';
+import { expectFileToMatch, writeFile } from '../../utils/fs';
 import { exec, ng, silentNpm } from '../../utils/process';
 import { updateJsonFile } from '../../utils/project';
 import { readNgVersion } from '../../utils/version';
 
-export default function() {
-  let platformServerVersion = readNgVersion();
-
-  if (getGlobalVariable('argv')['ng-snapshots']) {
-    platformServerVersion = 'github:angular/platform-server-builds';
-  }
-
+export default async function () {
   // Skip this test in Angular 2/4.
   if (getGlobalVariable('argv').ng2 || getGlobalVariable('argv').ng4) {
-    return Promise.resolve();
+    return;
   }
 
-  return (
-    Promise.resolve()
-      .then(() =>
-        updateJsonFile('package.json', packageJson => {
-          const dependencies = packageJson['dependencies'];
-          dependencies['@angular/platform-server'] = platformServerVersion;
-        }),
-      )
-      .then(() =>
-        updateJsonFile('angular.json', workspaceJson => {
-          const appArchitect = workspaceJson.projects['test-project'].architect;
-          appArchitect['server'] = {
-            builder: '@angular-devkit/build-angular:server',
-            options: {
-              outputPath: 'dist/test-project-server',
-              main: 'src/main.server.ts',
-              tsConfig: 'tsconfig.server.json',
-            },
-          };
-        }),
-      )
-      .then(() =>
-        writeFile(
-          './tsconfig.server.json',
-          `
-      {
-        "extends": "./tsconfig.app.json",
-        "compilerOptions": {
-          "outDir": "../dist-server",
-          "baseUrl": "./",
-          "module": "commonjs",
-          "types": []
-        },
-        "files": [
-          "src/main.server.ts"
-        ],
-        "include": [
-          "src/**/*.d.ts"
-        ],
-        "angularCompilerOptions": {
-          "entryModule": "src/app/app.server.module#AppServerModule"
-        }
-      }
-    `,
-        ),
-      )
-      .then(() =>
-        writeFile(
-          './src/main.server.ts',
-          `
-      import { enableProdMode } from '@angular/core';
+  await ng('add', '@nguniversal/express-engine', '--client-project', 'test-project');
 
-      import { environment } from './environments/environment';
+  await updateJsonFile('package.json', packageJson => {
+    const dependencies = packageJson['dependencies'];
+    dependencies['@angular/platform-server'] = getGlobalVariable('argv')['ng-snapshots']
+      ? 'github:angular/platform-server-builds'
+      : readNgVersion();
+  });
 
-      if (environment.production) {
-        enableProdMode();
-      }
+  await silentNpm('install');
+  await ng('run', 'test-project:server:production');
+  await expectFileToMatch('dist/server/main.js', /exports.*AppServerModuleNgFactory/);
 
-      export { AppServerModule } from './app/app.server.module';
-    `,
-        ),
-      )
-      .then(() =>
-        writeFile(
-          './src/app/app.server.module.ts',
-          `
-      import { NgModule } from '@angular/core';
-      import { BrowserModule } from '@angular/platform-browser';
-      import { ServerModule } from '@angular/platform-server';
-
-      import { AppModule } from './app.module';
-      import { AppComponent } from './app.component';
-
-      @NgModule({
-        imports: [
-          AppModule,
-          BrowserModule.withServerTransition(\{ appId: 'app' \}),
-          ServerModule,
-        ],
-        bootstrap: [AppComponent],
-      })
-      export class AppServerModule {}
-    `,
-        ),
-      )
-      .then(() => silentNpm('install'))
-      // This part of the test requires a non-aot build, which isn't available anymore.
-      // .then(() => ng('run', 'test-project:server'))
-      // // files were created successfully
-      // .then(() => expectFileToMatch('dist/test-project-server/main.js',
-      //   /exports.*AppServerModule/))
-      // .then(() => writeFile('./index.js', `
-      //   require('zone.js/dist/zone-node');
-      //   require('reflect-metadata');
-      //   const fs = require('fs');
-      //   const \{ AppServerModule \} = require('./dist/test-project-server/main');
-      //   const \{ renderModule \} = require('@angular/platform-server');
-
-      //   renderModule(AppServerModule, \{
-      //     url: '/',
-      //     document: '<app-root></app-root>'
-      //   \}).then(html => \{
-      //     fs.writeFileSync('dist/test-project-server/index.html', html);
-      //   \});
-      // `))
-      // .then(() => exec(normalize('node'), 'index.js'))
-      // .then(() => expectFileToMatch('dist/test-project-server/index.html',
-      //   new RegExp('<h2 _ngcontent-c0="">Here are some links to help you start: </h2>')))
-      .then(() => ng('run', 'test-project:server'))
-      // files were created successfully
-      .then(() =>
-        expectFileToMatch('dist/test-project-server/main.js', /exports.*AppServerModuleNgFactory/),
-      )
-      .then(() =>
-        writeFile(
-          './index.js',
-          `
-      require('zone.js/dist/zone-node');
-      require('reflect-metadata');
+  await writeFile(
+    './index.js',
+    ` require('zone.js/dist/zone-node');
       const fs = require('fs');
-      const \{ AppServerModuleNgFactory \} = require('./dist/test-project-server/main');
-      const \{ renderModuleFactory \} = require('@angular/platform-server');
+      const { AppServerModuleNgFactory } = require('./dist/server/main');
+      const { renderModuleFactory } = require('@angular/platform-server');
 
-      renderModuleFactory(AppServerModuleNgFactory, \{
+      renderModuleFactory(AppServerModuleNgFactory, {
         url: '/',
         document: '<app-root></app-root>'
-      \}).then(html => \{
-        fs.writeFileSync('dist/test-project-server/index.html', html);
-      \});
-    `,
-        ),
-      )
-      .then(() => exec(normalize('node'), 'index.js'))
-      .then(() =>
-        expectFileToMatch(
-          'dist/test-project-server/index.html',
-          /<p.*>Here are some links to help you get started:<\/p>/,
-        ),
-      )
-      .then(() =>
-        expectFileToMatch(
-          './dist/test-project-server/main.js',
-          /require\(["']@angular\/[^"']*["']\)/,
-        ),
-      )
+      }).then(html => {
+        fs.writeFileSync('dist/server/index.html', html);
+      });
+      `,
+  );
 
-      // Check externals.
-      .then(() =>
-        prependToFile(
-          './src/app/app.server.module.ts',
-          `
-      import 'zone.js/dist/zone-node';
-      import 'reflect-metadata';
-    `,
-        ).then(() =>
-          appendToFile(
-            './src/app/app.server.module.ts',
-            `
-      import * as fs from 'fs';
-      import { renderModule } from '@angular/platform-server';
-
-      renderModule(AppModule, \{
-        url: '/',
-        document: '<app-root></app-root>'
-      \}).then(html => \{
-        fs.writeFileSync('dist/test-project-server/index.html', html);
-      \});
-    `,
-          ),
-        ),
-      )
+  await exec(normalize('node'), 'index.js');
+  await expectFileToMatch(
+    'dist/server/index.html',
+    /<p.*>Here are some links to help you get started:<\/p>/,
   );
 }


### PR DESCRIPTION
The universal schematic by itself doesn't get you a working server application.

BREAKING CHANGE: universal schematic is now hidden and cannot be used with the `ng generate` command.

Users who want a working universal application should use `ng add @nguniversal/express-engine` or `ng add @nguniversal/hapi-engine`

Closes: #15166

//cc @vikerman 