### PR TITLE
fix(@angular/cli): correctly read transitive dependency

### DIFF
--- a/packages/angular/cli/commands/update-impl.ts
+++ b/packages/angular/cli/commands/update-impl.ts
@@ -439,7 +439,7 @@ export class UpdateCommand extends Command<UpdateCommandSchema> {
         const packageJson = findPackageJson(this.context.root, packageName);
         if (packageJson) {
           packagePath = path.dirname(packageJson);
-          packageNode = await readPackageJson(packagePath);
+          packageNode = await readPackageJson(packageJson);
         }
       }
 


### PR DESCRIPTION
For `ng update --migrateOnly ...` the update implementation checks for transitive
dependencies and tries to parse the containing directory as JSON. This PR
fixes this by providing the correct path to the package.json.