### PR TITLE
refactor(@angular-devkit/build-angular): replace most custom path normalize usage with Node.js builtins

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/app-shell/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/app-shell/index.ts
@@ -12,7 +12,7 @@ import {
   createBuilder,
   targetFromTargetString,
 } from '@angular-devkit/architect';
-import { JsonObject, normalize } from '@angular-devkit/core';
+import { JsonObject } from '@angular-devkit/core';
 import * as fs from 'fs';
 import * as path from 'path';
 import { normalizeOptimization } from '../../utils';
@@ -114,8 +114,8 @@ async function _renderUniversal(
 
     if (browserOptions.serviceWorker) {
       await augmentAppWithServiceWorker(
-        normalize(projectRoot),
-        normalize(outputPath),
+        projectRoot,
+        outputPath,
         browserOptions.baseHref || '/',
         browserOptions.ngswConfigPath,
       );

--- a/packages/angular_devkit/build_angular/src/builders/browser/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/index.ts
@@ -8,7 +8,7 @@
 
 import { BuilderContext, BuilderOutput, createBuilder } from '@angular-devkit/architect';
 import { EmittedFiles, WebpackLoggingCallback, runWebpack } from '@angular-devkit/build-webpack';
-import { logging, normalize } from '@angular-devkit/core';
+import { logging } from '@angular-devkit/core';
 import * as fs from 'fs';
 import * as path from 'path';
 import { Observable, from } from 'rxjs';
@@ -106,9 +106,9 @@ async function initialize(
   if (options.assets?.length && !adjustedOptions.assets?.length) {
     normalizeAssetPatterns(
       options.assets,
-      normalize(context.workspaceRoot),
-      normalize(projectRoot),
-      projectSourceRoot === undefined ? undefined : normalize(projectSourceRoot),
+      context.workspaceRoot,
+      projectRoot,
+      projectSourceRoot,
     ).forEach(({ output }) => {
       if (output.startsWith('..')) {
         throw new Error('An asset cannot be written to a location outside of the output path.');
@@ -268,9 +268,9 @@ export function buildWebpackBrowser(
                     await copyAssets(
                       normalizeAssetPatterns(
                         options.assets,
-                        normalize(context.workspaceRoot),
-                        normalize(projectRoot),
-                        projectSourceRoot === undefined ? undefined : normalize(projectSourceRoot),
+                        context.workspaceRoot,
+                        projectRoot,
+                        projectSourceRoot,
                       ),
                       Array.from(outputPaths.values()),
                       context.workspaceRoot,
@@ -347,8 +347,8 @@ export function buildWebpackBrowser(
                   for (const [locale, outputPath] of outputPaths.entries()) {
                     try {
                       await augmentAppWithServiceWorker(
-                        normalize(projectRoot),
-                        normalize(outputPath),
+                        projectRoot,
+                        outputPath,
                         getLocaleBaseHref(i18n, locale) || options.baseHref || '/',
                         options.ngswConfigPath,
                       );

--- a/packages/angular_devkit/build_angular/src/builders/karma/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/index.ts
@@ -7,9 +7,8 @@
  */
 
 import { BuilderContext, BuilderOutput, createBuilder } from '@angular-devkit/architect';
-import { getSystemPath, join, normalize } from '@angular-devkit/core';
 import { Config, ConfigOptions } from 'karma';
-import { resolve as fsResolve } from 'path';
+import * as path from 'path';
 import { Observable, from } from 'rxjs';
 import { defaultIfEmpty, switchMap } from 'rxjs/operators';
 import { Configuration } from 'webpack';
@@ -119,12 +118,13 @@ export function execute(
         }
 
         const projectMetadata = await context.getProjectMetadata(projectName);
-        const projectSourceRoot = getSystemPath(
-          join(
-            normalize(context.workspaceRoot),
-            (projectMetadata.root as string | undefined) ?? '',
-            (projectMetadata.sourceRoot as string | undefined) ?? '',
-          ),
+        const projectRoot = path.join(
+          context.workspaceRoot,
+          (projectMetadata.root as string | undefined) ?? '',
+        );
+        const projectSourceRoot = path.join(
+          projectRoot,
+          (projectMetadata.sourceRoot as string | undefined) ?? '',
         );
 
         const files = await findTests(options.include, context.workspaceRoot, projectSourceRoot);
@@ -144,7 +144,7 @@ export function execute(
         }
 
         rules.unshift({
-          test: fsResolve(context.workspaceRoot, options.main),
+          test: path.resolve(context.workspaceRoot, options.main),
           use: {
             // cannot be a simple path as it differs between environments
             loader: SingleTestTransformLoader,
@@ -163,7 +163,7 @@ export function execute(
       };
 
       const config = await karma.config.parseConfig(
-        fsResolve(context.workspaceRoot, options.karmaConfig),
+        path.resolve(context.workspaceRoot, options.karmaConfig),
         transforms.karmaOptions ? transforms.karmaOptions(karmaOptions) : karmaOptions,
         { promiseConfig: true, throwErrors: true },
       );

--- a/packages/angular_devkit/build_angular/src/utils/normalize-asset-patterns.ts
+++ b/packages/angular_devkit/build_angular/src/utils/normalize-asset-patterns.ts
@@ -6,18 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {
-  BaseException,
-  Path,
-  basename,
-  dirname,
-  getSystemPath,
-  join,
-  normalize,
-  relative,
-  resolve,
-} from '@angular-devkit/core';
+import { BaseException } from '@angular-devkit/core';
 import { statSync } from 'fs';
+import * as path from 'path';
 import { AssetPattern, AssetPatternClass } from '../builders/browser/schema';
 
 export class MissingAssetSourceRootException extends BaseException {
@@ -28,34 +19,34 @@ export class MissingAssetSourceRootException extends BaseException {
 
 export function normalizeAssetPatterns(
   assetPatterns: AssetPattern[],
-  root: Path,
-  projectRoot: Path,
-  maybeSourceRoot: Path | undefined,
+  workspaceRoot: string,
+  projectRoot: string,
+  projectSourceRoot: string | undefined,
 ): AssetPatternClass[] {
-  // When sourceRoot is not available, we default to ${projectRoot}/src.
-  const sourceRoot = maybeSourceRoot || join(projectRoot, 'src');
-  const resolvedSourceRoot = resolve(root, sourceRoot);
-
   if (assetPatterns.length === 0) {
     return [];
   }
 
+  // When sourceRoot is not available, we default to ${projectRoot}/src.
+  const sourceRoot = projectSourceRoot || path.join(projectRoot, 'src');
+  const resolvedSourceRoot = path.resolve(workspaceRoot, sourceRoot);
+
   return assetPatterns.map((assetPattern) => {
     // Normalize string asset patterns to objects.
     if (typeof assetPattern === 'string') {
-      const assetPath = normalize(assetPattern);
-      const resolvedAssetPath = resolve(root, assetPath);
+      const assetPath = path.normalize(assetPattern);
+      const resolvedAssetPath = path.resolve(workspaceRoot, assetPath);
 
       // Check if the string asset is within sourceRoot.
       if (!resolvedAssetPath.startsWith(resolvedSourceRoot)) {
         throw new MissingAssetSourceRootException(assetPattern);
       }
 
-      let glob: string, input: Path;
+      let glob: string, input: string;
       let isDirectory = false;
 
       try {
-        isDirectory = statSync(getSystemPath(resolvedAssetPath)).isDirectory();
+        isDirectory = statSync(resolvedAssetPath).isDirectory();
       } catch {
         isDirectory = true;
       }
@@ -67,13 +58,13 @@ export function normalizeAssetPatterns(
         input = assetPath;
       } else {
         // Files are their own glob.
-        glob = basename(assetPath);
+        glob = path.basename(assetPath);
         // Input directory is their original dirname.
-        input = dirname(assetPath);
+        input = path.dirname(assetPath);
       }
 
       // Output directory for both is the relative path from source root to input.
-      const output = relative(resolvedSourceRoot, resolve(root, input));
+      const output = path.relative(resolvedSourceRoot, path.resolve(workspaceRoot, input));
 
       // Return the asset pattern in object format.
       return { glob, input, output };

--- a/packages/angular_devkit/build_angular/src/utils/normalize-builder-schema.ts
+++ b/packages/angular_devkit/build_angular/src/utils/normalize-builder-schema.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { json, normalize } from '@angular-devkit/core';
+import { json } from '@angular-devkit/core';
 import {
   AssetPatternClass,
   Schema as BrowserBuilderSchema,
@@ -48,14 +48,11 @@ export function normalizeBrowserSchema(
     cache: normalizeCacheOptions(metadata, workspaceRoot),
     assets: normalizeAssetPatterns(
       options.assets || [],
-      normalize(workspaceRoot),
-      normalize(projectRoot),
-      projectSourceRoot ? normalize(projectSourceRoot) : undefined,
+      workspaceRoot,
+      projectRoot,
+      projectSourceRoot,
     ),
-    fileReplacements: normalizeFileReplacements(
-      options.fileReplacements || [],
-      normalize(workspaceRoot),
-    ),
+    fileReplacements: normalizeFileReplacements(options.fileReplacements || [], workspaceRoot),
     optimization: normalizeOptimization(options.optimization),
     sourceMap: normalizedSourceMapOptions,
     preserveSymlinks:

--- a/packages/angular_devkit/build_angular/src/webpack/plugins/typescript.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/plugins/typescript.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { getSystemPath } from '@angular-devkit/core';
 import type { CompilerOptions } from '@angular/compiler-cli';
 import { AngularWebpackPlugin } from '@ngtools/webpack';
 import { ScriptTarget } from 'typescript';
@@ -59,7 +58,7 @@ export function createIvyPlugin(
   const fileReplacements: Record<string, string> = {};
   if (buildOptions.fileReplacements) {
     for (const replacement of buildOptions.fileReplacements) {
-      fileReplacements[getSystemPath(replacement.replace)] = getSystemPath(replacement.with);
+      fileReplacements[replacement.replace] = replacement.with;
     }
   }
 


### PR DESCRIPTION
During the build initialization phase, many paths are converted back and forth between multiple normalized forms. These conversions involve potentially expensive string operations. The majority of the custom path `normalize` function from `@angular-devkit/core` usages have now been removed in favor of the Node.js builtin path functions. This change reduces the need to perform additional string manipulation where possible.