### PR TITLE
ci: Use node v10.20 for node v10 e2e test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,7 +178,7 @@ jobs:
   e2e-cli-node-10:
     executor:
       name: test-executor
-      nodeversion: "10.16"
+      nodeversion: "10.20"
     parallelism: 4
     steps:
       - custom_attach_workspace


### PR DESCRIPTION
CI on master is currently failing because the node v10 e2e test is failing due to the following error:
```
error move-file@2.0.0: The engine "node" is incompatible with this module. Expected version ">=10.17". Got "10.16.3"
```