### PR TITLE
build: fix snapshot build package.json substitution

### DIFF
--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -162,6 +162,7 @@ def pkg_npm(name, pkg_deps = [], use_prodmode_output = False, **kwargs):
         exclude_prefixes = [
             "packages",  # Exclude compiled outputs of dependent packages
         ],
+        allow_overwrites = True,
     )
 
     _pkg_npm(


### PR DESCRIPTION
This relied on undocumented behaviour in copy_to_directory which now needs to be enabled with a flag. The package.json file which had the correct substitutions wasn't included in the package.