### PR TITLE
Fix relative paths with bundleDependencies=false

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/server.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/server.ts
@@ -53,7 +53,7 @@ export function getServerConfig(wco: WebpackConfigOptions): Configuration {
       ...externalDependencies,
       (context: string, request: string, callback: (error?: null, result?: string) => void) => {
         // Absolute & Relative paths are not externals
-        if (request.startsWith('./') || isAbsolute(request)) {
+        if (request.startsWith('.') || isAbsolute(request)) {
           callback();
 
           return;


### PR DESCRIPTION
When `bundleDependencies` is turned off, webpack is configured to bundle all modules imported via relative path.
It works well for import paths like `'./some/file'` but fails for imports traversing the dir structure up, like `'../some/file'`.

In most cases it would still work well, because of the additional fallback (which checks whether node can resolve this module at all). However, in rare cases this fallback fails (see https://github.com/angular/universal/issues/1792)

Closes: #18493