### PR TITLE
fix(@angular/cli): add engine field support for npm 8 and higher

### DIFF
--- a/lib/packages.ts
+++ b/lib/packages.ts
@@ -86,7 +86,7 @@ function loadPackageJson(p: string) {
       case 'engines':
         pkg['engines'] = {
           'node': '^12.20.0 || ^14.15.0 || >=16.10.0',
-          'npm': '^6.11.0 || ^7.5.6',
+          'npm': '^6.11.0 || ^7.5.6 || >=8.0.0',
           'yarn': '>= 1.13.0',
         };
         break;


### PR DESCRIPTION
The `npm` package manager recently released version 8. This version removes support for older versions of Node.js but retains support for the versions that align with Angular's support range. The Angular CLI packages unfortunately did not support version 8 due to the ranges only permitting versions ^6.11.0 and ^7.5.6 which were the minimums for each that ensured a functioning Angular CLI environment. The range has now been expanded to include >=8.0.0 to allow newer versions of `npm` to function as well.

npm 8.0.0 release information: https://github.com/npm/cli/releases/tag/v8.0.0