### PR TITLE
fix(@angular/cli): improve logs in ng update

### DIFF
--- a/packages/angular/cli/commands/update-impl.ts
+++ b/packages/angular/cli/commands/update-impl.ts
@@ -100,7 +100,7 @@ export class UpdateCommand extends Command<UpdateCommandSchema> {
           this.logger.error(`ERROR! ${eventPath} ${desc}.`);
           break;
         case 'update':
-          logs.push(`${colors.whiteBright('UPDATE')} ${eventPath} (${event.content.length} bytes)`);
+          logs.push(`${colors.cyan('UPDATE')} ${eventPath} (${event.content.length} bytes)`);
           files.add(eventPath);
           break;
         case 'create':

--- a/packages/angular/cli/commands/update-impl.ts
+++ b/packages/angular/cli/commands/update-impl.ts
@@ -123,7 +123,7 @@ export class UpdateCommand extends Command<UpdateCommandSchema> {
       if (event.kind == 'end' || event.kind == 'post-tasks-start') {
         if (!error) {
           // Output the logging queue, no error happened.
-          logs.forEach(log => this.logger.info(log));
+          logs.forEach(log => this.logger.info(`  ${log}`));
           logs = [];
         }
       }
@@ -231,7 +231,16 @@ export class UpdateCommand extends Command<UpdateCommandSchema> {
     commit = false,
   ): Promise<boolean> {
     for (const migration of migrations) {
-      this.logger.info(`${colors.symbols.pointer} ${migration.description.replace(/\. /g, '.\n  ')}`);
+      const [title, ...description] = migration.description.split('. ');
+
+      this.logger.info(
+        colors.cyan(colors.symbols.pointer) + ' ' +
+        colors.bold(title.endsWith('.') ? title : title + '.'),
+      );
+
+      if (description.length) {
+        this.logger.info('  ' + description.join('.\n  '));
+      }
 
       const result = await this.executeSchematic(migration.collection.name, migration.name);
       if (!result.success) {

--- a/packages/angular/cli/models/schematic-command.ts
+++ b/packages/angular/cli/models/schematic-command.ts
@@ -501,7 +501,7 @@ export abstract class SchematicCommand<
           break;
         case 'update':
           loggingQueue.push(tags.oneLine`
-            ${colors.white('UPDATE')} ${eventPath} (${event.content.length} bytes)
+            ${colors.cyan('UPDATE')} ${eventPath} (${event.content.length} bytes)
           `);
           break;
         case 'create':

--- a/packages/angular_devkit/schematics_cli/bin/schematics.ts
+++ b/packages/angular_devkit/schematics_cli/bin/schematics.ts
@@ -217,7 +217,7 @@ export async function main({
         break;
       case 'update':
         loggingQueue.push(tags.oneLine`
-        ${colors.white('UPDATE')} ${eventPath} (${event.content.length} bytes)
+        ${colors.cyan('UPDATE')} ${eventPath} (${event.content.length} bytes)
       `);
         break;
       case 'create':


### PR DESCRIPTION
When a large number of migration are executed, it's hard to differentiate between the title and description.

Before
<img src=https://user-images.githubusercontent.com/17563226/92917152-80838f80-f42e-11ea-899b-58d47d0eca04.png height="800px">

After
<img width="917" alt="Screenshot 2020-09-12 at 18 19 41" height="800px" src="https://user-images.githubusercontent.com/17563226/93000155-bf950c00-f526-11ea-9697-1d06385c1d81.png">


