### PR TITLE
build: perform package.json substitutions in bazel build

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -11,6 +11,7 @@ exports_files([
     "tsconfig.json",  # @external
     "tsconfig-test.json",  # @external
     "tsconfig-build.json",  # @external
+    "package.json",
 ])
 
 # Detect if the build is running under --stamp

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -50,3 +50,17 @@ yarn_install(
     package_json = "//:package.json",
     yarn_lock = "//:yarn.lock",
 )
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "aspect_bazel_lib",
+    sha256 = "a28dbee79b1382a170d4b93ba676a9e31cea48f1985dbdd4ee500211d2a005e9",
+    strip_prefix = "bazel-lib-0.4.0",
+    url = "https://github.com/aspect-build/bazel-lib/archive/v0.4.0.tar.gz",
+)
+
+load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies", "register_jq_toolchains")
+
+aspect_bazel_lib_dependencies()
+register_jq_toolchains(version = "1.6")

--- a/packages/schematics/angular/BUILD.bazel
+++ b/packages/schematics/angular/BUILD.bazel
@@ -46,8 +46,6 @@ ts_library(
             # Also exclude templated files.
             "*/files/**/*.ts",
             "*/other-files/**/*.ts",
-            # Exclude test helpers.
-            "utility/test/**/*.ts",
             # NB: we need to exclude the nested node_modules that is laid out by yarn workspaces
             "node_modules/**",
         ],
@@ -76,6 +74,7 @@ ts_library(
         "//packages/angular_devkit/core",
         "//packages/angular_devkit/schematics",
         "//packages/angular_devkit/schematics/tasks",
+        "//packages/angular_devkit/schematics/testing",
         "//packages/schematics/angular/third_party/github.com/Microsoft/TypeScript",
         "@npm//@types/browserslist",
         "@npm//@types/node",


### PR DESCRIPTION
fyi: @gregmagolan 

Need a new bazel-lib release with the extra copy_directory flags as well as the windows implementation before I PR this against angular.