### PR TITLE
test: remove use of global npm cache and config 

### DIFF
--- a/tests/legacy-cli/e2e/setup/001-create-tmp-dir.ts
+++ b/tests/legacy-cli/e2e/setup/001-create-tmp-dir.ts
@@ -17,5 +17,4 @@ export default function () {
   }
   console.log(`  Using "${tempRoot}" as temporary directory for a new project.`);
   setGlobalVariable('tmp-root', tempRoot);
-  process.chdir(tempRoot);
 }

--- a/tests/legacy-cli/e2e/setup/002-npm-sandbox.ts
+++ b/tests/legacy-cli/e2e/setup/002-npm-sandbox.ts
@@ -1,0 +1,31 @@
+import { mkdir, writeFile } from 'fs/promises';
+import { delimiter, join } from 'path';
+import { getGlobalVariable } from '../utils/env';
+
+/**
+ * Configure npm to use a unique sandboxed environment.
+ */
+export default async function () {
+  const tempRoot: string = getGlobalVariable('tmp-root');
+  const npmModulesPrefix = join(tempRoot, 'npm-global');
+  const npmrc = join(tempRoot, '.npmrc');
+
+  // Configure npm to use the sandboxed npm globals and rc file
+  process.env.NPM_CONFIG_USERCONFIG = npmrc;
+  process.env.NPM_CONFIG_PREFIX = npmModulesPrefix;
+
+  // Ensure the custom npm global bin is first on the PATH
+  // https://docs.npmjs.com/cli/v8/configuring-npm/folders#executables
+  if (process.platform.startsWith('win')) {
+    process.env.PATH = npmModulesPrefix + delimiter + process.env.PATH;
+  } else {
+    process.env.PATH = join(npmModulesPrefix, 'bin') + delimiter + process.env.PATH;
+  }
+
+  // Ensure the globals directory and npmrc file exist.
+  // Configure the registry in the npmrc in addition to the environment variable.
+  await writeFile(npmrc, 'registry=' + getGlobalVariable('package-registry'));
+  await mkdir(npmModulesPrefix);
+
+  console.log(`  Using "${npmModulesPrefix}" as e2e test global npm cache.`);
+}

--- a/tests/legacy-cli/e2e/setup/010-local-publish.ts
+++ b/tests/legacy-cli/e2e/setup/010-local-publish.ts
@@ -1,5 +1,5 @@
 import { getGlobalVariable } from '../utils/env';
-import { execWithEnv } from '../utils/process';
+import { execWithEnv, extractNpmEnv } from '../utils/process';
 import { isPrereleaseCli } from '../utils/project';
 
 export default async function () {
@@ -18,7 +18,7 @@ export default async function () {
       isPrereleaseCli() ? 'next' : 'latest',
     ],
     {
-      ...process.env,
+      ...extractNpmEnv(),
       // Also set an auth token value for the local test registry which is required by npm 7+
       // even though it is never actually used.
       'NPM_CONFIG__AUTH': 'e2e-testing',

--- a/tests/legacy-cli/e2e/setup/200-create-project-dir.ts
+++ b/tests/legacy-cli/e2e/setup/200-create-project-dir.ts
@@ -1,0 +1,19 @@
+import { mkdir } from 'fs/promises';
+import { join } from 'path';
+import { getGlobalVariable, setGlobalVariable } from '../utils/env';
+
+/**
+ * Create a parent directory for test projects to be created within.
+ * Change the cwd() to that directory in preparation for launching the cli.
+ */
+export default async function () {
+  const tempRoot: string = getGlobalVariable('tmp-root');
+  const projectsRoot = join(tempRoot, 'e2e-test');
+
+  setGlobalVariable('projects-root', projectsRoot);
+
+  await mkdir(projectsRoot);
+
+  console.log(`  Using "${projectsRoot}" as temporary directory for a new project.`);
+  process.chdir(projectsRoot);
+}

--- a/tests/legacy-cli/e2e/setup/500-create-project.ts
+++ b/tests/legacy-cli/e2e/setup/500-create-project.ts
@@ -1,9 +1,9 @@
 import { join } from 'path';
 import { getGlobalVariable } from '../utils/env';
-import { expectFileToExist, writeFile } from '../utils/fs';
+import { expectFileToExist } from '../utils/fs';
 import { gitClean } from '../utils/git';
 import { setRegistry as setNPMConfigRegistry } from '../utils/packages';
-import { ng, npm } from '../utils/process';
+import { ng } from '../utils/process';
 import { prepareProjectForE2e, updateJsonFile } from '../utils/project';
 
 export default async function () {
@@ -18,8 +18,6 @@ export default async function () {
     await gitClean();
   } else {
     const extraArgs = [];
-    const testRegistry = getGlobalVariable('package-registry');
-    const isCI = getGlobalVariable('ci');
 
     // Ensure local test registry is used when outside a project
     await setNPMConfigRegistry(true);
@@ -27,12 +25,6 @@ export default async function () {
     await ng('new', 'test-project', '--skip-install', ...extraArgs);
     await expectFileToExist(join(process.cwd(), 'test-project'));
     process.chdir('./test-project');
-
-    // If on CI, the user configuration set above will handle project usage
-    if (!isCI) {
-      // Ensure local test registry is used inside a project
-      await writeFile('.npmrc', `registry=${testRegistry}`);
-    }
 
     // Setup esbuild builder if requested on the commandline
     const useEsbuildBuilder = !!getGlobalVariable('argv')['esbuild'];

--- a/tests/legacy-cli/e2e/tests/misc/invalid-schematic-dependencies.ts
+++ b/tests/legacy-cli/e2e/tests/misc/invalid-schematic-dependencies.ts
@@ -1,5 +1,5 @@
 import { expectFileToMatch } from '../../utils/fs';
-import { execWithEnv, ng, silentNpm } from '../../utils/process';
+import { execWithEnv, extractNpmEnv, ng, silentNpm } from '../../utils/process';
 import { installPackage, uninstallPackage } from '../../utils/packages';
 import { isPrereleaseCli } from '../../utils/project';
 
@@ -29,7 +29,7 @@ async function publishOutdated(npmSpecifier: string): Promise<void> {
     '--registry=https://registry.npmjs.org',
   );
   await execWithEnv('npm', ['publish', stdoutPack.trim(), '--tag=outdated'], {
-    ...process.env,
+    ...extractNpmEnv(),
     // Also set an auth token value for the local test registry which is required by npm 7+
     // even though it is never actually used.
     'NPM_CONFIG__AUTH': 'e2e-testing',

--- a/tests/legacy-cli/e2e/tests/misc/update-git-clean-subdirectory.ts
+++ b/tests/legacy-cli/e2e/tests/misc/update-git-clean-subdirectory.ts
@@ -4,7 +4,7 @@ import { ng, silentGit } from '../../utils/process';
 import { prepareProjectForE2e } from '../../utils/project';
 
 export default async function () {
-  process.chdir(getGlobalVariable('tmp-root'));
+  process.chdir(getGlobalVariable('projects-root'));
 
   await createDir('./subdirectory');
   process.chdir('./subdirectory');

--- a/tests/legacy-cli/e2e/utils/assets.ts
+++ b/tests/legacy-cli/e2e/utils/assets.ts
@@ -11,7 +11,7 @@ export function assetDir(assetName: string) {
 }
 
 export function copyProjectAsset(assetName: string, to?: string) {
-  const tempRoot = join(getGlobalVariable('tmp-root'), 'test-project');
+  const tempRoot = join(getGlobalVariable('projects-root'), 'test-project');
   const sourcePath = assetDir(assetName);
   const targetPath = join(tempRoot, to || assetName);
 
@@ -20,7 +20,7 @@ export function copyProjectAsset(assetName: string, to?: string) {
 
 export function copyAssets(assetName: string, to?: string) {
   const seed = +Date.now();
-  const tempRoot = join(getGlobalVariable('tmp-root'), 'assets', assetName + '-' + seed);
+  const tempRoot = join(getGlobalVariable('projects-root'), 'assets', assetName + '-' + seed);
   const root = assetDir(assetName);
 
   return Promise.resolve()
@@ -30,7 +30,7 @@ export function copyAssets(assetName: string, to?: string) {
       return allFiles.reduce((promise, filePath) => {
         const toPath =
           to !== undefined
-            ? resolve(getGlobalVariable('tmp-root'), 'test-project', to, filePath)
+            ? resolve(getGlobalVariable('projects-root'), 'test-project', to, filePath)
             : join(tempRoot, filePath);
 
         return promise.then(() => copyFile(join(root, filePath), toPath));


### PR DESCRIPTION
Removing the use of globally installed npm and npm packages. Instead npm+yarn within the test-runner use npm+yarn from package.json (not globals). Tests no longer depend on any `--global` and use npm+ng installed locally within the temporary test directories.

This might be the last step before being able to run multiple tests concurrently (https://github.com/angular/angular-cli/pull/23114 was the other big one).

This might be the last one before getting the e2e tests working in bazel (https://github.com/angular/angular-cli/pull/23074)

EDIT: this has changed to keep globals but use a isolated global cache per invocation, see comment below


Original attempt removing use of `--global`: https://github.com/angular/angular-cli/commit/02f703999694056b5b4253a6b7da63f3c5926dc3