### PR TITLE
build: add caretaker configuration to ng-dev config

### DIFF
--- a/.ng-dev/caretaker.ts
+++ b/.ng-dev/caretaker.ts
@@ -1,0 +1,16 @@
+import { CaretakerConfig } from '@angular/dev-infra-private/ng-dev';
+
+/** The configuration for `ng-dev caretaker` commands. */
+export const caretaker: CaretakerConfig = {
+  githubQueries: [
+    {
+      name: 'Merge Queue',
+      query: `is:pr is:open status:success label:"action: merge"`,
+    },
+    {
+      name: 'Merge Assistance Queue',
+      query: `is:pr is:open label:"action: merge-assistance"`,
+    },
+  ],
+  caretakerGroup: 'angular-cli-caretaker',
+};

--- a/.ng-dev/config.ts
+++ b/.ng-dev/config.ts
@@ -3,3 +3,4 @@ export { format } from './format';
 export { github } from './github';
 export { pullRequest } from './pull-request';
 export { release } from './release';
+export { caretaker } from './caretaker';

--- a/docs/process/release.md
+++ b/docs/process/release.md
@@ -17,6 +17,15 @@ Each shift consists of two caretakers. The primary caretaker is responsible for
 merging PRs to `main` and patch whereas the secondary caretaker is responsible
 for the release.
 
+At the end of each caretaker's rotation, they should peform a handoff in which they provide
+information to the next caretaker about the current state of the repository and update the
+access group to now include the next caretaker and their secondary. To perform this update
+to the access group, the caretaker can run:
+
+```bash
+$ yarn ng-dev caretaker handoff
+```
+
 ## Merging PRs
 
 The list of PRs which are currently ready to merge (approved with passing status checks) can


### PR DESCRIPTION
Add the caretaker configuration to set up being able to run both the carataker
check and the handoff commands.

The caretaker handoff command will operate using the angular-cli-caretaker group
which has already been seeded with the current information.


Caretakers can update the current caretakers in the angular-cli-caretaker group, granting them the necessary access for caretaking using the `ng-dev caretaker handoff` command.  Additionally, the caretaker can check the status of the repository and merge queues using `ng-dev caretaker check`.