### PR TITLE
perf(@angular-devkit/build-angular): clean no-longer used assets during builds

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
@@ -443,6 +443,7 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
     context: root,
     entry: entryPoints,
     output: {
+      clean: buildOptions.deleteOutputPath,
       path: path.resolve(root, buildOptions.outputPath),
       publicPath: buildOptions.deployUrl ?? '',
       filename: ({ chunk }) => {


### PR DESCRIPTION

This reduce memory consumption during re-builds.

```
runtime.ba93f81591909b93394f.hot-update.js.map will be removed
styles.ba93f81591909b93394f.hot-update.js.map will be removed
runtime.ba93f81591909b93394f.hot-update.json will be removed
runtime.ba93f81591909b93394f.hot-update.js will be removed
styles.ba93f81591909b93394f.hot-update.js will be removed
```

See https://github.com/webpack/webpack/issues/12947#issuecomment-812108140 and https://github.com/webpack/webpack/issues/13127