### PR TITLE
fix(@angular/cli): update `engines` to require `node` `12.20.0`

### DIFF
--- a/lib/packages.ts
+++ b/lib/packages.ts
@@ -85,7 +85,7 @@ function loadPackageJson(p: string) {
       // Overwrite engines to a common default.
       case 'engines':
         pkg['engines'] = {
-          'node': '^12.14.1 || >=14.0.0',
+          'node': '^12.20.0 || >=14.0.0',
           'npm': '^6.11.0 || ^7.5.6',
           'yarn': '>= 1.13.0',
         };

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "url": "https://github.com/angular/angular-cli.git"
   },
   "engines": {
-    "node": "^12.14.1 || ^14.0.0",
+    "node": "^12.20.0 || ^14.0.0",
     "yarn": ">=1.21.1 <2",
     "npm": "Please use yarn instead of NPM to install dependencies"
   },

--- a/packages/angular/cli/bin/ng
+++ b/packages/angular/cli/bin/ng
@@ -29,7 +29,7 @@ if (version[0] % 2 === 1 && version[0] > 14) {
 } else if (
   version[0] < 12 ||
   version[0] === 13 ||
-  (version[0] === 12 && version[1] < 14) ||
+  (version[0] === 12 && version[1] < 20) ||
   (version[0] === 14 && version[1] < 15)
 ) {
   // Error and exit if less than 12.14 or 13.x or less than 14.15

--- a/packages/angular_devkit/build_angular/src/sass/sass-service.ts
+++ b/packages/angular_devkit/build_angular/src/sass/sass-service.ts
@@ -40,15 +40,6 @@ interface RenderResponseMessage {
 }
 
 /**
- * Workaround required for lack of new Worker transfer list support in Node.js prior to 12.17
- */
-let transferListWorkaround = false;
-const version = process.versions.node.split('.').map((part) => Number(part));
-if (version[0] === 12 && version[1] < 17) {
-  transferListWorkaround = true;
-}
-
-/**
  * A Sass renderer implementation that provides an interface that can be used by Webpack's
  * `sass-loader`. The implementation uses a Worker thread to perform the Sass rendering
  * with the `dart-sass` package.  The `dart-sass` synchronous render function is used within
@@ -134,13 +125,9 @@ export class SassWorkerImplementation {
 
     const workerPath = require.resolve('./worker');
     const worker = new Worker(workerPath, {
-      workerData: transferListWorkaround ? undefined : { workerImporterPort, importerSignal },
-      transferList: transferListWorkaround ? undefined : [workerImporterPort],
+      workerData: { workerImporterPort, importerSignal },
+      transferList: [workerImporterPort],
     });
-
-    if (transferListWorkaround) {
-      worker.postMessage({ init: true, workerImporterPort, importerSignal }, [workerImporterPort]);
-    }
 
     worker.on('message', (response: RenderResponseMessage) => {
       const request = this.requests.get(response.id);


### PR DESCRIPTION
    We drop support for Node.js versions prior to `12.20`.