### PR TITLE
feat(@angular-devkit/build-angular): enable inlining of critical CSS optimizations

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
     "conventional-commits-parser": "^3.0.0",
     "copy-webpack-plugin": "6.3.2",
     "core-js": "3.8.0",
+    "critters": "0.0.6",
     "css-loader": "5.0.1",
     "cssnano": "4.1.10",
     "debug": "^4.1.1",

--- a/packages/angular/cli/lib/config/schema.json
+++ b/packages/angular/cli/lib/config/schema.json
@@ -715,7 +715,7 @@
               "additionalProperties": false
             },
             "optimization": {
-              "description": "Enables optimization of the build output. Including minification of scripts and styles, tree-shaking, dead-code elimination and fonts inlining. For more information, see https://angular.io/guide/workspace-config#optimization-and-source-map-configuration.",
+              "description": "Enables optimization of the build output. Including minification of scripts and styles, tree-shaking, dead-code elimination, inlining of critical CSS and fonts inlining. For more information, see https://angular.io/guide/workspace-config#optimization-and-source-map-configuration.",
               "oneOf": [
                 {
                   "type": "object",
@@ -726,9 +726,29 @@
                       "default": true
                     },
                     "styles": {
-                      "type": "boolean",
                       "description": "Enables optimization of the styles output.",
-                      "default": true
+                      "default": true,
+                      "oneOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "minify": {
+                              "type": "boolean",
+                              "description": "Minify CSS definitions by removing extraneous whitespace and comments, merging identifiers and minimizing values.",
+                              "default": true
+                            },
+                            "inlineCritical": {
+                              "type": "boolean",
+                              "description": "Extract and inline critical CSS definitions to improve first paint time.",
+                              "default": false
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "boolean"
+                        }
+                      ]
                     },
                     "fonts": {
                       "description": "Enables optimization for fonts. This requires internet access.",

--- a/packages/angular_devkit/build_angular/BUILD.bazel
+++ b/packages/angular_devkit/build_angular/BUILD.bazel
@@ -145,6 +145,7 @@ ts_library(
         "@npm//circular-dependency-plugin",
         "@npm//copy-webpack-plugin",
         "@npm//core-js",
+        "@npm//critters",
         "@npm//css-loader",
         "@npm//cssnano",
         "@npm//file-loader",

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -28,6 +28,7 @@
     "circular-dependency-plugin": "5.2.2",
     "copy-webpack-plugin": "6.3.2",
     "core-js": "3.8.0",
+    "critters": "0.0.6",
     "css-loader": "5.0.1",
     "cssnano": "4.1.10",
     "file-loader": "6.2.0",

--- a/packages/angular_devkit/build_angular/src/browser/index.ts
+++ b/packages/angular_devkit/build_angular/src/browser/index.ts
@@ -685,7 +685,7 @@ export function buildWebpackBrowser(
 
                   for (const [locale, outputPath] of outputPaths.entries()) {
                     try {
-                      const content = await indexHtmlGenerator.process({
+                      const { content, warnings, errors } = await indexHtmlGenerator.process({
                         baseHref: getLocaleBaseHref(i18n, locale) || options.baseHref,
                         // i18nLocale is used when Ivy is disabled
                         lang: locale || options.i18nLocale,
@@ -694,6 +694,13 @@ export function buildWebpackBrowser(
                         noModuleFiles: mapEmittedFilesToFileInfo(noModuleFiles),
                         moduleFiles: mapEmittedFilesToFileInfo(moduleFiles),
                       });
+
+                      if (warnings.length || errors.length) {
+                        spinner.stop();
+                        warnings.forEach(m => context.logger.warn(m));
+                        errors.forEach(m => context.logger.error(m));
+                        spinner.start();
+                      }
 
                       const indexOutput = path.join(outputPath, getIndexOutputFile(options.index));
                       await mkdir(path.dirname(indexOutput), { recursive: true });

--- a/packages/angular_devkit/build_angular/src/browser/schema.json
+++ b/packages/angular_devkit/build_angular/src/browser/schema.json
@@ -57,7 +57,7 @@
       "additionalProperties": false
     },
     "optimization": {
-      "description": "Enables optimization of the build output. Including minification of scripts and styles, tree-shaking, dead-code elimination and fonts inlining. For more information, see https://angular.io/guide/workspace-config#optimization-and-source-map-configuration.",
+      "description": "Enables optimization of the build output. Including minification of scripts and styles, tree-shaking, dead-code elimination, inlining of critical CSS and fonts inlining. For more information, see https://angular.io/guide/workspace-config#optimization-and-source-map-configuration.",
       "x-user-analytics": 16,
       "default": false,
       "oneOf": [
@@ -70,9 +70,29 @@
               "default": true
             },
             "styles": {
-              "type": "boolean",
               "description": "Enables optimization of the styles output.",
-              "default": true
+              "default": true,
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "minify": {
+                      "type": "boolean",
+                      "description": "Minify CSS definitions by removing extraneous whitespace and comments, merging identifiers and minimizing values.",
+                      "default": true
+                    },
+                    "inlineCritical": {
+                      "type": "boolean",
+                      "description": "Extract and inline critical CSS definitions to improve first paint time.",
+                      "default": false
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "boolean"
+                }
+              ]
             },
             "fonts": {
               "description": "Enables optimization for fonts. This requires internet access.",

--- a/packages/angular_devkit/build_angular/src/browser/specs/inline-critical-css-optimization_spec.ts
+++ b/packages/angular_devkit/build_angular/src/browser/specs/inline-critical-css-optimization_spec.ts
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { Architect } from '@angular-devkit/architect';
+import { browserBuild, createArchitect, host } from '../../test-utils';
+
+describe('Browser Builder inline critical CSS optimization', () => {
+  const target = { project: 'app', target: 'build' };
+  const overrides = {
+    optimization: {
+      scripts: false,
+      styles: {
+        minify: true,
+        inlineCritical: true,
+      },
+      fonts: false,
+    },
+  };
+
+  let architect: Architect;
+
+  beforeEach(async () => {
+    await host.initialize().toPromise();
+    architect = (await createArchitect(host.root())).architect;
+    host.writeMultipleFiles({
+      'src/styles.css': `
+        body { color: #000 }
+      `,
+    });
+  });
+
+  afterEach(async () => host.restore().toPromise());
+
+  it('works', async () => {
+    const { files } = await browserBuild(architect, host, target, overrides);
+    const html = await files['index.html'];
+    expect(html).toContain(`<link rel="stylesheet" href="styles.css" media="print" onload="this.media='all'">`);
+    expect(html).toContain(`body{color:#000;}`);
+  });
+
+  it('works with deployUrl', async () => {
+    const { files } = await browserBuild(architect, host, target, { ...overrides, deployUrl: 'http://cdn.com/' });
+    const html = await files['index.html'];
+    expect(html).toContain(`<link rel="stylesheet" href="http://cdn.com/styles.css" media="print" onload="this.media='all'">`);
+    expect(html).toContain(`body{color:#000;}`);
+  });
+
+  it('should not inline critical css when option is disabled', async () => {
+    const { files } = await browserBuild(architect, host, target, { optimization: false });
+    const html = await files['index.html'];
+    expect(html).toContain(`<link rel="stylesheet" href="styles.css">`);
+    expect(html).not.toContain(`body{color:#000;}`);
+  });
+});

--- a/packages/angular_devkit/build_angular/src/dev-server/index.ts
+++ b/packages/angular_devkit/build_angular/src/dev-server/index.ts
@@ -107,9 +107,11 @@ export function serveWebpackBrowser(
       );
 
     // Get dev-server only options.
-    const devServerOptions = (Object.keys(options) as (keyof Schema)[])
+    type DevServerOptions = Partial<Omit<Schema,
+      'watch' | 'optimization' | 'aot' | 'sourceMap' | 'vendorChunk' | 'commonChunk' | 'baseHref' | 'progress' | 'poll' | 'verbose' | 'deployUrl'>>;
+    const devServerOptions: DevServerOptions = (Object.keys(options) as (keyof Schema)[])
       .filter(key => !devServerBuildOverriddenKeys.includes(key) && key !== 'browserTarget')
-      .reduce<Partial<Schema>>(
+      .reduce<DevServerOptions>(
         (previous, key) => ({
           ...previous,
           [key]: options[key],
@@ -288,7 +290,7 @@ export function serveWebpackBrowser(
         );
       }
 
-      if (normalizedOptimization.scripts || normalizedOptimization.styles) {
+      if (normalizedOptimization.scripts || normalizedOptimization.styles.minify) {
         logger.error(tags.stripIndents`
           ****************************************************************************************
           This is a simple server for use in testing or debugging Angular applications locally.

--- a/packages/angular_devkit/build_angular/src/dev-server/inline-critical-css-optimization_spec.ts
+++ b/packages/angular_devkit/build_angular/src/dev-server/inline-critical-css-optimization_spec.ts
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { Architect, BuilderRun } from '@angular-devkit/architect';
+import { DevServerBuilderOutput } from '@angular-devkit/build-angular';
+import fetch from 'node-fetch'; // tslint:disable-line:no-implicit-dependencies
+import { createArchitect, host } from '../test-utils';
+
+describe('Dev Server Builder inline critical CSS optimization', () => {
+  const target = { project: 'app', target: 'serve' };
+  let architect: Architect;
+  let runs: BuilderRun[] = [];
+
+  beforeEach(async () => {
+    await host.initialize().toPromise();
+    architect = (await createArchitect(host.root())).architect;
+    runs = [];
+
+    host.writeMultipleFiles({
+      'src/styles.css': `
+        body { color: #000 }
+      `,
+    });
+  });
+
+  afterEach(async () => {
+    await host.restore().toPromise();
+    await Promise.all(runs.map(r => r.stop()));
+  });
+
+  it('works', async () => {
+    const run = await architect.scheduleTarget(target, { browserTarget: 'app:build:production,inline-critical-css' });
+    runs.push(run);
+    const output = await run.result as DevServerBuilderOutput;
+    expect(output.success).toBe(true);
+    const response = await fetch(`${output.baseUrl}/index.html`);
+    expect(await response.text()).toContain(`body{color:#000;}`);
+  }, 30000);
+});

--- a/packages/angular_devkit/build_angular/src/extract-i18n/index.ts
+++ b/packages/angular_devkit/build_angular/src/extract-i18n/index.ts
@@ -140,10 +140,7 @@ export async function execute(
   const { config, projectRoot } = await generateBrowserWebpackConfigFromContext(
     {
       ...browserOptions,
-      optimization: {
-        scripts: false,
-        styles: false,
-      },
+      optimization: false,
       sourceMap: {
         scripts: true,
         styles: false,

--- a/packages/angular_devkit/build_angular/src/utils/build-options.ts
+++ b/packages/angular_devkit/build_angular/src/utils/build-options.ts
@@ -21,9 +21,10 @@ import {
 } from '../browser/schema';
 import { Schema as DevServerSchema } from '../dev-server/schema';
 import { NormalizedFileReplacement } from './normalize-file-replacements';
+import { NormalizedOptimizationOptions } from './normalize-optimization';
 
 export interface BuildOptions {
-  optimization: OptimizationClass;
+  optimization: NormalizedOptimizationOptions;
   environment?: string;
   outputPath: string;
   resourcesOutputPath?: string;

--- a/packages/angular_devkit/build_angular/src/utils/index-file/inline-critical-css.ts
+++ b/packages/angular_devkit/build_angular/src/utils/index-file/inline-critical-css.ts
@@ -1,0 +1,70 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { readFile } from '../fs';
+
+const Critters: typeof import('critters').default = require('critters');
+
+export interface InlineCriticalCssProcessOptions {
+  outputPath: string;
+}
+
+export interface InlineCriticalCssProcessorOptions {
+  minify?: boolean;
+  deployUrl?: string;
+  readAsset?: (path: string) => Promise<string>;
+}
+class CrittersExtended extends Critters {
+  readonly warnings: string[] = [];
+  readonly errors: string[] = [];
+
+  constructor(private readonly optionsExtended: InlineCriticalCssProcessorOptions & InlineCriticalCssProcessOptions) {
+    super({
+      logger: {
+        warn: (s: string) => this.warnings.push(s),
+        error: (s: string) => this.errors.push(s),
+        log: () => { },
+        info: () => { },
+      },
+      path: optionsExtended.outputPath,
+      publicPath: optionsExtended.deployUrl,
+      compress: !!optionsExtended.minify,
+      pruneSource: false,
+      reduceInlineStyles: false,
+      mergeStylesheets: false,
+      preload: 'media',
+      noscriptFallback: true,
+      // tslint:disable-next-line: no-any
+    } as any);
+  }
+
+  protected readFile(path: string): Promise<string> {
+    const readAsset = this.optionsExtended.readAsset;
+
+    return readAsset ? readAsset(path) : readFile(path, 'utf-8');
+  }
+}
+
+export class InlineCriticalCssProcessor {
+  constructor(protected readonly options: InlineCriticalCssProcessorOptions) { }
+
+  async process(html: string, options: InlineCriticalCssProcessOptions)
+    : Promise<{ content: string, warnings: string[], errors: string[] }> {
+    const critters = new CrittersExtended({ ...this.options, ...options });
+    const content = await critters.process(html);
+
+    return {
+      // Clean up value from value less attributes.
+      // This is caused because parse5 always requires attributes to have a string value.
+      // nomodule="" defer="" -> nomodule defer.
+      content: content.replace(/(\s[a-z]+)=""/g, '$1'),
+      errors: critters.errors,
+      warnings: critters.warnings,
+    };
+  }
+}

--- a/packages/angular_devkit/build_angular/src/utils/index-file/inline-critical-css_spec.ts
+++ b/packages/angular_devkit/build_angular/src/utils/index-file/inline-critical-css_spec.ts
@@ -1,0 +1,103 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { tags } from '@angular-devkit/core';
+import { InlineCriticalCssProcessor } from './inline-critical-css';
+
+describe('InlineCriticalCssProcessor', () => {
+  const styles: Record<string, string> = {
+    '/dist/styles.css': `
+      body { margin: 0; }
+      html { color: white; }
+    `,
+    '/dist/theme.css': `
+      span { color: blue; }
+      p { color: blue; }
+    `,
+  };
+
+  const readAsset = async (file: string): Promise<string> => {
+    const content = styles[file];
+    if (content) {
+      return content;
+    }
+
+    throw new Error('Cannot read asset.');
+  };
+
+  const getContent = (deployUrl: string): string => {
+    return `
+      <html>
+      <head>
+        <link href="${deployUrl}styles.css" rel="stylesheet">
+        <link href="${deployUrl}theme.css" rel="stylesheet">
+      </head>
+      <body></body>
+    </html>`;
+  };
+
+  it('should inline critical css', async () => {
+    const inlineFontsProcessor = new InlineCriticalCssProcessor({
+      readAsset,
+    });
+
+    const { content } = await inlineFontsProcessor.process(getContent(''), {
+      outputPath: '/dist/',
+    });
+
+    expect(content).toContain(`<link href="styles.css" rel="stylesheet" media="print" onload="this.media='all'">`);
+    expect(content).toContain(`<link href="theme.css" rel="stylesheet" media="print" onload="this.media='all'">`);
+    expect(content).not.toContain('color: blue');
+    expect(tags.stripIndents`${content}`).toContain(tags.stripIndents`
+    <style>body {
+      margin: 0;
+      }
+
+      html {
+      color: white;
+      }</style>
+      `);
+  });
+
+  it('should inline critical css when using deployUrl', async () => {
+    const inlineFontsProcessor = new InlineCriticalCssProcessor({
+      readAsset,
+      deployUrl: 'http://cdn.com',
+    });
+
+    const { content } = await inlineFontsProcessor.process(getContent('http://cdn.com/'), {
+      outputPath: '/dist/',
+    });
+
+    expect(content).toContain(`<link href="http://cdn.com/styles.css" rel="stylesheet" media="print" onload="this.media='all'">`);
+    expect(content).toContain(`<link href="http://cdn.com/theme.css" rel="stylesheet" media="print" onload="this.media='all'">`);
+    expect(tags.stripIndents`${content}`).toContain(tags.stripIndents`
+    <style>body {
+      margin: 0;
+      }
+
+      html {
+      color: white;
+      }</style>
+      `);
+  });
+
+  it('should compress inline critical css when minify is enabled', async () => {
+    const inlineFontsProcessor = new InlineCriticalCssProcessor({
+      readAsset,
+      minify: true,
+    });
+
+    const { content } = await inlineFontsProcessor.process(getContent(''), {
+      outputPath: '/dist/',
+    });
+
+    expect(content).toContain(`<link href="styles.css" rel="stylesheet" media="print" onload="this.media='all'">`);
+    expect(content).toContain(`<link href="theme.css" rel="stylesheet" media="print" onload="this.media='all'">`);
+    expect(content).toContain('<style>body{margin:0;}html{color:white;}</style>');
+  });
+});

--- a/packages/angular_devkit/build_angular/src/utils/index-file/inline-fonts.ts
+++ b/packages/angular_devkit/build_angular/src/utils/index-file/inline-fonts.ts
@@ -27,7 +27,7 @@ const SUPPORTED_PROVIDERS = [
 ];
 
 export interface InlineFontsOptions {
-  minifyInlinedCSS: boolean;
+  minify?: boolean;
   WOFFSupportNeeded: boolean;
 }
 
@@ -157,7 +157,7 @@ export class InlineFontsProcessor {
       }
       cssContent += await this.getResponse(url, UserAgent.Chrome);
 
-      if (this.options.minifyInlinedCSS) {
+      if (this.options.minify) {
         cssContent = cssContent
           // Comments.
           .replace(/\/\*([\s\S]*?)\*\//g, '')

--- a/packages/angular_devkit/build_angular/src/utils/index-file/inline-fonts_spec.ts
+++ b/packages/angular_devkit/build_angular/src/utils/index-file/inline-fonts_spec.ts
@@ -18,7 +18,7 @@ describe('InlineFontsProcessor', () => {
 
   it('should inline supported fonts and icons in HTML', async () => {
     const inlineFontsProcessor = new InlineFontsProcessor({
-      minifyInlinedCSS: false,
+      minify: false,
       WOFFSupportNeeded: false,
     });
 
@@ -41,7 +41,7 @@ describe('InlineFontsProcessor', () => {
 
   it('should inline multiple fonts from a single request with minification enabled', async () => {
     const inlineFontsProcessor = new InlineFontsProcessor({
-      minifyInlinedCSS: true,
+      minify: true,
       WOFFSupportNeeded: false,
     });
 
@@ -63,7 +63,7 @@ describe('InlineFontsProcessor', () => {
   it('works with http protocol', async () => {
     const inlineFontsProcessor = new InlineFontsProcessor({
       WOFFSupportNeeded: false,
-      minifyInlinedCSS: false,
+      minify: false,
     });
 
     const html = await inlineFontsProcessor
@@ -74,7 +74,7 @@ describe('InlineFontsProcessor', () => {
   it('works with // protocol', async () => {
     const inlineFontsProcessor = new InlineFontsProcessor({
       WOFFSupportNeeded: false,
-      minifyInlinedCSS: false,
+      minify: false,
     });
 
     const html = await inlineFontsProcessor
@@ -85,7 +85,7 @@ describe('InlineFontsProcessor', () => {
   it('should include WOFF1 definitions when `WOFF1SupportNeeded` is true', async () => {
     const inlineFontsProcessor = new InlineFontsProcessor({
       WOFFSupportNeeded: true,
-      minifyInlinedCSS: false,
+      minify: false,
     });
 
     const html = await inlineFontsProcessor.process(content);
@@ -96,7 +96,7 @@ describe('InlineFontsProcessor', () => {
   it('should remove comments and line breaks when `minifyInlinedCSS` is true', async () => {
     const inlineFontsProcessor = new InlineFontsProcessor({
       WOFFSupportNeeded: false,
-      minifyInlinedCSS: true,
+      minify: true,
     });
 
     const html = await inlineFontsProcessor.process(content);

--- a/packages/angular_devkit/build_angular/src/utils/normalize-builder-schema.ts
+++ b/packages/angular_devkit/build_angular/src/utils/normalize-builder-schema.ts
@@ -11,7 +11,6 @@
 import { Path, virtualFs } from '@angular-devkit/core';
 import {
   AssetPatternClass,
-  OptimizationClass,
   Schema as BrowserBuilderSchema,
   SourceMapClass,
 } from '../browser/schema';
@@ -21,7 +20,7 @@ import {
   NormalizedFileReplacement,
   normalizeFileReplacements,
 } from './normalize-file-replacements';
-import { normalizeOptimization } from './normalize-optimization';
+import { NormalizedOptimizationOptions, normalizeOptimization } from './normalize-optimization';
 import { normalizeSourceMaps } from './normalize-source-maps';
 
 
@@ -32,7 +31,7 @@ export type NormalizedBrowserBuilderSchema = BrowserBuilderSchema & BuildOptions
   sourceMap: SourceMapClass;
   assets: AssetPatternClass[];
   fileReplacements: NormalizedFileReplacement[];
-  optimization: OptimizationClass;
+  optimization: NormalizedOptimizationOptions;
 };
 
 export function normalizeBrowserSchema(

--- a/packages/angular_devkit/build_angular/src/utils/normalize-optimization.ts
+++ b/packages/angular_devkit/build_angular/src/utils/normalize-optimization.ts
@@ -6,17 +6,22 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { FontsClass, OptimizationClass, OptimizationUnion } from '../browser/schema';
+import { FontsClass, OptimizationClass, OptimizationUnion, StylesClass } from '../browser/schema';
 
-export type NormalizeOptimizationOptions = Required<Omit<OptimizationClass, 'fonts'>> & {
+export type NormalizedOptimizationOptions = Required<Omit<OptimizationClass, 'fonts' | 'styles'>> & {
   fonts: FontsClass,
+  styles: StylesClass,
 };
 
-export function normalizeOptimization(optimization: OptimizationUnion = false): NormalizeOptimizationOptions {
+export function normalizeOptimization(optimization: OptimizationUnion = false): NormalizedOptimizationOptions {
   if (typeof optimization === 'object') {
     return {
       scripts: !!optimization.scripts,
-      styles: !!optimization.styles,
+      styles: typeof optimization.styles === 'object' ? optimization.styles : {
+        minify: !!optimization.styles,
+        // inlineCritical is always false unless explictly set.
+        inlineCritical: false,
+      },
       fonts: typeof optimization.fonts === 'object' ? optimization.fonts : {
         inline: !!optimization.fonts,
       },
@@ -25,7 +30,11 @@ export function normalizeOptimization(optimization: OptimizationUnion = false): 
 
   return {
     scripts: optimization,
-    styles: optimization,
+    styles: {
+      minify: optimization,
+      // inlineCritical is always false unless explictly set.
+      inlineCritical: false,
+    },
     fonts: {
       inline: optimization,
     },

--- a/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
@@ -390,7 +390,7 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
   }
 
   const extraMinimizers = [];
-  if (stylesOptimization) {
+  if (stylesOptimization.minify) {
     extraMinimizers.push(
       new OptimizeCssWebpackPlugin({
         sourceMap: stylesSourceMap,
@@ -481,7 +481,7 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
   }
 
   return {
-    mode: scriptsOptimization || stylesOptimization ? 'production' : 'development',
+    mode: scriptsOptimization || stylesOptimization.minify ? 'production' : 'development',
     devtool: false,
     profile: buildOptions.statsJson,
     resolve: {

--- a/packages/angular_devkit/build_angular/src/webpack/configs/dev-server.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/dev-server.ts
@@ -106,11 +106,11 @@ export function getDevServerConfig(
       },
       sockPath: posix.join(servePath, 'sockjs-node'),
       stats: false,
-      compress: stylesOptimization || scriptsOptimization,
+      compress: stylesOptimization.minify || scriptsOptimization,
       watchOptions: getWatchOptions(poll),
       https: getSslConfig(root, wco.buildOptions),
       overlay: {
-        errors: !(stylesOptimization || scriptsOptimization),
+        errors: !(stylesOptimization.minify || scriptsOptimization),
         warnings: false,
       },
       public: publicHost,

--- a/packages/angular_devkit/build_angular/src/webpack/configs/styles.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/styles.ts
@@ -191,7 +191,7 @@ export function getStylesConfig(wco: WebpackConfigOptions) {
     cssSourceMap
     // Never use component css sourcemap when style optimizations are on.
     // It will just increase bundle size without offering good debug experience.
-    && !buildOptions.optimization.styles
+    && !buildOptions.optimization.styles.minify
     // Inline all sourcemap types except hidden ones, which are the same as no sourcemaps
     // for component css.
     && !buildOptions.sourceMap.hidden

--- a/packages/angular_devkit/build_angular/test/hello-world-app/angular.json
+++ b/packages/angular_devkit/build_angular/test/hello-world-app/angular.json
@@ -48,6 +48,16 @@
               "extractLicenses": true,
               "vendorChunk": false,
               "buildOptimizer": true
+            },
+            "inline-critical-css": {
+              "optimization": {
+                "styles": {
+                  "minify": true,
+                  "inlineCritical": true
+                },
+                "scripts": true,
+                "fonts": true
+              }
             }
           }
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3953,6 +3953,17 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+critters@0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/critters/-/critters-0.0.6.tgz#b71384113d8b5f5c82f3aeba80c122437f195d8c"
+  integrity sha512-NUB3Om7tkf+XWi9+2kJ2A3l4/tHORDI1UT+nHxUqay2B/tJvMpiXcklDDLBH3fPn9Pe23uu0we/08Ukjy4cLCQ==
+  dependencies:
+    chalk "^4.1.0"
+    css "^3.0.0"
+    parse5 "^6.0.1"
+    parse5-htmlparser2-tree-adapter "^6.0.1"
+    pretty-bytes "^5.3.0"
+
 cross-spawn@^6.0.0:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -4081,6 +4092,15 @@ css@^2.0.0:
     source-map "^0.6.1"
     source-map-resolve "^0.5.2"
     urix "^0.1.0"
+
+css@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/css/-/css-3.0.0.tgz#4447a4d58fdd03367c516ca9f64ae365cee4aa5d"
+  integrity sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==
+  dependencies:
+    inherits "^2.0.4"
+    source-map "^0.6.1"
+    source-map-resolve "^0.6.0"
 
 cssauron@^1.4.0:
   version "1.4.0"
@@ -9036,6 +9056,13 @@ parse5-html-rewriting-stream@6.0.1:
     parse5 "^6.0.1"
     parse5-sax-parser "^6.0.1"
 
+parse5-htmlparser2-tree-adapter@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz#2cdf9ad823321140370d4dbf5d3e92c7c8ddc6e6"
+  integrity sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==
+  dependencies:
+    parse5 "^6.0.1"
+
 parse5-sax-parser@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/parse5-sax-parser/-/parse5-sax-parser-6.0.1.tgz#98b4d366b5b266a7cd90b4b58906667af882daba"
@@ -9662,6 +9689,11 @@ prettier@^2.0.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
   integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
+
+pretty-bytes@^5.3.0:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-5.4.1.tgz#cd89f79bbcef21e3d21eb0da68ffe93f803e884b"
+  integrity sha512-s1Iam6Gwz3JI5Hweaz4GoCD1WUNUIyzePFy5+Js2hjwGVt2Z79wNN+ZKOZ2vB6C+Xs6njyB84Z1IthQg8d9LxA==
 
 process-nextick-args@~1.0.6:
   version "1.0.7"


### PR DESCRIPTION

This is another feature that we mentioned in the Eliminate Render Blocking Requests RFC (#18730)

Inlining of critical CSS is turned off by default. To opt-in this feature set `inlineCritical` to `true`.

Example:
```json

"configurations": {
  "production": {
    "fileReplacements": [
      {
        "replace": "src/environments/environment.ts",
        "with": "src/environments/environment.prod.ts"
      }
    ],
    "optimization": {
      "styles": {
        "minify": true,
        "inlineCritical": true,
       }
    },
```

To learn more about critical CSS see;
https://web.dev/defer-non-critical-css
https://web.dev/extract-critical-css/

In a future version of the Angular CLI `inlineCritical` will be enabled by default.

Closes: #17966
Closes: #11395
Closes: #19445