### PR TITLE
build: update to codelyzer@6.0.0-next.1

### DIFF
--- a/packages/schematics/angular/workspace/files/package.json.template
+++ b/packages/schematics/angular/workspace/files/package.json.template
@@ -30,7 +30,7 @@
     "@types/node": "^12.11.1",<% if (!minimal) { %>
     "@types/jasmine": "~3.5.0",
     "@types/jasminewd2": "~2.0.3",
-    "codelyzer": "^5.1.2",
+    "codelyzer": "^6.0.0-next.1",
     "jasmine-core": "~3.5.0",
     "jasmine-spec-reporter": "~5.0.0",
     "karma": "~5.0.0",


### PR DESCRIPTION
This version of codelyzer will not be broken after the removal of view engine from Angular's code base.