### PR TITLE
test: pin moment in e2e tests

### DIFF
--- a/tests/legacy-cli/e2e/tests/build/material.ts
+++ b/tests/legacy-cli/e2e/tests/build/material.ts
@@ -29,7 +29,7 @@ export default async function () {
     await silentNpm('install', '@angular/material-moment-adapter');
   }
 
-  await silentNpm('install', 'moment');
+  await silentNpm('install', 'moment@2.24.0');
 
   await ng('build', '--prod');
 

--- a/tests/legacy-cli/e2e/tests/misc/lazy-module.ts
+++ b/tests/legacy-cli/e2e/tests/misc/lazy-module.ts
@@ -1,5 +1,4 @@
 import {readdirSync} from 'fs';
-
 import {ng, silentNpm} from '../../utils/process';
 import {appendToFile, writeFile, prependToFile, replaceInFile} from '../../utils/fs';
 
@@ -53,7 +52,7 @@ export default function() {
       oldNumberOfFiles = currentNumberOfDistFiles;
     })
     // verify 'import *' syntax doesn't break lazy modules
-    .then(() => silentNpm('install', 'moment'))
+    .then(() => silentNpm('install', 'moment@2.24.0'))
     .then(() => appendToFile('src/app/app.component.ts', `
       import * as moment from 'moment';
       console.log(moment);


### PR DESCRIPTION
Moment 2.25.0 typings are broken and results in red ci, for the time being we use a previous version of moment

See: https://github.com/moment/moment/issues/5486