### PR TITLE
refactor(@angular/cli): remove most of `getWorkspaceRaw` usages

### DIFF
--- a/packages/angular/cli/src/commands/analytics/settings/cli.ts
+++ b/packages/angular/cli/src/commands/analytics/settings/cli.ts
@@ -51,7 +51,7 @@ export class AnalyticsDisableModule
   describe = 'Disables analytics gathering and reporting for the user.';
 
   async run({ global }: Options<AnalyticsCommandArgs>): Promise<void> {
-    setAnalyticsConfig(global, false);
+    await setAnalyticsConfig(global, false);
     process.stderr.write(await getAnalyticsInfoString());
   }
 }
@@ -64,7 +64,7 @@ export class AnalyticsEnableModule
   aliases = 'on';
   describe = 'Enables analytics gathering and reporting for the user.';
   async run({ global }: Options<AnalyticsCommandArgs>): Promise<void> {
-    setAnalyticsConfig(global, true);
+    await setAnalyticsConfig(global, true);
     process.stderr.write(await getAnalyticsInfoString());
   }
 }

--- a/packages/angular/cli/src/commands/cache/settings/cli.ts
+++ b/packages/angular/cli/src/commands/cache/settings/cli.ts
@@ -25,8 +25,8 @@ export class CacheDisableModule extends CommandModule implements CommandModuleIm
     return localYargs;
   }
 
-  run(): void {
-    updateCacheConfig('enabled', false);
+  run(): Promise<void> {
+    return updateCacheConfig(this.getWorkspaceOrThrow(), 'enabled', false);
   }
 }
 
@@ -41,7 +41,7 @@ export class CacheEnableModule extends CommandModule implements CommandModuleImp
     return localYargs;
   }
 
-  run(): void {
-    updateCacheConfig('enabled', true);
+  run(): Promise<void> {
+    return updateCacheConfig(this.getWorkspaceOrThrow(), 'enabled', true);
   }
 }

--- a/packages/angular/cli/src/commands/cache/utilities.ts
+++ b/packages/angular/cli/src/commands/cache/utilities.ts
@@ -9,16 +9,18 @@
 import { isJsonObject } from '@angular-devkit/core';
 import { resolve } from 'path';
 import { Cache, Environment } from '../../../lib/config/workspace-schema';
-import { AngularWorkspace, getWorkspaceRaw } from '../../utilities/config';
+import { AngularWorkspace } from '../../utilities/config';
 
-export function updateCacheConfig<K extends keyof Cache>(key: K, value: Cache[K]): void {
-  const [localWorkspace] = getWorkspaceRaw('local');
-  if (!localWorkspace) {
-    throw new Error('Cannot find workspace configuration file.');
-  }
+export function updateCacheConfig<K extends keyof Cache>(
+  workspace: AngularWorkspace,
+  key: K,
+  value: Cache[K],
+): Promise<void> {
+  const cli = (workspace.extensions['cli'] ??= {}) as Record<string, Record<string, unknown>>;
+  const cache = (cli['cache'] ??= {});
+  cache[key] = value;
 
-  localWorkspace.modify(['cli', 'cache', key], value);
-  localWorkspace.save();
+  return workspace.save();
 }
 
 export function getCacheConfig(workspace: AngularWorkspace | undefined): Required<Cache> {


### PR DESCRIPTION
This changes removes most of the usage of `getWorkspaceRaw` in the Angular CLI. This is needed to eventually drop the direct dependency on `jsonc-parser`.