### PR TITLE
build: use import instead of require for fast-json-stable-stringify

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "@types/clean-css": "^4.2.1",
     "@types/copy-webpack-plugin": "^4.4.1",
     "@types/express": "^4.16.0",
+    "@types/fast-json-stable-stringify": "^2.0.0",
     "@types/find-cache-dir": "^2.0.0",
     "@types/glob": "^7.0.0",
     "@types/inquirer": "^0.0.44",

--- a/packages/angular_devkit/core/BUILD
+++ b/packages/angular_devkit/core/BUILD
@@ -35,6 +35,7 @@ ts_library(
     deps = [
         "@npm//rxjs",
         "@npm//@types/node",
+        "@npm//@types/fast-json-stable-stringify",
         "@npm//ajv",
         "@npm//magic-string",
         "@npm//source-map",

--- a/packages/angular_devkit/core/src/experimental/jobs/strategy.ts
+++ b/packages/angular_devkit/core/src/experimental/jobs/strategy.ts
@@ -5,6 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import * as stableStringify from 'fast-json-stable-stringify';
 import { Observable, Subject, concat, of } from 'rxjs';
 import { finalize, ignoreElements, share, shareReplay, tap } from 'rxjs/operators';
 import { JsonValue } from '../../json';
@@ -15,8 +16,6 @@ import {
   JobOutboundMessage,
   JobOutboundMessageKind,
 } from './api';
-
-const stableStringify = require('fast-json-stable-stringify');
 
 export namespace strategy {
 

--- a/packages/angular_devkit/core/src/workspace/json/utilities.ts
+++ b/packages/angular_devkit/core/src/workspace/json/utilities.ts
@@ -5,6 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import * as stableStringify from 'fast-json-stable-stringify';
 import {
   JsonAstArray,
   JsonAstKeyValue,
@@ -13,8 +14,6 @@ import {
   JsonObject,
   JsonValue,
 } from '../../json';
-
-const stableStringify = require('fast-json-stable-stringify');
 
 interface CacheEntry {
   value?: JsonValue;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1013,6 +1013,11 @@
     "@types/express-serve-static-core" "*"
     "@types/serve-static" "*"
 
+"@types/fast-json-stable-stringify@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#40363bb847cb86b2c2e1599f1398d11e8329c921"
+  integrity sha512-mky/O83TXmGY39P1H9YbUpjV6l6voRYlufqfFCvel8l1phuy8HRjdWc1rrPuN53ITBJlbyMSV6z3niOySO5pgQ==
+
 "@types/find-cache-dir@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/find-cache-dir/-/find-cache-dir-2.0.0.tgz#6ee79b947b8e51ce8c565fc8278822b2605609db"
@@ -9073,7 +9078,6 @@ sauce-connect-launcher@^1.2.4:
 
 "sauce-connect-proxy@https://saucelabs.com/downloads/sc-4.5.4-linux.tar.gz":
   version "0.0.0"
-  uid dc5efcd2be24ddb099a85b923d6e754754651fa8
   resolved "https://saucelabs.com/downloads/sc-4.5.4-linux.tar.gz#dc5efcd2be24ddb099a85b923d6e754754651fa8"
 
 saucelabs@^1.5.0:


### PR DESCRIPTION
`require` statements make g3 imports difficult because the dependency is not visible to the Bazel system. Moreover proper typings make the code more robust.