### PR TITLE
fix(@angular-devkit/build-angular): resolve postcss from build-angular package

### DIFF
--- a/package.json
+++ b/package.json
@@ -191,7 +191,7 @@
     "popper.js": "^1.14.1",
     "postcss": "8.2.4",
     "postcss-import": "14.0.0",
-    "postcss-loader": "4.1.0",
+    "postcss-loader": "4.2.0",
     "prettier": "^2.0.0",
     "protractor": "~7.0.0",
     "puppeteer": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
     "karma-jasmine-html-reporter": "^1.5.0",
     "karma-source-map-support": "1.4.0",
     "less": "4.1.0",
-    "less-loader": "7.2.1",
+    "less-loader": "7.3.0",
     "license-checker": "^25.0.0",
     "license-checker-webpack-plugin": "0.2.1",
     "loader-utils": "2.0.0",

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -49,7 +49,7 @@
     "pnp-webpack-plugin": "1.6.4",
     "postcss": "8.2.4",
     "postcss-import": "14.0.0",
-    "postcss-loader": "4.1.0",
+    "postcss-loader": "4.2.0",
     "raw-loader": "4.0.2",
     "regenerator-runtime": "0.13.7",
     "resolve-url-loader": "3.1.2",

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -38,7 +38,7 @@
     "jest-worker": "26.6.2",
     "karma-source-map-support": "1.4.0",
     "less": "4.1.0",
-    "less-loader": "7.2.1",
+    "less-loader": "7.3.0",
     "license-webpack-plugin": "2.3.11",
     "loader-utils": "2.0.0",
     "mini-css-extract-plugin": "1.3.4",

--- a/packages/angular_devkit/build_angular/src/webpack/configs/styles.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/styles.ts
@@ -126,6 +126,7 @@ export function getStylesConfig(wco: WebpackConfigOptions) {
         {
           loader: require.resolve('less-loader'),
           options: {
+            implementation: require('less'),
             sourceMap: cssSourceMap,
             lessOptions: {
               javascriptEnabled: true,

--- a/packages/angular_devkit/build_angular/src/webpack/configs/styles.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/styles.ts
@@ -210,6 +210,7 @@ export function getStylesConfig(wco: WebpackConfigOptions) {
       {
         loader: require.resolve('postcss-loader'),
         options: {
+          implementation: require('postcss'),
           postcssOptions: postcssOptionsCreator(componentsSourceMap, false),
         },
       },
@@ -242,6 +243,7 @@ export function getStylesConfig(wco: WebpackConfigOptions) {
             {
               loader: require.resolve('postcss-loader'),
               options: {
+                implementation: require('postcss'),
                 postcssOptions: postcssOptionsCreator(globalSourceMap, buildOptions.extractCss),
               },
             },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7091,10 +7091,10 @@ lcid@^2.0.0:
   dependencies:
     invert-kv "^2.0.0"
 
-less-loader@7.2.1:
-  version "7.2.1"
-  resolved "https://registry.yarnpkg.com/less-loader/-/less-loader-7.2.1.tgz#a923df8567256751b0ab4e0c3eecff10fd0a5876"
-  integrity sha512-4v83WZ7KGbluOWPgk3iNjreAaJDNStfmmdfJbQIib3Jlc8mejV3w6A9xU+EkaivjBVqwQEK0y8cFthyNeGnrTQ==
+less-loader@7.3.0:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/less-loader/-/less-loader-7.3.0.tgz#f9d6d36d18739d642067a05fb5bd70c8c61317e5"
+  integrity sha512-Mi8915g7NMaLlgi77mgTTQvK022xKRQBIVDSyfl3ErTuBhmZBQab0mjeJjNNqGbdR+qrfTleKXqbGI4uEFavxg==
   dependencies:
     klona "^2.0.4"
     loader-utils "^2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9149,16 +9149,16 @@ postcss-import@14.0.0:
     read-cache "^1.0.0"
     resolve "^1.1.7"
 
-postcss-loader@4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/postcss-loader/-/postcss-loader-4.1.0.tgz#4647a6c8dad3cb6b253fbfaa21d62201086f6e39"
-  integrity sha512-vbCkP70F3Q9PIk6d47aBwjqAMI4LfkXCoyxj+7NPNuVIwfTGdzv2KVQes59/RuxMniIgsYQCFSY42P3+ykJfaw==
+postcss-loader@4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/postcss-loader/-/postcss-loader-4.2.0.tgz#f6993ea3e0f46600fb3ee49bbd010448123a7db4"
+  integrity sha512-mqgScxHqbiz1yxbnNcPdKYo/6aVt+XExURmEbQlviFVWogDbM4AJ0A/B+ZBpYsJrTRxKw7HyRazg9x0Q9SWwLA==
   dependencies:
     cosmiconfig "^7.0.0"
     klona "^2.0.4"
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
-    semver "^7.3.2"
+    semver "^7.3.4"
 
 postcss-merge-longhand@^4.0.11:
   version "4.0.11"
@@ -10493,7 +10493,7 @@ semver@7.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
-semver@7.3.4, semver@^7.0.0, semver@^7.1.1, semver@^7.3.2:
+semver@7.3.4, semver@^7.0.0, semver@^7.1.1, semver@^7.3.2, semver@^7.3.4:
   version "7.3.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.4.tgz#27aaa7d2e4ca76452f98d3add093a72c943edc97"
   integrity sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==


### PR DESCRIPTION


`postcss-loader` version 4.2.0 added an `implementation` option. Using the using will ensure that the correct postcss version is used.

More info: https://github.com/webpack-contrib/postcss-loader/commit/deac9787eed614b1c445f091a2b70736a6212812

Fixes #19839