### PR TITLE
test: use correct snapshot versions in add-pwa E2E test

### DIFF
--- a/tests/legacy-cli/e2e/ng-snapshot/package.json
+++ b/tests/legacy-cli/e2e/ng-snapshot/package.json
@@ -16,6 +16,7 @@
     "@angular/platform-browser": "github:angular/platform-browser-builds#8a3b383485754ffe85453d972db8709484a56ab3",
     "@angular/platform-browser-dynamic": "github:angular/platform-browser-dynamic-builds#b6d2d193af01f8ac5951a5e6e945712a0d948fe5",
     "@angular/platform-server": "github:angular/platform-server-builds#7553899212283c15a3bd08661417b8c0b06f51f9",
-    "@angular/router": "github:angular/router-builds#76cd3541b820ddac2416de5f1bb48c106b4973dc"
+    "@angular/router": "github:angular/router-builds#76cd3541b820ddac2416de5f1bb48c106b4973dc",
+    "@angular/service-worker": "github:angular/service-worker-builds#163cd9d311092d2358f33f2de0b3e8eb97a0f38e"
   }
 }

--- a/tests/legacy-cli/e2e/tests/commands/add/add-pwa.ts
+++ b/tests/legacy-cli/e2e/tests/commands/add/add-pwa.ts
@@ -1,6 +1,11 @@
 import { join } from 'path';
+import { getGlobalVariable } from '../../../utils/env';
 import { expectFileToExist, readFile, rimraf } from '../../../utils/fs';
+import { installPackage } from '../../../utils/packages';
 import { ng } from '../../../utils/process';
+import { updateJsonFile } from '../../../utils/project';
+
+const snapshots = require('../../../ng-snapshot/package.json');
 
 export default async function () {
   // forcibly remove in case another test doesn't clean itself up
@@ -17,6 +22,24 @@ export default async function () {
   );
   if (hasPWADep) {
     throw new Error(`Expected 'package.json' not to contain a dependency on '@angular/pwa'.`);
+  }
+
+  const isSnapshotBuild = getGlobalVariable('argv')['ng-snapshots'];
+  if (isSnapshotBuild) {
+    const packagesToInstall = [];
+    await updateJsonFile('package.json', (packageJson) => {
+      const dependencies = packageJson['dependencies'];
+      // Iterate over all of the packages to update them to the snapshot version.
+      for (const [name, version] of Object.entries(snapshots.dependencies)) {
+        if (name in dependencies && dependencies[name] !== version) {
+          packagesToInstall.push(version);
+        }
+      }
+    });
+
+    for (const pkg of packagesToInstall) {
+      await installPackage(pkg);
+    }
   }
 
   // It should generate a SW configuration file (`ngsw.json`).


### PR DESCRIPTION
When executing the add-pwa E2E test with Angular snapshots, the package versions need to be updated after the `ng add @angular/pwa` call to ensure that the correct version of `@angular/service-worker` is used.