### PR TITLE
fix(@angular-devkit/core): correctly handle null prototype in deepCopy

### DIFF
--- a/packages/angular_devkit/core/src/utils/object.ts
+++ b/packages/angular_devkit/core/src/utils/object.ts
@@ -40,7 +40,7 @@ export function deepCopy<T extends any>(value: T): T {
       return JSON.parse(valueCasted['toJSON']());
     }
 
-    const copy = new (Object.getPrototypeOf(valueCasted).constructor)();
+    const copy = Object.create(Object.getPrototypeOf(valueCasted));
     valueCasted[copySymbol] = copy;
     for (const key of Object.getOwnPropertyNames(valueCasted)) {
       copy[key] = deepCopy(valueCasted[key]);

--- a/packages/angular_devkit/core/src/utils/object_spec.ts
+++ b/packages/angular_devkit/core/src/utils/object_spec.ts
@@ -50,5 +50,11 @@ describe('object', () => {
       expect(result.b).not.toBe(data1);
       expect(result.b).toBe(result.b.circular.b);
     });
+
+    it('works with null prototype', () => {
+      const data = Object.create(null);
+      data['a'] = 1;
+      expect(deepCopy(data)).toEqual(data);
+    });
   });
 });


### PR DESCRIPTION
Cherry-pick of the fix already in master and 11.2.x for #19492