### PR TITLE
feat(@angular-devkit/build-angular): support ESM proxy configuration files for the dev server

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/dev-server/tests/options/proxy-config_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/tests/options/proxy-config_spec.ts
@@ -25,28 +25,67 @@ describeBuilder(serveWebpackBrowser, DEV_SERVER_BUILDER_INFO, (harness) => {
       await harness.writeFile('src/main.ts', '');
     });
 
-    it('proxies requests based on the proxy configuration file provided in the option', async () => {
+    it('proxies requests based on the JSON proxy configuration file provided in the option', async () => {
       harness.useTarget('serve', {
         ...BASE_OPTIONS,
         proxyConfig: 'proxy.config.json',
       });
 
-      const proxyServer = http.createServer((request, response) => {
-        if (request.url?.endsWith('/test')) {
-          response.writeHead(200);
-          response.end('TEST_API_RETURN');
-        } else {
-          response.writeHead(404);
-          response.end();
-        }
-      });
-
+      const proxyServer = createProxyServer();
       try {
         await new Promise<void>((resolve) => proxyServer.listen(0, '127.0.0.1', resolve));
         const proxyAddress = proxyServer.address() as import('net').AddressInfo;
 
         await harness.writeFiles({
           'proxy.config.json': `{ "/api/*": { "target": "http://127.0.0.1:${proxyAddress.port}" } }`,
+        });
+
+        const { result, response } = await executeOnceAndFetch(harness, '/api/test');
+
+        expect(result?.success).toBeTrue();
+        expect(await response?.text()).toContain('TEST_API_RETURN');
+      } finally {
+        await new Promise<void>((resolve) => proxyServer.close(() => resolve()));
+      }
+    });
+
+    it('proxies requests based on the JS proxy configuration file provided in the option', async () => {
+      harness.useTarget('serve', {
+        ...BASE_OPTIONS,
+        proxyConfig: 'proxy.config.js',
+      });
+
+      const proxyServer = createProxyServer();
+      try {
+        await new Promise<void>((resolve) => proxyServer.listen(0, '127.0.0.1', resolve));
+        const proxyAddress = proxyServer.address() as import('net').AddressInfo;
+
+        await harness.writeFiles({
+          'proxy.config.js': `module.exports = { "/api/*": { "target": "http://127.0.0.1:${proxyAddress.port}" } }`,
+        });
+
+        const { result, response } = await executeOnceAndFetch(harness, '/api/test');
+
+        expect(result?.success).toBeTrue();
+        expect(await response?.text()).toContain('TEST_API_RETURN');
+      } finally {
+        await new Promise<void>((resolve) => proxyServer.close(() => resolve()));
+      }
+    });
+
+    it('proxies requests based on the MJS proxy configuration file provided in the option', async () => {
+      harness.useTarget('serve', {
+        ...BASE_OPTIONS,
+        proxyConfig: 'proxy.config.mjs',
+      });
+
+      const proxyServer = createProxyServer();
+      try {
+        await new Promise<void>((resolve) => proxyServer.listen(0, '127.0.0.1', resolve));
+        const proxyAddress = proxyServer.address() as import('net').AddressInfo;
+
+        await harness.writeFiles({
+          'proxy.config.mjs': `export default { "/api/*": { "target": "http://127.0.0.1:${proxyAddress.port}" } }`,
         });
 
         const { result, response } = await executeOnceAndFetch(harness, '/api/test');
@@ -75,3 +114,22 @@ describeBuilder(serveWebpackBrowser, DEV_SERVER_BUILDER_INFO, (harness) => {
     });
   });
 });
+
+/**
+ * Creates an HTTP Server used for proxy testing that provides a `/test` endpoint
+ * that returns a 200 response with a body of `TEST_API_RETURN`. All other requests
+ * will return a 404 response.
+ *
+ * @returns An HTTP Server instance.
+ */
+function createProxyServer() {
+  return http.createServer((request, response) => {
+    if (request.url?.endsWith('/test')) {
+      response.writeHead(200);
+      response.end('TEST_API_RETURN');
+    } else {
+      response.writeHead(404);
+      response.end();
+    }
+  });
+}


### PR DESCRIPTION
The `proxyConfig` option now supports loading ESM configuration files in addition to JSON and CommonJS files. ESM files (such as those ending with `.mjs`) must provide a default export with the configuration object.
For example, a `proxy.config.mjs` containing the follow is now possible:
```
export default { "/api/*": { "target": "http://127.0.0.1:5001" } };
```

Closes #21623