### PR TITLE
doc: update `yarn` command to freeze lockfile.

### DIFF
--- a/docs/process/release.md
+++ b/docs/process/release.md
@@ -118,13 +118,13 @@ For the first release of a major version, follow the instructions in
 
 For non-major release, check out the patch branch (e.g. `9.1.x`), then run:
 ```bash
-rm -rf node_modules/ && yarn # Reload dependencies
+rm -rf node_modules/ && yarn install --frozen-lockfile # Reload dependencies
 yarn admin publish --tag latest
 ```
 
 If also publishing a prerelease, check out `master`, then run:
 ```bash
-rm -rf node_modules/ && yarn # Reload dependencies
+rm -rf node_modules/ && yarn install --frozen-lockfile # Reload dependencies
 yarn admin publish --tag next
 ```
 


### PR DESCRIPTION
In today's release, running `yarn` modified the `yarn.lock` file, which is not desireable for releases which should be as close to CI as possible. This updates the docs to freeze the lockfile (similar to `npm ci`) to avoid changing dependency verisons mid-release.

/cc Caretakers for release (@kyliau and @josephperrott).