### PR TITLE
fix(@angular-devkit/build-angular): remove usage of deprecated View Engine compiler

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/environment-options.ts
+++ b/packages/angular_devkit/build_angular/src/utils/environment-options.ts
@@ -82,8 +82,3 @@ export const cachingBasePath = (() => {
 // Build profiling
 const profilingVariable = process.env['NG_BUILD_PROFILING'];
 export const profilingEnabled = isPresent(profilingVariable) && isEnabled(profilingVariable);
-
-// Legacy Webpack plugin with Ivy
-const legacyIvyVariable = process.env['NG_BUILD_IVY_LEGACY'];
-export const legacyIvyPluginEnabled =
-  isPresent(legacyIvyVariable) && !isDisabled(legacyIvyVariable);

--- a/tests/legacy-cli/e2e/tests/i18n/extract-ivy.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/extract-ivy.ts
@@ -42,7 +42,7 @@ export default async function() {
   });
 
   // Should show ivy disabled application warning with enableIvy false
-  const { message: message4 } = await expectToFail(() => ng('extract-i18n'));
+  const { stderr: message4 } = await ng('extract-i18n');
   if (!message4.includes(`Ivy extraction enabled but application is not Ivy enabled.`)) {
     throw new Error('Expected ivy disabled application warning');
   }


### PR DESCRIPTION
BREAKING CHANGE: Removal of View Engine support from application builds
With the removal of the deprecated View Engine compiler in Angular version 12 for applications, Ivy-based compilation will always be used when building an application.
The default behavior for applications is to use the Ivy compiler when building and no changes are required for these applications.
For applications that have opted-out of Ivy, a warning will be shown and an Ivy-based build will be attempted. If the build fails,
the application may need to be updated to become Ivy compatible.