### PR TITLE
fix(@angular/cli): fix the URL for doc search

### DIFF
--- a/packages/angular/cli/commands/doc-impl.ts
+++ b/packages/angular/cli/commands/doc-impl.ts
@@ -47,7 +47,7 @@ export class DocCommand extends Command<DocCommandSchema> {
     let searchUrl = `https://${domain}/api?query=${options.keyword}`;
 
     if (options.search) {
-      searchUrl = `https://${domain}/?search=${options.keyword}`;
+      searchUrl = `https://${domain}/docs?search=${options.keyword}`;
     }
 
     // We should wrap `open` in a new Promise because `open` is already resolved


### PR DESCRIPTION
In #16846, the URL for docs search was updated to point to the corresponding vX.angular.io website (with an appropriate query for the search). However, on the archive versions of the website (i.e. versions older than the current stable), non-docs pages (including the home page) are redirected to `/docs` (losing the query params).

This commit fixes the URL to include `/docs`, so that it is not redirected (and preserve the query params that will trigger the search).