### PR TITLE
build: changes for primary branch rename to `main` [11.2.x]

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,7 +19,7 @@
     "every weekend"
   ],
   "baseBranches": [
-    "master"
+    "main"
   ],
   "ignoreDeps": [
     "@types/node"

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -67,10 +67,10 @@ function _branchCheck(args: PublishArgs, logger: logging.Logger) {
   const branch = ref.trim().replace(/^refs\/heads\//, '');
 
   switch (branch) {
-    case 'master':
+    case 'main':
       if (args.tag !== 'next') {
         throw new Error(tags.oneLine`
-          Releasing from master requires a next tag. Use --no-branchCheck to
+          Releasing from main requires a next tag. Use --no-branchCheck to
           skip this check.
         `);
       }

--- a/scripts/snapshots.ts
+++ b/scripts/snapshots.ts
@@ -149,7 +149,7 @@ export default async function(opts: SnapshotsOptions, logger: logging.Logger) {
 
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'angular-cli-publish-'));
   const message = execSync(`git log --format="%h %s" -n1`).toString().trim();
-  let branch = opts.branch || 'master';
+  let branch = opts.branch || 'main';
 
   // CIRCLE_BRANCH
   if (typeof process.env['CIRCLE_BRANCH'] == 'string') {


### PR DESCRIPTION
Changes part of the `DIRECT` phase of the "renaming master
to main" planning doc.

Note the version of ng-dev used in this LTS branch does not properly
support custom primary branches, but this should be non-relevant here
because this commit will only land in a version branch (11.2.x)