### PR TITLE
refactor(@angular/cli): exclude .yarn directory

### DIFF
--- a/.idea/angular-cli.iml
+++ b/.idea/angular-cli.iml
@@ -6,6 +6,7 @@
       <sourceFolder url="file://$MODULE_DIR$/tests" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/scripts" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/packages" isTestSource="false" />
+      <excludeFolder url="file://$MODULE_DIR$/.yarn" />
       <excludeFolder url="file://$MODULE_DIR$/tests/legacy-cli/e2e/assets/1.7-project/dist" />
       <excludeFolder url="file://$MODULE_DIR$/tests/legacy-cli/e2e/assets/1.7-project/tmp" />
       <excludeFolder url="file://$MODULE_DIR$/third_party" />


### PR DESCRIPTION
Exclude .yarn directory from IntelliJ IDEs searches. Selecting a Yarn release file from the files search results will cause the IDE to halt, this commit removes those files from search results.

To recover from such a situation you need to `killall -9 java`.

The configuration files for IntelliJ IDEs were added in c5671e08699d165941c82ccb8a8837329259fc68

cc: @dgp1130 