### PR TITLE
Backport additional differential loading improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "@bazel/jasmine": "0.35.0",
     "@bazel/karma": "0.35.0",
     "@bazel/typescript": "0.35.0",
+    "@types/babel__core": "7.1.3",
     "@types/browserslist": "^4.4.0",
     "@types/caniuse-lite": "^1.0.0",
     "@types/clean-css": "^4.2.1",

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -54,7 +54,7 @@
     "stylus": "0.54.5",
     "stylus-loader": "3.0.2",
     "tree-kill": "1.2.1",
-    "terser": "4.1.4",
+    "terser": "4.3.8",
     "terser-webpack-plugin": "1.4.1",
     "webpack": "4.39.2",
     "webpack-dev-middleware": "3.7.0",

--- a/packages/angular_devkit/build_angular/src/browser/action-cache.ts
+++ b/packages/angular_devkit/build_angular/src/browser/action-cache.ts
@@ -1,0 +1,191 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { createHash } from 'crypto';
+import * as findCacheDirectory from 'find-cache-dir';
+import * as fs from 'fs';
+import { manglingDisabled } from '../utils/mangle-options';
+import { CacheKey, ProcessBundleOptions, ProcessBundleResult } from '../utils/process-bundle';
+
+const cacache = require('cacache');
+const cacheDownlevelPath = findCacheDirectory({ name: 'angular-build-dl' });
+const packageVersion = require('../../package.json').version;
+
+// Workaround Node.js issue prior to 10.16 with copyFile on macOS
+// https://github.com/angular/angular-cli/issues/15544 & https://github.com/nodejs/node/pull/27241
+let copyFileWorkaround = false;
+if (process.platform === 'darwin') {
+  const version = process.versions.node.split('.').map(part => Number(part));
+  if (version[0] < 10 || version[0] === 11 || (version[0] === 10 && version[1] < 16)) {
+    copyFileWorkaround = true;
+  }
+}
+
+export interface CacheEntry {
+  path: string;
+  size: number;
+  integrity?: string;
+}
+
+export class BundleActionCache {
+  constructor(private readonly integrityAlgorithm?: string) {}
+
+  static copyEntryContent(entry: CacheEntry | string, dest: fs.PathLike): void {
+    if (copyFileWorkaround) {
+      try {
+        fs.unlinkSync(dest);
+      } catch {}
+    }
+
+    fs.copyFileSync(
+      typeof entry === 'string' ? entry : entry.path,
+      dest,
+      fs.constants.COPYFILE_FICLONE,
+    );
+    if (process.platform !== 'win32') {
+      // The cache writes entries as readonly and when using copyFile the permissions will also be copied.
+      // See: https://github.com/npm/cacache/blob/073fbe1a9f789ba42d9a41de7b8429c93cf61579/lib/util/move-file.js#L36
+      fs.chmodSync(dest, 0o644);
+    }
+  }
+
+  generateBaseCacheKey(content: string): string {
+    // Create base cache key with elements:
+    // * package version - different build-angular versions cause different final outputs
+    // * code length/hash - ensure cached version matches the same input code
+    const algorithm = this.integrityAlgorithm || 'sha1';
+    const codeHash = createHash(algorithm)
+      .update(content)
+      .digest('base64');
+    let baseCacheKey = `${packageVersion}|${content.length}|${algorithm}-${codeHash}`;
+    if (manglingDisabled) {
+      baseCacheKey += '|MD';
+    }
+
+    return baseCacheKey;
+  }
+
+  generateCacheKeys(action: ProcessBundleOptions): string[] {
+    const baseCacheKey = this.generateBaseCacheKey(action.code);
+
+    // Postfix added to sourcemap cache keys when vendor sourcemaps are present
+    // Allows non-destructive caching of both variants
+    const SourceMapVendorPostfix = !!action.sourceMaps && action.vendorSourceMaps ? '|vendor' : '';
+
+    // Determine cache entries required based on build settings
+    const cacheKeys = [];
+
+    // If optimizing and the original is not ignored, add original as required
+    if ((action.optimize || action.optimizeOnly) && !action.ignoreOriginal) {
+      cacheKeys[CacheKey.OriginalCode] = baseCacheKey + '|orig';
+
+      // If sourcemaps are enabled, add original sourcemap as required
+      if (action.sourceMaps) {
+        cacheKeys[CacheKey.OriginalMap] = baseCacheKey + SourceMapVendorPostfix + '|orig-map';
+      }
+    }
+    // If not only optimizing, add downlevel as required
+    if (!action.optimizeOnly) {
+      cacheKeys[CacheKey.DownlevelCode] = baseCacheKey + '|dl';
+
+      // If sourcemaps are enabled, add downlevel sourcemap as required
+      if (action.sourceMaps) {
+        cacheKeys[CacheKey.DownlevelMap] = baseCacheKey + SourceMapVendorPostfix + '|dl-map';
+      }
+    }
+
+    return cacheKeys;
+  }
+
+  async getCacheEntries(cacheKeys: (string | null)[]): Promise<(CacheEntry | null)[] | false> {
+    // Attempt to get required cache entries
+    const cacheEntries = [];
+    for (const key of cacheKeys) {
+      if (key) {
+        const entry = await cacache.get.info(cacheDownlevelPath, key);
+        if (!entry) {
+          return false;
+        }
+        cacheEntries.push({
+          path: entry.path,
+          size: entry.size,
+          integrity: entry.metadata && entry.metadata.integrity,
+        });
+      } else {
+        cacheEntries.push(null);
+      }
+    }
+
+    return cacheEntries;
+  }
+
+  async getCachedBundleResult(action: ProcessBundleOptions): Promise<ProcessBundleResult | null> {
+    const entries = action.cacheKeys && await this.getCacheEntries(action.cacheKeys);
+    if (!entries) {
+      return null;
+    }
+
+    const result: ProcessBundleResult = { name: action.name };
+
+    let cacheEntry = entries[CacheKey.OriginalCode];
+    if (cacheEntry) {
+      result.original = {
+        filename: action.filename,
+        size: cacheEntry.size,
+        integrity: cacheEntry.integrity,
+      };
+
+      BundleActionCache.copyEntryContent(cacheEntry, result.original.filename);
+
+      cacheEntry = entries[CacheKey.OriginalMap];
+      if (cacheEntry) {
+        result.original.map = {
+          filename: action.filename + '.map',
+          size: cacheEntry.size,
+        };
+
+        BundleActionCache.copyEntryContent(cacheEntry, result.original.filename + '.map');
+      }
+    } else if (!action.ignoreOriginal) {
+      // If the original wasn't processed (and therefore not cached), add info
+      result.original = {
+        filename: action.filename,
+        size: Buffer.byteLength(action.code, 'utf8'),
+        map:
+          action.map === undefined
+            ? undefined
+            : {
+                filename: action.filename + '.map',
+                size: Buffer.byteLength(action.map, 'utf8'),
+              },
+      };
+    }
+
+    cacheEntry = entries[CacheKey.DownlevelCode];
+    if (cacheEntry) {
+      result.downlevel = {
+        filename: action.filename.replace('es2015', 'es5'),
+        size: cacheEntry.size,
+        integrity: cacheEntry.integrity,
+      };
+
+      BundleActionCache.copyEntryContent(cacheEntry, result.downlevel.filename);
+
+      cacheEntry = entries[CacheKey.DownlevelMap];
+      if (cacheEntry) {
+        result.downlevel.map = {
+          filename: action.filename.replace('es2015', 'es5') + '.map',
+          size: cacheEntry.size,
+        };
+
+        BundleActionCache.copyEntryContent(cacheEntry, result.downlevel.filename + '.map');
+      }
+    }
+
+    return result;
+  }
+}

--- a/packages/angular_devkit/build_angular/src/browser/action-executor.ts
+++ b/packages/angular_devkit/build_angular/src/browser/action-executor.ts
@@ -7,49 +7,110 @@
  */
 import JestWorker from 'jest-worker';
 import * as os from 'os';
+import * as path from 'path';
+import { ProcessBundleOptions, ProcessBundleResult } from '../utils/process-bundle';
+import { BundleActionCache } from './action-cache';
 
-export class ActionExecutor<Input extends { size: number }, Output> {
-  private largeWorker: JestWorker;
-  private smallWorker: JestWorker;
+let workerFile = require.resolve('../utils/process-bundle');
+workerFile =
+  path.extname(workerFile) === '.ts'
+    ? require.resolve('../utils/process-bundle-bootstrap')
+    : workerFile;
 
-  private smallThreshold = 32 * 1024;
+export class BundleActionExecutor {
+  private largeWorker?: JestWorker;
+  private smallWorker?: JestWorker;
+  private cache: BundleActionCache;
 
-  constructor(actionFile: string, private readonly actionName: string, setupOptions?: unknown) {
+  constructor(
+    private workerOptions: unknown,
+    integrityAlgorithm?: string,
+    private readonly sizeThreshold = 32 * 1024,
+  ) {
+    this.cache = new BundleActionCache(integrityAlgorithm);
+  }
+
+  private static executeMethod<O>(worker: JestWorker, method: string, input: unknown): Promise<O> {
+    return ((worker as unknown) as Record<string, (i: unknown) => Promise<O>>)[method](input);
+  }
+
+  private ensureLarge(): JestWorker {
+    if (this.largeWorker) {
+      return this.largeWorker;
+    }
+
     // larger files are processed in a separate process to limit memory usage in the main process
-    this.largeWorker = new JestWorker(actionFile, {
-      exposedMethods: [actionName],
-      setupArgs: setupOptions === undefined ? undefined : [setupOptions],
-    });
+    return (this.largeWorker = new JestWorker(workerFile, {
+      exposedMethods: ['process'],
+      setupArgs: [this.workerOptions],
+    }));
+  }
+
+  private ensureSmall(): JestWorker {
+    if (this.smallWorker) {
+      return this.smallWorker;
+    }
 
     // small files are processed in a limited number of threads to improve speed
     // The limited number also prevents a large increase in memory usage for an otherwise short operation
-    this.smallWorker = new JestWorker(actionFile, {
-      exposedMethods: [actionName],
-      setupArgs: setupOptions === undefined ? undefined : [setupOptions],
+    return (this.smallWorker = new JestWorker(workerFile, {
+      exposedMethods: ['process'],
+      setupArgs: [this.workerOptions],
       numWorkers: os.cpus().length < 2 ? 1 : 2,
       // Will automatically fallback to processes if not supported
       enableWorkerThreads: true,
-    });
+    }));
   }
 
-  execute(options: Input): Promise<Output> {
-    if (options.size > this.smallThreshold) {
-      return ((this.largeWorker as unknown) as Record<string, (options: Input) => Promise<Output>>)[
-        this.actionName
-      ](options);
+  private executeAction<O>(method: string, action: { code: string }): Promise<O> {
+    // code.length is not an exact byte count but close enough for this
+    if (action.code.length > this.sizeThreshold) {
+      return BundleActionExecutor.executeMethod<O>(this.ensureLarge(), method, action);
     } else {
-      return ((this.smallWorker as unknown) as Record<string, (options: Input) => Promise<Output>>)[
-        this.actionName
-      ](options);
+      return BundleActionExecutor.executeMethod<O>(this.ensureSmall(), method, action);
     }
   }
 
-  executeAll(options: Input[]): Promise<Output[]> {
-    return Promise.all(options.map(o => this.execute(o)));
+  async process(action: ProcessBundleOptions) {
+    const cacheKeys = this.cache.generateCacheKeys(action);
+    action.cacheKeys = cacheKeys;
+
+    // Try to get cached data, if it fails fallback to processing
+    try {
+      const cachedResult = await this.cache.getCachedBundleResult(action);
+      if (cachedResult) {
+        return cachedResult;
+      }
+    } catch {}
+
+    return this.executeAction<ProcessBundleResult>('process', action);
+  }
+
+  async *processAll(actions: Iterable<ProcessBundleOptions>) {
+    const executions = new Map<Promise<ProcessBundleResult>, Promise<ProcessBundleResult>>();
+    for (const action of actions) {
+      const execution = this.process(action);
+      executions.set(
+        execution,
+        execution.then(result => {
+          executions.delete(execution);
+
+          return result;
+        }),
+      );
+    }
+
+    while (executions.size > 0) {
+      yield Promise.race(executions.values());
+    }
   }
 
   stop() {
-    this.largeWorker.end();
-    this.smallWorker.end();
+    if (this.largeWorker) {
+      this.largeWorker.end();
+    }
+    if (this.smallWorker) {
+      this.smallWorker.end();
+    }
   }
 }

--- a/packages/angular_devkit/build_angular/src/browser/action-executor.ts
+++ b/packages/angular_devkit/build_angular/src/browser/action-executor.ts
@@ -14,16 +14,18 @@ export class ActionExecutor<Input extends { size: number }, Output> {
 
   private smallThreshold = 32 * 1024;
 
-  constructor(actionFile: string, private readonly actionName: string) {
+  constructor(actionFile: string, private readonly actionName: string, setupOptions?: unknown) {
     // larger files are processed in a separate process to limit memory usage in the main process
     this.largeWorker = new JestWorker(actionFile, {
       exposedMethods: [actionName],
+      setupArgs: setupOptions === undefined ? undefined : [setupOptions],
     });
 
     // small files are processed in a limited number of threads to improve speed
     // The limited number also prevents a large increase in memory usage for an otherwise short operation
     this.smallWorker = new JestWorker(actionFile, {
       exposedMethods: [actionName],
+      setupArgs: setupOptions === undefined ? undefined : [setupOptions],
       numWorkers: os.cpus().length < 2 ? 1 : 2,
       // Will automatically fallback to processes if not supported
       enableWorkerThreads: true,

--- a/packages/angular_devkit/build_angular/src/browser/index.ts
+++ b/packages/angular_devkit/build_angular/src/browser/index.ts
@@ -554,13 +554,11 @@ export function buildWebpackBrowser(
                   processRuntimeAction = {
                     ...action,
                     cacheKeys,
-                    cachePath: cacheDownlevelPath || undefined,
                   };
                 } else {
                   processActions.push({
                     ...action,
                     cacheKeys,
-                    cachePath: cacheDownlevelPath || undefined,
                   });
                 }
               }
@@ -604,6 +602,7 @@ export function buildWebpackBrowser(
                     ? workerFile
                     : require.resolve('../utils/process-bundle-bootstrap'),
                   'process',
+                  { cachePath: cacheDownlevelPath },
                 );
 
                 try {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11178,10 +11178,10 @@ terser-webpack-plugin@1.4.1, terser-webpack-plugin@^1.4.1:
     webpack-sources "^1.4.0"
     worker-farm "^1.7.0"
 
-terser@4.1.4:
-  version "4.1.4"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-4.1.4.tgz#4478b6a08bb096a61e793fea1a4434408bab936c"
-  integrity sha512-+ZwXJvdSwbd60jG0Illav0F06GDJF0R4ydZ21Q3wGAFKoBGyJGo34F63vzJHgvYxc1ukOtIjvwEvl9MkjzM6Pg==
+terser@4.3.8:
+  version "4.3.8"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-4.3.8.tgz#707f05f3f4c1c70c840e626addfdb1c158a17136"
+  integrity sha512-otmIRlRVmLChAWsnSFNO0Bfk6YySuBp6G9qrHiJwlLDd4mxe2ta4sjI7TzIR+W1nBMjilzrMcPOz9pSusgx3hQ==
   dependencies:
     commander "^2.20.0"
     source-map "~0.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -324,6 +324,11 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
+"@babel/parser@^7.1.0":
+  version "7.6.2"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.6.2.tgz#205e9c95e16ba3b8b96090677a67c9d6075b70a1"
+  integrity sha512-mdFqWrSPCmikBoaBYMuBulzTIKuXVPtEISFbRRVNwMWpCms/hmE2kRq0bblUHaNRKrjRlmVbx1sDHmjmRgD2Xg==
+
 "@babel/parser@^7.1.2":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.1.3.tgz#2c92469bac2b7fbff810b67fca07bd138b48af77"
@@ -772,6 +777,15 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
+"@babel/types@^7.3.0":
+  version "7.6.1"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.6.1.tgz#53abf3308add3ac2a2884d539151c57c4b3ac648"
+  integrity sha512-X7gdiuaCmA0uRjCmRtYJNAVCc/q+5xSgsfKJHqMN4iNLILX39677fJE1O40arPMh0TTtS9ItH67yre6c7k6t0g==
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.17.13"
+    to-fast-properties "^2.0.0"
+
 "@bazel/bazel-darwin_x64@0.28.1":
   version "0.28.1"
   resolved "https://registry.yarnpkg.com/@bazel/bazel-darwin_x64/-/bazel-darwin_x64-0.28.1.tgz#415658785e1dbd6f7ab5c8f2b98c1c99c614e1d5"
@@ -939,6 +953,39 @@
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"
   integrity sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==
+
+"@types/babel__core@7.1.3":
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.3.tgz#e441ea7df63cd080dfcd02ab199e6d16a735fc30"
+  integrity sha512-8fBo0UR2CcwWxeX7WIIgJ7lXjasFxoYgRnFHUj+hRvKkpiBJbxhdAPTCY6/ZKM0uxANFVzt4yObSLuTiTnazDA==
+  dependencies:
+    "@babel/parser" "^7.1.0"
+    "@babel/types" "^7.0.0"
+    "@types/babel__generator" "*"
+    "@types/babel__template" "*"
+    "@types/babel__traverse" "*"
+
+"@types/babel__generator@*":
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@types/babel__generator/-/babel__generator-7.6.0.tgz#f1ec1c104d1bb463556ecb724018ab788d0c172a"
+  integrity sha512-c1mZUu4up5cp9KROs/QAw0gTeHrw/x7m52LcnvMxxOZ03DmLwPV0MlGmlgzV3cnSdjhJOZsj7E7FHeioai+egw==
+  dependencies:
+    "@babel/types" "^7.0.0"
+
+"@types/babel__template@*":
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/@types/babel__template/-/babel__template-7.0.2.tgz#4ff63d6b52eddac1de7b975a5223ed32ecea9307"
+  integrity sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==
+  dependencies:
+    "@babel/parser" "^7.1.0"
+    "@babel/types" "^7.0.0"
+
+"@types/babel__traverse@*":
+  version "7.0.7"
+  resolved "https://registry.yarnpkg.com/@types/babel__traverse/-/babel__traverse-7.0.7.tgz#2496e9ff56196cc1429c72034e07eab6121b6f3f"
+  integrity sha512-CeBpmX1J8kWLcDEnI3Cl2Eo6RfbGvzUctA+CjZUhOKDFbLfcr7fc4usEqLNWetrlJd7RhAkyYe2czXop4fICpw==
+  dependencies:
+    "@babel/types" "^7.3.0"
 
 "@types/bluebird@*":
   version "3.5.26"


### PR DESCRIPTION
This also provides a workaround for an issue wherein larger files (10MB+) currently cause an excessive amount of memory usage during AST processing.  This is currently being remedied upstream.  However for the current time period, this change allows for successful builds without increasing the Node.js memory limit.