### PR TITLE
fix(@angular-devkit/build-angular): exclude `outputPath` from persistent build cache key

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
@@ -507,7 +507,14 @@ function getCacheSettings(
         .update(packageVersion)
         .update(wco.projectRoot)
         .update(JSON.stringify(wco.tsConfig))
-        .update(JSON.stringify(wco.buildOptions))
+        .update(
+          JSON.stringify({
+            ...wco.buildOptions,
+            // Needed because outputPath changes on every build when using i18n extraction
+            // https://github.com/angular/angular-cli/blob/736a5f89deaca85f487b78aec9ff66d4118ceb6a/packages/angular_devkit/build_angular/src/utils/i18n-options.ts#L264-L265
+            outputPath: undefined,
+          }),
+        )
         .update(supportedBrowsers.join(''))
         .digest('hex'),
     };


### PR DESCRIPTION


With this change we exclude `outputPath` from cache key due to i18n extraction which causes it to change on every build https://github.com/angular/angular-cli/blob/736a5f89deaca85f487b78aec9ff66d4118ceb6a/packages/angular_devkit/build_angular/src/utils/i18n-options.ts#L264-L265

Closes #21275