### PR TITLE
fix(@schematics/angular): only show legacy browsers deprecation warning when option is used

### DIFF
--- a/packages/schematics/angular/ng-new/index.ts
+++ b/packages/schematics/angular/ng-new/index.ts
@@ -63,7 +63,7 @@ export default function(options: NgNewOptions): Rule {
     skipInstall: true,
     strict: options.strict,
     minimal: options.minimal,
-    legacyBrowsers: options.legacyBrowsers,
+    legacyBrowsers: options.legacyBrowsers || undefined,
   };
 
   return chain([


### PR DESCRIPTION
…
This ensures that the deprecate warning is only displayed when the option is used.