### PR TITLE
fix(@angular-devkit/build-angular): augment base HREF when localizing

### DIFF
--- a/packages/angular/cli/lib/config/schema.json
+++ b/packages/angular/cli/lib/config/schema.json
@@ -376,17 +376,57 @@
           "type": "object",
           "properties": {
             "sourceLocale": {
-              "type": "string",
-              "description": "Specifies the source language of the application.",
-              "default": "en-US"
+              "oneOf": [
+                {
+                  "type": "string",
+                  "description": "Specifies the source locale of the application.",
+                  "default": "en-US",
+                  "pattern": "^[a-z]{2}(-[a-zA-Z]{2,})?$"
+                },
+                {
+                  "type": "object",
+                  "description": "Localization options to use for the source locale",
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                      "description": "Specifies the locale code of the source locale",
+                      "pattern": "^[a-z]{2}(-[a-zA-Z]{2,})?$"
+                    },
+                    "baseHref": {
+                      "type": "string",
+                      "description": "HTML base HREF to use for the locale (defaults to the locale code)"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ]
             },
             "locales": {
               "type": "object",
               "additionalProperties": false,
               "patternProperties": {
                 "^[a-z]{2}(-[a-zA-Z]{2,})?$": {
-                  "type": "string",
-                  "description": "Localization file to use for i18n"
+                  "oneOf": [
+                    {
+                      "type": "string",
+                      "description": "Localization file to use for i18n"
+                    },
+                    {
+                      "type": "object",
+                      "description": "Localization options to use for the locale",
+                      "properties": {
+                        "translation": {
+                          "type": "string",
+                          "description": "Localization file to use for i18n"
+                        },
+                        "baseHref": {
+                          "type": "string",
+                          "description": "HTML base HREF to use for the locale (defaults to the locale code)"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  ]
                 }
               }
             }

--- a/packages/angular_devkit/build_angular/src/browser/index.ts
+++ b/packages/angular_devkit/build_angular/src/browser/index.ts
@@ -673,6 +673,16 @@ export function buildWebpackBrowser(
 
             if (options.index) {
               for (const [locale, outputPath] of outputPaths.entries()) {
+                let localeBaseHref;
+                if (i18n.locales[locale] && i18n.locales[locale].baseHref !== '') {
+                  localeBaseHref = path.posix.join(
+                    options.baseHref || '',
+                    i18n.locales[locale].baseHref === undefined
+                      ? `/${locale}/`
+                      : i18n.locales[locale].baseHref,
+                  );
+                }
+
                 try {
                   await generateIndex(
                     outputPath,
@@ -684,6 +694,7 @@ export function buildWebpackBrowser(
                     transforms.indexHtml,
                     // i18nLocale is used when Ivy is disabled
                     locale || options.i18nLocale,
+                    localeBaseHref || options.baseHref,
                   );
                 } catch (err) {
                   return { success: false, error: mapErrorToMessage(err) };
@@ -734,6 +745,7 @@ function generateIndex(
   moduleFiles: EmittedFiles[] | undefined,
   transformer?: IndexHtmlTransform,
   locale?: string,
+  baseHref?: string,
 ): Promise<void> {
   const host = new NodeJsSyncHost();
 
@@ -744,7 +756,7 @@ function generateIndex(
     files,
     noModuleFiles,
     moduleFiles,
-    baseHref: options.baseHref,
+    baseHref,
     deployUrl: options.deployUrl,
     sri: options.subresourceIntegrity,
     scripts: options.scripts,

--- a/packages/angular_devkit/core/src/experimental/workspace/workspace-schema.json
+++ b/packages/angular_devkit/core/src/experimental/workspace/workspace-schema.json
@@ -131,17 +131,57 @@
       "type": "object",
       "properties": {
         "sourceLocale": {
-          "type": "string",
-          "description": "Specifies the source language of the application.",
-          "default": "en-US"
+          "oneOf": [
+            {
+              "type": "string",
+              "description": "Specifies the source locale of the application.",
+              "default": "en-US",
+              "pattern": "^[a-z]{2}(-[a-zA-Z]{2,})?$"
+            },
+            {
+              "type": "object",
+              "description": "Localization options to use for the source locale",
+              "properties": {
+                "code": {
+                  "type": "string",
+                  "description": "Specifies the locale code of the source locale",
+                  "pattern": "^[a-z]{2}(-[a-zA-Z]{2,})?$"
+                },
+                "baseHref": {
+                  "type": "string",
+                  "description": "HTML base HREF to use for the locale (defaults to the locale code)"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
         },
         "locales": {
           "type": "object",
           "additionalProperties": false,
           "patternProperties": {
             "^[a-z]{2}(-[a-zA-Z]{2,})?$": {
-              "type": "string",
-              "description": "Localization file to use for i18n."
+              "oneOf": [
+                {
+                  "type": "string",
+                  "description": "Localization file to use for i18n"
+                },
+                {
+                  "type": "object",
+                  "description": "Localization options to use for the locale",
+                  "properties": {
+                    "translation": {
+                      "type": "string",
+                      "description": "Localization file to use for i18n"
+                    },
+                    "baseHref": {
+                      "type": "string",
+                      "description": "HTML base HREF to use for the locale (defaults to the locale code)"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ]
             }
           }
         }

--- a/packages/schematics/angular/migrations/update-9/update-workspace-config.ts
+++ b/packages/schematics/angular/migrations/update-9/update-workspace-config.ts
@@ -70,14 +70,6 @@ function addProjectI18NOptions(
     return;
   }
 
-  const mainOptions = findPropertyInAstObject(browserConfig, 'options');
-  const mainBaseHref =
-    mainOptions &&
-    mainOptions.kind === 'object' &&
-    findPropertyInAstObject(mainOptions, 'baseHref');
-  const hasMainBaseHref =
-    !!mainBaseHref && mainBaseHref.kind === 'string' && mainBaseHref.value !== '/';
-
   // browser builder options
   let locales: Record<string, string | { translation: string; baseHref: string }> | undefined;
   const options = getAllOptions(browserConfig);
@@ -97,9 +89,7 @@ function addProjectI18NOptions(
 
     const baseHref = findPropertyInAstObject(option, 'baseHref');
     let baseHrefValue;
-    // if the main options has a non-default base href, the i18n configuration
-    // for the locale baseHref is disabled to more obviously mimic existing behavior
-    if (baseHref && !hasMainBaseHref) {
+    if (baseHref) {
       if (baseHref.kind === 'string' && baseHref.value !== `/${localIdValue}/`) {
         baseHrefValue = baseHref.value;
       }
@@ -187,11 +177,15 @@ function addBuilderI18NOptions(recorder: UpdateRecorder, builderConfig: JsonAstO
     }
 
     // localize base HREF values are controlled by the i18n configuration
-    // except if the main options has a non-default base href, the i18n configuration
-    // for the locale baseHref is disabled in that case to more obviously mimic existing behavior
     const baseHref = findPropertyInAstObject(option, 'baseHref');
-    if (localeId && i18nFile && baseHref && !hasMainBaseHref) {
+    if (localeId && i18nFile && baseHref) {
       removePropertyInAstObject(recorder, option, 'baseHref');
+
+      // if the main option set has a non-default base href,
+      // ensure that the augmented base href has the correct base value
+      if (hasMainBaseHref) {
+        insertPropertyInAstObjectInOrder(recorder, option, 'baseHref', '/', 12);
+      }
     }
   }
 }

--- a/packages/schematics/angular/migrations/update-9/update-workspace-config_spec.ts
+++ b/packages/schematics/angular/migrations/update-9/update-workspace-config_spec.ts
@@ -383,7 +383,7 @@ describe('Migration to version 9', () => {
           const tree2 = await schematicRunner.runSchematicAsync('workspace-version-9', {}, tree.branch()).toPromise();
           config = getWorkspaceTargets(tree2).build;
           expect(config.options.baseHref).toBe('/my-app/');
-          expect(config.configurations.de.baseHref).toBe('/de/');
+          expect(config.configurations.de.baseHref).toBe('/');
         });
 
         it('should remove deprecated extract-i18n options', async () => {
@@ -454,8 +454,8 @@ describe('Migration to version 9', () => {
           const projectConfig = JSON.parse(tree2.readContent(workspacePath)).projects['migration-test'];
           expect(projectConfig.i18n.sourceLocale).toBeUndefined();
           expect(projectConfig.i18n.locales).toEqual({
-            de: { translation: 'src/locale/messages.de.xlf', baseHref: '' },
-            fr: { translation: 'src/locale/messages.fr.xlf', baseHref: '' },
+            de: { translation: 'src/locale/messages.de.xlf', baseHref: '/abc/' },
+            fr: 'src/locale/messages.fr.xlf',
           });
         });
       });

--- a/tests/legacy-cli/e2e/tests/i18n/ivy-localize-basehref.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/ivy-localize-basehref.ts
@@ -1,0 +1,103 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { expectFileToMatch } from '../../utils/fs';
+import { ng } from '../../utils/process';
+import { updateJsonFile } from '../../utils/project';
+import { externalServer, langTranslations, setupI18nConfig } from './legacy';
+
+const baseHrefs = {
+  'en-US': '/en/',
+  fr: '/fr-FR/',
+  de: '',
+};
+
+export default async function() {
+  // Setup i18n tests and config.
+  await setupI18nConfig(true);
+
+  // Update angular.json
+  await updateJsonFile('angular.json', workspaceJson => {
+    const appProject = workspaceJson.projects['test-project'];
+    // tslint:disable-next-line: no-any
+    const i18n: Record<string, any> = appProject.i18n;
+
+    i18n.sourceLocale = {
+      baseHref: baseHrefs['en-US'],
+    };
+
+    i18n.locales['fr'] = {
+      translation: i18n.locales['fr'],
+      baseHref: baseHrefs['fr'],
+    };
+
+    i18n.locales['de'] = {
+      translation: i18n.locales['de'],
+      baseHref: baseHrefs['de'],
+    };
+  });
+
+  // Build each locale and verify the output.
+  await ng('build');
+  for (const { lang, outputPath } of langTranslations) {
+    if (baseHrefs[lang] === undefined) {
+      throw new Error('Invalid E2E test setup: unexpected locale ' + lang);
+    }
+
+    // Verify the HTML lang attribute is present
+    await expectFileToMatch(`${outputPath}/index.html`, `lang="${lang}"`);
+
+    // Verify the HTML base HREF attribute is present
+    await expectFileToMatch(`${outputPath}/index.html`, `href="${baseHrefs[lang] || '/'}"`);
+
+    // Execute Application E2E tests with dev server
+    await ng('e2e', `--configuration=${lang}`, '--port=0');
+
+    // Execute Application E2E tests for a production build without dev server
+    const server = externalServer(outputPath, baseHrefs[lang] || '/');
+    try {
+      await ng(
+        'e2e',
+        `--configuration=${lang}`,
+        '--devServerTarget=',
+        `--baseUrl=http://localhost:4200${baseHrefs[lang] || '/'}`,
+      );
+    } finally {
+      server.close();
+    }
+  }
+
+  // Update angular.json
+  await updateJsonFile('angular.json', workspaceJson => {
+    const appArchitect = workspaceJson.projects['test-project'].architect;
+
+    appArchitect['build'].options.baseHref = '/test/';
+  });
+
+  // Build each locale and verify the output.
+  await ng('build');
+  for (const { lang, outputPath } of langTranslations) {
+    // Verify the HTML base HREF attribute is present
+    await expectFileToMatch(`${outputPath}/index.html`, `href="/test${baseHrefs[lang] || '/'}"`);
+
+    // Execute Application E2E tests with dev server
+    await ng('e2e', `--configuration=${lang}`, '--port=0');
+
+    // Execute Application E2E tests for a production build without dev server
+    const server = externalServer(outputPath, '/test' + (baseHrefs[lang] || '/'));
+    try {
+      await ng(
+        'e2e',
+        `--configuration=${lang}`,
+        '--devServerTarget=',
+        `--baseUrl=http://localhost:4200/test${baseHrefs[lang] || '/'}`,
+      );
+    } finally {
+      server.close();
+    }
+  }
+}

--- a/tests/legacy-cli/e2e/tests/i18n/ivy-localize-dl-xliff2.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/ivy-localize-dl-xliff2.ts
@@ -34,6 +34,9 @@ export async function executeTest() {
     // Verify the HTML lang attribute is present
     await expectFileToMatch(`${outputPath}/index.html`, `lang="${lang}"`);
 
+    // Verify the HTML base HREF attribute is present
+    await expectFileToMatch(`${outputPath}/index.html`, `href="/${lang}/"`);
+
     // Verify the locale data is registered using the global files
     await expectFileToMatch(`${outputPath}/vendor-es5.js`, '.ng.common.locales');
     await expectFileToMatch(`${outputPath}/vendor-es2015.js`, '.ng.common.locales');
@@ -42,9 +45,14 @@ export async function executeTest() {
     await ng('e2e', `--configuration=${lang}`, '--port=0');
 
     // Execute Application E2E tests for a production build without dev server
-    const server = externalServer(outputPath);
+    const server = externalServer(outputPath, `/${lang}/`);
     try {
-      await ng('e2e', `--configuration=${lang}`, '--devServerTarget=');
+      await ng(
+        'e2e',
+        `--configuration=${lang}`,
+        '--devServerTarget=',
+        `--baseUrl=http://localhost:4200/${lang}/`,
+      );
     } finally {
       server.close();
     }

--- a/tests/legacy-cli/e2e/tests/i18n/ivy-localize-es2015.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/ivy-localize-es2015.ts
@@ -29,9 +29,14 @@ export default async function() {
     await ng('e2e', `--configuration=${lang}`, '--port=0');
 
     // Execute Application E2E tests for a production build without dev server
-    const server = externalServer(outputPath);
+    const server = externalServer(outputPath, `/${lang}/`);
     try {
-      await ng('e2e', `--configuration=${lang}`, '--devServerTarget=');
+      await ng(
+        'e2e',
+        `--configuration=${lang}`,
+        '--devServerTarget=',
+        `--baseUrl=http://localhost:4200/${lang}/`,
+      );
     } finally {
       server.close();
     }

--- a/tests/legacy-cli/e2e/tests/i18n/ivy-localize-es5.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/ivy-localize-es5.ts
@@ -29,9 +29,14 @@ export default async function() {
     await ng('e2e', `--configuration=${lang}`, '--port=0');
 
     // Execute Application E2E tests for a production build without dev server
-    const server = externalServer(outputPath);
+    const server = externalServer(outputPath, `/${lang}/`);
     try {
-      await ng('e2e', `--configuration=${lang}`, '--devServerTarget=');
+      await ng(
+        'e2e',
+        `--configuration=${lang}`,
+        '--devServerTarget=',
+        `--baseUrl=http://localhost:4200/${lang}/`,
+      );
     } finally {
       server.close();
     }

--- a/tests/legacy-cli/e2e/tests/i18n/legacy.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/legacy.ts
@@ -56,9 +56,9 @@ export const langTranslations = [
 ];
 export const sourceLocale = langTranslations[0].lang;
 
-export const externalServer = (outputPath: string) => {
+export const externalServer = (outputPath: string, baseUrl = '/') => {
   const app = express();
-  app.use(express.static(resolve(outputPath)));
+  app.use(baseUrl, express.static(resolve(outputPath)));
 
   // call .close() on the return value to close the server.
   return app.listen(4200, 'localhost');

--- a/tests/legacy-cli/e2e/tests/i18n/ve-localize-es2015.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/ve-localize-es2015.ts
@@ -44,9 +44,14 @@ export default async function() {
     await ng('e2e', `--configuration=${lang}`, '--port=0');
 
     // Execute Application E2E tests for a production build without dev server
-    const server = externalServer(outputPath);
+    const server = externalServer(outputPath, `/${lang}/`);
     try {
-      await ng('e2e', `--configuration=${lang}`, '--devServerTarget=');
+      await ng(
+        'e2e',
+        `--configuration=${lang}`,
+        '--devServerTarget=',
+        `--baseUrl=http://localhost:4200/${lang}/`,
+      );
     } finally {
       server.close();
     }


### PR DESCRIPTION
All locale i18n options now support an object form which allows a base HREF to be defined for the locale.  This allows each locale to optionally define a custom base HREF that will be combined with the base HREF defined for the build configuration.

By default if the shorthand form for the locale is used or the field is not present in the longhand form, the locale code will be used as the base HREF.  To disable automatic augmentation, a base HREF value of an empty string (`""`) can be used.  This will prevent anything from being added to the existing base HREF.

For common scenarios, the shorthand form will result in the preferred and recommended outcome of each built locale variant of the application having a defined base HREF containing the locale code.

Closes #16301