### PR TITLE
fix(@angular-devkit/build-angular): avoid attempting to copy directories

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/copy-assets.ts
+++ b/packages/angular_devkit/build_angular/src/utils/copy-assets.ts
@@ -29,8 +29,11 @@ export async function copyAssets(
     const files = await globAsync(entry.glob, {
       cwd,
       dot: true,
+      nodir: true,
       ignore: entry.ignore ? defaultIgnore.concat(entry.ignore) : defaultIgnore,
     });
+
+    const directoryExists = new Set<string>();
 
     for (const file of files) {
       const src = path.join(cwd, file);
@@ -42,9 +45,11 @@ export async function copyAssets(
       for (const base of basePaths) {
         const dest = path.join(base, entry.output, filePath);
         const dir = path.dirname(dest);
-        if (!fs.existsSync(dir)) {
-          // tslint:disable-next-line: no-any
-          fs.mkdirSync(dir, { recursive: true } as any);
+        if (!directoryExists.has(dir)) {
+          if (!fs.existsSync(dir)) {
+            fs.mkdirSync(dir, { recursive: true });
+          }
+          directoryExists.add(dir);
         }
         copyFile(src, dest);
       }

--- a/packages/angular_devkit/build_angular/test/browser/assets_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/browser/assets_spec_large.ts
@@ -28,6 +28,7 @@ describe('Browser Builder assets', () => {
       './src/folder/.gitkeep': '',
       './src/string-file-asset.txt': 'string-file-asset.txt',
       './src/string-folder-asset/file.txt': 'string-folder-asset.txt',
+      './src/nested/nested/file.txt': 'nested-file.txt',
       './src/glob-asset.txt': 'glob-asset.txt',
       './src/folder/folder-asset.txt': 'folder-asset.txt',
       './src/output-asset.txt': 'output-asset.txt',
@@ -35,6 +36,7 @@ describe('Browser Builder assets', () => {
     const matches: { [path: string]: string } = {
       './dist/string-file-asset.txt': 'string-file-asset.txt',
       './dist/string-folder-asset/file.txt': 'string-folder-asset.txt',
+      './dist/nested/nested/file.txt': 'nested-file.txt',
       './dist/glob-asset.txt': 'glob-asset.txt',
       './dist/folder/folder-asset.txt': 'folder-asset.txt',
       './dist/output-folder/output-asset.txt': 'output-asset.txt',
@@ -43,6 +45,7 @@ describe('Browser Builder assets', () => {
 
     const overrides = {
       assets: [
+        'src/nested',
         'src/string-file-asset.txt',
         'src/string-folder-asset',
         { glob: 'glob-asset.txt', input: 'src/', output: '/' },


### PR DESCRIPTION
Avoid copying directly directories, also which this change we cache `fs.existsSync` to optimize copying when a lot of files are being copied to the same destination.

Closes: #15816