### PR TITLE
ci: remove unused --ci option from validate script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,7 +173,7 @@ jobs:
               echo "This build is not over a PR, nothing to do."
             fi
       - run:
-          command: yarn -s admin validate --ci
+          command: yarn -s admin validate
 
   e2e-cli:
     parameters:

--- a/scripts/validate.ts
+++ b/scripts/validate.ts
@@ -13,7 +13,7 @@ import validateBuildFiles from './validate-build-files';
 import validateLicenses from './validate-licenses';
 import validateUserAnalytics from './validate-user-analytics';
 
-export default async function (options: { verbose: boolean; ci: boolean }, logger: logging.Logger) {
+export default async function (options: { verbose: boolean }, logger: logging.Logger) {
   let error = false;
 
   if (execSync(`git status --porcelain`).toString()) {


### PR DESCRIPTION
`--ci` is not used in any way.