### PR TITLE
feat(@angular-devkit/build-angular): pass "grep" and "invertGrep"

### DIFF
--- a/packages/angular/cli/lib/config/schema.json
+++ b/packages/angular/cli/lib/config/schema.json
@@ -1646,6 +1646,15 @@
               "type": "string",
               "description": "Dev server target to run tests against."
             },
+            "grep": {
+              "type": "string",
+              "description": "Execute specs whose names match the pattern, which is internally compiled to a RegExp."
+            },
+            "invertGrep": {
+              "type": "boolean",
+              "description": "Invert the selection specified by the 'grep' option.",
+              "default": false
+            },
             "specs": {
               "type": "array",
               "description": "Override specs in the protractor config.",

--- a/packages/angular_devkit/build_angular/src/protractor/index.ts
+++ b/packages/angular_devkit/build_angular/src/protractor/index.ts
@@ -17,12 +17,23 @@ import * as url from 'url';
 import { runModuleAsObservableFork } from '../utils';
 import { Schema as ProtractorBuilderOptions } from './schema';
 
+interface JasmineNodeOpts {
+  jasmineNodeOpts: {
+    grep?: string;
+    invertGrep?: boolean;
+  };
+}
+
 function runProtractor(root: string, options: ProtractorBuilderOptions): Promise<BuilderOutput> {
-  const additionalProtractorConfig: Partial<ProtractorBuilderOptions> = {
+  const additionalProtractorConfig: Partial<ProtractorBuilderOptions> & Partial<JasmineNodeOpts> = {
     elementExplorer: options.elementExplorer,
     baseUrl: options.baseUrl,
     specs: options.specs && options.specs.length ? options.specs : undefined,
     suite: options.suite,
+    jasmineNodeOpts: {
+      grep: options.grep,
+      invertGrep: options.invertGrep,
+    },
   };
 
   // TODO: Protractor manages process.exit itself, so this target will allways quit the

--- a/packages/angular_devkit/build_angular/src/protractor/schema.json
+++ b/packages/angular_devkit/build_angular/src/protractor/schema.json
@@ -13,6 +13,15 @@
       "description": "Dev server target to run tests against.",
       "pattern": "^([^:\\s]+:[^:\\s]+(:[^\\s]+)?)?$"
     },
+    "grep": {
+      "type": "string",
+      "description": "Execute specs whose names match the pattern, which is internally compiled to a RegExp."
+    },
+    "invertGrep": {
+      "type": "boolean",
+      "description": "Invert the selection specified by the 'grep' option.",
+      "default": false
+    },
     "specs": {
       "type": "array",
       "description": "Override specs in the protractor config.",

--- a/packages/angular_devkit/build_angular/test/protractor/works_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/protractor/works_spec_large.ts
@@ -97,4 +97,37 @@ describe('Protractor Builder', () => {
     await run.stop();
   }, 30000);
 
+  it('supports running tests by pattern', async () => {
+    host.writeMultipleFiles({
+      'e2e/app.e2e-spec.ts': `
+        it('should succeed', () => expect(true).toBeTruthy());
+        it('should fail', () => expect(false).toBeTruthy());
+      `,
+    });
+
+    const overrides = { grep: 'succeed' };
+
+    const run = await architect.scheduleTarget(protractorTargetSpec, overrides);
+
+    await expectAsync(run.result).toBeResolvedTo(jasmine.objectContaining({ success: true }));
+
+    await run.stop();
+  }, 30000);
+
+  it('supports running tests excluding a pattern', async () => {
+    host.writeMultipleFiles({
+      'e2e/app.e2e-spec.ts': `
+        it('should succeed', () => expect(true).toBeTruthy());
+        it('should fail', () => expect(false).toBeTruthy());
+      `,
+    });
+
+    const overrides = { grep: 'fail', invertGrep: true };
+
+    const run = await architect.scheduleTarget(protractorTargetSpec, overrides);
+
+    await expectAsync(run.result).toBeResolvedTo(jasmine.objectContaining({ success: true }));
+
+    await run.stop();
+  }, 30000);
 });


### PR DESCRIPTION
# Problem
Jasmine has a useful "tagging" feature that allows specific suites/specs to be targeted by pattern.
Protractor also exposes this via a `grep` option in both the Protractor CLI and Protractor config, as well as an `invertGrep` option that "inverts" whatever pattern was specified in the `grep` option. However, the Angular Protractor Builder currently does not recognize the `grep` or `invertGrep` options, so in order to take advantage of this useful feature, developers had to find a way around the builder.

# Solution
 I added these two options to the Protractor Builder JSON schema, as well as made sure they got passed to the Protractor runner correctly. I also needed to add these options to the top-level Angular CLI schema to satisfy `angular.json`.

# Notes
1. Because the Protractor config expects these options nested under a `jasmineNodeOpts` object, I had to use an additional interface to the one that is generated by `schema.json`. Open to better ways of doing this.
2. I tried to find a way to test my work in the associated test file, but I am not getting enough information from the `run.result` to make any tests of value. Also tried using a logger, but that didn't have any useful information for what I am working on. Open to suggestions here.
3. Fixes #13020