### PR TITLE
fix(@angular-devkit/build-angular): disable top level variable and fu…

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/process-bundle.ts
+++ b/packages/angular_devkit/build_angular/src/utils/process-bundle.ts
@@ -132,11 +132,10 @@ async function processWorker(options: ProcessBundleOptions): Promise<void> {
 
     // Mangle downlevel code
     const result = minify(code, {
-      compress: false,
+      compress: true,
       ecma: 5,
       mangle: true,
       safari10: true,
-      toplevel: true,
       output: {
         ascii_only: true,
         webkit: true,

--- a/tests/legacy-cli/e2e/tests/build/prod-build.ts
+++ b/tests/legacy-cli/e2e/tests/build/prod-build.ts
@@ -33,8 +33,8 @@ export default async function () {
   const argv = getGlobalVariable('argv');
   const veProject = argv['ve'];
   const bootstrapRegExp = veProject
-    ? /bootstrapModuleFactory\([$]?[a-zA-Z]+\)\./
-    : /bootstrapModule\([$]?[a-zA-Z]+\)\./;
+    ? /bootstrapModuleFactory\(.?[a-zA-Z]+\)\./
+    : /bootstrapModule\(.?[a-zA-Z]+\)\./;
 
   await ng('build', '--prod');
   await expectFileToExist(join(process.cwd(), 'dist'));


### PR DESCRIPTION
…nction name mangling

Disables toplevel mangling and enables compression for es5 bundles. With compress enabled we reduce a further ~7Kb

Closes: #15436