### PR TITLE
test: change webpack angular tests to use es2015 

### DIFF
--- a/tests/angular_devkit/build_webpack/angular-app/tsconfig.json
+++ b/tests/angular_devkit/build_webpack/angular-app/tsconfig.json
@@ -8,7 +8,7 @@
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "target": "es5",
+    "target": "es2015",
     "typeRoots": [
       "node_modules/@types"
     ],


### PR DESCRIPTION
This is to avoid having NGCC go through and transform ES5 entrypoints