### PR TITLE
fix(@schematics/angular): rename the `ivy-ngcc` command to `ngcc`

### DIFF
--- a/packages/schematics/angular/workspace/files/package.json.template
+++ b/packages/schematics/angular/workspace/files/package.json.template
@@ -8,7 +8,7 @@
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e",
-    "postinstall": "ivy-ngcc --properties es2015 --create-ivy-entry-points"
+    "postinstall": "ngcc --properties es2015 --create-ivy-entry-points"
   },
   "private": true,
   "dependencies": {

--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -95,7 +95,7 @@ export default function(args: ParsedArgs, logger: logging.Logger) {
   } else if (args.shard !== undefined) {
     // CI is really flaky with NGCC
     // This is a working around test order and isolation issues.
-    execSync('./node_modules/.bin/ivy-ngcc', { stdio: 'inherit' });
+    execSync('./node_modules/.bin/ngcc', { stdio: 'inherit' });
   }
 
   if (args.large) {


### PR DESCRIPTION
With angular/angular#33140, the Angular Compatibility Compiler executable will be renamed from `ivy-ngcc` to `ngcc`.