### PR TITLE
fix(@angular-devkit/build-angular): fix aot mode for web worker

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/typescript.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/typescript.ts
@@ -239,7 +239,9 @@ export function getAotConfig(wco: WebpackConfigOptions, i18nExtract = false) {
 
 export function getTypescriptWorkerPlugin(wco: WebpackConfigOptions, workerTsConfigPath: string) {
   if (canUseIvyPlugin(wco)) {
-    return createIvyPlugin(wco, false, workerTsConfigPath);
+    return wco.buildOptions.aot 
+      ? createIvyPlugin(wco, true, workerTsConfigPath) 
+      : createIvyPlugin(wco, false, workerTsConfigPath);
   }
 
   const { buildOptions } = wco;


### PR DESCRIPTION
i setup angular app in web-worker to use angular DI powers. It all worked well until i build production build. I got error about something bootstrap of undefined. I started investigate angular sources, and found this code. 
With aot flag set to false my angularApp inside web-worker with production build doesnt have ivy metadata like "emod".
Comparing this flag to other flags about aot i didnt find out why this flag is set to false. So i made if condition like other places