### PR TITLE
fix(@angular-devkit/build-angular): update `babel-loader` to 8.2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "ajv": "8.9.0",
     "ajv-formats": "2.1.1",
     "ansi-colors": "4.1.1",
-    "babel-loader": "8.2.3",
+    "babel-loader": "8.2.5",
     "babel-plugin-istanbul": "6.1.1",
     "bootstrap": "^4.0.0",
     "browserslist": "^4.9.1",

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -22,7 +22,7 @@
     "@discoveryjs/json-ext": "0.5.6",
     "@ngtools/webpack": "0.0.0-PLACEHOLDER",
     "ansi-colors": "4.1.1",
-    "babel-loader": "8.2.3",
+    "babel-loader": "8.2.5",
     "babel-plugin-istanbul": "6.1.1",
     "browserslist": "^4.9.1",
     "cacache": "15.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3247,6 +3247,16 @@ babel-loader@8.2.3:
     make-dir "^3.1.0"
     schema-utils "^2.6.5"
 
+babel-loader@8.2.5:
+  version "8.2.5"
+  resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.2.5.tgz#d45f585e654d5a5d90f5350a779d7647c5ed512e"
+  integrity sha512-OSiFfH89LrEMiWd4pLNqGz4CwJDtbs2ZVc+iGu2HrkRfPxId9F2anQj38IxWpmRfsUY0aBZYi1EFcd3mhtRMLQ==
+  dependencies:
+    find-cache-dir "^3.3.1"
+    loader-utils "^2.0.0"
+    make-dir "^3.1.0"
+    schema-utils "^2.6.5"
+
 babel-plugin-dynamic-import-node@^2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz#84fda19c976ec5c6defef57f9427b3def66e17a3"


### PR DESCRIPTION
The newer version of `babel-loader` contains a fix for its hash function usage
that will cause it to not use MD4 on Node.js versions that no longer support that
hashing algorithm.

Fixes #23134