### PR TITLE
fix(@angular/cli): add builders and schematic names as page titles in collected analytics

### DIFF
--- a/packages/angular/cli/src/command-builder/architect-base-command-module.ts
+++ b/packages/angular/cli/src/command-builder/architect-base-command-module.ts
@@ -53,10 +53,15 @@ export abstract class ArchitectBaseCommandModule<T extends object>
       return this.onMissingTarget(e.message);
     }
 
-    await this.reportAnalytics({
-      ...(await architectHost.getOptionsForTarget(target)),
-      ...options,
-    });
+    await this.reportAnalytics(
+      {
+        ...(await architectHost.getOptionsForTarget(target)),
+        ...options,
+      },
+      undefined /** paths */,
+      undefined /** dimensions */,
+      builderName,
+    );
 
     const { logger } = this.context;
 

--- a/packages/angular/cli/src/command-builder/schematics-command-module.ts
+++ b/packages/angular/cli/src/command-builder/schematics-command-module.ts
@@ -147,14 +147,13 @@ export abstract class SchematicsCommandModule
     workflow.engineHost.registerOptionsTransform(async (schematic, options) => {
       if (shouldReportAnalytics) {
         shouldReportAnalytics = false;
-        // ng generate lib -> ng generate
-        const commandName = this.command?.split(' ', 1)[0];
 
-        await this.reportAnalytics(options as {}, [
-          commandName,
-          schematic.collection.name.replace(/\//g, '_'),
-          schematic.name.replace(/\//g, '_'),
-        ]);
+        await this.reportAnalytics(
+          options as {},
+          undefined /** paths */,
+          undefined /** dimensions */,
+          schematic.collection.name + ':' + schematic.name,
+        );
       }
 
       // TODO: The below should be removed in version 15 when we change 1P schematics to use the `workingDirectory smart default`.


### PR DESCRIPTION
With this commit the builder and schematic names are added as page title to page events.

Also, we address a bug where during a watch or error in some cases analytics where not flushed. Examples when the builder has a watch mode.

<img width="1426" alt="Screenshot 2022-08-10 at 11 25 11" src="https://user-images.githubusercontent.com/17563226/183866166-61491938-45d0-4dba-9c6a-cff23f38f779.png">

