### PR TITLE
fix(@ngtools/webpack): elide type-only imports when using emitDecoratorMetadata

### DIFF
--- a/packages/ngtools/webpack/src/transformers/elide_imports.ts
+++ b/packages/ngtools/webpack/src/transformers/elide_imports.ts
@@ -48,7 +48,9 @@ export function elideImports(
 
     // Record import and skip
     if (ts.isImportDeclaration(node)) {
-      imports.push(node);
+      if (!node.importClause?.isTypeOnly) {
+        imports.push(node);
+      }
 
       return;
     }


### PR DESCRIPTION

Closes #19234