### PR TITLE
refactor(@schematics/angular): convert test to use async await

### DIFF
--- a/packages/schematics/angular/e2e/files/src/app.e2e-spec.ts.template
+++ b/packages/schematics/angular/e2e/files/src/app.e2e-spec.ts.template
@@ -8,9 +8,9 @@ describe('workspace-project App', () => {
     page = new AppPage();
   });
 
-  it('should display welcome message', () => {
-    page.navigateTo();
-    expect(page.getTitleText()).toEqual('<%= relatedAppName %> app is running!');
+  it('should display welcome message', async() => {
+    await page.navigateTo();
+    expect(await page.getTitleText()).toEqual('<%= relatedAppName %> app is running!');
   });
 
   afterEach(async () => {


### PR DESCRIPTION
Update to have newly generated `e2e` tests use an `async()` function and `await`s within that function.

Original discussion that lead to this PR: https://github.com/angular/material.angular.io/pull/641#discussion_r330674621

Relates to PR https://github.com/angular/angular-cli/pull/15472.