### PR TITLE
fix(@schematics/angular): don't error out on blank JSON files during migrations

### DIFF
--- a/packages/schematics/angular/migrations/update-10/solution-style-tsconfig.ts
+++ b/packages/schematics/angular/migrations/update-10/solution-style-tsconfig.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import { JsonAstString, JsonParseMode, dirname, join, normalize, parseJsonAst, resolve } from '@angular-devkit/core';
+import { JsonAstNode, JsonAstString, JsonParseMode, dirname, join, normalize, parseJsonAst, resolve } from '@angular-devkit/core';
 import { DirEntry, Rule, chain } from '@angular-devkit/schematics';
 import { findPropertyInAstObject } from '../../utility/json-utils';
 import { getWorkspace } from '../../utility/workspace';
@@ -25,11 +25,18 @@ function* visitExtendedJsonFiles(directory: DirEntry): IterableIterator<[string,
     }
 
     const entry = directory.file(path);
-    if (!entry) {
+    const content = entry?.content.toString();
+    if (!content) {
       continue;
     }
 
-    const jsonAst = parseJsonAst(entry.content.toString(), JsonParseMode.Loose);
+    let jsonAst: JsonAstNode;
+    try {
+      jsonAst = parseJsonAst(content, JsonParseMode.Loose);
+    } catch {
+      throw new Error(`Invalid JSON AST Object (${path})`);
+    }
+
     if (jsonAst.kind !== 'object') {
       continue;
     }

--- a/packages/schematics/angular/migrations/update-10/solution-style-tsconfig_spec.ts
+++ b/packages/schematics/angular/migrations/update-10/solution-style-tsconfig_spec.ts
@@ -114,4 +114,10 @@ describe('Migration to create "Solution Style" tsconfig', () => {
       ],
     });
   });
+
+  it('should not error out when a JSON file is a blank', async () => {
+    tree.create('blank.json', '');
+    const newTree = await schematicRunner.runSchematicAsync(schematicName, {}, tree).toPromise();
+    expect(readJsonFile(newTree, 'src/tsconfig.json').extends).toEqual('./../tsconfig.base.json');
+  });
 });


### PR DESCRIPTION

During the solution-style-tsconfig migration we are unexpectedly erroring out when encounter a blank JSON file. This PR fixes this behaviour and also prints the file path when an error occurs when parsing JSON contents.

Closes: #18012 and closes: #18038 