### PR TITLE
fix(@angular-devkit/build-angular): enable webpack Trusted Types support

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/browser.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/browser.ts
@@ -87,6 +87,7 @@ export function getBrowserConfig(wco: WebpackConfigOptions): webpack.Configurati
         : 'web',
     output: {
       crossOriginLoading,
+      trustedTypes: 'angular#bundler',
     },
     optimization: {
       runtimeChunk: 'single',

--- a/tests/legacy-cli/e2e/tests/misc/http-headers.ts
+++ b/tests/legacy-cli/e2e/tests/misc/http-headers.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { ng } from '../../utils/process';
+import { updateJsonFile } from '../../utils/project';
+
+export default async function () {
+  // This test ensures that ng e2e serves the HTTP headers that are configured
+  // in the 'headers' field of the serve options. We do this by serving the
+  // strictest possible CSP headers (default-src 'none') which blocks loading of
+  // any resources (including scripts, styles and images) and should cause ng
+  // e2e to fail with a CSP-related error, which is asserted below.
+
+  await updateJsonFile('angular.json', (json) => {
+    const serve = json['projects']['test-project']['architect']['serve'];
+    if (!serve['options']) serve['options'] = {};
+    serve['options']['headers'] = {
+      'Content-Security-Policy': "default-src 'none'",
+    };
+  });
+
+  let errorMessage = null;
+  try {
+    await ng('e2e');
+  } catch (error) {
+    errorMessage = error.message;
+  }
+
+  if (!errorMessage) {
+    throw new Error(
+      'Application loaded successfully, indicating that the CSP headers were not served.',
+    );
+  }
+  if (!errorMessage.match(/Refused to load/)) {
+    throw new Error('Expected to see CSP loading failure in error logs.');
+  }
+}

--- a/tests/legacy-cli/e2e/tests/misc/trusted-types.ts
+++ b/tests/legacy-cli/e2e/tests/misc/trusted-types.ts
@@ -1,0 +1,78 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { appendToFile, prependToFile, replaceInFile, writeFile } from '../../utils/fs';
+import { ng } from '../../utils/process';
+import { updateJsonFile } from '../../utils/project';
+
+export default async function () {
+  // Add app routing.
+  // This is done automatically on a new app with --routing.
+  await prependToFile('src/app/app.module.ts', `import { RouterModule } from '@angular/router';`);
+  await replaceInFile(
+    'src/app/app.module.ts',
+    `imports: [`,
+    `imports: [ RouterModule.forRoot([]),`,
+  );
+  await appendToFile('src/app/app.component.html', '<router-outlet></router-outlet>');
+
+  // Add lazy route.
+  await ng('generate', 'module', 'lazy', '--route', 'lazy', '--module', 'app.module');
+
+  // Add lazy route e2e
+  await writeFile(
+    'e2e/src/app.e2e-spec.ts',
+    `
+     import { browser, logging, element, by } from 'protractor';
+
+     describe('workspace-project App', () => {
+       it('should display lazy route', async () => {
+         await browser.get(browser.baseUrl + '/lazy');
+         expect(await element(by.css('app-lazy p')).getText()).toEqual('lazy works!');
+       });
+
+       afterEach(async () => {
+         // Assert that there are no errors emitted from the browser
+         const logs = await browser.manage().logs().get(logging.Type.BROWSER);
+         expect(logs).not.toContain(jasmine.objectContaining({
+           level: logging.Level.SEVERE,
+         }));
+       });
+     });
+   `,
+  );
+
+  const testCases = [
+    {
+      aot: false,
+      csp: `trusted-types angular angular#unsafe-bypass angular#unsafe-jit angular#bundler; require-trusted-types-for 'script';`,
+    },
+    {
+      aot: true,
+      csp: `trusted-types angular angular#unsafe-bypass angular#bundler; require-trusted-types-for 'script';`,
+    },
+  ];
+
+  for (const { aot, csp } of testCases) {
+    await updateJsonFile('angular.json', (json) => {
+      const architect = json['projects']['test-project']['architect'];
+      architect['build']['options']['aot'] = aot;
+      if (!architect['serve']['options']) architect['serve']['options'] = {};
+      architect['serve']['options']['headers'] = {
+        'Content-Security-Policy': csp,
+      };
+    });
+
+    try {
+      await ng('e2e');
+    } catch (error) {
+      console.error(`Test case AOT ${aot} with CSP header ${csp} failed.`);
+      throw error;
+    }
+  }
+}


### PR DESCRIPTION
As reported in #20113, webpack triggers a Trusted Types violation when lazy-loading is used. To mitigate that, enable webpack's Trusted Types module (introduced in https://github.com/webpack/webpack/pull/9856) using 'angular#bundler' as the policy name.