### PR TITLE
feat(@schematics/angular): add VS Code configurations when generating a new workspace

### DIFF
--- a/packages/schematics/angular/workspace/files/__dot__vscode/extensions.json.template
+++ b/packages/schematics/angular/workspace/files/__dot__vscode/extensions.json.template
@@ -1,0 +1,4 @@
+{
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=827846
+  "recommendations": ["angular.ng-template"]
+}

--- a/packages/schematics/angular/workspace/files/__dot__vscode/launch.json.template
+++ b/packages/schematics/angular/workspace/files/__dot__vscode/launch.json.template
@@ -1,0 +1,20 @@
+{
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "ng serve",
+      "type": "pwa-chrome",
+      "request": "launch",
+      "preLaunchTask": "npm: start",
+      "url": "http://localhost:4200/"
+    },
+    {
+      "name": "ng test",
+      "type": "chrome",
+      "request": "launch",
+      "preLaunchTask": "npm: test",
+      "url": "http://localhost:9876/debug.html"
+    }
+  ]
+}

--- a/packages/schematics/angular/workspace/files/__dot__vscode/tasks.json.template
+++ b/packages/schematics/angular/workspace/files/__dot__vscode/tasks.json.template
@@ -1,0 +1,42 @@
+{
+  // For more information, visit: https://go.microsoft.com/fwlink/?LinkId=733558
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "npm",
+      "script": "start",
+      "isBackground": true,
+      "problemMatcher": {
+        "owner": "typescript",
+        "pattern": "$tsc",
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": {
+            "regexp": "(.*?)"
+          },
+          "endsPattern": {
+            "regexp": "bundle generation complete"
+          }
+        }
+      }
+    },
+    {
+      "type": "npm",
+      "script": "test",
+      "isBackground": true,
+      "problemMatcher": {
+        "owner": "typescript",
+        "pattern": "$tsc",
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": {
+            "regexp": "(.*?)"
+          },
+          "endsPattern": {
+            "regexp": "bundle generation complete"
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION


When generating a new workspace we now generate several VS Code configurations.

- extensions: we added config to recommand to use official VS Code extensions.
- launch: added run and debug launch scripts for `ng test` and `ng serve`
- tasks: configured `npm start` and `npm test` to better support the launch scripts

More information about each files can be found
- extensions: https://go.microsoft.com/fwlink/?linkid=827846
- launch: https://go.microsoft.com/fwlink/?linkid=830387
- tasks: https://go.microsoft.com/fwlink/?LinkId=733558

Closes #2672