### PR TITLE
build: set minimum Node.js version to 12.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,9 +77,9 @@ commands:
           at: *workspace_location
   setup_windows:
     steps:
-      - run: nvm install 12.1.0
-      - run: nvm use 12.1.0
-      - run: npm install -g yarn@1.17.3
+      - run: nvm install 12.13
+      - run: nvm use 12.13
+      - run: npm install -g yarn@1.22.10
       - run: node --version
       - run: yarn --version
 

--- a/lib/packages.ts
+++ b/lib/packages.ts
@@ -87,7 +87,7 @@ function loadPackageJson(p: string) {
       // Overwrite engines to a common default.
       case 'engines':
         pkg['engines'] = {
-          'node': '>= 10.13.0',
+          'node': '>= 12.13.0',
           'npm': '^6.11.0',
           'yarn': '>= 1.13.0',
         };

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "url": "https://github.com/angular/angular-cli.git"
   },
   "engines": {
-    "node": ">=10.13.0 <13.0.0",
+    "node": ">=12.13.0 <15.0.0",
     "yarn": ">=1.22.4"
   },
   "author": "Angular Authors",

--- a/packages/angular/cli/bin/ng
+++ b/packages/angular/cli/bin/ng
@@ -14,12 +14,28 @@ try {
 // These may not support ES2015 features such as const/let/async/await/etc.
 // These would then crash with a hard to diagnose error message.
 // tslint:disable-next-line: no-var-keyword
-var version = process.versions.node.split('.').map(part => Number(part));
-if (version[0] < 10 || version[0] === 11 || (version[0] === 10 && version[1] < 13)) {
+var version = process.versions.node.split('.').map((part) => Number(part));
+if (version[0] % 2 === 1 && version[0] > 14) {
+  // Allow new odd numbered releases with a warning (currently v15+)
+  console.warn(
+    'Node.js version ' +
+      process.version +
+      ' detected.\n' +
+      'Odd numbered Node.js versions will not enter LTS status and should not be used for production.' +
+      ' For more information, please see https://nodejs.org/en/about/releases/.',
+  );
+} else if (
+  version[0] < 12 ||
+  version[0] === 13 ||
+  (version[0] === 12 && version[1] < 13) ||
+  (version[0] === 14 && version[1] < 15)
+) {
   console.error(
-    'Node.js version ' + process.version + ' detected.\n' +
-    'The Angular CLI requires a minimum Node.js version of either v10.13 or v12.0.\n\n' +
-    'Please update your Node.js version or visit https://nodejs.org/ for additional instructions.\n'
+    'Node.js version ' +
+      process.version +
+      ' detected.\n' +
+      'The Angular CLI requires a minimum Node.js version of either v12.13 or v14.15.\n\n' +
+      'Please update your Node.js version or visit https://nodejs.org/ for additional instructions.\n',
   );
 
   process.exitCode = 3;

--- a/packages/angular_devkit/benchmark/package.json
+++ b/packages/angular_devkit/benchmark/package.json
@@ -9,10 +9,6 @@
   "keywords": [
     "benchmark"
   ],
-  "engines": {
-    "node": ">= 10.13.0",
-    "npm": ">= 6.2.0"
-  },
   "dependencies": {
     "@angular-devkit/core": "0.0.0",
     "ansi-colors": "4.1.1",


### PR DESCRIPTION
This change provides an improved performance baseline as well as access to newer Node.js APIs and Javascript language features which the Angular CLI will now be able to leverage.

BREAKING CHANGE:
Node.js version 10 will become EOL on 2021-04-30.
Angular CLI 12 will require Node.js 12.13+ or 14.15+. Node.js 12.13 and 14.15 are the first LTS releases for their respective majors.