### PR TITLE
feat(@schematics/angular): emit declaration maps for local library builds

### DIFF
--- a/packages/angular_devkit/build_ng_packagr/test/ng-packaged/projects/lib/tsconfig.lib.json
+++ b/packages/angular_devkit/build_ng_packagr/test/ng-packaged/projects/lib/tsconfig.lib.json
@@ -3,12 +3,18 @@
   "compilerOptions": {
     "target": "es2015",
     "declaration": true,
+    "declarationMap": true,
     "inlineSources": true,
     "types": [],
     "lib": [
       "dom",
       "es2018"
     ]
+  },
+  "angularCompilerOptions": {
+    "skipTemplateCodegen": true,
+    "strictMetadataEmit": true,
+    "enableResourceInlining": true
   },
   "exclude": [
     "src/test.ts",

--- a/packages/angular_devkit/build_ng_packagr/test/ng-packaged/projects/lib/tsconfig.lib.prod.json
+++ b/packages/angular_devkit/build_ng_packagr/test/ng-packaged/projects/lib/tsconfig.lib.prod.json
@@ -1,9 +1,9 @@
 {
   "extends": "./tsconfig.lib.json",
+  "compilerOptions": {
+    "declarationMap": false
+  },
   "angularCompilerOptions": {
-    "skipTemplateCodegen": true,
-    "strictMetadataEmit": true,
-    "enableResourceInlining": true,
     "enableIvy": false
   }
 }

--- a/packages/schematics/angular/library/files/tsconfig.lib.json.template
+++ b/packages/schematics/angular/library/files/tsconfig.lib.json.template
@@ -4,6 +4,7 @@
     "outDir": "<%= relativePathToWorkspaceRoot %>/out-tsc/lib",
     "target": "es2015",
     "declaration": true,
+    "declarationMap": true,
     "inlineSources": true,
     "types": [],
     "lib": [

--- a/packages/schematics/angular/library/files/tsconfig.lib.prod.json.template
+++ b/packages/schematics/angular/library/files/tsconfig.lib.prod.json.template
@@ -1,5 +1,8 @@
 {
   "extends": "./tsconfig.lib.json",
+  "compilerOptions": {
+    "declarationMap": false
+  },
   "angularCompilerOptions": {
     "enableIvy": false
   }


### PR DESCRIPTION


With this change we enable emitting declaration maps when building libraries to be consumed locally as this improved DX as this will allow editors to go to the original typescript file when using `Go to Definition`.

For production builds, declaration maps are disabled because they are not useful since the source files are not included in the distributable package.

Closes #17888