### PR TITLE
fix(@angular/cli): during an update only use package manager force option with npm 7+

### DIFF
--- a/packages/angular/cli/src/commands/update/cli.ts
+++ b/packages/angular/cli/src/commands/update/cli.ts
@@ -686,7 +686,7 @@ export class UpdateCommandModule extends CommandModule<UpdateCommandArgs> {
         });
       } catch {}
 
-      let forceInstall = options.force;
+      let forceInstall = false;
       // npm 7+ can fail due to it incorrectly resolving peer dependencies that have valid SemVer
       // ranges during an update. Update will set correct versions of dependencies within the
       // package.json file. The force option is set to workaround these errors.

--- a/packages/angular/cli/src/utilities/package-manager.ts
+++ b/packages/angular/cli/src/utilities/package-manager.ts
@@ -8,7 +8,7 @@
 
 import { isJsonObject, json } from '@angular-devkit/core';
 import { execSync, spawn } from 'child_process';
-import { existsSync, promises as fs, realpathSync, rmdirSync } from 'fs';
+import { existsSync, promises as fs, realpathSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { satisfies, valid } from 'semver';
@@ -111,7 +111,7 @@ export class PackageManagerUtils {
     // clean up temp directory on process exit
     process.on('exit', () => {
       try {
-        rmdirSync(tempPath, { recursive: true, maxRetries: 3 });
+        rmSync(tempPath, { recursive: true, maxRetries: 3 });
       } catch {}
     });
 


### PR DESCRIPTION
The package manager `--force` option is only relevant to npm 7+ wherein the option controls
the strictness of the npm 7+ peer dependency resolution. Yarn 2+ does not support a `--force`
option. When the `ng update` `--force` option was used, `ng update` was incorrectly
applying the package manager `--force` option to Yarn which lead to an installation failure.
This has now been corrected and the package manager `--force` option is now only applied to npm 7+.