### PR TITLE
fix(@angular-devkit/build-angular): disable Webpack 5 automatic public path support

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
@@ -432,7 +432,7 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
     entry: entryPoints,
     output: {
       path: path.resolve(root, buildOptions.outputPath),
-      publicPath: buildOptions.deployUrl,
+      publicPath: buildOptions.deployUrl ?? '',
       filename: ({ chunk }) => {
         if (chunk?.name === 'polyfills-es5') {
           return `polyfills-es5${hashFormat.chunk}.js`;


### PR DESCRIPTION
The Webpack 5 automatic public path support can cause an incorrect public path to be used to load assets and lazy loaded routes. The current logic relies on the last script element found at runtime in the application's index HTML which may not be related to the application scripts. Now if a `deployUrl` is not specified, the Webpack `publicPath` option is defaulted to an empty string which provides equivalent behavior to Webpack 4.