### PR TITLE
fix(@angular-devkit/build-angular): don't watch nested `node_modules` when polling is enabled

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
@@ -347,7 +347,7 @@ export async function getCommonConfig(wco: WebpackConfigOptions): Promise<Config
     watch: buildOptions.watch,
     watchOptions: {
       poll,
-      ignored: poll === undefined ? undefined : 'node_modules/**',
+      ignored: poll === undefined ? undefined : '**/node_modules/**',
     },
     performance: {
       hints: false,


### PR DESCRIPTION


Previously the glob didn't catch nested `node_modules`.

Closes #22163