### PR TITLE
fix(@angular/cli): populate path with working directory in nested schematics

### DIFF
--- a/packages/angular/cli/src/command-builder/command-module.ts
+++ b/packages/angular/cli/src/command-builder/command-module.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { analytics, logging, normalize, schema, strings } from '@angular-devkit/core';
+import { analytics, logging, schema, strings } from '@angular-devkit/core';
 import { readFileSync } from 'fs';
 import * as path from 'path';
 import {
@@ -197,8 +197,6 @@ export abstract class CommandModule<T extends {} = {}> implements CommandModuleI
    * **Note:** This method should be called from the command bundler method.
    */
   protected addSchemaOptionsToCommand<T>(localYargs: Argv<T>, options: Option[]): Argv<T> {
-    const workingDir = normalize(path.relative(this.context.root, process.cwd()));
-
     for (const option of options) {
       const {
         default: defaultVal,
@@ -211,7 +209,6 @@ export abstract class CommandModule<T extends {} = {}> implements CommandModuleI
         hidden,
         name,
         choices,
-        format,
       } = option;
 
       const sharedOptions: YargsOptions & PositionalOptions = {
@@ -223,11 +220,6 @@ export abstract class CommandModule<T extends {} = {}> implements CommandModuleI
         // This should only be done when `--help` is used otherwise default will override options set in angular.json.
         ...(this.context.args.options.help ? { default: defaultVal } : {}),
       };
-
-      // Special case for schematics
-      if (workingDir && format === 'path' && name === 'path' && hidden) {
-        sharedOptions.default = workingDir;
-      }
 
       if (positional === undefined) {
         localYargs = localYargs.option(strings.dasherize(name), {

--- a/packages/schematics/angular/app-shell/schema.json
+++ b/packages/schematics/angular/app-shell/schema.json
@@ -27,19 +27,16 @@
     },
     "main": {
       "type": "string",
-      "format": "path",
       "description": "The name of the main entry-point file.",
       "default": "main.server.ts"
     },
     "appDir": {
       "type": "string",
-      "format": "path",
       "description": "The name of the application directory.",
       "default": "app"
     },
     "rootModuleFileName": {
       "type": "string",
-      "format": "path",
       "description": "The name of the root module file",
       "default": "app.server.module.ts"
     },

--- a/packages/schematics/angular/class/schema.json
+++ b/packages/schematics/angular/class/schema.json
@@ -18,6 +18,9 @@
     "path": {
       "type": "string",
       "format": "path",
+      "$default": {
+        "$source": "workingDirectory"
+      },
       "description": "The path at which to create the class, relative to the workspace root.",
       "visible": false
     },

--- a/packages/schematics/angular/component/schema.json
+++ b/packages/schematics/angular/component/schema.json
@@ -9,6 +9,9 @@
     "path": {
       "type": "string",
       "format": "path",
+      "$default": {
+        "$source": "workingDirectory"
+      },
       "description": "The path at which to create the component file, relative to the current workspace. Default is a folder with the same name as the component in the project root.",
       "visible": false
     },

--- a/packages/schematics/angular/directive/schema.json
+++ b/packages/schematics/angular/directive/schema.json
@@ -18,6 +18,9 @@
     "path": {
       "type": "string",
       "format": "path",
+      "$default": {
+        "$source": "workingDirectory"
+      },
       "description": "The path at which to create the interface that defines the directive, relative to the workspace root.",
       "visible": false
     },

--- a/packages/schematics/angular/enum/schema.json
+++ b/packages/schematics/angular/enum/schema.json
@@ -18,6 +18,9 @@
     "path": {
       "type": "string",
       "format": "path",
+      "$default": {
+        "$source": "workingDirectory"
+      },
       "description": "The path at which to create the enum definition, relative to the current workspace.",
       "visible": false
     },

--- a/packages/schematics/angular/guard/schema.json
+++ b/packages/schematics/angular/guard/schema.json
@@ -29,6 +29,9 @@
     "path": {
       "type": "string",
       "format": "path",
+      "$default": {
+        "$source": "workingDirectory"
+      },
       "description": "The path at which to create the interface that defines the guard, relative to the current workspace.",
       "visible": false
     },

--- a/packages/schematics/angular/interceptor/schema.json
+++ b/packages/schematics/angular/interceptor/schema.json
@@ -18,6 +18,9 @@
     "path": {
       "type": "string",
       "format": "path",
+      "$default": {
+        "$source": "workingDirectory"
+      },
       "description": "The path at which to create the interceptor, relative to the workspace root.",
       "visible": false
     },

--- a/packages/schematics/angular/interface/schema.json
+++ b/packages/schematics/angular/interface/schema.json
@@ -18,6 +18,9 @@
     "path": {
       "type": "string",
       "format": "path",
+      "$default": {
+        "$source": "workingDirectory"
+      },
       "description": "The path at which to create the interface, relative to the workspace root.",
       "visible": false
     },

--- a/packages/schematics/angular/module/schema.json
+++ b/packages/schematics/angular/module/schema.json
@@ -18,6 +18,9 @@
     "path": {
       "type": "string",
       "format": "path",
+      "$default": {
+        "$source": "workingDirectory"
+      },
       "description": "The path at which to create the NgModule, relative to the workspace root.",
       "visible": false
     },

--- a/packages/schematics/angular/pipe/schema.json
+++ b/packages/schematics/angular/pipe/schema.json
@@ -18,6 +18,9 @@
     "path": {
       "type": "string",
       "format": "path",
+      "$default": {
+        "$source": "workingDirectory"
+      },
       "description": "The path at which to create the pipe, relative to the workspace root.",
       "visible": false
     },

--- a/packages/schematics/angular/resolver/schema.json
+++ b/packages/schematics/angular/resolver/schema.json
@@ -29,6 +29,9 @@
     "path": {
       "type": "string",
       "format": "path",
+      "$default": {
+        "$source": "workingDirectory"
+      },
       "description": "The path at which to create the interface that defines the resolver, relative to the current workspace.",
       "visible": false
     },

--- a/packages/schematics/angular/service/schema.json
+++ b/packages/schematics/angular/service/schema.json
@@ -17,7 +17,9 @@
     },
     "path": {
       "type": "string",
-      "format": "path",
+      "$default": {
+        "$source": "workingDirectory"
+      },
       "description": "The path at which to create the service, relative to the workspace root.",
       "visible": false
     },

--- a/packages/schematics/angular/web-worker/schema.json
+++ b/packages/schematics/angular/web-worker/schema.json
@@ -9,6 +9,9 @@
     "path": {
       "type": "string",
       "format": "path",
+      "$default": {
+        "$source": "workingDirectory"
+      },
       "description": "The path at which to create the worker file, relative to the current workspace.",
       "visible": false
     },


### PR DESCRIPTION

With this change we change the how we handle `"format": "path"` schematic property option. We replace the formatter in favour of a `SmartDefaultProvider`, which ensures that nested schematics can access the `workingDirectory`.