### PR TITLE
fix(@schematics/angular): fix recursion in `findNodes` ast utils

### DIFF
--- a/packages/schematics/angular/utility/ast-utils.ts
+++ b/packages/schematics/angular/utility/ast-utils.ts
@@ -132,7 +132,7 @@ export function findNodes<T extends ts.Node>(
   }
   if (max > 0 && (recursive || !test(node))) {
     for (const child of node.getChildren()) {
-      findNodes(child, test, max).forEach((node) => {
+      findNodes(child, test, max, recursive).forEach((node) => {
         if (max > 0) {
           arr.push(node);
         }

--- a/packages/schematics/angular/utility/ast-utils_spec.ts
+++ b/packages/schematics/angular/utility/ast-utils_spec.ts
@@ -609,4 +609,45 @@ describe('ast utils', () => {
       );
     });
   });
+
+  describe('findNodes', () => {
+    const filePath = './src/foo.ts';
+    const fileContent = `
+      const a = {
+        nodeAtDepth0: {
+          nodeAtDepth1: {
+            nodeAtDepth2: { nodeAtDepth3: 'foo' },
+          },
+        },
+      };
+    `;
+
+    let recursive: boolean;
+
+    describe('when `recursive` is not set', () => {
+      beforeEach(() => {
+        recursive = false;
+      });
+
+      it('should return node excluding nested nodes', () => {
+        const source = getTsSource(filePath, fileContent);
+        const paNodes = findNodes(source, ts.SyntaxKind.PropertyAssignment, Infinity, recursive);
+
+        expect(paNodes.length).toEqual(1);
+      });
+    });
+
+    describe('when `recursive` is set', () => {
+      beforeEach(() => {
+        recursive = true;
+      });
+
+      it('should return node including all nested nodes', () => {
+        const source = getTsSource(filePath, fileContent);
+        const paNodes = findNodes(source, ts.SyntaxKind.PropertyAssignment, Infinity, recursive);
+
+        expect(paNodes.length).toEqual(4);
+      });
+    });
+  });
 });


### PR DESCRIPTION
### Problem
`findNodes` is not recursive when `recursive` flag is set.
### Solution
Pass down `recursive` flag when  calling `findNodes` recursively.