### PR TITLE
perf(@angular-devkit/build-angular): avoid async downlevel for known ES2015 code

### DIFF
--- a/packages/angular_devkit/build_angular/src/babel/webpack-loader.ts
+++ b/packages/angular_devkit/build_angular/src/babel/webpack-loader.ts
@@ -66,7 +66,7 @@ export default custom<AngularCustomOptions>(() => {
           // TypeScript files will have already been downlevelled
           customOptions.forceES5 = !/\.tsx?$/.test(this.resourcePath);
         } else if (esTarget >= ScriptTarget.ES2017) {
-          customOptions.forceAsyncTransformation = !/[\\\/]fesm2015[\\\/]/.test(this.resourcePath) && source.includes('async');
+          customOptions.forceAsyncTransformation = !/[\\\/][_f]?esm2015[\\\/]/.test(this.resourcePath) && source.includes('async');
         }
         shouldProcess ||= customOptions.forceAsyncTransformation || customOptions.forceES5;
       }


### PR DESCRIPTION
Library code inside fesm2015/esm2015/_esm2015 directories has been downlevelled to ES2015 which will not have native async/await. As a result, code from those directories can be skipped from the additional checks as well as the downlevel processing. RxJS uses the `_esm2015` directory naming convention.