### PR TITLE
fix(@angular/cli): disable version check when running `ng completion` commands

### DIFF
--- a/packages/angular/cli/lib/init.ts
+++ b/packages/angular/cli/lib/init.ts
@@ -78,11 +78,13 @@ let forceExit = false;
       console.error('Version mismatch check skipped. Unable to compare local version: ' + error);
     }
 
-    if (isGlobalGreater) {
+    const rawCommandName = process.argv[2];
+    // When using the completion command, don't show the warning as otherwise this will break completion.
+    if (isGlobalGreater && rawCommandName !== 'completion') {
       // If using the update command and the global version is greater, use the newer update command
       // This allows improvements in update to be used in older versions that do not have bootstrapping
       if (
-        process.argv[2] === 'update' &&
+        rawCommandName === 'update' &&
         cli.VERSION &&
         cli.VERSION.major - globalVersion.major <= 1
       ) {


### PR DESCRIPTION

Running autocompletion with `14.0.1` installed globally in a `14.0.0` project logs the version warning in a very annoying fashion:

```
$ ng verYour global Angular CLI version (14.0.1) is greater than your local version (14.0.0). The local Angular CLI version is used.

To disable this warning use "ng config -g cli.warnings.versionMismatch false".
sion
```

This adds an exception for `ng completion` commands to avoid this edge case.