### PR TITLE
feat(schematics/component): add a includeStyles option

### DIFF
--- a/packages/schematics/angular/component/files/__name@dasherize@if-flat__/__name@dasherize__.__type@dasherize__.ts.template
+++ b/packages/schematics/angular/component/files/__name@dasherize@if-flat__/__name@dasherize__.__type@dasherize__.ts.template
@@ -14,7 +14,7 @@ import { Component, OnInit<% if(!!viewEncapsulation) { %>, ViewEncapsulation<% }
         display: block;
       }
     `<% } %>
-  ]<% } else { %>
+  ]<% } else if(includeStyles) { %>
   styleUrls: ['./<%= dasherize(name) %><%= type ? '.' + dasherize(type): '' %>.<%= style %>']<% } %><% if(!!viewEncapsulation) { %>,
   encapsulation: ViewEncapsulation.<%= viewEncapsulation %><% } if (changeDetection !== 'Default') { %>,
   changeDetection: ChangeDetectionStrategy.<%= changeDetection %><% } %>

--- a/packages/schematics/angular/component/index.ts
+++ b/packages/schematics/angular/component/index.ts
@@ -150,7 +150,7 @@ export default function (options: ComponentOptions): Rule {
 
     const templateSource = apply(url('./files'), [
       options.skipTests ? filter(path => !path.endsWith('.spec.ts.template')) : noop(),
-      options.inlineStyle ? filter(path => !path.endsWith('.__style__.template')) : noop(),
+      options.inlineStyle || !options.includeStyles ? filter(path => !path.endsWith('.__style__.template')) : noop(),
       options.inlineTemplate ? filter(path => !path.endsWith('.html.template')) : noop(),
       applyTemplates({
         ...strings,

--- a/packages/schematics/angular/component/index_spec.ts
+++ b/packages/schematics/angular/component/index_spec.ts
@@ -249,6 +249,15 @@ describe('Component Schematic', () => {
     expect(tree.files).not.toContain('/projects/bar/src/app/foo/foo.component.css');
   });
 
+  it('should respect the includeStyles option', async () => {
+    const options = { ...defaultOptions, includeStyles: false };
+    const tree = await schematicRunner.runSchematicAsync('component', options, appTree).toPromise();
+    const content = tree.readContent('/projects/bar/src/app/foo/foo.component.ts');
+    expect(content).not.toMatch(/styles: \[/);
+    expect(content).not.toMatch(/styleUrls: /);
+    expect(tree.files).not.toContain('/projects/bar/src/app/foo/foo.component.css');
+  });
+
   it('should respect the displayBlock option when inlineStyle is `false`', async () => {
     const options = { ...defaultOptions, displayBlock: true };
     const tree = await schematicRunner.runSchematicAsync('component', options, appTree).toPromise();

--- a/packages/schematics/angular/component/schema.json
+++ b/packages/schematics/angular/component/schema.json
@@ -40,6 +40,12 @@
       "alias": "s",
       "x-user-analytics": 9
     },
+    "includeStyles": {
+      "description": "Specifies if the component should include a styles property",
+      "type": "boolean",
+      "default": true,
+      "alias": "is"
+    },
     "inlineTemplate": {
       "description": "When true, includes template inline in the component.ts file. By default, an external template file is created and referenced in the component.ts file.",
       "type": "boolean",


### PR DESCRIPTION
There are several use cases where we create components knowing there will be no styles attached.
To keep them as simple as possible, there should be an option to create them without any styles/stylesUrl property into the @Component metadata.

## new Component schematic option

```
"includeStyles": {
      "description": "Specifies if the component should include a styles property",
      "type": "boolean",
      "default": true,
      "alias": "is"
    }
```
