### PR TITLE
fix(@angular-devkit/build-angular): resolve lazy route Angular package from project base

### DIFF
--- a/packages/ngtools/webpack/src/angular_compiler_plugin.ts
+++ b/packages/ngtools/webpack/src/angular_compiler_plugin.ts
@@ -792,7 +792,9 @@ export class AngularCompilerPlugin {
     if (this._discoverLazyRoutes) {
       // Add lazy modules to the context module for @angular/core
       compiler.hooks.contextModuleFactory.tap('angular-compiler', cmf => {
-        const angularCorePackagePath = require.resolve('@angular/core/package.json');
+        const angularCorePackagePath = require.resolve('@angular/core/package.json', {
+          paths: [this._basePath],
+        });
 
         // APFv6 does not have single FESM anymore. Instead of verifying if we're pointing to
         // FESMs, we resolve the `@angular/core` path and verify that the path for the


### PR DESCRIPTION
The plugin's package could technically be installed outside of the location containing the Angular dependencies and/or the project root.  This is particularly relevant for `pnpm` or `yarn pnp` (even though the later is not yet supported) since they strictly enforce package presence and versioning.

Closes #16219