### PR TITLE
fix(@schematics/angular): remove solution style throw an error

### DIFF
--- a/packages/schematics/angular/migrations/update-10/remove-solution-style-tsconfig.ts
+++ b/packages/schematics/angular/migrations/update-10/remove-solution-style-tsconfig.ts
@@ -35,16 +35,23 @@ export default function (): Rule {
   return (host, context) => {
     const logger = context.logger;
 
-    const files = new JSONFile(host, 'tsconfig.json').get(['files']);
-    if (!(Array.isArray(files) && files.length === 0)) {
-      logger.info('Migration has already been executed.');
+    const tsConfigExists = host.exists('tsconfig.json');
+    if (tsConfigExists) {
+      const files = new JSONFile(host, 'tsconfig.json').get(['files']);
+      if (!(Array.isArray(files) && files.length === 0)) {
+        logger.info('Migration has already been executed.');
 
-      return;
+        return;
+      }
     }
 
     if (host.exists('tsconfig.base.json')) {
-      host.overwrite('tsconfig.json', host.read('tsconfig.base.json') || '');
-      host.delete('tsconfig.base.json');
+      if (tsConfigExists) {
+        host.overwrite('tsconfig.json', host.read('tsconfig.base.json') || '');
+        host.delete('tsconfig.base.json');
+      } else {
+        host.rename('tsconfig.base.json', 'tsconfig.json');
+      }
     }
 
     // Iterate over all tsconfig files and change the extends from 'tsconfig.base.json' to 'tsconfig.json'.

--- a/packages/schematics/angular/migrations/update-10/remove-solution-style-tsconfig_spec.ts
+++ b/packages/schematics/angular/migrations/update-10/remove-solution-style-tsconfig_spec.ts
@@ -114,4 +114,12 @@ describe('Migration to remove "Solution Style" tsconfig', () => {
     expect(readJsonFile(newTree, 'src/tsconfig.spec.json').extends).toEqual('./../tsconfig.json');
     expect(logs.join('\n')).toContain('Failed to parse "/src/invalid/error.json" as JSON AST Object. InvalidSymbol at location: 43.');
   });
+
+  it(`should not error when 'tsconfig.json' doesn't exist`, async () => {
+    tree.delete('tsconfig.json');
+    const newTree = await schematicRunner.runSchematicAsync(schematicName, {}, tree).toPromise();
+
+    expect(readJsonFile(newTree, 'tsconfig.json')['compilerOptions']).toBeTruthy();
+    expect(newTree.exists('tsconfig.base.json')).toBeFalse();
+  });
 });


### PR DESCRIPTION
`remove-solution-style-tsconfig` migration fails when upgrading from version 10.0.* to 10.1.* with the following error:
```bash
[error] Error: Could not read 'tsconfig.json'
```

There is no issue regarding this but you can see the following comments:
https://github.com/angular/angular-cli/issues/18744#issuecomment-689790320
https://github.com/angular/angular-cli/issues/18040#issuecomment-689833338

Btw, the files are not formatted correctly by the `prettier` configuration but I decided to leave these changes out of the scope of this PR.