### PR TITLE
build: update tree-kill to version ^1.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "spdx-satisfies": "^5.0.0",
     "tar": "^5.0.0",
     "through2": "^3.0.0",
-    "tree-kill": "^1.2.0",
+    "tree-kill": "^1.2.2",
     "ts-api-guardian": "0.4.6",
     "ts-node": "^5.0.0",
     "tslint-no-circular-imports": "^0.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10624,7 +10624,7 @@ tr46@^1.0.1:
   dependencies:
     punycode "^2.1.0"
 
-tree-kill@1.2.2:
+tree-kill@1.2.2, tree-kill@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
   integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==


### PR DESCRIPTION
Update tree-kill dependency to ^1.2.2 in response to https://npmjs.com/advisories/1432.  Advisory affects tree-kill dependency, not angular-cli.