### PR TITLE
fix(@angular/cli): change package installation to async

### DIFF
--- a/packages/angular/cli/commands/update-impl.ts
+++ b/packages/angular/cli/commands/update-impl.ts
@@ -285,7 +285,6 @@ export class UpdateCommand extends Command<UpdateCommandSchema> {
 
       return runTempPackageBin(
         `@angular/cli@${options.next ? 'next' : 'latest'}`,
-        this.logger,
         this.packageManager,
         process.argv.slice(2),
       );


### PR DESCRIPTION
With this change we change the package installation to async. This is needed as otherwise during `ng-add` the spinner gets stuck. With this change we also add the spinner in the installation methods.