### PR TITLE
fix(@schematics/update): update line end normalization for CA file read from .npmrc

### DIFF
--- a/packages/angular/cli/utilities/package-metadata.ts
+++ b/packages/angular/cli/utilities/package-metadata.ts
@@ -143,7 +143,7 @@ function readOptions(
             if (typeof value === 'string') {
               const cafile = path.resolve(path.dirname(location), value);
               try {
-                options['ca'] = readFileSync(cafile, 'utf8').replace(/\r?\n/, '\\n');
+                options['ca'] = readFileSync(cafile, 'utf8').replace(/\r?\n/g, '\n');
               } catch { }
             }
             break;

--- a/packages/schematics/update/update/npm.ts
+++ b/packages/schematics/update/update/npm.ts
@@ -90,7 +90,7 @@ function readOptions(
             if (typeof value === 'string') {
               const cafile = path.resolve(path.dirname(location), value);
               try {
-                options['ca'] = readFileSync(cafile, 'utf8').replace(/\r?\n/, '\\n');
+                options['ca'] = readFileSync(cafile, 'utf8').replace(/\r?\n/g, '\n');
               } catch { }
             }
             break;


### PR DESCRIPTION
Before only first line end was being replaced.
Also, the replace value was incorrectly escaped.

The CA read from cafile being corrupt resulted in broken updates
when using registry with self-signed certificate.

The workaround till this is merged is to use `ca` or `ca[]` properties in `.npmrc`.


Before:
```
-----BEGIN CERTIFICATE-----\nMIIC5DCCAcwCCQDBp0EioJnYqTANBgkqhkiG9w0BAQsFADA0MQswCQYDVQQGEwJT
RTESMBAGA1UEBwwJU3RvY2tob2xtMREwDwYDVQQKDAhTd2VkYmFuazAeFw0yMTAx
...rest_of_certificate
-----END CERTIFICATE-----
```

After:
```
-----BEGIN CERTIFICATE-----
MIIC5DCCAcwCCQDBp0EioJnYqTANBgkqhkiG9w0BAQsFADA0MQswCQYDVQQGEwJT
RTESMBAGA1UEBwwJU3RvY2tob2xtMREwDwYDVQQKDAhTd2VkYmFuazAeFw0yMTAx
...rest_of_certificate
-----END CERTIFICATE-----
```
