### PR TITLE
fix(@angular-devkit/build-angular): handling of `@media` queries inside css layers

### DIFF
--- a/package.json
+++ b/package.json
@@ -186,7 +186,7 @@
     "piscina": "3.2.0",
     "popper.js": "^1.14.1",
     "postcss": "8.4.16",
-    "postcss-import": "14.1.0",
+    "postcss-import": "15.0.0",
     "postcss-loader": "7.0.1",
     "postcss-preset-env": "7.8.0",
     "prettier": "^2.0.0",

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -46,7 +46,7 @@
     "parse5-html-rewriting-stream": "6.0.1",
     "piscina": "3.2.0",
     "postcss": "8.4.16",
-    "postcss-import": "14.1.0",
+    "postcss-import": "15.0.0",
     "postcss-loader": "7.0.1",
     "postcss-preset-env": "7.8.0",
     "regenerator-runtime": "0.13.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8788,6 +8788,15 @@ postcss-import@14.1.0:
     read-cache "^1.0.0"
     resolve "^1.1.7"
 
+postcss-import@15.0.0:
+  version "15.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-import/-/postcss-import-15.0.0.tgz#0b66c25fdd9c0d19576e63c803cf39e4bad08822"
+  integrity sha512-Y20shPQ07RitgBGv2zvkEAu9bqvrD77C9axhj/aA1BQj4czape2MdClCExvB27EwYEJdGgKZBpKanb0t1rK2Kg==
+  dependencies:
+    postcss-value-parser "^4.0.0"
+    read-cache "^1.0.0"
+    resolve "^1.1.7"
+
 postcss-initial@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/postcss-initial/-/postcss-initial-4.0.1.tgz#529f735f72c5724a0fb30527df6fb7ac54d7de42"


### PR DESCRIPTION

See: https://github.com/postcss/postcss-import/pull/496


Note: the major bump is due to drop of support of Node.Js prior to version 14, which the CLI doesn't support anyways.