### PR TITLE
[patch] fix(@angular-devkit/build-angular): parse web-workers in tests when webWorkerTsConfig is defined

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/test.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/test.ts
@@ -64,13 +64,13 @@ export function getTestConfig(
       rules: extraRules,
       parser:
         webWorkerTsConfig === undefined
-          ? undefined
-          : {
+          ? {
               javascript: {
                 worker: false,
                 url: false,
               },
-            },
+            }
+          : undefined,
     },
     plugins: extraPlugins,
     optimization: {


### PR DESCRIPTION

The logic was inverted which caused workers not to be parsed when webWorkerTsConfig is defined.

Patch version of https://github.com/angular/angular-cli/pull/21160