### PR TITLE
perf(@ngtools/webpack): use Webpack's built-in xxhash64 support

### DIFF
--- a/packages/ngtools/webpack/package.json
+++ b/packages/ngtools/webpack/package.json
@@ -24,7 +24,7 @@
   "peerDependencies": {
     "@angular/compiler-cli": "^14.0.0 || ^14.0.0-next",
     "typescript": "~4.6.2",
-    "webpack": "^5.30.0"
+    "webpack": "^5.54.0"
   },
   "devDependencies": {
     "@angular-devkit/core": "0.0.0-PLACEHOLDER",


### PR DESCRIPTION
Webpack provides built-in support for creating hashes using the xxhash64 algorithm via a WebAssembly module.
This can be significantly faster than the previously used md5 algorithm and is currently used as the output hashing algorithm  within the Webpack configuration.
The Webpack peer dependency has also been update to a minimum of 5.54.0 to ensure xxhash64 supported is available.