### PR TITLE
fix(@angular/cli): re-introduce install package using shell spawn

### DIFF
--- a/packages/angular/cli/tasks/install-package.ts
+++ b/packages/angular/cli/tasks/install-package.ts
@@ -50,6 +50,7 @@ export function installPackage(
 
   const { status, stderr, stdout, error } = spawnSync(packageManager, [...installArgs, ...extraArgs], {
     stdio: 'pipe',
+    shell: true,
     encoding: 'utf8',
     cwd,
   });


### PR DESCRIPTION
This works around a Windows CI failure that related to the PATH environment variable and a failure to located the `npm` command.