### PR TITLE
fix(@angular-devkit/core): workspace writer skip creating empty projects property

### DIFF
--- a/packages/angular_devkit/core/src/workspace/json/writer.ts
+++ b/packages/angular_devkit/core/src/workspace/json/writer.ts
@@ -53,7 +53,9 @@ function convertJsonWorkspace(workspace: WorkspaceDefinition, schema?: string): 
     $schema: schema || './node_modules/@angular/cli/lib/config/schema.json',
     version: 1,
     ...workspace.extensions,
-    projects: workspace.projects ? convertJsonProjectCollection(workspace.projects) : {},
+    ...(isEmpty(workspace.projects)
+      ? {}
+      : { projects: convertJsonProjectCollection(workspace.projects) }),
   };
 
   return obj;


### PR DESCRIPTION


Before
```json
{
  "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
  "version": 1,
  "projects": {},
  "cli": {
    "analytics": false,
    "warnings": {
      "versionMismatch": false
    }
  }
}
````

After
```json
{
  "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
  "version": 1,
  "cli": {
    "analytics": false,
    "warnings": {
      "versionMismatch": false
    }
  }
}
```