### PR TITLE
refactor(@angular-devkit/build-angular): remove unused rxjs path mapping

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
@@ -349,17 +349,6 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
   const loaderNodeModules = findAllNodeModules(__dirname, projectRoot);
   loaderNodeModules.unshift('node_modules');
 
-  // Load rxjs path aliases.
-  // https://github.com/ReactiveX/rxjs/blob/master/doc/pipeable-operators.md#build-and-treeshaking
-  let alias = {};
-  try {
-    const rxjsPathMappingImport = wco.supportES2015
-      ? 'rxjs/_esm2015/path-mapping'
-      : 'rxjs/_esm5/path-mapping';
-    const rxPaths = require(require.resolve(rxjsPathMappingImport, { paths: [projectRoot] }));
-    alias = rxPaths();
-  } catch {}
-
   const extraMinimizers = [];
   if (stylesOptimization) {
     extraMinimizers.push(
@@ -488,7 +477,6 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
       extensions: ['.ts', '.tsx', '.mjs', '.js'],
       symlinks: !buildOptions.preserveSymlinks,
       modules: [wco.tsConfig.options.baseUrl || projectRoot, 'node_modules'],
-      alias,
       plugins: [PnpWebpackPlugin],
     },
     resolveLoader: {


### PR DESCRIPTION
This path mapping was used during the transition to rxjs 5 via the use of rxjs-compat package during the Angular 5.x timeframe.  Now that the minimum version is 6.x and this transition is complete, these mappings are no longer necessary.