### PR TITLE
ci: change test and integration step to use `medium` resource class

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -244,7 +244,7 @@ jobs:
 
   test:
     executor: test-executor
-    resource_class: xlarge
+    resource_class: medium
     steps:
       - custom_attach_workspace
       - browser-tools/install-chrome
@@ -256,7 +256,7 @@ jobs:
 
   integration:
     executor: test-executor
-    resource_class: xlarge
+    resource_class: medium
     steps:
       - custom_attach_workspace
       - install_python


### PR DESCRIPTION
We are limiting Bazel to consuming resources that fit in CircleCI "medium" class which is the default

https://github.com/angular/angular-cli/blob/aacb98d85bac837b898dc6158459aef53f5569a3/.circleci/bazel.rc#L13-L17