### PR TITLE
fix(@angular-devkit/build-angular): allow new i18n options to work with VE

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/output-paths.ts
+++ b/packages/angular_devkit/build_angular/src/utils/output-paths.ts
@@ -5,21 +5,21 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-
 import { existsSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import { I18nOptions } from './i18n-options';
 
 export function ensureOutputPaths(baseOutputPath: string, i18n: I18nOptions): string[] {
-    const outputPaths = i18n.shouldInline && !i18n.flatOutput
-        ? [...i18n.inlineLocales].map(l => join(baseOutputPath, l))
-        : [baseOutputPath];
+  const outputPaths =
+    i18n.shouldInline && !i18n.flatOutput
+      ? [...i18n.inlineLocales].map(l => join(baseOutputPath, l))
+      : [i18n.veCompatLocale ? join(baseOutputPath, i18n.veCompatLocale) : baseOutputPath];
 
-    for (const outputPath of outputPaths) {
-        if (!existsSync(outputPath)) {
-            mkdirSync(outputPath, { recursive: true });
-        }
+  for (const outputPath of outputPaths) {
+    if (!existsSync(outputPath)) {
+      mkdirSync(outputPath, { recursive: true });
     }
+  }
 
-    return outputPaths;
+  return outputPaths;
 }

--- a/tests/legacy-cli/e2e/tests/i18n/ve-localize-es2015.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/ve-localize-es2015.ts
@@ -1,0 +1,67 @@
+import { getGlobalVariable } from '../../utils/env';
+import { expectFileToMatch, writeFile } from '../../utils/fs';
+import { execAndWaitForOutputToMatch, ng, npm } from '../../utils/process';
+import { updateJsonFile } from '../../utils/project';
+import { expectToFail } from '../../utils/utils';
+import { readNgVersion } from '../../utils/version';
+import { baseDir, externalServer, langTranslations, setupI18nConfig } from './legacy';
+
+export default async function() {
+  if (!getGlobalVariable('argv')['ve']) {
+    return;
+  }
+
+  // Setup i18n tests and config.
+  await setupI18nConfig();
+
+  // Using localize-based options requires the @angular/locale package
+  let localizeVersion = '@angular/localize@' + readNgVersion();
+  if (getGlobalVariable('argv')['ng-snapshots']) {
+    localizeVersion = require('../../ng-snapshot/package.json').dependencies['@angular/localize'];
+  }
+  await npm('install', `${localizeVersion}`);
+
+  // Ensure a ES2015 build is used.
+  await writeFile('browserslist', 'Chrome 65');
+  await updateJsonFile('tsconfig.json', config => {
+    config.compilerOptions.target = 'es2015';
+    config.angularCompilerOptions.disableTypeScriptVersionCheck = true;
+  });
+
+  // Attempts to build multiple locales with VE should fail
+  await expectToFail(() => ng('build'));
+
+  for (const { lang, outputPath, translation } of langTranslations) {
+    await ng('build', `--configuration=${lang}`);
+
+    await expectFileToMatch(`${outputPath}/main.js`, translation.helloPartial);
+    await expectToFail(() => expectFileToMatch(`${outputPath}/main.js`, '$localize`'));
+
+    // Execute Application E2E tests with dev server
+    await ng('e2e', `--configuration=${lang}`, '--port=0');
+
+    // Execute Application E2E tests for a production build without dev server
+    const server = externalServer(outputPath);
+    try {
+      await ng('e2e', `--configuration=${lang}`, '--devServerTarget=');
+    } finally {
+      server.close();
+    }
+  }
+
+  await execAndWaitForOutputToMatch(
+    'ng',
+    ['build', '--configuration=fr', '--i18n-locale=en-US'],
+    /Option 'localize' and deprecated 'i18nLocale' found.  Using 'localize'./,
+  );
+  await execAndWaitForOutputToMatch(
+    'ng',
+    ['build', '--configuration=fr', '--i18n-format=xmb'],
+    /Option 'localize' and deprecated 'i18nFormat' found.  Using 'localize'./,
+  );
+  await execAndWaitForOutputToMatch(
+    'ng',
+    ['build', '--configuration=fr', '--i18n-file=error.json'],
+    /Option 'localize' and deprecated 'i18nFile' found.  Using 'localize'./,
+  );
+}


### PR DESCRIPTION
This allows one set of options to be used for localization regardless of Ivy usage.  Also simplifies Ivy opt out.