### PR TITLE
fix(@angular/cli): provide an actionable error when using `--configuration` with `ng run`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,7 @@ Alan Agius, Charles Lyding and Doug Parker
 - Support for TypeScript 4.4 and 4.5 has been removed. Please update to TypeScript 4.6.
 - `--all` option from `ng update` has been removed without replacement. To update packages which don’t provide `ng update` capabilities in your workspace `package.json` use `npm update`, `yarn upgrade-interactive` or `yarn upgrade` instead.
 - Deprecated option `--prod` has been removed from all builders. `--configuration production`/`-c production` should be used instead if the default configuration of the builder is not configured to `production`.
+- `--configuration` cannot be used with `ng run`. Provide the configuration as part of the target. Ex: `ng run project:builder:configuration`.
 - Deprecated `ng x18n` and `ng i18n-extract` commands have been removed in favor of `ng extract-i18n`.
 - Several changes in the Angular CLI commands and arguments handling.
 

--- a/packages/angular/cli/src/commands/run/cli.ts
+++ b/packages/angular/cli/src/commands/run/cli.ts
@@ -45,6 +45,21 @@ export class RunCommandModule
         // Also, hide choices from JSON help so that we don't display them in AIO.
         choices: (getYargsCompletions || help) && !jsonHelp ? this.getTargetChoices() : undefined,
       })
+      .middleware((args) => {
+        // TODO: remove in version 15.
+        const { configuration, target } = args;
+        if (typeof configuration === 'string' && target) {
+          const targetWithConfig = target.split(':', 2);
+          targetWithConfig.push(configuration);
+
+          throw new CommandModuleError(
+            'Unknown argument: configuration.\n' +
+              `Provide the configuration as part of the target 'ng run ${targetWithConfig.join(
+                ':',
+              )}'.`,
+          );
+        }
+      }, true)
       .strict();
 
     const target = this.makeTargetSpecifier();

--- a/tests/legacy-cli/e2e/tests/basic/run.ts
+++ b/tests/legacy-cli/e2e/tests/basic/run.ts
@@ -1,0 +1,18 @@
+import { getGlobalVariable } from '../../utils/env';
+import { expectFileToMatch } from '../../utils/fs';
+import { silentNg } from '../../utils/process';
+
+export default async function () {
+  // Development build
+  await silentNg('run', 'test-project:build:development');
+  await expectFileToMatch('dist/test-project/index.html', 'main.js');
+
+  // Production build
+  await silentNg('run', 'test-project:build');
+  if (getGlobalVariable('argv')['esbuild']) {
+    // esbuild uses an 8 character hash
+    await expectFileToMatch('dist/test-project/index.html', /main\.[a-zA-Z0-9]{8}\.js/);
+  } else {
+    await expectFileToMatch('dist/test-project/index.html', /main\.[a-zA-Z0-9]{16}\.js/);
+  }
+}

--- a/tests/legacy-cli/e2e/tests/commands/run-configuration-option.ts
+++ b/tests/legacy-cli/e2e/tests/commands/run-configuration-option.ts
@@ -1,0 +1,26 @@
+import { silentNg } from '../../utils/process';
+import { expectToFail } from '../../utils/utils';
+
+export default async function () {
+  const errorMatch = `Provide the configuration as part of the target 'ng run test-project:build:production`;
+
+  {
+    const { message } = await expectToFail(() =>
+      silentNg('run', 'test-project:build:development', '--configuration=production'),
+    );
+
+    if (!message.includes(errorMatch)) {
+      throw new Error(`Expected error to include '${errorMatch}' but didn't.\n\n${message}`);
+    }
+  }
+
+  {
+    const { message } = await expectToFail(() =>
+      silentNg('run', 'test-project:build', '--configuration=production'),
+    );
+
+    if (!message.includes(errorMatch)) {
+      throw new Error(`Expected error to include '${errorMatch}' but didn't.\n\n${message}`);
+    }
+  }
+}


### PR DESCRIPTION


    
With this commit we issue a more actionable error message when using the unsupported
    `--configuration` option with the`ng run` command.
    
    Closes #23385
