### PR TITLE
fix(@angular-devkit/build-angular): add verbose logging for differential loading and i18n

### DIFF
--- a/packages/angular_devkit/build_angular/src/browser/index.ts
+++ b/packages/angular_devkit/build_angular/src/browser/index.ts
@@ -414,6 +414,13 @@ export function buildWebpackBrowser(
                 const processActions: typeof actions = [];
                 let processRuntimeAction: ProcessBundleOptions | undefined;
                 for (const action of actions) {
+                  if (options.verbose) {
+                    context.logger.info(
+                      `[${new Date().toISOString()}] Differential loading file queued: ${
+                        action.filename
+                      }`,
+                    );
+                  }
                   // If SRI is enabled always process the runtime bundle
                   // Lazy route integrity values are stored in the runtime bundle
                   if (action.integrityAlgorithm && action.runtime) {
@@ -434,6 +441,22 @@ export function buildWebpackBrowser(
                   for await (const result of differentialLoadingExecutor.processAll(
                     processActions,
                   )) {
+                    if (options.verbose) {
+                      if (result.original) {
+                        context.logger.info(
+                          `[${new Date().toISOString()}] Differential loading file processed: ${
+                            result.original.filename
+                          }`,
+                        );
+                      }
+                      if (result.downlevel) {
+                        context.logger.info(
+                          `[${new Date().toISOString()}] Differential loading file processed: ${
+                            result.downlevel.filename
+                          }`,
+                        );
+                      }
+                    }
                     processResults.push(result);
                   }
                 } finally {
@@ -452,6 +475,12 @@ export function buildWebpackBrowser(
                   );
                 }
 
+                if (options.verbose) {
+                  context.logger.info(
+                    `[${new Date().toISOString()}] Differential loading processing complete.`,
+                  );
+                }
+
                 spinner.succeed('ES5 bundle generation complete.');
 
                 if (i18n.shouldInline) {
@@ -459,6 +488,13 @@ export function buildWebpackBrowser(
                   const inlineActions: InlineOptions[] = [];
                   for (const result of processResults) {
                     if (result.original) {
+                      if (options.verbose) {
+                        context.logger.info(
+                          `[${new Date().toISOString()}] i18n localize file queued: ${
+                            result.original.filename
+                          }`,
+                        );
+                      }
                       inlineActions.push({
                         filename: path.basename(result.original.filename),
                         // Memory mode is always enabled for i18n
@@ -472,6 +508,13 @@ export function buildWebpackBrowser(
                       });
                     }
                     if (result.downlevel) {
+                      if (options.verbose) {
+                        context.logger.info(
+                          `[${new Date().toISOString()}] i18n localize file queued: ${
+                            result.downlevel.filename
+                          }`,
+                        );
+                      }
                       inlineActions.push({
                         filename: path.basename(result.downlevel.filename),
                         // Memory mode is always enabled for i18n
@@ -492,10 +535,14 @@ export function buildWebpackBrowser(
                     options.subresourceIntegrity ? 'sha384' : undefined,
                   );
                   try {
+                    let localizedCount = 0;
                     for await (const result of i18nExecutor.inlineAll(inlineActions)) {
+                      localizedCount++;
                       if (options.verbose) {
                         context.logger.info(
-                          `Localized "${result.file}" [${result.count} translation(s)].`,
+                          `[${new Date().toISOString()}] (${localizedCount}/${
+                            inlineActions.length
+                          }) Localized "${result.file}" [${result.count} translation(s)].`,
                         );
                       }
                       for (const diagnostic of result.diagnostics) {


### PR DESCRIPTION
When the verbose option is enabled during a build, additional logs are generated for the differential loading and i18n localization processing. These logs can be used to trace which files were queued for processing and when the files were processed.