### PR TITLE
fix(@angular/cli): cannot locate bin for temporary package

### DIFF
--- a/packages/angular/cli/commands/add-impl.ts
+++ b/packages/angular/cli/commands/add-impl.ts
@@ -205,13 +205,13 @@ export class AddCommand extends SchematicCommand<AddCommandSchema> {
     if (savePackage === false) {
       // Temporary packages are located in a different directory
       // Hence we need to resolve them using the temp path
-      const { status, tempPath } = await installTempPackage(
+      const { status, tempNodeModules } = await installTempPackage(
         packageIdentifier.raw,
         packageManager,
         options.registry ? [`--registry="${options.registry}"`] : undefined,
       );
       const resolvedCollectionPath = require.resolve(join(collectionName, 'package.json'), {
-        paths: [tempPath],
+        paths: [tempNodeModules],
       });
 
       if (status !== 0) {

--- a/packages/angular/cli/utilities/install-package.ts
+++ b/packages/angular/cli/utilities/install-package.ts
@@ -78,7 +78,7 @@ export async function installTempPackage(
   extraArgs?: string[],
 ): Promise<{
   status: 1 | 0;
-  tempPath: string;
+  tempNodeModules: string;
 }> {
   const tempPath = mkdtempSync(join(realpathSync(tmpdir()), 'angular-cli-packages-'));
 
@@ -121,7 +121,7 @@ export async function installTempPackage(
 
   return {
     status: await installPackage(packageName, packageManager, true, installArgs, tempPath),
-    tempPath,
+    tempNodeModules,
   };
 }
 
@@ -130,7 +130,7 @@ export async function runTempPackageBin(
   packageManager: PackageManager = PackageManager.Npm,
   args: string[] = [],
 ): Promise<number> {
-  const { status: code, tempPath } = await installTempPackage(packageName, packageManager);
+  const { status: code, tempNodeModules } = await installTempPackage(packageName, packageManager);
   if (code !== 0) {
     return code;
   }
@@ -138,7 +138,7 @@ export async function runTempPackageBin(
   // Remove version/tag etc... from package name
   // Ex: @angular/cli@latest -> @angular/cli
   const packageNameNoVersion = packageName.substring(0, packageName.lastIndexOf('@'));
-  const pkgLocation = join(tempPath, packageNameNoVersion);
+  const pkgLocation = join(tempNodeModules, packageNameNoVersion);
   const packageJsonPath = join(pkgLocation, 'package.json');
 
   // Get a binary location for this package


### PR DESCRIPTION
This fixes an issue where the installation of the temporary Angular CLI failed with `Cannot locate bin for temporary package: @angular/cli.`