### PR TITLE
fix(@angular-devkit/build-angular): mocked context in single test transform matches webpack API

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/single-test-transform.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/single-test-transform.ts
@@ -51,7 +51,7 @@ export default function loader(this: loader.LoaderContext, source: string) {
     options.logger.error(message.join(lineSeparator));
   }
 
-  const mockedRequireContext = '{ keys: () => ({ map: (_a) => { } }) };' + lineSeparator;
+  const mockedRequireContext = 'Object.assign(() => { }, { keys: () => [], resolve: () => undefined });' + lineSeparator;
   source = source.replace(regex, mockedRequireContext + targettedImports);
 
   return source;


### PR DESCRIPTION
I've ran into an issue at work with the mocked context in single test transform - it does not match [webpack API](https://webpack.js.org/guides/dependency-management/#requirecontext).

Basically I have to filter out certain values from `require.context(...).keys()` before importing the actual file to fix another issue in `test.ts`. (Desired outcome is for code coverage to include untested ts files)

Currently with angular 8 (and master branch) it fails when running `ng test --include <file>`, as the value returned from keys does not have a `filter` method. This PR fixes that by returning an empty array instead of partial object.

@filipesilva since you approved my original PR, could you give a quick look here? It is a very minor change :) 