### PR TITLE
ci: disable Webpack updates until `5.37.2` is released

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,7 @@
   },
   "schedule": ["after 10pm every weekday", "before 4am every weekday", "every weekend"],
   "baseBranches": ["master"],
-  "ignoreDeps": ["@types/node", "quicktype-core", "eslint-plugin-import"],
+  "ignoreDeps": ["@types/node", "quicktype-core", "eslint-plugin-import", "webpack"],
   "packageFiles": [
     "WORKSPACE",
     "package.json",


### PR DESCRIPTION
`5.37.1` contains a bug which causes `modifiedFiles` to always be `undefined`.