### PR TITLE
fix(@angular-devkit/build-angular): display FS cache information when `verbose` option is used

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/utils/helpers.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/utils/helpers.ts
@@ -126,6 +126,7 @@ export function getCacheSettings(
 
     return {
       type: 'filesystem',
+      profile: wco.buildOptions.verbose,
       cacheDirectory: path.join(cacheDirectory, 'angular-webpack'),
       maxMemoryGenerations: 1,
       // We use the versions and build options as the cache name. The Webpack configurations are too


### PR DESCRIPTION

With this change we enabling Webpack to display additional cache related logs when the `verbose` option is enabled. This is helpful to debug cache misses.