### PR TITLE
Several `ng update` fixes

### DIFF
--- a/packages/angular/cli/src/commands/update/schematic/index.ts
+++ b/packages/angular/cli/src/commands/update/schematic/index.ts
@@ -178,6 +178,7 @@ function _validateReversePeerDependencies(
         'codelyzer',
         '@schematics/update',
         '@angular-devkit/build-ng-packagr',
+        'tsickle',
       ];
       if (ignoredPackages.includes(installed)) {
         continue;

--- a/packages/angular/cli/src/commands/update/schematic/schema.json
+++ b/packages/angular/cli/src/commands/update/schematic/schema.json
@@ -63,11 +63,6 @@
         "cnpm",
         "pnpm"
       ]
-    },
-    "migrateExternal": {
-      "type": "boolean",
-      "default": false,
-      "hidden": true
     }
   },
   "required": [


### PR DESCRIPTION

**fix(@angular/cli): run all migrations when updating from or between prereleases**
    
With this change we consider the update schematics are idempotent. When updating from or between prereleases we will execute all migrations for the version.

**refactor(@angular/cli): clean up left over @schematics/update code**


**fix(@angular/cli): ignore `tsickle` during updates**
`tsickle` doesn't be a dependency in users projects, if it is most certain it will cause updates to fail due to mismatching peer dependency on TypeScript.
