### PR TITLE
fix(@angular-devkit/build-angular): correctly handle parenthesis in url

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/styles_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/styles_spec.ts
@@ -706,4 +706,20 @@ describe('Browser Builder styles', () => {
     const result = await browserBuild(architect, host, target, { styles: ['src/styles.css'] });
     expect(await result.files['styles.css']).toContain(svgData);
   });
+
+  it('works when Data URI has parenthesis', async () => {
+    const svgData =
+      '"data:image/svg+xml;charset=utf-8,<svg>' +
+      `<mask id='clip'><g><circle mask='url(%23clip)' cx='11.5' cy='11.5' r='9.25'/><use xlink:href='#text' mask='url(#clip)'/></g>` +
+      '</svg>"';
+
+    host.writeMultipleFiles({
+      'src/styles.css': `
+        div { background: url(${svgData}) }
+      `,
+    });
+
+    const result = await browserBuild(architect, host, target, { styles: ['src/styles.css'] });
+    expect(await result.files['styles.css']).toContain(svgData);
+  });
 });

--- a/packages/angular_devkit/build_angular/src/webpack/plugins/postcss-cli-resources.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/plugins/postcss-cli-resources.ts
@@ -155,7 +155,7 @@ export default function (options?: PostcssCliResourcesOptions): Plugin {
       }
 
       const value = decl.value;
-      const urlRegex = /url(?:\(\s*['"]?)(.*?)(?:['"]?\s*\))/g;
+      const urlRegex = /url(?:\(\s*(['"]?))(.*?)(?:\1\s*\))/g;
       const segments: string[] = [];
 
       let match;
@@ -166,9 +166,8 @@ export default function (options?: PostcssCliResourcesOptions): Plugin {
       const inputFile = decl.source && decl.source.input.file;
       const context = (inputFile && path.dirname(inputFile)) || loader.context;
 
-      // eslint-disable-next-line no-cond-assign
       while ((match = urlRegex.exec(value))) {
-        const originalUrl = match[1];
+        const originalUrl = match[2];
         let processedUrl;
         try {
           processedUrl = await process(originalUrl, context, resourceCache);


### PR DESCRIPTION
PR #23691 introduced a regression that caused paranthesis in url not to be handled correctly.

This change correct this behaviour and adds a test case to valid this.

Closes #23773