### PR TITLE
fix(@angular-devkit/core): address Node.js `DEP0128` warning

### DIFF
--- a/packages/angular_devkit/core/node/package.json
+++ b/packages/angular_devkit/core/node/package.json
@@ -1,5 +1,4 @@
 {
   "name": "@angular-devkit/core/node",
-  "main": "index.js",
   "typings": "index.d.ts"
 }

--- a/packages/angular_devkit/schematics/tasks/package.json
+++ b/packages/angular_devkit/schematics/tasks/package.json
@@ -1,5 +1,4 @@
 {
   "name": "@angular-devkit/schematics/tasks",
-  "main": "index.js",
   "typings": "index.d.ts"
 }

--- a/packages/angular_devkit/schematics/testing/package.json
+++ b/packages/angular_devkit/schematics/testing/package.json
@@ -1,5 +1,4 @@
 {
   "name": "@angular-devkit/schematics/testing",
-  "main": "index.js",
   "typings": "index.d.ts"
 }

--- a/packages/angular_devkit/schematics/tools/package.json
+++ b/packages/angular_devkit/schematics/tools/package.json
@@ -1,5 +1,4 @@
 {
   "name": "@angular-devkit/schematics/tools",
-  "main": "index.js",
   "typings": "index.d.ts"
 }


### PR DESCRIPTION
Modules that have an invalid `main` entry as `index.js` file in the top level directory will resolve the `index.js` file. That is deprecated and is going to throw an error in future Node.js versions.

See: https://nodejs.org/api/deprecations.html#DEP0128