### PR TITLE
perf(@angular-devkit/build-angular): update `license-webpack-plugin` to `4.0.1`

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
     "less": "4.1.2",
     "less-loader": "10.2.0",
     "license-checker": "^25.0.0",
-    "license-webpack-plugin": "4.0.0",
+    "license-webpack-plugin": "4.0.1",
     "loader-utils": "3.2.0",
     "magic-string": "0.25.7",
     "mini-css-extract-plugin": "2.5.3",

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -39,7 +39,7 @@
     "karma-source-map-support": "1.4.0",
     "less": "4.1.2",
     "less-loader": "10.2.0",
-    "license-webpack-plugin": "4.0.0",
+    "license-webpack-plugin": "4.0.1",
     "loader-utils": "3.2.0",
     "mini-css-extract-plugin": "2.5.3",
     "minimatch": "3.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -205,7 +205,6 @@
 
 "@angular/dev-infra-private@https://github.com/angular/dev-infra-private-builds.git#2024033f3123cd1beed78d43ec7269467cd9fa93":
   version "0.0.0-354871956801929457d9f08482fb81f7012ed7c8"
-  uid "2024033f3123cd1beed78d43ec7269467cd9fa93"
   resolved "https://github.com/angular/dev-infra-private-builds.git#2024033f3123cd1beed78d43ec7269467cd9fa93"
   dependencies:
     "@actions/core" "^1.4.0"
@@ -7127,6 +7126,13 @@ license-webpack-plugin@4.0.0:
   dependencies:
     webpack-sources "^3.0.0"
 
+license-webpack-plugin@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/license-webpack-plugin/-/license-webpack-plugin-4.0.1.tgz#957930fa595f5b65aa0b21bfd2c19644486f3d9f"
+  integrity sha512-SQum9mg3BgnY5BK+2KYl4W7pk9b26Q8tW2lTsO6tidD0/Ds9ksdXvp3ip2s9LqDjj5gtBMyWRfOPZptWj4PfCg==
+  dependencies:
+    webpack-sources "^3.0.0"
+
 lie@~3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/lie/-/lie-3.3.0.tgz#dcf82dee545f46074daf200c7c1c5a08e0f40f6a"
@@ -9628,7 +9634,6 @@ sass@1.49.0, sass@^1.32.8:
 
 "sauce-connect-proxy@https://saucelabs.com/downloads/sc-4.6.4-linux.tar.gz":
   version "0.0.0"
-  uid "992e2cb0d91e54b27a4f5bbd2049f3b774718115"
   resolved "https://saucelabs.com/downloads/sc-4.6.4-linux.tar.gz#992e2cb0d91e54b27a4f5bbd2049f3b774718115"
 
 saucelabs@^1.5.0:


### PR DESCRIPTION

Changes that improve performance:
- use resolve data already present in most modules
- use throwIfNoEntry option on filesystem operations to improve performance