### PR TITLE
feat(@schematics/angular): production builds by default

### DIFF
--- a/packages/angular/cli/commands/build-long.md
+++ b/packages/angular/cli/commands/build-long.md
@@ -3,7 +3,7 @@ When used to build a library, a different builder is invoked, and only the `ts-c
 All other options apply only to building applications.
 
 The application builder uses the [webpack](https://webpack.js.org/) build tool, with default configuration options specified in the workspace configuration file (`angular.json`) or with a named alternative configuration.
-A "production" configuration is created by default when you use the CLI to create the project, and you can use that configuration by specifying the `--configuration="production"` or the `--prod` option.
+A "development" configuration is created by default when you use the CLI to create the project, and you can use that configuration by specifying the `--configuration development`.
 
 The configuration options generally correspond to the command options.
 You can override individual configuration defaults by specifying the corresponding options on the command line.

--- a/packages/angular/cli/commands/definitions.json
+++ b/packages/angular/cli/commands/definitions.json
@@ -22,7 +22,8 @@
         },
         "prod": {
           "description": "Shorthand for \"--configuration=production\".\nSet the build configuration to the production target.\nBy default, the production target is set up in the workspace configuration such that all builds make use of bundling, limited tree-shaking, and also limited dead code elimination.",
-          "type": "boolean"
+          "type": "boolean",
+          "x-deprecated": "Use `--configuration production` instead."
         }
       }
     },

--- a/packages/angular/cli/models/architect-command.ts
+++ b/packages/angular/cli/models/architect-command.ts
@@ -328,6 +328,7 @@ export abstract class ArchitectCommand<
       if (commandOptions.prod) {
         // The --prod flag will always be the first configuration, available to be overwritten
         // by following configurations.
+        this.logger.warn('Option "--prod" is deprecated: Use "--configuration production" instead.');
         configuration = 'production';
       }
       if (commandOptions.configuration) {

--- a/packages/angular/pwa/pwa/index_spec.ts
+++ b/packages/angular/pwa/pwa/index_spec.ts
@@ -52,7 +52,7 @@ describe('PWA Schematic', () => {
     schematicRunner.runSchematicAsync('ng-add', defaultOptions, appTree).toPromise().then(tree => {
       const configText = tree.readContent('/angular.json');
       const config = JSON.parse(configText);
-      const swFlag = config.projects.bar.architect.build.configurations.production.serviceWorker;
+      const swFlag = config.projects.bar.architect.build.options.serviceWorker;
       expect(swFlag).toEqual(true);
       done();
     }, done.fail);

--- a/packages/schematics/angular/app-shell/index_spec.ts
+++ b/packages/schematics/angular/app-shell/index_spec.ts
@@ -68,9 +68,9 @@ describe('App Shell Schematic', () => {
     const content = tree.readContent(filePath);
     const workspace = JSON.parse(content);
     const target = workspace.projects.bar.architect['app-shell'];
-    expect(target.options.browserTarget).toEqual('bar:build');
-    expect(target.options.serverTarget).toEqual('bar:server');
     expect(target.options.route).toEqual('shell');
+    expect(target.configurations.development.browserTarget).toEqual('bar:build:development');
+    expect(target.configurations.development.serverTarget).toEqual('bar:server:development');
     expect(target.configurations.production.browserTarget).toEqual('bar:build:production');
     expect(target.configurations.production.serverTarget).toEqual('bar:server:production');
   });

--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -172,6 +172,7 @@ function addAppToWorkspaceFile(options: ApplicationOptions, appDir: string): Rul
     targets: {
       build: {
         builder: Builders.Browser,
+        defaultConfiguration: 'production',
         options: {
           outputPath: `dist/${options.name}`,
           index: `${sourceRoot}/index.html`,
@@ -190,29 +191,34 @@ function addAppToWorkspaceFile(options: ApplicationOptions, appDir: string): Rul
         },
         configurations: {
           production: {
+            budgets,
             fileReplacements: [{
               replace: `${sourceRoot}/environments/environment.ts`,
               with: `${sourceRoot}/environments/environment.prod.ts`,
             }],
+            buildOptimizer: true,
             optimization: true,
             outputHashing: 'all',
             sourceMap: false,
             namedChunks: false,
             extractLicenses: true,
             vendorChunk: false,
-            buildOptimizer: true,
-            budgets,
+          },
+          development: {
+            vendorChunk: true,
           },
         },
       },
       serve: {
         builder: Builders.DevServer,
-        options: {
-          browserTarget: `${options.name}:build`,
-        },
+        defaultConfiguration: 'development',
+        options: {},
         configurations: {
           production: {
             browserTarget: `${options.name}:build:production`,
+          },
+          development: {
+            browserTarget: `${options.name}:build:development`,
           },
         },
       },

--- a/packages/schematics/angular/e2e/index.ts
+++ b/packages/schematics/angular/e2e/index.ts
@@ -48,13 +48,16 @@ export default function (options: E2eOptions): Rule {
     project.targets.add({
       name: 'e2e',
       builder: Builders.Protractor,
+      defaultConfiguration: 'development',
       options: {
         protractorConfig: `${root}/protractor.conf.js`,
-        devServerTarget: `${options.relatedAppName}:serve`,
       },
       configurations: {
         production: {
           devServerTarget: `${options.relatedAppName}:serve:production`,
+        },
+        development: {
+          devServerTarget: `${options.relatedAppName}:serve:development`,
         },
       },
     });

--- a/packages/schematics/angular/e2e/index_spec.ts
+++ b/packages/schematics/angular/e2e/index_spec.ts
@@ -94,9 +94,9 @@ describe('Application Schematic', () => {
       const tree = await schematicRunner.runSchematicAsync('e2e', defaultOptions, applicationTree)
         .toPromise();
       const workspace = JSON.parse(tree.readContent('/angular.json'));
-      const e2eOptions = workspace.projects.foo.architect.e2e.options;
-      expect(e2eOptions.protractorConfig).toEqual('projects/foo/e2e/protractor.conf.js');
-      expect(e2eOptions.devServerTarget).toEqual('foo:serve');
+      const { options, configurations } = workspace.projects.foo.architect.e2e;
+      expect(options.protractorConfig).toEqual('projects/foo/e2e/protractor.conf.js');
+      expect(configurations.development.devServerTarget).toEqual('foo:serve:development');
     });
   });
 

--- a/packages/schematics/angular/library/index.ts
+++ b/packages/schematics/angular/library/index.ts
@@ -95,13 +95,16 @@ function addLibToWorkspaceFile(
       targets: {
         build: {
           builder: Builders.NgPackagr,
+          defaultConfiguration: 'production',
           options: {
-            tsConfig: `${projectRoot}/tsconfig.lib.json`,
             project: `${projectRoot}/ng-package.json`,
           },
           configurations: {
             production: {
               tsConfig: `${projectRoot}/tsconfig.lib.prod.json`,
+            },
+            development: {
+              tsConfig: `${projectRoot}/tsconfig.lib.json`,
             },
           },
         },

--- a/packages/schematics/angular/library/index_spec.ts
+++ b/packages/schematics/angular/library/index_spec.ts
@@ -309,22 +309,22 @@ describe('Library Schematic', () => {
     const config = getJsonFileContent(tree, '/angular.json');
     const project = config.projects.foo;
     expect(project.root).toEqual('foo');
-    const buildOpt = project.architect.build.options;
-    expect(buildOpt.project).toEqual('foo/ng-package.json');
-    expect(buildOpt.tsConfig).toEqual('foo/tsconfig.lib.json');
+    const { options, configurations } = project.architect.build;
+    expect(options.project).toEqual('foo/ng-package.json');
+    expect(configurations.production.tsConfig).toEqual('foo/tsconfig.lib.prod.json');
 
-    const appTsConfig = getJsonFileContent(tree, '/foo/tsconfig.lib.json');
-    expect(appTsConfig.extends).toEqual('../tsconfig.json');
+    const libTsConfig = getJsonFileContent(tree, '/foo/tsconfig.lib.json');
+    expect(libTsConfig.extends).toEqual('../tsconfig.json');
     const specTsConfig = getJsonFileContent(tree, '/foo/tsconfig.spec.json');
     expect(specTsConfig.extends).toEqual('../tsconfig.json');
   });
 
-  it(`should add 'production' configuration`, async () => {
+  it(`should add 'development' configuration`, async () => {
     const tree = await schematicRunner.runSchematicAsync('library', defaultOptions, workspaceTree)
       .toPromise();
 
     const workspace = JSON.parse(tree.readContent('/angular.json'));
-    expect(workspace.projects.foo.architect.build.configurations.production).toBeDefined();
+    expect(workspace.projects.foo.architect.build.configurations.development).toBeDefined();
   });
 
   it(`should add 'ng-packagr' builder`, async () => {

--- a/packages/schematics/angular/migrations/update-9/update-i18n_spec.ts
+++ b/packages/schematics/angular/migrations/update-9/update-i18n_spec.ts
@@ -49,6 +49,8 @@ describe('Migration to version 9', () => {
           tree,
         )
         .toPromise();
+
+      tree.overwrite('angular.json', tree.readContent('angular.json').replace(/development/g, 'production'));
     });
 
     describe('i18n configuration', () => {

--- a/packages/schematics/angular/migrations/update-9/update-workspace-config_spec.ts
+++ b/packages/schematics/angular/migrations/update-9/update-workspace-config_spec.ts
@@ -93,6 +93,8 @@ describe('Migration to version 9', () => {
       );
 
       tree.overwrite('tsconfig.app.json', tsConfig);
+
+      tree.overwrite('angular.json', tree.readContent('angular.json').replace(/development/g, 'production'));
     });
 
     describe('scripts and style options', () => {
@@ -277,6 +279,8 @@ describe('Migration to version 9', () => {
             tree,
           )
           .toPromise();
+
+        tree.overwrite('angular.json', tree.readContent('angular.json').replace(/development/g, 'production'));
       });
 
       it('should add optimization option when not defined', async () => {

--- a/packages/schematics/angular/service-worker/index.ts
+++ b/packages/schematics/angular/service-worker/index.ts
@@ -130,21 +130,12 @@ export default function (options: ServiceWorkerOptions): Rule {
     if (!buildTarget) {
       throw targetBuildNotFoundError();
     }
-    const buildOptions =
-      (buildTarget.options || {}) as unknown as BrowserBuilderOptions;
-    let buildConfiguration;
-    if (options.configuration && buildTarget.configurations) {
-      buildConfiguration =
-        buildTarget.configurations[options.configuration] as unknown as BrowserBuilderOptions | undefined;
-    }
-
-    const config = buildConfiguration || buildOptions;
+    const buildOptions = (buildTarget.options || {}) as unknown as BrowserBuilderOptions;
     const root = project.root;
+    buildOptions.serviceWorker = true;
+    buildOptions.ngswConfigPath = join(normalize(root), 'ngsw-config.json');
 
-    config.serviceWorker = true;
-    config.ngswConfigPath = join(normalize(root), 'ngsw-config.json');
-
-    let { resourcesOutputPath = '' } = config;
+    let { resourcesOutputPath = '' } = buildOptions;
     if (resourcesOutputPath) {
       resourcesOutputPath = normalize(`/${resourcesOutputPath}`);
     }

--- a/packages/schematics/angular/service-worker/index_spec.ts
+++ b/packages/schematics/angular/service-worker/index_spec.ts
@@ -19,7 +19,7 @@ describe('Service Worker Schematic', () => {
   const defaultOptions: ServiceWorkerOptions = {
     project: 'bar',
     target: 'build',
-    configuration: 'production',
+    configuration: '',
   };
 
   let appTree: UnitTestTree;
@@ -45,25 +45,13 @@ describe('Service Worker Schematic', () => {
       .toPromise();
   });
 
-  it('should update the production configuration', async () => {
+  it('should add `serviceWorker` option to build target', async () => {
     const tree = await schematicRunner.runSchematicAsync('service-worker', defaultOptions, appTree)
       .toPromise();
     const configText = tree.readContent('/angular.json');
-    const config = JSON.parse(configText);
-    const swFlag = config.projects.bar.architect
-      .build.configurations.production.serviceWorker;
-    expect(swFlag).toEqual(true);
-  });
+    const buildConfig = JSON.parse(configText).projects.bar.architect.build;
 
-  it('should update the target options if no configuration is set', async () => {
-    const options = { ...defaultOptions, configuration: '' };
-    const tree = await schematicRunner.runSchematicAsync('service-worker', options, appTree)
-      .toPromise();
-    const configText = tree.readContent('/angular.json');
-    const config = JSON.parse(configText);
-    const swFlag = config.projects.bar.architect
-      .build.options.serviceWorker;
-    expect(swFlag).toEqual(true);
+    expect(buildConfig.options.serviceWorker).toBeTrue();
   });
 
   it('should add the necessary dependency', async () => {
@@ -162,8 +150,7 @@ describe('Service Worker Schematic', () => {
     expect(tree.exists(path)).toEqual(true);
 
     const { projects } = JSON.parse(tree.readContent('/angular.json'));
-    expect(projects.bar.architect.build.configurations.production.ngswConfigPath)
-      .toBe('projects/bar/ngsw-config.json');
+    expect(projects.bar.architect.build.options.ngswConfigPath).toBe('projects/bar/ngsw-config.json');
   });
 
   it('should add $schema in ngsw-config.json with correct relative path', async () => {
@@ -214,7 +201,7 @@ describe('Service Worker Schematic', () => {
 
   it('should add resourcesOutputPath to root assets when specified', async () => {
     const config = JSON.parse(appTree.readContent('/angular.json'));
-    config.projects.bar.architect.build.configurations.production.resourcesOutputPath = 'outDir';
+    config.projects.bar.architect.build.options.resourcesOutputPath = 'outDir';
     appTree.overwrite('/angular.json', JSON.stringify(config));
     const tree = await schematicRunner.runSchematicAsync('service-worker', defaultOptions, appTree)
       .toPromise();
@@ -243,7 +230,6 @@ describe('Service Worker Schematic', () => {
     expect(tree.exists('/ngsw-config.json')).toBe(true);
 
     const { projects } = JSON.parse(tree.readContent('/angular.json'));
-    expect(projects.foo.architect.build.configurations.production.ngswConfigPath)
-      .toBe('ngsw-config.json');
+    expect(projects.foo.architect.build.options.ngswConfigPath).toBe('ngsw-config.json');
   });
 });

--- a/packages/schematics/angular/service-worker/schema.json
+++ b/packages/schematics/angular/service-worker/schema.json
@@ -20,7 +20,7 @@
     "configuration": {
       "type": "string",
       "description": "The configuration to apply service worker to.",
-      "default": "production"
+      "x-deprecated": "No longer has an effect."
     }
   },
   "required": [

--- a/packages/schematics/angular/universal/index_spec.ts
+++ b/packages/schematics/angular/universal/index_spec.ts
@@ -156,13 +156,9 @@ describe('Universal Schematic', () => {
     expect(opts.main).toEqual('projects/bar/src/main.server.ts');
     expect(opts.tsConfig).toEqual('projects/bar/tsconfig.server.json');
     const configurations = targets.server.configurations;
-    expect(configurations.production).toBeDefined();
-    expect(configurations.production.fileReplacements).toBeDefined();
-    expect(configurations.production.outputHashing).toBe('media');
-    const fileReplacements = targets.server.configurations.production.fileReplacements;
-    expect(fileReplacements.length).toEqual(1);
-    expect(fileReplacements[0].replace).toEqual('projects/bar/src/environments/environment.ts');
-    expect(fileReplacements[0].with).toEqual('projects/bar/src/environments/environment.prod.ts');
+    expect(configurations.production.fileReplacements.length).toEqual(1);
+    expect(configurations.production.fileReplacements[0].replace).toEqual('projects/bar/src/environments/environment.ts');
+    expect(configurations.production.fileReplacements[0].with).toEqual('projects/bar/src/environments/environment.prod.ts');
   });
 
   it('should update workspace with a build target outputPath', async () => {

--- a/packages/schematics/angular/workspace/files/package.json.template
+++ b/packages/schematics/angular/workspace/files/package.json.template
@@ -4,7 +4,8 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "build": "ng build"<% if (!minimal) { %>,
+    "build": "ng build",
+    "watch": "ng build --watch --configuration development"<% if (!minimal) { %>,
     "test": "ng test",
     "lint": "ng lint"<% } %>
   },

--- a/tests/legacy-cli/e2e/setup/500-create-project.ts
+++ b/tests/legacy-cli/e2e/setup/500-create-project.ts
@@ -50,8 +50,8 @@ export default async function() {
       // In VE non prod builds are non AOT by default
       await updateJsonFile('angular.json', config => {
         const build = config.projects['test-project'].architect.build;
-        build.options.aot = false;
-        build.configurations.production.aot = true;
+        build.options.aot = true;
+        build.configurations.development.aot = false;
       });
     }
   }

--- a/tests/legacy-cli/e2e/tests/basic/aot.ts
+++ b/tests/legacy-cli/e2e/tests/basic/aot.ts
@@ -3,7 +3,7 @@ import { expectFileToMatch } from '../../utils/fs';
 import { ng } from '../../utils/process';
 
 export default async function () {
-  await ng('build', '--aot=true');
+  await ng('build', '--aot=true', '--configuration=development');
 
   if (getGlobalVariable('argv')['ve']) {
     await expectFileToMatch('dist/test-project/main.js',

--- a/tests/legacy-cli/e2e/tests/basic/build.ts
+++ b/tests/legacy-cli/e2e/tests/basic/build.ts
@@ -4,13 +4,13 @@ import { ng } from '../../utils/process';
 
 export default async function() {
   // Development build
-  await ng('build');
+  await ng('build', '--configuration=development');
   await expectFileToMatch('dist/test-project/index.html', 'main.js');
 
   // Named Development build
-  await ng('build', 'test-project');
-  await ng('build', 'test-project', '--no-progress');
-  await ng('build', '--no-progress', 'test-project');
+  await ng('build', 'test-project', '--configuration=development');
+  await ng('build', '--configuration=development', 'test-project', '--no-progress');
+  await ng('build', '--configuration=development', '--no-progress', 'test-project');
 
   // Enable Differential loading to run both size checks
   await replaceInFile(
@@ -19,7 +19,7 @@ export default async function() {
     'IE 11',
   );
   // Production build
-  const { stderr: stderrProgress, stdout } = await ng('build', '--prod', '--progress');
+  const { stderr: stderrProgress, stdout } = await ng('build', '--progress');
   await expectFileToMatch('dist/test-project/index.html', /main-es5\.[a-zA-Z0-9]{20}\.js/);
   await expectFileToMatch('dist/test-project/index.html', /main-es2015\.[a-zA-Z0-9]{20}\.js/);
 
@@ -44,7 +44,7 @@ export default async function() {
     }
   }
 
-  const { stderr: stderrNoProgress } = await ng('build', '--prod', '--no-progress');
+  const { stderr: stderrNoProgress } = await ng('build', '--no-progress');
   for (const log of logs) {
     if (stderrNoProgress.includes(log)) {
       throw new Error(`Expected stderr not to contain '${log}' but it did.\n${stderrProgress}`);

--- a/tests/legacy-cli/e2e/tests/basic/e2e.ts
+++ b/tests/legacy-cli/e2e/tests/basic/e2e.ts
@@ -12,7 +12,7 @@ export default function () {
     .then(() => expectToFail(() => ng('e2e', 'test-project', '--devServerTarget=')))
     // These should work.
     .then(() => ng('e2e', 'test-project'))
-    .then(() => ng('e2e', 'test-project', '--devServerTarget=test-project:serve:production'))
+    .then(() => ng('e2e', 'test-project', '--devServerTarget=test-project:serve'))
     // Should accept different config file
     .then(() => moveFile('./e2e/protractor.conf.js',
       './e2e/renamed-protractor.conf.js'))

--- a/tests/legacy-cli/e2e/tests/basic/environment.ts
+++ b/tests/legacy-cli/e2e/tests/basic/environment.ts
@@ -8,6 +8,7 @@ export default async function () {
   await updateJsonFile('angular.json', configJson => {
     const appArchitect = configJson.projects['test-project'].architect;
     appArchitect.build.configurations['prod-env'] = {
+      ...appArchitect.build.configurations['development'],
       fileReplacements: [
         {
           src: 'src/environments/environment.ts',

--- a/tests/legacy-cli/e2e/tests/basic/ngcc-es2015-only.ts
+++ b/tests/legacy-cli/e2e/tests/basic/ngcc-es2015-only.ts
@@ -13,7 +13,7 @@ export default async function() {
     // Don't run this test for VE jobs. It only applies to Ivy.
     return;
   }
-  const { stderr, stdout } = await ng('build', '--prod');
+  const { stderr, stdout } = await ng('build');
 
   if (stdout.includes('as esm5') || stderr.includes('as esm5')) {
     throw new Error('ngcc should not process ES5 during differential loading builds.');

--- a/tests/legacy-cli/e2e/tests/basic/scripts-array.ts
+++ b/tests/legacy-cli/e2e/tests/basic/scripts-array.ts
@@ -41,7 +41,7 @@ export default async function () {
     ];
   });
 
-  await ng('build', '--extract-css');
+  await ng('build', '--extract-css', '--configuration=development');
 
   // files were created successfully
   await expectFileToMatch('dist/test-project/scripts.js', 'string-script');

--- a/tests/legacy-cli/e2e/tests/basic/size-tracking.ts
+++ b/tests/legacy-cli/e2e/tests/basic/size-tracking.ts
@@ -31,7 +31,7 @@ export default async function () {
     await ng('generate', 'module', 'lazy', '--route=lazy', '--module=app.module');
 
     // Build without hashing and with named chunks to keep have consistent file names.
-    await ng('build', '--prod', '--output-hashing=none', '--named-chunks=true');
+    await ng('build', '--output-hashing=none', '--named-chunks=true');
 
     // Upload to the store_artifacts dir listed in .circleci/config.yml
     await moveDirectory('dist', '/tmp/dist');

--- a/tests/legacy-cli/e2e/tests/basic/styles-array.ts
+++ b/tests/legacy-cli/e2e/tests/basic/styles-array.ts
@@ -27,7 +27,7 @@ export default async function() {
     ];
   });
 
-  await ng('build', '--extract-css');
+  await ng('build', '--extract-css', '--configuration=development');
 
   await expectFileToMatch('dist/test-project/styles.css', '.string-style');
   await expectFileToMatch('dist/test-project/styles.css', '.input-style');

--- a/tests/legacy-cli/e2e/tests/build/allow-js.ts
+++ b/tests/legacy-cli/e2e/tests/build/allow-js.ts
@@ -15,6 +15,6 @@ export default async function() {
     json['compilerOptions'].allowJs = true;
   });
 
-  await ng('build');
-  await ng('build', '--aot');
+  await ng('build', '--configuration=development');
+  await ng('build', '--aot', '--configuration=development');
 }

--- a/tests/legacy-cli/e2e/tests/build/assets.ts
+++ b/tests/legacy-cli/e2e/tests/build/assets.ts
@@ -8,7 +8,7 @@ export default async function () {
   await writeFile('src/assets/.file', '');
   await writeFile('src/assets/test.abc', 'hello world');
 
-  await ng('build');
+  await ng('build', '--configuration=development');
 
   await expectFileToExist('dist/test-project/favicon.ico');
   await expectFileToExist('dist/test-project/assets/.file');
@@ -28,7 +28,7 @@ export default async function () {
   fs.writeFileSync('dirToSymlink/subdir2/subsubdir1/d.txt', '');
   fs.symlinkSync(process.cwd() + '/dirToSymlink', 'src/assets/symlinkDir');
 
-  await ng('build');
+  await ng('build', '--configuration=development');
 
   await expectFileToExist('dist/test-project/assets/symlinkDir/a.txt');
   await expectFileToExist('dist/test-project/assets/symlinkDir/subdir1/b.txt');

--- a/tests/legacy-cli/e2e/tests/build/barrel-file.ts
+++ b/tests/legacy-cli/e2e/tests/build/barrel-file.ts
@@ -4,5 +4,5 @@ import { ng } from '../../utils/process';
 export default async function() {
   await writeFile('src/app/index.ts', `export { AppModule } from './app.module';`);
   await replaceInFile('src/main.ts', './app/app.module', './app');
-  await ng('build');
+  await ng('build', '--configuration=development');
 }

--- a/tests/legacy-cli/e2e/tests/build/base-href.ts
+++ b/tests/legacy-cli/e2e/tests/build/base-href.ts
@@ -5,6 +5,6 @@ import { expectFileToMatch } from '../../utils/fs';
 export default function() {
   // TODO(architect): Delete this test. It is now in devkit/build-angular.
 
-  return ng('build', '--base-href', '/myUrl')
+  return ng('build', '--base-href', '/myUrl', '--configuration=development')
     .then(() => expectFileToMatch('dist/test-project/index.html', /<base href="\/myUrl">/));
 }

--- a/tests/legacy-cli/e2e/tests/build/build-app-shell-with-schematic.ts
+++ b/tests/legacy-cli/e2e/tests/build/build-app-shell-with-schematic.ts
@@ -28,9 +28,9 @@ export default async function () {
     }
   }
 
-  await ng('run', 'test-project:app-shell');
+  await ng('run', 'test-project:app-shell:development');
   await expectFileToMatch('dist/test-project/browser/index.html', /app-shell works!/);
 
-  await ng('run', 'test-project:app-shell:production');
+  await ng('run', 'test-project:app-shell');
   await expectFileToMatch('dist/test-project/browser/index.html', /app-shell works!/);
 }

--- a/tests/legacy-cli/e2e/tests/build/build-app-shell.ts
+++ b/tests/legacy-cli/e2e/tests/build/build-app-shell.ts
@@ -29,7 +29,7 @@ export default function() {
         appArchitect['app-shell'] = {
           builder: '@angular-devkit/build-angular:app-shell',
           options: {
-            browserTarget: 'test-project:build:production',
+            browserTarget: 'test-project:build',
             serverTarget: 'test-project:server',
             route: '/shell',
           },

--- a/tests/legacy-cli/e2e/tests/build/build-optimizer.ts
+++ b/tests/legacy-cli/e2e/tests/build/build-optimizer.ts
@@ -8,7 +8,7 @@ export default function () {
 
   return ng('build', '--aot', '--build-optimizer')
     .then(() => expectToFail(() => expectFileToMatch('dist/test-project/main.js', /\.decorators =/)))
-    .then(() => ng('build', '--prod'))
+    .then(() => ng('build'))
     .then(() => expectToFail(() => expectFileToExist('dist/vendor.js')))
     .then(() => expectToFail(() => expectFileToMatch('dist/test-project/main.js', /\.decorators =/)))
     .then(() => expectToFail(() => ng('build', '--aot=false', '--build-optimizer')));

--- a/tests/legacy-cli/e2e/tests/build/bundle-budgets.ts
+++ b/tests/legacy-cli/e2e/tests/build/bundle-budgets.ts
@@ -13,7 +13,7 @@ import { expectToFail } from '../../utils/utils';
 export default async function () {
   // Error
   await updateJsonFile('angular.json', json => {
-    json.projects['test-project'].architect.build.options.budgets = [
+    json.projects['test-project'].architect.build.configurations.production.budgets = [
       { type: 'all', maximumError: '100b' },
     ];
   });
@@ -25,7 +25,7 @@ export default async function () {
 
   // Warning
   await updateJsonFile('angular.json', json => {
-    json.projects['test-project'].architect.build.options.budgets = [
+    json.projects['test-project'].architect.build.configurations.production.budgets = [
       { type: 'all', minimumWarning: '100mb' },
     ];
   });
@@ -37,7 +37,7 @@ export default async function () {
 
   // Pass
   await updateJsonFile('angular.json', json => {
-    json.projects['test-project'].architect.build.options.budgets = [
+    json.projects['test-project'].architect.build.configurations.production.budgets = [
       { type: 'allScript', maximumError: '100mb' },
     ];
   });

--- a/tests/legacy-cli/e2e/tests/build/chunk-hash.ts
+++ b/tests/legacy-cli/e2e/tests/build/chunk-hash.ts
@@ -58,11 +58,11 @@ export default function() {
       RouterModule.forRoot([{ path: "lazy", loadChildren: "./lazy/lazy.module#LazyModule" }]),
       ReactiveFormsModule,
     `))
-    .then(() => ng('build', '--output-hashing=all'))
+    .then(() => ng('build', '--output-hashing=all', '--configuration=development'))
     .then(() => {
       oldHashes = generateFileHashMap();
     })
-    .then(() => ng('build', '--output-hashing=all'))
+    .then(() => ng('build', '--output-hashing=all', '--configuration=development'))
     .then(() => {
       newHashes = generateFileHashMap();
     })
@@ -71,7 +71,7 @@ export default function() {
       oldHashes = newHashes;
     })
     .then(() => writeFile('src/styles.css', 'body { background: blue; }'))
-    .then(() => ng('build', '--output-hashing=all'))
+    .then(() => ng('build', '--output-hashing=all', '--configuration=development'))
     .then(() => {
       newHashes = generateFileHashMap();
     })
@@ -80,7 +80,7 @@ export default function() {
       oldHashes = newHashes;
     })
     .then(() => writeFile('src/app/app.component.css', 'h1 { margin: 10px; }'))
-    .then(() => ng('build', '--output-hashing=all'))
+    .then(() => ng('build', '--output-hashing=all', '--configuration=development'))
     .then(() => {
       newHashes = generateFileHashMap();
     })
@@ -95,7 +95,7 @@ export default function() {
       imports: [
          ReactiveFormsModule,
     `))
-    .then(() => ng('build', '--output-hashing=all'))
+    .then(() => ng('build', '--output-hashing=all', '--configuration=development'))
     .then(() => {
       newHashes = generateFileHashMap();
     })

--- a/tests/legacy-cli/e2e/tests/build/css-urls.ts
+++ b/tests/legacy-cli/e2e/tests/build/css-urls.ts
@@ -31,7 +31,7 @@ export default function () {
     }))
     .then(() => copyProjectAsset('images/spectrum.png', './src/assets/global-img-relative.png'))
     .then(() => copyProjectAsset('images/spectrum.png', './src/assets/component-img-relative.png'))
-    .then(() => ng('build', '--extract-css', '--aot'))
+    .then(() => ng('build', '--extract-css', '--aot', '--configuration=development'))
     // Check paths are correctly generated.
     .then(() => expectFileToMatch('dist/test-project/styles.css', 'assets/global-img-absolute.svg'))
     .then(() => expectFileToMatch('dist/test-project/styles.css',
@@ -49,28 +49,28 @@ export default function () {
     .then(() => expectFileMatchToExist('./dist/test-project', /component-img-relative\.png/))
     // Check urls with deploy-url scheme are used as is.
     .then(() => ng('build', '--base-href=/base/', '--deploy-url=http://deploy.url/',
-      '--extract-css'))
+      '--extract-css', '--configuration=development'))
     .then(() => expectFileToMatch('dist/test-project/styles.css',
       /url\(\'\/assets\/global-img-absolute\.svg\'\)/))
     .then(() => expectFileToMatch('dist/test-project/main.js',
       /url\(\'\/assets\/component-img-absolute\.svg\'\)/))
     // Check urls with base-href scheme are used as is (with deploy-url).
     .then(() => ng('build', '--base-href=http://base.url/', '--deploy-url=deploy/',
-      '--extract-css'))
+      '--extract-css', '--configuration=development'))
     .then(() => expectFileToMatch('dist/test-project/styles.css',
       /url\(\'\/assets\/global-img-absolute\.svg\'\)/))
     .then(() => expectFileToMatch('dist/test-project/main.js',
       /url\(\'\/assets\/component-img-absolute\.svg\'\)/))
     // Check urls with deploy-url and base-href scheme only use deploy-url.
     .then(() => ng('build', '--base-href=http://base.url/', '--deploy-url=http://deploy.url/',
-      '--extract-css'))
+      '--extract-css', '--configuration=development'))
     .then(() => expectFileToMatch('dist/test-project/styles.css',
       /url\(\'\/assets\/global-img-absolute\.svg\'\)/))
     .then(() => expectFileToMatch('dist/test-project/main.js',
       /url\(\'\/assets\/component-img-absolute\.svg\'\)/))
     // Check with base-href and deploy-url flags.
     .then(() => ng('build', '--base-href=/base/', '--deploy-url=deploy/',
-      '--extract-css', '--aot'))
+      '--extract-css', '--aot', '--configuration=development'))
     .then(() => expectFileToMatch('dist/test-project/styles.css',
       '/assets/global-img-absolute.svg'))
     .then(() => expectFileToMatch('dist/test-project/styles.css',
@@ -81,7 +81,7 @@ export default function () {
       /deploy\/component-img-relative\.png/))
     // Check with identical base-href and deploy-url flags.
     .then(() => ng('build', '--base-href=/base/', '--deploy-url=/base/',
-      '--extract-css', '--aot'))
+      '--extract-css', '--aot', '--configuration=development'))
     .then(() => expectFileToMatch('dist/test-project/styles.css',
       '/assets/global-img-absolute.svg'))
     .then(() => expectFileToMatch('dist/test-project/styles.css',
@@ -92,7 +92,7 @@ export default function () {
       /\/base\/component-img-relative\.png/))
     // Check with only base-href flag.
     .then(() => ng('build', '--base-href=/base/',
-      '--extract-css', '--aot'))
+      '--extract-css', '--aot', '--configuration=development'))
     .then(() => expectFileToMatch('dist/test-project/styles.css',
       '/assets/global-img-absolute.svg'))
     .then(() => expectFileToMatch('dist/test-project/styles.css',

--- a/tests/legacy-cli/e2e/tests/build/delete-output-path.ts
+++ b/tests/legacy-cli/e2e/tests/build/delete-output-path.ts
@@ -13,6 +13,6 @@ export default function() {
     .then(() => expectToFail(() => ng('build', '--delete-output-path=false')))
     .then(() => expectFileToExist('dist'))
     // By default, output path is always cleared.
-    .then(() => expectToFail(() => ng('build')))
+    .then(() => expectToFail(() => ng('build', '--configuration=development')))
     .then(() => expectToFail(() => expectFileToExist('dist/test-project')));
 }

--- a/tests/legacy-cli/e2e/tests/build/deploy-url.ts
+++ b/tests/legacy-cli/e2e/tests/build/deploy-url.ts
@@ -11,15 +11,15 @@ export default function () {
     .then(() => appendToFile('src/main.ts', 'import("./lazy");'))
     // use image with file size >10KB to prevent inlining
     .then(() => copyProjectAsset('images/spectrum.png', './src/assets/more.png'))
-    .then(() => ng('build', '--deploy-url=deployUrl/', '--extract-css'))
+    .then(() => ng('build', '--deploy-url=deployUrl/', '--extract-css', '--configuration=development'))
     .then(() => expectFileToMatch('dist/test-project/index.html', 'deployUrl/main.js'))
     // verify --deploy-url isn't applied to extracted css urls
     .then(() => expectFileToMatch('dist/test-project/styles.css',
       /url\(['"]?more\.png['"]?\)/))
-    .then(() => ng('build', '--deploy-url=http://example.com/some/path/', '--extract-css'))
+    .then(() => ng('build', '--deploy-url=http://example.com/some/path/', '--extract-css', '--configuration=development'))
     .then(() => expectFileToMatch('dist/test-project/index.html', 'http://example.com/some/path/main.js'))
     // verify --deploy-url is applied to non-extracted css urls
-    .then(() => ng('build', '--deploy-url=deployUrl/', '--extract-css=false'))
+    .then(() => ng('build', '--deploy-url=deployUrl/', '--extract-css=false', '--configuration=development'))
     .then(() => expectFileToMatch('dist/test-project/styles.js',
       /\(['"]?deployUrl\/more\.png['"]?\)/))
     .then(() => expectFileToMatch('dist/test-project/runtime.js',

--- a/tests/legacy-cli/e2e/tests/build/differential-cache.ts
+++ b/tests/legacy-cli/e2e/tests/build/differential-cache.ts
@@ -55,12 +55,12 @@ export default async function() {
   await rimraf('./node_modules/.cache');
 
   let start = Date.now();
-  await ng('build');
+  await ng('build', '--configuration=development');
   let initial = Date.now() - start;
   oldHashes = generateFileHashMap();
 
   start = Date.now();
-  await ng('build');
+  await ng('build', '--configuration=development');
   let cached = Date.now() - start;
   newHashes = generateFileHashMap();
 
@@ -76,12 +76,12 @@ export default async function() {
   await rimraf('./node_modules/.cache');
 
   start = Date.now();
-  await ng('build', '--prod');
+  await ng('build');
   initial = Date.now() - start;
   oldHashes = generateFileHashMap();
 
   start = Date.now();
-  await ng('build', '--prod');
+  await ng('build');
   cached = Date.now() - start;
   newHashes = generateFileHashMap();
 

--- a/tests/legacy-cli/e2e/tests/build/differential-loading-sri.ts
+++ b/tests/legacy-cli/e2e/tests/build/differential-loading-sri.ts
@@ -43,7 +43,6 @@ export default async function () {
 
   await ng(
     'build',
-    '--prod',
     '--subresource-integrity',
     '--output-hashing=none',
     '--output-path=dist/first',
@@ -52,7 +51,6 @@ export default async function () {
   // Second build used to ensure cached files use correct integrity values
   await ng(
     'build',
-    '--prod',
     '--subresource-integrity',
     '--output-hashing=none',
     '--output-path=dist/second',

--- a/tests/legacy-cli/e2e/tests/build/differential-loading-watch.ts
+++ b/tests/legacy-cli/e2e/tests/build/differential-loading-watch.ts
@@ -8,7 +8,7 @@ export default async function () {
     'IE 11',
   );
 
-  await execAndWaitForOutputToMatch('ng', ['build', '--watch'], /Initial Total/i);
+  await execAndWaitForOutputToMatch('ng', ['build', '--watch', '--configuration=development'], /Initial Total/i);
   await expectFileToExist('dist/test-project/runtime-es2015.js');
   await expectFileToExist('dist/test-project/main-es2015.js');
 }

--- a/tests/legacy-cli/e2e/tests/build/differential-loading.ts
+++ b/tests/legacy-cli/e2e/tests/build/differential-loading.ts
@@ -25,7 +25,7 @@ export default async function () {
     ];
   });
 
-  await ng('build', '--extract-css', '--vendor-chunk', '--optimization');
+  await ng('build', '--extract-css', '--vendor-chunk', '--optimization', '--configuration=development');
 
   // index.html lists the right bundles
   await expectFileToMatch(

--- a/tests/legacy-cli/e2e/tests/build/dynamic-import.ts
+++ b/tests/legacy-cli/e2e/tests/build/dynamic-import.ts
@@ -44,7 +44,7 @@ export default async function() {
   `);
 
   // Build and look for the split lazy module
-  await ng('build');
+  await ng('build', '--configuration=development');
   for (const file of fs.readdirSync('./dist/test-project')) {
     if (file === 'src-app-lazy-lazy-module.js') {
       // Lazy module chunk was found and succesfully split

--- a/tests/legacy-cli/e2e/tests/build/extract-licenses.ts
+++ b/tests/legacy-cli/e2e/tests/build/extract-licenses.ts
@@ -4,13 +4,13 @@ import { expectToFail } from '../../utils/utils';
 
 export default async function() {
   // Licenses should be left intact if extraction is disabled
-  await ng('build', '--prod', '--extract-licenses=false', '--output-hashing=none');
+  await ng('build', '--extract-licenses=false', '--output-hashing=none');
 
   await expectToFail(() => expectFileToExist('dist/test-project/3rdpartylicenses.txt'));
   await expectFileToMatch('dist/test-project/main.js', '@license');
 
   // Licenses should be removed if extraction is enabled
-  await ng('build', '--prod', '--extract-licenses', '--output-hashing=none');
+  await ng('build', '--extract-licenses', '--output-hashing=none');
 
   await expectFileToExist('dist/test-project/3rdpartylicenses.txt');
   await expectToFail(() => expectFileToMatch('dist/test-project/main.js', '@license'));

--- a/tests/legacy-cli/e2e/tests/build/jit-prod.ts
+++ b/tests/legacy-cli/e2e/tests/build/jit-prod.ts
@@ -11,5 +11,5 @@ export default async function () {
   });
 
   // Test it works
-  await ng('e2e', '--prod');
+  await ng('e2e', '--configuration=production');
 }

--- a/tests/legacy-cli/e2e/tests/build/json.ts
+++ b/tests/legacy-cli/e2e/tests/build/json.ts
@@ -3,7 +3,7 @@ import { expectGitToBeClean } from '../../utils/git';
 import { ng } from '../../utils/process';
 
 export default async function() {
-  await ng('build', '--stats-json');
+  await ng('build', '--stats-json', '--configuration=development');
   await expectFileToExist('./dist/test-project/stats.json');
   await expectGitToBeClean();
 }

--- a/tests/legacy-cli/e2e/tests/build/lazy-load-syntax.ts
+++ b/tests/legacy-cli/e2e/tests/build/lazy-load-syntax.ts
@@ -5,7 +5,6 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import { getGlobalVariable } from '../../utils/env';
 import { appendToFile, prependToFile, readFile, replaceInFile, writeFile } from '../../utils/fs';
 import { ng } from '../../utils/process';
 import { updateJsonFile } from '../../utils/project';
@@ -75,8 +74,8 @@ export default async function () {
   // This way we can use `ng e2e` to test JIT and `ng e2e --prod` to test AOT.
   await updateJsonFile('angular.json', json => {
     const buildTarget = json['projects'][projectName]['architect']['build'];
-    buildTarget['options']['aot'] = false;
-    buildTarget['configurations']['production'] = { aot: true };
+    buildTarget['options']['aot'] = true;
+    buildTarget['configurations']['development']['aot'] = false;
   });
 
   // Test `import()` style lazy load.
@@ -84,7 +83,7 @@ export default async function () {
   await replaceLoadChildren(`() => import('./lazy/lazy.module').then(m => m.LazyModule)`);
 
   await ng('e2e');
-  await ng('e2e', '--prod');
+  await ng('e2e', '--configuration=production');
 
   // Test string import.
   // Both Ivy and View Engine should support it.
@@ -93,5 +92,5 @@ export default async function () {
   });
   await replaceLoadChildren(`'./lazy/lazy.module#LazyModule'`);
   await ng('e2e');
-  await ng('e2e', '--prod');
+  await ng('e2e', '--configuration=production');
 }

--- a/tests/legacy-cli/e2e/tests/build/material.ts
+++ b/tests/legacy-cli/e2e/tests/build/material.ts
@@ -33,7 +33,7 @@ export default async function () {
 
   await installPackage('moment');
 
-  await ng('build', '--prod');
+  await ng('build');
 
   // Ensure moment adapter works (uses unique importing mechanism for moment)
   // Issue: https://github.com/angular/angular-cli/issues/17320

--- a/tests/legacy-cli/e2e/tests/build/module-id.ts
+++ b/tests/legacy-cli/e2e/tests/build/module-id.ts
@@ -7,5 +7,5 @@ export default function() {
     .then(() => replaceInFile('src/app/app.component.ts',
       '@Component({',
       '@Component({ moduleId: module.id,'))
-    .then(() => ng('build'));
+    .then(() => ng('build', '--configuration=development'));
 }

--- a/tests/legacy-cli/e2e/tests/build/multiple-configs.ts
+++ b/tests/legacy-cli/e2e/tests/build/multiple-configs.ts
@@ -11,9 +11,14 @@ export default async function () {
     // sourceMap defaults to true
     appArchitect['build'] = {
       ...appArchitect['build'],
+      defaultConfiguration: undefined,
       options: {
         ...appArchitect['build'].options,
-        extractCss: false,
+        buildOptimizer: false,
+        optimization: false,
+        sourceMap: true,
+        outputHashing: 'none',
+        vendorChunk: true,
         assets: [
           'src/favicon.ico',
           'src/assets',
@@ -22,10 +27,12 @@ export default async function () {
           'src/styles.css',
         ],
         scripts: [],
+        budgets: [],
       },
       configurations: {
-        production: {
-          extractCss: true,
+        development: {
+          sourceMap: true,
+          extractCss: false,
         },
         one: {
           assets: [],
@@ -43,16 +50,15 @@ export default async function () {
   });
 
   // Test the base configuration.
-  await ng('build');
+  await ng('build', '--configuration=development');
   await expectFileToExist('dist/test-project/favicon.ico');
   await expectFileToExist('dist/test-project/main.js.map');
   await expectFileToExist('dist/test-project/styles.js');
   await expectFileToExist('dist/test-project/vendor.js');
-  // Test that --prod extracts css.
-  await ng('build', '--prod');
+  await ng('build');
   await expectFileToExist('dist/test-project/styles.css');
   // But using a config overrides prod.
-  await ng('build', '--prod', '--configuration=three');
+  await ng('build', '--configuration=three');
   await expectFileToExist('dist/test-project/styles.js');
   await expectToFail(() => expectFileToExist('dist/test-project/styles.css'));
   // Use two configurations.
@@ -64,8 +70,8 @@ export default async function () {
   await expectToFail(() => expectFileToExist('dist/test-project/favicon.ico'));
   await expectFileToExist('dist/test-project/main.js.map');
   await expectToFail(() => expectFileToExist('dist/test-project/vendor.js'));
-  // Use three configurations and a override, and prod at the end.
-  await ng('build', '--configuration=one,two,three', '--vendor-chunk=false', '--prod');
+  // Use three configuration and check that last on value wins
+  await ng('build', '--configuration=one,two,three', '--vendor-chunk=false');
   await expectToFail(() => expectFileToExist('dist/test-project/favicon.ico'));
   await expectToFail(() => expectFileToExist('dist/test-project/main.js.map'));
   await expectToFail(() => expectFileToExist('dist/test-project/vendor.js'));

--- a/tests/legacy-cli/e2e/tests/build/no-angular-router.ts
+++ b/tests/legacy-cli/e2e/tests/build/no-angular-router.ts
@@ -9,7 +9,7 @@ export default function() {
 
   return Promise.resolve()
     .then(() => moveFile('node_modules/@angular/router', path.join(tmp, '@angular-router.backup')))
-    .then(() => ng('build'))
+    .then(() => ng('build', '--configuration=development'))
     .then(() => expectFileToExist('./dist/test-project/index.html'))
     .then(() => moveFile(path.join(tmp, '@angular-router.backup'), 'node_modules/@angular/router'));
 }

--- a/tests/legacy-cli/e2e/tests/build/no-entry-module.ts
+++ b/tests/legacy-cli/e2e/tests/build/no-entry-module.ts
@@ -12,5 +12,5 @@ export default async function() {
     + 'console.log(AppModule);';  // Use AppModule to make sure it's imported properly.
 
   await writeFile('src/main.ts', newMainTs);
-  await ng('build');
+  await ng('build', '--configuration=development');
 }

--- a/tests/legacy-cli/e2e/tests/build/no-sourcemap.ts
+++ b/tests/legacy-cli/e2e/tests/build/no-sourcemap.ts
@@ -2,10 +2,10 @@ import * as fs from 'fs';
 import { ng } from '../../utils/process';
 
 export default async function () {
-  await ng('build', '--prod', '--output-hashing=none', '--source-map', 'false');
+  await ng('build', '--output-hashing=none', '--source-map', 'false');
   await testForSourceMaps(3);
 
-  await ng('build', '--output-hashing=none', '--source-map', 'false');
+  await ng('build', '--output-hashing=none', '--source-map', 'false', '--configuration=development');
   await testForSourceMaps(4);
 }
 

--- a/tests/legacy-cli/e2e/tests/build/output-dir.ts
+++ b/tests/legacy-cli/e2e/tests/build/output-dir.ts
@@ -8,7 +8,7 @@ import {expectToFail} from '../../utils/utils';
 export default function() {
   // TODO(architect): Delete this test. It is now in devkit/build-angular.
 
-  return ng('build', '--output-path', 'build-output')
+  return ng('build', '--output-path', 'build-output', '--configuration=development')
     .then(() => expectFileToExist('./build-output/index.html'))
     .then(() => expectFileToExist('./build-output/main.js'))
     .then(() => expectToFail(expectGitToBeClean))
@@ -16,7 +16,7 @@ export default function() {
       const appArchitect = workspaceJson.projects['test-project'].architect;
       appArchitect.build.options.outputPath = 'config-build-output';
     }))
-    .then(() => ng('build'))
+    .then(() => ng('build', '--configuration=development'))
     .then(() => expectFileToExist('./config-build-output/index.html'))
     .then(() => expectFileToExist('./config-build-output/main.js'))
     .then(() => expectToFail(expectGitToBeClean));

--- a/tests/legacy-cli/e2e/tests/build/output-hashing.ts
+++ b/tests/legacy-cli/e2e/tests/build/output-hashing.ts
@@ -14,25 +14,25 @@ export default async function () {
   });
   // use image with file size >10KB to prevent inlining
   await copyProjectAsset('images/spectrum.png', './src/assets/image.png');
-  await ng('build', '--output-hashing=all');
+  await ng('build', '--output-hashing=all', '--configuration=development');
   await expectFileToMatch('dist/test-project/index.html', /runtime\.[0-9a-f]{20}\.js/);
   await expectFileToMatch('dist/test-project/index.html', /main\.[0-9a-f]{20}\.js/);
   await expectFileToMatch('dist/test-project/index.html', /styles\.[0-9a-f]{20}\.(css|js)/);
   await verifyMedia(/styles\.[0-9a-f]{20}\.(css|js)/, /image\.[0-9a-f]{20}\.png/);
 
-  await ng('build', '--output-hashing=none');
+  await ng('build', '--output-hashing=none', '--configuration=development');
   await expectFileToMatch('dist/test-project/index.html', /runtime\.js/);
   await expectFileToMatch('dist/test-project/index.html', /main\.js/);
   await expectFileToMatch('dist/test-project/index.html', /styles\.(css|js)/);
   await verifyMedia(/styles\.(css|js)/, /image\.png/);
 
-  await ng('build', '--output-hashing=media');
+  await ng('build', '--output-hashing=media', '--configuration=development');
   await expectFileToMatch('dist/test-project/index.html', /runtime\.js/);
   await expectFileToMatch('dist/test-project/index.html', /main\.js/);
   await expectFileToMatch('dist/test-project/index.html', /styles\.(css|js)/);
   await verifyMedia(/styles\.(css|js)/, /image\.[0-9a-f]{20}\.png/);
 
-  await ng('build', '--output-hashing=bundles');
+  await ng('build', '--output-hashing=bundles', '--configuration=development');
   await expectFileToMatch('dist/test-project/index.html', /runtime\.[0-9a-f]{20}\.js/);
   await expectFileToMatch('dist/test-project/index.html', /main\.[0-9a-f]{20}\.js/);
   await expectFileToMatch('dist/test-project/index.html', /styles\.[0-9a-f]{20}\.(css|js)/);

--- a/tests/legacy-cli/e2e/tests/build/platform-server.ts
+++ b/tests/legacy-cli/e2e/tests/build/platform-server.ts
@@ -74,7 +74,7 @@ export default async function () {
   await replaceInFile('tsconfig.server.json', 'src/main.server.ts', 'server.ts');
   await replaceInFile('angular.json', 'src/main.server.ts', 'server.ts');
 
-  await ng('run', 'test-project:server:production', '--optimization', 'false');
+  await ng('run', 'test-project:server', '--optimization', 'false');
 
   if (veEnabled) {
     await expectFileToMatch('dist/test-project/server/main.js', /exports.*AppServerModuleNgFactory|"AppServerModuleNgFactory":/);
@@ -88,7 +88,7 @@ export default async function () {
   );
 
   // works with optimization and bundleDependencies enabled
-  await ng('run', 'test-project:server:production', '--optimization', '--bundleDependencies');
+  await ng('run', 'test-project:server', '--optimization', '--bundleDependencies');
   await exec(normalize('node'), 'dist/test-project/server/main.js');
   await expectFileToMatch(
     'dist/test-project/server/index.html',

--- a/tests/legacy-cli/e2e/tests/build/polyfills.ts
+++ b/tests/legacy-cli/e2e/tests/build/polyfills.ts
@@ -17,7 +17,7 @@ export default async function () {
     'IE 11',
   );
 
-  await ng('build', '--aot=false');
+  await ng('build', '--aot=false', '--configuration=development');
   // files were created successfully
   await expectFileToMatch('dist/test-project/polyfills-es5.js', 'core-js/proposals/reflect-metadata');
   await expectFileToMatch('dist/test-project/polyfills-es5.js', 'zone.js');
@@ -29,7 +29,7 @@ export default async function () {
 
   const jitPolyfillSize = await getFileSize('dist/test-project/polyfills-es5.js');
 
-  await ng('build', '--aot=true');
+  await ng('build', '--aot=true', '--configuration=development');
   // files were created successfully
   await expectFileToExist('dist/test-project/polyfills-es5.js');
   await expectFileSizeToBeUnder('dist/test-project/polyfills-es5.js', jitPolyfillSize);

--- a/tests/legacy-cli/e2e/tests/build/prod-build.ts
+++ b/tests/legacy-cli/e2e/tests/build/prod-build.ts
@@ -43,7 +43,7 @@ export default async function () {
     'IE 11',
   );
 
-  await ng('build', '--prod');
+  await ng('build');
   await expectFileToExist(join(process.cwd(), 'dist'));
   // Check for cache busting hash script src
   await expectFileToMatch('dist/test-project/index.html', /main-es5\.[0-9a-f]{20}\.js/);

--- a/tests/legacy-cli/e2e/tests/build/profile.ts
+++ b/tests/legacy-cli/e2e/tests/build/profile.ts
@@ -4,7 +4,7 @@ import { ng } from '../../utils/process';
 export default async function() {
   try {
     process.env['NG_BUILD_PROFILING'] = '1';
-    await ng('build');
+    await ng('build', '--configuration=development');
     await expectFileToExist('chrome-profiler-events.json');
     await expectFileToExist('speed-measure-plugin.json');
     await expectFileToMatch('speed-measure-plugin.json', 'plugins');

--- a/tests/legacy-cli/e2e/tests/build/relative-sourcemap.ts
+++ b/tests/legacy-cli/e2e/tests/build/relative-sourcemap.ts
@@ -6,10 +6,10 @@ import { ng } from '../../utils/process';
 export default async function () {
   // General secondary application project
   await ng('generate', 'application', 'secondary-project', '--skip-install');
-  await ng('build', 'secondary-project');
+  await ng('build', 'secondary-project', '--configuration=development');
 
 
-  await ng('build', '--output-hashing=none', '--source-map');
+  await ng('build', '--output-hashing=none', '--source-map', '--configuration=development');
   const content = fs.readFileSync('./dist/secondary-project/main.js.map', 'utf8');
   const {sources} = JSON.parse(content);
   for (const source of sources) {

--- a/tests/legacy-cli/e2e/tests/build/sourcemap.ts
+++ b/tests/legacy-cli/e2e/tests/build/sourcemap.ts
@@ -12,12 +12,12 @@ export default async function () {
 
   // The below is needed to cache bundles and verify that sourcemaps are generated
   // corretly when output-hashing is disabled.
-  await ng('build', '--output-hashing=bundles', '--source-map');
-
-  await ng('build', '--prod', '--output-hashing=none', '--source-map');
-  await testForSourceMaps(6);
+  await ng('build', '--output-hashing=bundles', '--source-map', '--configuration=development');
 
   await ng('build', '--output-hashing=none', '--source-map');
+  await testForSourceMaps(6);
+
+  await ng('build', '--output-hashing=none', '--source-map', '--configuration=development');
   await testForSourceMaps(8);
 }
 

--- a/tests/legacy-cli/e2e/tests/build/styles/empty-style-urls.ts
+++ b/tests/legacy-cli/e2e/tests/build/styles/empty-style-urls.ts
@@ -21,5 +21,5 @@ export default function () {
         }
       `
     }))
-    .then(() => ng('build'));
+    .then(() => ng('build', '--configuration=development'));
 }

--- a/tests/legacy-cli/e2e/tests/build/styles/extract-css.ts
+++ b/tests/legacy-cli/e2e/tests/build/styles/extract-css.ts
@@ -34,7 +34,7 @@ export default function() {
           ];
         }),
       )
-      .then(() => ng('build', '--extract-css'))
+      .then(() => ng('build', '--extract-css', '--configuration=development'))
       // files were created successfully
       .then(() => expectFileToMatch('dist/test-project/styles.css', '.string-style'))
       .then(() => expectFileToMatch('dist/test-project/styles.css', '.input-style'))
@@ -68,7 +68,7 @@ export default function() {
         `)),
       )
       // also check when css isn't extracted
-      .then(() => ng('build', '--no-extract-css'))
+      .then(() => ng('build', '--no-extract-css', '--configuration=development'))
       // files were created successfully
       .then(() => expectFileToMatch('dist/test-project/styles.js', '.string-style'))
       .then(() => expectFileToMatch('dist/test-project/styles.js', '.input-style'))

--- a/tests/legacy-cli/e2e/tests/build/styles/imports.ts
+++ b/tests/legacy-cli/e2e/tests/build/styles/imports.ts
@@ -46,7 +46,7 @@ export default function () {
         .then(() => replaceInFile('src/app/app.component.ts',
           './app.component.css', `./app.component.${ext}`))
         // run build app
-        .then(() => ng('build', '--extract-css', '--source-map'))
+        .then(() => ng('build', '--extract-css', '--source-map', '--configuration=development'))
         // verify global styles
         .then(() => expectFileToMatch('dist/test-project/styles.css',
           /body\s*{\s*background-color: #00f;\s*}/))

--- a/tests/legacy-cli/e2e/tests/build/styles/include-paths.ts
+++ b/tests/legacy-cli/e2e/tests/build/styles/include-paths.ts
@@ -57,14 +57,14 @@ export default function () {
       };
     }))
     // files were created successfully
-    .then(() => ng('build', '--extract-css'))
+    .then(() => ng('build', '--extract-css', '--configuration=development'))
     .then(() => expectFileToMatch('dist/test-project/styles.css', /h1\s*{\s*color: red;\s*}/))
     .then(() => expectFileToMatch('dist/test-project/main.js', /h2.*{.*color: red;.*}/))
     .then(() => expectFileToMatch('dist/test-project/styles.css', /h3\s*{\s*color: #008000;\s*}/))
     .then(() => expectFileToMatch('dist/test-project/main.js', /h4.*{.*color: #008000;.*}/))
     .then(() => expectFileToMatch('dist/test-project/styles.css', /h5\s*{\s*color: #ADDADD;\s*}/))
     .then(() => expectFileToMatch('dist/test-project/main.js', /h6.*{.*color: #ADDADD;.*}/))
-    .then(() => ng('build', '--extract-css', '--aot'))
+    .then(() => ng('build', '--extract-css', '--aot', '--configuration=development'))
     .then(() => expectFileToMatch('dist/test-project/styles.css', /h1\s*{\s*color: red;\s*}/))
     .then(() => expectFileToMatch('dist/test-project/main.js', /h2.*{.*color: red;.*}/))
     .then(() => expectFileToMatch('dist/test-project/styles.css', /h3\s*{\s*color: #008000;\s*}/))

--- a/tests/legacy-cli/e2e/tests/build/styles/less.ts
+++ b/tests/legacy-cli/e2e/tests/build/styles/less.ts
@@ -36,7 +36,7 @@ export default function () {
     }))
     .then(() => replaceInFile('src/app/app.component.ts',
       './app.component.css', './app.component.less'))
-    .then(() => ng('build', '--extract-css', '--source-map'))
+    .then(() => ng('build', '--extract-css', '--source-map', '--configuration=development'))
     .then(() => expectFileToMatch('dist/test-project/styles.css',
       /body\s*{\s*background-color: blue;\s*}/))
     .then(() => expectFileToMatch('dist/test-project/styles.css',

--- a/tests/legacy-cli/e2e/tests/build/styles/loaders.ts
+++ b/tests/legacy-cli/e2e/tests/build/styles/loaders.ts
@@ -34,7 +34,7 @@ export default function () {
     }))
     .then(() => replaceInFile('src/app/app.component.ts',
       './app.component.css', './app.component.scss'))
-    .then(() => ng('build'))
+    .then(() => ng('build', '--configuration=development'))
     .then(() => expectToFail(() => expectFileToMatch('dist/test-project/styles.css', /exports/)))
     .then(() => expectToFail(() => expectFileToMatch('dist/test-project/main-es5.js',
       /".*module\.exports.*\.outer.*background:/)));

--- a/tests/legacy-cli/e2e/tests/build/styles/material-import.ts
+++ b/tests/legacy-cli/e2e/tests/build/styles/material-import.ts
@@ -45,7 +45,7 @@ export default async function () {
     await replaceInFile('src/app/app.component.ts', './app.component.css', `./app.component.${ext}`);
 
     // run build app
-    await ng('build', '--extract-css', '--source-map');
+    await ng('build', '--extract-css', '--source-map', '--configuration=development');
     await writeMultipleFiles({
       [`src/styles.${ext}`]: stripIndents`
           @import "@angular/material/prebuilt-themes/indigo-pink.css";
@@ -55,6 +55,6 @@ export default async function () {
         `,
     });
 
-    await ng('build', '--extract-css');
+    await ng('build', '--extract-css', '--configuration=development');
   }
 }

--- a/tests/legacy-cli/e2e/tests/build/styles/node-sass.ts
+++ b/tests/legacy-cli/e2e/tests/build/styles/node-sass.ts
@@ -31,11 +31,11 @@ export default async function () {
 
   await silentExec('rm', '-rf', 'node_modules/node-sass');
   await silentExec('rm', '-rf', 'node_modules/sass');
-  await expectToFail(() => ng('build', '--extract-css', '--source-map'));
+  await expectToFail(() => ng('build', '--extract-css', '--source-map', '--configuration=development'));
 
   await installPackage('node-sass');
   await silentExec('rm', '-rf', 'node_modules/sass');
-  await ng('build', '--extract-css', '--source-map');
+  await ng('build', '--extract-css', '--source-map', '--configuration=development');
 
   await expectFileToMatch('dist/test-project/styles.css', /body\s*{\s*background-color: blue;\s*}/);
   await expectFileToMatch('dist/test-project/styles.css', /p\s*{\s*background-color: red;\s*}/);
@@ -46,7 +46,7 @@ export default async function () {
   await installPackage('fibers');
   await installPackage('sass');
   await silentExec('rm', '-rf', 'node_modules/node-sass');
-  await ng('build', '--extract-css', '--source-map');
+  await ng('build', '--extract-css', '--source-map', '--configuration=development');
 
   await expectFileToMatch('dist/test-project/styles.css', /body\s*{\s*background-color: blue;\s*}/);
   await expectFileToMatch('dist/test-project/styles.css', /p\s*{\s*background-color: red;\s*}/);

--- a/tests/legacy-cli/e2e/tests/build/styles/preset-env.ts
+++ b/tests/legacy-cli/e2e/tests/build/styles/preset-env.ts
@@ -15,7 +15,7 @@ export default async function () {
     'IE 11',
   );
 
-  await ng('build');
+  await ng('build', '--configuration=development');
   await expectFileToMatch('dist/test-project/styles.css', 'z-index: auto');
   await expectFileToMatch('dist/test-project/styles.css', 'all: initial');
 }

--- a/tests/legacy-cli/e2e/tests/build/styles/scss.ts
+++ b/tests/legacy-cli/e2e/tests/build/styles/scss.ts
@@ -36,7 +36,7 @@ export default function () {
     }))
     .then(() => replaceInFile('src/app/app.component.ts',
       './app.component.css', './app.component.scss'))
-    .then(() => ng('build', '--extract-css', '--source-map'))
+    .then(() => ng('build', '--extract-css', '--source-map', '--configuration=development'))
     .then(() => expectFileToMatch('dist/test-project/styles.css',
       /body\s*{\s*background-color: blue;\s*}/))
     .then(() => expectFileToMatch('dist/test-project/styles.css',

--- a/tests/legacy-cli/e2e/tests/build/styles/stylus.ts
+++ b/tests/legacy-cli/e2e/tests/build/styles/stylus.ts
@@ -36,7 +36,7 @@ export default function () {
     }))
     .then(() => replaceInFile('src/app/app.component.ts',
       './app.component.css', './app.component.styl'))
-    .then(() => ng('build', '--extract-css', '--source-map'))
+    .then(() => ng('build', '--extract-css', '--source-map', '--configuration=development'))
     .then(() => expectFileToMatch('dist/test-project/styles.css',
       /body\s*{\s*background-color: #00f;\s*}/))
     .then(() => expectFileToMatch('dist/test-project/styles.css',

--- a/tests/legacy-cli/e2e/tests/build/styles/symlinked-global.ts
+++ b/tests/legacy-cli/e2e/tests/build/styles/symlinked-global.ts
@@ -23,11 +23,11 @@ export default async function () {
     ];
   });
 
-  await ng('build');
+  await ng('build', '--configuration=development');
   await expectFileToMatch('dist/test-project/styles.css', 'red');
   await expectFileToMatch('dist/test-project/styles.css', 'blue');
 
-  await ng('build', '--preserve-symlinks');
+  await ng('build', '--preserve-symlinks', '--configuration=development');
   await expectFileToMatch('dist/test-project/styles.css', 'red');
   await expectFileToMatch('dist/test-project/styles.css', 'blue');
 }

--- a/tests/legacy-cli/e2e/tests/build/styles/tailwind.ts
+++ b/tests/legacy-cli/e2e/tests/build/styles/tailwind.ts
@@ -22,7 +22,7 @@ export default async function () {
   await writeFile('src/styles.css', '@tailwind base; @tailwind components;');
 
   // Build should succeed and process Tailwind directives
-  await ng('build');
+  await ng('build', '--configuration=development');
 
   // Check for Tailwind output
   await expectFileToMatch('dist/test-project/styles.css', /::placeholder/);
@@ -38,7 +38,7 @@ export default async function () {
   await deleteFile('tailwind.config.js');
 
   // Ensure Tailwind is disabled when no configuration file is present
-  await ng('build');
+  await ng('build', '--configuration=development');
   await expectFileToMatch('dist/test-project/styles.css', '@tailwind base; @tailwind components;');
   await expectFileToMatch('dist/test-project/main.js', '@tailwind base; @tailwind components;');
 
@@ -49,7 +49,7 @@ export default async function () {
   await uninstallPackage('tailwindcss');
 
   // Ensure installation warning is present
-  const { stderr } = await ng('build');
+  const { stderr } = await ng('build', '--configuration=development');
   if (!stderr.includes("To enable Tailwind CSS, please install the 'tailwindcss' package.")) {
     throw new Error('Expected tailwind installation warning');
   }

--- a/tests/legacy-cli/e2e/tests/build/ts-paths.ts
+++ b/tests/legacy-cli/e2e/tests/build/ts-paths.ts
@@ -27,7 +27,7 @@ export default async function () {
   });
 
   await replaceInFile('src/app/app.module.ts', './app.component', '@root/app/app.component');
-  await ng('build');
+  await ng('build', '--configuration=development');
 
   await updateTsConfig(json => {
     json['compilerOptions']['paths']['*'] = [
@@ -52,9 +52,9 @@ export default async function () {
     console.log(meaning5)
   `);
 
-  await ng('build');
+  await ng('build', '--configuration=development');
 
   // Simulate no package.json file which causes Webpack to have an undefined 'descriptionFileData'.
   await rimraf('package.json');
-  await ng('build');
+  await ng('build', '--configuration=development');
 }

--- a/tests/legacy-cli/e2e/tests/build/vendor-chunk.ts
+++ b/tests/legacy-cli/e2e/tests/build/vendor-chunk.ts
@@ -4,8 +4,8 @@ import { expectToFail } from '../../utils/utils';
 
 
 export default async function () {
-  await ng('build');
+  await ng('build', '--configuration=development');
   await expectFileToExist('dist/test-project/vendor.js');
-  await ng('build', '--vendor-chunk=false');
+  await ng('build', '--configuration=development', '--vendor-chunk=false');
   await expectToFail(() => expectFileToExist('dist/test-project/vendor.js'));
 }

--- a/tests/legacy-cli/e2e/tests/build/worker.ts
+++ b/tests/legacy-cli/e2e/tests/build/worker.ts
@@ -29,7 +29,7 @@ export default async function () {
   await expectFileToExist(workerTsConfig);
   await expectFileToMatch(snippetPath, `new Worker('./app.worker', { type: 'module' })`);
 
-  await ng('build');
+  await ng('build', '--configuration=development');
   await expectFileToExist('dist/test-project/0-es5.worker.js');
   await expectFileToMatch('dist/test-project/main-es5.js', '0-es5.worker.js');
   await expectToFail(() => expectFileToMatch('dist/test-project/main-es5.js', '0-es2015.worker.js'));
@@ -37,7 +37,7 @@ export default async function () {
   await expectFileToMatch('dist/test-project/main-es2015.js', '0-es2015.worker.js');
   await expectToFail(() => expectFileToMatch('dist/test-project/main-es2015.js', '0-es5.worker.js'));
 
-  await ng('build', '--prod', '--output-hashing=none');
+  await ng('build', '--output-hashing=none');
   await expectFileToExist('dist/test-project/0-es5.worker.js');
   await expectFileToMatch('dist/test-project/main-es5.js', '0-es5.worker.js');
   await expectToFail(() => expectFileToMatch('dist/test-project/main-es5.js', '0-es2015.worker.js'));

--- a/tests/legacy-cli/e2e/tests/commands/build/build-outdir.ts
+++ b/tests/legacy-cli/e2e/tests/commands/build/build-outdir.ts
@@ -11,6 +11,6 @@ export default function() {
       const appArchitect = workspaceJson.projects['test-project'].architect;
       appArchitect.build.options.outputPath = './';
     }))
-    .then(() => expectToFail(() => ng('build')))
+    .then(() => expectToFail(() => ng('build', '--configuration=development')))
     .then(() => expectToFail(() => ng('serve')));
 }

--- a/tests/legacy-cli/e2e/tests/commands/new/new-minimal.ts
+++ b/tests/legacy-cli/e2e/tests/commands/new/new-minimal.ts
@@ -26,6 +26,6 @@ export default function() {
       .then(() => expectToFail(() => expectFileToMatch('package.json', '"jasmine-core":')))
 
       // Try to run a build.
-      .then(() => ng('build'))
+      .then(() => ng('build', '--configuration=development'))
   );
 }

--- a/tests/legacy-cli/e2e/tests/generate/component/component-module-2.ts
+++ b/tests/legacy-cli/e2e/tests/generate/component/component-module-2.ts
@@ -16,5 +16,5 @@ export default function() {
                  /from '..\/..\/other\/test-component\/test-component.component'/.source)))
 
     // Try to run the unit tests.
-    .then(() => ng('build'));
+    .then(() => ng('build', '--configuration=development'));
 }

--- a/tests/legacy-cli/e2e/tests/generate/component/component-module.ts
+++ b/tests/legacy-cli/e2e/tests/generate/component/component-module.ts
@@ -19,5 +19,5 @@ export default function() {
       /import { TestComponent2Component } from '.\/test-component2\/test-component2.component'/))
 
     // Try to run the unit tests.
-    .then(() => ng('build'));
+    .then(() => ng('build', '--configuration=development'));
 }

--- a/tests/legacy-cli/e2e/tests/generate/directive/directive-module.ts
+++ b/tests/legacy-cli/e2e/tests/generate/directive/directive-module.ts
@@ -17,5 +17,5 @@ export default function() {
       /import { TestDirective2Directive } from '.\/test-directive2.directive'/))
 
     // Try to run the unit tests.
-    .then(() => ng('build'));
+    .then(() => ng('build', '--configuration=development'));
 }

--- a/tests/legacy-cli/e2e/tests/generate/library/library-basic.ts
+++ b/tests/legacy-cli/e2e/tests/generate/library/library-basic.ts
@@ -6,6 +6,6 @@ export default function () {
   return ng('generate', 'library', 'my-lib')
     .then(() => expectFileToMatch('angular.json', /\"my-lib\":/))
     .then(() => useCIChrome('projects/my-lib'))
-    .then(() => ng('build', 'my-lib'))
+    .then(() => ng('build', 'my-lib', '--configuration=development'))
     .then(() => ng('test', 'my-lib', '--watch=false'));
 }

--- a/tests/legacy-cli/e2e/tests/generate/library/library-consumption-linker.ts
+++ b/tests/legacy-cli/e2e/tests/generate/library/library-consumption-linker.ts
@@ -91,8 +91,8 @@ export default async function () {
 
 async function runLibraryTests(prodMode = false): Promise<void> {
   const args = ['build', 'my-lib'];
-  if (prodMode) {
-    args.push('--prod');
+  if (!prodMode) {
+    args.push('--configuration=development');
   }
 
   await ng(...args);

--- a/tests/legacy-cli/e2e/tests/generate/library/library-consumption.ts
+++ b/tests/legacy-cli/e2e/tests/generate/library/library-consumption.ts
@@ -73,8 +73,8 @@ export default async function () {
 
 async function runLibraryTests(prodMode = false): Promise<void> {
   const args = ['build', 'my-lib'];
-  if (prodMode) {
-    args.push('--prod');
+  if (!prodMode) {
+    args.push('--configuration=development');
   }
 
   await ng(...args);

--- a/tests/legacy-cli/e2e/tests/generate/pipe/pipe-module.ts
+++ b/tests/legacy-cli/e2e/tests/generate/pipe/pipe-module.ts
@@ -17,5 +17,5 @@ export default function() {
       /import { TestPipe2Pipe } from '.\/test-pipe2.pipe'/))
 
     // Try to run the unit tests.
-    .then(() => ng('build'));
+    .then(() => ng('build', '--configuration=development'));
 }

--- a/tests/legacy-cli/e2e/tests/i18n/build-locale.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/build-locale.ts
@@ -10,13 +10,13 @@ export default async function () {
   }
 
   // tests for register_locale_data transformer
-  await ng('build', '--aot', '--i18n-locale=fr');
+  await ng('build', '--aot', '--i18n-locale=fr', '--configuration=development');
   await expectFileToMatch('dist/test-project/main.js', /registerLocaleData/);
   await expectFileToMatch('dist/test-project/main.js', /angular_common_locales_fr/);
   await expectFileToMatch('dist/test-project/index.html', /lang="fr"/);
 
   await rimraf('dist');
-  await ng('build', '--aot', '--i18n-locale=fr_FR');
+  await ng('build', '--aot', '--i18n-locale=fr_FR', '--configuration=development');
   await expectFileToMatch('dist/test-project/main.js', /registerLocaleData/);
   await expectFileToMatch('dist/test-project/main.js', /angular_common_locales_fr/);
   await expectFileToMatch('dist/test-project/index.html', /lang="fr_FR"/);

--- a/tests/legacy-cli/e2e/tests/i18n/extract-ivy-libraries.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/extract-ivy-libraries.ts
@@ -19,7 +19,7 @@ export default async function() {
   );
 
   // Build library
-  await ng('build', 'i18n-lib-test');
+  await ng('build', 'i18n-lib-test', '--configuration=development');
 
   // Consume library in application
   await writeFile(

--- a/tests/legacy-cli/e2e/tests/i18n/ivy-localize-basehref.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/ivy-localize-basehref.ts
@@ -79,7 +79,7 @@ export default async function() {
   });
 
   // Build each locale and verify the output.
-  await ng('build');
+  await ng('build', '--configuration=development');
   for (const { lang, outputPath } of langTranslations) {
     // Verify the HTML base HREF attribute is present
     await expectFileToMatch(`${outputPath}/index.html`, `href="/test${baseHrefs[lang] || '/'}"`);
@@ -102,7 +102,7 @@ export default async function() {
   }
 
   // Test absolute base href.
-  await ng('build', '--base-href', 'http://www.domain.com/');
+  await ng('build', '--base-href', 'http://www.domain.com/', '--configuration=development');
   for (const { lang, outputPath } of langTranslations) {
     // Verify the HTML base HREF attribute is present
     await expectFileToMatch(`${outputPath}/index.html`, `href="http://www.domain.com${baseHrefs[lang] || '/'}"`);

--- a/tests/legacy-cli/e2e/tests/i18n/ivy-localize-dl-xliff2.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/ivy-localize-dl-xliff2.ts
@@ -80,7 +80,7 @@ export async function executeTest() {
   }
 
   // Verify deprecated locale data registration is not present
-  await ng('build', '--configuration=fr', '--optimization=false');
+  await ng('build', '--configuration=fr', '--optimization=false', '--configuration=development');
   await expectToFail(() => expectFileToMatch(`${baseDir}/fr/main-es5.js`, 'registerLocaleData('));
   await expectToFail(() =>
     expectFileToMatch(`${baseDir}/fr/main-es2015.js`, 'registerLocaleData('),
@@ -88,10 +88,10 @@ export async function executeTest() {
 
   // Verify missing translation behaviour.
   await appendToFile('src/app/app.component.html', '<p i18n>Other content</p>');
-  await ng('build', '--i18n-missing-translation', 'ignore');
+  await ng('build', '--i18n-missing-translation', 'ignore', '--configuration=development');
   await expectFileToMatch(`${baseDir}/fr/main-es5.js`, /Other content/);
   await expectFileToMatch(`${baseDir}/fr/main-es2015.js`, /Other content/);
-  await expectToFail(() => ng('build'));
+  await expectToFail(() => ng('build', '--configuration=development'));
   try {
     await execAndWaitForOutputToMatch(
       'ng',

--- a/tests/legacy-cli/e2e/tests/i18n/ivy-localize-hashes.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/ivy-localize-hashes.ts
@@ -18,7 +18,7 @@ export default async function() {
 
   // Build each locale and record output file hashes
   const hashes = new Map<string, string>();
-  await ng('build', '--output-hashing=all');
+  await ng('build', '--output-hashing=all', '--configuration=development');
   for (const { lang, outputPath } of langTranslations) {
     for (const entry of fs.readdirSync(outputPath)) {
       const match = entry.match(OUTPUT_RE);
@@ -39,7 +39,7 @@ export default async function() {
   await appendToFile('src/locale/messages.fr.xlf', '\n');
 
   // Build each locale and ensure hashes are different
-  await ng('build', '--output-hashing=all');
+  await ng('build', '--output-hashing=all', '--configuration=development');
   for (const { lang, outputPath } of langTranslations) {
     for (const entry of fs.readdirSync(outputPath)) {
       const match = entry.match(OUTPUT_RE);

--- a/tests/legacy-cli/e2e/tests/i18n/ivy-localize-locale-data.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/ivy-localize-locale-data.ts
@@ -53,7 +53,7 @@ export default async function() {
     appProject.architect['build'].options.localize = ['en-x-abc'];
   });
 
-  const { stderr: err3 } = await ng('build');
+  const { stderr: err3 } = await ng('build', '--configuration=development');
   if (err3.includes(`Locale data for 'en-x-abc' cannot be found.  No locale data will be included for this locale.`)) {
     throw new Error('locale data not found warning shown');
   }

--- a/tests/legacy-cli/e2e/tests/i18n/ivy-localize-sourcelocale.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/ivy-localize-sourcelocale.ts
@@ -26,7 +26,7 @@ export default async function() {
   });
 
   // Build each locale and verify the output.
-  await ng('build');
+  await ng('build', '--configuration=development');
   for (const { lang, outputPath } of langTranslations) {
     // does not exist in this test due to the source locale change
     if (lang === 'en-US') {

--- a/tests/legacy-cli/e2e/tests/i18n/legacy.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/legacy.ts
@@ -171,7 +171,9 @@ export async function setupI18nConfig(useLocalize = true, format: keyof typeof f
     const serveConfigs = appArchitect['serve'].configurations;
     const e2eConfigs = appArchitect['e2e'].configurations;
 
-    // Make default builds prod.
+    appArchitect['build'].defaultConfiguration = undefined;
+
+    // Always error on missing translations.
     appArchitect['build'].options.optimization = true;
     appArchitect['build'].options.buildOptimizer = true;
     appArchitect['build'].options.aot = true;
@@ -179,9 +181,10 @@ export async function setupI18nConfig(useLocalize = true, format: keyof typeof f
       replace: 'src/environments/environment.ts',
       with: 'src/environments/environment.prod.ts',
     }];
-
-    // Always error on missing translations.
     appArchitect['build'].options.i18nMissingTranslation = 'error';
+    appArchitect['build'].options.vendorChunk = true;
+    appArchitect['build'].options.sourceMap = true;
+    appArchitect['build'].options.outputHashing = 'none';
 
     if (useLocalize) {
       // Enable localization for all locales

--- a/tests/legacy-cli/e2e/tests/i18n/ve-localize-es2015.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/ve-localize-es2015.ts
@@ -33,7 +33,7 @@ export default async function() {
   });
 
   // Attempts to build multiple locales with VE should fail
-  await expectToFail(() => ng('build'));
+  await expectToFail(() => ng('build', '--configuration=development'));
 
   for (const { lang, outputPath, translation } of langTranslations) {
     await ng('build', `--configuration=${lang}`);

--- a/tests/legacy-cli/e2e/tests/misc/browsers.ts
+++ b/tests/legacy-cli/e2e/tests/misc/browsers.ts
@@ -30,7 +30,7 @@ export default async function () {
     );
   }
 
-  await ng('build', '--prod');
+  await ng('build');
 
   // Add Protractor configuration
   await copyProjectAsset('protractor-saucelabs.conf.js', 'e2e/protractor-saucelabs.conf.js');

--- a/tests/legacy-cli/e2e/tests/misc/circular-dependency.ts
+++ b/tests/legacy-cli/e2e/tests/misc/circular-dependency.ts
@@ -7,7 +7,7 @@ export default async function () {
 
   await prependToFile('src/app/app.component.ts',
     `import { AppModule } from './app.module'; console.log(AppModule);`);
-  const { stderr } = await ng('build', '--show-circular-dependencies');
+  const { stderr } = await ng('build', '--show-circular-dependencies', '--configuration=development');
   if (!stderr.match(/Warning: Circular dependency detected/)) {
     throw new Error('Expected to have circular dependency warning in output.');
   }

--- a/tests/legacy-cli/e2e/tests/misc/dedupe-duplicate-modules.ts
+++ b/tests/legacy-cli/e2e/tests/misc/dedupe-duplicate-modules.ts
@@ -30,7 +30,7 @@ export default async function () {
         })
     `);
 
-  const { stderr } = await ng('build', '--verbose', '--no-vendor-chunk', '--no-progress');
+  const { stderr } = await ng('build', '--verbose', '--no-vendor-chunk', '--no-progress', '--configuration=development');
   const outFile = 'dist/test-project/main.js';
 
   if (/\[DedupeModuleResolvePlugin\]:.+tslib-1-copy.+ -> .+tslib-1.+/.test(stderr)) {

--- a/tests/legacy-cli/e2e/tests/misc/e2e-host.ts
+++ b/tests/legacy-cli/e2e/tests/misc/e2e-host.ts
@@ -15,6 +15,7 @@ export default async function () {
   try {
     await updateJsonFile('angular.json', workspaceJson => {
       const appArchitect = workspaceJson.projects['test-project'].architect;
+      appArchitect.serve.options = appArchitect.serve.options || {};
       appArchitect.serve.options.port = 8888;
       appArchitect.serve.options.host = host;
     });

--- a/tests/legacy-cli/e2e/tests/misc/es5-polyfills.ts
+++ b/tests/legacy-cli/e2e/tests/misc/es5-polyfills.ts
@@ -10,7 +10,7 @@ export default async function () {
   });
 
   await writeFile('.browserslistrc', 'last 2 Chrome versions');
-  await ng('build');
+  await ng('build', '--configuration=development');
   await expectFileNotToExist('dist/test-project/polyfills-es5.js');
   await expectFileToMatch('dist/test-project/index.html', oneLineTrim`
     <script src="runtime.js" defer></script>
@@ -20,7 +20,7 @@ export default async function () {
   `);
 
   await writeFile('.browserslistrc', 'IE 10');
-  await ng('build');
+  await ng('build', '--configuration=development');
   await expectFileToMatch('dist/test-project/polyfills-es5.js', 'core-js');
   await expectFileToMatch('dist/test-project/index.html', oneLineTrim`
     <script src="runtime.js" defer></script>

--- a/tests/legacy-cli/e2e/tests/misc/lazy-module.ts
+++ b/tests/legacy-cli/e2e/tests/misc/lazy-module.ts
@@ -7,7 +7,7 @@ import {appendToFile, writeFile, prependToFile, replaceInFile} from '../../utils
 export default function() {
   let oldNumberOfFiles = 0;
   return Promise.resolve()
-    .then(() => ng('build'))
+    .then(() => ng('build', '--configuration=development'))
     .then(() => oldNumberOfFiles = readdirSync('dist').length)
     .then(() => ng('generate', 'module', 'lazy', '--routing'))
     .then(() => ng('generate', 'module', 'too/lazy', '--routing'))
@@ -19,7 +19,7 @@ export default function() {
       RouterModule.forRoot([{ path: "lazy1", loadChildren: () => import('./lazy/lazy.module').then(m => m.LazyModule) }]),
       RouterModule.forRoot([{ path: "lazy2", loadChildren: () => import('./too/lazy/lazy.module').then(m => m.LazyModule) }]),
     `))
-    .then(() => ng('build', '--named-chunks'))
+    .then(() => ng('build', '--named-chunks', '--configuration=development'))
     .then(() => readdirSync('dist/test-project'))
     .then((distFiles) => {
       const currentNumberOfDistFiles = distFiles.length;
@@ -40,7 +40,7 @@ export default function() {
       const lazyFile = 'file';
       System.import(/*webpackChunkName: '[request]'*/'./lazy-' + lazyFile);
     `))
-    .then(() => ng('build', '--named-chunks'))
+    .then(() => ng('build', '--named-chunks', '--configuration=development'))
     .then(() => readdirSync('dist/test-project'))
     .then((distFiles) => {
       const currentNumberOfDistFiles = distFiles.length;
@@ -58,14 +58,14 @@ export default function() {
       import * as moment from 'moment';
       console.log(moment);
     `))
-    .then(() => ng('build'))
+    .then(() => ng('build', '--configuration=development'))
     .then(() => readdirSync('dist/test-project').length)
     .then(currentNumberOfDistFiles => {
       if (oldNumberOfFiles != currentNumberOfDistFiles) {
         throw new Error('Bundles were not created after adding \'import *\'.');
       }
     })
-    .then(() => ng('build', '--no-named-chunks'))
+    .then(() => ng('build', '--no-named-chunks', '--configuration=development'))
     .then(() => readdirSync('dist/test-project'))
     .then((distFiles) => {
       if (distFiles.includes('lazy-lazy-module.js') || distFiles.includes('too-lazy-lazy-module.js')) {
@@ -73,7 +73,7 @@ export default function() {
       }
     })
     // Check for AoT and lazy routes.
-    .then(() => ng('build', '--aot'))
+    .then(() => ng('build', '--aot', '--configuration=development'))
     .then(() => readdirSync('dist/test-project').length)
     .then(currentNumberOfDistFiles => {
       if (oldNumberOfFiles != currentNumberOfDistFiles) {

--- a/tests/legacy-cli/e2e/tests/misc/loaders-resolution.ts
+++ b/tests/legacy-cli/e2e/tests/misc/loaders-resolution.ts
@@ -8,7 +8,7 @@ export default async function () {
     'node_modules/@angular-devkit/build-angular/node_modules/@ngtools'
   );
 
-  await ng('build');
+  await ng('build', '--configuration=development');
 
   // Move it back.
   await moveFile(

--- a/tests/legacy-cli/e2e/tests/misc/module-resolution.ts
+++ b/tests/legacy-cli/e2e/tests/misc/module-resolution.ts
@@ -11,7 +11,7 @@ export default async function () {
       '*': ['./node_modules/*'],
     };
   });
-  await ng('build');
+  await ng('build', '--configuration=development');
 
   await createDir('xyz');
   await moveFile(
@@ -19,14 +19,14 @@ export default async function () {
     'xyz/common',
   );
 
-  await expectToFail(() => ng('build'));
+  await expectToFail(() => ng('build', '--configuration=development'));
 
   await updateJsonFile('tsconfig.json', tsconfig => {
     tsconfig.compilerOptions.paths = {
       '@angular/common': [ './xyz/common' ],
     };
   });
-  await ng('build');
+  await ng('build', '--configuration=development');
 
   await updateJsonFile('tsconfig.json', tsconfig => {
     tsconfig.compilerOptions.paths = {
@@ -34,7 +34,7 @@ export default async function () {
       '@angular/common': [ './xyz/common' ],
     };
   });
-  await ng('build');
+  await ng('build', '--configuration=development');
 
   await updateJsonFile('tsconfig.json', tsconfig => {
     tsconfig.compilerOptions.paths = {
@@ -42,7 +42,7 @@ export default async function () {
       '*': ['./node_modules/*'],
     };
   });
-  await ng('build');
+  await ng('build', '--configuration=development');
 
   await updateJsonFile('tsconfig.json', tsconfig => {
     delete tsconfig.compilerOptions.paths;
@@ -52,17 +52,17 @@ export default async function () {
   await appendToFile('src/app/app.module.ts', 'firebase.initializeApp({});');
 
   await installPackage('firebase@3.7.8');
-  await ng('build', '--aot');
+  await ng('build', '--aot', '--configuration=development');
   await ng('test', '--watch=false');
 
   await installPackage('firebase@4.9.0');
-  await ng('build', '--aot');
+  await ng('build', '--aot', '--configuration=development');
   await ng('test', '--watch=false');
 
   await updateJsonFile('tsconfig.json', tsconfig => {
     tsconfig.compilerOptions.paths = {};
   });
-  await ng('build');
+  await ng('build', '--configuration=development');
 
   await updateJsonFile('tsconfig.json', tsconfig => {
     tsconfig.compilerOptions.paths = {
@@ -70,19 +70,19 @@ export default async function () {
       '@lib/*/test': ['*/test'],
     };
   });
-  await ng('build');
+  await ng('build', '--configuration=development');
 
   await updateJsonFile('tsconfig.json', tsconfig => {
     tsconfig.compilerOptions.paths = {
       '@firebase/polyfill': ['./node_modules/@firebase/polyfill/index.ts'],
     };
   });
-  await expectToFail(() => ng('build'));
+  await expectToFail(() => ng('build', '--configuration=development'));
 
   await updateJsonFile('tsconfig.json', tsconfig => {
     tsconfig.compilerOptions.paths = {
       '@firebase/polyfill*': ['./node_modules/@firebase/polyfill/index.ts'],
     };
   });
-  await expectToFail(() => ng('build'));
+  await expectToFail(() => ng('build', '--configuration=development'));
 }

--- a/tests/legacy-cli/e2e/tests/misc/multiple-targets.ts
+++ b/tests/legacy-cli/e2e/tests/misc/multiple-targets.ts
@@ -9,7 +9,7 @@ export default async function () {
     workspaceJson.defaultProject = undefined;
   });
 
-  await ng('build', 'secondary-app');
+  await ng('build', 'secondary-app', '--configuration=development');
 
   expectFileToExist('dist/secondary-app/index.html');
   expectFileToExist('dist/secondary-app/main.js');

--- a/tests/legacy-cli/e2e/tests/misc/non-relative-module-resolution.ts
+++ b/tests/legacy-cli/e2e/tests/misc/non-relative-module-resolution.ts
@@ -18,6 +18,5 @@ export default async function () {
 
   await prependToFile('src/app/app.module.ts', `import './bar';\n`);
 
-  await ng('build');
-  await ng('build', '--aot');
+  await ng('build', '--configuration=development');
 }

--- a/tests/legacy-cli/e2e/tests/misc/npm-7.ts
+++ b/tests/legacy-cli/e2e/tests/misc/npm-7.ts
@@ -43,7 +43,7 @@ export default async function() {
     }
 
     // Ensure `ng build` executes successfully
-    const { stderr: stderrBuild } = await ng('build');
+    const { stderr: stderrBuild } = await ng('build', '--configuration=development');
     if (stderrBuild.includes(warningText)) {
       throw new Error('ng build expected to not show npm version warning.');
     }

--- a/tests/legacy-cli/e2e/tests/misc/title.ts
+++ b/tests/legacy-cli/e2e/tests/misc/title.ts
@@ -9,14 +9,14 @@ export default async function() {
   }
 
   try {
-    await execAndWaitForOutputToMatch('ng', ['build', '--watch'], /./);
+    await execAndWaitForOutputToMatch('ng', ['build', '--configuration=development', '--watch'], /./);
 
     const output = await execWithEnv('ps', ['x'], { COLUMNS: '200' });
 
-    if (!output.stdout.match(/ng build --watch/)) {
+    if (!output.stdout.match(/ng build --configuration=development --watch/)) {
       throw new Error('Title of the process was not properly set.');
     }
   } finally {
-    await killAllProcesses();
+    killAllProcesses();
   }
 }

--- a/tests/legacy-cli/e2e/tests/misc/trace-resolution.ts
+++ b/tests/legacy-cli/e2e/tests/misc/trace-resolution.ts
@@ -6,7 +6,7 @@ export default async function () {
     tsconfig.compilerOptions.traceResolution = true;
   });
 
-  const { stdout: stdoutTraced } = await ng('build');
+  const { stdout: stdoutTraced } = await ng('build', '--configuration=development');
   if (!/Resolving module/.test(stdoutTraced)) {
     throw new Error(`Modules resolutions must be printed when 'traceResolution' is enabled.`);
   }
@@ -15,7 +15,7 @@ export default async function () {
     tsconfig.compilerOptions.traceResolution = false;
   });
 
-  const { stdout: stdoutUnTraced } = await ng('build');
+  const { stdout: stdoutUnTraced } = await ng('build', '--configuration=development');
   if (/Resolving module/.test(stdoutUnTraced)) {
     throw new Error(`Modules resolutions must not be printed when 'traceResolution' is disabled.`);
   }

--- a/tests/legacy-cli/e2e/tests/misc/webpack-5.ts
+++ b/tests/legacy-cli/e2e/tests/misc/webpack-5.ts
@@ -23,8 +23,8 @@ export default async function() {
 
   // Execute the CLI with Webpack 5
   await ng('test', '--watch=false');
+  await ng('build', '--configuration=development');
   await ng('build');
-  await ng('build', '--prod');
   await ng('e2e');
   try {
     await ngServe();

--- a/tests/legacy-cli/e2e/tests/third-party/bootstrap.ts
+++ b/tests/legacy-cli/e2e/tests/third-party/bootstrap.ts
@@ -19,7 +19,7 @@ export default function() {
         { input: 'node_modules/bootstrap/dist/js/bootstrap.js' },
       ];
     }))
-    .then(() => ng('build', '--extract-css'))
+    .then(() => ng('build', '--extract-css', '--configuration=development'))
     .then(() => expectFileToMatch('dist/test-project/scripts.js', '* Bootstrap'))
     .then(() => expectFileToMatch('dist/test-project/styles.css', '* Bootstrap'))
     .then(() => expectFileToMatch('dist/test-project/index.html', oneLineTrim`
@@ -27,6 +27,7 @@ export default function() {
     `))
     .then(() => ng(
       'build',
+      '--configuration=development',
       '--optimization',
       '--extract-css',
       '--output-hashing=none',

--- a/tests/legacy-cli/e2e/tests/third-party/material-icons.ts
+++ b/tests/legacy-cli/e2e/tests/third-party/material-icons.ts
@@ -16,14 +16,14 @@ export default async function() {
   });
 
   // Build dev application
-  await ng('build', '--extract-css');
+  await ng('build', '--extract-css', '--configuration=development');
 
   // Ensure icons are included
-  await expectFileToMatch('dist/test-project/styles.css', 'Material Icons')
+  await expectFileToMatch('dist/test-project/styles.css', 'Material Icons');
 
   // Build prod application
-  await ng('build', '--prod', '--extract-css', '--output-hashing=none');
+  await ng('build', '--extract-css', '--output-hashing=none');
 
   // Ensure icons are included
-  await expectFileToMatch('dist/test-project/styles.css', 'Material Icons')
+  await expectFileToMatch('dist/test-project/styles.css', 'Material Icons');
 }


### PR DESCRIPTION
With this change we do several changes to the `angular.json` configuration for `build` , `server` and `app-shell` targets.

- build, server and app-shell targets are configured to run production by default.
- We add a new configuration named `development` to run the mentioned builder targets in development. Ex: `ng build --configuration development`.
- When adding `universal` or `app-shell`, we generate the full set of configurations as per the `buiid` target. Previously, we only generated the `production` configuration.
- We added a helper script in `package.json` to run build in watch mode. `npm run watch` which is a shortcut for `ng build --watch --configuration development`
- We deprecated the `--prod` command line argument. This argument is confusing especially to new users, since users expect that this builds an application in production mode. This however, is only an alias for `--configuration="production"`


Closes #14471