### PR TITLE
feat(@schematics/angular): update compiler options target and module settings

### DIFF
--- a/integration/angular_cli/e2e/tsconfig.json
+++ b/integration/angular_cli/e2e/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "../out-tsc/e2e",
     "module": "commonjs",
-    "target": "es5",
+    "target": "es2018",
     "types": [
       "jasmine",
       "jasminewd2",

--- a/integration/angular_cli/tsconfig.json
+++ b/integration/angular_cli/tsconfig.json
@@ -7,10 +7,10 @@
     "declaration": false,
     "downlevelIteration": true,
     "experimentalDecorators": true,
-    "module": "esnext",
+    "module": "es2020",
     "moduleResolution": "node",
     "importHelpers": true,
-    "target": "es2015",
+    "target": "es2016",
     "lib": [
       "es2018",
       "dom"

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
@@ -193,7 +193,7 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
   if (profilingEnabled) {
     extraPlugins.push(
       new debug.ProfilingPlugin({
-        outputPath: path.resolve(root, `chrome-profiler-events${targetInFileName}.json`),
+        outputPath: path.resolve(root, 'chrome-profiler-events.json'),
       }),
     );
   }
@@ -302,7 +302,7 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
         apply(compiler: Compiler) {
           compiler.hooks.emit.tap('angular-cli-stats', compilation => {
             const data = JSON.stringify(compilation.getStats().toJson('verbose'));
-            compilation.assets[`stats${targetInFileName}.json`] = new RawSource(data);
+            compilation.assets['stats.json'] = new RawSource(data);
           });
         }
       })(),

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/bundle-calculator.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/bundle-calculator.ts
@@ -32,7 +32,8 @@ export enum ThresholdSeverity {
 }
 
 enum DifferentialBuildType {
-  ORIGINAL = 'es2015',
+  // FIXME: this should match the actual file suffix and not hardcoded.
+  ORIGINAL = 'es2016',
   DOWNLEVEL = 'es5',
 }
 

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/bundle-calculator_spec.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/bundle-calculator_spec.ts
@@ -126,7 +126,7 @@ describe('bundle-calculator', () => {
         {
           name: '0',
           original: {
-            filename: 'foo-es2015.js',
+            filename: 'foo-es2016.js',
             size: 1.25 * KB,
           },
           downlevel: {
@@ -141,7 +141,7 @@ describe('bundle-calculator', () => {
       expect(failures.length).toBe(2);
       expect(failures).toContain({
         severity: ThresholdSeverity.Error,
-        message: jasmine.stringMatching('Exceeded maximum budget for foo-es2015.'),
+        message: jasmine.stringMatching('Exceeded maximum budget for foo-es2016.'),
       });
       expect(failures).toContain({
         severity: ThresholdSeverity.Error,
@@ -170,7 +170,7 @@ describe('bundle-calculator', () => {
           name: '0',
           // Individual builds are under budget, but combined they are over.
           original: {
-            filename: 'foo-es2015.js',
+            filename: 'foo-es2016.js',
             size: 0.5 * KB,
           },
           downlevel: {
@@ -240,7 +240,7 @@ describe('bundle-calculator', () => {
           name: '0',
           // Individual builds are under budget, but combined they are over.
           original: {
-            filename: 'initial-es2015.js',
+            filename: 'initial-es2016.js',
             size: 1.25 * KB,
           },
           downlevel: {
@@ -255,7 +255,7 @@ describe('bundle-calculator', () => {
       expect(failures.length).toBe(2);
       expect(failures).toContain({
         severity: ThresholdSeverity.Error,
-        message: jasmine.stringMatching('Exceeded maximum budget for initial-es2015.'),
+        message: jasmine.stringMatching('Exceeded maximum budget for initial-es2016.'),
       });
       expect(failures).toContain({
         severity: ThresholdSeverity.Error,
@@ -283,7 +283,7 @@ describe('bundle-calculator', () => {
           name: '0',
           // Individual builds are under budget, but combined they are over.
           original: {
-            filename: 'initial-es2015.js',
+            filename: 'initial-es2016.js',
             size: 0.5 * KB,
           },
           downlevel: {

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/index-file/augment-index-html_spec.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/index-file/augment-index-html_spec.ts
@@ -51,10 +51,10 @@ describe('augment-index-html', () => {
 
   it(`should emit correct script tags when having 'module' and 'non-module' js`, async () => {
     const es2015JsFiles: FileInfo[] = [
-      { file: 'runtime-es2015.js', extension: '.js', name: 'main' },
-      { file: 'main-es2015.js', extension: '.js', name: 'main' },
-      { file: 'runtime-es2015.js', extension: '.js', name: 'polyfills' },
-      { file: 'polyfills-es2015.js', extension: '.js', name: 'polyfills' },
+      { file: 'runtime-es2016.js', extension: '.js', name: 'main' },
+      { file: 'main-es2016.js', extension: '.js', name: 'main' },
+      { file: 'runtime-es2016.js', extension: '.js', name: 'polyfills' },
+      { file: 'polyfills-es2016.js', extension: '.js', name: 'polyfills' },
     ];
 
     const es5JsFiles: FileInfo[] = [
@@ -82,11 +82,11 @@ describe('augment-index-html', () => {
           <link rel="stylesheet" href="styles.css">
         </head>
         <body>
-          <script src="runtime-es2015.js" type="module"></script>
-          <script src="polyfills-es2015.js" type="module"></script>
+          <script src="runtime-es2016.js" type="module"></script>
+          <script src="polyfills-es2016.js" type="module"></script>
           <script src="runtime-es5.js" nomodule defer></script>
           <script src="polyfills-es5.js" nomodule defer></script>
-          <script src="main-es2015.js" type="module"></script>
+          <script src="main-es2016.js" type="module"></script>
           <script src="main-es5.js" nomodule defer></script>
         </body>
       </html>
@@ -98,7 +98,7 @@ describe('augment-index-html', () => {
     async () => {
       const es2015JsFiles: FileInfo[] = [
         { file: 'scripts.js', extension: '.js', name: 'scripts' },
-        { file: 'main-es2015.js', extension: '.js', name: 'main' },
+        { file: 'main-es2016.js', extension: '.js', name: 'main' },
       ];
 
       const es5JsFiles: FileInfo[] = [
@@ -125,7 +125,7 @@ describe('augment-index-html', () => {
         </head>
         <body>
           <script src="scripts.js" defer></script>
-          <script src="main-es2015.js" type="module"></script>
+          <script src="main-es2016.js" type="module"></script>
           <script src="main-es5.js" nomodule defer></script>
         </body>
       </html>

--- a/packages/angular_devkit/build_angular/src/browser/specs/differential_loading_spec.ts
+++ b/packages/angular_devkit/build_angular/src/browser/specs/differential_loading_spec.ts
@@ -33,28 +33,28 @@ describe('Browser Builder with differential loading', () => {
       'favicon.ico',
       'index.html',
 
-      'main-es2015.js',
-      'main-es2015.js.map',
+      'main-es2016.js',
+      'main-es2016.js.map',
       'main-es5.js',
       'main-es5.js.map',
 
-      'polyfills-es2015.js',
-      'polyfills-es2015.js.map',
+      'polyfills-es2016.js',
+      'polyfills-es2016.js.map',
       'polyfills-es5.js',
       'polyfills-es5.js.map',
 
-      'runtime-es2015.js',
-      'runtime-es2015.js.map',
+      'runtime-es2016.js',
+      'runtime-es2016.js.map',
       'runtime-es5.js',
       'runtime-es5.js.map',
 
-      'styles-es2015.js',
-      'styles-es2015.js.map',
+      'styles-es2016.js',
+      'styles-es2016.js.map',
       'styles-es5.js',
       'styles-es5.js.map',
 
-      'vendor-es2015.js',
-      'vendor-es2015.js.map',
+      'vendor-es2016.js',
+      'vendor-es2016.js.map',
       'vendor-es5.js',
       'vendor-es5.js.map',
     ] as PathFragment[];
@@ -178,7 +178,7 @@ describe('Browser Builder with differential loading', () => {
       vendorChunk: false,
     });
     expect(await files['main-es5.js']).not.toContain('const ');
-    expect(await files['main-es2015.js']).toContain('const ');
+    expect(await files['main-es2016.js']).toContain('const ');
   });
 
   it('uses the right zone.js variant', async () => {
@@ -186,9 +186,9 @@ describe('Browser Builder with differential loading', () => {
     expect(await files['polyfills-es5.js']).toContain('zone.js/dist/zone-legacy');
     expect(await files['polyfills-es5.js']).toContain('registerElementPatch');
     expect(await files['polyfills-es5.js']).toContain('zone.js/dist/zone-evergreen');
-    expect(await files['polyfills-es2015.js']).toContain('zone.js/dist/zone-evergreen');
-    expect(await files['polyfills-es2015.js']).not.toContain('zone.js/dist/zone-legacy');
-    expect(await files['polyfills-es2015.js']).not.toContain('registerElementPatch');
+    expect(await files['polyfills-es2016.js']).toContain('zone.js/dist/zone-evergreen');
+    expect(await files['polyfills-es2016.js']).not.toContain('zone.js/dist/zone-legacy');
+    expect(await files['polyfills-es2016.js']).not.toContain('registerElementPatch');
   });
 
   it('adds `type="module"` when differential loading is needed', async () => {

--- a/packages/angular_devkit/build_angular/test/hello-world-app/e2e/tsconfig.e2e.json
+++ b/packages/angular_devkit/build_angular/test/hello-world-app/e2e/tsconfig.e2e.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "../out-tsc/e2e",
     "module": "commonjs",
-    "target": "es5",
+    "target": "es2018",
     "types": [
       "jasmine",
       "jasminewd2",

--- a/packages/angular_devkit/build_angular/test/hello-world-app/tsconfig.json
+++ b/packages/angular_devkit/build_angular/test/hello-world-app/tsconfig.json
@@ -9,8 +9,8 @@
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "target": "es2015",
-    "module": "esnext",
+    "target": "es2016",
+    "module": "es2020",
     "typeRoots": [
       "../node_modules/@types"
     ],

--- a/packages/angular_devkit/build_ng_packagr/test/ng-packaged/projects/lib/tsconfig.lib.json
+++ b/packages/angular_devkit/build_ng_packagr/test/ng-packaged/projects/lib/tsconfig.lib.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "target": "es2015",
+    "target": "es2016",
     "declaration": true,
     "inlineSources": true,
     "types": [],

--- a/packages/angular_devkit/build_ng_packagr/test/ng-packaged/tsconfig.json
+++ b/packages/angular_devkit/build_ng_packagr/test/ng-packaged/tsconfig.json
@@ -7,8 +7,8 @@
     "declaration": false,
     "moduleResolution": "node",
     "experimentalDecorators": true,
-    "target": "es2015",
-    "module": "esnext",
+    "target": "es2016",
+    "module": "es2020",
     "typeRoots": [
       "node_modules/@types"
     ],

--- a/packages/angular_devkit/build_webpack/test/angular-app/src/tsconfig.app.json
+++ b/packages/angular_devkit/build_webpack/test/angular-app/src/tsconfig.app.json
@@ -2,7 +2,7 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "outDir": "../out-tsc/app",
-    "module": "es2015",
+    "module": "es2020",
     "types": []
   },
   "exclude": [

--- a/packages/schematics/angular/e2e/files/tsconfig.json.template
+++ b/packages/schematics/angular/e2e/files/tsconfig.json.template
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "<%= relativePathToWorkspaceRoot %>/out-tsc/e2e",
     "module": "commonjs",
-    "target": "es5",
+    "target": "es2018",
     "types": [
       "jasmine",
       "jasminewd2",

--- a/packages/schematics/angular/migrations/migration-collection.json
+++ b/packages/schematics/angular/migrations/migration-collection.json
@@ -84,6 +84,11 @@
       "version": "10.0.0-beta.3",
       "factory": "./update-10/update-angular-config",
       "description": "Remove deprecated 'evalSourceMap', `profile`, 'skipAppShell' and 'vendorSourceMap' from 'angular.json'."
+    },
+    "update-module-and-target-compiler-options": {
+      "version": "10.0.0-next.3",
+      "factory": "./update-10/update-module-and-target-compiler-options",
+      "description": "Update 'module' and 'target' TypeScript compiler options."
     }
   }
 }

--- a/packages/schematics/angular/migrations/update-10/update-module-and-target-compiler-options.ts
+++ b/packages/schematics/angular/migrations/update-10/update-module-and-target-compiler-options.ts
@@ -1,0 +1,128 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { dirname, join, normalize } from '@angular-devkit/core';
+import { Rule, Tree } from '@angular-devkit/schematics';
+import { findPropertyInAstObject, removePropertyInAstObject } from '../../utility/json-utils';
+import { getWorkspace } from '../../utility/workspace';
+import { Builders } from '../../utility/workspace-models';
+import { readJsonFileAsAstObject } from '../update-9/utils';
+
+
+interface ModuleAndTargetReplamenent {
+  oldModule?: string;
+  newModule?: string | false;
+  oldTarget?: string;
+  newTarget?: string;
+}
+
+export default function (): Rule {
+  return async host => {
+    // Workspace level tsconfig
+    updateModuleAndTarget(host, 'tsconfig.json', {
+      oldModule: 'esnext',
+      newModule: 'es2020',
+      oldTarget: 'es2015',
+      newTarget: 'es2016',
+    });
+
+    const workspace = await getWorkspace(host);
+    // Find all tsconfig which are refereces used by builders
+    for (const [, project] of workspace.projects) {
+      for (const [, target] of project.targets) {
+        // E2E builder doesn't reference a tsconfig but it uses one found in the root folder.
+        if (target.builder === Builders.Protractor && typeof target.options?.protractorConfig === 'string') {
+          const tsConfigPath = join(dirname(normalize(target.options.protractorConfig)), 'tsconfig.json');
+
+          updateModuleAndTarget(host, tsConfigPath, {
+            oldTarget: 'es5',
+            newTarget: 'es2018',
+          });
+
+          continue;
+        }
+
+        // Update all other known CLI builders that use a tsconfig
+        const tsConfigs = [
+          target.options || {},
+          ...Object.values(target.configurations || {}),
+        ]
+          .filter(opt => typeof opt?.tsConfig === 'string')
+          .map(opt => (opt as { tsConfig: string }).tsConfig);
+
+        const uniqueTsConfigs = [...new Set(tsConfigs)];
+
+        if (uniqueTsConfigs.length < 1) {
+          continue;
+        }
+
+        switch (target.builder as Builders) {
+          case Builders.Server:
+            uniqueTsConfigs.forEach(p => {
+              updateModuleAndTarget(host, p, {
+                oldModule: 'commonjs',
+                // False will remove the module
+                // NB: For server we no longer use commonjs because it is bundled using webpack which has it's own module system.
+                // This ensures that lazy-loaded works on the server.
+                newModule: false,
+              });
+            });
+            break;
+          case Builders.Karma:
+          case Builders.Browser:
+          case Builders.NgPackagr:
+            uniqueTsConfigs.forEach(p => {
+              updateModuleAndTarget(host, p, {
+                oldModule: 'esnext',
+                newModule: 'es2020',
+                oldTarget: 'es2015',
+                newTarget: 'es2016',
+              });
+            });
+            break;
+        }
+      }
+    }
+  };
+}
+
+function updateModuleAndTarget(host: Tree, tsConfigPath: string, replacements: ModuleAndTargetReplamenent) {
+  const jsonAst = readJsonFileAsAstObject(host, tsConfigPath);
+  if (!jsonAst) {
+    return;
+  }
+
+  const compilerOptionsAst = findPropertyInAstObject(jsonAst, 'compilerOptions');
+  if (compilerOptionsAst?.kind !== 'object') {
+    return;
+  }
+
+  const { oldTarget, newTarget, newModule, oldModule } = replacements;
+
+  const recorder = host.beginUpdate(tsConfigPath);
+  if (newTarget) {
+    const targetAst = findPropertyInAstObject(compilerOptionsAst, 'target');
+    if (targetAst?.kind === 'string' && oldTarget === targetAst.value.toLowerCase()) {
+      const offset = targetAst.start.offset + 1;
+      recorder.remove(offset, targetAst.value.length);
+      recorder.insertLeft(offset, newTarget);
+    }
+  }
+
+  if (newModule === false) {
+    removePropertyInAstObject(recorder, compilerOptionsAst, 'module');
+  } else if (newModule) {
+    const moduleAst = findPropertyInAstObject(compilerOptionsAst, 'module');
+    if (moduleAst?.kind === 'string' && oldModule === moduleAst.value.toLowerCase()) {
+      const offset = moduleAst.start.offset + 1;
+      recorder.remove(offset, moduleAst.value.length);
+      recorder.insertLeft(offset, newModule);
+    }
+  }
+
+  host.commitUpdate(recorder);
+}

--- a/packages/schematics/angular/migrations/update-10/update-module-and-target-compiler-options_spec.ts
+++ b/packages/schematics/angular/migrations/update-10/update-module-and-target-compiler-options_spec.ts
@@ -1,0 +1,144 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { JsonParseMode, parseJson } from '@angular-devkit/core';
+import { EmptyTree } from '@angular-devkit/schematics';
+import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';
+import { Builders, ProjectType, WorkspaceSchema } from '../../utility/workspace-models';
+
+describe('Migration to update target and module compiler options', () => {
+  const schematicName = 'update-module-and-target-compiler-options';
+
+  const schematicRunner = new SchematicTestRunner(
+    'migrations',
+    require.resolve('../migration-collection.json'),
+  );
+
+  function createJsonFile(tree: UnitTestTree, filePath: string, content: {}) {
+    tree.create(filePath, JSON.stringify(content, undefined, 2));
+  }
+
+  // tslint:disable-next-line: no-any
+  function readJsonFile(tree: UnitTestTree, filePath: string): any {
+    // tslint:disable-next-line: no-any
+    return parseJson(tree.readContent(filePath).toString(), JsonParseMode.Loose) as any;
+  }
+
+  function createWorkSpaceConfig(tree: UnitTestTree) {
+    const angularConfig: WorkspaceSchema = {
+      version: 1,
+      projects: {
+        app: {
+          root: '',
+          sourceRoot: 'src',
+          projectType: ProjectType.Application,
+          prefix: 'app',
+          architect: {
+            build: {
+              builder: Builders.Browser,
+              options: {
+                tsConfig: 'src/tsconfig.app.json',
+                main: '',
+                polyfills: '',
+              },
+              configurations: {
+                production: {
+                  tsConfig: 'src/tsconfig.app.prod.json',
+                },
+              },
+            },
+            test: {
+              builder: Builders.Karma,
+              options: {
+                karmaConfig: '',
+                tsConfig: 'src/tsconfig.spec.json',
+              },
+            },
+            e2e: {
+              builder: Builders.Protractor,
+              options: {
+                protractorConfig: 'src/e2e/protractor.conf.js',
+                devServerTarget: '',
+              },
+            },
+            server: {
+              builder: Builders.Server,
+              options: {
+                tsConfig: 'src/tsconfig.server.json',
+                outputPath: '',
+                main: '',
+              },
+            },
+          },
+        },
+      },
+    };
+
+    createJsonFile(tree, 'angular.json', angularConfig);
+  }
+
+
+  let tree: UnitTestTree;
+  beforeEach(() => {
+    tree = new UnitTestTree(new EmptyTree());
+    createWorkSpaceConfig(tree);
+
+    // Create tsconfigs
+    const compilerOptions = { target: 'es2015', module: 'esnext' };
+
+    // Workspace
+    createJsonFile(tree, 'tsconfig.json', { compilerOptions });
+
+    // Application
+    createJsonFile(tree, 'src/tsconfig.app.json', { compilerOptions });
+    createJsonFile(tree, 'src/tsconfig.app.prod.json', { compilerOptions });
+    createJsonFile(tree, 'src/tsconfig.spec.json', { compilerOptions });
+
+    // E2E
+    createJsonFile(tree, 'src/e2e/protractor.conf.js', '');
+    createJsonFile(tree, 'src/e2e/tsconfig.json', { compilerOptions: { module: 'commonjs', target: 'es5' } });
+
+    // Universal
+    createJsonFile(tree, 'src/tsconfig.server.json', { compilerOptions: { module: 'commonjs' } });
+  });
+
+  it(`should update module and target in workspace 'tsconfig.json'`, async () => {
+    const newTree = await schematicRunner.runSchematicAsync(schematicName, {}, tree).toPromise();
+    const { module, target } = readJsonFile(newTree, 'tsconfig.json').compilerOptions;
+    expect(module).toBe('es2020');
+    expect(target).toBe('es2016');
+  });
+
+  it(`should update module and target in 'tsconfig.json' which is referenced in option`, async () => {
+    const newTree = await schematicRunner.runSchematicAsync(schematicName, {}, tree).toPromise();
+    const { module, target } = readJsonFile(newTree, 'src/tsconfig.spec.json').compilerOptions;
+    expect(module).toBe('es2020');
+    expect(target).toBe('es2016');
+  });
+
+  it(`should update module and target in 'tsconfig.json' which is referenced in a configuration`, async () => {
+    const newTree = await schematicRunner.runSchematicAsync(schematicName, {}, tree).toPromise();
+    const { module, target } = readJsonFile(newTree, 'src/tsconfig.app.prod.json').compilerOptions;
+    expect(module).toBe('es2020');
+    expect(target).toBe('es2016');
+  });
+
+  it(`should update target to es2018 in E2E 'tsconfig.json'`, async () => {
+    const newTree = await schematicRunner.runSchematicAsync(schematicName, {}, tree).toPromise();
+    const { module, target } = readJsonFile(newTree, 'src/e2e/tsconfig.json').compilerOptions;
+    expect(module).toBe('commonjs');
+    expect(target).toBe('es2018');
+  });
+
+
+  it(`should remove module in 'tsconfig.server.json'`, async () => {
+    const newTree = await schematicRunner.runSchematicAsync(schematicName, {}, tree).toPromise();
+    const { module, target } = readJsonFile(newTree, 'src/tsconfig.server.json').compilerOptions;
+    expect(module).toBeUndefined();
+    expect(target).toBeUndefined();
+  });
+});

--- a/packages/schematics/angular/workspace/files/tsconfig.json.template
+++ b/packages/schematics/angular/workspace/files/tsconfig.json.template
@@ -12,10 +12,10 @@
     "declaration": false,
     "downlevelIteration": true,
     "experimentalDecorators": true,
-    "module": "esnext",
+    "module": "es2020",
     "moduleResolution": "node",
     "importHelpers": true,
-    "target": "es2015",
+    "target": "es2016",
     "lib": [
       "es2018",
       "dom"

--- a/tests/legacy-cli/e2e/assets/1.7-project/e2e/tsconfig.e2e.json
+++ b/tests/legacy-cli/e2e/assets/1.7-project/e2e/tsconfig.e2e.json
@@ -4,7 +4,7 @@
     "outDir": "../out-tsc/e2e",
     "baseUrl": "./",
     "module": "commonjs",
-    "target": "es5",
+    "target": "es2018",
     "types": [
       "jasmine",
       "jasminewd2",

--- a/tests/legacy-cli/e2e/assets/7.0-project/e2e/tsconfig.e2e.json
+++ b/tests/legacy-cli/e2e/assets/7.0-project/e2e/tsconfig.e2e.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "../out-tsc/app",
     "module": "commonjs",
-    "target": "es5",
+    "target": "es2018",
     "types": [
       "jasmine",
       "jasminewd2",

--- a/tests/legacy-cli/e2e/tests/build/differential-loading.ts
+++ b/tests/legacy-cli/e2e/tests/build/differential-loading.ts
@@ -31,19 +31,19 @@ export default async function () {
   await expectFileToMatch(
     'dist/test-project/index.html',
     oneLineTrim`
-    <script src="runtime-es2015.js" type="module"></script>
+    <script src="runtime-es2016.js" type="module"></script>
     <script src="runtime-es5.js" nomodule defer></script>
     <script src="polyfills-es5.js" nomodule defer></script>
-    <script src="polyfills-es2015.js" type="module"></script>
+    <script src="polyfills-es2016.js" type="module"></script>
     <script src="scripts.js" defer></script>
     <script src="renamed-script.js" defer></script>
-    <script src="vendor-es2015.js" type="module"></script>
+    <script src="vendor-es2016.js" type="module"></script>
     <script src="vendor-es5.js" nomodule defer></script>
-    <script src="main-es2015.js" type="module"></script>
+    <script src="main-es2016.js" type="module"></script>
     <script src="main-es5.js" nomodule defer></script>
   `,
   );
 
-  await expectFileToMatch('dist/test-project/vendor-es2015.js', /class \w{constructor\(/);
+  await expectFileToMatch('dist/test-project/vendor-es2016.js', /class \w{constructor\(/);
   await expectToFail(() => expectFileToMatch('dist/test-project/vendor-es5.js', /class \w{constructor\(/));
 }

--- a/tests/legacy-cli/e2e/tests/build/polyfills.ts
+++ b/tests/legacy-cli/e2e/tests/build/polyfills.ts
@@ -24,7 +24,7 @@ export default async function () {
 
   await expectFileToMatch('dist/test-project/index.html', oneLineTrim`
     <script src="polyfills-es5.js" nomodule defer></script>
-    <script src="polyfills-es2015.js" type="module">
+    <script src="polyfills-es2016.js" type="module">
   `);
 
   const jitPolyfillSize = await getFileSize('dist/test-project/polyfills-es5.js');
@@ -38,6 +38,6 @@ export default async function () {
 
   await expectFileToMatch('dist/test-project/index.html', oneLineTrim`
     <script src="polyfills-es5.js" nomodule defer></script>
-    <script src="polyfills-es2015.js" type="module">
+    <script src="polyfills-es2016.js" type="module">
   `);
 }

--- a/tests/legacy-cli/e2e/tests/build/prod-build.ts
+++ b/tests/legacy-cli/e2e/tests/build/prod-build.ts
@@ -47,13 +47,13 @@ export default async function () {
   await expectFileToExist(join(process.cwd(), 'dist'));
   // Check for cache busting hash script src
   await expectFileToMatch('dist/test-project/index.html', /main-es5\.[0-9a-f]{20}\.js/);
-  await expectFileToMatch('dist/test-project/index.html', /main-es2015\.[0-9a-f]{20}\.js/);
+  await expectFileToMatch('dist/test-project/index.html', /main-es2016\.[0-9a-f]{20}\.js/);
   await expectFileToMatch('dist/test-project/index.html', /styles\.[0-9a-f]{20}\.css/);
   await expectFileToMatch('dist/test-project/3rdpartylicenses.txt', /MIT/);
 
   const indexContent = await readFile('dist/test-project/index.html');
   const mainES5Path = indexContent.match(/src="(main-es5\.[a-z0-9]{0,32}\.js)"/)[1];
-  const mainES2015Path = indexContent.match(/src="(main-es2015\.[a-z0-9]{0,32}\.js)"/)[1];
+  const mainES2015Path = indexContent.match(/src="(main-es2016\.[a-z0-9]{0,32}\.js)"/)[1];
 
   // Content checks
   await expectFileToMatch(`dist/test-project/${mainES5Path}`, bootstrapRegExp);

--- a/tests/legacy-cli/e2e/tests/build/sourcemap.ts
+++ b/tests/legacy-cli/e2e/tests/build/sourcemap.ts
@@ -23,7 +23,7 @@ export default async function () {
 
 async function testForSourceMaps(expectedNumberOfFiles: number): Promise <void> {
   await expectFileToExist('dist/test-project/main-es5.js.map');
-  await expectFileToExist('dist/test-project/main-es2015.js.map');
+  await expectFileToExist('dist/test-project/main-es2016.js.map');
 
   const files = fs.readdirSync('./dist/test-project');
 

--- a/tests/legacy-cli/e2e/tests/build/worker.ts
+++ b/tests/legacy-cli/e2e/tests/build/worker.ts
@@ -32,18 +32,18 @@ export default async function () {
   await ng('build');
   await expectFileToExist('dist/test-project/0-es5.worker.js');
   await expectFileToMatch('dist/test-project/main-es5.js', '0-es5.worker.js');
-  await expectToFail(() => expectFileToMatch('dist/test-project/main-es5.js', '0-es2015.worker.js'));
-  await expectFileToExist('dist/test-project/0-es2015.worker.js');
-  await expectFileToMatch('dist/test-project/main-es2015.js', '0-es2015.worker.js');
-  await expectToFail(() => expectFileToMatch('dist/test-project/main-es2015.js', '0-es5.worker.js'));
+  await expectToFail(() => expectFileToMatch('dist/test-project/main-es5.js', '0-es2016.worker.js'));
+  await expectFileToExist('dist/test-project/0-es2016.worker.js');
+  await expectFileToMatch('dist/test-project/main-es2016.js', '0-es2016.worker.js');
+  await expectToFail(() => expectFileToMatch('dist/test-project/main-es2016.js', '0-es5.worker.js'));
 
   await ng('build', '--prod', '--output-hashing=none');
   await expectFileToExist('dist/test-project/0-es5.worker.js');
   await expectFileToMatch('dist/test-project/main-es5.js', '0-es5.worker.js');
-  await expectToFail(() => expectFileToMatch('dist/test-project/main-es5.js', '0-es2015.worker.js'));
-  await expectFileToExist('dist/test-project/0-es2015.worker.js');
-  await expectFileToMatch('dist/test-project/main-es2015.js', '0-es2015.worker.js');
-  await expectToFail(() => expectFileToMatch('dist/test-project/main-es2015.js', '0-es5.worker.js'));
+  await expectToFail(() => expectFileToMatch('dist/test-project/main-es5.js', '0-es2016.worker.js'));
+  await expectFileToExist('dist/test-project/0-es2016.worker.js');
+  await expectFileToMatch('dist/test-project/main-es2016.js', '0-es2016.worker.js');
+  await expectToFail(() => expectFileToMatch('dist/test-project/main-es2016.js', '0-es5.worker.js'));
 
   // console.warn has to be used because chrome only captures warnings and errors by default
   // https://github.com/angular/protractor/issues/2207

--- a/tests/legacy-cli/e2e/tests/i18n/ivy-localize-dl-xliff2.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/ivy-localize-dl-xliff2.ts
@@ -21,7 +21,7 @@ export async function executeTest() {
   );
 
   await updateJsonFile('tsconfig.json', config => {
-    config.compilerOptions.target = 'es2015';
+    config.compilerOptions.target = 'es2016';
     config.angularCompilerOptions.disableTypeScriptVersionCheck = true;
   });
 
@@ -29,13 +29,13 @@ export async function executeTest() {
   await ng('build');
   for (const { lang, outputPath, translation } of langTranslations) {
     await expectFileToMatch(`${outputPath}/main-es5.js`, translation.helloPartial);
-    await expectFileToMatch(`${outputPath}/main-es2015.js`, translation.helloPartial);
+    await expectFileToMatch(`${outputPath}/main-es2016.js`, translation.helloPartial);
     await expectToFail(() => expectFileToMatch(`${outputPath}/main-es5.js`, '$localize`'));
-    await expectToFail(() => expectFileToMatch(`${outputPath}/main-es2015.js`, '$localize`'));
+    await expectToFail(() => expectFileToMatch(`${outputPath}/main-es2016.js`, '$localize`'));
 
     // Verify the locale ID is present
     await expectFileToMatch(`${outputPath}/vendor-es5.js`, lang);
-    await expectFileToMatch(`${outputPath}/vendor-es2015.js`, lang);
+    await expectFileToMatch(`${outputPath}/vendor-es2016.js`, lang);
 
     // Verify the HTML lang attribute is present
     await expectFileToMatch(`${outputPath}/index.html`, `lang="${lang}"`);
@@ -45,7 +45,7 @@ export async function executeTest() {
 
     // Verify the locale data is registered using the global files
     await expectFileToMatch(`${outputPath}/vendor-es5.js`, '.ng.common.locales');
-    await expectFileToMatch(`${outputPath}/vendor-es2015.js`, '.ng.common.locales');
+    await expectFileToMatch(`${outputPath}/vendor-es2016.js`, '.ng.common.locales');
 
     // Execute Application E2E tests with dev server
     await ng('e2e', `--configuration=${lang}`, '--port=0');
@@ -68,14 +68,14 @@ export async function executeTest() {
   await ng('build', '--configuration=fr', '--optimization=false');
   await expectToFail(() => expectFileToMatch(`${baseDir}/fr/main-es5.js`, 'registerLocaleData('));
   await expectToFail(() =>
-    expectFileToMatch(`${baseDir}/fr/main-es2015.js`, 'registerLocaleData('),
+    expectFileToMatch(`${baseDir}/fr/main-es2016.js`, 'registerLocaleData('),
   );
 
   // Verify missing translation behaviour.
   await appendToFile('src/app/app.component.html', '<p i18n>Other content</p>');
   await ng('build', '--i18n-missing-translation', 'ignore');
   await expectFileToMatch(`${baseDir}/fr/main-es5.js`, /Other content/);
-  await expectFileToMatch(`${baseDir}/fr/main-es2015.js`, /Other content/);
+  await expectFileToMatch(`${baseDir}/fr/main-es2016.js`, /Other content/);
   await expectToFail(() => ng('build'));
   try {
     await execAndWaitForOutputToMatch(

--- a/tests/legacy-cli/e2e/tests/i18n/ivy-localize-es2015.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/ivy-localize-es2015.ts
@@ -11,7 +11,7 @@ export default async function() {
   // Ensure a ES2015 build is used.
   await writeFile('.browserslistrc', 'Chrome 65');
   await updateJsonFile('tsconfig.json', config => {
-    config.compilerOptions.target = 'es2015';
+    config.compilerOptions.target = 'es2016';
     config.angularCompilerOptions.disableTypeScriptVersionCheck = true;
   });
 

--- a/tests/legacy-cli/e2e/tests/i18n/ivy-localize-es5.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/ivy-localize-es5.ts
@@ -19,7 +19,7 @@ export default async function() {
   for (const { lang, outputPath, translation } of langTranslations) {
     await expectFileToMatch(`${outputPath}/main.js`, translation.helloPartial);
     await expectToFail(() => expectFileToMatch(`${outputPath}/main.js`, '$localize`'));
-    await expectFileNotToExist(`${outputPath}/main-es2015.js`);
+    await expectFileNotToExist(`${outputPath}/main-es2016.js`);
 
     // Ensure sourcemap for modified file contains content
     const mainSourceMap = JSON.parse(await readFile(`${outputPath}/main.js.map`));

--- a/tests/legacy-cli/e2e/tests/i18n/ivy-localize-serviceworker.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/ivy-localize-serviceworker.ts
@@ -33,7 +33,7 @@ export default async function() {
   await npm('install', `${serviceWorkerVersion}`);
 
   await updateJsonFile('tsconfig.json', config => {
-    config.compilerOptions.target = 'es2015';
+    config.compilerOptions.target = 'es2016';
     config.angularCompilerOptions.disableTypeScriptVersionCheck = true;
   });
 
@@ -140,11 +140,11 @@ export default async function() {
   await ng('build', '--i18n-missing-translation', 'error');
   for (const { lang, translation } of langTranslations) {
     await expectFileToMatch(`${baseDir}/${lang}/main-es5.js`, translation);
-    await expectFileToMatch(`${baseDir}/${lang}/main-es2015.js`, translation);
+    await expectFileToMatch(`${baseDir}/${lang}/main-es2016.js`, translation);
     await expectToFail(() => expectFileToMatch(`${baseDir}/${lang}/main-es5.js`, '$localize`'));
-    await expectToFail(() => expectFileToMatch(`${baseDir}/${lang}/main-es2015.js`, '$localize`'));
+    await expectToFail(() => expectFileToMatch(`${baseDir}/${lang}/main-es2016.js`, '$localize`'));
     await expectFileToMatch(`${baseDir}/${lang}/main-es5.js`, lang);
-    await expectFileToMatch(`${baseDir}/${lang}/main-es2015.js`, lang);
+    await expectFileToMatch(`${baseDir}/${lang}/main-es2016.js`, lang);
 
     // Expect service worker configuration to be present
     await expectFileToExist(`${baseDir}/${lang}/ngsw.json`);

--- a/tests/legacy-cli/e2e/tests/i18n/ve-localize-es2015.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/ve-localize-es2015.ts
@@ -24,7 +24,7 @@ export default async function() {
   // Ensure a ES2015 build is used.
   await writeFile('.browserslistrc', 'Chrome 65');
   await updateJsonFile('tsconfig.json', config => {
-    config.compilerOptions.target = 'es2015';
+    config.compilerOptions.target = 'es2016';
     config.angularCompilerOptions.disableTypeScriptVersionCheck = true;
   });
 

--- a/tests/legacy-cli/e2e/tests/test/test-target.ts
+++ b/tests/legacy-cli/e2e/tests/test/test-target.ts
@@ -8,11 +8,11 @@ export default function () {
 
   return updateJsonFile('tsconfig.json', configJson => {
     const compilerOptions = configJson['compilerOptions'];
-    compilerOptions['target'] = 'es2015';
+    compilerOptions['target'] = 'es2016';
   })
     .then(() => updateJsonFile('src/tsconfig.spec.json', configJson => {
       const compilerOptions = configJson['compilerOptions'];
-      compilerOptions['target'] = 'es2015';
+      compilerOptions['target'] = 'es2016';
     }))
     .then(() => ng('test', '--watch=false'));
 }

--- a/tests/legacy-cli/e2e/tests/update/update-7.0.ts
+++ b/tests/legacy-cli/e2e/tests/update/update-7.0.ts
@@ -29,7 +29,6 @@ export default async function() {
     `loadChildren: () => import('./lazy/lazy.module').then(m => m.LazyModule)`,
   );
   // Should update tsconfig and src/browserslist via differential-loading.
-  await expectFileToMatch('tsconfig.json', `"target": "es2015",`);
   await expectToFail(() => expectFileToExist('e2e/browserlist'));
   // Should rename codelyzer rules.
   await expectFileToMatch('tslint.json', `use-lifecycle-interface`);
@@ -57,5 +56,5 @@ export default async function() {
   // Verify project now creates bundles for differential loading.
   await noSilentNg('build', '--prod');
   await expectFileMatchToExist('dist/seven-oh-project/', /main-es5\.[0-9a-f]{20}\.js/);
-  await expectFileMatchToExist('dist/seven-oh-project/', /main-es2015\.[0-9a-f]{20}\.js/);
+  await expectFileMatchToExist('dist/seven-oh-project/', /main-es2016\.[0-9a-f]{20}\.js/);
 }


### PR DESCRIPTION


With this change we update the target and module settings of various compilation units.

- We replace ES5 target in protractor. Protractor runs on Node.Js which support ES2018
- For applications we now use `ES2020` instead of `ESNext` as a module to avoid unexpected changes in behaviour
- For application we now use `ES2016` as a syntax target instead of `ES2015`

This changes also adds a migration to update existing projects and also removes `module` from the Universal tsconfig as per #17352 to enable lazy loading on the server.