### PR TITLE
revert "fix(@angular-devkit/build-optimizer): wrap classes which cont…

### DIFF
--- a/packages/angular_devkit/build_optimizer/src/transforms/wrap-enums.ts
+++ b/packages/angular_devkit/build_optimizer/src/transforms/wrap-enums.ts
@@ -322,15 +322,7 @@ function findStatements(
 
   for (let index = statementIndex + 1; index < statements.length; ++index) {
     const statement = statements[index];
-
     if (!ts.isExpressionStatement(statement)) {
-      // The below is a workaround for NGCC as TS will never emit an EmptyStatement.
-      // See: https://github.com/angular/angular-cli/issues/16509#issuecomment-570198398
-      if (ts.isEmptyStatement(statement)) {
-        count++;
-        continue;
-      }
-
       break;
     }
 

--- a/packages/angular_devkit/build_optimizer/src/transforms/wrap-enums_spec.ts
+++ b/packages/angular_devkit/build_optimizer/src/transforms/wrap-enums_spec.ts
@@ -88,36 +88,6 @@ describe('wrap enums and classes transformer', () => {
       expect(tags.oneLine`${transform(input)}`).toEqual(tags.oneLine`${output}`);
     });
 
-    it('should wrap classes which contain EmptyStatement', () => {
-      const input = tags.stripIndent`
-        let JigsawTrustedHtml = JigsawTrustedHtml_1 = class JigsawTrustedHtml {
-          constructor(_sanitizer, zone) {
-          }
-          static _getContext(magicNumber) {
-            return JigsawTrustedHtml_1._contexts[magicNumber];
-          }
-        };
-        JigsawTrustedHtml.ɵfac = function JigsawTrustedHtml_Factory(t) { };
-        // NGCC outputs an empty statement sometimes like the below:
-        // https://github.com/angular/angular-cli/issues/16509#issuecomment-570198398
-        JigsawTrustedHtml.ɵdir = ɵngcc0.ɵɵdefineDirective(); ;
-        JigsawTrustedHtml.ctorParameters = () => [
-          { type: DomSanitizer },
-          { type: NgZone }
-        ];
-      `;
-
-      const output = tags.stripIndent`
-        let JigsawTrustedHtml = /*@__PURE__*/ (() => {
-          ${input}
-
-          return JigsawTrustedHtml;
-        })();
-      `;
-
-      expect(tags.oneLine`${transform(input)}`).toEqual(tags.oneLine`${output}`);
-    });
-
     it('should not wrap enum like which are inside of methods', () => {
       const input = tags.stripIndent`
         class LayoutDirective {


### PR DESCRIPTION
…ain empty statements (#16538)"

This reverts commit 4cde9228df5118a6c743467c668b6b7c5fe73013.

This is no longer needed as NGCC issue has been fixed in https://github.com/angular/angular/pull/34677