### PR TITLE
ci: exclude angular packages from all-minor-patch

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -65,6 +65,7 @@
         "!packages/angular_devkit/schematics_cli/schematic/files/package.json",
         "!packages/schematics/angular/utility/latest-versions/package.json"
       ],
+      "excludePackagePatterns": ["^@angular/.*"],
       "matchPackagePatterns": ["*"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "all non-major dependencies",


### PR DESCRIPTION
With this change we restore the behaviour that Angular packages are updated via a separate PR.