### PR TITLE
fix(@angular/cli): set inlineTemplate and inlineStyle for minimal projects

### DIFF
--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -151,14 +151,15 @@ function addAppToWorkspaceFile(options: ApplicationOptions, appDir: string): Rul
 
   const schematics: JsonObject = {};
 
-  if (options.inlineTemplate === true
-    || options.inlineStyle === true
+  if (options.inlineTemplate
+    || options.inlineStyle
+    || options.minimal
     || options.style !== Style.Css) {
     const componentSchematicsOptions: JsonObject = {};
-    if (options.inlineTemplate === true) {
+    if (options.inlineTemplate || options.minimal) {
       componentSchematicsOptions.inlineTemplate = true;
     }
-    if (options.inlineStyle === true) {
+    if (options.inlineStyle || options.minimal) {
       componentSchematicsOptions.inlineStyle = true;
     }
     if (options.style && options.style !== Style.Css) {

--- a/packages/schematics/angular/application/index_spec.ts
+++ b/packages/schematics/angular/application/index_spec.ts
@@ -184,6 +184,19 @@ describe('Application Schematic', () => {
     expect(architect.e2e).not.toBeDefined();
   });
 
+  it('minimal=true should configure the schematics options for components', async () => {
+    const options = { ...defaultOptions, minimal: true };
+    const tree = await schematicRunner.runSchematicAsync('application', options, workspaceTree)
+      .toPromise();
+    const config = JSON.parse(tree.readContent('/angular.json'));
+    const schematics = config.projects.foo.schematics;
+    expect(schematics['@schematics/angular:component']).toEqual({
+      inlineTemplate: true,
+      inlineStyle: true,
+      skipTests: true,
+    });
+  });
+
   it('should create correct files when using minimal', async () => {
     const options = { ...defaultOptions, minimal: true };
     const tree = await schematicRunner.runSchematicAsync('application', options, workspaceTree)


### PR DESCRIPTION
I noticed that when creating a project with the `minimal` flag like this `npx @angular/cli new my-demo --minimal true` it will create an `app.component.ts` with inline styles and inline templates. However when creating another component with `ng generate component another-component` it will have an external template and external styles.

This pull request tries to fix this inconsistency by setting the `inlineTemplate` and `inlineStyle` options when creating a `minimal` project to make sure all generated components will have inlined styles and templates.

Please let me know if there is anything that needs to be changed.