### PR TITLE
ci: disable lockFileMaintenance for `all-schematics-dependencies` group

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -56,7 +56,8 @@
       ],
       "matchPackagePatterns": ["*"],
       "groupName": "schematics dependencies",
-      "groupSlug": "all-schematics-dependencies"
+      "groupSlug": "all-schematics-dependencies",
+      "lockFileMaintenance": { "enabled": false }
     },
     {
       "matchPaths": [


### PR DESCRIPTION
This should avoid Renovate creating redudant PRs such as https://github.com/angular/angular-cli/pull/21480