### PR TITLE
fix(@angular-devkit/build-angular): allow esbuild-based builder to use SVG Angular templates

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/compiler-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/compiler-plugin.ts
@@ -213,8 +213,8 @@ export function createCompilerPlugin(
         // The AOT compiler currently requires this hook to allow for a transformResource hook.
         // Once the AOT compiler allows only a transformResource hook, this can be reevaluated.
         (host as CompilerHost).readResource = async function (fileName) {
-          // Template resources (.html) files are not bundled or transformed
-          if (fileName.endsWith('.html')) {
+          // Template resources (.html/.svg) files are not bundled or transformed
+          if (fileName.endsWith('.html') || fileName.endsWith('.svg')) {
             return this.readFile(fileName) ?? '';
           }
 


### PR DESCRIPTION
The experimental esbuild-based browser application builder will now consider SVG files as
Angular component templates. Previously, only HTML files were considered templates and this
resulted in the esbuild-based builder to try to process the SVG file as a stylesheet.