### PR TITLE
fix(@angular-devkit/build-angular): fallback to use language ID to set the `dir` attribute

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/index-file/augment-index-html_spec.ts
+++ b/packages/angular_devkit/build_angular/src/utils/index-file/augment-index-html_spec.ts
@@ -104,6 +104,24 @@ describe('augment-index-html', () => {
       `);
   });
 
+  it(`should fallback to use language ID to set the dir attribute (en-US)`, async () => {
+    const { content, warnings } = await augmentIndexHtml({
+      ...indexGeneratorOptions,
+      lang: 'en-US',
+    });
+
+    expect(warnings).toHaveSize(0);
+    expect(content).toEqual(oneLineHtml`
+        <html lang="en-US" dir="ltr">
+          <head>
+            <base href="/">
+          </head>
+          <body>
+          </body>
+        </html>
+      `);
+  });
+
   it(`should work when lang (locale) is not provided by '@angular/common'`, async () => {
     const { content, warnings } = await augmentIndexHtml({
       ...indexGeneratorOptions,


### PR DESCRIPTION

In some cases we don't ship certain locales, or they map to files which are named only the language IDs. Example `en-US`, which it's locale data is available from `@angular/common/locales/en.mjs`

Closes #22285