### PR TITLE
fix(@angular/cli): exit with a non-zero error code when migration fails during `ng update`

### DIFF
--- a/packages/angular/cli/commands/update-impl.ts
+++ b/packages/angular/cli/commands/update-impl.ts
@@ -482,8 +482,9 @@ export class UpdateCommand extends Command<UpdateCommandSchema> {
         }
       }
 
+      let result: boolean;
       if (typeof options.migrateOnly == 'string') {
-        await this.executeMigration(
+        result = await this.executeMigration(
           packageName,
           migrations,
           options.migrateOnly,
@@ -497,7 +498,7 @@ export class UpdateCommand extends Command<UpdateCommandSchema> {
           return 1;
         }
 
-        await this.executeMigrations(
+        result = await this.executeMigrations(
           packageName,
           migrations,
           from,
@@ -506,7 +507,7 @@ export class UpdateCommand extends Command<UpdateCommandSchema> {
         );
       }
 
-      return 1;
+      return result ? 0 : 1;
     }
 
     const requests: {


### PR DESCRIPTION


In some cases, when a migration fails an error is not thrown, instead the `executeMigration` return a `false` value when resolved.

With this change, we fix an issue were failed migrations resulted in the process of not terminating with a non-zero error code.