### PR TITLE
build: update some types to be compatible with Node v14

### DIFF
--- a/packages/angular_devkit/schematics/src/utility/update-buffer.ts
+++ b/packages/angular_devkit/schematics/src/utility/update-buffer.ts
@@ -52,7 +52,7 @@ export class Chunk {
       (this._right ? this._right.length : 0)
     );
   }
-  toString(encoding = 'utf-8') {
+  toString(encoding: BufferEncoding = 'utf-8') {
     return (
       (this._left ? this._left.toString(encoding) : '') +
       (this._content ? this._content.toString(encoding) : '') +
@@ -279,7 +279,7 @@ export class UpdateBuffer extends UpdateBufferBase {
     return this._originalContent;
   }
 
-  toString(encoding = 'utf-8'): string {
+  toString(encoding: BufferEncoding = 'utf-8'): string {
     return this._linkedList.reduce((acc, chunk) => acc + chunk.toString(encoding), '');
   }
   generate(): Buffer {


### PR DESCRIPTION
See http://cl/406111801 with the google3 version of this change. There's no immediate rush for this in the GitHub repository, but it is something we'll need to upgrade to eventually anyways once we bump our minimum Node version to 14.