### PR TITLE
Update next branch to reflect new release-train "v12.3.0-next.0".

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+<a name="12.2.0-rc.0"></a>
+# 12.2.0-rc.0 (2021-07-28)
+### @angular/cli
+| Commit | Description |
+| -- | -- |
+| [259e26979](https://github.com/angular/angular-cli/commit/259e26979ebc712ee08fd36fb68a9576c1e02447) | fix(@angular/cli): merge npmrc files values |
+### @angular-devkit/build-angular
+| Commit | Description |
+| -- | -- |
+| [d750c686f](https://github.com/angular/angular-cli/commit/d750c686fd26f3ccfccb039027bd816a91279497) | fix(@angular-devkit/build-angular): add priority to copy-webpack-plugin patterns |
+### @angular-devkit/build-webpack
+| Commit | Description |
+| -- | -- |
+| [615353022](https://github.com/angular/angular-cli/commit/61535302204a2a767f85053b7efaa6ac5ac64098) | fix(@angular-devkit/build-webpack): emit result when webpack is closed |
+## Special Thanks:
+Alan Agius, Charles Lyding, Joey Perrott and originalfrostig
+
+
 <a name="12.1.4"></a>
 # 12.1.4 (2021-07-28)
 ### @angular/cli

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@angular/devkit-repo",
-  "version": "12.2.0-next.3",
+  "version": "12.3.0-next.0",
   "private": true,
   "description": "Software Development Kit for Angular",
   "bin": {


### PR DESCRIPTION
The previous "next" release-train has moved into the release-candidate phase. This PR updates the next branch to the subsequent release-train.

Also this PR cherry-picks the changelog for v12.2.0-rc.0 into the master branch so that the changelog is up to date.