### PR TITLE
feat(@angular-devkit/build-angular): `ng extract-i18n` support json and arb

### DIFF
--- a/packages/angular/cli/lib/config/schema.json
+++ b/packages/angular/cli/lib/config/schema.json
@@ -1403,7 +1403,8 @@
                 "xlif",
                 "xliff",
                 "xlf2",
-                "xliff2"
+                "xliff2",
+                "json"
               ]
             },
             "i18nFormat": {
@@ -1417,7 +1418,8 @@
                 "xlif",
                 "xliff",
                 "xlf2",
-                "xliff2"
+                "xliff2",
+                "json"
               ]
             },
             "i18nLocale": {

--- a/packages/angular/cli/lib/config/schema.json
+++ b/packages/angular/cli/lib/config/schema.json
@@ -1404,7 +1404,8 @@
                 "xliff",
                 "xlf2",
                 "xliff2",
-                "json"
+                "json",
+                "arb"
               ]
             },
             "i18nFormat": {
@@ -1419,7 +1420,8 @@
                 "xliff",
                 "xlf2",
                 "xliff2",
-                "json"
+                "json",
+                "arb"
               ]
             },
             "i18nLocale": {

--- a/packages/angular_devkit/build_angular/src/extract-i18n/index.ts
+++ b/packages/angular_devkit/build_angular/src/extract-i18n/index.ts
@@ -37,6 +37,8 @@ function getI18nOutfile(format: string | undefined) {
     case 'xlf2':
     case 'xliff2':
       return 'messages.xlf';
+    case 'json':
+      return 'messages.json';
     default:
       throw new Error(`Unsupported format "${format}"`);
   }
@@ -65,6 +67,12 @@ async function getSerializer(format: Format, sourceLocale: string, basePath: str
 
       // tslint:disable-next-line: no-any
       return new Xliff2TranslationSerializer(sourceLocale, basePath as any, useLegacyIds, {});
+    case Format.Json:
+      const { SimpleJsonTranslationSerializer } =
+        await import('@angular/localize/src/tools/src/extract/translation_files/json_translation_serializer');
+
+      // tslint:disable-next-line: no-any
+      return new SimpleJsonTranslationSerializer(sourceLocale);
   }
 }
 
@@ -85,6 +93,9 @@ function normalizeFormatOption(options: ExtractI18nBuilderOptions) {
     case Format.Xlf2:
     case Format.Xliff2:
       format = Format.Xlf2;
+      break;
+    case Format.Json:
+      format = Format.Json;
       break;
     case undefined:
       format = Format.Xlf;

--- a/packages/angular_devkit/build_angular/src/extract-i18n/index.ts
+++ b/packages/angular_devkit/build_angular/src/extract-i18n/index.ts
@@ -39,6 +39,8 @@ function getI18nOutfile(format: string | undefined) {
       return 'messages.xlf';
     case 'json':
       return 'messages.json';
+    case 'arb':
+      return 'messages.arb';
     default:
       throw new Error(`Unsupported format "${format}"`);
   }
@@ -73,6 +75,18 @@ async function getSerializer(format: Format, sourceLocale: string, basePath: str
 
       // tslint:disable-next-line: no-any
       return new SimpleJsonTranslationSerializer(sourceLocale);
+    case Format.Arb:
+      const { ArbTranslationSerializer } =
+        await import('@angular/localize/src/tools/src/extract/translation_files/arb_translation_serializer');
+
+      const fileSystem = {
+        relative(from: string, to: string): string {
+          return path.relative(from, to);
+        },
+      };
+
+      // tslint:disable-next-line: no-any
+      return new ArbTranslationSerializer(sourceLocale, basePath as any, fileSystem as any);
   }
 }
 
@@ -96,6 +110,9 @@ function normalizeFormatOption(options: ExtractI18nBuilderOptions) {
       break;
     case Format.Json:
       format = Format.Json;
+      break;
+    case Format.Arb:
+      format = Format.Arb;
       break;
     case undefined:
       format = Format.Xlf;

--- a/packages/angular_devkit/build_angular/src/extract-i18n/schema.json
+++ b/packages/angular_devkit/build_angular/src/extract-i18n/schema.json
@@ -19,7 +19,8 @@
         "xlif",
         "xliff",
         "xlf2",
-        "xliff2"
+        "xliff2",
+        "json"
       ]
     },
     "i18nFormat": {
@@ -33,7 +34,8 @@
         "xlif",
         "xliff",
         "xlf2",
-        "xliff2"
+        "xliff2",
+        "json"
       ]
     },
     "i18nLocale": {

--- a/packages/angular_devkit/build_angular/src/extract-i18n/schema.json
+++ b/packages/angular_devkit/build_angular/src/extract-i18n/schema.json
@@ -20,7 +20,8 @@
         "xliff",
         "xlf2",
         "xliff2",
-        "json"
+        "json",
+        "arb"
       ]
     },
     "i18nFormat": {
@@ -35,7 +36,8 @@
         "xliff",
         "xlf2",
         "xliff2",
-        "json"
+        "json",
+        "arb"
       ]
     },
     "i18nLocale": {

--- a/packages/angular_devkit/build_angular/src/utils/load-translations.ts
+++ b/packages/angular_devkit/build_angular/src/utils/load-translations.ts
@@ -66,6 +66,10 @@ async function importParsers() {
     const diagnostics = new localizeDiag.Diagnostics();
 
     const parsers = {
+      arb: new (await import(
+        // tslint:disable-next-line:trailing-comma
+        '@angular/localize/src/tools/src/translate/translation_files/translation_parsers/arb_translation_parser'
+        )).ArbTranslationParser(),
       json: new (await import(
         // tslint:disable-next-line:trailing-comma
         '@angular/localize/src/tools/src/translate/translation_files/translation_parsers/simple_json_translation_parser'

--- a/tests/legacy-cli/e2e/tests/i18n/ivy-localize-dl-arb.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/ivy-localize-dl-arb.ts
@@ -1,0 +1,10 @@
+import { executeTest } from './ivy-localize-dl-xliff2';
+import { setupI18nConfig } from './legacy';
+
+export default async function() {
+  // Setup i18n tests and config.
+  await setupI18nConfig(true, 'arb');
+
+  // Execute the tests
+  await executeTest();
+}

--- a/tests/legacy-cli/e2e/tests/i18n/ivy-localize-dl-json.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/ivy-localize-dl-json.ts
@@ -1,0 +1,10 @@
+import { executeTest } from './ivy-localize-dl-xliff2';
+import { setupI18nConfig } from './legacy';
+
+export default async function() {
+  // Setup i18n tests and config.
+  await setupI18nConfig(true, 'json');
+
+  // Execute the tests
+  await executeTest();
+}

--- a/tests/legacy-cli/e2e/tests/i18n/legacy.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/legacy.ts
@@ -89,6 +89,12 @@ export const formats = {
       [/<source>.*?<\/source>/g, ''],
     ],
   },
+  'json': {
+    ext: 'json',
+    sourceCheck: '"locale": "en-US"',
+    replacements: [
+    ],
+  }
 };
 
 export async function setupI18nConfig(useLocalize = true, format: keyof typeof formats = 'xlf') {
@@ -226,7 +232,10 @@ export async function setupI18nConfig(useLocalize = true, format: keyof typeof f
   const translationFile = `src/locale/messages.${formats[format].ext}`;
   await expectFileToExist(translationFile);
   await expectFileToMatch(translationFile, formats[format].sourceCheck);
-  await expectFileToMatch(translationFile, `An introduction header for this sample`);
+
+  if (format !== 'json') {
+    await expectFileToMatch(translationFile, `An introduction header for this sample`);
+  }
 
   // Make translations for each language.
   for (const { lang, translationReplacements } of langTranslations) {

--- a/tests/legacy-cli/e2e/tests/i18n/legacy.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/legacy.ts
@@ -94,6 +94,12 @@ export const formats = {
     sourceCheck: '"locale": "en-US"',
     replacements: [
     ],
+  },
+  'arb': {
+    ext: 'arb',
+    sourceCheck: '"@@locale": "en-US"',
+    replacements: [
+    ],
   }
 };
 


### PR DESCRIPTION
`@angular/localize` supports extracting as `json` file, but CLI does not support this.