### PR TITLE
feat(@schematics/angular): add migration to replace deprecated library builder

### DIFF
--- a/packages/schematics/angular/migrations/migration-collection.json
+++ b/packages/schematics/angular/migrations/migration-collection.json
@@ -104,6 +104,11 @@
       "version": "10.1.0-next.5",
       "factory": "./update-10/remove-solution-style-tsconfig",
       "description": "Removing \"Solution Style\" TypeScript configuration file support."
+    },
+    "replace-ng-packagr-builder": {
+      "version": "11.0.0-next.0",
+      "factory": "./update-11/replace-ng-packagr-builder",
+      "description": "Replace deprecated library builder '@angular-devkit/build-ng-packagr'."
     }
   }
 }

--- a/packages/schematics/angular/migrations/update-11/replace-ng-packagr-builder.ts
+++ b/packages/schematics/angular/migrations/update-11/replace-ng-packagr-builder.ts
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { Rule, chain } from '@angular-devkit/schematics';
+import { NodeDependencyType, addPackageJsonDependency, removePackageJsonDependency } from '../../utility/dependencies';
+import { latestVersions } from '../../utility/latest-versions';
+import { updateWorkspace } from '../../utility/workspace';
+import { Builders } from '../../utility/workspace-models';
+
+export default function (): Rule {
+  return chain([
+    updateWorkspace(workspace => {
+      for (const [, project] of workspace.projects) {
+        for (const [, target] of project.targets) {
+          if (target.builder === Builders.DeprecatedNgPackagr) {
+            target.builder = Builders.NgPackagr;
+          }
+        }
+      }
+    }),
+    host => {
+      removePackageJsonDependency(host, '@angular-devkit/build-ng-packagr');
+      addPackageJsonDependency(host, {
+        type: NodeDependencyType.Dev,
+        name: '@angular-devkit/build-angular',
+        version: latestVersions.DevkitBuildAngular,
+        overwrite: false,
+      });
+    },
+  ]);
+}

--- a/packages/schematics/angular/migrations/update-11/replace-ng-packagr-builder_spec.ts
+++ b/packages/schematics/angular/migrations/update-11/replace-ng-packagr-builder_spec.ts
@@ -1,0 +1,72 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { EmptyTree } from '@angular-devkit/schematics';
+import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';
+import { Builders, ProjectType, WorkspaceSchema } from '../../utility/workspace-models';
+
+function createWorkSpaceConfig(tree: UnitTestTree) {
+  const angularConfig: WorkspaceSchema = {
+    version: 1,
+    projects: {
+      lib: {
+        root: '/project/lib',
+        sourceRoot: '/project/lib/src',
+        projectType: ProjectType.Library,
+        prefix: 'lib',
+        architect: {
+          build: {
+            builder: Builders.DeprecatedNgPackagr,
+          // tslint:disable-next-line: no-any
+          } as any,
+        },
+      },
+    },
+  };
+
+  tree.create('/angular.json', JSON.stringify(angularConfig, undefined, 2));
+}
+
+describe(`Migration to replace '@angular-devkit/build-ng-packagr' builder`, () => {
+  const schematicName = 'replace-ng-packagr-builder';
+
+  const schematicRunner = new SchematicTestRunner(
+    'migrations',
+    require.resolve('../migration-collection.json'),
+  );
+
+  let tree: UnitTestTree;
+  beforeEach(() => {
+    tree = new UnitTestTree(new EmptyTree());
+    createWorkSpaceConfig(tree);
+    tree.create('/package.json', JSON.stringify({
+      devDependencies: {
+        '@angular/compiler-cli': '0.0.0',
+        '@angular-devkit/build-ng-packagr': '0.0.0',
+      },
+    }, undefined, 2));
+  });
+
+  it(`should remove '@angular-devkit/build-ng-packagr' from devDependencies`, async () => {
+    const newTree = await schematicRunner.runSchematicAsync(schematicName, {}, tree).toPromise();
+    const { devDependencies } = JSON.parse(newTree.readContent('/package.json'));
+    expect(devDependencies['@angular-devkit/build-ng-packagr']).toBeUndefined();
+  });
+
+  it(`should add '@angular-devkit/build-angular' to devDependencies`, async () => {
+    const newTree = await schematicRunner.runSchematicAsync(schematicName, {}, tree).toPromise();
+    const { devDependencies } = JSON.parse(newTree.readContent('/package.json'));
+    expect(devDependencies['@angular-devkit/build-angular']).toBeTruthy();
+  });
+
+  it('should update library builder target', async () => {
+    const newTree = await schematicRunner.runSchematicAsync(schematicName, {}, tree).toPromise();
+    const { projects: { lib } } = JSON.parse(newTree.readContent('/angular.json'));
+    expect(lib.architect.build.builder).toBe('@angular-devkit/build-angular:ng-packagr');
+  });
+});


### PR DESCRIPTION


In 10.1, `@angular-devkit/build-ng-packagr` was deprecated in favor of `@angular-devkit/build-angular`. This migration updates the library build target to use the non deprecated builder.