### PR TITLE
fix(@angular/cli): correctly handle `--search` option in `ng doc`

### DIFF
--- a/packages/angular/cli/src/commands/doc/cli.ts
+++ b/packages/angular/cli/src/commands/doc/cli.ts
@@ -83,8 +83,8 @@ export class DocCommandModule
 
     await open(
       options.search
-        ? `https://${domain}/api?query=${options.keyword}`
-        : `https://${domain}/docs?search=${options.keyword}`,
+        ? `https://${domain}/docs?search=${options.keyword}`
+        : `https://${domain}/api?query=${options.keyword}`,
     );
   }
 }


### PR DESCRIPTION
When the `--search` option is passed to `ng doc`, it should open a URL that does a search across the whole website (instead of the default behavior of limiting the search to API docs).
Fix the `ng doc` command to implement the iteded behavior (previously, it did the opposite).
