### PR TITLE
fix(@angular/cli): print entire config when no positional args are provided to `ng config`

### DIFF
--- a/packages/angular/cli/src/commands/config/cli.ts
+++ b/packages/angular/cli/src/commands/config/cli.ts
@@ -20,7 +20,7 @@ import { getWorkspaceRaw, validateWorkspace } from '../../utilities/config';
 import { JSONFile, parseJson } from '../../utilities/json-file';
 
 interface ConfigCommandArgs {
-  'json-path': string;
+  'json-path'?: string;
   value?: string;
   global?: boolean;
 }
@@ -29,7 +29,7 @@ export class ConfigCommandModule
   extends CommandModule<ConfigCommandArgs>
   implements CommandModuleImplementation<ConfigCommandArgs>
 {
-  command = 'config <json-path> [value]';
+  command = 'config [json-path] [value]';
   describe =
     'Retrieves or sets Angular configuration values in the angular.json file for the workspace.';
   longDescriptionPath = join(__dirname, 'long-description.md');
@@ -41,7 +41,6 @@ export class ConfigCommandModule
           `The configuration key to set or query, in JSON path format. ` +
           `For example: "a[3].foo.bar[2]". If no new value is provided, returns the current value of this key.`,
         type: 'string',
-        demandOption: true,
       })
       .positional('value', {
         description: 'If provided, a new value for the given configuration key.',

--- a/tests/legacy-cli/e2e/tests/commands/config/config-get.ts
+++ b/tests/legacy-cli/e2e/tests/commands/config/config-get.ts
@@ -1,35 +1,44 @@
 import { ng } from '../../../utils/process';
 import { expectToFail } from '../../../utils/utils';
 
+export default async function () {
+  await expectToFail(() => ng('config', 'schematics.@schematics/angular.component.inlineStyle'));
+  await ng('config', 'schematics.@schematics/angular.component.inlineStyle', 'false');
+  const { stdout } = await ng('config', 'schematics.@schematics/angular.component.inlineStyle');
+  if (!stdout.match(/false\n?/)) {
+    throw new Error(`Expected "false", received "${JSON.stringify(stdout)}".`);
+  }
 
-export default function() {
-  return Promise.resolve()
-    .then(() => expectToFail(() => ng('config', 'schematics.@schematics/angular.component.inlineStyle')))
-    .then(() => ng('config', 'schematics.@schematics/angular.component.inlineStyle', 'false'))
-    .then(() => ng('config', 'schematics.@schematics/angular.component.inlineStyle'))
-    .then(({ stdout }) => {
-      if (!stdout.match(/false\n?/)) {
-        throw new Error(`Expected "false", received "${JSON.stringify(stdout)}".`);
-      }
-    })
-    .then(() => ng('config', 'schematics.@schematics/angular.component.inlineStyle', 'true'))
-    .then(() => ng('config', 'schematics.@schematics/angular.component.inlineStyle'))
-    .then(({ stdout }) => {
-      if (!stdout.match(/true\n?/)) {
-        throw new Error(`Expected "true", received "${JSON.stringify(stdout)}".`);
-      }
-    })
-    .then(() => ng('config', 'schematics.@schematics/angular.component.inlineStyle', 'false'))
-    .then(() => ng('config', `projects.test-project.architect.build.options.assets[0]`))
-    .then(({ stdout }) => {
-      if (!stdout.includes('src/favicon.ico')) {
-        throw new Error(`Expected "src/favicon.ico", received "${JSON.stringify(stdout)}".`);
-      }
-    })
-    .then(() => ng('config', `projects["test-project"].architect.build.options.assets[0]`))
-    .then(({ stdout }) => {
-      if (!stdout.includes('src/favicon.ico')) {
-        throw new Error(`Expected "src/favicon.ico", received "${JSON.stringify(stdout)}".`);
-      }
-    });
+  await ng('config', 'schematics.@schematics/angular.component.inlineStyle', 'true');
+  const { stdout: stdout1 } = await ng(
+    'config',
+    'schematics.@schematics/angular.component.inlineStyle',
+  );
+  if (!stdout1.match(/true\n?/)) {
+    throw new Error(`Expected "true", received "${JSON.stringify(stdout)}".`);
+  }
+
+  await ng('config', 'schematics.@schematics/angular.component.inlineStyle', 'false');
+  const { stdout: stdout2 } = await ng(
+    'config',
+    `projects.test-project.architect.build.options.assets[0]`,
+  );
+  if (!stdout2.includes('src/favicon.ico')) {
+    throw new Error(`Expected "src/favicon.ico", received "${JSON.stringify(stdout)}".`);
+  }
+
+  const { stdout: stdout3 } = await ng(
+    'config',
+    `projects["test-project"].architect.build.options.assets[0]`,
+  );
+
+  if (!stdout3.includes('src/favicon.ico')) {
+    throw new Error(`Expected "src/favicon.ico", received "${JSON.stringify(stdout)}".`);
+  }
+
+  // should print all config when no positional args are provided.
+  const { stdout: stdout4 } = await ng('config');
+  if (!stdout4.includes('$schema')) {
+    throw new Error(`Expected to contain "$schema", received "${JSON.stringify(stdout)}".`);
+  }
 }

--- a/tests/legacy-cli/e2e/tests/commands/help/help-json.ts
+++ b/tests/legacy-cli/e2e/tests/commands/help/help-json.ts
@@ -4,7 +4,7 @@ export default async function () {
   // This test is use as a sanity check.
   const addHelpOutputSnapshot = JSON.stringify({
     'name': 'config',
-    'command': 'ng config <json-path> [value]',
+    'command': 'ng config [json-path] [value]',
     'shortDescription':
       'Retrieves or sets Angular configuration values in the angular.json file for the workspace.',
     'longDescriptionRelativePath': '@angular/cli/src/commands/config/long-description.md',


### PR DESCRIPTION
This fixes a regression were when no positional args are provided to `ng config` the entire config file should to be printed in the console.