### PR TITLE
fix(@ngtools/webpack): don't elide used imports for transformed Short…

### DIFF
--- a/packages/ngtools/webpack/src/transformers/elide_imports.ts
+++ b/packages/ngtools/webpack/src/transformers/elide_imports.ts
@@ -85,7 +85,15 @@ export function elideImports(
     } else {
       switch (node.kind) {
         case ts.SyntaxKind.Identifier:
-          symbol = typeChecker.getSymbolAtLocation(node);
+          const parent = node.parent;
+          if (parent && ts.isShorthandPropertyAssignment(parent)) {
+            const shorthandSymbol = typeChecker.getShorthandAssignmentValueSymbol(parent);
+            if (shorthandSymbol) {
+              symbol = shorthandSymbol;
+            }
+          } else {
+            symbol = typeChecker.getSymbolAtLocation(node);
+          }
           break;
         case ts.SyntaxKind.ExportSpecifier:
           symbol = typeChecker.getExportSpecifierLocalTargetSymbol(node as ts.ExportSpecifier);


### PR DESCRIPTION
…handPropertyAssignment

NGTSC, will transform `ShorthandPropertyAssignment` to `PropertyAssignment`, with this change we handle such cases and retain the import which previously was dropped.

Closes #18149 and closes #17347