### PR TITLE
fix(@angular-devkit/build-angular): fix error with inline styles when running extract-i18n

### DIFF
--- a/packages/angular_devkit/build_angular/src/extract-i18n/index.ts
+++ b/packages/angular_devkit/build_angular/src/extract-i18n/index.ts
@@ -237,6 +237,10 @@ export async function execute(
             /\.(css|scss|sass|styl|less)$/,
             path.join(__dirname, 'empty-export-default.js'),
           ),
+          new webpack.NormalModuleReplacementPlugin(
+            /^angular-resource:\/\//,
+            path.join(__dirname, 'empty-export-default.js'),
+          ),
         ],
       });
 


### PR DESCRIPTION
fixes: #20750

When extracting inline styles in Angular 12 there seems to be no CSS loader specified and there will be something like the following message:

```
angular-resource://:2:4 - Error: Module parse failed: Unexpected token (2:4) You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
|
>     :host {
|       display: block;
|       height: 0;
```

This change adds a `webpack.NormalModuleReplacementPlugin` in extract-i18n for `angular-resource://` handling them as the non inline styles are handled.

