### PR TITLE
fix(@angular-devkit/build-angular): mark rxjs add imports as having side effects

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
@@ -527,6 +527,13 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
           parser: { system: true },
         },
         {
+          // Mark files inside `rxjs/add` as containing side effects.
+          // If this is fixed upstream and the fixed version becomes the minimum
+          // supported version, this can be removed.
+          test: /[\/\\]rxjs[\/\\]add[\/\\].+\.js$/,
+          sideEffects: true,
+        },
+        {
           test: /\.m?js$/,
           exclude: [/[\/\\](?:core-js|\@babel|tslib)[\/\\]/, /(ngfactory|ngstyle)\.js$/],
           use: [


### PR DESCRIPTION
This change prevents webpack from removing the operator add imports from the rxjs package (for example, `import 'rxjs/add/operator/filter';`).  The entire rxjs package is currently marked as side effect free from within the rxjs `package.json` but the files in the add directory intentionally contain side effects.