### PR TITLE
fix(@angular-devkit/build-angular): suppress duplicate 3rdpartylicenses.txt warning

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/stats.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/stats.ts
@@ -84,12 +84,20 @@ export function statsToString(json: any, statsConfig: any) {
   }
 }
 
+// TODO(#16193): Don't emit this warning in the first place rather than just suppressing it.
+const ERRONEOUS_WARNINGS = [
+  /multiple assets emit different content.*3rdpartylicenses\.txt/i,
+];
 export function statsWarningsToString(json: any, statsConfig: any) {
   const colors = statsConfig.colors;
   const rs = (x: string) => colors ? reset(x) : x;
   const y = (x: string) => colors ? bold(yellow(x)) : x;
 
-  return rs('\n' + json.warnings.map((warning: any) => y(`WARNING in ${warning}`)).join('\n\n'));
+  return rs('\n' + json.warnings
+      .map((warning: any) => `${warning}`)
+      .filter((warning: string) => !ERRONEOUS_WARNINGS.some((erroneous) => erroneous.test(warning)))
+      .map((warning: string) => y(`WARNING in ${warning}`))
+      .join('\n\n'));
 }
 
 export function statsErrorsToString(json: any, statsConfig: any) {


### PR DESCRIPTION
Refs #16193

This detects and filters out error messages about duplicate `3rdpartylicenses.txt`. This is a short-term fix intended to get us to 9.0.x release while a follow up effort will work to properly fix this bug. Left a `TODO` to remove this filter once a real fix is ready.