### PR TITLE
docs(@schematics/angular): clarify that users need to install ng e2e …

### DIFF
--- a/packages/schematics/angular/workspace/files/README.md.template
+++ b/packages/schematics/angular/workspace/files/README.md.template
@@ -20,7 +20,7 @@ Run `ng test` to execute the unit tests via [Karma](https://karma-runner.github.
 
 ## Running end-to-end tests
 
-Run `ng e2e` to execute the end-to-end tests via a platform of your choice.
+Run `ng e2e` to execute the end-to-end tests via a platform of your choice. To use this command, you need to first add a package that implements end-to-end testing capabilities.
 
 ## Further help
 


### PR DESCRIPTION
This commit adds a sentence to clarify that users need to install a `ng e2e`
builder when invoking the command for the first time.