### PR TITLE
build: update codelyzer to v6

### DIFF
--- a/packages/schematics/angular/migrations/update-10/update-dependencies.ts
+++ b/packages/schematics/angular/migrations/update-10/update-dependencies.ts
@@ -16,6 +16,7 @@ import { latestVersions } from '../../utility/latest-versions';
 export default function (): Rule {
   return (host, context) => {
     const dependenciesToUpdate: Record<string, string> = {
+      'codelyzer': '^6.0.0',
       'jasmine-core': '~3.5.0',
       'jasmine-spec-reporter': '~5.0.0',
       'karma': '~5.0.0',

--- a/packages/schematics/angular/workspace/files/package.json.template
+++ b/packages/schematics/angular/workspace/files/package.json.template
@@ -29,7 +29,7 @@
     "@types/node": "^12.11.1",<% if (!minimal) { %>
     "@types/jasmine": "~3.5.0",
     "@types/jasminewd2": "~2.0.3",
-    "codelyzer": "^6.0.0-next.1",
+    "codelyzer": "^6.0.0",
     "jasmine-core": "~3.5.0",
     "jasmine-spec-reporter": "~5.0.0",
     "karma": "~5.0.0",


### PR DESCRIPTION
This version uses `@angular/core` and `@angular/compiler` as dependencies to prepare for the removal of view engine. It also updates `peerDependencies` for compatibility with v10.