### PR TITLE
fix(@angular-devkit/build-angular): add es2015 exports package condition to browser-esbuild

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
@@ -281,7 +281,7 @@ async function bundleCode(
     assetNames: outputNames.media,
     target: 'es2020',
     mainFields: ['es2020', 'browser', 'module', 'main'],
-    conditions: ['es2020', 'module'],
+    conditions: ['es2020', 'es2015', 'module'],
     resolveExtensions: ['.ts', '.tsx', '.mjs', '.js'],
     logLevel: options.verbose ? 'debug' : 'silent',
     metafile: true,


### PR DESCRIPTION
The `es2015` exports package condition is used by `rxjs` to allow bundlers to use the ES2015-based
ESM code instead of the default of ES5-based ESM code. The ES5-based ESM code is larger in size
and harder to optimize due to the downlevelled classes. This change results in a ~5Kb size reduction
for the main bundle of a new application (129920 -> 124183).