### PR TITLE
WIP: pre-parse source-files for ngcc

### DIFF
--- a/packages/ngtools/webpack/src/compiler_host.ts
+++ b/packages/ngtools/webpack/src/compiler_host.ts
@@ -420,7 +420,7 @@ export class WebpackCompilerHost implements ts.CompilerHost {
   resolveModuleNames(
     moduleNames: string[],
     containingFile: string,
-  ): (ts.ResolvedModule | undefined)[] {
+  ): (ts.ResolvedModuleFull | undefined)[] {
     return moduleNames.map(moduleName => {
       const { resolvedModule } = ts.resolveModuleName(
         moduleName,

--- a/packages/ngtools/webpack/src/dependencyFinder.ts
+++ b/packages/ngtools/webpack/src/dependencyFinder.ts
@@ -1,0 +1,76 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import * as ts from 'typescript';
+import { WebpackCompilerHost } from './compiler_host';
+
+/**
+ * Helper functions for computing dependencies.
+ */
+export class DependencyFinder {
+  alreadySeen = new Set<string>();
+  dependencies = new Set<string>();
+
+  constructor (private _compilerHost: WebpackCompilerHost & ts.CompilerHost, private scriptTarget: ts.ScriptTarget) {}
+
+  collectDependencies(resolvedFile: string): void {
+    this.recursivelyCollectDependencies(resolvedFile);
+  }
+
+  protected recursivelyCollectDependencies(filePath: string): void {
+    console.log('collecting', filePath);
+    const sf = this._compilerHost.getSourceFile(filePath, this.scriptTarget);
+    if (sf === undefined) {
+      return;
+    }
+    const imports = this.extractImports(sf);
+    for (const importPath of imports) {
+      this.processImport(importPath, filePath);
+    }
+  }
+
+  protected processImport(importPath: string, file: string): void {
+    const [resolvedModule] = this._compilerHost.resolveModuleNames([importPath], file);
+
+    if (resolvedModule === undefined) {
+      return;
+    }
+
+    console.log(resolvedModule);
+
+    if (resolvedModule.isExternalLibraryImport || resolvedModule.extension === '.d.ts') {
+      this.dependencies.add(importPath);
+    } else {
+      const internalDependency = resolvedModule.resolvedFileName;
+      console.log('internal dep', internalDependency);
+      if (!this.alreadySeen.has(internalDependency)) {
+        this.alreadySeen.add(internalDependency);
+        this.recursivelyCollectDependencies(internalDependency);
+      }
+    }
+  }
+
+  protected extractImports(sf: ts.SourceFile): Set<string> {
+    return new Set(sf.statements
+        // filter out statements that are not imports or reexports
+        .filter(isStringImportOrReexport)
+        // Grab the id of the module that is being imported
+        .map(stmt => stmt.moduleSpecifier.text));
+  }
+}
+
+/**
+ * Check whether the given statement is an import with a string literal module specifier.
+ * @param stmt the statement node to check.
+ * @returns true if the statement is an import with a string literal module specifier.
+ */
+export function isStringImportOrReexport(stmt: ts.Statement): stmt is ts.ImportDeclaration&
+    {moduleSpecifier: ts.StringLiteral} {
+  return ts.isImportDeclaration(stmt) ||
+      ts.isExportDeclaration(stmt) && !!stmt.moduleSpecifier &&
+      ts.isStringLiteral(stmt.moduleSpecifier);
+}

--- a/packages/ngtools/webpack/src/ngcc_processor.ts
+++ b/packages/ngtools/webpack/src/ngcc_processor.ts
@@ -42,7 +42,7 @@ export class NgccProcessor {
   }
 
   /** Process the entire node modules tree. */
-  process() {
+  process(entryPointListPath: string) {
     // Under Bazel when running in sandbox mode parts of the filesystem is read-only.
     if (process.env.BAZEL_TARGET) {
       return;
@@ -68,6 +68,8 @@ export class NgccProcessor {
         require.resolve('@angular/compiler-cli/ngcc/main-ngcc.js'),
         '--source', /** basePath */
         this._nodeModulesDirectory,
+        '--entry-points-file',
+        entryPointListPath,
         '--properties', /** propertiesToConsider */
         ...this.propertiesToConsider,
         '--first-only', /** compileAllFormats */


### PR DESCRIPTION
This was a proof-of-concept for pre-parsing the application source-code for entry-points that need to be processed by ngcc.

By doing this inside the CLI, the module-resolution and source-file parsing can be cached (in the `CompilerHost`) to be used in the actual compilation that would happen later in the build.

We feel that this would have a limited benefit especially if we can avoid running ngcc at all if we believe that the entry-points have already been processed (e.g. https://github.com/angular/angular-cli/pull/18030).