### PR TITLE
fix(@angular-devkit/build-angular): set Tailwind CSS mode when using Tailwind

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/styles.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/styles.ts
@@ -141,6 +141,9 @@ export function getStylesConfig(wco: WebpackConfigOptions): webpack.Configuratio
       );
     }
     if (tailwindPackagePath) {
+      if (process.env['TAILWIND_MODE'] === undefined) {
+        process.env['TAILWIND_MODE'] = buildOptions.watch ? 'watch' : 'build';
+      }
       extraPostcssPlugins.push(require(tailwindPackagePath)({ config: tailwindConfigPath }));
     }
   }


### PR DESCRIPTION
Tailwind now suppports an environment variable named `TAILWIND_MODE` with possible values of `build` and `watch`. If the variable has not been set, the tooling will now set the variable based on the builder's `watch` option.