### PR TITLE
fix(@angular/cli): remove @angular-devkit/build-ng-packagr from update

### DIFF
--- a/packages/angular/cli/package.json
+++ b/packages/angular/cli/package.json
@@ -52,7 +52,6 @@
     "packageGroup": {
       "@angular/cli": "0.0.0",
       "@angular-devkit/build-angular": "0.0.0",
-      "@angular-devkit/build-ng-packagr": "0.0.0",
       "@angular-devkit/build-webpack": "0.0.0",
       "@angular-devkit/core": "0.0.0",
       "@angular-devkit/schematics": "0.0.0"


### PR DESCRIPTION
This package is no longer released.