### PR TITLE
feat(@angular/cli): Support XDG Base Directory Specfication

### DIFF
--- a/packages/angular/cli/utilities/config.ts
+++ b/packages/angular/cli/utilities/config.ts
@@ -31,6 +31,13 @@ export const workspaceSchemaPath = getSchemaLocation();
 const configNames = [ 'angular.json', '.angular.json' ];
 const globalFileName = '.angular-config.json';
 
+function xdgConfigHome(home: string, configFile?: string): string {
+  // https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+  const p = process.env['XDG_CONFIG_HOME'] || path.join(home, '.config', 'angular');
+  
+  return configFile ? path.join(p, configFile) : p;
+}
+
 function projectFilePath(projectPath?: string): string | null {
   // Find the configuration, either where specified, in the Angular CLI project
   // (if it's in node_modules) or from the current process.
@@ -43,6 +50,15 @@ function globalFilePath(): string | null {
   const home = os.homedir();
   if (!home) {
     return null;
+  }
+
+  // follow XDG Base Directory spec
+  // note that createGlobalSettings() will continue creating
+  // global file in home directory, with this user will have
+  // choice to move change its location to meet XDG convention
+  const xdgConfig = xdgConfigHome(home, globalFileName);
+  if (existsSync(xdgConfig)) {
+    return xdgConfig;
   }
 
   const p = path.join(home, globalFileName);


### PR DESCRIPTION
Explained here: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html

Current change affects reading of global config from `.angular-config.json`. By default it will be created in user's home directory. If user moves it manually to `$HOME/.config/angular/.angular-config.json`, it will be subsequently read from new location.