### PR TITLE
[9.1.x] build: update to new remote instance name for RBE

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -89,7 +89,7 @@ test --test_output=errors
 ################################
 
 # Use the Angular team internal GCP instance for remote execution.
-build:remote --remote_instance_name=projects/internal-200822/instances/default_instance
+build:remote --remote_instance_name=projects/internal-200822/instances/primary_instance
 build:remote --project_id=internal-200822
 
 # Starting with Bazel 0.27.0 strategies do not need to be explicitly

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,9 +14,9 @@ version: 2.1
 ## IMPORTANT
 # Windows needs its own cache key because binaries in node_modules are different.
 # See https://circleci.com/docs/2.0/caching/#restoring-cache for how prefixes work in CircleCI.
-var_1: &cache_key angular_devkit-12.9-{{ checksum "yarn.lock" }}
-var_1_win: &cache_key_win angular_devkit-win-12.9-{{ checksum "yarn.lock" }}
-var_3: &default_nodeversion "12.9"
+var_1: &cache_key angular_devkit-12.18-{{ checksum "yarn.lock" }}
+var_1_win: &cache_key_win angular_devkit-win-12.18-{{ checksum "yarn.lock" }}
+var_3: &default_nodeversion "12.18"
 # Workspace initially persisted by the `setup` job, and then enhanced by `setup-and-build-win`.
 # https://circleci.com/docs/2.0/workflows/#using-workspaces-to-share-data-among-jobs
 # https://circleci.com/blog/deep-diving-into-circleci-workspaces/

--- a/tests/legacy-cli/e2e/tests/misc/update-git-clean-subdirectory.ts
+++ b/tests/legacy-cli/e2e/tests/misc/update-git-clean-subdirectory.ts
@@ -18,7 +18,7 @@ export default async function() {
   await writeFile('../added.ts', 'console.log(\'created\');\n');
   await silentGit('add', '../added.ts');
 
-  const { stderr } = await ng('update', '--all', '--force');
+  const { stderr } = await ng('update', '@angular/cli');
   if (stderr && stderr.includes('Repository is not clean.')) {
     throw new Error('Expected clean repository');
   }


### PR DESCRIPTION
Update to use remote instance name, primary_instance, for RBE

(cherry picked from commit 4d31fc6a74b68968707ff8aa12b0842e0ea5dd10)