### PR TITLE
build: bump typescript to 4.1.5 due to security issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -230,7 +230,7 @@
     "tslint": "^6.1.3",
     "tslint-no-circular-imports": "^0.7.0",
     "tslint-sonarts": "1.9.0",
-    "typescript": "4.1.3",
+    "typescript": "4.1.5",
     "verdaccio": "4.11.0",
     "verdaccio-auth-memory": "^9.7.2",
     "webpack": "4.44.2",

--- a/packages/angular_devkit/build_optimizer/package.json
+++ b/packages/angular_devkit/build_optimizer/package.json
@@ -12,7 +12,7 @@
     "loader-utils": "2.0.0",
     "source-map": "0.7.3",
     "tslib": "2.1.0",
-    "typescript": "4.1.3",
+    "typescript": "4.1.5",
     "webpack-sources": "2.2.0"
   }
 }

--- a/packages/ngtools/webpack/package.json
+++ b/packages/ngtools/webpack/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@angular/compiler": "11.2.0-next.0",
     "@angular/compiler-cli": "11.2.0-next.0",
-    "typescript": "4.1.3",
+    "typescript": "4.1.5",
     "webpack": "4.44.2"
   }
 }

--- a/packages/schematics/angular/utility/latest-versions.ts
+++ b/packages/schematics/angular/utility/latest-versions.ts
@@ -11,7 +11,7 @@ export const latestVersions = {
   Angular: '~11.2.3',
   RxJs: '~6.6.0',
   ZoneJs: '~0.11.3',
-  TypeScript: '~4.1.2',
+  TypeScript: '~4.1.5',
   TsLib: '^2.0.0',
 
   // The versions below must be manually updated when making a new devkit release.

--- a/packages/schematics/schematics/schematic/files/package.json
+++ b/packages/schematics/schematics/schematic/files/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@angular-devkit/core": "^<%= coreVersion %>",
     "@angular-devkit/schematics": "^<%= schematicsVersion %>",
-    "typescript": "~4.1.2"
+    "typescript": "~4.1.5"
   },
   "devDependencies": {
     "@types/node": "^12.11.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11805,7 +11805,12 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@4.1.3, typescript@~4.1.2:
+typescript@4.1.5:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.5.tgz#123a3b214aaff3be32926f0d8f1f6e704eb89a72"
+  integrity sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==
+
+typescript@~4.1.2:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
   integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==


### PR DESCRIPTION
TypeScript v4.1.3 and below are susceptible to a security risk involving
language service plugin loading.
https://github.com/microsoft/TypeScript/releases/tag/v4.1.4

Note typescript in `master` branch has already been updated.