### PR TITLE
refactor(@schematics/angular): use a helper function for basic generation schematics

### DIFF
--- a/packages/schematics/angular/class/index.ts
+++ b/packages/schematics/angular/class/index.ts
@@ -6,48 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { strings } from '@angular-devkit/core';
-import {
-  Rule,
-  Tree,
-  apply,
-  applyTemplates,
-  chain,
-  filter,
-  mergeWith,
-  move,
-  noop,
-  url,
-} from '@angular-devkit/schematics';
-import { applyLintFix } from '../utility/lint-fix';
-import { parseName } from '../utility/parse-name';
-import { createDefaultPath } from '../utility/workspace';
+import { Rule } from '@angular-devkit/schematics';
+import { generateFromFiles } from '../utility/generate-from-files';
 import { Schema as ClassOptions } from './schema';
 
 export default function (options: ClassOptions): Rule {
-  return async (host: Tree) => {
-    if (options.path === undefined) {
-      options.path = await createDefaultPath(host, options.project as string);
-    }
+  options.type = options.type ? `.${options.type}` : '';
 
-    options.type = options.type ? `.${options.type}` : '';
-
-    const parsedPath = parseName(options.path, options.name);
-    options.name = parsedPath.name;
-    options.path = parsedPath.path;
-
-    const templateSource = apply(url('./files'), [
-      options.skipTests ? filter((path) => !path.endsWith('.spec.ts.template')) : noop(),
-      applyTemplates({
-        ...strings,
-        ...options,
-      }),
-      move(parsedPath.path),
-    ]);
-
-    return chain([
-      mergeWith(templateSource),
-      options.lintFix ? applyLintFix(options.path) : noop(),
-    ]);
-  };
+  return generateFromFiles(options);
 }

--- a/packages/schematics/angular/enum/index.ts
+++ b/packages/schematics/angular/enum/index.ts
@@ -6,46 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { strings } from '@angular-devkit/core';
-import {
-  Rule,
-  Tree,
-  apply,
-  applyTemplates,
-  chain,
-  mergeWith,
-  move,
-  noop,
-  url,
-} from '@angular-devkit/schematics';
-import { applyLintFix } from '../utility/lint-fix';
-import { parseName } from '../utility/parse-name';
-import { createDefaultPath } from '../utility/workspace';
+import { Rule } from '@angular-devkit/schematics';
+import { generateFromFiles } from '../utility/generate-from-files';
 import { Schema as EnumOptions } from './schema';
 
 export default function (options: EnumOptions): Rule {
-  return async (host: Tree) => {
-    if (options.path === undefined) {
-      options.path = await createDefaultPath(host, options.project as string);
-    }
+  options.type = options.type ? `.${options.type}` : '';
 
-    const parsedPath = parseName(options.path, options.name);
-    options.name = parsedPath.name;
-    options.path = parsedPath.path;
-
-    options.type = options.type ? `.${options.type}` : '';
-
-    const templateSource = apply(url('./files'), [
-      applyTemplates({
-        ...strings,
-        ...options,
-      }),
-      move(parsedPath.path),
-    ]);
-
-    return chain([
-      mergeWith(templateSource),
-      options.lintFix ? applyLintFix(options.path) : noop(),
-    ]);
-  };
+  return generateFromFiles(options);
 }

--- a/packages/schematics/angular/guard/index.ts
+++ b/packages/schematics/angular/guard/index.ts
@@ -6,72 +6,37 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { strings } from '@angular-devkit/core';
-import {
-  Rule,
-  SchematicsException,
-  Tree,
-  apply,
-  applyTemplates,
-  chain,
-  filter,
-  mergeWith,
-  move,
-  noop,
-  url,
-} from '@angular-devkit/schematics';
-import { applyLintFix } from '../utility/lint-fix';
-import { parseName } from '../utility/parse-name';
-import { createDefaultPath } from '../utility/workspace';
+import { Rule, SchematicsException } from '@angular-devkit/schematics';
+import { generateFromFiles } from '../utility/generate-from-files';
 import { Implement as GuardInterface, Schema as GuardOptions } from './schema';
 
 export default function (options: GuardOptions): Rule {
-  return async (host: Tree) => {
-    if (options.path === undefined) {
-      options.path = await createDefaultPath(host, options.project as string);
-    }
+  if (!options.implements) {
+    throw new SchematicsException('Option "implements" is required.');
+  }
 
-    if (!options.implements) {
-      throw new SchematicsException('Option "implements" is required.');
-    }
+  const implementations = options.implements
+    .map((implement) => (implement === 'CanDeactivate' ? 'CanDeactivate<unknown>' : implement))
+    .join(', ');
+  const commonRouterNameImports = ['ActivatedRouteSnapshot', 'RouterStateSnapshot'];
+  const routerNamedImports: string[] = [...options.implements, 'UrlTree'];
 
-    const implementations = options.implements
-      .map((implement) => (implement === 'CanDeactivate' ? 'CanDeactivate<unknown>' : implement))
-      .join(', ');
-    const commonRouterNameImports = ['ActivatedRouteSnapshot', 'RouterStateSnapshot'];
-    const routerNamedImports: string[] = [...options.implements, 'UrlTree'];
+  if (options.implements.includes(GuardInterface.CanLoad)) {
+    routerNamedImports.push('Route', 'UrlSegment');
 
-    if (options.implements.includes(GuardInterface.CanLoad)) {
-      routerNamedImports.push('Route', 'UrlSegment');
-
-      if (options.implements.length > 1) {
-        routerNamedImports.push(...commonRouterNameImports);
-      }
-    } else {
+    if (options.implements.length > 1) {
       routerNamedImports.push(...commonRouterNameImports);
     }
+  } else {
+    routerNamedImports.push(...commonRouterNameImports);
+  }
 
-    routerNamedImports.sort();
+  routerNamedImports.sort();
 
-    const implementationImports = routerNamedImports.join(', ');
-    const parsedPath = parseName(options.path, options.name);
-    options.name = parsedPath.name;
-    options.path = parsedPath.path;
+  const implementationImports = routerNamedImports.join(', ');
 
-    const templateSource = apply(url('./files'), [
-      options.skipTests ? filter((path) => !path.endsWith('.spec.ts.template')) : noop(),
-      applyTemplates({
-        implementations,
-        implementationImports,
-        ...strings,
-        ...options,
-      }),
-      move(parsedPath.path + (options.flat ? '' : '/' + strings.dasherize(options.name))),
-    ]);
-
-    return chain([
-      mergeWith(templateSource),
-      options.lintFix ? applyLintFix(options.path) : noop(),
-    ]);
-  };
+  return generateFromFiles(options, {
+    implementations,
+    implementationImports,
+  });
 }

--- a/packages/schematics/angular/interceptor/index.ts
+++ b/packages/schematics/angular/interceptor/index.ts
@@ -6,47 +6,16 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { strings } from '@angular-devkit/core';
-import {
-  Rule,
-  Tree,
-  apply,
-  applyTemplates,
-  chain,
-  filter,
-  mergeWith,
-  move,
-  noop,
-  url,
-} from '@angular-devkit/schematics';
-import { applyLintFix } from '../utility/lint-fix';
-import { parseName } from '../utility/parse-name';
-import { createDefaultPath } from '../utility/workspace';
+import { Rule } from '@angular-devkit/schematics';
+import { generateFromFiles } from '../utility/generate-from-files';
 import { Schema as InterceptorOptions } from './schema';
 
 export default function (options: InterceptorOptions): Rule {
-  return async (host: Tree) => {
-    if (options.path === undefined) {
-      options.path = await createDefaultPath(host, options.project as string);
-    }
+  // This schematic uses an older method to implement the flat option
+  const flat = options.flat;
+  options.flat = true;
 
-    const parsedPath = parseName(options.path, options.name);
-    options.name = parsedPath.name;
-    options.path = parsedPath.path;
-
-    const templateSource = apply(url('./files'), [
-      options.skipTests ? filter((path) => !path.endsWith('.spec.ts.template')) : noop(),
-      applyTemplates({
-        ...strings,
-        'if-flat': (s: string) => (options.flat ? '' : s),
-        ...options,
-      }),
-      move(parsedPath.path),
-    ]);
-
-    return chain([
-      mergeWith(templateSource),
-      options.lintFix ? applyLintFix(options.path) : noop(),
-    ]);
-  };
+  return generateFromFiles(options, {
+    'if-flat': (s: string) => (flat ? '' : s),
+  });
 }

--- a/packages/schematics/angular/interface/index.ts
+++ b/packages/schematics/angular/interface/index.ts
@@ -6,47 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { strings } from '@angular-devkit/core';
-import {
-  Rule,
-  Tree,
-  apply,
-  applyTemplates,
-  chain,
-  mergeWith,
-  move,
-  noop,
-  url,
-} from '@angular-devkit/schematics';
-import { applyLintFix } from '../utility/lint-fix';
-import { parseName } from '../utility/parse-name';
-import { createDefaultPath } from '../utility/workspace';
+import { Rule } from '@angular-devkit/schematics';
+import { generateFromFiles } from '../utility/generate-from-files';
 import { Schema as InterfaceOptions } from './schema';
 
 export default function (options: InterfaceOptions): Rule {
-  return async (host: Tree) => {
-    if (options.path === undefined) {
-      options.path = await createDefaultPath(host, options.project as string);
-    }
+  options.type = options.type ? `.${options.type}` : '';
 
-    const parsedPath = parseName(options.path, options.name);
-    options.name = parsedPath.name;
-    options.path = parsedPath.path;
-
-    options.prefix = options.prefix ? options.prefix : '';
-    options.type = options.type ? `.${options.type}` : '';
-
-    const templateSource = apply(url('./files'), [
-      applyTemplates({
-        ...strings,
-        ...options,
-      }),
-      move(parsedPath.path),
-    ]);
-
-    return chain([
-      mergeWith(templateSource),
-      options.lintFix ? applyLintFix(options.path) : noop(),
-    ]);
-  };
+  return generateFromFiles(options);
 }

--- a/packages/schematics/angular/resolver/index.ts
+++ b/packages/schematics/angular/resolver/index.ts
@@ -6,42 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { strings } from '@angular-devkit/core';
-import {
-  Rule,
-  Tree,
-  apply,
-  applyTemplates,
-  chain,
-  filter,
-  mergeWith,
-  move,
-  noop,
-  url,
-} from '@angular-devkit/schematics';
-import { parseName } from '../utility/parse-name';
-import { createDefaultPath } from '../utility/workspace';
+import { Rule } from '@angular-devkit/schematics';
+import { generateFromFiles } from '../utility/generate-from-files';
 import { Schema } from './schema';
 
 export default function (options: Schema): Rule {
-  return async (host: Tree) => {
-    if (options.path === undefined) {
-      options.path = await createDefaultPath(host, options.project as string);
-    }
-
-    const parsedPath = parseName(options.path, options.name);
-    options.name = parsedPath.name;
-    options.path = parsedPath.path;
-
-    const templateSource = apply(url('./files'), [
-      options.skipTests ? filter((path) => !path.endsWith('.spec.ts.template')) : noop(),
-      applyTemplates({
-        ...strings,
-        ...options,
-      }),
-      move(parsedPath.path + (options.flat ? '' : '/' + strings.dasherize(options.name))),
-    ]);
-
-    return chain([mergeWith(templateSource)]);
-  };
+  return generateFromFiles(options);
 }

--- a/packages/schematics/angular/service/index.ts
+++ b/packages/schematics/angular/service/index.ts
@@ -6,47 +6,16 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { strings } from '@angular-devkit/core';
-import {
-  Rule,
-  Tree,
-  apply,
-  applyTemplates,
-  chain,
-  filter,
-  mergeWith,
-  move,
-  noop,
-  url,
-} from '@angular-devkit/schematics';
-import { applyLintFix } from '../utility/lint-fix';
-import { parseName } from '../utility/parse-name';
-import { createDefaultPath } from '../utility/workspace';
+import { Rule } from '@angular-devkit/schematics';
+import { generateFromFiles } from '../utility/generate-from-files';
 import { Schema as ServiceOptions } from './schema';
 
 export default function (options: ServiceOptions): Rule {
-  return async (host: Tree) => {
-    if (options.path === undefined) {
-      options.path = await createDefaultPath(host, options.project as string);
-    }
+  // This schematic uses an older method to implement the flat option
+  const flat = options.flat;
+  options.flat = true;
 
-    const parsedPath = parseName(options.path, options.name);
-    options.name = parsedPath.name;
-    options.path = parsedPath.path;
-
-    const templateSource = apply(url('./files'), [
-      options.skipTests ? filter((path) => !path.endsWith('.spec.ts.template')) : noop(),
-      applyTemplates({
-        ...strings,
-        'if-flat': (s: string) => (options.flat ? '' : s),
-        ...options,
-      }),
-      move(parsedPath.path),
-    ]);
-
-    return chain([
-      mergeWith(templateSource),
-      options.lintFix ? applyLintFix(options.path) : noop(),
-    ]);
-  };
+  return generateFromFiles(options, {
+    'if-flat': (s: string) => (flat ? '' : s),
+  });
 }

--- a/packages/schematics/angular/utility/generate-from-files.ts
+++ b/packages/schematics/angular/utility/generate-from-files.ts
@@ -1,0 +1,64 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { strings } from '@angular-devkit/core';
+import {
+  Rule,
+  Tree,
+  apply,
+  applyTemplates,
+  chain,
+  filter,
+  mergeWith,
+  move,
+  noop,
+  url,
+} from '@angular-devkit/schematics';
+import { applyLintFix } from './lint-fix';
+import { parseName } from './parse-name';
+import { createDefaultPath } from './workspace';
+
+export interface GenerateFromFilesOptions {
+  flat?: boolean;
+  lintFix?: boolean;
+  name: string;
+  path?: string;
+  prefix?: string;
+  project?: string;
+  skipTests?: boolean;
+}
+
+export function generateFromFiles(
+  options: GenerateFromFilesOptions,
+  extraTemplateValues: Record<string, string | ((v: string) => string)> = {},
+): Rule {
+  return async (host: Tree) => {
+    options.path ??= await createDefaultPath(host, options.project as string);
+    options.prefix ??= '';
+    options.flat ??= true;
+
+    const parsedPath = parseName(options.path, options.name);
+    options.name = parsedPath.name;
+    options.path = parsedPath.path;
+
+    const templateSource = apply(url('./files'), [
+      options.skipTests ? filter((path) => !path.endsWith('.spec.ts.template')) : noop(),
+      applyTemplates({
+        ...strings,
+        ...options,
+        ...extraTemplateValues,
+      }),
+      move(parsedPath.path + (options.flat ? '' : '/' + strings.dasherize(options.name))),
+    ]);
+
+    return chain([
+      mergeWith(templateSource),
+      options.lintFix ? applyLintFix(options.path) : noop(),
+    ]);
+  };
+}


### PR DESCRIPTION
An internal schematics helper rule has been introduced for Angular schematics that only generate a set of project files from a set of templated files. Multiple current generation schematics contained essentially the same code which increased the sustainment burden and made refactoring and improvements more complicated.