### PR TITLE
build: run prettier on legacy-cli e2e files

### DIFF
--- a/tests/legacy-cli/e2e/setup/100-global-cli.ts
+++ b/tests/legacy-cli/e2e/setup/100-global-cli.ts
@@ -1,7 +1,7 @@
 import { getGlobalVariable } from '../utils/env';
 import { exec, silentNpm } from '../utils/process';
 
-export default async function() {
+export default async function () {
   const argv = getGlobalVariable('argv');
   if (argv.noglobal) {
     return;
@@ -10,12 +10,7 @@ export default async function() {
   const testRegistry = getGlobalVariable('package-registry');
 
   // Install global Angular CLI.
-  await silentNpm(
-    'install',
-    '--global',
-    '@angular/cli',
-    `--registry=${testRegistry}`,
-  );
+  await silentNpm('install', '--global', '@angular/cli', `--registry=${testRegistry}`);
 
   try {
     await exec(process.platform.startsWith('win') ? 'where' : 'which', 'ng');

--- a/tests/legacy-cli/e2e/setup/200-create-tmp-dir.ts
+++ b/tests/legacy-cli/e2e/setup/200-create-tmp-dir.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'os';
 import { dirname, join } from 'path';
 import { getGlobalVariable, setGlobalVariable } from '../utils/env';
 
-export default function() {
+export default function () {
   const argv = getGlobalVariable('argv');
 
   // Get to a temporary directory.

--- a/tests/legacy-cli/e2e/setup/300-log-environment.ts
+++ b/tests/legacy-cli/e2e/setup/300-log-environment.ts
@@ -1,9 +1,9 @@
 import { ng, node, npm } from '../utils/process';
 
-export default async function() {
+export default async function () {
   console.log('Environment:');
 
-  Object.keys(process.env).forEach(envName => {
+  Object.keys(process.env).forEach((envName) => {
     // CI Logs should not contain environment variables that are considered secret
     const lowerName = envName.toLowerCase();
     if (lowerName.includes('key') || lowerName.includes('secret')) {

--- a/tests/legacy-cli/e2e/tests/basic/aot.ts
+++ b/tests/legacy-cli/e2e/tests/basic/aot.ts
@@ -3,6 +3,8 @@ import { ng } from '../../utils/process';
 
 export default async function () {
   await ng('build', '--aot=true', '--configuration=development');
-  await expectFileToMatch('dist/test-project/main.js',
-    /platformBrowser.*bootstrapModule.*AppModule/);
+  await expectFileToMatch(
+    'dist/test-project/main.js',
+    /platformBrowser.*bootstrapModule.*AppModule/,
+  );
 }

--- a/tests/legacy-cli/e2e/tests/basic/environment.ts
+++ b/tests/legacy-cli/e2e/tests/basic/environment.ts
@@ -2,10 +2,9 @@ import { expectFileToMatch } from '../../utils/fs';
 import { ng } from '../../utils/process';
 import { updateJsonFile } from '../../utils/project';
 
-
 export default async function () {
   // Try a prod build.
-  await updateJsonFile('angular.json', configJson => {
+  await updateJsonFile('angular.json', (configJson) => {
     const appArchitect = configJson.projects['test-project'].architect;
     appArchitect.build.configurations['prod-env'] = {
       ...appArchitect.build.configurations['development'],

--- a/tests/legacy-cli/e2e/tests/basic/in-project-logic.ts
+++ b/tests/legacy-cli/e2e/tests/basic/in-project-logic.ts
@@ -4,17 +4,18 @@ import { writeFile, deleteFile } from '../../utils/fs';
 import { ng } from '../../utils/process';
 import { expectToFail } from '../../utils/utils';
 
-
-export default function() {
+export default function () {
   const homedir = os.homedir();
   const globalConfigPath = join(homedir, '.angular-config.json');
-  return Promise.resolve()
-    .then(() => writeFile(globalConfigPath, '{"version":1}'))
-    .then(() => process.chdir(homedir))
-    .then(() => ng('new', 'proj-name', '--dry-run'))
-    .then(() => deleteFile(globalConfigPath))
-    // Test that we cannot create a project inside another project.
-    .then(() => writeFile(join(homedir, '.angular.json'), '{"version":1}'))
-    .then(() => expectToFail(() => ng('new', 'proj-name', '--dry-run')))
-    .then(() => deleteFile(join(homedir, '.angular.json')));
+  return (
+    Promise.resolve()
+      .then(() => writeFile(globalConfigPath, '{"version":1}'))
+      .then(() => process.chdir(homedir))
+      .then(() => ng('new', 'proj-name', '--dry-run'))
+      .then(() => deleteFile(globalConfigPath))
+      // Test that we cannot create a project inside another project.
+      .then(() => writeFile(join(homedir, '.angular.json'), '{"version":1}'))
+      .then(() => expectToFail(() => ng('new', 'proj-name', '--dry-run')))
+      .then(() => deleteFile(join(homedir, '.angular.json')))
+  );
 }

--- a/tests/legacy-cli/e2e/tests/basic/size-tracking.ts
+++ b/tests/legacy-cli/e2e/tests/basic/size-tracking.ts
@@ -1,16 +1,22 @@
-import { appendToFile, moveDirectory, prependToFile, replaceInFile, writeFile } from '../../utils/fs';
+import {
+  appendToFile,
+  moveDirectory,
+  prependToFile,
+  replaceInFile,
+  writeFile,
+} from '../../utils/fs';
 import { ng } from '../../utils/process';
-
 
 export default async function () {
   // Store the production build for artifact storage on CircleCI
   if (process.env['CIRCLECI']) {
-
     // Add initial app routing.
     // This is done automatically on a new app with --routing but must be done manually on
     // existing apps.
     const appRoutingModulePath = 'src/app/app-routing.module.ts';
-    await writeFile(appRoutingModulePath, `
+    await writeFile(
+      appRoutingModulePath,
+      `
       import { NgModule } from '@angular/core';
       import { Routes, RouterModule } from '@angular/router';
 
@@ -21,9 +27,12 @@ export default async function () {
         exports: [RouterModule]
       })
       export class AppRoutingModule { }
-    `);
-    await prependToFile('src/app/app.module.ts',
-      `import { AppRoutingModule } from './app-routing.module';`);
+    `,
+    );
+    await prependToFile(
+      'src/app/app.module.ts',
+      `import { AppRoutingModule } from './app-routing.module';`,
+    );
     await replaceInFile('src/app/app.module.ts', `imports: [`, `imports: [ AppRoutingModule,`);
     await appendToFile('src/app/app.component.html', '<router-outlet></router-outlet>');
 

--- a/tests/legacy-cli/e2e/tests/build/allow-js.ts
+++ b/tests/legacy-cli/e2e/tests/build/allow-js.ts
@@ -2,16 +2,19 @@ import { ng } from '../../utils/process';
 import { updateTsConfig } from '../../utils/project';
 import { appendToFile, writeFile } from '../../utils/fs';
 
-export default async function() {
+export default async function () {
   // TODO(architect): Delete this test. It is now in devkit/build-angular.
 
   await writeFile('src/my-js-file.js', 'console.log(1); export const a = 2;');
-  await appendToFile('src/main.ts', `
+  await appendToFile(
+    'src/main.ts',
+    `
     import { a } from './my-js-file';
     console.log(a);
-  `);
+  `,
+  );
 
-  await updateTsConfig(json => {
+  await updateTsConfig((json) => {
     json['compilerOptions'].allowJs = true;
   });
 

--- a/tests/legacy-cli/e2e/tests/build/assets.ts
+++ b/tests/legacy-cli/e2e/tests/build/assets.ts
@@ -16,9 +16,11 @@ export default async function () {
   await expectToFail(() => expectFileToExist('dist/test-project/assets/.gitkeep'));
 
   // Ensure `followSymlinks` option follows symlinks
-  await updateJsonFile('angular.json', workspaceJson => {
+  await updateJsonFile('angular.json', (workspaceJson) => {
     const appArchitect = workspaceJson.projects['test-project'].architect;
-    appArchitect['build'].options.assets = [{ glob: '**/*', input: 'src/assets', output: 'assets', followSymlinks: true }];
+    appArchitect['build'].options.assets = [
+      { glob: '**/*', input: 'src/assets', output: 'assets', followSymlinks: true },
+    ];
   });
   fs.mkdirSync('dirToSymlink/subdir1', { recursive: true });
   fs.mkdirSync('dirToSymlink/subdir2/subsubdir1', { recursive: true });

--- a/tests/legacy-cli/e2e/tests/build/barrel-file.ts
+++ b/tests/legacy-cli/e2e/tests/build/barrel-file.ts
@@ -1,7 +1,7 @@
 import { replaceInFile, writeFile } from '../../utils/fs';
 import { ng } from '../../utils/process';
 
-export default async function() {
+export default async function () {
   await writeFile('src/app/index.ts', `export { AppModule } from './app.module';`);
   await replaceInFile('src/main.ts', './app/app.module', './app');
   await ng('build', '--configuration=development');

--- a/tests/legacy-cli/e2e/tests/build/base-href.ts
+++ b/tests/legacy-cli/e2e/tests/build/base-href.ts
@@ -1,10 +1,10 @@
 import { ng } from '../../utils/process';
 import { expectFileToMatch } from '../../utils/fs';
 
-
-export default function() {
+export default function () {
   // TODO(architect): Delete this test. It is now in devkit/build-angular.
 
-  return ng('build', '--base-href', '/myUrl', '--configuration=development')
-    .then(() => expectFileToMatch('dist/test-project/index.html', /<base href="\/myUrl">/));
+  return ng('build', '--base-href', '/myUrl', '--configuration=development').then(() =>
+    expectFileToMatch('dist/test-project/index.html', /<base href="\/myUrl">/),
+  );
 }

--- a/tests/legacy-cli/e2e/tests/build/build-errors.ts
+++ b/tests/legacy-cli/e2e/tests/build/build-errors.ts
@@ -10,7 +10,7 @@ const extraErrors = [
   `main.ts is not part of the TypeScript compilation.`,
 ];
 
-export default function() {
+export default function () {
   // TODO(architect): Delete this test. It is now in devkit/build-angular.
 
   if (process.platform.startsWith('win')) {
@@ -28,11 +28,11 @@ export default function() {
     Promise.resolve()
       // Save the original contents of `./src/app/app.component.ts`.
       .then(() => readFile('./src/app/app.component.ts'))
-      .then(contents => (origContent = contents))
+      .then((contents) => (origContent = contents))
       // Check `part of the TypeScript compilation` errors.
       // These should show an error only for the missing file.
       .then(() =>
-        updateJsonFile('./tsconfig.app.json', configJson => {
+        updateJsonFile('./tsconfig.app.json', (configJson) => {
           (configJson.include = undefined), (configJson.files = ['src/main.ts']);
         }),
       )
@@ -41,12 +41,12 @@ export default function() {
         if (!message.includes('polyfills.ts is missing from the TypeScript compilation')) {
           throw new Error(`Expected missing TS file error, got this instead:\n${message}`);
         }
-        if (extraErrors.some(e => message.includes(e))) {
+        if (extraErrors.some((e) => message.includes(e))) {
           throw new Error(`Did not expect extra errors but got:\n${message}`);
         }
       })
       .then(() =>
-        updateJsonFile('./tsconfig.app.json', configJson => {
+        updateJsonFile('./tsconfig.app.json', (configJson) => {
           configJson.include = ['src/**/*.ts'];
           configJson.exclude = ['**/**.spec.ts'];
           configJson.files = undefined;
@@ -60,7 +60,7 @@ export default function() {
         if (!message.includes('Declaration or statement expected.')) {
           throw new Error(`Expected syntax error, got this instead:\n${message}`);
         }
-        if (extraErrors.some(e => message.includes(e))) {
+        if (extraErrors.some((e) => message.includes(e))) {
           throw new Error(`Did not expect extra errors but got:\n${message}`);
         }
       })
@@ -76,7 +76,7 @@ export default function() {
         ) {
           throw new Error(`Expected static analysis error, got this instead:\n${message}`);
         }
-        if (extraErrors.some(e => message.includes(e))) {
+        if (extraErrors.some((e) => message.includes(e))) {
           throw new Error(`Did not expect extra errors but got:\n${message}`);
         }
       })

--- a/tests/legacy-cli/e2e/tests/build/build-optimizer.ts
+++ b/tests/legacy-cli/e2e/tests/build/build-optimizer.ts
@@ -2,14 +2,17 @@ import { ng } from '../../utils/process';
 import { expectFileToMatch, expectFileToExist } from '../../utils/fs';
 import { expectToFail } from '../../utils/utils';
 
-
 export default function () {
   // TODO(architect): Delete this test. It is now in devkit/build-angular.
 
   return ng('build', '--aot', '--build-optimizer')
-    .then(() => expectToFail(() => expectFileToMatch('dist/test-project/main.js', /\.decorators =/)))
+    .then(() =>
+      expectToFail(() => expectFileToMatch('dist/test-project/main.js', /\.decorators =/)),
+    )
     .then(() => ng('build'))
     .then(() => expectToFail(() => expectFileToExist('dist/vendor.js')))
-    .then(() => expectToFail(() => expectFileToMatch('dist/test-project/main.js', /\.decorators =/)))
+    .then(() =>
+      expectToFail(() => expectFileToMatch('dist/test-project/main.js', /\.decorators =/)),
+    )
     .then(() => expectToFail(() => ng('build', '--aot=false', '--build-optimizer')));
 }

--- a/tests/legacy-cli/e2e/tests/build/bundle-budgets.ts
+++ b/tests/legacy-cli/e2e/tests/build/bundle-budgets.ts
@@ -11,7 +11,7 @@ import { expectToFail } from '../../utils/utils';
 
 export default async function () {
   // Error
-  await updateJsonFile('angular.json', json => {
+  await updateJsonFile('angular.json', (json) => {
     json.projects['test-project'].architect.build.configurations.production.budgets = [
       { type: 'all', maximumError: '100b' },
     ];
@@ -23,7 +23,7 @@ export default async function () {
   }
 
   // Warning
-  await updateJsonFile('angular.json', json => {
+  await updateJsonFile('angular.json', (json) => {
     json.projects['test-project'].architect.build.configurations.production.budgets = [
       { type: 'all', minimumWarning: '100mb' },
     ];
@@ -35,7 +35,7 @@ export default async function () {
   }
 
   // Pass
-  await updateJsonFile('angular.json', json => {
+  await updateJsonFile('angular.json', (json) => {
     json.projects['test-project'].architect.build.configurations.production.budgets = [
       { type: 'allScript', maximumError: '100mb' },
     ];

--- a/tests/legacy-cli/e2e/tests/build/config-file-fallback.ts
+++ b/tests/legacy-cli/e2e/tests/build/config-file-fallback.ts
@@ -1,8 +1,7 @@
-import {ng} from '../../utils/process';
-import {moveFile} from '../../utils/fs';
+import { ng } from '../../utils/process';
+import { moveFile } from '../../utils/fs';
 
-
-export default function() {
+export default function () {
   return Promise.resolve()
     .then(() => ng('build'))
     .then(() => moveFile('angular.json', '.angular.json'))

--- a/tests/legacy-cli/e2e/tests/build/delete-output-path.ts
+++ b/tests/legacy-cli/e2e/tests/build/delete-output-path.ts
@@ -1,18 +1,20 @@
-import {ng} from '../../utils/process';
-import {expectToFail} from '../../utils/utils';
-import {deleteFile, expectFileToExist} from '../../utils/fs';
-import {getGlobalVariable} from '../../utils/env';
+import { ng } from '../../utils/process';
+import { expectToFail } from '../../utils/utils';
+import { deleteFile, expectFileToExist } from '../../utils/fs';
+import { getGlobalVariable } from '../../utils/env';
 
-export default function() {
+export default function () {
   // TODO(architect): Delete this test. It is now in devkit/build-angular.
 
-  return ng('build')
-    // This is supposed to fail since there's a missing file
-    .then(() => deleteFile('src/app/app.component.ts'))
-    // The build fails but we don't delete the output of the previous build.
-    .then(() => expectToFail(() => ng('build', '--delete-output-path=false')))
-    .then(() => expectFileToExist('dist'))
-    // By default, output path is always cleared.
-    .then(() => expectToFail(() => ng('build', '--configuration=development')))
-    .then(() => expectToFail(() => expectFileToExist('dist/test-project')));
+  return (
+    ng('build')
+      // This is supposed to fail since there's a missing file
+      .then(() => deleteFile('src/app/app.component.ts'))
+      // The build fails but we don't delete the output of the previous build.
+      .then(() => expectToFail(() => ng('build', '--delete-output-path=false')))
+      .then(() => expectFileToExist('dist'))
+      // By default, output path is always cleared.
+      .then(() => expectToFail(() => ng('build', '--configuration=development')))
+      .then(() => expectToFail(() => expectFileToExist('dist/test-project')))
+  );
 }

--- a/tests/legacy-cli/e2e/tests/build/extract-licenses.ts
+++ b/tests/legacy-cli/e2e/tests/build/extract-licenses.ts
@@ -2,7 +2,7 @@ import { expectFileToExist, expectFileToMatch } from '../../utils/fs';
 import { ng } from '../../utils/process';
 import { expectToFail } from '../../utils/utils';
 
-export default async function() {
+export default async function () {
   // Licenses should be left intact if extraction is disabled
   await ng('build', '--extract-licenses=false', '--output-hashing=none');
 

--- a/tests/legacy-cli/e2e/tests/build/jit-prod.ts
+++ b/tests/legacy-cli/e2e/tests/build/jit-prod.ts
@@ -1,10 +1,9 @@
 import { ng } from '../../utils/process';
 import { updateJsonFile } from '../../utils/project';
 
-
 export default async function () {
   // Make prod use JIT.
-  await updateJsonFile('angular.json', configJson => {
+  await updateJsonFile('angular.json', (configJson) => {
     const appArchitect = configJson.projects['test-project'].architect;
     appArchitect.build.configurations['production'].aot = false;
     appArchitect.build.configurations['production'].buildOptimizer = false;

--- a/tests/legacy-cli/e2e/tests/build/json.ts
+++ b/tests/legacy-cli/e2e/tests/build/json.ts
@@ -2,7 +2,7 @@ import { expectFileToExist } from '../../utils/fs';
 import { expectGitToBeClean } from '../../utils/git';
 import { ng } from '../../utils/process';
 
-export default async function() {
+export default async function () {
   await ng('build', '--stats-json', '--configuration=development');
   await expectFileToExist('./dist/test-project/stats.json');
   await expectGitToBeClean();

--- a/tests/legacy-cli/e2e/tests/build/no-angular-router.ts
+++ b/tests/legacy-cli/e2e/tests/build/no-angular-router.ts
@@ -1,10 +1,9 @@
-import {ng} from '../../utils/process';
-import {expectFileToExist, moveFile} from '../../utils/fs';
-import {getGlobalVariable} from '../../utils/env';
+import { ng } from '../../utils/process';
+import { expectFileToExist, moveFile } from '../../utils/fs';
+import { getGlobalVariable } from '../../utils/env';
 import * as path from 'path';
 
-
-export default function() {
+export default function () {
   const tmp = getGlobalVariable('tmp-root');
 
   return Promise.resolve()

--- a/tests/legacy-cli/e2e/tests/build/no-entry-module.ts
+++ b/tests/legacy-cli/e2e/tests/build/no-entry-module.ts
@@ -1,15 +1,13 @@
 import { readFile, writeFile } from '../../utils/fs';
 import { ng } from '../../utils/process';
 
-
-export default async function() {
+export default async function () {
   // TODO(architect): Delete this test. It is now in devkit/build-angular.
 
   const mainTs = await readFile('src/main.ts');
 
-  const newMainTs = mainTs
-    .replace(/platformBrowserDynamic.*?bootstrapModule.*?;/, '')
-    + 'console.log(AppModule);';  // Use AppModule to make sure it's imported properly.
+  const newMainTs =
+    mainTs.replace(/platformBrowserDynamic.*?bootstrapModule.*?;/, '') + 'console.log(AppModule);'; // Use AppModule to make sure it's imported properly.
 
   await writeFile('src/main.ts', newMainTs);
   await ng('build', '--configuration=development');

--- a/tests/legacy-cli/e2e/tests/build/no-sourcemap.ts
+++ b/tests/legacy-cli/e2e/tests/build/no-sourcemap.ts
@@ -5,11 +5,17 @@ export default async function () {
   await ng('build', '--output-hashing=none', '--source-map', 'false');
   await testForSourceMaps(3);
 
-  await ng('build', '--output-hashing=none', '--source-map', 'false', '--configuration=development');
+  await ng(
+    'build',
+    '--output-hashing=none',
+    '--source-map',
+    'false',
+    '--configuration=development',
+  );
   await testForSourceMaps(4);
 }
 
-async function testForSourceMaps(expectedNumberOfFiles: number): Promise <void> {
+async function testForSourceMaps(expectedNumberOfFiles: number): Promise<void> {
   const files = fs.readdirSync('./dist/test-project');
 
   let count = 0;
@@ -31,6 +37,8 @@ async function testForSourceMaps(expectedNumberOfFiles: number): Promise <void> 
   }
 
   if (count < expectedNumberOfFiles) {
-    throw new Error(`Javascript file count is low. Expected ${expectedNumberOfFiles} but found ${count}`);
+    throw new Error(
+      `Javascript file count is low. Expected ${expectedNumberOfFiles} but found ${count}`,
+    );
   }
 }

--- a/tests/legacy-cli/e2e/tests/build/output-dir.ts
+++ b/tests/legacy-cli/e2e/tests/build/output-dir.ts
@@ -1,21 +1,22 @@
-import {expectFileToExist} from '../../utils/fs';
-import {expectGitToBeClean} from '../../utils/git';
-import {ng} from '../../utils/process';
-import {updateJsonFile} from '../../utils/project';
-import {expectToFail} from '../../utils/utils';
+import { expectFileToExist } from '../../utils/fs';
+import { expectGitToBeClean } from '../../utils/git';
+import { ng } from '../../utils/process';
+import { updateJsonFile } from '../../utils/project';
+import { expectToFail } from '../../utils/utils';
 
-
-export default function() {
+export default function () {
   // TODO(architect): Delete this test. It is now in devkit/build-angular.
 
   return ng('build', '--output-path', 'build-output', '--configuration=development')
     .then(() => expectFileToExist('./build-output/index.html'))
     .then(() => expectFileToExist('./build-output/main.js'))
     .then(() => expectToFail(expectGitToBeClean))
-    .then(() => updateJsonFile('angular.json', workspaceJson => {
-      const appArchitect = workspaceJson.projects['test-project'].architect;
-      appArchitect.build.options.outputPath = 'config-build-output';
-    }))
+    .then(() =>
+      updateJsonFile('angular.json', (workspaceJson) => {
+        const appArchitect = workspaceJson.projects['test-project'].architect;
+        appArchitect.build.options.outputPath = 'config-build-output';
+      }),
+    )
     .then(() => ng('build', '--configuration=development'))
     .then(() => expectFileToExist('./config-build-output/index.html'))
     .then(() => expectFileToExist('./config-build-output/main.js'))

--- a/tests/legacy-cli/e2e/tests/build/poll.ts
+++ b/tests/legacy-cli/e2e/tests/build/poll.ts
@@ -1,14 +1,11 @@
 import { appendToFile } from '../../utils/fs';
-import {
-  killAllProcesses,
-  waitForAnyProcessOutputToMatch,
-} from '../../utils/process';
+import { killAllProcesses, waitForAnyProcessOutputToMatch } from '../../utils/process';
 import { ngServe } from '../../utils/project';
 import { expectToFail, wait } from '../../utils/utils';
 
 const webpackGoodRegEx = / Compiled successfully./;
 
-export default async function() {
+export default async function () {
   try {
     await ngServe('--poll=10000');
 

--- a/tests/legacy-cli/e2e/tests/build/rebuild-css-change.ts
+++ b/tests/legacy-cli/e2e/tests/build/rebuild-css-change.ts
@@ -1,26 +1,31 @@
 import {
   killAllProcesses,
   waitForAnyProcessOutputToMatch,
-  execAndWaitForOutputToMatch
+  execAndWaitForOutputToMatch,
 } from '../../utils/process';
-import {appendToFile} from '../../utils/fs';
-import {getGlobalVariable} from '../../utils/env';
+import { appendToFile } from '../../utils/fs';
+import { getGlobalVariable } from '../../utils/env';
 
 const webpackGoodRegEx = / Compiled successfully./;
 
-export default function() {
+export default function () {
   // TODO(architect): Delete this test. It is now in devkit/build-angular.
 
   if (process.platform.startsWith('win')) {
     return Promise.resolve();
   }
 
-  return execAndWaitForOutputToMatch('ng', ['serve'], webpackGoodRegEx)
-    // Should trigger a rebuild.
-    .then(() => appendToFile('src/app/app.component.css', ':host { color: blue; }'))
-    .then(() => waitForAnyProcessOutputToMatch(webpackGoodRegEx, 10000))
-    .then(() => killAllProcesses(), (err: any) => {
-      killAllProcesses();
-      throw err;
-    });
+  return (
+    execAndWaitForOutputToMatch('ng', ['serve'], webpackGoodRegEx)
+      // Should trigger a rebuild.
+      .then(() => appendToFile('src/app/app.component.css', ':host { color: blue; }'))
+      .then(() => waitForAnyProcessOutputToMatch(webpackGoodRegEx, 10000))
+      .then(
+        () => killAllProcesses(),
+        (err: any) => {
+          killAllProcesses();
+          throw err;
+        },
+      )
+  );
 }

--- a/tests/legacy-cli/e2e/tests/build/rebuild-deps-type-check.ts
+++ b/tests/legacy-cli/e2e/tests/build/rebuild-deps-type-check.ts
@@ -3,86 +3,123 @@ import {
   waitForAnyProcessOutputToMatch,
   execAndWaitForOutputToMatch,
 } from '../../utils/process';
-import {writeFile, prependToFile, appendToFile} from '../../utils/fs';
+import { writeFile, prependToFile, appendToFile } from '../../utils/fs';
 
-
-const doneRe =
-  / Compiled successfully.|: Failed to compile./;
+const doneRe = / Compiled successfully.|: Failed to compile./;
 const errorRe = /Error/;
 
-
-export default function() {
+export default function () {
   // TODO(architect): Delete this test. It is now in devkit/build-angular.
 
   if (process.platform.startsWith('win')) {
     return Promise.resolve();
   }
 
-  return Promise.resolve()
-    // Create and import files.
-    .then(() => writeFile('src/funky2.ts', `
+  return (
+    Promise.resolve()
+      // Create and import files.
+      .then(() =>
+        writeFile(
+          'src/funky2.ts',
+          `
       export function funky2(value: string): string {
         return value + 'hello';
       }
-    `))
-    .then(() => writeFile('src/funky.ts', `
+    `,
+        ),
+      )
+      .then(() =>
+        writeFile(
+          'src/funky.ts',
+          `
       export * from './funky2';
-    `))
-    .then(() => prependToFile('src/main.ts', `
+    `,
+        ),
+      )
+      .then(() =>
+        prependToFile(
+          'src/main.ts',
+          `
       import { funky2 } from './funky';
-    `))
-    .then(() => appendToFile('src/main.ts', `
+    `,
+        ),
+      )
+      .then(() =>
+        appendToFile(
+          'src/main.ts',
+          `
       console.log(funky2('town'));
-    `))
-    // Should trigger a rebuild, no error expected.
-    .then(() => execAndWaitForOutputToMatch('ng', ['serve'], doneRe))
-    // Make an invalid version of the file.
-    // Should trigger a rebuild, this time an error is expected.
-    .then(() => Promise.all([
-      waitForAnyProcessOutputToMatch(errorRe, 20000),
-      writeFile('src/funky2.ts', `
+    `,
+        ),
+      )
+      // Should trigger a rebuild, no error expected.
+      .then(() => execAndWaitForOutputToMatch('ng', ['serve'], doneRe))
+      // Make an invalid version of the file.
+      // Should trigger a rebuild, this time an error is expected.
+      .then(() =>
+        Promise.all([
+          waitForAnyProcessOutputToMatch(errorRe, 20000),
+          writeFile(
+            'src/funky2.ts',
+            `
         export function funky2(value: number): number {
           return value + 1;
         }
-      `)
-    ]))
-    .then((results) => {
-      const stderr = results[0].stderr;
-      if (!/Error: (.*src\/)?main\.ts/.test(stderr)) {
-        throw new Error('Expected an error but none happened.');
-      }
-    })
-    // Change an UNRELATED file and the error should still happen.
-    // Should trigger a rebuild, this time an error is also expected.
-    .then(() => Promise.all([
-      waitForAnyProcessOutputToMatch(errorRe, 20000),
-      appendToFile('src/app/app.module.ts', `
+      `,
+          ),
+        ]),
+      )
+      .then((results) => {
+        const stderr = results[0].stderr;
+        if (!/Error: (.*src\/)?main\.ts/.test(stderr)) {
+          throw new Error('Expected an error but none happened.');
+        }
+      })
+      // Change an UNRELATED file and the error should still happen.
+      // Should trigger a rebuild, this time an error is also expected.
+      .then(() =>
+        Promise.all([
+          waitForAnyProcessOutputToMatch(errorRe, 20000),
+          appendToFile(
+            'src/app/app.module.ts',
+            `
         function anything(): number { return 1; }
-      `)
-    ]))
-    .then((results) => {
-      const stderr = results[0].stderr;
-      if (!/Error: (.*src\/)?main\.ts/.test(stderr)) {
-        throw new Error('Expected an error to still be there but none was.');
-      }
-    })
-    // Fix the error!
-    .then(() => Promise.all([
-      waitForAnyProcessOutputToMatch(doneRe, 20000),
-      writeFile('src/funky2.ts', `
+      `,
+          ),
+        ]),
+      )
+      .then((results) => {
+        const stderr = results[0].stderr;
+        if (!/Error: (.*src\/)?main\.ts/.test(stderr)) {
+          throw new Error('Expected an error to still be there but none was.');
+        }
+      })
+      // Fix the error!
+      .then(() =>
+        Promise.all([
+          waitForAnyProcessOutputToMatch(doneRe, 20000),
+          writeFile(
+            'src/funky2.ts',
+            `
         export function funky2(value: string): string {
           return value + 'hello';
         }
-      `)
-    ]))
-    .then((results) => {
-      const stderr = results[0].stderr;
-      if (/Error: (.*src\/)?main\.ts/.test(stderr)) {
-        throw new Error('Expected no error but an error was shown.');
-      }
-    })
-    .then(() => killAllProcesses(), (err: any) => {
-      killAllProcesses();
-      throw err;
-    });
+      `,
+          ),
+        ]),
+      )
+      .then((results) => {
+        const stderr = results[0].stderr;
+        if (/Error: (.*src\/)?main\.ts/.test(stderr)) {
+          throw new Error('Expected no error but an error was shown.');
+        }
+      })
+      .then(
+        () => killAllProcesses(),
+        (err: any) => {
+          killAllProcesses();
+          throw err;
+        },
+      )
+  );
 }

--- a/tests/legacy-cli/e2e/tests/build/rebuild-error.ts
+++ b/tests/legacy-cli/e2e/tests/build/rebuild-error.ts
@@ -7,7 +7,6 @@ import { replaceInFile, readFile, writeFile } from '../../utils/fs';
 import { getGlobalVariable } from '../../utils/env';
 import { wait, expectToFail } from '../../utils/utils';
 
-
 const failedRe = /: Failed to compile/;
 const successRe = / Compiled successfully/;
 const errorRe = /ERROR in/;
@@ -33,76 +32,95 @@ export default function () {
 
   let origContent: string;
 
-  return Promise.resolve()
-    // Save the original contents of `./src/app/app.component.ts`.
-    .then(() => readFile('./src/app/app.component.ts'))
-    .then((contents) => origContent = contents)
-    // Add a major static analysis error on a non-main file to the initial build.
-    .then(() => replaceInFile('./src/app/app.component.ts', `'app-root'`, `(() => 'app-root')()`))
-    // Should have an error.
-    .then(() => execAndWaitForOutputToMatch('ng', ['build', '--watch', '--aot'], failedRe))
-    .then((results) => {
-      const stderr = results.stderr;
-      if (!stderr.includes('Function calls are not supported')
-        && !stderr.includes('Function expressions are not supported in decorators')) {
-        throw new Error(`Expected static analysis error, got this instead:\n${stderr}`);
-      }
-      if (extraErrors.some((e) => stderr.includes(e))) {
-        throw new Error(`Did not expect extra errors but got:\n${stderr}`);
-      }
-    })
-    // Fix the error, should trigger a successful rebuild.
-    .then(() => Promise.all([
-      waitForAnyProcessOutputToMatch(successRe, 20000),
-      writeFile('src/app/app.component.ts', origContent)
-    ]))
-    .then(() => wait(2000))
-    // Add an syntax error to a non-main file.
-    // Build should still be successfull and error reported on forked type checker.
-    .then(() => Promise.all([
-      waitForAnyProcessOutputToMatch(errorRe, 20000),
-      writeFile('src/app/app.component.ts', origContent + '\n]]]]]')
-    ]))
-    .then((results) => {
-      const stderr = results[0].stderr;
-      if (!stderr.includes('Declaration or statement expected.')) {
-        throw new Error(`Expected syntax error, got this instead:\n${stderr}`);
-      }
-      if (extraErrors.some((e) => stderr.includes(e))) {
-        throw new Error(`Did not expect extra errors but got:\n${stderr}`);
-      }
-    })
-    // Fix the error, should trigger a successful rebuild.
-    // We have to wait for the type checker to run, so we expect to NOT
-    // have an error message in 5s.
-    .then(() => Promise.all([
-      expectToFail(() => waitForAnyProcessOutputToMatch(errorRe, 5000)),
-      writeFile('src/app/app.component.ts', origContent)
-    ]))
-    .then(() => wait(2000))
-    // Add a major static analysis error on a rebuild.
-    // Should fail the rebuild.
-    .then(() => Promise.all([
-      waitForAnyProcessOutputToMatch(failedRe, 20000),
-      replaceInFile('./src/app/app.component.ts', `'app-root'`, `(() => 'app-root')()`)
-    ]))
-    .then((results) => {
-      const stderr = results[0].stderr;
-      if (!stderr.includes('Function calls are not supported')
-        && !stderr.includes('Function expressions are not supported in decorators')) {
-        throw new Error(`Expected static analysis error, got this instead:\n${stderr}`);
-      }
-      if (extraErrors.some((e) => stderr.includes(e))) {
-        throw new Error(`Did not expect extra errors but got:\n${stderr}`);
-      }
-    })
-    // Fix the error, should trigger a successful rebuild.
-    .then(() => Promise.all([
-      waitForAnyProcessOutputToMatch(successRe, 20000),
-      writeFile('src/app/app.component.ts', origContent)
-    ]))
-    .then(() => killAllProcesses(), (err: any) => {
-      killAllProcesses();
-      throw err;
-    });
+  return (
+    Promise.resolve()
+      // Save the original contents of `./src/app/app.component.ts`.
+      .then(() => readFile('./src/app/app.component.ts'))
+      .then((contents) => (origContent = contents))
+      // Add a major static analysis error on a non-main file to the initial build.
+      .then(() => replaceInFile('./src/app/app.component.ts', `'app-root'`, `(() => 'app-root')()`))
+      // Should have an error.
+      .then(() => execAndWaitForOutputToMatch('ng', ['build', '--watch', '--aot'], failedRe))
+      .then((results) => {
+        const stderr = results.stderr;
+        if (
+          !stderr.includes('Function calls are not supported') &&
+          !stderr.includes('Function expressions are not supported in decorators')
+        ) {
+          throw new Error(`Expected static analysis error, got this instead:\n${stderr}`);
+        }
+        if (extraErrors.some((e) => stderr.includes(e))) {
+          throw new Error(`Did not expect extra errors but got:\n${stderr}`);
+        }
+      })
+      // Fix the error, should trigger a successful rebuild.
+      .then(() =>
+        Promise.all([
+          waitForAnyProcessOutputToMatch(successRe, 20000),
+          writeFile('src/app/app.component.ts', origContent),
+        ]),
+      )
+      .then(() => wait(2000))
+      // Add an syntax error to a non-main file.
+      // Build should still be successfull and error reported on forked type checker.
+      .then(() =>
+        Promise.all([
+          waitForAnyProcessOutputToMatch(errorRe, 20000),
+          writeFile('src/app/app.component.ts', origContent + '\n]]]]]'),
+        ]),
+      )
+      .then((results) => {
+        const stderr = results[0].stderr;
+        if (!stderr.includes('Declaration or statement expected.')) {
+          throw new Error(`Expected syntax error, got this instead:\n${stderr}`);
+        }
+        if (extraErrors.some((e) => stderr.includes(e))) {
+          throw new Error(`Did not expect extra errors but got:\n${stderr}`);
+        }
+      })
+      // Fix the error, should trigger a successful rebuild.
+      // We have to wait for the type checker to run, so we expect to NOT
+      // have an error message in 5s.
+      .then(() =>
+        Promise.all([
+          expectToFail(() => waitForAnyProcessOutputToMatch(errorRe, 5000)),
+          writeFile('src/app/app.component.ts', origContent),
+        ]),
+      )
+      .then(() => wait(2000))
+      // Add a major static analysis error on a rebuild.
+      // Should fail the rebuild.
+      .then(() =>
+        Promise.all([
+          waitForAnyProcessOutputToMatch(failedRe, 20000),
+          replaceInFile('./src/app/app.component.ts', `'app-root'`, `(() => 'app-root')()`),
+        ]),
+      )
+      .then((results) => {
+        const stderr = results[0].stderr;
+        if (
+          !stderr.includes('Function calls are not supported') &&
+          !stderr.includes('Function expressions are not supported in decorators')
+        ) {
+          throw new Error(`Expected static analysis error, got this instead:\n${stderr}`);
+        }
+        if (extraErrors.some((e) => stderr.includes(e))) {
+          throw new Error(`Did not expect extra errors but got:\n${stderr}`);
+        }
+      })
+      // Fix the error, should trigger a successful rebuild.
+      .then(() =>
+        Promise.all([
+          waitForAnyProcessOutputToMatch(successRe, 20000),
+          writeFile('src/app/app.component.ts', origContent),
+        ]),
+      )
+      .then(
+        () => killAllProcesses(),
+        (err: any) => {
+          killAllProcesses();
+          throw err;
+        },
+      )
+  );
 }

--- a/tests/legacy-cli/e2e/tests/build/rebuild-ngfactories.ts
+++ b/tests/legacy-cli/e2e/tests/build/rebuild-ngfactories.ts
@@ -22,49 +22,68 @@ export default function () {
     return Promise.resolve();
   }
 
-  return execAndWaitForOutputToMatch('ng', ['build', '--watch', '--aot'], validBundleRegEx)
-    .then(() => writeMultipleFiles({
-      'src/app/app.component.css': `
+  return (
+    execAndWaitForOutputToMatch('ng', ['build', '--watch', '--aot'], validBundleRegEx)
+      .then(() =>
+        writeMultipleFiles({
+          'src/app/app.component.css': `
         @import './imported-styles.css';
         body {background-color: #00f;}
       `,
-      'src/app/imported-styles.css': 'p {color: #f00;}',
-    }))
-    // Trigger a few rebuilds first.
-    // The AOT compiler is still optimizing rebuilds on the first rebuild.
-    .then(() => Promise.all([
-      waitForAnyProcessOutputToMatch(validBundleRegEx, 10000),
-      appendToFile('src/main.ts', 'console.log(1)\n')
-    ]))
-    .then(() => Promise.all([
-      waitForAnyProcessOutputToMatch(validBundleRegEx, 10000),
-      appendToFile('src/main.ts', 'console.log(1)\n')
-    ]))
-    // Check if html changes are built.
-    .then(() => Promise.all([
-      waitForAnyProcessOutputToMatch(validBundleRegEx, 10000),
-      appendToFile('src/app/app.component.html', '<p>HTML_REBUILD_STRING<p>')
-    ]))
-    .then(() => expectFileToMatch('dist/test-project/main.js', 'HTML_REBUILD_STRING'))
-    // Check if css changes are built.
-    .then(() => Promise.all([
-      waitForAnyProcessOutputToMatch(validBundleRegEx, 10000),
-      appendToFile('src/app/app.component.css', 'CSS_REBUILD_STRING {color: #f00;}')
-    ]))
-    .then(() => expectFileToMatch('dist/test-project/main.js', 'CSS_REBUILD_STRING'))
-    // Check if css dependency changes are built.
-    .then(() => Promise.all([
-      waitForAnyProcessOutputToMatch(validBundleRegEx, 10000),
-      appendToFile('src/app/imported-styles.css', 'CSS_DEP_REBUILD_STRING {color: #f00;}')
-    ]))
-    .then(() => expectFileToMatch('dist/test-project/main.js', 'CSS_DEP_REBUILD_STRING'))
-    .then(() => Promise.all([
-      waitForAnyProcessOutputToMatch(validBundleRegEx, 10000),
-      replaceInFile('src/app/app.component.ts', 'app-root', 'app-root-FACTORY_REBUILD_STRING')
-    ]))
-    .then(() => expectFileToMatch('dist/test-project/main.js', 'FACTORY_REBUILD_STRING'))
-    .then(() => killAllProcesses(), (err: any) => {
-      killAllProcesses();
-      throw err;
-    });
+          'src/app/imported-styles.css': 'p {color: #f00;}',
+        }),
+      )
+      // Trigger a few rebuilds first.
+      // The AOT compiler is still optimizing rebuilds on the first rebuild.
+      .then(() =>
+        Promise.all([
+          waitForAnyProcessOutputToMatch(validBundleRegEx, 10000),
+          appendToFile('src/main.ts', 'console.log(1)\n'),
+        ]),
+      )
+      .then(() =>
+        Promise.all([
+          waitForAnyProcessOutputToMatch(validBundleRegEx, 10000),
+          appendToFile('src/main.ts', 'console.log(1)\n'),
+        ]),
+      )
+      // Check if html changes are built.
+      .then(() =>
+        Promise.all([
+          waitForAnyProcessOutputToMatch(validBundleRegEx, 10000),
+          appendToFile('src/app/app.component.html', '<p>HTML_REBUILD_STRING<p>'),
+        ]),
+      )
+      .then(() => expectFileToMatch('dist/test-project/main.js', 'HTML_REBUILD_STRING'))
+      // Check if css changes are built.
+      .then(() =>
+        Promise.all([
+          waitForAnyProcessOutputToMatch(validBundleRegEx, 10000),
+          appendToFile('src/app/app.component.css', 'CSS_REBUILD_STRING {color: #f00;}'),
+        ]),
+      )
+      .then(() => expectFileToMatch('dist/test-project/main.js', 'CSS_REBUILD_STRING'))
+      // Check if css dependency changes are built.
+      .then(() =>
+        Promise.all([
+          waitForAnyProcessOutputToMatch(validBundleRegEx, 10000),
+          appendToFile('src/app/imported-styles.css', 'CSS_DEP_REBUILD_STRING {color: #f00;}'),
+        ]),
+      )
+      .then(() => expectFileToMatch('dist/test-project/main.js', 'CSS_DEP_REBUILD_STRING'))
+      .then(() =>
+        Promise.all([
+          waitForAnyProcessOutputToMatch(validBundleRegEx, 10000),
+          replaceInFile('src/app/app.component.ts', 'app-root', 'app-root-FACTORY_REBUILD_STRING'),
+        ]),
+      )
+      .then(() => expectFileToMatch('dist/test-project/main.js', 'FACTORY_REBUILD_STRING'))
+      .then(
+        () => killAllProcesses(),
+        (err: any) => {
+          killAllProcesses();
+          throw err;
+        },
+      )
+  );
 }

--- a/tests/legacy-cli/e2e/tests/build/rebuild-types.ts
+++ b/tests/legacy-cli/e2e/tests/build/rebuild-types.ts
@@ -4,12 +4,11 @@ import {
   execAndWaitForOutputToMatch,
 } from '../../utils/process';
 import { writeFile, prependToFile } from '../../utils/fs';
-import {getGlobalVariable} from '../../utils/env';
-
+import { getGlobalVariable } from '../../utils/env';
 
 const successRe = / Compiled successfully/;
 
-export default async function() {
+export default async function () {
   // TODO(architect): Delete this test. It is now in devkit/build-angular.
 
   if (process.platform.startsWith('win')) {

--- a/tests/legacy-cli/e2e/tests/build/relative-sourcemap.ts
+++ b/tests/legacy-cli/e2e/tests/build/relative-sourcemap.ts
@@ -8,13 +8,12 @@ export default async function () {
   await ng('generate', 'application', 'secondary-project', '--skip-install');
   await ng('build', 'secondary-project', '--configuration=development');
 
-
   await ng('build', '--output-hashing=none', '--source-map', '--configuration=development');
   const content = fs.readFileSync('./dist/secondary-project/main.js.map', 'utf8');
-  const {sources} = JSON.parse(content);
+  const { sources } = JSON.parse(content);
   for (const source of sources) {
-      if (isAbsolute(source)) {
-        throw new Error(`Expected ${source} to be relative.`);
-      }
+    if (isAbsolute(source)) {
+      throw new Error(`Expected ${source} to be relative.`);
+    }
   }
 }

--- a/tests/legacy-cli/e2e/tests/build/styles/empty-style-urls.ts
+++ b/tests/legacy-cli/e2e/tests/build/styles/empty-style-urls.ts
@@ -1,14 +1,15 @@
 import { writeMultipleFiles } from '../../../utils/fs';
 import { ng } from '../../../utils/process';
 
-
 export default function () {
   // TODO(architect): Delete this test. It is now in devkit/build-angular.
 
-  return Promise.resolve()
-    // Write assets.
-    .then(_ => writeMultipleFiles({
-      './src/app/app.component.ts': `
+  return (
+    Promise.resolve()
+      // Write assets.
+      .then((_) =>
+        writeMultipleFiles({
+          './src/app/app.component.ts': `
         import { Component } from '@angular/core';
 
         @Component({
@@ -19,7 +20,9 @@ export default function () {
         export class AppComponent {
           title = 'app';
         }
-      `
-    }))
-    .then(() => ng('build', '--configuration=development'));
+      `,
+        }),
+      )
+      .then(() => ng('build', '--configuration=development'))
+  );
 }

--- a/tests/legacy-cli/e2e/tests/build/styles/symlinked-global.ts
+++ b/tests/legacy-cli/e2e/tests/build/styles/symlinked-global.ts
@@ -10,17 +10,11 @@ export default async function () {
     'src/styles-for-link.scss': `p { color: blue }`,
   });
 
-  symlinkSync(
-    resolve('src/styles-for-link.scss'),
-    resolve('src/styles-linked.scss'),
-  );
+  symlinkSync(resolve('src/styles-for-link.scss'), resolve('src/styles-linked.scss'));
 
-  await updateJsonFile('angular.json', workspaceJson => {
+  await updateJsonFile('angular.json', (workspaceJson) => {
     const appArchitect = workspaceJson.projects['test-project'].architect;
-    appArchitect.build.options.styles = [
-      'src/styles.scss',
-      'src/styles-linked.scss',
-    ];
+    appArchitect.build.options.styles = ['src/styles.scss', 'src/styles-linked.scss'];
   });
 
   await ng('build', '--configuration=development');

--- a/tests/legacy-cli/e2e/tests/build/subresource-integrity.ts
+++ b/tests/legacy-cli/e2e/tests/build/subresource-integrity.ts
@@ -4,15 +4,14 @@ import { expectToFail } from '../../utils/utils';
 
 const integrityRe = /integrity="\w+-[A-Za-z0-9\/\+=]+"/;
 
-export default async function() {
+export default async function () {
   // TODO(architect): Delete this test. It is now in devkit/build-angular.
 
   // WEBPACK4_DISABLED - disabled pending a webpack 4 version
   return;
 
   return ng('build')
-    .then(() => expectToFail(() =>
-      expectFileToMatch('dist/test-project/index.html', integrityRe)))
+    .then(() => expectToFail(() => expectFileToMatch('dist/test-project/index.html', integrityRe)))
     .then(() => ng('build', '--sri'))
     .then(() => expectFileToMatch('dist/test-project/index.html', integrityRe));
 }

--- a/tests/legacy-cli/e2e/tests/build/vendor-chunk.ts
+++ b/tests/legacy-cli/e2e/tests/build/vendor-chunk.ts
@@ -2,7 +2,6 @@ import { expectFileToExist } from '../../utils/fs';
 import { ng } from '../../utils/process';
 import { expectToFail } from '../../utils/utils';
 
-
 export default async function () {
   await ng('build', '--configuration=development');
   await expectFileToExist('dist/test-project/vendor.js');

--- a/tests/legacy-cli/e2e/tests/commands/add/add-material.ts
+++ b/tests/legacy-cli/e2e/tests/commands/add/add-material.ts
@@ -3,12 +3,11 @@ import { uninstallPackage } from '../../../utils/packages';
 import { ng } from '../../../utils/process';
 import { isPrereleaseCli } from '../../../utils/project';
 
-
 export default async function () {
   // forcibly remove in case another test doesn't clean itself up
   await rimraf('node_modules/@angular/material');
 
-  const tag = await isPrereleaseCli() ?  '@next' : '';
+  const tag = (await isPrereleaseCli()) ? '@next' : '';
 
   try {
     await ng('add', `@angular/material${tag}`, '--unknown', '--skip-confirmation');
@@ -18,7 +17,14 @@ export default async function () {
     }
   }
 
-  await ng('add',  `@angular/material${tag}`, '--theme', 'custom', '--verbose', '--skip-confirmation');
+  await ng(
+    'add',
+    `@angular/material${tag}`,
+    '--theme',
+    'custom',
+    '--verbose',
+    '--skip-confirmation',
+  );
   await expectFileToMatch('package.json', /@angular\/material/);
 
   // Clean up existing cdk package

--- a/tests/legacy-cli/e2e/tests/commands/add/add-version.ts
+++ b/tests/legacy-cli/e2e/tests/commands/add/add-version.ts
@@ -1,7 +1,6 @@
 import { expectFileToExist, expectFileToMatch, rimraf } from '../../../utils/fs';
 import { ng } from '../../../utils/process';
 
-
 export default async function () {
   await ng('add', '@angular-devkit-tests/ng-add-simple@^1.0.0', '--skip-confirmation');
   await expectFileToMatch('package.json', /\/ng-add-simple.*\^1\.0\.0/);

--- a/tests/legacy-cli/e2e/tests/commands/add/add.ts
+++ b/tests/legacy-cli/e2e/tests/commands/add/add.ts
@@ -1,7 +1,6 @@
 import { expectFileToExist, expectFileToMatch, rimraf } from '../../../utils/fs';
 import { ng } from '../../../utils/process';
 
-
 export default async function () {
   await ng('add', '@angular-devkit-tests/ng-add-simple', '--skip-confirmation');
   await expectFileToMatch('package.json', /@angular-devkit-tests\/ng-add-simple/);

--- a/tests/legacy-cli/e2e/tests/commands/add/base.ts
+++ b/tests/legacy-cli/e2e/tests/commands/add/base.ts
@@ -3,7 +3,6 @@ import { expectFileToExist, rimraf, symlinkFile } from '../../../utils/fs';
 import { ng } from '../../../utils/process';
 import { expectToFail } from '../../../utils/utils';
 
-
 export default async function () {
   await symlinkFile(assetDir('add-collection'), `./node_modules/add-collection`, 'dir');
 
@@ -13,7 +12,7 @@ export default async function () {
   await ng('add', 'add-collection', '--name=blah');
   await expectFileToExist('blah');
 
-  await expectToFail(() => ng('add', 'add-collection'));  // File already exists.
+  await expectToFail(() => ng('add', 'add-collection')); // File already exists.
 
   // Cleanup the package
   await rimraf('node_modules/add-collection');

--- a/tests/legacy-cli/e2e/tests/commands/add/dir.ts
+++ b/tests/legacy-cli/e2e/tests/commands/add/dir.ts
@@ -2,7 +2,6 @@ import { assetDir } from '../../../utils/assets';
 import { expectFileToExist } from '../../../utils/fs';
 import { ng } from '../../../utils/process';
 
-
 export default async function () {
   await ng('add', assetDir('add-collection'), '--name=blah', '--skip-confirmation');
   await expectFileToExist('blah');

--- a/tests/legacy-cli/e2e/tests/commands/add/file.ts
+++ b/tests/legacy-cli/e2e/tests/commands/add/file.ts
@@ -2,7 +2,6 @@ import { assetDir } from '../../../utils/assets';
 import { expectFileToExist } from '../../../utils/fs';
 import { ng } from '../../../utils/process';
 
-
 export default async function () {
   await ng('add', assetDir('add-collection.tgz'), '--name=blah', '--skip-confirmation');
   await expectFileToExist('blah');

--- a/tests/legacy-cli/e2e/tests/commands/add/peer.ts
+++ b/tests/legacy-cli/e2e/tests/commands/add/peer.ts
@@ -4,17 +4,25 @@ import { ng } from '../../../utils/process';
 const warning = 'Adding the package may not succeed.';
 
 export default async function () {
-  const { stderr: bad } = await ng('add', assetDir('add-collection-peer-bad'), '--skip-confirmation');
+  const { stderr: bad } = await ng(
+    'add',
+    assetDir('add-collection-peer-bad'),
+    '--skip-confirmation',
+  );
   if (!bad.includes(warning)) {
     throw new Error('peer warning not shown on bad package');
   }
 
-  const { stderr: base  } = await ng('add', assetDir('add-collection'), '--skip-confirmation');
+  const { stderr: base } = await ng('add', assetDir('add-collection'), '--skip-confirmation');
   if (base.includes(warning)) {
     throw new Error('peer warning shown on base package');
   }
 
-  const { stderr: good  } = await ng('add', assetDir('add-collection-peer-good'), '--skip-confirmation');
+  const { stderr: good } = await ng(
+    'add',
+    assetDir('add-collection-peer-good'),
+    '--skip-confirmation',
+  );
   if (good.includes(warning)) {
     throw new Error('peer warning shown on good package');
   }

--- a/tests/legacy-cli/e2e/tests/commands/build/build-outdir.ts
+++ b/tests/legacy-cli/e2e/tests/commands/build/build-outdir.ts
@@ -1,16 +1,18 @@
-import {ng} from '../../../utils/process';
-import {updateJsonFile} from '../../../utils/project';
-import {expectToFail} from '../../../utils/utils';
+import { ng } from '../../../utils/process';
+import { updateJsonFile } from '../../../utils/project';
+import { expectToFail } from '../../../utils/utils';
 
-export default function() {
+export default function () {
   // TODO(architect): This isn't working correctly in devkit/build-angular, due to module resolution.
   return;
 
   return Promise.resolve()
-    .then(() => updateJsonFile('angular.json', workspaceJson => {
-      const appArchitect = workspaceJson.projects['test-project'].architect;
-      appArchitect.build.options.outputPath = './';
-    }))
+    .then(() =>
+      updateJsonFile('angular.json', (workspaceJson) => {
+        const appArchitect = workspaceJson.projects['test-project'].architect;
+        appArchitect.build.options.outputPath = './';
+      }),
+    )
     .then(() => expectToFail(() => ng('build', '--configuration=development')))
     .then(() => expectToFail(() => ng('serve')));
 }

--- a/tests/legacy-cli/e2e/tests/commands/config/config-global.ts
+++ b/tests/legacy-cli/e2e/tests/commands/config/config-global.ts
@@ -4,13 +4,10 @@ import { deleteFile, expectFileToExist } from '../../../utils/fs';
 import { ng } from '../../../utils/process';
 import { expectToFail } from '../../../utils/utils';
 
-
-export default async function() {
-  await expectToFail(() => ng(
-    'config',
-    '--global',
-    'schematics.@schematics/angular.component.inlineStyle',
-  ));
+export default async function () {
+  await expectToFail(() =>
+    ng('config', '--global', 'schematics.@schematics/angular.component.inlineStyle'),
+  );
 
   await ng('config', '--global', 'schematics.@schematics/angular.component.inlineStyle', 'false');
   let output = await ng(

--- a/tests/legacy-cli/e2e/tests/commands/config/config-set-enum-check.ts
+++ b/tests/legacy-cli/e2e/tests/commands/config/config-set-enum-check.ts
@@ -1,20 +1,15 @@
 import { ng } from '../../../utils/process';
 
-export default async function() {
+export default async function () {
+  // These tests require schema querying capabilities
+  // .then(() => expectToFail(
+  //   () => ng('config', 'schematics.@schematics/angular.component.aaa', 'bbb')),
+  // )
+  // .then(() => expectToFail(() => ng(
+  //   'config',
+  //   'schematics.@schematics/angular.component.viewEncapsulation',
+  //   'bbb',
+  // )))
 
-    // These tests require schema querying capabilities
-    // .then(() => expectToFail(
-    //   () => ng('config', 'schematics.@schematics/angular.component.aaa', 'bbb')),
-    // )
-    // .then(() => expectToFail(() => ng(
-    //   'config',
-    //   'schematics.@schematics/angular.component.viewEncapsulation',
-    //   'bbb',
-    // )))
-
-  await ng(
-    'config',
-    'schematics.@schematics/angular.component.viewEncapsulation',
-    'Emulated',
-  );
+  await ng('config', 'schematics.@schematics/angular.component.viewEncapsulation', 'Emulated');
 }

--- a/tests/legacy-cli/e2e/tests/commands/config/config-set-prefix.ts
+++ b/tests/legacy-cli/e2e/tests/commands/config/config-set-prefix.ts
@@ -1,10 +1,10 @@
 import { ng } from '../../../utils/process';
 import { expectToFail } from '../../../utils/utils';
 
-export default function() {
+export default function () {
   return Promise.resolve()
     .then(() => expectToFail(() => ng('config', 'schematics.@schematics/angular.component.prefix')))
-    .then(() => ng('config', 'schematics.@schematics/angular.component.prefix' , 'new-prefix'))
+    .then(() => ng('config', 'schematics.@schematics/angular.component.prefix', 'new-prefix'))
     .then(() => ng('config', 'schematics.@schematics/angular.component.prefix'))
     .then(({ stdout }) => {
       if (!stdout.match(/new-prefix/)) {

--- a/tests/legacy-cli/e2e/tests/commands/config/config-set-serve-port.ts
+++ b/tests/legacy-cli/e2e/tests/commands/config/config-set-serve-port.ts
@@ -1,7 +1,7 @@
 import { expectFileToMatch } from '../../../utils/fs';
 import { ng } from '../../../utils/process';
 
-export default function() {
+export default function () {
   return Promise.resolve()
     .then(() => ng('config', 'projects.test-project.architect.serve.options.port', '1234'))
     .then(() => expectFileToMatch('angular.json', /"port": 1234/));

--- a/tests/legacy-cli/e2e/tests/commands/serve/reload-shims.ts
+++ b/tests/legacy-cli/e2e/tests/commands/serve/reload-shims.ts
@@ -1,7 +1,7 @@
 import { prependToFile, writeFile } from '../../../utils/fs';
 import { execAndWaitForOutputToMatch, killAllProcesses } from '../../../utils/process';
 
-export default async function() {
+export default async function () {
   // Simulate a JS library using a Node.js specific module
   await writeFile('src/node-usage.js', `const path = require('path');\n`);
   await prependToFile('src/main.ts', `import './node-usage';\n`);

--- a/tests/legacy-cli/e2e/tests/commands/serve/serve-path.ts
+++ b/tests/legacy-cli/e2e/tests/commands/serve/serve-path.ts
@@ -8,24 +8,30 @@ export default function () {
   return Promise.resolve()
     .then(() => ngServe('--serve-path', 'test/'))
     .then(() => request('http://localhost:4200/test'))
-    .then(body => {
+    .then((body) => {
       if (!body.match(/<app-root><\/app-root>/)) {
         throw new Error('Response does not match expected value.');
       }
     })
     .then(() => request('http://localhost:4200/test/abc'))
-    .then(body => {
+    .then((body) => {
       if (!body.match(/<app-root><\/app-root>/)) {
         throw new Error('Response does not match expected value.');
       }
     })
-    .then(() => killAllProcesses(), (err) => { killAllProcesses(); throw err; })
-    // .then(() => ngServe('--base-href', 'test/'))
-    // .then(() => request('http://localhost:4200/test'))
-    // .then(body => {
-    //   if (!body.match(/<app-root><\/app-root>/)) {
-    //     throw new Error('Response does not match expected value.');
-    //   }
-    // })
-    // .then(() => killAllProcesses(), (err) => { killAllProcesses(); throw err; });
+    .then(
+      () => killAllProcesses(),
+      (err) => {
+        killAllProcesses();
+        throw err;
+      },
+    );
+  // .then(() => ngServe('--base-href', 'test/'))
+  // .then(() => request('http://localhost:4200/test'))
+  // .then(body => {
+  //   if (!body.match(/<app-root><\/app-root>/)) {
+  //     throw new Error('Response does not match expected value.');
+  //   }
+  // })
+  // .then(() => killAllProcesses(), (err) => { killAllProcesses(); throw err; });
 }

--- a/tests/legacy-cli/e2e/tests/commands/unknown-configuration.ts
+++ b/tests/legacy-cli/e2e/tests/commands/unknown-configuration.ts
@@ -1,4 +1,4 @@
-import { ng } from "../../utils/process";
+import { ng } from '../../utils/process';
 
 export default async function () {
   try {
@@ -9,4 +9,4 @@ export default async function () {
       throw error;
     }
   }
-};
+}

--- a/tests/legacy-cli/e2e/tests/generate/application/application-basic.ts
+++ b/tests/legacy-cli/e2e/tests/generate/application/application-basic.ts
@@ -2,8 +2,7 @@ import { expectFileToMatch } from '../../../utils/fs';
 import { ng } from '../../../utils/process';
 import { useCIChrome } from '../../../utils/project';
 
-
-export default function() {
+export default function () {
   return ng('generate', 'application', 'app2')
     .then(() => expectFileToMatch('angular.json', /\"app2\":/))
     .then(() => useCIChrome('projects/app2'))

--- a/tests/legacy-cli/e2e/tests/generate/class.ts
+++ b/tests/legacy-cli/e2e/tests/generate/class.ts
@@ -1,16 +1,17 @@
-import {join} from 'path';
-import {ng} from '../../utils/process';
-import {expectFileToExist} from '../../utils/fs';
+import { join } from 'path';
+import { ng } from '../../utils/process';
+import { expectFileToExist } from '../../utils/fs';
 
-
-export default function() {
+export default function () {
   const projectDir = join('src', 'app');
 
-  return ng('generate', 'class', 'test-class')
-    .then(() => expectFileToExist(projectDir))
-    .then(() => expectFileToExist(join(projectDir, 'test-class.ts')))
-    .then(() => expectFileToExist(join(projectDir, 'test-class.spec.ts')))
+  return (
+    ng('generate', 'class', 'test-class')
+      .then(() => expectFileToExist(projectDir))
+      .then(() => expectFileToExist(join(projectDir, 'test-class.ts')))
+      .then(() => expectFileToExist(join(projectDir, 'test-class.spec.ts')))
 
-    // Try to run the unit tests.
-    .then(() => ng('test', '--watch=false'));
+      // Try to run the unit tests.
+      .then(() => ng('test', '--watch=false'))
+  );
 }

--- a/tests/legacy-cli/e2e/tests/generate/component/component-basic.ts
+++ b/tests/legacy-cli/e2e/tests/generate/component/component-basic.ts
@@ -1,22 +1,22 @@
-import {join} from 'path';
-import {ng} from '../../../utils/process';
-import {expectFileToExist, expectFileToMatch} from '../../../utils/fs';
+import { join } from 'path';
+import { ng } from '../../../utils/process';
+import { expectFileToExist, expectFileToMatch } from '../../../utils/fs';
 
-
-export default function() {
+export default function () {
   const projectDir = join('src', 'app');
   const componentDir = join(projectDir, 'test-component');
 
-  const importCheck =
-    `import { TestComponentComponent } from './test-component/test-component.component';`;
-  return ng('generate', 'component', 'test-component')
-    .then(() => expectFileToExist(componentDir))
-    .then(() => expectFileToExist(join(componentDir, 'test-component.component.ts')))
-    .then(() => expectFileToExist(join(componentDir, 'test-component.component.spec.ts')))
-    .then(() => expectFileToExist(join(componentDir, 'test-component.component.html')))
-    .then(() => expectFileToExist(join(componentDir, 'test-component.component.css')))
-    .then(() => expectFileToMatch(join(projectDir, 'app.module.ts'), importCheck))
+  const importCheck = `import { TestComponentComponent } from './test-component/test-component.component';`;
+  return (
+    ng('generate', 'component', 'test-component')
+      .then(() => expectFileToExist(componentDir))
+      .then(() => expectFileToExist(join(componentDir, 'test-component.component.ts')))
+      .then(() => expectFileToExist(join(componentDir, 'test-component.component.spec.ts')))
+      .then(() => expectFileToExist(join(componentDir, 'test-component.component.html')))
+      .then(() => expectFileToExist(join(componentDir, 'test-component.component.css')))
+      .then(() => expectFileToMatch(join(projectDir, 'app.module.ts'), importCheck))
 
-    // Try to run the unit tests.
-    .then(() => ng('test', '--watch=false'));
+      // Try to run the unit tests.
+      .then(() => ng('test', '--watch=false'))
+  );
 }

--- a/tests/legacy-cli/e2e/tests/generate/component/component-flag-case.ts
+++ b/tests/legacy-cli/e2e/tests/generate/component/component-flag-case.ts
@@ -1,19 +1,34 @@
-import {join} from 'path';
-import {ng} from '../../../utils/process';
-import {expectFileToMatch} from '../../../utils/fs';
+import { join } from 'path';
+import { ng } from '../../../utils/process';
+import { expectFileToMatch } from '../../../utils/fs';
 
-
-export default function() {
+export default function () {
   // TODO:BREAKING CHANGE... NO LONGER SUPPORTED
   return Promise.resolve();
   const compDir = join('projects', 'test-project', 'src', 'test');
 
   return Promise.resolve()
-    .then(() => ng('generate', 'component', 'test',
-      '--change-detection', 'onpush',
-      '--view-encapsulation', 'emulated'))
-    .then(() => expectFileToMatch(join(compDir, 'test.component.ts'),
-      /changeDetection: ChangeDetectionStrategy.OnPush/))
-    .then(() => expectFileToMatch(join(compDir, 'test.component.ts'),
-      /encapsulation: ViewEncapsulation.Emulated/));
+    .then(() =>
+      ng(
+        'generate',
+        'component',
+        'test',
+        '--change-detection',
+        'onpush',
+        '--view-encapsulation',
+        'emulated',
+      ),
+    )
+    .then(() =>
+      expectFileToMatch(
+        join(compDir, 'test.component.ts'),
+        /changeDetection: ChangeDetectionStrategy.OnPush/,
+      ),
+    )
+    .then(() =>
+      expectFileToMatch(
+        join(compDir, 'test.component.ts'),
+        /encapsulation: ViewEncapsulation.Emulated/,
+      ),
+    );
 }

--- a/tests/legacy-cli/e2e/tests/generate/component/component-flat.ts
+++ b/tests/legacy-cli/e2e/tests/generate/component/component-flat.ts
@@ -1,24 +1,27 @@
-import {join} from 'path';
-import {ng} from '../../../utils/process';
-import {expectFileToExist} from '../../../utils/fs';
-import {updateJsonFile} from '../../../utils/project';
+import { join } from 'path';
+import { ng } from '../../../utils/process';
+import { expectFileToExist } from '../../../utils/fs';
+import { updateJsonFile } from '../../../utils/project';
 
-
-export default function() {
+export default function () {
   const appDir = join('src', 'app');
-  return Promise.resolve()
-    .then(() => updateJsonFile('angular.json', configJson => {
-      configJson.projects['test-project'].schematics = {
-        '@schematics/angular:component': { flat: true }
-      };
-    }))
-    .then(() => ng('generate', 'component', 'test-component'))
-    .then(() => expectFileToExist(appDir))
-    .then(() => expectFileToExist(join(appDir, 'test-component.component.ts')))
-    .then(() => expectFileToExist(join(appDir, 'test-component.component.spec.ts')))
-    .then(() => expectFileToExist(join(appDir, 'test-component.component.html')))
-    .then(() => expectFileToExist(join(appDir, 'test-component.component.css')))
+  return (
+    Promise.resolve()
+      .then(() =>
+        updateJsonFile('angular.json', (configJson) => {
+          configJson.projects['test-project'].schematics = {
+            '@schematics/angular:component': { flat: true },
+          };
+        }),
+      )
+      .then(() => ng('generate', 'component', 'test-component'))
+      .then(() => expectFileToExist(appDir))
+      .then(() => expectFileToExist(join(appDir, 'test-component.component.ts')))
+      .then(() => expectFileToExist(join(appDir, 'test-component.component.spec.ts')))
+      .then(() => expectFileToExist(join(appDir, 'test-component.component.html')))
+      .then(() => expectFileToExist(join(appDir, 'test-component.component.css')))
 
-    // Try to run the unit tests.
-    .then(() => ng('test', '--watch=false'));
+      // Try to run the unit tests.
+      .then(() => ng('test', '--watch=false'))
+  );
 }

--- a/tests/legacy-cli/e2e/tests/generate/component/component-inline-template.ts
+++ b/tests/legacy-cli/e2e/tests/generate/component/component-inline-template.ts
@@ -1,26 +1,31 @@
-import {join} from 'path';
-import {ng} from '../../../utils/process';
-import {expectFileToExist} from '../../../utils/fs';
-import {updateJsonFile} from '../../../utils/project';
+import { join } from 'path';
+import { ng } from '../../../utils/process';
+import { expectFileToExist } from '../../../utils/fs';
+import { updateJsonFile } from '../../../utils/project';
 import { expectToFail } from '../../../utils/utils';
 
-
 // tslint:disable:max-line-length
-export default function() {
+export default function () {
   const componentDir = join('src', 'app', 'test-component');
-  return Promise.resolve()
-    .then(() => updateJsonFile('angular.json', configJson => {
-      configJson.projects['test-project'].schematics = {
-        '@schematics/angular:component': { inlineTemplate: true }
-      };
-    }))
-    .then(() => ng('generate', 'component', 'test-component'))
-    .then(() => expectFileToExist(componentDir))
-    .then(() => expectFileToExist(join(componentDir, 'test-component.component.ts')))
-    .then(() => expectFileToExist(join(componentDir, 'test-component.component.spec.ts')))
-    .then(() => expectToFail(() => expectFileToExist(join(componentDir, 'test-component.component.html'))))
-    .then(() => expectFileToExist(join(componentDir, 'test-component.component.css')))
+  return (
+    Promise.resolve()
+      .then(() =>
+        updateJsonFile('angular.json', (configJson) => {
+          configJson.projects['test-project'].schematics = {
+            '@schematics/angular:component': { inlineTemplate: true },
+          };
+        }),
+      )
+      .then(() => ng('generate', 'component', 'test-component'))
+      .then(() => expectFileToExist(componentDir))
+      .then(() => expectFileToExist(join(componentDir, 'test-component.component.ts')))
+      .then(() => expectFileToExist(join(componentDir, 'test-component.component.spec.ts')))
+      .then(() =>
+        expectToFail(() => expectFileToExist(join(componentDir, 'test-component.component.html'))),
+      )
+      .then(() => expectFileToExist(join(componentDir, 'test-component.component.css')))
 
-    // Try to run the unit tests.
-    .then(() => ng('test', '--watch=false'));
+      // Try to run the unit tests.
+      .then(() => ng('test', '--watch=false'))
+  );
 }

--- a/tests/legacy-cli/e2e/tests/generate/component/component-module-2.ts
+++ b/tests/legacy-cli/e2e/tests/generate/component/component-module-2.ts
@@ -1,20 +1,26 @@
-import {join} from 'path';
-import {ng} from '../../../utils/process';
-import {expectFileToMatch} from '../../../utils/fs';
+import { join } from 'path';
+import { ng } from '../../../utils/process';
+import { expectFileToMatch } from '../../../utils/fs';
 
-
-export default function() {
+export default function () {
   const root = process.cwd();
-  const modulePath = join(root, 'src', 'app',
-    'admin', 'module', 'module.module.ts');
+  const modulePath = join(root, 'src', 'app', 'admin', 'module', 'module.module.ts');
 
-  return Promise.resolve()
-    .then(() => ng('generate', 'module', 'admin/module'))
-    .then(() => ng('generate', 'component', 'other/test-component', '--module', 'admin/module'))
-    .then(() => expectFileToMatch(modulePath,
-      new RegExp(/import { TestComponentComponent } /.source +
-                 /from '..\/..\/other\/test-component\/test-component.component'/.source)))
+  return (
+    Promise.resolve()
+      .then(() => ng('generate', 'module', 'admin/module'))
+      .then(() => ng('generate', 'component', 'other/test-component', '--module', 'admin/module'))
+      .then(() =>
+        expectFileToMatch(
+          modulePath,
+          new RegExp(
+            /import { TestComponentComponent } /.source +
+              /from '..\/..\/other\/test-component\/test-component.component'/.source,
+          ),
+        ),
+      )
 
-    // Try to run the unit tests.
-    .then(() => ng('build', '--configuration=development'));
+      // Try to run the unit tests.
+      .then(() => ng('build', '--configuration=development'))
+  );
 }

--- a/tests/legacy-cli/e2e/tests/generate/component/component-module-export.ts
+++ b/tests/legacy-cli/e2e/tests/generate/component/component-module-export.ts
@@ -1,14 +1,17 @@
-import {join} from 'path';
-import {ng} from '../../../utils/process';
-import {expectFileToMatch} from '../../../utils/fs';
+import { join } from 'path';
+import { ng } from '../../../utils/process';
+import { expectFileToMatch } from '../../../utils/fs';
 
-
-export default function() {
+export default function () {
   const modulePath = join('src', 'app', 'app.module.ts');
 
-  return ng('generate', 'component', 'test-component', '--export')
-    .then(() => expectFileToMatch(modulePath, /exports: \[\r?\n(\s*)  TestComponentComponent\r?\n\1\]/))
+  return (
+    ng('generate', 'component', 'test-component', '--export')
+      .then(() =>
+        expectFileToMatch(modulePath, /exports: \[\r?\n(\s*)  TestComponentComponent\r?\n\1\]/),
+      )
 
-    // Try to run the unit tests.
-    .then(() => ng('test', '--watch=false'));
+      // Try to run the unit tests.
+      .then(() => ng('test', '--watch=false'))
+  );
 }

--- a/tests/legacy-cli/e2e/tests/generate/component/component-module-fail.ts
+++ b/tests/legacy-cli/e2e/tests/generate/component/component-module-fail.ts
@@ -1,9 +1,10 @@
-import {ng} from '../../../utils/process';
-import {expectToFail} from '../../../utils/utils';
+import { ng } from '../../../utils/process';
+import { expectToFail } from '../../../utils/utils';
 
-
-export default function() {
-  return Promise.resolve()
-    .then(() => expectToFail(() =>
-      ng('generate', 'component', 'test-component', '--module', 'app.moduleXXX.ts')));
+export default function () {
+  return Promise.resolve().then(() =>
+    expectToFail(() =>
+      ng('generate', 'component', 'test-component', '--module', 'app.moduleXXX.ts'),
+    ),
+  );
 }

--- a/tests/legacy-cli/e2e/tests/generate/component/component-module.ts
+++ b/tests/legacy-cli/e2e/tests/generate/component/component-module.ts
@@ -1,23 +1,32 @@
-import {join} from 'path';
-import {ng} from '../../../utils/process';
-import {expectFileToMatch} from '../../../utils/fs';
+import { join } from 'path';
+import { ng } from '../../../utils/process';
+import { expectFileToMatch } from '../../../utils/fs';
 
-
-export default function() {
+export default function () {
   const root = process.cwd();
   //                       projects/   test-project/   src/   app.module.ts
   const modulePath = join('src', 'app', 'app.module.ts');
 
-  return ng('generate', 'component', 'test-component', '--module', 'app.module.ts')
-    .then(() => expectFileToMatch(modulePath,
-      /import { TestComponentComponent } from '.\/test-component\/test-component.component'/))
+  return (
+    ng('generate', 'component', 'test-component', '--module', 'app.module.ts')
+      .then(() =>
+        expectFileToMatch(
+          modulePath,
+          /import { TestComponentComponent } from '.\/test-component\/test-component.component'/,
+        ),
+      )
 
-    .then(() => process.chdir(join(root, 'src', 'app')))
-    .then(() => ng('generate', 'component', 'test-component2', '--module', 'app.module.ts'))
-    .then(() => process.chdir('../..'))
-    .then(() => expectFileToMatch(modulePath,
-      /import { TestComponent2Component } from '.\/test-component2\/test-component2.component'/))
+      .then(() => process.chdir(join(root, 'src', 'app')))
+      .then(() => ng('generate', 'component', 'test-component2', '--module', 'app.module.ts'))
+      .then(() => process.chdir('../..'))
+      .then(() =>
+        expectFileToMatch(
+          modulePath,
+          /import { TestComponent2Component } from '.\/test-component2\/test-component2.component'/,
+        ),
+      )
 
-    // Try to run the unit tests.
-    .then(() => ng('build', '--configuration=development'));
+      // Try to run the unit tests.
+      .then(() => ng('build', '--configuration=development'))
+  );
 }

--- a/tests/legacy-cli/e2e/tests/generate/component/component-not-flat.ts
+++ b/tests/legacy-cli/e2e/tests/generate/component/component-not-flat.ts
@@ -1,25 +1,28 @@
-import {join} from 'path';
-import {ng} from '../../../utils/process';
-import {expectFileToExist} from '../../../utils/fs';
-import {updateJsonFile} from '../../../utils/project';
+import { join } from 'path';
+import { ng } from '../../../utils/process';
+import { expectFileToExist } from '../../../utils/fs';
+import { updateJsonFile } from '../../../utils/project';
 
-
-export default function() {
+export default function () {
   const componentDir = join('src', 'app', 'test-component');
 
-  return Promise.resolve()
-    .then(() => updateJsonFile('angular.json', configJson => {
-      configJson.projects['test-project'].schematics = {
-        '@schematics/angular:component': { flat: false }
-      };
-    }))
-    .then(() => ng('generate', 'component', 'test-component'))
-    .then(() => expectFileToExist(componentDir))
-    .then(() => expectFileToExist(join(componentDir, 'test-component.component.ts')))
-    .then(() => expectFileToExist(join(componentDir, 'test-component.component.spec.ts')))
-    .then(() => expectFileToExist(join(componentDir, 'test-component.component.html')))
-    .then(() => expectFileToExist(join(componentDir, 'test-component.component.css')))
+  return (
+    Promise.resolve()
+      .then(() =>
+        updateJsonFile('angular.json', (configJson) => {
+          configJson.projects['test-project'].schematics = {
+            '@schematics/angular:component': { flat: false },
+          };
+        }),
+      )
+      .then(() => ng('generate', 'component', 'test-component'))
+      .then(() => expectFileToExist(componentDir))
+      .then(() => expectFileToExist(join(componentDir, 'test-component.component.ts')))
+      .then(() => expectFileToExist(join(componentDir, 'test-component.component.spec.ts')))
+      .then(() => expectFileToExist(join(componentDir, 'test-component.component.html')))
+      .then(() => expectFileToExist(join(componentDir, 'test-component.component.css')))
 
-    // Try to run the unit tests.
-    .then(() => ng('test', '--watch=false'));
+      // Try to run the unit tests.
+      .then(() => ng('test', '--watch=false'))
+  );
 }

--- a/tests/legacy-cli/e2e/tests/generate/component/component-path-case.ts
+++ b/tests/legacy-cli/e2e/tests/generate/component/component-path-case.ts
@@ -11,7 +11,7 @@ export default async function () {
 
   try {
     // Generate a component
-    await ng('generate', 'component', `${upperDirs}/test-component`)
+    await ng('generate', 'component', `${upperDirs}/test-component`);
 
     // Ensure component is created in the correct location relative to the workspace root
     await expectFileToExist(join(componentDirectory, 'test-component.component.ts'));

--- a/tests/legacy-cli/e2e/tests/generate/component/component-prefix.ts
+++ b/tests/legacy-cli/e2e/tests/generate/component/component-prefix.ts
@@ -1,26 +1,29 @@
-import {join} from 'path';
-import {ng} from '../../../utils/process';
-import {expectFileToMatch} from '../../../utils/fs';
+import { join } from 'path';
+import { ng } from '../../../utils/process';
+import { expectFileToMatch } from '../../../utils/fs';
 import { updateJsonFile } from '../../../utils/project';
 
-
-export default function() {
+export default function () {
   const testCompDir = join('src', 'app', 'test-component');
   const aliasCompDir = join('src', 'app', 'alias');
 
-  return Promise.resolve()
-    .then(() => updateJsonFile('angular.json', configJson => {
-      configJson.projects['test-project'].schematics = {
-        '@schematics/angular:component': { prefix: 'pre' }
-      };
-    }))
-    .then(() => ng('generate', 'component', 'test-component'))
-    .then(() => expectFileToMatch(join(testCompDir, 'test-component.component.ts'),
-      /selector: 'pre-/))
-    .then(() => ng('g', 'c', 'alias'))
-    .then(() => expectFileToMatch(join(aliasCompDir, 'alias.component.ts'),
-      /selector: 'pre-/))
+  return (
+    Promise.resolve()
+      .then(() =>
+        updateJsonFile('angular.json', (configJson) => {
+          configJson.projects['test-project'].schematics = {
+            '@schematics/angular:component': { prefix: 'pre' },
+          };
+        }),
+      )
+      .then(() => ng('generate', 'component', 'test-component'))
+      .then(() =>
+        expectFileToMatch(join(testCompDir, 'test-component.component.ts'), /selector: 'pre-/),
+      )
+      .then(() => ng('g', 'c', 'alias'))
+      .then(() => expectFileToMatch(join(aliasCompDir, 'alias.component.ts'), /selector: 'pre-/))
 
-    // Try to run the unit tests.
-    .then(() => ng('test', '--watch=false'));
+      // Try to run the unit tests.
+      .then(() => ng('test', '--watch=false'))
+  );
 }

--- a/tests/legacy-cli/e2e/tests/generate/directive/directive-basic.ts
+++ b/tests/legacy-cli/e2e/tests/generate/directive/directive-basic.ts
@@ -1,14 +1,15 @@
-import {ng} from '../../../utils/process';
-import {join} from 'path';
-import {expectFileToExist} from '../../../utils/fs';
+import { ng } from '../../../utils/process';
+import { join } from 'path';
+import { expectFileToExist } from '../../../utils/fs';
 
-
-export default function() {
+export default function () {
   const directiveDir = join('src', 'app');
-  return ng('generate', 'directive', 'test-directive')
-    .then(() => expectFileToExist(join(directiveDir, 'test-directive.directive.ts')))
-    .then(() => expectFileToExist(join(directiveDir, 'test-directive.directive.spec.ts')))
+  return (
+    ng('generate', 'directive', 'test-directive')
+      .then(() => expectFileToExist(join(directiveDir, 'test-directive.directive.ts')))
+      .then(() => expectFileToExist(join(directiveDir, 'test-directive.directive.spec.ts')))
 
-    // Try to run the unit tests.
-    .then(() => ng('test', '--watch=false'));
+      // Try to run the unit tests.
+      .then(() => ng('test', '--watch=false'))
+  );
 }

--- a/tests/legacy-cli/e2e/tests/generate/directive/directive-module-export.ts
+++ b/tests/legacy-cli/e2e/tests/generate/directive/directive-module-export.ts
@@ -1,14 +1,17 @@
-import {join} from 'path';
-import {ng} from '../../../utils/process';
-import {expectFileToMatch} from '../../../utils/fs';
+import { join } from 'path';
+import { ng } from '../../../utils/process';
+import { expectFileToMatch } from '../../../utils/fs';
 
-
-export default function() {
+export default function () {
   const modulePath = join('src', 'app', 'app.module.ts');
 
-  return ng('generate', 'directive', 'test-directive', '--export')
-    .then(() => expectFileToMatch(modulePath, /exports: \[\r?\n(\s*)  TestDirectiveDirective\r?\n\1\]/))
+  return (
+    ng('generate', 'directive', 'test-directive', '--export')
+      .then(() =>
+        expectFileToMatch(modulePath, /exports: \[\r?\n(\s*)  TestDirectiveDirective\r?\n\1\]/),
+      )
 
-    // Try to run the unit tests.
-    .then(() => ng('test', '--watch=false'));
+      // Try to run the unit tests.
+      .then(() => ng('test', '--watch=false'))
+  );
 }

--- a/tests/legacy-cli/e2e/tests/generate/directive/directive-module-fail.ts
+++ b/tests/legacy-cli/e2e/tests/generate/directive/directive-module-fail.ts
@@ -1,8 +1,10 @@
-import {ng} from '../../../utils/process';
-import {expectToFail} from '../../../utils/utils';
+import { ng } from '../../../utils/process';
+import { expectToFail } from '../../../utils/utils';
 
-export default function() {
-  return Promise.resolve()
-    .then(() => expectToFail(() =>
-      ng('generate', 'directive', 'test-directive', '--module', 'app.moduleXXX.ts')));
+export default function () {
+  return Promise.resolve().then(() =>
+    expectToFail(() =>
+      ng('generate', 'directive', 'test-directive', '--module', 'app.moduleXXX.ts'),
+    ),
+  );
 }

--- a/tests/legacy-cli/e2e/tests/generate/directive/directive-module.ts
+++ b/tests/legacy-cli/e2e/tests/generate/directive/directive-module.ts
@@ -1,21 +1,30 @@
-import {join} from 'path';
-import {ng} from '../../../utils/process';
-import {expectFileToMatch} from '../../../utils/fs';
+import { join } from 'path';
+import { ng } from '../../../utils/process';
+import { expectFileToMatch } from '../../../utils/fs';
 
-
-export default function() {
+export default function () {
   const modulePath = join('src', 'app', 'app.module.ts');
 
-  return ng('generate', 'directive', 'test-directive', '--module', 'app.module.ts')
-    .then(() => expectFileToMatch(modulePath,
-      /import { TestDirectiveDirective } from '.\/test-directive.directive'/))
+  return (
+    ng('generate', 'directive', 'test-directive', '--module', 'app.module.ts')
+      .then(() =>
+        expectFileToMatch(
+          modulePath,
+          /import { TestDirectiveDirective } from '.\/test-directive.directive'/,
+        ),
+      )
 
-    .then(() => process.chdir(join('src', 'app')))
-    .then(() => ng('generate', 'directive', 'test-directive2', '--module', 'app.module.ts'))
-    .then(() => process.chdir('../..'))
-    .then(() => expectFileToMatch(modulePath,
-      /import { TestDirective2Directive } from '.\/test-directive2.directive'/))
+      .then(() => process.chdir(join('src', 'app')))
+      .then(() => ng('generate', 'directive', 'test-directive2', '--module', 'app.module.ts'))
+      .then(() => process.chdir('../..'))
+      .then(() =>
+        expectFileToMatch(
+          modulePath,
+          /import { TestDirective2Directive } from '.\/test-directive2.directive'/,
+        ),
+      )
 
-    // Try to run the unit tests.
-    .then(() => ng('build', '--configuration=development'));
+      // Try to run the unit tests.
+      .then(() => ng('build', '--configuration=development'))
+  );
 }

--- a/tests/legacy-cli/e2e/tests/generate/directive/directive-prefix.ts
+++ b/tests/legacy-cli/e2e/tests/generate/directive/directive-prefix.ts
@@ -1,40 +1,51 @@
-import {join} from 'path';
-import {ng} from '../../../utils/process';
-import {expectFileToMatch} from '../../../utils/fs';
+import { join } from 'path';
+import { ng } from '../../../utils/process';
+import { expectFileToMatch } from '../../../utils/fs';
 import { updateJsonFile, useCIChrome, useCIDefaults } from '../../../utils/project';
 
-
-export default function() {
+export default function () {
   const directiveDir = join('src', 'app');
 
-  return Promise.resolve()
-    .then(() => updateJsonFile('angular.json', configJson => {
-      configJson.schematics = {
-        '@schematics/angular:directive': { prefix: 'preW' }
-      };
-    }))
-    .then(() => ng('generate', 'directive', 'test2-directive'))
-    .then(() => expectFileToMatch(join(directiveDir, 'test2-directive.directive.ts'),
-      /selector: '\[preW/))
-    .then(() => ng('generate', 'application', 'app-two', '--skip-install'))
-    .then(() => useCIDefaults('app-two'))
-    .then(() => useCIChrome('./projects/app-two'))
-    .then(() => updateJsonFile('angular.json', configJson => {
-      configJson.projects['test-project'].schematics = {
-        '@schematics/angular:directive': { prefix: 'preP' }
-      };
-    }))
-    .then(() => process.chdir('projects/app-two'))
-    .then(() => ng('generate', 'directive', '--skip-import', 'test3-directive'))
-    .then(() => process.chdir('../..'))
-    .then(() => expectFileToMatch(join('projects', 'app-two', 'test3-directive.directive.ts'),
-      /selector: '\[preW/))
-    .then(() => process.chdir('src/app'))
-    .then(() => ng('generate', 'directive', 'test-directive'))
-    .then(() => process.chdir('../..'))
-    .then(() => expectFileToMatch(join(directiveDir, 'test-directive.directive.ts'),
-      /selector: '\[preP/))
+  return (
+    Promise.resolve()
+      .then(() =>
+        updateJsonFile('angular.json', (configJson) => {
+          configJson.schematics = {
+            '@schematics/angular:directive': { prefix: 'preW' },
+          };
+        }),
+      )
+      .then(() => ng('generate', 'directive', 'test2-directive'))
+      .then(() =>
+        expectFileToMatch(join(directiveDir, 'test2-directive.directive.ts'), /selector: '\[preW/),
+      )
+      .then(() => ng('generate', 'application', 'app-two', '--skip-install'))
+      .then(() => useCIDefaults('app-two'))
+      .then(() => useCIChrome('./projects/app-two'))
+      .then(() =>
+        updateJsonFile('angular.json', (configJson) => {
+          configJson.projects['test-project'].schematics = {
+            '@schematics/angular:directive': { prefix: 'preP' },
+          };
+        }),
+      )
+      .then(() => process.chdir('projects/app-two'))
+      .then(() => ng('generate', 'directive', '--skip-import', 'test3-directive'))
+      .then(() => process.chdir('../..'))
+      .then(() =>
+        expectFileToMatch(
+          join('projects', 'app-two', 'test3-directive.directive.ts'),
+          /selector: '\[preW/,
+        ),
+      )
+      .then(() => process.chdir('src/app'))
+      .then(() => ng('generate', 'directive', 'test-directive'))
+      .then(() => process.chdir('../..'))
+      .then(() =>
+        expectFileToMatch(join(directiveDir, 'test-directive.directive.ts'), /selector: '\[preP/),
+      )
 
-    // Try to run the unit tests.
-    .then(() => ng('test', '--watch=false'));
+      // Try to run the unit tests.
+      .then(() => ng('test', '--watch=false'))
+  );
 }

--- a/tests/legacy-cli/e2e/tests/generate/generate-error.ts
+++ b/tests/legacy-cli/e2e/tests/generate/generate-error.ts
@@ -1,8 +1,9 @@
-import {ng} from '../../utils/process';
-import {deleteFile} from '../../utils/fs';
-import {expectToFail} from '../../utils/utils';
+import { ng } from '../../utils/process';
+import { deleteFile } from '../../utils/fs';
+import { expectToFail } from '../../utils/utils';
 
-export default function() {
-  return deleteFile('angular.json')
-    .then(() => expectToFail(() => ng('generate', 'class', 'hello')));
+export default function () {
+  return deleteFile('angular.json').then(() =>
+    expectToFail(() => ng('generate', 'class', 'hello')),
+  );
 }

--- a/tests/legacy-cli/e2e/tests/generate/generate-name-check.ts
+++ b/tests/legacy-cli/e2e/tests/generate/generate-name-check.ts
@@ -1,24 +1,27 @@
-import {join} from 'path';
-import {ng} from '../../utils/process';
-import {expectFileToExist} from '../../utils/fs';
-import {updateJsonFile} from '../../utils/project';
+import { join } from 'path';
+import { ng } from '../../utils/process';
+import { expectFileToExist } from '../../utils/fs';
+import { updateJsonFile } from '../../utils/project';
 
-
-export default function() {
+export default function () {
   const compDir = join('src', 'app', 'test-component');
 
-  return Promise.resolve()
-    .then(() => updateJsonFile('package.json', configJson => {
-      delete configJson.name;
-      return configJson;
-    }))
-    .then(() => ng('generate', 'component', 'test-component'))
-    .then(() => expectFileToExist(compDir))
-    .then(() => expectFileToExist(join(compDir, 'test-component.component.ts')))
-    .then(() => expectFileToExist(join(compDir, 'test-component.component.spec.ts')))
-    .then(() => expectFileToExist(join(compDir, 'test-component.component.html')))
-    .then(() => expectFileToExist(join(compDir, 'test-component.component.css')))
+  return (
+    Promise.resolve()
+      .then(() =>
+        updateJsonFile('package.json', (configJson) => {
+          delete configJson.name;
+          return configJson;
+        }),
+      )
+      .then(() => ng('generate', 'component', 'test-component'))
+      .then(() => expectFileToExist(compDir))
+      .then(() => expectFileToExist(join(compDir, 'test-component.component.ts')))
+      .then(() => expectFileToExist(join(compDir, 'test-component.component.spec.ts')))
+      .then(() => expectFileToExist(join(compDir, 'test-component.component.html')))
+      .then(() => expectFileToExist(join(compDir, 'test-component.component.css')))
 
-    // Try to run the unit tests.
-    .then(() => ng('test', '--watch=false'));
+      // Try to run the unit tests.
+      .then(() => ng('test', '--watch=false'))
+  );
 }

--- a/tests/legacy-cli/e2e/tests/generate/generate-name-error.ts
+++ b/tests/legacy-cli/e2e/tests/generate/generate-name-error.ts
@@ -1,9 +1,8 @@
-import {ng} from '../../utils/process';
-import {expectToFail} from '../../utils/utils';
+import { ng } from '../../utils/process';
+import { expectToFail } from '../../utils/utils';
 
-
-export default function() {
-  return Promise.resolve()
-    .then(() => expectToFail(() =>
-      ng('generate', 'component', '1my-component')));
+export default function () {
+  return Promise.resolve().then(() =>
+    expectToFail(() => ng('generate', 'component', '1my-component')),
+  );
 }

--- a/tests/legacy-cli/e2e/tests/generate/guard/guard-basic.ts
+++ b/tests/legacy-cli/e2e/tests/generate/guard/guard-basic.ts
@@ -1,9 +1,8 @@
-import {join} from 'path';
-import {ng} from '../../../utils/process';
-import {expectFileToExist, expectFileToMatch} from '../../../utils/fs';
+import { join } from 'path';
+import { ng } from '../../../utils/process';
+import { expectFileToExist, expectFileToMatch } from '../../../utils/fs';
 
-
-export default async function() {
+export default async function () {
   // Does not create a sub directory.
   const guardDir = join('src', 'app');
 

--- a/tests/legacy-cli/e2e/tests/generate/guard/guard-implements.ts
+++ b/tests/legacy-cli/e2e/tests/generate/guard/guard-implements.ts
@@ -1,9 +1,8 @@
-import {join} from 'path';
-import {ng} from '../../../utils/process';
-import {expectFileToExist,expectFileToMatch} from '../../../utils/fs';
+import { join } from 'path';
+import { ng } from '../../../utils/process';
+import { expectFileToExist, expectFileToMatch } from '../../../utils/fs';
 
-
-export default async function() {
+export default async function () {
   // Does not create a sub directory.
   const guardDir = join('src', 'app');
 

--- a/tests/legacy-cli/e2e/tests/generate/guard/guard-multiple-implements.ts
+++ b/tests/legacy-cli/e2e/tests/generate/guard/guard-multiple-implements.ts
@@ -1,16 +1,18 @@
-import {join} from 'path';
-import {ng} from '../../../utils/process';
-import {expectFileToExist,expectFileToMatch} from '../../../utils/fs';
+import { join } from 'path';
+import { ng } from '../../../utils/process';
+import { expectFileToExist, expectFileToMatch } from '../../../utils/fs';
 
-
-export default async function() {
+export default async function () {
   // Does not create a sub directory.
   const guardDir = join('src', 'app');
 
   await ng('generate', 'guard', 'load', '--implements=CanLoad', '--implements=CanDeactivate');
   await expectFileToExist(guardDir);
   await expectFileToExist(join(guardDir, 'load.guard.ts'));
-  await expectFileToMatch(join(guardDir, 'load.guard.ts'), /implements CanLoad, CanDeactivate<unknown>/);
+  await expectFileToMatch(
+    join(guardDir, 'load.guard.ts'),
+    /implements CanLoad, CanDeactivate<unknown>/,
+  );
   await expectFileToExist(join(guardDir, 'load.guard.spec.ts'));
   await ng('test', '--watch=false');
 }

--- a/tests/legacy-cli/e2e/tests/generate/help-output-no-duplicates.ts
+++ b/tests/legacy-cli/e2e/tests/generate/help-output-no-duplicates.ts
@@ -1,7 +1,7 @@
 import { ng } from '../../utils/process';
 
-export default async function() {
-    // Verify that there are no duplicate options
+export default async function () {
+  // Verify that there are no duplicate options
   const { stdout } = await ng('generate', 'component', '--help');
   const firstIndex = stdout.indexOf('--prefix');
 

--- a/tests/legacy-cli/e2e/tests/generate/interceptor/interceptor-basic.ts
+++ b/tests/legacy-cli/e2e/tests/generate/interceptor/interceptor-basic.ts
@@ -1,17 +1,18 @@
-import {join} from 'path';
-import {ng} from '../../../utils/process';
-import {expectFileToExist} from '../../../utils/fs';
+import { join } from 'path';
+import { ng } from '../../../utils/process';
+import { expectFileToExist } from '../../../utils/fs';
 
-
-export default function() {
+export default function () {
   // Does not create a sub directory.
   const interceptorDir = join('src', 'app');
 
-  return ng('generate', 'interceptor', 'test-interceptor')
-    .then(() => expectFileToExist(interceptorDir))
-    .then(() => expectFileToExist(join(interceptorDir, 'test-interceptor.interceptor.ts')))
-    .then(() => expectFileToExist(join(interceptorDir, 'test-interceptor.interceptor.spec.ts')))
+  return (
+    ng('generate', 'interceptor', 'test-interceptor')
+      .then(() => expectFileToExist(interceptorDir))
+      .then(() => expectFileToExist(join(interceptorDir, 'test-interceptor.interceptor.ts')))
+      .then(() => expectFileToExist(join(interceptorDir, 'test-interceptor.interceptor.spec.ts')))
 
-    // Try to run the unit tests.
-    .then(() => ng('test', '--watch=false'));
+      // Try to run the unit tests.
+      .then(() => ng('test', '--watch=false'))
+  );
 }

--- a/tests/legacy-cli/e2e/tests/generate/interface.ts
+++ b/tests/legacy-cli/e2e/tests/generate/interface.ts
@@ -1,15 +1,16 @@
-import {join} from 'path';
-import {ng} from '../../utils/process';
-import {expectFileToExist} from '../../utils/fs';
+import { join } from 'path';
+import { ng } from '../../utils/process';
+import { expectFileToExist } from '../../utils/fs';
 
-
-export default function() {
+export default function () {
   const interfaceDir = join('src', 'app');
 
-  return ng('generate', 'interface', 'test-interface', 'model')
-    .then(() => expectFileToExist(interfaceDir))
-    .then(() => expectFileToExist(join(interfaceDir, 'test-interface.model.ts')))
+  return (
+    ng('generate', 'interface', 'test-interface', 'model')
+      .then(() => expectFileToExist(interfaceDir))
+      .then(() => expectFileToExist(join(interfaceDir, 'test-interface.model.ts')))
 
-    // Try to run the unit tests.
-    .then(() => ng('test', '--watch=false'));
+      // Try to run the unit tests.
+      .then(() => ng('test', '--watch=false'))
+  );
 }

--- a/tests/legacy-cli/e2e/tests/generate/module/module-basic.ts
+++ b/tests/legacy-cli/e2e/tests/generate/module/module-basic.ts
@@ -1,19 +1,20 @@
-import {join} from 'path';
-import {ng} from '../../../utils/process';
-import {expectFileToExist, expectFileToMatch} from '../../../utils/fs';
-import {expectToFail} from '../../../utils/utils';
+import { join } from 'path';
+import { ng } from '../../../utils/process';
+import { expectFileToExist, expectFileToMatch } from '../../../utils/fs';
+import { expectToFail } from '../../../utils/utils';
 
-
-export default function() {
+export default function () {
   const moduleDir = join('src', 'app', 'test');
 
-  return ng('generate', 'module', 'test')
-    .then(() => expectFileToExist(moduleDir))
-    .then(() => expectFileToExist(join(moduleDir, 'test.module.ts')))
-    .then(() => expectToFail(() => expectFileToExist(join(moduleDir, 'test-routing.module.ts'))))
-    .then(() => expectToFail(() => expectFileToExist(join(moduleDir, 'test.spec.ts'))))
-    .then(() => expectFileToMatch(join(moduleDir, 'test.module.ts'), 'TestModule'))
+  return (
+    ng('generate', 'module', 'test')
+      .then(() => expectFileToExist(moduleDir))
+      .then(() => expectFileToExist(join(moduleDir, 'test.module.ts')))
+      .then(() => expectToFail(() => expectFileToExist(join(moduleDir, 'test-routing.module.ts'))))
+      .then(() => expectToFail(() => expectFileToExist(join(moduleDir, 'test.spec.ts'))))
+      .then(() => expectFileToMatch(join(moduleDir, 'test.module.ts'), 'TestModule'))
 
-    // Try to run the unit tests.
-    .then(() => ng('test', '--watch=false'));
+      // Try to run the unit tests.
+      .then(() => ng('test', '--watch=false'))
+  );
 }

--- a/tests/legacy-cli/e2e/tests/generate/module/module-import.ts
+++ b/tests/legacy-cli/e2e/tests/generate/module/module-import.ts
@@ -13,42 +13,62 @@ export default function () {
     .then(() => ng('generate', 'module', 'sub/deep'))
 
     .then(() => ng('generate', 'module', 'test1', '--module', 'app.module.ts'))
-    .then(() => expectFileToMatch(modulePath,
-      /import { Test1Module } from '.\/test1\/test1.module'/))
+    .then(() =>
+      expectFileToMatch(modulePath, /import { Test1Module } from '.\/test1\/test1.module'/),
+    )
     .then(() => expectFileToMatch(modulePath, /imports: \[(.|\s)*Test1Module(.|\s)*\]/m))
 
     .then(() => ng('generate', 'module', 'test2', '--module', 'app.module'))
-    .then(() => expectFileToMatch(modulePath,
-      /import { Test2Module } from '.\/test2\/test2.module'/))
+    .then(() =>
+      expectFileToMatch(modulePath, /import { Test2Module } from '.\/test2\/test2.module'/),
+    )
     .then(() => expectFileToMatch(modulePath, /imports: \[(.|\s)*Test2Module(.|\s)*\]/m))
 
     .then(() => ng('generate', 'module', 'test3', '--module', 'app'))
-    .then(() => expectFileToMatch(modulePath,
-      /import { Test3Module } from '.\/test3\/test3.module'/))
+    .then(() =>
+      expectFileToMatch(modulePath, /import { Test3Module } from '.\/test3\/test3.module'/),
+    )
     .then(() => expectFileToMatch(modulePath, /imports: \[(.|\s)*Test3Module(.|\s)*\]/m))
 
     .then(() => ng('generate', 'module', 'test4', '--routing', '--module', 'app'))
     .then(() => expectFileToMatch(modulePath, /imports: \[(.|\s)*Test4Module(.|\s)*\]/m))
-    .then(() => expectFileToMatch(join('src', 'app', 'test4', 'test4.module.ts'),
-      /import { Test4RoutingModule } from '.\/test4-routing.module'/))
-    .then(() => expectFileToMatch(join('src', 'app', 'test4', 'test4.module.ts'),
-      /imports: \[(.|\s)*Test4RoutingModule(.|\s)*\]/m))
+    .then(() =>
+      expectFileToMatch(
+        join('src', 'app', 'test4', 'test4.module.ts'),
+        /import { Test4RoutingModule } from '.\/test4-routing.module'/,
+      ),
+    )
+    .then(() =>
+      expectFileToMatch(
+        join('src', 'app', 'test4', 'test4.module.ts'),
+        /imports: \[(.|\s)*Test4RoutingModule(.|\s)*\]/m,
+      ),
+    )
 
     .then(() => ng('generate', 'module', 'test5', '--module', 'sub'))
-    .then(() => expectFileToMatch(subModulePath,
-      /import { Test5Module } from '..\/test5\/test5.module'/))
+    .then(() =>
+      expectFileToMatch(subModulePath, /import { Test5Module } from '..\/test5\/test5.module'/),
+    )
     .then(() => expectFileToMatch(subModulePath, /imports: \[(.|\s)*Test5Module(.|\s)*\]/m))
 
-    .then(() => ng('generate', 'module', 'test6', '--module', join('sub', 'deep'))
-    .then(() => expectFileToMatch(deepSubModulePath,
-      /import { Test6Module } from '..\/..\/test6\/test6.module'/))
-    .then(() => expectFileToMatch(deepSubModulePath, /imports: \[(.|\s)*Test6Module(.|\s)*\]/m)));
+    .then(() =>
+      ng('generate', 'module', 'test6', '--module', join('sub', 'deep'))
+        .then(() =>
+          expectFileToMatch(
+            deepSubModulePath,
+            /import { Test6Module } from '..\/..\/test6\/test6.module'/,
+          ),
+        )
+        .then(() =>
+          expectFileToMatch(deepSubModulePath, /imports: \[(.|\s)*Test6Module(.|\s)*\]/m),
+        ),
+    );
 
-    // E2E_DISABLE: temporarily disable pending investigation
-    // .then(() => process.chdir(join(root, 'src', 'app')))
-    // .then(() => ng('generate', 'module', 'test7', '--module', 'app.module.ts'))
-    // .then(() => process.chdir('..'))
-    // .then(() => expectFileToMatch(modulePath,
-    //   /import { Test7Module } from '.\/test7\/test7.module'/))
-    // .then(() => expectFileToMatch(modulePath, /imports: \[(.|\s)*Test7Module(.|\s)*\]/m));
+  // E2E_DISABLE: temporarily disable pending investigation
+  // .then(() => process.chdir(join(root, 'src', 'app')))
+  // .then(() => ng('generate', 'module', 'test7', '--module', 'app.module.ts'))
+  // .then(() => process.chdir('..'))
+  // .then(() => expectFileToMatch(modulePath,
+  //   /import { Test7Module } from '.\/test7\/test7.module'/))
+  // .then(() => expectFileToMatch(modulePath, /imports: \[(.|\s)*Test7Module(.|\s)*\]/m));
 }

--- a/tests/legacy-cli/e2e/tests/generate/module/module-routing-child-folder.ts
+++ b/tests/legacy-cli/e2e/tests/generate/module/module-routing-child-folder.ts
@@ -3,23 +3,21 @@ import { ng } from '../../../utils/process';
 import { expectFileToExist } from '../../../utils/fs';
 import { expectToFail } from '../../../utils/utils';
 
-
 export default function () {
   const root = process.cwd();
   const testPath = join(root, 'src', 'app');
 
   process.chdir(testPath);
 
-  return Promise.resolve()
-    .then(() =>
-      ng('generate', 'module', 'sub-dir/child', '--routing')
-        .then(() => expectFileToExist(join(testPath, 'sub-dir/child')))
-        .then(() => expectFileToExist(join(testPath, 'sub-dir/child', 'child.module.ts')))
-        .then(() => expectFileToExist(join(testPath, 'sub-dir/child', 'child-routing.module.ts')))
-        .then(() => expectToFail(() =>
-          expectFileToExist(join(testPath, 'sub-dir/child', 'child.spec.ts'))
-        ))
-        // Try to run the unit tests.
-        .then(() => ng('test', '--watch=false'))
-    );
+  return Promise.resolve().then(() =>
+    ng('generate', 'module', 'sub-dir/child', '--routing')
+      .then(() => expectFileToExist(join(testPath, 'sub-dir/child')))
+      .then(() => expectFileToExist(join(testPath, 'sub-dir/child', 'child.module.ts')))
+      .then(() => expectFileToExist(join(testPath, 'sub-dir/child', 'child-routing.module.ts')))
+      .then(() =>
+        expectToFail(() => expectFileToExist(join(testPath, 'sub-dir/child', 'child.spec.ts'))),
+      )
+      // Try to run the unit tests.
+      .then(() => ng('test', '--watch=false')),
+  );
 }

--- a/tests/legacy-cli/e2e/tests/generate/module/module-routing.ts
+++ b/tests/legacy-cli/e2e/tests/generate/module/module-routing.ts
@@ -1,17 +1,18 @@
-import {join} from 'path';
-import {ng} from '../../../utils/process';
-import {expectFileToExist} from '../../../utils/fs';
-import {expectToFail} from '../../../utils/utils';
+import { join } from 'path';
+import { ng } from '../../../utils/process';
+import { expectFileToExist } from '../../../utils/fs';
+import { expectToFail } from '../../../utils/utils';
 
-
-export default function() {
+export default function () {
   const moduleDir = join('src', 'app', 'test');
 
-  return ng('generate', 'module', 'test', '--routing')
-    .then(() => expectFileToExist(moduleDir))
-    .then(() => expectFileToExist(join(moduleDir, 'test.module.ts')))
-    .then(() => expectFileToExist(join(moduleDir, 'test-routing.module.ts')))
-    .then(() => expectToFail(() => expectFileToExist(join(moduleDir, 'test.spec.ts'))))
-    // Try to run the unit tests.
-    .then(() => ng('test', '--watch=false'));
+  return (
+    ng('generate', 'module', 'test', '--routing')
+      .then(() => expectFileToExist(moduleDir))
+      .then(() => expectFileToExist(join(moduleDir, 'test.module.ts')))
+      .then(() => expectFileToExist(join(moduleDir, 'test-routing.module.ts')))
+      .then(() => expectToFail(() => expectFileToExist(join(moduleDir, 'test.spec.ts'))))
+      // Try to run the unit tests.
+      .then(() => ng('test', '--watch=false'))
+  );
 }

--- a/tests/legacy-cli/e2e/tests/generate/pipe/pipe-basic.ts
+++ b/tests/legacy-cli/e2e/tests/generate/pipe/pipe-basic.ts
@@ -1,17 +1,19 @@
-import {join} from 'path';
-import {ng} from '../../../utils/process';
+import { join } from 'path';
+import { ng } from '../../../utils/process';
 
-import {expectFileToExist} from '../../../utils/fs';
+import { expectFileToExist } from '../../../utils/fs';
 
-export default function() {
+export default function () {
   // Create the pipe in the same directory.
   const pipeDir = join('src', 'app');
 
-  return ng('generate', 'pipe', 'test-pipe')
-    .then(() => expectFileToExist(pipeDir))
-    .then(() => expectFileToExist(join(pipeDir, 'test-pipe.pipe.ts')))
-    .then(() => expectFileToExist(join(pipeDir, 'test-pipe.pipe.spec.ts')))
+  return (
+    ng('generate', 'pipe', 'test-pipe')
+      .then(() => expectFileToExist(pipeDir))
+      .then(() => expectFileToExist(join(pipeDir, 'test-pipe.pipe.ts')))
+      .then(() => expectFileToExist(join(pipeDir, 'test-pipe.pipe.spec.ts')))
 
-    // Try to run the unit tests.
-    .then(() => ng('test', '--watch=false'));
+      // Try to run the unit tests.
+      .then(() => ng('test', '--watch=false'))
+  );
 }

--- a/tests/legacy-cli/e2e/tests/generate/pipe/pipe-module-export.ts
+++ b/tests/legacy-cli/e2e/tests/generate/pipe/pipe-module-export.ts
@@ -1,14 +1,15 @@
-import {join} from 'path';
-import {ng} from '../../../utils/process';
-import {expectFileToMatch} from '../../../utils/fs';
+import { join } from 'path';
+import { ng } from '../../../utils/process';
+import { expectFileToMatch } from '../../../utils/fs';
 
-
-export default function() {
+export default function () {
   const modulePath = join('src', 'app', 'app.module.ts');
 
-  return ng('generate', 'pipe', 'test-pipe', '--export')
-    .then(() => expectFileToMatch(modulePath, /exports: \[\r?\n(\s*)  TestPipePipe\r?\n\1\]/))
+  return (
+    ng('generate', 'pipe', 'test-pipe', '--export')
+      .then(() => expectFileToMatch(modulePath, /exports: \[\r?\n(\s*)  TestPipePipe\r?\n\1\]/))
 
-    // Try to run the unit tests.
-    .then(() => ng('test', '--watch=false'));
+      // Try to run the unit tests.
+      .then(() => ng('test', '--watch=false'))
+  );
 }

--- a/tests/legacy-cli/e2e/tests/generate/pipe/pipe-module-fail.ts
+++ b/tests/legacy-cli/e2e/tests/generate/pipe/pipe-module-fail.ts
@@ -1,9 +1,8 @@
-import {ng} from '../../../utils/process';
-import {expectToFail} from '../../../utils/utils';
+import { ng } from '../../../utils/process';
+import { expectToFail } from '../../../utils/utils';
 
-
-export default function() {
-  return Promise.resolve()
-    .then(() => expectToFail(() =>
-      ng('generate', 'pipe', 'test-pipe', '--module', 'app.moduleXXX.ts')));
+export default function () {
+  return Promise.resolve().then(() =>
+    expectToFail(() => ng('generate', 'pipe', 'test-pipe', '--module', 'app.moduleXXX.ts')),
+  );
 }

--- a/tests/legacy-cli/e2e/tests/generate/pipe/pipe-module.ts
+++ b/tests/legacy-cli/e2e/tests/generate/pipe/pipe-module.ts
@@ -1,21 +1,22 @@
-import {join} from 'path';
-import {ng} from '../../../utils/process';
-import {expectFileToMatch} from '../../../utils/fs';
+import { join } from 'path';
+import { ng } from '../../../utils/process';
+import { expectFileToMatch } from '../../../utils/fs';
 
-
-export default function() {
+export default function () {
   const modulePath = join('src', 'app', 'app.module.ts');
 
-  return ng('generate', 'pipe', 'test-pipe', '--module', 'app.module.ts')
-    .then(() => expectFileToMatch(modulePath,
-      /import { TestPipePipe } from '.\/test-pipe.pipe'/))
+  return (
+    ng('generate', 'pipe', 'test-pipe', '--module', 'app.module.ts')
+      .then(() => expectFileToMatch(modulePath, /import { TestPipePipe } from '.\/test-pipe.pipe'/))
 
-    .then(() => process.chdir(join('src', 'app')))
-    .then(() => ng('generate', 'pipe', 'test-pipe2', '--module', 'app.module.ts'))
-    .then(() => process.chdir('../..'))
-    .then(() => expectFileToMatch(modulePath,
-      /import { TestPipe2Pipe } from '.\/test-pipe2.pipe'/))
+      .then(() => process.chdir(join('src', 'app')))
+      .then(() => ng('generate', 'pipe', 'test-pipe2', '--module', 'app.module.ts'))
+      .then(() => process.chdir('../..'))
+      .then(() =>
+        expectFileToMatch(modulePath, /import { TestPipe2Pipe } from '.\/test-pipe2.pipe'/),
+      )
 
-    // Try to run the unit tests.
-    .then(() => ng('build', '--configuration=development'));
+      // Try to run the unit tests.
+      .then(() => ng('build', '--configuration=development'))
+  );
 }

--- a/tests/legacy-cli/e2e/tests/generate/service/service-basic.ts
+++ b/tests/legacy-cli/e2e/tests/generate/service/service-basic.ts
@@ -1,17 +1,18 @@
-import {join} from 'path';
-import {ng} from '../../../utils/process';
-import {expectFileToExist} from '../../../utils/fs';
+import { join } from 'path';
+import { ng } from '../../../utils/process';
+import { expectFileToExist } from '../../../utils/fs';
 
-
-export default function() {
+export default function () {
   // Does not create a sub directory.
   const serviceDir = join('src', 'app');
 
-  return ng('generate', 'service', 'test-service')
-    .then(() => expectFileToExist(serviceDir))
-    .then(() => expectFileToExist(join(serviceDir, 'test-service.service.ts')))
-    .then(() => expectFileToExist(join(serviceDir, 'test-service.service.spec.ts')))
+  return (
+    ng('generate', 'service', 'test-service')
+      .then(() => expectFileToExist(serviceDir))
+      .then(() => expectFileToExist(join(serviceDir, 'test-service.service.ts')))
+      .then(() => expectFileToExist(join(serviceDir, 'test-service.service.spec.ts')))
 
-    // Try to run the unit tests.
-    .then(() => ng('test', '--watch=false'));
+      // Try to run the unit tests.
+      .then(() => ng('test', '--watch=false'))
+  );
 }

--- a/tests/legacy-cli/e2e/tests/i18n/extract-ivy-libraries.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/extract-ivy-libraries.ts
@@ -4,7 +4,7 @@ import { installPackage, uninstallPackage } from '../../utils/packages';
 import { ng } from '../../utils/process';
 import { readNgVersion } from '../../utils/version';
 
-export default async function() {
+export default async function () {
   // Setup a library
   await ng('generate', 'library', 'i18n-lib-test');
   await replaceInFile(

--- a/tests/legacy-cli/e2e/tests/i18n/ivy-localize-hashes.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/ivy-localize-hashes.ts
@@ -13,7 +13,7 @@ import { langTranslations, setupI18nConfig } from './setup';
 
 const OUTPUT_RE = /^(?<name>(?:main|vendor|\d+))\.(?<hash>[a-z0-9]+)\.js$/i;
 
-export default async function() {
+export default async function () {
   // Setup i18n tests and config.
   await setupI18nConfig();
 

--- a/tests/legacy-cli/e2e/tests/i18n/ivy-localize-locale-data.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/ivy-localize-locale-data.ts
@@ -10,12 +10,12 @@ import { ng } from '../../utils/process';
 import { updateJsonFile } from '../../utils/project';
 import { setupI18nConfig } from './setup';
 
-export default async function() {
+export default async function () {
   // Setup i18n tests and config.
   await setupI18nConfig();
 
   // Update angular.json
-  await updateJsonFile('angular.json', workspaceJson => {
+  await updateJsonFile('angular.json', (workspaceJson) => {
     const appProject = workspaceJson.projects['test-project'];
     // tslint:disable-next-line: no-any
     const i18n: Record<string, any> = appProject.i18n;
@@ -30,7 +30,7 @@ export default async function() {
   }
 
   // Update angular.json
-  await updateJsonFile('angular.json', workspaceJson => {
+  await updateJsonFile('angular.json', (workspaceJson) => {
     const appProject = workspaceJson.projects['test-project'];
     // tslint:disable-next-line: no-any
     const i18n: Record<string, any> = appProject.i18n;
@@ -40,12 +40,16 @@ export default async function() {
   });
 
   const { stderr: err2 } = await ng('build');
-  if (err2.includes(`Locale data for 'en-US' cannot be found.  No locale data will be included for this locale.`)) {
+  if (
+    err2.includes(
+      `Locale data for 'en-US' cannot be found.  No locale data will be included for this locale.`,
+    )
+  ) {
     throw new Error('locale data not found warning shown');
   }
 
   // Update angular.json
-  await updateJsonFile('angular.json', workspaceJson => {
+  await updateJsonFile('angular.json', (workspaceJson) => {
     const appProject = workspaceJson.projects['test-project'];
     // tslint:disable-next-line: no-any
     const i18n: Record<string, any> = appProject.i18n;
@@ -55,7 +59,11 @@ export default async function() {
   });
 
   const { stderr: err3 } = await ng('build', '--configuration=development');
-  if (err3.includes(`Locale data for 'en-x-abc' cannot be found.  No locale data will be included for this locale.`)) {
+  if (
+    err3.includes(
+      `Locale data for 'en-x-abc' cannot be found.  No locale data will be included for this locale.`,
+    )
+  ) {
     throw new Error('locale data not found warning shown');
   }
 }

--- a/tests/legacy-cli/e2e/tests/i18n/ivy-localize-sourcelocale.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/ivy-localize-sourcelocale.ts
@@ -11,12 +11,12 @@ import { ng } from '../../utils/process';
 import { updateJsonFile } from '../../utils/project';
 import { langTranslations, setupI18nConfig } from './setup';
 
-export default async function() {
+export default async function () {
   // Setup i18n tests and config.
   await setupI18nConfig();
 
   // Update angular.json
-  await updateJsonFile('angular.json', workspaceJson => {
+  await updateJsonFile('angular.json', (workspaceJson) => {
     const appProject = workspaceJson.projects['test-project'];
     // tslint:disable-next-line: no-any
     const i18n: Record<string, any> = appProject.i18n;

--- a/tests/legacy-cli/e2e/tests/misc/coverage.ts
+++ b/tests/legacy-cli/e2e/tests/misc/coverage.ts
@@ -1,29 +1,29 @@
-import {expectFileToExist, expectFileToMatch} from '../../utils/fs';
-import {updateJsonFile} from '../../utils/project';
-import {expectToFail} from '../../utils/utils';
-import {ng} from '../../utils/process';
-
+import { expectFileToExist, expectFileToMatch } from '../../utils/fs';
+import { updateJsonFile } from '../../utils/project';
+import { expectToFail } from '../../utils/utils';
+import { ng } from '../../utils/process';
 
 export default function () {
   // TODO(architect): This test is broken in devkit/build-angular, istanbul and
   // istanbul-instrumenter-loader are missing from the dependencies.
   return;
 
-  return ng('test', '--watch=false', '--code-coverage')
-    .then(output => expect(output.stdout).toContain('Coverage summary'))
-    .then(() => expectFileToExist('coverage/src/app'))
-    .then(() => expectFileToExist('coverage/lcov.info'))
-    // Verify code coverage exclude work
-    .then(() => expectFileToMatch('coverage/lcov.info', 'polyfills.ts'))
-    .then(() => expectFileToMatch('coverage/lcov.info', 'test.ts'))
-    .then(() => updateJsonFile('angular.json', workspaceJson => {
-      const appArchitect = workspaceJson.projects['test-project'].architect;
-      appArchitect.test.options.codeCoverageExclude = [
-        'src/polyfills.ts',
-        '**/test.ts',
-      ];
-    }))
-    .then(() => ng('test', '--watch=false', '--code-coverage'))
-    .then(() => expectToFail(() => expectFileToMatch('coverage/lcov.info', 'polyfills.ts')))
-    .then(() => expectToFail(() => expectFileToMatch('coverage/lcov.info', 'test.ts')));
+  return (
+    ng('test', '--watch=false', '--code-coverage')
+      .then((output) => expect(output.stdout).toContain('Coverage summary'))
+      .then(() => expectFileToExist('coverage/src/app'))
+      .then(() => expectFileToExist('coverage/lcov.info'))
+      // Verify code coverage exclude work
+      .then(() => expectFileToMatch('coverage/lcov.info', 'polyfills.ts'))
+      .then(() => expectFileToMatch('coverage/lcov.info', 'test.ts'))
+      .then(() =>
+        updateJsonFile('angular.json', (workspaceJson) => {
+          const appArchitect = workspaceJson.projects['test-project'].architect;
+          appArchitect.test.options.codeCoverageExclude = ['src/polyfills.ts', '**/test.ts'];
+        }),
+      )
+      .then(() => ng('test', '--watch=false', '--code-coverage'))
+      .then(() => expectToFail(() => expectFileToMatch('coverage/lcov.info', 'polyfills.ts')))
+      .then(() => expectToFail(() => expectFileToMatch('coverage/lcov.info', 'test.ts')))
+  );
 }

--- a/tests/legacy-cli/e2e/tests/misc/dedupe-duplicate-modules.ts
+++ b/tests/legacy-cli/e2e/tests/misc/dedupe-duplicate-modules.ts
@@ -6,7 +6,7 @@ import { expectToFail } from '../../utils/utils';
 
 export default async function () {
   // Force duplicate modules
-  await updateJsonFile('package.json', json => {
+  await updateJsonFile('package.json', (json) => {
     json.dependencies = {
       ...json.dependencies,
       'tslib': '2.0.0',
@@ -17,7 +17,8 @@ export default async function () {
 
   await installWorkspacePackages();
 
-  await writeFile('./src/main.ts',
+  await writeFile(
+    './src/main.ts',
     `
         import { __assign as __assign_0 } from 'tslib';
         import { __assign as __assign_1 } from 'tslib-1';
@@ -28,14 +29,23 @@ export default async function () {
             __assign_1,
             __assign_2,
         })
-    `);
+    `,
+  );
 
-  const { stderr } = await ng('build', '--verbose', '--no-vendor-chunk', '--no-progress', '--configuration=development');
+  const { stderr } = await ng(
+    'build',
+    '--verbose',
+    '--no-vendor-chunk',
+    '--no-progress',
+    '--configuration=development',
+  );
   const outFile = 'dist/test-project/main.js';
 
   if (/\[DedupeModuleResolvePlugin\]:.+tslib-1-copy.+ -> .+tslib-1.+/.test(stderr)) {
     await expectFileToMatch(outFile, './node_modules/tslib-1/tslib.es6.js');
-    await expectToFail(() => expectFileToMatch(outFile, './node_modules/tslib-1-copy/tslib.es6.js'));
+    await expectToFail(() =>
+      expectFileToMatch(outFile, './node_modules/tslib-1-copy/tslib.es6.js'),
+    );
   } else if (/\[DedupeModuleResolvePlugin\]:.+tslib-1.+ -> .+tslib-1-copy.+/.test(stderr)) {
     await expectFileToMatch(outFile, './node_modules/tslib-1-copy/tslib.es6.js');
     await expectToFail(() => expectFileToMatch(outFile, './node_modules/tslib-1/tslib.es6.js'));

--- a/tests/legacy-cli/e2e/tests/misc/e2e-host.ts
+++ b/tests/legacy-cli/e2e/tests/misc/e2e-host.ts
@@ -13,7 +13,7 @@ export default async function () {
   }
 
   try {
-    await updateJsonFile('angular.json', workspaceJson => {
+    await updateJsonFile('angular.json', (workspaceJson) => {
       const appArchitect = workspaceJson.projects['test-project'].architect;
       appArchitect.serve.options = appArchitect.serve.options || {};
       appArchitect.serve.options.port = 8888;

--- a/tests/legacy-cli/e2e/tests/misc/es2015-nometa.ts
+++ b/tests/legacy-cli/e2e/tests/misc/es2015-nometa.ts
@@ -1,17 +1,14 @@
 import { prependToFile, replaceInFile, writeFile } from '../../utils/fs';
 import { ng } from '../../utils/process';
 
-export default async function() {
+export default async function () {
   // Ensure an ES2015 build is used in test
   await writeFile('.browserslistrc', 'Chrome 65');
 
   await ng('generate', 'service', 'user');
 
   // Update the application to use the new service
-  await prependToFile(
-    'src/app/app.component.ts',
-    'import { UserService } from \'./user.service\';',
-  );
+  await prependToFile('src/app/app.component.ts', "import { UserService } from './user.service';");
 
   await replaceInFile(
     'src/app/app.component.ts',

--- a/tests/legacy-cli/e2e/tests/misc/fallback.ts
+++ b/tests/legacy-cli/e2e/tests/misc/fallback.ts
@@ -4,32 +4,47 @@ import { ngServe } from '../../utils/project';
 import { updateJsonFile } from '../../utils/project';
 import { moveFile } from '../../utils/fs';
 
-
 export default function () {
   // TODO(architect): Delete this test. It is now in devkit/build-angular.
 
   // should fallback to config.app[0].index (index.html by default)
-  return Promise.resolve()
-    .then(() => ngServe())
-    .then(() => request('http://localhost:4200/'))
-    .then(body => {
-      if (!body.match(/<app-root><\/app-root>/)) {
-        throw new Error('Response does not match expected value.');
-      }
-    })
-    .then(() => killAllProcesses(), (err) => { killAllProcesses(); throw err; })
-    // should correctly fallback to a changed index
-    .then(() => moveFile('src/index.html', 'src/not-index.html'))
-    .then(() => updateJsonFile('angular.json', workspaceJson => {
-      const appArchitect = workspaceJson.projects['test-project'].architect;
-      appArchitect.build.options.index = 'src/not-index.html';
-    }))
-    .then(() => ngServe())
-    .then(() => request('http://localhost:4200/'))
-    .then(body => {
-      if (!body.match(/<app-root><\/app-root>/)) {
-        throw new Error('Response does not match expected value.');
-      }
-    })
-    .then(() => killAllProcesses(), (err) => { killAllProcesses(); throw err; });
+  return (
+    Promise.resolve()
+      .then(() => ngServe())
+      .then(() => request('http://localhost:4200/'))
+      .then((body) => {
+        if (!body.match(/<app-root><\/app-root>/)) {
+          throw new Error('Response does not match expected value.');
+        }
+      })
+      .then(
+        () => killAllProcesses(),
+        (err) => {
+          killAllProcesses();
+          throw err;
+        },
+      )
+      // should correctly fallback to a changed index
+      .then(() => moveFile('src/index.html', 'src/not-index.html'))
+      .then(() =>
+        updateJsonFile('angular.json', (workspaceJson) => {
+          const appArchitect = workspaceJson.projects['test-project'].architect;
+          appArchitect.build.options.index = 'src/not-index.html';
+        }),
+      )
+      .then(() => ngServe())
+      .then(() => request('http://localhost:4200/'))
+      .then((body) => {
+        if (!body.match(/<app-root><\/app-root>/)) {
+          throw new Error('Response does not match expected value.');
+        }
+      })
+      .then(
+        () => killAllProcesses(),
+        (err) => {
+          killAllProcesses();
+          throw err;
+        },
+      )
+  );
 }

--- a/tests/legacy-cli/e2e/tests/misc/forwardref-es2015.ts
+++ b/tests/legacy-cli/e2e/tests/misc/forwardref-es2015.ts
@@ -2,15 +2,15 @@ import { appendToFile, replaceInFile, writeFile } from '../../utils/fs';
 import { ng } from '../../utils/process';
 import { expectToFail } from '../../utils/utils';
 
-export default async function() {
+export default async function () {
   // Ensure an ES2015 build is used in test
   await writeFile('.browserslistrc', 'Chrome 65');
 
   // Update the application to use a forward reference
   await replaceInFile(
     'src/app/app.component.ts',
-    'import { Component } from \'@angular/core\';',
-    'import { Component, Inject, Injectable, forwardRef } from \'@angular/core\';',
+    "import { Component } from '@angular/core';",
+    "import { Component, Inject, Injectable, forwardRef } from '@angular/core';",
   );
   await appendToFile('src/app/app.component.ts', '\n@Injectable() export class Lock { }\n');
   await replaceInFile(
@@ -22,8 +22,8 @@ export default async function() {
   // Update the application's unit tests to include the new injectable
   await replaceInFile(
     'src/app/app.component.spec.ts',
-    'import { AppComponent } from \'./app.component\';',
-    'import { AppComponent, Lock } from \'./app.component\';',
+    "import { AppComponent } from './app.component';",
+    "import { AppComponent, Lock } from './app.component';",
   );
   await replaceInFile(
     'src/app/app.component.spec.ts',

--- a/tests/legacy-cli/e2e/tests/misc/karma-error-paths.ts
+++ b/tests/legacy-cli/e2e/tests/misc/karma-error-paths.ts
@@ -19,6 +19,8 @@ export default async function () {
   }
 
   if (!message.includes('(src/app/app.component.spec.ts:4:25)')) {
-    throw new Error(`Expected logs to contain relative path to (src/app/app.component.spec.ts:4:25)\n${message}`);
+    throw new Error(
+      `Expected logs to contain relative path to (src/app/app.component.spec.ts:4:25)\n${message}`,
+    );
   }
 }

--- a/tests/legacy-cli/e2e/tests/misc/lazy-module.ts
+++ b/tests/legacy-cli/e2e/tests/misc/lazy-module.ts
@@ -1,63 +1,83 @@
-import {readdirSync} from 'fs';
+import { readdirSync } from 'fs';
 import { installPackage } from '../../utils/packages';
-import {ng} from '../../utils/process';
-import {appendToFile, writeFile, prependToFile, replaceInFile} from '../../utils/fs';
+import { ng } from '../../utils/process';
+import { appendToFile, writeFile, prependToFile, replaceInFile } from '../../utils/fs';
 
-
-export default function() {
+export default function () {
   let oldNumberOfFiles = 0;
-  return Promise.resolve()
-    .then(() => ng('build', '--configuration=development'))
-    .then(() => oldNumberOfFiles = readdirSync('dist').length)
-    .then(() => ng('generate', 'module', 'lazy', '--routing'))
-    .then(() => ng('generate', 'module', 'too/lazy', '--routing'))
-    .then(() => prependToFile('src/app/app.module.ts', `
+  return (
+    Promise.resolve()
+      .then(() => ng('build', '--configuration=development'))
+      .then(() => (oldNumberOfFiles = readdirSync('dist').length))
+      .then(() => ng('generate', 'module', 'lazy', '--routing'))
+      .then(() => ng('generate', 'module', 'too/lazy', '--routing'))
+      .then(() =>
+        prependToFile(
+          'src/app/app.module.ts',
+          `
       import { RouterModule } from '@angular/router';
-    `))
-    .then(() => replaceInFile('src/app/app.module.ts', 'imports: [', `imports: [
+    `,
+        ),
+      )
+      .then(() =>
+        replaceInFile(
+          'src/app/app.module.ts',
+          'imports: [',
+          `imports: [
       RouterModule.forRoot([{ path: "lazy", loadChildren: () => import('src/app/lazy/lazy.module').then(m => m.LazyModule) }]),
       RouterModule.forRoot([{ path: "lazy1", loadChildren: () => import('./lazy/lazy.module').then(m => m.LazyModule) }]),
       RouterModule.forRoot([{ path: "lazy2", loadChildren: () => import('./too/lazy/lazy.module').then(m => m.LazyModule) }]),
-    `))
-    .then(() => ng('build', '--named-chunks', '--configuration=development'))
-    .then(() => readdirSync('dist/test-project'))
-    .then((distFiles) => {
-      const currentNumberOfDistFiles = distFiles.length;
-      if (oldNumberOfFiles >= currentNumberOfDistFiles) {
-        throw new Error('A bundle for the lazy module was not created.');
-      }
-      oldNumberOfFiles = currentNumberOfDistFiles;
+    `,
+        ),
+      )
+      .then(() => ng('build', '--named-chunks', '--configuration=development'))
+      .then(() => readdirSync('dist/test-project'))
+      .then((distFiles) => {
+        const currentNumberOfDistFiles = distFiles.length;
+        if (oldNumberOfFiles >= currentNumberOfDistFiles) {
+          throw new Error('A bundle for the lazy module was not created.');
+        }
+        oldNumberOfFiles = currentNumberOfDistFiles;
 
-      if (!distFiles.includes('src_app_too_lazy_lazy_module_ts.js')) {
-        throw new Error('The lazy module chunk did not use a unique name.');
-      }
-    })
-    // verify 'import *' syntax doesn't break lazy modules
-    .then(() => installPackage('moment'))
-    .then(() => appendToFile('src/app/app.component.ts', `
+        if (!distFiles.includes('src_app_too_lazy_lazy_module_ts.js')) {
+          throw new Error('The lazy module chunk did not use a unique name.');
+        }
+      })
+      // verify 'import *' syntax doesn't break lazy modules
+      .then(() => installPackage('moment'))
+      .then(() =>
+        appendToFile(
+          'src/app/app.component.ts',
+          `
       import * as moment from 'moment';
       console.log(moment);
-    `))
-    .then(() => ng('build', '--configuration=development'))
-    .then(() => readdirSync('dist/test-project').length)
-    .then(currentNumberOfDistFiles => {
-      if (oldNumberOfFiles != currentNumberOfDistFiles) {
-        throw new Error('Bundles were not created after adding \'import *\'.');
-      }
-    })
-    .then(() => ng('build', '--no-named-chunks', '--configuration=development'))
-    .then(() => readdirSync('dist/test-project'))
-    .then((distFiles) => {
-      if (distFiles.includes('lazy-lazy-module.js') || distFiles.includes('too-lazy-lazy-module.js')) {
-        throw new Error('Lazy chunks shouldn\'t have a name but did.');
-      }
-    })
-    // Check for AoT and lazy routes.
-    .then(() => ng('build', '--aot', '--configuration=development'))
-    .then(() => readdirSync('dist/test-project').length)
-    .then(currentNumberOfDistFiles => {
-      if (oldNumberOfFiles != currentNumberOfDistFiles) {
-        throw new Error('AoT build contains a different number of files.');
-      }
-    });
+    `,
+        ),
+      )
+      .then(() => ng('build', '--configuration=development'))
+      .then(() => readdirSync('dist/test-project').length)
+      .then((currentNumberOfDistFiles) => {
+        if (oldNumberOfFiles != currentNumberOfDistFiles) {
+          throw new Error("Bundles were not created after adding 'import *'.");
+        }
+      })
+      .then(() => ng('build', '--no-named-chunks', '--configuration=development'))
+      .then(() => readdirSync('dist/test-project'))
+      .then((distFiles) => {
+        if (
+          distFiles.includes('lazy-lazy-module.js') ||
+          distFiles.includes('too-lazy-lazy-module.js')
+        ) {
+          throw new Error("Lazy chunks shouldn't have a name but did.");
+        }
+      })
+      // Check for AoT and lazy routes.
+      .then(() => ng('build', '--aot', '--configuration=development'))
+      .then(() => readdirSync('dist/test-project').length)
+      .then((currentNumberOfDistFiles) => {
+        if (oldNumberOfFiles != currentNumberOfDistFiles) {
+          throw new Error('AoT build contains a different number of files.');
+        }
+      })
+  );
 }

--- a/tests/legacy-cli/e2e/tests/misc/loaders-resolution.ts
+++ b/tests/legacy-cli/e2e/tests/misc/loaders-resolution.ts
@@ -5,7 +5,7 @@ export default async function () {
   await createDir('node_modules/@angular-devkit/build-angular/node_modules');
   await moveFile(
     'node_modules/@ngtools',
-    'node_modules/@angular-devkit/build-angular/node_modules/@ngtools'
+    'node_modules/@angular-devkit/build-angular/node_modules/@ngtools',
   );
 
   await ng('build', '--configuration=development');

--- a/tests/legacy-cli/e2e/tests/misc/module-resolution.ts
+++ b/tests/legacy-cli/e2e/tests/misc/module-resolution.ts
@@ -4,9 +4,8 @@ import { ng } from '../../utils/process';
 import { updateJsonFile } from '../../utils/project';
 import { expectToFail } from '../../utils/utils';
 
-
 export default async function () {
-  await updateJsonFile('tsconfig.json', tsconfig => {
+  await updateJsonFile('tsconfig.json', (tsconfig) => {
     tsconfig.compilerOptions.paths = {
       '*': ['./node_modules/*'],
     };
@@ -14,41 +13,38 @@ export default async function () {
   await ng('build', '--configuration=development');
 
   await createDir('xyz');
-  await moveFile(
-    'node_modules/@angular/common',
-    'xyz/common',
-  );
+  await moveFile('node_modules/@angular/common', 'xyz/common');
 
   await expectToFail(() => ng('build', '--configuration=development'));
 
-  await updateJsonFile('tsconfig.json', tsconfig => {
+  await updateJsonFile('tsconfig.json', (tsconfig) => {
     tsconfig.compilerOptions.paths = {
-      '@angular/common': [ './xyz/common' ],
+      '@angular/common': ['./xyz/common'],
     };
   });
   await ng('build', '--configuration=development');
 
-  await updateJsonFile('tsconfig.json', tsconfig => {
+  await updateJsonFile('tsconfig.json', (tsconfig) => {
     tsconfig.compilerOptions.paths = {
       '*': ['./node_modules/*'],
-      '@angular/common': [ './xyz/common' ],
+      '@angular/common': ['./xyz/common'],
     };
   });
   await ng('build', '--configuration=development');
 
-  await updateJsonFile('tsconfig.json', tsconfig => {
+  await updateJsonFile('tsconfig.json', (tsconfig) => {
     tsconfig.compilerOptions.paths = {
-      '@angular/common': [ './xyz/common' ],
+      '@angular/common': ['./xyz/common'],
       '*': ['./node_modules/*'],
     };
   });
   await ng('build', '--configuration=development');
 
-  await updateJsonFile('tsconfig.json', tsconfig => {
+  await updateJsonFile('tsconfig.json', (tsconfig) => {
     delete tsconfig.compilerOptions.paths;
   });
 
-  await prependToFile('src/app/app.module.ts', 'import * as firebase from \'firebase\';');
+  await prependToFile('src/app/app.module.ts', "import * as firebase from 'firebase';");
   await appendToFile('src/app/app.module.ts', 'firebase.initializeApp({});');
 
   await installPackage('firebase@3.7.8');
@@ -59,12 +55,12 @@ export default async function () {
   await ng('build', '--aot', '--configuration=development');
   await ng('test', '--watch=false');
 
-  await updateJsonFile('tsconfig.json', tsconfig => {
+  await updateJsonFile('tsconfig.json', (tsconfig) => {
     tsconfig.compilerOptions.paths = {};
   });
   await ng('build', '--configuration=development');
 
-  await updateJsonFile('tsconfig.json', tsconfig => {
+  await updateJsonFile('tsconfig.json', (tsconfig) => {
     tsconfig.compilerOptions.paths = {
       '@app/*': ['*'],
       '@lib/*/test': ['*/test'],
@@ -72,14 +68,14 @@ export default async function () {
   });
   await ng('build', '--configuration=development');
 
-  await updateJsonFile('tsconfig.json', tsconfig => {
+  await updateJsonFile('tsconfig.json', (tsconfig) => {
     tsconfig.compilerOptions.paths = {
       '@firebase/polyfill': ['./node_modules/@firebase/polyfill/index.ts'],
     };
   });
   await expectToFail(() => ng('build', '--configuration=development'));
 
-  await updateJsonFile('tsconfig.json', tsconfig => {
+  await updateJsonFile('tsconfig.json', (tsconfig) => {
     tsconfig.compilerOptions.paths = {
       '@firebase/polyfill*': ['./node_modules/@firebase/polyfill/index.ts'],
     };

--- a/tests/legacy-cli/e2e/tests/misc/non-relative-module-resolution.ts
+++ b/tests/legacy-cli/e2e/tests/misc/non-relative-module-resolution.ts
@@ -1,7 +1,6 @@
 import { prependToFile, writeMultipleFiles } from '../../utils/fs';
 import { ng } from '../../utils/process';
 
-
 export default async function () {
   // TODO(architect): Delete this test. It is now in devkit/build-angular.
 
@@ -13,10 +12,9 @@ export default async function () {
       import { foo } from './foo';
 
       console.log(foo);
-    `
+    `,
   }),
-
-  await prependToFile('src/app/app.module.ts', `import './bar';\n`);
+    await prependToFile('src/app/app.module.ts', `import './bar';\n`);
 
   await ng('build', '--configuration=development');
 }

--- a/tests/legacy-cli/e2e/tests/misc/npm-audit.ts
+++ b/tests/legacy-cli/e2e/tests/misc/npm-audit.ts
@@ -1,7 +1,6 @@
 import { npm } from '../../utils/process';
 
-
-export default async function() {
+export default async function () {
   try {
     await npm('audit');
   } catch {}

--- a/tests/legacy-cli/e2e/tests/misc/ssl-default.ts
+++ b/tests/legacy-cli/e2e/tests/misc/ssl-default.ts
@@ -2,17 +2,22 @@ import { request } from '../../utils/http';
 import { killAllProcesses } from '../../utils/process';
 import { ngServe } from '../../utils/project';
 
-
-export default function() {
+export default function () {
   // TODO(architect): Delete this test. It is now in devkit/build-angular.
 
   return Promise.resolve()
     .then(() => ngServe('--ssl', 'true'))
     .then(() => request('https://localhost:4200/'))
-    .then(body => {
+    .then((body) => {
       if (!body.match(/<app-root><\/app-root>/)) {
         throw new Error('Response does not match expected value.');
       }
     })
-    .then(() => killAllProcesses(), (err) => { killAllProcesses(); throw err; });
+    .then(
+      () => killAllProcesses(),
+      (err) => {
+        killAllProcesses();
+        throw err;
+      },
+    );
 }

--- a/tests/legacy-cli/e2e/tests/misc/ssl-with-cert.ts
+++ b/tests/legacy-cli/e2e/tests/misc/ssl-with-cert.ts
@@ -3,22 +3,31 @@ import { assetDir } from '../../utils/assets';
 import { killAllProcesses } from '../../utils/process';
 import { ngServe } from '../../utils/project';
 
-
-export default function() {
+export default function () {
   // TODO(architect): Delete this test. It is now in devkit/build-angular.
 
   return Promise.resolve()
-    .then(() => ngServe(
-      '--ssl', 'true',
-      '--ssl-key', assetDir('ssl/server.key'),
-      '--ssl-cert', assetDir('ssl/server.crt')
-    ))
+    .then(() =>
+      ngServe(
+        '--ssl',
+        'true',
+        '--ssl-key',
+        assetDir('ssl/server.key'),
+        '--ssl-cert',
+        assetDir('ssl/server.crt'),
+      ),
+    )
     .then(() => request('https://localhost:4200/'))
-    .then(body => {
+    .then((body) => {
       if (!body.match(/<app-root><\/app-root>/)) {
         throw new Error('Response does not match expected value.');
       }
     })
-    .then(() => killAllProcesses(), (err) => { killAllProcesses(); throw err; });
-
+    .then(
+      () => killAllProcesses(),
+      (err) => {
+        killAllProcesses();
+        throw err;
+      },
+    );
 }

--- a/tests/legacy-cli/e2e/tests/misc/supported-angular.ts
+++ b/tests/legacy-cli/e2e/tests/misc/supported-angular.ts
@@ -4,7 +4,6 @@ import { readFile, writeFile } from '../../utils/fs';
 import { ng } from '../../utils/process';
 import { expectToFail } from '../../utils/utils';
 
-
 export default async function () {
   if (getGlobalVariable('argv')['ng-snapshots']) {
     // The snapshots job won't work correctly because it doesn't use semver for Angular.

--- a/tests/legacy-cli/e2e/tests/misc/target-default-configuration.ts
+++ b/tests/legacy-cli/e2e/tests/misc/target-default-configuration.ts
@@ -4,7 +4,7 @@ import { updateJsonFile } from '../../utils/project';
 import { expectToFail } from '../../utils/utils';
 
 export default async function () {
-  await updateJsonFile('angular.json', workspace => {
+  await updateJsonFile('angular.json', (workspace) => {
     const build = workspace.projects['test-project'].architect.build;
     build.defaultConfiguration = undefined;
     build.options = {
@@ -21,7 +21,7 @@ export default async function () {
   await expectFileToExist('dist/test-project/main.js.map');
 
   // Add new configuration and set "defaultConfiguration"
-  await updateJsonFile('angular.json', workspace => {
+  await updateJsonFile('angular.json', (workspace) => {
     const build = workspace.projects['test-project'].architect.build;
     build.defaultConfiguration = 'foo';
     build.configurations.foo = {

--- a/tests/legacy-cli/e2e/tests/misc/title.ts
+++ b/tests/legacy-cli/e2e/tests/misc/title.ts
@@ -1,7 +1,6 @@
 import { execAndWaitForOutputToMatch, execWithEnv, killAllProcesses } from '../../utils/process';
 
-
-export default async function() {
+export default async function () {
   if (process.platform.startsWith('win')) {
     // "On Windows, process.title affects the console title, but not the name of the process in the task manager."
     // https://stackoverflow.com/questions/44756196/how-to-change-the-node-js-process-name-on-windows-10#comment96259375_44756196
@@ -9,7 +8,11 @@ export default async function() {
   }
 
   try {
-    await execAndWaitForOutputToMatch('ng', ['build', '--configuration=development', '--watch'], /./);
+    await execAndWaitForOutputToMatch(
+      'ng',
+      ['build', '--configuration=development', '--watch'],
+      /./,
+    );
 
     const output = await execWithEnv('ps', ['x'], { COLUMNS: '200' });
 

--- a/tests/legacy-cli/e2e/tests/misc/trace-resolution.ts
+++ b/tests/legacy-cli/e2e/tests/misc/trace-resolution.ts
@@ -2,7 +2,7 @@ import { ng } from '../../utils/process';
 import { updateJsonFile } from '../../utils/project';
 
 export default async function () {
-  await updateJsonFile('tsconfig.json', tsconfig => {
+  await updateJsonFile('tsconfig.json', (tsconfig) => {
     tsconfig.compilerOptions.traceResolution = true;
   });
 
@@ -11,7 +11,7 @@ export default async function () {
     throw new Error(`Modules resolutions must be printed when 'traceResolution' is enabled.`);
   }
 
-  await updateJsonFile('tsconfig.json', tsconfig => {
+  await updateJsonFile('tsconfig.json', (tsconfig) => {
     tsconfig.compilerOptions.traceResolution = false;
   });
 

--- a/tests/legacy-cli/e2e/tests/misc/universal-bundle-dependencies.ts
+++ b/tests/legacy-cli/e2e/tests/misc/universal-bundle-dependencies.ts
@@ -9,8 +9,8 @@ import {
 import { ng } from '../../utils/process';
 import { updateJsonFile } from '../../utils/project';
 
-export default async function() {
-  await updateJsonFile('angular.json', workspaceJson => {
+export default async function () {
+  await updateJsonFile('angular.json', (workspaceJson) => {
     const appArchitect = workspaceJson.projects['test-project'].architect;
     appArchitect['server'] = {
       builder: '@angular-devkit/build-angular:server',

--- a/tests/legacy-cli/e2e/tests/misc/update-git-clean-subdirectory.ts
+++ b/tests/legacy-cli/e2e/tests/misc/update-git-clean-subdirectory.ts
@@ -3,7 +3,7 @@ import { createDir, writeFile } from '../../utils/fs';
 import { ng, silentGit } from '../../utils/process';
 import { prepareProjectForE2e } from '../../utils/project';
 
-export default async function() {
+export default async function () {
   process.chdir(getGlobalVariable('tmp-root'));
 
   await createDir('./subdirectory');
@@ -15,7 +15,7 @@ export default async function() {
   process.chdir('./subdirectory-test-project');
   await prepareProjectForE2e('subdirectory-test-project');
 
-  await writeFile('../added.ts', 'console.log(\'created\');\n');
+  await writeFile('../added.ts', "console.log('created');\n");
   await silentGit('add', '../added.ts');
 
   const { stderr } = await ng('update', '@angular/cli');

--- a/tests/legacy-cli/e2e/tests/misc/update-git-clean.ts
+++ b/tests/legacy-cli/e2e/tests/misc/update-git-clean.ts
@@ -2,8 +2,8 @@ import { appendToFile } from '../../utils/fs';
 import { ng } from '../../utils/process';
 import { expectToFail } from '../../utils/utils';
 
-export default async function() {
-  await appendToFile('src/main.ts', 'console.log(\'changed\');\n');
+export default async function () {
+  await appendToFile('src/main.ts', "console.log('changed');\n");
 
   const { message } = await expectToFail(() => ng('update', '@angular/cli'));
   if (!message || !message.includes('Repository is not clean.')) {

--- a/tests/legacy-cli/e2e/tests/misc/workspace-verification.ts
+++ b/tests/legacy-cli/e2e/tests/misc/workspace-verification.ts
@@ -1,13 +1,14 @@
-import {deleteFile} from '../../utils/fs';
-import {ng} from '../../utils/process';
+import { deleteFile } from '../../utils/fs';
+import { ng } from '../../utils/process';
 import { expectToFail } from '../../utils/utils';
 
-
-export default function() {
-  return ng('generate', 'component', 'foo', '--dry-run')
-    .then(() => deleteFile('angular.json'))
-    // fails because it needs to be inside a project
-    // without a workspace file
-    .then(() => expectToFail(() => ng('generate', 'component', 'foo', '--dry-run')))
-    .then(() => ng('version'));
+export default function () {
+  return (
+    ng('generate', 'component', 'foo', '--dry-run')
+      .then(() => deleteFile('angular.json'))
+      // fails because it needs to be inside a project
+      // without a workspace file
+      .then(() => expectToFail(() => ng('generate', 'component', 'foo', '--dry-run')))
+      .then(() => ng('version'))
+  );
 }

--- a/tests/legacy-cli/e2e/tests/schematics_cli/basic.ts
+++ b/tests/legacy-cli/e2e/tests/schematics_cli/basic.ts
@@ -10,11 +10,7 @@ export default async function () {
     return;
   }
 
-  await silentNpm(
-    'install',
-    '-g',
-    '@angular-devkit/schematics-cli',
-  );
+  await silentNpm('install', '-g', '@angular-devkit/schematics-cli');
   await exec(process.platform.startsWith('win') ? 'where' : 'which', 'schematics');
 
   const startCwd = process.cwd();
@@ -30,7 +26,6 @@ export default async function () {
       ['.:', '--list-schematics'],
       /my-full-schematic/,
     );
-
   } finally {
     // restore path
     process.chdir(startCwd);

--- a/tests/legacy-cli/e2e/tests/schematics_cli/blank-test.ts
+++ b/tests/legacy-cli/e2e/tests/schematics_cli/blank-test.ts
@@ -11,11 +11,7 @@ export default async function () {
     return;
   }
 
-  await silentNpm(
-    'install',
-    '-g',
-    '@angular-devkit/schematics-cli',
-  );
+  await silentNpm('install', '-g', '@angular-devkit/schematics-cli');
   await exec(process.platform.startsWith('win') ? 'where' : 'which', 'schematics');
 
   const startCwd = process.cwd();

--- a/tests/legacy-cli/e2e/tests/schematics_cli/schematic-test.ts
+++ b/tests/legacy-cli/e2e/tests/schematics_cli/schematic-test.ts
@@ -11,11 +11,7 @@ export default async function () {
     return;
   }
 
-  await silentNpm(
-    'install',
-    '-g',
-    '@angular-devkit/schematics-cli',
-  );
+  await silentNpm('install', '-g', '@angular-devkit/schematics-cli');
   await exec(process.platform.startsWith('win') ? 'where' : 'which', 'schematics');
 
   const startCwd = process.cwd();

--- a/tests/legacy-cli/e2e/tests/test/test-fail-single-run.ts
+++ b/tests/legacy-cli/e2e/tests/test/test-fail-single-run.ts
@@ -2,11 +2,11 @@ import { ng } from '../../utils/process';
 import { writeFile } from '../../utils/fs';
 import { expectToFail } from '../../utils/utils';
 
-
 export default function () {
   // TODO(architect): Delete this test. It is now in devkit/build-angular.
 
   // Fails on single run with broken compilation.
-  return writeFile('src/app.component.spec.ts', '<p> definitely not typescript </p>')
-    .then(() => expectToFail(() => ng('test', '--watch=false')));
+  return writeFile('src/app.component.spec.ts', '<p> definitely not typescript </p>').then(() =>
+    expectToFail(() => ng('test', '--watch=false')),
+  );
 }

--- a/tests/legacy-cli/e2e/tests/test/test-fail-watch.ts
+++ b/tests/legacy-cli/e2e/tests/test/test-fail-watch.ts
@@ -6,7 +6,6 @@ import {
 import { expectToFail } from '../../utils/utils';
 import { readFile, writeFile } from '../../utils/fs';
 
-
 // Karma is only really finished with a run when it shows a non-zero total time in the first slot.
 const karmaGoodRegEx = /Executed 3 of 3 SUCCESS \(\d+\.\d+ secs/;
 
@@ -16,17 +15,22 @@ export default function () {
   return;
 
   let originalSpec: string;
-  return execAndWaitForOutputToMatch('ng', ['test'], karmaGoodRegEx)
-    .then(() => readFile('src/app/app.component.spec.ts'))
-    .then((data) => originalSpec = data)
-    // Trigger a failed rebuild, which shouldn't run tests again.
-    .then(() => writeFile('src/app/app.component.spec.ts', '<p> definitely not typescript </p>'))
-    .then(() => expectToFail(() => waitForAnyProcessOutputToMatch(karmaGoodRegEx, 10000)))
-    // Restore working spec.
-    .then(() => writeFile('src/app/app.component.spec.ts', originalSpec))
-    .then(() => waitForAnyProcessOutputToMatch(karmaGoodRegEx, 20000))
-    .then(() => killAllProcesses(), (err: any) => {
-      killAllProcesses();
-      throw err;
-    });
+  return (
+    execAndWaitForOutputToMatch('ng', ['test'], karmaGoodRegEx)
+      .then(() => readFile('src/app/app.component.spec.ts'))
+      .then((data) => (originalSpec = data))
+      // Trigger a failed rebuild, which shouldn't run tests again.
+      .then(() => writeFile('src/app/app.component.spec.ts', '<p> definitely not typescript </p>'))
+      .then(() => expectToFail(() => waitForAnyProcessOutputToMatch(karmaGoodRegEx, 10000)))
+      // Restore working spec.
+      .then(() => writeFile('src/app/app.component.spec.ts', originalSpec))
+      .then(() => waitForAnyProcessOutputToMatch(karmaGoodRegEx, 20000))
+      .then(
+        () => killAllProcesses(),
+        (err: any) => {
+          killAllProcesses();
+          throw err;
+        },
+      )
+  );
 }

--- a/tests/legacy-cli/e2e/tests/test/test-sourcemap.ts
+++ b/tests/legacy-cli/e2e/tests/test/test-sourcemap.ts
@@ -3,13 +3,16 @@ import { ng } from '../../utils/process';
 import { updateJsonFile } from '../../utils/project';
 
 export default async function () {
-  await writeFile('src/app/app.component.spec.ts', `
+  await writeFile(
+    'src/app/app.component.spec.ts',
+    `
       it('show fail', () => {
         expect(undefined).toBeTruthy();
       });
-    `);
+    `,
+  );
 
-  await updateJsonFile('angular.json', configJson => {
+  await updateJsonFile('angular.json', (configJson) => {
     const appArchitect = configJson.projects['test-project'].architect;
     appArchitect.test.options.sourceMap = {
       scripts: true,
@@ -23,10 +26,10 @@ export default async function () {
   } catch (error) {
     if (!error.message.includes('app.component.spec.ts')) {
       throw error;
-    };
+    }
   }
 
-  await updateJsonFile('angular.json', configJson => {
+  await updateJsonFile('angular.json', (configJson) => {
     const appArchitect = configJson.projects['test-project'].architect;
     appArchitect.test.options.sourceMap = true;
   });
@@ -38,10 +41,10 @@ export default async function () {
   } catch (error) {
     if (!error.message.includes('app.component.spec.ts')) {
       throw error;
-    };
+    }
   }
 
-  await updateJsonFile('angular.json', configJson => {
+  await updateJsonFile('angular.json', (configJson) => {
     const appArchitect = configJson.projects['test-project'].architect;
     appArchitect.test.options.sourceMap = false;
   });
@@ -53,6 +56,6 @@ export default async function () {
   } catch (error) {
     if (!error.message.includes('main.js')) {
       throw error;
-    };
+    }
   }
 }

--- a/tests/legacy-cli/e2e/tests/test/test-target.ts
+++ b/tests/legacy-cli/e2e/tests/test/test-target.ts
@@ -6,13 +6,15 @@ export default function () {
   // TypeError: Assignment to constant variable.
   return;
 
-  return updateJsonFile('tsconfig.json', configJson => {
+  return updateJsonFile('tsconfig.json', (configJson) => {
     const compilerOptions = configJson['compilerOptions'];
     compilerOptions['target'] = 'es2015';
   })
-    .then(() => updateJsonFile('src/tsconfig.spec.json', configJson => {
-      const compilerOptions = configJson['compilerOptions'];
-      compilerOptions['target'] = 'es2015';
-    }))
+    .then(() =>
+      updateJsonFile('src/tsconfig.spec.json', (configJson) => {
+        const compilerOptions = configJson['compilerOptions'];
+        compilerOptions['target'] = 'es2015';
+      }),
+    )
     .then(() => ng('test', '--watch=false'));
 }

--- a/tests/legacy-cli/e2e/utils/env.ts
+++ b/tests/legacy-cli/e2e/utils/env.ts
@@ -1,5 +1,4 @@
-const global: {[name: string]: any} = Object.create(null);
-
+const global: { [name: string]: any } = Object.create(null);
 
 export function setGlobalVariable(name: string, value: any) {
   global[name] = value;

--- a/tests/legacy-cli/e2e/utils/git.ts
+++ b/tests/legacy-cli/e2e/utils/git.ts
@@ -1,5 +1,4 @@
-import {git, silentGit} from './process';
-
+import { git, silentGit } from './process';
 
 export function gitClean() {
   console.log('  Cleaning git...');
@@ -8,22 +7,23 @@ export function gitClean() {
     .then(() => {
       // Checkout missing files
       return silentGit('status', '--porcelain')
-        .then(({ stdout }) => stdout
-          .split(/[\n\r]+/g)
-          .filter(line => line.match(/^ D/))
-          .map(line => line.replace(/^\s*\S+\s+/, '')))
-        .then(files => silentGit('checkout', ...files));
+        .then(({ stdout }) =>
+          stdout
+            .split(/[\n\r]+/g)
+            .filter((line) => line.match(/^ D/))
+            .map((line) => line.replace(/^\s*\S+\s+/, '')),
+        )
+        .then((files) => silentGit('checkout', ...files));
     })
     .then(() => expectGitToBeClean());
 }
 
 export function expectGitToBeClean() {
-  return silentGit('status', '--porcelain')
-    .then(({ stdout }) => {
-      if (stdout != '') {
-        throw new Error('Git repo is not clean...\n' + stdout);
-      }
-    });
+  return silentGit('status', '--porcelain').then(({ stdout }) => {
+    if (stdout != '') {
+      throw new Error('Git repo is not clean...\n' + stdout);
+    }
+  });
 }
 
 export function gitCommit(message: string) {

--- a/tests/legacy-cli/e2e/utils/utils.ts
+++ b/tests/legacy-cli/e2e/utils/utils.ts
@@ -1,12 +1,16 @@
-
 export function expectToFail(fn: () => Promise<any>, errorMessage?: string): Promise<any> {
-  return fn()
-    .then(() => {
+  return fn().then(
+    () => {
       const functionSource = fn.name || (<any>fn).source || fn.toString();
       const errorDetails = errorMessage ? `\n\tDetails:\n\t${errorMessage}` : '';
       throw new Error(
-        `Function ${functionSource} was expected to fail, but succeeded.${errorDetails}`);
-    }, (err) => { return err; });
+        `Function ${functionSource} was expected to fail, but succeeded.${errorDetails}`,
+      );
+    },
+    (err) => {
+      return err;
+    },
+  );
 }
 
 export function wait(msecs: number): Promise<void> {

--- a/tests/legacy-cli/e2e/utils/version.ts
+++ b/tests/legacy-cli/e2e/utils/version.ts
@@ -1,9 +1,10 @@
 import * as fs from 'fs';
 import * as semver from 'semver';
 
-
 export function readNgVersion(): string {
-  const packageJson: any = JSON.parse(fs.readFileSync('./node_modules/@angular/core/package.json', 'utf8'));
+  const packageJson: any = JSON.parse(
+    fs.readFileSync('./node_modules/@angular/core/package.json', 'utf8'),
+  );
   return packageJson['version'];
 }
 


### PR DESCRIPTION
I'm working on switching these to run via bazel and getting significant diffs when editing the files. Are we ok with a single commit formatting all these? For now it's just the legacy-cli which I hope is all the files I'll be editing when switching to bazel...