### PR TITLE
fix(@angular-devkit/core): workspaces reader should work with duplicate keys

### DIFF
--- a/packages/angular_devkit/core/src/workspace/json/reader_spec.ts
+++ b/packages/angular_devkit/core/src/workspace/json/reader_spec.ts
@@ -93,6 +93,16 @@ describe('readJsonWorkpace Parsing', () => {
     expect({ ...prodConfig }).toEqual(prodConfig);
   });
 
+  it('does work with duplicate keys and use last value', async () => {
+    const host = createTestHost(stripIndent`{
+      "version": 1,
+      "x-foo": 1,
+      "x-foo": 2
+    }`);
+    const workspace = await readJsonWorkspace('', host);
+    expect(workspace.extensions['x-foo']).toBe(2);
+  });
+
   it('parses extensions only into extensions object', async () => {
     const host = createTestHost(representativeFile);
 

--- a/packages/angular_devkit/core/src/workspace/json/utilities.ts
+++ b/packages/angular_devkit/core/src/workspace/json/utilities.ts
@@ -42,7 +42,7 @@ function findNode(
   p: PropertyKey,
 ): { node?: JsonAstNode; parent: JsonAstArray | JsonAstKeyValue | JsonAstObject } {
   if (parent.kind === 'object') {
-    const entry = parent.properties.find(entry => entry.key.value === p);
+    const entry = [...parent.properties].reverse().find(entry => entry.key.value === p);
     if (entry) {
       return { node: entry.value, parent: entry };
     }


### PR DESCRIPTION

Previously, when having duplicate keys defined in the first one used to supersede the preceding which is not conformant with the spec.