### PR TITLE
test: remove reliance on built tarballs in E2E tests

### DIFF
--- a/tests/legacy-cli/e2e/tests/misc/cli-exit-interop.ts
+++ b/tests/legacy-cli/e2e/tests/misc/cli-exit-interop.ts
@@ -1,6 +1,5 @@
 import { createProjectFromAsset } from '../../utils/assets';
 import { moveFile, replaceInFile } from '../../utils/fs';
-import { setRegistry } from '../../utils/packages';
 import { noSilentNg } from '../../utils/process';
 import { useCIChrome, useCIDefaults } from '../../utils/project';
 import { expectToFail } from '../../utils/utils';
@@ -12,11 +11,12 @@ import { expectToFail } from '../../utils/utils';
  */
 
 export default async function () {
+  let restoreRegistry: (() => Promise<void>) | undefined;
+
   try {
     // We need to use the public registry because in the local NPM server we don't have
     // older versions @angular/cli packages which would cause `npm install` during `ng update` to fail.
-    await setRegistry(false);
-    await createProjectFromAsset('13.0-project', true);
+    restoreRegistry = await createProjectFromAsset('13.0-project', true);
 
     // A missing stylesheet error will trigger the stuck process issue with v13 when building
     await moveFile('src/styles.css', 'src/styles.scss');
@@ -30,6 +30,6 @@ export default async function () {
     await useCIDefaults('thirteen-project');
     await noSilentNg('test', '--watch=false');
   } finally {
-    await setRegistry(true);
+    await restoreRegistry?.();
   }
 }

--- a/tests/legacy-cli/e2e/tests/packages/webpack/test-app.ts
+++ b/tests/legacy-cli/e2e/tests/packages/webpack/test-app.ts
@@ -5,8 +5,7 @@ import { execWithEnv } from '../../../utils/process';
 
 export default async function () {
   const webpackCLIBin = normalize('node_modules/.bin/webpack-cli');
-
-  await createProjectFromAsset('webpack/test-app');
+  const restoreRegistry = await createProjectFromAsset('webpack/test-app');
 
   // DISABLE_V8_COMPILE_CACHE=1 is required to disable the `v8-compile-cache` package.
   // It currently does not support dynamic import expressions which are now required by the
@@ -30,4 +29,5 @@ export default async function () {
     'DISABLE_V8_COMPILE_CACHE': '1',
   });
   await expectFileToMatch('dist/app.main.js', 'AppModule');
+  await restoreRegistry();
 }

--- a/tests/legacy-cli/e2e/tests/update/update-multiple-versions.ts
+++ b/tests/legacy-cli/e2e/tests/update/update-multiple-versions.ts
@@ -1,14 +1,13 @@
 import { createProjectFromAsset } from '../../utils/assets';
-import { installWorkspacePackages, setRegistry } from '../../utils/packages';
+import { setRegistry } from '../../utils/packages';
 import { ng } from '../../utils/process';
 import { isPrereleaseCli } from '../../utils/project';
 import { expectToFail } from '../../utils/utils';
 
 export default async function () {
+  let restoreRegistry: (() => Promise<void>) | undefined;
   try {
-    await createProjectFromAsset('12.0-project', true, true);
-    await setRegistry(false);
-    await installWorkspacePackages();
+    restoreRegistry = await createProjectFromAsset('12.0-project', true);
     await setRegistry(true);
 
     const extraArgs = ['--force'];
@@ -38,6 +37,6 @@ export default async function () {
       );
     }
   } finally {
-    await setRegistry(true);
+    await restoreRegistry?.();
   }
 }

--- a/tests/legacy-cli/e2e/utils/project.ts
+++ b/tests/legacy-cli/e2e/utils/project.ts
@@ -94,16 +94,16 @@ export async function prepareProjectForE2e(name: string) {
   await gitCommit('prepare-project-for-e2e');
 }
 
-export function useBuiltPackages(): Promise<void> {
+export function useBuiltPackagesVersions(): Promise<void> {
   return updateJsonFile('package.json', (json) => {
     json['dependencies'] ??= {};
     json['devDependencies'] ??= {};
 
     for (const packageName of Object.keys(packages)) {
       if (packageName in json['dependencies']) {
-        json['dependencies'][packageName] = packages[packageName].tar;
+        json['dependencies'][packageName] = packages[packageName].version;
       } else if (packageName in json['devDependencies']) {
-        json['devDependencies'][packageName] = packages[packageName].tar;
+        json['devDependencies'][packageName] = packages[packageName].version;
       }
     }
   });


### PR DESCRIPTION
Remove reliance on tarballs during E2E. Instead we always download the package from the private NPM server.