### PR TITLE
refactor(@angular/cli): correct various uncaught code style issues

### DIFF
--- a/packages/angular/cli/commands/add-impl.ts
+++ b/packages/angular/cli/commands/add-impl.ts
@@ -131,7 +131,7 @@ export class AddCommand extends SchematicCommand<AddCommandSchema> {
         // 'latest' is invalid so search for most recent matching package
         const versionManifests = Object.values(packageMetadata.versions).filter(
           (value: PackageManifest) => !prerelease(value.version) && !value.deprecated,
-        ) as PackageManifest[];
+        );
 
         versionManifests.sort((a, b) => rcompare(a.version, b.version, true));
 

--- a/packages/angular/cli/commands/extract-i18n-impl.ts
+++ b/packages/angular/cli/commands/extract-i18n-impl.ts
@@ -16,15 +16,19 @@ export class ExtractI18nCommand extends ArchitectCommand<ExtractI18nCommandSchem
     const version = process.version.substr(1).split('.');
     if (Number(version[0]) === 12 && Number(version[1]) === 0) {
       this.logger.error(
-        'Due to a defect in Node.js 12.0, the command is not supported on this Node.js version. '
-        + 'Please upgrade to Node.js 12.1 or later.');
+        'Due to a defect in Node.js 12.0, the command is not supported on this Node.js version. ' +
+          'Please upgrade to Node.js 12.1 or later.',
+      );
 
       return 1;
     }
 
     const commandName = process.argv[2];
     if (['xi18n', 'i18n-extract'].includes(commandName)) {
-      this.logger.warn(`Warning: "ng ${commandName}" has been deprecated and will be removed in a future major version. Please use "ng extract-i18n" instead.`);
+      this.logger.warn(
+        `Warning: "ng ${commandName}" has been deprecated and will be removed in a future major version. ` +
+          'Please use "ng extract-i18n" instead.',
+      );
     }
 
     return this.runArchitectTarget(options);

--- a/packages/angular/cli/commands/new-impl.ts
+++ b/packages/angular/cli/commands/new-impl.ts
@@ -8,7 +8,6 @@
 
 import { Arguments } from '../models/interface';
 import { SchematicCommand } from '../models/schematic-command';
-import { ensureCompatibleNpm } from '../utilities/package-manager';
 import { Schema as NewCommandSchema } from './new';
 
 

--- a/packages/angular/cli/commands/serve-impl.ts
+++ b/packages/angular/cli/commands/serve-impl.ts
@@ -13,7 +13,7 @@ import { Schema as ServeCommandSchema } from './serve';
 export class ServeCommand extends ArchitectCommand<ServeCommandSchema> {
   public readonly target = 'serve';
 
-  public validate(_options: ArchitectCommandOptions & Arguments) {
+  public validate() {
     return true;
   }
 

--- a/packages/angular/cli/lib/init.ts
+++ b/packages/angular/cli/lib/init.ts
@@ -12,7 +12,6 @@ import 'symbol-observable';
 import * as fs from 'fs';
 import * as path from 'path';
 import { SemVer } from 'semver';
-import { Duplex } from 'stream';
 import { colors } from '../utilities/color';
 import { isWarningEnabled } from '../utilities/config';
 

--- a/packages/angular/cli/models/command.ts
+++ b/packages/angular/cli/models/command.ts
@@ -52,7 +52,7 @@ export abstract class Command<T extends BaseCommandOptions = BaseCommandOptions>
     return 0;
   }
 
-  async printJsonHelp(_options: T & Arguments): Promise<number> {
+  async printJsonHelp(): Promise<number> {
     const replacer = (key: string, value: string) => key === 'name'
       ? strings.dasherize(value)
       : value;
@@ -176,7 +176,7 @@ export abstract class Command<T extends BaseCommandOptions = BaseCommandOptions>
     if (options.help === true) {
       return this.printHelp();
     } else if (options.help === 'json' || options.help === 'JSON') {
-      return this.printJsonHelp(options);
+      return this.printJsonHelp();
     } else {
       const startTime = +new Date();
       if (this.useReportAnalytics) {

--- a/packages/angular/cli/models/schematic-command.ts
+++ b/packages/angular/cli/models/schematic-command.ts
@@ -243,7 +243,7 @@ export abstract class SchematicCommand<
       packageRegistry: options.packageRegistry,
       // A schema registry is required to allow customizing addUndefinedDefaults
       registry: new schema.CoreSchemaRegistry(formats.standardFormats),
-      resolvePaths: !!this.workspace
+      resolvePaths: this.workspace
         // Workspace
         ? this.collectionName === this.defaultCollectionName
           // Favor __dirname for @schematics/angular to use the build-in version

--- a/packages/angular/cli/package.json
+++ b/packages/angular/cli/package.json
@@ -46,6 +46,9 @@
     "symbol-observable": "4.0.0",
     "uuid": "8.3.2"
   },
+  "devDependencies": {
+    "rxjs": "6.6.7"
+  },
   "ng-update": {
     "migrations": "@schematics/angular/migrations/migration-collection.json",
     "packageGroup": {

--- a/packages/angular/cli/src/commands/update/schematic/index.ts
+++ b/packages/angular/cli/src/commands/update/schematic/index.ts
@@ -435,7 +435,7 @@ function _usageMessage(
         target,
       };
     })
-    .filter(({ name, info, version, target }) => {
+    .filter(({ info, version, target }) => {
       return (target && semver.compare(info.installed.version, version) < 0);
     })
     .filter(({ target }) => {


### PR DESCRIPTION
This change cleans up some of the CLI code by removing unused variables/imports, unnecessary double negation, and some long line lengths.