### PR TITLE
fix(@ngtools/webpack): format Ivy diagnostics properly

### DIFF
--- a/packages/ngtools/webpack/src/diagnostics.ts
+++ b/packages/ngtools/webpack/src/diagnostics.ts
@@ -141,12 +141,12 @@ export function reportDiagnostics(
   }
 
   if (tsErrors.length > 0) {
-    const message = ts.formatDiagnosticsWithColorAndContext(tsErrors, compilerHost);
+    const message = formatDiagnostics(tsErrors);
     reportError(message);
   }
 
   if (tsWarnings.length > 0) {
-    const message = ts.formatDiagnosticsWithColorAndContext(tsWarnings, compilerHost);
+    const message = formatDiagnostics(tsWarnings);
     reportWarning(message);
   }
 


### PR DESCRIPTION
By passing all diagnostics through formatDiagnostics from compiler-cli.

Without this we were printing negative TS error codes which was
compiler-cli way of marking Angular errors.