### PR TITLE
fix(@angular-devkit/build-angular): optimize web worker differential loading processing

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/process-bundle.ts
+++ b/packages/angular_devkit/build_angular/src/utils/process-bundle.ts
@@ -489,7 +489,7 @@ function createReplacePlugin(replacements: [string, string][]): PluginObj {
       StringLiteral(path: NodePath<types.StringLiteral>) {
         for (const replacement of replacements) {
           if (path.node.value === replacement[0]) {
-            path.replaceWith(types.stringLiteral(replacement[1]));
+            path.node.value = replacement[1];
           }
         }
       },


### PR DESCRIPTION
Replacing the node path can cause stack overflows for very large files.

Closes #16441