### PR TITLE
refactor(@angular/cli): rename `ng xi18n` to `ng extract-i18n`

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.md
@@ -27,7 +27,7 @@ Existing issues often contain information about workarounds, resolution, or prog
 - [ ] add
 - [ ] update
 - [ ] lint
-- [ ] xi18n
+- [ ] extract-i18n
 - [ ] run
 - [ ] config
 - [ ] help

--- a/.github/ISSUE_TEMPLATE/2-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.md
@@ -28,7 +28,7 @@ Existing issues often contain information about workarounds, resolution, or prog
 - [ ] add
 - [ ] update
 - [ ] lint
-- [ ] xi18n
+- [ ] extract-i18n
 - [ ] run
 - [ ] config
 - [ ] help

--- a/packages/angular/cli/BUILD.bazel
+++ b/packages/angular/cli/BUILD.bazel
@@ -46,7 +46,7 @@ ts_library(
         "//packages/angular/cli:commands/update.ts",
         "//packages/angular/cli:commands/version.ts",
         "//packages/angular/cli:commands/run.ts",
-        "//packages/angular/cli:commands/xi18n.ts",
+        "//packages/angular/cli:commands/extract-i18n.ts",
         # @external_end
     ],
     data = glob(
@@ -223,8 +223,8 @@ ts_json_schema(
 )
 
 ts_json_schema(
-    name = "xi18n_schema",
-    src = "commands/xi18n.json",
+    name = "extract-i18n_schema",
+    src = "commands/extract-i18n.json",
     data = [
         "commands/definitions.json",
     ],

--- a/packages/angular/cli/commands.json
+++ b/packages/angular/cli/commands.json
@@ -6,6 +6,7 @@
   "deploy": "./commands/deploy.json",
   "doc": "./commands/doc.json",
   "e2e": "./commands/e2e.json",
+  "extract-i18n": "./commands/extract-i18n.json",
   "make-this-awesome": "./commands/easter-egg.json",
   "generate": "./commands/generate.json",
   "help": "./commands/help.json",
@@ -15,6 +16,5 @@
   "serve": "./commands/serve.json",
   "test": "./commands/test.json",
   "update": "./commands/update.json",
-  "version": "./commands/version.json",
-  "xi18n": "./commands/xi18n.json"
+  "version": "./commands/version.json"
 }

--- a/packages/angular/cli/commands/extract-i18n-impl.ts
+++ b/packages/angular/cli/commands/extract-i18n-impl.ts
@@ -8,12 +8,12 @@
 
 import { ArchitectCommand } from '../models/architect-command';
 import { Arguments } from '../models/interface';
-import { Schema as Xi18nCommandSchema } from './xi18n';
+import { Schema as ExtractI18nCommandSchema } from './extract-i18n';
 
-export class Xi18nCommand extends ArchitectCommand<Xi18nCommandSchema> {
+export class ExtractI18nCommand extends ArchitectCommand<ExtractI18nCommandSchema> {
   public readonly target = 'extract-i18n';
 
-  public async run(options: Xi18nCommandSchema & Arguments) {
+  public async run(options: ExtractI18nCommandSchema & Arguments) {
     const version = process.version.substr(1).split('.');
     if (Number(version[0]) === 12 && Number(version[1]) === 0) {
       this.logger.error(
@@ -21,6 +21,11 @@ export class Xi18nCommand extends ArchitectCommand<Xi18nCommandSchema> {
         + 'Please upgrade to Node.js 12.1 or later.');
 
       return 1;
+    }
+
+    const commandName = process.argv[2];
+    if (['xi18n', 'i18n-extract'].includes(commandName)) {
+      this.logger.warn(`Warning: "ng ${commandName}" has been deprecated and will be removed in a future major version. Please use "ng extract-i18n" instead.`);
     }
 
     return this.runArchitectTarget(options);

--- a/packages/angular/cli/commands/extract-i18n.json
+++ b/packages/angular/cli/commands/extract-i18n.json
@@ -1,13 +1,13 @@
 {
   "$schema": "http://json-schema.org/schema",
-  "$id": "ng-cli://commands/xi18n.json",
+  "$id": "ng-cli://commands/extract-i18n.json",
   "description": "Extracts i18n messages from source code.",
   "$longDescription": "",
 
-  "$aliases": ["i18n-extract"],
+  "$aliases": ["i18n-extract", "xi18n"],
   "$scope": "in",
   "$type": "architect",
-  "$impl": "./xi18n-impl#Xi18nCommand",
+  "$impl": "./extract-i18n-impl#ExtractI18nCommand",
 
   "type": "object",
   "allOf": [

--- a/packages/angular/cli/models/command-runner.ts
+++ b/packages/angular/cli/models/command-runner.ts
@@ -39,6 +39,7 @@ const standardCommands = {
   'config': '../commands/config.json',
   'doc': '../commands/doc.json',
   'e2e': '../commands/e2e.json',
+  'extract-i18n': '../commands/extract-i18n.json',
   'make-this-awesome': '../commands/easter-egg.json',
   'generate': '../commands/generate.json',
   'help': '../commands/help.json',
@@ -49,7 +50,6 @@ const standardCommands = {
   'test': '../commands/test.json',
   'update': '../commands/update.json',
   'version': '../commands/version.json',
-  'xi18n': '../commands/xi18n.json',
 };
 
 export interface CommandMapOptions {

--- a/tests/legacy-cli/e2e/tests/i18n/extract-default.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/extract-default.ts
@@ -15,7 +15,7 @@ export default async function() {
     join('src/app/i18n-test', 'i18n-test.component.html'),
     '<p i18n>Hello world</p>',
   );
-  await ng('xi18n');
+  await ng('extract-i18n');
   await expectFileToExist('messages.xlf');
   await expectFileToMatch('messages.xlf', /Hello world/);
 }

--- a/tests/legacy-cli/e2e/tests/i18n/extract-errors.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/extract-errors.ts
@@ -16,7 +16,7 @@ export default async function () {
     '<p i18n>Hello world <span i18n>inner</span></p>',
   );
 
-  const { message } = await expectToFail(() => ng('xi18n'));
+  const { message } = await expectToFail(() => ng('extract-i18n'));
 
   const veProject = getGlobalVariable('argv')['ve'];
   const msg = veProject

--- a/tests/legacy-cli/e2e/tests/i18n/extract-ivy-libraries.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/extract-ivy-libraries.ts
@@ -61,7 +61,7 @@ export default async function() {
   await installPackage(localizeVersion);
 
   // Extract messages
-  await ng('xi18n', '--ivy');
+  await ng('extract-i18n', '--ivy');
   await expectFileToMatch('messages.xlf', 'Hello world');
   await expectFileToMatch('messages.xlf', 'i18n-lib-test works!');
   await expectFileToMatch('messages.xlf', 'src/app/app.component.html');

--- a/tests/legacy-cli/e2e/tests/i18n/extract-ivy.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/extract-ivy.ts
@@ -21,7 +21,7 @@ export default async function() {
   );
 
   // Should fail with --ivy flag if `@angular/localize` is missing
-  const { message: message1 } = await expectToFail(() => ng('xi18n'));
+  const { message: message1 } = await expectToFail(() => ng('extract-i18n'));
   if (!message1.includes(`Ivy extraction requires the '@angular/localize' package.`)) {
     throw new Error('Expected localize package error message when missing');
   }
@@ -34,13 +34,13 @@ export default async function() {
   await installPackage(localizeVersion);
 
   // Should show ivy enabled application warning without --ivy flag
-  const { stderr: message3 } = await ng('xi18n', '--no-ivy');
+  const { stderr: message3 } = await ng('extract-i18n', '--no-ivy');
   if (!message3.includes(`Ivy extraction not enabled but application is Ivy enabled.`)) {
     throw new Error('Expected ivy enabled application warning');
   }
 
   // Should not show any warnings when extracting
-  const { stderr: message5 } = await ng('xi18n', '--ivy');
+  const { stderr: message5 } = await ng('extract-i18n', '--ivy');
   if (message5.includes('WARNING')) {
     throw new Error('Expected no warnings to be shown');
   }
@@ -53,7 +53,7 @@ export default async function() {
   });
 
   // Should show ivy disabled application warning with --ivy flag and enableIvy false
-  const { message: message4 } = await expectToFail(() => ng('xi18n', '--ivy'));
+  const { message: message4 } = await expectToFail(() => ng('extract-i18n', '--ivy'));
   if (!message4.includes(`Ivy extraction enabled but application is not Ivy enabled.`)) {
     throw new Error('Expected ivy disabled application warning');
   }

--- a/tests/legacy-cli/e2e/tests/i18n/extract-locale.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/extract-locale.ts
@@ -14,7 +14,7 @@ export default function() {
     .then(() => writeFile(
       join('src/app/i18n-test', 'i18n-test.component.html'),
       '<p i18n>Hello world</p>'))
-    .then(() => ng('xi18n', '--i18n-locale', 'fr'))
+    .then(() => ng('extract-i18n', '--i18n-locale', 'fr'))
     .then((output) => {
       if (!output.stderr.match(/starting from Angular v4/)) {
         return expectFileToMatch('messages.xlf', 'source-language="fr"');

--- a/tests/legacy-cli/e2e/tests/i18n/extract-outfile.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/extract-outfile.ts
@@ -14,6 +14,6 @@ export default async function () {
     join('src/app/i18n-test', 'i18n-test.component.html'),
     '<p i18n>Hello world</p>',
   );
-  await ng('xi18n', '--out-file', 'messages.fr.xlf');
+  await ng('extract-i18n', '--out-file', 'messages.fr.xlf');
   await expectFileToMatch('messages.fr.xlf', 'Hello world');
 }

--- a/tests/legacy-cli/e2e/tests/i18n/extract-xmb.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/extract-xmb.ts
@@ -17,7 +17,7 @@ export default function() {
     .then(() =>
       writeFile(join('src/app/i18n-test', 'i18n-test.component.html'), '<p i18n>Hello world</p>'),
     )
-    .then(() => ng('xi18n', '--format', 'xmb'))
+    .then(() => ng('extract-i18n', '--format', 'xmb'))
     .then(() => expectFileToExist('messages.xmb'))
     .then(() => expectFileToMatch('messages.xmb', /Hello world/));
 }

--- a/tests/legacy-cli/e2e/tests/i18n/ivy-localize-app-shell.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/ivy-localize-app-shell.ts
@@ -104,7 +104,7 @@ export default async function () {
   );
 
   // Extract the translation messages and copy them for each language.
-  await ng('xi18n', '--output-path=src/locale');
+  await ng('extract-i18n', '--output-path=src/locale');
   await expectFileToExist('src/locale/messages.xlf');
   await expectFileToMatch('src/locale/messages.xlf', `source-language="en-US"`);
   await expectFileToMatch('src/locale/messages.xlf', `An introduction header for this sample`);

--- a/tests/legacy-cli/e2e/tests/i18n/ivy-localize-serviceworker.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/ivy-localize-serviceworker.ts
@@ -119,7 +119,7 @@ export default async function() {
   );
 
   // Extract the translation messages and copy them for each language.
-  await ng('xi18n', '--output-path=src/locale');
+  await ng('extract-i18n', '--output-path=src/locale');
   await expectFileToExist('src/locale/messages.xlf');
   await expectFileToMatch('src/locale/messages.xlf', `source-language="en-US"`);
   await expectFileToMatch('src/locale/messages.xlf', `An introduction header for this sample`);

--- a/tests/legacy-cli/e2e/tests/i18n/legacy.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/legacy.ts
@@ -219,7 +219,7 @@ export async function setupI18nConfig(useLocalize = true, format: keyof typeof f
 
   // Extract the translation messages.
   await ng(
-    'xi18n',
+    'extract-i18n',
     '--output-path=src/locale',
     `--format=${format}`,
   );

--- a/tests/legacy-cli/e2e/utils/process.ts
+++ b/tests/legacy-cli/e2e/utils/process.ts
@@ -187,7 +187,7 @@ export function execAndWaitForOutputToMatch(cmd: string, args: string[], match: 
 export function ng(...args: string[]) {
   const argv = getGlobalVariable('argv');
   const maybeSilentNg = argv['nosilent'] ? noSilentNg : silentNg;
-  if (['build', 'serve', 'test', 'e2e', 'xi18n'].indexOf(args[0]) != -1) {
+  if (['build', 'serve', 'test', 'e2e', 'extract-i18n'].indexOf(args[0]) != -1) {
     if (args[0] == 'e2e') {
       // Wait 1 second before running any end-to-end test.
       return new Promise(resolve => setTimeout(resolve, 1000))


### PR DESCRIPTION


`ng i18n-extract` and `ng xi18n` has been deprecated in favor of `ng extract-i18n` to have a better intuitive naming and match the architect key in `angular.json`.