### PR TITLE
test(@angular-devkit/build-angular): pin node-sass to version 4

### DIFF
--- a/tests/legacy-cli/e2e/tests/build/styles/node-sass.ts
+++ b/tests/legacy-cli/e2e/tests/build/styles/node-sass.ts
@@ -32,7 +32,7 @@ export default async function () {
   await silentExec('rm', '-rf', 'node_modules/sass');
   await expectToFail(() => ng('build', '--extract-css', '--source-map'));
 
-  await silentNpm('install', 'node-sass');
+  await silentNpm('install', 'node-sass@4');
   await silentExec('rm', '-rf', 'node_modules/sass');
   await ng('build', '--extract-css', '--source-map');
 


### PR DESCRIPTION
The curent version of sass-loader doesn't support node-sass version 5.

https://github.com/webpack-contrib/sass-loader/issues/898
(cherry picked from commit 6717d181bd58a3c14818afd4dfa9c9dffe93b9b4)