### PR TITLE
style(@schematics/angular): prevent adding redundant whitespace in ge…

### DIFF
--- a/packages/schematics/angular/workspace/files/angular.json.template
+++ b/packages/schematics/angular/workspace/files/angular.json.template
@@ -1,6 +1,6 @@
 {
   "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
-  "version": 1, <% if (packageManager) { %>
+  "version": 1,<% if (packageManager) { %>
   "cli": {
     "packageManager": "<%= packageManager %>"
   },<% } %>


### PR DESCRIPTION
…nerated angular.json file

Previously "ng new" was generating angular.json file containing redundant whitespace after "version" property.
When file was edited some IDEs automatically removed this whitespace making additional change in diff.
If "packageManager" option is used, whitespace is still present.