### PR TITLE
fix(@ngtools/webpack): always use VE for deprecated string route discovery

### DIFF
--- a/packages/ngtools/webpack/src/angular_compiler_plugin.ts
+++ b/packages/ngtools/webpack/src/angular_compiler_plugin.ts
@@ -470,7 +470,7 @@ export class AngularCompilerPlugin {
       time('AngularCompilerPlugin._listLazyRoutesFromProgram.createProgram');
       ngProgram = createProgram({
         rootNames: this._rootNames,
-        options: { ...this._compilerOptions, genDir: '', collectAllErrors: true },
+        options: { ...this._compilerOptions, genDir: '', collectAllErrors: true, enableIvy: false },
         host: this._compilerHost,
       });
       timeEnd('AngularCompilerPlugin._listLazyRoutesFromProgram.createProgram');


### PR DESCRIPTION
When in JIT mode during lazy route discovery, the Ivy compiler willl attempt to parse templates which may fail when this plugin is used with webpack loaders that support custom template formats.  The string lazy routes must be discovered before the webpack build starts but the template loading/processing does not occur until the webpack build commences.

Fixes: #17002