### PR TITLE
@v8.3.x - auditted cross site scripting vulnerability in `serialize-javascript`

### DIFF
--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -55,7 +55,7 @@
     "stylus-loader": "3.0.2",
     "tree-kill": "1.2.1",
     "terser": "4.3.9",
-    "terser-webpack-plugin": "1.4.1",
+    "terser-webpack-plugin": "1.4.3",
     "webpack": "4.39.2",
     "webpack-dev-middleware": "3.7.2",
     "webpack-dev-server": "3.9.0",

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -21,7 +21,7 @@
     "caniuse-lite": "1.0.30000989",
     "circular-dependency-plugin": "5.2.0",
     "clean-css": "4.2.1",
-    "copy-webpack-plugin": "5.0.4",
+    "copy-webpack-plugin": "5.0.5",
     "core-js": "3.2.1",
     "file-loader": "4.2.0",
     "find-cache-dir": "3.0.0",


### PR DESCRIPTION
Hi Guys

I hope I'm targetting the right branch for `"@angular-devkit/build-angular": "^0.803.20"`. There is a `yarn audit` reported vulnerability via `terser-webpack-plugin@4.1.1` and `copy-webpack-plugin@5.0.4`.

```bash
$ yarn audit
yarn audit v1.19.2
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ moderate      │ Cross-Site Scripting                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ serialize-javascript                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=2.1.1                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ @angular-devkit/build-angular                                │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ @angular-devkit/build-angular > copy-webpack-plugin >        │
│               │ serialize-javascript                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1426                        │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ serialize-javascript                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=2.1.1                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ @angular-devkit/build-angular                                │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ @angular-devkit/build-angular > terser-webpack-plugin >      │
│               │ serialize-javascript                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1426                        │
└───────────────┴──────────────────────────────────────────────────────────────┘
2 vulnerabilities found - Packages audited: 19126
Severity: 2 Moderate
Done in 2.41s.
```

Let me know if there's something more to do for the fix 🚀 