### PR TITLE
fix(@angular-devkit/build-optimizer): use TypeScript 3.6

### DIFF
--- a/packages/angular_devkit/build_optimizer/package.json
+++ b/packages/angular_devkit/build_optimizer/package.json
@@ -12,7 +12,7 @@
     "loader-utils": "2.0.0",
     "source-map": "0.7.3",
     "tslib": "1.11.1",
-    "typescript": "3.8.3",
+    "typescript": "3.6.5",
     "webpack-sources": "1.4.3"
   }
 }

--- a/packages/angular_devkit/build_optimizer/src/transforms/scrub-file.ts
+++ b/packages/angular_devkit/build_optimizer/src/transforms/scrub-file.ts
@@ -594,7 +594,7 @@ function isTslibHelper(
   checker: ts.TypeChecker,
 ) {
 
-  let callExprIdent = callExpr.expression as ts.Identifier | ts.PrivateIdentifier;
+  let callExprIdent = callExpr.expression as ts.Identifier;
 
   if (callExpr.expression.kind !== ts.SyntaxKind.Identifier) {
     if (callExpr.expression.kind === ts.SyntaxKind.PropertyAccessExpression) {

--- a/tests/legacy-cli/e2e/ng-snapshot/package.json
+++ b/tests/legacy-cli/e2e/ng-snapshot/package.json
@@ -12,6 +12,7 @@
     "@angular/language-service": "github:angular/language-service-builds#e4c45a027958642903873913bdeb5a321b1a2220",
     "@angular/localize": "github:angular/localize-builds#00aca0caa37113b01dd270c31fcb1c3009807539",
     "@angular/material": "github:angular/material2-builds#261ff75b8acdbfda3d69c65a30898df029816f32",
+    "@angular/material-moment-adapter": "github:angular/material-moment-adapter-builds#93f405e88f0360127bf2419941ec133dac84b4a5",
     "@angular/platform-browser": "github:angular/platform-browser-builds#2f6d4dd67601a7589783a226b8145837dd3c963c",
     "@angular/platform-browser-dynamic": "github:angular/platform-browser-dynamic-builds#609599de331caf8bc05f6e522823c2f07162772d",
     "@angular/platform-server": "github:angular/platform-server-builds#f4b83463f893b894a9984446782086f9bde8b240",

--- a/tests/legacy-cli/e2e/tests/build/material.ts
+++ b/tests/legacy-cli/e2e/tests/build/material.ts
@@ -1,26 +1,74 @@
 import { getGlobalVariable } from '../../utils/env';
+import { replaceInFile } from '../../utils/fs';
 import { ng, silentNpm } from '../../utils/process';
 import { updateJsonFile } from '../../utils/project';
 
 const snapshots = require('../../ng-snapshot/package.json');
 
 export default async function () {
-    await ng('add', '@angular/material');
+  await ng('add', '@angular/material');
 
-    const isSnapshotBuild = getGlobalVariable('argv')['ng-snapshots'];
-    if (isSnapshotBuild) {
-        await updateJsonFile('package.json', packageJson => {
-            const dependencies = packageJson['dependencies'];
-            // Angular material adds dependencies on other Angular packages
-            // Iterate over all of the packages to update them to the snapshot version.
-            for (const [name, version] of Object.entries(snapshots.dependencies)) {
-                if (name in dependencies) {
-                    dependencies[name] = version;
-                }
-            }
-        });
-    }
+  const isSnapshotBuild = getGlobalVariable('argv')['ng-snapshots'];
+  if (isSnapshotBuild) {
+    await updateJsonFile('package.json', (packageJson) => {
+      const dependencies = packageJson['dependencies'];
+      // Angular material adds dependencies on other Angular packages
+      // Iterate over all of the packages to update them to the snapshot version.
+      for (const [name, version] of Object.entries(snapshots.dependencies)) {
+        if (name in dependencies) {
+          dependencies[name] = version;
+        }
+      }
+
+      dependencies['@angular/material-moment-adapter'] =
+        snapshots.dependencies['@angular/material-moment-adapter'];
+    });
 
     await silentNpm('install');
-    await ng('build', '--prod');
+  } else {
+    await silentNpm('install', '@angular/material-moment-adapter');
+  }
+
+  await silentNpm('install', 'moment');
+
+  await ng('build', '--prod');
+
+  // Ensure moment adapter works (uses unique importing mechanism for moment)
+  // Issue: https://github.com/angular/angular-cli/issues/17320
+  await replaceInFile(
+    'src/app/app.module.ts',
+    `import { AppComponent } from './app.component';`,
+    `
+    import { AppComponent } from './app.component';
+    import {
+      MomentDateAdapter,
+      MAT_MOMENT_DATE_FORMATS
+    } from '@angular/material-moment-adapter';
+    import {
+      DateAdapter,
+      MAT_DATE_LOCALE,
+      MAT_DATE_FORMATS
+    } from '@angular/material/core';
+  `,
+  );
+
+  await replaceInFile(
+    'src/app/app.module.ts',
+    `providers: []`,
+    `
+    providers: [
+      {
+        provide: DateAdapter,
+        useClass: MomentDateAdapter,
+        deps: [MAT_DATE_LOCALE]
+      },
+      {
+        provide: MAT_DATE_FORMATS,
+        useValue: MAT_MOMENT_DATE_FORMATS
+      }
+    ]
+  `,
+  );
+
+  await ng('e2e', '--prod');
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11553,6 +11553,11 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
+typescript@3.6.5:
+  version "3.6.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.5.tgz#dae20114a7b4ff4bd642db9c8c699f2953e8bbdb"
+  integrity sha512-BEjlc0Z06ORZKbtcxGrIvvwYs5hAnuo6TKdNFL55frVDlB+na3z5bsLhFaIxmT+dPWgBIjMo6aNnTOgHHmHgiQ==
+
 typescript@3.8.3:
   version "3.8.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"


### PR DESCRIPTION
When used within the build optimizer, TypeScript 3.8 will consider certain imports to be unreferenced and errantly remove them even though they are used within the module.  This results in runtime errors during application load.  TypeScript 3.7 cannot be used due to it causing a build time error when used within the build optimizer.  The build optimizer uses an independent version of TypeScript which allows it to use TypeScript 3.6 while applications continue to use TypeScript 3.7 or 3.8 to build the actual application.

Fixes: #17320