### PR TITLE
Remove TypeScript 3.9 support

### DIFF
--- a/integration/angular_cli/package.json
+++ b/integration/angular_cli/package.json
@@ -43,7 +43,7 @@
     "puppeteer": "5.2.1",
     "ts-node": "~8.3.0",
     "tslint": "~6.1.0",
-    "typescript": "~3.9.2"
+    "typescript": "~4.0.0"
   },
   "resolutions": {
     "rxjs": "6.5.4",

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -84,7 +84,7 @@
     "ng-packagr": "^11.0.0 || ^11.0.0-next",
     "protractor": "^7.0.0",
     "tslint": "^6.1.0",
-    "typescript": ">=3.9 < 4.1"
+    "typescript": "~4.0.0"
   },
   "peerDependenciesMeta": {
     "@angular/localize": {

--- a/packages/ngtools/webpack/package.json
+++ b/packages/ngtools/webpack/package.json
@@ -27,7 +27,7 @@
   },
   "peerDependencies": {
     "@angular/compiler-cli": "^11.0.0 || ^11.0.0-next",
-    "typescript": ">=3.9 < 4.1",
+    "typescript": "~4.0.0",
     "webpack": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Block until https://github.com/angular/angular/pull/39313 is merged.