### PR TITLE
fix(@schematics/angular): use `sourceRoot` instead of `src` in universal schematic

### DIFF
--- a/packages/schematics/angular/universal/files/root/tsconfig.server.json.template
+++ b/packages/schematics/angular/universal/files/root/tsconfig.server.json.template
@@ -12,6 +12,6 @@
     "src/<%= stripTsExtension(main) %>.ts"
   ],
   "angularCompilerOptions": {
-    "entryModule": "./<%= rootInSrc ? '' : 'src/' %><%= appDir %>/<%= stripTsExtension(rootModuleFileName) %>#<%= rootModuleClassName %>"
+    "entryModule": "./<%= sourceRoot ? sourceRoot + '/' : ''%><%= appDir %>/<%= stripTsExtension(rootModuleFileName) %>#<%= rootModuleClassName %>"
   }
 }


### PR DESCRIPTION

Closes #12104