### PR TITLE
refactor(@ngtools/webpack): remove usage of `enhanced-resolve` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,7 +148,6 @@
     "css-loader": "6.2.0",
     "css-minimizer-webpack-plugin": "3.0.2",
     "debug": "^4.1.1",
-    "enhanced-resolve": "5.8.2",
     "esbuild": "0.12.16",
     "eslint": "7.31.0",
     "eslint-config-prettier": "8.3.0",

--- a/packages/ngtools/webpack/BUILD.bazel
+++ b/packages/ngtools/webpack/BUILD.bazel
@@ -38,7 +38,6 @@ ts_library(
     deps = [
         "@npm//@angular/compiler-cli",
         "@npm//@types/node",
-        "@npm//enhanced-resolve",
         "@npm//typescript",
         "@npm//webpack",
     ],

--- a/packages/ngtools/webpack/package.json
+++ b/packages/ngtools/webpack/package.json
@@ -20,9 +20,7 @@
     "url": "https://github.com/angular/angular-cli/issues"
   },
   "homepage": "https://github.com/angular/angular-cli/tree/master/packages/@ngtools/webpack",
-  "dependencies": {
-    "enhanced-resolve": "5.8.2"
-  },
+  "dependencies": {},
   "peerDependencies": {
     "@angular/compiler-cli": "^12.0.0 || ^12.2.0-next",
     "typescript": "~4.2.3 || ~4.3.2",

--- a/packages/ngtools/webpack/src/ngcc_processor.ts
+++ b/packages/ngtools/webpack/src/ngcc_processor.ts
@@ -9,12 +9,15 @@
 import { LogLevel, Logger, process as mainNgcc } from '@angular/compiler-cli/ngcc';
 import { spawnSync } from 'child_process';
 import { createHash } from 'crypto';
-import { Resolver } from 'enhanced-resolve';
 import { accessSync, constants, existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import * as path from 'path';
 import * as ts from 'typescript';
+import type { Compiler } from 'webpack';
 import { time, timeEnd } from './benchmark';
 import { InputFileSystem } from './ivy/system';
+
+// Extract Resolver type from Webpack types since it is not directly exported
+type ResolverWithOptions = ReturnType<Compiler['resolverFactory']['get']>;
 
 // We cannot create a plugin for this, because NGTSC requires addition type
 // information which ngcc creates when processing a package which was compiled with NGC.
@@ -38,7 +41,7 @@ export class NgccProcessor {
     private readonly basePath: string,
     private readonly tsConfigPath: string,
     private readonly inputFileSystem: InputFileSystem,
-    private readonly resolver: Resolver,
+    private readonly resolver: ResolverWithOptions,
   ) {
     this._logger = new NgccLogger(this.compilationWarnings, this.compilationErrors);
     this._nodeModulesDirectory = this.findNodeModulesDirectory(this.basePath);

--- a/packages/ngtools/webpack/src/paths-plugin.ts
+++ b/packages/ngtools/webpack/src/paths-plugin.ts
@@ -8,11 +8,13 @@
 
 import * as path from 'path';
 import { CompilerOptions, MapLike } from 'typescript';
-
-const getInnerRequest = require('enhanced-resolve/lib/getInnerRequest');
+import type { Configuration } from 'webpack';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface TypeScriptPathsPluginOptions extends Pick<CompilerOptions, 'paths' | 'baseUrl'> {}
+
+// Extract Resolver type from Webpack types since it is not directly exported
+type Resolver = Exclude<Exclude<Configuration['resolve'], undefined>['resolver'], undefined>;
 
 export class TypeScriptPathsPlugin {
   constructor(private options?: TypeScriptPathsPluginOptions) {}
@@ -21,8 +23,7 @@ export class TypeScriptPathsPlugin {
     this.options = options;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  apply(resolver: import('enhanced-resolve').Resolver) {
+  apply(resolver: Resolver): void {
     const target = resolver.ensureHook('resolve');
 
     resolver.getHook('described-resolve').tapAsync(
@@ -41,7 +42,7 @@ export class TypeScriptPathsPlugin {
           return;
         }
 
-        const originalRequest = getInnerRequest(resolver, request);
+        const originalRequest = request.request || request.path;
         if (!originalRequest) {
           callback();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -94,7 +94,6 @@
 
 "@angular/dev-infra-private@https://github.com/angular/dev-infra-private-builds.git#5fa832317b3d2ca4f743079c7b3ae747c375db31":
   version "0.0.0"
-  uid "5fa832317b3d2ca4f743079c7b3ae747c375db31"
   resolved "https://github.com/angular/dev-infra-private-builds.git#5fa832317b3d2ca4f743079c7b3ae747c375db31"
   dependencies:
     "@angular/benchpress" "0.2.1"
@@ -4473,7 +4472,7 @@ engine.io@~4.1.0:
     engine.io-parser "~4.0.0"
     ws "~7.4.2"
 
-enhanced-resolve@5.8.2, enhanced-resolve@^5.8.0:
+enhanced-resolve@^5.8.0:
   version "5.8.2"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.8.2.tgz#15ddc779345cbb73e97c611cd00c01c1e7bf4d8b"
   integrity sha512-F27oB3WuHDzvR2DOGNTaYy0D5o0cnrv8TeI482VM4kYgQd/FT9lUQwuNsJ0oOHtBUq7eiW5ytqzp7nBFknL+GA==
@@ -9942,7 +9941,6 @@ sass@1.36.0, sass@^1.32.8:
 
 "sauce-connect-proxy@https://saucelabs.com/downloads/sc-4.6.4-linux.tar.gz":
   version "0.0.0"
-  uid "992e2cb0d91e54b27a4f5bbd2049f3b774718115"
   resolved "https://saucelabs.com/downloads/sc-4.6.4-linux.tar.gz#992e2cb0d91e54b27a4f5bbd2049f3b774718115"
 
 saucelabs@^1.5.0:


### PR DESCRIPTION
The types used from the `enhanced-resolve` package are available from the `webpack` package and the `getInnerRequest` helper function used in the TypeScript paths resolver plugin is not actually needed.  Webpack's `AliasPlugin` which has similar behavior also does not use the `getInnerRequest` helper function.