### PR TITLE
fix(@angular/cli): disallow additional properties in builders sections

### DIFF
--- a/packages/angular/cli/lib/config/workspace-schema.json
+++ b/packages/angular/cli/lib/config/workspace-schema.json
@@ -324,10 +324,12 @@
                   }
                 }
               },
+              "additionalProperties": false,
               "required": ["builder"]
             },
             {
               "type": "object",
+              "additionalProperties": false,
               "properties": {
                 "builder": {
                   "const": "@angular-devkit/build-angular:app-shell"
@@ -349,6 +351,7 @@
             },
             {
               "type": "object",
+              "additionalProperties": false,
               "properties": {
                 "builder": {
                   "const": "@angular-devkit/build-angular:browser"
@@ -370,6 +373,7 @@
             },
             {
               "type": "object",
+              "additionalProperties": false,
               "properties": {
                 "builder": {
                   "const": "@angular-devkit/build-angular:dev-server"
@@ -391,6 +395,7 @@
             },
             {
               "type": "object",
+              "additionalProperties": false,
               "properties": {
                 "builder": {
                   "const": "@angular-devkit/build-angular:extract-i18n"
@@ -412,6 +417,7 @@
             },
             {
               "type": "object",
+              "additionalProperties": false,
               "properties": {
                 "builder": {
                   "const": "@angular-devkit/build-angular:karma"
@@ -433,6 +439,7 @@
             },
             {
               "type": "object",
+              "additionalProperties": false,
               "properties": {
                 "builder": {
                   "const": "@angular-devkit/build-angular:protractor"
@@ -454,6 +461,7 @@
             },
             {
               "type": "object",
+              "additionalProperties": false,
               "properties": {
                 "builder": {
                   "const": "@angular-devkit/build-angular:server"
@@ -475,6 +483,7 @@
             },
             {
               "type": "object",
+              "additionalProperties": false,
               "properties": {
                 "builder": {
                   "const": "@angular-devkit/build-angular:tslint"
@@ -496,9 +505,14 @@
             },
             {
               "type": "object",
+              "additionalProperties": false,
               "properties": {
                 "builder": {
                   "const": "@angular-devkit/build-angular:ng-packagr"
+                },
+                "defaultConfiguration": {
+                  "type": "string",
+                  "description": "A default named configuration to use when a target configuration is not provided."
                 },
                 "options": {
                   "$ref": "../../../../angular_devkit/build_angular/src/ng-packagr/schema.json"


### PR DESCRIPTION
With this change we disallow add additional properties to the `target` object.