### PR TITLE
refactor(@angular-devkit/build-angular): deprecate karma `environment` option

### DIFF
--- a/packages/angular_devkit/build_angular/src/karma/schema.json
+++ b/packages/angular_devkit/build_angular/src/karma/schema.json
@@ -61,7 +61,8 @@
     },
     "environment": {
       "type": "string",
-      "description": "Defines the build environment."
+      "description": "Defines the build environment.",
+      "x-deprecated": "This option has no effect."
     },
     "include": {
       "type": "array",


### PR DESCRIPTION
This option is unused and has no effect.