### PR TITLE
build: only include `packages/angular_devkit/build_angular/src/typings.d.ts` during bazel builds

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -49,6 +49,7 @@
     "suppressTsconfigOverrideWarnings": true
   },
   "exclude": [
+    "packages/angular_devkit/build_angular/src/typings.d.ts",
     "bazel-out/**/*",
     "dist/**/*",
     "dist-schema/**",


### PR DESCRIPTION

`packages/angular_devkit/build_angular/src/typings.d.ts` is only needed for a Bazel build to workaround https://github.com/bazelbuild/rules_nodejs/issues/1033

Including this typings in a non Bazel build creates broken triple slash references https://unpkg.com/browse/@angular-devkit/build-angular@0.1100.0-next.6/src/utils/process-bundle.d.ts

Closes #19072