### PR TITLE
ci: fix dedupe-duplicate-modules flakes

### DIFF
--- a/tests/legacy-cli/e2e/tests/misc/dedupe-duplicate-modules.ts
+++ b/tests/legacy-cli/e2e/tests/misc/dedupe-duplicate-modules.ts
@@ -4,20 +4,20 @@ import { updateJsonFile } from '../../utils/project';
 import { expectToFail } from '../../utils/utils';
 
 export default async function () {
-    // Force duplicate modules
-    await updateJsonFile('package.json', json => {
-        json.dependencies = {
-            ...json.dependencies,
-            'tslib': '2.0.0',
-            'tslib-1': 'npm:tslib@1.13.0',
-            'tslib-1-copy': 'npm:tslib@1.13.0',
-        };
-    });
+  // Force duplicate modules
+  await updateJsonFile('package.json', json => {
+    json.dependencies = {
+      ...json.dependencies,
+      'tslib': '2.0.0',
+      'tslib-1': 'npm:tslib@1.13.0',
+      'tslib-1-copy': 'npm:tslib@1.13.0',
+    };
+  });
 
-    await silentNpm('install');
+  await silentNpm('install');
 
-    await writeFile('./src/main.ts',
-        `
+  await writeFile('./src/main.ts',
+    `
         import { __assign as __assign_0 } from 'tslib';
         import { __assign as __assign_1 } from 'tslib-1';
         import { __assign as __assign_2 } from 'tslib-1-copy';
@@ -29,14 +29,19 @@ export default async function () {
         })
     `);
 
-    const { stderr } = await ng('build', '--verbose', '--no-vendor-chunk', '--no-progress');
-    if (!/\[DedupeModuleResolvePlugin\]:.+tslib-1-copy -> .+tslib-1/.test(stderr)) {
-        console.error(`\n\n\n${stderr}\n\n\n`);
-        throw new Error('Expected stderr to contain [DedupeModuleResolvePlugin] log for tslib.');
-    }
+  const { stderr } = await ng('build', '--verbose', '--no-vendor-chunk', '--no-progress');
+  const outFile = 'dist/test-project/main.js';
 
-    const outFile = 'dist/test-project/main.js';
-    await expectFileToMatch(outFile, './node_modules/tslib/tslib.es6.js');
+  if (/\[DedupeModuleResolvePlugin\]:.+tslib-1-copy -> .+tslib-1/.test(stderr)) {
     await expectFileToMatch(outFile, './node_modules/tslib-1/tslib.es6.js');
     await expectToFail(() => expectFileToMatch(outFile, './node_modules/tslib-1-copy/tslib.es6.js'));
+  } else if (/\[DedupeModuleResolvePlugin\]:.+tslib-1 -> .+tslib-1-copy/.test(stderr)) {
+    await expectFileToMatch(outFile, './node_modules/tslib-1-copy/tslib.es6.js');
+    await expectToFail(() => expectFileToMatch(outFile, './node_modules/tslib-1/tslib.es6.js'));
+  } else {
+    console.error(`\n\n\n${stderr}\n\n\n`);
+    throw new Error('Expected stderr to contain [DedupeModuleResolvePlugin] log for tslib.');
+  }
+
+  await expectFileToMatch(outFile, './node_modules/tslib/tslib.es6.js');
 }


### PR DESCRIPTION


Following #17973, which we emitted the stderr when this test failed on CI.

We see that the resolved module order sometimes changes, which is totally fine because of the async nature of the operation.

https://circleci.com/gh/angular/angular-cli/167318#tests/containers/5
```
[DedupeModuleResolvePlugin]: /tmp/angular-cli-e2e-i03vMQ/test-project/node_modules/tslib-1 -> /tmp/angular-cli-e2e-i03vMQ/test-project/node_modules/tslib-1-copy
```

With this change we handle both cases which should eliminate the flakes