### PR TITLE
fix(@ngtools/webpack): issue warning when using `strictMetadataEmit`

### DIFF
--- a/packages/ngtools/webpack/src/angular_compiler_plugin.ts
+++ b/packages/ngtools/webpack/src/angular_compiler_plugin.ts
@@ -275,6 +275,14 @@ export class AngularCompilerPlugin {
       );
     }
 
+    if (this._compilerOptions.strictMetadataEmit) {
+      this._warnings.push(
+        new Error(
+          `Using Angular compiler option 'strictMetadataEmit' for applications might cause undefined behavior.`,
+        ),
+      );
+    }
+
     if (this._discoverLazyRoutes === false && this.options.additionalLazyModules
       && Object.keys(this.options.additionalLazyModules).length > 0) {
       this._warnings.push(


### PR DESCRIPTION
`strictMetadataEmit` option which is not intended to be used  for applications. See: https://angular.io/guide/angular-compiler-options#strictmetadataemit

Closes #18424