### PR TITLE
fix(@angular-devkit/build-angular): silence Sass compiler warnings from 3rd party stylesheets

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/styles.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/styles.ts
@@ -347,6 +347,9 @@ export function getStylesConfig(wco: WebpackConfigOptions): webpack.Configuratio
               // Ex: /* autoprefixer grid: autoplace */
               // See: https://github.com/webpack-contrib/sass-loader/blob/45ad0be17264ceada5f0b4fb87e9357abe85c4ff/src/getSassOptions.js#L68-L70
               outputStyle: 'expanded',
+              // Silences compiler warnings from 3rd party stylesheets
+              quietDeps: !buildOptions.verbose,
+              verbose: buildOptions.verbose,
             },
           },
         },
@@ -377,6 +380,9 @@ export function getStylesConfig(wco: WebpackConfigOptions): webpack.Configuratio
               // Ex: /* autoprefixer grid: autoplace */
               // See: https://github.com/webpack-contrib/sass-loader/blob/45ad0be17264ceada5f0b4fb87e9357abe85c4ff/src/getSassOptions.js#L68-L70
               outputStyle: 'expanded',
+              // Silences compiler warnings from 3rd party stylesheets
+              quietDeps: !buildOptions.verbose,
+              verbose: buildOptions.verbose,
             },
           },
         },


### PR DESCRIPTION

With this change we enable `quietDeps`, which causes the Sass compiler not to emit warnings from a stylesheet that is loaded through load-path.

The `--verbose` option can be used to opt-out from this behaviour and display all warnings.

Closes #21235