### PR TITLE
feat(@schematics/angular): update browser output path when adding universal

### DIFF
--- a/packages/schematics/angular/universal/index.ts
+++ b/packages/schematics/angular/universal/index.ts
@@ -49,12 +49,16 @@ function updateConfigFile(options: UniversalOptions, tsConfigDirectory: Path): R
         fileReplacements = buildTarget.configurations.production.fileReplacements;
       }
 
+      if (buildTarget && buildTarget.options) {
+        buildTarget.options.outputPath = `dist/${options.clientProject}/browser`;
+      }
+
       const mainPath = options.main as string;
       clientProject.targets.add({
         name: 'server',
         builder: Builders.Server,
         options: {
-          outputPath: `dist/${options.clientProject}-server`,
+          outputPath: `dist/${options.clientProject}/server`,
           main: join(normalize(clientProject.root), 'src', mainPath.endsWith('.ts') ? mainPath : mainPath + '.ts'),
           tsConfig: join(tsConfigDirectory, `${options.tsconfigFileName}.json`),
         },

--- a/packages/schematics/angular/universal/index_spec.ts
+++ b/packages/schematics/angular/universal/index_spec.ts
@@ -149,7 +149,7 @@ describe('Universal Schematic', () => {
     expect(targets.server).toBeDefined();
     expect(targets.server.builder).toBeDefined();
     const opts = targets.server.options;
-    expect(opts.outputPath).toEqual('dist/bar-server');
+    expect(opts.outputPath).toEqual('dist/bar/server');
     expect(opts.main).toEqual('projects/bar/src/main.server.ts');
     expect(opts.tsConfig).toEqual('projects/bar/tsconfig.server.json');
     const configurations = targets.server.configurations;
@@ -159,6 +159,16 @@ describe('Universal Schematic', () => {
     expect(fileReplacements.length).toEqual(1);
     expect(fileReplacements[0].replace).toEqual('projects/bar/src/environments/environment.ts');
     expect(fileReplacements[0].with).toEqual('projects/bar/src/environments/environment.prod.ts');
+  });
+
+  it('should update workspace with a build target outputPath', async () => {
+    const tree = await schematicRunner.runSchematicAsync('universal', defaultOptions, appTree)
+      .toPromise();
+    const filePath = '/angular.json';
+    const contents = tree.readContent(filePath);
+    const config = JSON.parse(contents.toString());
+    const targets = config.projects.bar.architect;
+    expect(targets.build.options.outputPath).toEqual('dist/bar/browser');
   });
 
   it('should add a server transition to BrowerModule import', async () => {

--- a/tests/legacy-cli/e2e/tests/build/build-app-shell-with-schematic.ts
+++ b/tests/legacy-cli/e2e/tests/build/build-app-shell-with-schematic.ts
@@ -17,8 +17,8 @@ export default async function () {
 
   await silentNpm('install');
   await ng('run', 'test-project:app-shell');
-  await expectFileToMatch('dist/test-project/index.html', /app-shell works!/);
+  await expectFileToMatch('dist/test-project/browser/index.html', /app-shell works!/);
 
   await ng('run', 'test-project:app-shell:production');
-  await expectFileToMatch('dist/test-project/index.html', /app-shell works!/);
+  await expectFileToMatch('dist/test-project/browser/index.html', /app-shell works!/);
 }


### PR DESCRIPTION
Currently, in the CLI universal schematic we are setting the server output path to `dist/project-server` and not amending the build outputPath

Ex:
```
dist/project
dist/project-server
```

However, the above paths are being update when adding `nguniversal` to the below:

```
dist/project/browser
dist/project/server
```

With this change it is proposed to move that logic to upstream.

Related PR to clean up nguniversal schematics https://github.com/angular/universal/pull/1265