### PR TITLE
fix(@angular-devkit/build-angular): support both pure annotation forms for static properties

### DIFF
--- a/packages/angular_devkit/build_angular/src/babel/plugins/adjust-static-class-members.ts
+++ b/packages/angular_devkit/build_angular/src/babel/plugins/adjust-static-class-members.ts
@@ -74,7 +74,10 @@ function canWrapProperty(propertyName: string, assignmentValue: NodePath): boole
   if (
     leadingComments?.some(
       // `@pureOrBreakMyCode` is used by closure and is present in Angular code
-      ({ value }) => value.includes('#__PURE__') || value.includes('@pureOrBreakMyCode'),
+      ({ value }) =>
+        value.includes('@__PURE__') ||
+        value.includes('#__PURE__') ||
+        value.includes('@pureOrBreakMyCode'),
     )
   ) {
     return true;

--- a/packages/angular_devkit/build_angular/src/babel/plugins/adjust-static-class-members_spec.ts
+++ b/packages/angular_devkit/build_angular/src/babel/plugins/adjust-static-class-members_spec.ts
@@ -207,7 +207,7 @@ describe('adjust-static-class-members Babel plugin', () => {
     `);
   });
 
-  it('wraps class with pure annotated side effect fields', () => {
+  it('wraps class with pure annotated side effect fields (#__PURE__)', () => {
     testCase({
       input: `
         class CustomComponentEffects {
@@ -228,6 +228,62 @@ describe('adjust-static-class-members Babel plugin', () => {
           }
 
           CustomComponentEffects.someFieldWithSideEffects = /*#__PURE__*/ console.log('foo');
+          return CustomComponentEffects;
+        })();
+      `,
+    });
+  });
+
+  it('wraps class with pure annotated side effect fields (@__PURE__)', () => {
+    testCase({
+      input: `
+        class CustomComponentEffects {
+          constructor(_actions) {
+            this._actions = _actions;
+            this.doThis = this._actions;
+          }
+        }
+        CustomComponentEffects.someFieldWithSideEffects = /*@__PURE__*/ console.log('foo');
+      `,
+      expected: `
+        let CustomComponentEffects = /*#__PURE__*/ (() => {
+          class CustomComponentEffects {
+            constructor(_actions) {
+              this._actions = _actions;
+              this.doThis = this._actions;
+            }
+          }
+
+          CustomComponentEffects.someFieldWithSideEffects = /*@__PURE__*/ console.log('foo');
+          return CustomComponentEffects;
+        })();
+      `,
+    });
+  });
+
+  it('wraps class with pure annotated side effect fields (@pureOrBreakMyCode)', () => {
+    testCase({
+      input: `
+        class CustomComponentEffects {
+          constructor(_actions) {
+            this._actions = _actions;
+            this.doThis = this._actions;
+          }
+        }
+        CustomComponentEffects.someFieldWithSideEffects = /**@pureOrBreakMyCode*/ console.log('foo');
+      `,
+      expected: `
+        let CustomComponentEffects = /*#__PURE__*/ (() => {
+          class CustomComponentEffects {
+            constructor(_actions) {
+              this._actions = _actions;
+              this.doThis = this._actions;
+            }
+          }
+
+          CustomComponentEffects.someFieldWithSideEffects =
+            /**@pureOrBreakMyCode*/
+            console.log('foo');
           return CustomComponentEffects;
         })();
       `,


### PR DESCRIPTION
The static property optimization pass analyzes the initializers of static properties for possible side effects to determine if optimization is safe to perform. Previously the pure annotation of the form `@__PURE__` was not considered during the analysis. This has now been corrected and all of the following forms are supported: `@__PURE__`, `#__PURE__`, and `@pureOrBreakMyCode`.