### PR TITLE
fix(@angular-devkit/build-angular): re-enable webpack 5 license extraction support

### DIFF
--- a/packages/angular_devkit/build_angular/src/browser/index.ts
+++ b/packages/angular_devkit/build_angular/src/browser/index.ts
@@ -152,15 +152,6 @@ async function initialize(
   // Assets are processed directly by the builder except when watching
   const adjustedOptions = options.watch ? options : { ...options, assets: [] };
 
-  // TODO_WEBPACK_5: Investigate build/serve issues with the `license-webpack-plugin` package
-  if (adjustedOptions.extractLicenses && isWebpackFiveOrHigher()) {
-    adjustedOptions.extractLicenses = false;
-    context.logger.warn(
-      'Warning: License extraction is currently disabled when using Webpack 5. ' +
-        'This is temporary and will be corrected in a future update.',
-    );
-  }
-
   const {
     config,
     projectRoot,

--- a/packages/angular_devkit/build_angular/src/webpack/configs/browser.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/browser.ts
@@ -47,6 +47,7 @@ export function getBrowserConfig(wco: WebpackConfigOptions): webpack.Configurati
       },
       perChunkOutput: false,
       outputFilename: '3rdpartylicenses.txt',
+      skipChildCompilers: true,
     }));
   }
 

--- a/packages/angular_devkit/build_angular/src/webpack/configs/worker.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/worker.ts
@@ -22,12 +22,27 @@ export function getWorkerConfig(wco: WebpackConfigOptions): Configuration {
   }
 
   const workerTsConfigPath = resolve(wco.root, buildOptions.webWorkerTsConfig);
-  const WorkerPlugin = require('worker-plugin');
+  const WebWorkerPlugin = require('worker-plugin');
+
+  const workerPlugins = [getTypescriptWorkerPlugin(wco, workerTsConfigPath)];
+  if (buildOptions.extractLicenses) {
+    // Webpack child compilations will not inherit the license plugin
+    const LicenseWebpackPlugin = require('license-webpack-plugin').LicenseWebpackPlugin;
+    workerPlugins.push(new LicenseWebpackPlugin({
+      stats: {
+        warnings: false,
+        errors: false,
+      },
+      perChunkOutput: false,
+      // The name needs to be unique to this child compilation to avoid duplicate asset errors
+      outputFilename: '3rdpartylicenses-worker-[hash].txt',
+    }));
+  }
 
   return {
-    plugins: [new WorkerPlugin({
+    plugins: [new WebWorkerPlugin({
       globalObject: false,
-      plugins: [getTypescriptWorkerPlugin(wco, workerTsConfigPath)],
+      plugins: workerPlugins,
     })],
   };
 }

--- a/packages/angular_devkit/build_angular/src/webpack/utils/stats.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/utils/stats.ts
@@ -140,8 +140,6 @@ export function statsToString(json: any, statsConfig: any) {
 }
 
 const ERRONEOUS_WARNINGS_FILTER = (warning: string) => ![
-  // TODO(#16193): Don't emit this warning in the first place rather than just suppressing it.
-  /multiple assets emit different content.*3rdpartylicenses\.txt/i,
   // Webpack 5+ has no facility to disable this warning.
   // System.import is used in @angular/core for deprecated string-form lazy routes
   /System.import\(\) is deprecated and will be removed soon/i,


### PR DESCRIPTION
With updates to the `license-webpack-plugin` and adjustments to the web worker plugin configuration, license extraction can now be used with webpack 5.  This change also removes the need to filter out the duplicate asset warning on Webpack 4 that was previously being generated.