### PR TITLE
fix(@angular/cli): favor ng-update `packageGroupName` in ng update output

### DIFF
--- a/packages/angular/cli/src/commands/update/schematic/index.ts
+++ b/packages/angular/cli/src/commands/update/schematic/index.ts
@@ -460,17 +460,15 @@ function _usageMessage(
         target,
       };
     })
-    .filter(({ info, version, target }) => {
-      return target && semver.compare(info.installed.version, version) < 0;
-    })
-    .filter(({ target }) => {
-      return target['ng-update'];
-    })
+    .filter(
+      ({ info, version, target }) =>
+        target?.['ng-update'] && semver.compare(info.installed.version, version) < 0,
+    )
     .map(({ name, info, version, tag, target }) => {
       // Look for packageGroup.
-      const packageGroup = target['ng-update']?.['packageGroup'];
+      const packageGroup = target['ng-update']['packageGroup'];
       if (packageGroup) {
-        const packageGroupName = packageGroup?.[0];
+        const packageGroupName = target['ng-update']['packageGroupName'] || packageGroup[0];
         if (packageGroupName) {
           if (packageGroups.has(name)) {
             return null;


### PR DESCRIPTION

With this change we favor the `packageGroupName` name when specified and only fallback to use the first item in in the `packageGroup` array when it is not specified.

Closes #22087