### PR TITLE
fix(@angular-devkit/build-angular): remove deprecation of `baseUrl` i…

### DIFF
--- a/packages/angular_devkit/build_angular/src/protractor/schema.json
+++ b/packages/angular_devkit/build_angular/src/protractor/schema.json
@@ -45,8 +45,7 @@
     },
     "baseUrl": {
       "type": "string",
-      "description": "Base URL for protractor to connect to.",
-      "x-deprecated": "Use \"baseUrl\" in the Protractor config file instead."
+      "description": "Base URL for protractor to connect to."
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
…n protractor builder

Closes #13952