### PR TITLE
fix(@angular-devkit/build-angular): dasherize disable-host-check suggestion

### DIFF
--- a/packages/angular_devkit/build_angular/src/dev-server/index.ts
+++ b/packages/angular_devkit/build_angular/src/dev-server/index.ts
@@ -175,7 +175,7 @@ export function serveWebpackBrowser(
 
         Binding this server to an open connection can result in compromising your application or
         computer. Using a different host than the one passed to the "--host" flag might result in
-        websocket connection issues. You might need to use "--disableHostCheck" if that's the
+        websocket connection issues. You might need to use "--disable-host-check" if that's the
         case.
       `);
     }


### PR DESCRIPTION
Camel case arguments have been deprecated and therefore shouldn't be suggested.