### PR TITLE
test(@angular/cli): skip npm version limit E2E on Windows

### DIFF
--- a/tests/legacy-cli/e2e/tests/misc/npm-7.ts
+++ b/tests/legacy-cli/e2e/tests/misc/npm-7.ts
@@ -10,6 +10,11 @@ export default async function() {
     return;
   }
 
+  // Windows CI fails with permission errors when trying to replace npm
+  if (process.platform.startsWith('win')) {
+    return;
+  }
+
   const currentDirectory = process.cwd();
   try {
     // Install version 7.x


### PR DESCRIPTION
Due to the setup of the Windows CI image, attempting to replace npm will fail.  This change skips the npm version limit test for now pending infrastructure updates to the Windows CI image.