### PR TITLE
fix(@angular/cli): remove no-bin-links during npm/yarn install

### DIFF
--- a/packages/angular/cli/tasks/install-package.ts
+++ b/packages/angular/cli/tasks/install-package.ts
@@ -21,7 +21,6 @@ interface PackageManagerOptions {
   saveDev: string;
   install: string;
   prefix: string;
-  noBinLinks: string;
   noLockfile: string;
 }
 
@@ -39,7 +38,6 @@ export function installPackage(
     packageManagerArgs.install,
     packageName,
     packageManagerArgs.silent,
-    packageManagerArgs.noBinLinks,
   ];
 
   logger.info(colors.green(`Installing packages for tooling via ${packageManager}.`));
@@ -153,7 +151,6 @@ function getPackageManagerArguments(packageManager: PackageManager): PackageMana
         saveDev: '--dev',
         install: 'add',
         prefix: '--modules-folder',
-        noBinLinks: '--no-bin-links',
         noLockfile: '--no-lockfile',
       }
     : {
@@ -161,7 +158,6 @@ function getPackageManagerArguments(packageManager: PackageManager): PackageMana
         saveDev: '--save-dev',
         install: 'install',
         prefix: '--prefix',
-        noBinLinks: '--no-bin-links',
         noLockfile: '--no-package-lock',
       };
 }


### PR DESCRIPTION
Previously we passed `--no-bin-links` because we used to install packages globally in some cases. But now this is no longer needed as we should now have permissions to generate "local" bin links even during a temp installations as these  will no longer generate bin links in the global context.

Fixes #16133