### PR TITLE
ci: set Node.js v14 as the default version for jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,9 +17,9 @@ orbs:
 ## IMPORTANT
 # Windows needs its own cache key because binaries in node_modules are different.
 # See https://circleci.com/docs/2.0/caching/#restoring-cache for how prefixes work in CircleCI.
-var_1: &cache_key v1-angular_devkit-12.18-{{ checksum "yarn.lock" }}
-var_1_win: &cache_key_win v1-angular_devkit-win-12.18-{{ checksum "yarn.lock" }}
-var_3: &default_nodeversion "12.18"
+var_1: &cache_key v1-angular_devkit-14.15-{{ checksum "yarn.lock" }}
+var_1_win: &cache_key_win v1-angular_devkit-win-14.15-{{ checksum "yarn.lock" }}
+var_3: &default_nodeversion "14.15"
 # Workspace initially persisted by the `setup` job, and then enhanced by `setup-and-build-win`.
 # https://circleci.com/docs/2.0/workflows/#using-workspaces-to-share-data-among-jobs
 # https://circleci.com/blog/deep-diving-into-circleci-workspaces/
@@ -75,8 +75,8 @@ commands:
           at: *workspace_location
   setup_windows:
     steps:
-      - run: nvm install 12.13
-      - run: nvm use 12.13
+      - run: nvm install 14.15
+      - run: nvm use 14.15
       - run: npm install -g yarn@1.22.10
       - run: node --version
       - run: yarn --version
@@ -338,8 +338,8 @@ workflows:
                 - renovate/angular
                 - master
       - e2e-cli:
-          name: e2e-cli-node-14
-          nodeversion: "14.15"
+          name: e2e-cli-node-12
+          nodeversion: "12.18"
           <<: *only_release_branches
           requires:
             - e2e-cli


### PR DESCRIPTION
All PR jobs will use Node.js v14.
A Node.js v12 E2E job is now run on release branches.