### PR TITLE
fix(@angular-devkit/build-angular): handle `FORCE_COLOR` when stdout is not instance of `WriteStream`

### DIFF
--- a/packages/angular/cli/utilities/color.ts
+++ b/packages/angular/cli/utilities/color.ts
@@ -10,7 +10,33 @@ import * as ansiColors from 'ansi-colors';
 import { WriteStream } from 'tty';
 
 type AnsiColors = typeof ansiColors;
-const supportsColor = process.stdout instanceof WriteStream && process.stdout.getColorDepth() > 1;
+
+function supportColor(): boolean {
+  if (process.env.FORCE_COLOR !== undefined) {
+    // 2 colors: FORCE_COLOR = 0 (Disables colors), depth 1
+    // 16 colors: FORCE_COLOR = 1, depth 4
+    // 256 colors: FORCE_COLOR = 2, depth 8
+    // 16,777,216 colors: FORCE_COLOR = 3, depth 16
+    // See: https://nodejs.org/dist/latest-v12.x/docs/api/tty.html#tty_writestream_getcolordepth_env
+    // and https://github.com/nodejs/node/blob/b9f36062d7b5c5039498e98d2f2c180dca2a7065/lib/internal/tty.js#L106;
+    switch (process.env.FORCE_COLOR) {
+      case '':
+      case 'true':
+      case '1':
+      case '2':
+      case '3':
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  if (process.stdout instanceof WriteStream) {
+    return process.stdout.getColorDepth() > 1;
+  }
+
+  return false;
+}
 
 export function removeColor(text: string): string {
   // This has been created because when colors.enabled is false unstyle doesn't work
@@ -21,6 +47,6 @@ export function removeColor(text: string): string {
 // Create a separate instance to prevent unintended global changes to the color configuration
 // Create function is not defined in the typings. See: https://github.com/doowb/ansi-colors/pull/44
 const colors = (ansiColors as AnsiColors & { create: () => AnsiColors }).create();
-colors.enabled = supportsColor;
+colors.enabled = supportColor();
 
 export { colors };

--- a/packages/angular_devkit/build_angular/src/utils/color.ts
+++ b/packages/angular_devkit/build_angular/src/utils/color.ts
@@ -10,7 +10,33 @@ import * as ansiColors from 'ansi-colors';
 import { WriteStream } from 'tty';
 
 type AnsiColors = typeof ansiColors;
-const supportsColor = process.stdout instanceof WriteStream && process.stdout.getColorDepth() > 1;
+
+function supportColor(): boolean {
+  if (process.env.FORCE_COLOR !== undefined) {
+    // 2 colors: FORCE_COLOR = 0 (Disables colors), depth 1
+    // 16 colors: FORCE_COLOR = 1, depth 4
+    // 256 colors: FORCE_COLOR = 2, depth 8
+    // 16,777,216 colors: FORCE_COLOR = 3, depth 16
+    // See: https://nodejs.org/dist/latest-v12.x/docs/api/tty.html#tty_writestream_getcolordepth_env
+    // and https://github.com/nodejs/node/blob/b9f36062d7b5c5039498e98d2f2c180dca2a7065/lib/internal/tty.js#L106;
+    switch (process.env.FORCE_COLOR) {
+      case '':
+      case 'true':
+      case '1':
+      case '2':
+      case '3':
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  if (process.stdout instanceof WriteStream) {
+    return process.stdout.getColorDepth() > 1;
+  }
+
+  return false;
+}
 
 export function removeColor(text: string): string {
   // This has been created because when colors.enabled is false unstyle doesn't work
@@ -21,6 +47,6 @@ export function removeColor(text: string): string {
 // Create a separate instance to prevent unintended global changes to the color configuration
 // Create function is not defined in the typings. See: https://github.com/doowb/ansi-colors/pull/44
 const colors = (ansiColors as AnsiColors & { create: () => AnsiColors }).create();
-colors.enabled = supportsColor;
+colors.enabled = supportColor();
 
 export { colors };


### PR DESCRIPTION
In some cases, custom implementation of stdout, don't extend `WriteStream` which causes colors not to be included in the output.

Closes #21732