### PR TITLE
fix(@angular/pwa): add purpose any to manifest icons

### DIFF
--- a/packages/angular/pwa/pwa/files/root/manifest.webmanifest
+++ b/packages/angular/pwa/pwa/files/root/manifest.webmanifest
@@ -11,49 +11,49 @@
       "src": "assets/icons/icon-72x72.png",
       "sizes": "72x72",
       "type": "image/png",
-      "purpose": "maskable"
+      "purpose": "maskable any"
     },
     {
       "src": "assets/icons/icon-96x96.png",
       "sizes": "96x96",
       "type": "image/png",
-      "purpose": "maskable"
+      "purpose": "maskable any"
     },
     {
       "src": "assets/icons/icon-128x128.png",
       "sizes": "128x128",
       "type": "image/png",
-      "purpose": "maskable"
+      "purpose": "maskable any"
     },
     {
       "src": "assets/icons/icon-144x144.png",
       "sizes": "144x144",
       "type": "image/png",
-      "purpose": "maskable"
+      "purpose": "maskable any"
     },
     {
       "src": "assets/icons/icon-152x152.png",
       "sizes": "152x152",
       "type": "image/png",
-      "purpose": "maskable"
+      "purpose": "maskable any"
     },
     {
       "src": "assets/icons/icon-192x192.png",
       "sizes": "192x192",
       "type": "image/png",
-      "purpose": "maskable"
+      "purpose": "maskable any"
     },
     {
       "src": "assets/icons/icon-384x384.png",
       "sizes": "384x384",
       "type": "image/png",
-      "purpose": "maskable"
+      "purpose": "maskable any"
     },
     {
       "src": "assets/icons/icon-512x512.png",
       "sizes": "512x512",
       "type": "image/png",
-      "purpose": "maskable"
+      "purpose": "maskable any"
     }
   ]
 }


### PR DESCRIPTION
The `purpose` property defines the purpose of an icon, for example if the icon is intended to serve some special purpose in the context of the host OS (i.e., for better integration).

`Purpose` can have one or more of the following values, separated by spaces:

- `badge`: A user agent can present this icon where space constraints and/or color requirements differ from those of the application icon.
- `maskable`: The image is designed with icon masks and safe zone in mind, such that any part of the image outside the safe zone can safely be ignored and masked away by the user agent.
- `any`: The user agent is free to display the icon in any context (this is the default value).

Closes #17384