### PR TITLE
fix(@schematics/angular): remove extra comma when inlineStyle is on

### DIFF
--- a/packages/schematics/angular/component/files/__name@dasherize@if-flat__/__name@dasherize__.__type@dasherize__.ts.template
+++ b/packages/schematics/angular/component/files/__name@dasherize@if-flat__/__name@dasherize__.__type@dasherize__.ts.template
@@ -14,7 +14,7 @@ import { Component, OnInit<% if(!!viewEncapsulation) { %>, ViewEncapsulation<% }
         display: block;
       }
     `<% } %>
-  ],<% } else { %>
+  ]<% } else { %>
   styleUrls: ['./<%= dasherize(name) %><%= type ? '.' + dasherize(type): '' %>.<%= style %>']<% } %><% if(!!viewEncapsulation) { %>,
   encapsulation: ViewEncapsulation.<%= viewEncapsulation %><% } if (changeDetection !== 'Default') { %>,
   changeDetection: ChangeDetectionStrategy.<%= changeDetection %><% } %>


### PR DESCRIPTION
When generating a new component, if `inlineStyle` and either
`viewEncapsulation` or `changeDetection` flag are provided, there is an
extra comma after `styles: [],,` causing the component to bug out.

- With `ChangeDetection`

```typescript
@Component({
  selector: 'app-test-two',
  templateUrl: './test-two.component.html',
  styles: [
  ],, // <-- extra comma
  changeDetection: ChangeDetectionStrategy.OnPush
})
export class TestTwoComponent implements OnInit {

  constructor() { }

  ngOnInit(): void {
  }

}
```

- With both `ViewEncapsulation` and `ChangeDetection`

```typescript
import { Component, OnInit, ViewEncapsulation, ChangeDetectionStrategy } from '@angular/core';

@Component({
  selector: 'app-test-three',
  templateUrl: './test-three.component.html',
  styles: [
  ],, // <-- extra comma
  encapsulation: ViewEncapsulation.None,
  changeDetection: ChangeDetectionStrategy.OnPush
})
export class TestThreeComponent implements OnInit {

  constructor() { }

  ngOnInit(): void {
  }

}
```