### PR TITLE
refactor(@angular-devkit/build-angular): remove unused code in webpack configuration partials

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/browser.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/browser.ts
@@ -6,9 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { ScriptTarget } from 'typescript';
 import * as webpack from 'webpack';
-import { BuildBrowserFeatures } from '../../utils';
 import { WebpackConfigOptions } from '../../utils/build-options';
 import { CommonJsUsageWarnPlugin } from '../plugins';
 import { getSourceMapDevTool } from '../utils/helpers';
@@ -18,7 +16,6 @@ export function getBrowserConfig(wco: WebpackConfigOptions): webpack.Configurati
   const {
     crossOrigin = 'none',
     subresourceIntegrity,
-    extractLicenses,
     vendorChunk,
     commonChunk,
     allowedCommonJsDependencies,
@@ -58,8 +55,6 @@ export function getBrowserConfig(wco: WebpackConfigOptions): webpack.Configurati
   } else if (crossOrigin !== 'none') {
     crossOriginLoading = crossOrigin;
   }
-
-  const buildBrowserFeatures = new BuildBrowserFeatures(wco.projectRoot);
 
   return {
     devtool: false,

--- a/packages/angular_devkit/build_angular/src/webpack/configs/worker.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/worker.ts
@@ -12,19 +12,13 @@ import { WebpackConfigOptions } from '../../utils/build-options';
 import { getTypescriptWorkerPlugin } from './typescript';
 
 export function getWorkerConfig(wco: WebpackConfigOptions): Configuration {
-  const { buildOptions } = wco;
+  const { webWorkerTsConfig } = wco.buildOptions;
 
-  if (!buildOptions.webWorkerTsConfig) {
+  if (!webWorkerTsConfig) {
     return {};
   }
 
-  if (typeof buildOptions.webWorkerTsConfig != 'string') {
-    throw new Error('The `webWorkerTsConfig` must be a string.');
-  }
-
-  const workerTsConfigPath = resolve(wco.root, buildOptions.webWorkerTsConfig);
-
   return {
-    plugins: [getTypescriptWorkerPlugin(wco, workerTsConfigPath)],
+    plugins: [getTypescriptWorkerPlugin(wco, resolve(wco.root, webWorkerTsConfig))],
   };
 }


### PR DESCRIPTION
Several unused imports and variables as well as redundant conditional checks were removed from the Webpack configuration partials.