### PR TITLE
test: support Webpack 5 in deployUrl E2E test

### DIFF
--- a/tests/legacy-cli/e2e/tests/build/deploy-url.ts
+++ b/tests/legacy-cli/e2e/tests/build/deploy-url.ts
@@ -1,12 +1,14 @@
 import { ng } from '../../utils/process';
 import { copyProjectAsset } from '../../utils/assets';
-import { expectFileToMatch, writeMultipleFiles } from '../../utils/fs';
+import { appendToFile, expectFileToMatch, writeMultipleFiles } from '../../utils/fs';
 
 export default function () {
   return Promise.resolve()
     .then(() => writeMultipleFiles({
       'src/styles.css': 'div { background: url("./assets/more.png"); }',
+      'src/lazy.ts': 'export const lazy = "lazy";',
     }))
+    .then(() => appendToFile('src/main.ts', 'import("./lazy");'))
     // use image with file size >10KB to prevent inlining
     .then(() => copyProjectAsset('images/spectrum.png', './src/assets/more.png'))
     .then(() => ng('build', '--deploy-url=deployUrl/', '--extract-css'))


### PR DESCRIPTION
The public path will not be stored in the Webpack runtime chunk in Webpack 5 unless the public path is used by the application.  A lazy import is added to the test to ensure that the public path is used.