### PR TITLE
refactor(@angular-devkit/core): update missing workspace file error to explicitly call out `angular.json`

### DIFF
--- a/packages/angular_devkit/core/src/workspace/core.ts
+++ b/packages/angular_devkit/core/src/workspace/core.ts
@@ -81,7 +81,10 @@ export async function readWorkspace(
       }
     }
     if (!found) {
-      throw new Error('Unable to locate a workspace file for workspace path.');
+      throw new Error(
+        'Unable to locate a workspace file for workspace path. Are you missing an `angular.json`' +
+          ' or `.angular.json` file?',
+      );
     }
   } else if (format === undefined) {
     const filename = basename(normalize(path));


### PR DESCRIPTION
Internally, we've gotten a lot of bugs of users running the CLI in the wrong directory and not understanding this error. Hopefully calling this out more explicitly will key users to double-check their working directory before filing a bug.