### PR TITLE
fix(@angular/cli): add @angular-devkit/architect to ng-update packageGroup

### DIFF
--- a/packages/angular/cli/package.json
+++ b/packages/angular/cli/package.json
@@ -51,6 +51,7 @@
     "migrations": "@schematics/angular/migrations/migration-collection.json",
     "packageGroup": {
       "@angular/cli": "0.0.0",
+      "@angular-devkit/architect": "0.0.0",
       "@angular-devkit/build-angular": "0.0.0",
       "@angular-devkit/build-webpack": "0.0.0",
       "@angular-devkit/core": "0.0.0",


### PR DESCRIPTION
Having `@angular-devkit/architect` as a dependency and running `ng update @angular/cli` leaves it not updated.
Adding this package to `@angular/cli` `packageGroup` will solve this inconvenience.