### PR TITLE
fix(@angular-devkit/build-angular): correctly extract messages when using cached build

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/extract-i18n/ivy-extract-loader.ts
+++ b/packages/angular_devkit/build_angular/src/builders/extract-i18n/ivy-extract-loader.ts
@@ -21,6 +21,11 @@ export default function localizeExtractLoader(
   content: string,
   map: LoaderSourceMap,
 ) {
+  // This loader is not cacheable due to message extraction works.
+  // Extracted messages are not part of webpack pipeline and hence they cannot be retrieved from cache.
+  // TODO: We should investigate in the future on making this deterministic and more cacheable.
+  this.cacheable(false);
+
   const options = this.getOptions();
   const callback = this.async();
 

--- a/packages/angular_devkit/build_angular/src/builders/extract-i18n/ivy-extract-loader.ts
+++ b/packages/angular_devkit/build_angular/src/builders/extract-i18n/ivy-extract-loader.ts
@@ -21,7 +21,7 @@ export default function localizeExtractLoader(
   content: string,
   map: LoaderSourceMap,
 ) {
-  // This loader is not cacheable due to message extraction works.
+  // This loader is not cacheable due to how message extraction works.
   // Extracted messages are not part of webpack pipeline and hence they cannot be retrieved from cache.
   // TODO: We should investigate in the future on making this deterministic and more cacheable.
   this.cacheable(false);

--- a/tests/legacy-cli/e2e/tests/i18n/extract-ivy-disk-cache.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/extract-ivy-disk-cache.ts
@@ -1,37 +1,36 @@
 import { join } from 'path';
 import { getGlobalVariable } from '../../utils/env';
-import { expectFileToMatch, writeFile } from '../../utils/fs';
+import { expectFileToMatch, rimraf, writeFile } from '../../utils/fs';
 import { installPackage, uninstallPackage } from '../../utils/packages';
 import { ng } from '../../utils/process';
 import { updateJsonFile } from '../../utils/project';
-import { expectToFail } from '../../utils/utils';
 import { readNgVersion } from '../../utils/version';
 
 export default async function () {
+  // Enable disk cache
+  updateJsonFile('angular.json', (config) => {
+    config.cli ??= {};
+    config.cli.cache = { environment: 'all' };
+  });
+
   // Setup an i18n enabled component
   await ng('generate', 'component', 'i18n-test');
   await writeFile(join('src/app/i18n-test', 'i18n-test.component.html'), '<p i18n>Hello world</p>');
-
-  // Should fail if `@angular/localize` is missing
-  const { message: message1 } = await expectToFail(() => ng('extract-i18n'));
-  if (!message1.includes(`i18n extraction requires the '@angular/localize' package.`)) {
-    throw new Error('Expected localize package error message when missing');
-  }
 
   // Install correct version
   let localizeVersion = '@angular/localize@' + readNgVersion();
   if (getGlobalVariable('argv')['ng-snapshots']) {
     localizeVersion = require('../../ng-snapshot/package.json').dependencies['@angular/localize'];
   }
+
   await installPackage(localizeVersion);
 
-  // Should not show any warnings when extracting
-  const { stderr: message5 } = await ng('extract-i18n');
-  if (message5.includes('WARNING')) {
-    throw new Error('Expected no warnings to be shown');
+  for (let i = 0; i < 2; i++) {
+    // Run the extraction twice and make sure the second time round works with cache.
+    await rimraf('messages.xlf');
+    await ng('extract-i18n');
+    await expectFileToMatch('messages.xlf', 'Hello world');
   }
-
-  expectFileToMatch('messages.xlf', 'Hello world');
 
   await uninstallPackage('@angular/localize');
 }


### PR DESCRIPTION
Extracted messages are not part of Webpack pipeline and hence they cannot be retrieved from cache. Therefore, we need to mark the extraction loader as non cacheable.

Closes #22264