### PR TITLE
test(@angular/cli): minimize project changes during E2E project CI setup

### DIFF
--- a/tests/legacy-cli/e2e/tests/generate/application/application-basic.ts
+++ b/tests/legacy-cli/e2e/tests/generate/application/application-basic.ts
@@ -7,5 +7,5 @@ export default function() {
   return ng('generate', 'application', 'app2')
     .then(() => expectFileToMatch('angular.json', /\"app2\":/))
     .then(() => useCIChrome('projects/app2'))
-    .then(() => ng('test', 'app2', '--watch=false', '--browsers=ChromeHeadlessCI'));
+    .then(() => ng('test', 'app2', '--watch=false'));
 }

--- a/tests/legacy-cli/e2e/tests/generate/library/library-basic.ts
+++ b/tests/legacy-cli/e2e/tests/generate/library/library-basic.ts
@@ -7,5 +7,5 @@ export default function () {
     .then(() => expectFileToMatch('angular.json', /\"my-lib\":/))
     .then(() => useCIChrome('projects/my-lib'))
     .then(() => ng('build', 'my-lib'))
-    .then(() => ng('test', 'my-lib', '--watch=false', '--browsers=ChromeHeadlessCI'));
+    .then(() => ng('test', 'my-lib', '--watch=false'));
 }


### PR DESCRIPTION
This change removes the attempted addition of the `karma-chrome-launcher` package which is already present in new projects.
The karma configuration custom launcher section is also no longer added and instead `ChromeHeadless` is configured as the default browser which removes the need to modify the Angular workspace configuration to add the custom browser launcher.