### PR TITLE
ci: group all scorecard action dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -71,6 +71,12 @@
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch"
+    },
+    {
+      "matchPaths": [".github/workflows/scorecard.yml"],
+      "matchPackagePatterns": ["*"],
+      "groupName": "scorecard action dependencies",
+      "groupSlug": "scorecard-action"
     }
   ]
 }


### PR DESCRIPTION
With this change we group all the scorecard action dependencies so that Renovate opens a single PR.