### PR TITLE
build: determine release version from package.json instead of git tag

### DIFF
--- a/docs/process/release.md
+++ b/docs/process/release.md
@@ -22,9 +22,6 @@ Alan    | Doug
 Charles | Keen
 Filipe  | Joey
 
-## Triaging Issues
-TBD
-
 ## Merging PRs
 
 The list of PRs which are currently ready to merge (approved with passing status checks) can
@@ -37,7 +34,6 @@ When ready to merge a PR, run the following command:
 ```
 yarn ng-dev pr merge <pr>
 ```
-
 
 ### Maintaining LTS branches
 
@@ -57,26 +53,20 @@ In general, cherry picks for LTS should only be done if it meets one of the crit
 
 ## Before releasing
 
-Make sure the CI is green.
-
-Consider if you need to update [`packages/schematics/angular/utility/latest-versions.ts`](https://github.com/angular/angular-cli/blob/master/packages/schematics/angular/utility/latest-versions.ts) to reflect changes in dependent versions.
+Update `Angular` version in [`packages/schematics/angular/utility/latest-versions.ts`](https://github.com/angular/angular-cli/blob/master/packages/schematics/angular/utility/latest-versions.ts).
 
 ## Shepparding
 
 As commits are cherry-picked when PRs are merged, creating the release should be a matter of creating a tag.
 
-Update the package versions to reflect the new release version in **both**:
-1. [`package.json`](https://github.com/angular/angular-cli/blob/master/package.json#L3)
-1. [`packages/schematics/angular/utility/latest-versions.ts`](https://github.com/angular/angular-cli/blob/master/packages/schematics/angular/utility/latest-versions.ts)
-
 ```bash
-git add package.json packages/schematics/angular/utility/latest-versions.ts
+git add packages/schematics/angular/utility/latest-versions.ts
 git commit -m 'release: vXX'
 git tag -a 'vXX' -m 'release: tag vXX'
 ```
 
-The package versions we are about to publish are derived from the git tag that
-we just created. Double check that the versions are correct by running the
+The package versions we are about to publish are derived from `version` in the root
+[`package.json`](https://github.com/angular/angular-cli/blob/master/package.json#L3). Double check that the versions are correct by running the
 following command.
 
 ```bash
@@ -95,7 +85,7 @@ git push upstream --follow-tags
 **This can ONLY be done by a Google employee.**
 
 Log in to the Wombat publishing service using your own github and google.com
-account to publish.  This enforces the loging is done using 2Factor auth.
+account to publish.  This enforces the login is done using 2Factor auth.
 
 Run `npm login --registry https://wombat-dressing-room.appspot.com`:
 
@@ -111,7 +101,7 @@ After closing the tab, you have successfully logged in, it is time to publish.
 
 **This can ONLY be done by a Google employee.**
 
-**It is a good idea to wait for CI to be green on the patch branch and tag before doing the release.**
+**Wait for CI to be green after pushing the release commit.**
 
 For the first release of a major version, follow the instructions in
 [Publishing a Major Version](#publishing-a-major-version) section.
@@ -158,6 +148,16 @@ If you have an API token for GitHub you can create a draft automatically by
 using the `--githubToken` flag. You just then have to confirm the draft.
 
 > **Tags containing `next` or `rc` should be marked as pre-release.**
+
+## Post-release Version Update
+
+Update the package versions to reflect the *next* release version in **both**:
+1. `version` in [`package.json`](https://github.com/angular/angular-cli/blob/master/package.json#L3)
+1. `DevkitBuildAngular` in [`packages/schematics/angular/utility/latest-versions.ts`](https://github.com/angular/angular-cli/blob/master/packages/schematics/angular/utility/latest-versions.ts)
+
+```sh
+git commit package.json packages/schematics/angular/utility/latest-versions.ts -m "build: bump version to vXX"
+```
 
 ### Microsite Publishing
 

--- a/lib/packages.ts
+++ b/lib/packages.ts
@@ -160,25 +160,8 @@ function _getSnapshotHash(_pkg: PackageInfo): string {
 }
 
 
-let stableVersion = '';
-let experimentalVersion = '';
-function _getVersionFromGit(experimental: boolean): string {
-  if (stableVersion && experimentalVersion) {
-    return experimental ? experimentalVersion : stableVersion;
-  }
-
-  const hasLocalChanges = _exec(`git status --porcelain`) != '';
-  const scmVersionTagRaw = _exec(`git describe --match v[0-9]*.[0-9]*.[0-9]* --abbrev=7 --tags`)
-    .slice(1);
-  stableVersion = scmVersionTagRaw.replace(/-([0-9]+)-g/, '+$1.');
-  if (hasLocalChanges) {
-    stableVersion += stableVersion.includes('+') ? '.with-local-changes' : '+with-local-changes';
-  }
-
-  experimentalVersion = stableToExperimentalVersion(stableVersion);
-
-  return experimental ? experimentalVersion : stableVersion;
-}
+const stableVersion = loadRootPackageJson().version;
+const experimentalVersion = stableToExperimentalVersion(stableVersion);
 
 /**
  * Convert a stable version to its experimental equivalent. For example,
@@ -245,9 +228,7 @@ export const packages: PackageMap =
 
         dependencies: [],
         reverseDependencies: [],
-        get version() {
-          return _getVersionFromGit(experimental);
-        },
+        version: experimental ? experimentalVersion : stableVersion,
       };
 
       return packages;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@angular/devkit-repo",
-  "version": "12.0.0-next.5",
+  "version": "12.0.0-next.6",
   "private": true,
   "description": "Software Development Kit for Angular",
   "bin": {

--- a/packages/schematics/angular/utility/latest-versions.ts
+++ b/packages/schematics/angular/utility/latest-versions.ts
@@ -18,7 +18,7 @@ export const latestVersions = {
   // For our e2e tests, these versions must match the latest tag present on the branch.
   // During RC periods they will not match the latest RC until there's a new git tag, and
   // should not be updated.
-  DevkitBuildAngular: '~0.1200.0-next.5',
+  DevkitBuildAngular: '~0.1200.0-next.6',
 
   ngPackagr: '^12.0.0-next.0',
 };

--- a/scripts/packages.ts
+++ b/scripts/packages.ts
@@ -17,7 +17,7 @@ export default function(args: { json: boolean, version: boolean, releaseCheck: b
   if (args.releaseCheck) {
     const {version: root} = loadRootPackageJson();
     const experimental = stableToExperimentalVersion(root);
-    logger.info(`The expected version for the release is ${colors.bold(root)} (${experimental})`);
+    logger.info(`The expected version for the release is ${colors.bold(root)} (${experimental}) based on root package.json.`);
     logger.info(
       Object.keys(packages)
         .filter(name => !packages[name].private)

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -111,9 +111,9 @@ function _versionCheck(args: PublishArgs, logger: logging.Logger) {
 export default async function (args: PublishArgs, logger: logging.Logger) {
   const { tag } = args;
   if (!tag) {
-    // NPM requires that all releases have a tag associated, defaulting to
-    // `latest`, so there is no way to allow a publish without a tag.
+    // NPM requires that all releases have a tag associated.
     // https://github.com/npm/npm/issues/10625#issuecomment-162106553
+    // Do not publish without a tag.
     throw new Error('--tag is required.');
   }
 


### PR DESCRIPTION
Currently, the version of a release is determined by the git tag.
This PR changes the release script to determine the release version from the
`version` property in the root `package.json`.

With this change, the caretaker will have to update the version in both
`package.json` and `latest-versions.ts` **after** the release.

Release doc has also been updated.