### PR TITLE
Generate sourcemaps with relative paths 

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "@types/semver": "^7.0.0",
     "@types/universal-analytics": "^0.4.2",
     "@types/uuid": "^8.0.0",
-    "@types/webpack": "^4.32.1",
+    "@types/webpack": "^4.41.22",
     "@types/webpack-dev-server": "^3.1.7",
     "@types/webpack-sources": "^1.4.2",
     "@yarnpkg/lockfile": "1.1.0",

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
@@ -24,6 +24,7 @@ import {
   compilation,
   debug,
 } from 'webpack';
+import webpack = require('webpack');
 import { RawSource } from 'webpack-sources';
 import { AssetPatternClass } from '../../../browser/schema';
 import { BuildBrowserFeatures, maxWorkers } from '../../../utils';
@@ -471,13 +472,16 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
     devtool: false,
     profile: buildOptions.statsJson,
     resolve: {
+      roots: [projectRoot],
       extensions: ['.ts', '.tsx', '.mjs', '.js'],
       symlinks: !buildOptions.preserveSymlinks,
       modules: [wco.tsConfig.options.baseUrl || projectRoot, 'node_modules'],
       plugins: [
         PnpWebpackPlugin,
       ],
-    },
+      // Cast since roots is currently not in typings
+      // See: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/47233
+    } as webpack.Resolve,
     resolveLoader: {
       symlinks: !buildOptions.preserveSymlinks,
       modules: [

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
@@ -489,7 +489,7 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
       ],
       plugins: [PnpWebpackPlugin.moduleLoader(module)],
     },
-    context: projectRoot,
+    context: root,
     entry: entryPoints,
     output: {
       futureEmitAssets: true,

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
@@ -24,7 +24,6 @@ import {
   compilation,
   debug,
 } from 'webpack';
-import webpack = require('webpack');
 import { RawSource } from 'webpack-sources';
 import { AssetPatternClass } from '../../../browser/schema';
 import { BuildBrowserFeatures, maxWorkers } from '../../../utils';
@@ -479,9 +478,7 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
       plugins: [
         PnpWebpackPlugin,
       ],
-      // Cast since roots is currently not in typings
-      // See: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/47233
-    } as webpack.Resolve,
+    },
     resolveLoader: {
       symlinks: !buildOptions.preserveSymlinks,
       modules: [

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/utils.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/utils.ts
@@ -91,7 +91,7 @@ export function getSourceMapDevTool(
     // inline sourcemaps as otherwise paths to sourcemaps will be broken in browser
     // `webpack:///` is needed for Visual Studio breakpoints to work properly as currently
     // there is no way to set the 'webRoot'
-    sourceRoot: inlineSourceMap ? '' : 'webpack:///',
+    sourceRoot: 'webpack:///',
     moduleFilenameTemplate: '[resource-path]',
     append: hiddenSourceMap ? false : undefined,
     exclude: vendorSourceMap ? undefined : /vendor.*\.js/,

--- a/tests/legacy-cli/e2e/tests/build/relative-sourcemap.ts
+++ b/tests/legacy-cli/e2e/tests/build/relative-sourcemap.ts
@@ -1,0 +1,20 @@
+import * as fs from 'fs';
+
+import { isAbsolute } from 'path';
+import { ng } from '../../utils/process';
+
+export default async function () {
+  // General secondary application project
+  await ng('generate', 'application', 'secondary-project', '--skip-install');
+  await ng('build', 'secondary-project');
+
+
+  await ng('build', '--output-hashing=none', '--source-map');
+  const content = fs.readFileSync('./dist/secondary-project/main.js.map', 'utf8');
+  const {sources} = JSON.parse(content);
+  for (const source of sources) {
+      if (isAbsolute(source)) {
+        throw new Error(`Expected ${source} to be relative.`);
+      }
+  }
+}

--- a/tests/legacy-cli/e2e/tests/misc/karma-error-paths.ts
+++ b/tests/legacy-cli/e2e/tests/misc/karma-error-paths.ts
@@ -1,0 +1,24 @@
+import { writeMultipleFiles } from '../../utils/fs';
+import { ng } from '../../utils/process';
+import { expectToFail } from '../../utils/utils';
+
+export default async function () {
+  await writeMultipleFiles({
+    'src/app/app.component.spec.ts': `
+        describe('AppComponent', () => {
+          it('failing test', () => {
+            expect('1').toEqual('2');
+          });
+        });
+      `,
+  });
+
+  const { message } = await expectToFail(() => ng('test', '--no-watch'));
+  if (message.includes('_karma_webpack_')) {
+    throw new Error(`Didn't expect logs to server address and webpack scheme.\n${message}`);
+  }
+
+  if (!message.includes('(src/app/app.component.spec.ts:4:25)')) {
+    throw new Error(`Expected logs to contain relative path to (src/app/app.component.spec.ts:4:25)\n${message}`);
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1756,10 +1756,10 @@
     "@types/source-list-map" "*"
     source-map "^0.6.1"
 
-"@types/webpack@*", "@types/webpack@^4.32.1":
-  version "4.41.21"
-  resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.41.21.tgz#cc685b332c33f153bb2f5fc1fa3ac8adeb592dee"
-  integrity sha512-2j9WVnNrr/8PLAB5csW44xzQSJwS26aOnICsP3pSGCEdsu6KYtfQ6QJsVUKHWRnm1bL7HziJsfh5fHqth87yKA==
+"@types/webpack@*", "@types/webpack@^4.41.22":
+  version "4.41.22"
+  resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.41.22.tgz#ff9758a17c6bd499e459b91e78539848c32d0731"
+  integrity sha512-JQDJK6pj8OMV9gWOnN1dcLCyU9Hzs6lux0wBO4lr1+gyEhIBR9U3FMrz12t2GPkg110XAxEAw2WHF6g7nZIbRQ==
   dependencies:
     "@types/anymatch" "*"
     "@types/node" "*"


### PR DESCRIPTION
**fix(@angular-devkit/buid-angular): generate sourcemaps with relative paths in monorepo**
    
With this change we fix the issue that when having a monorepo style workspace, sourcemaps sources references absolute paths.
    
Closes #17046

**fix(@angular-devkit/build-angular): improve debugging experience**

With this change we improve the debugging experience with 2 things.

1. Cleaner Karma stack traces in the terminal
Before
```
Chrome 84.0.4147.105 (Mac OS 10.15.5) AppComponent should have as title 'foo' FAILED
        Error: Expected 'foo' to equal 'fox'.
            at <Jasmine>
            at UserContext.<anonymous> (http://localhost:9876/_karma_webpack_/webpack:/projects/foo/src/app/app.component.spec.ts:22:23)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/webpack:/node_modules/zone.js/dist/zone-evergreen.js:364:1)
            at ProxyZoneSpec.push../node_modules/zone.js/dist/zone-testing.js.ProxyZoneSpec.onInvoke (http://localhost:9876/_karma_webpack_/webpack:/node_modules/zone.js/dist/zone-testing.js:292:1)
Chrome 84.0.4147.105 (Mac OS 10.15.5): Executed 3 of 3 (1 FAILED) (0 secs / 0.214 secs)
Chrome 84.0.4147.105 (Mac OS 10.15.5) AppComponent should have as title 'foo' FAILED
        Error: Expected 'foo' to equal 'fox'.
            at <Jasmine>
            at UserContext.<anonymous> (http://localhost:9876/_karma_webpack_/webpack:/projects/foo/src/app/app.component.spec.ts:22:23)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/webpack:/node_modules/zone.js/dist/zone-evergreen.js:364:1)
            at ProxyZoneSpec.push../node_modules/zone.js/dist/zone-testing.js.ProxyZoneSpec.onInvoke (http://localhost:9876/_karma_webpack_/webpack:/node_modules/zone.js/dist/zChrome 84.0.4147.105 (Mac OS 10.15.5): Executed 3 of 3 (1 FAILED) (0.225 secs / 0.214 secs)
```

After
```
Chrome 84.0.4147.105 (Mac OS 10.15.5) AppComponent should have as title 'foo' FAILED
        Error: Expected 'foo' to equal 'fox'.
            at <Jasmine>
            at UserContext.<anonymous> (projects/foo/src/app/app.component.spec.ts:22:23)
            at ZoneDelegate.invoke (node_modules/zone.js/dist/zone-evergreen.js:364:1)
            at ProxyZoneSpec.push../node_modules/zone.js/dist/zone-testing.js.ProxyZoneSpec.onInvoke (node_modules/zone.js/dist/zone-testing.js:292:1)
Chrome 84.0.4147.105 (Mac OS 10.15.5): Executed 2 of 3 (1 FAILED) (0 secs / 0.225 secs)
Chrome 84.0.4147.105 (Mac OS 10.15.5) AppComponent should have as title 'foo' FAILED
        Error: Expected 'foo' to equal 'fox'.
            at <Jasmine>
            at UserContext.<anonymous> (projects/foo/src/app/app.component.spec.ts:22:23)
            at ZoneDelegate.invoke (node_modules/zone.js/dist/zone-evergreen.js:364:1)
Chrome 84.0.4147.105 (Mac OS 10.15.5): Executed 3 of 3 (1 FAILED) (0.281 secs / 0.237 secs)
```

2. Reduce VS Code configuration
Before
```
{
  "name": "ng test",
  "type": "chrome",
  "request": "launch",
  "url": "http://localhost:9876/debug.html",
  "webRoot": "${workspaceFolder}",
  "sourceMaps": true,
  "sourceMapPathOverrides": {
    "webpack:/*": "${webRoot}/*",
    "/./*": "${webRoot}/*",
    "/src/*": "${webRoot}/*",
    "/*": "*",
    "/./~/*": "${webRoot}/node_modules/*"
  }
},
```

After
```
{
  "name": "ng test",
  "type": "chrome",
  "request": "launch",
  "url": "http://localhost:9876/debug.html",
  "webRoot": "${workspaceFolder}"
},
```