### PR TITLE
ExtractCss and Inject migrations

### DIFF
--- a/packages/angular/cli/lib/config/schema.json
+++ b/packages/angular/cli/lib/config/schema.json
@@ -831,8 +831,8 @@
             },
             "extractCss": {
               "type": "boolean",
-              "description": "Extract css from global styles onto css files instead of js ones.",
-              "default": false
+              "description": "Extract CSS from global styles into '.css' files instead of '.js'.",
+              "default": true
             },
             "watch": {
               "type": "boolean",

--- a/packages/angular/cli/lib/config/schema.json
+++ b/packages/angular/cli/lib/config/schema.json
@@ -1072,11 +1072,6 @@
                       "type": "string",
                       "description": "The bundle name for this extra entry point."
                     },
-                    "lazy": {
-                      "type": "boolean",
-                      "description": "If the bundle will be lazy loaded.",
-                      "default": false
-                    },
                     "inject": {
                       "type": "boolean",
                       "description": "If the bundle will be referenced in the HTML file.",
@@ -1615,11 +1610,6 @@
                     "bundleName": {
                       "type": "string",
                       "description": "The bundle name for this extra entry point."
-                    },
-                    "lazy": {
-                      "type": "boolean",
-                      "description": "If the bundle will be lazy loaded.",
-                      "default": false
                     },
                     "inject": {
                       "type": "boolean",

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/build-options.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/build-options.ts
@@ -43,6 +43,7 @@ export interface BuildOptions {
   i18nLocale?: string;
   localize?: Localize;
   i18nMissingTranslation?: I18NMissingTranslation;
+  /** @deprecated since version 11.0. No longer required to disable CSS extraction for HMR.*/
   extractCss?: boolean;
   bundleDependencies?: boolean;
   externalDependencies?: string[];

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/utils.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/utils.ts
@@ -40,38 +40,31 @@ export function getOutputHashFormat(option: string, length = 20): HashFormat {
   return hashFormats[option] || hashFormats['none'];
 }
 
-// todo: replace with Omit when we update to TS 3.5
-type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
-export type NormalizedEntryPoint = Required<Omit<ExtraEntryPointClass, 'lazy'>>;
+export type NormalizedEntryPoint = Required<ExtraEntryPointClass>;
 
 export function normalizeExtraEntryPoints(
   extraEntryPoints: ExtraEntryPoint[],
   defaultBundleName: string,
 ): NormalizedEntryPoint[] {
   return extraEntryPoints.map(entry => {
-    let normalizedEntry;
     if (typeof entry === 'string') {
-      normalizedEntry = { input: entry, inject: true, bundleName: defaultBundleName };
-    } else {
-      const { lazy, inject = true, ...newEntry } = entry;
-      const injectNormalized = entry.lazy !== undefined ? !entry.lazy : inject;
-      let bundleName;
-
-      if (entry.bundleName) {
-        bundleName = entry.bundleName;
-      } else if (!injectNormalized) {
-        // Lazy entry points use the file name as bundle name.
-        bundleName = basename(
-          normalize(entry.input.replace(/\.(js|css|scss|sass|less|styl)$/i, '')),
-        );
-      } else {
-        bundleName = defaultBundleName;
-      }
-
-      normalizedEntry = { ...newEntry, inject: injectNormalized, bundleName };
+      return { input: entry, inject: true, bundleName: defaultBundleName };
     }
 
-    return normalizedEntry;
+    const { inject = true, ...newEntry } = entry;
+    let bundleName;
+    if (entry.bundleName) {
+      bundleName = entry.bundleName;
+    } else if (!inject) {
+      // Lazy entry points use the file name as bundle name.
+      bundleName = basename(
+        normalize(entry.input.replace(/\.(js|css|scss|sass|less|styl)$/i, '')),
+      );
+    } else {
+      bundleName = defaultBundleName;
+    }
+
+    return { ...newEntry, inject, bundleName };
   });
 }
 

--- a/packages/angular_devkit/build_angular/src/browser/schema.json
+++ b/packages/angular_devkit/build_angular/src/browser/schema.json
@@ -206,8 +206,9 @@
     },
     "extractCss": {
       "type": "boolean",
-      "description": "Extract css from global styles into css files instead of js ones.",
-      "default": false
+      "description": "Extract CSS from global styles into '.css' files instead of '.js'.",
+      "default": true,
+      "x-deprecated": "Deprecated since version 11.0. No longer required to disable CSS extraction for HMR."
     },
     "watch": {
       "type": "boolean",

--- a/packages/angular_devkit/build_angular/src/browser/schema.json
+++ b/packages/angular_devkit/build_angular/src/browser/schema.json
@@ -455,12 +455,6 @@
               "type": "string",
               "description": "The bundle name for this extra entry point."
             },
-            "lazy": {
-              "type": "boolean",
-              "description": "If the bundle will be lazy loaded.",
-              "default": false,
-              "x-deprecated": "Use 'inject' option with 'false' value instead."
-            },
             "inject": {
               "type": "boolean",
               "description": "If the bundle will be referenced in the HTML file.",

--- a/packages/angular_devkit/build_angular/src/browser/specs/base-href_spec.ts
+++ b/packages/angular_devkit/build_angular/src/browser/specs/base-href_spec.ts
@@ -54,7 +54,7 @@ describe('Browser Builder base href', () => {
     expect(output.success).toBe(true);
     const fileName = join(normalize(output.outputPath), 'index.html');
     const content = virtualFs.fileBufferToString(await host.read(normalize(fileName)).toPromise());
-    expect(content).toContain('<head><base href="/myUrl"><meta charset="UTF-8"></head>');
+    expect(content).toContain('<head><base href="/myUrl"><meta charset="UTF-8">');
     await run.stop();
   });
 });

--- a/packages/angular_devkit/build_angular/src/browser/specs/cross-origin_spec.ts
+++ b/packages/angular_devkit/build_angular/src/browser/specs/cross-origin_spec.ts
@@ -37,11 +37,10 @@ describe('Browser Builder crossOrigin', () => {
     const fileName = join(normalize(output.outputPath), 'index.html');
     const content = virtualFs.fileBufferToString(await host.read(normalize(fileName)).toPromise());
     expect(content).toBe(
-      `<html><head><base href="/"></head>` +
+      `<html><head><base href="/"><link rel="stylesheet" href="styles.css" crossorigin="use-credentials"></head>` +
         `<body><app-root></app-root>` +
         `<script src="runtime.js" crossorigin="use-credentials" defer></script>` +
         `<script src="polyfills.js" crossorigin="use-credentials" defer></script>` +
-        `<script src="styles.js" crossorigin="use-credentials" defer></script>` +
         `<script src="vendor.js" crossorigin="use-credentials" defer></script>` +
         `<script src="main.js" crossorigin="use-credentials" defer></script></body></html>`,
     );
@@ -56,11 +55,11 @@ describe('Browser Builder crossOrigin', () => {
     const fileName = join(normalize(output.outputPath), 'index.html');
     const content = virtualFs.fileBufferToString(await host.read(normalize(fileName)).toPromise());
     expect(content).toBe(
-      `<html><head><base href="/"></head>` +
+        `<html><head><base href="/">` +
+        `<link rel="stylesheet" href="styles.css" crossorigin="anonymous"></head>` +
         `<body><app-root></app-root>` +
         `<script src="runtime.js" crossorigin="anonymous" defer></script>` +
         `<script src="polyfills.js" crossorigin="anonymous" defer></script>` +
-        `<script src="styles.js" crossorigin="anonymous" defer></script>` +
         `<script src="vendor.js" crossorigin="anonymous" defer></script>` +
         `<script src="main.js" crossorigin="anonymous" defer></script></body></html>`,
     );
@@ -75,11 +74,11 @@ describe('Browser Builder crossOrigin', () => {
     const fileName = join(normalize(output.outputPath), 'index.html');
     const content = virtualFs.fileBufferToString(await host.read(normalize(fileName)).toPromise());
     expect(content).toBe(
-      `<html><head><base href="/"></head>` +
+        `<html><head><base href="/">` +
+        `<link rel="stylesheet" href="styles.css"></head>` +
         `<body><app-root></app-root>` +
         `<script src="runtime.js" defer></script>` +
         `<script src="polyfills.js" defer></script>` +
-        `<script src="styles.js" defer></script>` +
         `<script src="vendor.js" defer></script>` +
         `<script src="main.js" defer></script></body></html>`,
     );

--- a/packages/angular_devkit/build_angular/src/browser/specs/differential_loading_spec.ts
+++ b/packages/angular_devkit/build_angular/src/browser/specs/differential_loading_spec.ts
@@ -49,15 +49,13 @@ describe('Browser Builder with differential loading', () => {
       'runtime-es5.js',
       'runtime-es5.js.map',
 
-      'styles-es2015.js',
-      'styles-es2015.js.map',
-      'styles-es5.js',
-      'styles-es5.js.map',
-
       'vendor-es2015.js',
       'vendor-es2015.js.map',
       'vendor-es5.js',
       'vendor-es5.js.map',
+
+      'styles.css',
+      'styles.css.map',
     ] as PathFragment[];
 
     expect(Object.keys(files)).toEqual(jasmine.arrayWithExactContents(expectedOutputs));
@@ -91,15 +89,13 @@ describe('Browser Builder with differential loading', () => {
       'runtime-es5.js',
       'runtime-es5.js.map',
 
-      'styles-es2016.js',
-      'styles-es2016.js.map',
-      'styles-es5.js',
-      'styles-es5.js.map',
-
       'vendor-es2016.js',
       'vendor-es2016.js.map',
       'vendor-es5.js',
       'vendor-es5.js.map',
+
+      'styles.css',
+      'styles.css.map',
     ] as PathFragment[];
 
     expect(Object.keys(files)).toEqual(jasmine.arrayWithExactContents(expectedOutputs));
@@ -133,15 +129,13 @@ describe('Browser Builder with differential loading', () => {
       'runtime-es5.js',
       'runtime-es5.js.map',
 
-      'styles-esnext.js',
-      'styles-esnext.js.map',
-      'styles-es5.js',
-      'styles-es5.js.map',
-
       'vendor-esnext.js',
       'vendor-esnext.js.map',
       'vendor-es5.js',
       'vendor-es5.js.map',
+
+      'styles.css',
+      'styles.css.map',
     ] as PathFragment[];
 
     expect(Object.keys(files)).toEqual(jasmine.arrayWithExactContents(expectedOutputs));
@@ -163,11 +157,11 @@ describe('Browser Builder with differential loading', () => {
       'runtime.js',
       'runtime.js.map',
 
-      'styles.js',
-      'styles.js.map',
-
       'vendor.js',
       'vendor.js.map',
+
+      'styles.css',
+      'styles.css.map',
     ] as PathFragment[];
 
     expect(Object.keys(files)).toEqual(jasmine.arrayWithExactContents(expectedOutputs));
@@ -209,10 +203,9 @@ describe('Browser Builder with differential loading', () => {
     const { files } = await browserBuild(architect, host, target, { watch: true });
     expect(await files['index.html']).toContain(
       '<script src="runtime.js" type="module"></script>' +
-        '<script src="polyfills.js" type="module"></script>' +
-        '<script src="styles.js" type="module"></script>' +
-        '<script src="vendor.js" type="module"></script>' +
-        '<script src="main.js" type="module"></script>',
+      '<script src="polyfills.js" type="module"></script>' +
+      '<script src="vendor.js" type="module"></script>' +
+      '<script src="main.js" type="module"></script>',
     );
   });
 });

--- a/packages/angular_devkit/build_angular/src/browser/specs/index_spec.ts
+++ b/packages/angular_devkit/build_angular/src/browser/specs/index_spec.ts
@@ -34,9 +34,9 @@ describe('Browser Builder index HTML processing', () => {
     const fileName = join(normalize(output.outputPath), 'index.html');
     const content = virtualFs.fileBufferToString(await host.read(normalize(fileName)).toPromise());
     expect(content).toBe(
-      `<html><head><base href="/"></head>`
+      `<html><head><base href="/"><link rel="stylesheet" href="styles.css"></head>`
       + `<body><app-root></app-root><script src="runtime.js" defer></script>`
-      + `<script src="polyfills.js" defer></script><script src="styles.js" defer></script>`
+      + `<script src="polyfills.js" defer></script>`
       + `<script src="vendor.js" defer></script><script src="main.js" defer></script></body></html>`,
     );
     await run.stop();
@@ -56,9 +56,10 @@ describe('Browser Builder index HTML processing', () => {
     const fileName = join(normalize(output.outputPath), 'index.html');
     const content = virtualFs.fileBufferToString(await host.read(normalize(fileName)).toPromise());
     expect(content).toBe(
-      `<html><head><base href="/"></head><body><app-root></app-root>`
+      `<html><head><base href="/"><link rel="stylesheet" href="styles.css"></head>`
+      + `<body><app-root></app-root>`
       + `<script src="runtime.js" defer></script><script src="polyfills.js" defer></script>`
-      + `<script src="styles.js" defer></script><script src="vendor.js" defer></script>`
+      + `<script src="vendor.js" defer></script>`
       + `<script src="main.js" defer></script></body></html>`,
     );
     await run.stop();
@@ -78,9 +79,9 @@ describe('Browser Builder index HTML processing', () => {
     const fileName = join(normalize(output.outputPath), 'index.html');
     const content = virtualFs.fileBufferToString(await host.read(normalize(fileName)).toPromise());
     expect(content).toBe(
-      `<html><head><title>&iacute;</title><base href="/"></head> `
+      `<html><head><title>&iacute;</title><base href="/"><link rel="stylesheet" href="styles.css"></head> `
       + `<body><app-root></app-root><script src="runtime.js" defer></script>`
-      + `<script src="polyfills.js" defer></script><script src="styles.js" defer></script>`
+      + `<script src="polyfills.js" defer></script>`
       + `<script src="vendor.js" defer></script><script src="main.js" defer></script></body></html>`,
     );
     await run.stop();
@@ -100,9 +101,9 @@ describe('Browser Builder index HTML processing', () => {
     const fileName = join(normalize(output.outputPath), 'index.html');
     const content = virtualFs.fileBufferToString(await host.read(normalize(fileName)).toPromise());
     expect(content).toBe(
-      `<html><head><base href="/"><%= csrf_meta_tags %></head> `
+      `<html><head><base href="/"><%= csrf_meta_tags %><link rel="stylesheet" href="styles.css"></head> `
       + `<body><app-root></app-root><script src="runtime.js" defer></script>`
-      + `<script src="polyfills.js" defer></script><script src="styles.js" defer></script>`
+      + `<script src="polyfills.js" defer></script>`
       + `<script src="vendor.js" defer></script><script src="main.js" defer></script></body></html>`,
     );
     await run.stop();
@@ -145,9 +146,9 @@ describe('Browser Builder index HTML processing', () => {
     const outputIndexPath = join(host.root(), 'dist', 'index.html');
     const content = await host.read(normalize(outputIndexPath)).toPromise();
     expect(virtualFs.fileBufferToString(content)).toBe(
-      `<html><head><base href="/"><%= csrf_meta_tags %></head> `
+      `<html><head><base href="/"><%= csrf_meta_tags %><link rel="stylesheet" href="styles.css"></head> `
       + `<body><app-root></app-root><script src="runtime.js" defer></script>`
-      + `<script src="polyfills.js" defer></script><script src="styles.js" defer></script>`
+      + `<script src="polyfills.js" defer></script>`
       + `<script src="vendor.js" defer></script><script src="main.js" defer></script></body></html>`,
     );
   });
@@ -188,9 +189,9 @@ describe('Browser Builder index HTML processing', () => {
     const outputIndexPath = join(host.root(), 'dist', 'main.html');
     const content = await host.read(normalize(outputIndexPath)).toPromise();
     expect(virtualFs.fileBufferToString(content)).toBe(
-      `<html><head><base href="/"></head> `
+      `<html><head><base href="/"><link rel="stylesheet" href="styles.css"></head> `
       + `<body><app-root></app-root><script src="runtime.js" defer></script>`
-      + `<script src="polyfills.js" defer></script><script src="styles.js" defer></script>`
+      + `<script src="polyfills.js" defer></script>`
       + `<script src="vendor.js" defer></script><script src="main.js" defer></script></body></html>`,
     );
   });
@@ -231,9 +232,9 @@ describe('Browser Builder index HTML processing', () => {
     const outputIndexPath = join(host.root(), 'dist', 'extra', 'main.html');
     const content = await host.read(normalize(outputIndexPath)).toPromise();
     expect(virtualFs.fileBufferToString(content)).toBe(
-      `<html><head><base href="/"></head> `
+      `<html><head><base href="/"><link rel="stylesheet" href="styles.css"></head> `
       + `<body><app-root></app-root><script src="runtime.js" defer></script>`
-      + `<script src="polyfills.js" defer></script><script src="styles.js" defer></script>`
+      + `<script src="polyfills.js" defer></script>`
       + `<script src="vendor.js" defer></script><script src="main.js" defer></script></body></html>`,
     );
   });

--- a/packages/angular_devkit/build_angular/src/browser/specs/service-worker_spec.ts
+++ b/packages/angular_devkit/build_angular/src/browser/specs/service-worker_spec.ts
@@ -118,7 +118,7 @@ describe('Browser Builder service worker', () => {
       hashTable: {
         '/favicon.ico': '84161b857f5c547e3699ddfbffc6d8d737542e01',
         '/assets/folder-asset.txt': '617f202968a6a81050aa617c2e28e1dca11ce8d4',
-        '/index.html': 'f95e7a84949070c4984069b592be7969bc3187a0',
+        '/index.html': 'f0bea8ced1dfbeeb771a5f48651fbcff52a625eb',
         '/spectrum.png': '8d048ece46c0f3af4b598a95fd8e4709b631c3c0',
       },
     }));
@@ -235,7 +235,7 @@ describe('Browser Builder service worker', () => {
       hashTable: {
         '/foo/bar/favicon.ico': '84161b857f5c547e3699ddfbffc6d8d737542e01',
         '/foo/bar/assets/folder-asset.txt': '617f202968a6a81050aa617c2e28e1dca11ce8d4',
-        '/foo/bar/index.html': 'e92a780dba6f6099adafb72d7611f6660a91a70b',
+        '/foo/bar/index.html': 'f6650ac91428c6933dfe4c24079b3b15400da1ba',
       },
     }));
 

--- a/packages/angular_devkit/build_angular/src/browser/specs/works_spec.ts
+++ b/packages/angular_devkit/build_angular/src/browser/specs/works_spec.ts
@@ -29,9 +29,9 @@ describe('Browser Builder basic test', () => {
     expect(await host.scopedSync().exists(normalize('dist/runtime.js'))).toBe(true);
     expect(await host.scopedSync().exists(normalize('dist/main.js'))).toBe(true);
     expect(await host.scopedSync().exists(normalize('dist/polyfills.js'))).toBe(true);
-    expect(await host.scopedSync().exists(normalize('dist/styles.js'))).toBe(true);
     expect(await host.scopedSync().exists(normalize('dist/vendor.js'))).toBe(true);
     expect(await host.scopedSync().exists(normalize('dist/favicon.ico'))).toBe(true);
+    expect(await host.scopedSync().exists(normalize('dist/styles.css'))).toBe(true);
     expect(await host.scopedSync().exists(normalize('dist/index.html'))).toBe(true);
   });
 });

--- a/packages/angular_devkit/build_angular/src/dev-server/index_spec.ts
+++ b/packages/angular_devkit/build_angular/src/dev-server/index_spec.ts
@@ -32,7 +32,6 @@ describe('Dev Server Builder index', () => {
     expect(await response.text()).toContain(
       '<script src="runtime.js" type="module"></script>' +
         '<script src="polyfills.js" type="module"></script>' +
-        '<script src="styles.js" type="module"></script>' +
         '<script src="vendor.js" type="module"></script>' +
         '<script src="main.js" type="module"></script>',
     );
@@ -75,7 +74,6 @@ describe('Dev Server Builder index', () => {
     expect(await response.text()).toContain(
       '<script src="runtime.js" type="module"></script>' +
         '<script src="polyfills.js" type="module"></script>' +
-        '<script src="styles.js" type="module"></script>' +
         '<script src="scripts.js" defer></script>' +
         '<script src="vendor.js" type="module"></script>' +
         '<script src="main.js" type="module"></script>',
@@ -98,7 +96,6 @@ describe('Dev Server Builder index', () => {
     expect(await response.text()).toContain(
       '<script src="runtime.js" defer></script>' +
         '<script src="polyfills.js" defer></script>' +
-        '<script src="styles.js" defer></script>' +
         '<script src="vendor.js" defer></script>' +
         '<script src="main.js" defer></script>',
     );

--- a/packages/angular_devkit/build_angular/src/karma/schema.json
+++ b/packages/angular_devkit/build_angular/src/karma/schema.json
@@ -244,12 +244,6 @@
               "type": "string",
               "description": "The bundle name for this extra entry point."
             },
-            "lazy": {
-              "type": "boolean",
-              "description": "If the bundle will be lazy loaded.",
-              "default": false,
-              "x-deprecated": "Use 'inject' option with 'false' value instead."
-            },
             "inject": {
               "type": "boolean",
               "description": "If the bundle will be referenced in the HTML file.",

--- a/packages/schematics/angular/app-shell/schema.json
+++ b/packages/schematics/angular/app-shell/schema.json
@@ -47,12 +47,6 @@
       "format": "html-selector",
       "description": "The name of the root module class.",
       "default": "AppServerModule"
-    },
-    "tsconfigFileName": {
-      "type": "string",
-      "default": "tsconfig.server",
-      "description": "The name of the TypeScript configuration file.",
-      "x-deprecated": "This option has no effect."
     }
   },
   "required": [

--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -197,7 +197,6 @@ function addAppToWorkspaceFile(options: ApplicationOptions, appDir: string): Rul
             optimization: true,
             outputHashing: 'all',
             sourceMap: false,
-            extractCss: true,
             namedChunks: false,
             extractLicenses: true,
             vendorChunk: false,

--- a/packages/schematics/angular/migrations/migration-collection.json
+++ b/packages/schematics/angular/migrations/migration-collection.json
@@ -109,6 +109,11 @@
       "version": "11.0.0-next.0",
       "factory": "./update-11/replace-ng-packagr-builder",
       "description": "Replace deprecated library builder '@angular-devkit/build-ng-packagr'."
+    },
+    "update-angular-config-v11": {
+      "version": "11.0.0-next.0",
+      "factory": "./update-11/update-angular-config",
+      "description": "Remove deprecated options from 'angular.json' that are no longer present in v11."
     }
   }
 }

--- a/packages/schematics/angular/migrations/update-11/update-angular-config.ts
+++ b/packages/schematics/angular/migrations/update-11/update-angular-config.ts
@@ -1,0 +1,85 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { JsonArray, isJsonArray, isJsonObject, workspaces } from '@angular-devkit/core';
+import { Rule } from '@angular-devkit/schematics';
+import { updateWorkspace } from '../../utility/workspace';
+
+export default function (): Rule {
+  return updateWorkspace(workspace => {
+
+    const optionsToRemove: Record<string, undefined> = {
+      extractCss: undefined,
+      tsconfigFileName: undefined,
+    };
+
+    for (const [, project] of workspace.projects) {
+      for (const [, target] of project.targets) {
+        // Only interested in Angular Devkit builders
+        if (!target?.builder.startsWith('@angular-devkit/build-angular')) {
+          continue;
+        }
+
+        // Check options
+        if (target.options) {
+          target.options = {
+            ...updateLazyScriptsStyleOption(target.options),
+            ...optionsToRemove,
+          };
+        }
+
+        // Go through each configuration entry
+        if (!target.configurations) {
+          continue;
+        }
+
+        for (const configurationName of Object.keys(target.configurations)) {
+          target.configurations[configurationName] = {
+            ...updateLazyScriptsStyleOption(target.configurations[configurationName]),
+            ...optionsToRemove,
+          };
+        }
+      }
+    }
+  });
+}
+
+type TargetOptions = workspaces.TargetDefinition['options'];
+
+function updateLazyScriptsStyleOption(options: TargetOptions): TargetOptions {
+  function visitor(options: NonNullable<TargetOptions>, type: 'scripts' | 'styles'): JsonArray | undefined {
+    // tslint:disable-next-line: no-non-null-assertion
+    if (!options[type] || !isJsonArray(options[type]!)) {
+      return undefined;
+    }
+    const entries = [];
+    for (const entry of options[type] as JsonArray) {
+      if (isJsonObject(entry) && 'lazy' in entry) {
+        entries.push({
+          ...entry,
+          inject: !entry.lazy,
+          lazy: undefined,
+        });
+      } else {
+        entries.push(entry);
+      }
+    }
+
+    return entries as JsonArray;
+  }
+
+  if (!options) {
+    return undefined;
+  }
+
+  return {
+    ...options,
+    styles: visitor(options, 'styles'),
+    scripts: visitor(options, 'scripts'),
+  };
+}

--- a/packages/schematics/angular/migrations/update-11/update-angular-config_spec.ts
+++ b/packages/schematics/angular/migrations/update-11/update-angular-config_spec.ts
@@ -1,0 +1,115 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { JsonObject } from '@angular-devkit/core';
+import { EmptyTree } from '@angular-devkit/schematics';
+import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';
+import { BuilderTarget, Builders, ProjectType, WorkspaceSchema } from '../../utility/workspace-models';
+
+function getBuildTarget(tree: UnitTestTree): BuilderTarget<Builders.Browser, JsonObject> {
+  return JSON.parse(tree.readContent('/angular.json')).projects.app.architect.build;
+}
+
+function createWorkSpaceConfig(tree: UnitTestTree) {
+  const angularConfig: WorkspaceSchema = {
+    version: 1,
+    projects: {
+      app: {
+        root: '',
+        sourceRoot: 'src',
+        projectType: ProjectType.Application,
+        prefix: 'app',
+        architect: {
+          build: {
+            builder: Builders.Browser,
+            options: {
+              scripts: [
+                { lazy: true, name: 'bundle-1.js' },
+              ],
+              extractCss: false,
+              sourceMaps: true,
+              buildOptimizer: false,
+              // tslint:disable-next-line:no-any
+            } as any,
+            configurations: {
+              one: {
+                aot: true,
+                scripts: [
+                  { lazy: true, name: 'bundle-1.js' },
+                  { lazy: false, name: 'bundle-2.js' },
+                  { inject: true, name: 'bundle-3.js' },
+                  'bundle-4.js',
+                ],
+                styles: [
+                  { lazy: true, name: 'bundle-1.css' },
+                  { lazy: false, name: 'bundle-2.css' },
+                  { inject: true, name: 'bundle-3.css' },
+                  'bundle-3.css',
+                ],
+              },
+              two: {
+                extractCss: true,
+                aot: true,
+              },
+              // tslint:disable-next-line:no-any
+            } as any,
+          },
+        },
+      },
+    },
+  };
+
+  tree.create('/angular.json', JSON.stringify(angularConfig, undefined, 2));
+}
+
+const schematicName = 'update-angular-config-v11';
+
+describe(`Migration to update 'angular.json'. ${schematicName}`, () => {
+  const schematicRunner = new SchematicTestRunner(
+    'migrations',
+    require.resolve('../migration-collection.json'),
+  );
+
+  let tree: UnitTestTree;
+  beforeEach(() => {
+    tree = new UnitTestTree(new EmptyTree());
+    createWorkSpaceConfig(tree);
+  });
+
+  it(`should remove 'extractCss'`, async () => {
+    const newTree = await schematicRunner.runSchematicAsync(schematicName, {}, tree).toPromise();
+    const { options, configurations } = getBuildTarget(newTree);
+
+    expect(options.extractCss).toBeUndefined();
+    expect(configurations).toBeDefined();
+    expect(configurations?.one.extractCss).toBeUndefined();
+    expect(configurations?.two.extractCss).toBeUndefined();
+  });
+
+  it(`should replace 'lazy' with 'inject'`, async () => {
+    const newTree = await schematicRunner.runSchematicAsync(schematicName, {}, tree).toPromise();
+    const { options, configurations } = getBuildTarget(newTree);
+
+    expect(configurations?.one.scripts).toEqual([
+      { inject: false, name: 'bundle-1.js' },
+      { inject: true, name: 'bundle-2.js' },
+      { inject: true, name: 'bundle-3.js' },
+      'bundle-4.js',
+    ]);
+
+    expect(configurations?.one.styles).toEqual([
+      { inject: false, name: 'bundle-1.css' },
+      { inject: true, name: 'bundle-2.css' },
+      { inject: true, name: 'bundle-3.css' },
+      'bundle-3.css',
+    ]);
+
+    expect(options.scripts).toEqual([
+      { inject: false, name: 'bundle-1.js' },
+    ]);
+  });
+});

--- a/packages/schematics/angular/universal/schema.json
+++ b/packages/schematics/angular/universal/schema.json
@@ -21,12 +21,6 @@
       "description": "The name of the main entry-point file.",
       "default": "main.server.ts"
     },
-    "tsconfigFileName": {
-      "type": "string",
-      "default": "tsconfig.server",
-      "description": "The name of the TypeScript configuration file.",
-      "x-deprecated": "This option has no effect."
-    },
     "appDir": {
       "type": "string",
       "format": "path",

--- a/tests/legacy-cli/e2e/tests/misc/es5-polyfills.ts
+++ b/tests/legacy-cli/e2e/tests/misc/es5-polyfills.ts
@@ -15,7 +15,6 @@ export default async function () {
   await expectFileToMatch('dist/test-project/index.html', oneLineTrim`
     <script src="runtime.js" defer></script>
     <script src="polyfills.js" defer></script>
-    <script src="styles.js" defer></script>
     <script src="vendor.js" defer></script>
     <script src="main.js" defer></script>
   `);
@@ -27,7 +26,6 @@ export default async function () {
     <script src="runtime.js" defer></script>
     <script src="polyfills-es5.js" nomodule defer></script>
     <script src="polyfills.js" defer></script>
-    <script src="styles.js" defer></script>
     <script src="vendor.js" defer></script>
     <script src="main.js" defer></script>
   `);


### PR DESCRIPTION


**feat(@schematics/angular): add migration to replace deprecated options**

**refactor(@angular-devkit/build-angular): remove deprecated `scripts[].lazy` and `styles[].lazy`**

BREAKING CHANGE:

- Deprecated `scripts[].lazy` has been renamed with `scripts[].inject`
- Deprecated `styles[].lazy` has been renamed with `styles[].inject`

Note: this change only effects direct `@angular-devkit/build-angular` users and not application developers. Users will be migrated automatically off these options.


**refactor(@schematics/angular): remove deprecated `tsconfigFileName` option from universal schematic**

**refactor(@angular-devkit/build-angular): deprecate `extractCss` browser builder option**

BREAKING CHANGE:

Browser builder `extractCss` option default value has been changed from `false` to `true`. This is to reflect the default behaviour when this deprecated option is removed.