### PR TITLE
refactor(@angular-devkit/build-angular): pass SSL cert and key path to dev-server

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/dev-server.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/dev-server.ts
@@ -7,7 +7,7 @@
  */
 
 import { logging, tags } from '@angular-devkit/core';
-import { existsSync, readFileSync } from 'fs';
+import { existsSync } from 'fs';
 import { posix, resolve } from 'path';
 import * as url from 'url';
 import * as webpack from 'webpack';
@@ -143,8 +143,8 @@ function getSslConfig(root: string, options: WebpackDevServerOptions): Configura
   const { ssl, sslCert, sslKey } = options;
   if (ssl && sslCert && sslKey) {
     return {
-      key: readFileSync(resolve(root, sslKey), 'utf-8'),
-      cert: readFileSync(resolve(root, sslCert), 'utf-8'),
+      key: resolve(root, sslKey),
+      cert: resolve(root, sslCert),
     };
   }
 


### PR DESCRIPTION


Since version 4.2.0 webpack-dev-server supports read the mentioned files.

See:
https://github.com/webpack/webpack-dev-server/blob/9bb6f7894833fa561882258a307e45294427187b/CHANGELOG.md#420-2021-09-09