### PR TITLE
Fix for webpack 5 + babel "failed to resolve" error

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
@@ -483,6 +483,8 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
         },
         {
           test: /\.[cm]?js$|\.tsx?$/,
+          // The below is needed due to a bug in `@babel/runtime`. See: https://github.com/babel/babel/issues/12824
+          resolve: { fullySpecified: false },
           exclude: [/[\/\\](?:core-js|\@babel|tslib|web-animations-js)[\/\\]/],
           use: [
             {


### PR DESCRIPTION
Addresses #20800.

I don't know if this is the best fix for this issue, but seems to be an effective temporary workaround at least. It's possible that a bug may need to be fixed in `babel-loader` or `@babel/runtime`.