### PR TITLE
fix(@angular-devkit/build-angular): handle `ENOENT` and `ENOTDIR` errors when deleting outputs

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/delete-output-dir.ts
+++ b/packages/angular_devkit/build_angular/src/utils/delete-output-dir.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { rmdirSync } from 'fs';
+import * as fs from 'fs';
 import { resolve } from 'path';
 
 /**
@@ -18,5 +18,22 @@ export function deleteOutputDir(root: string, outputPath: string): void {
     throw new Error('Output path MUST not be project root directory!');
   }
 
-  rmdirSync(resolvedOutputPath, { recursive: true, maxRetries: 3 });
+  // The below should be removed and replace with just `rmSync` when support for Node.Js 12 is removed.
+  const { rmSync, rmdirSync } = fs as typeof fs & {
+    rmSync?: (
+      path: fs.PathLike,
+      options?: {
+        force?: boolean;
+        maxRetries?: number;
+        recursive?: boolean;
+        retryDelay?: number;
+      },
+    ) => void;
+  };
+
+  if (rmSync) {
+    rmSync(resolvedOutputPath, { force: true, recursive: true, maxRetries: 3 });
+  } else {
+    rmdirSync(resolvedOutputPath, { recursive: true, maxRetries: 3 });
+  }
 }


### PR DESCRIPTION

Closes #21202