### PR TITLE
fix(@schematics/angular): don't add `@angular/language-service` in new Angular projects

### DIFF
--- a/integration/angular_cli/package.json
+++ b/integration/angular_cli/package.json
@@ -28,7 +28,6 @@
     "@angular-devkit/build-angular": "~0.901.1",
     "@angular/cli": "~9.1.1",
     "@angular/compiler-cli": "~9.1.1",
-    "@angular/language-service": "~9.1.1",
     "@types/node": "^12.11.1",
     "@types/jasmine": "~3.5.0",
     "@types/jasminewd2": "~2.0.3",

--- a/packages/schematics/angular/workspace/files/package.json.template
+++ b/packages/schematics/angular/workspace/files/package.json.template
@@ -26,7 +26,6 @@
   "devDependencies": {
     "@angular/cli": "<%= '~' + version %>",
     "@angular/compiler-cli": "<%= latestVersions.Angular %>",
-    "@angular/language-service": "<%= latestVersions.Angular %>",
     "@types/node": "^12.11.1",<% if (!minimal) { %>
     "@types/jasmine": "~3.5.0",
     "@types/jasminewd2": "~2.0.3",


### PR DESCRIPTION

This package is no longer required since the VS code extension is already shipped with it.