### PR TITLE
ci: consolidate Windows test jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ orbs:
 # See https://circleci.com/docs/2.0/caching/#restoring-cache for how prefixes work in CircleCI.
 var_1: &cache_key v1-angular_devkit-14.15-{{ checksum "yarn.lock" }}
 var_1_win: &cache_key_win v1-angular_devkit-win-12.22-{{ checksum "yarn.lock" }}
-var_3: &default_nodeversion "14.15"
+var_3: &default_nodeversion '14.15'
 # Workspace initially persisted by the `setup` job, and then enhanced by `setup-and-build-win`.
 # https://circleci.com/docs/2.0/workflows/#using-workspaces-to-share-data-among-jobs
 # https://circleci.com/blog/deep-diving-into-circleci-workspaces/
@@ -88,7 +88,7 @@ commands:
         default: CIRCLE_PROJECT_REPONAME
     steps:
       - run:
-          name: "Setup bazel RBE remote execution"
+          name: 'Setup bazel RBE remote execution'
           command: |
             touch .bazelrc.user;
             # We need ensure that the same default digest is used for encoding and decoding
@@ -111,7 +111,7 @@ commands:
   install_python:
     steps:
       - run:
-          name: "Install Python 2"
+          name: 'Install Python 2'
           command: |
             sudo apt-get update > /dev/null 2>&1
             sudo apt-get install -y python
@@ -155,10 +155,10 @@ jobs:
       - custom_attach_workspace
       - run: yarn lint
       - run: 'yarn bazel:format -mode=check ||
-              (echo "BUILD files not formatted. Please run ''yarn bazel:format''" ; exit 1)'
+          (echo "BUILD files not formatted. Please run ''yarn bazel:format''" ; exit 1)'
       # Run the skylark linter to check our Bazel rules
       - run: 'yarn bazel:lint ||
-              (echo -e "\n.bzl files have lint errors. Please run ''yarn bazel:lint-fix''"; exit 1)'
+          (echo -e "\n.bzl files have lint errors. Please run ''yarn bazel:lint-fix''"; exit 1)'
 
   validate:
     executor: action-executor
@@ -226,7 +226,7 @@ jobs:
         # too early without Saucelabs not being ready.
       - run: ./scripts/saucelabs/wait-for-tunnel.sh
       - run: node ./tests/legacy-cli/run_e2e ./tests/legacy-cli/e2e/tests/misc/browsers.ts --ve
-      - run: node ./tests/legacy-cli/run_e2e ./tests/legacy-cli/e2e/tests/misc/browsers.ts 
+      - run: node ./tests/legacy-cli/run_e2e ./tests/legacy-cli/e2e/tests/misc/browsers.ts
       - run: ./scripts/saucelabs/stop-tunnel.sh
 
   build:
@@ -254,7 +254,7 @@ jobs:
       - custom_attach_workspace
       - run:
           name: Decrypt Credentials
-          # Note: when changing the image, you might have to re-encrypt the credentials with a 
+          # Note: when changing the image, you might have to re-encrypt the credentials with a
           # matching version of openssl.
           # See https://stackoverflow.com/a/43847627/2116927 for more info.
           command: |
@@ -324,7 +324,7 @@ workflows:
                 - master
       - e2e-cli:
           name: e2e-cli-node-12
-          nodeversion: "12.18"
+          nodeversion: '12.18'
           <<: *only_release_branches
           requires:
             - e2e-cli
@@ -334,12 +334,12 @@ workflows:
 
       # Bazel jobs
       # These jobs only really depend on Setup, but the build job is very quick to run (~35s) and
-      # will catch any build errors before proceeding to the more lengthy and resource intensive 
+      # will catch any build errors before proceeding to the more lengthy and resource intensive
       # Bazel jobs.
       - test:
           requires:
             - build
-      
+
       # Windows jobs
       - e2e-cli-win:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -265,10 +265,9 @@ jobs:
             yarn admin snapshots --verbose --githubTokenFile=${HOME}/github_token
 
   # Windows jobs
-  # CircleCI support for Windows jobs is still in preview.
-  # Docs: https://github.com/CircleCI-Public/windows-preview-docs
-  setup-and-build-win:
+  e2e-cli-win:
     executor: windows-executor
+    parallelism: 8
     steps:
       - custom_attach_workspace
       - setup_windows
@@ -276,33 +275,19 @@ jobs:
           keys:
             - *cache_key_win
       - run: yarn install --frozen-lockfile --cache-folder ../.cache/yarn
-      - run: yarn build
       - save_cache:
           key: *cache_key_win
           paths:
             - ~/.cache/yarn
-      # Only jobs downstream from this one will see the updated workspace
-      # https://circleci.com/blog/deep-diving-into-circleci-workspaces/
-      - persist_to_workspace:
-          root: *workspace_location
-          paths:
-            - ./*
-
-  test-win:
-    executor: windows-executor
-    steps:
-      - custom_attach_workspace
-      - setup_windows
-      # Run partial e2e suite on PRs only. Master will run the full e2e suite with sharding.
-      - run: if (Test-Path env:CIRCLE_PR_NUMBER) { node tests\legacy-cli\run_e2e.js "--glob={tests/basic/**,tests/i18n/extract-ivy*.ts,tests/build/profile.ts}" }
-             
-  e2e-cli-win:
-    executor: windows-executor
-    parallelism: 4
-    steps:
-      - custom_attach_workspace
-      - setup_windows
-      - run: node tests\legacy-cli\run_e2e.js --nb-shards=$env:CIRCLE_NODE_TOTAL --shard=$env:CIRCLE_NODE_INDEX
+      # Run partial e2e suite on PRs only. Release branches will run the full e2e suite.
+      - run:
+          name: Execute E2E Tests
+          command: |
+            if (Test-Path env:CIRCLE_PR_NUMBER) {
+              node tests\legacy-cli\run_e2e.js "--glob={tests/basic/**,tests/i18n/extract-ivy*.ts,tests/build/profile.ts}" --nb-shards=$env:CIRCLE_NODE_TOTAL --shard=$env:CIRCLE_NODE_INDEX
+            } else {
+              node tests\legacy-cli\run_e2e.js --nb-shards=$env:CIRCLE_NODE_TOTAL --shard=$env:CIRCLE_NODE_INDEX
+            }
 
 workflows:
   version: 2
@@ -356,24 +341,10 @@ workflows:
             - build
       
       # Windows jobs
-      # These jobs only run after their non-windows counterparts finish successfully.
-      # This isn't strictly necessary as there is no artifact dependency, but helps economize
-      # CI resources by not attempting to build when we know it should fail.
-      - setup-and-build-win:
-          requires:
-            # The Linux setup job also does checkout and rebase, which we get via the workspace.
-            - setup
-            - build
-      - test-win:
+      - e2e-cli-win:
           requires:
             - test
-            - setup-and-build-win
-      - e2e-cli-win:
-          <<: *only_release_branches
-          requires:
-            - setup-and-build-win
-            - e2e-cli
-      
+
       # Publish jobs
       - snapshot_publish:
           <<: *only_release_branches

--- a/.github/angular-robot.yml
+++ b/.github/angular-robot.yml
@@ -42,11 +42,10 @@ merge:
     requiredStatuses:
       - "ci/circleci: build"
       - "ci/circleci: setup"
-      - "ci/circleci: setup-and-build-win"
       - "ci/circleci: lint"
       - "ci/circleci: validate"
       - "ci/circleci: test"
-      - "ci/circleci: test-win"
+      - "ci/circleci: e2e-cli-win"
       - "ci/circleci: e2e-cli"
       - "ci/circleci: test-browsers"
       - "ci/angular: size"


### PR DESCRIPTION
The Windows CI test jobs are now contained within one `e2e-cli-win` job. This removes the need to start up multiple jobs to initialize Windows as well as store and retrieve the saved workspace.
The parallelism is increased to 8 and the Windows test job is started earlier in the workflow to decrease the total time for the workflow.
This change also removes the partial double Windows testing currently present on release branches due to the previous `test-win` and `e2e-cli-win` jobs.

NOTE: This requires the removal of `test-win` from the required Github checks and the addition of `e2e-cli-win`.