### PR TITLE
fix(@angular/cli): correctly handle `--collection` option in `ng new`

### DIFF
--- a/packages/angular/cli/src/commands/new/cli.ts
+++ b/packages/angular/cli/src/commands/new/cli.ts
@@ -45,7 +45,7 @@ export class NewCommandModule
     });
 
     const {
-      options: { collectionNameFromArgs },
+      options: { collection: collectionNameFromArgs },
     } = this.context.args;
 
     const collectionName =

--- a/tests/legacy-cli/e2e/tests/commands/ng-new-collection.ts
+++ b/tests/legacy-cli/e2e/tests/commands/ng-new-collection.ts
@@ -1,0 +1,19 @@
+import { execAndWaitForOutputToMatch } from '../../utils/process';
+
+export default async function () {
+  const currentDirectory = process.cwd();
+
+  try {
+    process.chdir('..');
+
+    // The below is a way to validate that the `--collection` option is being considered.
+    await execAndWaitForOutputToMatch(
+      'ng',
+      ['new', '--collection', 'invalid-schematic'],
+      /Collection "invalid-schematic" cannot be resolved/,
+    );
+  } finally {
+    // Change directory back
+    process.chdir(currentDirectory);
+  }
+}


### PR DESCRIPTION
Previously, this option was ignored due to an incorrect deconstruction.

Closes #23414