### PR TITLE
fix(@angular-devkit/build-angular): apply local libraries sourcemap without `vendor: true`

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
@@ -47,6 +47,7 @@ import {
   WebpackRollupLoader,
 } from '../plugins';
 import { getEsVersionForFileName, getOutputHashFormat, getWatchOptions, normalizeExtraEntryPoints } from '../utils/helpers';
+import { IGNORE_WARNINGS } from '../utils/stats';
 
 const TerserPlugin = require('terser-webpack-plugin');
 const PnpWebpackPlugin = require('pnp-webpack-plugin');
@@ -366,10 +367,12 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
     extraPlugins.push(new BundleBudgetPlugin({ budgets: buildOptions.budgets }));
   }
 
-  if ((scriptsSourceMap || stylesSourceMap) && vendorSourceMap) {
+  if ((scriptsSourceMap || stylesSourceMap)) {
     extraRules.push({
       test: /\.m?js$/,
-      exclude: /(ngfactory|ngstyle)\.js$/,
+      exclude: vendorSourceMap
+        ? /(ngfactory|ngstyle)\.js$/
+        : [/[\\\/]node_modules[\\\/]/, /(ngfactory|ngstyle)\.js$/],
       enforce: 'pre',
       loader: require.resolve('source-map-loader'),
     });
@@ -512,6 +515,7 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
     performance: {
       hints: false,
     },
+    ...withWebpackFourOrFive({}, { ignoreWarnings: IGNORE_WARNINGS }),
     module: {
       // Show an error for missing exports instead of a warning.
       strictExportPresence: true,

--- a/packages/angular_devkit/build_angular/src/webpack/utils/stats.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/utils/stats.ts
@@ -13,6 +13,7 @@ import * as path from 'path';
 import * as textTable from 'text-table';
 import { colors as ansiColors, removeColor } from '../../utils/color';
 import { Configuration, Stats } from 'webpack';
+import { isWebpackFiveOrHigher } from '../../utils/webpack-version';
 
 export function formatSize(size: number): string {
   if (size <= 0) {
@@ -212,11 +213,19 @@ function statsToString(json: any, statsConfig: any, bundleState?: BundleStats[])
   }
 }
 
-const ERRONEOUS_WARNINGS_FILTER = (warning: string) => ![
+export const IGNORE_WARNINGS = [
   // Webpack 5+ has no facility to disable this warning.
   // System.import is used in @angular/core for deprecated string-form lazy routes
   /System.import\(\) is deprecated and will be removed soon/i,
-].some(msg => msg.test(warning));
+  // https://github.com/webpack-contrib/source-map-loader/blob/b2de4249c7431dd8432da607e08f0f65e9d64219/src/index.js#L83
+  /Failed to parse source map from/,
+];
+
+// TODO: remove when Webpack 4 is no longer supported.
+// See: https://webpack.js.org/configuration/other-options/#ignorewarnings
+const ERRONEOUS_WARNINGS_FILTER = isWebpackFiveOrHigher()
+  ? (warning: string) => warning
+  : (warning: string) => !IGNORE_WARNINGS.some(msg => msg.test(warning));
 
 interface WebpackDiagnostic {
   message: string;


### PR DESCRIPTION


With this change we apply sourcemaps of libraries in a monorepo without the need to enable `vendor: true`. This is more intuitive behavior and  in line with what the users expect.

We also suppress the `Failed to parse source map from` in-actionable warning.

Closes #11305