### PR TITLE
fix(@ngtools/webpack): improve eliding in constructor parameter transform

### DIFF
--- a/packages/ngtools/webpack/src/transformers/ctor-parameters_spec.ts
+++ b/packages/ngtools/webpack/src/transformers/ctor-parameters_spec.ts
@@ -276,4 +276,43 @@ describe('Constructor Parameter Transformer', () => {
 
     expect(tags.oneLine`${result}`).toEqual(tags.oneLine`${output}`);
   });
+
+  it('should allow unused imports to be elided', () => {
+    const otherFiles = {
+      'material.ts': `
+        export class MatDialog {
+          constructor() { }
+        }
+        export class MatButton {
+          constructor() { }
+        }
+      `,
+    };
+
+    const input = `
+      import {MatDialog, MatButton} from './material';
+
+      @Directive()
+      export class AppComp {
+        constructor(button: MatButton) {}
+      }
+    `;
+
+    const output = `
+      import { __decorate } from "tslib";
+      import { MatButton } from './material';
+
+      let AppComp = /** @class */ (() => {
+        let AppComp = class AppComp { constructor(button) { } };
+        AppComp.ctorParameters = () => [ { type: MatButton } ];
+        AppComp = __decorate([ Directive() ], AppComp);
+        return AppComp;
+      })();
+      export { AppComp };
+    `;
+
+    const result = transform(input, otherFiles);
+
+    expect(tags.oneLine`${result}`).toEqual(tags.oneLine`${output}`);
+  });
 });


### PR DESCRIPTION
This change allows TypeScript to directly elide unused imports that were also used to reference constructor parameter metadata.  Previously the plugin's import elider was necessary to remove these imports.