### PR TITLE
docs: release notes for the v13.0.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+<a name="13.0.3"></a>
+
+# 13.0.3 (2021-11-17)
+
+## Special Thanks
+
+Alan Agius, Joey Perrott and Krzysztof Platis
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="13.1.0-next.1"></a>
 
 # 13.1.0-next.1 (2021-11-10)


### PR DESCRIPTION
Cherry-picks the changelog from the "13.0.x" branch to the next branch (master).