### PR TITLE
fix(@angular-devkit/build-angular): increase resilience of babel cache identifier

### DIFF
--- a/packages/angular_devkit/build_angular/src/babel/webpack-loader.ts
+++ b/packages/angular_devkit/build_angular/src/babel/webpack-loader.ts
@@ -98,6 +98,14 @@ export default custom<AngularCustomOptions>(() => {
       const options: Record<string, unknown> = {
         ...baseOptions,
         ...loaderOptions,
+        cacheIdentifier: JSON.stringify({
+          buildAngular: require('../../package.json').version,
+          forceAsyncTransformation,
+          forceES5,
+          shouldLink,
+          baseOptions,
+          loaderOptions,
+        }),
       };
 
       // Skip babel processing if no actions are needed

--- a/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
@@ -535,9 +535,6 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
               loader: require.resolve('../../babel/webpack-loader'),
               options: {
                 cacheDirectory: findCachePath('babel-webpack'),
-                cacheIdentifier: JSON.stringify({
-                  buildAngular: require('../../../package.json').version,
-                }),
                 scriptTarget: wco.scriptTarget,
               },
             },


### PR DESCRIPTION
This provides a default cache identifer to the babel loader that includes all internal options from the customized babel loader.