### PR TITLE
Bundle output stats fixes

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/utils/stats.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/utils/stats.ts
@@ -21,8 +21,10 @@ export function formatSize(size: number): string {
 
   const abbreviations = ['bytes', 'kB', 'MB', 'GB'];
   const index = Math.floor(Math.log(size) / Math.log(1024));
-
-  return `${+(size / Math.pow(1024, index)).toPrecision(3)} ${abbreviations[index]}`;
+  const roundedSize = size / Math.pow(1024, index);
+  // bytes don't have a fraction
+  const fractionDigits = index === 0 ? 0 : 2;
+  return `${roundedSize.toFixed(fractionDigits)} ${abbreviations[index]}`;
 }
 
 export type BundleStatsData = [files: string, names: string, size: number | string];


### PR DESCRIPTION
See each commit.

These changes are following feedback from twitter and GDE slack channel.

![Screenshot 2020-10-29 at 17 19 02](https://user-images.githubusercontent.com/17563226/97601807-dcb86800-1a0a-11eb-8e6a-6ef04c720f31.png)

