### PR TITLE
fix(@angular-devkit/build-angular): do not consume inline sourcemaps when vendor sourcemaps is disabled.

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
@@ -284,9 +284,20 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
   if (scriptsSourceMap || stylesSourceMap) {
     extraRules.push({
       test: /\.m?js$/,
-      exclude: vendorSourceMap ? undefined : /[\\\/]node_modules[\\\/]/,
       enforce: 'pre',
       loader: require.resolve('source-map-loader'),
+      options: {
+        filterSourceMappingUrl: (_mapUri: string, resourcePath: string) => {
+          if (vendorSourceMap) {
+            // Consume all sourcemaps when vendor option is enabled.
+            return true;
+          }
+
+          // Don't consume sourcemaps in node_modules when vendor is disabled.
+          // But, do consume local libraries sourcemaps.
+          return !resourcePath.includes('node_modules');
+        },
+      },
     });
   }
 


### PR DESCRIPTION


Not removing inline sourcemaps when vendor sourcemaps is disabled causes an issue during the JS optimization sourcemap merging phase.

```
Optimization error [936.cf7797927c7f989bd40d.js]: Error: Transformation map 1 must have exactly one source file.
```

When vendor sourcemaps is disabled we are not interested into the said sourcemaps so now we remove the inline sourcemap.

Closes #21508