### PR TITLE
fix(@schematics/angular): use ES2016 as syntax target for server bundles

### DIFF
--- a/packages/angular_devkit/build_angular/test/hello-world-app/src/tsconfig.server.json
+++ b/packages/angular_devkit/build_angular/test/hello-world-app/src/tsconfig.server.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.app.json",
   "compilerOptions": {
     "outDir": "../dist-server",
+    "target": "es2016",
     "baseUrl": "./",
     "types": []
   },

--- a/packages/schematics/angular/migrations/migration-collection.json
+++ b/packages/schematics/angular/migrations/migration-collection.json
@@ -80,11 +80,6 @@
       "factory": "./update-10/side-effects-package-json",
       "description": "Create a special 'package.json' file that is used to tell the tools and bundlers whether the code under the app directory is free of code with non-local side-effect."
     },
-    "update-module-and-target-compiler-options": {
-      "version": "10.0.0-beta.3",
-      "factory": "./update-10/update-module-and-target-compiler-options",
-      "description": "Update 'module' and 'target' TypeScript compiler options."
-    },
     "update-angular-config": {
       "version": "10.0.0-beta.6",
       "factory": "./update-10/update-angular-config",
@@ -109,6 +104,11 @@
       "version": "10.0.0-beta.7",
       "factory": "./update-10/solution-style-tsconfig",
       "description": "Adding \"Solution Style\" tsconfig.json. This improves developer experience using editors powered by TypeScript’s language server."
+    },
+    "update-module-and-target-compiler-options": {
+      "version": "10.0.0-rc.1",
+      "factory": "./update-10/update-module-and-target-compiler-options",
+      "description": "Update 'module' and 'target' TypeScript compiler options."
     }
   }
 }

--- a/packages/schematics/angular/migrations/update-10/update-module-and-target-compiler-options_spec.ts
+++ b/packages/schematics/angular/migrations/update-10/update-module-and-target-compiler-options_spec.ts
@@ -131,11 +131,23 @@ describe('Migration to update target and module compiler options', () => {
     expect(target).toBe('es2018');
   });
 
-
   it(`should remove module in 'tsconfig.server.json'`, async () => {
     const newTree = await schematicRunner.runSchematicAsync(schematicName, {}, tree).toPromise();
-    const { module, target } = readJsonFile(newTree, 'src/tsconfig.server.json').compilerOptions;
+    const { module } = readJsonFile(newTree, 'src/tsconfig.server.json').compilerOptions;
     expect(module).toBeUndefined();
-    expect(target).toBeUndefined();
+  });
+
+  it(`should add target in 'tsconfig.server.json'`, async () => {
+    const newTree = await schematicRunner.runSchematicAsync(schematicName, {}, tree).toPromise();
+    const { target } = readJsonFile(newTree, 'src/tsconfig.server.json').compilerOptions;
+    expect(target).toBe('es2016');
+  });
+
+  it(`should update target to es2016 in 'tsconfig.server.json'`, async () => {
+    tree.delete('src/tsconfig.server.json');
+    createJsonFile(tree, 'src/tsconfig.server.json', { compilerOptions: { module: 'commonjs', target: 'es5' } });
+    const newTree = await schematicRunner.runSchematicAsync(schematicName, {}, tree).toPromise();
+    const { target } = readJsonFile(newTree, 'src/tsconfig.server.json').compilerOptions;
+    expect(target).toBe('es2016');
   });
 });

--- a/packages/schematics/angular/universal/files/root/tsconfig.server.json.template
+++ b/packages/schematics/angular/universal/files/root/tsconfig.server.json.template
@@ -2,6 +2,7 @@
   "extends": "./<%= tsConfigExtends %>",
   "compilerOptions": {
     "outDir": "<%= relativePathToWorkspaceRoot %>/out-tsc/server",
+    "target": "es2016",
     "types": [
       "node"
     ]

--- a/packages/schematics/angular/universal/index_spec.ts
+++ b/packages/schematics/angular/universal/index_spec.ts
@@ -92,6 +92,7 @@ describe('Universal Schematic', () => {
       extends: './tsconfig.app.json',
       compilerOptions: {
         outDir: './out-tsc/server',
+        target: 'es2016',
         types: ['node'],
       },
       files: [
@@ -116,6 +117,7 @@ describe('Universal Schematic', () => {
       extends: './tsconfig.app.json',
       compilerOptions: {
         outDir: '../../out-tsc/server',
+        target: 'es2016',
         types: ['node'],
       },
       files: [


### PR DESCRIPTION
fix(@schematics/angular): use ES2016 as syntax target for server bundles

The supported versions of Node.js support up to ES2018, the only reason why we don't use ES2017+ is because native `async` and `await` don't work with zone.js

See: https://github.com/angular/angular/issues/31730

With this change, we also ensure that we don't downlevel the server bundle to ES5 which is unnecessary.

Closes: #17794