### PR TITLE
feat(@angular-devkit/build-angular):  ignore express and hapi depeden…

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/server.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/server.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import { isAbsolute } from 'path';
-import { Configuration } from 'webpack';
+import { Configuration, ContextReplacementPlugin } from 'webpack';
 import { WebpackConfigOptions } from '../build-options';
 import { getSourceMapDevTool } from './utils';
 
@@ -30,7 +30,12 @@ export function getServerConfig(wco: WebpackConfigOptions): Configuration {
     output: {
       libraryTarget: 'commonjs',
     },
-    plugins: extraPlugins,
+    plugins: [
+      // Fixes Critical dependency: the request of a dependency is an expression
+      new ContextReplacementPlugin(/@?hapi(\\|\/)/),
+      new ContextReplacementPlugin(/express(\\|\/)/),
+      ...extraPlugins,
+    ],
     node: false,
   };
 


### PR DESCRIPTION
…cy expresstion

In version 9 universal express and hapi `server.ts` will be bundled using the CLI server builder.

We need to add this to avoid `the request of a dependency is an expression` warnings

See: https://github.com/angular/universal/pull/1237