### PR TITLE
feat(@angular-devkit/build-optimizer): support Webpack 5

### DIFF
--- a/etc/api/angular_devkit/build_optimizer/src/_golden-api.d.ts
+++ b/etc/api/angular_devkit/build_optimizer/src/_golden-api.d.ts
@@ -6,7 +6,17 @@ export declare class BuildOptimizerWebpackPlugin {
     apply(compiler: Compiler): void;
 }
 
-export default function buildOptimizerLoader(this: webpack.loader.LoaderContext, content: string, previousSourceMap: RawSourceMap): void;
+export default function buildOptimizerLoader(this: {
+    resourcePath: string;
+    _module: {
+        factoryMeta: {
+            skipBuildOptimizer?: boolean;
+            sideEffectFree?: boolean;
+        };
+    };
+    cacheable(): void;
+    callback(error?: Error | null, content?: string, sourceMap?: unknown): void;
+}, content: string, previousSourceMap: RawSourceMap): void;
 
 export declare function getPrefixClassesTransformer(): ts.TransformerFactory<ts.SourceFile>;
 

--- a/packages/angular_devkit/build_optimizer/package.json
+++ b/packages/angular_devkit/build_optimizer/package.json
@@ -14,5 +14,13 @@
     "tslib": "2.1.0",
     "typescript": "4.1.5",
     "webpack-sources": "2.2.0"
+  },
+  "peerDependencies": {
+    "webpack": "^4.0.0 || ^5.20.0"
+  },
+  "peerDependenciesMeta": {
+    "webpack": {
+      "optional": true
+    }
   }
 }

--- a/packages/angular_devkit/build_optimizer/src/build-optimizer/webpack-plugin.ts
+++ b/packages/angular_devkit/build_optimizer/src/build-optimizer/webpack-plugin.ts
@@ -1,4 +1,3 @@
-
 /**
  * @license
  * Copyright Google Inc. All Rights Reserved.
@@ -6,13 +5,18 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import { Compiler } from 'webpack';  // tslint:disable-line:no-implicit-dependencies
+import { Compiler } from 'webpack';
+
+interface ModuleData {
+  resourceResolveData: { descriptionFileData?: { typings?: string } };
+}
 
 export class BuildOptimizerWebpackPlugin {
   apply(compiler: Compiler) {
     compiler.hooks.normalModuleFactory.tap('BuildOptimizerWebpackPlugin', nmf => {
+      // tslint:disable-next-line: no-any
       nmf.hooks.module.tap('BuildOptimizerWebpackPlugin', (module, data) => {
-        const { descriptionFileData } = data.resourceResolveData;
+        const { descriptionFileData } = (data as ModuleData).resourceResolveData;
         if (descriptionFileData) {
           // Only TS packages should use Build Optimizer.
           // Notes:


### PR DESCRIPTION
The `@angular-devkit/build-optimizer` package now officially supports Webpack 5.
Webpack 4 support is temporarily maintained while the remainder of the tooling is transitioned.