### PR TITLE
fix(@schematics/angular): use `sourceRoot` instead of `src` in universal schematic

### DIFF
--- a/packages/angular_devkit/build_angular/test/hello-world-app/src/tsconfig.server.json
+++ b/packages/angular_devkit/build_angular/test/hello-world-app/src/tsconfig.server.json
@@ -8,8 +8,5 @@
   },
   "files": [
     "main.server.ts"
-  ],
-  "angularCompilerOptions": {
-    "entryModule": "app/app.server.module#AppServerModule"
-  }
+  ]
 }

--- a/packages/schematics/angular/universal/files/root/tsconfig.server.json.template
+++ b/packages/schematics/angular/universal/files/root/tsconfig.server.json.template
@@ -10,8 +10,5 @@
   },
   "files": [
     "src/<%= stripTsExtension(main) %>.ts"
-  ],
-  "angularCompilerOptions": {
-    "entryModule": "./<%= rootInSrc ? '' : 'src/' %><%= appDir %>/<%= stripTsExtension(rootModuleFileName) %>#<%= rootModuleClassName %>"
-  }
+  ]
 }

--- a/packages/schematics/angular/universal/index_spec.ts
+++ b/packages/schematics/angular/universal/index_spec.ts
@@ -97,9 +97,6 @@ describe('Universal Schematic', () => {
         types: ['node'],
       },
       files: ['src/main.server.ts'],
-      angularCompilerOptions: {
-        entryModule: './src/app/app.server.module#AppServerModule',
-      },
     });
     const angularConfig = JSON.parse(tree.readContent('angular.json'));
     expect(angularConfig.projects.workspace.architect.server.options.tsConfig).toEqual(
@@ -122,9 +119,6 @@ describe('Universal Schematic', () => {
         types: ['node'],
       },
       files: ['src/main.server.ts'],
-      angularCompilerOptions: {
-        entryModule: './src/app/app.server.module#AppServerModule',
-      },
     });
     const angularConfig = JSON.parse(tree.readContent('angular.json'));
     expect(angularConfig.projects.bar.architect.server.options.tsConfig).toEqual(

--- a/packages/schematics/angular/universal/schema.json
+++ b/packages/schematics/angular/universal/schema.json
@@ -29,7 +29,8 @@
       "type": "string",
       "format": "path",
       "description": "The name of the application folder.",
-      "default": "app"
+      "default": "app",
+      "x-deprecated": "This option has no effect."
     },
     "rootModuleFileName": {
       "type": "string",


### PR DESCRIPTION


With this change we remove the usage of harded `src` directory and instead infer this from the `sourceRoot` project option.

We also remove the `angularCompilerOptions.entryModule` property in the server tsconfig as this is no longer needed with Ivy.

Closes #12104