### PR TITLE
fix(@angular-devkit/build-angular): compile schema in synchronously

### DIFF
--- a/packages/angular_devkit/core/src/json/schema/registry.ts
+++ b/packages/angular_devkit/core/src/json/schema/registry.ts
@@ -296,7 +296,7 @@ export class CoreSchemaRegistry implements SchemaRegistry {
     let validator: ValidateFunction;
     try {
       this._currentCompilationSchemaInfo = schemaInfo;
-      validator = await this._ajv.compileAsync(schema);
+      validator = this._ajv.compile(schema);
     } finally {
       this._currentCompilationSchemaInfo = undefined;
     }


### PR DESCRIPTION
AJV only support a single schema with the same ID, compiling schemas async can cause a race condition were multiple schemas with the same name as compiled at the same time.

Closes #20847