### PR TITLE
refactor(@angular-devkit/build-angular): avoid loading Webpack for differential loading sourcemaps

### DIFF
--- a/packages/angular_devkit/build_angular/BUILD.bazel
+++ b/packages/angular_devkit/build_angular/BUILD.bazel
@@ -178,7 +178,6 @@ ts_library(
         "@npm//sass",
         "@npm//sass-loader",
         "@npm//semver",
-        "@npm//source-map",
         "@npm//source-map-loader",
         "@npm//source-map-support",
         "@npm//style-loader",

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -61,7 +61,6 @@
     "sass": "1.35.1",
     "sass-loader": "12.1.0",
     "semver": "7.3.5",
-    "source-map": "0.7.3",
     "source-map-loader": "3.0.0",
     "source-map-support": "0.5.19",
     "style-loader": "3.0.0",


### PR DESCRIPTION
The `@ampproject/remapping` package is now used for sourcemap processing instead of Webpack for differential loading and i18n processing. This dependency is already used within the recently added JavaScript optimizer refactoring and reduces the amount of code that needs to be loaded into each worker to support differential loading source maps. Testing with large output bundles (~12MB vendor bundles) resulted in an ~8% total build time improvement when using differential loading and source maps.