### PR TITLE
fix(@schematics/angular): add tslib as a direct dependency for new libraries

### DIFF
--- a/packages/schematics/angular/library/files/package.json.template
+++ b/packages/schematics/angular/library/files/package.json.template
@@ -3,7 +3,9 @@
   "version": "0.0.1",
   "peerDependencies": {
     "@angular/common": "^<%= angularLatestVersion %>",
-    "@angular/core": "^<%= angularLatestVersion %>",
+    "@angular/core": "^<%= angularLatestVersion %>"
+  },
+  "dependencies": {
     "tslib": "^<%= tsLibLatestVersion %>"
   }
 }


### PR DESCRIPTION
Tslib version is bound to the TypeScript version used to compile the library. Thus, we shouldn't list `tslib` as a `peerDependencies`. This is because, a user can install libraries which have been compiled with older versions of TypeScript and thus require multiple `tslib` versions to be installed.

Reference: TOOL-1374