### PR TITLE
ci: update Windows E2E job to use Node.js 16.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,8 +83,8 @@ commands:
           at: *workspace_location
   setup_windows:
     steps:
-      - run: nvm install 14.19
-      - run: nvm use 14.19
+      - run: nvm install 16.10
+      - run: nvm use 16.10
       - run: npm install -g yarn@1.22.10
       - run: node --version
       - run: yarn --version


### PR DESCRIPTION
Node.js v16 is now the default development environment for the CLI. v16
also should provide performance improvements for the E2E test runs and is
the more commonly used version of Node.js at this time. v16.10 is currently
the minimum supported version of the Node.js v16 major for the Angular CLI.