### PR TITLE
fix(@angular-devkit/build-angular): account for hashed and non hashed…

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/action-cache.ts
+++ b/packages/angular_devkit/build_angular/src/utils/action-cache.ts
@@ -56,7 +56,8 @@ export class BundleActionCache {
 
     // sourceMappingURL is added at the very end which causes the code to be the same when sourcemaps are enabled/disabled
     // When using hiddenSourceMaps we can omit the postfix since sourceMappingURL will not be added.
-    const sourceMapPostFix = action.sourceMaps && !action.hiddenSourceMaps ? '|sourcemap' : '';
+    // When having sourcemaps a hashed file and non hashed file can have the same content. But the sourceMappingURL will differ.
+    const sourceMapPostFix = action.sourceMaps && !action.hiddenSourceMaps ? `|sourcemap|${action.filename}` : '';
 
     const baseCacheKey = this.generateBaseCacheKey(action.code);
 

--- a/tests/legacy-cli/e2e/tests/build/sourcemap.ts
+++ b/tests/legacy-cli/e2e/tests/build/sourcemap.ts
@@ -3,6 +3,10 @@ import { expectFileToExist } from '../../utils/fs';
 import { ng } from '../../utils/process';
 
 export default async function () {
+  // The below is needed to cache bundles and verify that sourcemaps are generated
+  // corretly when output-hashing is disabled.
+  await ng('build', '--output-hashing=bundles', '--source-map');
+
   await ng('build', '--prod', '--output-hashing=none', '--source-map');
   await testForSourceMaps(6);
 


### PR DESCRIPTION
… filesnames when having sourcemaps