### PR TITLE
docs: clarify that the options of `ng lint` in AIO are of the deprecated builder

### DIFF
--- a/packages/angular/cli/commands/lint-long.md
+++ b/packages/angular/cli/commands/lint-long.md
@@ -2,3 +2,6 @@ Takes the name of the project, as specified in the  `projects` section of the `a
 When a project name is not supplied, it will execute for all projects.
 
 The default linting tool is [TSLint](https://palantir.github.io/tslint/), and the default configuration is specified in the project's `tslint.json` file.
+
+**Note**: TSLint has been discontinued and support has been deprecated in the Angular CLI. The options shown below are for the deprecated TSLint builder.
+To opt-in using the community driven ESLint builder, see [angular-eslint](https://github.com/angular-eslint/angular-eslint#migrating-from-codelyzer-and-tslint) README.


### PR DESCRIPTION

Fix: #19638