### PR TITLE
refactor(@angular-devkit/build-angular): remove use of Webpack RuleSetLoader type

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
@@ -17,7 +17,6 @@ import {
   Compiler,
   Configuration,
   ContextReplacementPlugin,
-  RuleSetLoader,
   RuleSetRule,
   compilation,
   debug,
@@ -326,7 +325,7 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
     });
   }
 
-  let buildOptimizerUseRule: RuleSetLoader[] = [];
+  let buildOptimizerUseRule: RuleSetRule[] = [];
   if (buildOptions.buildOptimizer) {
     extraPlugins.push(new BuildOptimizerWebpackPlugin());
     buildOptimizerUseRule = [

--- a/packages/angular_devkit/build_angular/src/webpack/configs/styles.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/styles.ts
@@ -91,7 +91,7 @@ export function getStylesConfig(wco: WebpackConfigOptions) {
   }
 
   // set base rules to derive final rules from
-  const baseRules: { test: RegExp, use: webpack.RuleSetLoader[] }[] = [
+  const baseRules: { test: RegExp, use: webpack.RuleSetUseItem[] }[] = [
     { test: /\.css$/, use: [] },
     {
       test: /\.scss$|\.sass$/,

--- a/packages/angular_devkit/build_angular/src/webpack/configs/typescript.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/typescript.ts
@@ -18,7 +18,6 @@ import {
   ivy,
 } from '@ngtools/webpack';
 import * as path from 'path';
-import { RuleSetLoader } from 'webpack';
 import { WebpackConfigOptions, BuildOptions } from '../../utils/build-options';
 import { legacyIvyPluginEnabled } from '../../utils/environment-options';
 
@@ -191,21 +190,20 @@ export function getAotConfig(wco: WebpackConfigOptions, i18nExtract = false) {
   const optimize = buildOptions.optimization.scripts;
   const useIvyOnlyPlugin = canUseIvyPlugin(wco) && !i18nExtract;
 
-  let buildOptimizerRules: RuleSetLoader[] = [];
-  if (buildOptions.buildOptimizer) {
-    buildOptimizerRules = [{
-      loader: buildOptimizerLoaderPath,
-      options: { sourceMap: buildOptions.sourceMap.scripts }
-    }];
-  }
-
   return {
     module: {
       rules: [
         {
           test: useIvyOnlyPlugin ? /\.tsx?$/ : /(?:\.ngfactory\.js|\.ngstyle\.js|\.tsx?)$/,
           use: [
-            ...buildOptimizerRules,
+            ...(buildOptions.buildOptimizer
+              ? [
+                  {
+                    loader: buildOptimizerLoaderPath,
+                    options: { sourceMap: buildOptions.sourceMap.scripts },
+                  },
+                ]
+              : []),
             useIvyOnlyPlugin ? ivy.AngularWebpackLoaderPath : NgToolsLoader,
           ],
         },


### PR DESCRIPTION
The `RuleSetLoader` type is not exported from the Webpack 5 types.