### PR TITLE
fix(@angular-devkit/schematics-cli): replace deprecated runSchematic

### DIFF
--- a/packages/schematics/schematics/blank/schematic-files/src/__name@dasherize__/index_spec.ts.template
+++ b/packages/schematics/schematics/blank/schematic-files/src/__name@dasherize__/index_spec.ts.template
@@ -6,10 +6,10 @@ import * as path from 'path';
 const collectionPath = path.join(__dirname, '../collection.json');
 
 
-describe('<%= dasherize(name) %>', () => {
+describe('<%= dasherize(name) %>', async () => {
   it('works', () => {
     const runner = new SchematicTestRunner('schematics', collectionPath);
-    const tree = runner.runSchematic('<%= dasherize(name) %>', {}, Tree.empty());
+    const tree = await runner.runSchematicAsync('<%= dasherize(name) %>', {}, Tree.empty());
 
     expect(tree.files).toEqual([]);
   });

--- a/packages/schematics/schematics/blank/schematic-files/src/__name@dasherize__/index_spec.ts.template
+++ b/packages/schematics/schematics/blank/schematic-files/src/__name@dasherize__/index_spec.ts.template
@@ -6,11 +6,13 @@ import * as path from 'path';
 const collectionPath = path.join(__dirname, '../collection.json');
 
 
-describe('<%= dasherize(name) %>', async () => {
-  it('works', () => {
+describe('<%= dasherize(name) %>', () => {
+  it('works', async () => {
     const runner = new SchematicTestRunner('schematics', collectionPath);
     const tree = await runner.runSchematicAsync('<%= dasherize(name) %>', {}, Tree.empty());
 
-    expect(tree.files).toEqual([]);
+    tree.subscribe((testTree: UnitTestTree) => {
+      expect(testTree.files).toEqual([]);
+    });
   });
 });


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)

## What is the current behavior?

The `angular-devkit/schematics-cli` blank schematic default spec file include a deprecated function `runSchematic` as stated in the docs :

```typescript
/**
     * @deprecated Since v8.0.0 - Use {@link SchematicTestRunner.runSchematicAsync} instead.
     * All schematics can potentially be async.
     * This synchronous variant will fail if the schematic, any of its rules, or any schematics
     * it calls are async.
     */
    runSchematic<SchematicSchemaT>(schematicName: string, opts?: SchematicSchemaT, tree?: Tree): UnitTestTree;
```

## What is the new behavior?

The function `runSchematic` is replaced by `runSchematicAsync` into the generated spec file and the callback of the test is now async : 

```typescript
const tree = await runner.runSchematicAsync('<%= dasherize(name) %>', {}, Tree.empty());
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No