### PR TITLE
build: set up ng-dev tooling to perform merges in the repository

### DIFF
--- a/.ng-dev/config.ts
+++ b/.ng-dev/config.ts
@@ -1,2 +1,3 @@
 export { commitMessage } from './commit-message';
 export { github } from './github';
+export { merge } from './merge';

--- a/.ng-dev/merge.ts
+++ b/.ng-dev/merge.ts
@@ -1,0 +1,26 @@
+import { DevInfraMergeConfig } from '@angular/dev-infra-private/pr/merge/config';
+import { getDefaultTargetLabelConfiguration } from '@angular/dev-infra-private/pr/merge/defaults';
+import { github } from './github';
+import { release } from './release';
+
+/**
+ * Configuration for the merge tool in `ng-dev`. This sets up the labels which
+ * are respected by the merge script (e.g. the target labels).
+ */
+export const merge: DevInfraMergeConfig['merge'] = async api => {
+  return {
+    githubApiMerge: {
+      default: 'squash',
+      labels: [
+        {pattern: 'preserve commits', method: 'rebase'},
+      ],
+    },
+    claSignedLabel: 'cla: yes',
+    mergeReadyLabel: /^action: merge(-assistance)?/,
+    caretakerNoteLabel: /(action: merge-assistance)/,
+    commitMessageFixupLabel: 'commit message fixup',
+    // We can pick any of the NPM packages as we are in a monorepo where all packages are
+    // published together with the same version and branching.
+    labels: await getDefaultTargetLabelConfiguration(api, github, release),
+  };
+};

--- a/.ng-dev/release.ts
+++ b/.ng-dev/release.ts
@@ -1,0 +1,11 @@
+import { ReleaseConfig } from '@angular/dev-infra-private/release/config';
+import { packages } from '../lib/packages';
+
+/** Configuration for the `ng-dev release` command. */
+export const release: ReleaseConfig = {
+  npmPackages: Object.keys(packages),
+  // TODO: Set up package building.
+  buildPackages: async () => [],
+  // TODO: Set up generating changelogs
+  generateReleaseNotesForHead: async () => {},
+};

--- a/docs/process/release.md
+++ b/docs/process/release.md
@@ -29,54 +29,15 @@ TBD
 
 The list of PRs which are currently ready to merge (approved with passing status checks) can
 be found with [this search](https://github.com/angular/angular-cli/pulls?q=is%3Apr+is%3Aopen+label%3A%22PR+action%3A+merge%22+-is%3Adraft).
-This list should be checked daily and any ready PRs should be merged. For each
-PR, check the `PR target` label to understand where it should be merged to. If
-`master` is targetted, then click "Rebase and Merge". If the PR also targets a
-patch branch, see [Maintaining Patch Branches](#maintaining-patch-branches).
-Whatever the target, rebasing should be used over merging to avoid cluttering
-the Git history with merge commits.
+This list should be checked daily and any ready PRs should be merged. For each PR, check the
+`PR target` label to understand where it should be merged to.  You can find which branches a specific
+PR will be merged into with the `yarn ng-dev pr check-target-branches <pr>` command.
 
-### Maintaining Patch Branches
-
-When a PR is merged, if the `PR target` label includes a branch other than
-`master`, commits will need to be cherry-picked to an associated branch. In
-particular, the `patch` target simply refers to the latest patch branch (eg.
-`1.2.x` or `1.3.x-rc.0`). This branch should be updated by cherry-picking all
-commits from the PR to it.
-
-Cherry picking is done by checking out the patch branch and cherry picking the new commit onto it.
-The patch branch is simply named as a version number, with a X in the relevant spot, such as `9.0.x`.
-This should be done after merging to master.
-
-```shell
-# Make sure commit to upstream/master is present in local repo.
-git fetch upstream master
-
-# Check out patch branch from upstream.
-git fetch upstream <patch branch>
-git checkout <patch branch>
-
-# Cherry pick the commit. Use the hash from the commit which was merged
-# into upstream/master, which should be known to your local repo.
-git cherry-pick -x <commit hash from master>
-# If you have multiple cherry picks, you can do them all here.
-
-# Resolve merge conflicts if necessary...
-# Or abort and ask author to submit a separate commit targeting patch-only.
-
-# Push changes.
-git push upstream <patch branch>
+When ready to merge a PR, run the following command:
+```
+yarn ng-dev pr merge <pr>
 ```
 
-If you get a `bad revision` error when cherry picking, make sure you are using
-the commit hash used when merged into `master`, _not_ the hash listed in the PR.
-Also verify that you have fetched `master` from `upstream` since that commit was
-merged.
-
-If the commit is not merged to `master` (because it targets `patch only` for
-instance), then you will need to fetch the contributor's branch for your local
-Git instance to have knowledge of the commit being cherry picked onto the patch
-branch.
 
 ### Maintaining LTS branches
 


### PR DESCRIPTION
Set up the configurations required for caretakers to be able to rely
on ng-dev for performing merges to all targeted branches.



Blocked on #19515, #19516, #19517 and updating labeling scheme.