### PR TITLE
refactor(@schematics/angular): remove deprecated `spec` and `styleext` options

### DIFF
--- a/packages/angular/cli/lib/config/schema.json
+++ b/packages/angular/cli/lib/config/schema.json
@@ -134,16 +134,6 @@
               "description": "Flag to skip the module import.",
               "default": false
             },
-            "spec": {
-              "type": "boolean",
-              "description": "Specifies if a spec file is generated.",
-              "default": true
-            },
-            "styleext": {
-              "description": "The file extension to be used for style files.",
-              "type": "string",
-              "default": "css"
-            },
             "style": {
               "description": "The file extension or preprocessor to use for style files.",
               "type": "string",
@@ -199,11 +189,6 @@
               "description": "Flag to skip the module import.",
               "default": false
             },
-            "spec": {
-              "type": "boolean",
-              "description": "Specifies if a spec file is generated.",
-              "default": true
-            },
             "skipTests": {
               "type": "boolean",
               "description": "When true, does not create test files.",
@@ -251,11 +236,6 @@
               "default": true,
               "description": "Flag to indicate if a directory is created."
             },
-            "spec": {
-              "type": "boolean",
-              "description": "Specifies if a spec file is generated.",
-              "default": true
-            },
             "skipTests": {
               "type": "boolean",
               "description": "When true, does not create test files.",
@@ -270,11 +250,6 @@
               "type": "boolean",
               "default": true,
               "description": "Flag to indicate if a directory is created."
-            },
-            "spec": {
-              "type": "boolean",
-              "description": "Specifies if a spec file is generated.",
-              "default": true
             },
             "skipTests": {
               "type": "boolean",
@@ -302,11 +277,6 @@
         "@schematics/angular:class": {
           "type": "object",
           "properties": {
-            "spec": {
-              "type": "boolean",
-              "description": "Specifies if a spec file is generated.",
-              "default": true
-            },
             "skipTests": {
               "type": "boolean",
               "description": "When true, does not create test files.",

--- a/packages/schematics/angular/class/index.ts
+++ b/packages/schematics/angular/class/index.ts
@@ -35,9 +35,6 @@ export default function (options: ClassOptions): Rule {
     options.name = parsedPath.name;
     options.path = parsedPath.path;
 
-    // todo remove these when we remove the deprecations
-    options.skipTests = options.skipTests || !options.spec;
-
     const templateSource = apply(url('./files'), [
       options.skipTests ? filter(path => !path.endsWith('.spec.ts.template')) : noop(),
       applyTemplates({

--- a/packages/schematics/angular/class/index_spec.ts
+++ b/packages/schematics/angular/class/index_spec.ts
@@ -19,7 +19,7 @@ describe('Class Schematic', () => {
   const defaultOptions: ClassOptions = {
     name: 'foo',
     type: '',
-    spec: false,
+    skipTests: true,
     project: 'bar',
   };
 
@@ -55,7 +55,7 @@ describe('Class Schematic', () => {
   it('should create the class and spec file', async () => {
     const options = {
       ...defaultOptions,
-      spec: true,
+      skipTests: false,
     };
     const tree = await schematicRunner.runSchematicAsync('class', options, appTree)
       .toPromise();

--- a/packages/schematics/angular/class/schema.json
+++ b/packages/schematics/angular/class/schema.json
@@ -27,12 +27,6 @@
         "$source": "projectName"
       }
     },
-    "spec": {
-      "type": "boolean",
-      "description": "When true (the default), generates a  \"spec.ts\" test file for the new class.",
-      "default": true,
-      "x-deprecated": "Use \"skipTests\" instead."
-    },
     "skipTests": {
       "type": "boolean",
       "description": "When true, does not create \"spec.ts\" test files for the new class.",

--- a/packages/schematics/angular/component/index.ts
+++ b/packages/schematics/angular/component/index.ts
@@ -143,13 +143,6 @@ export default function (options: ComponentOptions): Rule {
     options.path = parsedPath.path;
     options.selector = options.selector || buildSelector(options, project && project.prefix || '');
 
-    // todo remove these when we remove the deprecations
-    options.style = (
-      options.style && options.style !== Style.Css
-        ? options.style : options.styleext as Style
-    ) || Style.Css;
-    options.skipTests = options.skipTests || !options.spec;
-
     validateName(options.name);
     validateHtmlSelector(options.selector);
 

--- a/packages/schematics/angular/component/index_spec.ts
+++ b/packages/schematics/angular/component/index_spec.ts
@@ -333,33 +333,4 @@ describe('Component Schematic', () => {
       .toPromise();
     expect(appTree.files).toContain('/projects/bar/custom/app/foo/foo.component.ts');
   });
-
-  // testing deprecating options don't cause conflicts
-  it('should respect the deprecated styleext (scss) option', async () => {
-    const options = { ...defaultOptions, style: undefined, styleext: 'scss' };
-    const tree = await schematicRunner.runSchematicAsync('component', options, appTree).toPromise();
-    const files = tree.files;
-    expect(files).toContain('/projects/bar/src/app/foo/foo.component.scss');
-  });
-
-  it('should respect the deprecated styleext (css) option', async () => {
-    const options = { ...defaultOptions, style: undefined, styleext: 'css' };
-    const tree = await schematicRunner.runSchematicAsync('component', options, appTree).toPromise();
-    const files = tree.files;
-    expect(files).toContain('/projects/bar/src/app/foo/foo.component.css');
-  });
-
-  it('should respect the deprecated spec option when false', async () => {
-    const options = { ...defaultOptions, skipTests: undefined, spec: false };
-    const tree = await schematicRunner.runSchematicAsync('component', options, appTree).toPromise();
-    const files = tree.files;
-    expect(files).not.toContain('/projects/bar/src/app/foo/foo.component.spec.ts');
-  });
-
-  it('should respect the deprecated spec option when true', async () => {
-    const options = { ...defaultOptions, skipTests: false, spec: true };
-    const tree = await schematicRunner.runSchematicAsync('component', options, appTree).toPromise();
-    const files = tree.files;
-    expect(files).toContain('/projects/bar/src/app/foo/foo.component.spec.ts');
-  });
 });

--- a/packages/schematics/angular/component/schema.json
+++ b/packages/schematics/angular/component/schema.json
@@ -69,12 +69,6 @@
         }
       ]
     },
-    "styleext": {
-      "description": "The file extension to use for style files.",
-      "type": "string",
-      "default": "css",
-      "x-deprecated": "Use \"style\" instead."
-    },
     "style": {
       "description": "The file extension or preprocessor to use for style files.",
       "type": "string",
@@ -92,12 +86,6 @@
       "type": "string",
       "description": "Adds a developer-defined type to the filename, in the format \"name.type.ts\".",
       "default": "Component"
-    },
-    "spec": {
-      "type": "boolean",
-      "description": "When true (the default), generates a  \"spec.ts\" test file for the new component.",
-      "default": true,
-      "x-deprecated": "Use \"skipTests\" instead."
     },
     "skipTests": {
       "type": "boolean",

--- a/packages/schematics/angular/directive/index.ts
+++ b/packages/schematics/angular/directive/index.ts
@@ -121,9 +121,6 @@ export default function (options: DirectiveOptions): Rule {
 
     validateHtmlSelector(options.selector);
 
-    // todo remove these when we remove the deprecations
-    options.skipTests = options.skipTests || !options.spec;
-
     const templateSource = apply(url('./files'), [
       options.skipTests ? filter(path => !path.endsWith('.spec.ts.template')) : noop(),
       applyTemplates({

--- a/packages/schematics/angular/directive/schema.json
+++ b/packages/schematics/angular/directive/schema.json
@@ -41,12 +41,6 @@
         }
       ]
     },
-    "spec": {
-      "type": "boolean",
-      "description": "When true (the default), generates a  \"spec.ts\" test file for the new directive.",
-      "default": true,
-      "x-deprecated": "Use \"skipTests\" instead."
-    },
     "skipTests": {
       "type": "boolean",
       "description": "When true, does not create \"spec.ts\" test files for the new class.",

--- a/packages/schematics/angular/pipe/index.ts
+++ b/packages/schematics/angular/pipe/index.ts
@@ -96,9 +96,6 @@ export default function (options: PipeOptions): Rule {
     options.name = parsedPath.name;
     options.path = parsedPath.path;
 
-    // todo remove these when we remove the deprecations
-    options.skipTests = options.skipTests || !options.spec;
-
     const templateSource = apply(url('./files'), [
       options.skipTests ? filter(path => !path.endsWith('.spec.ts.template')) : noop(),
       applyTemplates({

--- a/packages/schematics/angular/pipe/index_spec.ts
+++ b/packages/schematics/angular/pipe/index_spec.ts
@@ -19,7 +19,6 @@ describe('Pipe Schematic', () => {
   );
   const defaultOptions: PipeOptions = {
     name: 'foo',
-    spec: true,
     module: undefined,
     export: false,
     flat: true,

--- a/packages/schematics/angular/pipe/schema.json
+++ b/packages/schematics/angular/pipe/schema.json
@@ -32,12 +32,6 @@
       "default": true,
       "description": "When true (the default) creates files at the top level of the project."
     },
-    "spec": {
-      "type": "boolean",
-      "default": true,
-      "description": "When true (the default), generates a  \"spec.ts\" test file for the new pipe.",
-      "x-deprecated": "Use \"skipTests\" instead."
-    },
     "skipTests": {
       "type": "boolean",
       "description": "When true, does not create \"spec.ts\" test files for the new pipe.",

--- a/packages/schematics/angular/service/index.ts
+++ b/packages/schematics/angular/service/index.ts
@@ -33,9 +33,6 @@ export default function (options: ServiceOptions): Rule {
     options.name = parsedPath.name;
     options.path = parsedPath.path;
 
-    // todo remove these when we remove the deprecations
-    options.skipTests = options.skipTests || !options.spec;
-
     const templateSource = apply(url('./files'), [
       options.skipTests ? filter(path => !path.endsWith('.spec.ts.template')) : noop(),
       applyTemplates({

--- a/packages/schematics/angular/service/schema.json
+++ b/packages/schematics/angular/service/schema.json
@@ -32,12 +32,6 @@
       "default": true,
       "description": "When true (the default), creates files at the top level of the project."
     },
-    "spec": {
-      "type": "boolean",
-      "default": true,
-      "description": "When true (the default), generates a  \"spec.ts\" test file for the new service.",
-      "x-deprecated": "Use \"skipTests\" instead."
-    },
     "skipTests": {
       "type": "boolean",
       "description": "When true, does not create \"spec.ts\" test files for the new service.",

--- a/tests/legacy-cli/e2e/tests/commands/new/new-style.ts
+++ b/tests/legacy-cli/e2e/tests/commands/new/new-style.ts
@@ -5,7 +5,7 @@ import {expectFileToExist} from '../../../utils/fs';
 
 export default function() {
   return Promise.resolve()
-    .then(() => ng('config', 'defaults.styleExt', 'scss', '--global'))
+    .then(() => ng('config', 'defaults.style', 'scss', '--global'))
     .then(() => createProject('style-project'))
     .then(() => expectFileToExist('src/app/app.component.scss'))
 


### PR DESCRIPTION

BREAKING CHANGE:

Deprecated `styleext` and `spec` options have been removed.  Use `style` and `skipTests` options instead.