### PR TITLE
ci: remove View Engine related test jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,9 +180,6 @@ jobs:
       nodeversion:
         type: string
         default: *default_nodeversion
-      ve:
-        type: boolean
-        default: false
       snapshots:
         type: boolean
         default: false
@@ -200,12 +197,12 @@ jobs:
           name: Execute CLI E2E Tests
           command: |
             mkdir /mnt/ramdisk/e2e-main
-            node ./tests/legacy-cli/run_e2e --nb-shards=${CIRCLE_NODE_TOTAL} --shard=${CIRCLE_NODE_INDEX} <<# parameters.ve >>--ve<</ parameters.ve >> <<# parameters.snapshots >>--ng-snapshots<</ parameters.snapshots >> --tmpdir=/mnt/ramdisk/e2e-main
+            node ./tests/legacy-cli/run_e2e --nb-shards=${CIRCLE_NODE_TOTAL} --shard=${CIRCLE_NODE_INDEX} <<# parameters.snapshots >>--ng-snapshots<</ parameters.snapshots >> --tmpdir=/mnt/ramdisk/e2e-main
       - run:
           name: Execute CLI E2E Tests Subset with Yarn
           command: |
             mkdir /mnt/ramdisk/e2e-yarn
-            node ./tests/legacy-cli/run_e2e --nb-shards=${CIRCLE_NODE_TOTAL} --shard=${CIRCLE_NODE_INDEX} <<# parameters.ve >>--ve<</ parameters.ve >> <<# parameters.snapshots >>--ng-snapshots<</ parameters.snapshots >> --yarn --tmpdir=/mnt/ramdisk/e2e-yarn --glob="{tests/basic/**,tests/update/**,tests/commands/add/**}"
+            node ./tests/legacy-cli/run_e2e --nb-shards=${CIRCLE_NODE_TOTAL} --shard=${CIRCLE_NODE_INDEX} <<# parameters.snapshots >>--ng-snapshots<</ parameters.snapshots >> --yarn --tmpdir=/mnt/ramdisk/e2e-yarn --glob="{tests/basic/**,tests/update/**,tests/commands/add/**}"
 
   test-browsers:
     executor:
@@ -324,27 +321,16 @@ workflows:
           requires:
             - setup
       - e2e-cli:
-          name: e2e-cli<<# matrix.ve >>-ve<</ matrix.ve >>
-          matrix:
-            alias: e2e-cli-renderers
-            parameters:
-              ve: [true, false]
+          name: e2e-cli
           post-steps:
-            - unless:
-                condition: << matrix.ve >>
-                steps:
-                  - store_artifacts:
-                      path: /tmp/dist
-                      destination: cli/new-production
+            - store_artifacts:
+                path: /tmp/dist
+                destination: cli/new-production
           requires:
             - build
       - e2e-cli:
-          name: e2e-cli-ng<<# matrix.ve >>-ve<</ matrix.ve >>-snapshots
+          name: e2e-cli-ng-snapshots
           snapshots: true
-          matrix:
-            alias: e2e-cli-renderers-snapshots
-            parameters:
-              ve: [true, false]
           requires:
             - e2e-cli
           filters:

--- a/.github/angular-robot.yml
+++ b/.github/angular-robot.yml
@@ -48,7 +48,6 @@ merge:
       - "ci/circleci: test"
       - "ci/circleci: test-win"
       - "ci/circleci: e2e-cli"
-      - "ci/circleci: e2e-cli-ve"
       - "ci/circleci: test-browsers"
       - "ci/angular: size"
       - "cla/google"

--- a/packages/angular_devkit/build_angular/BUILD.bazel
+++ b/packages/angular_devkit/build_angular/BUILD.bazel
@@ -395,15 +395,3 @@ LARGE_SPECS = {
     )
     for spec in LARGE_SPECS
 ]
-
-jasmine_node_test(
-    name = "build_angular_browser_ve_test",
-    size = "large",
-    flaky = True,
-    shard_count = 30,
-    tags = ["cpu:2"],
-    templated_args = [
-        "view_engine",
-    ],
-    deps = [":build_angular_browser_test_lib"],
-)


### PR DESCRIPTION
With the upcoming removal of View Engine support for applications in version 12, the View Engine E2E test job and unit tests are no longer needed.
Only application build support for View Engine will be removed in version 12.  Libraries will continue to support View Engine to maintain backward compatibility.