### PR TITLE
perf(@ngtools/webpack): reduce resource processing during JIT initial lazy route analysis

### DIFF
--- a/packages/ngtools/webpack/src/ivy/host.ts
+++ b/packages/ngtools/webpack/src/ivy/host.ts
@@ -10,12 +10,12 @@ import { createHash } from 'crypto';
 import * as path from 'path';
 import * as ts from 'typescript';
 import { NgccProcessor } from '../ngcc_processor';
-import { WebpackResourceLoader } from '../resource_loader';
+import { ResourceLoader } from '../resource_loader';
 import { normalizePath } from './paths';
 
 export function augmentHostWithResources(
   host: ts.CompilerHost,
-  resourceLoader: WebpackResourceLoader,
+  resourceLoader: ResourceLoader,
   options: { directTemplateLoading?: boolean } = {},
 ) {
   const resourceHost = host as CompilerHost;

--- a/packages/ngtools/webpack/src/resource_loader.ts
+++ b/packages/ngtools/webpack/src/resource_loader.ts
@@ -13,6 +13,17 @@ import * as vm from 'vm';
 import { RawSource } from 'webpack-sources';
 import { normalizePath } from './ivy/paths';
 
+export interface ResourceLoader {
+  get(file: string): Promise<string>;
+  getModifiedResourceFiles(): Set<string>;
+  getResourceDependencies(file: string): Iterable<string>;
+  setAffectedResources(file: string, resources: Iterable<string>): void;
+  update(
+    parentCompilation: import('webpack').compilation.Compilation,
+    changedFiles?: Iterable<string>,
+  ): void;
+}
+
 const NodeTemplatePlugin = require('webpack/lib/node/NodeTemplatePlugin');
 const NodeTargetPlugin = require('webpack/lib/node/NodeTargetPlugin');
 const LibraryTemplatePlugin = require('webpack/lib/LibraryTemplatePlugin');
@@ -23,6 +34,23 @@ interface CompilationOutput {
   outputName: string;
   source: string;
   success: boolean;
+}
+
+export class NoopResourceLoader implements ResourceLoader {
+  async get(): Promise<string> {
+    return '';
+  }
+
+  getModifiedResourceFiles(): Set<string> {
+    return new Set();
+  }
+
+  getResourceDependencies(): Iterable<string> {
+    return [];
+  }
+
+  setAffectedResources(): void {}
+  update(): void {}
 }
 
 export class WebpackResourceLoader {


### PR DESCRIPTION
During JIT mode, deprecated string-form lazy routes are discovered by analyzing the application via the compiler-cli.
This process, however, does not need any of the component resources nor does the CLI need to load them. In JIT mode,
a no-op resource loader is now used that will provide the compiler with blank templates and styles. This can greatly
reduce the amount of processing required during an initial JIT build, especially for large projects.