### PR TITLE
fix(@schematics/angular): remove duplicated Karma traces

### DIFF
--- a/integration/angular_cli/karma.conf.js
+++ b/integration/angular_cli/karma.conf.js
@@ -18,6 +18,9 @@ module.exports = function (config) {
     client: {
       clearContext: false, // leave Jasmine Spec Runner output visible in browser
     },
+    jasmineHtmlReporter: {
+      suppressAll: true // removes the duplicated traces
+    },
     coverageReporter: {
       dir: path.join(__dirname, 'coverage'),
       subdir: '.',

--- a/packages/angular_devkit/build_angular/test/hello-world-app/karma.conf.js
+++ b/packages/angular_devkit/build_angular/test/hello-world-app/karma.conf.js
@@ -25,6 +25,9 @@ module.exports = function(config) {
     client: {
       clearContext: false, // leave Jasmine Spec Runner output visible in browser
     },
+    jasmineHtmlReporter: {
+      suppressAll: true // removes the duplicated traces
+    },
     coverageReporter: {
       dir: path.join(__dirname, './coverage'),
       subdir: '.',

--- a/packages/angular_devkit/build_angular/test/hello-world-lib/projects/lib/karma.conf.js
+++ b/packages/angular_devkit/build_angular/test/hello-world-lib/projects/lib/karma.conf.js
@@ -22,6 +22,9 @@ module.exports = function (config) {
     client: {
       clearContext: false // leave Jasmine Spec Runner output visible in browser
     },
+    jasmineHtmlReporter: {
+      suppressAll: true // removes the duplicated traces
+    },
     coverageIstanbulReporter: {
       dir: require('path').join(__dirname, 'coverage'),
       reports: ['html', 'lcovonly'],

--- a/packages/schematics/angular/application/files/karma.conf.js.template
+++ b/packages/schematics/angular/application/files/karma.conf.js.template
@@ -15,6 +15,9 @@ module.exports = function (config) {
     client: {
       clearContext: false // leave Jasmine Spec Runner output visible in browser
     },
+    jasmineHtmlReporter: {
+      suppressAll: true // removes the duplicated traces
+    },
     coverageReporter: {
       dir: require('path').join(__dirname, '<%= relativePathToWorkspaceRoot %>/coverage/<%= appName%>'),
       subdir: '.',

--- a/packages/schematics/angular/library/files/karma.conf.js.template
+++ b/packages/schematics/angular/library/files/karma.conf.js.template
@@ -15,6 +15,9 @@ module.exports = function (config) {
     client: {
       clearContext: false // leave Jasmine Spec Runner output visible in browser
     },
+    jasmineHtmlReporter: {
+      suppressAll: true // removes the duplicated traces
+    },
     coverageReporter: {
       dir: require('path').join(__dirname, '<%= relativePathToWorkspaceRoot %>/coverage/<%= folderName %>'),
       subdir: '.',


### PR DESCRIPTION
Currently, Karma is reporting a failed test and the total twice in a bare CLI project:

```
12 11 2020 13:59:46.666:INFO [launcher]: Starting browser Chrome
✔ Browser application bundle generation complete.
12 11 2020 13:59:50.457:INFO [Chrome 86.0.4240.198 (Mac OS 10.15.7)]: Connected on socket F0ehOBWL6BYFqXfbAAAA with id 69358036
Chrome 86.0.4240.198 (Mac OS 10.15.7) AppComponent should render title FAILED
	Error: Expected 'ponyracer app is running!' to contain 'other'.
	    at <Jasmine>
	    at UserContext.<anonymous> (src/app/app.component.spec.ts:29:65)
	    at ZoneDelegate.invoke (node_modules/zone.js/dist/zone-evergreen.js:364:1)
	    at ProxyZoneSpec.push.QpwO.ProxyZoneSpec.onInvoke (node_modules/zone.js/dist/zone-testing.js:292:1)
Chrome 86.0.4240.198 (Mac OS 10.15.7): Executed 2 of 3 (1 FAILED) (0 secs / 0.231 secs)
Chrome 86.0.4240.198 (Mac OS 10.15.7) AppComponent should render title FAILED
	Error: Expected 'ponyracer app is running!' to contain 'other'.
	    at <Jasmine>
	    at UserContext.<anonymous> (src/app/app.component.spec.ts:29:65)
	    at ZoneDelegate.invoke (node_modules/zone.js/dist/zone-evergreen.js:364:1)
Chrome 86.0.4240.198 (Mac OS 10.15.7): Executed 3 of 3 (1 FAILED) (0.309 secs / 0.242 secs)
TOTAL: 1 FAILED, 2 SUCCESS
TOTAL: 1 FAILED, 2 SUCCESS
```

This is a bit annoying when you have several tests failing, and tend to confuse beginners.

This commit configures the Karma HTML reporter to suppress the duplicates (both error and success), which results in only one reporter showing the failed test and total:

```
12 11 2020 14:01:43.002:INFO [launcher]: Starting browser Chrome
✔ Browser application bundle generation complete.
12 11 2020 14:01:58.728:INFO [Chrome 86.0.4240.198 (Mac OS 10.15.7)]: Connected on socket Pc0xPggxJPdC8E_LAAAA with id 54797430
Chrome 86.0.4240.198 (Mac OS 10.15.7) AppComponent should render title FAILED
	Error: Expected 'ponyracer app is running!' to contain 'other'.
	    at <Jasmine>
	    at UserContext.<anonymous> (src/app/app.component.spec.ts:29:65)
	    at ZoneDelegate.invoke (node_modules/zone.js/dist/zone-evergreen.js:364:1)
	    at ProxyZoneSpec.push.QpwO.ProxyZoneSpec.onInvoke (node_modules/zone.js/dist/zone-testing.js:292:1)
Chrome 86.0.4240.198 (Mac OS 10.15.7): Executed 3 of 3 (1 FAILED) (0.331 secs / 0.252 secs)
TOTAL: 1 FAILED, 2 SUCCESS
```