### PR TITLE
ci: increase parallelism for Linux E2E

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,7 +199,7 @@ jobs:
     executor:
       name: test-executor
       nodeversion: << parameters.nodeversion >>
-    parallelism: 6
+    parallelism: 8
     steps:
       - custom_attach_workspace
       - browser-tools/install-chrome


### PR DESCRIPTION
This reduced the Linux CI time by around 7 mins