### PR TITLE
fix(@angular-devkit/build-angular): the root Tailwind configuration f…

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/styles.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/styles.ts
@@ -166,6 +166,7 @@ export function getStylesConfig(wco: WebpackConfigOptions) {
     const fullPath = path.join(basePath, tailwindConfigFile);
     if (fs.existsSync(fullPath)) {
       tailwindConfigPath = fullPath;
+      break;
     }
   }
   // Only load Tailwind CSS plugin if configuration file was found.


### PR DESCRIPTION
…ile is always picked

 A configuration file in the project root should take precedence over one in the workspace root, but it's not currently the case.