### PR TITLE
refactor(@angular/cli): remove deprecated command aliases for `extract-i18n`.

### DIFF
--- a/packages/angular/cli/commands/extract-i18n-impl.ts
+++ b/packages/angular/cli/commands/extract-i18n-impl.ts
@@ -24,14 +24,6 @@ export class ExtractI18nCommand extends ArchitectCommand<ExtractI18nCommandSchem
       return 1;
     }
 
-    const commandName = process.argv[2];
-    if (['xi18n', 'i18n-extract'].includes(commandName)) {
-      this.logger.warn(
-        `Warning: "ng ${commandName}" has been deprecated and will be removed in a future major version. ` +
-          'Please use "ng extract-i18n" instead.',
-      );
-    }
-
     return this.runArchitectTarget(options);
   }
 }

--- a/packages/angular/cli/commands/extract-i18n-impl.ts
+++ b/packages/angular/cli/commands/extract-i18n-impl.ts
@@ -14,16 +14,6 @@ export class ExtractI18nCommand extends ArchitectCommand<ExtractI18nCommandSchem
   public override readonly target = 'extract-i18n';
 
   public override async run(options: ExtractI18nCommandSchema & Arguments) {
-    const version = process.version.substr(1).split('.');
-    if (Number(version[0]) === 12 && Number(version[1]) === 0) {
-      this.logger.error(
-        'Due to a defect in Node.js 12.0, the command is not supported on this Node.js version. ' +
-          'Please upgrade to Node.js 12.1 or later.',
-      );
-
-      return 1;
-    }
-
     return this.runArchitectTarget(options);
   }
 }

--- a/packages/angular/cli/commands/extract-i18n.json
+++ b/packages/angular/cli/commands/extract-i18n.json
@@ -3,8 +3,6 @@
   "$id": "ng-cli://commands/extract-i18n.json",
   "description": "Extracts i18n messages from source code.",
   "$longDescription": "",
-
-  "$aliases": ["i18n-extract", "xi18n"],
   "$scope": "in",
   "$type": "architect",
   "$impl": "./extract-i18n-impl#ExtractI18nCommand",


### PR DESCRIPTION

BREAKING CHANGE:

Deprecated `ng x18n` and `ng i18n-extract` commands have been removed in favor of `ng extract-i18n`.