### PR TITLE
test(@angular-devkit/build-angular): avoid loading dev typings in unit test

### DIFF
--- a/packages/angular_devkit/build_angular/src/browser/tests/options/tsconfig_spec.ts
+++ b/packages/angular_devkit/build_angular/src/browser/tests/options/tsconfig_spec.ts
@@ -19,6 +19,7 @@ describeBuilder(buildWebpackBrowser, BROWSER_BUILDER_INFO, (harness) => {
         JSON.stringify({
           compilerOptions: {
             target: 'es5',
+            types: [],
           },
           files: ['main.ts'],
         }),


### PR DESCRIPTION
The `tsconfig` browser builder option unit test was unintentionally loading all development typings.