### PR TITLE
fix(@angular-devkit/build-angular): downlevel libraries based on the browserslist configurations

### DIFF
--- a/packages/angular_devkit/build_angular/src/babel/presets/application.ts
+++ b/packages/angular_devkit/build_angular/src/babel/presets/application.ts
@@ -47,7 +47,7 @@ export interface ApplicationPresetOptions {
     linkerPluginCreator: typeof import('@angular/compiler-cli/linker/babel').createEs2015LinkerPlugin;
   };
 
-  forceES5?: boolean;
+  forcePresetEnv?: boolean;
   forceAsyncTransformation?: boolean;
   instrumentCode?: {
     includedBasePath: string;
@@ -59,6 +59,7 @@ export interface ApplicationPresetOptions {
     wrapDecorators: boolean;
   };
 
+  supportedBrowsers?: string[];
   diagnosticReporter?: DiagnosticReporter;
 }
 
@@ -178,14 +179,13 @@ export default function (api: unknown, options: ApplicationPresetOptions) {
     );
   }
 
-  if (options.forceES5) {
+  if (options.forcePresetEnv) {
     presets.push([
       require('@babel/preset-env').default,
       {
         bugfixes: true,
         modules: false,
-        // Comparable behavior to tsconfig target of ES5
-        targets: { ie: 9 },
+        targets: options.supportedBrowsers,
         exclude: ['transform-typeof-symbol'],
       },
     ]);

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/tests/behavior/build_localize_replaced_watch_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/tests/behavior/build_localize_replaced_watch_spec.ts
@@ -55,7 +55,7 @@ describeBuilder(serveWebpackBrowser, DEV_SERVER_BUILDER_INFO, (harness) => {
       const buildCount = await harness
         .execute()
         .pipe(
-          timeout(BUILD_TIMEOUT),
+          timeout(BUILD_TIMEOUT * 2),
           concatMap(async ({ result }, index) => {
             expect(result?.success).toBe(true);
 

--- a/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
@@ -378,6 +378,7 @@ export async function getCommonConfig(wco: WebpackConfigOptions): Promise<Config
                 scriptTarget,
                 aot: buildOptions.aot,
                 optimize: buildOptions.buildOptimizer,
+                supportedBrowsers: buildOptions.supportedBrowsers,
                 instrumentCode: codeCoverage
                   ? {
                       includedBasePath: sourceRoot,

--- a/packages/angular_devkit/build_angular/src/webpack/plugins/typescript.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/plugins/typescript.ts
@@ -26,6 +26,7 @@ function ensureIvy(wco: WebpackConfigOptions): void {
   wco.tsConfig.options.enableIvy = true;
 }
 
+let es5TargetWarningsShown = false;
 export function createIvyPlugin(
   wco: WebpackConfigOptions,
   aot: boolean,
@@ -53,6 +54,13 @@ export function createIvyPlugin(
   // as for third-party libraries. This greatly reduces the complexity of static analysis.
   if (wco.scriptTarget < ScriptTarget.ES2015) {
     compilerOptions.target = ScriptTarget.ES2015;
+    if (!es5TargetWarningsShown) {
+      wco.logger.warn(
+        'DEPRECATED: ES5 output is deprecated. Please update TypeScript `target` compiler option to ES2015 or later.',
+      );
+
+      es5TargetWarningsShown = true;
+    }
   }
 
   const fileReplacements: Record<string, string> = {};


### PR DESCRIPTION


There is no standard for library authors to ship their library in different ES versions, which can result in vendor libraries to ship ES features which are not supported by one or more browsers that the user's application supports.

With this change, we will be downlevelling libraries based on the list of supported browsers which is configured in the browserslist configuration. Previously, we only downlevelled libraries when targeting ES 5.

The TypeScript target option will not effect how the libraries get downlevelled.

Closes #23126