### PR TITLE
fix(@angular-devkit/build-angular): handle null maps in JavaScript optimizer worker

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/plugins/javascript-optimizer-worker.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/plugins/javascript-optimizer-worker.ts
@@ -74,7 +74,9 @@ export default async function ({ asset, options }: OptimizeRequest) {
       partialSourcemaps.unshift(terserResult.map);
     }
 
-    partialSourcemaps.push(asset.map);
+    if (asset.map) {
+      partialSourcemaps.push(asset.map);
+    }
 
     fullSourcemap = remapping(partialSourcemaps, () => null);
   }


### PR DESCRIPTION

`asset.map` can be `null` which causes an unhandled exception.

```
Error: Optimization error [generated/js/custom-elements-es5-polyfills.js]: TypeError: Cannot destructure property 'mappings' of 'map' as it is null.
    at decodeSourceMap (/angular/aio/node_modules/@ampproject/remapping/dist/remapping.umd.js:178:15)
    at Array.map (<anonymous>)
    at buildSourceMapTree (/angular/aio/node_modules/@ampproject/remapping/dist/remapping.umd.js:725:37)
    at Object.remapping [as default] (/angular/aio/node_modules/@ampproject/remapping/dist/remapping.umd.js:831:23)
    at default_1 (/angular/aio/node_modules/@angular-devkit/build-angular/src/webpack/plugins/javascript-optimizer-worker.js:44:44)
```

AIO CI failure: https://app.circleci.com/pipelines/github/angular/angular/35940/workflows/c9c91ad3-1645-4a88-bb5b-6a06a9b887b9/jobs/1032993