### PR TITLE
ci: update release docs to use annotated tags for releases

### DIFF
--- a/docs/process/release.md
+++ b/docs/process/release.md
@@ -121,7 +121,7 @@ As commits are cherry-picked when PRs are merged, creating the release should be
 
 ```bash
 git commit -a -m 'release: vXX'
-git tag 'vXX'
+git tag -a 'vXX' -m 'release: tag vXX'
 ```
 
 The package versions we are about to publish are derived from the git tag that
@@ -132,11 +132,11 @@ following command.
 yarn admin packages --version
 ```
 
-Now push the commit and the tag to the upstream repository.
-**Make sure to run these commands together, as missing tags can cause CI failures.**
+Now push the commit and the tag to the upstream repository. **Make sure to use
+`--follow-tags, as tags need to be pushed immediately or CI may fail!**
 
 ```bash
-git push upstream && git push upstream --tags
+git push upstream --follow-tags
 ```
 
 ### Authenticating


### PR DESCRIPTION
This changes from using lightweight tags to annotated tags. The later includes author, time, and message information that is lacking from the former. It is also included in Git's `--follow-tags` option. This should allow us to push tags alongside release commits more atomically and hopefully eliminate or at least reduce the possibility of a race condition arising from CI starting on the release commit before the associated tag is pushed. Such a state causes CI failures, because they take the latest version from the most recent `v*` tag.

I tested the flow on my local fork, but I can't test a real release unfortunately. I believe our existing infrastructure should "just work", but please let me know if that doesn't appear to be the case.