### PR TITLE
feat(@angular-devkit/build-angular): support multiple translation files per locale

### DIFF
--- a/packages/angular/cli/lib/config/schema.json
+++ b/packages/angular/cli/lib/config/schema.json
@@ -419,12 +419,32 @@
                       "description": "Localization file to use for i18n"
                     },
                     {
+                      "type": "array",
+                      "description": "Localization files to use for i18n",
+                      "items": {
+                        "type": "string",
+                        "uniqueItems": true
+                      }
+                    },
+                    {
                       "type": "object",
                       "description": "Localization options to use for the locale",
                       "properties": {
                         "translation": {
-                          "type": "string",
-                          "description": "Localization file to use for i18n"
+                          "oneOf": [
+                            {
+                              "type": "string",
+                              "description": "Localization file to use for i18n"
+                            },
+                            {
+                              "type": "array",
+                              "description": "Localization files to use for i18n",
+                              "items": {
+                                "type": "string",
+                                "uniqueItems": true
+                              }
+                            }
+                          ]
                         },
                         "baseHref": {
                           "type": "string",

--- a/packages/angular_devkit/build_angular/src/dev-server/index.ts
+++ b/packages/angular_devkit/build_angular/src/dev-server/index.ts
@@ -287,14 +287,13 @@ async function setupLocalize(
   const localeDescription = i18n.locales[locale];
   const { plugins, diagnostics } = await createI18nPlugins(
     locale,
-    localeDescription && localeDescription.translation,
+    localeDescription?.translation,
     browserOptions.i18nMissingTranslation || 'ignore',
   );
 
   // Modify main entrypoint to include locale data
   if (
-    localeDescription &&
-    localeDescription.dataPath &&
+    localeDescription?.dataPath &&
     typeof webpackConfig.entry === 'object' &&
     !Array.isArray(webpackConfig.entry) &&
     webpackConfig.entry['main']
@@ -321,7 +320,7 @@ async function setupLocalize(
           cacheIdentifier: JSON.stringify({
             buildAngular: require('../../package.json').version,
             locale,
-            translationIntegrity: localeDescription && localeDescription.integrity,
+            translationIntegrity: localeDescription?.files.map((file) => file.integrity),
           }),
           plugins,
         },

--- a/packages/angular_devkit/build_angular/src/utils/webpack-browser-config.ts
+++ b/packages/angular_devkit/build_angular/src/utils/webpack-browser-config.ts
@@ -158,7 +158,7 @@ export async function generateI18nBrowserWebpackConfigFromContext(
 
     // Update file hashes to include translation file content
     const i18nHash = Object.values(i18n.locales).reduce(
-      (data, locale) => data + (locale.integrity || ''),
+      (data, locale) => data + locale.files.map((file) => file.integrity || '').join('|'),
       '',
     );
     if (!config.plugins) {

--- a/packages/angular_devkit/core/src/experimental/workspace/workspace-schema.json
+++ b/packages/angular_devkit/core/src/experimental/workspace/workspace-schema.json
@@ -167,12 +167,32 @@
                   "description": "Localization file to use for i18n"
                 },
                 {
+                  "type": "array",
+                  "description": "Localization files to use for i18n",
+                  "items": {
+                    "type": "string",
+                    "uniqueItems": true
+                  }
+                },
+                {
                   "type": "object",
                   "description": "Localization options to use for the locale",
                   "properties": {
                     "translation": {
-                      "type": "string",
-                      "description": "Localization file to use for i18n"
+                      "oneOf": [
+                        {
+                          "type": "string",
+                          "description": "Localization file to use for i18n"
+                        },
+                        {
+                          "type": "array",
+                          "description": "Localization files to use for i18n",
+                          "items": {
+                            "type": "string",
+                            "uniqueItems": true
+                          }
+                        }
+                      ]
                     },
                     "baseHref": {
                       "type": "string",

--- a/tests/legacy-cli/e2e/tests/i18n/ivy-localize-merging.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/ivy-localize-merging.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { ng } from '../../utils/process';
+import { updateJsonFile } from '../../utils/project';
+import { setupI18nConfig } from './legacy';
+
+export default async function() {
+  // Setup i18n tests and config.
+  await setupI18nConfig(true);
+
+  // Update angular.json
+  await updateJsonFile('angular.json', workspaceJson => {
+    const appProject = workspaceJson.projects['test-project'];
+    // tslint:disable-next-line: no-any
+    const i18n: Record<string, any> = appProject.i18n;
+
+    i18n.locales['fr'] = [
+      i18n.locales['fr'],
+      i18n.locales['fr'],
+    ]
+    appProject.architect['build'].options.localize = ['fr'];
+  });
+
+  const { stderr: err1 } = await ng('build');
+  if (!err1.includes('Duplicate translations for message')) {
+    throw new Error('duplicate translations warning not shown');
+  }
+
+
+}


### PR DESCRIPTION
This change implements the capability to specify multiple translation files per locale. The specified translation files for each locale will be merged prior to localization. The Angular configuration file has been updated to allow for both a single path string or an array of path strings when specifying the translations for each locale. If the same message identifier is present in multiple translation files, a warning will currently be issued and the last file with the duplicate message identifier will take precedence.

Closes #18276