### PR TITLE
fix(@angular-devkit/build-angular): avoid collect stats from chunks with no files

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/plugins/analytics.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/plugins/analytics.ts
@@ -172,7 +172,7 @@ export class NgBuildAnalyticsPlugin {
   protected _collectBundleStats(compilation: Compilation) {
     const chunkAssets = new Set<string>();
     for (const chunk of compilation.chunks) {
-      if (!chunk.rendered) {
+      if (!chunk.rendered || chunk.files.size === 0) {
         continue;
       }
 


### PR DESCRIPTION


This commit updates to bundle stats logic to skip checking chunks with no files.

Closes #23717