### PR TITLE
fix(@angular/cli): don't display options multiple times in schematics…

### DIFF
--- a/packages/angular/cli/models/command.ts
+++ b/packages/angular/cli/models/command.ts
@@ -75,12 +75,6 @@ export abstract class Command<T extends BaseCommandOptions = BaseCommandOptions>
     this.logger.info('');
   }
 
-  protected async printHelpSubcommand(subcommand: SubCommandDescription) {
-    this.logger.info(subcommand.description);
-
-    await this.printHelpOptions(subcommand.options);
-  }
-
   protected async printHelpOptions(options: Option[] = this.description.options) {
     const args = options.filter((opt) => opt.positional !== undefined);
     const opts = options.filter((opt) => opt.positional === undefined);

--- a/packages/angular/cli/models/schematic-command.ts
+++ b/packages/angular/cli/models/schematic-command.ts
@@ -82,6 +82,7 @@ export abstract class SchematicCommand<
         schematic.description.schemaJson || {},
       );
 
+      this.description.description = schematic.description.description;
       this.description.options.push(...options.filter((x) => !x.hidden));
 
       // Remove any user analytics from schematics that are NOT part of our safelist.
@@ -132,9 +133,6 @@ export abstract class SchematicCommand<
           this.logger.info(`    ${schematicName}`);
         });
       });
-    } else if (schematicNames.length == 1) {
-      this.logger.info('Help for schematic ' + schematicNames[0]);
-      await this.printHelpSubcommand(subCommandOption.subcommands[schematicNames[0]]);
     }
 
     return 0;

--- a/tests/legacy-cli/e2e/tests/generate/help-output-no-duplicates.ts
+++ b/tests/legacy-cli/e2e/tests/generate/help-output-no-duplicates.ts
@@ -1,0 +1,17 @@
+import { ng } from '../../utils/process';
+
+export default async function() {
+    // Verify that there are no duplicate options
+  const { stdout } = await ng('generate', 'component', '--help');
+  const firstIndex = stdout.indexOf('--prefix');
+
+  if (firstIndex < 0) {
+    console.log(stdout);
+    throw new Error('--prefix was not part of the help output.');
+  }
+
+  if (firstIndex !== stdout.lastIndexOf('--prefix')) {
+    console.log(stdout);
+    throw new Error('--prefix first and last index were different. Possible duplicate output!');
+  }
+}


### PR DESCRIPTION
… help output

Previously, we disabled options in the help output multiple times.

Previous output
```
Generates and/or modifies files based on a schematic.
usage: ng generate c <name> [options]

arguments:
  schematic
    The schematic or collection:schematic to generate.
  name
    The name of the component.

options:
  --change-detection (-c)
    The change detection strategy to use in the new component.
  --defaults
    When true, disables interactive input prompts for options with a default.
  --display-block (-b)
    Specifies if the style will contain `:host { display: block; }`.
  --dry-run (-d)
    When true, runs through and reports activity without writing out results.
  --entry-component
    When true, the new component is the entry component of the declaring NgModule.
  --export
    When true, the declaring NgModule exports this component.
  --flat
    When true, creates the new files at the top level of the current project.
  --force (-f)
    When true, forces overwriting of existing files.
  --help
    Shows a help message for this command in the console.
  --inline-style (-s)
    When true, includes styles inline in the component.ts file. Only CSS styles can be included inline. By default, an external styles file is created and referenced in the component.ts file.
  --inline-template (-t)
    When true, includes template inline in the component.ts file. By default, an external template file is created and referenced in the component.ts file.
  --interactive
    When false, disables interactive input prompts.
  --lint-fix
    When true, applies lint fixes after generating the component.
  --module (-m)
    The declaring NgModule.
  --prefix (-p)
    The prefix to apply to the generated component selector.
  --project
    The name of the project.
  --selector
    The HTML selector to use for this component.
  --skip-import
    When true, does not import this component into the owning NgModule.
  --skip-selector
    Specifies if the component should have a selector or not.
  --skip-tests
    When true, does not create "spec.ts" test files for the new component.
  --style
    The file extension or preprocessor to use for style files.
  --type
    Adds a developer-defined type to the filename, in the format "name.type.ts".
  --view-encapsulation (-v)
    The view encapsulation strategy to use in the new component.

Help for schematic c
Creates a new generic component definition in the given or default project.
arguments:
  name
    The name of the component.

options:
  --change-detection (-c)
    The change detection strategy to use in the new component.
  --display-block (-b)
    Specifies if the style will contain `:host { display: block; }`.
  --entry-component
    When true, the new component is the entry component of the declaring NgModule.
  --export
    When true, the declaring NgModule exports this component.
  --flat
    When true, creates the new files at the top level of the current project.
  --inline-style (-s)
    When true, includes styles inline in the component.ts file. Only CSS styles can be included inline. By default, an external styles file is created and referenced in the component.ts file.
  --inline-template (-t)
    When true, includes template inline in the component.ts file. By default, an external template file is created and referenced in the component.ts file.
  --lint-fix
    When true, applies lint fixes after generating the component.
  --module (-m)
    The declaring NgModule.
  --prefix (-p)
    The prefix to apply to the generated component selector.
  --project
    The name of the project.
  --selector
    The HTML selector to use for this component.
  --skip-import
    When true, does not import this component into the owning NgModule.
  --skip-selector
    Specifies if the component should have a selector or not.
  --skip-tests
    When true, does not create "spec.ts" test files for the new component.
  --style
    The file extension or preprocessor to use for style files.
  --type
    Adds a developer-defined type to the filename, in the format "name.type.ts".
  --view-encapsulation (-v)
    The view encapsulation strategy to use in the new component.

To see help for a schematic run:
  ng generate <schematic> --help
```

New output
```
Generates and/or modifies files based on a schematic.
usage: ng generate c <name> [options]

arguments:
  schematic
    The schematic or collection:schematic to generate.
  name
    The name of the component.

options:
  --change-detection (-c)
    The change detection strategy to use in the new component.
  --defaults
    Disable interactive input prompts for options with a default.
  --display-block (-b)
    Specifies if the style will contain `:host { display: block; }`.
  --dry-run (-d)
    Run through and reports activity without writing out results.
  --export
    The declaring NgModule exports this component.
  --flat
    Create the new files at the top level of the current project.
  --force (-f)
    Force overwriting of existing files.
  --help
    Shows a help message for this command in the console.
  --inline-style (-s)
    Include styles inline in the component.ts file. Only CSS styles can be included inline. By default, an external styles file is created and referenced in the component.ts file.
  --inline-template (-t)
    Include template inline in the component.ts file. By default, an external template file is created and referenced in the component.ts file.
  --interactive
    Enable interactive input prompts.
  --lint-fix
    Apply lint fixes after generating the component.
  --module (-m)
    The declaring NgModule.
  --prefix (-p)
    The prefix to apply to the generated component selector.
  --project
    The name of the project.
  --selector
    The HTML selector to use for this component.
  --skip-import
    Do not import this component into the owning NgModule.
  --skip-selector
    Specifies if the component should have a selector or not.
  --skip-tests
    Do not create "spec.ts" test files for the new component.
  --style
    The file extension or preprocessor to use for style files.
  --type
    Adds a developer-defined type to the filename, in the format "name.type.ts".
  --view-encapsulation (-v)
    The view encapsulation strategy to use in the new component.

To see help for a schematic run:
  ng generate <schematic> --help
```