### PR TITLE
refactor(@angular-devkit/build-angular): replace usage of `webpack-dev-server` deprecated `https` option

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "@types/semver": "^7.0.0",
     "@types/text-table": "^0.2.1",
     "@types/uuid": "^8.0.0",
-    "@types/webpack-dev-server": "^4.0.3",
+    "@types/webpack-dev-server": "^4.5.0",
     "@typescript-eslint/eslint-plugin": "5.4.0",
     "@typescript-eslint/parser": "5.4.0",
     "@yarnpkg/lockfile": "1.1.0",

--- a/packages/angular_devkit/build_angular/src/webpack/configs/dev-server.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/dev-server.ts
@@ -83,7 +83,7 @@ export async function getDevServerConfig(
       },
       compress: false,
       static: false,
-      https: getSslConfig(root, wco.buildOptions),
+      server: getServerConfig(root, wco.buildOptions),
       allowedHosts: getAllowedHostsConfig(wco.buildOptions),
       devMiddleware: {
         publicPath: servePath,
@@ -139,19 +139,25 @@ export function buildServePath(
  * Private method to enhance a webpack config with SSL configuration.
  * @private
  */
-function getSslConfig(
+function getServerConfig(
   root: string,
   options: WebpackDevServerOptions,
-): DevServerConfiguration['https'] {
+): DevServerConfiguration['server'] {
   const { ssl, sslCert, sslKey } = options;
-  if (ssl && sslCert && sslKey) {
-    return {
-      key: resolve(root, sslKey),
-      cert: resolve(root, sslCert),
-    };
+  if (!ssl) {
+    return 'http';
   }
 
-  return ssl;
+  return {
+    type: 'https',
+    options:
+      sslCert && sslKey
+        ? {
+            key: resolve(root, sslKey),
+            cert: resolve(root, sslCert),
+          }
+        : undefined,
+  };
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -114,7 +114,6 @@
 
 "@angular/dev-infra-private@https://github.com/angular/dev-infra-private-builds.git#6cdeb28b4c4adfa8c7e3a84f5ca5cb11bab21760":
   version "0.0.0-2357f952775070b44dbc09363c4593d033b982b3"
-  uid "6cdeb28b4c4adfa8c7e3a84f5ca5cb11bab21760"
   resolved "https://github.com/angular/dev-infra-private-builds.git#6cdeb28b4c4adfa8c7e3a84f5ca5cb11bab21760"
   dependencies:
     "@actions/core" "^1.4.0"
@@ -2274,10 +2273,10 @@
     tapable "^2.1.1"
     webpack "^5.38.1"
 
-"@types/webpack-dev-server@^4.0.3":
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/@types/webpack-dev-server/-/webpack-dev-server-4.3.1.tgz#e6174f753aabdd3b2de8e4bc98df024365067011"
-  integrity sha512-sFAFnvz1Ah17Kt4pFjATbPtuAmFS9s2dUUKhpz0kkB+X7vpJF2tbO7JoHP42od0SKijtrB7CHbsa3/lnztjpvw==
+"@types/webpack-dev-server@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@types/webpack-dev-server/-/webpack-dev-server-4.5.0.tgz#52a983de97db81a38b7309a8cf8a730c3e02f28e"
+  integrity sha512-HMb6pZPANObue3LwbdpQLWzQyF9O0wntiPyXj4vGutlAbNKTXH4hDCHaZyfvfZDmFn+5HprrWHm1TGt3awNr/A==
   dependencies:
     "@types/bonjour" "*"
     "@types/connect-history-api-fallback" "*"


### PR DESCRIPTION


See: https://github.com/webpack/webpack-dev-server/blob/master/CHANGELOG.md#450-2021-11-13