### PR TITLE
ci: bump cache key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,10 +16,10 @@ version: 2.1
 # Keep the static part of the cache key as prefix to enable correct fallbacks.
 # Windows needs its own cache key because binaries in node_modules are different.
 # See https://circleci.com/docs/2.0/caching/#restoring-cache for how prefixes work in CircleCI.
-var_1: &cache_key angular_devkit-0.11.0-{{ checksum "yarn.lock" }}
-var_2: &cache_key_fallback angular_devkit-0.11.0
-var_1_win: &cache_key_win angular_devkit-win-0.11.0-{{ checksum "yarn.lock" }}
-var_2_win: &cache_key_fallback_win angular_devkit-win-0.11.0
+var_1: &cache_key angular_devkit-0.12.0-{{ checksum "yarn.lock" }}
+var_2: &cache_key_fallback angular_devkit-0.12.0
+var_1_win: &cache_key_win angular_devkit-win-0.12.0-{{ checksum "yarn.lock" }}
+var_2_win: &cache_key_fallback_win angular_devkit-win-0.12.0
 var_3: &default_nodeversion "12.9"
 # Workspace initially persisted by the `setup` job, and then enhanced by `setup-and-build-win`.
 # https://circleci.com/docs/2.0/workflows/#using-workspaces-to-share-data-among-jobs


### PR DESCRIPTION
Our yarn cache is now at 4gb:
```
No cache is found for key: angular_devkit-0.11.0-m+RxJhhe6Gc_rzgntffBpEs5LmGYauhWKuRZBYBtlP0=
Found a cache from build 106076 at angular_devkit-0.11.0
Size: 4.0 GB
Cached paths:
  * /home/circleci/.cache/yarn

Downloading cache archive...
Unarchiving cache...
```

By bumping the cache key we'll reset it.