### PR TITLE
fix(@schematics/angular): allow inlineTemplate/inlineStyle with minimal application

### DIFF
--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -103,10 +103,10 @@ function addAppToWorkspaceFile(options: ApplicationOptions, appDir: string): Rul
     || options.minimal
     || options.style !== Style.Css) {
     const componentSchematicsOptions: JsonObject = {};
-    if (options.inlineTemplate || options.minimal) {
+    if (options.inlineTemplate ?? options.minimal) {
       componentSchematicsOptions.inlineTemplate = true;
     }
-    if (options.inlineStyle || options.minimal) {
+    if (options.inlineStyle ?? options.minimal) {
       componentSchematicsOptions.inlineStyle = true;
     }
     if (options.style && options.style !== Style.Css) {
@@ -289,10 +289,11 @@ export default function (options: ApplicationOptions): Rule {
         viewEncapsulation: options.viewEncapsulation,
       } :
       {
-        inlineStyle: true,
-        inlineTemplate: true,
+        inlineStyle: options.inlineStyle ?? true,
+        inlineTemplate: options.inlineTemplate ?? true,
         skipTests: true,
         style: options.style,
+        viewEncapsulation: options.viewEncapsulation,
       };
 
     const workspace = await getWorkspace(host);

--- a/packages/schematics/angular/application/index_spec.ts
+++ b/packages/schematics/angular/application/index_spec.ts
@@ -32,8 +32,6 @@ describe('Application Schematic', () => {
 
   const defaultOptions: ApplicationOptions = {
     name: 'foo',
-    inlineStyle: false,
-    inlineTemplate: false,
     routing: false,
     skipPackageJson: false,
   };
@@ -206,6 +204,30 @@ describe('Application Schematic', () => {
     });
   });
 
+  it('minimal=true allows inlineStyle=false when configuring the schematics options for components', async () => {
+    const options = { ...defaultOptions, minimal: true, inlineStyle: false };
+    const tree = await schematicRunner.runSchematicAsync('application', options, workspaceTree)
+      .toPromise();
+    const config = JSON.parse(tree.readContent('/angular.json'));
+    const schematics = config.projects.foo.schematics;
+    expect(schematics['@schematics/angular:component']).toEqual({
+      inlineTemplate: true,
+      skipTests: true,
+    });
+  });
+
+  it('minimal=true allows inlineTemplate=false when configuring the schematics options for components', async () => {
+    const options = { ...defaultOptions, minimal: true, inlineTemplate: false };
+    const tree = await schematicRunner.runSchematicAsync('application', options, workspaceTree)
+      .toPromise();
+    const config = JSON.parse(tree.readContent('/angular.json'));
+    const schematics = config.projects.foo.schematics;
+    expect(schematics['@schematics/angular:component']).toEqual({
+      inlineStyle: true,
+      skipTests: true,
+    });
+  });
+
   it('should create correct files when using minimal', async () => {
     const options = { ...defaultOptions, minimal: true };
     const tree = await schematicRunner.runSchematicAsync('application', options, workspaceTree)
@@ -231,6 +253,64 @@ describe('Application Schematic', () => {
       '/projects/foo/src/polyfills.ts',
       '/projects/foo/src/styles.css',
       '/projects/foo/src/app/app.module.ts',
+      '/projects/foo/src/app/app.component.ts',
+    ]));
+  });
+
+  it('should create correct files when using minimal and inlineStyle=false', async () => {
+    const options = { ...defaultOptions, minimal: true, inlineStyle: false };
+    const tree = await schematicRunner.runSchematicAsync('application', options, workspaceTree)
+      .toPromise();
+    const files = tree.files;
+    [
+      '/projects/foo/tsconfig.spec.json',
+      '/projects/foo/tslint.json',
+      '/projects/foo/karma.conf.js',
+      '/projects/foo/src/test.ts',
+      '/projects/foo/src/app/app.component.html',
+      '/projects/foo/src/app/app.component.spec.ts',
+    ].forEach(x => expect(files).not.toContain(x));
+
+    expect(files).toEqual(jasmine.arrayContaining([
+      '/projects/foo/tsconfig.app.json',
+      '/projects/foo/src/environments/environment.ts',
+      '/projects/foo/src/environments/environment.prod.ts',
+      '/projects/foo/src/favicon.ico',
+      '/projects/foo/src/index.html',
+      '/projects/foo/src/main.ts',
+      '/projects/foo/src/polyfills.ts',
+      '/projects/foo/src/styles.css',
+      '/projects/foo/src/app/app.module.ts',
+      '/projects/foo/src/app/app.component.css',
+      '/projects/foo/src/app/app.component.ts',
+    ]));
+  });
+
+  it('should create correct files when using minimal and inlineTemplate=false', async () => {
+    const options = { ...defaultOptions, minimal: true, inlineTemplate: false };
+    const tree = await schematicRunner.runSchematicAsync('application', options, workspaceTree)
+      .toPromise();
+    const files = tree.files;
+    [
+      '/projects/foo/tsconfig.spec.json',
+      '/projects/foo/tslint.json',
+      '/projects/foo/karma.conf.js',
+      '/projects/foo/src/test.ts',
+      '/projects/foo/src/app/app.component.css',
+      '/projects/foo/src/app/app.component.spec.ts',
+    ].forEach(x => expect(files).not.toContain(x));
+
+    expect(files).toEqual(jasmine.arrayContaining([
+      '/projects/foo/tsconfig.app.json',
+      '/projects/foo/src/environments/environment.ts',
+      '/projects/foo/src/environments/environment.prod.ts',
+      '/projects/foo/src/favicon.ico',
+      '/projects/foo/src/index.html',
+      '/projects/foo/src/main.ts',
+      '/projects/foo/src/polyfills.ts',
+      '/projects/foo/src/styles.css',
+      '/projects/foo/src/app/app.module.ts',
+      '/projects/foo/src/app/app.component.html',
       '/projects/foo/src/app/app.component.ts',
     ]));
   });

--- a/packages/schematics/angular/application/schema.json
+++ b/packages/schematics/angular/application/schema.json
@@ -22,14 +22,12 @@
     "inlineStyle": {
       "description": "When true, includes styles inline in the root component.ts file. Only CSS styles can be included inline. Default is false, meaning that an external styles file is created and referenced in the root component.ts file.",
       "type": "boolean",
-      "default": false,
       "alias": "s",
       "x-user-analytics": 9
     },
     "inlineTemplate": {
       "description": "When true, includes template inline in the root component.ts file. Default is false, meaning that an external template file is created and referenced in the root component.ts file. ",
       "type": "boolean",
-      "default": false,
       "alias": "t",
       "x-user-analytics": 10
     },

--- a/packages/schematics/angular/ng-new/schema.json
+++ b/packages/schematics/angular/ng-new/schema.json
@@ -66,14 +66,12 @@
     "inlineStyle": {
       "description": "When true, includes styles inline in the component TS file. By default, an external styles file is created and referenced in the component TS file.",
       "type": "boolean",
-      "default": false,
       "alias": "s",
       "x-user-analytics": 9
     },
     "inlineTemplate": {
       "description": "When true, includes template inline in the component TS file. By default, an external template file is created and referenced in the component TS file.",
       "type": "boolean",
-      "default": false,
       "alias": "t",
       "x-user-analytics": 10
     },


### PR DESCRIPTION
This change allows `inlineTemplate=false` and/or `inlineStyle=false` to be used with the `minimal` option when creating an application either by `ng new` or `ng generate application`.

Closes #17528