### PR TITLE
test: move tempdir creation to util method

### DIFF
--- a/tests/legacy-cli/e2e/setup/001-create-tmp-dir.ts
+++ b/tests/legacy-cli/e2e/setup/001-create-tmp-dir.ts
@@ -1,9 +1,8 @@
-import { mkdtempSync, realpathSync } from 'fs';
-import { tmpdir } from 'os';
-import { dirname, join } from 'path';
+import { dirname } from 'path';
 import { getGlobalVariable, setGlobalVariable } from '../utils/env';
+import { mktempd } from '../utils/utils';
 
-export default function () {
+export default async function () {
   const argv = getGlobalVariable('argv');
 
   // Get to a temporary directory.
@@ -13,7 +12,7 @@ export default function () {
   } else if (argv.tmpdir) {
     tempRoot = argv.tmpdir;
   } else {
-    tempRoot = mkdtempSync(join(realpathSync(tmpdir()), 'angular-cli-e2e-'));
+    tempRoot = await mktempd('angular-cli-e2e-');
   }
   console.log(`  Using "${tempRoot}" as temporary directory for a new project.`);
   setGlobalVariable('tmp-root', tempRoot);

--- a/tests/legacy-cli/e2e/tests/commands/completion/completion-prompt.ts
+++ b/tests/legacy-cli/e2e/tests/commands/completion/completion-prompt.ts
@@ -1,8 +1,9 @@
 import { promises as fs } from 'fs';
-import * as os from 'os';
 import * as path from 'path';
 import { env } from 'process';
 import { getGlobalVariable } from '../../../utils/env';
+import { mktempd } from '../../../utils/utils';
+
 import {
   execAndCaptureError,
   execAndWaitForOutputToMatch,
@@ -448,7 +449,7 @@ async function windowsTests(): Promise<void> {
 }
 
 async function mockHome(cb: (home: string) => Promise<void>): Promise<void> {
-  const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), 'angular-cli-e2e-home-'));
+  const tempHome = await mktempd('angular-cli-e2e-home-');
 
   try {
     await cb(tempHome);

--- a/tests/legacy-cli/e2e/tests/commands/completion/completion.ts
+++ b/tests/legacy-cli/e2e/tests/commands/completion/completion.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from 'fs';
-import * as os from 'os';
 import * as path from 'path';
 import { getGlobalVariable } from '../../../utils/env';
+import { mktempd } from '../../../utils/utils';
 import {
   execAndCaptureError,
   execAndWaitForOutputToMatch,
@@ -397,7 +397,7 @@ async function windowsTests(): Promise<void> {
 }
 
 async function mockHome(cb: (home: string) => Promise<void>): Promise<void> {
-  const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), 'angular-cli-e2e-home-'));
+  const tempHome = await mktempd('angular-cli-e2e-home-');
 
   try {
     await cb(tempHome);

--- a/tests/legacy-cli/e2e/utils/registry.ts
+++ b/tests/legacy-cli/e2e/utils/registry.ts
@@ -1,9 +1,8 @@
 import { spawn } from 'child_process';
-import { mkdtempSync, realpathSync } from 'fs';
-import { tmpdir } from 'os';
 import { join } from 'path';
 import { getGlobalVariable } from './env';
 import { writeFile, readFile } from './fs';
+import { mktempd } from './utils';
 
 export async function createNpmRegistry(
   port: number,
@@ -11,7 +10,7 @@ export async function createNpmRegistry(
   withAuthentication = false,
 ) {
   // Setup local package registry
-  const registryPath = mkdtempSync(join(realpathSync(tmpdir()), 'angular-cli-e2e-registry-'));
+  const registryPath = await mktempd('angular-cli-e2e-registry-');
 
   let configContent = await readFile(
     join(__dirname, '../../', withAuthentication ? 'verdaccio_auth.yaml' : 'verdaccio.yaml'),

--- a/tests/legacy-cli/e2e/utils/utils.ts
+++ b/tests/legacy-cli/e2e/utils/utils.ts
@@ -1,3 +1,7 @@
+import { mkdtemp, realpath } from 'fs/promises';
+import { tmpdir } from 'os';
+import path from 'path';
+
 export function expectToFail(fn: () => Promise<any>, errorMessage?: string): Promise<any> {
   return fn().then(
     () => {
@@ -17,4 +21,8 @@ export function wait(msecs: number): Promise<void> {
   return new Promise((resolve) => {
     setTimeout(resolve, msecs);
   });
+}
+
+export async function mktempd(prefix: string): Promise<string> {
+  return realpath(await mkdtemp(path.join(tmpdir(), prefix)));
 }


### PR DESCRIPTION
To put the login in a common location. This will allow easily using the bazel temp dir when converting to bazel.