### PR TITLE
fix(@angular-devkit/build-angular): don't restore `input` of type `file` during HMR

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/dev-server/hmr_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/hmr_spec.ts
@@ -58,7 +58,9 @@ describe('Dev Server Builder HMR', () => {
         <p>{{title}}</p>
 
         <input class="visible" type="text">
+        <input type="file">
         <input type="hidden">
+
         <select>
           <option>one</option>
           <option>two</option>

--- a/packages/angular_devkit/build_angular/src/webpack/plugins/hmr/hmr-accept.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/plugins/hmr/hmr-accept.ts
@@ -197,7 +197,6 @@ function restoreFormValues(oldInputs: any[], oldOptions: any[]): void {
         case 'date':
         case 'datetime-local':
         case 'email':
-        case 'file':
         case 'hidden':
         case 'month':
         case 'number':


### PR DESCRIPTION

```
Uncaught DOMException: Failed to set the 'value' property on 'HTMLInputElement': This input element accepts a filename, which may only be programmatically set to the empty string.
```

Closes #22084