### PR TITLE
[13.3.x] fix(@angular-devkit/build-angular): correctly resolve custom service worker configuration file

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/app-shell/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/app-shell/index.ts
@@ -115,6 +115,7 @@ async function _renderUniversal(
     if (browserOptions.serviceWorker) {
       await augmentAppWithServiceWorker(
         projectRoot,
+        context.workspaceRoot,
         normalize(outputPath),
         browserOptions.baseHref || '/',
         browserOptions.ngswConfigPath,

--- a/packages/angular_devkit/build_angular/src/builders/browser/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/index.ts
@@ -354,6 +354,7 @@ export function buildWebpackBrowser(
                     try {
                       await augmentAppWithServiceWorker(
                         normalize(projectRoot),
+                        context.workspaceRoot,
                         normalize(outputPath),
                         getLocaleBaseHref(i18n, locale) || options.baseHref || '/',
                         options.ngswConfigPath,

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/service-worker_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/service-worker_spec.ts
@@ -52,6 +52,24 @@ describe('Browser Builder service worker', () => {
     await run.stop();
   });
 
+  it('supports specifying a custom service worker configuration file', async () => {
+    host.writeMultipleFiles({
+      'src/configs/ngsw.json': JSON.stringify(manifest),
+      'src/assets/folder-asset.txt': 'folder-asset.txt',
+      'src/styles.css': `body { background: url(./spectrum.png); }`,
+    });
+
+    const overrides = { serviceWorker: true, ngswConfigPath: 'src/configs/ngsw.json' };
+
+    const run = await architect.scheduleTarget(target, overrides);
+
+    await expectAsync(run.result).toBeResolvedTo(jasmine.objectContaining({ success: true }));
+
+    await run.stop();
+
+    expect(host.scopedSync().exists(normalize('dist/ngsw.json'))).toBeTrue();
+  });
+
   it('works with service worker', async () => {
     host.writeMultipleFiles({
       'src/ngsw-config.json': JSON.stringify(manifest),

--- a/packages/angular_devkit/build_angular/src/utils/service-worker.ts
+++ b/packages/angular_devkit/build_angular/src/utils/service-worker.ts
@@ -63,6 +63,7 @@ class CliFilesystem implements Filesystem {
 
 export async function augmentAppWithServiceWorker(
   appRoot: Path,
+  workspaceRoot: string,
   outputPath: Path,
   baseHref: string,
   ngswConfigPath?: string,
@@ -71,7 +72,7 @@ export async function augmentAppWithServiceWorker(
 
   // Determine the configuration file path
   const configPath = ngswConfigPath
-    ? getSystemPath(normalize(ngswConfigPath))
+    ? path.join(workspaceRoot, getSystemPath(normalize(ngswConfigPath)))
     : path.join(getSystemPath(appRoot), 'ngsw-config.json');
 
   // Read the configuration file


### PR DESCRIPTION
Paths within the `angular.json` file should be relative to the location of the `angular.json` file.
The `ngswConfigPath` option was incorrectly using the current working directory for a base path when
a relative configuration path was specified. Most of the time this would work as a build command usually
is executed from the root of the workspace. However, this may not always be the case and for those cases
the actual workspace root is now used to resolve the full path for the service worker configuration file.