### PR TITLE
fix(@angular/cli): correctly print package manager name when an install is needed

### DIFF
--- a/packages/angular/cli/src/command-builder/architect-base-command-module.ts
+++ b/packages/angular/cli/src/command-builder/architect-base-command-module.ts
@@ -151,7 +151,7 @@ export abstract class ArchitectBaseCommandModule<T extends object>
     }
 
     this.context.logger.warn(
-      `Node packages may not be installed. Try installing with '${this.context.packageManager} install'.`,
+      `Node packages may not be installed. Try installing with '${this.context.packageManager.name} install'.`,
     );
   }
 

--- a/tests/legacy-cli/e2e/tests/commands/builder-not-found.ts
+++ b/tests/legacy-cli/e2e/tests/commands/builder-not-found.ts
@@ -1,5 +1,5 @@
 import { moveFile } from '../../utils/fs';
-import { installPackage, uninstallPackage } from '../../utils/packages';
+import { getActivePackageManager, installPackage, uninstallPackage } from '../../utils/packages';
 import { execAndWaitForOutputToMatch, ng } from '../../utils/process';
 import { expectToFail } from '../../utils/utils';
 
@@ -14,7 +14,13 @@ export default async function () {
       /Could not find the '@angular-devkit\/build-angular:browser' builder's node package\./,
     );
     await expectToFail(() =>
-      execAndWaitForOutputToMatch('ng', ['build'], /Node packages may not be installed\./),
+      execAndWaitForOutputToMatch(
+        'ng',
+        ['build'],
+        new RegExp(
+          `Node packages may not be installed\. Try installing with '${getActivePackageManager()} install'\.`,
+        ),
+      ),
     );
 
     await moveFile('node_modules', 'temp_node_modules');
@@ -25,7 +31,13 @@ export default async function () {
       ['build'],
       /Could not find the '@angular-devkit\/build-angular:browser' builder's node package\./,
     );
-    await execAndWaitForOutputToMatch('ng', ['build'], /Node packages may not be installed\./);
+    await execAndWaitForOutputToMatch(
+      'ng',
+      ['build'],
+      new RegExp(
+        `Node packages may not be installed\. Try installing with '${getActivePackageManager()} install'\.`,
+      ),
+    );
   } finally {
     await moveFile('temp_node_modules', 'node_modules');
     await installPackage('@angular-devkit/build-angular');


### PR DESCRIPTION
I was testing if we supported a warning here today and noticed that it was printing "Try installing with '[object Object] install'". Easy fix at least.