### PR TITLE
[9.1.x] test(@angular/cli): reuse chrome/chromedriver in E2E tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,6 +130,7 @@ jobs:
           keys:
             - *cache_key
       - run: yarn install --frozen-lockfile
+      - run: yarn webdriver-update
       - persist_to_workspace:
           root: *workspace_location
           paths:
@@ -174,7 +175,6 @@ jobs:
     parallelism: 4
     steps:
       - custom_attach_workspace
-      - run: yarn webdriver-update
       - run: yarn test-large --full <<# parameters.ve >>--ve<</ parameters.ve >> <<# parameters.glob >>--glob="<< parameters.glob >>"<</ parameters.glob >> --nb-shards=${CIRCLE_NODE_TOTAL} --shard=${CIRCLE_NODE_INDEX}
 
   e2e-cli:
@@ -249,7 +249,6 @@ jobs:
     resource_class: medium
     steps:
       - custom_attach_workspace
-      - run: yarn webdriver-update
       - run: yarn test-large --full --flakey --ve
       - run: yarn test-large --full --flakey
       - run: yarn test-large --full --glob packages/angular_devkit/build_angular/test/app-shell/app-shell_spec_large_disabled.ts --ve
@@ -306,6 +305,7 @@ jobs:
           keys:
             - *cache_key_win
       - run: yarn install --frozen-lockfile
+      - run: yarn webdriver-update
       - run: yarn build
       - save_cache:
           key: *cache_key_win

--- a/tests/legacy-cli/e2e/tests/basic/e2e.ts
+++ b/tests/legacy-cli/e2e/tests/basic/e2e.ts
@@ -1,26 +1,13 @@
-// TODO(architect): edit the architect config instead of the cli config.
-
 import {
   ng,
-  npm,
   execAndWaitForOutputToMatch,
   killAllProcesses
 } from '../../utils/process';
-import {updateJsonFile} from '../../utils/project';
 import {expectToFail} from '../../utils/utils';
 import {moveFile, copyFile, replaceInFile} from '../../utils/fs';
 
 export default function () {
-  // Should fail without updated webdriver
-  return updateJsonFile('package.json', packageJson => {
-    // Add to npm scripts to make running the binary compatible with Windows
-    const scripts = packageJson['scripts'];
-    scripts['wd:clean'] = 'webdriver-manager clean';
-  })
-    .then(() => npm('run', 'wd:clean'))
-    .then(() => expectToFail(() => ng('e2e', 'test-project', '--no-webdriver-update', '--devServerTarget=')))
-    // Add back the pre-defined version of webdriver. This script is defined when making projects.
-    .then(() => npm('run', 'webdriver-update'))
+  return Promise.resolve()
     // Should fail without serving
     .then(() => expectToFail(() => ng('e2e', 'test-project', '--devServerTarget=')))
     // These should work.
@@ -61,7 +48,10 @@ export default function () {
     .then(() => execAndWaitForOutputToMatch('ng', ['serve'],
       /: Compiled successfully./))
     .then(() => ng('e2e', 'test-project', '--devServerTarget='))
-    .then(() => killAllProcesses(), (err: any) => {
+    // Should fail without updated webdriver
+    .then(() => replaceInFile('e2e/protractor.conf.js', /chromeDriver: String.raw`[^`]*`,/, ''))
+    .then(() => expectToFail(() => ng('e2e', 'test-project', '--no-webdriver-update', '--devServerTarget=')))
+    .then(() => killAllProcesses(), (err) => {
       killAllProcesses();
       throw err;
     });

--- a/tests/legacy-cli/e2e/tests/commands/add/add-pwa-yarn.ts
+++ b/tests/legacy-cli/e2e/tests/commands/add/add-pwa-yarn.ts
@@ -20,9 +20,6 @@ export default async function () {
     }
 
     // 'yarn' will nuke the entire node_modules when it is triggered during the above tests.
-    // Let's restore the previous node_modules state by re-installing using 'npm'
-    // and run 'webdriver-update'. Otherwise, we will start seeing errors in CI like:
-    // Error: Could not find update-config.json. Run 'webdriver-manager update' to download binaries.
+    await rimraf('node_modules');
     await npm('install');
-    await npm('run', 'webdriver-update');
 }


### PR DESCRIPTION
This changes the E2E test project setup to reuse the repository's existing puppeteer chrome instance and already downloaded chrome driver.  Previously puppeteer was added to each E2E test project which required an additional download of both chrome and an associated chromedriver.  Downloads previously needed to occur multiple times during the test process due to tests changing/removing the test project's node modules directory.

(cherry picked from commit 206d62ab7dc0aa55d86598686114651095be05c1)