### PR TITLE
fix(@schematics/angular): add strict setting to angular.json

### DIFF
--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -179,6 +179,14 @@ function addAppToWorkspaceFile(options: ApplicationOptions, appDir: string): Rul
     });
   }
 
+  if (options.strict) {
+    if (!('@schematics/angular:application' in schematics)) {
+      schematics['@schematics/angular:application'] = {};
+    }
+
+    (schematics['@schematics/angular:application'] as JsonObject).strict = true;
+  }
+
   const sourceRoot = join(normalize(projectRoot), 'src');
   let budgets = [];
   if (options.strict) {


### PR DESCRIPTION
With this change we add the `strict` setting to the schematics settings in the angular.json, so that when creating a strict application and/or workspace all future applications will be strict by default