### PR TITLE
fix(@angular-devkit/build-angular): control linker template sourcemapping via builder sourcemap options

### DIFF
--- a/packages/angular_devkit/build_angular/src/babel/presets/application.ts
+++ b/packages/angular_devkit/build_angular/src/babel/presets/application.ts
@@ -20,6 +20,7 @@ export interface ApplicationPresetOptions {
   angularLinker?: {
     shouldLink: boolean;
     jitMode: boolean;
+    sourcemap: boolean;
   };
 
   forceES5?: boolean;
@@ -31,7 +32,8 @@ export interface ApplicationPresetOptions {
 type I18nDiagnostics = import('@angular/localize/src/tools/src/diagnostics').Diagnostics;
 function createI18nDiagnostics(reporter: DiagnosticReporter | undefined): I18nDiagnostics {
   // Babel currently is synchronous so import cannot be used
-  const diagnostics: I18nDiagnostics = new (require('@angular/localize/src/tools/src/diagnostics').Diagnostics)();
+  const diagnostics: I18nDiagnostics =
+    new (require('@angular/localize/src/tools/src/diagnostics').Diagnostics)();
 
   if (!reporter) {
     return diagnostics;
@@ -130,13 +132,13 @@ export default function (api: unknown, options: ApplicationPresetOptions) {
 
   if (options.angularLinker?.shouldLink) {
     // Babel currently is synchronous so import cannot be used
-    const {
-      createEs2015LinkerPlugin,
-    } = require('@angular/compiler-cli/linker/babel') as typeof import('@angular/compiler-cli/linker/babel');
+    const { createEs2015LinkerPlugin } =
+      require('@angular/compiler-cli/linker/babel') as typeof import('@angular/compiler-cli/linker/babel');
 
     plugins.push(
       createEs2015LinkerPlugin({
         linkerJitMode: options.angularLinker.jitMode,
+        sourceMapping: options.angularLinker.sourcemap,
         logger: createNgtscLogger(options.diagnosticReporter),
         fileSystem: {
           resolve: path.resolve,

--- a/packages/angular_devkit/build_angular/src/babel/webpack-loader.ts
+++ b/packages/angular_devkit/build_angular/src/babel/webpack-loader.ts
@@ -58,6 +58,7 @@ export default custom<AngularCustomOptions>(() => {
         customOptions.angularLinker = {
           shouldLink: true,
           jitMode: aot !== true,
+          sourcemap: false,
         };
         shouldProcess = true;
       }
@@ -138,6 +139,15 @@ export default custom<AngularCustomOptions>(() => {
             { wrapDecorators: customOptions.optimize.wrapDecorators },
           ],
         );
+      }
+
+      // Only enable linker template sourcemapping if linker is enabled and Webpack provides
+      // a sourcemap. This logic allows the linker sourcemap behavior to be controlled by the
+      // Webpack sourcemap configuration. For example, if a vendor file is being processed
+      // and vendor sourcemaps are disabled, the `inputSourceMap` property will be `undefined`
+      // which will effectively disable linker sourcemapping for vendor files.
+      if (customOptions.angularLinker && configuration.options.inputSourceMap) {
+        customOptions.angularLinker.sourcemap = true;
       }
 
       return {


### PR DESCRIPTION
This change allows the linker sourcemap behavior to be controlled by the Webpack sourcemap configuration. For example, if a vendor file is being processed and vendor sourcemaps are disabled, the linker will now skip its internal sourcemap loading and processing steps.