### PR TITLE
fix(@angular-devkit/build-angular): ensure Sass worker implementation supports Node.js 12.14

### DIFF
--- a/packages/angular_devkit/build_angular/src/sass/worker.ts
+++ b/packages/angular_devkit/build_angular/src/sass/worker.ts
@@ -18,27 +18,46 @@ interface RenderRequestMessage {
    * importer on the main thread.
    */
   id: number;
+
   /**
    * The Sass options to provide to the `dart-sass` render function.
    */
   options: Options;
+
   /**
    * Indicates the request has a custom importer function on the main thread.
    */
   hasImporter: boolean;
+
+  /**
+   * Indicates this is not an init message.
+   */
+  init: undefined;
 }
 
-if (!parentPort || !workerData) {
+interface InitMessage {
+  init: true;
+  workerImporterPort: MessagePort;
+  importerSignal: Int32Array;
+}
+
+if (!parentPort) {
   throw new Error('Sass worker must be executed as a Worker.');
 }
 
 // The importer variables are used to proxy import requests to the main thread
-const { workerImporterPort, importerSignal } = workerData as {
-  workerImporterPort: MessagePort;
-  importerSignal: Int32Array;
-};
+let { workerImporterPort, importerSignal } = (workerData || {}) as InitMessage;
 
-parentPort.on('message', ({ id, hasImporter, options }: RenderRequestMessage) => {
+parentPort.on('message', (message: RenderRequestMessage | InitMessage) => {
+  // The init message is only needed to support Node.js < 12.17 and can be removed once support is dropped
+  if (message.init) {
+    workerImporterPort = message.workerImporterPort;
+    importerSignal = message.importerSignal;
+
+    return;
+  }
+
+  const { id, hasImporter, options } = message;
   try {
     if (hasImporter) {
       // When a custom importer function is present, the importer request must be proxied


### PR DESCRIPTION
The Worker constructor option for a transfer list is unfortunately not supported until Node.js 12.17. For Node.js versions prior to 12.17, a manual message post is now used to transfer the necessary initialization data to the Sass workers.

Closes #20863