### PR TITLE
feat(@angular-devkit/build-angular): add `type=module` to all scripts tags

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/index.ts
@@ -172,13 +172,12 @@ export function buildWebpackBrowser(
 
       return {
         ...(await initialize(options, context, transforms.webpackConfiguration)),
-        buildBrowserFeatures,
         target,
       };
     }),
     switchMap(
       // eslint-disable-next-line max-lines-per-function
-      ({ config, projectRoot, projectSourceRoot, i18n, buildBrowserFeatures, target }) => {
+      ({ config, projectRoot, projectSourceRoot, i18n, target }) => {
         const normalizedOptimization = normalizeOptimization(options.optimization);
 
         return runWebpack(config, context, {
@@ -191,7 +190,6 @@ export function buildWebpackBrowser(
               }
             }),
         }).pipe(
-          // eslint-disable-next-line max-lines-per-function
           concatMap(async (buildEvent) => {
             const spinner = new Spinner();
             spinner.enabled = options.progress !== false;
@@ -226,8 +224,6 @@ export function buildWebpackBrowser(
               return { success };
             } else {
               outputPaths = ensureOutputPaths(baseOutputPath, i18n);
-
-              let moduleFiles: EmittedFiles[] | undefined;
 
               const scriptsEntryPointName = normalizeExtraEntryPoints(
                 options.scripts || [],
@@ -320,8 +316,6 @@ export function buildWebpackBrowser(
                         lang: locale || undefined,
                         outputPath,
                         files: mapEmittedFilesToFileInfo(emittedFiles),
-                        noModuleFiles: [],
-                        moduleFiles: mapEmittedFilesToFileInfo(moduleFiles),
                       });
 
                       if (warnings.length || errors.length) {

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/cross-origin_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/cross-origin_spec.ts
@@ -39,10 +39,10 @@ describe('Browser Builder crossOrigin', () => {
     expect(content).toBe(
       `<html><head><base href="/"><link rel="stylesheet" href="styles.css" crossorigin="use-credentials"></head>` +
         `<body><app-root></app-root>` +
-        `<script src="runtime.js" crossorigin="use-credentials" defer></script>` +
-        `<script src="polyfills.js" crossorigin="use-credentials" defer></script>` +
-        `<script src="vendor.js" crossorigin="use-credentials" defer></script>` +
-        `<script src="main.js" crossorigin="use-credentials" defer></script></body></html>`,
+        `<script src="runtime.js" type="module" crossorigin="use-credentials"></script>` +
+        `<script src="polyfills.js" type="module" crossorigin="use-credentials"></script>` +
+        `<script src="vendor.js" type="module" crossorigin="use-credentials"></script>` +
+        `<script src="main.js" type="module" crossorigin="use-credentials"></script></body></html>`,
     );
     await run.stop();
   });
@@ -58,10 +58,10 @@ describe('Browser Builder crossOrigin', () => {
       `<html><head><base href="/">` +
         `<link rel="stylesheet" href="styles.css" crossorigin="anonymous"></head>` +
         `<body><app-root></app-root>` +
-        `<script src="runtime.js" crossorigin="anonymous" defer></script>` +
-        `<script src="polyfills.js" crossorigin="anonymous" defer></script>` +
-        `<script src="vendor.js" crossorigin="anonymous" defer></script>` +
-        `<script src="main.js" crossorigin="anonymous" defer></script></body></html>`,
+        `<script src="runtime.js" type="module" crossorigin="anonymous"></script>` +
+        `<script src="polyfills.js" type="module" crossorigin="anonymous"></script>` +
+        `<script src="vendor.js" type="module" crossorigin="anonymous"></script>` +
+        `<script src="main.js" type="module" crossorigin="anonymous"></script></body></html>`,
     );
     await run.stop();
   });
@@ -77,10 +77,10 @@ describe('Browser Builder crossOrigin', () => {
       `<html><head><base href="/">` +
         `<link rel="stylesheet" href="styles.css"></head>` +
         `<body><app-root></app-root>` +
-        `<script src="runtime.js" defer></script>` +
-        `<script src="polyfills.js" defer></script>` +
-        `<script src="vendor.js" defer></script>` +
-        `<script src="main.js" defer></script></body></html>`,
+        `<script src="runtime.js" type="module"></script>` +
+        `<script src="polyfills.js" type="module"></script>` +
+        `<script src="vendor.js" type="module"></script>` +
+        `<script src="main.js" type="module"></script></body></html>`,
     );
     await run.stop();
   });

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/index_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/index_spec.ts
@@ -36,9 +36,9 @@ describe('Browser Builder index HTML processing', () => {
     const content = virtualFs.fileBufferToString(await host.read(normalize(fileName)).toPromise());
     expect(content).toBe(
       `<html><head><base href="/"><link rel="stylesheet" href="styles.css"></head>` +
-        `<body><app-root></app-root><script src="runtime.js" defer></script>` +
-        `<script src="polyfills.js" defer></script>` +
-        `<script src="vendor.js" defer></script><script src="main.js" defer></script></body></html>`,
+        `<body><app-root></app-root><script src="runtime.js" type="module"></script>` +
+        `<script src="polyfills.js" type="module"></script>` +
+        `<script src="vendor.js" type="module"></script><script src="main.js" type="module"></script></body></html>`,
     );
     await run.stop();
   });
@@ -60,9 +60,9 @@ describe('Browser Builder index HTML processing', () => {
     expect(content).toBe(
       `<html><head><base href="/"><link rel="stylesheet" href="styles.css"></head>` +
         `<body><app-root></app-root>` +
-        `<script src="runtime.js" defer></script><script src="polyfills.js" defer></script>` +
-        `<script src="vendor.js" defer></script>` +
-        `<script src="main.js" defer></script></body></html>`,
+        `<script src="runtime.js" type="module"></script><script src="polyfills.js" type="module"></script>` +
+        `<script src="vendor.js" type="module"></script>` +
+        `<script src="main.js" type="module"></script></body></html>`,
     );
     await run.stop();
   });
@@ -82,9 +82,9 @@ describe('Browser Builder index HTML processing', () => {
     const content = virtualFs.fileBufferToString(await host.read(normalize(fileName)).toPromise());
     expect(content).toBe(
       `<html><head><title>&iacute;</title><base href="/"><link rel="stylesheet" href="styles.css"></head> ` +
-        `<body><app-root></app-root><script src="runtime.js" defer></script>` +
-        `<script src="polyfills.js" defer></script>` +
-        `<script src="vendor.js" defer></script><script src="main.js" defer></script></body></html>`,
+        `<body><app-root></app-root><script src="runtime.js" type="module"></script>` +
+        `<script src="polyfills.js" type="module"></script>` +
+        `<script src="vendor.js" type="module"></script><script src="main.js" type="module"></script></body></html>`,
     );
     await run.stop();
   });
@@ -104,9 +104,9 @@ describe('Browser Builder index HTML processing', () => {
     const content = virtualFs.fileBufferToString(await host.read(normalize(fileName)).toPromise());
     expect(content).toBe(
       `<html><head><base href="/"><%= csrf_meta_tags %><link rel="stylesheet" href="styles.css"></head> ` +
-        `<body><app-root></app-root><script src="runtime.js" defer></script>` +
-        `<script src="polyfills.js" defer></script>` +
-        `<script src="vendor.js" defer></script><script src="main.js" defer></script></body></html>`,
+        `<body><app-root></app-root><script src="runtime.js" type="module"></script>` +
+        `<script src="polyfills.js" type="module"></script>` +
+        `<script src="vendor.js" type="module"></script><script src="main.js" type="module"></script></body></html>`,
     );
     await run.stop();
   });
@@ -152,9 +152,9 @@ describe('Browser Builder index HTML processing', () => {
     const content = await host.read(normalize(outputIndexPath)).toPromise();
     expect(virtualFs.fileBufferToString(content)).toBe(
       `<html><head><base href="/"><%= csrf_meta_tags %><link rel="stylesheet" href="styles.css"></head> ` +
-        `<body><app-root></app-root><script src="runtime.js" defer></script>` +
-        `<script src="polyfills.js" defer></script>` +
-        `<script src="vendor.js" defer></script><script src="main.js" defer></script></body></html>`,
+        `<body><app-root></app-root><script src="runtime.js" type="module"></script>` +
+        `<script src="polyfills.js" type="module"></script>` +
+        `<script src="vendor.js" type="module"></script><script src="main.js" type="module"></script></body></html>`,
     );
   });
 
@@ -198,9 +198,9 @@ describe('Browser Builder index HTML processing', () => {
     const content = await host.read(normalize(outputIndexPath)).toPromise();
     expect(virtualFs.fileBufferToString(content)).toBe(
       `<html><head><base href="/"><link rel="stylesheet" href="styles.css"></head> ` +
-        `<body><app-root></app-root><script src="runtime.js" defer></script>` +
-        `<script src="polyfills.js" defer></script>` +
-        `<script src="vendor.js" defer></script><script src="main.js" defer></script></body></html>`,
+        `<body><app-root></app-root><script src="runtime.js" type="module"></script>` +
+        `<script src="polyfills.js" type="module"></script>` +
+        `<script src="vendor.js" type="module"></script><script src="main.js" type="module"></script></body></html>`,
     );
   });
 
@@ -244,9 +244,9 @@ describe('Browser Builder index HTML processing', () => {
     const content = await host.read(normalize(outputIndexPath)).toPromise();
     expect(virtualFs.fileBufferToString(content)).toBe(
       `<html><head><base href="/"><link rel="stylesheet" href="styles.css"></head> ` +
-        `<body><app-root></app-root><script src="runtime.js" defer></script>` +
-        `<script src="polyfills.js" defer></script>` +
-        `<script src="vendor.js" defer></script><script src="main.js" defer></script></body></html>`,
+        `<body><app-root></app-root><script src="runtime.js" type="module"></script>` +
+        `<script src="polyfills.js" type="module"></script>` +
+        `<script src="vendor.js" type="module"></script><script src="main.js" type="module"></script></body></html>`,
     );
   });
 });

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/scripts-array_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/scripts-array_spec.ts
@@ -53,12 +53,12 @@ describe('Browser Builder scripts array', () => {
       'renamed-lazy-script.js': 'pre-rename-lazy-script',
       'main.js': 'input-script',
       'index.html':
-        '<script src="runtime.js" defer></script>' +
-        '<script src="polyfills.js" defer></script>' +
+        '<script src="runtime.js" type="module"></script>' +
+        '<script src="polyfills.js" type="module"></script>' +
         '<script src="scripts.js" defer></script>' +
         '<script src="renamed-script.js" defer></script>' +
-        '<script src="vendor.js" defer></script>' +
-        '<script src="main.js" defer></script>',
+        '<script src="vendor.js" type="module"></script>' +
+        '<script src="main.js" type="module"></script>',
     };
 
     host.writeMultipleFiles(scripts);

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/service-worker_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/service-worker_spec.ts
@@ -105,7 +105,7 @@ describe('Browser Builder service worker', () => {
         hashTable: {
           '/favicon.ico': '84161b857f5c547e3699ddfbffc6d8d737542e01',
           '/assets/folder-asset.txt': '617f202968a6a81050aa617c2e28e1dca11ce8d4',
-          '/index.html': 'f0bea8ced1dfbeeb771a5f48651fbcff52a625eb',
+          '/index.html': '8964a35a8b850942f8d18ba919f248762ff3154d',
           '/spectrum.png': '8d048ece46c0f3af4b598a95fd8e4709b631c3c0',
         },
       }),
@@ -222,7 +222,7 @@ describe('Browser Builder service worker', () => {
         hashTable: {
           '/foo/bar/favicon.ico': '84161b857f5c547e3699ddfbffc6d8d737542e01',
           '/foo/bar/assets/folder-asset.txt': '617f202968a6a81050aa617c2e28e1dca11ce8d4',
-          '/foo/bar/index.html': 'f6650ac91428c6933dfe4c24079b3b15400da1ba',
+          '/foo/bar/index.html': '5c99755c1e7cfd1c8aba34ad1155afc72a288fec',
         },
       }),
     );

--- a/packages/angular_devkit/build_angular/src/utils/index-file/augment-index-html.ts
+++ b/packages/angular_devkit/build_angular/src/utils/index-file/augment-index-html.ts
@@ -13,6 +13,8 @@ export type LoadOutputFileFunctionType = (file: string) => Promise<string>;
 
 export type CrossOriginValue = 'none' | 'anonymous' | 'use-credentials';
 
+export type Entrypoint = [name: string, isModule: boolean];
+
 export interface AugmentIndexHtmlOptions {
   /* Input contents */
   html: string;
@@ -23,13 +25,8 @@ export interface AugmentIndexHtmlOptions {
   crossOrigin?: CrossOriginValue;
   /*
    * Files emitted by the build.
-   * Js files will be added without 'nomodule' nor 'module'.
    */
   files: FileInfo[];
-  /** Files that should be added using 'nomodule'. */
-  noModuleFiles?: FileInfo[];
-  /** Files that should be added using 'module'. */
-  moduleFiles?: FileInfo[];
   /*
    * Function that loads a file used.
    * This allows us to use different routines within the IndexHtmlWebpackPlugin and
@@ -37,7 +34,7 @@ export interface AugmentIndexHtmlOptions {
    */
   loadOutputFile: LoadOutputFileFunctionType;
   /** Used to sort the inseration of files in the HTML file */
-  entrypoints: string[];
+  entrypoints: Entrypoint[];
   /** Used to set the document default locale */
   lang?: string;
 }
@@ -47,7 +44,6 @@ export interface FileInfo {
   name: string;
   extension: string;
 }
-
 /*
  * Helper function used by the IndexHtmlWebpackPlugin.
  * Can also be directly used by builder, e. g. in order to generate an index.html
@@ -55,18 +51,7 @@ export interface FileInfo {
  * bundles for differential serving.
  */
 export async function augmentIndexHtml(params: AugmentIndexHtmlOptions): Promise<string> {
-  const {
-    loadOutputFile,
-    files,
-    noModuleFiles = [],
-    moduleFiles = [],
-    entrypoints,
-    sri,
-    deployUrl = '',
-    lang,
-    baseHref,
-    html,
-  } = params;
+  const { loadOutputFile, files, entrypoints, sri, deployUrl = '', lang, baseHref, html } = params;
 
   let { crossOrigin = 'none' } = params;
   if (sri && crossOrigin === 'none') {
@@ -74,19 +59,19 @@ export async function augmentIndexHtml(params: AugmentIndexHtmlOptions): Promise
   }
 
   const stylesheets = new Set<string>();
-  const scripts = new Set<string>();
+  const scripts = new Map</** file name */ string, /** isModule */ boolean>();
 
-  // Sort files in the order we want to insert them by entrypoint and dedupes duplicates
-  const mergedFiles = [...moduleFiles, ...noModuleFiles, ...files];
-  for (const entrypoint of entrypoints) {
-    for (const { extension, file, name } of mergedFiles) {
-      if (name !== entrypoint) {
+  // Sort files in the order we want to insert them by entrypoint
+  for (const [entrypoint, isModule] of entrypoints) {
+    for (const { extension, file, name } of files) {
+      if (name !== entrypoint || scripts.has(file) || stylesheets.has(file)) {
         continue;
       }
 
       switch (extension) {
         case '.js':
-          scripts.add(file);
+          // Also, non entrypoints need to be loaded as no module as they can contain problematic code.
+          scripts.set(file, isModule);
           break;
         case '.css':
           stylesheets.add(file);
@@ -96,36 +81,22 @@ export async function augmentIndexHtml(params: AugmentIndexHtmlOptions): Promise
   }
 
   let scriptTags: string[] = [];
-  for (const script of scripts) {
-    const attrs = [`src="${deployUrl}${script}"`];
+  for (const [src, isModule] of scripts) {
+    const attrs = [`src="${deployUrl}${src}"`];
+
+    // This is also need for non entry-points as they may contain problematic code.
+    if (isModule) {
+      attrs.push('type="module"');
+    } else {
+      attrs.push('defer');
+    }
 
     if (crossOrigin !== 'none') {
       attrs.push(`crossorigin="${crossOrigin}"`);
     }
 
-    // We want to include nomodule or module when a file is not common amongs all
-    // such as runtime.js
-    const scriptPredictor = ({ file }: FileInfo): boolean => file === script;
-    if (!files.some(scriptPredictor)) {
-      // in some cases for differential loading file with the same name is available in both
-      // nomodule and module such as scripts.js
-      // we shall not add these attributes if that's the case
-      const isNoModuleType = noModuleFiles.some(scriptPredictor);
-      const isModuleType = moduleFiles.some(scriptPredictor);
-
-      if (isNoModuleType && !isModuleType) {
-        attrs.push('nomodule', 'defer');
-      } else if (isModuleType && !isNoModuleType) {
-        attrs.push('type="module"');
-      } else {
-        attrs.push('defer');
-      }
-    } else {
-      attrs.push('defer');
-    }
-
     if (sri) {
-      const content = await loadOutputFile(script);
+      const content = await loadOutputFile(src);
       attrs.push(generateSriAttributes(content));
     }
 
@@ -133,15 +104,15 @@ export async function augmentIndexHtml(params: AugmentIndexHtmlOptions): Promise
   }
 
   let linkTags: string[] = [];
-  for (const stylesheet of stylesheets) {
-    const attrs = [`rel="stylesheet"`, `href="${deployUrl}${stylesheet}"`];
+  for (const src of stylesheets) {
+    const attrs = [`rel="stylesheet"`, `href="${deployUrl}${src}"`];
 
     if (crossOrigin !== 'none') {
       attrs.push(`crossorigin="${crossOrigin}"`);
     }
 
     if (sri) {
-      const content = await loadOutputFile(stylesheet);
+      const content = await loadOutputFile(src);
       attrs.push(generateSriAttributes(content));
     }
 

--- a/packages/angular_devkit/build_angular/src/utils/index-file/augment-index-html_spec.ts
+++ b/packages/angular_devkit/build_angular/src/utils/index-file/augment-index-html_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import { tags } from '@angular-devkit/core';
-import { AugmentIndexHtmlOptions, FileInfo, augmentIndexHtml } from './augment-index-html';
+import { AugmentIndexHtmlOptions, augmentIndexHtml } from './augment-index-html';
 
 describe('augment-index-html', () => {
   const indexGeneratorOptions: AugmentIndexHtmlOptions = {
@@ -16,7 +16,12 @@ describe('augment-index-html', () => {
     sri: false,
     files: [],
     loadOutputFile: async (_fileName: string) => '',
-    entrypoints: ['scripts', 'polyfills', 'main', 'styles'],
+    entrypoints: [
+      ['scripts', false],
+      ['polyfills', true],
+      ['main', true],
+      ['styles', false],
+    ],
   };
 
   const oneLineHtml = (html: TemplateStringsArray) =>
@@ -41,9 +46,9 @@ describe('augment-index-html', () => {
           <link rel="stylesheet" href="styles.css">
         </head>
         <body>
-          <script src="runtime.js" defer></script>
-          <script src="polyfills.js" defer></script>
-          <script src="main.js" defer></script>
+          <script src="runtime.js" type="module"></script>
+          <script src="polyfills.js" type="module"></script>
+          <script src="main.js" type="module"></script>
         </body>
       </html>
     `);
@@ -62,87 +67,6 @@ describe('augment-index-html', () => {
         <head><base href="/Apps/">
       </head>
         <body>
-        </body>
-      </html>
-    `);
-  });
-
-  it(`should emit correct script tags when having 'module' and 'non-module' js`, async () => {
-    const es2017JsFiles: FileInfo[] = [
-      { file: 'runtime-es2017.js', extension: '.js', name: 'main' },
-      { file: 'main-es2017.js', extension: '.js', name: 'main' },
-      { file: 'runtime-es2017.js', extension: '.js', name: 'polyfills' },
-      { file: 'polyfills-es2017.js', extension: '.js', name: 'polyfills' },
-    ];
-
-    const es5JsFiles: FileInfo[] = [
-      { file: 'runtime-es5.js', extension: '.js', name: 'main' },
-      { file: 'main-es5.js', extension: '.js', name: 'main' },
-      { file: 'runtime-es5.js', extension: '.js', name: 'polyfills' },
-      { file: 'polyfills-es5.js', extension: '.js', name: 'polyfills' },
-    ];
-
-    const source = augmentIndexHtml({
-      ...indexGeneratorOptions,
-      files: [
-        { file: 'styles.css', extension: '.css', name: 'styles' },
-        { file: 'styles.css', extension: '.css', name: 'styles' },
-      ],
-      moduleFiles: es2017JsFiles,
-      noModuleFiles: es5JsFiles,
-    });
-
-    const html = await source;
-    expect(html).toEqual(oneLineHtml`
-      <html>
-        <head>
-          <base href="/">
-          <link rel="stylesheet" href="styles.css">
-        </head>
-        <body>
-          <script src="runtime-es2017.js" type="module"></script>
-          <script src="polyfills-es2017.js" type="module"></script>
-          <script src="runtime-es5.js" nomodule defer></script>
-          <script src="polyfills-es5.js" nomodule defer></script>
-          <script src="main-es2017.js" type="module"></script>
-          <script src="main-es5.js" nomodule defer></script>
-        </body>
-      </html>
-    `);
-  });
-
-  it(`should not add 'module' and 'non-module' attr to js files which are in both module formats`, async () => {
-    const es2017JsFiles: FileInfo[] = [
-      { file: 'scripts.js', extension: '.js', name: 'scripts' },
-      { file: 'main-es2017.js', extension: '.js', name: 'main' },
-    ];
-
-    const es5JsFiles: FileInfo[] = [
-      { file: 'scripts.js', extension: '.js', name: 'scripts' },
-      { file: 'main-es5.js', extension: '.js', name: 'main' },
-    ];
-
-    const source = augmentIndexHtml({
-      ...indexGeneratorOptions,
-      files: [
-        { file: 'styles.css', extension: '.css', name: 'styles' },
-        { file: 'styles.css', extension: '.css', name: 'styles' },
-      ],
-      moduleFiles: es2017JsFiles,
-      noModuleFiles: es5JsFiles,
-    });
-
-    const html = await source;
-    expect(html).toEqual(oneLineHtml`
-      <html>
-        <head>
-          <base href="/">
-          <link rel="stylesheet" href="styles.css">
-        </head>
-        <body>
-          <script src="scripts.js" defer></script>
-          <script src="main-es2017.js" type="module"></script>
-          <script src="main-es5.js" nomodule defer></script>
         </body>
       </html>
     `);
@@ -182,9 +106,9 @@ describe('augment-index-html', () => {
     const html = await source;
     expect(html).toEqual(oneLineHtml`
       <link rel="stylesheet" href="styles.css">
-      <script src="runtime.js" defer></script>
-      <script src="polyfills.js" defer></script>
-      <script src="main.js" defer></script>
+      <script src="runtime.js" type="module"></script>
+      <script src="polyfills.js" type="module"></script>
+      <script src="main.js" type="module"></script>
       <app-root></app-root>
     `);
   });

--- a/packages/angular_devkit/build_angular/src/utils/index-file/index-html-generator.ts
+++ b/packages/angular_devkit/build_angular/src/utils/index-file/index-html-generator.ts
@@ -10,7 +10,7 @@ import * as fs from 'fs';
 import { join } from 'path';
 import { NormalizedOptimizationOptions } from '../normalize-optimization';
 import { stripBom } from '../strip-bom';
-import { CrossOriginValue, FileInfo, augmentIndexHtml } from './augment-index-html';
+import { CrossOriginValue, Entrypoint, FileInfo, augmentIndexHtml } from './augment-index-html';
 import { InlineCriticalCssProcessor } from './inline-critical-css';
 import { InlineFontsProcessor } from './inline-fonts';
 
@@ -24,15 +24,13 @@ export interface IndexHtmlGeneratorProcessOptions {
   baseHref: string | undefined;
   outputPath: string;
   files: FileInfo[];
-  noModuleFiles: FileInfo[];
-  moduleFiles: FileInfo[];
 }
 
 export interface IndexHtmlGeneratorOptions {
   indexPath: string;
   deployUrl?: string;
   sri?: boolean;
-  entrypoints: string[];
+  entrypoints: Entrypoint[];
   postTransform?: IndexHtmlTransform;
   crossOrigin?: CrossOriginValue;
   optimization?: NormalizedOptimizationOptions;
@@ -104,7 +102,7 @@ function augmentIndexHtmlPlugin(generator: IndexHtmlGenerator): IndexHtmlGenerat
   const { deployUrl, crossOrigin, sri = false, entrypoints } = generator.options;
 
   return async (html, options) => {
-    const { lang, baseHref, outputPath = '', noModuleFiles, files, moduleFiles } = options;
+    const { lang, baseHref, outputPath = '', files } = options;
 
     return augmentIndexHtml({
       html,
@@ -115,8 +113,6 @@ function augmentIndexHtmlPlugin(generator: IndexHtmlGenerator): IndexHtmlGenerat
       lang,
       entrypoints,
       loadOutputFile: (filePath) => generator.readAsset(join(outputPath, filePath)),
-      noModuleFiles,
-      moduleFiles,
       files,
     });
   };

--- a/packages/angular_devkit/build_angular/src/webpack/configs/browser.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/browser.ts
@@ -59,6 +59,7 @@ export function getBrowserConfig(wco: WebpackConfigOptions): webpack.Configurati
     output: {
       crossOriginLoading,
       trustedTypes: 'angular#bundler',
+      scriptType: 'module',
     },
     optimization: {
       runtimeChunk: 'single',

--- a/tests/legacy-cli/e2e/tests/basic/scripts-array.ts
+++ b/tests/legacy-cli/e2e/tests/basic/scripts-array.ts
@@ -54,12 +54,12 @@ export default async function () {
   await expectFileToMatch(
     'dist/test-project/index.html',
     oneLineTrim`
-    <script src="runtime.js" defer></script>
-    <script src="polyfills.js" defer></script>
+    <script src="runtime.js" type="module"></script>
+    <script src="polyfills.js" type="module"></script>
     <script src="scripts.js" defer></script>
     <script src="renamed-script.js" defer></script>
-    <script src="vendor.js" defer></script>
-    <script src="main.js" defer></script>
+    <script src="vendor.js" type="module"></script>
+    <script src="main.js" type="module"></script>
   `,
   );
 }

--- a/tests/legacy-cli/e2e/tests/build/polyfills.ts
+++ b/tests/legacy-cli/e2e/tests/build/polyfills.ts
@@ -14,7 +14,10 @@ export default async function () {
   // files were created successfully
   await expectFileToMatch('dist/test-project/polyfills.js', 'core-js/proposals/reflect-metadata');
   await expectFileToMatch('dist/test-project/polyfills.js', 'zone.js');
-  await expectFileToMatch('dist/test-project/index.html', '<script src="polyfills.js" defer>');
+  await expectFileToMatch(
+    'dist/test-project/index.html',
+    '<script src="polyfills.js" type="module">',
+  );
   const jitPolyfillSize = await getFileSize('dist/test-project/polyfills.js');
 
   await ng('build', '--aot=true', '--configuration=development');
@@ -26,5 +29,8 @@ export default async function () {
     expectFileToMatch('dist/test-project/polyfills.js', 'core-js/proposals/reflect-metadata'),
   );
   await expectFileToMatch('dist/test-project/polyfills.js', 'zone.js');
-  await expectFileToMatch('dist/test-project/index.html', '<script src="polyfills.js" defer>');
+  await expectFileToMatch(
+    'dist/test-project/index.html',
+    '<script src="polyfills.js" type="module">',
+  );
 }

--- a/tests/legacy-cli/e2e/tests/third-party/bootstrap.ts
+++ b/tests/legacy-cli/e2e/tests/third-party/bootstrap.ts
@@ -36,7 +36,6 @@ export default function () {
         'build',
         '--configuration=development',
         '--optimization',
-
         '--output-hashing=none',
         '--vendor-chunk=false',
       ),


### PR DESCRIPTION

With this change we add `type=module` to all script tags. This is now possible since IE is no longer supported.

More information about modules can be found here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules