### PR TITLE
perf(@angular-devkit/build-angular): disable webpack backwards compatible APIs

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
@@ -403,6 +403,7 @@ export async function getCommonConfig(wco: WebpackConfigOptions): Promise<Config
       ],
     },
     experiments: {
+      backCompat: false,
       syncWebAssembly: true,
       asyncWebAssembly: true,
     },


### PR DESCRIPTION

See https://github.com/webpack/webpack/releases/tag/v5.62.0 and https://github.com/webpack/webpack/issues/14580 for more context.