### PR TITLE
ci: update saucelabs protractor config to run e2e tests in series rather than parallel

### DIFF
--- a/tests/legacy-cli/e2e/assets/protractor-saucelabs.conf.js
+++ b/tests/legacy-cli/e2e/assets/protractor-saucelabs.conf.js
@@ -101,6 +101,9 @@ exports.config = {
     },
   ],
 
+  // Only allow one session at a time to prevent over saturation of Saucelabs sessions.
+  maxSessions: 1,
+
   baseUrl: 'http://localhost:2000/',
   framework: 'jasmine',
   jasmineNodeOpts: {


### PR DESCRIPTION
Our combined CI usage is often hitting the max number of concurrent sessions on saucelabs.  Currentl the saucelabs job takes 12 sessions at once because the tests run in parallel, instead we should run these in series to only use 1 session.  

It should not have a large impact on overall CI run time as each of the tests take ~10 seconds so we are moving from the Saucelabs steps taking ~1:45 to ~3:00 each.  Based on previous CI runs it looks like this change will still cause the saucelabs test runs to complete ~15 minutes before other jobs in the sequence.