### PR TITLE
fix(@ngtools/webpack): remove Webpack 5 deprecation warning in resource loader

### DIFF
--- a/packages/ngtools/webpack/src/resource_loader.ts
+++ b/packages/ngtools/webpack/src/resource_loader.ts
@@ -135,7 +135,8 @@ export class WebpackResourceLoader {
     let finalMap: string | undefined;
     if (isWebpackFiveOrHigher()) {
       childCompiler.hooks.compilation.tap('angular-compiler', (childCompilation) => {
-        childCompilation.hooks.processAssets.tap('angular-compiler', () => {
+        // tslint:disable-next-line: no-any
+        (childCompilation.hooks as any).processAssets.tap('angular-compiler', () => {
           finalContent = childCompilation.assets[filePath]?.source().toString();
           finalMap = childCompilation.assets[filePath + '.map']?.source().toString();
 


### PR DESCRIPTION
This change adds support for using the Webpack `processAssets` hook to handle the resource loader child compilation's assets. This new hook is the recommended way to process assets in Webpack 5+.