### PR TITLE
fix(@angular-devkit/build-angular): disable declaration and declarationMap

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/typescript.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/typescript.ts
@@ -54,6 +54,8 @@ function createIvyPlugin(
 
   const compilerOptions: CompilerOptions = {
     sourceMap: buildOptions.sourceMap.scripts,
+    declaration: false,
+    declarationMap: false,
   };
 
   if (buildOptions.preserveSymlinks !== undefined) {


### PR DESCRIPTION


When building an application or testing a library. TypeScript declarations are not needed.

Closes #20103