### PR TITLE
feat(@schematics/angular): add `noImplicitOverride` and `noPropertyAccessFromIndexSignature` to workspace tsconfig

### DIFF
--- a/packages/schematics/angular/workspace/files/tsconfig.json.template
+++ b/packages/schematics/angular/workspace/files/tsconfig.json.template
@@ -6,6 +6,8 @@
     "outDir": "./dist/out-tsc",<% if (strict) { %>
     "forceConsistentCasingInFileNames": true,
     "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,<% } %>
     "sourceMap": true,


### PR DESCRIPTION


With this change, when the workspace is created in strict mode (the default) we add the following  additional tsconfig options;
- [noImplicitOverride](https://www.typescriptlang.org/tsconfig#noImplicitOverride)
- [noPropertyAccessFromIndexSignature](https://www.typescriptlang.org/tsconfig#noPropertyAccessFromIndexSignature)

Closes #21279