### PR TITLE
fix(@angular-devkit/build-angular): Downgrade Karma to 5.1.x

### DIFF
--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -13,7 +13,7 @@
     "@angular-devkit/core": "0.0.0",
     "@babel/core": "7.12.3",
     "@babel/generator": "7.12.1",
-    "@babel/plugin-transform-runtime": "7.12.1",  
+    "@babel/plugin-transform-runtime": "7.12.1",
     "@babel/preset-env": "7.12.1",
     "@babel/runtime": "7.12.1",
     "@babel/template": "7.10.4",
@@ -80,7 +80,7 @@
   "peerDependencies": {
     "@angular/compiler-cli": "^11.0.0 || ^11.0.0-next",
     "@angular/localize": "^11.0.0 || ^11.0.0-next",
-    "karma": "^5.2.0",
+    "karma": "~5.1.0",
     "ng-packagr": "^11.0.0 || ^11.0.0-next",
     "protractor": "^7.0.0",
     "tslint": "^6.1.0",

--- a/packages/angular_devkit/build_angular/src/webpack/plugins/karma.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/plugins/karma.ts
@@ -99,6 +99,7 @@ const init: any = (config: any, emitter: any, customFileHandlers: any) => {
     const hasIstanbulReporter = reporters.includes('coverage-istanbul');
     if (hasCoveragePlugin && !hasCoverageReporter) {
       reporters.push('coverage');
+      logger.warn(`There is a known issue with Karma and karma-coverage. Tests that exceed the coverage threshold will not fail. This will be fixed in Karma 5.2.x soon.`)
     }
     else if (hasIstanbulPlugin && !hasIstanbulReporter) {
       // coverage-istanbul is deprecated in favor of karma-coverage

--- a/packages/schematics/angular/workspace/files/package.json.template
+++ b/packages/schematics/angular/workspace/files/package.json.template
@@ -30,7 +30,7 @@
     "codelyzer": "^6.0.0",
     "jasmine-core": "~3.6.0",
     "jasmine-spec-reporter": "~5.0.0",
-    "karma": "~5.2.0",
+    "karma": "~5.1.0",
     "karma-chrome-launcher": "~3.1.0",
     "karma-coverage": "~2.0.3",
     "karma-jasmine": "~4.0.0",


### PR DESCRIPTION
There's a bug in Karma 5.2.x that causes unit tests to fail when they
should not. It was supposed to be fixed in
https://github.com/karma-runner/karma/pull/3565 but CI still failed,
blocking the release of Karma.

In order to mitigate this, we temporarily downgrade Karma back to 5.1.x

A side-effect of this is that coverage tests that uses karma-coverage
and exceeds the threshold will not fail, because karma-coverage requires
Karma 5.2.x. We expect this to be fixed very soon.