### PR TITLE
feat(@angular-devkit/build-angular): exclude TSX test files from test coverage

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/test.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/test.ts
@@ -33,7 +33,7 @@ export function getTestConfig(
   if (buildOptions.codeCoverage) {
     const codeCoverageExclude = buildOptions.codeCoverageExclude;
     const exclude: (string | RegExp)[] = [
-      /\.(e2e|spec)\.ts$/,
+      /\.(e2e|spec)\.tsx?$/,
       /node_modules/,
     ];
 


### PR DESCRIPTION
I missed this in #15381.

Workaround is to use `codeCoverageExclude` in `angular.json`:
```json
"codeCoverageExclude": ["**/*.spec.tsx"],
```