### PR TITLE
Fix alphabetize imports

### DIFF
--- a/packages/schematics/angular/application/other-files/app.module.ts.template
+++ b/packages/schematics/angular/application/other-files/app.module.ts.template
@@ -1,5 +1,5 @@
-import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
 <% if (routing) { %>
 import { AppRoutingModule } from './app-routing.module';<% } %>
 import { AppComponent } from './app.component';

--- a/packages/schematics/angular/e2e/files/src/app.e2e-spec.ts.template
+++ b/packages/schematics/angular/e2e/files/src/app.e2e-spec.ts.template
@@ -1,5 +1,5 @@
-import { AppPage } from './app.po';
 import { browser, logging } from 'protractor';
+import { AppPage } from './app.po';
 
 describe('workspace-project App', () => {
   let page: AppPage;

--- a/packages/schematics/angular/module/files/__name@dasherize@if-flat__/__name@dasherize__-routing.module.ts.template
+++ b/packages/schematics/angular/module/files/__name@dasherize@if-flat__/__name@dasherize__-routing.module.ts.template
@@ -1,6 +1,5 @@
 import { NgModule } from '@angular/core';
-import { Routes, RouterModule } from '@angular/router';<% if (lazyRoute) { %>
-
+import { RouterModule, Routes } from '@angular/router';<% if (lazyRoute) { %>
 import { <%= classify(name) %>Component } from './<%= dasherize(name) %>.component';<% } %>
 
 const routes: Routes = [<% if (lazyRoute) { %>{ path: '', component: <%= classify(name) %>Component }<% } %>];


### PR DESCRIPTION
In this PR I've alphabetized some imports to avoid potential linting errors when generating files with angular-cli.

Also see:
https://palantir.github.io/tslint/rules/ordered-imports/