### PR TITLE
fix(@angular/cli): collect analytics option usage from workspace config and prompts

### DIFF
--- a/packages/angular/cli/commands/build-impl.ts
+++ b/packages/angular/cli/commands/build-impl.ts
@@ -15,13 +15,4 @@ export class BuildCommand extends ArchitectCommand<BuildCommandSchema> {
   public async run(options: ArchitectCommandOptions & Arguments) {
     return this.runArchitectTarget(options);
   }
-
-  async reportAnalytics(
-    paths: string[],
-    options: BuildCommandSchema & Arguments,
-    dimensions: (boolean | number | string)[] = [],
-    metrics: (boolean | number | string)[] = [],
-  ): Promise<void> {
-    return super.reportAnalytics(paths, options, dimensions, metrics);
-  }
 }

--- a/packages/angular/cli/commands/deploy-impl.ts
+++ b/packages/angular/cli/commands/deploy-impl.ts
@@ -37,13 +37,4 @@ export class DeployCommand extends ArchitectCommand<DeployCommandSchema> {
       return super.initialize(options);
     }
   }
-
-  async reportAnalytics(
-    paths: string[],
-    options: DeployCommandSchema & Arguments,
-    dimensions: (boolean | number | string)[] = [],
-    metrics: (boolean | number | string)[] = [],
-  ): Promise<void> {
-    return super.reportAnalytics(paths, options, dimensions, metrics);
-  }
 }

--- a/packages/angular/cli/commands/generate-impl.ts
+++ b/packages/angular/cli/commands/generate-impl.ts
@@ -78,22 +78,18 @@ export class GenerateCommand extends SchematicCommand<GenerateCommandSchema> {
     paths: string[],
     options: GenerateCommandSchema & Arguments,
   ): Promise<void> {
-    const [collectionName, schematicName] = await this.parseSchematicInfo(options);
-
-    if (!schematicName || !collectionName) {
+    if (!this.collectionName || !this.schematicName) {
       return;
     }
-    const escapedSchematicName = (this.longSchematicName || schematicName).replace(/\//g, '_');
+    const escapedSchematicName = (this.longSchematicName || this.schematicName).replace(/\//g, '_');
 
     return super.reportAnalytics(
-      ['generate', collectionName.replace(/\//g, '_'), escapedSchematicName],
+      ['generate', this.collectionName.replace(/\//g, '_'), escapedSchematicName],
       options,
     );
   }
 
-  private async parseSchematicInfo(options: {
-    schematic?: string;
-  }): Promise<[string, string | undefined]> {
+  private async parseSchematicInfo(options: GenerateCommandSchema): Promise<[string, string | undefined]> {
     let collectionName = await this.getDefaultSchematicCollection();
 
     let schematicName = options.schematic;

--- a/packages/angular/cli/commands/serve-impl.ts
+++ b/packages/angular/cli/commands/serve-impl.ts
@@ -7,7 +7,6 @@
  */
 import { ArchitectCommand, ArchitectCommandOptions } from '../models/architect-command';
 import { Arguments } from '../models/interface';
-import { Schema as BuildCommandSchema } from './build';
 import { Schema as ServeCommandSchema } from './serve';
 
 export class ServeCommand extends ArchitectCommand<ServeCommandSchema> {
@@ -19,14 +18,5 @@ export class ServeCommand extends ArchitectCommand<ServeCommandSchema> {
 
   public async run(options: ArchitectCommandOptions & Arguments) {
     return this.runArchitectTarget(options);
-  }
-
-  async reportAnalytics(
-    paths: string[],
-    options: BuildCommandSchema & Arguments,
-    dimensions: (boolean | number | string)[] = [],
-    metrics: (boolean | number | string)[] = [],
-  ): Promise<void> {
-    return super.reportAnalytics(paths, options, dimensions, metrics);
   }
 }

--- a/packages/angular/cli/models/command.ts
+++ b/packages/angular/cli/models/command.ts
@@ -23,7 +23,8 @@ export interface BaseCommandOptions {
 }
 
 export abstract class Command<T extends BaseCommandOptions = BaseCommandOptions> {
-  public allowMissingWorkspace = false;
+  protected allowMissingWorkspace = false;
+  protected useReportAnalytics = true;
   readonly workspace?: AngularWorkspace;
   readonly analytics: analytics.Analytics;
 
@@ -143,7 +144,7 @@ export abstract class Command<T extends BaseCommandOptions = BaseCommandOptions>
 
   async reportAnalytics(
     paths: string[],
-    options: T & Arguments,
+    options: Arguments,
     dimensions: (boolean | number | string)[] = [],
     metrics: (boolean | number | string)[] = [],
   ): Promise<void> {
@@ -173,7 +174,9 @@ export abstract class Command<T extends BaseCommandOptions = BaseCommandOptions>
       return this.printJsonHelp(options);
     } else {
       const startTime = +new Date();
-      await this.reportAnalytics([this.description.name], options);
+      if (this.useReportAnalytics) {
+        await this.reportAnalytics([this.description.name], options);
+      }
       const result = await this.run(options);
       const endTime = +new Date();
 

--- a/packages/angular/cli/models/schematic-command.ts
+++ b/packages/angular/cli/models/schematic-command.ts
@@ -70,7 +70,8 @@ export class UnknownCollectionError extends Error {
 export abstract class SchematicCommand<
   T extends BaseSchematicSchema & BaseCommandOptions
 > extends Command<T> {
-  readonly allowPrivateSchematics: boolean = false;
+  protected readonly allowPrivateSchematics: boolean = false;
+  protected readonly useReportAnalytics = false;
   protected _workflow!: NodeWorkflow;
 
   protected defaultCollectionName = '@schematics/angular';
@@ -481,6 +482,9 @@ export abstract class SchematicCommand<
       ...input,
       ...options.additionalOptions,
     };
+
+    const transformOptions = await workflow.engine.transformOptions(schematic, input).toPromise();
+    await this.reportAnalytics([this.description.name], transformOptions as Arguments);
 
     workflow.reporter.subscribe((event: DryRunEvent) => {
       nothingDone = false;


### PR DESCRIPTION

With this change we fix two analytics collection bugs:
- We now collect the usage of options defined in the workspace config (angular.json).
- We now also collect values set via schematic prompts.

Closes: #17900