### PR TITLE
ci: remove Node.js v12 E2E job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -357,12 +357,6 @@ workflows:
                 - renovate/angular
                 - master
       - e2e-cli:
-          name: e2e-cli-node-12
-          nodeversion: '12.20'
-          <<: *only_release_branches
-          requires:
-            - build
-      - e2e-cli:
           name: e2e-cli-node-16
           nodeversion: '16.10'
           <<: *only_release_branches


### PR DESCRIPTION
Node.js v12 will become EOL on 2022-04-30. As a result, Angular as of v14 will no longer support Node.js v12.