### PR TITLE
fix(@ngtools/webpack): normalize paths when adding file dependencies

### DIFF
--- a/packages/ngtools/webpack/src/ivy/plugin.ts
+++ b/packages/ngtools/webpack/src/ivy/plugin.ts
@@ -268,8 +268,9 @@ export class AngularWebpackPlugin {
           continue;
         }
 
-        // Ensure all program files are considered part of the compilation and will be watched
-        compilation.fileDependencies.add(sourceFile.fileName);
+        // Ensure all program files are considered part of the compilation and will be watched.
+        // Webpack does not normalize paths. Therefore, we need to normalize the path with FS seperators.
+        compilation.fileDependencies.add(externalizePath(sourceFile.fileName));
 
         // Add all non-declaration files to the initial set of unused files. The set will be
         // analyzed and pruned after all Webpack modules are finished building.


### PR DESCRIPTION
This caused Webpack to mark all TypeScript files as removed after the first compilation on Windows because the file separators didn't match

Closes #20891


A big thanks goes to @elvisbegovic, who provided multiple teamviewer sessions to track down this issue.