### PR TITLE
build: reproduce original package structure using bazel

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -68,7 +68,11 @@ test:saucelabs --define=KARMA_WEB_TEST_MODE=SL_REQUIRED
 # Releases should always be stamped with version control info
 # This command assumes node on the path and is a workaround for
 # https://github.com/bazelbuild/bazel/issues/4802
-build:release --workspace_status_command="yarn -s ng-dev release build-env-stamp"
+build:release --workspace_status_command="yarn -s ng-dev release build-env-stamp --mode=release"
+build:release --stamp
+
+build:snapshot --workspace_status_command="yarn -s ng-dev release build-env-stamp --mode=snapshot"
+build:snapshot --stamp
 
 ###############################
 # Output                      #

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -12,3 +12,9 @@ exports_files([
     "tsconfig-test.json",  # @external
     "tsconfig-build.json",  # @external
 ])
+
+# Detect if the build is running under --stamp
+config_setting(
+    name = "stamp",
+    values = {"stamp": "true"},
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -11,6 +11,16 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/4.4.6/rules_nodejs-4.4.6.tar.gz"],
 )
 
+http_archive(
+    name = "rules_pkg",
+    sha256 = "a89e203d3cf264e564fcb96b6e06dd70bc0557356eb48400ce4b5d97c2c3720d",
+    urls = ["https://github.com/bazelbuild/rules_pkg/releases/download/0.5.1/rules_pkg-0.5.1.tar.gz"],
+)
+
+load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
+
+rules_pkg_dependencies()
+
 # Check the bazel version and download npm dependencies
 load("@build_bazel_rules_nodejs//:index.bzl", "check_bazel_version", "check_rules_nodejs_version", "node_repositories", "yarn_install")
 

--- a/packages/angular/cli/BUILD.bazel
+++ b/packages/angular/cli/BUILD.bazel
@@ -6,12 +6,7 @@
 load("@npm//@bazel/jasmine:index.bzl", "jasmine_node_test")
 load("//tools:ts_json_schema.bzl", "ts_json_schema")
 load("//tools:ng_cli_schema_generator.bzl", "cli_json_schema")
-load("//tools:defaults.bzl", "ts_library")
-
-# @external_begin
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
-load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
-# @external_end
+load("//tools:defaults.bzl", "pkg_npm", "ts_library")
 
 licenses(["notice"])  # MIT
 
@@ -61,7 +56,7 @@ ts_library(
         exclude = [
             # NB: we need to exclude the nested node_modules that is laid out by yarn workspaces
             "node_modules/**",
-            "cli/lib/config/workspace-schema.json",
+            "lib/config/workspace-schema.json",
         ],
     ) + [
         "//packages/angular/cli:lib/config/schema.json",
@@ -312,19 +307,22 @@ jasmine_node_test(
     srcs = [":angular-cli_test_lib"],
 )
 
-# @external_begin
-pkg_npm(
-    name = "npm_package",
-    deps = [
-        ":angular-cli",
-    ],
+genrule(
+    name = "license",
+    srcs = ["//:LICENSE"],
+    outs = ["LICENSE"],
+    cmd = "cp $(execpath //:LICENSE) $@",
 )
 
-pkg_tar(
-    name = "npm_package_archive",
-    srcs = [":npm_package"],
-    extension = "tar.gz",
-    strip_prefix = "./npm_package",
-    tags = ["manual"],
+pkg_npm(
+    name = "npm_package",
+    srcs = [":package.json"],
+    deps = [
+        ":README.md",
+        ":angular-cli",
+        ":license",
+        ":src/commands/update/schematic/collection.json",
+        ":src/commands/update/schematic/schema.json",
+        ":utilities/INITIAL_COMMIT_MESSAGE.txt",
+    ],
 )
-# @external_end

--- a/packages/angular/pwa/BUILD.bazel
+++ b/packages/angular/pwa/BUILD.bazel
@@ -4,10 +4,8 @@
 # found in the LICENSE file at https://angular.io/license
 
 load("@npm//@bazel/jasmine:index.bzl", "jasmine_node_test")
-load("//tools:defaults.bzl", "ts_library")
+load("//tools:defaults.bzl", "pkg_npm", "ts_library")
 load("//tools:ts_json_schema.bzl", "ts_json_schema")
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
-load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
 
 licenses(["notice"])  # MIT
 
@@ -35,7 +33,6 @@ ts_library(
     data = glob(
         include = [
             "collection.json",
-            "package.json",
             "pwa/schema.json",
             "pwa/files/**/*",
         ],
@@ -70,17 +67,19 @@ jasmine_node_test(
     srcs = [":pwa_test_lib"],
 )
 
-pkg_npm(
-    name = "npm_package",
-    deps = [
-        ":pwa",
-    ],
+genrule(
+    name = "license",
+    srcs = ["//:LICENSE"],
+    outs = ["LICENSE"],
+    cmd = "cp $(execpath //:LICENSE) $@",
 )
 
-pkg_tar(
-    name = "npm_package_archive",
-    srcs = [":npm_package"],
-    extension = "tar.gz",
-    strip_prefix = "./npm_package",
-    tags = ["manual"],
+pkg_npm(
+    name = "npm_package",
+    srcs = [":package.json"],
+    deps = [
+        ":README.md",
+        ":license",
+        ":pwa",
+    ],
 )

--- a/packages/angular_devkit/architect/BUILD.bazel
+++ b/packages/angular_devkit/architect/BUILD.bazel
@@ -4,14 +4,9 @@
 # found in the LICENSE file at https://angular.io/license
 
 load("@npm//@bazel/jasmine:index.bzl", "jasmine_node_test")
-load("//tools:defaults.bzl", "ts_library")
+load("//tools:defaults.bzl", "pkg_npm", "ts_library")
 load("//tools:ts_json_schema.bzl", "ts_json_schema")
-
-# @external_begin
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
-load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
 load("@npm//@angular/dev-infra-private/bazel/api-golden:index.bzl", "api_golden_test_npm_package")
-# @external_end
 
 licenses(["notice"])  # MIT
 
@@ -37,20 +32,27 @@ ts_json_schema(
     src = "src/progress-schema.json",
 )
 
+ts_json_schema(
+    name = "operator_schema",
+    src = "builders/operator-schema.json",
+)
+
 ts_library(
     name = "architect",
     package_name = "@angular-devkit/architect",
     srcs = glob(
-        include = ["src/**/*.ts"],
+        include = [
+            "src/**/*.ts",
+            "builders/*.ts",
+        ],
         exclude = ["**/*_spec.ts"],
     ) + [
-        # @external_begin
         # These files are generated from the JSON schema
         "//packages/angular_devkit/architect:src/input-schema.ts",
         "//packages/angular_devkit/architect:src/output-schema.ts",
         "//packages/angular_devkit/architect:src/builders-schema.ts",
         "//packages/angular_devkit/architect:src/progress-schema.ts",
-        # @external_end
+        "//packages/angular_devkit/architect:builders/operator-schema.ts",
     ],
     # strict_checks = False,
     data = glob(
@@ -88,22 +90,23 @@ jasmine_node_test(
     srcs = [":architect_test_lib"],
 )
 
-# @external_begin
+genrule(
+    name = "license",
+    srcs = ["//:LICENSE"],
+    outs = ["LICENSE"],
+    cmd = "cp $(execpath //:LICENSE) $@",
+)
+
 pkg_npm(
     name = "npm_package",
+    srcs = [":package.json"],
     deps = [
+        ":README.md",
         ":architect",
+        ":license",
         "//packages/angular_devkit/architect/node",
         "//packages/angular_devkit/architect/testing",
     ],
-)
-
-pkg_tar(
-    name = "npm_package_archive",
-    srcs = [":npm_package"],
-    extension = "tar.gz",
-    strip_prefix = "./npm_package",
-    tags = ["manual"],
 )
 
 api_golden_test_npm_package(
@@ -115,4 +118,3 @@ api_golden_test_npm_package(
     golden_dir = "angular_cli/goldens/public-api/angular_devkit/architect",
     npm_package = "angular_cli/packages/angular_devkit/architect/npm_package",
 )
-# @external_end

--- a/packages/angular_devkit/architect_cli/BUILD.bazel
+++ b/packages/angular_devkit/architect_cli/BUILD.bazel
@@ -1,6 +1,4 @@
-load("//tools:defaults.bzl", "ts_library")
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
-load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
+load("//tools:defaults.bzl", "pkg_npm", "ts_library")
 
 # Copyright Google Inc. All Rights Reserved.
 #
@@ -30,17 +28,19 @@ ts_library(
     ],
 )
 
-pkg_npm(
-    name = "npm_package",
-    deps = [
-        ":architect_cli",
-    ],
+genrule(
+    name = "license",
+    srcs = ["//:LICENSE"],
+    outs = ["LICENSE"],
+    cmd = "cp $(execpath //:LICENSE) $@",
 )
 
-pkg_tar(
-    name = "npm_package_archive",
-    srcs = [":npm_package"],
-    extension = "tar.gz",
-    strip_prefix = "./npm_package",
-    tags = ["manual"],
+pkg_npm(
+    name = "npm_package",
+    srcs = [":package.json"],
+    deps = [
+        ":README.md",
+        ":architect_cli",
+        ":license",
+    ],
 )

--- a/packages/angular_devkit/benchmark/BUILD.bazel
+++ b/packages/angular_devkit/benchmark/BUILD.bazel
@@ -4,12 +4,7 @@
 # found in the LICENSE file at https://angular.io/license
 
 load("@npm//@bazel/jasmine:index.bzl", "jasmine_node_test")
-load("//tools:defaults.bzl", "ts_library")
-
-# @external_begin
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
-load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
-# @external_end
+load("//tools:defaults.bzl", "pkg_npm", "ts_library")
 
 licenses(["notice"])  # MIT
 
@@ -74,19 +69,25 @@ jasmine_node_test(
     ],
 )
 
-# @external_begin
-pkg_npm(
-    name = "npm_package",
-    deps = [
-        ":benchmark",
-    ],
+genrule(
+    name = "license",
+    srcs = ["//:LICENSE"],
+    outs = ["LICENSE"],
+    cmd = "cp $(execpath //:LICENSE) $@",
 )
 
-pkg_tar(
-    name = "npm_package_archive",
-    srcs = [":npm_package"],
-    extension = "tar.gz",
-    strip_prefix = "./npm_package",
-    tags = ["manual"],
+pkg_npm(
+    name = "npm_package",
+    srcs = [":package.json"],
+    deps = [
+        "src/test/exit-code-one.js",
+        "src/test/fibonacci.js",
+        "src/test/test-script.js",
+        "src/test/watch-test-cmd.js",
+        "src/test/watch-test-file.txt",
+        "src/test/watch-test-script.js",
+        ":README.md",
+        ":benchmark",
+        ":license",
+    ],
 )
-# @external_end

--- a/packages/angular_devkit/build_angular/BUILD.bazel
+++ b/packages/angular_devkit/build_angular/BUILD.bazel
@@ -4,14 +4,9 @@
 # found in the LICENSE file at https://angular.io/license
 
 load("@npm//@bazel/jasmine:index.bzl", "jasmine_node_test")
-load("//tools:defaults.bzl", "ts_library")
+load("//tools:defaults.bzl", "pkg_npm", "ts_library")
 load("//tools:ts_json_schema.bzl", "ts_json_schema")
-
-# @external_begin
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
-load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
 load("@npm//@angular/dev-infra-private/bazel/api-golden:index.bzl", "api_golden_test_npm_package")
-# @external_end
 
 licenses(["notice"])  # MIT
 
@@ -217,20 +212,21 @@ jasmine_node_test(
     srcs = [":build_angular_test_lib"],
 )
 
-# @external_begin
-pkg_npm(
-    name = "npm_package",
-    deps = [
-        ":build_angular",
-    ],
+genrule(
+    name = "license",
+    srcs = ["//:LICENSE"],
+    outs = ["LICENSE"],
+    cmd = "cp $(execpath //:LICENSE) $@",
 )
 
-pkg_tar(
-    name = "npm_package_archive",
-    srcs = [":npm_package"],
-    extension = "tar.gz",
-    strip_prefix = "./npm_package",
-    tags = ["manual"],
+pkg_npm(
+    name = "npm_package",
+    srcs = [":package.json"],
+    deps = [
+        ":README.md",
+        ":build_angular",
+        ":license",
+    ],
 )
 
 api_golden_test_npm_package(
@@ -242,7 +238,7 @@ api_golden_test_npm_package(
     golden_dir = "angular_cli/goldens/public-api/angular_devkit/build_angular",
     npm_package = "angular_cli/packages/angular_devkit/build_angular/npm_package",
 )
-# @external_end
+
 # Large build_angular specs
 
 ts_library(

--- a/packages/angular_devkit/build_optimizer/BUILD.bazel
+++ b/packages/angular_devkit/build_optimizer/BUILD.bazel
@@ -4,13 +4,8 @@
 # found in the LICENSE file at https://angular.io/license
 
 load("@npm//@bazel/jasmine:index.bzl", "jasmine_node_test")
-load("//tools:defaults.bzl", "ts_library")
-
-# @external_begin
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
-load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
+load("//tools:defaults.bzl", "pkg_npm", "ts_library")
 load("@npm//@angular/dev-infra-private/bazel/api-golden:index.bzl", "api_golden_test_npm_package")
-# @external_end
 
 licenses(["notice"])  # MIT
 
@@ -22,9 +17,6 @@ ts_library(
     srcs = glob(
         include = ["src/**/*.ts"],
         exclude = [
-            # TODO(@filipesilva): shouldn't need to exclude the cli files but can't exclude them
-            # from jasmine_node_test.
-            "src/**/cli.ts",
             "src/**/*_spec.ts",
             "src/**/*_benchmark.ts",
         ],
@@ -67,20 +59,22 @@ jasmine_node_test(
     ],
 )
 
-# @external_begin
-pkg_npm(
-    name = "npm_package",
-    deps = [
-        ":build_optimizer",
-    ],
+genrule(
+    name = "license",
+    srcs = ["//:LICENSE"],
+    outs = ["LICENSE"],
+    cmd = "cp $(execpath //:LICENSE) $@",
 )
 
-pkg_tar(
-    name = "npm_package_archive",
-    srcs = [":npm_package"],
-    extension = "tar.gz",
-    strip_prefix = "./npm_package",
-    tags = ["manual"],
+pkg_npm(
+    name = "npm_package",
+    srcs = [":package.json"],
+    deps = [
+        ":README.md",
+        ":build_optimizer",
+        ":license",
+        ":webpack-loader/package.json",
+    ],
 )
 
 api_golden_test_npm_package(
@@ -92,4 +86,3 @@ api_golden_test_npm_package(
     golden_dir = "angular_cli/goldens/public-api/angular_devkit/build_optimizer",
     npm_package = "angular_cli/packages/angular_devkit/build_optimizer/npm_package",
 )
-# @external_end

--- a/packages/angular_devkit/build_webpack/BUILD.bazel
+++ b/packages/angular_devkit/build_webpack/BUILD.bazel
@@ -4,14 +4,9 @@
 # found in the LICENSE file at https://angular.io/license
 
 load("@npm//@bazel/jasmine:index.bzl", "jasmine_node_test")
-load("//tools:defaults.bzl", "ts_library")
+load("//tools:defaults.bzl", "pkg_npm", "ts_library")
 load("//tools:ts_json_schema.bzl", "ts_json_schema")
-
-# @external_begin
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
-load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
 load("@npm//@angular/dev-infra-private/bazel/api-golden:index.bzl", "api_golden_test_npm_package")
-# @external_end
 
 licenses(["notice"])  # MIT
 
@@ -105,20 +100,22 @@ jasmine_node_test(
     ],
 )
 
-# @external_begin
-pkg_npm(
-    name = "npm_package",
-    deps = [
-        ":build_webpack",
-    ],
+genrule(
+    name = "license",
+    srcs = ["//:LICENSE"],
+    outs = ["LICENSE"],
+    cmd = "cp $(execpath //:LICENSE) $@",
 )
 
-pkg_tar(
-    name = "npm_package_archive",
-    srcs = [":npm_package"],
-    extension = "tar.gz",
-    strip_prefix = "./npm_package",
-    tags = ["manual"],
+pkg_npm(
+    name = "npm_package",
+    srcs = [":package.json"],
+    deps = [
+        ":README.md",
+        ":build_webpack",
+        ":builders.json",
+        ":license",
+    ],
 )
 
 api_golden_test_npm_package(
@@ -130,4 +127,3 @@ api_golden_test_npm_package(
     golden_dir = "angular_cli/goldens/public-api/angular_devkit/build_webpack",
     npm_package = "angular_cli/packages/angular_devkit/build_webpack/npm_package",
 )
-# @external_end

--- a/packages/angular_devkit/core/BUILD.bazel
+++ b/packages/angular_devkit/core/BUILD.bazel
@@ -1,11 +1,6 @@
 load("@npm//@bazel/jasmine:index.bzl", "jasmine_node_test")
-load("//tools:defaults.bzl", "ts_library")
-
-# @external_begin
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
-load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
+load("//tools:defaults.bzl", "pkg_npm", "ts_library")
 load("@npm//@angular/dev-infra-private/bazel/api-golden:index.bzl", "api_golden_test_npm_package")
-# @external_end
 
 # Copyright Google Inc. All Rights Reserved.
 #
@@ -30,7 +25,10 @@ ts_library(
     data = glob(
         include = ["**/*.json"],
         # NB: we need to exclude the nested node_modules that is laid out by yarn workspaces
-        exclude = ["node_modules/**"],
+        exclude = [
+            "node_modules/**",
+            "src/workspace/json/test/**",
+        ],
     ),
     module_name = "@angular-devkit/core",
     module_root = "src/index.d.ts",
@@ -78,22 +76,26 @@ jasmine_node_test(
     ],
 )
 
-# @external_begin
-pkg_npm(
-    name = "npm_package",
-    deps = [
-        ":core",
-        "//packages/angular_devkit/core/node",
-        "//packages/angular_devkit/core/node/testing",
-    ],
+genrule(
+    name = "license",
+    srcs = ["//:LICENSE"],
+    outs = ["LICENSE"],
+    cmd = "cp $(execpath //:LICENSE) $@",
 )
 
-pkg_tar(
-    name = "npm_package_archive",
-    srcs = [":npm_package"],
-    extension = "tar.gz",
-    strip_prefix = "./npm_package",
-    tags = ["manual"],
+pkg_npm(
+    name = "npm_package",
+    srcs = [":package.json"],
+    deps = [
+        ":README.md",
+        ":core",
+        ":license",
+        ":src/experimental/jobs/README.md",
+        ":src/experimental/jobs/architecture.md",
+        "//packages/angular_devkit/core/node",
+        "//packages/angular_devkit/core/node:package.json",
+        "//packages/angular_devkit/core/node/testing",
+    ],
 )
 
 api_golden_test_npm_package(
@@ -106,4 +108,3 @@ api_golden_test_npm_package(
     npm_package = "angular_cli/packages/angular_devkit/core/npm_package",
     types = ["@npm//@types/node"],
 )
-# @external_end

--- a/packages/angular_devkit/schematics/BUILD.bazel
+++ b/packages/angular_devkit/schematics/BUILD.bazel
@@ -1,11 +1,6 @@
 load("@npm//@bazel/jasmine:index.bzl", "jasmine_node_test")
-load("//tools:defaults.bzl", "ts_library")
-
-# @external_begin
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
-load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
+load("//tools:defaults.bzl", "pkg_npm", "ts_library")
 load("@npm//@angular/dev-infra-private/bazel/api-golden:index.bzl", "api_golden_test_npm_package")
-# @external_end
 
 # Copyright Google Inc. All Rights Reserved.
 #
@@ -69,23 +64,27 @@ jasmine_node_test(
     ],
 )
 
-# @external_begin
-pkg_npm(
-    name = "npm_package",
-    deps = [
-        ":schematics",
-        "//packages/angular_devkit/schematics/tasks",
-        "//packages/angular_devkit/schematics/testing",
-        "//packages/angular_devkit/schematics/tools",
-    ],
+genrule(
+    name = "license",
+    srcs = ["//:LICENSE"],
+    outs = ["LICENSE"],
+    cmd = "cp $(execpath //:LICENSE) $@",
 )
 
-pkg_tar(
-    name = "npm_package_archive",
-    srcs = [":npm_package"],
-    extension = "tar.gz",
-    strip_prefix = "./npm_package",
-    tags = ["manual"],
+pkg_npm(
+    name = "npm_package",
+    srcs = [":package.json"],
+    deps = [
+        ":README.md",
+        ":collection-schema.json",
+        ":license",
+        ":schematics",
+        "//packages/angular_devkit/schematics/tasks",
+        "//packages/angular_devkit/schematics/tasks:package.json",
+        "//packages/angular_devkit/schematics/testing",
+        "//packages/angular_devkit/schematics/testing:package.json",
+        "//packages/angular_devkit/schematics/tools:package.json",
+    ],
 )
 
 api_golden_test_npm_package(
@@ -98,4 +97,3 @@ api_golden_test_npm_package(
     npm_package = "angular_cli/packages/angular_devkit/schematics/npm_package",
     types = ["@npm//@types/node"],
 )
-# @external_end

--- a/packages/angular_devkit/schematics_cli/BUILD.bazel
+++ b/packages/angular_devkit/schematics_cli/BUILD.bazel
@@ -1,8 +1,6 @@
 load("@npm//@bazel/jasmine:index.bzl", "jasmine_node_test")
-load("//tools:defaults.bzl", "ts_library")
+load("//tools:defaults.bzl", "pkg_npm", "ts_library")
 load("//tools:ts_json_schema.bzl", "ts_json_schema")
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
-load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
 
 # Copyright Google Inc. All Rights Reserved.
 #
@@ -91,17 +89,19 @@ ts_json_schema(
     src = "schematic/schema.json",
 )
 
-pkg_npm(
-    name = "npm_package",
-    deps = [
-        ":schematics_cli",
-    ],
+genrule(
+    name = "license",
+    srcs = ["//:LICENSE"],
+    outs = ["LICENSE"],
+    cmd = "cp $(execpath //:LICENSE) $@",
 )
 
-pkg_tar(
-    name = "npm_package_archive",
-    srcs = [":npm_package"],
-    extension = "tar.gz",
-    strip_prefix = "./npm_package",
-    tags = ["manual"],
+pkg_npm(
+    name = "npm_package",
+    srcs = [":package.json"],
+    deps = [
+        ":README.md",
+        ":license",
+        ":schematics_cli",
+    ],
 )

--- a/packages/ngtools/webpack/BUILD.bazel
+++ b/packages/ngtools/webpack/BUILD.bazel
@@ -4,13 +4,8 @@
 # found in the LICENSE file at https://angular.io/license
 
 load("@npm//@bazel/jasmine:index.bzl", "jasmine_node_test")
-load("//tools:defaults.bzl", "ts_library")
-
-# @external_begin
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
-load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
+load("//tools:defaults.bzl", "pkg_npm", "ts_library")
 load("@npm//@angular/dev-infra-private/bazel/api-golden:index.bzl", "api_golden_test_npm_package")
-# @external_end
 
 licenses(["notice"])  # MIT
 
@@ -72,20 +67,21 @@ jasmine_node_test(
     ],
 )
 
-# @external_begin
-pkg_npm(
-    name = "npm_package",
-    deps = [
-        ":webpack",
-    ],
+genrule(
+    name = "license",
+    srcs = ["//:LICENSE"],
+    outs = ["LICENSE"],
+    cmd = "cp $(execpath //:LICENSE) $@",
 )
 
-pkg_tar(
-    name = "npm_package_archive",
-    srcs = [":npm_package"],
-    extension = "tar.gz",
-    strip_prefix = "./npm_package",
-    tags = ["manual"],
+pkg_npm(
+    name = "npm_package",
+    srcs = [":package.json"],
+    deps = [
+        ":README.md",
+        ":license",
+        ":webpack",
+    ],
 )
 
 api_golden_test_npm_package(
@@ -97,4 +93,3 @@ api_golden_test_npm_package(
     golden_dir = "angular_cli/goldens/public-api/ngtools/webpack",
     npm_package = "angular_cli/packages/ngtools/webpack/npm_package",
 )
-# @external_end

--- a/packages/schematics/angular/BUILD.bazel
+++ b/packages/schematics/angular/BUILD.bazel
@@ -4,13 +4,8 @@
 # found in the LICENSE file at https://angular.io/license
 
 load("@npm//@bazel/jasmine:index.bzl", "jasmine_node_test")
-load("//tools:defaults.bzl", "ts_library")
+load("//tools:defaults.bzl", "pkg_npm", "ts_library")
 load("//tools:ts_json_schema.bzl", "ts_json_schema")
-
-# @external_begin
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
-load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
-# @external_end
 
 licenses(["notice"])  # MIT
 
@@ -136,19 +131,25 @@ jasmine_node_test(
     ],
 )
 
-# @external_begin
-pkg_npm(
-    name = "npm_package",
-    deps = [
-        ":angular",
-    ],
+genrule(
+    name = "license",
+    srcs = ["//:LICENSE"],
+    outs = ["LICENSE"],
+    cmd = "cp $(execpath //:LICENSE) $@",
 )
 
-pkg_tar(
-    name = "npm_package_archive",
-    srcs = [":npm_package"],
-    extension = "tar.gz",
-    strip_prefix = "./npm_package",
-    tags = ["manual"],
+pkg_npm(
+    name = "npm_package",
+    srcs = [":package.json"],
+    deps = [
+        "library/library-long.md",
+        ":README.md",
+        ":angular",
+        ":app-shell/app-shell-long.md",
+        ":e2e/e2e-long.md",
+        ":license",
+        ":migrations/migration-collection.json",
+        ":utility/latest-versions/package.json",
+        "//packages/schematics/angular/third_party/github.com/Microsoft/TypeScript:LICENSE",
+    ],
 )
-# @external_end

--- a/packages/schematics/angular/third_party/github.com/Microsoft/TypeScript/BUILD.bazel
+++ b/packages/schematics/angular/third_party/github.com/Microsoft/TypeScript/BUILD.bazel
@@ -4,6 +4,10 @@ load("//tools:defaults.bzl", "ts_library")
 # https://github.com/microsoft/TypeScript/releases/tag/v4.4.3
 licenses(["notice"])  # Apache 2.0
 
+exports_files([
+    "LICENSE",
+])
+
 ts_library(
     name = "TypeScript",
     srcs = ["lib/typescript.d.ts"],

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -1,6 +1,9 @@
 """Re-export of some bazel rules with repository-wide defaults."""
 
 load("@npm//@bazel/typescript:index.bzl", _ts_library = "ts_library")
+load("@build_bazel_rules_nodejs//:index.bzl", _pkg_npm = "pkg_npm")
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("@npm//@angular/dev-infra-private/bazel:extract_js_module_output.bzl", "extract_js_module_output")
 
 _DEFAULT_TSCONFIG = "//:tsconfig-build.json"
 _DEFAULT_TSCONFIG_TEST = "//:tsconfig-test.json"
@@ -39,4 +42,74 @@ def ts_library(
         devmode_target = devmode_target,
         # @external_end
         **kwargs
+    )
+
+def pkg_npm(name, use_prodmode_output = False, **kwargs):
+    """Default values for pkg_npm"""
+    visibility = kwargs.pop("visibility", None)
+
+    common_substitutions = dict(kwargs.pop("substitutions", {}))
+    substitutions = dict(common_substitutions, **{
+        # TODO: Current build script relies on 0.0.0 in package.json; uncomment after replacing build script.
+        #"0.0.0-PLACEHOLDER": "0.0.0",
+    })
+    stamped_substitutions = dict(common_substitutions, **{
+        # TODO: Current build script relies on 0.0.0 in package.json; uncomment after replacing build script.
+        #"0.0.0-PLACEHOLDER": "{BUILD_SCM_VERSION}",
+        "0.0.0": "{BUILD_SCM_VERSION}",
+    })
+
+    deps = kwargs.pop("deps", [])
+
+    # The `pkg_npm` rule brings in devmode (`JSModuleInfo`) and prodmode (`JSEcmaScriptModuleInfo`)
+    # output into the the NPM package We do not intend to ship the prodmode ECMAScript `.mjs`
+    # files, but the `JSModuleInfo` outputs (which correspond to devmode output). Depending on
+    # the `use_prodmode_output` macro attribute, we either ship the ESM output of dependencies,
+    # or continue shipping the devmode ES5 output.
+    # TODO: Clean this up in the future if we have combined devmode and prodmode output.
+    # https://github.com/bazelbuild/rules_nodejs/commit/911529fd364eb3ee1b8ecdc568a9fcf38a8b55ca.
+    # https://github.com/bazelbuild/rules_nodejs/blob/stable/packages/typescript/internal/build_defs.bzl#L334-L337.
+    extract_js_module_output(
+        name = "%s_js_module_output" % name,
+        provider = "JSEcmaScriptModuleInfo" if use_prodmode_output else "JSModuleInfo",
+        include_declarations = True,
+        include_default_files = True,
+        forward_linker_mappings = False,
+        include_external_npm_packages = False,
+        deps = deps,
+    )
+
+    _pkg_npm(
+        name = name,
+        # We never set a `package_name` for NPM packages, neither do we enable validation.
+        # This is necessary because the source targets of the NPM packages all have
+        # package names set and setting a similar `package_name` on the NPM package would
+        # result in duplicate linker mappings that will conflict. e.g. consider the following
+        # scenario: We have a `ts_library` for `@angular/core`. We will configure a package
+        # name for the target so that it can be resolved in NodeJS executions from `node_modules`.
+        # If we'd also set a `package_name` for the associated `pkg_npm` target, there would be
+        # two mappings for `@angular/core` and the linker will complain. For a better development
+        # experience, we want the mapping to resolve to the direct outputs of the `ts_library`
+        # instead of requiring tests and other targets to assemble the NPM package first.
+        # TODO(devversion): consider removing this if `rules_nodejs` allows for duplicate
+        # linker mappings where transitive-determined mappings are skipped on conflicts.
+        # https://github.com/bazelbuild/rules_nodejs/issues/2810.
+        package_name = None,
+        validate = False,
+        substitutions = select({
+            "//:stamp": stamped_substitutions,
+            "//conditions:default": substitutions,
+        }),
+        visibility = visibility,
+        deps = [":%s_js_module_output" % name],
+        tgz = None,
+        **kwargs
+    )
+
+    pkg_tar(
+        name = name + "_archive",
+        srcs = [":%s" % name],
+        extension = "tar.gz",
+        strip_prefix = "./%s" % name,
+        visibility = visibility,
     )


### PR DESCRIPTION
@gregmagolan @josephperrott 

This PR modifies the existing bazel rules to reproduce the packages that are currently being produced by the `build.ts` script. I also added version stamping which works for snapshot and release builds.

There are still some differences between the `package.json` files that bazel produces compared to `build.ts`, which I will work through in future pull requests. These differences include:
* using tars as dependency versions for local builds
* additional substitutions such as removing devDependencies, merging keywords from the base package.json, etc.

Once bazel is producing identical pacakges, I will switch the `build.ts` script to call bazel instead of tsc. Until then, none of this should affect the currently used build process.