### PR TITLE
feat(@angular-devkit/build-angular): default to NodeJS value for pres…

### DIFF
--- a/packages/angular/cli/lib/config/schema.json
+++ b/packages/angular/cli/lib/config/schema.json
@@ -844,8 +844,7 @@
             },
             "preserveSymlinks": {
               "type": "boolean",
-              "description": "Do not use the real path when resolving modules.",
-              "default": false
+              "description": "Do not use the real path when resolving modules."
             },
             "extractLicenses": {
               "type": "boolean",
@@ -1478,8 +1477,7 @@
             },
             "preserveSymlinks": {
               "type": "boolean",
-              "description": "Do not use the real path when resolving modules.",
-              "default": false
+              "description": "Do not use the real path when resolving modules."
             },
             "browsers": {
               "type": "string",
@@ -1855,8 +1853,7 @@
             },
             "preserveSymlinks": {
               "type": "boolean",
-              "description": "Do not use the real path when resolving modules.",
-              "default": false
+              "description": "Do not use the real path when resolving modules."
             },
             "extractLicenses": {
               "type": "boolean",

--- a/packages/angular_devkit/build_angular/src/browser/schema.json
+++ b/packages/angular_devkit/build_angular/src/browser/schema.json
@@ -248,8 +248,7 @@
     },
     "preserveSymlinks": {
       "type": "boolean",
-      "description": "Do not use the real path when resolving modules.",
-      "default": false
+      "description": "Do not use the real path when resolving modules. If unset then will default to `true` if NodeJS option --preserve-symlinks is set."
     },
     "extractLicenses": {
       "type": "boolean",

--- a/packages/angular_devkit/build_angular/src/karma/schema.json
+++ b/packages/angular_devkit/build_angular/src/karma/schema.json
@@ -126,8 +126,7 @@
     },
     "preserveSymlinks": {
       "type": "boolean",
-      "description": "Do not use the real path when resolving modules.",
-      "default": false
+      "description": "Do not use the real path when resolving modules. If unset then will default to `true` if NodeJS option --preserve-symlinks is set."
     },
     "browsers": {
       "type": "string",

--- a/packages/angular_devkit/build_angular/src/server/schema.json
+++ b/packages/angular_devkit/build_angular/src/server/schema.json
@@ -198,8 +198,7 @@
     },
     "preserveSymlinks": {
       "type": "boolean",
-      "description": "Do not use the real path when resolving modules.",
-      "default": false
+      "description": "Do not use the real path when resolving modules. If unset then will default to `true` if NodeJS option --preserve-symlinks is set."
     },
     "extractLicenses": {
       "type": "boolean",

--- a/packages/angular_devkit/build_angular/src/utils/normalize-builder-schema.ts
+++ b/packages/angular_devkit/build_angular/src/utils/normalize-builder-schema.ts
@@ -53,7 +53,7 @@ export function normalizeBrowserSchema(
     fileReplacements: normalizeFileReplacements(options.fileReplacements || [], syncHost, root),
     optimization: normalizeOptimization(options.optimization),
     sourceMap: normalizedSourceMapOptions,
-
+    preserveSymlinks: options.preserveSymlinks === undefined ? process.execArgv.includes('--preserve-symlinks') : options.preserveSymlinks,
     statsJson: options.statsJson || false,
     forkTypeChecker: options.forkTypeChecker || false,
     budgets: options.budgets || [],

--- a/tests/angular_devkit/core/json/schema/serializers/schema_benchmark.json
+++ b/tests/angular_devkit/core/json/schema/serializers/schema_benchmark.json
@@ -480,8 +480,7 @@
             },
             "preserveSymlinks": {
               "description": "Do not use the real path when resolving modules.",
-              "type": "boolean",
-              "default": false
+              "type": "boolean"
             },
             "showCircularDependencies": {
               "description": "Show circular dependency warnings on builds.",


### PR DESCRIPTION
…erveSymlinks

Under bazel `preserveSymlinks` would have to be set in two different places, this makes it so it only has to be set once by using the value from NodeJS if it's set.