### PR TITLE
build: changes for primary branch rename to `main` [12.2.x]

### DIFF
--- a/.ng-dev/github.ts
+++ b/.ng-dev/github.ts
@@ -7,5 +7,5 @@ import { GithubConfig } from '@angular/dev-infra-private/ng-dev/utils/config';
 export const github: GithubConfig = {
   owner: 'angular',
   name: 'angular-cli',
-  mainBranchName: 'master',
+  mainBranchName: 'main',
 };

--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,7 @@
     "enabled": true
   },
   "schedule": ["after 10pm every weekday", "before 4am every weekday", "every weekend"],
-  "baseBranches": ["master"],
+  "baseBranches": ["main"],
   "ignoreDeps": ["@types/node", "quicktype-core"],
   "packageFiles": [
     "WORKSPACE",

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -66,10 +66,10 @@ function _branchCheck(args: PublishArgs, logger: logging.Logger) {
   const branch = ref.trim().replace(/^refs\/heads\//, '');
 
   switch (branch) {
-    case 'master':
+    case 'main':
       if (args.tag !== 'next') {
         throw new Error(tags.oneLine`
-          Releasing from master requires a next tag. Use --no-branchCheck to
+          Releasing from main requires a next tag. Use --no-branchCheck to
           skip this check.
         `);
       }

--- a/scripts/snapshots.ts
+++ b/scripts/snapshots.ts
@@ -144,7 +144,7 @@ export default async function (opts: SnapshotsOptions, logger: logging.Logger) {
 
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'angular-cli-publish-'));
   const message = execSync(`git log --format="%h %s" -n1`).toString().trim();
-  let branch = opts.branch || 'master';
+  let branch = opts.branch || 'main';
 
   // CIRCLE_BRANCH
   if (typeof process.env['CIRCLE_BRANCH'] == 'string') {


### PR DESCRIPTION
Changes part of the `DIRECT` phase of the "renaming master
to main" planning doc.