### PR TITLE
release: cut the v14.0.0-next.11 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-<a name="14.0.0-next.10"></a>
+<a name="14.0.0-next.11"></a>
 
-# 14.0.0-next.10 (2022-04-20)
+# 14.0.0-next.11 (2022-04-21)
 
 ### @angular/cli
 
@@ -23,6 +23,12 @@
 ## Special Thanks
 
 Alan Agius, Charles Lyding and Daniil Dubrava
+
+<!-- CHANGELOG SPLIT MARKER -->
+
+<a name="14.0.0-next.10"></a>
+
+# 14.0.0-next.10 (2022-04-21)
 
 <!-- CHANGELOG SPLIT MARKER -->
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@angular/devkit-repo",
-  "version": "14.0.0-next.10",
+  "version": "14.0.0-next.11",
   "private": true,
   "description": "Software Development Kit for Angular",
   "bin": {


### PR DESCRIPTION
Due to an issue in releasing the next.10 package to npm re-releasing it as next.11