### PR TITLE
Log stack trace on error

### DIFF
--- a/packages/angular/cli/commands/analytics-impl.ts
+++ b/packages/angular/cli/commands/analytics-impl.ts
@@ -87,6 +87,9 @@ export class AnalyticsCommand extends Command<AnalyticsCommandSchema> {
       }
     } catch (err) {
       this.logger.fatal(err.message);
+      if (err.stack) {
+        this.logger.fatal(err.stack);
+      }
 
       return 1;
     }

--- a/packages/angular/cli/models/schematic-command.ts
+++ b/packages/angular/cli/models/schematic-command.ts
@@ -554,6 +554,9 @@ export abstract class SchematicCommand<
               this.logger.fatal(`An error occured:\n${err.message}\n${err.stack}`);
             } else {
               this.logger.fatal(err.message);
+              if (err.stack) {
+                this.logger.fatal(err.stack);
+              }
             }
 
             resolve(1);


### PR DESCRIPTION
As it's done on lib/cli/index.js, very useful in case of errors as the message is almost never sufficient.