### PR TITLE
fix(@angular/cli): remove color from help epilogue

### DIFF
--- a/packages/angular/cli/src/command-builder/command-runner.ts
+++ b/packages/angular/cli/src/command-builder/command-runner.ts
@@ -149,7 +149,7 @@ export async function runCommand(args: string[], logger: logging.Logger): Promis
       'deprecated: %s': colors.yellow('deprecated:') + ' %s',
       'Did you mean %s?': 'Unknown command. Did you mean %s?',
     })
-    .epilogue(colors.gray('For more information, see https://angular.io/cli/.\n'))
+    .epilogue('For more information, see https://angular.io/cli/.\n')
     .demandCommand(1, demandCommandFailureMessage)
     .recommendCommands()
     .middleware(normalizeOptionsMiddleware)


### PR DESCRIPTION
In some cases gray doesn't provide enough contrast.

Before
<img width="1000" alt="Screenshot 2022-06-27 at 12 58 44" src="https://user-images.githubusercontent.com/17563226/175926568-8a714bd1-d861-4173-9769-2180395d6833.png">


After
<img width="1002" alt="Screenshot 2022-06-27 at 12 58 53" src="https://user-images.githubusercontent.com/17563226/175926574-74e4ebbf-3c84-4d11-94b8-f0a11f75462a.png">