### PR TITLE
Revert "test: enable rbe on all unit tests"

### DIFF
--- a/packages/angular_devkit/build_angular/BUILD.bazel
+++ b/packages/angular_devkit/build_angular/BUILD.bazel
@@ -295,6 +295,8 @@ LARGE_SPECS = {
             "@npm//puppeteer",
             "@npm//ts-node",
         ],
+        # NB: does not run on rbe because webdriver manager uses an absolute path to chromedriver
+        "tags": ["no-remote-exec"],
     },
     "dev-server": {
         "shards": 10,
@@ -327,6 +329,8 @@ LARGE_SPECS = {
             "@npm//puppeteer",
             "@npm//ts-node",
         ],
+        # NB: does not run on rbe because webdriver manager uses an absolute path to chromedriver
+        "tags": ["no-remote-exec"],
         # NB: multiple shards will compete for port 4200 so limiting to 1
         "shards": 1,
     },


### PR DESCRIPTION
This reverts commit 1193886df5e8110de20ba534e2b4572da72b5e4a.

Commit was causing `ci/circleci: test` to fail.  Example run: https://app.circleci.com/pipelines/github/angular/angular-cli/25678/workflows/18659a91-2a18-466f-8228-011900c623e1/jobs/336368