### PR TITLE
fix(@angular-devkit/build-angular): inlining fonts behind proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,6 +156,7 @@
     "git-raw-commits": "^2.0.0",
     "glob": "7.1.6",
     "http-proxy": "^1.18.1",
+    "https-proxy-agent": "5.0.0",
     "husky": "5.0.6",
     "inquirer": "7.3.3",
     "jasmine": "^3.3.1",

--- a/packages/angular/cli/lib/config/schema.json
+++ b/packages/angular/cli/lib/config/schema.json
@@ -751,7 +751,7 @@
                       ]
                     },
                     "fonts": {
-                      "description": "Enables optimization for fonts. This requires internet access.",
+                      "description": "Enables optimization for fonts. This option requires internet access. `HTTPS_PROXY` environment variable can be used to specify a proxy server.",
                       "default": true,
                       "oneOf": [
                         {
@@ -759,7 +759,7 @@
                           "properties": {
                             "inline": {
                               "type": "boolean",
-                              "description": "Reduce render blocking requests by inlining external Google fonts and icons CSS definitions in the application's HTML index file. This requires internet access.",
+                              "description": "Reduce render blocking requests by inlining external Google fonts and icons CSS definitions in the application's HTML index file. This option requires internet access. `HTTPS_PROXY` environment variable can be used to specify a proxy server.",
                               "default": true
                             }
                           },

--- a/packages/angular_devkit/build_angular/BUILD.bazel
+++ b/packages/angular_devkit/build_angular/BUILD.bazel
@@ -153,6 +153,7 @@ ts_library(
         "@npm//file-loader",
         "@npm//find-cache-dir",
         "@npm//glob",
+        "@npm//https-proxy-agent",
         "@npm//inquirer",
         "@npm//jest-worker",
         "@npm//karma",

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -34,6 +34,7 @@
     "file-loader": "6.2.0",
     "find-cache-dir": "3.3.1",
     "glob": "7.1.6",
+    "https-proxy-agent": "5.0.0",
     "inquirer": "7.3.3",
     "jest-worker": "26.6.2",
     "karma-source-map-support": "1.4.0",

--- a/packages/angular_devkit/build_angular/src/browser/schema.json
+++ b/packages/angular_devkit/build_angular/src/browser/schema.json
@@ -95,7 +95,7 @@
               ]
             },
             "fonts": {
-              "description": "Enables optimization for fonts. This requires internet access.",
+              "description": "Enables optimization for fonts. This option requires internet access. `HTTPS_PROXY` environment variable can be used to specify a proxy server.",
               "default": true,
               "oneOf": [
                 {
@@ -103,7 +103,7 @@
                   "properties": {
                     "inline": {
                       "type": "boolean",
-                      "description": "Reduce render blocking requests by inlining external Google fonts and icons CSS definitions in the application's HTML index file. This requires internet access.",
+                      "description": "Reduce render blocking requests by inlining external Google fonts and icons CSS definitions in the application's HTML index file. This option requires internet access. `HTTPS_PROXY` environment variable can be used to specify a proxy server.",
                       "default": true
                     }
                   },

--- a/packages/angular_devkit/build_angular/src/utils/index-file/inline-fonts.ts
+++ b/packages/angular_devkit/build_angular/src/utils/index-file/inline-fonts.ts
@@ -8,6 +8,7 @@
 
 import * as cacache from 'cacache';
 import * as https from 'https';
+import * as proxyAgent from 'https-proxy-agent';
 import { URL } from 'url';
 import { findCachePath } from '../cache-path';
 import { cachingDisabled } from '../environment-options';
@@ -100,11 +101,20 @@ export class InlineFontsProcessor {
       }
     }
 
+    let agent: proxyAgent.HttpsProxyAgent | undefined;
+    const httpsProxy = process.env.HTTPS_PROXY ?? process.env.https_proxy;
+
+    if (httpsProxy) {
+      agent = proxyAgent(httpsProxy);
+    }
+
     const data = await new Promise<string>((resolve, reject) => {
       let rawResponse = '';
       https.get(
         url,
         {
+          agent,
+          rejectUnauthorized: false,
           headers: {
             'user-agent': userAgent,
           },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6006,6 +6006,14 @@ https-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
 
+https-proxy-agent@5.0.0, https-proxy-agent@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz#e2a90542abb68a762e0a0850f6c9edadfd8506b2"
+  integrity sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==
+  dependencies:
+    agent-base "6"
+    debug "4"
+
 https-proxy-agent@^2.2.1:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz#4ee7a737abd92678a293d9b34a1af4d0d08c787b"
@@ -6020,14 +6028,6 @@ https-proxy-agent@^4.0.0:
   integrity sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==
   dependencies:
     agent-base "5"
-    debug "4"
-
-https-proxy-agent@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz#e2a90542abb68a762e0a0850f6c9edadfd8506b2"
-  integrity sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==
-  dependencies:
-    agent-base "6"
     debug "4"
 
 humanize-ms@^1.2.1:


### PR DESCRIPTION
With this change users can now their proxy server via the `HTTPS_PROXY` environment variable. The specified proxy will be used when making requests to inline fonts.

Closes #19401