### PR TITLE
fix(@angular-devkit/build-angular): remove deprecated i18nLocale and i18nFormat options

### DIFF
--- a/packages/angular_devkit/build_angular/src/extract-i18n/index.ts
+++ b/packages/angular_devkit/build_angular/src/extract-i18n/index.ts
@@ -96,13 +96,8 @@ async function getSerializer(format: Format, sourceLocale: string, basePath: str
   }
 }
 
-function normalizeFormatOption(options: ExtractI18nBuilderOptions) {
-  let format;
-  if (options.i18nFormat !== Format.Xlf) {
-    format = options.i18nFormat;
-  } else {
-    format = options.format;
-  }
+function normalizeFormatOption(options: ExtractI18nBuilderOptions): Format {
+  let format = options.format;
 
   switch (format) {
     case Format.Xlf:
@@ -114,21 +109,10 @@ function normalizeFormatOption(options: ExtractI18nBuilderOptions) {
     case Format.Xliff2:
       format = Format.Xlf2;
       break;
-    case Format.Json:
-      format = Format.Json;
-      break;
-    case Format.Arb:
-      format = Format.Arb;
-      break;
-    case Format.LegacyMigrate:
-      format = Format.LegacyMigrate;
-      break;
-    case undefined:
-      format = Format.Xlf;
-      break;
   }
 
-  return format;
+  // Default format is xliff1
+  return format ?? Format.Xlf;
 }
 
 class NoEmitPlugin {
@@ -183,7 +167,7 @@ export async function execute(
         vendor: true,
       },
       buildOptimizer: false,
-      i18nLocale: options.i18nLocale || i18n.sourceLocale,
+      i18nLocale: i18n.sourceLocale,
       i18nFormat: format,
       i18nFile: outFile,
       aot: true,

--- a/packages/angular_devkit/build_angular/src/extract-i18n/schema.json
+++ b/packages/angular_devkit/build_angular/src/extract-i18n/schema.json
@@ -25,28 +25,6 @@
         "legacy-migrate"
       ]
     },
-    "i18nFormat": {
-      "type": "string",
-      "description": "Output format for the generated file.",
-      "default": "xlf",
-      "x-deprecated": "Use 'format' option instead.",
-      "enum": [
-        "xmb",
-        "xlf",
-        "xlif",
-        "xliff",
-        "xlf2",
-        "xliff2",
-        "json",
-        "arb",
-        "legacy-migrate"
-      ]
-    },
-    "i18nLocale": {
-      "type": "string",
-      "description": "Specifies the source language of the application.",
-      "x-deprecated": "Use 'i18n' project level sub-option 'sourceLocale' instead."
-    },
     "progress": {
       "type": "boolean",
       "description": "Log progress to the console.",

--- a/packages/schematics/angular/migrations/migration-collection.json
+++ b/packages/schematics/angular/migrations/migration-collection.json
@@ -145,6 +145,11 @@
       "factory": "./update-8/#updateLazyModulePaths",
       "description": "Lazy loading syntax migration. Update lazy loading string syntax to use dynamic imports."
     },
+    "remove-deprecated-i18n-options": {
+      "version": "12.0.0-next.7",
+      "factory": "./update-9/update-i18n#updateI18nConfig",
+      "description": "Remove deprecated ViewEngine-based i18n build and extract options. Options present in the configuration will be converted to use non-deprecated options."
+    },
     "production-by-default": {
       "version": "9999.0.0",
       "factory": "./update-12/production-default-config",


### PR DESCRIPTION
BREAKING CHANGE: Removal of deprecated `extract-i18n` command options
The deprecated `i18nLocale` option has been removed and the `i18n.sourceLocale` within a project's configuration should be used instead.
The deprecated `i18nFormat` option has been removed and the `format` option should be used instead.