### PR TITLE
build: add pkg_npm rules for remaining packages

### DIFF
--- a/packages/angular/pwa/BUILD.bazel
+++ b/packages/angular/pwa/BUILD.bazel
@@ -6,6 +6,8 @@
 load("@npm//@bazel/jasmine:index.bzl", "jasmine_node_test")
 load("//tools:defaults.bzl", "ts_library")
 load("//tools:ts_json_schema.bzl", "ts_json_schema")
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
 
 licenses(["notice"])  # MIT
 
@@ -66,4 +68,19 @@ ts_library(
 jasmine_node_test(
     name = "pwa_test",
     srcs = [":pwa_test_lib"],
+)
+
+pkg_npm(
+    name = "npm_package",
+    deps = [
+        ":pwa",
+    ],
+)
+
+pkg_tar(
+    name = "npm_package_archive",
+    srcs = [":npm_package"],
+    extension = "tar.gz",
+    strip_prefix = "./npm_package",
+    tags = ["manual"],
 )

--- a/packages/angular_devkit/architect_cli/BUILD.bazel
+++ b/packages/angular_devkit/architect_cli/BUILD.bazel
@@ -1,4 +1,6 @@
 load("//tools:defaults.bzl", "ts_library")
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
 
 # Copyright Google Inc. All Rights Reserved.
 #
@@ -26,4 +28,19 @@ ts_library(
         "@npm//ansi-colors",
         "@npm//rxjs",
     ],
+)
+
+pkg_npm(
+    name = "npm_package",
+    deps = [
+        ":architect_cli",
+    ],
+)
+
+pkg_tar(
+    name = "npm_package_archive",
+    srcs = [":npm_package"],
+    extension = "tar.gz",
+    strip_prefix = "./npm_package",
+    tags = ["manual"],
 )

--- a/packages/angular_devkit/schematics_cli/BUILD.bazel
+++ b/packages/angular_devkit/schematics_cli/BUILD.bazel
@@ -1,6 +1,8 @@
 load("@npm//@bazel/jasmine:index.bzl", "jasmine_node_test")
 load("//tools:defaults.bzl", "ts_library")
 load("//tools:ts_json_schema.bzl", "ts_json_schema")
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
 
 # Copyright Google Inc. All Rights Reserved.
 #
@@ -87,4 +89,19 @@ ts_json_schema(
 ts_json_schema(
     name = "schematic_schema",
     src = "schematic/schema.json",
+)
+
+pkg_npm(
+    name = "npm_package",
+    deps = [
+        ":schematics_cli",
+    ],
+)
+
+pkg_tar(
+    name = "npm_package_archive",
+    srcs = [":npm_package"],
+    extension = "tar.gz",
+    strip_prefix = "./npm_package",
+    tags = ["manual"],
 )


### PR DESCRIPTION
Before re-writing the `build.ts` script to use bazel for building, I thought a good place to start would be to add some missing rules. Three of the packages built by `build.ts` didn't have corresponding `pkg_npm` targets.