### PR TITLE
refactor(@angular-devkit/architect): remove builder option generic json constraint

### DIFF
--- a/etc/api/angular_devkit/architect/src/index.d.ts
+++ b/etc/api/angular_devkit/architect/src/index.d.ts
@@ -26,7 +26,7 @@ export interface BuilderContext {
     validateOptions<T extends json.JsonObject = json.JsonObject>(options: json.JsonObject, builderName: string): Promise<T>;
 }
 
-export interface BuilderHandlerFn<A extends json.JsonObject> {
+export interface BuilderHandlerFn<A> {
     (input: A, context: BuilderContext): BuilderOutputLike;
 }
 
@@ -60,7 +60,7 @@ export interface BuilderRun {
     stop(): Promise<void>;
 }
 
-export declare function createBuilder<OptT extends json.JsonObject, OutT extends BuilderOutput = BuilderOutput>(fn: BuilderHandlerFn<OptT>): Builder<OptT>;
+export declare function createBuilder<OptT = json.JsonObject, OutT extends BuilderOutput = BuilderOutput>(fn: BuilderHandlerFn<OptT>): Builder<OptT & json.JsonObject>;
 
 export declare function fromAsyncIterable<T>(iterable: AsyncIterable<T>): Observable<T>;
 

--- a/packages/angular_devkit/architect/src/api.ts
+++ b/packages/angular_devkit/architect/src/api.ts
@@ -305,7 +305,7 @@ async function handleAsyncIterator<T>(
 /**
  * A builder handler function. The function signature passed to `createBuilder()`.
  */
-export interface BuilderHandlerFn<A extends json.JsonObject> {
+export interface BuilderHandlerFn<A> {
   /**
    * Builders are defined by users to perform any kind of task, like building, testing or linting,
    * and should use this interface.

--- a/packages/angular_devkit/architect/src/create-builder.ts
+++ b/packages/angular_devkit/architect/src/create-builder.ts
@@ -28,11 +28,11 @@ import { scheduleByName, scheduleByTarget } from './schedule-by-name';
 
 // tslint:disable-next-line: no-big-function
 export function createBuilder<
-  OptT extends json.JsonObject,
+  OptT = json.JsonObject,
   OutT extends BuilderOutput = BuilderOutput,
 >(
   fn: BuilderHandlerFn<OptT>,
-): Builder<OptT> {
+): Builder<OptT & json.JsonObject> {
   const cjh = experimental.jobs.createJobHandler;
   const handler = cjh<json.JsonObject, BuilderInput, OutT>((options, context) => {
     const scheduler = context.scheduler;

--- a/packages/angular_devkit/build_webpack/BUILD.bazel
+++ b/packages/angular_devkit/build_webpack/BUILD.bazel
@@ -48,7 +48,6 @@ ts_library(
     module_root = "src/index.d.ts",
     deps = [
         "//packages/angular_devkit/architect",
-        "//packages/angular_devkit/core",
         "@npm//@types/node",
         "@npm//@types/webpack",
         "@npm//@types/webpack-dev-server",

--- a/packages/angular_devkit/build_webpack/package.json
+++ b/packages/angular_devkit/build_webpack/package.json
@@ -8,8 +8,11 @@
   "builders": "builders.json",
   "dependencies": {
     "@angular-devkit/architect": "0.0.0",
-    "@angular-devkit/core": "0.0.0",
     "rxjs": "6.6.7"
+  },
+  "devDependencies": {
+    "@angular-devkit/core": "0.0.0",
+    "node-fetch": "2.6.1"
   },
   "peerDependencies": {
     "webpack": "^4.6.0",

--- a/packages/angular_devkit/build_webpack/src/webpack-dev-server/index.ts
+++ b/packages/angular_devkit/build_webpack/src/webpack-dev-server/index.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import { BuilderContext, createBuilder } from '@angular-devkit/architect';
-import { json } from '@angular-devkit/core';
 import * as net from 'net';
 import { resolve as pathResolve } from 'path';
 import { Observable, from, isObservable, of } from 'rxjs';
@@ -117,12 +116,12 @@ export function runWebpackDevServer(
 }
 
 
-export default createBuilder<
-  json.JsonObject & WebpackDevServerBuilderSchema, DevServerBuildOutput
->((options, context) => {
-  const configPath = pathResolve(context.workspaceRoot, options.webpackConfig);
+export default createBuilder<WebpackDevServerBuilderSchema, DevServerBuildOutput>(
+  (options, context) => {
+    const configPath = pathResolve(context.workspaceRoot, options.webpackConfig);
 
-  return from(import(configPath)).pipe(
-    switchMap((config: webpack.Configuration) => runWebpackDevServer(config, context)),
-  );
-});
+    return from(import(configPath)).pipe(
+      switchMap((config: webpack.Configuration) => runWebpackDevServer(config, context)),
+    );
+  },
+);

--- a/packages/angular_devkit/build_webpack/src/webpack-dev-server/index_spec.ts
+++ b/packages/angular_devkit/build_webpack/src/webpack-dev-server/index_spec.ts
@@ -8,8 +8,8 @@
 import { Architect } from '@angular-devkit/architect';
 import { WorkspaceNodeModulesArchitectHost } from '@angular-devkit/architect/node';
 import { TestingArchitectHost } from '@angular-devkit/architect/testing';
-import { schema, workspaces } from '@angular-devkit/core';
-import { NodeJsSyncHost } from '@angular-devkit/core/node';
+import { schema, workspaces } from '@angular-devkit/core'; // tslint:disable-line:no-implicit-dependencies
+import { NodeJsSyncHost } from '@angular-devkit/core/node'; // tslint:disable-line:no-implicit-dependencies
 import fetch from 'node-fetch';  // tslint:disable-line:no-implicit-dependencies
 import * as path from 'path';
 import { DevServerBuildOutput } from './index';

--- a/packages/angular_devkit/build_webpack/src/webpack/index.ts
+++ b/packages/angular_devkit/build_webpack/src/webpack/index.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import { BuilderContext, BuilderOutput, createBuilder } from '@angular-devkit/architect';
-import { json } from '@angular-devkit/core';
 import { resolve as pathResolve } from 'path';
 import { Observable, from, isObservable, of } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
@@ -14,7 +13,7 @@ import * as webpack from 'webpack';
 import { EmittedFiles, getEmittedFiles } from '../utils';
 import { Schema as RealWebpackBuilderSchema } from './schema';
 
-export type WebpackBuilderSchema = json.JsonObject & RealWebpackBuilderSchema;
+export type WebpackBuilderSchema = RealWebpackBuilderSchema;
 
 export interface WebpackLoggingCallback {
   (stats: webpack.Stats, config: webpack.Configuration): void;

--- a/packages/angular_devkit/build_webpack/src/webpack/index_spec.ts
+++ b/packages/angular_devkit/build_webpack/src/webpack/index_spec.ts
@@ -8,8 +8,8 @@
 import { Architect } from '@angular-devkit/architect';
 import { WorkspaceNodeModulesArchitectHost } from '@angular-devkit/architect/node';
 import { TestingArchitectHost } from '@angular-devkit/architect/testing';
-import { join, normalize, schema, workspaces } from '@angular-devkit/core';
-import { NodeJsSyncHost, createConsoleLogger } from '@angular-devkit/core/node';
+import { join, normalize, schema, workspaces } from '@angular-devkit/core'; // tslint:disable-line:no-implicit-dependencies
+import { NodeJsSyncHost, createConsoleLogger } from '@angular-devkit/core/node'; // tslint:disable-line:no-implicit-dependencies
 import * as path from 'path';
 import { BuildResult } from './index';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8689,6 +8689,11 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
+node-fetch@2.6.1, node-fetch@^2.2.0, node-fetch@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+
 node-fetch@^1.0.1:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
@@ -8696,11 +8701,6 @@ node-fetch@^1.0.1:
   dependencies:
     encoding "^0.1.11"
     is-stream "^1.0.1"
-
-node-fetch@^2.2.0, node-fetch@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
-  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
 node-forge@^0.10.0:
   version "0.10.0"


### PR DESCRIPTION
The `json.JsonObject` generic constraint did not force the options type to be a valid JSON object but required all builders to add the `json.JsonObject` type to all builder option types when calling `createBuilder`.