### PR TITLE
fix(@ngtools/webpack): update peer dependency to reflect TS 4.6 support

### DIFF
--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -81,7 +81,7 @@
     "ng-packagr": "^14.0.0 || ^14.0.0-next",
     "protractor": "^7.0.0",
     "tailwindcss": "^2.0.0 || ^3.0.0",
-    "typescript": "^4.6.2"
+    "typescript": "~4.6.2"
   },
   "peerDependenciesMeta": {
     "@angular/localize": {

--- a/packages/ngtools/webpack/package.json
+++ b/packages/ngtools/webpack/package.json
@@ -23,7 +23,7 @@
   "dependencies": {},
   "peerDependencies": {
     "@angular/compiler-cli": "^14.0.0 || ^14.0.0-next",
-    "typescript": ">=4.4.3 <4.6",
+    "typescript": "~4.6.2",
     "webpack": "^5.30.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Updates the peer dependency to reflect the TS 4.6 support, avoiding
warnings like:

```
warning "@angular-devkit/build-angular > @ngtools/webpack@14.0.0-next.6" has incorrect peer dependency "typescript@>=4.4.3 <4.6".

```

TS 4.4 and 4.5 have been removed in https://github.com/angular/angular-cli/commit/7fa3e6587955d0638929758d3c257392c242c796