### PR TITLE
fix(@ngtools/webpack): disable ngcc async under Bazel

### DIFF
--- a/packages/ngtools/webpack/src/ngcc_processor.ts
+++ b/packages/ngtools/webpack/src/ngcc_processor.ts
@@ -52,18 +52,19 @@ export class NgccProcessor {
 
   /** Process the entire node modules tree. */
   process() {
-    const timeLabel = 'NgccProcessor.process';
-    time(timeLabel);
-
-    const corePackage = this.tryResolvePackage('@angular/core', this._nodeModulesDirectory);
-
-    // If the package.json is read only we should skip calling NGCC.
-    // With Bazel when running under sandbox the filesystem is read-only.
-    if (corePackage && isReadOnlyFile(corePackage)) {
-      timeEnd(timeLabel);
-
+    // Under Bazel when running in sandbox mode parts of the filesystem is read-only.
+    if (process.env.BAZEL_TARGET) {
       return;
     }
+
+    // Skip if node_modules are read-only
+    const corePackage = this.tryResolvePackage('@angular/core', this._nodeModulesDirectory);
+    if (corePackage && isReadOnlyFile(corePackage)) {
+      return;
+    }
+
+    const timeLabel = 'NgccProcessor.process';
+    time(timeLabel);
 
     // We spawn instead of using the API because:
     // - NGCC Async uses clustering which is problematic when used via the API which means


### PR DESCRIPTION
Under Bazel some dependencies might be readonly we shouldn't run NGCC async version because we are unable to verify which modules are read-only and which not.