### PR TITLE
test(@angular-devkit/build-angular): avoid crashing during test failure in utility function

### DIFF
--- a/packages/angular_devkit/build_angular/src/test-utils.ts
+++ b/packages/angular_devkit/build_angular/src/test-utils.ts
@@ -81,6 +81,15 @@ export async function browserBuild(
   const output = (await run.result) as BrowserBuilderOutput;
   expect(output.success).toBe(true);
 
+  if (!output.success) {
+    await run.stop();
+
+    return {
+      output,
+      files: {},
+    };
+  }
+
   expect(output.outputPaths[0]).not.toBeUndefined();
   const outputPath = normalize(output.outputPaths[0]);
 


### PR DESCRIPTION
Previously, if a browser build failed using the `browserBuild` test utility function, the test utility would try to access properties that did not exist and would crash. This increased the complexity to debug failing tests. With the new behavior, the `browserBuild` test utility will return with an empty `files` object and the failed builder result.