### PR TITLE
fix(@angular-devkit/build-angular): generate different content hashes for scripts which are changed during the optimization phase

### DIFF
--- a/tests/legacy-cli/e2e/tests/build/scripts-output-hashing.ts
+++ b/tests/legacy-cli/e2e/tests/build/scripts-output-hashing.ts
@@ -1,0 +1,45 @@
+import { expectFileMatchToExist, expectFileToMatch, writeMultipleFiles } from '../../utils/fs';
+import { ng } from '../../utils/process';
+import { updateJsonFile, updateTsConfig } from '../../utils/project';
+
+function getScriptsFilename(): Promise<string> {
+  return expectFileMatchToExist('dist/test-project/', /external-module\.[0-9a-f]{16}\.js/);
+}
+
+export default async function () {
+  // verify content hash is based on code after optimizations
+  await writeMultipleFiles({
+    'src/script.js': 'try { console.log(); } catch {}',
+  });
+  await updateJsonFile('angular.json', (configJson) => {
+    const build = configJson.projects['test-project'].architect.build;
+    build.options['scripts'] = [
+      {
+        input: 'src/script.js',
+        inject: true,
+        bundleName: 'external-module',
+      },
+    ];
+    build.configurations['production'].outputHashing = 'all';
+    configJson['cli'] = { cache: { enabled: 'false' } };
+  });
+  await updateTsConfig((json) => {
+    json['compilerOptions']['target'] = 'es2017';
+    json['compilerOptions']['module'] = 'es2020';
+  });
+  await ng('build', '--configuration=production');
+  const filenameBuild1 = await getScriptsFilename();
+  await expectFileToMatch(`dist/test-project/${filenameBuild1}`, 'try{console.log()}catch(c){}');
+
+  await updateTsConfig((json) => {
+    json['compilerOptions']['target'] = 'es2019';
+  });
+  await ng('build', '--configuration=production');
+  const filenameBuild2 = await getScriptsFilename();
+  await expectFileToMatch(`dist/test-project/${filenameBuild2}`, 'try{console.log()}catch{}');
+  if (filenameBuild1 === filenameBuild2) {
+    throw new Error(
+      'Contents of the built file changed between builds, but the content hash stayed the same!',
+    );
+  }
+}


### PR DESCRIPTION
Instead of generating the content hash based on the content of scripts BEFORE the optimization phase,
the content hash is generated AFTER the optimization phase.

Prevents caching issues where browsers block execution of scripts due to the integrity hash not matching
with the cached script in case of a script being optimized differently than in a previous build,
where it would previously result in the same content hash.

Fixes #22906

Test case is based on the reproduction example as specified in #22906 (thanks!).