### PR TITLE
fix(@angular-devkit/build-angular): normalize optimization in getComm…

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
@@ -25,7 +25,7 @@ import {
 } from 'webpack';
 import { RawSource } from 'webpack-sources';
 import { AssetPatternClass } from '../../browser/schema';
-import { BuildBrowserFeatures, maxWorkers } from '../../utils';
+import { BuildBrowserFeatures, maxWorkers, normalizeOptimization } from '../../utils';
 import { WebpackConfigOptions } from '../../utils/build-options';
 import { findCachePath } from '../../utils/cache-path';
 import {
@@ -62,11 +62,12 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
       scripts: scriptsSourceMap,
       vendor: vendorSourceMap,
     },
-    optimization: {
-      styles: stylesOptimization,
-      scripts: scriptsOptimization,
-    },
   } = buildOptions;
+
+  const {
+    styles: stylesOptimization,
+    scripts: scriptsOptimization,
+  } = normalizeOptimization(buildOptions.optimization);
 
   const extraPlugins: { apply(compiler: Compiler): void }[] = [];
   const extraRules: RuleSetRule[] = [];


### PR DESCRIPTION
…onConfig

Ref: https://github.com/angular/angular-cli/commit/eb30a92e8ad4bf27461010b1917d1fcffd10ff31#diff-f3bcbd6f6b0756d2178dd69396750fa742093fb7f4668ab284463c0ca348b032R393

WARN TypeError: Cannot read property 'minify' of undefined
WARN     at getCommonConfig (node_modules\@angular-devkit\build-angular\src\webpack\configs\common.js:299:28)
WARN     at Object.getAngularCliParts (node_modules\@storybook\angular\dist\server\angular-cli_utils.js:83:30)
WARN     at Object.applyAngularCliWebpackConfig (node_modules\@storybook\angular\dist\server\angular-cli_config.js:134:40)
WARN     at Object.webpackFinal (node_modules\@storybook\angular\dist\server\framework-preset-angular-cli.js:10:33)
WARN     at node_modules\@storybook\core\dist\server\presets.js:259:28