### PR TITLE
[11.2.x] fix(@angular/cli): remove npm 7 incompatibility notification

### DIFF
--- a/lib/packages.ts
+++ b/lib/packages.ts
@@ -88,7 +88,7 @@ function loadPackageJson(p: string) {
       case 'engines':
         pkg['engines'] = {
           'node': '>= 10.13.0',
-          'npm': '^6.11.0',
+          'npm': '^6.11.0 || ^7.5.6',
           'yarn': '>= 1.13.0',
         };
         break;

--- a/tests/legacy-cli/e2e/tests/misc/npm-7.ts
+++ b/tests/legacy-cli/e2e/tests/misc/npm-7.ts
@@ -3,7 +3,7 @@ import { getActivePackageManager } from '../../utils/packages';
 import { ng, npm } from '../../utils/process';
 import { expectToFail } from '../../utils/utils';
 
-const errorText = 'The Angular CLI temporarily requires npm version 6';
+const warningText = 'npm version 7.5.6 or higher is recommended';
 
 export default async function() {
   // Only relevant with npm as a package manager
@@ -18,53 +18,62 @@ export default async function() {
 
   const currentDirectory = process.cwd();
   try {
-    // Install version 7.x
-    await npm('install', '--global', 'npm@7');
+    // Install version >=7.5.6
+    await npm('install', '--global', 'npm@>=7.5.6');
 
-    // Ensure `ng add` exits and shows npm error
-    const { message: stderrAdd } = await expectToFail(() => ng('add'));
-    if (!stderrAdd.includes(errorText)) {
-      throw new Error('ng add expected to show npm version error.');
+    // Ensure `ng update` does not show npm warning
+    const { stderr: stderrUpdate1 } = await ng('update');
+    if (stderrUpdate1.includes(warningText)) {
+      throw new Error('ng update expected to not show npm version warning.');
     }
 
-    // Ensure `ng update` exits and shows npm error
-    const { message: stderrUpdate } = await expectToFail(() => ng('update'));
-    if (!stderrUpdate.includes(errorText)) {
-      throw new Error('ng update expected to show npm version error.');
+    // Install version <7.5.6
+    await npm('install', '--global', 'npm@7.4.0');
+
+    // Ensure `ng add` shows npm warning
+    const { message: stderrAdd } = await expectToFail(() => ng('add'));
+    if (!stderrAdd.includes(warningText)) {
+      throw new Error('ng add expected to show npm version warning.');
+    }
+
+    // Ensure `ng update` shows npm warning
+    const { stderr: stderrUpdate2 } = await ng('update');
+    if (!stderrUpdate2.includes(warningText)) {
+      throw new Error('ng update expected to show npm version warning.');
     }
 
     // Ensure `ng build` executes successfully
     const { stderr: stderrBuild } = await ng('build');
-    if (stderrBuild.includes(errorText)) {
-      throw new Error('ng build expected to not show npm version error.');
+    if (stderrBuild.includes(warningText)) {
+      throw new Error('ng build expected to not show npm version warning.');
     }
 
-    // Ensure `ng new` exits and shows npm error
+    // Ensure `ng new` shows npm warning
     // Must be outside the project for `ng new`
     process.chdir('..');
     const { message: stderrNew } = await expectToFail(() => ng('new'));
-    if (!stderrNew.includes(errorText)) {
-      throw new Error('ng new expected to show npm version error.');
+    if (!stderrNew.includes(warningText)) {
+      throw new Error('ng new expected to show npm version warning.');
     }
 
-    // Ensure `ng new --package-manager=npm` exits and shows npm error
+    // Ensure `ng new --package-manager=npm` shows npm warning
     const { message: stderrNewNpm } = await expectToFail(() => ng('new', '--package-manager=npm'));
-    if (!stderrNewNpm.includes(errorText)) {
-      throw new Error('ng new expected to show npm version error.');
+    if (!stderrNewNpm.includes(warningText)) {
+      throw new Error('ng new expected to show npm version warning.');
     }
 
     // Ensure `ng new --skip-install` executes successfully
     const { stderr: stderrNewSkipInstall } = await ng('new', 'npm-seven-skip', '--skip-install');
-    if (stderrNewSkipInstall.includes(errorText)) {
-      throw new Error('ng new --skip-install expected to not show npm version error.');
+    if (stderrNewSkipInstall.includes(warningText)) {
+      throw new Error('ng new --skip-install expected to not show npm version warning.');
     }
 
     // Ensure `ng new --package-manager=yarn` executes successfully
     // Need an additional npmrc file since yarn does not use the NPM registry environment variable
     await writeFile('.npmrc', 'registry=http://localhost:4873')
     const { stderr: stderrNewYarn } = await ng('new', 'npm-seven-yarn', '--package-manager=yarn');
-    if (stderrNewYarn.includes(errorText)) {
-      throw new Error('ng new --package-manager=yarn expected to not show npm version error.');
+    if (stderrNewYarn.includes(warningText)) {
+      throw new Error('ng new --package-manager=yarn expected to not show npm version warning.');
     }
   } finally {
     // Cleanup extra test projects


### PR DESCRIPTION
npm 7.5.6 contains several fixes that allow it to work successfully with the Angular CLI.
The minimum npm engine value is now set to support npm versions greater than 7.5.6 (npm 6 support remains unchanged).
A warning will be shown to users with npm 7 versions less than 7.5.6 when used with the new, add, or update commands.

(cherry picked from commit 065ac4546fbb4928245609d52c1f6d81fdd48cb9)