### PR TITLE
refactor(@ngtools/webpack): remove unneeded tree-kill dependency

### DIFF
--- a/packages/ngtools/webpack/package.json
+++ b/packages/ngtools/webpack/package.json
@@ -24,7 +24,6 @@
     "@angular-devkit/core": "0.0.0",
     "enhanced-resolve": "4.1.1",
     "rxjs": "6.5.3",
-    "tree-kill": "1.2.1",
     "webpack-sources": "1.4.3"
   },
   "peerDependencies": {

--- a/packages/ngtools/webpack/src/angular_compiler_plugin.ts
+++ b/packages/ngtools/webpack/src/angular_compiler_plugin.ts
@@ -83,8 +83,6 @@ import {
 } from './webpack';
 import { WebpackInputHost } from './webpack-input-host';
 
-const treeKill = require('tree-kill');
-
 export class AngularCompilerPlugin {
   private _options: AngularCompilerPluginOptions;
 
@@ -570,8 +568,10 @@ export class AngularCompilerPlugin {
   }
 
   private _killForkedTypeChecker() {
-    if (this._typeCheckerProcess && this._typeCheckerProcess.pid) {
-      treeKill(this._typeCheckerProcess.pid, 'SIGTERM');
+    if (this._typeCheckerProcess && !this._typeCheckerProcess.killed) {
+      try {
+        this._typeCheckerProcess.kill();
+      } catch {}
       this._typeCheckerProcess = null;
     }
   }


### PR DESCRIPTION
The forked type checker is only a single process and can be sent a signal directly.