### PR TITLE
refactor(@ngtools/angular): use type guard based narrowing with TS AST

### DIFF
--- a/packages/ngtools/webpack/src/entry_resolver.ts
+++ b/packages/ngtools/webpack/src/entry_resolver.ts
@@ -8,7 +8,7 @@
 
 import { Path, join } from '@angular-devkit/core';
 import * as ts from 'typescript';
-import { TypeScriptFileRefactor } from './refactor';
+import { TypeScriptFileRefactor, findAstNodes } from './refactor';
 
 
 function _recursiveSymbolExportLookup(refactor: TypeScriptFileRefactor,
@@ -16,8 +16,8 @@ function _recursiveSymbolExportLookup(refactor: TypeScriptFileRefactor,
                                       host: ts.CompilerHost,
                                       program: ts.Program): string | null {
   // Check this file.
-  const hasSymbol = refactor.findAstNodes(null, ts.SyntaxKind.ClassDeclaration)
-    .some((cd: ts.ClassDeclaration) => {
+  const hasSymbol = findAstNodes(null, refactor.sourceFile, ts.isClassDeclaration)
+    .some((cd) => {
       return cd.name != undefined && cd.name.text == symbolName;
     });
   if (hasSymbol) {
@@ -69,8 +69,8 @@ function _recursiveSymbolExportLookup(refactor: TypeScriptFileRefactor,
 
         // Create the source and verify that the symbol is at least a class.
         const source = new TypeScriptFileRefactor(module, host, program);
-        const hasSymbol = source.findAstNodes(null, ts.SyntaxKind.ClassDeclaration)
-          .some((cd: ts.ClassDeclaration) => {
+        const hasSymbol = findAstNodes(null, source.sourceFile, ts.isClassDeclaration)
+          .some((cd) => {
             return cd.name != undefined && cd.name.text == symbolName;
           });
 

--- a/packages/ngtools/webpack/src/transformers/find_resources.ts
+++ b/packages/ngtools/webpack/src/transformers/find_resources.ts
@@ -27,7 +27,7 @@ export function findResources(sourceFile: ts.SourceFile): string[] {
 
     ts.visitNodes(
       (args[0] as ts.ObjectLiteralExpression).properties,
-      (node: ts.ObjectLiteralElementLike) => {
+      (node) => {
         if (!ts.isPropertyAssignment(node) || ts.isComputedPropertyName(node.name)) {
           return node;
         }
@@ -47,7 +47,7 @@ export function findResources(sourceFile: ts.SourceFile): string[] {
               return node;
             }
 
-            ts.visitNodes(node.initializer.elements, (node: ts.Expression) => {
+            ts.visitNodes(node.initializer.elements, (node) => {
               const url = getResourceUrl(node);
 
               if (url) {

--- a/packages/ngtools/webpack/src/transformers/insert_import.ts
+++ b/packages/ngtools/webpack/src/transformers/insert_import.ts
@@ -69,12 +69,13 @@ export function insertImport(
   // Find all imports.
   const allImports = collectDeepNodes(sourceFile, ts.SyntaxKind.ImportDeclaration);
   const maybeImports = allImports
-    .filter((node: ts.ImportDeclaration) => {
+    .filter(ts.isImportDeclaration)
+    .filter((node) => {
       // Filter all imports that do not match the modulePath.
       return node.moduleSpecifier.kind == ts.SyntaxKind.StringLiteral
         && (node.moduleSpecifier as ts.StringLiteral).text == modulePath;
     })
-    .filter((node: ts.ImportDeclaration) => {
+    .filter((node) => {
       // Filter out import statements that are either `import 'XYZ'` or `import * as X from 'XYZ'`.
       const clause = node.importClause as ts.ImportClause;
       if (!clause || clause.name || !clause.namedBindings) {
@@ -83,7 +84,7 @@ export function insertImport(
 
       return clause.namedBindings.kind == ts.SyntaxKind.NamedImports;
     })
-    .map((node: ts.ImportDeclaration) => {
+    .map((node) => {
       // Return the `{ ... }` list of the named import.
       return (node.importClause as ts.ImportClause).namedBindings as ts.NamedImports;
     });

--- a/packages/ngtools/webpack/src/utils.ts
+++ b/packages/ngtools/webpack/src/utils.ts
@@ -18,7 +18,7 @@ export function workaroundResolve(path: Path | string): string {
 }
 
 export function flattenArray<T>(value: Array<T | T[]>): T[] {
-  return [].concat.apply([], value);
+  return ([] as T[]).concat.apply([], value);
 }
 
 // TS represents paths internally with '/' and expects paths to be in this format.

--- a/packages/ngtools/webpack/src/virtual_file_system_decorator.ts
+++ b/packages/ngtools/webpack/src/virtual_file_system_decorator.ts
@@ -60,7 +60,7 @@ export class VirtualFileSystemDecorator implements InputFileSystem {
     (this._inputFileSystem as any).readJson(path, callback);
   }
 
-  readlink(path: string, callback: (err: Error, linkString: string) => void): void {
+  readlink(path: string, callback: (err: Error | null | undefined, linkString: string) => void): void {
     this._inputFileSystem.readlink(path, callback);
   }
 


### PR DESCRIPTION
By leveraging TypeScript's AST type guards, function parameter assumptions and casting can be removed.  Many of these cases caused errors when enabling TypeScript's strict option. This is preliminary work to support enabling full TypeScript strict mode within the project.