### PR TITLE
fix(@angular-devkit/build-angular): don't load an input sourcemap from file when using Babel

### DIFF
--- a/packages/angular_devkit/build_angular/src/babel/webpack-loader.ts
+++ b/packages/angular_devkit/build_angular/src/babel/webpack-loader.ts
@@ -64,6 +64,7 @@ export default custom<AngularCustomOptions>(() => {
     compact: false,
     cacheCompression: false,
     sourceType: 'unambiguous',
+    inputSourceMap: false,
   });
 
   return {


### PR DESCRIPTION


This ensures that vendor sourcemaps are not loaded from file when they have not been previously loaded via sourcemap-loader.

When vendor sourcemap is enabled, `inputSourceMap` is not needed, since the sourcemap is already available and the `sourceMappingURL` comment is removed from source.