### PR TITLE
fix(@angular-devkit/build-angular): avoid double build optimizer processing

### DIFF
--- a/packages/angular_devkit/build_angular/src/browser/index.ts
+++ b/packages/angular_devkit/build_angular/src/browser/index.ts
@@ -52,12 +52,11 @@ import {
   getIndexOutputFile,
 } from '../utils/webpack-browser-config';
 import {
-  getAotConfig,
   getBrowserConfig,
   getCommonConfig,
-  getNonAotConfig,
   getStatsConfig,
   getStylesConfig,
+  getTypeScriptConfig,
   getWorkerConfig,
 } from '../webpack/configs';
 import { NgBuildAnalyticsPlugin } from '../webpack/plugins/analytics';
@@ -121,7 +120,7 @@ export function getAnalyticsConfig(
 
 export function getCompilerConfig(wco: WebpackConfigOptions): webpack.Configuration {
   if (wco.buildOptions.main || wco.buildOptions.polyfills) {
-    return wco.buildOptions.aot ? getAotConfig(wco) : getNonAotConfig(wco);
+    return getTypeScriptConfig(wco);
   }
 
   return {};

--- a/packages/angular_devkit/build_angular/src/extract-i18n/index.ts
+++ b/packages/angular_devkit/build_angular/src/extract-i18n/index.ts
@@ -22,7 +22,12 @@ import { ExecutionTransformer } from '../transforms';
 import { createI18nOptions } from '../utils/i18n-options';
 import { assertCompatibleAngularVersion } from '../utils/version';
 import { generateBrowserWebpackConfigFromContext } from '../utils/webpack-browser-config';
-import { getAotConfig, getBrowserConfig, getCommonConfig, getStatsConfig } from '../webpack/configs';
+import {
+  getBrowserConfig,
+  getCommonConfig,
+  getStatsConfig,
+  getTypeScriptConfig,
+} from '../webpack/configs';
 import { createWebpackLoggingCallback } from '../webpack/utils/stats';
 import { Format, Schema } from './schema';
 
@@ -194,7 +199,7 @@ export async function execute(
         { plugins: [new NoEmitPlugin()] },
         getCommonConfig(wco),
         getBrowserConfig(wco),
-        getAotConfig(wco),
+        getTypeScriptConfig(wco),
         getStatsConfig(wco),
       ];
 

--- a/packages/angular_devkit/build_angular/src/karma/index.ts
+++ b/packages/angular_devkit/build_angular/src/karma/index.ts
@@ -18,9 +18,9 @@ import { assertCompatibleAngularVersion } from '../utils/version';
 import { generateBrowserWebpackConfigFromContext } from '../utils/webpack-browser-config';
 import {
   getCommonConfig,
-  getNonAotConfig,
   getStylesConfig,
   getTestConfig,
+  getTypeScriptConfig,
   getWorkerConfig,
 } from '../webpack/configs';
 import { SingleTestTransformLoader } from '../webpack/plugins/single-test-transform';
@@ -46,7 +46,7 @@ async function initialize(
     wco => [
       getCommonConfig(wco),
       getStylesConfig(wco),
-      getNonAotConfig(wco),
+      getTypeScriptConfig(wco),
       getTestConfig(wco),
       getWorkerConfig(wco),
     ],

--- a/packages/angular_devkit/build_angular/src/server/index.ts
+++ b/packages/angular_devkit/build_angular/src/server/index.ts
@@ -22,11 +22,11 @@ import { readTsconfig } from '../utils/read-tsconfig';
 import { assertCompatibleAngularVersion } from '../utils/version';
 import { generateI18nBrowserWebpackConfigFromContext } from '../utils/webpack-browser-config';
 import {
-  getAotConfig,
   getCommonConfig,
   getServerConfig,
   getStatsConfig,
   getStylesConfig,
+  getTypeScriptConfig,
 } from '../webpack/configs';
 import { JsonCompilationStats, webpackStatsLogger } from '../webpack/utils/stats';
 import { Schema as ServerBuilderOptions } from './schema';
@@ -166,7 +166,7 @@ async function initialize(
       getServerConfig(wco),
       getStylesConfig(wco),
       getStatsConfig(wco),
-      getAotConfig(wco),
+      getTypeScriptConfig(wco),
     ],
   );
 

--- a/packages/angular_devkit/build_angular/src/webpack/configs/typescript.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/typescript.ts
@@ -5,7 +5,6 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import { buildOptimizerLoaderPath } from '@angular-devkit/build-optimizer';
 import { getSystemPath } from '@angular-devkit/core';
 import { CompilerOptions } from '@angular/compiler-cli';
 import { AngularWebpackLoaderPath, AngularWebpackPlugin } from '@ngtools/webpack';
@@ -78,8 +77,11 @@ function createIvyPlugin(
   });
 }
 
-export function getNonAotConfig(wco: WebpackConfigOptions) {
-  const { tsConfigPath } = wco;
+export function getTypeScriptConfig(wco: WebpackConfigOptions) {
+  const { buildOptions, tsConfigPath } = wco;
+  const aot = !!buildOptions.aot;
+
+  ensureIvy(wco);
 
   return {
     module: {
@@ -91,42 +93,7 @@ export function getNonAotConfig(wco: WebpackConfigOptions) {
       ],
     },
     plugins: [
-      createIvyPlugin(wco, false, tsConfigPath),
-    ],
-  };
-}
-
-export function getAotConfig(wco: WebpackConfigOptions) {
-  const { tsConfigPath, buildOptions } = wco;
-
-  ensureIvy(wco);
-
-  return {
-    module: {
-      rules: [
-        {
-          test: /\.tsx?$/,
-          use: [
-            ...(buildOptions.buildOptimizer
-              ? [
-                  {
-                    loader: buildOptimizerLoaderPath,
-                    options: { sourceMap: buildOptions.sourceMap.scripts },
-                  },
-                ]
-              : []),
-            AngularWebpackLoaderPath,
-          ],
-        },
-        // "allowJs" support with ivy plugin - ensures build optimizer is not run twice
-        {
-          test: /\.jsx?$/,
-          use: [AngularWebpackLoaderPath],
-        },
-      ],
-    },
-    plugins: [
-      createIvyPlugin(wco, true, tsConfigPath),
+      createIvyPlugin(wco, aot, tsConfigPath),
     ],
   };
 }

--- a/tests/legacy-cli/e2e/tests/build/differential-loading-sri.ts
+++ b/tests/legacy-cli/e2e/tests/build/differential-loading-sri.ts
@@ -56,7 +56,7 @@ export default async function () {
     '--output-path=dist/second',
   );
 
-  const chunkId = '730';
+  const chunkId = '265';
   const codeHashES5 = createHash('sha384')
     .update(await readFile(`dist/first/${chunkId}-es5.js`))
     .digest('base64');

--- a/tests/legacy-cli/e2e/tests/build/worker.ts
+++ b/tests/legacy-cli/e2e/tests/build/worker.ts
@@ -35,7 +35,7 @@ export default async function () {
   await expectFileToMatch('dist/test-project/main-es2017.js', 'src_app_app_worker_ts');
 
   await ng('build', '--output-hashing=none');
-  const chunkId = '137';
+  const chunkId = '954';
   await expectFileToExist(`dist/test-project/${chunkId}-es5.js`);
   await expectFileToMatch('dist/test-project/main-es5.js', chunkId);
   await expectFileToExist(`dist/test-project/${chunkId}-es2017.js`);


### PR DESCRIPTION
TypeScript files had the potential to be processed twice by the build optimizer. This did not affect the output code but could lead to longer production build times. The build optimizer is now configured in one centralized location for both TypeScript and JavaScript files. The Webpack configuration partial for TypeScript support is also reduced to one common function for both AOT and JIT as a result.