### PR TITLE
feat(@schematics/angular): add a new schematic command

### DIFF
--- a/packages/schematics/angular/collection.json
+++ b/packages/schematics/angular/collection.json
@@ -118,6 +118,11 @@
       "factory": "./web-worker",
       "schema": "./web-worker/schema.json",
       "description": "Create a Web Worker."
+    },
+    "schematic": {
+      "factory": "./schematic",
+      "schema": "./schematic/schema.json",
+      "description": "Create a schematic"
     }
   }
 }

--- a/packages/schematics/angular/schematic/files/__name@dasherize@if-flat__/__name@dasherize__.spec.ts.template
+++ b/packages/schematics/angular/schematic/files/__name@dasherize@if-flat__/__name@dasherize__.spec.ts.template
@@ -1,0 +1,21 @@
+import { Tree } from '@angular-devkit/schematics';
+import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
+import * as path from 'path';
+
+const collectionPath = path.join(__dirname, '<%= collectionJsonPath %>');
+
+describe('<%= dasherize(name) %>', () => {
+  let runner: SchematicTestRunner;
+  let tree: Tree;
+
+  beforeEach(() => {
+    runner = new SchematicTestRunner('schematics', collectionPath);
+    tree = Tree.empty();
+  });
+
+  // todo add proper default test
+  it('noop', async () => {
+    await runner.runSchematicAsync('<%= dasherize(name) %>', {}, tree).toPromise();
+    expect(true).toBe(true);
+  });
+});

--- a/packages/schematics/angular/schematic/files/__name@dasherize@if-flat__/__name@dasherize__.ts.template
+++ b/packages/schematics/angular/schematic/files/__name@dasherize@if-flat__/__name@dasherize__.ts.template
@@ -1,0 +1,11 @@
+import { noop, Tree } from "@angular-devkit/schematics";
+
+export interface <%= classify(name) %>Options {
+  name: string;
+}
+
+export function <%= camelize(name) %>(options: <%= classify(name) %>Options) {
+  return async (host: Tree) => {
+    return noop();
+  };
+}

--- a/packages/schematics/angular/schematic/files/__name@dasherize@if-flat__/schema.json.template
+++ b/packages/schematics/angular/schematic/files/__name@dasherize@if-flat__/schema.json.template
@@ -1,0 +1,19 @@
+{
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Name",
+      "$default": {
+        "$source": "argv",
+        "index": 0
+      }
+    },
+    "path": {
+      "type": "string",
+      "format": "path",
+      "description": "",
+      "visible": false
+    }
+  },
+  "required": ["name"]
+}

--- a/packages/schematics/angular/schematic/index.ts
+++ b/packages/schematics/angular/schematic/index.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { strings } from '@angular-devkit/core';
+import { apply, applyTemplates, chain, FileOperator, filter, forEach, mergeWith, move, noop, Rule, SchematicsException, Tree, url } from '@angular-devkit/schematics';
+import { parseName } from '../utility/parse-name';
+import { buildDefaultPath, getWorkspace } from '../utility/workspace';
+import { Schema as ComponentOptions } from './schema';
+
+export default function (options: ComponentOptions): Rule {
+  return async (host: Tree) => {
+    const workspace = await getWorkspace(host);
+    const project = workspace.projects.get(options.project as string);
+
+    if (!project) {
+      throw new SchematicsException(`Project "${options.project}" does not exist.`);
+    }
+
+    if (options.path === undefined) {
+      options.path = buildDefaultPath(project);
+    }
+
+    const parsedPath = parseName(options.path as string, options.name);
+    options.name = parsedPath.name;
+    options.path = parsedPath.path;
+
+    const templateSource = apply(url('./files'), [
+      options.skipTests ? filter((path) => !path.endsWith('.spec.ts.template')) : noop(),
+      applyTemplates({
+        ...strings,
+        'if-flat': (s: string) => (options.flat ? '' : s),
+        ...options,
+      }),
+      !options.type
+        ? forEach(((file) => {
+            return file.path.includes('..')
+              ? {
+                  content: file.content,
+                  path: file.path.replace('..', '.'),
+                }
+              : file;
+          }) as FileOperator)
+        : noop(),
+      move(parsedPath.path),
+    ]);
+
+    return chain([mergeWith(templateSource)]);
+  };
+}

--- a/packages/schematics/angular/schematic/index_spec.ts
+++ b/packages/schematics/angular/schematic/index_spec.ts
@@ -1,0 +1,128 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';
+import { Schema as ApplicationOptions, Style as AppStyle } from '../application/schema';
+import { Schema as WorkspaceOptions } from '../workspace/schema';
+import { Schema as SchematicOptions, Type } from './schema';
+
+describe('Ng Schematic Schematic', () => {
+  const schematicRunner = new SchematicTestRunner(
+    '@schematics/angular',
+    require.resolve('../collection.json'),
+  );
+  const defaultOptions: SchematicOptions = {
+    name: 'foo',
+    // path: 'src/app',
+    type: 'Generate' as Type,
+    skipTests: false,
+    project: 'bar',
+  };
+
+  const workspaceOptions: WorkspaceOptions = {
+    name: 'workspace',
+    newProjectRoot: 'projects',
+    version: '6.0.0',
+  };
+
+  const appOptions: ApplicationOptions = {
+    name: 'bar',
+    inlineStyle: false,
+    inlineTemplate: false,
+    routing: false,
+    style: AppStyle.Css,
+    skipTests: false,
+    skipPackageJson: false,
+  };
+  let appTree: UnitTestTree;
+  beforeEach(async () => {
+    appTree = await schematicRunner.runSchematicAsync('workspace', workspaceOptions).toPromise();
+    appTree = await schematicRunner
+      .runSchematicAsync('application', appOptions, appTree)
+      .toPromise();
+  });
+
+  it('should create a schematic', async () => {
+    const options = { ...defaultOptions };
+    const tree = await schematicRunner.runSchematicAsync('schematic', options, appTree).toPromise();
+    const files = tree.files;
+    expect(files).toEqual(
+      jasmine.arrayContaining([
+        '/projects/bar/src/app/foo/foo.spec.ts',
+        '/projects/bar/src/app/foo/foo.ts',
+        '/projects/bar/src/app/foo/schema.json',
+      ]),
+    );
+  });
+
+  it('should create a flat schematic', async () => {
+    const options = { ...defaultOptions, flat: true };
+
+    const tree = await schematicRunner.runSchematicAsync('schematic', options, appTree).toPromise();
+    const files = tree.files;
+    expect(files).toEqual(
+      jasmine.arrayContaining([
+        '/projects/bar/src/app/foo.spec.ts',
+        '/projects/bar/src/app/foo.ts',
+        '/projects/bar/src/app/foo/schema.json',
+      ]),
+    );
+  });
+
+  it('should handle upper case paths', async () => {
+    const pathOption = 'projects/bar/src/app/SOME/UPPER/DIR';
+    const options = { ...defaultOptions, path: pathOption };
+
+    const tree = await schematicRunner.runSchematicAsync('schematic', options, appTree).toPromise();
+    let files = tree.files;
+    let name = 'foo';
+    let root = `/${pathOption}/${name}/${name}`;
+    expect(files).toEqual(
+      jasmine.arrayContaining([`${root}.spec.ts`, `${root}.ts`, `/${pathOption}/${name}/schema.json`]),
+    );
+
+    const options2 = { ...options, name: 'BAR' };
+    const tree2 = await schematicRunner.runSchematicAsync('schematic', options2, tree).toPromise();
+    files = tree2.files;
+    name = 'bar';
+    root = `/${pathOption}/${name}/${name}.component`;
+    expect(files).toEqual(
+      jasmine.arrayContaining([`${root}.spec.ts`, `${root}.ts`, `/${pathOption}/${name}/schema.json`]),
+    );
+  });
+
+  it('should create a schematic in a sub-directory', async () => {
+    const options = { ...defaultOptions, path: 'projects/bar/src/app/a/b/c' };
+
+    const tree = await schematicRunner.runSchematicAsync('schematic', options, appTree).toPromise();
+    const files = tree.files;
+    const name = 'foo';
+    const root = `/${options.path}/${name}/${name}`;
+    expect(files).toEqual(
+      jasmine.arrayContaining([`${root}.spec.ts`, `${root}.ts`, `/${options.path}/${name}/schema.json`]),
+    );
+  });
+
+  it('TODO: test type input', async () => {
+    expect(true).toBe(true);
+  });
+
+  it('should respect the skipTests option', async () => {
+    const options = { ...defaultOptions, skipTests: true };
+    const tree = await schematicRunner.runSchematicAsync('schematic', options, appTree).toPromise();
+    const files = tree.files;
+
+    expect(files).toEqual(
+      jasmine.arrayContaining([
+        '/projects/bar/src/app/foo/foo.ts',
+        '/projects/bar/src/app/foo/schema.json',
+      ]),
+    );
+    expect(tree.files).not.toContain('/projects/bar/src/app/foo/foo.spec.ts');
+  });
+});

--- a/packages/schematics/angular/schematic/schema.json
+++ b/packages/schematics/angular/schematic/schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "SchematicsAngularSchematic",
+  "title": "Angular Schematic Options Schema",
+  "type": "object",
+  "description": "Creates a new, generic schematic in the given or default project.",
+  "additionalProperties": false,
+  "properties": {
+    "path": {
+      "type": "string",
+      "format": "path",
+      "description": "The path at which to create the schematic file, relative to the current workspace. Default is a folder with the same name as the schematic in the project root.",
+      "visible": false
+    },
+    "project": {
+      "type": "string",
+      "description": "The name of the project.",
+      "$default": {
+        "$source": "projectName"
+      }
+    },
+    "name": {
+      "type": "string",
+      "description": "The name of the schematic.",
+      "$default": {
+        "$source": "argv",
+        "index": 0
+      },
+      "x-prompt": "What name would you like to use for the schematic?"
+    },
+    "type": {
+      "type": "string",
+      "description": "The type of the schematic.",
+      "enum": [
+        "Generate",
+        "Update",
+        "Add"
+      ],
+      "x-prompt": "Which schematic type would you like to generate?"
+    },
+    "skipTests": {
+      "type": "boolean",
+      "description": "Do not create \"spec.ts\" test files for the new schematic.",
+      "default": false,
+      "x-user-analytics": 12
+    },
+    "flat": {
+      "type": "boolean",
+      "description": "Create the new files at the top level of the current project.",
+      "default": false
+    }
+  },
+  "required": ["name", "type"]
+}


### PR DESCRIPTION
# Introduction

This PR adds a new command `ng generate schematic` to the CLI. The primary goal is to automate the initial setup and support the creation of new schematics by letting the CLI update the corresponding JSON config files (migration.json, collection.json).

See https://angular.io/guide/schematics-for-libraries

## Current situation

Right now, developers can already set up schematics outside of an existing Angular workspace:

```
// see https://angular.io/guide/schematics-authoring#schematics-cli
npm i -g @angular-devkit/schematics-cli
schematics blank --name=hello-world
```

The command above creates a new, independent, TypeScript project with a basic schematic and a collection.json. 

```
hello-world/
├── node_modules
├── src/
│   ├── hello-world/
│   │   ├── index_spec.ts
│   │   └── index.ts
│   └── collection.json
├── .gitignore
├── .npmignore
├── package-lock.json
├── package.json
├── README.md
└── tsconfig.json
```

The most significant pain point is that it does not integrate into an existing Angular workspace which gives developers two choices:

1) Copy and paste things over to their project
2) Use a manual guide https://angular.io/guide/schematics-for-libraries

# What is this PR trying to solve?

## Goals
- Extend the Angular CLI with a new command "ng generate schematic <options>"
- Automate the initial setup for Angular workspaces
  - Install necessary dependencies
  - Create a schematics directory
  - Create a collection.json or migration.json and add their path to the package.json of the project
  - Add necessary manual build steps (https://angular.io/guide/schematics-for-libraries#building-your-schematics)
- Provide schematics for
  - Adding ng-add support (ng generate schematic --type add <...>)
  - Creating ng-generate schematics (ng generate schematic --type generate <...>)
  - Creating ng-update schematics (ng generate schematic --type update <...>)

## Non-Goals
- Add a builder that handles all necessary build steps
- Extending the existing "@angular-devkit/schematics-cli" API

# Related issues 

https://github.com/ng-packagr/ng-packagr/issues/1180 
https://github.com/angular/angular-cli/issues/13505

Closes #22288