### PR TITLE
fix(@angular-devkit/build-angular): limit advanced terser passes to two

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/plugins/javascript-optimizer-worker.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/plugins/javascript-optimizer-worker.ts
@@ -93,7 +93,7 @@ async function optimizeWithTerser(
     { [name]: code },
     {
       compress: {
-        passes: advanced ? 3 : 1,
+        passes: advanced ? 2 : 1,
         pure_getters: advanced,
       },
       ecma: target,


### PR DESCRIPTION
Limiting the terser passes to two helps to workaround an issue with terser wherein terser will errantly inline a function argument containing a `yield` expression inside an inner arrow function.  This results in a syntax error since the yield expression is no longer within the scope of a generator.
Reducing the number of terser passes to two does cause a minor increase in size as shown below.  However, the change is far less than 1% in both cases.

| File      | 2 passes (this PR) | 3 passes (master) | Change       |
| --------- | ----------------- | ----------------- | ------------ |
| main      | 3755283           | 3754440 (broken)  | 843 (~0.02%) |
| polyfills | 37207             | 37207             | 0            |
| runtime   | 1545              | 1545              | 0            |

| File      | 2 passes (this PR) | 3 passes (master) | Change       |
| --------- | ----------------- | ----------------- | ------------ |
| main      | 137466            | 137226            | 240 (~0.17%) |
| polyfills | 37100             | 37100             | 0            |
| runtime   | 1031              | 1031              | 0            |