### PR TITLE
Switch angular.io from HTTP to HTTPS

### DIFF
--- a/packages/angular/cli/models/analytics.ts
+++ b/packages/angular/cli/models/analytics.ts
@@ -388,7 +388,7 @@ export async function promptGlobalAnalytics(force = false) {
         message: tags.stripIndents`
           Would you like to share anonymous usage data with the Angular Team at Google under
           Google’s Privacy Policy at https://policies.google.com/privacy? For more details and
-          how to change this setting, see http://angular.io/analytics.
+          how to change this setting, see https://angular.io/analytics.
         `,
         default: false,
       },
@@ -446,7 +446,7 @@ export async function promptProjectAnalytics(force = false): Promise<boolean> {
         message: tags.stripIndents`
           Would you like to share anonymous usage data about this project with the Angular Team at
           Google under Google’s Privacy Policy at https://policies.google.com/privacy? For more
-          details and how to change this setting, see http://angular.io/analytics.
+          details and how to change this setting, see https://angular.io/analytics.
 
         `,
         default: false,


### PR DESCRIPTION
Since angular.io/analytics supports HTTPS, why not use that instead of HTTP?