### PR TITLE
fix(@angular-devkit/build-angular): don't override asset info when updating assets

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/plugins/css-optimizer-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/plugins/css-optimizer-plugin.ts
@@ -71,9 +71,10 @@ export class CssOptimizerPlugin {
 
               if (cachedOutput) {
                 await this.addWarnings(compilation, cachedOutput.warnings);
-                compilation.updateAsset(name, cachedOutput.source, {
+                compilation.updateAsset(name, cachedOutput.source, (assetInfo) => ({
+                  ...assetInfo,
                   minimized: true,
-                });
+                }));
                 continue;
               }
             }
@@ -93,7 +94,10 @@ export class CssOptimizerPlugin {
             const optimizedAsset = map
               ? new SourceMapSource(code, name, map)
               : new OriginalSource(code, name);
-            compilation.updateAsset(name, optimizedAsset, { minimized: true });
+            compilation.updateAsset(name, optimizedAsset, (assetInfo) => ({
+              ...assetInfo,
+              minimized: true,
+            }));
 
             await cacheItem?.storePromise({
               source: optimizedAsset,

--- a/packages/angular_devkit/build_angular/src/webpack/plugins/javascript-optimizer-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/plugins/javascript-optimizer-plugin.ts
@@ -123,9 +123,10 @@ export class JavaScriptOptimizerPlugin {
               >();
 
               if (cachedOutput) {
-                compilation.updateAsset(name, cachedOutput.source, {
+                compilation.updateAsset(name, cachedOutput.source, (assetInfo) => ({
+                  ...assetInfo,
                   minimized: true,
-                });
+                }));
                 continue;
               }
             }
@@ -209,7 +210,10 @@ export class JavaScriptOptimizerPlugin {
                       const optimizedAsset = map
                         ? new SourceMapSource(code, name, map)
                         : new OriginalSource(code, name);
-                      compilation.updateAsset(name, optimizedAsset, { minimized: true });
+                      compilation.updateAsset(name, optimizedAsset, (assetInfo) => ({
+                        ...assetInfo,
+                        minimized: true,
+                      }));
 
                       return cacheItem?.storePromise({
                         source: optimizedAsset,

--- a/packages/angular_devkit/build_angular/src/webpack/plugins/transfer-size-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/plugins/transfer-size-plugin.ts
@@ -39,9 +39,14 @@ export class TransferSizePlugin {
             actions.push(
               brotliCompressAsync(scriptAsset.source.source())
                 .then((result) => {
-                  compilation.updateAsset(assetName, (s) => s, {
-                    estimatedTransferSize: result.length,
-                  });
+                  compilation.updateAsset(
+                    assetName,
+                    (s) => s,
+                    (assetInfo) => ({
+                      ...assetInfo,
+                      estimatedTransferSize: result.length,
+                    }),
+                  );
                 })
                 .catch((error) => {
                   compilation.warnings.push(


### PR DESCRIPTION


Currently, we are overriding asset info instead of appending additional data to it.