### PR TITLE
feat(@angular/service-worker): Update asset file list

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/service-worker_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/service-worker_spec.ts
@@ -27,7 +27,7 @@ describe('Browser Builder service worker', () => {
         installMode: 'lazy',
         updateMode: 'prefetch',
         resources: {
-          files: ['/assets/**', '/*.(eot|svg|cur|jpg|png|webp|gif|otf|ttf|woff|woff2|ani)'],
+          files: ['/assets/**', '/*.(svg|cur|jpg|jpeg|png|apng|webp|avif|gif|otf|ttf|woff|woff2)'],
         },
       },
     ],

--- a/packages/schematics/angular/service-worker/files/ngsw-config.json.template
+++ b/packages/schematics/angular/service-worker/files/ngsw-config.json.template
@@ -22,7 +22,7 @@
       "resources": {
         "files": [
           "/assets/**",
-          "<%= resourcesOutputPath %>/*.(eot|svg|cur|jpg|png|webp|gif|otf|ttf|woff|woff2|ani)"
+          "<%= resourcesOutputPath %>/*.(svg|cur|jpg|jpeg|png|apng|webp|avif|gif|otf|ttf|woff|woff2)"
         ]
       }
     }

--- a/packages/schematics/angular/service-worker/index_spec.ts
+++ b/packages/schematics/angular/service-worker/index_spec.ts
@@ -225,7 +225,7 @@ describe('Service Worker Schematic', () => {
     const pkgText = tree.readContent('/projects/bar/ngsw-config.json');
     const config = JSON.parse(pkgText);
     expect(config.assetGroups[1].resources.files).toContain(
-      '/*.(eot|svg|cur|jpg|png|webp|gif|otf|ttf|woff|woff2|ani)',
+      '/*.(svg|cur|jpg|jpeg|png|apng|webp|avif|gif|otf|ttf|woff|woff2)',
     );
   });
 
@@ -239,7 +239,7 @@ describe('Service Worker Schematic', () => {
     const pkgText = tree.readContent('/projects/bar/ngsw-config.json');
     const ngswConfig = JSON.parse(pkgText);
     expect(ngswConfig.assetGroups[1].resources.files).toContain(
-      '/outDir/*.(eot|svg|cur|jpg|png|webp|gif|otf|ttf|woff|woff2|ani)',
+      '/outDir/*.(svg|cur|jpg|jpeg|png|apng|webp|avif|gif|otf|ttf|woff|woff2)',
     );
   });
 

--- a/tests/legacy-cli/e2e/tests/i18n/ivy-localize-serviceworker.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/ivy-localize-serviceworker.ts
@@ -105,7 +105,7 @@ export default async function () {
         installMode: 'lazy',
         updateMode: 'prefetch',
         resources: {
-          files: ['/assets/**', '/*.(eot|svg|cur|jpg|png|webp|gif|otf|ttf|woff|woff2|ani)'],
+          files: ['/assets/**', '/*.(svg|cur|jpg|jpeg|png|apng|webp|avif|gif|otf|ttf|woff|woff2)'],
         },
       },
     ],


### PR DESCRIPTION
Fixes  #21526 .

* Remove `eot`. Old IE font format. Not supported by browsers which support service worker.
* Remove `ani`. Not supported by browsers.
* Add `jpeg` as common alias for `jpg`.
* Add `apng` as modern alternative to `gif`.
* Add `avif`. A new modern image format.