### PR TITLE
Fix example on README

### DIFF
--- a/packages/angular_devkit/core/README.md
+++ b/packages/angular_devkit/core/README.md
@@ -144,7 +144,7 @@ import { workspaces } from '@angular-devkit/core';
 
 async function demonstrate() {
     const host = workspaces.createWorkspaceHost(new NodeJsSyncHost());
-    const workspace = await workspaces.readWorkspace('path/to/workspace/directory/', host);
+    const { workspace } = await workspaces.readWorkspace('path/to/workspace/directory/', host);
 
     const project = workspace.projects.get('my-app');
     if (!project) {


### PR DESCRIPTION
The method `workspaces.readWorkspace()` returns an object containing the member `workspace`, and not the workspace itself directly.

Added destructuring to the assignment of `workspace`.