### PR TITLE
fix(@angular-devkit/build-optimizer): mark rxjs add imports as having side effects

### DIFF
--- a/packages/angular_devkit/build_optimizer/src/build-optimizer/build-optimizer.ts
+++ b/packages/angular_devkit/build_optimizer/src/build-optimizer/build-optimizer.ts
@@ -54,6 +54,11 @@ function isKnownCoreFile(filePath: string) {
 }
 
 function isKnownSideEffectFree(filePath: string) {
+  // rxjs add imports contain intentional side effects
+  if (/[\\/]node_modules[\\/]rxjs[\\/]add[\\/]/.test(filePath)) {
+    return false;
+  }
+
   return ngFactories.some((s) => filePath.endsWith(s)) ||
     knownSideEffectFreeAngularModules.some((re) => re.test(filePath));
 }


### PR DESCRIPTION
This change prevents the build optimizer from removing the operator add imports from the rxjs package (for example, `import 'rxjs/add/operator/filter';`).  The entire rxjs package is currently marked as side effect free from within the rxjs `package.json` but the files in the add directory intentionally contain side effects.