### PR TITLE
fix(@angular-devkit/build-angular): correct Windows paths in ivy i18n extract

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -313,7 +313,7 @@ jobs:
       - custom_attach_workspace
       - setup_windows
       # Run partial e2e suite on PRs only. Master will run the full e2e suite with sharding.
-      - run: if (Test-Path env:CIRCLE_PR_NUMBER) { node tests\legacy-cli\run_e2e.js "--glob=tests/{basic,ivy}/**" }
+      - run: if (Test-Path env:CIRCLE_PR_NUMBER) { node tests\legacy-cli\run_e2e.js "--glob={tests/basic/**,tests/i18n/extract-ivy.ts}" }
              
   e2e-cli-win:
     executor: windows-executor

--- a/packages/angular_devkit/build_angular/src/extract-i18n/ivy-extract-loader.ts
+++ b/packages/angular_devkit/build_angular/src/extract-i18n/ivy-extract-loader.ts
@@ -47,7 +47,7 @@ export default function localizeExtractLoader(
   let filename = loaderContext.resourcePath;
   if (map?.file) {
     // The extractor's internal sourcemap handling expects the filenames to match
-    filename = nodePath.posix.join(loaderContext.context, map.file);
+    filename = nodePath.join(loaderContext.context, map.file);
   }
 
   // Setup a virtual file system instance for the extractor
@@ -64,13 +64,13 @@ export default function localizeExtractLoader(
       }
     },
     resolve(...paths: string[]): string {
-      return nodePath.posix.resolve(...paths);
+      return nodePath.resolve(...paths);
     },
     exists(path: string): boolean {
       return path === filename || path === filename + '.map';
     },
     dirname(path: string): string {
-      return nodePath.posix.dirname(path);
+      return nodePath.dirname(path);
     },
   };
 


### PR DESCRIPTION
POSIX path handling was errantly being used to resolve paths which does not handle Windows drive letters.