### PR TITLE
test: print stderr if DedupeModuleResolvePlugin not found

### DIFF
--- a/tests/legacy-cli/e2e/tests/misc/dedupe-duplicate-modules.ts
+++ b/tests/legacy-cli/e2e/tests/misc/dedupe-duplicate-modules.ts
@@ -31,6 +31,7 @@ export default async function () {
 
     const { stderr } = await ng('build', '--verbose', '--no-vendor-chunk', '--no-progress');
     if (!/\[DedupeModuleResolvePlugin\]:.+tslib-1-copy -> .+tslib-1/.test(stderr)) {
+        console.error(`\n\n\n${stderr}\n\n\n`);
         throw new Error('Expected stderr to contain [DedupeModuleResolvePlugin] log for tslib.');
     }
 


### PR DESCRIPTION
This commit attempts to identify flakiness in the dedupe-duplicate-modules.ts test
in which the signature string occasionally fails to show up in stderr.
Dumping out the whole stderr would help us identify the bug.

Example failure on master:
https://app.circleci.com/pipelines/github/angular/angular-cli/7867/workflows/fdabb867-5dbe-4b85-80c5-24b6bca328dd/jobs/167264/steps