### PR TITLE
fix(@angular-devkit/build-angular): define `forwardRef` as a pure function

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
@@ -440,6 +440,7 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
             // See https://github.com/webpack/webpack/issues/2899#issuecomment-317425926.
             passes: buildOptions.buildOptimizer ? 3 : 1,
             global_defs: angularGlobalDefinitions,
+            pure_funcs: ['forwardRef'],
           }),
       // We also want to avoid mangling on server.
       // Name mangling is handled within the browser builder


### PR DESCRIPTION
By configuring the optimizer (`terser`) to be aware that the Angular `forwardRef` helper function is a pure function, the optimizer can completely remove the helper call when the return value is unused.

Closes #19572