### PR TITLE
fix(@angular/cli): change wrapping of schematic code

### DIFF
--- a/packages/angular/cli/src/command-builder/utilities/schematic-engine-host.ts
+++ b/packages/angular/cli/src/command-builder/utilities/schematic-engine-host.ts
@@ -195,7 +195,9 @@ function wrap(
   const schematicCode = readFileSync(schematicFile, 'utf8');
   // `module` is required due to @angular/localize ng-add being in UMD format
   const headerCode = '(function() {\nvar exports = {};\nvar module = { exports };\n';
-  const footerCode = exportName ? `\nreturn exports['${exportName}'];});` : '\nreturn exports;});';
+  const footerCode = exportName
+    ? `\nreturn module.exports['${exportName}'];});`
+    : '\nreturn module.exports;});';
 
   const script = new Script(headerCode + schematicCode + footerCode, {
     filename: schematicFile,


### PR DESCRIPTION
Fixes the schematic wrapper function used to capture the module's exports to correctly return `module.exports` instead of just `exports`.

### Problem Demo

```ts
(function() {
  var exports = {};
  var module = { exports };

  // schematic #1 code example
  // exports.default = ...

  // schematic #2 code example
  // module.exports = ...

  // works for schematic #1 but fails for schematic #2
  return exports['default'];
});
```