### PR TITLE
feat(@angular-devkit/build-angular): collect test coverage from JSX/TSX files

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/test.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/test.ts
@@ -47,7 +47,7 @@ export function getTestConfig(
     }
 
     extraRules.push({
-      test: /\.(js|ts)$/,
+      test: /\.(jsx?|tsx?)$/,
       loader: 'istanbul-instrumenter-loader',
       options: { esModules: true },
       enforce: 'post',


### PR DESCRIPTION
When testing React with Karma in a monorepo managed with [Nx](https://nx.dev/) (built on top of the Angular CLI), I
found that TSX files were not showing up in test coverage reports. This change seems to fix that issue.