### PR TITLE
refactor(@ngtools/webpack): avoid exposing internal types in public API

### DIFF
--- a/packages/ngtools/webpack/src/ivy/loader.ts
+++ b/packages/ngtools/webpack/src/ivy/loader.ts
@@ -7,21 +7,18 @@
  */
 
 import * as path from 'path';
+import type { LoaderContext } from 'webpack';
 import { AngularPluginSymbol, FileEmitterCollection } from './symbol';
 
-export function angularWebpackLoader(
-  this: import('webpack').LoaderContext<unknown> & {
-    [AngularPluginSymbol]?: FileEmitterCollection;
-  },
-  content: string,
-  map: string,
-) {
+export function angularWebpackLoader(this: LoaderContext<unknown>, content: string, map: string) {
   const callback = this.async();
   if (!callback) {
     throw new Error('Invalid webpack version');
   }
 
-  const fileEmitter = this[AngularPluginSymbol];
+  const fileEmitter = (
+    this as LoaderContext<unknown> & { [AngularPluginSymbol]?: FileEmitterCollection }
+  )[AngularPluginSymbol];
   if (!fileEmitter || typeof fileEmitter !== 'object') {
     if (this.resourcePath.endsWith('.js')) {
       // Passthrough for JS files when no plugin is used


### PR DESCRIPTION
The `AngularPluginSymbol` and `FileEmitterCollection` types are not intended to be exported for use within the public API of the package.