### PR TITLE
test: ensure saucelabs tests are not excluded in CI

### DIFF
--- a/.circleci/dynamic_config.yml
+++ b/.circleci/dynamic_config.yml
@@ -237,7 +237,7 @@ jobs:
             - run:
                 name: Execute CLI E2E Tests with NPM
                 command: |
-                  node ./tests/legacy-cli/run_e2e --nb-shards=${CIRCLE_NODE_TOTAL} --shard=${CIRCLE_NODE_INDEX} <<# parameters.snapshots >>--ng-snapshots<</ parameters.snapshots >> --tmpdir=/mnt/ramdisk/e2e
+                  node ./tests/legacy-cli/run_e2e --nb-shards=${CIRCLE_NODE_TOTAL} --shard=${CIRCLE_NODE_INDEX} <<# parameters.snapshots >>--ng-snapshots<</ parameters.snapshots >> --tmpdir=/mnt/ramdisk/e2e --ignore="tests/misc/browsers.ts"
       - when:
           condition:
             equal: ['esbuild', << parameters.subset >>]
@@ -259,8 +259,6 @@ jobs:
   test-browsers:
     executor:
       name: test-executor
-    environment:
-      E2E_BROWSERS: true
     resource_class: medium
     steps:
       - custom_attach_workspace
@@ -355,7 +353,7 @@ jobs:
           name: Execute E2E Tests
           command: |
             mkdir X:/ramdisk/e2e-main
-            node tests\legacy-cli\run_e2e.js --nb-shards=$env:CIRCLE_NODE_TOTAL --shard=$env:CIRCLE_NODE_INDEX --tmpdir=X:/ramdisk/e2e-main
+            node tests\legacy-cli\run_e2e.js --nb-shards=$env:CIRCLE_NODE_TOTAL --shard=$env:CIRCLE_NODE_INDEX --tmpdir=X:/ramdisk/e2e-main --ignore="tests/misc/browsers.ts"
       - fail_fast
 
 workflows:

--- a/tests/legacy-cli/e2e/tests/misc/browsers.ts
+++ b/tests/legacy-cli/e2e/tests/misc/browsers.ts
@@ -5,10 +5,6 @@ import { replaceInFile } from '../../utils/fs';
 import { ng } from '../../utils/process';
 
 export default async function () {
-  if (!process.env['E2E_BROWSERS']) {
-    return;
-  }
-
   // Ensure SauceLabs configuration
   if (!process.env['SAUCE_USERNAME'] || !process.env['SAUCE_ACCESS_KEY']) {
     throw new Error('SauceLabs is not configured.');

--- a/tests/legacy-cli/e2e/utils/process.ts
+++ b/tests/legacy-cli/e2e/utils/process.ts
@@ -172,6 +172,15 @@ export function extractNpmEnv() {
     }, {});
 }
 
+function extractCIEnv(): NodeJS.ProcessEnv {
+  return Object.keys(process.env)
+    .filter((v) => v.startsWith('SAUCE_') || v === 'CI' || v === 'CIRCLECI')
+    .reduce<NodeJS.ProcessEnv>((vars, n) => {
+      vars[n] = process.env[n];
+      return vars;
+    }, {});
+}
+
 export function waitForAnyProcessOutputToMatch(
   match: RegExp,
   timeout = 30000,
@@ -375,6 +384,7 @@ export async function launchTestProcess(entry: string, ...args: any[]) {
   // Extract explicit environment variables for the test process.
   const env: NodeJS.ProcessEnv = {
     ...extractNpmEnv(),
+    ...extractCIEnv(),
     ...getGlobalVariablesEnv(),
   };
 


### PR DESCRIPTION
The saucelabs tests were blindly noop-ing because the `E2E_BROWSERS` variable was not propagated to the child process.

This fixes the variables not propagating, but I'd like to also ensure this doesn't happen again. Currently I've changed the saucelabs test to fail if running without saucelabs configured instead of being a silent noop, but that means it must be manually excluded when saucelabs is not setup. Any other ideas or preferences?