### PR TITLE
refactor(@schematics/angular): remove deprecated guard `spec` option

### DIFF
--- a/packages/schematics/angular/guard/index.ts
+++ b/packages/schematics/angular/guard/index.ts
@@ -48,9 +48,6 @@ export default function (options: GuardOptions): Rule {
     options.name = parsedPath.name;
     options.path = parsedPath.path;
 
-    // todo remove these when we remove the deprecations
-    options.skipTests = options.skipTests || !options.spec;
-
     const templateSource = apply(url('./files'), [
       options.skipTests ? filter(path => !path.endsWith('.spec.ts.template')) : noop(),
       applyTemplates({

--- a/packages/schematics/angular/guard/schema.json
+++ b/packages/schematics/angular/guard/schema.json
@@ -14,12 +14,6 @@
       },
       "x-prompt": "What name would you like to use for the guard?"
     },
-    "spec": {
-      "type": "boolean",
-      "description": "When true (the default), generates a  \"spec.ts\" test file for the new guard.",
-      "default": true,
-      "x-deprecated": "Use \"skipTests\" instead."
-    },
     "skipTests": {
       "type": "boolean",
       "description": "When true, does not create \"spec.ts\" test files for the new guard.",

--- a/packages/schematics/angular/migrations/migration-collection.json
+++ b/packages/schematics/angular/migrations/migration-collection.json
@@ -74,6 +74,11 @@
       "version": "10.0.0-beta.2",
       "factory": "./update-10/remove-es5-browser-support",
       "description": "Remove deprecated 'es5BrowserSupport' browser builder option. The inclusion for ES5 polyfills will be determined from the browsers listed in the browserslist configuration."
+    },
+    "schematic-options-10": {
+      "version": "10.0.0-beta.2",
+      "factory": "./update-9/schematic-options",
+      "description": "Replace deprecated 'styleext' and 'spec' Angular schematic options."
     }
   }
 }


### PR DESCRIPTION
BREAKING CHANGE
Deprecated guard schematic option `spec` has been removed. Please use `skipTests` instead.