### PR TITLE
refactor(@schematics/angular): change the order of node types in package.json template

### DIFF
--- a/packages/schematics/angular/workspace/files/package.json.template
+++ b/packages/schematics/angular/workspace/files/package.json.template
@@ -24,10 +24,10 @@
   },
   "devDependencies": {
     "@angular/cli": "<%= '~' + version %>",
-    "@angular/compiler-cli": "<%= latestVersions.Angular %>",
-    "@types/node": "^12.11.1",<% if (!minimal) { %>
+    "@angular/compiler-cli": "<%= latestVersions.Angular %>",<% if (!minimal) { %>
     "@types/jasmine": "~3.5.0",
-    "@types/jasminewd2": "~2.0.3",
+    "@types/jasminewd2": "~2.0.3",<% } %>
+    "@types/node": "^12.11.1",<% if (!minimal) { %>
     "codelyzer": "^6.0.0",
     "jasmine-core": "~3.6.0",
     "jasmine-spec-reporter": "~5.0.0",


### PR DESCRIPTION
Re-arrange the node types npm package so that `devDependencies` are sorted in  alphabetical order