### PR TITLE
fix(@schematics/angular): update protractor version for new projects

### DIFF
--- a/packages/schematics/angular/workspace/files/package.json.template
+++ b/packages/schematics/angular/workspace/files/package.json.template
@@ -38,7 +38,7 @@
     "karma-coverage-istanbul-reporter": "~2.1.0",
     "karma-jasmine": "~3.0.1",
     "karma-jasmine-html-reporter": "^1.4.2",
-    "protractor": "~5.4.2",<% } %>
+    "protractor": "~5.4.3",<% } %>
     "ts-node": "~8.3.0",
     "tslint": "~5.18.0",
     "typescript": "<%= latestVersions.TypeScript %>"


### PR DESCRIPTION
New projects will now be created with `~5.4.3`