### PR TITLE
fix(@angular/cli): Do not use floating promises, we can resolve these…

### DIFF
--- a/packages/schematics/angular/application/other-files/app.component.spec.ts.template
+++ b/packages/schematics/angular/application/other-files/app.component.spec.ts.template
@@ -3,8 +3,8 @@ import { RouterTestingModule } from '@angular/router/testing';<% } %>
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({<% if (routing) { %>
+  beforeEach(async () => {
+    return TestBed.configureTestingModule({<% if (routing) { %>
       imports: [
         RouterTestingModule
       ],<% } %>
@@ -12,7 +12,7 @@ describe('AppComponent', () => {
         AppComponent
       ],
     }).compileComponents();
-  }));
+  });
 
   it('should create the app', () => {
     const fixture = TestBed.createComponent(AppComponent);

--- a/packages/schematics/angular/component/files/__name@dasherize@if-flat__/__name@dasherize__.__type@dasherize__.spec.ts.template
+++ b/packages/schematics/angular/component/files/__name@dasherize@if-flat__/__name@dasherize__.__type@dasherize__.spec.ts.template
@@ -6,12 +6,12 @@ describe('<%= classify(name) %><%= classify(type) %>', () => {
   let component: <%= classify(name) %><%= classify(type) %>;
   let fixture: ComponentFixture<<%= classify(name) %><%= classify(type) %>>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
+  beforeEach(async () => {
+    return TestBed.configureTestingModule({
       declarations: [ <%= classify(name) %><%= classify(type) %> ]
     })
     .compileComponents();
-  }));
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(<%= classify(name) %><%= classify(type) %>);

--- a/packages/schematics/angular/e2e/files/src/app.po.ts.template
+++ b/packages/schematics/angular/e2e/files/src/app.po.ts.template
@@ -1,11 +1,11 @@
 import { browser, by, element } from 'protractor';
 
 export class AppPage {
-  navigateTo(): Promise<unknown> {
+  async navigateTo(): Promise<unknown> {
     return browser.get(browser.baseUrl) as Promise<unknown>;
   }
 
-  getTitleText(): Promise<string> {
+  async getTitleText(): Promise<string> {
     return element(by.css('<%= rootSelector %> .content span')).getText() as Promise<string>;
   }
 }


### PR DESCRIPTION
In this PR I've fixed some floating promises in the generation of component spec files and app.component.spec.ts.

Without this fix tslint errors occur when generating components when the tslint option 'no-floating-promises' is enabled. 

Also see:
https://palantir.github.io/tslint/rules/no-floating-promises/