### PR TITLE
docs(@angular-devkit/build-ng-packagr): Add deprecation message

### DIFF
--- a/packages/angular_devkit/build_ng_packagr/README.md
+++ b/packages/angular_devkit/build_ng_packagr/README.md
@@ -1,3 +1,3 @@
 # Angular Build Architect for ng-packagr
 
-WIP
+This package has been deprecated. Please use the `ng-packagr` builder from `@angular-devkit/build-angular` instead.


### PR DESCRIPTION
Add deprecation message so that it shows up on https://www.npmjs.com/package/@angular-devkit/build-ng-packagr