### PR TITLE
fix(@angular-devkit/build-angular): suppress "@charset" must be the first rule in the file warning

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
@@ -353,6 +353,9 @@ export async function getCommonConfig(wco: WebpackConfigOptions): Promise<Config
       /Failed to parse source map from/,
       // https://github.com/webpack-contrib/postcss-loader/blob/bd261875fdf9c596af4ffb3a1a73fe3c549befda/src/index.js#L153-L158
       /Add postcss as project dependency/,
+      // esbuild will issue a warning, while still hoists the @charset at the very top.
+      // This is caused by a bug in css-loader https://github.com/webpack-contrib/css-loader/issues/1212
+      /"@charset" must be the first rule in the file/,
     ],
     module: {
       // Show an error for missing exports instead of a warning.


### PR DESCRIPTION


esbuild will issue a warning when `@charset` is in the middle of the file. This is caused by css-loader will concats the file and doesn't hoist `@charset`, (https://github.com/webpack-contrib/css-loader/issues/1212).

While, esbuild will issue a warning regarding the above, it will hoist to the very top.

In many cases, this warning is not actionable by the users as the `@charset` would be likely specified in 3rd party libs.

Closes #22097