### PR TITLE
fix(@angular-devkit/build-angular): show missing karma-coverage error when it's not configured

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/plugins/karma.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/plugins/karma.ts
@@ -99,14 +99,13 @@ const init: any = (config: any, emitter: any, customFileHandlers: any) => {
     const hasIstanbulReporter = reporters.includes('coverage-istanbul');
     if (hasCoveragePlugin && !hasCoverageReporter) {
       reporters.push('coverage');
-    }
-    else if (hasIstanbulPlugin && !hasIstanbulReporter) {
+    } else if (hasIstanbulPlugin && !hasIstanbulReporter) {
       // coverage-istanbul is deprecated in favor of karma-coverage
       reporters.push('coverage-istanbul');
+    } else if (!hasCoveragePlugin && !hasIstanbulPlugin) {
+      throw new Error('karma-coverage must be installed in order to run code coverage.');
     }
-    else {
-      throw new Error('karma-coverage must be installed in order to run code coverage');
-    }
+
     if (hasIstanbulPlugin) {
       logger.warn(`'karma-coverage-istanbul-reporter' usage has been deprecated since version 11.\n` +
        `Please install 'karma-coverage' and update 'karma.conf.js.' ` +


### PR DESCRIPTION

This fixes an issue where previously `karma-coverage must be installed in order to run code coverage` error was shown incorrectly.

Closes: #19359