### PR TITLE
fix(@angular-devkit/build-angular): handle `codeCoverageExclude` correctly in Windows

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/utils/helpers.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/utils/helpers.ts
@@ -126,8 +126,8 @@ export function getInstrumentationExcludedPaths(
 
   for (const excludeGlob of excludedPaths) {
     glob
-      .sync(path.join(sourceRoot, excludeGlob), { nodir: true })
-      .forEach((p) => excluded.add(path.normalize(p)));
+      .sync(excludeGlob, { nodir: true, cwd: sourceRoot })
+      .forEach((p) => excluded.add(path.join(sourceRoot, p)));
   }
 
   return excluded;

--- a/tests/legacy-cli/e2e/tests/test/test-code-coverage-exclude.ts
+++ b/tests/legacy-cli/e2e/tests/test/test-code-coverage-exclude.ts
@@ -1,0 +1,22 @@
+import { expectFileToExist, rimraf } from '../../utils/fs';
+import { silentNg } from '../../utils/process';
+import { expectToFail } from '../../utils/utils';
+
+export default async function () {
+  // This test is already in build-angular, but that doesn't run on Windows.
+  await silentNg('test', '--no-watch', '--code-coverage');
+  await expectFileToExist('coverage/test-project/app.component.ts.html');
+  // Delete coverage directory
+  await rimraf('coverage');
+
+  await silentNg(
+    'test',
+    '--no-watch',
+    '--code-coverage',
+    `--code-coverage-exclude='src/**/app.component.ts'`,
+  );
+
+  // Doesn't include excluded.
+  await expectFileToExist('coverage/test-project/index.html');
+  await expectToFail(() => expectFileToExist('coverage/test-project/app.component.ts.html'));
+}


### PR DESCRIPTION

Previously, `codeCoverageExclude` didn't work correct on Windows

Closes #23403