### PR TITLE
fix(@angular/cli): unset config value when setting empty string

### DIFF
--- a/packages/angular/cli/commands/config-impl.ts
+++ b/packages/angular/cli/commands/config-impl.ts
@@ -24,7 +24,7 @@ const validCliPaths = new Map<
   ['cli.analytics', undefined],
 
   ['cli.analyticsSharing.tracking', undefined],
-  ['cli.analyticsSharing.uuid', (v) => (v ? `${v}` : uuidV4())],
+  ['cli.analyticsSharing.uuid', (v) => (v == undefined ? uuidV4() : `${v}`)],
 
   ['cli.cache.enabled', undefined],
   ['cli.cache.environment', undefined],
@@ -77,6 +77,7 @@ function normalizeValue(value: string | undefined | boolean | number): JsonValue
     case 'null':
       return null;
     case 'undefined':
+    case '':
       return undefined;
   }
 

--- a/tests/legacy-cli/e2e/tests/commands/config/config-set.ts
+++ b/tests/legacy-cli/e2e/tests/commands/config/config-set.ts
@@ -15,13 +15,25 @@ export default async function () {
     throw new Error(`Expected "yarn", received "${JSON.stringify(stdout2)}".`);
   }
 
+  // Set config as object literal
   await ng('config', 'schematics', '{"@schematics/angular:component":{"style": "scss"}}');
   const { stdout: stdout3 } = await ng('config', 'schematics.@schematics/angular:component.style');
   if (!stdout3.includes('scss')) {
     throw new Error(`Expected "scss", received "${JSON.stringify(stdout3)}".`);
   }
 
+  // Remove config when setting value to undefined.
   await ng('config', 'schematics');
   await ng('config', 'schematics', 'undefined');
   await expectToFail(() => ng('config', 'schematics'));
+
+  // Remove config when setting value to empty string.
+  await ng('config', 'cli.analyticsSharing.uuid', 'foo-bar');
+  const { stdout: stdout4 } = await ng('config', 'cli.analyticsSharing.uuid');
+  if (!stdout4.includes('foo-bar')) {
+    throw new Error(`Expected "foo-bar", received "${JSON.stringify(stdout3)}".`);
+  }
+
+  await ng('config', 'cli.analyticsSharing.uuid', '');
+  await expectToFail(() => ng('config', 'cli.analyticsSharing.uuid'));
 }


### PR DESCRIPTION
This fixes an issue were when using an empty string as value the property was not removed from the worksapce configuration.

Example, the below will remove `uuid` property from the `analyticsSharing` configuration object.

```
ng config  cli.analyticsSharing.uuid ""
```