### PR TITLE
refactor(@angular-devkit/build-angular): export executeExtractI18nBuilder

### DIFF
--- a/packages/angular_devkit/build_angular/src/extract-i18n/index.ts
+++ b/packages/angular_devkit/build_angular/src/extract-i18n/index.ts
@@ -25,7 +25,9 @@ import { Schema as BrowserBuilderOptions } from '../browser/schema';
 import { createI18nOptions } from '../utils/i18n-options';
 import { assertCompatibleAngularVersion } from '../utils/version';
 import { generateBrowserWebpackConfigFromContext } from '../utils/webpack-browser-config';
-import { Format, Schema as ExtractI18nBuilderOptions } from './schema';
+import { Format, Schema } from './schema';
+
+export type ExtractI18nBuilderOptions = Schema & JsonObject;
 
 function getI18nOutfile(format: string | undefined) {
   switch (format) {
@@ -49,7 +51,7 @@ class InMemoryOutputPlugin {
   }
 }
 
-async function execute(options: ExtractI18nBuilderOptions, context: BuilderContext) {
+export async function execute(options: ExtractI18nBuilderOptions, context: BuilderContext) {
   // Check Angular version.
   assertCompatibleAngularVersion(context.workspaceRoot, context.logger);
 

--- a/packages/angular_devkit/build_angular/src/index.ts
+++ b/packages/angular_devkit/build_angular/src/index.ts
@@ -44,6 +44,11 @@ export {
 } from './dev-server';
 
 export {
+  execute as executeExtractI18nBuilder,
+  ExtractI18nBuilderOptions,
+} from './extract-i18n';
+
+export {
   execute as executeKarmaBuilder,
   KarmaBuilderOptions,
   KarmaConfigOptions,


### PR DESCRIPTION
export executeExtractI18nBuilder for use in custom builders and to be consistent with browser- and dev-server-builder.

no breaking changes, no issue