### PR TITLE
build: migrate from deprecated `logs` verdaccio option

### DIFF
--- a/tests/legacy-cli/verdaccio.yaml
+++ b/tests/legacy-cli/verdaccio.yaml
@@ -42,7 +42,9 @@ packages:
     proxy: npmjs
 
 logs:
-  - { type: stdout, format: pretty, level: warn }
+  type: stdout
+  format: pretty
+  level: warn
 
 # https://github.com/verdaccio/verdaccio/issues/301
 server:

--- a/tests/legacy-cli/verdaccio_auth.yaml
+++ b/tests/legacy-cli/verdaccio_auth.yaml
@@ -17,12 +17,17 @@ uplinks:
       keepAlive: true
       maxSockets: 32
       maxFreeSockets: 8
+
 packages:
   '**':
     access: $authenticated
     proxy: local
+
 logs:
-  - { type: stdout, format: pretty, level: http }
+  type: stdout
+  format: pretty
+  level: warn
+
 # https://github.com/verdaccio/verdaccio/issues/301
 server:
   keepAliveTimeout: 0


### PR DESCRIPTION
See: https://verdaccio.org/blog/