### PR TITLE
fix(@angular/cli): ensure lint command auto-add exits after completion

### DIFF
--- a/packages/angular/cli/commands/lint-impl.ts
+++ b/packages/angular/cli/commands/lint-impl.ts
@@ -50,8 +50,9 @@ export class LintCommand extends ArchitectCommand<LintCommandSchema> {
       if (error) {
         throw error;
       }
-
-      return status ?? 0;
     }
+
+    // Return an exit code to force the command to exit after adding the package
+    return 1;
   }
 }


### PR DESCRIPTION
When no lint target is present for a project, the command will ask if linting should be added to the project.
However, after adding the package, the command incorrectly kept executing and then failing due to the lint command not being fully setup yet.
Instead, the command will now exit after adding the linting package. This also allows inspection and/or adjustment of the linting configuration prior to actually linting.

Fixes: #22937