### PR TITLE
ci: add `Python-2.0` as a valid license

### DIFF
--- a/scripts/validate-licenses.ts
+++ b/scripts/validate-licenses.ts
@@ -30,6 +30,7 @@ const allowedLicenses = [
   'MIT',
   'ISC',
   'Apache-2.0',
+  'Python-2.0',
 
   'BSD-2-Clause',
   'BSD-3-Clause',


### PR DESCRIPTION
`Python-2.0` is in the same category as `MIT`, hence it's a valid license that we can allow.

This is needed for `verdaccio` version 5 which uses `argparse` which is licenced as `Python-2.0`.