### PR TITLE
ci: reduce windows parallelism from 16 to 14

### DIFF
--- a/.circleci/dynamic_config.yml
+++ b/.circleci/dynamic_config.yml
@@ -328,7 +328,7 @@ jobs:
   # Windows jobs
   e2e-cli-win:
     executor: windows-executor
-    parallelism: 16
+    parallelism: 12
     steps:
       - checkout
       - rebase_pr


### PR DESCRIPTION
Since reducing the `resource_class` we started seeing flakes similar to https://app.circleci.com/pipelines/github/angular/angular-cli/25049/workflows/e451d67c-a44b-49d8-919b-928bf98c3473/jobs/326520

Therefore, we try to reduce parallelism to see if this flakiness improves.