### PR TITLE
fix(@angular-devkit/core): remove deprecated isObservable function

### DIFF
--- a/etc/api/angular_devkit/core/src/_golden-api.d.ts
+++ b/etc/api/angular_devkit/core/src/_golden-api.d.ts
@@ -308,8 +308,6 @@ export declare function isJsonArray(value: JsonValue): value is JsonArray;
 
 export declare function isJsonObject(value: JsonValue): value is JsonObject;
 
-export declare function isObservable(obj: any | Observable<any>): obj is Observable<any>;
-
 export declare function isPromise(obj: any): obj is Promise<any>;
 
 export declare function join(p1: Path, ...others: string[]): Path;

--- a/packages/angular_devkit/core/src/utils/lang.ts
+++ b/packages/angular_devkit/core/src/utils/lang.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 // Borrowed from @angular/core
-import { Observable } from 'rxjs';
 
 /**
  * Determine if the argument is shaped like a Promise
@@ -16,21 +15,4 @@ export function isPromise(obj: any): obj is Promise<any> {
   // allow any Promise/A+ compliant thenable.
   // It's up to the caller to ensure that obj.then conforms to the spec
   return !!obj && typeof obj.then === 'function';
-}
-
-/**
- * Determine if the argument is an Observable
- * @deprecated as of 8.0; use rxjs' built-in version
- */
-// tslint:disable-next-line:no-any
-export function isObservable(obj: any | Observable<any>): obj is Observable<any> {
-  if (!obj || typeof obj !== 'object') {
-    return false;
-  }
-
-  if (Symbol.observable && Symbol.observable in obj) {
-    return true;
-  }
-
-  return typeof obj.subscribe === 'function';
 }


### PR DESCRIPTION
BREAKING CHANGE:
Deprecated `isObservable` function removed.  As an alternative, use `isObservable` from the `rxjs` package.
NOTE: This change does not affect application development.