### PR TITLE
fix(@angular/cli): alphabetically order imports during component generation

### DIFF
--- a/packages/schematics/angular/component/files/__name@dasherize@if-flat__/__name@dasherize__.__type@dasherize__.ts.template
+++ b/packages/schematics/angular/component/files/__name@dasherize@if-flat__/__name@dasherize__.__type@dasherize__.ts.template
@@ -1,4 +1,4 @@
-import { Component, OnInit<% if(!!viewEncapsulation) { %>, ViewEncapsulation<% }%><% if(changeDetection !== 'Default') { %>, ChangeDetectionStrategy<% }%> } from '@angular/core';<% if(standalone) {%>
+import { <% if(changeDetection !== 'Default') { %>ChangeDetectionStrategy, <% }%>Component, OnInit<% if(!!viewEncapsulation) { %>, ViewEncapsulation<% }%> } from '@angular/core';<% if(standalone) {%>
 import { CommonModule } from '@angular/common';<% } %>
 
 @Component({<% if(!skipSelector) {%>


### PR DESCRIPTION
change the order of imports during component generation using `changeDetectionStrategy` set to `OnPush`

closes [angular#23156](https://github.com/angular/angular-cli/issues/23156#issue-1239014925)