### PR TITLE
docs: replace broken link

### DIFF
--- a/packages/schematics/angular/ng-new/schema.json
+++ b/packages/schematics/angular/ng-new/schema.json
@@ -127,7 +127,7 @@
       "x-user-analytics": 14
     },
     "strict": {
-      "description": "Creates a workspace with stricter type checking and stricter bundle budgets settings. This setting helps improve maintainability and catch bugs ahead of time. For more information, see https://angular.io/strict",
+      "description": "Creates a workspace with stricter type checking and stricter bundle budgets settings. This setting helps improve maintainability and catch bugs ahead of time. For more information, see https://angular.io/guide/strict-mode",
       "x-prompt": "Do you want to enforce stricter type checking and stricter bundle budgets in the workspace?\n  This setting helps improve maintainability and catch bugs ahead of time.\n  For more information, see https://angular.io/strict",
       "type": "boolean",
       "default": false,


### PR DESCRIPTION
There is a broken link inside `ng new` section (https://angular.io/cli/new). When you click on that link, placed next to `strict` option, you are redirected to 404 (Page not found).