### PR TITLE
fix(@angular-devkit/build-angular): several fixes for commonjs warnings 

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/common-js-usage-warn-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/common-js-usage-warn-plugin.ts
@@ -81,8 +81,16 @@ export class CommonJsUsageWarnPlugin {
             // And if the issuer request is not from 'webpack-dev-server', as 'webpack-dev-server'
             // will require CommonJS libraries for live reloading such as 'sockjs-node'.
             if (mainIssuer?.name === 'main' && !issuer?.userRequest?.includes('webpack-dev-server')) {
-              const warning = `${issuer?.userRequest} depends on ${rawRequest}. CommonJS or AMD dependencies can cause optimization bailouts.\n` +
-                'For more info see: https://angular.io/guide/build#configuring-commonjs-dependencies';
+              let warning = `${issuer?.userRequest} depends on '${rawRequest}'.`;
+
+              if (rawRequest.startsWith('@angular/common/locales')) {
+                warning += `\nWhen using the 'localize' option this import is not needed. ` +
+                  `Did you mean to import '${rawRequest.replace(/locales(\/extra)?\//, 'locales/global/')}'?\n` +
+                  'For more info see: https://angular.io/guide/i18n#import-global-variants-of-the-locale-data';
+              } else {
+                warning += ' CommonJS or AMD dependencies can cause optimization bailouts.\n' +
+                  'For more info see: https://angular.io/guide/build#configuring-commonjs-dependencies';
+              }
 
               // Avoid showing the same warning multiple times when in 'watch' mode.
               if (!this.shownWarnings.has(warning)) {

--- a/packages/angular_devkit/build_angular/src/browser/specs/common-js-warning_spec.ts
+++ b/packages/angular_devkit/build_angular/src/browser/specs/common-js-warning_spec.ts
@@ -21,7 +21,10 @@ describe('Browser Builder commonjs warning', () => {
     architect = (await createArchitect(host.root())).architect;
 
     // Add a Common JS dependency
-    host.appendToFile('src/app/app.component.ts', `import 'bootstrap';`);
+    host.appendToFile('src/app/app.component.ts', `
+      import 'bootstrap';
+      import 'zone.js/dist/zone-error';
+    `);
 
     // Create logger
     logger = new logging.Logger('');
@@ -45,6 +48,7 @@ describe('Browser Builder commonjs warning', () => {
     const overrides = {
       allowedCommonJsDependencies: [
         'bootstrap',
+        'zone.js',
       ],
     };
 


### PR DESCRIPTION
**fix(@angular-devkit/build-angular): match allowed dependencies against the package name**

With this change we add the functionality to also match an allowed dependency against a package name. The package name is retrieved from the rawRequest.

Previously, users needed to add the request path which in some case might be a deep import. Ex: `zone.js/dist/zone-error`. With this change adding the package name example `zone.js` will suffice.

Closes: #18058

**fix(@angular-devkit/build-angular): show warning when using non global locale data**

When using the `localize` option directly importing locale data from `@angular/common` is not needed because the Angular CLI  will automatically include locale data. When not using the `localize` option, most likely users meant to import the global variant of the local data.

See: https://angular.io/guide/i18n#import-global-variants-of-the-locale-data