### PR TITLE
    feat(@angular-devkit/build-angular): add `externalDependencies` to the esbuild browser builder

### DIFF
--- a/packages/angular/cli/BUILD.bazel
+++ b/packages/angular/cli/BUILD.bazel
@@ -85,6 +85,7 @@ ts_library(
 CLI_SCHEMA_DATA = [
     "//packages/angular_devkit/build_angular:src/builders/app-shell/schema.json",
     "//packages/angular_devkit/build_angular:src/builders/browser/schema.json",
+    "//packages/angular_devkit/build_angular:src/builders/browser-esbuild/schema.json",
     "//packages/angular_devkit/build_angular:src/builders/dev-server/schema.json",
     "//packages/angular_devkit/build_angular:src/builders/extract-i18n/schema.json",
     "//packages/angular_devkit/build_angular:src/builders/karma/schema.json",

--- a/packages/angular/cli/lib/config/workspace-schema.json
+++ b/packages/angular/cli/lib/config/workspace-schema.json
@@ -341,6 +341,7 @@
                     "enum": [
                       "@angular-devkit/build-angular:app-shell",
                       "@angular-devkit/build-angular:browser",
+                      "@angular-devkit/build-angular:browser-esbuild",
                       "@angular-devkit/build-angular:dev-server",
                       "@angular-devkit/build-angular:extract-i18n",
                       "@angular-devkit/build-angular:karma",
@@ -408,6 +409,28 @@
                   "type": "object",
                   "additionalProperties": {
                     "$ref": "../../../../angular_devkit/build_angular/src/builders/browser/schema.json"
+                  }
+                }
+              }
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "builder": {
+                  "const": "@angular-devkit/build-angular:browser-esbuild"
+                },
+                "defaultConfiguration": {
+                  "type": "string",
+                  "description": "A default named configuration to use when a target configuration is not provided."
+                },
+                "options": {
+                  "$ref": "../../../../angular_devkit/build_angular/src/builders/browser-esbuild/schema.json"
+                },
+                "configurations": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "$ref": "../../../../angular_devkit/build_angular/src/builders/browser-esbuild/schema.json"
                   }
                 }
               }

--- a/packages/angular_devkit/build_angular/BUILD.bazel
+++ b/packages/angular_devkit/build_angular/BUILD.bazel
@@ -23,6 +23,11 @@ ts_json_schema(
 )
 
 ts_json_schema(
+    name = "browser_esbuild_schema",
+    src = "src/builders/browser-esbuild/schema.json",
+)
+
+ts_json_schema(
     name = "dev_server_schema",
     src = "src/builders/dev-server/schema.json",
 )
@@ -70,6 +75,7 @@ ts_library(
     ) + [
         "//packages/angular_devkit/build_angular:src/builders/app-shell/schema.ts",
         "//packages/angular_devkit/build_angular:src/builders/browser/schema.ts",
+        "//packages/angular_devkit/build_angular:src/builders/browser-esbuild/schema.ts",
         "//packages/angular_devkit/build_angular:src/builders/dev-server/schema.ts",
         "//packages/angular_devkit/build_angular:src/builders/extract-i18n/schema.ts",
         "//packages/angular_devkit/build_angular:src/builders/karma/schema.ts",

--- a/packages/angular_devkit/build_angular/BUILD.bazel
+++ b/packages/angular_devkit/build_angular/BUILD.bazel
@@ -340,6 +340,7 @@ LARGE_SPECS = {
             "@npm//popper.js",
         ],
     },
+    "browser-esbuild": {},
 }
 
 [

--- a/packages/angular_devkit/build_angular/builders.json
+++ b/packages/angular_devkit/build_angular/builders.json
@@ -13,7 +13,7 @@
     },
     "browser-esbuild": {
       "implementation": "./src/builders/browser-esbuild",
-      "schema": "./src/builders/browser/schema.json",
+      "schema": "./src/builders/browser-esbuild/schema.json",
       "description": "Build a browser application."
     },
     "dev-server": {

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
@@ -20,11 +20,11 @@ import { generateEntryPoints } from '../../utils/package-chunk-sort';
 import { augmentAppWithServiceWorker } from '../../utils/service-worker';
 import { getIndexInputFile, getIndexOutputFile } from '../../utils/webpack-browser-config';
 import { resolveGlobalStyles } from '../../webpack/configs';
-import { Schema as BrowserBuilderOptions, SourceMapClass } from '../browser/schema';
 import { createCompilerPlugin } from './compiler-plugin';
 import { DEFAULT_OUTDIR, bundle, logMessages } from './esbuild';
 import { logExperimentalWarnings } from './experimental-warnings';
 import { normalizeOptions } from './options';
+import { Schema as BrowserBuilderOptions, SourceMapClass } from './schema';
 import { bundleStylesheetText } from './stylesheets';
 
 /**
@@ -35,7 +35,7 @@ import { bundleStylesheetText } from './stylesheets';
  * @returns A promise with the builder result output
  */
 // eslint-disable-next-line max-lines-per-function
-export async function execute(
+export async function buildEsbuildBrowser(
   options: BrowserBuilderOptions,
   context: BuilderContext,
 ): Promise<BuilderOutput> {
@@ -312,6 +312,7 @@ async function bundleCode(
     sourcemap: sourcemapOptions.scripts && (sourcemapOptions.hidden ? 'external' : true),
     splitting: true,
     tsconfig,
+    external: options.externalDependencies,
     write: false,
     platform: 'browser',
     preserveSymlinks: options.preserveSymlinks,
@@ -339,4 +340,4 @@ async function bundleCode(
   });
 }
 
-export default createBuilder(execute);
+export default createBuilder(buildEsbuildBrowser);

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/schema.json
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/schema.json
@@ -1,0 +1,542 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "title": "Esbuild browser schema for Build Facade.",
+  "description": "Browser target options",
+  "type": "object",
+  "properties": {
+    "assets": {
+      "type": "array",
+      "description": "List of static application assets.",
+      "default": [],
+      "items": {
+        "$ref": "#/definitions/assetPattern"
+      }
+    },
+    "main": {
+      "type": "string",
+      "description": "The full path for the main entry point to the app, relative to the current workspace."
+    },
+    "polyfills": {
+      "type": "string",
+      "description": "The full path for the polyfills file, relative to the current workspace."
+    },
+    "tsConfig": {
+      "type": "string",
+      "description": "The full path for the TypeScript configuration file, relative to the current workspace."
+    },
+    "scripts": {
+      "description": "Global scripts to be included in the build.",
+      "type": "array",
+      "default": [],
+      "items": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "input": {
+                "type": "string",
+                "description": "The file to include.",
+                "pattern": "\\.[cm]?jsx?$"
+              },
+              "bundleName": {
+                "type": "string",
+                "pattern": "^[\\w\\-.]*$",
+                "description": "The bundle name for this extra entry point."
+              },
+              "inject": {
+                "type": "boolean",
+                "description": "If the bundle will be referenced in the HTML file.",
+                "default": true
+              }
+            },
+            "additionalProperties": false,
+            "required": ["input"]
+          },
+          {
+            "type": "string",
+            "description": "The file to include.",
+            "pattern": "\\.[cm]?jsx?$"
+          }
+        ]
+      }
+    },
+    "styles": {
+      "description": "Global styles to be included in the build.",
+      "type": "array",
+      "default": [],
+      "items": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "input": {
+                "type": "string",
+                "description": "The file to include.",
+                "pattern": "\\.(?:css|scss|sass|less|styl)$"
+              },
+              "bundleName": {
+                "type": "string",
+                "pattern": "^[\\w\\-.]*$",
+                "description": "The bundle name for this extra entry point."
+              },
+              "inject": {
+                "type": "boolean",
+                "description": "If the bundle will be referenced in the HTML file.",
+                "default": true
+              }
+            },
+            "additionalProperties": false,
+            "required": ["input"]
+          },
+          {
+            "type": "string",
+            "description": "The file to include.",
+            "pattern": "\\.(?:css|scss|sass|less|styl)$"
+          }
+        ]
+      }
+    },
+    "inlineStyleLanguage": {
+      "description": "The stylesheet language to use for the application's inline component styles.",
+      "type": "string",
+      "default": "css",
+      "enum": ["css", "less", "sass", "scss"]
+    },
+    "stylePreprocessorOptions": {
+      "description": "Options to pass to style preprocessors.",
+      "type": "object",
+      "properties": {
+        "includePaths": {
+          "description": "Paths to include. Paths will be resolved to workspace root.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        }
+      },
+      "additionalProperties": false
+    },
+    "externalDependencies": {
+      "description": "Exclude the listed external dependencies from being bundled into the bundle. Instead, the created bundle relies on these dependencies to be available during runtime.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": []
+    },
+    "optimization": {
+      "description": "Enables optimization of the build output. Including minification of scripts and styles, tree-shaking, dead-code elimination, inlining of critical CSS and fonts inlining. For more information, see https://angular.io/guide/workspace-config#optimization-configuration.",
+      "x-user-analytics": 16,
+      "default": true,
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "scripts": {
+              "type": "boolean",
+              "description": "Enables optimization of the scripts output.",
+              "default": true
+            },
+            "styles": {
+              "description": "Enables optimization of the styles output.",
+              "default": true,
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "minify": {
+                      "type": "boolean",
+                      "description": "Minify CSS definitions by removing extraneous whitespace and comments, merging identifiers and minimizing values.",
+                      "default": true
+                    },
+                    "inlineCritical": {
+                      "type": "boolean",
+                      "description": "Extract and inline critical CSS definitions to improve first paint time.",
+                      "default": true
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "boolean"
+                }
+              ]
+            },
+            "fonts": {
+              "description": "Enables optimization for fonts. This option requires internet access. `HTTPS_PROXY` environment variable can be used to specify a proxy server.",
+              "default": true,
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "inline": {
+                      "type": "boolean",
+                      "description": "Reduce render blocking requests by inlining external Google Fonts and Adobe Fonts CSS definitions in the application's HTML index file. This option requires internet access. `HTTPS_PROXY` environment variable can be used to specify a proxy server.",
+                      "default": true
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "boolean"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "boolean"
+        }
+      ]
+    },
+    "fileReplacements": {
+      "description": "Replace compilation source files with other compilation source files in the build.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/fileReplacement"
+      },
+      "default": []
+    },
+    "outputPath": {
+      "type": "string",
+      "description": "The full path for the new output directory, relative to the current workspace.\nBy default, writes output to a folder named dist/ in the current project."
+    },
+    "resourcesOutputPath": {
+      "type": "string",
+      "description": "The path where style resources will be placed, relative to outputPath."
+    },
+    "aot": {
+      "type": "boolean",
+      "description": "Build using Ahead of Time compilation.",
+      "x-user-analytics": 13,
+      "default": true
+    },
+    "sourceMap": {
+      "description": "Output source maps for scripts and styles. For more information, see https://angular.io/guide/workspace-config#source-map-configuration.",
+      "default": false,
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "scripts": {
+              "type": "boolean",
+              "description": "Output source maps for all scripts.",
+              "default": true
+            },
+            "styles": {
+              "type": "boolean",
+              "description": "Output source maps for all styles.",
+              "default": true
+            },
+            "hidden": {
+              "type": "boolean",
+              "description": "Output source maps used for error reporting tools.",
+              "default": false
+            },
+            "vendor": {
+              "type": "boolean",
+              "description": "Resolve vendor packages source maps.",
+              "default": false
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "boolean"
+        }
+      ]
+    },
+    "vendorChunk": {
+      "type": "boolean",
+      "description": "Generate a seperate bundle containing only vendor libraries. This option should only used for development.",
+      "default": false
+    },
+    "commonChunk": {
+      "type": "boolean",
+      "description": "Generate a seperate bundle containing code used across multiple bundles.",
+      "default": true
+    },
+    "baseHref": {
+      "type": "string",
+      "description": "Base url for the application being built."
+    },
+    "deployUrl": {
+      "type": "string",
+      "description": "URL where files will be deployed.",
+      "x-deprecated": "Use \"baseHref\" option, \"APP_BASE_HREF\" DI token or a combination of both instead. For more information, see https://angular.io/guide/deployment#the-deploy-url."
+    },
+    "verbose": {
+      "type": "boolean",
+      "description": "Adds more details to output logging.",
+      "default": false
+    },
+    "progress": {
+      "type": "boolean",
+      "description": "Log progress to the console while building.",
+      "default": true
+    },
+    "i18nMissingTranslation": {
+      "type": "string",
+      "description": "How to handle missing translations for i18n.",
+      "enum": ["warning", "error", "ignore"],
+      "default": "warning"
+    },
+    "i18nDuplicateTranslation": {
+      "type": "string",
+      "description": "How to handle duplicate translations for i18n.",
+      "enum": ["warning", "error", "ignore"],
+      "default": "warning"
+    },
+    "localize": {
+      "description": "Translate the bundles in one or more locales.",
+      "oneOf": [
+        {
+          "type": "boolean",
+          "description": "Translate all locales."
+        },
+        {
+          "type": "array",
+          "description": "List of locales ID's to translate.",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "pattern": "^[a-zA-Z]{2,3}(-[a-zA-Z]{4})?(-([a-zA-Z]{2}|[0-9]{3}))?(-[a-zA-Z]{5,8})?(-x(-[a-zA-Z0-9]{1,8})+)?$"
+          }
+        }
+      ]
+    },
+    "watch": {
+      "type": "boolean",
+      "description": "Run build when files change.",
+      "default": false
+    },
+    "outputHashing": {
+      "type": "string",
+      "description": "Define the output filename cache-busting hashing mode.",
+      "default": "none",
+      "enum": ["none", "all", "media", "bundles"]
+    },
+    "poll": {
+      "type": "number",
+      "description": "Enable and define the file watching poll time period in milliseconds."
+    },
+    "deleteOutputPath": {
+      "type": "boolean",
+      "description": "Delete the output path before building.",
+      "default": true
+    },
+    "preserveSymlinks": {
+      "type": "boolean",
+      "description": "Do not use the real path when resolving modules. If unset then will default to `true` if NodeJS option --preserve-symlinks is set."
+    },
+    "extractLicenses": {
+      "type": "boolean",
+      "description": "Extract all licenses in a separate file.",
+      "default": true
+    },
+    "buildOptimizer": {
+      "type": "boolean",
+      "description": "Enables advanced build optimizations when using the 'aot' option.",
+      "default": true
+    },
+    "namedChunks": {
+      "type": "boolean",
+      "description": "Use file name for lazy loaded chunks.",
+      "default": false
+    },
+    "subresourceIntegrity": {
+      "type": "boolean",
+      "description": "Enables the use of subresource integrity validation.",
+      "default": false
+    },
+    "serviceWorker": {
+      "type": "boolean",
+      "description": "Generates a service worker config for production builds.",
+      "default": false
+    },
+    "ngswConfigPath": {
+      "type": "string",
+      "description": "Path to ngsw-config.json."
+    },
+    "index": {
+      "description": "Configures the generation of the application's HTML index.",
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "The path of a file to use for the application's HTML index. The filename of the specified path will be used for the generated file and will be created in the root of the application's configured output path."
+        },
+        {
+          "type": "object",
+          "description": "",
+          "properties": {
+            "input": {
+              "type": "string",
+              "minLength": 1,
+              "description": "The path of a file to use for the application's generated HTML index."
+            },
+            "output": {
+              "type": "string",
+              "minLength": 1,
+              "default": "index.html",
+              "description": "The output path of the application's generated HTML index file. The full provided path will be used and will be considered relative to the application's configured output path."
+            }
+          },
+          "required": ["input"]
+        }
+      ]
+    },
+    "statsJson": {
+      "type": "boolean",
+      "description": "Generates a 'stats.json' file which can be analyzed using tools such as 'webpack-bundle-analyzer'.",
+      "default": false
+    },
+    "budgets": {
+      "description": "Budget thresholds to ensure parts of your application stay within boundaries which you set.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/budget"
+      },
+      "default": []
+    },
+    "webWorkerTsConfig": {
+      "type": "string",
+      "description": "TypeScript configuration for Web Worker modules."
+    },
+    "crossOrigin": {
+      "type": "string",
+      "description": "Define the crossorigin attribute setting of elements that provide CORS support.",
+      "default": "none",
+      "enum": ["none", "anonymous", "use-credentials"]
+    },
+    "allowedCommonJsDependencies": {
+      "description": "A list of CommonJS packages that are allowed to be used without a build time warning.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": []
+    }
+  },
+  "additionalProperties": false,
+  "required": ["outputPath", "index", "main", "tsConfig"],
+  "definitions": {
+    "assetPattern": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "followSymlinks": {
+              "type": "boolean",
+              "default": false,
+              "description": "Allow glob patterns to follow symlink directories. This allows subdirectories of the symlink to be searched."
+            },
+            "glob": {
+              "type": "string",
+              "description": "The pattern to match."
+            },
+            "input": {
+              "type": "string",
+              "description": "The input directory path in which to apply 'glob'. Defaults to the project root."
+            },
+            "ignore": {
+              "description": "An array of globs to ignore.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "output": {
+              "type": "string",
+              "description": "Absolute path within the output."
+            }
+          },
+          "additionalProperties": false,
+          "required": ["glob", "input", "output"]
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "fileReplacement": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "src": {
+              "type": "string",
+              "pattern": "\\.(([cm]?j|t)sx?|json)$"
+            },
+            "replaceWith": {
+              "type": "string",
+              "pattern": "\\.(([cm]?j|t)sx?|json)$"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["src", "replaceWith"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "replace": {
+              "type": "string",
+              "pattern": "\\.(([cm]?j|t)sx?|json)$"
+            },
+            "with": {
+              "type": "string",
+              "pattern": "\\.(([cm]?j|t)sx?|json)$"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["replace", "with"]
+        }
+      ]
+    },
+    "budget": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The type of budget.",
+          "enum": ["all", "allScript", "any", "anyScript", "anyComponentStyle", "bundle", "initial"]
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the bundle."
+        },
+        "baseline": {
+          "type": "string",
+          "description": "The baseline size for comparison."
+        },
+        "maximumWarning": {
+          "type": "string",
+          "description": "The maximum threshold for warning relative to the baseline."
+        },
+        "maximumError": {
+          "type": "string",
+          "description": "The maximum threshold for error relative to the baseline."
+        },
+        "minimumWarning": {
+          "type": "string",
+          "description": "The minimum threshold for warning relative to the baseline."
+        },
+        "minimumError": {
+          "type": "string",
+          "description": "The minimum threshold for error relative to the baseline."
+        },
+        "warning": {
+          "type": "string",
+          "description": "The threshold for warning relative to the baseline (min & max)."
+        },
+        "error": {
+          "type": "string",
+          "description": "The threshold for error relative to the baseline (min & max)."
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type"]
+    }
+  }
+}

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/tests/options/external-dependencies_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/tests/options/external-dependencies_spec.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { buildEsbuildBrowser } from '../../index';
+import { BASE_OPTIONS, BROWSER_BUILDER_INFO, describeBuilder } from '../setup';
+
+describeBuilder(buildEsbuildBrowser, BROWSER_BUILDER_INFO, (harness) => {
+  describe('Option: "externalDependencies"', () => {
+    it('should not externalize any dependency when option is not set', async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+      });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
+      harness.expectFile('dist/main.js').content.not.toMatch(/from ['"]@angular\/core['"]/);
+      harness.expectFile('dist/main.js').content.not.toMatch(/from ['"]@angular\/common['"]/);
+    });
+
+    it('should only externalize the listed depedencies when option is set', async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        externalDependencies: ['@angular/core'],
+      });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
+
+      harness.expectFile('dist/main.js').content.toMatch(/from ['"]@angular\/core['"]/);
+      harness.expectFile('dist/main.js').content.not.toMatch(/from ['"]@angular\/common['"]/);
+    });
+  });
+});

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/tests/setup.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/tests/setup.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { Schema } from '../schema';
+
+export { describeBuilder } from '../../../testing';
+
+export const BROWSER_BUILDER_INFO = Object.freeze({
+  name: '@angular-devkit/build-angular:browser-esbuild',
+  schemaPath: __dirname + '/../schema.json',
+});
+
+/**
+ * Contains all required browser builder fields.
+ * Also disables progress reporting to minimize logging output.
+ */
+export const BASE_OPTIONS = Object.freeze<Schema>({
+  index: 'src/index.html',
+  main: 'src/main.ts',
+  outputPath: 'dist',
+  tsConfig: 'src/tsconfig.app.json',
+  progress: false,
+
+  // Disable optimizations
+  optimization: false,
+  buildOptimizer: false,
+});


### PR DESCRIPTION
    
This commit add a new `externalDependencies` option to the experimental browser builder.
    
Dependencies listed in this option will not be included in the final bundle, instead the user would need to provide them at runtime using import maps or another method.

Closes #23322