### PR TITLE
fix(@angular-devkit/build-angular): stylus not resolving imports from libraries

### DIFF
--- a/package.json
+++ b/package.json
@@ -212,7 +212,7 @@
     "speed-measure-webpack-plugin": "1.3.3",
     "style-loader": "2.0.0",
     "stylus": "0.54.7",
-    "stylus-loader": "4.3.0",
+    "stylus-loader": "4.3.1",
     "symbol-observable": "3.0.0",
     "tar": "^6.0.0",
     "temp": "^0.9.0",

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -64,7 +64,7 @@
     "speed-measure-webpack-plugin": "1.3.3",
     "style-loader": "2.0.0",
     "stylus": "0.54.8",
-    "stylus-loader": "4.3.0",
+    "stylus-loader": "4.3.1",
     "terser": "5.5.1",
     "terser-webpack-plugin": "4.2.3",
     "text-table": "0.2.0",

--- a/packages/angular_devkit/build_angular/src/webpack/configs/styles.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/styles.ts
@@ -134,16 +134,9 @@ export function getStylesConfig(wco: WebpackConfigOptions) {
       test: /\.styl$/,
       use: [
         {
-          loader: require.resolve('resolve-url-loader'),
-          options: {
-            sourceMap: cssSourceMap,
-          },
-        },
-        {
           loader: require.resolve('stylus-loader'),
           options: {
             sourceMap: cssSourceMap,
-            webpackImporter: false,
             stylusOptions: {
               compress: false,
               sourceMap: { comment: false },

--- a/yarn.lock
+++ b/yarn.lock
@@ -11519,10 +11519,10 @@ stylehacks@^4.0.0:
     postcss "^7.0.0"
     postcss-selector-parser "^3.0.0"
 
-stylus-loader@4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/stylus-loader/-/stylus-loader-4.3.0.tgz#d4bab5a4d957f4b1f567be108185ff23be216ad4"
-  integrity sha512-S6j5Onp4AJJIXZomHYknFEnV6/4zhPoEKxMPu0iExPgJLlGO7CeBGu+xpYCup1hiZmDBnC3BKRswADKN9goLfw==
+stylus-loader@4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/stylus-loader/-/stylus-loader-4.3.1.tgz#8b4e749294d9fe0729c2e5e1f04cbf87e1c941aa"
+  integrity sha512-apDYJEM5ZpOAWbWInWcsbtI8gHNr/XYVcSY/tWqOUPt7M5tqhtwXVsAkgyiVjhuvw2Yrjq474a9H+g4d047Ebw==
   dependencies:
     fast-glob "^3.2.4"
     klona "^2.0.4"


### PR DESCRIPTION
- Adds usage of webpackImporter https://www.npmjs.com/package/stylus-loader#webpackimporter
- Removes resolve-url-loader usage since stylus handles resolve paths https://stylus-lang.com/docs/js.html#stylusresolveroptions

Closes #19524