### PR TITLE
Fixes publish and dist-tag scripts.

### DIFF
--- a/docs/process/release.md
+++ b/docs/process/release.md
@@ -168,13 +168,23 @@ For the first release of a major version, follow the instructions in
 For non-major release, check out the patch branch (e.g. `9.1.x`), then run:
 ```bash
 yarn # Reload dependencies
-yarn admin publish
+yarn admin publish --tag latest
 ```
 
 If also publishing a prerelease, check out `master`, then run:
 ```bash
 yarn # Reload dependencies
 yarn admin publish --tag next
+```
+
+If also publish an LTS branch, check out that patch branch (e.g. `8.3.x`), then
+run:
+
+**Make sure to update the NPM tag for the version you are releasing!**
+
+```bash
+yarn # Reload dependencies
+yarn admin publish --tag v8-lts
 ```
 
 ### Release Notes

--- a/lib/registries.ts
+++ b/lib/registries.ts
@@ -1,0 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/** URL to Wombat NPM registry proxy. */
+export const wombat = 'https://wombat-dressing-room.appspot.com';

--- a/scripts/dist-tag.ts
+++ b/scripts/dist-tag.ts
@@ -37,7 +37,7 @@ interface DistTagOptions {
 /**
  * This function adds a tag to all public packages in the CLI repo.
  */
-export default function(args: DistTagOptions, logger: logging.Logger) {
+export default function(args: Partial<DistTagOptions>, logger: logging.Logger) {
   if (args.help) {
     logger.info(`dist-tag adds a tag to all public packages in the CLI repo.
 

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -10,8 +10,8 @@ import { logging, tags } from '@angular-devkit/core';
 import { spawnSync } from 'child_process';
 import * as semver from 'semver';
 import { packages } from '../lib/packages';
+import { wombat } from '../lib/registries';
 import build from './build';
-
 
 export interface PublishArgs {
   tag?: string;
@@ -118,7 +118,7 @@ export default async function (args: PublishArgs, logger: logging.Logger) {
         }
 
         // If no registry is provided, the wombat proxy should be used.
-        publishArgs.push('--registry', args.registry || 'https://wombat-dressing-room.appspot.com');
+        publishArgs.push('--registry', args.registry ?? wombat);
 
         return _exec('npm', publishArgs, {
           cwd: pkg.dist,

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -20,7 +20,6 @@ export interface PublishArgs {
   registry?: string;
 }
 
-
 function _exec(command: string, args: string[], opts: { cwd?: string }, logger: logging.Logger) {
   if (process.platform.startsWith('win')) {
     args.unshift('/c', command);
@@ -52,7 +51,8 @@ function _branchCheck(args: PublishArgs, logger: logging.Logger) {
     case 'master':
       if (args.tag !== 'next') {
         throw new Error(tags.oneLine`
-          Releasing from master requires a next tag. Use --branchCheck=false to skip this check.
+          Releasing from master requires a next tag. Use --no-branchCheck to
+          skip this check.
         `);
       }
   }
@@ -75,7 +75,7 @@ function _versionCheck(args: PublishArgs, logger: logging.Logger) {
   if (betaOrRc && args.tag !== 'next') {
     throw new Error(tags.oneLine`
       Releasing version ${JSON.stringify(version)} requires a next tag.
-      Use --versionCheck=false to skip this check.
+      Use --no-versionCheck to skip this check.
     `);
   }
 
@@ -90,10 +90,11 @@ function _versionCheck(args: PublishArgs, logger: logging.Logger) {
 }
 
 export default async function (args: PublishArgs, logger: logging.Logger) {
-  if (args.branchCheck === undefined || args.branchCheck === true) {
+  if (args.branchCheck ?? true) {
     _branchCheck(args, logger);
   }
-  if (args.versionCheck === undefined || args.versionCheck === true) {
+
+  if (args.versionCheck ?? true) {
     _versionCheck(args, logger);
   }
 

--- a/tests/legacy-cli/e2e/setup/010-local-publish.ts
+++ b/tests/legacy-cli/e2e/setup/010-local-publish.ts
@@ -8,8 +8,8 @@ export default async function() {
     'admin',
     '--',
     'publish',
-    '--versionCheck=false',
-    '--branchCheck=false',
+    '--no-versionCheck',
+    '--no-branchCheck',
     '--registry=http://localhost:4873',
   ];
 

--- a/tests/legacy-cli/e2e/setup/010-local-publish.ts
+++ b/tests/legacy-cli/e2e/setup/010-local-publish.ts
@@ -16,6 +16,8 @@ export default async function() {
   const pre = prerelease(packages['@angular/cli'].version);
   if (pre && pre.length > 0) {
     publishArgs.push('--tag', 'next');
+  } else {
+    publishArgs.push('--tag', 'latest');
   }
 
   await npm(...publishArgs);


### PR DESCRIPTION
This fixes a few known bugs in `publish` and `dist-tag`, as well as a few new ones I found along the way.

Ideally this would have been at least two distinct PRs, but they touched each other when it relates to registries in a way that would have been a pain with multiple PRs.