### PR TITLE
fix(@angular/cli): keep relative migration paths during update analysis

### DIFF
--- a/packages/angular/cli/src/commands/update/schematic/index.ts
+++ b/packages/angular/cli/src/commands/update/schematic/index.ts
@@ -325,13 +325,9 @@ function _performUpdate(
         return;
       }
 
-      const collection =
-        (target.updateMetadata.migrations.match(/^[./]/) ? name + '/' : '') +
-        target.updateMetadata.migrations;
-
       externalMigrations.push({
         package: name,
-        collection,
+        collection: target.updateMetadata.migrations,
         from: installed.version,
         to: target.version,
       });

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/index.ts
@@ -321,7 +321,7 @@ async function setupLocalize(
   };
 
   const i18nRule: webpack.RuleSetRule = {
-    test: /\.(?:[cm]?js|ts)$/,
+    test: /\.[cm]?[tj]sx?$/,
     enforce: 'post',
     use: [
       {

--- a/packages/angular_devkit/build_angular/src/builders/extract-i18n/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/extract-i18n/index.ts
@@ -249,7 +249,7 @@ export async function execute(
         module: {
           rules: [
             {
-              test: /\.[t|j]s$/,
+              test: /\.[cm]?[tj]sx?$/,
               loader: require.resolve('./ivy-extract-loader'),
               options: {
                 messageHandler: (messages: LocalizeMessage[]) => ivyMessages.push(...messages),

--- a/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
@@ -290,7 +290,7 @@ export async function getCommonConfig(wco: WebpackConfigOptions): Promise<Config
 
   if (scriptsSourceMap || stylesSourceMap) {
     extraRules.push({
-      test: /\.m?js$/,
+      test: /\.[cm]?jsx?$/,
       enforce: 'pre',
       loader: require.resolve('source-map-loader'),
       options: {
@@ -381,7 +381,7 @@ export async function getCommonConfig(wco: WebpackConfigOptions): Promise<Config
           sideEffects: true,
         },
         {
-          test: /\.[cm]?js$|\.tsx?$/,
+          test: /\.[cm]?[tj]sx?$/,
           // The below is needed due to a bug in `@babel/runtime`. See: https://github.com/babel/babel/issues/12824
           resolve: { fullySpecified: false },
           exclude: [/[/\\](?:core-js|@babel|tslib|web-animations-js|web-streams-polyfill)[/\\]/],

--- a/packages/angular_devkit/build_angular/src/webpack/configs/test.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/test.ts
@@ -37,7 +37,7 @@ export function getTestConfig(
     }
 
     extraRules.push({
-      test: /\.(jsx?|tsx?)$/,
+      test: /\.[cm]?[tj]sx?$/,
       loader: require.resolve('@jsdevtools/coverage-istanbul-loader'),
       options: { esModules: true },
       enforce: 'post',

--- a/tests/legacy-cli/e2e/assets/webpack/test-app/webpack.config.js
+++ b/tests/legacy-cli/e2e/assets/webpack/test-app/webpack.config.js
@@ -14,6 +14,10 @@ module.exports = {
   plugins: [new ngToolsWebpack.AngularWebpackPlugin()],
   module: {
     rules: [
+      // rxjs 6 requires directory imports which are not support in ES modules.
+      // Disabling `fullySpecified` allows Webpack to ignore this but this is
+      // not ideal because it currently disables ESM behavior import for all JS files.
+      { test: /\.[m]?js$/, resolve: { fullySpecified: false } },
       { test: /\.scss$/, use: ['sass-loader'], type: 'asset/source' },
       { test: /\.html$/, type: 'asset/source' },
       { test: /\.ts$/, loader: ngToolsWebpack.AngularWebpackLoaderPath },


### PR DESCRIPTION
The original update analysis would prepend the package name to all migration collection files. This was required at the time to ensure the migration collection files would be found. The existing update logic, however, no longer requires this change but the change previously had no negative effects as both the relative and module specifier methods would successfully resolve the migrations. But with the conversion to ESM-based packages that use the package.json `exports` field, deep imports into a package are no longer possible unless the migration collection files are explicitly exported. Relative migration collection paths are now preferred since they are based off of the location of the package's `package.json` and do not require additional `exports` field entries. The original update analysis logic, unfortunately, prevent the relative paths from working as intended. Since this original logic is no longer required by the update process, it has been removed allowing the relative paths to be kept and used directly.