### PR TITLE
Library imports

### DIFF
--- a/packages/schematics/angular/library/index.ts
+++ b/packages/schematics/angular/library/index.ts
@@ -68,13 +68,6 @@ function updateTsConfig(packageName: string, distRoot: string) {
         tsconfig.compilerOptions.paths[packageName] = [];
       }
       tsconfig.compilerOptions.paths[packageName].push(distRoot);
-
-      // deep import & secondary entrypoint support
-      const deepPackagePath = packageName + '/*';
-      if (!tsconfig.compilerOptions.paths[deepPackagePath]) {
-        tsconfig.compilerOptions.paths[deepPackagePath] = [];
-      }
-      tsconfig.compilerOptions.paths[deepPackagePath].push(distRoot + '/*');
     });
   };
 }

--- a/packages/schematics/angular/library/index_spec.ts
+++ b/packages/schematics/angular/library/index_spec.ts
@@ -208,9 +208,6 @@ describe('Library Schematic', () => {
       expect(tsConfigJson.compilerOptions.paths.foo).toBeTruthy();
       expect(tsConfigJson.compilerOptions.paths.foo.length).toEqual(1);
       expect(tsConfigJson.compilerOptions.paths.foo[0]).toEqual('dist/foo');
-      expect(tsConfigJson.compilerOptions.paths['foo/*']).toBeTruthy();
-      expect(tsConfigJson.compilerOptions.paths['foo/*'].length).toEqual(1);
-      expect(tsConfigJson.compilerOptions.paths['foo/*'][0]).toEqual('dist/foo/*');
     });
 
     it(`should append to existing paths mappings`, async () => {

--- a/packages/schematics/angular/workspace/files/tsconfig.json.template
+++ b/packages/schematics/angular/workspace/files/tsconfig.json.template
@@ -2,7 +2,7 @@
   "compileOnSave": false,
   "compilerOptions": {
     "baseUrl": "./",
-    "outDir": "./dist/out-tsc",<% if (strict) { %>
+    "outDir": "./dist",<% if (strict) { %>
     "noImplicitAny": true,
     "noImplicitReturns": true,
     "noImplicitThis": true,

--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -89,17 +89,18 @@ export default function(args: ParsedArgs, logger: logging.Logger) {
   const specGlob = args.large ? '*_spec_large.ts' : '*_spec.ts';
   const regex = args.glob ? args.glob : `packages/**/${specGlob}`;
 
-  if (args['ve']) {
-    // tslint:disable-next-line:no-console
-    console.warn('********* VE Enabled ***********');
-  } else {
-    // CI is really flaky with NGCC
-    // This is a working around test order and isolation issues.
-    console.warn('********* Running ngcc ***********');
-    execSync('yarn ngcc', { stdio: 'inherit' });
-  }
-
   if (args.large) {
+    if (args['ve']) {
+      // tslint:disable-next-line:no-console
+      console.warn('********* VE Enabled ***********');
+    } else {
+      console.warn('********* Ivy Enabled ***********');
+      // CI is really flaky with NGCC
+      // This is a working around test order and isolation issues.
+      console.warn('********* Running ngcc ***********');
+      execSync('yarn ngcc', { stdio: 'inherit' });
+    }
+
     // Default timeout for large specs is 2.5 minutes.
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 150000;
   }


### PR DESCRIPTION

- Currently the library schematic doesn't support adding a secondary entry-point and having deep imports is not recommanded.

It's best if paths are more stricter when having a secondary entry-point instead of a wildcard.

Instead of :
```
"lib/*": [
  "dist/lib/*"
]
```

Users should configure:
```
"lib/secondary": [
  "dist/lib/secondary"
]
```

This would allow a better DX experience when using auto imports in IDE's.

Closes: #15952