### PR TITLE
fix(@angular-devkit/build-angular): use IE11 as oldest browser when downlevelling

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/process-bundle.ts
+++ b/packages/angular_devkit/build_angular/src/utils/process-bundle.ts
@@ -922,8 +922,8 @@ async function loadLocaleData(path: string, optimize: boolean, es5: boolean): Pr
         require.resolve('@babel/preset-env'),
         {
           bugfixes: true,
-          // IE 9 is the oldest supported browser
-          targets: es5 ? { ie: '9' } : { esmodules: true },
+          // IE 11 is the oldest supported browser
+          targets: es5 ? { ie: '11' } : { esmodules: true },
         },
       ],
     ],


### PR DESCRIPTION
IE9 and 10 are no longer supported.