### PR TITLE
fix(@angular/cli): display package manager during `ng update`

### DIFF
--- a/packages/angular/cli/src/commands/update/cli.ts
+++ b/packages/angular/cli/src/commands/update/cli.ts
@@ -220,7 +220,7 @@ export class UpdateCommandModule extends CommandModule<UpdateCommandArgs> {
       }
     }
 
-    logger.info(`Using package manager: '${packageManager}'`);
+    logger.info(`Using package manager: ${colors.grey(packageManager.name)}`);
     logger.info('Collecting installed dependencies...');
 
     const rootDependencies = await getProjectDependencies(this.context.root);


### PR DESCRIPTION
This also aligns the output to have the same style of `ng add`