### PR TITLE
[13.3.x] build: cleanup references to old `master` branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,8 @@ var_5: &only_release_branches
   filters:
     branches:
       only:
+        - main
+        # TODO(BRANCH_RENAME_CLEANUP): remove
         - master
         - /\d+\.\d+\.x/
 
@@ -354,6 +356,8 @@ workflows:
             branches:
               only:
                 - renovate/angular
+                - main
+                # TODO(BRANCH_RENAME_CLEANUP): remove
                 - master
       - e2e-cli:
           name: e2e-cli-node-12

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,8 +30,6 @@ var_5: &only_release_branches
     branches:
       only:
         - main
-        # TODO(BRANCH_RENAME_CLEANUP): remove
-        - master
         - /\d+\.\d+\.x/
 
 # Executor Definitions
@@ -357,8 +355,6 @@ workflows:
               only:
                 - renovate/angular
                 - main
-                # TODO(BRANCH_RENAME_CLEANUP): remove
-                - master
       - e2e-cli:
           name: e2e-cli-node-12
           nodeversion: '12.20'

--- a/.github/ISSUE_TEMPLATE/1-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.md
@@ -57,7 +57,7 @@ Share the link to the repo below along with step-by-step instructions to reprodu
 
 Issues that don't have enough info and can't be reproduced will be closed.
 
-You can read more about issue submission guidelines here: https://github.com/angular/angular-cli/blob/master/CONTRIBUTING.md#-submitting-an-issue
+You can read more about issue submission guidelines here: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-submitting-an-issue
 -->
 
 ## 🔥 Exception or Error

--- a/.github/ISSUE_TEMPLATE/5-support-request.md
+++ b/.github/ISSUE_TEMPLATE/5-support-request.md
@@ -8,7 +8,7 @@ about: Questions and requests for support
 Please do not file questions or support requests on the GitHub issues tracker.
 
 You can get your questions answered using other communication channels. Please see:
-https://github.com/angular/angular-cli/blob/master/CONTRIBUTING.md#question
+https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#question
 
 Thank you!
 

--- a/.github/SAVED_REPLIES.md
+++ b/.github/SAVED_REPLIES.md
@@ -29,7 +29,7 @@ Thanks for reporting this issue. However, this issue is a duplicate of #<ISSUE_N
 ## Angular CLI: Insufficient Information Provided (v1)
 
 ```
-Thanks for reporting this issue. However, you didn't provide sufficient information for us to understand and reproduce the problem. Please check out [our submission guidelines](https://github.com/angular/angular-cli/blob/master/CONTRIBUTING.md#-submitting-an-issue) to understand why we can't act on issues that are lacking important information.
+Thanks for reporting this issue. However, you didn't provide sufficient information for us to understand and reproduce the problem. Please check out [our submission guidelines](https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-submitting-an-issue) to understand why we can't act on issues that are lacking important information.
 
 If the problem persists, please file a new issue and ensure you provide all of the required information when filling out the issue template.
 ```
@@ -55,7 +55,7 @@ I'm sorry, but we can't reproduce the problem following the instructions you pro
 Remember that we have a large number of issues to resolve, and have only a limited amount of time to reproduce your issue.
 Short, explicit instructions make it much more likely we'll be able to reproduce the problem so we can fix it.
 
-If the problem persists, please open a new issue following [our submission guidelines](https://github.com/angular/angular-cli/blob/master/CONTRIBUTING.md#-submitting-an-issue).
+If the problem persists, please open a new issue following [our submission guidelines](https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-submitting-an-issue).
 
 A good way to make a minimal repro is to create a new app via `ng new repro-app` and adding the minimum possible code to show the problem. Then you can push this repository to github and link it here.
 ```
@@ -73,7 +73,7 @@ If the problem persists after upgrading, please open a new issue, provide a simp
 ```
 Hello, we reviewed this issue and determined that it doesn't fall into the bug report or feature request category. This issue tracker is not suitable for support requests, please repost your issue on [StackOverflow](http://stackoverflow.com/) using tag `angular-cli`.
 
-If you are wondering why we don't resolve support issues via the issue tracker, please [check out this explanation](https://github.com/angular/angular-cli/blob/master/CONTRIBUTING.md#-got-a-question-or-problem).
+If you are wondering why we don't resolve support issues via the issue tracker, please [check out this explanation](https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-got-a-question-or-problem).
 ```
 
 ## Angular CLI: Static Analysis errors (v1)

--- a/.github/angular-robot.yml
+++ b/.github/angular-robot.yml
@@ -58,11 +58,11 @@ merge:
     checks are still failing:
 
     {{PLACEHOLDER}}
-     
+
     **If you want your PR to be merged, it has to pass all the CI checks.**
-     
-    If you can't get the PR to a green state due to flakes or broken master,
-    please try rebasing to master and/or restarting the CI job. If that fails
+
+    If you can't get the PR to a green state due to flakes or broken `main`,
+    please try rebasing to `main` and/or restarting the CI job. If that fails
     and you believe that the issue is not due to your change, please contact the
     caretaker and ask for help.
 # options for the triage plugin

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -4,11 +4,7 @@ on:
   schedule:
     - cron: '0 2 * * 0'
   push:
-    branches: [
-        main,
-        # TODO(BRANCH_RENAME_CLEANUP): remove
-        master,
-      ]
+    branches: [main]
   workflow_dispatch:
 
 # Declare default permissions as read only.

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -4,7 +4,11 @@ on:
   schedule:
     - cron: '0 2 * * 0'
   push:
-    branches: [master]
+    branches: [
+        main,
+        # TODO(BRANCH_RENAME_CLEANUP): remove
+        master,
+      ]
   workflow_dispatch:
 
 # Declare default permissions as read only.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,7 @@ Before you submit your Pull Request (PR) consider the following guidelines:
 * Make your changes in a new git branch:
 
      ```shell
-     git checkout -b my-fix-branch master
+     git checkout -b my-fix-branch main
      ```
 
 * Create your patch, **including appropriate test cases**.
@@ -106,19 +106,19 @@ Before you submit your Pull Request (PR) consider the following guidelines:
     git push origin my-fix-branch
     ```
 
-* In GitHub, send a pull request to `angular/angular-cli:master`.
+* In GitHub, send a pull request to `angular/angular-cli:main`.
 * If we suggest changes then:
   * Make the required updates.
   * Re-run the Angular DevKit test suites to ensure tests are still passing.
 * Once your PR is approved and you are done with any follow up changes:
-  * Rebase to the current master to pre-emptively address any merge conflicts.
+  * Rebase to the current main to pre-emptively address any merge conflicts.
 
     ```shell
-    git rebase master -i
+    git rebase upstream/main -i
     git push -f
     ```
   * Add the `action: merge` label and the correct
-[target label](https://github.com/angular/angular/blob/master/docs/TRIAGE_AND_LABELS.md#pr-target)
+[target label](https://github.com/angular/angular/blob/main/docs/TRIAGE_AND_LABELS.md#pr-target)
     (if PR author has the project collaborator status, or else the last reviewer
     should do this).
   * The current caretaker will merge the PR to the target branch(es) within 1-2
@@ -137,10 +137,10 @@ from the main (upstream) repository:
     git push origin --delete my-fix-branch
     ```
 
-* Check out the master branch:
+* Check out the main branch:
 
     ```shell
-    git checkout master -f
+    git checkout main -f
     ```
 
 * Delete the local branch:
@@ -149,10 +149,10 @@ from the main (upstream) repository:
     git branch -D my-fix-branch
     ```
 
-* Update your master with the latest upstream version:
+* Update your local `main` with the latest upstream version:
 
     ```shell
-    git pull --ff upstream master
+    git pull --ff upstream main
     ```
 
 ## <a name="rules"></a> Coding Rules
@@ -192,15 +192,15 @@ If the commit reverts a previous commit, it should begin with `revert: `, follow
 ### Type
 Must be one of the following:
 
-* **build**: Changes to local repository build system and tooling 
+* **build**: Changes to local repository build system and tooling
 * **ci**: Changes to CI configuration and CI specific tooling [2]
-* **docs**: Changes which exclusively affects documentation. 
+* **docs**: Changes which exclusively affects documentation.
 * **feat**: Creates a new feature [1]
 * **fix**: Fixes a previously discovered failure/bug [1]
 * **perf**: Improves performance without any change in functionality or API [1]
-* **refactor**: Refactor without any change in functionality or API (includes style changes) 
+* **refactor**: Refactor without any change in functionality or API (includes style changes)
 * **release**: A release point in the repository [2]
-* **test**: Improvements or corrections made to the project's test suite 
+* **test**: Improvements or corrections made to the project's test suite
 
 
 <sup>[1] This type MUST have a scope. See the next section for more information.</sup><br/>
@@ -293,7 +293,7 @@ changes to be accepted, the CLA must be signed. It's a quick process, we promise
 [coc]: https://github.com/angular/code-of-conduct/blob/master/CODE_OF_CONDUCT.md
 [commit-message-format]: https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit#
 [corporate-cla]: http://code.google.com/legal/corporate-cla-v1.0.html
-[dev-doc]: https://github.com/angular/angular-cli/blob/master/packages/angular/cli/README.md#development-hints-for-working-on-angular-cli
+[dev-doc]: https://github.com/angular/angular-cli/blob/main/packages/angular/cli/README.md#development-hints-for-working-on-angular-cli
 [GitHub]: https://github.com/angular/angular-cli
 [gitter]: https://gitter.im/angular/angular-cli
 [individual-cla]: http://code.google.com/legal/individual-cla-v1.0.html

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   <br>
   <img src="/docs/images/angular-cli-logo.png" alt="Angular CLI logo" width="100px" height="108px"/>
   <br><br>
-  <i>The Angular CLI is a command-line interface tool that you use to initialize, develop, scaffold, 
+  <i>The Angular CLI is a command-line interface tool that you use to initialize, develop, scaffold,
     <br>and maintain Angular applications directly from a command shell.</i>
   <br>
 </p>
@@ -37,8 +37,8 @@
 </p>
 
 <p align="center">
-  <a href="https://circleci.com/gh/angular/workflows/angular-cli/tree/master">
-    <img src="https://img.shields.io/circleci/build/github/angular/angular-cli/master.svg?logo=circleci&logoColor=fff&label=CircleCI" alt="CI status" />
+  <a href="https://circleci.com/gh/angular/workflows/angular-cli/tree/main">
+    <img src="https://img.shields.io/circleci/build/github/angular/angular-cli/main.svg?logo=circleci&logoColor=fff&label=CircleCI" alt="CI status" />
   </a>&nbsp;
   <a href="https://discord.gg/angular">
     <img src="https://img.shields.io/discord/463752820026376202.svg?logo=discord&logoColor=fff&label=Discord&color=7389d8" alt="Discord conversation" />
@@ -194,7 +194,7 @@ This is a monorepo which contains many tools and packages:
 [filestructure]: https://angular.io/guide/file-structure
 [node.js]: https://nodejs.org/
 [npm]: https://www.npmjs.com/get-npm
-[codeofconduct]: https://github.com/angular/angular/blob/master/CODE_OF_CONDUCT.md
+[codeofconduct]: https://github.com/angular/angular/blob/main/CODE_OF_CONDUCT.md
 [twitter]: https://www.twitter.com/angular
 [discord]: https://discord.gg/angular
 [gitter]: https://gitter.im/angular/angular-cli

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -78,7 +78,7 @@ There are two different test suites which can be run locally:
 - Run a subset of the tests, use the full Bazel target example: `yarn bazel test //packages/schematics/angular:angular_test`
 - For a complete list of test targets use the following Bazel query: `yarn bazel query "tests(//packages/...)"`
 
-You can find more info about debugging [tests with Bazel in the docs.](https://github.com/angular/angular-cli/blob/master/docs/process/bazel.md#debugging-jasmine_node_test)
+You can find more info about debugging [tests with Bazel in the docs.](https://github.com/angular/angular-cli/blob/main/docs/process/bazel.md#debugging-jasmine_node_test)
 
 ### End to end tests
 

--- a/docs/design/build-system.md
+++ b/docs/design/build-system.md
@@ -24,7 +24,7 @@ It's not strictly accurate because some options remove certain processing stages
 This diagram doesn't show these conditionals and only shows the possible processing steps.
 Relative paths, such as `./raw-css-loader.ts`, refer to internal plugins, while other names usually refer to public npm packages.
 
-![Overview diagram](https://g.gravizo.com/source/svg?https://raw.githubusercontent.com/angular/angular-cli/master/docs/design/build-system-overview.dot)
+![Overview diagram](https://g.gravizo.com/source/svg?https://raw.githubusercontent.com/angular/angular-cli/main/docs/design/build-system-overview.dot)
 
 ## Loading and processing sources
 
@@ -128,7 +128,7 @@ We also use Terser's mangling, by which names, but not properties, are renamed t
 The main characteristics of Terser to keep in mind is that it operates via static analysis and does not support the indirection introduced by module loading.
 Thus the rest of the pipeline is directed towards providing Terser with code that can be removed via static analysis in large single modules scopes.
 
-To this end we developed [@angular-devkit/build-optimizer](https://github.com/angular/angular-cli/tree/master/packages/angular_devkit/build_optimizer), a post-processing tool for TS code.
+To this end we developed [@angular-devkit/build-optimizer](https://github.com/angular/angular-cli/tree/main/packages/angular_devkit/build_optimizer), a post-processing tool for TS code.
 Build Optimizer searches for code patterns produced by the TypeScript and Angular compiler that are known to inhibit dead code elimination, and converts them into equivalent structures that enable it instead (the link above contains some examples).
 It also adds Terser [annotations](https://github.com/terser/terser#annotations) marking top-level functions as free from side effects for libraries that have the `sideEffects` flag set to false in `package.json`.
 

--- a/docs/process/release.md
+++ b/docs/process/release.md
@@ -14,7 +14,7 @@ The caretaker should triage issues, merge PR, and sheppard the release.
 Caretaker calendar can be found [here](https://calendar.google.com/calendar/embed?src=angular.io_jf53juok1lhpm84hv6bo6fmgbc%40group.calendar.google.com&ctz=America%2FLos_Angeles).
 
 Each shift consists of two caretakers. The primary caretaker is responsible for
-merging PRs to master and patch whereas the secondary caretaker is responsible
+merging PRs to `main` and patch whereas the secondary caretaker is responsible
 for the release. Primary-secondary pairs are as follows:
 
 | Primary | Secondary |

--- a/packages/angular_devkit/build_angular/test/hello-world-app/README.md
+++ b/packages/angular_devkit/build_angular/test/hello-world-app/README.md
@@ -24,4 +24,4 @@ Run `ng e2e` to execute the end-to-end tests via [Protractor](http://www.protrac
 
 ## Further help
 
-To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI README](https://github.com/angular/angular-cli/blob/master/README.md).
+To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI README](https://github.com/angular/angular-cli/blob/main/README.md).

--- a/packages/angular_devkit/schematics/README.md
+++ b/packages/angular_devkit/schematics/README.md
@@ -23,7 +23,7 @@ What distinguishes Schematics from other generators, such as Yeoman or Yarn Crea
 
 # Tooling
 
-Schematics is a library, and does not work by itself. A [reference CLI](https://github.com/angular/angular-cli/blob/master/packages/angular_devkit/schematics_cli/bin/schematics.ts) is available on this repository, and is published on NPM at [@angular-devkit/schematics-cli](https://www.npmjs.com/package/@angular-devkit/schematics-cli). This document explains the library usage and the tooling API, but does not go into the tool implementation itself.
+Schematics is a library, and does not work by itself. A [reference CLI](https://github.com/angular/angular-cli/blob/main/packages/angular_devkit/schematics_cli/bin/schematics.ts) is available on this repository, and is published on NPM at [@angular-devkit/schematics-cli](https://www.npmjs.com/package/@angular-devkit/schematics-cli). This document explains the library usage and the tooling API, but does not go into the tool implementation itself.
 
 The tooling is responsible for the following tasks:
 

--- a/packages/ngtools/webpack/package.json
+++ b/packages/ngtools/webpack/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/angular/angular-cli/issues"
   },
-  "homepage": "https://github.com/angular/angular-cli/tree/master/packages/@ngtools/webpack",
+  "homepage": "https://github.com/angular/angular-cli/tree/main/packages/ngtools/webpack",
   "dependencies": {},
   "peerDependencies": {
     "@angular/compiler-cli": "^13.0.0",

--- a/scripts/templates/contributing.ejs
+++ b/scripts/templates/contributing.ejs
@@ -84,7 +84,7 @@ Before you submit your Pull Request (PR) consider the following guidelines:
 * Make your changes in a new git branch:
 
      ```shell
-     git checkout -b my-fix-branch master
+     git checkout -b my-fix-branch main
      ```
 
 * Create your patch, **including appropriate test cases**.
@@ -106,19 +106,19 @@ Before you submit your Pull Request (PR) consider the following guidelines:
     git push origin my-fix-branch
     ```
 
-* In GitHub, send a pull request to `angular/angular-cli:master`.
+* In GitHub, send a pull request to `angular/angular-cli:main`.
 * If we suggest changes then:
   * Make the required updates.
   * Re-run the Angular DevKit test suites to ensure tests are still passing.
 * Once your PR is approved and you are done with any follow up changes:
-  * Rebase to the current master to pre-emptively address any merge conflicts.
+  * Rebase to the current main to pre-emptively address any merge conflicts.
 
     ```shell
-    git rebase master -i
+    git rebase upstream/main -i
     git push -f
     ```
   * Add the `action: merge` label and the correct
-[target label](https://github.com/angular/angular/blob/master/docs/TRIAGE_AND_LABELS.md#pr-target)
+[target label](https://github.com/angular/angular/blob/main/docs/TRIAGE_AND_LABELS.md#pr-target)
     (if PR author has the project collaborator status, or else the last reviewer
     should do this).
   * The current caretaker will merge the PR to the target branch(es) within 1-2
@@ -137,10 +137,10 @@ from the main (upstream) repository:
     git push origin --delete my-fix-branch
     ```
 
-* Check out the master branch:
+* Check out the main branch:
 
     ```shell
-    git checkout master -f
+    git checkout main -f
     ```
 
 * Delete the local branch:
@@ -149,10 +149,10 @@ from the main (upstream) repository:
     git branch -D my-fix-branch
     ```
 
-* Update your master with the latest upstream version:
+* Update your local `main` with the latest upstream version:
 
     ```shell
-    git pull --ff upstream master
+    git pull --ff upstream main
     ```
 
 ## <a name="rules"></a> Coding Rules
@@ -196,11 +196,11 @@ Must be one of the following:
 const { COMMIT_TYPES, ScopeRequirement } = require('../../.ng-dev/commit-message');
 for (const typeName of Object.keys(COMMIT_TYPES).sort()) {
   const type = COMMIT_TYPES[typeName];
-%>* **<%= typeName %>**: <%= type.description %> <%
+%>* **<%= typeName %>**: <%= type.description %><%
   if (type.scope == ScopeRequirement.Required) {
-    %>[1]<%
+    %> [1]<%
   } else if (type.scope == ScopeRequirement.Forbidden) {
-    %>[2]<%
+    %> [2]<%
   }
 %>
 <% } %>
@@ -286,7 +286,7 @@ changes to be accepted, the CLA must be signed. It's a quick process, we promise
 [coc]: https://github.com/angular/code-of-conduct/blob/master/CODE_OF_CONDUCT.md
 [commit-message-format]: https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit#
 [corporate-cla]: http://code.google.com/legal/corporate-cla-v1.0.html
-[dev-doc]: https://github.com/angular/angular-cli/blob/master/packages/angular/cli/README.md#development-hints-for-working-on-angular-cli
+[dev-doc]: https://github.com/angular/angular-cli/blob/main/packages/angular/cli/README.md#development-hints-for-working-on-angular-cli
 [GitHub]: https://github.com/angular/angular-cli
 [gitter]: https://gitter.im/angular/angular-cli
 [individual-cla]: http://code.google.com/legal/individual-cla-v1.0.html

--- a/scripts/templates/readme.ejs
+++ b/scripts/templates/readme.ejs
@@ -16,7 +16,7 @@
   <br>
   <img src="/docs/images/angular-cli-logo.png" alt="Angular CLI logo" width="100px" height="108px"/>
   <br><br>
-  <i>The Angular CLI is a command-line interface tool that you use to initialize, develop, scaffold, 
+  <i>The Angular CLI is a command-line interface tool that you use to initialize, develop, scaffold,
     <br>and maintain Angular applications directly from a command shell.</i>
   <br>
 </p>
@@ -37,8 +37,8 @@
 </p>
 
 <p align="center">
-  <a href="https://circleci.com/gh/angular/workflows/angular-cli/tree/master">
-    <img src="https://img.shields.io/circleci/build/github/angular/angular-cli/master.svg?logo=circleci&logoColor=fff&label=CircleCI" alt="CI status" />
+  <a href="https://circleci.com/gh/angular/workflows/angular-cli/tree/main">
+    <img src="https://img.shields.io/circleci/build/github/angular/angular-cli/main.svg?logo=circleci&logoColor=fff&label=CircleCI" alt="CI status" />
   </a>&nbsp;
   <a href="https://discord.gg/angular">
     <img src="https://img.shields.io/discord/463752820026376202.svg?logo=discord&logoColor=fff&label=Discord&color=7389d8" alt="Discord conversation" />
@@ -222,7 +222,7 @@ for (const pkgName of Object.keys(packages)) {
 [filestructure]: https://angular.io/guide/file-structure
 [node.js]: https://nodejs.org/
 [npm]: https://www.npmjs.com/get-npm
-[codeofconduct]: https://github.com/angular/angular/blob/master/CODE_OF_CONDUCT.md
+[codeofconduct]: https://github.com/angular/angular/blob/main/CODE_OF_CONDUCT.md
 [twitter]: https://www.twitter.com/angular
 [discord]: https://discord.gg/angular
 [gitter]: https://gitter.im/angular/angular-cli

--- a/tests/angular_devkit/core/json/schema/serializers/schema_benchmark.json
+++ b/tests/angular_devkit/core/json/schema/serializers/schema_benchmark.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://github.com/angular/angular-cli/blob/master/packages/@angular/cli/lib/config/schema.json#CliConfig",
+  "$id": "https://github.com/angular/angular-cli/blob/main/packages/@angular/cli/lib/config/schema.json#CliConfig",
   "title": "Angular CLI Config Schema",
   "type": "object",
   "properties": {

--- a/tests/legacy-cli/e2e_runner.ts
+++ b/tests/legacy-cli/e2e_runner.ts
@@ -23,7 +23,7 @@ Error.stackTraceLimit = Infinity;
  *   --noglobal       Skip linking your local @angular/cli directory. Can save a few seconds.
  *   --nosilent       Never silence ng commands.
  *   --ng-tag=TAG     Use a specific tag for build snapshots. Similar to ng-snapshots but point to a
- *                    tag instead of using the latest master.
+ *                    tag instead of using the latest `main`.
  *   --ng-snapshots   Install angular snapshot builds in the test project.
  *   --ve             Use the View Engine compiler.
  *   --glob           Run tests matching this glob pattern (relative to tests/e2e/).


### PR DESCRIPTION
Patch port of changes for the `master` rename that conflicted with the 13.3.x branch