### PR TITLE
fix(@angular/pwa): add peer dependency on Angular CLI

### DIFF
--- a/packages/angular/pwa/package.json
+++ b/packages/angular/pwa/package.json
@@ -15,5 +15,13 @@
     "@angular-devkit/schematics": "0.0.0-PLACEHOLDER",
     "@schematics/angular": "0.0.0-PLACEHOLDER",
     "parse5-html-rewriting-stream": "6.0.1"
+  },
+  "peerDependencies": {
+    "@angular/cli": "^14.0.0 || ^14.0.0-next || ^14.1.0-next"
+  },
+  "peerDependenciesMeta": {
+    "@angular/cli": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
The peer dependency is needed so that the correct version that mathes the installed Angular CLI is installated.