### PR TITLE
fix(@angular-devkit/build-angular): don't rename blocks which have a name

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/plugins/named-chunks-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/plugins/named-chunks-plugin.ts
@@ -41,6 +41,11 @@ export class NamedChunksPlugin {
         continue;
       }
 
+      if (block.groupOptions.name) {
+        // Ignore groups which have been named already.
+        return undefined;
+      }
+
       for (const dependency of block.dependencies) {
         if (dependency instanceof ImportDependency) {
           return Template.toPath(dependency.request);


### PR DESCRIPTION
When using the unsupported `webpackChunkName` magic comment we renamed the chunk which in some cases causes a runtime error.

Closes #22525