### PR TITLE
docs: clarify that patch/next releases do not require framework to release in advance

### DIFF
--- a/docs/process/release.md
+++ b/docs/process/release.md
@@ -73,6 +73,9 @@ The current packages that require adjustment are:
 
 ## Releasing the CLI
 
+Typical patch and next releases do not require FW to release in advance, as CLI does not pin the FW
+dependency.
+
 After confirming that the above steps have been done or are not necessary, run the following and
 navigate the prompts:
 


### PR DESCRIPTION
This allows CLI releases to generally be done in parallel with framework and save a lot of time. Major and minor version bumps do require waiting for FW however and that is unchanged.