### PR TITLE
fix(@schematics/schematics): replaced removed `runner.runSchematic` w…

### DIFF
--- a/packages/schematics/schematics/blank/schematic-files/src/__name@dasherize__/index_spec.ts.template
+++ b/packages/schematics/schematics/blank/schematic-files/src/__name@dasherize__/index_spec.ts.template
@@ -7,9 +7,9 @@ const collectionPath = path.join(__dirname, '../collection.json');
 
 
 describe('<%= dasherize(name) %>', () => {
-  it('works', () => {
+  it('works', async () => {
     const runner = new SchematicTestRunner('schematics', collectionPath);
-    const tree = runner.runSchematic('<%= dasherize(name) %>', {}, Tree.empty());
+    const tree = await runner.runSchematicAsync('<%= dasherize(name) %>', {}, Tree.empty()).toPromise();
 
     expect(tree.files).toEqual([]);
   });

--- a/packages/schematics/schematics/schematic/files/src/my-full-schematic/index_spec.ts
+++ b/packages/schematics/schematics/schematic/files/src/my-full-schematic/index_spec.ts
@@ -11,12 +11,12 @@ describe('my-full-schematic', () => {
   it('requires required option', () => {
     // We test that
     const runner = new SchematicTestRunner('schematics', collectionPath);
-    expect(() => runner.runSchematic('my-full-schematic', {}, Tree.empty())).toThrow();
+    expectAsync(runner.runSchematicAsync('my-full-schematic', {}, Tree.empty()).toPromise()).toBeRejected();
   });
 
-  it('works', () => {
+  it('works', async () => {
     const runner = new SchematicTestRunner('schematics', collectionPath);
-    const tree = runner.runSchematic('my-full-schematic', { name: 'str' }, Tree.empty());
+    const tree = await runner.runSchematicAsync('my-full-schematic', { name: 'str' }, Tree.empty()).toPromise();
 
     // Listing files
     expect(tree.files.sort()).toEqual(['/allo', '/hola', '/test1', '/test2']);

--- a/packages/schematics/schematics/schematic/files/src/my-other-schematic/index_spec.ts
+++ b/packages/schematics/schematics/schematic/files/src/my-other-schematic/index_spec.ts
@@ -7,9 +7,9 @@ const collectionPath = path.join(__dirname, '../collection.json');
 
 
 describe('my-other-schematic', () => {
-  it('works', () => {
+  it('works', async () => {
     const runner = new SchematicTestRunner('schematics', collectionPath);
-    const tree = runner.runSchematic('my-other-schematic', {}, Tree.empty());
+    const tree = await runner.runSchematicAsync('my-other-schematic', {}, Tree.empty()).toPromise();
 
     expect(tree.files.sort()).toEqual(['/allo', '/hola']);
   });

--- a/packages/schematics/schematics/schematic/files/src/my-schematic/index_spec.ts
+++ b/packages/schematics/schematics/schematic/files/src/my-schematic/index_spec.ts
@@ -7,9 +7,9 @@ const collectionPath = path.join(__dirname, '../collection.json');
 
 
 describe('my-schematic', () => {
-  it('works', () => {
+  it('works', async () => {
     const runner = new SchematicTestRunner('schematics', collectionPath);
-    const tree = runner.runSchematic('my-schematic', {}, Tree.empty());
+    const tree = await runner.runSchematicAsync('my-schematic', {}, Tree.empty()).toPromise();
 
     expect(tree.files).toEqual(['/hello']);
   });

--- a/tests/legacy-cli/e2e/tests/schematics_cli/blank-test.ts
+++ b/tests/legacy-cli/e2e/tests/schematics_cli/blank-test.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import { getGlobalVariable } from '../../utils/env';
-import { exec, execAndWaitForOutputToMatch, silentNpm } from '../../utils/process';
+import { exec, silentNpm } from '../../utils/process';
 import { rimraf } from '../../utils/fs';
 
 export default async function () {
@@ -22,16 +22,13 @@ export default async function () {
   const schematicPath = path.join(startCwd, 'test-schematic');
 
   try {
-    // create blank schematic
-    await exec('schematics', 'schematic', '--name', 'test-schematic');
+    // create schematic
+    await exec('schematics', 'blank', '--name', 'test-schematic');
 
-    process.chdir(path.join(startCwd, 'test-schematic'));
-    await execAndWaitForOutputToMatch(
-      'schematics',
-      ['.:', '--list-schematics'],
-      /my-full-schematic/,
-    );
+    process.chdir(schematicPath);
 
+    await silentNpm('install');
+    await silentNpm('test');
   } finally {
     // restore path
     process.chdir(startCwd);

--- a/tests/legacy-cli/e2e/tests/schematics_cli/schematic-test.ts
+++ b/tests/legacy-cli/e2e/tests/schematics_cli/schematic-test.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import { getGlobalVariable } from '../../utils/env';
-import { exec, execAndWaitForOutputToMatch, silentNpm } from '../../utils/process';
+import { exec, silentNpm } from '../../utils/process';
 import { rimraf } from '../../utils/fs';
 
 export default async function () {
@@ -22,16 +22,13 @@ export default async function () {
   const schematicPath = path.join(startCwd, 'test-schematic');
 
   try {
-    // create blank schematic
+    // create schematic
     await exec('schematics', 'schematic', '--name', 'test-schematic');
 
-    process.chdir(path.join(startCwd, 'test-schematic'));
-    await execAndWaitForOutputToMatch(
-      'schematics',
-      ['.:', '--list-schematics'],
-      /my-full-schematic/,
-    );
+    process.chdir(schematicPath);
 
+    await silentNpm('install');
+    await silentNpm('test');
   } finally {
     // restore path
     process.chdir(startCwd);


### PR DESCRIPTION
…ith `runner.runSchematicAsync`

Deprecated `runSchematic` has been removed in version 10, `runSchematicAsync` should be used instead.

Closes #18062