### PR TITLE
ci: disable lint check in the update test

### DIFF
--- a/tests/legacy-cli/e2e/tests/update/update-7.0.ts
+++ b/tests/legacy-cli/e2e/tests/update/update-7.0.ts
@@ -36,7 +36,8 @@ export default async function() {
   // Run CLI commands.
   await ng('generate', 'component', 'my-comp');
   await ng('test', '--watch=false');
-  await ng('lint');
+  // TODO: Re-enable after v11.0.0-next.4 release.
+  // await ng('lint');
   await ng('e2e');
   await ng('e2e', '--prod');
 


### PR DESCRIPTION
This is currently failing with FW 11.0.0-next.4 due to a migration using double quotes instead of single quotes. This is
for a beta release and the impact is relatively minor, so we've decided to just disable the test for now.