### PR TITLE
feat(@angular-devkit/build-angular): export protractor builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/index.ts
+++ b/packages/angular_devkit/build_angular/src/index.ts
@@ -50,6 +50,11 @@ export {
 } from './karma';
 
 export {
+  execute as executeProtractorBuilder,
+  ProtractorBuilderOptions,
+} from './protractor';
+
+export {
   execute as executeServerBuilder,
   ServerBuilderOptions,
   ServerBuilderOutput,

--- a/packages/angular_devkit/build_angular/src/protractor/index.ts
+++ b/packages/angular_devkit/build_angular/src/protractor/index.ts
@@ -76,7 +76,9 @@ async function updateWebdriver() {
   } as unknown as JSON);
 }
 
-async function execute(
+export { ProtractorBuilderOptions };
+
+export async function execute(
   options: ProtractorBuilderOptions,
   context: BuilderContext,
 ): Promise<BuilderOutput> {


### PR DESCRIPTION
When using custom builder for dev-server it is not possible to pass additional parameters through protractor builder to it (`ng e2e --additionalParam`) does not work.

Thus, exposing protractor builder (`executeProtractorBuilder`) would allow building custom protractor builders that internally use custom dev-server builders with additional parameters.