### PR TITLE
build: update minimum supported node.js version to 12.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ To get started locally, follow these instructions:
 
 1. If you haven't done it already, [make a fork of this repo](https://github.com/angular/angular-cli/fork).
 1. Clone to your local computer using `git`.
-1. Make sure that you have Node 10.13 or later installed. See instructions [here](https://nodejs.org/en/download/).
+1. Make sure that you have Node 12.14 or 14.0 installed. See instructions [here](https://nodejs.org/en/download/).
 1. Make sure that you have `yarn` installed; see instructions [here](https://yarnpkg.com/lang/en/docs/install/).
 1. Run `yarn` (no arguments) from the root of your clone of this project to install dependencies.
 

--- a/lib/packages.ts
+++ b/lib/packages.ts
@@ -87,7 +87,7 @@ function loadPackageJson(p: string) {
       // Overwrite engines to a common default.
       case 'engines':
         pkg['engines'] = {
-          'node': '>= 12.13.0',
+          'node': '^12.14.1 || ^14.0.0',
           'npm': '^6.11.0 || ^7.5.6',
           'yarn': '>= 1.13.0',
         };

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "url": "https://github.com/angular/angular-cli.git"
   },
   "engines": {
-    "node": ">=12.13.0 <15.0.0",
+    "node": "^12.14.1 || ^14.0.0",
     "yarn": ">=1.21.1 <2",
     "npm": "Please use yarn instead of NPM to install dependencies"
   },

--- a/packages/angular/cli/bin/ng
+++ b/packages/angular/cli/bin/ng
@@ -29,15 +29,15 @@ if (version[0] % 2 === 1 && version[0] > 14) {
 } else if (
   version[0] < 12 ||
   version[0] === 13 ||
-  (version[0] === 12 && version[1] < 13) ||
+  (version[0] === 12 && version[1] < 14) ||
   (version[0] === 14 && version[1] < 15)
 ) {
-  // Error and exit if less than 12.13 or 13.x or less than 14.15
+  // Error and exit if less than 12.14 or 13.x or less than 14.15
   console.error(
     'Node.js version ' +
       process.version +
       ' detected.\n' +
-      'The Angular CLI requires a minimum Node.js version of either v12.13 or v14.15.\n\n' +
+      'The Angular CLI requires a minimum Node.js version of either v12.14 or v14.15.\n\n' +
       'Please update your Node.js version or visit https://nodejs.org/ for additional instructions.\n',
   );
 

--- a/packages/angular/cli/lib/cli/index.ts
+++ b/packages/angular/cli/lib/cli/index.ts
@@ -25,10 +25,10 @@ const isDebug =
 export default async function(options: { testing?: boolean; cliArgs: string[] }) {
   // This node version check ensures that the requirements of the project instance of the CLI are met
   const version = process.versions.node.split('.').map(part => Number(part));
-  if (version[0] < 10 || version[0] === 11 || (version[0] === 10 && version[1] < 13)) {
+  if (version[0] < 12 || (version[0] === 12 && version[1] < 14)) {
     process.stderr.write(
       `Node.js version ${process.version} detected.\n` +
-      'The Angular CLI requires a minimum Node.js version of either v10.13 or v12.0.\n\n' +
+      'The Angular CLI requires a minimum v12.14.\n\n' +
       'Please update your Node.js version or visit https://nodejs.org/ for additional instructions.\n',
     );
 

--- a/scripts/templates/readme.ejs
+++ b/scripts/templates/readme.ejs
@@ -57,7 +57,7 @@ To get started locally, follow these instructions:
 
 1. If you haven't done it already, [make a fork of this repo](https://github.com/angular/angular-cli/fork).
 1. Clone to your local computer using `git`.
-1. Make sure that you have Node 10.13 or later installed. See instructions [here](https://nodejs.org/en/download/).
+1. Make sure that you have Node 12.14 or 14.0 installed. See instructions [here](https://nodejs.org/en/download/).
 1. Make sure that you have `yarn` installed; see instructions [here](https://yarnpkg.com/lang/en/docs/install/).
 1. Run `yarn` (no arguments) from the root of your clone of this project to install dependencies.
 


### PR DESCRIPTION
This is to match the ranges in the framework repo.