### PR TITLE
fix(@schematics/angular): make version 12 workspace config migration idempotent

### DIFF
--- a/packages/schematics/angular/migrations/update-12/update-angular-config.ts
+++ b/packages/schematics/angular/migrations/update-12/update-angular-config.ts
@@ -59,6 +59,15 @@ function updateOptions(
   target: workspaces.TargetDefinition,
   optionsToUpdate: typeof ServerBuilderOptions | typeof BrowserBuilderOptions,
 ): void {
+  // This is a hacky way to make this migration idempotent.
+  // `defaultConfiguration` was only introduced in v12 projects and hence v11 projects do not have this property.
+  // Setting it as an empty string will not cause any side-effect.
+  if (typeof target.defaultConfiguration === 'string') {
+    return;
+  }
+
+  target.defaultConfiguration = '';
+
   if (!target.options) {
     target.options = {};
   }

--- a/packages/schematics/angular/migrations/update-12/update-angular-config_spec.ts
+++ b/packages/schematics/angular/migrations/update-12/update-angular-config_spec.ts
@@ -120,4 +120,21 @@ describe(`Migration to update 'angular.json'. ${schematicName}`, () => {
     expect(options.namedChunks).toBeTrue();
     expect(options.buildOptimizer).toBeFalse();
   });
+
+  it('migration should be idempotent', async () => {
+    const { options } = getBuildTarget(tree);
+    expect(options.aot).toBeTrue();
+
+    // First run
+    const newTree1 = await schematicRunner.runSchematicAsync(schematicName, {}, tree).toPromise();
+    const { options: options1 } = getBuildTarget(newTree1);
+    expect(options1.aot).toBeUndefined();
+
+    // Second run
+    const newTree2 = await schematicRunner
+      .runSchematicAsync(schematicName, {}, newTree1)
+      .toPromise();
+    const { options: options2 } = getBuildTarget(newTree2);
+    expect(options2.aot).toBeUndefined();
+  });
 });


### PR DESCRIPTION


With this change we ensure that `update-angular-config-v12` migration is idempotent

Closes #20979