### PR TITLE
fix(@angular-devkit/build-angular): no script type module attribute o…

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/index.ts
@@ -300,6 +300,7 @@ export function buildWebpackBrowser(
                   const entrypoints = generateEntryPoints({
                     scripts: options.scripts ?? [],
                     styles: options.styles ?? [],
+                    scriptType: config.output?.scriptType,
                   });
 
                   const indexHtmlGenerator = new IndexHtmlGenerator({

--- a/packages/angular_devkit/build_angular/src/utils/package-chunk-sort.ts
+++ b/packages/angular_devkit/build_angular/src/utils/package-chunk-sort.ts
@@ -15,6 +15,7 @@ export function generateEntryPoints(options: {
   styles: StyleElement[];
   scripts: ScriptElement[];
   isHMREnabled?: boolean;
+  scriptType?: false | 'text/javascript' | 'module';
 }): EntryPointsType[] {
   // Add all styles/scripts, except lazy-loaded ones.
   const extraEntryPoints = (
@@ -29,13 +30,15 @@ export function generateEntryPoints(options: {
     return [...new Set(entryPoints)].map<EntryPointsType>((f) => [f, false]);
   };
 
+  const isModule = options.scriptType === 'module';
+
   const entryPoints: EntryPointsType[] = [
-    ['runtime', !options.isHMREnabled],
-    ['polyfills', true],
+    ['runtime', isModule ? !options.isHMREnabled : false],
+    ['polyfills', isModule],
     ...extraEntryPoints(options.styles, 'styles'),
     ...extraEntryPoints(options.scripts, 'scripts'),
-    ['vendor', true],
-    ['main', true],
+    ['vendor', isModule],
+    ['main', isModule],
   ];
 
   const duplicates = entryPoints.filter(

--- a/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
@@ -324,7 +324,7 @@ export async function getCommonConfig(wco: WebpackConfigOptions): Promise<Config
       libraryTarget: isPlatformServer ? 'commonjs' : undefined,
       crossOriginLoading,
       trustedTypes: 'angular#bundler',
-      scriptType: 'module',
+      scriptType: scriptTarget <= ScriptTarget.ES5 ? 'text/javascript' : 'module',
     },
     watch: buildOptions.watch,
     watchOptions: {


### PR DESCRIPTION
…n below es5 target build

With this browsers that don't support [type=module] will works properly.

----

The `script[type=module]` attribute makes browser freeze on script loading that does not support.

But es5 bundles are can work properly despite of unsupported that feature.