### PR TITLE
fix(@angular-devkit/build-angular): correctly respond to preflight requests

### DIFF
--- a/tests/legacy-cli/e2e/tests/commands/serve/preflight-request.ts
+++ b/tests/legacy-cli/e2e/tests/commands/serve/preflight-request.ts
@@ -1,0 +1,15 @@
+import fetch from 'node-fetch';
+import { ngServe } from '../../../utils/project';
+
+export default async function () {
+  const port = await ngServe();
+  const { size, status } = await fetch(`http://localhost:${port}/main.js`, { method: 'OPTIONS' });
+
+  if (size !== 0) {
+    throw new Error(`Expected "size" to be "0" but got "${size}".`);
+  }
+
+  if (status !== 204) {
+    throw new Error(`Expected "status" to be "204" but got "${status}".`);
+  }
+}


### PR DESCRIPTION


With this commit, we add a middleware that handles preflight requests as currently responses for this type of requests returning 404.

This is a temporary workaround until this issue is fixed upstream. See: https://github.com/webpack/webpack-dev-server/issues/4180

Closes #23639