### PR TITLE
fix(@angular-devkit/build-angular): set HTML lang attribute when serving

### DIFF
--- a/packages/angular_devkit/build_angular/src/dev-server/index.ts
+++ b/packages/angular_devkit/build_angular/src/dev-server/index.ts
@@ -92,6 +92,7 @@ export function serveWebpackBrowser(
     webpackConfig: webpack.Configuration;
     webpackDevServerConfig: WebpackDevServer.Configuration;
     projectRoot: string;
+    locale: string | undefined;
   }> {
     // Get the browser configuration from the target name.
     const rawBrowserOptions = await context.getTargetOptions(browserTarget);
@@ -151,11 +152,13 @@ export function serveWebpackBrowser(
       webpackConfig,
       webpackDevServerConfig,
       projectRoot,
+      locale:
+        browserOptions.i18nLocale || (i18n.shouldInline ? [...i18n.inlineLocales][0] : undefined),
     };
   }
 
   return from(setup()).pipe(
-    switchMap(({ browserOptions, webpackConfig, webpackDevServerConfig, projectRoot }) => {
+    switchMap(({ browserOptions, webpackConfig, webpackDevServerConfig, projectRoot, locale }) => {
       // Resolve public host and client address.
       let clientAddress = url.parse(`${options.ssl ? 'https' : 'http'}://0.0.0.0:0`);
       if (options.publicHost) {
@@ -212,7 +215,7 @@ export function serveWebpackBrowser(
             noModuleEntrypoints: ['polyfills-es5'],
             postTransform: transforms.indexHtml,
             crossOrigin: browserOptions.crossOrigin,
-            lang: browserOptions.i18nLocale,
+            lang: locale,
           }),
         );
       }


### PR DESCRIPTION
When using the non-deprecated localization options, the development server was not properly setting the HTML `lang` attribute for the application.  This change ensures that the active locale is used within the application's index HTML file.

Closes #18094