### PR TITLE
test: remove unmaintained third-party tslint rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -219,7 +219,6 @@
     "tslib": "^2.0.0",
     "tslint": "^6.1.3",
     "tslint-no-circular-imports": "^0.7.0",
-    "tslint-sonarts": "1.9.0",
     "typescript": "4.2.4",
     "verdaccio": "5.0.4",
     "verdaccio-auth-memory": "^10.0.0",

--- a/scripts/validate-licenses.ts
+++ b/scripts/validate-licenses.ts
@@ -69,7 +69,6 @@ const ignoredPackages = [
   '@angular/devkit-repo@0.0.0',  // Hey, that's us!
   // * Development only
   'spdx-license-ids@3.0.5',  // CC0 but it's content only (index.json, no code) and not distributed.
-  'tslint-sonarts@1.9.0', // LGPL-3.0 but only used as a tool, not linked in the build.
 
   // * Broken license fields
   'pako@1.0.11', // MIT but broken license in package.json

--- a/tslint.json
+++ b/tslint.json
@@ -5,9 +5,6 @@
   "extends": [
     "tslint-no-circular-imports"
   ],
-  "rulesDirectory": [
-    "node_modules/tslint-sonarts/lib/rules"
-  ],
   "linterOptions": {
     "format": "codeFrame",
     "exclude": [
@@ -16,31 +13,6 @@
     ]
   },
   "rules": {
-    // ==================================================================================================
-    // tslint-sonarts rules. See https://github.com/SonarSource/SonarTS
-    // These rules are part of the bug detection section of tslint-sonarts
-    "no-big-function": true,
-    "no-all-duplicated-branches": true,
-    "no-case-with-or": true,
-    "no-collection-size-mischeck": true,
-    "no-element-overwrite": true,
-    "no-empty-destructuring": true,
-    "no-identical-conditions": true,
-    "no-ignored-initial-value": true,
-    "no-ignored-return": true,
-    "no-in-misuse": true,
-    "no-misleading-array-reverse": true,
-    "no-misspelled-operator": true,
-    "no-self-assignment": true,
-    "no-unthrown-error": true,
-    "no-use-of-empty-return-value": true,
-    "no-useless-increment": true,
-    "no-invalid-await": true,
-    "prefer-promise-shorthand": true,
-
-    //These rules are part of the code smell detection section of tslint-sonarts
-    "no-dead-store": true,
-    "no-useless-intersection": true,
     // ==================================================================================================
     // base tslint rules
     "arrow-return-shorthand": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -86,7 +86,6 @@
 
 "@angular/dev-infra-private@https://github.com/angular/dev-infra-private-builds.git#8e28890cecf2ac5d0d5ca590fafc323dea5f133f":
   version "0.0.0"
-  uid "8e28890cecf2ac5d0d5ca590fafc323dea5f133f"
   resolved "https://github.com/angular/dev-infra-private-builds.git#8e28890cecf2ac5d0d5ca590fafc323dea5f133f"
   dependencies:
     "@angular/benchpress" "0.2.1"
@@ -5592,11 +5591,6 @@ immediate@~3.0.5:
   resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
   integrity sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=
 
-immutable@^3.8.2:
-  version "3.8.2"
-  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.2.tgz#c2439951455bb39913daf281376f1530e104adf3"
-  integrity sha1-wkOZUUVbs5kT2vKBN28VMOEErfM=
-
 import-fresh@^3.2.1:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
@@ -10871,13 +10865,6 @@ tslint-no-circular-imports@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/tslint-no-circular-imports/-/tslint-no-circular-imports-0.7.0.tgz#9df0a15654d66b172e0b7843eed073fa5ae99b5f"
   integrity sha512-k3wxpeMC4ef40UbpfBVHEHIzKfNZq5/SCtAO1YjGsaNTklo+K53/TWLrym+poA65RJFDiYgYNWvkeIIkJNA0Vw==
-
-tslint-sonarts@1.9.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/tslint-sonarts/-/tslint-sonarts-1.9.0.tgz#feb593e92db328c0328b430b838adbe65d504de9"
-  integrity sha512-CJWt+IiYI8qggb2O/JPkS6CkC5DY1IcqRsm9EHJ+AxoWK70lvtP7jguochyNDMP2vIz/giGdWCfEM39x/I/Vnw==
-  dependencies:
-    immutable "^3.8.2"
 
 tslint@^6.1.3:
   version "6.1.3"


### PR DESCRIPTION
The `tslint-sonarts` package is both deprecated and unmaintained. The rules provided by the package are now removed from the `tslint` configuration for the project.