### PR TITLE
build: update `@angular/dev-infra-private` package

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@angular/compiler": "12.0.0-next.7",
     "@angular/compiler-cli": "12.0.0-next.7",
     "@angular/core": "12.0.0-next.7",
-    "@angular/dev-infra-private": "https://github.com/angular/dev-infra-private-builds.git#ebf0a487a4de71746b5b025e4e7878ca5714ba46",
+    "@angular/dev-infra-private": "https://github.com/angular/dev-infra-private-builds.git#5b679b4e99a3280a2670fdea92729ebf9ba1cb72",
     "@angular/forms": "12.0.0-next.7",
     "@angular/localize": "12.0.0-next.7",
     "@angular/material": "11.2.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -85,10 +85,9 @@
   dependencies:
     tslib "^2.0.0"
 
-"@angular/dev-infra-private@https://github.com/angular/dev-infra-private-builds.git#ebf0a487a4de71746b5b025e4e7878ca5714ba46":
+"@angular/dev-infra-private@https://github.com/angular/dev-infra-private-builds.git#5b679b4e99a3280a2670fdea92729ebf9ba1cb72":
   version "0.0.0"
-  uid ebf0a487a4de71746b5b025e4e7878ca5714ba46
-  resolved "https://github.com/angular/dev-infra-private-builds.git#ebf0a487a4de71746b5b025e4e7878ca5714ba46"
+  resolved "https://github.com/angular/dev-infra-private-builds.git#5b679b4e99a3280a2670fdea92729ebf9ba1cb72"
   dependencies:
     "@angular/benchpress" "0.2.1"
     "@bazel/buildifier" "^0.29.0"


### PR DESCRIPTION
This updates to a version that contains the following fix https://github.com/angular/angular/pull/41430