### PR TITLE
ci: remove flakey test behaviour

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser/tests/behavior/typescript-target_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/tests/behavior/typescript-target_spec.ts
@@ -243,11 +243,11 @@ describeBuilder(buildWebpackBrowser, BROWSER_BUILDER_INFO, (harness) => {
       const { result, logs } = await harness.executeOnce();
       expect(result?.success).toBeTrue();
 
-      const deprecationMessages = logs.filter(({ message }) =>
-        message.startsWith('DEPRECATED: ES5 output is deprecated'),
+      expect(logs).toContain(
+        jasmine.objectContaining<logging.LogEntry>({
+          message: jasmine.stringMatching('DEPRECATED: ES5 output is deprecated'),
+        }),
       );
-
-      expect(deprecationMessages).toHaveSize(1);
     });
   });
 });

--- a/packages/angular_devkit/build_angular/src/webpack/plugins/typescript.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/plugins/typescript.ts
@@ -26,7 +26,6 @@ function ensureIvy(wco: WebpackConfigOptions): void {
   wco.tsConfig.options.enableIvy = true;
 }
 
-let es5TargetWarningsShown = false;
 export function createIvyPlugin(
   wco: WebpackConfigOptions,
   aot: boolean,
@@ -54,13 +53,9 @@ export function createIvyPlugin(
   // as for third-party libraries. This greatly reduces the complexity of static analysis.
   if (wco.scriptTarget < ScriptTarget.ES2015) {
     compilerOptions.target = ScriptTarget.ES2015;
-    if (!es5TargetWarningsShown) {
-      wco.logger.warn(
-        'DEPRECATED: ES5 output is deprecated. Please update TypeScript `target` compiler option to ES2015 or later.',
-      );
-
-      es5TargetWarningsShown = true;
-    }
+    wco.logger.warn(
+      'DEPRECATED: ES5 output is deprecated. Please update TypeScript `target` compiler option to ES2015 or later.',
+    );
   }
 
   const fileReplacements: Record<string, string> = {};


### PR DESCRIPTION
During testing architect isn't spawned as a new process therefore we the global state can be tained from previous runs.

`es5TargetWarningsShown` which was saved in the global state caused flakiness.