### PR TITLE
feat(@angular/pwa): support for maskable icons

### DIFF
--- a/packages/angular/pwa/pwa/files/root/manifest.webmanifest
+++ b/packages/angular/pwa/pwa/files/root/manifest.webmanifest
@@ -10,42 +10,50 @@
     {
       "src": "assets/icons/icon-72x72.png",
       "sizes": "72x72",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "maskable"
     },
     {
       "src": "assets/icons/icon-96x96.png",
       "sizes": "96x96",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "maskable"
     },
     {
       "src": "assets/icons/icon-128x128.png",
       "sizes": "128x128",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "maskable"
     },
     {
       "src": "assets/icons/icon-144x144.png",
       "sizes": "144x144",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "maskable"
     },
     {
       "src": "assets/icons/icon-152x152.png",
       "sizes": "152x152",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "maskable"
     },
     {
       "src": "assets/icons/icon-192x192.png",
       "sizes": "192x192",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "maskable"
     },
     {
       "src": "assets/icons/icon-384x384.png",
       "sizes": "384x384",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "maskable"
     },
     {
       "src": "assets/icons/icon-512x512.png",
       "sizes": "512x512",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "maskable"
     }
   ]
 }


### PR DESCRIPTION
Icon Mask is a new feature coming to app manifest that allows developers to specify if their icons could be masked to better fit the system's design. A detailed explainer can be found on the Web App Manifest spec page

https://www.w3.org/TR/appmanifest/#icon-masks

And an more abridged version can be found here

https://css-tricks.com/maskable-icons-android-adaptive-icons-for-your-pwa/

This PR adds support for the `purpose` key and `maskable` value in app manifest.


In testing on [maskable.app](https://maskable.app), it appears the current set of Icons will need to be resized a bit. The suggest size is about 40% of the entire image dimension.

<img width="291" alt="Screen Shot 2019-11-13 at 5 45 23 PM" src="https://user-images.githubusercontent.com/2835826/68810896-61b14280-063d-11ea-863b-c3623c02723e.png">


I did not include this in the PR and the current icons are just placeholders and not sure it would make sense to mondify. 