### PR TITLE
build: pin quicktype-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -189,7 +189,7 @@
     "prettier": "^2.0.0",
     "protractor": "~7.0.0",
     "puppeteer": "8.0.0",
-    "quicktype-core": "^6.0.69",
+    "quicktype-core": "6.0.69",
     "raw-loader": "4.0.2",
     "regenerator-runtime": "0.13.7",
     "resolve-url-loader": "3.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10061,7 +10061,7 @@ quick-lru@^4.0.1:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz#5b8878f113a58217848c6482026c73e1ba57727f"
   integrity sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==
 
-quicktype-core@^6.0.69:
+quicktype-core@6.0.69:
   version "6.0.69"
   resolved "https://registry.yarnpkg.com/quicktype-core/-/quicktype-core-6.0.69.tgz#955347b64e8a7b6a37af49fe12f5772abc153b8e"
   integrity sha512-wKQ+/fwgdtFOcbeRiZkIBLA2ajvrFvmtTmexdv7PlO1dyp3C7Irbn2/HjwzalD1dYFrtMEYWohB/4rr3Mg75Xw==


### PR DESCRIPTION
This is needed as currently this breaks lock file maintenance Renovate  PR https://github.com/angular/angular-cli/pull/20107 due to quicktype-core has an unspecified dependency on lodash.

```
  bazel-out/host/bin/tools/quicktype_runner.sh packages/angular_devkit/build_angular/src/app-shell/schema.json bazel-out/k8-fastbuild/bin/packages/angular_devkit/build_angular/src/app-shell/schema.ts)
Execution platform: //tools:rbe_ubuntu1604-angular
Error: Cannot find module 'lodash'. Please verify that the package.json has a valid "main" entry
    at Function.module.constructor._resolveFilename (/b/f/w/bazel-out/host/bin/tools/quicktype_runner.sh.runfiles/angular_cli/tools/quicktype_runner_require_patch.js:480:17)
    at Function.Module._load (internal/modules/cjs/loader.js:667:27)
    at Module.require (internal/modules/cjs/loader.js:887:19)
    at require (internal/modules/cjs/helpers.js:74:18)
    at Object.<anonymous> (/b/f/w/bazel-out/host/bin/tools/quicktype_runner.sh.runfiles/npm/node_modules/quicktype-core/dist/language/Dart.js:14:18)
    at Module._compile (internal/modules/cjs/loader.js:999:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
    at Module.load (internal/modules/cjs/loader.js:863:32)
    at Function.Module._load (internal/modules/cjs/loader.js:708:14)
    at Module.require (internal/modules/cjs/loader.js:887:19)
INFO: Elapsed time: 81.607s, Critical Path: 8.94s
```