### PR TITLE
fix(@angular-devkit/build-angular): handle undefined entrypoints when marking async chunks

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/utils/async-chunks.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/utils/async-chunks.ts
@@ -26,7 +26,7 @@ export function markAsyncChunksNonInitial(
   // depended upon in Webpack, thus any extra entry point with `inject: false`,
   // **cannot** be loaded in main bundle.
   const asyncChunkIds = extraEntryPoints
-    .filter((entryPoint) => !entryPoint.inject)
+    .filter((entryPoint) => !entryPoint.inject && entryPoints[entryPoint.bundleName])
     .flatMap((entryPoint) =>
       entryPoints[entryPoint.bundleName].chunks?.filter((n) => n !== 'runtime'),
     );


### PR DESCRIPTION
When using custom builders, it is possible to remove entries from the webpack-configuration manually. This may eventually lead to undefined entryPoints in async-chunks.ts - this fix handles exactly this problem