### PR TITLE
refactor(@angular/cli): remove outdated 1.x karma plugin error placeholder

### DIFF
--- a/packages/angular/cli/plugins/karma.js
+++ b/packages/angular/cli/plugins/karma.js
@@ -1,4 +1,0 @@
-throw new Error(
-  'In Angular CLI >6.0 the Karma plugin is now exported by "@angular-devkit/build-angular" instead.\n'
-  + 'Please replace "@angular/cli" with "@angular-devkit/build-angular" in your "karma.conf.js" file.'
-);


### PR DESCRIPTION
For Angular 6, an error inducing file was introduced in the 1.x location of the karma plugin for the Angular CLI.  This was useful during the 1.x -> 6 transition to assist users to migrate with a helpful error message.  Now that 1.x and 6 are no longer supported, this can be removed.