### PR TITLE
fix(@schematics/angular): address vulnerability in protractor

### DIFF
--- a/packages/angular/cli/lib/config/schema.json
+++ b/packages/angular/cli/lib/config/schema.json
@@ -1645,11 +1645,6 @@
               "type": "string",
               "description": "Override suite in the protractor config."
             },
-            "elementExplorer": {
-              "type": "boolean",
-              "description": "Start Protractor's Element Explorer for debugging.",
-              "default": false
-            },
             "webdriverUpdate": {
               "type": "boolean",
               "description": "Try to update webdriver.",

--- a/packages/angular_devkit/build_angular/src/protractor/index.ts
+++ b/packages/angular_devkit/build_angular/src/protractor/index.ts
@@ -26,7 +26,6 @@ interface JasmineNodeOpts {
 
 function runProtractor(root: string, options: ProtractorBuilderOptions): Promise<BuilderOutput> {
   const additionalProtractorConfig: Partial<ProtractorBuilderOptions> & Partial<JasmineNodeOpts> = {
-    elementExplorer: options.elementExplorer,
     baseUrl: options.baseUrl,
     specs: options.specs && options.specs.length ? options.specs : undefined,
     suite: options.suite,

--- a/packages/angular_devkit/build_angular/src/protractor/schema.json
+++ b/packages/angular_devkit/build_angular/src/protractor/schema.json
@@ -35,11 +35,6 @@
       "type": "string",
       "description": "Override suite in the protractor config."
     },
-    "elementExplorer": {
-      "type": "boolean",
-      "description": "Start Protractor's Element Explorer for debugging.",
-      "default": false
-    },
     "webdriverUpdate": {
       "type": "boolean",
       "description": "Try to update webdriver.",

--- a/packages/schematics/angular/migrations/migration-collection.json
+++ b/packages/schematics/angular/migrations/migration-collection.json
@@ -65,11 +65,6 @@
       "factory": "./update-10/rename-browserslist-config",
       "description": "Update Browserslist configurations to '.browserslistrc'."
     },
-    "update-workspace-dependencies": {
-      "version": "10.0.0-beta.1",
-      "factory": "./update-10/update-dependencies",
-      "description": "Workspace dependencies updates."
-    },
     "remove-es5-browser-support-option": {
       "version": "10.0.0-beta.2",
       "factory": "./update-10/remove-es5-browser-support",
@@ -94,6 +89,11 @@
       "version": "10.0.0-beta.3",
       "factory": "./update-10/update-module-and-target-compiler-options",
       "description": "Update 'module' and 'target' TypeScript compiler options."
+    },
+    "update-workspace-dependencies": {
+      "version": "10.0.0-beta.6",
+      "factory": "./update-10/update-dependencies",
+      "description": "Workspace dependencies updates."
     }
   }
 }

--- a/packages/schematics/angular/migrations/migration-collection.json
+++ b/packages/schematics/angular/migrations/migration-collection.json
@@ -75,11 +75,6 @@
       "factory": "./update-9/schematic-options",
       "description": "Replace deprecated 'styleext' and 'spec' Angular schematic options."
     },
-    "update-angular-config": {
-      "version": "10.0.0-beta.3",
-      "factory": "./update-10/update-angular-config",
-      "description": "Remove various deprecated builders options from 'angular.json'."
-    },
     "side-effects-package-json": {
       "version": "10.0.0-beta.3",
       "factory": "./update-10/side-effects-package-json",
@@ -94,6 +89,11 @@
       "version": "10.0.0-beta.6",
       "factory": "./update-10/update-dependencies",
       "description": "Workspace dependencies updates."
+    },
+    "update-angular-config": {
+      "version": "10.0.0-beta.6",
+      "factory": "./update-10/update-angular-config",
+      "description": "Remove various deprecated builders options from 'angular.json'."
     }
   }
 }

--- a/packages/schematics/angular/migrations/update-10/update-angular-config.ts
+++ b/packages/schematics/angular/migrations/update-10/update-angular-config.ts
@@ -31,9 +31,16 @@ export default function (): Rule {
           continue;
         }
 
-        let extraOptionsToRemove = {};
+        let optionsToRemove: Record<string, undefined> = {
+          evalSourceMap: undefined,
+          skipAppShell: undefined,
+          profile: undefined,
+          elementExplorer: undefined,
+        };
+
         if (target.builder === Builders.Server) {
-          extraOptionsToRemove = {
+          optionsToRemove = {
+            ...optionsToRemove,
             vendorChunk: undefined,
             commonChunk: undefined,
           };
@@ -43,10 +50,7 @@ export default function (): Rule {
         if (target.options) {
           target.options = {
             ...updateVendorSourceMap(target.options),
-            evalSourceMap: undefined,
-            skipAppShell: undefined,
-            profile: undefined,
-            ...extraOptionsToRemove,
+            ...optionsToRemove,
           };
         }
 
@@ -58,10 +62,7 @@ export default function (): Rule {
         for (const configurationName of Object.keys(target.configurations)) {
           target.configurations[configurationName] = {
             ...updateVendorSourceMap(target.configurations[configurationName]),
-            evalSourceMap: undefined,
-            skipAppShell: undefined,
-            profile: undefined,
-            ...extraOptionsToRemove,
+            ...optionsToRemove,
           };
         }
       }

--- a/packages/schematics/angular/migrations/update-10/update-dependencies.ts
+++ b/packages/schematics/angular/migrations/update-10/update-dependencies.ts
@@ -16,7 +16,7 @@ export default function (): Rule {
   return (host, context) => {
     const dependenciesToUpdate: Record<string, string> = {
       'karma': '~5.0.0',
-      'protractor': '~5.4.4',
+      'protractor': '~7.0.0',
       'ng-packagr': latestVersions.ngPackagr,
     };
 

--- a/packages/schematics/angular/workspace/files/package.json.template
+++ b/packages/schematics/angular/workspace/files/package.json.template
@@ -37,7 +37,7 @@
     "karma-coverage-istanbul-reporter": "~3.0.2",
     "karma-jasmine": "~3.1.1",
     "karma-jasmine-html-reporter": "^1.4.2",
-    "protractor": "~5.4.3",<% } %>
+    "protractor": "~7.0.0",<% } %>
     "ts-node": "~8.3.0",
     "tslint": "~6.1.0",
     "typescript": "<%= latestVersions.TypeScript %>"

--- a/tests/legacy-cli/e2e/tests/basic/e2e.ts
+++ b/tests/legacy-cli/e2e/tests/basic/e2e.ts
@@ -57,13 +57,6 @@ export default function () {
           },
     `, `allScriptsTimeout: 11000,`
     ))
-    // Should start up Element Explorer
-    .then(() => execAndWaitForOutputToMatch('ng', ['e2e', 'test-project', '--element-explorer'],
-      /Element Explorer/))
-    .then(() => killAllProcesses(), (err: any) => {
-      killAllProcesses();
-      throw err;
-    })
     // Should run side-by-side with `ng serve`
     .then(() => execAndWaitForOutputToMatch('ng', ['serve'],
       /: Compiled successfully./))


### PR DESCRIPTION
potractor <7 contains a low severity vulnerability due to one of its dependencies (yargs-parser)

See: https://npmjs.com/advisories/1500

Fixes #17642


Protractor `elementExplorer` debugger and element explorer cannot be used for Node.js 8+ since it relied on `_debugger` module.

In protractor version 5, this resulted in the below error:
```
** Angular Live Development Server is listening on localhost:4200, open your browser on http://localhost:4200/ **
: Compiled successfully.
[10:25:35] I/direct - Using ChromeDriver directly...
[10:25:37] I/protractor -
[10:25:37] I/protractor - ------- Element Explorer -------
[10:25:37] I/protractor - Starting WebDriver debugger in a child process. Element Explorer is still beta, please report issues at github.com/angular/protractor
[10:25:37] I/protractor -
[10:25:37] I/protractor - Type <tab> to see a list of locator strategies.
[10:25:37] I/protractor - Use the `list` helper function to find elements by strategy:
[10:25:37] I/protractor -   e.g., list(by.binding('')) gets all bindings.
[10:25:37] I/protractor -
***********************************************************
* WARNING: _debugger module not available on Node.js 8    *
* and higher.                                             *
*                                                         *
* Use 'debugger' keyword instead:                       *
* https://goo.gl/MvWqFh                                   *
***********************************************************
/Users/alanagius/cli-repos/demo-several/node_modules/protractor/built/debugger/debuggerCommons.js:14
  throw e;
  ^

Error: Cannot find module '_debugger'
Require stack:
- /Users/alanagius/cli-repos/demo-several/node_modules/protractor/built/debugger/debuggerCommons.js
- /Users/alanagius/cli-repos/demo-several/node_modules/protractor/built/debugger/clients/explorer.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:980:15)
    at Function.Module._load (internal/modules/cjs/loader.js:862:27)
    at Module.require (internal/modules/cjs/loader.js:1042:19)
    at require (internal/modules/cjs/helpers.js:77:18)
    at Object.<anonymous> (/Users/alanagius/cli-repos/demo-several/node_modules/protractor/built/debugger/debuggerCommons.js:3:18)
    at Module._compile (internal/modules/cjs/loader.js:1156:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1176:10)
    at Module.load (internal/modules/cjs/loader.js:1000:32)
    at Function.Module._load (internal/modules/cjs/loader.js:899:14)
    at Module.require (internal/modules/cjs/loader.js:1042:19) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/Users/alanagius/cli-repos/demo-several/node_modules/protractor/built/debugger/debuggerCommons.js',
    '/Users/alanagius/cli-repos/demo-several/node_modules/protractor/built/debugger/clients/explorer.js'
  ]
}
```

but in protractor version 7, this logic was removed.

**BREAKING CHANGE:**
Protractor builder elementExplorer option has been removed. This was not compatable with the Node.Js versions that the Angular CLI supports. See: https://github.com/angular/protractor/blob/master/docs/debugging.md#enabled-control-flow for an alternative debugging methods.
