### PR TITLE
docs: release notes for the v12.2.11 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,31 @@
+<a name="12.2.11"></a>
+
+# 12.2.11 (2021-10-20)
+
+### @angular/cli
+
+| Commit                                                                                              | Type | Description                                              |
+| --------------------------------------------------------------------------------------------------- | ---- | -------------------------------------------------------- |
+| [e0112603c](https://github.com/angular/angular-cli/commit/e0112603c139847c649413ba95faef93d9b74bf0) | fix  | add engine field support for npm 8 and higher            |
+| [b93e63ff6](https://github.com/angular/angular-cli/commit/b93e63ff6b99ecdf4d5861feea3dd5b5adf86061) | fix  | correct grammar error in Analytics consent prompt        |
+| [008094bd1](https://github.com/angular/angular-cli/commit/008094bd1690aa73fdfd18852fd7b8b274c22e7f) | fix  | run stable migrations when package version is prerelease |
+
+### @angular-devkit/build-angular
+
+| Commit                                                                                              | Type | Description                                      |
+| --------------------------------------------------------------------------------------------------- | ---- | ------------------------------------------------ |
+| [227bf2e86](https://github.com/angular/angular-cli/commit/227bf2e86b8a6e6fe41fdbc0f77365d96d79d831) | fix  | add "Failed to compile" message                  |
+| [6173609c5](https://github.com/angular/angular-cli/commit/6173609c5b1fd27c75cee8dd9b67de9ef332ef98) | fix  | transform remapped sourcemap into a plain object |
+| [349047523](https://github.com/angular/angular-cli/commit/349047523ad0110a25d7f730cd0160b76dcfc265) | fix  | update `esbuild` to 0.13.8                       |
+| [892eeadd1](https://github.com/angular/angular-cli/commit/892eeadd11f8b702094640addc8a6f16236e5e08) | fix  | update `mini-css-extract-plugin` to 2.4.2        |
+| [8d52d9b7f](https://github.com/angular/angular-cli/commit/8d52d9b7faa44be5063905ed54b3c0d12d506af4) | fix  | use a separate worker pool for i18n inlining     |
+
+## Special Thanks
+
+Alan Agius, Charles Lyding, Extacy and Sushrit_Lawliet
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="13.0.0-rc.0"></a>
 
 # 13.0.0-rc.0 (2021-10-13)


### PR DESCRIPTION
Cherry-picks the changelog from the "12.2.x" branch to the next branch (master).