### PR TITLE
feat(@schematics/angular): generate new projects with tslint 6.1.0

### DIFF
--- a/packages/schematics/angular/application/index_spec.ts
+++ b/packages/schematics/angular/application/index_spec.ts
@@ -378,7 +378,7 @@ describe('Application Schematic', () => {
       const content = JSON.parse(tree.readContent('/tslint.json'));
       expect(content.extends).toMatch('tslint:recommended');
       expect(content.rules['component-selector'][2]).toMatch('app');
-      expect(content.rules['trailing-comma']).toBeDefined();
+      expect(content.rules['no-console']).toBeDefined();
     });
 
     it(`should create correct paths when 'newProjectRoot' is blank`, async () => {

--- a/packages/schematics/angular/migrations/migration-collection.json
+++ b/packages/schematics/angular/migrations/migration-collection.json
@@ -54,6 +54,11 @@
       "version": "9.0.2",
       "factory": "./update-9/schematic-options",
       "description": "Replace deprecated 'styleext' and 'spec' Angular schematic options."
+    },
+    "tslint-version-6": {
+      "version": "10.0.0-beta.0",
+      "factory": "./update-10/update-tslint",
+      "description": "Update tslint to version 6."
     }
   }
 }

--- a/packages/schematics/angular/migrations/update-10/update-tslint.ts
+++ b/packages/schematics/angular/migrations/update-10/update-tslint.ts
@@ -1,0 +1,156 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { JsonAstObject, JsonValue } from '@angular-devkit/core';
+import { Rule } from '@angular-devkit/schematics';
+import { addPackageJsonDependency, getPackageJsonDependency } from '../../utility/dependencies';
+import { findPropertyInAstObject, insertPropertyInAstObjectInOrder, removePropertyInAstObject } from '../../utility/json-utils';
+import { readJsonFileAsAstObject } from '../update-9/utils';
+
+export const TSLINT_VERSION = '~6.1.0';
+const TSLINT_CONFIG_PATH = '/tslint.json';
+
+const RULES_TO_DELETE: string[] = [
+  'no-use-before-declare',
+  'no-unused-variable',
+];
+
+const RULES_TO_ADD: Record<string, JsonValue> = {
+  align: {
+    options: ['parameters', 'statements'],
+  },
+  'arrow-return-shorthand': true,
+  curly: true,
+  eofline: true,
+  'import-spacing': true,
+  indent: {
+    options: ['spaces'],
+  },
+  'variable-name': {
+    options: ['ban-keywords', 'check-format', 'allow-pascal-case'],
+  },
+  semicolon: { options: ['always'] },
+  'space-before-function-paren': {
+    options: {
+      anonymous: 'never',
+      asyncArrow: 'always',
+      constructor: 'never',
+      method: 'never',
+      named: 'never',
+    },
+  },
+  'typedef-whitespace': {
+    options: [
+      {
+        'call-signature': 'nospace',
+        'index-signature': 'nospace',
+        parameter: 'nospace',
+        'property-declaration': 'nospace',
+        'variable-declaration': 'nospace',
+      },
+      {
+        'call-signature': 'onespace',
+        'index-signature': 'onespace',
+        parameter: 'onespace',
+        'property-declaration': 'onespace',
+        'variable-declaration': 'onespace',
+      },
+    ],
+  },
+  whitespace: {
+    options: [
+      'check-branch',
+      'check-decl',
+      'check-operator',
+      'check-separator',
+      'check-type',
+      'check-typecast',
+    ],
+  },
+};
+
+export default function (): Rule {
+  return (tree, context) => {
+    const logger = context.logger;
+
+    // Update tslint dependency
+    const current = getPackageJsonDependency(tree, 'tslint');
+
+    if (!current) {
+      logger.info('"tslint" in not a dependency of this workspace.');
+
+      return;
+    }
+
+    if (current.version !== TSLINT_VERSION) {
+      addPackageJsonDependency(tree, {
+        type: current.type,
+        name: 'tslint',
+        version: TSLINT_VERSION,
+        overwrite: true,
+      });
+    }
+
+    // Update tslint config.
+    const tslintJsonAst = readJsonFileAsAstObject(tree, TSLINT_CONFIG_PATH);
+    if (!tslintJsonAst) {
+      const config = ['tslint.js', 'tslint.yaml'].find(c => tree.exists(c));
+      if (config) {
+        logger.warn(`Expected a JSON configuration file but found "${config}".`);
+      } else {
+        logger.warn('Cannot find "tslint.json" configuration file.');
+      }
+
+      return;
+    }
+
+    // Remove old/deprecated rules.
+    for (const rule of RULES_TO_DELETE) {
+      const tslintJsonAst = readJsonFileAsAstObject(tree, TSLINT_CONFIG_PATH) as JsonAstObject;
+      const rulesAst = findPropertyInAstObject(tslintJsonAst, 'rules');
+      if (rulesAst?.kind !== 'object') {
+        break;
+      }
+
+      const recorder = tree.beginUpdate(TSLINT_CONFIG_PATH);
+      removePropertyInAstObject(recorder, rulesAst, rule);
+      tree.commitUpdate(recorder);
+    }
+
+    // Add new rules only iif the configuration extends 'tslint:recommended'.
+    // This is because some rules conflict with prettier or other tools.
+    const extendsAst = findPropertyInAstObject(tslintJsonAst, 'extends');
+    if (
+      !extendsAst ||
+      (extendsAst.kind === 'string' && extendsAst.value !== 'tslint:recommended') ||
+      (extendsAst.kind === 'array' && extendsAst.elements.some(e => e.value !== 'tslint:recommended'))
+    ) {
+      logger.warn(`tslint configuration does not extend "tslint:recommended".`
+        + '\nMigration will terminate as some rules might conflict.');
+
+      return;
+    }
+
+    for (const [name, value] of Object.entries(RULES_TO_ADD)) {
+      const tslintJsonAst = readJsonFileAsAstObject(tree, TSLINT_CONFIG_PATH) as JsonAstObject;
+      const rulesAst = findPropertyInAstObject(tslintJsonAst, 'rules');
+      if (rulesAst?.kind !== 'object') {
+        break;
+      }
+
+      if (findPropertyInAstObject(rulesAst, name)) {
+        // Skip as rule already exists.
+        continue;
+      }
+
+      const recorder = tree.beginUpdate(TSLINT_CONFIG_PATH);
+      insertPropertyInAstObjectInOrder(recorder, rulesAst, name, value, 4);
+      tree.commitUpdate(recorder);
+    }
+
+  };
+}

--- a/packages/schematics/angular/migrations/update-10/update-tslint_spec.ts
+++ b/packages/schematics/angular/migrations/update-10/update-tslint_spec.ts
@@ -1,0 +1,114 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { EmptyTree } from '@angular-devkit/schematics';
+import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';
+import { TSLINT_VERSION } from './update-tslint';
+
+describe('Migration of tslint to version 6', () => {
+  const schematicRunner = new SchematicTestRunner(
+    'migrations',
+    require.resolve('../migration-collection.json'),
+  );
+
+  let tree: UnitTestTree;
+  const TSLINT_PATH = '/tslint.json';
+  const PACKAGE_JSON_PATH = '/package.json';
+
+  const TSLINT_CONFIG = {
+    extends: 'tslint:recommended',
+    rules: {
+      'no-use-before-declare': true,
+      'arrow-return-shorthand': false,
+      'label-position': true,
+    },
+  };
+
+  const PACKAGE_JSON = {
+    devDependencies: {
+      tslint: '~5.1.0',
+    },
+  };
+
+  beforeEach(() => {
+    tree = new UnitTestTree(new EmptyTree());
+    tree.create(PACKAGE_JSON_PATH, JSON.stringify(PACKAGE_JSON, null, 2));
+    tree.create(TSLINT_PATH, JSON.stringify(TSLINT_CONFIG, null, 2));
+  });
+
+  it('should update tslint dependency', async () => {
+    const newTree = await schematicRunner.runSchematicAsync('tslint-version-6', {}, tree).toPromise();
+    const packageJson = JSON.parse(newTree.readContent(PACKAGE_JSON_PATH));
+    expect(packageJson.devDependencies.tslint).toBe(TSLINT_VERSION);
+  });
+
+  it('should remove old/deprecated rules', async () => {
+    const newTree = await schematicRunner.runSchematicAsync('tslint-version-6', {}, tree).toPromise();
+    const { rules } = JSON.parse(newTree.readContent(TSLINT_PATH));
+    expect(rules['no-use-before-declare']).toBeUndefined();
+  });
+
+  it('should add new rules', async () => {
+    const newTree = await schematicRunner.runSchematicAsync('tslint-version-6', {}, tree).toPromise();
+    const { rules } = JSON.parse(newTree.readContent(TSLINT_PATH));
+    expect(rules['eofline']).toBe(true);
+  });
+
+  it('should not update already present rules', async () => {
+    const newTree = await schematicRunner.runSchematicAsync('tslint-version-6', {}, tree).toPromise();
+    const { rules } = JSON.parse(newTree.readContent(TSLINT_PATH));
+    expect(rules['arrow-return-shorthand']).toBe(false);
+  });
+
+  it(`should not add new rules when not extending 'tslint:recommended'`, async () => {
+    tree.overwrite(
+      TSLINT_PATH,
+      JSON.stringify({
+        ...TSLINT_CONFIG,
+        extends: 'tslint-config-prettier',
+      }, null, 2),
+    );
+
+    const newTree = await schematicRunner.runSchematicAsync('tslint-version-6', {}, tree).toPromise();
+    const { rules } = JSON.parse(newTree.readContent(TSLINT_PATH));
+    expect(rules['eofline']).toBeUndefined();
+  });
+
+  it(`should not add new rules when extending multiple configs`, async () => {
+    tree.overwrite(
+      TSLINT_PATH,
+      JSON.stringify({
+        ...TSLINT_CONFIG,
+        extends: [
+          'tslint:recommended',
+          'tslint-config-prettier',
+        ],
+      }, null, 2),
+    );
+
+    const newTree = await schematicRunner.runSchematicAsync('tslint-version-6', {}, tree).toPromise();
+    const { rules } = JSON.parse(newTree.readContent(TSLINT_PATH));
+    expect(rules['eofline']).toBeUndefined();
+  });
+
+  it(`should remove old/deprecated rules when extending multiple configs`, async () => {
+    tree.overwrite(
+      TSLINT_PATH,
+      JSON.stringify({
+        ...TSLINT_CONFIG,
+        extends: [
+          'tslint:recommended',
+          'tslint-config-prettier',
+        ],
+      }, null, 2),
+    );
+
+    const newTree = await schematicRunner.runSchematicAsync('tslint-version-6', {}, tree).toPromise();
+    const { rules } = JSON.parse(newTree.readContent(TSLINT_PATH));
+    expect(rules['no-use-before-declare']).toBeUndefined();
+  });
+});

--- a/packages/schematics/angular/workspace/files/package.json.template
+++ b/packages/schematics/angular/workspace/files/package.json.template
@@ -40,7 +40,7 @@
     "karma-jasmine-html-reporter": "^1.4.2",
     "protractor": "~5.4.3",<% } %>
     "ts-node": "~8.3.0",
-    "tslint": "~5.18.0",
+    "tslint": "~6.1.0",
     "typescript": "<%= latestVersions.TypeScript %>"
   }
 }

--- a/packages/schematics/angular/workspace/files/tslint.json.template
+++ b/packages/schematics/angular/workspace/files/tslint.json.template
@@ -4,22 +4,34 @@
     "codelyzer"
   ],
   "rules": {
+    "align": {
+      "options": [
+        "parameters",
+        "statements"
+      ]
+    },
     "array-type": false,
-    "arrow-parens": false,
+    "arrow-return-shorthand": true,
+    "curly": true,
     "deprecation": {
       "severity": "warning"
     },
+    "eofline": true,
     "import-blacklist": [
       true,
       "rxjs/Rx"
     ],
-    "interface-name": false,
+    "import-spacing": true,
+    "indent": {
+      "options": [
+        "spaces"
+      ]
+    },
     "max-classes-per-file": false,
     "max-line-length": [
       true,
       140
     ],
-    "member-access": false,
     "member-ordering": [
       true,
       {
@@ -31,7 +43,6 @@
         ]
       }
     ],
-    "no-consecutive-blank-lines": false,
     "no-console": [
       true,
       "debug",
@@ -53,13 +64,59 @@
       true,
       "as-needed"
     ],
-    "object-literal-sort-keys": false,
-    "ordered-imports": false,
     "quotemark": [
       true,
       "single"
     ],
-    "trailing-comma": false,
+    "semicolon": {
+      "options": [
+        "always"
+      ]
+    },
+    "space-before-function-paren": {
+      "options": {
+        "anonymous": "never",
+        "asyncArrow": "always",
+        "constructor": "never",
+        "method": "never",
+        "named": "never"
+      }
+    },
+    "typedef-whitespace": {
+      "options": [
+        {
+          "call-signature": "nospace",
+          "index-signature": "nospace",
+          "parameter": "nospace",
+          "property-declaration": "nospace",
+          "variable-declaration": "nospace"
+        },
+        {
+          "call-signature": "onespace",
+          "index-signature": "onespace",
+          "parameter": "onespace",
+          "property-declaration": "onespace",
+          "variable-declaration": "onespace"
+        }
+      ]
+    },
+    "variable-name": {
+      "options": [
+        "ban-keywords",
+        "check-format",
+        "allow-pascal-case"
+      ]
+    },
+    "whitespace": {
+      "options": [
+        "check-branch",
+        "check-decl",
+        "check-operator",
+        "check-separator",
+        "check-type",
+        "check-typecast"
+      ]
+    },
     "component-class-suffix": true,
     "contextual-lifecycle": true,
     "directive-class-suffix": true,

--- a/tests/angular_devkit/build_angular/hello-world-app-ve/tslint.json
+++ b/tests/angular_devkit/build_angular/hello-world-app-ve/tslint.json
@@ -1,38 +1,37 @@
 {
+  "extends": "tslint:recommended",
   "rulesDirectory": [
-    "../../../../node_modules/codelyzer"
+    "codelyzer"
   ],
   "rules": {
+    "align": {
+      "options": [
+        "parameters",
+        "statements"
+      ]
+    },
+    "array-type": false,
     "arrow-return-shorthand": true,
-    "callable-types": true,
-    "class-name": true,
-    "comment-format": [
-      true,
-      "check-space"
-    ],
     "curly": true,
     "deprecation": {
-      "severity": "warn"
+      "severity": "warning"
     },
     "eofline": true,
-    "forin": true,
     "import-blacklist": [
       true,
-      "rxjs",
       "rxjs/Rx"
     ],
     "import-spacing": true,
-    "indent": [
-      true,
-      "spaces"
-    ],
-    "interface-over-type-literal": true,
-    "label-position": true,
+    "indent": {
+      "options": [
+        "spaces"
+      ]
+    },
+    "max-classes-per-file": false,
     "max-line-length": [
       true,
       140
     ],
-    "member-access": false,
     "member-ordering": [
       true,
       {
@@ -44,8 +43,6 @@
         ]
       }
     ],
-    "no-arg": true,
-    "no-bitwise": true,
     "no-console": [
       true,
       "debug",
@@ -54,90 +51,79 @@
       "timeEnd",
       "trace"
     ],
-    "no-construct": true,
-    "no-debugger": true,
-    "no-duplicate-super": true,
     "no-empty": false,
-    "no-empty-interface": true,
-    "no-eval": true,
     "no-inferrable-types": [
       true,
       "ignore-params"
     ],
-    "no-misused-new": true,
     "no-non-null-assertion": true,
-    "no-shadowed-variable": true,
-    "no-string-literal": false,
-    "no-string-throw": true,
+    "no-redundant-jsdoc": true,
     "no-switch-case-fall-through": true,
-    "no-trailing-whitespace": true,
-    "no-unnecessary-initializer": true,
-    "no-unused-expression": true,
-    "no-use-before-declare": true,
-    "no-var-keyword": true,
-    "object-literal-sort-keys": false,
-    "one-line": [
+    "no-var-requires": false,
+    "object-literal-key-quotes": [
       true,
-      "check-open-brace",
-      "check-catch",
-      "check-else",
-      "check-whitespace"
+      "as-needed"
     ],
-    "prefer-const": true,
     "quotemark": [
       true,
       "single"
     ],
-    "radix": true,
-    "semicolon": [
-      true,
-      "always"
-    ],
-    "triple-equals": [
-      true,
-      "allow-null-check"
-    ],
-    "typedef-whitespace": [
-      true,
-      {
-        "call-signature": "nospace",
-        "index-signature": "nospace",
-        "parameter": "nospace",
-        "property-declaration": "nospace",
-        "variable-declaration": "nospace"
+    "semicolon": {
+      "options": [
+        "always"
+      ]
+    },
+    "space-before-function-paren": {
+      "options": {
+        "anonymous": "never",
+        "asyncArrow": "always",
+        "constructor": "never",
+        "method": "never",
+        "named": "never"
       }
-    ],
-    "unified-signatures": true,
-    "variable-name": false,
-    "whitespace": [
-      true,
-      "check-branch",
-      "check-decl",
-      "check-operator",
-      "check-separator",
-      "check-type"
-    ],
-    "directive-selector": [
-      true,
-      "attribute",
-      "app",
-      "camelCase"
-    ],
-    "component-selector": [
-      true,
-      "element",
-      "app",
-      "kebab-case"
-    ],
-    "no-output-on-prefix": true,
-    "no-inputs-metadata-property": true,
-    "no-outputs-metadata-property": true,
+    },
+    "typedef-whitespace": {
+      "options": [
+        {
+          "call-signature": "nospace",
+          "index-signature": "nospace",
+          "parameter": "nospace",
+          "property-declaration": "nospace",
+          "variable-declaration": "nospace"
+        },
+        {
+          "call-signature": "onespace",
+          "index-signature": "onespace",
+          "parameter": "onespace",
+          "property-declaration": "onespace",
+          "variable-declaration": "onespace"
+        }
+      ]
+    },
+    "whitespace": {
+      "options": [
+        "check-branch",
+        "check-decl",
+        "check-operator",
+        "check-separator",
+        "check-type",
+        "check-typecast"
+      ]
+    },
+    "component-class-suffix": true,
+    "contextual-lifecycle": true,
+    "directive-class-suffix": true,
+    "no-conflicting-lifecycle": true,
     "no-host-metadata-property": true,
     "no-input-rename": true,
+    "no-inputs-metadata-property": true,
+    "no-output-native": true,
+    "no-output-on-prefix": true,
     "no-output-rename": true,
+    "no-outputs-metadata-property": true,
+    "template-banana-in-box": true,
+    "template-no-negated-async": true,
     "use-lifecycle-interface": true,
-    "use-pipe-transform-interface": true,
-    "component-class-suffix": true,
-    "directive-class-suffix": true
+    "use-pipe-transform-interface": true
   }
 }

--- a/tests/angular_devkit/build_angular/hello-world-app/tslint.json
+++ b/tests/angular_devkit/build_angular/hello-world-app/tslint.json
@@ -1,38 +1,37 @@
 {
+  "extends": "tslint:recommended",
   "rulesDirectory": [
-    "../../../../node_modules/codelyzer"
+    "codelyzer"
   ],
   "rules": {
+    "align": {
+      "options": [
+        "parameters",
+        "statements"
+      ]
+    },
+    "array-type": false,
     "arrow-return-shorthand": true,
-    "callable-types": true,
-    "class-name": true,
-    "comment-format": [
-      true,
-      "check-space"
-    ],
     "curly": true,
     "deprecation": {
-      "severity": "warn"
+      "severity": "warning"
     },
     "eofline": true,
-    "forin": true,
     "import-blacklist": [
       true,
-      "rxjs",
       "rxjs/Rx"
     ],
     "import-spacing": true,
-    "indent": [
-      true,
-      "spaces"
-    ],
-    "interface-over-type-literal": true,
-    "label-position": true,
+    "indent": {
+      "options": [
+        "spaces"
+      ]
+    },
+    "max-classes-per-file": false,
     "max-line-length": [
       true,
       140
     ],
-    "member-access": false,
     "member-ordering": [
       true,
       {
@@ -44,8 +43,6 @@
         ]
       }
     ],
-    "no-arg": true,
-    "no-bitwise": true,
     "no-console": [
       true,
       "debug",
@@ -54,90 +51,79 @@
       "timeEnd",
       "trace"
     ],
-    "no-construct": true,
-    "no-debugger": true,
-    "no-duplicate-super": true,
     "no-empty": false,
-    "no-empty-interface": true,
-    "no-eval": true,
     "no-inferrable-types": [
       true,
       "ignore-params"
     ],
-    "no-misused-new": true,
     "no-non-null-assertion": true,
-    "no-shadowed-variable": true,
-    "no-string-literal": false,
-    "no-string-throw": true,
+    "no-redundant-jsdoc": true,
     "no-switch-case-fall-through": true,
-    "no-trailing-whitespace": true,
-    "no-unnecessary-initializer": true,
-    "no-unused-expression": true,
-    "no-use-before-declare": true,
-    "no-var-keyword": true,
-    "object-literal-sort-keys": false,
-    "one-line": [
+    "no-var-requires": false,
+    "object-literal-key-quotes": [
       true,
-      "check-open-brace",
-      "check-catch",
-      "check-else",
-      "check-whitespace"
+      "as-needed"
     ],
-    "prefer-const": true,
     "quotemark": [
       true,
       "single"
     ],
-    "radix": true,
-    "semicolon": [
-      true,
-      "always"
-    ],
-    "triple-equals": [
-      true,
-      "allow-null-check"
-    ],
-    "typedef-whitespace": [
-      true,
-      {
-        "call-signature": "nospace",
-        "index-signature": "nospace",
-        "parameter": "nospace",
-        "property-declaration": "nospace",
-        "variable-declaration": "nospace"
+    "semicolon": {
+      "options": [
+        "always"
+      ]
+    },
+    "space-before-function-paren": {
+      "options": {
+        "anonymous": "never",
+        "asyncArrow": "always",
+        "constructor": "never",
+        "method": "never",
+        "named": "never"
       }
-    ],
-    "unified-signatures": true,
-    "variable-name": false,
-    "whitespace": [
-      true,
-      "check-branch",
-      "check-decl",
-      "check-operator",
-      "check-separator",
-      "check-type"
-    ],
-    "directive-selector": [
-      true,
-      "attribute",
-      "app",
-      "camelCase"
-    ],
-    "component-selector": [
-      true,
-      "element",
-      "app",
-      "kebab-case"
-    ],
-    "no-output-on-prefix": true,
-    "no-inputs-metadata-property": true,
-    "no-outputs-metadata-property": true,
+    },
+    "typedef-whitespace": {
+      "options": [
+        {
+          "call-signature": "nospace",
+          "index-signature": "nospace",
+          "parameter": "nospace",
+          "property-declaration": "nospace",
+          "variable-declaration": "nospace"
+        },
+        {
+          "call-signature": "onespace",
+          "index-signature": "onespace",
+          "parameter": "onespace",
+          "property-declaration": "onespace",
+          "variable-declaration": "onespace"
+        }
+      ]
+    },
+    "whitespace": {
+      "options": [
+        "check-branch",
+        "check-decl",
+        "check-operator",
+        "check-separator",
+        "check-type",
+        "check-typecast"
+      ]
+    },
+    "component-class-suffix": true,
+    "contextual-lifecycle": true,
+    "directive-class-suffix": true,
+    "no-conflicting-lifecycle": true,
     "no-host-metadata-property": true,
     "no-input-rename": true,
+    "no-inputs-metadata-property": true,
+    "no-output-native": true,
+    "no-output-on-prefix": true,
     "no-output-rename": true,
+    "no-outputs-metadata-property": true,
+    "template-banana-in-box": true,
+    "template-no-negated-async": true,
     "use-lifecycle-interface": true,
-    "use-pipe-transform-interface": true,
-    "component-class-suffix": true,
-    "directive-class-suffix": true
+    "use-pipe-transform-interface": true
   }
 }

--- a/tests/angular_devkit/build_ng_packagr/ng-packaged-ve/tslint.json
+++ b/tests/angular_devkit/build_ng_packagr/ng-packaged-ve/tslint.json
@@ -1,38 +1,37 @@
 {
+  "extends": "tslint:recommended",
   "rulesDirectory": [
-    "../../../../node_modules/codelyzer"
+    "codelyzer"
   ],
   "rules": {
+    "align": {
+      "options": [
+        "parameters",
+        "statements"
+      ]
+    },
+    "array-type": false,
     "arrow-return-shorthand": true,
-    "callable-types": true,
-    "class-name": true,
-    "comment-format": [
-      true,
-      "check-space"
-    ],
     "curly": true,
     "deprecation": {
-      "severity": "warn"
+      "severity": "warning"
     },
     "eofline": true,
-    "forin": true,
     "import-blacklist": [
       true,
-      "rxjs",
       "rxjs/Rx"
     ],
     "import-spacing": true,
-    "indent": [
-      true,
-      "spaces"
-    ],
-    "interface-over-type-literal": true,
-    "label-position": true,
+    "indent": {
+      "options": [
+        "spaces"
+      ]
+    },
+    "max-classes-per-file": false,
     "max-line-length": [
       true,
       140
     ],
-    "member-access": false,
     "member-ordering": [
       true,
       {
@@ -44,8 +43,6 @@
         ]
       }
     ],
-    "no-arg": true,
-    "no-bitwise": true,
     "no-console": [
       true,
       "debug",
@@ -54,78 +51,79 @@
       "timeEnd",
       "trace"
     ],
-    "no-construct": true,
-    "no-debugger": true,
-    "no-duplicate-super": true,
     "no-empty": false,
-    "no-empty-interface": true,
-    "no-eval": true,
     "no-inferrable-types": [
       true,
       "ignore-params"
     ],
-    "no-misused-new": true,
     "no-non-null-assertion": true,
-    "no-shadowed-variable": true,
-    "no-string-literal": false,
-    "no-string-throw": true,
+    "no-redundant-jsdoc": true,
     "no-switch-case-fall-through": true,
-    "no-trailing-whitespace": true,
-    "no-unnecessary-initializer": true,
-    "no-unused-expression": true,
-    "no-use-before-declare": true,
-    "no-var-keyword": true,
-    "object-literal-sort-keys": false,
-    "one-line": [
+    "no-var-requires": false,
+    "object-literal-key-quotes": [
       true,
-      "check-open-brace",
-      "check-catch",
-      "check-else",
-      "check-whitespace"
+      "as-needed"
     ],
-    "prefer-const": true,
     "quotemark": [
       true,
       "single"
     ],
-    "radix": true,
-    "semicolon": [
-      true,
-      "always"
-    ],
-    "triple-equals": [
-      true,
-      "allow-null-check"
-    ],
-    "typedef-whitespace": [
-      true,
-      {
-        "call-signature": "nospace",
-        "index-signature": "nospace",
-        "parameter": "nospace",
-        "property-declaration": "nospace",
-        "variable-declaration": "nospace"
+    "semicolon": {
+      "options": [
+        "always"
+      ]
+    },
+    "space-before-function-paren": {
+      "options": {
+        "anonymous": "never",
+        "asyncArrow": "always",
+        "constructor": "never",
+        "method": "never",
+        "named": "never"
       }
-    ],
-    "unified-signatures": true,
-    "variable-name": false,
-    "whitespace": [
-      true,
-      "check-branch",
-      "check-decl",
-      "check-operator",
-      "check-separator",
-      "check-type"
-    ],
-    "no-output-on-prefix": true,
-    "use-input-property-decorator": true,
-    "use-output-property-decorator": true,
-    "use-host-property-decorator": true,
-    "no-input-rename": true,
-    "no-output-rename": true,
-    "use-life-cycle-interface": true,
-    "use-pipe-transform-interface": true,
+    },
+    "typedef-whitespace": {
+      "options": [
+        {
+          "call-signature": "nospace",
+          "index-signature": "nospace",
+          "parameter": "nospace",
+          "property-declaration": "nospace",
+          "variable-declaration": "nospace"
+        },
+        {
+          "call-signature": "onespace",
+          "index-signature": "onespace",
+          "parameter": "onespace",
+          "property-declaration": "onespace",
+          "variable-declaration": "onespace"
+        }
+      ]
+    },
+    "whitespace": {
+      "options": [
+        "check-branch",
+        "check-decl",
+        "check-operator",
+        "check-separator",
+        "check-type",
+        "check-typecast"
+      ]
+    },
     "component-class-suffix": true,
-    "directive-class-suffix": true
+    "contextual-lifecycle": true,
+    "directive-class-suffix": true,
+    "no-conflicting-lifecycle": true,
+    "no-host-metadata-property": true,
+    "no-input-rename": true,
+    "no-inputs-metadata-property": true,
+    "no-output-native": true,
+    "no-output-on-prefix": true,
+    "no-output-rename": true,
+    "no-outputs-metadata-property": true,
+    "template-banana-in-box": true,
+    "template-no-negated-async": true,
+    "use-lifecycle-interface": true,
+    "use-pipe-transform-interface": true
   }
 }

--- a/tests/angular_devkit/build_ng_packagr/ng-packaged/tslint.json
+++ b/tests/angular_devkit/build_ng_packagr/ng-packaged/tslint.json
@@ -1,38 +1,37 @@
 {
+  "extends": "tslint:recommended",
   "rulesDirectory": [
-    "../../../../node_modules/codelyzer"
+    "codelyzer"
   ],
   "rules": {
+    "align": {
+      "options": [
+        "parameters",
+        "statements"
+      ]
+    },
+    "array-type": false,
     "arrow-return-shorthand": true,
-    "callable-types": true,
-    "class-name": true,
-    "comment-format": [
-      true,
-      "check-space"
-    ],
     "curly": true,
     "deprecation": {
-      "severity": "warn"
+      "severity": "warning"
     },
     "eofline": true,
-    "forin": true,
     "import-blacklist": [
       true,
-      "rxjs",
       "rxjs/Rx"
     ],
     "import-spacing": true,
-    "indent": [
-      true,
-      "spaces"
-    ],
-    "interface-over-type-literal": true,
-    "label-position": true,
+    "indent": {
+      "options": [
+        "spaces"
+      ]
+    },
+    "max-classes-per-file": false,
     "max-line-length": [
       true,
       140
     ],
-    "member-access": false,
     "member-ordering": [
       true,
       {
@@ -44,8 +43,6 @@
         ]
       }
     ],
-    "no-arg": true,
-    "no-bitwise": true,
     "no-console": [
       true,
       "debug",
@@ -54,78 +51,79 @@
       "timeEnd",
       "trace"
     ],
-    "no-construct": true,
-    "no-debugger": true,
-    "no-duplicate-super": true,
     "no-empty": false,
-    "no-empty-interface": true,
-    "no-eval": true,
     "no-inferrable-types": [
       true,
       "ignore-params"
     ],
-    "no-misused-new": true,
     "no-non-null-assertion": true,
-    "no-shadowed-variable": true,
-    "no-string-literal": false,
-    "no-string-throw": true,
+    "no-redundant-jsdoc": true,
     "no-switch-case-fall-through": true,
-    "no-trailing-whitespace": true,
-    "no-unnecessary-initializer": true,
-    "no-unused-expression": true,
-    "no-use-before-declare": true,
-    "no-var-keyword": true,
-    "object-literal-sort-keys": false,
-    "one-line": [
+    "no-var-requires": false,
+    "object-literal-key-quotes": [
       true,
-      "check-open-brace",
-      "check-catch",
-      "check-else",
-      "check-whitespace"
+      "as-needed"
     ],
-    "prefer-const": true,
     "quotemark": [
       true,
       "single"
     ],
-    "radix": true,
-    "semicolon": [
-      true,
-      "always"
-    ],
-    "triple-equals": [
-      true,
-      "allow-null-check"
-    ],
-    "typedef-whitespace": [
-      true,
-      {
-        "call-signature": "nospace",
-        "index-signature": "nospace",
-        "parameter": "nospace",
-        "property-declaration": "nospace",
-        "variable-declaration": "nospace"
+    "semicolon": {
+      "options": [
+        "always"
+      ]
+    },
+    "space-before-function-paren": {
+      "options": {
+        "anonymous": "never",
+        "asyncArrow": "always",
+        "constructor": "never",
+        "method": "never",
+        "named": "never"
       }
-    ],
-    "unified-signatures": true,
-    "variable-name": false,
-    "whitespace": [
-      true,
-      "check-branch",
-      "check-decl",
-      "check-operator",
-      "check-separator",
-      "check-type"
-    ],
-    "no-output-on-prefix": true,
-    "use-input-property-decorator": true,
-    "use-output-property-decorator": true,
-    "use-host-property-decorator": true,
-    "no-input-rename": true,
-    "no-output-rename": true,
-    "use-life-cycle-interface": true,
-    "use-pipe-transform-interface": true,
+    },
+    "typedef-whitespace": {
+      "options": [
+        {
+          "call-signature": "nospace",
+          "index-signature": "nospace",
+          "parameter": "nospace",
+          "property-declaration": "nospace",
+          "variable-declaration": "nospace"
+        },
+        {
+          "call-signature": "onespace",
+          "index-signature": "onespace",
+          "parameter": "onespace",
+          "property-declaration": "onespace",
+          "variable-declaration": "onespace"
+        }
+      ]
+    },
+    "whitespace": {
+      "options": [
+        "check-branch",
+        "check-decl",
+        "check-operator",
+        "check-separator",
+        "check-type",
+        "check-typecast"
+      ]
+    },
     "component-class-suffix": true,
-    "directive-class-suffix": true
+    "contextual-lifecycle": true,
+    "directive-class-suffix": true,
+    "no-conflicting-lifecycle": true,
+    "no-host-metadata-property": true,
+    "no-input-rename": true,
+    "no-inputs-metadata-property": true,
+    "no-output-native": true,
+    "no-output-on-prefix": true,
+    "no-output-rename": true,
+    "no-outputs-metadata-property": true,
+    "template-banana-in-box": true,
+    "template-no-negated-async": true,
+    "use-lifecycle-interface": true,
+    "use-pipe-transform-interface": true
   }
 }


### PR DESCRIPTION
tslint 6.1 adds support for TypeScript 3.8 syntax

See: https://github.com/palantir/tslint/blob/master/CHANGELOG.md#v610

Pr to update the package in the repo https://github.com/angular/angular-cli/pull/17202

See individual commits for more details.