### PR TITLE
fix(@angular/cli): remove alias for deploy command

### DIFF
--- a/packages/angular/cli/commands/deploy.json
+++ b/packages/angular/cli/commands/deploy.json
@@ -4,7 +4,6 @@
   "description": "Invokes the deploy builder for a specified project or for the default project in the workspace.",
   "$longDescription": "./deploy-long.md",
 
-  "$aliases": [ "d" ],
   "$scope": "in",
   "$type": "architect",
   "$impl": "./deploy-impl#DeployCommand",


### PR DESCRIPTION
I remove the alias for deploy command.

## Why
- Because alias 'd' is a duplicate.
- The image below shows the result of the `$ ng help` command.

<img width="1208" alt="ng-help" src="https://user-images.githubusercontent.com/2771212/70243860-c41dde80-17b6-11ea-93be-5d9f60ff58f8.png">

- I removed alias for deploy command instead of doc.
    - https://github.com/angular/angular-cli/pull/16364#issuecomment-562251529

## version
- Angular CLI : 8.3.20
