### PR TITLE
fix(@angular-devkit/build-angular): downlevel with non-loose ECMA compliance

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/process-bundle.ts
+++ b/packages/angular_devkit/build_angular/src/utils/process-bundle.ts
@@ -105,10 +105,9 @@ export async function processAsync(options: ProcessBundleOptions): Promise<Proce
     inputSourceMap: !manualSourceMaps && options.map !== undefined && JSON.parse(options.map),
     babelrc: false,
     // modules aren't needed since the bundles use webpack's custom module loading
-    // loose generates more ES5-like code but does not strictly adhere to the ES2015 spec (Typescript is loose)
     // 'transform-typeof-symbol' generates slower code
     presets: [
-      ['@babel/preset-env', { modules: false, loose: true, exclude: ['transform-typeof-symbol'] }],
+      ['@babel/preset-env', { modules: false, exclude: ['transform-typeof-symbol'] }],
     ],
     minified: options.optimize,
     // `false` ensures it is disabled and prevents large file warnings

--- a/yarn.lock
+++ b/yarn.lock
@@ -8959,7 +8959,6 @@ sauce-connect-launcher@^1.2.4:
 
 "sauce-connect-proxy@https://saucelabs.com/downloads/sc-4.5.4-linux.tar.gz":
   version "0.0.0"
-  uid dc5efcd2be24ddb099a85b923d6e754754651fa8
   resolved "https://saucelabs.com/downloads/sc-4.5.4-linux.tar.gz#dc5efcd2be24ddb099a85b923d6e754754651fa8"
 
 saucelabs@^1.5.0:


### PR DESCRIPTION
This helps to ensure that the ES5 bundles operate consistently with the ES2015+ bundles.

Fixes #15673