### PR TITLE
refactor(@angular-devkit/build-angular): remove redundant `require.resolve` for `@angular/service-worker`

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/app-shell/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/app-shell/index.ts
@@ -114,7 +114,6 @@ async function _renderUniversal(
 
     if (browserOptions.serviceWorker) {
       await augmentAppWithServiceWorker(
-        normalize(root),
         projectRoot,
         normalize(outputPath),
         browserOptions.baseHref || '/',

--- a/packages/angular_devkit/build_angular/src/builders/browser/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/index.ts
@@ -352,7 +352,6 @@ export function buildWebpackBrowser(
                   for (const [locale, outputPath] of outputPaths.entries()) {
                     try {
                       await augmentAppWithServiceWorker(
-                        root,
                         normalize(projectRoot),
                         normalize(outputPath),
                         getLocaleBaseHref(i18n, locale) || options.baseHref || '/',


### PR DESCRIPTION


This was mainly done prior to the introduction of optional peer dependencies.