### PR TITLE
feat(@angular-devkit/build-angular): set document locale with i18n

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/index-html-webpack-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/index-html-webpack-plugin.ts
@@ -27,6 +27,7 @@ export interface IndexHtmlWebpackPluginOptions {
   moduleEntrypoints: string[];
   postTransform?: IndexHtmlTransform;
   crossOrigin?: CrossOriginValue;
+  lang?: string;
 }
 
 function readFile(filename: string, compilation: compilation.Compilation): Promise<string> {
@@ -100,6 +101,7 @@ export class IndexHtmlWebpackPlugin {
         loadOutputFile,
         moduleFiles,
         entrypoints: this._options.entrypoints,
+        lang: this._options.lang,
       });
 
       if (this._options.postTransform) {

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/index-file/augment-index-html_spec.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/index-file/augment-index-html_spec.ts
@@ -132,4 +132,21 @@ describe('augment-index-html', () => {
     `);
     });
 
+  it('should add lang attribute', async () => {
+    const source = augmentIndexHtml({
+      ...indexGeneratorOptions,
+      lang: 'fr',
+    });
+
+    const html = await source;
+    expect(html).toEqual(oneLineHtml`
+        <html lang="fr">
+          <head>
+            <base href="/">
+          </head>
+          <body>
+          </body>
+        </html>
+      `);
+  });
 });

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/index-file/write-index-html.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/index-file/write-index-html.ts
@@ -31,6 +31,7 @@ export interface WriteIndexHtmlOptions {
   styles?: ExtraEntryPoint[];
   postTransform?: IndexHtmlTransform;
   crossOrigin?: CrossOriginValue;
+  lang?: string;
 }
 
 export type IndexHtmlTransform = (content: string) => Promise<string>;
@@ -49,6 +50,7 @@ export function writeIndexHtml({
   styles = [],
   postTransform,
   crossOrigin,
+  lang,
 }: WriteIndexHtmlOptions): Observable<void> {
   return host.read(indexPath).pipe(
     map(content => stripBom(virtualFs.fileBufferToString(content))),
@@ -70,6 +72,7 @@ export function writeIndexHtml({
             .pipe(map(data => virtualFs.fileBufferToString(data)))
             .toPromise();
         },
+        lang: lang,
       }),
     ),
     switchMap(content => (postTransform ? postTransform(content) : of(content))),

--- a/packages/angular_devkit/build_angular/src/browser/index.ts
+++ b/packages/angular_devkit/build_angular/src/browser/index.ts
@@ -708,6 +708,7 @@ export function buildWebpackBrowser(
                 styles: options.styles,
                 postTransform: transforms.indexHtml,
                 crossOrigin: options.crossOrigin,
+                lang: options.i18nLocale,
               })
                 .pipe(
                   map(() => ({ success: true })),

--- a/packages/angular_devkit/build_angular/src/dev-server/index.ts
+++ b/packages/angular_devkit/build_angular/src/dev-server/index.ts
@@ -209,6 +209,7 @@ export function serveWebpackBrowser(
             noModuleEntrypoints: ['polyfills-es5'],
             postTransform: transforms.indexHtml,
             crossOrigin: browserOptions.crossOrigin,
+            lang: browserOptions.i18nLocale,
           }),
         );
       }

--- a/tests/legacy-cli/e2e/tests/i18n/build-locale.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/build-locale.ts
@@ -19,11 +19,13 @@ export default function () {
     .then(() => expectFileToMatch('dist/test-project/main-es5.js', /angular_common_locales_fr/))
     .then(() => expectFileToMatch('dist/test-project/main-es2015.js', /registerLocaleData/))
     .then(() => expectFileToMatch('dist/test-project/main-es2015.js', /angular_common_locales_fr/))
+    .then(() => expectFileToMatch('dist/test-project/index.html', /lang="fr"/))
     .then(() => rimraf('dist'))
     .then(() => ng('build', '--aot', '--i18n-locale=fr_FR'))
     .then(() => expectFileToMatch('dist/test-project/main-es2015.js', /registerLocaleData/))
     .then(() => expectFileToMatch('dist/test-project/main-es2015.js', /angular_common_locales_fr/))
     .then(() => expectFileToMatch('dist/test-project/main-es5.js', /registerLocaleData/))
     .then(() => expectFileToMatch('dist/test-project/main-es5.js', /angular_common_locales_fr/))
+    .then(() => expectFileToMatch('dist/test-project/index.html', /lang="fr_FR"/))
     .then(() => rimraf('dist'));
 }


### PR DESCRIPTION
When using i18n (`i18nLocale`), set the document locale in `index.html` using the html `lang` attribute.

Fixes #8102