### PR TITLE
fix(@angular-devkit/build-angular): update tree-kill dependency to 1.…

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "spdx-satisfies": "^4.0.0",
     "tar": "^4.4.4",
     "through2": "^2.0.3",
-    "tree-kill": "^1.2.0",
+    "tree-kill": "^1.2.2",
     "ts-node": "^5.0.0",
     "tslint-no-circular-imports": "^0.6.0",
     "tslint-sonarts": "1.9.0"

--- a/packages/angular_devkit/benchmark/package.json
+++ b/packages/angular_devkit/benchmark/package.json
@@ -19,6 +19,6 @@
     "pidusage": "2.0.17",
     "pidtree": "0.3.0",
     "rxjs": "6.3.3",
-    "tree-kill": "^1.2.0"
+    "tree-kill": "^1.2.2"
   }
 }

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -42,7 +42,7 @@
     "style-loader": "0.23.1",
     "stylus": "0.54.5",
     "stylus-loader": "3.0.2",
-    "tree-kill": "1.2.1",
+    "tree-kill": "1.2.2",
     "terser-webpack-plugin": "1.2.2",
     "webpack": "4.29.0",
     "webpack-dev-middleware": "3.5.1",

--- a/packages/ngtools/webpack/package.json
+++ b/packages/ngtools/webpack/package.json
@@ -24,7 +24,7 @@
     "@angular-devkit/core": "0.0.0",
     "enhanced-resolve": "4.1.0",
     "rxjs": "6.3.3",
-    "tree-kill": "1.2.1",
+    "tree-kill": "1.2.2",
     "webpack-sources": "1.3.0"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9925,15 +9925,10 @@ tough-cookie@~2.4.3:
     psl "^1.1.24"
     punycode "^1.4.1"
 
-tree-kill@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.1.tgz#5398f374e2f292b9dcc7b2e71e30a5c3bb6c743a"
-  integrity sha512-4hjqbObwlh2dLyW4tcz0Ymw0ggoaVDMveUB9w8kFSQScdRLo0gxO9J7WFcUBo+W3C1TLdFIEwNOWebgZZ0RH9Q==
-
-tree-kill@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.0.tgz#5846786237b4239014f05db156b643212d4c6f36"
-  integrity sha512-DlX6dR0lOIRDFxI0mjL9IYg6OTncLm/Zt+JiBhE5OlFcAR8yc9S7FFXU9so0oda47frdM/JFsk7UjNt9vscKcg==
+tree-kill@1.2.2, tree-kill@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
+  integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
 
 treeify@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
…2.2 for 7.3.x

Backported to 7.3.x as supposed by
https://github.com/angular/angular-cli/issues/16629#issuecomment-585905350