### PR TITLE
build: remove renovate ignore of webpack-subresource-integrity

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,8 +18,7 @@
     "master"
   ],
   "ignoreDeps": [
-    "@types/node",
-    "webpack-subresource-integrity"
+    "@types/node"
   ],
   "packageFiles": [
     "WORKSPACE",


### PR DESCRIPTION
As of v6.11.0, npm supports optional peer dependencies.  This prevents webpack-subresource-integrity from showing peer dependency warnings for its optional peer dependency on html-webpack-plugin.