### PR TITLE
[10.2.x] ci: provide names for nightly E2E jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -433,10 +433,11 @@ workflows:
           requires:
             - setup
       - e2e-cli:
+          name: e2e-cli-nightly
           requires:
             - build
       - e2e-cli:
-          name: e2e-cli-ve
+          name: e2e-cli-ve-nightly
           ve: true
           requires:
             - build


### PR DESCRIPTION
The CI size check uses the `e2e-cli` job to retrieve the build artifacts. But with the nightly E2E job having the same name, CircleCI named the regular E2E job `e2e-cli-1` which caused the CI size check to get stuck in a pending state.