### PR TITLE
docs: remove `@latest` reference from `npm init` command

### DIFF
--- a/packages/angular/create/README.md
+++ b/packages/angular/create/README.md
@@ -9,7 +9,7 @@ Scaffold an Angular CLI workspace without needing to install the Angular CLI glo
 NPM
 
 ```
-npm init @angular@latest [project-name] -- [...options]
+npm init @angular [project-name] -- [...options]
 ```
 
 Yarn


### PR DESCRIPTION
NPM doesn't correctly handle version specifier for scoped packages when using the `init` command

See: https://github.com/npm/cli/issues/5175