### PR TITLE
WIP:Feat/extends angular cli questionnaire

### DIFF
--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -31,7 +31,7 @@ import { relativePathToWorkspaceRoot } from '../utility/paths';
 import { validateProjectName } from '../utility/validation';
 import { getWorkspace, updateWorkspace } from '../utility/workspace';
 import { Builders, ProjectType } from '../utility/workspace-models';
-import { Schema as ApplicationOptions, Style } from './schema';
+import { Schema as ApplicationOptions, ChangeDetection, Style } from './schema';
 
 function addDependenciesToPackageJson(options: ApplicationOptions) {
   return (host: Tree, context: SchematicContext) => {
@@ -81,6 +81,11 @@ function addAppToWorkspaceFile(options: ApplicationOptions, appDir: string): Rul
     }
     if (options.inlineStyle ?? options.minimal) {
       componentSchematicsOptions.inlineStyle = true;
+    }
+    if (options.changeDetection ?? options.minimal) {
+      componentSchematicsOptions.changeDetection = options.changeDetection
+        ? ChangeDetection[options.changeDetection]
+        : ChangeDetection.Default;
     }
     if (options.style && options.style !== Style.Css) {
       componentSchematicsOptions.style = options.style;
@@ -252,6 +257,7 @@ export default function (options: ApplicationOptions): Rule {
           skipTests: options.skipTests,
           style: options.style,
           viewEncapsulation: options.viewEncapsulation,
+          changeDetection: options.changeDetection,
         }
       : {
           inlineStyle: options.inlineStyle ?? true,
@@ -259,6 +265,7 @@ export default function (options: ApplicationOptions): Rule {
           skipTests: true,
           style: options.style,
           viewEncapsulation: options.viewEncapsulation,
+          changeDetection: options.changeDetection,
         };
 
     const workspace = await getWorkspace(host);

--- a/packages/schematics/angular/application/other-files/app.component.ts.template
+++ b/packages/schematics/angular/application/other-files/app.component.ts.template
@@ -29,7 +29,8 @@ import { Component } from '@angular/core';
   `,<% } else { %>
   templateUrl: './app.component.html',<% } if(inlineStyle) { %>
   styles: []<% } else { %>
-  styleUrls: ['./app.component.<%= style %>']<% } %>
+  styleUrls: ['./app.component.<%= style %>']<% } %>,
+  changeDetection: ChangeDetectionStrategy.<%= changeDetection %>
 })
 export class AppComponent {
   title = '<%= name %>';

--- a/packages/schematics/angular/application/schema.json
+++ b/packages/schematics/angular/application/schema.json
@@ -24,13 +24,22 @@
       "description": "Include styles inline in the root component.ts file. Only CSS styles can be included inline. Default is false, meaning that an external styles file is created and referenced in the root component.ts file.",
       "type": "boolean",
       "alias": "s",
+      "x-prompt": "Would you like to have Inline Styles?",
       "x-user-analytics": 9
     },
     "inlineTemplate": {
       "description": "Include template inline in the root component.ts file. Default is false, meaning that an external template file is created and referenced in the root component.ts file. ",
       "type": "boolean",
       "alias": "t",
+      "x-prompt": "Would you like to have Inline Template?",
       "x-user-analytics": 10
+    },
+    "changeDetection": {
+      "description": "Default setting for changeDetectionStrategy",
+      "enum": ["OnPush", "Default"],
+      "type":"string",
+      "default": "OnPush",
+      "x-prompt": "Which Change Detection Strategy would you like to use?"
     },
     "viewEncapsulation": {
       "description": "The view encapsulation strategy to use in the new application.",
@@ -50,7 +59,8 @@
       "format": "html-selector",
       "description": "A prefix to apply to generated selectors.",
       "default": "app",
-      "alias": "p"
+      "alias": "p",
+      "x-prompt": "Prefix for selectors"
     },
     "style": {
       "description": "The file extension or preprocessor to use for style files.",

--- a/packages/schematics/angular/application/schema.json
+++ b/packages/schematics/angular/application/schema.json
@@ -37,7 +37,7 @@
     "changeDetection": {
       "description": "Default setting for changeDetectionStrategy",
       "enum": ["OnPush", "Default"],
-      "type":"string",
+      "type": "string",
       "default": "OnPush",
       "x-prompt": "Which Change Detection Strategy would you like to use?"
     },

--- a/packages/schematics/angular/ng-new/index.ts
+++ b/packages/schematics/angular/ng-new/index.ts
@@ -63,6 +63,7 @@ export default function (options: NgNewOptions): Rule {
     skipInstall: true,
     strict: options.strict,
     minimal: options.minimal,
+    changeDetection: options.changeDetection,
   };
 
   return chain([

--- a/packages/schematics/angular/ng-new/schema.json
+++ b/packages/schematics/angular/ng-new/schema.json
@@ -66,16 +66,27 @@
       "default": "projects"
     },
     "inlineStyle": {
-      "description": "Include styles inline in the component TS file. By default, an external styles file is created and referenced in the component TypeScript file.",
+      "description": "Include styles inline in the root component.ts file. Only CSS styles can be included inline. Default is false, meaning that an external styles file is created and referenced in the root component.ts file.",
       "type": "boolean",
       "alias": "s",
+      "default": false,
+      "x-prompt": "Would you like to have Inline Styles?",
       "x-user-analytics": 9
     },
     "inlineTemplate": {
-      "description": "Include template inline in the component TS file. By default, an external template file is created and referenced in the component TypeScript file.",
+      "description": "Include template inline in the root component.ts file. Default is false, meaning that an external template file is created and referenced in the root component.ts file. ",
       "type": "boolean",
       "alias": "t",
+      "default": false,
+      "x-prompt": "Would you like to have Inline Template?",
       "x-user-analytics": 10
+    },
+    "changeDetection": {
+      "description": "Default setting for changeDetectionStrategy",
+      "enum": ["OnPush", "Default"],
+      "type": "string",
+      "default": "OnPush",
+      "x-prompt": "Which Change Detection Strategy would you like to use?"
     },
     "viewEncapsulation": {
       "description": "The view encapsulation strategy to use in the initial project.",
@@ -102,7 +113,8 @@
       "description": "The prefix to apply to generated selectors for the initial project.",
       "minLength": 1,
       "default": "app",
-      "alias": "p"
+      "alias": "p",
+      "x-prompt": "Prefix for selectors"
     },
     "style": {
       "description": "The file extension or preprocessor to use for style files.",


### PR DESCRIPTION
### Extend AngularCLI Questionnaire
**Current behaviour:**
Currently Angular CLI asks only few questions during creating new application. 
1. Name
2. Routing
3. Styles

Rest of configuration has to be done after project is created.

Based on VueCLI I would like to extend CLI questionnaire with some additional options. In my opinion, they would speed up a little generating new Workspace.

**Expected behaviour:**
`ng new` triggers Angular CLI schematics.
User has to answer to few more questions before new workspace will be created.

1. Name (duh)
2. Would you like to have Inline Styles? (y/N) `by default it's False`
3. Would you like to have Inline Template? (y/N) `by default is' False` - this one is often used for small components. Personal choice
4. Which Change Detection Strategy would you like to use? `OnPush / Default`. Currently developer has to manually edit angular.json to include this option for newly created components
5. Prefix for selectors (app) - `by default is 'app'`, but sometimes we need to change it in case of having multiple projects + library
6. Would you like to add Angular routing? (y/N) - default one. Nothing has changed.
7. Which stylesheet format would you like to use? - default one. Nothing has changed.

