### PR TITLE
fix(@schematics/angular): validate project name before prompts

### DIFF
--- a/packages/schematics/angular/ng-new/index.ts
+++ b/packages/schematics/angular/ng-new/index.ts
@@ -24,6 +24,7 @@ import {
   RepositoryInitializerTask,
 } from '@angular-devkit/schematics/tasks';
 import { Schema as ApplicationOptions } from '../application/schema';
+import { validateProjectName } from '../utility/validation';
 import { Schema as WorkspaceOptions } from '../workspace/schema';
 import { Schema as NgNewOptions } from './schema';
 
@@ -32,6 +33,8 @@ export default function(options: NgNewOptions): Rule {
   if (!options.name) {
     throw new SchematicsException(`Invalid options, "name" is required.`);
   }
+
+  validateProjectName(options.name);
 
   if (!options.directory) {
     options.directory = options.name;


### PR DESCRIPTION
When an invalid project name is given, throw an error before going through prompts.

I'm not sure if this validation can be removed but let me know if it should: https://github.com/angular/angular-cli/blob/master/packages/schematics/angular/application/index.ts#L335

Closes #14994