### PR TITLE
Fix warning in localized projects

### DIFF
--- a/packages/angular_devkit/core/src/workspace/json/reader.ts
+++ b/packages/angular_devkit/core/src/workspace/json/reader.ts
@@ -74,7 +74,7 @@ export async function readJsonWorkspace(
 
 const specialWorkspaceExtensions = ['cli', 'defaultProject', 'newProjectRoot', 'schematics'];
 
-const specialProjectExtensions = ['cli', 'schematics', 'projectType'];
+const specialProjectExtensions = ['cli', 'schematics', 'projectType', 'i18n'];
 
 function parseWorkspace(workspaceNode: Node, context: ParserContext): WorkspaceDefinition {
   const jsonMetadata = context.metadata;


### PR DESCRIPTION
When parsing the angular.json file, the 'i18n' key used to configure localization in a localized project should be treated as a special project extension key.

This fixes the warning "Project extension with invalid name found." printed when starting/building the project.