### PR TITLE
fix(@angular-devkit/build-angular): webpack5 deprecation of module property in Dependency

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/browser.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/browser.ts
@@ -111,7 +111,7 @@ export function getBrowserConfig(wco: WebpackConfigOptions): webpack.Configurati
     },
     plugins: [
       new CommonJsUsageWarnPlugin({
-        allowedDepedencies: allowedCommonJsDependencies,
+        allowedDependencies: allowedCommonJsDependencies,
       }),
       ...extraPlugins,
     ],


### PR DESCRIPTION
fixes 24 occurances of `Error: module property was removed from Dependency (use compilation.moduleGraph.getModule(dependency) instead)`
in:
```bash
yarn bazel test //packages/angular_devkit/build_angular:build_angular_browser_test
yarn bazel test //packages/angular_devkit/build_angular:build_angular_browser_ve_test
```

