### PR TITLE
fix(@angular-devkit/build-webpack): avoid deprecation warning with Webpack 5 watch mode

### DIFF
--- a/packages/angular_devkit/build_webpack/src/webpack-dev-server/index.ts
+++ b/packages/angular_devkit/build_webpack/src/webpack-dev-server/index.ts
@@ -68,7 +68,7 @@ export function runWebpackDevServer(
   // Disable stats reporting by the devserver, we have our own logger.
   devServerConfig.stats = false;
 
-  return createWebpack(config).pipe(
+  return createWebpack({ ...config, watch: false }).pipe(
     switchMap(webpackCompiler => new Observable<DevServerBuildOutput>(obs => {
       const server = createWebpackDevServer(webpackCompiler, devServerConfig);
       let result: DevServerBuildOutput;

--- a/packages/angular_devkit/build_webpack/src/webpack/index.ts
+++ b/packages/angular_devkit/build_webpack/src/webpack/index.ts
@@ -50,7 +50,7 @@ export function runWebpack(
   const log: WebpackLoggingCallback = options.logging
     || ((stats, config) => context.logger.info(stats.toString(config.stats)));
 
-  return createWebpack(config).pipe(
+  return createWebpack({ ...config, watch: false }).pipe(
     switchMap(webpackCompiler => new Observable<BuildResult>(obs => {
       const callback = (err?: Error, stats?: webpack.Stats) => {
         if (err) {

--- a/tests/legacy-cli/e2e/tests/misc/webpack-5.ts
+++ b/tests/legacy-cli/e2e/tests/misc/webpack-5.ts
@@ -6,7 +6,7 @@ export default async function() {
   // Setup project for yarn usage
   await rimraf('node_modules');
   await updateJsonFile('package.json', (json) => {
-    json.resolutions = { webpack: '5.0.0-beta.30' };
+    json.resolutions = { webpack: '5.0.0-rc.3' };
   });
   await silentYarn();
   await silentYarn('webdriver-update');


### PR DESCRIPTION
With Webpack 5, passing the watch configuration option into the `webpack` factory function will cause the Webpack compiler to assume it should immediately start watching which requires a callback to be passed as well.  Since the execution of the compiler is handled later in the process, a callback at the compiler creation stage is undesirable and could result in potentially breaking changes to accomplish.