### PR TITLE
refactor(@schematics/angular): read build-angular's version from package.json

### DIFF
--- a/docs/process/release.md
+++ b/docs/process/release.md
@@ -153,9 +153,7 @@ using the `--githubToken` flag. You just then have to confirm the draft.
 
 **For each released version**:
 
-Update the package versions to reflect the *next* release version in **both**:
-1. `version` in [`package.json`](https://github.com/angular/angular-cli/blob/master/package.json#L3)
-1. `DevkitBuildAngular` in [`packages/schematics/angular/utility/latest-versions.ts`](https://github.com/angular/angular-cli/blob/master/packages/schematics/angular/utility/latest-versions.ts)
+Update `version` in root [`package.json`](/package.json#L3) to the *next* release version.
 
 ```sh
 git checkout -b release-bump-vXX

--- a/packages/schematics/angular/utility/latest-versions.ts
+++ b/packages/schematics/angular/utility/latest-versions.ts
@@ -14,11 +14,10 @@ export const latestVersions = {
   TypeScript: '~4.2.3',
   TsLib: '^2.1.0',
 
-  // The versions below must be manually updated when making a new devkit release.
-  // For our e2e tests, these versions must match the latest tag present on the branch.
-  // During RC periods they will not match the latest RC until there's a new git tag, and
-  // should not be updated.
-  DevkitBuildAngular: '~12.1.0-next.0',
+  // Since @angular-devkit/build-angular and @schematics/angular are always
+  // published together from the same monorepo, and they are both
+  // non-experimental, they will always have the same version.
+  DevkitBuildAngular: '~' + require('../package.json')['version'],
 
   ngPackagr: '^12.0.0-next.8',
 };


### PR DESCRIPTION
Now that `@angular-devkit/build-angular` is promoted to stable
(https://github.com/angular/angular-cli/pull/20528), it will
always have the same version as `@schematics/angular`.

With this change, there is no need to manually update `DevkitBuildAngular`
field in `latest-versions.ts` anymore.