### PR TITLE
ci: update safari to 14.0

### DIFF
--- a/tests/legacy-cli/e2e/assets/protractor-saucelabs.conf.js
+++ b/tests/legacy-cli/e2e/assets/protractor-saucelabs.conf.js
@@ -34,14 +34,14 @@ exports.config = {
     },
     {
       browserName: 'safari',
-      platform: 'macOS 10.13',
-      version: '12.1',
+      platform: 'macOS 10.15',
+      version: '13.1',
       tunnelIdentifier,
     },
     {
       browserName: 'safari',
       platform: 'macOS 10.15',
-      version: '13.1',
+      version: '14.0',
       tunnelIdentifier,
     },
     {


### PR DESCRIPTION
Based on https://angular.io/guide/browser-support Safari 12.1 is no longer supported. Also recently this version has been flaky.