### PR TITLE
fix(@angular-devkit/build-angular): support emitting AVIF image files

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
@@ -497,7 +497,7 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
       strictExportPresence: true,
       rules: [
         {
-          test: /\.(eot|svg|cur|jpg|png|webp|gif|otf|ttf|woff|woff2|ani)$/,
+          test: /\.(eot|svg|cur|jpg|png|webp|gif|otf|ttf|woff|woff2|ani|avif)$/,
           loader: require.resolve('file-loader'),
           options: {
             name: `[name]${hashFormat.file}.[ext]`,


### PR DESCRIPTION
The file-loader within the browser builder's Webpack configuration previously did not allow emitting AVIF images.