### PR TITLE
fix(@angular-devkit/build-angular): update karma builder to use non-deprecated API

### DIFF
--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -81,7 +81,7 @@
     "@angular/compiler-cli": "^12.0.0-next",
     "@angular/localize": "^12.0.0-next",
     "@angular/service-worker": "^12.0.0-next",
-    "karma": "^6.0.0",
+    "karma": "^6.3.0",
     "ng-packagr": "^12.0.0-next",
     "protractor": "^7.0.0",
     "tailwindcss": "^2.0.0",

--- a/packages/angular_devkit/build_angular/src/karma/selected_spec.ts
+++ b/packages/angular_devkit/build_angular/src/karma/selected_spec.ts
@@ -26,8 +26,8 @@ describe('Karma Builder', () => {
       };
       const run = await architect.scheduleTarget(karmaTargetSpec, overrides);
 
-      await expectAsync(run.result).toBeRejectedWith(
-        `Specified patterns: "abc.spec.ts, def.spec.ts" did not match any spec files`,
+      await expectAsync(run.result).toBeRejectedWithError(
+        `Specified patterns: "abc.spec.ts, def.spec.ts" did not match any spec files.`,
       );
 
       await run.stop();


### PR DESCRIPTION

With this change we update the Karma builder to use the new Server API.

Closes: #20479