### PR TITLE
refactor(@angular-devkit/core): deprecate unused exception classes

### DIFF
--- a/goldens/public-api/angular_devkit/core/index.md
+++ b/goldens/public-api/angular_devkit/core/index.md
@@ -189,7 +189,7 @@ export class CircularDependencyFoundException extends BaseException {
 // @public
 function classify(str: string): string;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export class ContentHasMutatedException extends BaseException {
     constructor(path: string);
 }
@@ -532,7 +532,7 @@ export class InvalidPathException extends BaseException {
     constructor(path: string);
 }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export class InvalidUpdateRecordException extends BaseException {
     constructor();
 }
@@ -1034,7 +1034,7 @@ class LoggingAnalytics implements Analytics {
 // @public (undocumented)
 type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'fatal';
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export class MergeConflictException extends BaseException {
     constructor(path: string);
 }
@@ -2013,7 +2013,7 @@ function trimNewlines(strings: TemplateStringsArray, ...values: any[]): string;
 // @public
 function underscore(str: string): string;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export class UnimplementedException extends BaseException {
     constructor();
 }
@@ -2023,7 +2023,7 @@ export class UnknownException extends BaseException {
     constructor(message: string);
 }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export class UnsupportedPlatformException extends BaseException {
     constructor();
 }

--- a/packages/angular_devkit/core/src/exception.ts
+++ b/packages/angular_devkit/core/src/exception.ts
@@ -39,28 +39,47 @@ export class PathIsFileException extends BaseException {
     super(`Path "${path}" is a file.`);
   }
 }
+
+/**
+ * @deprecated since version 14. Use the same symbol from `@angular-devkit/schematics`.
+ */
 export class ContentHasMutatedException extends BaseException {
   constructor(path: string) {
     super(`Content at path "${path}" has changed between the start and the end of an update.`);
   }
 }
+
+/**
+ * @deprecated since version 14. Use the same symbol from `@angular-devkit/schematics`.
+ */
+
 export class InvalidUpdateRecordException extends BaseException {
   constructor() {
     super(`Invalid record instance.`);
   }
 }
+
+/**
+ * @deprecated since version 14. Use the same symbol from `@angular-devkit/schematics`.
+ */
 export class MergeConflictException extends BaseException {
   constructor(path: string) {
     super(`A merge conflicted on path "${path}".`);
   }
 }
 
+/**
+ * @deprecated since version 14. Create a custom exception implementation instead.
+ */
 export class UnimplementedException extends BaseException {
   constructor() {
     super('This function is unimplemented.');
   }
 }
 
+/**
+ * @deprecated since version 14. Create a custom exception implementation instead.
+ */
 export class UnsupportedPlatformException extends BaseException {
   constructor() {
     super('This platform is not supported by this code path.');

--- a/packages/angular_devkit/core/src/exception/index.ts
+++ b/packages/angular_devkit/core/src/exception/index.ts
@@ -1,9 +1,0 @@
-/**
- * @license
- * Copyright Google LLC All Rights Reserved.
- *
- * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
- */
-
-export * from './exception';

--- a/packages/angular_devkit/core/src/experimental/jobs/create-job-handler.ts
+++ b/packages/angular_devkit/core/src/experimental/jobs/create-job-handler.ts
@@ -8,7 +8,7 @@
 
 import { Observable, Observer, Subject, Subscription, from, isObservable, of } from 'rxjs';
 import { switchMap, tap } from 'rxjs/operators';
-import { BaseException } from '../../exception/index';
+import { BaseException } from '../../exception';
 import { JsonValue } from '../../json/index';
 import { LoggerApi } from '../../logger';
 import { isPromise } from '../../utils/index';
@@ -34,7 +34,7 @@ export class ChannelAlreadyExistException extends BaseException {
 export interface SimpleJobHandlerContext<
   A extends JsonValue,
   I extends JsonValue,
-  O extends JsonValue
+  O extends JsonValue,
 > extends JobHandlerContext<A, I, O> {
   createChannel: (name: string) => Observer<JsonValue>;
   input: Observable<I>;

--- a/packages/angular_devkit/core/src/experimental/jobs/exception.ts
+++ b/packages/angular_devkit/core/src/experimental/jobs/exception.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { BaseException } from '../../exception/index';
+import { BaseException } from '../../exception';
 import { JobName } from './api';
 
 export class JobNameAlreadyRegisteredException extends BaseException {

--- a/packages/angular_devkit/core/src/index.ts
+++ b/packages/angular_devkit/core/src/index.ts
@@ -12,7 +12,7 @@ import * as json from './json/index';
 import * as logging from './logger/index';
 import * as workspaces from './workspace';
 
-export * from './exception/exception';
+export * from './exception';
 export * from './json/index';
 export * from './utils/index';
 export * from './virtual-fs/index';

--- a/packages/angular_devkit/core/src/json/schema/registry.ts
+++ b/packages/angular_devkit/core/src/json/schema/registry.ts
@@ -13,7 +13,7 @@ import * as https from 'https';
 import { Observable, from, isObservable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import * as Url from 'url';
-import { BaseException } from '../../exception/exception';
+import { BaseException } from '../../exception';
 import { PartiallyOrderedSet, deepCopy } from '../../utils';
 import { JsonArray, JsonObject, JsonValue, isJsonObject } from '../utils';
 import {


### PR DESCRIPTION
With this change we deprecate exception classes that are not used in the CLI repo.

DEPRECATED:

- `ContentHasMutatedException`, `InvalidUpdateRecordException`, `UnimplementedException` and `MergeConflictException` symbol from `@angular-devkit/core` have been deprecated in favor of the  symbol from `@angular-devkit/schematics`.
- `UnsupportedPlatformException` - A custom error exception should be created instead.