### PR TITLE
docs: change sourcemap to source map

### DIFF
--- a/packages/angular/cli/commands/definitions.json
+++ b/packages/angular/cli/commands/definitions.json
@@ -14,7 +14,7 @@
           }
         },
         "configuration": {
-          "description": "One or more named builder configurations as a comma-separated list as specified in the \"configurations\" section of angular.json.\nThe builder uses the named configurations to run the given target.\nFor more information, see https://angular.io/guide/workspace-config#alternate-build-configurations.\nSetting this explicitly overrides the \"--prod\" flag",
+          "description": "One or more named builder configurations as a comma-separated list as specified in the \"configurations\" section of angular.json.\nThe builder uses the named configurations to run the given target.\nFor more information, see https://angular.io/guide/workspace-config#alternate-build-configurations.\nSetting this explicitly overrides the \"--prod\" flag.",
           "type": "string",
           "aliases": [
             "c"

--- a/packages/angular/cli/lib/config/schema.json
+++ b/packages/angular/cli/lib/config/schema.json
@@ -759,7 +759,7 @@
                           "properties": {
                             "inline": {
                               "type": "boolean",
-                              "description": "Reduce render blocking requests by inlining external fonts in the application's HTML index file. This requires internet access.",
+                              "description": "Reduce render blocking requests by inlining external Google fonts and icons CSS definitions in the application's HTML index file. This requires internet access.",
                               "default": true
                             }
                           },

--- a/packages/angular/cli/lib/config/schema.json
+++ b/packages/angular/cli/lib/config/schema.json
@@ -800,7 +800,7 @@
               "default": false
             },
             "sourceMap": {
-              "description": "Output sourcemaps.",
+              "description": "Output source maps.",
               "default": true,
               "oneOf": [
                 {
@@ -808,22 +808,22 @@
                   "properties": {
                     "scripts": {
                       "type": "boolean",
-                      "description": "Output sourcemaps for all scripts.",
+                      "description": "Output source maps for all scripts.",
                       "default": true
                     },
                     "styles": {
                       "type": "boolean",
-                      "description": "Output sourcemaps for all styles.",
+                      "description": "Output source maps for all styles.",
                       "default": true
                     },
                     "hidden": {
                       "type": "boolean",
-                      "description": "Output sourcemaps used for error reporting tools.",
+                      "description": "Output source maps used for error reporting tools.",
                       "default": false
                     },
                     "vendor": {
                       "type": "boolean",
-                      "description": "Resolve vendor packages sourcemaps.",
+                      "description": "Resolve vendor packages source maps.",
                       "default": false
                     }
                   },
@@ -1329,7 +1329,7 @@
               "description": "Build using ahead-of-time compilation."
             },
             "sourceMap": {
-              "description": "Output sourcemaps.",
+              "description": "Output source maps.",
               "default": true,
               "oneOf": [
                 {
@@ -1337,17 +1337,17 @@
                   "properties": {
                     "scripts": {
                       "type": "boolean",
-                      "description": "Output sourcemaps for all scripts.",
+                      "description": "Output source maps for all scripts.",
                       "default": true
                     },
                     "styles": {
                       "type": "boolean",
-                      "description": "Output sourcemaps for all styles.",
+                      "description": "Output source maps for all styles.",
                       "default": true
                     },
                     "vendor": {
                       "type": "boolean",
-                      "description": "Resolve vendor packages sourcemaps.",
+                      "description": "Resolve vendor packages source maps.",
                       "default": false
                     }
                   },
@@ -1505,7 +1505,7 @@
               "additionalProperties": false
             },
             "sourceMap": {
-              "description": "Output sourcemaps.",
+              "description": "Output source maps.",
               "default": true,
               "oneOf": [
                 {
@@ -1513,17 +1513,17 @@
                   "properties": {
                     "scripts": {
                       "type": "boolean",
-                      "description": "Output sourcemaps for all scripts.",
+                      "description": "Output source maps for all scripts.",
                       "default": true
                     },
                     "styles": {
                       "type": "boolean",
-                      "description": "Output sourcemaps for all styles.",
+                      "description": "Output source maps for all styles.",
                       "default": true
                     },
                     "vendor": {
                       "type": "boolean",
-                      "description": "Resolve vendor packages sourcemaps.",
+                      "description": "Resolve vendor packages source maps.",
                       "default": false
                     }
                   },
@@ -1828,7 +1828,7 @@
               "description": "The path where style resources will be placed, relative to outputPath."
             },
             "sourceMap": {
-              "description": "Output sourcemaps.",
+              "description": "Output source maps.",
               "default": true,
               "oneOf": [
                 {
@@ -1836,22 +1836,22 @@
                   "properties": {
                     "scripts": {
                       "type": "boolean",
-                      "description": "Output sourcemaps for all scripts.",
+                      "description": "Output source maps for all scripts.",
                       "default": true
                     },
                     "styles": {
                       "type": "boolean",
-                      "description": "Output sourcemaps for all styles.",
+                      "description": "Output source maps for all styles.",
                       "default": true
                     },
                     "hidden": {
                       "type": "boolean",
-                      "description": "Output sourcemaps used for error reporting tools.",
+                      "description": "Output source maps used for error reporting tools.",
                       "default": false
                     },
                     "vendor": {
                       "type": "boolean",
-                      "description": "Resolve vendor packages sourcemaps.",
+                      "description": "Resolve vendor packages source maps.",
                       "default": false
                     }
                   },

--- a/packages/angular_devkit/build_angular/src/browser/schema.json
+++ b/packages/angular_devkit/build_angular/src/browser/schema.json
@@ -146,7 +146,7 @@
       "default": false
     },
     "sourceMap": {
-      "description": "Output sourcemaps.",
+      "description": "Output source maps.",
       "default": true,
       "oneOf": [
         {
@@ -154,22 +154,22 @@
           "properties": {
             "scripts": {
               "type": "boolean",
-              "description": "Output sourcemaps for all scripts.",
+              "description": "Output source maps for all scripts.",
               "default": true
             },
             "styles": {
               "type": "boolean",
-              "description": "Output sourcemaps for all styles.",
+              "description": "Output source maps for all styles.",
               "default": true
             },
             "hidden": {
               "type": "boolean",
-              "description": "Output sourcemaps used for error reporting tools.",
+              "description": "Output source maps used for error reporting tools.",
               "default": false
             },
             "vendor": {
               "type": "boolean",
-              "description": "Resolve vendor packages sourcemaps.",
+              "description": "Resolve vendor packages source maps.",
               "default": false
             }
           },

--- a/packages/angular_devkit/build_angular/src/browser/schema.json
+++ b/packages/angular_devkit/build_angular/src/browser/schema.json
@@ -103,7 +103,7 @@
                   "properties": {
                     "inline": {
                       "type": "boolean",
-                      "description": "Reduce render blocking requests by inlining external fonts in the application's HTML index file. This requires internet access.",
+                      "description": "Reduce render blocking requests by inlining external Google fonts and icons CSS definitions in the application's HTML index file. This requires internet access.",
                       "default": true
                     }
                   },

--- a/packages/angular_devkit/build_angular/src/dev-server/schema.json
+++ b/packages/angular_devkit/build_angular/src/dev-server/schema.json
@@ -137,29 +137,29 @@
       "x-deprecated": "Use the \"aot\" option in the browser builder instead."
     },
     "sourceMap": {
-      "description": "Output sourcemaps.",
+      "description": "Output source maps.",
       "oneOf": [
         {
           "type": "object",
           "properties": {
             "scripts": {
               "type": "boolean",
-              "description": "Output sourcemaps for all scripts.",
+              "description": "Output source maps for all scripts.",
               "default": true
             },
             "styles": {
               "type": "boolean",
-              "description": "Output sourcemaps for all styles.",
+              "description": "Output source maps for all styles.",
               "default": true
             },
             "hidden": {
               "type": "boolean",
-              "description": "Output sourcemaps used for error reporting tools.",
+              "description": "Output source maps used for error reporting tools.",
               "default": false
             },
             "vendor": {
               "type": "boolean",
-              "description": "Resolve vendor packages sourcemaps.",
+              "description": "Resolve vendor packages source maps.",
               "default": false
             }
           },

--- a/packages/angular_devkit/build_angular/src/karma/schema.json
+++ b/packages/angular_devkit/build_angular/src/karma/schema.json
@@ -67,7 +67,7 @@
       "description": "Globs of files to include, relative to workspace or project root. \nThere are 2 special cases:\n - when a path to directory is provided, all spec files ending \".spec.@(ts|tsx)\" will be included\n - when a path to a file is provided, and a matching spec file exists it will be included instead"
     },
     "sourceMap": {
-      "description": "Output sourcemaps.",
+      "description": "Output source maps.",
       "default": true,
       "oneOf": [
         {
@@ -75,17 +75,17 @@
           "properties": {
             "scripts": {
               "type": "boolean",
-              "description": "Output sourcemaps for all scripts.",
+              "description": "Output source maps for all scripts.",
               "default": true
             },
             "styles": {
               "type": "boolean",
-              "description": "Output sourcemaps for all styles.",
+              "description": "Output source maps for all styles.",
               "default": true
             },
             "vendor": {
               "type": "boolean",
-              "description": "Resolve vendor packages sourcemaps.",
+              "description": "Resolve vendor packages source maps.",
               "default": false
             }
           },

--- a/packages/angular_devkit/build_angular/src/server/schema.json
+++ b/packages/angular_devkit/build_angular/src/server/schema.json
@@ -72,7 +72,7 @@
       "default": ""
     },
     "sourceMap": {
-      "description": "Output sourcemaps.",
+      "description": "Output source maps.",
       "default": true,
       "oneOf": [
         {
@@ -80,22 +80,22 @@
           "properties": {
             "scripts": {
               "type": "boolean",
-              "description": "Output sourcemaps for all scripts.",
+              "description": "Output source maps for all scripts.",
               "default": true
             },
             "styles": {
               "type": "boolean",
-              "description": "Output sourcemaps for all styles.",
+              "description": "Output source maps for all styles.",
               "default": true
             },
             "hidden": {
               "type": "boolean",
-              "description": "Output sourcemaps used for error reporting tools.",
+              "description": "Output source maps used for error reporting tools.",
               "default": false
             },
             "vendor": {
               "type": "boolean",
-              "description": "Resolve vendor packages sourcemaps.",
+              "description": "Resolve vendor packages source maps.",
               "default": false
             }
           },

--- a/tests/angular_devkit/core/json/schema/serializers/schema_benchmark.json
+++ b/tests/angular_devkit/core/json/schema/serializers/schema_benchmark.json
@@ -457,7 +457,7 @@
           "type": "object",
           "properties": {
             "sourcemaps": {
-              "description": "Output sourcemaps.",
+              "description": "Output source maps.",
               "type": "boolean"
             },
             "baseHref": {


### PR DESCRIPTION
The latter is more in used in other articules such as:
-  https://developer.mozilla.org/en-US/docs/Tools/Debugger/How_to/Use_a_source_map
- https://developers.google.com/web/tools/chrome-devtools/javascript/source-maps