### PR TITLE
docs: update release documentation regarding prerelease semver ranges

### DIFF
--- a/docs/process/release.md
+++ b/docs/process/release.md
@@ -55,6 +55,13 @@ In general, cherry picks for LTS should only be done if it meets one of the crit
 
 Releasing is performed using Angular's unified release tooling. Each week, two releases are expected, `latest` and `next` on npm.
 
+When a release is transitioning from a prerelease to a stable release, the semver ranges for Angular dependencies within the packages' `package.json` files will need to be updated to remove the prerelease version segment.
+For example, `"@angular/compiler-cli": "^13.0.0 || ^13.0.0-next"` in a prerelease should become `"@angular/compiler-cli": "^13.0.0"` in the stable release.
+The current packages that require adjustment are:
+
+- `@angular-devkit/build-angular`: packages/angular_devkit/build_angular/package.json
+- `@ngtools/webpack`: packages/ngtools/webpack/package.json
+
 To perform a release run the following and navigate the prompts:
 
 ```sh


### PR DESCRIPTION
When transitioning from prerelease to stable, several SemVer ranges for packages referenced in the `package.json` files need to be adjusted so that the unsupported prerelease versions are not mentioned in the final stable release.