### PR TITLE
fix(@angular/cli): open AIO search only when using `--search` flag

### DIFF
--- a/packages/angular/cli/src/commands/doc/cli.ts
+++ b/packages/angular/cli/src/commands/doc/cli.ts
@@ -83,8 +83,8 @@ export class DocCommandModule
 
     await open(
       options.search
-        ? `https://${domain}/api?query=${options.keyword}`
-        : `https://${domain}/docs?search=${options.keyword}`,
+        ? `https://${domain}/docs?search=${options.keyword}`
+        : `https://${domain}/api?query=${options.keyword}`,
     );
   }
 }


### PR DESCRIPTION
Previously, the ternary was wrong which causes the search to be opened even when the `--search` is not specified.