### PR TITLE
refactor(@ngtools/webpack) remove deprecated ivy namespace

### DIFF
--- a/goldens/public-api/ngtools/webpack/src/index.md
+++ b/goldens/public-api/ngtools/webpack/src/index.md
@@ -46,18 +46,6 @@ export interface AngularWebpackPluginOptions {
     tsconfig: string;
 }
 
-// @public @deprecated (undocumented)
-export namespace ivy {
-    const // (undocumented)
-    AngularWebpackLoaderPath: string;
-    const // (undocumented)
-    AngularWebpackPlugin: typeof ivyInternal.AngularWebpackPlugin;
-    // (undocumented)
-    export type AngularPluginOptions = ivyInternal.AngularWebpackPluginOptions;
-    // (undocumented)
-    export type AngularWebpackPlugin = ivyInternal.AngularWebpackPlugin;
-}
-
 // (No @packageDocumentation comment for this package)
 
 ```

--- a/packages/ngtools/webpack/src/index.ts
+++ b/packages/ngtools/webpack/src/index.ts
@@ -6,22 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import * as ivyInternal from './ivy';
-
 export {
   AngularWebpackLoaderPath,
   AngularWebpackPlugin,
   AngularWebpackPluginOptions,
   default,
 } from './ivy';
-
-/** @deprecated Deprecated as of v12, please use the direct exports
- * (`AngularWebpackPlugin` instead of `ivy.AngularWebpackPlugin`)
- */
-// eslint-disable-next-line @typescript-eslint/no-namespace
-export namespace ivy {
-  export const AngularWebpackLoaderPath = ivyInternal.AngularWebpackLoaderPath;
-  export const AngularWebpackPlugin = ivyInternal.AngularWebpackPlugin;
-  export type AngularWebpackPlugin = ivyInternal.AngularWebpackPlugin;
-  export type AngularPluginOptions = ivyInternal.AngularWebpackPluginOptions;
-}


### PR DESCRIPTION
BREAKING CHANGE:

`ivy` namespace has been removed from the public API.

- `ivy.AngularWebpackPlugin` -> `AngularWebpackPlugin`
- `ivy.AngularPluginOptions` -> `AngularPluginOptions`