### PR TITLE
fix(@angular-devkit/build-angular): remove unneeded update package group

### DIFF
--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -102,10 +102,5 @@
     "tslint": {
       "optional": true
     }
-  },
-  "ng-update": {
-    "packageGroup": {
-      "codelyzer": "^6.0.0"
-    }
   }
 }


### PR DESCRIPTION
The `ng-update` field errantly caused this package to show up in the ng update list.  The package group with `codelyzer` also did not provide a benefit as `codelyzer` is updated via a migration and tslint support is now deprecated.