### PR TITLE
fix(@angular/cli): improve resilience of logging during process exit

### DIFF
--- a/tests/legacy-cli/e2e/tests/misc/completion-script.ts
+++ b/tests/legacy-cli/e2e/tests/misc/completion-script.ts
@@ -1,4 +1,4 @@
-import { execAndWaitForOutputToMatch } from '../../utils/process';
+import { exec, execAndWaitForOutputToMatch } from '../../utils/process';
 
 export default async function () {
   // ng build
@@ -54,10 +54,17 @@ export default async function () {
     ['--get-yargs-completions', 'ng', 'run', 'test-project:'],
     /test-project\\:test/,
   );
-  await execAndWaitForOutputToMatch(
+
+  const { stdout: noServeStdout } = await exec(
     'ng',
-    ['--get-yargs-completions', 'ng', 'run', 'test-project:build'],
-    // does not include 'test-project:serve'
-    /^((?!:serve).)*$/,
+    '--get-yargs-completions',
+    'ng',
+    'run',
+    'test-project:build',
   );
+  if (noServeStdout.includes(':serve')) {
+    throw new Error(
+      `':serve' should not have been listed as a completion option.\nSTDOUT:\n${noServeStdout}`,
+    );
+  }
 }


### PR DESCRIPTION
In certain situations the existing console logger created via `@angular-devkit/core` `createConsoleLogger`
could try to write to a closed stdout pipe stream. This would result in an error during
execution. For cases such as the completion script command, this would also prevent the
command from functioning. To mitigate these cases, `createConsoleLogger` is no longer used
and instead a logger instance is directly created within the CLI that uses `Console.log`
and `Console.error` to write output. Exiting the CLI also now waits for messages to be
logged before proceeding with the exit.

Fixes #23288