### PR TITLE
test: update FW size expectations

### DIFF
--- a/tests/legacy-cli/e2e/tests/build/prod-build.ts
+++ b/tests/legacy-cli/e2e/tests/build/prod-build.ts
@@ -57,8 +57,8 @@ export default async function () {
     verifySize(mainES5Path, 184470);
     verifySize(mainES2015Path, 163627);
   } else {
-    verifySize(mainES5Path, 148031);
-    verifySize(mainES2015Path, 137494);
+    verifySize(mainES5Path, 163321);
+    verifySize(mainES2015Path, 141032);
   }
 
   // Check that the process didn't change local files.


### PR DESCRIPTION
We verified this size change happens just from increasing FW version from 9.0.0-rc.0 to 9.0.0-rc.1

CLI master with FW rc.1:
```
141032 Nov  6 20:08 main-es2015.ed01ec5f480fa886325f.js
163321 Nov  6 20:08 main-es5.ed01ec5f480fa886325f.js
 36808 Nov  6 20:08 polyfills-es2015.b6fe2b19564e29c5d554.js
127927 Nov  6 20:08 polyfills-es5.9cbeb6b4a192c8c548fe.js
  1485 Nov  6 20:08 runtime-es2015.52756d3ab8e6582f0541.js
  1485 Nov  6 20:08 runtime-es5.52756d3ab8e6582f0541.js
```
CLI master with FW rc.0:
```
139902 Nov  6 20:05 main-es2015.cd909d61c6a4766689e9.js
162180 Nov  6 20:05 main-es5.cd909d61c6a4766689e9.js
 36808 Nov  6 20:05 polyfills-es2015.b6fe2b19564e29c5d554.js
127927 Nov  6 20:05 polyfills-es5.9cbeb6b4a192c8c548fe.js
  1485 Nov  6 20:05 runtime-es2015.52756d3ab8e6582f0541.js
  1485 Nov  6 20:05 runtime-es5.52756d3ab8e6582f0541.js
```

Likely related to these PRs:
- https://github.com/angular/angular/pull/33602
- https://github.com/angular/angular/pull/33540
- https://github.com/angular/angular/pull/31270