### PR TITLE
fix(@angular/cli): resolve migration collections from containing package

### DIFF
--- a/packages/angular/cli/commands/update-impl.ts
+++ b/packages/angular/cli/commands/update-impl.ts
@@ -650,11 +650,35 @@ export class UpdateCommand extends Command<UpdateCommandSchema> {
 
     if (success && migrations) {
       for (const migration of migrations) {
+        // Resolve the package from the workspace root, as otherwise it will be resolved from the temp
+        // installed CLI version.
+        const packagePath = require.resolve(migration.package, { paths: [this.context.root] });
+        let migrations;
+
+        // Check if it is a package-local location
+        const localMigrations = path.join(packagePath, migration.collection);
+        if (fs.existsSync(localMigrations)) {
+          migrations = localMigrations;
+        } else {
+          // Try to resolve from package location.
+          // This avoids issues with package hoisting.
+          try {
+            migrations = require.resolve(migration.collection, { paths: [packagePath] });
+          } catch (e) {
+            if (e.code === 'MODULE_NOT_FOUND') {
+              this.logger.error(`Migrations for package (${migration.package}) were not found.`);
+            } else {
+              this.logger.error(
+                `Unable to resolve migrations for package (${migration.package}).  [${e.message}]`,
+              );
+            }
+
+            return 1;
+          }
+        }
         const result = await this.executeMigrations(
           migration.package,
-          // Resolve the collection from the workspace root, as otherwise it will be resolved from the temp
-          // installed CLI version.
-          require.resolve(migration.collection, { paths: [this.context.root] }),
+          migrations,
           new semver.Range('>' + migration.from + ' <=' + migration.to),
           options.createCommits,
         );


### PR DESCRIPTION
This change ensures that migration collections defined in a package's `ng-update` metadata are resolved from the containing package.  This avoids issues that may arise from package manager hoisting behavior which can result in the wrong migration collection being chosen.  The `--migrate-only` option already contained this resolution logic and now the full update contains it as well.