### PR TITLE
ci: enable full E2E suit test on Windows for PRs

### DIFF
--- a/.circleci/dynamic_config.yml
+++ b/.circleci/dynamic_config.yml
@@ -311,7 +311,8 @@ jobs:
   # Windows jobs
   e2e-cli-win:
     executor: windows-executor
-    parallelism: 8
+    resource_class: windows.large
+    parallelism: 16
     steps:
       - checkout
       - rebase_pr
@@ -338,11 +339,7 @@ jobs:
           name: Execute E2E Tests
           command: |
             mkdir X:/ramdisk/e2e-main
-            if (Test-Path env:CIRCLE_PULL_REQUEST) {
-              node tests\legacy-cli\run_e2e.js "--glob={tests/basic/**,tests/i18n/extract-ivy*.ts,tests/build/profile.ts,tests/test/test-sourcemap.ts,tests/misc/check-postinstalls.ts}" --nb-shards=$env:CIRCLE_NODE_TOTAL --shard=$env:CIRCLE_NODE_INDEX --tmpdir=X:/ramdisk/e2e-main
-            } else {
-              node tests\legacy-cli\run_e2e.js --nb-shards=$env:CIRCLE_NODE_TOTAL --shard=$env:CIRCLE_NODE_INDEX --tmpdir=X:/ramdisk/e2e-main
-            }
+            node tests\legacy-cli\run_e2e.js --nb-shards=$env:CIRCLE_NODE_TOTAL --shard=$env:CIRCLE_NODE_INDEX --tmpdir=X:/ramdisk/e2e-main
       - fail_fast
 
 workflows:
@@ -412,9 +409,7 @@ workflows:
             - build
 
       # Windows jobs
-      - e2e-cli-win:
-          requires:
-            - build
+      - e2e-cli-win
 
       # Publish jobs
       - snapshot_publish:


### PR DESCRIPTION
This commits changes the CI workflow to run all the complete E2E test suit on Windows for PRs.

The also increase the parallelism for Windows tests to 16 to reduce the time taken for this step and removes the requirement for the `build` step before running `e2e-cli-win`.

Based on the current timings, this change will not increase PR CI times.