### PR TITLE
test(@schematics/schematics): run npm install from local registry

### DIFF
--- a/tests/legacy-cli/e2e/tests/schematics_cli/blank-test.ts
+++ b/tests/legacy-cli/e2e/tests/schematics_cli/blank-test.ts
@@ -1,3 +1,4 @@
+import * as fs from 'fs';
 import * as path from 'path';
 import { getGlobalVariable } from '../../utils/env';
 import { exec, silentNpm } from '../../utils/process';
@@ -10,11 +11,12 @@ export default async function () {
     return;
   }
 
+  fs.writeFileSync('.npmrc', 'registry = http://localhost:4873', 'utf8');
+
   await silentNpm(
     'install',
     '-g',
     '@angular-devkit/schematics-cli',
-    '--registry=http://localhost:4873',
   );
   await exec(process.platform.startsWith('win') ? 'where' : 'which', 'schematics');
 

--- a/tests/legacy-cli/e2e/tests/schematics_cli/schematic-test.ts
+++ b/tests/legacy-cli/e2e/tests/schematics_cli/schematic-test.ts
@@ -1,3 +1,4 @@
+import * as fs from 'fs';
 import * as path from 'path';
 import { getGlobalVariable } from '../../utils/env';
 import { exec, silentNpm } from '../../utils/process';
@@ -10,11 +11,12 @@ export default async function () {
     return;
   }
 
+  fs.writeFileSync('.npmrc', 'registry = http://localhost:4873', 'utf8');
+
   await silentNpm(
     'install',
     '-g',
     '@angular-devkit/schematics-cli',
-    '--registry=http://localhost:4873',
   );
   await exec(process.platform.startsWith('win') ? 'where' : 'which', 'schematics');
 


### PR DESCRIPTION
After a new tag is pushed, the schematic e2e test will attempt to
install the latest version, but it incorrectly installs the version
from the actual NPM registry instead of the local registry.