### PR TITLE
fix(@ngtools/webpack): perform import eliding before TypeScript transforms

### DIFF
--- a/packages/ngtools/webpack/src/ivy/transformation.ts
+++ b/packages/ngtools/webpack/src/ivy/transformation.ts
@@ -25,7 +25,7 @@ export function createAotTransformers(
   const removeNgModuleScope = !options.emitNgModuleScope;
   if (removeClassMetadata || removeNgModuleScope) {
     // tslint:disable-next-line: no-non-null-assertion
-    transformers.after!.push(
+    transformers.before!.push(
       removeIvyJitSupportCalls(removeClassMetadata, removeNgModuleScope, getTypeChecker),
     );
   }

--- a/packages/ngtools/webpack/src/transformers/elide_imports.ts
+++ b/packages/ngtools/webpack/src/transformers/elide_imports.ts
@@ -118,6 +118,11 @@ export function elideImports(
   }
 
   const isUnused = (node: ts.Identifier) => {
+    // Do not remove JSX factory imports
+    if (node.text === compilerOptions.jsxFactory) {
+      return false;
+    }
+
     const symbol = typeChecker.getSymbolAtLocation(node);
 
     return symbol && !usedSymbols.has(symbol);

--- a/packages/ngtools/webpack/src/transformers/spec_helpers.ts
+++ b/packages/ngtools/webpack/src/transformers/spec_helpers.ts
@@ -14,7 +14,7 @@ import { WebpackCompilerHost } from '../compiler_host';
 
 // Test transform helpers.
 const basePath = '/project/src/';
-const fileName = basePath + 'test-file.ts';
+const basefileName = basePath + 'test-file.ts';
 const typeScriptLibFiles = loadTypeScriptLibFiles();
 const tsLibFiles = loadTsLibFiles();
 
@@ -23,7 +23,9 @@ export function createTypescriptContext(
   additionalFiles?: Record<string, string>,
   useLibs = false,
   extraCompilerOptions: ts.CompilerOptions = {},
+  jsxFile = false,
 ) {
+  const fileName = basefileName + (jsxFile ? 'x' : '');
   // Set compiler options.
   const compilerOptions: ts.CompilerOptions = {
     noEmitOnError: useLibs,
@@ -107,7 +109,7 @@ export function transformTypescript(
   }
 
   // Return the transpiled js.
-  return compilerHost.readFile(fileName.replace(/\.tsx?$/, '.js'));
+  return compilerHost.readFile(basefileName.replace(/\.tsx?$/, '.js'));
 }
 
 function loadTypeScriptLibFiles(): Record<string, string> {


### PR DESCRIPTION
Due to the method used by TypeScript to emit decorator metadata via the `emitDecoratorMetadata` function, the import eliding algorithm within the Angular compiler plugin may errantly remove imports to type metadata included in the emitted decorator calls. By moving the eliding before TypeScript, the eliding can use the Type nodes to analyze for used imports when `emitDecoratorMetadata` is enabled. This fix also reworks the previous fix to prevent the eliding to errantly remove certain factory functions that TypeScript may use in emitted code but are not yet referenced in the input code. The previous fix was to move the eliding after the TypeScript transformations.  The new fix is therefore not as comprehensive as the original but covers the usecase within the originating issue (#13297).

Angular (8.0.4+) no longer requires the use of the `emitDecoratorMetadata` option and in most cases can safely be removed.  With the uncommon exception being third-party libraries and custom application code that specifically require the option.