### PR TITLE
[11.2.x] perf(@ngtools/webpack): use precalculated dependencies in unused file check

### DIFF
--- a/packages/ngtools/webpack/src/ivy/plugin.ts
+++ b/packages/ngtools/webpack/src/ivy/plugin.ts
@@ -569,7 +569,6 @@ export class AngularWebpackPlugin {
         rootNames,
         compilerOptions,
         host,
-        this.ngtscNextProgram,
       );
       const angularCompiler = angularProgram.compiler;
       const pendingAnalysis = angularCompiler.analyzeAsync().then(() => {
@@ -585,10 +584,6 @@ export class AngularWebpackPlugin {
 
         return innerFileEmitter(file);
       };
-
-      if (this.watchMode) {
-        this.ngtscNextProgram = angularProgram;
-      }
 
       return {
         fileEmitter: analyzingFileEmitter,


### PR DESCRIPTION
This change uses the newly introduced precalculated file dependencies for each TypeScript file instead of querying TypeScript for the SourceFile's dependencies when performing the unused file check at the end of the build cycle. This change removes the need to recalculate the dependencies for each TypeScript file present in the Webpack compilation.