### PR TITLE
refactor(@angular-devkit/build-optimizer): improve transitional Webpack 5 compatibility

### DIFF
--- a/etc/api/angular_devkit/build_optimizer/src/_golden-api.d.ts
+++ b/etc/api/angular_devkit/build_optimizer/src/_golden-api.d.ts
@@ -3,7 +3,7 @@ export declare function buildOptimizer(options: BuildOptimizerOptions): Transfor
 export declare const buildOptimizerLoaderPath: string;
 
 export declare class BuildOptimizerWebpackPlugin {
-    apply(compiler: Compiler): void;
+    apply(compiler: Compiler | WebpackFourCompiler): void;
 }
 
 export default function buildOptimizerLoader(this: {

--- a/packages/angular_devkit/build_optimizer/package.json
+++ b/packages/angular_devkit/build_optimizer/package.json
@@ -22,5 +22,9 @@
     "webpack": {
       "optional": true
     }
+  },
+  "devDependencies": {
+    "@types/webpack": "^4.41.22",
+    "webpack": "5.21.2"
   }
 }

--- a/packages/angular_devkit/build_optimizer/src/build-optimizer/webpack-plugin.ts
+++ b/packages/angular_devkit/build_optimizer/src/build-optimizer/webpack-plugin.ts
@@ -5,15 +5,15 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import { Compiler } from 'webpack';
+import { Compiler, WebpackFourCompiler } from 'webpack';
 
 interface ModuleData {
   resourceResolveData: { descriptionFileData?: { typings?: string } };
 }
 
 export class BuildOptimizerWebpackPlugin {
-  apply(compiler: Compiler) {
-    compiler.hooks.normalModuleFactory.tap('BuildOptimizerWebpackPlugin', nmf => {
+  apply(compiler: Compiler | WebpackFourCompiler) {
+    (compiler as Compiler).hooks.normalModuleFactory.tap('BuildOptimizerWebpackPlugin', nmf => {
       // tslint:disable-next-line: no-any
       nmf.hooks.module.tap('BuildOptimizerWebpackPlugin', (module, data) => {
         const { descriptionFileData } = (data as ModuleData).resourceResolveData;

--- a/packages/angular_devkit/build_optimizer/src/webpack.d.ts
+++ b/packages/angular_devkit/build_optimizer/src/webpack.d.ts
@@ -1,0 +1,14 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import * as webpack from 'webpack';
+import { Compiler as webpack4Compiler } from '@types/webpack';
+
+// Webpack 5 transition support types
+declare module 'webpack' {
+  export type WebpackFourCompiler = webpack4Compiler;
+}


### PR DESCRIPTION
This change provides both Webpack 4 and 5 compatible types for the the build optimizer Webpack plugin.