### PR TITLE
test(@ngtools/webpack): update webpack test-app E2E to use ivy plugin

### DIFF
--- a/tests/legacy-cli/e2e/assets/webpack/test-app/package.json
+++ b/tests/legacy-cli/e2e/assets/webpack/test-app/package.json
@@ -2,25 +2,25 @@
   "name": "test",
   "license": "MIT",
   "dependencies": {
-    "@angular/common": "11.0.0",
-    "@angular/compiler": "11.0.0",
-    "@angular/compiler-cli": "11.0.0",
-    "@angular/core": "11.0.0",
-    "@angular/platform-browser": "11.0.0",
-    "@angular/platform-browser-dynamic": "11.0.0",
-    "@angular/platform-server": "11.0.0",
-    "@angular/router": "11.0.0",
+    "@angular/common": "^12.0.0-next",
+    "@angular/compiler": "^12.0.0-next",
+    "@angular/compiler-cli": "^12.0.0-next",
+    "@angular/core": "^12.0.0-next",
+    "@angular/platform-browser": "^12.0.0-next",
+    "@angular/platform-browser-dynamic": "^12.0.0-next",
+    "@angular/platform-server": "^12.0.0-next",
+    "@angular/router": "^12.0.0-next",
     "@ngtools/webpack": "0.0.0",
-    "core-js": "^3.0.0",
-    "rxjs": "^6.4.0",
-    "zone.js": "^0.9.1"
+    "core-js": "^3.10.0",
+    "rxjs": "^6.6.7",
+    "zone.js": "^0.11.4"
   },
   "devDependencies": {
     "raw-loader": "^4.0.2",
-    "sass": "^1.32.5",
+    "sass": "^1.32.8",
     "sass-loader": "^10.1.1",
-    "typescript": "~4.0.1",
-    "webpack": "^4.0.1",
-    "webpack-cli": "^4.4.0"
+    "typescript": "~4.2.3",
+    "webpack": "^4.46.0",
+    "webpack-cli": "^4.5.0"
   }
 }

--- a/tests/legacy-cli/e2e/assets/webpack/test-app/webpack.config.js
+++ b/tests/legacy-cli/e2e/assets/webpack/test-app/webpack.config.js
@@ -12,15 +12,13 @@ module.exports = {
     filename: 'app.main.js'
   },
   plugins: [
-    new ngToolsWebpack.AngularCompilerPlugin({
-      tsConfigPath: './tsconfig.json'
-    })
+    new ngToolsWebpack.ivy.AngularWebpackPlugin(),
   ],
   module: {
     rules: [
-      { test: /\.scss$/, loaders: ['raw-loader', 'sass-loader'] },
+      { test: /\.scss$/, use: ['raw-loader', 'sass-loader'] },
       { test: /\.html$/, loader: 'raw-loader' },
-      { test: /\.ts$/, loader: '@ngtools/webpack' }
+      { test: /\.ts$/, loader: ngToolsWebpack.ivy.AngularWebpackLoaderPath }
     ]
   },
   devServer: {


### PR DESCRIPTION
This webpack E2E test application now uses the Ivy webpack plugin instead of the deprecated ViewEngine plugin.