### PR TITLE
refactor(@ngtools/webpack): use Webpack inline resource matching for inline resources

### DIFF
--- a/packages/angular_devkit/build_angular/src/browser/tests/options/inline-style-language_spec.ts
+++ b/packages/angular_devkit/build_angular/src/browser/tests/options/inline-style-language_spec.ts
@@ -32,10 +32,7 @@ describeBuilder(buildWebpackBrowser, BROWSER_BUILDER_INFO, (harness) => {
           });
 
           await harness.modifyFile('src/app/app.component.ts', (content) =>
-            content.replace(
-              '__STYLE_MARKER__',
-              '$primary-color: green;\\nh1 { color: $primary-color; }',
-            ),
+            content.replace('__STYLE_MARKER__', '$primary: green;\\nh1 { color: $primary; }'),
           );
 
           const { result } = await harness.executeOnce();
@@ -52,10 +49,7 @@ describeBuilder(buildWebpackBrowser, BROWSER_BUILDER_INFO, (harness) => {
           });
 
           await harness.modifyFile('src/app/app.component.ts', (content) =>
-            content.replace(
-              '__STYLE_MARKER__',
-              '$primary-color: green\\nh1\\n\\tcolor: $primary-color',
-            ),
+            content.replace('__STYLE_MARKER__', '$primary: green\\nh1\\n\\tcolor: $primary'),
           );
 
           const { result } = await harness.executeOnce();
@@ -77,7 +71,7 @@ describeBuilder(buildWebpackBrowser, BROWSER_BUILDER_INFO, (harness) => {
         //   await harness.modifyFile('src/app/app.component.ts', (content) =>
         //     content.replace(
         //       '__STYLE_MARKER__',
-        //       '$primary-color = green;\\nh1 { color: $primary-color; }',
+        //       '$primary = green;\\nh1 { color: $primary; }',
         //     ),
         //   );
 
@@ -95,10 +89,7 @@ describeBuilder(buildWebpackBrowser, BROWSER_BUILDER_INFO, (harness) => {
           });
 
           await harness.modifyFile('src/app/app.component.ts', (content) =>
-            content.replace(
-              '__STYLE_MARKER__',
-              '@primary-color: green;\\nh1 { color: @primary-color; }',
-            ),
+            content.replace('__STYLE_MARKER__', '@primary: green;\\nh1 { color: @primary; }'),
           );
 
           const { result } = await harness.executeOnce();
@@ -106,67 +97,64 @@ describeBuilder(buildWebpackBrowser, BROWSER_BUILDER_INFO, (harness) => {
           expect(result?.success).toBe(true);
           harness.expectFile('dist/main.js').content.toContain('color: green');
         });
-      });
 
-      it('updates produced stylesheet in watch mode', async () => {
-        harness.useTarget('build', {
-          ...BASE_OPTIONS,
-          main: 'src/main.ts',
-          inlineStyleLanguage: InlineStyleLanguage.Scss,
-          aot,
-          watch: true,
+        it('updates produced stylesheet in watch mode', async () => {
+          harness.useTarget('build', {
+            ...BASE_OPTIONS,
+            main: 'src/main.ts',
+            inlineStyleLanguage: InlineStyleLanguage.Scss,
+            aot,
+            watch: true,
+          });
+
+          await harness.modifyFile('src/app/app.component.ts', (content) =>
+            content.replace('__STYLE_MARKER__', '$primary: green;\\nh1 { color: $primary; }'),
+          );
+
+          const buildCount = await harness
+            .execute()
+            .pipe(
+              timeout(30000),
+              concatMap(async ({ result }, index) => {
+                expect(result?.success).toBe(true);
+
+                switch (index) {
+                  case 0:
+                    harness.expectFile('dist/main.js').content.toContain('color: green');
+                    harness.expectFile('dist/main.js').content.not.toContain('color: aqua');
+
+                    await harness.modifyFile('src/app/app.component.ts', (content) =>
+                      content.replace(
+                        '$primary: green;\\nh1 { color: $primary; }',
+                        '$primary: aqua;\\nh1 { color: $primary; }',
+                      ),
+                    );
+                    break;
+                  case 1:
+                    harness.expectFile('dist/main.js').content.not.toContain('color: green');
+                    harness.expectFile('dist/main.js').content.toContain('color: aqua');
+
+                    await harness.modifyFile('src/app/app.component.ts', (content) =>
+                      content.replace(
+                        '$primary: aqua;\\nh1 { color: $primary; }',
+                        '$primary: blue;\\nh1 { color: $primary; }',
+                      ),
+                    );
+                    break;
+                  case 2:
+                    harness.expectFile('dist/main.js').content.not.toContain('color: green');
+                    harness.expectFile('dist/main.js').content.not.toContain('color: aqua');
+                    harness.expectFile('dist/main.js').content.toContain('color: blue');
+                    break;
+                }
+              }),
+              take(3),
+              count(),
+            )
+            .toPromise();
+
+          expect(buildCount).toBe(3);
         });
-
-        await harness.modifyFile('src/app/app.component.ts', (content) =>
-          content.replace(
-            '__STYLE_MARKER__',
-            '$primary-color: green;\\nh1 { color: $primary-color; }',
-          ),
-        );
-
-        const buildCount = await harness
-          .execute()
-          .pipe(
-            timeout(30000),
-            concatMap(async ({ result }, index) => {
-              expect(result?.success).toBe(true);
-
-              switch (index) {
-                case 0:
-                  harness.expectFile('dist/main.js').content.toContain('color: green');
-                  harness.expectFile('dist/main.js').content.not.toContain('color: aqua');
-
-                  await harness.modifyFile('src/app/app.component.ts', (content) =>
-                    content.replace(
-                      '$primary-color: green;\\nh1 { color: $primary-color; }',
-                      '$primary-color: aqua;\\nh1 { color: $primary-color; }',
-                    ),
-                  );
-                  break;
-                case 1:
-                  harness.expectFile('dist/main.js').content.not.toContain('color: green');
-                  harness.expectFile('dist/main.js').content.toContain('color: aqua');
-
-                  await harness.modifyFile('src/app/app.component.ts', (content) =>
-                    content.replace(
-                      '$primary-color: aqua;\\nh1 { color: $primary-color; }',
-                      '$primary-color: blue;\\nh1 { color: $primary-color; }',
-                    ),
-                  );
-                  break;
-                case 2:
-                  harness.expectFile('dist/main.js').content.not.toContain('color: green');
-                  harness.expectFile('dist/main.js').content.not.toContain('color: aqua');
-                  harness.expectFile('dist/main.js').content.toContain('color: blue');
-                  break;
-              }
-            }),
-            take(3),
-            count(),
-          )
-          .toPromise();
-
-        expect(buildCount).toBe(3);
       });
     }
   });

--- a/packages/angular_devkit/build_angular/src/webpack/configs/typescript.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/typescript.ts
@@ -51,20 +51,20 @@ function createIvyPlugin(
     }
   }
 
-  let inlineStyleMimeType;
+  let inlineStyleFileExtension;
   switch (buildOptions.inlineStyleLanguage) {
     case 'less':
-      inlineStyleMimeType = 'text/x-less';
+      inlineStyleFileExtension = 'less';
       break;
     case 'sass':
-      inlineStyleMimeType = 'text/x-sass';
+      inlineStyleFileExtension = 'sass';
       break;
     case 'scss':
-      inlineStyleMimeType = 'text/x-scss';
+      inlineStyleFileExtension = 'scss';
       break;
     case 'css':
     default:
-      inlineStyleMimeType = 'text/css';
+      inlineStyleFileExtension = 'css';
       break;
   }
 
@@ -74,7 +74,7 @@ function createIvyPlugin(
     fileReplacements,
     jitMode: !aot,
     emitNgModuleScope: !optimize,
-    inlineStyleMimeType,
+    inlineStyleFileExtension,
   });
 }
 

--- a/packages/ngtools/webpack/src/inline-data-loader.ts
+++ b/packages/ngtools/webpack/src/inline-data-loader.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { Compilation, LoaderContext } from 'webpack';
+
+export const InlineAngularResourceSymbol = Symbol();
+
+export interface CompilationWithInlineAngularResource extends Compilation {
+  [InlineAngularResourceSymbol]: string;
+}
+
+export default function (this: LoaderContext<{ data?: string }>) {
+  const callback = this.async();
+  const { data } = this.getOptions();
+
+  if (data) {
+    callback(undefined, Buffer.from(data, 'base64').toString());
+  } else {
+    const content = (this._compilation as CompilationWithInlineAngularResource)[
+      InlineAngularResourceSymbol
+    ];
+    callback(undefined, content);
+  }
+}

--- a/packages/ngtools/webpack/src/ivy/host.ts
+++ b/packages/ngtools/webpack/src/ivy/host.ts
@@ -19,7 +19,11 @@ import { normalizePath } from './paths';
 export function augmentHostWithResources(
   host: ts.CompilerHost,
   resourceLoader: WebpackResourceLoader,
-  options: { directTemplateLoading?: boolean; inlineStyleMimeType?: string } = {},
+  options: {
+    directTemplateLoading?: boolean;
+    inlineStyleMimeType?: string;
+    inlineStyleFileExtension?: string;
+  } = {},
 ) {
   const resourceHost = host as CompilerHost;
 
@@ -57,10 +61,11 @@ export function augmentHostWithResources(
       return null;
     }
 
-    if (options.inlineStyleMimeType) {
+    if (options.inlineStyleMimeType || options.inlineStyleFileExtension) {
       const content = await resourceLoader.process(
         data,
         options.inlineStyleMimeType,
+        options.inlineStyleFileExtension,
         context.type,
         context.containingFile,
       );

--- a/packages/ngtools/webpack/src/ivy/plugin.ts
+++ b/packages/ngtools/webpack/src/ivy/plugin.ts
@@ -55,6 +55,7 @@ export interface AngularWebpackPluginOptions {
   emitNgModuleScope: boolean;
   jitMode: boolean;
   inlineStyleMimeType?: string;
+  inlineStyleFileExtension?: string;
 }
 
 // Add support for missing properties in Webpack types as well as the loader's file emitter
@@ -241,6 +242,7 @@ export class AngularWebpackPlugin {
       augmentHostWithResources(host, resourceLoader, {
         directTemplateLoading: this.pluginOptions.directTemplateLoading,
         inlineStyleMimeType: this.pluginOptions.inlineStyleMimeType,
+        inlineStyleFileExtension: this.pluginOptions.inlineStyleFileExtension,
       });
 
       // Setup source file adjustment options

--- a/packages/ngtools/webpack/src/ivy/transformation.ts
+++ b/packages/ngtools/webpack/src/ivy/transformation.ts
@@ -36,7 +36,11 @@ export function createAotTransformers(
 
 export function createJitTransformers(
   builder: ts.BuilderProgram,
-  options: { directTemplateLoading?: boolean; inlineStyleMimeType?: string },
+  options: {
+    directTemplateLoading?: boolean;
+    inlineStyleMimeType?: string;
+    inlineStyleFileExtension?: string;
+  },
 ): ts.CustomTransformers {
   const getTypeChecker = () => builder.getProgram().getTypeChecker();
 
@@ -47,6 +51,7 @@ export function createJitTransformers(
         getTypeChecker,
         options.directTemplateLoading,
         options.inlineStyleMimeType,
+        options.inlineStyleFileExtension,
       ),
       constructorParametersDownlevelTransform(builder.getProgram()),
     ],


### PR DESCRIPTION
Webpack provides a method to construct a special request string that will remap a loader chain to appear to be from a specific resource path. This requires a custom loader, however, it allows rule matching to leverage the existing file extension based approach and allows providing a path to other loaders which simplifies relative request handling.