### PR TITLE
fix(@angular/cli): remove deprecation warning of `no` prefixed schema options

### DIFF
--- a/packages/angular/cli/src/command-builder/command-module.ts
+++ b/packages/angular/cli/src/command-builder/command-module.ts
@@ -226,18 +226,12 @@ export abstract class CommandModule<T extends {} = {}> implements CommandModuleI
         ...(this.context.args.options.help ? { default: defaultVal } : {}),
       };
 
-      // TODO(alanagius4): remove in a major version.
-      // the below is an interim workaround to handle options which have been defined in the schema with `no` prefix.
       let dashedName = strings.dasherize(name);
+
+      // Handle options which have been defined in the schema with `no` prefix.
       if (type === 'boolean' && dashedName.startsWith('no-')) {
         dashedName = dashedName.slice(3);
         booleanOptionsWithNoPrefix.add(dashedName);
-
-        // eslint-disable-next-line no-console
-        console.warn(
-          `Warning: '${name}' option has been declared with a 'no' prefix in the schema.` +
-            'Please file an issue with the author of this package.',
-        );
       }
 
       if (positional === undefined) {
@@ -258,8 +252,7 @@ export abstract class CommandModule<T extends {} = {}> implements CommandModuleI
       }
     }
 
-    // TODO(alanagius4): remove in a major version.
-    // the below is an interim workaround to handle options which have been defined in the schema with `no` prefix.
+    // Handle options which have been defined in the schema with `no` prefix.
     if (booleanOptionsWithNoPrefix.size) {
       localYargs.middleware((options: Arguments) => {
         for (const key of booleanOptionsWithNoPrefix) {

--- a/tests/legacy-cli/e2e/tests/misc/negated-boolean-options.ts
+++ b/tests/legacy-cli/e2e/tests/misc/negated-boolean-options.ts
@@ -15,10 +15,4 @@ export default async function () {
     ['generate', './schematic-boolean-option-negated:test', '--watch'],
     /noWatch: false/,
   );
-
-  await execAndWaitForOutputToMatch(
-    'ng',
-    ['generate', './schematic-boolean-option-negated:test'],
-    /'noWatch' option has been declared with a 'no' prefix in the schema/,
-  );
 }


### PR DESCRIPTION


Prefixing options with `no` in schema definitions appears to be used more widely than initially thought.

The `noOption` can also be provided in the `angular.json` which makes this property definition less ambiguous, since boolean options don't get prefixed with `no` in the JSON config. Therefore, in order to reduce the community changes we remove the deprecation warning for such options and change the interim solution to permanent one.

None-the-less, it's still recommended that options are defined without the `no` prefix.