### PR TITLE
fix(@angular-devkit/build-angular): ensure ivy extraction file names match sourcemaps

### DIFF
--- a/tests/legacy-cli/e2e/tests/i18n/extract-ivy.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/extract-ivy.ts
@@ -45,6 +45,12 @@ export default async function() {
     throw new Error('Expected ivy enabled application warning');
   }
 
+  // Should not show any warnings when extracting
+  const { stderr: message5 } = await ng('xi18n', '--ivy');
+  if (message5.includes('WARNING')) {
+    throw new Error('Expected no warnings to be shown');
+  }
+
   // Disable Ivy
   await updateJsonFile('tsconfig.json', config => {
     const { angularCompilerOptions = {} } = config;


### PR DESCRIPTION
Not doing so results in a circular sourcemap warning when attempting extraction.