### PR TITLE
revert: fix(@angular-devkit/build-angular): sockPath for custom path

### DIFF
--- a/packages/angular_devkit/build_angular/src/dev-server/index.ts
+++ b/packages/angular_devkit/build_angular/src/dev-server/index.ts
@@ -434,10 +434,6 @@ function _addLiveReload(
   if (clientAddress.pathname) {
     clientAddress.pathname = path.posix.join(clientAddress.pathname, 'sockjs-node');
     sockjsPath = '&sockPath=' + clientAddress.pathname;
-    // ensure webpack-dev-server uses the correct path to connect to the reloading socket
-    if (webpackConfig.devServer) {
-      webpackConfig.devServer.sockPath = clientAddress.pathname;
-    }
   }
 
   const entryPoints = [`${webpackDevServerPath}?${url.format(clientAddress)}${sockjsPath}`];


### PR DESCRIPTION
This reverts commit e097c56ada8dabddb7f0fd62b5cc0dd000179938.

8.3.x variant of #16416

Fixes #16410
Fixes #16266

NOTE TO CARETAKER: pending status of `ci/angular: merge status` is incorrect and can be ignored.  The two _missing_ status checks do not exist on this branch.