### PR TITLE
refactor(@angular-devkit/core): deprecate flatten schema method

### DIFF
--- a/packages/angular_devkit/core/src/json/schema/interface.ts
+++ b/packages/angular_devkit/core/src/json/schema/interface.ts
@@ -113,6 +113,11 @@ export type PromptProvider = (definitions: Array<PromptDefinition>)
 
 export interface SchemaRegistry {
   compile(schema: Object): Observable<SchemaValidator>;
+  /**
+   * @deprecated since 11.2 without replacement.
+   * Producing a flatten schema document does not in all cases produce a schema with identical behavior to the original.
+   * See: https://json-schema.org/draft/2019-09/json-schema-core.html#rfc.appendix.B.2
+   */
   flatten(schema: JsonObject | string): Observable<JsonObject>;
   addFormat(format: SchemaFormat): void;
   addSmartDefaultProvider<T>(source: string, provider: SmartDefaultProvider<T>): void;

--- a/packages/angular_devkit/core/src/json/schema/registry.ts
+++ b/packages/angular_devkit/core/src/json/schema/registry.ts
@@ -239,6 +239,9 @@ export class CoreSchemaRegistry implements SchemaRegistry {
    *
    * @param schema The schema or URI to flatten.
    * @returns An Observable of the flattened schema object.
+   * @deprecated since 11.2 without replacement.
+   * Producing a flatten schema document does not in all cases produce a schema with identical behavior to the original.
+   * See: https://json-schema.org/draft/2019-09/json-schema-core.html#rfc.appendix.B.2
    */
   flatten(schema: JsonObject): Observable<JsonObject> {
     this._ajv.removeSchema(schema);


### PR DESCRIPTION
The flatten schema method has been deprecated without replacement.

Producing a flatten schema document does not in all cases produce a schema with identical behavior to the original.

See: https://json-schema.org/draft/2019-09/json-schema-core.html#rfc.appendix.B.2