### PR TITLE
build: bump Angular peer deps to 13.2.0-next

### DIFF
--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -75,11 +75,11 @@
     "esbuild": "0.14.11"
   },
   "peerDependencies": {
-    "@angular/compiler-cli": "^13.0.0 || ^13.1.0-next",
-    "@angular/localize": "^13.0.0 || ^13.1.0-next",
-    "@angular/service-worker": "^13.0.0 || ^13.1.0-next",
+    "@angular/compiler-cli": "^13.0.0 || ^13.2.0-next",
+    "@angular/localize": "^13.0.0 || ^13.2.0-next",
+    "@angular/service-worker": "^13.0.0 || ^13.2.0-next",
     "karma": "^6.3.0",
-    "ng-packagr": "^13.0.0 || ^13.1.0-next",
+    "ng-packagr": "^13.0.0 || ^13.2.0-next",
     "protractor": "^7.0.0",
     "tailwindcss": "^2.0.0 || ^3.0.0",
     "typescript": ">=4.4.3 <4.6"

--- a/packages/ngtools/webpack/package.json
+++ b/packages/ngtools/webpack/package.json
@@ -22,7 +22,7 @@
   "homepage": "https://github.com/angular/angular-cli/tree/master/packages/@ngtools/webpack",
   "dependencies": {},
   "peerDependencies": {
-    "@angular/compiler-cli": "^13.0.0 || ^13.1.0-next",
+    "@angular/compiler-cli": "^13.0.0 || ^13.2.0-next",
     "typescript": ">=4.4.3 <4.6",
     "webpack": "^5.30.0"
   },


### PR DESCRIPTION
`next` releases are currently for 13.2.0, so this is necessary to avoid peer dep warnings.