### PR TITLE
fix(@angular-devkit/build-optimizer): remove decorators calls when tslib helpers are inlined

### DIFF
--- a/packages/angular_devkit/build_optimizer/src/transforms/scrub-file.ts
+++ b/packages/angular_devkit/build_optimizer/src/transforms/scrub-file.ts
@@ -141,7 +141,7 @@ function isAngularCoreImport(node: ts.ImportDeclaration, isAngularCoreFile: bool
   }
 
   // Relative imports from a Angular core file are also core imports.
-  if (isAngularCoreFile && (importText.startsWith('./') || importText.startsWith('../'))) {
+  if (isAngularCoreFile && importText.startsWith('.')) {
     return true;
   }
 
@@ -571,11 +571,14 @@ function isTslibHelper(
     return false;
   }
 
-  for (const name of tslibImports) {
-    for (const dec of symbol.declarations) {
-      if (ts.isImportSpecifier(dec) && name.elements.includes(dec)) {
-        return true;
-      }
+  for (const dec of symbol.declarations) {
+    if (ts.isImportSpecifier(dec) && tslibImports.some(name => name.elements.includes(dec))) {
+      return true;
+    }
+
+    // Handle inline helpers `var __decorate = (this...`
+    if (ts.isVariableDeclaration(dec)) {
+      return true;
     }
   }
 

--- a/packages/angular_devkit/build_optimizer/src/transforms/scrub-file_spec.ts
+++ b/packages/angular_devkit/build_optimizer/src/transforms/scrub-file_spec.ts
@@ -118,6 +118,49 @@ describe('scrub-file', () => {
       expect(tags.oneLine`${transform(input)}`).toEqual(tags.oneLine`${output}`);
     });
 
+    it('removes Angular decorators calls when __decorate is inlined', () => {
+      const output = tags.stripIndent`
+        var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+          var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+          if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+          else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+          return c > 3 && r && Object.defineProperty(target, key, r), r;
+        };
+
+        import { Component, Injectable } from '@angular/core';
+        var Clazz = (function () {
+          function Clazz() { }
+          return Clazz;
+        }());
+      `;
+
+      const input = tags.stripIndent`
+        var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+          var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+          if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+          else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+          return c > 3 && r && Object.defineProperty(target, key, r), r;
+        };
+
+        import { Component, Injectable } from '@angular/core';
+        var Clazz = (function () {
+          function Clazz() { }
+          Clazz = __decorate([
+            Injectable(),
+            Component({
+              selector: 'app-root',
+              templateUrl: './app.component.html',
+              styleUrls: ['./app.component.css']
+            })
+          ], Clazz);
+          return Clazz;
+        }());
+      `;
+
+      expect(testScrubFile(input)).toBeTruthy();
+      expect(tags.oneLine`${transform(input)}`).toEqual(tags.oneLine`${output}`);
+    });
+
     it('removes constructor parameter metadata in __decorate', () => {
       const output = tags.stripIndent`
         import { __decorate, __metadata } from "tslib";


### PR DESCRIPTION

Closes #18682