### PR TITLE
feat(@schematics/angular): add node types to universal tsconfig

### DIFF
--- a/packages/schematics/angular/universal/files/root/__tsconfigFileName__.json.template
+++ b/packages/schematics/angular/universal/files/root/__tsconfigFileName__.json.template
@@ -2,7 +2,10 @@
   "extends": "./<%= tsConfigExtends %>",
   "compilerOptions": {
     "outDir": "<%= outDir %>-server",
-    "module": "commonjs"
+    "module": "commonjs",
+    "types": [
+      "node"
+    ]
   },
   "files": [
     "src/<%= stripTsExtension(main) %>.ts"

--- a/packages/schematics/angular/universal/index_spec.ts
+++ b/packages/schematics/angular/universal/index_spec.ts
@@ -91,6 +91,7 @@ describe('Universal Schematic', () => {
       compilerOptions: {
         outDir: './out-tsc/app-server',
         module: 'commonjs',
+        types: ['node'],
       },
       files: [
         'src/main.server.ts',
@@ -115,6 +116,7 @@ describe('Universal Schematic', () => {
       compilerOptions: {
         outDir: '../../out-tsc/app-server',
         module: 'commonjs',
+        types: ['node'],
       },
       files: [
         'src/main.server.ts',


### PR DESCRIPTION
By default we disable types inclusion in tsconfig.app.json which this tsconfig extends from