### PR TITLE
feat(@angular-devkit/build-angular): expose declarations in AngularWebpackPlugin

### DIFF
--- a/packages/ngtools/webpack/src/ivy/plugin.ts
+++ b/packages/ngtools/webpack/src/ivy/plugin.ts
@@ -655,6 +655,7 @@ export class AngularWebpackPlugin {
 
       let content: string | undefined;
       let map: string | undefined;
+      let declaration: string | undefined;
       program.emit(
         sourceFile,
         (filename, data) => {
@@ -662,6 +663,8 @@ export class AngularWebpackPlugin {
             map = data;
           } else if (filename.endsWith('.js')) {
             content = data;
+          } else if (filename.endsWith('.d.ts')) {
+            declaration = data;
           }
         },
         undefined,
@@ -683,7 +686,7 @@ export class AngularWebpackPlugin {
         ...getExtraDependencies(sourceFile),
       ].map(externalizePath);
 
-      return { content, map, dependencies, hash };
+      return { content, map, declaration, dependencies, hash };
     };
   }
 }

--- a/packages/ngtools/webpack/src/ivy/symbol.ts
+++ b/packages/ngtools/webpack/src/ivy/symbol.ts
@@ -11,6 +11,7 @@ export const AngularPluginSymbol = Symbol.for('@ngtools/webpack[angular-compiler
 export interface EmitFileResult {
   content?: string;
   map?: string;
+  declaration?: string;
   dependencies: readonly string[];
   hash?: Uint8Array;
 }


### PR DESCRIPTION
When creating an instance of the AngularWebpackPlugin where the `CompilerOptions` contain `declarations: true` it is now possible to access the declarations emitted by the typescript compiler through the `FileEmitter`. This makes it possible to write a Webpack plugin to emit .d.ts files for files compiled through the AngularWebpackPlugin.

This is useful when using the angular-cli to bundle libraries intended to be consumed in other frameworks or when ng-packagr cannot be used. 