### PR TITLE
feat(@schematics/angular): add migration to enable AOT by default

### DIFF
--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -215,7 +215,6 @@ function addAppToWorkspaceFile(options: ApplicationOptions, appDir: string): Rul
             sourceMap: false,
             extractCss: true,
             namedChunks: false,
-            aot: true,
             extractLicenses: true,
             vendorChunk: false,
             buildOptimizer: true,

--- a/packages/schematics/angular/migrations/update-9/utils_spec.ts
+++ b/packages/schematics/angular/migrations/update-9/utils_spec.ts
@@ -1,0 +1,107 @@
+
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { HostTree } from '@angular-devkit/schematics';
+import { isIvyEnabled } from './utils';
+
+describe('migrations update-9 utils', () => {
+  describe('isIvyEnabled', () => {
+    let tree: HostTree;
+
+    beforeEach(() => {
+      tree = new HostTree();
+    });
+
+    it('should return false when disabled in base tsconfig', () => {
+      tree.create('tsconfig.json', JSON.stringify({
+        angularCompilerOptions: {
+          enableIvy: false,
+        },
+      }));
+
+      tree.create('foo/tsconfig.app.json', JSON.stringify({
+        extends: '../tsconfig.json',
+      }));
+
+      expect(isIvyEnabled(tree, 'foo/tsconfig.app.json')).toBe(false);
+    });
+
+    it('should return true when enable in child tsconfig but disabled in base tsconfig', () => {
+      tree.create('tsconfig.json', JSON.stringify({
+        angularCompilerOptions: {
+          enableIvy: false,
+        },
+      }));
+
+      tree.create('foo/tsconfig.app.json', JSON.stringify({
+        extends: '../tsconfig.json',
+        angularCompilerOptions: {
+          enableIvy: true,
+        },
+      }));
+
+      expect(isIvyEnabled(tree, 'foo/tsconfig.app.json')).toBe(true);
+    });
+
+    it('should return false when disabled in child tsconfig but enabled in base tsconfig', () => {
+      tree.create('tsconfig.json', JSON.stringify({
+        angularCompilerOptions: {
+          enableIvy: true,
+        },
+      }));
+
+      tree.create('foo/tsconfig.app.json', JSON.stringify({
+        extends: '../tsconfig.json',
+        angularCompilerOptions: {
+          enableIvy: false,
+        },
+      }));
+
+      expect(isIvyEnabled(tree, 'foo/tsconfig.app.json')).toBe(false);
+    });
+
+    it('should return false when disabled in base with multiple extends', () => {
+      tree.create('tsconfig.json', JSON.stringify({
+        angularCompilerOptions: {
+          enableIvy: false,
+        },
+      }));
+
+      tree.create('foo/tsconfig.project.json', JSON.stringify({
+        extends: '../tsconfig.json',
+      }));
+
+      tree.create('foo/tsconfig.app.json', JSON.stringify({
+        extends: './tsconfig.project.json',
+      }));
+
+      expect(isIvyEnabled(tree, 'foo/tsconfig.app.json')).toBe(false);
+    });
+
+    it('should return true when enable in intermediate tsconfig with multiple extends', () => {
+      tree.create('tsconfig.json', JSON.stringify({
+        angularCompilerOptions: {
+          enableIvy: false,
+        },
+      }));
+
+      tree.create('foo/tsconfig.project.json', JSON.stringify({
+        extends: '../tsconfig.json',
+        angularCompilerOptions: {
+          enableIvy: true,
+        },
+      }));
+
+      tree.create('foo/tsconfig.app.json', JSON.stringify({
+        extends: './tsconfig.project.json',
+      }));
+
+      expect(isIvyEnabled(tree, 'foo/tsconfig.app.json')).toBe(true);
+    });
+  });
+});

--- a/tests/legacy-cli/e2e/setup/500-create-project.ts
+++ b/tests/legacy-cli/e2e/setup/500-create-project.ts
@@ -29,7 +29,9 @@ export default async function() {
 
       // In VE non prod builds are non AOT by default
       await updateJsonFile('angular.json', config => {
-        config.projects['test-project'].architect.build.options.aot = false;
+        const build = config.projects['test-project'].architect.build;
+        build.options.aot = false;
+        build.configurations.production.aot = true;
       });
     }
   }


### PR DESCRIPTION
With this change we enable the AOT option for the browser builder when an application will use Ivy as rendering engine.