### PR TITLE
fix(@angular-devkit/build-angular): fix numberOfComponents in JIT mode

### DIFF
--- a/packages/angular_devkit/build_angular/plugins/webpack/analytics.ts
+++ b/packages/angular_devkit/build_angular/plugins/webpack/analytics.ts
@@ -158,7 +158,7 @@ export class NgBuildAnalyticsPlugin {
 
       // Count the number of `Component({` strings (case sensitive), which happens in __decorate().
       // This does not include View Engine AOT compilation, we use the ngfactory for it.
-      this._stats.numberOfComponents += countOccurrences(module._source.source(), ' Component({');
+      this._stats.numberOfComponents += countOccurrences(module._source.source(), 'Component({');
       // For Ivy we just count ɵcmp.
       this._stats.numberOfComponents += countOccurrences(module._source.source(), '.ɵcmp', true);
     }


### PR DESCRIPTION
Current we are always sending `0` as the number of components in JIT mode because ` Component({` doesn't match the component source