### PR TITLE
fix(@angular-devkit/build-angular): load translations fresh start

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/i18n-options.ts
+++ b/packages/angular_devkit/build_angular/src/utils/i18n-options.ts
@@ -310,6 +310,7 @@ export function loadTranslations(
   usedFormats?: Set<string>,
   duplicateTranslation?: I18NTranslation,
 ) {
+  let translations: Record<string, unknown> | undefined = undefined;
   for (const file of desc.files) {
     const loadResult = loader(path.join(workspaceRoot, file.path));
 
@@ -331,10 +332,10 @@ export function loadTranslations(
     file.format = loadResult.format;
     file.integrity = loadResult.integrity;
 
-    if (desc.translation) {
+    if (translations) {
       // Merge translations
       for (const [id, message] of Object.entries(loadResult.translations)) {
-        if (desc.translation[id] !== undefined) {
+        if (translations[id] !== undefined) {
           const duplicateTranslationMessage = `[${file.path}]: Duplicate translations for message '${id}' when merging.`;
           switch (duplicateTranslation) {
             case I18NTranslation.Ignore:
@@ -348,11 +349,12 @@ export function loadTranslations(
               break;
           }
         }
-        desc.translation[id] = message;
+        translations[id] = message;
       }
     } else {
       // First or only translation file
-      desc.translation = loadResult.translations;
+      translations = loadResult.translations;
     }
   }
+  desc.translation = translations;
 }


### PR DESCRIPTION
Currently when making a change while serving a localized application, duplicate
translation warnings appear for every translation id. This fixes that by
replacing the whole translation object with a new one each time translations
are loaded.

fixes #22398

Minor version of https://github.com/angular/angular-cli/pull/22460