### PR TITLE
docs(@angular/cli): Add Nightwatch schematics to e2e command

### DIFF
--- a/packages/angular/cli/commands/e2e-impl.ts
+++ b/packages/angular/cli/commands/e2e-impl.ts
@@ -20,6 +20,7 @@ You should add a package that implements end-to-end testing capabilities.
 
 For example:
   Cypress: ng add @cypress/schematic
+  Nightwatch: ng add @nightwatch/schematics
   WebdriverIO: ng add @wdio/schematics
 
 More options will be added to the list as they become available.


### PR DESCRIPTION
**Overview**
Added Nightwatch Schematic to e2e command. Nightwatch schematics would add both schematics and custom builder to Angular Project.

Ref:
https://github.com/nightwatchjs/nightwatch-schematics
https://www.npmjs.com/package/@nightwatch/schematics