### PR TITLE
Improve async handling in generated code

### DIFF
--- a/integration/angular_cli/e2e/src/app.e2e-spec.ts
+++ b/integration/angular_cli/e2e/src/app.e2e-spec.ts
@@ -8,9 +8,9 @@ describe('workspace-project App', () => {
     page = new AppPage();
   });
 
-  it('should display welcome message', () => {
-    page.navigateTo();
-    expect(page.getTitleText()).toEqual('integration-project app is running!');
+  it('should display welcome message', async () => {
+    await page.navigateTo();
+    await expect(await page.getTitleText()).toEqual('integration-project app is running!');
   });
 
   afterEach(async () => {

--- a/integration/angular_cli/e2e/src/app.po.ts
+++ b/integration/angular_cli/e2e/src/app.po.ts
@@ -1,11 +1,11 @@
 import { browser, by, element } from 'protractor';
 
 export class AppPage {
-  navigateTo(): Promise<unknown> {
+  async navigateTo(): Promise<unknown> {
     return browser.get(browser.baseUrl) as Promise<unknown>;
   }
 
-  getTitleText(): Promise<string> {
+  async getTitleText(): Promise<string> {
     return element(by.css('app-root .content span')).getText() as Promise<string>;
   }
 }

--- a/packages/angular_devkit/build_angular/test/hello-world-app/e2e/app.e2e-spec.ts
+++ b/packages/angular_devkit/build_angular/test/hello-world-app/e2e/app.e2e-spec.ts
@@ -14,8 +14,8 @@ describe('hello-world-app App', () => {
     page = new AppPage();
   });
 
-  it('should display welcome message', () => {
-    page.navigateTo();
-    expect(page.getTitleText()).toEqual('Welcome to app!');
+  it('should display welcome message', async () => {
+    await page.navigateTo();
+    await expect(await page.getTitleText()).toEqual('Welcome to app!');
   });
 });

--- a/packages/angular_devkit/build_angular/test/hello-world-app/e2e/app.po.ts
+++ b/packages/angular_devkit/build_angular/test/hello-world-app/e2e/app.po.ts
@@ -8,11 +8,11 @@
 import { browser, by, element } from 'protractor';
 
 export class AppPage {
-  navigateTo(): Promise<unknown> {
+  async navigateTo(): Promise<unknown> {
     return browser.get(browser.baseUrl) as Promise<unknown>;
   }
 
-  getTitleText(): Promise<string> {
+  async getTitleText(): Promise<string> {
     return element(by.css('app-root h1')).getText() as Promise<string>;
   }
 }

--- a/packages/schematics/angular/e2e/files/src/app.e2e-spec.ts.template
+++ b/packages/schematics/angular/e2e/files/src/app.e2e-spec.ts.template
@@ -8,9 +8,9 @@ describe('workspace-project App', () => {
     page = new AppPage();
   });
 
-  it('should display welcome message', () => {
-    page.navigateTo();
-    expect(page.getTitleText()).toEqual('<%= relatedAppName %> app is running!');
+  it('should display welcome message', async () => {
+    await page.navigateTo();
+    await expect(await page.getTitleText()).toEqual('<%= relatedAppName %> app is running!');
   });
 
   afterEach(async () => {

--- a/packages/schematics/angular/e2e/files/src/app.po.ts.template
+++ b/packages/schematics/angular/e2e/files/src/app.po.ts.template
@@ -1,11 +1,11 @@
 import { browser, by, element } from 'protractor';
 
 export class AppPage {
-  navigateTo(): Promise<unknown> {
+  async navigateTo(): Promise<unknown> {
     return browser.get(browser.baseUrl) as Promise<unknown>;
   }
 
-  getTitleText(): Promise<string> {
+  async getTitleText(): Promise<string> {
     return element(by.css('<%= rootSelector %> .content span')).getText() as Promise<string>;
   }
 }


### PR DESCRIPTION
This PR fixes two tslint errors in generated projects:

- Promise returning method should be async
- Avoid floating promises