### PR TITLE
fix(@schematics/angular): drop deprecated tslint rule

### DIFF
--- a/packages/schematics/angular/workspace/files/tslint.json.template
+++ b/packages/schematics/angular/workspace/files/tslint.json.template
@@ -48,7 +48,6 @@
     "no-non-null-assertion": true,
     "no-redundant-jsdoc": true,
     "no-switch-case-fall-through": true,
-    "no-use-before-declare": true,
     "no-var-requires": false,
     "object-literal-key-quotes": [
       true,


### PR DESCRIPTION
>no-use-before-declare is deprecated. Since TypeScript 2.9. Please use the built-in compiler checks instead.