### PR TITLE
fix(@angular/cli): no-op ng update --all

### DIFF
--- a/packages/angular/cli/commands/update.json
+++ b/packages/angular/cli/commands/update.json
@@ -35,7 +35,8 @@
         "all": {
           "description": "Whether to update all packages in package.json.",
           "default": false,
-          "type": "boolean"
+          "type": "boolean",
+          "x-deprecated": true
         },
         "next": {
           "description": "Use the prerelease version, including beta and RCs.",

--- a/packages/schematics/update/update/index.ts
+++ b/packages/schematics/update/update/index.ts
@@ -530,6 +530,11 @@ function _usageMessage(
     logger.info('  ' + fields.map((x, i) => x.padEnd(pads[i])).join(''));
   });
 
+  logger.info(
+    `There might be additional packages which don't provide 'ng update' capabilities that are outdated.\n`
+    + `You can update the addition packages by running the update command of your package manager.`,
+  );
+
   return;
 }
 

--- a/tests/legacy-cli/e2e/tests/misc/update-git-clean-subdirectory.ts
+++ b/tests/legacy-cli/e2e/tests/misc/update-git-clean-subdirectory.ts
@@ -18,7 +18,7 @@ export default async function() {
   await writeFile('../added.ts', 'console.log(\'created\');\n');
   await silentGit('add', '../added.ts');
 
-  const { stderr } = await ng('update', '--all', '--force');
+  const { stderr } = await ng('update', '@angular/cli');
   if (stderr && stderr.includes('Repository is not clean.')) {
     throw new Error('Expected clean repository');
   }

--- a/tests/legacy-cli/e2e/tests/misc/update-git-clean.ts
+++ b/tests/legacy-cli/e2e/tests/misc/update-git-clean.ts
@@ -5,7 +5,7 @@ import { expectToFail } from '../../utils/utils';
 export default async function() {
   await appendToFile('src/main.ts', 'console.log(\'changed\');\n');
 
-  const { message } = await expectToFail(() => ng('update', '--all'));
+  const { message } = await expectToFail(() => ng('update', '@angular/cli'));
   if (!message || !message.includes('Repository is not clean.')) {
     throw new Error('Expected unclean repository');
   }


### PR DESCRIPTION
`--all` functionality has been removed from `ng update` as updating multiple packages at once is not recommended. To update the depencencies in your workspace 'package.json' use the update command of your package manager.

Closes #15278
Closes #13095
Closes #12261
Closes #12243
Closes #18813