### PR TITLE
ci: remove nightly CI run for 9.1.x branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -451,29 +451,3 @@ workflows:
               only: /^v\d+/
             branches:
               ignore: /.*/
-  nightly:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only:
-                - 9.1.x
-    jobs:
-      - setup
-      - build:
-          requires:
-            - setup
-      - test:
-          requires:
-            - build
-      - test-large:
-          requires:
-            - build
-      - test-browsers:
-          requires:
-            - build
-      - e2e-cli:
-          name: e2e-cli-nightly
-          requires:
-            - build


### PR DESCRIPTION
Version 9 is no longer in LTS