### PR TITLE
fix(@angular-devkit/build-angular): output webpack-dev-server and webpack-dev-middleware errors

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/dev-server.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/dev-server.ts
@@ -126,7 +126,7 @@ export function getDevServerConfig(
       hot: hmr,
       proxy: addProxyConfig(root, proxyConfig),
       contentBase: false,
-      logLevel: 'silent',
+      logLevel: 'error',
     } as Configuration & { logLevel: Configuration['clientLogLevel'] },
   };
 }


### PR DESCRIPTION


With this change we configure `webpack-dev-middleware` and `webpack-dev-server` to print errors to the console, which previously were not displayed. This is because both of these libraries log/emit errors using the logger and the compilation API.

Certain errors such as the one below, were being swallowed during `ng serve`.
```
An unhandled exception occurred: Prevent writing to file that only differs in casing or query string from already written file.
This will lead to a race-condition and corrupted files on case-insensitive file systems.
/home/circleci/ng/aio/dist/generated/docs/api/router/Routes.json
/home/circleci/ng/aio/dist/generated/docs/api/router/ROUTES.json
```