### PR TITLE
ci: update `default_nodeversion` to `14.17`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,9 +17,9 @@ orbs:
 ## IMPORTANT
 # Windows needs its own cache key because binaries in node_modules are different.
 # See https://circleci.com/docs/2.0/caching/#restoring-cache for how prefixes work in CircleCI.
-var_1: &cache_key v1-angular_devkit-14.15-{{ checksum "yarn.lock" }}
+var_1: &cache_key v1-angular_devkit-14.17-{{ checksum "yarn.lock" }}
 var_1_win: &cache_key_win v1-angular_devkit-win-12.22-{{ checksum "yarn.lock" }}
-var_3: &default_nodeversion '14.15'
+var_3: &default_nodeversion '14.17'
 # Workspace initially persisted by the `setup` job, and then enhanced by `setup-and-build-win`.
 # https://circleci.com/docs/2.0/workflows/#using-workspaces-to-share-data-among-jobs
 # https://circleci.com/blog/deep-diving-into-circleci-workspaces/
@@ -338,6 +338,7 @@ workflows:
             - setup
       - e2e-cli:
           name: e2e-cli
+          nodeversion: '14.15'
           post-steps:
             - store_artifacts:
                 path: /tmp/dist


### PR DESCRIPTION
This is needed because Eslint 8 requires 14.17.x or higher.