### PR TITLE
fix(@angular-devkit/build-angular): don't downlevel web-animations-js

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
@@ -545,7 +545,7 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
         },
         {
           test: /\.m?js$/,
-          exclude: [/[\/\\](?:core-js|\@babel|tslib)[\/\\]/, /(ngfactory|ngstyle)\.js$/],
+          exclude: [/[\/\\](?:core-js|\@babel|tslib|web-animations-js)[\/\\]/, /(ngfactory|ngstyle)\.js$/],
           use: [
             ...(wco.supportES2015
               ? []


### PR DESCRIPTION
This library is minified and it causes Babel to consume a lot of resources when trying to downlevel.

Closes #19660