### PR TITLE
fix(@angular/cli): favor project in cwd when running architect commands 

### DIFF
--- a/packages/angular/cli/src/command-builder/architect-command-module.ts
+++ b/packages/angular/cli/src/command-builder/architect-command-module.ts
@@ -7,6 +7,7 @@
  */
 
 import { Argv } from 'yargs';
+import { getProjectByCwd } from '../utilities/config';
 import { ArchitectBaseCommandModule } from './architect-base-command-module';
 import {
   CommandModuleError,
@@ -127,14 +128,9 @@ export abstract class ArchitectCommandModule
       // For multi target commands, we always list all projects that have the target.
       return allProjectsForTargetName;
     } else {
-      // For single target commands, we try the default project first,
-      // then the full list if it has a single project, then error out.
-      const maybeDefaultProject = workspace.extensions['defaultProject'];
-      if (
-        typeof maybeDefaultProject === 'string' &&
-        allProjectsForTargetName.includes(maybeDefaultProject)
-      ) {
-        return [maybeDefaultProject];
+      const maybeProject = getProjectByCwd(workspace);
+      if (maybeProject && allProjectsForTargetName.includes(maybeProject)) {
+        return [maybeProject];
       }
 
       if (allProjectsForTargetName.length === 1) {

--- a/tests/legacy-cli/e2e/tests/commands/builder-project-by-cwd.ts
+++ b/tests/legacy-cli/e2e/tests/commands/builder-project-by-cwd.ts
@@ -1,0 +1,21 @@
+import { join } from 'path';
+import { expectFileToExist } from '../../utils/fs';
+import { ng } from '../../utils/process';
+
+export default async function () {
+  await ng('generate', 'app', 'second-app', '--skip-install');
+  await ng('generate', 'app', 'third-app', '--skip-install');
+  const startCwd = process.cwd();
+
+  try {
+    // When no project is provided it should favor the project that is located in the current working directory.
+    process.chdir(join(startCwd, 'projects/second-app'));
+    await ng('build', '--configuration=development');
+
+    process.chdir(startCwd);
+    await expectFileToExist('dist/second-app');
+  } finally {
+    // restore path
+    process.chdir(startCwd);
+  }
+}


### PR DESCRIPTION
When running architect command such as `ng build`, `ng test`, `ng lint`... and no project is provided as a positional argument. The project in the current working directory is favoured instead of the configured as default project.