### PR TITLE
refactor(@schematics/angular): Brackets formatting in angular.json

### DIFF
--- a/packages/schematics/angular/workspace/files/angular.json.template
+++ b/packages/schematics/angular/workspace/files/angular.json.template
@@ -5,5 +5,6 @@
     "packageManager": "<%= packageManager %>"
   },<% } %>
   "newProjectRoot": "<%= newProjectRoot %>",
-  "projects": {}
+  "projects": {
+  }
 }


### PR DESCRIPTION
Apply consistent formatting in closing brackets at the end of the `angular.json` file.

Currently, if you create a new Angular CLI project, the end of the `angular.json` looks like this:

![image](https://user-images.githubusercontent.com/7170892/92323219-99133480-f03f-11ea-9891-1e1585b903c1.png)

This PR adds a new line between the two brackets so that it can be easier to understand where each section of the JSON file ends.
