### PR TITLE
fix(@angular-devkit/build-angular): correct esbuild builder global stylesheet sourcemap URL

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
@@ -386,10 +386,15 @@ async function bundleGlobalStylesheets(
     // with the actual name of the global style and the leading directory separator must
     // also be removed to make the path relative.
     const sheetPath = sheetResult.path.replace('stdin', name);
-    outputFiles.push(createOutputFileFromText(sheetPath, sheetResult.contents));
+    let sheetContents = sheetResult.contents;
     if (sheetResult.map) {
       outputFiles.push(createOutputFileFromText(sheetPath + '.map', sheetResult.map));
+      sheetContents = sheetContents.replace(
+        'sourceMappingURL=stdin.css.map',
+        `sourceMappingURL=${name}.css.map`,
+      );
     }
+    outputFiles.push(createOutputFileFromText(sheetPath, sheetContents));
 
     if (!noInjectNames.includes(name)) {
       initialFiles.push({


### PR DESCRIPTION
The sourcemap URL in the output CSS files for global stylesheets is now correctly updated to
reflect the name of the global stylesheet output file and not the internal `stdin` virtual
file name.