### PR TITLE
fix(@angular/cli): directly remove ansi color codes when no color support

### DIFF
--- a/packages/angular/cli/lib/cli/index.ts
+++ b/packages/angular/cli/lib/cli/index.ts
@@ -8,7 +8,7 @@
 import { createConsoleLogger } from '@angular-devkit/core/node';
 import { format } from 'util';
 import { runCommand } from '../../models/command-runner';
-import { colors, supportsColor } from '../../utilities/color';
+import { colors, removeColor, supportsColor } from '../../utilities/color';
 import { getWorkspaceRaw } from '../../utilities/config';
 import { writeErrorToLogFile } from '../../utilities/log-file';
 import { getWorkspaceDetails } from '../../utilities/project';
@@ -34,11 +34,11 @@ export default async function(options: { testing?: boolean; cliArgs: string[] })
   }
 
   const logger = createConsoleLogger(isDebug, process.stdout, process.stderr, {
-    info: s => (supportsColor ? s : colors.unstyle(s)),
-    debug: s => (supportsColor ? s : colors.unstyle(s)),
-    warn: s => (supportsColor ? colors.bold.yellow(s) : colors.unstyle(s)),
-    error: s => (supportsColor ? colors.bold.red(s) : colors.unstyle(s)),
-    fatal: s => (supportsColor ? colors.bold.red(s) : colors.unstyle(s)),
+    info: s => (supportsColor ? s : removeColor(s)),
+    debug: s => (supportsColor ? s : removeColor(s)),
+    warn: s => (supportsColor ? colors.bold.yellow(s) : removeColor(s)),
+    error: s => (supportsColor ? colors.bold.red(s) : removeColor(s)),
+    fatal: s => (supportsColor ? colors.bold.red(s) : removeColor(s)),
   });
 
   // Redirect console to logger

--- a/packages/angular/cli/utilities/color.ts
+++ b/packages/angular/cli/utilities/color.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import * as colors from 'ansi-colors';
+import * as ansiColors from 'ansi-colors';
 import { WriteStream } from 'tty';
 
 // Typings do not contain the function call (added in Node.js v9.9.0)
@@ -13,6 +13,12 @@ export const supportsColor =
   process.stdout instanceof WriteStream &&
   ((process.stdout as unknown) as { getColorDepth(): number }).getColorDepth() > 1;
 
-(colors as { enabled: boolean }).enabled = supportsColor;
+export function removeColor(text: string): string {
+  return text.replace(new RegExp(ansiColors.ansiRegex), '');
+}
+
+// tslint:disable-next-line: no-any
+const colors = (ansiColors as any).create() as typeof ansiColors;
+colors.enabled = supportsColor;
 
 export { colors };


### PR DESCRIPTION
Third party libraries can attempt to write color codes to the output even though the CLI has already determined that color should not be used.  The previously implemented color removal code is no longer functional since the update of ansi-colors to 4.1.0.  While this appears to be a defect in the aforementioned package, the new CLI removal method not only bypasses the defect but also unneeded execution logic that the CLI does not need in this case.

Fixes: #17053