### PR TITLE
fix(@angular/cli): correct scope cache command

### DIFF
--- a/packages/angular/cli/src/commands/cache/clean/cli.ts
+++ b/packages/angular/cli/src/commands/cache/clean/cli.ts
@@ -19,7 +19,7 @@ export class CacheCleanModule extends CommandModule implements CommandModuleImpl
   command = 'clean';
   describe = 'Deletes persistent disk cache from disk.';
   longDescriptionPath: string | undefined;
-  static override scope: CommandScope.In;
+  static override scope = CommandScope.In;
 
   builder(localYargs: Argv): Argv {
     return localYargs.strict();

--- a/packages/angular/cli/src/commands/cache/cli.ts
+++ b/packages/angular/cli/src/commands/cache/cli.ts
@@ -26,7 +26,7 @@ export class CacheCommandModule extends CommandModule implements CommandModuleIm
   command = 'cache';
   describe = 'Configure persistent disk cache and retrieve cache statistics.';
   longDescriptionPath = join(__dirname, 'long-description.md');
-  static override scope: CommandScope.In;
+  static override scope = CommandScope.In;
 
   builder(localYargs: Argv): Argv {
     const subcommands = [

--- a/packages/angular/cli/src/commands/cache/info/cli.ts
+++ b/packages/angular/cli/src/commands/cache/info/cli.ts
@@ -22,7 +22,7 @@ export class CacheInfoCommandModule extends CommandModule implements CommandModu
   command = 'info';
   describe = 'Prints persistent disk cache configuration and statistics in the console.';
   longDescriptionPath?: string | undefined;
-  static override scope: CommandScope.In;
+  static override scope = CommandScope.In;
 
   builder(localYargs: Argv): Argv {
     return localYargs.strict();

--- a/packages/angular/cli/src/commands/cache/settings/cli.ts
+++ b/packages/angular/cli/src/commands/cache/settings/cli.ts
@@ -19,7 +19,7 @@ export class CacheDisableModule extends CommandModule implements CommandModuleIm
   aliases = 'off';
   describe = 'Disables persistent disk cache for all projects in the workspace.';
   longDescriptionPath: string | undefined;
-  static override scope: CommandScope.In;
+  static override scope = CommandScope.In;
 
   builder(localYargs: Argv): Argv {
     return localYargs;
@@ -35,7 +35,7 @@ export class CacheEnableModule extends CommandModule implements CommandModuleImp
   aliases = 'on';
   describe = 'Enables disk cache for all projects in the workspace.';
   longDescriptionPath: string | undefined;
-  static override scope: CommandScope.In;
+  static override scope = CommandScope.In;
 
   builder(localYargs: Argv): Argv {
     return localYargs;


### PR DESCRIPTION
Currently, this was being shown available as a global command which shouldn't be the case.