### PR TITLE
feat(@schematics/angular): don't generate  special `package.json` and `no-any` when using `--strict`

### DIFF
--- a/packages/schematics/angular/application/index_spec.ts
+++ b/packages/schematics/angular/application/index_spec.ts
@@ -289,23 +289,6 @@ describe('Application Schematic', () => {
     });
   });
 
-  it('sideEffects property should be true when strict mode', async () => {
-    const options = { ...defaultOptions, projectRoot: '', strict: true };
-
-    const tree = await schematicRunner.runSchematicAsync('application', options, workspaceTree)
-      .toPromise();
-    const content = JSON.parse(tree.readContent('/src/app/package.json'));
-    expect(content.sideEffects).toBe(false);
-  });
-
-  it('sideEffects package.json should not exist when not in strict mode', async () => {
-    const options = { ...defaultOptions, projectRoot: '', strict: false };
-
-    const tree = await schematicRunner.runSchematicAsync('application', options, workspaceTree)
-      .toPromise();
-    expect(tree.exists('/src/app/package.json')).toBeFalse();
-  });
-
   describe('custom projectRoot', () => {
     it('should put app files in the right spot', async () => {
       const options = { ...defaultOptions, projectRoot: '' };

--- a/packages/schematics/angular/application/other-files/package.json.template
+++ b/packages/schematics/angular/application/other-files/package.json.template
@@ -1,9 +1,0 @@
-{
-  "name": "<%= utils.dasherize(name) %>",
-  "private": true,
-  "description_1": "This is a special package.json file that is not used by package managers.",
-  "description_2": "It is used to tell the tools and bundlers whether the code under this directory is free of code with non-local side-effect. Any code that does have non-local side-effects can't be well optimized (tree-shaken) and will result in unnecessary increased payload size.",
-  "description_3": "It should be safe to set this option to 'false' for new applications, but existing code bases could be broken when built with the production config if the application code does contain non-local side-effects that the application depends on.",
-  "description_4": "To learn more about this file see: https://angular.io/config/app-package-json.",
-  "sideEffects": <%= !strict %>
-}

--- a/packages/schematics/angular/application/schema.json
+++ b/packages/schematics/angular/application/schema.json
@@ -107,7 +107,7 @@
       "x-user-analytics": 15
     },
     "strict": {
-      "description": "Creates an application with stricter build optimization options.",
+      "description": "Creates an application with stricter bundle budgets settings.",
       "type": "boolean",
       "default": false
     },

--- a/packages/schematics/angular/ng-new/schema.json
+++ b/packages/schematics/angular/ng-new/schema.json
@@ -129,7 +129,7 @@
       "x-user-analytics": 14
     },
     "strict": {
-      "description": "Creates a workspace with stricter type checking and build optimization options.",
+      "description": "Creates a workspace with stricter type checking and stricter bundle budgets settings.",
       "type": "boolean",
       "default": false
     },

--- a/packages/schematics/angular/workspace/files/tslint.json.template
+++ b/packages/schematics/angular/workspace/files/tslint.json.template
@@ -42,8 +42,7 @@
           "instance-method"
         ]
       }
-    ],<% if (strict) { %>
-    "no-any": true,<% } %>
+    ],
     "no-console": [
       true,
       "debug",

--- a/packages/schematics/angular/workspace/index_spec.ts
+++ b/packages/schematics/angular/workspace/index_spec.ts
@@ -90,16 +90,4 @@ describe('Workspace Schematic', () => {
     expect(compilerOptions.strict).toBe(true);
     expect(angularCompilerOptions.strictTemplates).toBe(true);
   });
-
-  it('should not add strict lint options when false', async () => {
-    const tree = await schematicRunner.runSchematicAsync('workspace', { ...defaultOptions, strict: false }).toPromise();
-    const { rules } = JSON.parse(tree.readContent('/tslint.json'));
-    expect(rules['no-any']).toBeUndefined();
-  });
-
-  it('should add strict lint options when true', async () => {
-    const tree = await schematicRunner.runSchematicAsync('workspace', { ...defaultOptions, strict: true }).toPromise();
-    const { rules } = JSON.parse(tree.readContent('/tslint.json'));
-    expect(rules['no-any']).toBe(true);
-  });
 });


### PR DESCRIPTION

Following feedback from the community, which showed a high number of users found it hard to work with the `no-any` lint rule and also the `sideEffects` package.json file. With DevRel we decided to remove both features when generating a strict workspace and/or application.