### PR TITLE
feat(@angular-devkit/build-angular): support TSLint 6.0+

### DIFF
--- a/packages/angular_devkit/build_angular/src/tslint/index.ts
+++ b/packages/angular_devkit/build_angular/src/tslint/index.ts
@@ -31,7 +31,11 @@ async function _loadTslint() {
   }
 
   const version = tslint.Linter.VERSION && tslint.Linter.VERSION.split('.');
-  if (!version || version.length < 2 || Number(version[0]) < 5 || Number(version[1]) < 5) {
+  if (
+    !version || version.length < 2
+    || (Number(version[0]) === 5 && Number(version[1]) < 5) // 5.5+
+    || Number(version[0]) < 5 // 6.0+
+  ) {
     throw new Error('TSLint must be version 5.5 or higher.');
   }
 


### PR DESCRIPTION
TSLint [6.0.0-beta0](https://github.com/palantir/tslint/releases/tag/6.0.0-beta0) was released, and `ng lint` throws with:

    TSLint must be version 5.5 or higher.

if we try to use it in a CLI project.

It looks like the current version check allows v5.5+ by checking that both the major and minor versions are > 5. So this fails with 6.0 (but would succeed with 6.5).
This fixes the check to allow using v6.0.