### PR TITLE
fix(@schematics/angular): remove extra space in standalone imports

### DIFF
--- a/packages/schematics/angular/component/files/__name@dasherize@if-flat__/__name@dasherize__.__type@dasherize__.ts.template
+++ b/packages/schematics/angular/component/files/__name@dasherize@if-flat__/__name@dasherize__.__type@dasherize__.ts.template
@@ -4,7 +4,7 @@ import { CommonModule } from '@angular/common';<% } %>
 @Component({<% if(!skipSelector) {%>
   selector: '<%= selector %>',<%}%><% if(standalone) {%>
   standalone: true,
-  imports: [CommonModule], <%}%><% if(inlineTemplate) { %>
+  imports: [CommonModule],<%}%><% if(inlineTemplate) { %>
   template: `
     <p>
       <%= dasherize(name) %> works!


### PR DESCRIPTION
There is an extra space after the new `imports` decorator option in standalone components, whereas there are none after all the other existing options.