### PR TITLE
build: version from git tag which consists two or more digits

### DIFF
--- a/lib/packages.ts
+++ b/lib/packages.ts
@@ -164,7 +164,7 @@ function _getVersionFromGit(experimental: boolean): string {
   }
 
   const hasLocalChanges = _exec(`git status --porcelain`) != '';
-  const scmVersionTagRaw = _exec(`git describe --match v[0-9].[0-9].[0-9]* --abbrev=7 --tags`)
+  const scmVersionTagRaw = _exec(`git describe --match v[0-9]*.[0-9]*.[0-9]* --abbrev=7 --tags`)
     .slice(1);
   stableVersion = scmVersionTagRaw.replace(/-([0-9]+)-g/, '+$1.');
   if (hasLocalChanges) {


### PR DESCRIPTION
Currently, we can't publish v10 because the `--match` pattern in describe can't match the tag `v10.0.0`. The new glob has the following semantics:

```
v[0-9]*.[0-9]*.[0-9]*
# start with a "v" and a number
# followed by 0 or more characters
# followed by a "." and a number
# followed by 0 or more characters
# followed by a "." and a number
# followed by 0 or more characters
```

Couldn't make it stricter because didn't find an easy way to enable extglobs for git for everyone.