### PR TITLE
feat(@schematics/angular): componentClass.name instead of string vari…

### DIFF
--- a/packages/schematics/angular/component/files/__name@dasherize@if-flat__/__name@dasherize__.__type@dasherize__.spec.ts.template
+++ b/packages/schematics/angular/component/files/__name@dasherize@if-flat__/__name@dasherize__.__type@dasherize__.spec.ts.template
@@ -2,7 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { <%= classify(name) %><%= classify(type) %> } from './<%= dasherize(name) %><%= type ? '.' + dasherize(type): '' %>';
 
-describe('<%= classify(name) %><%= classify(type) %>', () => {
+describe(<%= classify(name) %><%= classify(type) %>.name, () => {
   let component: <%= classify(name) %><%= classify(type) %>;
   let fixture: ComponentFixture<<%= classify(name) %><%= classify(type) %>>;
 


### PR DESCRIPTION
**Description:**
At the moment ng new component <name> generates .spec file with describe(**'className'**, () => {}) string variable

I propose to replace it with describe(**className.name**, () => {})

![image](https://user-images.githubusercontent.com/15340874/134649330-2e0073a5-177e-4c46-9f32-1bfece185eb9.png)
