### PR TITLE
[10.2.x] test(@angular/cli): reuse chrome/chromedriver in E2E tests

### DIFF
--- a/tests/legacy-cli/e2e/tests/basic/e2e.ts
+++ b/tests/legacy-cli/e2e/tests/basic/e2e.ts
@@ -1,26 +1,13 @@
-// TODO(architect): edit the architect config instead of the cli config.
-
 import {
   ng,
-  npm,
   execAndWaitForOutputToMatch,
   killAllProcesses
 } from '../../utils/process';
-import {updateJsonFile} from '../../utils/project';
 import {expectToFail} from '../../utils/utils';
 import {moveFile, copyFile, replaceInFile} from '../../utils/fs';
 
 export default function () {
-  // Should fail without updated webdriver
-  return updateJsonFile('package.json', packageJson => {
-    // Add to npm scripts to make running the binary compatible with Windows
-    const scripts = packageJson['scripts'];
-    scripts['wd:clean'] = 'webdriver-manager clean';
-  })
-    .then(() => npm('run', 'wd:clean'))
-    .then(() => expectToFail(() => ng('e2e', 'test-project', '--no-webdriver-update', '--devServerTarget=')))
-    // Add back the pre-defined version of webdriver. This script is defined when making projects.
-    .then(() => npm('run', 'webdriver-update'))
+  return Promise.resolve()
     // Should fail without serving
     .then(() => expectToFail(() => ng('e2e', 'test-project', '--devServerTarget=')))
     // These should work.
@@ -61,7 +48,10 @@ export default function () {
     .then(() => execAndWaitForOutputToMatch('ng', ['serve'],
       /: Compiled successfully./))
     .then(() => ng('e2e', 'test-project', '--devServerTarget='))
-    .then(() => killAllProcesses(), (err: any) => {
+    // Should fail without updated webdriver
+    .then(() => replaceInFile('e2e/protractor.conf.js', /chromeDriver: String.raw`[^`]*`,/, ''))
+    .then(() => expectToFail(() => ng('e2e', 'test-project', '--no-webdriver-update', '--devServerTarget=')))
+    .then(() => killAllProcesses(), (err) => {
       killAllProcesses();
       throw err;
     });

--- a/tests/legacy-cli/e2e/tests/commands/add/add-pwa-yarn.ts
+++ b/tests/legacy-cli/e2e/tests/commands/add/add-pwa-yarn.ts
@@ -20,9 +20,6 @@ export default async function () {
     }
 
     // 'yarn' will nuke the entire node_modules when it is triggered during the above tests.
-    // Let's restore the previous node_modules state by re-installing using 'npm'
-    // and run 'webdriver-update'. Otherwise, we will start seeing errors in CI like:
-    // Error: Could not find update-config.json. Run 'webdriver-manager update' to download binaries.
+    await rimraf('node_modules');
     await npm('install');
-    await npm('run', 'webdriver-update');
 }

--- a/tests/legacy-cli/e2e/utils/project.ts
+++ b/tests/legacy-cli/e2e/utils/project.ts
@@ -245,16 +245,7 @@ export function useCIDefaults(projectName = 'test-project') {
       const e2eTargets = e2eProject.targets || e2eProject.architect;
       e2eTargets.e2e.options.webdriverUpdate = false;
     }
-  })
-    .then(() => updateJsonFile('package.json', json => {
-      // Use matching versions of Chromium and ChromeDriver.
-      // https://github.com/GoogleChrome/puppeteer/releases
-      // http://chromedriver.chromium.org/downloads
-      json['scripts']['webdriver-update'] = 'webdriver-manager update' +
-        ` --standalone false --gecko false --versions.chrome 81.0.4044.0`; // Supports Chrome 81
-
-    }))
-    .then(() => npm('run', 'webdriver-update'));
+  });
 }
 
 export function useCIChrome(projectDir: string) {
@@ -262,32 +253,36 @@ export function useCIChrome(projectDir: string) {
   const protractorConf = `${dir}protractor.conf.js`;
   const karmaConf = `${dir}karma.conf.js`;
 
+  const chromePath = require('puppeteer').executablePath();
+  const chromeDriverPath = require('webdriver-manager/selenium/update-config.json').chrome.last;
+
   return Promise.resolve()
     .then(() => updateJsonFile('package.json', json => {
-      // Use matching versions of Chromium (via puppeteer) and ChromeDriver.
-      // https://github.com/GoogleChrome/puppeteer/releases
-      // http://chromedriver.chromium.org/downloads
-      json['devDependencies']['puppeteer'] = '3.0.2'; // Chromium 81.0.4044.0 (r737027)
       json['devDependencies']['karma-chrome-launcher'] = '~3.1.0';
     }))
     // Use Pupeteer in protractor if a config is found on the project.
-    .then(() => {
+    .then(async () => {
       if (fs.existsSync(protractorConf)) {
-        return replaceInFile(protractorConf,
+        await replaceInFile(protractorConf,
           `browserName: 'chrome'`,
           `browserName: 'chrome',
           chromeOptions: {
             args: ['--headless'],
-            binary: require('puppeteer').executablePath()
+            binary: String.raw\`${chromePath}\`,
           }
         `);
+        await replaceInFile(
+          protractorConf,
+          'directConnect: true,',
+          `directConnect: true, chromeDriver: String.raw\`${chromeDriverPath}\`,`,
+        );
       }
     })
     // Use Pupeteer in karma if a config is found on the project.
     .then(() => {
       if (fs.existsSync(karmaConf)) {
         return prependToFile(karmaConf,
-          `process.env.CHROME_BIN = require('puppeteer').executablePath();`)
+          `process.env.CHROME_BIN = String.raw\`${chromePath}\`;`)
           .then(() => replaceInFile(karmaConf,
             `browsers: ['Chrome']`,
             `browsers: ['Chrome'],


### PR DESCRIPTION
This changes the E2E test project setup to reuse the repository's existing puppeteer chrome instance and already downloaded chrome driver.  Previously puppeteer was added to each E2E test project which required an additional download of both chrome and an associated chromedriver.  Downloads previously needed to occur multiple times during the test process due to tests changing/removing the test project's node modules directory.

(cherry picked from commit 206d62ab7dc0aa55d86598686114651095be05c1)