### PR TITLE
refactor(@angular-devkit/build-angular): use Webpack provided loader types

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/plugins/single-test-transform.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/plugins/single-test-transform.ts
@@ -7,7 +7,6 @@
  */
 
 import { logging, tags } from '@angular-devkit/core';
-import { getOptions } from 'loader-utils';
 import { extname } from 'path';
 
 export interface SingleTestTransformLoaderOptions {
@@ -32,8 +31,11 @@ export const SingleTestTransformLoader = __filename;
  * array to import them directly, and thus run the tests there.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export default function loader(this: any, source: string): string {
-  const { files = [], logger = console } = getOptions(this) as SingleTestTransformLoaderOptions;
+export default function loader(
+  this: import('webpack').LoaderContext<SingleTestTransformLoaderOptions>,
+  source: string,
+): string {
+  const { files = [], logger = console } = this.getOptions();
   // signal the user that expected content is not present.
   if (!source.includes('require.context(')) {
     logger.error(tags.stripIndent`The 'include' option requires that the 'main' file for tests includes the below line:


### PR DESCRIPTION
Webpack now provides loader function type definitions. These type definitions are now used in custom loaders within the package.
This improves type safety and behavior correctness of the loaders when used with Webpack.
The direct usage of the `loader-utils` package is also reduced as the Webpack 5 loader context now provides the `getOptions` function.