### PR TITLE
build: update Angular CLI repo to use ES2019

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,9 +11,9 @@
     "rootDir": ".",
     "skipLibCheck": true,
     "strict": true,
-    "target": "es2018",
+    "target": "es2019",
     "lib": [
-      "es2018"
+      "es2019"
     ],
     "baseUrl": "",
     "rootDirs": [


### PR DESCRIPTION
Since we no longer support Node.JS 10 we can ship our code in ES2019
See: https://node.green/#ES2019