### PR TITLE
Unset config

### DIFF
--- a/packages/angular/cli/commands/config-impl.ts
+++ b/packages/angular/cli/commands/config-impl.ts
@@ -21,6 +21,7 @@ const validCliPaths = new Map<
   ['cli.warnings.versionMismatch', undefined],
   ['cli.defaultCollection', undefined],
   ['cli.packageManager', undefined],
+
   ['cli.analytics', undefined],
   ['cli.analyticsSharing.tracking', undefined],
   ['cli.analyticsSharing.uuid', (v) => (v ? `${v}` : uuidV4())],
@@ -64,15 +65,22 @@ function parseJsonPath(path: string): (string | number)[] {
 
 function normalizeValue(value: string | undefined | boolean | number): JsonValue | undefined {
   const valueString = `${value}`.trim();
-  if (valueString === 'true') {
-    return true;
-  } else if (valueString === 'false') {
-    return false;
-  } else if (isFinite(+valueString)) {
+  switch (valueString) {
+    case 'true':
+      return true;
+    case 'false':
+      return false;
+    case 'null':
+      return null;
+    case 'undefined':
+      return undefined;
+  }
+
+  if (isFinite(+valueString)) {
     return +valueString;
   }
 
-  return value || undefined;
+  return value ?? undefined;
 }
 
 export class ConfigCommand extends Command<ConfigCommandSchema> {

--- a/packages/angular/cli/commands/config-impl.ts
+++ b/packages/angular/cli/commands/config-impl.ts
@@ -80,7 +80,7 @@ function normalizeValue(value: string | undefined | boolean | number): JsonValue
     return +valueString;
   }
 
-  return value ?? undefined;
+  return parseJson(valueString) ?? value ?? undefined;
 }
 
 export class ConfigCommand extends Command<ConfigCommandSchema> {

--- a/tests/legacy-cli/e2e/tests/commands/config/config-set.ts
+++ b/tests/legacy-cli/e2e/tests/commands/config/config-set.ts
@@ -15,14 +15,13 @@ export default async function () {
     throw new Error(`Expected "yarn", received "${JSON.stringify(stdout2)}".`);
   }
 
-  await ng('config', 'schematics.@schematics/angular:component.style', 'css');
-  const { stdout: stdout3 } = await ng('config', '@schematics/angular:component.style');
-  if (!stdout2.includes('css')) {
-    throw new Error(`Expected "css", received "${JSON.stringify(stdout3)}".`);
+  await ng('config', 'schematics', '{"@schematics/angular:component":{"style": "scss"}}');
+  const { stdout: stdout3 } = await ng('config', 'schematics.@schematics/angular:component.style');
+  if (!stdout3.includes('scss')) {
+    throw new Error(`Expected "scss", received "${JSON.stringify(stdout3)}".`);
   }
 
-  const { stderr } = await ng('config', 'schematics', 'undefined');
-  if (!stderr.includes('Value cannot be found.')) {
-    throw new Error(`Expected "Value cannot be found", received "${JSON.stringify(stderr)}".`);
-  }
+  await ng('config', 'schematics');
+  await ng('config', 'schematics', 'undefined');
+  await expectToFail(() => ng('config', 'schematics'));
 }

--- a/tests/legacy-cli/e2e/tests/commands/config/config-set.ts
+++ b/tests/legacy-cli/e2e/tests/commands/config/config-set.ts
@@ -1,21 +1,28 @@
 import { ng } from '../../../utils/process';
 import { expectToFail } from '../../../utils/utils';
 
-export default function() {
-  return Promise.resolve()
-    .then(() => expectToFail(() => ng('config', 'cli.warnings.zzzz')))
-    .then(() => ng('config', 'cli.warnings.versionMismatch' , 'false'))
-    .then(() => ng('config', 'cli.warnings.versionMismatch'))
-    .then(({ stdout }) => {
-      if (!stdout.match(/false/)) {
-        throw new Error(`Expected "false", received "${JSON.stringify(stdout)}".`);
-      }
-    })
-    .then(() => ng('config', 'cli.packageManager' , 'yarn'))
-    .then(() => ng('config', 'cli.packageManager'))
-    .then(({ stdout }) => {
-      if (!stdout.match(/yarn/)) {
-        throw new Error(`Expected "yarn", received "${JSON.stringify(stdout)}".`);
-      }
-    });
+export default async function () {
+  await expectToFail(() => ng('config', 'cli.warnings.zzzz'));
+  await ng('config', 'cli.warnings.versionMismatch', 'false');
+  const { stdout } = await ng('config', 'cli.warnings.versionMismatch');
+  if (!stdout.includes('false')) {
+    throw new Error(`Expected "false", received "${JSON.stringify(stdout)}".`);
+  }
+
+  await ng('config', 'cli.packageManager', 'yarn');
+  const { stdout: stdout2 } = await ng('config', 'cli.packageManager');
+  if (!stdout2.includes('yarn')) {
+    throw new Error(`Expected "yarn", received "${JSON.stringify(stdout2)}".`);
+  }
+
+  await ng('config', 'schematics.@schematics/angular:component.style', 'css');
+  const { stdout: stdout3 } = await ng('config', '@schematics/angular:component.style');
+  if (!stdout2.includes('css')) {
+    throw new Error(`Expected "css", received "${JSON.stringify(stdout3)}".`);
+  }
+
+  const { stderr } = await ng('config', 'schematics', 'undefined');
+  if (!stderr.includes('Value cannot be found.')) {
+    throw new Error(`Expected "Value cannot be found", received "${JSON.stringify(stderr)}".`);
+  }
 }


### PR DESCRIPTION


**fix(@angular/cli): allow config object to be of JSON.**

With this change we allow unset a config value to be a JSON.
    
Example, `ng config -g schematics {}` will remove the entire `schematics` section from the configuration.


**fix(@angular/cli): allow unsetting config when value is `undefined`**
    
With this change we allow unset a config value when the provided value is `undefined`.
    
Example, `ng config -g schematics undefined` will remove the entire `schematics` section from the configuration.


Closes #20718