### PR TITLE
Bump version to "v13.2.0" with changelog.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,19 @@
-<a name="13.2.0-rc.1"></a>
+<a name="13.2.0"></a>
 
-# 13.2.0-rc.1 (2022-01-24)
+# 13.2.0 (2022-01-26)
 
 ### @angular-devkit/architect
 
 | Commit                                                                                              | Type | Description                   |
 | --------------------------------------------------------------------------------------------------- | ---- | ----------------------------- |
 | [f2c6b2b7e](https://github.com/angular/angular-cli/commit/f2c6b2b7ec88a1b7e45884b38faa0978af1b4b74) | fix  | correctly handle ESM builders |
+
+### @angular-devkit/build-angular
+
+| Commit                                                                                              | Type | Description                                                           |
+| --------------------------------------------------------------------------------------------------- | ---- | --------------------------------------------------------------------- |
+| [cbe028e37](https://github.com/angular/angular-cli/commit/cbe028e37c8af6f2e17cbbeddc968c9410151bbb) | feat | expose i18nDuplicateTranslation option of browser and server builders |
+| [509322b62](https://github.com/angular/angular-cli/commit/509322b6214b3425bd209087ac99ee9b14edeaba) | fix  | Don't use TAILWIND_MODE=watch                                         |
 
 ### @angular-devkit/build-webpack
 
@@ -16,25 +23,7 @@
 
 ## Special Thanks
 
-Alan Agius, Derek Cormier and Doug Parker
-
-<!-- CHANGELOG SPLIT MARKER -->
-
-<a name="13.2.0-rc.0"></a>
-
-# 13.2.0-rc.0 (2022-01-19)
-
-### @angular-devkit/build-angular
-
-| Commit                                                                                              | Type | Description                                           |
-| --------------------------------------------------------------------------------------------------- | ---- | ----------------------------------------------------- |
-| [a0784bd8c](https://github.com/angular/angular-cli/commit/a0784bd8cb64bd719ed499f97603522fbc9db02d) | fix  | disable parsing `new URL` syntax                      |
-| [acf7532bd](https://github.com/angular/angular-cli/commit/acf7532bd7f39274bc641d8161bdfe7b3be3750b) | fix  | load translations fresh start                         |
-| [b5c4a2344](https://github.com/angular/angular-cli/commit/b5c4a234465729f2f763c9601a0c5ff577e5a90d) | fix  | support ESNext as target for JavaScript optimizations |
-
-## Special Thanks
-
-Alan Agius, Bill Barry, Doug Parker and Joey Perrott
+Alan Agius, Cédric Exbrayat, Derek Cormier, Doug Parker, Joey Perrott, Jordan Pittman, grant-wilson and minijus
 
 <!-- CHANGELOG SPLIT MARKER -->
 
@@ -88,42 +77,6 @@ Alan Agius, Derek Cormier and Doug Parker
 ## Special Thanks
 
 Alan Agius, Bill Barry, Derek Cormier, Elio Goettelmann, Joey Perrott, Kasper Christensen, Lukas Spirig and Zoltan Lehoczky
-
-<!-- CHANGELOG SPLIT MARKER -->
-
-<a name="13.2.0-next.2"></a>
-
-# 13.2.0-next.2 (2022-01-12)
-
-### @angular/cli
-
-| Commit                                                                                              | Type | Description                                                               |
-| --------------------------------------------------------------------------------------------------- | ---- | ------------------------------------------------------------------------- |
-| [b7e292374](https://github.com/angular/angular-cli/commit/b7e29237437dcfaa9a745824a15360812f1ade3c) | fix  | remove extra space in `Unable to find compatible package` during `ng add` |
-
-### @schematics/angular
-
-| Commit                                                                                              | Type | Description                                                      |
-| --------------------------------------------------------------------------------------------------- | ---- | ---------------------------------------------------------------- |
-| [aadfc7915](https://github.com/angular/angular-cli/commit/aadfc791524ff2bf6d040f288e7a2cca8f49b9cc) | fix  | set `skipTest` flag for resolvers when using ng new --skip-tests |
-
-### @angular-devkit/build-angular
-
-| Commit                                                                                              | Type | Description                                                           |
-| --------------------------------------------------------------------------------------------------- | ---- | --------------------------------------------------------------------- |
-| [cbe028e37](https://github.com/angular/angular-cli/commit/cbe028e37c8af6f2e17cbbeddc968c9410151bbb) | feat | expose i18nDuplicateTranslation option of browser and server builders |
-| [6d2087b8f](https://github.com/angular/angular-cli/commit/6d2087b8f8332d742bc1140b7c4e490f5cc57d08) | fix  | automatically purge stale build cache entries                         |
-| [a5e375ca9](https://github.com/angular/angular-cli/commit/a5e375ca93a93dd887d7fde34686ec9019619981) | fix  | correctly resolve `core-js/proposals/reflect-metadata`                |
-| [509322b62](https://github.com/angular/angular-cli/commit/509322b6214b3425bd209087ac99ee9b14edeaba) | fix  | Don't use TAILWIND_MODE=watch                                         |
-| [9a9af2040](https://github.com/angular/angular-cli/commit/9a9af20400a4be53f6c62187401cc9bf2fadc57e) | fix  | enable `:where` CSS pseudo-class                                      |
-| [426ddb68d](https://github.com/angular/angular-cli/commit/426ddb68d9a21b036d6151e6cdee625e58ca1194) | fix  | ensure `$localize` calls are replaced in watch mode                   |
-| [0d68ed547](https://github.com/angular/angular-cli/commit/0d68ed547362e6bad0a9c5ca5209b65ed125bbd8) | fix  | localized bundle generation fails in watch mode                       |
-| [11f817ada](https://github.com/angular/angular-cli/commit/11f817adae4f06d8b80a9d74534468f6e3c2d2c5) | fix  | use `contenthash` instead of `chunkhash` for chunks                   |
-| [50167a36b](https://github.com/angular/angular-cli/commit/50167a36b0f9803ebcedafa9abbd9ecc5bc19a40) | fix  | websocket client only injected if required                            |
-
-## Special Thanks
-
-Alan Agius, Derek Cormier, Doug Parker, Elio Goettelmann, Joey Perrott, Jordan Pittman, Kasper Christensen, Lukas Spirig, Zoltan Lehoczky and minijus
 
 <!-- CHANGELOG SPLIT MARKER -->
 
@@ -280,16 +233,6 @@ Alan Agius, Charles Lyding, Doug Parker and Joey Perrott
 ## Special Thanks
 
 Alan Agius, Cédric Exbrayat and Derek Cormier
-
-<!-- CHANGELOG SPLIT MARKER -->
-
-<a name="13.2.0-next.0"></a>
-
-# 13.2.0-next.0 (2021-12-09)
-
-## Special Thanks
-
-Joey Perrott
 
 <!-- CHANGELOG SPLIT MARKER -->
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@angular/devkit-repo",
-  "version": "13.2.0-rc.1",
+  "version": "13.2.0",
   "private": true,
   "description": "Software Development Kit for Angular",
   "bin": {

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -75,11 +75,11 @@
     "esbuild": "0.14.14"
   },
   "peerDependencies": {
-    "@angular/compiler-cli": "^13.0.0 || ^13.2.0-next || ^13.2.0-rc",
-    "@angular/localize": "^13.0.0 || ^13.2.0-next || ^13.2.0-rc",
-    "@angular/service-worker": "^13.0.0 || ^13.2.0-next || ^13.2.0-rc",
+    "@angular/compiler-cli": "^13.0.0",
+    "@angular/localize": "^13.0.0",
+    "@angular/service-worker": "^13.0.0",
     "karma": "^6.3.0",
-    "ng-packagr": "^13.0.0 || ^13.2.0-next || ^13.2.0-rc",
+    "ng-packagr": "^13.0.0",
     "protractor": "^7.0.0",
     "tailwindcss": "^2.0.0 || ^3.0.0",
     "typescript": ">=4.4.3 <4.6"

--- a/packages/ngtools/webpack/package.json
+++ b/packages/ngtools/webpack/package.json
@@ -22,7 +22,7 @@
   "homepage": "https://github.com/angular/angular-cli/tree/master/packages/@ngtools/webpack",
   "dependencies": {},
   "peerDependencies": {
-    "@angular/compiler-cli": "^13.0.0 || ^13.2.0-next || ^13.2.0-rc",
+    "@angular/compiler-cli": "^13.0.0",
     "typescript": ">=4.4.3 <4.6",
     "webpack": "^5.30.0"
   },

--- a/packages/schematics/angular/utility/latest-versions.ts
+++ b/packages/schematics/angular/utility/latest-versions.ts
@@ -15,7 +15,7 @@ export const latestVersions: Record<string, string> & {
   ...require('./latest-versions/package.json')['dependencies'],
 
   // As Angular CLI works with same minor versions of Angular Framework, a tilde match for the current
-  Angular: '~13.2.0-rc.0',
+  Angular: '~13.2.0',
 
   // Since @angular-devkit/build-angular and @schematics/angular are always
   // published together from the same monorepo, and they are both


### PR DESCRIPTION
NOTE: This is a non-standard release since it is a minor. This PR includes manual edits to `latest-versions.ts` and peer deps on the framework to drop prerelease tags and bump the versions to `13.2.0` where appropriate.