### PR TITLE
fix(@schematics/angular): add compliance with no-any lint rule

### DIFF
--- a/packages/schematics/angular/application/files/src/test.ts.template
+++ b/packages/schematics/angular/application/files/src/test.ts.template
@@ -7,7 +7,12 @@ import {
   platformBrowserDynamicTesting
 } from '@angular/platform-browser-dynamic/testing';
 
-declare const require: any;
+declare const require: {
+  context(path: string, deep?: boolean, filter?: RegExp): {
+    keys(): string[];
+    <T>(id: string): T;
+  };
+};
 
 // First, initialize the Angular testing environment.
 getTestBed().initTestEnvironment(

--- a/packages/schematics/angular/e2e/files/src/app.po.ts.template
+++ b/packages/schematics/angular/e2e/files/src/app.po.ts.template
@@ -1,8 +1,8 @@
 import { browser, by, element } from 'protractor';
 
 export class AppPage {
-  navigateTo(): Promise<any> {
-    return browser.get(browser.baseUrl) as Promise<any>;
+  navigateTo(): Promise<unknown> {
+    return browser.get(browser.baseUrl) as Promise<unknown>;
   }
 
   getTitleText(): Promise<string> {

--- a/packages/schematics/angular/library/files/src/test.ts.template
+++ b/packages/schematics/angular/library/files/src/test.ts.template
@@ -8,7 +8,12 @@ import {
   platformBrowserDynamicTesting
 } from '@angular/platform-browser-dynamic/testing';
 
-declare const require: any;
+declare const require: {
+  context(path: string, deep?: boolean, filter?: RegExp): {
+    keys(): string[];
+    <T>(id: string): T;
+  };
+};
 
 // First, initialize the Angular testing environment.
 getTestBed().initTestEnvironment(

--- a/packages/schematics/angular/pipe/files/__name@dasherize@if-flat__/__name@dasherize__.pipe.ts.template
+++ b/packages/schematics/angular/pipe/files/__name@dasherize@if-flat__/__name@dasherize__.pipe.ts.template
@@ -5,7 +5,7 @@ import { Pipe, PipeTransform } from '@angular/core';
 })
 export class <%= classify(name) %>Pipe implements PipeTransform {
 
-  transform(value: any, ...args: any[]): any {
+  transform(value: unknown, ...args: unknown[]): unknown {
     return null;
   }
 

--- a/packages/schematics/angular/pipe/index_spec.ts
+++ b/packages/schematics/angular/pipe/index_spec.ts
@@ -57,7 +57,7 @@ describe('Pipe Schematic', () => {
     expect(moduleContent).toMatch(/import.*Foo.*from '.\/foo.pipe'/);
     expect(moduleContent).toMatch(/declarations:\s*\[[^\]]+?,\r?\n\s+FooPipe\r?\n/m);
     const fileContent = tree.readContent('/projects/bar/src/app/foo.pipe.ts');
-    expect(fileContent).toContain('transform(value: any, ...args: any[])');
+    expect(fileContent).toContain('transform(value: unknown, ...args: unknown[])');
   });
 
   it('should import into a specified module', async () => {

--- a/tests/angular_devkit/build_angular/hello-world-app-ve/e2e/app.po.ts
+++ b/tests/angular_devkit/build_angular/hello-world-app-ve/e2e/app.po.ts
@@ -8,11 +8,11 @@
 import { browser, by, element } from 'protractor';
 
 export class AppPage {
-  navigateTo() {
-    return browser.get(browser.baseUrl);
+  navigateTo(): Promise<unknown> {
+    return browser.get(browser.baseUrl) as Promise<unknown>;
   }
 
-  getTitleText() {
-    return element(by.css('app-root h1')).getText();
+  getTitleText(): Promise<string> {
+    return element(by.css('app-root h1')).getText() as Promise<string>;
   }
 }

--- a/tests/angular_devkit/build_angular/hello-world-app-ve/src/test.ts
+++ b/tests/angular_devkit/build_angular/hello-world-app-ve/src/test.ts
@@ -14,7 +14,12 @@ import {
   platformBrowserDynamicTesting
 } from '@angular/platform-browser-dynamic/testing';
 
-declare const require: any;
+declare const require: {
+  context(path: string, deep?: boolean, filter?: RegExp): {
+    keys(): string[];
+    <T>(id: string): T;
+  };
+};
 
 // First, initialize the Angular testing environment.
 getTestBed().initTestEnvironment(

--- a/tests/angular_devkit/build_angular/hello-world-app/e2e/app.po.ts
+++ b/tests/angular_devkit/build_angular/hello-world-app/e2e/app.po.ts
@@ -8,11 +8,11 @@
 import { browser, by, element } from 'protractor';
 
 export class AppPage {
-  navigateTo() {
-    return browser.get(browser.baseUrl);
+  navigateTo(): Promise<unknown> {
+    return browser.get(browser.baseUrl) as Promise<unknown>;
   }
 
-  getTitleText() {
-    return element(by.css('app-root h1')).getText();
+  getTitleText(): Promise<string> {
+    return element(by.css('app-root h1')).getText() as Promise<string>;
   }
 }

--- a/tests/angular_devkit/build_angular/hello-world-app/src/test.ts
+++ b/tests/angular_devkit/build_angular/hello-world-app/src/test.ts
@@ -14,7 +14,12 @@ import {
   platformBrowserDynamicTesting,
 } from '@angular/platform-browser-dynamic/testing';
 
-declare const require: any;
+declare const require: {
+  context(path: string, deep?: boolean, filter?: RegExp): {
+    keys(): string[];
+    <T>(id: string): T;
+  };
+};
 
 // First, initialize the Angular testing environment.
 getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());

--- a/tests/angular_devkit/build_ng_packagr/ng-packaged-ve/projects/lib/src/test.ts
+++ b/tests/angular_devkit/build_ng_packagr/ng-packaged-ve/projects/lib/src/test.ts
@@ -15,7 +15,12 @@ import {
   platformBrowserDynamicTesting
 } from '@angular/platform-browser-dynamic/testing';
 
-declare const require: any;
+declare const require: {
+  context(path: string, deep?: boolean, filter?: RegExp): {
+    keys(): string[];
+    <T>(id: string): T;
+  };
+};
 
 // First, initialize the Angular testing environment.
 getTestBed().initTestEnvironment(

--- a/tests/angular_devkit/build_ng_packagr/ng-packaged/projects/lib/src/test.ts
+++ b/tests/angular_devkit/build_ng_packagr/ng-packaged/projects/lib/src/test.ts
@@ -15,7 +15,12 @@ import {
   platformBrowserDynamicTesting
 } from '@angular/platform-browser-dynamic/testing';
 
-declare const require: any;
+declare const require: {
+  context(path: string, deep?: boolean, filter?: RegExp): {
+    keys(): string[];
+    <T>(id: string): T;
+  };
+};
 
 // First, initialize the Angular testing environment.
 getTestBed().initTestEnvironment(


### PR DESCRIPTION
Fixes #16770

Make Angular CLI schematics compliant with `no-any` TSLint rule.

For `test.ts` files, as they are just configuration files for unit tests, not real code, the rule is just disabled.