### PR TITLE
fix(@angular-devkit/build-angular): display incompatibility errors

### DIFF
--- a/packages/angular_devkit/build_angular/src/browser/index.ts
+++ b/packages/angular_devkit/build_angular/src/browser/index.ts
@@ -171,7 +171,7 @@ export function buildWebpackBrowser(
   let outputPaths: undefined | Map<string, string>;
 
   // Check Angular version.
-  assertCompatibleAngularVersion(context.workspaceRoot, context.logger);
+  assertCompatibleAngularVersion(context.workspaceRoot);
 
   return from(context.getProjectMetadata(projectName)).pipe(
     switchMap(async (projectMetadata) => {

--- a/packages/angular_devkit/build_angular/src/dev-server/index.ts
+++ b/packages/angular_devkit/build_angular/src/dev-server/index.ts
@@ -112,7 +112,7 @@ export function serveWebpackBrowser(
 ): Observable<DevServerBuilderOutput> {
   // Check Angular version.
   const { logger, workspaceRoot } = context;
-  assertCompatibleAngularVersion(workspaceRoot, logger);
+  assertCompatibleAngularVersion(workspaceRoot);
 
   const browserTarget = targetFromTargetString(options.browserTarget);
 

--- a/packages/angular_devkit/build_angular/src/extract-i18n/index.ts
+++ b/packages/angular_devkit/build_angular/src/extract-i18n/index.ts
@@ -147,7 +147,7 @@ export async function execute(
   },
 ): Promise<BuildResult> {
   // Check Angular version.
-  assertCompatibleAngularVersion(context.workspaceRoot, context.logger);
+  assertCompatibleAngularVersion(context.workspaceRoot);
 
   const browserTarget = targetFromTargetString(options.browserTarget);
   const browserOptions = await context.validateOptions<JsonObject & BrowserBuilderOptions>(

--- a/packages/angular_devkit/build_angular/src/karma/index.ts
+++ b/packages/angular_devkit/build_angular/src/karma/index.ts
@@ -91,7 +91,7 @@ export function execute(
   } = {},
 ): Observable<BuilderOutput> {
   // Check Angular version.
-  assertCompatibleAngularVersion(context.workspaceRoot, context.logger);
+  assertCompatibleAngularVersion(context.workspaceRoot);
 
   let singleRun: boolean | undefined;
   if (options.watch !== undefined) {

--- a/packages/angular_devkit/build_angular/src/server/index.ts
+++ b/packages/angular_devkit/build_angular/src/server/index.ts
@@ -60,7 +60,7 @@ export function execute(
   const root = context.workspaceRoot;
 
   // Check Angular version.
-  assertCompatibleAngularVersion(root, context.logger);
+  assertCompatibleAngularVersion(root);
 
   const tsConfig = readTsconfig(options.tsConfig, root);
   const target = tsConfig.options.target || ScriptTarget.ES5;

--- a/packages/angular_devkit/build_angular/src/utils/version.ts
+++ b/packages/angular_devkit/build_angular/src/utils/version.ts
@@ -6,10 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { logging, tags } from '@angular-devkit/core';
-import { SemVer, gte, satisfies } from 'semver';
+/* eslint-disable no-console */
 
-export function assertCompatibleAngularVersion(projectRoot: string, logger: logging.LoggerApi) {
+import { tags } from '@angular-devkit/core';
+import { SemVer, satisfies } from 'semver';
+
+export function assertCompatibleAngularVersion(projectRoot: string): void | never {
   let angularCliPkgJson;
   let angularPkgJson;
   let rxjsPkgJson;
@@ -22,7 +24,7 @@ export function assertCompatibleAngularVersion(projectRoot: string, logger: logg
     angularPkgJson = require(angularPackagePath);
     rxjsPkgJson = require(rxjsPackagePath);
   } catch {
-    logger.error(tags.stripIndents`
+    console.error(tags.stripIndents`
       You seem to not be depending on "@angular/core" and/or "rxjs". This is an error.
     `);
 
@@ -30,7 +32,7 @@ export function assertCompatibleAngularVersion(projectRoot: string, logger: logg
   }
 
   if (!(angularPkgJson && angularPkgJson['version'] && rxjsPkgJson && rxjsPkgJson['version'])) {
-    logger.error(tags.stripIndents`
+    console.error(tags.stripIndents`
       Cannot determine versions of "@angular/core" and/or "rxjs".
       This likely means your local installation is broken. Please reinstall your packages.
     `);
@@ -63,7 +65,7 @@ export function assertCompatibleAngularVersion(projectRoot: string, logger: logg
   const supportedAngularSemver = `^${cliMajor}.0.0-next || >=${cliMajor}.0.0 <${cliMajor + 1}.0.0`;
 
   if (!satisfies(angularVersion, supportedAngularSemver, { includePrerelease: true })) {
-    logger.error(
+    console.error(
       tags.stripIndents`
         This version of CLI is only compatible with Angular versions ${supportedAngularSemver},
         but Angular version ${angularVersion} was found instead.


### PR DESCRIPTION
The logger API writes logs in an async fasion which previously caused messages not to be printed in the terminal when `process.exit` was invoked.

Closes #21322