### PR TITLE
build: adjust BUILD file external comment markers

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -10,9 +10,9 @@ licenses(["notice"])
 
 exports_files([
     "LICENSE",
-    "tsconfig.json",  # @external
-    "tsconfig-test.json",  # @external
-    "tsconfig-build.json",  # @external
+    "tsconfig.json",
+    "tsconfig-test.json",
+    "tsconfig-build.json",
     "package.json",
 ])
 

--- a/packages/angular_devkit/core/BUILD.bazel
+++ b/packages/angular_devkit/core/BUILD.bazel
@@ -39,7 +39,7 @@ ts_library(
         "@npm//ajv-formats",
         "@npm//jsonc-parser",
         "@npm//rxjs",
-        "@npm//source-map",  # @external
+        "@npm//source-map",
         # @node_module: typescript:es2015.proxy
         # @node_module: typescript:es2015.reflect
         # @node_module: typescript:es2015.symbol.wellknown

--- a/packages/angular_devkit/schematics/tools/BUILD.bazel
+++ b/packages/angular_devkit/schematics/tools/BUILD.bazel
@@ -35,6 +35,8 @@ ts_library(
     ],
 )
 
+# @external_begin
+
 ts_library(
     name = "tools_test_lib",
     testonly = True,
@@ -71,3 +73,5 @@ ts_library(
         TOOLCHAINS_VERSIONS,
     )
 ]
+
+# @external_end

--- a/packages/angular_devkit/schematics_cli/BUILD.bazel
+++ b/packages/angular_devkit/schematics_cli/BUILD.bazel
@@ -55,9 +55,9 @@ ts_library(
         "@npm//@types/node",
         "@npm//@types/yargs-parser",
         "@npm//ansi-colors",
-        "@npm//inquirer",  # @external
-        "@npm//symbol-observable",  # @external
-        "@npm//yargs-parser",  # @external
+        "@npm//inquirer",
+        "@npm//symbol-observable",
+        "@npm//yargs-parser",
     ],
 )
 


### PR DESCRIPTION
Improvements to the syncing process allow for reduced usage of the comment markers.