### PR TITLE
Schematics code cleanup and refactoring to support strict compilation

### DIFF
--- a/packages/schematics/angular/app-shell/index.ts
+++ b/packages/schematics/angular/app-shell/index.ts
@@ -110,11 +110,11 @@ function getBootstrapComponentPath(
   const componentSymbol = arrLiteral.elements[0].getText();
 
   const relativePath = getSourceNodes(moduleSource)
-    .filter(node => node.kind === ts.SyntaxKind.ImportDeclaration)
+    .filter(ts.isImportDeclaration)
     .filter(imp => {
       return findNode(imp, ts.SyntaxKind.Identifier, componentSymbol);
     })
-    .map((imp: ts.ImportDeclaration) => {
+    .map(imp => {
       const pathStringLiteral = imp.moduleSpecifier as ts.StringLiteral;
 
       return pathStringLiteral.text;
@@ -205,8 +205,8 @@ function addRouterModule(mainPath: string): Rule {
 function getMetadataProperty(metadata: ts.Node, propertyName: string): ts.PropertyAssignment {
   const properties = (metadata as ts.ObjectLiteralExpression).properties;
   const property = properties
-    .filter(prop => prop.kind === ts.SyntaxKind.PropertyAssignment)
-    .filter((prop: ts.PropertyAssignment) => {
+    .filter(ts.isPropertyAssignment)
+    .filter((prop) => {
       const name = prop.name;
       switch (name.kind) {
         case ts.SyntaxKind.Identifier:

--- a/packages/schematics/angular/migrations/update-6/index.ts
+++ b/packages/schematics/angular/migrations/update-6/index.ts
@@ -260,7 +260,7 @@ function extractProjectsConfig(
       const outDir = app.outDir || defaults.outDir;
       const appRoot = app.root || defaults.appRoot;
 
-      function _mapAssets(asset: string | JsonObject) {
+      function _mapAssets(asset: string | { glob?: string; input?: string; output?: string; allowOutsideOutDir?: boolean}) {
         if (typeof asset === 'string') {
           return normalize(appRoot + '/' + asset);
         } else {
@@ -268,6 +268,13 @@ function extractProjectsConfig(
             logger.warn(tags.oneLine`
               Asset with input '${asset.input}' was not migrated because it
               uses the 'allowOutsideOutDir' option which is not supported in Angular CLI 6.
+            `);
+
+            return null;
+          } else if (!asset.glob) {
+            logger.warn(tags.oneLine`
+              Asset with input '${asset.input}' was not migrated because it
+              does not contain a glob property.
             `);
 
             return null;

--- a/packages/schematics/angular/service-worker/index.ts
+++ b/packages/schematics/angular/service-worker/index.ts
@@ -21,7 +21,7 @@ import {
 import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
 import * as ts from '../third_party/github.com/Microsoft/TypeScript/lib/typescript';
 import { addSymbolToNgModuleMetadata, getEnvironmentExportName, insertImport, isImported } from '../utility/ast-utils';
-import { InsertChange } from '../utility/change';
+import { applyToUpdateRecorder } from '../utility/change';
 import { addPackageJsonDependency, getPackageJsonDependency } from '../utility/dependencies';
 import { getAppModulePath } from '../utility/ng-ast-utils';
 import { relativePathToWorkspaceRoot } from '../utility/paths';
@@ -63,7 +63,7 @@ function updateAppModule(mainPath: string): Rule {
       const change = insertImport(moduleSource, modulePath, importModule, importPath);
       if (change) {
         const recorder = host.beginUpdate(modulePath);
-        recorder.insertLeft((change as InsertChange).pos, (change as InsertChange).toAdd);
+        applyToUpdateRecorder(recorder, [change]);
         host.commitUpdate(recorder);
       }
     }
@@ -84,7 +84,7 @@ function updateAppModule(mainPath: string): Rule {
       const change = insertImport(moduleSource, modulePath, importModule, importPath);
       if (change) {
         const recorder = host.beginUpdate(modulePath);
-        recorder.insertLeft((change as InsertChange).pos, (change as InsertChange).toAdd);
+        applyToUpdateRecorder(recorder, [change]);
         host.commitUpdate(recorder);
       }
     }
@@ -97,9 +97,7 @@ function updateAppModule(mainPath: string): Rule {
       moduleSource, modulePath, 'imports', importText);
     if (metadataChanges) {
       const recorder = host.beginUpdate(modulePath);
-      metadataChanges.forEach((change: InsertChange) => {
-        recorder.insertRight(change.pos, change.toAdd);
-      });
+      applyToUpdateRecorder(recorder, metadataChanges);
       host.commitUpdate(recorder);
     }
 

--- a/packages/schematics/angular/utility/ng-ast-utils.ts
+++ b/packages/schematics/angular/utility/ng-ast-utils.ts
@@ -62,11 +62,11 @@ export function findBootstrapModulePath(host: Tree, mainPath: string): string {
   const source = ts.createSourceFile(mainPath, mainText, ts.ScriptTarget.Latest, true);
   const allNodes = getSourceNodes(source);
   const bootstrapModuleRelativePath = allNodes
-    .filter(node => node.kind === ts.SyntaxKind.ImportDeclaration)
+    .filter(ts.isImportDeclaration)
     .filter(imp => {
       return findNode(imp, ts.SyntaxKind.Identifier, bootstrapModule.getText());
     })
-    .map((imp: ts.ImportDeclaration) => {
+    .map(imp => {
       const modulePathStringLiteral = imp.moduleSpecifier as ts.StringLiteral;
 
       return modulePathStringLiteral.text;

--- a/packages/schematics/update/update/index.ts
+++ b/packages/schematics/update/update/index.ts
@@ -884,7 +884,7 @@ export default function(options: UpdateSchema): Rule {
       )),
 
       // Build a map of all dependencies and their packageJson.
-      reduce<NpmRepositoryPackageJson, Map<string, NpmRepositoryPackageJson>>(
+      reduce<Partial<NpmRepositoryPackageJson>, Map<string, NpmRepositoryPackageJson>>(
         (acc, npmPackageJson) => {
           // If the package was not found on the registry. It could be private, so we will just
           // ignore. If the package was part of the list, we will error out, but will simply ignore
@@ -892,7 +892,7 @@ export default function(options: UpdateSchema): Rule {
           // `--all` situation. There is an edge case here where a public package peer depends on a
           // private one, but it's rare enough.
           if (!npmPackageJson.name) {
-            if (packages.has(npmPackageJson.requestedName)) {
+            if (npmPackageJson.requestedName && packages.has(npmPackageJson.requestedName)) {
               if (options.all) {
                 logger.warn(`Package ${JSON.stringify(npmPackageJson.requestedName)} was not `
                   + 'found on the registry. Skipping.');
@@ -903,7 +903,8 @@ export default function(options: UpdateSchema): Rule {
               }
             }
           } else {
-            acc.set(npmPackageJson.name, npmPackageJson);
+            // If a name is present, it is assumed to be fully populated
+            acc.set(npmPackageJson.name, npmPackageJson as NpmRepositoryPackageJson);
           }
 
           return acc;


### PR DESCRIPTION
Several code changes to support enabling TypeScript's strict compilation options.  See individual commits for details.