### PR TITLE
perf(@angular-devkit/build-angular): reduce JSON stats

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/utils/stats.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/utils/stats.ts
@@ -12,6 +12,7 @@ import * as path from 'path';
 import * as textTable from 'text-table';
 import { Configuration, StatsCompilation } from 'webpack';
 import { colors as ansiColors, removeColor } from '../../utils/color';
+import { getWebpackStatsConfig } from '../configs/stats';
 
 export function formatSize(size: number): string {
   if (size <= 0) {
@@ -332,17 +333,7 @@ export function createWebpackLoggingCallback(
       logger.info(stats.toString(config.stats));
     }
 
-    webpackStatsLogger(
-      logger,
-      stats.toJson({
-        errors: true,
-        warnings: true,
-        builtAt: true,
-        assets: true,
-        chunks: true,
-      }),
-      config,
-    );
+    webpackStatsLogger(logger, stats.toJson(getWebpackStatsConfig(false)), config);
   };
 }
 


### PR DESCRIPTION
With this change we reduce the size of the JSON stats object, the main benefit that this change brings is that unspecified stats now default to `false`, due to the `all: false` configuration in https://github.com/angular/angular-cli/blob/e992c9a70b55b6cedbe15e4af7ad9c287a33ee29/packages/angular_devkit/build_angular/src/webpack/configs/stats.ts#L12