### PR TITLE
ci: configure renovate to group all non-major dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -38,11 +38,11 @@
       "groupName": "angular",
       "pinVersions": false
     },
-   {
+    {
       "packagePatterns": [
         "^@babel\/.*"
       ],
-      "groupName": "Babel",
+      "groupName": "babel",
       "pinVersions": false
     },
     {
@@ -69,6 +69,20 @@
         "major"
       ],
       "enabled": false
+    },
+    {
+      "excludePackagePatterns": [
+        "^@angular/.*"
+      ],
+      "matchPackagePatterns": [
+        "*"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "groupName": "all non-major dependencies",
+      "groupSlug": "all-minor-patch"
     }
   ]
 }


### PR DESCRIPTION
With this change we configure renovate to group all non-major dependencies and create a single PR