### PR TITLE
fix(@angular-devkit/build-angular): suppress warning for CommonJS templateUrl and styleUrl

### DIFF
--- a/packages/angular_devkit/build_angular/src/browser/specs/common-js-warning_spec.ts
+++ b/packages/angular_devkit/build_angular/src/browser/specs/common-js-warning_spec.ts
@@ -77,4 +77,24 @@ describe('Browser Builder commonjs warning', () => {
     expect(logs.join()).not.toContain('WARNING');
     await run.stop();
   });
+
+  it('should not show warning in JIT for templateUrl and styleUrl when using paths', async () => {
+    host.replaceInFile('tsconfig.base.json', /"baseUrl": ".\/",/, `
+      "baseUrl": "./",
+      "paths": {
+        "@app/*": [
+          "src/app/*"
+        ]
+      },
+    `);
+
+    host.replaceInFile('src/app/app.module.ts', './app.component', '@app/app.component');
+
+    const run = await architect.scheduleTarget(targetSpec, { aot: false }, { logger });
+    const output = await run.result;
+    expect(output.success).toBe(true);
+
+    expect(logs.join()).not.toContain('WARNING');
+    await run.stop();
+  });
 });


### PR DESCRIPTION


Currently, when users use either absolute paths, or path mappings in JIT mode, we issue a warning for templateUrl and styleUrl. With this change we suppress those warning.

Closes: #18057