### PR TITLE
test: remove unnecessary `extract-i18n` command from i18n setup

### DIFF
--- a/tests/legacy-cli/e2e/tests/i18n/ivy-localize-sourcemaps.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/ivy-localize-sourcemaps.ts
@@ -6,7 +6,7 @@ export default async function () {
   // Setup i18n tests and config.
   await setupI18nConfig();
 
-  const { stderr } = await ng('build', '--source-map');
+  await ng('build', '--source-map');
 
   for (const { outputPath } of langTranslations) {
     // Ensure sourcemap for modified file contains content


### PR DESCRIPTION
This helps to cut down on the time taken i18n tests take to run.