### PR TITLE
ci: change shell to bash in fail_fast job

### DIFF
--- a/.circleci/dynamic_config.yml
+++ b/.circleci/dynamic_config.yml
@@ -77,6 +77,7 @@ commands:
     steps:
       - run:
           name: 'Cancel workflow on fail'
+          shell: bash
           when: on_fail
           command: |
             curl -X POST --header "Content-Type: application/json" "https://circleci.com/api/v2/workflow/${CIRCLE_WORKFLOW_ID}/cancel?circle-token=${CIRCLE_TOKEN}"


### PR DESCRIPTION
Currently fail_fast doesn't work in Windows as the shell is set to Powershell

```
#!powershell.exe -ExecutionPolicy Bypass
curl -X POST --header "Content-Type: application/json" "https://circleci.com/api/v2/workflow/${CIRCLE_WORKFLOW_ID}/cancel?circle-token=${CIRCLE_TOKEN}"

Invoke-WebRequest : A parameter cannot be found that matches parameter name 'X'.
At line:1 char:6
+ curl -X POST --header "Content-Type: application/json" "https://circl ...
+      ~~
    + CategoryInfo          : InvalidArgument: (:) [Invoke-WebRequest], ParameterBindingException
    + FullyQualifiedErrorId : NamedParameterNotFound,Microsoft.PowerShell.Commands.InvokeWebRequestCommand

Exited with code exit status 1
CircleCI received exit code 1
```