### PR TITLE
fix(@angular/cli): favor dirname when resolving @schematics/angular

### DIFF
--- a/packages/angular/cli/models/schematic-command.ts
+++ b/packages/angular/cli/models/schematic-command.ts
@@ -256,7 +256,10 @@ export abstract class SchematicCommand<
       registry: new schema.CoreSchemaRegistry(formats.standardFormats),
       resolvePaths: !!this.workspace.configFile
         // Workspace
-        ? [process.cwd(), this.workspace.root, __dirname]
+        ? this.collectionName === this.defaultCollectionName
+          // Favor __dirname for @schematics/angular to use the build-in version
+          ? [__dirname, process.cwd(), this.workspace.root]
+          : [process.cwd(), this.workspace.root, __dirname]
         // Global
         : [__dirname, process.cwd()],
     });


### PR DESCRIPTION


This ensures that the correct build-in version of `@schematics/angular` is resolved.

Closes #18840