### PR TITLE
fix(@angular-devkit/build-angular): add a base href to karma debug context

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/plugins/karma-debug.html
+++ b/packages/angular_devkit/build_angular/src/webpack/plugins/karma-debug.html
@@ -9,6 +9,7 @@ just for immediate execution, without reporting to Karma server.
 <head>
 %X_UA_COMPATIBLE%
   <title>Karma DEBUG RUNNER</title>
+  <base href="/">
   <link href="favicon.ico" rel="icon" type="image/x-icon" />
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />


### PR DESCRIPTION
This commits adds a base href value in the karma context iframe used to run unit tests.

It solves #19116  where a unit test throws:

```
No base href set. Please provide a value for the APP_BASE_HREF token or add a base element to the document.
```

Even if the application is fine. This is because the index.html from Angular CLI contains a base href value, but not the Karma context iframe. So when adding a unit test with a testing module that imports a NgModule, for example AppModule, which itself imports RouterModule, the unit test used to throw an error (regression appeared in router 3.1).

That could be solved by either adding `RouterTestingModule` to the testing module, or by adding a provider `{ provide: APP_BASE_HREF, useValue: '/' }`, but required to understand the issue.

This solves the issue in a transparent way: developers won't even encounter the problem anymore.