### PR TITLE
fix(@angular/cli): skip searching deprecated packages with ng add

### DIFF
--- a/packages/angular/cli/commands/add-impl.ts
+++ b/packages/angular/cli/commands/add-impl.ts
@@ -115,7 +115,7 @@ export class AddCommand extends SchematicCommand<AddCommandSchema> {
       } else if (!latestManifest || (await this.hasMismatchedPeer(latestManifest))) {
         // 'latest' is invalid so search for most recent matching package
         const versionManifests = Object.values(packageMetadata.versions).filter(
-          (value: PackageManifest) => !prerelease(value.version),
+          (value: PackageManifest) => !prerelease(value.version) && !value.deprecated,
         ) as PackageManifest[];
 
         versionManifests.sort((a, b) => rcompare(a.version, b.version, true));


### PR DESCRIPTION
When attempting to add a package via the add command, packages that have been marked as deprecated will no longer be installed when the deprecated package's peer dependencies match the project's dependencies.

Partially addresses: #17983