### PR TITLE
fix(@angular-devkit/build-angular): make parallel a build option

### DIFF
--- a/packages/angular/cli/lib/config/schema.json
+++ b/packages/angular/cli/lib/config/schema.json
@@ -975,6 +975,19 @@
                 "anonymous",
                 "use-credentials"
               ]
+            },
+            "parallel": {
+              "description": "Define how many parallel node threads will run simultaneous",
+              "default": true,
+              "oneOf": [
+                {
+                  "type": "integer",
+                  "minimum": 1
+                },
+                {
+                  "type": "boolean"
+                }
+              ]
             }
           },
           "additionalProperties": false,

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/build-options.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/build-options.ts
@@ -89,6 +89,7 @@ export interface BuildOptions {
   esVersionInFileName?: boolean;
 
   experimentalRollupPass?: boolean;
+  parallel?: boolean|number;
 }
 
 export interface WebpackTestOptions extends BuildOptions {

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
@@ -12,7 +12,6 @@ import {
 import { tags } from '@angular-devkit/core';
 import * as CopyWebpackPlugin from 'copy-webpack-plugin';
 import { existsSync } from 'fs';
-import { cpus } from 'os';
 import * as path from 'path';
 import { RollupOptions } from 'rollup';
 import { ScriptTarget } from 'typescript';
@@ -29,7 +28,7 @@ import {
 } from 'webpack';
 import { RawSource } from 'webpack-sources';
 import { AssetPatternClass, ExtraEntryPoint } from '../../../browser/schema';
-import { BuildBrowserFeatures } from '../../../utils';
+import {BuildBrowserFeatures, maxWorkers} from '../../../utils';
 import { findCachePath } from '../../../utils/cache-path';
 import {
   allowMangle,
@@ -432,7 +431,10 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
     // Some environments, like CircleCI, report a large number of CPUs but trying to use them
     // Will cause `Error: Call retries were exceeded` errors.
     // https://github.com/webpack-contrib/terser-webpack-plugin/issues/143
-    const maxCpus = Math.min(cpus().length, 7);
+    let maxCpus: number | boolean = maxWorkers;
+    if (buildOptions.parallel !== undefined) {
+      maxCpus = buildOptions.parallel;
+    }
 
     extraMinimizers.push(
       new TerserPlugin({

--- a/packages/angular_devkit/build_angular/src/browser/index.ts
+++ b/packages/angular_devkit/build_angular/src/browser/index.ts
@@ -454,7 +454,7 @@ export function buildWebpackBrowser(
               const executor = new BundleActionExecutor(
                 { cachePath: cacheDownlevelPath, i18n },
                 options.subresourceIntegrity ? 'sha384' : undefined,
-                isNaN(options.parallel) ? undefined : Number(options.parallel)
+                options.parallel && !isNaN(options.parallel) ? Number(options.parallel) : undefined
               );
 
               // Execute the bundle processing actions

--- a/packages/angular_devkit/build_angular/src/browser/index.ts
+++ b/packages/angular_devkit/build_angular/src/browser/index.ts
@@ -72,6 +72,7 @@ import {
   getIndexOutputFile,
 } from '../utils/webpack-browser-config';
 import { Schema as BrowserBuilderSchema } from './schema';
+import {formatNumber} from "@angular/common";
 
 const cacheDownlevelPath = cachingDisabled ? undefined : findCachePath('angular-build-dl');
 
@@ -453,6 +454,7 @@ export function buildWebpackBrowser(
               const executor = new BundleActionExecutor(
                 { cachePath: cacheDownlevelPath, i18n },
                 options.subresourceIntegrity ? 'sha384' : undefined,
+                isNaN(options.parallel) ? undefined : Number(options.parallel)
               );
 
               // Execute the bundle processing actions

--- a/packages/angular_devkit/build_angular/src/browser/schema.json
+++ b/packages/angular_devkit/build_angular/src/browser/schema.json
@@ -376,6 +376,19 @@
         "use-credentials"
       ]
     },
+    "parallel": {
+      "description": "Define how many parallel node threads will run simultaneous",
+      "default": true,
+      "oneOf": [
+        {
+          "type": "integer",
+          "minimum": 1
+        },
+        {
+          "type": "boolean"
+        }
+      ]
+    },
     "experimentalRollupPass": {
       "type": "boolean",
       "description": "Concatenate modules with Rollup before bundling them with Webpack.",

--- a/packages/angular_devkit/build_angular/src/utils/action-executor.ts
+++ b/packages/angular_devkit/build_angular/src/utils/action-executor.ts
@@ -12,6 +12,7 @@ import * as v8 from 'v8';
 import { BundleActionCache } from './action-cache';
 import { I18nOptions } from './i18n-options';
 import { InlineOptions, ProcessBundleOptions, ProcessBundleResult } from './process-bundle';
+import { maxWorkers } from './workers';
 
 const hasThreadSupport = (() => {
   try {
@@ -42,6 +43,7 @@ export class BundleActionExecutor {
   constructor(
     private workerOptions: { cachePath?: string; i18n: I18nOptions },
     integrityAlgorithm?: string,
+    private numWorkers?: number,
     private readonly sizeThreshold = 32 * 1024,
   ) {
     if (workerOptions.cachePath) {
@@ -62,6 +64,7 @@ export class BundleActionExecutor {
     return (this.largeWorker = new JestWorker(workerFile, {
       exposedMethods: ['process', 'inlineLocales'],
       setupArgs: [[...serialize(this.workerOptions)]],
+      numWorkers: this.numWorkers ? this.numWorkers : maxWorkers,
     }));
   }
 

--- a/packages/angular_devkit/build_angular/src/utils/index.ts
+++ b/packages/angular_devkit/build_angular/src/utils/index.ts
@@ -15,3 +15,4 @@ export * from './normalize-asset-patterns';
 export * from './normalize-source-maps';
 export * from './normalize-optimization';
 export * from './normalize-builder-schema';
+export * from './workers';

--- a/packages/angular_devkit/build_angular/src/utils/workers.ts
+++ b/packages/angular_devkit/build_angular/src/utils/workers.ts
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { cpus } from 'os';
+/**
+ * Use CPU count -1 with limit to 7 for workers not to clog the system.
+ * Some environments, like CircleCI which use Docker report a number of CPUs by the host and not the count of available.
+ * This cause `Error: Call retries were exceeded` errors when trying to use them.
+ *
+ * See:
+ *
+ * https://github.com/nodejs/node/issues/28762
+ *
+ * https://github.com/webpack-contrib/terser-webpack-plugin/issues/143
+ *
+ * https://github.com/angular/angular-cli/issues/16860#issuecomment-588828079
+ *
+ */
+export const maxWorkers = Math.min(cpus().length, 7) || 1;


### PR DESCRIPTION
As suggested in https://github.com/angular/angular-cli/issues/16860#issuecomment-588244896 I've started a change to make parallel an option to be able to configure Terser to run in containers and CircleCi.