### PR TITLE
fix(@schematics/angular): remove unsafe `any` usage in application spec file

### DIFF
--- a/packages/schematics/angular/application/other-files/app.component.spec.ts.template
+++ b/packages/schematics/angular/application/other-files/app.component.spec.ts.template
@@ -29,7 +29,7 @@ describe('AppComponent', () => {
   it('should render title', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
-    const compiled = fixture.nativeElement;
-    expect(compiled.querySelector('.content span').textContent).toContain('<%= name %> app is running!');
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.querySelector('.content span')?.textContent).toContain('<%= name %> app is running!');
   });
 });


### PR DESCRIPTION
The `nativeElement` property on a `TestBed` fixture is of type `any`. In one of the tests within a new application's spec file, the `nativeElement` is accessed but not cast to an appropriate type which results in potentially unsafe member access. The `nativeElement` is now cast as an `HTMLElement` and allows additional usage to be type checked.