### PR TITLE
fix(@angular-devkit/core): add Angular CLI major version as analytics dimension

### DIFF
--- a/docs/design/analytics.md
+++ b/docs/design/analytics.md
@@ -51,7 +51,7 @@ Note: There's a limit of 20 custom dimensions.
 | 5 | `Flag: --style` | `string` |
 | 6 | `--collection` | `string` |
 | 7 | `Flag: --strict` | `boolean` |
-| 8 | `AOT Enabled` | `boolean` |
+| 8 | `Angular CLI Major Version` | `string` |
 | 9 | `Flag: --inline-style` | `boolean` |
 | 10 | `Flag: --inline-template` | `boolean` |
 | 11 | `Flag: --view-encapsulation` | `string` |

--- a/goldens/public-api/angular_devkit/core/src/index.md
+++ b/goldens/public-api/angular_devkit/core/src/index.md
@@ -1064,7 +1064,7 @@ class MultiAnalytics implements Analytics {
 // @public
 enum NgCliAnalyticsDimensions {
     // (undocumented)
-    AotEnabled = 8,
+    AngularCLIMajorVersion = 8,
     // (undocumented)
     BuildErrors = 20,
     // (undocumented)

--- a/packages/angular/cli/src/analytics/analytics-collector.ts
+++ b/packages/angular/cli/src/analytics/analytics-collector.ts
@@ -117,6 +117,9 @@ export class AnalyticsCollector implements analytics.Analytics {
       os.totalmem() / (1024 * 1024 * 1024),
     );
     this.parameters['cd' + analytics.NgCliAnalyticsDimensions.NodeVersion] = nodeVersion;
+
+    this.parameters['cd' + analytics.NgCliAnalyticsDimensions.AngularCLIMajorVersion] =
+      VERSION.major;
   }
 
   event(ec: string, ea: string, options: analytics.EventOptions = {}): void {

--- a/packages/angular_devkit/build_angular/src/webpack/configs/analytics.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/analytics.ts
@@ -28,13 +28,6 @@ export function getAnalyticsConfig(
 
   // The category is the builder name if it's an angular builder.
   return {
-    plugins: [
-      new NgBuildAnalyticsPlugin(
-        wco.projectRoot,
-        context.analytics,
-        category,
-        wco.buildOptions.aot ?? false,
-      ),
-    ],
+    plugins: [new NgBuildAnalyticsPlugin(wco.projectRoot, context.analytics, category)],
   };
 }

--- a/packages/angular_devkit/build_angular/src/webpack/plugins/analytics.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/plugins/analytics.ts
@@ -81,7 +81,6 @@ export class NgBuildAnalyticsPlugin {
     protected _projectRoot: string,
     protected _analytics: analytics.Analytics,
     protected _category: string,
-    private aotEnabled: boolean,
   ) {}
 
   protected _reset() {
@@ -114,8 +113,6 @@ export class NgBuildAnalyticsPlugin {
       // Adding commas before and after so the regex are easier to define filters.
       dimensions[analytics.NgCliAnalyticsDimensions.BuildErrors] = `,${this._stats.errors.join()},`;
     }
-
-    dimensions[analytics.NgCliAnalyticsDimensions.AotEnabled] = this.aotEnabled;
 
     return dimensions;
   }

--- a/packages/angular_devkit/core/src/analytics/index.ts
+++ b/packages/angular_devkit/core/src/analytics/index.ts
@@ -27,7 +27,7 @@ export enum NgCliAnalyticsDimensions {
   RamInGigabytes = 3,
   NodeVersion = 4,
   NgAddCollection = 6,
-  AotEnabled = 8,
+  AngularCLIMajorVersion = 8,
   BuildErrors = 20,
 }
 
@@ -57,7 +57,7 @@ export const NgCliAnalyticsDimensionsFlagInfo: { [name: string]: [string, string
   RamInGigabytes: ['RAM (In GB)', 'number'],
   NodeVersion: ['Node Version', 'number'],
   NgAddCollection: ['--collection', 'string'],
-  AotEnabled: ['AOT Enabled', 'boolean'],
+  AngularCLIMajorVersion: ['Angular CLI Major Version', 'string'],
   BuildErrors: ['Build Errors (comma separated)', 'string'],
 };
 


### PR DESCRIPTION


With this change we replace the custom dimension 8 `AOT Enabled`, with `Angular CLI Major Version`. The motivation behind replacing this dimension is that the there is already an `aot` dimension with id 13 which serves for the same purpose.

More information to why we need a new dimension for the Angular CLI major version can be found #22130

Closes #22130