### PR TITLE
fix(@angular-devkit/build-angular): only espace unicode characters in ES5 bundles

### DIFF
--- a/packages/angular_devkit/build_angular/src/browser/specs/optimization-level_spec.ts
+++ b/packages/angular_devkit/build_angular/src/browser/specs/optimization-level_spec.ts
@@ -80,7 +80,7 @@ describe('Browser Builder optimization level', () => {
     expect(await files['styles.css']).toContain('color: white');
   });
 
-  it('outputs ASCII only content', async () => {
+  it('outputs unescaped unicode content', async () => {
     const overrides = { aot: true, optimization: true };
 
     host.writeMultipleFiles({
@@ -88,8 +88,6 @@ describe('Browser Builder optimization level', () => {
     });
 
     const { files } = await browserBuild(architect, host, target, overrides);
-    expect(await files['main.js']).not.toContain('ɵ');
-    expect(await files['main.js']).not.toContain('€€€');
-    expect(await files['main.js']).toContain('\\u20ac\\u20ac\\u20ac');
+    expect(await files['main.js']).toContain('€€€');
   });
 });

--- a/packages/angular_devkit/build_angular/src/utils/process-bundle.ts
+++ b/packages/angular_devkit/build_angular/src/utils/process-bundle.ts
@@ -389,13 +389,13 @@ async function terserMangle(
   // estree -> terser is already supported; need babel -> estree/terser
 
   // Mangle downlevel code
+  const ecma = options.ecma ?? 5;
   const minifyOutput = await minify(options.filename ? { [options.filename]: code } : code, {
     compress: allowMinify && !!options.compress,
-    ecma: options.ecma || 5,
+    ecma,
     mangle: allowMangle,
-    safari10: true,
     format: {
-      ascii_only: true,
+      ascii_only: ecma === 5,
       webkit: true,
       beautify: shouldBeautify,
       wrap_func_args: false,

--- a/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
@@ -355,11 +355,10 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
 
     const terserOptions = {
       warnings: !!buildOptions.verbose,
-      safari10: true,
       output: {
         ecma: terserEcma,
-        // For differential loading, this is handled in the bundle processing.
-        ascii_only: !differentialLoadingMode,
+        // For differential loading, this is handled in the bundle processing for ES5 bundles.
+        ascii_only: tsConfig.options.target === ScriptTarget.ES5,
         // Default behavior (undefined value) is to keep only important comments (licenses, etc.)
         comments: !buildOptions.extractLicenses && undefined,
         webkit: true,

--- a/tests/legacy-cli/e2e/tests/build/differential-loading.ts
+++ b/tests/legacy-cli/e2e/tests/build/differential-loading.ts
@@ -1,5 +1,5 @@
 import { oneLineTrim } from 'common-tags';
-import { appendToFile, expectFileToMatch, replaceInFile, writeMultipleFiles } from '../../utils/fs';
+import { expectFileToMatch, replaceInFile, writeMultipleFiles } from '../../utils/fs';
 import { ng } from '../../utils/process';
 import { updateJsonFile } from '../../utils/project';
 import { expectToFail } from '../../utils/utils';
@@ -46,4 +46,9 @@ export default async function () {
 
   await expectFileToMatch('dist/test-project/vendor-es2015.js', /class \w{constructor\(/);
   await expectToFail(() => expectFileToMatch('dist/test-project/vendor-es5.js', /class \w{constructor\(/));
+
+  await expectFileToMatch('dist/test-project/main-es2015.js', 'ɵ');
+  await expectToFail(() => expectFileToMatch('dist/test-project/main-es2015.js', '\\u0275'));
+  await expectFileToMatch('dist/test-project/main-es5.js', '\\u0275');
+  await expectToFail(() => expectFileToMatch('dist/test-project/main-es5.js', 'ɵ'));
 }


### PR DESCRIPTION

With this change we no longer escape unicode characters in non ES5 bundles.

Closes #20255