### PR TITLE
perf(@angular-devkit/build-angular): remove Webpack Stats.toJson usage in karma plugin

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/plugins/karma/karma.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/plugins/karma/karma.ts
@@ -167,7 +167,7 @@ const init: any = (config: any, emitter: any) => {
   webpackConfig.output.path = `/${KARMA_APPLICATION_PATH}/`;
   webpackConfig.output.publicPath = `/${KARMA_APPLICATION_PATH}/`;
 
-  let compiler: any;
+  let compiler;
   try {
     compiler = webpack(webpackConfig);
   } catch (e) {
@@ -200,11 +200,10 @@ const init: any = (config: any, emitter: any) => {
 
   let lastCompilationHash: string | undefined;
   const statsConfig = getWebpackStatsConfig();
-  compiler.hooks.done.tap('karma', (stats: any) => {
-    if (stats.compilation.errors.length > 0) {
-      const json = stats.toJson(config.stats);
+  compiler.hooks.done.tap('karma', (stats) => {
+    if (stats.hasErrors()) {
       // Print compilation errors.
-      logger.error(statsErrorsToString(json, statsConfig));
+      logger.error(statsErrorsToString(stats.compilation, statsConfig));
       lastCompilationHash = undefined;
       // Emit a failure build event if there are compilation errors.
       failureCb();


### PR DESCRIPTION
Webpack's `Stats.toJson` function is an expensive operation and is recommended to be avoided where possible. In the case of the karma plugin, the compilation errors can be accessed directly without the need for the function call.