### PR TITLE
fix(@angular-devkit/build-optimizer): set rxjs as having safe side effects

### DIFF
--- a/packages/angular_devkit/build_optimizer/src/build-optimizer/build-optimizer.ts
+++ b/packages/angular_devkit/build_optimizer/src/build-optimizer/build-optimizer.ts
@@ -37,6 +37,7 @@ const knownSideEffectFreeAngularModules = [
   /[\\/]node_modules[\\/]@angular[\\/]upgrade[\\/]/,
   /[\\/]node_modules[\\/]@angular[\\/]material[\\/]/,
   /[\\/]node_modules[\\/]@angular[\\/]cdk[\\/]/,
+  /[\\/]node_modules[\\/]rxjs[\\/]/,
 ];
 
 // Factories created by AOT are known to have no side effects.


### PR DESCRIPTION
The rxjs package contains module level side effects that are not marked with a pure annotation.  However, these side effects are safe to remove if the values are unused.