### PR TITLE
fix(@angular-devkit/build-angular): always use ECMA 5 optimizations with terser

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
@@ -332,11 +332,14 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
       }
     }
 
+    // TODO: Investigate why this fails for some packages: wco.supportES2015 ? 6 : 5;
+    const terserEcma = 5;
+
     const terserOptions = {
       warnings: !!buildOptions.verbose,
       safari10: true,
       output: {
-        ecma: wco.supportES2015 ? 6 : 5,
+        ecma: terserEcma,
         comments: false,
         webkit: true,
       },
@@ -345,12 +348,12 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
       compress:
         buildOptions.platform == 'server'
           ? {
-              ecma: wco.supportES2015 ? 6 : 5,
+              ecma: terserEcma,
               global_defs: angularGlobalDefinitions,
               keep_fnames: true,
             }
           : {
-              ecma: wco.supportES2015 ? 6 : 5,
+              ecma: terserEcma,
               pure_getters: buildOptions.buildOptimizer,
               // PURE comments work best with 3 passes.
               // See https://github.com/webpack/webpack/issues/2899#issuecomment-317425926.


### PR DESCRIPTION
There appears to be defects related to terser's ECMA 6 options.  The optimizations present a minimal size improvement in general and was the default for differential loading prior to #15566.  Further investigation is required to determine the underlying cause within terser.

Fixes #15580