### PR TITLE
Revert "feat(@schematics/angular): create new projects with rxjs 7"

### DIFF
--- a/packages/schematics/angular/utility/latest-versions/package.json
+++ b/packages/schematics/angular/utility/latest-versions/package.json
@@ -12,7 +12,7 @@
     "karma-jasmine": "~4.0.0",
     "karma": "~6.3.0",
     "ng-packagr": "~13.0.0-next.0",
-    "rxjs": "~7.3.0",
+    "rxjs": "~6.6.0",
     "tslib": "^2.3.0",
     "typescript": "~4.4.3",
     "zone.js": "~0.11.4"


### PR DESCRIPTION
This reverts commit 7bdcd7da1ff3a31f4958d90d856beb297e99b187.

As of `rxjs` version 7 (up to and including the current 7.3.1), only the ES5 variant of `rxjs` can be imported/required when bundling. ES2015 files are available but currently not resolvable via the `exports` field defined within the package. While the ES5 variant is functional, it can lead to larger application sizes due to the extra code from the ES5 down-leveling process. This unfortunately can also lead to performance regressions with newly created applications (or applications that transition to v7) both by being larger and needing to execute more (down-leveled) code at application runtime. As a result, Angular’s current recommendation is to use `rxjs` version 6 to prevent performance regressions within Angular applications. Once these issues have been resolved and the ES2015 code is available for use, the new project default can be updated to use version 7 but that change is limited to only major versions of Angular.
One potential solution is the following PR: https://github.com/ReactiveX/rxjs/pull/6614