### PR TITLE
refactor(@angular-devkit/build-angular): remove types for `@discoveryjs/json-ext`

### DIFF
--- a/packages/angular_devkit/build_angular/src/typings.d.ts
+++ b/packages/angular_devkit/build_angular/src/typings.d.ts
@@ -6,10 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-declare module '@discoveryjs/json-ext' {
-  export function stringifyStream(value: unknown): import('stream').Readable;
-}
-
 declare module '@babel/helper-annotate-as-pure' {
   export default function annotateAsPure(
     pathOrNode: import('@babel/types').Node | { node: import('@babel/types').Node },


### PR DESCRIPTION


This package now ships TypeScript declaration files.