### PR TITLE
fix(@angular/cli): exclude deprecated packages with removal migration…

### DIFF
--- a/packages/schematics/update/update/index.ts
+++ b/packages/schematics/update/update/index.ts
@@ -172,9 +172,16 @@ function _validateReversePeerDependencies(
         continue;
       }
 
-      if (installed === '@angular-devkit/build-ng-packagr') {
-        // Ignore peerDependencies mismatches for `@angular-devkit/build-ng-packagr`.
-        // This package is deprecated and is removed via a migration.
+      // Ignore peerDependency mismatches for these packages.
+      // They are deprecated and removed via a migration.
+      const ignoredPackages = [
+        'codelyzer',
+        '@schematics/update',
+        '@angular-devkit/build-ng-packagr',
+        'tsickle',
+      ];
+
+      if (ignoredPackages.includes(installed)) {
         continue;
       }
 


### PR DESCRIPTION
… from update

Deprecated packages that may have been included in a project by the tooling are now ignored when validating an update. This change removes the need to use the `--force` option in a situation where the later migrations will remove and cleanup the deprecated packages.

Backport https://github.com/angular/angular-cli/commit/8a805fe0b9a0db3329aa51d95a41f3baacd45feb#diff-50a772efb6fc4c6286638ecac4856aa001c5c91aba8c84bd051d434f11446403 to v11 LTS