### PR TITLE
fix(@angular-devkit/build-angular): re-introduce pure_getters

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
@@ -354,6 +354,7 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
             }
           : {
               ecma: terserEcma,
+              pure_getters: buildOptions.buildOptimizer,
               // PURE comments work best with 3 passes.
               // See https://github.com/webpack/webpack/issues/2899#issuecomment-317425926.
               passes: buildOptions.buildOptimizer ? 3 : 1,


### PR DESCRIPTION
PR #15607 removed the `_pure_getters` optimization as it no longer has effect on the framework size.
But it does have an effect on third party library.

For example a simple project using `@ng-bootstrap/ng-bootstrap` goes from `444K` uncompressed with CLI `9.0.0-next.5` to `488K` with CLI `9.0.0-next.6` which introduced the removal.