### PR TITLE
fix(@angular-devkit/schematics-cli): accept windows like paths for sc…

### DIFF
--- a/packages/angular_devkit/schematics_cli/bin/schematics.ts
+++ b/packages/angular_devkit/schematics_cli/bin/schematics.ts
@@ -38,7 +38,10 @@ function parseSchematicName(str: string | null): { collection: string, schematic
 
   let schematic = str;
   if (schematic && schematic.indexOf(':') != -1) {
-    [collection, schematic] = schematic.split(':', 2);
+    [collection, schematic] = [
+      schematic.slice(0, schematic.lastIndexOf(':')),
+      schematic.substring(schematic.lastIndexOf(':') + 1),
+    ];
   }
 
   return { collection, schematic };


### PR DESCRIPTION
…hematics

correctly identify schematics paths like 'C:/dir/collection.json:schematic' that used to return 'C' as collection