### PR TITLE
fix(@angular/pwa): add peer dependency on Angular CLI

### DIFF
--- a/packages/angular/pwa/package.json
+++ b/packages/angular/pwa/package.json
@@ -15,5 +15,13 @@
     "@angular-devkit/schematics": "0.0.0-PLACEHOLDER",
     "@schematics/angular": "0.0.0-PLACEHOLDER",
     "parse5-html-rewriting-stream": "6.0.1"
+  },
+  "peerDependencies": {
+    "@angular/cli": "^13.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@angular/cli": {
+      "optional": true
+    }
   }
 }

--- a/tests/legacy-cli/e2e/tests/build/material.ts
+++ b/tests/legacy-cli/e2e/tests/build/material.ts
@@ -1,5 +1,5 @@
 import { getGlobalVariable } from '../../utils/env';
-import { replaceInFile } from '../../utils/fs';
+import { readFile, replaceInFile } from '../../utils/fs';
 import { installPackage, installWorkspacePackages } from '../../utils/packages';
 import { ng } from '../../utils/process';
 import { isPrereleaseCli, updateJsonFile } from '../../utils/project';
@@ -7,7 +7,7 @@ import { isPrereleaseCli, updateJsonFile } from '../../utils/project';
 const snapshots = require('../../ng-snapshot/package.json');
 
 export default async function () {
-  const tag = await isPrereleaseCli() ?  '@next' : '';
+  let tag = (await isPrereleaseCli()) ? '@next' : '';
   await ng('add', `@angular/material${tag}`, '--skip-confirmation');
 
   const isSnapshotBuild = getGlobalVariable('argv')['ng-snapshots'];
@@ -25,10 +25,15 @@ export default async function () {
       dependencies['@angular/material-moment-adapter'] =
         snapshots.dependencies['@angular/material-moment-adapter'];
     });
-
     await installWorkspacePackages();
   } else {
-    await installPackage('@angular/material-moment-adapter');
+    if (!tag) {
+      const installedMaterialVersion = JSON.parse(await readFile('package.json'))['dependencies'][
+        '@angular/material'
+      ];
+      tag = `@${installedMaterialVersion}`;
+    }
+    await installPackage(`@angular/material-moment-adapter${tag}`);
   }
 
   await installPackage('moment');


### PR DESCRIPTION
The peer dependency is needed so that the correct version that matches the installed Angular CLI is installed.

(cherry picked from commit d59ba3110b7a12b8f64427609decefbe9d693e90)

Closes #23343