### PR TITLE
fix(@angular/cli): improve robustness of Node.js version check

### DIFF
--- a/packages/angular/cli/bin/ng
+++ b/packages/angular/cli/bin/ng
@@ -5,18 +5,21 @@
 // Due to an obscure Mac bug, do not start this title with any symbol.
 try {
   process.title = 'ng ' + Array.from(process.argv).slice(2).join(' ');
-} catch(_) {
+} catch (_) {
   // If an error happened above, use the most basic title.
   process.title = 'ng';
 }
 
-// Some older versions of Node do not support let or const.
-var version = process.version.substr(1).split('.');
-if (Number(version[0]) < 10 || (Number(version[0]) === 10 && Number(version[1]) < 9)) {
+// This node version check ensures that extremely old versions of node are not used.
+// These may not support ES2015 features such as const/let/async/await/etc.
+// These would then crash with a hard to diagnose error message.
+// tslint:disable-next-line: no-var-keyword
+var version = process.versions.node.split('.').map(part => Number(part));
+if (version[0] < 10 || version[0] === 11 || (version[0] === 10 && version[1] < 13)) {
   process.stderr.write(
-    'You are running version ' + process.version + ' of Node.js, which is not supported by Angular CLI 9.0+.\n' +
-    'The official Node.js version that is supported is 10.13.0 or greater.\n\n' +
-    'Please visit https://nodejs.org/en/ to find instructions on how to update Node.js.\n'
+    'Node.js version ' + process.verson + ' detected.\n' +
+    'The Angular CLI requires a minimum Node.js version of either v10.13 or v12.0.\n\n' +
+    'Please update your Node.js version or visit https://nodejs.org/ for additional instructions.\n',
   );
 
   process.exit(3);

--- a/packages/angular/cli/lib/cli/index.ts
+++ b/packages/angular/cli/lib/cli/index.ts
@@ -21,6 +21,18 @@ const isDebug =
 
 // tslint:disable: no-console
 export default async function(options: { testing?: boolean; cliArgs: string[] }) {
+  // This node version check ensures that the requirements of the project instance of the CLI are met
+  const version = process.versions.node.split('.').map(part => Number(part));
+  if (version[0] < 10 || version[0] === 11 || (version[0] === 10 && version[1] < 13)) {
+    process.stderr.write(
+      `Node.js version ${process.version} detected.\n` +
+      'The Angular CLI requires a minimum Node.js version of either v10.13 or v12.0.\n\n' +
+      'Please update your Node.js version or visit https://nodejs.org/ for additional instructions.\n',
+    );
+
+    return 3;
+  }
+
   const logger = createConsoleLogger(isDebug, process.stdout, process.stderr, {
     info: s => (supportsColor ? s : colors.unstyle(s)),
     debug: s => (supportsColor ? s : colors.unstyle(s)),


### PR DESCRIPTION
This change ensures that both the global version and the project version Node.js version requirements are met before the CLI executes a command.  Previously an older global version of the CLI would allow a newer project version to execute even if the project version had more strict Node.js version requirements.  The Node.js version is now checked twice.  Once in an ES5 safe script to ensure that ancient Node.js versions are not in use.  And secondly in the CLI entry code that is executed after global/project bootstrapping.