### PR TITLE
feat(@angular/cli): show Node.js version support status in version command

### DIFF
--- a/packages/angular/cli/commands/version-impl.ts
+++ b/packages/angular/cli/commands/version-impl.ts
@@ -13,6 +13,11 @@ import { colors } from '../utilities/color';
 import { getPackageManager } from '../utilities/package-manager';
 import { Schema as VersionCommandSchema } from './version';
 
+/**
+ * Major versions of Node.js that are officially supported by Angular.
+ */
+const SUPPORTED_NODE_MAJORS = [12, 14];
+
 interface PartialPackageInfo {
   name: string;
   version: string;
@@ -29,6 +34,9 @@ export class VersionCommand extends Command<VersionCommandSchema> {
     try {
       workspacePackage = require(path.resolve(this.context.root, 'package.json'));
     } catch {}
+
+    const [nodeMajor] = process.versions.node.split('.').map((part) => Number(part));
+    const unsupportedNodeVersion = !SUPPORTED_NODE_MAJORS.includes(nodeMajor);
 
     const patterns = [
       /^@angular\/.*/,
@@ -104,7 +112,7 @@ export class VersionCommand extends Command<VersionCommandSchema> {
     this.logger.info(
       `
       Angular CLI: ${ngCliVersion}
-      Node: ${process.versions.node}
+      Node: ${process.versions.node}${unsupportedNodeVersion ? ' (Unsupported)' : ''}
       Package Manager: ${await this.getPackageManager()}
       OS: ${process.platform} ${process.arch}
 
@@ -134,6 +142,12 @@ export class VersionCommand extends Command<VersionCommandSchema> {
         .join('\n')}
     `.replace(/^ {6}/gm, ''),
     );
+
+    if (unsupportedNodeVersion) {
+      this.logger.warn(
+        `Warning: The current version of Node (${process.versions.node}) is not supported by Angular.`,
+      );
+    }
   }
 
   private getVersion(moduleName: string): string {

--- a/tests/legacy-cli/e2e/tests/misc/version.ts
+++ b/tests/legacy-cli/e2e/tests/misc/version.ts
@@ -1,7 +1,7 @@
 import { deleteFile } from '../../utils/fs';
 import { ng } from '../../utils/process';
 
-export default async function() {
+export default async function () {
   const { stdout: commandOutput } = await ng('version');
   const { stdout: optionOutput } = await ng('--version');
   if (!optionOutput.includes('Angular CLI:')) {
@@ -10,6 +10,14 @@ export default async function() {
 
   if (commandOutput !== optionOutput) {
     throw new Error('version variants have differing output');
+  }
+
+  if (commandOutput.includes(process.versions.node + ' (Unsupported)')) {
+    throw new Error('Node version should not show unsupported entry');
+  }
+
+  if (commandOutput.includes('Warning: The current version of Node ')) {
+    throw new Error('Node support warning should not be shown');
   }
 
   // doesn't fail on a project with missing angular.json


### PR DESCRIPTION
Unsupported versions of Node.js will now show an unsupported warning when the `ng version` command is executed.
Currently Node.js major versions 12 and 14 are considered supported and tested.

Closes #20879