### PR TITLE
perf(@ngtools/webpack): only request semantic diagnostics once for each source file

### DIFF
--- a/packages/ngtools/webpack/src/ivy/plugin.ts
+++ b/packages/ngtools/webpack/src/ivy/plugin.ts
@@ -476,6 +476,14 @@ export class AngularWebpackPlugin {
         }
 
         affectedFiles.add(result.affected as ts.SourceFile);
+        diagnosticsReporter(result.result);
+      }
+    } else {
+      // Collect semantic diagnostics
+      for (const sourceFile of builder.getSourceFiles()) {
+        if (!ignoreForDiagnostics.has(sourceFile)) {
+          diagnosticsReporter(builder.getSemanticDiagnostics(sourceFile));
+        }
       }
     }
 
@@ -487,13 +495,6 @@ export class AngularWebpackPlugin {
       ...builder.getSyntacticDiagnostics(),
     ];
     diagnosticsReporter(diagnostics);
-
-    // Collect semantic diagnostics
-    for (const sourceFile of builder.getSourceFiles()) {
-      if (!ignoreForDiagnostics.has(sourceFile)) {
-        diagnosticsReporter(builder.getSemanticDiagnostics(sourceFile));
-      }
-    }
 
     const transformers = createAotTransformers(builder, this.pluginOptions);
 


### PR DESCRIPTION

Currently, we request `SemanticDiagnostics` twice for each source file when in watch mode. Once, using `builder.getSemanticDiagnosticsOfNextAffectedFile` and right after we iterate over each source file and call `builder.getSemanticDiagnostics`.

With this change the build time of an `ng-new` application is reduced by `~1s`, while on a larger application this reduces the compilation time by `4s`.