### PR TITLE
feat(@angular/cli): Add option "openPage"

### DIFF
--- a/packages/angular/cli/lib/config/schema.json
+++ b/packages/angular/cli/lib/config/schema.json
@@ -1166,6 +1166,12 @@
               "default": false,
               "alias": "o"
             },
+            "openPage": {
+              "type": "string",
+              "description": "When set, open the given live-reload URL in default browser.",
+              "default": null,
+              "alias": "op"
+            },
             "liveReload": {
               "type": "boolean",
               "description": "When true, reload the page on change using live-reload.",

--- a/packages/angular_devkit/build_angular/src/dev-server/index.ts
+++ b/packages/angular_devkit/build_angular/src/dev-server/index.ts
@@ -248,7 +248,7 @@ export function serveWebpackBrowser(
           const serverAddress = url.format({
             protocol: options.ssl ? 'https' : 'http',
             hostname: options.host === '0.0.0.0' ? 'localhost' : options.host,
-            pathname: webpackDevServerConfig.publicPath,
+            pathname: 'string' === typeof options.openPage ? options.openPage : webpackDevServerConfig.publicPath,
             port: buildEvent.port,
           });
 

--- a/packages/angular_devkit/build_angular/src/dev-server/schema.json
+++ b/packages/angular_devkit/build_angular/src/dev-server/schema.json
@@ -45,7 +45,7 @@
     "openPage": {
       "type": "string",
       "description": "Opens the given url in default browser if \"open\" is true.",
-      "default": "",
+      "default": null,
       "alias": "op"
     },
     "verbose": {

--- a/packages/angular_devkit/build_angular/src/dev-server/schema.json
+++ b/packages/angular_devkit/build_angular/src/dev-server/schema.json
@@ -42,6 +42,12 @@
       "default": false,
       "alias": "o"
     },
+    "openPage": {
+      "type": "string",
+      "description": "Opens the given url in default browser if \"open\" is true.",
+      "default": "",
+      "alias": "op"
+    },
     "verbose": {
       "type": "boolean",
       "description": "Adds more details to output logging."


### PR DESCRIPTION
Allow specification of the URL path to open in the browser in conjunction with "open" set to true to mimic webpack-dev-server's "openPage" option