### PR TITLE
feat(@angular-devkit/core): auto discover multiselect schema prompt types

### DIFF
--- a/etc/api/angular_devkit/core/src/_golden-api.d.ts
+++ b/etc/api/angular_devkit/core/src/_golden-api.d.ts
@@ -798,7 +798,7 @@ export interface PromptDefinition {
     multiselect?: boolean;
     raw?: string | JsonObject;
     type: string;
-    validator?: (value: string) => boolean | string | Promise<boolean | string>;
+    validator?: (value: JsonValue) => boolean | string | Promise<boolean | string>;
 }
 
 export declare type PromptProvider = (definitions: Array<PromptDefinition>) => SubscribableOrPromise<{

--- a/packages/angular_devkit/core/src/json/schema/interface.ts
+++ b/packages/angular_devkit/core/src/json/schema/interface.ts
@@ -100,7 +100,7 @@ export interface PromptDefinition {
   type: string;
   message: string;
   default?: string | string[] | number | boolean | null;
-  validator?: (value: string) => boolean | string | Promise<boolean | string>;
+  validator?: (value: JsonValue) => boolean | string | Promise<boolean | string>;
 
   items?: Array<string | { value: JsonValue, label: string }>;
 

--- a/packages/angular_devkit/core/src/json/schema/prompt_spec.ts
+++ b/packages/angular_devkit/core/src/json/schema/prompt_spec.ts
@@ -262,7 +262,7 @@ describe('Prompt Provider', () => {
         .toPromise().then(done, done.fail);
     });
 
-    it('analyzes list with multiselect option and object items', done => {
+    it('analyzes list with true multiselect option and object items', done => {
       const registry = new CoreSchemaRegistry();
       const data: any = {};
 
@@ -301,6 +301,45 @@ describe('Prompt Provider', () => {
         .toPromise().then(done, done.fail);
     });
 
+    it('analyzes list with false multiselect option and object items', done => {
+      const registry = new CoreSchemaRegistry();
+      const data: any = {};
+
+      registry.usePromptProvider(async definitions => {
+        expect(definitions.length).toBe(1);
+        expect(definitions[0].type).toBe('list');
+        expect(definitions[0].multiselect).toBe(false);
+        expect(definitions[0].items).toEqual([
+          { 'value': 'one', 'label': 'one' },
+          { 'value': 'two', 'label': 'two' },
+        ]);
+
+        return { [definitions[0].id]: { 'value': 'one', 'label': 'one' } };
+      });
+
+      registry
+        .compile({
+          properties: {
+            test: {
+              type: 'array',
+              'x-prompt': {
+                'type': 'list',
+                'multiselect': false,
+                'items': [
+                  { 'value': 'one', 'label': 'one' },
+                  { 'value': 'two', 'label': 'two' },
+                ],
+                'message': 'test-message',
+              },
+            },
+          },
+        })
+        .pipe(
+          mergeMap(validator => validator(data)),
+        )
+        .toPromise().then(done, done.fail);
+    });
+
     it('analyzes list without multiselect option and object items', done => {
       const registry = new CoreSchemaRegistry();
       const data: any = {};
@@ -308,7 +347,7 @@ describe('Prompt Provider', () => {
       registry.usePromptProvider(async definitions => {
         expect(definitions.length).toBe(1);
         expect(definitions[0].type).toBe('list');
-        expect(definitions[0].multiselect).toBeUndefined();
+        expect(definitions[0].multiselect).toBe(true);
         expect(definitions[0].items).toEqual([
           { 'value': 'one', 'label': 'one' },
           { 'value': 'two', 'label': 'two' },
@@ -346,6 +385,7 @@ describe('Prompt Provider', () => {
       registry.usePromptProvider(async definitions => {
         expect(definitions.length).toBe(1);
         expect(definitions[0].type).toBe('list');
+        expect(definitions[0].multiselect).toBeFalsy();
         expect(definitions[0].items).toEqual([
           'one',
           'two',
@@ -368,6 +408,45 @@ describe('Prompt Provider', () => {
               'x-prompt': {
                 'message': 'test-message',
               },
+            },
+          },
+        })
+        .pipe(
+          mergeMap(validator => validator(data)),
+        )
+        .toPromise().then(done, done.fail);
+    });
+
+    it('analyzes enums WITHOUT explicit list type and multiselect', done => {
+      const registry = new CoreSchemaRegistry();
+      const data: any = {};
+
+      registry.usePromptProvider(async definitions => {
+        expect(definitions.length).toBe(1);
+        expect(definitions[0].type).toBe('list');
+        expect(definitions[0].multiselect).toBe(true);
+        expect(definitions[0].items).toEqual([
+          'one',
+          'two',
+          'three',
+        ]);
+
+        return {};
+      });
+
+      registry
+        .compile({
+          properties: {
+            test: {
+              type: 'array',
+              items: {
+                enum: [
+                  'one',
+                  'two',
+                  'three',
+                ],
+              },
+              'x-prompt': 'test-message',
             },
           },
         })

--- a/packages/schematics/angular/guard/schema.json
+++ b/packages/schematics/angular/guard/schema.json
@@ -54,6 +54,7 @@
       "type": "array",
       "description": "Specifies which interfaces to implement.",
       "uniqueItems": true,
+      "minItems": 1,
       "items": {
         "enum": [
           "CanActivate",
@@ -65,17 +66,7 @@
       "default": [
         "CanActivate"
       ],
-      "minItems": 1,
-      "x-prompt": {
-        "message": "Which interfaces would you like to implement?",
-        "type": "list",
-        "multiselect": true,
-        "items": [
-          "CanActivate",
-          "CanActivateChild",
-          "CanLoad"
-        ]
-      }
+      "x-prompt": "Which interfaces would you like to implement?"
     }
   },
   "required": [


### PR DESCRIPTION
If a prompt is present on a schema property and the type is an array with a set of enum values, then the prompt type is a list with multiselect capabilites.  This eliminates the need to specify the longhand form for typical multiselect prompts.