### PR TITLE
doc: update package.json version note to be more visible

### DIFF
--- a/docs/process/release.md
+++ b/docs/process/release.md
@@ -65,9 +65,9 @@ Consider if you need to update [`packages/schematics/angular/utility/latest-vers
 
 As commits are cherry-picked when PRs are merged, creating the release should be a matter of creating a tag.
 
-**Make sure you update the package versions in `packages/schematics/angular/utility/latest-versions.ts`.**
-
-Update the version in the root package.json file to reflect the new release version.
+Update the package versions to reflect the new release version in **both**:
+1. [`package.json`](https://github.com/angular/angular-cli/blob/master/package.json#L3)
+1. [`packages/schematics/angular/utility/latest-versions.ts`](https://github.com/angular/angular-cli/blob/master/packages/schematics/angular/utility/latest-versions.ts)
 
 ```bash
 git commit -a -m 'release: vXX'


### PR DESCRIPTION
During the release today my eyes completely skipped over the new requirement to update `package.json`. I didn't notice this requirement and was very confused when the release check failed. Changed this to a list to give more visual weight and guide readers eyes to both places that need to be modified.