### PR TITLE
feat(@schematics/angular): support adding app-shell without specifyin…

### DIFF
--- a/packages/schematics/angular/app-shell/schema.json
+++ b/packages/schematics/angular/app-shell/schema.json
@@ -8,7 +8,10 @@
   "properties": {
     "clientProject": {
       "type": "string",
-      "description": "The name of the related client app."
+      "description": "The name of the related client app.",
+      "$default": {
+        "$source": "projectName"
+      }
     },
     "universalProject": {
       "type": "string",


### PR DESCRIPTION
…g `clientProject`

When unset we set the clientProject to the resolved packageName from the current working directory