### PR TITLE
fix(@angular-devkit/build-angular): add validation to fileReplacement values

### DIFF
--- a/packages/angular/cli/lib/config/schema.json
+++ b/packages/angular/cli/lib/config/schema.json
@@ -1062,10 +1062,12 @@
                   "type": "object",
                   "properties": {
                     "src": {
-                      "type": "string"
+                      "type": "string",
+                      "pattern": "\\.([cm]?j|t)sx?$"
                     },
                     "replaceWith": {
-                      "type": "string"
+                      "type": "string",
+                      "pattern": "\\.([cm]?j|t)sx?$"
                     }
                   },
                   "additionalProperties": false,
@@ -1078,10 +1080,12 @@
                   "type": "object",
                   "properties": {
                     "replace": {
-                      "type": "string"
+                      "type": "string",
+                      "pattern": "\\.([cm]?j|t)sx?$"
                     },
                     "with": {
-                      "type": "string"
+                      "type": "string",
+                      "pattern": "\\.([cm]?j|t)sx?$"
                     }
                   },
                   "additionalProperties": false,
@@ -1955,10 +1959,12 @@
                   "type": "object",
                   "properties": {
                     "src": {
-                      "type": "string"
+                      "type": "string",
+                      "pattern": "\\.([cm]?j|t)sx?$"
                     },
                     "replaceWith": {
-                      "type": "string"
+                      "type": "string",
+                      "pattern": "\\.([cm]?j|t)sx?$"
                     }
                   },
                   "additionalProperties": false,
@@ -1971,10 +1977,12 @@
                   "type": "object",
                   "properties": {
                     "replace": {
-                      "type": "string"
+                      "type": "string",
+                      "pattern": "\\.([cm]?j|t)sx?$"
                     },
                     "with": {
-                      "type": "string"
+                      "type": "string",
+                      "pattern": "\\.([cm]?j|t)sx?$"
                     }
                   },
                   "additionalProperties": false,

--- a/packages/angular_devkit/build_angular/src/browser/schema.json
+++ b/packages/angular_devkit/build_angular/src/browser/schema.json
@@ -433,10 +433,12 @@
           "type": "object",
           "properties": {
             "src": {
-              "type": "string"
+              "type": "string",
+              "pattern": "\\.([cm]?j|t)sx?$"
             },
             "replaceWith": {
-              "type": "string"
+              "type": "string",
+              "pattern": "\\.([cm]?j|t)sx?$"
             }
           },
           "additionalProperties": false,
@@ -449,10 +451,12 @@
           "type": "object",
           "properties": {
             "replace": {
-              "type": "string"
+              "type": "string",
+              "pattern": "\\.([cm]?j|t)sx?$"
             },
             "with": {
-              "type": "string"
+              "type": "string",
+              "pattern": "\\.([cm]?j|t)sx?$"
             }
           },
           "additionalProperties": false,

--- a/packages/angular_devkit/build_angular/src/server/schema.json
+++ b/packages/angular_devkit/build_angular/src/server/schema.json
@@ -259,10 +259,12 @@
           "type": "object",
           "properties": {
             "src": {
-              "type": "string"
+              "type": "string",
+              "pattern": "\\.([cm]?j|t)sx?$"
             },
             "replaceWith": {
-              "type": "string"
+              "type": "string",
+              "pattern": "\\.([cm]?j|t)sx?$"
             }
           },
           "additionalProperties": false,
@@ -275,10 +277,12 @@
           "type": "object",
           "properties": {
             "replace": {
-              "type": "string"
+              "type": "string",
+              "pattern": "\\.([cm]?j|t)sx?$"
             },
             "with": {
-              "type": "string"
+              "type": "string",
+              "pattern": "\\.([cm]?j|t)sx?$"
             }
           },
           "additionalProperties": false,


### PR DESCRIPTION


fileReplacement is meant to replace compilation source files (JavaScript or TypeScript) with other compilation source files in the build. With this change we add validation to fail the build when the files have unsupported extensions.

Closes #11451