### PR TITLE
perf(@angular-devkit/build-angular): use Webpack's GC memory caching in watch mode

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
@@ -483,7 +483,10 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
         ...extraRules,
       ],
     },
-    cache: !!buildOptions.watch && !cachingDisabled,
+    cache: !!buildOptions.watch && !cachingDisabled && {
+      type: 'memory',
+      maxGenerations: 1,
+    },
     optimization: {
       minimizer: extraMinimizers,
       moduleIds: 'deterministic',


### PR DESCRIPTION
The GC caching mode will remove any unused cache entries after each rebuild. This prevents old modules from being retained indefinitely during long-lived development sessions.