### PR TITLE
test(@angular-devkit/build-angular): update tests to reflect new output of `critters`

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser/tests/options/inline-critical_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/tests/options/inline-critical_spec.ts
@@ -55,7 +55,7 @@ describeBuilder(buildWebpackBrowser, BROWSER_BUILDER_INFO, (harness) => {
         .content.toContain(
           `<link rel="stylesheet" href="styles.css" media="print" onload="this.media='all'">`,
         );
-      harness.expectFile('dist/index.html').content.toContain(`body{color:#000;}`);
+      harness.expectFile('dist/index.html').content.toContain(`body{color:#000}`);
     });
 
     it(`should extract critical css when 'optimization' is true`, async () => {
@@ -73,7 +73,7 @@ describeBuilder(buildWebpackBrowser, BROWSER_BUILDER_INFO, (harness) => {
         .content.toContain(
           `<link rel="stylesheet" href="styles.css" media="print" onload="this.media='all'">`,
         );
-      harness.expectFile('dist/index.html').content.toContain(`body{color:#000;}`);
+      harness.expectFile('dist/index.html').content.toContain(`body{color:#000}`);
     });
 
     it(`should not extract critical css when 'optimization' is false`, async () => {


### PR DESCRIPTION
The tests have been re-introduced in the code base via a revert #21899

Fixes CI failures.
