### PR TITLE
ci: change merge strategy to rebase instead of squash

### DIFF
--- a/.ng-dev/merge.ts
+++ b/.ng-dev/merge.ts
@@ -10,9 +10,9 @@ import { release } from './release';
 export const merge: DevInfraMergeConfig['merge'] = async api => {
   return {
     githubApiMerge: {
-      default: 'squash',
+      default: 'rebase',
       labels: [
-        {pattern: 'preserve commits', method: 'rebase'},
+        {pattern: 'squash commits', method: 'squash'},
       ],
     },
     claSignedLabel: 'cla: yes',


### PR DESCRIPTION
Change the merge method used by merge tooling to use rebase instead of using
squash.