### PR TITLE
Revert "test(@angular/cli): disable Webpack 5 e2e tests"

### DIFF
--- a/tests/legacy-cli/e2e/tests/misc/webpack-5.ts
+++ b/tests/legacy-cli/e2e/tests/misc/webpack-5.ts
@@ -3,10 +3,6 @@ import { killAllProcesses, ng, silentYarn } from '../../utils/process';
 import { ngServe, updateJsonFile } from '../../utils/project';
 
 export default async function() {
-  // Currently disabled as it breaks tslib 2.0.2
-  // Cannot destructure property '__extends' of '_tslib_js__WEBPACK_IMPORTED_MODULE_0___default(...)' as it is undefined.
-  return;
-
   // Setup project for yarn usage
   await rimraf('node_modules');
   await updateJsonFile('package.json', (json) => {


### PR DESCRIPTION
Reverts angular/angular-cli#18987

Tslib 2.0.3 works-around this issue.

Full discussion here: https://github.com/webpack/webpack/issues/11613