### PR TITLE
feat(@angular-devkit/build-angular): add "Failed to compile" message

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/dev-server/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/index.ts
@@ -279,6 +279,8 @@ export function serveWebpackBrowser(
 
           if (buildEvent.success) {
             logger.info(`\n${colors.greenBright(colors.symbols.check)} Compiled successfully.`);
+          } else {
+            logger.info(`\n${colors.redBright(colors.symbols.cross)} Failed to compile.`);
           }
 
           return { ...buildEvent, baseUrl: serverAddress } as DevServerBuilderOutput;


### PR DESCRIPTION
Add missing "Failed to compile" message when the webpack build is not
successful. This is useful for [background problem matchers](https://code.visualstudio.com/docs/editor/tasks#_background-watching-tasks).
Previously, it was not possible to tell using a regular expression when
the compiler has stopped when there was an error, as no message was
printed.