### PR TITLE
feat(@schematics/angular): minimal=true should not create tests files when using `ng generate` command

### DIFF
--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -168,7 +168,7 @@ function addAppToWorkspaceFile(options: ApplicationOptions, appDir: string): Rul
     schematics['@schematics/angular:component'] = componentSchematicsOptions;
   }
 
-  if (options.skipTests === true) {
+  if (options.skipTests || options.minimal) {
     ['class', 'component', 'directive', 'guard', 'module', 'pipe', 'service'].forEach((type) => {
       if (!(`@schematics/angular:${type}` in schematics)) {
         schematics[`@schematics/angular:${type}`] = {};


### PR DESCRIPTION
Before this commit:
`--minimal=true` create project without any testing frameworks and disable e2e, lint, test targets. Thereafter, if in this minimal project we try command `ng generate class|component|directive|guard|module|pipe|service`, it will always create `*_spec.ts` files.

After this commit:
`--minimal=true` override `@schematics/angular` in `angular.json` to not create `*_spec.ts` files when using `ng generate *` commands.