### PR TITLE
ci: update remaining references to old pr targeting system

### DIFF
--- a/.github/angular-robot.yml
+++ b/.github/angular-robot.yml
@@ -18,7 +18,7 @@ merge:
 \nPlease help to unblock it by resolving these conflicts. Thanks!"
 
   # label to monitor
-  mergeLabel: "PR action: merge"
+  mergeLabel: "action: merge"
 
   # list of checks that will determine if the merge label can be added
   checks:
@@ -26,16 +26,15 @@ merge:
     noConflict: true
     # whether the PR should have all reviews completed.
     requireReviews: true
-    # list of labels that a PR needs to have, checked with a regexp (e.g. "PR target:" will work for the label "PR target: master")
+    # list of labels that a PR needs to have, checked with a regexp (e.g. "target:" will work for the label "target: major")
     requiredLabels:
-      - "PR target: *"
+      - "target: *"
       - "cla: yes"
 
     # list of labels that a PR shouldn't have, checked after the required labels with a regexp
     forbiddenLabels:
-      - "PR target: TBD"
-      - "PR action: cleanup"
-      - "PR action: review"
+      - "action: cleanup"
+      - "action: review"
       - "PR state: blocked"
       - "cla: no"
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,8 @@ updates:
       prefix: "build"
     labels:
       - "comp: build & ci"
-      - "PR target: master & patch"
-      - "PR action: merge"
+      - "target: patch"
+      - "action: merge"
     # Disable version updates
     # This does not affect security updates
     open-pull-requests-limit: 0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,7 +117,7 @@ Before you submit your Pull Request (PR) consider the following guidelines:
     git rebase master -i
     git push -f
     ```
-  * Add the `PR action: merge` label and the correct
+  * Add the `action: merge` label and the correct
 [target label](https://github.com/angular/angular/blob/master/docs/TRIAGE_AND_LABELS.md#pr-target)
     (if PR author has the project collaborator status, or else the last reviewer
     should do this).

--- a/docs/process/release.md
+++ b/docs/process/release.md
@@ -30,7 +30,7 @@ TBD
 The list of PRs which are currently ready to merge (approved with passing status checks) can
 be found with [this search](https://github.com/angular/angular-cli/pulls?q=is%3Apr+is%3Aopen+label%3A%22PR+action%3A+merge%22+-is%3Adraft).
 This list should be checked daily and any ready PRs should be merged. For each PR, check the
-`PR target` label to understand where it should be merged to.  You can find which branches a specific
+`target` label to understand where it should be merged to.  You can find which branches a specific
 PR will be merged into with the `yarn ng-dev pr check-target-branches <pr>` command.
 
 When ready to merge a PR, run the following command:

--- a/renovate.json
+++ b/renovate.json
@@ -6,8 +6,8 @@
   "separateMajorMinor": false,
   "prHourlyLimit": 2,
   "labels": [
-    "PR target: master-only",
-    "PR action: merge"
+    "target: minor",
+    "action: merge"
   ],
   "timezone": "America/Tijuana",
   "lockFileMaintenance": {

--- a/scripts/templates/contributing.ejs
+++ b/scripts/templates/contributing.ejs
@@ -117,7 +117,7 @@ Before you submit your Pull Request (PR) consider the following guidelines:
     git rebase master -i
     git push -f
     ```
-  * Add the `PR action: merge` label and the correct
+  * Add the `action: merge` label and the correct
 [target label](https://github.com/angular/angular/blob/master/docs/TRIAGE_AND_LABELS.md#pr-target)
     (if PR author has the project collaborator status, or else the last reviewer
     should do this).


### PR DESCRIPTION
Completes the migration to use the new unified target label system, updating
dependabot, renovate and angular-robot to expect the new labels.