### PR TITLE
fix(@angular/cli): catch clause variable is not an Error instance

### DIFF
--- a/packages/angular/cli/src/utilities/error.ts
+++ b/packages/angular/cli/src/utilities/error.ts
@@ -9,5 +9,9 @@
 import assert from 'assert';
 
 export function assertIsError(value: unknown): asserts value is Error & { code?: string } {
-  assert(value instanceof Error, 'catch clause variable is not an Error instance');
+  const isError =
+    value instanceof Error ||
+    // The following is needing to identify errors coming from RxJs.
+    (typeof value === 'object' && value && 'name' in value && 'message' in value);
+  assert(isError, 'catch clause variable is not an Error instance');
 }

--- a/packages/angular_devkit/build_angular/src/utils/error.ts
+++ b/packages/angular_devkit/build_angular/src/utils/error.ts
@@ -9,5 +9,9 @@
 import assert from 'assert';
 
 export function assertIsError(value: unknown): asserts value is Error & { code?: string } {
-  assert(value instanceof Error, 'catch clause variable is not an Error instance');
+  const isError =
+    value instanceof Error ||
+    // The following is needing to identify errors coming from RxJs.
+    (typeof value === 'object' && value && 'name' in value && 'message' in value);
+  assert(isError, 'catch clause variable is not an Error instance');
 }


### PR DESCRIPTION


Errors thrown in RxJs are not instanceof Error and therefore the check will always fail.

Closes #23631