### PR TITLE
build: update next branch to reflect new release-train `v12.0.0-next.0` 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@angular/devkit-repo",
-  "version": "11.2.0-next.0",
+  "version": "12.0.0-next.0",
   "private": true,
   "description": "Software Development Kit for Angular",
   "bin": {

--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
   "separateMajorMinor": false,
   "prHourlyLimit": 2,
   "labels": [
-    "target: minor",
+    "target: major",
     "action: merge"
   ],
   "timezone": "America/Tijuana",


### PR DESCRIPTION

This is needed as otherwise the ng-dev tools will fail due to `Error: Discovered unexpected version-branch "11.2.x" for a release-train that is already active in the "master" branch. Please either delete the branch if created by accident, or update the version in the next branch (master).