### PR TITLE
build: add required fields to dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,14 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
+    schedule:
+      interval: "daily"
     commit-message:
       prefix: "build"
     labels:
       - "comp: build & ci"
       - "PR target: master & patch"
       - "PR action: merge"
+    # Disable version updates
+    # This does not affect security updates
+    open-pull-requests-limit: 0


### PR DESCRIPTION
The configuration is currently only used for automated security updates.
For information about the `open-pull-requests-limit` option: https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates#open-pull-requests-limit