### PR TITLE
fix(@angular/cli): handle promise rejection on analytics install prompt

### DIFF
--- a/packages/angular/cli/bin/postinstall/analytics-prompt.js
+++ b/packages/angular/cli/bin/postinstall/analytics-prompt.js
@@ -8,9 +8,12 @@ if ('NG_CLI_ANALYTICS' in process.env) {
 try {
   var analytics = require('../../models/analytics');
 
-  analytics.hasGlobalAnalyticsConfiguration().then(hasGlobalConfig => {
-    if (!hasGlobalConfig) {
-      return analytics.promptGlobalAnalytics();
-    }
-  });
+  analytics
+    .hasGlobalAnalyticsConfiguration()
+    .then(hasGlobalConfig => {
+      if (!hasGlobalConfig) {
+        return analytics.promptGlobalAnalytics();
+      }
+    })
+    .catch(() => {});
 } catch (_) {}


### PR DESCRIPTION
A rejection in this case should be ignored to prevent potential installation failure.