### PR TITLE
feat(@angular-devkit/build-optimizer): don't use getImportTslibTransformer

### DIFF
--- a/packages/angular_devkit/build_optimizer/src/build-optimizer/build-optimizer.ts
+++ b/packages/angular_devkit/build_optimizer/src/build-optimizer/build-optimizer.ts
@@ -11,7 +11,6 @@ import {
   TransformJavascriptOutput,
   transformJavascript,
 } from '../helpers/transform-javascript';
-import { getImportTslibTransformer, testImportTslib } from '../transforms/import-tslib';
 import { getPrefixClassesTransformer, testPrefixClasses } from '../transforms/prefix-classes';
 import { getPrefixFunctionsTransformer } from '../transforms/prefix-functions';
 import {
@@ -109,8 +108,6 @@ export function buildOptimizer(options: BuildOptimizerOptions): TransformJavascr
     selectedGetScrubFileTransformer = getScrubFileTransformerForCore;
   }
 
-  const isWebpackBundle = content.indexOf('__webpack_require__') !== -1;
-
   // Determine which transforms to apply.
   const getTransforms = [];
 
@@ -133,20 +130,8 @@ export function buildOptimizer(options: BuildOptimizerOptions): TransformJavascr
     typeCheck = true;
   }
 
-  // tests are not needed for fast path
-  // usage will be expanded once transformers are verified safe
-  const ignoreTest = !options.emitSourceMap && !typeCheck;
-
   if (testPrefixClasses(content)) {
     getTransforms.unshift(getPrefixClassesTransformer);
-  }
-
-  // This transform introduces import/require() calls, but this won't work properly on libraries
-  // built with Webpack. These libraries use __webpack_require__() calls instead, which will break
-  // with a new import that wasn't part of it's original module list.
-  // We ignore this transform for such libraries.
-  if (!isWebpackBundle && (ignoreTest || testImportTslib(content))) {
-    getTransforms.unshift(getImportTslibTransformer);
   }
 
   getTransforms.push(getWrapEnumsTransformer);

--- a/packages/angular_devkit/build_optimizer/src/build-optimizer/build-optimizer_spec.ts
+++ b/packages/angular_devkit/build_optimizer/src/build-optimizer/build-optimizer_spec.ts
@@ -22,11 +22,6 @@ describe('build-optimizer', () => {
     it('applies scrub-file and prefix-functions to side-effect free modules', () => {
       const input = tags.stripIndent`
         ${imports}
-        var __extends = (this && this.__extends) || function (d, b) {
-            for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
-            function __() { this.constructor = d; }
-            d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
-        };
         var ChangeDetectionStrategy;
         (function (ChangeDetectionStrategy) {
           ChangeDetectionStrategy[ChangeDetectionStrategy["OnPush"] = 0] = "OnPush";
@@ -55,7 +50,6 @@ describe('build-optimizer', () => {
         var RenderType_MdOption = ɵcrt({ encapsulation: 2, styles: styles_MdOption});
       `;
       const output = tags.oneLine`
-        import { __extends } from "tslib";
         ${imports}
         var ChangeDetectionStrategy = /*@__PURE__*/ (function (ChangeDetectionStrategy) {
           ChangeDetectionStrategy[ChangeDetectionStrategy["OnPush"] = 0] = "OnPush";

--- a/packages/angular_devkit/build_optimizer/src/transforms/import-tslib.ts
+++ b/packages/angular_devkit/build_optimizer/src/transforms/import-tslib.ts
@@ -9,15 +9,6 @@ import * as ts from 'typescript';
 import { getCleanHelperName } from '../helpers/ast-utils';
 
 /**
- * @deprecated From 0.9.0
- */
-export function testImportTslib(content: string) {
-  const regex = /var (__extends|__decorate|__metadata|__param)(\$\d+)? = \(.*\r?\n\s+(.*\r?\n)*\s*\};/;
-
-  return regex.test(content);
-}
-
-/**
  * @deprecated From 0.900.0
  */
 export function getImportTslibTransformer(): ts.TransformerFactory<ts.SourceFile> {

--- a/packages/angular_devkit/build_optimizer/src/transforms/import-tslib.ts
+++ b/packages/angular_devkit/build_optimizer/src/transforms/import-tslib.ts
@@ -17,6 +17,9 @@ export function testImportTslib(content: string) {
   return regex.test(content);
 }
 
+/**
+ * @deprecated From 0.900.0
+ */
 export function getImportTslibTransformer(): ts.TransformerFactory<ts.SourceFile> {
   return (context: ts.TransformationContext): ts.Transformer<ts.SourceFile> => {
 

--- a/packages/angular_devkit/build_optimizer/src/transforms/import-tslib_spec.ts
+++ b/packages/angular_devkit/build_optimizer/src/transforms/import-tslib_spec.ts
@@ -8,7 +8,7 @@
 // tslint:disable-next-line:no-implicit-dependencies
 import { tags } from '@angular-devkit/core';
 import { transformJavascript } from '../helpers/transform-javascript';
-import { getImportTslibTransformer, testImportTslib } from './import-tslib';
+import { getImportTslibTransformer } from './import-tslib';
 
 
 const transform = (content: string) => transformJavascript(
@@ -27,7 +27,6 @@ describe('import-tslib', () => {
       import { __extends } from "tslib";
     `;
 
-    expect(testImportTslib(input)).toBeTruthy();
     expect(tags.oneLine`${transform(input)}`).toEqual(tags.oneLine`${output}`);
   });
 
@@ -46,7 +45,6 @@ describe('import-tslib', () => {
       export default function appGlobal() { }
     `;
 
-    expect(testImportTslib(input)).toBeTruthy();
     expect(tags.oneLine`${transform(input)}`).toEqual(tags.oneLine`${output}`);
   });
 
@@ -64,7 +62,6 @@ describe('import-tslib', () => {
       import { __decorate } from "tslib";
     `;
 
-    expect(testImportTslib(input)).toBeTruthy();
     expect(tags.oneLine`${transform(input)}`).toEqual(tags.oneLine`${output}`);
   });
 
@@ -89,7 +86,6 @@ describe('import-tslib', () => {
       import { __decorate as __decorate$2 } from "tslib";
     `;
 
-    expect(testImportTslib(input)).toBeTruthy();
     expect(tags.oneLine`${transform(input)}`).toEqual(tags.oneLine`${output}`);
   });
 
@@ -118,7 +114,6 @@ describe('import-tslib', () => {
       exports.meaning = 42;
     `;
 
-    expect(testImportTslib(input)).toBeTruthy();
     expect(tags.oneLine`${transform(input)}`).toEqual(tags.oneLine`${output}`);
   });
 
@@ -132,7 +127,6 @@ describe('import-tslib', () => {
       import { __metadata } from "tslib";
     `;
 
-    expect(testImportTslib(input)).toBeTruthy();
     expect(tags.oneLine`${transform(input)}`).toEqual(tags.oneLine`${output}`);
   });
 
@@ -147,7 +141,6 @@ describe('import-tslib', () => {
       import { __param } from "tslib";
     `;
 
-    expect(testImportTslib(input)).toBeTruthy();
     expect(tags.oneLine`${transform(input)}`).toEqual(tags.oneLine`${output}`);
   });
 


### PR DESCRIPTION
This transformer can cause size regressions when it introduces `tslib` imports across independent chunks.

It should be deprecated because tslib adoption has become more ubiquitous.

Should also speed up Build Optimizer processing time because there's one less thing to do.