### PR TITLE
fix(@ngtools/webpack): reduce overhead of Angular compiler rebuild requests

### DIFF
--- a/packages/ngtools/webpack/src/ivy/symbol.ts
+++ b/packages/ngtools/webpack/src/ivy/symbol.ts
@@ -11,6 +11,7 @@ export interface EmitFileResult {
   content?: string;
   map?: string;
   dependencies: readonly string[];
+  hash?: Uint8Array;
 }
 
 export type FileEmitter = (file: string) => Promise<EmitFileResult | undefined>;


### PR DESCRIPTION
This change adds additional checks to reduce the number of Webpack `rebuildModule` calls when the Angular compiler requests additional files to be rebuilt. Now if an emitted file's output does not change from its previous emit, a Webpack rebuild of the module is not performed. This can greatly reduce the amount of computation needed during a rebuild as any files that required re-analysis by the Angular compiler but whose final output did not change will not trigger potential expensive Webpack module graph analysis and additonal module rebuilds.