### PR TITLE
refactor(@angular-devkit/core): remove deprecated rxjs `empty` function usage

### DIFF
--- a/packages/angular_devkit/core/src/logger/logger.ts
+++ b/packages/angular_devkit/core/src/logger/logger.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { Observable, Operator, PartialObserver, Subject, Subscription, empty } from 'rxjs';
+import { EMPTY, Observable, Operator, PartialObserver, Subject, Subscription } from 'rxjs';
 import { JsonObject } from '../json/utils';
 
 export interface LoggerMetadata extends JsonObject {
@@ -34,7 +34,7 @@ export class Logger extends Observable<LogEntry> implements LoggerApi {
   protected readonly _subject: Subject<LogEntry> = new Subject<LogEntry>();
   protected _metadata: LoggerMetadata;
 
-  private _obs: Observable<LogEntry> = empty();
+  private _obs: Observable<LogEntry> = EMPTY;
   private _subscription: Subscription | null = null;
 
   protected get _observable() {


### PR DESCRIPTION
The RxJS `empty` function is deprecated and will be removed in future versions.
The `EMPTY` constant is the recommended replacement.

Closes #23729