### PR TITLE
ci: use npm 6.x on Node.js 10 CI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,8 +216,8 @@ jobs:
           name: Initialize Environment
           command: |
             ./.circleci/env.sh
-            # Ensure latest npm version to support local package repository
-            PATH=~/.npm-global/bin:$PATH npm install --global npm
+            # Ensure latest v6 npm version to support local package repository
+            PATH=~/.npm-global/bin:$PATH npm install --global npm@6
       - run: PATH=~/.npm-global/bin:$PATH node ./tests/legacy-cli/run_e2e --nb-shards=${CIRCLE_NODE_TOTAL} --shard=${CIRCLE_NODE_INDEX}
 
   e2e-cli-node-14:


### PR DESCRIPTION
Latest npm is now 7.x and 7.x appears to cause CI failures when setting up the E2E test framework on Node.js 10.

(cherry picked from commit dfc6d89155cb717d09a8101ec8ce6622e34bae44)