### PR TITLE
build: use bazel for snapshot builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -270,6 +270,7 @@ jobs:
     resource_class: medium
     steps:
       - custom_attach_workspace
+      - install_python
       - run:
           name: Decrypt Credentials
           # Note: when changing the image, you might have to re-encrypt the credentials with a

--- a/lib/packages.ts
+++ b/lib/packages.ts
@@ -152,14 +152,15 @@ const packageJsonPaths = [
   ..._findPrimaryPackageJsonFiles(path.join(__dirname, '..', 'packages'), excludeRe),
 ];
 
-function _exec(cmd: string) {
-  return execSync(cmd).toString().trim();
+function _exec(cmd: string, opts?: { cwd?: string }) {
+  return execSync(cmd, opts).toString().trim();
 }
 
 let gitShaCache: string;
 function _getSnapshotHash(_pkg: PackageInfo): string {
   if (!gitShaCache) {
-    gitShaCache = _exec('git log --format=%h -n1');
+    const opts = { cwd: __dirname }; // Ensure we call git from within this repo
+    gitShaCache = _exec('git log --format=%h -n1', opts);
   }
 
   return gitShaCache;

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@angular/compiler": "14.0.0-next.0",
     "@angular/compiler-cli": "14.0.0-next.0",
     "@angular/core": "14.0.0-next.0",
-    "@angular/dev-infra-private": "https://github.com/angular/dev-infra-private-builds.git#2024033f3123cd1beed78d43ec7269467cd9fa93",
+    "@angular/dev-infra-private": "https://github.com/angular/dev-infra-private-builds.git#3a34722a82fb0e8cd3fa00dfc5476767a35e021a",
     "@angular/forms": "14.0.0-next.0",
     "@angular/localize": "14.0.0-next.0",
     "@angular/material": "14.0.0-next.0",

--- a/packages/angular_devkit/build_angular/BUILD.bazel
+++ b/packages/angular_devkit/build_angular/BUILD.bazel
@@ -221,6 +221,7 @@ pkg_npm(
         "//packages/angular_devkit/architect:package.json",
         "//packages/angular_devkit/build_webpack:package.json",
         "//packages/angular_devkit/core:package.json",
+        "//packages/ngtools/webpack:package.json",
     ],
     deps = [
         ":README.md",

--- a/scripts/snapshots.ts
+++ b/scripts/snapshots.ts
@@ -12,7 +12,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { PackageInfo, packages } from '../lib/packages';
-import build from './build';
+import build from './build-bazel';
 import create from './create';
 
 // Added to the README.md of the snapshot. This is markdown.

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -70,7 +70,7 @@ def pkg_npm(name, pkg_deps = [], use_prodmode_output = False, **kwargs):
         # Version of the local package being built, generated via the `--workspace_status_command` flag.
         "0.0.0-PLACEHOLDER": "{BUILD_SCM_VERSION}",
         "0.0.0-EXPERIMENTAL-PLACEHOLDER": "{BUILD_SCM_EXPERIMENTAL_VERSION}",
-        "BUILD_SCM_HASH-PLACEHOLDER": "{BUILD_SCM_COMMIT_SHA}",
+        "BUILD_SCM_HASH-PLACEHOLDER": "{BUILD_SCM_ABBREV_HASH}",
         "0.0.0-ENGINES-NODE": RELEASE_ENGINES_NODE,
         "0.0.0-ENGINES-NPM": RELEASE_ENGINES_NPM,
         "0.0.0-ENGINES-YARN": RELEASE_ENGINES_YARN,

--- a/tools/snapshot_repo_filter.bzl
+++ b/tools/snapshot_repo_filter.bzl
@@ -8,7 +8,7 @@ load("//:constants.bzl", "SNAPSHOT_REPOS")
 def _generate_snapshot_repo_filter():
     filter = ""
     for (i, pkg_name) in enumerate(SNAPSHOT_REPOS.keys()):
-        filter += "{sep}(..|objects|select(has(\"{pkg_name}\")))[\"{pkg_name}\"] |= \"github:{snapshot_repo}:BUILD_SCM_HASH-PLACEHOLDER\"\n".format(
+        filter += "{sep}(..|objects|select(has(\"{pkg_name}\")))[\"{pkg_name}\"] |= \"github:{snapshot_repo}#BUILD_SCM_HASH-PLACEHOLDER\"\n".format(
             sep = "| " if i > 0 else "",
             pkg_name = pkg_name,
             snapshot_repo = SNAPSHOT_REPOS[pkg_name],

--- a/yarn.lock
+++ b/yarn.lock
@@ -51,10 +51,10 @@
     "@angular-devkit/core" "13.2.0"
     rxjs "6.6.7"
 
-"@angular-devkit/build-angular@^13.2.0-rc":
-  version "13.2.0"
-  resolved "https://registry.yarnpkg.com/@angular-devkit/build-angular/-/build-angular-13.2.0.tgz#5880890b5083a31f96d237ffee5f82af6fcc11a8"
-  integrity sha512-cHnm/P7uKJjKh2BCN8gnnd240J5z3IesQyRAx88kFSlL5sKCGyGoAYKAjU585/lllIXjtFXSR/S2d/cHg8ShKw==
+"@angular-devkit/build-angular@13.2.0-rc.1":
+  version "13.2.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@angular-devkit/build-angular/-/build-angular-13.2.0-rc.1.tgz#d07eeec25c00c9ed025aa599263d98ad22d39f4a"
+  integrity sha512-kKElUuHAocImUQmYnlkmk/8UJh8eYw7GqvcfSxIcxJ8euLS2hnavmUCexxtlPsgWmwJTdwXDnRYVCmr4n8hQqA==
   dependencies:
     "@ampproject/remapping" "1.1.1"
     "@angular-devkit/architect" "0.1302.0"
@@ -212,14 +212,13 @@
   dependencies:
     tslib "^2.0.0"
 
-"@angular/dev-infra-private@https://github.com/angular/dev-infra-private-builds.git#2024033f3123cd1beed78d43ec7269467cd9fa93":
-  version "0.0.0-354871956801929457d9f08482fb81f7012ed7c8"
-  uid "2024033f3123cd1beed78d43ec7269467cd9fa93"
-  resolved "https://github.com/angular/dev-infra-private-builds.git#2024033f3123cd1beed78d43ec7269467cd9fa93"
+"@angular/dev-infra-private@https://github.com/angular/dev-infra-private-builds.git#3a34722a82fb0e8cd3fa00dfc5476767a35e021a":
+  version "0.0.0-c922f5b23611024bc9d94833ae147f6048ab0275"
+  resolved "https://github.com/angular/dev-infra-private-builds.git#3a34722a82fb0e8cd3fa00dfc5476767a35e021a"
   dependencies:
     "@actions/core" "^1.4.0"
     "@actions/github" "^5.0.0"
-    "@angular-devkit/build-angular" "^13.2.0-rc"
+    "@angular-devkit/build-angular" "13.2.0-rc.1"
     "@angular/benchpress" "0.2.1"
     "@babel/core" "^7.16.0"
     "@bazel/bazelisk" "^1.10.1"


### PR DESCRIPTION
@gregmagolan @josephperrott 

Here are the snapshot repo diffs caused by flipping to the bazel build.
| Snapshot repo  | Diff |
| ------------- | ------------- |
| @angular/cli  | [diff](https://github.com/angular/cli-builds/compare/master...snapshot-test)  |
| @angular/pwa  | [diff](https://github.com/angular/angular-pwa-builds/compare/master...snapshot-test)  |
| @angular-devkit/architect | [diff](https://github.com/angular/angular-devkit-architect-builds/compare/master...snapshot-test)  |
| @angular-devkit/architect-cli | [diff](https://github.com/angular/angular-devkit-architect-cli-builds/compare/master...snapshot-test)  |
| @angular-devkit/build-angular | [diff](https://github.com/angular/angular-devkit-build-angular-builds/compare/master...snapshot-test)  |
| @angular-devkit/build-webpack | [diff](https://github.com/angular/angular-devkit-build-webpack-builds/compare/master...snapshot-test)  |
| @angular-devkit/core | [diff](https://github.com/angular/angular-devkit-core-builds/compare/master...snapshot-test)  |
| @angular-devkit/schematics | [diff](https://github.com/angular/angular-devkit-schematics-builds/compare/master...snapshot-test)  |
| @angular-devkit/schematics-cli | [diff](https://github.com/angular/angular-devkit-schematics-cli-builds/compare/master...snapshot-test)  |
| @ngtools/webpack | [diff](https://github.com/angular/ngtools-webpack-builds/compare/master...snapshot-test)  |
| @schematics/angular | [diff](https://github.com/angular/schematics-angular-builds/compare/master...snapshot-test)  |

Note that some changes in these diffs may be caused by new things pushed to `master` of the "build" repos.

[CI runs](https://app.circleci.com/pipelines/github/angular/angular-cli?branch=snapshot-test&filter=all) for the `snapshot-test` branch set up to test the ci. The build artifacts are published to the build repos under the same `snapshot-test` branch name.