### PR TITLE
fix(@angular-devkit/build-webpack): properly shutdown webpack 5 compilation

### DIFF
--- a/packages/angular_devkit/build_webpack/src/webpack/index.ts
+++ b/packages/angular_devkit/build_webpack/src/webpack/index.ts
@@ -54,10 +54,9 @@ export function runWebpack(
   return createWebpack({ ...config, watch: false }).pipe(
     switchMap(webpackCompiler => new Observable<BuildResult>(obs => {
       // Webpack 5 has a compiler level close function
-      // The close function will crash if caching is disabled
-      const compilerClose = webpackCompiler.options.cache !== false
-        ? (webpackCompiler as { close?(callback: () => void): void }).close
-        : undefined;
+      const compilerClose = (webpackCompiler as { close?(callback: () => void): void }).close?.bind(
+        webpackCompiler,
+      );
 
       const callback = (err?: Error, stats?: webpack.Stats) => {
         if (err) {


### PR DESCRIPTION
This change ensures that the compiler instance is used when closing the compiler.