### PR TITLE
fix(@schematics/angular): don't add e2e tsconfig reference in solution tsconfig

### DIFF
--- a/packages/schematics/angular/application/index_spec.ts
+++ b/packages/schematics/angular/application/index_spec.ts
@@ -88,7 +88,6 @@ describe('Application Schematic', () => {
     expect(references).toEqual([
       { path: './projects/foo/tsconfig.app.json' },
       { path: './projects/foo/tsconfig.spec.json' },
-      { path: './projects/foo/e2e/tsconfig.json' },
     ]);
   });
 

--- a/packages/schematics/angular/e2e/index.ts
+++ b/packages/schematics/angular/e2e/index.ts
@@ -18,7 +18,7 @@ import {
   url,
 } from '@angular-devkit/schematics';
 import { relativePathToWorkspaceRoot } from '../utility/paths';
-import { addTsConfigProjectReferences, verifyBaseTsConfigExists } from '../utility/tsconfig';
+import { verifyBaseTsConfigExists } from '../utility/tsconfig';
 import { getWorkspace, updateWorkspace } from '../utility/workspace';
 import { Builders } from '../utility/workspace-models';
 import { Schema as E2eOptions } from './schema';
@@ -68,9 +68,6 @@ export default function (options: E2eOptions): Rule {
           }),
           move(root),
         ])),
-      addTsConfigProjectReferences([
-        e2eTsConfig,
-      ]),
     ]);
   };
 }

--- a/packages/schematics/angular/e2e/index_spec.ts
+++ b/packages/schematics/angular/e2e/index_spec.ts
@@ -82,19 +82,6 @@ describe('Application Schematic', () => {
     expect(content).toMatch(/🌮-🌯/);
   });
 
-  it('should add reference in solution style tsconfig', async () => {
-    const tree = await schematicRunner.runSchematicAsync('e2e', defaultOptions, applicationTree)
-      .toPromise();
-
-    // tslint:disable-next-line:no-any
-    const { references } = parseJson(tree.readContent('/tsconfig.json').toString(), JsonParseMode.Loose) as any;
-    expect(references).toEqual([
-      { path: './projects/foo/tsconfig.app.json' },
-      { path: './projects/foo/tsconfig.spec.json' },
-      { path: './projects/foo/e2e/tsconfig.json' },
-    ]);
-  });
-
   describe('workspace config', () => {
     it('should add e2e targets for the app', async () => {
       const tree = await schematicRunner.runSchematicAsync('e2e', defaultOptions, applicationTree)

--- a/packages/schematics/angular/universal/index_spec.ts
+++ b/packages/schematics/angular/universal/index_spec.ts
@@ -273,10 +273,8 @@ describe('Universal Schematic', () => {
     expect(references).toEqual([
       { path: './tsconfig.app.json' },
       { path: './tsconfig.spec.json' },
-      { path: './e2e/tsconfig.json' },
       { path: './projects/bar/tsconfig.app.json' },
       { path: './projects/bar/tsconfig.spec.json' },
-      { path: './projects/bar/e2e/tsconfig.json' },
       { path: './tsconfig.server.json' },
     ]);
   });

--- a/packages/schematics/angular/web-worker/index_spec.ts
+++ b/packages/schematics/angular/web-worker/index_spec.ts
@@ -162,7 +162,6 @@ describe('Web Worker Schematic', () => {
     expect(references).toEqual([
       { path: './projects/bar/tsconfig.app.json' },
       { path: './projects/bar/tsconfig.spec.json' },
-      { path: './projects/bar/e2e/tsconfig.json' },
       { path: './projects/bar/tsconfig.worker.json' },
     ]);
   });


### PR DESCRIPTION


Since the tsconfig for e2e’s is named tsconfig.json there is no reason why it should be included in the solutions typescript configuration file.

Closes #18190