### PR TITLE
refactor(@schematics/angular): remove deprecated appDir option

### DIFF
--- a/packages/schematics/angular/app-shell/schema.json
+++ b/packages/schematics/angular/app-shell/schema.json
@@ -29,11 +29,6 @@
       "description": "The name of the main entry-point file.",
       "default": "main.server.ts"
     },
-    "appDir": {
-      "type": "string",
-      "description": "The name of the application directory.",
-      "default": "app"
-    },
     "rootModuleFileName": {
       "type": "string",
       "description": "The name of the root module file",

--- a/packages/schematics/angular/universal/schema.json
+++ b/packages/schematics/angular/universal/schema.json
@@ -25,13 +25,6 @@
       "description": "The name of the main entry-point file.",
       "default": "main.server.ts"
     },
-    "appDir": {
-      "type": "string",
-      "format": "path",
-      "description": "The name of the application folder.",
-      "default": "app",
-      "x-deprecated": "This option has no effect."
-    },
     "rootModuleFileName": {
       "type": "string",
       "format": "path",


### PR DESCRIPTION
BREAKING CHANGE: Removed unused`appDir` option from Universal schematic