### PR TITLE
Small Feature - Adding pluralize to string utils

### DIFF
--- a/packages/angular_devkit/core/src/utils/strings.ts
+++ b/packages/angular_devkit/core/src/utils/strings.ts
@@ -176,3 +176,21 @@ export function levenshtein(a: string, b: string): number {
 
   return matrix[b.length][a.length];
 }
+
+/**
+ Returns the plural form of a string
+ ```javascript
+ 'innerHTML'.pluralize()         // 'innerHTMLs'
+ 'action_name'.pluralize()       // 'actionNames'
+ 'css-class-name'.pluralize()    // 'cssClassNames'
+ 'regex'.pluralize()            // 'regexes'
+ 'user'.pluralize()             // 'users'
+ ```
+ */
+export function pluralize(str: string): string {
+  return camelize(
+    [/([^aeiou])y$/, /()fe?$/, /([^aeiou]o|[sxz]|[cs]h)$/].map(
+      (c, i) => (str = str.replace(c, `$1${'iv'[i] || ''}e`))
+    ) && str + 's'
+  );
+}


### PR DESCRIPTION
when creating our own schemas, the function to pluralize is handy, as we're scaffolding new files.

stole the code from https://github.com/ngrx/platform/blob/master/modules/data/schematics-core/utility/strings.ts