### PR TITLE
fix(@angular/cli): print schematic errors correctly

### DIFF
--- a/packages/angular/cli/lib/cli/index.ts
+++ b/packages/angular/cli/lib/cli/index.ts
@@ -77,7 +77,9 @@ export default async function (options: { cliArgs: string[] }) {
     } else if (typeof err === 'number') {
       // Log nothing.
     } else {
-      logger.fatal('An unexpected error occurred: ' + JSON.stringify(err));
+      logger.fatal(
+        `An unexpected error occurred: ${'toString' in err ? err.toString() : JSON.stringify(err)}`,
+      );
     }
 
     return 1;

--- a/packages/angular/cli/src/command-builder/schematics-command-module.ts
+++ b/packages/angular/cli/src/command-builder/schematics-command-module.ts
@@ -321,11 +321,11 @@ export abstract class SchematicsCommandModule
       if (err instanceof UnsuccessfulWorkflowExecution) {
         // "See above" because we already printed the error.
         logger.fatal('The Schematic workflow failed. See above.');
-
-        return 1;
       } else {
-        throw err;
+        logger.fatal(err.message);
       }
+
+      return 1;
     } finally {
       unsubscribe();
     }


### PR DESCRIPTION
Previously, the errors were JSON stringified (https://github.com/angular/angular-cli/blob/main/packages/angular/cli/lib/cli/index.ts#L80) which caused them not to be displayed correctly.

Closes #23141