### PR TITLE
test: remove `common-tags` dependency from E2E tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,6 @@
     "browserslist": "^4.9.1",
     "cacache": "15.3.0",
     "chokidar": "^3.5.2",
-    "common-tags": "^1.8.0",
     "copy-webpack-plugin": "10.2.4",
     "core-js": "3.21.1",
     "critters": "0.0.16",

--- a/tests/legacy-cli/e2e/tests/basic/scripts-array.ts
+++ b/tests/legacy-cli/e2e/tests/basic/scripts-array.ts
@@ -1,4 +1,3 @@
-import { oneLineTrim } from 'common-tags';
 import { appendToFile, expectFileToMatch, writeMultipleFiles } from '../../utils/fs';
 import { ng } from '../../utils/process';
 import { updateJsonFile } from '../../utils/project';
@@ -53,13 +52,13 @@ export default async function () {
   // index.html lists the right bundles
   await expectFileToMatch(
     'dist/test-project/index.html',
-    oneLineTrim`
-    <script src="runtime.js" type="module"></script>
-    <script src="polyfills.js" type="module"></script>
-    <script src="scripts.js" defer></script>
-    <script src="renamed-script.js" defer></script>
-    <script src="vendor.js" type="module"></script>
-    <script src="main.js" type="module"></script>
-  `,
+    [
+      '<script src="runtime.js" type="module"></script>',
+      '<script src="polyfills.js" type="module"></script>',
+      '<script src="scripts.js" defer></script>',
+      '<script src="renamed-script.js" defer></script>',
+      '<script src="vendor.js" type="module"></script>',
+      '<script src="main.js" type="module"></script>',
+    ].join(''),
   );
 }

--- a/tests/legacy-cli/e2e/tests/basic/styles-array.ts
+++ b/tests/legacy-cli/e2e/tests/basic/styles-array.ts
@@ -1,4 +1,3 @@
-import { oneLineTrim } from 'common-tags';
 import { expectFileToMatch, writeMultipleFiles } from '../../utils/fs';
 import { ng } from '../../utils/process';
 import { updateJsonFile } from '../../utils/project';
@@ -36,10 +35,7 @@ export default async function () {
   await expectFileToMatch('dist/test-project/renamed-lazy-style.css', '.pre-rename-lazy-style');
   await expectFileToMatch(
     'dist/test-project/index.html',
-    oneLineTrim`
-      <link rel="stylesheet" href="styles.css">
-      <link rel="stylesheet" href="renamed-style.css">
-    `,
+    '<link rel="stylesheet" href="styles.css"><link rel="stylesheet" href="renamed-style.css">',
   );
 
   // Non injected styles should be listed under lazy chunk files

--- a/tests/legacy-cli/e2e/tests/build/polyfills.ts
+++ b/tests/legacy-cli/e2e/tests/build/polyfills.ts
@@ -1,4 +1,3 @@
-import { oneLineTrim } from 'common-tags';
 import {
   expectFileSizeToBeUnder,
   expectFileToExist,

--- a/tests/legacy-cli/e2e/tests/build/styles/imports.ts
+++ b/tests/legacy-cli/e2e/tests/build/styles/imports.ts
@@ -1,9 +1,7 @@
 import { writeMultipleFiles, expectFileToMatch, replaceInFile } from '../../../utils/fs';
 import { expectToFail } from '../../../utils/utils';
 import { ng } from '../../../utils/process';
-import { stripIndents } from 'common-tags';
 import { updateJsonFile } from '../../../utils/project';
-import { getGlobalVariable } from '../../../utils/env';
 
 export default function () {
   // TODO(architect): Delete this test. It is now in devkit/build-angular.
@@ -15,14 +13,14 @@ export default function () {
     promise = promise.then(() => {
       return (
         writeMultipleFiles({
-          [`src/styles.${ext}`]: stripIndents`
+          [`src/styles.${ext}`]: `
           @import './imported-styles.${ext}';
           body { background-color: #00f; }
         `,
-          [`src/imported-styles.${ext}`]: stripIndents`
+          [`src/imported-styles.${ext}`]: `
           p { background-color: #f00; }
         `,
-          [`src/app/app.component.${ext}`]: stripIndents`
+          [`src/app/app.component.${ext}`]: `
           @import './imported-component-styles.${ext}';
           .outer {
             .inner {
@@ -30,9 +28,7 @@ export default function () {
             }
           }
         `,
-          [`src/app/imported-component-styles.${ext}`]: stripIndents`
-          h1 { background: #000; }
-        `,
+          [`src/app/imported-component-styles.${ext}`]: 'h1 { background: #000; }',
         })
           // change files to use preprocessor
           .then(() =>

--- a/tests/legacy-cli/e2e/tests/build/styles/less.ts
+++ b/tests/legacy-cli/e2e/tests/build/styles/less.ts
@@ -6,21 +6,18 @@ import {
 } from '../../../utils/fs';
 import { expectToFail } from '../../../utils/utils';
 import { ng } from '../../../utils/process';
-import { stripIndents } from 'common-tags';
 import { updateJsonFile } from '../../../utils/project';
 
 export default function () {
   // TODO(architect): Delete this test. It is now in devkit/build-angular.
 
   return writeMultipleFiles({
-    'src/styles.less': stripIndents`
+    'src/styles.less': `
       @import './imported-styles.less';
       body { background-color: blue; }
     `,
-    'src/imported-styles.less': stripIndents`
-      p { background-color: red; }
-    `,
-    'src/app/app.component.less': stripIndents`
+    'src/imported-styles.less': 'p { background-color: red; }',
+    'src/app/app.component.less': `
         .outer {
           .inner {
             background: #fff;

--- a/tests/legacy-cli/e2e/tests/build/styles/loaders.ts
+++ b/tests/legacy-cli/e2e/tests/build/styles/loaders.ts
@@ -2,40 +2,39 @@ import {
   writeMultipleFiles,
   deleteFile,
   expectFileToMatch,
-  replaceInFile
+  replaceInFile,
 } from '../../../utils/fs';
 import { ng } from '../../../utils/process';
-import { stripIndents } from 'common-tags';
 import { updateJsonFile } from '../../../utils/project';
 import { expectToFail } from '../../../utils/utils';
 
-export default function () {
-  return writeMultipleFiles({
-    'src/styles.scss': stripIndents`
+export default async function () {
+  await writeMultipleFiles({
+    'src/styles.scss': `
       @import './imported-styles.scss';
       body { background-color: blue; }
     `,
-    'src/imported-styles.scss': stripIndents`
-      p { background-color: red; }
-    `,
-    'src/app/app.component.scss': stripIndents`
-        .outer {
-          .inner {
-            background: #fff;
-          }
+    'src/imported-styles.scss': 'p { background-color: red; }',
+    'src/app/app.component.scss': `
+      .outer {
+        .inner {
+          background: #fff;
         }
-      `})
-    .then(() => deleteFile('src/app/app.component.css'))
-    .then(() => updateJsonFile('angular.json', workspaceJson => {
-      const appArchitect = workspaceJson.projects['test-project'].architect;
-      appArchitect.build.options.styles = [
-        { input: 'src/styles.scss' },
-      ];
-    }))
-    .then(() => replaceInFile('src/app/app.component.ts',
-      './app.component.css', './app.component.scss'))
-    .then(() => ng('build', '--configuration=development'))
-    .then(() => expectToFail(() => expectFileToMatch('dist/test-project/styles.css', /exports/)))
-    .then(() => expectToFail(() => expectFileToMatch('dist/test-project/main-es5.js',
-      /".*module\.exports.*\.outer.*background:/)));
+      }
+    `,
+  });
+
+  await deleteFile('src/app/app.component.css');
+  await updateJsonFile('angular.json', (workspaceJson) => {
+    const appArchitect = workspaceJson.projects['test-project'].architect;
+    appArchitect.build.options.styles = [{ input: 'src/styles.scss' }];
+  });
+  await replaceInFile('src/app/app.component.ts', './app.component.css', './app.component.scss');
+
+  await ng('build', '--configuration=development');
+
+  await expectToFail(() => expectFileToMatch('dist/test-project/styles.css', /exports/));
+  await expectToFail(() =>
+    expectFileToMatch('dist/test-project/main.js', /".*module\.exports.*\.outer.*background:/),
+  );
 }

--- a/tests/legacy-cli/e2e/tests/build/styles/material-import.ts
+++ b/tests/legacy-cli/e2e/tests/build/styles/material-import.ts
@@ -1,4 +1,3 @@
-import { stripIndents } from 'common-tags';
 import { getGlobalVariable } from '../../../utils/env';
 import { replaceInFile, writeMultipleFiles } from '../../../utils/fs';
 import { installWorkspacePackages } from '../../../utils/packages';
@@ -25,12 +24,9 @@ export default async function () {
 
   for (const ext of ['css', 'scss', 'less', 'styl']) {
     await writeMultipleFiles({
-      [`src/styles.${ext}`]: stripIndents`
-        @import "~@angular/material/prebuilt-themes/indigo-pink.css";
-      `,
-      [`src/app/app.component.${ext}`]: stripIndents`
-        @import "~@angular/material/prebuilt-themes/indigo-pink.css";
-      `,
+      [`src/styles.${ext}`]: '@import "~@angular/material/prebuilt-themes/indigo-pink.css";',
+      [`src/app/app.component.${ext}`]:
+        '@import "~@angular/material/prebuilt-themes/indigo-pink.css";',
     });
 
     // change files to use preprocessor
@@ -48,12 +44,9 @@ export default async function () {
     // run build app
     await ng('build', '--source-map', '--configuration=development');
     await writeMultipleFiles({
-      [`src/styles.${ext}`]: stripIndents`
-          @import "@angular/material/prebuilt-themes/indigo-pink.css";
-        `,
-      [`src/app/app.component.${ext}`]: stripIndents`
-          @import "@angular/material/prebuilt-themes/indigo-pink.css";
-        `,
+      [`src/styles.${ext}`]: '@import "@angular/material/prebuilt-themes/indigo-pink.css";',
+      [`src/app/app.component.${ext}`]:
+        '@import "@angular/material/prebuilt-themes/indigo-pink.css";',
     });
 
     await ng('build', '--configuration=development');

--- a/tests/legacy-cli/e2e/tests/build/styles/scss.ts
+++ b/tests/legacy-cli/e2e/tests/build/styles/scss.ts
@@ -6,21 +6,18 @@ import {
 } from '../../../utils/fs';
 import { expectToFail } from '../../../utils/utils';
 import { ng } from '../../../utils/process';
-import { stripIndents } from 'common-tags';
 import { updateJsonFile } from '../../../utils/project';
 
 export default function () {
   // TODO(architect): Delete this test. It is now in devkit/build-angular.
 
   return writeMultipleFiles({
-    'src/styles.scss': stripIndents`
+    'src/styles.scss': `
       @import './imported-styles.scss';
       body { background-color: blue; }
     `,
-    'src/imported-styles.scss': stripIndents`
-      p { background-color: red; }
-    `,
-    'src/app/app.component.scss': stripIndents`
+    'src/imported-styles.scss': 'p { background-color: red; }',
+    'src/app/app.component.scss': `
         .outer {
           .inner {
             background: #fff;

--- a/tests/legacy-cli/e2e/tests/build/styles/stylus.ts
+++ b/tests/legacy-cli/e2e/tests/build/styles/stylus.ts
@@ -6,21 +6,18 @@ import {
 } from '../../../utils/fs';
 import { expectToFail } from '../../../utils/utils';
 import { ng } from '../../../utils/process';
-import { stripIndents } from 'common-tags';
 import { updateJsonFile } from '../../../utils/project';
 
 export default function () {
   // TODO(architect): Delete this test. It is now in devkit/build-angular.
 
   return writeMultipleFiles({
-    'src/styles.styl': stripIndents`
+    'src/styles.styl': `
       @import './imported-styles.styl';
       body { background-color: blue; }
     `,
-    'src/imported-styles.styl': stripIndents`
-      p { background-color: red; }
-    `,
-    'src/app/app.component.styl': stripIndents`
+    'src/imported-styles.styl': 'p { background-color: red; }',
+    'src/app/app.component.styl': `
         .outer {
           .inner {
             background: #fff;

--- a/tests/legacy-cli/e2e/tests/build/ts-paths.ts
+++ b/tests/legacy-cli/e2e/tests/build/ts-paths.ts
@@ -1,21 +1,14 @@
-import { stripIndents } from 'common-tags';
 import { appendToFile, createDir, replaceInFile, rimraf, writeMultipleFiles } from '../../utils/fs';
 import { ng } from '../../utils/process';
 import { updateTsConfig } from '../../utils/project';
 
 export default async function () {
-  await updateTsConfig(json => {
+  await updateTsConfig((json) => {
     json['compilerOptions']['baseUrl'] = './src';
     json['compilerOptions']['paths'] = {
-      '@shared': [
-        'app/shared',
-      ],
-      '@shared/*': [
-        'app/shared/*',
-      ],
-      '@root/*': [
-        './*',
-      ],
+      '@shared': ['app/shared'],
+      '@shared/*': ['app/shared/*'],
+      '@root/*': ['./*'],
     };
   });
 
@@ -29,14 +22,13 @@ export default async function () {
   await replaceInFile('src/app/app.module.ts', './app.component', '@root/app/app.component');
   await ng('build', '--configuration=development');
 
-  await updateTsConfig(json => {
-    json['compilerOptions']['paths']['*'] = [
-      '*',
-      'app/shared/*',
-    ];
+  await updateTsConfig((json) => {
+    json['compilerOptions']['paths']['*'] = ['*', 'app/shared/*'];
   });
 
-  await appendToFile('src/app/app.component.ts', stripIndents`
+  await appendToFile(
+    'src/app/app.component.ts',
+    `
     import { meaning } from 'app/shared/meaning';
     import { meaning as meaning2 } from '@shared';
     import { meaning as meaning3 } from '@shared/meaning';
@@ -50,7 +42,8 @@ export default async function () {
     console.log(meaning3)
     console.log(meaning4)
     console.log(meaning5)
-  `);
+  `,
+  );
 
   await ng('build', '--configuration=development');
 

--- a/tests/legacy-cli/e2e/tests/commands/help/help-hidden.ts
+++ b/tests/legacy-cli/e2e/tests/commands/help/help-hidden.ts
@@ -1,26 +1,19 @@
-import { oneLine } from 'common-tags';
-
 import { silentNg } from '../../../utils/process';
 
-
-export default function() {
+export default function () {
   return Promise.resolve()
     .then(() => silentNg('--help'))
     .then(({ stdout }) => {
       if (stdout.match(/(easter-egg)|(ng make-this-awesome)|(ng init)/)) {
-        throw new Error(oneLine`
-          Expected to not match "(easter-egg)|(ng make-this-awesome)|(ng init)"
-          in help output.
-        `);
+        throw new Error(
+          'Expected to not match "(easter-egg)|(ng make-this-awesome)|(ng init)" in help output.',
+        );
       }
     })
     .then(() => silentNg('--help', 'new'))
     .then(({ stdout }) => {
       if (stdout.match(/--link-cli/)) {
-        throw new Error(oneLine`
-          Expected to not match "--link-cli"
-          in help output.
-        `);
+        throw new Error('Expected to not match "--link-cli" in help output.');
       }
-    })
+    });
 }

--- a/tests/legacy-cli/e2e/tests/generate/component/component-duplicate.ts
+++ b/tests/legacy-cli/e2e/tests/generate/component/component-duplicate.ts
@@ -1,4 +1,3 @@
-import { oneLine } from 'common-tags';
 import { appendToFile } from '../../../utils/fs';
 import { ng } from '../../../utils/process';
 import { expectToFail } from '../../../utils/utils';
@@ -7,12 +6,11 @@ export default function () {
   return ng('generate', 'component', 'test-component')
     .then((output) => {
       if (!output.stdout.match(/UPDATE src[\\|\/]app[\\|\/]app.module.ts/)) {
-        throw new Error(oneLine`
-          Expected to match
-          "UPDATE src/app.module.ts"
-          in ${output.stdout}.`);
+        throw new Error(`Expected to match "UPDATE src/app.module.ts" in ${output.stdout}.`);
       }
     })
-    .then(() => appendToFile('src/app/test-component/test-component.component.ts', '\n// new content'))
+    .then(() =>
+      appendToFile('src/app/test-component/test-component.component.ts', '\n// new content'),
+    )
     .then(() => expectToFail(() => ng('generate', 'component', 'test-component')));
 }

--- a/tests/legacy-cli/e2e/tests/misc/common-async.ts
+++ b/tests/legacy-cli/e2e/tests/misc/common-async.ts
@@ -1,78 +1,102 @@
-import {readdirSync} from 'fs';
-import {oneLine} from 'common-tags';
+import { readdirSync } from 'fs';
 import { installPackage } from '../../utils/packages';
 import { ng } from '../../utils/process';
-import {appendToFile, expectFileToExist, prependToFile, replaceInFile} from '../../utils/fs';
-import {expectToFail} from '../../utils/utils';
+import { appendToFile, expectFileToExist, prependToFile, replaceInFile } from '../../utils/fs';
+import { expectToFail } from '../../utils/utils';
 
-
-export default function() {
+export default function () {
   // TODO(architect): The common chunk seems to have a different name in devkit/build-angular.
   // Investigate, validate, then delete this test.
   return;
 
+  const commonFile = 'dist/test-project/common.chunk.js';
   let oldNumberOfFiles = 0;
-  return Promise.resolve()
-    .then(() => ng('build'))
-    .then(() => oldNumberOfFiles = readdirSync('dist/test-project').length)
-    .then(() => ng('generate', 'module', 'lazyA', '--routing'))
-    .then(() => ng('generate', 'module', 'lazyB', '--routing'))
-    .then(() => prependToFile('src/app/app.module.ts', `
+  return (
+    Promise.resolve()
+      .then(() => ng('build'))
+      .then(() => (oldNumberOfFiles = readdirSync('dist/test-project').length))
+      .then(() => ng('generate', 'module', 'lazyA', '--routing'))
+      .then(() => ng('generate', 'module', 'lazyB', '--routing'))
+      .then(() =>
+        prependToFile(
+          'src/app/app.module.ts',
+          `
       import { RouterModule } from '@angular/router';
-    `))
-    .then(() => replaceInFile('src/app/app.module.ts', 'imports: [', `imports: [
+    `,
+        ),
+      )
+      .then(() =>
+        replaceInFile(
+          'src/app/app.module.ts',
+          'imports: [',
+          `imports: [
       RouterModule.forRoot([{ path: "lazyA", loadChildren: "./lazy-a/lazy-a.module#LazyAModule" }]),
       RouterModule.forRoot([{ path: "lazyB", loadChildren: "./lazy-b/lazy-b.module#LazyBModule" }]),
-    `))
-    .then(() => ng('build'))
-    .then(() => readdirSync('dist').length)
-    .then(currentNumberOfDistFiles => {
-      if (oldNumberOfFiles >= currentNumberOfDistFiles) {
-        throw new Error('A bundle for the lazy module was not created.');
-      }
-      oldNumberOfFiles = currentNumberOfDistFiles;
-    })
-    .then(() => installPackage('moment'))
-    .then(() => appendToFile('src/app/lazy-a/lazy-a.module.ts', `
+    `,
+        ),
+      )
+      .then(() => ng('build'))
+      .then(() => readdirSync('dist').length)
+      .then((currentNumberOfDistFiles) => {
+        if (oldNumberOfFiles >= currentNumberOfDistFiles) {
+          throw new Error('A bundle for the lazy module was not created.');
+        }
+        oldNumberOfFiles = currentNumberOfDistFiles;
+      })
+      .then(() => installPackage('moment'))
+      .then(() =>
+        appendToFile(
+          'src/app/lazy-a/lazy-a.module.ts',
+          `
       import * as moment from 'moment';
       console.log(moment);
-    `))
-    .then(() => ng('build'))
-    .then(() => readdirSync('dist/test-project').length)
-    .then(currentNumberOfDistFiles => {
-      if (oldNumberOfFiles != currentNumberOfDistFiles) {
-        throw new Error('The build contains a different number of files.');
-      }
-    })
-    .then(() => appendToFile('src/app/lazy-b/lazy-b.module.ts', `
+    `,
+        ),
+      )
+      .then(() => ng('build'))
+      .then(() => readdirSync('dist/test-project').length)
+      .then((currentNumberOfDistFiles) => {
+        if (oldNumberOfFiles != currentNumberOfDistFiles) {
+          throw new Error('The build contains a different number of files.');
+        }
+      })
+      .then(() =>
+        appendToFile(
+          'src/app/lazy-b/lazy-b.module.ts',
+          `
       import * as moment from 'moment';
       console.log(moment);
-    `))
-    .then(() => ng('build'))
-    .then(() => expectFileToExist('dist/test-project/common.chunk.js'))
-    .then(() => readdirSync('dist/test-project').length)
-    .then(currentNumberOfDistFiles => {
-      if (oldNumberOfFiles >= currentNumberOfDistFiles) {
-        throw new Error(oneLine`The build contains the wrong number of files.
-          The test for 'dist/test-project/common.chunk.js' to exist should have failed.`);
-      }
-      oldNumberOfFiles = currentNumberOfDistFiles;
-    })
-    .then(() => ng('build', '--no-common-chunk'))
-    .then(() => expectToFail(() => expectFileToExist('dist/test-project/common.chunk.js')))
-    .then(() => readdirSync('dist/test-project').length)
-    .then(currentNumberOfDistFiles => {
-      if (oldNumberOfFiles <= currentNumberOfDistFiles) {
-        throw new Error(oneLine`The build contains the wrong number of files.
-          The test for 'dist/test-project/common.chunk.js' not to exist should have failed.`);
-      }
-    })
-    // Check for AoT and lazy routes.
-    .then(() => ng('build', '--aot'))
-    .then(() => readdirSync('dist/test-project').length)
-    .then(currentNumberOfDistFiles => {
-      if (oldNumberOfFiles != currentNumberOfDistFiles) {
-        throw new Error('AoT build contains a different number of files.');
-      }
-    });
+    `,
+        ),
+      )
+      .then(() => ng('build'))
+      .then(() => expectFileToExist(commonFile))
+      .then(() => readdirSync('dist/test-project').length)
+      .then((currentNumberOfDistFiles) => {
+        if (oldNumberOfFiles >= currentNumberOfDistFiles) {
+          throw new Error(
+            `The build contains the wrong number of files. The test for '${commonFile}' to exist should have failed.`,
+          );
+        }
+        oldNumberOfFiles = currentNumberOfDistFiles;
+      })
+      .then(() => ng('build', '--no-common-chunk'))
+      .then(() => expectToFail(() => expectFileToExist(commonFile)))
+      .then(() => readdirSync('dist/test-project').length)
+      .then((currentNumberOfDistFiles) => {
+        if (oldNumberOfFiles <= currentNumberOfDistFiles) {
+          throw new Error(
+            `The build contains the wrong number of files. The test for '${commonFile}' not to exist should have failed.`,
+          );
+        }
+      })
+      // Check for AoT and lazy routes.
+      .then(() => ng('build', '--aot'))
+      .then(() => readdirSync('dist/test-project').length)
+      .then((currentNumberOfDistFiles) => {
+        if (oldNumberOfFiles != currentNumberOfDistFiles) {
+          throw new Error('AoT build contains a different number of files.');
+        }
+      })
+  );
 }

--- a/tests/legacy-cli/e2e/tests/test/test-scripts.ts
+++ b/tests/legacy-cli/e2e/tests/test/test-scripts.ts
@@ -2,74 +2,74 @@ import { writeMultipleFiles } from '../../utils/fs';
 import { ng } from '../../utils/process';
 import { updateJsonFile } from '../../utils/project';
 import { expectToFail } from '../../utils/utils';
-import { stripIndent } from 'common-tags';
 
-
-export default function () {
+export default async function () {
   // TODO(architect): Delete this test. It is now in devkit/build-angular.
 
-  return Promise.resolve()
-    .then(() => ng('test', '--watch=false'))
-    // prepare global scripts test files
-    .then(() => writeMultipleFiles({
-      'src/string-script.js': `stringScriptGlobal = 'string-scripts.js';`,
-      'src/input-script.js': `inputScriptGlobal = 'input-scripts.js';`,
-      'src/typings.d.ts': stripIndent`
-        declare var stringScriptGlobal: any;
-        declare var inputScriptGlobal: any;
-      `,
-      'src/app/app.component.ts': stripIndent`
-        import { Component } from '@angular/core';
+  await ng('test', '--watch=false');
 
-        @Component({ selector: 'app-root', template: '' })
-        export class AppComponent {
-          stringScriptGlobalProp = stringScriptGlobal;
-          inputScriptGlobalProp = inputScriptGlobal;
-        }
-      `,
-      'src/app/app.component.spec.ts': stripIndent`
-        import { TestBed } from '@angular/core/testing';
-        import { AppComponent } from './app.component';
+  // prepare global scripts test files
+  await writeMultipleFiles({
+    'src/string-script.js': `stringScriptGlobal = 'string-scripts.js';`,
+    'src/input-script.js': `inputScriptGlobal = 'input-scripts.js';`,
+    'src/typings.d.ts': `
+      declare var stringScriptGlobal: any;
+      declare var inputScriptGlobal: any;
+    `,
+    'src/app/app.component.ts': `
+      import { Component } from '@angular/core';
 
-        describe('AppComponent', () => {
-          beforeEach(async () => {
-            await TestBed.configureTestingModule({
-              declarations: [ AppComponent ]
-            }).compileComponents();
-          });
+      @Component({ selector: 'app-root', template: '' })
+      export class AppComponent {
+        stringScriptGlobalProp = stringScriptGlobal;
+        inputScriptGlobalProp = inputScriptGlobal;
+      }
+    `,
+    'src/app/app.component.spec.ts': `
+      import { TestBed } from '@angular/core/testing';
+      import { AppComponent } from './app.component';
 
-          it('should have access to string-script.js', () => {
-            let app = TestBed.createComponent(AppComponent).debugElement.componentInstance;
-            expect(app.stringScriptGlobalProp).toEqual('string-scripts.js');
-          });
-
-          it('should have access to input-script.js', () => {
-            let app = TestBed.createComponent(AppComponent).debugElement.componentInstance;
-            expect(app.inputScriptGlobalProp).toEqual('input-scripts.js');
-          });
+      describe('AppComponent', () => {
+        beforeEach(async () => {
+          await TestBed.configureTestingModule({
+            declarations: [ AppComponent ]
+          }).compileComponents();
         });
 
-        describe('Spec', () => {
-          it('should have access to string-script.js', () => {
-            expect(stringScriptGlobal).toBe('string-scripts.js');
-          });
-
-          it('should have access to input-script.js', () => {
-            expect(inputScriptGlobal).toBe('input-scripts.js');
-          });
+        it('should have access to string-script.js', () => {
+          let app = TestBed.createComponent(AppComponent).debugElement.componentInstance;
+          expect(app.stringScriptGlobalProp).toEqual('string-scripts.js');
         });
-      `
-    }))
-    // should fail because the global scripts were not added to scripts array
-    .then(() => expectToFail(() => ng('test', '--watch=false')))
-    .then(() => updateJsonFile('angular.json', workspaceJson => {
-      const appArchitect = workspaceJson.projects['test-project'].architect;
-      appArchitect.test.options.scripts = [
-        { input: 'src/string-script.js' },
-        { input: 'src/input-script.js' },
-      ];
-    }))
-    // should pass now
-    .then(() => ng('test', '--watch=false'));
+
+        it('should have access to input-script.js', () => {
+          let app = TestBed.createComponent(AppComponent).debugElement.componentInstance;
+          expect(app.inputScriptGlobalProp).toEqual('input-scripts.js');
+        });
+      });
+
+      describe('Spec', () => {
+        it('should have access to string-script.js', () => {
+          expect(stringScriptGlobal).toBe('string-scripts.js');
+        });
+
+        it('should have access to input-script.js', () => {
+          expect(inputScriptGlobal).toBe('input-scripts.js');
+        });
+      });
+    `,
+  });
+
+  // should fail because the global scripts were not added to scripts array
+  await expectToFail(() => ng('test', '--watch=false'));
+
+  await updateJsonFile('angular.json', (workspaceJson) => {
+    const appArchitect = workspaceJson.projects['test-project'].architect;
+    appArchitect.test.options.scripts = [
+      { input: 'src/string-script.js' },
+      { input: 'src/input-script.js' },
+    ];
+  });
+
+  // should pass now
+  await ng('test', '--watch=false');
 }
-

--- a/tests/legacy-cli/e2e/tests/third-party/bootstrap.ts
+++ b/tests/legacy-cli/e2e/tests/third-party/bootstrap.ts
@@ -2,7 +2,6 @@ import { installPackage } from '../../utils/packages';
 import { ng } from '../../utils/process';
 import { updateJsonFile } from '../../utils/project';
 import { expectFileToMatch } from '../../utils/fs';
-import { oneLineTrim } from 'common-tags';
 
 export default function () {
   // TODO(architect): Delete this test. It is now in devkit/build-angular.
@@ -24,12 +23,7 @@ export default function () {
     .then(() => expectFileToMatch('dist/test-project/scripts.js', '* Bootstrap'))
     .then(() => expectFileToMatch('dist/test-project/styles.css', '* Bootstrap'))
     .then(() =>
-      expectFileToMatch(
-        'dist/test-project/index.html',
-        oneLineTrim`
-      <script src="scripts.js" defer></script>
-    `,
-      ),
+      expectFileToMatch('dist/test-project/index.html', '<script src="scripts.js" defer></script>'),
     )
     .then(() =>
       ng(
@@ -43,11 +37,6 @@ export default function () {
     .then(() => expectFileToMatch('dist/test-project/scripts.js', 'jQuery'))
     .then(() => expectFileToMatch('dist/test-project/styles.css', ':root'))
     .then(() =>
-      expectFileToMatch(
-        'dist/test-project/index.html',
-        oneLineTrim`
-    <script src="scripts.js" defer></script>
-    `,
-      ),
+      expectFileToMatch('dist/test-project/index.html', '<script src="scripts.js" defer></script>'),
     );
 }

--- a/tests/legacy-cli/e2e/utils/fs.ts
+++ b/tests/legacy-cli/e2e/utils/fs.ts
@@ -1,6 +1,5 @@
 import { PathLike, promises as fs, constants } from 'fs';
 import { dirname, join } from 'path';
-import { stripIndents } from 'common-tags';
 
 export function readFile(fileName: string): Promise<string> {
   return fs.readFile(fileName, 'utf-8');
@@ -126,26 +125,16 @@ export async function expectFileToExist(fileName: string): Promise<void> {
   }
 }
 
-export function expectFileToMatch(fileName: string, regEx: RegExp | string) {
-  return readFile(fileName).then((content) => {
-    if (typeof regEx == 'string') {
-      if (content.indexOf(regEx) == -1) {
-        throw new Error(stripIndents`File "${fileName}" did not contain "${regEx}"...
-            Content:
-            ${content}
-            ------
-          `);
-      }
-    } else {
-      if (!content.match(regEx)) {
-        throw new Error(stripIndents`File "${fileName}" did not contain "${regEx}"...
-            Content:
-            ${content}
-            ------
-          `);
-      }
-    }
-  });
+export async function expectFileToMatch(fileName: string, regEx: RegExp | string): Promise<void> {
+  const content = await readFile(fileName);
+
+  const found = typeof regEx === 'string' ? content.includes(regEx) : content.match(regEx);
+
+  if (!found) {
+    throw new Error(
+      `File "${fileName}" did not contain "${regEx}"...\nContent:\n${content}\n------`,
+    );
+  }
 }
 
 export async function getFileSize(fileName: string) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3985,11 +3985,6 @@ commander@^8.3.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
   integrity sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
 
-common-tags@^1.8.0:
-  version "1.8.2"
-  resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.8.2.tgz#94ebb3c076d26032745fd54face7f688ef5ac9c6"
-  integrity sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==
-
 commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"


### PR DESCRIPTION
The `common-tags` development dependency was only used in several E2E tests.
Removing the usage of the dependency also allows it to be removed as a development dependency from the root `package.json`.