### PR TITLE
fix(@angular-devkit/build-angular): provided earlier build feedback in console

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
@@ -68,6 +68,42 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
     buildOptions.differentialLoadingNeeded,
   );
 
+  if (buildOptions.progress) {
+    const spinner = new Spinner();
+    spinner.start(`Generating ${platform} application bundles (phase: setup)...`);
+
+    let previousPercentage: number | undefined;
+    extraPlugins.push(
+      new ProgressPlugin({
+        handler: (percentage: number, message: string) => {
+          if (previousPercentage === 1 && percentage !== 0) {
+            // In some scenarios in Webpack 5 percentage goes from 1 back to 0.99.
+            // Ex: 0.99 -> 1 -> 0.99 -> 1
+            // This causes the "complete" message to be displayed multiple times.
+
+            return;
+          }
+
+          switch (percentage) {
+            case 1:
+              spinner.succeed(
+                `${platform.replace(/^\w/, (s) =>
+                  s.toUpperCase(),
+                )} application bundle generation complete.`,
+              );
+              break;
+            case 0:
+            default:
+              spinner.text = `Generating ${platform} application bundles (phase: ${message})...`;
+              break;
+          }
+
+          previousPercentage = percentage;
+        },
+      }),
+    );
+  }
+
   if (buildOptions.main) {
     const mainPath = path.resolve(root, buildOptions.main);
     entryPoints['main'] = [mainPath];
@@ -212,43 +248,6 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
     extraPlugins.push(
       new CopyWebpackPlugin({
         patterns: copyWebpackPluginPatterns,
-      }),
-    );
-  }
-
-  if (buildOptions.progress) {
-    const spinner = new Spinner();
-
-    let previousPercentage: number | undefined;
-    extraPlugins.push(
-      new ProgressPlugin({
-        handler: (percentage: number, message: string) => {
-          if (previousPercentage === 1 && percentage !== 0) {
-            // In some scenarios in Webpack 5 percentage goes from 1 back to 0.99.
-            // Ex: 0.99 -> 1 -> 0.99 -> 1
-            // This causes the "complete" message to be displayed multiple times.
-
-            return;
-          }
-
-          switch (percentage) {
-            case 0:
-              spinner.start(`Generating ${platform} application bundles...`);
-              break;
-            case 1:
-              spinner.succeed(
-                `${platform.replace(/^\w/, (s) =>
-                  s.toUpperCase(),
-                )} application bundle generation complete.`,
-              );
-              break;
-            default:
-              spinner.text = `Generating ${platform} application bundles (phase: ${message})...`;
-              break;
-          }
-
-          previousPercentage = percentage;
-        },
       }),
     );
   }


### PR DESCRIPTION

With this change we provide earlier feedback in the console during a build. The setup phase can take some times if the project has a large set of dependencies.

We also move several warnings in the dev-server to an earlier phase so that we don't clutter the progress indicator.

Closes #20957