### PR TITLE
refactor(@angular/cli): Update error message when multiple NgModules to auto add a component to are found.

### DIFF
--- a/packages/schematics/angular/utility/find-module.ts
+++ b/packages/schematics/angular/utility/find-module.ts
@@ -100,8 +100,9 @@ export function findModule(host: Tree, generateDir: string,
     if (filteredMatches.length == 1) {
       return join(dir.path, filteredMatches[0]);
     } else if (filteredMatches.length > 1) {
-      throw new Error('More than one module matches. Use skip-import option to skip importing '
-        + 'the component into the closest module.');
+      throw new Error('More than one module matches. Use --module flag to explicitly '
+        + 'specify which NgModule to import the component into or use skip-import option '
+        + 'to skip importing the component into the closest module.');
     }
 
     dir = dir.parent;


### PR DESCRIPTION

The prior message makes it sound like the only option is to skip the auto import. I've just updated it to let people know that there is another way to get the auto module import goodness.

Example of the new message in a dummy repository:
![example_message](https://user-images.githubusercontent.com/1403638/75046238-beb96180-5492-11ea-8979-bbe71998912a.png)
