### PR TITLE
Use PNPM as package manager when `pnpm-lock.yaml` exists

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ Before you submit an issue, please search the issue tracker, maybe an issue for 
 We want to fix all the issues as soon as possible, but before fixing a bug we need to reproduce and confirm it. Having a reproducible scenario gives us wealth of important information without going back & forth to you with additional questions like:
 
 - version of Angular CLI used
-- `.angular-cli.json` or `angular.json` configuration
+- `angular.json` configuration
 - version of Angular DevKit used
 - 3rd-party libraries and their versions
 - and most importantly - a use-case that fails

--- a/packages/angular/cli/commands/config-impl.ts
+++ b/packages/angular/cli/commands/config-impl.ts
@@ -6,11 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { JsonValue, tags } from '@angular-devkit/core';
+import { JsonValue } from '@angular-devkit/core';
 import { v4 as uuidV4 } from 'uuid';
 import { Command } from '../models/command';
 import { Arguments, CommandScope } from '../models/interface';
-import { getWorkspaceRaw, migrateLegacyGlobalConfig, validateWorkspace } from '../utilities/config';
+import { getWorkspaceRaw, validateWorkspace } from '../utilities/config';
 import { JSONFile, parseJson } from '../utilities/json-file';
 import { Schema as ConfigCommandSchema } from './config';
 
@@ -103,18 +103,7 @@ export class ConfigCommand extends Command<ConfigCommandSchema> {
       await this.validateScope(CommandScope.InProject);
     }
 
-    let [config] = getWorkspaceRaw(level);
-
-    if (options.global && !config) {
-      try {
-        if (migrateLegacyGlobalConfig()) {
-          config = getWorkspaceRaw(level)[0];
-          this.logger.info(tags.oneLine`
-            We found a global configuration that was used in Angular CLI 1.
-            It has been automatically migrated.`);
-        }
-      } catch {}
-    }
+    const [config] = getWorkspaceRaw(level);
 
     if (options.value == undefined) {
       if (!config) {

--- a/packages/angular/cli/models/architect-command.ts
+++ b/packages/angular/cli/models/architect-command.ts
@@ -261,20 +261,9 @@ export abstract class ArchitectCommand<
     }
 
     const packageManager = await getPackageManager(basePath);
-    let installSuggestion = 'Try installing with ';
-    switch (packageManager) {
-      case 'npm':
-        installSuggestion += `'npm install'`;
-        break;
-      case 'yarn':
-        installSuggestion += `'yarn'`;
-        break;
-      default:
-        installSuggestion += `the project's package manager`;
-        break;
-    }
-
-    this.logger.warn(`Node packages may not be installed. ${installSuggestion}.`);
+    this.logger.warn(
+      `Node packages may not be installed. Try installing with '${packageManager} install'.`,
+    );
   }
 
   async run(options: ArchitectCommandOptions & Arguments) {

--- a/packages/angular/cli/utilities/project.ts
+++ b/packages/angular/cli/utilities/project.ts
@@ -13,12 +13,7 @@ import * as path from 'path';
 import { findUp } from './find-up';
 
 export function findWorkspaceFile(currentDirectory = process.cwd()): string | null {
-  const possibleConfigFiles = [
-    'angular.json',
-    '.angular.json',
-    'angular-cli.json',
-    '.angular-cli.json',
-  ];
+  const possibleConfigFiles = ['angular.json', '.angular.json'];
   const configFilePath = findUp(possibleConfigFiles, currentDirectory);
   if (configFilePath === null) {
     return null;

--- a/packages/angular_devkit/build_angular/test/hello-world-app/src/environments/environment.ts
+++ b/packages/angular_devkit/build_angular/test/hello-world-app/src/environments/environment.ts
@@ -9,7 +9,7 @@
 // The file contents for the current environment will overwrite these during build.
 // The build system defaults to the dev environment which uses `environment.ts`, but if you do
 // `ng build --env=prod` then `environment.prod.ts` will be used instead.
-// The list of which env maps to which file can be found in `.angular-cli.json`.
+// The list of which env maps to which file can be found in `angular.json`.
 
 export const environment = {
   production: false,

--- a/scripts/templates/contributing.ejs
+++ b/scripts/templates/contributing.ejs
@@ -60,7 +60,7 @@ Before you submit an issue, please search the issue tracker, maybe an issue for 
 We want to fix all the issues as soon as possible, but before fixing a bug we need to reproduce and confirm it. Having a reproducible scenario gives us wealth of important information without going back & forth to you with additional questions like:
 
 - version of Angular CLI used
-- `.angular-cli.json` or `angular.json` configuration
+- `angular.json` configuration
 - version of Angular DevKit used
 - 3rd-party libraries and their versions
 - and most importantly - a use-case that fails


### PR DESCRIPTION
**refactor(@angular/cli): remove support for legacy Angular CLI version 1 configurations**
Remove references to legacy Angular CLI version 1 configurations. By now users should have been migrated to use the new configuration.

**feat(@angular/cli): use PNPM as package manager when pnpm-lock.yaml exists**
While supported, we didn't automatically try to determine if PNPM was used through the lock files like we do for other package managers.