### PR TITLE
fix(@angular-devkit/build-angular): add `node_modules` prefix to excludes RegExp

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
@@ -243,7 +243,9 @@ export async function getCommonConfig(wco: WebpackConfigOptions): Promise<Config
       test: tsConfig.options.allowJs ? /\.[cm]?[tj]sx?$/ : /\.[cm]?tsx?$/,
       loader: AngularWebpackLoaderPath,
       // The below are known paths that are not part of the TypeScript compilation even when allowJs is enabled.
-      exclude: [/[/\\](?:css-loader|mini-css-extract-plugin|webpack-dev-server|webpack)[/\\]/],
+      exclude: [
+        /[\\/]node_modules[/\\](?:css-loader|mini-css-extract-plugin|webpack-dev-server|webpack)[/\\]/,
+      ],
     });
     extraPlugins.push(createIvyPlugin(wco, aot, tsConfigPath));
   }
@@ -366,7 +368,7 @@ export async function getCommonConfig(wco: WebpackConfigOptions): Promise<Config
           // The below is needed due to a bug in `@babel/runtime`. See: https://github.com/babel/babel/issues/12824
           resolve: { fullySpecified: false },
           exclude: [
-            /[/\\](?:core-js|@babel|tslib|web-animations-js|web-streams-polyfill|whatwg-url)[/\\]/,
+            /[\\/]node_modules[/\\](?:core-js|@babel|tslib|web-animations-js|web-streams-polyfill|whatwg-url)[/\\]/,
           ],
           use: [
             {


### PR DESCRIPTION


Without the `node_modules` prefix, projects named the same as the excluded package names ex: `webpack` will not compile successfully as all files under the mentioned project will be excluded from being requested by the respective loaders.

Closes #22902