### PR TITLE
fix(@angular-devkit/core): allow property remove with workspace API

### DIFF
--- a/packages/angular_devkit/core/src/workspace/json/test/cases/ObjectRemove.json
+++ b/packages/angular_devkit/core/src/workspace/json/test/cases/ObjectRemove.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  // Comment
+  "schematics": {
+    "@angular/schematics:component": {
+      "prefix": "abc"
+    }
+  },
+  "x-foo": {
+    "is": ["good", "great", "awesome"]
+  },
+  "x-bar": 5,
+}

--- a/packages/angular_devkit/core/src/workspace/json/test/cases/ObjectRemoveMultiple.json
+++ b/packages/angular_devkit/core/src/workspace/json/test/cases/ObjectRemoveMultiple.json
@@ -1,0 +1,8 @@
+{
+  "version": 1,
+  // Comment
+  "x-foo": {
+    "is": ["good", "great", "awesome"]
+  },
+  "x-bar": 5,
+}

--- a/packages/angular_devkit/core/src/workspace/json/writer_spec.ts
+++ b/packages/angular_devkit/core/src/workspace/json/writer_spec.ts
@@ -592,4 +592,35 @@ describe('writeJsonWorkpaceFile', () => {
 
     await writeJsonWorkspace(workspace, host, 'ObjectReplace3');
   });
+
+  it('removes a property when property value is set to undefined', async () => {
+    const host = createTestCaseHost(basicFile);
+
+    const workspace = await readJsonWorkspace('', host);
+
+    workspace.extensions['x-baz'] = undefined;
+
+    await writeJsonWorkspace(workspace, host, 'ObjectRemove');
+  });
+
+  it('removes a property when using delete operator', async () => {
+    const host = createTestCaseHost(basicFile);
+
+    const workspace = await readJsonWorkspace('', host);
+
+    delete workspace.extensions['x-baz'];
+
+    await writeJsonWorkspace(workspace, host, 'ObjectRemove');
+  });
+
+  it('removes multiple properties when using delete operator', async () => {
+    const host = createTestCaseHost(basicFile);
+
+    const workspace = await readJsonWorkspace('', host);
+
+    delete workspace.extensions['x-baz'];
+    delete workspace.extensions.schematics;
+
+    await writeJsonWorkspace(workspace, host, 'ObjectRemoveMultiple');
+  });
 });


### PR DESCRIPTION
Removal changes were previously being improperly recorded with the wrong parent.  A property can now be directly removed by setting the value to undefined or by using the delete operator.