### PR TITLE
ci: add 0BSD as a valid license

### DIFF
--- a/scripts/validate-licenses.ts
+++ b/scripts/validate-licenses.ts
@@ -42,6 +42,7 @@ const licensesWhitelist = [
   // Have a full copyright grant. Validated by opensource team.
   'Unlicense',
   'CC0-1.0',
+  '0BSD',
 
   // Combinations.
   '(AFL-2.1 OR BSD-2-Clause)',


### PR DESCRIPTION

This is required for tslib versions >= 1.11.2. Tslib changed it's license to 0BSD which should allow projects that embed or bundle tslib to omit its license header.

See: https://opensource.google/docs/thirdparty/licenses/#unencumbered