### PR TITLE
fix(@angular/cli): don't prompt for analytics when running `ng analytics`

### DIFF
--- a/packages/angular/cli/src/command-builder/command-module.ts
+++ b/packages/angular/cli/src/command-builder/command-module.ts
@@ -171,7 +171,8 @@ export abstract class CommandModule<T extends {} = {}> implements CommandModuleI
 
     return (this._analytics = await createAnalytics(
       !!this.context.workspace,
-      this.commandName === 'update',
+      // Don't prompt for `ng update` and `ng analytics` commands.
+      ['update', 'analytics'].includes(this.commandName),
     ));
   }
 


### PR DESCRIPTION



This addresses the issue  when trying to disable analytics the prompt will be shown

```
ng analytics off
Would you like to share anonymous usage data about this project with the Angular Team at Google under Google’s Privacy Policy at https://policies.google.com/privacy? For more details and how to change this setting, see http://angular.io/analytics. (y/N)
```

Closes #16784
 