### PR TITLE
feat(@angular/cli): add support for custom npmrc path

### DIFF
--- a/packages/angular/cli/utilities/package-metadata.ts
+++ b/packages/angular/cli/utilities/package-metadata.ts
@@ -91,8 +91,8 @@ function readOptions(
   }
 
   const defaultConfigLocations = [
-    path.join(globalPrefix, 'etc', baseFilename),
-    path.join(homedir(), dotFilename),
+    (!yarn && process.env.NPM_CONFIG_GLOBALCONFIG) || path.join(globalPrefix, 'etc', baseFilename),
+    (!yarn && process.env.NPM_CONFIG_USERCONFIG) || path.join(homedir(), dotFilename),
   ];
 
   const projectConfigLocations: string[] = [


### PR DESCRIPTION
According to [the npm config docs](https://docs.npmjs.com/misc/config#npmrc-files), a user can specify the path to their
`npmrc` file using the environment variable `NPM_CONFIG_USERCONFIG`.

I ran into this issue on my system because I have my `npmrc` file in a custom location. I noticed it when running `ng
update @angular/cli` because there were 404 errors on a few internal packages, which indicated that my `npmrc` was not
being honored.

I'm not sure if this fix is sufficient, but wanted to at least start a conversation about the issue.