### PR TITLE
refactor(@angular/cli): always use posix separator in `longDescriptionRelativePath`

### DIFF
--- a/packages/angular/cli/src/command-builder/command-module.ts
+++ b/packages/angular/cli/src/command-builder/command-module.ts
@@ -89,10 +89,9 @@ export abstract class CommandModule<T extends {} = {}> implements CommandModuleI
           describe: this.describe,
           ...(this.longDescriptionPath
             ? {
-                longDescriptionRelativePath: path.relative(
-                  path.join(__dirname, '../../../../'),
-                  this.longDescriptionPath,
-                ),
+                longDescriptionRelativePath: path
+                  .relative(path.join(__dirname, '../../../../'), this.longDescriptionPath)
+                  .replace(/\\/g, path.posix.sep),
                 longDescription: readFileSync(this.longDescriptionPath, 'utf8'),
               }
             : {}),


### PR DESCRIPTION

Needed for consistency that will fix a Windows CI failure