### PR TITLE
ci: disable separate renovate PRs for devDependencies and dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -85,7 +85,8 @@
         "^@bazel\/.*",
         "^build_bazel.*",
         "^@angular\/.*"
-      ]
+      ],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
In most cases, this setting up creating more PRs instead of reducing them. This is because if a depedency is listed as both a `devDependencies` and `dependencies`, Renovate will create 2 PRs;

Example: https://github.com/angular/angular-cli/pull/17380 and https://github.com/angular/angular-cli/pull/17379

This will happen more often now when adding Bazel integration tests see: https://github.com/angular/angular-cli/pull/17304#discussion_r400840301