### PR TITLE
ci: disable major updates for rxjs and tslib

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -35,12 +35,17 @@
       "pinVersions": false
     },
     {
-      "packageNames": ["typescript"],
+      "packageNames": ["typescript", "rxjs", "tslib"],
       "separateMinorPatch": true
     },
     {
+      "packageNames": ["typescript", "rxjs", "tslib"],
+      "updateTypes": ["major"],
+      "enabled": false
+    },
+    {
       "packageNames": ["typescript"],
-      "updateTypes": ["minor", "major"],
+      "updateTypes": ["minor"],
       "enabled": false
     },
     {


### PR DESCRIPTION
With this change we update renovate configuration to disallow major update for rxjs and tslib