### PR TITLE
fix(@schematics/angular): remove compileComponents from component test schematic

### DIFF
--- a/integration/angular_cli/src/app/app.component.spec.ts
+++ b/integration/angular_cli/src/app/app.component.spec.ts
@@ -2,13 +2,9 @@ import { TestBed } from '@angular/core/testing';
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [
-        AppComponent
-      ],
-    }).compileComponents();
-  });
+  beforeEach(() => TestBed.configureTestingModule({
+    declarations: [AppComponent]
+  }));
 
   it('should create the app', () => {
     const fixture = TestBed.createComponent(AppComponent);

--- a/packages/angular_devkit/build_angular/src/karma/works_spec.ts
+++ b/packages/angular_devkit/build_angular/src/karma/works_spec.ts
@@ -68,15 +68,10 @@ describe('Karma Builder', () => {
         import { AppComponent } from './app.component';
 
         describe('AppComponent', () => {
-          beforeEach(async () => {
-            await TestBed.configureTestingModule({
-              imports: [
-              ],
-              declarations: [
-                AppComponent
-              ]
-            }).compileComponents();
-          });
+          beforeEach(() => TestBed.configureTestingModule({
+            imports: [],
+            declarations: [AppComponent]
+          }));
 
           it('should not contain text that is hidden via css', () => {
             const fixture = TestBed.createComponent(AppComponent);
@@ -148,16 +143,10 @@ describe('Karma Builder', () => {
         import { AppComponent } from './app.component';
 
         describe('AppComponent', () => {
-          beforeEach(async () => {
-            await TestBed.configureTestingModule({
-              imports: [
-                HttpClientModule
-              ],
-              declarations: [
-                AppComponent
-              ]
-            }).compileComponents();
-          });
+          beforeEach(() => TestBed.configureTestingModule({
+            imports: [HttpClientModule],
+            declarations: [AppComponent]
+          }));
 
           it('should create the app', () => {
             const fixture = TestBed.createComponent(AppComponent);

--- a/packages/angular_devkit/build_angular/test/hello-world-app/src/app/app.component.spec.ts
+++ b/packages/angular_devkit/build_angular/test/hello-world-app/src/app/app.component.spec.ts
@@ -8,11 +8,9 @@
 import { TestBed } from '@angular/core/testing';
 import { AppComponent } from './app.component';
 describe('AppComponent', () => {
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [AppComponent],
-    }).compileComponents();
-  });
+  beforeEach(() => TestBed.configureTestingModule({
+    declarations: [AppComponent],
+  }));
   it('should create the app', () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.debugElement.componentInstance;

--- a/packages/angular_devkit/build_ng_packagr/test/ng-packaged/projects/lib/src/lib/lib.component.spec.ts
+++ b/packages/angular_devkit/build_ng_packagr/test/ng-packaged/projects/lib/src/lib/lib.component.spec.ts
@@ -13,12 +13,9 @@ describe('LibComponent', () => {
   let component: LibComponent;
   let fixture: ComponentFixture<LibComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [ LibComponent ]
-    })
-    .compileComponents();
-  });
+  beforeEach(() => TestBed.configureTestingModule({
+    declarations: [LibComponent]
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(LibComponent);

--- a/packages/angular_devkit/build_webpack/test/angular-app/src/app/app.component.spec.ts
+++ b/packages/angular_devkit/build_webpack/test/angular-app/src/app/app.component.spec.ts
@@ -8,13 +8,9 @@
 import { TestBed } from '@angular/core/testing';
 import { AppComponent } from './app.component';
 describe('AppComponent', () => {
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [
-        AppComponent
-      ],
-    }).compileComponents();
-  });
+  beforeEach(() => TestBed.configureTestingModule({
+      declarations: [AppComponent]
+  }));
   it('should create the app', () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.debugElement.componentInstance;

--- a/packages/schematics/angular/application/other-files/app.component.spec.ts.template
+++ b/packages/schematics/angular/application/other-files/app.component.spec.ts.template
@@ -3,16 +3,10 @@ import { RouterTestingModule } from '@angular/router/testing';<% } %>
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({<% if (routing) { %>
-      imports: [
-        RouterTestingModule
-      ],<% } %>
-      declarations: [
-        AppComponent
-      ],
-    }).compileComponents();
-  });
+  beforeEach(() => TestBed.configureTestingModule({<% if (routing) { %>
+    imports: [RouterTestingModule],<% } %>
+    declarations: [AppComponent]
+  }));
 
   it('should create the app', () => {
     const fixture = TestBed.createComponent(AppComponent);

--- a/packages/schematics/angular/component/files/__name@dasherize@if-flat__/__name@dasherize__.__type@dasherize__.spec.ts.template
+++ b/packages/schematics/angular/component/files/__name@dasherize@if-flat__/__name@dasherize__.__type@dasherize__.spec.ts.template
@@ -6,12 +6,9 @@ describe('<%= classify(name) %><%= classify(type) %>', () => {
   let component: <%= classify(name) %><%= classify(type) %>;
   let fixture: ComponentFixture<<%= classify(name) %><%= classify(type) %>>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [ <%= classify(name) %><%= classify(type) %> ]
-    })
-    .compileComponents();
-  });
+  beforeEach(() => TestBed.configureTestingModule({
+    declarations: [<%= classify(name) %><%= classify(type) %>]
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(<%= classify(name) %><%= classify(type) %>);

--- a/tests/legacy-cli/e2e/assets/1.0-project/src/app/app.component.spec.ts
+++ b/tests/legacy-cli/e2e/assets/1.0-project/src/app/app.component.spec.ts
@@ -3,13 +3,9 @@ import { TestBed } from '@angular/core/testing';
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [
-        AppComponent
-      ],
-    }).compileComponents();
-  });
+  beforeEach(() => TestBed.configureTestingModule({
+    declarations: [AppComponent]
+  }));
 
   it('should create the app', () => {
     const fixture = TestBed.createComponent(AppComponent);

--- a/tests/legacy-cli/e2e/assets/1.7-project/src/app/app.component.spec.ts
+++ b/tests/legacy-cli/e2e/assets/1.7-project/src/app/app.component.spec.ts
@@ -1,13 +1,9 @@
 import { TestBed } from '@angular/core/testing';
 import { AppComponent } from './app.component';
 describe('AppComponent', () => {
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [
-        AppComponent
-      ],
-    }).compileComponents();
-  });
+  beforeEach(() => TestBed.configureTestingModule({
+    declarations: [AppComponent]
+  }));
   it('should create the app', () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.debugElement.componentInstance;

--- a/tests/legacy-cli/e2e/assets/7.0-project/src/app/app.component.spec.ts
+++ b/tests/legacy-cli/e2e/assets/7.0-project/src/app/app.component.spec.ts
@@ -3,16 +3,10 @@ import { RouterModule } from '@angular/router';
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [
-        AppComponent
-      ],
-      imports: [
-        RouterModule.forRoot([])
-      ],
-    }).compileComponents();
-  });
+  beforeEach(() => TestBed.configureTestingModule({
+    declarations: [AppComponent],
+    imports: [RouterModule.forRoot([])]
+  }));
 
   it('should create the app', () => {
     const fixture = TestBed.createComponent(AppComponent);

--- a/tests/legacy-cli/e2e/assets/7.0-project/src/app/lazy/lazy-comp/lazy-comp.component.spec.ts
+++ b/tests/legacy-cli/e2e/assets/7.0-project/src/app/lazy/lazy-comp/lazy-comp.component.spec.ts
@@ -6,12 +6,9 @@ describe('LazyCompComponent', () => {
   let component: LazyCompComponent;
   let fixture: ComponentFixture<LazyCompComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [ LazyCompComponent ]
-    })
-    .compileComponents();
-  });
+  beforeEach(() => TestBed.configureTestingModule({
+    declarations: [LazyCompComponent]
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(LazyCompComponent);

--- a/tests/legacy-cli/e2e/tests/test/test-scripts.ts
+++ b/tests/legacy-cli/e2e/tests/test/test-scripts.ts
@@ -32,11 +32,9 @@ export default function () {
         import { AppComponent } from './app.component';
 
         describe('AppComponent', () => {
-          beforeEach(async () => {
-            await TestBed.configureTestingModule({
-              declarations: [ AppComponent ]
-            }).compileComponents();
-          });
+          beforeEach(() => TestBed.configureTestingModule({
+            declarations: [AppComponent]
+          }));
 
           it('should have access to string-script.js', () => {
             let app = TestBed.createComponent(AppComponent).debugElement.componentInstance;


### PR DESCRIPTION
`compileComponents` is not necessary when using the CLI and just adds boilerplate code, so we can remove it from the test schematic and make it independent from `async/await` (only place we would have it in the CLI generated code, and in most Angular apps).