### PR TITLE
feat(@angular-devkit/build-angular): favor es2020 main fields

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/browser.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/browser.ts
@@ -54,7 +54,7 @@ export function getBrowserConfig(wco: WebpackConfigOptions): webpack.Configurati
   return {
     devtool: false,
     resolve: {
-      mainFields: ['es2015', 'browser', 'module', 'main'],
+      mainFields: ['es2020', 'es2015', 'browser', 'module', 'main'],
     },
     output: {
       crossOriginLoading,

--- a/packages/angular_devkit/build_angular/src/webpack/configs/server.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/server.ts
@@ -31,9 +31,9 @@ export function getServerConfig(wco: WebpackConfigOptions): Configuration {
     );
   }
 
-  const config: Configuration = {
+  return {
     resolve: {
-      mainFields: ['es2015', 'main', 'module'],
+      mainFields: ['es2020', 'es2015', 'main', 'module'],
     },
     output: {
       libraryTarget: 'commonjs',
@@ -55,8 +55,6 @@ export function getServerConfig(wco: WebpackConfigOptions): Configuration {
     node: false,
     externals,
   };
-
-  return config;
 }
 
 function externalizePackages(

--- a/packages/angular_devkit/build_angular/src/webpack/configs/test.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/test.ts
@@ -54,7 +54,7 @@ export function getTestConfig(
     mode: 'development',
     target: wco.tsConfig.options.target === ScriptTarget.ES5 ? ['web', 'es5'] : 'web',
     resolve: {
-      mainFields: ['es2015', 'browser', 'module', 'main'],
+      mainFields: ['es2020', 'es2015', 'browser', 'module', 'main'],
     },
     devtool: false,
     entry: {


### PR DESCRIPTION
APF version 13 will include es2020, with this change we favor es2020 entrypoints.