### PR TITLE
feat(@angular/cli): provide more detailed error for not found builder

### DIFF
--- a/tests/legacy-cli/e2e/tests/commands/builder-not-found.ts
+++ b/tests/legacy-cli/e2e/tests/commands/builder-not-found.ts
@@ -1,0 +1,33 @@
+import { moveFile } from '../../utils/fs';
+import { installPackage, uninstallPackage } from '../../utils/packages';
+import { execAndWaitForOutputToMatch, ng } from '../../utils/process';
+import { expectToFail } from '../../utils/utils';
+
+export default async function () {
+  try {
+    await uninstallPackage('@angular-devkit/build-angular');
+
+    await expectToFail(() => ng('build'));
+    await execAndWaitForOutputToMatch(
+      'ng',
+      ['build'],
+      /Could not find the '@angular-devkit\/build-angular:browser' builder's node package\./,
+    );
+    await expectToFail(() =>
+      execAndWaitForOutputToMatch('ng', ['build'], /Node packages may not be installed\./),
+    );
+
+    await moveFile('node_modules', 'temp_node_modules');
+
+    await expectToFail(() => ng('build'));
+    await execAndWaitForOutputToMatch(
+      'ng',
+      ['build'],
+      /Could not find the '@angular-devkit\/build-angular:browser' builder's node package\./,
+    );
+    await execAndWaitForOutputToMatch('ng', ['build'], /Node packages may not be installed\./);
+  } finally {
+    await moveFile('temp_node_modules', 'node_modules');
+    await installPackage('@angular-devkit/build-angular');
+  }
+}


### PR DESCRIPTION
When a builder-based command is executed (build, serve, test, etc.) and the builder's node package cannot be found a more user-friendly error message is now displayed. In addition, when the builder's node package cannot be found, a check is performed to determine if the node packages for the workspace may have not been installed. Previously, a potentially long stacktrace was shown which did not provide much information regarding how to correct the issue.

Closes: #10536