### PR TITLE
fix(@angular-devkit/build-angular): don't watch nested `node_modules` when polling is enabled

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/utils/helpers.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/utils/helpers.ts
@@ -102,7 +102,7 @@ export function getWatchOptions(
 ): NonNullable<Configuration['watchOptions']> {
   return {
     poll,
-    ignored: poll === undefined ? '**/$_lazy_route_resources' : 'node_modules/**',
+    ignored: poll === undefined ? '**/$_lazy_route_resources' : '**/node_modules/**',
   };
 }
 


### PR DESCRIPTION
Patch version of https://github.com/angular/angular-cli/pull/22254

Closes #22163
