### PR TITLE
fix(@angular/cli): resolve packages package.json from workspace directory

### DIFF
--- a/packages/angular/cli/utilities/package-tree.ts
+++ b/packages/angular/cli/utilities/package-tree.ts
@@ -54,7 +54,7 @@ export interface PackageTreeNode {
 export async function readPackageJson(packageJsonPath: string): Promise<PackageJson | undefined> {
   try {
     return await readJSON(packageJsonPath);
-  } catch (err) {
+  } catch {
     return undefined;
   }
 }
@@ -62,16 +62,16 @@ export async function readPackageJson(packageJsonPath: string): Promise<PackageJ
 export function findPackageJson(workspaceDir: string, packageName: string) {
   try {
     // avoid require.resolve here, see: https://github.com/angular/angular-cli/pull/18610#issuecomment-681980185
-    const packageJsonPath = resolve.sync(`${packageName}/package.json`, { paths: [workspaceDir] });
+    const packageJsonPath = resolve.sync(`${packageName}/package.json`, { basedir: workspaceDir });
 
     return packageJsonPath;
-  } catch (err) {
+  } catch {
     return undefined;
   }
 }
 
 export async function getProjectDependencies(dir: string) {
-  const pkgJsonPath = resolve.sync(join(dir, `package.json`));
+  const pkgJsonPath = join(dir, 'package.json');
   if (!pkgJsonPath) {
     throw new Error('Could not find package.json');
   }

--- a/packages/schematics/update/update/index.ts
+++ b/packages/schematics/update/update/index.ts
@@ -531,7 +531,7 @@ function _usageMessage(
   });
 
   logger.info(
-    `There might be additional packages which don't provide 'ng update' capabilities that are outdated.\n`
+    `\nThere might be additional packages which don't provide 'ng update' capabilities that are outdated.\n`
     + `You can update the addition packages by running the update command of your package manager.`,
   );
 


### PR DESCRIPTION

Unlike `require.resolve`, the `resolve` package `paths` is only used as a fallback when the package is not resolved from the `basedir`,

Previously this resulted in the temporary version of CLI being resolved here which resulted in `ng update` incorrectly stating that there are no updates.