### PR TITLE
fix(@angular-devkit/build-angular): limit the amount of CPUs used by workers

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/action-executor.ts
+++ b/packages/angular_devkit/build_angular/src/utils/action-executor.ts
@@ -12,6 +12,7 @@ import * as v8 from 'v8';
 import { BundleActionCache } from './action-cache';
 import { I18nOptions } from './i18n-options';
 import { InlineOptions, ProcessBundleOptions, ProcessBundleResult } from './process-bundle';
+import { maxWorkers } from './workers';
 
 const hasThreadSupport = (() => {
   try {
@@ -62,6 +63,7 @@ export class BundleActionExecutor {
     return (this.largeWorker = new JestWorker(workerFile, {
       exposedMethods: ['process', 'inlineLocales'],
       setupArgs: [[...serialize(this.workerOptions)]],
+      numWorkers: maxWorkers,
     }));
   }
 

--- a/packages/angular_devkit/build_angular/src/utils/index.ts
+++ b/packages/angular_devkit/build_angular/src/utils/index.ts
@@ -16,3 +16,4 @@ export * from './normalize-source-maps';
 export * from './normalize-optimization';
 export * from './normalize-builder-schema';
 export * from './url';
+export * from './workers';

--- a/packages/angular_devkit/build_angular/src/utils/workers.ts
+++ b/packages/angular_devkit/build_angular/src/utils/workers.ts
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { cpus } from 'os';
+/**
+ * Use CPU count -1 with limit to 7 for workers not to clog the system.
+ * Some environments, like CircleCI which use Docker report a number of CPUs by the host and not the count of available.
+ * This cause `Error: Call retries were exceeded` errors when trying to use them.
+ *
+ * See:
+ *
+ * https://github.com/nodejs/node/issues/28762
+ *
+ * https://github.com/webpack-contrib/terser-webpack-plugin/issues/143
+ *
+ * https://github.com/angular/angular-cli/issues/16860#issuecomment-588828079
+ *
+ */
+export const maxWorkers = Math.max(Math.min(cpus().length, 8) - 1, 1);


### PR DESCRIPTION


See: https://github.com/angular/angular-cli/issues/16860#issuecomment-588828079