### PR TITLE
refactor(@angular/cli): replace `longDescription` line endings with `\n`

### DIFF
--- a/packages/angular/cli/src/command-builder/command-module.ts
+++ b/packages/angular/cli/src/command-builder/command-module.ts
@@ -92,7 +92,10 @@ export abstract class CommandModule<T extends {} = {}> implements CommandModuleI
                 longDescriptionRelativePath: path
                   .relative(path.join(__dirname, '../../../../'), this.longDescriptionPath)
                   .replace(/\\/g, path.posix.sep),
-                longDescription: readFileSync(this.longDescriptionPath, 'utf8'),
+                longDescription: readFileSync(this.longDescriptionPath, 'utf8').replace(
+                  /\r\n/g,
+                  '\n',
+                ),
               }
             : {}),
         };


### PR DESCRIPTION
Needed to fix Windows CI.

Successful run: https://app.circleci.com/pipelines/github/angular/angular-cli/21152/workflows/06f9c9c2-ae91-454d-939e-ee50b7919cee/jobs/292323/parallel-runs/0?filterBy=ALL