### PR TITLE
fix(@angular/cli): initialize baseUrl variable

### DIFF
--- a/packages/angular_devkit/build_angular/src/protractor/index.ts
+++ b/packages/angular_devkit/build_angular/src/protractor/index.ts
@@ -92,7 +92,7 @@ async function execute(
     await updateWebdriver();
   }
 
-  let baseUrl;
+  let baseUrl = options.baseUrl;
   let server;
   if (options.devServerTarget) {
     const target = targetFromTargetString(options.devServerTarget);


### PR DESCRIPTION
`baseUrl` is not provided to protractor config because it was undefined

Fixes #15716