### PR TITLE
fix(@schematics/angular): pin `karma-jasmine-html-reporter` to patches in new projects

### DIFF
--- a/packages/schematics/angular/workspace/files/package.json.template
+++ b/packages/schematics/angular/workspace/files/package.json.template
@@ -34,7 +34,7 @@
     "karma-chrome-launcher": "~3.1.0",
     "karma-coverage": "~2.0.3",
     "karma-jasmine": "~4.0.0",
-    "karma-jasmine-html-reporter": "^1.5.0",
+    "karma-jasmine-html-reporter": "~1.5.0",
     "protractor": "~7.0.0",
     "ts-node": "~8.3.0",
     "tslint": "~6.1.0",<% } %>


### PR DESCRIPTION
Synchronizes the version pinning strategy with the other karma and jasmine project dependencies.
Allows project's created with npm 7+ to successfully install. `karma-jasmine-html-reporter@1.6` requires dependency versions not present in a new 11.2.x project.

Fixes #20719