### PR TITLE
refactor(@schematics/angular): automatically determine the version string to match latest Angular

### DIFF
--- a/packages/schematics/angular/utility/latest-versions.ts
+++ b/packages/schematics/angular/utility/latest-versions.ts
@@ -6,6 +6,18 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+/** Retrieve the minor version for the provided version string. */
+function getEarliestMinorVersion(version: string) {
+  const versionMatching = version.match(/^(\d+)\.(\d+)\.*/);
+
+  if (versionMatching === null) {
+    throw Error('Unable to determine the minor version for the provided version');
+  }
+  const [_, major, minor] = versionMatching;
+
+  return `${major}.${minor}.0`;
+}
+
 export const latestVersions: Record<string, string> & {
   Angular: string;
   DevkitBuildAngular: string;
@@ -14,8 +26,10 @@ export const latestVersions: Record<string, string> & {
   // but ts_library doesn't support JSON inputs.
   ...require('./latest-versions/package.json')['dependencies'],
 
-  // These versions should be kept up to date with latest Angular peer dependencies.
-  Angular: '~12.2.0-next.2',
+  // As Angular CLI works with same minor versions of Angular Framework, a tilde match for the current
+  // Angular CLI minor version with earliest prerelease (appended with `-`) will match the latest
+  // Angular Framework minor.
+  Angular: `~${getEarliestMinorVersion(require('../package.json')['version'])}-`,
 
   // Since @angular-devkit/build-angular and @schematics/angular are always
   // published together from the same monorepo, and they are both


### PR DESCRIPTION
Automatically determine the latest compatible Angular Framework version by using `~` matching for the current minor version of @schematics/angular.