### PR TITLE
refactor(@ngtools/webpack): remove deprecated isSupported method

### DIFF
--- a/packages/ngtools/webpack/src/angular_compiler_plugin.ts
+++ b/packages/ngtools/webpack/src/angular_compiler_plugin.ts
@@ -24,7 +24,6 @@ import {
   Program,
   SOURCE,
   UNKNOWN_ERROR_CODE,
-  VERSION,
   createCompilerHost,
   createProgram,
   formatDiagnostics,
@@ -154,11 +153,6 @@ export class AngularCompilerPlugin {
     const tsProgram = this._getTsProgram();
 
     return tsProgram ? tsProgram.getTypeChecker() : null;
-  }
-
-  /** @deprecated  From 8.0.2 */
-  static isSupported() {
-    return VERSION && parseInt(VERSION.major) >= 8;
   }
 
   private _setupOptions(options: AngularCompilerPluginOptions) {


### PR DESCRIPTION
BREAKING CHANGE:
`isSupported` method has been removed from `AngularCompilerPlugin` as it has become redundant with peer dependencies.

Note: this change only effects direct `@ngtools/webpack` users and not the application developers.