### PR TITLE
build: update Webpack to version 5.38.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     ]
   },
   "resolutions": {
-    "**/@types/copy-webpack-plugin/webpack": "5.37.0",
+    "**/@types/copy-webpack-plugin/webpack": "5.38.1",
     "ajv-formats/ajv": "8.4.0"
   },
   "devDependencies": {
@@ -230,7 +230,7 @@
     "typescript": "4.2.4",
     "verdaccio": "5.0.4",
     "verdaccio-auth-memory": "^10.0.0",
-    "webpack": "5.37.0",
+    "webpack": "5.38.1",
     "webpack-dev-middleware": "4.2.0",
     "webpack-dev-server": "3.11.2",
     "webpack-merge": "5.7.3",

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -68,7 +68,7 @@
     "terser-webpack-plugin": "5.1.2",
     "text-table": "0.2.0",
     "tree-kill": "1.2.2",
-    "webpack": "5.37.0",
+    "webpack": "5.38.1",
     "webpack-dev-middleware": "4.2.0",
     "webpack-dev-server": "3.11.2",
     "webpack-merge": "5.7.3",

--- a/packages/angular_devkit/build_angular/src/browser/specs/differential_loading_spec.ts
+++ b/packages/angular_devkit/build_angular/src/browser/specs/differential_loading_spec.ts
@@ -31,7 +31,7 @@ describe('Browser Builder with differential loading', () => {
   it(
     'emits all the neccessary files for default configuration',
     async () => {
-      const { files } = await browserBuild(architect, host, target);
+      const { files } = await browserBuild(architect, host, target, { sourceMap: true });
 
       const expectedOutputs = [
         'favicon.ico',
@@ -71,8 +71,7 @@ describe('Browser Builder with differential loading', () => {
     async () => {
       host.replaceInFile('tsconfig.json', '"target": "es2017",', `"target": "esnext",`);
 
-      const { files } = await browserBuild(architect, host, target);
-
+      const { files } = await browserBuild(architect, host, target, { sourceMap: true });
       const expectedOutputs = [
         'favicon.ico',
         'index.html',
@@ -109,7 +108,10 @@ describe('Browser Builder with differential loading', () => {
   it(
     'deactivates differential loading for watch mode',
     async () => {
-      const { files } = await browserBuild(architect, host, target, { watch: true });
+      const { files } = await browserBuild(architect, host, target, {
+        watch: true,
+        sourceMap: true,
+      });
 
       const expectedOutputs = [
         'favicon.ico',

--- a/packages/angular_devkit/build_angular/src/browser/specs/scripts-array_spec.ts
+++ b/packages/angular_devkit/build_angular/src/browser/specs/scripts-array_spec.ts
@@ -174,9 +174,9 @@ describe('Browser Builder scripts array', () => {
     );
 
     const joinedLogs = logs.join('\n');
-    expect(joinedLogs).toMatch(/lazy-script.+69 bytes/);
-    expect(joinedLogs).toMatch(/renamed-script.+78 bytes/);
-    expect(joinedLogs).toMatch(/renamed-lazy-script.+88 bytes/);
+    expect(joinedLogs).toMatch(/lazy-script.+\d+ bytes/);
+    expect(joinedLogs).toMatch(/renamed-script.+\d+ bytes/);
+    expect(joinedLogs).toMatch(/renamed-lazy-script.+\d+ bytes/);
     expect(joinedLogs).not.toContain('Lazy Chunks');
   });
 

--- a/packages/angular_devkit/build_angular/test/hello-world-app/angular.json
+++ b/packages/angular_devkit/build_angular/test/hello-world-app/angular.json
@@ -22,7 +22,7 @@
             "polyfills": "src/polyfills.ts",
             "tsConfig": "src/tsconfig.app.json",
             "progress": false,
-            "sourceMap": true,
+            "sourceMap": false,
             "aot": false,
             "vendorChunk": true,
             "buildOptimizer": false,

--- a/packages/angular_devkit/build_optimizer/package.json
+++ b/packages/angular_devkit/build_optimizer/package.json
@@ -22,6 +22,6 @@
     }
   },
   "devDependencies": {
-    "webpack": "5.37.0"
+    "webpack": "5.38.1"
   }
 }

--- a/packages/angular_devkit/build_webpack/package.json
+++ b/packages/angular_devkit/build_webpack/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@angular-devkit/core": "0.0.0",
     "node-fetch": "2.6.1",
-    "webpack": "5.37.0"
+    "webpack": "5.38.1"
   },
   "peerDependencies": {
     "webpack": "^5.30.0",

--- a/packages/ngtools/webpack/package.json
+++ b/packages/ngtools/webpack/package.json
@@ -33,6 +33,6 @@
     "@angular/compiler": "12.0.0",
     "@angular/compiler-cli": "12.0.0",
     "typescript": "4.2.4",
-    "webpack": "5.37.0"
+    "webpack": "5.38.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -86,7 +86,6 @@
 
 "@angular/dev-infra-private@https://github.com/angular/dev-infra-private-builds.git#bab06572744a776c0fe52114b2eb8470dcd9e30b":
   version "0.0.0"
-  uid bab06572744a776c0fe52114b2eb8470dcd9e30b
   resolved "https://github.com/angular/dev-infra-private-builds.git#bab06572744a776c0fe52114b2eb8470dcd9e30b"
   dependencies:
     "@angular/benchpress" "0.2.1"
@@ -4775,7 +4774,7 @@ eslint-plugin-import@2.22.1:
     resolve "^1.17.0"
     tsconfig-paths "^3.9.0"
 
-eslint-scope@^5.0.0, eslint-scope@^5.1.1:
+eslint-scope@5.1.1, eslint-scope@^5.0.0, eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
   integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
@@ -10210,7 +10209,6 @@ sass@1.32.13, sass@^1.32.8:
 
 "sauce-connect-proxy@https://saucelabs.com/downloads/sc-4.6.4-linux.tar.gz":
   version "0.0.0"
-  uid "992e2cb0d91e54b27a4f5bbd2049f3b774718115"
   resolved "https://saucelabs.com/downloads/sc-4.6.4-linux.tar.gz#992e2cb0d91e54b27a4f5bbd2049f3b774718115"
 
 saucelabs@^1.5.0:
@@ -11945,10 +11943,10 @@ w3c-xmlserializer@^1.1.2:
     webidl-conversions "^4.0.2"
     xml-name-validator "^3.0.0"
 
-watchpack@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.1.1.tgz#e99630550fca07df9f90a06056987baa40a689c7"
-  integrity sha512-Oo7LXCmc1eE1AjyuSBmtC3+Wy4HcV8PxWh2kP6fOl8yTlNS7r0K9l1ao2lrrUza7V39Y3D/BbJgY8VeSlc5JKw==
+watchpack@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.2.0.tgz#47d78f5415fe550ecd740f99fe2882323a58b1ce"
+  integrity sha512-up4YAn/XHgZHIxFBVCdlMiWDj6WaLKpwVeGQk2I5thdYxF/KmF0aaz6TfJZ/hfl1h/XlcDr7k1KH7ThDagpFaA==
   dependencies:
     glob-to-regexp "^0.4.1"
     graceful-fs "^4.1.2"
@@ -12083,10 +12081,10 @@ webpack-sources@^1.1.0, webpack-sources@^1.2.0, webpack-sources@^1.3.0:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack-sources@^2.1.1:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-2.2.0.tgz#058926f39e3d443193b6c31547229806ffd02bac"
-  integrity sha512-bQsA24JLwcnWGArOKUxYKhX3Mz/nK1Xf6hxullKERyktjNMC4x8koOeaDNTA2fEJ09BdWLbM/iTW0ithREUP0w==
+webpack-sources@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-2.3.0.tgz#9ed2de69b25143a4c18847586ad9eccb19278cfa"
+  integrity sha512-WyOdtwSvOML1kbgtXbTDnEW0jkJ7hZr/bDByIwszhWd/4XX1A3XMkrbFMsuH4+/MfLlZCUzlAdg4r7jaGKEIgQ==
   dependencies:
     source-list-map "^2.0.1"
     source-map "^0.6.1"
@@ -12098,10 +12096,10 @@ webpack-subresource-integrity@1.5.2:
   dependencies:
     webpack-sources "^1.3.0"
 
-webpack@5.37.0, webpack@^5.1.0:
-  version "5.37.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.37.0.tgz#2ab00f613faf494504eb2beef278dab7493cc39d"
-  integrity sha512-yvdhgcI6QkQkDe1hINBAJ1UNevqNGTVaCkD2SSJcB8rcrNNl922RI8i2DXUAuNfANoxwsiXXEA4ZPZI9q2oGLA==
+webpack@5.38.1, webpack@^5.1.0:
+  version "5.38.1"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.38.1.tgz#5224c7f24c18e729268d3e3bc97240d6e880258e"
+  integrity sha512-OqRmYD1OJbHZph6RUMD93GcCZy4Z4wC0ele4FXyYF0J6AxO1vOSuIlU1hkS/lDlR9CDYBz64MZRmdbdnFFoT2g==
   dependencies:
     "@types/eslint-scope" "^3.7.0"
     "@types/estree" "^0.0.47"
@@ -12113,7 +12111,7 @@ webpack@5.37.0, webpack@^5.1.0:
     chrome-trace-event "^1.0.2"
     enhanced-resolve "^5.8.0"
     es-module-lexer "^0.4.0"
-    eslint-scope "^5.1.1"
+    eslint-scope "5.1.1"
     events "^3.2.0"
     glob-to-regexp "^0.4.1"
     graceful-fs "^4.2.4"
@@ -12124,8 +12122,8 @@ webpack@5.37.0, webpack@^5.1.0:
     schema-utils "^3.0.0"
     tapable "^2.1.1"
     terser-webpack-plugin "^5.1.1"
-    watchpack "^2.0.0"
-    webpack-sources "^2.1.1"
+    watchpack "^2.2.0"
+    webpack-sources "^2.3.0"
 
 websocket-driver@>=0.5.1, websocket-driver@^0.7.4:
   version "0.7.4"


### PR DESCRIPTION
With this change we update to `webpack` to `5.38.1`, this also updates `webpack-sources` to `2.3.0`, The latter is causing OOM errors on our CI, but it in real projects the memory usage only increased by a small fraction. Also, the OOM errors don't manifest themselves when the entire test suit is run locally.

Therefore with this change we also disable sourcemap genertation for most of the browser builds to speed up the tests and reduce memery usage.