### PR TITLE
fix(@angular-devkit/build-angular): fix webpack 5 deprecation warning for chunk.push

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/plugins/scripts-webpack-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/plugins/scripts-webpack-plugin.ts
@@ -12,6 +12,7 @@ import { Compiler, loader } from 'webpack';
 import { CachedSource, ConcatSource, OriginalSource, RawSource, Source } from 'webpack-sources';
 import { interpolateName } from 'loader-utils';
 import * as path from 'path';
+import { isWebpackFiveOrHigher } from '../../utils/webpack-version';
 
 const Chunk = require('webpack/lib/Chunk');
 const EntryPoint = require('webpack/lib/Entrypoint');
@@ -72,7 +73,11 @@ export class ScriptsWebpackPlugin {
     chunk.rendered = !cached;
     chunk.id = this.options.name;
     chunk.ids = [chunk.id];
-    chunk.files.push(filename);
+    if (isWebpackFiveOrHigher()) {
+      chunk.files.add(filename);
+    } else {
+      chunk.files.push(filename);
+    }
 
     const entrypoint = new EntryPoint(this.options.name);
     entrypoint.pushChunk(chunk);


### PR DESCRIPTION
should fix 18 webpack 5 deprecation warnings `[DEP_WEBPACK_DEPRECATION_ARRAY_TO_SET_PUSH] DeprecationWarning: chunk.files was changed from Array to Set (using Array method 'push' is deprecated)`