### PR TITLE
fix(@angular-devkit/build-angular): inline critical font-face rules when using critical css inlining

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/index-file/inline-critical-css.ts
+++ b/packages/angular_devkit/build_angular/src/utils/index-file/inline-critical-css.ts
@@ -39,6 +39,7 @@ class CrittersExtended extends Critters {
       mergeStylesheets: false,
       preload: 'media',
       noscriptFallback: true,
+      inlineFonts: true,
       // tslint:disable-next-line: no-any
     } as any);
   }


### PR DESCRIPTION


When critical font rules are not inlined it will cause blinking as during first render the fallback font will be rendered.

Related to https://github.com/angular/universal/issues/2002