### PR TITLE
docs: use specific `git add` command to avoid adding unnecessary files

### DIFF
--- a/docs/process/release.md
+++ b/docs/process/release.md
@@ -70,7 +70,8 @@ Update the package versions to reflect the new release version in **both**:
 1. [`packages/schematics/angular/utility/latest-versions.ts`](https://github.com/angular/angular-cli/blob/master/packages/schematics/angular/utility/latest-versions.ts)
 
 ```bash
-git commit -a -m 'release: vXX'
+git add package.json packages/schematics/angular/utility/latest-versions.ts
+git commit -m 'release: vXX'
 git tag -a 'vXX' -m 'release: tag vXX'
 ```
 


### PR DESCRIPTION
Today when releasing v9 and v10, I found two extra files in Git (`.husky/` and `.ng-dev.log`). These are a part of the toolchain in later versions, but not known ignored in older versions. Using `git commit -a` would have included both of those files in the release commit which would not be desirable. Instead, the solution for releases is to add the specific files that are modified to remove this possibility.

I'll do a separate PR to back-port the `.gitignore` updates to those branches and start a broader discussion about how we should manage `.gitignore` for LTS branches.

cc @kyliau @josephperrott for visibility to other caretakers.