### PR TITLE
refactor(@angular-devkit/build-angular): add space after file path in budget warnings

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/bundle-calculator.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/bundle-calculator.ts
@@ -275,7 +275,7 @@ class AnyScriptCalculator extends Calculator {
       .filter(asset => asset.name.endsWith('.js'))
       .map(asset => ({
         size: asset.size,
-        label: asset.name,
+        label: `${asset.name} `,
       }));
   }
 }
@@ -289,7 +289,7 @@ class AnyCalculator extends Calculator {
       .filter(asset => !asset.name.endsWith('.map'))
       .map(asset => ({
         size: asset.size,
-        label: asset.name,
+        label: `${asset.name} `,
       }));
   }
 }
@@ -360,7 +360,7 @@ export function* checkThresholds(thresholds: IterableIterator<Threshold>, size: 
         const sizeDifference = formatSize(size - threshold.limit);
         yield {
           severity: threshold.severity,
-          message: `Exceeded maximum budget for ${label} . Budget ${
+          message: `Exceeded maximum budget for ${label}. Budget ${
             formatSize(threshold.limit)} was not met by ${
             sizeDifference} with a total of ${formatSize(size)}.`,
         };
@@ -374,7 +374,7 @@ export function* checkThresholds(thresholds: IterableIterator<Threshold>, size: 
         const sizeDifference = formatSize(threshold.limit - size);
         yield {
           severity: threshold.severity,
-          message: `Failed to meet minimum budget for ${label} . Budget ${
+          message: `Failed to meet minimum budget for ${label}. Budget ${
             formatSize(threshold.limit)} was not met by ${
             sizeDifference} with a total of ${formatSize(size)}.`,
         };
@@ -403,14 +403,14 @@ function getDifferentialBuildResult(
  * Preconditions: All the sizes should be equivalent, or else they represent
  * differential builds.
  */
-function mergeDifferentialBuildSizes(buildSizes: Size[], margeLabel: string): Size[] {
+function mergeDifferentialBuildSizes(buildSizes: Size[], mergeLabel: string): Size[] {
   if (buildSizes.length === 0) {
     return [];
   }
 
   // Only one size.
   return [{
-    label: margeLabel,
+    label: mergeLabel,
     size: buildSizes[0].size,
   }];
 }

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/bundle-calculator.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/bundle-calculator.ts
@@ -360,7 +360,7 @@ export function* checkThresholds(thresholds: IterableIterator<Threshold>, size: 
         const sizeDifference = formatSize(size - threshold.limit);
         yield {
           severity: threshold.severity,
-          message: `Exceeded maximum budget for ${label}. Budget ${
+          message: `Exceeded maximum budget for ${label} . Budget ${
             formatSize(threshold.limit)} was not met by ${
             sizeDifference} with a total of ${formatSize(size)}.`,
         };
@@ -374,7 +374,7 @@ export function* checkThresholds(thresholds: IterableIterator<Threshold>, size: 
         const sizeDifference = formatSize(threshold.limit - size);
         yield {
           severity: threshold.severity,
-          message: `Failed to meet minimum budget for ${label}. Budget ${
+          message: `Failed to meet minimum budget for ${label} . Budget ${
             formatSize(threshold.limit)} was not met by ${
             sizeDifference} with a total of ${formatSize(size)}.`,
         };

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/bundle-calculator_spec.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/bundle-calculator_spec.ts
@@ -40,7 +40,7 @@ describe('bundle-calculator', () => {
       expect(failures.length).toBe(1);
       expect(failures).toContain({
         severity: ThresholdSeverity.Error,
-        message: jasmine.stringMatching('Exceeded maximum budget for foo.js.'),
+        message: jasmine.stringMatching('Exceeded maximum budget for foo.js .'),
       });
     });
 
@@ -68,7 +68,7 @@ describe('bundle-calculator', () => {
       expect(failures.length).toBe(1);
       expect(failures).toContain({
         severity: ThresholdSeverity.Error,
-        message: jasmine.stringMatching('Failed to meet minimum budget for bar.js.'),
+        message: jasmine.stringMatching('Failed to meet minimum budget for bar.js .'),
       });
     });
 

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/bundle-calculator_spec.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/bundle-calculator_spec.ts
@@ -461,7 +461,7 @@ describe('bundle-calculator', () => {
       expect(failures.length).toBe(1);
       expect(failures).toContain({
         severity: ThresholdSeverity.Error,
-        message: jasmine.stringMatching('Exceeded maximum budget for foo.ext.'),
+        message: jasmine.stringMatching('Exceeded maximum budget for foo.ext .'),
       });
     });
   });


### PR DESCRIPTION
Visual Studio Code editor has nice link handling that allows one to easily open a file from the terminal output, however it doesn't work if the file path ends with a dot.

Another option would be to add quotes or parentheses around the file path.

Here's a screenshot of the issue:
<img width="1110" alt="Screen Shot 2020-06-19 at 17 23 39" src="https://user-images.githubusercontent.com/633524/85149512-ad6e3f00-b251-11ea-95bf-dd52c3670640.png">
