### PR TITLE
refactor(@angular-devkit/build-angular): allow @angular/core version 0.0.0

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/version.ts
+++ b/packages/angular_devkit/build_angular/src/utils/version.ts
@@ -59,9 +59,10 @@ export function assertCompatibleAngularVersion(projectRoot: string, logger: logg
 
   const cliMajor = new SemVer(angularCliPkgJson['version']).major;
   // e.g. CLI 8.0 supports '>=8.0.0 <9.0.0', including pre-releases (betas, rcs, snapshots)
-  // of both 8 and 9.
+  // of both 8 and 9. Also allow version "0.0.0" for integration testing in the angular/angular
+  // repository with the generated development @angular/core npm package which is versioned "0.0.0".
   const supportedAngularSemver =
-    `^${cliMajor}.0.0-beta || ` + `>=${cliMajor}.0.0 <${cliMajor + 1}.0.0`;
+    `0.0.0 || ^${cliMajor}.0.0-beta || ` + `>=${cliMajor}.0.0 <${cliMajor + 1}.0.0`;
 
   const angularVersion = new SemVer(angularPkgJson['version']);
   const rxjsVersion = new SemVer(rxjsPkgJson['version']);


### PR DESCRIPTION
Allow version "0.0.0" for integration testing in the angular/angular repository with the generated development @angular/core npm package which is versioned "0.0.0".

This is a pre-req for https://github.com/angular/angular/pull/33927 which runs integration tests against the bazel generated npm packages.

To green up that PR I have a patch that does the same thing https://github.com/angular/angular/pull/33927/files#diff-817b74474f8a65162b6115d04a6f43c7 which will get removed once this change makes it in to the next release