### PR TITLE
fix(@angular-devkit/build-angular): correct i18n function parameter type

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/process-bundle.ts
+++ b/packages/angular_devkit/build_angular/src/utils/process-bundle.ts
@@ -884,7 +884,7 @@ function findLocalizePositions(
 let localizeOld: boolean | undefined;
 
 function unwrapTemplateLiteral(
-  path: NodePath<types.TemplateLiteral>,
+  path: NodePath<types.TaggedTemplateExpression>,
   utils: LocalizeUtilities,
 ): [TemplateStringsArray, types.Expression[]] {
   if (localizeOld === undefined) {


### PR DESCRIPTION
The type of the first parameter of the internal unwrapTemplateLiteral function should be a `NodePath<types.TaggedTemplateExpression>` not a `NodePath<types.TemplateLiteral>`.