### PR TITLE
refactor(@angular-devkit/build-angular): use script target in custom babel loader

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/build-options.ts
+++ b/packages/angular_devkit/build_angular/src/utils/build-options.ts
@@ -16,7 +16,6 @@ import {
   I18NMissingTranslation,
   IndexUnion,
   Localize,
-  OptimizationClass,
   SourceMapClass,
 } from '../browser/schema';
 import { Schema as DevServerSchema } from '../dev-server/schema';
@@ -98,5 +97,5 @@ export interface WebpackConfigOptions<T = BuildOptions> {
   buildOptions: T;
   tsConfig: ParsedConfiguration;
   tsConfigPath: string;
-  supportES2015: boolean;
+  scriptTarget: import('typescript').ScriptTarget;
 }

--- a/packages/angular_devkit/build_angular/src/utils/webpack-browser-config.ts
+++ b/packages/angular_devkit/build_angular/src/utils/webpack-browser-config.ts
@@ -77,7 +77,7 @@ export async function generateWebpackConfig(
     buildOptions,
     tsConfig,
     tsConfigPath,
-    supportES2015,
+    scriptTarget,
   };
 
   wco.buildOptions.progress = defaultProgress(wco.buildOptions.progress);

--- a/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
@@ -554,7 +554,7 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
                 cacheIdentifier: JSON.stringify({
                   buildAngular: require('../../../package.json').version,
                 }),
-                forceES5: !wco.supportES2015,
+                scriptTarget: wco.scriptTarget,
               },
             },
             ...buildOptimizerUseRule,


### PR DESCRIPTION
This change uses the project's TypeScript configuration script target to determine the required Babel processing.