### PR TITLE
fix(@angular/cli): remove unused cli project options.

### DIFF
--- a/packages/angular/cli/lib/config/workspace-schema.json
+++ b/packages/angular/cli/lib/config/workspace-schema.json
@@ -139,7 +139,10 @@
       "type": "object",
       "properties": {
         "cli": {
-          "$ref": "#/definitions/cliOptions"
+          "defaultCollection": {
+            "description": "The default schematics collection to use.",
+            "type": "string"
+          }
         },
         "schematics": {
           "$ref": "#/definitions/schematicOptions"


### PR DESCRIPTION
This fixes the JSON workspace schema and removed options projects `.project.cli`. Currently only `defaultCollection` is used from `projects.cli` other options are ignored.

https://github.com/angular/angular-cli/blob/9afe185fc61390efec6bfbb16a0586487fd6f118/packages/angular/cli/models/schematic-command.ts#L381