### PR TITLE
fix(@angular/cli): throw error when specified project does not exist

### DIFF
--- a/packages/angular/cli/models/architect-command.ts
+++ b/packages/angular/cli/models/architect-command.ts
@@ -66,8 +66,12 @@ export abstract class ArchitectCommand<
       return;
     }
 
-    const commandLeftovers = options['--'];
     let projectName = options.project;
+    if (projectName && !this._workspace.projects.has(projectName)) {
+      throw new Error(`Project '${projectName}' does not exist.`);
+    }
+
+    const commandLeftovers = options['--'];
     const targetProjectNames: string[] = [];
     for (const [name, project] of this._workspace.projects) {
       if (project.targets.has(this.target)) {


### PR DESCRIPTION
Adds a check to see if the specified project exists, otherwise throws an error. This prevents it from falling through to the "build target not supported" error which is misleading.

Closes #17682