### PR TITLE
fix(@schematics/angular): only issue a warning for addDependency existing specifier

### DIFF
--- a/packages/schematics/angular/utility/dependency.ts
+++ b/packages/schematics/angular/utility/dependency.ts
@@ -103,13 +103,23 @@ export function addDependency(
     if (!dependencySection) {
       // Section is not present. The dependency can be added to a new object literal for the section.
       manifest[type] = { [name]: specifier };
-    } else if (dependencySection[name] === specifier) {
-      // Already present with same specifier
-      return;
-    } else if (dependencySection[name]) {
-      // Already present but different specifier
-      throw new Error(`Package dependency "${name}" already exists with a different specifier.`);
     } else {
+      const existingSpecifier = dependencySection[name];
+
+      if (existingSpecifier === specifier) {
+        // Already present with same specifier
+        return;
+      }
+
+      if (existingSpecifier) {
+        // Already present but different specifier
+        // This warning may become an error in the future
+        context.logger.warn(
+          `Package dependency "${name}" already exists with a different specifier. ` +
+            `"${existingSpecifier}" will be replaced with "${specifier}".`,
+        );
+      }
+
       // Add new dependency in alphabetical order
       const entries = Object.entries(dependencySection);
       entries.push([name, specifier]);


### PR DESCRIPTION
When using the `addDependency` helper rule, a package specifier mismatch will
now result in a warning instead of an error. This prevents the potential
for breaking changes in schematics that previously allowed the behavior.
The warning will also display the existing and new specifiers to better inform
the schematic user of the outcome of the schematic.