### PR TITLE
fix(@angular-devkit/build-angular): remove potential race condition in i18n worker execution

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/action-executor.ts
+++ b/packages/angular_devkit/build_angular/src/utils/action-executor.ts
@@ -47,21 +47,19 @@ export class BundleActionExecutor {
     actions: Iterable<I>,
     executor: (action: I) => Promise<O>,
   ): AsyncIterable<O> {
-    const executions = new Map<Promise<O>, Promise<O>>();
+    const executions = new Map<Promise<O>, Promise<[Promise<O>, O]>>();
     for (const action of actions) {
       const execution = executor(action);
       executions.set(
         execution,
-        execution.then((result) => {
-          executions.delete(execution);
-
-          return result;
-        }),
+        execution.then((result) => [execution, result]),
       );
     }
 
     while (executions.size > 0) {
-      yield Promise.race(executions.values());
+      const [execution, result] = await Promise.race(executions.values());
+      executions.delete(execution);
+      yield result;
     }
   }
 


### PR DESCRIPTION
There was previously the potential for two workers to complete quickly at the same time which could result in one of the results not being propagated to the remainder of the system. This situation has now been corrected by removing the worker execution at a later point in the process.