### PR TITLE
fix(@angular/cli): include deprecated option in JSON help

### DIFF
--- a/packages/angular/cli/models/interface.ts
+++ b/packages/angular/cli/models/interface.ts
@@ -153,6 +153,12 @@ export interface Option {
    * If this is falsey, do not report this option.
    */
   userAnalytics?: number;
+
+  /**
+   * Deprecation. If this flag is not false a warning will be shown on the console. Either `true`
+   * or a string to show the user as a notice.
+  */
+  deprecated?: boolean | string;
 }
 
 /**

--- a/packages/angular/cli/utilities/json-schema.ts
+++ b/packages/angular/cli/utilities/json-schema.ts
@@ -251,6 +251,11 @@ export async function parseJsonSchemaToOptions(
     const xUserAnalytics = current['x-user-analytics'];
     const userAnalytics = typeof xUserAnalytics == 'number' ? xUserAnalytics : undefined;
 
+    // Deprecated is set only if it's true or a string.
+    const xDeprecated = current['x-deprecated'];
+    const deprecated = (xDeprecated === true || typeof xDeprecated === 'string')
+      ? xDeprecated : undefined;
+
     const option: Option = {
       name,
       description: '' + (current.description === undefined ? '' : current.description),
@@ -262,6 +267,7 @@ export async function parseJsonSchemaToOptions(
       ...format !== undefined ? { format } : {},
       hidden,
       ...userAnalytics ? { userAnalytics } : {},
+      ...deprecated !== undefined ? { deprecated } : {},
       ...positional !== undefined ? { positional } : {},
     };
 


### PR DESCRIPTION
This option is used to mark deprecated options as such in AIO.