### PR TITLE
refactor(@schematics/angular): remove lcov from coverage reporters

### DIFF
--- a/packages/schematics/angular/application/files/karma.conf.js.template
+++ b/packages/schematics/angular/application/files/karma.conf.js.template
@@ -20,7 +20,6 @@ module.exports = function (config) {
       subdir: '.',
       reporters: [
         {type: 'html'},
-        {type: 'lcov'},
         {type: 'text-summary'},
       ],
     },

--- a/packages/schematics/angular/library/files/karma.conf.js.template
+++ b/packages/schematics/angular/library/files/karma.conf.js.template
@@ -20,7 +20,6 @@ module.exports = function (config) {
       subdir: '.',
       reporters: [
         {type: 'html'},
-        {type: 'lcov'},
         {type: 'text-summary'},
       ],
     },


### PR DESCRIPTION
In many users will not use lcov reports, also  this reporter generates an HTML report, which we are already generating using the html reporter.\