### PR TITLE
fix(@angular/cli): exclude packages from ng add that contain invalid peer dependencies

### DIFF
--- a/packages/angular/cli/utilities/spinner.ts
+++ b/packages/angular/cli/utilities/spinner.ts
@@ -44,7 +44,7 @@ export class Spinner {
   }
 
   warn(text?: string): void {
-    this.spinner.fail(text && colors.yellowBright(text));
+    this.spinner.warn(text && colors.yellowBright(text));
   }
 
   stop(): void {


### PR DESCRIPTION
Certain older versions of packages may contain missing or invalid peer dependencies. As a result these packages may be incorrectly added to the project when no newer compatible version is found. An exclusion list is now present within `ng add` that will exclude packages with known peer dependency concerns from consideration when adding a package. This will cause the fallback to the `latest` tag instead of installing a potentially very old and incompatible version. Currently, only `@angular/localize@9.x` is included in the list and is also no longer an actively supported version.