### PR TITLE
fix(@angular/cli): accept `UA-00000-0` format in analytics `tracking` id

### DIFF
--- a/packages/angular/cli/lib/config/workspace-schema.json
+++ b/packages/angular/cli/lib/config/workspace-schema.json
@@ -69,7 +69,7 @@
             "tracking": {
               "description": "Analytics sharing info tracking ID.",
               "type": "string",
-              "pattern": "^GA-\\d+-\\d+$"
+              "pattern": "^(GA|UA)?-\\d+-\\d+$"
             },
             "uuid": {
               "description": "Analytics sharing info universally unique identifier.",


### PR DESCRIPTION
With this change we update the validation of the tracking id to accept  tracking ids in `UA-00000-0` format.

Partially addressses #21916