### PR TITLE
test: remove last string-form loadChildren usage

### DIFF
--- a/tests/legacy-cli/e2e/assets/webpack/test-app/app/feature/lazy-feature.module.ts
+++ b/tests/legacy-cli/e2e/assets/webpack/test-app/app/feature/lazy-feature.module.ts
@@ -1,19 +1,22 @@
-import {NgModule, Component} from '@angular/core';
-import {RouterModule} from '@angular/router';
+import { NgModule, Component } from '@angular/core';
+import { RouterModule } from '@angular/router';
 
 @Component({
   selector: 'lazy-feature-comp',
-  template: 'lazy feature!'
+  template: 'lazy feature!',
 })
 export class LazyFeatureComponent {}
 
 @NgModule({
   imports: [
     RouterModule.forChild([
-      {path: '', component: LazyFeatureComponent, pathMatch: 'full'},
-      {path: 'feature', loadChildren: './feature.module#FeatureModule'}
-    ])
+      { path: '', component: LazyFeatureComponent, pathMatch: 'full' },
+      {
+        path: 'feature',
+        loadChildren: () => import('./feature.module').then((m) => m.FeatureModule),
+      },
+    ]),
   ],
-  declarations: [LazyFeatureComponent]
+  declarations: [LazyFeatureComponent],
 })
 export class LazyFeatureModule {}


### PR DESCRIPTION
One E2E test was still using the deprecated string-form of the routing `loadChildren` property. The `loadChildren` usage has now been converted to use the suppported dynamic import form. The string-form has been removed from Angular v13.