### PR TITLE
[12.1.x]fix(@angular-devkit/build-angular): correctly ignore inline styles during i18n extraction

### DIFF
--- a/packages/angular_devkit/build_angular/src/extract-i18n/empty-export-default.js
+++ b/packages/angular_devkit/build_angular/src/extract-i18n/empty-export-default.js
@@ -1,1 +1,0 @@
-export default '';

--- a/packages/angular_devkit/build_angular/src/extract-i18n/empty-loader.ts
+++ b/packages/angular_devkit/build_angular/src/extract-i18n/empty-loader.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export default function () {
+  return `export default '';`;
+}

--- a/packages/angular_devkit/build_angular/src/extract-i18n/index.ts
+++ b/packages/angular_devkit/build_angular/src/extract-i18n/index.ts
@@ -232,14 +232,16 @@ export async function execute(
         },
       });
 
-      // Replace all stylesheets with an empty default export
+      // Replace all stylesheets with empty content
       partials.push({
-        plugins: [
-          new webpack.NormalModuleReplacementPlugin(
-            /\.(css|scss|sass|styl|less)$/,
-            path.join(__dirname, 'empty-export-default.js'),
-          ),
-        ],
+        module: {
+          rules: [
+            {
+              test: /\.(css|scss|sass|styl|less)$/,
+              loader: require.resolve('./empty-loader'),
+            },
+          ],
+        },
       });
 
       return partials;

--- a/packages/angular_devkit/build_angular/src/extract-i18n/works_spec.ts
+++ b/packages/angular_devkit/build_angular/src/extract-i18n/works_spec.ts
@@ -146,4 +146,17 @@ describe('Extract i18n Target', () => {
     const fullLog = logs.join();
     expect(fullLog).toContain('Duplicate messages with id');
   });
+
+  it('ignores inline styles', async () => {
+    host.appendToFile('src/app/app.component.html', '<p i18n>i18n test</p>');
+    host.replaceInFile('src/app/app.component.ts', 'styleUrls', 'styles');
+    host.replaceInFile('src/app/app.component.ts', './app.component.css', 'h1 { color: green; }');
+
+    const run = await architect.scheduleTarget(extractI18nTargetSpec);
+
+    // This will fail if a style is processed since the style rules are not included during extraction
+    await expectAsync(run.result).toBeResolvedTo(jasmine.objectContaining({ success: true }));
+
+    await run.stop();
+  });
 });


### PR DESCRIPTION
Stylesheets are not processed during i18n extraction to improve performance  and the rules to support them are intentionally not present.