### PR TITLE
fix(@ngtools/webpack): re-emit component stylesheet assets

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/plugins/postcss-cli-resources.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/plugins/postcss-cli-resources.ts
@@ -125,7 +125,7 @@ export default function (options?: PostcssCliResourcesOptions): Plugin {
 
         loader.addDependency(result);
         if (emitFile) {
-          loader.emitFile(outputPath, content, undefined);
+          loader.emitFile(outputPath, content, undefined, { sourceFilename: result });
         }
 
         let outputUrl = outputPath.replace(/\\/g, '/');


### PR DESCRIPTION
With this change we re-emit assets referenced in component stylesheets which where uneffected by the change that re-triggered a re-compilation.

Since we cache the the result of processed component CSS, during a re-compilation `postcss-cli-resources` plugin will not run which causes assets to be to emit. With this change we now cache the asset and re-emit them on every change.

Closes #20882