### PR TITLE
feat(@schematics/angular): enable scripts optimization for server bundle  

### DIFF
--- a/packages/schematics/angular/migrations/update-9/ivy-libraries_spec.ts
+++ b/packages/schematics/angular/migrations/update-9/ivy-libraries_spec.ts
@@ -49,6 +49,7 @@ describe('Migration to version 9', () => {
           tree,
         )
         .toPromise();
+
       tree = await schematicRunner
         .runExternalSchematicAsync(
           require.resolve('../../collection.json'),

--- a/packages/schematics/angular/migrations/update-9/update-workspace-config.ts
+++ b/packages/schematics/angular/migrations/update-9/update-workspace-config.ts
@@ -40,6 +40,10 @@ export function updateWorkspaceConfig(): Rule {
       updateStyleOrScriptOption('scripts', recorder, target);
     }
 
+    for (const { target } of getTargets(workspace, 'server', Builders.Server)) {
+      updateOptimizationOption(recorder, target);
+    }
+
     tree.commitUpdate(recorder);
 
     return tree;
@@ -136,6 +140,25 @@ function addAnyComponentStyleBudget(recorder: UpdateRecorder, builderConfig: Jso
 
     if (!hasAnyComponentStyle) {
       appendValueInAstArray(recorder, budgetOption, ANY_COMPONENT_STYLE_BUDGET, 16);
+    }
+  }
+}
+
+function updateOptimizationOption(recorder: UpdateRecorder, builderConfig: JsonAstObject) {
+  const options = getAllOptions(builderConfig, true);
+
+  for (const option of options) {
+    const optimizationOption = findPropertyInAstObject(option, 'optimization');
+    if (!optimizationOption) {
+      // add
+      insertPropertyInAstObjectInOrder(recorder, option, 'optimization', true, 14);
+      continue;
+    }
+
+    if (optimizationOption.kind !== 'true') {
+      const { start, end } = optimizationOption;
+      recorder.remove(start.offset, end.offset - start.offset);
+      recorder.insertLeft(start.offset, 'true');
     }
   }
 }

--- a/packages/schematics/angular/migrations/update-9/update-workspace-config_spec.ts
+++ b/packages/schematics/angular/migrations/update-9/update-workspace-config_spec.ts
@@ -248,5 +248,53 @@ describe('Migration to version 9', () => {
         expect(config.configurations.production.aot).toBeUndefined();
       });
     });
+
+    describe('server optimization option', () => {
+      beforeEach(async () => {
+        tree = await schematicRunner
+          .runExternalSchematicAsync(
+            require.resolve('../../collection.json'),
+            'universal',
+            {
+              clientProject: 'migration-test',
+            },
+            tree,
+          )
+          .toPromise();
+      });
+
+      it('should add optimization option when not defined', async () => {
+        let config = getWorkspaceTargets(tree);
+        config.server.configurations.production.optimization = undefined;
+        updateWorkspaceTargets(tree, config);
+
+        const tree2 = await schematicRunner.runSchematicAsync('migration-09', {}, tree.branch()).toPromise();
+        config = getWorkspaceTargets(tree2).server.configurations;
+        expect(config.production.optimization).toBe(true);
+      });
+
+      it('should set optimization to true when false', async () => {
+        let config = getWorkspaceTargets(tree);
+        config.server.configurations.production.optimization = false;
+        updateWorkspaceTargets(tree, config);
+
+        const tree2 = await schematicRunner.runSchematicAsync('migration-09', {}, tree.branch()).toPromise();
+        config = getWorkspaceTargets(tree2).server.configurations;
+        expect(config.production.optimization).toBe(true);
+      });
+
+      it('should set optimization to true when optimization is fine grained', async () => {
+        let config = getWorkspaceTargets(tree);
+        config.server.configurations.production.optimization = {
+          scripts: false,
+          styles: true,
+        };
+        updateWorkspaceTargets(tree, config);
+
+        const tree2 = await schematicRunner.runSchematicAsync('migration-09', {}, tree.branch()).toPromise();
+        config = getWorkspaceTargets(tree2).server.configurations;
+        expect(config.production.optimization).toBe(true);
+      });
+    });
   });
 });

--- a/packages/schematics/angular/universal/index.ts
+++ b/packages/schematics/angular/universal/index.ts
@@ -62,10 +62,7 @@ function updateConfigFile(options: UniversalOptions, tsConfigDirectory: Path): R
           production: {
             fileReplacements,
             sourceMap: false,
-            optimization: {
-              scripts: false,
-              styles: true,
-            },
+            optimization: true,
           },
         },
       });

--- a/tests/legacy-cli/e2e/tests/build/platform-server.ts
+++ b/tests/legacy-cli/e2e/tests/build/platform-server.ts
@@ -52,7 +52,7 @@ export default async function () {
   }
 
 
-  await ng('run', 'test-project:server:production');
+  await ng('run', 'test-project:server:production', '--optimization', 'false');
 
   await expectFileToMatch('dist/server/main.js', veEnabled ? /exports.*AppServerModuleNgFactory/ : /exports.*AppServerModule/);
   await exec(normalize('node'), 'index.js');


### PR DESCRIPTION
The optimizations are suggested to;
1) disables ngDevMode via terser
2) helps with cold server starts the same way as client by lowering JS parse times

//cc @vikerman 