### PR TITLE
docs: mark `@angular-devkit/build-optimizer` as deprecated.

### DIFF
--- a/packages/angular_devkit/build_optimizer/README.md
+++ b/packages/angular_devkit/build_optimizer/README.md
@@ -2,6 +2,11 @@
 
 Angular Build Optimizer contains Angular optimizations applicable to JavaScript code as a TypeScript transform pipeline.
 
+This package is **deprecated** and should not be used. It has always been experimental (never hit
+`1.0.0`) and was an internal package for the Angular CLI. All the relevant functionality has been
+moved into
+[`@angular-devkit/build-angular`](https://npmjs.com/package/@angular-devkit/build-angular).
+
 ## Available optimizations
 
 Transformations applied depend on file content:


### PR DESCRIPTION
It's functionality has been included in `@angular-devkit/build-angular` so this package is no longer needed by the CLI and we will stop publishing the package soon.