### PR TITLE
ci: fix component-child-dir E2E test on Windows CI

### DIFF
--- a/tests/legacy-cli/e2e/tests/generate/component/component-child-dir.ts
+++ b/tests/legacy-cli/e2e/tests/generate/component/component-child-dir.ts
@@ -1,24 +1,34 @@
-import {join} from 'path';
-import {ng} from '../../../utils/process';
-import {createDir, expectFileToExist} from '../../../utils/fs';
+import { join } from 'path';
+import { ng } from '../../../utils/process';
+import { createDir, expectFileToExist, rimraf } from '../../../utils/fs';
 
+export default async function () {
+  const currentDirectory = process.cwd();
+  const childDirectory = join('src', 'app', 'sub-dir');
 
-export default function() {
-  const subDir = 'sub-dir';
-  const componentDir = join('src', 'app', subDir, 'test-component');
+  try {
+    // Create and enter a child directory inside the project
+    await createDir(childDirectory);
+    process.chdir(childDirectory);
 
-  return Promise.resolve()
-    .then(() => process.chdir('src'))
-    .then(() => process.chdir('app'))
-    .then(() => createDir(subDir))
-    .then(() => process.chdir(subDir))
-    .then(() => ng('generate', 'component', 'test-component'))
-    .then(() => process.chdir('../../..'))
-    .then(() => expectFileToExist(join(componentDir, 'test-component.component.ts')))
-    .then(() => expectFileToExist(join(componentDir, 'test-component.component.spec.ts')))
-    .then(() => expectFileToExist(join(componentDir, 'test-component.component.html')))
-    .then(() => expectFileToExist(join(componentDir, 'test-component.component.css')))
+    // Generate a component inside the child directory
+    await ng('generate', 'component', 'test-component');
 
-    // Try to run the unit tests.
-    .then(() => ng('test', '--watch=false'));
+    // Move back to the root of the workspacee
+    process.chdir(currentDirectory);
+
+    // Ensure component is created in the correct location relative to the workspace root
+    const componentDirectory = join(childDirectory, 'test-component');
+    await expectFileToExist(join(componentDirectory, 'test-component.component.ts'));
+    await expectFileToExist(join(componentDirectory, 'test-component.component.spec.ts'));
+    await expectFileToExist(join(componentDirectory, 'test-component.component.html'));
+    await expectFileToExist(join(componentDirectory, 'test-component.component.css'));
+
+    // Ensure unit test execute and pass
+    await ng('test', '--watch=false');
+  } finally {
+    // Windows CI may fail to clean up the created directory
+    // Resolves: "Error: Running "cmd.exe /c git clean -df" returned error code 1"
+    await rimraf(childDirectory);
+  }
 }


### PR DESCRIPTION
Windows CI is failing when trying to use the common test cleanup routine for the `generate/component/component-child-dir` E2E test. This fix manually removes the newly created directory within the test.