### PR TITLE
refactor(@angular/cli): rename json help `shortDescription` to `description`

### DIFF
--- a/packages/angular/cli/src/command-builder/utilities/json-help.ts
+++ b/packages/angular/cli/src/command-builder/utilities/json-help.ts
@@ -11,7 +11,7 @@ import { FullDescribe } from '../command-module';
 
 export interface JsonHelp {
   name: string;
-  shortDescription?: string;
+  description?: string;
   command: string;
   longDescription?: string;
   longDescriptionRelativePath?: string;
@@ -115,18 +115,18 @@ export function jsonHelpUsage(): string {
     try {
       const {
         longDescription,
-        describe: shortDescription,
+        describe: description,
         longDescriptionRelativePath,
       } = JSON.parse(rawDescription) as FullDescribe;
 
       return {
-        shortDescription,
+        description,
         longDescriptionRelativePath,
         longDescription,
       };
     } catch {
       return {
-        shortDescription: rawDescription,
+        description: rawDescription,
       };
     }
   };

--- a/tests/legacy-cli/e2e/tests/commands/help/help-json.ts
+++ b/tests/legacy-cli/e2e/tests/commands/help/help-json.ts
@@ -5,7 +5,7 @@ export default async function () {
   const addHelpOutputSnapshot = JSON.stringify({
     'name': 'analytics',
     'command': 'ng analytics <setting-or-project>',
-    'shortDescription': 'Configures the gathering of Angular CLI usage metrics.',
+    'description': 'Configures the gathering of Angular CLI usage metrics.',
     'longDescriptionRelativePath': '@angular/cli/src/commands/analytics/long-description.md',
     'longDescription':
       'The value of `setting-or-project` is one of the following.\n\n- `on`: Enables analytics gathering and reporting for the user.\n- `off`: Disables analytics gathering and reporting for the user.\n- `ci`: Enables analytics and configures reporting for use with Continuous Integration,\n  which uses a common CI user.\n- `prompt`: Prompts the user to set the status interactively.\n- `project`: Sets the default status for the project to the `project-setting` value, which can be any of the other values. The `project-setting` argument is ignored for all other values of `setting_or_project`.\n\nFor further details, see [Gathering an Viewing CLI Usage Analytics](cli/usage-analytics-gathering).\n',


### PR DESCRIPTION


This is needed to avoid amending a number of AIO tests.