### PR TITLE
fix(@angular-devkit/build-angular): display debug logs when using the `--verbose` option

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
@@ -397,6 +397,7 @@ export async function getCommonConfig(wco: WebpackConfigOptions): Promise<Config
       asyncWebAssembly: true,
     },
     infrastructureLogging: {
+      debug: verbose,
       level: verbose ? 'verbose' : 'error',
     },
     stats: getStatsOptions(verbose),


### PR DESCRIPTION

Webpack doesn't display debug logs when setting the log level to verbose.

See: https://webpack.js.org/configuration/other-options/#debug and https://webpack.js.org/configuration/other-options/#level