### PR TITLE
ci: format angular-robot configuration

### DIFF
--- a/.github/angular-robot.yml
+++ b/.github/angular-robot.yml
@@ -14,8 +14,10 @@ merge:
     failureText: "The following checks are failing:"
 
   # comment that will be added to a PR when there is a conflict, leave empty or set to false to disable
-  mergeConflictComment: "Hi @{{PRAuthor}}! This PR has merge conflicts due to recent upstream merges.
-\nPlease help to unblock it by resolving these conflicts. Thanks!"
+  mergeConflictComment: >-
+    Hi @{{PRAuthor}}! This PR has merge conflicts due to recent upstream merges.
+
+    Please help to unblock it by resolving these conflicts. Thanks!
 
   # label to monitor
   mergeLabel: "action: merge"
@@ -54,13 +56,18 @@ merge:
   # the comment that will be added when the merge label is added despite failing checks, leave empty or set to false to disable
   # {{MERGE_LABEL}} will be replaced by the value of the mergeLabel option
   # {{PLACEHOLDER}} will be replaced by the list of failing checks
-  mergeRemovedComment: "I see that you just added the `{{MERGE_LABEL}}` label, but the following checks are still failing:
-\n{{PLACEHOLDER}}
-\n
-\n**If you want your PR to be merged, it has to pass all the CI checks.**
-\n
-\nIf you can't get the PR to a green state due to flakes or broken master, please try rebasing to master and/or restarting the CI job. If that fails and you believe that the issue is not due to your change, please contact the caretaker and ask for help."
+  mergeRemovedComment: >-
+    I see that you just added the `{{MERGE_LABEL}}` label, but the following
+    checks are still failing:
 
+    {{PLACEHOLDER}}
+     
+    **If you want your PR to be merged, it has to pass all the CI checks.**
+     
+    If you can't get the PR to a green state due to flakes or broken master,
+    please try rebasing to master and/or restarting the CI job. If that fails
+    and you believe that the issue is not due to your change, please contact the
+    caretaker and ask for help.
 # options for the triage plugin
 triage:
   # set to true to disable


### PR DESCRIPTION
Previously, running `yarn ng-dev caretaker check` would fail with `Multi-line double-quoted string needs to be sufficiently indented`.