### PR TITLE
build: perform package.json substitutions in bazel build

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -11,6 +11,7 @@ exports_files([
     "tsconfig.json",  # @external
     "tsconfig-test.json",  # @external
     "tsconfig-build.json",  # @external
+    "package.json",
 ])
 
 # Detect if the build is running under --stamp

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -50,3 +50,16 @@ yarn_install(
     package_json = "//:package.json",
     yarn_lock = "//:yarn.lock",
 )
+
+http_archive(
+    name = "aspect_bazel_lib",
+    sha256 = "534c9c61b72c257c95302d544984fd8ee63953c233292c5b6952ca5b33cd225e",
+    strip_prefix = "bazel-lib-0.4.2",
+    url = "https://github.com/aspect-build/bazel-lib/archive/v0.4.2.tar.gz",
+)
+
+load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies", "register_jq_toolchains")
+
+aspect_bazel_lib_dependencies()
+
+register_jq_toolchains(version = "1.6")


### PR DESCRIPTION
@josephperrott @gregmagolan 

This pr mimics the `package.json` substitutions that `build.ts` performs, minus substituting dependency versions for tar paths on a local build (that's coming up in the next pr). The current build will not be affected by this change as we haven't yet flipped `build.ts` to use bazel.