### PR TITLE
feat(@ngtools/webpack): add support for custom typescript transformers

### DIFF
--- a/packages/ngtools/webpack/src/ivy/plugin.ts
+++ b/packages/ngtools/webpack/src/ivy/plugin.ts
@@ -48,6 +48,7 @@ const DIAGNOSTICS_AFFECTED_THRESHOLD = 1;
 export interface AngularWebpackPluginOptions {
   tsconfig: string;
   compilerOptions?: CompilerOptions;
+  customTransformers: ts.CustomTransformers;
   fileReplacements: Record<string, string>;
   substitutions: Record<string, string>;
   directTemplateLoading: boolean;
@@ -111,6 +112,7 @@ export class AngularWebpackPlugin {
       substitutions: {},
       directTemplateLoading: true,
       tsconfig: 'tsconfig.json',
+      customTransformers: {},
       ...options,
     };
   }
@@ -497,7 +499,10 @@ export class AngularWebpackPlugin {
       }
     }
 
-    const transformers = createAotTransformers(builder, this.pluginOptions);
+    const transformers = mergeTransformers(
+      createAotTransformers(builder, this.pluginOptions),
+      this.pluginOptions.customTransformers,
+    );
 
     const getDependencies = (sourceFile: ts.SourceFile) => {
       const dependencies = [];
@@ -613,7 +618,10 @@ export class AngularWebpackPlugin {
     ];
     diagnosticsReporter(diagnostics);
 
-    const transformers = createJitTransformers(builder, this.pluginOptions);
+    const transformers = mergeTransformers(
+      createJitTransformers(builder, this.pluginOptions),
+      this.pluginOptions.customTransformers,
+    );
 
     return {
       fileEmitter: this.createFileEmitter(builder, transformers, () => []),


### PR DESCRIPTION
This change allows developers to add custom typescript transformers to the webpack compilation, which was previously supported by AngularCompilerPlugin and its platformTransformers option.


The rationale behind this change is that before we were able to specify custom transformers either via platformTransformers or by hacking into `_transformers` (https://medium.com/joolsoftware/custom-typescript-transformers-with-angular-cli-7f4150797e05). Since that is not available anymore, some projects are no longer able to use such transformations.