### PR TITLE
ci: add "PR action: merge" label to renovate bot PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,8 @@
   "separateMajorMinor": false,
   "prHourlyLimit": 2,
   "labels": [
-    "PR target: master-only"
+    "PR target: master-only",
+    "PR action: merge"
   ],
   "timezone": "America/Tijuana",
   "lockFileMaintenance": {


### PR DESCRIPTION
This label is expected to be added by authors after the review once they have made final edits to the PR (per contributing guidelines: https://github.com/angular/angular-cli/blob/master/CONTRIBUTING.md#-submitting-a-pull-request-pr). The bot will never make additional edits from a review, so it is always ready to merge. This adds the "PR action: merge" label so it will show up correctly in the caretaker search for PRs ready to merge (https://github.com/angular/angular-cli/blob/master/CONTRIBUTING.md#-submitting-a-pull-request-pr). Renovate PRs will still require review and passing status checks before becoming visible to caretakers.