### PR TITLE
fix(@angular-devkit/build-angular): add web-streams-polyfill to downlevel exclusion list

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
@@ -460,7 +460,7 @@ export function getCommonConfig(wco: WebpackConfigOptions): Configuration {
           test: /\.[cm]?js$|\.tsx?$/,
           // The below is needed due to a bug in `@babel/runtime`. See: https://github.com/babel/babel/issues/12824
           resolve: { fullySpecified: false },
-          exclude: [/[\/\\](?:core-js|\@babel|tslib|web-animations-js)[\/\\]/],
+          exclude: [/[/\\](?:core-js|@babel|tslib|web-animations-js|web-streams-polyfill)[/\\]/],
           use: [
             {
               loader: require.resolve('../../babel/webpack-loader'),


### PR DESCRIPTION
Polyfill related packages should not be downlevelled due to the nature of their code which may need to perform feature testing or leverage native capabilities to extract browser support information necessary to properly polyfill a given browser. In the case of `web-streams-polyfill`, it leverages the `%AsyncIteratorPrototype%`, when available, to fully polyfill its stream implementations.  To access `%AsyncIteratorPrototype%`, a native async generator is needed and therefore the code present in the package cannot have this case of a native async generator downlevelled. `core-js` is also excluded for similar (and additional reasons).