### PR TITLE
fix(@angular/cli): avoid shell exec when bootstrapping update command

### DIFF
--- a/packages/angular/cli/utilities/install-package.ts
+++ b/packages/angular/cli/utilities/install-package.ts
@@ -204,11 +204,8 @@ export async function runTempPackageBin(
     throw new Error(`Cannot locate bin for temporary package: ${packageNameNoVersion}.`);
   }
 
-  const argv = [`"${binPath}"`, ...args];
-
-  const { status, error } = spawnSync('node', argv, {
+  const { status, error } = spawnSync(process.execPath, [binPath, ...args], {
     stdio: 'inherit',
-    shell: true,
     env: {
       ...process.env,
       NG_DISABLE_VERSION_CHECK: 'true',


### PR DESCRIPTION
This change removes the usage of the shell execution when spawning the latest CLI version when bootstrapping the update command. The absolute path of the node process is now spawned which removes the need for any shell path resolution. This also removes the need to quote and/or escape command arguments which can be error-prone. Node.js and the OS will now handle any quoting and escaping automatically and without any custom logic.