### PR TITLE
fix(@ngtools/webpack): use correct Webpack asset stage in resource loader

### DIFF
--- a/packages/ngtools/webpack/src/resource_loader.ts
+++ b/packages/ngtools/webpack/src/resource_loader.ts
@@ -136,7 +136,7 @@ export class WebpackResourceLoader {
     if (isWebpackFiveOrHigher()) {
       childCompiler.hooks.compilation.tap('angular-compiler', (childCompilation) => {
         // tslint:disable-next-line: no-any
-        (childCompilation.hooks as any).processAssets.tap('angular-compiler', () => {
+        (childCompilation.hooks as any).processAssets.tap({name: 'angular-compiler', stage: 5000}, () => {
           finalContent = childCompilation.assets[filePath]?.source().toString();
           finalMap = childCompilation.assets[filePath + '.map']?.source().toString();
 


### PR DESCRIPTION
The asset extraction within the Angular compiler plugin resource loader needs to occur at the end of the Webpack asset processing pipeline. This ensures that all analysis and preprocessing of the asset have been performed before the resource asset is extracted from the Webpack child compilation.