### PR TITLE
build: adjust BUILD file external comment markers

### DIFF
--- a/packages/angular/cli/BUILD.bazel
+++ b/packages/angular/cli/BUILD.bazel
@@ -5,12 +5,9 @@
 
 load("@npm//@bazel/jasmine:index.bzl", "jasmine_node_test")
 load("//tools:defaults.bzl", "pkg_npm", "ts_library")
-load("//tools:toolchain_info.bzl", "TOOLCHAINS_NAMES", "TOOLCHAINS_VERSIONS")
-
-# @external_begin
-load("//tools:ts_json_schema.bzl", "ts_json_schema")
 load("//tools:ng_cli_schema_generator.bzl", "cli_json_schema")
-# @external_end
+load("//tools:toolchain_info.bzl", "TOOLCHAINS_NAMES", "TOOLCHAINS_VERSIONS")
+load("//tools:ts_json_schema.bzl", "ts_json_schema")
 
 licenses(["notice"])  # MIT
 
@@ -45,10 +42,11 @@ ts_library(
             "lib/config/workspace-schema.json",
         ],
     ) + [
+        # @external_begin
         "//packages/angular/cli:lib/config/schema.json",
+        # @external_end
     ],
     module_name = "@angular/cli",
-    # strict_checks = False,
     deps = [
         "//packages/angular_devkit/architect",
         "//packages/angular_devkit/architect/node",
@@ -129,7 +127,6 @@ ts_json_schema(
     name = "update_schematic_schema",
     src = "src/commands/update/schematic/schema.json",
 )
-# @external_end
 
 ts_library(
     name = "angular-cli_test_lib",
@@ -141,7 +138,6 @@ ts_library(
             "node_modules/**",
         ],
     ),
-    # strict_checks = False,
     deps = [
         ":angular-cli",
         "//packages/angular_devkit/core",
@@ -164,7 +160,6 @@ ts_library(
     )
 ]
 
-# @external_begin
 genrule(
     name = "license",
     srcs = ["//:LICENSE"],

--- a/packages/angular/pwa/BUILD.bazel
+++ b/packages/angular/pwa/BUILD.bazel
@@ -55,7 +55,6 @@ ts_library(
     name = "pwa_test_lib",
     testonly = True,
     srcs = glob(["pwa/**/*_spec.ts"]),
-    # strict_checks = False,
     deps = [
         ":pwa",
         "//packages/angular_devkit/schematics/testing",

--- a/packages/angular_devkit/architect/BUILD.bazel
+++ b/packages/angular_devkit/architect/BUILD.bazel
@@ -3,14 +3,11 @@
 # Use of this source code is governed by an MIT-style license that can be
 # found in the LICENSE file at https://angular.io/license
 
+load("@npm//@angular/build-tooling/bazel/api-golden:index.bzl", "api_golden_test_npm_package")
 load("@npm//@bazel/jasmine:index.bzl", "jasmine_node_test")
 load("//tools:defaults.bzl", "pkg_npm", "ts_library")
 load("//tools:toolchain_info.bzl", "TOOLCHAINS_NAMES", "TOOLCHAINS_VERSIONS")
-
-# @external_begin
 load("//tools:ts_json_schema.bzl", "ts_json_schema")
-load("@npm//@angular/build-tooling/bazel/api-golden:index.bzl", "api_golden_test_npm_package")
-# @external_end
 
 licenses(["notice"])  # MIT
 
@@ -60,7 +57,6 @@ ts_library(
         "//packages/angular_devkit/architect:src/progress-schema.ts",
         "//packages/angular_devkit/architect:builders/operator-schema.ts",
     ],
-    # strict_checks = False,
     data = glob(
         include = ["**/*.json"],
         exclude = [
@@ -82,7 +78,6 @@ ts_library(
     name = "architect_test_lib",
     testonly = True,
     srcs = glob(["src/**/*_spec.ts"]),
-    # strict_checks = False,
     deps = [
         ":architect",
         "//packages/angular_devkit/architect/testing",

--- a/packages/angular_devkit/architect/node/BUILD.bazel
+++ b/packages/angular_devkit/architect/node/BUILD.bazel
@@ -17,7 +17,6 @@ ts_library(
     ),
     module_name = "@angular-devkit/architect/node",
     module_root = "index.d.ts",
-    # strict_checks = False,
     deps = [
         "//packages/angular_devkit/architect",
         "//packages/angular_devkit/core",

--- a/packages/angular_devkit/build_angular/BUILD.bazel
+++ b/packages/angular_devkit/build_angular/BUILD.bazel
@@ -198,7 +198,6 @@ ts_library(
         ],
     ),
     data = glob(["test/**/*"]),
-    # strict_checks = False,
     deps = [
         ":build_angular",
         ":build_angular_test_utils",

--- a/packages/angular_devkit/core/BUILD.bazel
+++ b/packages/angular_devkit/core/BUILD.bazel
@@ -1,10 +1,7 @@
+load("@npm//@angular/build-tooling/bazel/api-golden:index.bzl", "api_golden_test_npm_package")
 load("@npm//@bazel/jasmine:index.bzl", "jasmine_node_test")
 load("//tools:defaults.bzl", "pkg_npm", "ts_library")
 load("//tools:toolchain_info.bzl", "TOOLCHAINS_NAMES", "TOOLCHAINS_VERSIONS")
-
-# @external_begin
-load("@npm//@angular/build-tooling/bazel/api-golden:index.bzl", "api_golden_test_npm_package")
-# @external_end
 
 # Copyright Google Inc. All Rights Reserved.
 #
@@ -36,8 +33,6 @@ ts_library(
     ),
     module_name = "@angular-devkit/core",
     module_root = "src/index.d.ts",
-    # The attribute below is needed in g3 to turn off strict typechecking
-    # strict_checks = False,
     deps = [
         "@npm//@types/node",
         "@npm//ajv",
@@ -52,13 +47,13 @@ ts_library(
     ],
 )
 
+# @external_begin
+
 ts_library(
     name = "core_test_lib",
     testonly = True,
     srcs = glob(["src/**/*_spec.ts"]),
     data = glob(["src/workspace/json/test/**/*.json"]),
-    # The attribute below is needed in g3 to turn off strict typechecking
-    # strict_checks = False,
     deps = [
         ":core",
         "//packages/angular_devkit/core/node",
@@ -71,11 +66,6 @@ ts_library(
         name = "core_test_" + toolchain_name,
         srcs = [":core_test_lib"],
         toolchain = toolchain,
-        deps = [
-            # @node_module: ajv
-            # @node_module: fast_json_stable_stringify
-            # @node_module: source_map
-        ],
     )
     for toolchain_name, toolchain in zip(
         TOOLCHAINS_NAMES,
@@ -83,7 +73,6 @@ ts_library(
     )
 ]
 
-# @external_begin
 genrule(
     name = "license",
     srcs = ["//:LICENSE"],

--- a/packages/angular_devkit/core/node/BUILD.bazel
+++ b/packages/angular_devkit/core/node/BUILD.bazel
@@ -24,8 +24,6 @@ ts_library(
     data = ["package.json"],
     module_name = "@angular-devkit/core/node",
     module_root = "index.d.ts",
-    # The attribute below is needed in g3 to turn off strict typechecking
-    # strict_checks = False,
     deps = [
         "//packages/angular_devkit/core",
         "@npm//@types/node",
@@ -33,6 +31,8 @@ ts_library(
         "@npm//rxjs",
     ],
 )
+
+# @external_begin
 
 ts_library(
     name = "node_test_lib",
@@ -60,9 +60,6 @@ ts_library(
         toolchain = toolchain,
         deps = [
             "@npm//chokidar",
-            # @node_module: ajv
-            # @node_module: fast_json_stable_stringify
-            # @node_module: magic_string
         ],
     )
     for toolchain_name, toolchain in zip(
@@ -70,3 +67,4 @@ ts_library(
         TOOLCHAINS_VERSIONS,
     )
 ]
+# @external_end

--- a/packages/angular_devkit/core/node/testing/BUILD.bazel
+++ b/packages/angular_devkit/core/node/testing/BUILD.bazel
@@ -19,8 +19,6 @@ ts_library(
     ),
     module_name = "@angular-devkit/core/node/testing",
     module_root = "index.d.ts",
-    # The attribute below is needed in g3 to turn off strict typechecking
-    # strict_checks = False,
     deps = [
         "//packages/angular_devkit/core",
         "//packages/angular_devkit/core/node",

--- a/packages/angular_devkit/schematics/BUILD.bazel
+++ b/packages/angular_devkit/schematics/BUILD.bazel
@@ -1,10 +1,7 @@
+load("@npm//@angular/build-tooling/bazel/api-golden:index.bzl", "api_golden_test_npm_package")
 load("@npm//@bazel/jasmine:index.bzl", "jasmine_node_test")
 load("//tools:defaults.bzl", "pkg_npm", "ts_library")
 load("//tools:toolchain_info.bzl", "TOOLCHAINS_NAMES", "TOOLCHAINS_VERSIONS")
-
-# @external_begin
-load("@npm//@angular/build-tooling/bazel/api-golden:index.bzl", "api_golden_test_npm_package")
-# @external_end
 
 # Copyright Google Inc. All Rights Reserved.
 #
@@ -26,8 +23,6 @@ ts_library(
             "src/**/*_benchmark.ts",
         ],
     ),
-    # The attribute below is needed in g3 to turn off strict typechecking
-    # strict_checks = False,
     data = glob(
         include = ["**/*.json"],
         exclude = [
@@ -46,6 +41,8 @@ ts_library(
         "@npm//rxjs",
     ],
 )
+
+# @external_begin
 
 ts_library(
     name = "schematics_test_lib",
@@ -76,7 +73,6 @@ ts_library(
     )
 ]
 
-# @external_begin
 genrule(
     name = "license",
     srcs = ["//:LICENSE"],

--- a/packages/angular_devkit/schematics/tasks/BUILD.bazel
+++ b/packages/angular_devkit/schematics/tasks/BUILD.bazel
@@ -21,8 +21,6 @@ ts_library(
     data = ["package.json"],
     module_name = "@angular-devkit/schematics/tasks",
     module_root = "index.d.ts",
-    # The attribute below is needed in g3 to turn off strict typechecking
-    # strict_checks = False,
     deps = [
         "//packages/angular_devkit/core",
         "//packages/angular_devkit/core/node",

--- a/packages/angular_devkit/schematics/tasks/node/BUILD.bazel
+++ b/packages/angular_devkit/schematics/tasks/node/BUILD.bazel
@@ -19,8 +19,6 @@ ts_library(
     ),
     module_name = "@angular-devkit/schematics/tasks/node",
     module_root = "index.d.ts",
-    # The attribute below is needed in g3 to turn off strict typechecking
-    # strict_checks = False,
     deps = [
         "//packages/angular_devkit/core",
         "//packages/angular_devkit/core/node",

--- a/packages/angular_devkit/schematics/tools/BUILD.bazel
+++ b/packages/angular_devkit/schematics/tools/BUILD.bazel
@@ -23,8 +23,6 @@ ts_library(
     data = ["package.json"],
     module_name = "@angular-devkit/schematics/tools",
     module_root = "index.d.ts",
-    # The attribute below is needed in g3 to turn off strict typechecking
-    # strict_checks = False,
     deps = [
         "//packages/angular_devkit/core",
         "//packages/angular_devkit/core/node",

--- a/packages/angular_devkit/schematics_cli/BUILD.bazel
+++ b/packages/angular_devkit/schematics_cli/BUILD.bazel
@@ -69,7 +69,6 @@ ts_library(
             "bin/**/*_spec.ts",
         ],
     ),
-    # strict_checks = False,
     deps = [
         ":schematics_cli",
     ],

--- a/packages/schematics/angular/BUILD.bazel
+++ b/packages/schematics/angular/BUILD.bazel
@@ -56,7 +56,6 @@ ts_library(
         "//packages/schematics/angular:" + src.replace(".json", ".ts")
         for (src, _) in ALL_SCHEMA_TARGETS
     ],
-    # strict_checks = False,
     data = glob(
         include = [
             "collection.json",

--- a/tools/ng_cli_schema_generator.bzl
+++ b/tools/ng_cli_schema_generator.bzl
@@ -3,7 +3,6 @@
 # Use of this source code is governed by an MIT-style license that can be
 # found in the LICENSE file at https://angular.io/license
 
-# @external_begin
 def _cli_json_schema_interface_impl(ctx):
     args = [
         ctx.files.src[0].path,
@@ -36,11 +35,10 @@ cli_json_schema = rule(
         "_binary": attr.label(
             default = Label("//tools:ng_cli_schema"),
             executable = True,
-            cfg = "host",
+            cfg = "exec",
         ),
     },
     outputs = {
         "json": "%{out}",
     },
 )
-# @external_end

--- a/tools/ts_json_schema.bzl
+++ b/tools/ts_json_schema.bzl
@@ -3,7 +3,6 @@
 # Use of this source code is governed by an MIT-style license that can be
 # found in the LICENSE file at https://angular.io/license
 
-# @external_begin
 def _ts_json_schema_interface_impl(ctx):
     args = [
         ctx.files.src[0].path,
@@ -35,14 +34,13 @@ _ts_json_schema_interface = rule(
         "_binary": attr.label(
             default = Label("//tools:quicktype_runner"),
             executable = True,
-            cfg = "host",
+            cfg = "exec",
         ),
     },
     outputs = {
         "ts": "%{out}",
     },
 )
-# @external_end
 
 # Generates a TS file that contains the interface for a JSON Schema file. Takes a single `src`
 # argument as input, an optional data field for reference files, and produces a
@@ -52,11 +50,9 @@ _ts_json_schema_interface = rule(
 def ts_json_schema(name, src, data = []):
     out = src.replace(".json", ".ts")
 
-    # @external_begin
     _ts_json_schema_interface(
         name = name + ".interface",
         src = src,
         out = out,
         data = data,
     )
-    # @external_end


### PR DESCRIPTION
Improvements to the syncing process allow for reduced usage of the comment markers.