### PR TITLE
test(@angular/cli): run version 11 update with `--force` flag

### DIFF
--- a/tests/legacy-cli/e2e/tests/update/update-9.ts
+++ b/tests/legacy-cli/e2e/tests/update/update-9.ts
@@ -21,7 +21,7 @@ export default async function () {
     }
 
     // Update Angular to 11
-    await ng('update', '@angular/cli@11', '@angular/core@11');
+    await ng('update', '@angular/cli@11', '@angular/core@11', '--force');
 
     // Update Angular to 12
     await ng('update', '@angular/cli@12', '@angular/core@12');


### PR DESCRIPTION
This is needed because in version 11 we didn't backport the change to exclude deprecated packages from peer dependencies validations. Therefore the update is failing due to the below.

```
STDERR:
The installed Angular CLI version is outdated.
Installing a temporary Angular CLI versioned 11.2.16 to perform the update.
- Installing package...
✔ Package successfully installed.
                  Package "codelyzer" has an incompatible peer dependency to "@angular/compiler" (requires ">=2.3.1 <10.0.0 || >9.0.0-beta <10.0.0 || >9.1.0-beta <10.0.0 || >9.2.0-beta <10.0.0" (extended), would install "11.2.14").
                  Package "codelyzer" has an incompatible peer dependency to "@angular/core" (requires ">=2.3.1 <10.0.0 || >9.0.0-beta <10.0.0 || >9.1.0-beta <10.0.0 || >9.2.0-beta <10.0.0" (extended), would install "11.2.14").
✖ Migration failed: Incompatible peer dependencies found
```

This change should be reverted once https://github.com/angular/angular-cli/pull/22392 is released.