### PR TITLE
docs: remove azure builder reference

### DIFF
--- a/packages/angular/cli/src/commands/deploy/cli.ts
+++ b/packages/angular/cli/src/commands/deploy/cli.ts
@@ -22,10 +22,6 @@ export class DeployCommandModule
       value: '@jefiozie/ngx-aws-deploy',
     },
     {
-      name: 'Azure',
-      value: '@azure/ng-deploy',
-    },
-    {
       name: 'Firebase',
       value: '@angular/fire',
     },


### PR DESCRIPTION
This builder is not compatible with newer versions of the Angular CLI.

See https://github.com/angular/angular-cli/issues/23255 for more context

Closes #23255