### PR TITLE
refactor(@schematics/angular): remove hardcoded value of `newProjectR…

### DIFF
--- a/packages/schematics/angular/ng-new/index.ts
+++ b/packages/schematics/angular/ng-new/index.ts
@@ -40,7 +40,7 @@ export default function (options: NgNewOptions): Rule {
   const workspaceOptions: WorkspaceOptions = {
     name: options.name,
     version: options.version,
-    newProjectRoot: options.newProjectRoot || 'projects',
+    newProjectRoot: options.newProjectRoot,
     minimal: options.minimal,
     strict: options.strict,
   };


### PR DESCRIPTION
…oot`

the default value of `newProjectRoot` is already defined in the schema