### PR TITLE
feat(@angular-devkit/build-angular): add support for i18n extraction …

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/typescript.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/typescript.ts
@@ -68,6 +68,12 @@ function _createAotPlugin(
       i18nInFormat: buildOptions.i18nFormat,
     };
 
+  const compilerOptions = options.compilerOptions || {};
+  if (i18nExtract) {
+    // Extraction of i18n is still using the legacy VE pipeline
+    compilerOptions.enableIvy = false;
+  }
+
   const additionalLazyModules: { [module: string]: string } = {};
   if (buildOptions.lazyModules) {
     for (const lazyModule of buildOptions.lazyModules) {
@@ -92,6 +98,7 @@ function _createAotPlugin(
     logger: wco.logger,
     directTemplateLoading: true,
     ...options,
+    compilerOptions,
   };
 
   pluginOptions = _pluginOptionsOverrides(buildOptions, pluginOptions);

--- a/packages/angular_devkit/build_angular/src/extract-i18n/index.ts
+++ b/packages/angular_devkit/build_angular/src/extract-i18n/index.ts
@@ -20,7 +20,6 @@ import {
   getStatsConfig,
   getStylesConfig,
 } from '../angular-cli-files/models/webpack-configs';
-import { readTsconfig } from '../angular-cli-files/utilities/read-tsconfig';
 import { statsErrorsToString, statsWarningsToString } from '../angular-cli-files/utilities/stats';
 import { Schema as BrowserBuilderOptions } from '../browser/schema';
 import { assertCompatibleAngularVersion } from '../utils/version';
@@ -58,15 +57,6 @@ async function execute(options: ExtractI18nBuilderOptions, context: BuilderConte
     await context.getTargetOptions(browserTarget),
     await context.getBuilderNameForTarget(browserTarget),
   );
-
-  // FIXME: i18n is not yet implemented in Ivy
-  // We should display a warning and exit gracefully.
-  const { options: compilerOptions } = readTsconfig(browserOptions.tsConfig, context.workspaceRoot);
-  if (compilerOptions.enableIvy) {
-    context.logger.warn('We are sorry but i18n is not yet implemented in Ivy.');
-
-    return { success: true };
-  }
 
   // We need to determine the outFile name so that AngularCompiler can retrieve it.
   let outFile = options.outFile || getI18nOutfile(options.i18nFormat);

--- a/packages/angular_devkit/build_angular/test/extract-i18n/works_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/extract-i18n/works_spec_large.ts
@@ -8,11 +8,10 @@
 import { Architect } from '@angular-devkit/architect';
 import { TestLogger } from '@angular-devkit/architect/testing';
 import { join, normalize, virtualFs } from '@angular-devkit/core';
-import { createArchitect, extractI18nTargetSpec, host, veEnabled } from '../utils';
+import { createArchitect, extractI18nTargetSpec, host } from '../utils';
 
 
-// DISABLED_FOR_IVY   These should pass but are currently not supported
-(veEnabled ? describe : xdescribe)('Extract i18n Target', () => {
+describe('Extract i18n Target', () => {
   const extractionFile = join(normalize('src'), 'messages.xlf');
   let architect: Architect;
 

--- a/tests/legacy-cli/e2e_runner.ts
+++ b/tests/legacy-cli/e2e_runner.ts
@@ -100,8 +100,7 @@ if (!argv.ve) {
   // As we transition into using Ivy as the default this list should be reassessed.
   allTests = allTests
     // Ivy doesn't support i18n externally at the moment.
-    .filter(name => !name.includes('tests/i18n/'))
-    .filter(name => !name.endsWith('tests/build/aot/aot-i18n.ts'))
+    .filter(name => !name.endsWith('tests/build/aot/aot-i18n.ts'));
 }
 
 const shardId = 'shard' in argv ? argv['shard'] : null;


### PR DESCRIPTION
…with Ivy

Re-enable i18n extraction in Ivy by using the legacy VE compiler.