### PR TITLE
fix(@angular-devkit/build-angular): remove title attribute from inlined fonts style tag

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/index-file/inline-fonts.ts
+++ b/packages/angular_devkit/build_angular/src/utils/index-file/inline-fonts.ts
@@ -81,7 +81,7 @@ export class InlineFontsProcessor {
       if (hrefAttr) {
         const href = hrefAttr.value;
         const cssContent = hrefsContent.get(href);
-        rewriter.emitRaw(`<style type="text/css" title="${href}">${cssContent}</style>`);
+        rewriter.emitRaw(`<style type="text/css">${cssContent}</style>`);
       } else {
         rewriter.emitStartTag(tag);
       }


### PR DESCRIPTION

title is not a valid style tag attribute.

Closes #19271