### PR TITLE
fix(@angular-devkit/architect): add name of the non-existing project

### DIFF
--- a/packages/angular_devkit/architect/node/node-modules-architect-host.ts
+++ b/packages/angular_devkit/architect/node/node-modules-architect-host.ts
@@ -129,7 +129,7 @@ export class WorkspaceNodeModulesArchitectHost implements ArchitectHost<NodeModu
 
     const projectDefinition = this._workspace.projects.get(projectName);
     if (!projectDefinition) {
-      throw new Error('Project does not exist.');
+      throw new Error(`Project "${projectName}" does not exist.`);
     }
 
     const metadata = ({
@@ -154,7 +154,7 @@ export class WorkspaceNodeModulesArchitectHost implements ArchitectHost<NodeModu
   private findProjectTarget(target: Target) {
     const projectDefinition = this._workspace.projects.get(target.project);
     if (!projectDefinition) {
-      throw new Error('Project does not exist.');
+      throw new Error(`Project "${target.project}" does not exist.`);
     }
 
     return projectDefinition.targets.get(target.target);


### PR DESCRIPTION
This PR should improve debugging angular.json. In my case I could not figure out which project was missing. There was a small typo in one of the references to the project-name. Displaying the name of the missing project helps finding the error.
