### PR TITLE
ci: reduce ci time for renovate PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -391,7 +391,7 @@ workflows:
           filters:
             branches:
               only:
-                - /renovate\/.+/
+                - renovate/angular
                 - master
       - e2e-cli:
           name: e2e-cli-ng-ve-snapshots
@@ -402,7 +402,7 @@ workflows:
           filters:
             branches:
               only:
-                - /renovate\/.+/
+                - renovate/angular
                 - master
       - e2e-cli-node-10:
           <<: *only_release_branches


### PR DESCRIPTION
Only run running `e2e-cli-ng-snapshots`  and `e2e-cli-ve-ng-snapshots` for non `renovate/angular` and `master` PRs to reduce CI time for renovate PRs.