### PR TITLE
fix(@angular-devkit/build-angular): resolve i18n outFile with normalized format

### DIFF
--- a/packages/angular_devkit/build_angular/src/extract-i18n/index.ts
+++ b/packages/angular_devkit/build_angular/src/extract-i18n/index.ts
@@ -147,7 +147,7 @@ export async function execute(
   const format = normalizeFormatOption(options);
 
   // We need to determine the outFile name so that AngularCompiler can retrieve it.
-  let outFile = options.outFile || getI18nOutfile(options.format);
+  let outFile = options.outFile || getI18nOutfile(format);
   if (options.outputPath) {
     // AngularCompilerPlugin doesn't support genDir so we have to adjust outFile instead.
     outFile = path.join(options.outputPath, outFile);


### PR DESCRIPTION
If someone uses the `extract-i18n` command with the deprecated `--i18n-format` option,
then `options.format` is undefined and the `outFile` defaults to `messages.xlf`,
whereas the content will be using the proper format.

    ng extract-i18n --i18n-format json
    # generates messages.xlf with JSON content

As the command is deprecated I'm not sure it's worth adding a complete e2e test. Let me know if the PR needs to be improved.