### PR TITLE
ci: fix issue where renovate is not updating the root level package.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -30,11 +30,6 @@
     "packages/**/package.json",
     "tests/legacy-cli/e2e/ng-snapshot/package.json"
   ],
-  "major": {
-    "devDependencies": {
-      "enabled": true
-    }
-  },
   "packageRules": [
     {
       "packagePatterns": [
@@ -72,19 +67,6 @@
       "updateTypes": [
         "minor",
         "major"
-      ],
-      "enabled": false
-    },
-    {
-      "depTypeList": ["devDependencies"],
-      "updateTypes": ["patch", "minor"],
-      "groupName": "non-major devDependencies",
-      "excludePackagePatterns": [
-        "typescript",
-        "bazel_toolchains",
-        "^@bazel\/.*",
-        "^build_bazel.*",
-        "^@angular\/.*"
       ],
       "enabled": false
     }


### PR DESCRIPTION
With this change we fix an issue where dev dependencies in the root package.json are not being updated.

In #18299 we that the `open` has been updated in 2 child `package.json`, however the root `package.json` has been left out of sync. https://github.com/angular/angular-cli/blob/65d0d952f193f8c8e419a62659ac0954cf57b6b8/package.json#L177
