### PR TITLE
ci: reduce resource classes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,7 @@ executors:
     docker:
       - image: circleci/node:<< parameters.nodeversion >>
     working_directory: ~/ng
+    resource_class: small
 
   test-executor:
     parameters:
@@ -55,7 +56,7 @@ executors:
     working_directory: ~/ng
     environment:
       NPM_CONFIG_PREFIX: ~/.npm-global
-    resource_class: xlarge
+    resource_class: large
 
   windows-executor:
     # Same as https://circleci.com/orbs/registry/orb/circleci/windows, but named.
@@ -114,6 +115,7 @@ commands:
 jobs:
   setup:
     executor: action-executor
+    resource_class: medium
     steps:
       - checkout
       - run:
@@ -174,7 +176,6 @@ jobs:
         type: string
         default: ""
     executor: test-executor
-    resource_class: large
     parallelism: 4
     steps:
       - custom_attach_workspace
@@ -190,7 +191,7 @@ jobs:
         type: boolean
         default: false
     executor: test-executor
-    parallelism: 4
+    parallelism: 6
     steps:
       - custom_attach_workspace
       - run:
@@ -220,6 +221,7 @@ jobs:
       name: test-executor
     environment:
       E2E_BROWSERS: true
+    resource_class: medium
     steps:
       - custom_attach_workspace
       - run:
@@ -258,7 +260,7 @@ jobs:
 
   build-bazel:
     executor: action-executor
-    resource_class: xlarge
+    resource_class: large
     steps:
       - custom_attach_workspace
       - setup_bazel_rbe
@@ -267,6 +269,7 @@ jobs:
 
   snapshot_publish:
     executor: action-executor
+    resource_class: medium
     steps:
       - custom_attach_workspace
       - run:


### PR DESCRIPTION
Estimated credit cost reduction: 40%
Estimated critical path runtime reduction: 8 minutes
Previous critical path: `setup` -> `build` -> `e2e-cli`
New critical path: `setup` -> `build` -> `build-and-setup` -> `test-win`