### PR TITLE
fix(@angular/cli): prevent schema validation error

### DIFF
--- a/packages/angular/cli/lib/config/workspace-schema.json
+++ b/packages/angular/cli/lib/config/workspace-schema.json
@@ -67,7 +67,8 @@
               "description": "Show a warning when the global version is newer than the local one.",
               "type": "boolean"
             }
-          }
+          },
+          "additionalProperties": false
         },
         "analytics": {
           "type": ["boolean", "string"],
@@ -86,7 +87,8 @@
               "type": "string",
               "format": "uuid"
             }
-          }
+          },
+          "additionalProperties": false
         },
         "cache": {
           "description": "Control disk cache.",
@@ -105,7 +107,74 @@
               "description": "Cache base path.",
               "type": "string"
             }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "cliGlobalOptions": {
+      "type": "object",
+      "properties": {
+        "defaultCollection": {
+          "description": "The default schematics collection to use.",
+          "type": "string",
+          "x-deprecated": "Use 'schematicCollections' instead."
+        },
+        "schematicCollections": {
+          "type": "array",
+          "description": "The list of schematic collections to use.",
+          "items": {
+            "type": "string",
+            "uniqueItems": true
           }
+        },
+        "packageManager": {
+          "description": "Specify which package manager tool to use.",
+          "type": "string",
+          "enum": ["npm", "cnpm", "yarn", "pnpm"]
+        },
+        "warnings": {
+          "description": "Control CLI specific console warnings",
+          "type": "object",
+          "properties": {
+            "versionMismatch": {
+              "description": "Show a warning when the global version is newer than the local one.",
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        "analytics": {
+          "type": ["boolean", "string"],
+          "description": "Share anonymous usage data with the Angular Team at Google."
+        },
+        "analyticsSharing": {
+          "type": "object",
+          "properties": {
+            "tracking": {
+              "description": "Analytics sharing info tracking ID.",
+              "type": "string",
+              "pattern": "^(GA|UA)?-\\d+-\\d+$"
+            },
+            "uuid": {
+              "description": "Analytics sharing info universally unique identifier.",
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          "additionalProperties": false
+        },
+        "completion": {
+          "type": "object",
+          "description": "Angular CLI completion settings.",
+          "properties": {
+            "prompted": {
+              "type": "boolean",
+              "description": "Whether the user has been prompted to add completion command prompt."
+            }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -552,14 +621,13 @@
       "type": "object",
       "properties": {
         "$schema": {
-          "type": "string",
-          "format": "uri"
+          "type": "string"
         },
         "version": {
           "$ref": "#/definitions/fileVersion"
         },
         "cli": {
-          "$ref": "#/definitions/cliOptions"
+          "$ref": "#/definitions/cliGlobalOptions"
         },
         "schematics": {
           "$ref": "#/definitions/schematicOptions"

--- a/packages/angular/cli/src/commands/config/cli.ts
+++ b/packages/angular/cli/src/commands/config/cli.ts
@@ -97,27 +97,6 @@ export class ConfigCommandModule
       throw new CommandModuleError('Invalid Path.');
     }
 
-    const validGlobalCliPaths = new Set<string>([
-      'cli.warnings.versionMismatch',
-      'cli.defaultCollection',
-      'cli.schematicCollections',
-      'cli.packageManager',
-
-      'cli.analytics',
-      'cli.analyticsSharing.tracking',
-      'cli.analyticsSharing.uuid',
-
-      'cli.completion.prompted',
-    ]);
-
-    if (
-      options.global &&
-      !options.jsonPath.startsWith('schematics.') &&
-      !validGlobalCliPaths.has(options.jsonPath)
-    ) {
-      throw new CommandModuleError('Invalid Path.');
-    }
-
     const [config, configPath] = await getWorkspaceRaw(options.global ? 'global' : 'local');
     const { logger } = this.context;
 
@@ -140,7 +119,7 @@ export class ConfigCommandModule
       return 1;
     }
 
-    await validateWorkspace(parseJson(config.content));
+    await validateWorkspace(parseJson(config.content), options.global ?? false);
 
     config.save();
 

--- a/tests/legacy-cli/e2e/tests/commands/config/config-global-validation.ts
+++ b/tests/legacy-cli/e2e/tests/commands/config/config-global-validation.ts
@@ -1,0 +1,51 @@
+import { homedir } from 'os';
+import * as path from 'path';
+import { deleteFile, expectFileToExist } from '../../../utils/fs';
+import { ng, silentNg } from '../../../utils/process';
+import { expectToFail } from '../../../utils/utils';
+
+export default async function () {
+  let ngError: Error;
+
+  ngError = await expectToFail(() => silentNg('config', 'cli.completion.prompted', 'true'));
+
+  if (
+    !ngError.message.includes('Data path "/cli" must NOT have additional properties(completion).')
+  ) {
+    throw new Error('Should have failed with must NOT have additional properties(completion).');
+  }
+
+  ngError = await expectToFail(() =>
+    silentNg('config', '--global', 'cli.completion.invalid', 'true'),
+  );
+
+  if (
+    !ngError.message.includes(
+      'Data path "/cli/completion" must NOT have additional properties(invalid).',
+    )
+  ) {
+    throw new Error('Should have failed with must NOT have additional properties(invalid).');
+  }
+
+  ngError = await expectToFail(() => silentNg('config', '--global', 'cli.cache.enabled', 'true'));
+
+  if (!ngError.message.includes('Data path "/cli" must NOT have additional properties(cache).')) {
+    throw new Error('Should have failed with must NOT have additional properties(cache).');
+  }
+
+  ngError = await expectToFail(() => silentNg('config', 'cli.completion.prompted'));
+
+  if (!ngError.message.includes('Value cannot be found.')) {
+    throw new Error('Should have failed with Value cannot be found.');
+  }
+
+  await ng('config', '--global', 'cli.completion.prompted', 'true');
+  const { stdout } = await silentNg('config', '--global', 'cli.completion.prompted');
+
+  if (!stdout.includes('true')) {
+    throw new Error(`Expected "true", received "${JSON.stringify(stdout)}".`);
+  }
+
+  await expectFileToExist(path.join(homedir(), '.angular-config.json'));
+  await deleteFile(path.join(homedir(), '.angular-config.json'));
+}

--- a/tests/legacy-cli/e2e/tests/commands/config/config-set.ts
+++ b/tests/legacy-cli/e2e/tests/commands/config/config-set.ts
@@ -1,8 +1,23 @@
-import { ng } from '../../../utils/process';
+import { ng, silentNg } from '../../../utils/process';
 import { expectToFail } from '../../../utils/utils';
 
 export default async function () {
-  await expectToFail(() => ng('config', 'cli.warnings.zzzz'));
+  let ngError: Error;
+
+  ngError = await expectToFail(() => silentNg('config', 'cli.warnings.zzzz', 'true'));
+  if (
+    !ngError.message.includes(
+      'Data path "/cli/warnings" must NOT have additional properties(zzzz).',
+    )
+  ) {
+    throw new Error('Should have failed with must NOT have additional properties(zzzz).');
+  }
+
+  ngError = await expectToFail(() => silentNg('config', 'cli.warnings.zzzz'));
+  if (!ngError.message.includes('Value cannot be found.')) {
+    throw new Error('Should have failed with Value cannot be found.');
+  }
+
   await ng('config', 'cli.warnings.versionMismatch', 'false');
   const { stdout } = await ng('config', 'cli.warnings.versionMismatch');
   if (!stdout.includes('false')) {


### PR DESCRIPTION
Add `cliOptions.completion` to workspace-schema.json.

Resolve an error found using `ng-config` to disable version mismatch:

```
$ ng config -g cli.warnings.versionMismatch false
Your global Angular CLI version (14.0.2) is greater than your local version (14.0.1). The local Angular CLI version is used.

To disable this warning use "ng config -g cli.warnings.versionMismatch false".
Error: Schema validation failed with the following errors:
  Data path "/cli" must NOT have additional properties(completion).
```

---

Please note that I was unable to run the test suite locally on my M1 Mac. After running `yarn bazel test //packages/...`, I received the following error that I was unable to resolve (I tried following the error message guidance to no avail):

```
ERROR: no such package '@nodejs_darwin_arm64//': No nodejs is available for darwin_arm64 at version 14.17.1
    Consider upgrading by setting node_version in a call to node_repositories in WORKSPACE.
    Note that Node 16.x is the minimum published for Apple Silicon (M1 Macs)
```

However, I did test a build locally following the [developer guide instructions](https://github.com/angular/angular-cli/blob/main/docs/DEVELOPER.md#building-and-installing-the-cli) and `ng config -g cli.warnings.versionMismatch false` completed without an error.