### PR TITLE
fix(@schematics/angular) remove reference to IE10 in comment

### DIFF
--- a/packages/schematics/angular/application/files/src/polyfills.ts.template
+++ b/packages/schematics/angular/application/files/src/polyfills.ts.template
@@ -18,7 +18,7 @@
  * BROWSER POLYFILLS
  */
 
-/** IE10 and IE11 requires the following for NgClass support on SVG elements */
+/** IE11 requires the following for NgClass support on SVG elements */
 // import 'classlist.js';  // Run `npm install --save classlist.js`.
 
 /**


### PR DESCRIPTION
IE 10 is no longer supported therefore we removed it from the classlist polyfill comment.