### PR TITLE
fix(@angular-devkit/build-angular): correctly reference hmr-accept.js file in windows error

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/plugins/hmr/hmr-loader.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/plugins/hmr/hmr-loader.ts
@@ -9,7 +9,7 @@
 import { join } from 'path';
 
 export const HmrLoader = __filename;
-const hmrAcceptPath = join(__dirname, './hmr-accept.js');
+const hmrAcceptPath = join(__dirname, './hmr-accept.js').replace(/\\/g, '/');
 
 export default function (
   this: import('webpack').loader.LoaderContext,

--- a/tests/legacy-cli/e2e/tests/basic/serve.ts
+++ b/tests/legacy-cli/e2e/tests/basic/serve.ts
@@ -1,0 +1,26 @@
+import { request } from '../../utils/http';
+import { killAllProcesses } from '../../utils/process';
+import { ngServe } from '../../utils/project';
+
+export default async function () {
+  try {
+    // Serve works without HMR
+    await ngServe('--no-hmr');
+    await verifyResponse();
+    killAllProcesses();
+
+    // Serve works with HMR
+    await ngServe('--hmr');
+    await verifyResponse();
+  } finally {
+    killAllProcesses();
+  }
+}
+
+async function verifyResponse(): Promise<void> {
+  const response = await request('http://localhost:4200/');
+
+  if (!/<app-root><\/app-root>/.test(response)) {
+    throw new Error('Response does not match expected value.');
+  }
+}


### PR DESCRIPTION
Backslashes need to be changed to forward slashes for absolute imports to work in Windows.

Closes: https://github.com/angular/angular-cli/issues/19099