### PR TITLE
fix(@angular/cli): ensure all available package migrations are executed

### DIFF
--- a/packages/angular/cli/src/commands/update/cli.ts
+++ b/packages/angular/cli/src/commands/update/cli.ts
@@ -787,8 +787,9 @@ export class UpdateCommandModule extends CommandModule<UpdateCommandArgs> {
           options.createCommits,
         );
 
-        if (!result) {
-          return 0;
+        // A non-zero value is a failure for the package's migrations
+        if (result !== 0) {
+          return result;
         }
       }
     }


### PR DESCRIPTION
For v14, the update command migration execution logic was incorrectly exiting after
the success of the first package's migrations. This prevented any other updated
packages from executing migrations automatically. The success check is now a failure
check and will allow the migration execution process to continue to execute migrations
until complete or a failure occurs.