### PR TITLE
build: update renovate to update @angular/dev-infra-private as target: patch

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,8 +21,14 @@
   "packageRules": [
     {
       "packagePatterns": ["^@angular/.*"],
+      "excludePackageNames": ["@angular/dev-infra-private"],
       "groupName": "angular",
       "pinVersions": false
+    },
+    {
+      "matchPackageNames": ["@angular/dev-infra-private"],
+      "groupName": "dev-infra",
+      "labels": ["action: merge", "target: patch"]
     },
     {
       "packagePatterns": ["^@babel/.*"],


### PR DESCRIPTION
Updating the @angular/dev-infra-private packages should be done on all active
development branches.