### PR TITLE
fix(@angular/cli): updated CLI should not have analytics enabled

### DIFF
--- a/packages/angular/cli/tasks/install-package.ts
+++ b/packages/angular/cli/tasks/install-package.ts
@@ -155,6 +155,7 @@ export function runTempPackageBin(
     env: {
       ...process.env,
       NG_DISABLE_VERSION_CHECK: 'true',
+      NG_CLI_ANALYTICS: 'false',
     },
   });
 


### PR DESCRIPTION
In the case users don't have analytics globally configured when the CLI will self update during ng update. It will prompt to configure this.

However, afterwards the update will fail with `Repository is not clean.  Please commit or stash any changes before updating.` as there would be uncommited local changed.