### PR TITLE
docs: remove `universal-project` options reference from app-shell docs

### DIFF
--- a/packages/schematics/angular/app-shell/app-shell-long.md
+++ b/packages/schematics/angular/app-shell/app-shell-long.md
@@ -7,7 +7,7 @@ Use this command with a routing app that is accompanied by a Universal server-si
 To create an app shell, use the following command.
 
 <code-example format="." language="bash">
- ng generate app-shell --client-project my-app --universal-project server-app
+ ng generate app-shell --client-project my-app
 </code-example>
 
 * `my-app` is the name of your client application

--- a/packages/schematics/angular/app-shell/app-shell-long.md
+++ b/packages/schematics/angular/app-shell/app-shell-long.md
@@ -7,7 +7,7 @@ Use this command with a routing app that is accompanied by a Universal server-si
 To create an app shell, use the following command.
 
 <code-example format="." language="bash">
- ng generate app-shell --client-project my-app
+ ng generate app-shell my-app
 </code-example>
 
 * `my-app` is the name of your client application


### PR DESCRIPTION
`universal-project` has been deprecated and has no effect. See: https://github.com/angular/angular-cli/blob/493aa74019104fe029e3527b519918a0ae6febf0/packages/schematics/angular/app-shell/schema.json#L19