### PR TITLE
test: increase wait time for ask analytics npm install E2E test

### DIFF
--- a/tests/legacy-cli/e2e/tests/misc/ask-analytics-install.ts
+++ b/tests/legacy-cli/e2e/tests/misc/ask-analytics-install.ts
@@ -20,7 +20,7 @@ export default async function() {
     );
 
     // Check if the prompt is shown
-    await waitForAnyProcessOutputToMatch(/Would you like to share anonymous usage data/);
+    await waitForAnyProcessOutputToMatch(/Would you like to share anonymous usage data/, 60000);
 
   } finally {
     killAllProcesses();


### PR DESCRIPTION
The npm install can take longer than the default 30 second timeout.