### PR TITLE
fix(@angular-devkit/build-angular): update license-webpack-plugin to 4.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
     "less": "4.1.2",
     "less-loader": "10.2.0",
     "license-checker": "^25.0.0",
-    "license-webpack-plugin": "4.0.1",
+    "license-webpack-plugin": "4.0.2",
     "loader-utils": "3.2.0",
     "magic-string": "0.25.7",
     "mini-css-extract-plugin": "2.5.3",

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -38,7 +38,7 @@
     "karma-source-map-support": "1.4.0",
     "less": "4.1.2",
     "less-loader": "10.2.0",
-    "license-webpack-plugin": "4.0.1",
+    "license-webpack-plugin": "4.0.2",
     "loader-utils": "3.2.0",
     "mini-css-extract-plugin": "2.5.3",
     "minimatch": "3.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -219,7 +219,6 @@
 
 "@angular/dev-infra-private@https://github.com/angular/dev-infra-private-builds.git#bc95d30fc481710a0634188e5a47ab08246cd966":
   version "0.0.0-2c23378f310c42b482d246886ed2aab1550dc650"
-  uid bc95d30fc481710a0634188e5a47ab08246cd966
   resolved "https://github.com/angular/dev-infra-private-builds.git#bc95d30fc481710a0634188e5a47ab08246cd966"
   dependencies:
     "@actions/core" "^1.4.0"
@@ -7399,6 +7398,13 @@ license-webpack-plugin@4.0.1:
   dependencies:
     webpack-sources "^3.0.0"
 
+license-webpack-plugin@4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/license-webpack-plugin/-/license-webpack-plugin-4.0.2.tgz#1e18442ed20b754b82f1adeff42249b81d11aec6"
+  integrity sha512-771TFWFD70G1wLTC4oU2Cw4qvtmNrIw+wRvBtn+okgHl7slJVi7zfNcdmqDL72BojM30VNJ2UHylr1o77U37Jw==
+  dependencies:
+    webpack-sources "^3.0.0"
+
 lie@~3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/lie/-/lie-3.3.0.tgz#dcf82dee545f46074daf200c7c1c5a08e0f40f6a"
@@ -9970,7 +9976,6 @@ sass@1.49.7, sass@^1.49.0:
 
 "sauce-connect-proxy@https://saucelabs.com/downloads/sc-4.6.4-linux.tar.gz":
   version "0.0.0"
-  uid "992e2cb0d91e54b27a4f5bbd2049f3b774718115"
   resolved "https://saucelabs.com/downloads/sc-4.6.4-linux.tar.gz#992e2cb0d91e54b27a4f5bbd2049f3b774718115"
 
 saucelabs@^1.5.0:


### PR DESCRIPTION
Fixes builds with extractLicenses enabled when using dynamic exports

Fixes #22662