### PR TITLE
ci: only validate PR commit messages and remove do not submit check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,10 +167,12 @@ jobs:
       - custom_attach_workspace
       - run:
           name: Validate Commit Messages
-          command: yarn -s admin validate-commits
-      - run:
-          name: Validate "do not submit" Commits
-          command: yarn -s admin validate-do-not-submit
+          command: >
+            if [[ -n "${CIRCLE_PR_NUMBER}" ]]; then
+              yarn -s admin validate-commits
+            else
+              echo "This build is not over a PR, nothing to do."
+            fi
       - run:
           command: yarn -s admin validate --ci
 


### PR DESCRIPTION
This fixes 10.2.x CI failures as well as synchronizes validation activity with master.