### PR TITLE
fix(@angular-devkit/build-angular): ensure live-reload shim workaround isolation

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
@@ -524,14 +524,6 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
           parser: { system: true },
         },
         {
-          test: /[\/\\]hot[\/\\]emitter\.js$/,
-          parser: { node: { events: true } },
-        },
-        {
-          test: /[\/\\]webpack-dev-server[\/\\]client[\/\\]utils[\/\\]createSocketUrl\.js$/,
-          parser: { node: { querystring: true } },
-        },
-        {
           test: /\.js$/,
           // Factory files are processed by BO in the rules added in typescript.ts.
           exclude: /(ngfactory|ngstyle)\.js$/,

--- a/tests/legacy-cli/e2e/tests/commands/serve/reload-shims.ts
+++ b/tests/legacy-cli/e2e/tests/commands/serve/reload-shims.ts
@@ -1,0 +1,25 @@
+import { prependToFile, writeFile } from '../../../utils/fs';
+import { execAndWaitForOutputToMatch, killAllProcesses } from '../../../utils/process';
+
+export default async function() {
+  // Simulate a JS library using a Node.js specific module
+  await writeFile('src/node-usage.js', `const path = require('path');\n`);
+  await prependToFile('src/main.ts', `import './node-usage';\n`);
+
+  try {
+    // Make sure serve is consistent with build
+    await execAndWaitForOutputToMatch(
+      'ng',
+      ['build'],
+      /Module not found: Error: Can't resolve 'path'/,
+    );
+    // The Node.js specific module should not be found
+    await execAndWaitForOutputToMatch(
+      'ng',
+      ['serve', '--port=0'],
+      /Module not found: Error: Can't resolve 'path'/,
+    );
+  } finally {
+    killAllProcesses();
+  }
+}


### PR DESCRIPTION
This change reduces the workaround to a single file location as well as ensuring that only the shims of interest from the two necessary live reload files are affected.  This makes sure that build and serve behavior is the same in this regard.