### PR TITLE
refactor(@angular-devkit/build-angular): remove redundant tslint vers…

### DIFF
--- a/packages/angular_devkit/build_angular/src/tslint/index.ts
+++ b/packages/angular_devkit/build_angular/src/tslint/index.ts
@@ -30,15 +30,6 @@ async function _loadTslint() {
     throw new Error('Unable to find TSLint. Ensure TSLint is installed.');
   }
 
-  const version = tslint.Linter.VERSION && tslint.Linter.VERSION.split('.');
-  if (
-    !version || version.length < 2
-    || (Number(version[0]) === 5 && Number(version[1]) < 5) // 5.5+
-    || Number(version[0]) < 5 // 6.0+
-  ) {
-    throw new Error('TSLint must be version 5.5 or higher.');
-  }
-
   return tslint;
 }
 


### PR DESCRIPTION
…ion check

Tslint has been added as an optional peer dependency which makes this check unnecessary since the package manager will issue a warning when an incorrect version is installed.