### PR TITLE
feat(@schematics/angular): enable lazy loading on the server for new projects

### DIFF
--- a/packages/angular_devkit/build_angular/src/server/schema.json
+++ b/packages/angular_devkit/build_angular/src/server/schema.json
@@ -213,8 +213,7 @@
     "namedChunks": {
       "type": "boolean",
       "description": "Use file name for lazy loaded chunks.",
-      "default": true,
-      "x-deprecated": "Since version 9. This option has no effect on server platform."
+      "default": true
     },
     "bundleDependencies": {
       "description": "Which external dependencies to bundle into the bundle. By default, all of node_modules will be bundled.",

--- a/packages/schematics/angular/universal/files/root/__tsconfigFileName__.json.template
+++ b/packages/schematics/angular/universal/files/root/__tsconfigFileName__.json.template
@@ -2,7 +2,6 @@
   "extends": "./<%= tsConfigExtends %>",
   "compilerOptions": {
     "outDir": "<%= outDir %>-server",
-    "module": "commonjs",
     "types": [
       "node"
     ]

--- a/packages/schematics/angular/universal/index_spec.ts
+++ b/packages/schematics/angular/universal/index_spec.ts
@@ -91,7 +91,6 @@ describe('Universal Schematic', () => {
       extends: './tsconfig.app.json',
       compilerOptions: {
         outDir: './out-tsc/app-server',
-        module: 'commonjs',
         types: ['node'],
       },
       files: [
@@ -116,7 +115,6 @@ describe('Universal Schematic', () => {
       extends: './tsconfig.app.json',
       compilerOptions: {
         outDir: '../../out-tsc/app-server',
-        module: 'commonjs',
         types: ['node'],
       },
       files: [

--- a/tests/angular_devkit/build_angular/hello-world-app-ve/src/tsconfig.server.json
+++ b/tests/angular_devkit/build_angular/hello-world-app-ve/src/tsconfig.server.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.app.json",
   "compilerOptions": {
     "outDir": "../dist-server",
-    "module": "commonjs",
     "types": []
   },
   "files": [

--- a/tests/angular_devkit/build_angular/hello-world-app/src/tsconfig.server.json
+++ b/tests/angular_devkit/build_angular/hello-world-app/src/tsconfig.server.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "outDir": "../dist-server",
     "baseUrl": "./",
-    "module": "commonjs",
     "types": []
   },
   "files": [


### PR DESCRIPTION


With this change, lazy-loading on the server becomes enabled out of the box for new projects. This is because webpack will only split ES6 imports into separate chunks. However when using commonjs all lazy loaded paths will be concatenated into the main.js file.