### PR TITLE
test: skip differential loading cache test on CI

### DIFF
--- a/tests/legacy-cli/e2e/tests/build/differential-cache.ts
+++ b/tests/legacy-cli/e2e/tests/build/differential-cache.ts
@@ -36,6 +36,11 @@ function validateHashes(
 }
 
 export default async function() {
+  // Skip on CI due to large variability of performance
+  if (process.env['CI']) {
+    return;
+  }
+
   let oldHashes: Map<string, string>;
   let newHashes: Map<string, string>;
 


### PR DESCRIPTION
There is a large amount of performance variability on CI which can cause test flakes.