### PR TITLE
Replace regex with correct project name valdiation

### DIFF
--- a/packages/angular/cli/lib/config/schema.json
+++ b/packages/angular/cli/lib/config/schema.json
@@ -27,7 +27,7 @@
     "projects": {
       "type": "object",
       "patternProperties": {
-        "^(?:@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$": {
+        "^(?:@[a-zA-Z0-9_-]+\/)?[a-zA-Z0-9_-]+$": {
           "$ref": "#/definitions/project"
         }
       },

--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -300,7 +300,7 @@ export default function (options: ApplicationOptions): Rule {
     const isRootApp = options.projectRoot !== undefined;
     const appDir = isRootApp
       ? normalize(options.projectRoot || '')
-      : join(normalize(newProjectRoot), options.name);
+      : join(normalize(newProjectRoot), strings.dasherize(options.name));
     const sourceDir = `${appDir}/src/app`;
 
     const e2eOptions: E2eOptions = {

--- a/packages/schematics/angular/application/index_spec.ts
+++ b/packages/schematics/angular/application/index_spec.ts
@@ -451,4 +451,20 @@ describe('Application Schematic', () => {
     expect(content).toContain('not IE 11');
     expect(content).toContain('not IE 9-10');
   });
+
+  it(`should create kebab-case project folder names with camelCase project name`, async () => {
+    const options: ApplicationOptions = { ...defaultOptions, name: 'myCool' };
+    const tree = await schematicRunner.runSchematicAsync('application', options, workspaceTree)
+      .toPromise();
+    const exists = tree.exists('/projects/my-cool/.browserslistrc');
+    expect(exists).toBeTrue();
+  });
+
+  it(`should create kebab-case project folder names with PascalCase project name`, async () => {
+    const options: ApplicationOptions = { ...defaultOptions, name: 'MyCool' };
+    const tree = await schematicRunner.runSchematicAsync('application', options, workspaceTree)
+      .toPromise();
+    const exists = tree.exists('/projects/my-cool/.browserslistrc');
+    expect(exists).toBeTrue();
+  });
 });


### PR DESCRIPTION
If I understand the comments of @alan-agius4 on #17579 correct this PR will fix the IDE validation error that it is providing today.
I've replaced the regex with the correct one, just to make sure we are not forgetting when closing the ticket there is a second comment by @alan-agius4:

>When it comes to project directories, I am inclined towards always dasherizing the project folder name to align with other schematics where the folder name is always dasherized, that being said It's not a biggy, as long as the schema validation is fixed.

Should we make a separate issue for this or are we leaving this as is?

Let me know if I need to make changes or add additional information.

Closes #17579 