### PR TITLE
fix(@angular-devkit/build-angular): sockPath for custom path

### DIFF
--- a/packages/angular_devkit/build_angular/src/dev-server/index.ts
+++ b/packages/angular_devkit/build_angular/src/dev-server/index.ts
@@ -423,6 +423,10 @@ function _addLiveReload(
   if (clientAddress.pathname) {
     clientAddress.pathname = path.posix.join(clientAddress.pathname, 'sockjs-node');
     sockjsPath = '&sockPath=' + clientAddress.pathname;
+    // ensure webpack-dev-server uses the correct path to connect to the reloading socket
+    if (webpackConfig.devServer) {
+      webpackConfig.devServer.sockPath = clientAddress.pathname;
+    }
   }
 
   const entryPoints = [`${webpackDevServerPath}?${url.format(clientAddress)}${sockjsPath}`];


### PR DESCRIPTION
Fixes #9146 

# Issue

```bash
# setup project
ng new base-href-socket-path --style=css --inlineStyle=true --inlineTemplate=true --routing=false --minimal=true
# Start server with baseHref and publicHost
ng serve --baseHref="/my-app/" --publicHost="http://localhost:4200/my-app"
```

The auto-reload `sockjs-node/*` websocket requests fails with a 404:

E.g. `curl http://localhost:4200/my-app/sockjs-node/info` returns:
```html
> GET /my-app/sockjs-node/info HTTP/1.1
> Host: localhost:4200
> User-Agent: curl/7.54.0
> Accept: */*
>
< HTTP/1.1 404 Not Found
< X-Powered-By: Express
< Access-Control-Allow-Origin: *
< Content-Security-Policy: default-src 'none'
< X-Content-Type-Options: nosniff
< Content-Type: text/html; charset=utf-8
< Content-Length: 162
< Date: Sat, 19 Oct 2019 13:43:22 GMT
< Connection: keep-alive
<
<!DOCTYPE html>
<html lang="en">
<head>
<meta charset="utf-8">
<title>Error</title>
</head>
<body>
<pre>Cannot GET /my-app/sockjs-node/info</pre>
</body>
</html>
```

setting webpack dev-servers [`sockPath`](https://webpack.js.org/configuration/dev-server/#devserversockpath) to connect to reloading socket via custom path when serving the app on a custom path.

See https://github.com/micmro/angular-base-href-reload-socket-path-workaround for issue and a currently working workaround using `@angular-builders/custom-webpack`.