### PR TITLE
build: ensure ng-dev command works on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "build:bazel": "node ./bin/devkit-admin build-bazel",
     "build-tsc": "tsc -p tsconfig.json",
     "lint": "eslint --cache --max-warnings=0 \"**/*.ts\"",
-    "ng-dev": "TS_NODE_PROJECT=$PWD/.ng-dev/tsconfig.json node_modules/@angular/dev-infra-private/ng-dev/bundles/cli.mjs",
+    "ng-dev": "ts-node --esm --project .ng-dev/tsconfig.json node_modules/@angular/dev-infra-private/ng-dev/bundles/cli.mjs",
     "templates": "node ./bin/devkit-admin templates",
     "validate": "node ./bin/devkit-admin validate",
     "postinstall": "yarn webdriver-update && yarn husky install",


### PR DESCRIPTION
Apparently the `ng-dev` command does not work with Git Bash on windows
because of the environment variable being set. We should use `ts-node`
directly to avoid this issue, and also avoid the `$PWD` access which
might not work depending on the shell.

Also on the dev-infra side we would need to remove the ts-node shebang
and leave the responsibility to the consumer project.