### PR TITLE
Update .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,7 @@ indent_size = 2
 insert_final_newline = true
 spaces_around_brackets = inside
 trim_trailing_whitespace = true
+quote_type = single
 
 [*.md]
 insert_final_newline = false


### PR DESCRIPTION
Update .editorconfig with "quote_type = single"

Single quotes seems to be the default used, but without this config in .editorconfig it might be overridden by the default of code formatters.

Eg: Using "Prettier" on Visual Studio Code. Since CLI creates a .editorconfig, configurations to enforce single quotes are overridden by the lack of this in .editorconfig.  