### PR TITLE
fix(@ngtools/webpack): handle promise rejection during Angular program analyzes

### DIFF
--- a/packages/ngtools/webpack/src/ivy/loader.ts
+++ b/packages/ngtools/webpack/src/ivy/loader.ts
@@ -67,7 +67,9 @@ export function angularWebpackLoader(this: LoaderContext<unknown>, content: stri
       callback(undefined, resultContent, resultMap);
     })
     .catch((err) => {
-      callback(err);
+      // The below is needed to hide stacktraces from users.
+      const message = err instanceof Error ? err.message : err;
+      callback(new Error(message));
     });
 }
 


### PR DESCRIPTION


Currently, when `analyzeAsync` promise is rejected, the build fails with an `UnhandledPromiseRejectionWarning`.

Example:
```
(node:69086) UnhandledPromiseRejectionWarning: Error: Cannot use a JavaScript or TypeScript file (/Users/error-testing/src/app/app.component.ts) in a component's styleUrls or templateUrl.
    at WebpackResourceLoader._compile (/Users/error-testing/node_modules/@ngtools/webpack/src/resource_loader.js:107:19)
    at WebpackResourceLoader.get (/Users/error-testing/node_modules/@ngtools/webpack/src/resource_loader.js:266:44)
    at Object.resourceHost.readResource (/Users/error-testing/node_modules/@ngtools/webpack/src/ivy/host.js:48:35)
    at AdapterResourceLoader.preload (file:///Users/error-testing/node_modules/@angular/compiler-cli/bundles/index.js:12177:31)
    at resolveStyleUrl (file:///Users/error-testing/node_modules/@angular/compiler-cli/bundles/index.js:9593:36)
    at file:///Users/error-testing/node_modules/@angular/compiler-cli/bundles/index.js:9621:47
    at Array.map (<anonymous>)
    at ComponentDecoratorHandler.preanalyze (file:///Users/error-testing/node_modules/@angular/compiler-cli/bundles/index.js:9621:29)
    at TraitCompiler.analyzeClass (file:///Users/error-testing/node_modules/@angular/compiler-cli/bundles/index.js:6647:39)
    at visit2 (file:///Users/error-testing/node_modules/@angular/compiler-cli/bundles/index.js:6494:14)
```

With this change we handle such error and also hide stacktraces
```
./src/app/app.module.ts - Error: Module build failed (from ./node_modules/@ngtools/webpack/src/ivy/index.js):
Error: Cannot use a JavaScript or TypeScript file (/Users/error-testing/src/app/app.component.ts) in a component's styleUrls or templateUrl.
    at /Users/error-testing/node_modules/@ngtools/webpack/src/ivy/loader.js:75:34
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
```