### PR TITLE
test(@angular/cli): force using `NPM_CONFIG_legacy_peer_deps` for  `ng add` NPM 7 test

### DIFF
--- a/tests/legacy-cli/e2e/tests/misc/npm-7.ts
+++ b/tests/legacy-cli/e2e/tests/misc/npm-7.ts
@@ -3,7 +3,7 @@ import { execSync } from 'child_process';
 import { valid as validSemVer } from 'semver';
 import { rimraf } from '../../utils/fs';
 import { getActivePackageManager } from '../../utils/packages';
-import { ng, npm } from '../../utils/process';
+import { execWithEnv, ng, npm } from '../../utils/process';
 import { isPrereleaseCli } from '../../utils/project';
 import { expectToFail } from '../../utils/utils';
 
@@ -58,10 +58,12 @@ export default async function () {
     await npm('install', '--global', 'npm@7.4.0');
 
     // Ensure `ng add` shows npm warning
-    // The below command will fail with the below due to incorrect peerDeps
-    const { message: stderrAdd } = await expectToFail(() =>
-      ng('add', '@angular/localize', '--skip-confirmation'),
+    const { stderr: stderrAdd } = await execWithEnv(
+      'ng',
+      ['add', '@angular/localize', '--skip-confirmation'],
+      { ...process.env, 'NPM_CONFIG_legacy_peer_deps': 'true' },
     );
+
     if (!stderrAdd.includes(warningText)) {
       throw new Error('ng add expected to show npm version warning.');
     }


### PR DESCRIPTION

`NPM_CONFIG_legacy_peer_deps` is set to `true` during snapshot test runs https://github.com/angular/angular-cli/blob/177fa0d8c0076589fc12bce5ca5969606d541336/tests/legacy-cli/e2e/utils/packages.ts#L67-L69. This causes the `ng add @angular/localize` to not fail because of incorrect peer dependencies, which isn't the case when test against latest or next versions.

With this change, we update this test to always set `NPM_CONFIG_legacy_peer_deps` to `true`.