### PR TITLE
build: set minimum Node.js version to 10.13

### DIFF
--- a/lib/packages.ts
+++ b/lib/packages.ts
@@ -82,7 +82,7 @@ function loadPackageJson(p: string) {
       // Overwrite engines to a common default.
       case 'engines':
         pkg['engines'] = {
-          'node': '>= 10.9.0',
+          'node': '>= 10.13.0',
           'npm': '>= 6.11.0',
           'pnpm': '>= 3.2.0',
           'yarn': '>= 1.13.0',

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "url": "https://github.com/angular/angular-cli.git"
   },
   "engines": {
-    "node": ">=10.9.0 <13.0.0",
+    "node": ">=10.13.0 <13.0.0",
     "yarn": ">=1.17.3 <2.0.0"
   },
   "author": "Angular Authors",
@@ -101,7 +101,7 @@
     "@types/karma": "^3.0.2",
     "@types/loader-utils": "^1.1.3",
     "@types/minimist": "^1.2.0",
-    "@types/node": "10.9.4",
+    "@types/node": "10.12.30",
     "@types/request": "^2.47.1",
     "@types/semver": "^6.0.0",
     "@types/webpack": "^4.32.1",

--- a/packages/angular/cli/bin/ng
+++ b/packages/angular/cli/bin/ng
@@ -14,8 +14,8 @@ try {
 var version = process.version.substr(1).split('.');
 if (Number(version[0]) < 10 || (Number(version[0]) === 10 && Number(version[1]) < 9)) {
   process.stderr.write(
-    'You are running version ' + process.version + ' of Node.js, which is not supported by Angular CLI 8.0+.\n' +
-    'The official Node.js version that is supported is 10.9 or greater.\n\n' +
+    'You are running version ' + process.version + ' of Node.js, which is not supported by Angular CLI 9.0+.\n' +
+    'The official Node.js version that is supported is 10.13.0 or greater.\n\n' +
     'Please visit https://nodejs.org/en/ to find instructions on how to update Node.js.\n'
   );
 

--- a/packages/angular_devkit/benchmark/package.json
+++ b/packages/angular_devkit/benchmark/package.json
@@ -10,7 +10,7 @@
     "benchmark"
   ],
   "engines": {
-    "node": ">= 10.9.0",
+    "node": ">= 10.13.0",
     "npm": ">= 6.2.0"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1143,10 +1143,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.8.tgz#cb1bf6800238898bc2ff6ffa5702c3cadd350708"
   integrity sha512-FMdVn84tJJdV+xe+53sYiZS4R5yn1mAIxfj+DVoNiQjTYz1+OYmjwEZr1ev9nU0axXwda0QDbYl06QHanRVH3A==
 
-"@types/node@10.9.4":
-  version "10.9.4"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.9.4.tgz#0f4cb2dc7c1de6096055357f70179043c33e9897"
-  integrity sha512-fCHV45gS+m3hH17zgkgADUSi2RR1Vht6wOZ0jyHP8rjiQra9f+mIcgwPQHllmDocYOstIEbKlxbFDYlgrTPYqw==
+"@types/node@10.12.30":
+  version "10.12.30"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.30.tgz#4c2b4f0015f214f8158a347350481322b3b29b2f"
+  integrity sha512-nsqTN6zUcm9xtdJiM9OvOJ5EF0kOI8f1Zuug27O/rgtxCRJHGqncSWfCMZUP852dCKPsDsYXGvBhxfRjDBkF5Q==
 
 "@types/node@^10.1.0":
   version "10.14.19"


### PR DESCRIPTION
Version 10.13.0 was the first version of 10.x that was considered LTS.  This also provides an improved performance baseline as well as access to newer Node.js APIs and Javascript language features which the Angular CLI will now be able to leverage.