### PR TITLE
perf(@angular-devkit/build-angular): reduce memory usage by cleaning output directory before emitting

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
@@ -413,7 +413,7 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
     context: root,
     entry: entryPoints,
     output: {
-      clean: buildOptions.deleteOutputPath,
+      clean: buildOptions.deleteOutputPath ?? true,
       path: path.resolve(root, buildOptions.outputPath),
       publicPath: buildOptions.deployUrl ?? '',
       filename: ({ chunk }) => {


### PR DESCRIPTION

Unless `deleteOutputPath` is false, we should clean, this helps reduce assets in tests.