### PR TITLE
build: update to TypeScript 4.7 final

### DIFF
--- a/package.json
+++ b/package.json
@@ -209,7 +209,7 @@
     "tree-kill": "1.2.2",
     "ts-node": "^10.0.0",
     "tslib": "2.4.0",
-    "typescript": "4.7.1-rc",
+    "typescript": "~4.7.2",
     "verdaccio": "5.10.2",
     "verdaccio-auth-memory": "^10.0.0",
     "webpack": "5.72.1",

--- a/packages/angular_devkit/schematics_cli/blank/project-files/package.json
+++ b/packages/angular_devkit/schematics_cli/blank/project-files/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@angular-devkit/core": "^<%= coreVersion %>",
     "@angular-devkit/schematics": "^<%= schematicsVersion %>",
-    "typescript": "~4.6.2"
+    "typescript": "~4.7.2"
   },
   "devDependencies": {
     "@types/node": "^14.15.0",

--- a/packages/angular_devkit/schematics_cli/schematic/files/package.json
+++ b/packages/angular_devkit/schematics_cli/schematic/files/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@angular-devkit/core": "^<%= coreVersion %>",
     "@angular-devkit/schematics": "^<%= schematicsVersion %>",
-    "typescript": "~4.6.2"
+    "typescript": "~4.7.2"
   },
   "devDependencies": {
     "@types/node": "^14.15.0",

--- a/packages/ngtools/webpack/package.json
+++ b/packages/ngtools/webpack/package.json
@@ -30,7 +30,7 @@
     "@angular-devkit/core": "0.0.0-PLACEHOLDER",
     "@angular/compiler": "14.0.0-next.16",
     "@angular/compiler-cli": "14.0.0-next.16",
-    "typescript": "4.7.1-rc",
+    "typescript": "~4.7.2",
     "webpack": "5.72.1"
   }
 }

--- a/packages/schematics/angular/third_party/github.com/Microsoft/TypeScript/BUILD.bazel
+++ b/packages/schematics/angular/third_party/github.com/Microsoft/TypeScript/BUILD.bazel
@@ -1,11 +1,11 @@
 load("//tools:defaults.bzl", "ts_library")
 
-# files fetched on 2022-05-06 from
-# https://github.com/microsoft/TypeScript/releases/tag/v4.7-rc
+# files fetched on 2022-05-25 from
+# https://github.com/microsoft/TypeScript/releases/tag/v4.7.2
 
 # Commands to download:
-# curl https://raw.githubusercontent.com/microsoft/TypeScript/v4.7-rc/lib/typescript.d.ts -o packages/schematics/angular/third_party/github.com/Microsoft/TypeScript/lib/typescript.d.ts
-# curl https://raw.githubusercontent.com/microsoft/TypeScript/v4.7-rc/lib/typescript.js -o packages/schematics/angular/third_party/github.com/Microsoft/TypeScript/lib/typescript.js
+# curl https://raw.githubusercontent.com/microsoft/TypeScript/v4.7.2/lib/typescript.d.ts -o packages/schematics/angular/third_party/github.com/Microsoft/TypeScript/lib/typescript.d.ts
+# curl https://raw.githubusercontent.com/microsoft/TypeScript/v4.7.2/lib/typescript.js -o packages/schematics/angular/third_party/github.com/Microsoft/TypeScript/lib/typescript.js
 
 licenses(["notice"])  # Apache 2.0
 

--- a/packages/schematics/angular/utility/latest-versions/package.json
+++ b/packages/schematics/angular/utility/latest-versions/package.json
@@ -15,7 +15,7 @@
     "rxjs": "~7.5.0",
     "tslib": "^2.3.0",
     "ts-node": "~10.7.0",
-    "typescript": "~4.6.2",
+    "typescript": "~4.7.2",
     "zone.js": "~0.11.4"
   }
 }

--- a/tests/legacy-cli/e2e/assets/webpack/test-app/package.json
+++ b/tests/legacy-cli/e2e/assets/webpack/test-app/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "sass": "^1.32.8",
     "sass-loader": "^11.0.1",
-    "typescript": "~4.3.2",
+    "typescript": "~4.7.2",
     "webpack": "^5.27.0",
     "webpack-cli": "^4.5.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10201,15 +10201,15 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@4.7.1-rc:
-  version "4.7.1-rc"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.1-rc.tgz#23a0517d36c56de887b4457f29e2d265647bbd7c"
-  integrity sha512-EQd2NVelDe6ZVc2sO1CSpuSs+RHzY8c2n/kTNQAHw4um/eAXY+ZY4IKoUpNK0wO6C5hN+XcUXR7yqT8VbwwNIQ==
-
 typescript@~4.6.2, typescript@~4.6.3:
   version "4.6.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.4.tgz#caa78bbc3a59e6a5c510d35703f6a09877ce45e9"
   integrity sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==
+
+typescript@~4.7.2:
+  version "4.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.2.tgz#1f9aa2ceb9af87cca227813b4310fff0b51593c4"
+  integrity sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A==
 
 ua-parser-js@1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Bumps up the TypeScript 4.7 for our own build as well as any newly-created apps.

(cherry picked from commit d2e9edd46304d2187b18f673db620bdd1892a39e)