### PR TITLE
feat(@angular-devkit/core): provide prompt validation errors to provider

### DIFF
--- a/packages/angular/cli/models/schematic-command.ts
+++ b/packages/angular/cli/models/schematic-command.ts
@@ -356,17 +356,6 @@ export abstract class SchematicCommand<
                     };
                 });
                 break;
-              case 'input':
-                if (
-                  definition.propertyTypes.size === 1 &&
-                  (definition.propertyTypes.has('number') ||
-                    definition.propertyTypes.has('integer'))
-                ) {
-                  question.type = 'number';
-                } else {
-                  question.type = 'input';
-                }
-                break;
               default:
                 question.type = definition.type;
                 break;


### PR DESCRIPTION
This change provides the first schema validation error to a prompt provider when using a prompt definition's `validate` function.  This allows a prompt provider to show additional context to a user when an entered value is invalid.