### PR TITLE
build: changer angular packages local version to `0.0.0`

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/version.ts
+++ b/packages/angular_devkit/build_angular/src/utils/version.ts
@@ -49,9 +49,9 @@ export function assertCompatibleAngularVersion(projectRoot: string, logger: logg
     return;
   }
 
-  if (angularCliPkgJson['version'] === '0.0.0' || angularPkgJson['version'] === '0.0.0-PLACEHOLDER') {
+  if (angularCliPkgJson['version'] === '0.0.0' || angularPkgJson['version'] === '0.0.0') {
     // Internal CLI testing version or integration testing in the angular/angular
-    // repository with the generated development @angular/core npm package which is versioned "0.0.0-PLACEHOLDER".
+    // repository with the generated development @angular/core npm package which is versioned "0.0.0".
     return;
   }
 


### PR DESCRIPTION
The integration tests run in the framework repo use `0.0.0` as version and not a previously stated `0.0.0-PLACEHOLDER`
