### PR TITLE
refactor(@angular/cli): update Intellij/Webstorm settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ jsconfig.json
 
 # Intellij IDEA/WebStorm
 # https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+.idea/inspectionProfiles/
+.idea/**/compiler.xml
+.idea/**/encodings.xml
 .idea/**/workspace.xml
 .idea/**/tasks.xml
 .idea/**/usage.statistics.xml

--- a/.idea/angular-cli.iml
+++ b/.idea/angular-cli.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module type="JAVA_MODULE" version="4">
+<module type="WEB_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">


### PR DESCRIPTION
Intellij and Webstorm unfortunately don't the use the exact same
configuration system. For example, Intellij treats every project as
`JAVA_MODULE` but Webstorm doesn't recognize the `JAVA_MODULE`.
Therefore, I think that the modules.xml and iml should be left
out from version control.

refs #16152