### PR TITLE
refactor(@angular-devkit/build-angular): mention how to disable the w…

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/common-js-usage-warn-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/common-js-usage-warn-plugin.ts
@@ -82,7 +82,8 @@ export class CommonJsUsageWarnPlugin {
             // will require CommonJS libraries for live reloading such as 'sockjs-node'.
             if (mainIssuer?.name === 'main' && !issuer?.userRequest?.includes('webpack-dev-server')) {
               const warning = `${issuer?.userRequest} depends on ${rawRequest}. CommonJS or AMD dependencies can cause optimization bailouts.\n` +
-                'For more info see: https://web.dev/commonjs-larger-bundles';
+                'For more info see: https://web.dev/commonjs-larger-bundles\n' +
+                `To disable this warning add "${rawRequest}" to the "allowedCommonJsDependencies" option under "build" options in "angular.json".`;
 
               // Avoid showing the same warning multiple times when in 'watch' mode.
               if (!this.shownWarnings.has(warning)) {

--- a/packages/angular_devkit/build_angular/src/browser/specs/common-js-warning_spec.ts
+++ b/packages/angular_devkit/build_angular/src/browser/specs/common-js-warning_spec.ts
@@ -37,6 +37,7 @@ describe('Browser Builder commonjs warning', () => {
     expect(output.success).toBe(true);
     const logMsg = logs.join();
     expect(logMsg).toMatch(/WARNING in.+app\.component\.ts depends on bootstrap\. CommonJS or AMD dependencies/);
+    expect(logMsg).toMatch(/To disable this warning add "bootstrap" to the "allowedCommonJsDependencies" option/);
     expect(logMsg).not.toContain('jquery', 'Should not warn on transitive CommonJS packages which parent is also CommonJS.');
     await run.stop();
   });


### PR DESCRIPTION
…arning for commonjs dependencies

The current message clearly mentions which dependencies are CommonJS ones, but doesn't point out how to get rid of the warning if nothing can be done. This commit adds a mention of `allowedCommonJsDependencies` in the warning to help developers (as we do for `versionMismatch` for example).