### PR TITLE
fix(@angular-devkit/build-angular): explicitly set compilation target  in test configuration

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/test.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/test.ts
@@ -8,6 +8,7 @@
 
 import * as glob from 'glob';
 import * as path from 'path';
+import { ScriptTarget } from 'typescript';
 import * as webpack from 'webpack';
 import { WebpackConfigOptions, WebpackTestOptions } from '../../utils/build-options';
 import { getSourceMapDevTool, isPolyfillsEntry } from '../utils/helpers';
@@ -51,6 +52,7 @@ export function getTestConfig(
 
   return {
     mode: 'development',
+    target: wco.tsConfig.options.target === ScriptTarget.ES5 ? ['web', 'es5'] : 'web',
     resolve: {
       mainFields: ['es2015', 'browser', 'module', 'main'],
     },


### PR DESCRIPTION


When not set, and browserslist returns no supported result due to the file being empty or commented. Webpack will generate invalid code because it doesn't know which enviorment we want to target.

```diff
- (self["webpackChunktest_app"] = self["webpackChunktest_app"] || []).push([["vendor"],{

/***/ 8583:
```

Closes #21111