### PR TITLE
ci: change renovate label to `target: minor`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
   "separateMajorMinor": false,
   "prHourlyLimit": 2,
   "labels": [
-    "target: major",
+    "target: minor",
     "action: merge"
   ],
   "timezone": "America/Tijuana",


### PR DESCRIPTION
This eliminates the requirement that when master is not a major we require to change the label.  `target: minor` is always get merged into master (and master only): https://github.com/angular/angular/blob/ed77bfea26e64bd24019812131e14f5dd450fcf5/docs/BRANCHES.md#pull-request-examples  hence using `target: major` is not needed in this case.