### PR TITLE
refactor(@angular-devkit/schematics): remove deprecated sync test helpers

### DIFF
--- a/etc/api/angular_devkit/schematics/testing/index.d.ts
+++ b/etc/api/angular_devkit/schematics/testing/index.d.ts
@@ -5,9 +5,7 @@ export declare class SchematicTestRunner {
     constructor(_collectionName: string, collectionPath: string);
     callRule(rule: Rule, tree: Tree, parentContext?: Partial<SchematicContext>): Observable<Tree>;
     registerCollection(collectionName: string, collectionPath: string): void;
-    runExternalSchematic<SchematicSchemaT>(collectionName: string, schematicName: string, opts?: SchematicSchemaT, tree?: Tree): UnitTestTree;
     runExternalSchematicAsync<SchematicSchemaT>(collectionName: string, schematicName: string, opts?: SchematicSchemaT, tree?: Tree): Observable<UnitTestTree>;
-    runSchematic<SchematicSchemaT>(schematicName: string, opts?: SchematicSchemaT, tree?: Tree): UnitTestTree;
     runSchematicAsync<SchematicSchemaT>(schematicName: string, opts?: SchematicSchemaT, tree?: Tree): Observable<UnitTestTree>;
 }
 

--- a/packages/angular_devkit/schematics/testing/schematic-test-runner.ts
+++ b/packages/angular_devkit/schematics/testing/schematic-test-runner.ts
@@ -89,38 +89,6 @@ export class SchematicTestRunner {
       .pipe(map(tree => new UnitTestTree(tree)));
   }
 
-  /**
-   * @deprecated Since v8.0.0 - Use {@link SchematicTestRunner.runSchematicAsync} instead.
-   * All schematics can potentially be async.
-   * This synchronous variant will fail if the schematic, any of its rules, or any schematics
-   * it calls are async.
-   */
-  runSchematic<SchematicSchemaT>(
-    schematicName: string,
-    opts?: SchematicSchemaT,
-    tree?: Tree,
-  ): UnitTestTree {
-    const schematic = this._collection.createSchematic(schematicName, true);
-
-    let result: UnitTestTree | null = null;
-    let error;
-    const host = observableOf(tree || new HostTree);
-    this._engineHost.clearTasks();
-
-    schematic.call(opts || {}, host, { logger: this._logger })
-      .subscribe(t => result = new UnitTestTree(t), e => error = e);
-
-    if (error) {
-      throw error;
-    }
-
-    if (result === null) {
-      throw new Error('Schematic is async, please use runSchematicAsync');
-    }
-
-    return result;
-  }
-
   runExternalSchematicAsync<SchematicSchemaT>(
     collectionName: string,
     schematicName: string,
@@ -134,35 +102,6 @@ export class SchematicTestRunner {
 
     return schematic.call(opts || {}, host, { logger: this._logger })
       .pipe(map(tree => new UnitTestTree(tree)));
-  }
-
-  /**
-   * @deprecated Since v8.0.0 - Use {@link SchematicTestRunner.runExternalSchematicAsync} instead.
-   * All schematics can potentially be async.
-   * This synchronous variant will fail if the schematic, any of its rules, or any schematics
-   * it calls are async.
-   */
-  runExternalSchematic<SchematicSchemaT>(
-    collectionName: string,
-    schematicName: string,
-    opts?: SchematicSchemaT,
-    tree?: Tree,
-  ): UnitTestTree {
-    const externalCollection = this._engine.createCollection(collectionName);
-    const schematic = externalCollection.createSchematic(schematicName, true);
-
-    let result: UnitTestTree | null = null;
-    const host = observableOf(tree || new HostTree);
-    this._engineHost.clearTasks();
-
-    schematic.call(opts || {}, host, { logger: this._logger })
-      .subscribe(t => result = new UnitTestTree(t));
-
-    if (result === null) {
-      throw new Error('Schematic is async, please use runSchematicAsync');
-    }
-
-    return result;
   }
 
   callRule(rule: Rule, tree: Tree, parentContext?: Partial<SchematicContext>): Observable<Tree> {

--- a/packages/schematics/angular/interceptor/index_spec.ts
+++ b/packages/schematics/angular/interceptor/index_spec.ts
@@ -36,7 +36,7 @@ describe('Interceptor Schematic', () => {
   };
   let appTree: UnitTestTree;
   beforeEach(async () => {
-    appTree = schematicRunner.runSchematic('workspace', workspaceOptions);
+    appTree = await schematicRunner.runSchematicAsync('workspace', workspaceOptions).toPromise();
     appTree = await schematicRunner.runSchematicAsync('application', appOptions, appTree).toPromise();
   });
 


### PR DESCRIPTION
BREAKING CHANGE
Deprecated `SchematicTestRunner.runSchematic` and  `SchematicTestRunner.runExternalSchematic` have been removed. Use `SchematicTestRunner.runSchematicAsync` or `SchematicTestRunner.runExternalSchematicAsync` instead.

Note: this change only effects direct `@angular-devkit/schematics` users and not the application developers.