### PR TITLE
test: use common mockHome method

### DIFF
--- a/tests/legacy-cli/e2e/tests/commands/completion/completion-prompt.ts
+++ b/tests/legacy-cli/e2e/tests/commands/completion/completion-prompt.ts
@@ -2,7 +2,7 @@ import { promises as fs } from 'fs';
 import * as path from 'path';
 import { env } from 'process';
 import { getGlobalVariable } from '../../../utils/env';
-import { mktempd } from '../../../utils/utils';
+import { mockHome } from '../../../utils/utils';
 
 import {
   execAndCaptureError,
@@ -446,14 +446,4 @@ async function windowsTests(): Promise<void> {
       );
     }
   });
-}
-
-async function mockHome(cb: (home: string) => Promise<void>): Promise<void> {
-  const tempHome = await mktempd('angular-cli-e2e-home-');
-
-  try {
-    await cb(tempHome);
-  } finally {
-    await fs.rm(tempHome, { recursive: true, force: true });
-  }
 }

--- a/tests/legacy-cli/e2e/tests/commands/completion/completion.ts
+++ b/tests/legacy-cli/e2e/tests/commands/completion/completion.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from 'fs';
 import * as path from 'path';
 import { getGlobalVariable } from '../../../utils/env';
-import { mktempd } from '../../../utils/utils';
+import { mockHome } from '../../../utils/utils';
 import {
   execAndCaptureError,
   execAndWaitForOutputToMatch,
@@ -29,7 +29,6 @@ export default async function () {
       {
         ...process.env,
         'SHELL': '/bin/bash',
-        'HOME': home,
       },
     );
 
@@ -52,7 +51,6 @@ source <(ng completion script)
       {
         ...process.env,
         'SHELL': '/usr/bin/zsh',
-        'HOME': home,
       },
     );
 
@@ -77,7 +75,6 @@ source <(ng completion script)
       {
         ...process.env,
         'SHELL': '/bin/bash',
-        'HOME': home,
       },
     );
 
@@ -103,7 +100,6 @@ source <(ng completion script)
       {
         ...process.env,
         'SHELL': '/bin/bash',
-        'HOME': home,
       },
     );
 
@@ -129,7 +125,6 @@ source <(ng completion script)
       {
         ...process.env,
         'SHELL': '/bin/bash',
-        'HOME': home,
       },
     );
 
@@ -160,7 +155,6 @@ source <(ng completion script)
       {
         ...process.env,
         'SHELL': '/bin/bash',
-        'HOME': home,
       },
     );
 
@@ -196,7 +190,6 @@ source <(ng completion script)
       {
         ...process.env,
         'SHELL': '/usr/bin/zsh',
-        'HOME': home,
       },
     );
 
@@ -222,7 +215,6 @@ source <(ng completion script)
       {
         ...process.env,
         'SHELL': '/usr/bin/zsh',
-        'HOME': home,
       },
     );
 
@@ -248,7 +240,6 @@ source <(ng completion script)
       {
         ...process.env,
         'SHELL': '/usr/bin/zsh',
-        'HOME': home,
       },
     );
 
@@ -279,7 +270,6 @@ source <(ng completion script)
       {
         ...process.env,
         'SHELL': '/usr/bin/zsh',
-        'HOME': home,
       },
     );
 
@@ -322,7 +312,6 @@ source <(ng completion script)
     const err = await execAndCaptureError('ng', ['completion'], {
       ...process.env,
       SHELL: undefined,
-      HOME: home,
     });
     if (!err.message.includes('`$SHELL` environment variable not set.')) {
       throw new Error(`Expected unset \`$SHELL\` error message, but got:\n\n${err.message}`);
@@ -334,7 +323,6 @@ source <(ng completion script)
     const err = await execAndCaptureError('ng', ['completion'], {
       ...process.env,
       SHELL: '/usr/bin/unknown',
-      HOME: home,
     });
     if (!err.message.includes('Unknown `$SHELL` environment variable')) {
       throw new Error(`Expected unknown \`$SHELL\` error message, but got:\n\n${err.message}`);
@@ -346,7 +334,6 @@ source <(ng completion script)
     const { stdout } = await execWithEnv('ng', ['completion'], {
       ...process.env,
       'SHELL': '/usr/bin/zsh',
-      'HOME': home,
     });
 
     if (stdout.includes('there does not seem to be a global install of the Angular CLI')) {
@@ -373,7 +360,6 @@ source <(ng completion script)
       const { stdout } = await execWithEnv(localCliBinary, ['completion'], {
         ...process.env,
         'SHELL': '/usr/bin/zsh',
-        'HOME': home,
       });
 
       if (stdout.includes('there does not seem to be a global install of the Angular CLI')) {
@@ -393,15 +379,5 @@ async function windowsTests(): Promise<void> {
     throw new Error(
       `Expected Windows autocompletion to fail with custom error, but got:\n\n${err.message}`,
     );
-  }
-}
-
-async function mockHome(cb: (home: string) => Promise<void>): Promise<void> {
-  const tempHome = await mktempd('angular-cli-e2e-home-');
-
-  try {
-    await cb(tempHome);
-  } finally {
-    await fs.rm(tempHome, { recursive: true, force: true });
   }
 }

--- a/tests/legacy-cli/e2e/tests/misc/ask-analytics-command.ts
+++ b/tests/legacy-cli/e2e/tests/misc/ask-analytics-command.ts
@@ -1,17 +1,16 @@
-import { promises as fs } from 'fs';
 import { execWithEnv } from '../../utils/process';
+import { mockHome } from '../../utils/utils';
 
 const ANALYTICS_PROMPT = /Would you like to share anonymous usage data/;
 
 export default async function () {
   // CLI should prompt for analytics permissions.
-  await mockHome(async (home) => {
+  await mockHome(async () => {
     const { stdout } = await execWithEnv(
       'ng',
       ['version'],
       {
         ...process.env,
-        HOME: home,
         NG_FORCE_TTY: '1',
         NG_FORCE_AUTOCOMPLETE: 'false',
       },
@@ -24,10 +23,9 @@ export default async function () {
   });
 
   // CLI should skip analytics prompt with `NG_CLI_ANALYTICS=false`.
-  await mockHome(async (home) => {
+  await mockHome(async () => {
     const { stdout } = await execWithEnv('ng', ['version'], {
       ...process.env,
-      HOME: home,
       NG_FORCE_TTY: '1',
       NG_CLI_ANALYTICS: 'false',
       NG_FORCE_AUTOCOMPLETE: 'false',
@@ -39,10 +37,9 @@ export default async function () {
   });
 
   // CLI should skip analytics prompt during `ng update`.
-  await mockHome(async (home) => {
+  await mockHome(async () => {
     const { stdout } = await execWithEnv('ng', ['update', '--help'], {
       ...process.env,
-      HOME: home,
       NG_FORCE_TTY: '1',
       NG_FORCE_AUTOCOMPLETE: 'false',
     });
@@ -53,14 +50,4 @@ export default async function () {
       );
     }
   });
-}
-
-async function mockHome(cb: (home: string) => Promise<void>): Promise<void> {
-  const tempHome = await fs.mkdtemp('angular-cli-e2e-home-');
-
-  try {
-    await cb(tempHome);
-  } finally {
-    await fs.rm(tempHome, { recursive: true, force: true });
-  }
 }

--- a/tests/legacy-cli/e2e/utils/utils.ts
+++ b/tests/legacy-cli/e2e/utils/utils.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, realpath } from 'fs/promises';
+import { mkdtemp, realpath, rm } from 'fs/promises';
 import { tmpdir } from 'os';
 import path from 'path';
 
@@ -25,4 +25,19 @@ export function wait(msecs: number): Promise<void> {
 
 export async function mktempd(prefix: string): Promise<string> {
   return realpath(await mkdtemp(path.join(tmpdir(), prefix)));
+}
+
+export async function mockHome(cb: (home: string) => Promise<void>): Promise<void> {
+  const tempHome = await mktempd('angular-cli-e2e-home-');
+
+  const oldHome = process.env.HOME;
+  process.env.HOME = tempHome;
+
+  try {
+    await cb(tempHome);
+  } finally {
+    process.env.HOME = oldHome;
+
+    await rm(tempHome, { recursive: true, force: true });
+  }
 }


### PR DESCRIPTION
Primarily because one of them was using `fs.mkdtemp` instead of the util `mktempd` method which standardizes the tempdir logic. Using the common util method will allow bazel (#23074) to use the bazel tempdir instead of system tempdir