### PR TITLE
fix(@angular-devkit/build-angular): use `contenthash` instead of `chunkhash` for chunks

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/utils/helpers.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/utils/helpers.ts
@@ -32,13 +32,13 @@ export function getOutputHashFormat(option: string, length = 20): HashFormat {
     none: { chunk: '', extract: '', file: '', script: '' },
     media: { chunk: '', extract: '', file: `.[hash:${length}]`, script: '' },
     bundles: {
-      chunk: `.[chunkhash:${length}]`,
+      chunk: `.[contenthash:${length}]`,
       extract: `.[contenthash:${length}]`,
       file: '',
       script: `.[hash:${length}]`,
     },
     all: {
-      chunk: `.[chunkhash:${length}]`,
+      chunk: `.[contenthash:${length}]`,
       extract: `.[contenthash:${length}]`,
       file: `.[hash:${length}]`,
       script: `.[hash:${length}]`,


### PR DESCRIPTION


See https://github.com/waysact/webpack-subresource-integrity/tree/main/webpack-subresource-integrity#caching and https://github.com/waysact/webpack-subresource-integrity/issues/162 for more information about this.

Closes #22439