### PR TITLE
fix(@angular-devkit/build-angular): disable parsing `new URL` syntax

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
@@ -356,16 +356,14 @@ export async function getCommonConfig(wco: WebpackConfigOptions): Promise<Config
     module: {
       // Show an error for missing exports instead of a warning.
       strictExportPresence: true,
-      parser:
-        webWorkerTsConfig === undefined
-          ? {
-              javascript: {
-                worker: false,
-                url: false,
-              },
-            }
-          : undefined,
-
+      parser: {
+        javascript: {
+          // Disable auto URL asset module creation. This doesn't effect `new Worker(new URL(...))`
+          // https://webpack.js.org/guides/asset-modules/#url-assets
+          url: false,
+          worker: !!webWorkerTsConfig,
+        },
+      },
       rules: [
         {
           test: /\.?(svg|html)$/,


### PR DESCRIPTION
When web-workers are enabled we allowing parsing `new URL` syntax which has the side-effect that Webpack will treat all assets as asset modules (https://webpack.js.org/guides/asset-modules/#url-assets). With this change we remove this inconsistency by disabling the `url` parsing which doesn't effect `new Worker(new URL(...))`.