### PR TITLE
refactor(@angular-devkit/build-angular): remove deprecated `NG_BUILD_CACHE` environment variable

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/environment-options.ts
+++ b/packages/angular_devkit/build_angular/src/utils/environment-options.ts
@@ -6,8 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { colors } from './color';
-
 function isDisabled(variable: string): boolean {
   return variable === '0' || variable.toLowerCase() === 'false';
 }
@@ -77,21 +75,3 @@ export const allowMinify = debugOptimize.minify;
  */
 const maxWorkersVariable = process.env['NG_BUILD_MAX_WORKERS'];
 export const maxWorkers = isPresent(maxWorkersVariable) ? +maxWorkersVariable : 4;
-
-// Build cache
-const cacheVariable = process.env['NG_BUILD_CACHE'];
-export const cachingDisabled = (() => {
-  if (!isPresent(cacheVariable)) {
-    return null;
-  }
-
-  // eslint-disable-next-line no-console
-  console.warn(
-    colors.yellow(
-      `Warning: 'NG_BUILD_CACHE' environment variable support will be removed in version 14.\n` +
-        `Configure 'cli.cache' in the workspace configuration instead.`,
-    ),
-  );
-
-  return isDisabled(cacheVariable);
-})();

--- a/packages/angular_devkit/build_angular/src/utils/normalize-cache.ts
+++ b/packages/angular_devkit/build_angular/src/utils/normalize-cache.ts
@@ -8,7 +8,6 @@
 
 import { json } from '@angular-devkit/core';
 import { join, resolve } from 'path';
-import { cachingDisabled } from './environment-options';
 import { VERSION } from './package-version';
 
 export interface NormalizedCachedOptions {
@@ -39,10 +38,6 @@ export function normalizeCacheOptions(
   const isCI = process.env['CI'] === '1' || process.env['CI']?.toLowerCase() === 'true';
 
   let cacheEnabled = enabled;
-  if (cachingDisabled !== null) {
-    cacheEnabled = !cachingDisabled;
-  }
-
   if (cacheEnabled) {
     switch (environment) {
       case 'ci':


### PR DESCRIPTION

BREAKING CHANGE:

`NG_BUILD_CACHE` environment variable has been removed. `cli.cache` in the workspace configuration should be used instead.