### PR TITLE
fix(@schematics/angular): add migration to remove `package.json` in libraries secondary entry-points

### DIFF
--- a/packages/schematics/angular/migrations/migration-collection.json
+++ b/packages/schematics/angular/migrations/migration-collection.json
@@ -24,6 +24,11 @@
       "version": "14.0.0",
       "factory": "./update-14/replace-default-collection-option",
       "description": "Replace 'defaultCollection' option in workspace configuration with 'schematicCollections'."
+    },
+    "update-libraries-secondary-entrypoints": {
+      "version": "14.0.0",
+      "factory": "./update-14/update-libraries-secondary-entrypoints",
+      "description": "Remove 'package.json' files from library projects secondary entrypoints."
     }
   }
 }

--- a/packages/schematics/angular/migrations/update-14/update-libraries-secondary-entrypoints.ts
+++ b/packages/schematics/angular/migrations/update-14/update-libraries-secondary-entrypoints.ts
@@ -1,0 +1,65 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { dirname, isJsonObject, join, normalize } from '@angular-devkit/core';
+import { DirEntry, Rule } from '@angular-devkit/schematics';
+import { getWorkspace } from '../../utility/workspace';
+
+function* visitPackageJsonFiles(
+  directory: DirEntry,
+  includedInLookup = false,
+): IterableIterator<string> {
+  if (includedInLookup) {
+    for (const path of directory.subfiles) {
+      if (path !== 'package.json') {
+        continue;
+      }
+
+      yield join(directory.path, path);
+    }
+  }
+
+  for (const path of directory.subdirs) {
+    if (path === 'node_modules' || path.startsWith('.')) {
+      continue;
+    }
+
+    yield* visitPackageJsonFiles(directory.dir(path), true);
+  }
+}
+
+/** Migration to remove secondary entrypoints 'package.json' files and migrate ng-packagr configurations. */
+export default function (): Rule {
+  return async (tree) => {
+    const workspace = await getWorkspace(tree);
+
+    for (const project of workspace.projects.values()) {
+      if (
+        project.extensions['projectType'] !== 'library' ||
+        ![...project.targets.values()].some(
+          ({ builder }) => builder === '@angular-devkit/build-angular:ng-packagr',
+        )
+      ) {
+        // Project is not a library or doesn't use ng-packagr, skip.
+        continue;
+      }
+
+      for (const path of visitPackageJsonFiles(tree.getDir(project.root))) {
+        const json = tree.readJson(path);
+        if (isJsonObject(json) && json['ngPackage']) {
+          // Migrate ng-packagr config to an ng-packagr config file.
+          const configFilePath = join(dirname(normalize(path)), 'ng-package.json');
+          tree.create(configFilePath, JSON.stringify(json['ngPackage'], undefined, 2));
+        }
+
+        // Delete package.json as it is no longer needed in APF 14.
+        tree.delete(path);
+      }
+    }
+  };
+}

--- a/packages/schematics/angular/migrations/update-14/update-libraries-secondary-entrypoints_spec.ts
+++ b/packages/schematics/angular/migrations/update-14/update-libraries-secondary-entrypoints_spec.ts
@@ -1,0 +1,122 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { EmptyTree } from '@angular-devkit/schematics';
+import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';
+import { Builders, ProjectType, WorkspaceSchema } from '../../utility/workspace-models';
+
+function createFileStructure(tree: UnitTestTree) {
+  const angularConfig: WorkspaceSchema = {
+    version: 1,
+    projects: {
+      foo: {
+        root: 'projects/foo',
+        sourceRoot: 'projects/foo/src',
+        projectType: ProjectType.Library,
+        prefix: 'lib',
+        architect: {
+          build: {
+            builder: Builders.NgPackagr,
+            options: {
+              project: '',
+              tsConfig: '',
+            },
+          },
+        },
+      },
+      bar: {
+        root: 'projects/bar',
+        sourceRoot: 'projects/bar/src',
+        projectType: ProjectType.Library,
+        prefix: 'lib',
+        architect: {
+          test: {
+            builder: Builders.Karma,
+            options: {
+              karmaConfig: '',
+              tsConfig: '',
+            },
+          },
+        },
+      },
+    },
+  };
+
+  tree.create('/angular.json', JSON.stringify(angularConfig, undefined, 2));
+
+  // Library foo
+  tree.create('/projects/foo/package.json', JSON.stringify({ version: '0.0.0' }, undefined, 2));
+  // Library foo/secondary
+  tree.create(
+    '/projects/foo/secondary/package.json',
+    JSON.stringify(
+      { version: '0.0.0', ngPackage: { lib: { entryFile: 'src/public-api.ts' } } },
+      undefined,
+      2,
+    ),
+  );
+
+  // Library bar
+  tree.create('/projects/bar/package.json', JSON.stringify({ version: '0.0.0' }, undefined, 2));
+  // Library bar/secondary
+  tree.create(
+    '/projects/bar/secondary/package.json',
+    JSON.stringify({ version: '0.0.0' }, undefined, 2),
+  );
+}
+
+describe(`Migration to update Angular libraries secondary entrypoints.`, () => {
+  const schematicName = 'update-libraries-secondary-entrypoints';
+  const schematicRunner = new SchematicTestRunner(
+    'migrations',
+    require.resolve('../migration-collection.json'),
+  );
+
+  let tree: UnitTestTree;
+  beforeEach(() => {
+    tree = new UnitTestTree(new EmptyTree());
+    createFileStructure(tree);
+  });
+
+  describe(`when library has '@angular-devkit/build-angular:ng-packagr' as a builder`, () => {
+    it(`should not delete 'package.json' of primary entry-point`, async () => {
+      const newTree = await schematicRunner.runSchematicAsync(schematicName, {}, tree).toPromise();
+
+      expect(newTree.exists('/projects/foo/package.json')).toBeTrue();
+    });
+
+    it(`should delete 'package.json' of secondary entry-point`, async () => {
+      const newTree = await schematicRunner.runSchematicAsync(schematicName, {}, tree).toPromise();
+      expect(newTree.exists('/projects/foo/secondary/package.json')).toBeFalse();
+    });
+
+    it(`should move ng-packagr configuration from 'package.json' to 'ng-package.json'`, async () => {
+      const newTree = await schematicRunner.runSchematicAsync(schematicName, {}, tree).toPromise();
+      expect(newTree.readJson('projects/foo/secondary/ng-package.json')).toEqual({
+        lib: { entryFile: 'src/public-api.ts' },
+      });
+    });
+  });
+
+  describe(`when library doesn't have '@angular-devkit/build-angular:ng-packagr' as a builder`, () => {
+    it(`should not delete 'package.json' of primary entry-point`, async () => {
+      const newTree = await schematicRunner.runSchematicAsync(schematicName, {}, tree).toPromise();
+      expect(newTree.exists('/projects/bar/package.json')).toBeTrue();
+    });
+
+    it(`should not delete 'package.json' of secondary entry-point`, async () => {
+      const newTree = await schematicRunner.runSchematicAsync(schematicName, {}, tree).toPromise();
+      expect(newTree.exists('/projects/bar/package.json')).toBeTrue();
+    });
+
+    it(`should not create ng-packagr configuration`, async () => {
+      const newTree = await schematicRunner.runSchematicAsync(schematicName, {}, tree).toPromise();
+      expect(newTree.exists('projects/bar/secondary/ng-package.json')).toBeFalse();
+    });
+  });
+});


### PR DESCRIPTION
`package.json` files have been remove from secondary entrypoints in version 14 of Angular package format (APF).

With this change we delete the now redundant files and in case these contained the deprecated way of how to configure secondary entrypoints in ng-packagr we migrate these as well.

//cc @devversion