### PR TITLE
fix(@angular-devkit/build-webpack): emit result when webpack is closed

### DIFF
--- a/packages/angular_devkit/build_angular/src/app-shell/index.ts
+++ b/packages/angular_devkit/build_angular/src/app-shell/index.ts
@@ -180,10 +180,9 @@ async function _appShellBuilder(
   let spinner: Spinner | undefined;
 
   try {
-    // Using `.result` instead of `.output` causes Webpack FS cache not to be created.
     const [browserResult, serverResult] = await Promise.all([
-      browserTargetRun.output.toPromise() as Promise<BrowserBuilderOutput>,
-      serverTargetRun.output.toPromise() as Promise<ServerBuilderOutput>,
+      browserTargetRun.result as Promise<BrowserBuilderOutput>,
+      serverTargetRun.result as Promise<ServerBuilderOutput>,
     ]);
 
     if (browserResult.success === false || browserResult.baseOutputPath === undefined) {
@@ -203,8 +202,7 @@ async function _appShellBuilder(
 
     return { success: false, error: err.message };
   } finally {
-    // workaround for [tsetse] All Promises in async functions must either be awaited or used in an expression.
-    const _ = Promise.all([browserTargetRun.stop(), serverTargetRun.stop()]);
+    await Promise.all([browserTargetRun.stop(), serverTargetRun.stop()]);
   }
 }
 

--- a/packages/angular_devkit/build_webpack/src/webpack/index.ts
+++ b/packages/angular_devkit/build_webpack/src/webpack/index.ts
@@ -72,16 +72,20 @@ export function runWebpack(
             log(stats, config);
 
             const statsOptions = typeof config.stats === 'boolean' ? undefined : config.stats;
-
-            obs.next({
+            const result = {
               success: !stats.hasErrors(),
               webpackStats: shouldProvideStats ? stats.toJson(statsOptions) : undefined,
               emittedFiles: getEmittedFiles(stats.compilation),
               outputPath: stats.compilation.outputOptions.path,
-            } as unknown as BuildResult);
+            } as unknown as BuildResult;
 
-            if (!config.watch) {
-              webpackCompiler.close(() => obs.complete());
+            if (config.watch) {
+              obs.next(result);
+            } else {
+              webpackCompiler.close(() => {
+                obs.next(result);
+                obs.complete();
+              });
             }
           };
 


### PR DESCRIPTION
With this change we emit the compilation result when the compilation is closed, when the compilation is not in watch mode.

This is needed so that when persistent caching is enabled and architect promise API is used (`.result`) instead of `.output` we wait for the cache to be written prior to terminating the process/resolving the result promise.

The `result` API currently, takes the first emit https://github.com/angular/angular-cli/blob/4f9df9f4a4da81c9ecd8733204226c030f8f7d56/packages/angular_devkit/architect/src/schedule-by-name.ts#L118-L120

Closes #21419