### PR TITLE
refactor(@schematics/angular): hard code version of Angular in latest-versions

### DIFF
--- a/packages/schematics/angular/utility/latest-versions.ts
+++ b/packages/schematics/angular/utility/latest-versions.ts
@@ -6,18 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-/** Retrieve the minor version for the provided version string. */
-function getAngularEarliestMinorVersion(version: string): string {
-  const versionMatching = version.match(/^(\d+)\.(\d+)\.\d+(-\w+)?/);
-
-  if (versionMatching === null) {
-    throw Error('Unable to determine the minor version for the provided version');
-  }
-  const [_, major, minor, prerelease = ''] = versionMatching;
-
-  return `~${major}.${minor}.0${prerelease}`;
-}
-
 export const latestVersions: Record<string, string> & {
   Angular: string;
   DevkitBuildAngular: string;
@@ -27,7 +15,7 @@ export const latestVersions: Record<string, string> & {
   ...require('./latest-versions/package.json')['dependencies'],
 
   // As Angular CLI works with same minor versions of Angular Framework, a tilde match for the current
-  Angular: getAngularEarliestMinorVersion(require('../package.json')['version']),
+  Angular: '~12.2.0-rc.0',
 
   // Since @angular-devkit/build-angular and @schematics/angular are always
   // published together from the same monorepo, and they are both


### PR DESCRIPTION
Update the version of Angular in latest-versions as `13.0.0-next.0` is not on npm.