### PR TITLE
refactor(@angular/cli): remove `Ivy Workspace` from `ng version`

### DIFF
--- a/packages/angular/cli/commands/version-impl.ts
+++ b/packages/angular/cli/commands/version-impl.ts
@@ -8,7 +8,6 @@
 import * as path from 'path';
 import { Command } from '../models/command';
 import { colors } from '../utilities/color';
-import { JSONFile } from '../utilities/json-file';
 import { Schema as VersionCommandSchema } from './version';
 
 interface PartialPackageInfo {
@@ -125,7 +124,6 @@ export class VersionCommand extends Command<VersionCommandSchema> {
           return acc;
         }, [])
         .join('\n... ')}
-      Ivy Workspace: ${workspacePackage ? this.getIvyWorkspace() : ''}
 
       Package${namePad.slice(7)}Version
       -------${namePad.replace(/ /g, '-')}------------------
@@ -164,17 +162,5 @@ export class VersionCommand extends Command<VersionCommandSchema> {
     }
 
     return version || '<error>';
-  }
-
-  private getIvyWorkspace(): string {
-    try {
-      const json = new JSONFile(path.resolve(this.context.root, 'tsconfig.json'));
-
-      return json.get(['angularCompilerOptions', 'enableIvy']) === false
-        ? 'No'
-        : 'Yes';
-    } catch {
-      return '<error>';
-    }
   }
 }

--- a/tests/legacy-cli/e2e/tests/misc/version.ts
+++ b/tests/legacy-cli/e2e/tests/misc/version.ts
@@ -1,23 +1,11 @@
-import { getGlobalVariable } from '../../utils/env';
 import { deleteFile } from '../../utils/fs';
 import { ng } from '../../utils/process';
-
 
 export default async function() {
   const { stdout: commandOutput } = await ng('version');
   const { stdout: optionOutput } = await ng('--version');
   if (!optionOutput.includes('Angular CLI:')) {
     throw new Error('version not displayed');
-  }
-
-  const argv = getGlobalVariable('argv');
-  const veProject = argv['ve'];
-
-  const ivyWorkspaceMatch = veProject
-    ? 'Ivy Workspace: No'
-    : 'Ivy Workspace: Yes';
-  if (!optionOutput.includes(ivyWorkspaceMatch)) {
-    throw new Error(`Expected output to contain ${ivyWorkspaceMatch}`);
   }
 
   if (commandOutput !== optionOutput) {


### PR DESCRIPTION
In version 12, only Ivy will be allowed to be used to compile an application.