### PR TITLE
fix(@angular-devkit/build-angular): fix incorrect glob cwd in karma when using `--include` option

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/karma/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/index.ts
@@ -118,14 +118,8 @@ export function execute(
         }
 
         const projectMetadata = await context.getProjectMetadata(projectName);
-        const projectRoot = path.join(
-          context.workspaceRoot,
-          (projectMetadata.root as string | undefined) ?? '',
-        );
-        const projectSourceRoot = path.join(
-          projectRoot,
-          (projectMetadata.sourceRoot as string | undefined) ?? '',
-        );
+        const sourceRoot = (projectMetadata.sourceRoot ?? projectMetadata.root ?? '') as string;
+        const projectSourceRoot = path.join(context.workspaceRoot, sourceRoot);
 
         const files = await findTests(options.include, context.workspaceRoot, projectSourceRoot);
         // early exit, no reason to start karma

--- a/tests/legacy-cli/e2e/tests/test/test-include-glob.ts
+++ b/tests/legacy-cli/e2e/tests/test/test-include-glob.ts
@@ -1,0 +1,5 @@
+import { ng } from '../../utils/process';
+
+export default async function () {
+  await ng('test', '--no-watch', `--include='**/*.spec.ts'`);
+}


### PR DESCRIPTION

Previously, we amended the project source root to the source root which resulted in an invalid path.

Closes #23396