### PR TITLE
docs: add `rm -rf node_modules/` to release docs

### DIFF
--- a/docs/process/release.md
+++ b/docs/process/release.md
@@ -154,13 +154,13 @@ For the first release of a major version, follow the instructions in
 
 For non-major release, check out the patch branch (e.g. `9.1.x`), then run:
 ```bash
-yarn # Reload dependencies
+rm -rf node_modules/ && yarn # Reload dependencies
 yarn admin publish --tag latest
 ```
 
 If also publishing a prerelease, check out `master`, then run:
 ```bash
-yarn # Reload dependencies
+rm -rf node_modules/ && yarn # Reload dependencies
 yarn admin publish --tag next
 ```
 
@@ -170,7 +170,7 @@ run:
 **Make sure to update the NPM tag for the version you are releasing!**
 
 ```bash
-yarn # Reload dependencies
+rm -rf node_modules/ && yarn # Reload dependencies
 yarn admin publish --tag v8-lts
 ```
 


### PR DESCRIPTION
In the latest release, I was not able to build even after running `yarn` to refresh dependencies. Eventually, we tracked
the issue down to `rm -rf node_modules/`. There may be some instances where this can be necessary to ensure clean
builds.

I opted to just include this change directly in the commands to be more clear that people saw it. If devs want to be lazy they can always skip that step, but they will hopefully at least see it and be reminded that if something doesn't work, they should at least try `rm -rf node_modules/`.