### PR TITLE
build: update next branch to reflect new release-train `v11.2.0-next.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@angular/devkit-repo",
-  "version": "11.1.0-next.4",
+  "version": "11.2.0-next.0",
   "private": true,
   "description": "Software Development Kit for Angular",
   "bin": {


### PR DESCRIPTION
This is needed as otherwise the ng-dev tools will fail due to `Error: Discovered unexpected version-branch "11.1.x" for a release-train that is already active in the "master" branch. Please either delete the branch if created by accident, or update the version in the next branch (master).`