### PR TITLE
refactor: clean up old ansi-colors castings

### DIFF
--- a/packages/angular/cli/src/utilities/color.ts
+++ b/packages/angular/cli/src/utilities/color.ts
@@ -45,8 +45,7 @@ export function removeColor(text: string): string {
 }
 
 // Create a separate instance to prevent unintended global changes to the color configuration
-// Create function is not defined in the typings. See: https://github.com/doowb/ansi-colors/pull/44
-const colors = (ansiColors as AnsiColors & { create: () => AnsiColors }).create();
+const colors = ansiColors.create();
 colors.enabled = supportColor();
 
 export { colors };

--- a/packages/angular_devkit/architect_cli/bin/architect.ts
+++ b/packages/angular_devkit/architect_cli/bin/architect.ts
@@ -71,8 +71,7 @@ interface BarInfo {
 }
 
 // Create a separate instance to prevent unintended global changes to the color configuration
-// Create function is not defined in the typings. See: https://github.com/doowb/ansi-colors/pull/44
-const colors = (ansiColors as typeof ansiColors & { create: () => typeof ansiColors }).create();
+const colors = ansiColors.create();
 
 async function _executeTarget(
   parentLogger: logging.Logger,

--- a/packages/angular_devkit/benchmark/src/main.ts
+++ b/packages/angular_devkit/benchmark/src/main.ts
@@ -111,8 +111,7 @@ export async function main({
   );
 
   // Create a separate instance to prevent unintended global changes to the color configuration
-  // Create function is not defined in the typings. See: https://github.com/doowb/ansi-colors/pull/44
-  const colors = (ansiColors as typeof ansiColors & { create: () => typeof ansiColors }).create();
+  const colors = ansiColors.create();
 
   // Log to console.
   logger.pipe(filter((entry) => entry.level != 'debug' || argv['verbose'])).subscribe((entry) => {

--- a/packages/angular_devkit/build_angular/src/utils/color.ts
+++ b/packages/angular_devkit/build_angular/src/utils/color.ts
@@ -45,8 +45,7 @@ export function removeColor(text: string): string {
 }
 
 // Create a separate instance to prevent unintended global changes to the color configuration
-// Create function is not defined in the typings. See: https://github.com/doowb/ansi-colors/pull/44
-const colors = (ansiColors as AnsiColors & { create: () => AnsiColors }).create();
+const colors = ansiColors.create();
 colors.enabled = supportColor();
 
 export { colors };

--- a/packages/angular_devkit/schematics_cli/bin/schematics.ts
+++ b/packages/angular_devkit/schematics_cli/bin/schematics.ts
@@ -117,8 +117,7 @@ export async function main({
   const { cliOptions, schematicOptions, _ } = parseArgs(args);
 
   // Create a separate instance to prevent unintended global changes to the color configuration
-  // Create function is not defined in the typings. See: https://github.com/doowb/ansi-colors/pull/44
-  const colors = (ansiColors as typeof ansiColors & { create: () => typeof ansiColors }).create();
+  const colors = ansiColors.create();
 
   /** Create the DevKit Logger used through the CLI. */
   const logger = createConsoleLogger(!!cliOptions.verbose, stdout, stderr, {

--- a/tests/legacy-cli/e2e/utils/process.ts
+++ b/tests/legacy-cli/e2e/utils/process.ts
@@ -27,8 +27,7 @@ export type ProcessOutput = {
 
 function _exec(options: ExecOptions, cmd: string, args: string[]): Promise<ProcessOutput> {
   // Create a separate instance to prevent unintended global changes to the color configuration
-  // Create function is not defined in the typings. See: https://github.com/doowb/ansi-colors/pull/44
-  const colors = (ansiColors as typeof ansiColors & { create: () => typeof ansiColors }).create();
+  const colors = ansiColors.create();
 
   let stdout = '';
   let stderr = '';


### PR DESCRIPTION
This has been fixed in https://github.com/doowb/ansi-colors/pull/44