### PR TITLE
fix(@schematics/angular): open twitter link in new tab

### DIFF
--- a/packages/schematics/angular/application/other-files/app.component.html.template
+++ b/packages/schematics/angular/application/other-files/app.component.html.template
@@ -304,7 +304,7 @@
   />
   <span>Welcome</span>
     <div class="spacer"></div>
-  <a aria-label="Angular on twitter" href="https://twitter.com/angular" title="Twitter">
+  <a aria-label="Angular on twitter" target="_blank" rel="noopener" href="https://twitter.com/angular" title="Twitter">
     
     <svg id="twitter-logo" height="24" data-name="Logo — FIXED" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
       <defs>


### PR DESCRIPTION
Change the default application to open the twitter link in a new tab
instead of in the current tab. This is consistent with all the other
external links in the page.