### PR TITLE
ci: use branch filtering to run `e2e-cli-ng-snapshots` and `e2e-cli-ng-ve-snapshots

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -387,28 +387,22 @@ workflows:
           snapshots: true
           requires:
             - e2e-cli
-          pre-steps:
-            - run:
-                name: Don't run expensive e2e snapshots tests for forks other than renovate-bot and angular
-                command: >
-                  if [[ "$CIRCLE_PR_USERNAME" != "renovate-bot" ]] &&
-                    [[ "$CIRCLE_PROJECT_USERNAME" != "angular" || $CIRCLE_BRANCH != "master" ]]; then
-                    circleci step halt
-                  fi
+          filters:
+            branches:
+              only:
+                - /renovate\/.+/
+                - master
       - e2e-cli:
           name: e2e-cli-ng-ve-snapshots
           snapshots: true
           ve: true
           requires:
             - e2e-cli
-          pre-steps:
-            - run:
-                name: Don't run expensive e2e snapshots tests for forks other than renovate-bot and angular
-                command: >
-                  if [[ "$CIRCLE_PR_USERNAME" != "renovate-bot" ]] &&
-                    [[ "$CIRCLE_PROJECT_USERNAME" != "angular" || $CIRCLE_BRANCH != "master" ]]; then
-                    circleci step halt
-                  fi
+          filters:
+            branches:
+              only:
+                - /renovate\/.+/
+                - master
       - e2e-cli-node-10:
           <<: *ignore_pull_requests
           requires:


### PR DESCRIPTION
ci: use branch filtering to run `e2e-cli-ng-snapshots` and `e2e-cli-ng-ve-snapshots`

Unlike PRs from users, when renovate opens a PR, the branch name will be in the following format `renovate/typescript-3.7.x` with `CIRCLE_BRANCH` being set to the same value. Also, `CIRCLE_PR_USERNAME` will not be defined in this case. Thus currently these 2 tasks are not being run for PRs which are being open by renovate.

Example of such build: https://circleci.com/gh/angular/angular-cli/129384