### PR TITLE
fix(@angular-devkit/build-angular): calculate valid Angular versions from peerDependencies

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/version.ts
+++ b/packages/angular_devkit/build_angular/src/utils/version.ts
@@ -58,11 +58,9 @@ export function assertCompatibleAngularVersion(projectRoot: string): void | neve
     return;
   }
 
+  const supportedAngularSemver =
+    require('../../package.json')['peerDependencies']['@angular/compiler-cli'];
   const angularVersion = new SemVer(angularPkgJson['version']);
-  const cliMajor = new SemVer(angularCliPkgJson['version']).major;
-  // e.g. CLI 8.0 supports '>=8.0.0 <9.0.0', including pre-releases (next, rcs, snapshots)
-  // of both 8 and 9.
-  const supportedAngularSemver = `^${cliMajor}.0.0-next || >=${cliMajor}.0.0 <${cliMajor + 1}.0.0`;
 
   if (!satisfies(angularVersion, supportedAngularSemver, { includePrerelease: true })) {
     console.error(


### PR DESCRIPTION


With this change we update the `assertCompatibleAngularVersion` logic to use `peerDependencies` on `@angular/compiler-cli` listed in the `package.json` to determine if the installed Angular version is supported or not.

This is a fix for:
https://github.com/angular/angular-cli/pull/21449
https://circleci.com/gh/angular/angular-cli/259835?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link