### PR TITLE
perf(@ngtools/webpack): only process dependent packages with NGCC

### DIFF
--- a/packages/ngtools/webpack/src/ngcc_processor.ts
+++ b/packages/ngtools/webpack/src/ngcc_processor.ts
@@ -85,6 +85,7 @@ export class NgccProcessor {
         '--async',
         '--tsconfig', /** tsConfigPath */
         this.tsConfigPath,
+        '--use-program-dependencies',
       ],
       {
         stdio: ['inherit', process.stderr, process.stderr],


### PR DESCRIPTION
With this change we consume the change in https://github.com/angular/angular/pull/37075 where the NGCC now exposes a new option `--use-program-dependencies`, to only process packages which are part of the TypeScript program.

From the initial benchmarking the time taken for NGCC to process that dependencies needed for an `ng new` application went down by 36% from 10526ms to 6708ms.