### PR TITLE
feat(@schematics/angular): support pipe name prefix

### DIFF
--- a/packages/schematics/angular/pipe/files/__name@dasherize@if-flat__/__name@dasherize__.pipe.ts.template
+++ b/packages/schematics/angular/pipe/files/__name@dasherize@if-flat__/__name@dasherize__.pipe.ts.template
@@ -1,7 +1,7 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({
-  name: '<%= camelize(name) %>'
+  name: '<%= selector %>'
 })
 export class <%= classify(name) %>Pipe implements PipeTransform {
 

--- a/packages/schematics/angular/pipe/index_spec.ts
+++ b/packages/schematics/angular/pipe/index_spec.ts
@@ -147,4 +147,28 @@ describe('Pipe Schematic', () => {
     expect(files).not.toContain('/projects/bar/src/app/foo.pipe.spec.ts');
     expect(files).toContain('/projects/bar/src/app/foo.pipe.ts');
   });
+
+  it('should use the prefix', async () => {
+    const options = { ...defaultOptions, prefix: 'pre' };
+
+    const tree = await schematicRunner.runSchematicAsync('pipe', options, appTree).toPromise();
+    const content = tree.readContent('/projects/bar/src/app/foo.pipe.ts');
+    expect(content).toMatch(/name: 'preFoo'/);
+  });
+
+  it('should use the default project prefix if none is passed', async () => {
+    const options = { ...defaultOptions, prefix: undefined };
+
+    const tree = await schematicRunner.runSchematicAsync('pipe', options, appTree).toPromise();
+    const content = tree.readContent('/projects/bar/src/app/foo.pipe.ts');
+    expect(content).toMatch(/name: 'appFoo'/);
+  });
+
+  it('should use the supplied prefix if it is ""', async () => {
+    const options = { ...defaultOptions, prefix: '' };
+
+    const tree = await schematicRunner.runSchematicAsync('pipe', options, appTree).toPromise();
+    const content = tree.readContent('/projects/bar/src/app/foo.pipe.ts');
+    expect(content).toMatch(/name: 'foo'/);
+  });
 });

--- a/packages/schematics/angular/pipe/schema.json
+++ b/packages/schematics/angular/pipe/schema.json
@@ -21,6 +21,20 @@
       "description": "The path at which to create the pipe, relative to the workspace root.",
       "visible": false
     },
+    "prefix": {
+      "type": "string",
+      "description": "The prefix to apply to the generated pipe name.",
+      "alias": "p",
+      "oneOf": [
+        {
+          "maxLength": 0
+        },
+        {
+          "minLength": 1,
+          "format": "html-selector"
+        }
+      ]
+    },
     "project": {
       "type": "string",
       "description": "The name of the project.",


### PR DESCRIPTION
like components often you want to prefix your pipes

BREAKING CHANGE: creating a new pipe will prefix the name with the project's prefix if defined