### PR TITLE
build: update dev-infra merge configuration

### DIFF
--- a/.ng-dev/merge.ts
+++ b/.ng-dev/merge.ts
@@ -1,25 +1,16 @@
-import { DevInfraMergeConfig } from '@angular/dev-infra-private/ng-dev/pr/merge/config';
-import { getDefaultTargetLabelConfiguration } from '@angular/dev-infra-private/ng-dev/pr/merge/defaults';
-import { github } from './github';
-import { release } from './release';
+import { MergeConfig } from '@angular/dev-infra-private/ng-dev/pr/merge/config';
 
 /**
  * Configuration for the merge tool in `ng-dev`. This sets up the labels which
  * are respected by the merge script (e.g. the target labels).
  */
-export const merge: DevInfraMergeConfig['merge'] = async (api) => {
-  return {
-    githubApiMerge: {
-      default: 'rebase',
-      labels: [{ pattern: 'squash commits', method: 'squash' }],
-    },
-    claSignedLabel: 'cla: yes',
-    breakingChangeLabel: 'flag: breaking change',
-    mergeReadyLabel: /^action: merge(-assistance)?/,
-    caretakerNoteLabel: /(action: merge-assistance)/,
-    commitMessageFixupLabel: 'commit message fixup',
-    // We can pick any of the NPM packages as we are in a monorepo where all packages are
-    // published together with the same version and branching.
-    labels: await getDefaultTargetLabelConfiguration(api, github, release),
-  };
+export const merge: MergeConfig = {
+  githubApiMerge: {
+    default: 'rebase',
+    labels: [{ pattern: 'squash commits', method: 'squash' }],
+  },
+  claSignedLabel: 'cla: yes',
+  mergeReadyLabel: /^action: merge(-assistance)?/,
+  caretakerNoteLabel: /(action: merge-assistance)/,
+  commitMessageFixupLabel: 'commit message fixup',
 };


### PR DESCRIPTION
Merge configuration no longer accepts custom labels, in order to achieve consistent labelling as specified in the Angular versioning/branching/labelling spec.