### PR TITLE
fix(@schematics/angular): update ng-packagr version to `^14.2.0`

### DIFF
--- a/packages/schematics/angular/utility/latest-versions/package.json
+++ b/packages/schematics/angular/utility/latest-versions/package.json
@@ -12,7 +12,7 @@
     "karma-jasmine-html-reporter": "~2.0.0",
     "karma-jasmine": "~5.1.0",
     "karma": "~6.4.0",
-    "ng-packagr": "^14.0.0-next.8",
+    "ng-packagr": "^14.2.0",
     "protractor": "~7.0.0",
     "rxjs": "~7.5.0",
     "tslib": "^2.3.0",


### PR DESCRIPTION
This is one-half of the fix in https://github.com/angular/angular-cli/pull/23801 in case we need to decouple this fix from the TS 4.8 update.