### PR TITLE
ci: disable 8.3 nightly build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -459,28 +459,3 @@ workflows:
               only: /^v\d+/
             branches:
               ignore: /.*/
-  nightly:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only:
-                - 8.3.x
-    jobs:
-      - setup
-      - build:
-          requires:
-            - setup
-      - test:
-          requires:
-            - build
-      - test-large:
-          requires:
-            - build
-      - test-browsers:
-          requires:
-            - build
-      - e2e-cli:
-          requires:
-            - build


### PR DESCRIPTION
Version 8 is close to it's end of life.