### PR TITLE
fix(@angular-devkit/build-angular): RGBA converted to hex notation in component styles breaks IE11

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/styles.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/styles.ts
@@ -489,7 +489,10 @@ function transformSupportedBrowsersToTargets(supportedBrowsers: string[]): strin
 
   for (const browser of supportedBrowsers) {
     const [browserName, version] = browser.split(' ');
-    if (esBuildSupportedBrowsers.has(browserName)) {
+
+    if (browserName === 'ie') {
+      transformed.push('edge12');
+    } else if (esBuildSupportedBrowsers.has(browserName)) {
       transformed.push(browserName + version);
     }
   }


### PR DESCRIPTION


ESBuild which is used to optimize CSS in components, doesn't support IE. With this change we workaround this limitation by adding `Edge 13` when the user needs `IE 11` support.

Closes #21652