### PR TITLE
test(@angular-devkit/build-angular): add browser builder namedChunks option tests

### DIFF
--- a/packages/angular_devkit/build_angular/src/browser/specs/lazy-module_spec.ts
+++ b/packages/angular_devkit/build_angular/src/browser/specs/lazy-module_spec.ts
@@ -176,17 +176,6 @@ describe('Browser Builder lazy modules', () => {
     expect(files['lazy-module.js']).not.toBeUndefined();
   });
 
-  it(`supports hiding lazy bundle module name`, async () => {
-    host.writeMultipleFiles({
-      'src/lazy-module.ts': 'export const value = 42;',
-      'src/main.ts': `const lazyFileName = 'module'; import('./lazy-' + lazyFileName);`,
-    });
-    host.replaceInFile('src/tsconfig.app.json', `"module": "es2015"`, `"module": "esnext"`);
-
-    const { files } = await browserBuild(architect, host, target, { namedChunks: false });
-    expect(files['0.js']).not.toBeUndefined();
-  });
-
   it(`supports making a common bundle for shared lazy modules`, async () => {
     host.writeMultipleFiles({
       'src/one.ts': `import * as http from '@angular/common/http'; console.log(http);`,

--- a/packages/angular_devkit/build_angular/src/browser/tests/options/named-chunks_spec.ts
+++ b/packages/angular_devkit/build_angular/src/browser/tests/options/named-chunks_spec.ts
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { buildWebpackBrowser } from '../../index';
+import { BASE_OPTIONS, BROWSER_BUILDER_INFO, describeBuilder } from '../setup';
+
+const MAIN_OUTPUT = 'dist/main.js';
+const NAMED_LAZY_OUTPUT = 'dist/lazy-module.js';
+const UNNAMED_LAZY_OUTPUT = 'dist/0.js';
+
+describeBuilder(buildWebpackBrowser, BROWSER_BUILDER_INFO, (harness) => {
+  describe('Option: "namedChunks"', () => {
+    beforeEach(async () => {
+      // Setup a lazy loaded chunk
+      await harness.writeFiles({
+        'src/lazy-module.ts': 'export const value = 42;',
+        'src/main.ts': `import('./lazy-module');`,
+      });
+    });
+
+    it('generates named files in output when true', async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        namedChunks: true,
+      });
+
+      const { result } = await harness.executeOnce();
+
+      expect(result?.success).toBe(true);
+
+      harness.expectFile(MAIN_OUTPUT).toExist();
+      harness.expectFile(NAMED_LAZY_OUTPUT).toExist();
+      harness.expectFile(UNNAMED_LAZY_OUTPUT).toNotExist();
+    });
+
+    it('does not generate named files in output when false', async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        namedChunks: false,
+      });
+
+      const { result } = await harness.executeOnce();
+
+      expect(result?.success).toBe(true);
+
+      harness.expectFile(MAIN_OUTPUT).toExist();
+      harness.expectFile(NAMED_LAZY_OUTPUT).toNotExist();
+      harness.expectFile(UNNAMED_LAZY_OUTPUT).toExist();
+    });
+
+    it('generates named files in output when not present', async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+      });
+
+      const { result } = await harness.executeOnce();
+
+      expect(result?.success).toBe(true);
+
+      harness.expectFile(MAIN_OUTPUT).toExist();
+      harness.expectFile(NAMED_LAZY_OUTPUT).toExist();
+      harness.expectFile(UNNAMED_LAZY_OUTPUT).toNotExist();
+    });
+  });
+});


### PR DESCRIPTION
This change adds expanded unit tests for the browser builder's `namedChunks` option using the builder test harness.