### PR TITLE
build: revert @angular/dev-infra-private package to bb9763f15077a4cb279ba0e210d337e2fde4be0e

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@angular/compiler": "11.0.0-rc.0",
     "@angular/compiler-cli": "11.0.0-rc.0",
     "@angular/core": "11.0.0-rc.0",
-    "@angular/dev-infra-private": "https://github.com/angular/dev-infra-private-builds.git#f920e544255f1f6b36507f525db9020b5f591295",
+    "@angular/dev-infra-private": "https://github.com/angular/dev-infra-private-builds.git#bb9763f15077a4cb279ba0e210d337e2fde4be0e",
     "@angular/forms": "11.0.0-rc.0",
     "@angular/localize": "11.0.0-rc.0",
     "@angular/material": "10.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -85,9 +85,9 @@
   dependencies:
     tslib "^2.0.0"
 
-"@angular/dev-infra-private@https://github.com/angular/dev-infra-private-builds.git#f920e544255f1f6b36507f525db9020b5f591295":
+"@angular/dev-infra-private@https://github.com/angular/dev-infra-private-builds.git#bb9763f15077a4cb279ba0e210d337e2fde4be0e":
   version "0.0.0"
-  resolved "https://github.com/angular/dev-infra-private-builds.git#f920e544255f1f6b36507f525db9020b5f591295"
+  resolved "https://github.com/angular/dev-infra-private-builds.git#bb9763f15077a4cb279ba0e210d337e2fde4be0e"
   dependencies:
     "@angular/benchpress" "0.2.1"
     "@bazel/buildifier" "^0.29.0"


### PR DESCRIPTION


Temp workaround to solve the CI validation error
```
 /home/circleci/ng/node_modules/.bin/ng-dev commit-message validate-range --range f6d9028f8b088e1e4aca80c73c455c61b97400a5...fa4e13adf1a4e30048ef541d6af7c6fc5d0b1683
/home/circleci/ng/node_modules/.bin/ng-dev: 1: Syntax error: word unexpected (expecting ")")
```

Will properly be resolved via https://github.com/angular/angular/pull/39443