### PR TITLE
fix(@angular/cli): require to run in a project if the help flag is present

### DIFF
--- a/packages/angular/cli/models/command.ts
+++ b/packages/angular/cli/models/command.ts
@@ -169,9 +169,7 @@ export abstract class Command<T extends BaseCommandOptions = BaseCommandOptions>
   abstract async run(options: T & Arguments): Promise<number | void>;
 
   async validateAndRun(options: T & Arguments): Promise<number | void> {
-    if (!(options.help === true || options.help === 'json' || options.help === 'JSON')) {
-      await this.validateScope();
-    }
+    await this.validateScope();
     await this.initialize(options);
 
     if (options.help === true) {

--- a/tests/legacy-cli/e2e/tests/commands/help/help-hidden.ts
+++ b/tests/legacy-cli/e2e/tests/commands/help/help-hidden.ts
@@ -14,7 +14,7 @@ export default function() {
         `);
       }
     })
-    .then(() => silentNg('--help', 'new'))
+    .then(() => silentNg('--help', 'generate'))
     .then(({ stdout }) => {
       if (stdout.match(/--link-cli/)) {
         throw new Error(oneLine`

--- a/tests/legacy-cli/e2e/tests/commands/help/help-json.ts
+++ b/tests/legacy-cli/e2e/tests/commands/help/help-json.ts
@@ -1,15 +1,27 @@
 import { silentNg } from '../../../utils/process';
-
+import { deleteFile } from '../../../utils/fs';
 
 export default async function() {
   const commands = require('@angular/cli/commands.json');
-  for (const commandName of Object.keys(commands)) {
-    const { stdout } = await silentNg(commandName, '--help=json');
 
-    if (stdout.trim()) {
-      JSON.parse(stdout);
-    } else {
-      console.warn(`No JSON output for command [${commandName}].`);
+  async function execCommands(commands: string[]) {
+    for (const commandName of commands) {
+      const { stdout } = await silentNg(commandName, '--help=json');
+
+      if (stdout.trim()) {
+        JSON.parse(stdout);
+      } else {
+        console.warn(`No JSON output for command [${commandName}].`);
+      }
     }
   }
+
+  const commandsToRunInAProject = Object.keys(commands).filter(commandName => commandName !== 'new');
+  // `ng new` is the only command that's required to run outside of an Angular project
+  const commandsToRunOutsideOfAProject = ['new'];
+
+  await execCommands(commandsToRunInAProject);
+  // Remove `angular.json` to ensure `ng new` is runnable in the same directory
+  await deleteFile('angular.json');
+  await execCommands(commandsToRunOutsideOfAProject);
 }


### PR DESCRIPTION
Closes: #16241

Currently, when running `ng generate --help` or any other command (e.g. `ng add --help`), it throws such exception:
```
An unhandled exception occurred: Unable to locate a workspace file for workspace path.
See "/tmp/ng-lBY5ie/angular-errors.log" for further details.
```

Angular CLI requires commands to be run in an Angular project only if there is no `help` flag.

This PR provides a small fix that removes condition allowing to always validate scope and throw:
`The <command> command requires to be run in an Angular project`

Except of unhandled exception.

Otherwise it would need to edit more code.