### PR TITLE
fix(@ngtools/webpack): show zone.js incompatibility warning when using ES2017+

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
@@ -9,7 +9,6 @@ import {
   BuildOptimizerWebpackPlugin,
   buildOptimizerLoaderPath,
 } from '@angular-devkit/build-optimizer';
-import { tags } from '@angular-devkit/core';
 import * as CopyWebpackPlugin from 'copy-webpack-plugin';
 import { existsSync } from 'fs';
 import * as path from 'path';
@@ -444,17 +443,6 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
         },
       }),
     );
-  }
-
-  if (
-    wco.tsConfig.options.target !== undefined &&
-    wco.tsConfig.options.target >= ScriptTarget.ES2017
-  ) {
-    wco.logger.warn(tags.stripIndent`
-      Warning: Zone.js does not support native async/await in ES2017.
-      These blocks are not intercepted by zone.js and will not triggering change detection.
-      See: https://github.com/angular/zone.js/pull/1140 for more information.
-    `);
   }
 
   return {

--- a/packages/ngtools/webpack/README.md
+++ b/packages/ngtools/webpack/README.md
@@ -63,6 +63,8 @@ The loader works with webpack plugin to compile your TypeScript. It's important 
 * `i18nOutFile`. Optional and only used for View Engine compilations. The name of the file to write extractions to.
 * `i18nOutFormat`. Optional and only used for View Engine compilations. The format of the localization file where extractions will be written to.
 * `locale`. Optional and only used for View Engine compilations. Locale to use for i18n.
+* `suppressZoneJsIncompatibilityWarning`. Optional, defaults to `false`. A Zone.js incompatibility warning is shown when the compilation target is ES2017+. Zone.js does not support native async/await in ES2017+. These blocks are not intercepted by zone.js and will not triggering change detection. 
+See https://github.com/angular/zone.js/pull/1140 for more information.
 
 ## Features
 The benefits and ability of using [`@ngtools/webpack`](https://www.npmjs.com/~ngtools) standalone from the Angular CLI as presented in [Stephen Fluin's Angular CLI talk](https://youtu.be/uBRK6cTr4Vk?t=6m45s) at Angular Connect 2016:

--- a/packages/ngtools/webpack/src/angular_compiler_plugin.ts
+++ b/packages/ngtools/webpack/src/angular_compiler_plugin.ts
@@ -269,6 +269,18 @@ export class AngularCompilerPlugin {
       this._discoverLazyRoutes = options.discoverLazyRoutes;
     }
 
+    if (
+      !this.options.suppressZoneJsIncompatibilityWarning &&
+      this._compilerOptions.target !== undefined &&
+      this._compilerOptions.target >= ts.ScriptTarget.ES2017
+    ) {
+      this._warnings.push(
+        'Zone.js does not support native async/await in ES2017+.\n' +
+        'These blocks are not intercepted by zone.js and will not triggering change detection.\n' +
+        'See: https://github.com/angular/zone.js/pull/1140 for more information.',
+      );
+    }
+
     if (this._discoverLazyRoutes === false && this.options.additionalLazyModuleResources
       && this.options.additionalLazyModuleResources.length > 0) {
       this._warnings.push(

--- a/packages/ngtools/webpack/src/interfaces.ts
+++ b/packages/ngtools/webpack/src/interfaces.ts
@@ -83,4 +83,12 @@ export interface AngularCompilerPluginOptions {
 
   host?: virtualFs.Host<fs.Stats>;
   platformTransformers?: ts.TransformerFactory<ts.SourceFile>[];
+
+  /**
+   * Suppress Zone.js incompatibility warning when using ES2017+.
+   * Zone.js does not support native async/await in ES2017+.
+   * These blocks are not intercepted by zone.js and will not triggering change detection.
+   * @see https://github.com/angular/zone.js/pull/1140
+  */
+  suppressZoneJsIncompatibilityWarning?: boolean;
 }


### PR DESCRIPTION
Closes: #19226