### PR TITLE
fix(@angular-devkit/build-angular): emit error when a script is not found.

### DIFF
--- a/packages/angular_devkit/build_angular/test/browser/scripts-array_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/browser/scripts-array_spec_large.ts
@@ -175,4 +175,16 @@ describe('Browser Builder scripts array', () => {
     expect(logs.join('\n')).toMatch(/\(renamed-script\) 78 bytes.*\[entry].*\[rendered]/);
     expect(logs.join('\n')).toMatch(/\(renamed-lazy-script\) 88 bytes.*\[entry].*\[rendered]/);
   });
+
+  it(`should error when a script doesn't exist`, async () => {
+    await expectAsync(browserBuild(
+      architect,
+      host,
+      target,
+      {
+        scripts: ['./invalid.js'],
+      },
+    ))
+      .toBeRejectedWithError(`Script file ./invalid.js does not exist.`);
+  });
 });


### PR DESCRIPTION

While we currently invoke the `callback` with the error in https://github.com/angular/angular-cli/blob/d4f1ff82c5d994aca68c39ff31f5d8b22e694b87/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/scripts-webpack-plugin.ts#L163 this is not bubbled up to the main webpack compilation due to the usage of `thisCompilation`.

Closes #16659