### PR TITLE
ci: remove redundant PR required statuses check from bot configuration

### DIFF
--- a/.github/angular-robot.yml
+++ b/.github/angular-robot.yml
@@ -39,16 +39,8 @@ merge:
       - 'PR state: blocked'
 
     # list of PR statuses that need to be successful
-    requiredStatuses:
-      - 'ci/circleci: build'
-      - 'ci/circleci: setup'
-      - 'ci/circleci: lint'
-      - 'ci/circleci: validate'
-      - 'ci/circleci: test'
-      - 'ci/circleci: e2e-cli-win'
-      - 'ci/circleci: e2e-cli'
-      - 'ci/circleci: test-browsers'
-      - 'ci/angular: size'
+    # NOTE: Required PR statuses are now exclusively handled via Github configuration
+    requiredStatuses: []
 
   # the comment that will be added when the merge label is added despite failing checks, leave empty or set to false to disable
   # {{MERGE_LABEL}} will be replaced by the value of the mergeLabel option


### PR DESCRIPTION
Required PR statuses are now exclusively handled via Github configuration.