### PR TITLE
refactor(@angular/cli): remove deprecated path handler

### DIFF
--- a/packages/angular/cli/src/command-builder/schematics-command-module.ts
+++ b/packages/angular/cli/src/command-builder/schematics-command-module.ts
@@ -178,14 +178,6 @@ export abstract class SchematicsCommandModule
         return options;
       }
 
-      if (property['format'] === 'path' && !property['$default']) {
-        (options as Record<string, unknown>)['path'] = workingDir || undefined;
-        this.context.logger.warn(
-          `The 'path' option in '${schematic?.schema}' is using deprecated behaviour. ` +
-            `'workingDirectory' smart default provider should be used instead.`,
-        );
-      }
-
       return options;
     });
 


### PR DESCRIPTION
BREAKING CHANGE: The 'path' option in schematics schema no longer has a special meaning. Use 'workingDirectory' smart default provider should be used instead.