### PR TITLE
feat(@angular/cli): update command should print error stack in verbose mode

### DIFF
--- a/packages/schematics/update/update/index.ts
+++ b/packages/schematics/update/update/index.ts
@@ -784,7 +784,7 @@ function _addPeerDependencies(
   }
 
   if (error) {
-    throw new SchematicsException('An error occured, see above.');
+    throw new SchematicsException('An error occurred, see above.');
   }
 }
 


### PR DESCRIPTION
Currently, the Angular CLI only prints the erorr message if a migration
fails unexpectedly. This is not helpful because developers running `ng
update`
usually share the error upstream if they run into a bug. Sharing the error
upstream without a stack trace isn't helpful in most of the cases, so there
needs to be a way for developers to retrieve a more verbose error w/ stack trace.

Based on various ng-update issues, developers seem to pass the `--verbose`
flag with the assumption of getting a more _verbose_ error. This change
ensures that this works as expected.

Based on initial discussion over Slack, a better long-term solution
would be to always print the verbose stack trace to a debug/error file.
That way, the update experience is not too verbose by default, but the
intitial errors could be easily shared when an update issue is reported
upstream. This is out of scope for now though because the current goal
is to just provide a way to even retrieve the full error.