### PR TITLE
fix(@angular/cli): propagate update's force option to package managers

### DIFF
--- a/goldens/public-api/angular_devkit/schematics/tools/index.d.ts
+++ b/goldens/public-api/angular_devkit/schematics/tools/index.d.ts
@@ -138,6 +138,7 @@ export interface NodeWorkflowOptions {
     force?: boolean;
     optionTransforms?: OptionTransform<object, object>[];
     packageManager?: string;
+    packageManagerForce?: boolean;
     packageRegistry?: string;
     registry?: schema.CoreSchemaRegistry;
     resolvePaths?: string[];

--- a/packages/angular/cli/commands/update-impl.ts
+++ b/packages/angular/cli/commands/update-impl.ts
@@ -66,10 +66,11 @@ export class UpdateCommand extends Command<UpdateCommandSchema> {
   private workflow!: NodeWorkflow;
   private packageManager = PackageManager.Npm;
 
-  async initialize() {
+  async initialize(options: UpdateCommandSchema & Arguments) {
     this.packageManager = await getPackageManager(this.context.root);
     this.workflow = new NodeWorkflow(this.context.root, {
       packageManager: this.packageManager,
+      packageManagerForce: options.force,
       // __dirname -> favor @schematics/update from this package
       // Otherwise, use packages from the active workspace (migrations)
       resolvePaths: [__dirname, this.context.root],

--- a/packages/angular/cli/commands/update.json
+++ b/packages/angular/cli/commands/update.json
@@ -28,7 +28,7 @@
           }
         },
         "force": {
-          "description": "If false, will error out if installed packages are incompatible with the update.",
+          "description": "Ignore peer dependency version mismatches. Passes the `--force` flag to the package manager when installing packages.",
           "default": false,
           "type": "boolean"
         },

--- a/packages/angular_devkit/schematics/tasks/package-manager/executor.ts
+++ b/packages/angular_devkit/schematics/tasks/package-manager/executor.ts
@@ -104,6 +104,10 @@ export default function (
       args.push(`--registry="${factoryOptions.registry}"`);
     }
 
+    if (factoryOptions.force) {
+      args.push('--force');
+    }
+
     return new Observable((obs) => {
       const spinner = ora({
         text: `Installing packages (${taskPackageManagerName})...`,

--- a/packages/angular_devkit/schematics/tasks/package-manager/options.ts
+++ b/packages/angular_devkit/schematics/tasks/package-manager/options.ts
@@ -13,6 +13,7 @@ export interface NodePackageTaskFactoryOptions {
   packageManager?: string;
   allowPackageManagerOverride?: boolean;
   registry?: string;
+  force?: boolean;
 }
 
 export interface NodePackageTaskOptions {

--- a/packages/angular_devkit/schematics/tools/workflow/node-workflow.ts
+++ b/packages/angular_devkit/schematics/tools/workflow/node-workflow.ts
@@ -19,6 +19,7 @@ export interface NodeWorkflowOptions {
   force?: boolean;
   dryRun?: boolean;
   packageManager?: string;
+  packageManagerForce?: boolean;
   packageRegistry?: string;
   registry?: schema.CoreSchemaRegistry;
   resolvePaths?: string[];
@@ -60,6 +61,7 @@ export class NodeWorkflow extends workflow.BaseWorkflow {
     engineHost.registerTaskExecutor(BuiltinTaskExecutor.NodePackage, {
       allowPackageManagerOverride: true,
       packageManager: options.packageManager,
+      force: options.packageManagerForce,
       rootDirectory: root && getSystemPath(root),
       registry: options.packageRegistry,
     });


### PR DESCRIPTION
When the CLI update command's `--force` option is used, the underlying package manager will also be executed with its force option. This behavior is especially important with the advent of npm 7 which will fail installation if any peer dependency version ranges are mismatched.