### PR TITLE
fix(@schematics/angular): migrate ng-packagr configurations in package.json

### DIFF
--- a/packages/schematics/angular/migrations/update-13/update-libraries.ts
+++ b/packages/schematics/angular/migrations/update-13/update-libraries.ts
@@ -13,9 +13,16 @@ import { allTargetOptions, getWorkspace } from '../../utility/workspace';
 
 function* visit(directory: DirEntry): IterableIterator<string> {
   for (const path of directory.subfiles) {
-    if (path === 'ng-package.json') {
-      yield join(directory.path, path);
+    if (path === 'package.json') {
+      const entry = directory.file(path);
+      if (entry?.content.toString().includes('ngPackage') !== true) {
+        continue;
+      }
+    } else if (path !== 'ng-package.json') {
+      continue;
     }
+
+    yield join(directory.path, path);
   }
 
   for (const path of directory.subdirs) {
@@ -34,6 +41,9 @@ export default function (): Rule {
     ['lib', 'umdModuleIds'],
     ['lib', 'amdId'],
     ['lib', 'umdId'],
+    ['ngPackage', 'lib', 'umdModuleIds'],
+    ['ngPackage', 'lib', 'amdId'],
+    ['ngPackage', 'lib', 'umdId'],
   ];
 
   return async (tree, context) => {

--- a/packages/schematics/angular/migrations/update-13/update-libraries_spec.ts
+++ b/packages/schematics/angular/migrations/update-13/update-libraries_spec.ts
@@ -69,6 +69,25 @@ function createWorkSpaceConfig(tree: UnitTestTree) {
       2,
     ),
   );
+
+  tree.create(
+    '/package.json',
+    JSON.stringify(
+      {
+        dependencies: { tslib: '^2.0.0' },
+        ngPackage: {
+          lib: {
+            entryFile: 'src/public-api.ts',
+            amdId: 'foo',
+            umdId: 'foo',
+            umdModuleIds: ['foo'],
+          },
+        },
+      },
+      undefined,
+      2,
+    ),
+  );
 }
 
 const schematicName = 'update-libraries-v13';
@@ -133,6 +152,21 @@ describe(`Migration to update library projects. ${schematicName}`, () => {
       expect(lib.amdId).toBeUndefined();
       expect(lib.umdId).toBeUndefined();
       expect(lib.umdModuleIds).toBeUndefined();
+    });
+  });
+
+  describe('Ng-packagr properties in package.json', () => {
+    it(`should remove UMD related options from package.json`, async () => {
+      const newTree = await schematicRunner.runSchematicAsync(schematicName, {}, tree).toPromise();
+      const pkg = readJsonFile(newTree, 'package.json');
+      expect(pkg).toEqual({
+        dependencies: { tslib: '^2.0.0' },
+        ngPackage: {
+          lib: {
+            entryFile: 'src/public-api.ts',
+          },
+        },
+      });
     });
   });
 });


### PR DESCRIPTION

Currently ng-packagr, can be configured used in package.json. Previously, the migration didn't handle this case.

Closes #22129