### PR TITLE
refactor(@schematics/angular): include CommonModule for standalone components

### DIFF
--- a/packages/schematics/angular/component/files/__name@dasherize@if-flat__/__name@dasherize__.__type@dasherize__.ts.template
+++ b/packages/schematics/angular/component/files/__name@dasherize@if-flat__/__name@dasherize__.__type@dasherize__.ts.template
@@ -1,8 +1,10 @@
-import { Component, OnInit<% if(!!viewEncapsulation) { %>, ViewEncapsulation<% }%><% if(changeDetection !== 'Default') { %>, ChangeDetectionStrategy<% }%> } from '@angular/core';
+import { Component, OnInit<% if(!!viewEncapsulation) { %>, ViewEncapsulation<% }%><% if(changeDetection !== 'Default') { %>, ChangeDetectionStrategy<% }%> } from '@angular/core';<% if(standalone) {%>
+import { CommonModule } from '@angular/common';<% } %>
 
 @Component({<% if(!skipSelector) {%>
   selector: '<%= selector %>',<%}%><% if(standalone) {%>
-  standalone: true,<%}%><% if(inlineTemplate) { %>
+  standalone: true,
+  imports: [CommonModule], <%}%><% if(inlineTemplate) { %>
   template: `
     <p>
       <%= dasherize(name) %> works!

--- a/packages/schematics/angular/component/index_spec.ts
+++ b/packages/schematics/angular/component/index_spec.ts
@@ -426,9 +426,11 @@ describe('Component Schematic', () => {
     const tree = await schematicRunner.runSchematicAsync('component', options, appTree).toPromise();
     const moduleContent = tree.readContent('/projects/bar/src/app/app.module.ts');
     const componentContent = tree.readContent('/projects/bar/src/app/foo/foo.component.ts');
-    expect(componentContent).toContain('standalone: true');
+    expect(componentContent).toContain('@angular/common');
     expect(componentContent).toContain('class FooComponent');
     expect(moduleContent).not.toContain('FooComponent');
+    expect(componentContent).toContain('standalone: true');
+    expect(componentContent).toContain('imports: [CommonModule]');
   });
 
   it('should declare standalone components in the `imports` of a test', async () => {


### PR DESCRIPTION
This commit adds the CommonModule imports to the standalone components
generated by the Angular's ng add component schematic.