### PR TITLE
fix(@angular/cli): improve error message for Windows autocompletion use cases

### DIFF
--- a/packages/angular/cli/src/utilities/completion.ts
+++ b/packages/angular/cli/src/utilities/completion.ts
@@ -193,7 +193,9 @@ export async function initializeAutocomplete(): Promise<string> {
   if (!shell) {
     throw new Error(
       '`$SHELL` environment variable not set. Angular CLI autocompletion only supports Bash or' +
-        ' Zsh.',
+        " Zsh. If you're on Windows, Cmd and Powershell don't support command autocompletion," +
+        ' but Git Bash or Windows Subsystem for Linux should work, so please try again in one of' +
+        ' those environments.',
     );
   }
   const home = env['HOME'];
@@ -234,7 +236,7 @@ export async function initializeAutocomplete(): Promise<string> {
   return rcFile;
 }
 
-/** Returns an ordered list of possibile candidates of RC files used by the given shell. */
+/** Returns an ordered list of possible candidates of RC files used by the given shell. */
 function getShellRunCommandCandidates(shell: string, home: string): string[] | undefined {
   if (shell.toLowerCase().includes('bash')) {
     return ['.bashrc', '.bash_profile', '.profile'].map((file) => path.join(home, file));


### PR DESCRIPTION
Autocompletion tests [were failing on Windows](https://app.circleci.com/pipelines/github/angular/angular-cli/22152/workflows/8d883186-c144-4924-8a14-088e32d7c584/jobs/300321) due to a missing `$HOME` variable, presumably Windows wasn't inheriting the `$HOME` variable like Linux does?

Also fixing a semi-related typo I happened to notice around the same time.

Not sure exactly how to test this on Windows before merging, just hope for the best I guess?