### PR TITLE
refactor(@angular-devkit/core): deprecate unused utility functions

### DIFF
--- a/packages/angular_devkit/core/src/utils/array.ts
+++ b/packages/angular_devkit/core/src/utils/array.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/** @deprecated Since v12.0, unused by the Angular tooling */
 export function clean<T>(array: Array<T | undefined>): Array<T> {
   return array.filter(x => x !== undefined) as Array<T>;
 }

--- a/packages/angular_devkit/core/src/utils/object.ts
+++ b/packages/angular_devkit/core/src/utils/object.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/** @deprecated Since v12.0, unused by the Angular tooling */
 export function mapObject<T, V>(obj: { [k: string]: T },
                                 mapper: (k: string, v: T) => V): { [k: string]: V } {
   return Object.keys(obj).reduce((acc: { [k: string]: V }, k: string) => {


### PR DESCRIPTION
The `clean` and `mapObject` utility functions are unused by the Angular CLI.