### PR TITLE
feat(@angular/cli): allow subclass to override default collection name

### DIFF
--- a/packages/angular/cli/models/schematic-command.ts
+++ b/packages/angular/cli/models/schematic-command.ts
@@ -78,7 +78,7 @@ export abstract class SchematicCommand<
   private _workspace: workspaces.WorkspaceDefinition;
   protected _workflow: NodeWorkflow;
 
-  private readonly defaultCollectionName = '@schematics/angular';
+  protected defaultCollectionName = '@schematics/angular';
   protected collectionName = this.defaultCollectionName;
   protected schematicName?: string;
 


### PR DESCRIPTION
This PR provides a way for subclass that extends `SchematicCommand` to
provide a different default collection name.
This is needed in g3 where the collection name is different from
external.