### PR TITLE
docs: fix typo in ng update --next description

### DIFF
--- a/packages/angular/cli/commands/update.json
+++ b/packages/angular/cli/commands/update.json
@@ -38,7 +38,7 @@
           "type": "boolean"
         },
         "next": {
-          "description": "Use the latest version, including beta and RCs.",
+          "description": "Use the prerelease version, including beta and RCs.",
           "default": false,
           "type": "boolean"
         },

--- a/packages/angular/cli/commands/update.json
+++ b/packages/angular/cli/commands/update.json
@@ -38,7 +38,7 @@
           "type": "boolean"
         },
         "next": {
-          "description": "Use the largest version, including beta and RCs.",
+          "description": "Use the latest version, including beta and RCs.",
           "default": false,
           "type": "boolean"
         },


### PR DESCRIPTION
`--next` arg description probably should be 
Use the **latest** version, including beta and RCs and not **largest**