### PR TITLE
fix(@schematics/angular): Consolidated setup with a single `beforeEach()`

### DIFF
--- a/packages/schematics/angular/component/files/__name@dasherize@if-flat__/__name@dasherize__.__type@dasherize__.spec.ts.template
+++ b/packages/schematics/angular/component/files/__name@dasherize@if-flat__/__name@dasherize__.__type@dasherize__.spec.ts.template
@@ -11,9 +11,7 @@ describe('<%= classify(name) %><%= classify(type) %>', () => {
       declarations: [ <%= classify(name) %><%= classify(type) %> ]
     })
     .compileComponents();
-  });
 
-  beforeEach(() => {
     fixture = TestBed.createComponent(<%= classify(name) %><%= classify(type) %>);
     component = fixture.componentInstance;
     fixture.detectChanges();


### PR DESCRIPTION
Since f463c8403547 we use native `async`/`await` and thus we do not need
to split setup in two `beforeEach()`

This would avoid confusion for newcomers as seen in https://stackoverflow.com/questions/52170948/why-component-generated-by-ng-cli-has-the-spec-file-with-2-beforeeach-method