### PR TITLE
fix(@angular/cli): print `ng update` errors stack to log file

### DIFF
--- a/packages/angular/cli/lib/cli/index.ts
+++ b/packages/angular/cli/lib/cli/index.ts
@@ -6,11 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import { createConsoleLogger } from '@angular-devkit/core/node';
-import { normalize } from 'path';
 import { format } from 'util';
 import { runCommand } from '../../models/command-runner';
 import { colors, supportsColor } from '../../utilities/color';
 import { getWorkspaceRaw } from '../../utilities/config';
+import { writeErrorToLogFile } from '../../utilities/log-file';
 import { getWorkspaceDetails } from '../../utilities/project';
 
 const debugEnv = process.env['NG_DEBUG'];
@@ -82,12 +82,7 @@ export default async function(options: { testing?: boolean; cliArgs: string[] })
   } catch (err) {
     if (err instanceof Error) {
       try {
-        const fs = await import('fs');
-        const os = await import('os');
-        const tempDirectory = fs.mkdtempSync(fs.realpathSync(os.tmpdir()) + '/' + 'ng-');
-        const logPath = normalize(tempDirectory + '/angular-errors.log');
-        fs.appendFileSync(logPath, '[error] ' + (err.stack || err));
-
+        const logPath = writeErrorToLogFile(err);
         logger.fatal(
           `An unhandled exception occurred: ${err.message}\n` +
             `See "${logPath}" for further details.`,

--- a/packages/angular/cli/utilities/log-file.ts
+++ b/packages/angular/cli/utilities/log-file.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { appendFileSync, mkdtempSync, realpathSync } from 'fs';
+import { tmpdir } from 'os';
+import { normalize } from 'path';
+
+let logPath: string | undefined;
+
+/**
+ * Writes an Error to a temporary log file.
+ * If this method is called multiple times from the same process the same log file will be used.
+ * @returns The path of the generated log file.
+ */
+export function writeErrorToLogFile(error: Error): string {
+  if (!logPath) {
+    const tempDirectory = mkdtempSync(realpathSync(tmpdir()) + '/ng-');
+    logPath = normalize(tempDirectory + '/angular-errors.log');
+  }
+
+  appendFileSync(logPath, '[error] ' + (error.stack || error) + '\n\n');
+
+  return logPath;
+}


### PR DESCRIPTION
When an error occurs during `ng update` we currently discard the stack trace which in some cases made it hard to identify the cause of the error.

Now, we print the stack trace to a log file similarly to unhandled exceptions.

Example of CMD output;
```cmd
** Executing migrations of package '@angular/core' **

> Static flag migration.
  Removes the `static` flag from dynamic queries.
  As of Angular 9, the "static" flag defaults to false and is no longer required for your view and content queries.
  Read more about this here: https://v9.angular.io/guide/migration-dynamic-flag
× Migration failed: x
  See "C:\Users\alag\AppData\Local\Temp\ng-NgmC1G\angular-errors.log" for further details.
```

Example of log file contents:
```txt
[error] Error: x
    at UpdateCommand.executeSchematic (C:\git\angular-cli\test\node_modules\@angular\cli\commands\update-impl.js:98:19)
    at UpdateCommand.executePackageMigrations (C:\git\angular-cli\test\node_modules\@angular\cli\commands\update-impl.js:167:39)
    at UpdateCommand.executeMigrations (C:\git\angular-cli\test\node_modules\@angular\cli\commands\update-impl.js:161:21)
    at UpdateCommand.run (C:\git\angular-cli\test\node_modules\@angular\cli\commands\update-impl.js:394:38)
    at async UpdateCommand.validateAndRun (C:\git\angular-cli\test\node_modules\@angular\cli\models\command.js:134:28)
    at async Object.runCommand (C:\git\angular-cli\test\node_modules\@angular\cli\models\command-runner.js:201:24)
    at async default_1 (C:\git\angular-cli\test\node_modules\@angular\cli\lib\cli\index.js:62:31)
```

//cc @devversion 