### PR TITLE
perf(@angular-devkit/build-angular): reduce babel transformation in esbuild builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/compiler-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/compiler-plugin.ts
@@ -341,7 +341,7 @@ export function createCompilerPlugin(
               [
                 angularApplicationPreset,
                 {
-                  forceAsyncTransformation: data.includes('async'),
+                  forceAsyncTransformation: /for\s+await\s*\(|async\s+function\s*\*/.test(data),
                   optimize: pluginOptions.advancedOptimizations && {},
                 },
               ],
@@ -388,7 +388,8 @@ export function createCompilerPlugin(
                   linkerPluginCreator,
                 },
                 forceAsyncTransformation:
-                  !/[\\/][_f]?esm2015[\\/]/.test(args.path) && data.includes('async'),
+                  !/[\\/][_f]?esm2015[\\/]/.test(args.path) &&
+                  /for\s+await\s*\(|async\s+function\s*\*/.test(data),
                 optimize: pluginOptions.advancedOptimizations && {
                   looseEnums: angularPackage,
                   pureTopLevel: angularPackage,

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
@@ -307,6 +307,18 @@ async function bundleCode(
     entryNames: outputNames.bundles,
     assetNames: outputNames.media,
     target: 'es2020',
+    supported: {
+      // Native async/await is not supported with Zone.js. Disabling support here will cause
+      // esbuild to downlevel async/await to a Zone.js supported form.
+      'async-await': false,
+      // Zone.js also does not support async generators or async iterators. However, esbuild does
+      // not currently support downleveling either of them. Instead babel is used within the JS/TS
+      // loader to perform the downlevel transformation. They are both disabled here to allow
+      // esbuild to handle them in the future if support is ever added.
+      // NOTE: If esbuild adds support in the future, the babel support for these can be disabled.
+      'async-generator': false,
+      'for-await': false,
+    },
     mainFields: ['es2020', 'browser', 'module', 'main'],
     conditions: ['es2020', 'es2015', 'module'],
     resolveExtensions: ['.ts', '.tsx', '.mjs', '.js'],


### PR DESCRIPTION
When using the experimental esbuild-based browser application builder, babel transformation
is now only performed on a file if the file requires the specific transformations enabled
for the build. This has the benefit of removing the need to parse and process files that
will not be affected by the enabled transformations.
From initial testing, this provides a 30% build time improvement for development builds of a
newly generated application and a 10% improvement for production builds.