### PR TITLE
test(@angular-devkit/build-webpack): disable webpack cache during uni…

### DIFF
--- a/packages/angular_devkit/build_webpack/test/angular-app/angular.json
+++ b/packages/angular_devkit/build_webpack/test/angular-app/angular.json
@@ -2,7 +2,11 @@
   "$schema": "../../../../packages/angular_devkit/core/src/workspace/workspace-schema.json",
   "version": 1,
   "newProjectRoot": "./projects",
-  "cli": {},
+  "cli": {
+    "cache": {
+      "enabled": false
+    }
+  },
   "schematics": {},
   "targets": {},
   "projects": {


### PR DESCRIPTION
…t tests

Unit tests are not isolated and therefore using cache might be flakey due to race conditions.