### PR TITLE
fix(@angular/cli): allow trailing commas in JSON files

### DIFF
--- a/packages/angular/cli/utilities/json-file.ts
+++ b/packages/angular/cli/utilities/json-file.ts
@@ -38,7 +38,7 @@ export class JSONFile {
     }
 
     const errors: ParseError[] = [];
-    this._jsonAst = parseTree(this.content, errors);
+    this._jsonAst = parseTree(this.content, errors, { allowTrailingComma: true });
     if (errors.length) {
       formatError(this.path, errors);
     }
@@ -106,7 +106,7 @@ export class JSONFile {
 // tslint:disable-next-line: no-any
 export function readAndParseJson(path: string): any {
   const errors: ParseError[] = [];
-  const content = parse(readFileSync(path, 'utf-8'), errors);
+  const content = parse(readFileSync(path, 'utf-8'), errors, { allowTrailingComma: true });
   if (errors.length) {
     formatError(path, errors);
   }
@@ -121,5 +121,5 @@ function formatError(path: string, errors: ParseError[]): never {
 
 // tslint:disable-next-line: no-any
 export function parseJson(content: string): any {
-  return parse(content);
+  return parse(content, undefined, { allowTrailingComma: true });
 }

--- a/packages/schematics/angular/utility/json-file.ts
+++ b/packages/schematics/angular/utility/json-file.ts
@@ -36,7 +36,7 @@ export class JSONFile {
     }
 
     const errors: ParseError[] = [];
-    this._jsonAst = parseTree(this.content, errors);
+    this._jsonAst = parseTree(this.content, errors, { allowTrailingComma: true });
     if (errors.length) {
       const { error, offset } = errors[0];
       throw new Error(`Failed to parse "${this.path}" as JSON AST Object. ${printParseErrorCode(error)} at location: ${offset}.`);


### PR DESCRIPTION


Currently, both tsconfigs and workspace configuration files can contain trailing commas

Closes #19576