### PR TITLE
ci: disable redundant Angular bot size check

### DIFF
--- a/.github/angular-robot.yml
+++ b/.github/angular-robot.yml
@@ -93,6 +93,8 @@ triage:
 
 # Size checking
 size:
+  # Size checking for production build is performed via the E2E test `build/prod-build`
+  disabled: true
   circleCiStatusName: 'ci/circleci: e2e-cli'
   maxSizeIncrease: 10000
   comment: false

--- a/tests/legacy-cli/e2e/tests/build/prod-build.ts
+++ b/tests/legacy-cli/e2e/tests/build/prod-build.ts
@@ -24,8 +24,6 @@ function verifySize(bundle: string, baselineBytes: number) {
 }
 
 export default async function () {
-  // TODO(architect): Delete this test. It is now in devkit/build-angular.
-
   // Can't use the `ng` helper because somewhere the environment gets
   // stuck to the first build done
   const bootstrapRegExp = /bootstrapModule\([_a-zA-Z]+[0-9]*\)\./;


### PR DESCRIPTION
The E2E test suite contains a production build test (`build/prod-build`) that performs
a size comparison check to ensure a production build of a newly generated application
stays within 10% of a predefined value (currently 124,000 bytes).
As a result of this preexisting check, the need to perform another check that involves
the added complexity of Github status hooks and API calls is currently not needed.