### PR TITLE
refactor(@angular/cli): discover/load workspace on startup

### DIFF
--- a/packages/angular/cli/commands/add-impl.ts
+++ b/packages/angular/cli/commands/add-impl.ts
@@ -79,7 +79,7 @@ export class AddCommand extends SchematicCommand<AddCommandSchema> {
       }
     }
 
-    const packageManager = await getPackageManager(this.workspace.root);
+    const packageManager = await getPackageManager(this.context.root);
     const usingYarn = packageManager === PackageManager.Yarn;
 
     if (packageIdentifier.type === 'tag' && !packageIdentifier.rawSpec) {
@@ -210,7 +210,7 @@ export class AddCommand extends SchematicCommand<AddCommandSchema> {
 
   private isPackageInstalled(name: string): boolean {
     try {
-      require.resolve(join(name, 'package.json'), { paths: [this.workspace.root] });
+      require.resolve(join(name, 'package.json'), { paths: [this.context.root] });
 
       return true;
     } catch (e) {
@@ -254,7 +254,7 @@ export class AddCommand extends SchematicCommand<AddCommandSchema> {
     let installedPackage;
     try {
       installedPackage = require.resolve(join(name, 'package.json'), {
-        paths: [this.workspace.root],
+        paths: [this.context.root],
       });
     } catch {}
 
@@ -268,7 +268,7 @@ export class AddCommand extends SchematicCommand<AddCommandSchema> {
 
     let projectManifest;
     try {
-      projectManifest = await fetchPackageManifest(this.workspace.root, this.logger);
+      projectManifest = await fetchPackageManifest(this.context.root, this.logger);
     } catch {}
 
     if (projectManifest) {

--- a/packages/angular/cli/commands/version-impl.ts
+++ b/packages/angular/cli/commands/version-impl.ts
@@ -26,7 +26,7 @@ export class VersionCommand extends Command<VersionCommandSchema> {
     const cliPackage: PartialPackageInfo = require('../package.json');
     let workspacePackage: PartialPackageInfo | undefined;
     try {
-      workspacePackage = require(path.resolve(this.workspace.root, 'package.json'));
+      workspacePackage = require(path.resolve(this.context.root, 'package.json'));
     } catch {}
 
     const patterns = [
@@ -144,7 +144,7 @@ export class VersionCommand extends Command<VersionCommandSchema> {
 
     // Try to find the package in the workspace
     try {
-      packagePath = require.resolve(`${moduleName}/package.json`, { paths: [ this.workspace.root ]});
+      packagePath = require.resolve(`${moduleName}/package.json`, { paths: [ this.context.root ]});
     } catch {}
 
     // If not found, try to find within the CLI
@@ -169,7 +169,7 @@ export class VersionCommand extends Command<VersionCommandSchema> {
 
   private getIvyWorkspace(): string {
     try {
-      const content = fs.readFileSync(path.resolve(this.workspace.root, 'tsconfig.json'), 'utf-8');
+      const content = fs.readFileSync(path.resolve(this.context.root, 'tsconfig.json'), 'utf-8');
       const tsConfig = parseJson(content, JsonParseMode.Loose);
       if (!isJsonObject(tsConfig)) {
         return '<error>';

--- a/packages/angular/cli/models/interface.ts
+++ b/packages/angular/cli/models/interface.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import { analytics, json, logging } from '@angular-devkit/core';
+import { AngularWorkspace } from '../utilities/config';
 
 /**
  * Value type of arguments.
@@ -45,20 +46,15 @@ export interface CommandConstructor {
 }
 
 /**
- * A CLI workspace information.
- */
-export interface CommandWorkspace {
-  root: string;
-  configFile?: string;
-}
-
-/**
  * A command runner context.
  */
 export interface CommandContext {
-  workspace: CommandWorkspace;
+  currentDirectory: string;
+  root: string;
 
-  // This feel is optional for backward compatibility.
+  workspace?: AngularWorkspace;
+
+  // This property is optional for backward compatibility.
   analytics?: analytics.Analytics;
 }
 


### PR DESCRIPTION
Previously, the workspace configuration file was found and loaded by individual commands potentially multiple times.  This change moves the initial workspace location discovery and loading of the workspace to the CLI startup.  It also provides the workspace to each command so that the commands can reuse the already loaded and parsed workspace configuration.
This change will serve as a base to further refactor and consolidate workspace option usage.