### PR TITLE
build: add RC releases to framework peer deps

### DIFF
--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -75,11 +75,11 @@
     "esbuild": "0.14.13"
   },
   "peerDependencies": {
-    "@angular/compiler-cli": "^13.0.0 || ^13.2.0-next",
-    "@angular/localize": "^13.0.0 || ^13.2.0-next",
-    "@angular/service-worker": "^13.0.0 || ^13.2.0-next",
+    "@angular/compiler-cli": "^13.0.0 || ^13.2.0-next || ^13.2.0-rc",
+    "@angular/localize": "^13.0.0 || ^13.2.0-next || ^13.2.0-rc",
+    "@angular/service-worker": "^13.0.0 || ^13.2.0-next || ^13.2.0-rc",
     "karma": "^6.3.0",
-    "ng-packagr": "^13.0.0 || ^13.2.0-next",
+    "ng-packagr": "^13.0.0 || ^13.2.0-next || ^13.2.0-rc",
     "protractor": "^7.0.0",
     "tailwindcss": "^2.0.0 || ^3.0.0",
     "typescript": ">=4.4.3 <4.6"

--- a/packages/ngtools/webpack/package.json
+++ b/packages/ngtools/webpack/package.json
@@ -22,7 +22,7 @@
   "homepage": "https://github.com/angular/angular-cli/tree/master/packages/@ngtools/webpack",
   "dependencies": {},
   "peerDependencies": {
-    "@angular/compiler-cli": "^13.0.0 || ^13.2.0-next",
+    "@angular/compiler-cli": "^13.0.0 || ^13.2.0-next || ^13.2.0-rc",
     "typescript": ">=4.4.3 <4.6",
     "webpack": "^5.30.0"
   },


### PR DESCRIPTION
This will allow `13.2.0-rc` CLI packages like `@angular-devkit/build-angular` to depend on RC versions of FW packages like `@angular/compiler-cli`. As it stands, `next` releases are allowed, but `rc` aren't, which makes prerelease testing more difficult than it needs to be.

Related: https://github.com/angular/angular-cli/commit/4de2eb54f82c676b94f352f694ffa7268ce98d0d