### PR TITLE
fix(@schematics/angular): remove unnecessary scripts and dependencies

### DIFF
--- a/packages/schematics/angular/workspace/files/package.json.template
+++ b/packages/schematics/angular/workspace/files/package.json.template
@@ -4,9 +4,9 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "build": "ng build",
+    "build": "ng build"<% if (!minimal) { %>,
     "test": "ng test",
-    "lint": "ng lint"
+    "lint": "ng lint"<% } %>
   },
   "private": true,
   "dependencies": {
@@ -35,9 +35,9 @@
     "karma-coverage": "~2.0.3",
     "karma-jasmine": "~4.0.0",
     "karma-jasmine-html-reporter": "^1.5.0",
-    "protractor": "~7.0.0",<% } %>
+    "protractor": "~7.0.0",
     "ts-node": "~8.3.0",
-    "tslint": "~6.1.0",
+    "tslint": "~6.1.0",<% } %>
     "typescript": "<%= latestVersions.TypeScript %>"
   }
 }


### PR DESCRIPTION
When new application is generated with `--minimal` flag it will be created without any testing frameworks, linters, etc. But `package.json` still contains broken scripts and dependencies. So `"test": "ng test"`, `"lint": "ng lint"` and `"tslint": "~6.1.0"` should be removed. By analogy with `"e2e": "ng e2e"`.