### PR TITLE
fix(@angular/pwa): use relative paths in webmanifest

### DIFF
--- a/packages/angular/pwa/pwa/files/root/manifest.webmanifest
+++ b/packages/angular/pwa/pwa/files/root/manifest.webmanifest
@@ -4,8 +4,8 @@
   "theme_color": "#1976d2",
   "background_color": "#fafafa",
   "display": "standalone",
-  "scope": "/",
-  "start_url": "/",
+  "scope": "./",
+  "start_url": "./",
   "icons": [
     {
       "src": "assets/icons/icon-72x72.png",


### PR DESCRIPTION
Use relative paths instead of absolute paths in `manifest.webmanifest`, so PWA (including the service worker) can work with apps with `base-href` different from just `/`. It's especially important since Angular CLI v9 as the new `--localize` option uses `base-href` values different from just `/`. 

Fixes #16922 
Fixes #15092