### PR TITLE
[8.3.x] fix(@angular-devkit/build-angular): prevent differential loading double sourcemap search

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/process-bundle.ts
+++ b/packages/angular_devkit/build_angular/src/utils/process-bundle.ts
@@ -97,7 +97,7 @@ export async function process(options: ProcessBundleOptions): Promise<ProcessBun
   const manualSourceMaps = codeSize >= 1024 * 1024 || mapSize >= 1024 * 1024;
 
   const sourceCode = options.code;
-  const sourceMap = options.map ? JSON.parse(options.map) : undefined;
+  const sourceMap = options.map ? JSON.parse(options.map) : false;
 
   let downlevelCode;
   let downlevelMap;
@@ -105,7 +105,8 @@ export async function process(options: ProcessBundleOptions): Promise<ProcessBun
     // Downlevel the bundle
     const transformResult = await transformAsync(sourceCode, {
       filename: options.filename,
-      inputSourceMap: manualSourceMaps ? undefined : sourceMap,
+      // using false ensures that babel will NOT search and process sourcemap comments (large memory usage)
+      inputSourceMap: manualSourceMaps ? false : sourceMap,
       babelrc: false,
       presets: [
         [


### PR DESCRIPTION
This can drastically reduce memory usage; especially in cases where bundled code modules contain individual sourcemap comments and vendor sourcemaps are disabled.  When enabling the vendor sourcemap option it has the side effect of removing all individual module sourcemap comments and as a result removes the potential for those comments to be found and processed.  This option can be used as a workaround, where possible, until this PR is merged and released.


NOTE TO CARETAKER: pending status of `ci/angular: merge status` is incorrect and can be ignored.  The two _missing_ status checks do not exist on this branch.