### PR TITLE
Support a future ESM-only `@angular/compiler-cli` package (1)

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/build-options.ts
+++ b/packages/angular_devkit/build_angular/src/utils/build-options.ts
@@ -7,7 +7,7 @@
  */
 
 import { logging } from '@angular-devkit/core';
-import { ParsedConfiguration } from '@angular/compiler-cli';
+import type { ParsedConfiguration } from '@angular/compiler-cli';
 import {
   AssetPatternClass,
   Budget,

--- a/packages/angular_devkit/build_angular/src/utils/i18n-options.ts
+++ b/packages/angular_devkit/build_angular/src/utils/i18n-options.ts
@@ -161,7 +161,7 @@ export async function configureI18nBuild<T extends BrowserBuilderSchema | Server
   }
 
   const buildOptions = { ...options };
-  const tsConfig = readTsconfig(buildOptions.tsConfig, context.workspaceRoot);
+  const tsConfig = await readTsconfig(buildOptions.tsConfig, context.workspaceRoot);
   const metadata = await context.getProjectMetadata(context.target);
   const i18n = createI18nOptions(metadata, buildOptions.localize);
 

--- a/packages/angular_devkit/build_angular/src/utils/read-tsconfig.ts
+++ b/packages/angular_devkit/build_angular/src/utils/read-tsconfig.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { ParsedConfiguration } from '@angular/compiler-cli';
+import type { ParsedConfiguration } from '@angular/compiler-cli';
 import * as path from 'path';
 
 /**

--- a/packages/angular_devkit/build_angular/src/utils/read-tsconfig.ts
+++ b/packages/angular_devkit/build_angular/src/utils/read-tsconfig.ts
@@ -16,16 +16,28 @@ import * as path from 'path';
  * @param workspaceRoot - workspaceRoot root location when provided
  * it will resolve 'tsconfigPath' from this path.
  */
-export function readTsconfig(tsconfigPath: string, workspaceRoot?: string): ParsedConfiguration {
+export async function readTsconfig(
+  tsconfigPath: string,
+  workspaceRoot?: string,
+): Promise<ParsedConfiguration> {
   const tsConfigFullPath = workspaceRoot ? path.resolve(workspaceRoot, tsconfigPath) : tsconfigPath;
 
-  // We use 'ng' instead of 'ts' here because 'ts' is not aware of 'angularCompilerOptions'
-  // and will not merged them if they are at un upper level tsconfig file when using `extends`.
-  const ng: typeof import('@angular/compiler-cli') = require('@angular/compiler-cli');
+  // This uses a dynamic import to load `@angular/compiler-cli` which may be ESM.
+  // CommonJS code can load ESM code via a dynamic import. Unfortunately, TypeScript
+  // will currently, unconditionally downlevel dynamic import into a require call.
+  // require calls cannot load ESM code and will result in a runtime error. To workaround
+  // this, a Function constructor is used to prevent TypeScript from changing the dynamic import.
+  // Once TypeScript provides support for keeping the dynamic import this workaround can
+  // be dropped.
+  const compilerCliModule = await new Function(`return import('@angular/compiler-cli');`)();
+  // If it is not ESM then the functions needed will be stored in the `default` property.
+  const { formatDiagnostics, readConfiguration } = (
+    compilerCliModule.readConfiguration ? compilerCliModule : compilerCliModule.default
+  ) as typeof import('@angular/compiler-cli');
 
-  const configResult = ng.readConfiguration(tsConfigFullPath);
+  const configResult = readConfiguration(tsConfigFullPath);
   if (configResult.errors && configResult.errors.length) {
-    throw new Error(ng.formatDiagnostics(configResult.errors));
+    throw new Error(formatDiagnostics(configResult.errors));
   }
 
   return configResult;

--- a/packages/angular_devkit/build_angular/src/utils/webpack-browser-config.ts
+++ b/packages/angular_devkit/build_angular/src/utils/webpack-browser-config.ts
@@ -40,7 +40,7 @@ export async function generateWebpackConfig(
   }
 
   const tsConfigPath = path.resolve(workspaceRoot, options.tsConfig);
-  const tsConfig = readTsconfig(tsConfigPath);
+  const tsConfig = await readTsconfig(tsConfigPath);
 
   const ts = await import('typescript');
   const scriptTarget = tsConfig.options.target || ts.ScriptTarget.ES5;

--- a/packages/angular_devkit/build_angular/src/webpack/configs/typescript.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/typescript.ts
@@ -7,7 +7,7 @@
  */
 
 import { getSystemPath } from '@angular-devkit/core';
-import { CompilerOptions } from '@angular/compiler-cli';
+import type { CompilerOptions } from '@angular/compiler-cli';
 import { AngularWebpackLoaderPath, AngularWebpackPlugin } from '@ngtools/webpack';
 import { ScriptTarget } from 'typescript';
 import { Configuration } from 'webpack';

--- a/packages/ngtools/webpack/src/ivy/plugin.ts
+++ b/packages/ngtools/webpack/src/ivy/plugin.ts
@@ -6,8 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { CompilerHost, CompilerOptions, readConfiguration } from '@angular/compiler-cli';
-import { NgtscProgram } from '@angular/compiler-cli/src/ngtsc/program';
+import {
+  CompilerHost,
+  CompilerOptions,
+  NgtscProgram,
+  readConfiguration,
+} from '@angular/compiler-cli';
 import { createHash } from 'crypto';
 import * as ts from 'typescript';
 import type { Compilation, Compiler, Module, NormalModule } from 'webpack';


### PR DESCRIPTION
With the Angular CLI currently being a CommonJS package, this change uses a dynamic import to load `@angular/compiler-cli` which may be ESM. CommonJS code can load ESM code via a dynamic import. Unfortunately, TypeScript will currently, unconditionally downlevel dynamic import into a require call. require calls cannot load ESM code and will result in a runtime error. To workaround this, a Function constructor is used to prevent TypeScript from changing the dynamic import. Once TypeScript provides support for keeping the dynamic import this workaround can be dropped and replaced with a standard dynamic import.