### PR TITLE
feat(@angular-devkit/schematics): extend move rule to accept array of destinations

### DIFF
--- a/packages/angular_devkit/schematics/src/rules/move.ts
+++ b/packages/angular_devkit/schematics/src/rules/move.ts
@@ -10,29 +10,42 @@ import { join, normalize } from '@angular-devkit/core';
 import { Rule } from '../engine/interface';
 import { noop } from './base';
 
-export function move(from: string, to?: string): Rule {
+export function move(from: string, to?: string | string[]): Rule {
   if (to === undefined) {
     to = from;
     from = '/';
   }
 
-  const fromPath = normalize('/' + from);
-  const toPath = normalize('/' + to);
+  if (typeof to === 'string') {
+    // For simplicity, we wrap to string into an array
+    to = new Array(to);
+  }
 
-  if (fromPath === toPath) {
+  if (typeof from === 'string' && typeof to === 'string' && from === to) {
     return noop;
   }
 
   return (tree) => {
-    if (tree.exists(fromPath)) {
-      // fromPath is a file
-      tree.rename(fromPath, toPath);
-    } else {
-      // fromPath is a directory
-      tree.getDir(fromPath).visit((path) => {
-        tree.rename(path, join(toPath, path.substr(fromPath.length)));
-      });
-    }
+    const fromPath = normalize('/' + from);
+
+    (to as Array<string>).forEach((toElement: string) => {
+      const toPath = normalize('/' + toElement);
+
+      // we branch on tree to not override former fromPath
+      const branch = tree.branch();
+
+      if (tree.exists(fromPath)) {
+        // fromPath is a file
+        branch.rename(fromPath, toPath);
+      } else {
+        // fromPath is a directory
+        branch.getDir(fromPath).visit((path) => {
+          branch.rename(path, join(toPath, path.substr(fromPath.length)));
+        });
+      }
+
+      tree.merge(branch);
+    });
 
     return tree;
   };

--- a/packages/angular_devkit/schematics/src/rules/move_spec.ts
+++ b/packages/angular_devkit/schematics/src/rules/move_spec.ts
@@ -97,4 +97,29 @@ describe('move', () => {
       })
       .then(done, done.fail);
   });
+
+  it('works on copying a directory into multiple directories', (done) => {
+    const tree = new HostTree();
+    tree.create('a/b/file1', 'hello world');
+    tree.create('a/b/file2', 'hello world');
+    tree.create('a/c/file3', 'hello world');
+    tree.create('b/c/file3', 'hello world');
+
+    callRule(move('a/b', ['a', 'b', 'c']), observableOf(tree), context)
+      .toPromise()
+      .then((result) => {
+        expect(result.exists('file1')).toBe(false);
+        expect(result.exists('file2')).toBe(false);
+        expect(result.exists('a/file1')).toBe(true);
+        expect(result.exists('a/file2')).toBe(true);
+        expect(result.exists('a/c/file3')).toBe(true);
+        expect(result.exists('b/file1')).toBe(true);
+        expect(result.exists('b/file2')).toBe(true);
+        expect(result.exists('b/c/file3')).toBe(true);
+        expect(result.exists('c/file1')).toBe(true);
+        expect(result.exists('c/file2')).toBe(true);
+        expect(result.exists('c/c/file3')).toBe(false);
+      })
+      .then(done, done.fail);
+  });
 });


### PR DESCRIPTION
### Current behaviour

Currently, if we want to move the same source files to multiple directories, we have to repeat the rule multiple times.

For example:

```javascript
  const toPath1 = 'a/b';
  const toPath2 = 'a/c';
  const toPath3 = 'a/d';

  const sourceFiles = url(path);
  return chain([
    apply(sourceFiles, [template({ ...options, ...strings }), move(toPath1)]),
    apply(sourceFiles, [template({ ...options, ...strings }), move(toPath2)]),
    apply(sourceFiles, [template({ ...options, ...strings }), move(toPath3)]),
  ]);
```

### New behaviour

This pull request suggest to extend `move` rule to also accept an array of destination paths:

```javascript
  const toPath1 = 'a/b';
  const toPath2 = 'a/c';
  const toPath3 = 'a/d';

  const sourceFiles = url(path);
  return chain([
    apply(sourceFiles, [template({ ...options, ...strings }), move([toPath1, toPath2, toPath3])]),
  ]);
```

### Introduce breaking changes
- [ ] Yes
- [X] No