### PR TITLE
docs(@angular-devkit/build-angular): update browserTarget doc to be more specific about usage

### DIFF
--- a/packages/angular/cli/lib/config/schema.json
+++ b/packages/angular/cli/lib/config/schema.json
@@ -1136,7 +1136,7 @@
           "properties": {
             "browserTarget": {
               "type": "string",
-              "description": "Target to serve."
+              "description": "Build target to serve in the format of project-name:builder:config. Useful for when there are additional alternate configurations (such as stable, or archive that are used by AIO)."
             },
             "port": {
               "type": "number",

--- a/packages/angular_devkit/build_angular/src/dev-server/schema.json
+++ b/packages/angular_devkit/build_angular/src/dev-server/schema.json
@@ -6,7 +6,7 @@
   "properties": {
     "browserTarget": {
       "type": "string",
-      "description": "Target to serve.",
+      "description": "Build target to serve in the format of project-name:builder:config. Useful for when there are additional alternate configurations (such as stable, or archive that are used by AIO).",
       "pattern": "^[^:\\s]+:[^:\\s]+(:[^\\s]+)?$"
     },
     "port": {


### PR DESCRIPTION
Old documentation was "Target to serve.", this commit aims to provide more clarity over that.

Closes #16572