### PR TITLE
fix(@angular-devkit/build-angular): add web-workers in lazy chunks in stats output

### DIFF
--- a/packages/angular_devkit/build_angular/src/browser/index.ts
+++ b/packages/angular_devkit/build_angular/src/browser/index.ts
@@ -143,25 +143,21 @@ async function initialize(
   // Assets are processed directly by the builder except when watching
   const adjustedOptions = options.watch ? options : { ...options, assets: [] };
 
-  const {
-    config,
-    projectRoot,
-    projectSourceRoot,
-    i18n,
-  } = await generateI18nBrowserWebpackConfigFromContext(
-    adjustedOptions,
-    context,
-    (wco) => [
-      getCommonConfig(wco),
-      getBrowserConfig(wco),
-      getStylesConfig(wco),
-      getStatsConfig(wco),
-      getAnalyticsConfig(wco, context),
-      getCompilerConfig(wco),
-      wco.buildOptions.webWorkerTsConfig ? getWorkerConfig(wco) : {},
-    ],
-    { differentialLoadingNeeded },
-  );
+  const { config, projectRoot, projectSourceRoot, i18n } =
+    await generateI18nBrowserWebpackConfigFromContext(
+      adjustedOptions,
+      context,
+      (wco) => [
+        getCommonConfig(wco),
+        getBrowserConfig(wco),
+        getStylesConfig(wco),
+        getStatsConfig(wco),
+        getAnalyticsConfig(wco, context),
+        getCompilerConfig(wco),
+        wco.buildOptions.webWorkerTsConfig ? getWorkerConfig(wco) : {},
+      ],
+      { differentialLoadingNeeded },
+    );
 
   // Validate asset option values if processed directly
   if (options.assets?.length && !adjustedOptions.assets?.length) {
@@ -803,7 +799,6 @@ function generateBundleInfoStats(
     size: bundle.size,
     files: bundle.map ? [bundle.filename, bundle.map.filename] : [bundle.filename],
     names: chunk?.names,
-    entry: !!chunk?.names?.includes('runtime'),
     initial: !!chunk?.initial,
     rendered: true,
     chunkType,

--- a/packages/angular_devkit/build_angular/src/webpack/utils/async-chunks.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/utils/async-chunks.ts
@@ -27,7 +27,9 @@ export function markAsyncChunksNonInitial(
   // **cannot** be loaded in main bundle.
   const asyncChunkIds = extraEntryPoints
     .filter((entryPoint) => !entryPoint.inject)
-    .flatMap((entryPoint) => entryPoints[entryPoint.bundleName].chunks);
+    .flatMap((entryPoint) =>
+      entryPoints[entryPoint.bundleName].chunks?.filter((n) => n !== 'runtime'),
+    );
 
   // Find chunks for each ID.
   const asyncChunks = asyncChunkIds.map((chunkId) => {
@@ -41,8 +43,12 @@ export function markAsyncChunksNonInitial(
 
   // A chunk is considered `initial` only if Webpack already belives it to be initial
   // and the application developer did not mark it async via an extra entry point.
-  return chunks.map((chunk) => ({
-    ...chunk,
-    initial: chunk.initial && !asyncChunks.find((asyncChunk) => asyncChunk === chunk),
-  }));
+  return chunks.map((chunk) => {
+    return asyncChunks.find((asyncChunk) => asyncChunk === chunk)
+      ? {
+          ...chunk,
+          initial: false,
+        }
+      : chunk;
+  });
 }

--- a/packages/angular_devkit/build_angular/src/webpack/utils/stats.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/utils/stats.ts
@@ -42,7 +42,6 @@ export function generateBundleStats(info: {
   size?: number;
   files?: string[];
   names?: string[];
-  entry?: boolean;
   initial?: boolean;
   rendered?: boolean;
   chunkType?: ChunkType;
@@ -54,7 +53,7 @@ export function generateBundleStats(info: {
       .map((f) => path.basename(f))
       .join(', ') ?? '';
   const names = info.names?.length ? info.names.join(', ') : '-';
-  const initial = !!(info.entry || info.initial);
+  const initial = !!info.initial;
   const chunkType = info.chunkType || 'unknown';
 
   return {


### PR DESCRIPTION

Web-workers are not marked as `initial` since their initialization can be guarded.

Closes #21059