### PR TITLE
refactor(@angular-devkit/build-angular): display translation-file dia…

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/load-translations.ts
+++ b/packages/angular_devkit/build_angular/src/utils/load-translations.ts
@@ -24,17 +24,37 @@ export async function createTranslationLoader(): Promise<TranslationLoader> {
   return (path: string) => {
     const content = fs.readFileSync(path, 'utf8');
 
+    const unusedParsers = new Map();
     for (const [format, parser] of Object.entries(parsers)) {
-      if (parser.canParse(path, content)) {
-        const result = parser.parse(path, content);
+      const analysis = analyze(parser, path, content);
+      if (analysis.canParse) {
+        const translationBundle = parser.parse(path, content, analysis.hint);
         const integrity = 'sha256-' + createHash('sha256').update(content).digest('base64');
 
-        return { format, translation: result.translations, diagnostics, integrity };
+        return { format, translation: translationBundle.translations, diagnostics, integrity };
+      } else {
+        unusedParsers.set(parser, analysis);
       }
     }
 
-    throw new Error('Unsupported translation file format.');
+    const messages: string[] = [];
+    for (const [parser, analysis] of unusedParsers.entries()) {
+      messages.push(analysis.diagnostics.formatDiagnostics(`*** ${parser.constructor.name} ***`));
+    }
+    throw new Error(`Unsupported translation file format in ${path}. The following parsers were tried:\n` + messages.join('\n'));
   };
+
+  // TODO: `parser.canParse()` is deprecated; remove this polyfill once we are sure all parsers provide the `parser.analyze()` method.
+  // tslint:disable-next-line: no-any
+  function analyze(parser: any, path: string, content: string) {
+    if (parser.analyze !== undefined) {
+      return parser.analyze(path, content);
+    } else {
+      const hint = parser.canParse(path, content);
+
+      return {canParse: hint !== false, hint, diagnostics};
+    }
+  }
 }
 
 async function importParsers() {


### PR DESCRIPTION
…gnostics

If no translation parsers could parse a translation-file
we displayed a generic error, which makes it difficult to
track down if there is a problem with the file.

https://github.com/angular/angular/pull/37909 introduces
a new `parser.analyze()` API that allows us to get hold
of the diagnostic messages from trying to parse the
translation-files.

This commit will render these messages if none of the
translation parsers are succcesful.

Note that in order to maintain compatibility with versions
of `@angular/localize` that do not have the `analyze()`
method, the commit includes a polyfill, which can be removed
after a release where we can guarantee that the method
will be available.