### PR TITLE
refactor(@angular/cli): remove usage of rimraf dependency

### DIFF
--- a/packages/angular/cli/BUILD.bazel
+++ b/packages/angular/cli/BUILD.bazel
@@ -81,7 +81,6 @@ ts_library(
         "@npm//@types/node",
         "@npm//@types/npm-package-arg",
         "@npm//@types/resolve",
-        "@npm//@types/rimraf",
         "@npm//@types/semver",
         "@npm//@types/uuid",
         "@npm//ansi-colors",

--- a/packages/angular/cli/package.json
+++ b/packages/angular/cli/package.json
@@ -41,7 +41,6 @@
     "ora": "5.4.0",
     "pacote": "11.3.4",
     "resolve": "1.20.0",
-    "rimraf": "3.0.2",
     "semver": "7.3.5",
     "symbol-observable": "4.0.0",
     "uuid": "8.3.2"

--- a/packages/angular/cli/utilities/install-package.ts
+++ b/packages/angular/cli/utilities/install-package.ts
@@ -7,10 +7,9 @@
  */
 
 import { spawn, spawnSync } from 'child_process';
-import { existsSync, mkdtempSync, readFileSync, realpathSync, writeFileSync } from 'fs';
+import { existsSync, mkdtempSync, readFileSync, realpathSync, rmdirSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join, resolve } from 'path';
-import * as rimraf from 'rimraf';
 import { PackageManager } from '../lib/config/workspace-schema';
 import { NgAddSaveDepedency } from '../utilities/package-metadata';
 import { Spinner } from './spinner';
@@ -130,7 +129,7 @@ export async function installTempPackage(
   // clean up temp directory on process exit
   process.on('exit', () => {
     try {
-      rimraf.sync(tempPath);
+      rmdirSync(tempPath, { recursive: true, maxRetries: 3 });
     } catch {}
   });
 

--- a/scripts/build-schema.ts
+++ b/scripts/build-schema.ts
@@ -11,24 +11,6 @@ import * as fs from 'fs';
 import * as glob from 'glob';
 import * as path from 'path';
 
-function _mkdirp(p: string) {
-  // Create parent folder if necessary.
-  if (!fs.existsSync(path.dirname(p))) {
-    _mkdirp(path.dirname(p));
-  }
-  if (!fs.existsSync(p)) {
-    fs.mkdirSync(p);
-  }
-}
-
-function _rimraf(p: string) {
-  glob.sync(path.join(p, '**/*'), { dot: true, nodir: true }).forEach((p) => fs.unlinkSync(p));
-  glob
-    .sync(path.join(p, '**/*'), { dot: true })
-    .sort((a, b) => b.length - a.length)
-    .forEach((p) => fs.rmdirSync(p));
-}
-
 export default async function (argv: {}, logger: logging.Logger) {
   const allJsonFiles = glob.sync('packages/**/*.json', {
     ignore: ['**/node_modules/**', '**/files/**', '**/*-files/**', '**/package.json'],
@@ -37,7 +19,7 @@ export default async function (argv: {}, logger: logging.Logger) {
 
   const quicktypeRunner = require('../tools/quicktype_runner');
   logger.info('Removing dist-schema/...');
-  _rimraf(dist);
+  fs.rmdirSync(dist, { recursive: true, maxRetries: 3 });
 
   logger.info('Generating JSON Schema....');
 
@@ -65,7 +47,7 @@ export default async function (argv: {}, logger: logging.Logger) {
     const tsContent = await quicktypeRunner.generate(fileName);
     const tsPath = path.join(dist, fileName.replace(/\.json$/, '.ts'));
 
-    _mkdirp(path.dirname(tsPath));
+    fs.mkdirSync(path.dirname(tsPath), { recursive: true });
     fs.writeFileSync(tsPath, tsContent, 'utf-8');
   }
 


### PR DESCRIPTION
With the removal of support for Node.js v10, the Node.js native support for recursively removing a directory can now be used.
Also updates several of the dev scripts as well.