### PR TITLE
[9.1.x] test: move app-shell tests to flake jail

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -252,6 +252,8 @@ jobs:
       - run: yarn webdriver-update
       - run: yarn test-large --full --flakey --ve
       - run: yarn test-large --full --flakey
+      - run: yarn test-large --full --glob packages/angular_devkit/build_angular/test/app-shell/app-shell_spec_large_disabled.ts --ve
+      - run: yarn test-large --full --glob packages/angular_devkit/build_angular/test/app-shell/app-shell_spec_large_disabled.ts
 
   build-bazel:
     executor: action-executor

--- a/packages/angular_devkit/build_angular/test/app-shell/app-shell_spec_large_disabled.ts
+++ b/packages/angular_devkit/build_angular/test/app-shell/app-shell_spec_large_disabled.ts
@@ -5,11 +5,20 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+// tslint:disable-next-line: no-global-tslint-disable
 // tslint:disable:no-big-function
 import { Architect } from '@angular-devkit/architect/src/architect';
 import { getSystemPath, join, normalize, virtualFs } from '@angular-devkit/core';
 import * as express from 'express'; // tslint:disable-line:no-implicit-dependencies
 import { createArchitect, host } from '../utils';
+
+// This test is excluded by default and will need to be run explicitly.
+// This is because App-Shell builder uses zone.js which patched the global Promise
+// Currently there is no clean way to unload zone.js which causes tests that run after
+// this to be extremly flaky.
+
+// To run this test use:
+// yarn test-large --full --glob packages/angular_devkit/build_angular/test/app-shell/app-shell_spec_large_disabled.ts
 
 describe('AppShell Builder', () => {
   const target = { project: 'app', target: 'app-shell' };


### PR DESCRIPTION
App-shell builder imports zone.js, which patches the global promises. In some cases this will causes flakiness in tests that run after this one.

With this change we move the app-shell tests to the flake jail and force them to be run at the very last.

Successful runs when disabling app-shell tests from test-large
https://circleci.com/workflow-run/4afb40f2-19ec-46ab-bb94-4153d448e6ad

(cherry picked from commit 7cb470f32ea6fffdb8915a2948abb355101e927f)