### PR TITLE
test: use random ports for local verdaccio npm servers

### DIFF
--- a/tests/legacy-cli/verdaccio.yaml
+++ b/tests/legacy-cli/verdaccio.yaml
@@ -3,7 +3,7 @@ storage: ./storage
 auth:
   auth-memory:
     users: {}
-listen: localhost:4873
+listen: localhost:${HTTP_PORT}
 uplinks:
   npmjs:
     url: https://registry.npmjs.org/

--- a/tests/legacy-cli/verdaccio_auth.yaml
+++ b/tests/legacy-cli/verdaccio_auth.yaml
@@ -5,10 +5,10 @@ auth:
       testing:
         name: testing
         password: s3cret
-listen: localhost:4876
+listen: localhost:${HTTPS_PORT}
 uplinks:
   local:
-    url: http://localhost:4873
+    url: http://localhost:${HTTP_PORT}
     cache: false
     maxage: 20m
     max_fails: 32


### PR DESCRIPTION
Best viewed [ignoring whitespace](https://github.com/angular/angular-cli/pull/23114/files?w=1).

When working on the bazel e2e tests (#23074) we might run tests in parallel such as bazel + non-bazel, npm + yarn etc.

Unfortunately the verdaccio `--listen` only sets the primary port and not the fallback which we need to also set, so we need to do the `.replace` thing :(