### PR TITLE
fix(@angular/cli): skip prompt or warn when setting up autocompletion without a global CLI install

### DIFF
--- a/packages/angular/cli/src/commands/completion/cli.ts
+++ b/packages/angular/cli/src/commands/completion/cli.ts
@@ -8,14 +8,10 @@
 
 import { join } from 'path';
 import yargs, { Argv } from 'yargs';
-import {
-  CommandModule,
-  CommandModuleImplementation,
-  CommandScope,
-} from '../../command-builder/command-module';
+import { CommandModule, CommandModuleImplementation } from '../../command-builder/command-module';
 import { addCommandModuleToYargs } from '../../command-builder/utilities/command';
 import { colors } from '../../utilities/color';
-import { initializeAutocomplete } from '../../utilities/completion';
+import { hasGlobalCliInstall, initializeAutocomplete } from '../../utilities/completion';
 
 export class CompletionCommandModule extends CommandModule implements CommandModuleImplementation {
   command = 'completion';
@@ -43,6 +39,16 @@ Appended \`source <(ng completion script)\` to \`${rcFile}\`. Restart your termi
     ${colors.yellow('source <(ng completion script)')}
       `.trim(),
     );
+
+    if ((await hasGlobalCliInstall()) === false) {
+      this.context.logger.warn(
+        'Setup completed successfully, but there does not seem to be a global install of the' +
+          ' Angular CLI. For autocompletion to work, the CLI will need to be on your `$PATH`, which' +
+          ' is typically done with the `-g` flag in `npm install -g @angular/cli`.' +
+          '\n\n' +
+          'For more information, see https://angular.io/cli/completion#global-install',
+      );
+    }
 
     return 0;
   }


### PR DESCRIPTION
If the user does not have a global install of the Angular CLI, the autocompletion prompt is skipped and `ng completion` emits a warning. The reasoning for this is that `source <(ng completion script)` won't work without `ng` on the `$PATH`, which is only really viable with a global install. Local executions like `git clone ... && npm install && npm start` or ephemeral executions like `npx @angular/cli` don't benefit from autocompletion and unnecessarily impede users.

A global install of the Angular CLI is detected by running `which -a ng`, which appears to be a cross-platform means of listing all `ng` commands on the `$PATH`. We then look over all binaries in the list and exclude anything which is a directo child of a `node_modules/.bin/` directory. These include local executions and `npx`, so the only remaining locations should be global installs (`/usr/bin/ng`, NVM, etc.).

The tests are a little awkward since `ng` is installed globally by helper functions before tests start. These tests uninstall the global CLI and install a local, project-specific version to verify behavior, before restoring the global version. Hypothetically this could be emulated by manipulating the `$PATH` variable, but `which` needs to be available (so we can't clobber the whole `$PATH`) and `node` exists in the same directory as the global `ng` command (so we can't remove that directory anyways). There's also no good way of testing the case where `which` fails to run.

Closes #23135.

/cc @alan-agius4