### PR TITLE
refactor(@angular-devkit/build-angular): cleanup Webpack rule generation

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
@@ -327,15 +327,13 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
     extraPlugins.push(new BundleBudgetPlugin({ budgets: buildOptions.budgets }));
   }
 
-  let sourceMapUseRule;
   if ((scriptsSourceMap || stylesSourceMap) && vendorSourceMap) {
-    sourceMapUseRule = {
-      use: [
-        {
-          loader: require.resolve('source-map-loader'),
-        },
-      ],
-    };
+    extraRules.push({
+      test: /\.m?js$/,
+      exclude: /(ngfactory|ngstyle)\.js$/,
+      enforce: 'pre',
+      loader: require.resolve('source-map-loader'),
+    });
   }
 
   let buildOptimizerUseRule: RuleSetLoader[] = [];
@@ -582,12 +580,6 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
                 ]),
             ...buildOptimizerUseRule,
           ],
-        },
-        {
-          test: /\.m?js$/,
-          exclude: /(ngfactory|ngstyle)\.js$/,
-          enforce: 'pre',
-          ...sourceMapUseRule,
         },
         ...extraRules,
       ],

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/styles.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/styles.ts
@@ -121,7 +121,7 @@ export function getStylesConfig(wco: WebpackConfigOptions) {
   }
 
   // set base rules to derive final rules from
-  const baseRules: webpack.RuleSetRule[] = [
+  const baseRules: { test: RegExp, use: webpack.RuleSetLoader[] }[] = [
     { test: /\.css$/, use: [] },
     {
       test: /\.scss$|\.sass$/,
@@ -206,7 +206,7 @@ export function getStylesConfig(wco: WebpackConfigOptions) {
             && !buildOptions.sourceMap.hidden ? 'inline' : false,
         },
       },
-      ...(use as webpack.Loader[]),
+      ...use,
     ],
   }));
 
@@ -237,7 +237,7 @@ export function getStylesConfig(wco: WebpackConfigOptions) {
                     : cssSourceMap,
               },
             },
-            ...(use as webpack.Loader[]),
+            ...use,
           ],
         };
       }),

--- a/packages/angular_devkit/build_angular/src/karma/index.ts
+++ b/packages/angular_devkit/build_angular/src/karma/index.ts
@@ -18,10 +18,7 @@ import {
   getTestConfig,
   getWorkerConfig,
 } from '../angular-cli-files/models/webpack-configs';
-import {
-  SingleTestTransformLoader,
-  SingleTestTransformLoaderOptions,
-} from '../angular-cli-files/plugins/single-test-transform';
+import { SingleTestTransformLoader } from '../angular-cli-files/plugins/single-test-transform';
 import { findTests } from '../angular-cli-files/utilities/find-tests';
 import { Schema as BrowserBuilderOptions } from '../browser/schema';
 import { ExecutionTransformer } from '../transforms';
@@ -104,12 +101,7 @@ export function execute(
           }
 
           // prepend special webpack loader that will transform test.ts
-          if (
-            webpackConfig &&
-            webpackConfig.module &&
-            options.include &&
-            options.include.length > 0
-          ) {
+          if (options.include && options.include.length > 0) {
             const mainFilePath = getSystemPath(
               join(normalize(context.workspaceRoot), options.main),
             );
@@ -123,15 +115,21 @@ export function execute(
               return;
             }
 
+            if (!webpackConfig.module) {
+              webpackConfig.module = { rules: [] };
+            } else if (!webpackConfig.module.rules) {
+              webpackConfig.module.rules = [];
+            }
+
             webpackConfig.module.rules.unshift({
-              test: path => path === mainFilePath,
+              test: mainFilePath,
               use: {
                 // cannot be a simple path as it differs between environments
                 loader: SingleTestTransformLoader,
                 options: {
                   files,
                   logger: context.logger,
-                } as SingleTestTransformLoaderOptions,
+                },
               },
             });
           }


### PR DESCRIPTION
This change reduces the number of variables needed as well as reduces type casting.