### PR TITLE
fix(@angular-devkit/schematics): resolve external schematics from requesting collection

### DIFF
--- a/etc/api/angular_devkit/schematics/src/_golden-api.d.ts
+++ b/etc/api/angular_devkit/schematics/src/_golden-api.d.ts
@@ -197,7 +197,7 @@ export declare class EmptyTree extends HostTree {
 export interface Engine<CollectionMetadataT extends object, SchematicMetadataT extends object> {
     readonly defaultMergeStrategy: MergeStrategy;
     readonly workflow: Workflow | null;
-    createCollection(name: string): Collection<CollectionMetadataT, SchematicMetadataT>;
+    createCollection(name: string, requester?: Collection<CollectionMetadataT, SchematicMetadataT>): Collection<CollectionMetadataT, SchematicMetadataT>;
     createContext(schematic: Schematic<CollectionMetadataT, SchematicMetadataT>, parent?: Partial<TypedSchematicContext<CollectionMetadataT, SchematicMetadataT>>, executionOptions?: Partial<ExecutionOptions>): TypedSchematicContext<CollectionMetadataT, SchematicMetadataT>;
     createSchematic(name: string, collection: Collection<CollectionMetadataT, SchematicMetadataT>): Schematic<CollectionMetadataT, SchematicMetadataT>;
     createSourceFromUrl(url: Url, context: TypedSchematicContext<CollectionMetadataT, SchematicMetadataT>): Source;
@@ -207,7 +207,7 @@ export interface Engine<CollectionMetadataT extends object, SchematicMetadataT e
 
 export interface EngineHost<CollectionMetadataT extends object, SchematicMetadataT extends object> {
     readonly defaultMergeStrategy?: MergeStrategy;
-    createCollectionDescription(name: string): CollectionDescription<CollectionMetadataT>;
+    createCollectionDescription(name: string, requester?: CollectionDescription<CollectionMetadataT>): CollectionDescription<CollectionMetadataT>;
     createSchematicDescription(name: string, collection: CollectionDescription<CollectionMetadataT>): SchematicDescription<CollectionMetadataT, SchematicMetadataT> | null;
     createSourceFromUrl(url: Url, context: TypedSchematicContext<CollectionMetadataT, SchematicMetadataT>): Source | null;
     createTaskExecutor(name: string): Observable<TaskExecutor>;
@@ -445,7 +445,7 @@ export declare class SchematicEngine<CollectionT extends object, SchematicT exte
     get defaultMergeStrategy(): MergeStrategy;
     get workflow(): Workflow | null;
     constructor(_host: EngineHost<CollectionT, SchematicT>, _workflow?: Workflow | undefined);
-    createCollection(name: string): Collection<CollectionT, SchematicT>;
+    createCollection(name: string, requester?: Collection<CollectionT, SchematicT>): Collection<CollectionT, SchematicT>;
     createContext(schematic: Schematic<CollectionT, SchematicT>, parent?: Partial<TypedSchematicContext<CollectionT, SchematicT>>, executionOptions?: Partial<ExecutionOptions>): TypedSchematicContext<CollectionT, SchematicT>;
     createSchematic(name: string, collection: Collection<CollectionT, SchematicT>, allowPrivate?: boolean): Schematic<CollectionT, SchematicT>;
     createSourceFromUrl(url: Url, context: TypedSchematicContext<CollectionT, SchematicT>): Source;

--- a/etc/api/angular_devkit/schematics/tools/index.d.ts
+++ b/etc/api/angular_devkit/schematics/tools/index.d.ts
@@ -53,14 +53,14 @@ export declare class FileSystemEngineHost extends FileSystemEngineHostBase {
 }
 
 export declare abstract class FileSystemEngineHostBase implements FileSystemEngineHost {
-    protected abstract _resolveCollectionPath(name: string): string;
+    protected abstract _resolveCollectionPath(name: string, requester?: string): string;
     protected abstract _resolveReferenceString(name: string, parentPath: string): {
         ref: RuleFactory<{}>;
         path: string;
     } | null;
     protected abstract _transformCollectionDescription(name: string, desc: Partial<FileSystemCollectionDesc>): FileSystemCollectionDesc;
     protected abstract _transformSchematicDescription(name: string, collection: FileSystemCollectionDesc, desc: Partial<FileSystemSchematicDesc>): FileSystemSchematicDesc;
-    createCollectionDescription(name: string): FileSystemCollectionDesc;
+    createCollectionDescription(name: string, requester?: FileSystemCollectionDesc): FileSystemCollectionDesc;
     createSchematicDescription(name: string, collection: FileSystemCollectionDesc): FileSystemSchematicDesc | null;
     createSourceFromUrl(url: Url): Source | null;
     createTaskExecutor(name: string): Observable<TaskExecutor>;
@@ -102,7 +102,7 @@ export declare class InvalidCollectionJsonException extends BaseException {
 
 export declare class NodeModulesEngineHost extends FileSystemEngineHostBase {
     constructor(paths?: string[] | undefined);
-    protected _resolveCollectionPath(name: string): string;
+    protected _resolveCollectionPath(name: string, requester?: string): string;
     protected _resolveReferenceString(refString: string, parentPath: string): {
         ref: RuleFactory<{}>;
         path: string;
@@ -113,7 +113,7 @@ export declare class NodeModulesEngineHost extends FileSystemEngineHostBase {
 
 export declare class NodeModulesTestEngineHost extends NodeModulesEngineHost {
     get tasks(): TaskConfiguration<{}>[];
-    protected _resolveCollectionPath(name: string): string;
+    protected _resolveCollectionPath(name: string, requester?: string): string;
     clearTasks(): void;
     registerCollection(name: string, path: string): void;
     transformContext(context: FileSystemSchematicContext): FileSystemSchematicContext;

--- a/packages/angular_devkit/schematics/src/engine/interface.ts
+++ b/packages/angular_devkit/schematics/src/engine/interface.ts
@@ -76,7 +76,10 @@ export type SchematicDescription<CollectionMetadataT extends object,
  * parameters contain additional metadata that you want to store while remaining type-safe.
  */
 export interface EngineHost<CollectionMetadataT extends object, SchematicMetadataT extends object> {
-  createCollectionDescription(name: string): CollectionDescription<CollectionMetadataT>;
+  createCollectionDescription(
+    name: string,
+    requester?: CollectionDescription<CollectionMetadataT>,
+  ): CollectionDescription<CollectionMetadataT>;
   listSchematicNames(collection: CollectionDescription<CollectionMetadataT>): string[];
 
   createSchematicDescription(
@@ -116,24 +119,27 @@ export interface EngineHost<CollectionMetadataT extends object, SchematicMetadat
  * SchematicMetadataT is a type that contains additional typing for the Schematic Description.
  */
 export interface Engine<CollectionMetadataT extends object, SchematicMetadataT extends object> {
-  createCollection(name: string): Collection<CollectionMetadataT, SchematicMetadataT>;
+  createCollection(
+    name: string,
+    requester?: Collection<CollectionMetadataT, SchematicMetadataT>,
+  ): Collection<CollectionMetadataT, SchematicMetadataT>;
   createContext(
     schematic: Schematic<CollectionMetadataT, SchematicMetadataT>,
     parent?: Partial<TypedSchematicContext<CollectionMetadataT, SchematicMetadataT>>,
     executionOptions?: Partial<ExecutionOptions>,
   ): TypedSchematicContext<CollectionMetadataT, SchematicMetadataT>;
   createSchematic(
-      name: string,
-      collection: Collection<CollectionMetadataT, SchematicMetadataT>,
+    name: string,
+    collection: Collection<CollectionMetadataT, SchematicMetadataT>,
   ): Schematic<CollectionMetadataT, SchematicMetadataT>;
   createSourceFromUrl(
     url: Url,
     context: TypedSchematicContext<CollectionMetadataT, SchematicMetadataT>,
   ): Source;
   transformOptions<OptionT extends object, ResultT extends object>(
-      schematic: Schematic<CollectionMetadataT, SchematicMetadataT>,
-      options: OptionT,
-      context?: TypedSchematicContext<CollectionMetadataT, SchematicMetadataT>,
+    schematic: Schematic<CollectionMetadataT, SchematicMetadataT>,
+    options: OptionT,
+    context?: TypedSchematicContext<CollectionMetadataT, SchematicMetadataT>,
   ): Observable<ResultT>;
   executePostTasks(): Observable<void>;
 

--- a/packages/angular_devkit/schematics/src/rules/schematic.ts
+++ b/packages/angular_devkit/schematics/src/rules/schematic.ts
@@ -26,7 +26,7 @@ export function externalSchematic<OptionT extends object>(
   executionOptions?: Partial<ExecutionOptions>,
 ): Rule {
   return (input: Tree, context: SchematicContext) => {
-    const collection = context.engine.createCollection(collectionName);
+    const collection = context.engine.createCollection(collectionName, context.schematic.collection);
     const schematic = collection.createSchematic(schematicName);
 
     return schematic.call(options, observableOf(branch(input)), context, executionOptions);

--- a/packages/angular_devkit/schematics/tools/fallback-engine-host.ts
+++ b/packages/angular_devkit/schematics/tools/fallback-engine-host.ts
@@ -47,10 +47,10 @@ export class FallbackEngineHost implements EngineHost<{}, {}> {
     this._hosts.push(host);
   }
 
-  createCollectionDescription(name: string): CollectionDescription<FallbackCollectionDescription> {
+  createCollectionDescription(name: string, requester?: CollectionDescription<{}>): CollectionDescription<FallbackCollectionDescription> {
     for (const host of this._hosts) {
       try {
-        const description = host.createCollectionDescription(name);
+        const description = host.createCollectionDescription(name, requester);
 
         return { name, host, description };
       } catch (_) {

--- a/packages/angular_devkit/schematics/tools/file-system-engine-host-base.ts
+++ b/packages/angular_devkit/schematics/tools/file-system-engine-host-base.ts
@@ -109,7 +109,7 @@ export class SchematicNameCollisionException extends BaseException {
  * all other EngineHost provided by the tooling part of the Schematics library.
  */
 export abstract class FileSystemEngineHostBase implements FileSystemEngineHost {
-  protected abstract _resolveCollectionPath(name: string): string;
+  protected abstract _resolveCollectionPath(name: string, requester?: string): string;
   protected abstract _resolveReferenceString(
       name: string, parentPath: string): { ref: RuleFactory<{}>, path: string } | null;
   protected abstract _transformCollectionDescription(
@@ -158,8 +158,11 @@ export abstract class FileSystemEngineHostBase implements FileSystemEngineHost {
    * @param name
    * @return {{path: string}}
    */
-  createCollectionDescription(name: string): FileSystemCollectionDesc {
-    const path = this._resolveCollectionPath(name);
+  createCollectionDescription(
+    name: string,
+    requester?: FileSystemCollectionDesc,
+  ): FileSystemCollectionDesc {
+    const path = this._resolveCollectionPath(name, requester?.path);
     const jsonValue = readJsonFile(path);
     if (!jsonValue || typeof jsonValue != 'object' || Array.isArray(jsonValue)) {
       throw new InvalidCollectionJsonException(name, path);

--- a/packages/angular_devkit/schematics/tools/node-module-engine-host.ts
+++ b/packages/angular_devkit/schematics/tools/node-module-engine-host.ts
@@ -97,8 +97,8 @@ export class NodeModulesEngineHost extends FileSystemEngineHostBase {
     return collectionPath;
   }
 
-  protected _resolveCollectionPath(name: string): string {
-    const collectionPath = this.resolve(name);
+  protected _resolveCollectionPath(name: string, requester?: string): string {
+    const collectionPath = this.resolve(name, requester);
 
     try {
       readJsonFile(collectionPath);

--- a/packages/angular_devkit/schematics/tools/node-modules-test-engine-host.ts
+++ b/packages/angular_devkit/schematics/tools/node-modules-test-engine-host.ts
@@ -37,12 +37,12 @@ export class NodeModulesTestEngineHost extends NodeModulesEngineHost {
     return context;
   }
 
-  protected _resolveCollectionPath(name: string): string {
+  protected _resolveCollectionPath(name: string, requester?: string): string {
     const maybePath = this._collections.get(name);
     if (maybePath) {
       return maybePath;
     }
 
-    return super._resolveCollectionPath(name);
+    return super._resolveCollectionPath(name, requester);
   }
 }

--- a/tests/legacy-cli/e2e/assets/nested-schematic-dependency/collection.json
+++ b/tests/legacy-cli/e2e/assets/nested-schematic-dependency/collection.json
@@ -1,0 +1,8 @@
+{
+  "schematics": {
+    "nested": {
+      "factory": "./index.js",
+      "description": "Add empty file to your application."
+    }
+  }
+}

--- a/tests/legacy-cli/e2e/assets/nested-schematic-dependency/index.js
+++ b/tests/legacy-cli/e2e/assets/nested-schematic-dependency/index.js
@@ -1,0 +1,1 @@
+exports.default = (options) => tree => tree.create(options.name || 'empty-file', '');

--- a/tests/legacy-cli/e2e/assets/nested-schematic-dependency/package.json
+++ b/tests/legacy-cli/e2e/assets/nested-schematic-dependency/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "empty-app-nested",
+  "version": "0.0.1",
+  "schematics": "./collection.json"
+}

--- a/tests/legacy-cli/e2e/assets/nested-schematic-main/collection.json
+++ b/tests/legacy-cli/e2e/assets/nested-schematic-main/collection.json
@@ -1,0 +1,8 @@
+{
+  "schematics": {
+    "test": {
+      "factory": "./index.js",
+      "description": "call an external schematic from nested package collection."
+    }
+  }
+}

--- a/tests/legacy-cli/e2e/assets/nested-schematic-main/index.js
+++ b/tests/legacy-cli/e2e/assets/nested-schematic-main/index.js
@@ -1,0 +1,1 @@
+exports.default = (options) => require("@angular-devkit/schematics").externalSchematic('empty-app-nested', 'nested', {});

--- a/tests/legacy-cli/e2e/assets/nested-schematic-main/package.json
+++ b/tests/legacy-cli/e2e/assets/nested-schematic-main/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "nested-main",
+  "version": "0.0.1",
+  "schematics": "./collection.json"
+}

--- a/tests/legacy-cli/e2e/tests/misc/nested-schematic-packages.ts
+++ b/tests/legacy-cli/e2e/tests/misc/nested-schematic-packages.ts
@@ -1,0 +1,11 @@
+import { copyAssets } from '../../utils/assets';
+import { expectFileToExist } from '../../utils/fs';
+import { ng } from '../../utils/process';
+
+export default async function () {
+  await copyAssets('nested-schematic-main', 'nested');
+  await copyAssets('nested-schematic-dependency', 'nested/node_modules/empty-app-nested');
+
+  await ng('generate', './nested:test');
+  await expectFileToExist('empty-file');
+}

--- a/tests/legacy-cli/e2e/utils/assets.ts
+++ b/tests/legacy-cli/e2e/utils/assets.ts
@@ -1,7 +1,7 @@
 import { join } from 'path';
 import * as glob from 'glob';
 import { getGlobalVariable } from './env';
-import { relative } from 'path';
+import { relative, resolve } from 'path';
 import { copyFile, writeFile } from './fs';
 import { useBuiltPackages } from './project';
 import { silentNpm } from './process';
@@ -18,7 +18,7 @@ export function copyProjectAsset(assetName: string, to?: string) {
   return copyFile(sourcePath, targetPath);
 }
 
-export function copyAssets(assetName: string) {
+export function copyAssets(assetName: string, to?: string) {
   const seed = +Date.now();
   const tempRoot = join(getGlobalVariable('tmp-root'), 'assets', assetName + '-' + seed);
   const root = assetDir(assetName);
@@ -29,7 +29,10 @@ export function copyAssets(assetName: string) {
 
       return allFiles.reduce((promise, filePath) => {
         const relPath = relative(root, filePath);
-        const toPath = join(tempRoot, relPath);
+        const toPath =
+          to !== undefined
+            ? resolve(getGlobalVariable('tmp-root'), 'test-project', to, relPath)
+            : join(tempRoot, relPath);
 
         return promise.then(() => copyFile(filePath, toPath));
       }, Promise.resolve());


### PR DESCRIPTION
This change first attempts to resolve a schematic referenced via the external schematic rule from the requesting schematic collection.  This allows schematic packages that are direct dependencies of another schematic package to be used with the external schematic rule without manual package resolution code within the schematic.