### PR TITLE
feat(@schematics/angular): create new projects with rxjs 7

### DIFF
--- a/packages/schematics/angular/utility/latest-versions/package.json
+++ b/packages/schematics/angular/utility/latest-versions/package.json
@@ -12,7 +12,7 @@
     "karma-jasmine": "~4.0.0",
     "karma": "~6.3.0",
     "ng-packagr": "~13.0.0-next.0",
-    "rxjs": "~6.6.0",
+    "rxjs": "~7.3.0",
     "tslib": "^2.3.0",
     "typescript": "~4.3.5",
     "zone.js": "~0.11.4"


### PR DESCRIPTION
With the Angular framework supporting rxjs 7 for Angular 13, new projects (`ng new ...`) can now be created using rxjs 7. rxjs 6 is also still fully supported with Angular 13 allowing existing projects to continue to use rxjs 6 if preferred or required.
Support for rxjs 7 within the framework was enabled via https://github.com/angular/angular/pull/42991