### PR TITLE
feat(@angular-devkit/build-angular): add analytics for ivy/non-ivy builds

### DIFF
--- a/docs/design/analytics.md
+++ b/docs/design/analytics.md
@@ -28,8 +28,7 @@ To create a new dimension (tracking a new flag):
    defined on GA.
 1. Use the ID of the dimension as the `x-user-analytics` value in the `schema.json` file.
 1. Add a new row to the table below in the same PR as the one adding the dimension to the code.
-1. New dimensions PRs need to be approved by [bradgreen@google.com](mailto:bradgreen@google.com),
-   [stephenfluin@google.com](mailto:stephenfluin@google.com) and
+1. New dimensions PRs need to be approved by [stephenfluin@google.com](mailto:stephenfluin@google.com) and
    [iminar@google.com](mailto:iminar@google.com). **This is not negotiable.**
 
 **DO NOT ADD `x-user-analytics` FOR VALUES THAT ARE USER IDENTIFIABLE (PII), FOR EXAMPLE A
@@ -48,6 +47,7 @@ Note: There's a limit of 20 custom dimensions.
 | 5 | `Flag: --style` | `string` |
 | 6 | `--collection` | `string` |
 | 7 | `--buildEventLog` | `boolean` |
+| 8 | `Ivy Enabled` | `boolean` |
 | 9 | `Flag: --inlineStyle` | `boolean` |
 | 10 | `Flag: --inlineTemplate` | `boolean` |
 | 11 | `Flag: --viewEncapsulation` | `string` |

--- a/etc/api/angular_devkit/core/src/_golden-api.d.ts
+++ b/etc/api/angular_devkit/core/src/_golden-api.d.ts
@@ -618,6 +618,7 @@ export declare enum NgCliAnalyticsDimensions {
     NodeVersion = 4,
     NgAddCollection = 6,
     NgBuildBuildEventLog = 7,
+    NgIvyEnabled = 8,
     BuildErrors = 20
 }
 

--- a/packages/angular_devkit/core/src/analytics/index.ts
+++ b/packages/angular_devkit/core/src/analytics/index.ts
@@ -26,6 +26,7 @@ export enum NgCliAnalyticsDimensions {
   NodeVersion = 4,
   NgAddCollection = 6,
   NgBuildBuildEventLog = 7,
+  NgIvyEnabled = 8,
   BuildErrors = 20,
 }
 
@@ -56,6 +57,7 @@ export const NgCliAnalyticsDimensionsFlagInfo: { [name: string]: [string, string
   NodeVersion: ['Node Version', 'number'],
   NgAddCollection: ['--collection', 'string'],
   NgBuildBuildEventLog: ['--buildEventLog', 'boolean'],
+  NgIvyEnabled: ['Ivy Enabled', 'boolean'],
   BuildErrors: ['Build Errors (comma separated)', 'string'],
 };
 


### PR DESCRIPTION
Look for `ngComponentDef` or `ngModuleDef` in the webpack analytics plugin
to report back whether the current build is Ivy enabled.