### PR TITLE
build: use rimraf instead of custom rimraf

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -11,6 +11,7 @@ import * as child_process from 'child_process';
 import * as fs from 'fs';
 import * as glob from 'glob';
 import * as path from 'path';
+import * as rimraf from 'rimraf';
 import { packages } from '../lib/packages';
 import buildSchema from './build-schema';
 
@@ -132,20 +133,10 @@ function _rm(p: string) {
   fs.unlinkSync(p);
 }
 
-
-function _rimraf(p: string) {
-  glob.sync(path.join(p, '**/*'), { dot: true, nodir: true })
-    .forEach(p => fs.unlinkSync(p));
-  glob.sync(path.join(p, '**/*'), { dot: true })
-    .sort((a, b) => b.length - a.length)
-    .forEach(p => fs.rmdirSync(p));
-}
-
-
 function _clean(logger: logging.Logger) {
   logger.info('Cleaning...');
   logger.info('  Removing dist/...');
-  _rimraf(path.join(__dirname, '../dist'));
+  rimraf.sync(path.join(__dirname, '../dist'));
 }
 
 
@@ -229,7 +220,7 @@ export default async function(
     packageLogger.info(packageName);
     const pkg = packages[packageName];
     _recursiveCopy(pkg.build, pkg.dist, logger);
-    _rimraf(pkg.build);
+    rimraf.sync(pkg.build);
   }
 
   logger.info('Merging bazel-bin/ with dist/');
@@ -241,7 +232,7 @@ export default async function(
     if (fs.existsSync(bazelBinPath)) {
       packageLogger.info(packageName);
       _recursiveCopy(bazelBinPath, pkg.dist, logger);
-      _rimraf(bazelBinPath);
+      rimraf.sync(bazelBinPath);
     }
   }
 


### PR DESCRIPTION
With this change we replace the custom rimraf implementation in the build script with the rimraf npm package. The main reason for this change is because `dist` can be a symlink when building with bazel but our implementation doesn't that.