### PR TITLE
Don't set TAILWIND_MODE=watch

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/styles.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/styles.ts
@@ -149,9 +149,6 @@ export function getStylesConfig(wco: WebpackConfigOptions): Configuration {
       );
     }
     if (tailwindPackagePath) {
-      if (process.env['TAILWIND_MODE'] === undefined) {
-        process.env['TAILWIND_MODE'] = buildOptions.watch ? 'watch' : 'build';
-      }
       extraPostcssPlugins.push(require(tailwindPackagePath)({ config: tailwindConfigPath }));
     }
   }


### PR DESCRIPTION
This env var only now exists as a workaround for older `postcss-loader` versions that don't support build dependencies. It is not necessary when using postcss-loader >= 5.3. Additionally it does not work with polling. This shows itself when running docker containers on Windows which require angular to poll for changes because filesystem events from volumes are not delivered to the container.

Internally we use postcss dependencies and rely on the build tool running tailwind to track file changes for us. Using `TAILWIND_MODE=watch` sidesteps that entirely and causes tailwind to watch files for changes itself. We only use this as a workaround for when tools aren't behaving properly.

The relevant issue on tailwindcss is here: https://github.com/tailwindlabs/tailwindcss/issues/6343

Relevant PostCSS discussion: https://github.com/postcss/postcss/issues/1537
