### PR TITLE
fix(@schematics/update): ignore `@angular-devkit/build-ng-packagr` incompatible peer dependency

### DIFF
--- a/packages/schematics/update/update/index.ts
+++ b/packages/schematics/update/update/index.ts
@@ -172,6 +172,12 @@ function _validateReversePeerDependencies(
         continue;
       }
 
+      if (installed === '@angular-devkit/build-ng-packagr') {
+        // Ignore peerDependencies mismatches for `@angular-devkit/build-ng-packagr`.
+        // This package is deprecated and is removed via a migration.
+        continue;
+      }
+
       // Override the peer version range if it's known as a compatible.
       const extendedRange = _updatePeerVersion(infoMap, peer, range);
 


### PR DESCRIPTION

This package is deprecated and is removed via a migration.

Closes #19384