### PR TITLE
fix(@angular-devkit/build-angular): provide locale data discovery fallbacks

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/i18n-options.ts
+++ b/packages/angular_devkit/build_angular/src/utils/i18n-options.ts
@@ -206,7 +206,18 @@ export async function configureI18nBuild<T extends BrowserBuilderSchema | Server
         continue;
       }
 
-      const localeDataPath = findLocaleDataPath(locale, localeDataBasePath);
+      let localeDataPath = findLocaleDataPath(locale, localeDataBasePath);
+      if (!localeDataPath) {
+        const [first] = locale.split('-');
+        if (first) {
+          localeDataPath = findLocaleDataPath(first.toLowerCase(), localeDataBasePath);
+          if (localeDataPath) {
+            context.logger.warn(
+              `Locale data for '${locale}' cannot be found.  Using locale data for '${first}'.`,
+            );
+          }
+        }
+      }
       if (!localeDataPath) {
         context.logger.warn(
           `Locale data for '${locale}' cannot be found.  No locale data will be included for this locale.`,
@@ -330,6 +341,11 @@ function findLocaleDataPath(locale: string, basePath: string): string | null {
   const localeDataPath = path.join(basePath, locale + '.js');
 
   if (!fs.existsSync(localeDataPath)) {
+    if (locale === 'en-US') {
+      // fallback to known existing en-US locale data as of 9.0
+      return findLocaleDataPath('en-US-POSIX', basePath);
+    }
+
     return null;
   }
 

--- a/tests/legacy-cli/e2e/tests/i18n/ivy-localize-locale-data.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/ivy-localize-locale-data.ts
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { ng } from '../../utils/process';
+import { updateJsonFile } from '../../utils/project';
+import { setupI18nConfig } from './legacy';
+
+export default async function() {
+  // Setup i18n tests and config.
+  await setupI18nConfig(true);
+
+  // Update angular.json
+  await updateJsonFile('angular.json', workspaceJson => {
+    const appProject = workspaceJson.projects['test-project'];
+    // tslint:disable-next-line: no-any
+    const i18n: Record<string, any> = appProject.i18n;
+
+    i18n.sourceLocale = 'fr-Abcd';
+    appProject.architect['build'].options.localize = ['fr-Abcd'];
+  });
+
+  const { stderr: err1 } = await ng('build');
+  if (!err1.includes(`Locale data for 'fr-Abcd' cannot be found.  Using locale data for 'fr'.`)) {
+    throw new Error('locale data fallback warning not shown');
+  }
+
+  // Update angular.json
+  await updateJsonFile('angular.json', workspaceJson => {
+    const appProject = workspaceJson.projects['test-project'];
+    // tslint:disable-next-line: no-any
+    const i18n: Record<string, any> = appProject.i18n;
+
+    i18n.sourceLocale = 'en-US';
+    appProject.architect['build'].options.localize = ['en-US'];
+  });
+
+  const { stderr: err2 } = await ng('build');
+  if (err2.includes(`Locale data for 'en-US' cannot be found.  No locale data will be included for this locale.`)) {
+    throw new Error('locale data not found warning shown');
+  }
+
+}


### PR DESCRIPTION
This synchronizes the behavior with the FW's wherein the language code will be used if the data for the full locale is not found.  The user will still be notified in the event this occurs.