### PR TITLE
test(@schematics/angular): add missing unit test for skipTests flag

### DIFF
--- a/packages/schematics/angular/class/index_spec.ts
+++ b/packages/schematics/angular/class/index_spec.ts
@@ -99,4 +99,14 @@ describe('Class Schematic', () => {
     appTree = await schematicRunner.runSchematicAsync('class', defaultOptions, appTree).toPromise();
     expect(appTree.files).toContain('/projects/bar/custom/app/foo.ts');
   });
+
+  it('should respect the skipTests flag', async () => {
+    const options = {
+      ...defaultOptions,
+      skipTests: true,
+    };
+    const tree = await schematicRunner.runSchematicAsync('class', options, appTree).toPromise();
+    expect(tree.files).toContain('/projects/bar/src/app/foo.ts');
+    expect(tree.files).not.toContain('/projects/bar/src/app/foo.spec.ts');
+  });
 });

--- a/packages/schematics/angular/component/index_spec.ts
+++ b/packages/schematics/angular/component/index_spec.ts
@@ -365,4 +365,19 @@ describe('Component Schematic', () => {
       .toPromise();
     expect(appTree.files).toContain('/projects/bar/custom/app/foo/foo.component.ts');
   });
+
+  it('should respect the skipTests option', async () => {
+    const options = { ...defaultOptions, skipTests: true };
+    const tree = await schematicRunner.runSchematicAsync('component', options, appTree).toPromise();
+    const files = tree.files;
+
+    expect(files).toEqual(
+      jasmine.arrayContaining([
+        '/projects/bar/src/app/foo/foo.component.css',
+        '/projects/bar/src/app/foo/foo.component.html',
+        '/projects/bar/src/app/foo/foo.component.ts',
+      ]),
+    );
+    expect(tree.files).not.toContain('/projects/bar/src/app/foo/foo.component.spec.ts');
+  });
 });

--- a/packages/schematics/angular/directive/index_spec.ts
+++ b/packages/schematics/angular/directive/index_spec.ts
@@ -174,4 +174,13 @@ describe('Directive Schematic', () => {
       .toPromise();
     expect(appTree.files).toContain('/projects/bar/custom/app/foo.directive.ts');
   });
+
+  it('should respect skipTests flag', async () => {
+    const options = { ...defaultOptions, skipTests: true };
+
+    const tree = await schematicRunner.runSchematicAsync('directive', options, appTree).toPromise();
+    const files = tree.files;
+    expect(files).toContain('/projects/bar/src/app/foo.directive.ts');
+    expect(files).not.toContain('/projects/bar/src/app/foo.directive.spec.ts');
+  });
 });

--- a/packages/schematics/angular/pipe/index_spec.ts
+++ b/packages/schematics/angular/pipe/index_spec.ts
@@ -138,4 +138,13 @@ describe('Pipe Schematic', () => {
     appTree = await schematicRunner.runSchematicAsync('pipe', defaultOptions, appTree).toPromise();
     expect(appTree.files).toContain('/projects/bar/custom/app/foo.pipe.ts');
   });
+
+  it('should respect the skipTests flag', async () => {
+    const options = { ...defaultOptions, skipTests: true };
+
+    const tree = await schematicRunner.runSchematicAsync('pipe', options, appTree).toPromise();
+    const files = tree.files;
+    expect(files).not.toContain('/projects/bar/src/app/foo.pipe.spec.ts');
+    expect(files).toContain('/projects/bar/src/app/foo.pipe.ts');
+  });
 });


### PR DESCRIPTION
add missing unit test of skipTests flag for component, class, directive, and pipe