### PR TITLE
fix(@schematics/angular): set `skipTests` flag for resolvers when using ng new --skip-tests

### DIFF
--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -92,14 +92,23 @@ function addAppToWorkspaceFile(
   }
 
   if (options.skipTests || options.minimal) {
-    ['class', 'component', 'directive', 'guard', 'interceptor', 'pipe', 'service'].forEach(
-      (type) => {
-        if (!(`@schematics/angular:${type}` in schematics)) {
-          schematics[`@schematics/angular:${type}`] = {};
-        }
-        (schematics[`@schematics/angular:${type}`] as JsonObject).skipTests = true;
-      },
-    );
+    const schematicsWithTests = [
+      'class',
+      'component',
+      'directive',
+      'guard',
+      'interceptor',
+      'pipe',
+      'resolver',
+      'service',
+    ];
+
+    schematicsWithTests.forEach((type) => {
+      if (!(`@schematics/angular:${type}` in schematics)) {
+        schematics[`@schematics/angular:${type}`] = {};
+      }
+      (schematics[`@schematics/angular:${type}`] as JsonObject).skipTests = true;
+    });
   }
 
   if (options.strict) {

--- a/packages/schematics/angular/application/index_spec.ts
+++ b/packages/schematics/angular/application/index_spec.ts
@@ -179,6 +179,24 @@ describe('Application Schematic', () => {
     expect(karmaConf).toContain(`dir: require('path').join(__dirname, '../../coverage/foo')`);
   });
 
+  it('should set the skipTests flag for other schematics when using --skipTests=true', async () => {
+    const options: ApplicationOptions = { ...defaultOptions, skipTests: true };
+    const tree = await schematicRunner
+      .runSchematicAsync('application', options, workspaceTree)
+      .toPromise();
+    const config = JSON.parse(tree.readContent('/angular.json'));
+    const schematics = config.projects.foo.schematics;
+
+    expect(schematics['@schematics/angular:class']).toEqual({ skipTests: true });
+    expect(schematics['@schematics/angular:component']).toEqual({ skipTests: true });
+    expect(schematics['@schematics/angular:directive']).toEqual({ skipTests: true });
+    expect(schematics['@schematics/angular:guard']).toEqual({ skipTests: true });
+    expect(schematics['@schematics/angular:interceptor']).toEqual({ skipTests: true });
+    expect(schematics['@schematics/angular:pipe']).toEqual({ skipTests: true });
+    expect(schematics['@schematics/angular:resolver']).toEqual({ skipTests: true });
+    expect(schematics['@schematics/angular:service']).toEqual({ skipTests: true });
+  });
+
   it('minimal=true should not create e2e and test targets', async () => {
     const options = { ...defaultOptions, minimal: true };
     const tree = await schematicRunner


### PR DESCRIPTION
Currently when creating a new project with `ng new xy --skip-tests`, the `ng g` command will still generate spec files for resolvers.

This PR aims to fix this issue.