### PR TITLE
fix(@angular-devkit/build-angular): use the name as chunk filename instead of id

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
@@ -425,7 +425,7 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
           return `[name]${targetInFileName}${hashFormat.chunk}.js`;
         }
       },
-      chunkFilename: `[id]${targetInFileName}${hashFormat.chunk}.js`,
+      chunkFilename: `[name]${targetInFileName}${hashFormat.chunk}.js`,
     },
     watch: buildOptions.watch,
     watchOptions: getWatchOptions(buildOptions.poll),


### PR DESCRIPTION
Solves the following regression in Angular 12: https://github.com/angular/angular-cli/issues/21129