### PR TITLE
fix(@angular/cli): Renames "Migration succeeded" to "Migration completed. (#16016)

### DIFF
--- a/packages/angular/cli/commands/update-impl.ts
+++ b/packages/angular/cli/commands/update-impl.ts
@@ -186,7 +186,7 @@ export class UpdateCommand extends Command<UpdateCommandSchema> {
         return false;
       }
 
-      this.logger.info(colors.green(`${colors.symbols.check} Migration succeeded.`));
+      this.logger.info('  Migration completed.');
 
       // Commit migration
       if (commit) {


### PR DESCRIPTION
We don't actually know for certain that the migration was successful, only that it finished. This updates the messaging to be more clear about this distinction. I also removed the check mark and green coloring which implied success.