### PR TITLE
fix(@angular-devkit/build-angular): dispose Sass worker resources on Webpack shutdown

### DIFF
--- a/packages/angular_devkit/build_angular/src/sass/sass-service.ts
+++ b/packages/angular_devkit/build_angular/src/sass/sass-service.ts
@@ -118,13 +118,12 @@ export class SassWorkerImplementation {
   /**
    * Shutdown the Sass render worker.
    * Executing this method will stop any pending render requests.
-   *
-   * The worker is unreferenced upon creation and will not block application exit. This method
-   * is only needed if early cleanup is needed.
    */
   close(): void {
     for (const worker of this.workers) {
-      void worker.terminate();
+      try {
+        void worker.terminate();
+      } catch {}
     }
     this.requests.clear();
   }
@@ -207,7 +206,6 @@ export class SassWorkerImplementation {
       },
     );
 
-    worker.unref();
     mainImporterPort.unref();
 
     return worker;

--- a/packages/angular_devkit/build_angular/src/webpack/configs/styles.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/styles.ts
@@ -108,7 +108,7 @@ export function getStylesConfig(wco: WebpackConfigOptions): webpack.Configuratio
     );
   }
 
-  let sassImplementation: {} | undefined;
+  let sassImplementation: SassWorkerImplementation | undefined;
   try {
     sassImplementation = require('node-sass');
     wco.logger.warn(
@@ -117,6 +117,13 @@ export function getStylesConfig(wco: WebpackConfigOptions): webpack.Configuratio
     );
   } catch {
     sassImplementation = new SassWorkerImplementation();
+    extraPlugins.push({
+      apply(compiler) {
+        compiler.hooks.shutdown.tap('sass-worker', () => {
+          sassImplementation?.close();
+        });
+      },
+    });
   }
 
   const assetNameTemplate = assetNameTemplateFactory(hashFormat);


### PR DESCRIPTION
Sass Worker instances and resource requests are now cleaned up when the Webpack compiler is shutdown. This removes the need to unreference the workers upon creation.

Fixes #20985