### PR TITLE
perf(@angular-devkit/core): avoid RxJS performance penalty in sync fs calls

### DIFF
--- a/packages/angular_devkit/core/src/virtual-fs/host/sync.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/host/sync.ts
@@ -37,11 +37,13 @@ export class SyncDelegateHost<T extends object = {}> {
     let completed = false;
     let result: ResultT | undefined = undefined;
     let errorResult: Error | undefined = undefined;
-    observable.subscribe({
-      next(x: ResultT) { result = x; },
-      error(err: Error) { errorResult = err; },
-      complete() { completed = true; },
-    });
+    // Perf note: this is not using an observer object to avoid a performance penalty in RxJS.
+    // See https://github.com/ReactiveX/rxjs/pull/5646 for details.
+    observable.subscribe(
+      (x: ResultT) => result = x,
+      (err: Error) => errorResult = err,
+      () => completed = true,
+    );
 
     if (errorResult !== undefined) {
       throw errorResult;


### PR DESCRIPTION
While testing compiler performance with [ng9-aot-build-times](https://github.com/JoostK/ng9-aot-build-times) I noticed RxJS's `SafeSubscriber` to show up as hot function. I opened ReactiveX/rxjs#5646 to mitigate it, however this change cannot be accepted because it breaks a certain usage pattern. As an alternative, this PR avoids the performance penalty by switching over the anonymous observer object to use 3 separate callbacks instead, such that RxJS doesn't have to create calling context objects using slow `Object.create`.

On a new CLI app, local testing indicates that this saves about 120ms or 2%, whereas the [ng9-aot-build-times](https://github.com/JoostK/ng9-aot-build-times) repo shows approximately 2 second improvement, or ~6%.