### PR TITLE
feat(@angular/cli): add support for ng-add packages that should not b…

### DIFF
--- a/packages/angular/cli/tasks/npm-uninstall.ts
+++ b/packages/angular/cli/tasks/npm-uninstall.ts
@@ -9,58 +9,43 @@
 import { logging } from '@angular-devkit/core';
 import { spawn } from 'child_process';
 import { colors } from '../utilities/color';
-import { NgAddSaveDepedency } from '../utilities/package-metadata';
 
 export default async function(
   packageName: string,
   logger: logging.Logger,
   packageManager: string,
-  save: NgAddSaveDepedency = true,
 ) {
   const installArgs: string[] = [];
   switch (packageManager) {
     case 'cnpm':
     case 'pnpm':
     case 'npm':
-      installArgs.push('install');
+      installArgs.push('uninstall');
       break;
 
     case 'yarn':
-      installArgs.push('add');
+      installArgs.push('remove');
       break;
 
     default:
       packageManager = 'npm';
-      installArgs.push('install');
+      installArgs.push('uninstall');
       break;
   }
 
-  logger.info(colors.green(`Installing packages for tooling via ${packageManager}.`));
+  installArgs.push(packageName, '--quiet');
 
-  if (packageName) {
-    installArgs.push(packageName);
-  }
-
-  if (!save) {
-    // IMP: yarn doesn't have a no-save option
-    installArgs.push('--no-save');
-  }
-
-  if (save === 'devDependencies') {
-    installArgs.push(packageManager === 'yarn' ? '--dev' : '--save-dev');
-  }
-
-  installArgs.push('--quiet');
+  logger.info(colors.green(`Uninstalling packages for tooling via ${packageManager}.`));
 
   await new Promise((resolve, reject) => {
     spawn(packageManager, installArgs, { stdio: 'inherit', shell: true }).on(
       'close',
       (code: number) => {
         if (code === 0) {
-          logger.info(colors.green(`Installed packages for tooling via ${packageManager}.`));
+          logger.info(colors.green(`Uninstalling packages for tooling via ${packageManager}.`));
           resolve();
         } else {
-          reject('Package install failed, see above.');
+          reject('Package uninstallation failed, see above.');
         }
       },
     );

--- a/packages/angular/cli/utilities/package-metadata.ts
+++ b/packages/angular/cli/utilities/package-metadata.ts
@@ -18,6 +18,8 @@ export interface PackageDependencies {
   [dependency: string]: string;
 }
 
+export type NgAddSaveDepedency = 'dependencies' | 'devDependencies' | boolean;
+
 export interface PackageIdentifier {
   type: 'git' | 'tag' | 'version' | 'range' | 'file' | 'directory' | 'remote';
   name: string;
@@ -39,8 +41,9 @@ export interface PackageManifest {
   devDependencies: PackageDependencies;
   peerDependencies: PackageDependencies;
   optionalDependencies: PackageDependencies;
-
-  'ng-add'?: {};
+  'ng-add'?: {
+    save?: NgAddSaveDepedency;
+  };
   'ng-update'?: {
     migrations: string;
     packageGroup: { [name: string]: string };

--- a/packages/angular/cli/utilities/package-tree.ts
+++ b/packages/angular/cli/utilities/package-tree.ts
@@ -5,6 +5,10 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+
+
+import { NgAddSaveDepedency } from './package-metadata';
+
 export interface PackageTreeNodeBase {
   name: string;
   path: string;
@@ -21,6 +25,9 @@ export interface PackageTreeNodeBase {
     optionalDependencies?: Record<string, string>;
     'ng-update'?: {
       migrations?: string;
+    };
+    'ng-add'?: {
+      save?: NgAddSaveDepedency;
     };
   };
   parent?: PackageTreeNode;

--- a/packages/angular/pwa/package.json
+++ b/packages/angular/pwa/package.json
@@ -9,6 +9,9 @@
     "schematics"
   ],
   "schematics": "./collection.json",
+  "ng-add": {
+    "save": false
+  },
   "dependencies": {
     "@angular-devkit/core": "0.0.0",
     "@angular-devkit/schematics": "0.0.0",

--- a/packages/schematics/angular/migrations/update-8/update-dependencies.ts
+++ b/packages/schematics/angular/migrations/update-8/update-dependencies.ts
@@ -12,7 +12,7 @@ import { latestVersions } from '../../utility/latest-versions';
 export function updateDependencies() {
   return (host: Tree) => {
     const dependenciesToUpdate: Record<string, string> = {
-      '@angular/pwa': latestVersions.AngularPWA,
+      '@angular/pwa': '^0.803.9',
       '@angular-devkit/build-angular': latestVersions.DevkitBuildAngular,
       '@angular-devkit/build-ng-packagr': latestVersions.DevkitBuildNgPackagr,
       '@angular-devkit/build-webpack': latestVersions.DevkitBuildWebpack,

--- a/packages/schematics/angular/migrations/update-9/update-dependencies.ts
+++ b/packages/schematics/angular/migrations/update-9/update-dependencies.ts
@@ -6,13 +6,16 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import { Rule } from '@angular-devkit/schematics';
-import { addPackageJsonDependency, getPackageJsonDependency } from '../../utility/dependencies';
+import {
+  addPackageJsonDependency,
+  getPackageJsonDependency,
+  removePackageJsonDependency,
+} from '../../utility/dependencies';
 import { latestVersions } from '../../utility/latest-versions';
 
 export function updateDependencies(): Rule {
   return host => {
     const dependenciesToUpdate: Record<string, string> = {
-      '@angular/pwa': latestVersions.AngularPWA,
       '@angular-devkit/build-angular': latestVersions.DevkitBuildAngular,
       '@angular-devkit/build-ng-packagr': latestVersions.DevkitBuildNgPackagr,
       '@angular-devkit/build-webpack': latestVersions.DevkitBuildWebpack,
@@ -35,5 +38,8 @@ export function updateDependencies(): Rule {
         overwrite: true,
       });
     }
+
+    // `@angular/pwa` package is only needed when running `ng-add`.
+    removePackageJsonDependency(host, '@angular/pwa');
   };
 }

--- a/packages/schematics/angular/utility/latest-versions.ts
+++ b/packages/schematics/angular/utility/latest-versions.ts
@@ -18,7 +18,6 @@ export const latestVersions = {
   DevkitBuildAngular: '~0.900.0-next.9',
   DevkitBuildNgPackagr: '~0.900.0-next.9',
   DevkitBuildWebpack: '~0.900.0-next.9',
-  AngularPWA: '~0.900.0-next.9',
 
   ngPackagr: '^5.5.1',
 };

--- a/tests/legacy-cli/e2e/tests/commands/add/add-pwa.ts
+++ b/tests/legacy-cli/e2e/tests/commands/add/add-pwa.ts
@@ -1,0 +1,20 @@
+import { join } from 'path';
+import { expectFileToExist, expectFileToMatch, rimraf, readFile } from '../../../utils/fs';
+import { ng } from '../../../utils/process';
+
+export default async function () {
+    // forcibly remove in case another test doesn't clean itself up
+    await rimraf('node_modules/@angular/pwa');
+
+    await ng('add', '@angular/pwa');
+
+    await expectFileToExist(join(process.cwd(), 'src/manifest.webmanifest'));
+
+    // Angular PWA doesn't install as a dependency
+    const { dependencies, devDependencies } = JSON.parse(await readFile(join(process.cwd(), 'package.json')));
+    const hasPWADep = Object.keys({ ...dependencies, ...devDependencies })
+        .some(d => d === '@angular/pwa');
+    if (hasPWADep) {
+        throw new Error(`Expected 'package.json' not to contain a dependency on '@angular/pwa'.`);
+    }
+}


### PR DESCRIPTION
feat(@angular/cli): add support for ng-add packages that should not be saved as `dependencies`

With this change the CLI offers a way for a package authors to specify if during `ng add` the package should be saved as a `dependencies`, `devDependencies` or not saved at all.

Such config needs to be specified in `package.json`

Example:
```json
  "ng-add": {
    "save": false
  }
```

Possible values are;
- false - Don't add the package to `package.json`
- true - Add the package to the `dependencies`
- `dependencies` - Add the package to the `dependencies`
- `devDependencies` - Add the package to the `devDependencies `

Closes #12003 , closes #15764 and closes #13237