### PR TITLE
test: ensure test assets are writable when copied for use in e2e tests

### DIFF
--- a/tests/legacy-cli/e2e/utils/assets.ts
+++ b/tests/legacy-cli/e2e/utils/assets.ts
@@ -1,4 +1,5 @@
 import { join } from 'path';
+import { chmod } from 'fs/promises';
 import glob from 'glob';
 import { getGlobalVariable } from './env';
 import { relative, resolve } from 'path';
@@ -33,7 +34,9 @@ export function copyAssets(assetName: string, to?: string) {
             ? resolve(getGlobalVariable('projects-root'), 'test-project', to, filePath)
             : join(tempRoot, filePath);
 
-        return promise.then(() => copyFile(join(root, filePath), toPath));
+        return promise
+          .then(() => copyFile(join(root, filePath), toPath))
+          .then(() => chmod(toPath, 0o777));
       }, Promise.resolve());
     })
     .then(() => tempRoot);


### PR DESCRIPTION
The source files within the git repo would normally be `rwxr-xr-x`, so writable only by the owner. If the tests are run under a different user they need write permission on the files once copied into the temp directory the e2e tests are running in.