### PR TITLE
feat(@schematics/angular): create add schema method in ast-utils

### DIFF
--- a/packages/schematics/angular/utility/ast-utils.ts
+++ b/packages/schematics/angular/utility/ast-utils.ts
@@ -504,6 +504,15 @@ export function addExportToModule(source: ts.SourceFile,
 }
 
 /**
+ * Custom function to insert a schema into NgModule. It also imports it.
+ */
+export function addSchemaToModule(source: ts.SourceFile,
+                                  modulePath: string, classifiedName: string,
+                                  importPath: string): Change[] {
+  return addSymbolToNgModuleMetadata(source, modulePath, 'schemas', classifiedName, importPath);
+}
+
+/**
  * Custom function to insert an export into NgModule. It also imports it.
  */
 export function addBootstrapToModule(source: ts.SourceFile,

--- a/packages/schematics/angular/utility/ast-utils_spec.ts
+++ b/packages/schematics/angular/utility/ast-utils_spec.ts
@@ -16,6 +16,7 @@ import {
   addExportToModule,
   addProviderToModule,
   addRouteDeclarationToModule,
+  addSchemaToModule,
   addSymbolToNgModuleMetadata,
   findNodes,
   insertAfterLastOccurrence,
@@ -80,6 +81,23 @@ describe('ast utils', () => {
     const output = applyChanges(modulePath, moduleContent, changes);
     expect(output).toMatch(/import { FooComponent } from '.\/foo.component';/);
     expect(output).toMatch(/exports: \[FooComponent\]/);
+  });
+
+  it('should add schema to module', () => {
+    const source = getTsSource(modulePath, moduleContent);
+    const changes = addSchemaToModule(source, modulePath, 'CUSTOM_ELEMENTS_SCHEMA', '@angular/core');
+    const output = applyChanges(modulePath, moduleContent, changes);
+    expect(output).toMatch(/import { NgModule, CUSTOM_ELEMENTS_SCHEMA } from '@angular\/core';/);
+    expect(output).toMatch(/schemas: \[CUSTOM_ELEMENTS_SCHEMA\]/);
+  });
+
+  it('should add schema to module if not indented', () => {
+    moduleContent = tags.stripIndents`${moduleContent}`;
+    const source = getTsSource(modulePath, moduleContent);
+    const changes = addSchemaToModule(source, modulePath, 'CUSTOM_ELEMENTS_SCHEMA', '@angular/core');
+    const output = applyChanges(modulePath, moduleContent, changes);
+    expect(output).toMatch(/import { NgModule, CUSTOM_ELEMENTS_SCHEMA } from '@angular\/core';/);
+    expect(output).toMatch(/schemas: \[CUSTOM_ELEMENTS_SCHEMA\]/);
   });
 
   it('should add declarations to module if not indented', () => {


### PR DESCRIPTION
The AST Utils include methods to add new values to each section of an NgModule's metadata including `declarations`, `imports`, `providers`, `exports`, `bootstrap` and `entryComponents`. However, there is no method for schemas. Schematics authors can easily use the `addSymbolToNgModuleMetadata` method to achieve this capability, but I propose to add this `addSchemaToModule` method as a minor quality of life improvement.