### PR TITLE
fix(@angular-devkit/build-angular): find `ngswConfig` as relative to the application root

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/service-worker.ts
+++ b/packages/angular_devkit/build_angular/src/utils/service-worker.ts
@@ -69,10 +69,11 @@ export async function augmentAppWithServiceWorker(
 ): Promise<void> {
   const distPath = getSystemPath(normalize(outputPath));
 
-  // Determine the configuration file path
-  const configPath = ngswConfigPath
-    ? getSystemPath(normalize(ngswConfigPath))
-    : path.join(getSystemPath(appRoot), 'ngsw-config.json');
+  // Determine the configuration file path, relative to the application root.
+  const configPath = path.join(
+    getSystemPath(appRoot),
+    ngswConfigPath ? getSystemPath(normalize(ngswConfigPath)) : 'ngsw-config.json',
+  );
 
   // Read the configuration file
   let config: Config | undefined;


### PR DESCRIPTION
Previously when determining the `configPath` for building the service worker, the config path
was loaded as a relative path to location where  execution of ng build occured.  Instead the
`ngswConfig` value provided in `angular.json` should be considered relative to th application
root, as is the case with the other paths provided in the configuration.

Before this change, assuming a project root of `/project`, and a `ngswConfig` value of `ngsw-config.json`,
the application built successfully when the exuction working directory was `/project`, but if the
user invoked ng build from `/project/src` for instance, the build failed as `ngsw-config.json` does not
exist at `/project/src/ngsw-config.json`.