### PR TITLE
feat(@angular/cli): migrate e2e tests to async/await

### DIFF
--- a/packages/angular_devkit/build_angular/test/app-shell/app-shell_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/app-shell/app-shell_spec_large.ts
@@ -210,15 +210,15 @@ import { createArchitect, host, veEnabled } from '../utils';
       'e2e/app.e2e-spec.ts': `
         import { browser, by, element } from 'protractor';
 
-        it('should have ngsw in normal state', () => {
-          browser.get('/');
+        it('should have ngsw in normal state', async () => {
+          await browser.get('/');
           // Wait for service worker to load.
-          browser.sleep(2000);
-          browser.waitForAngularEnabled(false);
-          browser.get('/ngsw/state');
+          await browser.sleep(2000);
+          await browser.waitForAngularEnabled(false);
+          await browser.get('/ngsw/state');
           // Should have updated, and be in normal state.
-          expect(element(by.css('pre')).getText()).not.toContain('Last update check: never');
-          expect(element(by.css('pre')).getText()).toContain('Driver state: NORMAL');
+          expect(await element(by.css('pre')).getText()).not.toContain('Last update check: never');
+          expect(await element(by.css('pre')).getText()).toContain('Driver state: NORMAL');
         });
       `,
     });

--- a/packages/schematics/angular/e2e/files/protractor.conf.js.template
+++ b/packages/schematics/angular/e2e/files/protractor.conf.js.template
@@ -8,6 +8,7 @@ const { SpecReporter } = require('jasmine-spec-reporter');
  * @type { import("protractor").Config }
  */
 exports.config = {
+  SELENIUM_PROMISE_MANAGER: false,
   allScriptsTimeout: 11000,
   specs: [
     './src/**/*.e2e-spec.ts'

--- a/packages/schematics/angular/e2e/files/src/app.e2e-spec.ts.template
+++ b/packages/schematics/angular/e2e/files/src/app.e2e-spec.ts.template
@@ -8,9 +8,9 @@ describe('workspace-project App', () => {
     page = new AppPage();
   });
 
-  it('should display welcome message', () => {
-    page.navigateTo();
-    expect(page.getTitleText()).toEqual('<%= relatedAppName %> app is running!');
+  it('should display welcome message', async () => {
+    await page.navigateTo();
+    expect(await page.getTitleText()).toEqual('<%= relatedAppName %> app is running!');
   });
 
   afterEach(async () => {

--- a/tests/angular_devkit/build_angular/hello-world-app-ve/e2e/app.e2e-spec.ts
+++ b/tests/angular_devkit/build_angular/hello-world-app-ve/e2e/app.e2e-spec.ts
@@ -14,8 +14,8 @@ describe('hello-world-app App', () => {
     page = new AppPage();
   });
 
-  it('should display welcome message', () => {
-    page.navigateTo();
-    expect(page.getTitleText()).toEqual('Welcome to app!');
+  it('should display welcome message', async () => {
+    await page.navigateTo();
+    expect(await page.getTitleText()).toEqual('Welcome to app!');
   });
 });

--- a/tests/angular_devkit/build_angular/hello-world-app-ve/protractor.conf.js
+++ b/tests/angular_devkit/build_angular/hello-world-app-ve/protractor.conf.js
@@ -12,6 +12,7 @@ const { SpecReporter } = require('jasmine-spec-reporter');
 const { resolve } = require('path');
 
 exports.config = {
+  SELENIUM_PROMISE_MANAGER: false,
   allScriptsTimeout: 11000,
   specs: [
     './e2e/**/*.e2e-spec.ts'

--- a/tests/angular_devkit/build_angular/hello-world-app/e2e/app.e2e-spec.ts
+++ b/tests/angular_devkit/build_angular/hello-world-app/e2e/app.e2e-spec.ts
@@ -14,8 +14,8 @@ describe('hello-world-app App', () => {
     page = new AppPage();
   });
 
-  it('should display welcome message', () => {
-    page.navigateTo();
-    expect(page.getTitleText()).toEqual('Welcome to app!');
+  it('should display welcome message', async () => {
+    await page.navigateTo();
+    expect(await page.getTitleText()).toEqual('Welcome to app!');
   });
 });

--- a/tests/angular_devkit/build_angular/hello-world-app/protractor.conf.js
+++ b/tests/angular_devkit/build_angular/hello-world-app/protractor.conf.js
@@ -12,6 +12,7 @@ const { SpecReporter } = require('jasmine-spec-reporter');
 const { resolve } = require('path');
 
 exports.config = {
+  SELENIUM_PROMISE_MANAGER: false,
   allScriptsTimeout: 11000,
   specs: ['./e2e/**/*.e2e-spec.ts'],
   capabilities: {

--- a/tests/legacy-cli/e2e/assets/1.0-project/e2e/app.e2e-spec.ts
+++ b/tests/legacy-cli/e2e/assets/1.0-project/e2e/app.e2e-spec.ts
@@ -7,8 +7,8 @@ describe('one-oh-project App', () => {
     page = new OneOhProjectPage();
   });
 
-  it('should display message saying app works', () => {
-    page.navigateTo();
-    expect(page.getParagraphText()).toEqual('app works!');
+  it('should display message saying app works', async () => {
+    await page.navigateTo();
+    expect(await page.getParagraphText()).toEqual('app works!');
   });
 });

--- a/tests/legacy-cli/e2e/assets/1.0-project/protractor.conf.js
+++ b/tests/legacy-cli/e2e/assets/1.0-project/protractor.conf.js
@@ -5,6 +5,7 @@
 const { SpecReporter } = require('jasmine-spec-reporter');
 
 exports.config = {
+  SELENIUM_PROMISE_MANAGER: false,
   allScriptsTimeout: 11000,
   specs: [
     './e2e/**/*.e2e-spec.ts'

--- a/tests/legacy-cli/e2e/assets/1.7-project/e2e/app.e2e-spec.ts
+++ b/tests/legacy-cli/e2e/assets/1.7-project/e2e/app.e2e-spec.ts
@@ -7,8 +7,8 @@ describe('latest-project App', () => {
     page = new AppPage();
   });
 
-  it('should display welcome message', () => {
-    page.navigateTo();
-    expect(page.getParagraphText()).toEqual('Welcome to app!');
+  it('should display welcome message', async () => {
+    await page.navigateTo();
+    expect(await page.getParagraphText()).toEqual('Welcome to app!');
   });
 });

--- a/tests/legacy-cli/e2e/assets/1.7-project/protractor.conf.js
+++ b/tests/legacy-cli/e2e/assets/1.7-project/protractor.conf.js
@@ -5,6 +5,7 @@
 const { SpecReporter } = require('jasmine-spec-reporter');
 
 exports.config = {
+  SELENIUM_PROMISE_MANAGER: false,
   allScriptsTimeout: 11000,
   specs: [
     './e2e/**/*.e2e-spec.ts'

--- a/tests/legacy-cli/e2e/assets/7.0-project/e2e/protractor.conf.js
+++ b/tests/legacy-cli/e2e/assets/7.0-project/e2e/protractor.conf.js
@@ -4,6 +4,7 @@
 const { SpecReporter } = require('jasmine-spec-reporter');
 
 exports.config = {
+  SELENIUM_PROMISE_MANAGER: false,
   allScriptsTimeout: 11000,
   specs: [
     './src/**/*.e2e-spec.ts'

--- a/tests/legacy-cli/e2e/assets/7.0-project/e2e/src/app.e2e-spec.ts
+++ b/tests/legacy-cli/e2e/assets/7.0-project/e2e/src/app.e2e-spec.ts
@@ -1,9 +1,9 @@
 import { browser, logging, element, by } from 'protractor';
 
 describe('workspace-project App', () => {
-  it('should display lazy route', () => {
-    browser.get(browser.baseUrl + '/lazy');
-    expect(element(by.css('app-lazy-comp p')).getText()).toEqual('lazy-comp works!');
+  it('should display lazy route', async () => {
+    await browser.get(browser.baseUrl + '/lazy');
+    expect(await element(by.css('app-lazy-comp p')).getText()).toEqual('lazy-comp works!');
   });
 
   afterEach(async () => {

--- a/tests/legacy-cli/e2e/assets/protractor-saucelabs.conf.js
+++ b/tests/legacy-cli/e2e/assets/protractor-saucelabs.conf.js
@@ -13,6 +13,7 @@ exports.config = {
   sauceUser: process.env['SAUCE_USERNAME'],
   sauceKey: process.env['SAUCE_ACCESS_KEY'],
 
+  SELENIUM_PROMISE_MANAGER: false,
   allScriptsTimeout: 11000,
   specs: ['./src/**/*.e2e-spec.ts'],
 

--- a/tests/legacy-cli/e2e/tests/build/lazy-load-syntax.ts
+++ b/tests/legacy-cli/e2e/tests/build/lazy-load-syntax.ts
@@ -56,9 +56,9 @@ export default async function () {
     import { browser, logging, element, by } from 'protractor';
 
     describe('workspace-project App', () => {
-      it('should display lazy route', () => {
-        browser.get(browser.baseUrl + '/lazy');
-        expect(element(by.css('app-lazy-comp p')).getText()).toEqual('lazy-comp works!');
+      it('should display lazy route', async () => {
+        await browser.get(browser.baseUrl + '/lazy');
+        expect(await element(by.css('app-lazy-comp p')).getText()).toEqual('lazy-comp works!');
       });
 
       afterEach(async () => {

--- a/tests/legacy-cli/e2e/tests/build/worker.ts
+++ b/tests/legacy-cli/e2e/tests/build/worker.ts
@@ -32,8 +32,8 @@ export default async function () {
     import { browser, logging } from 'protractor';
     describe('worker bundle', () => {
       it('should log worker messages', async () => {
-        const page = new AppPage();;
-        page.navigateTo();
+        const page = new AppPage();
+        await page.navigateTo();
         const logs = await browser.manage().logs().get(logging.Type.BROWSER);
         expect(logs.length).toEqual(1);
         expect(logs[0].message).toContain('page got message: worker response to hello');

--- a/tests/legacy-cli/e2e/tests/generate/library/library-consumption.ts
+++ b/tests/legacy-cli/e2e/tests/generate/library/library-consumption.ts
@@ -52,9 +52,9 @@ export default async function () {
         page = new AppPage();
       });
 
-      it('should display text from library component', () => {
-        page.navigateTo();
-        expect(element(by.css('lib-my-lib p')).getText()).toEqual('my-lib works!');
+      it('should display text from library component', async () => {
+        await page.navigateTo();
+        expect(await element(by.css('lib-my-lib p')).getText()).toEqual('my-lib works!');
       });
 
       afterEach(async () => {

--- a/tests/legacy-cli/e2e/tests/misc/live-reload.ts
+++ b/tests/legacy-cli/e2e/tests/misc/live-reload.ts
@@ -75,9 +75,9 @@ export default function temporarilyDisabledTest() { return Promise.resolve(); }
 //         import { browser } from 'protractor';
 
 //         describe('master-project App', function() {
-//           it('should wait', _ => {
-//             browser.get('/');
-//             browser.sleep(30000);
+//           it('should wait', async _ => {
+//             await browser.get('/');
+//             await browser.sleep(30000);
 //           });
 //         });
 //       `,

--- a/tests/legacy-cli/e2e/tests/misc/minimal-config.ts
+++ b/tests/legacy-cli/e2e/tests/misc/minimal-config.ts
@@ -27,10 +27,10 @@ export default function () {
         import { browser, element, by } from 'protractor';
 
         describe('minimal project App', function() {
-          it('should display message saying app works', () => {
+          it('should display message saying app works', async () => {
             browser.ignoreSynchronization = true;
-            browser.get('/');
-            let el = element(by.css('app-root h1')).getText();
+            await browser.get('/');
+            let el = await element(by.css('app-root h1')).getText();
             expect(el).toEqual('app works!');
           });
         });

--- a/tests/legacy-cli/e2e/tests/misc/third-party-decorators.ts
+++ b/tests/legacy-cli/e2e/tests/misc/third-party-decorators.ts
@@ -33,15 +33,15 @@ export default function () {
             page = new AppPage();
           });
 
-          it('should operate counter', () => {
-            page.navigateTo();
-            page.getIncrementButton().click();
-            page.getIncrementButton().click();
-            expect(page.getCounter()).toEqual('2');
-            page.getDecrementButton().click();
-            expect(page.getCounter()).toEqual('1');
-            page.getResetButton().click();
-            expect(page.getCounter()).toEqual('0');
+          it('should operate counter', async () => {
+            await page.navigateTo();
+            await page.getIncrementButton().click();
+            await page.getIncrementButton().click();
+            expect(await page.getCounter()).toEqual('2');
+            await page.getDecrementButton().click();
+            expect(await page.getCounter()).toEqual('1');
+            await page.getResetButton().click();
+            expect(await page.getCounter()).toEqual('0');
           });
         });
       `,


### PR DESCRIPTION
Protractor recently introduced a breaking change in version 6.0.0: no more custom control flow, everyone should use async/await instead.

Source: https://github.com/angular/protractor/blob/master/CHANGELOG.md
> Control flow is removed and you should use async await to run your tests.

This behaviour is already accessible in versions before 6.0.0 under the flag SELENIUM_PROMISE_MANAGER=false.

By setting this flag to false - which is the default in 6.0.0 - I hope to reduce the migration time of new users of Angular using the CLI and using Protractor for e2e.

I personnaly did the migration 2 years ago and I believe it is preferable to start directly in async/await mode. It makes the test easier to read and futurproof.