### PR TITLE
test(@angular-devkit/build-angular): increase rebuild debounce times

### DIFF
--- a/packages/angular_devkit/build_angular/src/browser/specs/web-worker_spec.ts
+++ b/packages/angular_devkit/build_angular/src/browser/specs/web-worker_spec.ts
@@ -147,7 +147,7 @@ describe('Browser Builder Web Worker support', () => {
     const { run } = await timer(1000).pipe(
       switchMap(() => architect.scheduleTarget(target, overrides)),
       switchMap(run => run.output.pipe(map(output => ({ run, output })))),
-      debounceTime(500),
+      debounceTime(1000),
       tap(({ output }) => expect(output.success).toBe(true, 'build should succeed')),
       tap(() => {
         switch (phase) {


### PR DESCRIPTION
CI performance variability can cause test flakes in rebuild tests due to the rebuilds taking longer than expected.  This change increases the 500ms debounce time for the web worker rebuild tests to 1000ms to mitigate these issues.