### PR TITLE
Correctly prints the size of the chunk during the build statistic print

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/stats.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/stats.ts
@@ -64,8 +64,9 @@ export function statsToString(json: any, statsConfig: any) {
   const changedChunksStats = json.chunks
     .filter((chunk: any) => chunk.rendered)
     .map((chunk: any) => {
-      const asset = json.assets.filter((x: any) => x.name == chunk.files[0])[0];
-      return generateBundleStats({ ...chunk, size: asset && asset.size }, colors);
+      const assets = json.assets.filter((asset: any) => chunk.files.indexOf(asset.name) != -1);
+      const summedSize = assets.filter((asset: any) => !asset.name.endsWith(".map")).reduce((total: number, asset: any) => { return total + asset.size }, 0);
+      return generateBundleStats({ ...chunk, size: summedSize }, colors);
     });
 
   const unchangedChunkNumber = json.chunks.length - changedChunksStats.length;


### PR DESCRIPTION
This commits allows the cli to correctly print the sum of the sizes of the assets of a given chunk instead of the size of the first emitted asset

Attached:
-Before.PNG: What was happening before the fix in my local environment
-After.PNG: What's happening after the fix, notice that now the size of the "main-client" is the actual sum of the sizes of main-client.js and initial.css
-[webpack.config.js](https://pastebin.com/MreT3kuc): As requested, my current webpack configuration. This problem happens when i'm using the [MiniCssExtractPlugin ](https://github.com/webpack-contrib/mini-css-extract-plugin)to extract my initial.css together with the main client

Before.PNG
![Before](https://user-images.githubusercontent.com/12494403/72915191-32573a00-3d40-11ea-8389-62c135851bfb.PNG)

After.PNG
![After](https://user-images.githubusercontent.com/12494403/72915189-32573a00-3d40-11ea-97d7-9bcfd149b48f.PNG)

