### PR TITLE
fix(@schematics/angular): implements items type for guard schematic

### DIFF
--- a/packages/schematics/angular/guard/schema.json
+++ b/packages/schematics/angular/guard/schema.json
@@ -59,7 +59,8 @@
           "CanActivate",
           "CanActivateChild",
           "CanLoad"
-        ]
+        ],
+        "type": "string"
       },
       "default": [
         "CanActivate"

--- a/tests/legacy-cli/e2e/tests/generate/guard/guard-basic.ts
+++ b/tests/legacy-cli/e2e/tests/generate/guard/guard-basic.ts
@@ -1,19 +1,16 @@
 import {join} from 'path';
 import {ng} from '../../../utils/process';
-import {expectFileToExist} from '../../../utils/fs';
+import {expectFileToExist, expectFileToMatch} from '../../../utils/fs';
 
 
-export default function() {
+export default async function() {
   // Does not create a sub directory.
   const guardDir = join('src', 'app');
 
-  return ng('generate', 'guard', 'test-guard')
-    .then(() => expectFileToExist(guardDir))
-    .then(() => expectFileToExist(join(guardDir, 'test-guard.guard.ts')))
-    .then(() => expectFileToExist(join(guardDir, 'test-guard.guard.spec.ts')));
-
-
-    // Try to run the unit tests.
-    // TODO: Enable once schematic is updated for rxjs 6
-    // .then(() => ng('test', '--watch=false'));
+  await ng('generate', 'guard', 'test-guard');
+  await expectFileToExist(guardDir);
+  await expectFileToExist(join(guardDir, 'test-guard.guard.ts'));
+  await expectFileToMatch(join(guardDir, 'test-guard.guard.ts'), /implements CanActivate/);
+  await expectFileToExist(join(guardDir, 'test-guard.guard.spec.ts'));
+  await ng('test', '--watch=false');
 }

--- a/tests/legacy-cli/e2e/tests/generate/guard/guard-implements.ts
+++ b/tests/legacy-cli/e2e/tests/generate/guard/guard-implements.ts
@@ -1,0 +1,16 @@
+import {join} from 'path';
+import {ng} from '../../../utils/process';
+import {expectFileToExist,expectFileToMatch} from '../../../utils/fs';
+
+
+export default async function() {
+  // Does not create a sub directory.
+  const guardDir = join('src', 'app');
+
+  await ng('generate', 'guard', 'load', '--implements=CanLoad');
+  await expectFileToExist(guardDir);
+  await expectFileToExist(join(guardDir, 'load.guard.ts'));
+  await expectFileToMatch(join(guardDir, 'load.guard.ts'), /implements CanLoad/);
+  await expectFileToExist(join(guardDir, 'load.guard.spec.ts'));
+  await ng('test', '--watch=false');
+}


### PR DESCRIPTION
Fixes the type of the items in the `schema.json` for `implements`, as `enum` is not picked up by the CLI.
Also migrates the existing e2e test to `async/await` and adds another one with `implements` to avoid regressions.

My previous PR #15313 fixed an issue in the guard schematic but introduced a regression (sorry!) as:

```json
"items": {
  "enum": [
    "CanActivate",
    "CanActivateChild",
    "CanLoad"
  ]
},
```
is not picked up by the CLI, so `--implements` ends up not being recognized when running:

    ng g guard foo --implements=CanActivate

The regression was released in CLI v8.3.0 stable (not in the next or rc releases).

If the issue is encountered, it can be easily worked around by using `--defaults` or manually picking the interface wanted in the prompt.