### PR TITLE
fix(@angular/cli): add blank line in migration commit message

### DIFF
--- a/packages/angular/cli/commands/update-impl.ts
+++ b/packages/angular/cli/commands/update-impl.ts
@@ -248,7 +248,7 @@ export class UpdateCommand extends Command<UpdateCommandSchema> {
       if (commit) {
         const commitPrefix = `${packageName} migration - ${migration.name}`;
         const commitMessage = migration.description
-          ? `${commitPrefix}\n${migration.description}`
+          ? `${commitPrefix}\n\n${migration.description}`
           : commitPrefix;
         const committed = this.commit(commitMessage);
         if (!committed) {


### PR DESCRIPTION
When using the `-C` option of `update`, the commit message of the migration is missing a blank line between the subject and body. 

For example,

Previously was missing blank line after the commit subject:
```
@angular/cli migration - rename-browserslist-config
Update Browserslist configuration file name to '.browserslistrc' from deprecated 'browserslist'.
```

Now fixed:
```
@angular/cli migration - rename-browserslist-config

Update Browserslist configuration file name to '.browserslistrc' from deprecated 'browserslist'.
```