### PR TITLE
fix(@angular-devkit/build-angular): ensure `NG_PERSISTENT_BUILD_CACHE` always creates a cache in the specified cache directory

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
@@ -532,7 +532,7 @@ function getCacheSettings(
         .update(JSON.stringify(wco.tsConfig))
         .update(JSON.stringify(wco.buildOptions))
         .update(supportedBrowsers.join(''))
-        .digest('base64'),
+        .digest('hex'),
     };
   }
 


### PR DESCRIPTION
This change fixes `NG_PERSISTENT_BUILD_CACHE` sometimes creating cache entries that live outside of the cache directory by using a hex encoding rather than a base64 encoding. This error is caused because the base64 alphabet includes `/`. According to the webpack documentation [1] the default `cacheLocation` is: `path.resolve(cache.cacheDirectory, cache.name)` which means cache names with a leading `/` would remove the `cacheDirectory` altogether.

[1]: https://webpack.js.org/configuration/other-options/#cachecachelocation