### PR TITLE
fix(@angular-devkit/build-angular): favour sass over node-sass

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/styles.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/styles.ts
@@ -124,10 +124,10 @@ export function getStylesConfig(wco: WebpackConfigOptions) {
 
   let sassImplementation: {} | undefined;
   try {
+    sassImplementation = require('sass');
+  } catch {
     // tslint:disable-next-line:no-implicit-dependencies
     sassImplementation = require('node-sass');
-  } catch {
-    sassImplementation = require('sass');
   }
 
   // set base rules to derive final rules from


### PR DESCRIPTION
Fixes #15806