### PR TITLE
feat(@schematics/angular): Add `index.ts`, so that IDEs can "shorten import" normally

### DIFF
--- a/packages/schematics/angular/library/files/index.ts
+++ b/packages/schematics/angular/library/files/index.ts
@@ -1,0 +1,1 @@
+export * from './src/public-api';


### PR DESCRIPTION
If the source code of the library is added to the path map in `tsconfig.json`. Then IDE (such as WebStorm) will not be able to "shorten import" normally, because it only recognizes `/index.ts`, but not `/src/public-api.ts`. Adding an `/index.ts` by default can solve this issue.

Considering that many internal libraries may prefer this way, I think it might be worth being shipped by default.

Reprod: https://github.com/asnowwolf/reprod-path-mapping