### PR TITLE
fix(@angular/cli): dasherize names option names when using JSON help

### DIFF
--- a/packages/angular/cli/models/command.ts
+++ b/packages/angular/cli/models/command.ts
@@ -54,7 +54,10 @@ export abstract class Command<T extends BaseCommandOptions = BaseCommandOptions>
   }
 
   async printJsonHelp(_options: T & Arguments): Promise<number> {
-    this.logger.info(JSON.stringify(this.description));
+    const replacer = (key: string, value: string) => key === 'name'
+      ? strings.dasherize(value)
+      : value;
+    this.logger.info(JSON.stringify(this.description, replacer, 2));
 
     return 0;
   }

--- a/tests/legacy-cli/e2e/tests/commands/help/help-json.ts
+++ b/tests/legacy-cli/e2e/tests/commands/help/help-json.ts
@@ -7,7 +7,11 @@ export default async function() {
     const { stdout } = await silentNg(commandName, '--help=json');
 
     if (stdout.trim()) {
-      JSON.parse(stdout);
+      JSON.parse(stdout, (key, value) => {
+        if (key === 'name' && /[A-Z]/.test(value)) {
+          throw new Error(`Option named '${value}' is not kebab case.`);
+        }
+      });
     } else {
       console.warn(`No JSON output for command [${commandName}].`);
     }


### PR DESCRIPTION
This ensures that arguments listed in https://angular.io/cli help pages are all in kebab cases.

This is a prerequisite to deprecate camel cased arguments.