### PR TITLE
refactor(@angular-devkit/build-angular): remove workaround for handle options requests

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/dev-server.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/dev-server.ts
@@ -92,26 +92,6 @@ export async function getDevServerConfig(
         publicPath: servePath,
         stats: false,
       },
-      setupMiddlewares: (middlewares, _devServer) => {
-        // Temporary workaround for https://github.com/webpack/webpack-dev-server/issues/4180
-        middlewares.push({
-          name: 'options-request-response',
-          path: '*',
-          middleware: (req: Request, res: Response, next: NextFunction) => {
-            if (req.method === 'OPTIONS') {
-              res.statusCode = 204;
-              res.setHeader('Content-Length', 0);
-              res.end();
-
-              return;
-            }
-
-            next();
-          },
-        });
-
-        return middlewares;
-      },
       liveReload,
       hot: hmr && !liveReload ? 'only' : hmr,
       proxy: await addProxyConfig(root, proxyConfig),


### PR DESCRIPTION

The upstream fix https://github.com/webpack/webpack-dev-server/issues/4180 has been merged and released as part of `webpack-dev-server` version `4.10.0`