### PR TITLE
fix(@ngtools/webpack): resolve absolute paths in templateURLs

### DIFF
--- a/packages/ngtools/webpack/src/ivy/host.ts
+++ b/packages/ngtools/webpack/src/ivy/host.ts
@@ -41,7 +41,7 @@ export function augmentHostWithResources(
   };
 
   resourceHost.resourceNameToFileName = function (resourceName: string, containingFile: string) {
-    return path.join(path.dirname(containingFile), resourceName);
+    return path.resolve(path.dirname(containingFile), resourceName);
   };
 
   resourceHost.getModifiedResourceFiles = function () {


### PR DESCRIPTION
Closes #20162