### PR TITLE
fix(@schematics/angular) remove lint command from package.json

### DIFF
--- a/packages/schematics/angular/workspace/files/package.json.template
+++ b/packages/schematics/angular/workspace/files/package.json.template
@@ -6,8 +6,7 @@
     "start": "ng serve",
     "build": "ng build",
     "watch": "ng build --watch --configuration development"<% if (!minimal) { %>,
-    "test": "ng test",
-    "lint": "ng lint"<% } %>
+    "test": "ng test"<% } %>
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
Angular 12 does not provide the default linter but CLI adds the ng lint
this PR removes the ng lint from new app created

Fixes #20618