### PR TITLE
build: enable TypeScript useUnknownInCatchVariables compiler option

### DIFF
--- a/packages/angular_devkit/architect/node/node-modules-architect-host.ts
+++ b/packages/angular_devkit/architect/node/node-modules-architect-host.ts
@@ -245,7 +245,7 @@ async function getBuilder(builderPath: string): Promise<any> {
       try {
         return require(builderPath);
       } catch (e) {
-        if (e.code === 'ERR_REQUIRE_ESM') {
+        if ((e as NodeJS.ErrnoException).code === 'ERR_REQUIRE_ESM') {
           // Load the ESM configuration file using the TypeScript dynamic import workaround.
           // Once TypeScript provides support for keeping the dynamic import this workaround can be
           // changed to a direct dynamic import.

--- a/packages/angular_devkit/architect/src/index_spec.ts
+++ b/packages/angular_devkit/architect/src/index_spec.ts
@@ -136,13 +136,10 @@ describe('architect', () => {
     await run.stop();
   });
 
-  it(`errors when target configuration doesn't exists`, async () => {
-    try {
-      await architect.scheduleBuilder('test:test:invalid', {});
-      throw new Error('should have thrown');
-    } catch (err) {
-      expect(err.message).toContain('Job name "test:test:invalid" does not exist.');
-    }
+  it(`errors when target configuration does not exist`, async () => {
+    await expectAsync(architect.scheduleBuilder('test:test:invalid', {})).toBeRejectedWithError(
+      'Job name "test:test:invalid" does not exist.',
+    );
   });
 
   it('errors when builder cannot be resolved', async () => {

--- a/packages/angular_devkit/architect_cli/bin/architect.ts
+++ b/packages/angular_devkit/architect_cli/bin/architect.ts
@@ -179,7 +179,7 @@ async function _executeTarget(
     logs.forEach((l) => parentLogger.next(l));
 
     parentLogger.fatal('Exception:');
-    parentLogger.fatal(err.stack);
+    parentLogger.fatal((err instanceof Error && err.stack) || `${err}`);
 
     return 2;
   }

--- a/packages/angular_devkit/benchmark/src/main.ts
+++ b/packages/angular_devkit/benchmark/src/main.ts
@@ -221,11 +221,7 @@ export async function main({
       return 1;
     }
   } catch (error) {
-    if (error.message) {
-      logger.fatal(error.message);
-    } else {
-      logger.fatal(error);
-    }
+    logger.fatal(error instanceof Error ? error.message : `${error}`);
 
     return 1;
   }

--- a/packages/angular_devkit/build_angular/src/builders/app-shell/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/app-shell/index.ts
@@ -16,6 +16,7 @@ import { JsonObject } from '@angular-devkit/core';
 import * as fs from 'fs';
 import * as path from 'path';
 import { normalizeOptimization } from '../../utils';
+import { assertIsError } from '../../utils/error';
 import { InlineCriticalCssProcessor } from '../../utils/index-file/inline-critical-css';
 import { augmentAppWithServiceWorker } from '../../utils/service-worker';
 import { Spinner } from '../../utils/spinner';
@@ -199,6 +200,7 @@ async function _appShellBuilder(
     return result;
   } catch (err) {
     spinner?.fail('Application shell generation failed.');
+    assertIsError(err);
 
     return { success: false, error: err.message };
   } finally {

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
@@ -13,6 +13,7 @@ import { promises as fs } from 'fs';
 import * as path from 'path';
 import { NormalizedOptimizationOptions, deleteOutputDir } from '../../utils';
 import { copyAssets } from '../../utils/copy-assets';
+import { assertIsError } from '../../utils/error';
 import { FileInfo } from '../../utils/index-file/augment-index-html';
 import { IndexHtmlGenerator } from '../../utils/index-file/index-html-generator';
 import { generateEntryPoints } from '../../utils/package-chunk-sort';
@@ -134,8 +135,8 @@ export async function execute(
   try {
     await fs.mkdir(outputPath, { recursive: true });
   } catch (e) {
-    const reason = 'message' in e ? e.message : 'Unknown error';
-    context.logger.error('Unable to create output directory: ' + reason);
+    assertIsError(e);
+    context.logger.error('Unable to create output directory: ' + e.message);
 
     return { success: false };
   }

--- a/packages/angular_devkit/build_angular/src/builders/browser/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/index.ts
@@ -29,6 +29,7 @@ import {
 } from '../../utils/bundle-calculator';
 import { colors } from '../../utils/color';
 import { copyAssets } from '../../utils/copy-assets';
+import { assertIsError } from '../../utils/error';
 import { i18nInlineEmittedFiles } from '../../utils/i18n-inlining';
 import { I18nOptions } from '../../utils/i18n-options';
 import { FileInfo } from '../../utils/index-file/augment-index-html';
@@ -278,6 +279,7 @@ export function buildWebpackBrowser(
                     spinner.succeed('Copying assets complete.');
                   } catch (err) {
                     spinner.fail(colors.redBright('Copying of assets failed.'));
+                    assertIsError(err);
 
                     return { success: false, error: 'Unable to copy assets: ' + err.message };
                   }

--- a/packages/angular_devkit/build_angular/src/builders/protractor/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/protractor/index.ts
@@ -16,6 +16,7 @@ import { json, tags } from '@angular-devkit/core';
 import { resolve } from 'path';
 import * as url from 'url';
 import { runModuleAsObservableFork } from '../../utils';
+import { assertIsError } from '../../utils/error';
 import { DevServerBuilderOptions } from '../dev-server/index';
 import { Schema as ProtractorBuilderOptions } from './schema';
 
@@ -56,6 +57,7 @@ async function updateWebdriver() {
 
     path = require.resolve(webdriverDeepImport, { paths: [protractorPath] });
   } catch (error) {
+    assertIsError(error);
     if (error.code !== 'MODULE_NOT_FOUND') {
       throw error;
     }

--- a/packages/angular_devkit/build_angular/src/sass/worker.ts
+++ b/packages/angular_devkit/build_angular/src/sass/worker.ts
@@ -60,7 +60,8 @@ parentPort.on('message', ({ id, hasImporter, options }: RenderRequestMessage) =>
     const result = renderSync(options);
 
     parentPort?.postMessage({ id, result });
-  } catch (error) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } catch (error: any) {
     // Needed because V8 will only serialize the message and stack properties of an Error instance.
     const { formatted, file, line, column, message, stack } = error;
     parentPort?.postMessage({ id, error: { formatted, file, line, column, message, stack } });

--- a/packages/angular_devkit/build_angular/src/testing/jasmine-helpers.ts
+++ b/packages/angular_devkit/build_angular/src/testing/jasmine-helpers.ts
@@ -95,7 +95,7 @@ export function expectFile<T>(path: string, harness: BuilderHarness<T>): Harness
       try {
         return expect(harness.readFile(path)).withContext(`With file content for '${path}'`);
       } catch (e) {
-        if (e.code !== 'ENOENT') {
+        if ((e as NodeJS.ErrnoException).code !== 'ENOENT') {
           throw e;
         }
 
@@ -112,7 +112,7 @@ export function expectFile<T>(path: string, harness: BuilderHarness<T>): Harness
           `With file size for '${path}'`,
         );
       } catch (e) {
-        if (e.code !== 'ENOENT') {
+        if ((e as NodeJS.ErrnoException).code !== 'ENOENT') {
           throw e;
         }
 

--- a/packages/angular_devkit/build_angular/src/utils/error.ts
+++ b/packages/angular_devkit/build_angular/src/utils/error.ts
@@ -1,0 +1,13 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import assert from 'assert';
+
+export function assertIsError(value: unknown): asserts value is Error & { code?: string } {
+  assert(value instanceof Error, 'catch clause variable is not an Error instance');
+}

--- a/packages/angular_devkit/build_angular/src/utils/i18n-inlining.ts
+++ b/packages/angular_devkit/build_angular/src/utils/i18n-inlining.ts
@@ -12,6 +12,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { BundleActionExecutor } from './action-executor';
 import { copyAssets } from './copy-assets';
+import { assertIsError } from './error';
 import { I18nOptions } from './i18n-options';
 import { InlineOptions } from './process-bundle';
 import { Spinner } from './spinner';
@@ -52,6 +53,7 @@ function emittedFilesToInlineOptions(
       action.map = fs.readFileSync(originalMapPath, 'utf8');
       originalFiles.push(originalMapPath);
     } catch (err) {
+      assertIsError(err);
       if (err.code !== 'ENOENT') {
         throw err;
       }
@@ -121,6 +123,7 @@ export async function i18nInlineEmittedFiles(
       '',
     );
   } catch (err) {
+    assertIsError(err);
     spinner.fail('Localized bundle generation failed: ' + err.message);
 
     return false;

--- a/packages/angular_devkit/build_angular/src/utils/process-bundle.ts
+++ b/packages/angular_devkit/build_angular/src/utils/process-bundle.ts
@@ -21,6 +21,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { workerData } from 'worker_threads';
 import { allowMinify, shouldBeautify } from './environment-options';
+import { assertIsError } from './error';
 import { I18nOptions } from './i18n-options';
 import { loadEsmModule } from './load-esm';
 
@@ -151,14 +152,14 @@ export async function inlineLocales(options: InlineOptions) {
       filename: options.filename,
     });
   } catch (error) {
-    if (error.message) {
-      // Make the error more readable.
-      // Same errors will contain the full content of the file as the error message
-      // Which makes it hard to find the actual error message.
-      const index = error.message.indexOf(')\n');
-      const msg = index !== -1 ? error.message.slice(0, index + 1) : error.message;
-      throw new Error(`${msg}\nAn error occurred inlining file "${options.filename}"`);
-    }
+    assertIsError(error);
+
+    // Make the error more readable.
+    // Same errors will contain the full content of the file as the error message
+    // Which makes it hard to find the actual error message.
+    const index = error.message.indexOf(')\n');
+    const msg = index !== -1 ? error.message.slice(0, index + 1) : error.message;
+    throw new Error(`${msg}\nAn error occurred inlining file "${options.filename}"`);
   }
 
   if (!ast) {

--- a/packages/angular_devkit/build_angular/src/utils/service-worker.ts
+++ b/packages/angular_devkit/build_angular/src/utils/service-worker.ts
@@ -11,6 +11,7 @@ import * as crypto from 'crypto';
 import { createReadStream, promises as fs, constants as fsConstants } from 'fs';
 import * as path from 'path';
 import { pipeline } from 'stream';
+import { assertIsError } from './error';
 import { loadEsmModule } from './load-esm';
 
 class CliFilesystem implements Filesystem {
@@ -78,6 +79,7 @@ export async function augmentAppWithServiceWorker(
     const configurationData = await fs.readFile(configPath, 'utf-8');
     config = JSON.parse(configurationData) as Config;
   } catch (error) {
+    assertIsError(error);
     if (error.code === 'ENOENT') {
       throw new Error(
         'Error: Expected to find an ngsw-config.json configuration file' +
@@ -130,6 +132,7 @@ export async function augmentAppWithServiceWorker(
       fsConstants.COPYFILE_FICLONE,
     );
   } catch (error) {
+    assertIsError(error);
     if (error.code !== 'ENOENT') {
       throw error;
     }

--- a/packages/angular_devkit/build_angular/src/webpack/configs/dev-server.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/dev-server.ts
@@ -13,6 +13,7 @@ import { URL, pathToFileURL } from 'url';
 import { Configuration, RuleSetRule } from 'webpack';
 import { Configuration as DevServerConfiguration } from 'webpack-dev-server';
 import { WebpackConfigOptions, WebpackDevServerOptions } from '../../utils/build-options';
+import { assertIsError } from '../../utils/error';
 import { loadEsmModule } from '../../utils/load-esm';
 import { getIndexOutputFile } from '../../utils/webpack-browser-config';
 import { HmrLoader } from '../plugins/hmr/hmr-loader';
@@ -193,6 +194,7 @@ async function addProxyConfig(root: string, proxyConfig: string | undefined) {
       try {
         return require(proxyPath);
       } catch (e) {
+        assertIsError(e);
         if (e.code === 'ERR_REQUIRE_ESM') {
           // Load the ESM configuration file using the TypeScript dynamic import workaround.
           // Once TypeScript provides support for keeping the dynamic import this workaround can be

--- a/packages/angular_devkit/build_angular/src/webpack/plugins/index-html-webpack-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/plugins/index-html-webpack-plugin.ts
@@ -8,6 +8,7 @@
 
 import { basename, dirname, extname } from 'path';
 import { Compilation, Compiler, sources } from 'webpack';
+import { assertIsError } from '../../utils/error';
 import { FileInfo } from '../../utils/index-file/augment-index-html';
 import {
   IndexHtmlGenerator,
@@ -77,6 +78,7 @@ export class IndexHtmlWebpackPlugin extends IndexHtmlGenerator {
         warnings.forEach((msg) => addWarning(this.compilation, msg));
         errors.forEach((msg) => addError(this.compilation, msg));
       } catch (error) {
+        assertIsError(error);
         addError(this.compilation, error.message);
       }
     };

--- a/packages/angular_devkit/build_angular/src/webpack/plugins/json-stats-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/plugins/json-stats-plugin.ts
@@ -9,6 +9,7 @@
 import { createWriteStream, promises as fsPromises } from 'fs';
 import { dirname } from 'path';
 import { Compiler } from 'webpack';
+import { assertIsError } from '../../utils/error';
 
 import { addError } from '../../utils/webpack-diagnostics';
 
@@ -29,6 +30,7 @@ export class JsonStatsPlugin {
             .on('error', reject),
         );
       } catch (error) {
+        assertIsError(error);
         addError(
           stats.compilation,
           `Unable to write stats file: ${error.message || 'unknown error'}`,

--- a/packages/angular_devkit/build_angular/src/webpack/plugins/postcss-cli-resources.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/plugins/postcss-cli-resources.ts
@@ -10,6 +10,7 @@ import { interpolateName } from 'loader-utils';
 import * as path from 'path';
 import { Declaration, Plugin } from 'postcss';
 import * as url from 'url';
+import { assertIsError } from '../../utils/error';
 
 function wrapUrl(url: string): string {
   let wrappedUrl;
@@ -172,6 +173,7 @@ export default function (options?: PostcssCliResourcesOptions): Plugin {
         try {
           processedUrl = await process(originalUrl, context, resourceCache);
         } catch (err) {
+          assertIsError(err);
           loader.emitError(decl.error(err.message, { word: originalUrl }));
           continue;
         }

--- a/packages/angular_devkit/build_webpack/src/utils.ts
+++ b/packages/angular_devkit/build_webpack/src/utils.ts
@@ -90,7 +90,7 @@ export async function getWebpackConfig(configPath: string): Promise<Configuratio
       try {
         return require(configPath);
       } catch (e) {
-        if (e.code === 'ERR_REQUIRE_ESM') {
+        if ((e as NodeJS.ErrnoException).code === 'ERR_REQUIRE_ESM') {
           // Load the ESM configuration file using the TypeScript dynamic import workaround.
           // Once TypeScript provides support for keeping the dynamic import this workaround can be
           // changed to a direct dynamic import.

--- a/packages/angular_devkit/build_webpack/src/webpack/index.ts
+++ b/packages/angular_devkit/build_webpack/src/webpack/index.ts
@@ -105,7 +105,7 @@ export function runWebpack(
           } catch (err) {
             if (err) {
               context.logger.error(
-                `\nAn error occurred during the build:\n${(err && err.stack) || err}`,
+                `\nAn error occurred during the build:\n${err instanceof Error ? err.stack : err}`,
               );
             }
             throw err;

--- a/packages/angular_devkit/core/node/experimental/jobs/job-registry.ts
+++ b/packages/angular_devkit/core/node/experimental/jobs/job-registry.ts
@@ -12,18 +12,15 @@ import { JsonValue, experimental as core_experimental, schema } from '../../../s
 export class NodeModuleJobRegistry<
   MinimumArgumentValueT extends JsonValue = JsonValue,
   MinimumInputValueT extends JsonValue = JsonValue,
-  MinimumOutputValueT extends JsonValue = JsonValue
+  MinimumOutputValueT extends JsonValue = JsonValue,
 > implements
-    core_experimental.jobs.Registry<
-      MinimumArgumentValueT,
-      MinimumInputValueT,
-      MinimumOutputValueT
-    > {
+    core_experimental.jobs.Registry<MinimumArgumentValueT, MinimumInputValueT, MinimumOutputValueT>
+{
   protected _resolve(name: string): string | null {
     try {
       return require.resolve(name);
     } catch (e) {
-      if (e.code === 'MODULE_NOT_FOUND') {
+      if ((e as NodeJS.ErrnoException).code === 'MODULE_NOT_FOUND') {
         return null;
       }
       throw e;

--- a/packages/angular_devkit/core/node/host.ts
+++ b/packages/angular_devkit/core/node/host.ts
@@ -45,7 +45,7 @@ function loadFSWatcher() {
       // eslint-disable-next-line import/no-extraneous-dependencies
       FSWatcher = require('chokidar').FSWatcher;
     } catch (e) {
-      if (e.code !== 'MODULE_NOT_FOUND') {
+      if ((e as NodeJS.ErrnoException).code !== 'MODULE_NOT_FOUND') {
         throw new Error(
           'As of angular-devkit version 8.0, the "chokidar" package ' +
             'must be installed in order to use watch() features.',

--- a/packages/angular_devkit/core/src/json/schema/registry.ts
+++ b/packages/angular_devkit/core/src/json/schema/registry.ts
@@ -528,20 +528,21 @@ export class CoreSchemaRegistry implements SchemaRegistry {
             !Array.isArray((parentSchema as JsonObject).default)
               ? undefined
               : ((parentSchema as JsonObject).default as string[]),
-          async validator(data: JsonValue) {
+          async validator(data: JsonValue): Promise<boolean | string> {
             try {
               const result = await it.self.validate(parentSchema, data);
               // If the schema is sync then false will be returned on validation failure
               if (result) {
-                return result;
+                return result as boolean | string;
               } else if (it.self.errors?.length) {
                 // Validation errors will be present on the Ajv instance when sync
-                return it.self.errors[0].message;
+                return it.self.errors[0].message as string;
               }
             } catch (e) {
+              const validationError = e as { errors?: Error[] };
               // If the schema is async then an error will be thrown on validation failure
-              if (Array.isArray(e.errors) && e.errors.length) {
-                return e.errors[0].message;
+              if (Array.isArray(validationError.errors) && validationError.errors.length) {
+                return validationError.errors[0].message;
               }
             }
 

--- a/packages/angular_devkit/core/src/workspace/core_spec.ts
+++ b/packages/angular_devkit/core/src/workspace/core_spec.ts
@@ -116,12 +116,9 @@ describe('readWorkspace', () => {
       },
     };
 
-    try {
-      await readWorkspace(requestedPath, host);
-      fail();
-    } catch (e) {
-      expect(e.message).toContain('Unable to determine format for workspace path');
-    }
+    await expectAsync(readWorkspace(requestedPath, host)).toBeRejectedWithError(
+      /Unable to determine format for workspace path/,
+    );
   });
 
   it('errors when reading from specified file path with invalid specified format', async () => {
@@ -146,12 +143,9 @@ describe('readWorkspace', () => {
       },
     };
 
-    try {
-      await readWorkspace(requestedPath, host, 12 as WorkspaceFormat);
-      fail();
-    } catch (e) {
-      expect(e.message).toContain('Unsupported workspace format');
-    }
+    await expectAsync(
+      readWorkspace(requestedPath, host, 12 as WorkspaceFormat),
+    ).toBeRejectedWithError(/Unsupported workspace format/);
   });
 
   it('attempts to find/read from directory path', async () => {
@@ -260,12 +254,9 @@ describe('readWorkspace', () => {
       },
     };
 
-    try {
-      await readWorkspace(requestedPath, host);
-      fail();
-    } catch (e) {
-      expect(e.message).toContain('Unable to locate a workspace file');
-    }
+    await expectAsync(readWorkspace(requestedPath, host)).toBeRejectedWithError(
+      /Unable to locate a workspace file/,
+    );
   });
 });
 
@@ -324,12 +315,9 @@ describe('writeWorkspace', () => {
       },
     };
 
-    try {
-      await writeWorkspace({} as WorkspaceDefinition, host, requestedPath, 12 as WorkspaceFormat);
-      fail();
-    } catch (e) {
-      expect(e.message).toContain('Unsupported workspace format');
-    }
+    await expectAsync(
+      writeWorkspace({} as WorkspaceDefinition, host, requestedPath, 12 as WorkspaceFormat),
+    ).toBeRejectedWithError(/Unsupported workspace format/);
   });
 
   it('errors when writing custom workspace without specified format', async () => {
@@ -356,11 +344,8 @@ describe('writeWorkspace', () => {
       },
     };
 
-    try {
-      await writeWorkspace({} as WorkspaceDefinition, host, requestedPath);
-      fail();
-    } catch (e) {
-      expect(e.message).toContain('A format is required');
-    }
+    await expectAsync(
+      writeWorkspace({} as WorkspaceDefinition, host, requestedPath),
+    ).toBeRejectedWithError(/A format is required/);
   });
 });

--- a/packages/angular_devkit/core/src/workspace/json/reader_spec.ts
+++ b/packages/angular_devkit/core/src/workspace/json/reader_spec.ts
@@ -120,12 +120,9 @@ describe('readJsonWorkpace Parsing', () => {
       }
     `);
 
-    try {
-      await readJsonWorkspace('', host);
-      fail();
-    } catch (e) {
-      expect(e.message).toContain('Invalid format version detected');
-    }
+    await expectAsync(readJsonWorkspace('', host)).toBeRejectedWithError(
+      /Invalid format version detected/,
+    );
   });
 
   it('errors on missing version', async () => {
@@ -136,12 +133,9 @@ describe('readJsonWorkpace Parsing', () => {
       }
     `);
 
-    try {
-      await readJsonWorkspace('', host);
-      fail();
-    } catch (e) {
-      expect(e.message).toContain('version specifier not found');
-    }
+    await expectAsync(readJsonWorkspace('', host)).toBeRejectedWithError(
+      /version specifier not found/,
+    );
   });
 });
 

--- a/packages/angular_devkit/core/src/workspace/json/writer_spec.ts
+++ b/packages/angular_devkit/core/src/workspace/json/writer_spec.ts
@@ -45,7 +45,7 @@ function createTestCaseHost(inputData = '') {
         );
         expect(data).toEqual(testCase);
       } catch (e) {
-        fail(`Unable to load test case '${path}': ${e.message || e}`);
+        fail(`Unable to load test case '${path}': ${e instanceof Error ? e.message : e}`);
       }
     },
     async isFile() {

--- a/packages/angular_devkit/schematics/src/rules/template.ts
+++ b/packages/angular_devkit/schematics/src/rules/template.ts
@@ -63,7 +63,7 @@ export function applyContentTemplate<T>(options: T): FileOperator {
         content: Buffer.from(templateImpl(decodedContent, {})(options)),
       };
     } catch (e) {
-      if (e.code === 'ERR_ENCODING_INVALID_ENCODED_DATA') {
+      if ((e as NodeJS.ErrnoException).code === 'ERR_ENCODING_INVALID_ENCODED_DATA') {
         return entry;
       }
 

--- a/packages/angular_devkit/schematics/tools/node-module-engine-host.ts
+++ b/packages/angular_devkit/schematics/tools/node-module-engine-host.ts
@@ -67,7 +67,7 @@ export class NodeModulesEngineHost extends FileSystemEngineHostBase {
 
       collectionPath = this.resolve(schematics, packageJsonPath, references);
     } catch (e) {
-      if (e.code !== 'MODULE_NOT_FOUND') {
+      if ((e as NodeJS.ErrnoException).code !== 'MODULE_NOT_FOUND') {
         throw e;
       }
     }
@@ -77,7 +77,7 @@ export class NodeModulesEngineHost extends FileSystemEngineHostBase {
       try {
         collectionPath = require.resolve(name, resolveOptions);
       } catch (e) {
-        if (e.code !== 'MODULE_NOT_FOUND') {
+        if ((e as NodeJS.ErrnoException).code !== 'MODULE_NOT_FOUND') {
           throw e;
         }
       }

--- a/packages/angular_devkit/schematics_cli/bin/schematics.ts
+++ b/packages/angular_devkit/schematics_cli/bin/schematics.ts
@@ -57,7 +57,7 @@ function _listSchematics(workflow: NodeWorkflow, collectionName: string, logger:
     const collection = workflow.engine.createCollection(collectionName);
     logger.info(collection.listSchematicNames().join('\n'));
   } catch (error) {
-    logger.fatal(error.message);
+    logger.fatal(error instanceof Error ? error.message : `${error}`);
 
     return 1;
   }
@@ -285,10 +285,10 @@ export async function main({
     if (err instanceof UnsuccessfulWorkflowExecution) {
       // "See above" because we already printed the error.
       logger.fatal('The Schematic workflow failed. See above.');
-    } else if (debug) {
+    } else if (debug && err instanceof Error) {
       logger.fatal(`An error occured:\n${err.stack}`);
     } else {
-      logger.fatal(`Error: ${err.message}`);
+      logger.fatal(`Error: ${err instanceof Error ? err.message : err}`);
     }
 
     return 1;

--- a/packages/ngtools/webpack/src/resource_loader.ts
+++ b/packages/ngtools/webpack/src/resource_loader.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import assert from 'assert';
 import * as path from 'path';
 import * as vm from 'vm';
 import type { Asset, Compilation } from 'webpack';
@@ -115,6 +116,7 @@ export class WebpackResourceLoader {
     const {
       EntryPlugin,
       NormalModule,
+      WebpackError,
       library,
       node,
       sources,
@@ -208,8 +210,9 @@ export class WebpackResourceLoader {
               compilation.assets[outputFilePath] = new sources.RawSource(output);
             }
           } catch (error) {
+            assert(error instanceof Error, 'catch clause variable is not an Error instance');
             // Use compilation errors, as otherwise webpack will choke
-            compilation.errors.push(error);
+            compilation.errors.push(new WebpackError(error.message));
           }
         });
       },

--- a/packages/schematics/angular/component/index_spec.ts
+++ b/packages/schematics/angular/component/index_spec.ts
@@ -159,13 +159,10 @@ describe('Component Schematic', () => {
 
   it('should fail if specified module does not exist', async () => {
     const options = { ...defaultOptions, module: '/projects/bar/src/app.moduleXXX.ts' };
-    let thrownError: Error | null = null;
-    try {
-      await schematicRunner.runSchematicAsync('component', options, appTree).toPromise();
-    } catch (err) {
-      thrownError = err;
-    }
-    expect(thrownError).toBeDefined();
+
+    await expectAsync(
+      schematicRunner.runSchematicAsync('component', options, appTree).toPromise(),
+    ).toBeRejected();
   });
 
   it('should handle upper case paths', async () => {

--- a/packages/schematics/angular/directive/index_spec.ts
+++ b/packages/schematics/angular/directive/index_spec.ts
@@ -108,13 +108,10 @@ describe('Directive Schematic', () => {
 
   it('should fail if specified module does not exist', async () => {
     const options = { ...defaultOptions, module: '/projects/bar/src/app/app.moduleXXX.ts' };
-    let thrownError: Error | null = null;
-    try {
-      await schematicRunner.runSchematicAsync('directive', options, appTree).toPromise();
-    } catch (err) {
-      thrownError = err;
-    }
-    expect(thrownError).toBeDefined();
+
+    await expectAsync(
+      schematicRunner.runSchematicAsync('directive', options, appTree).toPromise(),
+    ).toBeRejected();
   });
 
   it('should converts dash-cased-name to a camelCasedSelector', async () => {

--- a/packages/schematics/angular/pipe/index_spec.ts
+++ b/packages/schematics/angular/pipe/index_spec.ts
@@ -72,13 +72,10 @@ describe('Pipe Schematic', () => {
 
   it('should fail if specified module does not exist', async () => {
     const options = { ...defaultOptions, module: '/projects/bar/src/app/app.moduleXXX.ts' };
-    let thrownError: Error | null = null;
-    try {
-      await schematicRunner.runSchematicAsync('pipe', options, appTree).toPromise();
-    } catch (err) {
-      thrownError = err;
-    }
-    expect(thrownError).toBeDefined();
+
+    await expectAsync(
+      schematicRunner.runSchematicAsync('pipe', options, appTree).toPromise(),
+    ).toBeRejected();
   });
 
   it('should handle a path in the name and module options', async () => {

--- a/packages/schematics/angular/utility/find-module_spec.ts
+++ b/packages/schematics/angular/utility/find-module_spec.ts
@@ -43,34 +43,24 @@ describe('find-module', () => {
 
     it('should throw if no modules found', () => {
       host.create('/foo/src/app/oops.module.ts', 'app module');
-      try {
-        findModule(host, 'foo/src/app/bar');
-        throw new Error('Succeeded, should have failed');
-      } catch (err) {
-        expect(err.message).toMatch(/More than one module matches/);
-      }
+
+      expect(() => findModule(host, 'foo/src/app/bar')).toThrowError(
+        /More than one module matches/,
+      );
     });
 
     it('should throw if only routing modules were found', () => {
       host = new EmptyTree();
       host.create('/foo/src/app/anything-routing.module.ts', 'anything routing module');
 
-      try {
-        findModule(host, 'foo/src/app/anything-routing');
-        throw new Error('Succeeded, should have failed');
-      } catch (err) {
-        expect(err.message).toMatch(/Could not find a non Routing NgModule/);
-      }
+      expect(() => findModule(host, 'foo/src/app/anything-routing')).toThrowError(
+        /Could not find a non Routing NgModule/,
+      );
     });
 
     it('should throw if two modules found', () => {
-      try {
-        host = new EmptyTree();
-        findModule(host, 'foo/src/app/bar');
-        throw new Error('Succeeded, should have failed');
-      } catch (err) {
-        expect(err.message).toMatch(/Could not find an NgModule/);
-      }
+      host = new EmptyTree();
+      expect(() => findModule(host, 'foo/src/app/bar')).toThrowError(/Could not find an NgModule/);
     });
 
     it('should accept custom ext for module', () => {

--- a/tests/legacy-cli/e2e/tests/commands/add/add-material.ts
+++ b/tests/legacy-cli/e2e/tests/commands/add/add-material.ts
@@ -12,7 +12,7 @@ export default async function () {
   try {
     await ng('add', `@angular/material${tag}`, '--unknown', '--skip-confirmation');
   } catch (error) {
-    if (!(error.message && error.message.includes(`Unknown option: '--unknown'`))) {
+    if (!(error instanceof Error && error.message.includes(`Unknown option: '--unknown'`))) {
       throw error;
     }
   }

--- a/tests/legacy-cli/e2e/tests/commands/help/help-json.ts
+++ b/tests/legacy-cli/e2e/tests/commands/help/help-json.ts
@@ -52,13 +52,21 @@ export default async function () {
   try {
     JSON.parse(stdout2.trim());
   } catch (error) {
-    throw new Error(`'ng --help ---json-help' failed to return JSON.\n${error.message}`);
+    throw new Error(
+      `'ng --help ---json-help' failed to return JSON.\n${
+        error instanceof Error ? error.message : error
+      }`,
+    );
   }
 
   const { stdout: stdout3 } = await silentNg('generate', '--help', '--json-help');
   try {
     JSON.parse(stdout3.trim());
   } catch (error) {
-    throw new Error(`'ng generate --help ---json-help' failed to return JSON.\n${error.message}`);
+    throw new Error(
+      `'ng generate --help ---json-help' failed to return JSON.\n${
+        error instanceof Error ? error.message : error
+      }`,
+    );
   }
 }

--- a/tests/legacy-cli/e2e/tests/commands/unknown-configuration.ts
+++ b/tests/legacy-cli/e2e/tests/commands/unknown-configuration.ts
@@ -5,7 +5,12 @@ export default async function () {
     await ng('build', '--configuration', 'invalid');
     throw new Error('should have failed.');
   } catch (error) {
-    if (!error.message.includes(`Configuration 'invalid' is not set in the workspace`)) {
+    if (
+      !(
+        error instanceof Error &&
+        error.message.includes(`Configuration 'invalid' is not set in the workspace`)
+      )
+    ) {
       throw error;
     }
   }

--- a/tests/legacy-cli/e2e/tests/misc/http-headers.ts
+++ b/tests/legacy-cli/e2e/tests/misc/http-headers.ts
@@ -28,7 +28,7 @@ export default async function () {
   try {
     await ng('e2e');
   } catch (error) {
-    errorMessage = error.message;
+    errorMessage = error instanceof Error ? error.message : null;
   }
 
   if (!errorMessage) {

--- a/tests/legacy-cli/e2e/tests/test/test-sourcemap.ts
+++ b/tests/legacy-cli/e2e/tests/test/test-sourcemap.ts
@@ -16,7 +16,7 @@ export default async function () {
     await ng('test', '--no-watch', '--source-map');
     throw new Error('ng test should have failed.');
   } catch (error) {
-    if (!error.message.includes('app.component.spec.ts')) {
+    if (!(error instanceof Error && error.message.includes('app.component.spec.ts'))) {
       throw error;
     }
   }
@@ -26,7 +26,7 @@ export default async function () {
     await ng('test', '--no-watch', '--no-source-map');
     throw new Error('ng test should have failed.');
   } catch (error) {
-    if (!error.message.includes('main.js')) {
+    if (!(error instanceof Error && error.message.includes('main.js'))) {
       throw error;
     }
   }

--- a/tests/legacy-cli/e2e/utils/process.ts
+++ b/tests/legacy-cli/e2e/utils/process.ts
@@ -242,7 +242,10 @@ export async function execAndCaptureError(
     await _exec({ env, stdin }, cmd, args);
     throw new Error('Tried to capture subprocess exception, but it completed successfully.');
   } catch (err) {
-    return err;
+    if (err instanceof Error) {
+      return err;
+    }
+    throw new Error('Subprocess exception was not an Error instance');
   }
 }
 

--- a/tests/legacy-cli/e2e_runner.ts
+++ b/tests/legacy-cli/e2e_runner.ts
@@ -139,9 +139,13 @@ Promise.all([findFreePort(), findFreePort()])
 
       console.log(colors.green('Done.'));
     } catch (err) {
-      console.log('\n');
-      console.error(colors.red(err.message));
-      console.error(colors.red(err.stack));
+      if (err instanceof Error) {
+        console.log('\n');
+        console.error(colors.red(err.message));
+        if (err.stack) {
+          console.error(colors.red(err.stack));
+        }
+      }
 
       if (argv.debug) {
         console.log(`Current Directory: ${process.cwd()}`);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,6 @@
     "noImplicitOverride": true,
     "noUnusedParameters": false,
     "noUnusedLocals": false,
-    "useUnknownInCatchVariables": false,
     "outDir": "./dist",
     "rootDir": ".",
     "skipLibCheck": true,


### PR DESCRIPTION
Enables the TypeScript `useUnknownInCatchVariables` option. This option
provides additional code safety by ensuring that the catch clause variable
is the proper type before attempting to access its properties.

Closes #22465