### PR TITLE
feat(@schematics/angular): update several TypeScript compilation target (Syntax)

### DIFF
--- a/integration/angular_cli/e2e/tsconfig.json
+++ b/integration/angular_cli/e2e/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "../out-tsc/e2e",
     "module": "commonjs",
-    "target": "es2018",
+    "target": "es2019",
     "types": [
       "jasmine",
       "node"

--- a/integration/angular_cli/tsconfig.json
+++ b/integration/angular_cli/tsconfig.json
@@ -8,7 +8,7 @@
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "target": "es2015",
+    "target": "es2017",
     "module": "es2020",
     "typeRoots": [
       "node_modules/@types"

--- a/packages/angular_devkit/build_angular/src/browser/index.ts
+++ b/packages/angular_devkit/build_angular/src/browser/index.ts
@@ -221,14 +221,6 @@ export function buildWebpackBrowser(
         const buildBrowserFeatures = new BuildBrowserFeatures(sysProjectRoot);
         const isDifferentialLoadingNeeded = buildBrowserFeatures.isDifferentialLoadingNeeded(target);
 
-        if (target > ScriptTarget.ES2015 && isDifferentialLoadingNeeded) {
-          context.logger.warn(tags.stripIndent`
-          Warning: Using differential loading with targets ES5 and ES2016 or higher may
-          cause problems. Browsers with support for ES2015 will load the ES2016+ scripts
-          referenced with script[type="module"] but they may not support ES2016+ syntax.
-        `);
-        }
-
         checkInternetExplorerSupport(buildBrowserFeatures.supportedBrowsers, context.logger);
 
         return {

--- a/packages/angular_devkit/build_angular/src/browser/specs/allow-js_spec.ts
+++ b/packages/angular_devkit/build_angular/src/browser/specs/allow-js_spec.ts
@@ -31,7 +31,7 @@ describe('Browser Builder allow js', () => {
 
     host.replaceInFile(
       'tsconfig.json',
-      '"target": "es2015"',
+      '"target": "es2017"',
       '"target": "es5", "allowJs": true',
     );
 
@@ -56,7 +56,7 @@ describe('Browser Builder allow js', () => {
 
     host.replaceInFile(
       'tsconfig.json',
-      '"target": "es2015"',
+      '"target": "es2017"',
       '"target": "es5", "allowJs": true',
     );
 
@@ -83,7 +83,7 @@ describe('Browser Builder allow js', () => {
 
     host.replaceInFile(
       'tsconfig.json',
-      '"target": "es2015"',
+      '"target": "es2017"',
       '"target": "es5", "allowJs": true',
     );
 

--- a/packages/angular_devkit/build_angular/src/browser/specs/browser-support_spec.ts
+++ b/packages/angular_devkit/build_angular/src/browser/specs/browser-support_spec.ts
@@ -18,7 +18,7 @@ describe('Browser Builder browser support', () => {
     architect = (await createArchitect(host.root())).architect;
 
     // target ES5 to disable differential loading which is not needed for the tests
-    host.replaceInFile('tsconfig.json', '"target": "es2015"', '"target": "es5"');
+    host.replaceInFile('tsconfig.json', '"target": "es2017"', '"target": "es5"');
   });
   afterEach(async () => host.restore().toPromise());
 

--- a/packages/angular_devkit/build_angular/src/browser/specs/differential_loading_spec.ts
+++ b/packages/angular_devkit/build_angular/src/browser/specs/differential_loading_spec.ts
@@ -34,63 +34,23 @@ describe('Browser Builder with differential loading', () => {
       'favicon.ico',
       'index.html',
 
-      'main-es2015.js',
-      'main-es2015.js.map',
+      'main-es2017.js',
+      'main-es2017.js.map',
       'main-es5.js',
       'main-es5.js.map',
 
-      'polyfills-es2015.js',
-      'polyfills-es2015.js.map',
+      'polyfills-es2017.js',
+      'polyfills-es2017.js.map',
       'polyfills-es5.js',
       'polyfills-es5.js.map',
 
-      'runtime-es2015.js',
-      'runtime-es2015.js.map',
+      'runtime-es2017.js',
+      'runtime-es2017.js.map',
       'runtime-es5.js',
       'runtime-es5.js.map',
 
-      'vendor-es2015.js',
-      'vendor-es2015.js.map',
-      'vendor-es5.js',
-      'vendor-es5.js.map',
-
-      'styles.css',
-      'styles.css.map',
-    ] as PathFragment[];
-
-    expect(Object.keys(files)).toEqual(jasmine.arrayWithExactContents(expectedOutputs));
-  });
-
-  it('emits all the neccessary files for target of ES2016', async () => {
-    host.replaceInFile(
-      'tsconfig.json',
-      '"target": "es2015",',
-      `"target": "es2016",`,
-    );
-
-    const { files } = await browserBuild(architect, host, target);
-
-    const expectedOutputs = [
-      'favicon.ico',
-      'index.html',
-
-      'main-es2016.js',
-      'main-es2016.js.map',
-      'main-es5.js',
-      'main-es5.js.map',
-
-      'polyfills-es2016.js',
-      'polyfills-es2016.js.map',
-      'polyfills-es5.js',
-      'polyfills-es5.js.map',
-
-      'runtime-es2016.js',
-      'runtime-es2016.js.map',
-      'runtime-es5.js',
-      'runtime-es5.js.map',
-
-      'vendor-es2016.js',
-      'vendor-es2016.js.map',
+      'vendor-es2017.js',
+      'vendor-es2017.js.map',
       'vendor-es5.js',
       'vendor-es5.js.map',
 
@@ -104,7 +64,7 @@ describe('Browser Builder with differential loading', () => {
   it('emits all the neccessary files for target of ESNext', async () => {
     host.replaceInFile(
       'tsconfig.json',
-      '"target": "es2015",',
+      '"target": "es2017",',
       `"target": "esnext",`,
     );
 
@@ -148,17 +108,17 @@ describe('Browser Builder with differential loading', () => {
       'favicon.ico',
       'index.html',
 
-      'main-es2015.js',
-      'main-es2015.js.map',
+      'main-es2017.js',
+      'main-es2017.js.map',
 
-      'polyfills-es2015.js',
-      'polyfills-es2015.js.map',
+      'polyfills-es2017.js',
+      'polyfills-es2017.js.map',
 
-      'runtime-es2015.js',
-      'runtime-es2015.js.map',
+      'runtime-es2017.js',
+      'runtime-es2017.js.map',
 
-      'vendor-es2015.js',
-      'vendor-es2015.js.map',
+      'vendor-es2017.js',
+      'vendor-es2017.js.map',
 
       'styles.css',
       'styles.css.map',
@@ -173,21 +133,21 @@ describe('Browser Builder with differential loading', () => {
       vendorChunk: false,
     });
     expect(await files['main-es5.js']).not.toContain('const ');
-    expect(await files['main-es2015.js']).toContain('const ');
+    expect(await files['main-es2017.js']).toContain('const ');
   });
 
   it('wraps ES5 scripts in an IIFE', async () => {
     const { files } = await browserBuild(architect, host, target, { optimization: false });
     expect(await files['main-es5.js']).toMatch(/^\(function \(\) \{/);
-    expect(await files['main-es2015.js']).not.toMatch(/^\(function \(\) \{/);
+    expect(await files['main-es2017.js']).not.toMatch(/^\(function \(\) \{/);
   });
 
   it('uses the right zone.js variant', async () => {
     const { files } = await browserBuild(architect, host, target, { optimization: false });
     expect(await files['polyfills-es5.js']).toContain('zone.js/plugins/zone-legacy');
     expect(await files['polyfills-es5.js']).toContain('registerElementPatch');
-    expect(await files['polyfills-es2015.js']).not.toContain('zone.js/plugins/zone-legacy');
-    expect(await files['polyfills-es2015.js']).not.toContain('registerElementPatch');
+    expect(await files['polyfills-es2017.js']).not.toContain('zone.js/plugins/zone-legacy');
+    expect(await files['polyfills-es2017.js']).not.toContain('registerElementPatch');
   });
 
   it('adds `type="module"` when differential loading is needed', async () => {
@@ -200,10 +160,10 @@ describe('Browser Builder with differential loading', () => {
 
     const { files } = await browserBuild(architect, host, target, { watch: true });
     expect(await files['index.html']).toContain(
-      '<script src="runtime-es2015.js" type="module"></script>' +
-      '<script src="polyfills-es2015.js" type="module"></script>' +
-      '<script src="vendor-es2015.js" type="module"></script>' +
-      '<script src="main-es2015.js" type="module"></script>',
+      '<script src="runtime-es2017.js" type="module"></script>' +
+      '<script src="polyfills-es2017.js" type="module"></script>' +
+      '<script src="vendor-es2017.js" type="module"></script>' +
+      '<script src="main-es2017.js" type="module"></script>',
     );
   });
 });

--- a/packages/angular_devkit/build_angular/src/browser/specs/lazy-module_spec.ts
+++ b/packages/angular_devkit/build_angular/src/browser/specs/lazy-module_spec.ts
@@ -131,8 +131,6 @@ describe('Browser Builder lazy modules', () => {
       'src/lazy-module.ts': 'export const value = 42;',
       'src/main.ts': `import('./lazy-module');`,
     });
-    // Using `import()` in TS require targetting `esnext` modules.
-    host.replaceInFile('src/tsconfig.app.json', `"module": "es2015"`, `"module": "esnext"`);
 
     const { files } = await browserBuild(architect, host, target);
     expect(files['lazy-module.js']).not.toBeUndefined();
@@ -146,7 +144,6 @@ describe('Browser Builder lazy modules', () => {
         import(/*webpackChunkName: '[request]'*/'./lazy-' + lazyFileName);
       `,
     });
-    host.replaceInFile('src/tsconfig.app.json', `"module": "es2015"`, `"module": "esnext"`);
 
     const { files } = await browserBuild(architect, host, target);
     expect(files['lazy-module.js']).not.toBeUndefined();

--- a/packages/angular_devkit/build_angular/src/browser/specs/optimization-level_spec.ts
+++ b/packages/angular_devkit/build_angular/src/browser/specs/optimization-level_spec.ts
@@ -26,8 +26,8 @@ describe('Browser Builder optimization level', () => {
     expect(await files['main.js']).not.toContain('AppComponent');
   });
 
-  it('tsconfig target changes optimizations to use ES2015', async () => {
-    host.replaceInFile('tsconfig.json', '"target": "es5"', '"target": "es2015"');
+  it('tsconfig target changes optimizations to use es2017', async () => {
+    host.replaceInFile('tsconfig.json', '"target": "es5"', '"target": "es2017"');
 
     const overrides = { optimization: true };
     const { files } = await browserBuild(architect, host, target, overrides);

--- a/packages/angular_devkit/build_angular/src/browser/specs/resolve-json-module_spec.ts
+++ b/packages/angular_devkit/build_angular/src/browser/specs/resolve-json-module_spec.ts
@@ -30,7 +30,7 @@ describe('Browser Builder resolve json module', () => {
 
     host.replaceInFile(
       'tsconfig.json',
-      '"target": "es2015"',
+      '"target": "es2017"',
       '"target": "es5", "resolveJsonModule": true',
     );
 

--- a/packages/angular_devkit/build_angular/src/browser/specs/scripts-array_spec.ts
+++ b/packages/angular_devkit/build_angular/src/browser/specs/scripts-array_spec.ts
@@ -81,13 +81,13 @@ describe('Browser Builder scripts array', () => {
       'lazy-script.js': 'lazy-script',
       'renamed-script.js': 'pre-rename-script',
       'renamed-lazy-script.js': 'pre-rename-lazy-script',
-      'main-es2015.js': 'input-script',
-      'index.html': '<script src="runtime-es2015.js" type="module"></script>'
-        + '<script src="polyfills-es2015.js" type="module"></script>'
+      'main-es2017.js': 'input-script',
+      'index.html': '<script src="runtime-es2017.js" type="module"></script>'
+        + '<script src="polyfills-es2017.js" type="module"></script>'
         + '<script src="scripts.js" defer></script>'
         + '<script src="renamed-script.js" defer></script>'
-        + '<script src="vendor-es2015.js" type="module"></script>'
-        + '<script src="main-es2015.js" type="module"></script>',
+        + '<script src="vendor-es2017.js" type="module"></script>'
+        + '<script src="main-es2017.js" type="module"></script>',
     };
 
     host.writeMultipleFiles(scripts);

--- a/packages/angular_devkit/build_angular/src/browser/specs/styles_spec.ts
+++ b/packages/angular_devkit/build_angular/src/browser/specs/styles_spec.ts
@@ -306,7 +306,7 @@ describe('Browser Builder styles', () => {
     });
 
     // Set to target to ES5 to avoid differential loading and unnecessary testing time
-    host.replaceInFile('tsconfig.json', '"target": "es2015"', '"target": "es5"');
+    host.replaceInFile('tsconfig.json', '"target": "es2017"', '"target": "es5"');
 
     const overrides = { extractCss: true, optimization: false };
     const { files } = await browserBuild(architect, host, target, overrides);
@@ -346,7 +346,7 @@ describe('Browser Builder styles', () => {
     });
 
     // Set target to ES5 to avoid differential loading and unnecessary testing time
-    host.replaceInFile('tsconfig.json', '"target": "es2015"', '"target": "es5"');
+    host.replaceInFile('tsconfig.json', '"target": "es2017"', '"target": "es5"');
 
     const overrides = { extractCss: true, optimization: true, styles: ['src/styles.scss'] };
     const { files } = await browserBuild(architect, host, target, overrides);

--- a/packages/angular_devkit/build_angular/src/karma/works_spec.ts
+++ b/packages/angular_devkit/build_angular/src/karma/works_spec.ts
@@ -40,16 +40,6 @@ describe('Karma Builder', () => {
     await run.stop();
   });
 
-  it('supports ES2015 target', async () => {
-    host.replaceInFile('tsconfig.json', '"target": "es5"', '"target": "es2015"');
-
-    const run = await architect.scheduleTarget(karmaTargetSpec);
-
-    await expectAsync(run.result).toBeResolvedTo(jasmine.objectContaining({ success: true }));
-
-    await run.stop();
-  });
-
   it('generates and uses global styles', async () => {
     host.writeMultipleFiles({
       'src/styles.css': 'p {display: none}',

--- a/packages/angular_devkit/build_angular/src/utils/build-browser-features.ts
+++ b/packages/angular_devkit/build_angular/src/utils/build-browser-features.ts
@@ -21,7 +21,7 @@ export class BuildBrowserFeatures {
 
   /**
    * True, when one or more browsers requires ES5
-   * support and the scirpt target is ES2015 or greater.
+   * support and the script target is ES2015 or greater.
    */
   isDifferentialLoadingNeeded(scriptTarget: ts.ScriptTarget): boolean {
     const es6TargetOrLater = scriptTarget > ts.ScriptTarget.ES5;

--- a/packages/angular_devkit/build_angular/src/utils/build-browser-features_spec.ts
+++ b/packages/angular_devkit/build_angular/src/utils/build-browser-features_spec.ts
@@ -25,22 +25,22 @@ describe('BuildBrowserFeatures', () => {
   afterEach(async () => host.restore().toPromise());
 
   describe('isDifferentialLoadingNeeded', () => {
-    it('should be true for IE 9-11 and ES2015', () => {
+    it('should be true for IE 9-11 and ES2017', () => {
       host.writeMultipleFiles({
         '.browserslistrc': 'IE 9-11',
       });
 
       const buildBrowserFeatures = new BuildBrowserFeatures(workspaceRootSysPath);
-      expect(buildBrowserFeatures.isDifferentialLoadingNeeded(ScriptTarget.ES2015)).toBe(true);
+      expect(buildBrowserFeatures.isDifferentialLoadingNeeded(ScriptTarget.ES2017)).toBe(true);
     });
 
-    it('should be false for Chrome and ES2015', () => {
+    it('should be false for Chrome and ES2017', () => {
       host.writeMultipleFiles({
         '.browserslistrc': 'last 1 chrome version',
       });
 
       const buildBrowserFeatures = new BuildBrowserFeatures(workspaceRootSysPath);
-      expect(buildBrowserFeatures.isDifferentialLoadingNeeded(ScriptTarget.ES2015)).toBe(false);
+      expect(buildBrowserFeatures.isDifferentialLoadingNeeded(ScriptTarget.ES2017)).toBe(false);
     });
 
     it('detects no need for differential loading for target is ES5', () => {
@@ -52,13 +52,13 @@ describe('BuildBrowserFeatures', () => {
       expect(buildBrowserFeatures.isDifferentialLoadingNeeded(ScriptTarget.ES5)).toBe(false);
     });
 
-    it('should be false for Safari 10.1 when target is ES2015', () => {
+    it('should be false for Safari 10.1 when target is ES2017', () => {
       host.writeMultipleFiles({
         '.browserslistrc': 'Safari 10.1',
       });
 
       const buildBrowserFeatures = new BuildBrowserFeatures(workspaceRootSysPath);
-      expect(buildBrowserFeatures.isDifferentialLoadingNeeded(ScriptTarget.ES2015)).toBe(false);
+      expect(buildBrowserFeatures.isDifferentialLoadingNeeded(ScriptTarget.ES2017)).toBe(false);
     });
   });
 

--- a/packages/angular_devkit/build_angular/src/utils/index-file/augment-index-html_spec.ts
+++ b/packages/angular_devkit/build_angular/src/utils/index-file/augment-index-html_spec.ts
@@ -67,11 +67,11 @@ describe('augment-index-html', () => {
   });
 
   it(`should emit correct script tags when having 'module' and 'non-module' js`, async () => {
-    const es2015JsFiles: FileInfo[] = [
-      { file: 'runtime-es2015.js', extension: '.js', name: 'main' },
-      { file: 'main-es2015.js', extension: '.js', name: 'main' },
-      { file: 'runtime-es2015.js', extension: '.js', name: 'polyfills' },
-      { file: 'polyfills-es2015.js', extension: '.js', name: 'polyfills' },
+    const es2017JsFiles: FileInfo[] = [
+      { file: 'runtime-es2017.js', extension: '.js', name: 'main' },
+      { file: 'main-es2017.js', extension: '.js', name: 'main' },
+      { file: 'runtime-es2017.js', extension: '.js', name: 'polyfills' },
+      { file: 'polyfills-es2017.js', extension: '.js', name: 'polyfills' },
     ];
 
     const es5JsFiles: FileInfo[] = [
@@ -87,7 +87,7 @@ describe('augment-index-html', () => {
         { file: 'styles.css', extension: '.css', name: 'styles' },
         { file: 'styles.css', extension: '.css', name: 'styles' },
       ],
-      moduleFiles: es2015JsFiles,
+      moduleFiles: es2017JsFiles,
       noModuleFiles: es5JsFiles,
     });
 
@@ -99,11 +99,11 @@ describe('augment-index-html', () => {
           <link rel="stylesheet" href="styles.css">
         </head>
         <body>
-          <script src="runtime-es2015.js" type="module"></script>
-          <script src="polyfills-es2015.js" type="module"></script>
+          <script src="runtime-es2017.js" type="module"></script>
+          <script src="polyfills-es2017.js" type="module"></script>
           <script src="runtime-es5.js" nomodule defer></script>
           <script src="polyfills-es5.js" nomodule defer></script>
-          <script src="main-es2015.js" type="module"></script>
+          <script src="main-es2017.js" type="module"></script>
           <script src="main-es5.js" nomodule defer></script>
         </body>
       </html>
@@ -113,9 +113,9 @@ describe('augment-index-html', () => {
   it(
     `should not add 'module' and 'non-module' attr to js files which are in both module formats`,
     async () => {
-      const es2015JsFiles: FileInfo[] = [
+      const es2017JsFiles: FileInfo[] = [
         { file: 'scripts.js', extension: '.js', name: 'scripts' },
-        { file: 'main-es2015.js', extension: '.js', name: 'main' },
+        { file: 'main-es2017.js', extension: '.js', name: 'main' },
       ];
 
       const es5JsFiles: FileInfo[] = [
@@ -129,7 +129,7 @@ describe('augment-index-html', () => {
           { file: 'styles.css', extension: '.css', name: 'styles' },
           { file: 'styles.css', extension: '.css', name: 'styles' },
         ],
-        moduleFiles: es2015JsFiles,
+        moduleFiles: es2017JsFiles,
         noModuleFiles: es5JsFiles,
       });
 
@@ -142,7 +142,7 @@ describe('augment-index-html', () => {
         </head>
         <body>
           <script src="scripts.js" defer></script>
-          <script src="main-es2015.js" type="module"></script>
+          <script src="main-es2017.js" type="module"></script>
           <script src="main-es5.js" nomodule defer></script>
         </body>
       </html>

--- a/packages/angular_devkit/build_angular/src/webpack/configs/typescript.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/typescript.ts
@@ -70,7 +70,6 @@ function createIvyPlugin(
     fileReplacements,
     jitMode: !aot,
     emitNgModuleScope: !optimize,
-    suppressZoneJsIncompatibilityWarning: true,
   });
 }
 
@@ -139,7 +138,6 @@ function _createAotPlugin(
     directTemplateLoading: true,
     ...options,
     compilerOptions,
-    suppressZoneJsIncompatibilityWarning: true,
   };
 
   pluginOptions = _pluginOptionsOverrides(buildOptions, pluginOptions);

--- a/packages/angular_devkit/build_angular/test/hello-world-app/tsconfig.json
+++ b/packages/angular_devkit/build_angular/test/hello-world-app/tsconfig.json
@@ -8,7 +8,7 @@
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "target": "es2015",
+    "target": "es2017",
     "module": "es2020",
     "typeRoots": [
       "node_modules/@types"

--- a/packages/angular_devkit/build_webpack/test/angular-app/tsconfig.json
+++ b/packages/angular_devkit/build_webpack/test/angular-app/tsconfig.json
@@ -8,7 +8,7 @@
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "target": "es2015",
+    "target": "es2017",
     "typeRoots": [
       "node_modules/@types"
     ],

--- a/packages/angular_devkit/build_webpack/test/basic-app/tsconfig.json
+++ b/packages/angular_devkit/build_webpack/test/basic-app/tsconfig.json
@@ -7,7 +7,7 @@
     "declaration": false,
     "moduleResolution": "node",
     "experimentalDecorators": true,
-    "target": "es2015",
+    "target": "es2017",
     "module": "esnext",
     "typeRoots": [
       "node_modules/@types"

--- a/packages/ngtools/webpack/README.md
+++ b/packages/ngtools/webpack/README.md
@@ -63,9 +63,6 @@ The loader works with webpack plugin to compile your TypeScript. It's important 
 * `i18nOutFile`. Optional and only used for View Engine compilations. The name of the file to write extractions to.
 * `i18nOutFormat`. Optional and only used for View Engine compilations. The format of the localization file where extractions will be written to.
 * `locale`. Optional and only used for View Engine compilations. Locale to use for i18n.
-* `suppressZoneJsIncompatibilityWarning`. Optional, defaults to `false`. A Zone.js incompatibility warning is shown when the compilation target is ES2017+. Zone.js does not support native async/await in ES2017+. These blocks are not intercepted by zone.js and will not triggering change detection. 
-See https://github.com/angular/zone.js/pull/1140 for more information.
-
 ## Features
 The benefits and ability of using [`@ngtools/webpack`](https://www.npmjs.com/~ngtools) standalone from the Angular CLI as presented in [Stephen Fluin's Angular CLI talk](https://youtu.be/uBRK6cTr4Vk?t=6m45s) at Angular Connect 2016:
 

--- a/packages/ngtools/webpack/src/angular_compiler_plugin.ts
+++ b/packages/ngtools/webpack/src/angular_compiler_plugin.ts
@@ -252,18 +252,6 @@ export class AngularCompilerPlugin {
       this._platformTransformers = options.platformTransformers;
     }
 
-    if (
-      !this.options.suppressZoneJsIncompatibilityWarning &&
-      this._compilerOptions.target !== undefined &&
-      this._compilerOptions.target >= ts.ScriptTarget.ES2017
-    ) {
-      this._warnings.push(
-        'Zone.js does not support native async/await in ES2017+.\n' +
-        'These blocks are not intercepted by zone.js and will not triggering change detection.\n' +
-        'See: https://github.com/angular/zone.js/pull/1140 for more information.',
-      );
-    }
-
     if (this._compilerOptions.strictMetadataEmit) {
       this._warnings.push(
         `Using Angular compiler option 'strictMetadataEmit' for applications might cause undefined behavior.`,

--- a/packages/ngtools/webpack/src/interfaces.ts
+++ b/packages/ngtools/webpack/src/interfaces.ts
@@ -55,12 +55,4 @@ export interface AngularCompilerPluginOptions {
 
   host?: virtualFs.Host<fs.Stats>;
   platformTransformers?: ts.TransformerFactory<ts.SourceFile>[];
-
-  /**
-   * Suppress Zone.js incompatibility warning when using ES2017+.
-   * Zone.js does not support native async/await in ES2017+.
-   * These blocks are not intercepted by zone.js and will not triggering change detection.
-   * @see https://github.com/angular/zone.js/pull/1140
-  */
-  suppressZoneJsIncompatibilityWarning?: boolean;
 }

--- a/packages/ngtools/webpack/src/ivy/plugin.ts
+++ b/packages/ngtools/webpack/src/ivy/plugin.ts
@@ -44,7 +44,6 @@ export interface AngularPluginOptions {
   directTemplateLoading: boolean;
   emitClassMetadata: boolean;
   emitNgModuleScope: boolean;
-  suppressZoneJsIncompatibilityWarning: boolean;
   jitMode: boolean;
 }
 
@@ -105,7 +104,6 @@ export class AngularWebpackPlugin {
       substitutions: {},
       directTemplateLoading: true,
       tsconfig: 'tsconfig.json',
-      suppressZoneJsIncompatibilityWarning: false,
       ...options,
     };
   }
@@ -378,19 +376,6 @@ export class AngularWebpackPlugin {
     compilerOptions.allowEmptyCodegenFiles = false;
     compilerOptions.annotationsAs = 'decorators';
     compilerOptions.enableResourceInlining = false;
-
-    if (
-      !this.pluginOptions.suppressZoneJsIncompatibilityWarning &&
-      compilerOptions.target &&
-      compilerOptions.target >= ts.ScriptTarget.ES2017
-    ) {
-      addWarning(
-        compilation,
-        'Zone.js does not support native async/await in ES2017+.\n' +
-          'These blocks are not intercepted by zone.js and will not triggering change detection.\n' +
-          'See: https://github.com/angular/zone.js/pull/1140 for more information.',
-      );
-    }
 
     return { compilerOptions, rootNames, errors };
   }

--- a/packages/schematics/angular/e2e/files/tsconfig.json.template
+++ b/packages/schematics/angular/e2e/files/tsconfig.json.template
@@ -4,7 +4,7 @@
   "compilerOptions": {
     "outDir": "<%= relativePathToWorkspaceRoot %>/out-tsc/e2e",
     "module": "commonjs",
-    "target": "es2018",
+    "target": "es2019",
     "types": [
       "jasmine",
       "node"

--- a/packages/schematics/angular/universal/files/root/tsconfig.server.json.template
+++ b/packages/schematics/angular/universal/files/root/tsconfig.server.json.template
@@ -3,7 +3,7 @@
   "extends": "./<%= tsConfigExtends %>",
   "compilerOptions": {
     "outDir": "<%= relativePathToWorkspaceRoot %>/out-tsc/server",
-    "target": "es2016",
+    "target": "es2019",
     "types": [
       "node"
     ]

--- a/packages/schematics/angular/universal/index_spec.ts
+++ b/packages/schematics/angular/universal/index_spec.ts
@@ -93,7 +93,7 @@ describe('Universal Schematic', () => {
       extends: './tsconfig.app.json',
       compilerOptions: {
         outDir: './out-tsc/server',
-        target: 'es2016',
+        target: 'es2019',
         types: ['node'],
       },
       files: [
@@ -119,7 +119,7 @@ describe('Universal Schematic', () => {
       extends: './tsconfig.app.json',
       compilerOptions: {
         outDir: '../../out-tsc/server',
-        target: 'es2016',
+        target: 'es2019',
         types: ['node'],
       },
       files: [

--- a/packages/schematics/angular/workspace/files/tsconfig.json.template
+++ b/packages/schematics/angular/workspace/files/tsconfig.json.template
@@ -14,7 +14,7 @@
     "experimentalDecorators": true,
     "moduleResolution": "node",
     "importHelpers": true,
-    "target": "es2015",
+    "target": "es2017",
     "module": "es2020",
     "lib": [
       "es2018",

--- a/tests/legacy-cli/e2e/tests/basic/build.ts
+++ b/tests/legacy-cli/e2e/tests/basic/build.ts
@@ -21,14 +21,14 @@ export default async function() {
   // Production build
   const { stderr: stderrProgress, stdout } = await ng('build', '--progress');
   await expectFileToMatch('dist/test-project/index.html', /main-es5\.[a-zA-Z0-9]{20}\.js/);
-  await expectFileToMatch('dist/test-project/index.html', /main-es2015\.[a-zA-Z0-9]{20}\.js/);
+  await expectFileToMatch('dist/test-project/index.html', /main-es2017\.[a-zA-Z0-9]{20}\.js/);
 
   if (!stdout.includes('Initial ES5 Total')) {
     throw new Error(`Expected stdout not to contain 'Initial ES5 Total' but it did.\n${stdout}`);
   }
 
-  if (!stdout.includes('Initial ES2015 Total')) {
-    throw new Error(`Expected stdout not to contain 'Initial ES2015 Total' but it did.\n${stdout}`);
+  if (!stdout.includes('Initial ES2017 Total')) {
+    throw new Error(`Expected stdout not to contain 'Initial ES2017 Total' but it did.\n${stdout}`);
   }
 
   const logs: string[] = [

--- a/tests/legacy-cli/e2e/tests/build/differential-loading-sri.ts
+++ b/tests/legacy-cli/e2e/tests/build/differential-loading-sri.ts
@@ -59,13 +59,13 @@ export default async function () {
   const codeHashES5 = createHash('sha384')
     .update(await readFile('dist/first/5-es5.js'))
     .digest('base64');
-  const codeHashES2015 = createHash('sha384')
-    .update(await readFile('dist/first/5-es2015.js'))
+  const codeHashes2017 = createHash('sha384')
+    .update(await readFile('dist/first/5-es2017.js'))
     .digest('base64');
 
   await expectFileToMatch('dist/first/runtime-es5.js', 'sha384-' + codeHashES5);
-  await expectFileToMatch('dist/first/runtime-es2015.js', 'sha384-' + codeHashES2015);
+  await expectFileToMatch('dist/first/runtime-es2017.js', 'sha384-' + codeHashes2017);
 
   await expectFileToMatch('dist/second/runtime-es5.js', 'sha384-' + codeHashES5);
-  await expectFileToMatch('dist/second/runtime-es2015.js', 'sha384-' + codeHashES2015);
+  await expectFileToMatch('dist/second/runtime-es2017.js', 'sha384-' + codeHashes2017);
 }

--- a/tests/legacy-cli/e2e/tests/build/differential-loading-watch.ts
+++ b/tests/legacy-cli/e2e/tests/build/differential-loading-watch.ts
@@ -9,6 +9,6 @@ export default async function () {
   );
 
   await execAndWaitForOutputToMatch('ng', ['build', '--watch', '--configuration=development'], /Initial Total/i);
-  await expectFileToExist('dist/test-project/runtime-es2015.js');
-  await expectFileToExist('dist/test-project/main-es2015.js');
+  await expectFileToExist('dist/test-project/runtime-es2017.js');
+  await expectFileToExist('dist/test-project/main-es2017.js');
 }

--- a/tests/legacy-cli/e2e/tests/build/differential-loading.ts
+++ b/tests/legacy-cli/e2e/tests/build/differential-loading.ts
@@ -31,19 +31,19 @@ export default async function () {
   await expectFileToMatch(
     'dist/test-project/index.html',
     oneLineTrim`
-    <script src="runtime-es2015.js" type="module"></script>
+    <script src="runtime-es2017.js" type="module"></script>
     <script src="runtime-es5.js" nomodule defer></script>
     <script src="polyfills-es5.js" nomodule defer></script>
-    <script src="polyfills-es2015.js" type="module"></script>
+    <script src="polyfills-es2017.js" type="module"></script>
     <script src="scripts.js" defer></script>
     <script src="renamed-script.js" defer></script>
-    <script src="vendor-es2015.js" type="module"></script>
+    <script src="vendor-es2017.js" type="module"></script>
     <script src="vendor-es5.js" nomodule defer></script>
-    <script src="main-es2015.js" type="module"></script>
+    <script src="main-es2017.js" type="module"></script>
     <script src="main-es5.js" nomodule defer></script>
   `,
   );
 
-  await expectFileToMatch('dist/test-project/vendor-es2015.js', /class \w{constructor\(/);
+  await expectFileToMatch('dist/test-project/vendor-es2017.js', /class \w{constructor\(/);
   await expectToFail(() => expectFileToMatch('dist/test-project/vendor-es5.js', /class \w{constructor\(/));
 }

--- a/tests/legacy-cli/e2e/tests/build/polyfills.ts
+++ b/tests/legacy-cli/e2e/tests/build/polyfills.ts
@@ -24,7 +24,7 @@ export default async function () {
 
   await expectFileToMatch('dist/test-project/index.html', oneLineTrim`
     <script src="polyfills-es5.js" nomodule defer></script>
-    <script src="polyfills-es2015.js" type="module">
+    <script src="polyfills-es2017.js" type="module">
   `);
 
   const jitPolyfillSize = await getFileSize('dist/test-project/polyfills-es5.js');
@@ -38,6 +38,6 @@ export default async function () {
 
   await expectFileToMatch('dist/test-project/index.html', oneLineTrim`
     <script src="polyfills-es5.js" nomodule defer></script>
-    <script src="polyfills-es2015.js" type="module">
+    <script src="polyfills-es2017.js" type="module">
   `);
 }

--- a/tests/legacy-cli/e2e/tests/build/prod-build.ts
+++ b/tests/legacy-cli/e2e/tests/build/prod-build.ts
@@ -47,17 +47,17 @@ export default async function () {
   await expectFileToExist(join(process.cwd(), 'dist'));
   // Check for cache busting hash script src
   await expectFileToMatch('dist/test-project/index.html', /main-es5\.[0-9a-f]{20}\.js/);
-  await expectFileToMatch('dist/test-project/index.html', /main-es2015\.[0-9a-f]{20}\.js/);
+  await expectFileToMatch('dist/test-project/index.html', /main-es2017\.[0-9a-f]{20}\.js/);
   await expectFileToMatch('dist/test-project/index.html', /styles\.[0-9a-f]{20}\.css/);
   await expectFileToMatch('dist/test-project/3rdpartylicenses.txt', /MIT/);
 
   const indexContent = await readFile('dist/test-project/index.html');
   const mainES5Path = indexContent.match(/src="(main-es5\.[a-z0-9]{0,32}\.js)"/)[1];
-  const mainES2015Path = indexContent.match(/src="(main-es2015\.[a-z0-9]{0,32}\.js)"/)[1];
+  const mainES2017Path = indexContent.match(/src="(main-es2017\.[a-z0-9]{0,32}\.js)"/)[1];
 
   // Content checks
   await expectFileToMatch(`dist/test-project/${mainES5Path}`, bootstrapRegExp);
-  await expectFileToMatch(`dist/test-project/${mainES2015Path}`, bootstrapRegExp);
+  await expectFileToMatch(`dist/test-project/${mainES2017Path}`, bootstrapRegExp);
   await expectToFail(() =>
     expectFileToMatch(`dist/test-project/${mainES5Path}`, 'setNgModuleScope'),
   );
@@ -68,9 +68,9 @@ export default async function () {
   // Size checks in bytes
   if (veProject) {
     verifySize(mainES5Path, 184470);
-    verifySize(mainES2015Path, 163627);
+    verifySize(mainES2017Path, 163627);
   } else {
     verifySize(mainES5Path, 163321);
-    verifySize(mainES2015Path, 141032);
+    verifySize(mainES2017Path, 141032);
   }
 }

--- a/tests/legacy-cli/e2e/tests/build/sourcemap.ts
+++ b/tests/legacy-cli/e2e/tests/build/sourcemap.ts
@@ -23,7 +23,7 @@ export default async function () {
 
 async function testForSourceMaps(expectedNumberOfFiles: number): Promise <void> {
   await expectFileToExist('dist/test-project/main-es5.js.map');
-  await expectFileToExist('dist/test-project/main-es2015.js.map');
+  await expectFileToExist('dist/test-project/main-es2017.js.map');
 
   const files = fs.readdirSync('./dist/test-project');
 

--- a/tests/legacy-cli/e2e/tests/build/worker.ts
+++ b/tests/legacy-cli/e2e/tests/build/worker.ts
@@ -32,18 +32,18 @@ export default async function () {
   await ng('build', '--configuration=development');
   await expectFileToExist('dist/test-project/0-es5.worker.js');
   await expectFileToMatch('dist/test-project/main-es5.js', '0-es5.worker.js');
-  await expectToFail(() => expectFileToMatch('dist/test-project/main-es5.js', '0-es2015.worker.js'));
-  await expectFileToExist('dist/test-project/0-es2015.worker.js');
-  await expectFileToMatch('dist/test-project/main-es2015.js', '0-es2015.worker.js');
-  await expectToFail(() => expectFileToMatch('dist/test-project/main-es2015.js', '0-es5.worker.js'));
+  await expectToFail(() => expectFileToMatch('dist/test-project/main-es5.js', '0-es2017.worker.js'));
+  await expectFileToExist('dist/test-project/0-es2017.worker.js');
+  await expectFileToMatch('dist/test-project/main-es2017.js', '0-es2017.worker.js');
+  await expectToFail(() => expectFileToMatch('dist/test-project/main-es2017.js', '0-es5.worker.js'));
 
   await ng('build', '--output-hashing=none');
   await expectFileToExist('dist/test-project/0-es5.worker.js');
   await expectFileToMatch('dist/test-project/main-es5.js', '0-es5.worker.js');
-  await expectToFail(() => expectFileToMatch('dist/test-project/main-es5.js', '0-es2015.worker.js'));
-  await expectFileToExist('dist/test-project/0-es2015.worker.js');
-  await expectFileToMatch('dist/test-project/main-es2015.js', '0-es2015.worker.js');
-  await expectToFail(() => expectFileToMatch('dist/test-project/main-es2015.js', '0-es5.worker.js'));
+  await expectToFail(() => expectFileToMatch('dist/test-project/main-es5.js', '0-es2017.worker.js'));
+  await expectFileToExist('dist/test-project/0-es2017.worker.js');
+  await expectFileToMatch('dist/test-project/main-es2017.js', '0-es2017.worker.js');
+  await expectToFail(() => expectFileToMatch('dist/test-project/main-es2017.js', '0-es5.worker.js'));
 
   // console.warn has to be used because chrome only captures warnings and errors by default
   // https://github.com/angular/protractor/issues/2207

--- a/tests/legacy-cli/e2e/tests/i18n/ivy-localize-dl-xliff2.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/ivy-localize-dl-xliff2.ts
@@ -21,7 +21,7 @@ export async function executeTest() {
   );
 
   await updateJsonFile('tsconfig.json', config => {
-    config.compilerOptions.target = 'es2015';
+    config.compilerOptions.target = 'es2017';
     if (!config.angularCompilerOptions) {
       config.angularCompilerOptions = {};
     }
@@ -32,13 +32,13 @@ export async function executeTest() {
   await ng('build');
   for (const { lang, outputPath, translation } of langTranslations) {
     await expectFileToMatch(`${outputPath}/main-es5.js`, translation.helloPartial);
-    await expectFileToMatch(`${outputPath}/main-es2015.js`, translation.helloPartial);
+    await expectFileToMatch(`${outputPath}/main-es2017.js`, translation.helloPartial);
     await expectToFail(() => expectFileToMatch(`${outputPath}/main-es5.js`, '$localize`'));
-    await expectToFail(() => expectFileToMatch(`${outputPath}/main-es2015.js`, '$localize`'));
+    await expectToFail(() => expectFileToMatch(`${outputPath}/main-es2017.js`, '$localize`'));
 
     // Verify the locale ID is present
     await expectFileToMatch(`${outputPath}/vendor-es5.js`, lang);
-    await expectFileToMatch(`${outputPath}/vendor-es2015.js`, lang);
+    await expectFileToMatch(`${outputPath}/vendor-es2017.js`, lang);
 
     // Verify the HTML lang attribute is present
     await expectFileToMatch(`${outputPath}/index.html`, `lang="${lang}"`);
@@ -48,18 +48,18 @@ export async function executeTest() {
 
     // Verify the locale data is registered using the global files
     await expectFileToMatch(`${outputPath}/vendor-es5.js`, '.ng.common.locales');
-    await expectFileToMatch(`${outputPath}/vendor-es2015.js`, '.ng.common.locales');
+    await expectFileToMatch(`${outputPath}/vendor-es2017.js`, '.ng.common.locales');
 
     // Verify the locale data is browser compatible
     await expectToFail(() => expectFileToMatch(`${outputPath}/vendor-es5.js`, /\bconst\b/));
-    await expectFileToMatch(`${outputPath}/vendor-es2015.js`, /\bconst\b/);
+    await expectFileToMatch(`${outputPath}/vendor-es2017.js`, /\bconst\b/);
 
     // Verify locale data comments are removed in production
     await expectToFail(() =>
       expectFileToMatch(`${outputPath}/vendor-es5.js`, '// See angular/tools/gulp-tasks/cldr/extract.js'),
     );
     await expectToFail(() =>
-      expectFileToMatch(`${outputPath}/vendor-es2015.js`, '// See angular/tools/gulp-tasks/cldr/extract.js'),
+      expectFileToMatch(`${outputPath}/vendor-es2017.js`, '// See angular/tools/gulp-tasks/cldr/extract.js'),
     );
 
     // Execute Application E2E tests with dev server
@@ -83,14 +83,14 @@ export async function executeTest() {
   await ng('build', '--configuration=fr', '--optimization=false', '--configuration=development');
   await expectToFail(() => expectFileToMatch(`${baseDir}/fr/main-es5.js`, 'registerLocaleData('));
   await expectToFail(() =>
-    expectFileToMatch(`${baseDir}/fr/main-es2015.js`, 'registerLocaleData('),
+    expectFileToMatch(`${baseDir}/fr/main-es2017.js`, 'registerLocaleData('),
   );
 
   // Verify missing translation behaviour.
   await appendToFile('src/app/app.component.html', '<p i18n>Other content</p>');
   await ng('build', '--i18n-missing-translation', 'ignore', '--configuration=development');
   await expectFileToMatch(`${baseDir}/fr/main-es5.js`, /Other content/);
-  await expectFileToMatch(`${baseDir}/fr/main-es2015.js`, /Other content/);
+  await expectFileToMatch(`${baseDir}/fr/main-es2017.js`, /Other content/);
   await expectToFail(() => ng('build', '--configuration=development'));
   try {
     await execAndWaitForOutputToMatch(

--- a/tests/legacy-cli/e2e/tests/i18n/ivy-localize-es2015.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/ivy-localize-es2015.ts
@@ -8,10 +8,10 @@ export default async function() {
   // Setup i18n tests and config.
   await setupI18nConfig();
 
-  // Ensure a ES2015 build is used.
+  // Ensure a es2017 build is used.
   await writeFile('.browserslistrc', 'Chrome 65');
   await updateJsonFile('tsconfig.json', config => {
-    config.compilerOptions.target = 'es2015';
+    config.compilerOptions.target = 'es2017';
     if (!config.angularCompilerOptions) {
       config.angularCompilerOptions = {};
     }

--- a/tests/legacy-cli/e2e/tests/i18n/ivy-localize-es5.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/ivy-localize-es5.ts
@@ -22,7 +22,7 @@ export default async function() {
   for (const { lang, outputPath, translation } of langTranslations) {
     await expectFileToMatch(`${outputPath}/main.js`, translation.helloPartial);
     await expectToFail(() => expectFileToMatch(`${outputPath}/main.js`, '$localize`'));
-    await expectFileNotToExist(`${outputPath}/main-es2015.js`);
+    await expectFileNotToExist(`${outputPath}/main-es2017.js`);
 
     // Ensure sourcemap for modified file contains content
     const mainSourceMap = JSON.parse(await readFile(`${outputPath}/main.js.map`));

--- a/tests/legacy-cli/e2e/tests/i18n/ve-localize-es2015.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/ve-localize-es2015.ts
@@ -22,10 +22,10 @@ export default async function() {
   }
   await installPackage(localizeVersion);
 
-  // Ensure a ES2015 build is used.
+  // Ensure a es2017 build is used.
   await writeFile('.browserslistrc', 'Chrome 65');
   await updateJsonFile('tsconfig.json', config => {
-    config.compilerOptions.target = 'es2015';
+    config.compilerOptions.target = 'es2017';
     if (!config.angularCompilerOptions) {
       config.angularCompilerOptions = {};
     }


### PR DESCRIPTION
  
With this change we update the TypeScript target of server compilation unit for new projects.

- E2E target has been update from `es2018` to `es2019`
- Browser target has been update from `es2015` to `es2017`
- Server target has been update from `es2016` to `es2019`