### PR TITLE
fix(@angular/cli): ensure analytics postinstall script is ES5

### DIFF
--- a/packages/angular/cli/bin/postinstall/analytics-prompt.js
+++ b/packages/angular/cli/bin/postinstall/analytics-prompt.js
@@ -1,16 +1,14 @@
 'use strict';
-// This file is ES6 because it needs to be executed as is.
+// This file is ES5 because it needs to be executed as is.
 
-if ('NG_CLI_ANALYTICS' in process.env) {
+if (process.env['NG_CLI_ANALYTICS'] !== undefined) {
   return;
 }
 
-(async () => {
-  try {
-    const analytics = require('../../models/analytics');
+try {
+  var analytics = require('../../models/analytics');
 
-    if (!analytics.hasGlobalAnalyticsConfiguration()) {
-      await analytics.promptGlobalAnalytics();
-    }
-  } catch (_) {}
-})();
+  if (!analytics.hasGlobalAnalyticsConfiguration()) {
+    analytics.promptGlobalAnalytics().catch(function() { });
+  }
+} catch (_) {}


### PR DESCRIPTION
This can potentially execute on very old versions of Node.js and can crash otherwise.  The `ng` command itself has an initial Node.js version check that will then inform the user of the required minimum.