### PR TITLE
refactor(@angular/cli): remove deprecated `--all` option from `ng update`

### DIFF
--- a/docs/specifications/update.md
+++ b/docs/specifications/update.md
@@ -14,7 +14,6 @@ You can specify more than one package. Each package follows the convention of `[
 
 | Flag             | Argument  | Description                                                                                                                                                                                 |
 | ---------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--all`          | `boolean` | If true, implies that all dependencies should be updated. Defaults is false, using dependencies from the command line instead.                                                              |
 | `--force`        | `boolean` | If true, skip the verification step and perform the update even if some peer dependencies would be invalidated. Peer dependencies errors will still be shown as warning. Defaults to false. |
 | `--next`         | `boolean` | If true, allows version discovery to include Beta and RC. Defaults to false.                                                                                                                |
 | `--migrate-only` | `boolean` | If true, don't change the `package.json` file, only apply migration scripts.                                                                                                                |

--- a/packages/angular/cli/commands/update-impl.ts
+++ b/packages/angular/cli/commands/update-impl.ts
@@ -297,21 +297,6 @@ export class UpdateCommand extends Command<UpdateCommandSchema> {
       }
     };
 
-    if (options.all) {
-      const updateCmd =
-        this.packageManager === PackageManager.Yarn
-          ? `'yarn upgrade-interactive' or 'yarn upgrade'`
-          : `'${this.packageManager} update'`;
-
-      this.logger.warn(`
-        '--all' functionality has been removed as updating multiple packages at once is not recommended.
-        To update packages which don’t provide 'ng update' capabilities in your workspace 'package.json' use ${updateCmd} instead.
-        Run the package manager update command after updating packages which provide 'ng update' capabilities.
-      `);
-
-      return 0;
-    }
-
     const packages: PackageIdentifier[] = [];
     for (const request of options['--'] || []) {
       try {

--- a/packages/angular/cli/commands/update.json
+++ b/packages/angular/cli/commands/update.json
@@ -32,12 +32,6 @@
           "default": false,
           "type": "boolean"
         },
-        "all": {
-          "description": "Whether to update all packages in package.json.",
-          "default": false,
-          "type": "boolean",
-          "x-deprecated": true
-        },
         "next": {
           "description": "Use the prerelease version, including beta and RCs.",
           "default": false,

--- a/packages/angular/cli/src/commands/update/schematic/index.ts
+++ b/packages/angular/cli/src/commands/update/schematic/index.ts
@@ -852,9 +852,7 @@ export default function (options: UpdateSchema): Rule {
     const npmPackageJsonMap = allPackageMetadata.reduce((acc, npmPackageJson) => {
       // If the package was not found on the registry. It could be private, so we will just
       // ignore. If the package was part of the list, we will error out, but will simply ignore
-      // if it's either not requested (so just part of package.json. silently) or if it's a
-      // `--all` situation. There is an edge case here where a public package peer depends on a
-      // private one, but it's rare enough.
+      // if it's either not requested (so just part of package.json. silently).
       if (!npmPackageJson.name) {
         if (npmPackageJson.requestedName && packages.has(npmPackageJson.requestedName)) {
           throw new SchematicsException(


### PR DESCRIPTION
BREAKING CHANGE:

`--all` option from `ng update` has been removed without replacement. To update packages which don’t provide `ng  update` capabilities in your workspace `package.json` use `npm update`, `yarn upgrade-interactive` or `yarn upgrade` instead.