### PR TITLE
build: add permissions to current github action workflows

### DIFF
--- a/.github/workflows/dev-infra.yml
+++ b/.github/workflows/dev-infra.yml
@@ -1,5 +1,9 @@
 name: DevInfra
 
+# Declare default permissions as read only.
+permissions:
+  contents: read
+
 on:
   pull_request_target:
     types: [opened, synchronize, reopened]

--- a/.github/workflows/feature-requests.yml
+++ b/.github/workflows/feature-requests.yml
@@ -1,5 +1,9 @@
 name: Feature request triage bot
 
+# Declare default permissions as read only.
+permissions:
+  contents: read
+
 on:
   schedule:
     # Run at 13:00 every day

--- a/.github/workflows/lock-closed.yml
+++ b/.github/workflows/lock-closed.yml
@@ -1,5 +1,9 @@
 name: Lock Inactive Issues
 
+# Declare default permissions as read only.
+permissions:
+  contents: read
+
 on:
   schedule:
     # Run at 08:00 every day

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -8,7 +8,8 @@ on:
   workflow_dispatch:
 
 # Declare default permissions as read only.
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   analysis:


### PR DESCRIPTION
The currently recommended best practice for Github action workflows is to set top-level permissions to read only. And if the job uses the automatic `GITHUB_TOKEN`, fine-grained permissions for each job based on the job's requirements should also be added.
All existing workflows in the repository now have top-level read only permission blocks.
Only the `scorecard` workflow currently requires additional job level permissions and the minimum set of permissions were already present for the job.