### PR TITLE
fix(@ngtools/webpack): better handle cache in multiple plugin instances

### DIFF
--- a/packages/ngtools/webpack/src/ivy/plugin.ts
+++ b/packages/ngtools/webpack/src/ivy/plugin.ts
@@ -184,7 +184,7 @@ export class AngularWebpackPlugin {
 
       // Initialize webpack cache
       if (!this.webpackCache && compilation.options.cache) {
-        this.webpackCache = compilation.getCache(PLUGIN_NAME);
+        this.webpackCache = compilation.getCache(`${PLUGIN_NAME}__${this.pluginOptions.tsconfig}`);
       }
 
       // Initialize the resource loader if not already setup


### PR DESCRIPTION
When using multiple instances we used the same cache key, with this change we update the cache name to include the TypeScript configuration path which is unique per instance.

Closes #22428