### PR TITLE
fix(@angular-devkit/build-angular): ignore node modules when polling

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
@@ -479,6 +479,7 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
     watch: buildOptions.watch,
     watchOptions: {
       poll: buildOptions.poll,
+      ignored: buildOptions.poll === undefined ? undefined : /[\\\/]node_modules[\\\/]/,
     },
     performance: {
       hints: false,

--- a/packages/angular_devkit/build_angular/src/dev-server/index.ts
+++ b/packages/angular_devkit/build_angular/src/dev-server/index.ts
@@ -423,7 +423,11 @@ export function buildServerConfig(
     stats: false,
     compress: styles || scripts,
     watchOptions: {
-      poll: browserOptions.poll,
+      // Using just `--poll` will result in a value of 0 which is very likely not the intention
+      // A value of 0 is falsy and will disable polling rather then enable
+      // 500 ms is a sensible default in this case
+      poll: serverOptions.poll === 0 ? 500 : serverOptions.poll,
+      ignored: serverOptions.poll === undefined ? undefined : /[\\\/]node_modules[\\\/]/,
     },
     https: serverOptions.ssl,
     overlay: {


### PR DESCRIPTION
The node modules directory contains a massive set of directories and files.  When watching via polling, that set needs to be queried repeatedly to determine if any files have changed.  Changes within node modules are quite rare while using `ng serve` or `ng build --watch`.  As a result, polling the node modules directory is rarely useful.  This change causes CPU usage to drop from a potential high of ~80% to a more manageable ~5-10%.

This also fixes the flag option variant of `--poll` for `ng serve` so that it results in the default value of 500 ms instead of disabling polling.  `ng build --watch` already contains a fix for this.