### PR TITLE
test: reduce disk-cache E2E tests duration

### DIFF
--- a/tests/legacy-cli/e2e/tests/build/disk-cache-purge.ts
+++ b/tests/legacy-cli/e2e/tests/build/disk-cache-purge.ts
@@ -1,11 +1,15 @@
 import { join } from 'path';
-import { createDir, expectFileNotToExist, expectFileToExist } from '../../utils/fs';
+import { createDir, expectFileNotToExist, expectFileToExist, writeFile } from '../../utils/fs';
 import { ng } from '../../utils/process';
 import { updateJsonFile } from '../../utils/project';
 
 export default async function () {
   const cachePath = '.angular/cache';
   const staleCachePath = join(cachePath, 'v1.0.0');
+
+  // No need to include all applications code to verify disk cache existence.
+  await writeFile('src/main.ts', 'console.log(1);');
+  await writeFile('src/polyfills.ts', 'console.log(1);');
 
   // Enable cache for all environments
   await updateJsonFile('angular.json', (config) => {

--- a/tests/legacy-cli/e2e/tests/build/disk-cache.ts
+++ b/tests/legacy-cli/e2e/tests/build/disk-cache.ts
@@ -1,4 +1,4 @@
-import { expectFileNotToExist, expectFileToExist, rimraf } from '../../utils/fs';
+import { expectFileNotToExist, expectFileToExist, rimraf, writeFile } from '../../utils/fs';
 import { ng } from '../../utils/process';
 import { updateJsonFile } from '../../utils/project';
 
@@ -7,6 +7,10 @@ const overriddenCachePath = '.cache/angular-cli';
 
 export default async function () {
   const originalCIValue = process.env['CI'];
+
+  // No need to include all applications code to verify disk cache existence.
+  await writeFile('src/main.ts', 'console.log(1);');
+  await writeFile('src/polyfills.ts', 'console.log(1);');
 
   try {
     // Should be enabled by default.


### PR DESCRIPTION
We don't need to include all applications code to verify disk cache existence.

This reduces the test duration of `disk-cache.ts` by a whopping `~65s` since this tests runs `ng build` 5 times and `disk-cache-purge.ts` by `~13s`.

These timings were gathered using gLinux and is expected that the gain is more significant on Circle CI Linux and Windows executors