### PR TITLE
ci(@angular-devkit/build-angular): add ability to include untested files to coverage result

### DIFF
--- a/packages/angular/cli/README.md
+++ b/packages/angular/cli/README.md
@@ -162,6 +162,7 @@ You can find more details about changes between versions in [the Releases tab on
 
 ```bash
 git clone https://github.com/angular/angular-cli.git
+cd angular-cli
 yarn
 npm run build
 cd dist/@angular/cli

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -94,6 +94,7 @@
     "karma-coverage-istanbul-reporter": "~2.1.0",
     "karma-jasmine": "~3.1.0",
     "karma-jasmine-html-reporter": "^1.4.0",
+    "karma-sabarivka-reporter": "~3.0.2",
     "popper.js": "^1.14.1",
     "protractor": "~5.4.0",
     "tslib": "~1.11.0",

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/karma.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/karma.ts
@@ -70,10 +70,15 @@ const init: any = (config: any, emitter: any, customFileHandlers: any) => {
   successCb = config.buildWebpack.successCb;
   failureCb = config.buildWebpack.failureCb;
 
-  // When using code-coverage, auto-add coverage-istanbul.
+  // When using code-coverage, auto-add coverage-istanbul & karma-sabarivka-reporter.
   config.reporters = config.reporters || [];
-  if (options.codeCoverage && config.reporters.indexOf('coverage-istanbul') === -1) {
-    config.reporters.push('coverage-istanbul');
+  if (options.codeCoverage) {
+    if (config.reporters.indexOf('coverage-istanbul') === -1) {
+      config.reporters.push('coverage-istanbul');
+    }
+    if (config.reporters.indexOf('sabarivka') === -1 || config.reporters.indexOf('karma-sabarivka-reporter') === -1) {
+      config.reporters.push('karma-sabarivka-reporter');
+    }
   }
 
   // Add a reporter that fixes sourcemap urls.

--- a/packages/schematics/angular/application/files/karma.conf.js.template
+++ b/packages/schematics/angular/application/files/karma.conf.js.template
@@ -10,10 +10,14 @@ module.exports = function (config) {
       require('karma-chrome-launcher'),
       require('karma-jasmine-html-reporter'),
       require('karma-coverage-istanbul-reporter'),
+      require('karma-sabarivka-reporter'),
       require('@angular-devkit/build-angular/plugins/karma')
     ],
     client: {
       clearContext: false // leave Jasmine Spec Runner output visible in browser
+    },
+    coverageReporter: {
+      include: [] // Specify coverage include glob pattern(s)
     },
     coverageIstanbulReporter: {
       dir: require('path').join(__dirname, '<%= relativePathToWorkspaceRoot %>/coverage/<%= appName%>'),

--- a/packages/schematics/angular/library/files/karma.conf.js.template
+++ b/packages/schematics/angular/library/files/karma.conf.js.template
@@ -10,10 +10,14 @@ module.exports = function (config) {
       require('karma-chrome-launcher'),
       require('karma-jasmine-html-reporter'),
       require('karma-coverage-istanbul-reporter'),
+      require('karma-sabarivka-reporter'),
       require('@angular-devkit/build-angular/plugins/karma')
     ],
     client: {
       clearContext: false // leave Jasmine Spec Runner output visible in browser
+    },
+    coverageReporter: {
+      include: [] // Specify coverage include glob pattern(s)
     },
     coverageIstanbulReporter: {
       dir: require('path').join(__dirname, '<%= relativePathToWorkspaceRoot %>/coverage/<%= folderName %>'),

--- a/packages/schematics/angular/workspace/files/package.json.template
+++ b/packages/schematics/angular/workspace/files/package.json.template
@@ -38,6 +38,7 @@
     "karma-coverage-istanbul-reporter": "~2.1.0",
     "karma-jasmine": "~3.0.1",
     "karma-jasmine-html-reporter": "^1.4.2",
+    "karma-sabarivka-reporter": "~3.0.2",
     "protractor": "~5.4.3",<% } %>
     "ts-node": "~8.3.0",
     "tslint": "~5.18.0",

--- a/tests/angular_devkit/build_angular/hello-world-app-ve/karma.conf.js
+++ b/tests/angular_devkit/build_angular/hello-world-app-ve/karma.conf.js
@@ -19,6 +19,7 @@ module.exports = function (config) {
       require('karma-chrome-launcher'),
       require('karma-jasmine-html-reporter'),
       require('karma-coverage-istanbul-reporter'),
+      require('karma-sabarivka-reporter'),
       require('@angular-devkit/build-angular/plugins/karma')
     ],
     client:{
@@ -28,6 +29,9 @@ module.exports = function (config) {
       dir: path.join(__dirname, 'coverage'),
       reports: [ 'html', 'lcovonly' ],
       fixWebpackSourcePaths: true
+    },
+    coverageReporter: {
+      include: []
     },
     reporters: ['progress', 'kjhtml'],
     port: 9876,

--- a/tests/angular_devkit/build_angular/hello-world-app-ve/package.json
+++ b/tests/angular_devkit/build_angular/hello-world-app-ve/package.json
@@ -42,6 +42,7 @@
     "karma-coverage-istanbul-reporter": "~2.0.0",
     "karma-jasmine": "~1.1.0",
     "karma-jasmine-html-reporter": "^0.2.2",
+    "karma-sabarivka-reporter": "~3.0.2",
     "protractor": "~5.4.0",
     "ts-node": "~4.1.0",
     "tslint": "~5.9.1",

--- a/tests/angular_devkit/build_angular/hello-world-app/karma.conf.js
+++ b/tests/angular_devkit/build_angular/hello-world-app/karma.conf.js
@@ -19,6 +19,7 @@ module.exports = function(config) {
       require('karma-chrome-launcher'),
       require('karma-jasmine-html-reporter'),
       require('karma-coverage-istanbul-reporter'),
+      require('karma-sabarivka-reporter'),
       require('@angular-devkit/build-angular/plugins/karma'),
     ],
     client: {
@@ -28,6 +29,9 @@ module.exports = function(config) {
       dir: path.join(__dirname, 'coverage'),
       reports: ['html', 'lcovonly'],
       fixWebpackSourcePaths: true,
+    },
+    coverageReporter: {
+      include: []
     },
     reporters: ['progress', 'kjhtml'],
     port: 9876,

--- a/tests/angular_devkit/build_angular/hello-world-app/package.json
+++ b/tests/angular_devkit/build_angular/hello-world-app/package.json
@@ -42,6 +42,7 @@
     "karma-coverage-istanbul-reporter": "~2.0.0",
     "karma-jasmine": "~1.1.0",
     "karma-jasmine-html-reporter": "^0.2.2",
+    "karma-sabarivka-reporter": "~3.0.2",
     "protractor": "~5.4.0",
     "ts-node": "~4.1.0",
     "tslint": "~5.9.1",

--- a/tests/angular_devkit/build_ng_packagr/ng-packaged-ve/projects/lib/karma.conf.js
+++ b/tests/angular_devkit/build_ng_packagr/ng-packaged-ve/projects/lib/karma.conf.js
@@ -17,6 +17,7 @@ module.exports = function (config) {
       require('karma-chrome-launcher'),
       require('karma-jasmine-html-reporter'),
       require('karma-coverage-istanbul-reporter'),
+      require('karma-sabarivka-reporter'),
       require('@angular-devkit/build-angular/plugins/karma')
     ],
     client: {
@@ -26,6 +27,9 @@ module.exports = function (config) {
       dir: require('path').join(__dirname, 'coverage'),
       reports: ['html', 'lcovonly'],
       fixWebpackSourcePaths: true
+    },
+    coverageReporter: {
+      include: []
     },
     reporters: ['progress', 'kjhtml'],
     port: 9876,

--- a/tests/angular_devkit/build_ng_packagr/ng-packaged/projects/lib/karma.conf.js
+++ b/tests/angular_devkit/build_ng_packagr/ng-packaged/projects/lib/karma.conf.js
@@ -17,6 +17,7 @@ module.exports = function (config) {
       require('karma-chrome-launcher'),
       require('karma-jasmine-html-reporter'),
       require('karma-coverage-istanbul-reporter'),
+      require('karma-sabarivka-reporter'),
       require('@angular-devkit/build-angular/plugins/karma')
     ],
     client: {
@@ -26,6 +27,9 @@ module.exports = function (config) {
       dir: require('path').join(__dirname, 'coverage'),
       reports: ['html', 'lcovonly'],
       fixWebpackSourcePaths: true
+    },
+    coverageReporter: {
+      include: []
     },
     reporters: ['progress', 'kjhtml'],
     port: 9876,


### PR DESCRIPTION
Fix for issue  #1735 and #11227. Add `karma-sabarivka-reporter` as dependency for any new Angular project. This would allow including (if needed) untested files to coverage result. By default, no extra files are included, `include` config is empty.