### PR TITLE
fix(@angular-devkit/build-angular): always inject live reload client when using live reload

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/dev-server.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/dev-server.ts
@@ -121,6 +121,7 @@ export function getDevServerConfig(
       inline: hmr,
       publicPath: servePath,
       liveReload,
+      injectClient: liveReload,
       hotOnly: hmr && !liveReload,
       hot: hmr,
       proxy: addProxyConfig(root, proxyConfig),


### PR DESCRIPTION
The current stable version of `webpack-dev-server` does not fully handle Webpack 5's configuration options. In this case, the `target` option can now be an array. However, the array form is ignored by the dev server which can cause the live reload client code to not be included in the output bundles. To remedy this, the `injectClient` option is used when live reload is enabled which forces the client code to be included regardless of the `target` option.