### PR TITLE
test(@angular-devkit/build-angular): test Ivy specific files in unused file tests

### DIFF
--- a/packages/angular_devkit/build_angular/src/browser/specs/unused-files-warning_spec.ts
+++ b/packages/angular_devkit/build_angular/src/browser/specs/unused-files-warning_spec.ts
@@ -80,10 +80,6 @@ describe('Browser Builder unused files warnings', () => {
 
     const ignoredFiles = {
       'src/file.d.ts': 'export type MyType = number;',
-      'src/file.ngsummary.ts': 'export const hello = 42;',
-      'src/file.ngfactory.ts': 'export const hello = 42;',
-      'src/file.ngstyle.ts': 'export const hello = 42;',
-      'src/file.ng_typecheck__.ts': 'export const hello = 42;',
     };
 
     host.writeMultipleFiles(ignoredFiles);
@@ -94,11 +90,17 @@ describe('Browser Builder unused files warnings', () => {
       `"main.ts", ${Object.keys(ignoredFiles).map(f => `"${f.replace('src/', '')}"`).join(',')}`,
     );
 
+    host.replaceInFile(
+      'src/tsconfig.app.json',
+      '"compilerOptions":',
+      '"angularCompilerOptions": { "strictTemplates": true }, "compilerOptions":',
+    );
+
     const logger = new logging.Logger('');
     const logs: string[] = [];
     logger.subscribe(e => logs.push(e.message));
 
-    const run = await architect.scheduleTarget(targetSpec, undefined, { logger });
+    const run = await architect.scheduleTarget(targetSpec, { aot: true }, { logger });
     const output = await run.result as BrowserBuilderOutput;
     expect(output.success).toBe(true);
     expect(logs.join().includes(warningMessageSuffix)).toBe(false);


### PR DESCRIPTION
The test was previously run only in Ivy mode but with VE specific test case files.  The test now also enables strict templates to ensure template type checking files are properly excluded.