### PR TITLE
fix(@schematics/angular): add `skipLibCheck` to workspace tsconfig

### DIFF
--- a/packages/schematics/angular/workspace/files/tsconfig.json.template
+++ b/packages/schematics/angular/workspace/files/tsconfig.json.template
@@ -8,6 +8,7 @@
     "noImplicitThis": true,
     "noFallthroughCasesInSwitch": true,
     "strictNullChecks": true,<% } %>
+    "skipLibCheck": true,
     "sourceMap": true,
     "declaration": false,
     "downlevelIteration": true,

--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -23,6 +23,7 @@ const knownFlakes = [
   // Rebuild tests in test-large are flakey if not run as the first suite.
   // https://github.com/angular/angular-cli/pull/15204
   'packages/angular_devkit/build_angular/test/browser/rebuild_spec_large.ts',
+  'packages/angular_devkit/build_angular/test/browser/web-worker_spec_large.ts',
 ];
 
 const projectBaseDir = join(__dirname, '..');

--- a/tests/angular_devkit/build_angular/hello-world-app-ve/tsconfig.json
+++ b/tests/angular_devkit/build_angular/hello-world-app-ve/tsconfig.json
@@ -5,6 +5,7 @@
     "outDir": "./dist/out-tsc",
     "sourceMap": true,
     "declaration": false,
+    "skipLibCheck": true,
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,

--- a/tests/angular_devkit/build_angular/hello-world-app/tsconfig.json
+++ b/tests/angular_devkit/build_angular/hello-world-app/tsconfig.json
@@ -5,6 +5,7 @@
     "outDir": "./dist/out-tsc",
     "sourceMap": true,
     "declaration": false,
+    "skipLibCheck": true,
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,

--- a/tests/angular_devkit/build_ng_packagr/ng-packaged-ve/tsconfig.json
+++ b/tests/angular_devkit/build_ng_packagr/ng-packaged-ve/tsconfig.json
@@ -5,6 +5,7 @@
     "outDir": "./dist/out-tsc",
     "sourceMap": true,
     "declaration": false,
+    "skipLibCheck": true,
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,

--- a/tests/angular_devkit/build_ng_packagr/ng-packaged/tsconfig.json
+++ b/tests/angular_devkit/build_ng_packagr/ng-packaged/tsconfig.json
@@ -5,6 +5,7 @@
     "outDir": "./dist/out-tsc",
     "sourceMap": true,
     "declaration": false,
+    "skipLibCheck": true,
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,

--- a/tests/legacy-cli/e2e/tests/build/skip-lib-check.ts
+++ b/tests/legacy-cli/e2e/tests/build/skip-lib-check.ts
@@ -1,0 +1,11 @@
+import { ng } from '../../utils/process';
+import { createProject, updateTsConfig } from '../../utils/project';
+
+
+export default async function() {
+  await createProject('strict-workspace-test-project', '--strict');
+  await updateTsConfig(json => {
+    json['compilerOptions']['skipLibCheck'] = false;
+  });
+  await ng('build');
+}


### PR DESCRIPTION


Add skipLibCheck to speed up TypeScript analysis and prevent compilation errors caused by incompatible declaration files which were generated with older/new TS versions.

//cc @IgorMinar 