### PR TITLE
Experimental Webpack 5 Support

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/webpack-diagnostics.ts
+++ b/packages/angular_devkit/build_angular/src/utils/webpack-diagnostics.ts
@@ -6,21 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import * as webpack from 'webpack';
+import { isWebpackFiveOrHigher } from './webpack-version';
 
 const WebpackError = require('webpack/lib/WebpackError');
-const isWebpackFiveOrHigher = (() => {
-  if (typeof webpack.version === 'string') {
-    const versionParts = webpack.version.split('.');
-    if (versionParts[0] && Number(versionParts[0]) >= 5) {
-      return true;
-    }
-  }
-
-  return false;
-})();
 
 export function addWarning(compilation: webpack.compilation.Compilation, message: string): void {
-  if (isWebpackFiveOrHigher) {
+  if (isWebpackFiveOrHigher()) {
     compilation.warnings.push(new WebpackError(message));
   } else {
     // Allows building with either Webpack 4 or 5+ types
@@ -30,7 +21,7 @@ export function addWarning(compilation: webpack.compilation.Compilation, message
 }
 
 export function addError(compilation: webpack.compilation.Compilation, message: string): void {
-  if (isWebpackFiveOrHigher) {
+  if (isWebpackFiveOrHigher()) {
     compilation.errors.push(new WebpackError(message));
   } else {
     // Allows building with either Webpack 4 or 5+ types

--- a/packages/angular_devkit/build_angular/src/utils/webpack-version.ts
+++ b/packages/angular_devkit/build_angular/src/utils/webpack-version.ts
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import * as webpack from 'webpack';
+
+let cachedIsWebpackFiveOrHigher: boolean | undefined;
+export function isWebpackFiveOrHigher(): boolean {
+  if (cachedIsWebpackFiveOrHigher === undefined) {
+    cachedIsWebpackFiveOrHigher = false;
+    if (typeof webpack.version === 'string') {
+      const versionParts = webpack.version.split('.');
+      if (versionParts[0] && Number(versionParts[0]) >= 5) {
+        cachedIsWebpackFiveOrHigher = true;
+      }
+    }
+  }
+
+  return cachedIsWebpackFiveOrHigher;
+}
+
+// tslint:disable-next-line: no-any
+export function withWebpackFourOrFive<T, R>(webpackFourValue: T, webpackFiveValue: R): any {
+  return isWebpackFiveOrHigher() ? webpackFiveValue : webpackFourValue;
+}

--- a/packages/angular_devkit/build_angular/src/webpack/configs/browser.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/browser.ts
@@ -7,7 +7,7 @@
  */
 import * as webpack from 'webpack';
 import { WebpackConfigOptions } from '../../utils/build-options';
-import { withWebpackFourOrFive } from '../../utils/webpack-version';
+import { isWebpackFiveOrHigher, withWebpackFourOrFive } from '../../utils/webpack-version';
 import { CommonJsUsageWarnPlugin } from '../plugins';
 import { getSourceMapDevTool } from '../utils/helpers';
 
@@ -38,7 +38,13 @@ export function getBrowserConfig(wco: WebpackConfigOptions): webpack.Configurati
     }));
   }
 
-  if (extractLicenses) {
+  // TODO_WEBPACK_5: Investigate build/serve issues with the `license-webpack-plugin` package
+  if (extractLicenses && isWebpackFiveOrHigher()) {
+    wco.logger.warn(
+      'WARNING: License extraction is currently disabled when using Webpack 5. ' +
+        'This is temporary and will be corrected in a future update.',
+    );
+  } else if (extractLicenses) {
     const LicenseWebpackPlugin = require('license-webpack-plugin').LicenseWebpackPlugin;
     extraPlugins.push(new LicenseWebpackPlugin({
       stats: {

--- a/packages/angular_devkit/build_angular/src/webpack/configs/browser.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/browser.ts
@@ -7,6 +7,7 @@
  */
 import * as webpack from 'webpack';
 import { WebpackConfigOptions } from '../../utils/build-options';
+import { withWebpackFourOrFive } from '../../utils/webpack-version';
 import { CommonJsUsageWarnPlugin } from '../plugins';
 import { getSourceMapDevTool } from '../utils/helpers';
 
@@ -71,6 +72,7 @@ export function getBrowserConfig(wco: WebpackConfigOptions): webpack.Configurati
     resolve: {
       mainFields: ['es2015', 'browser', 'module', 'main'],
     },
+    ...withWebpackFourOrFive({}, { target: ['web', 'es5'] }),
     output: {
       crossOriginLoading,
     },

--- a/packages/angular_devkit/build_angular/src/webpack/configs/server.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/server.ts
@@ -8,7 +8,13 @@
 import { isAbsolute } from 'path';
 import { Configuration, ContextReplacementPlugin } from 'webpack';
 import { WebpackConfigOptions } from '../../utils/build-options';
+import { isWebpackFiveOrHigher } from '../../utils/webpack-version';
 import { getSourceMapDevTool } from '../utils/helpers';
+
+type ExternalHookWebpack5 = (
+  data: { context: string; request: string },
+  callback: (err?: Error, result?: string) => void,
+) => void;
 
 /**
  * Returns a partial Webpack configuration specific to creating a bundle for node
@@ -29,7 +35,13 @@ export function getServerConfig(wco: WebpackConfigOptions): Configuration {
 
   const externals: Configuration['externals'] = [...externalDependencies];
   if (!bundleDependencies) {
-    externals.push(externalizePackages);
+    if (isWebpackFiveOrHigher()) {
+      const hook: ExternalHookWebpack5 = ({ context, request }, callback) =>
+        externalizePackages(request, context, callback);
+      externals.push(hook);
+    } else {
+      externals.push(externalizePackages as unknown as ExternalHookWebpack5);
+    }
   }
 
   const config: Configuration = {

--- a/packages/ngtools/webpack/src/virtual_file_system_decorator.ts
+++ b/packages/ngtools/webpack/src/virtual_file_system_decorator.ts
@@ -10,6 +10,7 @@ import { Stats } from 'fs';
 import { InputFileSystem } from 'webpack';
 import { WebpackCompilerHost } from './compiler_host';
 import { NodeWatchFileSystemInterface } from './webpack';
+import { isWebpackFiveOrHigher } from './webpack-version';
 
 export const NodeWatchFileSystem: NodeWatchFileSystemInterface = require(
   'webpack/lib/node/NodeWatchFileSystem');
@@ -112,106 +113,187 @@ export class VirtualWatchFileSystemDecorator extends NodeWatchFileSystem {
     super(_virtualInputFileSystem);
   }
 
-  watch = (
-    files: Iterable<string>,
-    dirs: Iterable<string>,
-    missing: Iterable<string>,
-    startTime: number,
-    options: {},
-    callback: Parameters<NodeWatchFileSystemInterface['watch']>[5],
-    callbackUndelayed: (filename: string, timestamp: number) => void,
-  ): ReturnType<NodeWatchFileSystemInterface['watch']> => {
-    const reverseReplacements = new Map<string, string>();
-    const reverseTimestamps = <T>(map: Map<string, T>) => {
-      for (const entry of Array.from(map.entries())) {
-        const original = reverseReplacements.get(entry[0]);
-        if (original) {
-          map.set(original, entry[1]);
-          map.delete(entry[0]);
+  mapReplacements(
+    original: Iterable<string>,
+    reverseReplacements: Map<string, string>,
+  ): Iterable<string> {
+    if (!this._replacements) {
+      return original;
+    }
+    const replacements = this._replacements;
+
+    return [...original].map(file => {
+      if (typeof replacements === 'function') {
+        const replacement = getSystemPath(replacements(normalize(file)));
+        if (replacement !== file) {
+          reverseReplacements.set(replacement, file);
         }
-      }
 
-      return map;
-    };
-
-    const newCallbackUndelayed = (filename: string, timestamp: number) => {
-      const original = reverseReplacements.get(filename);
-      if (original) {
-        this._virtualInputFileSystem.purge(original);
-        callbackUndelayed(original, timestamp);
+        return replacement;
       } else {
-        callbackUndelayed(filename, timestamp);
-      }
-    };
+        const replacement = replacements.get(normalize(file));
+        if (replacement) {
+          const fullReplacement = getSystemPath(replacement);
+          reverseReplacements.set(fullReplacement, file);
 
-    const newCallback: Parameters<NodeWatchFileSystemInterface['watch']>[5] = (
-      err: Error | null,
-      filesModified: string[],
-      contextModified: string[],
-      missingModified: string[],
-      fileTimestamps: Map<string, number>,
-      contextTimestamps: Map<string, number>,
-    ) => {
-      // Update fileTimestamps with timestamps from virtual files.
-      const virtualFilesStats = this._virtualInputFileSystem.getVirtualFilesPaths()
-        .map((fileName) => ({
-          path: fileName,
-          mtime: +this._virtualInputFileSystem.statSync(fileName).mtime,
-        }));
-      virtualFilesStats.forEach(stats => fileTimestamps.set(stats.path, +stats.mtime));
-      callback(
-        err,
-        filesModified.map(value => reverseReplacements.get(value) || value),
-        contextModified.map(value => reverseReplacements.get(value) || value),
-        missingModified.map(value => reverseReplacements.get(value) || value),
-        reverseTimestamps(fileTimestamps),
-        reverseTimestamps(contextTimestamps),
-      );
-    };
-
-    const mapReplacements = (original: Iterable<string>): Iterable<string> => {
-      if (!this._replacements) {
-        return original;
-      }
-      const replacements = this._replacements;
-
-      return [...original].map(file => {
-        if (typeof replacements === 'function') {
-          const replacement = getSystemPath(replacements(normalize(file)));
-          if (replacement !== file) {
-            reverseReplacements.set(replacement, file);
-          }
-
-          return replacement;
+          return fullReplacement;
         } else {
-          const replacement = replacements.get(normalize(file));
-          if (replacement) {
-            const fullReplacement = getSystemPath(replacement);
-            reverseReplacements.set(fullReplacement, file);
-
-            return fullReplacement;
-          } else {
-            return file;
-          }
+          return file;
         }
-      });
-    };
+      }
+    });
+  }
 
-    const watcher = super.watch(
-      mapReplacements(files),
-      mapReplacements(dirs),
-      mapReplacements(missing),
-      startTime,
-      options,
-      newCallback,
-      newCallbackUndelayed,
-    );
+  reverseTimestamps<T>(
+    map: Map<string, T>,
+    reverseReplacements: Map<string, string>,
+  ): Map<string, T> {
+    for (const entry of Array.from(map.entries())) {
+      const original = reverseReplacements.get(entry[0]);
+      if (original) {
+        map.set(original, entry[1]);
+        map.delete(entry[0]);
+      }
+    }
 
-    return {
-      close: () => watcher.close(),
-      pause: () => watcher.pause(),
-      getFileTimestamps: () => reverseTimestamps(watcher.getFileTimestamps()),
-      getContextTimestamps: () => reverseTimestamps(watcher.getContextTimestamps()),
+    return map;
+  }
+
+  createWebpack4Watch() {
+    return (
+      files: Iterable<string>,
+      dirs: Iterable<string>,
+      missing: Iterable<string>,
+      startTime: number,
+      options: {},
+      callback: Parameters<NodeWatchFileSystemInterface['watch']>[5],
+      callbackUndelayed: (filename: string, timestamp: number) => void,
+    ): ReturnType<NodeWatchFileSystemInterface['watch']> => {
+      const reverseReplacements = new Map<string, string>();
+
+      const newCallbackUndelayed = (filename: string, timestamp: number) => {
+        const original = reverseReplacements.get(filename);
+        if (original) {
+          this._virtualInputFileSystem.purge(original);
+          callbackUndelayed(original, timestamp);
+        } else {
+          callbackUndelayed(filename, timestamp);
+        }
+      };
+
+      const newCallback: Parameters<NodeWatchFileSystemInterface['watch']>[5] = (
+        err: Error | null,
+        filesModified: string[],
+        contextModified: string[],
+        missingModified: string[],
+        fileTimestamps: Map<string, number>,
+        contextTimestamps: Map<string, number>,
+      ) => {
+        // Update fileTimestamps with timestamps from virtual files.
+        const virtualFilesStats = this._virtualInputFileSystem.getVirtualFilesPaths()
+          .map((fileName) => ({
+            path: fileName,
+            mtime: +this._virtualInputFileSystem.statSync(fileName).mtime,
+          }));
+        virtualFilesStats.forEach(stats => fileTimestamps.set(stats.path, +stats.mtime));
+        callback(
+          err,
+          filesModified.map(value => reverseReplacements.get(value) || value),
+          contextModified.map(value => reverseReplacements.get(value) || value),
+          missingModified.map(value => reverseReplacements.get(value) || value),
+          this.reverseTimestamps(fileTimestamps, reverseReplacements),
+          this.reverseTimestamps(contextTimestamps, reverseReplacements),
+        );
+      };
+
+      const watcher = super.watch(
+        this.mapReplacements(files, reverseReplacements),
+        this.mapReplacements(dirs, reverseReplacements),
+        this.mapReplacements(missing, reverseReplacements),
+        startTime,
+        options,
+        newCallback,
+        newCallbackUndelayed,
+      );
+
+      return {
+        close: () => watcher.close(),
+        pause: () => watcher.pause(),
+        getFileTimestamps: () =>
+          this.reverseTimestamps(watcher.getFileTimestamps(), reverseReplacements),
+        getContextTimestamps: () =>
+          this.reverseTimestamps(watcher.getContextTimestamps(), reverseReplacements),
+      };
     };
   }
+
+  createWebpack5Watch() {
+    return (
+      files: Iterable<string>,
+      dirs: Iterable<string>,
+      missing: Iterable<string>,
+      startTime: number,
+      options: {},
+      callback: Parameters<NodeWatchFileSystemInterface['watch']>[5],
+      callbackUndelayed: (filename: string, timestamp: number) => void,
+    ): ReturnType<NodeWatchFileSystemInterface['watch']> => {
+      const reverseReplacements = new Map<string, string>();
+
+      const newCallbackUndelayed = (filename: string, timestamp: number) => {
+        const original = reverseReplacements.get(filename);
+        if (original) {
+          this._virtualInputFileSystem.purge(original);
+          callbackUndelayed(original, timestamp);
+        } else {
+          callbackUndelayed(filename, timestamp);
+        }
+      };
+
+      const newCallback = (
+        err: Error,
+        // tslint:disable-next-line: no-any
+        fileTimeInfoEntries: Map<string, any>,
+        // tslint:disable-next-line: no-any
+        contextTimeInfoEntries: Map<string, any>,
+        missing: Set<string>,
+        removals: Set<string>,
+      ) => {
+        // Update fileTimestamps with timestamps from virtual files.
+        const virtualFilesStats = this._virtualInputFileSystem.getVirtualFilesPaths()
+          .map((fileName) => ({
+            path: fileName,
+            mtime: +this._virtualInputFileSystem.statSync(fileName).mtime,
+          }));
+        virtualFilesStats.forEach(stats => fileTimeInfoEntries.set(stats.path, +stats.mtime));
+        callback(
+          err,
+          this.reverseTimestamps(fileTimeInfoEntries, reverseReplacements),
+          this.reverseTimestamps(contextTimeInfoEntries, reverseReplacements),
+          new Set([...missing].map(value => reverseReplacements.get(value) || value)),
+          new Set([...removals].map(value => reverseReplacements.get(value) || value)),
+        );
+      };
+
+      const watcher = super.watch(
+        this.mapReplacements(files, reverseReplacements),
+        this.mapReplacements(dirs, reverseReplacements),
+        this.mapReplacements(missing, reverseReplacements),
+        startTime,
+        options,
+        newCallback,
+        newCallbackUndelayed,
+      );
+
+      return {
+        close: () => watcher.close(),
+        pause: () => watcher.pause(),
+        getFileTimeInfoEntries: () =>
+          this.reverseTimestamps(watcher.getFileTimeInfoEntries(), reverseReplacements),
+        getContextTimeInfoEntries: () =>
+          this.reverseTimestamps(watcher.getContextTimeInfoEntries(), reverseReplacements),
+      };
+    };
+  }
+
+  watch = isWebpackFiveOrHigher() ? this.createWebpack5Watch : this.createWebpack4Watch();
 }

--- a/tests/legacy-cli/e2e/tests/misc/webpack-5.ts
+++ b/tests/legacy-cli/e2e/tests/misc/webpack-5.ts
@@ -1,0 +1,33 @@
+import { rimraf } from '../../utils/fs';
+import { killAllProcesses, ng, silentYarn } from '../../utils/process';
+import { ngServe, updateJsonFile } from '../../utils/project';
+
+export default async function() {
+  // Setup project for yarn usage
+  await rimraf('node_modules');
+  await updateJsonFile('package.json', (json) => {
+    json.resolutions = { webpack: '5.0.0-beta.30' };
+  });
+  await silentYarn();
+  await silentYarn('webdriver-update');
+
+  // Ensure webpack 5 is used
+  const { stdout } = await silentYarn('list', '--pattern', 'webpack');
+  if (!/\swebpack@5/.test(stdout)) {
+    throw new Error('Expected Webpack 5 to be installed.');
+  }
+  if (/\swebpack@4/.test(stdout)) {
+    throw new Error('Expected Webpack 4 to not be installed.');
+  }
+
+  // Execute the CLI with Webpack 5
+  await ng('test', '--watch=false');
+  await ng('build');
+  await ng('build', '--prod');
+  await ng('e2e');
+  try {
+    await ngServe();
+  } finally {
+    killAllProcesses();
+  }
+}


### PR DESCRIPTION
This change enables experimental support for Webpack v5 in the Angular CLI. At this point, we don't recommend using Webpack v5 for production usage.

By default, the Angular CLI uses Webpack v4. To enable Webpack v5, use `yarn` as your package manager and add the following top-level property to `package.json`:
```
  "resolutions": {
    "webpack": "^5.0.0-beta.30"
  }
```

Please note that the support is experimental, and webpack v5 is still in beta. Some Angular CLI features and options are partially supported, and new prereleases of webpack v5 may contain breaking changes. You may temporarily see Webpack deprecation warnings, which we'll fix over time.