### PR TITLE
docs(@angular/cli): fix schema.json description for `stylePreprocessorOptions.includePaths`

### DIFF
--- a/packages/angular/cli/lib/config/schema.json
+++ b/packages/angular/cli/lib/config/schema.json
@@ -675,7 +675,7 @@
               "type": "object",
               "properties": {
                 "includePaths": {
-                  "description": "Paths to include. Paths will be resolved to project root.",
+                  "description": "Paths to include. Paths will be resolved to workspace root. (Not project root!)",
                   "type": "array",
                   "items": {
                     "type": "string"
@@ -1430,7 +1430,7 @@
               "type": "object",
               "properties": {
                 "includePaths": {
-                  "description": "Paths to include. Paths will be resolved to project root.",
+                  "description": "Paths to include. Paths will be resolved to workspace root. (Not project root!)",
                   "type": "array",
                   "items": {
                     "type": "string"
@@ -1722,7 +1722,7 @@
               "type": "object",
               "properties": {
                 "includePaths": {
-                  "description": "Paths to include. Paths will be resolved to project root.",
+                  "description": "Paths to include. Paths will be resolved to workspace root. (Not project root!)",
                   "type": "array",
                   "items": {
                     "type": "string"


### PR DESCRIPTION
Previously, the `schema.json` description for `stylePreprocessorOptions` > `includePaths` specified that paths were resolved with respect to "project root", but this should read "workspace root".

Starting at [styles.ts#L81](https://github.com/angular/angular-cli/blob/v9.0.5/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/styles.ts#L81),

    includePaths.push(path.resolve(root, includePath)),

each user-specified include path is resolved with respect to `root`, declared at [styles.ts#L27](https://github.com/angular/angular-cli/blob/v9.0.5/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/styles.ts#L27)

    const { root, buildOptions } = wco;

where `wco` is passed in from the containing function, [`getStylesConfig`](https://github.com/angular/angular-cli/blob/v9.0.5/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/styles.ts#L26), called at [index.ts#L138](https://github.com/angular/angular-cli/blob/v9.0.5/packages/angular_devkit/build_angular/src/browser/index.ts#L138)

    getStylesConfig(wco),

inside the `webpackPartialGenerator` callback, which was passed to `generateBrowserWebpackConfigFromContext` at [index.ts#L154](https://github.com/angular/angular-cli/blob/v9.0.5/packages/angular_devkit/build_angular/src/browser/index.ts#L154)

    return generateBrowserWebpackConfigFromContext(options, context, webpackPartialGenerator, host);

which in turn passed the callback to [`generateWebpackConfig`](https://github.com/angular/angular-cli/blob/v9.0.5/packages/angular_devkit/build_angular/src/utils/webpack-browser-config.ts#L226), which calls the callback at [webpack-browser-config.ts#L104](https://github.com/angular/angular-cli/blob/v9.0.5/packages/angular_devkit/build_angular/src/utils/webpack-browser-config.ts#L104)

    const partials = webpackPartialGenerator(wco);

with the `wco` object declared at [webpack-browser-config.ts#L91](https://github.com/angular/angular-cli/blob/v9.0.5/packages/angular_devkit/build_angular/src/utils/webpack-browser-config.ts#L91), which has its `root` field set to `workspaceRoot`

    root: workspaceRoot,

which was passed in from `generateBrowserWebpackConfigFromContext` at [webpack-browser-config.ts#L222](https://github.com/angular/angular-cli/blob/v9.0.5/packages/angular_devkit/build_angular/src/utils/webpack-browser-config.ts#L222) as

    getSystemPath(workspaceRoot),

where `workspaceRoot` was declared at [webpack-browser-config.ts#L204](https://github.com/angular/angular-cli/blob/v9.0.5/packages/angular_devkit/build_angular/src/utils/webpack-browser-config.ts#L204) as

    const workspaceRoot = normalize(context.workspaceRoot);

using the `context` received from the caller, [`buildBrowserWebpackConfigFromContext`](https://github.com/angular/angular-cli/blob/v9.0.5/packages/angular_devkit/build_angular/src/browser/index.ts#L129), whose own caller, [`setup`](https://github.com/angular/angular-cli/blob/v9.0.5/packages/angular_devkit/build_angular/src/dev-server/index.ts#L163), passed in the `context` it received from [`setupWebpackBrowser`](https://github.com/angular/angular-cli/blob/v9.0.5/packages/angular_devkit/build_angular/src/dev-server/index.ts#L115) which declares the type of `context` to be `BuilderContext`, whose definition includes a comment for the `workspaceRoot` field at [api.ts#L146](https://github.com/angular/angular-cli/blob/v9.0.5/packages/angular_devkit/architect/src/api.ts#L146),

    The absolute workspace root of this run.

motivating this PR.

It would probably also be helpful to also mention the include path resolution strategy in the [relevant section of the docs](https://angular.io/guide/workspace-config#style-preprocessor-options).