### PR TITLE
fix(@angular-devkit/build-angular): fixed ignoring of karma plugins config

### DIFF
--- a/packages/angular_devkit/build_angular/src/karma/code-coverage_spec.ts
+++ b/packages/angular_devkit/build_angular/src/karma/code-coverage_spec.ts
@@ -184,4 +184,16 @@ describe('Karma Builder code coverage', () => {
     expect(success).toBe(true);
     await run.stop();
   }, 120000);
+
+  it('is able to process coverage plugins provided as string karma-*', async () => {
+    host.replaceInFile('karma.conf.js', /plugins: \[.+?\]/s, `plugins: [
+      'karma-*',
+      require('@angular-devkit/build-angular/plugins/karma'),
+    ]`);
+    const run = await architect.scheduleTarget(karmaTargetSpec, { codeCoverage: true });
+
+    const {success} = await run.result;
+    expect(success).toBe(true);
+    await run.stop();
+  }, 120000);
 });

--- a/packages/angular_devkit/build_angular/src/webpack/plugins/karma/karma.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/plugins/karma/karma.ts
@@ -336,7 +336,17 @@ function fallbackMiddleware() {
 function isPlugin(moduleId: string, pluginName: string) {
   return (plugin: string|{}): boolean => {
     if (typeof plugin === 'string') {
-      return plugin === moduleId;
+      if (!plugin.includes('*')) {
+        return plugin === moduleId;
+      }
+      const regexp = new RegExp(`^${plugin.replace('*', '.*')}`);
+      if (regexp.test(moduleId)) {
+        try {
+          require.resolve(moduleId);
+          return true;
+        } catch {}
+      }
+      return false;
     }
     return pluginName in plugin;
   }


### PR DESCRIPTION
In angular 11 Previously `karma-coverage` was validated only when in karma plugins config one of these was added
``'karma-coverage'` or `require('karma-coverage')`

This change will allow cli to validate `karma-coverage` plugin if in `karma.conf.js` `'karma-*'` is used. Example:
```
plugins: [
      ...
      'karma-*',
      require('@angular-devkit/build-angular/plugins/karma'),
      ...
    ]
```

Fixes #19993