### PR TITLE
fix(@angular-devkit/build-angular): add `whatwg-url` to downlevel exclusion list

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
@@ -374,7 +374,9 @@ export async function getCommonConfig(wco: WebpackConfigOptions): Promise<Config
           test: /\.[cm]?[tj]sx?$/,
           // The below is needed due to a bug in `@babel/runtime`. See: https://github.com/babel/babel/issues/12824
           resolve: { fullySpecified: false },
-          exclude: [/[/\\](?:core-js|@babel|tslib|web-animations-js|web-streams-polyfill)[/\\]/],
+          exclude: [
+            /[/\\](?:core-js|@babel|tslib|web-animations-js|web-streams-polyfill|whatwg-url)[/\\]/,
+          ],
           use: [
             {
               loader: require.resolve('../../babel/webpack-loader'),


### PR DESCRIPTION


Similar to https://github.com/angular/angular-cli/pull/21739, `whatwg-url` seems to suffer from the same issue as https://github.com/angular/angular-cli/issues/21735

```ts
const AsyncIteratorPrototype = Object.getPrototypeOf(Object.getPrototypeOf(async function* () {}).prototype);
```