### PR TITLE
fix(@angular-devkit/build-angular): prefer workspace node_modules

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/dedupe-module-resolve-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/dedupe-module-resolve-plugin.ts
@@ -42,7 +42,7 @@ export class DedupeModuleResolvePlugin {
   apply(resolver: any) {
     resolver
       .getHook('before-described-relative')
-      .tapPromise('DedupeModuleResolvePlugin', async (request: NormalModuleFactoryRequest) => {
+      .tap('DedupeModuleResolvePlugin', (request: NormalModuleFactoryRequest) => {
         if (request.relativePath !== '.') {
           return;
         }

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/find-up.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/find-up.ts
@@ -9,7 +9,7 @@ import { existsSync } from 'fs';
 import * as path from 'path';
 import { isDirectory } from './is-directory';
 
-export function findUp(names: string | string[], from: string, stopOnNodeModules = false) {
+export function findUp(names: string | string[], from: string, stopOnNodeModules = false): string | null {
   if (!Array.isArray(names)) {
     names = [names];
   }
@@ -37,7 +37,7 @@ export function findUp(names: string | string[], from: string, stopOnNodeModules
   return null;
 }
 
-export function findAllNodeModules(from: string, root?: string) {
+export function findAllNodeModules(from: string, root?: string): string[] {
   const nodeModules: string[] = [];
 
   let current = from;


### PR DESCRIPTION
In Webpack absolute and relative paths in resolve.module and resolveLoader.modules  behave differently.

A relative path will be scanned similarly to how Node scans for node_modules, by looking through the current directory as well as its ancestors (i.e. ./node_modules, ../node_modules, and on).

With an absolute path, it will only search in the given directory.

With this change we give preference to the workspace level node_nodules directory.

Modules resolved with this change
```
/workspace/angular-test/client/node_modules/@angular/core
/workspace/angular-test/client/node_modules/@angular/core
/workspace/angular-test/client/node_modules/@angular/core
/workspace/angular-test/client/node_modules/@angular/common
/workspace/angular-test/client/node_modules/@angular/platform-browser
/workspace/angular-test/client/node_modules/@angular/platform-browser
/workspace/angular-test/client/node_modules/simple-peer
/workspace/angular-test/client/node_modules/@angular/core
/workspace/angular-test/client/node_modules/@angular/common
/workspace/angular-test/client/node_modules/@angular/core
/workspace/angular-test/client/node_modules/rxjs
/workspace/angular-test/client/node_modules/debug
/workspace/angular-test/client/node_modules/get-browser-rtc
/workspace/angular-test/client/node_modules/randombytes
/workspace/angular-test/client/node_modules/queue-microtask
/workspace/angular-test/client/node_modules/readable-stream
/workspace/angular-test/client/node_modules/safe-buffer
/workspace/angular-test/client/node_modules/safe-buffer
/workspace/angular-test/client/node_modules/safe-buffer
/workspace/angular-test/client/node_modules/safe-buffer
/workspace/angular-test/client/node_modules/process-nextick-args
/workspace/angular-test/client/node_modules/process-nextick-args
/workspace/angular-test/client/node_modules/process-nextick-args
/workspace/angular-test/client/node_modules/process-nextick-args
/workspace/angular-test/client/node_modules/inherits
/workspace/angular-test/client/node_modules/inherits
/workspace/angular-test/client/node_modules/inherits
/workspace/angular-test/client/node_modules/inherits
/workspace/angular-test/client/node_modules/inherits
/workspace/angular-test/client/node_modules/util-deprecate
/workspace/angular-test/client/node_modules/events
/workspace/angular-test/client/node_modules/events
/workspace/angular-test/client/node_modules/core-util-is
/workspace/angular-test/client/node_modules/core-util-is
/workspace/angular-test/client/node_modules/core-util-is
/workspace/angular-test/client/node_modules/core-util-is
/workspace/angular-test/client/node_modules/core-util-is
/workspace/angular-test/client/node_modules/isarray
/workspace/angular-test/client/node_modules/string_decoder
/workspace/angular-test/client/node_modules/ms
/workspace/angular-test/client/node_modules/safe-buffer
/workspace/angular-test/client/node_modules/buffer
/workspace/angular-test/client/node_modules/isarray
/workspace/angular-test/client/node_modules/base64-js
/workspace/angular-test/client/node_modules/ieee754
```

Modules resolved before
```
/workspace/angular-test/client/node_modules/@angular/core
/workspace/angular-test/client/node_modules/@angular/core
/workspace/angular-test/client/node_modules/@angular/core
/workspace/angular-test/client/node_modules/@angular/common
/workspace/angular-test/client/node_modules/@angular/platform-browser
/workspace/angular-test/client/node_modules/@angular/platform-browser
/workspace/angular-test/node_modules/simple-peer
/workspace/angular-test/client/node_modules/simple-peer
/workspace/angular-test/client/node_modules/@angular/core
/workspace/angular-test/client/node_modules/@angular/common
/workspace/angular-test/client/node_modules/@angular/core
/workspace/angular-test/client/node_modules/rxjs
/workspace/angular-test/client/node_modules/debug
/workspace/angular-test/node_modules/debug
/workspace/angular-test/client/node_modules/get-browser-rtc
/workspace/angular-test/node_modules/get-browser-rtc
/workspace/angular-test/client/node_modules/randombytes
/workspace/angular-test/node_modules/randombytes
/workspace/angular-test/client/node_modules/readable-stream
/workspace/angular-test/node_modules/readable-stream
/workspace/angular-test/client/node_modules/queue-microtask
/workspace/angular-test/node_modules/queue-microtask
/workspace/angular-test/client/node_modules/simple-peer/node_modules/readable-stream
/workspace/angular-test/client/node_modules/safe-buffer
/workspace/angular-test/node_modules/safe-buffer
/workspace/angular-test/client/node_modules/events
/workspace/angular-test/client/node_modules/events
/workspace/angular-test/client/node_modules/util-deprecate
/workspace/angular-test/node_modules/util-deprecate
/workspace/angular-test/client/node_modules/inherits
/workspace/angular-test/client/node_modules/inherits
/workspace/angular-test/client/node_modules/inherits
/workspace/angular-test/client/node_modules/inherits
/workspace/angular-test/client/node_modules/inherits
/workspace/angular-test/node_modules/inherits
/workspace/angular-test/node_modules/inherits
/workspace/angular-test/node_modules/inherits
/workspace/angular-test/node_modules/inherits
/workspace/angular-test/node_modules/inherits
/workspace/angular-test/client/node_modules/buffer
/workspace/angular-test/client/node_modules/buffer
/workspace/angular-test/client/node_modules/buffer
/workspace/angular-test/client/node_modules/string_decoder
/workspace/angular-test/node_modules/string_decoder
/workspace/angular-test/client/node_modules/ms
/workspace/angular-test/node_modules/ms
/workspace/angular-test/client/node_modules/buffer
/workspace/angular-test/client/node_modules/safe-buffer
/workspace/angular-test/node_modules/safe-buffer
/workspace/angular-test/client/node_modules/base64-js
/workspace/angular-test/client/node_modules/ieee754
/workspace/angular-test/client/node_modules/isarray
```

Closes #18396