### PR TITLE
build: support ES2020 API usage

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "skipLibCheck": true,
     "strict": true,
     "target": "es2019",
-    "lib": ["es2019"],
+    "lib": ["es2020"],
     "baseUrl": "",
     "rootDirs": [".", "./dist-schema/", "./bazel-bin/"],
     "typeRoots": ["./node_modules/@types"],


### PR DESCRIPTION
With the removal of support for Node.js v10, the TypeScript library version can be updated to ES2020. Node.js v12.11+ supports the API elements of ES2020.
The compilation target must still be set to ES2019 as the language syntax elements are not fully supported until Node.js v14+.