### PR TITLE
fix(@schematics/angular): fix youtube icon margin

### DIFF
--- a/packages/schematics/angular/application/other-files/app.component.html.template
+++ b/packages/schematics/angular/application/other-files/app.component.html.template
@@ -58,7 +58,7 @@
 
   .toolbar #youtube-logo {
     height: 40px;
-    margin-left: 16px;
+    margin: 0 16px;
   }
 
   .toolbar #twitter-logo:hover,


### PR DESCRIPTION
change youtube icon style from `margin-left: 16px;` to `margin: 0 16px;`

to be like this 
![image](https://user-images.githubusercontent.com/8146344/111141611-6cab1880-858c-11eb-85e2-3c199812a964.png)

instead of this 
![image](https://user-images.githubusercontent.com/8146344/111141661-76cd1700-858c-11eb-88e9-9384a551bd62.png)
