### PR TITLE
build: experimental stamping and snapshot repo substitutions

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -73,6 +73,7 @@ build:release --stamp
 
 build:snapshot --workspace_status_command="yarn -s ng-dev release build-env-stamp --mode=snapshot"
 build:snapshot --stamp
+build:snapshot --//:enable_snapshot_repo_deps
 
 build:local --//:enable_package_json_tar_deps
 

--- a/.monorepo.json
+++ b/.monorepo.json
@@ -89,16 +89,6 @@
       ],
       "snapshotRepo": "angular/angular-devkit-build-optimizer-builds"
     },
-    "@angular-devkit/build-ng-packagr": {
-      "name": "Build NgPackagr",
-      "links": [
-        {
-          "label": "README",
-          "url": "/packages/angular_devkit/build_ng_packagr/README.md"
-        }
-      ],
-      "snapshotRepo": "angular/angular-devkit-build-ng-packagr-builds"
-    },
     "@angular-devkit/build-angular": {
       "name": "Build Angular",
       "links": [

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -34,3 +34,16 @@ config_setting(
         ":enable_package_json_tar_deps": "true",
     },
 )
+
+# If set will replace dependency versions with snapshot repos for packages in this repo
+bool_flag(
+    name = "enable_snapshot_repo_deps",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "package_json_use_snapshot_repo_deps",
+    flag_values = {
+        ":enable_snapshot_repo_deps": "true",
+    },
+)

--- a/constants.bzl
+++ b/constants.bzl
@@ -2,3 +2,18 @@
 RELEASE_ENGINES_NODE = "^12.20.0 || ^14.15.0 || >=16.10.0"
 RELEASE_ENGINES_NPM = "^6.11.0 || ^7.5.6 || >=8.0.0"
 RELEASE_ENGINES_YARN = ">= 1.13.0"
+
+SNAPSHOT_REPOS = {
+    "@angular/cli": "angular/cli-builds",
+    "@angular/pwa": "angular/angular-pwa-builds",
+    "@angular-devkit/architect": "angular/angular-devkit-architect-builds",
+    "@angular-devkit/architect-cli": "angular/angular-devkit-architect-cli-builds",
+    "@angular-devkit/build-optimizer": "angular/angular-devkit-build-optimizer-builds",
+    "@angular-devkit/build-angular": "angular/angular-devkit-build-angular-builds",
+    "@angular-devkit/build-webpack": "angular/angular-devkit-build-webpack-builds",
+    "@angular-devkit/core": "angular/angular-devkit-core-builds",
+    "@angular-devkit/schematics": "angular/angular-devkit-schematics-builds",
+    "@angular-devkit/schematics-cli": "angular/angular-devkit-schematics-cli-builds",
+    "@ngtools/webpack": "angular/ngtools-webpack-builds",
+    "@schematics/angular": "angular/schematics-angular-builds",
+}

--- a/packages/angular/cli/package.json
+++ b/packages/angular/cli/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/angular/angular-cli",
   "dependencies": {
-    "@angular-devkit/architect": "0.0.0-PLACEHOLDER",
+    "@angular-devkit/architect": "0.0.0-EXPERIMENTAL-PLACEHOLDER",
     "@angular-devkit/core": "0.0.0-PLACEHOLDER",
     "@angular-devkit/schematics": "0.0.0-PLACEHOLDER",
     "@schematics/angular": "0.0.0-PLACEHOLDER",
@@ -52,9 +52,9 @@
     "migrations": "@schematics/angular/migrations/migration-collection.json",
     "packageGroup": {
       "@angular/cli": "0.0.0-PLACEHOLDER",
-      "@angular-devkit/architect": "0.0.0-PLACEHOLDER",
+      "@angular-devkit/architect": "0.0.0-EXPERIMENTAL-PLACEHOLDER",
       "@angular-devkit/build-angular": "0.0.0-PLACEHOLDER",
-      "@angular-devkit/build-webpack": "0.0.0-PLACEHOLDER",
+      "@angular-devkit/build-webpack": "0.0.0-EXPERIMENTAL-PLACEHOLDER",
       "@angular-devkit/core": "0.0.0-PLACEHOLDER",
       "@angular-devkit/schematics": "0.0.0-PLACEHOLDER"
     }

--- a/packages/angular_devkit/architect/package.json
+++ b/packages/angular_devkit/architect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@angular-devkit/architect",
-  "version": "0.0.0-PLACEHOLDER",
+  "version": "0.0.0-EXPERIMENTAL-PLACEHOLDER",
   "description": "Angular Build Facade",
   "experimental": true,
   "main": "src/index.js",

--- a/packages/angular_devkit/architect_cli/package.json
+++ b/packages/angular_devkit/architect_cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@angular-devkit/architect-cli",
-  "version": "0.0.0-PLACEHOLDER",
+  "version": "0.0.0-EXPERIMENTAL-PLACEHOLDER",
   "description": "Angular Architect CLI",
   "homepage": "https://github.com/angular/angular-cli",
   "experimental": true,
@@ -14,7 +14,7 @@
     "tooling"
   ],
   "dependencies": {
-    "@angular-devkit/architect": "0.0.0-PLACEHOLDER",
+    "@angular-devkit/architect": "0.0.0-EXPERIMENTAL-PLACEHOLDER",
     "@angular-devkit/core": "0.0.0-PLACEHOLDER",
     "ansi-colors": "4.1.1",
     "minimist": "1.2.5",

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -7,8 +7,8 @@
   "builders": "builders.json",
   "dependencies": {
     "@ampproject/remapping": "1.0.2",
-    "@angular-devkit/architect": "0.0.0-PLACEHOLDER",
-    "@angular-devkit/build-webpack": "0.0.0-PLACEHOLDER",
+    "@angular-devkit/architect": "0.0.0-EXPERIMENTAL-PLACEHOLDER",
+    "@angular-devkit/build-webpack": "0.0.0-EXPERIMENTAL-PLACEHOLDER",
     "@angular-devkit/core": "0.0.0-PLACEHOLDER",
     "@babel/core": "7.16.7",
     "@babel/generator": "7.16.8",

--- a/packages/angular_devkit/build_optimizer/package.json
+++ b/packages/angular_devkit/build_optimizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@angular-devkit/build-optimizer",
-  "version": "0.0.0-PLACEHOLDER",
+  "version": "0.0.0-EXPERIMENTAL-PLACEHOLDER",
   "description": "Angular Build Optimizer",
   "experimental": true,
   "main": "src/index.js",

--- a/packages/angular_devkit/build_webpack/package.json
+++ b/packages/angular_devkit/build_webpack/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@angular-devkit/build-webpack",
-  "version": "0.0.0-PLACEHOLDER",
+  "version": "0.0.0-EXPERIMENTAL-PLACEHOLDER",
   "description": "Webpack Builder for Architect",
   "experimental": true,
   "main": "src/index.js",
   "typings": "src/index.d.ts",
   "builders": "builders.json",
   "dependencies": {
-    "@angular-devkit/architect": "0.0.0-PLACEHOLDER",
+    "@angular-devkit/architect": "0.0.0-EXPERIMENTAL-PLACEHOLDER",
     "rxjs": "6.6.7"
   },
   "devDependencies": {

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -413,6 +413,11 @@ export default async function (
             }
           } else if ((obj[depName] as string).match(/\b0\.0\.0-PLACEHOLDER\b/)) {
             obj[depName] = (obj[depName] as string).replace(/\b0\.0\.0-PLACEHOLDER\b/, v);
+          } else if ((obj[depName] as string).match(/\b0\.0\.0-EXPERIMENTAL-PLACEHOLDER\b/)) {
+            obj[depName] = (obj[depName] as string).replace(
+              /\b0\.0\.0-EXPERIMENTAL-PLACEHOLDER\b/,
+              v,
+            );
           }
         }
       }

--- a/scripts/validate-licenses.ts
+++ b/scripts/validate-licenses.ts
@@ -81,7 +81,10 @@ const ignoredPackages = [
 
 // Ignore own packages (all MIT)
 for (const packageName of Object.keys(packages)) {
-  ignoredPackages.push(`${packageName}@0.0.0-PLACEHOLDER`);
+  const version = packages[packageName].experimental
+    ? '0.0.0-EXPERIMENTAL-PLACEHOLDER'
+    : '0.0.0-PLACEHOLDER';
+  ignoredPackages.push(`${packageName}@${version}`);
 }
 
 // Find all folders directly under a `node_modules` that have a package.json.

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -68,6 +68,7 @@ def pkg_npm(name, pkg_deps = [], use_prodmode_output = False, **kwargs):
     NPM_PACKAGE_SUBSTITUTIONS = {
         # Version of the local package being built, generated via the `--workspace_status_command` flag.
         "0.0.0-PLACEHOLDER": "{BUILD_SCM_VERSION}",
+        "0.0.0-EXPERIMENTAL-PLACEHOLDER": "{BUILD_SCM_EXPERIMENTAL_VERSION}",
         "0.0.0-ENGINES-NODE": RELEASE_ENGINES_NODE,
         "0.0.0-ENGINES-NPM": RELEASE_ENGINES_NPM,
         "0.0.0-ENGINES-YARN": RELEASE_ENGINES_YARN,
@@ -75,6 +76,7 @@ def pkg_npm(name, pkg_deps = [], use_prodmode_output = False, **kwargs):
 
     NO_STAMP_PACKAGE_SUBSTITUTIONS = dict(NPM_PACKAGE_SUBSTITUTIONS, **{
         "0.0.0-PLACEHOLDER": "0.0.0",
+        "0.0.0-EXPERIMENTAL-PLACEHOLDER": "0.0.0",
     })
 
     deps = kwargs.pop("deps", [])

--- a/tools/snapshot_repo_filter.bzl
+++ b/tools/snapshot_repo_filter.bzl
@@ -1,0 +1,19 @@
+# Copyright Google Inc. All Rights Reserved.
+#
+# Use of this source code is governed by an MIT-style license that can be
+# found in the LICENSE file at https://angular.io/license
+
+load("//:constants.bzl", "SNAPSHOT_REPOS")
+
+def _generate_snapshot_repo_filter():
+    filter = ""
+    for (i, pkg_name) in enumerate(SNAPSHOT_REPOS.keys()):
+        filter += "{sep}(..|objects|select(has(\"{pkg_name}\")))[\"{pkg_name}\"] |= \"github:{snapshot_repo}:BUILD_SCM_HASH-PLACEHOLDER\"\n".format(
+            sep = "| " if i > 0 else "",
+            pkg_name = pkg_name,
+            snapshot_repo = SNAPSHOT_REPOS[pkg_name],
+        )
+    return filter
+
+# jq filter that replaces package.json dependencies with snapshot repos
+SNAPSHOT_REPO_JQ_FILTER = _generate_snapshot_repo_filter()


### PR DESCRIPTION
@josephperrott @devversion  @gregmagolan

The first commit performs stamping for experimental packages which get a different version format (e.g., `0.1302.0-next.1` vs `13.2.0-next.1`). Basically any package with `"experimental": true` gets the alternative placeholder. If it becomes non-experimental then the version placeholder should also change. The two should be manually kept in sync.

The second commit performs substitutions for github snapshot repos in a snapshot build similar to the non-bazel snapshot build, so it stamps versions like `github:angular/angular-devkit-architect-builds:174fe1056a9ca4987c9176f5f2d18faf0e71c92b`.