### PR TITLE
fix(@angular/cli): use spawned process error when it's available

### DIFF
--- a/packages/angular/cli/tasks/install-package.ts
+++ b/packages/angular/cli/tasks/install-package.ts
@@ -48,18 +48,18 @@ export function installPackage(
     installArgs.push(packageManagerArgs.saveDev);
   }
 
-  const { status, stderr, stdout } = spawnSync(packageManager, [...installArgs, ...extraArgs], {
+  const { status, stderr, stdout, error } = spawnSync(packageManager, [...installArgs, ...extraArgs], {
     stdio: 'pipe',
     encoding: 'utf8',
     cwd,
   });
 
   if (status !== 0) {
-    let error = (stderr || stdout).trim();
-    if (error) {
-      error += '\n';
+    let errorMessage = ((error && error.message) || stderr || stdout || '').trim();
+    if (errorMessage) {
+      errorMessage += '\n';
     }
-    throw new Error(error + `Package install failed${error ? ', see above' : ''}.`);
+    throw new Error(errorMessage + `Package install failed${errorMessage ? ', see above' : ''}.`);
   }
 
   logger.info(colors.green(`Installed packages for tooling via ${packageManager}.`));


### PR DESCRIPTION
In some cases when an error occurs in the spawned process the `error` property will be populated instead of `stderr` or `stdout`.

See: https://nodejs.org/api/child_process.html#child_process_child_process_spawnsync_command_args_options