### PR TITLE
ci: ensure Windows CI installs Windows specific npm dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -285,7 +285,19 @@ jobs:
     executor: windows-executor
     parallelism: 8
     steps:
-      - custom_attach_workspace
+      - checkout
+      - run:
+          name: Rebase PR on target branch
+          command: |
+            if (Test-Path env:CIRCLE_PR_NUMBER) {
+              # User is required for rebase.
+              git config user.name "angular-ci"
+              git config user.email "angular-ci"
+              # Rebase PR on top of target branch.
+              node tools/rebase-pr.js angular/angular-cli $env:CIRCLE_PR_NUMBER
+            } else {
+              echo "This build is not over a PR, nothing to do."
+            }
       - setup_windows
       - restore_cache:
           keys:


### PR DESCRIPTION
The Windows CI test job is now isolated from the linux jobs.
The previous Windows CI setup reused the workspace from the linux CI setup job. This job performed a package install which would install linux specific dependencies. Some dependencies (e.g., `esbuild`) modify themselves as a post-install action to optimize the runtime performance and may alter themselves in platform specific ways. As a result the existing packages may then be invalid on Windows. Even though the Windows CI job performed another package install, these self-modified packages may persist and cause install and/or runtime issues on Windows. By isolating the Windows CI jobs via separately checking out and rebasing the code, the Windows dependencies will no longer be affected by the linux CI jobs. This change also has the benefit of removing the need to attach the custom CircleCI workspace to the Windows job prior to execution which can be time consuming.