### PR TITLE
build: update prettier configuration and ignore files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,9 @@
+/bazel-out/
+/dist-schema/
 /etc/api
+/tests/
+/README.md
+/CONTRIBUTING.md
+.yarn/
+dist/
+third_party/

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,6 @@
 {
   "printWidth": 100,
+  "quoteProps": "preserve",
   "singleQuote": true,
   "trailingComma": "all"
 }


### PR DESCRIPTION
Quoted properties are now configured to be preserved within code and is needed for cases of closure compiler usage.
The ignore files list is also updated to now ignore all directories that contain code that should not be formatted; either because the code is auto-generated, an output directory, or third party vendor code.