### PR TITLE
fix(@angular-devkit/build-optimizer): fix error when `__decorate` has…

### DIFF
--- a/packages/angular_devkit/build_optimizer/src/transforms/scrub-file_spec.ts
+++ b/packages/angular_devkit/build_optimizer/src/transforms/scrub-file_spec.ts
@@ -319,6 +319,107 @@ describe('scrub-file', () => {
       expect(testScrubFile(input)).toBeTruthy();
       expect(tags.oneLine`${transformCore(input)}`).toEqual(tags.oneLine`${output}`);
     });
+
+    it('removes Angular decorators calls in __decorate when no __metadata is present', () => {
+      const input = tags.stripIndent`
+        import { __decorate } from 'tslib';
+        import { Component, ElementRef, ContentChild} from '@angular/core';
+
+        var FooBarComponent = /** @class */ (function () {
+            function FooBarComponent(elementRef) {
+                this.elementRef = elementRef;
+                this.inlineButtons = [];
+                this.menuButtons = [];
+            }
+            FooBarComponent.ctorParameters = function () { return [
+                { type: ElementRef }
+            ]; };
+            __decorate([
+                ContentChild('heading', { read: ElementRef, static: true })
+            ], FooBarComponent.prototype, "buttons", void 0);
+            FooBarComponent = __decorate([
+                Component({
+                  selector: 'custom-foo-bar',
+                  template: '',
+                  styles: []
+                })
+            ], FooBarComponent);
+            return FooBarComponent;
+        }());
+      `;
+
+      const output = tags.stripIndent`
+        import { __decorate } from 'tslib';
+        import { Component, ElementRef, ContentChild } from '@angular/core';
+
+        var FooBarComponent = /** @class */ (function () {
+          function FooBarComponent(elementRef) {
+            this.elementRef = elementRef;
+            this.inlineButtons = [];
+            this.menuButtons = [];
+          }
+
+          return FooBarComponent;
+        }());
+      `;
+
+      expect(testScrubFile(input)).toBeTruthy();
+      expect(tags.oneLine`${transformCore(input)}`).toEqual(tags.oneLine`${output}`);
+    });
+
+    it('removes only Angular decorators calls in __decorate when no __metadata is present', () => {
+      const input = tags.stripIndent`
+        import { __decorate } from 'tslib';
+        import { Component, ElementRef, ContentChild} from '@angular/core';
+        import { NotComponent } from 'another-lib';
+
+        var FooBarComponent = /** @class */ (function () {
+            function FooBarComponent(elementRef) {
+                this.elementRef = elementRef;
+                this.inlineButtons = [];
+                this.menuButtons = [];
+            }
+            FooBarComponent.ctorParameters = function () { return [
+                { type: ElementRef }
+            ]; };
+            __decorate([
+                NotComponent(),
+                ContentChild('heading', { read: ElementRef, static: true })
+            ], FooBarComponent.prototype, "buttons", void 0);
+            FooBarComponent = __decorate([
+                NotComponent(),
+                Component({
+                  selector: 'custom-foo-bar',
+                  template: '',
+                  styles: []
+                })
+            ], FooBarComponent);
+            return FooBarComponent;
+        }());
+      `;
+
+      const output = tags.stripIndent`
+        import { __decorate } from 'tslib';
+        import { Component, ElementRef, ContentChild } from '@angular/core';
+        import { NotComponent } from 'another-lib';
+
+        var FooBarComponent = /** @class */ (function () {
+          function FooBarComponent(elementRef) {
+            this.elementRef = elementRef;
+            this.inlineButtons = [];
+            this.menuButtons = [];
+          }
+          __decorate([
+            NotComponent()
+          ], FooBarComponent.prototype, "buttons", void 0);
+
+          FooBarComponent = __decorate([ NotComponent() ], FooBarComponent); return FooBarComponent;
+          }());
+      `;
+
+      expect(testScrubFile(input)).toBeTruthy();
+      expect(tags.oneLine`${transformCore(input)}`).toEqual(tags.oneLine`${output}`);
+    });
   });
 
   describe('__metadata', () => {


### PR DESCRIPTION
… no `__metadata`

When a `__decorator` expression has no `__metadata` call, example:

```js
__decorate([
    ContentChild('heading', { read: ElementRef, static: true })
], FooBarComponent.prototype, "buttons", void 0);
```

A `Cannot read property 'kind' of undefined` error will be thrown.

Closes: #15703