### PR TITLE
build: provide build artifact location directories instead of tar files

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -404,7 +404,7 @@ export default async function (
     if (!pkg.private) {
       tarLogger.info(`${pkgName} => ${pkg.tar}`);
       _tar(pkg.tar, pkg.dist);
-      output.push({ name: pkgName, outputPath: pkg.tar });
+      output.push({ name: pkgName, outputPath: pkg.dist });
     }
   });
 


### PR DESCRIPTION
Provide the location of the directories rather than the tar files as the
release tooling inspects the package.json fiels to confirm the correct
version being published.