### PR TITLE
build: sort changelog by commit message scope

### DIFF
--- a/scripts/templates/changelog.ejs
+++ b/scripts/templates/changelog.ejs
@@ -77,7 +77,7 @@
         continue;
     }
 
-    scopeCommits.sort((a, b) => a.type - b.type);
+    scopeCommits.sort((a,b) => a.type > b.type ? 1 : -1);
 %>
 <tr><td colspan=3><h3><%
   if (scope) {


### PR DESCRIPTION
Previously `a.type - b.type` always returned NaN, which broke sorting