### PR TITLE
feat(@schematics/angular): strict mode by default

### DIFF
--- a/packages/schematics/angular/application/schema.json
+++ b/packages/schematics/angular/application/schema.json
@@ -107,7 +107,7 @@
     "strict": {
       "description": "Creates an application with stricter bundle budgets settings.",
       "type": "boolean",
-      "default": false,
+      "default": true,
       "x-user-analytics": 7
     },
     "legacyBrowsers": {

--- a/packages/schematics/angular/ng-new/schema.json
+++ b/packages/schematics/angular/ng-new/schema.json
@@ -128,9 +128,8 @@
     },
     "strict": {
       "description": "Creates a workspace with stricter type checking and stricter bundle budgets settings. This setting helps improve maintainability and catch bugs ahead of time. For more information, see https://angular.io/guide/strict-mode",
-      "x-prompt": "Do you want to enforce stricter type checking and stricter bundle budgets in the workspace?\n  This setting helps improve maintainability and catch bugs ahead of time.\n  For more information, see https://angular.io/strict",
       "type": "boolean",
-      "default": false,
+      "default": true,
       "x-user-analytics": 7
     },
     "legacyBrowsers": {

--- a/packages/schematics/angular/workspace/schema.json
+++ b/packages/schematics/angular/workspace/schema.json
@@ -35,7 +35,7 @@
     "strict": {
       "description": "Create a workspace with stricter type checking options. This setting helps improve maintainability and catch bugs ahead of time. For more information, see https://angular.io/strict",
       "type": "boolean",
-      "default": false,
+      "default": true,
       "x-user-analytics": 7
     },
     "packageManager": {

--- a/tests/legacy-cli/e2e/tests/build/strict-mode.ts
+++ b/tests/legacy-cli/e2e/tests/build/strict-mode.ts
@@ -1,7 +1,0 @@
-import { ng } from '../../utils/process';
-import { createProject } from '../../utils/project';
-
-export default async function() {
-  await createProject('strict-test-project', '--strict');
-  await ng('e2e', '--prod');
-}


### PR DESCRIPTION
With this change we workspaces are generated strict by default. To create non-strict workspace the `--no-strict` command line option.