### PR TITLE
fix(@angular/cli): avoid creating unnecessary global configuration

### DIFF
--- a/packages/angular/cli/src/command-builder/command-module.ts
+++ b/packages/angular/cli/src/command-builder/command-module.ts
@@ -40,7 +40,7 @@ export interface CommandContext {
   currentDirectory: string;
   root: string;
   workspace?: AngularWorkspace;
-  globalConfiguration?: AngularWorkspace;
+  globalConfiguration: AngularWorkspace;
   logger: logging.Logger;
   packageManager: PackageManagerUtils;
   /** Arguments parsed in free-from without parser configuration. */

--- a/packages/angular/cli/src/command-builder/command-runner.ts
+++ b/packages/angular/cli/src/command-builder/command-runner.ts
@@ -77,7 +77,7 @@ export async function runCommand(args: string[], logger: logging.Logger): Promis
   const positional = getYargsCompletions ? _.slice(1) : _;
 
   let workspace: AngularWorkspace | undefined;
-  let globalConfiguration: AngularWorkspace | undefined;
+  let globalConfiguration: AngularWorkspace;
   try {
     [workspace, globalConfiguration] = await Promise.all([
       getWorkspace('local'),

--- a/packages/angular/cli/src/command-builder/schematics-command-module.ts
+++ b/packages/angular/cli/src/command-builder/schematics-command-module.ts
@@ -304,7 +304,7 @@ export abstract class SchematicsCommandModule
 
     const value =
       getSchematicCollections(workspace?.getCli()) ??
-      getSchematicCollections(globalConfiguration?.getCli());
+      getSchematicCollections(globalConfiguration.getCli());
     if (value) {
       return value;
     }

--- a/packages/angular/cli/src/commands/config/cli.ts
+++ b/packages/angular/cli/src/commands/config/cli.ts
@@ -57,7 +57,7 @@ export class ConfigCommandModule
 
   async run(options: Options<ConfigCommandArgs>): Promise<number | void> {
     const level = options.global ? 'global' : 'local';
-    const [config] = getWorkspaceRaw(level);
+    const [config] = await getWorkspaceRaw(level);
 
     if (options.value == undefined) {
       if (!config) {
@@ -118,7 +118,7 @@ export class ConfigCommandModule
       throw new CommandModuleError('Invalid Path.');
     }
 
-    const [config, configPath] = getWorkspaceRaw(options.global ? 'global' : 'local');
+    const [config, configPath] = await getWorkspaceRaw(options.global ? 'global' : 'local');
     const { logger } = this.context;
 
     if (!config || !configPath) {

--- a/packages/angular/cli/src/utilities/package-manager.ts
+++ b/packages/angular/cli/src/utilities/package-manager.ts
@@ -26,7 +26,7 @@ interface PackageManagerOptions {
 }
 
 export interface PackageManagerUtilsContext {
-  globalConfiguration?: AngularWorkspace;
+  globalConfiguration: AngularWorkspace;
   workspace?: AngularWorkspace;
   root: string;
 }
@@ -326,7 +326,7 @@ export class PackageManagerUtils {
     }
 
     if (!result) {
-      result = getPackageManager(globalWorkspace?.extensions['cli']);
+      result = getPackageManager(globalWorkspace.extensions['cli']);
     }
 
     return result;


### PR DESCRIPTION
Previously, when a global configuration was not found on disk we forcefully created it even when it was not needed.

This causes issues in CI when multiple `ng` commands would run in parallel as it caused a read/write race conditions.

See: https://angular-team.slack.com/archives/C46U16D4Z/p1654089933910829