### PR TITLE
Fix for migration from v8.x to v9.x installs latest @angular-devkit/build-angular (0.1000.0) and tslib (2.0.0)

### DIFF
--- a/packages/angular/cli/commands/update-impl.ts
+++ b/packages/angular/cli/commands/update-impl.ts
@@ -667,7 +667,9 @@ export class UpdateCommand extends Command<UpdateCommandSchema> {
       for (const migration of migrations) {
         const result = await this.executeMigrations(
           migration.package,
-          migration.collection,
+          // Resolve the collection from the workspace root, as otherwise it will be resolved from the temp
+          // installed CLI version.
+          require.resolve(migration.collection, { paths: [this.workspace.root] }),
           new semver.Range('>' + migration.from + ' <=' + migration.to),
           options.createCommits,
         );


### PR DESCRIPTION
See each commit.