### PR TITLE
build: promote @angular-devkit/schematics-cli to stable

### DIFF
--- a/packages/angular_devkit/schematics_cli/package.json
+++ b/packages/angular_devkit/schematics_cli/package.json
@@ -2,7 +2,7 @@
   "name": "@angular-devkit/schematics-cli",
   "version": "0.0.0",
   "description": "Angular Schematics - CLI",
-  "experimental": true,
+  "homepage": "https://github.com/angular/angular-cli",
   "bin": {
     "schematics": "./bin/schematics.js"
   },


### PR DESCRIPTION
This package contains just the executable for schematics and two internal
schematics, there is no public facing APIs.