### PR TITLE
refactor(@angular-devkit/build-angular): remove virtualfs host usage from browser/dev-server

### DIFF
--- a/packages/angular_devkit/build_angular/src/app-shell/index.ts
+++ b/packages/angular_devkit/build_angular/src/app-shell/index.ts
@@ -12,7 +12,6 @@ import {
   targetFromTargetString,
 } from '@angular-devkit/architect';
 import { JsonObject, normalize, resolve } from '@angular-devkit/core';
-import { NodeJsSyncHost } from '@angular-devkit/core/node';
 import * as fs from 'fs';
 import * as path from 'path';
 import { BrowserBuilderOutput } from '../browser';
@@ -47,7 +46,6 @@ async function _renderUniversal(
   const zonePackage = require.resolve('zone.js', { paths: [root] });
   await import(zonePackage);
 
-  const host = new NodeJsSyncHost();
   const projectName = context.target && context.target.project;
   if (!projectName) {
     throw new Error('The builder requires a target.');
@@ -121,7 +119,6 @@ async function _renderUniversal(
 
     if (browserOptions.serviceWorker) {
       await augmentAppWithServiceWorker(
-        host,
         normalize(root),
         projectRoot,
         normalize(outputPath),

--- a/packages/angular_devkit/build_angular/src/dev-server/index.ts
+++ b/packages/angular_devkit/build_angular/src/dev-server/index.ts
@@ -13,7 +13,6 @@ import {
   runWebpackDevServer,
 } from '@angular-devkit/build-webpack';
 import { json, tags } from '@angular-devkit/core';
-import { NodeJsSyncHost } from '@angular-devkit/core/node';
 import * as path from 'path';
 import { Observable, from, of } from 'rxjs';
 import { concatMap, switchMap } from 'rxjs/operators';
@@ -83,7 +82,6 @@ export function serveWebpackBrowser(
   assertCompatibleAngularVersion(workspaceRoot, logger);
 
   const browserTarget = targetFromTargetString(options.browserTarget);
-  const host = new NodeJsSyncHost();
 
   async function setup(): Promise<{
     browserOptions: json.JsonObject & BrowserBuilderSchema;
@@ -148,7 +146,6 @@ export function serveWebpackBrowser(
         getCompilerConfig(wco),
         browserOptions.webWorkerTsConfig ? getWorkerConfig(wco) : {},
       ],
-      host,
       devServerOptions,
     );
 

--- a/packages/angular_devkit/build_angular/src/utils/normalize-asset-patterns.ts
+++ b/packages/angular_devkit/build_angular/src/utils/normalize-asset-patterns.ts
@@ -10,12 +10,13 @@ import {
   Path,
   basename,
   dirname,
+  getSystemPath,
   join,
   normalize,
   relative,
   resolve,
-  virtualFs,
 } from '@angular-devkit/core';
+import { statSync } from 'fs';
 import { AssetPattern, AssetPatternClass } from '../browser/schema';
 
 
@@ -27,7 +28,6 @@ export class MissingAssetSourceRootException extends BaseException {
 
 export function normalizeAssetPatterns(
   assetPatterns: AssetPattern[],
-  host: virtualFs.SyncDelegateHost,
   root: Path,
   projectRoot: Path,
   maybeSourceRoot: Path | undefined,
@@ -56,7 +56,7 @@ export function normalizeAssetPatterns(
         let isDirectory = false;
 
         try {
-          isDirectory = host.isDirectory(resolvedAssetPath);
+          isDirectory = statSync(getSystemPath(resolvedAssetPath)).isDirectory();
         } catch {
           isDirectory = true;
         }

--- a/packages/angular_devkit/build_angular/src/utils/normalize-builder-schema.ts
+++ b/packages/angular_devkit/build_angular/src/utils/normalize-builder-schema.ts
@@ -8,7 +8,7 @@
  */
 
 
-import { Path, virtualFs } from '@angular-devkit/core';
+import { Path } from '@angular-devkit/core';
 import {
   AssetPatternClass,
   Schema as BrowserBuilderSchema,
@@ -35,19 +35,17 @@ export type NormalizedBrowserBuilderSchema = BrowserBuilderSchema & BuildOptions
 };
 
 export function normalizeBrowserSchema(
-  host: virtualFs.Host<{}>,
   root: Path,
   projectRoot: Path,
   sourceRoot: Path | undefined,
   options: BrowserBuilderSchema,
 ): NormalizedBrowserBuilderSchema {
-  const syncHost = new virtualFs.SyncDelegateHost(host);
   const normalizedSourceMapOptions = normalizeSourceMaps(options.sourceMap || false);
 
   return {
     ...options,
-    assets: normalizeAssetPatterns(options.assets || [], syncHost, root, projectRoot, sourceRoot),
-    fileReplacements: normalizeFileReplacements(options.fileReplacements || [], syncHost, root),
+    assets: normalizeAssetPatterns(options.assets || [], root, projectRoot, sourceRoot),
+    fileReplacements: normalizeFileReplacements(options.fileReplacements || [], root),
     optimization: normalizeOptimization(options.optimization),
     sourceMap: normalizedSourceMapOptions,
     preserveSymlinks: options.preserveSymlinks === undefined ? process.execArgv.includes('--preserve-symlinks') : options.preserveSymlinks,

--- a/packages/angular_devkit/build_angular/src/utils/normalize-file-replacements.ts
+++ b/packages/angular_devkit/build_angular/src/utils/normalize-file-replacements.ts
@@ -12,8 +12,8 @@ import {
   getSystemPath,
   join,
   normalize,
-  virtualFs,
 } from '@angular-devkit/core';
+import { existsSync } from 'fs';
 import { FileReplacement } from '../browser/schema';
 
 
@@ -30,7 +30,6 @@ export interface NormalizedFileReplacement {
 
 export function normalizeFileReplacements(
   fileReplacements: FileReplacement[],
-  host: virtualFs.SyncDelegateHost,
   root: Path,
 ): NormalizedFileReplacement[] {
   if (fileReplacements.length === 0) {
@@ -41,11 +40,11 @@ export function normalizeFileReplacements(
     .map(replacement => normalizeFileReplacement(replacement, root));
 
   for (const { replace, with: replacementWith } of normalizedReplacement) {
-    if (!host.exists(replacementWith)) {
+    if (!existsSync(getSystemPath(replacementWith))) {
       throw new MissingFileReplacementException(getSystemPath(replacementWith));
     }
 
-    if (!host.exists(replace)) {
+    if (!existsSync(getSystemPath(replace))) {
       throw new MissingFileReplacementException(getSystemPath(replace));
     }
   }

--- a/packages/angular_devkit/build_angular/src/utils/service-worker.ts
+++ b/packages/angular_devkit/build_angular/src/utils/service-worker.ts
@@ -15,6 +15,7 @@ import {
   tags,
   virtualFs,
 } from '@angular-devkit/core';
+import { NodeJsSyncHost } from '@angular-devkit/core/node';
 import {
   Filesystem,
   Generator,
@@ -70,13 +71,13 @@ class CliFilesystem implements Filesystem {
 }
 
 export async function augmentAppWithServiceWorker(
-  host: virtualFs.Host,
   projectRoot: Path,
   appRoot: Path,
   outputPath: Path,
   baseHref: string,
   ngswConfigPath?: string,
 ): Promise<void> {
+  const host = new NodeJsSyncHost();
   const distPath = normalize(outputPath);
   const systemProjectRoot = getSystemPath(projectRoot);
 

--- a/packages/angular_devkit/build_angular/src/utils/webpack-browser-config.ts
+++ b/packages/angular_devkit/build_angular/src/utils/webpack-browser-config.ts
@@ -11,10 +11,7 @@ import {
   logging,
   normalize,
   resolve,
-  virtualFs,
 } from '@angular-devkit/core';
-import { NodeJsSyncHost } from '@angular-devkit/core/node';
-import * as fs from 'fs';
 import * as path from 'path';
 import * as webpack from 'webpack';
 import { merge as webpackMerge } from 'webpack-merge';
@@ -126,7 +123,6 @@ export async function generateI18nBrowserWebpackConfigFromContext(
   options: BrowserBuilderSchema,
   context: BuilderContext,
   webpackPartialGenerator: (wco: BrowserWebpackConfigOptions) => webpack.Configuration[],
-  host: virtualFs.Host<fs.Stats> = new NodeJsSyncHost(),
   extraBuildOptions: Partial<NormalizedBrowserBuilderSchema> = {},
 ): Promise<{ config: webpack.Configuration; projectRoot: string; projectSourceRoot?: string, i18n: I18nOptions }> {
   const { buildOptions, i18n } = await configureI18nBuild(context, options);
@@ -134,7 +130,6 @@ export async function generateI18nBrowserWebpackConfigFromContext(
     buildOptions,
     context,
     webpackPartialGenerator,
-    host,
     extraBuildOptions,
   );
   const config = result.config;
@@ -196,7 +191,6 @@ export async function generateBrowserWebpackConfigFromContext(
   options: BrowserBuilderSchema,
   context: BuilderContext,
   webpackPartialGenerator: (wco: BrowserWebpackConfigOptions) => webpack.Configuration[],
-  host: virtualFs.Host<fs.Stats> = new NodeJsSyncHost(),
   extraBuildOptions: Partial<NormalizedBrowserBuilderSchema> = {},
 ): Promise<{ config: webpack.Configuration; projectRoot: string; projectSourceRoot?: string }> {
   const projectName = context.target && context.target.project;
@@ -213,7 +207,6 @@ export async function generateBrowserWebpackConfigFromContext(
     : undefined;
 
   const normalizedOptions = normalizeBrowserSchema(
-    host,
     workspaceRoot,
     projectRoot,
     sourceRoot,


### PR DESCRIPTION
The virtualfs Host was only used for exist and directory checks during asset and file replacement option normalization within the browser and dev-server builders.