### PR TITLE
fix(@angular-devkit/build-angular): only show index and service worker status once

### DIFF
--- a/packages/angular_devkit/build_angular/src/browser/index.ts
+++ b/packages/angular_devkit/build_angular/src/browser/index.ts
@@ -709,9 +709,9 @@ export function buildWebpackBrowser(
 
                       return { success: false, error: mapErrorToMessage(error) };
                     }
-
-                    spinner.succeed('Index html generation complete.');
                   }
+
+                  spinner.succeed('Index html generation complete.');
                 }
 
                 if (options.serviceWorker) {
@@ -730,9 +730,9 @@ export function buildWebpackBrowser(
 
                       return { success: false, error: mapErrorToMessage(error) };
                     }
-
-                    spinner.succeed('Service worker generation complete.');
                   }
+
+                  spinner.succeed('Service worker generation complete.');
                 }
               }
 


### PR DESCRIPTION


Previously the `Index html generation complete` and `Service worker generation complete` where displayed multiple times when localization was enabled.