### PR TITLE
fix(@angular-devkit/build-angular): add karma as an optional peer dependency

### DIFF
--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -83,6 +83,7 @@
     "@angular/localize": "^11.0.0 || ^11.0.0-next",
     "karma": "^5.2.0",
     "ng-packagr": "^10.0.0",
+    "protractor": "^7.0.0",
     "typescript": ">=3.9 < 4.1"
   },
   "peerDependenciesMeta": {
@@ -93,6 +94,9 @@
       "optional": true
     },
     "ng-packagr": {
+      "optional": true
+    },
+    "protractor": {
       "optional": true
     }
   }

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -84,6 +84,7 @@
     "karma": "^5.2.0",
     "ng-packagr": "^10.0.0",
     "protractor": "^7.0.0",
+    "tslint": "^6.1.0",
     "typescript": ">=3.9 < 4.1"
   },
   "peerDependenciesMeta": {
@@ -97,6 +98,9 @@
       "optional": true
     },
     "protractor": {
+      "optional": true
+    },
+    "tslint": {
       "optional": true
     }
   }

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -81,11 +81,15 @@
   "peerDependencies": {
     "@angular/compiler-cli": "^11.0.0 || ^11.0.0-next",
     "@angular/localize": "^11.0.0 || ^11.0.0-next",
+    "karma": "^5.2.0",
     "ng-packagr": "^10.0.0",
     "typescript": ">=3.9 < 4.1"
   },
   "peerDependenciesMeta": {
     "@angular/localize": {
+      "optional": true
+    },
+    "karma": {
       "optional": true
     },
     "ng-packagr": {

--- a/packages/angular_devkit/build_angular/src/karma/index.ts
+++ b/packages/angular_devkit/build_angular/src/karma/index.ts
@@ -26,7 +26,6 @@ import { SingleTestTransformLoader } from '../webpack/plugins/single-test-transf
 import { findTests } from './find-tests';
 import { Schema as KarmaBuilderOptions } from './schema';
 
-// tslint:disable-next-line:no-implicit-dependencies
 export type KarmaConfigOptions = import('karma').ConfigOptions & {
   buildWebpack?: unknown;
   configFile?: string;
@@ -36,7 +35,6 @@ async function initialize(
   options: KarmaBuilderOptions,
   context: BuilderContext,
   webpackConfigurationTransformer?: ExecutionTransformer<webpack.Configuration>,
-  // tslint:disable-next-line:no-implicit-dependencies
 ): Promise<[typeof import('karma'), webpack.Configuration]> {
   const { config } = await generateBrowserWebpackConfigFromContext(
     // only two properties are missing:
@@ -53,7 +51,6 @@ async function initialize(
     ],
   );
 
-  // tslint:disable-next-line:no-implicit-dependencies
   const karma = await import('karma');
 
   return [

--- a/packages/angular_devkit/build_angular/src/tslint/index.ts
+++ b/packages/angular_devkit/build_angular/src/tslint/index.ts
@@ -11,7 +11,7 @@ import { readFileSync } from 'fs';
 import * as glob from 'glob';
 import { Minimatch } from 'minimatch';
 import * as path from 'path';
-import * as tslint from 'tslint'; // tslint:disable-line:no-implicit-dependencies
+import * as tslint from 'tslint';
 import { Program } from 'typescript';
 import { stripBom } from '../utils/strip-bom';
 import { Schema as RealTslintBuilderOptions } from './schema';
@@ -25,7 +25,7 @@ interface LintResult extends tslint.LintResult {
 async function _loadTslint() {
   let tslint;
   try {
-    tslint = await import('tslint'); // tslint:disable-line:no-implicit-dependencies
+    tslint = await import('tslint');
   } catch {
     throw new Error('Unable to find TSLint. Ensure TSLint is installed.');
   }

--- a/packages/angular_devkit/build_angular/src/utils/load-translations.ts
+++ b/packages/angular_devkit/build_angular/src/utils/load-translations.ts
@@ -11,11 +11,9 @@ import * as fs from 'fs';
 export type TranslationLoader = (
   path: string,
 ) => {
-  // tslint:disable-next-line: no-implicit-dependencies
   translations: Record<string, import('@angular/localize').ɵParsedTranslation>;
   format: string;
   locale?: string;
-  // tslint:disable-next-line: no-implicit-dependencies
   diagnostics: import('@angular/localize/src/tools/src/diagnostics').Diagnostics;
   integrity: string;
 };
@@ -63,26 +61,26 @@ export async function createTranslationLoader(): Promise<TranslationLoader> {
 
 async function importParsers() {
   try {
-    // tslint:disable-next-line: no-implicit-dependencies
+
     const localizeDiag = await import('@angular/localize/src/tools/src/diagnostics');
     const diagnostics = new localizeDiag.Diagnostics();
 
     const parsers = {
       json: new (await import(
-        // tslint:disable-next-line:trailing-comma no-implicit-dependencies
+        // tslint:disable-next-line:trailing-comma
         '@angular/localize/src/tools/src/translate/translation_files/translation_parsers/simple_json_translation_parser'
       )).SimpleJsonTranslationParser(),
       xlf: new (await import(
-        // tslint:disable-next-line:trailing-comma no-implicit-dependencies
+        // tslint:disable-next-line:trailing-comma
         '@angular/localize/src/tools/src/translate/translation_files/translation_parsers/xliff1_translation_parser'
       )).Xliff1TranslationParser(),
       xlf2: new (await import(
-        // tslint:disable-next-line:trailing-comma no-implicit-dependencies
+        // tslint:disable-next-line:trailing-comma
         '@angular/localize/src/tools/src/translate/translation_files/translation_parsers/xliff2_translation_parser'
       )).Xliff2TranslationParser(),
       // The name ('xmb') needs to match the AOT compiler option
       xmb: new (await import(
-        // tslint:disable-next-line:trailing-comma no-implicit-dependencies
+        // tslint:disable-next-line:trailing-comma
         '@angular/localize/src/tools/src/translate/translation_files/translation_parsers/xtb_translation_parser'
       )).XtbTranslationParser(),
     };

--- a/packages/angular_devkit/build_angular/src/utils/process-bundle.ts
+++ b/packages/angular_devkit/build_angular/src/utils/process-bundle.ts
@@ -560,7 +560,7 @@ export async function createI18nPlugins(
   const diagnostics = new localizeDiag.Diagnostics();
 
   const es2015 = await import(
-    // tslint:disable-next-line: trailing-comma no-implicit-dependencies
+    // tslint:disable-next-line: trailing-comma
     '@angular/localize/src/tools/src/translate/source_files/es2015_translate_plugin'
   );
   plugins.push(
@@ -571,7 +571,7 @@ export async function createI18nPlugins(
   );
 
   const es5 = await import(
-    // tslint:disable-next-line: trailing-comma no-implicit-dependencies
+    // tslint:disable-next-line: trailing-comma
     '@angular/localize/src/tools/src/translate/source_files/es5_translate_plugin'
   );
   plugins.push(
@@ -582,7 +582,7 @@ export async function createI18nPlugins(
   );
 
   const inlineLocale = await import(
-    // tslint:disable-next-line: trailing-comma no-implicit-dependencies
+    // tslint:disable-next-line: trailing-comma
     '@angular/localize/src/tools/src/translate/source_files/locale_plugin'
   );
   plugins.push(inlineLocale.makeLocalePlugin(locale));


### PR DESCRIPTION
karma is currently used by the karma builder within this package but is not represented in the dependencies.  The can lead to accidental version mismatches as well as package manager hoisting problems due to the package manager not knowing the full dependency set of the package.