### PR TITLE
refactor(@schematic/angular): remove deprecated options from app-shell and universal schematics

### DIFF
--- a/packages/schematics/angular/app-shell/index.ts
+++ b/packages/schematics/angular/app-shell/index.ts
@@ -148,13 +148,7 @@ function addUniversalTarget(options: AppShellOptions): Rule {
     };
 
     // Delete non-universal options.
-    delete universalOptions.universalProject;
     delete universalOptions.route;
-    delete universalOptions.name;
-    delete universalOptions.outDir;
-    delete universalOptions.root;
-    delete universalOptions.index;
-    delete universalOptions.sourceDir;
 
     return schematic('universal', universalOptions);
   };

--- a/packages/schematics/angular/app-shell/index_spec.ts
+++ b/packages/schematics/angular/app-shell/index_spec.ts
@@ -17,7 +17,6 @@ describe('App Shell Schematic', () => {
     require.resolve('../collection.json'),
   );
   const defaultOptions: AppShellOptions = {
-    name: 'foo',
     clientProject: 'bar',
   };
 

--- a/packages/schematics/angular/app-shell/schema.json
+++ b/packages/schematics/angular/app-shell/schema.json
@@ -13,21 +13,10 @@
         "$source": "projectName"
       }
     },
-    "universalProject": {
-      "type": "string",
-      "description": "The name of related Universal app.",
-      "x-deprecated": "This option has no effect."
-    },
     "route": {
       "type": "string",
       "description": "Route path used to produce the app shell.",
       "default": "shell"
-    },
-    "name": {
-      "type": "string",
-      "format": "html-selector",
-      "description": "The HTML selector of the Universal app",
-      "x-deprecated": "This option has no effect."
     },
     "appId": {
       "type": "string",
@@ -35,51 +24,11 @@
       "description": "The app ID to use in withServerTransition().",
       "default": "serverApp"
     },
-    "outDir": {
-      "type": "string",
-      "format": "path",
-      "description": "The output directory for build results.",
-      "default": "dist-server",
-      "x-deprecated": "This option has no effect."
-    },
-    "root": {
-      "type": "string",
-      "format": "path",
-      "description": "The root directory of the app.",
-      "default": "src",
-      "x-deprecated": "This option has no effect."
-    },
-    "index": {
-      "type": "string",
-      "format": "path",
-      "description": "The name of the index file",
-      "default": "index.html",
-      "x-deprecated": "This option has no effect."
-    },
     "main": {
       "type": "string",
       "format": "path",
       "description": "The name of the main entry-point file.",
       "default": "main.server.ts"
-    },
-    "test": {
-      "type": "string",
-      "format": "path",
-      "description": "The name of the test entry-point file.",
-      "x-deprecated": "This option has no effect."
-    },
-    "tsconfigFileName": {
-      "type": "string",
-      "format": "path",
-      "default": "tsconfig.server",
-      "description": "The name of the TypeScript configuration file."
-    },
-    "testTsconfigFileName": {
-      "type": "string",
-      "format": "path",
-      "description": "The name of the TypeScript configuration file for tests.",
-      "default": "tsconfig.spec",
-      "x-deprecated": "This option has no effect."
     },
     "appDir": {
       "type": "string",
@@ -99,13 +48,10 @@
       "description": "The name of the root module class.",
       "default": "AppServerModule"
     },
-    "sourceDir": {
+    "tsconfigFileName": {
       "type": "string",
-      "format": "path",
-      "description": "The path of the source directory.",
-      "default": "src",
-      "alias": "D",
-      "x-deprecated": "This option has no effect."
+      "default": "tsconfig.server",
+      "description": "The name of the TypeScript configuration file."
     }
   },
   "required": [

--- a/packages/schematics/angular/universal/schema.json
+++ b/packages/schematics/angular/universal/schema.json
@@ -21,23 +21,10 @@
       "description": "The name of the main entry-point file.",
       "default": "main.server.ts"
     },
-    "test": {
-      "type": "string",
-      "format": "path",
-      "description": "The name of the test entry-point file.",
-      "x-deprecated": "This option has no effect."
-    },
     "tsconfigFileName": {
       "type": "string",
       "default": "tsconfig.server",
       "description": "The name of the TypeScript configuration file."
-    },
-    "testTsconfigFileName": {
-      "type": "string",
-      "format": "path",
-      "description": "The name of the TypeScript configuration file for tests.",
-      "default": "tsconfig.spec",
-      "x-deprecated": "This option has no effect."
     },
     "appDir": {
       "type": "string",


### PR DESCRIPTION
BREAKING CHANGE:  The below options have been removed as they had no effect:
- `test` and `testTsconfigFileName` have been removed form the universal schematic
- `universalProject`, `name`, `outDir`, `root` and `index` have been removed from the app-shell schematic