### PR TITLE
fix(@ngtools/webpack): encode component style data

### DIFF
--- a/packages/ngtools/webpack/src/transformers/replace_resources.ts
+++ b/packages/ngtools/webpack/src/transformers/replace_resources.ts
@@ -208,7 +208,9 @@ function visitComponentMetadata(
           } else if (inlineStyleFileExtension) {
             const data = Buffer.from(node.text).toString('base64');
             const containingFile = node.getSourceFile().fileName;
-            url = `${containingFile}.${inlineStyleFileExtension}!=!${inlineDataLoaderPath}?data=${data}!${containingFile}`;
+            url = `${containingFile}.${inlineStyleFileExtension}!=!${inlineDataLoaderPath}?data=${encodeURIComponent(
+              data,
+            )}!${containingFile}`;
           } else {
             return nodeFactory.createStringLiteral(node.text);
           }


### PR DESCRIPTION
We now encode the data using `encodeURIComponent` which safely encodes `+` signs. Without this a portion of the buffer was lost and caused `Unrecognised input` errors.

Closes #21236