### PR TITLE
[10.2.x] build: update to new remote instance name for RBE

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -89,7 +89,7 @@ test --test_output=errors
 ################################
 
 # Use the Angular team internal GCP instance for remote execution.
-build:remote --remote_instance_name=projects/internal-200822/instances/default_instance
+build:remote --remote_instance_name=projects/internal-200822/instances/primary_instance
 build:remote --project_id=internal-200822
 
 # Starting with Bazel 0.27.0 strategies do not need to be explicitly

--- a/.ng-dev.log
+++ b/.ng-dev.log
@@ -1,0 +1,8 @@
+####################################################################################################
+Command: ng-dev commit-message restore-commit-message-draft
+Ran at: Thu Jun 24 2021 13:15:43 GMT+0200 (Central European Summer Time)
+LOG:    Skipping commit message restoration attempt
+DEBUG:  A commit message was already provided via the command with a -m or -F flag
+####################################################################################################
+Command ran in 7ms
+Exit Code: 0

--- a/tests/legacy-cli/e2e/tests/misc/update-git-clean-subdirectory.ts
+++ b/tests/legacy-cli/e2e/tests/misc/update-git-clean-subdirectory.ts
@@ -18,7 +18,7 @@ export default async function() {
   await writeFile('../added.ts', 'console.log(\'created\');\n');
   await silentGit('add', '../added.ts');
 
-  const { stderr } = await ng('update', '--all', '--force');
+  const { stderr } = await ng('update', '@angular/cli');
   if (stderr && stderr.includes('Repository is not clean.')) {
     throw new Error('Expected clean repository');
   }


### PR DESCRIPTION
Update to use remote instance name, primary_instance, for RBE

(cherry picked from commit 4d31fc6a74b68968707ff8aa12b0842e0ea5dd10)