### PR TITLE
fix(@angular-devkit/build-angular): reduce fast sourcemap threshold

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/process-bundle.ts
+++ b/packages/angular_devkit/build_angular/src/utils/process-bundle.ts
@@ -29,8 +29,8 @@ import { I18nOptions } from './i18n-options';
 const cacache = require('cacache');
 const deserialize = ((v8 as unknown) as { deserialize(buffer: Buffer): unknown }).deserialize;
 
-// If code size is larger than 1MB, consider lower fidelity but faster sourcemap merge
-const FAST_SOURCEMAP_THRESHOLD = 1024 * 1024;
+// If code size is larger than 500KB, consider lower fidelity but faster sourcemap merge
+const FAST_SOURCEMAP_THRESHOLD = 500 * 1024;
 
 export interface ProcessBundleOptions {
   filename: string;


### PR DESCRIPTION
High fidelity sourcemap processing can be expensive for larger bundle sizes.  This reduces the threshold to the original 500KB value to improve performance.