### PR TITLE
fix(@angular-devkit/build-angular): avoid ES module assumption for vendor files

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
@@ -544,6 +544,7 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
                       cacheIdentifier: JSON.stringify({
                         buildAngular: require('../../../../package.json').version,
                       }),
+                      sourceType: 'unambiguous',
                       presets: [
                         [
                           require.resolve('@babel/preset-env'),


### PR DESCRIPTION
This change prevents import statements from being added to commonjs files when downleveling helpers are needed.  These imports would then cause webpack to assume that the file is an ES module and potentially break the commonjs file.

Fixes #18284