### PR TITLE
refactor(@angular-devkit/build-angular): remove unneeded 10.1 localize checks

### DIFF
--- a/packages/angular_devkit/build_angular/src/extract-i18n/index.ts
+++ b/packages/angular_devkit/build_angular/src/extract-i18n/index.ts
@@ -15,7 +15,6 @@ import { JsonObject } from '@angular-devkit/core';
 import type { ɵParsedMessage as LocalizeMessage } from '@angular/localize';
 import * as fs from 'fs';
 import * as path from 'path';
-import { gte as semverGte } from 'semver';
 import * as webpack from 'webpack';
 import { Schema as BrowserBuilderOptions } from '../browser/schema';
 import { ExecutionTransformer } from '../transforms';
@@ -212,16 +211,12 @@ export async function execute(
   );
 
   if (usingIvy) {
-    let validLocalizePackage = false;
     try {
-      const { version: localizeVersion } = require('@angular/localize/package.json');
-      validLocalizePackage = semverGte(localizeVersion, '10.1.0-next.0', { includePrerelease: true });
-    } catch {}
-
-    if (!validLocalizePackage) {
+      require.resolve('@angular/localize');
+    } catch {
       return {
         success: false,
-        error: `Ivy extraction requires the '@angular/localize' package version 10.1.0 or higher.`,
+        error: `Ivy extraction requires the '@angular/localize' package.`,
        };
     }
   }

--- a/tests/legacy-cli/e2e/tests/i18n/extract-ivy.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/extract-ivy.ts
@@ -21,15 +21,8 @@ export default async function() {
 
   // Should fail with --ivy flag if `@angular/localize` is missing
   const { message: message1 } = await expectToFail(() => ng('xi18n'));
-  if (!message1.includes(`Ivy extraction requires the '@angular/localize' package version 10.1.0 or higher.`)) {
+  if (!message1.includes(`Ivy extraction requires the '@angular/localize' package.`)) {
     throw new Error('Expected localize package error message when missing');
-  }
-
-  // Should fail with --ivy flag if `@angular/localize` is wrong version
-  await npm('install', '@angular/localize@9');
-  const { message: message2 } = await expectToFail(() => ng('xi18n', '--ivy'));
-  if (!message2.includes(`Ivy extraction requires the '@angular/localize' package version 10.1.0 or higher.`)) {
-    throw new Error('Expected localize package error message when wrong version');
   }
 
   // Install correct version


### PR DESCRIPTION
Now that 11.0 is the minimum supported version, the 10.1 support checks for the `@angular/localize` package can be removed.