### PR TITLE
test: reduce use of npmrc for test npm configuration

### DIFF
--- a/tests/legacy-cli/e2e/setup/002-npm-sandbox.ts
+++ b/tests/legacy-cli/e2e/setup/002-npm-sandbox.ts
@@ -16,6 +16,7 @@ export default async function () {
   // isolated within this e2e test invocation.
   process.env.NPM_CONFIG_USERCONFIG = npmrc;
   process.env.NPM_CONFIG_PREFIX = npmModulesPrefix;
+  process.env.NPM_CONFIG_REGISTRY = npmRegistry;
 
   // Snapshot builds may contain versions that are not yet released (e.g., RC phase main branch).
   // In this case peer dependency ranges may not resolve causing npm 7+ to fail during tests.

--- a/tests/legacy-cli/e2e/tests/commands/add/registry-option.ts
+++ b/tests/legacy-cli/e2e/tests/commands/add/registry-option.ts
@@ -1,18 +1,13 @@
 import { getGlobalVariable } from '../../../utils/env';
-import { expectFileToExist, writeMultipleFiles } from '../../../utils/fs';
+import { expectFileToExist } from '../../../utils/fs';
 import { ng } from '../../../utils/process';
 import { expectToFail } from '../../../utils/utils';
 
 export default async function () {
   const testRegistry = getGlobalVariable('package-registry');
 
-  // Setup an invalid registry
-  await writeMultipleFiles({
-    '.npmrc': 'registry=http://127.0.0.1:9999',
-  });
-
-  // The environment variable has priority over the .npmrc
-  delete process.env['NPM_CONFIG_REGISTRY'];
+  // Set an invalid registry
+  process.env['NPM_CONFIG_REGISTRY'] = 'http://127.0.0.1:9999';
 
   await expectToFail(() => ng('add', '@angular/pwa', '--skip-confirmation'));
 

--- a/tests/legacy-cli/e2e/utils/packages.ts
+++ b/tests/legacy-cli/e2e/utils/packages.ts
@@ -52,11 +52,6 @@ export async function setRegistry(useTestRegistry: boolean): Promise<void> {
   const isCI = getGlobalVariable('ci');
 
   // Ensure local test registry is used when outside a project
-  if (isCI) {
-    // Safe to set a user configuration on CI
-    await npm('config', 'set', 'registry', url);
-  } else {
-    // Yarn supports both `NPM_CONFIG_REGISTRY` and `YARN_REGISTRY`.
-    process.env['NPM_CONFIG_REGISTRY'] = url;
-  }
+  // Yarn supports both `NPM_CONFIG_REGISTRY` and `YARN_REGISTRY`.
+  process.env['NPM_CONFIG_REGISTRY'] = url;
 }


### PR DESCRIPTION
This way npmrc can be used for global cross-test configuration and environment variables can be overridden locally for each test case. There's probably more but these are some simple ones for now.