### PR TITLE
fix: @angular/cli web worker schematic

### DIFF
--- a/packages/schematics/angular/web-worker/files/worker-tsconfig/tsconfig.worker.json.template
+++ b/packages/schematics/angular/web-worker/files/worker-tsconfig/tsconfig.worker.json.template
@@ -1,6 +1,6 @@
 /* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
-  "extends": "<%= relativePathToWorkspaceRoot %>/tsconfig.json",
+  "extends": "<%= relativePathToWorkspaceRoot %>/tsconfig.base.json",
   "compilerOptions": {
     "outDir": "<%= relativePathToWorkspaceRoot %>/out-tsc/worker",
     "lib": [


### PR DESCRIPTION
web worker schematics are missing base suffix in tsconfig