### PR TITLE
fix(@angular-devkit/build-angular): ensure all Webpack Stats assets are present on rebuilds

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/stats.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/stats.ts
@@ -18,6 +18,7 @@ const webpackOutputOptions = {
   warnings: true,
   errors: true,
   assets: true, // required by custom stat output
+  cachedAssets: true, // required for bundle size calculators
 
   // Needed for markAsyncChunksNonInitial.
   ids: true,


### PR DESCRIPTION
Webpack will only provide emitted assets in the returned Stats each rebuild unless the `cachedAssets` option is enabled. This is currently needed for the bundle budget calculations.

Fixes #21038