### PR TITLE
fix(@angular-devkit/build-angular): remove unneeded regex polyfills

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/es5-polyfills.js
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/es5-polyfills.js
@@ -91,7 +91,14 @@ import 'core-js/modules/es.parse-float';
 import 'core-js/es/number';
 import 'core-js/es/math';
 import 'core-js/es/date';
-import 'core-js/es/regexp';
+
+import 'core-js/modules/es.regexp.constructor';
+import 'core-js/modules/es.regexp.to-string';
+import 'core-js/modules/es.regexp.flags';
+import 'core-js/modules/es.string.match';
+import 'core-js/modules/es.string.replace';
+import 'core-js/modules/es.string.search';
+import 'core-js/modules/es.string.split';
 
 import 'core-js/modules/es.map';
 import 'core-js/modules/es.weak-map';


### PR DESCRIPTION
This imports the individual regex polyfills allowing control of each element.  The new (core-js 3.6.0) sticky related polyfills are not included as they are not needed and may cause conflicts with some existing third-party libraries.

Related: #16715