### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/lib/bootstrap-local.js
+++ b/lib/bootstrap-local.js
@@ -109,7 +109,7 @@ if (!__dirname.match(new RegExp(`\\${path.sep}node_modules\\${path.sep}`))) {
     } else {
       const match = Object.keys(packages).find((pkgName) => request.startsWith(pkgName + '/'));
       if (match) {
-        const p = path.join(packages[match].root, request.substr(match.length));
+        const p = path.join(packages[match].root, request.slice(match.length));
         return oldResolve.call(this, p, parent);
       } else if (!resolved) {
         if (exception) {

--- a/lib/packages.ts
+++ b/lib/packages.ts
@@ -211,7 +211,7 @@ export const packages: PackageMap = packageJsonPaths
     const experimental = !!packageJson.private || !!packageJson.experimental;
 
     packages[name] = {
-      build: path.join(distRoot, pkgRoot.substr(path.dirname(__dirname).length)),
+      build: path.join(distRoot, pkgRoot.slice(path.dirname(__dirname).length)),
       dist: path.join(distRoot, name),
       root: pkgRoot,
       relative: path.relative(path.dirname(__dirname), pkgRoot),

--- a/packages/angular_devkit/build_angular/src/utils/process-bundle.ts
+++ b/packages/angular_devkit/build_angular/src/utils/process-bundle.ts
@@ -156,7 +156,7 @@ export async function inlineLocales(options: InlineOptions) {
       // Same errors will contain the full content of the file as the error message
       // Which makes it hard to find the actual error message.
       const index = error.message.indexOf(')\n');
-      const msg = index !== -1 ? error.message.substr(0, index + 1) : error.message;
+      const msg = index !== -1 ? error.message.slice(0, index + 1) : error.message;
       throw new Error(`${msg}\nAn error occurred inlining file "${options.filename}"`);
     }
   }

--- a/packages/angular_devkit/build_angular/src/webpack/configs/dev-server.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/dev-server.ts
@@ -111,7 +111,7 @@ export function buildServePath(
   }
 
   if (servePath.endsWith('/')) {
-    servePath = servePath.substr(0, servePath.length - 1);
+    servePath = servePath.slice(0, -1);
   }
 
   if (!servePath.startsWith('/')) {

--- a/packages/angular_devkit/build_angular/src/webpack/configs/styles.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/styles.ts
@@ -169,7 +169,7 @@ export function getStylesConfig(wco: WebpackConfigOptions): Configuration {
         : undefined,
       plugins: [
         postcssImports({
-          resolve: (url: string) => (url.startsWith('~') ? url.substr(1) : url),
+          resolve: (url: string) => (url.startsWith('~') ? url.slice(1) : url),
           load: (filename: string) => {
             return new Promise<string>((resolve, reject) => {
               loader.fs.readFile(filename, (err: Error, data: Buffer) => {

--- a/packages/angular_devkit/build_angular/src/webpack/plugins/postcss-cli-resources.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/plugins/postcss-cli-resources.ts
@@ -77,7 +77,7 @@ export default function (options?: PostcssCliResourcesOptions): Plugin {
     // If starts with a caret, remove and return remainder
     // this supports bypassing asset processing
     if (inputUrl.startsWith('^')) {
-      return inputUrl.substr(1);
+      return inputUrl.slice(1);
     }
 
     const cacheKey = path.resolve(context, inputUrl);
@@ -87,7 +87,7 @@ export default function (options?: PostcssCliResourcesOptions): Plugin {
     }
 
     if (inputUrl.startsWith('~')) {
-      inputUrl = inputUrl.substr(1);
+      inputUrl = inputUrl.slice(1);
     }
 
     const { pathname, hash, search } = url.parse(inputUrl.replace(/\\/g, '/'));

--- a/packages/angular_devkit/core/src/json/parser.ts
+++ b/packages/angular_devkit/core/src/json/parser.ts
@@ -587,7 +587,7 @@ function _readIdentifier(
         kind: 'identifier',
         start,
         end: context.position,
-        text: context.original.substr(start.offset, context.position.offset),
+        text: context.original.slice(start.offset, start.offset + context.position.offset),
         value,
         comments,
       };
@@ -894,8 +894,8 @@ export function parseJsonAst(input: string, mode = JsonParseMode.Default): JsonA
 
   const ast = _readValue(context);
   if (context.position.offset < input.length) {
-    const rest = input.substr(context.position.offset);
-    const i = rest.length > 20 ? rest.substr(0, 20) + '...' : rest;
+    const rest = input.slice(context.position.offset);
+    const i = rest.length > 20 ? rest.slice(0, 20) + '...' : rest;
     throw new Error(
       `Expected end of file, got "${i}" at ` +
         `${context.position.line}:${context.position.character}.`,

--- a/packages/angular_devkit/core/src/utils/strings.ts
+++ b/packages/angular_devkit/core/src/utils/strings.ts
@@ -129,7 +129,7 @@ export function underscore(str: string): string {
  @return {String} The capitalized string.
  */
 export function capitalize(str: string): string {
-  return str.charAt(0).toUpperCase() + str.substr(1);
+  return str.charAt(0).toUpperCase() + str.slice(1);
 }
 
 /**

--- a/packages/angular_devkit/core/src/virtual-fs/path.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/path.ts
@@ -75,7 +75,7 @@ export function extname(path: Path): string {
   if (i < 1) {
     return '';
   } else {
-    return base.substr(i);
+    return base.slice(i);
   }
 }
 
@@ -87,7 +87,7 @@ export function basename(path: Path): PathFragment {
   if (i == -1) {
     return fragment(path);
   } else {
-    return fragment(path.substr(path.lastIndexOf(NormalizedSep) + 1));
+    return fragment(path.slice(path.lastIndexOf(NormalizedSep) + 1));
   }
 }
 
@@ -102,7 +102,7 @@ export function dirname(path: Path): Path {
 
   const endIndex = index === 0 ? 1 : index; // case of file under root: '/file'
 
-  return normalize(path.substr(0, endIndex));
+  return normalize(path.slice(0, endIndex));
 }
 
 /**
@@ -233,7 +233,7 @@ export function noCacheNormalize(path: string): Path {
   // Match absolute windows path.
   const original = path;
   if (path.match(/^[A-Z]:[/\\]/i)) {
-    path = '\\' + path[0] + '\\' + path.substr(3);
+    path = '\\' + path[0] + '\\' + path.slice(3);
   }
 
   // We convert Windows paths as well here.

--- a/packages/angular_devkit/core/src/workspace/json/utilities.ts
+++ b/packages/angular_devkit/core/src/workspace/json/utilities.ts
@@ -287,7 +287,7 @@ function create(
       }
 
       for (const key of cache.keys()) {
-        const relativeKey = key.substr(path.length + 1);
+        const relativeKey = key.slice(path.length + 1);
         if (relativeKey.length > 0 && !relativeKey.includes('/')) {
           keys.push(`${unescapeKey(relativeKey)}`);
         }

--- a/packages/angular_devkit/schematics/src/rules/move.ts
+++ b/packages/angular_devkit/schematics/src/rules/move.ts
@@ -30,7 +30,7 @@ export function move(from: string, to?: string): Rule {
     } else {
       // fromPath is a directory
       tree.getDir(fromPath).visit((path) => {
-        tree.rename(path, join(toPath, path.substr(fromPath.length)));
+        tree.rename(path, join(toPath, path.slice(fromPath.length)));
       });
     }
 

--- a/packages/angular_devkit/schematics/tools/file-system-engine-host-base.ts
+++ b/packages/angular_devkit/schematics/tools/file-system-engine-host-base.ts
@@ -217,9 +217,9 @@ export abstract class FileSystemEngineHostBase implements FileSystemEngineHost {
 
     if (partialDesc.extends) {
       const index = partialDesc.extends.indexOf(':');
-      const collectionName = index !== -1 ? partialDesc.extends.substr(0, index) : null;
+      const collectionName = index !== -1 ? partialDesc.extends.slice(0, index) : null;
       const schematicName =
-        index === -1 ? partialDesc.extends : partialDesc.extends.substr(index + 1);
+        index === -1 ? partialDesc.extends : partialDesc.extends.slice(index + 1);
 
       if (collectionName !== null) {
         const extendCollection = this.createCollectionDescription(collectionName);

--- a/packages/angular_devkit/schematics_cli/bin/schematics.ts
+++ b/packages/angular_devkit/schematics_cli/bin/schematics.ts
@@ -197,7 +197,7 @@ export async function main({
   workflow.reporter.subscribe((event) => {
     nothingDone = false;
     // Strip leading slash to prevent confusion.
-    const eventPath = event.path.startsWith('/') ? event.path.substr(1) : event.path;
+    const eventPath = event.path.startsWith('/') ? event.path.slice(1) : event.path;
 
     switch (event.kind) {
       case 'error':
@@ -216,7 +216,7 @@ export async function main({
         loggingQueue.push(`${colors.yellow('DELETE')} ${eventPath}`);
         break;
       case 'rename':
-        const eventToPath = event.to.startsWith('/') ? event.to.substr(1) : event.to;
+        const eventToPath = event.to.startsWith('/') ? event.to.slice(1) : event.to;
         loggingQueue.push(`${colors.blue('RENAME')} ${eventPath} => ${eventToPath}`);
         break;
     }

--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -271,7 +271,7 @@ export default function (options: ApplicationOptions): Rule {
     const isRootApp = options.projectRoot !== undefined;
 
     // If scoped project (i.e. "@foo/bar"), convert dir to "foo/bar".
-    let folderName = options.name.startsWith('@') ? options.name.substr(1) : options.name;
+    let folderName = options.name.startsWith('@') ? options.name.slice(1) : options.name;
     if (/[A-Z]/.test(folderName)) {
       folderName = strings.dasherize(folderName);
     }

--- a/packages/schematics/angular/library/index.ts
+++ b/packages/schematics/angular/library/index.ts
@@ -135,7 +135,7 @@ export default function (options: LibraryOptions): Rule {
     const workspace = await getWorkspace(host);
     const newProjectRoot = (workspace.extensions.newProjectRoot as string | undefined) || '';
 
-    let folderName = packageName.startsWith('@') ? packageName.substr(1) : packageName;
+    let folderName = packageName.startsWith('@') ? packageName.slice(1) : packageName;
     if (/[A-Z]/.test(folderName)) {
       folderName = strings.dasherize(folderName);
     }

--- a/packages/schematics/angular/ng-new/index.ts
+++ b/packages/schematics/angular/ng-new/index.ts
@@ -30,7 +30,7 @@ import { Schema as NgNewOptions } from './schema';
 export default function (options: NgNewOptions): Rule {
   if (!options.directory) {
     // If scoped project (i.e. "@foo/bar"), convert directory to "foo/bar".
-    options.directory = options.name.startsWith('@') ? options.name.substr(1) : options.name;
+    options.directory = options.name.startsWith('@') ? options.name.slice(1) : options.name;
   }
 
   const workspaceOptions: WorkspaceOptions = {

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -24,7 +24,7 @@ const gitIgnore = gitIgnoreFiles
   .filter((line) => !line.match(/^\s*$/));
 const gitIgnoreExcept = gitIgnoreFiles
   .filter((line) => line.startsWith('!'))
-  .map((line) => line.substr(1));
+  .map((line) => line.slice(1));
 
 function _gitIgnoreMatch(p: string): boolean {
   p = path.relative(path.dirname(__dirname), p);


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.