### PR TITLE
fix(@angular-devkit/build-angular): add whatwg-url to downlevel exclusion list

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
@@ -383,7 +383,7 @@ export async function getCommonConfig(wco: WebpackConfigOptions): Promise<Config
           test: /\.[cm]?[tj]sx?$/,
           // The below is needed due to a bug in `@babel/runtime`. See: https://github.com/babel/babel/issues/12824
           resolve: { fullySpecified: false },
-          exclude: [/[/\\](?:core-js|@babel|tslib|web-animations-js|web-streams-polyfill)[/\\]/],
+          exclude: [/[/\\](?:core-js|@babel|tslib|web-animations-js|web-streams-polyfill|whatwg-url)[/\\]/],
           use: [
             {
               loader: require.resolve('../../babel/webpack-loader'),


### PR DESCRIPTION
Similar to https://github.com/angular/angular-cli/pull/21739, whatwg-url seems to suffer from the same issue as https://github.com/angular/angular-cli/issues/21735 . Pulling in whatwg-url results in the below error:

```
/home/val/Workspace/MongoDB/troubleshoot-mongoose/angular-tour-of-heroes/dist/angular-tour-of-heroes/server/main.js:57981
const AsyncIteratorPrototype = Object.getPrototypeOf(Object.getPrototypeOf( /*#__PURE__*/_wrapAsyncGenerator(function* () {})).prototype);
                                      ^

TypeError: Cannot convert undefined or null to object
    at Function.getPrototypeOf (<anonymous>)
    at Object.30363 (/home/val/Workspace/MongoDB/troubleshoot-mongoose/angular-tour-of-heroes/dist/angular-tour-of-heroes/server/main.js:57981:39)
    at __webpack_require__ (/home/val/Workspace/MongoDB/troubleshoot-mongoose/angular-tour-of-heroes/dist/angular-tour-of-heroes/server/main.js:264171:42)
    at Object.62950 (/home/val/Workspace/MongoDB/troubleshoot-mongoose/angular-tour-of-heroes/dist/angular-tour-of-heroes/server/main.js:55286:15)
    at __webpack_require__ (/home/val/Workspace/MongoDB/troubleshoot-mongoose/angular-tour-of-heroes/dist/angular-tour-of-heroes/server/main.js:264171:42)
    at Object.1509 (/home/val/Workspace/MongoDB/troubleshoot-mongoose/angular-tour-of-heroes/dist/angular-tour-of-heroes/server/main.js:58153:13)
    at __webpack_require__ (/home/val/Workspace/MongoDB/troubleshoot-mongoose/angular-tour-of-heroes/dist/angular-tour-of-heroes/server/main.js:264171:42)
    at Object.97775 (/home/val/Workspace/MongoDB/troubleshoot-mongoose/angular-tour-of-heroes/dist/angular-tour-of-heroes/server/main.js:54974:34)
    at __webpack_require__ (/home/val/Workspace/MongoDB/troubleshoot-mongoose/angular-tour-of-heroes/dist/angular-tour-of-heroes/server/main.js:264171:42)
    at Object.34843 (/home/val/Workspace/MongoDB/troubleshoot-mongoose/angular-tour-of-heroes/dist/angular-tour-of-heroes/server/main.js:54688:22)
```

Re: Automattic/mongoose#11155

If you `npm install whatwg-url@11`, you'll see the below code that breaks when Angular "downlevels" it. Not sure where this code comes from, it isn't in the whatwg-url repo.

```
const AsyncIteratorPrototype = Object.getPrototypeOf(Object.getPrototypeOf(async function* () {}).prototype);
```