### PR TITLE
refactor(@angular-devkit/core): deprecate unused isFile/isDirectory utilities

### DIFF
--- a/packages/angular_devkit/core/node/fs.ts
+++ b/packages/angular_devkit/core/node/fs.ts
@@ -7,6 +7,7 @@
  */
 import { statSync } from 'fs';
 
+/** @deprecated Since v11.0, unused by the Angular tooling */
 export function isFile(filePath: string): boolean {
   let stat;
   try {
@@ -21,7 +22,7 @@ export function isFile(filePath: string): boolean {
   return stat.isFile() || stat.isFIFO();
 }
 
-
+/** @deprecated Since v11.0, unused by the Angular tooling */
 export function isDirectory(filePath: string): boolean {
   let stat;
   try {


### PR DESCRIPTION
`isFile` and `isDirectory` are tooling only APIs for Node.js that are no longer used by the Angular CLI.