### PR TITLE
fix(@angular-devkit/build-angular): invalid browsers version ranges

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/styles.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/styles.ts
@@ -494,10 +494,11 @@ function transformSupportedBrowsersToTargets(supportedBrowsers: string[]): strin
     // browserslist uses the name `ios_saf` for iOS Safari whereas esbuild uses `ios`
     if (browserName === 'ios_saf') {
       browserName = 'ios';
-      // browserslist also uses ranges for iOS Safari versions but only the lowest is required
-      // to perform minimum supported feature checks. esbuild also expects a single version.
-      [version] = version.split('-');
     }
+
+    // browserslist uses ranges `15.2-15.3` versions but only the lowest is required
+    // to perform minimum supported feature checks. esbuild also expects a single version.
+    [version] = version.split('-');
 
     if (browserName === 'ie') {
       transformed.push('edge12');


### PR DESCRIPTION
This change addresses the `Invalid version: "15.2-15.3"` range error. We previously only handled version ranges for `ios_safari`. Now, we handle such versions for all browsers.

Closes #22606