### PR TITLE
fix(@ngtools/webpack): getCanonicalFileName should return FS compatible paths

### DIFF
--- a/packages/ngtools/webpack/src/compiler_host.ts
+++ b/packages/ngtools/webpack/src/compiler_host.ts
@@ -359,7 +359,7 @@ export class WebpackCompilerHost implements ts.CompilerHost {
   }
 
   getCanonicalFileName(fileName: string): string {
-    const path = this.resolve(fileName);
+    const path = workaroundResolve(this.resolve(fileName));
 
     return this.useCaseSensitiveFileNames() ? path : path.toLowerCase();
   }

--- a/packages/ngtools/webpack/src/utils.ts
+++ b/packages/ngtools/webpack/src/utils.ts
@@ -9,9 +9,11 @@ import { Path, getSystemPath, normalize } from '@angular-devkit/core';
 
 // `TsCompilerAotCompilerTypeCheckHostAdapter` in @angular/compiler-cli seems to resolve module
 // names directly via `resolveModuleName`, which prevents full Path usage.
+// NSTSC also uses Node.JS `path.resolve` which will result in incorrect paths in Windows
+// Example: `/D/MyPath/MyProject` -> `D:/d/mypath/myproject`
 // To work around this we must provide the same path format as TS internally uses in
 // the SourceFile paths.
-export function workaroundResolve(path: Path | string) {
+export function workaroundResolve(path: Path | string): string {
   return forwardSlashPath(getSystemPath(normalize(path)));
 }
 
@@ -20,6 +22,6 @@ export function flattenArray<T>(value: Array<T | T[]>): T[] {
 }
 
 // TS represents paths internally with '/' and expects paths to be in this format.
-export function forwardSlashPath(path: string) {
+export function forwardSlashPath(path: string): string {
   return path.replace(/\\/g, '/');
 }


### PR DESCRIPTION


Unlike TSC which has it's own mechanism the resolve and join paths in POSIX format, NGTSC heavily relies onNode.JS `fs` and `path` modules. This prevents `Path` usage because in Windows `path.resolve` will causes an absolute path to be resolved or joined incorrectly.  Example:  `/D/MyPath/MyProject` -> `D:/d/mypath/myproject`.

With this change we change the `getCanonicalFileName` method to return FS compatible paths.