### PR TITLE
refactor(@angular-devkit/build-angular): remove redundant ES2015 string polyfills

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/es5-polyfills.js
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/es5-polyfills.js
@@ -95,10 +95,6 @@ import 'core-js/es/date';
 import 'core-js/modules/es.regexp.constructor';
 import 'core-js/modules/es.regexp.to-string';
 import 'core-js/modules/es.regexp.flags';
-import 'core-js/modules/es.string.match';
-import 'core-js/modules/es.string.replace';
-import 'core-js/modules/es.string.search';
-import 'core-js/modules/es.string.split';
 
 import 'core-js/modules/es.map';
 import 'core-js/modules/es.weak-map';


### PR DESCRIPTION
Several of the string polyfills were mentioned twice in the polyfill imports.
This had no runtime impact since the imports were only included in the application once.