### PR TITLE
build: disable UT testing multiple node versions

### DIFF
--- a/tools/toolchain_info.bzl
+++ b/tools/toolchain_info.bzl
@@ -4,7 +4,8 @@
 # the order will match against the order in the TOOLCHAIN_VERSION list.
 TOOLCHAINS_NAMES = [
     "node14",
-    "node16",
+    # TODO enable one we know more why there is a memory usage increase and app-shell tests work with Node.js 16.
+    # "node16",
 ]
 
 # this is the list of toolchains that should be used and are registered with nodejs_register_toolchains in the WORKSPACE file
@@ -14,11 +15,12 @@ TOOLCHAINS_VERSIONS = [
         "@bazel_tools//src/conditions:darwin": "@node14_darwin_amd64//:node_toolchain",
         "@bazel_tools//src/conditions:windows": "@node14_windows_amd64//:node_toolchain",
     }),
-    select({
-        "@bazel_tools//src/conditions:linux_x86_64": "@node14_linux_amd64//:node_toolchain",
-        "@bazel_tools//src/conditions:darwin": "@node14_darwin_amd64//:node_toolchain",
-        "@bazel_tools//src/conditions:windows": "@node14_windows_amd64//:node_toolchain",
-    }),
+    # TODO enable one we know more why there is a memory usage increase and app-shell tests work with Node.js 16.
+    # select({
+    #     "@bazel_tools//src/conditions:linux_x86_64": "@node16_linux_amd64//:node_toolchain",
+    #     "@bazel_tools//src/conditions:darwin": "@node16_darwin_amd64//:node_toolchain",
+    #     "@bazel_tools//src/conditions:windows": "@node16_windows_amd64//:node_toolchain",
+    # }),
 ]
 
 # A default toolchain for use when only one is necessary


### PR DESCRIPTION

With this change we disable running UTs on multiple node.js versions. This is mainly an interim solution until we find the root cause of the memory increase and OOM errors during bazel test.

During this change I also noticed that the toolchain was configured incorrectly. Setting the toolchain to use Node.js 16 causes the App-shell tests to fail when used under Bazel. See: https://app.circleci.com/pipelines/github/angular/angular-cli/25009/workflows/4ea86ec8-d1f7-4c91-8810-76f10f8e878c/jobs/325982