### PR TITLE
fix(@schematics/angular): updated Angular new project version to v13.1.0

### DIFF
--- a/packages/schematics/angular/utility/latest-versions.ts
+++ b/packages/schematics/angular/utility/latest-versions.ts
@@ -15,7 +15,7 @@ export const latestVersions: Record<string, string> & {
   ...require('./latest-versions/package.json')['dependencies'],
 
   // As Angular CLI works with same minor versions of Angular Framework, a tilde match for the current
-  Angular: '~13.0.0',
+  Angular: '~13.1.0',
 
   // Since @angular-devkit/build-angular and @schematics/angular are always
   // published together from the same monorepo, and they are both


### PR DESCRIPTION
New CLI projects are generated with Angular v13 (see https://github.com/cexbrayat/angular-cli-diff/blob/13.1.0/ponyracer/package.json) and TS v4.5 (which is only supported by Angular v13.1).


A new project is currently failing out of the box, as Angular v13 does not support TS 4.5.
```
npx @angular/cli@13.1.0 new v131 --defaults
cd v131
ng serve
```

throws:

```
UnhandledPromiseRejectionWarning: Error: The Angular Compiler requires TypeScript >=4.4.2 and <4.5.0 but 4.5.3 was found instead.
    at checkVersion (file:///Users/ced-pro/Code/test/cli-tests/v131/node_modules/@angular/compiler-cli/bundles/index.js:17440:11)
```

Fixes #22333 