### PR TITLE
fix(@angular-devkit/build-angular) allow json files in fileReplacement

### DIFF
--- a/packages/angular/cli/lib/config/schema.json
+++ b/packages/angular/cli/lib/config/schema.json
@@ -1063,11 +1063,11 @@
                   "properties": {
                     "src": {
                       "type": "string",
-                      "pattern": "\\.([cm]?j|t)sx?$"
+                      "pattern": "\\.(([cm]?j|t)sx?|json)$"
                     },
                     "replaceWith": {
                       "type": "string",
-                      "pattern": "\\.([cm]?j|t)sx?$"
+                      "pattern": "\\.(([cm]?j|t)sx?|json)$"
                     }
                   },
                   "additionalProperties": false,
@@ -1081,11 +1081,11 @@
                   "properties": {
                     "replace": {
                       "type": "string",
-                      "pattern": "\\.([cm]?j|t)sx?$"
+                      "pattern": "\\.(([cm]?j|t)sx?|json)$"
                     },
                     "with": {
                       "type": "string",
-                      "pattern": "\\.([cm]?j|t)sx?$"
+                      "pattern": "\\.(([cm]?j|t)sx?|json)$"
                     }
                   },
                   "additionalProperties": false,
@@ -1960,11 +1960,11 @@
                   "properties": {
                     "src": {
                       "type": "string",
-                      "pattern": "\\.([cm]?j|t)sx?$"
+                      "pattern": "\\.(([cm]?j|t)sx?|json)$"
                     },
                     "replaceWith": {
                       "type": "string",
-                      "pattern": "\\.([cm]?j|t)sx?$"
+                      "pattern": "\\.(([cm]?j|t)sx?|json)$"
                     }
                   },
                   "additionalProperties": false,
@@ -1978,11 +1978,11 @@
                   "properties": {
                     "replace": {
                       "type": "string",
-                      "pattern": "\\.([cm]?j|t)sx?$"
+                      "pattern": "\\.(([cm]?j|t)sx?|json)$"
                     },
                     "with": {
                       "type": "string",
-                      "pattern": "\\.([cm]?j|t)sx?$"
+                      "pattern": "\\.(([cm]?j|t)sx?|json)$"
                     }
                   },
                   "additionalProperties": false,

--- a/packages/angular_devkit/build_angular/src/browser/schema.json
+++ b/packages/angular_devkit/build_angular/src/browser/schema.json
@@ -434,11 +434,11 @@
           "properties": {
             "src": {
               "type": "string",
-              "pattern": "\\.([cm]?j|t)sx?$"
+              "pattern": "\\.(([cm]?j|t)sx?|json)$"
             },
             "replaceWith": {
               "type": "string",
-              "pattern": "\\.([cm]?j|t)sx?$"
+              "pattern": "\\.(([cm]?j|t)sx?|json)$"
             }
           },
           "additionalProperties": false,
@@ -452,11 +452,11 @@
           "properties": {
             "replace": {
               "type": "string",
-              "pattern": "\\.([cm]?j|t)sx?$"
+              "pattern": "\\.(([cm]?j|t)sx?|json)$"
             },
             "with": {
               "type": "string",
-              "pattern": "\\.([cm]?j|t)sx?$"
+              "pattern": "\\.(([cm]?j|t)sx?|json)$"
             }
           },
           "additionalProperties": false,

--- a/packages/angular_devkit/build_angular/src/server/schema.json
+++ b/packages/angular_devkit/build_angular/src/server/schema.json
@@ -260,11 +260,11 @@
           "properties": {
             "src": {
               "type": "string",
-              "pattern": "\\.([cm]?j|t)sx?$"
+              "pattern": "\\.(([cm]?j|t)sx?|json)$"
             },
             "replaceWith": {
               "type": "string",
-              "pattern": "\\.([cm]?j|t)sx?$"
+              "pattern": "\\.(([cm]?j|t)sx?|json)$"
             }
           },
           "additionalProperties": false,
@@ -278,11 +278,11 @@
           "properties": {
             "replace": {
               "type": "string",
-              "pattern": "\\.([cm]?j|t)sx?$"
+              "pattern": "\\.(([cm]?j|t)sx?|json)$"
             },
             "with": {
               "type": "string",
-              "pattern": "\\.([cm]?j|t)sx?$"
+              "pattern": "\\.(([cm]?j|t)sx?|json)$"
             }
           },
           "additionalProperties": false,


### PR DESCRIPTION
JSON files a can also be valid fileReplacement when using the `resolveJsonModule` TypeScript feature. This causes JSON files to be resolved as JS modules and hence be part of the TypeScript program.

Closes #19378