### PR TITLE
Added buildOptimizer option for the ng serve command

### DIFF
--- a/packages/angular_devkit/build_angular/src/dev-server/index.ts
+++ b/packages/angular_devkit/build_angular/src/dev-server/index.ts
@@ -44,6 +44,7 @@ export type DevServerBuilderOptions = Schema & json.JsonObject;
 const devServerBuildOverriddenKeys: (keyof DevServerBuilderOptions)[] = [
   'watch',
   'optimization',
+  'buildOptimizer',
   'aot',
   'sourceMap',
   'vendorChunk',

--- a/packages/angular_devkit/build_angular/src/dev-server/schema.json
+++ b/packages/angular_devkit/build_angular/src/dev-server/schema.json
@@ -117,6 +117,10 @@
         }
       ]
     },
+    "buildOptimizer": {
+      "type": "boolean",
+      "description": "Enables '@angular-devkit/build-optimizer' optimizations when using the 'aot' option."
+    },
     "aot": {
       "type": "boolean",
       "description": "Build using Ahead of Time compilation.",


### PR DESCRIPTION
Added the `--build-optimizer` option to the `ng serve` command. 

With this change you can use `ng serve` in a production configuration without optimization enabled, which is a lot faster. This can be convenient when doing debugging, of the production configuration. Without this change this is only possible by editing the `angular.json` file.
