### PR TITLE
test: update E2E production application size expectations

### DIFF
--- a/tests/legacy-cli/e2e/tests/build/prod-build.ts
+++ b/tests/legacy-cli/e2e/tests/build/prod-build.ts
@@ -1,7 +1,7 @@
 import { statSync } from 'fs';
 import { join } from 'path';
 import { expectFileToExist, expectFileToMatch, readFile } from '../../utils/fs';
-import { ng } from '../../utils/process';
+import { noSilentNg } from '../../utils/process';
 
 function verifySize(bundle: string, baselineBytes: number) {
   const size = statSync(`dist/test-project/${bundle}`).size;
@@ -29,7 +29,7 @@ export default async function () {
   // stuck to the first build done
   const bootstrapRegExp = /bootstrapModule\([a-zA-Z]+[0-9]*\)\./;
 
-  await ng('build');
+  await noSilentNg('build');
   await expectFileToExist(join(process.cwd(), 'dist'));
   // Check for cache busting hash script src
   await expectFileToMatch('dist/test-project/index.html', /main\.[0-9a-f]{16}\.js/);
@@ -43,5 +43,5 @@ export default async function () {
   await expectFileToMatch(`dist/test-project/${mainES2017Path}`, bootstrapRegExp);
 
   // Size checks in bytes
-  verifySize(mainES2017Path, 141032);
+  verifySize(mainES2017Path, 124000);
 }


### PR DESCRIPTION
Improvements to the framework for `13.2.5` resulted in reduced main bundle sizes.

(cherry picked from commit ed790c1155cb5d49d9985a9e27e239675f2939ba)