### PR TITLE
build(@angular/pwa): promote to stable

### DIFF
--- a/packages/angular/pwa/package.json
+++ b/packages/angular/pwa/package.json
@@ -2,7 +2,6 @@
   "name": "@angular/pwa",
   "version": "0.0.0",
   "description": "PWA schematics for Angular",
-  "experimental": true,
   "keywords": [
     "blueprints",
     "code generation",


### PR DESCRIPTION
As discussed in the weekly sync meeting, promote `@angular/pwa` to stable
since it is just a schematic library and does not have public facing APIs.