### PR TITLE
test: revert local test project file changes on test completion

### DIFF
--- a/tests/legacy-cli/e2e/tests/misc/supported-angular.ts
+++ b/tests/legacy-cli/e2e/tests/misc/supported-angular.ts
@@ -24,12 +24,14 @@ export default async function () {
 
   // Major should succeed, but we don't need to test it here since it's tested everywhere else.
   // Major+1 and -1 should fail architect commands, but allow other commands.
-  await fakeCoreVersion(cliMajor + 1);
-  await expectToFail(() => ng('build'), 'Should fail Major+1');
-  await ng('version');
-  await fakeCoreVersion(cliMajor - 1);
-  await ng('version');
-
-  // Restore the original core package.json.
-  await writeFile(angularCorePkgPath, originalAngularCorePkgJson);
+  try {
+    await fakeCoreVersion(cliMajor + 1);
+    await expectToFail(() => ng('build'), 'Should fail Major+1');
+    await ng('version');
+    await fakeCoreVersion(cliMajor - 1);
+    await ng('version');
+  } finally {
+    // Restore the original core package.json.
+    await writeFile(angularCorePkgPath, originalAngularCorePkgJson);
+  }
 }

--- a/tests/legacy-cli/e2e_runner.ts
+++ b/tests/legacy-cli/e2e_runner.ts
@@ -242,13 +242,15 @@ async function runInitializer(absoluteName: string) {
 async function runTest(absoluteName: string) {
   process.chdir(join(getGlobalVariable('projects-root'), 'test-project'));
 
-  await launchTestProcess(absoluteName);
-
-  logStack.push(new logging.NullLogger());
   try {
-    await gitClean();
+    await launchTestProcess(absoluteName);
   } finally {
-    logStack.pop();
+    logStack.push(new logging.NullLogger());
+    try {
+      await gitClean();
+    } finally {
+      logStack.pop();
+    }
   }
 }
 


### PR DESCRIPTION
To prevent cascading errors in other tests. Normally one error stops the entire suite but I've found this annoying when experimenting 🤷 