### PR TITLE
feat(@angular-devkit/build-angular): deprecate deployUrl

### DIFF
--- a/goldens/public-api/angular_devkit/build_angular/src/index.md
+++ b/goldens/public-api/angular_devkit/build_angular/src/index.md
@@ -39,6 +39,7 @@ export interface BrowserBuilderOptions {
     commonChunk?: boolean;
     crossOrigin?: CrossOrigin;
     deleteOutputPath?: boolean;
+    // @deprecated
     deployUrl?: string;
     extractLicenses?: boolean;
     fileReplacements?: FileReplacement[];
@@ -253,6 +254,7 @@ export interface ProtractorBuilderOptions {
 export interface ServerBuilderOptions {
     bundleDependencies?: BundleDependenciesUnion;
     deleteOutputPath?: boolean;
+    // @deprecated
     deployUrl?: string;
     externalDependencies?: string[];
     extractLicenses?: boolean;

--- a/packages/angular_devkit/build_angular/src/builders/browser/schema.json
+++ b/packages/angular_devkit/build_angular/src/builders/browser/schema.json
@@ -201,7 +201,8 @@
     },
     "deployUrl": {
       "type": "string",
-      "description": "URL where files will be deployed."
+      "description": "URL where files will be deployed.",
+      "x-deprecated": "Use \"baseHref\" option, \"APP_BASE_HREF\" DI token or a combination of both instead. For more information, see https://angular.io/guide/deployment#the-deploy-url."
     },
     "verbose": {
       "type": "boolean",

--- a/packages/angular_devkit/build_angular/src/builders/server/schema.json
+++ b/packages/angular_devkit/build_angular/src/builders/server/schema.json
@@ -114,7 +114,8 @@
     },
     "deployUrl": {
       "type": "string",
-      "description": "URL where files will be deployed."
+      "description": "URL where files will be deployed.",
+      "x-deprecated": "Use \"baseHref\" browser builder option, \"APP_BASE_HREF\" DI token or a combination of both instead. For more information, see https://angular.io/guide/deployment#the-deploy-url."
     },
     "verbose": {
       "type": "boolean",


### PR DESCRIPTION
With this change we deprecate deployUrl which in many case causes unexpected and undesired behaviour. Such as #12322, #21432 and #6666. This is because one of the drawbacks of deploy Url is that this url needs to be injected all over the bundles.

This option was previously introduced to handle application that only assets are hosted on a CDN. This setup is now mostly considered as legacy as it is recommended that the entire application is hosted on a CDN. That said, this legacy behaviour can still be achieved by setting the `baseHref` to the CDN address, while setting the `APP_BASE_HREF` to the application address.

Closes angular#12322 and closes #14901 and closes angular#6666
