### PR TITLE
fix(@ngtools/webpack): only track file dependencies

### DIFF
--- a/packages/ngtools/webpack/src/resource_loader.ts
+++ b/packages/ngtools/webpack/src/resource_loader.ts
@@ -232,15 +232,42 @@ export class WebpackResourceLoader {
         const parent = childCompiler.parentCompilation;
         if (parent) {
           parent.children = parent.children.filter((child) => child !== childCompilation);
+          let fileDependencies: Set<string> | undefined;
 
-          for (const fileDependency of childCompilation.fileDependencies) {
-            if (data && containingFile && fileDependency.endsWith(entry)) {
+          for (const dependency of childCompilation.fileDependencies) {
+            // Skip paths that do not appear to be files (have no extension).
+            // `fileDependencies` can contain directories and not just files which can
+            // cause incorrect cache invalidation on rebuilds.
+            if (!path.extname(dependency)) {
+              continue;
+            }
+
+            if (data && containingFile && dependency.endsWith(entry)) {
               // use containing file if the resource was inline
               parent.fileDependencies.add(containingFile);
             } else {
-              parent.fileDependencies.add(fileDependency);
+              parent.fileDependencies.add(dependency);
+            }
+
+            // Save the dependencies for this resource.
+            if (filePath) {
+              const resolvedFile = normalizePath(dependency);
+              const entry = this._reverseDependencies.get(resolvedFile);
+              if (entry) {
+                entry.add(filePath);
+              } else {
+                this._reverseDependencies.set(resolvedFile, new Set([filePath]));
+              }
+
+              if (fileDependencies) {
+                fileDependencies.add(dependency);
+              } else {
+                fileDependencies = new Set([dependency]);
+                this._fileDependencies.set(filePath, fileDependencies);
+              }
             }
           }
+
           parent.contextDependencies.addAll(childCompilation.contextDependencies);
           parent.missingDependencies.addAll(childCompilation.missingDependencies);
           parent.buildDependencies.addAll(childCompilation.buildDependencies);
@@ -253,28 +280,6 @@ export class WebpackResourceLoader {
             }
 
             this.assetCache?.set(info.sourceFilename, { info, name, source });
-          }
-        }
-
-        // Save the dependencies for this resource.
-        if (filePath) {
-          this._fileDependencies.set(filePath, new Set(childCompilation.fileDependencies));
-          for (const file of childCompilation.fileDependencies) {
-            const resolvedFile = normalizePath(file);
-
-            // Skip paths that do not appear to be files (have no extension).
-            // `fileDependencies` can contain directories and not just files which can
-            // cause incorrect cache invalidation on rebuilds.
-            if (!path.extname(resolvedFile)) {
-              continue;
-            }
-
-            const entry = this._reverseDependencies.get(resolvedFile);
-            if (entry) {
-              entry.add(filePath);
-            } else {
-              this._reverseDependencies.set(resolvedFile, new Set([filePath]));
-            }
           }
         }
 


### PR DESCRIPTION
`fileDependencies` can contain directories and not just files which can cause incorrect cache invalidation on rebuilds.

Example
```
'/Users/***/tailwindcss-angular12-replica/src/app/component19/component19.component.scss',
'/Users/***/tailwindcss-angular12-replica/tailwind.config.js',
'/var/folders/mp/zsgl3srd389_js72bk4_bkgh0000gn/T/tmp-19814-FDsnpPo5zlQK',
'/Users/***/tailwindcss-angular12-replica/package.json',
'/Users/***/tailwindcss-angular12-replica/src/app/component19',
'/Users/***/tailwindcss-angular12-replica/src/app',
'/Users/***/tailwindcss-angular12-replica/src',
'/Users/***/tailwindcss-angular12-replica',
'/Users/***',
'/Users/****',
'/Users',
'/'
```

Closes #21228