### PR TITLE
test: improve resilience of E2E postinstall check to package hoisting

### DIFF
--- a/tests/legacy-cli/e2e/tests/misc/check-postinstalls.ts
+++ b/tests/legacy-cli/e2e/tests/misc/check-postinstalls.ts
@@ -13,16 +13,24 @@ const POTENTIAL_SCRIPTS: ReadonlyArray<string> = ['preinstall', 'install', 'post
 
 // Some packages include test and/or example code that causes false positives
 const FALSE_POSITIVE_PATHS: ReadonlySet<string> = new Set([
-  'node_modules/jasmine-spec-reporter/examples/protractor/package.json',
-  'node_modules/resolve/test/resolver/multirepo/package.json',
+  'jasmine-spec-reporter/examples/protractor/package.json',
+  'resolve/test/resolver/multirepo/package.json',
 ]);
+
+const INNER_NODE_MODULES_SEGMENT = '/node_modules/';
 
 export default async function () {
   const manifestPaths = await globAsync('node_modules/**/package.json');
   const newPackages: string[] = [];
 
   for (const manifestPath of manifestPaths) {
-    if (FALSE_POSITIVE_PATHS.has(manifestPath)) {
+    const lastNodeModuleIndex = manifestPath.lastIndexOf(INNER_NODE_MODULES_SEGMENT);
+    const packageRelativePath = manifestPath.slice(
+      lastNodeModuleIndex === -1
+        ? INNER_NODE_MODULES_SEGMENT.length - 1
+        : lastNodeModuleIndex + INNER_NODE_MODULES_SEGMENT.length,
+    );
+    if (FALSE_POSITIVE_PATHS.has(packageRelativePath)) {
       continue;
     }
 


### PR DESCRIPTION
False positive package paths are now checked relative to their containing `node_modules` directory.
This avoids issues checking the paths when the package manager changes its hoisting strategy for
one of the affected paths.