### PR TITLE
build: update minimum npm/yarn engine versions for built packages

### DIFF
--- a/lib/packages.ts
+++ b/lib/packages.ts
@@ -83,7 +83,9 @@ function loadPackageJson(p: string) {
       case 'engines':
         pkg['engines'] = {
           'node': '>= 10.9.0',
-          'npm': '>= 6.2.0',
+          'npm': '>= 6.11.0',
+          'pnpm': '>= 3.2.0',
+          'yarn': '>= 1.13.0',
         };
         break;
 


### PR DESCRIPTION
The `peerDependenciesMeta` package.json field is becoming increasingly prevalent.  The minimum versions in this change provide support for the field and mitigate incorrect peer dependency warnings for end users.

npm: https://github.com/npm/cli/blob/fc5fc76182c0746433c84a7208877fb70ef62352/CHANGELOG.md#v6110-2019-08-20
yarn: https://github.com/yarnpkg/yarn/blob/53d8004229f543f342833310d5af63a4b6e59c8a/CHANGELOG.md#1130
pnpm:
https://github.com/pnpm/pnpm/releases/tag/v3.2.0