### PR TITLE
test: update prod-build E2E test to handle esbuild output

### DIFF
--- a/tests/legacy-cli/e2e/tests/build/prod-build.ts
+++ b/tests/legacy-cli/e2e/tests/build/prod-build.ts
@@ -26,7 +26,7 @@ function verifySize(bundle: string, baselineBytes: number) {
 export default async function () {
   // Can't use the `ng` helper because somewhere the environment gets
   // stuck to the first build done
-  const bootstrapRegExp = /bootstrapModule\([_a-zA-Z]+[0-9]*\)\./;
+  const bootstrapRegExp = /bootstrapModule\([\$_a-zA-Z]+[0-9]*\)\./;
 
   await noSilentNg('build');
   await expectFileToExist(join(process.cwd(), 'dist'));


### PR DESCRIPTION
The change in regexp now matched the below output


```
bootstrapModule($a).catch(e=>console.error(e));
```