### PR TITLE
fix(@angular-devkit/build-angular): ignore css only chunks during naming

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/plugins/named-chunks-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/plugins/named-chunks-plugin.ts
@@ -26,6 +26,12 @@ export class NamedChunksPlugin {
           return;
         }
 
+        if ([...chunk.files.values()].every((f) => f.endsWith('.css'))) {
+          // If all chunk files are CSS files skip.
+          // This happens when using `import('./styles.css')` in a lazy loaded module.
+          return undefined;
+        }
+
         const name = this.generateName(chunk);
         if (name) {
           chunk.name = name;


### PR DESCRIPTION
Don't name CSS only chunks.

Closes #22769