### PR TITLE
fix(@angular-devkit/build-angular): add sourceMappingURL comment for …

### DIFF
--- a/packages/angular_devkit/build_angular/src/browser/index.ts
+++ b/packages/angular_devkit/build_angular/src/browser/index.ts
@@ -390,12 +390,6 @@ export function buildWebpackBrowser(
                 if (!es5Polyfills) {
                   moduleFiles.push(file);
                 }
-                // If not optimizing then ES2015 polyfills do not need processing
-                // Unlike other module scripts, it is never downleveled
-                const es2015Polyfills = file.file.startsWith('polyfills-es20');
-                if (!actionOptions.optimize && es2015Polyfills) {
-                  continue;
-                }
 
                 // Retrieve the content/map for the file
                 // NOTE: Additional future optimizations will read directly from memory
@@ -416,6 +410,8 @@ export function buildWebpackBrowser(
                   fs.unlinkSync(filename);
                   filename = filename.replace(/\-es20\d{2}/, '');
                 }
+
+                const es2015Polyfills = file.file.startsWith('polyfills-es20');
 
                 // Record the bundle processing action
                 // The runtime chunk gets special processing for lazy loaded files

--- a/tests/legacy-cli/e2e/tests/build/no-sourcemap.ts
+++ b/tests/legacy-cli/e2e/tests/build/no-sourcemap.ts
@@ -1,0 +1,36 @@
+import * as fs from 'fs';
+import { ng } from '../../utils/process';
+
+export default async function () {
+  await ng('build', '--prod', '--output-hashing=none', '--source-map', 'false');
+  await testForSourceMaps(6);
+
+  await ng('build', '--output-hashing=none', '--source-map', 'false');
+  await testForSourceMaps(8);
+}
+
+async function testForSourceMaps(expectedNumberOfFiles: number): Promise <void> {
+  const files = fs.readdirSync('./dist/test-project');
+
+  let count = 0;
+  for (const file of files) {
+    if (!file.endsWith('.js')) {
+      continue;
+    }
+
+    ++count;
+
+    if (files.includes(file + '.map')) {
+      throw new Error('Sourcemap generated for ' + file);
+    }
+
+    const content = fs.readFileSync('./dist/test-project/' + file, 'utf8');
+    if (content.includes(`//# sourceMappingURL=${file}.map`)) {
+      throw new Error('Sourcemap comment found generated for ' + file);
+    }
+  }
+
+  if (count < expectedNumberOfFiles) {
+    throw new Error(`Javascript file count is low. Expected ${expectedNumberOfFiles} but found ${count}`);
+  }
+}

--- a/tests/legacy-cli/e2e/tests/build/sourcemap.ts
+++ b/tests/legacy-cli/e2e/tests/build/sourcemap.ts
@@ -2,10 +2,17 @@ import * as fs from 'fs';
 import { expectFileToExist } from '../../utils/fs';
 import { ng } from '../../utils/process';
 
-export default async function() {
+export default async function () {
   await ng('build', '--prod', '--output-hashing=none', '--source-map');
+  await testForSourceMaps(6);
 
+  await ng('build', '--output-hashing=none', '--source-map');
+  await testForSourceMaps(8);
+}
+
+async function testForSourceMaps(expectedNumberOfFiles: number): Promise <void> {
   await expectFileToExist('dist/test-project/main-es5.js.map');
+  await expectFileToExist('dist/test-project/main-es2015.js.map');
 
   const files = fs.readdirSync('./dist/test-project');
 
@@ -29,7 +36,7 @@ export default async function() {
     }
   }
 
-  if (count < 6) {
-    throw new Error('Javascript file count is low');
+  if (count < expectedNumberOfFiles) {
+    throw new Error(`Javascript file count is low. Expected ${expectedNumberOfFiles} but found ${count}`);
   }
 }


### PR DESCRIPTION
…ES2015 during differential loading

When having differential loading enabled we only add the `sourceMappingURL` comment when optimization is enabled, because we only process these bundles when we enabling optimization.

With this change we now process such bundles even when optimization is disabled and add `sourceMappingURL` when source maps are enabled and not hidden.

Closes #16522