### PR TITLE
fix(@angular-devkit/build-angular): use es2015 when generating server bundles

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/server.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/server.ts
@@ -33,7 +33,8 @@ export function getServerConfig(wco: WebpackConfigOptions): Configuration {
 
   return {
     resolve: {
-      mainFields: ['es2020', 'es2015', 'main', 'module'],
+      mainFields: ['es2015', 'main', 'module'],
+      conditionNames: ['es2015', '...'],
     },
     output: {
       libraryTarget: 'commonjs',


### PR DESCRIPTION

ES2020 can contain JS syntax which are not compatible with all supported Node.js versions such as optional chaining.