### PR TITLE
refactor(@angular-devkit/build-angular): replace most custom path `resolve` usages with Node.js builtins

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/app-shell/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/app-shell/index.ts
@@ -12,7 +12,7 @@ import {
   createBuilder,
   targetFromTargetString,
 } from '@angular-devkit/architect';
-import { JsonObject, normalize, resolve } from '@angular-devkit/core';
+import { JsonObject, normalize } from '@angular-devkit/core';
 import * as fs from 'fs';
 import * as path from 'path';
 import { normalizeOptimization } from '../../utils';
@@ -52,7 +52,7 @@ async function _renderUniversal(
   }
 
   const projectMetadata = await context.getProjectMetadata(projectName);
-  const projectRoot = resolve(normalize(root), normalize((projectMetadata.root as string) || ''));
+  const projectRoot = path.join(root, (projectMetadata.root as string | undefined) ?? '');
 
   const { styles } = normalizeOptimization(browserOptions.optimization);
   const inlineCriticalCssProcessor = styles.inlineCritical
@@ -114,7 +114,7 @@ async function _renderUniversal(
 
     if (browserOptions.serviceWorker) {
       await augmentAppWithServiceWorker(
-        projectRoot,
+        normalize(projectRoot),
         normalize(outputPath),
         browserOptions.baseHref || '/',
         browserOptions.ngswConfigPath,

--- a/packages/angular_devkit/build_angular/src/utils/normalize-builder-schema.ts
+++ b/packages/angular_devkit/build_angular/src/utils/normalize-builder-schema.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { Path, getSystemPath, json } from '@angular-devkit/core';
+import { json, normalize } from '@angular-devkit/core';
 import {
   AssetPatternClass,
   Schema as BrowserBuilderSchema,
@@ -35,9 +35,9 @@ export type NormalizedBrowserBuilderSchema = BrowserBuilderSchema &
   };
 
 export function normalizeBrowserSchema(
-  root: Path,
-  projectRoot: Path,
-  sourceRoot: Path | undefined,
+  workspaceRoot: string,
+  projectRoot: string,
+  projectSourceRoot: string | undefined,
   options: BrowserBuilderSchema,
   metadata: json.JsonObject,
 ): NormalizedBrowserBuilderSchema {
@@ -45,9 +45,17 @@ export function normalizeBrowserSchema(
 
   return {
     ...options,
-    cache: normalizeCacheOptions(metadata, getSystemPath(root)),
-    assets: normalizeAssetPatterns(options.assets || [], root, projectRoot, sourceRoot),
-    fileReplacements: normalizeFileReplacements(options.fileReplacements || [], root),
+    cache: normalizeCacheOptions(metadata, workspaceRoot),
+    assets: normalizeAssetPatterns(
+      options.assets || [],
+      normalize(workspaceRoot),
+      normalize(projectRoot),
+      projectSourceRoot ? normalize(projectSourceRoot) : undefined,
+    ),
+    fileReplacements: normalizeFileReplacements(
+      options.fileReplacements || [],
+      normalize(workspaceRoot),
+    ),
     optimization: normalizeOptimization(options.optimization),
     sourceMap: normalizedSourceMapOptions,
     preserveSymlinks:
@@ -66,6 +74,6 @@ export function normalizeBrowserSchema(
     // A value of 0 is falsy and will disable polling rather then enable
     // 500 ms is a sensible default in this case
     poll: options.poll === 0 ? 500 : options.poll,
-    supportedBrowsers: getSupportedBrowsers(getSystemPath(projectRoot)),
+    supportedBrowsers: getSupportedBrowsers(projectRoot),
   };
 }

--- a/packages/angular_devkit/build_angular/src/utils/webpack-browser-config.ts
+++ b/packages/angular_devkit/build_angular/src/utils/webpack-browser-config.ts
@@ -7,7 +7,7 @@
  */
 
 import { BuilderContext } from '@angular-devkit/architect';
-import { getSystemPath, json, logging, normalize, resolve } from '@angular-devkit/core';
+import { logging } from '@angular-devkit/core';
 import * as path from 'path';
 import { ScriptTarget } from 'typescript';
 import { Configuration, javascript } from 'webpack';
@@ -146,26 +146,24 @@ export async function generateBrowserWebpackConfigFromContext(
     throw new Error('The builder requires a target.');
   }
 
-  const workspaceRoot = normalize(context.workspaceRoot);
+  const workspaceRoot = context.workspaceRoot;
   const projectMetadata = await context.getProjectMetadata(projectName);
-  const projectRoot = resolve(workspaceRoot, normalize((projectMetadata.root as string) || ''));
-  const projectSourceRoot = projectMetadata.sourceRoot as string | undefined;
-  const sourceRoot = projectSourceRoot
-    ? resolve(workspaceRoot, normalize(projectSourceRoot))
-    : undefined;
+  const projectRoot = path.join(workspaceRoot, (projectMetadata.root as string | undefined) ?? '');
+  const sourceRoot = projectMetadata.sourceRoot as string | undefined;
+  const projectSourceRoot = sourceRoot ? path.join(workspaceRoot, sourceRoot) : undefined;
 
   const normalizedOptions = normalizeBrowserSchema(
     workspaceRoot,
     projectRoot,
-    sourceRoot,
+    projectSourceRoot,
     options,
     projectMetadata,
   );
 
   const config = await generateWebpackConfig(
-    getSystemPath(workspaceRoot),
-    getSystemPath(projectRoot),
-    sourceRoot && getSystemPath(sourceRoot),
+    workspaceRoot,
+    projectRoot,
+    projectSourceRoot,
     projectName,
     normalizedOptions,
     webpackPartialGenerator,
@@ -189,8 +187,8 @@ export async function generateBrowserWebpackConfigFromContext(
 
   return {
     config,
-    projectRoot: getSystemPath(projectRoot),
-    projectSourceRoot: sourceRoot && getSystemPath(sourceRoot),
+    projectRoot,
+    projectSourceRoot,
   };
 }
 


### PR DESCRIPTION
During the build initialization phase, many paths are converted back and forth between multiple normalized forms. These conversions involve potentially expensive string operations. The majority of the custom path `resolve` function from `@angular-devkit/core` usages have now been removed in favor of the Node.js builtin path functions. This change reduces the need to perform additional string manipulation where possible.