### PR TITLE
build: g3 sync for angular_devkit

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -4,7 +4,7 @@
 # found in the LICENSE file at https://angular.io/license
 package(default_visibility = ["//visibility:public"])
 
-licenses(["notice"])  # MIT License
+licenses(["notice"])
 
 exports_files([
     "LICENSE",

--- a/packages/angular_devkit/core/BUILD
+++ b/packages/angular_devkit/core/BUILD
@@ -30,6 +30,8 @@ ts_library(
     ],
     module_name = "@angular-devkit/core",
     module_root = "src/index.d.ts",
+    # The attribute below is needed in g3 to turn off strict typechecking
+    # strict_checks = False,
     deps = [
         "@npm//rxjs",
         "@npm//@types/node",
@@ -37,6 +39,8 @@ ts_library(
         "@npm//magic-string",
         "@npm//source-map",
         # @typings: es2015.core
+        # @typings: es2015.proxy
+        # @typings: es2015.reflect
         # @typings: es2015.symbol.wellknown
         # @typings: es2016.array.include
     ],
@@ -55,6 +59,8 @@ ts_library(
         "src/experimental/workspace/test/test-workspace.json",
         "src/experimental/workspace/workspace-schema.json",
     ],
+    # The attribute below is needed in g3 to turn off strict typechecking
+    # strict_checks = False,
     # @external_begin
     tsconfig = "//:tsconfig-test.json",
     # @external_end
@@ -93,6 +99,8 @@ ts_library(
     ),
     module_name = "@angular-devkit/core/node",
     module_root = "node/index.d.ts",
+    # The attribute below is needed in g3 to turn off strict typechecking
+    # strict_checks = False,
     deps = [
         ":core",
         "@npm//@types/node",
@@ -150,6 +158,8 @@ ts_library(
     ),
     module_name = "@angular-devkit/core/node/testing",
     module_root = "node/testing/index.d.ts",
+    # The attribute below is needed in g3 to turn off strict typechecking
+    # strict_checks = False,
     deps = [
         ":core",
         ":node",

--- a/packages/angular_devkit/core/node/host.ts
+++ b/packages/angular_devkit/core/node/host.ts
@@ -160,7 +160,7 @@ export class NodeJsAsyncHost implements virtualFs.Host<fs.Stats> {
 
   list(path: Path): Observable<PathFragment[]> {
     return _callFs(fs.readdir, getSystemPath(path)).pipe(
-      map(names => names.map(name => fragment(name))),
+      map((names: string[]) => names.map(name => fragment(name))),
     );
   }
 

--- a/packages/angular_devkit/core/src/json/schema/visitor.ts
+++ b/packages/angular_devkit/core/src/json/schema/visitor.ts
@@ -65,7 +65,7 @@ function _visitJsonRecursive<ContextT>(
     }
   }
 
-  const value = visitor(json, ptr, schema, root);
+  const value = visitor(json, ptr, schema as JsonObject, root);
 
   return (isObservable<JsonValue>(value) ? value : observableOf(value)).pipe(
     concatMap(value => {

--- a/packages/angular_devkit/schematics/BUILD
+++ b/packages/angular_devkit/schematics/BUILD
@@ -11,7 +11,7 @@ load("@npm_bazel_typescript//:defs.bzl", "ts_library")
 load("@build_bazel_rules_nodejs//:defs.bzl", "npm_package")
 # @external_end
 
-licenses(["notice"])  # MIT License
+licenses(["notice"])
 
 # @angular-devkit/schematics
 
@@ -27,6 +27,8 @@ ts_library(
     ),
     module_name = "@angular-devkit/schematics",
     module_root = "src/index.d.ts",
+    # The attribute below is needed in g3 to turn off strict typechecking
+    # strict_checks = False,
     deps = [
         "//packages/angular_devkit/core",
         "//packages/angular_devkit/core:node",  # TODO: get rid of this for 6.0
@@ -82,6 +84,8 @@ ts_library(
     ),
     module_name = "@angular-devkit/schematics/tasks",
     module_root = "tasks/index.d.ts",
+    # The attribute below is needed in g3 to turn off strict typechecking
+    # strict_checks = False,
     deps = [
         ":schematics",
         "//packages/angular_devkit/core",
@@ -106,6 +110,8 @@ ts_library(
     ),
     module_name = "@angular-devkit/schematics/tasks/node",
     module_root = "tasks/node/index.d.ts",
+    # The attribute below is needed in g3 to turn off strict typechecking
+    # strict_checks = False,
     deps = [
         ":schematics",
         ":tasks",
@@ -130,6 +136,8 @@ ts_library(
         "tasks/tslint-fix/test/collection.json",
         "tasks/tslint-fix/test/rules/customRuleRule.js",
     ],
+    # The attribute below is needed in g3 to turn off strict typechecking
+    # strict_checks = False,
     # @external_begin
     tsconfig = "//:tsconfig-test.json",
     # @external_end
@@ -169,6 +177,8 @@ ts_library(
     ),
     module_name = "@angular-devkit/schematics/tools",
     module_root = "tools/index.d.ts",
+    # The attribute below is needed in g3 to turn off strict typechecking
+    # strict_checks = False,
     deps = [
         ":schematics",
         ":tasks",

--- a/packages/angular_devkit/schematics_cli/BUILD
+++ b/packages/angular_devkit/schematics_cli/BUILD
@@ -6,7 +6,7 @@ package(default_visibility = ["//visibility:public"])
 
 load("@npm_bazel_typescript//:defs.bzl", "ts_library")
 
-licenses(["notice"])  # MIT License
+licenses(["notice"])
 
 # @angular-devkit/schematics-cli
 
@@ -22,6 +22,8 @@ ts_library(
     ),
     module_name = "@angular-devkit/schematics-cli",
     module_root = "bin",
+    # The attribute below is needed in g3 to turn off strict typechecking
+    # strict_checks = False,
     deps = [
         "//packages/angular_devkit/core",
         "//packages/angular_devkit/core:node",


### PR DESCRIPTION
Fix all build errors for packages under `angular_devkit` in g3