### PR TITLE
test: remove `disableTypeScriptVersionCheck` from tests setup

### DIFF
--- a/tests/legacy-cli/e2e/setup/500-create-project.ts
+++ b/tests/legacy-cli/e2e/setup/500-create-project.ts
@@ -6,7 +6,7 @@ import { setRegistry as setNPMConfigRegistry } from '../utils/packages';
 import { ng, npm } from '../utils/process';
 import { prepareProjectForE2e, updateJsonFile } from '../utils/project';
 
-export default async function() {
+export default async function () {
   const argv = getGlobalVariable('argv');
 
   if (argv.noproject) {
@@ -27,15 +27,6 @@ export default async function() {
     await ng('new', 'test-project', '--skip-install', ...extraArgs);
     await expectFileToExist(join(process.cwd(), 'test-project'));
     process.chdir('./test-project');
-
-    // Disable the TS version check to make TS updates easier.
-    // Only VE does it, but on Ivy the i18n extraction uses VE.
-    await updateJsonFile('tsconfig.json', config => {
-      if (!config.angularCompilerOptions) {
-        config.angularCompilerOptions = {};
-      }
-      config.angularCompilerOptions.disableTypeScriptVersionCheck = true;
-    });
 
     // If on CI, the user configuration set above will handle project usage
     if (!isCI) {

--- a/tests/legacy-cli/e2e/tests/i18n/ivy-localize-es2015.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/ivy-localize-es2015.ts
@@ -4,18 +4,14 @@ import { updateJsonFile } from '../../utils/project';
 import { expectToFail } from '../../utils/utils';
 import { externalServer, langTranslations, setupI18nConfig } from './setup';
 
-export default async function() {
+export default async function () {
   // Setup i18n tests and config.
   await setupI18nConfig();
 
   // Ensure a es2017 build is used.
   await writeFile('.browserslistrc', 'Chrome 65');
-  await updateJsonFile('tsconfig.json', config => {
+  await updateJsonFile('tsconfig.json', (config) => {
     config.compilerOptions.target = 'es2017';
-    if (!config.angularCompilerOptions) {
-      config.angularCompilerOptions = {};
-    }
-    config.angularCompilerOptions.disableTypeScriptVersionCheck = true;
   });
 
   await ng('build', '--source-map');


### PR DESCRIPTION
This option causes our CI to be green even when new projects are created with mismatching TypeScript versions, which causes failures in a real-world project.