### PR TITLE
feat(@angular/cli): add `--global` option to `ng analytics` command

### DIFF
--- a/docs/design/analytics.md
+++ b/docs/design/analytics.md
@@ -115,14 +115,5 @@ There are 2 ways of disabling usage analytics:
    as answering "No" to the prompt.
 1. There is an `NG_CLI_ANALYTICS` environment variable that overrides the global configuration.
    That flag is a string that represents the User ID. If the string `"false"` is used it will
-   disable analytics for this run. If the string `"ci"` is used it will show up as a CI run (see
-   below).
+   disable analytics for this run.
 
-# CI
-
-A special user named `ci` is used for analytics for tracking CI information. This is a convention
-and is in no way enforced.
-
-Running on CI by default will disable analytics (because of a lack of TTY on STDIN/OUT). It can be
-manually enabled using either a global configuration with a value of `ci`, or using the
-`NG_CLI_ANALYTICS=ci` environment variable.

--- a/docs/design/analytics.md
+++ b/docs/design/analytics.md
@@ -111,7 +111,7 @@ See [the `debug` NPM library](https://www.npmjs.com/package/debug) for more info
 
 There are 2 ways of disabling usage analytics:
 
-1. using `ng analytics off` (or changing the global configuration file yourself). This is the same
+1. using `ng analytics off --global` (or changing the global configuration file yourself). This is the same
    as answering "No" to the prompt.
 1. There is an `NG_CLI_ANALYTICS` environment variable that overrides the global configuration.
    That flag is a string that represents the User ID. If the string `"false"` is used it will

--- a/packages/angular/cli/bin/postinstall/analytics-prompt.js
+++ b/packages/angular/cli/bin/postinstall/analytics-prompt.js
@@ -17,10 +17,10 @@ try {
   var analytics = require('../../src/analytics/analytics');
 
   analytics
-    .hasGlobalAnalyticsConfiguration()
+    .hasAnalyticsConfig('global')
     .then((hasGlobalConfig) => {
       if (!hasGlobalConfig) {
-        return analytics.promptGlobalAnalytics();
+        return analytics.promptAnalytics(true /** global */);
       }
     })
     .catch(() => {});

--- a/packages/angular/cli/src/analytics/analytics-environment-options.ts
+++ b/packages/angular/cli/src/analytics/analytics-environment-options.ts
@@ -1,0 +1,22 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+function isDisabled(variable: string): boolean {
+  return variable === '0' || variable.toLowerCase() === 'false';
+}
+
+function isPresent(variable: string | undefined): variable is string {
+  return typeof variable === 'string' && variable !== '';
+}
+
+const analyticsVariable = process.env['NG_CLI_ANALYTICS'];
+export const analyticsDisabled = isPresent(analyticsVariable) && isDisabled(analyticsVariable);
+
+const analyticsShareVariable = process.env['NG_CLI_ANALYTICS_SHARE'];
+export const analyticsShareDisabled =
+  isPresent(analyticsShareVariable) && isDisabled(analyticsShareVariable);

--- a/packages/angular/cli/src/analytics/analytics.ts
+++ b/packages/angular/cli/src/analytics/analytics.ts
@@ -118,7 +118,7 @@ export async function promptGlobalAnalytics(force = false) {
         Thank you for sharing anonymous usage data. If you change your mind, the following
         command will disable this feature entirely:
 
-            ${colors.yellow('ng analytics off')}
+            ${colors.yellow('ng analytics off --global')}
       `);
       console.log('');
 
@@ -177,7 +177,7 @@ export async function promptProjectAnalytics(force = false): Promise<boolean> {
         Thank you for sharing anonymous usage data. Should you change your mind, the following
         command will disable this feature entirely:
 
-            ${colors.yellow('ng analytics project off')}
+            ${colors.yellow('ng analytics off')}
       `);
       console.log('');
 

--- a/packages/angular/cli/src/command-builder/command-module.ts
+++ b/packages/angular/cli/src/command-builder/command-module.ts
@@ -43,6 +43,7 @@ export interface CommandContext {
     positional: string[];
     options: {
       help: boolean;
+      jsonHelp: boolean;
     } & Record<string, unknown>;
   };
 }

--- a/packages/angular/cli/src/command-builder/utilities/command.ts
+++ b/packages/angular/cli/src/command-builder/utilities/command.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { Argv } from 'yargs';
+import { CommandContext, CommandModule, CommandModuleImplementation } from '../command-module';
+
+export const demandCommandFailureMessage = `You need to specify a command before moving on. Use '--help' to view the available commands.`;
+
+export function addCommandModuleToYargs<
+  T,
+  U extends Partial<CommandModuleImplementation> & {
+    new (context: CommandContext): Partial<CommandModuleImplementation> & CommandModule;
+  },
+>(localYargs: Argv<T>, commandModule: U, context: CommandContext): Argv<T> {
+  const cmd = new commandModule(context);
+  const describe = context.args.options.jsonHelp ? cmd.fullDescribe : cmd.describe;
+
+  return localYargs.command({
+    command: cmd.command,
+    aliases: cmd.aliases,
+    describe:
+      // We cannot add custom fields in help, such as long command description which is used in AIO.
+      // Therefore, we get around this by adding a complex object as a string which we later parse when generating the help files.
+      typeof describe === 'object' ? JSON.stringify(describe) : describe,
+    deprecated: cmd.deprecated,
+    builder: (argv) => cmd.builder(argv) as Argv<T>,
+    handler: (args) => cmd.handler(args),
+  });
+}

--- a/packages/angular/cli/src/commands/analytics/cli.ts
+++ b/packages/angular/cli/src/commands/analytics/cli.ts
@@ -18,9 +18,8 @@ import {
 } from '../../command-builder/utilities/command';
 import { AnalyticsInfoCommandModule } from './info/cli';
 import {
-  AnalyticsCIModule,
-  AnalyticsOffModule,
-  AnalyticsOnModule,
+  AnalyticsDisableModule,
+  AnalyticsEnableModule,
   AnalyticsPromptModule,
 } from './settings/cli';
 
@@ -32,12 +31,11 @@ export class AnalyticsCommandModule extends CommandModule implements CommandModu
 
   builder(localYargs: Argv): Argv {
     const subcommands = [
-      AnalyticsCIModule,
       AnalyticsInfoCommandModule,
-      AnalyticsOffModule,
-      AnalyticsOnModule,
+      AnalyticsDisableModule,
+      AnalyticsEnableModule,
       AnalyticsPromptModule,
-    ].sort();
+    ].sort(); // sort by class name.
 
     for (const module of subcommands) {
       localYargs = addCommandModuleToYargs(localYargs, module, this.context);

--- a/packages/angular/cli/src/commands/analytics/info/cli.ts
+++ b/packages/angular/cli/src/commands/analytics/info/cli.ts
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { tags } from '@angular-devkit/core';
+import { Argv } from 'yargs';
+import { analyticsConfigValueToHumanFormat, createAnalytics } from '../../../analytics/analytics';
+import {
+  CommandModule,
+  CommandModuleImplementation,
+  Options,
+} from '../../../command-builder/command-module';
+import { getWorkspaceRaw } from '../../../utilities/config';
+
+export class AnalyticsInfoCommandModule
+  extends CommandModule
+  implements CommandModuleImplementation
+{
+  command = 'info';
+  describe = 'Prints analytics gathering and reporting configuration in the console.';
+  longDescriptionPath?: string | undefined;
+
+  builder(localYargs: Argv): Argv {
+    return localYargs.strict();
+  }
+
+  async run(_options: Options<{}>): Promise<void> {
+    const [globalWorkspace] = getWorkspaceRaw('global');
+    const [localWorkspace] = getWorkspaceRaw('local');
+    const globalSetting = globalWorkspace?.get(['cli', 'analytics']);
+    const localSetting = localWorkspace?.get(['cli', 'analytics']);
+
+    const effectiveSetting = await createAnalytics(
+      !!this.context.workspace /** workspace */,
+      true /** skipPrompt */,
+    );
+
+    this.context.logger.info(tags.stripIndents`
+      Global setting: ${analyticsConfigValueToHumanFormat(globalSetting)}
+      Local setting: ${
+        this.context.workspace
+          ? analyticsConfigValueToHumanFormat(localSetting)
+          : 'No local workspace configuration file.'
+      }
+      Effective status: ${effectiveSetting ? 'enabled' : 'disabled'}
+    `);
+  }
+}

--- a/packages/angular/cli/src/commands/analytics/info/cli.ts
+++ b/packages/angular/cli/src/commands/analytics/info/cli.ts
@@ -6,15 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { tags } from '@angular-devkit/core';
 import { Argv } from 'yargs';
-import { analyticsConfigValueToHumanFormat, createAnalytics } from '../../../analytics/analytics';
+import { getAnalyticsInfoString } from '../../../analytics/analytics';
 import {
   CommandModule,
   CommandModuleImplementation,
   Options,
 } from '../../../command-builder/command-module';
-import { getWorkspaceRaw } from '../../../utilities/config';
 
 export class AnalyticsInfoCommandModule
   extends CommandModule
@@ -29,24 +27,6 @@ export class AnalyticsInfoCommandModule
   }
 
   async run(_options: Options<{}>): Promise<void> {
-    const [globalWorkspace] = getWorkspaceRaw('global');
-    const [localWorkspace] = getWorkspaceRaw('local');
-    const globalSetting = globalWorkspace?.get(['cli', 'analytics']);
-    const localSetting = localWorkspace?.get(['cli', 'analytics']);
-
-    const effectiveSetting = await createAnalytics(
-      !!this.context.workspace /** workspace */,
-      true /** skipPrompt */,
-    );
-
-    this.context.logger.info(tags.stripIndents`
-      Global setting: ${analyticsConfigValueToHumanFormat(globalSetting)}
-      Local setting: ${
-        this.context.workspace
-          ? analyticsConfigValueToHumanFormat(localSetting)
-          : 'No local workspace configuration file.'
-      }
-      Effective status: ${effectiveSetting ? 'enabled' : 'disabled'}
-    `);
+    this.context.logger.info(await getAnalyticsInfoString());
   }
 }

--- a/packages/angular/cli/src/commands/analytics/long-description.md
+++ b/packages/angular/cli/src/commands/analytics/long-description.md
@@ -1,10 +1,9 @@
-The value of `setting-or-project` is one of the following.
+The value of `setting` is one of the following.
 
 - `on`: Enables analytics gathering and reporting for the user.
 - `off`: Disables analytics gathering and reporting for the user.
 - `ci`: Enables analytics and configures reporting for use with Continuous Integration,
   which uses a common CI user.
 - `prompt`: Prompts the user to set the status interactively.
-- `project`: Sets the default status for the project to the `project-setting` value, which can be any of the other values. The `project-setting` argument is ignored for all other values of `setting_or_project`.
 
 For further details, see [Gathering an Viewing CLI Usage Analytics](cli/usage-analytics-gathering).

--- a/packages/angular/cli/src/commands/analytics/long-description.md
+++ b/packages/angular/cli/src/commands/analytics/long-description.md
@@ -1,9 +1,0 @@
-The value of `setting` is one of the following.
-
-- `on`: Enables analytics gathering and reporting for the user.
-- `off`: Disables analytics gathering and reporting for the user.
-- `ci`: Enables analytics and configures reporting for use with Continuous Integration,
-  which uses a common CI user.
-- `prompt`: Prompts the user to set the status interactively.
-
-For further details, see [Gathering an Viewing CLI Usage Analytics](cli/usage-analytics-gathering).

--- a/packages/angular/cli/src/commands/analytics/settings/cli.ts
+++ b/packages/angular/cli/src/commands/analytics/settings/cli.ts
@@ -42,11 +42,12 @@ abstract class AnalyticsSettingModule
   abstract override run({ global }: Options<AnalyticsCommandArgs>): Promise<void>;
 }
 
-export class AnalyticsOffModule
+export class AnalyticsDisableModule
   extends AnalyticsSettingModule
   implements CommandModuleImplementation<AnalyticsCommandArgs>
 {
-  command = 'off';
+  command = 'disable';
+  aliases = 'off';
   describe = 'Disables analytics gathering and reporting for the user.';
 
   async run({ global }: Options<AnalyticsCommandArgs>): Promise<void> {
@@ -55,11 +56,12 @@ export class AnalyticsOffModule
   }
 }
 
-export class AnalyticsOnModule
+export class AnalyticsEnableModule
   extends AnalyticsSettingModule
   implements CommandModuleImplementation<AnalyticsCommandArgs>
 {
-  command = 'on';
+  command = 'enable';
+  aliases = 'on';
   describe = 'Enables analytics gathering and reporting for the user.';
   async run({ global }: Options<AnalyticsCommandArgs>): Promise<void> {
     setAnalyticsConfig(global, true);

--- a/packages/angular/cli/src/commands/analytics/settings/cli.ts
+++ b/packages/angular/cli/src/commands/analytics/settings/cli.ts
@@ -1,0 +1,95 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { Argv } from 'yargs';
+import {
+  promptGlobalAnalytics,
+  promptProjectAnalytics,
+  setAnalyticsConfig,
+} from '../../../analytics/analytics';
+import {
+  CommandModule,
+  CommandModuleImplementation,
+  Options,
+} from '../../../command-builder/command-module';
+
+interface AnalyticsCommandArgs {
+  global: boolean;
+}
+
+abstract class AnalyticsSettingModule
+  extends CommandModule<AnalyticsCommandArgs>
+  implements CommandModuleImplementation<AnalyticsCommandArgs>
+{
+  longDescriptionPath?: string | undefined;
+
+  builder(localYargs: Argv): Argv<AnalyticsCommandArgs> {
+    return localYargs
+      .option('global', {
+        description: `Configure analytics gathering and reporting globally in the caller's home directory.`,
+        alias: ['g'],
+        type: 'boolean',
+        default: false,
+      })
+      .strict();
+  }
+
+  abstract override run({ global }: Options<AnalyticsCommandArgs>): void;
+}
+
+export class AnalyticsOffModule
+  extends AnalyticsSettingModule
+  implements CommandModuleImplementation<AnalyticsCommandArgs>
+{
+  command = 'off';
+  describe = 'Disables analytics gathering and reporting for the user.';
+
+  run({ global }: Options<AnalyticsCommandArgs>): void {
+    setAnalyticsConfig(global, false);
+  }
+}
+
+export class AnalyticsOnModule
+  extends AnalyticsSettingModule
+  implements CommandModuleImplementation<AnalyticsCommandArgs>
+{
+  command = 'on';
+  describe = 'Enables analytics gathering and reporting for the user.';
+  run({ global }: Options<AnalyticsCommandArgs>): void {
+    setAnalyticsConfig(global, true);
+  }
+}
+
+export class AnalyticsCIModule
+  extends AnalyticsSettingModule
+  implements CommandModuleImplementation<AnalyticsCommandArgs>
+{
+  command = 'ci';
+  describe =
+    'Enables analytics and configures reporting for use with Continuous Integration, which uses a common CI user.';
+
+  run({ global }: Options<AnalyticsCommandArgs>): void {
+    setAnalyticsConfig(global, 'ci');
+  }
+}
+
+export class AnalyticsPromptModule
+  extends AnalyticsSettingModule
+  implements CommandModuleImplementation<AnalyticsCommandArgs>
+{
+  command = 'prompt';
+  describe = 'Prompts the user to set the analytics gathering status interactively.';
+
+  async run({ global }: Options<AnalyticsCommandArgs>): Promise<void> {
+    if (global) {
+      await promptGlobalAnalytics(true);
+    } else {
+      await promptProjectAnalytics(true);
+    }
+  }
+}

--- a/tests/legacy-cli/e2e/tests/commands/help/help-json.ts
+++ b/tests/legacy-cli/e2e/tests/commands/help/help-json.ts
@@ -3,12 +3,13 @@ import { silentNg } from '../../../utils/process';
 export default async function () {
   // This test is use as a sanity check.
   const addHelpOutputSnapshot = JSON.stringify({
-    'name': 'analytics',
-    'command': 'ng analytics <setting>',
-    'shortDescription': 'Configures the gathering of Angular CLI usage metrics.',
-    'longDescriptionRelativePath': '@angular/cli/src/commands/analytics/long-description.md',
+    'name': 'config',
+    'command': 'ng config <json-path> [value]',
+    'shortDescription':
+      'Retrieves or sets Angular configuration values in the angular.json file for the workspace.',
+    'longDescriptionRelativePath': '@angular/cli/src/commands/config/long-description.md',
     'longDescription':
-      'The value of `setting` is one of the following.\n\n- `on`: Enables analytics gathering and reporting for the user.\n- `off`: Disables analytics gathering and reporting for the user.\n- `ci`: Enables analytics and configures reporting for use with Continuous Integration,\n  which uses a common CI user.\n- `prompt`: Prompts the user to set the status interactively.\n\nFor further details, see [Gathering an Viewing CLI Usage Analytics](cli/usage-analytics-gathering).\n',
+      'A workspace has a single CLI configuration file, `angular.json`, at the top level.\nThe `projects` object contains a configuration object for each project in the workspace.\n\nYou can edit the configuration directly in a code editor,\nor indirectly on the command line using this command.\n\nThe configurable property names match command option names,\nexcept that in the configuration file, all names must use camelCase,\nwhile on the command line options can be given dash-case.\n\nFor further details, see [Workspace Configuration](guide/workspace-config).\n\nFor configuration of CLI usage analytics, see [Gathering an Viewing CLI Usage Analytics](cli/usage-analytics-gathering).\n',
     'options': [
       {
         'name': 'global',
@@ -23,21 +24,27 @@ export default async function () {
         'description': 'Shows a help message for this command in the console.',
       },
       {
-        'name': 'setting',
+        'name': 'json-path',
         'type': 'string',
-        'enum': ['on', 'off', 'ci', 'prompt'],
-        'description': 'Directly enables or disables all usage analytics for the user.',
+        'description':
+          'The configuration key to set or query, in JSON path format. For example: "a[3].foo.bar[2]". If no new value is provided, returns the current value of this key.',
         'positional': 0,
+      },
+      {
+        'name': 'value',
+        'type': 'string',
+        'description': 'If provided, a new value for the given configuration key.',
+        'positional': 1,
       },
     ],
   });
 
-  const { stdout } = await silentNg('analytics', '--help', '--json-help');
+  const { stdout } = await silentNg('config', '--help', '--json-help');
   const output = JSON.stringify(JSON.parse(stdout.trim()));
 
   if (output !== addHelpOutputSnapshot) {
     throw new Error(
-      `ng analytics JSON help output didn\'t match snapshot.\n\nExpected "${output}" to be "${addHelpOutputSnapshot}".`,
+      `ng config JSON help output didn\'t match snapshot.\n\nExpected "${output}" to be "${addHelpOutputSnapshot}".`,
     );
   }
 

--- a/tests/legacy-cli/e2e/tests/commands/help/help-json.ts
+++ b/tests/legacy-cli/e2e/tests/commands/help/help-json.ts
@@ -4,30 +4,29 @@ export default async function () {
   // This test is use as a sanity check.
   const addHelpOutputSnapshot = JSON.stringify({
     'name': 'analytics',
-    'command': 'ng analytics <setting-or-project>',
+    'command': 'ng analytics <setting>',
     'shortDescription': 'Configures the gathering of Angular CLI usage metrics.',
     'longDescriptionRelativePath': '@angular/cli/src/commands/analytics/long-description.md',
     'longDescription':
-      'The value of `setting-or-project` is one of the following.\n\n- `on`: Enables analytics gathering and reporting for the user.\n- `off`: Disables analytics gathering and reporting for the user.\n- `ci`: Enables analytics and configures reporting for use with Continuous Integration,\n  which uses a common CI user.\n- `prompt`: Prompts the user to set the status interactively.\n- `project`: Sets the default status for the project to the `project-setting` value, which can be any of the other values. The `project-setting` argument is ignored for all other values of `setting_or_project`.\n\nFor further details, see [Gathering an Viewing CLI Usage Analytics](cli/usage-analytics-gathering).\n',
+      'The value of `setting` is one of the following.\n\n- `on`: Enables analytics gathering and reporting for the user.\n- `off`: Disables analytics gathering and reporting for the user.\n- `ci`: Enables analytics and configures reporting for use with Continuous Integration,\n  which uses a common CI user.\n- `prompt`: Prompts the user to set the status interactively.\n\nFor further details, see [Gathering an Viewing CLI Usage Analytics](cli/usage-analytics-gathering).\n',
     'options': [
+      {
+        'name': 'global',
+        'type': 'boolean',
+        'aliases': ['g'],
+        'default': false,
+        'description': "Access the global configuration in the caller's home directory.",
+      },
       {
         'name': 'help',
         'type': 'boolean',
         'description': 'Shows a help message for this command in the console.',
       },
       {
-        'name': 'project-setting',
-        'type': 'string',
-        'enum': ['on', 'off', 'prompt'],
-        'description': 'Sets the default analytics enablement status for the project.',
-        'positional': 1,
-      },
-      {
-        'name': 'setting-or-project',
+        'name': 'setting',
         'type': 'string',
         'enum': ['on', 'off', 'ci', 'prompt'],
-        'description':
-          'Directly enables or disables all usage analytics for the user, or prompts the user to set the status interactively, or sets the default status for the project.',
+        'description': 'Directly enables or disables all usage analytics for the user.',
         'positional': 0,
       },
     ],

--- a/tests/legacy-cli/e2e/tests/misc/ask-analytics-command.ts
+++ b/tests/legacy-cli/e2e/tests/misc/ask-analytics-command.ts
@@ -1,13 +1,12 @@
 import { execWithEnv, killAllProcesses, waitForAnyProcessOutputToMatch } from '../../utils/process';
 import { expectToFail } from '../../utils/utils';
 
-export default async function() {
+export default async function () {
   try {
     // Execute a command with TTY force enabled
-    const execution = execWithEnv('ng', ['version'], {
+    execWithEnv('ng', ['version'], {
       ...process.env,
       NG_FORCE_TTY: '1',
-      NG_CLI_ANALYTICS: 'ci',
     });
 
     // Check if the prompt is shown
@@ -18,7 +17,7 @@ export default async function() {
 
   try {
     // Execute a command with TTY force enabled
-    const execution = execWithEnv('ng', ['version'], {
+    execWithEnv('ng', ['version'], {
       ...process.env,
       NG_FORCE_TTY: '1',
       NG_CLI_ANALYTICS: 'false',
@@ -35,10 +34,9 @@ export default async function() {
   // Should not show a prompt when using update
   try {
     // Execute a command with TTY force enabled
-    const execution = execWithEnv('ng', ['update'], {
+    execWithEnv('ng', ['update'], {
       ...process.env,
       NG_FORCE_TTY: '1',
-      NG_CLI_ANALYTICS: 'ci',
     });
 
     // Check if the prompt is shown


### PR DESCRIPTION
With this change we add a `--global` option to `ng analytics` command.

BREAKING CHANGE:

Several changes to the `ng analytics` command syntax.

- `ng analytics project <setting>` has been replaced with `ng analytics <setting>`
- `ng analytics <setting>` has been replaced with `ng analytics <setting> --global`
---

feat(@angular/cli): add `ng analytics info` command

With this change we add a subcommand to `ng analytics`. This command can be used tp display analytics gathering and reporting configuration.

Example:
```
$ ng analytics info                              
Global setting: off
Local setting: on
Effective status: disabled
```