### PR TITLE
fix(@ngtools/webpack): remove use of Webpack compilation fileTimestamps property

### DIFF
--- a/packages/ngtools/webpack/src/ivy/cache.ts
+++ b/packages/ngtools/webpack/src/ivy/cache.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import * as ts from 'typescript';
+import { normalizePath } from './paths';
+
+export class SourceFileCache extends Map<string, ts.SourceFile> {
+  invalidate(
+    fileTimestamps: Map<string, number | { timestamp: number } | null>,
+    buildTimestamp: number,
+  ): Set<string> {
+    const changedFiles = new Set<string>();
+    for (const [file, timeOrEntry] of fileTimestamps) {
+      const time =
+        timeOrEntry && (typeof timeOrEntry === 'number' ? timeOrEntry : timeOrEntry.timestamp);
+      if (time === null || buildTimestamp < time) {
+        // Cache stores paths using the POSIX directory separator
+        const normalizedFile = normalizePath(file);
+        this.delete(normalizedFile);
+        changedFiles.add(normalizedFile);
+      }
+    }
+
+    return changedFiles;
+  }
+}

--- a/packages/ngtools/webpack/src/resource_loader.ts
+++ b/packages/ngtools/webpack/src/resource_loader.ts
@@ -32,27 +32,22 @@ export class WebpackResourceLoader {
   private _cachedSources = new Map<string, string>();
   private _cachedEvaluatedSources = new Map<string, RawSource>();
 
-  private buildTimestamp?: number;
-  public changedFiles = new Set<string>();
+  public changedFiles?: Iterable<string>;
 
-  update(parentCompilation: import('webpack').compilation.Compilation) {
+  update(parentCompilation: import('webpack').compilation.Compilation, changedFiles?: Iterable<string>) {
     this._parentCompilation = parentCompilation;
     this._context = parentCompilation.context;
 
     // Update changed file list
-    if (this.buildTimestamp !== undefined) {
-      this.changedFiles.clear();
-      for (const [file, time] of parentCompilation.fileTimestamps) {
-        if (this.buildTimestamp < time) {
-          this.changedFiles.add(normalizePath(file));
-        }
-      }
-    }
-    this.buildTimestamp = Date.now();
+    this.changedFiles = changedFiles;
   }
 
   getModifiedResourceFiles() {
     const modifiedResources = new Set<string>();
+    if (!this.changedFiles) {
+      return modifiedResources;
+    }
+
     for (const changedFile of this.changedFiles) {
       this.getAffectedResources(
         changedFile,


### PR DESCRIPTION
The `fileTimestamps` property on the Webpack compilation object no longer exists with Webpack 5.  This change uses the Webpack compiler's property of the same name instead.  The cache invalidation is also moved to a separate file and now calculates the changed file set as well.  This eliminates the second iteration of the file timestamps within the resource loader.