### PR TITLE
test(@angular/cli): locally publish LTS tooling packages for E2E update tests

### DIFF
--- a/tests/legacy-cli/e2e/setup/010-local-publish.ts
+++ b/tests/legacy-cli/e2e/setup/010-local-publish.ts
@@ -1,6 +1,17 @@
 import { getGlobalVariable } from '../utils/env';
-import { npm } from '../utils/process';
+import { npm, silentNpm } from '../utils/process';
 import { isPrereleaseCli } from '../utils/project';
+
+async function publishLocal(specifier: string, tags: string[], registry: string): Promise<void> {
+  const { stdout: stdoutPack1 } = await silentNpm(
+    'pack',
+    specifier,
+    '--registry=https://registry.npmjs.org',
+  );
+  for (const tag of tags) {
+    await silentNpm('publish', stdoutPack1.trim(), `--registry=${registry}`, `--tag=${tag}`);
+  }
+}
 
 export default async function () {
   const testRegistry = getGlobalVariable('package-registry');
@@ -15,4 +26,55 @@ export default async function () {
     '--tag',
     isPrereleaseCli() ? 'next' : 'latest',
   );
+
+  const basePackages = [
+    '@angular/cli',
+    '@angular-devkit/architect',
+    '@angular-devkit/build-angular',
+    '@angular-devkit/build-optimizer',
+    '@angular-devkit/build-webpack',
+    '@angular-devkit/core',
+    '@angular-devkit/schematics',
+    '@ngtools/webpack',
+    '@schematics/angular',
+    '@schematics/update',
+  ];
+
+  const ltsVersions = {
+    '8': [...basePackages],
+    '9': [...basePackages],
+    '10': [...basePackages],
+  };
+  for (const [ltsVersion, ltsPackages] of Object.entries(ltsVersions)) {
+    const tag = `v${ltsVersion}-lts`;
+
+    for (const packageName of ltsPackages) {
+      await publishLocal(
+        `${packageName}@${tag}`,
+        [tag],
+        testRegistry,
+      );
+    }
+  }
+
+  const v8OriginalPackages = [
+    '@angular/cli@8.0',
+    '@angular-devkit/architect@0.800',
+    '@angular-devkit/build-angular@0.800',
+    '@angular-devkit/build-optimizer@0.800',
+    '@angular-devkit/build-webpack@0.800',
+    '@angular-devkit/core@8.0',
+    '@angular-devkit/schematics@8.0',
+    '@ngtools/webpack@8.0.6',
+    '@schematics/angular@8.0',
+    '@schematics/update@0.800',
+  ];
+
+  for (const fullPackageSpecifier of v8OriginalPackages) {
+    await publishLocal(
+      fullPackageSpecifier,
+      ['v8-original'],
+      testRegistry,
+    );
+  }
 }

--- a/tests/legacy-cli/e2e/tests/update/update-8.ts
+++ b/tests/legacy-cli/e2e/tests/update/update-8.ts
@@ -5,26 +5,18 @@ import { ng, noSilentNg } from '../../utils/process';
 import { isPrereleaseCli, useCIChrome, useCIDefaults } from '../../utils/project';
 
 export default async function () {
-  // We need to use the public registry because in the local NPM server we don't have
-  // older versions @angular/cli packages which would cause `npm install` during `ng update` to fail.
-  try {
-    await createProjectFromAsset('8.0-project', true, true);
+  await createProjectFromAsset('8.0-project', true, true);
+  await installWorkspacePackages();
 
-    await setRegistry(false);
-    await installWorkspacePackages();
-
-    // Update Angular to 9
-    await installPackage('@angular/cli@8');
-    const { stdout } = await ng('update', '@angular/cli@9.x', '@angular/core@9.x');
-    if (!stdout.includes("Executing migrations of package '@angular/cli'")) {
-      throw new Error('Update did not execute migrations. OUTPUT: \n' + stdout);
-    }
-
-    // Update Angular to 10
-    await ng('update', '@angular/cli@10', '@angular/core@10');
-  } finally {
-    await setRegistry(true);
+  // Update Angular to 9
+  await installPackage('@angular/cli@8');
+  const { stdout } = await ng('update', '@angular/cli@9.x', '@angular/core@9.x');
+  if (!stdout.includes("Executing migrations of package '@angular/cli'")) {
+    throw new Error('Update did not execute migrations. OUTPUT: \n' + stdout);
   }
+
+  // Update Angular to 10
+  await ng('update', '@angular/cli@10', '@angular/core@10');
 
   // Update Angular current build
   const extraUpdateArgs = isPrereleaseCli() ? ['--next', '--force'] : ['--force'];


### PR DESCRIPTION
The tooling packages needed to perform a canonical update process are now published to the local test package registry. This removes the need to switch back and forth between the npm registry and the test registry during E2E tests. It also ensures that CLI versions are used that are compatible with the Node.js version used for the tests.