### PR TITLE
feat(@angular-devkit/build-angular): add errorOnCircularDependencies build option

### DIFF
--- a/docs/documentation/1-x/angular-cli.md
+++ b/docs/documentation/1-x/angular-cli.md
@@ -24,6 +24,7 @@
   - *prefix* (`string`): The prefix to apply to generated selectors.
   - *serviceWorker* (`boolean`): Experimental support for a service worker from @angular/service-worker. Default is `false`.
   - *showCircularDependencies* (`boolean`): Show circular dependency warnings on builds. Default is `true`.
+  - *errorOnCircularDependencies* (`boolean`): Treat circular dependency warnings as errors on builds. Default is `false`.
   - *styles* (`string|array`): Global styles to be included in the build.
   - *stylePreprocessorOptions* : Options to pass to style preprocessors.
     - *includePaths* (`array`): Paths to include. Paths will be resolved to project root.

--- a/docs/documentation/1-x/build.md
+++ b/docs/documentation/1-x/build.md
@@ -366,6 +366,16 @@ See https://github.com/angular/angular-cli/issues/7797 for details.
 </details>
 
 <details>
+  <summary>error-on-circular-dependencies</summary>
+  <p>
+    <code>--error-on-circular-dependencies</code> (aliases: <code>-ecd</code>)
+  </p>
+  <p>
+    Treat circular dependency warnings as errors on builds.
+  </p>
+</details>
+
+<details>
   <summary>build-optimizer</summary>
   <p>
     <code>--build-optimizer</code>

--- a/docs/documentation/build.md
+++ b/docs/documentation/build.md
@@ -326,6 +326,15 @@ See https://github.com/angular/angular-cli/issues/7797 for details.
   </p>
 </details>
 <details>
+  <summary>error-on-circular-dependencies</summary>
+  <p>
+    <code>--error-on-circular-dependencies</code> (aliases: <code>-ecd</code>)
+  </p>
+  <p>
+    Treat circular dependency warnings as errors on builds.
+  </p>
+</details>
+<details>
   <summary>build-optimizer</summary>
   <p>
     <code>--build-optimizer</code>

--- a/packages/angular/cli/lib/config/schema.json
+++ b/packages/angular/cli/lib/config/schema.json
@@ -817,6 +817,11 @@
               "description": "Show circular dependency warnings on builds.",
               "default": true
             },
+            "errorOnCircularDependencies": {
+              "type": "boolean",
+              "description": "Treat circular dependency warnings as errors on builds.",
+              "default": false
+            },
             "buildOptimizer": {
               "type": "boolean",
               "description": "Enables @angular-devkit/build-optimizer optimizations when using the 'aot' option.",
@@ -1776,6 +1781,11 @@
               "type": "boolean",
               "description": "Show circular dependency warnings on builds.",
               "default": true
+            },
+            "errorOnCircularDependencies": {
+              "type": "boolean",
+              "description": "Treat circular dependency warnings as errors on builds.",
+              "default": false
             },
             "namedChunks": {
               "type": "boolean",

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/build-options.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/build-options.ts
@@ -51,6 +51,7 @@ export interface BuildOptions {
   preserveSymlinks?: boolean;
   extractLicenses?: boolean;
   showCircularDependencies?: boolean;
+  errorOnCircularDependencies?: boolean;
   buildOptimizer?: boolean;
   namedChunks?: boolean;
   subresourceIntegrity?: boolean;

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
@@ -230,11 +230,16 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
   }
 
   if (buildOptions.showCircularDependencies) {
-    extraPlugins.push(
-      new CircularDependencyPlugin({
-        exclude: /([\\\/]node_modules[\\\/])|(ngfactory\.js$)/,
-      }),
-    );
+    const circularDependencyOptions = {
+      exclude: /([\\\/]node_modules[\\\/])|(ngfactory\.js$)/,
+      failOnError: false,
+    };
+
+    if (buildOptions.errorOnCircularDependencies) {
+      circularDependencyOptions.failOnError = true;
+    }
+
+    extraPlugins.push(new CircularDependencyPlugin(circularDependencyOptions));
   }
 
   if (buildOptions.statsJson) {

--- a/packages/angular_devkit/build_angular/src/browser/schema.json
+++ b/packages/angular_devkit/build_angular/src/browser/schema.json
@@ -239,6 +239,11 @@
       "description": "Show circular dependency warnings on builds.",
       "default": true
     },
+    "errorOnCircularDependencies": {
+      "type": "boolean",
+      "description": "Treat circular dependency warnings as errors on builds.",
+      "default": false
+    },
     "buildOptimizer": {
       "type": "boolean",
       "description": "Enables '@angular-devkit/build-optimizer' optimizations when using the 'aot' option.",

--- a/packages/angular_devkit/build_angular/src/server/schema.json
+++ b/packages/angular_devkit/build_angular/src/server/schema.json
@@ -187,6 +187,11 @@
       "description": "Show circular dependency warnings on builds.",
       "default": true
     },
+    "errorOnCircularDependencies": {
+      "type": "boolean",
+      "description": "Treat circular dependency warnings as errors on builds.",
+      "default": false
+    },
     "namedChunks": {
       "type": "boolean",
       "description": "Use file name for lazy loaded chunks.",

--- a/packages/angular_devkit/build_angular/test/browser/circular-dependency_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/browser/circular-dependency_spec_large.ts
@@ -35,4 +35,20 @@ describe('Browser Builder circular dependency detection', () => {
     expect(logs.join()).toContain('Circular dependency detected');
     await run.stop();
   });
+
+  it('works with errors on', async () => {
+    host.appendToFile('src/app/app.component.ts',
+      `import { AppModule } from './app.module'; console.log(AppModule);`);
+
+    const overrides = { baseHref: '/myUrl', errorOnCircularDependencies: true };
+    const logger = new logging.Logger('');
+    const logs: string[] = [];
+    logger.subscribe(e => logs.push(e.message));
+
+    const run = await architect.scheduleTarget(targetSpec, overrides, { logger });
+    const output = await run.result;
+    expect(output.success).toBe(false);
+    expect(logs.join()).toContain('Circular dependency detected');
+    await run.stop();
+  });
 });

--- a/packages/schematics/angular/utility/config.ts
+++ b/packages/schematics/angular/utility/config.ts
@@ -396,6 +396,10 @@ export interface CliConfig {
            */
           showCircularDependencies?: boolean;
           /**
+           * Treat circular dependency warnings as errors on builds.
+           */
+          errorOnCircularDependencies?: boolean;
+          /**
            * Use a separate bundle containing code used across multiple bundles.
            */
           commonChunk?: boolean;

--- a/tests/angular_devkit/core/json/schema/serializers/schema_benchmark.json
+++ b/tests/angular_devkit/core/json/schema/serializers/schema_benchmark.json
@@ -488,6 +488,11 @@
               "type": "boolean",
               "default": true
             },
+            "errorOnCircularDependencies": {
+              "type": "boolean",
+              "description": "Treat circular dependency warnings as errors on builds.",
+              "default": false
+            },
             "commonChunk": {
               "description": "Use a separate bundle containing code used across multiple bundles.",
               "type": "boolean",


### PR DESCRIPTION
Add an errorOnCircularDependencies build option that will cause the build to treat circular dependencies as errors. This flag allows CI tools to easily treat detected circular dependencies as failed builds.