### PR TITLE
fix(@angular/cli): remove incorrect warning during `ng update`

### DIFF
--- a/packages/angular/cli/src/commands/update/cli.ts
+++ b/packages/angular/cli/src/commands/update/cli.ts
@@ -130,7 +130,7 @@ export class UpdateCommandModule extends CommandModule<UpdateCommandArgs> {
         alias: ['C'],
         default: false,
       })
-      .check(({ packages, next, 'allow-dirty': allowDirty, 'migrate-only': migrateOnly }) => {
+      .check(({ packages, 'allow-dirty': allowDirty, 'migrate-only': migrateOnly }) => {
         const { logger } = this.context;
 
         // This allows the user to easily reset any changes from the update.
@@ -151,10 +151,6 @@ export class UpdateCommandModule extends CommandModule<UpdateCommandArgs> {
             throw new CommandModuleError(
               `A single package must be specified when using the 'migrate-only' option.`,
             );
-          }
-
-          if (next) {
-            logger.warn(`'next' option has no effect when using 'migrate-only' option.`);
           }
         }
 


### PR DESCRIPTION
The `next` option is not ignored when using the `migrate-only` option. This option is used to determine if a newer version of the CLI needs to be downloaded.

https://github.com/angular/angular-cli/blob/3d76cef369b936a6d01108802cfe7dabca602f2e/packages/angular/cli/src/commands/update/cli.ts#L876