### PR TITLE
fix(@angular-devkit/core): Rename to a non-existing dir

### DIFF
--- a/packages/angular_devkit/core/node/host.ts
+++ b/packages/angular_devkit/core/node/host.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import * as fs from 'fs';
+import * as path from 'path';
 import { Observable, concat, from as observableFrom, of, throwError } from 'rxjs';
 import {
   concatMap,
@@ -316,6 +317,10 @@ export class NodeJsSyncHost implements virtualFs.Host<fs.Stats> {
       // TODO: remove this try+catch when issue https://github.com/ReactiveX/rxjs/issues/3740 is
       // fixed.
       try {
+        const toSystemPath = getSystemPath(to);
+        if (!fs.existsSync(path.dirname(toSystemPath))) {
+            fs.mkdirSync(path.dirname(toSystemPath), { recursive: true });
+        }
         fs.renameSync(getSystemPath(from), getSystemPath(to));
         obs.next();
         obs.complete();

--- a/packages/angular_devkit/core/node/host_spec.ts
+++ b/packages/angular_devkit/core/node/host_spec.ts
@@ -108,4 +108,20 @@ describe('NodeJsSyncHost', () => {
       .then(done, done.fail);
   }, 30000);
 
+  linuxOnlyIt('rename to a non-existing dir', done => {
+
+    Promise.resolve()
+      .then(() => fs.mkdirSync(root + '/rename'))
+      .then(() => fs.writeFileSync(root + '/rename/a.txt', 'hello world'))
+      .then(() => {
+        host.rename(normalize('/rename/a.txt'), normalize('/rename/b/c/d/a.txt'));
+        if (fs.existsSync(root + '/rename/b/c/d/a.txt')) {
+          const resContent = host.read(normalize('/rename/b/c/d/a.txt'));
+          const content = virtualFs.fileBufferToString(resContent);
+          expect(content).toEqual('hello world');
+        }
+      })
+      .then(done, done.fail);
+  }, 30000);
+
 });


### PR DESCRIPTION
Schematics: rename to a non-existing dir fails on sync to disk #16484