### PR TITLE
fix(@angular-devkit/core): update workspace extension warning to use correct phrasing

### DIFF
--- a/packages/angular_devkit/core/src/workspace/json/reader.ts
+++ b/packages/angular_devkit/core/src/workspace/json/reader.ts
@@ -120,7 +120,7 @@ function parseWorkspace(workspaceNode: Node, context: ParserContext): WorkspaceD
       projects = parseProjectsObject(nodes, context);
     } else {
       if (!context.unprefixedWorkspaceExtensions.has(name) && !/^[a-z]{1,3}-.*/.test(name)) {
-        context.warn(`Project extension with invalid name (${name}) found.`, name);
+        context.warn(`Workspace extension with invalid name (${name}) found.`, name);
       }
       if (extensions) {
         extensions[name] = value;


### PR DESCRIPTION
## Current behavior
Warnings about workspace extensions are phrased:
> Invalid project extension....

## Expected behavior
Warnings about workspace extensions are phrased:
> Invalid workspace extension....