### PR TITLE
feat(@schematics/angular): add migration to add typedef tslint rule

### DIFF
--- a/packages/schematics/angular/migrations/migration-collection.json
+++ b/packages/schematics/angular/migrations/migration-collection.json
@@ -104,6 +104,11 @@
       "version": "10.1.0-next.5",
       "factory": "./update-10/remove-solution-style-tsconfig",
       "description": "Removing \"Solution Style\" TypeScript configuration file support."
+    },
+    "tslint-add-typedef-rule": {
+      "version": "11.0.0-next.0",
+      "factory": "./update-11/add-typedef-rule-tslint",
+      "description": "Add the tslint typedef rule to tslint JSON configuration files."
     }
   }
 }

--- a/packages/schematics/angular/migrations/update-11/add-typedef-rule-tslint.ts
+++ b/packages/schematics/angular/migrations/update-11/add-typedef-rule-tslint.ts
@@ -1,0 +1,115 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { JsonValue } from '@angular-devkit/core';
+import { DirEntry, Rule, Tree, UpdateRecorder } from '@angular-devkit/schematics';
+import * as ts from '../../third_party/github.com/Microsoft/TypeScript/lib/typescript';
+import { getPackageJsonDependency } from '../../utility/dependencies';
+import { JSONFile } from '../../utility/json-file';
+
+const TSLINT_CONFIG_PATH = '/tslint.json';
+const RULES_TO_ADD: Record<string, JsonValue> = {
+  typedef: [true, 'call-signature'],
+};
+
+function* visit(directory: DirEntry): IterableIterator<ts.SourceFile> {
+  for (const path of directory.subfiles) {
+    if (path.endsWith('.ts') && !path.endsWith('.d.ts')) {
+      const entry = directory.file(path);
+      if (entry) {
+        yield ts.createSourceFile(
+          entry.path,
+          entry.content.toString().replace(/^\uFEFF/, ''),
+          ts.ScriptTarget.Latest,
+          true,
+        );
+      }
+    }
+  }
+
+  for (const path of directory.subdirs) {
+    if (path === 'node_modules' || path.startsWith('.')) {
+      continue;
+    }
+
+    yield* visit(directory.dir(path));
+  }
+}
+
+function addTypedefDisableComments(tree: Tree) {
+  for (const sourceFile of visit(tree.root)) {
+    let recorder: UpdateRecorder | undefined;
+    ts.forEachChild(sourceFile, function analyze(node) {
+      switch (node.kind) {
+        case ts.SyntaxKind.FunctionDeclaration:
+        case ts.SyntaxKind.FunctionExpression:
+        case ts.SyntaxKind.GetAccessor:
+        case ts.SyntaxKind.MethodDeclaration:
+        case ts.SyntaxKind.MethodSignature:
+          if (!(node as ts.CallSignatureDeclaration).type) {
+            if (!recorder) {
+              recorder = tree.beginUpdate(sourceFile.fileName);
+            }
+
+            const triviaWidth = node.getLeadingTriviaWidth();
+            const lineBreakPosition = node.getFullText().substr(0, triviaWidth).lastIndexOf('\n') + 1;
+            const indent = triviaWidth - lineBreakPosition;
+            recorder.insertLeft(node.getStart(), `// tslint:disable-next-line:typedef\n${' '.repeat(indent)}`);
+          }
+
+          break;
+      }
+
+      ts.forEachChild(node, analyze);
+    });
+
+    if (recorder) {
+      tree.commitUpdate(recorder);
+    }
+  }
+}
+
+export default function (): Rule {
+  return (tree, context) => {
+    const logger = context.logger;
+
+    // Update tslint dependency
+    const current = getPackageJsonDependency(tree, 'tslint');
+
+    if (!current) {
+      logger.info('Skipping: "tslint" in not a dependency of this workspace.');
+
+      return;
+    }
+
+    // Update tslint config.
+    let json;
+    try {
+      json = new JSONFile(tree, TSLINT_CONFIG_PATH);
+    } catch {
+      const config = ['tslint.js', 'tslint.yaml'].find(c => tree.exists(c));
+      if (config) {
+        logger.warn(`Expected a JSON configuration file but found "${config}".`);
+      } else {
+        logger.warn('Cannot find "tslint.json" configuration file.');
+      }
+
+      return;
+    }
+
+    for (const [name, value] of Object.entries(RULES_TO_ADD)) {
+      const ruleName = ['rules', name];
+      if (json.get(ruleName) === undefined) {
+        json.modify(ruleName, value);
+
+        // typedef doesn't have a fixer.
+        // Let's add comments to disable typedef rule
+        addTypedefDisableComments(tree);
+      }
+    }
+  };
+}

--- a/packages/schematics/angular/migrations/update-11/add-typedef-rule-tslint_spec.ts
+++ b/packages/schematics/angular/migrations/update-11/add-typedef-rule-tslint_spec.ts
@@ -1,0 +1,108 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { EmptyTree } from '@angular-devkit/schematics';
+import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';
+
+describe('Migration of add typedef tslint rule', () => {
+  const schematicName = 'tslint-add-typedef-rule';
+
+  const schematicRunner = new SchematicTestRunner(
+    'migrations',
+    require.resolve('../migration-collection.json'),
+  );
+
+  let tree: UnitTestTree;
+  const TSLINT_PATH = '/tslint.json';
+  const PACKAGE_JSON_PATH = '/package.json';
+
+  const PACKAGE_JSON = {
+    devDependencies: {
+      tslint: '~6.1.0',
+    },
+  };
+
+  beforeEach(() => {
+    tree = new UnitTestTree(new EmptyTree());
+    tree.create(PACKAGE_JSON_PATH, JSON.stringify(PACKAGE_JSON, null, 2));
+    tree.create(TSLINT_PATH, JSON.stringify({ rules: {} }, null, 2));
+  });
+
+  it('should add new rules', async () => {
+    const config = {
+      extends: 'tslint:recommended',
+      rules: {
+        'no-use-before-declare': true,
+        'arrow-return-shorthand': false,
+        'label-position': true,
+      },
+    };
+    tree.overwrite(TSLINT_PATH, JSON.stringify(config, null, 2));
+
+    const newTree = await schematicRunner.runSchematicAsync(schematicName, {}, tree).toPromise();
+    const { rules } = JSON.parse(newTree.readContent(TSLINT_PATH));
+    expect(rules['typedef']).toEqual([true, 'call-signature']);
+  });
+
+  it('should not update already present rules', async () => {
+    const config = {
+      extends: 'tslint:recommended',
+      rules: {
+        'no-use-before-declare': true,
+        'arrow-return-shorthand': false,
+        'label-position': true,
+        typedef: false,
+      },
+    };
+    tree.overwrite(TSLINT_PATH, JSON.stringify(config, null, 2));
+
+    const newTree = await schematicRunner.runSchematicAsync(schematicName, {}, tree).toPromise();
+    const { rules } = JSON.parse(newTree.readContent(TSLINT_PATH));
+    expect(rules['typedef']).toBe(false);
+  });
+
+  it('should add tslint:disable-next-line comments to offending code.', async () => {
+    tree.create('/main.ts', `
+      export function bar(): boolean {
+        return true;
+      }
+
+      /** @deprecated */
+      export function foo() {
+        return true;
+      }
+    `);
+
+    tree.create('/index.ts', `
+      export class Foo {
+        bar(): boolean {
+          return true;
+        }
+
+        baz() {
+          return true;
+        }
+      }
+    `);
+
+    const newTree = await schematicRunner.runSchematicAsync(schematicName, {}, tree).toPromise();
+    expect(newTree.readContent('/main.ts')).toContain(`
+      /** @deprecated */
+      // tslint:disable-next-line:typedef
+      export function foo() {
+        return true;
+      }
+    `);
+
+    expect(newTree.readContent('/index.ts')).toContain(`
+        // tslint:disable-next-line:typedef
+        baz() {
+          return true;
+        }
+    `);
+  });
+});


### PR DESCRIPTION
With this change we add a migration to add the `typedef` tslint rule. Since this rule doesn't come with an fixer, the migratioin will add a comment to disable tslint line on the next line when we find possible linting failures.

Closes #18465