### PR TITLE
fix(@angular/cli): typo in error message

### DIFF
--- a/packages/angular/cli/bin/ng
+++ b/packages/angular/cli/bin/ng
@@ -17,7 +17,7 @@ try {
 var version = process.versions.node.split('.').map(part => Number(part));
 if (version[0] < 10 || version[0] === 11 || (version[0] === 10 && version[1] < 13)) {
   process.stderr.write(
-    'Node.js version ' + process.verson + ' detected.\n' +
+    'Node.js version ' + process.version + ' detected.\n' +
     'The Angular CLI requires a minimum Node.js version of either v10.13 or v12.0.\n\n' +
     'Please update your Node.js version or visit https://nodejs.org/ for additional instructions.\n',
   );


### PR DESCRIPTION
This change resolves the error in the console if the nodejs version is not supported showing the actual version instead of "undefined".

> Node.js version *undefined* detected.
> The Angular CLI requires a minimum Node.js version of either v10.13 or v12.0.