### PR TITLE
fix(@angular-devkit/benchmark): Allows the CLI repo to be hosted in a directory with spaces.

### DIFF
--- a/packages/angular_devkit/benchmark/src/monitored-process.ts
+++ b/packages/angular_devkit/benchmark/src/monitored-process.ts
@@ -37,7 +37,7 @@ export class LocalMonitoredProcess implements MonitoredProcess {
   run(): Observable<number> {
     return new Observable(obs => {
       const { cmd, cwd, args } = this.command;
-      const spawnOptions: SpawnOptions = { cwd: cwd, shell: true };
+      const spawnOptions: SpawnOptions = { cwd };
 
       // Spawn the process.
       const childProcess = spawn(cmd, args, spawnOptions);


### PR DESCRIPTION
`child_process.spawn()` with `shell: true` does not quote its arguments, so any data passed in must be surrounded by quotes to properly include spaces (https://github.com/nodejs/node/issues/5060). This was making tests fail when the repository is checked out to a directory with a space in it.

Easiest solution is to simply not use shell escaping which avoids the whole problem.

Alternatively, we could attempt to wrap every argument in quotes, but that would require escaping any existing quotes, which could cause other problems. In the [original PR](https://github.com/angular/angular-cli/pull/12022) for this file, I don't see a strong motivation for using `shell: true`, and all the tests pass without it, so I think the best solution is to just remove this flag.