### PR TITLE
fix(@angular-devkit/build-angular): avoid triggering file change after file build

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/utils/helpers.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/utils/helpers.ts
@@ -121,7 +121,7 @@ export function isPolyfillsEntry(name: string): boolean {
 export function getWatchOptions(poll: number | undefined): Configuration['watchOptions'] {
   return {
     poll,
-    ignored: poll === undefined ? undefined : 'node_modules/**',
+    ignored: poll === undefined ? '**/$_lazy_route_resources' : 'node_modules/**',
   };
 }
 


### PR DESCRIPTION


When using the `ContextReplacementPlugin` https://github.com/angular/angular-cli/blob/master/packages/angular_devkit/build_angular/src/webpack/configs/common.ts#L496 the new resource path will be watched by Webpack file watcher. This causes a redundant file remove event after the first build, which causes another partial rebuild right way.

Note: changing the call to ` new ContextReplacementPlugin(/\@angular(\\|\/)core(\\|\/)/);` doesn't address the problem.