### PR TITLE
feat(@angular-devkit/schematics) implement global package installatio…

### DIFF
--- a/etc/api/angular_devkit/schematics/tasks/index.d.ts
+++ b/etc/api/angular_devkit/schematics/tasks/index.d.ts
@@ -1,4 +1,5 @@
 export declare class NodePackageInstallTask implements TaskConfigurationGenerator<NodePackageTaskOptions> {
+    global: boolean;
     packageManager?: string;
     packageName?: string;
     quiet: boolean;

--- a/packages/angular_devkit/schematics/tasks/node-package/executor.ts
+++ b/packages/angular_devkit/schematics/tasks/node-package/executor.ts
@@ -17,6 +17,7 @@ type PackageManagerProfile = {
   commands: {
     installAll?: string;
     installPackage: string;
+    installGlobalPackage: Array<string>;
   },
 };
 
@@ -26,18 +27,21 @@ const packageManagers: { [name: string]: PackageManagerProfile } = {
     commands: {
       installAll: 'install',
       installPackage: 'install',
+      installGlobalPackage: ['install', '--global'],
     },
   },
   'cnpm': {
     commands: {
       installAll: 'install',
       installPackage: 'install',
+      installGlobalPackage: ['install', '--global'],
     },
-   },
+  },
   'yarn': {
     quietArgument: '--silent',
     commands: {
       installPackage: 'add',
+      installGlobalPackage: ['global', 'add'],
     },
   },
   'pnpm': {
@@ -45,6 +49,7 @@ const packageManagers: { [name: string]: PackageManagerProfile } = {
     commands: {
       installAll: 'install',
       installPackage: 'install',
+      installGlobalPackage: ['install', '--global'],
     },
   },
 };
@@ -88,7 +93,11 @@ export default function(
 
     if (options.packageName) {
       if (options.command === 'install') {
-        args.push(taskPackageManagerProfile.commands.installPackage);
+        if (options.global) {
+          args.push(...taskPackageManagerProfile.commands.installGlobalPackage);
+        } else {
+          args.push(taskPackageManagerProfile.commands.installPackage);
+        }
       }
       args.push(options.packageName);
     } else if (options.command === 'install' && taskPackageManagerProfile.commands.installAll) {

--- a/packages/angular_devkit/schematics/tasks/node-package/install-task.ts
+++ b/packages/angular_devkit/schematics/tasks/node-package/install-task.ts
@@ -13,6 +13,7 @@ export class NodePackageInstallTaskOptions {
   packageName: string;
   workingDirectory: string;
   quiet: boolean;
+  global: boolean;
 }
 
 export class NodePackageInstallTask implements TaskConfigurationGenerator<NodePackageTaskOptions> {
@@ -20,6 +21,7 @@ export class NodePackageInstallTask implements TaskConfigurationGenerator<NodePa
   workingDirectory?: string;
   packageManager?: string;
   packageName?: string;
+  global = false;
 
   constructor(workingDirectory?: string);
   constructor(options: Partial<NodePackageInstallTaskOptions>);
@@ -39,6 +41,9 @@ export class NodePackageInstallTask implements TaskConfigurationGenerator<NodePa
       if (options.packageName != undefined) {
         this.packageName = options.packageName;
       }
+      if (options.global != undefined) {
+        this.global = options.global;
+      }
     }
   }
 
@@ -51,6 +56,7 @@ export class NodePackageInstallTask implements TaskConfigurationGenerator<NodePa
         workingDirectory: this.workingDirectory,
         packageManager: this.packageManager,
         packageName: this.packageName,
+        global: this.global,
       },
     };
   }

--- a/packages/angular_devkit/schematics/tasks/node-package/options.ts
+++ b/packages/angular_devkit/schematics/tasks/node-package/options.ts
@@ -19,4 +19,5 @@ export interface NodePackageTaskOptions {
   workingDirectory?: string;
   packageName?: string;
   packageManager?: string;
+  global?: boolean;
 }


### PR DESCRIPTION
…n in the schematics node-package task

Extend the schematics node-package task to allow installing individual packages globally.

This is for https://github.com/angular/angular-cli/issues/15782

I haven't found any existing tests of any kind for the node-package task, and don't know how to write one from scratch.  I've tested this change by hand in one of my projects locally with all 4 package managers.