### PR TITLE
[11.2.x] fix(@angular-devkit/build-angular): support writing large Webpack stat outputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "@bazel/buildifier": "4.0.0",
     "@bazel/jasmine": "3.2.1",
     "@bazel/typescript": "3.2.1",
+    "@discoveryjs/json-ext": "0.5.2",
     "@jsdevtools/coverage-istanbul-loader": "3.0.5",
     "@types/babel__core": "7.1.12",
     "@types/babel__template": "7.4.0",

--- a/packages/angular_devkit/build_angular/BUILD.bazel
+++ b/packages/angular_devkit/build_angular/BUILD.bazel
@@ -113,6 +113,7 @@ ts_library(
         "@npm//@babel/preset-env",
         "@npm//@babel/runtime",
         "@npm//@babel/template",
+        "@npm//@discoveryjs/json-ext",
         "@npm//@jsdevtools/coverage-istanbul-loader",
         "@npm//@types/babel__core",
         "@npm//@types/babel__template",

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -18,6 +18,7 @@
     "@babel/preset-env": "7.12.11",
     "@babel/runtime": "7.12.5",
     "@babel/template": "7.12.7",
+    "@discoveryjs/json-ext": "0.5.2",
     "@jsdevtools/coverage-istanbul-loader": "3.0.5",
     "@ngtools/webpack": "0.0.0",
     "ansi-colors": "4.1.1",

--- a/packages/angular_devkit/build_angular/src/babel-bazel.d.ts
+++ b/packages/angular_devkit/build_angular/src/babel-bazel.d.ts
@@ -1,0 +1,22 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+// Workaround for https://github.com/bazelbuild/rules_nodejs/issues/1033
+// Alternative approach instead of https://github.com/angular/angular/pull/33226
+declare module '@babel/core' {
+  export * from '@types/babel__core';
+}
+declare module '@babel/generator' {
+  export { default } from '@types/babel__generator';
+}
+declare module '@babel/traverse' {
+  export { default } from '@types/babel__traverse';
+}
+declare module '@babel/template' {
+  export { default } from '@types/babel__template';
+}

--- a/packages/angular_devkit/build_angular/src/typings.d.ts
+++ b/packages/angular_devkit/build_angular/src/typings.d.ts
@@ -5,18 +5,6 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-
-// Workaround for https://github.com/bazelbuild/rules_nodejs/issues/1033
-// Alternative approach instead of https://github.com/angular/angular/pull/33226
-declare module '@babel/core' {
-  export * from '@types/babel__core';
-}
-declare module '@babel/generator' {
-  export { default } from '@types/babel__generator';
-}
-declare module '@babel/traverse' {
-  export { default } from '@types/babel__traverse';
-}
-declare module '@babel/template' {
-  export { default } from '@types/babel__template';
+declare module '@discoveryjs/json-ext' {
+  export function stringifyStream(value: unknown): import('stream').Readable;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -57,7 +57,7 @@
     "suppressTsconfigOverrideWarnings": true
   },
   "exclude": [
-    "packages/angular_devkit/build_angular/src/typings.d.ts",
+    "packages/angular_devkit/build_angular/src/bazel-babel.d.ts",
     "bazel-out/**/*",
     "dist/**/*",
     "dist-schema/**",

--- a/yarn.lock
+++ b/yarn.lock
@@ -87,7 +87,7 @@
 
 "@angular/dev-infra-private@https://github.com/angular/dev-infra-private-builds.git#0fd0f441648577e8c3966e9b59a88fefe350f514":
   version "0.0.0"
-  resolved "https://github.com/angular/dev-infra-private-builds.git#0fd0f441648577e8c3966e9b59a88fefe350f514"
+  resolved "https://github.com/angular/dev-infra-private-builds.git#a6b42dabedcf7c724bd36a614ebe9fa99c777e62"
   dependencies:
     "@angular/benchpress" "0.2.1"
     "@bazel/buildifier" "^0.29.0"
@@ -103,13 +103,13 @@
     inquirer-autocomplete-prompt "^1.0.2"
     minimatch "^3.0.4"
     multimatch "^4.0.0"
-    node-fetch "^2.6.0"
+    node-fetch "^2.6.1"
     node-uuid "1.4.8"
     ora "^5.0.0"
     protractor "^5.4.2"
     selenium-webdriver "3.5.0"
     semver "^6.3.0"
-    shelljs "^0.8.3"
+    shelljs "^0.8.4"
     ts-node "^8.6.2"
     tslib "^2.0.0"
     typed-graphqlify "^2.3.0"
@@ -1075,6 +1075,11 @@
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
+
+"@discoveryjs/json-ext@0.5.2":
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.2.tgz#8f03a22a04de437254e8ce8cc84ba39689288752"
+  integrity sha512-HyYEUDeIj5rRQU2Hk5HTB2uHsbRQpF70nvMhVzi+VJR0X+xNEhjPui4/kBf3VeH/wqD28PT4sVOm8qqLjBrSZg==
 
 "@istanbuljs/schema@^0.1.2":
   version "0.1.2"


### PR DESCRIPTION
When using the `statsJson` browser builder option, the resulting JSON data is now streamed into a file instead of written in one large block.  This mitigates crashes due to the generated string exceeded the Node.js limit.