### PR TITLE
fix(@ngtools/webpack): invalidate ngcc processor cache

### DIFF
--- a/packages/ngtools/webpack/src/compiler_host.ts
+++ b/packages/ngtools/webpack/src/compiler_host.ts
@@ -10,7 +10,7 @@ import { Stats } from 'fs';
 import * as ts from 'typescript';
 import { NgccProcessor } from './ngcc_processor';
 import { WebpackResourceLoader } from './resource_loader';
-import { workaroundResolve } from './utils';
+import { forwardSlashPath, workaroundResolve } from './utils';
 
 export interface OnErrorFn {
   (message: string): void;
@@ -100,6 +100,11 @@ export class WebpackCompilerHost implements ts.CompilerHost {
   invalidate(fileName: string): void {
     const fullPath = this.resolve(fileName);
     this._sourceFileCache.delete(fullPath);
+
+    if (this.ngccProcessor) {
+      // Delete the ngcc processor cache using the TS-format file names.
+      this.ngccProcessor.invalidate(forwardSlashPath(fileName));
+    }
 
     let exists = false;
     try {

--- a/packages/ngtools/webpack/src/ngcc_processor.ts
+++ b/packages/ngtools/webpack/src/ngcc_processor.ts
@@ -54,7 +54,8 @@ export class NgccProcessor {
     resolvedModule: ts.ResolvedModule | ts.ResolvedTypeReferenceDirective,
   ): void {
     const resolvedFileName = resolvedModule.resolvedFileName;
-    if (!resolvedFileName || moduleName.startsWith('.') || this._processedModules.has(moduleName)) {
+    if (!resolvedFileName || moduleName.startsWith('.')
+      || this._processedModules.has(resolvedFileName)) {
       // Skip when module is unknown, relative or NGCC compiler is not found or already processed.
       return;
     }
@@ -62,7 +63,7 @@ export class NgccProcessor {
     const packageJsonPath = this.tryResolvePackage(moduleName, resolvedFileName);
     if (!packageJsonPath) {
       // add it to processed so the second time round we skip this.
-      this._processedModules.add(moduleName);
+      this._processedModules.add(resolvedFileName);
 
       return;
     }
@@ -73,7 +74,7 @@ export class NgccProcessor {
       accessSync(packageJsonPath, constants.W_OK);
     } catch {
       // add it to processed so the second time round we skip this.
-      this._processedModules.add(moduleName);
+      this._processedModules.add(resolvedFileName);
 
       return;
     }
@@ -97,7 +98,11 @@ export class NgccProcessor {
     // tslint:disable-next-line:no-any
     (this.inputFileSystem as any).purge(packageJsonPath);
 
-    this._processedModules.add(moduleName);
+    this._processedModules.add(resolvedFileName);
+  }
+
+  invalidate(fileName: string) {
+    this._processedModules.delete(fileName);
   }
 
   /**


### PR DESCRIPTION
Fix #16397