### PR TITLE
fix(@angular-devkit/build-angular): ignore supported browsers during i18n extraction

### DIFF
--- a/packages/angular_devkit/build_angular/src/babel/webpack-loader.ts
+++ b/packages/angular_devkit/build_angular/src/babel/webpack-loader.ts
@@ -125,7 +125,7 @@ export default custom<ApplicationPresetOptions>(() => {
         customOptions.forcePresetEnv = true;
         // Comparable behavior to tsconfig target of ES5
         customOptions.supportedBrowsers = ['IE 9'];
-      } else if (isJsFile) {
+      } else if (isJsFile && customOptions.supportedBrowsers?.length) {
         // Applications code ES version can be controlled using TypeScript's `target` option.
         // However, this doesn't effect libraries and hence we use preset-env to downlevel ES fetaures
         // based on the supported browsers in browserlist.

--- a/packages/angular_devkit/build_angular/src/builders/extract-i18n/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/extract-i18n/index.ts
@@ -233,6 +233,8 @@ export async function execute(
 
       return partials;
     },
+    // During extraction we don't need specific browser support.
+    { supportedBrowsers: undefined },
   );
 
   // All the localize usages are setup to first try the ESM entry point then fallback to the deep imports.


### PR DESCRIPTION
Since extraction doesn't work on the browser we can ignore the `supportedBrowsers` configuration during message extraction.

Closes #23420