### PR TITLE
fix(@angular-devkit/build-angular): allow default Webpack 5 caching

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
@@ -584,8 +584,6 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
       ...withWebpackFourOrFive({}, buildOptions.namedChunks ? { chunkIds: 'named' } : {}),
       ...withWebpackFourOrFive({ noEmitOnErrors: true }, { emitOnErrors: false }),
     },
-    // TODO_WEBPACK_5: Investigate non-working cache in development builds
-    ...withWebpackFourOrFive({}, { cache: false }),
     plugins: [
       // Always replace the context for the System.import in angular/core to prevent warnings.
       // https://github.com/angular/angular/issues/11580


### PR DESCRIPTION
With upstream fixes in place, the default Webpack 5 caching behavior can now be enabled.  In development mode, memory caching will now be used, and in production, caching will be disabled as per Webpack 5 default behavior.