### PR TITLE
ci: use ramdisk for setup job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,6 @@ executors:
         default: *default_nodeversion
     docker:
       - image: cimg/node:<< parameters.nodeversion >>
-    working_directory: ~/ng
     resource_class: small
 
   test-executor:
@@ -52,14 +51,12 @@ executors:
         default: *default_nodeversion
     docker:
       - image: cimg/node:<< parameters.nodeversion >>
-    working_directory: ~/ng
     environment:
       NPM_CONFIG_PREFIX: ~/.npm-global
     resource_class: large
 
   windows-executor:
     # Same as https://circleci.com/orbs/registry/orb/circleci/windows, but named.
-    working_directory: ~/ng
     resource_class: windows.medium
     shell: powershell.exe -ExecutionPolicy Bypass
     machine:
@@ -124,6 +121,7 @@ jobs:
   setup:
     executor: action-executor
     resource_class: medium
+    working_directory: /mnt/ramdisk
     steps:
       - checkout
       - run:


### PR DESCRIPTION
The setup job performs a large amount of disk IO including yarn install and ngcc.