### PR TITLE
build: update SauceLabs connect proxy version to 4.7.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,7 +241,6 @@ jobs:
         # Waits for the Saucelabs tunnel to be ready. This ensures that we don't run tests
         # too early without Saucelabs not being ready.
       - run: ./scripts/saucelabs/wait-for-tunnel.sh
-      - run: node ./tests/legacy-cli/run_e2e ./tests/legacy-cli/e2e/tests/misc/browsers.ts --ve
       - run: node ./tests/legacy-cli/run_e2e ./tests/legacy-cli/e2e/tests/misc/browsers.ts
       - run: ./scripts/saucelabs/stop-tunnel.sh
       - fail_fast

--- a/package.json
+++ b/package.json
@@ -198,7 +198,7 @@
     "rxjs": "6.6.7",
     "sass": "1.49.9",
     "sass-loader": "12.4.0",
-    "sauce-connect-proxy": "https://saucelabs.com/downloads/sc-4.6.4-linux.tar.gz",
+    "sauce-connect-proxy": "https://saucelabs.com/downloads/sc-4.7.1-linux.tar.gz",
     "semver": "7.3.5",
     "shelljs": "^0.8.5",
     "source-map": "0.7.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9792,9 +9792,9 @@ sass@1.49.9:
     immutable "^4.0.0"
     source-map-js ">=0.6.2 <2.0.0"
 
-"sauce-connect-proxy@https://saucelabs.com/downloads/sc-4.6.4-linux.tar.gz":
+"sauce-connect-proxy@https://saucelabs.com/downloads/sc-4.7.1-linux.tar.gz":
   version "0.0.0"
-  resolved "https://saucelabs.com/downloads/sc-4.6.4-linux.tar.gz#992e2cb0d91e54b27a4f5bbd2049f3b774718115"
+  resolved "https://saucelabs.com/downloads/sc-4.7.1-linux.tar.gz#e5d7f82ad98251a653d1b0537f1103e49eda5e11"
 
 saucelabs@^1.5.0:
   version "1.5.0"


### PR DESCRIPTION
Cherry pick of #23071 targeting `13.3.x`.

Merge conflict was just from surrounding `package-lock.json` changes, nothing too interesting.