### PR TITLE
refactor: let library to support “@”

### DIFF
--- a/packages/schematics/angular/library/index.ts
+++ b/packages/schematics/angular/library/index.ts
@@ -181,7 +181,7 @@ export default function (options: LibraryOptions): Rule {
     let scopeName = null;
     if (/^@.*\/.*/.test(options.name)) {
       const [scope, name] = options.name.split('/');
-      scopeName = scope.replace(/^@/, '');
+      scopeName = scope;
       options.name = name;
     }
 


### PR DESCRIPTION
When I execute `ng g application @apps/app1`, I get the following results:
``` text
- @app/
-       app1/
(newProjectRoot = "")
```

But !!! When I execute `ng g library @libs/lib1`, I got the result:
``` text
- libs/
-      lib1/
```

This is too awkward !!!

Please! Remove the `.replace(/^@/, '')` here, or add the `.replace(/^@/, '')` to the application!

I think it's really weird now...