### PR TITLE
fix(@angular-devkit/build-angular): prevent double sourcemap processing

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/browser.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/browser.ts
@@ -55,7 +55,7 @@ export function getBrowserConfig(wco: WebpackConfigOptions): webpack.Configurati
     extraPlugins.push(getSourceMapDevTool(
       !!scriptsSourceMap,
       !!stylesSourceMap,
-      hiddenSourceMap,
+      wco.differentialLoadingMode ? true : hiddenSourceMap,
     ));
   }
 


### PR DESCRIPTION
Fixes the CI failure for #16065 and provides a noticeable memory improvement.  The failing test from the aforementioned PR went from 2GB to process the main bundle to just over 550MB.