### PR TITLE
refactor(@angular-devkit/build-angular): reduce repeat TypeScript configuration loading

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/dev-server/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/index.ts
@@ -27,7 +27,6 @@ import { colors } from '../../utils/color';
 import { I18nOptions } from '../../utils/i18n-options';
 import { IndexHtmlTransform } from '../../utils/index-file/index-html-generator';
 import { generateEntryPoints } from '../../utils/package-chunk-sort';
-import { readTsconfig } from '../../utils/read-tsconfig';
 import { assertCompatibleAngularVersion } from '../../utils/version';
 import {
   generateI18nBrowserWebpackConfigFromContext,
@@ -276,17 +275,13 @@ export function serveWebpackBrowser(
 
     // If a locale is defined, setup localization
     if (locale) {
-      // Only supported with Ivy
-      const tsConfig = readTsconfig(browserOptions.tsConfig, workspaceRoot);
-      if (tsConfig.options.enableIvy !== false) {
-        if (i18n.inlineLocales.size > 1) {
-          throw new Error(
-            'The development server only supports localizing a single locale per build.',
-          );
-        }
-
-        await setupLocalize(locale, i18n, browserOptions, webpackConfig);
+      if (i18n.inlineLocales.size > 1) {
+        throw new Error(
+          'The development server only supports localizing a single locale per build.',
+        );
       }
+
+      await setupLocalize(locale, i18n, browserOptions, webpackConfig);
     }
 
     if (transforms.webpackConfiguration) {

--- a/packages/angular_devkit/build_angular/src/builders/extract-i18n/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/extract-i18n/index.ts
@@ -200,12 +200,6 @@ export async function execute(
     builderOptions,
     context,
     (wco) => {
-      if (wco.tsConfig.options.enableIvy === false) {
-        context.logger.warn(
-          'Ivy extraction enabled but application is not Ivy enabled. Extraction may fail.',
-        );
-      }
-
       // Default value for legacy message ids is currently true
       useLegacyIds = wco.tsConfig.options.enableI18nLegacyMessageIdFormat ?? true;
 

--- a/packages/angular_devkit/build_angular/src/builders/server/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/server/index.ts
@@ -74,7 +74,7 @@ export function execute(
     );
   }
 
-  if (!options.bundleDependencies && tsConfig.options.enableIvy) {
+  if (!options.bundleDependencies) {
     // eslint-disable-next-line import/no-extraneous-dependencies
     const { __processed_by_ivy_ngcc__, main = '' } = require('@angular/core/package.json');
     if (

--- a/packages/angular_devkit/build_angular/src/utils/webpack-browser-config.ts
+++ b/packages/angular_devkit/build_angular/src/utils/webpack-browser-config.ts
@@ -9,6 +9,7 @@
 import { BuilderContext } from '@angular-devkit/architect';
 import { getSystemPath, logging, normalize, resolve } from '@angular-devkit/core';
 import * as path from 'path';
+import { ScriptTarget } from 'typescript';
 import { Configuration, javascript } from 'webpack';
 import { merge as webpackMerge } from 'webpack-merge';
 import { Schema as BrowserBuilderSchema } from '../builders/browser/schema';
@@ -69,12 +70,18 @@ export async function generateI18nBrowserWebpackConfigFromContext(
   projectRoot: string;
   projectSourceRoot?: string;
   i18n: I18nOptions;
+  target: ScriptTarget;
 }> {
   const { buildOptions, i18n } = await configureI18nBuild(context, options);
+  let target = ScriptTarget.ES5;
   const result = await generateBrowserWebpackConfigFromContext(
     buildOptions,
     context,
-    webpackPartialGenerator,
+    (wco) => {
+      target = wco.scriptTarget;
+
+      return webpackPartialGenerator(wco);
+    },
     extraBuildOptions,
   );
   const config = result.config;
@@ -119,7 +126,7 @@ export async function generateI18nBrowserWebpackConfigFromContext(
     });
   }
 
-  return { ...result, i18n };
+  return { ...result, i18n, target };
 }
 export async function generateBrowserWebpackConfigFromContext(
   options: BrowserBuilderSchema,

--- a/packages/angular_devkit/build_angular/src/webpack/configs/analytics.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/analytics.ts
@@ -28,13 +28,6 @@ export function getAnalyticsConfig(
 
   // The category is the builder name if it's an angular builder.
   return {
-    plugins: [
-      new NgBuildAnalyticsPlugin(
-        wco.projectRoot,
-        context.analytics,
-        category,
-        !!wco.tsConfig.options.enableIvy,
-      ),
-    ],
+    plugins: [new NgBuildAnalyticsPlugin(wco.projectRoot, context.analytics, category, true)],
   };
 }

--- a/tests/legacy-cli/e2e/tests/i18n/extract-ivy.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/extract-ivy.ts
@@ -7,13 +7,10 @@ import { updateJsonFile } from '../../utils/project';
 import { expectToFail } from '../../utils/utils';
 import { readNgVersion } from '../../utils/version';
 
-export default async function() {
+export default async function () {
   // Setup an i18n enabled component
   await ng('generate', 'component', 'i18n-test');
-  await writeFile(
-    join('src/app/i18n-test', 'i18n-test.component.html'),
-    '<p i18n>Hello world</p>',
-  );
+  await writeFile(join('src/app/i18n-test', 'i18n-test.component.html'), '<p i18n>Hello world</p>');
 
   // Should fail if `@angular/localize` is missing
   const { message: message1 } = await expectToFail(() => ng('extract-i18n'));
@@ -32,19 +29,6 @@ export default async function() {
   const { stderr: message5 } = await ng('extract-i18n');
   if (message5.includes('WARNING')) {
     throw new Error('Expected no warnings to be shown');
-  }
-
-  // Disable Ivy
-  await updateJsonFile('tsconfig.json', config => {
-    const { angularCompilerOptions = {} } = config;
-    angularCompilerOptions.enableIvy = false;
-    config.angularCompilerOptions = angularCompilerOptions;
-  });
-
-  // Should show ivy disabled application warning with enableIvy false
-  const { stderr: message4 } = await ng('extract-i18n');
-  if (!message4.includes(`Ivy extraction enabled but application is not Ivy enabled.`)) {
-    throw new Error('Expected ivy disabled application warning');
   }
 
   await uninstallPackage('@angular/localize');


### PR DESCRIPTION
An application's TypeScript configuration was previously being loaded multiple times in several different aspects of the build setup process. These aspects need to access specific compiler options relevant to that particular area of the setup. However, loading the configuration can be expensive due to the process also calculating the root files for the TypeScript compilation which can result in a large amount of file access. To improve the setup performance, the number of times the TypeScript configuration will be loaded has now been reduced with further reductions possible with additional refactorings.