### PR TITLE
fix(@angular/cli): remove alias for doc command

### DIFF
--- a/packages/angular/cli/commands/doc.json
+++ b/packages/angular/cli/commands/doc.json
@@ -4,7 +4,6 @@
   "description": "Opens the official Angular documentation (angular.io) in a browser, and searches for a given keyword.",
   "$longDescription": "",
 
-  "$aliases": [ "d" ],
   "$type": "native",
   "$impl": "./doc-impl#DocCommand",
 


### PR DESCRIPTION
## Suggestion
- I want to remove the alias for doc

## Why
- Because alias 'd' is a duplicate.
- The image below shows the result of the `$ ng help` command.

<img width="1208" alt="ng-help" src="https://user-images.githubusercontent.com/2771212/70243860-c41dde80-17b6-11ea-93be-5d9f60ff58f8.png">

- I have confirmed that if there are multiple same alias, the first command found is executed.
    - [command-runner.ts#L196](https://github.com/angular/angular-cli/blob/174b4f2ecedc4b63f4b4dd9702834efab4474177/packages/angular/cli/models/command-runner.ts#L196)

## version
- Angular CLI : 8.3.20
