### PR TITLE
refactor(@ngtools/webpack): create ngcc resolver from Webpack Compiler

### DIFF
--- a/packages/ngtools/webpack/src/ivy/plugin.ts
+++ b/packages/ngtools/webpack/src/ivy/plugin.ts
@@ -72,6 +72,10 @@ function initializeNgccProcessor(
 
   const errors: string[] = [];
   const warnings: string[] = [];
+  const resolver = compiler.resolverFactory.get('normal', {
+    extensions: ['.json'],
+    useSyncFileSystemCalls: true,
+  });
   const processor = new NgccProcessor(
     mainFields,
     warnings,
@@ -79,7 +83,7 @@ function initializeNgccProcessor(
     compiler.context,
     tsconfig,
     inputFileSystem,
-    webpackOptions.resolve?.symlinks,
+    resolver,
   );
 
   return { processor, errors, warnings };

--- a/packages/ngtools/webpack/src/ngcc_processor.ts
+++ b/packages/ngtools/webpack/src/ngcc_processor.ts
@@ -9,7 +9,7 @@
 import { LogLevel, Logger, process as mainNgcc } from '@angular/compiler-cli/ngcc';
 import { spawnSync } from 'child_process';
 import { createHash } from 'crypto';
-import { Resolver, ResolverFactory } from 'enhanced-resolve';
+import { Resolver } from 'enhanced-resolve';
 import { accessSync, constants, existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import * as path from 'path';
 import * as ts from 'typescript';
@@ -30,7 +30,6 @@ export class NgccProcessor {
   private _processedModules = new Set<string>();
   private _logger: NgccLogger;
   private _nodeModulesDirectory: string;
-  private _resolver: Resolver;
 
   constructor(
     private readonly propertiesToConsider: string[],
@@ -39,19 +38,10 @@ export class NgccProcessor {
     private readonly basePath: string,
     private readonly tsConfigPath: string,
     private readonly inputFileSystem: InputFileSystem,
-    private readonly symlinks: boolean | undefined,
+    private readonly resolver: Resolver,
   ) {
     this._logger = new NgccLogger(this.compilationWarnings, this.compilationErrors);
     this._nodeModulesDirectory = this.findNodeModulesDirectory(this.basePath);
-
-    this._resolver = ResolverFactory.createResolver({
-      // NOTE: @types/webpack InputFileSystem is missing some methods
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      fileSystem: this.inputFileSystem as any,
-      extensions: ['.json'],
-      useSyncFileSystemCalls: true,
-      symlinks,
-    });
   }
 
   /** Process the entire node modules tree. */
@@ -207,10 +197,7 @@ export class NgccProcessor {
 
     // Purge this file from cache, since NGCC add new mainFields. Ex: module_ivy_ngcc
     // which are unknown in the cached file.
-    if (this.inputFileSystem.purge) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (this.inputFileSystem.purge as any)(packageJsonPath);
-    }
+    this.inputFileSystem.purge?.(packageJsonPath);
 
     this._processedModules.add(resolvedFileName);
   }
@@ -224,7 +211,7 @@ export class NgccProcessor {
    */
   private tryResolvePackage(moduleName: string, resolvedFileName: string): string | undefined {
     try {
-      const resolvedPath = this._resolver.resolveSync(
+      const resolvedPath = this.resolver.resolveSync(
         {},
         resolvedFileName,
         `${moduleName}/package.json`,


### PR DESCRIPTION
By using the Webpack compiler to request a resolver, configuration supplied options will automatically be used (such as symlinks) and also ensures that the same version of the resolver code will be used. Additionally, this removes one of the reasons to directly depend on the `enhanced-resolve` package.