### PR TITLE
refactor(@angular-devkit/build-angular): remove unneeded JsonObject type casting

### DIFF
--- a/goldens/public-api/angular_devkit/build_angular/src/index.md
+++ b/goldens/public-api/angular_devkit/build_angular/src/index.md
@@ -10,8 +10,6 @@ import { BuildResult } from '@angular-devkit/build-webpack';
 import { ConfigOptions } from 'karma';
 import { Configuration } from 'webpack';
 import { DevServerBuildOutput } from '@angular-devkit/build-webpack';
-import { json } from '@angular-devkit/core';
-import { JsonObject } from '@angular-devkit/core';
 import { Observable } from 'rxjs';
 import webpack from 'webpack';
 import { WebpackLoggingCallback } from '@angular-devkit/build-webpack';
@@ -74,7 +72,7 @@ export interface BrowserBuilderOptions {
 }
 
 // @public
-export type BrowserBuilderOutput = json.JsonObject & BuilderOutput & {
+export type BrowserBuilderOutput = BuilderOutput & {
     baseOutputPath: string;
     outputPaths: string[];
     outputPath: string;
@@ -104,7 +102,7 @@ export enum CrossOrigin {
 }
 
 // @public (undocumented)
-export type DevServerBuilderOptions = Schema & json.JsonObject;
+export type DevServerBuilderOptions = Schema;
 
 // @public
 export type DevServerBuilderOutput = DevServerBuildOutput & {
@@ -151,7 +149,7 @@ export function executeServerBuilder(options: ServerBuilderOptions, context: Bui
 export type ExecutionTransformer<T> = (input: T) => T | Promise<T>;
 
 // @public (undocumented)
-export type ExtractI18nBuilderOptions = Schema_2 & JsonObject;
+export type ExtractI18nBuilderOptions = Schema_2;
 
 // @public (undocumented)
 export interface FileReplacement {
@@ -270,7 +268,7 @@ export interface ServerBuilderOptions {
 }
 
 // @public
-export type ServerBuilderOutput = json.JsonObject & BuilderOutput & {
+export type ServerBuilderOutput = BuilderOutput & {
     baseOutputPath: string;
     outputPaths: string[];
     outputPath: string;

--- a/packages/angular_devkit/build_angular/src/builders/browser/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/index.ts
@@ -8,7 +8,7 @@
 
 import { BuilderContext, BuilderOutput, createBuilder } from '@angular-devkit/architect';
 import { EmittedFiles, WebpackLoggingCallback, runWebpack } from '@angular-devkit/build-webpack';
-import { json, logging, normalize } from '@angular-devkit/core';
+import { logging, normalize } from '@angular-devkit/core';
 import * as fs from 'fs';
 import * as path from 'path';
 import { Observable, from } from 'rxjs';
@@ -64,15 +64,14 @@ import { Schema as BrowserBuilderSchema } from './schema';
 /**
  * @experimental Direct usage of this type is considered experimental.
  */
-export type BrowserBuilderOutput = json.JsonObject &
-  BuilderOutput & {
-    baseOutputPath: string;
-    outputPaths: string[];
-    /**
-     * @deprecated in version 9. Use 'outputPaths' instead.
-     */
-    outputPath: string;
-  };
+export type BrowserBuilderOutput = BuilderOutput & {
+  baseOutputPath: string;
+  outputPaths: string[];
+  /**
+   * @deprecated in version 9. Use 'outputPaths' instead.
+   */
+  outputPath: string;
+};
 
 /**
  * Maximum time in milliseconds for single build/rebuild
@@ -436,4 +435,4 @@ function checkInternetExplorerSupport(projectRoot: string, logger: logging.Logge
   }
 }
 
-export default createBuilder<json.JsonObject & BrowserBuilderSchema>(buildWebpackBrowser);
+export default createBuilder<BrowserBuilderSchema>(buildWebpackBrowser);

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/index.ts
@@ -47,7 +47,7 @@ import { createWebpackLoggingCallback } from '../../webpack/utils/stats';
 import { Schema as BrowserBuilderSchema, OutputHashing } from '../browser/schema';
 import { Schema } from './schema';
 
-export type DevServerBuilderOptions = Schema & json.JsonObject;
+export type DevServerBuilderOptions = Schema;
 
 /**
  * @experimental Direct usage of this type is considered experimental.
@@ -82,7 +82,7 @@ export function serveWebpackBrowser(
   const browserTarget = targetFromTargetString(options.browserTarget);
 
   async function setup(): Promise<{
-    browserOptions: json.JsonObject & BrowserBuilderSchema;
+    browserOptions: BrowserBuilderSchema;
     webpackConfig: webpack.Configuration;
     projectRoot: string;
   }> {

--- a/packages/angular_devkit/build_angular/src/builders/extract-i18n/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/extract-i18n/index.ts
@@ -25,7 +25,7 @@ import { createWebpackLoggingCallback } from '../../webpack/utils/stats';
 import { Schema as BrowserBuilderOptions, OutputHashing } from '../browser/schema';
 import { Format, Schema } from './schema';
 
-export type ExtractI18nBuilderOptions = Schema & JsonObject;
+export type ExtractI18nBuilderOptions = Schema;
 
 function getI18nOutfile(format: string | undefined) {
   switch (format) {

--- a/packages/angular_devkit/build_angular/src/builders/protractor/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/protractor/index.ts
@@ -12,7 +12,7 @@ import {
   createBuilder,
   targetFromTargetString,
 } from '@angular-devkit/architect';
-import { tags } from '@angular-devkit/core';
+import { json, tags } from '@angular-devkit/core';
 import { resolve } from 'path';
 import * as url from 'url';
 import { runModuleAsObservableFork } from '../../utils';
@@ -114,7 +114,7 @@ export async function execute(
     const overrides = {
       watch: false,
       liveReload: false,
-    } as DevServerBuilderOptions;
+    } as DevServerBuilderOptions & json.JsonObject;
 
     if (options.host !== undefined) {
       overrides.host = options.host;

--- a/packages/angular_devkit/build_angular/src/builders/server/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/server/index.ts
@@ -8,7 +8,7 @@
 
 import { BuilderContext, BuilderOutput, createBuilder } from '@angular-devkit/architect';
 import { runWebpack } from '@angular-devkit/build-webpack';
-import { json, tags } from '@angular-devkit/core';
+import { tags } from '@angular-devkit/core';
 import * as path from 'path';
 import { Observable, from } from 'rxjs';
 import { concatMap, map } from 'rxjs/operators';
@@ -29,15 +29,14 @@ import { Schema as ServerBuilderOptions } from './schema';
 /**
  * @experimental Direct usage of this type is considered experimental.
  */
-export type ServerBuilderOutput = json.JsonObject &
-  BuilderOutput & {
-    baseOutputPath: string;
-    outputPaths: string[];
-    /**
-     * @deprecated in version 9. Use 'outputPaths' instead.
-     */
-    outputPath: string;
-  };
+export type ServerBuilderOutput = BuilderOutput & {
+  baseOutputPath: string;
+  outputPaths: string[];
+  /**
+   * @deprecated in version 9. Use 'outputPaths' instead.
+   */
+  outputPath: string;
+};
 
 export { ServerBuilderOptions };
 


### PR DESCRIPTION
The use of the `@angular-devkit/core` `JsonObject` type is no longer needed to satisfy the type requirements of `@angular-devkit/architect` package builder creation functions.