### PR TITLE
fix(@angular-devkit/build-angular): exit dev-server when CTRL+C is pressed

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/dev-server.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/dev-server.ts
@@ -75,6 +75,10 @@ export async function getDevServerConfig(
           },
         ],
       },
+      // When setupExitSignals is enabled webpack-dev-server will shutdown gracefully which would
+      // require CTRL+C to be pressed multiple times to exit.
+      // See: https://github.com/webpack/webpack-dev-server/blob/c76b6d11a3821436c5e20207c8a38deb6ab7e33c/lib/Server.js#L1801-L1827
+      setupExitSignals: false,
       compress: false,
       static: false,
       server: getServerConfig(root, wco.buildOptions),


### PR DESCRIPTION


Since version 4, webpack-dev-server by default will shutdown gracefully. This results in `CTRL+C` needed to be pressed multiple times to exit the process.

See: https://github.com/webpack/webpack-dev-server/blob/c76b6d11a3821436c5e20207c8a38deb6ab7e33c/lib/Server.js#L1801-L1827

Closes #22216