### PR TITLE
fix(@schematics/angular): uniformize guard spec with service spec

### DIFF
--- a/packages/schematics/angular/guard/files/__name@dasherize__.guard.spec.ts.template
+++ b/packages/schematics/angular/guard/files/__name@dasherize__.guard.spec.ts.template
@@ -1,15 +1,16 @@
-import { TestBed, async, inject } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 
 import { <%= classify(name) %>Guard } from './<%= dasherize(name) %>.guard';
 
 describe('<%= classify(name) %>Guard', () => {
+  let guard: <%= classify(name) %>Guard;
+
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [<%= classify(name) %>Guard]
-    });
+    TestBed.configureTestingModule({});
+    guard = TestBed.inject(<%= classify(name) %>Guard);
   });
 
-  it('should ...', inject([<%= classify(name) %>Guard], (guard: <%= classify(name) %>Guard) => {
+  it('should be created', () => {
     expect(guard).toBeTruthy();
-  }));
+  });
 });


### PR DESCRIPTION
The current guard spec schematic uses `inject` whereas we dropped it for the service spec a while ago.
This commits updates the guard spec schematic to be similar to the current service spec.

