### PR TITLE
doc: adds "PR action: merge" label

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,14 +110,21 @@ Before you submit your Pull Request (PR) consider the following guidelines:
 * If we suggest changes then:
   * Make the required updates.
   * Re-run the Angular DevKit test suites to ensure tests are still passing.
-  * Rebase your branch and force push to your GitHub repository (this will update your Pull Request):
+* Once your PR is approved and you are done with any follow up changes:
+  * Rebase to the current master to pre-emptively address any merge conflicts.
 
     ```shell
     git rebase master -i
     git push -f
     ```
+  * Add the `PR action: merge` label and the correct
+[target label](https://github.com/angular/angular/blob/master/docs/TRIAGE_AND_LABELS.md#pr-target)
+    (if PR author has the project collaborator status, or else the last reviewer
+    should do this).
+  * The current caretaker will merge the PR to the target branch(es) within 1-2
+    business days.
 
-That's it! Thank you for your contribution!
+That's it! 🎉 Thank you for your contribution!
 
 #### After your pull request is merged
 
@@ -301,12 +308,12 @@ yarn bazel run //etc/api:angular_devkit_core_api.accept
 **Note**: In some cases we use aliased symbols to create namespaces.
 
 Example:
-```javascript 
+```javascript
 import * as foo from './foo';
 
 export { foo };
 ```
-There are currently not supported by the API guardian. 
+There are currently not supported by the API guardian.
 To overcome this limitation we created `_golden-api.ts` in certain packages.
 
 When adding a new API, it might be the case that you need to add it to `_golden-api.ts`.

--- a/docs/process/release.md
+++ b/docs/process/release.md
@@ -18,7 +18,7 @@ TBD
 ## Merging PRs
 
 The list of PRs which are currently ready to merge (approved with passing status checks) can
-be found with [this search](https://github.com/angular/angular-cli/pulls?q=is%3Apr+is%3Aopen+review%3Aapproved+status%3Asuccess).
+be found with [this search](https://github.com/angular/angular-cli/pulls?q=is%3Apr+is%3Aopen+label%3A%22PR+action%3A+merge%22).
 This list should be checked daily and any ready PRs should be merged. For each
 PR, check the `PR target` label to understand where it should be merged to. If
 `master` is targetted, then click "Rebase and Merge". If the PR also targets a

--- a/scripts/templates/contributing.ejs
+++ b/scripts/templates/contributing.ejs
@@ -110,14 +110,21 @@ Before you submit your Pull Request (PR) consider the following guidelines:
 * If we suggest changes then:
   * Make the required updates.
   * Re-run the Angular DevKit test suites to ensure tests are still passing.
-  * Rebase your branch and force push to your GitHub repository (this will update your Pull Request):
+* Once your PR is approved and you are done with any follow up changes:
+  * Rebase to the current master to pre-emptively address any merge conflicts.
 
     ```shell
     git rebase master -i
     git push -f
     ```
+  * Add the `PR action: merge` label and the correct
+[target label](https://github.com/angular/angular/blob/master/docs/TRIAGE_AND_LABELS.md#pr-target)
+    (if PR author has the project collaborator status, or else the last reviewer
+    should do this).
+  * The current caretaker will merge the PR to the target branch(es) within 1-2
+    business days.
 
-That's it! Thank you for your contribution!
+That's it! 🎉 Thank you for your contribution!
 
 #### After your pull request is merged
 
@@ -290,12 +297,12 @@ yarn bazel run //etc/api:angular_devkit_core_api.accept
 **Note**: In some cases we use aliased symbols to create namespaces.
 
 Example:
-```javascript 
+```javascript
 import * as foo from './foo';
 
 export { foo };
 ```
-There are currently not supported by the API guardian. 
+There are currently not supported by the API guardian.
 To overcome this limitation we created `_golden-api.ts` in certain packages.
 
 When adding a new API, it might be the case that you need to add it to `_golden-api.ts`.


### PR DESCRIPTION
This label should be placed by the author (or last reviewer if author is not a collaborator) when the PR is complete and ready to merged. This requires the author to explicitly acknolwedge that they are done with the PR and the caretaker is free to merge it. This label brings the CLI caretaking process into alignment with the frameworks and components repos.

A more automated solution is desired but difficult due to google3 merging challenges. That would be a separate problem, but this should at least get the Angular organization to a more consistent state and we can revisit that challenge when we get to it.

I chose to link to the existing PR target definitions in the framework docs, let me know if I should duplicate this for the CLI.