### PR TITLE
fix(@angular/cli): run stable migrations when package version is prerelease

### DIFF
--- a/packages/angular/cli/commands/update-impl.ts
+++ b/packages/angular/cli/commands/update-impl.ts
@@ -194,7 +194,7 @@ export class UpdateCommand extends Command<UpdateCommandSchema> {
   ): Promise<boolean> {
     const collection = this.workflow.engine.createCollection(collectionPath);
     const migrationRange = new semver.Range(
-      '>' + (semver.prerelease(from) ? from.split('-')[0] + '-0' : from) + ' <=' + to,
+      '>' + (semver.prerelease(from) ? from.split('-')[0] + '-0' : from) + ' <=' + to.split('-')[0],
     );
     const migrations = [];
 


### PR DESCRIPTION

With this change we fix an issue were migrations are not run when the version specified in migration collection is specified as stable example `13.0.0`, but the version specified in the `package.json` is still a prerelease example `13.0.0-rc.0`.

Closes: #21969