### PR TITLE
fix(@angular-devkit/build-angular): close dev-server on error

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/protractor/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/protractor/index.ts
@@ -107,67 +107,66 @@ export async function execute(
 
   let baseUrl = options.baseUrl;
   let server;
-  if (options.devServerTarget) {
-    const target = targetFromTargetString(options.devServerTarget);
-    const serverOptions = await context.getTargetOptions(target);
-
-    const overrides = {
-      watch: false,
-      liveReload: false,
-    } as DevServerBuilderOptions & json.JsonObject;
-
-    if (options.host !== undefined) {
-      overrides.host = options.host;
-    } else if (typeof serverOptions.host === 'string') {
-      options.host = serverOptions.host;
-    } else {
-      options.host = overrides.host = 'localhost';
-    }
-
-    if (options.port !== undefined) {
-      overrides.port = options.port;
-    } else if (typeof serverOptions.port === 'number') {
-      options.port = serverOptions.port;
-    }
-
-    server = await context.scheduleTarget(target, overrides);
-    const result = await server.result;
-    if (!result.success) {
-      return { success: false };
-    }
-
-    if (typeof serverOptions.publicHost === 'string') {
-      let publicHost = serverOptions.publicHost as string;
-      if (!/^\w+:\/\//.test(publicHost)) {
-        publicHost = `${serverOptions.ssl ? 'https' : 'http'}://${publicHost}`;
-      }
-      const clientUrl = url.parse(publicHost);
-      baseUrl = url.format(clientUrl);
-    } else if (typeof result.baseUrl === 'string') {
-      baseUrl = result.baseUrl;
-    } else if (typeof result.port === 'number') {
-      baseUrl = url.format({
-        protocol: serverOptions.ssl ? 'https' : 'http',
-        hostname: options.host,
-        port: result.port.toString(),
-      });
-    }
-  }
-
-  // Like the baseUrl in protractor config file when using the API we need to add
-  // a trailing slash when provide to the baseUrl.
-  if (baseUrl && !baseUrl.endsWith('/')) {
-    baseUrl += '/';
-  }
 
   try {
+    if (options.devServerTarget) {
+      const target = targetFromTargetString(options.devServerTarget);
+      const serverOptions = await context.getTargetOptions(target);
+
+      const overrides = {
+        watch: false,
+        liveReload: false,
+      } as DevServerBuilderOptions & json.JsonObject;
+
+      if (options.host !== undefined) {
+        overrides.host = options.host;
+      } else if (typeof serverOptions.host === 'string') {
+        options.host = serverOptions.host;
+      } else {
+        options.host = overrides.host = 'localhost';
+      }
+
+      if (options.port !== undefined) {
+        overrides.port = options.port;
+      } else if (typeof serverOptions.port === 'number') {
+        options.port = serverOptions.port;
+      }
+
+      server = await context.scheduleTarget(target, overrides);
+      const result = await server.result;
+      if (!result.success) {
+        return { success: false };
+      }
+
+      if (typeof serverOptions.publicHost === 'string') {
+        let publicHost = serverOptions.publicHost;
+        if (!/^\w+:\/\//.test(publicHost)) {
+          publicHost = `${serverOptions.ssl ? 'https' : 'http'}://${publicHost}`;
+        }
+        const clientUrl = url.parse(publicHost);
+        baseUrl = url.format(clientUrl);
+      } else if (typeof result.baseUrl === 'string') {
+        baseUrl = result.baseUrl;
+      } else if (typeof result.port === 'number') {
+        baseUrl = url.format({
+          protocol: serverOptions.ssl ? 'https' : 'http',
+          hostname: options.host,
+          port: result.port.toString(),
+        });
+      }
+    }
+
+    // Like the baseUrl in protractor config file when using the API we need to add
+    // a trailing slash when provide to the baseUrl.
+    if (baseUrl && !baseUrl.endsWith('/')) {
+      baseUrl += '/';
+    }
+
     return await runProtractor(context.workspaceRoot, { ...options, baseUrl });
   } catch {
     return { success: false };
   } finally {
-    if (server) {
-      await server.stop();
-    }
+    await server?.stop();
   }
 }
 


### PR DESCRIPTION
When running protractor, previously we didn't close the dev-server correctly when there was an error which caused the process to keep running following https://github.com/angular/angular-cli/pull/23166