### PR TITLE
refactor(@angular/cli): remove `hasAnalyticsConfig` analytics logic

### DIFF
--- a/packages/angular/cli/bin/postinstall/analytics-prompt.js
+++ b/packages/angular/cli/bin/postinstall/analytics-prompt.js
@@ -17,7 +17,7 @@ try {
   var analytics = require('../../src/analytics/analytics');
 
   analytics
-    .hasAnalyticsConfig('global')
+    .getAnalytics('global')
     .then((hasGlobalConfig) => {
       if (!hasGlobalConfig) {
         return analytics.promptAnalytics(true /** global */);


### PR DESCRIPTION
With this change we clean up further the analytics code and re-use the `getAnalytics` to determine if the config is set or not.

Also, this change inclused a refactor to the `createAnalytics` method to make it more readable.