### PR TITLE
fix(@ngtools/webpack): avoid non-actionable template type-checker syntax diagnostics

### DIFF
--- a/packages/ngtools/webpack/src/ivy/plugin.ts
+++ b/packages/ngtools/webpack/src/ivy/plugin.ts
@@ -495,18 +495,18 @@ export class AngularWebpackPlugin {
       }
     }
 
-    // Collect non-semantic diagnostics
+    // Collect program level diagnostics
     const diagnostics = [
       ...angularCompiler.getOptionDiagnostics(),
       ...builder.getOptionsDiagnostics(),
       ...builder.getGlobalDiagnostics(),
-      ...builder.getSyntacticDiagnostics(),
     ];
     diagnosticsReporter(diagnostics);
 
-    // Collect semantic diagnostics
+    // Collect source file specific diagnostics
     for (const sourceFile of builder.getSourceFiles()) {
       if (!ignoreForDiagnostics.has(sourceFile)) {
+        diagnosticsReporter(builder.getSyntacticDiagnostics(sourceFile));
         diagnosticsReporter(builder.getSemanticDiagnostics(sourceFile));
       }
     }


### PR DESCRIPTION
The AOT compiler's internal template type-checking files are not intended to be directly analyzed for diagnostics by the emitting program and are instead analyzed during the template type-checking phase. Previously, only semantic diagnostics were ignored. Now both syntactic and semantic diagnostics are ignored. This change prevents non-actionable diagnostics from being shown during a build.

Addresses: https://github.com/angular/angular/issues/42667