### PR TITLE
fix(@angular-devkit/build-angular): ensure babel configurations are isolated

### DIFF
--- a/packages/angular_devkit/build_angular/src/dev-server/index.ts
+++ b/packages/angular_devkit/build_angular/src/dev-server/index.ts
@@ -366,6 +366,7 @@ async function setupLocalize(
         loader: require.resolve('babel-loader'),
         options: {
           babelrc: false,
+          configFile: false,
           compact: false,
           cacheCompression: false,
           cacheDirectory: findCachePath('babel-loader'),

--- a/packages/angular_devkit/build_angular/src/utils/process-bundle.ts
+++ b/packages/angular_devkit/build_angular/src/utils/process-bundle.ts
@@ -125,6 +125,7 @@ export async function process(options: ProcessBundleOptions): Promise<ProcessBun
       // tslint:disable-next-line: no-any
       inputSourceMap: false as any,
       babelrc: false,
+      configFile: false,
       presets: [[
         require.resolve('@babel/preset-env'),
         {
@@ -613,6 +614,7 @@ function findLocalizePositions(
   try {
     ast = parseSync(options.code, {
       babelrc: false,
+      configFile: false,
       sourceType: 'script',
     });
   } catch (error) {


### PR DESCRIPTION
The `configFile` option needs to be set to false to ensure Babel does not attempt to discover and load any file based configurations.