### PR TITLE
test: remove ci specific logic

### DIFF
--- a/tests/legacy-cli/e2e_runner.ts
+++ b/tests/legacy-cli/e2e_runner.ts
@@ -160,7 +160,6 @@ if (testsToRun.length == allTests.length) {
 console.log(['Tests:', ...testsToRun].join('\n '));
 
 setGlobalVariable('argv', argv);
-setGlobalVariable('ci', process.env['CI']?.toLowerCase() === 'true' || process.env['CI'] === '1');
 setGlobalVariable('package-manager', argv.yarn ? 'yarn' : 'npm');
 
 Promise.all([findFreePort(), findFreePort()])


### PR DESCRIPTION
This seems unnecessary.

All the tests where the removed `if` is truthy seem to work locally and CI is green.