### PR TITLE
feat(@schematics/angular): always extract css on newly generated applications

### DIFF
--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -179,6 +179,7 @@ function addAppToWorkspaceFile(options: ApplicationOptions, appDir: string): Rul
           polyfills: `${sourceRoot}/polyfills.ts`,
           tsConfig: `${projectRoot}tsconfig.app.json`,
           aot: true,
+          extractCss: true,
           assets: [
             `${sourceRoot}/favicon.ico`,
             `${sourceRoot}/assets`,
@@ -197,7 +198,6 @@ function addAppToWorkspaceFile(options: ApplicationOptions, appDir: string): Rul
             optimization: true,
             outputHashing: 'all',
             sourceMap: false,
-            extractCss: true,
             namedChunks: false,
             extractLicenses: true,
             vendorChunk: false,

--- a/tests/legacy-cli/e2e/tests/build/multiple-configs.ts
+++ b/tests/legacy-cli/e2e/tests/build/multiple-configs.ts
@@ -9,34 +9,37 @@ export default async function () {
     // These are the default options, that we'll overwrite in subsequent configs.
     // extractCss defaults to false
     // sourceMap defaults to true
-    appArchitect['options'] = {
-      outputPath: 'dist/latest-project',
-      index: 'src/index.html',
-      main: 'src/main.ts',
-      polyfills: 'src/polyfills.ts',
-      tsConfig: 'tsconfig.app.json',
-      assets: [
-        'src/favicon.ico',
-        'src/assets',
-      ],
-      'styles': [
-        'src/styles.css',
-      ],
-      'scripts': [],
+    appArchitect['build'] = {
+      ...appArchitect['build'],
+      options: {
+        ...appArchitect['build'].options,
+        extractCss: false,
+        assets: [
+          'src/favicon.ico',
+          'src/assets',
+        ],
+        styles: [
+          'src/styles.css',
+        ],
+        scripts: [],
+      },
+      configurations: {
+        production: {
+          extractCss: true,
+        },
+        one: {
+          assets: [],
+        },
+        two: {
+          sourceMap: false,
+        },
+        three: {
+          extractCss: false, // Defaults to false when not set.
+        },
+      },
     };
-    const browserConfigs = appArchitect['build'].configurations;
-    browserConfigs['production'] = {
-      extractCss: true,
-    };
-    browserConfigs['one'] = {
-      assets: [],
-    };
-    browserConfigs['two'] = {
-      sourceMap: false,
-    };
-    browserConfigs['three'] = {
-      extractCss: false, // Defaults to false when not set.
-    };
+
+    return workspaceJson;
   });
 
   // Test the base configuration.

--- a/tests/legacy-cli/e2e/tests/misc/es5-polyfills.ts
+++ b/tests/legacy-cli/e2e/tests/misc/es5-polyfills.ts
@@ -15,7 +15,6 @@ export default async function () {
   await expectFileToMatch('dist/test-project/index.html', oneLineTrim`
     <script src="runtime.js" defer></script>
     <script src="polyfills.js" defer></script>
-    <script src="styles.js" defer></script>
     <script src="vendor.js" defer></script>
     <script src="main.js" defer></script>
   `);
@@ -27,7 +26,6 @@ export default async function () {
     <script src="runtime.js" defer></script>
     <script src="polyfills-es5.js" nomodule defer></script>
     <script src="polyfills.js" defer></script>
-    <script src="styles.js" defer></script>
     <script src="vendor.js" defer></script>
     <script src="main.js" defer></script>
   `);


### PR DESCRIPTION

`extractCss` will be deprecated in version 11 and the new behaviour will be to always extract css because for HMR to work we no longer the need to disable CSS extraction.

With this change we move new applications to the new behaviour.