### PR TITLE
fix(@angular-devkit/build-angular): transform remapped sourcemap into a plain object

### DIFF
--- a/packages/angular_devkit/build_angular/src/babel/webpack-loader.ts
+++ b/packages/angular_devkit/build_angular/src/babel/webpack-loader.ts
@@ -239,10 +239,16 @@ export default custom<ApplicationPresetOptions>(() => {
         // `@ampproject/remapping` source map objects but both are compatible with Webpack.
         // This method for merging is used because it provides more accurate output
         // and is faster while using less memory.
-        result.map = remapping(
-          [result.map as SourceMapInput, inputSourceMap as SourceMapInput],
-          () => null,
-        ) as typeof result.map;
+        result.map = {
+          // Convert the SourceMap back to simple plain object.
+          // This is needed because otherwise code-coverage will fail with `don't know how to turn this value into a node`
+          // Which is thrown by Babel if it is invoked again from `istanbul-lib-instrument`.
+          // https://github.com/babel/babel/blob/780aa48d2a34dc55f556843074b6aed45e7eabeb/packages/babel-types/src/converters/valueToNode.ts#L115-L130
+          ...(remapping(
+            [result.map as SourceMapInput, inputSourceMap as SourceMapInput],
+            () => null,
+          ) as typeof result.map),
+        };
       }
 
       return result;


### PR DESCRIPTION
Hello,

I am opening this PR to fix one of the problems we noticed when upgrading to Angular 13 in [ng-bootstrap](https://ng-bootstrap.github.io/) (cf https://github.com/ng-bootstrap/ng-bootstrap/issues/4178)

We are using a custom webpack configuration with `@angular-builders/custom-webpack:browser` to add `coverage-istanbul-loader` but it fails with the `don't know how to turn this value into a node` error.

This similar to #21967 which was previously fixed in commit da1733cc69eeac1417e47df23389da1658850ada but the fix was lost as part of commit 0c44ab305836abab26dc81d7c962f330898213fd.
Cf also https://github.com/istanbuljs/istanbuljs/issues/646

`remapping` returns a SourceMap object and not a plain object. This causes Babel to fail with `don't know how to turn this value into a node` when invoked from `istanbul-lib-instrument` as Babel checks if the value is a plain object.

See: https://github.com/babel/babel/blob/780aa48d2a34dc55f556843074b6aed45e7eabeb/packages/babel-types/src/converters/valueToNode.ts#L115-L130
