### PR TITLE
build: remove pnpm engine value due to lack of yarn support

### DIFF
--- a/lib/packages.ts
+++ b/lib/packages.ts
@@ -84,7 +84,6 @@ function loadPackageJson(p: string) {
         pkg['engines'] = {
           'node': '>= 10.13.0',
           'npm': '>= 6.11.0',
-          'pnpm': '>= 3.2.0',
           'yarn': '>= 1.13.0',
         };
         break;


### PR DESCRIPTION
Yarn displays a warning due to an unknown engine value of `pnpm`.  Until this is corrected upstream, the value can be temporarily removed to eliminate the multiple, but otherwise harmless, warnings shown to users upon package install.

Yarn Issue: https://github.com/yarnpkg/yarn/issues/7560
Yarn PR: https://github.com/yarnpkg/yarn/pull/7566