### PR TITLE
fix(@angular-devkit/build-angular): move `@angular/localize` detection prior to webpack initialization

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/extract-i18n/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/extract-i18n/index.ts
@@ -156,6 +156,16 @@ export async function execute(
     throw new Error('The builder requires a target.');
   }
 
+  try {
+    require.resolve('@angular/localize');
+  } catch {
+    return {
+      success: false,
+      error: `i18n extraction requires the '@angular/localize' package.`,
+      outputPath: outFile,
+    };
+  }
+
   const metadata = await context.getProjectMetadata(context.target);
   const i18n = createI18nOptions(metadata);
 
@@ -229,16 +239,6 @@ export async function execute(
       return partials;
     },
   );
-
-  try {
-    require.resolve('@angular/localize');
-  } catch {
-    return {
-      success: false,
-      error: `Ivy extraction requires the '@angular/localize' package.`,
-      outputPath: outFile,
-    };
-  }
 
   // All the localize usages are setup to first try the ESM entry point then fallback to the deep imports.
   // This provides interim compatibility while the framework is transitioned to bundled ESM packages.

--- a/tests/legacy-cli/e2e/tests/i18n/extract-ivy.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/extract-ivy.ts
@@ -14,7 +14,7 @@ export default async function () {
 
   // Should fail if `@angular/localize` is missing
   const { message: message1 } = await expectToFail(() => ng('extract-i18n'));
-  if (!message1.includes(`Ivy extraction requires the '@angular/localize' package.`)) {
+  if (!message1.includes(`i18n extraction requires the '@angular/localize' package.`)) {
     throw new Error('Expected localize package error message when missing');
   }
 


### PR DESCRIPTION
Fail faster if `@angular/localize` is not installed and update the error message since now there is a single extraction mode.