### PR TITLE
fix(@angular/cli): Prints out when a commit is made in `ng update`.

### DIFF
--- a/tests/legacy-cli/e2e/tests/update/update-1.0.ts
+++ b/tests/legacy-cli/e2e/tests/update/update-1.0.ts
@@ -10,8 +10,7 @@ export default async function() {
 
   await useCIChrome('.');
   await expectToFail(() => ng('build'));
-  // Turn off git commits ('-C') per migration to avoid breaking E2E cleanup process
-  await ng('update', '@angular/cli', '-C');
+  await ng('update', '@angular/cli');
   await useBuiltPackages();
   await silentNpm('install');
   await ng('update', '@angular/core', ...extraUpdateArgs);

--- a/tests/legacy-cli/e2e/tests/update/update-1.7-longhand.ts
+++ b/tests/legacy-cli/e2e/tests/update/update-1.7-longhand.ts
@@ -9,8 +9,7 @@ export default async function() {
   await createProjectFromAsset('1.7-project');
 
   await expectToFail(() => ng('build'));
-  // Turn off git commits ('-C') per migration to avoid breaking E2E cleanup process
-  await ng('update', '@angular/cli', '--migrate-only', '--from=1.7.1', '-C');
+  await ng('update', '@angular/cli', '--migrate-only', '--from=1.7.1');
   await useBuiltPackages();
   await silentNpm('install');
   await ng('update', '@angular/core', ...extraUpdateArgs);

--- a/tests/legacy-cli/e2e/tests/update/update-1.7.ts
+++ b/tests/legacy-cli/e2e/tests/update/update-1.7.ts
@@ -12,8 +12,7 @@ export default async function() {
 
   await useCIChrome('.');
   await expectToFail(() => ng('build'));
-  // Turn off git commits ('-C') per migration to avoid breaking E2E cleanup process
-  await ng('update', '@angular/cli', '-C');
+  await ng('update', '@angular/cli');
   await useBuiltPackages();
   await silentNpm('install');
   await ng('update', '@angular/core', ...extraUpdateArgs);


### PR DESCRIPTION
Any time a `git commit` is made, the CLI now prints out the hash and short message. For migrations, the message is simply the first line of the commit. For schematics, the commit message isn't all that helpful, so I used the list of packages instead.

I didn't see any good place to put tests for this code, so I didn't add any tests for this change. Let me know if there is a particular place I should include some.

Example run with the change:

```
$ ng update -C --next @angular/core --force
Fetching dependency metadata from registry...
                  Package "@angular-devkit/build-angular" has an incompatible peer dependency to "typescript" (requires ">=3.1 < 3.6", would install "3.6.4").
    Updating package.json with dependency @angular/compiler-cli @ "9.0.0-rc.1" (was "8.2.13")...
    Updating package.json with dependency @angular/compiler @ "9.0.0-rc.1" (was "8.2.13")...
    Updating package.json with dependency @angular/common @ "9.0.0-rc.1" (was "8.2.13")...
    Updating package.json with dependency @angular/core @ "9.0.0-rc.1" (was "8.2.13")...
    Updating package.json with dependency @angular/animations @ "9.0.0-rc.1" (was "8.2.13")...
    Updating package.json with dependency @angular/forms @ "9.0.0-rc.1" (was "8.2.13")...
    Updating package.json with dependency @angular/language-service @ "9.0.0-rc.1" (was "8.2.13")...
    Updating package.json with dependency @angular/platform-browser @ "9.0.0-rc.1" (was "8.2.13")...
    Updating package.json with dependency zone.js @ "0.10.2" (was "0.9.1")...
    Updating package.json with dependency rxjs @ "6.5.3" (was "6.4.0")...
    Updating package.json with dependency @angular/platform-browser-dynamic @ "9.0.0-rc.1" (was "8.2.13")...
    Updating package.json with dependency @angular/router @ "9.0.0-rc.1" (was "8.2.13")...
    Updating package.json with dependency typescript @ "3.6.4" (was "3.5.3")...
UPDATE package.json (1365 bytes)
✔ Packages installed successfully.
  Committed migration step (aa41b0513) for packages: @angular/core@next.
** Executing migrations of package '@angular/core' **

▸ Static flag migration.
  Removes the `static` flag from dynamic queries.
  As of Angular 9, the "static" flag defaults to false and is no longer required for your view and content queries.
  Read more about this here: https://v9.angular.io/guide/migration-dynamic-flag
✔ Migration succeeded.
  No changes to commit after migration.

▸ Missing @Injectable migration.
  In Angular 9, enforcement of @Injectable decorators for DI is a bit stricter.
  Read more about this here: https://v9.angular.io/guide/migration-injectable
✔ Migration succeeded.
  No changes to commit after migration.

▸ ModuleWithProviders migration.
  In Angular 9, the ModuleWithProviders type without a generic has been deprecated.
  This migration adds the generic where it is missing.
  Read more about this here: https://v9.angular.io/guide/migration-module-with-providers
✔ Migration succeeded.
  No changes to commit after migration.

▸ NGCC postinstall migration.
  Adds an ngcc invocation to npm/yarn's postinstall script.
  Read more about this here: https://v9.angular.io/guide/migration-ngcc
UPDATE package.json (1472 bytes)
✔ Packages installed successfully.
✔ Migration succeeded.
  Committed migration step (43bf7a265): @angular/core migration - migration-v9-postinstall-ngcc.

▸ Renderer to Renderer2 migration.
  As of Angular 9, the Renderer class is no longer available.
  Renderer2 should be used instead.
  Read more about this here: https://v9.angular.io/guide/migration-renderer
✔ Migration succeeded.
  No changes to commit after migration.

▸ Undecorated classes with decorated fields migration.
  As of Angular 9, it is no longer supported to have Angular field decorators on a class that does not have an Angular decorator.
  Read more about this here: https://v9.angular.io/guide/migration-undecorated-classes
✔ Migration succeeded.
  No changes to commit after migration.

▸ Undecorated classes with DI migration.
  As of Angular 9, it is no longer supported to use Angular DI on a class that does not have an Angular decorator.
  Read more about this here: https://v9.angular.io/guide/migration-undecorated-classes
✔ Migration succeeded.
  No changes to commit after migration.
```