### PR TITLE
refactor(@schematics/angular): remove redundant typeRoots

### DIFF
--- a/packages/schematics/angular/workspace/files/tsconfig.json.template
+++ b/packages/schematics/angular/workspace/files/tsconfig.json.template
@@ -16,9 +16,6 @@
     "moduleResolution": "node",
     "importHelpers": true,
     "target": "es2015",
-    "typeRoots": [
-      "node_modules/@types"
-    ],
     "lib": [
       "es2018",
       "dom"


### PR DESCRIPTION
By default TypeScript will look up in this directory (see [docs](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html#types-typeroots-and-types)).