### PR TITLE
feat(@schematics/angular): add migration to add declaration maps to libraries

### DIFF
--- a/packages/schematics/angular/migrations/migration-collection.json
+++ b/packages/schematics/angular/migrations/migration-collection.json
@@ -114,6 +114,11 @@
       "version": "11.0.0-next.0",
       "factory": "./update-11/update-angular-config",
       "description": "Remove deprecated options from 'angular.json' that are no longer present in v11."
+    },
+    "add-declaration-map-compiler-option": {
+      "version": "11.0.0-next.2",
+      "factory": "./update-11/add-declaration-map-compiler-option",
+      "description": "Add 'declarationMap' compiler options for non production library builds."
     }
   }
 }

--- a/packages/schematics/angular/migrations/update-11/add-declaration-map-compiler-option.ts
+++ b/packages/schematics/angular/migrations/update-11/add-declaration-map-compiler-option.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { Rule, Tree } from '@angular-devkit/schematics';
+import { JSONFile } from '../../utility/json-file';
+import { getWorkspace } from '../../utility/workspace';
+import { Builders } from '../../utility/workspace-models';
+
+export default function (): Rule {
+  return async host => {
+    const workspace = await getWorkspace(host);
+
+    for (const [, project] of workspace.projects) {
+      for (const [, target] of project.targets) {
+        if (target.builder !== Builders.NgPackagr) {
+          continue;
+        }
+
+        if (!target.configurations) {
+          continue;
+        }
+
+        for (const options of Object.values(target.configurations)) {
+          addDeclarationMapValue(host, options?.tsConfig, false);
+        }
+
+        addDeclarationMapValue(host, target.options?.tsConfig, true);
+      }
+    }
+  };
+}
+
+function addDeclarationMapValue(host: Tree, tsConfigPath: unknown, value: boolean): void {
+  if (typeof tsConfigPath !== 'string') {
+    return;
+  }
+
+  const declarationMapPath = ['compilerOptions', 'declarationMap'];
+  const file = new JSONFile(host, tsConfigPath);
+  if (file.get(declarationMapPath) === undefined) {
+    file.modify(declarationMapPath, value);
+  }
+}

--- a/packages/schematics/angular/migrations/update-11/add-declaration-map-compiler-option_spec.ts
+++ b/packages/schematics/angular/migrations/update-11/add-declaration-map-compiler-option_spec.ts
@@ -1,0 +1,84 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { EmptyTree } from '@angular-devkit/schematics';
+import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';
+import { Builders, ProjectType, WorkspaceSchema } from '../../utility/workspace-models';
+
+function createWorkSpaceConfig(tree: UnitTestTree) {
+  const angularConfig: WorkspaceSchema = {
+    version: 1,
+    projects: {
+      lib: {
+        root: '/project/lib',
+        sourceRoot: '/project/lib/src',
+        projectType: ProjectType.Library,
+        prefix: 'lib',
+        architect: {
+          build: {
+            builder: Builders.NgPackagr,
+            options: {
+              tsConfig: 'projects/lib/tsconfig.lib.json',
+            },
+            configurations: {
+              production: {
+                tsConfig: 'projects/lib/tsconfig.lib.prod.json',
+              },
+            },
+            // tslint:disable-next-line: no-any
+          } as any,
+        },
+      },
+    },
+  };
+
+  tree.create('/angular.json', JSON.stringify(angularConfig, undefined, 2));
+}
+
+describe(`Migration to add 'declarationMap' compiler option`, () => {
+  const schematicName = 'add-declaration-map-compiler-option';
+
+  const schematicRunner = new SchematicTestRunner(
+    'migrations',
+    require.resolve('../migration-collection.json'),
+  );
+
+  let tree: UnitTestTree;
+  beforeEach(() => {
+    tree = new UnitTestTree(new EmptyTree());
+    createWorkSpaceConfig(tree);
+    const tsConfig = JSON.stringify({ compilerOptions: {} }, undefined, 2);
+    tree.create('/projects/lib/tsconfig.lib.json', tsConfig);
+    tree.create('/projects/lib/tsconfig.lib.prod.json', tsConfig);
+  });
+
+  it(`should be added with a value of 'false' in a prod tsconfig`, async () => {
+    const newTree = await schematicRunner.runSchematicAsync(schematicName, {}, tree).toPromise();
+    const { compilerOptions } = JSON.parse(newTree.readContent('/projects/lib/tsconfig.lib.prod.json'));
+    expect(compilerOptions.declarationMap).toBeFalse();
+  });
+
+  it(`should be added with a value of 'true' in a non prod tsconfig`, async () => {
+    const newTree = await schematicRunner.runSchematicAsync(schematicName, {}, tree).toPromise();
+    const { compilerOptions } = JSON.parse(newTree.readContent('/projects/lib/tsconfig.lib.json'));
+    expect(compilerOptions.declarationMap).toBeTrue();
+  });
+
+  it('should not be overriden when already set', async () => {
+    const tsConfigPath = '/projects/lib/tsconfig.lib.json';
+    tree.overwrite(tsConfigPath, JSON.stringify({
+      compilerOptions: {
+        declarationMap: false,
+      },
+    }, undefined, 2));
+
+    const newTree = await schematicRunner.runSchematicAsync(schematicName, {}, tree).toPromise();
+    const { compilerOptions } = JSON.parse(newTree.readContent(tsConfigPath));
+    expect(compilerOptions.declarationMap).toBeFalse();
+  });
+});


### PR DESCRIPTION

Since version 10.1 we added declaration maps for local library builds, to improve the DX. With this change we add it to existing project.

See: #17920