### PR TITLE
docs: add README to `@schematics/update`

### DIFF
--- a/packages/schematics/update/BUILD.bazel
+++ b/packages/schematics/update/BUILD.bazel
@@ -102,6 +102,7 @@ jasmine_node_test(
 pkg_npm(
     name = "npm_package",
     deps = [
+        "README.md",
         ":update",
     ],
 )

--- a/packages/schematics/update/README.md
+++ b/packages/schematics/update/README.md
@@ -1,0 +1,4 @@
+# `@schematics/update`
+
+This package is **deprecated** and will not be updated beyond Angular v11 (`0.1102.x`). It should no
+longer be used.


### PR DESCRIPTION
This just points out that the package is deprecated and should no longer be used.

@alan-agius4, I believe this is considered a private package since it's experimental, so I didn't really give much context or justification in the README. Let me know if you think there's anything worth mentioning here.