### PR TITLE
fix(@angular-devkit/core): workspace reader spread/rest operator usage with falsy values

### DIFF
--- a/packages/angular_devkit/core/src/workspace/json/reader_spec.ts
+++ b/packages/angular_devkit/core/src/workspace/json/reader_spec.ts
@@ -86,6 +86,13 @@ describe('readJsonWorkpace Parsing', () => {
     );
   });
 
+  it(`doesn't remove falsy values when using the spread operator`, async () => {
+    const host = createTestHost(representativeFile);
+    const workspace = await readJsonWorkspace('', host);
+    const prodConfig = workspace.projects.get('my-app')!.targets.get('build')!.configurations!.production!;
+    expect({ ...prodConfig }).toEqual(prodConfig);
+  });
+
   it('parses extensions only into extensions object', async () => {
     const host = createTestHost(representativeFile);
 

--- a/packages/angular_devkit/core/src/workspace/json/utilities.ts
+++ b/packages/angular_devkit/core/src/workspace/json/utilities.ts
@@ -148,7 +148,7 @@ function create(
       const propertyPath = path + '/' + escapeKey(p);
       const cacheEntry = cache.get(propertyPath);
       if (cacheEntry) {
-        if (cacheEntry.value) {
+        if (cacheEntry.value !== undefined) {
           return createPropertyDescriptor(cacheEntry.value);
         }
 


### PR DESCRIPTION


Spread and Rest uses `[[GetOwnProperty]]`. Previously, properties with falsy values were being removed when using the spread operator due to an incorrect check.

https://tc39.es/proposal-object-rest-spread/#AbstractOperations-CopyDataProperties

Fixes #17021