### PR TITLE
feat(@angular/cli): add option to enable parallel linting operations

### DIFF
--- a/docs/documentation/lint.md
+++ b/docs/documentation/lint.md
@@ -74,3 +74,12 @@ ng lint [project]
     Output format (prose, json, stylish, verbose, pmd, msbuild, checkstyle, vso, fileslist, codeFrame).
   </p>
 </details>
+<details>
+  <summary>parallel</summary>
+  <p>
+    <code>--parallel</code>
+  </p>
+  <p>
+    Run multiple lint operations in parallel.
+  </p>
+</details>

--- a/packages/angular_devkit/build_angular/src/tslint/schema.json
+++ b/packages/angular_devkit/build_angular/src/tslint/schema.json
@@ -79,6 +79,11 @@
       "items": {
         "type": "string"
       }
+    },
+    "parallel": {
+      "type": "boolean",
+      "description": "Run multiple lint operations in parallel.",
+      "default": false
     }
   },
   "additionalProperties": false,

--- a/scripts/lint.ts
+++ b/scripts/lint.ts
@@ -59,9 +59,15 @@ export default async function(options: ParsedArgs, logger: logging.Logger) {
     oldWarn(...args);
   };
 
-  program.getRootFileNames().forEach(fileName => {
-    linter.lint(fileName, ts.sys.readFile(fileName) || '', tsLintConfig);
-  });
+  const rootFileNames = program.getRootFileNames();
+
+  if (options.parallel) {
+    await Promise.all(rootFileNames.map((fileName) => linter.lint(fileName, ts.sys.readFile(fileName) || '', tsLintConfig)));
+  } else {
+    rootFileNames.forEach(fileName => {
+      linter.lint(fileName, ts.sys.readFile(fileName) || '', tsLintConfig);
+    });
+  }
 
   console.warn = oldWarn;
 


### PR DESCRIPTION
Resolves #15482

Add `--parallel` option to `ng lint` command to run multiple lint operations in parallel