### PR TITLE
refactor(@schematics/update): missing space in usageMessage output

### DIFF
--- a/packages/schematics/update/update/index.ts
+++ b/packages/schematics/update/update/index.ts
@@ -489,7 +489,7 @@ function _usageMessage(
         command += ' --next';
       }
 
-      return [name, `${info.installed.version} -> ${version}`, command];
+      return [name, `${info.installed.version} -> ${version} `, command];
     })
     .filter(x => x !== null)
     .sort((a, b) => a && b ? a[0].localeCompare(b[0]) : 0);


### PR DESCRIPTION
Previously:
```
  Name                                               Version                  Command to update
 ------------------------------------------------------------------------------------------------
  @angular/cli                                       9.0.0-next.5 -> 9.0.0-next.8ng update @angular/cli --next
```
After:
```
  Name                                               Version                  Command to update
 ------------------------------------------------------------------------------------------------
  @angular/cli                                       9.0.0-next.5 -> 9.0.0-next.8 ng update @angular/cli --next
```
And it still looks fine with non-next versions
```
  Name                                               Version                  Command to update
 ------------------------------------------------------------------------------------------------
  @angular/cli                                       8.0.0 -> 8.3.8           ng update @angular/cli
```

Fixes #15784