### PR TITLE
E2E fixes

### DIFF
--- a/tests/legacy-cli/e2e/tests/misc/loaders-resolution.ts
+++ b/tests/legacy-cli/e2e/tests/misc/loaders-resolution.ts
@@ -1,18 +1,45 @@
 import { createDir, moveFile } from '../../utils/fs';
 import { ng } from '../../utils/process';
+import { assertIsError } from '../../utils/utils';
 
 export default async function () {
   await createDir('node_modules/@angular-devkit/build-angular/node_modules');
-  await moveFile(
-    'node_modules/@ngtools',
-    'node_modules/@angular-devkit/build-angular/node_modules/@ngtools',
-  );
+  let originalInRootNodeModules = true;
+
+  try {
+    await moveFile(
+      'node_modules/@ngtools',
+      'node_modules/@angular-devkit/build-angular/node_modules/@ngtools',
+    );
+  } catch (e) {
+    assertIsError(e);
+
+    if (e.code !== 'ENOENT') {
+      throw e;
+    }
+
+    // In some cases due to module resolution '@ngtools' might already been under `@angular-devkit/build-angular`.
+    originalInRootNodeModules = false;
+    await moveFile(
+      'node_modules/@angular-devkit/build-angular/node_modules/@ngtools',
+      'node_modules/@ngtools',
+    );
+  }
 
   await ng('build', '--configuration=development');
 
   // Move it back.
-  await moveFile(
-    'node_modules/@angular-devkit/build-angular/node_modules/@ngtools',
-    'node_modules/@ngtools',
-  );
+  await moveBack(originalInRootNodeModules);
+}
+
+function moveBack(originalInRootNodeModules: Boolean): Promise<void> {
+  return originalInRootNodeModules
+    ? moveFile(
+        'node_modules/@angular-devkit/build-angular/node_modules/@ngtools',
+        'node_modules/@ngtools',
+      )
+    : moveFile(
+        'node_modules/@ngtools',
+        'node_modules/@angular-devkit/build-angular/node_modules/@ngtools',
+      );
 }

--- a/tests/legacy-cli/e2e/utils/utils.ts
+++ b/tests/legacy-cli/e2e/utils/utils.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import { mkdtemp, realpath, rm } from 'fs/promises';
 import { tmpdir } from 'os';
 import path from 'path';
@@ -40,4 +41,12 @@ export async function mockHome(cb: (home: string) => Promise<void>): Promise<voi
 
     await rm(tempHome, { recursive: true, force: true });
   }
+}
+
+export function assertIsError(value: unknown): asserts value is Error & { code?: string } {
+  const isError =
+    value instanceof Error ||
+    // The following is needing to identify errors coming from RxJs.
+    (typeof value === 'object' && value && 'name' in value && 'message' in value);
+  assert(isError, 'catch clause variable is not an Error instance');
 }


### PR DESCRIPTION
**test: account for module resolution differences**
    
In some cases due to module resolution '@ngtools' might already been under `@angular-devkit/build-angular`.

**test: remove hardcoded worker chunk id**
    
This commit changes how we retrieve the worker chunk Id. Prior to this change we hard coded the value, now we get it by reading the file names on disk.