### PR TITLE
ci: update e2e-cli to use node 12.20

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -328,7 +328,7 @@ workflows:
                 - master
       - e2e-cli:
           name: e2e-cli-node-12
-          nodeversion: '12.18'
+          nodeversion: '12.20'
           <<: *only_release_branches
           requires:
             - e2e-cli


### PR DESCRIPTION
Update the e2e-cli job on CI to use 12.20 rather than 12.18.