### PR TITLE
test(@angular-devkit/build-angular): increase bazel shards for dev-server tests

### DIFF
--- a/packages/angular_devkit/build_angular/BUILD.bazel
+++ b/packages/angular_devkit/build_angular/BUILD.bazel
@@ -286,10 +286,10 @@ LARGE_SPECS = {
         "tags": ["no-remote-exec"],
     },
     "dev-server": {
+        "shards": 10,
+        "size": "large",
         "extra_deps": [
-            "@npm//@types/express",
             "@npm//@types/node-fetch",
-            "@npm//express",
             "@npm//node-fetch",
             "@npm//@types/http-proxy",
             "@npm//http-proxy",


### PR DESCRIPTION
With recent improvements to the dev-server builder unit tests, additional parallel testing should now be possible.
The unused `express` dependencies are also removed.