### PR TITLE
feat(@angular-devkit/schematics): allow `chain` rule to accept iterables of rules

### DIFF
--- a/goldens/public-api/angular_devkit/schematics/index.md
+++ b/goldens/public-api/angular_devkit/schematics/index.md
@@ -145,7 +145,7 @@ export function callRule(rule: Rule, input: Tree_2 | Observable<Tree_2>, context
 export function callSource(source: Source, context: SchematicContext): Observable<Tree_2>;
 
 // @public
-export function chain(rules: Rule[]): Rule;
+export function chain(rules: Iterable<Rule> | AsyncIterable<Rule>): Rule;
 
 // @public (undocumented)
 export class CircularCollectionException extends BaseException {

--- a/packages/angular_devkit/schematics/src/rules/base.ts
+++ b/packages/angular_devkit/schematics/src/rules/base.ts
@@ -33,9 +33,14 @@ export function empty(): Source {
 /**
  * Chain multiple rules into a single rule.
  */
-export function chain(rules: Rule[]): Rule {
-  return (tree, context) => {
-    return rules.reduce<Tree | Observable<Tree>>((acc, curr) => callRule(curr, acc, context), tree);
+export function chain(rules: Iterable<Rule> | AsyncIterable<Rule>): Rule {
+  return async (initialTree, context) => {
+    let intermediateTree: Observable<Tree> | undefined;
+    for await (const rule of rules) {
+      intermediateTree = callRule(rule, intermediateTree ?? initialTree, context);
+    }
+
+    return () => intermediateTree;
   };
 }
 


### PR DESCRIPTION
Previously, the `chain` base rule only accepted an `Array` of schematics rules.
In addition to still allowing an `Array`, `chain` now can accept either an `Iterable<Rule>`
or `AsyncIterable<Rule>`. This provides support for sync and async generator functions
with the `chain` rule.