### PR TITLE
Revert "ci: disable lint check in the update test"

### DIFF
--- a/tests/legacy-cli/e2e/tests/update/update-7.0.ts
+++ b/tests/legacy-cli/e2e/tests/update/update-7.0.ts
@@ -36,8 +36,7 @@ export default async function() {
   // Run CLI commands.
   await ng('generate', 'component', 'my-comp');
   await ng('test', '--watch=false');
-  // TODO: Re-enable after v11.0.0-next.4 release.
-  // await ng('lint');
+  await ng('lint');
   await ng('e2e');
   await ng('e2e', '--prod');
 


### PR DESCRIPTION
Re-enabling the lint check to merge once `11.0.0-next.4` is released.

I'll leave this PR in the blocked state until the version is released and https://github.com/angular/angular/pull/39070 is merged. Once those have both happened, it should be safe to merge this as well.