### PR TITLE
perf(@angular-devkit/build-webpack): include only required stats in webpackStats

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/stats.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/stats.ts
@@ -15,16 +15,13 @@ const webpackOutputOptions = {
   timings: true, // required by custom stat output
   chunks: true, // required by custom stat output
   builtAt: true, // required by custom stat output
-  chunkModules: false,
-  children: false, // listing all children is very noisy in AOT and hides warnings/errors
-  modules: false,
-  reasons: false,
   warnings: true,
   errors: true,
   assets: true, // required by custom stat output
-  version: false,
-  errorDetails: false,
-  moduleTrace: false,
+
+  // Needed for markAsyncChunksNonInitial.
+  ids: true,
+  entrypoints: true,
 };
 
 const verboseWebpackOutputOptions: Record<string, boolean | string | number> = {
@@ -40,9 +37,8 @@ const verboseWebpackOutputOptions: Record<string, boolean | string | number> = {
   errorDetails: true,
   moduleTrace: true,
   logging: 'verbose',
+  modulesSpace: Infinity,
 };
-
-verboseWebpackOutputOptions['modulesSpace'] = Infinity;
 
 export function getWebpackStatsConfig(verbose = false) {
   return verbose


### PR DESCRIPTION
Until we depend on `webpackStats` in the browser builder we should only included the required stats.

The below are the needed stats;
```
all: false,
colors: true,
hash: true,
timings: true,
chunks: true,
builtAt: true,
warnings: true,
errors: true,
assets: true,
ids: true,
entrypoints: true,
```