### PR TITLE
ci: update configuration to use new CircleCI docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,9 @@
 
 version: 2.1
 
+orbs:
+  browser-tools: circleci/browser-tools@1.0.1
+
 # Variables
 
 ## IMPORTANT
@@ -38,7 +41,7 @@ executors:
         type: string
         default: *default_nodeversion
     docker:
-      - image: circleci/node:<< parameters.nodeversion >>
+      - image: cimg/node:<< parameters.nodeversion >>
     working_directory: ~/ng
     resource_class: small
 
@@ -48,7 +51,7 @@ executors:
         type: string
         default: *default_nodeversion
     docker:
-      - image: circleci/node:<< parameters.nodeversion >>-browsers
+      - image: cimg/node:<< parameters.nodeversion >>
     working_directory: ~/ng
     environment:
       NPM_CONFIG_PREFIX: ~/.npm-global
@@ -106,6 +109,15 @@ commands:
             # Enable remote builds
             sudo bash -c "echo -e 'build --config=remote' >> .bazelrc.user";
             echo "Reading from remote cache for bazel remote jobs.";
+
+  install_python:
+    steps:
+      - run:
+          name: "Install Python 2"
+          command: |
+            sudo apt-get update > /dev/null 2>&1
+            sudo apt-get install -y python
+            python --version
 
 # Job definitions
 jobs:
@@ -168,6 +180,7 @@ jobs:
     parallelism: 6
     steps:
       - custom_attach_workspace
+      - browser-tools/install-chrome
       - run:
           name: Initialize Environment
           command: ./.circleci/env.sh
@@ -182,6 +195,7 @@ jobs:
     parallelism: 4
     steps:
       - custom_attach_workspace
+      - browser-tools/install-chrome
       - run:
           name: Initialize Environment
           command: |
@@ -226,6 +240,7 @@ jobs:
     resource_class: xlarge
     steps:
       - custom_attach_workspace
+      - browser-tools/install-chrome
       - setup_bazel_rbe
       - run: sudo cp .circleci/bazel.rc /etc/bazel.bazelrc
       - run: yarn bazel:test
@@ -235,6 +250,7 @@ jobs:
     resource_class: xlarge
     steps:
       - custom_attach_workspace
+      - install_python
       - run: 
           command: yarn bazel:integration
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,9 +17,9 @@ orbs:
 ## IMPORTANT
 # Windows needs its own cache key because binaries in node_modules are different.
 # See https://circleci.com/docs/2.0/caching/#restoring-cache for how prefixes work in CircleCI.
-var_1: &cache_key angular_devkit-12.9-{{ checksum "yarn.lock" }}
-var_1_win: &cache_key_win angular_devkit-win-12.9-{{ checksum "yarn.lock" }}
-var_3: &default_nodeversion "12.9"
+var_1: &cache_key angular_devkit-12.18-{{ checksum "yarn.lock" }}
+var_1_win: &cache_key_win angular_devkit-win-12.18-{{ checksum "yarn.lock" }}
+var_3: &default_nodeversion "12.18"
 # Workspace initially persisted by the `setup` job, and then enhanced by `setup-and-build-win`.
 # https://circleci.com/docs/2.0/workflows/#using-workspaces-to-share-data-among-jobs
 # https://circleci.com/blog/deep-diving-into-circleci-workspaces/


### PR DESCRIPTION
The previous images are now considered legacy.  The new images are smaller and faster to load.
For additional details: https://hub.docker.com/r/cimg/node