### PR TITLE
Webpack 5 Cleanup - Remove redundant dependencies

### DIFF
--- a/etc/api/angular_devkit/build_optimizer/src/_golden-api.d.ts
+++ b/etc/api/angular_devkit/build_optimizer/src/_golden-api.d.ts
@@ -16,6 +16,7 @@ export default function buildOptimizerLoader(this: {
     };
     cacheable(): void;
     callback(error?: Error | null, content?: string, sourceMap?: unknown): void;
+    getOptions(): unknown;
 }, content: string, previousSourceMap: RawSourceMap): void;
 
 export declare function getPrefixClassesTransformer(): ts.TransformerFactory<ts.SourceFile>;

--- a/package.json
+++ b/package.json
@@ -120,7 +120,6 @@
     "@types/text-table": "^0.2.1",
     "@types/uuid": "^8.0.0",
     "@types/webpack-dev-server": "^3.1.7",
-    "@types/webpack-sources": "^2.0.0",
     "@yarnpkg/lockfile": "1.1.0",
     "ajv": "8.1.0",
     "ajv-formats": "2.0.2",
@@ -228,7 +227,6 @@
     "webpack-dev-middleware": "4.1.0",
     "webpack-dev-server": "3.11.2",
     "webpack-merge": "5.7.3",
-    "webpack-sources": "2.2.0",
     "webpack-subresource-integrity": "1.5.2",
     "zone.js": "^0.11.3"
   }

--- a/packages/angular_devkit/build_angular/BUILD.bazel
+++ b/packages/angular_devkit/build_angular/BUILD.bazel
@@ -135,7 +135,6 @@ ts_library(
         "@npm//@types/semver",
         "@npm//@types/text-table",
         "@npm//@types/webpack-dev-server",
-        "@npm//@types/webpack-sources",
         "@npm//ajv",
         "@npm//ansi-colors",
         "@npm//babel-loader",
@@ -193,7 +192,6 @@ ts_library(
         "@npm//webpack-dev-middleware",
         "@npm//webpack-dev-server",
         "@npm//webpack-merge",
-        "@npm//webpack-sources",
         "@npm//webpack-subresource-integrity",
     ],
 )

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -73,7 +73,6 @@
     "webpack-dev-middleware": "4.1.0",
     "webpack-dev-server": "3.11.2",
     "webpack-merge": "5.7.3",
-    "webpack-sources": "2.2.0",
     "webpack-subresource-integrity": "1.5.2"
   },
   "peerDependencies": {

--- a/packages/angular_devkit/build_angular/src/webpack/plugins/analytics.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/plugins/analytics.ts
@@ -11,13 +11,13 @@ import {
   Compiler,
   Module,
   Stats,
+  sources,
 } from 'webpack';
-import { OriginalSource } from 'webpack-sources';
 
 const NormalModule = require('webpack/lib/NormalModule');
 
 interface NormalModule extends Module {
-  _source?: OriginalSource | null;
+  _source?: sources.OriginalSource | null;
   resource?: string;
 }
 
@@ -154,14 +154,14 @@ export class NgBuildAnalyticsPlugin {
 
       // Just count the ngOnInit occurences. Comments/Strings/calls occurences should be sparse
       // so we just consider them within the margin of error. We do break on word break though.
-      this._stats.numberOfNgOnInit += countOccurrences(module._source.source(), 'ngOnInit', true);
+      this._stats.numberOfNgOnInit += countOccurrences(module._source.source().toString(), 'ngOnInit', true);
 
       // Count the number of `Component({` strings (case sensitive), which happens in __decorate().
-      this._stats.numberOfComponents += countOccurrences(module._source.source(), 'Component({');
+      this._stats.numberOfComponents += countOccurrences(module._source.source().toString(), 'Component({');
       // For Ivy we just count ɵcmp.
-      this._stats.numberOfComponents += countOccurrences(module._source.source(), '.ɵcmp', true);
+      this._stats.numberOfComponents += countOccurrences(module._source.source().toString(), '.ɵcmp', true);
       // for ascii_only true
-      this._stats.numberOfComponents += countOccurrences(module._source.source(), '.\u0275cmp', true);
+      this._stats.numberOfComponents += countOccurrences(module._source.source().toString(), '.\u0275cmp', true);
     }
   }
 

--- a/packages/angular_devkit/build_angular/src/webpack/plugins/index-html-webpack-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/plugins/index-html-webpack-plugin.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import { basename, dirname, extname } from 'path';
-import { Compilation, Compiler } from 'webpack';
-import { RawSource } from 'webpack-sources';
+import { Compilation, Compiler, sources } from 'webpack';
 import { FileInfo } from '../../utils/index-file/augment-index-html';
 import { IndexHtmlGenerator, IndexHtmlGeneratorOptions, IndexHtmlGeneratorProcessOptions } from '../../utils/index-file/index-html-generator';
 import { addError, addWarning } from '../../utils/webpack-diagnostics';
@@ -80,7 +79,7 @@ export class IndexHtmlWebpackPlugin extends IndexHtmlGenerator {
           lang: this.options.lang,
         });
 
-        assets[this.options.outputPath] = new RawSource(content);
+        assets[this.options.outputPath] = new sources.RawSource(content);
 
         warnings.forEach(msg => addWarning(this.compilation, msg));
         errors.forEach(msg => addError(this.compilation, msg));

--- a/packages/angular_devkit/build_angular/src/webpack/plugins/scripts-webpack-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/plugins/scripts-webpack-plugin.ts
@@ -8,8 +8,7 @@
 
 import { interpolateName } from 'loader-utils';
 import * as path from 'path';
-import { Chunk, Compilation, Compiler } from 'webpack';
-import { CachedSource, ConcatSource, OriginalSource, RawSource, Source } from 'webpack-sources';
+import { Chunk, Compilation, Compiler, sources as webpackSources } from 'webpack';
 
 const Entrypoint = require('webpack/lib/Entrypoint');
 export interface ScriptsWebpackPluginOptions {
@@ -22,7 +21,7 @@ export interface ScriptsWebpackPluginOptions {
 
 interface ScriptOutput {
   filename: string;
-  source: CachedSource;
+  source: webpackSources.CachedSource;
 }
 
 function addDependencies(compilation: Compilation, scripts: string[]): void {
@@ -107,7 +106,7 @@ export class ScriptsWebpackPlugin {
           }
 
           const sourceGetters = scripts.map(fullPath => {
-            return new Promise<Source>((resolve, reject) => {
+            return new Promise<webpackSources.Source>((resolve, reject) => {
               compilation.inputFileSystem.readFile(fullPath, (err?: Error, data?: string | Buffer) => {
                 if (err) {
                   reject(err);
@@ -125,9 +124,9 @@ export class ScriptsWebpackPlugin {
                   if (this.options.basePath) {
                     adjustedPath = path.relative(this.options.basePath, fullPath);
                   }
-                  source = new OriginalSource(content, adjustedPath);
+                  source = new webpackSources.OriginalSource(content, adjustedPath);
                 } else {
-                  source = new RawSource(content);
+                  source = new webpackSources.RawSource(content);
                 }
 
                 resolve(source);
@@ -136,13 +135,13 @@ export class ScriptsWebpackPlugin {
           });
 
           const sources = await Promise.all(sourceGetters);
-          const concatSource = new ConcatSource();
+          const concatSource = new webpackSources.ConcatSource();
           sources.forEach(source => {
             concatSource.add(source);
             concatSource.add('\n;');
           });
 
-          const combinedSource = new CachedSource(concatSource);
+          const combinedSource = new webpackSources.CachedSource(concatSource);
           const filename = interpolateName(
             { resourcePath: 'scripts.js' },
             this.options.filename as string,

--- a/packages/angular_devkit/build_optimizer/BUILD.bazel
+++ b/packages/angular_devkit/build_optimizer/BUILD.bazel
@@ -35,8 +35,6 @@ ts_library(
     module_root = "src/index.d.ts",
     deps = [
         "@npm//@types/node",
-        "@npm//@types/webpack",
-        "@npm//@types/webpack-sources",
         "@npm//source-map",
         "@npm//tslib",
         "@npm//typescript",

--- a/packages/angular_devkit/build_optimizer/package.json
+++ b/packages/angular_devkit/build_optimizer/package.json
@@ -12,8 +12,7 @@
     "loader-utils": "2.0.0",
     "source-map": "0.7.3",
     "tslib": "2.2.0",
-    "typescript": "4.2.4",
-    "webpack-sources": "2.2.0"
+    "typescript": "4.2.4"
   },
   "peerDependencies": {
     "webpack": "^5.30.0"

--- a/packages/angular_devkit/build_optimizer/package.json
+++ b/packages/angular_devkit/build_optimizer/package.json
@@ -9,7 +9,6 @@
     "build-optimizer": "./src/build-optimizer/cli.js"
   },
   "dependencies": {
-    "loader-utils": "2.0.0",
     "source-map": "0.7.3",
     "tslib": "2.2.0",
     "typescript": "4.2.4"

--- a/packages/angular_devkit/build_optimizer/src/build-optimizer/webpack-loader.ts
+++ b/packages/angular_devkit/build_optimizer/src/build-optimizer/webpack-loader.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import { RawSourceMap } from 'source-map';
-import { SourceMapSource } from 'webpack-sources';
+import { sources } from 'webpack';
 const loaderUtils = require('loader-utils');
 
 import { buildOptimizer } from './build-optimizer';
@@ -72,7 +72,7 @@ export default function buildOptimizerLoader(
 
     if (previousSourceMap) {
       // Use http://sokra.github.io/source-map-visualization/ to validate sourcemaps make sense.
-      newSourceMap = new SourceMapSource(
+      newSourceMap = new sources.SourceMapSource(
         newContent,
         this.resourcePath,
         intermediateSourceMap,

--- a/packages/angular_devkit/build_optimizer/src/build-optimizer/webpack-loader.ts
+++ b/packages/angular_devkit/build_optimizer/src/build-optimizer/webpack-loader.ts
@@ -7,8 +7,6 @@
  */
 import { RawSourceMap } from 'source-map';
 import { sources } from 'webpack';
-const loaderUtils = require('loader-utils');
-
 import { buildOptimizer } from './build-optimizer';
 
 interface BuildOptimizerLoaderOptions {
@@ -26,6 +24,7 @@ export default function buildOptimizerLoader(
     _module: { factoryMeta: { skipBuildOptimizer?: boolean; sideEffectFree?: boolean } };
     cacheable(): void;
     callback(error?: Error | null, content?: string, sourceMap?: unknown): void;
+    getOptions(): unknown;
   },
   content: string,
   previousSourceMap: RawSourceMap,
@@ -43,7 +42,7 @@ export default function buildOptimizerLoader(
     return;
   }
 
-  const options: BuildOptimizerLoaderOptions = loaderUtils.getOptions(this) || {};
+  const options = (this.getOptions() || {}) as BuildOptimizerLoaderOptions;
 
   const boOutput = buildOptimizer({
     content,

--- a/packages/ngtools/webpack/BUILD.bazel
+++ b/packages/ngtools/webpack/BUILD.bazel
@@ -37,11 +37,9 @@ ts_library(
     deps = [
         "@npm//@angular/compiler-cli",
         "@npm//@types/node",
-        "@npm//@types/webpack-sources",
         "@npm//enhanced-resolve",
         "@npm//typescript",
         "@npm//webpack",
-        "@npm//webpack-sources",
     ],
 )
 

--- a/packages/ngtools/webpack/package.json
+++ b/packages/ngtools/webpack/package.json
@@ -21,8 +21,7 @@
   },
   "homepage": "https://github.com/angular/angular-cli/tree/master/packages/@ngtools/webpack",
   "dependencies": {
-    "enhanced-resolve": "5.7.0",
-    "webpack-sources": "2.2.0"
+    "enhanced-resolve": "5.7.0"
   },
   "peerDependencies": {
     "@angular/compiler-cli": "^12.0.0-next",

--- a/packages/ngtools/webpack/src/resource_loader.ts
+++ b/packages/ngtools/webpack/src/resource_loader.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import * as vm from 'vm';
-import { Compilation, EntryPlugin, NormalModule, library, node } from 'webpack';
-import { RawSource } from 'webpack-sources';
+import { Compilation, EntryPlugin, NormalModule, library, node, sources } from 'webpack';
 import { normalizePath } from './ivy/paths';
 
 interface CompilationOutput {
@@ -136,9 +135,7 @@ export class WebpackResourceLoader {
             const output = this._evaluate(outputFilePath, asset.source().toString());
 
             if (typeof output === 'string') {
-              // `webpack-sources` package has incomplete typings
-              // tslint:disable-next-line: no-any
-              compilation.assets[outputFilePath] = new RawSource(output) as any;
+              compilation.assets[outputFilePath] = new sources.RawSource(output);
             }
           } catch (error) {
             // Use compilation errors, as otherwise webpack will choke

--- a/yarn.lock
+++ b/yarn.lock
@@ -2138,15 +2138,6 @@
     "@types/source-list-map" "*"
     source-map "^0.6.1"
 
-"@types/webpack-sources@^2.0.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@types/webpack-sources/-/webpack-sources-2.1.0.tgz#8882b0bd62d1e0ce62f183d0d01b72e6e82e8c10"
-  integrity sha512-LXn/oYIpBeucgP1EIJbKQ2/4ZmpvRl+dlrFdX7+94SKRUV3Evy3FsfMZY318vGhkWUS5MPhtOM3w1/hCOAOXcg==
-  dependencies:
-    "@types/node" "*"
-    "@types/source-list-map" "*"
-    source-map "^0.7.3"
-
 "@types/webpack@*":
   version "5.28.0"
   resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-5.28.0.tgz#78dde06212f038d77e54116cfe69e88ae9ed2c03"
@@ -12726,14 +12717,6 @@ webpack-merge@5.7.3:
     clone-deep "^4.0.1"
     wildcard "^2.0.0"
 
-webpack-sources@2.2.0, webpack-sources@^2.1.1:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-2.2.0.tgz#058926f39e3d443193b6c31547229806ffd02bac"
-  integrity sha512-bQsA24JLwcnWGArOKUxYKhX3Mz/nK1Xf6hxullKERyktjNMC4x8koOeaDNTA2fEJ09BdWLbM/iTW0ithREUP0w==
-  dependencies:
-    source-list-map "^2.0.1"
-    source-map "^0.6.1"
-
 webpack-sources@^1.1.0, webpack-sources@^1.2.0, webpack-sources@^1.3.0, webpack-sources@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.4.3.tgz#eedd8ec0b928fbf1cbfe994e22d2d890f330a933"
@@ -12741,6 +12724,14 @@ webpack-sources@^1.1.0, webpack-sources@^1.2.0, webpack-sources@^1.3.0, webpack-
   dependencies:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
+
+webpack-sources@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-2.2.0.tgz#058926f39e3d443193b6c31547229806ffd02bac"
+  integrity sha512-bQsA24JLwcnWGArOKUxYKhX3Mz/nK1Xf6hxullKERyktjNMC4x8koOeaDNTA2fEJ09BdWLbM/iTW0ithREUP0w==
+  dependencies:
+    source-list-map "^2.0.1"
+    source-map "^0.6.1"
 
 webpack-subresource-integrity@1.5.2:
   version "1.5.2"


### PR DESCRIPTION
Webpack 5 now provides common utility functions and class as direct exports.  This includes getting a loader's options (`getOptions`) and the source classes from `webpack-sources`.