### PR TITLE
Replace deprecated TypeScript methods

### DIFF
--- a/packages/ngtools/webpack/src/transformers/export_ngfactory.ts
+++ b/packages/ngtools/webpack/src/transformers/export_ngfactory.ts
@@ -58,10 +58,10 @@ export function exportNgFactory(
       const factoryClassName = entryModule.className + 'NgFactory';
       const factoryModulePath = normalizedEntryModulePath + '.ngfactory';
 
-      const namedExports = ts.createNamedExports([ts.createExportSpecifier(undefined,
-        ts.createIdentifier(factoryClassName))]);
-      const newImport = ts.createExportDeclaration(undefined, undefined, namedExports,
-        ts.createLiteral(factoryModulePath));
+      const namedExports = ts.factory.createNamedExports([ts.factory.createExportSpecifier(undefined,
+        ts.factory.createIdentifier(factoryClassName))]);
+      const newImport = ts.factory.createExportDeclaration(undefined, undefined, false, namedExports,
+        ts.factory.createStringLiteral(factoryModulePath));
 
       const firstNode = getFirstNode(sourceFile);
       if (firstNode) {

--- a/packages/ngtools/webpack/src/transformers/import_factory.ts
+++ b/packages/ngtools/webpack/src/transformers/import_factory.ts
@@ -227,10 +227,10 @@ function replaceImport(
   const replacementVisitor: ts.Visitor = (node: ts.Node) => {
     if (node === importStringLit) {
       // Transform the import string.
-      return ts.createStringLiteral(newImportString);
+      return ts.factory.createStringLiteral(newImportString);
     } else if (node === exportNameId) {
       // Transform the export name.
-      return ts.createIdentifier(exportNameId.text + 'NgFactory');
+      return ts.factory.createIdentifier(exportNameId.text + 'NgFactory');
     }
 
     return ts.visitEachChild(node, replacementVisitor, context);

--- a/packages/ngtools/webpack/src/transformers/insert_import.ts
+++ b/packages/ngtools/webpack/src/transformers/insert_import.ts
@@ -23,10 +23,10 @@ export function insertStarImport(
   // We don't need to verify if the symbol is already imported, star imports should be unique.
 
   // Create the new import node.
-  const namespaceImport = ts.createNamespaceImport(identifier);
-  const importClause = ts.createImportClause(undefined, namespaceImport);
-  const newImport = ts.createImportDeclaration(undefined, undefined, importClause,
-    ts.createLiteral(modulePath));
+  const namespaceImport = ts.factory.createNamespaceImport(identifier);
+  const importClause = ts.factory.createImportClause(false, undefined, namespaceImport);
+  const newImport = ts.factory.createImportDeclaration(undefined, undefined, importClause,
+    ts.factory.createStringLiteral(modulePath));
 
   if (target) {
     ops.push(new AddNodeOperation(
@@ -106,15 +106,15 @@ export function insertImport(
       sourceFile,
       maybeImports[0].elements[maybeImports[0].elements.length - 1],
       undefined,
-      ts.createImportSpecifier(undefined, ts.createIdentifier(symbolName)),
+      ts.factory.createImportSpecifier(undefined, ts.factory.createIdentifier(symbolName)),
     ));
   } else {
     // Create the new import node.
-    const namedImports = ts.createNamedImports([ts.createImportSpecifier(undefined,
-      ts.createIdentifier(symbolName))]);
-    const importClause = ts.createImportClause(undefined, namedImports);
-    const newImport = ts.createImportDeclaration(undefined, undefined, importClause,
-      ts.createLiteral(modulePath));
+    const namedImports = ts.factory.createNamedImports([ts.factory.createImportSpecifier(undefined,
+      ts.factory.createIdentifier(symbolName))]);
+    const importClause = ts.factory.createImportClause(false, undefined, namedImports);
+    const newImport = ts.factory.createImportDeclaration(undefined, undefined, importClause,
+      ts.factory.createStringLiteral(modulePath));
 
     if (allImports.length > 0) {
       // Find the last import and insert after.

--- a/packages/ngtools/webpack/src/transformers/register_locale_data.ts
+++ b/packages/ngtools/webpack/src/transformers/register_locale_data.ts
@@ -66,7 +66,7 @@ export function registerLocaleData(
       }
 
       // Create the import node for the locale.
-      const localeNamespaceId = ts.createUniqueName('__NgCli_locale_');
+      const localeNamespaceId = ts.factory.createUniqueName('__NgCli_locale_');
       ops.push(...insertStarImport(
         sourceFile,
         localeNamespaceId,
@@ -76,19 +76,19 @@ export function registerLocaleData(
       ));
 
       // Create the import node for the registerLocaleData function.
-      const regIdentifier = ts.createIdentifier(`registerLocaleData`);
-      const regNamespaceId = ts.createUniqueName('__NgCli_locale_');
+      const regIdentifier = ts.factory.createIdentifier(`registerLocaleData`);
+      const regNamespaceId = ts.factory.createUniqueName('__NgCli_locale_');
       ops.push(
         ...insertStarImport(sourceFile, regNamespaceId, '@angular/common', firstNode, true),
       );
 
       // Create the register function call
-      const registerFunctionCall = ts.createCall(
-        ts.createPropertyAccess(regNamespaceId, regIdentifier),
+      const registerFunctionCall = ts.factory.createCallExpression(
+        ts.factory.createPropertyAccessExpression(regNamespaceId, regIdentifier),
         undefined,
-        [ts.createPropertyAccess(localeNamespaceId, 'default')],
+        [ts.factory.createPropertyAccessExpression(localeNamespaceId, 'default')],
       );
-      const registerFunctionStatement = ts.createStatement(registerFunctionCall);
+      const registerFunctionStatement = ts.factory.createExpressionStatement(registerFunctionCall);
 
       ops.push(new AddNodeOperation(
         sourceFile,

--- a/packages/ngtools/webpack/src/transformers/replace_bootstrap.ts
+++ b/packages/ngtools/webpack/src/transformers/replace_bootstrap.ts
@@ -74,8 +74,8 @@ export function replaceBootstrap(
 
       const platformBrowserDynamicIdentifier = innerCallExpr.expression as ts.Identifier;
 
-      const idPlatformBrowser = ts.createUniqueName('__NgCli_bootstrap_');
-      const idNgFactory = ts.createUniqueName('__NgCli_bootstrap_');
+      const idPlatformBrowser = ts.factory.createUniqueName('__NgCli_bootstrap_');
+      const idNgFactory = ts.factory.createUniqueName('__NgCli_bootstrap_');
 
       // Add the transform operations.
       const relativeEntryModulePath = relative(dirname(sourceFile.fileName), entryModule.path);
@@ -93,13 +93,13 @@ export function replaceBootstrap(
         // Replace the entry module import.
         ...insertStarImport(sourceFile, idNgFactory, modulePath),
         new ReplaceNodeOperation(sourceFile, entryModuleIdentifier,
-          ts.createPropertyAccess(idNgFactory, ts.createIdentifier(className))),
+          ts.factory.createPropertyAccessExpression(idNgFactory, ts.factory.createIdentifier(className))),
         // Replace the platformBrowserDynamic import.
         ...insertStarImport(sourceFile, idPlatformBrowser, '@angular/platform-browser'),
         new ReplaceNodeOperation(sourceFile, platformBrowserDynamicIdentifier,
-          ts.createPropertyAccess(idPlatformBrowser, 'platformBrowser')),
+          ts.factory.createPropertyAccessExpression(idPlatformBrowser, 'platformBrowser')),
         new ReplaceNodeOperation(sourceFile, bootstrapModuleIdentifier,
-          ts.createIdentifier(bootstrapIdentifier)),
+          ts.factory.createIdentifier(bootstrapIdentifier)),
       );
     });
 

--- a/packages/ngtools/webpack/src/transformers/replace_server_bootstrap.ts
+++ b/packages/ngtools/webpack/src/transformers/replace_server_bootstrap.ts
@@ -79,21 +79,21 @@ export function replaceServerBootstrap(
 
           const platformDynamicServerIdentifier = innerCallExpr.expression as ts.Identifier;
 
-          const idPlatformServer = ts.createUniqueName('__NgCli_bootstrap_');
-          const idNgFactory = ts.createUniqueName('__NgCli_bootstrap_');
+          const idPlatformServer = ts.factory.createUniqueName('__NgCli_bootstrap_');
+          const idNgFactory = ts.factory.createUniqueName('__NgCli_bootstrap_');
 
           // Add the transform operations.
           ops.push(
             // Replace the entry module import.
             ...insertStarImport(sourceFile, idNgFactory, factoryModulePath),
             new ReplaceNodeOperation(sourceFile, entryModuleIdentifier,
-              ts.createPropertyAccess(idNgFactory, ts.createIdentifier(factoryClassName))),
+              ts.factory.createPropertyAccessExpression(idNgFactory, ts.factory.createIdentifier(factoryClassName))),
             // Replace the platformBrowserDynamic import.
             ...insertStarImport(sourceFile, idPlatformServer, '@angular/platform-server'),
             new ReplaceNodeOperation(sourceFile, platformDynamicServerIdentifier,
-              ts.createPropertyAccess(idPlatformServer, 'platformServer')),
+              ts.factory.createPropertyAccessExpression(idPlatformServer, 'platformServer')),
             new ReplaceNodeOperation(sourceFile, bootstrapModuleIdentifier,
-              ts.createIdentifier('bootstrapModuleFactory')),
+              ts.factory.createIdentifier('bootstrapModuleFactory')),
           );
         } else if (callExpr.expression.kind === ts.SyntaxKind.Identifier) {
           // Figure out if it is renderModule
@@ -106,30 +106,30 @@ export function replaceServerBootstrap(
 
           const renderModuleIdentifier = identifierExpr as ts.Identifier;
 
-          const idPlatformServer = ts.createUniqueName('__NgCli_bootstrap_');
-          const idNgFactory = ts.createUniqueName('__NgCli_bootstrap_');
+          const idPlatformServer = ts.factory.createUniqueName('__NgCli_bootstrap_');
+          const idNgFactory = ts.factory.createUniqueName('__NgCli_bootstrap_');
 
           ops.push(
             // Replace the entry module import.
             ...insertStarImport(sourceFile, idNgFactory, factoryModulePath),
             new ReplaceNodeOperation(sourceFile, entryModuleIdentifier,
-              ts.createPropertyAccess(idNgFactory, ts.createIdentifier(factoryClassName))),
+              ts.factory.createPropertyAccessExpression(idNgFactory, ts.factory.createIdentifier(factoryClassName))),
             // Replace the renderModule import.
             ...insertStarImport(sourceFile, idPlatformServer, '@angular/platform-server'),
             new ReplaceNodeOperation(sourceFile, renderModuleIdentifier,
-              ts.createPropertyAccess(idPlatformServer, 'renderModuleFactory')),
+              ts.factory.createPropertyAccessExpression(idPlatformServer, 'renderModuleFactory')),
           );
         }
       } else if (entryModuleIdentifier.parent.kind === ts.SyntaxKind.PropertyAssignment) {
         // This is for things that accept a module as a property in a config object
         // .ie the express engine
 
-        const idNgFactory = ts.createUniqueName('__NgCli_bootstrap_');
+        const idNgFactory = ts.factory.createUniqueName('__NgCli_bootstrap_');
 
         ops.push(
           ...insertStarImport(sourceFile, idNgFactory, factoryModulePath),
           new ReplaceNodeOperation(sourceFile, entryModuleIdentifier,
-            ts.createPropertyAccess(idNgFactory, ts.createIdentifier(factoryClassName))),
+            ts.factory.createPropertyAccessExpression(idNgFactory, ts.factory.createIdentifier(factoryClassName))),
         );
       }
     });

--- a/tests/legacy-cli/e2e/assets/webpack/test-app/package.json
+++ b/tests/legacy-cli/e2e/assets/webpack/test-app/package.json
@@ -2,26 +2,25 @@
   "name": "test",
   "license": "MIT",
   "dependencies": {
-    "@angular/common": "9.0.0",
-    "@angular/compiler": "9.0.0",
-    "@angular/compiler-cli": "9.0.0",
-    "@angular/core": "9.0.0",
-    "@angular/platform-browser": "9.0.0",
-    "@angular/platform-browser-dynamic": "9.0.0",
-    "@angular/platform-server": "9.0.0",
-    "@angular/router": "9.0.0",
+    "@angular/common": "11.0.0",
+    "@angular/compiler": "11.0.0",
+    "@angular/compiler-cli": "11.0.0",
+    "@angular/core": "11.0.0",
+    "@angular/platform-browser": "11.0.0",
+    "@angular/platform-browser-dynamic": "11.0.0",
+    "@angular/platform-server": "11.0.0",
+    "@angular/router": "11.0.0",
     "@ngtools/webpack": "0.0.0",
     "core-js": "^3.0.0",
     "rxjs": "^6.4.0",
     "zone.js": "^0.9.1"
   },
   "devDependencies": {
-    "node-sass": "^4.7.0",
-    "performance-now": "^0.2.0",
-    "raw-loader": "^0.5.1",
-    "sass-loader": "^6.0.0",
-    "typescript": "~3.6.4",
-    "webpack": "~4.0.1",
-    "webpack-cli": "~2.0.9"
+    "raw-loader": "^4.0.2",
+    "sass": "^1.32.5",
+    "sass-loader": "^10.1.1",
+    "typescript": "~4.0.1",
+    "webpack": "^4.0.1",
+    "webpack-cli": "^4.4.0"
   }
 }

--- a/tests/legacy-cli/e2e/assets/webpack/test-app/tsconfig.json
+++ b/tests/legacy-cli/e2e/assets/webpack/test-app/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
     "baseUrl": "",
-    "module": "es2015",
+    "module": "es2020",
     "moduleResolution": "node",
-    "target": "es5",
+    "target": "es2015",
     "noImplicitAny": false,
     "sourceMap": true,
     "mapRoot": "",

--- a/tests/legacy-cli/e2e/assets/webpack/test-app/webpack.config.js
+++ b/tests/legacy-cli/e2e/assets/webpack/test-app/webpack.config.js
@@ -19,7 +19,6 @@ module.exports = {
   module: {
     rules: [
       { test: /\.scss$/, loaders: ['raw-loader', 'sass-loader'] },
-      { test: /\.css$/, loader: 'raw-loader' },
       { test: /\.html$/, loader: 'raw-loader' },
       { test: /\.ts$/, loader: '@ngtools/webpack' }
     ]

--- a/tests/legacy-cli/e2e/tests/packages/webpack/test-app.ts
+++ b/tests/legacy-cli/e2e/tests/packages/webpack/test-app.ts
@@ -24,7 +24,7 @@ export default async function (skipCleaning: () => void) {
   // Note: these sizes are without Build Optimizer or any advanced optimizations in the CLI.
   await expectFileSizeToBeUnder('dist/app.main.js', (isVe ? 483 : 565) * 1024);
   await expectFileSizeToBeUnder('dist/0.app.main.js', 1 * 1024);
-  await expectFileSizeToBeUnder('dist/1.app.main.js', 2 * 1024);
+  await expectFileSizeToBeUnder('dist/2.app.main.js', 2 * 1024);
 
   // test resource urls without ./
   await replaceInFile('app/app.component.ts', './app.component.html', 'app.component.html');


### PR DESCRIPTION
TypeScript provides a set of  pure  functions for producing syntax tree nodes. Since TypeScript 4.0 these methods have been deprecated in favor of the `factory` API.

See: https://github.com/microsoft/TypeScript/wiki/API-Breaking-Changes#typescript-40