### PR TITLE
docs: update the description of the lint command

### DIFF
--- a/packages/angular/cli/commands/lint-long.md
+++ b/packages/angular/cli/commands/lint-long.md
@@ -1,5 +1,5 @@
 The command takes an optional project name, as specified in the `projects` section of the `angular.json` workspace configuration file.
-When a project name is not supplied, executes the `lint` builder for the default project.
+When a project name is not supplied, executes the `lint` builder for all projects.
 
 To use the `ng lint` command, use `ng add` to add a package that implements linting capabilities. Adding the package automatically updates your workspace configuration, adding a lint [CLI builder](guide/cli-builder).
 For example:


### PR DESCRIPTION
- Update the description of the lint command for when a project name is not provided.
- Use diction equivalent to the [description of the test command](https://github.com/angular/angular-cli/blob/master/packages/angular/cli/commands/test-long.md).

Notes
- Closes #21619 