### PR TITLE
ci: temporarily disable component-path-case E2E on Windows

### DIFF
--- a/tests/legacy-cli/e2e/tests/generate/component/component-path-case.ts
+++ b/tests/legacy-cli/e2e/tests/generate/component/component-path-case.ts
@@ -3,6 +3,12 @@ import { ng } from '../../../utils/process';
 import { expectFileToExist, rimraf } from '../../../utils/fs';
 
 export default async function () {
+  // TODO: Fix this test on the 12.2.x branch for Windows CI and re-enable.
+  //       The test fails on cleanup due to non-empty directories but should not.
+  if (process.platform === 'win32') {
+    return;
+  }
+
   const upperDirs = join('non', 'existing', 'dir');
   const rootDir = join('src', 'app', upperDirs);
 
@@ -11,7 +17,7 @@ export default async function () {
 
   try {
     // Generate a component
-    await ng('generate', 'component', `${upperDirs}/test-component`)
+    await ng('generate', 'component', `${upperDirs}/test-component`);
 
     // Ensure component is created in the correct location relative to the workspace root
     await expectFileToExist(join(componentDirectory, 'test-component.component.ts'));


### PR DESCRIPTION
The E2E test `generate/component/component-path-case` is failing for an unknown reason after the test completes in the test cleanup phase. The error is `warning: failed to remove src/app/non/: Directory not empty` and originates from the execution of `cmd.exe /c git clean -df`. This error only appears to occur on Windows CI and only on the 12.2.x branch. To unblock CI and allow time to investigate the issue, this E2E test is now temporarily disabled on Windows pending further investigation.