### PR TITLE
test: remove `/tests/` from paths that prettier should ignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,7 +4,6 @@
 /goldens/public-api
 /packages/angular_devkit/build_angular/test/
 /packages/angular_devkit/core/src/workspace/json/test/
-/tests/
 /README.md
 /CONTRIBUTING.md
 .yarn/


### PR DESCRIPTION
This change is needed so that new/modified E2E tests get formatted.