### PR TITLE
fix(@angular-devkit/build-angular): use copy-on-write asset processing for non-watch builds

### DIFF
--- a/packages/angular_devkit/build_angular/src/browser/specs/assets_spec.ts
+++ b/packages/angular_devkit/build_angular/src/browser/specs/assets_spec.ts
@@ -113,10 +113,8 @@ describe('Browser Builder assets', () => {
     };
 
     const run = await architect.scheduleTarget(targetSpec, overrides);
-    try {
-      await run.result;
-      expect('THE ABOVE LINE SHOULD THROW').toBe('');
-    } catch {}
+
+    await expectAsync(run.result).toBeRejected();
 
     // The node_modules folder must be deleted, otherwise code that tries to find the
     // node_modules folder will hit this one and can fail.
@@ -135,10 +133,8 @@ describe('Browser Builder assets', () => {
     };
 
     const run = await architect.scheduleTarget(targetSpec, overrides);
-    try {
-      await run.result;
-      expect('THE ABOVE LINE SHOULD THROW').toBe('');
-    } catch {}
+
+    await expectAsync(run.result).toBeRejected();
 
     // The node_modules folder must be deleted, otherwise code that tries to find the
     // node_modules folder will hit this one and can fail.


### PR DESCRIPTION
Optimized asset processing was only being performed when differential loading was enabled.  This change ensures that the optimized approach is used for all builds.  This does not affect `ng serve` usage since it currently requires all application files to be in memory.