### PR TITLE
ci: add Node.js 14 E2E job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,6 +223,19 @@ jobs:
             PATH=~/.npm-global/bin:$PATH npm install --global npm
       - run: PATH=~/.npm-global/bin:$PATH node ./tests/legacy-cli/run_e2e --nb-shards=${CIRCLE_NODE_TOTAL} --shard=${CIRCLE_NODE_INDEX}
 
+  e2e-cli-node-14:
+    executor:
+      name: test-executor
+      nodeversion: "14.15"
+    parallelism: 6
+    steps:
+      - custom_attach_workspace
+      - browser-tools/install-chrome
+      - run:
+          name: Initialize Environment
+          command: ./.circleci/env.sh
+      - run: PATH=~/.npm-global/bin:$PATH node ./tests/legacy-cli/run_e2e --nb-shards=${CIRCLE_NODE_TOTAL} --shard=${CIRCLE_NODE_INDEX}
+
   test-browsers:
     executor:
       name: test-executor
@@ -384,6 +397,10 @@ workflows:
                 - renovate/angular
                 - master
       - e2e-cli-node-10:
+          <<: *only_release_branches
+          requires:
+            - e2e-cli
+      - e2e-cli-node-14:
           <<: *only_release_branches
           requires:
             - e2e-cli


### PR DESCRIPTION
This will run a full E2E test suite with Node.js 14 on master and release branches.  PRs are currently Node.js 12 only.  Node.js 10 is also not run on PRs.