### PR TITLE
feat(@angular-devkit/build-angular): add estimated transfer size to build output report

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
@@ -31,6 +31,7 @@ import {
   ScriptsWebpackPlugin,
 } from '../plugins';
 import { ProgressPlugin } from '../plugins/progress-plugin';
+import { TransferSizePlugin } from '../plugins/transfer-size-plugin';
 import { createIvyPlugin } from '../plugins/typescript';
 import {
   assetPatterns,
@@ -285,6 +286,10 @@ export async function getCommonConfig(wco: WebpackConfigOptions): Promise<Config
         advanced: buildOptions.buildOptimizer,
       }),
     );
+  }
+
+  if (platform === 'browser' && (scriptsOptimization || stylesOptimization.minify)) {
+    extraMinimizers.push(new TransferSizePlugin());
   }
 
   const externals: Configuration['externals'] = [...externalDependencies];

--- a/packages/angular_devkit/build_angular/src/webpack/plugins/transfer-size-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/plugins/transfer-size-plugin.ts
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { promisify } from 'util';
+import { Compiler } from 'webpack';
+import { brotliCompress } from 'zlib';
+
+const brotliCompressAsync = promisify(brotliCompress);
+
+const PLUGIN_NAME = 'angular-transfer-size-estimator';
+
+export class TransferSizePlugin {
+  constructor() {}
+
+  apply(compiler: Compiler) {
+    compiler.hooks.thisCompilation.tap(PLUGIN_NAME, (compilation) => {
+      compilation.hooks.processAssets.tapPromise(
+        {
+          name: PLUGIN_NAME,
+          stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ANALYSE,
+        },
+        async (compilationAssets) => {
+          const actions = [];
+          for (const assetName of Object.keys(compilationAssets)) {
+            if (!assetName.endsWith('.js') && !assetName.endsWith('.css')) {
+              continue;
+            }
+
+            const scriptAsset = compilation.getAsset(assetName);
+            if (!scriptAsset || scriptAsset.source.size() <= 0) {
+              continue;
+            }
+
+            actions.push(
+              brotliCompressAsync(scriptAsset.source.source())
+                .then((result) => {
+                  compilation.updateAsset(assetName, (s) => s, {
+                    estimatedTransferSize: result.length,
+                  });
+                })
+                .catch((error) => {
+                  compilation.warnings.push(
+                    new compilation.compiler.webpack.WebpackError(
+                      `Unable to calculate estimated transfer size for '${assetName}'. Reason: ${error.message}`,
+                    ),
+                  );
+                }),
+            );
+          }
+
+          await Promise.all(actions);
+        },
+      );
+    });
+  }
+}

--- a/tests/legacy-cli/e2e/tests/basic/build.ts
+++ b/tests/legacy-cli/e2e/tests/basic/build.ts
@@ -3,8 +3,13 @@ import { ng } from '../../utils/process';
 
 export default async function () {
   // Development build
-  await ng('build', '--configuration=development');
+  const { stdout: stdoutDev } = await ng('build', '--configuration=development');
   await expectFileToMatch('dist/test-project/index.html', 'main.js');
+  if (stdoutDev.includes('Estimated Transfer Size')) {
+    throw new Error(
+      `Expected stdout not to contain 'Estimated Transfer Size' but it did.\n${stdoutDev}`,
+    );
+  }
 
   // Named Development build
   await ng('build', 'test-project', '--configuration=development');
@@ -17,6 +22,12 @@ export default async function () {
 
   if (!stdout.includes('Initial Total')) {
     throw new Error(`Expected stdout to contain 'Initial Total' but it did not.\n${stdout}`);
+  }
+
+  if (!stdout.includes('Estimated Transfer Size')) {
+    throw new Error(
+      `Expected stdout to contain 'Estimated Transfer Size' but it did not.\n${stdout}`,
+    );
   }
 
   const logs: string[] = [


### PR DESCRIPTION
When optimizations are enabled (either scripts or styles), an additional column will now be present in the output report shown in the console for an application build. This additonal column will display the estimated transfer size for each file as well as the total initial estimated transfer size for the initial files. The estimated transfer size is determined by calculating the compressed size of the file using brotli's default settings. In a development configuration (a configuration with optimizations disabled), the calculations are not performed to avoid any potential increase in rebuild speed due to the large size of unoptimized files.

```
Initial Chunk Files           | Names         |  Raw Size | Estimated Transfer Size
main.51c3048e87eac4fd.js      | main          | 132.07 kB |                38.63 kB
polyfills.df676194f15dea6d.js | polyfills     |  36.20 kB |                11.47 kB
runtime.ab1d1f80a99b92f8.js   | runtime       |   1.05 kB |               601 bytes
styles.ef46db3751d8e999.css   | styles        |   0 bytes |                       -

                              | Initial Total | 169.33 kB |                50.69 kB
```

Closes: #21394