### PR TITLE
fix(@angular-devkit/build-angular): fallback to use projectRoot when sourceRoot is missing during coverage

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
@@ -386,7 +386,7 @@ export async function getCommonConfig(wco: WebpackConfigOptions): Promise<Config
                 supportedBrowsers: buildOptions.supportedBrowsers,
                 instrumentCode: codeCoverage
                   ? {
-                      includedBasePath: sourceRoot,
+                      includedBasePath: sourceRoot ?? projectRoot,
                       excludedPaths: getInstrumentationExcludedPaths(root, codeCoverageExclude),
                     }
                   : undefined,


### PR DESCRIPTION
…
With this change we fallback to use the projectRoot when the sourceRoot is missing for files to be included in coverage.

Closes: #23591