### PR TITLE
docs: release notes for the v11.2.18 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,20 @@ Alan Agius, Derek Cormier, Doug Parker, Elio Goettelmann, Joey Perrott, Jordan P
 
 Doug Parker and iRealNirmal
 
+<a name="11.2.18"></a>
+
+# 11.2.18 (2022-01-12)
+
+### @angular-devkit/build-angular
+
+| Commit                                                                                              | Type | Description                                         |
+| --------------------------------------------------------------------------------------------------- | ---- | --------------------------------------------------- |
+| [534678450](https://github.com/angular/angular-cli/commit/534678450196a45610e88a85ee01317aa43dc788) | fix  | updated webpack-dev-server to latest security patch |
+
+## Special Thanks
+
+Doug Parker and iRealNirmal
+
 <a name="13.2.0-next.1"></a>
 
 # 13.2.0-next.1 (2021-12-15)


### PR DESCRIPTION
Inserted underneath today's releases so as not to imply that this LTS release is the latest-and-greatest Angular.