### PR TITLE
fix(@angular-devkit/build-angular): configure webpack target in common configuration

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/browser.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/browser.ts
@@ -81,10 +81,6 @@ export function getBrowserConfig(wco: WebpackConfigOptions): webpack.Configurati
     resolve: {
       mainFields: ['es2015', 'browser', 'module', 'main'],
     },
-    target:
-      wco.tsConfig.options.target === ScriptTarget.ES5 || buildBrowserFeatures.isEs5SupportNeeded()
-        ? ['web', 'es5']
-        : 'web',
     output: {
       crossOriginLoading,
       trustedTypes: 'angular#bundler',

--- a/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
@@ -40,7 +40,6 @@ import {
   maxWorkers,
   persistentBuildCacheEnabled,
   profilingEnabled,
-  shouldBeautify,
 } from '../../utils/environment-options';
 import { findAllNodeModules } from '../../utils/find-up';
 import { Spinner } from '../../utils/spinner';
@@ -358,12 +357,19 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
   return {
     mode: scriptsOptimization || stylesOptimization.minify ? 'production' : 'development',
     devtool: false,
+    target: [
+      platform === 'server' ? 'node' : 'web',
+      tsConfig.options.target === ScriptTarget.ES5 ||
+      (platform !== 'server' && buildBrowserFeatures.isEs5SupportNeeded())
+        ? 'es5'
+        : 'es2015',
+    ],
     profile: buildOptions.statsJson,
     resolve: {
       roots: [projectRoot],
       extensions: ['.ts', '.tsx', '.mjs', '.js'],
       symlinks: !buildOptions.preserveSymlinks,
-      modules: [wco.tsConfig.options.baseUrl || projectRoot, 'node_modules'],
+      modules: [tsConfig.options.baseUrl || projectRoot, 'node_modules'],
     },
     resolveLoader: {
       symlinks: !buildOptions.preserveSymlinks,

--- a/packages/angular_devkit/build_angular/src/webpack/configs/server.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/server.ts
@@ -35,7 +35,6 @@ export function getServerConfig(wco: WebpackConfigOptions): Configuration {
     resolve: {
       mainFields: ['es2015', 'main', 'module'],
     },
-    target: 'node',
     output: {
       libraryTarget: 'commonjs',
     },


### PR DESCRIPTION


Previously, `target` was unset for `test` which caused the target to be set incorrectly.

Closes #21239