### PR TITLE
fix(@angular-devkit/build-angular): update `critters` to version `0.0.12`

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "conventional-commits-parser": "^3.0.0",
     "copy-webpack-plugin": "6.3.2",
     "core-js": "3.8.3",
-    "critters": "0.0.7",
+    "critters": "0.0.12",
     "css-loader": "5.0.1",
     "cssnano": "5.0.2",
     "debug": "^4.1.1",

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -30,7 +30,7 @@
     "circular-dependency-plugin": "5.2.2",
     "copy-webpack-plugin": "6.3.2",
     "core-js": "3.8.3",
-    "critters": "0.0.7",
+    "critters": "0.0.12",
     "css-loader": "5.0.1",
     "cssnano": "5.0.2",
     "file-loader": "6.2.0",

--- a/packages/angular_devkit/build_angular/src/app-shell/app-shell_spec.ts
+++ b/packages/angular_devkit/build_angular/src/app-shell/app-shell_spec.ts
@@ -290,7 +290,7 @@ describe('AppShell Builder', () => {
     const content = virtualFs.fileBufferToString(host.scopedSync().read(normalize(fileName)));
 
     expect(content).toContain('app-shell works!');
-    expect(content).toContain('p{color:#000;}');
+    expect(content).toContain('p{color:#000}');
     expect(content).toMatch(/<link rel="stylesheet" href="styles\.[a-z0-9]+\.css" media="print" onload="this\.media='all'">/);
   });
 });

--- a/packages/angular_devkit/build_angular/src/browser/specs/inline-critical-css-optimization_spec.ts
+++ b/packages/angular_devkit/build_angular/src/browser/specs/inline-critical-css-optimization_spec.ts
@@ -39,20 +39,20 @@ describe('Browser Builder inline critical CSS optimization', () => {
     const { files } = await browserBuild(architect, host, target, overrides);
     const html = await files['index.html'];
     expect(html).toContain(`<link rel="stylesheet" href="styles.css" media="print" onload="this.media='all'">`);
-    expect(html).toContain(`body{color:#000;}`);
+    expect(html).toContain(`body{color:#000}`);
   });
 
   it('works with deployUrl', async () => {
     const { files } = await browserBuild(architect, host, target, { ...overrides, deployUrl: 'http://cdn.com/' });
     const html = await files['index.html'];
     expect(html).toContain(`<link rel="stylesheet" href="http://cdn.com/styles.css" media="print" onload="this.media='all'">`);
-    expect(html).toContain(`body{color:#000;}`);
+    expect(html).toContain(`body{color:#000}`);
   });
 
   it('should not inline critical css when option is disabled', async () => {
     const { files } = await browserBuild(architect, host, target, { optimization: false });
     const html = await files['index.html'];
     expect(html).toContain(`<link rel="stylesheet" href="styles.css">`);
-    expect(html).not.toContain(`body{color:#000;}`);
+    expect(html).not.toContain(`body{color:#000}`);
   });
 });

--- a/packages/angular_devkit/build_angular/src/dev-server/inline-critical-css-optimization_spec.ts
+++ b/packages/angular_devkit/build_angular/src/dev-server/inline-critical-css-optimization_spec.ts
@@ -43,7 +43,7 @@ describe('Dev Server Builder inline critical CSS optimization', () => {
       mergeMap(async output => {
         expect(output.success).toBe(true);
         const response = await fetch(`${output.baseUrl}/index.html`);
-        expect(await response.text()).toContain(`body{color:#000;}`);
+        expect(await response.text()).toContain(`body{color:#000}`);
       }),
     ).toPromise();
 

--- a/packages/angular_devkit/build_angular/src/utils/index-file/inline-critical-css.ts
+++ b/packages/angular_devkit/build_angular/src/utils/index-file/inline-critical-css.ts
@@ -23,13 +23,16 @@ class CrittersExtended extends Critters {
   readonly warnings: string[] = [];
   readonly errors: string[] = [];
 
-  constructor(private readonly optionsExtended: InlineCriticalCssProcessorOptions & InlineCriticalCssProcessOptions) {
+  constructor(
+    private readonly optionsExtended: InlineCriticalCssProcessorOptions &
+      InlineCriticalCssProcessOptions,
+  ) {
     super({
       logger: {
         warn: (s: string) => this.warnings.push(s),
         error: (s: string) => this.errors.push(s),
-        log: () => { },
-        info: () => { },
+        log: () => {},
+        info: () => {},
       },
       path: optionsExtended.outputPath,
       publicPath: optionsExtended.deployUrl,
@@ -44,7 +47,7 @@ class CrittersExtended extends Critters {
     } as any);
   }
 
-  protected readFile(path: string): Promise<string> {
+  public readFile(path: string): Promise<string> {
     const readAsset = this.optionsExtended.readAsset;
 
     return readAsset ? readAsset(path) : readFile(path, 'utf-8');
@@ -52,10 +55,12 @@ class CrittersExtended extends Critters {
 }
 
 export class InlineCriticalCssProcessor {
-  constructor(protected readonly options: InlineCriticalCssProcessorOptions) { }
+  constructor(protected readonly options: InlineCriticalCssProcessorOptions) {}
 
-  async process(html: string, options: InlineCriticalCssProcessOptions)
-    : Promise<{ content: string, warnings: string[], errors: string[] }> {
+  async process(
+    html: string,
+    options: InlineCriticalCssProcessOptions,
+  ): Promise<{ content: string; warnings: string[]; errors: string[] }> {
     const critters = new CrittersExtended({ ...this.options, ...options });
     const content = await critters.process(html);
 

--- a/packages/angular_devkit/build_angular/src/utils/index-file/inline-critical-css_spec.ts
+++ b/packages/angular_devkit/build_angular/src/utils/index-file/inline-critical-css_spec.ts
@@ -53,14 +53,10 @@ describe('InlineCriticalCssProcessor', () => {
     expect(content).toContain(`<link href="theme.css" rel="stylesheet" media="print" onload="this.media='all'">`);
     expect(content).not.toContain('color: blue');
     expect(tags.stripIndents`${content}`).toContain(tags.stripIndents`
-    <style>body {
-      margin: 0;
-      }
-
-      html {
-      color: white;
-      }</style>
-      `);
+    <style>
+    body { margin: 0; }
+    html { color: white; }
+    </style>`);
   });
 
   it('should inline critical css when using deployUrl', async () => {
@@ -76,14 +72,10 @@ describe('InlineCriticalCssProcessor', () => {
     expect(content).toContain(`<link href="http://cdn.com/styles.css" rel="stylesheet" media="print" onload="this.media='all'">`);
     expect(content).toContain(`<link href="http://cdn.com/theme.css" rel="stylesheet" media="print" onload="this.media='all'">`);
     expect(tags.stripIndents`${content}`).toContain(tags.stripIndents`
-    <style>body {
-      margin: 0;
-      }
-
-      html {
-      color: white;
-      }</style>
-      `);
+    <style>
+    body { margin: 0; }
+    html { color: white; }
+    </style>`);
   });
 
   it('should compress inline critical css when minify is enabled', async () => {
@@ -98,6 +90,6 @@ describe('InlineCriticalCssProcessor', () => {
 
     expect(content).toContain(`<link href="styles.css" rel="stylesheet" media="print" onload="this.media='all'">`);
     expect(content).toContain(`<link href="theme.css" rel="stylesheet" media="print" onload="this.media='all'">`);
-    expect(content).toContain('<style>body{margin:0;}html{color:white;}</style>');
+    expect(content).toContain('<style>body{margin:0}html{color:white}</style>');
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3912,15 +3912,16 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-critters@0.0.7:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/critters/-/critters-0.0.7.tgz#548b470360f4f3c51e622de3b7aa733c8f0b17bf"
-  integrity sha512-qUF2SaAWFYjNPdCcPpu68p2DnHiosia84yx5mPTlUMQjkjChR+n6sO1/I7yn2U2qNDgSPTd2SoaTIDQcUL+EwQ==
+critters@0.0.12:
+  version "0.0.12"
+  resolved "https://registry.yarnpkg.com/critters/-/critters-0.0.12.tgz#32baa87526e053a41b67e19921673ed92264e2ab"
+  integrity sha512-ujxKtKc/mWpjrOKeaACTaQ1aP0O31M0ZPWhfl85jZF1smPU4Ivb9va5Ox2poif4zVJQQo0LCFlzGtEZAsCAPcw==
   dependencies:
     chalk "^4.1.0"
-    css "^3.0.0"
+    css-select "^4.1.3"
     parse5 "^6.0.1"
     parse5-htmlparser2-tree-adapter "^6.0.1"
+    postcss "^8.3.7"
     pretty-bytes "^5.3.0"
 
 cross-spawn@^6.0.0:
@@ -4036,6 +4037,17 @@ css-select@^3.1.2:
     domutils "^2.4.3"
     nth-check "^2.0.0"
 
+css-select@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-4.1.3.tgz#a70440f70317f2669118ad74ff105e65849c7067"
+  integrity sha512-gT3wBNd9Nj49rAbmtFHj1cljIAOLYSX1nZ8CB7TBO3INYckygm5B7LISU/szY//YmdiSLbJvDLOx9VnMVpMBxA==
+  dependencies:
+    boolbase "^1.0.0"
+    css-what "^5.0.0"
+    domhandler "^4.2.0"
+    domutils "^2.6.0"
+    nth-check "^2.0.0"
+
 css-selector-tokenizer@^0.7.1:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/css-selector-tokenizer/-/css-selector-tokenizer-0.7.3.tgz#735f26186e67c749aaf275783405cf0661fae8f1"
@@ -4070,6 +4082,11 @@ css-what@^4.0.0:
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-4.0.0.tgz#35e73761cab2eeb3d3661126b23d7aa0e8432233"
   integrity sha512-teijzG7kwYfNVsUh2H/YN62xW3KK9YhXEgSlbxMlcyjPNvdKJqFx5lrwlJgoFP1ZHlB89iGDlo/JyshKeRhv5A==
 
+css-what@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-5.1.0.tgz#3f7b707aadf633baf62c2ceb8579b545bb40f7fe"
+  integrity sha512-arSMRWIIFY0hV8pIxZMEfmMI47Wj3R/aWpZDDxWYCPEiOMv6tfOrnpDtgxBYPEQD4V0Y/958+1TdC3iWTFcUPw==
+
 css@^2.0.0:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/css/-/css-2.2.4.tgz#c646755c73971f2bba6a601e2cf2fd71b1298929"
@@ -4079,15 +4096,6 @@ css@^2.0.0:
     source-map "^0.6.1"
     source-map-resolve "^0.5.2"
     urix "^0.1.0"
-
-css@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/css/-/css-3.0.0.tgz#4447a4d58fdd03367c516ca9f64ae365cee4aa5d"
-  integrity sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==
-  dependencies:
-    inherits "^2.0.4"
-    source-map "^0.6.1"
-    source-map-resolve "^0.6.0"
 
 cssauron@^1.4.0:
   version "1.4.0"
@@ -4658,6 +4666,15 @@ domutils@^2.4.3:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.6.0.tgz#2e15c04185d43fb16ae7057cb76433c6edb938b7"
   integrity sha512-y0BezHuy4MDYxh6OvolXYsH+1EMGmFbwv5FKW7ovwMG6zTPWqNPq3WF9ayZssFq+UlKdffGLbOEaghNdaOm1WA==
+  dependencies:
+    dom-serializer "^1.0.1"
+    domelementtype "^2.2.0"
+    domhandler "^4.2.0"
+
+domutils@^2.6.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.8.0.tgz#4437def5db6e2d1f5d6ee859bd95ca7d02048135"
+  integrity sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==
   dependencies:
     dom-serializer "^1.0.1"
     domelementtype "^2.2.0"
@@ -8068,6 +8085,11 @@ nanoid@^3.1.23:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.23.tgz#f744086ce7c2bc47ee0a8472574d5c78e4183a81"
   integrity sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==
 
+nanoid@^3.1.30:
+  version "3.1.30"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.30.tgz#63f93cc548d2a113dc5dfbc63bfa09e2b9b64362"
+  integrity sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -9007,6 +9029,11 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
+picocolors@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
+  integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
+
 picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1, picomatch@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
@@ -9674,6 +9701,15 @@ postcss@^8.1.4:
     colorette "^1.2.1"
     nanoid "^3.1.20"
     source-map "^0.6.1"
+
+postcss@^8.3.7:
+  version "8.3.11"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.3.11.tgz#c3beca7ea811cd5e1c4a3ec6d2e7599ef1f8f858"
+  integrity sha512-hCmlUAIlUiav8Xdqw3Io4LcpA1DOt7h3LSTAC4G6JGHFFaWzI6qvFt9oilvl8BmkbBRX1IhM90ZAmpk68zccQA==
+  dependencies:
+    nanoid "^3.1.30"
+    picocolors "^1.0.0"
+    source-map-js "^0.6.2"
 
 prelude-ls@~1.1.2:
   version "1.1.2"
@@ -10995,6 +11031,11 @@ source-list-map@^2.0.0, source-list-map@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
+
+source-map-js@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-0.6.2.tgz#0bb5de631b41cfbda6cfba8bd05a80efdfd2385e"
+  integrity sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==
 
 source-map-loader@1.1.3:
   version "1.1.3"


### PR DESCRIPTION

This change brings in a security fix causes was causes by an outdated dependency. See https://github.com/GoogleChromeLabs/critters/pull/82 for more information.

Also, remote stylesheets are excluded from processing, were previously this caused build failures.

Closes #20794