### PR TITLE
test: fix i18n extraction e2e test (Make master green)

### DIFF
--- a/tests/legacy-cli/e2e/tests/build/aot/aot-i18n.ts
+++ b/tests/legacy-cli/e2e/tests/build/aot/aot-i18n.ts
@@ -82,7 +82,7 @@ export default async function () {
   // Extract the translation messages and copy them for each language.
   await ng('xi18n', '--output-path=src/locale');
   await expectFileToExist('src/locale/messages.xlf');
-  await expectFileToMatch('src/locale/messages.xlf', `source-language="en"`);
+  await expectFileToMatch('src/locale/messages.xlf', `source-language="en-US"`);
   await expectFileToMatch('src/locale/messages.xlf', `An introduction header for this sample`);
 
   for (const { lang, translation } of langTranslations) {


### PR DESCRIPTION
The default `source-language` is `en-US` and not `en`.