### PR TITLE
docs: include major-verson update advice

### DIFF
--- a/packages/angular/cli/commands/update-long.md
+++ b/packages/angular/cli/commands/update-long.md
@@ -6,4 +6,12 @@ ng update @angular/cli @angular/core
 
 To update to the next beta or pre-release version, use the `--next=true` option.
 
+To update from one major version to another, use the format
+`ng update @angular/cli@^<major_version> @angular/core@^<major_version>`.
+
+We recommend that you always update to the latest patch version, as it contains fixes we released since the initial major release.
+For example, use the following command to take the latest 7.x.x version and use that to update.
+
+`ng update @angular/cli@^7 @angular/core@^7`
+
 For detailed information and guidance on updating your application, see the interactive [Angular Update Guide](https://update.angular.io/).


### PR DESCRIPTION
https://github.com/angular/angular/issues/31259 requests more detail in doc for `ng update` on how to update to a specific version.
This adds Igor's recommendation to the AIO doc for the `ng update` command.