### PR TITLE
feat(@angular/cli): add support for auto completion

### DIFF
--- a/packages/angular/cli/src/command-builder/architect-base-command-module.ts
+++ b/packages/angular/cli/src/command-builder/architect-base-command-module.ts
@@ -7,7 +7,10 @@
  */
 
 import { Architect, Target } from '@angular-devkit/architect';
-import { WorkspaceNodeModulesArchitectHost } from '@angular-devkit/architect/node';
+import {
+  NodeModulesBuilderInfo,
+  WorkspaceNodeModulesArchitectHost,
+} from '@angular-devkit/architect/node';
 import { json } from '@angular-devkit/core';
 import { spawnSync } from 'child_process';
 import { existsSync } from 'fs';
@@ -100,9 +103,15 @@ export abstract class ArchitectBaseCommandModule<T>
 
   protected async getArchitectTargetOptions(target: Target): Promise<Option[]> {
     const architectHost = this.getArchitectHost();
-    const builderConf = await architectHost.getBuilderNameForTarget(target);
+    let builderConf: string;
 
-    let builderDesc;
+    try {
+      builderConf = await architectHost.getBuilderNameForTarget(target);
+    } catch {
+      return [];
+    }
+
+    let builderDesc: NodeModulesBuilderInfo;
     try {
       builderDesc = await architectHost.resolveBuilder(builderConf);
     } catch (e) {

--- a/packages/angular/cli/src/command-builder/command-module.ts
+++ b/packages/angular/cli/src/command-builder/command-module.ts
@@ -48,6 +48,7 @@ export interface CommandContext {
     options: {
       help: boolean;
       jsonHelp: boolean;
+      getYargsCompletions: boolean;
     } & Record<string, unknown>;
   };
 }

--- a/packages/angular/cli/src/commands/completion/cli.ts
+++ b/packages/angular/cli/src/commands/completion/cli.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { join } from 'path';
+import yargs, { Argv } from 'yargs';
+import { CommandModule, CommandModuleImplementation } from '../../command-builder/command-module';
+
+export class CompletionCommandModule extends CommandModule implements CommandModuleImplementation {
+  command = 'completion';
+  describe = 'Generate a bash and zsh real-time type-ahead autocompletion script.';
+  longDescriptionPath = join(__dirname, 'long-description.md');
+
+  builder(localYargs: Argv): Argv {
+    return localYargs;
+  }
+
+  run(): void {
+    yargs.showCompletionScript();
+  }
+}

--- a/packages/angular/cli/src/commands/completion/long-description.md
+++ b/packages/angular/cli/src/commands/completion/long-description.md
@@ -1,0 +1,1 @@
+To enable bash and zsh real-time type-ahead autocompletion, copy and paste the generated script to your `.bashrc`, `.bash_profile`, `.zshrc` or `.zsh_profile`.

--- a/tests/legacy-cli/e2e/tests/misc/browsers.ts
+++ b/tests/legacy-cli/e2e/tests/misc/browsers.ts
@@ -1,7 +1,7 @@
 import express from 'express';
 import * as path from 'path';
 import { copyProjectAsset } from '../../utils/assets';
-import { appendToFile, replaceInFile } from '../../utils/fs';
+import { replaceInFile } from '../../utils/fs';
 import { ng } from '../../utils/process';
 
 export default async function () {

--- a/tests/legacy-cli/e2e/tests/misc/completion.ts
+++ b/tests/legacy-cli/e2e/tests/misc/completion.ts
@@ -1,0 +1,51 @@
+import { execAndWaitForOutputToMatch } from '../../utils/process';
+
+export default async function () {
+  // ng build
+  await execAndWaitForOutputToMatch('ng', ['--get-yargs-completions', 'b', ''], /test-project/);
+  await execAndWaitForOutputToMatch('ng', ['--get-yargs-completions', 'build', ''], /test-project/);
+  await execAndWaitForOutputToMatch('ng', ['--get-yargs-completions', 'build', '--a'], /--aot/);
+  await execAndWaitForOutputToMatch(
+    'ng',
+    ['--get-yargs-completions', 'build', '--configuration'],
+    /production/,
+  );
+  await execAndWaitForOutputToMatch(
+    'ng',
+    ['--get-yargs-completions', 'b', '--configuration'],
+    /production/,
+  );
+
+  // ng run
+  await execAndWaitForOutputToMatch(
+    'ng',
+    ['--get-yargs-completions', 'run', ''],
+    /test-project\:build\:development/,
+  );
+  await execAndWaitForOutputToMatch(
+    'ng',
+    ['--get-yargs-completions', 'run', ''],
+    /test-project\:build/,
+  );
+  await execAndWaitForOutputToMatch(
+    'ng',
+    ['--get-yargs-completions', 'run', ''],
+    /test-project\:test/,
+  );
+  await execAndWaitForOutputToMatch(
+    'ng',
+    ['--get-yargs-completions', 'run', 'test-project:build'],
+    /test-project\:build\:development/,
+  );
+  await execAndWaitForOutputToMatch(
+    'ng',
+    ['--get-yargs-completions', 'run', 'test-project:'],
+    /test-project\:test/,
+  );
+  await execAndWaitForOutputToMatch(
+    'ng',
+    ['--get-yargs-completions', 'run', 'test-project:build'],
+    // does not include 'test-project:serve'
+    /^((?!:serve).)*$/,
+  );
+}


### PR DESCRIPTION
To enable bash and zsh real-time type-ahead autocompletion, copy and paste the generated script by the `ng completion` command to your `.bashrc`, `.bash_profile`, `.zshrc` or `.zsh_profile`.

Closes #11043