### PR TITLE
docs: fix typo in latest versions `package.json`

### DIFF
--- a/packages/schematics/angular/utility/latest-versions/package.json
+++ b/packages/schematics/angular/utility/latest-versions/package.json
@@ -1,6 +1,6 @@
 {
   "description": "Package versions used by schematics in @schematics/angular.",
-  "comment": "This file is needed so that depedencies are synced by Renovate.",
+  "comment": "This file is needed so that dependencies are synced by Renovate.",
   "private": true,
   "dependencies": {
     "@types/jasmine": "~4.0.0",


### PR DESCRIPTION
Happened to see this when I left the file open after doing the release.