### PR TITLE
refactor(@ngtools/webpack): initialize paths plugin in resolve options hook

### DIFF
--- a/packages/ngtools/webpack/src/angular_compiler_plugin.ts
+++ b/packages/ngtools/webpack/src/angular_compiler_plugin.ts
@@ -939,12 +939,16 @@ export class AngularCompilerPlugin {
           });
       }
 
-      // tslint:disable-next-line:no-any
-      (compiler as any).resolverFactory.hooks.resolver
+      // tslint:disable-next-line: no-any
+      (compiler as any).resolverFactory.hooks.resolveOptions
         .for('normal')
-        // tslint:disable-next-line:no-any
-        .tap('angular-compiler', (resolver: any) => {
-          new TypeScriptPathsPlugin(this._compilerOptions).apply(resolver);
+        .tap('angular-compiler', (resolveOptions: { plugins: unknown[] }) => {
+          if (!resolveOptions.plugins) {
+            resolveOptions.plugins = [];
+          }
+          resolveOptions.plugins.push(new TypeScriptPathsPlugin(this._compilerOptions));
+
+          return resolveOptions;
         });
 
       compiler.hooks.normalModuleFactory.tap('angular-compiler', nmf => {

--- a/packages/ngtools/webpack/src/ivy/plugin.ts
+++ b/packages/ngtools/webpack/src/ivy/plugin.ts
@@ -145,16 +145,17 @@ export class AngularWebpackPlugin {
       // Example: module -> module__ivy_ngcc
       resolverFactoryHooks.resolveOptions
         .for('normal')
-        .tap(PLUGIN_NAME, (resolveOptions: { mainFields: string[] }) => {
+        .tap(PLUGIN_NAME, (resolveOptions: { mainFields: string[], plugins: unknown[] }) => {
           const originalMainFields = resolveOptions.mainFields;
           const ivyMainFields = originalMainFields.map((f) => `${f}_ivy_ngcc`);
 
+          if (!resolveOptions.plugins) {
+            resolveOptions.plugins = [];
+          }
+          resolveOptions.plugins.push(pathsPlugin);
+
           return mergeResolverMainFields(resolveOptions, originalMainFields, ivyMainFields);
         });
-
-      resolverFactoryHooks.resolver.for('normal').tap(PLUGIN_NAME, (resolver: {}) => {
-        pathsPlugin.apply(resolver);
-      });
     });
 
     let ngccProcessor: NgccProcessor | undefined;


### PR DESCRIPTION
This change reduces the number of different Webpack resolver factory hooks required to initialize the compiler plugins.
Webpack 5 also requires the path plugin to be configured earlier in the process and the options hook provides that ability.