### PR TITLE
test: several fixes to update-8 E2E test

### DIFF
--- a/tests/legacy-cli/e2e/setup/010-local-publish.ts
+++ b/tests/legacy-cli/e2e/setup/010-local-publish.ts
@@ -1,11 +1,10 @@
-import { prerelease } from 'semver';
-import { packages } from '../../../../lib/packages';
 import { getGlobalVariable } from '../utils/env';
 import { npm } from '../utils/process';
+import { isPrereleaseCli } from '../utils/project';
 
-export default async function() {
+export default async function () {
   const testRegistry = getGlobalVariable('package-registry');
-  const publishArgs = [
+  await npm(
     'run',
     'admin',
     '--',
@@ -13,14 +12,7 @@ export default async function() {
     '--no-versionCheck',
     '--no-branchCheck',
     `--registry=${testRegistry}`,
-  ];
-
-  const pre = prerelease(packages['@angular/cli'].version);
-  if (pre && pre.length > 0) {
-    publishArgs.push('--tag', 'next');
-  } else {
-    publishArgs.push('--tag', 'latest');
-  }
-
-  await npm(...publishArgs);
+    '--tag',
+    isPrereleaseCli() ? 'next' : 'latest',
+  );
 }

--- a/tests/legacy-cli/e2e/tests/update/update-8.ts
+++ b/tests/legacy-cli/e2e/tests/update/update-8.ts
@@ -16,7 +16,7 @@ export default async function () {
     // Update Angular to 9
     await installPackage('@angular/cli@8');
     const { stdout } = await ng('update', '@angular/cli@9.x', '@angular/core@9.x');
-    if (!stdout.includes('Executing migrations of package \'@angular/cli\'')) {
+    if (!stdout.includes("Executing migrations of package '@angular/cli'")) {
       throw new Error('Update did not execute migrations. OUTPUT: \n' + stdout);
     }
 

--- a/tests/legacy-cli/e2e/tests/update/update-8.ts
+++ b/tests/legacy-cli/e2e/tests/update/update-8.ts
@@ -5,8 +5,6 @@ import { ng, noSilentNg } from '../../utils/process';
 import { isPrereleaseCli, useCIChrome, useCIDefaults } from '../../utils/project';
 
 export default async function () {
-  const extraUpdateArgs = await isPrereleaseCli()  || true ? ['--next', '--force'] : [];
-
   // We need to use the public registry because in the local NPM server we don't have
   // older versions @angular/cli packages which would cause `npm install` during `ng update` to fail.
   try {
@@ -32,7 +30,12 @@ export default async function () {
   }
 
   // Update Angular current build
-  await ng('update', '@angular/cli', '@angular/core', ...extraUpdateArgs);
+  const extraUpdateArgs = isPrereleaseCli() ? ['--next', '--force'] : [];
+  // For the latest/next release we purposely don't add `@angular/core`.
+  // This is due to our bumping strategy, which causes a period were `@angular/cli@latest` (v12.0.0) `@angular/core@latest` (v11.2.x)
+  // are of different major/minor version on the local NPM server. This causes `ng update` to fail.
+  // NB: `ng update @angula/cli` will still cause `@angular/core` packages to be updated.
+  await ng('update', '@angular/cli', ...extraUpdateArgs);
 
   // Setup testing to use CI Chrome.
   await useCIChrome('./');

--- a/tests/legacy-cli/e2e/utils/project.ts
+++ b/tests/legacy-cli/e2e/utils/project.ts
@@ -8,9 +8,6 @@ import { gitCommit } from './git';
 import { installWorkspacePackages } from './packages';
 import { execAndWaitForOutputToMatch, git, ng } from './process';
 
-const tsConfigPath = 'tsconfig.json';
-
-
 export function updateJsonFile(filePath: string, fn: (json: any) => any | void) {
   return readFile(filePath)
     .then(tsConfigJson => {
@@ -24,7 +21,7 @@ export function updateJsonFile(filePath: string, fn: (json: any) => any | void) 
 
 
 export function updateTsConfig(fn: (json: any) => any | void) {
-  return updateJsonFile(tsConfigPath, fn);
+  return updateJsonFile('tsconfig.json', fn);
 }
 
 
@@ -263,9 +260,8 @@ export async function useCIChrome(projectDir: string = ''): Promise<void> {
   }
 }
 
-export async function isPrereleaseCli() {
-  const angularCliPkgJson = JSON.parse(await readFile('node_modules/@angular/cli/package.json'));
-  const pre = prerelease(angularCliPkgJson.version);
+export function isPrereleaseCli(): boolean {
+  const pre = prerelease(packages['@angular/cli'].version);
 
   return pre && pre.length > 0;
 }


### PR DESCRIPTION

    
    
Previously in `update-8` test we used the Angular CLI in node_modules which caused incorrect result.
    
We now don't run `ng update @angular/core --next` or `ng update @angular/core`. This is due to our bumping strategy, which causes a period were `@angular/cli@latest` (v12.0.0) `@angular/core@latest` (v11.2.x) are of different major/minor version on the local NPM server. This causes `ng update` to fail.
    
NB: `ng update @angula/cli` will still cause `@angular/core` packages to be updated.