### PR TITLE
docs: fix build-system-overview graph

### DIFF
--- a/docs/design/build-system-overview.dot
+++ b/docs/design/build-system-overview.dot
@@ -9,7 +9,7 @@ digraph G {
   "*.scss\|sass" -> "sass-loader" -> "postcss-loader with postcss-import, ./postcss-cli-resources.ts, autoprefixer";
   "*.less" -> "less-loader" -> "postcss-loader with postcss-import, ./postcss-cli-resources.ts, autoprefixer";
   "*.styl" -> "stylus-loader" -> "postcss-loader with postcss-import, ./postcss-cli-resources.ts, autoprefixer";
-  "postcss-loader with postcss-import, ./postcss-cli-resources.ts, autoprefixer" -> "raw-loader" [label="component style?"] -> "./optimize-css-webpack-plugin.ts";
+  "postcss-loader with postcss-import, ./postcss-cli-resources.ts, autoprefixer" -> "raw-loader, ./optimize-css-webpack-plugin.ts"  [label="component style?"];
   "raw-loader" -> "./optimize-css-webpack-plugin.ts"
   "postcss-loader with postcss-import, ./postcss-cli-resources.ts, autoprefixer" -> "style-loader, ./raw-css-loader.ts, and mini-css-extract-plugin" [label="global style?"];
   "style-loader, ./raw-css-loader.ts, and mini-css-extract-plugin" -> "./optimize-css-webpack-plugin.ts"


### PR DESCRIPTION
When I was looking at different documents I found out that graph wasn't working anymore. 
This PR should resolve this, I don't believe I've seen a issue around this.