### PR TITLE
fix(@ngtools/webpack): restore process title after NGCC is executed

### DIFF
--- a/packages/ngtools/webpack/src/ngcc_processor.ts
+++ b/packages/ngtools/webpack/src/ngcc_processor.ts
@@ -117,29 +117,34 @@ export class NgccProcessor {
     // that we cannot setup multiple cluster masters with different options.
     // - We will not be able to have concurrent builds otherwise Ex: App-Shell,
     // as NGCC will create a lock file for both builds and it will cause builds to fails.
-    const { status, error } = spawnSync(
-      process.execPath,
-      [
-        this.compilerNgcc.ngccMainFilePath,
-        '--source' /** basePath */,
-        this._nodeModulesDirectory,
-        '--properties' /** propertiesToConsider */,
-        ...this.propertiesToConsider,
-        '--first-only' /** compileAllFormats */,
-        '--create-ivy-entry-points' /** createNewEntryPointFormats */,
-        '--async',
-        '--tsconfig' /** tsConfigPath */,
-        this.tsConfigPath,
-        '--use-program-dependencies',
-      ],
-      {
-        stdio: ['inherit', process.stderr, process.stderr],
-      },
-    );
+    const originalProcessTitle = process.title;
+    try {
+      const { status, error } = spawnSync(
+        process.execPath,
+        [
+          this.compilerNgcc.ngccMainFilePath,
+          '--source' /** basePath */,
+          this._nodeModulesDirectory,
+          '--properties' /** propertiesToConsider */,
+          ...this.propertiesToConsider,
+          '--first-only' /** compileAllFormats */,
+          '--create-ivy-entry-points' /** createNewEntryPointFormats */,
+          '--async',
+          '--tsconfig' /** tsConfigPath */,
+          this.tsConfigPath,
+          '--use-program-dependencies',
+        ],
+        {
+          stdio: ['inherit', process.stderr, process.stderr],
+        },
+      );
 
-    if (status !== 0) {
-      const errorMessage = error?.message || '';
-      throw new Error(errorMessage + `NGCC failed${errorMessage ? ', see above' : ''}.`);
+      if (status !== 0) {
+        const errorMessage = error?.message || '';
+        throw new Error(errorMessage + `NGCC failed${errorMessage ? ', see above' : ''}.`);
+      }
+    } finally {
+      process.title = originalProcessTitle;
     }
 
     timeEnd(timeLabel);


### PR DESCRIPTION
More context about this can be found in the following comment: https://github.com/angular/angular-cli/issues/19205#issuecomment-722727791

Closes #19205