### PR TITLE
fix(@angular-devkit/build-angular): ensure native async is downlevelled in third-party libraries

### DIFF
--- a/packages/angular_devkit/build_angular/src/babel/webpack-loader.ts
+++ b/packages/angular_devkit/build_angular/src/babel/webpack-loader.ts
@@ -68,7 +68,11 @@ export default custom<AngularCustomOptions>(() => {
         if (esTarget < ScriptTarget.ES2015) {
           // TypeScript files will have already been downlevelled
           customOptions.forceES5 = !/\.tsx?$/.test(this.resourcePath);
-        } else if (esTarget >= ScriptTarget.ES2017) {
+        } else if (esTarget >= ScriptTarget.ES2017 || /\.[cm]?js$/.test(this.resourcePath)) {
+          // Application code (TS files) will only contain native async if target is ES2017+.
+          // However, third-party libraries can regardless of the target option.
+          // APF packages with code in [f]esm2015 directories is downlevelled to ES2015 and
+          // will not have native async.
           customOptions.forceAsyncTransformation =
             !/[\\\/][_f]?esm2015[\\\/]/.test(this.resourcePath) && source.includes('async');
         }


### PR DESCRIPTION
12.2.x variant of #21552 