### PR TITLE
fix(@ngtools/webpack): improve bad component resource error message

### DIFF
--- a/packages/ngtools/webpack/src/resource_loader.ts
+++ b/packages/ngtools/webpack/src/resource_loader.ts
@@ -56,7 +56,7 @@ export class WebpackResourceLoader {
     // Simple sanity check.
     if (filePath.match(/\.[jt]s$/)) {
       return Promise.reject(
-        'Cannot use a JavaScript or TypeScript file for styleUrl or templateUrl.',
+        `Cannot use a JavaScript or TypeScript file (${filePath}) in a component's styleUrls or templateUrl.`,
       );
     }
 


### PR DESCRIPTION
The error message for when a TypeScript or JavaScript file is incorrectly used as a style or template within a component will now also provide the name of the file being incorrectly used.

Partially addresses: #17728