### PR TITLE
[9.0.x] fix(@angular-devkit/build-angular): update tree-kill dependency to 1.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "spdx-satisfies": "^4.0.0",
     "tar": "^4.4.4",
     "through2": "^2.0.3",
-    "tree-kill": "^1.2.0",
+    "tree-kill": "^1.2.2",
     "ts-api-guardian": "0.4.6",
     "ts-node": "^5.0.0",
     "tslint-no-circular-imports": "^0.7.0",

--- a/packages/angular_devkit/benchmark/package.json
+++ b/packages/angular_devkit/benchmark/package.json
@@ -19,6 +19,6 @@
     "pidusage": "2.0.17",
     "pidtree": "0.3.0",
     "rxjs": "6.5.3",
-    "tree-kill": "^1.2.0"
+    "tree-kill": "^1.2.2"
   }
 }

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -58,7 +58,7 @@
     "style-loader": "1.0.0",
     "stylus": "0.54.7",
     "stylus-loader": "3.0.2",
-    "tree-kill": "1.2.1",
+    "tree-kill": "1.2.2",
     "terser": "4.5.1",
     "terser-webpack-plugin": "2.2.1",
     "webpack": "4.41.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10487,10 +10487,10 @@ tr46@^1.0.1:
   dependencies:
     punycode "^2.1.0"
 
-tree-kill@1.2.1, tree-kill@^1.2.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.1.tgz#5398f374e2f292b9dcc7b2e71e30a5c3bb6c743a"
-  integrity sha512-4hjqbObwlh2dLyW4tcz0Ymw0ggoaVDMveUB9w8kFSQScdRLo0gxO9J7WFcUBo+W3C1TLdFIEwNOWebgZZ0RH9Q==
+tree-kill@1.2.2, tree-kill@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
+  integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
 
 treeify@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
While the CLI is not affected by the following advisory, this change will address the audit warning and prevent potential future usage of the package within the CLI from being affected.
Advisory: https://www.npmjs.com/advisories/1432