### PR TITLE
fix(@angular/cli): default project schematic resolution

### DIFF
--- a/packages/angular/cli/models/schematic-command.ts
+++ b/packages/angular/cli/models/schematic-command.ts
@@ -72,7 +72,7 @@ export class UnknownCollectionError extends Error {
 
 export abstract class SchematicCommand<
   T extends BaseSchematicSchema & BaseCommandOptions
-> extends Command<T> {
+  > extends Command<T> {
   readonly allowPrivateSchematics: boolean = false;
   private _host = new NodeJsSyncHost();
   private _workspace: workspaces.WorkspaceDefinition;
@@ -481,8 +481,11 @@ export abstract class SchematicCommand<
     const pathOptions = o ? this.setPathOptions(o, workingDir) : {};
     let input = { ...pathOptions, ...args };
 
+    const workspace = await getWorkspace('local');
+    const defaultProjectName = workspace?.getDefaultProjectName();
+
     // Read the default values from the workspace.
-    const projectName = input.project !== undefined ? '' + input.project : null;
+    const projectName = input.project !== undefined ? '' + input.project : defaultProjectName;
     const defaults = await getSchematicDefaults(collectionName, schematicName, projectName);
     input = {
       ...defaults,


### PR DESCRIPTION
The current Angular CLI doesn't properly resolve project specific schematic defaults if the project is not passed to the command, but rather the default project is just being used.

Several users reported this for [Nx](https://nx.dev) when they had SCSS configured for a given app, but still plain `css` files were generated.

Example `angular.json`:

```
{
  "version": 1,
  "projects": {
    "demoapp": {
      "projectType": "application",
      "schematics": {
        "@nrwl/angular:component": {
          "style": "scss"
        }
      },
      "root": "apps/demoapp",
      "sourceRoot": "apps/demoapp/src",
      "prefix": "ngdefaultschematics",
      "architect": {
        "build": {
          "builder": "@angular-devkit/build-angular:browser",
          "options": {
            "outputPath": "dist/apps/demoapp",
            "index": "apps/demoapp/src/index.html",
            "main": "apps/demoapp/src/main.ts",
            "polyfills": "apps/demoapp/src/polyfills.ts",
            "tsConfig": "apps/demoapp/tsconfig.app.json",
            "aot": true,
            "assets": [
              "apps/demoapp/src/favicon.ico",
              "apps/demoapp/src/assets"
            ],
            "styles": ["apps/demoapp/src/styles.scss"],
            "scripts": []
          },
          "configurations": {
            "production": {
              "fileReplacements": [
                {
                  "replace": "apps/demoapp/src/environments/environment.ts",
                  "with": "apps/demoapp/src/environments/environment.prod.ts"
                }
              ],
              "optimization": true,
              "outputHashing": "all",
              "sourceMap": false,
              "extractCss": true,
              "namedChunks": false,
              "extractLicenses": true,
              "vendorChunk": false,
              "buildOptimizer": true,
              "budgets": [
                {
                  "type": "initial",
                  "maximumWarning": "2mb",
                  "maximumError": "5mb"
                },
                {
                  "type": "anyComponentStyle",
                  "maximumWarning": "6kb",
                  "maximumError": "10kb"
                }
              ]
            }
          }
        },
        "serve": {
          "builder": "@angular-devkit/build-angular:dev-server",
          "options": {
            "browserTarget": "demoapp:build"
          },
          "configurations": {
            "production": {
              "browserTarget": "demoapp:build:production"
            }
          }
        },
        "extract-i18n": {
          "builder": "@angular-devkit/build-angular:extract-i18n",
          "options": {
            "browserTarget": "demoapp:build"
          }
        },
        "lint": {
          "builder": "@angular-devkit/build-angular:tslint",
          "options": {
            "tsConfig": [
              "apps/demoapp/tsconfig.app.json",
              "apps/demoapp/tsconfig.spec.json"
            ],
            "exclude": ["**/node_modules/**", "!apps/demoapp/**"]
          }
        },
        "test": {
          "builder": "@nrwl/jest:jest",
          "options": {
            "jestConfig": "apps/demoapp/jest.config.js",
            "tsConfig": "apps/demoapp/tsconfig.spec.json",
            "passWithNoTests": true,
            "setupFile": "apps/demoapp/src/test-setup.ts"
          }
        }
      }
    },
    "demoapp-e2e": {
      "root": "apps/demoapp-e2e",
      "sourceRoot": "apps/demoapp-e2e/src",
      "projectType": "application",
      "architect": {
        "e2e": {
          "builder": "@nrwl/cypress:cypress",
          "options": {
            "cypressConfig": "apps/demoapp-e2e/cypress.json",
            "tsConfig": "apps/demoapp-e2e/tsconfig.e2e.json",
            "devServerTarget": "demoapp:serve"
          },
          "configurations": {
            "production": {
              "devServerTarget": "demoapp:serve:production"
            }
          }
        },
        "lint": {
          "builder": "@angular-devkit/build-angular:tslint",
          "options": {
            "tsConfig": ["apps/demoapp-e2e/tsconfig.e2e.json"],
            "exclude": ["**/node_modules/**", "!apps/demoapp-e2e/**"]
          }
        }
      }
    }
  },
  "cli": {
    "defaultCollection": "@nrwl/angular"
  },
  "schematics": {
    "@nrwl/angular:application": {
      "unitTestRunner": "jest",
      "e2eTestRunner": "cypress"
    },
    "@nrwl/angular:library": {
      "unitTestRunner": "jest"
    }
  },
  "defaultProject": "demoapp"
}
```

As can be seen, the `demoapp` uses

```
"schematics": {
  "@nrwl/angular:component": {
      "style": "scss"
  }
},
```

If you use `ng g c test --project=demoapp`, everything works just fine and a `scss` file will be generated. Instead if you run `ng g c test`, then the schematic defaults are not being used.