### PR TITLE
feat(@angular-devkit/core): option to remove trailing new line in template

### DIFF
--- a/etc/api/angular_devkit/core/src/_golden-api.d.ts
+++ b/etc/api/angular_devkit/core/src/_golden-api.d.ts
@@ -1035,12 +1035,11 @@ export interface TemplateOptions {
     module?: boolean | {
         exports: {};
     };
+    removeTrailingNewLine?: boolean;
     sourceMap?: boolean;
     sourceRoot?: string;
     sourceURL?: string;
 }
-
-export declare function templateParser(sourceText: string, fileName: string): TemplateAst;
 
 export interface TemplateTag<R = string> {
     (template: TemplateStringsArray, ...substitutions: any[]): R;

--- a/etc/api/angular_devkit/schematics/src/_golden-api.d.ts
+++ b/etc/api/angular_devkit/schematics/src/_golden-api.d.ts
@@ -24,11 +24,11 @@ export declare class ActionList implements Iterable<Action> {
 
 export declare function apply(source: Source, rules: Rule[]): Source;
 
-export declare function applyContentTemplate<T>(options: T): FileOperator;
+export declare function applyContentTemplate<T>(replacement: T, options?: TemplateOptions): FileOperator;
 
 export declare function applyPathTemplate<T extends PathTemplateData>(data: T, options?: PathTemplateOptions): FileOperator;
 
-export declare function applyTemplates<T>(options: T): Rule;
+export declare function applyTemplates<T>(replacement: T, options?: TemplateOptions): Rule;
 
 export declare function applyToSubtree(path: string, rules: Rule[]): Rule;
 
@@ -104,7 +104,7 @@ export declare class ContentHasMutatedException extends BaseException {
     constructor(path: string);
 }
 
-export declare function contentTemplate<T>(options: T): Rule;
+export declare function contentTemplate<T>(replacement: T, options?: TemplateOptions): Rule;
 
 export interface CreateFileAction extends ActionBase {
     readonly content: Buffer;
@@ -534,7 +534,7 @@ export declare class TaskScheduler {
     schedule<T>(taskConfiguration: TaskConfiguration<T>): TaskId;
 }
 
-export declare function template<T>(options: T): Rule;
+export declare function template<T>(replacement: T, options?: TemplateOptions): Rule;
 
 export declare const TEMPLATE_FILENAME_RE: RegExp;
 

--- a/packages/angular_devkit/schematics/src/rules/template_spec.ts
+++ b/packages/angular_devkit/schematics/src/rules/template_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 // tslint:disable:no-implicit-dependencies
-import { normalize } from '@angular-devkit/core';
+import { TemplateOptions, normalize } from '@angular-devkit/core';
 import { UnitTestTree } from '@angular-devkit/schematics/testing';
 import { of as observableOf } from 'rxjs';
 import { SchematicContext } from '../engine/interface';
@@ -116,8 +116,8 @@ describe('applyPathTemplate', () => {
 
 
 describe('contentTemplate', () => {
-  function _applyContentTemplate(content: string, options: {}) {
-    const newEntry = applyContentTemplate(options)(_entry('', content));
+  function _applyContentTemplate(content: string, replacement: {}, options?: TemplateOptions) {
+    const newEntry = applyContentTemplate(replacement, options)(_entry('', content));
     if (newEntry) {
       return newEntry.content.toString('utf-8');
     } else {
@@ -156,6 +156,14 @@ describe('contentTemplate', () => {
     expect(_applyContentTemplate('a<%= value %>b', { value: `'abc'` })).toBe('a\'abc\'b');
     expect(_applyContentTemplate('a<%= \'a\' + "b" %>b', {})).toBe('aabb');
     expect(_applyContentTemplate('a<%= "\\n" + "b" %>b', {})).toBe('a\nbb');
+  });
+
+  it('removes trailing new line when removeTrailingNewLine is true', () => {
+    expect(_applyContentTemplate(`<% if (expr) { %>\nfoo\n<% } %>\n`, {
+      expr: true,
+    }, {
+      removeTrailingNewLine: true,
+    })).toBe(`foo\n`);
   });
 });
 


### PR DESCRIPTION
This commits add an option to the template parser to remove new line
characters that immediately follow an evaluation expression.

For example, currently
```
<% if (expr) { %>
foo
<% } %>
```
would generate
```
     <-- new line
foo
     <-- new line
```
With this change the output will be
```
foo
```

This option is backwards compatible since it is disabled by default.