### PR TITLE
Ivy app shell

### DIFF
--- a/packages/angular_devkit/build_angular/src/server/schema.json
+++ b/packages/angular_devkit/build_angular/src/server/schema.json
@@ -194,8 +194,8 @@
     },
     "bundleDependencies": {
       "type": "string",
-      "description": "Available on server platform only. Which external dependencies to bundle into the module. By default, all of node_modules will be kept as requires.",
-      "default": "none",
+      "description": "Available on server platform only. Which external dependencies to bundle into the module. By default, all of node_modules will be bundled.",
+      "default": "all",
       "enum": [
         "none",
         "all"

--- a/packages/angular_devkit/build_angular/test/app-shell/app-shell_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/app-shell/app-shell_spec_large.ts
@@ -9,12 +9,9 @@
 import { Architect } from '@angular-devkit/architect/src/architect';
 import { getSystemPath, join, normalize, virtualFs } from '@angular-devkit/core';
 import * as express from 'express'; // tslint:disable-line:no-implicit-dependencies
-import { createArchitect, host, veEnabled } from '../utils';
+import { createArchitect, host } from '../utils';
 
-
-// DISABLED_FOR_IVY   These should pass but are currently not supported
-// See https://github.com/angular/angular-cli/issues/15383 for details.
-(veEnabled ? describe : xdescribe)('AppShell Builder', () => {
+describe('AppShell Builder', () => {
   const target = { project: 'app', target: 'app-shell' };
   let architect: Architect;
 

--- a/packages/angular_devkit/build_angular/test/server/base_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/server/base_spec_large.ts
@@ -10,6 +10,7 @@ import { Architect } from '@angular-devkit/architect';
 import { getSystemPath, join, normalize, virtualFs } from '@angular-devkit/core';
 import { take, tap } from 'rxjs/operators';
 import { BrowserBuilderOutput } from '../../src/browser';
+import { BundleDependencies } from '../../src/server/schema';
 import { createArchitect, host, veEnabled } from '../utils';
 
 
@@ -85,6 +86,7 @@ describe('Server Builder', () => {
     });
 
     const run = await architect.scheduleTarget(target, {
+      bundleDependencies: BundleDependencies.None,
       sourceMap: {
         styles: false,
         scripts: true,
@@ -103,9 +105,10 @@ describe('Server Builder', () => {
 
     await run.stop();
   });
-  //
+
   it('supports component styles sourcemaps', async () => {
     const overrides = {
+      bundleDependencies: BundleDependencies.None,
       sourceMap: {
         styles: true,
         scripts: true,

--- a/packages/schematics/angular/migrations/update-9/index.ts
+++ b/packages/schematics/angular/migrations/update-9/index.ts
@@ -12,6 +12,7 @@ import { updateLibraries } from './ivy-libraries';
 import { updateNGSWConfig } from './ngsw-config';
 import { updateApplicationTsConfigs } from './update-app-tsconfigs';
 import { updateDependencies } from './update-dependencies';
+import { updateServerMainFile } from './update-server-main-file';
 import { updateWorkspaceConfig } from './update-workspace-config';
 
 export default function(): Rule {
@@ -22,6 +23,7 @@ export default function(): Rule {
       updateNGSWConfig(),
       updateApplicationTsConfigs(),
       updateDependencies(),
+      updateServerMainFile(),
       (tree, context) => {
         const packageChanges = tree.actions.some(a => a.path.endsWith('/package.json'));
         if (packageChanges) {

--- a/packages/schematics/angular/migrations/update-9/update-server-main-file.ts
+++ b/packages/schematics/angular/migrations/update-9/update-server-main-file.ts
@@ -1,0 +1,143 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { Rule } from '@angular-devkit/schematics';
+import * as ts from '../../third_party/github.com/Microsoft/TypeScript/lib/typescript';
+import { findNodes } from '../../utility/ast-utils';
+import { findPropertyInAstObject } from '../../utility/json-utils';
+import { Builders } from '../../utility/workspace-models';
+import { getTargets, getWorkspace } from './utils';
+
+/**
+ * Update the `main.server.ts` file by adding exports to `renderModule` and `renderModuleFactory` which are
+ * now required for Universal and App-Shell for Ivy and `bundleDependencies`.
+ */
+export function updateServerMainFile(): Rule {
+  return tree => {
+    const workspace = getWorkspace(tree);
+
+    for (const { target } of getTargets(workspace, 'server', Builders.Server)) {
+      const options = findPropertyInAstObject(target, 'options');
+      if (!options || options.kind !== 'object') {
+        continue;
+      }
+
+      // find the main server file
+      const mainFile = findPropertyInAstObject(options, 'main');
+      if (!mainFile || typeof mainFile.value !== 'string') {
+        continue;
+      }
+
+      const mainFilePath = mainFile.value;
+
+      const content = tree.read(mainFilePath);
+      if (!content) {
+        continue;
+      }
+
+      const source = ts.createSourceFile(
+        mainFilePath,
+        content.toString().replace(/^\uFEFF/, ''),
+        ts.ScriptTarget.Latest,
+        true,
+      );
+
+      // find exports in main server file
+      const exportDeclarations = findNodes(source, ts.SyntaxKind.ExportDeclaration) as ts.ExportDeclaration[];
+
+      const platformServerExports = exportDeclarations.filter(({ moduleSpecifier }) => (
+        moduleSpecifier && ts.isStringLiteral(moduleSpecifier) && moduleSpecifier.text === '@angular/platform-server'
+      ));
+
+      let hasRenderModule = false;
+      let hasRenderModuleFactory = false;
+
+      // find exports of renderModule or renderModuleFactory
+      for (const { exportClause } of platformServerExports) {
+        if (exportClause && ts.isNamedExports(exportClause)) {
+          if (!hasRenderModuleFactory) {
+            hasRenderModuleFactory = exportClause.elements.some(({ name }) => name.text === 'renderModuleFactory');
+          }
+
+          if (!hasRenderModule) {
+            hasRenderModule = exportClause.elements.some(({ name }) => name.text === 'renderModule');
+          }
+        }
+      }
+
+      if (hasRenderModule && hasRenderModuleFactory) {
+        // We have both required exports
+        continue;
+      }
+
+      let exportSpecifiers: ts.ExportSpecifier[] = [];
+      let updateExisting = false;
+
+      // Add missing exports
+      if (platformServerExports.length) {
+        const { exportClause } = platformServerExports[0] as ts.ExportDeclaration;
+        if (!exportClause) {
+          continue;
+        }
+
+        exportSpecifiers = [...exportClause.elements];
+        updateExisting = true;
+      }
+
+      if (!hasRenderModule) {
+        exportSpecifiers.push(ts.createExportSpecifier(
+          undefined,
+          ts.createIdentifier('renderModule'),
+        ));
+      }
+
+      if (!hasRenderModuleFactory) {
+        exportSpecifiers.push(ts.createExportSpecifier(
+          undefined,
+          ts.createIdentifier('renderModuleFactory'),
+        ));
+      }
+
+      // Create a TS printer to get the text of the export node
+      const printer = ts.createPrinter();
+
+      const moduleSpecifier = ts.createStringLiteral('@angular/platform-server');
+
+      // TypeScript will emit the Node with double quotes.
+      // In schematics we usually write code with a single quotes
+      // tslint:disable-next-line: no-any
+      (moduleSpecifier as any).singleQuote = true;
+
+      const newExportDeclarationText = printer.printNode(
+        ts.EmitHint.Unspecified,
+        ts.createExportDeclaration(
+          undefined,
+          undefined,
+          ts.createNamedExports(exportSpecifiers),
+          moduleSpecifier,
+        ),
+        source,
+      );
+
+      const recorder = tree.beginUpdate(mainFilePath);
+      if (updateExisting) {
+        const start = platformServerExports[0].getStart();
+        const width = platformServerExports[0].getWidth();
+
+        recorder
+          .remove(start, width)
+          .insertLeft(start, newExportDeclarationText);
+      } else {
+        recorder.insertLeft(source.getWidth(), '\n' + newExportDeclarationText);
+      }
+
+      tree.commitUpdate(recorder);
+    }
+
+    return tree;
+  };
+}

--- a/packages/schematics/angular/migrations/update-9/update-server-main-file_spec.ts
+++ b/packages/schematics/angular/migrations/update-9/update-server-main-file_spec.ts
@@ -1,0 +1,108 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { tags } from '@angular-devkit/core';
+import { EmptyTree } from '@angular-devkit/schematics';
+import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';
+
+const mainServerContent = tags.stripIndents`
+  import { enableProdMode } from '@angular/core';
+
+  import { environment } from './environments/environment';
+
+  if (environment.production) {
+    enableProdMode();
+  }
+
+  export { AppServerModule } from './app/app.server.module';
+`;
+
+const mainServerFile = 'src/main.server.ts';
+
+describe('Migration to version 9', () => {
+  describe('Migrate Server Main File', () => {
+    const schematicRunner = new SchematicTestRunner(
+      'migrations',
+      require.resolve('../migration-collection.json'),
+    );
+
+    let tree: UnitTestTree;
+
+    beforeEach(async () => {
+      tree = new UnitTestTree(new EmptyTree());
+      tree = await schematicRunner
+        .runExternalSchematicAsync(
+          require.resolve('../../collection.json'),
+          'ng-new',
+          {
+            name: 'migration-test',
+            version: '1.2.3',
+            directory: '.',
+          },
+          tree,
+        )
+        .toPromise();
+      tree = await schematicRunner
+        .runExternalSchematicAsync(
+          require.resolve('../../collection.json'),
+          'universal',
+          {
+            clientProject: 'migration-test',
+          },
+          tree,
+        )
+        .toPromise();
+    });
+
+    it(`should add exports from '@angular/platform-server'`, async () => {
+      tree.overwrite(mainServerFile, mainServerContent);
+      const tree2 = await schematicRunner.runSchematicAsync('migration-09', {}, tree.branch()).toPromise();
+      expect(tree2.readContent(mainServerFile)).toContain(tags.stripIndents`
+        export { AppServerModule } from './app/app.server.module';
+        export { renderModule, renderModuleFactory } from '@angular/platform-server';
+      `);
+    });
+
+    it(`should add 'renderModule' and 'renderModuleFactory' to existing '@angular/platform-server' export`, async () => {
+      tree.overwrite(mainServerFile, tags.stripIndents`
+        ${mainServerContent}
+        export { platformDynamicServer } from '@angular/platform-server';
+        export { PlatformConfig } from '@angular/platform-server';
+      `);
+      const tree2 = await schematicRunner.runSchematicAsync('migration-09', {}, tree.branch()).toPromise();
+      expect(tree2.readContent(mainServerFile)).toContain(tags.stripIndents`
+        export { AppServerModule } from './app/app.server.module';
+        export { platformDynamicServer, renderModule, renderModuleFactory } from '@angular/platform-server';
+        export { PlatformConfig } from '@angular/platform-server';
+      `);
+    });
+
+    it(`should add 'renderModule' to existing '@angular/platform-server' export`, async () => {
+      tree.overwrite(mainServerFile, tags.stripIndents`
+        ${mainServerContent}
+        export { platformDynamicServer, renderModuleFactory } from '@angular/platform-server';
+      `);
+      const tree2 = await schematicRunner.runSchematicAsync('migration-09', {}, tree.branch()).toPromise();
+      expect(tree2.readContent(mainServerFile)).toContain(tags.stripIndents`
+        export { AppServerModule } from './app/app.server.module';
+        export { platformDynamicServer, renderModuleFactory, renderModule } from '@angular/platform-server';
+      `);
+    });
+
+    it(`should not update exports when 'renderModule' and 'renderModuleFactory' are already exported`, async () => {
+      const input = tags.stripIndents`
+        ${mainServerContent}
+        export { renderModule, renderModuleFactory } from '@angular/platform-server';
+      `;
+
+      tree.overwrite(mainServerFile, input);
+      const tree2 = await schematicRunner.runSchematicAsync('migration-09', {}, tree.branch()).toPromise();
+      expect(tree2.readContent(mainServerFile)).toBe(input);
+    });
+  });
+});

--- a/packages/schematics/angular/universal/files/src/__main@stripTsExtension__.ts.template
+++ b/packages/schematics/angular/universal/files/src/__main@stripTsExtension__.ts.template
@@ -7,4 +7,4 @@ if (environment.production) {
 }
 
 export { <%= rootModuleClassName %> } from './app/<%= stripTsExtension(rootModuleFileName) %>';
-export { renderModule } from '@angular/platform-server';
+export { renderModule, renderModuleFactory } from '@angular/platform-server';

--- a/packages/schematics/angular/universal/files/src/__main@stripTsExtension__.ts.template
+++ b/packages/schematics/angular/universal/files/src/__main@stripTsExtension__.ts.template
@@ -7,3 +7,4 @@ if (environment.production) {
 }
 
 export { <%= rootModuleClassName %> } from './app/<%= stripTsExtension(rootModuleFileName) %>';
+export { renderModule } from '@angular/platform-server';

--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -8,7 +8,7 @@
 // tslint:disable:no-console
 // tslint:disable:no-implicit-dependencies
 import { logging } from '@angular-devkit/core';
-import { spawnSync } from 'child_process';
+import { execSync, spawnSync } from 'child_process';
 import * as glob from 'glob';
 import 'jasmine';
 import { SpecReporter as JasmineSpecReporter } from 'jasmine-spec-reporter';
@@ -23,8 +23,6 @@ const knownFlakes = [
   // Rebuild tests in test-large are flakey if not run as the first suite.
   // https://github.com/angular/angular-cli/pull/15204
   'packages/angular_devkit/build_angular/test/browser/rebuild_spec_large.ts',
-  // This is flaky with NGCC
-  'packages/angular_devkit/build_angular/test/karma/selected_spec_large.ts',
 ];
 
 const projectBaseDir = join(__dirname, '..');
@@ -94,6 +92,10 @@ export default function(args: ParsedArgs, logger: logging.Logger) {
   if (args['ve']) {
     // tslint:disable-next-line:no-console
     console.warn('********* VE Enabled ***********');
+  } else if (args.shard !== undefined) {
+    // CI is really flaky with NGCC
+    // This is a working around test order and isolation issues.
+    execSync('./node_modules/.bin/ivy-ngcc', { stdio: 'inherit' });
   }
 
   if (args.large) {

--- a/tests/angular_devkit/build_angular/hello-world-app-ve/src/main.server.ts
+++ b/tests/angular_devkit/build_angular/hello-world-app-ve/src/main.server.ts
@@ -14,4 +14,4 @@ if (environment.production) {
 }
 
 export { AppServerModule } from './app/app.server.module';
-export { renderModuleFactory } from '@angular/platform-server';
+export { renderModule, renderModuleFactory } from '@angular/platform-server';

--- a/tests/angular_devkit/build_angular/hello-world-app-ve/src/main.server.ts
+++ b/tests/angular_devkit/build_angular/hello-world-app-ve/src/main.server.ts
@@ -14,3 +14,4 @@ if (environment.production) {
 }
 
 export { AppServerModule } from './app/app.server.module';
+export { renderModuleFactory } from '@angular/platform-server';

--- a/tests/angular_devkit/build_angular/hello-world-app/src/app/app.module.ts
+++ b/tests/angular_devkit/build_angular/hello-world-app/src/app/app.module.ts
@@ -8,12 +8,18 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 
+
 import { AppComponent } from './app.component';
 
+
 @NgModule({
-  declarations: [AppComponent],
-  imports: [BrowserModule],
+  declarations: [
+    AppComponent
+  ],
+  imports: [
+    BrowserModule
+  ],
   providers: [],
-  bootstrap: [AppComponent],
+  bootstrap: [AppComponent]
 })
-export class AppModule {}
+export class AppModule { }

--- a/tests/angular_devkit/build_angular/hello-world-app/src/app/app.server.module.ts
+++ b/tests/angular_devkit/build_angular/hello-world-app/src/app/app.server.module.ts
@@ -12,7 +12,10 @@ import { AppModule } from './app.module';
 import { AppComponent } from './app.component';
 
 @NgModule({
-  imports: [AppModule, ServerModule],
+  imports: [
+    AppModule,
+    ServerModule,
+  ],
   bootstrap: [AppComponent],
 })
 export class AppServerModule {}

--- a/tests/angular_devkit/build_angular/hello-world-app/src/main.server.ts
+++ b/tests/angular_devkit/build_angular/hello-world-app/src/main.server.ts
@@ -14,4 +14,4 @@ if (environment.production) {
 }
 
 export { AppServerModule } from './app/app.server.module';
-export { renderModule } from '@angular/platform-server';
+export { renderModule, renderModuleFactory } from '@angular/platform-server';

--- a/tests/angular_devkit/build_angular/hello-world-app/src/main.server.ts
+++ b/tests/angular_devkit/build_angular/hello-world-app/src/main.server.ts
@@ -14,3 +14,4 @@ if (environment.production) {
 }
 
 export { AppServerModule } from './app/app.server.module';
+export { renderModule } from '@angular/platform-server';

--- a/tests/legacy-cli/e2e/tests/build/build-app-shell-with-schematic.ts
+++ b/tests/legacy-cli/e2e/tests/build/build-app-shell-with-schematic.ts
@@ -22,4 +22,7 @@ export default async function () {
   await silentNpm('install');
   await ng('run', 'test-project:app-shell');
   await expectFileToMatch('dist/test-project/index.html', /app-shell works!/);
+
+  await ng('run', 'test-project:app-shell:production');
+  await expectFileToMatch('dist/test-project/index.html', /app-shell works!/);
 }

--- a/tests/legacy-cli/e2e/tests/build/build-app-shell-with-schematic.ts
+++ b/tests/legacy-cli/e2e/tests/build/build-app-shell-with-schematic.ts
@@ -1,5 +1,5 @@
 import { getGlobalVariable } from '../../utils/env';
-import { appendToFile, expectFileToMatch, replaceInFile } from '../../utils/fs';
+import { appendToFile, expectFileToMatch } from '../../utils/fs';
 import { ng, silentNpm } from '../../utils/process';
 import { updateJsonFile } from '../../utils/project';
 import { readNgVersion } from '../../utils/version';
@@ -14,10 +14,6 @@ export default async function () {
       ? 'github:angular/platform-server-builds'
       : readNgVersion();
   });
-
-  if (argv['ve']) {
-    await replaceInFile('src/main.server.ts', /renderModule/g, 'renderModuleFactory');
-  }
 
   await silentNpm('install');
   await ng('run', 'test-project:app-shell');

--- a/tests/legacy-cli/e2e/tests/build/build-app-shell-with-schematic.ts
+++ b/tests/legacy-cli/e2e/tests/build/build-app-shell-with-schematic.ts
@@ -1,16 +1,11 @@
 import { getGlobalVariable } from '../../utils/env';
-import { appendToFile, expectFileToMatch } from '../../utils/fs';
+import { appendToFile, expectFileToMatch, replaceInFile } from '../../utils/fs';
 import { ng, silentNpm } from '../../utils/process';
 import { updateJsonFile } from '../../utils/project';
 import { readNgVersion } from '../../utils/version';
 
 
 export default async function () {
-  // Skip this test in Angular 2/4.
-  if (getGlobalVariable('argv').ng2 || getGlobalVariable('argv').ng4) {
-    return;
-  }
-
   await appendToFile('src/app/app.component.html', '<router-outlet></router-outlet>');
   await ng('generate', 'appShell', '--client-project', 'test-project');
   await updateJsonFile('package.json', packageJson => {
@@ -19,6 +14,10 @@ export default async function () {
       ? 'github:angular/platform-server-builds'
       : readNgVersion();
   });
+
+  if (argv['ve']) {
+    await replaceInFile('src/main.server.ts', /renderModule/g, 'renderModuleFactory');
+  }
 
   await silentNpm('install');
   await ng('run', 'test-project:app-shell');

--- a/tests/legacy-cli/e2e/tests/build/build-app-shell.ts
+++ b/tests/legacy-cli/e2e/tests/build/build-app-shell.ts
@@ -72,7 +72,7 @@ export default function() {
       }
 
       export { AppServerModule } from './app/app.server.module';
-      export { renderModule${veProject ? 'Factory' : ''} } from '@angular/platform-server';
+      export { renderModule, renderModuleFactory } from '@angular/platform-server';
     `,
       ),
     )

--- a/tests/legacy-cli/e2e/tests/build/build-app-shell.ts
+++ b/tests/legacy-cli/e2e/tests/build/build-app-shell.ts
@@ -6,13 +6,7 @@ import { updateJsonFile } from '../../utils/project';
 import { readNgVersion } from '../../utils/version';
 
 export default function() {
-  // Skip this test in Angular 2/4.
-  if (getGlobalVariable('argv').ng2 || getGlobalVariable('argv').ng4) {
-    return Promise.resolve();
-  }
-
   let platformServerVersion = readNgVersion();
-  let httpVersion = readNgVersion();
 
   if (getGlobalVariable('argv')['ng-snapshots']) {
     platformServerVersion = 'github:angular/platform-server-builds';
@@ -78,6 +72,7 @@ export default function() {
       }
 
       export { AppServerModule } from './app/app.server.module';
+      export { renderModule${veProject ? 'Factory' : ''} } from '@angular/platform-server';
     `,
       ),
     )

--- a/tests/legacy-cli/e2e/tests/build/platform-server.ts
+++ b/tests/legacy-cli/e2e/tests/build/platform-server.ts
@@ -20,13 +20,12 @@ export default async function () {
 
   await silentNpm('install');
   if (veEnabled) {
-    await replaceInFile('src/main.server.ts', /renderModule/g, 'renderModuleFactory');
     await writeFile(
       './index.js',
       ` require('zone.js/dist/zone-node');
         const fs = require('fs');
         const { AppServerModuleNgFactory, renderModuleFactory } = require('./dist/server/main');
-  
+
         renderModuleFactory(AppServerModuleNgFactory, {
           url: '/',
           document: '<app-root></app-root>'
@@ -41,7 +40,7 @@ export default async function () {
       ` require('zone.js/dist/zone-node');
         const fs = require('fs');
         const { AppServerModule, renderModule } = require('./dist/server/main');
-  
+
         renderModule(AppServerModule, {
           url: '/',
           document: '<app-root></app-root>'

--- a/tests/legacy-cli/e2e_runner.ts
+++ b/tests/legacy-cli/e2e_runner.ts
@@ -102,13 +102,6 @@ if (!argv.ve) {
     // Ivy doesn't support i18n externally at the moment.
     .filter(name => !name.includes('tests/i18n/'))
     .filter(name => !name.endsWith('tests/build/aot/aot-i18n.ts'))
-    // We don't have a platform-server usage story yet for Ivy.
-    // It's contingent on lazy loading and factory shim considerations that are still being
-    // discussed.
-    // Broken currently https://github.com/angular/angular-cli/issues/15383
-    .filter(name => !name.endsWith('tests/build/platform-server.ts'))
-    .filter(name => !name.endsWith('tests/build/build-app-shell.ts'))
-    .filter(name => !name.endsWith('tests/build/build-app-shell-with-schematic.ts'));
 }
 
 const shardId = 'shard' in argv ? argv['shard'] : null;


### PR DESCRIPTION
**feat(@angular-devkit/build-angular): enable bundleDependencies by default for server builder**

BREAKING CHANGE: bundleDependencies default value has been changed from none to all. This will result in all of node_modules to be bundled in the final server bundle.

Under Ivy, if users choose to opt-out from bundling dependencies they will need to run NGCC binary manually to make non-bundled node_modules compatible with Ivy.

**feat(@schematics/angular): add export to `renderModule` in server main file**

This will be used by universal and app-shell to render the server module

**fix(@angular-devkit/build-angular): make app-shell work with Ivy**
Fixes #15383

**feat(@schematics/angular): add export to `renderModuleFactory`  in server main file**
 
**feat(@schematics/angular): add migration to add missing exports in main server file**

Update the `main.server.ts` file by adding exports to `renderModule` and `renderModuleFactory` which are now required for Universal and App-Shell for Ivy and `bundleDependencies`.