### PR TITLE
build: use @angular/dev-infra-private for bazel stamping

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -65,7 +65,7 @@ test:saucelabs --define=KARMA_WEB_TEST_MODE=SL_REQUIRED
 # Releases should always be stamped with version control info
 # This command assumes node on the path and is a workaround for
 # https://github.com/bazelbuild/bazel/issues/4802
-build:release --workspace_status_command="node ./tools/bazel_stamp_vars.js"
+build:release --workspace_status_command="yarn -s ng-dev release build-env-stamp"
 
 ###############################
 # Output                      #


### PR DESCRIPTION
Some initial preparation for building the packages with bazel. Currently unused.