### PR TITLE
fix: remove alias for ng doc command

### DIFF
--- a/packages/angular/cli/commands/doc.json
+++ b/packages/angular/cli/commands/doc.json
@@ -4,7 +4,6 @@
   "description": "Opens the official Angular documentation (angular.io) in a browser, and searches for a given keyword.",
   "$longDescription": "",
 
-  "$aliases": [ "d" ],
   "$type": "native",
   "$impl": "./doc-impl#DocCommand",
 


### PR DESCRIPTION
Backport #16368 to 8.x branch

Closes: #16825