### PR TITLE
fix(@schematics/angular): remove jasmine-spec-reporter from default workspace

### DIFF
--- a/packages/schematics/angular/e2e/index.ts
+++ b/packages/schematics/angular/e2e/index.ts
@@ -74,11 +74,19 @@ export default function (options: E2eOptions): Rule {
           }),
           move(root),
         ])),
-      host => addPackageJsonDependency(host, {
+      host => [{
         type: NodeDependencyType.Dev,
         name: 'protractor',
         version: '~7.0.0',
-      }),
+      },       {
+        type: NodeDependencyType.Dev,
+        name: 'jasmine-spec-reporter',
+        version: '~7.0.0',
+      },       {
+        type: NodeDependencyType.Dev,
+        name: 'ts-node',
+        version: '~9.1.1',
+      }].forEach(dep => addPackageJsonDependency(host, dep)),
       addScriptsToPackageJson(),
     ]);
   };

--- a/packages/schematics/angular/workspace/files/package.json.template
+++ b/packages/schematics/angular/workspace/files/package.json.template
@@ -29,13 +29,11 @@
     "@types/jasmine": "~3.6.0",<% } %>
     "@types/node": "^12.11.1",<% if (!minimal) { %>
     "jasmine-core": "~3.7.0",
-    "jasmine-spec-reporter": "~7.0.0",
     "karma": "~6.3.0",
     "karma-chrome-launcher": "~3.1.0",
     "karma-coverage": "~2.0.3",
     "karma-jasmine": "~4.0.0",
-    "karma-jasmine-html-reporter": "^1.5.0",
-    "ts-node": "~9.1.1",<% } %>
+    "karma-jasmine-html-reporter": "^1.5.0",<% } %>
     "typescript": "<%= latestVersions.TypeScript %>"
   }
 }


### PR DESCRIPTION
The dependency is only needed for protractor tests, so it should only be added by the e2e schematics.