### PR TITLE
 feat(@angular-devkit/architect): add implementation for defaultConfiguration

### DIFF
--- a/etc/api/angular_devkit/core/src/_golden-api.d.ts
+++ b/etc/api/angular_devkit/core/src/_golden-api.d.ts
@@ -978,6 +978,7 @@ export declare class SynchronousDelegateExpectedException extends BaseException 
 export interface TargetDefinition {
     builder: string;
     configurations?: Record<string, Record<string, JsonValue | undefined> | undefined>;
+    defaultConfiguration?: string;
     options?: Record<string, JsonValue | undefined>;
 }
 

--- a/packages/angular/cli/lib/config/schema.json
+++ b/packages/angular/cli/lib/config/schema.json
@@ -496,6 +496,10 @@
                     ]
                   }
                 },
+                "defaultConfiguration": {
+                  "type": "string",
+                  "description": "A default named configuration to use when a target configuration is not provided."
+                },
                 "options": {
                   "type": "object"
                 },
@@ -516,6 +520,10 @@
               "properties": {
                 "builder": { "const": "@angular-devkit/build-angular:app-shell" },
                 "options": { "$ref": "#/definitions/targetOptions/definitions/appShell" },
+                "defaultConfiguration": {
+                  "type": "string",
+                  "description": "A default named configuration to use when a target configuration is not provided."
+                },
                 "configurations": {
                   "type": "object",
                   "additionalProperties": { "$ref": "#/definitions/targetOptions/definitions/appShell" }
@@ -527,6 +535,10 @@
               "properties": {
                 "builder": { "const": "@angular-devkit/build-angular:browser" },
                 "options": { "$ref": "#/definitions/targetOptions/definitions/browser" },
+                "defaultConfiguration": {
+                  "type": "string",
+                  "description": "A default named configuration to use when a target configuration is not provided."
+                },
                 "configurations": {
                   "type": "object",
                   "additionalProperties": { "$ref": "#/definitions/targetOptions/definitions/browser" }
@@ -538,6 +550,10 @@
               "properties": {
                 "builder": { "const": "@angular-devkit/build-angular:dev-server" },
                 "options": { "$ref": "#/definitions/targetOptions/definitions/devServer" },
+                "defaultConfiguration": {
+                  "type": "string",
+                  "description": "A default named configuration to use when a target configuration is not provided."
+                },
                 "configurations": {
                   "type": "object",
                   "additionalProperties": { "$ref": "#/definitions/targetOptions/definitions/devServer" }
@@ -549,6 +565,10 @@
               "properties": {
                 "builder": { "const": "@angular-devkit/build-angular:extract-i18n" },
                 "options": { "$ref": "#/definitions/targetOptions/definitions/extracti18n" },
+                "defaultConfiguration": {
+                  "type": "string",
+                  "description": "A default named configuration to use when a target configuration is not provided."
+                },
                 "configurations": {
                   "type": "object",
                   "additionalProperties": { "$ref": "#/definitions/targetOptions/definitions/extracti18n" }
@@ -560,6 +580,10 @@
               "properties": {
                 "builder": { "const": "@angular-devkit/build-angular:karma" },
                 "options": { "$ref": "#/definitions/targetOptions/definitions/karma" },
+                "defaultConfiguration": {
+                  "type": "string",
+                  "description": "A default named configuration to use when a target configuration is not provided."
+                },
                 "configurations": {
                   "type": "object",
                   "additionalProperties": { "$ref": "#/definitions/targetOptions/definitions/karma" }
@@ -571,6 +595,10 @@
               "properties": {
                 "builder": { "const": "@angular-devkit/build-angular:protractor" },
                 "options": { "$ref": "#/definitions/targetOptions/definitions/protractor" },
+                "defaultConfiguration": {
+                  "type": "string",
+                  "description": "A default named configuration to use when a target configuration is not provided."
+                },
                 "configurations": {
                   "type": "object",
                   "additionalProperties": { "$ref": "#/definitions/targetOptions/definitions/protractor" }
@@ -582,6 +610,10 @@
               "properties": {
                 "builder": { "const": "@angular-devkit/build-angular:server" },
                 "options": { "$ref": "#/definitions/targetOptions/definitions/server" },
+                "defaultConfiguration": {
+                  "type": "string",
+                  "description": "A default named configuration to use when a target configuration is not provided."
+                },
                 "configurations": {
                   "type": "object",
                   "additionalProperties": { "$ref": "#/definitions/targetOptions/definitions/server" }
@@ -593,6 +625,10 @@
               "properties": {
                 "builder": { "const": "@angular-devkit/build-angular:tslint" },
                 "options": { "$ref": "#/definitions/targetOptions/definitions/tslint" },
+                "defaultConfiguration": {
+                  "type": "string",
+                  "description": "A default named configuration to use when a target configuration is not provided."
+                },
                 "configurations": {
                   "type": "object",
                   "additionalProperties": { "$ref": "#/definitions/targetOptions/definitions/tslint" }

--- a/packages/angular_devkit/architect/node/node-modules-architect-host.ts
+++ b/packages/angular_devkit/architect/node/node-modules-architect-host.ts
@@ -30,6 +30,7 @@ export interface WorkspaceHost {
   getMetadata(project: string): Promise<json.JsonObject>;
   getOptions(project: string, target: string, configuration?: string): Promise<json.JsonObject>;
   hasTarget(project: string, target: string): Promise<boolean>;
+  getDefaultConfigurationName(project: string, target: string): Promise<string | undefined>;
 }
 
 function findProjectTarget(
@@ -99,6 +100,9 @@ export class WorkspaceNodeModulesArchitectHost implements ArchitectHost<NodeModu
         async hasTarget(project, target) {
           return !!workspaceOrHost.projects.get(project)?.targets.has(target);
         },
+        async getDefaultConfigurationName(project, target) {
+          return workspaceOrHost.projects.get(project)?.targets.get(target)?.defaultConfiguration;
+        },
       };
     }
   }
@@ -166,9 +170,11 @@ export class WorkspaceNodeModulesArchitectHost implements ArchitectHost<NodeModu
     }
 
     let options = await this.workspaceHost.getOptions(target.project, target.target);
+    const targetConfiguration =
+      target.configuration || await this.workspaceHost.getDefaultConfigurationName(target.project, target.target);
 
-    if (target.configuration) {
-      const configurations = target.configuration.split(',').map((c) => c.trim());
+    if (targetConfiguration) {
+      const configurations = targetConfiguration.split(',').map((c) => c.trim());
       for (const configuration of configurations) {
         options = {
           ...options,

--- a/packages/angular_devkit/build_angular/src/testing/builder-harness.ts
+++ b/packages/angular_devkit/build_angular/src/testing/builder-harness.ts
@@ -174,6 +174,9 @@ export class BuilderHarness<T> {
 
         return this.targetName === target || this.builderTargets.has(target);
       },
+      getDefaultConfigurationName: async (_project, _target) => {
+        return undefined;
+      },
       validate: async (options, builderName) => {
         let schema;
         if (builderName === this.builderInfo.builderName) {

--- a/packages/angular_devkit/core/src/workspace/definitions.ts
+++ b/packages/angular_devkit/core/src/workspace/definitions.ts
@@ -25,7 +25,7 @@ export interface ProjectDefinition {
 export interface TargetDefinition {
   options?: Record<string, JsonValue | undefined>;
   configurations?: Record<string, Record<string, JsonValue | undefined> | undefined>;
-
+  defaultConfiguration?: string;
   builder: string;
 }
 
@@ -234,6 +234,7 @@ export class TargetDefinitionCollection extends DefinitionCollection<TargetDefin
       builder: definition.builder,
       options: definition.options,
       configurations: definition.configurations,
+      defaultConfiguration: definition.defaultConfiguration,
     };
 
     super.set(definition.name, target);

--- a/packages/angular_devkit/core/src/workspace/json/reader.ts
+++ b/packages/angular_devkit/core/src/workspace/json/reader.ts
@@ -294,7 +294,7 @@ function parseTargetsObject(
     const name = key.value;
     if (context.trackChanges) {
       targets[name] = createVirtualAstObject<TargetDefinition>(value, {
-        include: [ 'builder', 'options', 'configurations' ],
+        include: [ 'builder', 'options', 'configurations', 'defaultConfiguration' ],
         listener(op, path, node, value) {
           jsonMetadata.addChange(
             op,

--- a/packages/angular_devkit/core/src/workspace/json/writer.ts
+++ b/packages/angular_devkit/core/src/workspace/json/writer.ts
@@ -104,6 +104,9 @@ function convertJsonTarget(target: TargetDefinition): JsonObject {
     ...(isEmpty(target.configurations)
       ? {}
       : { configurations: target.configurations as JsonObject }),
+    ...(target.defaultConfiguration === undefined
+      ? {}
+      : { defaultConfiguration: target.defaultConfiguration }),
   };
 }
 

--- a/tests/legacy-cli/e2e/tests/misc/target-default-configuration.ts
+++ b/tests/legacy-cli/e2e/tests/misc/target-default-configuration.ts
@@ -23,8 +23,8 @@ export default async function () {
   // Add new configuration and set "defaultConfiguration"
   await updateJsonFile('angular.json', workspace => {
     const build = workspace.projects['test-project'].architect.build;
-    build.defaultConfiguration = 'defaultConfiguration';
-    build.configurations.defaultConfiguration = {
+    build.defaultConfiguration = 'foo';
+    build.configurations.foo = {
       sourceMap: false,
     };
   });

--- a/tests/legacy-cli/e2e/tests/misc/target-default-configuration.ts
+++ b/tests/legacy-cli/e2e/tests/misc/target-default-configuration.ts
@@ -1,0 +1,35 @@
+import { expectFileToExist } from '../../utils/fs';
+import { ng } from '../../utils/process';
+import { updateJsonFile } from '../../utils/project';
+import { expectToFail } from '../../utils/utils';
+
+export default async function () {
+  await updateJsonFile('angular.json', workspace => {
+    const build = workspace.projects['test-project'].architect.build;
+    build.defaultConfiguration = undefined;
+    build.options = {
+      ...build.options,
+      optimization: false,
+      buildOptimizer: false,
+      outputHashing: 'none',
+      sourceMap: true,
+    };
+  });
+
+  await ng('build');
+  await expectFileToExist('dist/test-project/main.js');
+  await expectFileToExist('dist/test-project/main.js.map');
+
+  // Add new configuration and set "defaultConfiguration"
+  await updateJsonFile('angular.json', workspace => {
+    const build = workspace.projects['test-project'].architect.build;
+    build.defaultConfiguration = 'defaultConfiguration';
+    build.configurations.defaultConfiguration = {
+      sourceMap: false,
+    };
+  });
+
+  await ng('build');
+  await expectFileToExist('dist/test-project/main.js');
+  await expectToFail(() => expectFileToExist('dist/test-project/main.js.map'));
+}


### PR DESCRIPTION


With this change, the architect can be configured to use a default configuration when it's not provided as part of the target.

Consider the below, where `defaultConfiguration` is configured to `production`. Running `ng build` will be invoked with "production" configuration.

```js
"build": {
  "builder": "@angular-devkit/build-angular:browser",
  "defaultConfiguration": "production",
  "options": {
      ...
  },
  "configurations": {
    "production": {
        ...
    }
  }
}
```