### PR TITLE
fix(@angular-devkit/build-angular): disable dev-server response compression

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/dev-server.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/dev-server.ts
@@ -43,9 +43,8 @@ export function getDevServerConfig(
   } = wco;
 
   const servePath = buildServePath(wco.buildOptions, logger);
-  const { styles: stylesOptimization, scripts: scriptsOptimization } = normalizeOptimization(
-    optimization,
-  );
+  const { styles: stylesOptimization, scripts: scriptsOptimization } =
+    normalizeOptimization(optimization);
 
   const extraPlugins = [];
 
@@ -109,7 +108,7 @@ export function getDevServerConfig(
       },
       sockPath: posix.join(servePath, 'sockjs-node'),
       stats: false,
-      compress: stylesOptimization.minify || scriptsOptimization,
+      compress: false,
       watchOptions: getWatchOptions(poll),
       https: getSslConfig(root, wco.buildOptions),
       overlay: {


### PR DESCRIPTION
Compression isn't particular useful during development, also in version 13 we disable this completely due to timeouts issues which it causes.

This backports this change which also addresses another issues as described here #21720

Closes #21720