### PR TITLE
test(@angular/cli): centralize E2E test registry configuration

### DIFF
--- a/tests/legacy-cli/e2e/setup/010-local-publish.ts
+++ b/tests/legacy-cli/e2e/setup/010-local-publish.ts
@@ -1,8 +1,10 @@
 import { prerelease } from 'semver';
 import { packages } from '../../../../lib/packages';
+import { getGlobalVariable } from '../utils/env';
 import { npm } from '../utils/process';
 
 export default async function() {
+  const testRegistry = getGlobalVariable('package-registry');
   const publishArgs = [
     'run',
     'admin',
@@ -10,7 +12,7 @@ export default async function() {
     'publish',
     '--no-versionCheck',
     '--no-branchCheck',
-    '--registry=http://localhost:4873',
+    `--registry=${testRegistry}`,
   ];
 
   const pre = prerelease(packages['@angular/cli'].version);

--- a/tests/legacy-cli/e2e/setup/100-global-cli.ts
+++ b/tests/legacy-cli/e2e/setup/100-global-cli.ts
@@ -7,12 +7,14 @@ export default async function() {
     return;
   }
 
+  const testRegistry = getGlobalVariable('package-registry');
+
   // Install global Angular CLI.
   await silentNpm(
     'install',
     '--global',
     '@angular/cli',
-    '--registry=http://localhost:4873',
+    `--registry=${testRegistry}`,
   );
 
   try {

--- a/tests/legacy-cli/e2e/setup/500-create-project.ts
+++ b/tests/legacy-cli/e2e/setup/500-create-project.ts
@@ -1,8 +1,8 @@
 import { join } from 'path';
 import { getGlobalVariable } from '../utils/env';
-import { expectFileToExist } from '../utils/fs';
+import { expectFileToExist, writeFile } from '../utils/fs';
 import { gitClean } from '../utils/git';
-import { ng } from '../utils/process';
+import { ng, npm } from '../utils/process';
 import { prepareProjectForE2e, updateJsonFile } from '../utils/project';
 
 export default async function() {
@@ -17,10 +17,28 @@ export default async function() {
     await gitClean();
   } else {
     const extraArgs = [];
+    const testRegistry = getGlobalVariable('package-registry');
+    const isCI = getGlobalVariable('ci');
+
+    // Ensure local test registry is used when outside a project
+    if (isCI) {
+      // Safe to set a user configuration on CI
+      await npm('config', 'set', 'registry', testRegistry);
+    } else {
+      // Yarn does not use the environment variable so an .npmrc file is also required
+      await writeFile('.npmrc', `registry=${testRegistry}`);
+      process.env['NPM_CONFIG_REGISTRY'] = testRegistry;
+    }
 
     await ng('new', 'test-project', '--skip-install', ...extraArgs);
     await expectFileToExist(join(process.cwd(), 'test-project'));
     process.chdir('./test-project');
+
+    // If on CI, the user configuration set above will handle project usage
+    if (!isCI) {
+      // Ensure local test registry is used inside a project
+      await writeFile('.npmrc', `registry=${testRegistry}`);
+    }
 
     if (argv['ve']) {
       await updateJsonFile('tsconfig.json', config => {

--- a/tests/legacy-cli/e2e/tests/misc/ask-analytics-install.ts
+++ b/tests/legacy-cli/e2e/tests/misc/ask-analytics-install.ts
@@ -15,7 +15,7 @@ export default async function() {
     // Install the CLI with TTY force enabled
     const execution = execWithEnv(
       'npm',
-      ['install', '@angular/cli', '--registry=http://localhost:4873'],
+      ['install', '@angular/cli'],
       { ...process.env, 'NG_FORCE_TTY': '1' },
     );
 

--- a/tests/legacy-cli/e2e/tests/misc/invalid-schematic-dependencies.ts
+++ b/tests/legacy-cli/e2e/tests/misc/invalid-schematic-dependencies.ts
@@ -11,19 +11,19 @@ export default async function () {
     '@schematics/angular@7',
     '--registry=https://registry.npmjs.org',
   );
-  await silentNpm('publish', stdoutPack1.trim(), '--registry=http://localhost:4873', '--tag=outdated');
+  await silentNpm('publish', stdoutPack1.trim(), '--tag=outdated');
   const { stdout: stdoutPack2 } = await silentNpm(
     'pack',
     '@angular-devkit/core@7',
     '--registry=https://registry.npmjs.org',
   );
-  await silentNpm('publish', stdoutPack2.trim(), '--registry=http://localhost:4873', '--tag=outdated');
+  await silentNpm('publish', stdoutPack2.trim(), '--tag=outdated');
   const { stdout: stdoutPack3 } = await silentNpm(
     'pack',
     '@angular-devkit/schematics@7',
     '--registry=https://registry.npmjs.org',
   );
-  await silentNpm('publish', stdoutPack3.trim(), '--registry=http://localhost:4873', '--tag=outdated');
+  await silentNpm('publish', stdoutPack3.trim(), '--tag=outdated');
 
   // Install outdated and incompatible version
   await installPackage('@schematics/angular@7');

--- a/tests/legacy-cli/e2e/tests/misc/npm-7.ts
+++ b/tests/legacy-cli/e2e/tests/misc/npm-7.ts
@@ -70,7 +70,6 @@ export default async function() {
 
     // Ensure `ng new --package-manager=yarn` executes successfully
     // Need an additional npmrc file since yarn does not use the NPM registry environment variable
-    await writeFile('.npmrc', 'registry=http://localhost:4873')
     const { stderr: stderrNewYarn } = await ng('new', 'npm-seven-yarn', '--package-manager=yarn');
     if (stderrNewYarn.includes(warningText)) {
       throw new Error('ng new --package-manager=yarn expected to not show npm version warning.');
@@ -79,7 +78,6 @@ export default async function() {
     // Cleanup extra test projects
     await rimraf('npm-seven-skip');
     await rimraf('npm-seven-yarn');
-    await rimraf('.npmrc');
 
     // Change directory back
     process.chdir(currentDirectory);

--- a/tests/legacy-cli/e2e/tests/misc/webpack-5.ts
+++ b/tests/legacy-cli/e2e/tests/misc/webpack-5.ts
@@ -1,3 +1,4 @@
+import { getGlobalVariable } from '../../utils/env';
 import { rimraf } from '../../utils/fs';
 import { killAllProcesses, ng, silentYarn } from '../../utils/process';
 import { ngServe, updateJsonFile } from '../../utils/project';
@@ -8,7 +9,8 @@ export default async function() {
   await updateJsonFile('package.json', (json) => {
     json.resolutions = { webpack: '5.1.3' };
   });
-  await silentYarn();
+  const testRegistry = getGlobalVariable('package-registry');
+  await silentYarn(`--registry=${testRegistry}`);
 
   // Ensure webpack 5 is used
   const { stdout } = await silentYarn('list', '--pattern', 'webpack');

--- a/tests/legacy-cli/e2e/tests/schematics_cli/basic.ts
+++ b/tests/legacy-cli/e2e/tests/schematics_cli/basic.ts
@@ -10,13 +10,10 @@ export default async function () {
     return;
   }
 
-  process.env['NPM_CONFIG_REGISTRY'] = 'http://localhost:4873';
-
   await silentNpm(
     'install',
     '-g',
     '@angular-devkit/schematics-cli',
-    '--registry=http://localhost:4873',
   );
   await exec(process.platform.startsWith('win') ? 'where' : 'which', 'schematics');
 

--- a/tests/legacy-cli/e2e/tests/schematics_cli/blank-test.ts
+++ b/tests/legacy-cli/e2e/tests/schematics_cli/blank-test.ts
@@ -11,13 +11,10 @@ export default async function () {
     return;
   }
 
-  process.env['NPM_CONFIG_REGISTRY'] = 'http://localhost:4873';
-
   await silentNpm(
     'install',
     '-g',
     '@angular-devkit/schematics-cli',
-    '--registry=http://localhost:4873',
   );
   await exec(process.platform.startsWith('win') ? 'where' : 'which', 'schematics');
 

--- a/tests/legacy-cli/e2e/tests/schematics_cli/schematic-test.ts
+++ b/tests/legacy-cli/e2e/tests/schematics_cli/schematic-test.ts
@@ -11,13 +11,10 @@ export default async function () {
     return;
   }
 
-  process.env['NPM_CONFIG_REGISTRY'] = 'http://localhost:4873';
-
   await silentNpm(
     'install',
     '-g',
     '@angular-devkit/schematics-cli',
-    '--registry=http://localhost:4873',
   );
   await exec(process.platform.startsWith('win') ? 'where' : 'which', 'schematics');
 

--- a/tests/legacy-cli/e2e/utils/assets.ts
+++ b/tests/legacy-cli/e2e/utils/assets.ts
@@ -49,7 +49,10 @@ export async function createProjectFromAsset(
   process.chdir(dir);
   if (!useNpmPackages) {
     await useBuiltPackages();
-    await writeFile('.npmrc', 'registry = http://localhost:4873', 'utf8');
+    if (!getGlobalVariable('ci')) {
+      const testRegistry = getGlobalVariable('package-registry');
+      await writeFile('.npmrc', `registry=${testRegistry}`);
+    }
   }
 
   if (!skipInstall) {

--- a/tests/legacy-cli/e2e/utils/project.ts
+++ b/tests/legacy-cli/e2e/utils/project.ts
@@ -90,8 +90,6 @@ export async function prepareProjectForE2e(name) {
     await useSha();
   }
 
-  await writeFile('.npmrc', 'registry=http://localhost:4873');
-
   console.log(
     `Project ${name} created... Installing npm.`,
   );

--- a/tests/legacy-cli/e2e_runner.ts
+++ b/tests/legacy-cli/e2e_runner.ts
@@ -143,7 +143,9 @@ if (testsToRun.length == allTests.length) {
 }
 
 setGlobalVariable('argv', argv);
+setGlobalVariable('ci', process.env['CI']?.toLowerCase() === 'true' || process.env['CI'] === '1');
 setGlobalVariable('package-manager', argv.yarn ? 'yarn' : 'npm');
+setGlobalVariable('package-registry', 'http://localhost:4873');
 
 // Setup local package registry
 const registryPath =


### PR DESCRIPTION
E2E test registry configuration to ensure that package managers use the test registry during tests is now moved out of the tests and into the setup phase.