### PR TITLE
tests(@angular/cli): add `ng add` and `ng update` E2E tests for secure repositories

### DIFF
--- a/tests/legacy-cli/e2e/tests/commands/add/registry-option.ts
+++ b/tests/legacy-cli/e2e/tests/commands/add/registry-option.ts
@@ -12,7 +12,7 @@ export default async function () {
   });
   // The environment variable has priority over the .npmrc
   const originalRegistryVariable = process.env['NPM_CONFIG_REGISTRY'];
-  process.env['NPM_CONFIG_REGISTRY'] = undefined;
+  delete process.env['NPM_CONFIG_REGISTRY'];
 
   try {
     await expectToFail(() => ng('add', '@angular/pwa', '--skip-confirmation'));

--- a/tests/legacy-cli/e2e/tests/commands/add/secure-registry.ts
+++ b/tests/legacy-cli/e2e/tests/commands/add/secure-registry.ts
@@ -1,0 +1,37 @@
+import { expectFileNotToExist, expectFileToExist } from '../../../utils/fs';
+import { git, ng } from '../../../utils/process';
+import { createNpmConfigForAuthentication } from '../../../utils/registry';
+import { expectToFail } from '../../../utils/utils';
+
+export default async function () {
+  // The environment variable has priority over the .npmrc
+  const originalRegistryVariable = process.env['NPM_CONFIG_REGISTRY'];
+  delete process.env['NPM_CONFIG_REGISTRY'];
+
+  try {
+    const command = ['add', '@angular/pwa', '--skip-confirmation'];
+    await expectFileNotToExist('src/manifest.webmanifest');
+
+    // Works with unscoped registry authentication details
+    await createNpmConfigForAuthentication(false);
+    await ng(...command);
+    await expectFileToExist('src/manifest.webmanifest');
+    await git('clean', '-dxf');
+
+    // Works with scoped registry authentication details
+    await expectFileNotToExist('src/manifest.webmanifest');
+
+    await createNpmConfigForAuthentication(true);
+    await ng(...command);
+    await expectFileToExist('src/manifest.webmanifest');
+
+    // Invalid authentication token
+    await createNpmConfigForAuthentication(false, true);
+    await expectToFail(() => ng(...command));
+
+    await createNpmConfigForAuthentication(true, true);
+    await expectToFail(() => ng(...command));
+  } finally {
+    process.env['NPM_CONFIG_REGISTRY'] = originalRegistryVariable;
+  }
+}

--- a/tests/legacy-cli/e2e/tests/update/update-secure-registry.ts
+++ b/tests/legacy-cli/e2e/tests/update/update-secure-registry.ts
@@ -1,0 +1,35 @@
+import { ng } from '../../utils/process';
+import { createNpmConfigForAuthentication } from '../../utils/registry';
+import { expectToFail } from '../../utils/utils';
+
+export default async function () {
+  // The environment variable has priority over the .npmrc
+  const originalRegistryVariable = process.env['NPM_CONFIG_REGISTRY'];
+  delete process.env['NPM_CONFIG_REGISTRY'];
+
+  const worksMessage = 'We analyzed your package.json';
+
+  try {
+    // Valid authentication token
+    await createNpmConfigForAuthentication(false);
+    const { stdout: stdout1 } = await ng('update');
+    if (!stdout1.includes(worksMessage)) {
+      throw new Error(`Expected stdout to contain "${worksMessage}"`);
+    }
+
+    await createNpmConfigForAuthentication(true);
+    const { stdout: stdout2 } = await ng('update');
+    if (!stdout2.includes(worksMessage)) {
+      throw new Error(`Expected stdout to contain "${worksMessage}"`);
+    }
+
+    // Invalid authentication token
+    await createNpmConfigForAuthentication(false, true);
+    await expectToFail(() => ng('update'));
+
+    await createNpmConfigForAuthentication(true, true);
+    await expectToFail(() => ng('update'));
+  } finally {
+    process.env['NPM_CONFIG_REGISTRY'] = originalRegistryVariable;
+  }
+}

--- a/tests/legacy-cli/e2e/utils/registry.ts
+++ b/tests/legacy-cli/e2e/utils/registry.ts
@@ -1,0 +1,56 @@
+import { ChildProcess, spawn } from 'child_process';
+import { copyFileSync, mkdtempSync, realpathSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { writeFile } from './fs';
+
+export function createNpmRegistry(withAuthentication = false): ChildProcess {
+  // Setup local package registry
+  const registryPath = mkdtempSync(join(realpathSync(tmpdir()), 'angular-cli-e2e-registry-'));
+
+  copyFileSync(
+    join(__dirname, '../../', withAuthentication ? 'verdaccio_auth.yaml' : 'verdaccio.yaml'),
+    join(registryPath, 'verdaccio.yaml'),
+  );
+
+  return spawn('node', [require.resolve('verdaccio/bin/verdaccio'), '-c', './verdaccio.yaml'], {
+    cwd: registryPath,
+    stdio: 'inherit',
+  });
+}
+
+export function createNpmConfigForAuthentication(
+  /**
+   * When true, the authentication token will be scoped to the registry URL.
+   * @example
+   * ```ini
+   * //localhost:4876/:_auth="dGVzdGluZzpzM2NyZXQ="
+   * ```
+   *
+   * When false, the authentication will be added as seperate key.
+   * @example
+   * ```ini
+   * _auth="dGVzdGluZzpzM2NyZXQ="`
+   * ```
+   */
+  scopedAuthentication: boolean,
+  /** When true, an incorrect token is used. Use this to validate authentication failures. */
+  invalidToken = false,
+): Promise<void> {
+  // Token was generated using `echo -n 'testing:s3cret' | openssl base64`.
+  const token = invalidToken ? `invalid=` : `dGVzdGluZzpzM2NyZXQ=`;
+  const registry = `//localhost:4876/`;
+
+  return writeFile(
+    '.npmrc',
+    scopedAuthentication
+      ? `
+        ${registry}:_auth="${token}"
+        registry=http:${registry}
+      `
+      : `
+        _auth="${token}"
+        registry=http:${registry}
+      `,
+  );
+}

--- a/tests/legacy-cli/verdaccio.yaml
+++ b/tests/legacy-cli/verdaccio.yaml
@@ -3,7 +3,7 @@ storage: ./storage
 auth:
   auth-memory:
     users: {}
-
+listen: localhost:4873
 uplinks:
   npmjs:
     url: https://registry.npmjs.org/
@@ -20,7 +20,7 @@ packages:
   '@angular/{cli,pwa}':
     access: $all
     publish: $all
-    
+
   '@angular-devkit/*':
     access: $all
     publish: $all
@@ -42,7 +42,7 @@ packages:
     proxy: npmjs
 
 logs:
-  - {type: stdout, format: pretty, level: warn}
+  - { type: stdout, format: pretty, level: warn }
 
 # https://github.com/verdaccio/verdaccio/issues/301
 server:

--- a/tests/legacy-cli/verdaccio_auth.yaml
+++ b/tests/legacy-cli/verdaccio_auth.yaml
@@ -1,0 +1,28 @@
+storage: ./storage
+auth:
+  auth-memory:
+    users:
+      testing:
+        name: testing
+        password: s3cret
+listen: localhost:4876
+uplinks:
+  local:
+    url: http://localhost:4873
+    cache: false
+    maxage: 20m
+    max_fails: 32
+    timeout: 60s
+    agent_options:
+      keepAlive: true
+      maxSockets: 32
+      maxFreeSockets: 8
+packages:
+  '**':
+    access: $authenticated
+    proxy: local
+logs:
+  - { type: stdout, format: pretty, level: http }
+# https://github.com/verdaccio/verdaccio/issues/301
+server:
+  keepAliveTimeout: 0


### PR DESCRIPTION

With this change we add E2E tests to validate that `ng add` and `ng update` work with secure NPM registries.

This is a follow up of #21140 which addressed several issues with secure registries.