### PR TITLE
fix(@angular/cli): add more packages to packageGroup

### DIFF
--- a/packages/angular/cli/package.json
+++ b/packages/angular/cli/package.json
@@ -50,9 +50,17 @@
     "migrations": "@schematics/angular/migrations/migration-collection.json",
     "packageGroup": {
       "@angular/cli": "0.0.0",
-      "@angular-devkit/build-angular":  "0.0.0",
+      "@angular-devkit/architect": "0.0.0",
+      "@angular-devkit/architect-cli": "0.0.0",
+      "@angular-devkit/build-angular": "0.0.0",
       "@angular-devkit/build-ng-packagr": "0.0.0",
-      "@angular-devkit/build-webpack": "0.0.0"
+      "@angular-devkit/core": "0.0.0",
+      "@angular-devkit/build-optimizer": "0.0.0",
+      "@angular-devkit/schematics": "0.0.0",
+      "@angular-devkit/schematics-cli": "0.0.0",
+      "@ngtools/webpack": "0.0.0",
+      "@schematics/schematics": "0.0.0",
+      "@schematics/angular": "0.0.0"
     }
   }
 }


### PR DESCRIPTION
In a workspace users, might have a direct depedencies on packages which are currently not listed in the `packageGroup` such as `@angular-devkit/schematics`.

A use-case for this would be that users might have a schematics library in their workspace or using the `@angular-devkit/architect-cli` with Bazel which is currently in prototype.

Fixes #16307