### PR TITLE
docs: remove backticks from bug report in command section

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.md
@@ -17,7 +17,7 @@ Existing issues often contain information about workarounds, resolution, or prog
 ### Command (mark with an `x`)
 <!-- Can you pin-point the command or commands that are effected by this bug? -->
 <!-- ✍️edit: -->
-```
+
 - [ ] new
 - [ ] build
 - [ ] serve
@@ -33,7 +33,7 @@ Existing issues often contain information about workarounds, resolution, or prog
 - [ ] help
 - [ ] version
 - [ ] doc
-```
+
 
 ### Is this a regression?
 


### PR DESCRIPTION
With this change the author will be able to check the command in question after the issue creation.

Ex: https://github.com/angular/angular-cli/issues/16094