### PR TITLE
docs add npm link information for @angular-devkit/schematics and @ang…

### DIFF
--- a/packages/angular/cli/README.md
+++ b/packages/angular/cli/README.md
@@ -164,8 +164,15 @@ You can find more details about changes between versions in [the Releases tab on
 git clone https://github.com/angular/angular-cli.git
 yarn
 npm run build
-cd dist/@angular/cli
-npm link
+npm link dist/@angular/cli
+# if you wish to work with angular-devkit schematics, you also need
+npm link dist/@angular-devkit/schematics
+npm link dist/@angular-devkit/schematics-cli
+# these need to be run after each npm run build
+# in addition, npm link of schematics-cli installs the published copy of @angular-devkit/schematics into node_modules
+# To induce the schematics command to use the locally compiled version of @angular-devkit/schematics:
+(cd dist/@angular-devkit/schematics-cli; npm link @angular-devkit/schematics)
+# Similar commands may be needed to work with other angular-devkit packages.
 ```
 
 `npm link` is very similar to `npm install -g` except that instead of downloading the package


### PR DESCRIPTION
…ular-devkit/schematics-cli

The @angular-cli/README.md appears to be the build/link documentation
also for @angular-devkit/schematics and
@angular-devkit/schematics-cli, but following the instructions does
not result in usable local schematics. Add sufficient commands so
these projects can be used as local packages and the schematics
command works.

Fixes https://github.com/angular/angular-cli/issues/15779