### PR TITLE
build: wrap bazel-built tars in a package folder

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -11,16 +11,6 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/4.4.6/rules_nodejs-4.4.6.tar.gz"],
 )
 
-http_archive(
-    name = "rules_pkg",
-    sha256 = "a89e203d3cf264e564fcb96b6e06dd70bc0557356eb48400ce4b5d97c2c3720d",
-    urls = ["https://github.com/bazelbuild/rules_pkg/releases/download/0.5.1/rules_pkg-0.5.1.tar.gz"],
-)
-
-load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
-
-rules_pkg_dependencies()
-
 # Check the bazel version and download npm dependencies
 load("@build_bazel_rules_nodejs//:index.bzl", "check_bazel_version", "check_rules_nodejs_version", "node_repositories", "yarn_install")
 

--- a/scripts/build-bazel.ts
+++ b/scripts/build-bazel.ts
@@ -110,7 +110,7 @@ async function _build(logger: logging.Logger, mode: BuildMode): Promise<string[]
   logger.info(`Building (mode=${mode})...`);
 
   const queryLogger = logger.createChild('query');
-  const queryTargetsCmd = `${bazelCmd} query --output=label "attr(name, npm_package_archive, //packages/...)"`;
+  const queryTargetsCmd = `${bazelCmd} query --output=label "kind(pkg_npm, //packages/...)"`;
   const targets = (await _exec(queryTargetsCmd, true, queryLogger)).split(/\r?\n/);
 
   let configArg = '';
@@ -161,9 +161,9 @@ export default async function (
   const packageLogger = logger.createChild('packages');
 
   for (const target of targets) {
-    const packageDir = target.replace(/\/\/packages\/(.*):npm_package_archive/, '$1');
+    const packageDir = target.replace(/\/\/packages\/(.*):npm_package/, '$1');
     const bazelOutDir = join(bazelBin, 'packages', packageDir, 'npm_package');
-    const tarPath = `${bazelBin}/packages/${packageDir}/npm_package_archive.tar.gz`;
+    const tarPath = `${bazelBin}/packages/${packageDir}/npm_package_archive.tgz`;
     const packageJsonPath = `${bazelOutDir}/package.json`;
     const packageName = require(packageJsonPath).name;
     const destDir = `${distRoot}/${packageName}`;

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -2,7 +2,6 @@
 
 load("@npm//@bazel/typescript:index.bzl", _ts_library = "ts_library")
 load("@build_bazel_rules_nodejs//:index.bzl", _pkg_npm = "pkg_npm")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("@npm//@angular/dev-infra-private/bazel:extract_js_module_output.bzl", "extract_js_module_output")
 
 _DEFAULT_TSCONFIG = "//:tsconfig-build.json"
@@ -102,14 +101,6 @@ def pkg_npm(name, use_prodmode_output = False, **kwargs):
         }),
         visibility = visibility,
         deps = [":%s_js_module_output" % name],
-        tgz = None,
+        tgz = name + "_archive.tgz",
         **kwargs
-    )
-
-    pkg_tar(
-        name = name + "_archive",
-        srcs = [":%s" % name],
-        extension = "tar.gz",
-        strip_prefix = "./%s" % name,
-        visibility = visibility,
     )


### PR DESCRIPTION
@josephperrott @gregmagolan 

The tars produced by the current build script enclose the tar contents in a `package` folder. See https://github.com/angular/angular-cli/blob/master/scripts/build.ts#L76.

Is this something you want to preserve?

It turns out that the tar functionality built into `pkg_npm` already does this by default so we can just use that instead of `pkg_tar`.