### PR TITLE
[LTS] fix(@angular-devkit/build-angular): provide supported browsers to babel

### DIFF
--- a/packages/angular_devkit/build_angular/src/browser/index.ts
+++ b/packages/angular_devkit/build_angular/src/browser/index.ts
@@ -428,6 +428,7 @@ export function buildWebpackBrowser(
                 const runtimeOptions = {
                   ...processRuntimeAction,
                   runtimeData: processResults,
+                  supportedBrowsers: buildBrowserFeatures.supportedBrowsers,
                 };
                 processResults.push(
                   await import('../utils/process-bundle').then(m => m.process(runtimeOptions)),

--- a/packages/angular_devkit/build_angular/src/utils/build-browser-features.ts
+++ b/packages/angular_devkit/build_angular/src/utils/build-browser-features.ts
@@ -17,14 +17,14 @@ export const fullDifferential =
   fullDifferentialEnv.toLowerCase() !== 'false';
 
 export class BuildBrowserFeatures {
-  private readonly _supportedBrowsers: string[];
   private readonly _es6TargetOrLater: boolean;
+  readonly supportedBrowsers: string[];
 
   constructor(
     private projectRoot: string,
     private scriptTarget: ts.ScriptTarget,
   ) {
-    this._supportedBrowsers = browserslist(undefined, { path: this.projectRoot });
+    this.supportedBrowsers = browserslist(undefined, { path: this.projectRoot });
     this._es6TargetOrLater = this.scriptTarget > ts.ScriptTarget.ES5;
   }
 
@@ -59,7 +59,7 @@ export class BuildBrowserFeatures {
       'ios_saf 10.3',
     ];
 
-    return this._supportedBrowsers.some(browser => safariBrowsers.includes(browser));
+    return this.supportedBrowsers.some(browser => safariBrowsers.includes(browser));
   }
 
   /**
@@ -77,7 +77,7 @@ export class BuildBrowserFeatures {
 
     const data = feature(features[featureId]);
 
-    return !this._supportedBrowsers
+    return !this.supportedBrowsers
       .some(browser => {
         const [agentId, version] = browser.split(' ');
 

--- a/packages/angular_devkit/build_angular/src/utils/process-bundle.ts
+++ b/packages/angular_devkit/build_angular/src/utils/process-bundle.ts
@@ -30,6 +30,7 @@ export interface ProcessBundleOptions {
   cacheKeys?: (string | undefined)[];
   integrityAlgorithm?: 'sha256' | 'sha384' | 'sha512';
   runtimeData?: ProcessBundleResult[];
+  supportedBrowsers?: string [] | Record<string, string>;
 }
 
 export interface ProcessBundleResult {
@@ -111,6 +112,8 @@ export async function process(options: ProcessBundleOptions): Promise<ProcessBun
         [
           require.resolve('@babel/preset-env'),
           {
+            // browserslist-compatible query or object of minimum environment versions to support
+            targets: options.supportedBrowsers,
             // modules aren't needed since the bundles use webpack's custom module loading
             modules: false,
             // 'transform-typeof-symbol' generates slower code


### PR DESCRIPTION
By default the browserslist `configPath` will default to `process.cwd()`. This might return incorrect data in a multi app workspace setup.

https://babeljs.io/docs/en/babel-preset-env#configpath

LTS version of https://github.com/angular/angular-cli/pull/16829