### PR TITLE
feat(@schematics/angular): add migration to replace deprecated `--prod`

### DIFF
--- a/packages/schematics/angular/migrations/migration-collection.json
+++ b/packages/schematics/angular/migrations/migration-collection.json
@@ -120,6 +120,11 @@
       "factory": "./update-12/schematic-options",
       "description": "Remove invalid 'skipTests' option in '@schematics/angular:module' Angular schematic options."
     },
+    "replace-deprecated-prod-flag": {
+      "version": "12.1.0",
+      "factory": "./update-12/replace-prod-flag",
+      "description": "Replace the deprecated '--prod' in package.json scripts."
+    },
     "production-by-default": {
       "version": "9999.0.0",
       "factory": "./update-12/production-default-config",

--- a/packages/schematics/angular/migrations/update-12/replace-prod-flag.ts
+++ b/packages/schematics/angular/migrations/update-12/replace-prod-flag.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { Rule } from '@angular-devkit/schematics';
+import { JSONFile } from '../../utility/json-file';
+
+export default function (): Rule {
+  return (tree) => {
+    const file = new JSONFile(tree, 'package.json');
+    const scripts = file.get(['scripts']);
+    if (!scripts || typeof scripts !== 'object') {
+      return;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const updatedScripts = Object.entries(scripts!).map(([key, value]) => [
+      key,
+      typeof value === 'string'
+        ? value.replace(/ --prod(?!\w)/g, ' --configuration production')
+        : value,
+    ]);
+
+    file.modify(['scripts'], Object.fromEntries(updatedScripts));
+  };
+}

--- a/packages/schematics/angular/migrations/update-12/replace-prod-flag_spec.ts
+++ b/packages/schematics/angular/migrations/update-12/replace-prod-flag_spec.ts
@@ -1,0 +1,74 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { EmptyTree } from '@angular-devkit/schematics';
+import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';
+
+describe(`Migration to replace '--prod' flag from package.json scripts`, () => {
+  const pkgJsonPath = '/package.json';
+  const schematicName = 'replace-deprecated-prod-flag';
+
+  const schematicRunner = new SchematicTestRunner(
+    'migrations',
+    require.resolve('../migration-collection.json'),
+  );
+
+  let tree: UnitTestTree;
+
+  beforeEach(async () => {
+    tree = new UnitTestTree(new EmptyTree());
+  });
+
+  it(`should replace '--prod' with '--configuration production'`, async () => {
+    tree.create(
+      pkgJsonPath,
+      JSON.stringify(
+        {
+          scripts: {
+            build: 'ng build --prod',
+            test: 'ng test --prod && ng e2e --prod',
+          },
+        },
+        undefined,
+        2,
+      ),
+    );
+    const tree2 = await schematicRunner
+      .runSchematicAsync(schematicName, {}, tree.branch())
+      .toPromise();
+
+    const { scripts } = JSON.parse(tree2.readContent(pkgJsonPath));
+    expect(scripts).toEqual({
+      build: 'ng build --configuration production',
+      test: 'ng test --configuration production && ng e2e --configuration production',
+    });
+  });
+
+  it(`should not replace flags that start with '--prod...'`, async () => {
+    tree.create(
+      pkgJsonPath,
+      JSON.stringify(
+        {
+          scripts: {
+            test: 'npx test --production && ng e2e --prod',
+          },
+        },
+        undefined,
+        2,
+      ),
+    );
+    const tree2 = await schematicRunner
+      .runSchematicAsync(schematicName, {}, tree.branch())
+      .toPromise();
+
+    const { scripts } = JSON.parse(tree2.readContent(pkgJsonPath));
+    expect(scripts).toEqual({
+      test: 'npx test --production && ng e2e --configuration production',
+    });
+  });
+});


### PR DESCRIPTION
With this change we add migration to replace the deprecated `--prod` with `--configuration production` in the scripts section of the package.json.

Closes #21036