### PR TITLE
fix(@angular-devkit/build-angular): show `--disable-host-check` warning only when not using `disableHostCheck`

### DIFF
--- a/packages/angular_devkit/build_angular/src/dev-server/index.ts
+++ b/packages/angular_devkit/build_angular/src/dev-server/index.ts
@@ -226,6 +226,7 @@ export function serveWebpackBrowser(
     }
 
     if (
+      !options.disableHostCheck &&
       options.host &&
       !/^127\.\d+\.\d+\.\d+/g.test(options.host) &&
       options.host !== 'localhost'


### PR DESCRIPTION
Closes #20951