### PR TITLE
fix(@angular/cli): support the sublevel names of projects

### DIFF
--- a/packages/angular/cli/lib/config/schema.json
+++ b/packages/angular/cli/lib/config/schema.json
@@ -27,7 +27,7 @@
     "projects": {
       "type": "object",
       "patternProperties": {
-        "^[a-zA-Z][.0-9a-zA-Z]*(-[.0-9a-zA-Z]*)*$": {
+        "^(?:@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$": {
           "$ref": "#/definitions/project"
         }
       },


### PR DESCRIPTION
change projects.patternProperties to npm.name.pattern

Closes #14797