### PR TITLE
docs(@angular-devkit/core): typo in string.ts docs

### DIFF
--- a/packages/angular_devkit/core/src/utils/strings.ts
+++ b/packages/angular_devkit/core/src/utils/strings.ts
@@ -93,7 +93,7 @@ export function classify(str: string): string {
 }
 
 /**
- More general than decamelize. Returns the lower\_case\_and\_underscored
+ More general than decamelize. Returns the lower_case_and_underscored
  form of a string.
 
  ```javascript


### PR DESCRIPTION
Typo in underscore function code documentation.