### PR TITLE
feat(@schematics/angular): Schematic to migrate invalid interpolations

### DIFF
--- a/packages/schematics/angular/migrations/migration-collection.json
+++ b/packages/schematics/angular/migrations/migration-collection.json
@@ -119,6 +119,11 @@
       "version": "11.0.0-next.8",
       "factory": "./update-11/update-angular-config",
       "description": "Remove deprecated options from 'angular.json' that are no longer present in v11."
+    },
+    "fix-invalid-interpolations": {
+      "version": "11.1.0",
+      "factory": "./update-11/fix-invalid-interpolations",
+      "description": "Fix invalid interpolations no longer accepted by the compiler."
     }
   }
 }

--- a/packages/schematics/angular/migrations/update-11/fix-invalid-interpolations.ts
+++ b/packages/schematics/angular/migrations/update-11/fix-invalid-interpolations.ts
@@ -1,0 +1,85 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {extname, Path} from '@angular-devkit/core';
+import {Rule} from '@angular-devkit/schematics';
+
+const RE_INTERPOLATIONS: ReadonlyArray<[RegExp, string]> = [
+  // Matching an interpolation:
+  //
+  // {{((?:[^}'"]|'[^']*?'|"[^"]*?")*?)}
+  //        ^^^^^^                    match everything except a }, ", or '
+  //               ^^^^^^^^ ^^^^^^^^  or any quoted string
+
+  // Replace "{{expr}<!-- cmt -->}" with "{{ '{{' }} expr {{ '}}' }}".
+  // The former is a little-known pattern previously used to display an
+  // iterpolation literally, but that does not longer parse. The latter would
+  // still parse.
+  [
+    /{{((?:'[^']*?'|"[^"]*?"|[^}'"])*?)}<!--.*-->}/g,
+    //                                 ^^^^^^^^^^^ match a comment b/w braces
+    `{{ '{{' }}$1{{ '}}' }}`
+  ],
+
+  // Replace "{{expr}" with "{{expr}}".
+  [/{{((?:'[^']*?'|"[^"]*?"|[^}'"])*?)}(?!})/g, '{{$1}}'],
+  //                                  ^^^^^^ match a singularly-terminated
+  //                                         interpolation
+];
+
+export default function(): Rule {
+  return (tree) => {
+    tree.visit((path: Path) => {
+      if (extname(path) !== '.html' && extname(path) !== '.ts') {
+        return;
+      }
+      const contents = tree.read(path)?.toString();
+      if (contents === undefined) {
+        return;
+      }
+
+      if (extname(path) === '.html') {
+        tree.overwrite(path, cleanupInterpolations(contents));
+      } else {
+        // TS file
+        const templateRanges = getInlineTemplateRanges(contents);
+        const fixedContents =
+            templateRanges.reduceRight((content, [tStart, tEnd]) => {
+              const template = content.substring(tStart, tEnd);
+              return content.substring(0, tStart) +
+                  cleanupInterpolations(template) + content.substring(tEnd);
+            }, contents);
+        tree.overwrite(path, fixedContents);
+      }
+    });
+  };
+}
+
+function cleanupInterpolations(content: string): string {
+  return RE_INTERPOLATIONS.reduce(
+      (content, [reInterp, replacement]) =>
+          content.replace(reInterp, replacement),
+      content);
+}
+
+// If we are in a TypeScript file, we need to check for and fix contents in
+// `template:` keys. Ideally we would do this by walking the TS AST, but we
+// don't have a TypeScript dependency available.
+//
+// The returned ranges are guaranteed to be in increasing order.
+function getInlineTemplateRanges(contents: string): Array<[number, number]> {
+  const ranges: Array<[number, number]> = [];
+  let RE_TEMPLATE =
+      /(template:[\s]*)("[^"\\]*(\\.[^"\\]*)*"|'[^'\\]*(\\.[^'\\]*)*?'|`[^`\\]*(\\.[^`\\]*)*`)/g;
+  let match;
+  while (match = RE_TEMPLATE.exec(contents)) {
+    ranges.push([match.index, match.index + match[0].length]);
+  }
+
+  return ranges;
+}

--- a/packages/schematics/angular/migrations/update-11/fix-invalid-interpolations_spec.ts
+++ b/packages/schematics/angular/migrations/update-11/fix-invalid-interpolations_spec.ts
@@ -1,0 +1,123 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {JsonObject} from '@angular-devkit/core';
+import {EmptyTree} from '@angular-devkit/schematics';
+import {SchematicTestRunner, UnitTestTree} from '@angular-devkit/schematics/testing';
+
+const SCHEMATIC_NAME = 'fix-invalid-interpolations';
+
+fdescribe(`Fix invalid interpolations. ${SCHEMATIC_NAME}`, () => {
+  const schematicRunner = new SchematicTestRunner(
+      'migrations',
+      require.resolve('../migration-collection.json'),
+  );
+
+  let tree: UnitTestTree;
+  beforeEach(() => {
+    tree = new UnitTestTree(new EmptyTree());
+  });
+
+  it(`should replace interpolations with only one terminating brace`,
+     async () => {
+       tree.create('/test.html', `
+         <div>{{ 1 + 2 }</div> {{ 5 + 6 }
+       `);
+
+       const newTree =
+           await schematicRunner.runSchematicAsync(SCHEMATIC_NAME, {}, tree)
+               .toPromise();
+       expect(newTree.readContent('/test.html')).toBe(`
+         <div>{{ 1 + 2 }}</div> {{ 5 + 6 }}
+       `);
+     });
+
+  it(`should replace interpolations with comment between terminating braces`,
+     async () => {
+       tree.create('/test.html', `
+         {{ 1 + 2 }<!---->} is a literal
+         <span>{{ 3 }<!-- so is this one -->}</span>
+       `);
+
+       const newTree =
+           await schematicRunner.runSchematicAsync(SCHEMATIC_NAME, {}, tree)
+               .toPromise();
+       expect(newTree.readContent('/test.html')).toBe(`
+         {{ '{{' }} 1 + 2 {{ '}}' }} is a literal
+         <span>{{ '{{' }} 3 {{ '}}' }}</span>
+       `);
+     });
+
+  it(`should replace mixed types of invalid interpolations`, async () => {
+    tree.create('/test.html', `
+      {{ 1 + 2 }<!---->}
+      {{ 1 + 2 }
+    `);
+
+    const newTree =
+        await schematicRunner.runSchematicAsync(SCHEMATIC_NAME, {}, tree)
+            .toPromise();
+    expect(newTree.readContent('/test.html')).toBe(`
+      {{ '{{' }} 1 + 2 {{ '}}' }}
+      {{ 1 + 2 }}
+    `);
+  });
+
+  it(`should not replace valid interpolations`, async () => {
+    const contents = `
+      {{ 1 + 2 }}
+      <span>{{ 3 }} or {{ '{' + "a" + '}' }}</span> or {{ "{{" + "b" + "}}" }}
+    `;
+    tree.create('/test.html', contents);
+
+    const newTree =
+        await schematicRunner.runSchematicAsync(SCHEMATIC_NAME, {}, tree)
+            .toPromise();
+    expect(newTree.readContent('/test.html')).toBe(contents);
+  });
+
+  it(`should replace interpolations in inline templates`, async () => {
+    tree.create('/test.ts', `
+      @Component({
+        template: \`
+          {{ 1 + 2 }<!---->}
+          {{ 1 + 2 }
+        \`;
+      })
+      class Test {}
+
+      @Component({
+        template: \`
+          {{ 1 + 2 }<!---->}
+          {{ 1 + 2 }
+        \`;
+      })
+      class Test2 {}
+    `);
+
+    const newTree =
+        await schematicRunner.runSchematicAsync(SCHEMATIC_NAME, {}, tree)
+            .toPromise();
+    expect(newTree.readContent('/test.ts')).toBe(`
+      @Component({
+        template: \`
+          {{ '{{' }} 1 + 2 {{ '}}' }}
+          {{ 1 + 2 }}
+        \`;
+      })
+      class Test {}
+
+      @Component({
+        template: \`
+          {{ '{{' }} 1 + 2 {{ '}}' }}
+          {{ 1 + 2 }}
+        \`;
+      })
+      class Test2 {}
+    `);
+  });
+});


### PR DESCRIPTION
This commit adds a migration schematic to fix interpolation-like markup
now invalidated by #39107. Previously, the angular parser would not
match markup like `{{ 1 + 2 }` or `{{ 1 + 2 }<!-- -->}` to be partial
(but malformed) interpolations, an implementation detail that some
developers may have relied on to treat interpolation-like markup as
text. #39107 changes the parser implementation to know emit errors in
such cases, because the markup looks like an interpolation but is not
well-formed. In such cases it is preferred to use an interpolation
directly or escape interpolation delimiters (e.g. `{{ '{{' }} 1 + 2
{{ '}}' }}`). This commit provides fixes for malformed cases so as to
ease migration for applications relying on the previous implementation.