### PR TITLE
ci: fix saucelabs unsupported OS/browser/version/device combo

### DIFF
--- a/tests/legacy-cli/e2e/assets/protractor-saucelabs.conf.js
+++ b/tests/legacy-cli/e2e/assets/protractor-saucelabs.conf.js
@@ -41,7 +41,7 @@ exports.config = {
     {
       browserName: 'safari',
       platform: 'macOS 10.15',
-      version: '13.0',
+      version: '13.1',
       tunnelIdentifier,
     },
     {


### PR DESCRIPTION
```
UnsupportedOperationError: Misconfigured -- Unsupported OS/browser/version/device combo: OS: 'Mac 10.15', Browser: 'safari', Version: '13.0.', Device: 'unspecified'
```