### PR TITLE
fix(@angular/cli): favor non deprecated packages during update

### DIFF
--- a/packages/angular/cli/src/utilities/package-metadata.ts
+++ b/packages/angular/cli/src/utilities/package-metadata.ts
@@ -47,7 +47,9 @@ export interface NgPackageManifestProperties {
   };
 }
 
-export interface PackageManifest extends Manifest, NgPackageManifestProperties {}
+export interface PackageManifest extends Manifest, NgPackageManifestProperties {
+  deprecated?: boolean;
+}
 
 interface PackageManagerOptions extends Record<string, unknown> {
   forceAuth?: Record<string, unknown>;


### PR DESCRIPTION
Prior to this change during update deprecated packages that satisfied the version range constrain where being favored over the non-deprecated versions if the version of the deprecated version is greater. Ex: if `14.3.1` is deprecated and `14.3.0` is not the former was being installed.

With this change we now change the logic to favor non deprecated version of the package and only use the deprecated package when no satisfying version is found.

This fix is needed as in some cases a package which cannot be unpublished from NPM will gave to be to be deprecated, if the version is for a reason or another broken.
