### PR TITLE
perf(@angular-devkit/build-angular): skip FESM2015 from `async` transformation

### DIFF
--- a/packages/angular_devkit/build_angular/src/babel/webpack-loader.ts
+++ b/packages/angular_devkit/build_angular/src/babel/webpack-loader.ts
@@ -97,7 +97,7 @@ export default custom<AngularCustomOptions>(() => {
           // TypeScript files will have already been downlevelled
           customOptions.forceES5 = !/\.tsx?$/.test(this.resourcePath);
         } else if (esTarget >= ScriptTarget.ES2017) {
-          customOptions.forceAsyncTransformation = source.includes('async');
+          customOptions.forceAsyncTransformation = !/[\\\/]fesm2015[\\\/]/.test(this.resourcePath) && source.includes('async');
         }
         shouldProcess ||= customOptions.forceAsyncTransformation || customOptions.forceES5;
       }


### PR DESCRIPTION

Skip  `async` transformation when the path matches a FESM2015 entrypoint.  Ng-packagr doesn't allow changing the script target for entry-points which makes this possible https://github.com/ng-packagr/ng-packagr/blob/master/src/lib/ng-package/entry-point/compile-ngc.transform.ts#L48

This is important to reduce greatly the cold build performance overhead when targeting ES2017+