### PR TITLE
 build: replace minimist with yargs-parser 

### DIFF
--- a/bin/devkit-admin
+++ b/bin/devkit-admin
@@ -17,10 +17,10 @@
 require('../lib/bootstrap-local');
 
 
-const minimist = require('minimist');
+const yargsParser = require('yargs-parser');
 const path = require('path');
 
-const args = minimist(process.argv.slice(2), {
+const args = yargsParser(process.argv.slice(2), {
   boolean: ['verbose']
 });
 const scriptName = args._.shift();


### PR DESCRIPTION
`minimist` is not in package.json. This causes errors when building e2e tests with bazel which enforces this. Removing it was simple to reduce dependencies instead of adding more...