### PR TITLE
refactor(@angular-devkit/build-angular): simplify global_defs usage f…

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
@@ -366,28 +366,10 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
   }
 
   if (scriptsOptimization) {
-    let angularGlobalDefinitions = {
-      ngDevMode: false,
-      ngI18nClosureMode: false,
-    };
-
-    // Try to load known global definitions from @angular/compiler-cli.
-    const GLOBAL_DEFS_FOR_TERSER = require('@angular/compiler-cli').GLOBAL_DEFS_FOR_TERSER;
-    if (GLOBAL_DEFS_FOR_TERSER) {
-      angularGlobalDefinitions = GLOBAL_DEFS_FOR_TERSER;
-    }
-
-    if (buildOptions.aot) {
-      // Also try to load AOT-only global definitions.
-      const GLOBAL_DEFS_FOR_TERSER_WITH_AOT = require('@angular/compiler-cli')
-        .GLOBAL_DEFS_FOR_TERSER_WITH_AOT;
-      if (GLOBAL_DEFS_FOR_TERSER_WITH_AOT) {
-        angularGlobalDefinitions = {
-          ...angularGlobalDefinitions,
-          ...GLOBAL_DEFS_FOR_TERSER_WITH_AOT,
-        };
-      }
-    }
+    const { GLOBAL_DEFS_FOR_TERSER, GLOBAL_DEFS_FOR_TERSER_WITH_AOT } = require('@angular/compiler-cli');
+    const angularGlobalDefinitions = buildOptions.aot
+      ? GLOBAL_DEFS_FOR_TERSER_WITH_AOT
+      : GLOBAL_DEFS_FOR_TERSER;
 
     // TODO: Investigate why this fails for some packages: wco.supportES2015 ? 6 : 5;
     const terserEcma = 5;


### PR DESCRIPTION
…rom `@angular/compiler-cli`.

This change results in the same options being set. See: https://github.com/angular/angular/blob/66e6b932d818a161bd19c03e3e854a22552a7db2/packages/compiler-cli/src/tooling.ts#L25-L34