### PR TITLE
fix(@angular-devkit/build-angular): do not resolve web-workers in server builds

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/server.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/server.ts
@@ -39,6 +39,14 @@ export function getServerConfig(wco: WebpackConfigOptions): Configuration {
     output: {
       libraryTarget: 'commonjs',
     },
+    module: {
+      parser: {
+        javascript: {
+          worker: false,
+          url: false,
+        },
+      },
+    },
     plugins: [
       // Fixes Critical dependency: the request of a dependency is an expression
       new ContextReplacementPlugin(/@?hapi(\\|\/)/),


### PR DESCRIPTION
Web-workers are not supported on the server and therefore we should not try to request these files from the Angular plugin.
Closes #20877