### PR TITLE
fix(@schematics/angular): remove unneeded debugElement in test

### DIFF
--- a/packages/schematics/angular/application/other-files/app.component.spec.ts.template
+++ b/packages/schematics/angular/application/other-files/app.component.spec.ts.template
@@ -16,20 +16,20 @@ describe('AppComponent', () => {
 
   it('should create the app', () => {
     const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.debugElement.componentInstance;
+    const app = fixture.componentInstance;
     expect(app).toBeTruthy();
   });
 
   it(`should have as title '<%= name %>'`, () => {
     const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.debugElement.componentInstance;
+    const app = fixture.componentInstance;
     expect(app.title).toEqual('<%= name %>');
   });
 
   it('should render title', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
-    const compiled = fixture.debugElement.nativeElement;
+    const compiled = fixture.nativeElement;
     expect(compiled.querySelector('.content span').textContent).toContain('<%= name %> app is running!');
   });
 });


### PR DESCRIPTION
The generate tests in `app.component.spec.ts` are using `fixture.debugElement.componentInstance` whereas we can directly use `fixture.componentInstance`. This fixes the generated test to show a better example to users discovering unit tests.