### PR TITLE
build: fix bazel build on windows

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -26,6 +26,10 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_pkg/releases/download/0.5.1/rules_pkg-0.5.1.tar.gz"],
 )
 
+load("@bazel_tools//tools/sh:sh_configure.bzl", "sh_configure")
+
+sh_configure()
+
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
 bazel_skylib_workspace()


### PR DESCRIPTION
Add a missing toolchain that was causing the nodejs_binary target for ng_cli_schema to fail on windows. I encountered this while trying to flip the ci to build with bazel.

Caused this error: https://app.circleci.com/pipelines/github/angular/angular-cli/20529/workflows/7f1860fe-0296-49d0-8466-6b23d9347ff8/jobs/287310?invite=true#step-112-31