### PR TITLE
 ci: remove circle ci cache fallback

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,14 +12,10 @@ version: 2.1
 # Variables
 
 ## IMPORTANT
-# If you change the cache key prefix, also sync the fallback_cache_key fallback to match.
-# Keep the static part of the cache key as prefix to enable correct fallbacks.
 # Windows needs its own cache key because binaries in node_modules are different.
 # See https://circleci.com/docs/2.0/caching/#restoring-cache for how prefixes work in CircleCI.
-var_1: &cache_key angular_devkit-0.12.0-{{ checksum "yarn.lock" }}
-var_2: &cache_key_fallback angular_devkit-0.12.0
-var_1_win: &cache_key_win angular_devkit-win-0.12.0-{{ checksum "yarn.lock" }}
-var_2_win: &cache_key_fallback_win angular_devkit-win-0.12.0
+var_1: &cache_key angular_devkit-12.9-{{ checksum "yarn.lock" }}
+var_1_win: &cache_key_win angular_devkit-win-12.9-{{ checksum "yarn.lock" }}
 var_3: &default_nodeversion "12.9"
 # Workspace initially persisted by the `setup` job, and then enhanced by `setup-and-build-win`.
 # https://circleci.com/docs/2.0/workflows/#using-workspaces-to-share-data-among-jobs
@@ -133,7 +129,6 @@ jobs:
       - restore_cache:
           keys:
             - *cache_key
-            - *cache_key_fallback
       - run: yarn install --frozen-lockfile
       - persist_to_workspace:
           root: *workspace_location
@@ -308,7 +303,6 @@ jobs:
       - restore_cache:
           keys:
             - *cache_key_win
-            - *cache_key_fallback_win
       - run: yarn install --frozen-lockfile
       - run: yarn build
       - save_cache:


### PR DESCRIPTION

Cache fallback can be useful in some cases, but in our case it is hindering the CI performance as the cache is growing everyday which results in slower CI times because of the restoring and saving phases.

A fresh cache size is about 450Mb, while currently with fallbacking enabled it has grown to 3.8Gb

Below are some timings taken were we see that having cache fallbacking is doesn't help CI times:

| Caching                   | Cache Size | Restore Cache | Yarn Install | Save Cache | Total Time Elapsed |
|---------------------------|------------|---------------|--------------|------------|--------------------|
| Cache w/ Fallback (Miss)  | 3.81Gb     | 2m 50s        | 30s          | 7m 20s     | 10m 40s            |
| Cache w/ Fallback (Hit)   | 3.81Gb      | 2m 50s        | 20s          | 0          | 3m 10s             |
| Cache wo/ Fallback (Miss) | 0          | 0             | 40s          | 30s        | 1m 10s              |
| Cache wo/ Fallback (Hit)  | 458mb      | 20s           | 20s          | 0          | 40s                |
