### PR TITLE
fix(@schematics/angular): fix migration for namedChunks option

### DIFF
--- a/packages/schematics/angular/migrations/update-12/update-angular-config.ts
+++ b/packages/schematics/angular/migrations/update-12/update-angular-config.ts
@@ -15,11 +15,11 @@ type BuilderOptionsType = Readonly<[optionName: string, oldDefault: JsonValue | 
 const BrowserBuilderOptions: BuilderOptionsType = [
   ['aot', false, true],
   ['vendorChunk', true, false],
-  ['extractLicenses', true, false],
+  ['extractLicenses', false, true],
   ['buildOptimizer', false, true],
   ['sourceMap', true, false],
   ['optimization', false, true],
-  ['namedChunks', false, true],
+  ['namedChunks', true, false],
 ];
 
 const ServerBuilderOptions: BuilderOptionsType = [

--- a/packages/schematics/angular/migrations/update-12/update-angular-config_spec.ts
+++ b/packages/schematics/angular/migrations/update-12/update-angular-config_spec.ts
@@ -31,6 +31,7 @@ function createWorkSpaceConfig(tree: UnitTestTree) {
               optimization: true,
               experimentalRollupPass: false,
               buildOptimizer: false,
+              namedChunks: true,
               // tslint:disable-next-line:no-any
             } as any,
             configurations: {
@@ -104,5 +105,13 @@ describe(`Migration to update 'angular.json'. ${schematicName}`, () => {
     expect(configurations?.one.sourceMap).toBeUndefined();
     expect(configurations?.two.sourceMap).toBeUndefined();
     expect(configurations?.two.optimization).toBeFalse();
+  });
+
+  it(`should not remove value in "options" when value is not the new default`, async () => {
+    const newTree = await schematicRunner.runSchematicAsync(schematicName, {}, tree).toPromise();
+    const { options } = getBuildTarget(newTree);
+
+    expect(options.namedChunks).toBeTrue();
+    expect(options.buildOptimizer).toBeFalse();
   });
 });


### PR DESCRIPTION

The value for `namedChunk` was inverted, as previously `namedChunks` default value was `true` and not `false`.