### PR TITLE
refactor(@angular-devkit/build-angular): remove Webpack 4 specific type casting

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/plugins/any-component-style-budget-checker.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/plugins/any-component-style-budget-checker.ts
@@ -29,9 +29,7 @@ export class AnyComponentStyleBudgetChecker {
     compiler.hooks.compilation.tap(PLUGIN_NAME, (compilation) => {
       const afterOptimizeChunkAssets = () => {
         // In AOT compilations component styles get processed in child compilations.
-        // tslint:disable-next-line: no-any
-        const parentCompilation = (compilation.compiler as any).parentCompilation;
-        if (!parentCompilation) {
+        if (!compilation.compiler.parentCompilation) {
           return;
         }
 

--- a/packages/angular_devkit/build_angular/src/webpack/plugins/dedupe-module-resolve-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/plugins/dedupe-module-resolve-plugin.ts
@@ -21,30 +21,17 @@ export interface DedupeModuleResolvePluginOptions {
 
 // tslint:disable-next-line: no-any
 function getResourceData(resolveData: any): ResourceData {
-  if (resolveData.createData) {
-    // Webpack 5+
-    const {
-      descriptionFileData,
-      relativePath,
-    } = resolveData.createData.resourceResolveData;
+  const {
+    descriptionFileData,
+    relativePath,
+  } = resolveData.createData.resourceResolveData;
 
-    return {
-      packageName: descriptionFileData?.name,
-      packageVersion: descriptionFileData?.version,
-      relativePath,
-      resource: resolveData.createData.resource,
-    };
-  } else {
-    // Webpack 4
-    const { resource, resourceResolveData } = resolveData;
-
-    return {
-      packageName: resourceResolveData.descriptionFileData?.name,
-      packageVersion: resourceResolveData.descriptionFileData?.version,
-      relativePath: resourceResolveData.relativePath,
-      resource: resource,
-    };
-  }
+  return {
+    packageName: descriptionFileData?.name,
+    packageVersion: descriptionFileData?.version,
+    relativePath,
+    resource: resolveData.createData.resource,
+  };
 }
 
 /**
@@ -100,14 +87,9 @@ export class DedupeModuleResolvePlugin {
         }
 
         // Alter current request with previously resolved module.
-        // tslint:disable-next-line: no-any
-        const createData = (result as any).createData;
-        if (createData) {
-          createData.resource = prevResource;
-          createData.userRequest = prevResource;
-        } else {
-          result.request = prevRequest;
-        }
+        const createData = result.createData as { resource: string; userRequest: string };
+        createData.resource = prevResource;
+        createData.userRequest = prevRequest;
       });
     });
   }


### PR DESCRIPTION
Webpack 5 contains improved types and exports that reduce the need to perform additional type casting throughout the internal Webpack plugins.