### PR TITLE
fix(@angular-devkit/build-angular): ensure native async is downlevelled in third-party libraries

### DIFF
--- a/packages/angular_devkit/build_angular/src/babel/webpack-loader.ts
+++ b/packages/angular_devkit/build_angular/src/babel/webpack-loader.ts
@@ -67,7 +67,11 @@ export default custom<AngularCustomOptions>(() => {
       if (esTarget !== undefined) {
         if (esTarget < ScriptTarget.ES2015) {
           customOptions.forceES5 = true;
-        } else if (esTarget >= ScriptTarget.ES2017) {
+        } else if (esTarget >= ScriptTarget.ES2017 || /\.[cm]?js$/.test(this.resourcePath)) {
+          // Application code (TS files) will only contain native async if target is ES2017+.
+          // However, third-party libraries can regardless of the target option.
+          // APF packages with code in [f]esm2015 directories is downlevelled to ES2015 and
+          // will not have native async.
           customOptions.forceAsyncTransformation =
             !/[\\\/][_f]?esm2015[\\\/]/.test(this.resourcePath) && source.includes('async');
         }


### PR DESCRIPTION
Application code (TS files) will only contain native async if the TypeScript configuration target is ES2017+. However, third-party libraries can contain native async regardless of the target option. To address these third-party libraries, all non-application files need to be analyzed to determine if they must have native async downlevelled. The analysis is first resource path based and then a string match search for the async keyword. This approach has the potential for rare false positives (for example, the word async in a comment) but the outcome would only be a small amount of additional processing for that one file due to the no-op transformation. This is in contrast to a more exact method covering those rare false positives but that would require a more expensive analysis operation on every file and result in longer overall build times.

Fixes: #21551