### PR TITLE
feat(@ngtools/webpack): remove `isPlatform*` calls

### DIFF
--- a/packages/ngtools/webpack/src/angular_compiler_plugin.ts
+++ b/packages/ngtools/webpack/src/angular_compiler_plugin.ts
@@ -61,6 +61,7 @@ import {
 } from './transformers';
 import { collectDeepNodes } from './transformers/ast_helpers';
 import { removeIvyJitSupportCalls } from './transformers/remove-ivy-jit-support-calls';
+import { replaceIsPlatformCalls } from './transformers/replace_is_platform_calls';
 import {
   AUTO_START_ARG,
 } from './type_checker';
@@ -1102,7 +1103,7 @@ export class AngularCompilerPlugin {
             getEntryModule,
             getTypeChecker,
             this._useFactories,
-          ));
+          ), replaceIsPlatformCalls(PLATFORM.Browser));
         }
       } else if (this._platform === PLATFORM.Server) {
         // The export lazy module map is required only for string based lazy loading
@@ -1110,6 +1111,8 @@ export class AngularCompilerPlugin {
         if (!this._compilerOptions.enableIvy) {
           this._transformers.push(exportLazyModuleMap(isMainPath, getLazyRoutes));
         }
+
+        this._transformers.push(replaceIsPlatformCalls(PLATFORM.Server));
 
         if (this._useFactories) {
           this._transformers.push(

--- a/packages/ngtools/webpack/src/transformers/replace_is_platform_calls.ts
+++ b/packages/ngtools/webpack/src/transformers/replace_is_platform_calls.ts
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import * as ts from 'typescript';
+
+import { PLATFORM } from '../interfaces';
+
+export function replaceIsPlatformCalls(platform: PLATFORM): ts.TransformerFactory<ts.SourceFile> {
+  return (context: ts.TransformationContext) => (sourceFile: ts.SourceFile) => {
+    const visitCallExpression: ts.Visitor = (node: ts.Node) => {
+      if (ts.isCallExpression(node) && ts.isIdentifier(node.expression)) {
+        // If it's a call expression like `isPlatformServer(platformId)`.
+        if (node.expression.escapedText === 'isPlatformServer') {
+          // If Webpack bundles assets for the browser platform then we just
+          // replace `isPlatformServer()` with `true` and vice versa with `false` for the server platform.
+          return platform === PLATFORM.Server ? ts.factory.createTrue() : ts.factory.createFalse();
+        } else if (node.expression.escapedText === 'isPlatformBrowser') {
+          // If Webpack bundles assets for the browser platform then we just
+          // replace `isPlatformBrowser()` with `true` and vice versa with `false` for the server platform.
+          return platform === PLATFORM.Browser ? ts.factory.createTrue() : ts.factory.createFalse();
+        }
+      }
+
+      return ts.visitEachChild(node, visitCallExpression, context);
+    };
+
+    return ts.visitEachChild(sourceFile, visitCallExpression, context);
+  };
+}

--- a/packages/ngtools/webpack/src/transformers/replace_is_platform_calls_spec.ts
+++ b/packages/ngtools/webpack/src/transformers/replace_is_platform_calls_spec.ts
@@ -1,0 +1,121 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { tags } from '@angular-devkit/core';  // tslint:disable-line:no-implicit-dependencies
+import { PLATFORM } from '../interfaces';
+import { replaceIsPlatformCalls } from './replace_is_platform_calls';
+import { createTypescriptContext, transformTypescript } from './spec_helpers';
+
+describe('@ngtools/webpack transformers', () => {
+  describe('replace_is_platform_calls', () => {
+    describe('Browser platform', () => {
+      it('should replace isPlatformBrowser and isPlatformServer if the platform is browser', () => {
+        const input = tags.stripIndent`
+          import { enableProdMode } from '@angular/core';
+          import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+          import { PLATFORM_ID, isPlatformBrowser, isPlatformServer } from '@angular/common';
+
+          import { AppModule } from './app/app.module';
+          import { environment } from './environments/environment';
+
+          if (environment.production) {
+            enableProdMode();
+          }
+
+          platformBrowserDynamic().bootstrapModule(AppModule).then(ref => {
+            const platformId = ref.injector.get(PLATFORM_ID);
+
+            isPlatformBrowser(platformId) && console.log('browser');
+            isPlatformServer(platformId) && console.log('server');
+
+            if (true && isPlatformBrowser(platformId)) {
+              console.log('browser');
+            }
+            if (true && isPlatformServer(platformId)) {
+              console.log('server');
+            }
+          });
+        `;
+        const output = tags.stripIndent`
+          import { enableProdMode } from '@angular/core';
+          import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+          import { PLATFORM_ID, isPlatformBrowser, isPlatformServer } from '@angular/common';
+
+          import { AppModule } from './app/app.module';
+          import { environment } from './environments/environment';
+
+          if (environment.production) {
+            enableProdMode();
+          }
+
+          platformBrowserDynamic().bootstrapModule(AppModule).then(ref => {
+            const platformId = ref.injector.get(PLATFORM_ID);
+
+            true && console.log('browser');
+            false && console.log('server');
+
+            if (true && true) {
+              console.log('browser');
+            }
+            if (true && false) {
+              console.log('server');
+            }
+          });
+        `;
+
+        const { program, compilerHost } = createTypescriptContext(input);
+        const transformer = replaceIsPlatformCalls(PLATFORM.Browser);
+        const result = transformTypescript(undefined, [transformer], program, compilerHost);
+        expect(tags.oneLine`${result}`).toEqual(tags.oneLine`${output}`);
+      });
+    });
+
+    describe('Server platform', () => {
+      it('should replace isPlatformBrowser and isPlatformServer if the platform is browser', () => {
+        const input = tags.stripIndent`
+          export class AppModule {
+            constructor(injector: Injector) {
+              const platformId = injector.get(PLATFORM_ID);
+
+              isPlatformServer(platformId) && console.log('server');
+              isPlatformBrowser(platformId) && console.log('browser');
+
+              if (isPlatformServer(platformId)) {
+                console.log('server');
+              }
+              if (isPlatformBrowser(platformId)) {
+                console.log('browser');
+              }
+            }
+          }
+        `;
+        const output = tags.stripIndent`
+          export class AppModule {
+            constructor(injector) {
+              const platformId = injector.get(PLATFORM_ID);
+
+              true && console.log('server');
+              false && console.log('browser');
+
+              if (true) {
+                console.log('server');
+              }
+              if (false) {
+                console.log('browser');
+              }
+            }
+          }
+        `;
+
+        const { program, compilerHost } = createTypescriptContext(input);
+        const transformer = replaceIsPlatformCalls(PLATFORM.Server);
+        const result = transformTypescript(undefined, [transformer], program, compilerHost);
+        expect(tags.oneLine`${result}`).toEqual(tags.oneLine`${output}`);
+      });
+    });
+  });
+});


### PR DESCRIPTION
The original issue is: https://github.com/angular/universal/issues/1187

At the moment, the code that should be executed on the server is delivered to the browser, thereby increasing the size of the bundle, but this code will never be executed there.

This PR adds a transformer that replaces `isPlatform*` function calls with corresponding boolean values when the application is being built for the browser or the server.

This will allow Terser to remove unnecessary blocks of code during the optimization process.

I was wondering if it's possible to "enable" this transformer only when the application is built in production mode via `ng build --prod`.