### PR TITLE
feat(@angular-devkit/build-angular): enable inlineCritical by default

### DIFF
--- a/packages/angular/cli/lib/config/schema.json
+++ b/packages/angular/cli/lib/config/schema.json
@@ -740,7 +740,7 @@
                             "inlineCritical": {
                               "type": "boolean",
                               "description": "Extract and inline critical CSS definitions to improve first paint time.",
-                              "default": false
+                              "default": true
                             }
                           },
                           "additionalProperties": false

--- a/packages/angular_devkit/build_angular/src/browser/schema.json
+++ b/packages/angular_devkit/build_angular/src/browser/schema.json
@@ -84,7 +84,7 @@
                     "inlineCritical": {
                       "type": "boolean",
                       "description": "Extract and inline critical CSS definitions to improve first paint time.",
-                      "default": false
+                      "default": true
                     }
                   },
                   "additionalProperties": false

--- a/packages/angular_devkit/build_angular/src/utils/normalize-optimization.ts
+++ b/packages/angular_devkit/build_angular/src/utils/normalize-optimization.ts
@@ -19,8 +19,7 @@ export function normalizeOptimization(optimization: OptimizationUnion = false): 
       scripts: !!optimization.scripts,
       styles: typeof optimization.styles === 'object' ? optimization.styles : {
         minify: !!optimization.styles,
-        // inlineCritical is always false unless explictly set.
-        inlineCritical: false,
+        inlineCritical: !!optimization.styles,
       },
       fonts: typeof optimization.fonts === 'object' ? optimization.fonts : {
         inline: !!optimization.fonts,
@@ -32,8 +31,7 @@ export function normalizeOptimization(optimization: OptimizationUnion = false): 
     scripts: optimization,
     styles: {
       minify: optimization,
-      // inlineCritical is always false unless explictly set.
-      inlineCritical: false,
+      inlineCritical: optimization,
     },
     fonts: {
       inline: optimization,


### PR DESCRIPTION
BREAKING CHANGE:

Critical CSS inlining is now enabled by default. If you wish to turn this off set `inlineCritical` to `false`.

See: https://angular.io/guide/workspace-config#optimization-configuration