### PR TITLE
test: allow Artistic-2.0 license

### DIFF
--- a/scripts/validate-licenses.ts
+++ b/scripts/validate-licenses.ts
@@ -32,6 +32,7 @@ const allowedLicenses = [
   'ISC',
   'Apache-2.0',
   'Python-2.0',
+  'Artistic-2.0',
 
   'BSD-2-Clause',
   'BSD-3-Clause',


### PR DESCRIPTION
This is what node, npm use. I'm hitting this when switching the e2e tests to bazel (https://github.com/angular/angular-cli/pull/23074).