### PR TITLE
fix(@angular-devkit/build-angular): disable CSS `calc` optimizations

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/optimize-css-webpack-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/optimize-css-webpack-plugin.ts
@@ -78,8 +78,10 @@ export class OptimizeCssWebpackPlugin {
 
           const cssNanoOptions: cssNano.CssNanoOptions = {
             preset: ['default', {
-              // Disable SVG optimization, as this can cause optimizations which are not compatible in all browsers.
+              // Disable SVG optimizations, as this can cause optimizations which are not compatible in all browsers.
               svgo: false,
+              // Disable `calc` optimizations, due to several issues. #16910, #16875, #17890
+              calc: false,
             }],
           };
 


### PR DESCRIPTION
Disable `calc` optimizations due to several issues.

Closes #16910 closes #16875 and closes #17890