### PR TITLE
feat(@angular-devkit/build-webpack): provide output path in builder results

### DIFF
--- a/packages/angular_devkit/build_angular/src/browser/index.ts
+++ b/packages/angular_devkit/build_angular/src/browser/index.ts
@@ -257,7 +257,12 @@ export function buildWebpackBrowser(
             const spinner = new Spinner();
             spinner.enabled = options.progress !== false;
 
-            const { webpackStats: webpackRawStats, success, emittedFiles = [] } = buildEvent;
+            const {
+              webpackStats: webpackRawStats,
+              success,
+              emittedFiles = [],
+              outputPath: webpackOutputPath,
+            } = buildEvent;
             if (!webpackRawStats) {
               throw new Error('Webpack stats build result is required.');
             }
@@ -311,8 +316,7 @@ export function buildWebpackBrowser(
                     baseOutputPath,
                     Array.from(outputPaths.values()),
                     scriptsEntryPointName,
-                    // tslint:disable-next-line: no-non-null-assertion
-                    webpackStats.outputPath!,
+                    webpackOutputPath,
                     target <= ScriptTarget.ES5,
                     options.i18nMissingTranslation,
                   );
@@ -386,8 +390,7 @@ export function buildWebpackBrowser(
 
                   // Retrieve the content/map for the file
                   // NOTE: Additional future optimizations will read directly from memory
-                  // tslint:disable-next-line: no-non-null-assertion
-                  let filename = path.join(webpackStats.outputPath!, file.file);
+                  let filename = path.join(webpackOutputPath, file.file);
                   const code = fs.readFileSync(filename, 'utf8');
                   let map;
                   if (actionOptions.sourceMaps) {
@@ -537,12 +540,10 @@ export function buildWebpackBrowser(
                         [
                           {
                             glob: '**/*',
-                            // tslint:disable-next-line: no-non-null-assertion
-                            input: webpackStats.outputPath!,
+                            input: webpackOutputPath,
                             output: '',
                             ignore: [...processedFiles].map(f =>
-                              // tslint:disable-next-line: no-non-null-assertion
-                              path.relative(webpackStats.outputPath!, f),
+                              path.relative(webpackOutputPath, f),
                             ),
                           },
                         ],
@@ -598,8 +599,7 @@ export function buildWebpackBrowser(
                     baseOutputPath,
                     Array.from(outputPaths.values()),
                     scriptsEntryPointName,
-                    // tslint:disable-next-line: no-non-null-assertion
-                    webpackStats.outputPath!,
+                    webpackOutputPath,
                     target <= ScriptTarget.ES5,
                     options.i18nMissingTranslation,
                   );

--- a/packages/angular_devkit/build_angular/src/extract-i18n/index.ts
+++ b/packages/angular_devkit/build_angular/src/extract-i18n/index.ts
@@ -257,6 +257,7 @@ export async function execute(
       return {
         success: false,
         error: `Ivy extraction requires the '@angular/localize' package.`,
+        outputPath: outFile,
        };
     }
   }
@@ -270,13 +271,11 @@ export async function execute(
     },
   ).toPromise();
 
-  // Complete if using VE
-  if (!usingIvy) {
-    return webpackResult;
-  }
+  // Set the outputPath to the extraction output location for downstream consumers
+  webpackResult.outputPath = outFile;
 
-  // Nothing to process if the Webpack build failed
-  if (!webpackResult.success) {
+  // Complete if using VE or if Webpack build failed
+  if (!usingIvy || !webpackResult.success) {
     return webpackResult;
   }
 

--- a/packages/angular_devkit/build_angular/src/server/index.ts
+++ b/packages/angular_devkit/build_angular/src/server/index.ts
@@ -92,7 +92,7 @@ export function execute(
         },
       }).pipe(
         concatMap(async output => {
-          const { emittedFiles = [], webpackStats } = output;
+          const { emittedFiles = [], outputPath, webpackStats } = output;
           if (!webpackStats) {
             throw new Error('Webpack stats build result is required.');
           }
@@ -108,8 +108,7 @@ export function execute(
               baseOutputPath,
               Array.from(outputPaths.values()),
               [],
-              // tslint:disable-next-line: no-non-null-assertion
-              webpackStats.outputPath!,
+              outputPath,
               target <= ScriptTarget.ES5,
               options.i18nMissingTranslation,
             );

--- a/packages/angular_devkit/build_webpack/src/webpack-dev-server/index.ts
+++ b/packages/angular_devkit/build_webpack/src/webpack-dev-server/index.ts
@@ -72,7 +72,7 @@ export function runWebpackDevServer(
   return createWebpack({ ...config, watch: false }).pipe(
     switchMap(webpackCompiler => new Observable<DevServerBuildOutput>(obs => {
       const server = createWebpackDevServer(webpackCompiler, devServerConfig);
-      let result: DevServerBuildOutput;
+      let result: Partial<DevServerBuildOutput>;
 
       webpackCompiler.hooks.done.tap('build-webpack', (stats) => {
         // Log stats.
@@ -82,6 +82,7 @@ export function runWebpackDevServer(
           ...result,
           emittedFiles: getEmittedFiles(stats.compilation),
           success: !stats.hasErrors(),
+          outputPath: stats.compilation.outputOptions.path,
         } as unknown as DevServerBuildOutput);
       });
 

--- a/packages/angular_devkit/build_webpack/src/webpack/index.ts
+++ b/packages/angular_devkit/build_webpack/src/webpack/index.ts
@@ -26,6 +26,7 @@ export interface WebpackFactory {
 export type BuildResult = BuilderOutput & {
   emittedFiles?: EmittedFiles[];
   webpackStats?: webpack.Stats.ToJsonOutput;
+  outputPath: string;
 };
 
 export function runWebpack(
@@ -77,6 +78,7 @@ export function runWebpack(
           success: !stats.hasErrors(),
           webpackStats: shouldProvideStats ? stats.toJson() : undefined,
           emittedFiles: getEmittedFiles(stats.compilation),
+          outputPath: stats.compilation.outputOptions.path,
         } as unknown as BuildResult);
 
         if (!config.watch) {


### PR DESCRIPTION
This change adds the output path for the Webpack build directly to the result of the builder. This removes one of the reasons for using the Webpack JSON stats object which is expensive to generate.