### PR TITLE
fix(@schematics/angular): migrate project dependencies to new project versions

### DIFF
--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -102,5 +102,10 @@
     "tslint": {
       "optional": true
     }
+  },
+  "ng-update": {
+    "packageGroup": {
+      "codelyzer": "^6.0.0"
+    }
   }
 }

--- a/packages/schematics/angular/migrations/migration-collection.json
+++ b/packages/schematics/angular/migrations/migration-collection.json
@@ -119,6 +119,11 @@
       "version": "11.0.0-next.8",
       "factory": "./update-11/update-angular-config",
       "description": "Remove deprecated options from 'angular.json' that are no longer present in v11."
+    },
+    "update-workspace-dependencies-v11": {
+      "version": "11.0.0",
+      "factory": "./update-11/update-dependencies",
+      "description": "Update workspace dependencies to match a new v11 project."
     }
   }
 }

--- a/packages/schematics/angular/migrations/update-11/update-dependencies.ts
+++ b/packages/schematics/angular/migrations/update-11/update-dependencies.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { Rule } from '@angular-devkit/schematics';
+import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
+import {
+  addPackageJsonDependency,
+  getPackageJsonDependency,
+} from '../../utility/dependencies';
+import { latestVersions } from '../../utility/latest-versions';
+
+export default function (): Rule {
+  return (host, context) => {
+    const dependenciesToUpdate: Record<string, string> = {
+      '@types/jasmine': '~3.6.0',
+      'codelyzer': '^6.0.0',
+      'jasmine-core': '~3.6.0',
+      'jasmine-spec-reporter': '~5.0.0',
+      'karma-chrome-launcher': '~3.1.0',
+      'karma-coverage': '~2.0.3',
+      'karma-jasmine': '~4.0.0',
+      'karma-jasmine-html-reporter': '^1.5.0',
+      'tslib': '^2.0.0',
+    };
+
+    let hasChanges = false;
+    for (const [name, version] of Object.entries(dependenciesToUpdate)) {
+      const current = getPackageJsonDependency(host, name);
+      if (!current || current.version === version) {
+        continue;
+      }
+
+      addPackageJsonDependency(host, {
+        type: current.type,
+        name,
+        version,
+        overwrite: true,
+      });
+
+      hasChanges = true;
+    }
+
+    if (hasChanges) {
+      context.addTask(new NodePackageInstallTask());
+    }
+  };
+}


### PR DESCRIPTION
This change reuses the v10 migration with update package versions to ensure that an updated project matches the development dependency versions of a newly generated project.