### PR TITLE
fix(@angular-devkit/build-angular): disable extract comments for webpack terser plugin

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
@@ -374,6 +374,7 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
         sourceMap: scriptsSourceMap,
         parallel: true,
         cache: true,
+        extractComments: false,
         terserOptions,
       }),
     );


### PR DESCRIPTION
terser-webpack-plugin 2.0.0+ enables the extract comments option by default which is not used by the CLI.

terser-webpack plugin update PR: #15538