### PR TITLE
fix(@angular-devkit/build-angular): pass filename to `parseSync`

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/process-bundle.ts
+++ b/packages/angular_devkit/build_angular/src/utils/process-bundle.ts
@@ -614,6 +614,7 @@ function findLocalizePositions(
     ast = parseSync(options.code, {
       babelrc: false,
       sourceType: 'script',
+      filename: options.filename,
     });
   } catch (error) {
     if (error.message) {


### PR DESCRIPTION
The latest version of Babel (e.g. 7.8.3) requires a filename
to be passed to `parseSync()`.

Fixes #16781