### PR TITLE
fix(@angular-devkit/build-angular): remove prerelease @angular/compiler-cli peer dependency

### DIFF
--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -94,7 +94,7 @@
     "zone.js": "^0.9.1"
   },
   "peerDependencies": {
-    "@angular/compiler-cli": "^8.0.0-beta.0 || ^8.1.0-beta.0 || ^8.2.0-beta.0 || ^8.3.0-beta.0 || ^8.4.0-beta.0 || >=9.0.0-beta < 9",
+    "@angular/compiler-cli": "^8.0.0",
     "typescript": ">=3.1 < 3.6"
   }
 }

--- a/packages/ngtools/webpack/package.json
+++ b/packages/ngtools/webpack/package.json
@@ -28,7 +28,7 @@
     "webpack-sources": "1.4.3"
   },
   "peerDependencies": {
-    "@angular/compiler-cli": "^8.0.0-beta.0 || ^8.1.0-beta.0 || ^8.2.0-beta.0 || ^8.3.0-beta.0 || ^8.4.0-beta.0 || >=9.0.0-beta < 9",
+    "@angular/compiler-cli": "^8.0.0",
     "typescript": ">=3.4 < 3.6",
     "webpack": "^4.0.0"
   },


### PR DESCRIPTION
Prerelease versions of the `@angular/compiler-cli` package are not supported and should not be considered valid for a stable version of `@angular-devkit/build-angular`.

/cc @IgorMinar 