### PR TITLE
fix(@angular-devkit/build-angular): force less version 3.5 math behaviour

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/styles.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/styles.ts
@@ -129,6 +129,7 @@ export function getStylesConfig(wco: WebpackConfigOptions) {
             implementation: require('less'),
             sourceMap: cssSourceMap,
             lessOptions: {
+              math: 'always',
               javascriptEnabled: true,
               paths: includePaths,
             },


### PR DESCRIPTION


In version 4, LESS did a breaking change that set `parens-division` as the default math setting. With this change we change the behavior to mimic version 3.5.

See: https://github.com/less/less.js/releases/tag/v4.0.0

**Note**: In Angular CLI version 12, the math setting will be the default provided by the LESS compiler in v4.0.0

Closes #20088