### PR TITLE
Determine relative paths correctly

### DIFF
--- a/packages/angular/cli/commands/update-impl.ts
+++ b/packages/angular/cli/commands/update-impl.ts
@@ -550,6 +550,7 @@ export class UpdateCommand extends Command<UpdateCommandSchema> {
 
   checkCleanGit() {
     try {
+      const topLevel = execSync('git rev-parse --show-toplevel', { encoding: 'utf8', stdio: 'pipe' });
       const result = execSync('git status --porcelain', { encoding: 'utf8', stdio: 'pipe' });
       if (result.trim().length === 0) {
         return true;
@@ -559,7 +560,7 @@ export class UpdateCommand extends Command<UpdateCommandSchema> {
       for (const entry of result.split('\n')) {
         const relativeEntry = path.relative(
           path.resolve(this.workspace.root),
-          path.resolve(entry.slice(3).trim()),
+          path.resolve(topLevel.trim(), entry.slice(3).trim()),
         );
 
         if (!relativeEntry.startsWith('..') && !path.isAbsolute(relativeEntry)) {

--- a/tests/legacy-cli/e2e/tests/misc/update-git-clean-subdirectory.ts
+++ b/tests/legacy-cli/e2e/tests/misc/update-git-clean-subdirectory.ts
@@ -1,0 +1,26 @@
+import { createDir, writeFile } from '../../utils/fs';
+import { expectToFail } from '../../utils/utils';
+import { getGlobalVariable } from '../../utils/env';
+import { ng, silentGit } from '../../utils/process';
+import { prepareProjectForE2e } from '../../utils/project'
+
+export default async function() {
+  process.chdir(getGlobalVariable('tmp-root'));
+
+  await createDir('./subdirectory');
+  process.chdir('./subdirectory');
+
+  await silentGit('init', '.');
+
+  await ng('new', 'subdirectory-test-project', '--skip-install');
+  process.chdir('./subdirectory-test-project');
+  await prepareProjectForE2e('subdirectory-test-project');
+
+  await writeFile('../added.ts', 'console.log(\'created\');\n');
+  await silentGit('add', '../added.ts');
+
+  const { message } = await expectToFail(() => ng('update', '--all'));
+  if (message && message.includes('Repository is not clean.')) {
+    throw new Error('Expected clean repository');
+  }
+}


### PR DESCRIPTION
As `git status --porcelain` always shows paths relative to the top
level, fetch the top level path in `checkCleanGit` and properly
determine whether any modified files are actually within the
Angular workspace root.