### PR TITLE
feat(@angular-devkit/build-angular): change several builder options defaults

### DIFF
--- a/packages/angular/cli/lib/config/schema.json
+++ b/packages/angular/cli/lib/config/schema.json
@@ -797,11 +797,11 @@
             "aot": {
               "type": "boolean",
               "description": "Build using Ahead of Time compilation.",
-              "default": false
+              "default": true
             },
             "sourceMap": {
               "description": "Output source maps for scripts and styles. For more information, see https://angular.io/guide/workspace-config#source-map-configuration.",
-              "default": true,
+              "default": false,
               "oneOf": [
                 {
                   "type": "object",
@@ -837,7 +837,7 @@
             "vendorChunk": {
               "type": "boolean",
               "description": "Generate a seperate bundle containing only vendor libraries. This option should only used for development.",
-              "default": true
+              "default": false
             },
             "commonChunk": {
               "type": "boolean",
@@ -896,7 +896,7 @@
             "outputHashing": {
               "type": "string",
               "description": "Define the output filename cache-busting hashing mode.",
-              "default": "none",
+              "default": "all",
               "enum": [
                 "none",
                 "all",
@@ -930,12 +930,12 @@
             "buildOptimizer": {
               "type": "boolean",
               "description": "Enables @angular-devkit/build-optimizer optimizations when using the 'aot' option.",
-              "default": false
+              "default": true
             },
             "namedChunks": {
               "type": "boolean",
               "description": "Use file name for lazy loaded chunks.",
-              "default": true
+              "default": false
             },
             "subresourceIntegrity": {
               "type": "boolean",
@@ -1296,7 +1296,7 @@
             },
             "optimization": {
               "description": "Enables optimization of the build output. Including minification of scripts and styles, tree-shaking, dead-code elimination and fonts inlining. For more information, see https://angular.io/guide/workspace-config#optimization-configuration.",
-              "default": false,
+              "default": true,
               "oneOf": [
                 {
                   "type": "object",
@@ -1787,7 +1787,7 @@
             },
             "optimization": {
               "description": "Enables optimization of the build output. Including minification of scripts and styles, tree-shaking and dead-code elimination. For more information, see https://angular.io/guide/workspace-config#optimization-configuration.",
-              "default": false,
+              "default": true,
               "oneOf": [
                 {
                   "type": "object",
@@ -1828,7 +1828,7 @@
             },
             "sourceMap": {
               "description": "Output source maps for scripts and styles. For more information, see https://angular.io/guide/workspace-config#source-map-configuration.",
-              "default": true,
+              "default": false,
               "oneOf": [
                 {
                   "type": "object",
@@ -1895,7 +1895,7 @@
             "outputHashing": {
               "type": "string",
               "description": "Define the output filename cache-busting hashing mode.",
-              "default": "none",
+              "default": "media",
               "enum": [
                 "none",
                 "all",

--- a/packages/angular_devkit/build_angular/src/browser/schema.json
+++ b/packages/angular_devkit/build_angular/src/browser/schema.json
@@ -59,7 +59,7 @@
     "optimization": {
       "description": "Enables optimization of the build output. Including minification of scripts and styles, tree-shaking, dead-code elimination, inlining of critical CSS and fonts inlining. For more information, see https://angular.io/guide/workspace-config#optimization-configuration.",
       "x-user-analytics": 16,
-      "default": false,
+      "default": true,
       "oneOf": [
         {
           "type": "object",
@@ -143,11 +143,11 @@
       "type": "boolean",
       "description": "Build using Ahead of Time compilation.",
       "x-user-analytics": 13,
-      "default": false
+      "default": true
     },
     "sourceMap": {
       "description": "Output source maps for scripts and styles. For more information, see https://angular.io/guide/workspace-config#source-map-configuration.",
-      "default": true,
+      "default": false,
       "oneOf": [
         {
           "type": "object",
@@ -183,7 +183,7 @@
     "vendorChunk": {
       "type": "boolean",
       "description": "Generate a seperate bundle containing only vendor libraries. This option should only used for development.",
-      "default": true
+      "default": false
     },
     "commonChunk": {
       "type": "boolean",
@@ -261,7 +261,7 @@
     "outputHashing": {
       "type": "string",
       "description": "Define the output filename cache-busting hashing mode.",
-      "default": "none",
+      "default": "all",
       "enum": [
         "none",
         "all",
@@ -285,7 +285,7 @@
     "extractLicenses": {
       "type": "boolean",
       "description": "Extract all licenses in a separate file.",
-      "default": false
+      "default": true
     },
     "showCircularDependencies": {
       "type": "boolean",
@@ -295,12 +295,12 @@
     "buildOptimizer": {
       "type": "boolean",
       "description": "Enables '@angular-devkit/build-optimizer' optimizations when using the 'aot' option.",
-      "default": false
+      "default": true
     },
     "namedChunks": {
       "type": "boolean",
       "description": "Use file name for lazy loaded chunks.",
-      "default": true
+      "default": false
     },
     "subresourceIntegrity": {
       "type": "boolean",

--- a/packages/angular_devkit/build_angular/src/browser/tests/options/extract-licenses_spec.ts
+++ b/packages/angular_devkit/build_angular/src/browser/tests/options/extract-licenses_spec.ts
@@ -32,14 +32,14 @@ describeBuilder(buildWebpackBrowser, BROWSER_BUILDER_INFO, (harness) => {
       harness.expectFile('dist/3rdpartylicenses.txt').toNotExist();
     });
 
-    it(`should not generate '3rdpartylicenses.txt' when 'extractLicenses' is not set`, async () => {
+    it(`should generate '3rdpartylicenses.txt' when 'extractLicenses' is not set`, async () => {
       harness.useTarget('build', {
         ...BASE_OPTIONS,
       });
 
       const { result } = await harness.executeOnce();
       expect(result?.success).toBe(true);
-      harness.expectFile('dist/3rdpartylicenses.txt').toNotExist();
+      harness.expectFile('dist/3rdpartylicenses.txt').content.toContain('MIT');
     });
   });
 });

--- a/packages/angular_devkit/build_angular/src/browser/tests/options/output-hashing_spec.ts
+++ b/packages/angular_devkit/build_angular/src/browser/tests/options/output-hashing_spec.ts
@@ -40,7 +40,7 @@ describeBuilder(buildWebpackBrowser, BROWSER_BUILDER_INFO, (harness) => {
       expect(harness.hasFileMatch('dist', /spectrum\.[0-9a-f]{20}\.png$/)).toBeTrue();
     });
 
-    it(`doesn't hash any filenames when not set`, async () => {
+    it(`hashes all filenames when not set`, async () => {
       await harness.writeFile(
         'src/styles.css',
         `h1 { background: url('./spectrum.png')}`,
@@ -54,11 +54,11 @@ describeBuilder(buildWebpackBrowser, BROWSER_BUILDER_INFO, (harness) => {
       const { result } = await harness.executeOnce();
       expect(result?.success).toBe(true);
 
-      expect(harness.hasFileMatch('dist', /runtime\.[0-9a-f]{20}\.js$/)).toBeFalse();
-      expect(harness.hasFileMatch('dist', /main\.[0-9a-f]{20}\.js$/)).toBeFalse();
-      expect(harness.hasFileMatch('dist', /polyfills\.[0-9a-f]{20}\.js$/)).toBeFalse();
-      expect(harness.hasFileMatch('dist', /styles\.[0-9a-f]{20}\.css$/)).toBeFalse();
-      expect(harness.hasFileMatch('dist', /spectrum\.[0-9a-f]{20}\.png$/)).toBeFalse();
+      expect(harness.hasFileMatch('dist', /runtime\.[0-9a-f]{20}\.js$/)).toBeTrue();
+      expect(harness.hasFileMatch('dist', /main\.[0-9a-f]{20}\.js$/)).toBeTrue();
+      expect(harness.hasFileMatch('dist', /polyfills\.[0-9a-f]{20}\.js$/)).toBeTrue();
+      expect(harness.hasFileMatch('dist', /styles\.[0-9a-f]{20}\.css$/)).toBeTrue();
+      expect(harness.hasFileMatch('dist', /spectrum\.[0-9a-f]{20}\.png$/)).toBeTrue();
     });
 
     it(`doesn't hash any filenames when set to "none"`, async () => {

--- a/packages/angular_devkit/build_angular/src/extract-i18n/index.ts
+++ b/packages/angular_devkit/build_angular/src/extract-i18n/index.ts
@@ -16,7 +16,7 @@ import type { ɵParsedMessage as LocalizeMessage } from '@angular/localize';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as webpack from 'webpack';
-import { Schema as BrowserBuilderOptions } from '../browser/schema';
+import { OutputHashing, Schema as BrowserBuilderOptions } from '../browser/schema';
 import { ExecutionTransformer } from '../transforms';
 import { createI18nOptions } from '../utils/i18n-options';
 import { assertCompatibleAngularVersion } from '../utils/version';
@@ -180,12 +180,15 @@ export async function execute(
       i18nFile: outFile,
       aot: true,
       progress: options.progress,
+      budgets: [],
       assets: [],
       scripts: [],
       styles: [],
       deleteOutputPath: false,
       extractLicenses: false,
       subresourceIntegrity: false,
+      outputHashing: OutputHashing.None,
+      namedChunks: true,
     },
     context,
     (wco) => {

--- a/packages/angular_devkit/build_angular/src/karma/index.ts
+++ b/packages/angular_devkit/build_angular/src/karma/index.ts
@@ -11,7 +11,7 @@ import { dirname, resolve } from 'path';
 import { Observable, from } from 'rxjs';
 import { defaultIfEmpty, switchMap } from 'rxjs/operators';
 import * as webpack from 'webpack';
-import { Schema as BrowserBuilderOptions } from '../browser/schema';
+import { OutputHashing, Schema as BrowserBuilderOptions } from '../browser/schema';
 import { ExecutionTransformer } from '../transforms';
 import { assertCompatibleAngularVersion } from '../utils/version';
 import { generateBrowserWebpackConfigFromContext } from '../utils/webpack-browser-config';
@@ -40,7 +40,18 @@ async function initialize(
     // only two properties are missing:
     // * `outputPath` which is fixed for tests
     // * `budgets` which might be incorrect due to extra dev libs
-    { ...((options as unknown) as BrowserBuilderOptions), outputPath: '', budgets: undefined },
+    {
+      ...((options as unknown) as BrowserBuilderOptions),
+      outputPath: '',
+      budgets: undefined,
+      optimization: false,
+      buildOptimizer: false,
+      aot: false,
+      vendorChunk: true,
+      namedChunks: true,
+      extractLicenses: false,
+      outputHashing: OutputHashing.None,
+    },
     context,
     wco => [
       getCommonConfig(wco),
@@ -145,7 +156,7 @@ export function execute(
             // Workaround for https://github.com/karma-runner/karma/issues/3154
             // When this workaround is removed, user projects need to be updated to use a Karma
             // version that has a fix for this issue.
-            toJSON: () => {},
+            toJSON: () => { },
             logger: context.logger,
           };
 

--- a/packages/angular_devkit/build_angular/src/server/schema.json
+++ b/packages/angular_devkit/build_angular/src/server/schema.json
@@ -31,7 +31,7 @@
     "optimization": {
       "description": "Enables optimization of the build output. Including minification of scripts and styles, tree-shaking and dead-code elimination. For more information, see https://angular.io/guide/workspace-config#optimization-configuration.",
       "x-user-analytics": 16,
-      "default": false,
+      "default": true,
       "oneOf": [
         {
           "type": "object",
@@ -73,7 +73,7 @@
     },
     "sourceMap": {
       "description": "Output source maps for scripts and styles. For more information, see https://angular.io/guide/workspace-config#source-map-configuration.",
-      "default": true,
+      "default": false,
       "oneOf": [
         {
           "type": "object",
@@ -162,7 +162,7 @@
     "outputHashing": {
       "type": "string",
       "description": "Define the output filename cache-busting hashing mode.",
-      "default": "none",
+      "default": "media",
       "enum": [
         "none",
         "all",
@@ -192,7 +192,7 @@
     "namedChunks": {
       "type": "boolean",
       "description": "Use file name for lazy loaded chunks.",
-      "default": true
+      "default": false
     },
     "bundleDependencies": {
       "description": "Which external dependencies to bundle into the bundle. By default, all of node_modules will be bundled.",

--- a/packages/angular_devkit/build_angular/src/utils/normalize-optimization.ts
+++ b/packages/angular_devkit/build_angular/src/utils/normalize-optimization.ts
@@ -13,7 +13,7 @@ export type NormalizedOptimizationOptions = Required<Omit<OptimizationClass, 'fo
   styles: StylesClass,
 };
 
-export function normalizeOptimization(optimization: OptimizationUnion): NormalizedOptimizationOptions {
+export function normalizeOptimization(optimization: OptimizationUnion = true): NormalizedOptimizationOptions {
   if (typeof optimization === 'object') {
     return {
       scripts: !!optimization.scripts,

--- a/packages/angular_devkit/build_angular/src/utils/normalize-optimization.ts
+++ b/packages/angular_devkit/build_angular/src/utils/normalize-optimization.ts
@@ -13,7 +13,7 @@ export type NormalizedOptimizationOptions = Required<Omit<OptimizationClass, 'fo
   styles: StylesClass,
 };
 
-export function normalizeOptimization(optimization: OptimizationUnion = false): NormalizedOptimizationOptions {
+export function normalizeOptimization(optimization: OptimizationUnion): NormalizedOptimizationOptions {
   if (typeof optimization === 'object') {
     return {
       scripts: !!optimization.scripts,

--- a/packages/schematics/angular/migrations/migration-collection.json
+++ b/packages/schematics/angular/migrations/migration-collection.json
@@ -125,11 +125,6 @@
       "factory": "./update-11/update-dependencies",
       "description": "Update workspace dependencies to match a new v11 project."
     },
-    "update-angular-config-v12": {
-      "version": "12.0.0-next.0",
-      "factory": "./update-12/update-angular-config",
-      "description": "Remove deprecated options from 'angular.json' that are no longer present in v12."
-    },
     "update-zonejs": {
       "version": "12.0.0-next.1",
       "factory": "./update-12/update-zonejs",
@@ -139,6 +134,11 @@
       "version": "12.0.0-next.2",
       "factory": "./update-12/remove-emit-decorator-metadata",
       "description": "Remove 'emitDecoratorMetadata' TypeScript compiler option. Decorator metadata is no longer needed by Angular. Read more about this here: https://www.typescriptlang.org/docs/handbook/decorators.html#metadata"
+    },
+    "update-angular-config-v12": {
+      "version": "12.0.0-next.3",
+      "factory": "./update-12/update-angular-config",
+      "description": "Remove deprecated options from 'angular.json' that are no longer present in v12."
     }
   }
 }

--- a/packages/schematics/angular/migrations/update-12/update-angular-config.ts
+++ b/packages/schematics/angular/migrations/update-12/update-angular-config.ts
@@ -6,19 +6,68 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import { JsonValue, workspaces } from '@angular-devkit/core';
 import { Rule } from '@angular-devkit/schematics';
 import { allTargetOptions, allWorkspaceTargets, updateWorkspace } from '../../utility/workspace';
+
+type BuilderOptionsType = Readonly<[optionName: string, oldDefault: JsonValue | undefined, newDefault: JsonValue | undefined][]>;
+
+const BrowserBuilderOptions: BuilderOptionsType = [
+  ['aot', false, true],
+  ['vendorChunk', true, false],
+  ['extractLicenses', true, false],
+  ['buildOptimizer', false, true],
+  ['sourceMap', true, false],
+  ['optimization', false, true],
+  ['namedChunks', false, true],
+  ['outputHashing', 'none', 'all'],
+];
+
+const ServerBuilderOptions: BuilderOptionsType = [
+  ['sourceMap', true, false],
+  ['optimization', false, true],
+  ['outputHashing', 'none', 'media'],
+];
 
 export default function (): Rule {
   return updateWorkspace(workspace => {
     for (const [, target] of allWorkspaceTargets(workspace)) {
-      if (!target.builder.startsWith('@angular-devkit/build-angular')) {
-        continue;
-      }
+      // Only interested in Angular Devkit broweser and server builders
+      if (target?.builder === '@angular-devkit/build-angular:server') {
+        updateOptions(target, ServerBuilderOptions);
+      } else if (target?.builder === '@angular-devkit/build-angular:browser') {
+        updateOptions(target, BrowserBuilderOptions);
 
-      for (const [, options] of allTargetOptions(target)) {
-        delete options.experimentalRollupPass;
+        for (const [, options] of allTargetOptions(target)) {
+          delete options.experimentalRollupPass;
+        }
       }
     }
   });
+}
+
+function updateOptions(
+  target: workspaces.TargetDefinition, optionsToUpdate: typeof ServerBuilderOptions | typeof BrowserBuilderOptions,
+): void {
+  if (!target.options) {
+    target.options = {};
+  }
+
+  const configurationOptions = target.configurations && Object.values(target.configurations);
+
+  for (const [optionName, oldDefault, newDefault] of optionsToUpdate) {
+    let value = target.options[optionName];
+    if (value === newDefault) {
+      // Value is same as new default
+      delete target.options[optionName];
+    } else if (value === undefined) {
+      // Value is not defined, hence the default in the builder was used.
+      target.options[optionName] = oldDefault;
+      value = oldDefault;
+    }
+
+    // Remove overrides in configurations which are no longer needed.
+    configurationOptions?.filter(o => o && o[optionName] === value)
+      .forEach(o => o && delete o[optionName]);
+  }
 }

--- a/packages/schematics/angular/migrations/update-12/update-angular-config_spec.ts
+++ b/packages/schematics/angular/migrations/update-12/update-angular-config_spec.ts
@@ -27,33 +27,20 @@ function createWorkSpaceConfig(tree: UnitTestTree) {
           build: {
             builder: Builders.Browser,
             options: {
-              scripts: [
-                { lazy: true, name: 'bundle-1.js' },
-              ],
+              aot: true,
+              optimization: true,
               experimentalRollupPass: false,
-              sourceMaps: true,
               buildOptimizer: false,
               // tslint:disable-next-line:no-any
             } as any,
             configurations: {
               one: {
                 aot: true,
-                scripts: [
-                  { lazy: true, name: 'bundle-1.js' },
-                  { lazy: false, name: 'bundle-2.js' },
-                  { inject: true, name: 'bundle-3.js' },
-                  'bundle-4.js',
-                ],
-                styles: [
-                  { lazy: true, name: 'bundle-1.css' },
-                  { lazy: false, name: 'bundle-2.css' },
-                  { inject: true, name: 'bundle-3.css' },
-                  'bundle-3.css',
-                ],
               },
               two: {
                 experimentalRollupPass: true,
-                aot: true,
+                aot: false,
+                optimization: false,
               },
               // tslint:disable-next-line:no-any
             } as any,
@@ -85,9 +72,37 @@ describe(`Migration to update 'angular.json'. ${schematicName}`, () => {
     const { options, configurations } = getBuildTarget(newTree);
 
     expect(options.experimentalRollupPass).toBeUndefined();
-    expect(options.sourceMaps).toBeTrue();
+    expect(options.buildOptimizer).toBeFalse();
     expect(configurations).toBeDefined();
     expect(configurations?.one.experimentalRollupPass).toBeUndefined();
     expect(configurations?.two.experimentalRollupPass).toBeUndefined();
+  });
+
+  it(`should remove value from "options" section which value is now the new default`, async () => {
+    const newTree = await schematicRunner.runSchematicAsync(schematicName, {}, tree).toPromise();
+    const { options, configurations } = getBuildTarget(newTree);
+
+    expect(options.aot).toBeUndefined();
+    expect(configurations?.one.aot).toBeUndefined();
+    expect(configurations?.two.aot).toBeFalse();
+  });
+
+  it(`should remove value from "configuration" section when value is the same as that of "options"`, async () => {
+    const newTree = await schematicRunner.runSchematicAsync(schematicName, {}, tree).toPromise();
+    const { options, configurations } = getBuildTarget(newTree);
+
+    expect(options.aot).toBeUndefined();
+    expect(configurations?.one.aot).toBeUndefined();
+    expect(configurations?.two.aot).toBeFalse();
+  });
+
+  it(`should add value in "options" section when option was not defined`, async () => {
+    const newTree = await schematicRunner.runSchematicAsync(schematicName, {}, tree).toPromise();
+    const { options, configurations } = getBuildTarget(newTree);
+
+    expect(options.sourceMap).toBeTrue();
+    expect(configurations?.one.sourceMap).toBeUndefined();
+    expect(configurations?.two.sourceMap).toBeUndefined();
+    expect(configurations?.two.optimization).toBeFalse();
   });
 });


### PR DESCRIPTION

BFREAKING CHANGE:

A number of browser and server builder option defaults, with the aim to reduce the configuration complexity with the new production builds by default initiative.

**Browser builder**
| Option                                 | Previous default value    | New default value |
|----------------------------------------|---------------------------|-------------------|
| optimization                           | false                     | true              |
| aot                                    | false                     | true              |
| buildOptimizer                         | false                     | true              |
| sourceMap                              | true                      | false             |
| extractLicenses                        | false                     | true              |
| namedChunks                            | true                      | false             |
| vendorChunk                            | true                      | false             |
| outputHashing                          | none                      | all               |

**Server builder**
| Option        | Previous default value | New default value |
|---------------|------------------------|-------------------|
| optimization  | false                  | true              |
| sourceMap     | true                   | false             |
| outputHashing | none                   | media             |
