### PR TITLE
ci: change resource_class for flake jail to medium

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -246,6 +246,7 @@ jobs:
   # and rerun them faster.
   flake-jail:
     executor: test-executor
+    resource_class: medium
     steps:
       - attach_workspace: *attach_options
       - run: yarn webdriver-update


### PR DESCRIPTION

This is by default set to xlarge in the test-executor which is not needed for flake-jail.