### PR TITLE
fix(@angular/cli): show error when using non-TTY terminal without passing `--skip-confirmation` during `ng add`

### DIFF
--- a/packages/angular/cli/commands/add-impl.ts
+++ b/packages/angular/cli/commands/add-impl.ts
@@ -185,7 +185,7 @@ export class AddCommand extends SchematicCommand<AddCommandSchema> {
       );
 
       if (!confirmationResponse) {
-        if (!isTTY) {
+        if (!isTTY()) {
           this.logger.error(
             'No terminal detected. ' +
               `'--skip-confirmation' can be used to bypass installation confirmation. ` +


### PR DESCRIPTION


Closes #21512