### PR TITLE
fix(@schematics/angular): remove `@types/node` from new projects

### DIFF
--- a/packages/schematics/angular/e2e/index.ts
+++ b/packages/schematics/angular/e2e/index.ts
@@ -20,6 +20,7 @@ import {
 } from '@angular-devkit/schematics';
 import { NodeDependencyType, addPackageJsonDependency } from '../utility/dependencies';
 import { JSONFile } from '../utility/json-file';
+import { latestVersions } from '../utility/latest-versions';
 import { relativePathToWorkspaceRoot } from '../utility/paths';
 import { getWorkspace, updateWorkspace } from '../utility/workspace';
 import { Builders } from '../utility/workspace-models';
@@ -92,6 +93,11 @@ export default function (options: E2eOptions): Rule {
             type: NodeDependencyType.Dev,
             name: 'ts-node',
             version: '~9.1.1',
+          },
+          {
+            type: NodeDependencyType.Dev,
+            name: '@types/node',
+            version: latestVersions['@types/node'],
           },
         ].forEach((dep) => addPackageJsonDependency(host, dep)),
       addScriptsToPackageJson(),

--- a/packages/schematics/angular/universal/index.ts
+++ b/packages/schematics/angular/universal/index.ts
@@ -23,7 +23,12 @@ import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
 import * as ts from '../third_party/github.com/Microsoft/TypeScript/lib/typescript';
 import { findNode, getDecoratorMetadata } from '../utility/ast-utils';
 import { InsertChange } from '../utility/change';
-import { addPackageJsonDependency, getPackageJsonDependency } from '../utility/dependencies';
+import {
+  NodeDependencyType,
+  addPackageJsonDependency,
+  getPackageJsonDependency,
+} from '../utility/dependencies';
+import { latestVersions } from '../utility/latest-versions';
 import { findBootstrapModuleCall, findBootstrapModulePath } from '../utility/ng-ast-utils';
 import { relativePathToWorkspaceRoot } from '../utility/paths';
 import { targetBuildNotFoundError } from '../utility/project-targets';
@@ -226,7 +231,11 @@ function addDependencies(): Rule {
     };
     addPackageJsonDependency(host, platformServerDep);
 
-    return host;
+    addPackageJsonDependency(host, {
+      type: NodeDependencyType.Dev,
+      name: '@types/node',
+      version: latestVersions['@types/node'],
+    });
   };
 }
 

--- a/packages/schematics/angular/workspace/files/package.json.template
+++ b/packages/schematics/angular/workspace/files/package.json.template
@@ -25,8 +25,7 @@
   "devDependencies": {
     "@angular/cli": "<%= '~' + version %>",
     "@angular/compiler-cli": "<%= latestVersions.Angular %>",<% if (!minimal) { %>
-    "@types/jasmine": "<%= latestVersions['@types/jasmine'] %>",<% } %>
-    "@types/node": "<%= latestVersions['@types/node'] %>",<% if (!minimal) { %>
+    "@types/jasmine": "<%= latestVersions['@types/jasmine'] %>",
     "jasmine-core": "<%= latestVersions['jasmine-core'] %>",
     "karma": "<%= latestVersions['karma'] %>",
     "karma-chrome-launcher": "<%= latestVersions['karma-chrome-launcher'] %>",


### PR DESCRIPTION
The `@types/node` package is now only added if E2E tests (`ng generate e2e`) or universal are added to a project.