### PR TITLE
fix(@angular/cli): avoid analytics cli object check if not present

### DIFF
--- a/packages/angular/cli/models/analytics.ts
+++ b/packages/angular/cli/models/analytics.ts
@@ -358,7 +358,7 @@ export function setAnalyticsConfig(level: 'global' | 'local', value: string | bo
 
   const cli = config.get(['cli']);
 
-  if (!json.isJsonObject(cli as json.JsonValue)) {
+  if (cli !== undefined && !json.isJsonObject(cli as json.JsonValue)) {
     throw new Error(`Invalid config found at ${configPath}. CLI should be an object.`);
   }
 


### PR DESCRIPTION
The `cli` workspace configuration property was previously checked to determine if it was an object even if the property did not yet exist.