### PR TITLE
refactor(@angular-devkit/schematics): remove deprecated `analytics` property

### DIFF
--- a/goldens/public-api/angular_devkit/schematics/src/index.md
+++ b/goldens/public-api/angular_devkit/schematics/src/index.md
@@ -6,7 +6,6 @@
 
 /// <reference types="node" />
 
-import { analytics } from '@angular-devkit/core';
 import { BaseException } from '@angular-devkit/core';
 import { logging } from '@angular-devkit/core';
 import { Observable } from 'rxjs';
@@ -929,8 +928,6 @@ export const TreeSymbol: symbol;
 export interface TypedSchematicContext<CollectionMetadataT extends object, SchematicMetadataT extends object> {
     // (undocumented)
     addTask<T>(task: TaskConfigurationGenerator<T>, dependencies?: Array<TaskId>): TaskId;
-    // @deprecated (undocumented)
-    readonly analytics?: analytics.Analytics;
     // (undocumented)
     readonly debug: boolean;
     // (undocumented)

--- a/goldens/public-api/angular_devkit/schematics/testing/index.md
+++ b/goldens/public-api/angular_devkit/schematics/testing/index.md
@@ -6,7 +6,6 @@
 
 /// <reference types="node" />
 
-import { analytics } from '@angular-devkit/core';
 import { logging } from '@angular-devkit/core';
 import { Observable } from 'rxjs';
 import { Path } from '@angular-devkit/core';

--- a/goldens/public-api/angular_devkit/schematics/tools/index.md
+++ b/goldens/public-api/angular_devkit/schematics/tools/index.md
@@ -6,7 +6,6 @@
 
 /// <reference types="node" />
 
-import { analytics } from '@angular-devkit/core';
 import { BaseException } from '@angular-devkit/core';
 import { JsonObject } from '@angular-devkit/core';
 import { logging } from '@angular-devkit/core';

--- a/packages/angular_devkit/schematics/src/engine/interface.ts
+++ b/packages/angular_devkit/schematics/src/engine/interface.ts
@@ -65,7 +65,7 @@ export type CollectionDescription<CollectionMetadataT extends object> = Collecti
  */
 export type SchematicDescription<
   CollectionMetadataT extends object,
-  SchematicMetadataT extends object
+  SchematicMetadataT extends object,
 > = SchematicMetadataT & {
   readonly collection: CollectionDescription<CollectionMetadataT>;
   readonly name: string;
@@ -187,7 +187,7 @@ export interface Schematic<CollectionMetadataT extends object, SchematicMetadata
  */
 export interface TypedSchematicContext<
   CollectionMetadataT extends object,
-  SchematicMetadataT extends object
+  SchematicMetadataT extends object,
 > {
   readonly debug: boolean;
   readonly engine: Engine<CollectionMetadataT, SchematicMetadataT>;
@@ -196,10 +196,6 @@ export interface TypedSchematicContext<
   readonly strategy: MergeStrategy;
   readonly interactive: boolean;
   addTask<T>(task: TaskConfigurationGenerator<T>, dependencies?: Array<TaskId>): TaskId;
-
-  // This might be undefined if the feature is unsupported.
-  /** @deprecated since version 11 - as it's unused. */
-  readonly analytics?: analytics.Analytics;
 }
 
 /**


### PR DESCRIPTION


BREAKING CHANGE:

Deprecated `analytics` property has been removed from `TypedSchematicContext` interface