### PR TITLE
fix(@angular/cli): infer schematic defaults correctly when using `--project`

### DIFF
--- a/packages/schematics/angular/app-shell/index.ts
+++ b/packages/schematics/angular/app-shell/index.ts
@@ -153,7 +153,7 @@ function addAppShellConfigToWorkspace(options: AppShellOptions): Rule {
     }
 
     return updateWorkspace((workspace) => {
-      const project = workspace.projects.get(options.clientProject);
+      const project = workspace.projects.get(options.project);
       if (!project) {
         return;
       }
@@ -187,8 +187,8 @@ function addAppShellConfigToWorkspace(options: AppShellOptions): Rule {
         }
 
         configurations[key] = {
-          browserTarget: `${options.clientProject}:build:${key}`,
-          serverTarget: `${options.clientProject}:server:${key}`,
+          browserTarget: `${options.project}:build:${key}`,
+          serverTarget: `${options.project}:server:${key}`,
         };
       }
 
@@ -239,7 +239,7 @@ function addServerRoutes(options: AppShellOptions): Rule {
   return async (host: Tree) => {
     // The workspace gets updated so this needs to be reloaded
     const workspace = await getWorkspace(host);
-    const clientProject = workspace.projects.get(options.clientProject);
+    const clientProject = workspace.projects.get(options.project);
     if (!clientProject) {
       throw new Error('Universal schematic removed client project.');
     }
@@ -309,7 +309,7 @@ function addShellComponent(options: AppShellOptions): Rule {
   const componentOptions: ComponentOptions = {
     name: 'app-shell',
     module: options.rootModuleFileName,
-    project: options.clientProject,
+    project: options.project,
   };
 
   return schematic('component', componentOptions);
@@ -318,7 +318,7 @@ function addShellComponent(options: AppShellOptions): Rule {
 export default function (options: AppShellOptions): Rule {
   return async (tree) => {
     const workspace = await getWorkspace(tree);
-    const clientProject = workspace.projects.get(options.clientProject);
+    const clientProject = workspace.projects.get(options.project);
     if (!clientProject || clientProject.extensions.projectType !== 'application') {
       throw new SchematicsException(`A client project type of "application" is required.`);
     }

--- a/packages/schematics/angular/app-shell/index_spec.ts
+++ b/packages/schematics/angular/app-shell/index_spec.ts
@@ -17,7 +17,7 @@ describe('App Shell Schematic', () => {
     require.resolve('../collection.json'),
   );
   const defaultOptions: AppShellOptions = {
-    clientProject: 'bar',
+    project: 'bar',
   };
 
   const workspaceOptions: WorkspaceOptions = {

--- a/packages/schematics/angular/app-shell/schema.json
+++ b/packages/schematics/angular/app-shell/schema.json
@@ -7,7 +7,7 @@
   "additionalProperties": false,
   "long-description": "./app-shell-long.md",
   "properties": {
-    "clientProject": {
+    "project": {
       "type": "string",
       "description": "The name of the related client app.",
       "$default": {
@@ -50,5 +50,5 @@
       "default": "AppServerModule"
     }
   },
-  "required": ["clientProject"]
+  "required": ["project"]
 }

--- a/packages/schematics/angular/migrations/update-9/update-app-tsconfigs_spec.ts
+++ b/packages/schematics/angular/migrations/update-9/update-app-tsconfigs_spec.ts
@@ -251,7 +251,7 @@ describe('Migration to version 9', () => {
           require.resolve('../../collection.json'),
           'universal',
           {
-            clientProject: 'migration-test',
+            project: 'migration-test',
           },
           tree,
         )

--- a/packages/schematics/angular/migrations/update-9/update-server-main-file_spec.ts
+++ b/packages/schematics/angular/migrations/update-9/update-server-main-file_spec.ts
@@ -52,7 +52,7 @@ describe('Migration to version 9', () => {
           require.resolve('../../collection.json'),
           'universal',
           {
-            clientProject: 'migration-test',
+            project: 'migration-test',
           },
           tree,
         )

--- a/packages/schematics/angular/migrations/update-9/update-workspace-config_spec.ts
+++ b/packages/schematics/angular/migrations/update-9/update-workspace-config_spec.ts
@@ -300,7 +300,7 @@ describe('Migration to version 9', () => {
             require.resolve('../../collection.json'),
             'universal',
             {
-              clientProject: 'migration-test',
+              project: 'migration-test',
             },
             tree,
           )

--- a/packages/schematics/angular/universal/index.ts
+++ b/packages/schematics/angular/universal/index.ts
@@ -33,7 +33,7 @@ import { Schema as UniversalOptions } from './schema';
 
 function updateConfigFile(options: UniversalOptions, tsConfigDirectory: Path): Rule {
   return updateWorkspace((workspace) => {
-    const clientProject = workspace.projects.get(options.clientProject);
+    const clientProject = workspace.projects.get(options.project);
 
     if (clientProject) {
       // In case the browser builder hashes the assets
@@ -59,7 +59,7 @@ function updateConfigFile(options: UniversalOptions, tsConfigDirectory: Path): R
 
       const buildTarget = clientProject.targets.get('build');
       if (buildTarget?.options) {
-        buildTarget.options.outputPath = `dist/${options.clientProject}/browser`;
+        buildTarget.options.outputPath = `dist/${options.project}/browser`;
       }
 
       const buildConfigurations = buildTarget?.configurations;
@@ -77,7 +77,7 @@ function updateConfigFile(options: UniversalOptions, tsConfigDirectory: Path): R
         builder: Builders.Server,
         defaultConfiguration: 'production',
         options: {
-          outputPath: `dist/${options.clientProject}/server`,
+          outputPath: `dist/${options.project}/server`,
           main: join(
             normalize(clientProject.root),
             'src',
@@ -226,7 +226,7 @@ export default function (options: UniversalOptions): Rule {
   return async (host: Tree, context: SchematicContext) => {
     const workspace = await getWorkspace(host);
 
-    const clientProject = workspace.projects.get(options.clientProject);
+    const clientProject = workspace.projects.get(options.project);
     if (!clientProject || clientProject.extensions.projectType !== 'application') {
       throw new SchematicsException(`Universal requires a project type of "application".`);
     }

--- a/packages/schematics/angular/universal/index_spec.ts
+++ b/packages/schematics/angular/universal/index_spec.ts
@@ -19,10 +19,10 @@ describe('Universal Schematic', () => {
     require.resolve('../collection.json'),
   );
   const defaultOptions: UniversalOptions = {
-    clientProject: 'bar',
+    project: 'bar',
   };
   const workspaceUniversalOptions: UniversalOptions = {
-    clientProject: 'workspace',
+    project: 'workspace',
   };
 
   const workspaceOptions: WorkspaceOptions = {

--- a/packages/schematics/angular/universal/schema.json
+++ b/packages/schematics/angular/universal/schema.json
@@ -6,9 +6,12 @@
   "additionalProperties": false,
   "description": "Pass this schematic to the \"run\" command to set up server-side rendering for an app.",
   "properties": {
-    "clientProject": {
+    "project": {
       "type": "string",
-      "description": "The name of the related client app. Required in place of \"project\"."
+      "description": "The name of the project.",
+      "$default": {
+        "$source": "projectName"
+      }
     },
     "appId": {
       "type": "string",
@@ -45,5 +48,5 @@
       "default": false
     }
   },
-  "required": ["clientProject"]
+  "required": ["project"]
 }

--- a/tests/legacy-cli/e2e/tests/build/build-app-shell-with-schematic.ts
+++ b/tests/legacy-cli/e2e/tests/build/build-app-shell-with-schematic.ts
@@ -8,7 +8,7 @@ const snapshots = require('../../ng-snapshot/package.json');
 
 export default async function () {
   await appendToFile('src/app/app.component.html', '<router-outlet></router-outlet>');
-  await ng('generate', 'appShell', '--client-project', 'test-project');
+  await ng('generate', 'appShell', '--project', 'test-project');
 
   const isSnapshotBuild = getGlobalVariable('argv')['ng-snapshots'];
   if (isSnapshotBuild) {

--- a/tests/legacy-cli/e2e/tests/build/platform-server.ts
+++ b/tests/legacy-cli/e2e/tests/build/platform-server.ts
@@ -8,7 +8,7 @@ import { updateJsonFile } from '../../utils/project';
 const snapshots = require('../../ng-snapshot/package.json');
 
 export default async function () {
-  await ng('generate', 'universal', '--client-project', 'test-project');
+  await ng('generate', 'universal', '--project', 'test-project');
 
   const isSnapshotBuild = getGlobalVariable('argv')['ng-snapshots'];
   if (isSnapshotBuild) {
@@ -48,7 +48,10 @@ export default async function () {
 
   await ng('run', 'test-project:server', '--optimization', 'false');
 
-  await expectFileToMatch('dist/test-project/server/main.js', /exports.*AppServerModule|"AppServerModule":/);
+  await expectFileToMatch(
+    'dist/test-project/server/main.js',
+    /exports.*AppServerModule|"AppServerModule":/,
+  );
   await exec(normalize('node'), 'dist/test-project/server/main.js');
   await expectFileToMatch(
     'dist/test-project/server/index.html',

--- a/tests/legacy-cli/e2e/tests/generate/schematic-defaults.ts
+++ b/tests/legacy-cli/e2e/tests/generate/schematic-defaults.ts
@@ -1,0 +1,42 @@
+import { ng } from '../../utils/process';
+import { updateJsonFile } from '../../utils/project';
+
+export default async function () {
+  await updateJsonFile('angular.json', (config) => {
+    config.projects['test-project'].schematics = {
+      '@schematics/angular:component': {
+        style: 'scss',
+      },
+    };
+  });
+
+  // Generate component in application to verify that it's minimal
+  const { stdout } = await ng('generate', 'component', 'foo');
+  if (!stdout.includes('foo.component.scss')) {
+    console.log(stdout);
+    throw new Error('Expected "foo.component.scss" to exist.');
+  }
+
+  // Generate another project with different settings
+  await ng('generate', 'application', 'test-project-two', '--no-minimal');
+
+  await updateJsonFile('angular.json', (config) => {
+    config.projects['test-project-two'].schematics = {
+      '@schematics/angular:component': {
+        style: 'less',
+      },
+    };
+  });
+
+  const { stdout: stdout2 } = await ng(
+    'generate',
+    'component',
+    'foo',
+    '--project',
+    'test-project-two',
+  );
+  if (!stdout2.includes('foo.component.less')) {
+    console.log(stdout2);
+    throw new Error('Expected "foo.component.less" to exist.');
+  }
+}

--- a/tests/legacy-cli/e2e/tests/generate/schematic-defaults.ts
+++ b/tests/legacy-cli/e2e/tests/generate/schematic-defaults.ts
@@ -13,7 +13,6 @@ export default async function () {
   // Generate component in application to verify that it's minimal
   const { stdout } = await ng('generate', 'component', 'foo');
   if (!stdout.includes('foo.component.scss')) {
-    console.log(stdout);
     throw new Error('Expected "foo.component.scss" to exist.');
   }
 
@@ -36,7 +35,6 @@ export default async function () {
     'test-project-two',
   );
   if (!stdout2.includes('foo.component.less')) {
-    console.log(stdout2);
     throw new Error('Expected "foo.component.less" to exist.');
   }
 }

--- a/tests/legacy-cli/e2e/tests/i18n/ivy-localize-app-shell.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/ivy-localize-app-shell.ts
@@ -21,7 +21,7 @@ export default async function () {
 
   const isSnapshotBuild = getGlobalVariable('argv')['ng-snapshots'];
 
-  await updateJsonFile('package.json', packageJson => {
+  await updateJsonFile('package.json', (packageJson) => {
     const dependencies = packageJson['dependencies'];
     dependencies['@angular/localize'] = isSnapshotBuild
       ? snapshots.dependencies['@angular/localize']
@@ -29,10 +29,10 @@ export default async function () {
   });
 
   await appendToFile('src/app/app.component.html', '<router-outlet></router-outlet>');
-  await ng('generate', 'appShell', '--client-project', 'test-project');
+  await ng('generate', 'appShell', '--project', 'test-project');
 
   if (isSnapshotBuild) {
-    await updateJsonFile('package.json', packageJson => {
+    await updateJsonFile('package.json', (packageJson) => {
       const dependencies = packageJson['dependencies'];
       dependencies['@angular/platform-server'] = snapshots.dependencies['@angular/platform-server'];
       dependencies['@angular/router'] = snapshots.dependencies['@angular/router'];
@@ -49,7 +49,7 @@ export default async function () {
     { lang: 'fr', translation: 'Bonjour i18n!' },
   ];
 
-  await updateJsonFile('angular.json', workspaceJson => {
+  await updateJsonFile('angular.json', (workspaceJson) => {
     const appProject = workspaceJson.projects['test-project'];
     const appArchitect = appProject.architect || appProject.targets;
     const buildOptions = appArchitect['build'].options;
@@ -111,10 +111,7 @@ export default async function () {
 
   // Clean up app.component.html so that we can easily
   // find the translation text
-  await writeFile(
-    'src/app/app.component.html',
-    '<router-outlet></router-outlet>',
-  );
+  await writeFile('src/app/app.component.html', '<router-outlet></router-outlet>');
 
   for (const { lang, translation } of langTranslations) {
     if (lang != 'en-US') {


### PR DESCRIPTION

    
Previously, the `--project` flag was ignored when gathering and merging the schematics defaults from the angular workspace configuration file.
    
Closes #20666