### PR TITLE
test(@angular/cli): cleanup CDK in add material E2E test

### DIFF
--- a/tests/legacy-cli/e2e/tests/commands/add/add-material.ts
+++ b/tests/legacy-cli/e2e/tests/commands/add/add-material.ts
@@ -1,4 +1,5 @@
 import { expectFileToMatch, rimraf } from '../../../utils/fs';
+import { uninstallPackage } from '../../../utils/packages';
 import { ng } from '../../../utils/process';
 import { isPrereleaseCli } from '../../../utils/project';
 
@@ -24,6 +25,10 @@ export default async function () {
   if (!output1.stdout.includes('Skipping installation: Package already installed')) {
     throw new Error('Installation was not skipped');
   }
+
+  // Clean up existing cdk package
+  // Not doing so can cause adding material to fail if an incompatible cdk is present
+  await uninstallPackage('@angular/cdk');
 
   const output2 = await ng('add', '@angular/material@latest');
   if (output2.stdout.includes('Skipping installation: Package already installed')) {


### PR DESCRIPTION
Adding material to a project can fail if an incompatible version of the CDK is already present in the project.  This change adjusts the E2E test to include extra package cleanup between test cases.