### PR TITLE
fix(@angular-devkit/build-angular): allow the esbuild-based builder to fully resolve global stylesheet packages

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
@@ -149,7 +149,10 @@ export async function buildEsbuildBrowser(
     const { entryPoints: stylesheetEntrypoints, noInjectNames } = resolveGlobalStyles(
       options.styles,
       workspaceRoot,
-      !!options.preserveSymlinks,
+      // preserveSymlinks is always true here to allow the bundler to handle the option
+      true,
+      // skipResolution to leverage the bundler's more comprehensive resolution
+      true,
     );
     for (const [name, files] of Object.entries(stylesheetEntrypoints)) {
       const virtualEntryData = files
@@ -164,6 +167,7 @@ export async function buildEsbuildBrowser(
           sourcemap: !!sourcemapOptions.styles && (sourcemapOptions.hidden ? 'external' : true),
           outputNames: noInjectNames.includes(name) ? { media: outputNames.media } : outputNames,
           includePaths: options.stylePreprocessorOptions?.includePaths,
+          preserveSymlinks: options.preserveSymlinks,
         },
       );
 

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/stylesheets.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/stylesheets.ts
@@ -38,8 +38,8 @@ async function bundleStylesheet(
     write: false,
     platform: 'browser',
     preserveSymlinks: options.preserveSymlinks,
-    conditions: ['style'],
-    mainFields: ['style'],
+    conditions: ['style', 'sass'],
+    mainFields: ['style', 'sass'],
     plugins: [
       createSassPlugin({ sourcemap: !!options.sourcemap, includePaths: options.includePaths }),
     ],


### PR DESCRIPTION
The esbuild-based experimental builder will now leverage the bundler to perform resolution of CSS imports.
This allows for more comprehensive resolution including packages which use the `sass` and/or `style` custom
conditions within a `package.json` exports field.