### PR TITLE
test: update standalone test to add Protractor testing support

### DIFF
--- a/tests/legacy-cli/e2e/tests/basic/standalone.ts
+++ b/tests/legacy-cli/e2e/tests/basic/standalone.ts
@@ -22,7 +22,7 @@ import { ng } from '../../utils/process';
 const STANDALONE_MAIN_CONTENT = `
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { bootstrapApplication } from '@angular/platform-browser';
+import { bootstrapApplication, provideProtractorTestingSupport } from '@angular/platform-browser';
 
 @Component({
   selector: 'app-root',
@@ -41,7 +41,9 @@ export class AppComponent {
   isVisible = true;
 }
 
-bootstrapApplication(AppComponent);
+bootstrapApplication(AppComponent, {
+  providers: [ provideProtractorTestingSupport() ],
+});
 `;
 
 export default async function () {


### PR DESCRIPTION
After https://github.com/angular/angular/pull/45885, testability now needs to be explicitly added to `bootstrapApplication()`.

(cherry picked from commit 329a2a3798c1d5e60a7c6b165e9da2b9040c223b)