### PR TITLE
fix(@schematics/angular): explicitly specify ServiceWorker registration strategy

### DIFF
--- a/packages/schematics/angular/component/index_spec.ts
+++ b/packages/schematics/angular/component/index_spec.ts
@@ -145,7 +145,7 @@ describe('Component Schematic', () => {
 
     const tree = await schematicRunner.runSchematicAsync('component', options, appTree).toPromise();
     const appModuleContent = tree.readContent('/projects/bar/src/app/app.module.ts');
-    expect(appModuleContent).toMatch(/exports: \[FooComponent\]/);
+    expect(appModuleContent).toMatch(/exports: \[\n(\s*)  FooComponent\n\1\]/);
   });
 
   it('should set the entry component', async () => {
@@ -153,7 +153,7 @@ describe('Component Schematic', () => {
 
     const tree = await schematicRunner.runSchematicAsync('component', options, appTree).toPromise();
     const appModuleContent = tree.readContent('/projects/bar/src/app/app.module.ts');
-    expect(appModuleContent).toMatch(/entryComponents: \[FooComponent\]/);
+    expect(appModuleContent).toMatch(/entryComponents: \[\n(\s*)  FooComponent\n\1\]/);
   });
 
   it('should import into a specified module', async () => {

--- a/packages/schematics/angular/directive/index_spec.ts
+++ b/packages/schematics/angular/directive/index_spec.ts
@@ -93,7 +93,7 @@ describe('Directive Schematic', () => {
     const tree = await schematicRunner.runSchematicAsync('directive', options, appTree)
       .toPromise();
     const appModuleContent = tree.readContent('/projects/bar/src/app/app.module.ts');
-    expect(appModuleContent).toMatch(/exports: \[FooDirective\]/);
+    expect(appModuleContent).toMatch(/exports: \[\n(\s*)  FooDirective\n\1\]/);
   });
 
   it('should import into a specified module', async () => {

--- a/packages/schematics/angular/library/index_spec.ts
+++ b/packages/schematics/angular/library/index_spec.ts
@@ -139,7 +139,7 @@ describe('Library Schematic', () => {
   it('should export the component in the NgModule', async () => {
     const tree = await schematicRunner.runSchematicAsync('library', defaultOptions, workspaceTree).toPromise();
     const fileContent = getFileContent(tree, '/projects/foo/src/lib/foo.module.ts');
-    expect(fileContent).toContain('exports: [FooComponent]');
+    expect(fileContent).toMatch(/exports: \[\n(\s*)  FooComponent\n\1\]/);
   });
 
   describe(`update package.json`, () => {

--- a/packages/schematics/angular/pipe/index_spec.ts
+++ b/packages/schematics/angular/pipe/index_spec.ts
@@ -99,7 +99,7 @@ describe('Pipe Schematic', () => {
 
     const tree = await schematicRunner.runSchematicAsync('pipe', options, appTree).toPromise();
     const appModuleContent = getFileContent(tree, '/projects/bar/src/app/app.module.ts');
-    expect(appModuleContent).toMatch(/exports: \[FooPipe\]/);
+    expect(appModuleContent).toMatch(/exports: \[\n(\s*)  FooPipe\n\1\]/);
   });
 
   it('should respect the flat flag', async () => {

--- a/packages/schematics/angular/service-worker/index.ts
+++ b/packages/schematics/angular/service-worker/index.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import { join, normalize } from '@angular-devkit/core';
+import { join, normalize, tags } from '@angular-devkit/core';
 import {
   Rule,
   SchematicContext,
@@ -90,8 +90,14 @@ function updateAppModule(mainPath: string): Rule {
     }
 
     // register SW in app module
-    const importText =
-      `ServiceWorkerModule.register('ngsw-worker.js', { enabled: ${importModule}.production })`;
+    const importText = tags.stripIndent`
+      ServiceWorkerModule.register('ngsw-worker.js', {
+        enabled: ${importModule}.production,
+        // Register the ServiceWorker as soon as the app is stable
+        // or after 30 seconds (whichever comes first).
+        registrationStrategy: 'registerWhenStable:30000'
+      })
+    `;
     moduleSource = getTsSourceFile(host, modulePath);
     const metadataChanges = addSymbolToNgModuleMetadata(
       moduleSource, modulePath, 'imports', importText);

--- a/packages/schematics/angular/service-worker/index_spec.ts
+++ b/packages/schematics/angular/service-worker/index_spec.ts
@@ -81,8 +81,13 @@ describe('Service Worker Schematic', () => {
     const tree = await schematicRunner.runSchematicAsync('service-worker', defaultOptions, appTree)
       .toPromise();
     const pkgText = tree.readContent('/projects/bar/src/app/app.module.ts');
-    const expectedText = 'ServiceWorkerModule.register(\'ngsw-worker.js\', { enabled: environment.production })';
-    expect(pkgText).toContain(expectedText);
+    expect(pkgText).toMatch(new RegExp(
+        '(\\s+)ServiceWorkerModule\\.register\\(\'ngsw-worker\\.js\', \\{\\n' +
+        '\\1  enabled: environment\\.production,\\n' +
+        '\\1  // Register the ServiceWorker as soon as the app is stable\\n' +
+        '\\1  // or after 30 seconds \\(whichever comes first\\)\\.\\n' +
+        '\\1  registrationStrategy: \'registerWhenStable:30000\'\\n' +
+        '\\1}\\)'));
   });
 
   it('should add the SW import to the NgModule imports with aliased environment', async () => {
@@ -110,8 +115,13 @@ describe('Service Worker Schematic', () => {
     const tree = await schematicRunner.runSchematicAsync('service-worker', defaultOptions, appTree)
       .toPromise();
     const pkgText = tree.readContent('/projects/bar/src/app/app.module.ts');
-    const expectedText = 'ServiceWorkerModule.register(\'ngsw-worker.js\', { enabled: env.production })';
-    expect(pkgText).toContain(expectedText);
+    expect(pkgText).toMatch(new RegExp(
+        '(\\s+)ServiceWorkerModule\\.register\\(\'ngsw-worker\\.js\', \\{\\n' +
+        '\\1  enabled: env\\.production,\\n' +
+        '\\1  // Register the ServiceWorker as soon as the app is stable\\n' +
+        '\\1  // or after 30 seconds \\(whichever comes first\\)\\.\\n' +
+        '\\1  registrationStrategy: \'registerWhenStable:30000\'\\n' +
+        '\\1}\\)'));
   });
 
   it('should add the SW import to the NgModule imports with existing environment', async () => {
@@ -139,8 +149,13 @@ describe('Service Worker Schematic', () => {
     const tree = await schematicRunner.runSchematicAsync('service-worker', defaultOptions, appTree)
       .toPromise();
     const pkgText = tree.readContent('/projects/bar/src/app/app.module.ts');
-    const expectedText = 'ServiceWorkerModule.register(\'ngsw-worker.js\', { enabled: environment.production })';
-    expect(pkgText).toContain(expectedText);
+    expect(pkgText).toMatch(new RegExp(
+        '(\\s+)ServiceWorkerModule\\.register\\(\'ngsw-worker\\.js\', \\{\\n' +
+        '\\1  enabled: environment\\.production,\\n' +
+        '\\1  // Register the ServiceWorker as soon as the app is stable\\n' +
+        '\\1  // or after 30 seconds \\(whichever comes first\\)\\.\\n' +
+        '\\1  registrationStrategy: \'registerWhenStable:30000\'\\n' +
+        '\\1}\\)'));
   });
 
   it('should put the ngsw-config.json file in the project root', async () => {

--- a/packages/schematics/angular/utility/ast-utils.ts
+++ b/packages/schematics/angular/utility/ast-utils.ts
@@ -358,10 +358,6 @@ export function addSymbolToNgModuleMetadata(
     metadataField,
   );
 
-  // Get the last node of the array literal.
-  if (!matchingProperties) {
-    return [];
-  }
   if (matchingProperties.length == 0) {
     // We haven't found the field in the metadata declaration. Insert a new field.
     const expr = node as ts.ObjectLiteralExpression;
@@ -406,13 +402,6 @@ export function addSymbolToNgModuleMetadata(
     node = arrLiteral.elements;
   }
 
-  if (!node) {
-    // tslint:disable-next-line: no-console
-    console.error('No app module found. Please add your new class to your component.');
-
-    return [];
-  }
-
   if (Array.isArray(node)) {
     const nodeArray = node as {} as Array<ts.Node>;
     const symbolsArray = nodeArray.map(node => node.getText());
@@ -425,23 +414,7 @@ export function addSymbolToNgModuleMetadata(
 
   let toInsert: string;
   let position = node.getEnd();
-  if (node.kind == ts.SyntaxKind.ObjectLiteralExpression) {
-    // We haven't found the field in the metadata declaration. Insert a new
-    // field.
-    const expr = node as ts.ObjectLiteralExpression;
-    if (expr.properties.length == 0) {
-      position = expr.getEnd() - 1;
-      toInsert = `  ${symbolName}\n`;
-    } else {
-      // Get the indentation of the last element, if any.
-      const text = node.getFullText(source);
-      if (text.match(/^\r?\r?\n/)) {
-        toInsert = `,${text.match(/^\r?\n\s*/)[0]}${symbolName}`;
-      } else {
-        toInsert = `, ${symbolName}`;
-      }
-    }
-  } else if (node.kind == ts.SyntaxKind.ArrayLiteralExpression) {
+  if (node.kind == ts.SyntaxKind.ArrayLiteralExpression) {
     // We found the field but it's empty. Insert it just before the `]`.
     position--;
     toInsert = `${symbolName}`;

--- a/packages/schematics/angular/utility/ast-utils_spec.ts
+++ b/packages/schematics/angular/utility/ast-utils_spec.ts
@@ -70,7 +70,7 @@ describe('ast utils', () => {
     const changes = addExportToModule(source, modulePath, 'FooComponent', './foo.component');
     const output = applyChanges(modulePath, moduleContent, changes);
     expect(output).toMatch(/import { FooComponent } from '.\/foo.component';/);
-    expect(output).toMatch(/exports: \[FooComponent\]/);
+    expect(output).toMatch(/exports: \[\n(\s*)  FooComponent\n\1\]/);
   });
 
   it('should add export to module if not indented', () => {
@@ -79,7 +79,7 @@ describe('ast utils', () => {
     const changes = addExportToModule(source, modulePath, 'FooComponent', './foo.component');
     const output = applyChanges(modulePath, moduleContent, changes);
     expect(output).toMatch(/import { FooComponent } from '.\/foo.component';/);
-    expect(output).toMatch(/exports: \[FooComponent\]/);
+    expect(output).toMatch(/exports: \[\n(\s*)  FooComponent\n\1\]/);
   });
 
   it('should add declarations to module if not indented', () => {
@@ -120,7 +120,7 @@ describe('ast utils', () => {
     expect(changes).not.toBeNull();
 
     const output = applyChanges(modulePath, moduleContent, changes || []);
-    expect(output).toMatch(/imports: [\s\S]+,\n\s+HelloWorld\n\s+\]/m);
+    expect(output).toMatch(/imports: \[[^\]]+,\n(\s*)  HelloWorld\n\1\]/);
   });
 
   it('should add metadata (comma)', () => {
@@ -145,7 +145,7 @@ describe('ast utils', () => {
     expect(changes).not.toBeNull();
 
     const output = applyChanges(modulePath, moduleContent, changes || []);
-    expect(output).toMatch(/imports: [\s\S]+,\n\s+HelloWorld,\n\s+\]/m);
+    expect(output).toMatch(/imports: \[[^\]]+,\n(\s*)  HelloWorld,\n\1\]/);
   });
 
   it('should add metadata (missing)', () => {
@@ -167,7 +167,7 @@ describe('ast utils', () => {
     expect(changes).not.toBeNull();
 
     const output = applyChanges(modulePath, moduleContent, changes || []);
-    expect(output).toMatch(/imports: \[HelloWorld]\r?\n/m);
+    expect(output).toMatch(/imports: \[\n(\s*)  HelloWorld\n\1\]/);
   });
 
   it('should add metadata (empty)', () => {
@@ -190,7 +190,7 @@ describe('ast utils', () => {
     expect(changes).not.toBeNull();
 
     const output = applyChanges(modulePath, moduleContent, changes || []);
-    expect(output).toMatch(/imports: \[HelloWorld],\r?\n/m);
+    expect(output).toMatch(/imports: \[\n(\s*)  HelloWorld\n\1\],\n/);
   });
 
   it(`should handle NgModule with newline after '@'`, () => {

--- a/tests/legacy-cli/e2e/tests/generate/component/component-module-export.ts
+++ b/tests/legacy-cli/e2e/tests/generate/component/component-module-export.ts
@@ -7,7 +7,7 @@ export default function() {
   const modulePath = join('src', 'app', 'app.module.ts');
 
   return ng('generate', 'component', 'test-component', '--export')
-    .then(() => expectFileToMatch(modulePath, 'exports: [TestComponentComponent]'))
+    .then(() => expectFileToMatch(modulePath, /exports: \[\n(\s*)  TestComponentComponent\n\1\]/))
 
     // Try to run the unit tests.
     .then(() => ng('test', '--watch=false'));

--- a/tests/legacy-cli/e2e/tests/generate/directive/directive-module-export.ts
+++ b/tests/legacy-cli/e2e/tests/generate/directive/directive-module-export.ts
@@ -7,7 +7,7 @@ export default function() {
   const modulePath = join('src', 'app', 'app.module.ts');
 
   return ng('generate', 'directive', 'test-directive', '--export')
-    .then(() => expectFileToMatch(modulePath, 'exports: [TestDirectiveDirective]'))
+    .then(() => expectFileToMatch(modulePath, /exports: \[\n(\s*)  TestDirectiveDirective\n\1\]/))
 
     // Try to run the unit tests.
     .then(() => ng('test', '--watch=false'));

--- a/tests/legacy-cli/e2e/tests/generate/pipe/pipe-module-export.ts
+++ b/tests/legacy-cli/e2e/tests/generate/pipe/pipe-module-export.ts
@@ -7,7 +7,7 @@ export default function() {
   const modulePath = join('src', 'app', 'app.module.ts');
 
   return ng('generate', 'pipe', 'test-pipe', '--export')
-    .then(() => expectFileToMatch(modulePath, 'exports: [TestPipePipe]'))
+    .then(() => expectFileToMatch(modulePath, /exports: \[\n(\s*)  TestPipePipe\n\1\]/))
 
     // Try to run the unit tests.
     .then(() => ng('test', '--watch=false'));


### PR DESCRIPTION
This PR updates the `service-worker` schematics to explicitly specify the ServiceWorker registration strategy in the [ServiceWorkerModule.register()] call.

We still use the default strategy, so there should be no change in the behavior of the generated apps. However, it will help people find out what the default behavior is when debugging potential issues with delayed ServiceWorker registration.
(See the discussion in angular/angular#41223 for more details.)

##
In order to be able to do this (and format the code in a readable way), this PR also makes some updates to the `addSymbolToNgModuleMetadata()` function. See individual commits for details.

[1]: https://angular.io/api/service-worker/ServiceWorkerModule#register