### PR TITLE
docs(@angular-devkit/architect-cli): add a README file for the package

### DIFF
--- a/packages/angular_devkit/architect_cli/README.md
+++ b/packages/angular_devkit/architect_cli/README.md
@@ -1,0 +1,19 @@
+# Architect CLI
+
+This package contains the executable for running an [Architect Builder](/packages/angular_devkit/architect/README.md).
+
+# Usage
+
+```
+architect [project][:target][:configuration] [options, ...]
+
+Run a project target.
+If project/target/configuration are not specified, the workspace defaults will be used.
+
+Options:
+    --help              Show available options for project target.
+                        Shows this message instead when ran without the run argument.
+
+
+Any additional option is passed the target, overriding existing options.
+```

--- a/packages/angular_devkit/architect_cli/package.json
+++ b/packages/angular_devkit/architect_cli/package.json
@@ -2,6 +2,7 @@
   "name": "@angular-devkit/architect-cli",
   "version": "0.0.0",
   "description": "Angular Architect CLI",
+  "homepage": "https://github.com/angular/angular-cli",
   "experimental": true,
   "bin": {
     "architect": "./bin/architect.js"


### PR DESCRIPTION
A `README.md` file is now included in the package with an overview of the utility and the help output of the command.