### PR TITLE
fix(@angular-devkit/build-angular): keep licenses if extraction is disabled

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
@@ -380,7 +380,8 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
       safari10: true,
       output: {
         ecma: terserEcma,
-        comments: false,
+        // default behavior (undefined value) is to keep only important comments (licenses, etc.)
+        comments: !buildOptions.extractLicenses && undefined,
         webkit: true,
       },
       // On server, we don't want to compress anything. We still set the ngDevMode = false for it

--- a/packages/angular_devkit/build_angular/test/browser/bundle-budgets_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/browser/bundle-budgets_spec_large.ts
@@ -130,6 +130,7 @@ describe('Browser Builder bundle budgets', () => {
     it(`when 'bundle' budget`, async () => {
       const overrides = {
         optimization: true,
+        extractLicenses: true,
         budgets: [{ type: 'bundle', name: 'main', maximumError: '3Kb' }],
       };
 


### PR DESCRIPTION
Fixes #15890 
