### PR TITLE
fix(@angular-devkit/build-angular): disable output hashing when running dev-server

### DIFF
--- a/tests/legacy-cli/e2e/tests/basic/ivy.ts
+++ b/tests/legacy-cli/e2e/tests/basic/ivy.ts
@@ -38,9 +38,7 @@ export default async function() {
     }
 
     // Verify it's Ivy.
-    const mainUrlMatch = body.match(/src="(main\.[a-z0-9]{0,32}\.js)"/);
-    const mainUrl = mainUrlMatch && mainUrlMatch[1];
-    const main = await request('http://localhost:4200/' + mainUrl);
+    const main = await request('http://localhost:4200/main.js');
 
     if (!main.match(/ɵcmp\s*=/) && !main.match(/\\u0275cmp\s*=/)) {
       throw new Error('Ivy could not be found.');


### PR DESCRIPTION


Using output hashing with the dev-server can cause memory leaks because the dev server does not know when to clean up the old files.

See: https://github.com/webpack/webpack-dev-server/issues/377#issuecomment-241258405

Closes #10411