### PR TITLE
ci: update lock workflow action to latest sha version

### DIFF
--- a/.github/workflows/lock-closed.yml
+++ b/.github/workflows/lock-closed.yml
@@ -9,6 +9,6 @@ jobs:
   lock_closed:
     runs-on: ubuntu-latest
     steps:
-      - uses: angular/dev-infra/github-actions/lock-closed@0fc6f4d839e93312ed0dd9a2be88d4c11e947a0b
+      - uses: angular/dev-infra/github-actions/lock-closed@4f335a4c1f01f20bf905acee2d68c7248f50f2a0
         with:
           lock-bot-key: ${{ secrets.LOCK_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
The latest version fixes a runtime warning concerning an invalid configuration property.
Warning: `Unexpected input(s) 'lock-bot-key', valid inputs are ['lock-bot-token', 'locks-per-execution']`