### PR TITLE
fix(@schematics/angular): don't create e2e script when createApplication is false

### DIFF
--- a/packages/schematics/angular/e2e/index.ts
+++ b/packages/schematics/angular/e2e/index.ts
@@ -17,10 +17,22 @@ import {
   move,
   url,
 } from '@angular-devkit/schematics';
+import { JSONFile } from '../utility/json-file';
 import { relativePathToWorkspaceRoot } from '../utility/paths';
 import { getWorkspace, updateWorkspace } from '../utility/workspace';
 import { Builders } from '../utility/workspace-models';
 import { Schema as E2eOptions } from './schema';
+
+function addScriptsToPackageJson(): Rule {
+  return host => {
+    const pkgJson = new JSONFile(host, 'package.json');
+    const e2eScriptPath = ['scripts', 'e2e'];
+
+    if (!pkgJson.get(e2eScriptPath)) {
+      pkgJson.modify(e2eScriptPath, 'ng e2e', false);
+    }
+  };
+}
 
 export default function (options: E2eOptions): Rule {
   return async (host: Tree) => {
@@ -65,6 +77,7 @@ export default function (options: E2eOptions): Rule {
           }),
           move(root),
         ])),
+      addScriptsToPackageJson(),
     ]);
   };
 }

--- a/packages/schematics/angular/e2e/index_spec.ts
+++ b/packages/schematics/angular/e2e/index_spec.ts
@@ -99,4 +99,11 @@ describe('Application Schematic', () => {
       expect(e2eOptions.devServerTarget).toEqual('foo:serve');
     });
   });
+
+  it('should add an e2e script in package.json', async () => {
+    const tree = await schematicRunner.runSchematicAsync('e2e', defaultOptions, applicationTree)
+      .toPromise();
+    const pkg = JSON.parse(tree.readContent('/package.json'));
+    expect(pkg.scripts['e2e']).toBe('ng e2e');
+  });
 });

--- a/packages/schematics/angular/workspace/files/package.json.template
+++ b/packages/schematics/angular/workspace/files/package.json.template
@@ -6,8 +6,7 @@
     "start": "ng serve",
     "build": "ng build",
     "test": "ng test",
-    "lint": "ng lint",
-    "e2e": "ng e2e"
+    "lint": "ng lint"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
Bugfix for the `ng new --createApplication=false` command.
Currently, it creates an `e2e` script in `package.json`. This change will only add the script when the application is created.


Closes #13412