### PR TITLE
refactor: bump version of `main` branch to `14.2.0-next.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@angular/devkit-repo",
-  "version": "14.1.0-next.4",
+  "version": "14.2.0-next.0",
   "private": true,
   "description": "Software Development Kit for Angular",
   "bin": {


### PR DESCRIPTION
This should have been done automatically in the `14.1.0-rc.0` release, but tooling issues mean this was missed and we can't successfully fix the RC release since `main` and `14.1.x` and in inconsistent states, which confuses `ng-dev`.