### PR TITLE
fix(@angular-devkit/build-angular): downlevel and optimize locale data

### DIFF
--- a/tests/legacy-cli/e2e/tests/i18n/ivy-localize-dl-xliff2.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/ivy-localize-dl-xliff2.ts
@@ -41,6 +41,18 @@ export async function executeTest() {
     await expectFileToMatch(`${outputPath}/vendor-es5.js`, '.ng.common.locales');
     await expectFileToMatch(`${outputPath}/vendor-es2015.js`, '.ng.common.locales');
 
+    // Verify the locale data is browser compatible
+    await expectToFail(() => expectFileToMatch(`${outputPath}/vendor-es5.js`, /\bconst\b/));
+    await expectFileToMatch(`${outputPath}/vendor-es2015.js`, /\bconst\b/);
+
+    // Verify locale data comments are removed in production
+    await expectToFail(() =>
+      expectFileToMatch(`${outputPath}/vendor-es5.js`, '// See angular/tools/gulp-tasks/cldr/extract.js'),
+    );
+    await expectToFail(() =>
+      expectFileToMatch(`${outputPath}/vendor-es2015.js`, '// See angular/tools/gulp-tasks/cldr/extract.js'),
+    );
+
     // Execute Application E2E tests with dev server
     await ng('e2e', `--configuration=${lang}`, '--port=0');
 


### PR DESCRIPTION
Locale data is now transformed to be compatible with the ECMAScript level of the application bundles.  The locale data is also optimized to remove comments and unnecessary whitespace.

Fixes: #17497