### PR TITLE
refactor(@schematics/angular): deprecate component entryComponents

### DIFF
--- a/packages/schematics/angular/component/schema.json
+++ b/packages/schematics/angular/component/schema.json
@@ -128,7 +128,8 @@
     "entryComponent": {
       "type": "boolean",
       "default": false,
-      "description": "When true, the new component is the entry component of the declaring NgModule."
+      "description": "When true, the new component is the entry component of the declaring NgModule.",
+      "x-deprecated": "Since version 9.0.0 with Ivy, entryComponents is no longer necessary."
     },
     "lintFix": {
       "type": "boolean",

--- a/packages/schematics/angular/utility/ast-utils.ts
+++ b/packages/schematics/angular/utility/ast-utils.ts
@@ -537,6 +537,7 @@ export function addBootstrapToModule(source: ts.SourceFile,
 
 /**
  * Custom function to insert an entryComponent into NgModule. It also imports it.
+ * @deprecated - Since version 9.0.0 with Ivy, entryComponents is no longer necessary.
  */
 export function addEntryComponentToModule(source: ts.SourceFile,
                                           modulePath: string, classifiedName: string,


### PR DESCRIPTION
Since version 9.0.0 with Ivy, entryComponents is no longer necessary.