### PR TITLE
docs(@angular/cli): fix description

### DIFF
--- a/packages/angular/cli/README.md
+++ b/packages/angular/cli/README.md
@@ -94,7 +94,7 @@ ng g component my-new-component # using the alias
 # components support relative path generation
 # if in the directory src/app/feature/ and you run
 ng g component new-cmp
-# your component will be generated in src/app/feature/new-cmp
+# your component will be generated in src/app/new-cmp
 # but if you were to run
 ng g component ./newer-cmp
 # your component will be generated in src/app/newer-cmp


### PR DESCRIPTION
Ran `ng g component new-cmp` command if in the directory src/app/feature/.
Then my component was generated in `src/app/new-cmp/`.

## Version
```
Angular CLI: 8.3.21
Node: 12.13.0
OS: darwin x64
Angular: 8.2.14
```

## To Reproduce
```shell
$ ng new sample
$ cd sample/
$ mkdir src/app/feature
$ cd src/app/feature/
$ yarn ng g c new-cmp
CREATE src/app/new-cmp/new-cmp.component.scss (0 bytes)
CREATE src/app/new-cmp/new-cmp.component.html (22 bytes)
CREATE src/app/new-cmp/new-cmp.component.spec.ts (629 bytes)
CREATE src/app/new-cmp/new-cmp.component.ts (273 bytes)
UPDATE src/app/app.module.ts (477 bytes)
```