### PR TITLE
fix(@angular-devkit/build-angular): default poll value when not present

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/normalize-builder-schema.ts
+++ b/packages/angular_devkit/build_angular/src/utils/normalize-builder-schema.ts
@@ -65,5 +65,9 @@ export function normalizeBrowserSchema(
         || [],
     },
     lazyModules: options.lazyModules || [],
+    // Using just `--poll` will result in a value of 0 which is very likely not the intention
+    // A value of 0 is falsy and will disable polling rather then enable
+    // 500 ms is a sensible default in this case
+    poll: options.poll === 0 ? 500 : options.poll,
   };
 }


### PR DESCRIPTION
`--poll` is a valid command line option (vs. `--poll 1000`).  This however will result in a value of 0 which causes polling to be disabled rather than enabled which is completely non-obvious.  This change sets a default value of 500 when the commandline flag is used.