### PR TITLE
fix(@schematics/angular): Allow skipping existing dependencies in E2E schematic

### DIFF
--- a/packages/schematics/angular/e2e/index.ts
+++ b/packages/schematics/angular/e2e/index.ts
@@ -20,6 +20,7 @@ import {
 import {
   AngularBuilder,
   DependencyType,
+  ExistingBehavior,
   addDependency,
   updateWorkspace,
 } from '@schematics/angular/utility';
@@ -92,7 +93,10 @@ export default function (options: E2eOptions): Rule {
         ]),
       ),
       ...E2E_DEV_DEPENDENCIES.map((name) =>
-        addDependency(name, latestVersions[name], { type: DependencyType.Dev }),
+        addDependency(name, latestVersions[name], {
+          type: DependencyType.Dev,
+          existing: ExistingBehavior.Skip,
+        }),
       ),
       addScriptsToPackageJson(),
     ]);

--- a/packages/schematics/angular/utility/index.ts
+++ b/packages/schematics/angular/utility/index.ts
@@ -18,4 +18,4 @@ export {
 export { Builders as AngularBuilder } from './workspace-models';
 
 // Package dependency related rules and types
-export { DependencyType, InstallBehavior, addDependency } from './dependency';
+export { DependencyType, ExistingBehavior, InstallBehavior, addDependency } from './dependency';


### PR DESCRIPTION
The E2E schematic will now (as it did previously) skip adding dependencies
if they already exist within the `package.json` regardless of the specifier.
This is accomplished with the `existing` option for the `addDependency` rule
which allows defining the behavior for when a dependency already exists.
Currently the two option behaviors are skip and replace with replace being
the default to retain behavior for existing rule usages.