### PR TITLE
fix(@angular-devkit/build-angular): error with status code when response code is not 200

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/index-file/inline-fonts.ts
+++ b/packages/angular_devkit/build_angular/src/utils/index-file/inline-fonts.ts
@@ -120,6 +120,12 @@ export class InlineFontsProcessor {
           },
         },
         res => {
+          if (res.statusCode !== 200) {
+            reject(new Error(`Inlining of fonts failed. ${url} returned status code: ${res.statusCode}.`));
+
+            return;
+          }
+
           res
             .on('data', chunk => rawResponse += chunk)
             .on('end', () => resolve(rawResponse));


### PR DESCRIPTION


During font inlining, a request can return a response status code other than 200. In which case, the contents of the page should not be inlined.