### PR TITLE
fix(@ngtools/webpack): only use `require.resolve` as a fallback in NGCC processing

### DIFF
--- a/packages/ngtools/webpack/src/angular_compiler_plugin.ts
+++ b/packages/ngtools/webpack/src/angular_compiler_plugin.ts
@@ -785,21 +785,14 @@ export class AngularCompilerPlugin {
 
       let ngccProcessor: NgccProcessor | undefined;
       if (this._compilerOptions.enableIvy) {
-        const fileWatchPurger = (path: string) => {
-          // tslint:disable-next-line: no-any
-          if ((compilerWithFileSystems.inputFileSystem as any).purge) {
-            // tslint:disable-next-line: no-any
-            (compilerWithFileSystems.inputFileSystem as any).purge(path);
-          }
-        };
-
         ngccProcessor = new NgccProcessor(
           this._mainFields,
-          fileWatchPurger,
           this._warnings,
           this._errors,
           this._basePath,
           this._tsConfigPath,
+          compilerWithFileSystems.inputFileSystem,
+          compiler.options.resolve?.symlinks,
         );
 
         ngccProcessor.process();

--- a/packages/ngtools/webpack/src/ivy/plugin.ts
+++ b/packages/ngtools/webpack/src/ivy/plugin.ts
@@ -59,22 +59,16 @@ function initializeNgccProcessor(
   const { inputFileSystem, options: webpackOptions } = compiler;
   const mainFields = ([] as string[]).concat(...(webpackOptions.resolve?.mainFields || []));
 
-  const fileWatchPurger = (path: string) => {
-    if (inputFileSystem.purge) {
-      // Webpack typings do not contain the string parameter overload for purge
-      (inputFileSystem as { purge(path: string): void }).purge(path);
-    }
-  };
-
   const errors: string[] = [];
   const warnings: string[] = [];
   const processor = new NgccProcessor(
     mainFields,
-    fileWatchPurger,
     warnings,
     errors,
     compiler.context,
     tsconfig,
+    inputFileSystem,
+    webpackOptions.resolve?.symlinks,
   );
 
   return { processor, errors, warnings };


### PR DESCRIPTION
fix(@ngtools/webpack): only use `require.resolve` as a fallback in NGCC processing

Use `enhanced-resolve` instead of `require.resolve` to ensure that we can use symlink path instead of real-path when resolving a linked module.

Closes #19395