### PR TITLE
refactor(@angular-devkit/build-angular): add debug no mangle environment variable

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
@@ -23,6 +23,7 @@ import {
 import { RawSource } from 'webpack-sources';
 import { AssetPatternClass, ExtraEntryPoint } from '../../../browser/schema';
 import { BuildBrowserFeatures, fullDifferential } from '../../../utils';
+import { manglingDisabled } from '../../../utils/mangle-options';
 import { BundleBudgetPlugin } from '../../plugins/bundle-budget';
 import { CleanCssWebpackPlugin } from '../../plugins/cleancss-webpack-plugin';
 import { NamedLazyChunksPlugin } from '../../plugins/named-chunks-plugin';
@@ -362,6 +363,7 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
       // We also want to avoid mangling on server.
       // Name mangling is handled within the browser builder
       mangle:
+        !manglingDisabled &&
         buildOptions.platform !== 'server' &&
         (!differentialLoadingNeeded || (differentialLoadingNeeded && fullDifferential)),
     };

--- a/packages/angular_devkit/build_angular/src/utils/mangle-options.ts
+++ b/packages/angular_devkit/build_angular/src/utils/mangle-options.ts
@@ -1,0 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+const mangleVariable = process.env['NG_BUILD_MANGLE'];
+export const manglingDisabled =
+  !!mangleVariable && (mangleVariable === '0' || mangleVariable.toLowerCase() === 'false');

--- a/packages/angular_devkit/build_angular/src/utils/process-bundle.ts
+++ b/packages/angular_devkit/build_angular/src/utils/process-bundle.ts
@@ -9,6 +9,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { SourceMapConsumer, SourceMapGenerator } from 'source-map';
 import { minify } from 'terser';
+import { manglingDisabled } from './mangle-options';
 
 const { transformAsync } = require('@babel/core');
 const cacache = require('cacache');
@@ -134,7 +135,7 @@ async function processWorker(options: ProcessBundleOptions): Promise<void> {
     const result = minify(code, {
       compress: false,
       ecma: 5,
-      mangle: true,
+      mangle: !manglingDisabled,
       safari10: true,
       toplevel: true,
       output: {
@@ -184,7 +185,7 @@ async function mangleOriginal(options: ProcessBundleOptions): Promise<void> {
   const resultOriginal = minify(options.code, {
     compress: false,
     ecma: 6,
-    mangle: true,
+    mangle: !manglingDisabled,
     safari10: true,
     output: {
       ascii_only: true,


### PR DESCRIPTION
A debugging and troubleshooting aid to easily control name mangling independently of other optimizations without modifying code inside node modules.

`NG_BUILD_MANGLE=0 ng build --prod`