### PR TITLE
fix(@angular-devkit/build-angular): when optimizing don't wrap function arguments in parenthesis

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/process-bundle.ts
+++ b/packages/angular_devkit/build_angular/src/utils/process-bundle.ts
@@ -400,6 +400,7 @@ async function terserMangle(
       ascii_only: true,
       webkit: true,
       beautify: shouldBeautify,
+      wrap_func_args: false,
     },
     sourceMap:
       !!options.map &&

--- a/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
@@ -388,6 +388,7 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
         comments: !buildOptions.extractLicenses && undefined,
         webkit: true,
         beautify: shouldBeautify,
+        wrap_func_args: false,
       },
       // On server, we don't want to compress anything. We still set the ngDevMode = false for it
       // to remove dev code, and ngI18nClosureMode to remove Closure compiler i18n code


### PR DESCRIPTION


With this change function and arrow function arguments are not wrapped in parenthesis during the optimization phase. 

`wrap_func_args` which is enabled by default in terser will wrap function arguments in parenthesis. Recently this was also changed to wrap lamdas as well:
https://github.com/terser/terser/commit/66c3a5ce66c7873bded8c6466e72027f9816c548

An increase in bundle size was observed without this change. See: https://github.com/angular/angular/pull/39432#discussion_r512345752