### PR TITLE
refactor(@angular/cli): remove node module directory assumption during initialization

### DIFF
--- a/packages/angular/cli/lib/cli/index.ts
+++ b/packages/angular/cli/lib/cli/index.ts
@@ -19,6 +19,21 @@ const isDebug =
   debugEnv !== '0' &&
   debugEnv.toLowerCase() !== 'false';
 
+// Same structure as used in framework packages
+export class Version {
+  public readonly major: string;
+  public readonly minor: string;
+  public readonly patch: string;
+
+  constructor(public readonly full: string) {
+    this.major = full.split('.')[0];
+    this.minor = full.split('.')[1];
+    this.patch = full.split('.').slice(2).join('.');
+  }
+}
+
+export const VERSION = new Version(require('../../package.json').version);
+
 // tslint:disable: no-console
 export default async function(options: { testing?: boolean; cliArgs: string[] }) {
   // This node version check ensures that the requirements of the project instance of the CLI are met


### PR DESCRIPTION
This also does some minor code cleanup to the version mismatch check logic which contained the node modules directory reference.