### PR TITLE
fix(@angular-devkit/build-angular): don't parse `new Worker` syntax when `webWorkerTsConfig` is not defined in karma builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/test.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/test.ts
@@ -16,7 +16,7 @@ export function getTestConfig(
   wco: WebpackConfigOptions<WebpackTestOptions>,
 ): webpack.Configuration {
   const {
-    buildOptions: { codeCoverage, codeCoverageExclude, main, sourceMap },
+    buildOptions: { codeCoverage, codeCoverageExclude, main, sourceMap, webWorkerTsConfig },
     root,
     sourceRoot,
   } = wco;
@@ -60,6 +60,15 @@ export function getTestConfig(
     },
     module: {
       rules: extraRules,
+      parser:
+        webWorkerTsConfig === undefined
+          ? undefined
+          : {
+              javascript: {
+                worker: false,
+                url: false,
+              },
+            },
     },
     plugins: extraPlugins,
     optimization: {


### PR DESCRIPTION

This is to retain version 11 behaviour.

Closes #21108