### PR TITLE
feat(@angular-devkit/architect): support accessing project metadata

### DIFF
--- a/etc/api/angular_devkit/architect/src/index.d.ts
+++ b/etc/api/angular_devkit/architect/src/index.d.ts
@@ -15,6 +15,8 @@ export interface BuilderContext {
     workspaceRoot: string;
     addTeardown(teardown: () => (Promise<void> | void)): void;
     getBuilderNameForTarget(target: Target): Promise<string>;
+    getProjectMetadata(target: Target): Promise<json.JsonObject>;
+    getProjectMetadata(projectName: string): Promise<json.JsonObject>;
     getTargetOptions(target: Target): Promise<json.JsonObject>;
     reportProgress(current: number, total?: number, status?: string): void;
     reportRunning(): void;

--- a/etc/api/angular_devkit/architect/testing/index.d.ts
+++ b/etc/api/angular_devkit/architect/testing/index.d.ts
@@ -8,6 +8,7 @@ export declare class TestingArchitectHost implements ArchitectHost {
     getBuilderNameForTarget(target: Target): Promise<string | null>;
     getCurrentDirectory(): Promise<string>;
     getOptionsForTarget(target: Target): Promise<json.JsonObject | null>;
+    getProjectMetadata(target: Target | string): Promise<json.JsonObject | null>;
     getWorkspaceRoot(): Promise<string>;
     loadBuilder(info: BuilderInfo): Promise<Builder | null>;
     resolveBuilder(builderName: string): Promise<BuilderInfo | null>;

--- a/packages/angular_devkit/architect/node/node-modules-architect-host.ts
+++ b/packages/angular_devkit/architect/node/node-modules-architect-host.ts
@@ -113,6 +113,29 @@ export class WorkspaceNodeModulesArchitectHost implements ArchitectHost<NodeModu
     };
   }
 
+  async getProjectMetadata(target: Target | string): Promise<json.JsonObject | null> {
+    const projectName = typeof target === 'string' ? target : target.project;
+
+    // NOTE: Remove conditional when deprecated support for experimental workspace API is removed.
+    if ('getProject' in this._workspace) {
+      return this._workspace.getProject(projectName) as unknown as json.JsonObject;
+    } else {
+      const projectDefinition = this._workspace.projects.get(projectName);
+      if (!projectDefinition) {
+        throw new Error('Project does not exist.');
+      }
+
+      const metadata = {
+        root: projectDefinition.root,
+        sourceRoot: projectDefinition.sourceRoot,
+        prefix: projectDefinition.prefix,
+        ...projectDefinition.extensions,
+      } as unknown as json.JsonObject;
+
+      return metadata;
+    }
+  }
+
   async loadBuilder(info: NodeModulesBuilderInfo): Promise<Builder> {
     const builder = (await import(info.import)).default;
     if (builder[BuilderSymbol]) {

--- a/packages/angular_devkit/architect/src/api.ts
+++ b/packages/angular_devkit/architect/src/api.ts
@@ -197,6 +197,9 @@ export interface BuilderContext {
    */
   getTargetOptions(target: Target): Promise<json.JsonObject>;
 
+  getProjectMetadata(projectName: string): Promise<json.JsonObject>;
+  getProjectMetadata(target: Target): Promise<json.JsonObject>;
+
   /**
    * Resolves and return a builder name. The exact format of the name is up to the host,
    * so it should not be parsed to gather information (it's free form). This string can be

--- a/packages/angular_devkit/architect/src/create-builder.ts
+++ b/packages/angular_devkit/architect/src/create-builder.ts
@@ -25,6 +25,7 @@ import { Builder, BuilderSymbol, BuilderVersionSymbol } from './internal';
 import { scheduleByName, scheduleByTarget } from './schedule-by-name';
 
 
+// tslint:disable-next-line: no-big-function
 export function createBuilder<
   OptT extends json.JsonObject,
   OutT extends BuilderOutput = BuilderOutput,
@@ -143,6 +144,10 @@ export function createBuilder<
           async getTargetOptions(target: Target) {
             return scheduler.schedule<Target, json.JsonValue, json.JsonObject>(
                     '..getTargetOptions', target).output.toPromise();
+          },
+          async getProjectMetadata(target: Target | string) {
+            return scheduler.schedule<Target | string, json.JsonValue, json.JsonObject>(
+                    '..getProjectMetadata', target).output.toPromise();
           },
           async getBuilderNameForTarget(target: Target) {
             return scheduler.schedule<Target, json.JsonValue, string>(

--- a/packages/angular_devkit/architect/src/internal.ts
+++ b/packages/angular_devkit/architect/src/internal.ts
@@ -78,4 +78,7 @@ export interface ArchitectHost<BuilderInfoT extends BuilderInfo = BuilderInfo> {
   getWorkspaceRoot(): Promise<string>;
 
   getOptionsForTarget(target: Target): Promise<json.JsonObject | null>;
+
+  getProjectMetadata(projectName: string): Promise<json.JsonObject | null>;
+  getProjectMetadata(target: Target): Promise<json.JsonObject | null>;
 }

--- a/packages/angular_devkit/architect/testing/testing-architect-host.ts
+++ b/packages/angular_devkit/architect/testing/testing-architect-host.ts
@@ -104,6 +104,10 @@ export class TestingArchitectHost implements ArchitectHost {
     return maybeTarget.options;
   }
 
+  async getProjectMetadata(target: Target | string): Promise<json.JsonObject | null> {
+    return this._backendHost && this._backendHost.getProjectMetadata(target as string);
+  }
+
   async loadBuilder(info: BuilderInfo): Promise<Builder | null> {
     return this._builderImportMap.get(info.builderName)
         || (this._backendHost && this._backendHost.loadBuilder(info));

--- a/packages/angular_devkit/build_angular/src/browser/index.ts
+++ b/packages/angular_devkit/build_angular/src/browser/index.ts
@@ -13,7 +13,6 @@ import {
   runWebpack,
 } from '@angular-devkit/build-webpack';
 import {
-  experimental,
   getSystemPath,
   join,
   json,
@@ -27,7 +26,6 @@ import { NodeJsSyncHost } from '@angular-devkit/core/node';
 import { createHash } from 'crypto';
 import * as findCacheDirectory from 'find-cache-dir';
 import * as fs from 'fs';
-import * as os from 'os';
 import * as path from 'path';
 import { from, of } from 'rxjs';
 import { bufferCount, catchError, concatMap, map, mergeScan, switchMap } from 'rxjs/operators';
@@ -109,7 +107,7 @@ export async function buildBrowserWebpackConfigFromContext(
   options: BrowserBuilderSchema,
   context: BuilderContext,
   host: virtualFs.Host<fs.Stats> = new NodeJsSyncHost(),
-): Promise<{ workspace: experimental.workspace.Workspace; config: webpack.Configuration[] }> {
+): Promise<{ config: webpack.Configuration[], projectRoot: string, projectSourceRoot?: string }> {
   return generateBrowserWebpackConfigFromContext(
     options,
     context,
@@ -161,8 +159,12 @@ async function initialize(
   context: BuilderContext,
   host: virtualFs.Host<fs.Stats>,
   webpackConfigurationTransform?: ExecutionTransformer<webpack.Configuration>,
-): Promise<{ workspace: experimental.workspace.Workspace; config: webpack.Configuration[] }> {
-  const { config, workspace } = await buildBrowserWebpackConfigFromContext(options, context, host);
+): Promise<{ config: webpack.Configuration[]; projectRoot: string; projectSourceRoot?: string }> {
+  const { config, projectRoot, projectSourceRoot } = await buildBrowserWebpackConfigFromContext(
+    options,
+    context,
+    host,
+  );
 
   let transformedConfig;
   if (webpackConfigurationTransform) {
@@ -180,7 +182,7 @@ async function initialize(
     ).toPromise();
   }
 
-  return { config: transformedConfig || config, workspace };
+  return { config: transformedConfig || config, projectRoot, projectSourceRoot };
 }
 
 // tslint:disable-next-line: no-big-function
@@ -204,23 +206,10 @@ export function buildWebpackBrowser(
 
   return from(initialize(options, context, host, transforms.webpackConfiguration)).pipe(
     // tslint:disable-next-line: no-big-function
-    switchMap(({ workspace, config: configs }) => {
-      const projectName = context.target
-        ? context.target.project
-        : workspace.getDefaultProjectName();
-
-      if (!projectName) {
-        throw new Error('Must either have a target from the context or a default project.');
-      }
-
-      const projectRoot = resolve(
-        workspace.root,
-        normalize(workspace.getProject(projectName).root),
-      );
-
+    switchMap(({ config: configs, projectRoot }) => {
       const tsConfig = readTsconfig(options.tsConfig, context.workspaceRoot);
       const target = tsConfig.options.target || ScriptTarget.ES5;
-      const buildBrowserFeatures = new BuildBrowserFeatures(getSystemPath(projectRoot), target);
+      const buildBrowserFeatures = new BuildBrowserFeatures(projectRoot, target);
 
       const isDifferentialLoadingNeeded = buildBrowserFeatures.isDifferentialLoadingNeeded();
 
@@ -551,7 +540,7 @@ export function buildWebpackBrowser(
               augmentAppWithServiceWorker(
                 host,
                 root,
-                projectRoot,
+                normalize(projectRoot),
                 resolve(root, normalize(options.outputPath)),
                 options.baseHref || '/',
                 options.ngswConfigPath,

--- a/packages/angular_devkit/build_angular/src/utils/webpack-browser-config.ts
+++ b/packages/angular_devkit/build_angular/src/utils/webpack-browser-config.ts
@@ -7,12 +7,10 @@
  */
 import { BuilderContext } from '@angular-devkit/architect';
 import {
-  experimental,
   getSystemPath,
   logging,
   normalize,
   resolve,
-  schema,
   virtualFs,
 } from '@angular-devkit/core';
 import { NodeJsSyncHost } from '@angular-devkit/core/node';
@@ -60,9 +58,10 @@ export async function generateWebpackConfig(
   // However this config generation is used by multiple builders such as dev-server
   const scriptTarget = tsConfig.options.target || ts.ScriptTarget.ES5;
   const buildBrowserFeatures = new BuildBrowserFeatures(projectRoot, scriptTarget);
-  const differentialLoading = context.builder.builderName === 'browser'
-    && !options.watch
-    && buildBrowserFeatures.isDifferentialLoadingNeeded();
+  const differentialLoading =
+    context.builder.builderName === 'browser' &&
+    !options.watch &&
+    buildBrowserFeatures.isDifferentialLoadingNeeded();
 
   const scriptTargets = [scriptTarget];
 
@@ -73,29 +72,32 @@ export async function generateWebpackConfig(
   // For differential loading, we can have several targets
   return scriptTargets.map(scriptTarget => {
     let buildOptions: NormalizedBrowserBuilderSchema = { ...options };
-    const supportES2015
-      = scriptTarget !== ts.ScriptTarget.ES3 && scriptTarget !== ts.ScriptTarget.ES5;
+    const supportES2015 =
+      scriptTarget !== ts.ScriptTarget.ES3 && scriptTarget !== ts.ScriptTarget.ES5;
 
     if (differentialLoading && fullDifferential) {
       buildOptions = {
         ...options,
-        ...(
-          // FIXME: we do create better webpack config composition to achieve the below
-          // When DL is enabled and supportES2015 is true it means that we are on the second build
-          // This also means that we don't need to include styles and assets multiple times
-          supportES2015
-            ? {}
-            : {
+        ...// FIXME: we do create better webpack config composition to achieve the below
+        // When DL is enabled and supportES2015 is true it means that we are on the second build
+        // This also means that we don't need to include styles and assets multiple times
+        (supportES2015
+          ? {}
+          : {
               styles: options.extractCss ? [] : options.styles,
               assets: [],
-            }
-        ),
+            }),
         es5BrowserSupport: undefined,
         esVersionInFileName: true,
         scriptTargetOverride: scriptTarget,
       };
     } else if (differentialLoading && !fullDifferential) {
-      buildOptions = { ...options, esVersionInFileName: true, scriptTargetOverride: ts.ScriptTarget.ES5, es5BrowserSupport: undefined };
+      buildOptions = {
+        ...options,
+        esVersionInFileName: true,
+        scriptTargetOverride: ts.ScriptTarget.ES5,
+        es5BrowserSupport: undefined,
+      };
     }
 
     const wco: BrowserWebpackConfigOptions = {
@@ -145,75 +147,48 @@ export async function generateWebpackConfig(
   });
 }
 
-
-export async function generateBrowserWebpackConfigFromWorkspace(
-  options: BrowserBuilderSchema,
-  context: BuilderContext,
-  projectName: string,
-  workspace: experimental.workspace.Workspace,
-  host: virtualFs.Host<fs.Stats>,
-  webpackPartialGenerator: (wco: BrowserWebpackConfigOptions) => webpack.Configuration[],
-  logger: logging.LoggerApi,
-): Promise<webpack.Configuration[]> {
-  // TODO: Use a better interface for workspace access.
-  const projectRoot = resolve(workspace.root, normalize(workspace.getProject(projectName).root));
-  const projectSourceRoot = workspace.getProject(projectName).sourceRoot;
-  const sourceRoot = projectSourceRoot
-    ? resolve(workspace.root, normalize(projectSourceRoot))
-    : undefined;
-
-  const normalizedOptions = normalizeBrowserSchema(
-    host,
-    workspace.root,
-    projectRoot,
-    sourceRoot,
-    options,
-  );
-
-  return generateWebpackConfig(
-    context,
-    getSystemPath(workspace.root),
-    getSystemPath(projectRoot),
-    sourceRoot && getSystemPath(sourceRoot),
-    normalizedOptions,
-    webpackPartialGenerator,
-    logger,
-  );
-}
-
-
 export async function generateBrowserWebpackConfigFromContext(
   options: BrowserBuilderSchema,
   context: BuilderContext,
   webpackPartialGenerator: (wco: BrowserWebpackConfigOptions) => webpack.Configuration[],
   host: virtualFs.Host<fs.Stats> = new NodeJsSyncHost(),
-): Promise<{ workspace: experimental.workspace.Workspace, config: webpack.Configuration[] }> {
-  const registry = new schema.CoreSchemaRegistry();
-  registry.addPostTransform(schema.transforms.addUndefinedDefaults);
-
-  const workspace = await experimental.workspace.Workspace.fromPath(
-    host,
-    normalize(context.workspaceRoot),
-    registry,
-  );
-
-  const projectName = context.target ? context.target.project : workspace.getDefaultProjectName();
-
+): Promise<{ config: webpack.Configuration[]; projectRoot: string; projectSourceRoot?: string }> {
+  const projectName = context.target && context.target.project;
   if (!projectName) {
-    throw new Error('Must either have a target from the context or a default project.');
+    throw new Error('The builder requires a target.');
   }
 
-  const config = await generateBrowserWebpackConfigFromWorkspace(
-    options,
-    context,
-    projectName,
-    workspace,
+  const workspaceRoot = normalize(context.workspaceRoot);
+  const projectMetadata = await context.getProjectMetadata(projectName);
+  const projectRoot = resolve(workspaceRoot, normalize((projectMetadata.root as string) || ''));
+  const projectSourceRoot = projectMetadata.sourceRoot as string | undefined;
+  const sourceRoot = projectSourceRoot
+    ? resolve(workspaceRoot, normalize(projectSourceRoot))
+    : undefined;
+
+  const normalizedOptions = normalizeBrowserSchema(
     host,
+    workspaceRoot,
+    projectRoot,
+    sourceRoot,
+    options,
+  );
+
+  const config = await generateWebpackConfig(
+    context,
+    getSystemPath(workspaceRoot),
+    getSystemPath(projectRoot),
+    sourceRoot && getSystemPath(sourceRoot),
+    normalizedOptions,
     webpackPartialGenerator,
     context.logger,
   );
 
-  return { workspace, config };
+  return {
+    config,
+    projectRoot: getSystemPath(projectRoot),
+    projectSourceRoot: sourceRoot && getSystemPath(sourceRoot),
+  };
 }
 
 export function getIndexOutputFile(options: BrowserBuilderSchema): string {


### PR DESCRIPTION
This eliminates the need to manually read a workspace file and removes the use of the experimental workspace API from the `@angular-devkit/build-angular` package.

The `BuilderContext` now provides a `getProjectMetadata` function that provides the `root`, `sourceRoot`, `prefix`, and any custom extension fields from the project definition within `angular.json`.