### PR TITLE
build: add missing `breakingChangeLabel`

### DIFF
--- a/.ng-dev/merge.ts
+++ b/.ng-dev/merge.ts
@@ -14,6 +14,7 @@ export const merge: DevInfraMergeConfig['merge'] = async (api) => {
       labels: [{ pattern: 'squash commits', method: 'squash' }],
     },
     claSignedLabel: 'cla: yes',
+    breakingChangeLabel: 'flag: breaking change',
     mergeReadyLabel: /^action: merge(-assistance)?/,
     caretakerNoteLabel: /(action: merge-assistance)/,
     commitMessageFixupLabel: 'commit message fixup',


### PR DESCRIPTION
Currently, we are unable to merge breaking changes, because the label doesn't match the default value set in https://github.com/angular/angular/blob/1684b70b8830684deae4bae20c1e12aeddc4e1df/dev-infra/pr/merge/pull-request.ts#L23