### PR TITLE
refactor(@angular-devkit/build-angular): initial copy-on-write asset processing support

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
@@ -194,7 +194,10 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
   }
 
   // process asset entries
-  if (buildOptions.assets) {
+  if (
+    buildOptions.assets &&
+    (fullDifferential || buildOptions.watch || !differentialLoadingNeeded)
+  ) {
     const copyWebpackPluginPatterns = buildOptions.assets.map((asset: AssetPatternClass) => {
       // Resolve input paths relative to workspace root and add slash at the end.
       asset.input = path.resolve(root, asset.input).replace(/\\/g, '/');

--- a/packages/angular_devkit/build_angular/src/utils/copy-assets.ts
+++ b/packages/angular_devkit/build_angular/src/utils/copy-assets.ts
@@ -1,0 +1,53 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import * as fs from 'fs';
+import * as glob from 'glob';
+import * as path from 'path';
+import { copyFile } from './copy-file';
+
+function globAsync(pattern: string, options: glob.IOptions) {
+  return new Promise<string[]>((resolve, reject) =>
+    glob(pattern, options, (e, m) => (e ? reject(e) : resolve(m))),
+  );
+}
+
+export async function copyAssets(
+  entries: { glob: string; ignore?: string[]; input: string; output: string; flatten?: boolean }[],
+  basePaths: Iterable<string>,
+  root: string,
+  changed?: Set<string>,
+) {
+  const defaultIgnore = ['.gitkeep', '**/.DS_Store', '**/Thumbs.db'];
+
+  for (const entry of entries) {
+    const cwd = path.resolve(root, entry.input);
+    const files = await globAsync(entry.glob, {
+      cwd,
+      dot: true,
+      ignore: entry.ignore ? defaultIgnore.concat(entry.ignore) : defaultIgnore,
+    });
+
+    for (const file of files) {
+      const src = path.join(cwd, file);
+      if (changed && !changed.has(src)) {
+        continue;
+      }
+
+      const filePath = entry.flatten ? path.basename(file) : file;
+      for (const base of basePaths) {
+        const dest = path.join(base, entry.output, filePath);
+        const dir = path.dirname(dest);
+        if (!fs.existsSync(dir)) {
+          // tslint:disable-next-line: no-any
+          fs.mkdirSync(dir, { recursive: true } as any);
+        }
+        copyFile(src, dest);
+      }
+    }
+  }
+}

--- a/packages/angular_devkit/build_angular/src/utils/copy-file.ts
+++ b/packages/angular_devkit/build_angular/src/utils/copy-file.ts
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import * as fs from 'fs';
+
+// Workaround Node.js issue prior to 10.16 with copyFile on macOS
+// https://github.com/angular/angular-cli/issues/15544 & https://github.com/nodejs/node/pull/27241
+let copyFileWorkaround = false;
+if (process.platform === 'darwin') {
+  const version = process.versions.node.split('.').map(part => Number(part));
+  if (version[0] < 10 || version[0] === 11 || (version[0] === 10 && version[1] < 16)) {
+    copyFileWorkaround = true;
+  }
+}
+
+export function copyFile(src: fs.PathLike, dest: fs.PathLike): void {
+  if (copyFileWorkaround) {
+    try {
+      fs.unlinkSync(dest);
+    } catch {}
+  }
+
+  fs.copyFileSync(src, dest, fs.constants.COPYFILE_FICLONE);
+}


### PR DESCRIPTION
This is currently only supported when performing a differential loading build (no watch mode).  This will eventually be expanded to cover watch mode and non-differential loading builds.