### PR TITLE
 perf(@ngtools/webpack): execute modules instead of using child compilers for Angular component resources

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/environment-options.ts
+++ b/packages/angular_devkit/build_angular/src/utils/environment-options.ts
@@ -102,3 +102,7 @@ export const profilingEnabled = isPresent(profilingVariable) && isEnabled(profil
  */
 const maxWorkersVariable = process.env['NG_BUILD_MAX_WORKERS'];
 export const maxWorkers = isPresent(maxWorkersVariable) ? +maxWorkersVariable : 4;
+
+/** Disable Webpack experimental executeModule */
+const executeModules = process.env['NG_EXECUTE_MODULES'];
+export const executeModulesDisabled = isPresent(executeModules) && isDisabled(executeModules);

--- a/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
@@ -37,6 +37,7 @@ import {
   allowMangle,
   allowMinify,
   cachingDisabled,
+  executeModulesDisabled,
   maxWorkers,
   persistentBuildCacheEnabled,
   profilingEnabled,
@@ -480,6 +481,7 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
       ],
     },
     experiments: {
+      executeModule: !executeModulesDisabled,
       syncWebAssembly: true,
       asyncWebAssembly: true,
     },

--- a/packages/angular_devkit/build_angular/src/webpack/configs/styles.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/styles.ts
@@ -13,7 +13,7 @@ import { ExtraEntryPoint } from '../../browser/schema';
 import { SassWorkerImplementation } from '../../sass/sass-service';
 import { BuildBrowserFeatures } from '../../utils/build-browser-features';
 import { WebpackConfigOptions } from '../../utils/build-options';
-import { maxWorkers } from '../../utils/environment-options';
+import { executeModulesDisabled, maxWorkers } from '../../utils/environment-options';
 import {
   AnyComponentStyleBudgetChecker,
   PostcssCliResources,
@@ -229,7 +229,12 @@ export function getStylesConfig(wco: WebpackConfigOptions): webpack.Configuratio
 
   if (buildOptions.extractCss) {
     // extract global css from js files into own css file.
-    extraPlugins.push(new MiniCssExtractPlugin({ filename: `[name]${hashFormat.extract}.css` }));
+    extraPlugins.push(
+      new MiniCssExtractPlugin({
+        filename: `[name]${hashFormat.extract}.css`,
+        experimentalUseImportModule: !executeModulesDisabled,
+      }),
+    );
 
     if (!buildOptions.hmr) {
       // don't remove `.js` files for `.css` when we are using HMR these contain HMR accept codes.

--- a/packages/ngtools/webpack/src/inline-data-loader.ts
+++ b/packages/ngtools/webpack/src/inline-data-loader.ts
@@ -8,18 +8,26 @@
 
 import type { Compilation, LoaderContext } from 'webpack';
 
-export const InlineAngularResourceSymbol = Symbol();
+export const InlineAngularResourceSymbol = Symbol.for('@ngtools/webpack[inline-angular-resource]');
 
 export interface CompilationWithInlineAngularResource extends Compilation {
   [InlineAngularResourceSymbol]: string;
 }
 
-export default function (this: LoaderContext<{ data?: string }>) {
+export default function (
+  this: LoaderContext<{ data?: string }> & {
+    [InlineAngularResourceSymbol]?: Map<string, string>;
+  },
+) {
   const callback = this.async();
   const { data } = this.getOptions();
+  const userRequest = this._module?.userRequest;
+  const inlineAngularResourceSymbol = this[InlineAngularResourceSymbol];
 
   if (data) {
     callback(undefined, Buffer.from(data, 'base64').toString());
+  } else if (inlineAngularResourceSymbol && userRequest) {
+    callback(undefined, inlineAngularResourceSymbol.get(userRequest));
   } else {
     const content = (this._compilation as CompilationWithInlineAngularResource)[
       InlineAngularResourceSymbol

--- a/packages/ngtools/webpack/src/ivy/symbol.ts
+++ b/packages/ngtools/webpack/src/ivy/symbol.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export const AngularPluginSymbol = Symbol.for('@angular-devkit/build-angular[angular-compiler]');
+export const AngularPluginSymbol = Symbol.for('@ngtools/webpack[angular-compiler]');
 
 export interface EmitFileResult {
   content?: string;


### PR DESCRIPTION
This uses the experimental `executeModule` feature which was introduced in Webpack 5.33.2.
    
See: https://webpack.js.org/configuration/experiments/#experimentsexecutemodule