### PR TITLE
build: minor fixes for google3 sync

### DIFF
--- a/packages/angular/cli/BUILD.bazel
+++ b/packages/angular/cli/BUILD.bazel
@@ -3,13 +3,14 @@
 # Use of this source code is governed by an MIT-style license that can be
 # found in the LICENSE file at https://angular.io/license
 
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 load("@npm_bazel_jasmine//:index.bzl", "jasmine_node_test")
-load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
 load("//tools:ts_json_schema.bzl", "ts_json_schema")
 load("//tools:defaults.bzl", "ts_library")
 
-licenses(["notice"])  # MIT
+# @external_begin
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
+# @external_end
 
 licenses(["notice"])  # MIT
 
@@ -25,6 +26,8 @@ ts_library(
             "node_modules/**",
         ],
     ) + [
+        # @external_begin
+        # These files are generated from the JSON schema
         "//packages/angular/cli:lib/config/schema.ts",
         "//packages/angular/cli:commands/analytics.ts",
         "//packages/angular/cli:commands/add.ts",
@@ -44,6 +47,7 @@ ts_library(
         "//packages/angular/cli:commands/version.ts",
         "//packages/angular/cli:commands/run.ts",
         "//packages/angular/cli:commands/xi18n.ts",
+        # @external_end
     ],
     data = glob(
         include = [
@@ -65,10 +69,9 @@ ts_library(
         "//packages/angular_devkit/core/node",
         "//packages/angular_devkit/schematics",
         "//packages/angular_devkit/schematics/tools",
-        # @node_module: typescript:es2017.object
         "@npm//@types/debug",
-        "@npm//@types/node",
         "@npm//@types/inquirer",
+        "@npm//@types/node",
         "@npm//@types/rimraf",
         "@npm//@types/semver",
         "@npm//@types/universal-analytics",
@@ -248,6 +251,7 @@ jasmine_node_test(
     srcs = [":angular-cli_test_lib"],
 )
 
+# @external_begin
 pkg_npm(
     name = "npm_package",
     deps = [
@@ -262,3 +266,4 @@ pkg_tar(
     strip_prefix = "./npm_package",
     tags = ["manual"],
 )
+# @external_end

--- a/packages/angular/cli/commands/add-impl.ts
+++ b/packages/angular/cli/commands/add-impl.ts
@@ -147,7 +147,7 @@ export class AddCommand extends SchematicCommand<AddCommandSchema> {
         usingYarn,
       });
 
-      savePackage = manifest['ng-add'] && manifest['ng-add'].save;
+      savePackage = manifest['ng-add']?.save;
       collectionName = manifest.name;
 
       if (await this.hasMismatchedPeer(manifest)) {

--- a/packages/angular/pwa/BUILD.bazel
+++ b/packages/angular/pwa/BUILD.bazel
@@ -9,8 +9,6 @@ load("//tools:ts_json_schema.bzl", "ts_json_schema")
 
 licenses(["notice"])  # MIT
 
-licenses(["notice"])  # MIT
-
 package(default_visibility = ["//visibility:public"])
 
 ts_library(

--- a/packages/angular_devkit/architect/BUILD.bazel
+++ b/packages/angular_devkit/architect/BUILD.bazel
@@ -3,15 +3,14 @@
 # Use of this source code is governed by an MIT-style license that can be
 # found in the LICENSE file at https://angular.io/license
 
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 load("@npm_bazel_jasmine//:index.bzl", "jasmine_node_test")
 load("//tools:defaults.bzl", "ts_library")
+load("//tools:ts_json_schema.bzl", "ts_json_schema")
 
 # @external_begin
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
-
 # @external_end
-load("//tools:ts_json_schema.bzl", "ts_json_schema")
 
 licenses(["notice"])  # MIT
 
@@ -43,10 +42,13 @@ ts_library(
         include = ["src/**/*.ts"],
         exclude = ["**/*_spec.ts"],
     ) + [
+        # @external_begin
+        # These files are generated from the JSON schema
         "//packages/angular_devkit/architect:src/input-schema.ts",
         "//packages/angular_devkit/architect:src/output-schema.ts",
         "//packages/angular_devkit/architect:src/builders-schema.ts",
         "//packages/angular_devkit/architect:src/progress-schema.ts",
+        # @external_end
     ],
     # strict_checks = False,
     data = glob(

--- a/packages/angular_devkit/architect/node/BUILD.bazel
+++ b/packages/angular_devkit/architect/node/BUILD.bazel
@@ -7,8 +7,6 @@ load("//tools:defaults.bzl", "ts_library")
 
 licenses(["notice"])  # MIT
 
-licenses(["notice"])  # MIT
-
 package(default_visibility = ["//visibility:public"])
 
 ts_library(

--- a/packages/angular_devkit/architect/testing/BUILD.bazel
+++ b/packages/angular_devkit/architect/testing/BUILD.bazel
@@ -7,8 +7,6 @@ load("//tools:defaults.bzl", "ts_library")
 
 licenses(["notice"])  # MIT
 
-licenses(["notice"])  # MIT
-
 package(default_visibility = ["//visibility:public"])
 
 ts_library(

--- a/packages/angular_devkit/benchmark/BUILD.bazel
+++ b/packages/angular_devkit/benchmark/BUILD.bazel
@@ -3,10 +3,13 @@
 # Use of this source code is governed by an MIT-style license that can be
 # found in the LICENSE file at https://angular.io/license
 
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 load("@npm_bazel_jasmine//:index.bzl", "jasmine_node_test")
-load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
 load("//tools:defaults.bzl", "ts_library")
+
+# @external_begin
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
+# @external_end
 
 licenses(["notice"])  # MIT
 
@@ -68,6 +71,7 @@ jasmine_node_test(
     ],
 )
 
+# @external_begin
 pkg_npm(
     name = "npm_package",
     deps = [
@@ -82,3 +86,4 @@ pkg_tar(
     strip_prefix = "./npm_package",
     tags = ["manual"],
 )
+# @external_end

--- a/packages/angular_devkit/build_angular/BUILD.bazel
+++ b/packages/angular_devkit/build_angular/BUILD.bazel
@@ -3,11 +3,14 @@
 # Use of this source code is governed by an MIT-style license that can be
 # found in the LICENSE file at https://angular.io/license
 
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 load("@npm_bazel_jasmine//:index.bzl", "jasmine_node_test")
-load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
 load("//tools:defaults.bzl", "ts_library")
 load("//tools:ts_json_schema.bzl", "ts_json_schema")
+
+# @external_begin
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
+# @external_end
 
 licenses(["notice"])  # MIT
 
@@ -206,6 +209,7 @@ jasmine_node_test(
     srcs = [":build_angular_test_lib"],
 )
 
+# @external_begin
 pkg_npm(
     name = "npm_package",
     deps = [
@@ -220,7 +224,7 @@ pkg_tar(
     strip_prefix = "./npm_package",
     tags = ["manual"],
 )
-
+# @external_end
 # Large build_angular specs
 
 ts_library(

--- a/packages/angular_devkit/build_ng_packagr/BUILD.bazel
+++ b/packages/angular_devkit/build_ng_packagr/BUILD.bazel
@@ -3,11 +3,14 @@
 # Use of this source code is governed by an MIT-style license that can be
 # found in the LICENSE file at https://angular.io/license
 
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 load("@npm_bazel_jasmine//:index.bzl", "jasmine_node_test")
-load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
 load("//tools:defaults.bzl", "ts_library")
 load("//tools:ts_json_schema.bzl", "ts_json_schema")
+
+# @external_begin
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
+# @external_end
 
 licenses(["notice"])  # MIT
 
@@ -41,6 +44,7 @@ ts_library(
     ],
 )
 
+# @external_begin
 pkg_npm(
     name = "npm_package",
     deps = [
@@ -55,6 +59,7 @@ pkg_tar(
     strip_prefix = "./npm_package",
     tags = ["manual"],
 )
+# @external_end
 
 ts_library(
     name = "build_ng_packagr_test_lib",

--- a/packages/angular_devkit/build_optimizer/BUILD.bazel
+++ b/packages/angular_devkit/build_optimizer/BUILD.bazel
@@ -3,10 +3,13 @@
 # Use of this source code is governed by an MIT-style license that can be
 # found in the LICENSE file at https://angular.io/license
 
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 load("@npm_bazel_jasmine//:index.bzl", "jasmine_node_test")
-load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
 load("//tools:defaults.bzl", "ts_library")
+
+# @external_begin
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
+# @external_end
 
 licenses(["notice"])  # MIT
 
@@ -72,6 +75,7 @@ jasmine_node_test(
     ],
 )
 
+# @external_begin
 pkg_npm(
     name = "npm_package",
     deps = [
@@ -86,3 +90,4 @@ pkg_tar(
     strip_prefix = "./npm_package",
     tags = ["manual"],
 )
+# @external_end

--- a/packages/angular_devkit/build_webpack/BUILD.bazel
+++ b/packages/angular_devkit/build_webpack/BUILD.bazel
@@ -3,11 +3,14 @@
 # Use of this source code is governed by an MIT-style license that can be
 # found in the LICENSE file at https://angular.io/license
 
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 load("@npm_bazel_jasmine//:index.bzl", "jasmine_node_test")
-load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
 load("//tools:defaults.bzl", "ts_library")
 load("//tools:ts_json_schema.bzl", "ts_json_schema")
+
+# @external_begin
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
+# @external_end
 
 licenses(["notice"])  # MIT
 
@@ -103,6 +106,7 @@ jasmine_node_test(
     ],
 )
 
+# @external_begin
 pkg_npm(
     name = "npm_package",
     deps = [
@@ -117,3 +121,4 @@ pkg_tar(
     strip_prefix = "./npm_package",
     tags = ["manual"],
 )
+# @external_end

--- a/packages/angular_devkit/core/BUILD.bazel
+++ b/packages/angular_devkit/core/BUILD.bazel
@@ -1,8 +1,8 @@
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 load("@npm_bazel_jasmine//:index.bzl", "jasmine_node_test")
 load("//tools:defaults.bzl", "ts_library")
 
 # @external_begin
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
 # @external_end
 
@@ -42,12 +42,11 @@ ts_library(
         "@npm//fast-json-stable-stringify",
         "@npm//magic-string",
         "@npm//rxjs",
-        "@npm//source-map",
-        # @node_module: typescript:es2015.core
+        "@npm//source-map",  # @external
         # @node_module: typescript:es2015.proxy
         # @node_module: typescript:es2015.reflect
         # @node_module: typescript:es2015.symbol.wellknown
-        # @node_module: typescript:es2016.array.include
+        # @typings: source_map
     ],
 )
 

--- a/packages/angular_devkit/core/src/terminal/caps.ts
+++ b/packages/angular_devkit/core/src/terminal/caps.ts
@@ -76,7 +76,7 @@ function _getColumns() {
 
 
 function _createCapabilities(
-  stream: Socket,
+  stream: NodeJS.WriteStream,
   isTerminalStream: boolean,
   level: 0|1|2|3 = supportsColor.stdout.level,
 ): StreamCapabilities {
@@ -96,7 +96,7 @@ function _createCapabilities(
 
 
 export function getCapabilities(
-  stream: Socket,
+  stream: NodeJS.WriteStream,
   isTerminalStream = !!stream.isTTY,
 ): StreamCapabilities {
   let maybeCaps = streamMap.get(stream);

--- a/packages/angular_devkit/core/src/terminal/text.ts
+++ b/packages/angular_devkit/core/src/terminal/text.ts
@@ -8,34 +8,34 @@
 import * as caps from './caps';
 import { colors } from './colors';
 
-const stdout = typeof process == 'object'
-  ? caps.getCapabilities(process.stdout) : { colors: false };
+const supportColors: boolean = typeof process === 'object' ? caps.getCapabilities(process.stdout).colors : false;
+const identityFn = (x: string) => x;
 
-export const reset = stdout.colors ? colors.reset : (x: string) => x;
-export const bold = stdout.colors ? colors.bold : (x: string) => x;
-export const dim = stdout.colors ? colors.dim : (x: string) => x;
-export const italic = stdout.colors ? colors.italic : (x: string) => x;
-export const underline = stdout.colors ? colors.underline : (x: string) => x;
-export const inverse = stdout.colors ? colors.inverse : (x: string) => x;
-export const hidden = stdout.colors ? colors.hidden : (x: string) => x;
-export const strikethrough = stdout.colors ? colors.strikethrough : (x: string) => x;
+export const reset = supportColors ? colors.reset : identityFn;
+export const bold = supportColors ? colors.bold : identityFn;
+export const dim = supportColors ? colors.dim : identityFn;
+export const italic = supportColors ? colors.italic : identityFn;
+export const underline = supportColors ? colors.underline : identityFn;
+export const inverse = supportColors ? colors.inverse : identityFn;
+export const hidden = supportColors ? colors.hidden : identityFn;
+export const strikethrough = supportColors ? colors.strikethrough : identityFn;
 
-export const black = stdout.colors ? colors.black : (x: string) => x;
-export const red = stdout.colors ? colors.red : (x: string) => x;
-export const green = stdout.colors ? colors.green : (x: string) => x;
-export const yellow = stdout.colors ? colors.yellow : (x: string) => x;
-export const blue = stdout.colors ? colors.blue : (x: string) => x;
-export const magenta = stdout.colors ? colors.magenta : (x: string) => x;
-export const cyan = stdout.colors ? colors.cyan : (x: string) => x;
-export const white = stdout.colors ? colors.white : (x: string) => x;
-export const grey = stdout.colors ? colors.gray : (x: string) => x;
-export const gray = stdout.colors ? colors.gray : (x: string) => x;
+export const black = supportColors ? colors.black : identityFn;
+export const red = supportColors ? colors.red : identityFn;
+export const green = supportColors ? colors.green : identityFn;
+export const yellow = supportColors ? colors.yellow : identityFn;
+export const blue = supportColors ? colors.blue : identityFn;
+export const magenta = supportColors ? colors.magenta : identityFn;
+export const cyan = supportColors ? colors.cyan : identityFn;
+export const white = supportColors ? colors.white : identityFn;
+export const grey = supportColors ? colors.gray : identityFn;
+export const gray = supportColors ? colors.gray : identityFn;
 
-export const bgBlack = stdout.colors ? colors.bgBlack : (x: string) => x;
-export const bgRed = stdout.colors ? colors.bgRed : (x: string) => x;
-export const bgGreen = stdout.colors ? colors.bgGreen : (x: string) => x;
-export const bgYellow = stdout.colors ? colors.bgYellow : (x: string) => x;
-export const bgBlue = stdout.colors ? colors.bgBlue : (x: string) => x;
-export const bgMagenta = stdout.colors ? colors.bgMagenta : (x: string) => x;
-export const bgCyan = stdout.colors ? colors.bgCyan : (x: string) => x;
-export const bgWhite = stdout.colors ? colors.bgWhite : (x: string) => x;
+export const bgBlack = supportColors ? colors.bgBlack : identityFn;
+export const bgRed = supportColors ? colors.bgRed : identityFn;
+export const bgGreen = supportColors ? colors.bgGreen : identityFn;
+export const bgYellow = supportColors ? colors.bgYellow : identityFn;
+export const bgBlue = supportColors ? colors.bgBlue : identityFn;
+export const bgMagenta = supportColors ? colors.bgMagenta : identityFn;
+export const bgCyan = supportColors ? colors.bgCyan : identityFn;
+export const bgWhite = supportColors ? colors.bgWhite : identityFn;

--- a/packages/angular_devkit/schematics/BUILD.bazel
+++ b/packages/angular_devkit/schematics/BUILD.bazel
@@ -1,8 +1,8 @@
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 load("@npm_bazel_jasmine//:index.bzl", "jasmine_node_test")
 load("//tools:defaults.bzl", "ts_library")
 
 # @external_begin
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
 # @external_end
 

--- a/packages/angular_devkit/schematics_cli/BUILD.bazel
+++ b/packages/angular_devkit/schematics_cli/BUILD.bazel
@@ -41,10 +41,10 @@ ts_library(
         "@npm//@types/inquirer",
         "@npm//@types/minimist",
         "@npm//@types/node",
-        "@npm//inquirer",
-        "@npm//minimist",
+        "@npm//inquirer",  # @external
+        "@npm//minimist",  # @external
         "@npm//rxjs",
-        "@npm//symbol-observable",
+        "@npm//symbol-observable",  # @external
     ],
 )
 

--- a/packages/ngtools/webpack/BUILD.bazel
+++ b/packages/ngtools/webpack/BUILD.bazel
@@ -3,10 +3,13 @@
 # Use of this source code is governed by an MIT-style license that can be
 # found in the LICENSE file at https://angular.io/license
 
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 load("@npm_bazel_jasmine//:index.bzl", "jasmine_node_test")
-load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
 load("//tools:defaults.bzl", "ts_library")
+
+# @external_begin
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
+# @external_end
 
 licenses(["notice"])  # MIT
 
@@ -73,6 +76,7 @@ jasmine_node_test(
     ],
 )
 
+# @external_begin
 pkg_npm(
     name = "npm_package",
     deps = [
@@ -87,3 +91,4 @@ pkg_tar(
     strip_prefix = "./npm_package",
     tags = ["manual"],
 )
+# @external_end

--- a/packages/schematics/angular/BUILD.bazel
+++ b/packages/schematics/angular/BUILD.bazel
@@ -3,13 +3,14 @@
 # Use of this source code is governed by an MIT-style license that can be
 # found in the LICENSE file at https://angular.io/license
 
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 load("@npm_bazel_jasmine//:index.bzl", "jasmine_node_test")
-load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
 load("//tools:defaults.bzl", "ts_library")
 load("//tools:ts_json_schema.bzl", "ts_json_schema")
 
-licenses(["notice"])  # MIT
+# @external_begin
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
+# @external_end
 
 licenses(["notice"])  # MIT
 
@@ -137,6 +138,7 @@ jasmine_node_test(
     ],
 )
 
+# @external_begin
 pkg_npm(
     name = "npm_package",
     deps = [
@@ -151,3 +153,4 @@ pkg_tar(
     strip_prefix = "./npm_package",
     tags = ["manual"],
 )
+# @external_end

--- a/packages/schematics/schematics/BUILD.bazel
+++ b/packages/schematics/schematics/BUILD.bazel
@@ -8,8 +8,6 @@ load("//tools:ts_json_schema.bzl", "ts_json_schema")
 
 licenses(["notice"])  # MIT
 
-licenses(["notice"])  # MIT
-
 package(default_visibility = ["//visibility:public"])
 
 ts_library(
@@ -26,8 +24,11 @@ ts_library(
             "node_modules/**",
         ],
     ) + [
+        # @external_begin
+        # These files are generated from the JSON schema
         "//packages/schematics/schematics:blank/schema.ts",
         "//packages/schematics/schematics:schematic/schema.ts",
+        # @external_end
     ],
     data = glob(
         include = [

--- a/packages/schematics/schematics/blank/factory.ts
+++ b/packages/schematics/schematics/blank/factory.ts
@@ -102,7 +102,9 @@ export default function (options: Schema): Rule {
     try {
       const packageJsonContent = tree.read('/package.json');
       if (packageJsonContent) {
-        const packageJson = JSON.parse(packageJsonContent.toString('utf-8'));
+        // In google3 the return value of JSON.parse() must be immediately typed,
+        // otherwise it defaults to `any`, which is prohibited.
+        const packageJson = JSON.parse(packageJsonContent.toString('utf-8')) as never;
         if ('schematics' in packageJson) {
           const p = normalize(packageJson['schematics']);
           if (tree.exists(p)) {

--- a/packages/schematics/update/BUILD.bazel
+++ b/packages/schematics/update/BUILD.bazel
@@ -3,13 +3,14 @@
 # Use of this source code is governed by an MIT-style license that can be
 # found in the LICENSE file at https://angular.io/license
 
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 load("@npm_bazel_jasmine//:index.bzl", "jasmine_node_test")
-load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
 load("//tools:defaults.bzl", "ts_library")
 load("//tools:ts_json_schema.bzl", "ts_json_schema")
 
-licenses(["notice"])  # MIT
+# @external_begin
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
+# @external_end
 
 licenses(["notice"])  # MIT
 
@@ -98,6 +99,7 @@ jasmine_node_test(
     ],
 )
 
+# @external_begin
 pkg_npm(
     name = "npm_package",
     deps = [
@@ -112,3 +114,4 @@ pkg_tar(
     strip_prefix = "./npm_package",
     tags = ["manual"],
 )
+# @external_end

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -1,10 +1,10 @@
-load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
-
 # Copyright Google Inc. All Rights Reserved.
 #
 # Use of this source code is governed by an MIT-style license that can be
 # found in the LICENSE file at https://angular.io/license
 # @external_begin
+load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
+
 package(default_visibility = ["//visibility:public"])
 
 nodejs_binary(

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -27,10 +27,12 @@ def ts_library(
 
     _ts_library(
         name = name,
-        tsconfig = tsconfig,
         testonly = testonly,
         deps = deps,
+        # @external_begin
+        tsconfig = tsconfig,
         devmode_module = devmode_module,
         devmode_target = devmode_target,
+        # @external_end
         **kwargs
     )


### PR DESCRIPTION
This commit makes a few minor changes to enable syncing the CLI repository
into google3.

1. mark pkg_tar and pkg_npm as external
2. remove dependencies (marked as comment) which are stale in google3
3. add code fence for TS files generated from JSON schema in BUILD files
    since these files are compiled and added to the g3 codebase at sync time
4. Some minor typing changes
5. Remove duplicate licenses
6. mark dependencies which are not available in g3 as external
7. Immediately type the result of JSON.parse() as required by g3 linter.
   Otherwise, the type defaults to `any`.