### PR TITLE
fix(@schematics/angular): remove strict setting under application project

### DIFF
--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -112,14 +112,6 @@ function addAppToWorkspaceFile(
     });
   }
 
-  if (options.strict) {
-    if (!('@schematics/angular:application' in schematics)) {
-      schematics['@schematics/angular:application'] = {};
-    }
-
-    (schematics['@schematics/angular:application'] as JsonObject).strict = true;
-  }
-
   const sourceRoot = join(normalize(projectRoot), 'src');
   let budgets = [];
   if (options.strict) {


### PR DESCRIPTION


This setting is redundant under an application project since an application cannot be created under another application.