### PR TITLE
fix(@schematics/angular): remove trailing comma in karma conf

### DIFF
--- a/packages/schematics/angular/application/files/karma.conf.js.template
+++ b/packages/schematics/angular/application/files/karma.conf.js.template
@@ -21,7 +21,7 @@ module.exports = function (config) {
       reporters: [
         { type: 'html' },
         { type: 'text-summary' }
-      ],
+      ]
     },
     reporters: ['progress', 'kjhtml'],
     port: 9876,

--- a/packages/schematics/angular/library/files/karma.conf.js.template
+++ b/packages/schematics/angular/library/files/karma.conf.js.template
@@ -21,7 +21,7 @@ module.exports = function (config) {
       reporters: [
         { type: 'html' },
         { type: 'text-summary' }
-      ],
+      ]
     },
     reporters: ['progress', 'kjhtml'],
     port: 9876,


### PR DESCRIPTION
We usually don't have trailing commas in the generated code of the CLI (and this one makes the linter/formatter angry).