### PR TITLE
refactor(@angular-devkit/build-angular): ignore postcss-loader warning

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
@@ -44,7 +44,6 @@ import {
   getWatchOptions,
   normalizeExtraEntryPoints,
 } from '../utils/helpers';
-import { IGNORE_WARNINGS } from '../utils/stats';
 
 // eslint-disable-next-line max-lines-per-function
 export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
@@ -430,7 +429,15 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
     performance: {
       hints: false,
     },
-    ignoreWarnings: IGNORE_WARNINGS,
+    ignoreWarnings: [
+      // Webpack 5+ has no facility to disable this warning.
+      // System.import is used in @angular/core for deprecated string-form lazy routes
+      /System.import\(\) is deprecated and will be removed soon/i,
+      // https://github.com/webpack-contrib/source-map-loader/blob/b2de4249c7431dd8432da607e08f0f65e9d64219/src/index.js#L83
+      /Failed to parse source map from/,
+      // https://github.com/webpack-contrib/postcss-loader/blob/bd261875fdf9c596af4ffb3a1a73fe3c549befda/src/index.js#L153-L158
+      /Add postcss as project dependency/,
+    ],
     module: {
       // Show an error for missing exports instead of a warning.
       strictExportPresence: true,

--- a/packages/angular_devkit/build_angular/src/webpack/utils/stats.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/utils/stats.ts
@@ -240,14 +240,6 @@ function statsToString(
   }
 }
 
-export const IGNORE_WARNINGS = [
-  // Webpack 5+ has no facility to disable this warning.
-  // System.import is used in @angular/core for deprecated string-form lazy routes
-  /System.import\(\) is deprecated and will be removed soon/i,
-  // https://github.com/webpack-contrib/source-map-loader/blob/b2de4249c7431dd8432da607e08f0f65e9d64219/src/index.js#L83
-  /Failed to parse source map from/,
-];
-
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function statsWarningsToString(json: StatsCompilation, statsConfig: any): string {
   const colors = statsConfig.colors;


### PR DESCRIPTION
Users should not install `postcss` in their workspace as this is a dependency of `@angular-devkit/build-angular`.