### PR TITLE
refactor(@angular-devkit/build-angular): replace `Ivy Enabled` analytics dimension with `AOT Enabled`

### DIFF
--- a/docs/design/analytics.md
+++ b/docs/design/analytics.md
@@ -51,7 +51,7 @@ Note: There's a limit of 20 custom dimensions.
 | 5 | `Flag: --style` | `string` |
 | 6 | `--collection` | `string` |
 | 7 | `Flag: --strict` | `boolean` |
-| 8 | `Ivy Enabled` | `boolean` |
+| 8 | `AOT Enabled` | `boolean` |
 | 9 | `Flag: --inline-style` | `boolean` |
 | 10 | `Flag: --inline-template` | `boolean` |
 | 11 | `Flag: --view-encapsulation` | `string` |

--- a/goldens/public-api/angular_devkit/core/src/index.md
+++ b/goldens/public-api/angular_devkit/core/src/index.md
@@ -1074,6 +1074,8 @@ class MultiAnalytics implements Analytics {
 // @public
 enum NgCliAnalyticsDimensions {
     // (undocumented)
+    AotEnabled = 8,
+    // (undocumented)
     BuildErrors = 20,
     // (undocumented)
     CpuCount = 1,
@@ -1081,8 +1083,6 @@ enum NgCliAnalyticsDimensions {
     CpuSpeed = 2,
     // (undocumented)
     NgAddCollection = 6,
-    // (undocumented)
-    NgIvyEnabled = 8,
     // (undocumented)
     NodeVersion = 4,
     // (undocumented)

--- a/packages/angular_devkit/build_angular/src/webpack/configs/analytics.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/analytics.ts
@@ -28,6 +28,13 @@ export function getAnalyticsConfig(
 
   // The category is the builder name if it's an angular builder.
   return {
-    plugins: [new NgBuildAnalyticsPlugin(wco.projectRoot, context.analytics, category, true)],
+    plugins: [
+      new NgBuildAnalyticsPlugin(
+        wco.projectRoot,
+        context.analytics,
+        category,
+        wco.buildOptions.aot ?? false,
+      ),
+    ],
   };
 }

--- a/packages/angular_devkit/build_angular/src/webpack/plugins/analytics.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/plugins/analytics.ts
@@ -81,7 +81,7 @@ export class NgBuildAnalyticsPlugin {
     protected _projectRoot: string,
     protected _analytics: analytics.Analytics,
     protected _category: string,
-    private _isIvy: boolean,
+    private aotEnabled: boolean,
   ) {}
 
   protected _reset() {
@@ -115,7 +115,7 @@ export class NgBuildAnalyticsPlugin {
       dimensions[analytics.NgCliAnalyticsDimensions.BuildErrors] = `,${this._stats.errors.join()},`;
     }
 
-    dimensions[analytics.NgCliAnalyticsDimensions.NgIvyEnabled] = this._isIvy;
+    dimensions[analytics.NgCliAnalyticsDimensions.AotEnabled] = this.aotEnabled;
 
     return dimensions;
   }

--- a/packages/angular_devkit/core/src/analytics/index.ts
+++ b/packages/angular_devkit/core/src/analytics/index.ts
@@ -27,7 +27,7 @@ export enum NgCliAnalyticsDimensions {
   RamInGigabytes = 3,
   NodeVersion = 4,
   NgAddCollection = 6,
-  NgIvyEnabled = 8,
+  AotEnabled = 8,
   BuildErrors = 20,
 }
 
@@ -57,7 +57,7 @@ export const NgCliAnalyticsDimensionsFlagInfo: { [name: string]: [string, string
   RamInGigabytes: ['RAM (In GB)', 'number'],
   NodeVersion: ['Node Version', 'number'],
   NgAddCollection: ['--collection', 'string'],
-  NgIvyEnabled: ['Ivy Enabled', 'boolean'],
+  AotEnabled: ['AOT Enabled', 'boolean'],
   BuildErrors: ['Build Errors (comma separated)', 'string'],
 };
 


### PR DESCRIPTION


The motivation behind this change is that since version 12, application are always built using Ivy, in addition to this, adding AOT as dimension might be  helpful in our decision process if we want to remove JIT.