### PR TITLE
fix(@ngtools/webpack): don't elide imports for  type references that …

### DIFF
--- a/packages/ngtools/webpack/src/transformers/elide_imports_spec.ts
+++ b/packages/ngtools/webpack/src/transformers/elide_imports_spec.ts
@@ -31,6 +31,14 @@ describe('@ngtools/webpack transformers', () => {
         export const take = () => null;
         export default promise;
       `,
+      'decorator.ts': `
+        export function Decorator(value?: any): any {
+          return function (): any { };
+        }
+      `,
+      'service.ts': `
+        export class Service { }
+      `,
     };
 
     it('should remove unused imports', () => {
@@ -239,7 +247,7 @@ describe('@ngtools/webpack transformers', () => {
 
     it('should only drop default imports when having named and default (3)', () => {
       const input = tags.stripIndent`
-        import promise, { fromPromise } from './const';
+        import promise, { promise as fromPromise } from './const';
         const used = promise;
         const unused = fromPromise;
       `;
@@ -272,5 +280,230 @@ describe('@ngtools/webpack transformers', () => {
       expect(tags.oneLine`${result}`).toEqual(tags.oneLine`${output}`);
     });
 
+    describe('should elide imports decorator type references when emitDecoratorMetadata is false', () => {
+      const extraCompilerOptions: ts.CompilerOptions = {
+        emitDecoratorMetadata: false,
+        experimentalDecorators: true,
+      };
+
+      it('should remove ctor parameter type reference', () => {
+        const input = tags.stripIndent`
+          import { Decorator } from './decorator';
+          import { Service } from './service';
+
+          @Decorator()
+          export class Foo {
+            constructor(param: Service) {
+            }
+          }
+
+          ${dummyNode}
+        `;
+
+        const output = tags.stripIndent`
+          import { __decorate } from "tslib";
+          import { Decorator } from './decorator';
+
+          let Foo = class Foo { constructor(param) { } };
+          Foo = __decorate([ Decorator() ], Foo);
+          export { Foo };
+        `;
+
+        const { program, compilerHost } = createTypescriptContext(input, additionalFiles, true, extraCompilerOptions);
+        const result = transformTypescript(undefined, [transformer(program)], program, compilerHost);
+
+        expect(tags.oneLine`${result}`).toEqual(tags.oneLine`${output}`);
+      });
+    });
+
+    describe('should not elide imports decorator type references when emitDecoratorMetadata is true', () => {
+      const extraCompilerOptions: ts.CompilerOptions = {
+         emitDecoratorMetadata: true,
+         experimentalDecorators: true,
+      };
+
+      it('should not remove ctor parameter type reference', () => {
+        const input = tags.stripIndent`
+          import { Decorator } from './decorator';
+          import { Service } from './service';
+
+          @Decorator()
+          export class Foo {
+            constructor(param: Service) {
+            }
+          }
+
+          ${dummyNode}
+        `;
+
+        const output = tags.stripIndent`
+          import { __decorate, __metadata } from "tslib";
+          import { Decorator } from './decorator';
+          import { Service } from './service';
+
+          let Foo = class Foo { constructor(param) { } };
+          Foo = __decorate([ Decorator(), __metadata("design:paramtypes", [Service]) ], Foo);
+          export { Foo };
+        `;
+
+        const { program, compilerHost } = createTypescriptContext(input, additionalFiles, true, extraCompilerOptions);
+        const result = transformTypescript(undefined, [transformer(program)], program, compilerHost);
+
+        expect(tags.oneLine`${result}`).toEqual(tags.oneLine`${output}`);
+      });
+
+      it('should not remove property declaration parameter type reference', () => {
+        const input = tags.stripIndent`
+          import { Decorator } from './decorator';
+          import { Service } from './service';
+
+          export class Foo {
+            @Decorator() foo: Service;
+          }
+
+          ${dummyNode}
+        `;
+
+        const output = tags.stripIndent`
+          import { __decorate, __metadata } from "tslib";
+          import { Decorator } from './decorator';
+
+          import { Service } from './service';
+
+          export class Foo { }
+          __decorate([ Decorator(), __metadata("design:type", Service) ], Foo.prototype, "foo", void 0);
+        `;
+
+        const { program, compilerHost } = createTypescriptContext(input, additionalFiles, true, extraCompilerOptions);
+        const result = transformTypescript(undefined, [transformer(program)], program, compilerHost);
+
+        expect(tags.oneLine`${result}`).toEqual(tags.oneLine`${output}`);
+      });
+
+      it('should not remove set accessor parameter type reference', () => {
+        const input = tags.stripIndent`
+          import { Decorator } from './decorator';
+          import { Service } from './service';
+
+          export class Foo {
+            _foo: Service;
+
+            @Decorator()
+            set name(f: Service) {
+                this._foo = f;
+            }
+          }
+
+          ${dummyNode}
+        `;
+
+        const output = tags.stripIndent`
+          import { __decorate, __metadata } from "tslib";
+          import { Decorator } from './decorator';
+          import { Service } from './service';
+
+          export class Foo { set name(f) { this._foo = f; } }
+          __decorate([ Decorator(), __metadata("design:type", Service), __metadata("design:paramtypes", [Service]) ], Foo.prototype, "name", null);
+        `;
+
+        const { program, compilerHost } = createTypescriptContext(input, additionalFiles, true, extraCompilerOptions);
+        const result = transformTypescript(undefined, [transformer(program)], program, compilerHost);
+
+        expect(tags.oneLine`${result}`).toEqual(tags.oneLine`${output}`);
+      });
+
+      it('should not remove get accessor parameter type reference', () => {
+        const input = tags.stripIndent`
+          import { Decorator } from './decorator';
+          import { Service } from './service';
+
+          export class Foo {
+            _foo: Service;
+
+            @Decorator()
+            get name(): Service {
+              return this._foo;
+            }
+          }
+
+          ${dummyNode}
+        `;
+
+        const output = tags.stripIndent`
+          import { __decorate, __metadata } from "tslib";
+          import { Decorator } from './decorator';
+          import { Service } from './service';
+
+          export class Foo { get name() { return this._foo; } }
+         __decorate([ Decorator(), __metadata("design:type", Service), __metadata("design:paramtypes", []) ], Foo.prototype, "name", null);
+        `;
+
+        const { program, compilerHost } = createTypescriptContext(input, additionalFiles, true, extraCompilerOptions);
+        const result = transformTypescript(undefined, [transformer(program)], program, compilerHost);
+
+        expect(tags.oneLine`${result}`).toEqual(tags.oneLine`${output}`);
+      });
+
+      it('should not remove decorated method return type reference', () => {
+        const input = tags.stripIndent`
+          import { Decorator } from './decorator';
+          import { Service } from './service';
+
+          export class Foo {
+            @Decorator()
+            name(): Service {
+              return undefined;
+            }
+          }
+
+          ${dummyNode}
+        `;
+
+        const output = tags.stripIndent`
+          import { __decorate, __metadata } from "tslib";
+          import { Decorator } from './decorator';
+          import { Service } from './service';
+
+          export class Foo { name() { return undefined; } }
+          __decorate([ Decorator(), __metadata("design:type", Function),
+          __metadata("design:paramtypes", []), __metadata("design:returntype", Service) ], Foo.prototype, "name", null);
+        `;
+
+        const { program, compilerHost } = createTypescriptContext(input, additionalFiles, true, extraCompilerOptions);
+        const result = transformTypescript(undefined, [transformer(program)], program, compilerHost);
+
+        expect(tags.oneLine`${result}`).toEqual(tags.oneLine`${output}`);
+      });
+
+      it('should not remove decorated method parameter type reference', () => {
+        const input = tags.stripIndent`
+          import { Decorator } from './decorator';
+          import { Service } from './service';
+
+          export class Foo {
+            @Decorator()
+            name(f: Service) {
+            }
+          }
+
+          ${dummyNode}
+        `;
+
+        const output = tags.stripIndent`
+          import { __decorate, __metadata } from "tslib";
+
+          import { Decorator } from './decorator';
+          export class Foo { name(f) { } }
+
+          __decorate([ Decorator(), __metadata("design:type", Function), __metadata("design:paramtypes", [Service]),
+          __metadata("design:returntype", void 0) ], Foo.prototype, "name", null);
+        `;
+
+        const { program, compilerHost } = createTypescriptContext(input, additionalFiles, true, extraCompilerOptions);
+        const result = transformTypescript(undefined, [transformer(program)], program, compilerHost);
+
+        expect(tags.oneLine`${result}`).toEqual(tags.oneLine`${output}`);
+      });
+    });
   });
 });

--- a/packages/ngtools/webpack/src/transformers/make_transform.ts
+++ b/packages/ngtools/webpack/src/transformers/make_transform.ts
@@ -38,7 +38,7 @@ export function makeTransform(
       // replace_resources), but may not be true for new transforms.
       if (getTypeChecker && removeOps.length + replaceOps.length > 0) {
         const removedNodes = removeOps.concat(replaceOps).map(op => op.target);
-        removeOps.push(...elideImports(sf, removedNodes, getTypeChecker));
+        removeOps.push(...elideImports(sf, removedNodes, getTypeChecker, context.getCompilerOptions()));
       }
 
       const visitor: ts.Visitor = node => {

--- a/packages/ngtools/webpack/src/transformers/remove_decorators_spec.ts
+++ b/packages/ngtools/webpack/src/transformers/remove_decorators_spec.ts
@@ -11,7 +11,7 @@ import { createTypescriptContext, transformTypescript } from './ast_helpers';
 import { removeDecorators } from './remove_decorators';
 
 describe('@ngtools/webpack transformers', () => {
-  describe('decorator_remover', () => {
+  describe('remove_decorators', () => {
     it('should remove Angular decorators', () => {
       const input = tags.stripIndent`
         import { Component } from '@angular/core';

--- a/packages/ngtools/webpack/src/transformers/replace_resources_spec.ts
+++ b/packages/ngtools/webpack/src/transformers/replace_resources_spec.ts
@@ -15,8 +15,7 @@ function transform(
   directTemplateLoading = true,
   importHelpers = true,
 ) {
-  const { program, compilerHost } =
-    createTypescriptContext(input, undefined, undefined, importHelpers);
+  const { program, compilerHost } = createTypescriptContext(input, undefined, undefined, { importHelpers });
   const getTypeChecker = () => program.getTypeChecker();
   const transformer = replaceResources(
     () => shouldTransform, getTypeChecker, directTemplateLoading);


### PR DESCRIPTION
…are needed for decorator metadata

When `emitDecoratorMetadata` is set to true we don't elide type references imports that are used for decorated nodes.

Fixes #16808

Jira: TOOL-1308