### PR TITLE
fix(@angular-devkit/build-angular): ESM-interop loaded plugin creators of `@angular/localize/tools` not respected

### DIFF
--- a/packages/angular_devkit/build_angular/src/babel/webpack-loader.ts
+++ b/packages/angular_devkit/build_angular/src/babel/webpack-loader.ts
@@ -138,9 +138,9 @@ export default custom<AngularCustomOptions>(() => {
         }
 
         customOptions.i18n = {
-          ...(i18n as ApplicationPresetOptions['i18n']),
-          i18nPluginCreators,
-        } as ApplicationPresetOptions['i18n'];
+          ...(i18n as NonNullable<ApplicationPresetOptions['i18n']>),
+          pluginCreators: i18nPluginCreators,
+        };
         shouldProcess = true;
       }
 

--- a/packages/angular_devkit/build_angular/src/utils/process-bundle.ts
+++ b/packages/angular_devkit/build_angular/src/utils/process-bundle.ts
@@ -24,8 +24,6 @@ import { allowMinify, shouldBeautify } from './environment-options';
 import { I18nOptions } from './i18n-options';
 import { loadEsmModule } from './load-esm';
 
-type LocalizeUtilities = typeof import('@angular/localize/src/tools/src/source_file_utils');
-
 // Extract Sourcemap input type from the remapping function since it is not currently exported
 type SourceMapInput = Exclude<Parameters<typeof remapping>[0], unknown[]>;
 
@@ -386,7 +384,7 @@ function inlineCopyOnly(options: InlineOptions) {
 function findLocalizePositions(
   ast: ParseResult,
   options: InlineOptions,
-  utils: LocalizeUtilities,
+  utils: LocalizeUtilityModule,
 ): LocalizePosition[] {
   const positions: LocalizePosition[] = [];
 
@@ -438,7 +436,7 @@ function findLocalizePositions(
 
 function unwrapTemplateLiteral(
   path: NodePath<types.TaggedTemplateExpression>,
-  utils: LocalizeUtilities,
+  utils: LocalizeUtilityModule,
 ): [TemplateStringsArray, types.Expression[]] {
   const [messageParts] = utils.unwrapMessagePartsFromTemplateLiteral(
     path.get('quasi').get('quasis'),
@@ -450,7 +448,7 @@ function unwrapTemplateLiteral(
 
 function unwrapLocalizeCall(
   path: NodePath<types.CallExpression>,
-  utils: LocalizeUtilities,
+  utils: LocalizeUtilityModule,
 ): [TemplateStringsArray, types.Expression[]] {
   const [messageParts] = utils.unwrapMessagePartsFromLocalizeCall(path);
   const [expressions] = utils.unwrapSubstitutionsFromLocalizeCall(path);


### PR DESCRIPTION
This is a follow-up to fb210e5b747ce0351dd9ee7d482770b9cfa71133 which
added support for the ESM-variant of the `@angular/localize` package,
and also prepared for the `tools/` secondary entry-point we will expose
as of v13.

Unfortunately this change currently does not pass-through the ESM-loaded
plugin creators as the option (which is passed to the Babel plugin) is
incorrect. This was hidden due to a type cast. This commit fixes the
issue and also ensures TS would complain in the future if the option
names differ.

Also removes an unnecessary second `typeof import` where one already exists in the same file.