### PR TITLE
perf(@angular-devkit/build-angular): enforce Babel not to load sourcemaps from file

### DIFF
--- a/packages/angular_devkit/build_angular/src/babel/webpack-loader.ts
+++ b/packages/angular_devkit/build_angular/src/babel/webpack-loader.ts
@@ -136,6 +136,9 @@ export default custom<AngularCustomOptions>(() => {
     config(configuration, { customOptions }) {
       return {
         ...configuration.options,
+        // Workaround for https://github.com/babel/babel-loader/pull/896 is available
+        // Delete once the above PR is released
+        inputSourceMap: (configuration.options.inputSourceMap || false as {}), // Typings are not correct
         presets: [
           ...(configuration.options.presets || []),
           [


### PR DESCRIPTION


Workaround for https://github.com/babel/babel-loader/pull/896