### PR TITLE
feat(@schematics/angular): add `enableI18nLegacyMessageIdFormat` defa…

### DIFF
--- a/packages/schematics/angular/workspace/files/tsconfig.json.template
+++ b/packages/schematics/angular/workspace/files/tsconfig.json.template
@@ -20,10 +20,11 @@
       "es2018",
       "dom"
     ]
-  }<% if (strict) { %>,
+  },
   "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false<% if (strict) { %>,
     "strictInjectionParameters": true,
     "strictInputAccessModifiers": true,
-    "strictTemplates": true
-  }<% } %>
+    "strictTemplates": true<% } %>
+  }
 }

--- a/packages/schematics/angular/workspace/index_spec.ts
+++ b/packages/schematics/angular/workspace/index_spec.ts
@@ -73,13 +73,21 @@ describe('Workspace Schematic', () => {
     expect(files).not.toContain('/.editorconfig');
   });
 
+  it('should set the `enableI18nLegacyMessageIdFormat` Angular compiler option', async () => {
+    const tree = await schematicRunner.runSchematicAsync('workspace', defaultOptions).toPromise();
+    const { angularCompilerOptions } =
+      // tslint:disable-next-line: no-any
+      parseJson(tree.readContent('tsconfig.json').toString(), JsonParseMode.Loose) as any;
+    expect(angularCompilerOptions.enableI18nLegacyMessageIdFormat).toBe(false);
+  });
+
   it('should not add strict compiler options when false', async () => {
     const tree = await schematicRunner.runSchematicAsync('workspace', { ...defaultOptions, strict: false }).toPromise();
     const { compilerOptions, angularCompilerOptions } =
       // tslint:disable-next-line: no-any
       parseJson(tree.readContent('tsconfig.json').toString(), JsonParseMode.Loose) as any;
     expect(compilerOptions.strict).toBeUndefined();
-    expect(angularCompilerOptions).toBeUndefined();
+    expect(Object.keys(angularCompilerOptions).filter(option => option.startsWith('strict'))).toEqual([]);
   });
 
   it('should add strict compiler options when true', async () => {


### PR DESCRIPTION
…ult to new projects

The ViewEngine message extraction generates a variety of legacy formats
for extracted message ids. These formats have a number of issues related
to whitespace handling and reliance upon information inside the original
HTML of a template. The new message format is more resilient to things
like whitespace changes, and can be generated directly from calls to
`$localize`, which allows messages in application code to have the same
id as identical messages in templates.

As a first step in migrating projects away from the legacy id format
for i18n messages, this commit updates newly generated projects to turn
off the legacy ids.

In the future the default will be flipped and this can be removed.
Eventually the legacy message id support will be removed altogether,
probably in sync with removal of ViewEngine.