### PR TITLE
fix(@angular-devkit/build-angular): correctly set `ngDevMode` in esbuilder

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
@@ -342,7 +342,7 @@ async function bundleCode(
       ),
     ],
     define: {
-      'ngDevMode': optimizationOptions.scripts ? 'false' : 'true',
+      ...(optimizationOptions.scripts ? { 'ngDevMode': 'false' } : undefined),
       'ngJitMode': 'false',
     },
   });


### PR DESCRIPTION

During development we should not set `ngDevMode` to `true`, as this is expected to be an object literal.

Closes #23627