### PR TITLE
Revert license checker plugin to previously used plugin

### DIFF
--- a/packages/angular_devkit/build_angular/BUILD.bazel
+++ b/packages/angular_devkit/build_angular/BUILD.bazel
@@ -138,7 +138,7 @@ ts_library(
         "@npm//karma",
         "@npm//karma-source-map-support",
         "@npm//less-loader",
-        "@npm//license-checker-webpack-plugin",
+        "@npm//license-webpack-plugin",
         "@npm//loader-utils",
         "@npm//mini-css-extract-plugin",
         "@npm//minimatch",

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -36,7 +36,7 @@
     "jest-worker": "26.0.0",
     "karma-source-map-support": "1.4.0",
     "less-loader": "6.1.0",
-    "license-checker-webpack-plugin": "0.1.4",
+    "license-webpack-plugin": "2.2.0",
     "loader-utils": "2.0.0",
     "mini-css-extract-plugin": "0.9.0",
     "minimatch": "3.0.4",

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/browser.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/browser.ts
@@ -5,13 +5,13 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import * as LicenseCheckerWebpackPlugin from 'license-checker-webpack-plugin';
 import * as webpack from 'webpack';
 import { CommonJsUsageWarnPlugin } from '../../plugins/webpack';
 import { WebpackConfigOptions } from '../build-options';
 import { getSourceMapDevTool, isPolyfillsEntry, normalizeExtraEntryPoints } from './utils';
 
 const SubresourceIntegrityPlugin = require('webpack-subresource-integrity');
+const LicenseWebpackPlugin = require('license-webpack-plugin').LicenseWebpackPlugin;
 
 
 export function getBrowserConfig(wco: WebpackConfigOptions): webpack.Configuration {
@@ -41,7 +41,12 @@ export function getBrowserConfig(wco: WebpackConfigOptions): webpack.Configurati
   }
 
   if (extractLicenses) {
-    extraPlugins.push(new LicenseCheckerWebpackPlugin({
+    extraPlugins.push(new LicenseWebpackPlugin({
+      stats: {
+        warnings: false,
+        errors: false,
+      },
+      perChunkOutput: false,
       outputFilename: '3rdpartylicenses.txt',
     }));
   }

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/stats.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/stats.ts
@@ -86,12 +86,20 @@ export function statsToString(json: any, statsConfig: any) {
   }
 }
 
+// TODO(#16193): Don't emit this warning in the first place rather than just suppressing it.
+const ERRONEOUS_WARNINGS = [
+  /multiple assets emit different content.*3rdpartylicenses\.txt/i,
+];
 export function statsWarningsToString(json: any, statsConfig: any) {
   const colors = statsConfig.colors;
   const rs = (x: string) => colors ? reset(x) : x;
   const y = (x: string) => colors ? bold(yellow(x)) : x;
 
-  return rs('\n' + json.warnings.map((warning: any) => y(`WARNING in ${warning}`)).join('\n\n'));
+  return rs('\n' + json.warnings
+      .map((warning: any) => `${warning}`)
+      .filter((warning: string) => !ERRONEOUS_WARNINGS.some((erroneous) => erroneous.test(warning)))
+      .map((warning: string) => y(`WARNING in ${warning}`))
+      .join('\n\n'));
 }
 
 export function statsErrorsToString(json: any, statsConfig: any) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7286,6 +7286,14 @@ license-checker@^25.0.0:
     spdx-satisfies "^4.0.0"
     treeify "^1.1.0"
 
+license-webpack-plugin@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/license-webpack-plugin/-/license-webpack-plugin-2.2.0.tgz#5c964380d7d0e0c27c349d86a6f856c82924590e"
+  integrity sha512-XPsdL/0brSHf+7dXIlRqotnCQ58RX2au6otkOg4U3dm8uH+Ka/fW4iukEs95uXm+qKe/SBs+s1Ll/aQddKG+tg==
+  dependencies:
+    "@types/webpack-sources" "^0.1.5"
+    webpack-sources "^1.2.0"
+
 lie@~3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/lie/-/lie-3.3.0.tgz#dcf82dee545f46074daf200c7c1c5a08e0f40f6a"
@@ -12777,7 +12785,7 @@ webpack-merge@4.2.2:
   dependencies:
     lodash "^4.17.15"
 
-webpack-sources@1.4.3, webpack-sources@^1.1.0, webpack-sources@^1.3.0, webpack-sources@^1.4.0, webpack-sources@^1.4.1, webpack-sources@^1.4.3:
+webpack-sources@1.4.3, webpack-sources@^1.1.0, webpack-sources@^1.2.0, webpack-sources@^1.3.0, webpack-sources@^1.4.0, webpack-sources@^1.4.1, webpack-sources@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.4.3.tgz#eedd8ec0b928fbf1cbfe994e22d2d890f330a933"
   integrity sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==


### PR DESCRIPTION
The newly introduced plugin can cause performance degradation during builds.  This becomes more apparent the larger the project becomes.  Switching to the previous plugin removes the performance problems.