### PR TITLE
feat(@schematics/angular): update @types/node for version 9

### DIFF
--- a/packages/schematics/angular/migrations/update-9/update-dependencies.ts
+++ b/packages/schematics/angular/migrations/update-9/update-dependencies.ts
@@ -23,6 +23,7 @@ export function updateDependencies(): Rule {
       'ng-packagr': latestVersions.ngPackagr,
       'web-animations-js': '^2.3.2',
       'codelyzer': '^5.1.2',
+      '@types/node': '^12.11.1',
     };
 
     for (const [name, version] of Object.entries(dependenciesToUpdate)) {


### PR DESCRIPTION
Angular will only support TS 3.6+ on version 9, and older versions of `@types/node` are incompatible with it and will cause all builds to fail.

Related to https://github.com/angular/angular/pull/33250