### PR TITLE
fix(@angular-devkit/build-angular): temporarily remove localize peer dependency

### DIFF
--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -101,7 +101,6 @@
   },
   "peerDependencies": {
     "@angular/compiler-cli": ">=9.0.0-beta < 10",
-    "@angular/localize": "^9.0.0-next.11",
     "typescript": ">=3.6 < 3.7"
   },
   "peerDependenciesMeta": {

--- a/packages/angular_devkit/build_angular/src/utils/load-translations.ts
+++ b/packages/angular_devkit/build_angular/src/utils/load-translations.ts
@@ -29,15 +29,15 @@ async function importParsers() {
   try {
     return {
       json: new (await import(
-        // tslint:disable-next-line:trailing-comma
+        // tslint:disable-next-line:trailing-comma no-implicit-dependencies
         '@angular/localize/src/tools/src/translate/translation_files/translation_parsers/simple_json/simple_json_translation_parser'
       )).SimpleJsonTranslationParser(),
       xlf: new (await import(
-        // tslint:disable-next-line:trailing-comma
+        // tslint:disable-next-line:trailing-comma no-implicit-dependencies
         '@angular/localize/src/tools/src/translate/translation_files/translation_parsers/xliff1/xliff1_translation_parser'
       )).Xliff1TranslationParser(),
       xlf2: new (await import(
-        // tslint:disable-next-line:trailing-comma
+        // tslint:disable-next-line:trailing-comma no-implicit-dependencies
         '@angular/localize/src/tools/src/translate/translation_files/translation_parsers/xliff2/xliff2_translation_parser'
       )).Xliff2TranslationParser(),
     };
@@ -45,17 +45,17 @@ async function importParsers() {
     return {
       json: new (await import(
         // @ts-ignore
-        // tslint:disable-next-line:trailing-comma
+        // tslint:disable-next-line:trailing-comma no-implicit-dependencies
         '@angular/localize/src/tools/src/translate/translation_files/translation_parsers/simple_json_translation_parser'
       )).SimpleJsonTranslationParser(),
       xlf: new (await import(
         // @ts-ignore
-        // tslint:disable-next-line:trailing-comma
+        // tslint:disable-next-line:trailing-comma no-implicit-dependencies
         '@angular/localize/src/tools/src/translate/translation_files/translation_parsers/xliff1_translation_parser'
       )).Xliff1TranslationParser(),
       xlf2: new (await import(
         // @ts-ignore
-        // tslint:disable-next-line:trailing-comma
+        // tslint:disable-next-line:trailing-comma no-implicit-dependencies
         '@angular/localize/src/tools/src/translate/translation_files/translation_parsers/xliff2_translation_parser'
       )).Xliff2TranslationParser(),
     };

--- a/packages/angular_devkit/build_angular/src/utils/process-bundle.ts
+++ b/packages/angular_devkit/build_angular/src/utils/process-bundle.ts
@@ -502,9 +502,10 @@ export async function inlineLocales(options: InlineOptions) {
   const { default: MagicString } = await import('magic-string');
   const { default: generate } = await import('@babel/generator');
   const utils = await import(
-    // tslint:disable-next-line: trailing-comma
+    // tslint:disable-next-line: trailing-comma no-implicit-dependencies
     '@angular/localize/src/tools/src/translate/source_files/source_file_utils'
   );
+  // tslint:disable-next-line: no-implicit-dependencies
   const localizeDiag = await import('@angular/localize/src/tools/src/diagnostics');
 
   const diagnostics = new localizeDiag.Diagnostics();
@@ -594,6 +595,7 @@ function inlineCopyOnly(options: InlineOptions) {
 
 function findLocalizePositions(
   options: InlineOptions,
+  // tslint:disable-next-line: no-implicit-dependencies
   utils: typeof import('@angular/localize/src/tools/src/translate/source_files/source_file_utils'),
 ): LocalizePosition[] {
   let ast: ParseResult | undefined | null;


### PR DESCRIPTION
This will simplify the update process for the 9.0 timeframe and does not cause any runtime changes.
This should be reintroduced in 9.1 or 9.2.  The other remaining "hidden" peer dependencies should be included as well (currently `karma` and `node-sass`) with proper version ranges.