### PR TITLE
feat(@angular-devkit/core): remove deprecated schema id handling

### DIFF
--- a/packages/angular_devkit/core/src/json/schema/registry.ts
+++ b/packages/angular_devkit/core/src/json/schema/registry.ts
@@ -235,7 +235,6 @@ export class CoreSchemaRegistry implements SchemaRegistry {
   }
 
   private async _flatten(schema: JsonObject): Promise<JsonObject> {
-    this._replaceDeprecatedSchemaIdKeyword(schema);
     this._ajv.removeSchema(schema);
 
     this._currentCompilationSchemaInfo = undefined;
@@ -293,8 +292,6 @@ export class CoreSchemaRegistry implements SchemaRegistry {
     if (typeof schema === 'boolean') {
       return async (data) => ({ success: schema, data });
     }
-
-    this._replaceDeprecatedSchemaIdKeyword(schema);
 
     const schemaInfo: SchemaInfo = {
       smartDefaultRecord: new Map<string, JsonObject>(),
@@ -678,22 +675,6 @@ export class CoreSchemaRegistry implements SchemaRegistry {
       },
       errors: false,
     });
-  }
-
-  /**
-   * Workaround to avoid a breaking change in downstream schematics.
-   * @deprecated will be removed in version 13.
-   */
-  private _replaceDeprecatedSchemaIdKeyword(schema: JsonObject): void {
-    if (typeof schema.id === 'string') {
-      schema.$id = schema.id;
-      delete schema.id;
-
-      // eslint-disable-next-line no-console
-      console.warn(
-        `"${schema.$id}" schema is using the keyword "id" which its support is deprecated. Use "$id" for schema ID.`,
-      );
-    }
   }
 
   private normalizeDataPathArr(it: SchemaObjCxt): (number | string)[] {

--- a/tests/legacy-cli/e2e/tests/commands/add/version-specifier.ts
+++ b/tests/legacy-cli/e2e/tests/commands/add/version-specifier.ts
@@ -3,14 +3,13 @@ import { uninstallPackage } from '../../../utils/packages';
 import { ng } from '../../../utils/process';
 import { isPrereleaseCli } from '../../../utils/project';
 
-
 export default async function () {
   // forcibly remove in case another test doesn't clean itself up.
   await rimraf('node_modules/@angular/localize');
 
-  const tag = await isPrereleaseCli() ?  '@next' : '';
+  const tag = (await isPrereleaseCli()) ? '@next' : '';
 
-  await ng('add',  `@angular/localize${tag}`, '--skip-confirmation');
+  await ng('add', `@angular/localize${tag}`, '--skip-confirmation');
   await expectFileToMatch('package.json', /@angular\/localize/);
 
   const output1 = await ng('add', '@angular/localize', '--skip-confirmation');
@@ -23,12 +22,12 @@ export default async function () {
     throw new Error('Installation should not have been skipped');
   }
 
-  const output3 = await ng('add', '@angular/localize@10.0.0', '--skip-confirmation');
+  const output3 = await ng('add', '@angular/localize@12.0.0', '--skip-confirmation');
   if (output3.stdout.includes('Skipping installation: Package already installed')) {
     throw new Error('Installation should not have been skipped');
   }
 
-  const output4 = await ng('add', '@angular/localize@10', '--skip-confirmation');
+  const output4 = await ng('add', '@angular/localize@12', '--skip-confirmation');
   if (!output4.stdout.includes('Skipping installation: Package already installed')) {
     throw new Error('Installation was not skipped');
   }


### PR DESCRIPTION
BREAKING CHANGE: With this change we drop support for the deprecated behaviour to transform `id` in schemas. Use `$id` instead.

Note: this only effects schematics and builders authors.