### PR TITLE
`@angular/cli` global require cleanup

### DIFF
--- a/packages/angular/cli/commands/update-impl.ts
+++ b/packages/angular/cli/commands/update-impl.ts
@@ -11,6 +11,7 @@ import { NodeWorkflow } from '@angular-devkit/schematics/tools';
 import { execSync } from 'child_process';
 import * as fs from 'fs';
 import npa from 'npm-package-arg';
+import pickManifest from 'npm-pick-manifest';
 import * as path from 'path';
 import * as semver from 'semver';
 import { PackageManager } from '../lib/config/workspace-schema';
@@ -25,7 +26,6 @@ import { ensureCompatibleNpm, getPackageManager } from '../utilities/package-man
 import {
   PackageIdentifier,
   PackageManifest,
-  PackageMetadata,
   fetchPackageManifest,
   fetchPackageMetadata,
 } from '../utilities/package-metadata';
@@ -36,11 +36,6 @@ import {
   readPackageJson,
 } from '../utilities/package-tree';
 import { Schema as UpdateCommandSchema } from './update';
-
-const pickManifest = require('npm-pick-manifest') as (
-  metadata: PackageMetadata,
-  selector: string,
-) => PackageManifest;
 
 const NG_VERSION_9_POST_MSG = colors.cyan(
   '\nYour project has been updated to Angular version 9!\n' +

--- a/packages/angular/cli/commands/version-impl.ts
+++ b/packages/angular/cli/commands/version-impl.ts
@@ -7,7 +7,7 @@
  */
 
 import { execSync } from 'child_process';
-import * as path from 'path';
+import nodeModule from 'module';
 import { Command } from '../models/command';
 import { colors } from '../utilities/color';
 import { getPackageManager } from '../utilities/package-manager';
@@ -28,11 +28,15 @@ interface PartialPackageInfo {
 export class VersionCommand extends Command<VersionCommandSchema> {
   public static aliases = ['v'];
 
+  private readonly localRequire = nodeModule.createRequire(__filename);
+  // Trailing slash is used to allow the path to be treated as a directory
+  private readonly workspaceRequire = nodeModule.createRequire(this.context.root + '/');
+
   async run() {
-    const cliPackage: PartialPackageInfo = require('../package.json');
+    const cliPackage: PartialPackageInfo = this.localRequire('../package.json');
     let workspacePackage: PartialPackageInfo | undefined;
     try {
-      workspacePackage = require(path.resolve(this.context.root, 'package.json'));
+      workspacePackage = this.workspaceRequire('./package.json');
     } catch {}
 
     const [nodeMajor] = process.versions.node.split('.').map((part) => Number(part));
@@ -151,18 +155,18 @@ export class VersionCommand extends Command<VersionCommandSchema> {
   }
 
   private getVersion(moduleName: string): string {
-    let packagePath;
+    let packageInfo: PartialPackageInfo | undefined;
     let cliOnly = false;
 
     // Try to find the package in the workspace
     try {
-      packagePath = require.resolve(`${moduleName}/package.json`, { paths: [this.context.root] });
+      packageInfo = this.workspaceRequire(`${moduleName}/package.json`);
     } catch {}
 
     // If not found, try to find within the CLI
-    if (!packagePath) {
+    if (!packageInfo) {
       try {
-        packagePath = require.resolve(`${moduleName}/package.json`);
+        packageInfo = this.localRequire(`${moduleName}/package.json`);
         cliOnly = true;
       } catch {}
     }
@@ -170,9 +174,9 @@ export class VersionCommand extends Command<VersionCommandSchema> {
     let version: string | undefined;
 
     // If found, attempt to get the version
-    if (packagePath) {
+    if (packageInfo) {
       try {
-        version = require(packagePath).version + (cliOnly ? ' (cli-only)' : '');
+        version = packageInfo.version + (cliOnly ? ' (cli-only)' : '');
       } catch {}
     }
 

--- a/packages/angular/cli/models/schematic-engine-host.ts
+++ b/packages/angular/cli/models/schematic-engine-host.ts
@@ -121,7 +121,8 @@ function wrap(
   moduleCache: Map<string, unknown>,
   exportName?: string,
 ): () => unknown {
-  const scopedRequire = nodeModule.createRequire(schematicFile);
+  const hostRequire = nodeModule.createRequire(__filename);
+  const schematicRequire = nodeModule.createRequire(schematicFile);
 
   const customRequire = function (id: string) {
     if (legacyModules[id]) {
@@ -131,13 +132,13 @@ function wrap(
       // Resolve from inside the `@angular/cli` project
       const packagePath = require.resolve(id);
 
-      return require(packagePath);
+      return hostRequire(packagePath);
     } else if (id.startsWith('.') || id.startsWith('@angular/cdk')) {
       // Wrap relative files inside the schematic collection
       // Also wrap `@angular/cdk`, it contains helper utilities that import core schematic packages
 
       // Resolve from the original file
-      const modulePath = scopedRequire.resolve(id);
+      const modulePath = schematicRequire.resolve(id);
 
       // Use cached module if available
       const cachedModule = moduleCache.get(modulePath);
@@ -159,7 +160,7 @@ function wrap(
     }
 
     // All others are required directly from the original file
-    return scopedRequire(id);
+    return schematicRequire(id);
   };
 
   // Setup a wrapper function to capture the module's exports

--- a/packages/angular/cli/models/version.ts
+++ b/packages/angular/cli/models/version.ts
@@ -6,6 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
 // Same structure as used in framework packages
 export class Version {
   public readonly major: string;
@@ -19,4 +22,9 @@ export class Version {
   }
 }
 
-export const VERSION = new Version(require('../package.json').version);
+// TODO: Convert this to use build-time version stamping once implemented in the build system
+export const VERSION = new Version(
+  (
+    JSON.parse(readFileSync(resolve(__dirname, '../package.json'), 'utf-8')) as { version: string }
+  ).version,
+);

--- a/packages/angular/cli/src/typings.d.ts
+++ b/packages/angular/cli/src/typings.d.ts
@@ -6,6 +6,16 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+declare module '@yarnpkg/lockfile' {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  export function parse(data: string): Record<string, any>;
+}
+
+declare module 'ini' {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  export function parse(data: string): Record<string, any>;
+}
+
 declare module 'npm-pick-manifest' {
   function pickManifest(
     metadata: import('../utilities/package-metadata').PackageMetadata,

--- a/packages/angular/cli/src/typings.d.ts
+++ b/packages/angular/cli/src/typings.d.ts
@@ -1,0 +1,15 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+declare module 'npm-pick-manifest' {
+  function pickManifest(
+    metadata: import('../utilities/package-metadata').PackageMetadata,
+    selector: string,
+  ): import('../utilities/package-metadata').PackageManifest;
+  export = pickManifest;
+}

--- a/packages/angular/cli/src/typings.d.ts
+++ b/packages/angular/cli/src/typings.d.ts
@@ -23,3 +23,15 @@ declare module 'npm-pick-manifest' {
   ): import('../utilities/package-metadata').PackageManifest;
   export = pickManifest;
 }
+
+declare module 'pacote' {
+  export function manifest(
+    specifier: string,
+    options: Record<string, unknown>,
+  ): Promise<{ name: string; version: string }>;
+
+  export function packument(
+    specifier: string,
+    options: Record<string, unknown>,
+  ): Promise<import('../utilities/package-metadata').NpmRepositoryPackageJson>;
+}

--- a/packages/angular/cli/utilities/package-metadata.ts
+++ b/packages/angular/cli/utilities/package-metadata.ts
@@ -7,13 +7,13 @@
  */
 
 import { logging } from '@angular-devkit/core';
+import * as lockfile from '@yarnpkg/lockfile';
 import { existsSync, readFileSync } from 'fs';
+import * as ini from 'ini';
 import { homedir } from 'os';
 import * as path from 'path';
 import { JsonSchemaForNpmPackageJsonFiles } from './package-json';
 
-const lockfile = require('@yarnpkg/lockfile');
-const ini = require('ini');
 const pacote = require('pacote');
 
 const npmPackageJsonCache = new Map<string, Promise<Partial<NpmRepositoryPackageJson>>>();

--- a/packages/angular/cli/utilities/package-metadata.ts
+++ b/packages/angular/cli/utilities/package-metadata.ts
@@ -11,10 +11,9 @@ import * as lockfile from '@yarnpkg/lockfile';
 import { existsSync, readFileSync } from 'fs';
 import * as ini from 'ini';
 import { homedir } from 'os';
+import * as pacote from 'pacote';
 import * as path from 'path';
 import { JsonSchemaForNpmPackageJsonFiles } from './package-json';
-
-const pacote = require('pacote');
 
 const npmPackageJsonCache = new Map<string, Promise<Partial<NpmRepositoryPackageJson>>>();
 


### PR DESCRIPTION
Preparation for future transition to ESM output for `@angular/cli`.
See individual commits.