### PR TITLE
fix(@angular-devkit/core): throw error when project has missing root property

### DIFF
--- a/packages/angular_devkit/core/src/workspace/json/reader.ts
+++ b/packages/angular_devkit/core/src/workspace/json/reader.ts
@@ -190,11 +190,7 @@ function parseProject(
 
   const projectNodeValue = getNodeValue(projectNode);
   if (!('root' in projectNodeValue)) {
-    // TODO(alan-agius4): change this to error in v15.
-    context.warn(
-      `Project "${projectName}" is missing a required property "root". This will become an error in the next major version.`,
-      projectNodeValue,
-    );
+    throw new Error(`Project "${projectName}" is missing a required property "root".`);
   }
 
   for (const [name, value] of Object.entries<JsonValue>(projectNodeValue)) {

--- a/packages/angular_devkit/core/src/workspace/json/reader_spec.ts
+++ b/packages/angular_devkit/core/src/workspace/json/reader_spec.ts
@@ -148,11 +148,8 @@ describe('readJsonWorkpace Parsing', () => {
       }
     `);
 
-    const consoleWarnSpy = spyOn(console, 'warn').and.callFake(() => undefined);
-    await expectAsync(readJsonWorkspace('', host));
-
-    expect(consoleWarnSpy).toHaveBeenCalledWith(
-      `Project "foo" is missing a required property "root". This will become an error in the next major version.`,
+    await expectAsync(readJsonWorkspace('', host)).toBeRejectedWithError(
+      /Project "foo" is missing a required property "root"/,
     );
   });
 });


### PR DESCRIPTION


BREAKING CHANGE: Workspace projects with missing `root` is now an error.