### PR TITLE
fix(@angular/cli): ensure built-in Angular schematics package can be found

### DIFF
--- a/packages/angular/cli/models/schematic-command.ts
+++ b/packages/angular/cli/models/schematic-command.ts
@@ -254,7 +254,7 @@ export abstract class SchematicCommand<
       registry: new schema.CoreSchemaRegistry(formats.standardFormats),
       resolvePaths: !!this.workspace.configFile
         // Workspace
-        ? [process.cwd(), this.workspace.root]
+        ? [process.cwd(), this.workspace.root, __dirname]
         // Global
         : [__dirname, process.cwd()],
     });


### PR DESCRIPTION
The `@angular/cli` package contains a built-in version of the `@schematics/angular` package.  The module resolution paths for the schematics workflow should not assume package hoisting behavior when resolving.  This change corrects that oversight.