### PR TITLE
refactor(@angular-devkit/build-angular): remove file-loader dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,7 +149,6 @@
     "enhanced-resolve": "5.7.0",
     "express": "4.17.1",
     "fast-json-stable-stringify": "2.1.0",
-    "file-loader": "6.2.0",
     "find-cache-dir": "3.3.1",
     "font-awesome": "^4.7.0",
     "gh-got": "^9.0.0",

--- a/packages/angular_devkit/build_angular/BUILD.bazel
+++ b/packages/angular_devkit/build_angular/BUILD.bazel
@@ -150,7 +150,6 @@ ts_library(
         "@npm//critters",
         "@npm//css-loader",
         "@npm//cssnano",
-        "@npm//file-loader",
         "@npm//find-cache-dir",
         "@npm//glob",
         "@npm//https-proxy-agent",

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -32,7 +32,6 @@
     "critters": "0.0.6",
     "css-loader": "5.0.1",
     "cssnano": "4.1.10",
-    "file-loader": "6.2.0",
     "find-cache-dir": "3.3.1",
     "glob": "7.1.6",
     "https-proxy-agent": "5.0.0",

--- a/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
@@ -522,15 +522,6 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
       strictExportPresence: true,
       rules: [
         {
-          test: /\.(eot|svg|cur|jpg|png|webp|gif|otf|ttf|woff|woff2|ani|avif)$/,
-          loader: require.resolve('file-loader'),
-          options: {
-            name: `[name]${hashFormat.file}.[ext]`,
-            // Re-use emitted files from browser builder on the server.
-            emitFile: platform !== 'server',
-          },
-        },
-        {
           // Mark files inside `@angular/core` as using SystemJS style dynamic imports.
           // Removing this will cause deprecation warnings to appear.
           test: /[\/\\]@angular[\/\\]core[\/\\].+\.js$/,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5195,14 +5195,6 @@ figures@^3.0.0, figures@^3.2.0:
   dependencies:
     escape-string-regexp "^1.0.5"
 
-file-loader@6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-6.2.0.tgz#baef7cf8e1840df325e4390b4484879480eebe4d"
-  integrity sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==
-  dependencies:
-    loader-utils "^2.0.0"
-    schema-utils "^3.0.0"
-
 file-uri-to-path@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"


### PR DESCRIPTION
`file-loader` resolves `import/require()` on a file into a url. This is non standard, undocumented, unsupported Webpack specific functionality. This was introduced in the Angular CLI  before `postcss-cli-resources` existed and was never removed.

Using `file-loader` and `postcss-cli-resources` are no longer needed with Webpack 5, because of the introduction of [Assets Modules](https://webpack.js.org/guides/asset-modules/).

**BREAKING CHANGE:**

The unsupported/undocumented, Webpack specific functionality to `import`/`require()` a non-module file has been removed.

Before
```js
import img from './images/asset.png';
```

After
```html
<img src="images/asset.png">
```