### PR TITLE
refactor(@angular-devkit/build-angular): exit early when there are no component style budgets

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/plugins/any-component-style-budget-checker.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/plugins/any-component-style-budget-checker.ts
@@ -37,6 +37,11 @@ export class AnyComponentStyleBudgetChecker {
           stage: Compilation.PROCESS_ASSETS_STAGE_ANALYSE,
         },
         () => {
+          // No budgets.
+          if (this.budgets.length === 0) {
+            return;
+          }
+
           // In AOT compilations component styles get processed in child compilations.
           if (!compilation.compiler.parentCompilation) {
             return;


### PR DESCRIPTION

With this change we exit the function early, when there are no budgets defined.