### PR TITLE
build: add bazel config that disabled sharding and flaky re-runs

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -8,6 +8,10 @@ build --strategy=TypeScriptCompile=worker
 # Enable debugging tests with --config=debug
 test:debug --test_arg=--node_options=--inspect-brk --test_output=streamed --test_strategy=exclusive --test_timeout=9999 --nocache_test_results
 
+# Enable debugging tests with --config=no-sharding
+# The below is useful to while using `fit` and `fdescribe` to avoid sharing and re-runs of failed flaky tests.
+test:no-sharding --flaky_test_attempts=1 --test_sharding_strategy=disabled
+
 ###############################
 # Filesystem interactions     #
 ###############################


### PR DESCRIPTION
This is useful when running tests locally as otherwise 50 workers are spawned when running the `//packages/angular_devkit/build_angular:build_angular_browser_test` target even when having an `fit` on a single test. This also disabled re-runs on flaky tests.

//cc @devversion, not sure if there is a better way. 