### PR TITLE
fix(@angular-devkit/build-angular): fix node 16 breaking when deleting the output path

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/delete-output-dir.ts
+++ b/packages/angular_devkit/build_angular/src/utils/delete-output-dir.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { rmdirSync } from 'fs';
+import { existsSync, rmdirSync } from 'fs';
 import { resolve } from 'path';
 
 /**
@@ -18,5 +18,11 @@ export function deleteOutputDir(root: string, outputPath: string): void {
     throw new Error('Output path MUST not be project root directory!');
   }
 
-  rmdirSync(resolvedOutputPath, { recursive: true, maxRetries: 3 });
+  // NOTE: `recursive: true` does not silence errors about existence on node
+  //       v16. `rmdirSync` recursive is deprecated and when node v14.14.0 is
+  //       the default `rmSync` should be used with `force: true` in addition
+  //       to the existing options.
+  if (existsSync(resolvedOutputPath)) {
+    rmdirSync(resolvedOutputPath, { recursive: true, maxRetries: 3 });
+  }
 }


### PR DESCRIPTION
According to `rmdirSync` [1] the `recursive` option is deprecated. The wording looks like it was changed (compared to Node LTS [2]) to not include anything about ignoring errors on paths not existing. In the future the call should be `rmSync(..., {..., force: true})`, but when testing locally adding a "force" option does not restore the previous behavior. This isn't documented to work, but since the code original code is deprecated I was wondering if the underlying functionality was just passing all the options `rmSync` on Node 16.

This change includes an existence check to skip deleting a non existent directory.

Fixes: https://github.com/angular/angular-cli/issues/21216

[1]: https://nodejs.org/api/fs.html#fs_fs_rmdirsync_path_options
[2]: https://nodejs.org/docs/latest-v14.x/api/fs.html#fs_fs_rmdirsync_path_options