### PR TITLE
feat(@schematics/angular): augment universal/app-shell addition for `…

### DIFF
--- a/packages/schematics/angular/universal/files/src/__main@stripTsExtension__.ts.template
+++ b/packages/schematics/angular/universal/files/src/__main@stripTsExtension__.ts.template
@@ -1,4 +1,9 @@
-import { enableProdMode } from '@angular/core';
+<% if (hasLocalizePackage) { %>/***************************************************************************************************
+ * Load `$localize` onto the global scope - used if i18n tags appear in Angular templates.
+*/
+import '@angular/localize/init';
+
+<% } %>import { enableProdMode } from '@angular/core';
 
 import { environment } from './environments/environment';
 

--- a/packages/schematics/angular/universal/index.ts
+++ b/packages/schematics/angular/universal/index.ts
@@ -250,6 +250,7 @@ export default function (options: UniversalOptions): Rule {
         ...strings,
         ...options as object,
         stripTsExtension: (s: string) => s.replace(/\.ts$/, ''),
+        hasLocalizePackage: !!getPackageJsonDependency(host, '@angular/localize'),
       }),
       move(join(normalize(clientProject.root), 'src')),
     ]);

--- a/packages/schematics/angular/universal/index_spec.ts
+++ b/packages/schematics/angular/universal/index_spec.ts
@@ -7,6 +7,7 @@
  */
 import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';
 import { Schema as ApplicationOptions, Style } from '../application/schema';
+import { NodeDependencyType, addPackageJsonDependency } from '../utility/dependencies';
 import { Schema as WorkspaceOptions } from '../workspace/schema';
 import { Schema as UniversalOptions } from './schema';
 
@@ -227,4 +228,25 @@ describe('Universal Schematic', () => {
     expect(tree.exists(filePath)).toEqual(true);
   });
 
+  it(`should not add import to '@angular/localize' in main file when it's not a depedency`, async () => {
+    const tree = await schematicRunner.runSchematicAsync('universal', defaultOptions, appTree)
+      .toPromise();
+    const filePath = '/projects/bar/src/main.server.ts';
+    const contents = tree.readContent(filePath);
+    expect(contents).not.toContain('@angular/localize');
+  });
+
+  it(`should add import to '@angular/localize' in main file when it's a depedency`, async () => {
+    addPackageJsonDependency(appTree, {
+       name: '@angular/localize',
+       type: NodeDependencyType.Default,
+       version: 'latest',
+    });
+
+    const tree = await schematicRunner.runSchematicAsync('universal', defaultOptions, appTree)
+      .toPromise();
+    const filePath = '/projects/bar/src/main.server.ts';
+    const contents = tree.readContent(filePath);
+    expect(contents).toContain('@angular/localize/init');
+  });
 });


### PR DESCRIPTION
…@angular/localize`

If i18n support is already present within an application, the newly generated `main.server.ts` file should also contain the `@angular/localize` polyfill to allow the universal application to function.

This universal schematic here, is the base for app-shell, @nguniversal/express-engine, and @nguniversal/hapi-engine