### PR TITLE
fix(@schematics/angular): remove IE9/10 from browserslist for new projects

### DIFF
--- a/packages/angular_devkit/build_angular/src/browser/index.ts
+++ b/packages/angular_devkit/build_angular/src/browser/index.ts
@@ -256,6 +256,19 @@ export function buildWebpackBrowser(
         `);
         }
 
+        const hasIE9 = buildBrowserFeatures.supportedBrowsers.includes('ie 9');
+        const hasIE10 = buildBrowserFeatures.supportedBrowsers.includes('ie 10');
+        if (hasIE9 || hasIE10) {
+          const browsers =
+            (hasIE9 ? 'IE 9' + (hasIE10 ? ' & ' : '') : '') + (hasIE10 ? 'IE 10' : '');
+          context.logger.warn(
+            `WARNING: Support was requested for ${browsers} in the project's browserslist configuration. ` +
+              (hasIE9 && hasIE10 ? 'These browsers are' : 'This browser is') +
+              ' no longer officially supported with Angular v11 and higher.' +
+              '\nFor additional information: https://v10.angular.io/guide/deprecations#ie-9-10-and-mobile',
+          );
+        }
+
         return {
           ...(await initialize(options, context, host, differentialLoadingMode, transforms.webpackConfiguration)),
           buildBrowserFeatures,

--- a/packages/angular_devkit/build_angular/src/browser/specs/browser-support_spec.ts
+++ b/packages/angular_devkit/build_angular/src/browser/specs/browser-support_spec.ts
@@ -1,0 +1,84 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { Architect } from '@angular-devkit/architect';
+import { logging } from '@angular-devkit/core';
+import { createArchitect, host } from '../../test-utils';
+
+describe('Browser Builder browser support', () => {
+  const targetSpec = { project: 'app', target: 'build' };
+  let architect: Architect;
+
+  beforeEach(async () => {
+    await host.initialize().toPromise();
+    architect = (await createArchitect(host.root())).architect;
+
+    // target ES5 to disable differential loading which is not needed for the tests
+    host.replaceInFile('tsconfig.json', '"target": "es2015"', '"target": "es5"');
+  });
+  afterEach(async () => host.restore().toPromise());
+
+  it('warns when IE9 is present in browserslist', async () => {
+    host.appendToFile('.browserslistrc', '\nIE 9');
+
+    const logger = new logging.Logger('');
+    const logs: string[] = [];
+    logger.subscribe((e) => logs.push(e.message));
+
+    const run = await architect.scheduleTarget(targetSpec, undefined, { logger });
+    const output = await run.result;
+    expect(output.success).toBe(true);
+
+    const fullLog = logs.join();
+    expect(fullLog).toContain(
+      "WARNING: Support was requested for IE 9 in the project's browserslist configuration.",
+    );
+    expect(fullLog).toContain('This browser is ');
+
+    await run.stop();
+  });
+
+  it('warns when IE10 is present in browserslist', async () => {
+    host.appendToFile('.browserslistrc', '\nIE 10');
+
+    const logger = new logging.Logger('');
+    const logs: string[] = [];
+    logger.subscribe((e) => logs.push(e.message));
+
+    const run = await architect.scheduleTarget(targetSpec, undefined, { logger });
+    const output = await run.result;
+    expect(output.success).toBe(true);
+
+    const fullLog = logs.join();
+    expect(fullLog).toContain(
+      "WARNING: Support was requested for IE 10 in the project's browserslist configuration.",
+    );
+    expect(fullLog).toContain('This browser is ');
+
+    await run.stop();
+  });
+
+  it('warns when both IE9 & IE10 are present in browserslist', async () => {
+    host.appendToFile('.browserslistrc', '\nIE 9-10');
+
+    const logger = new logging.Logger('');
+    const logs: string[] = [];
+    logger.subscribe((e) => logs.push(e.message));
+
+    const run = await architect.scheduleTarget(targetSpec, undefined, { logger });
+    const output = await run.result;
+    expect(output.success).toBe(true);
+
+    const fullLog = logs.join();
+    expect(fullLog).toContain(
+      "WARNING: Support was requested for IE 9 & IE 10 in the project's browserslist configuration.",
+    );
+    expect(fullLog).toContain('These browsers are ');
+
+    await run.stop();
+  });
+});

--- a/packages/schematics/angular/application/files/.browserslistrc.template
+++ b/packages/schematics/angular/application/files/.browserslistrc.template
@@ -14,7 +14,5 @@ last 2 Edge major versions
 last 2 Safari major versions
 last 2 iOS major versions
 Firefox ESR<% if (legacyBrowsers) { %>
-IE 9-10 # Angular support for IE 9-10 has been deprecated and will be removed as of Angular v11.
 IE 11<% } else { %>
-not IE 9-10 # Angular support for IE 9-10 has been deprecated and will be removed as of Angular v11. To opt-in, remove the 'not' prefix on this line.
 not IE 11 # Angular supports IE 11 only as an opt-in. To opt-in, remove the 'not' prefix on this line.<% } %>

--- a/packages/schematics/angular/application/index_spec.ts
+++ b/packages/schematics/angular/application/index_spec.ts
@@ -431,25 +431,21 @@ describe('Application Schematic', () => {
     });
   });
 
-  it(`should add support for IE 9-11 in '.browserslistrc' when 'legacyBrowsers' is true`, async () => {
+  it(`should add support for IE 11 in '.browserslistrc' when 'legacyBrowsers' is true`, async () => {
     const options: ApplicationOptions = { ...defaultOptions, legacyBrowsers: true };
     const tree = await schematicRunner.runSchematicAsync('application', options, workspaceTree)
       .toPromise();
     const content = tree.readContent('/projects/foo/.browserslistrc');
     expect(content).not.toContain('not IE 11');
     expect(content).toContain('IE 11');
-
-    expect(content).not.toContain('not IE 9-10');
-    expect(content).toContain('IE 9-10');
   });
 
-  it(`should not add support for IE 9-11 in '.browserslistrc' when 'legacyBrowsers' is false`, async () => {
+  it(`should not add support for IE 11 in '.browserslistrc' when 'legacyBrowsers' is false`, async () => {
     const options: ApplicationOptions = { ...defaultOptions, legacyBrowsers: false };
     const tree = await schematicRunner.runSchematicAsync('application', options, workspaceTree)
       .toPromise();
     const content = tree.readContent('/projects/foo/.browserslistrc');
     expect(content).toContain('not IE 11');
-    expect(content).toContain('not IE 9-10');
   });
 
   it(`should create kebab-case project folder names with camelCase project name`, async () => {

--- a/tests/legacy-cli/e2e/assets/protractor-saucelabs.conf.js
+++ b/tests/legacy-cli/e2e/assets/protractor-saucelabs.conf.js
@@ -46,12 +46,6 @@ exports.config = {
     },
     {
       browserName: 'internet explorer',
-      platform: 'Windows 8',
-      version: '10',
-      tunnelIdentifier,
-    },
-    {
-      browserName: 'internet explorer',
       platform: 'Windows 8.1',
       version: '11',
       tunnelIdentifier,


### PR DESCRIPTION
BREAKING CHANGE:
Deprecated support for IE 9-10 has been removed in Angular 11.
Only IE 9-10 support has been removed. IE 11 is officially supported in Angular 11.
Additional information can be found here: https://v10.angular.io/guide/deprecations#ie-9-10-and-mobile