### PR TITLE
Fixes publish script to require NPM tag, use Wombat registry, and correctly read check flags

### DIFF
--- a/lib/registries.ts
+++ b/lib/registries.ts
@@ -1,0 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/** URL to Wombat NPM registry proxy. */
+export const wombat = 'https://wombat-dressing-room.appspot.com';

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -10,8 +10,8 @@ import { logging, tags } from '@angular-devkit/core';
 import { spawnSync } from 'child_process';
 import * as semver from 'semver';
 import { packages } from '../lib/packages';
+import { wombat } from '../lib/registries';
 import build from './build';
-
 
 export interface PublishArgs {
   tag?: string;
@@ -116,9 +116,10 @@ export default async function (args: PublishArgs, logger: logging.Logger) {
         if (args.tag) {
           publishArgs.push('--tag', args.tag);
         }
-        if (args.registry) {
-          publishArgs.push('--registry', args.registry);
-        }
+
+        // If no registry is provided, the wombat proxy should be used.
+        const registry = args.registry !== undefined ? args.registry : wombat;
+        publishArgs.push('--registry', registry);
 
         return _exec('npm', publishArgs, {
           cwd: pkg.dist,

--- a/tests/legacy-cli/e2e/setup/010-local-publish.ts
+++ b/tests/legacy-cli/e2e/setup/010-local-publish.ts
@@ -8,14 +8,16 @@ export default async function() {
     'admin',
     '--',
     'publish',
-    '--versionCheck=false',
-    '--branchCheck=false',
+    '--no-versionCheck',
+    '--no-branchCheck',
     '--registry=http://localhost:4873',
   ];
 
   const pre = prerelease(packages['@angular/cli'].version);
   if (pre && pre.length > 0) {
     publishArgs.push('--tag', 'next');
+  } else {
+    publishArgs.push('--tag', 'latest');
   }
 
   await npm(...publishArgs);


### PR DESCRIPTION
This is a patch PR for https://github.com/angular/angular-cli/pull/18219. The `dist-tag` changes are not present here because that script does not exist and would not be used from this branch.

I also dropped the `doc:` commit since we don't typically look at docs on the non-master branch.

Only meaningful difference with the base PR is that I replaced the nullish coalescing operators with ugly ternaries to be compatible with the older typescript version.