### PR TITLE
fix(@schematics/angular): ensure valid SemVer range for new project Angular packages

### DIFF
--- a/packages/schematics/angular/utility/latest-versions.ts
+++ b/packages/schematics/angular/utility/latest-versions.ts
@@ -26,9 +26,8 @@ export const latestVersions = {
   TsLib: '^2.2.0',
 
   // As Angular CLI works with same minor versions of Angular Framework, a tilde match for the current
-  // Angular CLI minor version with earliest prerelease (appended with `-`) will match the latest
-  // Angular Framework minor.
-  Angular: `~${getEarliestMinorVersion(require('../package.json')['version'])}-`,
+  // Angular CLI minor version will match the latest Angular Framework minor.
+  Angular: `~${getEarliestMinorVersion(require('../package.json')['version'])}`,
 
   // Since @angular-devkit/build-angular and @schematics/angular are always
   // published together from the same monorepo, and they are both


### PR DESCRIPTION
While npm supports a package specifier with a trailing dash, the trailing dash is technically not SemVer compliant and fails with Yarn 2+.
The 12.1.x branch will not have another prerelease which allows the prelease specifiers to be ignored in this case.