### PR TITLE
refactor(@angular-devkit/build-angular): remove unneeded TypeScript transforms with esbuild

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/compiler-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/compiler-plugin.ts
@@ -131,8 +131,8 @@ export function createCompilerPlugin(
 
       // Temporary deep import for transformer support
       const {
-        createAotTransformers,
         mergeTransformers,
+        replaceBootstrap,
       } = require('@ngtools/webpack/src/ivy/transformation');
 
       // Setup defines based on the values provided by the Angular compiler-cli
@@ -270,10 +270,9 @@ export function createCompilerPlugin(
 
         fileEmitter = createFileEmitter(
           builder,
-          mergeTransformers(
-            angularCompiler.prepareEmit().transformers,
-            createAotTransformers(builder, {}),
-          ),
+          mergeTransformers(angularCompiler.prepareEmit().transformers, {
+            before: [replaceBootstrap(() => builder.getProgram().getTypeChecker())],
+          }),
           () => [],
         );
 


### PR DESCRIPTION
Only the `replaceBootstrap` TypeScript transform is needed with the `browser-esbuild` builder.
The `replaceBootstrap` transform converts the default generated JIT bootstrap call into an AOT
bootstrap call within an application. The other transforms were used to remove the development
and JIT related metadata from the AOT compiler generated code. However, with the esbuild based
build pipeline, these will be automatically removed without the need for additional transforms
via the earlier usage of the `ngJitMode` and `ngDevMode` defines.