### PR TITLE
feat(@schematics/angular): destroy test module after every test

### DIFF
--- a/packages/angular_devkit/build_angular/test/hello-world-app/src/test.ts
+++ b/packages/angular_devkit/build_angular/test/hello-world-app/src/test.ts
@@ -23,7 +23,11 @@ declare const require: {
 };
 
 // First, initialize the Angular testing environment.
-getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
+getTestBed().initTestEnvironment(
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting(),
+  { teardown: { destroyAfterEach: true }},
+);
 // Then we find all the tests.
 const context = require.context('./', true, /\.spec\.ts$/);
 // And load the modules.

--- a/packages/angular_devkit/build_angular/test/hello-world-lib/projects/lib/src/test.ts
+++ b/packages/angular_devkit/build_angular/test/hello-world-lib/projects/lib/src/test.ts
@@ -26,7 +26,8 @@ declare const require: {
 // First, initialize the Angular testing environment.
 getTestBed().initTestEnvironment(
   BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting()
+  platformBrowserDynamicTesting(),
+  { teardown: { destroyAfterEach: true }},
 );
 // Then we find all the tests.
 const context = require.context('./', true, /\.spec\.ts$/);

--- a/packages/schematics/angular/application/files/src/test.ts.template
+++ b/packages/schematics/angular/application/files/src/test.ts.template
@@ -17,8 +17,10 @@ declare const require: {
 // First, initialize the Angular testing environment.
 getTestBed().initTestEnvironment(
   BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting()
+  platformBrowserDynamicTesting(),
+  { teardown: { destroyAfterEach: true }},
 );
+
 // Then we find all the tests.
 const context = require.context('./', true, /\.spec\.ts$/);
 // And load the modules.

--- a/packages/schematics/angular/library/files/src/test.ts.template
+++ b/packages/schematics/angular/library/files/src/test.ts.template
@@ -18,8 +18,10 @@ declare const require: {
 // First, initialize the Angular testing environment.
 getTestBed().initTestEnvironment(
   BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting()
+  platformBrowserDynamicTesting(),
+  { teardown: { destroyAfterEach: true }},
 );
+
 // Then we find all the tests.
 const context = require.context('./', true, /\.spec\.ts$/);
 // And load the modules.


### PR DESCRIPTION
In version 12.1, the framework added the `destroyAfterEach` an opt-in feature that improves tests performance and also addresses two long-standing issues.

The idea, is to have this enabled by default in the future.  Related PR: https://github.com/angular/angular/pull/42566

Closes #21280