### PR TITLE
refactor(@angular-devkit/schematics): replace `NodePackageInstallTasKOptions` class with interface

### DIFF
--- a/etc/api/angular_devkit/schematics/tasks/index.d.ts
+++ b/etc/api/angular_devkit/schematics/tasks/index.d.ts
@@ -4,7 +4,7 @@ export declare class NodePackageInstallTask implements TaskConfigurationGenerato
     packageName?: string;
     quiet: boolean;
     workingDirectory?: string;
-    constructor(options: Partial<NodePackageInstallTaskOptions>);
+    constructor(options: NodePackageInstallTaskOptions);
     constructor(workingDirectory?: string);
     toConfiguration(): TaskConfiguration<NodePackageTaskOptions>;
 }

--- a/packages/angular_devkit/schematics/tasks/package-manager/install-task.ts
+++ b/packages/angular_devkit/schematics/tasks/package-manager/install-task.ts
@@ -8,13 +8,12 @@
 import { TaskConfiguration, TaskConfigurationGenerator } from '../../src';
 import { NodePackageName, NodePackageTaskOptions } from './options';
 
-// TODO: This should be an interface but that would change the public API
-export class NodePackageInstallTaskOptions {
-  packageManager!: string;
-  packageName!: string;
-  workingDirectory!: string;
-  quiet!: boolean;
-  hideOutput!: boolean;
+interface NodePackageInstallTaskOptions {
+  packageManager?: string;
+  packageName?: string;
+  workingDirectory?: string;
+  quiet?: boolean;
+  hideOutput?: boolean;
 }
 
 export class NodePackageInstallTask implements TaskConfigurationGenerator<NodePackageTaskOptions> {
@@ -25,8 +24,8 @@ export class NodePackageInstallTask implements TaskConfigurationGenerator<NodePa
   packageName?: string;
 
   constructor(workingDirectory?: string);
-  constructor(options: Partial<NodePackageInstallTaskOptions>);
-  constructor(options?: string | Partial<NodePackageInstallTaskOptions>) {
+  constructor(options: NodePackageInstallTaskOptions);
+  constructor(options?: string | NodePackageInstallTaskOptions) {
     if (typeof options === 'string') {
       this.workingDirectory = options;
     } else if (typeof options === 'object') {


### PR DESCRIPTION


In this context this is not a breaking change for two reasons.

- `NodePackageInstallTaskOptions` is not exported.
- `NodePackageInstallTask` is using `NodePackageInstallTaskOptions` with `Partial` type which would cause the Class to become an object literal. This can be seen here: https://github.com/angular/angular-cli/blob/efb97c87f023497dc59a2f4fa3825a2ca78606da/packages/schematics/angular/ng-new/index.ts#L81-L84