### PR TITLE
build: use simplified stream construction in changelog script

### DIFF
--- a/package.json
+++ b/package.json
@@ -222,7 +222,6 @@
     "terser": "5.7.1",
     "terser-webpack-plugin": "5.1.4",
     "text-table": "0.2.0",
-    "through2": "^4.0.0",
     "tree-kill": "1.2.2",
     "ts-api-guardian": "0.6.0",
     "ts-node": "^10.0.0",


### PR DESCRIPTION
Node.js now provides simplified stream construction capabilities which removes the need for the `through2` dependency.
This change allows for the removal of the `through2` development dependency which was otherwise unused.

Probably easier to review with "Hide whitespace changes" enabled.