### PR TITLE
fix(@schematics/angular): keep tslint rules ordered

### DIFF
--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -96,23 +96,16 @@ function readTsLintConfig(host: Tree, path: string): JsonAstObject {
 function mergeWithRootTsLint(parentHost: Tree) {
   return (host: Tree) => {
     const tsLintPath = '/tslint.json';
+    const rulesPath = ['rules'];
     if (!host.exists(tsLintPath)) {
       return;
     }
 
-    const rootTslintConfig = new JSONFile(parentHost, tsLintPath);
-    const appTslintConfig = new JSONFile(host, tsLintPath);
-
-    for (const [pKey, pValue] of Object.entries(rootTslintConfig.get([]) as Record<string, JsonValue>)) {
-      if (typeof pValue !== 'object' || Array.isArray(pValue)) {
-        appTslintConfig.modify([pKey], pValue);
-        continue;
-      }
-
-      for (const [key, value] of Object.entries(rootTslintConfig.get([pKey]) as Record<string, JsonObject>)) {
-        appTslintConfig.modify([pKey, key], value);
-      }
-    }
+    const rootTsLintFile = new JSONFile(parentHost, tsLintPath);
+    const rootRules = rootTsLintFile.get(rulesPath) as {};
+    const appRules = new JSONFile(host, tsLintPath).get(rulesPath) as {};
+    rootTsLintFile.modify(rulesPath, { ...rootRules, ...appRules });
+    host.overwrite(tsLintPath, rootTsLintFile.content);
   };
 }
 

--- a/packages/schematics/angular/application/index_spec.ts
+++ b/packages/schematics/angular/application/index_spec.ts
@@ -417,6 +417,9 @@ describe('Application Schematic', () => {
       expect(content.extends).toMatch('tslint:recommended');
       expect(content.rules['component-selector'][2]).toMatch('app');
       expect(content.rules['no-console']).toBeDefined();
+      // codelyzer rules should be after base tslint rules
+      expect(Object.keys(content.rules).indexOf('component-selector'))
+        .toBeGreaterThan(Object.keys(content.rules).indexOf('no-console'));
     });
 
     it(`should create correct paths when 'newProjectRoot' is blank`, async () => {

--- a/packages/schematics/angular/utility/json-file.ts
+++ b/packages/schematics/angular/utility/json-file.ts
@@ -10,11 +10,12 @@ import { JsonValue } from '@angular-devkit/core';
 import { Tree } from '@angular-devkit/schematics';
 import { Node, applyEdits, findNodeAtLocation, getNodeValue, modify, parseTree } from 'jsonc-parser';
 
+export type InsertionIndex = (properties: string[]) => number;
 export type JSONPath = (string | number)[];
 
 /** @internal */
 export class JSONFile {
-  private content: string;
+  content: string;
   error: undefined | Error;
 
   constructor(
@@ -50,10 +51,13 @@ export class JSONFile {
     return node === undefined ? undefined : getNodeValue(node);
   }
 
-  modify(jsonPath: JSONPath, value: JsonValue | undefined, getInsertionIndex?: (properties: string[]) => number): void {
-    if (!getInsertionIndex) {
+  modify(jsonPath: JSONPath, value: JsonValue | undefined, insertInOrder?: InsertionIndex | false): void {
+    let getInsertionIndex: InsertionIndex | undefined;
+    if (insertInOrder === undefined) {
       const property = jsonPath.slice(-1)[0];
       getInsertionIndex = properties => [...properties, property].sort().findIndex(p => p === property);
+    } else if (insertInOrder !== false) {
+      getInsertionIndex = insertInOrder;
     }
 
     const edits = modify(


### PR DESCRIPTION
The schematics recently siwtcher to `jsonc-parser` as the JSOn parser, and that introduced a small regression in the tslint.json file where the rules order is not the same as previously.

See https://github.com/cexbrayat/angular-cli-diff/compare/10.0.2...10.1.0-next.0

This commit should fix the issue by providing the insertion index when merging the tslint files.
A test has also been added to avoid further regressions.