### PR TITLE
refactor(@angular-devkit/build-angular): change errors and warnings messages

### DIFF
--- a/packages/angular/cli/models/schematic-command.ts
+++ b/packages/angular/cli/models/schematic-command.ts
@@ -442,7 +442,7 @@ export abstract class SchematicCommand<
 
         if (positions.length > 0) {
           const warning = tags.oneLine`
-            WARNING: This command may not execute successfully.
+            Warning: This command may not execute successfully.
             The package/collection may not support the 'targets' field within '${configPath}'.
             This can be corrected by renaming the following 'targets' fields to 'architect':
           `;

--- a/packages/angular_devkit/build_angular/src/browser/index.ts
+++ b/packages/angular_devkit/build_angular/src/browser/index.ts
@@ -250,7 +250,7 @@ export function buildWebpackBrowser(
 
         if (target > ScriptTarget.ES2015 && isDifferentialLoadingNeeded) {
           context.logger.warn(tags.stripIndent`
-          WARNING: Using differential loading with targets ES5 and ES2016 or higher may
+          Warning: Using differential loading with targets ES5 and ES2016 or higher may
           cause problems. Browsers with support for ES2015 will load the ES2016+ scripts
           referenced with script[type="module"] but they may not support ES2016+ syntax.
         `);
@@ -262,7 +262,7 @@ export function buildWebpackBrowser(
           const browsers =
             (hasIE9 ? 'IE 9' + (hasIE10 ? ' & ' : '') : '') + (hasIE10 ? 'IE 10' : '');
           context.logger.warn(
-            `WARNING: Support was requested for ${browsers} in the project's browserslist configuration. ` +
+            `Warning: Support was requested for ${browsers} in the project's browserslist configuration. ` +
               (hasIE9 && hasIE10 ? 'These browsers are' : 'This browser is') +
               ' no longer officially supported with Angular v11 and higher.' +
               '\nFor additional information: https://v10.angular.io/guide/deprecations#ie-9-10-and-mobile',
@@ -654,13 +654,12 @@ export function buildWebpackBrowser(
                 const budgets = options.budgets || [];
                 const budgetFailures = checkBudgets(budgets, webpackStats, processResults);
                 for (const { severity, message } of budgetFailures) {
-                  const msg = `budgets: ${message}`;
                   switch (severity) {
                     case ThresholdSeverity.Warning:
-                      webpackStats.warnings.push(msg);
+                      webpackStats.warnings.push(message);
                       break;
                     case ThresholdSeverity.Error:
-                      webpackStats.errors.push(msg);
+                      webpackStats.errors.push(message);
                       break;
                     default:
                       assertNever(severity);

--- a/packages/angular_devkit/build_angular/src/browser/specs/browser-support_spec.ts
+++ b/packages/angular_devkit/build_angular/src/browser/specs/browser-support_spec.ts
@@ -35,7 +35,7 @@ describe('Browser Builder browser support', () => {
 
     const fullLog = logs.join();
     expect(fullLog).toContain(
-      "WARNING: Support was requested for IE 9 in the project's browserslist configuration.",
+      "Warning: Support was requested for IE 9 in the project's browserslist configuration.",
     );
     expect(fullLog).toContain('This browser is ');
 
@@ -55,7 +55,7 @@ describe('Browser Builder browser support', () => {
 
     const fullLog = logs.join();
     expect(fullLog).toContain(
-      "WARNING: Support was requested for IE 10 in the project's browserslist configuration.",
+      "Warning: Support was requested for IE 10 in the project's browserslist configuration.",
     );
     expect(fullLog).toContain('This browser is ');
 
@@ -75,7 +75,7 @@ describe('Browser Builder browser support', () => {
 
     const fullLog = logs.join();
     expect(fullLog).toContain(
-      "WARNING: Support was requested for IE 9 & IE 10 in the project's browserslist configuration.",
+      "Warning: Support was requested for IE 9 & IE 10 in the project's browserslist configuration.",
     );
     expect(fullLog).toContain('These browsers are ');
 

--- a/packages/angular_devkit/build_angular/src/browser/specs/bundle-budgets_spec.ts
+++ b/packages/angular_devkit/build_angular/src/browser/specs/bundle-budgets_spec.ts
@@ -33,7 +33,7 @@ describe('Browser Builder bundle budgets', () => {
     const run = await architect.scheduleTarget(targetSpec, overrides, { logger });
     const output = await run.result;
     expect(output.success).toBe(true);
-    expect(logs.join()).not.toContain('WARNING');
+    expect(logs.join()).not.toContain('Warning');
     await run.stop();
   });
 
@@ -61,7 +61,7 @@ describe('Browser Builder bundle budgets', () => {
     const run = await architect.scheduleTarget(targetSpec, overrides, { logger });
     const output = await run.result;
     expect(output.success).toBe(true);
-    expect(logs.join()).toContain('WARNING');
+    expect(logs.join()).toContain('Warning');
     await run.stop();
   });
 
@@ -100,7 +100,7 @@ describe('Browser Builder bundle budgets', () => {
       const output = await run.result;
       expect(output.success).toBe(true);
       expect(logs.length).toBe(2);
-      expect(logs.join()).toMatch(`WARNING.+app\.component\.${ext}`);
+      expect(logs.join()).toMatch(`Warning.+app\.component\.${ext}`);
       await run.stop();
     });
   });
@@ -140,7 +140,7 @@ describe('Browser Builder bundle budgets', () => {
       const output = await run.result;
       expect(output.success).toBe(false);
       expect(logs.length).toBe(2);
-      expect(logs.join()).toMatch(`ERROR.+app\.component\.${ext}`);
+      expect(logs.join()).toMatch(`Error.+app\.component\.${ext}`);
       await run.stop();
     });
   });

--- a/packages/angular_devkit/build_angular/src/browser/specs/common-js-warning_spec.ts
+++ b/packages/angular_devkit/build_angular/src/browser/specs/common-js-warning_spec.ts
@@ -46,7 +46,7 @@ describe('Browser Builder commonjs warning', () => {
       const run = await architect.scheduleTarget(targetSpec, { aot }, { logger });
       const output = await run.result;
       expect(output.success).toBe(true);
-      expect(logs.join()).not.toContain('WARNING');
+      expect(logs.join()).not.toContain('Warning');
       await run.stop();
     });
 
@@ -60,7 +60,7 @@ describe('Browser Builder commonjs warning', () => {
       const output = await run.result;
       expect(output.success).toBe(true);
       const logMsg = logs.join();
-      expect(logMsg).toMatch(/WARNING in.+app\.component\.ts depends on 'bootstrap'\. CommonJS or AMD dependencies/);
+      expect(logMsg).toMatch(/Warning: .+app\.component\.ts depends on 'bootstrap'\. CommonJS or AMD dependencies/);
       expect(logMsg).not.toContain('jquery', 'Should not warn on transitive CommonJS packages which parent is also CommonJS.');
       await run.stop();
     });
@@ -83,7 +83,7 @@ describe('Browser Builder commonjs warning', () => {
     const run = await architect.scheduleTarget(targetSpec, overrides, { logger });
     const output = await run.result;
     expect(output.success).toBe(true);
-    expect(logs.join()).not.toContain('WARNING');
+    expect(logs.join()).not.toContain('Warning');
     await run.stop();
   });
 
@@ -97,7 +97,7 @@ describe('Browser Builder commonjs warning', () => {
     const output = await run.result;
     expect(output.success).toBe(true);
 
-    expect(logs.join()).not.toContain('WARNING');
+    expect(logs.join()).not.toContain('Warning');
     await run.stop();
   });
 

--- a/packages/angular_devkit/build_angular/src/browser/specs/web-worker_spec.ts
+++ b/packages/angular_devkit/build_angular/src/browser/specs/web-worker_spec.ts
@@ -104,7 +104,7 @@ describe('Browser Builder Web Worker support', () => {
     const mainContent = virtualFs.fileBufferToString(
       host.scopedSync().read(join(outputPath, 'main.js')));
     expect(mainContent).toContain('0.worker.js');
-    expect(logs.join().includes('WARNING')).toBe(false, 'Should show no warnings.');
+    expect(logs.join().includes('Warning')).toBe(false, 'Should show no warnings.');
   });
 
   it('minimizes and hashes worker', async () => {

--- a/packages/angular_devkit/build_angular/src/dev-server/index.ts
+++ b/packages/angular_devkit/build_angular/src/dev-server/index.ts
@@ -376,7 +376,7 @@ export function buildServerConfig(
     && serverOptions.host !== 'localhost'
   ) {
     logger.warn(tags.stripIndent`
-        WARNING: This is a simple server for use in testing or debugging Angular applications
+        Warning: This is a simple server for use in testing or debugging Angular applications
         locally. It hasn't been reviewed for security issues.
 
         Binding this server to an open connection can result in compromising your application or
@@ -388,7 +388,7 @@ export function buildServerConfig(
 
   if (serverOptions.disableHostCheck) {
     logger.warn(tags.oneLine`
-        WARNING: Running a server with --disable-host-check is a security risk.
+        Warning: Running a server with --disable-host-check is a security risk.
         See https://medium.com/webpack/webpack-dev-server-middleware-security-issues-1489d950874a
         for more information.
       `);
@@ -466,7 +466,7 @@ export function buildServePath(
     const showWarning = serverOptions.servePathDefaultWarning;
     if (defaultPath == null && showWarning) {
       logger.warn(tags.oneLine`
-        WARNING: --deploy-url and/or --base-href contain unsupported values for ng serve. Default
+        Warning: --deploy-url and/or --base-href contain unsupported values for ng serve. Default
         serve path of '/' used. Use --serve-path to override.
       `);
     }

--- a/packages/angular_devkit/build_angular/src/server/index.ts
+++ b/packages/angular_devkit/build_angular/src/server/index.ts
@@ -74,7 +74,7 @@ export function execute(
       (main as string).includes('__ivy_ngcc__')
     ) {
       context.logger.warn(tags.stripIndent`
-      WARNING: Turning off 'bundleDependencies' with Ivy may result in undefined behaviour
+      Warning: Turning off 'bundleDependencies' with Ivy may result in undefined behaviour
       unless 'node_modules' are transformed using the standalone Angular compatibility compiler (NGCC).
       See: http://v9.angular.io/guide/ivy#ivy-and-universal-app-shell
     `);

--- a/packages/angular_devkit/build_angular/src/webpack/configs/browser.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/browser.ts
@@ -41,7 +41,7 @@ export function getBrowserConfig(wco: WebpackConfigOptions): webpack.Configurati
   // TODO_WEBPACK_5: Investigate build/serve issues with the `license-webpack-plugin` package
   if (extractLicenses && isWebpackFiveOrHigher()) {
     wco.logger.warn(
-      'WARNING: License extraction is currently disabled when using Webpack 5. ' +
+      'Warning: License extraction is currently disabled when using Webpack 5. ' +
         'This is temporary and will be corrected in a future update.',
     );
   } else if (extractLicenses) {

--- a/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
@@ -464,7 +464,7 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
     wco.tsConfig.options.target >= ScriptTarget.ES2017
   ) {
     wco.logger.warn(tags.stripIndent`
-      WARNING: Zone.js does not support native async/await in ES2017.
+      Warning: Zone.js does not support native async/await in ES2017.
       These blocks are not intercepted by zone.js and will not triggering change detection.
       See: https://github.com/angular/zone.js/pull/1140 for more information.
     `);

--- a/packages/angular_devkit/build_angular/src/webpack/utils/stats.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/utils/stats.ts
@@ -174,7 +174,7 @@ export function statsWarningsToString(json: any, statsConfig: any): string {
       if (!ERRONEOUS_WARNINGS_FILTER(warning)) {
         continue;
       }
-      output += yb(`WARNING in ${warning}\n\n`);
+      output += yb(`Warning: ${warning}\n\n`);
     } else {
       if (!ERRONEOUS_WARNINGS_FILTER(warning.message)) {
           continue;
@@ -218,7 +218,7 @@ export function statsErrorsToString(json: any, statsConfig: any): string {
   let output = '';
   for (const error of errors as (string | WebpackDiagnostic)[]) {
     if (typeof error === 'string') {
-      output += r(`ERROR in ${error}\n\n`);
+      output += r(`Error: ${error}\n\n`);
     } else {
       const file = error.file || error.moduleName;
       if (file) {

--- a/packages/ngtools/webpack/src/type_checker.ts
+++ b/packages/ngtools/webpack/src/type_checker.ts
@@ -114,8 +114,8 @@ export class TypeChecker {
     if (!cancellationToken.isCancellationRequested()) {
       reportDiagnostics(
         allDiagnostics,
-        msg => this.sendMessage(new LogMessage('error', 'ERROR in ' + msg)),
-        msg => this.sendMessage(new LogMessage('warn', 'WARNING in ' + msg)),
+        msg => this.sendMessage(new LogMessage('error', 'Error: ' + msg)),
+        msg => this.sendMessage(new LogMessage('warn', 'Warning: ' + msg)),
       );
     }
   }

--- a/tests/legacy-cli/e2e/tests/build/bundle-budgets.ts
+++ b/tests/legacy-cli/e2e/tests/build/bundle-budgets.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { getGlobalVariable } from '../../utils/env';
 import { ng } from '../../utils/process';
 import { updateJsonFile } from '../../utils/project';
 import { expectToFail } from '../../utils/utils';
@@ -39,7 +38,7 @@ export default function () {
           })
           .then(() => expectToFail(() => ng('build', '--optimization')))
           .then(errorMessage => {
-            if (!/ERROR in budgets/.test(errorMessage)) {
+            if (!/Error.+budgets/.test(errorMessage)) {
               throw new Error(cfg.message);
             }
           });
@@ -51,7 +50,7 @@ export default function () {
           })
           .then(() => ng('build', '--optimization'))
           .then(({ stderr }) => {
-            if (!/WARNING in budgets/.test(stderr)) {
+            if (!/Warning.+budgets/.test(stderr)) {
               throw new Error(cfg.message);
             }
           });
@@ -63,7 +62,7 @@ export default function () {
           })
           .then(() => ng('build', '--optimization'))
           .then(({ stderr }) => {
-            if (/(WARNING|ERROR)/.test(stderr)) {
+            if (/(Warning|Error)/.test(stderr)) {
               throw new Error(cfg.message);
             }
           });

--- a/tests/legacy-cli/e2e/tests/build/rebuild-deps-type-check.ts
+++ b/tests/legacy-cli/e2e/tests/build/rebuild-deps-type-check.ts
@@ -4,12 +4,11 @@ import {
   execAndWaitForOutputToMatch,
 } from '../../utils/process';
 import {writeFile, prependToFile, appendToFile} from '../../utils/fs';
-import {getGlobalVariable} from '../../utils/env';
 
 
 const doneRe =
   /: Compiled successfully.|: Failed to compile./;
-const errorRe = /ERROR in/;
+const errorRe = /Error/;
 
 
 export default function() {
@@ -49,7 +48,7 @@ export default function() {
     ]))
     .then((results) => {
       const stderr = results[0].stderr;
-      if (!/ERROR in (.*src\/)?main\.ts/.test(stderr)) {
+      if (!/Error: (.*src\/)?main\.ts/.test(stderr)) {
         throw new Error('Expected an error but none happened.');
       }
     })
@@ -63,7 +62,7 @@ export default function() {
     ]))
     .then((results) => {
       const stderr = results[0].stderr;
-      if (!/ERROR in (.*src\/)?main\.ts/.test(stderr)) {
+      if (!/Error: (.*src\/)?main\.ts/.test(stderr)) {
         throw new Error('Expected an error to still be there but none was.');
       }
     })
@@ -78,7 +77,7 @@ export default function() {
     ]))
     .then((results) => {
       const stderr = results[0].stderr;
-      if (/ERROR in (.*src\/)?main\.ts/.test(stderr)) {
+      if (/Error: (.*src\/)?main\.ts/.test(stderr)) {
         throw new Error('Expected no error but an error was shown.');
       }
     })

--- a/tests/legacy-cli/e2e/tests/misc/circular-dependency.ts
+++ b/tests/legacy-cli/e2e/tests/misc/circular-dependency.ts
@@ -8,7 +8,7 @@ export default async function () {
   await prependToFile('src/app/app.component.ts',
     `import { AppModule } from './app.module'; console.log(AppModule);`);
   const { stderr } = await ng('build', '--show-circular-dependencies');
-  if (!stderr.match(/WARNING in Circular dependency detected/)) {
+  if (!stderr.match(/Warning: Circular dependency detected/)) {
     throw new Error('Expected to have circular dependency warning in output.');
   }
 }


### PR DESCRIPTION
Sometimes the WARNING IN/ERROR IN can lead of ambiguous messages

 - Use `Warning` instead of `WARNING IN`
-  Use `Error` instead of `Error In`