### PR TITLE
fix(@schematics/angular): correctly handle PropertyAssignments with StringLiteral keys

### DIFF
--- a/packages/schematics/angular/utility/ast-utils.ts
+++ b/packages/schematics/angular/utility/ast-utils.ts
@@ -377,8 +377,7 @@ export function getMetadataField(
     // Filter out every fields that's not "metadataField". Also handles string literals
     // (but not expressions).
     .filter(({ name }) => {
-      return (ts.isIdentifier(name) || ts.isStringLiteral(name))
-        && name.getText() === metadataField;
+      return (ts.isIdentifier(name) || ts.isStringLiteral(name)) && name.text === metadataField;
     });
 }
 

--- a/packages/schematics/angular/utility/ast-utils_spec.ts
+++ b/packages/schematics/angular/utility/ast-utils_spec.ts
@@ -91,6 +91,29 @@ describe('ast utils', () => {
     expect(output).toMatch(/declarations: \[\nAppComponent,\nFooComponent\n\]/);
   });
 
+  it('should add declarations to module when PropertyAssignment is StringLiteral', () => {
+    moduleContent = tags.stripIndents`
+    import { BrowserModule } from '@angular/platform-browser';
+    import { NgModule } from '@angular/core';
+    import { AppComponent } from './app.component';
+
+    @NgModule({
+      "declarations": [
+        AppComponent
+      ],
+      "imports": [
+        BrowserModule
+      ],
+      "providers": [],
+      "bootstrap": [AppComponent]
+    })`;
+    const source = getTsSource(modulePath, moduleContent);
+    const changes = addDeclarationToModule(source, modulePath, 'FooComponent', './foo.component');
+    const output = applyChanges(modulePath, moduleContent, changes);
+    expect(output).toMatch(/import { FooComponent } from '.\/foo.component';/);
+    expect(output).toMatch(/"declarations": \[\nAppComponent,\nFooComponent\n\]/);
+  });
+
   it('should add metadata', () => {
     const source = getTsSource(modulePath, moduleContent);
     const changes = addSymbolToNgModuleMetadata(source, modulePath, 'imports', 'HelloWorld');


### PR DESCRIPTION


Closes #16009