### PR TITLE
docs: update install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Get started with Angular CLI, learn the fundamentals and explore advanced topics
 Install the Angular CLI globally:
 
 ```
-npm install -g @angular/cli
+npm install --location=global @angular/cli
 ```
 
 Create workspace:


### PR DESCRIPTION
Update the install command to be compliant with npm v8 and it does not throw the warning:
> npm WARN config global `--global`, `--local` are deprecated. Use `--location=global` instead.