### PR TITLE
test: support Webpack 5 in platform server E2E test

### DIFF
--- a/tests/legacy-cli/e2e/tests/build/platform-server.ts
+++ b/tests/legacy-cli/e2e/tests/build/platform-server.ts
@@ -84,7 +84,11 @@ export default async function () {
 
   await ng('run', 'test-project:server:production', '--optimization', 'false');
 
-  await expectFileToMatch('dist/test-project/server/main.js', veEnabled ? /exports.*AppServerModuleNgFactory/ : /exports.*AppServerModule/);
+  if (veEnabled) {
+    await expectFileToMatch('dist/test-project/server/main.js', /exports.*AppServerModuleNgFactory|"AppServerModuleNgFactory":/);
+  } else {
+    await expectFileToMatch('dist/test-project/server/main.js', /exports.*AppServerModule|"AppServerModule":/);
+  }
   await exec(normalize('node'), 'dist/test-project/server/main.js');
   await expectFileToMatch(
     'dist/test-project/server/index.html',


### PR DESCRIPTION
The platform server E2E test checks for a Webpack specific output to determine if the server module is present.  This output is different for Webpack 5.  This change tries to match either the Webpack 4 or Webpack 5 output.