### PR TITLE
fix(@schematics/angular): don't add path mapping to old entrypoint file

### DIFF
--- a/packages/schematics/angular/library/index.ts
+++ b/packages/schematics/angular/library/index.ts
@@ -139,7 +139,6 @@ export default function (options: LibraryOptions): Rule {
 
     const projectRoot = join(normalize(newProjectRoot), folderName);
     const distRoot = `dist/${folderName}`;
-    const pathImportLib = `${distRoot}/${folderName.replace('/', '-')}`;
     const sourceDir = `${projectRoot}/src/lib`;
 
     const templateSource = apply(url('./files'), [
@@ -162,7 +161,7 @@ export default function (options: LibraryOptions): Rule {
       mergeWith(templateSource),
       addLibToWorkspaceFile(options, projectRoot, packageName),
       options.skipPackageJson ? noop() : addDependenciesToPackageJson(),
-      options.skipTsConfig ? noop() : updateTsConfig(packageName, pathImportLib, distRoot),
+      options.skipTsConfig ? noop() : updateTsConfig(packageName, distRoot),
       schematic('module', {
         name: options.name,
         commonModule: false,

--- a/packages/schematics/angular/library/index_spec.ts
+++ b/packages/schematics/angular/library/index_spec.ts
@@ -236,10 +236,7 @@ describe('Library Schematic', () => {
         .toPromise();
 
       const tsConfigJson = getJsonFileContent(tree, 'tsconfig.json');
-      expect(tsConfigJson.compilerOptions.paths.foo).toBeTruthy();
-      expect(tsConfigJson.compilerOptions.paths.foo.length).toEqual(2);
-      expect(tsConfigJson.compilerOptions.paths.foo[0]).toEqual('dist/foo/foo');
-      expect(tsConfigJson.compilerOptions.paths.foo[1]).toEqual('dist/foo');
+      expect(tsConfigJson.compilerOptions.paths['foo']).toEqual(['dist/foo']);
     });
 
     it(`should append to existing paths mappings`, async () => {
@@ -259,10 +256,7 @@ describe('Library Schematic', () => {
         .toPromise();
 
       const tsConfigJson = getJsonFileContent(tree, 'tsconfig.json');
-      expect(tsConfigJson.compilerOptions.paths.foo).toBeTruthy();
-      expect(tsConfigJson.compilerOptions.paths.foo.length).toEqual(3);
-      expect(tsConfigJson.compilerOptions.paths.foo[1]).toEqual('dist/foo/foo');
-      expect(tsConfigJson.compilerOptions.paths.foo[2]).toEqual('dist/foo');
+      expect(tsConfigJson.compilerOptions.paths['foo']).toEqual(['libs/*', 'dist/foo']);
     });
 
     it(`should not modify the file when --skipTsConfig`, async () => {
@@ -316,10 +310,7 @@ describe('Library Schematic', () => {
     expect(cfg.projects['@myscope/mylib']).toBeDefined();
 
     const rootTsCfg = getJsonFileContent(tree, '/tsconfig.json');
-    expect(rootTsCfg.compilerOptions.paths['@myscope/mylib']).toEqual([
-      'dist/myscope/mylib/myscope-mylib',
-      'dist/myscope/mylib',
-    ]);
+    expect(rootTsCfg.compilerOptions.paths['@myscope/mylib']).toEqual(['dist/myscope/mylib']);
 
     const karmaConf = getFileContent(tree, '/projects/myscope/mylib/karma.conf.js');
     expect(karmaConf).toContain(


### PR DESCRIPTION
With the APF changes in version 14, the dts entrypoint file has been changed to `index.d.ts`, this results in TypeScript being able to resolve the type definition file without the need of the additional path to the flat module file dts.