### PR TITLE
ci: update schedule for locking inactive issues

### DIFF
--- a/.github/workflows/lock-closed.yml
+++ b/.github/workflows/lock-closed.yml
@@ -1,9 +1,9 @@
-name: Lock issues that are closed and inactive
+name: Lock Inactive Issues
 
 on:
   schedule:
-    # Run at the 40th minute of every hour
-    - cron: '40 * * * *'
+    # Run at 08:00 every day
+    - cron: '0 8 * * *'
 
 jobs:
   lock_closed:


### PR DESCRIPTION
Closes #15532 

Now that we have worked through the backlog of inactive closed issues. We will move to automatically locking issues once per day.