### PR TITLE
fix(@schematics/angular): canLoad guard signature

### DIFF
--- a/packages/schematics/angular/guard/files/__name@dasherize__.guard.ts.template
+++ b/packages/schematics/angular/guard/files/__name@dasherize__.guard.ts.template
@@ -25,7 +25,7 @@ export class <%= classify(name) %>Guard implements <%= implementations %> {
   }
   <% } %><% if (implements.includes('CanLoad')) { %>canLoad(
     route: Route,
-    segments: UrlSegment[]): Observable<boolean> | Promise<boolean> | boolean {
+    segments: UrlSegment[]): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
     return true;
   }<% } %>
 }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix


## What is the current behavior?

using the guard schematic with the `--implements CanLoad` option, the signature of the canLoad generated method is missing `UrlTree`.

```
export class TestGuard implements CanLoad {
  canLoad(
    route: Route,
    segments: UrlSegment[]): Observable<boolean> | Promise<boolean> | boolean {
    return true;
  }
}
```

Issue Number: #18751


## What is the new behavior?

The schematic file has been updated to provide the following result : 

```
export class TestGuard implements CanLoad {
  canLoad(
    route: Route,
    segments: UrlSegment[]): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
    return true;
  }
```


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No