### PR TITLE
fix(@schematics/angular): remove references to the prod flag

### DIFF
--- a/integration/angular_cli/src/app/app.component.html
+++ b/integration/angular_cli/src/app/app.component.html
@@ -419,7 +419,7 @@
       <pre *ngSwitchCase="'pwa'">ng add @angular/pwa</pre>
       <pre *ngSwitchCase="'dependency'">ng add _____</pre>
       <pre *ngSwitchCase="'test'">ng test</pre>
-      <pre *ngSwitchCase="'build'">ng build --prod</pre>
+      <pre *ngSwitchCase="'build'">ng build</pre>
   </div>
 
   <!-- Links -->

--- a/integration/angular_cli/src/environments/environment.ts
+++ b/integration/angular_cli/src/environments/environment.ts
@@ -1,5 +1,5 @@
 // This file can be replaced during build by using the `fileReplacements` array.
-// `ng build --prod` replaces `environment.ts` with `environment.prod.ts`.
+// `ng build` replaces `environment.ts` with `environment.prod.ts`.
 // The list of file replacements can be found in `angular.json`.
 
 export const environment = {

--- a/packages/schematics/angular/application/files/src/environments/environment.ts.template
+++ b/packages/schematics/angular/application/files/src/environments/environment.ts.template
@@ -1,5 +1,5 @@
 // This file can be replaced during build by using the `fileReplacements` array.
-// `ng build --prod` replaces `environment.ts` with `environment.prod.ts`.
+// `ng build` replaces `environment.ts` with `environment.prod.ts`.
 // The list of file replacements can be found in `angular.json`.
 
 export const environment = {

--- a/packages/schematics/angular/application/other-files/app.component.html.template
+++ b/packages/schematics/angular/application/other-files/app.component.html.template
@@ -431,7 +431,7 @@
       <pre *ngSwitchCase="'pwa'">ng add @angular/pwa</pre>
       <pre *ngSwitchCase="'dependency'">ng add _____</pre>
       <pre *ngSwitchCase="'test'">ng test</pre>
-      <pre *ngSwitchCase="'build'">ng build --prod</pre>
+      <pre *ngSwitchCase="'build'">ng build</pre>
   </div>
 
   <!-- Links -->


### PR DESCRIPTION
As the `--prod` is now deprecated, and `ng build` uses by default the `production` configuration,
then we should remove the references to `ng build --prod` in the generated project.