### PR TITLE
refactor(@angular/cli): remove use of process.exit 

### DIFF
--- a/packages/angular/cli/bin/ng
+++ b/packages/angular/cli/bin/ng
@@ -17,7 +17,7 @@ try {
 var version = process.versions.node.split('.').map(part => Number(part));
 if (version[0] < 10 || version[0] === 11 || (version[0] === 10 && version[1] < 13)) {
   process.stderr.write(
-    'Node.js version ' + process.verson + ' detected.\n' +
+    'Node.js version ' + process.version + ' detected.\n' +
     'The Angular CLI requires a minimum Node.js version of either v10.13 or v12.0.\n\n' +
     'Please update your Node.js version or visit https://nodejs.org/ for additional instructions.\n',
   );

--- a/packages/angular/cli/bin/ng
+++ b/packages/angular/cli/bin/ng
@@ -22,7 +22,7 @@ if (version[0] < 10 || version[0] === 11 || (version[0] === 10 && version[1] < 1
     'Please update your Node.js version or visit https://nodejs.org/ for additional instructions.\n',
   );
 
-  process.exit(3);
+  process.exitCode = 3;
+} else {
+  require('../lib/init');
 }
-
-require('../lib/init');

--- a/packages/angular/cli/lib/init.ts
+++ b/packages/angular/cli/lib/init.ts
@@ -122,15 +122,9 @@ if (process.env['NG_CLI_PROFILING']) {
 
       To disable this warning use "ng config -g cli.warnings.versionMismatch false".
       `);
-      // Don't show warning colorised on `ng completion`
-      if (process.argv[2] !== 'completion') {
-        // tslint:disable-next-line no-console
-        console.error(warning);
-      } else {
-        // tslint:disable-next-line no-console
-        console.error(warning);
-        process.exit(1);
-      }
+
+      // tslint:disable-next-line: no-console
+      console.error(warning);
     }
 
     // No error implies a projectLocalCli, which will load whatever
@@ -166,10 +160,10 @@ if (process.env['NG_CLI_PROFILING']) {
     outputStream: process.stdout,
   });
 }).then((exitCode: number) => {
-  process.exit(exitCode);
+  process.exitCode = exitCode;
 })
 .catch((err: Error) => {
   // tslint:disable-next-line no-console
   console.error('Unknown error: ' + err.toString());
-  process.exit(127);
+  process.exitCode = 127;
 });


### PR DESCRIPTION
process.exit() can cause the loss of asynchronous I/O.  This can include console output which may internally be asynchronous.
Reference: https://nodejs.org/api/process.html#process_process_exit_code