### PR TITLE
fix(@schematics/angular): remove --prod option from README template

### DIFF
--- a/packages/schematics/angular/workspace/files/README.md.template
+++ b/packages/schematics/angular/workspace/files/README.md.template
@@ -12,7 +12,7 @@ Run `ng generate component component-name` to generate a new component. You can 
 
 ## Build
 
-Run `ng build` to build the project. The build artifacts will be stored in the `dist/` directory. Use the `--prod` flag for a production build.
+Run `ng build` to build the project. The build artifacts will be stored in the `dist/` directory.
 
 ## Running unit tests
 


### PR DESCRIPTION
New apps using Angular 12 defaults `ng build` to use `--production configuration` (formerly `--prod`)