### PR TITLE
ci: increase shards for karma tests

### DIFF
--- a/packages/angular_devkit/build_angular/BUILD.bazel
+++ b/packages/angular_devkit/build_angular/BUILD.bazel
@@ -295,6 +295,7 @@ LARGE_SPECS = {
     },
     "extract-i18n": {},
     "karma": {
+        "shards": 3,
         "size": "large",
         "extra_deps": [
             "@npm//karma",


### PR DESCRIPTION
This should help to reduce heap out of memory errors during Karma tests.