### PR TITLE
fix(@angular-devkit/schematics): support ignore scripts package installs with Yarn 2+

### DIFF
--- a/packages/angular_devkit/schematics/tasks/package-manager/executor.ts
+++ b/packages/angular_devkit/schematics/tasks/package-manager/executor.ts
@@ -101,7 +101,18 @@ export default function (
     }
 
     if (!options.allowScripts) {
-      args.push('--ignore-scripts');
+      // Yarn requires special handling since Yarn 2+ no longer has the `--ignore-scripts` flag
+      if (taskPackageManagerName === 'yarn') {
+        spawnOptions.env = {
+          ...process.env,
+          // Supported with yarn 1
+          'npm_config_ignore_scripts': 'true',
+          // Supported with yarn 2+
+          'YARN_ENABLE_SCRIPTS': 'false',
+        };
+      } else {
+        args.push('--ignore-scripts');
+      }
     }
 
     if (factoryOptions.registry) {


### PR DESCRIPTION
Yarn 2 and higher no longer support the `--ignore-scripts` flag.
The `NodePackageInstallTask` will now spawn Yarn with environment variables to ignore
scripts instead of the commandline option. Other package managers remain unchanged.
This provides the necessary functionality for the task without relying on Yarn
commandline options.