### PR TITLE
refactor(@angular-devkit/build-angular): reorganize esbuild builder setup steps

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/options.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/options.ts
@@ -59,10 +59,24 @@ export async function normalizeOptions(
     outputNames.media = path.join(options.resourcesOutputPath, outputNames.media);
   }
 
+  // Setup bundler entry points
+  const entryPoints: Record<string, string> = {
+    main: mainEntryPoint,
+  };
+  if (polyfillsEntryPoint) {
+    entryPoints['polyfills'] = polyfillsEntryPoint;
+  }
+  // Create reverse lookup used during index HTML generation
+  const entryPointNameLookup: ReadonlyMap<string, string> = new Map(
+    Object.entries(entryPoints).map(
+      ([name, filePath]) => [path.relative(workspaceRoot, filePath), name] as const,
+    ),
+  );
+
   return {
     workspaceRoot,
-    mainEntryPoint,
-    polyfillsEntryPoint,
+    entryPoints,
+    entryPointNameLookup,
     optimizationOptions,
     outputPath,
     sourcemapOptions,


### PR DESCRIPTION
This contains several minor adjustments to the setup steps for the experimental
esbuild-based browser application builder. It better groups the output directory
deletion and creation steps as well as moves entry point normalization into the
normalize options helper function. This should reduce the size of the main
execution function as well as aid in future profiling of the build phases.