### PR TITLE
fix(@angular-devkit/build-angular): disable glob mounting for patterns that start with a forward slash

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/karma/find-tests.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/find-tests.ts
@@ -66,6 +66,8 @@ async function findMatchingTests(
 
   return globPromise(normalizedPattern, {
     cwd: projectSourceRoot,
+    root: projectSourceRoot,
+    nomount: true,
   });
 }
 

--- a/packages/angular_devkit/build_angular/src/builders/karma/tests/options/code-coverage-exclude_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/tests/options/code-coverage-exclude_spec.ts
@@ -37,6 +37,21 @@ describeBuilder(execute, KARMA_BUILDER_INFO, (harness) => {
       harness.expectFile(coveragePath).content.not.toContain('app.component.ts');
     });
 
+    it('should exclude file from coverage when set when glob starts with a forward slash', async () => {
+      harness.useTarget('test', {
+        ...BASE_OPTIONS,
+        codeCoverage: true,
+        codeCoverageExclude: ['/**/app.component.ts'],
+      });
+
+      const { result } = await harness.executeOnce();
+
+      expect(result?.success).toBeTrue();
+
+      await setTimeoutPromise(1000);
+      harness.expectFile(coveragePath).content.not.toContain('app.component.ts');
+    });
+
     it('should not exclude file from coverage when set', async () => {
       harness.useTarget('test', {
         ...BASE_OPTIONS,

--- a/packages/angular_devkit/build_angular/src/builders/karma/tests/options/include_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/tests/options/include_spec.ts
@@ -54,6 +54,10 @@ describeBuilder(execute, KARMA_BUILDER_INFO, (harness) => {
         test: 'glob with spec suffix',
         input: ['**/*.pipe.spec.ts', '**/*.pipe.spec.ts', '**/*test.service.spec.ts'],
       },
+      {
+        test: 'glob with forward slash and spec suffix',
+        input: ['/**/*test.service.spec.ts'],
+      },
     ].forEach((options, index) => {
       it(`should work with ${options.test} (${index})`, async () => {
         await harness.writeFiles({

--- a/packages/angular_devkit/build_angular/src/utils/copy-assets.ts
+++ b/packages/angular_devkit/build_angular/src/utils/copy-assets.ts
@@ -9,12 +9,9 @@
 import * as fs from 'fs';
 import glob from 'glob';
 import * as path from 'path';
+import { promisify } from 'util';
 
-function globAsync(pattern: string, options: glob.IOptions) {
-  return new Promise<string[]>((resolve, reject) =>
-    glob(pattern, options, (e, m) => (e ? reject(e) : resolve(m))),
-  );
-}
+const globPromise = promisify(glob);
 
 export async function copyAssets(
   entries: {
@@ -33,10 +30,12 @@ export async function copyAssets(
 
   for (const entry of entries) {
     const cwd = path.resolve(root, entry.input);
-    const files = await globAsync(entry.glob, {
+    const files = await globPromise(entry.glob, {
       cwd,
       dot: true,
       nodir: true,
+      root: cwd,
+      nomount: true,
       ignore: entry.ignore ? defaultIgnore.concat(entry.ignore) : defaultIgnore,
       follow: entry.followSymlinks,
     });

--- a/packages/angular_devkit/build_angular/src/webpack/utils/helpers.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/utils/helpers.ts
@@ -121,15 +121,15 @@ export function assetNameTemplateFactory(hashFormat: HashFormat): (resourcePath:
 }
 
 export function getInstrumentationExcludedPaths(
-  sourceRoot: string,
+  root: string,
   excludedPaths: string[],
 ): Set<string> {
   const excluded = new Set<string>();
 
   for (const excludeGlob of excludedPaths) {
     glob
-      .sync(excludeGlob, { nodir: true, cwd: sourceRoot })
-      .forEach((p) => excluded.add(path.join(sourceRoot, p)));
+      .sync(excludeGlob, { nodir: true, cwd: root, root, nomount: true })
+      .forEach((p) => excluded.add(path.join(root, p)));
   }
 
   return excluded;


### PR DESCRIPTION
By default, a glob pattern starting with a forward slash will be "mounted" onto the system root. This causes globs to escape the workspace root.

With this change we configure disable glob "mounting".

Closes #23467

---

Note: we should probably eventually validate the paths in the workspace config. 