### PR TITLE
fix(@schematics/angular): remove lint fix default value

### DIFF
--- a/packages/schematics/angular/application/schema.json
+++ b/packages/schematics/angular/application/schema.json
@@ -100,7 +100,6 @@
     },
     "lintFix": {
       "type": "boolean",
-      "default": false,
       "description": "When true, applies lint fixes after generating the application.",
       "x-user-analytics": 15,
       "x-deprecated": "Use \"ng lint --fix\" directly instead."

--- a/packages/schematics/angular/component/schema.json
+++ b/packages/schematics/angular/component/schema.json
@@ -139,7 +139,6 @@
     },
     "lintFix": {
       "type": "boolean",
-      "default": false,
       "description": "When true, applies lint fixes after generating the component.",
       "x-user-analytics": 15,
       "x-deprecated": "Use \"ng lint --fix\" directly instead."

--- a/packages/schematics/angular/directive/schema.json
+++ b/packages/schematics/angular/directive/schema.json
@@ -76,7 +76,6 @@
     },
     "lintFix": {
       "type": "boolean",
-      "default": false,
       "description": "When true, applies lint fixes after generating the directive.",
       "x-user-analytics": 15,
       "x-deprecated": "Use \"ng lint --fix\" directly instead."

--- a/packages/schematics/angular/enum/schema.json
+++ b/packages/schematics/angular/enum/schema.json
@@ -29,7 +29,6 @@
     },
     "lintFix": {
       "type": "boolean",
-      "default": false,
       "description": "When true, applies lint fixes after generating the enum.",
       "x-user-analytics": 15,
       "x-deprecated": "Use \"ng lint --fix\" directly instead."

--- a/packages/schematics/angular/guard/schema.json
+++ b/packages/schematics/angular/guard/schema.json
@@ -40,7 +40,6 @@
     },
     "lintFix": {
       "type": "boolean",
-      "default": false,
       "description": "When true, applies lint fixes after generating the guard.",
       "x-user-analytics": 15,
       "x-deprecated": "Use \"ng lint --fix\" directly instead."

--- a/packages/schematics/angular/interceptor/schema.json
+++ b/packages/schematics/angular/interceptor/schema.json
@@ -40,7 +40,6 @@
     },
     "lintFix": {
       "type": "boolean",
-      "default": false,
       "description": "When true, applies lint fixes after generating the interceptor.",
       "x-user-analytics": 15,
       "x-deprecated": "Use \"ng lint --fix\" directly instead."

--- a/packages/schematics/angular/interface/schema.json
+++ b/packages/schematics/angular/interface/schema.json
@@ -42,7 +42,6 @@
     },
     "lintFix": {
       "type": "boolean",
-      "default": false,
       "description": "When true, applies lint fixes after generating the interface.",
       "x-user-analytics": 15,
       "x-deprecated": "Use \"ng lint --fix\" directly instead."

--- a/packages/schematics/angular/library/schema.json
+++ b/packages/schematics/angular/library/schema.json
@@ -45,7 +45,6 @@
     },
     "lintFix": {
       "type": "boolean",
-      "default": false,
       "description": "When true, applies lint fixes after generating the library.",
       "x-user-analytics": 15,
       "x-deprecated": "Use \"ng lint --fix\" directly instead."

--- a/packages/schematics/angular/module/schema.json
+++ b/packages/schematics/angular/module/schema.json
@@ -61,7 +61,6 @@
     },
     "lintFix": {
       "type": "boolean",
-      "default": false,
       "description": "When true, applies lint fixes after generating the module.",
       "x-user-analytics": 15,
       "x-deprecated": "Use \"ng lint --fix\" directly instead."

--- a/packages/schematics/angular/service/schema.json
+++ b/packages/schematics/angular/service/schema.json
@@ -40,7 +40,6 @@
     },
     "lintFix": {
       "type": "boolean",
-      "default": false,
       "description": "When true, applies lint fixes after generating the service.",
       "x-user-analytics": 15,
       "x-deprecated": "Use \"ng lint --fix\" directly instead."


### PR DESCRIPTION
Since will remove lintFix usage warnings when the option is set by a default of another schematic.

Example when executing
```
ng generate module customers --route customers --module app.module
```

The lintFix default of the module schematic will be passed down to the component schematic which would cause a warning to be shown.

Closes #19169
