### PR TITLE
ci: disable ngcc async

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "postinstall": "yarn webdriver-update && yarn ngcc",
     "//webdriver-update-README": "ChromeDriver version must match Puppeteer Chromium version, see https://github.com/GoogleChrome/puppeteer/releases http://chromedriver.chromium.org/downloads",
     "webdriver-update": "webdriver-manager update --standalone false --gecko false --versions.chrome 81.0.4044.0",
-    "ngcc": "ngcc --properties es2015 browser module main --first-only --create-ivy-entry-points"
+    "ngcc": "ngcc --properties es2015 browser module main --first-only --create-ivy-entry-points --no-async"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Disable ngcc async mode, because the circle ci container is low on resources and causes worker failures when run in async.