### PR TITLE
test(@angular-devkit/build-angular): properly discover Bazel units tests

### DIFF
--- a/packages/angular_devkit/build_angular/BUILD.bazel
+++ b/packages/angular_devkit/build_angular/BUILD.bazel
@@ -346,7 +346,7 @@ LARGE_SPECS = {
     ts_library(
         name = "build_angular_" + spec + "_test_lib",
         testonly = True,
-        srcs = glob(["src/" + spec + "/**/*_spec.ts"]),
+        srcs = glob(["src/builders/" + spec + "/**/*_spec.ts"]),
         tsconfig = "//:tsconfig-test.json",
         deps = [
             # Dependencies needed to compile and run the specs themselves.

--- a/packages/angular_devkit/build_angular/src/builders/ng-packagr/works_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/ng-packagr/works_spec.ts
@@ -23,7 +23,7 @@ import { debounceTime, map, take, tap } from 'rxjs/operators';
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 150000;
 
 describe('NgPackagr Builder', () => {
-  const workspaceRoot = join(normalize(__dirname), `../../test/hello-world-lib/`);
+  const workspaceRoot = join(normalize(__dirname), `../../../test/hello-world-lib/`);
   const host = new TestProjectHost(workspaceRoot);
   let architect: Architect;
 


### PR DESCRIPTION
The unit tests for builders are now within the `src/builders/...` path.