### PR TITLE
revert: fix(@angular-devkit/build-angular): sockPath for custom path

### DIFF
--- a/packages/angular_devkit/build_angular/src/dev-server/index.ts
+++ b/packages/angular_devkit/build_angular/src/dev-server/index.ts
@@ -579,10 +579,6 @@ function _addLiveReload(
   if (clientAddress.pathname) {
     clientAddress.pathname = path.posix.join(clientAddress.pathname, 'sockjs-node');
     sockjsPath = '&sockPath=' + clientAddress.pathname;
-    // ensure webpack-dev-server uses the correct path to connect to the reloading socket
-    if (webpackConfig.devServer) {
-      webpackConfig.devServer.sockPath = clientAddress.pathname;
-    }
   }
 
   const entryPoints = [`${webpackDevServerPath}?${url.format(clientAddress)}${sockjsPath}`];


### PR DESCRIPTION
This reverts commit 5260bbb9a3d17aefb90bcf1b660e252996cf68df.

The public host option should only affect how clients access the development server and not how the development server actually serves the files.

Fixes #16410
Fixes #16266