### PR TITLE
fix(@angular-devkit/schematics): Export 'rename' rule

### DIFF
--- a/goldens/public-api/angular_devkit/schematics/index.md
+++ b/goldens/public-api/angular_devkit/schematics/index.md
@@ -699,6 +699,9 @@ export interface RandomOptions {
 }
 
 // @public (undocumented)
+export function rename(match: FilePredicate<boolean>, to: FilePredicate<string>): Rule;
+
+// @public (undocumented)
 export interface RenameFileAction extends ActionBase {
     // (undocumented)
     readonly kind: 'r';

--- a/packages/angular_devkit/schematics/src/index.ts
+++ b/packages/angular_devkit/schematics/src/index.ts
@@ -23,6 +23,7 @@ export * from './rules/base';
 export * from './rules/call';
 export * from './rules/move';
 export * from './rules/random';
+export * from './rules/rename';
 export * from './rules/schematic';
 export * from './rules/template';
 export * from './rules/url';


### PR DESCRIPTION
- Export the 'rename' rule.
  - The other rules in this directory are exported, so I assumed this one should
    be exported as well.