### PR TITLE
refactor(@angular-devkit/build-angular): remove unneeded `@angular/core` System.import workarounds

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser/tests/options/named-chunks_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/tests/options/named-chunks_spec.ts
@@ -11,7 +11,7 @@ import { BASE_OPTIONS, BROWSER_BUILDER_INFO, describeBuilder } from '../setup';
 
 const MAIN_OUTPUT = 'dist/main.js';
 const NAMED_LAZY_OUTPUT = 'dist/src_lazy-module_ts.js';
-const UNNAMED_LAZY_OUTPUT = 'dist/339.js';
+const UNNAMED_LAZY_OUTPUT = 'dist/629.js';
 
 describeBuilder(buildWebpackBrowser, BROWSER_BUILDER_INFO, (harness) => {
   describe('Option: "namedChunks"', () => {

--- a/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
@@ -355,9 +355,6 @@ export async function getCommonConfig(wco: WebpackConfigOptions): Promise<Config
       hints: false,
     },
     ignoreWarnings: [
-      // Webpack 5+ has no facility to disable this warning.
-      // System.import is used in @angular/core for deprecated string-form lazy routes
-      /System.import\(\) is deprecated and will be removed soon/i,
       // https://github.com/webpack-contrib/source-map-loader/blob/b2de4249c7431dd8432da607e08f0f65e9d64219/src/index.js#L83
       /Failed to parse source map from/,
       // https://github.com/webpack-contrib/postcss-loader/blob/bd261875fdf9c596af4ffb3a1a73fe3c549befda/src/index.js#L153-L158
@@ -367,12 +364,6 @@ export async function getCommonConfig(wco: WebpackConfigOptions): Promise<Config
       // Show an error for missing exports instead of a warning.
       strictExportPresence: true,
       rules: [
-        {
-          // Mark files inside `@angular/core` as using SystemJS style dynamic imports.
-          // Removing this will cause deprecation warnings to appear.
-          test: /[/\\]@angular[/\\]core[/\\].+\.js$/,
-          parser: { system: true },
-        },
         {
           // Mark files inside `rxjs/add` as containing side effects.
           // If this is fixed upstream and the fixed version becomes the minimum
@@ -414,17 +405,7 @@ export async function getCommonConfig(wco: WebpackConfigOptions): Promise<Config
       chunkIds: buildOptions.namedChunks ? 'named' : 'deterministic',
       emitOnErrors: false,
     },
-    plugins: [
-      // Always replace the context for the System.import in angular/core to prevent warnings.
-      // https://github.com/angular/angular/issues/11580
-      new ContextReplacementPlugin(
-        /@angular[\\/]core[\\/]/,
-        path.join(projectRoot, '$_lazy_route_resources'),
-        {},
-      ),
-      new DedupeModuleResolvePlugin({ verbose: buildOptions.verbose }),
-      ...extraPlugins,
-    ],
+    plugins: [new DedupeModuleResolvePlugin({ verbose: buildOptions.verbose }), ...extraPlugins],
   };
 }
 

--- a/tests/legacy-cli/e2e/tests/build/worker.ts
+++ b/tests/legacy-cli/e2e/tests/build/worker.ts
@@ -33,7 +33,7 @@ export default async function () {
   await expectFileToMatch('dist/test-project/main.js', 'src_app_app_worker_ts');
 
   await ng('build', '--output-hashing=none');
-  const chunkId = '151';
+  const chunkId = '310';
   await expectFileToExist(`dist/test-project/${chunkId}.js`);
   await expectFileToMatch('dist/test-project/main.js', chunkId);
 


### PR DESCRIPTION
With the removal of suppport for the string form of `loadChildren` within the Angular router, the usage of `System.import` has also been removal from `@angular/core`. This removal allows for the additional removal of all workarounds within the Angular CLI due to the `System.import` usage. Webpack's deprecated support for `System.import` was previously required to be enabled which resulted in warnings that then needed to be suppressed. A Webpack context dependency replacement was also previously required to prevent Webpack from failing due to the otherwise unknown behavior of the `System.import` call. All of these workarounds have now been removed. Since Webpack bases its output file numbering system on both the content and the configuration, several of the unnamed output test files needed to be adjusted as well to reflect the removal of some of the previously needed configuration items.