### PR TITLE
fix(@angular-devkit/build-angular): disable CSS declaration sorting optimizations

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/plugins/optimize-css-webpack-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/plugins/optimize-css-webpack-plugin.ts
@@ -83,6 +83,8 @@ export class OptimizeCssWebpackPlugin {
                 svgo: false,
                 // Disable `calc` optimizations, due to several issues. #16910, #16875, #17890
                 calc: false,
+                // Disable CSS rules sorted due to several issues #20693, https://github.com/ionic-team/ionic-framework/issues/23266 and https://github.com/cssnano/cssnano/issues/1054
+                cssDeclarationSorter: false,
               },
             ],
           };


### PR DESCRIPTION

CSS declaration orders matters in some cases. This optimization is currently causing broken CSS output.

Closes #20693