### PR TITLE
fix(@angular-devkit/build-angular): add service-worker as optional peer dependency

### DIFF
--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -81,6 +81,7 @@
   "peerDependencies": {
     "@angular/compiler-cli": "^11.0.0 || ^11.1.0-next",
     "@angular/localize": "^11.0.0 || ^11.1.0-next",
+    "@angular/service-worker": "^11.0.0 || ^11.1.0-next",
     "karma": "^5.2.0 || ^6.0.0",
     "ng-packagr": "^11.0.0 || ^11.1.0-next",
     "protractor": "^7.0.0",
@@ -89,6 +90,9 @@
   },
   "peerDependenciesMeta": {
     "@angular/localize": {
+      "optional": true
+    },
+    "@angular/service-worker": {
       "optional": true
     },
     "karma": {

--- a/packages/angular_devkit/build_angular/src/utils/service-worker.ts
+++ b/packages/angular_devkit/build_angular/src/utils/service-worker.ts
@@ -18,7 +18,7 @@ import {
 import {
   Filesystem,
   Generator,
-} from '@angular/service-worker/config'; // tslint:disable-line:no-implicit-dependencies
+} from '@angular/service-worker/config';
 import * as crypto from 'crypto';
 
 class CliFilesystem implements Filesystem {

--- a/packages/angular_devkit/build_angular/src/utils/webpack-browser-config.ts
+++ b/packages/angular_devkit/build_angular/src/utils/webpack-browser-config.ts
@@ -62,7 +62,6 @@ export async function generateWebpackConfig(
   const tsConfigPath = path.resolve(workspaceRoot, options.tsConfig);
   const tsConfig = readTsconfig(tsConfigPath);
 
-  // tslint:disable-next-line:no-implicit-dependencies
   const ts = await import('typescript');
   const scriptTarget = tsConfig.options.target || ts.ScriptTarget.ES5;
 


### PR DESCRIPTION
The `@angular/service-worker` package is used by the browser and app-shell builders.
By adding the package as an optional peer dependency, package managers can ensure that the package is available to import.