### PR TITLE
fix(@angular-devkit/core): strict typings for json, logger, and virtual-fs

### DIFF
--- a/etc/api/angular_devkit/core/src/_golden-api.d.ts
+++ b/etc/api/angular_devkit/core/src/_golden-api.d.ts
@@ -214,7 +214,7 @@ export interface CordHostRename {
 
 export declare class CoreSchemaRegistry implements SchemaRegistry {
     constructor(formats?: SchemaFormat[]);
-    protected _resolver(ref: string, validate: ajv.ValidateFunction): {
+    protected _resolver(ref: string, validate?: ajv.ValidateFunction): {
         context?: ajv.ValidateFunction;
         schema?: JsonObject;
     };
@@ -1133,7 +1133,7 @@ export declare namespace test {
     };
     class TestHost extends SimpleMemoryHost {
         protected _records: TestLogRecord[];
-        protected _sync: SyncDelegateHost<{}>;
+        protected _sync: SyncDelegateHost<{}> | null;
         get files(): Path[];
         get records(): TestLogRecord[];
         get sync(): SyncDelegateHost<{}>;

--- a/packages/angular_devkit/core/src/json/schema/registry.ts
+++ b/packages/angular_devkit/core/src/json/schema/registry.ts
@@ -58,6 +58,7 @@ export class SchemaValidationException extends BaseException {
   ) {
     if (!errors || errors.length === 0) {
       super('Schema validation failed.');
+      this.errors = [];
 
       return;
     }
@@ -194,7 +195,7 @@ export class CoreSchemaRegistry implements SchemaRegistry {
 
   protected _resolver(
     ref: string,
-    validate: ajv.ValidateFunction,
+    validate?: ajv.ValidateFunction,
   ): { context?: ajv.ValidateFunction, schema?: JsonObject } {
     if (!validate || !validate.refs || !validate.refVal || !ref) {
       return {};
@@ -396,10 +397,10 @@ export class CoreSchemaRegistry implements SchemaRegistry {
             switchMap(updatedData => {
               const result = validate.call(validationContext, updatedData);
 
-              return typeof result == 'boolean'
+              return typeof result === 'boolean'
                 ? of([updatedData, result])
                 : from((result as Promise<boolean>)
-                  .then(r => [updatedData, true])
+                  .then(() => [updatedData, true])
                   .catch((err: Error | AjvValidationError) => {
                     if ((err as AjvValidationError).ajv) {
                       validate.errors = (err as AjvValidationError).errors;
@@ -410,7 +411,7 @@ export class CoreSchemaRegistry implements SchemaRegistry {
                     return Promise.reject(err);
                   }));
             }),
-            switchMap(([data, valid]: [JsonValue, boolean]) => {
+            switchMap(([data, valid]) => {
               if (valid) {
                 let result = of(data);
 
@@ -430,7 +431,7 @@ export class CoreSchemaRegistry implements SchemaRegistry {
                 return of([data, valid]);
               }
             }),
-            map(([data, valid]: [JsonValue, boolean]) => {
+            map(([data, valid]) => {
               if (valid) {
                 return { data, success: true } as SchemaValidatorResult;
               }
@@ -520,7 +521,7 @@ export class CoreSchemaRegistry implements SchemaRegistry {
     this._ajv.addKeyword('x-prompt', {
       errors: false,
       valid: true,
-      compile: (schema, parentSchema: JsonObject, it) => {
+      compile: (schema, parentSchema, it) => {
         const compilationSchemInfo = this._currentCompilationSchemaInfo;
         if (!compilationSchemInfo) {
           return () => true;
@@ -541,17 +542,17 @@ export class CoreSchemaRegistry implements SchemaRegistry {
           items = schema.items;
         }
 
-        const propertyTypes = getTypesOfSchema(parentSchema);
+        const propertyTypes = getTypesOfSchema(parentSchema as JsonObject);
         if (!type) {
           if (propertyTypes.size === 1 && propertyTypes.has('boolean')) {
             type = 'confirmation';
-          } else if (Array.isArray(parentSchema.enum)) {
+          } else if (Array.isArray((parentSchema as JsonObject).enum)) {
             type = 'list';
           } else if (
             propertyTypes.size === 1 &&
             propertyTypes.has('array') &&
-            parentSchema.items &&
-            Array.isArray((parentSchema.items as JsonObject).enum)
+            (parentSchema as JsonObject).items &&
+            Array.isArray(((parentSchema as JsonObject).items as JsonObject).enum)
           ) {
             type = 'list';
           } else {
@@ -567,8 +568,8 @@ export class CoreSchemaRegistry implements SchemaRegistry {
               : schema.multiselect;
 
           const enumValues = multiselect
-            ? parentSchema.items && (parentSchema.items as JsonObject).enum
-            : parentSchema.enum;
+            ? (parentSchema as JsonObject).items && ((parentSchema as JsonObject).items as JsonObject).enum
+            : (parentSchema as JsonObject).enum;
           if (!items && Array.isArray(enumValues)) {
             items = [];
             for (const value of enumValues) {
@@ -591,11 +592,11 @@ export class CoreSchemaRegistry implements SchemaRegistry {
           items,
           multiselect,
           default:
-            typeof parentSchema.default == 'object' &&
-            parentSchema.default !== null &&
-            !Array.isArray(parentSchema.default)
+            typeof (parentSchema as JsonObject).default == 'object' &&
+            (parentSchema as JsonObject).default !== null &&
+            !Array.isArray((parentSchema as JsonObject).default)
               ? undefined
-              : parentSchema.default as string[],
+              : (parentSchema as JsonObject).default as string[],
           async validator(data: JsonValue) {
             try {
               return await it.self.validate(parentSchema, data);

--- a/packages/angular_devkit/core/src/logger/logger.ts
+++ b/packages/angular_devkit/core/src/logger/logger.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import { Observable, Operator, PartialObserver, Subject, Subscription } from 'rxjs';
+import { Observable, Operator, PartialObserver, Subject, Subscription, empty } from 'rxjs';
 import { JsonObject } from '../json/interface';
 
 
@@ -35,8 +35,8 @@ export class Logger extends Observable<LogEntry> implements LoggerApi {
   protected readonly _subject: Subject<LogEntry> = new Subject<LogEntry>();
   protected _metadata: LoggerMetadata;
 
-  private _obs: Observable<LogEntry>;
-  private _subscription: Subscription | null;
+  private _obs: Observable<LogEntry> = empty();
+  private _subscription: Subscription | null = null;
 
   protected get _observable() { return this._obs; }
   protected set _observable(v: Observable<LogEntry>) {
@@ -142,7 +142,7 @@ export class Logger extends Observable<LogEntry> implements LoggerApi {
   subscribe(_observerOrNext?: PartialObserver<LogEntry> | ((value: LogEntry) => void),
             _error?: (error: Error) => void,
             _complete?: () => void): Subscription {
-    return this._observable.subscribe.apply(this._observable, arguments);
+    return this._observable.subscribe.apply(this._observable, arguments as unknown);
   }
   forEach(next: (value: LogEntry) => void, PromiseCtor?: typeof Promise): Promise<void> {
     return this._observable.forEach(next, PromiseCtor);

--- a/packages/angular_devkit/core/src/virtual-fs/host/buffer.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/host/buffer.ts
@@ -73,7 +73,7 @@ export function fileBufferToString(fileBuffer: FileBuffer): string {
       if (i + chunkLength > bufLength) {
         chunkLength = bufLength - i;
       }
-      result += String.fromCharCode.apply(null, bufView.subarray(i, i + chunkLength));
+      result += String.fromCharCode.apply(null, [...bufView.subarray(i, i + chunkLength)]);
     }
 
     return result;

--- a/packages/angular_devkit/core/src/virtual-fs/host/test.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/host/test.ts
@@ -27,7 +27,7 @@ export namespace test {
 
   export class TestHost extends SimpleMemoryHost {
     protected _records: TestLogRecord[] = [];
-    protected _sync: SyncDelegateHost<{}>;
+    protected _sync: SyncDelegateHost<{}>|null = null;
 
     constructor(map: { [path: string]: string } = {}) {
       super();


### PR DESCRIPTION
This commit fixes typings errors after "strict: true" is enabled in
tsconfig.json for the json, logger, and virtual-fs subpackages in
`@angular-devkit/core`.