### PR TITLE
fix(@schematics/angular): exclude es5 bundles from being prefetch

### DIFF
--- a/packages/schematics/angular/service-worker/files/ngsw-config.json.template
+++ b/packages/schematics/angular/service-worker/files/ngsw-config.json.template
@@ -11,7 +11,8 @@
           "/index.html",
           "/manifest.webmanifest",
           "/*.css",
-          "/*.js"
+          "/*.js",
+          "!/*-es5*.js"
         ]
       }
     }, {
@@ -21,7 +22,8 @@
       "resources": {
         "files": [
           "/assets/**",
-          "<%= resourcesOutputPath %>/*.(eot|svg|cur|jpg|png|webp|gif|otf|ttf|woff|woff2|ani)"
+          "<%= resourcesOutputPath %>/*.(eot|svg|cur|jpg|png|webp|gif|otf|ttf|woff|woff2|ani)",
+          "/*-es5*.js"
         ]
       }
     }


### PR DESCRIPTION
Fixes https://github.com/angular/angular/issues/31256.

When differential loading is used, by default the Angular Service Worker will double-(pre)fetch the ES5 & ES2015 bundles, unless those are explicitly excluded as per https://github.com/angular/angular/issues/31256#issuecomment-506507021.

Excluding those ES5 bundles from the `ngsw-config.json` template would provide a better developer experience, removing the risk of double fetching the JS bundles when differential loading is used/enabled, while having no impact when differential loading isn't used.

Doing so would prevent browsers with Service Worker support but without `<script type="module">` support to prefect the correct JS bundles, but I'd argue the tradeoff is acceptable (and the default `ngsw-config.json` config can just be modified) compared to current double fetching.

In addition:
- the few browser versions that support Service Workers but not `<script type="module">`, which according to https://caniuse.com/#feat=es6-module & https://caniuse.com/#feat=serviceworkers are basically Firefox < 60 (current is 76), Chrome < 61 (current is 83), Opera < 48 (current is 68), are all outside Angular's browser support ranges (and outdated).
- the Angular Service Worker has also no support to load a different (es5) `ngsw.json` config for these browsers (nor the Angular CLI has support to built it), and realistically will never need to.