### PR TITLE
fix(@angular-devkiit/build-angular): avoid overwriting localize sourcemaps

### DIFF
--- a/packages/angular_devkit/build_angular/src/browser/index.ts
+++ b/packages/angular_devkit/build_angular/src/browser/index.ts
@@ -497,6 +497,9 @@ export function buildWebpackBrowser(
                         setLocale: result.name === mainChunkId,
                       });
                       processedFiles.add(result.original.filename);
+                      if (result.original.map) {
+                        processedFiles.add(result.original.map.filename);
+                      }
                     }
                     if (result.downlevel) {
                       inlineActions.push({
@@ -511,6 +514,9 @@ export function buildWebpackBrowser(
                         setLocale: result.name === mainChunkId,
                       });
                       processedFiles.add(result.downlevel.filename);
+                      if (result.downlevel.map) {
+                        processedFiles.add(result.downlevel.map.filename);
+                      }
                     }
                   }
 


### PR DESCRIPTION
All non-processed files are copied from the temporary location during localization.  Previously original sourcemap files were not marked as processed.