### PR TITLE
fix(@schematics/angular): only ngcc in prepare

### DIFF
--- a/packages/schematics/angular/workspace/files/package.json.template
+++ b/packages/schematics/angular/workspace/files/package.json.template
@@ -8,7 +8,7 @@
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e",
-    "postinstall": "ngcc --properties es2015 browser module main --first-only --create-ivy-entry-points"
+    "prepare": "ngcc --properties es2015 browser module main --first-only --create-ivy-entry-points"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
This fix is to make is so an npm/yarn install with --production mode will not fail as ngcc won't have been installed yet. This allows for workflows with docker and other production build mechanics.