### PR TITLE
fix(@angular-devkit/build-angular): disable inline svg optimizations

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/optimize-css-webpack-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/optimize-css-webpack-plugin.ts
@@ -77,7 +77,10 @@ export class OptimizeCssWebpackPlugin {
           }
 
           const cssNanoOptions: cssNano.CssNanoOptions = {
-            preset: 'default',
+            preset: ['default', {
+              // Disable SVG optimization, as this can cause optimizations which are not compatible in all browsers.
+              svgo: false,
+            }],
           };
 
           const postCssOptions: ProcessOptions = {


### PR DESCRIPTION
SVGO can cause optimizations which are not compatible in all browsers.

FIxes: #17564