### PR TITLE
refactor(@angular-devkit/architect-cli): remove rxjs as a dependency

### DIFF
--- a/packages/angular_devkit/architect_cli/BUILD.bazel
+++ b/packages/angular_devkit/architect_cli/BUILD.bazel
@@ -24,7 +24,6 @@ ts_library(
         "@npm//@types/progress",
         "@npm//@types/yargs-parser",
         "@npm//ansi-colors",
-        "@npm//rxjs",
     ],
 )
 

--- a/packages/angular_devkit/architect_cli/package.json
+++ b/packages/angular_devkit/architect_cli/package.json
@@ -18,7 +18,6 @@
     "@angular-devkit/core": "0.0.0-PLACEHOLDER",
     "ansi-colors": "4.1.3",
     "progress": "2.0.3",
-    "rxjs": "6.6.7",
     "symbol-observable": "4.0.0",
     "yargs-parser": "21.0.1"
   },


### PR DESCRIPTION
`rxjs` was only a dependency for the `tap` operator which can be replaced
by accessing the result object returned from awaiting the builder output
`Observable` which is already converted to a Promise.