### PR TITLE
fix(@angular/cli): update `ng update` output for Angular packages

### DIFF
--- a/tests/legacy-cli/e2e/tests/update/update-multiple-versions.ts
+++ b/tests/legacy-cli/e2e/tests/update/update-multiple-versions.ts
@@ -9,24 +9,32 @@ export default async function () {
     await createProjectFromAsset('9.0-project', true, true);
     await setRegistry(false);
     await installWorkspacePackages();
-
     await setRegistry(true);
+
     const extraArgs = ['--force'];
     if (isPrereleaseCli()) {
       extraArgs.push('--next');
     }
 
-    const { message } = await expectToFail(() =>
-      ng('update', '@angular/cli', '--force', ...extraArgs),
-    );
+    // Update Angular from v9 to 10
+    const { stdout } = await ng('update', ...extraArgs);
+    if (!/@angular\/core\s+9\.\d\.\d+ -> 10\.\d\.\d+\s+ng update @angular\/core@10/.test(stdout)) {
+      // @angular/core                      9.x.x -> 10.x.x         ng update @angular/core@11
+      throw new Error(
+        `Output didn't match "@angular/core                      9.x.x -> 10.x.x         ng update @angular/core@10". OUTPUT: \n` +
+          stdout,
+      );
+    }
+
+    const { message } = await expectToFail(() => ng('update', '@angular/cli', ...extraArgs));
     if (
       !message.includes(
         `Updating multiple major versions of '@angular/cli' at once is not supported`,
       )
     ) {
-      console.error(message);
       throw new Error(
-        `Expected error message to include "Updating multiple major versions of '@angular/cli' at once is not supported" but didn't.`,
+        `Expected error message to include "Updating multiple major versions of '@angular/cli' at once is not supported" but didn't. OUTPUT: \n` +
+          message,
       );
     }
   } finally {


### PR DESCRIPTION
With #21986 we now error when updating `@angular/` and `@nguniversal/` packages across multiple major versions. With this chnage we update `ng update` output to show the correct instructions.

Before
```
$ ng update --next

 We analyzed your package.json, there are some packages to update:

      Name                               Version                  Command to update
     --------------------------------------------------------------------------------
      @angular/cli                       12.2.12 -> 13.0.0-rc.2   ng update @angular/cli --next
      @angular/core                      11.2.14 -> 13.0.0-rc.2   ng update @angular/core --next
```

Now
```
$ ng update --next

 We analyzed your package.json, there are some packages to update:

      Name                               Version                  Command to update
     --------------------------------------------------------------------------------
      @angular/cli                       12.2.12 -> 13.0.0-rc.2   ng update @angular/cli --next
      @angular/core                      11.2.14 -> 12.2.9        ng update @angular/core@12
```

Closes #19381