### PR TITLE
refactor(@angular/cli): remove deprecated typescriptMismatch

### DIFF
--- a/packages/angular/cli/commands/config-impl.ts
+++ b/packages/angular/cli/commands/config-impl.ts
@@ -243,15 +243,6 @@ export class ConfigCommand extends Command<ConfigCommandSchema> {
   private get(config: experimental.workspace.WorkspaceSchema, options: ConfigCommandSchema) {
     let value;
     if (options.jsonPath) {
-      if (options.jsonPath === 'cli.warnings.typescriptMismatch') {
-        // NOTE: Remove this in 9.0.
-        this.logger.warn('The "typescriptMismatch" warning has been removed in 8.0.');
-        // Since there is no actual warning, this value is always false.
-        this.logger.info('false');
-
-        return 0;
-      }
-
       value = getValueFromPath((config as {}) as JsonObject, options.jsonPath);
     } else {
       value = config;
@@ -273,13 +264,6 @@ export class ConfigCommand extends Command<ConfigCommandSchema> {
   private async set(options: ConfigCommandSchema) {
     if (!options.jsonPath || !options.jsonPath.trim()) {
       throw new Error('Invalid Path.');
-    }
-
-    if (options.jsonPath === 'cli.warnings.typescriptMismatch') {
-      // NOTE: Remove this in 9.0.
-      this.logger.warn('The "typescriptMismatch" warning has been removed in 8.0.');
-
-      return 0;
     }
 
     if (

--- a/packages/angular/cli/lib/config/schema.json
+++ b/packages/angular/cli/lib/config/schema.json
@@ -58,11 +58,6 @@
             "versionMismatch": {
               "description": "Show a warning when the global version is newer than the local one.",
               "type": "boolean"
-            },
-            "typescriptMismatch": {
-              "description": "Show a warning when the TypeScript version is incompatible.",
-              "type": "boolean",
-              "x-deprecated": true
             }
           }
         },
@@ -1782,16 +1777,6 @@
                   "type": "boolean"
                 }
               ]
-            },
-            "vendorChunk": {
-              "type": "boolean",
-              "description": "Use a separate bundle containing only vendor libraries.",
-              "default": true
-            },
-            "commonChunk": {
-              "type": "boolean",
-              "description": "Use a separate bundle containing code used across multiple bundles.",
-              "default": true
             },
             "verbose": {
               "type": "boolean",

--- a/packages/angular/cli/models/command-runner.ts
+++ b/packages/angular/cli/models/command-runner.ts
@@ -15,7 +15,6 @@ import {
   strings,
   tags,
 } from '@angular-devkit/core';
-import * as debug from 'debug';
 import { readFileSync } from 'fs';
 import { join, resolve } from 'path';
 import { parseJsonSchemaToCommandDescription } from '../utilities/json-schema';
@@ -29,8 +28,6 @@ import {
 import { Command } from './command';
 import { CommandDescription, CommandWorkspace } from './interface';
 import * as parser from './parser';
-
-const analyticsDebug = debug('ng:analytics:commands');
 
 // NOTE: Update commands.json if changing this.  It's still deep imported in one CI validation
 const standardCommands = {

--- a/packages/schematics/angular/migrations/update-10/update-angular-config_spec.ts
+++ b/packages/schematics/angular/migrations/update-10/update-angular-config_spec.ts
@@ -17,8 +17,20 @@ function getBuildTarget(tree: UnitTestTree): BuilderTarget<Builders.Browser, Jso
 function createWorkSpaceConfig(tree: UnitTestTree) {
   const angularConfig: WorkspaceSchema = {
     version: 1,
+    cli: {
+      warnings: {
+        versionMismatch: false,
+        typescriptMismatch: true,
+      },
+    },
     projects: {
       app: {
+        cli: {
+          warnings: {
+            versionMismatch: false,
+            typescriptMismatch: true,
+          },
+        },
         root: '',
         sourceRoot: 'src',
         projectType: ProjectType.Application,
@@ -119,5 +131,19 @@ describe(`Migration to update 'angular.json'`, () => {
       scripts: true,
       styles: false,
     });
+  });
+
+  it(`should remove root level 'typescriptMismatch'`, async () => {
+    const newTree = await schematicRunner.runSchematicAsync(schematicName, {}, tree).toPromise();
+    const config = JSON.parse(newTree.readContent('/angular.json')).cli.warnings;
+    expect(config.typescriptMismatch).toBeUndefined();
+    expect(config.versionMismatch).toBeFalse();
+  });
+
+  it(`should remove project level 'typescriptMismatch'`, async () => {
+    const newTree = await schematicRunner.runSchematicAsync(schematicName, {}, tree).toPromise();
+    const config = JSON.parse(newTree.readContent('/angular.json')).projects.app.cli.warnings;
+    expect(config.typescriptMismatch).toBeUndefined();
+    expect(config.versionMismatch).toBeFalse();
   });
 });

--- a/packages/schematics/angular/utility/config.ts
+++ b/packages/schematics/angular/utility/config.ts
@@ -455,26 +455,7 @@ export interface CliConfig {
    * Allow people to disable console warnings.
    */
   warnings?: {
-      /**
-       * Show a warning when the user enabled the --hmr option.
-       */
-      hmrWarning?: boolean;
-      /**
-       * Show a warning when the node version is incompatible.
-       */
-      nodeDeprecation?: boolean;
-      /**
-       * Show a warning when the user installed angular-cli.
-       */
-      packageDeprecation?: boolean;
-      /**
-       * Show a warning when the global version is newer than the local one.
-       */
       versionMismatch?: boolean;
-      /**
-       * Show a warning when the TypeScript version is incompatible
-       */
-      typescriptMismatch?: boolean;
   };
 }
 


### PR DESCRIPTION
BREAKING CHANGE:
Removed deprecated `typescriptMismatch` warning option. Users will be migrated off this option automatically. Users wishing to disable TypeScript version checks should use the Angular compiler option `disableTypeScriptVersionCheck`, see https://angular.io/guide/angular-compiler-options#disabletypescriptversioncheck for more information.