### PR TITLE
fix(@angular/cli): disable duplicate arguments array merging

### DIFF
--- a/packages/angular/cli/src/command-builder/command-runner.ts
+++ b/packages/angular/cli/src/command-builder/command-runner.ts
@@ -57,6 +57,18 @@ const COMMANDS = [
 
 const yargsParser = Parser as unknown as typeof Parser.default;
 
+// https://github.com/yargs/yargs/blob/main/docs/advanced.md#customizing-yargs-parser
+const PARSER_CONFIGURATION: Partial<yargs.ParserConfigurationOptions> = {
+  'populate--': true,
+  'duplicate-arguments-array': false,
+  'unknown-options-as-args': false,
+  'dot-notation': false,
+  'boolean-negation': true,
+  'strip-aliased': true,
+  'strip-dashed': true,
+  'camel-case-expansion': false,
+};
+
 export async function runCommand(args: string[], logger: logging.Logger): Promise<number> {
   const {
     $0,
@@ -64,7 +76,11 @@ export async function runCommand(args: string[], logger: logging.Logger): Promis
     help = false,
     jsonHelp = false,
     ...rest
-  } = yargsParser(args, { boolean: ['help', 'json-help'], alias: { 'collection': 'c' } });
+  } = yargsParser(args, {
+    boolean: ['help', 'json-help'],
+    alias: { 'collection': 'c' },
+    configuration: PARSER_CONFIGURATION,
+  });
 
   let workspace: AngularWorkspace | undefined;
   let globalConfiguration: AngularWorkspace | undefined;
@@ -117,16 +133,7 @@ export async function runCommand(args: string[], logger: logging.Logger): Promis
 
   await localYargs
     .scriptName('ng')
-    // https://github.com/yargs/yargs/blob/main/docs/advanced.md#customizing-yargs-parser
-    .parserConfiguration({
-      'populate--': true,
-      'unknown-options-as-args': false,
-      'dot-notation': false,
-      'boolean-negation': true,
-      'strip-aliased': true,
-      'strip-dashed': true,
-      'camel-case-expansion': false,
-    })
+    .parserConfiguration(PARSER_CONFIGURATION)
     .option('json-help', {
       describe: 'Show help in JSON format.',
       implies: ['help'],

--- a/packages/angular_devkit/architect_cli/bin/architect.ts
+++ b/packages/angular_devkit/architect_cli/bin/architect.ts
@@ -194,6 +194,7 @@ async function main(args: string[]): Promise<number> {
       'boolean-negation': true,
       'strip-aliased': true,
       'camel-case-expansion': false,
+      'duplicate-arguments-array': false,
     },
   });
 

--- a/packages/angular_devkit/schematics_cli/bin/schematics.ts
+++ b/packages/angular_devkit/schematics_cli/bin/schematics.ts
@@ -366,6 +366,7 @@ function parseArgs(args: string[]): Options {
       'boolean-negation': true,
       'strip-aliased': true,
       'camel-case-expansion': false,
+      'duplicate-arguments-array': false,
     },
   });
 


### PR DESCRIPTION
Previously, any duplicate arguments where being parsed as arrays.

Before
```
$ node example.js -x 1 -x 2
{ _: [], x: [1, 2] }
```

Now
```
$ node example.js -x 1 -x 2
{ _: [], x: 2 }
```

Closes #22956