### PR TITLE
refactor(@angular-devkit/build-angular): support ESM `@angular/localize` usage

### DIFF
--- a/packages/angular_devkit/build_angular/src/babel/webpack-loader.ts
+++ b/packages/angular_devkit/build_angular/src/babel/webpack-loader.ts
@@ -9,7 +9,7 @@
 import { custom } from 'babel-loader';
 import { ScriptTarget } from 'typescript';
 import { loadEsmModule } from '../utils/load-esm';
-import { ApplicationPresetOptions } from './presets/application';
+import { ApplicationPresetOptions, I18nPluginCreators } from './presets/application';
 
 interface AngularCustomOptions extends Pick<ApplicationPresetOptions, 'angularLinker' | 'i18n'> {
   forceAsyncTransformation: boolean;
@@ -32,6 +32,11 @@ let needsLinking: typeof import('@angular/compiler-cli/linker').needsLinking | u
 let linkerPluginCreator:
   | typeof import('@angular/compiler-cli/linker/babel').createEs2015LinkerPlugin
   | undefined;
+
+/**
+ * Cached instance of the localize Babel plugins factory functions.
+ */
+let i18nPluginCreators: I18nPluginCreators | undefined;
 
 async function requiresLinking(path: string, source: string): Promise<boolean> {
   // @angular/core and @angular/compiler will cause false positives
@@ -117,7 +122,25 @@ export default custom<AngularCustomOptions>(() => {
         !/[\\/]@angular[\\/](?:compiler|localize)/.test(this.resourcePath) &&
         source.includes('$localize')
       ) {
-        customOptions.i18n = i18n as ApplicationPresetOptions['i18n'];
+        // Load the i18n plugin creators from the new `@angular/localize/tools` entry point.
+        // This may fail during the transition to ESM due to the entry point not yet existing.
+        // During the transition, this will always attempt to load the entry point for each file.
+        // This will only occur during prerelease and will be automatically corrected once the new
+        // entry point exists.
+        // TODO_ESM: Make import failure an error once the `tools` entry point exists.
+        if (i18nPluginCreators === undefined) {
+          // Load ESM `@angular/localize/tools` using the TypeScript dynamic import workaround.
+          // Once TypeScript provides support for keeping the dynamic import this workaround can be
+          // changed to a direct dynamic import.
+          try {
+            i18nPluginCreators = await loadEsmModule<I18nPluginCreators>('@angular/localize/tools');
+          } catch {}
+        }
+
+        customOptions.i18n = {
+          ...(i18n as ApplicationPresetOptions['i18n']),
+          i18nPluginCreators,
+        } as ApplicationPresetOptions['i18n'];
         shouldProcess = true;
       }
 

--- a/packages/angular_devkit/build_angular/src/builders/extract-i18n/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/extract-i18n/index.ts
@@ -16,6 +16,7 @@ import * as path from 'path';
 import webpack from 'webpack';
 import { ExecutionTransformer } from '../../transforms';
 import { createI18nOptions } from '../../utils/i18n-options';
+import { loadEsmModule } from '../../utils/load-esm';
 import { assertCompatibleAngularVersion } from '../../utils/version';
 import { generateBrowserWebpackConfigFromContext } from '../../utils/webpack-browser-config';
 import {
@@ -30,6 +31,24 @@ import { Schema as BrowserBuilderOptions, OutputHashing } from '../browser/schem
 import { Format, Schema } from './schema';
 
 export type ExtractI18nBuilderOptions = Schema & JsonObject;
+
+/**
+ * The manually constructed type for the `@angular/localize/tools` module.
+ * This type only contains the exports that are need for this file.
+ *
+ * TODO_ESM: Remove once the `tools` entry point exists in a published package version
+ */
+interface LocalizeToolsModule {
+  /* eslint-disable max-len */
+  checkDuplicateMessages: typeof import('@angular/localize/src/tools/src/extract/duplicates').checkDuplicateMessages;
+  XmbTranslationSerializer: typeof import('@angular/localize/src/tools/src/extract/translation_files/xmb_translation_serializer').XmbTranslationSerializer;
+  SimpleJsonTranslationSerializer: typeof import('@angular/localize/src/tools/src/extract/translation_files/json_translation_serializer').SimpleJsonTranslationSerializer;
+  Xliff1TranslationSerializer: typeof import('@angular/localize/src/tools/src/extract/translation_files/xliff1_translation_serializer').Xliff1TranslationSerializer;
+  Xliff2TranslationSerializer: typeof import('@angular/localize/src/tools/src/extract/translation_files/xliff2_translation_serializer').Xliff2TranslationSerializer;
+  ArbTranslationSerializer: typeof import('@angular/localize/src/tools/src/extract/translation_files/arb_translation_serializer').ArbTranslationSerializer;
+  LegacyMessageIdMigrationSerializer: typeof import('@angular/localize/src/tools/src/extract/translation_files/legacy_message_id_migration_serializer').LegacyMessageIdMigrationSerializer;
+  /* eslint-enable max-len */
+}
 
 function getI18nOutfile(format: string | undefined) {
   switch (format) {
@@ -52,6 +71,7 @@ function getI18nOutfile(format: string | undefined) {
 }
 
 async function getSerializer(
+  localizeToolsModule: LocalizeToolsModule | undefined,
   format: Format,
   sourceLocale: string,
   basePath: string,
@@ -60,45 +80,57 @@ async function getSerializer(
 ) {
   switch (format) {
     case Format.Xmb:
-      const { XmbTranslationSerializer } = await import(
-        '@angular/localize/src/tools/src/extract/translation_files/xmb_translation_serializer'
-      );
+      const { XmbTranslationSerializer } =
+        localizeToolsModule ??
+        (await import(
+          '@angular/localize/src/tools/src/extract/translation_files/xmb_translation_serializer'
+        ));
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       return new XmbTranslationSerializer(basePath as any, useLegacyIds);
     case Format.Xlf:
     case Format.Xlif:
     case Format.Xliff:
-      const { Xliff1TranslationSerializer } = await import(
-        '@angular/localize/src/tools/src/extract/translation_files/xliff1_translation_serializer'
-      );
+      const { Xliff1TranslationSerializer } =
+        localizeToolsModule ??
+        (await import(
+          '@angular/localize/src/tools/src/extract/translation_files/xliff1_translation_serializer'
+        ));
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       return new Xliff1TranslationSerializer(sourceLocale, basePath as any, useLegacyIds, {});
     case Format.Xlf2:
     case Format.Xliff2:
-      const { Xliff2TranslationSerializer } = await import(
-        '@angular/localize/src/tools/src/extract/translation_files/xliff2_translation_serializer'
-      );
+      const { Xliff2TranslationSerializer } =
+        localizeToolsModule ??
+        (await import(
+          '@angular/localize/src/tools/src/extract/translation_files/xliff2_translation_serializer'
+        ));
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       return new Xliff2TranslationSerializer(sourceLocale, basePath as any, useLegacyIds, {});
     case Format.Json:
-      const { SimpleJsonTranslationSerializer } = await import(
-        '@angular/localize/src/tools/src/extract/translation_files/json_translation_serializer'
-      );
+      const { SimpleJsonTranslationSerializer } =
+        localizeToolsModule ??
+        (await import(
+          '@angular/localize/src/tools/src/extract/translation_files/json_translation_serializer'
+        ));
 
       return new SimpleJsonTranslationSerializer(sourceLocale);
     case Format.LegacyMigrate:
-      const { LegacyMessageIdMigrationSerializer } = await import(
-        '@angular/localize/src/tools/src/extract/translation_files/legacy_message_id_migration_serializer'
-      );
+      const { LegacyMessageIdMigrationSerializer } =
+        localizeToolsModule ??
+        (await import(
+          '@angular/localize/src/tools/src/extract/translation_files/legacy_message_id_migration_serializer'
+        ));
 
       return new LegacyMessageIdMigrationSerializer(diagnostics);
     case Format.Arb:
-      const { ArbTranslationSerializer } = await import(
-        '@angular/localize/src/tools/src/extract/translation_files/arb_translation_serializer'
-      );
+      const { ArbTranslationSerializer } =
+        localizeToolsModule ??
+        (await import(
+          '@angular/localize/src/tools/src/extract/translation_files/arb_translation_serializer'
+        ));
 
       const fileSystem = {
         relative(from: string, to: string): string {
@@ -253,6 +285,17 @@ export async function execute(
     };
   }
 
+  // All the localize usages are setup to first try the ESM entry point then fallback to the deep imports.
+  // This provides interim compatibility while the framework is transitioned to bundled ESM packages.
+  // TODO_ESM: Remove all deep imports once `@angular/localize` is published with the `tools` entry point
+  let localizeToolsModule;
+  try {
+    // Load ESM `@angular/localize/tools` using the TypeScript dynamic import workaround.
+    // Once TypeScript provides support for keeping the dynamic import this workaround can be
+    // changed to a direct dynamic import.
+    localizeToolsModule = await loadEsmModule<LocalizeToolsModule>('@angular/localize/tools');
+  } catch {}
+
   const webpackResult = await runWebpack(
     (await transforms?.webpackConfiguration?.(config)) || config,
     context,
@@ -272,9 +315,8 @@ export async function execute(
 
   const basePath = config.context || projectRoot;
 
-  const { checkDuplicateMessages } = await import(
-    '@angular/localize/src/tools/src/extract/duplicates'
-  );
+  const { checkDuplicateMessages } =
+    localizeToolsModule ?? (await import('@angular/localize/src/tools/src/extract/duplicates'));
 
   // The filesystem is used to create a relative path for each file
   // from the basePath.  This relative path is then used in the error message.
@@ -297,6 +339,7 @@ export async function execute(
 
   // Serialize all extracted messages
   const serializer = await getSerializer(
+    localizeToolsModule,
     format,
     i18n.sourceLocale,
     basePath,

--- a/packages/angular_devkit/build_angular/src/utils/load-translations.ts
+++ b/packages/angular_devkit/build_angular/src/utils/load-translations.ts
@@ -8,10 +8,9 @@
 
 import { createHash } from 'crypto';
 import * as fs from 'fs';
+import { loadEsmModule } from './load-esm';
 
-export type TranslationLoader = (
-  path: string,
-) => {
+export type TranslationLoader = (path: string) => {
   translations: Record<string, import('@angular/localize').ɵParsedTranslation>;
   format: string;
   locale?: string;
@@ -61,36 +60,63 @@ export async function createTranslationLoader(): Promise<TranslationLoader> {
 }
 
 async function importParsers() {
+  // All the localize usages are setup to first try the ESM entry point then fallback to the deep imports.
+  // This provides interim compatibility while the framework is transitioned to bundled ESM packages.
+  // TODO_ESM: Remove all deep imports once `@angular/localize` is published with the `tools` entry point
+  let localizeToolsModule;
   try {
-    const localizeDiag = await import('@angular/localize/src/tools/src/diagnostics');
-    const diagnostics = new localizeDiag.Diagnostics();
+    // Load ESM `@angular/localize/tools` using the TypeScript dynamic import workaround.
+    // Once TypeScript provides support for keeping the dynamic import this workaround can be
+    // changed to a direct dynamic import.
+    // TODO_ESM: The type needs to be manually constructed until the tools entry point exists
+    localizeToolsModule = await loadEsmModule<{
+      Diagnostics: typeof import('@angular/localize/src/tools/src/diagnostics').Diagnostics;
+      /* eslint-disable max-len */
+      ArbTranslationParser: typeof import('@angular/localize/src/tools/src/translate/translation_files/translation_parsers/arb_translation_parser').ArbTranslationParser;
+      SimpleJsonTranslationParser: typeof import('@angular/localize/src/tools/src/translate/translation_files/translation_parsers/simple_json_translation_parser').SimpleJsonTranslationParser;
+      Xliff1TranslationParser: typeof import('@angular/localize/src/tools/src/translate/translation_files/translation_parsers/xliff1_translation_parser').Xliff1TranslationParser;
+      Xliff2TranslationParser: typeof import('@angular/localize/src/tools/src/translate/translation_files/translation_parsers/xliff2_translation_parser').Xliff2TranslationParser;
+      XtbTranslationParser: typeof import('@angular/localize/src/tools/src/translate/translation_files/translation_parsers/xtb_translation_parser').XtbTranslationParser;
+      /* eslint-enable max-len */
+    }>('@angular/localize/tools');
+  } catch {}
+
+  try {
+    const { Diagnostics } =
+      localizeToolsModule ?? (await import('@angular/localize/src/tools/src/diagnostics'));
+    const diagnostics = new Diagnostics();
 
     const parsers = {
       arb: new (
-        await import(
+        localizeToolsModule ??
+        (await import(
           '@angular/localize/src/tools/src/translate/translation_files/translation_parsers/arb_translation_parser'
-        )
+        ))
       ).ArbTranslationParser(),
       json: new (
-        await import(
+        localizeToolsModule ??
+        (await import(
           '@angular/localize/src/tools/src/translate/translation_files/translation_parsers/simple_json_translation_parser'
-        )
+        ))
       ).SimpleJsonTranslationParser(),
       xlf: new (
-        await import(
+        localizeToolsModule ??
+        (await import(
           '@angular/localize/src/tools/src/translate/translation_files/translation_parsers/xliff1_translation_parser'
-        )
+        ))
       ).Xliff1TranslationParser(),
       xlf2: new (
-        await import(
+        localizeToolsModule ??
+        (await import(
           '@angular/localize/src/tools/src/translate/translation_files/translation_parsers/xliff2_translation_parser'
-        )
+        ))
       ).Xliff2TranslationParser(),
       // The name ('xmb') needs to match the AOT compiler option
       xmb: new (
-        await import(
+        localizeToolsModule ??
+        (await import(
           '@angular/localize/src/tools/src/translate/translation_files/translation_parsers/xtb_translation_parser'
-        )
+        ))
       ).XtbTranslationParser(),
     };
 


### PR DESCRIPTION
With the Angular CLI currently being a CommonJS package, this change uses a dynamic import to load `@angular/localize` which may be ESM. CommonJS code can load ESM code via a dynamic import. Unfortunately, TypeScript will currently, unconditionally downlevel dynamic import into a require call. require calls cannot load ESM code and will result in a runtime error. To workaround this, a Function constructor is used to prevent TypeScript from changing the dynamic import. Once TypeScript provides support for keeping the dynamic import this workaround can be dropped and replaced with a standard dynamic import.