### PR TITLE
perf(@ngtools/webpack): remove child compilation stylesheet chunk assets

### DIFF
--- a/packages/ngtools/webpack/src/resource_loader.ts
+++ b/packages/ngtools/webpack/src/resource_loader.ts
@@ -199,15 +199,15 @@ export class WebpackResourceLoader {
 
     let finalContent: string | undefined;
     childCompiler.hooks.compilation.tap('angular-compiler', (childCompilation) => {
-      childCompilation.hooks.processAssets.tap(
-        { name: 'angular-compiler', stage: webpack.Compilation.PROCESS_ASSETS_STAGE_REPORT },
-        () => {
-          finalContent = childCompilation.assets[outputFilePath]?.source().toString();
+      childCompilation.hooks.processAssets.tap('angular-compiler', () => {
+        finalContent = childCompilation.assets[outputFilePath]?.source().toString();
 
-          delete childCompilation.assets[outputFilePath];
-          delete childCompilation.assets[outputFilePath + '.map'];
-        },
-      );
+        for (const { files } of childCompilation.chunks) {
+          for (const file of files) {
+            childCompilation.deleteAsset(file);
+          }
+        }
+      });
     });
 
     return new Promise<CompilationOutput>((resolve, reject) => {


### PR DESCRIPTION
Stylesheet chunk assets are emitted via the parent compilation and hence these are not needed to be retained in the child compilation.