### PR TITLE
docs: remove when true, when false from argument descriptions

### DIFF
--- a/packages/angular/cli/commands/config.json
+++ b/packages/angular/cli/commands/config.json
@@ -31,7 +31,7 @@
         },
         "global": {
           "type": "boolean",
-          "description": "When true, accesses the global configuration in the caller's home directory.",
+          "description": "Access the global configuration in the caller's home directory.",
           "default": false,
           "aliases": ["g"]
         }

--- a/packages/angular/cli/commands/definitions.json
+++ b/packages/angular/cli/commands/definitions.json
@@ -21,7 +21,7 @@
           ]
         },
         "prod": {
-          "description": "Shorthand for \"--configuration=production\".\nWhen true, sets the build configuration to the production target.\nBy default, the production target is set up in the workspace configuration such that all builds make use of bundling, limited tree-shaking, and also limited dead code elimination.",
+          "description": "Shorthand for \"--configuration=production\".\nSet the build configuration to the production target.\nBy default, the production target is set up in the workspace configuration such that all builds make use of bundling, limited tree-shaking, and also limited dead code elimination.",
           "type": "boolean"
         }
       }
@@ -42,13 +42,13 @@
           "type": "boolean",
           "default": false,
           "aliases": [ "d" ],
-          "description": "When true, runs through and reports activity without writing out results."
+          "description": "Run through and reports activity without writing out results."
         },
         "force": {
           "type": "boolean",
           "default": false,
           "aliases": [ "f" ],
-          "description": "When true, forces overwriting of existing files."
+          "description": "Force overwriting of existing files."
         }
       }
     },
@@ -57,12 +57,12 @@
         "interactive": {
           "type": "boolean",
           "default": "true",
-          "description": "When false, disables interactive input prompts."
+          "description": "Enable interactive input prompts."
         },
         "defaults": {
           "type": "boolean",
           "default": "false",
-          "description": "When true, disables interactive input prompts for options with a default."
+          "description": "Disable interactive input prompts for options with a default."
         }
       }
     }

--- a/packages/angular/cli/commands/doc.json
+++ b/packages/angular/cli/commands/doc.json
@@ -24,7 +24,7 @@
           "aliases": ["s"],
           "type": "boolean",
           "default": false,
-          "description": "When true, searches all of angular.io. Otherwise, searches only API reference documentation."
+          "description": "Search all of angular.io. Otherwise, searches only API reference documentation."
         },
         "version" : {
           "oneOf": [

--- a/packages/angular/cli/commands/new.json
+++ b/packages/angular/cli/commands/new.json
@@ -22,7 +22,7 @@
           "type": "boolean",
           "default": false,
           "aliases": [ "v" ],
-          "description": "When true, adds more details to output logging."
+          "description": "Add more details to output logging."
         }
       },
       "required": []

--- a/packages/angular/cli/commands/update.json
+++ b/packages/angular/cli/commands/update.json
@@ -44,7 +44,7 @@
           "type": "boolean"
         },
         "migrateOnly": {
-          "description": "Only perform a migration, does not update the installed version.",
+          "description": "Only perform a migration, do not update the installed version.",
           "oneOf": [
             {
               "type": "boolean"

--- a/packages/angular/cli/lib/config/schema.json
+++ b/packages/angular/cli/lib/config/schema.json
@@ -169,7 +169,7 @@
             },
             "skipTests": {
               "type": "boolean",
-              "description": "When true, does not create test files.",
+              "description": "Do not create test files.",
               "default": false
             }
           }
@@ -211,7 +211,7 @@
             },
             "skipTests": {
               "type": "boolean",
-              "description": "When true, does not create test files.",
+              "description": "Do not create test files.",
               "default": false
             }
           }
@@ -258,7 +258,7 @@
             },
             "skipTests": {
               "type": "boolean",
-              "description": "When true, does not create test files.",
+              "description": "Do not create test files.",
               "default": false
             }
           }
@@ -273,7 +273,7 @@
             },
             "skipTests": {
               "type": "boolean",
-              "description": "When true, does not create test files.",
+              "description": "Do not create test files.",
               "default": false
             },
             "skipImport": {
@@ -299,7 +299,7 @@
           "properties": {
             "skipTests": {
               "type": "boolean",
-              "description": "When true, does not create test files.",
+              "description": "Do not create test files.",
               "default": false
             }
           }
@@ -1249,13 +1249,13 @@
             },
             "open": {
               "type": "boolean",
-              "description": "When true, open the live-reload URL in default browser.",
+              "description": "Open the live-reload URL in default browser.",
               "default": false,
               "alias": "o"
             },
             "liveReload": {
               "type": "boolean",
-              "description": "When true, reload the page on change using live-reload.",
+              "description": "Reload the page on change using live-reload.",
               "default": true
             },
             "publicHost": {
@@ -1276,27 +1276,27 @@
             },
             "disableHostCheck": {
               "type": "boolean",
-              "description": "When true, don't verify that connected clients are part of allowed hosts.",
+              "description": "Do not verify that connected clients are part of allowed hosts.",
               "default": false
             },
             "hmr": {
               "type": "boolean",
-              "description": "When true, enable hot module replacement.",
+              "description": "Enable hot module replacement.",
               "default": false
             },
             "watch": {
               "type": "boolean",
-              "description": "When true, rebuild on change.",
+              "description": "Rebuild on change.",
               "default": true
             },
             "hmrWarning": {
               "type": "boolean",
-              "description": "When true, show a warning when the --hmr option is enabled.",
+              "description": "Show a warning when the --hmr option is enabled.",
               "default": true
             },
             "servePathDefaultWarning": {
               "type": "boolean",
-              "description": "When true, show a warning when deploy-url/base-href use unsupported serve path values.",
+              "description": "Show a warning when deploy-url/base-href use unsupported serve path values.",
               "default": true
             },
             "optimization": {
@@ -1308,12 +1308,12 @@
                   "properties": {
                     "scripts": {
                       "type": "boolean",
-                      "description": "When true, enable optimization of the scripts output.",
+                      "description": "Enable optimization of the scripts output.",
                       "default": true
                     },
                     "styles": {
                       "type": "boolean",
-                      "description": "When true, enable optimization of the styles output.",
+                      "description": "Enable optimization of the styles output.",
                       "default": true
                     }
                   },
@@ -1329,7 +1329,7 @@
               "description": "Build using ahead-of-time compilation."
             },
             "sourceMap": {
-              "description": "When true, output sourcemaps.",
+              "description": "Output sourcemaps.",
               "default": true,
               "oneOf": [
                 {
@@ -1337,17 +1337,17 @@
                   "properties": {
                     "scripts": {
                       "type": "boolean",
-                      "description": "When true, output sourcemaps for all scripts.",
+                      "description": "Output sourcemaps for all scripts.",
                       "default": true
                     },
                     "styles": {
                       "type": "boolean",
-                      "description": "When true, output sourcemaps for all styles.",
+                      "description": "Output sourcemaps for all styles.",
                       "default": true
                     },
                     "vendor": {
                       "type": "boolean",
-                      "description": "When true, resolve vendor packages sourcemaps.",
+                      "description": "Resolve vendor packages sourcemaps.",
                       "default": false
                     }
                   },
@@ -1360,11 +1360,11 @@
             },
             "vendorChunk": {
               "type": "boolean",
-              "description": "When true, use a separate bundle containing only vendor libraries."
+              "description": "Use a separate bundle containing only vendor libraries."
             },
             "commonChunk": {
               "type": "boolean",
-              "description": "When true, use a separate bundle containing code used across multiple bundles."
+              "description": "Use a separate bundle containing code used across multiple bundles."
             },
             "baseHref": {
               "type": "string",
@@ -1376,11 +1376,11 @@
             },
             "verbose": {
               "type": "boolean",
-              "description": "When true, add more details to output logging."
+              "description": "Add more details to output logging."
             },
             "progress": {
               "type": "boolean",
-              "description": "When true, log progress to the console while building."
+              "description": "Log progress to the console while building."
             }
           },
           "additionalProperties": false

--- a/packages/schematics/angular/application/schema.json
+++ b/packages/schematics/angular/application/schema.json
@@ -20,13 +20,13 @@
       "x-prompt": "What name would you like to use for the application?"
     },
     "inlineStyle": {
-      "description": "When true, includes styles inline in the root component.ts file. Only CSS styles can be included inline. Default is false, meaning that an external styles file is created and referenced in the root component.ts file.",
+      "description": "Include styles inline in the root component.ts file. Only CSS styles can be included inline. Default is false, meaning that an external styles file is created and referenced in the root component.ts file.",
       "type": "boolean",
       "alias": "s",
       "x-user-analytics": 9
     },
     "inlineTemplate": {
-      "description": "When true, includes template inline in the root component.ts file. Default is false, meaning that an external template file is created and referenced in the root component.ts file. ",
+      "description": "Include template inline in the root component.ts file. Default is false, meaning that an external template file is created and referenced in the root component.ts file. ",
       "type": "boolean",
       "alias": "t",
       "x-user-analytics": 10
@@ -39,7 +39,7 @@
     },
     "routing": {
       "type": "boolean",
-      "description": "When true, creates a routing NgModule.",
+      "description": "Create a routing NgModule.",
       "default": false,
       "x-prompt": "Would you like to add Angular routing?",
       "x-user-analytics": 17
@@ -76,7 +76,7 @@
       "x-user-analytics": 5
     },
     "skipTests": {
-      "description": "When true, does not create \"spec.ts\" test files for the application.",
+      "description": "Do not create \"spec.ts\" test files for the application.",
       "type": "boolean",
       "default": false,
       "alias": "S",
@@ -85,10 +85,10 @@
     "skipPackageJson": {
       "type": "boolean",
       "default": false,
-      "description": "When true, does not add dependencies to the \"package.json\" file."
+      "description": "Do not add dependencies to the \"package.json\" file."
     },
     "minimal": {
-      "description": "When true, creates a bare-bones project without any testing frameworks. (Use for learning purposes only.)",
+      "description": "Create a bare-bones project without any testing frameworks. (Use for learning purposes only.)",
       "type": "boolean",
       "default": false,
       "x-user-analytics": 14
@@ -100,7 +100,7 @@
     },
     "lintFix": {
       "type": "boolean",
-      "description": "When true, applies lint fixes after generating the application.",
+      "description": "Apply lint fixes after generating the application.",
       "x-user-analytics": 15,
       "x-deprecated": "Use \"ng lint --fix\" directly instead."
     },

--- a/packages/schematics/angular/class/schema.json
+++ b/packages/schematics/angular/class/schema.json
@@ -29,7 +29,7 @@
     },
     "skipTests": {
       "type": "boolean",
-      "description": "When true, does not create \"spec.ts\" test files for the new class.",
+      "description": "Do not create \"spec.ts\" test files for the new class.",
       "default": false,
       "x-user-analytics": 12
     },
@@ -41,7 +41,7 @@
     "lintFix": {
       "type": "boolean",
       "default": false,
-      "description": "When true, applies lint fixes after generating the class.",
+      "description": "Apply lint fixes after generating the class.",
       "x-user-analytics": 15,
       "x-deprecated": "Use \"ng lint --fix\" directly instead."
     }

--- a/packages/schematics/angular/component/schema.json
+++ b/packages/schematics/angular/component/schema.json
@@ -34,14 +34,14 @@
       "alias": "b"
     },
     "inlineStyle": {
-      "description": "When true, includes styles inline in the component.ts file. Only CSS styles can be included inline. By default, an external styles file is created and referenced in the component.ts file.",
+      "description": "Include styles inline in the component.ts file. Only CSS styles can be included inline. By default, an external styles file is created and referenced in the component.ts file.",
       "type": "boolean",
       "default": false,
       "alias": "s",
       "x-user-analytics": 9
     },
     "inlineTemplate": {
-      "description": "When true, includes template inline in the component.ts file. By default, an external template file is created and referenced in the component.ts file.",
+      "description": "Include template inline in the component.ts file. By default, an external template file is created and referenced in the component.ts file.",
       "type": "boolean",
       "default": false,
       "alias": "t",
@@ -95,18 +95,18 @@
     },
     "skipTests": {
       "type": "boolean",
-      "description": "When true, does not create \"spec.ts\" test files for the new component.",
+      "description": "Do not create \"spec.ts\" test files for the new component.",
       "default": false,
       "x-user-analytics": 12
     },
     "flat": {
       "type": "boolean",
-      "description": "When true, creates the new files at the top level of the current project.",
+      "description": "Create the new files at the top level of the current project.",
       "default": false
     },
     "skipImport": {
       "type": "boolean",
-      "description": "When true, does not import this component into the owning NgModule.",
+      "description": "Do not import this component into the owning NgModule.",
       "default": false,
       "x-user-analytics": 18
     },
@@ -128,18 +128,18 @@
     "export": {
       "type": "boolean",
       "default": false,
-      "description": "When true, the declaring NgModule exports this component.",
+      "description": "The declaring NgModule exports this component.",
       "x-user-analytics": 19
     },
     "entryComponent": {
       "type": "boolean",
       "default": false,
-      "description": "When true, the new component is the entry component of the declaring NgModule.",
+      "description": "The new component is the entry component of the declaring NgModule.",
       "x-deprecated": "Since version 9.0.0 with Ivy, entryComponents is no longer necessary."
     },
     "lintFix": {
       "type": "boolean",
-      "description": "When true, applies lint fixes after generating the component.",
+      "description": "Apply lint fixes after generating the component.",
       "x-user-analytics": 15,
       "x-deprecated": "Use \"ng lint --fix\" directly instead."
     }

--- a/packages/schematics/angular/directive/schema.json
+++ b/packages/schematics/angular/directive/schema.json
@@ -43,13 +43,13 @@
     },
     "skipTests": {
       "type": "boolean",
-      "description": "When true, does not create \"spec.ts\" test files for the new class.",
+      "description": "Do not create \"spec.ts\" test files for the new class.",
       "default": false,
       "x-user-analytics": 12
     },
     "skipImport": {
       "type": "boolean",
-      "description": "When true, does not import this directive into the owning NgModule.",
+      "description": "Do not import this directive into the owning NgModule.",
       "default": false,
       "x-user-analytics": 18
     },
@@ -71,12 +71,12 @@
     "export": {
       "type": "boolean",
       "default": false,
-      "description": "When true, the declaring NgModule exports this directive.",
+      "description": "The declaring NgModule exports this directive.",
       "x-user-analytics": 19
     },
     "lintFix": {
       "type": "boolean",
-      "description": "When true, applies lint fixes after generating the directive.",
+      "description": "Apply lint fixes after generating the directive.",
       "x-user-analytics": 15,
       "x-deprecated": "Use \"ng lint --fix\" directly instead."
     }

--- a/packages/schematics/angular/enum/schema.json
+++ b/packages/schematics/angular/enum/schema.json
@@ -29,7 +29,7 @@
     },
     "lintFix": {
       "type": "boolean",
-      "description": "When true, applies lint fixes after generating the enum.",
+      "description": "Apply lint fixes after generating the enum.",
       "x-user-analytics": 15,
       "x-deprecated": "Use \"ng lint --fix\" directly instead."
     }

--- a/packages/schematics/angular/guard/schema.json
+++ b/packages/schematics/angular/guard/schema.json
@@ -16,7 +16,7 @@
     },
     "skipTests": {
       "type": "boolean",
-      "description": "When true, does not create \"spec.ts\" test files for the new guard.",
+      "description": "Do not create \"spec.ts\" test files for the new guard.",
       "default": false,
       "x-user-analytics": 12
     },
@@ -40,7 +40,7 @@
     },
     "lintFix": {
       "type": "boolean",
-      "description": "When true, applies lint fixes after generating the guard.",
+      "description": "Apply lint fixes after generating the guard.",
       "x-user-analytics": 15,
       "x-deprecated": "Use \"ng lint --fix\" directly instead."
     },

--- a/packages/schematics/angular/interceptor/schema.json
+++ b/packages/schematics/angular/interceptor/schema.json
@@ -34,13 +34,13 @@
     },
     "skipTests": {
       "type": "boolean",
-      "description": "When true, does not create \"spec.ts\" test files for the new interceptor.",
+      "description": "Do not create \"spec.ts\" test files for the new interceptor.",
       "default": false,
       "x-user-analytics": 12
     },
     "lintFix": {
       "type": "boolean",
-      "description": "When true, applies lint fixes after generating the interceptor.",
+      "description": "Apply lint fixes after generating the interceptor.",
       "x-user-analytics": 15,
       "x-deprecated": "Use \"ng lint --fix\" directly instead."
     }

--- a/packages/schematics/angular/interface/schema.json
+++ b/packages/schematics/angular/interface/schema.json
@@ -42,7 +42,7 @@
     },
     "lintFix": {
       "type": "boolean",
-      "description": "When true, applies lint fixes after generating the interface.",
+      "description": "Apply lint fixes after generating the interface.",
       "x-user-analytics": 15,
       "x-deprecated": "Use \"ng lint --fix\" directly instead."
     }

--- a/packages/schematics/angular/library/schema.json
+++ b/packages/schematics/angular/library/schema.json
@@ -31,21 +31,21 @@
     "skipPackageJson": {
       "type": "boolean",
       "default": false,
-      "description": "When true, does not add dependencies to the \"package.json\" file. "
+      "description": "Do not add dependencies to the \"package.json\" file. "
     },
     "skipInstall": {
-      "description": "When true, does not install dependency packages.",
+      "description": "Do not install dependency packages.",
       "type": "boolean",
       "default": false
     },
     "skipTsConfig": {
       "type": "boolean",
       "default": false,
-      "description": "When true, does not update \"tsconfig.json\" to add a path mapping for the new library. The path mapping is needed to use the library in an app, but can be disabled here to simplify development."
+      "description": "Do not update \"tsconfig.json\" to add a path mapping for the new library. The path mapping is needed to use the library in an app, but can be disabled here to simplify development."
     },
     "lintFix": {
       "type": "boolean",
-      "description": "When true, applies lint fixes after generating the library.",
+      "description": "Apply lint fixes after generating the library.",
       "x-user-analytics": 15,
       "x-deprecated": "Use \"ng lint --fix\" directly instead."
     }

--- a/packages/schematics/angular/module/schema.json
+++ b/packages/schematics/angular/module/schema.json
@@ -29,7 +29,7 @@
     },
     "routing": {
       "type": "boolean",
-      "description": "When true, creates a routing module.",
+      "description": "Create a routing module.",
       "default": false,
       "x-user-analytics": 17
     },
@@ -45,12 +45,12 @@
     },
     "flat": {
       "type": "boolean",
-      "description": "When true, creates the new files at the top level of the current project root. ",
+      "description": "Create the new files at the top level of the current project root. ",
       "default": false
     },
     "commonModule": {
       "type": "boolean",
-      "description": "When true, the new NgModule imports \"CommonModule\". ",
+      "description": "The new NgModule imports \"CommonModule\". ",
       "default": true,
       "visible": false
     },
@@ -61,7 +61,7 @@
     },
     "lintFix": {
       "type": "boolean",
-      "description": "When true, applies lint fixes after generating the module.",
+      "description": "Apply lint fixes after generating the module.",
       "x-user-analytics": 15,
       "x-deprecated": "Use \"ng lint --fix\" directly instead."
     }

--- a/packages/schematics/angular/ng-new/schema.json
+++ b/packages/schematics/angular/ng-new/schema.json
@@ -19,18 +19,18 @@
       "x-prompt": "What name would you like to use for the new workspace and initial project?"
     },
     "skipInstall": {
-      "description": "When true, does not install dependency packages.",
+      "description": "Do not install dependency packages.",
       "type": "boolean",
       "default": false
     },
     "linkCli": {
-      "description": "When true, links the CLI to the global version (internal development only).",
+      "description": "Link the CLI to the global version (internal development only).",
       "type": "boolean",
       "default": false,
       "visible": false
     },
     "skipGit": {
-      "description": "When true, does not initialize a git repository.",
+      "description": "Do not initialize a git repository.",
       "type": "boolean",
       "default": false,
       "alias": "g"
@@ -64,13 +64,13 @@
       "default": "projects"
     },
     "inlineStyle": {
-      "description": "When true, includes styles inline in the component TS file. By default, an external styles file is created and referenced in the component TS file.",
+      "description": "Include styles inline in the component TS file. By default, an external styles file is created and referenced in the component TypeScript file.",
       "type": "boolean",
       "alias": "s",
       "x-user-analytics": 9
     },
     "inlineTemplate": {
-      "description": "When true, includes template inline in the component TS file. By default, an external template file is created and referenced in the component TS file.",
+      "description": "Include template inline in the component TS file. By default, an external template file is created and referenced in the component TypeScript file.",
       "type": "boolean",
       "alias": "t",
       "x-user-analytics": 10
@@ -91,7 +91,7 @@
     },
     "routing": {
       "type": "boolean",
-      "description": "When true, generates a routing module for the initial project.",
+      "description": "Generate a routing module for the initial project.",
       "x-user-analytics": 17
     },
     "prefix": {
@@ -109,19 +109,19 @@
       "x-user-analytics": 5
     },
     "skipTests": {
-      "description": "When true, does not generate \"spec.ts\" test files for the new project. ",
+      "description": "Do not generate \"spec.ts\" test files for the new project.",
       "type": "boolean",
       "default": false,
       "alias": "S",
       "x-user-analytics": 12
     },
     "createApplication": {
-      "description": "When true (the default), creates a new initial application project in the src folder of the new workspace. When false, creates an empty workspace with no initial app. You can then use the generate application command so that all apps are created in the projects folder.",
+      "description": "Create a new initial application project in the 'src' folder of the new workspace. When false, creates an empty workspace with no initial application. You can then use the generate application command so that all applications are created in the projects folder.",
       "type": "boolean",
       "default": true
     },
     "minimal": {
-      "description": "When true, creates a workspace without any testing frameworks. (Use for learning purposes only.)",
+      "description": "Create a workspace without any testing frameworks. (Use for learning purposes only.)",
       "type": "boolean",
       "default": false,
       "x-user-analytics": 14

--- a/packages/schematics/angular/pipe/schema.json
+++ b/packages/schematics/angular/pipe/schema.json
@@ -34,14 +34,14 @@
     },
     "skipTests": {
       "type": "boolean",
-      "description": "When true, does not create \"spec.ts\" test files for the new pipe.",
+      "description": "Do not create \"spec.ts\" test files for the new pipe.",
       "default": false,
       "x-user-analytics": 12
     },
     "skipImport": {
       "type": "boolean",
       "default": false,
-      "description": "When true, does not import this pipe into the owning NgModule.",
+      "description": "Do not import this pipe into the owning NgModule.",
       "x-user-analytics": 18
     },
     "module": {
@@ -52,13 +52,13 @@
     "export": {
       "type": "boolean",
       "default": false,
-      "description": "When true, the declaring NgModule exports this pipe.",
+      "description": "The declaring NgModule exports this pipe.",
       "x-user-analytics": 19
     },
     "lintFix": {
       "type": "boolean",
       "default": false,
-      "description": "When true, applies lint fixes after generating the pipe.",
+      "description": "Apply lint fixes after generating the pipe.",
       "x-user-analytics": 15,
       "x-deprecated": "Use \"ng lint --fix\" directly instead."
     }

--- a/packages/schematics/angular/resolver/schema.json
+++ b/packages/schematics/angular/resolver/schema.json
@@ -16,7 +16,7 @@
     },
     "skipTests": {
       "type": "boolean",
-      "description": "When true, does not create \"spec.ts\" test files for the new resolver.",
+      "description": "Do not create \"spec.ts\" test files for the new resolver.",
       "default": false,
       "x-user-analytics": 12
     },

--- a/packages/schematics/angular/service/schema.json
+++ b/packages/schematics/angular/service/schema.json
@@ -34,13 +34,13 @@
     },
     "skipTests": {
       "type": "boolean",
-      "description": "When true, does not create \"spec.ts\" test files for the new service.",
+      "description": "Do not create \"spec.ts\" test files for the new service.",
       "default": false,
       "x-user-analytics": 12
     },
     "lintFix": {
       "type": "boolean",
-      "description": "When true, applies lint fixes after generating the service.",
+      "description": "Apply lint fixes after generating the service.",
       "x-user-analytics": 15,
       "x-deprecated": "Use \"ng lint --fix\" directly instead."
     }

--- a/packages/schematics/angular/universal/schema.json
+++ b/packages/schematics/angular/universal/schema.json
@@ -39,7 +39,7 @@
       "default": "AppServerModule"
     },
     "skipInstall": {
-      "description": "When true, does not install packages for dependencies.",
+      "description": "Do not install packages for dependencies.",
       "type": "boolean",
       "default": false
     }

--- a/packages/schematics/angular/workspace/schema.json
+++ b/packages/schematics/angular/workspace/schema.json
@@ -27,13 +27,13 @@
       }
     },
     "minimal": {
-      "description": "When true, creates a workspace without any testing frameworks. (Use for learning purposes only.)",
+      "description": "Create a workspace without any testing frameworks. (Use for learning purposes only.)",
       "type": "boolean",
       "default": false,
       "x-user-analytics": 14
     },
     "strict": {
-      "description": "Creates a workspace with stricter type checking options. This setting helps improve maintainability and catch bugs ahead of time. For more information, see https://angular.io/strict",
+      "description": "Create a workspace with stricter type checking options. This setting helps improve maintainability and catch bugs ahead of time. For more information, see https://angular.io/strict",
       "type": "boolean",
       "default": false,
       "x-user-analytics": 7

--- a/packages/schematics/update/update/schema.json
+++ b/packages/schematics/update/update/schema.json
@@ -50,7 +50,7 @@
       ]
     },
     "verbose": {
-      "description": "When true, display additional details during the update process.",
+      "description": "Display additional details during the update process.",
       "type": "boolean"
     },
     "packageManager": {


### PR DESCRIPTION
It's confusing and redundant to use `When true` and `when false` in descriptions for a CLI arguments because specifying false/true is redundant in a command line argument flag and in most cases users will not do it.

Example:
`--foo=true` is the same as `--foo`
`--foo=false` is the same as `--no-foo`