### PR TITLE
Angular Builders testing refactor

### DIFF
--- a/packages/angular_devkit/build_angular/BUILD.bazel
+++ b/packages/angular_devkit/build_angular/BUILD.bazel
@@ -72,6 +72,7 @@ ts_library(
             "src/test-utils.ts",
             "src/**/*_spec.ts",
             "plugins/**/*_spec.ts",
+            "src/testing/**/*.ts",
         ],
     ) + [
         "//packages/angular_devkit/build_angular:src/app-shell/schema.ts",
@@ -249,7 +250,12 @@ pkg_tar(
 ts_library(
     name = "build_angular_test_utils",
     testonly = True,
-    srcs = [":src/test-utils.ts"],
+    srcs = glob(
+        include = [
+            "src/test-utils.ts",
+            "src/testing/**/*.ts",
+        ],
+    ),
     data = glob(["test/**/*"]),
     tsconfig = "//:tsconfig-test.json",
     deps = [
@@ -259,6 +265,7 @@ ts_library(
         "//packages/angular_devkit/architect/testing",
         "//packages/angular_devkit/core",
         "//packages/angular_devkit/core/node",
+        "@npm//rxjs",
     ],
 )
 

--- a/packages/angular_devkit/build_angular/BUILD.bazel
+++ b/packages/angular_devkit/build_angular/BUILD.bazel
@@ -71,6 +71,7 @@ ts_library(
         exclude = [
             "src/test-utils.ts",
             "src/**/*_spec.ts",
+            "src/**/tests/**/*.ts",
             "plugins/**/*_spec.ts",
             "src/testing/**/*.ts",
         ],
@@ -254,6 +255,7 @@ ts_library(
         include = [
             "src/test-utils.ts",
             "src/testing/**/*.ts",
+            "src/**/tests/*.ts",
         ],
     ),
     data = glob(["test/**/*"]),

--- a/packages/angular_devkit/build_angular/src/browser/specs/works_spec.ts
+++ b/packages/angular_devkit/build_angular/src/browser/specs/works_spec.ts
@@ -5,33 +5,41 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import { describeBuilder } from '../../testing';
+import { buildWebpackBrowser } from '../index';
 
-import { Architect } from '@angular-devkit/architect';
-import { normalize } from '@angular-devkit/core';
-import { browserBuild, createArchitect, host } from '../../test-utils';
+const BROWSER_BUILDER_INFO = {
+  name: '@angular-devkit/build-angular:browser',
+  schemaPath: __dirname + '/../schema.json',
+};
 
+describeBuilder(buildWebpackBrowser, BROWSER_BUILDER_INFO, (harness) => {
+  describe('basic test', () => {
+    it('works', async () => {
+      // Provide a target and options for builder execution
+      harness.useTarget('build', {
+        outputPath: 'dist',
+        index: 'src/index.html',
+        main: 'src/main.ts',
+        polyfills: 'src/polyfills.ts',
+        tsConfig: 'src/tsconfig.app.json',
+        progress: false,
+        assets: ['src/favicon.ico', 'src/assets'],
+        styles: ['src/styles.css'],
+        scripts: [],
+      });
 
-describe('Browser Builder basic test', () => {
-  const target = { project: 'app', target: 'build' };
-  let architect: Architect;
+      // Execute builder with above provided project, target, and options
+      await harness.executeOnce();
 
-  beforeEach(async () => {
-    await host.initialize().toPromise();
-    architect = (await createArchitect(host.root())).architect;
-  });
-
-  afterEach(async () => host.restore().toPromise());
-
-  it('works', async () => {
-    await browserBuild(architect, host, target);
-
-    // Default files should be in outputPath.
-    expect(await host.scopedSync().exists(normalize('dist/runtime.js'))).toBe(true);
-    expect(await host.scopedSync().exists(normalize('dist/main.js'))).toBe(true);
-    expect(await host.scopedSync().exists(normalize('dist/polyfills.js'))).toBe(true);
-    expect(await host.scopedSync().exists(normalize('dist/vendor.js'))).toBe(true);
-    expect(await host.scopedSync().exists(normalize('dist/favicon.ico'))).toBe(true);
-    expect(await host.scopedSync().exists(normalize('dist/styles.css'))).toBe(true);
-    expect(await host.scopedSync().exists(normalize('dist/index.html'))).toBe(true);
+      // Default files should be in outputPath.
+      expect(harness.hasFile('dist/runtime.js')).toBe(true);
+      expect(harness.hasFile('dist/main.js')).toBe(true);
+      expect(harness.hasFile('dist/polyfills.js')).toBe(true);
+      expect(harness.hasFile('dist/vendor.js')).toBe(true);
+      expect(harness.hasFile('dist/favicon.ico')).toBe(true);
+      expect(harness.hasFile('dist/styles.css')).toBe(true);
+      expect(harness.hasFile('dist/index.html')).toBe(true);
+    });
   });
 });

--- a/packages/angular_devkit/build_angular/src/browser/tests/options/main_spec.ts
+++ b/packages/angular_devkit/build_angular/src/browser/tests/options/main_spec.ts
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { buildWebpackBrowser } from '../../index';
+import { BASE_OPTIONS, BROWSER_BUILDER_INFO, describeBuilder } from '../setup';
+
+describeBuilder(buildWebpackBrowser, BROWSER_BUILDER_INFO, (harness) => {
+  describe('Option: "main"', () => {
+    it('uses a provided TypeScript file', async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        main: 'src/main.ts',
+      });
+
+      const { result } = await harness.executeOnce();
+
+      expect(result?.success).toBe(true);
+
+      harness.expectFile('dist/runtime.js').toExist();
+      harness.expectFile('dist/main.js').toExist();
+      harness.expectFile('dist/vendor.js').toExist();
+      harness.expectFile('dist/index.html').toExist();
+    });
+
+    it('uses a provided JavaScript file', async () => {
+      await harness.writeFile('src/main.js', `console.log('main');`);
+
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        main: 'src/main.js',
+      });
+
+      const { result } = await harness.executeOnce();
+
+      expect(result?.success).toBe(true);
+
+      harness.expectFile('dist/runtime.js').toExist();
+      harness.expectFile('dist/main.js').toExist();
+      harness.expectFile('dist/vendor.js').toNotExist();
+      harness.expectFile('dist/index.html').toExist();
+
+      harness.expectFile('dist/main.js').content.toContain(`console.log('main')`);
+    });
+
+    it('fails and shows an error when file does not exist', async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        main: 'src/missing.ts',
+      });
+
+      const { result, logs } = await harness.executeOnce({ outputLogsOnFailure: false });
+
+      expect(result?.success).toBe(false);
+      expect(logs).toContain(
+        jasmine.objectContaining({ message: jasmine.stringMatching('Module not found:') }),
+      );
+
+      harness.expectFile('dist/runtime.js').toNotExist();
+      harness.expectFile('dist/main.js').toNotExist();
+      harness.expectFile('dist/vendor.js').toNotExist();
+      harness.expectFile('dist/index.html').toNotExist();
+    });
+  });
+});

--- a/packages/angular_devkit/build_angular/src/browser/tests/setup.ts
+++ b/packages/angular_devkit/build_angular/src/browser/tests/setup.ts
@@ -1,0 +1,27 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { Schema } from '../schema';
+
+export { describeBuilder } from '../../testing';
+
+export const BROWSER_BUILDER_INFO = Object.freeze({
+  name: '@angular-devkit/build-angular:browser',
+  schemaPath: __dirname + '/../schema.json',
+});
+
+/**
+ * Contains all required browser builder fields.
+ * Also disables progress reporting to minimize logging output.
+ */
+export const BASE_OPTIONS = Object.freeze<Schema>({
+  index: 'src/index.html',
+  main: 'src/main.ts',
+  outputPath: 'dist',
+  tsConfig: 'src/tsconfig.app.json',
+  progress: false,
+});

--- a/packages/angular_devkit/build_angular/src/testing/builder-harness.ts
+++ b/packages/angular_devkit/build_angular/src/testing/builder-harness.ts
@@ -1,0 +1,410 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {
+  BuilderContext,
+  BuilderHandlerFn,
+  BuilderInfo,
+  BuilderOutput,
+  BuilderOutputLike,
+  BuilderProgressReport,
+  BuilderRun,
+  ScheduleOptions,
+  Target,
+  fromAsyncIterable,
+  isBuilderOutput,
+} from '@angular-devkit/architect';
+import { WorkspaceHost } from '@angular-devkit/architect/node';
+import { TestProjectHost } from '@angular-devkit/architect/testing';
+import { analytics, getSystemPath, json, logging, normalize } from '@angular-devkit/core';
+import { Observable, Subject, from as observableFrom, of as observableOf } from 'rxjs';
+import { catchError, first, map, mergeMap, shareReplay } from 'rxjs/operators';
+
+export interface BuilderHarnessExecutionResult<T extends BuilderOutput = BuilderOutput> {
+  result?: T;
+  error?: Error;
+  logs: readonly logging.LogEntry[];
+}
+
+export interface BuilderHarnessExecutionOptions {
+  configuration: string;
+  outputLogsOnFailure: boolean;
+  outputLogsOnException: boolean;
+}
+
+export class BuilderHarness<T> {
+  private readonly builderInfo: BuilderInfo;
+  private schemaRegistry = new json.schema.CoreSchemaRegistry();
+  private projectName = 'test';
+  private projectMetadata: Record<string, unknown> = { root: '.', sourceRoot: 'src' };
+  private targetName?: string;
+  private options = new Map<string | null, T>();
+  private builderTargets = new Map<
+    string,
+    // tslint:disable-next-line: no-any
+    { handler: BuilderHandlerFn<any>; info: BuilderInfo; options: json.JsonObject }
+  >();
+
+  constructor(
+    private readonly builderHandler: BuilderHandlerFn<T & json.JsonObject>,
+    private readonly host: TestProjectHost,
+    builderInfo?: Partial<BuilderInfo>,
+  ) {
+    // Generate default pseudo builder info for test purposes
+    this.builderInfo = {
+      builderName: builderHandler.name,
+      description: '',
+      optionSchema: true,
+      ...builderInfo,
+    };
+
+    this.schemaRegistry.addPostTransform(json.schema.transforms.addUndefinedDefaults);
+  }
+
+  useProject(name: string, metadata: Record<string, unknown> = {}): this {
+    if (!name) {
+      throw new Error('Project name cannot be an empty string.');
+    }
+
+    this.projectName = name;
+    this.projectMetadata = metadata;
+
+    return this;
+  }
+
+  useTarget(name: string, baseOptions: T): this {
+    if (!name) {
+      throw new Error('Target name cannot be an empty string.');
+    }
+
+    this.targetName = name;
+    this.options.set(null, baseOptions);
+
+    return this;
+  }
+
+  withConfiguration(configuration: string, options: T): this {
+    this.options.set(configuration, options);
+
+    return this;
+  }
+
+  withBuilderTarget<O>(
+    target: string,
+    handler: BuilderHandlerFn<O & json.JsonObject>,
+    options?: O,
+    info?: Partial<BuilderInfo>,
+  ): this {
+    this.builderTargets.set(target, {
+      handler,
+      options: options || {},
+      info: { builderName: handler.name, description: '', optionSchema: true, ...info },
+    });
+
+    return this;
+  }
+
+  execute(
+    options: Partial<BuilderHarnessExecutionOptions> = {},
+  ): Observable<BuilderHarnessExecutionResult> {
+    const { configuration, outputLogsOnException = true, outputLogsOnFailure = true } = options;
+    const targetOptions = {
+      ...this.options.get(null),
+      ...((configuration && this.options.get(configuration)) ?? {}),
+    };
+
+    const contextHost: ContextHost = {
+      findBuilderByTarget: async (project, target) => {
+        this.validateProjectName(project);
+        if (target === this.targetName) {
+          return {
+            info: this.builderInfo,
+            handler: this.builderHandler as BuilderHandlerFn<json.JsonObject>,
+          };
+        }
+
+        const builderTarget = this.builderTargets.get(target);
+        if (builderTarget) {
+          return { info: builderTarget.info, handler: builderTarget.handler };
+        }
+
+        throw new Error('Project target does not exist.');
+      },
+      async getBuilderName(project, target) {
+        return (await this.findBuilderByTarget(project, target)).info.builderName;
+      },
+      getMetadata: async (project) => {
+        this.validateProjectName(project);
+
+        return this.projectMetadata as json.JsonObject;
+      },
+      getOptions: async (project, target, configuration) => {
+        this.validateProjectName(project);
+        if (target === this.targetName) {
+          return this.options.get(configuration ?? null) ?? {};
+        } else if (configuration !== undefined) {
+          // Harness builder targets currently do not support configurations
+          return {};
+        } else {
+          return (this.builderTargets.get(target)?.options as json.JsonObject) || {};
+        }
+      },
+      hasTarget: async (project, target) => {
+        this.validateProjectName(project);
+
+        return this.targetName === target || this.builderTargets.has(target);
+      },
+      validate: async (options, builderName) => {
+        let schema;
+        if (builderName === this.builderInfo.builderName) {
+          schema = this.builderInfo.optionSchema;
+        } else {
+          for (const [, value] of this.builderTargets) {
+            if (value.info.builderName === builderName) {
+              schema = value.info.optionSchema;
+              break;
+            }
+          }
+        }
+
+        const validator = await this.schemaRegistry.compile(schema ?? true).toPromise();
+        const { data } = await validator(options).toPromise();
+
+        return data as json.JsonObject;
+      },
+    };
+    const context = new HarnessBuilderContext(
+      this.builderInfo,
+      getSystemPath(this.host.root()),
+      contextHost,
+    );
+    if (this.targetName !== undefined) {
+      context.target = {
+        project: this.projectName,
+        target: this.targetName,
+        configuration: configuration as string,
+      };
+    }
+
+    const logs: logging.LogEntry[] = [];
+    context.logger.subscribe((e) => logs.push(e));
+
+    return this.schemaRegistry.compile(this.builderInfo.optionSchema).pipe(
+      mergeMap((validator) => validator(targetOptions)),
+      map((validationResult) => validationResult.data),
+      mergeMap((data) =>
+        convertBuilderOutputToObservable(this.builderHandler(data as T & json.JsonObject, context)),
+      ),
+      map((buildResult) => ({ result: buildResult, error: undefined })),
+      catchError((error) => {
+        if (outputLogsOnException) {
+          // tslint:disable-next-line: no-console
+          console.error(logs.map((entry) => entry.message).join('\n'));
+          // tslint:disable-next-line: no-console
+          console.error(error);
+        }
+
+        return observableOf({ result: undefined, error });
+      }),
+      map(({ result, error }) => {
+        if (outputLogsOnFailure && result?.success === false && logs.length > 0) {
+          // tslint:disable-next-line: no-console
+          console.error(logs.map((entry) => entry.message).join('\n'));
+        }
+
+        // Capture current logs and clear for next
+        const currentLogs = logs.slice();
+        logs.length = 0;
+
+        return { result, error, logs: currentLogs };
+      }),
+      mergeMap(async (executionResult) => {
+        for (const teardown of context.teardowns) {
+          await teardown();
+        }
+
+        return executionResult;
+      }),
+    );
+  }
+
+  async executeOnce(
+    options?: Partial<BuilderHarnessExecutionOptions>,
+  ): Promise<BuilderHarnessExecutionResult> {
+    // Return the first result
+    return this.execute(options).pipe(first()).toPromise();
+  }
+
+  async writeFile(path: string, content: string | Buffer): Promise<void> {
+    this.host
+      .scopedSync()
+      .write(normalize(path), typeof content === 'string' ? Buffer.from(content) : content);
+  }
+
+  async writeFiles(files: Record<string, string | Buffer>): Promise<void> {
+    for (const [path, content] of Object.entries(files)) {
+      this.host
+        .scopedSync()
+        .write(normalize(path), typeof content === 'string' ? Buffer.from(content) : content);
+    }
+  }
+
+  async removeFile(path: string): Promise<void> {
+    return this.host.scopedSync().delete(normalize(path));
+  }
+
+  async modifyFile(
+    path: string,
+    modifier: (content: string) => string | Promise<string>,
+  ): Promise<void> {
+    const content = this.readFile(path);
+    await this.writeFile(path, await modifier(content));
+  }
+
+  hasFile(path: string): boolean {
+    return this.host.scopedSync().exists(normalize(path));
+  }
+
+  readFile(path: string): string {
+    const content = this.host.scopedSync().read(normalize(path));
+
+    return Buffer.from(content).toString('utf8');
+  }
+
+  private validateProjectName(name: string): void {
+    if (name !== this.projectName) {
+      throw new Error(`Project "${name}" does not exist.`);
+    }
+  }
+}
+
+interface ContextHost extends WorkspaceHost {
+  findBuilderByTarget(
+    project: string,
+    target: string,
+  ): Promise<{ info: BuilderInfo; handler: BuilderHandlerFn<json.JsonObject> }>;
+  validate(options: json.JsonObject, builderName: string): Promise<json.JsonObject>;
+}
+
+class HarnessBuilderContext implements BuilderContext {
+  id = Math.trunc(Math.random() * 1000000);
+  logger = new logging.Logger(`builder-harness-${this.id}`);
+  workspaceRoot: string;
+  currentDirectory: string;
+  target?: Target;
+
+  teardowns: (() => Promise<void> | void)[] = [];
+
+  constructor(
+    public builder: BuilderInfo,
+    basePath: string,
+    private readonly contextHost: ContextHost,
+  ) {
+    this.workspaceRoot = this.currentDirectory = basePath;
+  }
+
+  get analytics(): analytics.Analytics {
+    // Can be undefined even though interface does not allow it
+    return (undefined as unknown) as analytics.Analytics;
+  }
+
+  addTeardown(teardown: () => Promise<void> | void): void {
+    this.teardowns.push(teardown);
+  }
+
+  async getBuilderNameForTarget(target: Target): Promise<string> {
+    return this.contextHost.getBuilderName(target.project, target.target);
+  }
+
+  async getProjectMetadata(targetOrName: Target | string): Promise<json.JsonObject> {
+    const project = typeof targetOrName === 'string' ? targetOrName : targetOrName.project;
+
+    return this.contextHost.getMetadata(project);
+  }
+
+  async getTargetOptions(target: Target): Promise<json.JsonObject> {
+    return this.contextHost.getOptions(target.project, target.target, target.configuration);
+  }
+
+  // Unused by builders in this package
+  async scheduleBuilder(
+    builderName: string,
+    options?: json.JsonObject,
+    scheduleOptions?: ScheduleOptions,
+  ): Promise<BuilderRun> {
+    throw new Error('Not Implemented.');
+  }
+
+  async scheduleTarget(
+    target: Target,
+    overrides?: json.JsonObject,
+    scheduleOptions?: ScheduleOptions,
+  ): Promise<BuilderRun> {
+    const { info, handler } = await this.contextHost.findBuilderByTarget(
+      target.project,
+      target.target,
+    );
+    const targetOptions = await this.validateOptions(
+      {
+        ...(await this.getTargetOptions(target)),
+        ...overrides,
+      },
+      info.builderName,
+    );
+
+    const context = new HarnessBuilderContext(info, this.workspaceRoot, this.contextHost);
+    context.target = target;
+    context.logger = scheduleOptions?.logger || this.logger.createChild('');
+
+    const progressSubject = new Subject<BuilderProgressReport>();
+    const output = convertBuilderOutputToObservable(handler(targetOptions, context));
+
+    const run: BuilderRun = {
+      id: context.id,
+      info,
+      progress: progressSubject.asObservable(),
+      async stop() {
+        for (const teardown of context.teardowns) {
+          await teardown();
+        }
+        progressSubject.complete();
+      },
+      output: output.pipe(shareReplay()),
+      get result() {
+        return this.output.pipe(first()).toPromise();
+      },
+    };
+
+    return run;
+  }
+
+  async validateOptions<T extends json.JsonObject = json.JsonObject>(
+    options: json.JsonObject,
+    builderName: string,
+  ): Promise<T> {
+    return (this.contextHost.validate(options, builderName) as unknown) as T;
+  }
+
+  // Unused report methods
+  reportRunning(): void {}
+  reportStatus(): void {}
+  reportProgress(): void {}
+}
+
+function isAsyncIterable<T>(obj: unknown): obj is AsyncIterable<T> {
+  return !!obj && typeof (obj as AsyncIterable<T>)[Symbol.asyncIterator] === 'function';
+}
+
+function convertBuilderOutputToObservable(output: BuilderOutputLike): Observable<BuilderOutput> {
+  if (isBuilderOutput(output)) {
+    return observableOf(output);
+  } else if (isAsyncIterable(output)) {
+    return fromAsyncIterable(output);
+  } else {
+    return observableFrom(output);
+  }
+}

--- a/packages/angular_devkit/build_angular/src/testing/builder-harness_spec.ts
+++ b/packages/angular_devkit/build_angular/src/testing/builder-harness_spec.ts
@@ -1,0 +1,134 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { TestProjectHost } from '@angular-devkit/architect/testing';
+import { BuilderHarness } from './builder-harness';
+
+describe('BuilderHarness', () => {
+  let mockHost: TestProjectHost;
+
+  beforeEach(() => {
+    mockHost = jasmine.createSpyObj('TestProjectHost', ['root']);
+    (mockHost.root as jasmine.Spy).and.returnValue('.');
+  });
+
+  it('uses the provided builder handler', async () => {
+    const mockHandler = jasmine.createSpy().and.returnValue({ success: true });
+
+    const harness = new BuilderHarness(mockHandler, mockHost);
+
+    await harness.executeOnce();
+
+    expect(mockHandler).toHaveBeenCalled();
+  });
+
+  it('provides the builder output result when executing', async () => {
+    const mockHandler = jasmine.createSpy().and.returnValue({ success: false, property: 'value' });
+
+    const harness = new BuilderHarness(mockHandler, mockHost);
+    const { result } = await harness.executeOnce();
+
+    expect(result).toBeDefined();
+    expect(result?.success).toBeFalse();
+    expect(result?.property).toBe('value');
+  });
+
+  it('does not show builder logs on console when a builder succeeds', async () => {
+    const consoleErrorMock = spyOn(console, 'error');
+
+    const harness = new BuilderHarness(async (_, context) => {
+      context.logger.warn('TEST WARNING');
+
+      return { success: true };
+    }, mockHost);
+
+    const { result } = await harness.executeOnce();
+
+    expect(result).toBeDefined();
+    expect(result?.success).toBeTrue();
+
+    expect(consoleErrorMock).not.toHaveBeenCalledWith(jasmine.stringMatching('TEST WARNING'));
+  });
+
+  it('shows builder logs on console when a builder fails', async () => {
+    const consoleErrorMock = spyOn(console, 'error');
+
+    const harness = new BuilderHarness(async (_, context) => {
+      context.logger.warn('TEST WARNING');
+
+      return { success: false };
+    }, mockHost);
+
+    const { result } = await harness.executeOnce();
+
+    expect(result).toBeDefined();
+    expect(result?.success).toBeFalse();
+
+    expect(consoleErrorMock).toHaveBeenCalledWith(jasmine.stringMatching('TEST WARNING'));
+  });
+
+  it('does not show builder logs on console when a builder fails and outputLogsOnFailure: false', async () => {
+    const consoleErrorMock = spyOn(console, 'error');
+
+    const harness = new BuilderHarness(async (_, context) => {
+      context.logger.warn('TEST WARNING');
+
+      return { success: false };
+    }, mockHost);
+
+    const { result } = await harness.executeOnce({ outputLogsOnFailure: false });
+
+    expect(result).toBeDefined();
+    expect(result?.success).toBeFalse();
+
+    expect(consoleErrorMock).not.toHaveBeenCalledWith(jasmine.stringMatching('TEST WARNING'));
+  });
+
+  it('provides and logs the builder output exception when builder throws', async () => {
+    const mockHandler = jasmine.createSpy().and.throwError(new Error('Builder Error'));
+    const consoleErrorMock = spyOn(console, 'error');
+
+    const harness = new BuilderHarness(mockHandler, mockHost);
+    const { result, error } = await harness.executeOnce();
+
+    expect(result).toBeUndefined();
+    expect(error).toEqual(jasmine.objectContaining({ message: 'Builder Error' }));
+    expect(consoleErrorMock).toHaveBeenCalledWith(jasmine.stringMatching('Builder Error'));
+  });
+
+  it('does not log exception with outputLogsOnException false when builder throws', async () => {
+    const mockHandler = jasmine.createSpy().and.throwError(new Error('Builder Error'));
+    const consoleErrorMock = spyOn(console, 'error');
+
+    const harness = new BuilderHarness(mockHandler, mockHost);
+    const { result, error } = await harness.executeOnce({ outputLogsOnException: false });
+
+    expect(result).toBeUndefined();
+    expect(error).toEqual(jasmine.objectContaining({ message: 'Builder Error' }));
+    expect(consoleErrorMock).not.toHaveBeenCalledWith(jasmine.stringMatching('Builder Error'));
+  });
+
+  it('supports executing a target from within a builder', async () => {
+    const mockHandler = jasmine.createSpy().and.returnValue({ success: true });
+
+    const harness = new BuilderHarness(async (_, context) => {
+      const run = await context.scheduleTarget({project: 'test', target: 'another' });
+      expect(await run.result).toEqual(jasmine.objectContaining({ success: true }));
+      await run.stop();
+
+      return { success: true };
+    }, mockHost);
+    harness.withBuilderTarget('another', mockHandler);
+
+    const { result } = await harness.executeOnce();
+
+    expect(result).toBeDefined();
+    expect(result?.success).toBeTrue();
+
+    expect(mockHandler).toHaveBeenCalled();
+  });
+});

--- a/packages/angular_devkit/build_angular/src/testing/index.ts
+++ b/packages/angular_devkit/build_angular/src/testing/index.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+export { BuilderHarnessExecutionOptions, BuilderHarnessExecutionResult } from './builder-harness';
+export { describeBuilder } from './jasmine-helpers';

--- a/packages/angular_devkit/build_angular/src/testing/index.ts
+++ b/packages/angular_devkit/build_angular/src/testing/index.ts
@@ -6,4 +6,4 @@
  * found in the LICENSE file at https://angular.io/license
  */
 export { BuilderHarnessExecutionOptions, BuilderHarnessExecutionResult } from './builder-harness';
-export { describeBuilder } from './jasmine-helpers';
+export { HarnessFileMatchers, describeBuilder } from './jasmine-helpers';

--- a/packages/angular_devkit/build_angular/src/testing/jasmine-helpers.ts
+++ b/packages/angular_devkit/build_angular/src/testing/jasmine-helpers.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { BuilderHandlerFn } from '@angular-devkit/architect';
+import { json } from '@angular-devkit/core';
+import { readFileSync } from 'fs';
+import { host } from '../test-utils';
+import { BuilderHarness } from './builder-harness';
+
+const optionSchemaCache = new Map<string, json.schema.JsonSchema>();
+
+export function describeBuilder<T>(
+  builderHandler: BuilderHandlerFn<T & json.JsonObject>,
+  options: { name?: string; schemaPath: string },
+  specDefinitions: (harness: BuilderHarness<T>) => void,
+): void {
+  let optionSchema = optionSchemaCache.get(options.schemaPath);
+  if (optionSchema === undefined) {
+    optionSchema = JSON.parse(readFileSync(options.schemaPath, 'utf8')) as json.schema.JsonSchema;
+    optionSchemaCache.set(options.schemaPath, optionSchema);
+  }
+  const harness = new BuilderHarness<T>(builderHandler, host, {
+    builderName: options.name,
+    optionSchema,
+  });
+
+  describe(options.name || builderHandler.name, () => {
+    beforeEach(() => host.initialize().toPromise());
+
+    afterEach(() => host.restore().toPromise());
+
+    specDefinitions(harness);
+  });
+}


### PR DESCRIPTION
This introduces a Builder test harness to facilitate testing of each of the builders within the `build-angular` package.  The test harness is intended to reduce the amount of test code necessary to test the implementations of each builder while also moving the inputs of the test into the test code itself where possible.