### PR TITLE
ci: disable `eslint-plugin-import` from auto updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,7 @@
   },
   "schedule": ["after 10pm every weekday", "before 4am every weekday", "every weekend"],
   "baseBranches": ["master"],
-  "ignoreDeps": ["@types/node", "quicktype-core"],
+  "ignoreDeps": ["@types/node", "quicktype-core", "eslint-plugin-import"],
   "packageFiles": [
     "WORKSPACE",
     "package.json",


### PR DESCRIPTION
Disable the mentioned package from being managed by Renovate until https://github.com/benmosher/eslint-plugin-import/issues/2065 is fixed.