### PR TITLE
fix(@ngtools/webpack): don't use `skipTemplateCodegen` to determine if compilation is JIT mode

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/typescript.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/typescript.ts
@@ -59,7 +59,6 @@ function createIvyPlugin(
   const optimize = buildOptions.optimization.scripts;
 
   const compilerOptions: CompilerOptions = {
-    skipTemplateCodegen: !aot,
     sourceMap: buildOptions.sourceMap.scripts,
   };
 
@@ -78,6 +77,7 @@ function createIvyPlugin(
     tsconfig,
     compilerOptions,
     fileReplacements,
+    jitMode: !aot,
     emitNgModuleScope: !optimize,
     suppressZoneJsIncompatibilityWarning: true,
   });

--- a/packages/ngtools/webpack/src/ivy/plugin.ts
+++ b/packages/ngtools/webpack/src/ivy/plugin.ts
@@ -44,6 +44,7 @@ export interface AngularPluginOptions {
   emitClassMetadata: boolean;
   emitNgModuleScope: boolean;
   suppressZoneJsIncompatibilityWarning: boolean;
+  jitMode: boolean;
 }
 
 // Add support for missing properties in Webpack types as well as the loader's file emitter
@@ -91,6 +92,7 @@ export class AngularWebpackPlugin {
     this.pluginOptions = {
       emitClassMetadata: false,
       emitNgModuleScope: false,
+      jitMode: false,
       fileReplacements: {},
       substitutions: {},
       directTemplateLoading: true,
@@ -222,7 +224,7 @@ export class AngularWebpackPlugin {
       augmentHostWithSubstitutions(host, this.pluginOptions.substitutions);
 
       // Create the file emitter used by the webpack loader
-      const { fileEmitter, builder, internalFiles } = compilerOptions.skipTemplateCodegen
+      const { fileEmitter, builder, internalFiles } = this.pluginOptions.jitMode
         ? this.updateJitProgram(compilerOptions, rootNames, host, diagnosticsReporter)
         : this.updateAotProgram(
             compilerOptions,


### PR DESCRIPTION
With this change we add a new `jitMode` option to the ivy AngularWebpackPlugin.
`readConfiguration` from `@angular/compiler-cli` will use file configuration options over programmaticly supplied options. By using a separate option the options precedence issue can be avoided.

Closes #19949