### PR TITLE
fix(@angular/cli): coerce prompt answers to requested property types

### DIFF
--- a/etc/api/angular_devkit/core/src/_golden-api.d.ts
+++ b/etc/api/angular_devkit/core/src/_golden-api.d.ts
@@ -715,6 +715,7 @@ export interface PromptDefinition {
     }>;
     message: string;
     multiselect?: boolean;
+    propertyTypes: Set<string>;
     raw?: string | JsonObject;
     type: string;
     validator?: (value: JsonValue) => boolean | string | Promise<boolean | string>;

--- a/packages/angular/cli/models/schematic-command.ts
+++ b/packages/angular/cli/models/schematic-command.ts
@@ -322,6 +322,32 @@ export abstract class SchematicCommand<
             const validator = definition.validator;
             if (validator) {
               question.validate = input => validator(input);
+
+              // Filter allows transformation of the value prior to validation
+              question.filter = async (input) => {
+                for (const type of definition.propertyTypes) {
+                  let value;
+                  switch (type) {
+                    case 'string':
+                      value = String(input);
+                      break;
+                    case 'integer':
+                    case 'number':
+                      value = Number(input);
+                      break;
+                    default:
+                      value = input;
+                      break;
+                  }
+                  // Can be a string if validation fails
+                  const isValid = (await validator(value)) === true;
+                  if (isValid) {
+                    return value;
+                  }
+                }
+
+                return input;
+              };
             }
 
             switch (definition.type) {
@@ -338,6 +364,17 @@ export abstract class SchematicCommand<
                       value: item.value,
                     };
                 });
+                break;
+              case 'input':
+                if (
+                  definition.propertyTypes.size === 1 &&
+                  (definition.propertyTypes.has('number') ||
+                    definition.propertyTypes.has('integer'))
+                ) {
+                  question.type = 'number';
+                } else {
+                  question.type = 'input';
+                }
                 break;
               default:
                 question.type = definition.type;

--- a/packages/angular_devkit/core/src/json/schema/interface.ts
+++ b/packages/angular_devkit/core/src/json/schema/interface.ts
@@ -105,6 +105,7 @@ export interface PromptDefinition {
 
   raw?: string | JsonObject;
   multiselect?: boolean;
+  propertyTypes: Set<string>;
 }
 
 export type PromptProvider = (definitions: Array<PromptDefinition>)

--- a/packages/angular_devkit/core/src/json/schema/registry.ts
+++ b/packages/angular_devkit/core/src/json/schema/registry.ts
@@ -590,6 +590,7 @@ export class CoreSchemaRegistry implements SchemaRegistry {
           raw: schema,
           items,
           multiselect,
+          propertyTypes,
           default:
             typeof (parentSchema as JsonObject).default == 'object' &&
             (parentSchema as JsonObject).default !== null &&


### PR DESCRIPTION
This change converts answers from prompts into the property type requested from the schema.  This allows properties that expect a number to correctly validate when an input prompt is used.