### PR TITLE
fix(@angular-devkit/build-angular): fail ng test if compilation

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/plugins/karma/karma.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/plugins/karma/karma.ts
@@ -161,7 +161,7 @@ const init: any = (config: any, emitter: any) => {
   let lastCompilationHash: string | undefined;
   let isFirstRun = true;
 
-  return new Promise<void>((resolve) => {
+  return new Promise<void>((resolve, reject) => {
     compiler.hooks.done.tap('karma', (stats) => {
       if (isFirstRun) {
         // This is needed to block Karma from launching browsers before Webpack writes the assets in memory.
@@ -169,7 +169,9 @@ const init: any = (config: any, emitter: any) => {
         // https://github.com/karma-runner/karma-chrome-launcher/issues/154#issuecomment-986661937
         // https://github.com/angular/angular-cli/issues/22495
         isFirstRun = false;
-        resolve();
+        // In singleRun mode, if there are compilation errors, the process should terminate 
+        // in error at this point. In watch mode, the process is kept alive regardless.
+        config.singleRun && stats.hasErrors() ? reject() : resolve();
       }
 
       if (stats.hasErrors()) {


### PR DESCRIPTION
…errors exist and in singleRun mode

A bug was introduced in v13.2.3
(ref https://github.com/angular/angular-cli/pull/22670/files)
that makes the `ng test` command exit with success when run in
`singleRun` mode, even in the presence of compilation errors.

This change fixes the issue by calling karma `init`'s `reject` handler
if compilation errors are present and running in `singleRun` mode.

The effect is karma does not start and the browser does not launch,
instead the process simply terminates in error. This behavior is very
important to have for CICD systems.

Fixes #23751