### PR TITLE
fix(@schematics/angular): add compliance with call-signature lint rule

### DIFF
--- a/packages/schematics/angular/component/files/__name@dasherize@if-flat__/__name@dasherize__.__type@dasherize__.ts.template
+++ b/packages/schematics/angular/component/files/__name@dasherize@if-flat__/__name@dasherize__.__type@dasherize__.ts.template
@@ -17,7 +17,7 @@ export class <%= classify(name) %><%= classify(type) %> implements OnInit {
 
   constructor() { }
 
-  ngOnInit() {
+  ngOnInit(): void {
   }
 
 }

--- a/packages/schematics/angular/e2e/files/src/app.po.ts.template
+++ b/packages/schematics/angular/e2e/files/src/app.po.ts.template
@@ -1,11 +1,11 @@
 import { browser, by, element } from 'protractor';
 
 export class AppPage {
-  navigateTo() {
+  navigateTo(): Promise<any> {
     return browser.get(browser.baseUrl) as Promise<any>;
   }
 
-  getTitleText() {
+  getTitleText(): Promise<string> {
     return element(by.css('<%= rootSelector %> .content span')).getText() as Promise<string>;
   }
 }


### PR DESCRIPTION
Fixes #16754 

Make Angular CLI schematics compliant with `typedef: ["call-signature"]` TSLint rule.