### PR TITLE
docs: correct `completion.gif` image path

### DIFF
--- a/packages/angular/cli/src/commands/completion/long-description.md
+++ b/packages/angular/cli/src/commands/completion/long-description.md
@@ -4,7 +4,7 @@ discover and use CLI commands without lots of memorization.
 
 ![A demo of Angular CLI autocompletion in a terminal. The user types several partial `ng` commands,
 using autocompletion to finish several arguments and list contextual options.
-](/generated/images/guide/cli/completion.gif)
+](generated/images/guide/cli/completion.gif)
 
 ## Automated setup
 


### PR DESCRIPTION
Assets paths in AIO need to be relative. This also ensures that the base href element is respected if changed. 

https://app.circleci.com/pipelines/github/angular/angular/46755/workflows/ea228e6e-62ab-4d7f-9764-2c1056ad0366/jobs/1173152