### PR TITLE
fix(@angular-devkit/schematics-cli): log when in debug and/or dry run modes

### DIFF
--- a/packages/angular_devkit/schematics_cli/bin/schematics.ts
+++ b/packages/angular_devkit/schematics_cli/bin/schematics.ts
@@ -107,6 +107,7 @@ function _createPromptProvider(): schema.PromptProvider {
   };
 }
 
+// eslint-disable-next-line max-lines-per-function
 export async function main({
   args,
   stdout = process.stdout,
@@ -141,8 +142,10 @@ export async function main({
   const isLocalCollection = collectionName.startsWith('.') || collectionName.startsWith('/');
 
   /** Gather the arguments for later use. */
-  const debug: boolean = argv.debug === null ? isLocalCollection : argv.debug;
-  const dryRun: boolean = argv['dry-run'] === null ? debug : argv['dry-run'];
+  const debugPresent = argv['debug'] !== null;
+  const debug = debugPresent ? !!argv['debug'] : isLocalCollection;
+  const dryRunPresent = argv['dry-run'] !== null;
+  const dryRun = dryRunPresent ? !!argv['dry-run'] : debug;
   const force = argv['force'];
   const allowPrivate = argv['allow-private'];
 
@@ -163,6 +166,12 @@ export async function main({
     logger.info(getUsage());
 
     return 1;
+  }
+
+  if (debug) {
+    logger.info(
+      `Debug mode enabled${isLocalCollection ? ' by default for local collections' : ''}.`,
+    );
   }
 
   // Indicate to the user when nothing has been done. This is automatically set to off when there's
@@ -285,6 +294,12 @@ export async function main({
 
     if (nothingDone) {
       logger.info('Nothing to be done.');
+    } else if (dryRun) {
+      logger.info(
+        `Dry run enabled${
+          dryRunPresent ? '' : ' by default in debug mode'
+        }. No files written to disk.`,
+      );
     }
 
     return 0;

--- a/packages/angular_devkit/schematics_cli/bin/schematics_spec.ts
+++ b/packages/angular_devkit/schematics_cli/bin/schematics_spec.ts
@@ -50,16 +50,19 @@ describe('schematics-cli binary', () => {
     expect(stdout.lines).toMatch(/CREATE foo\/.gitignore/);
     expect(stdout.lines).toMatch(/CREATE foo\/src\/foo\/index.ts/);
     expect(stdout.lines).toMatch(/CREATE foo\/src\/foo\/index_spec.ts/);
+    expect(stdout.lines).toMatch(/Dry run enabled./);
     expect(res).toEqual(0);
   });
 
   it('dry-run is default when debug mode', async () => {
     const args = ['blank', 'foo', '--debug'];
     const res = await main({ args, stdout, stderr });
+    expect(stdout.lines).toMatch(/Debug mode enabled./);
     expect(stdout.lines).toMatch(/CREATE foo\/README.md/);
     expect(stdout.lines).toMatch(/CREATE foo\/.gitignore/);
     expect(stdout.lines).toMatch(/CREATE foo\/src\/foo\/index.ts/);
     expect(stdout.lines).toMatch(/CREATE foo\/src\/foo\/index_spec.ts/);
+    expect(stdout.lines).toMatch(/Dry run enabled by default in debug mode./);
     expect(res).toEqual(0);
   });
 


### PR DESCRIPTION
When using the schematics-cli with a local collection, the debug mode is enabled by default. Debug mode also enables dry run mode by default. This can result in a confusing situation when developing a schematic locally as files will not be written to disk but no messages are present explaining why. To improve the developer experience, messages will now be shown both when debug mode is enabled and when dry run is enabled. If either is enabled by default the reason will also be shown.