### PR TITLE
refactor(@schematics/angular): drop IE-only polyfills and drop versions from comment

### DIFF
--- a/packages/schematics/angular/application/files/src/polyfills.ts.template
+++ b/packages/schematics/angular/application/files/src/polyfills.ts.template
@@ -8,8 +8,8 @@
  *      file.
  *
  * The current setup is for so-called "evergreen" browsers; the last versions of browsers that
- * automatically update themselves. This includes Safari >= 10, Chrome >= 55 (including Opera),
- * Edge >= 13 on the desktop, and iOS 10 and Chrome on mobile.
+ * automatically update themselves. This includes recent versions of Safari, Chrome (including
+ * Opera), Edge on the desktop, and iOS and Chrome on mobile.
  *
  * Learn more in https://angular.io/guide/browser-support
  */
@@ -17,13 +17,6 @@
 /***************************************************************************************************
  * BROWSER POLYFILLS
  */
-
-/**
- * Web Animations `@angular/platform-browser/animations`
- * Only required if AnimationBuilder is used within the application and using IE/Edge or Safari.
- * Standard animation support in Angular DOES NOT require any polyfills (as of Angular 6.0).
- */
-// import 'web-animations-js';  // Run `npm install --save web-animations-js`.
 
 /**
  * By default, zone.js will patch all possible macroTask and DomEvents


### PR DESCRIPTION
This removes polyfills only required on Internet Explorer since it is no longer supported (`web-animations-js`). Also updates the doc comment to leave specific versions unspecified, since they are already out of date and updating them now would just cause them to go out of date again in the future. Instead, users can visit the browser support guide to understand find the most up to date browser versions supported.

Not sure if this is considered a breaking change, but personally I don't view the exact contents of any generated files to be strict public API. Since this PR doesn't change the polyfills actually used in a new project, I don't think this needs to be called out as a breaking change.