### PR TITLE
build: establish current version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@angular/devkit-repo",
-  "version": "0.0.0",
+  "version": "10.2.0",
   "private": true,
   "description": "Software Development Kit for Angular",
   "bin": {


### PR DESCRIPTION
Ahead of moving to common merge tooling, the current version
of the packages must be tracked in the package.json at the root
of the project.