### PR TITLE
fix(@schematics/angular): don't add `destroyAfterEach` in newly generated spec files

### DIFF
--- a/packages/angular_devkit/build_angular/test/hello-world-app/src/test.ts
+++ b/packages/angular_devkit/build_angular/test/hello-world-app/src/test.ts
@@ -26,7 +26,6 @@ declare const require: {
 getTestBed().initTestEnvironment(
   BrowserDynamicTestingModule,
   platformBrowserDynamicTesting(),
-  { teardown: { destroyAfterEach: true }},
 );
 // Then we find all the tests.
 const context = require.context('./', true, /\.spec\.ts$/);

--- a/packages/angular_devkit/build_angular/test/hello-world-lib/projects/lib/src/test.ts
+++ b/packages/angular_devkit/build_angular/test/hello-world-lib/projects/lib/src/test.ts
@@ -27,7 +27,6 @@ declare const require: {
 getTestBed().initTestEnvironment(
   BrowserDynamicTestingModule,
   platformBrowserDynamicTesting(),
-  { teardown: { destroyAfterEach: true }},
 );
 // Then we find all the tests.
 const context = require.context('./', true, /\.spec\.ts$/);

--- a/packages/schematics/angular/application/files/src/test.ts.template
+++ b/packages/schematics/angular/application/files/src/test.ts.template
@@ -18,7 +18,6 @@ declare const require: {
 getTestBed().initTestEnvironment(
   BrowserDynamicTestingModule,
   platformBrowserDynamicTesting(),
-  { teardown: { destroyAfterEach: true }},
 );
 
 // Then we find all the tests.

--- a/packages/schematics/angular/library/files/src/test.ts.template
+++ b/packages/schematics/angular/library/files/src/test.ts.template
@@ -19,7 +19,6 @@ declare const require: {
 getTestBed().initTestEnvironment(
   BrowserDynamicTestingModule,
   platformBrowserDynamicTesting(),
-  { teardown: { destroyAfterEach: true }},
 );
 
 // Then we find all the tests.


### PR DESCRIPTION
This is now enabled by default.

See https://github.com/angular/angular/pull/43353 for more context.