### PR TITLE
feat(@schematics/angular): generate E2E tests with native promise support

### DIFF
--- a/packages/schematics/angular/e2e/files/protractor.conf.js.template
+++ b/packages/schematics/angular/e2e/files/protractor.conf.js.template
@@ -16,6 +16,7 @@ exports.config = {
     browserName: 'chrome'
   },
   directConnect: true,
+  SELENIUM_PROMISE_MANAGER: false,
   baseUrl: 'http://localhost:4200/',
   framework: 'jasmine',
   jasmineNodeOpts: {

--- a/packages/schematics/angular/e2e/files/src/app.e2e-spec.ts.template
+++ b/packages/schematics/angular/e2e/files/src/app.e2e-spec.ts.template
@@ -8,9 +8,9 @@ describe('workspace-project App', () => {
     page = new AppPage();
   });
 
-  it('should display welcome message', () => {
-    page.navigateTo();
-    expect(page.getTitleText()).toEqual('<%= relatedAppName %> app is running!');
+  it('should display welcome message', async () => {
+    await page.navigateTo();
+    expect(await page.getTitleText()).toEqual('<%= relatedAppName %> app is running!');
   });
 
   afterEach(async () => {

--- a/packages/schematics/angular/e2e/files/src/app.po.ts.template
+++ b/packages/schematics/angular/e2e/files/src/app.po.ts.template
@@ -1,11 +1,11 @@
 import { browser, by, element } from 'protractor';
 
 export class AppPage {
-  navigateTo(): Promise<unknown> {
-    return browser.get(browser.baseUrl) as Promise<unknown>;
+  async navigateTo(): Promise<unknown> {
+    return browser.get(browser.baseUrl);
   }
 
-  getTitleText(): Promise<string> {
-    return element(by.css('<%= rootSelector %> .content span')).getText() as Promise<string>;
+  async getTitleText(): Promise<string> {
+    return element(by.css('<%= rootSelector %> .content span')).getText();
   }
 }

--- a/packages/schematics/angular/e2e/files/tsconfig.json.template
+++ b/packages/schematics/angular/e2e/files/tsconfig.json.template
@@ -7,7 +7,6 @@
     "target": "es2018",
     "types": [
       "jasmine",
-      "jasminewd2",
       "node"
     ]
   }

--- a/packages/schematics/angular/workspace/files/package.json.template
+++ b/packages/schematics/angular/workspace/files/package.json.template
@@ -25,8 +25,7 @@
   "devDependencies": {
     "@angular/cli": "<%= '~' + version %>",
     "@angular/compiler-cli": "<%= latestVersions.Angular %>",<% if (!minimal) { %>
-    "@types/jasmine": "~3.5.0",
-    "@types/jasminewd2": "~2.0.3",<% } %>
+    "@types/jasmine": "~3.5.0",<% } %>
     "@types/node": "^12.11.1",<% if (!minimal) { %>
     "codelyzer": "^6.0.0",
     "jasmine-core": "~3.6.0",

--- a/tests/legacy-cli/e2e/assets/protractor-saucelabs.conf.js
+++ b/tests/legacy-cli/e2e/assets/protractor-saucelabs.conf.js
@@ -67,6 +67,7 @@ exports.config = {
   // Only allow one session at a time to prevent over saturation of Saucelabs sessions.
   maxSessions: 1,
 
+  SELENIUM_PROMISE_MANAGER: false,
   baseUrl: 'http://localhost:2000/',
   framework: 'jasmine',
   jasmineNodeOpts: {

--- a/tests/legacy-cli/e2e/tests/build/lazy-load-syntax.ts
+++ b/tests/legacy-cli/e2e/tests/build/lazy-load-syntax.ts
@@ -56,9 +56,9 @@ export default async function () {
     import { browser, logging, element, by } from 'protractor';
 
     describe('workspace-project App', () => {
-      it('should display lazy route', () => {
-        browser.get(browser.baseUrl + '/lazy');
-        expect(element(by.css('app-lazy-comp p')).getText()).toEqual('lazy-comp works!');
+      it('should display lazy route', async () => {
+        await browser.get(browser.baseUrl + '/lazy');
+        expect(await element(by.css('app-lazy-comp p')).getText()).toEqual('lazy-comp works!');
       });
 
       afterEach(async () => {

--- a/tests/legacy-cli/e2e/tests/build/rollup.ts
+++ b/tests/legacy-cli/e2e/tests/build/rollup.ts
@@ -35,9 +35,9 @@ export default async function () {
     import { browser, logging, element, by } from 'protractor';
 
     describe('workspace-project App', () => {
-      it('should display lazy route', () => {
-        browser.get(browser.baseUrl + '/lazy');
-        expect(element(by.css('app-lazy p')).getText()).toEqual('lazy works!');
+      it('should display lazy route', async () => {
+        await browser.get(browser.baseUrl + '/lazy');
+        expect(await element(by.css('app-lazy p')).getText()).toEqual('lazy works!');
       });
 
       afterEach(async () => {

--- a/tests/legacy-cli/e2e/tests/generate/library/library-consumption.ts
+++ b/tests/legacy-cli/e2e/tests/generate/library/library-consumption.ts
@@ -52,9 +52,9 @@ export default async function () {
         page = new AppPage();
       });
 
-      it('should display text from library component', () => {
-        page.navigateTo();
-        expect(element(by.css('lib-my-lib p')).getText()).toEqual('my-lib works!');
+      it('should display text from library component', async () => {
+        await page.navigateTo();
+        expect(await element(by.css('lib-my-lib p')).getText()).toEqual('my-lib works!');
       });
 
       afterEach(async () => {

--- a/tests/legacy-cli/e2e/tests/i18n/legacy.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/legacy.ts
@@ -125,7 +125,7 @@ export async function setupI18nConfig(useLocalize = true, format: keyof typeof f
       import { browser, logging, element, by } from 'protractor';
 
       describe('workspace-project App', () => {
-        const getParagraph = (name: string) => element(by.css('app-root p#' + name)).getText();
+        const getParagraph = async (name: string) => element(by.css('app-root p#' + name)).getText();
         beforeEach(() => browser.get(browser.baseUrl));
         afterEach(async () => {
           // Assert that there are no errors emitted from the browser
@@ -135,17 +135,17 @@ export async function setupI18nConfig(useLocalize = true, format: keyof typeof f
           } as logging.Entry));
         });
 
-        it('should display welcome message', () =>
-          expect(getParagraph('hello')).toEqual('${translation.hello}'));
+        it('should display welcome message', async () =>
+          expect(await getParagraph('hello')).toEqual('${translation.hello}'));
 
-        it('should display locale', () =>
-          expect(getParagraph('locale')).toEqual('${lang}'));
+        it('should display locale', async () =>
+          expect(await getParagraph('locale')).toEqual('${lang}'));
 
-        it('should display localized date', () =>
-          expect(getParagraph('date')).toEqual('${translation.date}'));
+        it('should display localized date', async () =>
+          expect(await getParagraph('date')).toEqual('${translation.date}'));
 
-        it('should display pluralized message', () =>
-          expect(getParagraph('plural')).toEqual('${translation.plural}'));
+        it('should display pluralized message', async () =>
+          expect(await getParagraph('plural')).toEqual('${translation.plural}'));
       });
     `);
   }

--- a/tests/legacy-cli/e2e/tests/misc/browsers.ts
+++ b/tests/legacy-cli/e2e/tests/misc/browsers.ts
@@ -46,17 +46,7 @@ export default async function () {
   // Leading and trailing space is not removed
   await replaceInFile(
     'e2e/src/app.e2e-spec.ts',
-    '\'should display welcome message\',',
-    '\'should display welcome message\', async',
-  );
-  await replaceInFile(
-    'e2e/src/app.e2e-spec.ts',
-    'page.navigateTo();',
-    'await page.navigateTo();',
-  );
-  await replaceInFile(
-    'e2e/src/app.e2e-spec.ts',
-    'page.getTitleText()',
+    'await page.getTitleText()',
     '(await page.getTitleText()).trim()',
   );
 

--- a/tests/legacy-cli/e2e/tests/misc/third-party-decorators.ts
+++ b/tests/legacy-cli/e2e/tests/misc/third-party-decorators.ts
@@ -16,11 +16,11 @@ export default function () {
       './e2e/src/app.po.ts': `
         import { browser, by, element } from 'protractor';
         export class AppPage {
-          navigateTo() {    return browser.get('/');  }
+          async navigateTo() {    return browser.get('/');  }
           getIncrementButton() { return element(by.buttonText('Increment')); }
           getDecrementButton() { return element(by.buttonText('Decrement')); }
           getResetButton() { return element(by.buttonText('Reset Counter')); }
-          getCounter() { return element(by.xpath('/html/body/app-root/div/span')).getText(); }
+          async getCounter() { return element(by.xpath('/html/body/app-root/div/span')).getText(); }
         }
       `,
       './e2e/src/app.e2e-spec.ts': `
@@ -33,15 +33,15 @@ export default function () {
             page = new AppPage();
           });
 
-          it('should operate counter', () => {
-            page.navigateTo();
-            page.getIncrementButton().click();
-            page.getIncrementButton().click();
-            expect(page.getCounter()).toEqual('2');
-            page.getDecrementButton().click();
-            expect(page.getCounter()).toEqual('1');
-            page.getResetButton().click();
-            expect(page.getCounter()).toEqual('0');
+          it('should operate counter', async () => {
+            await page.navigateTo();
+            await page.getIncrementButton().click();
+            await page.getIncrementButton().click();
+            expect(await page.getCounter()).toEqual('2');
+            await page.getDecrementButton().click();
+            expect(await page.getCounter()).toEqual('1');
+            await page.getResetButton().click();
+            expect(await page.getCounter()).toEqual('0');
           });
         });
       `,


### PR DESCRIPTION
This change adjusts the E2E schematic to generate a protractor configuration with the selenium promise manager disabled.  It also adjusts the generated test files to use native promises and async/await to control test execution.