### PR TITLE
feat(@schematics/angular): add migration for applications tsconfigs

### DIFF
--- a/packages/schematics/angular/migrations/update-9/index.ts
+++ b/packages/schematics/angular/migrations/update-9/index.ts
@@ -8,17 +8,19 @@
 
 import { Rule, chain } from '@angular-devkit/schematics';
 import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
-import { UpdateLibraries } from './ivy-libraries';
+import { updateLibraries } from './ivy-libraries';
 import { updateNGSWConfig } from './ngsw-config';
+import { updateApplicationTsConfigs } from './update-app-tsconfigs';
 import { updateDependencies } from './update-dependencies';
-import { UpdateWorkspaceConfig } from './update-workspace-config';
+import { updateWorkspaceConfig } from './update-workspace-config';
 
 export default function(): Rule {
   return () => {
     return chain([
-      UpdateWorkspaceConfig(),
-      UpdateLibraries(),
+      updateWorkspaceConfig(),
+      updateLibraries(),
       updateNGSWConfig(),
+      updateApplicationTsConfigs(),
       updateDependencies(),
       (tree, context) => {
         const packageChanges = tree.actions.some(a => a.path.endsWith('/package.json'));

--- a/packages/schematics/angular/migrations/update-9/ivy-libraries.ts
+++ b/packages/schematics/angular/migrations/update-9/ivy-libraries.ts
@@ -23,7 +23,7 @@ import { getTargets, getWorkspace } from './utils';
  * - Creates a production configuration for VE compilations.
  * - Create a prod tsconfig for which disables Ivy and enables VE compilations.
  */
-export function UpdateLibraries(): Rule {
+export function updateLibraries(): Rule {
   return (tree: Tree) => {
     const workspacePath = getWorkspacePath(tree);
     const workspace = getWorkspace(tree);

--- a/packages/schematics/angular/migrations/update-9/ivy-libraries.ts
+++ b/packages/schematics/angular/migrations/update-9/ivy-libraries.ts
@@ -5,7 +5,6 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import { JsonParseMode, parseJsonAst } from '@angular-devkit/core';
 import { Rule, Tree } from '@angular-devkit/schematics';
 import { getWorkspacePath } from '../../utility/config';
 import {
@@ -14,7 +13,7 @@ import {
   insertPropertyInAstObjectInOrder,
 } from '../../utility/json-utils';
 import { Builders } from '../../utility/workspace-models';
-import { getTargets, getWorkspace } from './utils';
+import { getTargets, getWorkspace, readJsonFileAsAstObject } from './utils';
 
 /**
  * Updates a pre version 9 library to version 9 Ivy library.
@@ -62,17 +61,7 @@ export function updateLibraries(): Rule {
       }
 
       // tsConfig for production already exists.
-      const tsConfigContent = tree.read(tsConfigOption.value);
-      if (!tsConfigContent) {
-        continue;
-      }
-
-      const tsConfigAst = parseJsonAst(tsConfigContent.toString(), JsonParseMode.Loose);
-      if (!tsConfigAst || tsConfigAst.kind !== 'object') {
-        // Invalid tsConfig
-        continue;
-      }
-
+      const tsConfigAst = readJsonFileAsAstObject(tree, tsConfigOption.value);
       const tsConfigRecorder = tree.beginUpdate(tsConfigOption.value);
       const ngCompilerOptions = findPropertyInAstObject(tsConfigAst, 'angularCompilerOptions');
       if (!ngCompilerOptions) {

--- a/packages/schematics/angular/migrations/update-9/ngsw-config.ts
+++ b/packages/schematics/angular/migrations/update-9/ngsw-config.ts
@@ -5,11 +5,10 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import { JsonParseMode, parseJsonAst } from '@angular-devkit/core';
-import { Rule, SchematicsException, Tree } from '@angular-devkit/schematics';
+import { Rule,  Tree } from '@angular-devkit/schematics';
 import { appendValueInAstArray, findPropertyInAstObject } from '../../utility/json-utils';
 import { Builders } from '../../utility/workspace-models';
-import { getAllOptions, getTargets, getWorkspace } from './utils';
+import { getAllOptions, getTargets, getWorkspace, readJsonFileAsAstObject } from './utils';
 
 
 /**
@@ -27,13 +26,7 @@ export function updateNGSWConfig(): Rule {
         }
 
         const path = ngswConfigPath.value;
-        const configBuffer = tree.read(path);
-        if (!configBuffer) {
-          throw new SchematicsException(`Could not find (${path})`);
-        }
-
-        const content = configBuffer.toString();
-        const ngswConfigAst = parseJsonAst(content, JsonParseMode.Loose);
+        const ngswConfigAst = readJsonFileAsAstObject(tree, path);
         if (!ngswConfigAst || ngswConfigAst.kind !== 'object') {
           continue;
         }

--- a/packages/schematics/angular/migrations/update-9/update-app-tsconfigs.ts
+++ b/packages/schematics/angular/migrations/update-9/update-app-tsconfigs.ts
@@ -1,0 +1,124 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { JsonAstObject, JsonParseMode, parseJsonAst } from '@angular-devkit/core';
+import { Rule, Tree, UpdateRecorder } from '@angular-devkit/schematics';
+import {
+  findPropertyInAstObject,
+  insertPropertyInAstObjectInOrder,
+  removePropertyInAstObject,
+} from '../../utility/json-utils';
+import { Builders } from '../../utility/workspace-models';
+import { getAllOptions, getTargets, getWorkspace } from './utils';
+
+
+/**
+ * Update the tsconfig files for applications
+ * - Removes enableIvy: true
+ * - Sets stricter file inclusions
+ */
+export function updateApplicationTsConfigs(): Rule {
+  return (tree: Tree) => {
+    const workspace = getWorkspace(tree);
+
+    for (const { target } of getTargets(workspace, 'build', Builders.Browser)) {
+      updateTsConfig(tree, target, Builders.Browser);
+    }
+
+    for (const { target } of getTargets(workspace, 'server', Builders.Server)) {
+      updateTsConfig(tree, target, Builders.Server);
+    }
+
+    for (const { target } of getTargets(workspace, 'test', Builders.Karma)) {
+      updateTsConfig(tree, target, Builders.Karma);
+    }
+
+    return tree;
+  };
+}
+
+function updateTsConfig(tree: Tree, builderConfig: JsonAstObject, builderName: Builders) {
+  const options = getAllOptions(builderConfig);
+  for (const option of options) {
+    let recorder: UpdateRecorder;
+    const tsConfigOption = findPropertyInAstObject(option, 'tsConfig');
+
+    if (!tsConfigOption || tsConfigOption.kind !== 'string') {
+      continue;
+    }
+
+    const tsConfigPath = tsConfigOption.value;
+    let tsConfigAst = getTsConfigAst(tree, tsConfigPath);
+    if (!tsConfigAst) {
+      continue;
+    }
+
+    // Remove 'enableIvy: true' since this is the default in version 9.
+    const angularCompilerOptions = findPropertyInAstObject(tsConfigAst, 'angularCompilerOptions');
+    if (angularCompilerOptions && angularCompilerOptions.kind === 'object') {
+      const enableIvy = findPropertyInAstObject(angularCompilerOptions, 'enableIvy');
+      if (enableIvy && enableIvy.kind === 'true') {
+        recorder = tree.beginUpdate(tsConfigPath);
+        if (angularCompilerOptions.properties.length === 1) {
+          // remove entire 'angularCompilerOptions'
+          removePropertyInAstObject(recorder, tsConfigAst, 'angularCompilerOptions');
+        } else {
+          removePropertyInAstObject(recorder, angularCompilerOptions, 'enableIvy');
+        }
+        tree.commitUpdate(recorder);
+      }
+    }
+
+    // Add stricter file inclusions to avoid unused file warning during compilation
+    if (builderName !== Builders.Karma) {
+      // Note: we need to re-read the tsconfig after very commit because
+      // otherwise the updates will be out of sync since we are ammending the same node.
+      tsConfigAst = getTsConfigAst(tree, tsConfigPath) as JsonAstObject;
+      const files = findPropertyInAstObject(tsConfigAst, 'files');
+      const include = findPropertyInAstObject(tsConfigAst, 'include');
+
+      if (!files && !include) {
+        const rootInSrc = tsConfigPath.includes('src/');
+        const rootSrc = rootInSrc ? '' : 'src/';
+        const files = builderName === Builders.Server
+          ? [`${rootSrc}main.server.ts`]
+          : [`${rootSrc}main.ts`, `${rootSrc}polyfills.ts`];
+
+        recorder = tree.beginUpdate(tsConfigPath);
+        insertPropertyInAstObjectInOrder(recorder, tsConfigAst, 'files', files, 2);
+        tree.commitUpdate(recorder);
+
+        if (builderName === Builders.Browser) {
+          tsConfigAst = getTsConfigAst(tree, tsConfigPath) as JsonAstObject;
+          recorder = tree.beginUpdate(tsConfigPath);
+          insertPropertyInAstObjectInOrder(recorder, tsConfigAst, 'include', [`${rootSrc}**/*.d.ts`], 2);
+          tree.commitUpdate(recorder);
+        }
+
+        tsConfigAst = getTsConfigAst(tree, tsConfigPath) as JsonAstObject;
+        recorder = tree.beginUpdate(tsConfigPath);
+        removePropertyInAstObject(recorder, tsConfigAst, 'exclude');
+        tree.commitUpdate(recorder);
+      }
+    }
+  }
+}
+
+function getTsConfigAst(tree: Tree, path: string): JsonAstObject | undefined {
+  const configBuffer = tree.read(path);
+  if (!configBuffer) {
+    return undefined;
+  }
+
+  const content = configBuffer.toString();
+  const tsConfigAst = parseJsonAst(content, JsonParseMode.Loose);
+  if (!tsConfigAst || tsConfigAst.kind !== 'object') {
+    return undefined;
+  }
+
+  return tsConfigAst;
+}

--- a/packages/schematics/angular/migrations/update-9/update-app-tsconfigs_spec.ts
+++ b/packages/schematics/angular/migrations/update-9/update-app-tsconfigs_spec.ts
@@ -1,0 +1,120 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { EmptyTree } from '@angular-devkit/schematics';
+import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';
+
+// tslint:disable-next-line: no-any
+function overrideJsonFile(tree: UnitTestTree, path: string, newContent: object) {
+  tree.overwrite(path, JSON.stringify(newContent, undefined, 2));
+}
+
+const defaultTsConfigOptions = {
+  extends: './tsconfig.json',
+  compilerOptions: {
+    outDir: './out-tsc/app',
+    types: [],
+  },
+  exclude: [
+    'src/test.ts',
+    'src/**/*.spec.ts',
+  ],
+  angularCompilerOptions: {
+    enableIvy: true,
+  },
+};
+
+// tslint:disable:no-big-function
+describe('Migration to version 9', () => {
+  describe('Update applications tsconfig', () => {
+    const schematicRunner = new SchematicTestRunner(
+      'migrations',
+      require.resolve('../migration-collection.json'),
+    );
+
+    let tree: UnitTestTree;
+
+    beforeEach(async () => {
+      tree = new UnitTestTree(new EmptyTree());
+      tree = await schematicRunner
+        .runExternalSchematicAsync(
+          require.resolve('../../collection.json'),
+          'ng-new',
+          {
+            name: 'migration-test',
+            version: '1.2.3',
+            directory: '.',
+          },
+          tree,
+        )
+        .toPromise();
+    });
+
+    it('should update apps tsConfig with stricter files inclusions', async () => {
+      overrideJsonFile(tree, 'tsconfig.app.json', defaultTsConfigOptions);
+      const tree2 = await schematicRunner.runSchematicAsync('migration-09', {}, tree.branch()).toPromise();
+      const { exclude, files, include } = JSON.parse(tree2.readContent('tsconfig.app.json'));
+      expect(exclude).toBeUndefined();
+      expect(files).toEqual(['src/main.ts', 'src/polyfills.ts']);
+      expect(include).toEqual(['src/**/*.d.ts']);
+    });
+
+    it('should not update apps tsConfig when tsconfig has include', async () => {
+      const tsConfigContent = {
+        ...defaultTsConfigOptions,
+        include: ['foo.ts'],
+      };
+
+      overrideJsonFile(tree, 'tsconfig.app.json', tsConfigContent);
+
+      const tree2 = await schematicRunner.runSchematicAsync('migration-09', {}, tree.branch()).toPromise();
+      const { files, include } = JSON.parse(tree2.readContent('tsconfig.app.json'));
+      expect(files).toEqual(undefined);
+      expect(include).toEqual(['foo.ts']);
+    });
+
+    it(`should remove angularCompilerOptions when enableIvy is true and it's the only option`, async () => {
+      overrideJsonFile(tree, 'tsconfig.app.json', defaultTsConfigOptions);
+      const tree2 = await schematicRunner.runSchematicAsync('migration-09', {}, tree.branch()).toPromise();
+      const { angularCompilerOptions } = JSON.parse(tree2.readContent('tsconfig.app.json'));
+      expect(angularCompilerOptions).toBeUndefined();
+    });
+
+    it('should remove enableIvy only when true and there are other angularCompilerOptions', async () => {
+      const tsConfigContent = {
+        ...defaultTsConfigOptions,
+        angularCompilerOptions: {
+          enableIvy: true,
+          fullTemplateTypeCheck: true,
+        },
+      };
+
+      overrideJsonFile(tree, 'tsconfig.app.json', tsConfigContent);
+      const tree2 = await schematicRunner.runSchematicAsync('migration-09', {}, tree.branch()).toPromise();
+      const { angularCompilerOptions } = JSON.parse(tree2.readContent('tsconfig.app.json'));
+      expect(angularCompilerOptions.enableIvy).toBeUndefined();
+      expect(angularCompilerOptions.fullTemplateTypeCheck).toBe(true);
+    });
+
+    it('should note remove enableIvy is set to false', async () => {
+      const tsConfigContent = {
+        ...defaultTsConfigOptions,
+        angularCompilerOptions: {
+          enableIvy: false,
+          fullTemplateTypeCheck: true,
+        },
+      };
+
+      overrideJsonFile(tree, 'tsconfig.app.json', tsConfigContent);
+      const tree2 = await schematicRunner.runSchematicAsync('migration-09', {}, tree.branch()).toPromise();
+      const { angularCompilerOptions } = JSON.parse(tree2.readContent('tsconfig.app.json'));
+      expect(angularCompilerOptions.enableIvy).toBe(false);
+      expect(angularCompilerOptions.fullTemplateTypeCheck).toBe(true);
+    });
+  });
+});

--- a/packages/schematics/angular/migrations/update-9/update-workspace-config.ts
+++ b/packages/schematics/angular/migrations/update-9/update-workspace-config.ts
@@ -22,7 +22,7 @@ export const ANY_COMPONENT_STYLE_BUDGET = {
   maximumWarning: '6kb',
 };
 
-export function UpdateWorkspaceConfig(): Rule {
+export function updateWorkspaceConfig(): Rule {
   return (tree: Tree) => {
     const workspacePath = getWorkspacePath(tree);
     const workspace = getWorkspace(tree);

--- a/packages/schematics/angular/migrations/update-9/utils.ts
+++ b/packages/schematics/angular/migrations/update-9/utils.ts
@@ -72,14 +72,23 @@ export function getAllOptions(builderConfig: JsonAstObject, configurationsOnly =
 
 export function getWorkspace(host: Tree): JsonAstObject {
   const path = getWorkspacePath(host);
+
+  return readJsonFileAsAstObject(host, path);
+}
+
+export function readJsonFileAsAstObject(host: Tree, path: string): JsonAstObject {
   const configBuffer = host.read(path);
   if (!configBuffer) {
     throw new SchematicsException(`Could not find (${path})`);
   }
 
   const content = configBuffer.toString();
+  const astContent = parseJsonAst(content, JsonParseMode.Loose);
+  if (!astContent || astContent.kind !== 'object') {
+    throw new SchematicsException(`Invalid JSON AST Object (${path})`);
+  }
 
-  return parseJsonAst(content, JsonParseMode.Loose) as JsonAstObject;
+  return astContent;
 }
 
 export function isIvyEnabled(tree: Tree, tsConfigPath: string): boolean {


### PR DESCRIPTION
This migration updates the current tsconfig for the applications in two ways.

1) removes `enableIvy: true` option since it's by default true.
2) Amends the files/exclude/include options to only include files that are needed in the compilation.

Closes #15491