### PR TITLE
Update Angular peer dependency ranges to v13 prerelease

### DIFF
--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -76,11 +76,11 @@
     "webpack-subresource-integrity": "1.5.2"
   },
   "peerDependencies": {
-    "@angular/compiler-cli": "^12.0.0 || ^12.2.0-next",
-    "@angular/localize": "^12.0.0 || ^12.2.0-next",
-    "@angular/service-worker": "^12.0.0 || ^12.2.0-next",
+    "@angular/compiler-cli": "^13.0.0 || ^13.0.0-next",
+    "@angular/localize": "^13.0.0 || ^13.0.0-next",
+    "@angular/service-worker": "^13.0.0 || ^13.0.0-next",
     "karma": "^6.3.0",
-    "ng-packagr": "^12.0.0 || ^12.1.0-next",
+    "ng-packagr": "^12.0.0",
     "protractor": "^7.0.0",
     "tailwindcss": "^2.0.0",
     "typescript": "~4.2.3 || ~4.3.2"

--- a/packages/ngtools/webpack/package.json
+++ b/packages/ngtools/webpack/package.json
@@ -22,7 +22,7 @@
   "homepage": "https://github.com/angular/angular-cli/tree/master/packages/@ngtools/webpack",
   "dependencies": {},
   "peerDependencies": {
-    "@angular/compiler-cli": "^12.0.0 || ^12.2.0-next",
+    "@angular/compiler-cli": "^13.0.0 || ^13.0.0-next",
     "typescript": "~4.2.3 || ~4.3.2",
     "webpack": "^5.30.0"
   },

--- a/packages/schematics/angular/utility/latest-versions.ts
+++ b/packages/schematics/angular/utility/latest-versions.ts
@@ -15,7 +15,7 @@ export const latestVersions: Record<string, string> & {
   ...require('./latest-versions/package.json')['dependencies'],
 
   // As Angular CLI works with same minor versions of Angular Framework, a tilde match for the current
-  Angular: '~12.2.0-rc.0',
+  Angular: '~13.0.0-next.0',
 
   // Since @angular-devkit/build-angular and @schematics/angular are always
   // published together from the same monorepo, and they are both

--- a/tests/legacy-cli/e2e/tests/build/prod-build.ts
+++ b/tests/legacy-cli/e2e/tests/build/prod-build.ts
@@ -27,7 +27,7 @@ export default async function () {
 
   // Can't use the `ng` helper because somewhere the environment gets
   // stuck to the first build done
-  const bootstrapRegExp = /bootstrapModule\(.?[a-zA-Z]+\)\./;
+  const bootstrapRegExp = /bootstrapModule\([a-zA-Z]+[0-9]*\)\./;
 
   await ng('build');
   await expectFileToExist(join(process.cwd(), 'dist'));


### PR DESCRIPTION
This sets the peer dependency ranges for Angular packages to the upcoming v13.