### PR TITLE
Improve compiler options migration error reporting

### DIFF
--- a/packages/schematics/angular/migrations/update-10/add-deprecation-rule-tslint.ts
+++ b/packages/schematics/angular/migrations/update-10/add-deprecation-rule-tslint.ts
@@ -31,8 +31,10 @@ export default function (): Rule {
     }
 
     // Update tslint config.
-    const json = new JSONFile(tree, TSLINT_CONFIG_PATH);
-    if (json.error) {
+    let json;
+    try {
+      json = new JSONFile(tree, TSLINT_CONFIG_PATH);
+    } catch {
       const config = ['tslint.js', 'tslint.yaml'].find(c => tree.exists(c));
       if (config) {
         logger.warn(`Expected a JSON configuration file but found "${config}".`);

--- a/packages/schematics/angular/migrations/update-10/update-tslint.ts
+++ b/packages/schematics/angular/migrations/update-10/update-tslint.ts
@@ -95,8 +95,10 @@ export default function (): Rule {
     }
 
     // Update tslint config.
-    const json = new JSONFile(tree, TSLINT_CONFIG_PATH);
-    if (json.error) {
+    let json;
+    try {
+      json = new JSONFile(tree, TSLINT_CONFIG_PATH);
+    } catch {
       const config = ['tslint.js', 'tslint.yaml'].find(c => tree.exists(c));
       if (config) {
         logger.warn(`Expected a JSON configuration file but found "${config}".`);

--- a/packages/schematics/angular/utility/dependencies.ts
+++ b/packages/schematics/angular/utility/dependencies.ts
@@ -32,9 +32,6 @@ const ALL_DEPENDENCY_TYPE = [
 
 export function addPackageJsonDependency(tree: Tree, dependency: NodeDependency, pkgJsonPath = PKG_JSON_PATH): void {
   const json = new JSONFile(tree, pkgJsonPath);
-  if (json.error) {
-    throw json.error;
-  }
 
   const { overwrite, type, name, version } = dependency;
   const path = [type, name];
@@ -45,9 +42,6 @@ export function addPackageJsonDependency(tree: Tree, dependency: NodeDependency,
 
 export function removePackageJsonDependency(tree: Tree, name: string, pkgJsonPath = PKG_JSON_PATH): void {
   const json = new JSONFile(tree, pkgJsonPath);
-  if (json.error) {
-    throw json.error;
-  }
 
   for (const depType of ALL_DEPENDENCY_TYPE) {
     json.remove([depType, name]);
@@ -56,9 +50,6 @@ export function removePackageJsonDependency(tree: Tree, name: string, pkgJsonPat
 
 export function getPackageJsonDependency(tree: Tree, name: string, pkgJsonPath = PKG_JSON_PATH): NodeDependency | null {
   const json = new JSONFile(tree, pkgJsonPath);
-  if (json.error) {
-    throw json.error;
-  }
 
   for (const depType of ALL_DEPENDENCY_TYPE) {
     const version = json.get([depType, name]);

--- a/packages/schematics/angular/utility/json-file.ts
+++ b/packages/schematics/angular/utility/json-file.ts
@@ -16,7 +16,6 @@ export type JSONPath = (string | number)[];
 /** @internal */
 export class JSONFile {
   content: string;
-  error: undefined | Error;
 
   constructor(
     private readonly host: Tree,
@@ -26,7 +25,7 @@ export class JSONFile {
     if (buffer) {
       this.content = buffer.toString();
     } else {
-      this.error = new Error(`Could not read ${path}.`);
+      throw new Error(`Could not read '${path}'.`);
     }
   }
 

--- a/packages/schematics/angular/web-worker/index.ts
+++ b/packages/schematics/angular/web-worker/index.ts
@@ -34,13 +34,13 @@ function addConfig(options: WebWorkerOptions, root: string, tsConfigPath: string
     const isInSrc = dirname(normalize(tsConfigPath)).endsWith('src');
     const workerGlob = `${isInSrc ? '' : 'src/'}**/*.worker.ts`;
 
-    const  json = new JSONFile(host, tsConfigPath);
-    if (!json.error) {
+    try {
+      const json = new JSONFile(host, tsConfigPath);
       const exclude = json.get(['exclude']);
       if (exclude && Array.isArray(exclude) && !exclude.includes(workerGlob)) {
         json.modify(['exclude'], [...exclude, workerGlob]);
       }
-    }
+    } catch {}
 
     return mergeWith(
       apply(url('./files/worker-tsconfig'), [


### PR DESCRIPTION
This change provides more fine-grained warnings during the `update-module-and-target-compiler-options` migration for V10.0 in the event a TypeScript configuration file could not be updated.  This can help prevent update issues where, for instance, a tsconfig path was misspelled prior to the update.  The `JSONFile` utility class was also augmented to directly throw when creating to ensure that the `content` property is always initialized.