### PR TITLE
fix(@schematics/angular): added webWorkerTsConfig into test options

### DIFF
--- a/packages/schematics/angular/web-worker/index.ts
+++ b/packages/schematics/angular/web-worker/index.ts
@@ -105,7 +105,6 @@ function addSnippet(options: WebWorkerOptions): Rule {
 export default function (options: WebWorkerOptions): Rule {
   return async (host: Tree) => {
     const workspace = await getWorkspace(host);
-
     if (!options.project) {
       throw new SchematicsException('Option "project" is required.');
     }
@@ -140,6 +139,18 @@ export default function (options: WebWorkerOptions): Rule {
     if (needWebWorkerConfig) {
       const workerConfigPath = join(normalize(root), 'tsconfig.worker.json');
       projectTargetOptions.webWorkerTsConfig = workerConfigPath;
+    }
+
+    const projectTestTarget = project.targets.get('test');
+    if (projectTestTarget) {
+      const projectTestTargetOptions = ((projectTestTarget.options ||
+      {}) as unknown) as BrowserBuilderOptions;
+
+      const needWebWorkerConfig = !projectTestTargetOptions.webWorkerTsConfig;
+      if (needWebWorkerConfig) {
+        const workerConfigPath = join(normalize(root), 'tsconfig.worker.json');
+        projectTestTargetOptions.webWorkerTsConfig = workerConfigPath;
+      }
     }
 
     const templateSource = apply(url('./files/worker'), [

--- a/packages/schematics/angular/web-worker/index.ts
+++ b/packages/schematics/angular/web-worker/index.ts
@@ -105,6 +105,7 @@ function addSnippet(options: WebWorkerOptions): Rule {
 export default function (options: WebWorkerOptions): Rule {
   return async (host: Tree) => {
     const workspace = await getWorkspace(host);
+
     if (!options.project) {
       throw new SchematicsException('Option "project" is required.');
     }
@@ -124,8 +125,7 @@ export default function (options: WebWorkerOptions): Rule {
     if (!projectTarget) {
       throw new Error(`Target is not defined for this project.`);
     }
-    const projectTargetOptions = ((projectTarget.options ||
-      {}) as unknown) as BrowserBuilderOptions;
+    const projectTargetOptions = (projectTarget.options || {}) as unknown as BrowserBuilderOptions;
 
     if (options.path === undefined) {
       options.path = buildDefaultPath(project);
@@ -143,8 +143,8 @@ export default function (options: WebWorkerOptions): Rule {
 
     const projectTestTarget = project.targets.get('test');
     if (projectTestTarget) {
-      const projectTestTargetOptions = ((projectTestTarget.options ||
-      {}) as unknown) as BrowserBuilderOptions;
+      const projectTestTargetOptions = (projectTestTarget.options ||
+        {}) as unknown as BrowserBuilderOptions;
 
       const needWebWorkerConfig = !projectTestTargetOptions.webWorkerTsConfig;
       if (needWebWorkerConfig) {


### PR DESCRIPTION
I have found one issue while working with a web worker.
I have a simple web-worker and working perfectly with `ng build ` but in the case of the `ng test` will fail.

after some time I found that  `"webWorkerTsConfig": "tsconfig.worker.json"` missing in test options.

and also check --target with ng g web-worker CLI reference.

Today I have made a simple change in angular-cli so that it will also added same config into test if it available it will change.