### PR TITLE
fix(@schematics/angular): remove Native value from viewEncapsulation option

### DIFF
--- a/packages/schematics/angular/application/schema.json
+++ b/packages/schematics/angular/application/schema.json
@@ -34,7 +34,7 @@
     },
     "viewEncapsulation": {
       "description": "The view encapsulation strategy to use in the new app.",
-      "enum": ["Emulated", "Native", "None", "ShadowDom"],
+      "enum": ["Emulated", "None", "ShadowDom"],
       "type": "string",
       "x-user-analytics": 11
     },

--- a/packages/schematics/angular/component/schema.json
+++ b/packages/schematics/angular/component/schema.json
@@ -50,7 +50,7 @@
     },
     "viewEncapsulation": {
       "description": "The view encapsulation strategy to use in the new component.",
-      "enum": ["Emulated", "Native", "None", "ShadowDom"],
+      "enum": ["Emulated", "None", "ShadowDom"],
       "type": "string",
       "alias": "v",
       "x-user-analytics": 11

--- a/packages/schematics/angular/ng-new/schema.json
+++ b/packages/schematics/angular/ng-new/schema.json
@@ -78,7 +78,7 @@
     },
     "viewEncapsulation": {
       "description": "The view encapsulation strategy to use in the initial project.",
-      "enum": ["Emulated", "Native", "None", "ShadowDom"],
+      "enum": ["Emulated", "None", "ShadowDom"],
       "type": "string",
       "x-user-analytics": 11
     },


### PR DESCRIPTION
This commit remove "Native" value from `viewEncapsulation` option in `ng new`, `ng generate application` and `ng generate component`.

Has been removed here: [#38882](https://github.com/angular/angular/pull/38882)