### PR TITLE
fix(@angular-devkit/core): log name of invalid extension too

### DIFF
--- a/packages/angular_devkit/core/src/workspace/json/reader.ts
+++ b/packages/angular_devkit/core/src/workspace/json/reader.ts
@@ -100,7 +100,7 @@ function parseWorkspace(workspaceNode: Node, context: ParserContext): WorkspaceD
       projects = parseProjectsObject(nodes, context);
     } else {
       if (!specialWorkspaceExtensions.includes(name) && !/^[a-z]{1,3}-.*/.test(name)) {
-        context.warn(`Project extension with invalid name found.`, name);
+        context.warn(`Project extension with invalid name (${name}) found.`, name);
       }
       if (extensions) {
         extensions[name] = value;
@@ -202,7 +202,7 @@ function parseProject(
         break;
       default:
         if (!specialProjectExtensions.includes(name) && !/^[a-z]{1,3}-.*/.test(name)) {
-          context.warn(`Project extension with invalid name found.`, name);
+          context.warn(`Project extension with invalid name (${name}) found.`, name);
         }
         if (extensions) {
           extensions[name] = value;


### PR DESCRIPTION
When logging the warning `Project extension with invalid name found.`, include the name of the project extension, to facilitate debugging.