### PR TITLE
feat(@angular-devkit/build-angular): show warning during build when project requires IE 11 support

### DIFF
--- a/packages/schematics/angular/application/schema.json
+++ b/packages/schematics/angular/application/schema.json
@@ -113,7 +113,8 @@
     "legacyBrowsers": {
       "type": "boolean",
       "description": "Add support for legacy browsers like Internet Explorer using differential loading.",
-      "default": false
+      "default": false,
+      "x-deprecated": "Legacy browsers support is deprecated since version 12. For more information, see https://angular.io/guide/browser-support"
     }
   },
   "required": [

--- a/packages/schematics/angular/ng-new/schema.json
+++ b/packages/schematics/angular/ng-new/schema.json
@@ -135,7 +135,8 @@
     "legacyBrowsers": {
       "type": "boolean",
       "description": "Add support for legacy browsers like Internet Explorer using differential loading.",
-      "default": false
+      "default": false,
+      "x-deprecated": "Legacy browsers support is deprecated since version 12. For more information, see https://angular.io/guide/browser-support"
     },
     "packageManager": {
       "description": "The package manager used to install dependencies.",


### PR DESCRIPTION
   
    
Internet Explorer 11 support is deprecated and will be removed in future versions of the Angular CLI.