### PR TITLE
test: make CoreSchemaRegistry test green again

### DIFF
--- a/packages/angular_devkit/core/src/json/schema/registry.ts
+++ b/packages/angular_devkit/core/src/json/schema/registry.ts
@@ -7,6 +7,7 @@
  */
 import * as ajv from 'ajv';
 import * as http from 'http';
+import * as https from 'https';
 import { Observable, from, isObservable, of, throwError } from 'rxjs';
 import { concatMap, map, switchMap, tap } from 'rxjs/operators';
 import * as Url from 'url';
@@ -144,7 +145,9 @@ export class CoreSchemaRegistry implements SchemaRegistry {
 
     // If none are found, handle using http client.
     return new Promise<JsonObject>((resolve, reject) => {
-      http.get(uri, res => {
+      const url = new Url.URL(uri);
+      const client = url.protocol === 'https:' ? https : http;
+      client.get(url, res => {
         if (!res.statusCode || res.statusCode >= 300) {
           // Consume the rest of the data to free memory.
           res.resume();

--- a/packages/angular_devkit/core/src/json/schema/registry_spec.ts
+++ b/packages/angular_devkit/core/src/json/schema/registry_spec.ts
@@ -30,7 +30,7 @@ describe('CoreSchemaRegistry', () => {
             },
           },
           tslint: {
-            $ref: 'http://json.schemastore.org/tslint#',
+            $ref: 'https://json.schemastore.org/tslint#',
           },
         },
       })


### PR DESCRIPTION
`http://json.schemastore.org/tslint` has moved permanently to `https://json.schemastore.org/tslint` which is causing this test to fail

(cherry picked from commit 8d1309e697fbe78a23b1e7cd2c70ee995c1bb777)