### PR TITLE
Revert "fix(@angular-devkit/build-angular): don't generate `vendor.js…

### DIFF
--- a/packages/angular_devkit/build_angular/src/browser/specs/differential_loading_spec.ts
+++ b/packages/angular_devkit/build_angular/src/browser/specs/differential_loading_spec.ts
@@ -50,7 +50,9 @@ describe('Browser Builder with differential loading', () => {
       'runtime-es5.js.map',
 
       'vendor-es2015.js',
+      'vendor-es2015.js.map',
       'vendor-es5.js',
+      'vendor-es5.js.map',
 
       'styles.css',
       'styles.css.map',
@@ -88,7 +90,9 @@ describe('Browser Builder with differential loading', () => {
       'runtime-es5.js.map',
 
       'vendor-es2016.js',
+      'vendor-es2016.js.map',
       'vendor-es5.js',
+      'vendor-es5.js.map',
 
       'styles.css',
       'styles.css.map',
@@ -126,7 +130,9 @@ describe('Browser Builder with differential loading', () => {
       'runtime-es5.js.map',
 
       'vendor-esnext.js',
+      'vendor-esnext.js.map',
       'vendor-es5.js',
+      'vendor-es5.js.map',
 
       'styles.css',
       'styles.css.map',
@@ -152,6 +158,7 @@ describe('Browser Builder with differential loading', () => {
       'runtime.js.map',
 
       'vendor.js',
+      'vendor.js.map',
 
       'styles.css',
       'styles.css.map',

--- a/packages/angular_devkit/build_angular/src/browser/specs/vendor-source-map_spec.ts
+++ b/packages/angular_devkit/build_angular/src/browser/specs/vendor-source-map_spec.ts
@@ -34,7 +34,7 @@ describe('Browser Builder external source map', () => {
     expect(hasTsSourcePaths).toBe(true, `vendor.js.map should have '.ts' extentions`);
   });
 
-  it(`does not generate 'vendor.js.map' when vendor sourcemap is disabled`, async () => {
+  it('does not map sourcemaps from external library when disabled', async () => {
     const overrides = {
       sourceMap: {
         scripts: true,
@@ -44,6 +44,8 @@ describe('Browser Builder external source map', () => {
     };
 
     const { files } = await browserBuild(architect, host, target, overrides);
-    expect(files['vendor.js.map']).toBeUndefined();
+    const sourcePaths: string[] = JSON.parse(await files['vendor.js.map']).sources;
+    const hasTsSourcePaths = sourcePaths.some(p => path.extname(p) == '.ts');
+    expect(hasTsSourcePaths).toBe(false, `vendor.js.map not should have '.ts' extentions`);
   });
 });

--- a/packages/angular_devkit/build_angular/src/webpack/configs/browser.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/browser.ts
@@ -28,7 +28,6 @@ export function getBrowserConfig(wco: WebpackConfigOptions): webpack.Configurati
     styles: stylesSourceMap,
     scripts: scriptsSourceMap,
     hidden: hiddenSourceMap,
-    vendor: vendorSourceMap,
   } = buildOptions.sourceMap;
 
   if (subresourceIntegrity) {
@@ -57,7 +56,6 @@ export function getBrowserConfig(wco: WebpackConfigOptions): webpack.Configurati
       stylesSourceMap,
       buildOptions.differentialLoadingMode ? true : hiddenSourceMap,
       false,
-      vendorSourceMap,
     ));
   }
 

--- a/packages/angular_devkit/build_angular/src/webpack/configs/server.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/server.ts
@@ -28,9 +28,9 @@ export function getServerConfig(wco: WebpackConfigOptions): Configuration {
   } = wco.buildOptions;
 
   const extraPlugins = [];
-  const { scripts, styles, hidden, vendor } = sourceMap;
+  const { scripts, styles, hidden } = sourceMap;
   if (scripts || styles) {
-    extraPlugins.push(getSourceMapDevTool(scripts, styles, hidden, false, vendor));
+    extraPlugins.push(getSourceMapDevTool(scripts, styles, hidden));
   }
 
   const externals: Configuration['externals'] = [...externalDependencies];

--- a/packages/angular_devkit/build_angular/src/webpack/configs/test.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/test.ts
@@ -48,18 +48,13 @@ export function getTestConfig(
     });
   }
 
-  if (sourceMap) {
-    const { styles, scripts, vendor } = sourceMap;
-
-    if (styles || scripts) {
-      extraPlugins.push(getSourceMapDevTool(
-        scripts,
-        styles,
-        false,
-        true,
-        vendor,
-      ));
-    }
+  if (sourceMap.scripts || sourceMap.styles) {
+    extraPlugins.push(getSourceMapDevTool(
+      sourceMap.scripts,
+      sourceMap.styles,
+      false,
+      true,
+    ));
   }
 
   return {

--- a/packages/angular_devkit/build_angular/src/webpack/utils/helpers.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/utils/helpers.ts
@@ -73,7 +73,6 @@ export function getSourceMapDevTool(
   stylesSourceMap: boolean | undefined,
   hiddenSourceMap = false,
   inlineSourceMap = false,
-  vendorSourceMap = false,
 ): SourceMapDevToolPlugin {
   const include = [];
   if (scriptsSourceMap) {
@@ -94,7 +93,6 @@ export function getSourceMapDevTool(
     sourceRoot: 'webpack:///',
     moduleFilenameTemplate: '[resource-path]',
     append: hiddenSourceMap ? false : undefined,
-    exclude: vendorSourceMap ? undefined : /vendor.*\.js/,
   });
 }
 

--- a/tests/legacy-cli/e2e/tests/build/sourcemap.ts
+++ b/tests/legacy-cli/e2e/tests/build/sourcemap.ts
@@ -15,10 +15,10 @@ export default async function () {
   await ng('build', '--output-hashing=bundles', '--source-map');
 
   await ng('build', '--prod', '--output-hashing=none', '--source-map');
-  await testForSourceMaps(5);
+  await testForSourceMaps(6);
 
   await ng('build', '--output-hashing=none', '--source-map');
-  await testForSourceMaps(6);
+  await testForSourceMaps(8);
 }
 
 async function testForSourceMaps(expectedNumberOfFiles: number): Promise <void> {
@@ -29,7 +29,7 @@ async function testForSourceMaps(expectedNumberOfFiles: number): Promise <void> 
 
   let count = 0;
   for (const file of files) {
-    if (!file.endsWith('.js') || file.startsWith('vendor-')) {
+    if (!file.endsWith('.js')) {
       continue;
     }
 


### PR DESCRIPTION
….map` when vendor sourcemaps is disabled"

This reverts commit b17763b03d7ca1ce5d2a85d2d03d0029b6623339.

Closes #19236