### PR TITLE
Minor performance improvements for esbuild-based builder Sass support

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/sass-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/sass-plugin.ts
@@ -16,12 +16,10 @@ export function createSassPlugin(options: { sourcemap: boolean; loadPaths?: stri
     setup(build: PluginBuild): void {
       let sass: typeof import('sass');
 
-      build.onStart(async () => {
-        // Lazily load Sass
-        sass = await import('sass');
-      });
+      build.onLoad({ filter: /\.s[ac]ss$/ }, async (args) => {
+        // Lazily load Sass when a Sass file is found
+        sass ??= await import('sass');
 
-      build.onLoad({ filter: /\.s[ac]ss$/ }, (args) => {
         try {
           const warnings: PartialMessage[] = [];
           // Use sync version as async version is slower.

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/sass-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/sass-plugin.ts
@@ -42,7 +42,7 @@ export function createSassPlugin(options: { sourcemap: boolean; loadPaths?: stri
 
           return {
             loader: 'css',
-            contents: `${css}\n${sourceMapToUrlComment(sourceMap)}`,
+            contents: sourceMap ? `${css}\n${sourceMapToUrlComment(sourceMap)}` : css,
             watchFiles: loadedUrls.map((url) => fileURLToPath(url)),
             warnings,
           };
@@ -68,11 +68,7 @@ export function createSassPlugin(options: { sourcemap: boolean; loadPaths?: stri
   };
 }
 
-function sourceMapToUrlComment(sourceMap: CompileResult['sourceMap']): string {
-  if (!sourceMap) {
-    return '';
-  }
-
+function sourceMapToUrlComment(sourceMap: Exclude<CompileResult['sourceMap'], undefined>): string {
   const urlSourceMap = Buffer.from(JSON.stringify(sourceMap), 'utf-8').toString('base64');
 
   return `/*# sourceMappingURL=data:application/json;charset=utf-8;base64,${urlSourceMap} */`;


### PR DESCRIPTION
When using the experimental esbuild-based browser application builder with Sass stylesheets, an
additional string creation for each output stylesheet will now be avoided when sourcemaps are disabled.
Previously, the Sass compiler was imported on the start of every build regardless of its usage.
The Sass compiler will now only be loaded if a Sass stylesheet is requested.