### PR TITLE
ci: configure Renovate to ignore quicktype-core

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,7 +22,8 @@
     "master"
   ],
   "ignoreDeps": [
-    "@types/node"
+    "@types/node",
+    "quicktype-core"
   ],
   "packageFiles": [
     "WORKSPACE",


### PR DESCRIPTION
This is needed as currently this breaks lock file maintenance Renovate  PR https://github.com/angular/angular-cli/pull/20107 due to quicktype-core has an unspecified dependency on lodash.

```
  bazel-out/host/bin/tools/quicktype_runner.sh packages/angular_devkit/build_angular/src/app-shell/schema.json bazel-out/k8-fastbuild/bin/packages/angular_devkit/build_angular/src/app-shell/schema.ts)
Execution platform: //tools:rbe_ubuntu1604-angular
Error: Cannot find module 'lodash'. Please verify that the package.json has a valid "main" entry
    at Function.module.constructor._resolveFilename (/b/f/w/bazel-out/host/bin/tools/quicktype_runner.sh.runfiles/angular_cli/tools/quicktype_runner_require_patch.js:480:17)
    at Function.Module._load (internal/modules/cjs/loader.js:667:27)
    at Module.require (internal/modules/cjs/loader.js:887:19)
    at require (internal/modules/cjs/helpers.js:74:18)
    at Object.<anonymous> (/b/f/w/bazel-out/host/bin/tools/quicktype_runner.sh.runfiles/npm/node_modules/quicktype-core/dist/language/Dart.js:14:18)
    at Module._compile (internal/modules/cjs/loader.js:999:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
    at Module.load (internal/modules/cjs/loader.js:863:32)
    at Function.Module._load (internal/modules/cjs/loader.js:708:14)
    at Module.require (internal/modules/cjs/loader.js:887:19)
INFO: Elapsed time: 81.607s, Critical Path: 8.94s