### PR TITLE
perf(@angular-devkit/build-angular): enable opt-in usage of file system cache 

### DIFF
--- a/packages/angular_devkit/build_angular/src/app-shell/index.ts
+++ b/packages/angular_devkit/build_angular/src/app-shell/index.ts
@@ -75,9 +75,8 @@ async function _renderUniversal(
 
     const { AppServerModule, renderModule } = await import(serverBundlePath);
 
-    const renderModuleFn:
-      | ((module: unknown, options: {}) => Promise<string>)
-      | undefined = renderModule;
+    const renderModuleFn: ((module: unknown, options: {}) => Promise<string>) | undefined =
+      renderModule;
 
     if (!(renderModuleFn && AppServerModule)) {
       throw new Error(
@@ -172,7 +171,7 @@ async function _appShellBuilder(
   const browserTargetRun = await context.scheduleTarget(browserTarget, {
     watch: false,
     serviceWorker: false,
-    optimization: (optimization as unknown) as JsonObject,
+    optimization: optimization as unknown as JsonObject,
   });
   const serverTargetRun = await context.scheduleTarget(serverTarget, {
     watch: false,
@@ -181,9 +180,10 @@ async function _appShellBuilder(
   let spinner: Spinner | undefined;
 
   try {
+    // Using `.result` instead of `.output` causes Webpack FS cache not to be created.
     const [browserResult, serverResult] = await Promise.all([
-      (browserTargetRun.result as unknown) as BrowserBuilderOutput,
-      (serverTargetRun.result as unknown) as ServerBuilderOutput,
+      browserTargetRun.output.toPromise() as Promise<BrowserBuilderOutput>,
+      serverTargetRun.output.toPromise() as Promise<ServerBuilderOutput>,
     ]);
 
     if (browserResult.success === false || browserResult.baseOutputPath === undefined) {
@@ -203,8 +203,8 @@ async function _appShellBuilder(
 
     return { success: false, error: err.message };
   } finally {
-    // Just be good citizens and stop those jobs.
-    await Promise.all([browserTargetRun.stop(), serverTargetRun.stop()]);
+    // workaround for [tsetse] All Promises in async functions must either be awaited or used in an expression.
+    const _ = Promise.all([browserTargetRun.stop(), serverTargetRun.stop()]);
   }
 }
 

--- a/packages/angular_devkit/build_angular/src/utils/environment-options.ts
+++ b/packages/angular_devkit/build_angular/src/utils/environment-options.ts
@@ -80,6 +80,13 @@ export const cachingBasePath = (() => {
   return cacheVariable;
 })();
 
+// Persistent build cache
+const persistentBuildCacheVariable = process.env['NG_PERSISTENT_BUILD_CACHE'];
+export const persistentBuildCacheEnabled =
+  !cachingDisabled &&
+  isPresent(persistentBuildCacheVariable) &&
+  isEnabled(persistentBuildCacheVariable);
+
 // Build profiling
 const profilingVariable = process.env['NG_BUILD_PROFILING'];
 export const profilingEnabled = isPresent(profilingVariable) && isEnabled(profilingVariable);

--- a/packages/angular_devkit/build_angular/src/webpack/utils/stats.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/utils/stats.ts
@@ -160,6 +160,12 @@ function generateBuildStats(hash: string, time: number, colors: boolean): string
   return `Build at: ${w(new Date().toISOString())} - Hash: ${w(hash)} - Time: ${w('' + time)}ms`;
 }
 
+// We use this cache because we can have multiple builders running in the same process,
+// where each builder has different output path.
+
+// Ideally, we should create the logging callback as a factory, but that would need a refactoring.
+const runsCache = new Set<string>();
+
 function statsToString(
   json: StatsCompilation,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -176,8 +182,12 @@ function statsToString(
   const changedChunksStats: BundleStats[] = bundleState ?? [];
   let unchangedChunkNumber = 0;
   if (!bundleState?.length) {
+    const isFirstRun = !runsCache.has(json.outputPath || '');
+
     for (const chunk of json.chunks) {
-      if (!chunk.rendered) {
+      // During first build we want to display unchanged chunks
+      // but unchanged cached chunks are always marked as not rendered.
+      if (!isFirstRun && !chunk.rendered) {
         continue;
       }
 
@@ -188,6 +198,8 @@ function statsToString(
       changedChunksStats.push(generateBundleStats({ ...chunk, size: summedSize }));
     }
     unchangedChunkNumber = json.chunks.length - changedChunksStats.length;
+
+    runsCache.add(json.outputPath || '');
   }
 
   // Sort chunks by size in descending order


### PR DESCRIPTION


With this change we enable Webpack's filesystem cache, this important because `terser-webpack-plugin`, `css-minimizer-webpack-plugin` and `copy-webpack-plugin` all use Webpacks' caching API to avoid additional processing during the 2nd cold build.

This changes causes `node_modules` to be treated as immutable. Webpack will avoid hashing and timestamping them, assume the version is unique and will use it as a snapshot.

To opt-in using the experimental persistent build cache use the`NG_PERSISTENT_BUILD_CACHE` environment variable. 

```
NG_PERSISTENT_BUILD_CACHE=1 ng serve
```