### PR TITLE
refactor(@ngtools/webpack): support both sync and async resolvers with TypeScript paths plugin

### DIFF
--- a/packages/ngtools/webpack/src/ivy/plugin.ts
+++ b/packages/ngtools/webpack/src/ivy/plugin.ts
@@ -66,6 +66,8 @@ function initializeNgccProcessor(
   const errors: string[] = [];
   const warnings: string[] = [];
   const resolver = compiler.resolverFactory.get('normal', {
+    // Caching must be disabled because it causes the resolver to become async after a rebuild
+    cache: false,
     extensions: ['.json'],
     useSyncFileSystemCalls: true,
   });


### PR DESCRIPTION
Usage of async functions and promises were removed from the TypeScript paths resolver plugin to allow it to be used with both a synchronous and asychronous Webpack resolver.