### PR TITLE
refactor(@angular-devkit/build-angular): remove unused server builder options

### DIFF
--- a/packages/angular_devkit/build_angular/src/server/schema.json
+++ b/packages/angular_devkit/build_angular/src/server/schema.json
@@ -105,18 +105,6 @@
         }
       ]
     },
-    "vendorChunk": {
-      "type": "boolean",
-      "description": "Use a separate bundle containing only vendor libraries.",
-      "default": true,
-      "x-deprecated": "Since version 9. This option has no effect on server platform."
-    },
-    "commonChunk": {
-      "type": "boolean",
-      "description": "Use a separate bundle containing code used across multiple bundles.",
-      "default": true,
-      "x-deprecated": "Since version 9. This option has no effect on server platform."
-    },
     "deployUrl": {
       "type": "string",
       "description": "URL where files will be deployed."

--- a/packages/schematics/angular/migrations/migration-collection.json
+++ b/packages/schematics/angular/migrations/migration-collection.json
@@ -83,7 +83,7 @@
     "update-angular-config": {
       "version": "10.0.0-beta.3",
       "factory": "./update-10/update-angular-config",
-      "description": "Remove deprecated 'evalSourceMap', `profile`, 'skipAppShell' and 'vendorSourceMap' from 'angular.json'."
+      "description": "Remove various deprecated builders options from 'angular.json'."
     }
   }
 }

--- a/packages/schematics/angular/migrations/update-10/update-angular-config.ts
+++ b/packages/schematics/angular/migrations/update-10/update-angular-config.ts
@@ -9,7 +9,7 @@
 import { workspaces } from '@angular-devkit/core';
 import { Rule } from '@angular-devkit/schematics';
 import { updateWorkspace } from '../../utility/workspace';
-import { ProjectType } from '../../utility/workspace-models';
+import { Builders, ProjectType } from '../../utility/workspace-models';
 
 export default function (): Rule {
   return updateWorkspace(workspace => {
@@ -25,6 +25,14 @@ export default function (): Rule {
           continue;
         }
 
+        let extraOptionsToRemove = {};
+        if (target.builder === Builders.Server) {
+          extraOptionsToRemove = {
+            vendorChunk: undefined,
+            commonChunk: undefined,
+          };
+        }
+
         // Check options
         if (target.options) {
           target.options = {
@@ -32,6 +40,7 @@ export default function (): Rule {
             evalSourceMap: undefined,
             skipAppShell: undefined,
             profile: undefined,
+            ...extraOptionsToRemove,
           };
         }
 
@@ -46,6 +55,7 @@ export default function (): Rule {
             evalSourceMap: undefined,
             skipAppShell: undefined,
             profile: undefined,
+            ...extraOptionsToRemove,
           };
         }
       }


### PR DESCRIPTION


BREAKING CHANGE: options `commonChunk` and `vendorChunk` have been removed from the server builder.

Note: this change only effects direct @angular-devkit/build-angular users and not the application developers as users will be migrated automatically off these options.