### PR TITLE
refactor(@angular-devkit/build-angular): remove `postcss-import`

### DIFF
--- a/package.json
+++ b/package.json
@@ -183,7 +183,6 @@
     "pidusage": "^2.0.17",
     "popper.js": "^1.14.1",
     "postcss": "8.2.13",
-    "postcss-import": "14.0.1",
     "postcss-loader": "5.2.0",
     "postcss-preset-env": "6.7.0",
     "prettier": "^2.0.0",

--- a/packages/angular_devkit/build_angular/BUILD.bazel
+++ b/packages/angular_devkit/build_angular/BUILD.bazel
@@ -165,7 +165,6 @@ ts_library(
         "@npm//ora",
         "@npm//parse5-html-rewriting-stream",
         "@npm//postcss",
-        "@npm//postcss-import",
         "@npm//postcss-loader",
         "@npm//postcss-preset-env",
         "@npm//raw-loader",

--- a/packages/angular_devkit/build_angular/src/webpack/configs/styles.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/styles.ts
@@ -71,7 +71,6 @@ function resolveGlobalStyles(
 // tslint:disable-next-line: no-big-function
 export function getStylesConfig(wco: WebpackConfigOptions): webpack.Configuration {
   const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-  const postcssImports = require('postcss-import');
   const postcssPresetEnv: typeof import('postcss-preset-env') = require('postcss-preset-env');
 
   const { root, buildOptions } = wco;
@@ -167,23 +166,6 @@ export function getStylesConfig(wco: WebpackConfigOptions): webpack.Configuratio
           }
         : undefined,
       plugins: [
-        postcssImports({
-          resolve: (url: string) => (url.startsWith('~') ? url.substr(1) : url),
-          load: (filename: string) => {
-            return new Promise<string>((resolve, reject) => {
-              loader.fs.readFile(filename, (err: Error, data: Buffer) => {
-                if (err) {
-                  reject(err);
-
-                  return;
-                }
-
-                const content = data.toString();
-                resolve(content);
-              });
-            });
-          },
-        }),
         PostcssCliResources({
           baseHref: buildOptions.baseHref,
           deployUrl: buildOptions.deployUrl,


### PR DESCRIPTION
We use `css-loader` which already handles resolving of `@import` rules.
https://github.com/webpack-contrib/css-loader#import