### PR TITLE
build: add husky ignored files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ yarn-error.log*
 .ng_pkg_build/
 .ng-dev.log
 .ng-dev.user*
+.husky/_
 
 # Mac OSX Finder files.
 **/.DS_Store


### PR DESCRIPTION
Ahead of upgrading to husky v5, adding the shell file location
to .gitignore to prevent it from randomly showing up when devs
checkout older branches.