### PR TITLE
refactor(@angular/cli): assert catch clause variable type before usage

### DIFF
--- a/packages/angular/cli/lib/cli/index.ts
+++ b/packages/angular/cli/lib/cli/index.ts
@@ -92,7 +92,7 @@ export default async function (options: { cliArgs: string[] }) {
       } catch (e) {
         logger.fatal(
           `An unhandled exception occurred: ${err.message}\n` +
-            `Fatal error writing debug log file: ${e.message}`,
+            `Fatal error writing debug log file: ${e}`,
         );
         if (err.stack) {
           logger.fatal(err.stack);
@@ -105,9 +105,7 @@ export default async function (options: { cliArgs: string[] }) {
     } else if (typeof err === 'number') {
       // Log nothing.
     } else {
-      logger.fatal(
-        `An unexpected error occurred: ${'toString' in err ? err.toString() : JSON.stringify(err)}`,
-      );
+      logger.fatal(`An unexpected error occurred: ${err}`);
     }
 
     return 1;

--- a/packages/angular/cli/src/analytics/analytics.ts
+++ b/packages/angular/cli/src/analytics/analytics.ts
@@ -10,8 +10,9 @@ import { analytics, json, tags } from '@angular-devkit/core';
 import debug from 'debug';
 import { v4 as uuidV4 } from 'uuid';
 import { colors } from '../utilities/color';
-import { AngularWorkspace, getWorkspace } from '../utilities/config';
+import { getWorkspace } from '../utilities/config';
 import { analyticsDisabled, analyticsShareDisabled } from '../utilities/environment-options';
+import { assertIsError } from '../utilities/error';
 import { isTTY } from '../utilities/tty';
 import { VERSION } from '../utilities/version';
 import { AnalyticsCollector } from './analytics-collector';
@@ -190,6 +191,7 @@ export async function getAnalytics(
       return new AnalyticsCollector(AnalyticsProperties.AngularCliDefault, uid);
     }
   } catch (err) {
+    assertIsError(err);
     analyticsDebug('Error happened during reading of analytics config: %s', err.message);
 
     return undefined;
@@ -222,6 +224,7 @@ export async function getSharedAnalytics(): Promise<AnalyticsCollector | undefin
       return new AnalyticsCollector(analyticsConfig.tracking, analyticsConfig.uuid);
     }
   } catch (err) {
+    assertIsError(err);
     analyticsDebug('Error happened during reading of analytics sharing config: %s', err.message);
 
     return undefined;

--- a/packages/angular/cli/src/command-builder/architect-base-command-module.ts
+++ b/packages/angular/cli/src/command-builder/architect-base-command-module.ts
@@ -16,6 +16,7 @@ import { spawnSync } from 'child_process';
 import { existsSync } from 'fs';
 import { resolve } from 'path';
 import { isPackageNameSafeForAnalytics } from '../analytics/analytics';
+import { assertIsError } from '../utilities/error';
 import { askConfirmation, askQuestion } from '../utilities/prompt';
 import { isTTY } from '../utilities/tty';
 import {
@@ -47,6 +48,8 @@ export abstract class ArchitectBaseCommandModule<T extends object>
     try {
       builderName = await architectHost.getBuilderNameForTarget(target);
     } catch (e) {
+      assertIsError(e);
+
       return this.onMissingTarget(e.message);
     }
 
@@ -115,6 +118,7 @@ export abstract class ArchitectBaseCommandModule<T extends object>
     try {
       builderDesc = await architectHost.resolveBuilder(builderConf);
     } catch (e) {
+      assertIsError(e);
       if (e.code === 'MODULE_NOT_FOUND') {
         this.warnOnMissingNodeModules();
         throw new CommandModuleError(`Could not find the '${builderConf}' builder's node package.`);

--- a/packages/angular/cli/src/command-builder/command-runner.ts
+++ b/packages/angular/cli/src/command-builder/command-runner.ts
@@ -30,6 +30,7 @@ import { UpdateCommandModule } from '../commands/update/cli';
 import { VersionCommandModule } from '../commands/version/cli';
 import { colors } from '../utilities/color';
 import { AngularWorkspace, getWorkspace } from '../utilities/config';
+import { assertIsError } from '../utilities/error';
 import { PackageManagerUtils } from '../utilities/package-manager';
 import { CommandContext, CommandModuleError, CommandScope } from './command-module';
 import { addCommandModuleToYargs, demandCommandFailureMessage } from './utilities/command';
@@ -84,6 +85,7 @@ export async function runCommand(args: string[], logger: logging.Logger): Promis
       getWorkspace('global'),
     ]);
   } catch (e) {
+    assertIsError(e);
     logger.fatal(e.message);
 
     return 1;

--- a/packages/angular/cli/src/command-builder/schematics-command-module.ts
+++ b/packages/angular/cli/src/command-builder/schematics-command-module.ts
@@ -17,6 +17,7 @@ import type { CheckboxQuestion, Question } from 'inquirer';
 import { relative, resolve } from 'path';
 import { Argv } from 'yargs';
 import { getProjectByCwd, getSchematicDefaults } from '../utilities/config';
+import { assertIsError } from '../utilities/error';
 import { memoize } from '../utilities/memoize';
 import { isTTY } from '../utilities/tty';
 import {
@@ -364,6 +365,7 @@ export abstract class SchematicsCommandModule
         // "See above" because we already printed the error.
         logger.fatal('The Schematic workflow failed. See above.');
       } else {
+        assertIsError(err);
         logger.fatal(err.message);
       }
 

--- a/packages/angular/cli/src/command-builder/utilities/schematic-engine-host.ts
+++ b/packages/angular/cli/src/command-builder/utilities/schematic-engine-host.ts
@@ -13,6 +13,7 @@ import { parse as parseJson } from 'jsonc-parser';
 import nodeModule from 'module';
 import { dirname, resolve } from 'path';
 import { Script } from 'vm';
+import { assertIsError } from '../../utilities/error';
 
 /**
  * Environment variable to control schematic package redirection
@@ -153,6 +154,7 @@ function wrap(
         try {
           return schematicRequire(id);
         } catch (e) {
+          assertIsError(e);
           if (e.code !== 'MODULE_NOT_FOUND') {
             throw e;
           }

--- a/packages/angular/cli/src/commands/add/cli.ts
+++ b/packages/angular/cli/src/commands/add/cli.ts
@@ -24,6 +24,7 @@ import {
   SchematicsCommandModule,
 } from '../../command-builder/schematics-command-module';
 import { colors } from '../../utilities/color';
+import { assertIsError } from '../../utilities/error';
 import {
   NgAddSaveDependency,
   PackageManifest,
@@ -113,6 +114,7 @@ export class AddCommandModule
     try {
       packageIdentifier = npa(collection);
     } catch (e) {
+      assertIsError(e);
       logger.error(e.message);
 
       return 1;
@@ -151,6 +153,7 @@ export class AddCommandModule
           verbose,
         });
       } catch (e) {
+        assertIsError(e);
         spinner.fail(`Unable to load package information from registry: ${e.message}`);
 
         return 1;
@@ -237,6 +240,7 @@ export class AddCommandModule
         spinner.succeed(`Package information loaded.`);
       }
     } catch (e) {
+      assertIsError(e);
       spinner.fail(`Unable to fetch package information for '${packageIdentifier}': ${e.message}`);
 
       return 1;
@@ -341,6 +345,7 @@ export class AddCommandModule
 
       return true;
     } catch (e) {
+      assertIsError(e);
       if (e.code !== 'MODULE_NOT_FOUND') {
         throw e;
       }

--- a/packages/angular/cli/src/commands/completion/cli.ts
+++ b/packages/angular/cli/src/commands/completion/cli.ts
@@ -12,6 +12,7 @@ import { CommandModule, CommandModuleImplementation } from '../../command-builde
 import { addCommandModuleToYargs } from '../../command-builder/utilities/command';
 import { colors } from '../../utilities/color';
 import { hasGlobalCliInstall, initializeAutocomplete } from '../../utilities/completion';
+import { assertIsError } from '../../utilities/error';
 
 export class CompletionCommandModule extends CommandModule implements CommandModuleImplementation {
   command = 'completion';
@@ -27,6 +28,7 @@ export class CompletionCommandModule extends CommandModule implements CommandMod
     try {
       rcFile = await initializeAutocomplete();
     } catch (err) {
+      assertIsError(err);
       this.context.logger.error(err.message);
 
       return 1;

--- a/packages/angular/cli/src/commands/update/schematic/index.ts
+++ b/packages/angular/cli/src/commands/update/schematic/index.ts
@@ -11,6 +11,7 @@ import { Rule, SchematicContext, SchematicsException, Tree } from '@angular-devk
 import * as npa from 'npm-package-arg';
 import type { Manifest } from 'pacote';
 import * as semver from 'semver';
+import { assertIsError } from '../../../utilities/error';
 import {
   NgPackageManifestProperties,
   NpmRepositoryPackageJson,
@@ -269,6 +270,7 @@ function _performUpdate(
   try {
     packageJson = JSON.parse(packageJsonContent.toString()) as JsonSchemaForNpmPackageJsonFiles;
   } catch (e) {
+    assertIsError(e);
     throw new SchematicsException('package.json could not be parsed: ' + e.message);
   }
 
@@ -772,6 +774,7 @@ function _getAllDependencies(tree: Tree): Array<readonly [string, VersionRange]>
   try {
     packageJson = JSON.parse(packageJsonContent.toString()) as JsonSchemaForNpmPackageJsonFiles;
   } catch (e) {
+    assertIsError(e);
     throw new SchematicsException('package.json could not be parsed: ' + e.message);
   }
 

--- a/packages/angular/cli/src/utilities/completion.ts
+++ b/packages/angular/cli/src/utilities/completion.ts
@@ -15,6 +15,7 @@ import { colors } from '../utilities/color';
 import { getWorkspace } from '../utilities/config';
 import { forceAutocomplete } from '../utilities/environment-options';
 import { isTTY } from '../utilities/tty';
+import { assertIsError } from './error';
 
 /** Interface for the autocompletion configuration stored in the global workspace. */
 interface CompletionConfig {
@@ -64,6 +65,7 @@ Ok, you won't be prompted again. Should you change your mind, the following comm
   try {
     rcFile = await initializeAutocomplete();
   } catch (err) {
+    assertIsError(err);
     // Failed to set up autocompeletion, log the error and abort.
     logger.error(err.message);
 
@@ -247,6 +249,7 @@ export async function initializeAutocomplete(): Promise<string> {
       '\n\n# Load Angular CLI autocompletion.\nsource <(ng completion script)\n',
     );
   } catch (err) {
+    assertIsError(err);
     throw new Error(`Failed to append autocompletion setup to \`${rcFile}\`:\n${err.message}`);
   }
 

--- a/packages/angular/cli/src/utilities/error.ts
+++ b/packages/angular/cli/src/utilities/error.ts
@@ -1,0 +1,13 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import assert from 'assert';
+
+export function assertIsError(value: unknown): asserts value is Error & { code?: string } {
+  assert(value instanceof Error, 'catch clause variable is not an Error instance');
+}


### PR DESCRIPTION
Prepares the `@angular/cli` package for the eventual change of enabling the
TypeScript `useUnknownInCatchVariables` option. This option provides additional
code safety by ensuring that the catch clause variable is the proper type before
attempting to access its properties. Similar changes will be needed in the other
packages in the repository prior to enabling `useUnknownInCatchVariables`.