### PR TITLE
fix(@angular-devkit/build-angular): skip application emit during i18n extraction

### DIFF
--- a/packages/angular_devkit/build_angular/src/extract-i18n/index.ts
+++ b/packages/angular_devkit/build_angular/src/extract-i18n/index.ts
@@ -68,10 +68,9 @@ async function getSerializer(format: Format, sourceLocale: string, basePath: str
   }
 }
 
-class InMemoryOutputPlugin {
+class NoEmitPlugin {
   apply(compiler: webpack.Compiler): void {
-    // tslint:disable-next-line:no-any
-    compiler.outputFileSystem = new (webpack as any).MemoryOutputFileSystem();
+    compiler.hooks.shouldEmit.tap('angular-no-emit', () => false);
   }
 }
 
@@ -172,7 +171,7 @@ export async function execute(
       }
 
       const partials = [
-        { plugins: [new InMemoryOutputPlugin()] },
+        { plugins: [new NoEmitPlugin()] },
         getCommonConfig(wco),
         // Only use VE extraction if not using Ivy
         getAotConfig(wco, !usingIvy),


### PR DESCRIPTION
The application output files are not needed during an extraction.  Previously the files were emitted to a memory file system and discarded.  This change removes the processing overhead of emitting the files.  It also provides Webpack 5 support due to the internal memory file system no longer being exported.