### PR TITLE
refactor(@schematics/angular): display Stylus documentation url with HTTPS

### DIFF
--- a/packages/schematics/angular/application/schema.json
+++ b/packages/schematics/angular/application/schema.json
@@ -72,7 +72,7 @@
           { "value": "scss", "label": "SCSS   [ https://sass-lang.com/documentation/syntax#scss                ]" },
           { "value": "sass", "label": "Sass   [ https://sass-lang.com/documentation/syntax#the-indented-syntax ]" },
           { "value": "less", "label": "Less   [ http://lesscss.org                                             ]" },
-          { "value": "styl", "label": "Stylus [ http://stylus-lang.com                                         ]" }
+          { "value": "styl", "label": "Stylus [ https://stylus-lang.com                                        ]" }
         ]
       },
       "x-user-analytics": 5


### PR DESCRIPTION
Display the url of the Stylus format in the list of stylesheet format selection with SSL