### PR TITLE
fix(@ngtools/webpack): don't elide decorated method parameter type reference

### DIFF
--- a/packages/ngtools/webpack/src/transformers/elide_imports.ts
+++ b/packages/ngtools/webpack/src/transformers/elide_imports.ts
@@ -78,11 +78,9 @@ export function elideImports(
             (ts.isConstructorDeclaration(parent.parent) && !!parent.parent.parent.decorators?.length));
           break;
       }
+
       if (isTypeReferenceForDecoratoredNode) {
-        symbol = typeChecker.getSymbolAtLocation(node);
-      } else {
-        // If type reference is not for Decorator skip and marked as unused.
-        return;
+        symbol = typeChecker.getSymbolAtLocation(node.typeName);
       }
     } else {
       switch (node.kind) {

--- a/packages/ngtools/webpack/src/transformers/elide_imports_spec.ts
+++ b/packages/ngtools/webpack/src/transformers/elide_imports_spec.ts
@@ -281,6 +281,27 @@ describe('@ngtools/webpack transformers', () => {
       expect(tags.oneLine`${result}`).toEqual(tags.oneLine`${output}`);
     });
 
+    it(`should remove import for 'ExpressionWithTypeArguments' implements token`, () => {
+      const input = tags.stripIndent`
+        import { Bar, Buz, Unused } from './bar';
+
+        export class Foo extends Bar implements Buz { }
+
+        ${dummyNode}
+      `;
+
+      const output = tags.stripIndent`
+        import { Bar } from './bar';
+
+        export class Foo extends Bar { }
+      `;
+
+      const { program, compilerHost } = createTypescriptContext(input);
+      const result = transformTypescript(undefined, [transformer(program)], program, compilerHost);
+
+      expect(tags.oneLine`${result}`).toEqual(tags.oneLine`${output}`);
+    });
+
     describe('should elide imports decorator type references when emitDecoratorMetadata is false', () => {
       const extraCompilerOptions: ts.CompilerOptions = {
         emitDecoratorMetadata: false,
@@ -315,27 +336,6 @@ describe('@ngtools/webpack transformers', () => {
 
         expect(tags.oneLine`${result}`).toEqual(tags.oneLine`${output}`);
       });
-    });
-
-    it(`should remove import for 'ExpressionWithTypeArguments' implements token`, () => {
-      const input = tags.stripIndent`
-        import { Bar, Buz, Unused } from './bar';
-
-        export class Foo extends Bar implements Buz { }
-
-        ${dummyNode}
-      `;
-
-      const output = tags.stripIndent`
-        import { Bar } from './bar';
-
-        export class Foo extends Bar { }
-      `;
-
-      const { program, compilerHost } = createTypescriptContext(input);
-      const result = transformTypescript(undefined, [transformer(program)], program, compilerHost);
-
-      expect(tags.oneLine`${result}`).toEqual(tags.oneLine`${output}`);
     });
 
     describe('should not elide imports decorator type references when emitDecoratorMetadata is true', () => {
@@ -515,6 +515,8 @@ describe('@ngtools/webpack transformers', () => {
           import { __decorate, __metadata } from "tslib";
 
           import { Decorator } from './decorator';
+          import { Service } from './service';
+
           export class Foo { name(f) { } }
 
           __decorate([ Decorator(), __metadata("design:type", Function), __metadata("design:paramtypes", [Service]),


### PR DESCRIPTION
Fixes #17080
Reference: TOOL-1334