### PR TITLE
fix(@angular-devkit/build-angular): remove `sourceMappingURL` from vendor modules

### DIFF
--- a/packages/angular_devkit/build_angular/src/browser/specs/vendor-source-map_spec.ts
+++ b/packages/angular_devkit/build_angular/src/browser/specs/vendor-source-map_spec.ts
@@ -34,7 +34,7 @@ describe('Browser Builder external source map', () => {
     expect(hasTsSourcePaths).toBe(true, `vendor.js.map should have '.ts' extentions`);
   });
 
-  it(`does not generate 'vendor.js.map' when vendor sourcemap is disabled`, async () => {
+  it(`does not generate vendor sourcemaps when vendor sourcemap is disabled`, async () => {
     const overrides = {
       sourceMap: {
         scripts: true,
@@ -44,6 +44,7 @@ describe('Browser Builder external source map', () => {
     };
 
     const { files } = await browserBuild(architect, host, target, overrides);
-    expect(files['vendor.js.map']).toBeUndefined();
+    expect(files['vendor.js.map']).toBeUndefined('Expected vendor.js.map not to exists.');
+    expect(files['vendor.js']).not.toContain('sourceMappingURL', `Expected vendor.js not to contain '//# sourceMappingURL`);
   });
 });

--- a/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
@@ -46,6 +46,7 @@ import {
   ScriptsWebpackPlugin,
   WebpackRollupLoader,
 } from '../plugins';
+import { SourceMappingUrlRemoverLoaderPath } from '../plugins/source-mapping-url-remover-loader';
 import { getEsVersionForFileName, getOutputHashFormat, getWatchOptions, normalizeExtraEntryPoints } from '../utils/helpers';
 
 const TerserPlugin = require('terser-webpack-plugin');
@@ -358,13 +359,20 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
     extraPlugins.push(new BundleBudgetPlugin({ budgets: buildOptions.budgets }));
   }
 
-  if ((scriptsSourceMap || stylesSourceMap) && vendorSourceMap) {
-    extraRules.push({
-      test: /\.m?js$/,
-      exclude: /(ngfactory|ngstyle)\.js$/,
-      enforce: 'pre',
-      loader: require.resolve('source-map-loader'),
-    });
+  if (scriptsSourceMap || stylesSourceMap) {
+    extraRules.push(
+      vendorSourceMap
+        ? {
+          test: /\.m?js$/,
+          exclude: /(ngfactory|ngstyle)\.js$/,
+          enforce: 'pre',
+          loader: require.resolve('source-map-loader'),
+        }
+        : {
+          test: /\.m?js$/,
+          loader: SourceMappingUrlRemoverLoaderPath,
+        },
+    );
   }
 
   let buildOptimizerUseRule: RuleSetLoader[] = [];

--- a/packages/angular_devkit/build_angular/src/webpack/plugins/source-mapping-url-remover-loader.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/plugins/source-mapping-url-remover-loader.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export const SourceMappingUrlRemoverLoaderPath = __filename;
+
+/**
+ * This loader is used to remove the `//# sourceMappingURL=` comment from individual modules.
+ * Webpack will not remove these comments when the chunk that these mules are in, are excluded from
+ * `SourceMapDevToolPlugin`.
+ */
+export default function (
+  this: import('webpack').loader.LoaderContext,
+  content: string,
+  // Source map types are broken in the webpack type definitions
+  // tslint:disable-next-line: no-any
+  map: any,
+): void {
+  let source = content;
+  if (!map) {
+    const position = content.lastIndexOf('//# sourceMappingURL=');
+    if (position >= 0) {
+      source = content.substring(0, position);
+    }
+  }
+
+  this.callback(null, source, map);
+
+  return;
+}


### PR DESCRIPTION


With this change we add a loader that removes the `//# sourceMappingURL=` comment from `.js` files.
Webpack will not remove these comments when the chunk that these mules are in, are excluded from `SourceMapDevToolPlugin`.

Closes #19236