### PR TITLE
fix(@angular/cli): generate new random user ID when passing empty string to `uuid`

### DIFF
--- a/packages/angular/cli/commands/config-impl.ts
+++ b/packages/angular/cli/commands/config-impl.ts
@@ -24,7 +24,7 @@ const validCliPaths = new Map<
 
   ['cli.analytics', undefined],
   ['cli.analyticsSharing.tracking', undefined],
-  ['cli.analyticsSharing.uuid', (v) => (v ? `${v}` : uuidV4())],
+  ['cli.analyticsSharing.uuid', (v) => (v === '' ? uuidV4() : `${v}`)],
 ]);
 
 /**
@@ -80,7 +80,15 @@ function normalizeValue(value: string | undefined | boolean | number): JsonValue
     return +valueString;
   }
 
-  return parseJson(valueString) ?? value ?? undefined;
+  try {
+    // We use `JSON.parse` instead of `parseJson` because the latter will parse UUIDs
+    // and convert them into a numberic entities.
+    // Example: 73b61974-182c-48e4-b4c6-30ddf08c5c98 -> 73.
+    // These values should never contain comments, therefore using `JSON.parse` is safe.
+    return JSON.parse(valueString);
+  } catch {
+    return value;
+  }
 }
 
 export class ConfigCommand extends Command<ConfigCommandSchema> {

--- a/packages/angular/cli/lib/config/workspace-schema.json
+++ b/packages/angular/cli/lib/config/workspace-schema.json
@@ -73,7 +73,8 @@
             },
             "uuid": {
               "description": "Analytics sharing info universally unique identifier.",
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           }
         }

--- a/tests/legacy-cli/e2e/tests/commands/config/config-set.ts
+++ b/tests/legacy-cli/e2e/tests/commands/config/config-set.ts
@@ -24,4 +24,17 @@ export default async function () {
   await ng('config', 'schematics');
   await ng('config', 'schematics', 'undefined');
   await expectToFail(() => ng('config', 'schematics'));
+
+  /**
+   * `ng config cli.analyticsSharing.uuid ""` should generate new random user ID.
+   * @see: https://angular.io/cli/usage-analytics-gathering#per-user-tracking
+   */
+  await ng('config', 'cli.analyticsSharing.uuid', '');
+  const { stdout: stdout4 } = await ng('config', 'cli.analyticsSharing.uuid');
+  console.log(stdout4);
+  if (!/(?:urn:uuid:)?[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}/i.test(stdout4)) {
+    throw new Error(
+      `Expected "cli.analyticsSharing.uuid" to be a UUID, received "${JSON.stringify(stdout4)}".`,
+    );
+  }
 }


### PR DESCRIPTION

patch version of https://github.com/angular/angular-cli/pull/21926