### PR TITLE
fix(@angular/cli):  allow configuration options in `ng deploy`

### DIFF
--- a/packages/angular/cli/commands/deploy.json
+++ b/packages/angular/cli/commands/deploy.json
@@ -20,6 +20,13 @@
           }
         }
       },
+      "configuration": {
+        "description": "A named build target, as specified in the \"configurations\" section of angular.json.\nEach named target is accompanied by a configuration of option defaults for that target.",
+        "type": "string",
+        "aliases": [
+          "c"
+        ]
+      },
       "required": [
       ]
     },


### PR DESCRIPTION
fix(@angular/cli):  allow configuration option in `ng deploy`

Previously we only allowed `--project` and `--help` as a valid options. With this change we also allow `--configuration`

Fixes #17332