### PR TITLE
refactor(@angular-devkit/build-angular): remove Ivy checks

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/compiler-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/compiler-plugin.ts
@@ -166,7 +166,6 @@ export function createCompilerPlugin(
         rootNames,
         errors: configurationDiagnostics,
       } = compilerCli.readConfiguration(pluginOptions.tsconfig, {
-        enableIvy: true,
         noEmitOnError: false,
         suppressOutputPathCheck: true,
         outDir: undefined,

--- a/packages/angular_devkit/build_angular/src/webpack/plugins/typescript.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/plugins/typescript.ts
@@ -11,30 +11,11 @@ import { AngularWebpackPlugin } from '@ngtools/webpack';
 import { ScriptTarget } from 'typescript';
 import { WebpackConfigOptions } from '../../utils/build-options';
 
-function ensureIvy(wco: WebpackConfigOptions): void {
-  if (wco.tsConfig.options.enableIvy !== false) {
-    return;
-  }
-
-  wco.logger.warn(
-    'Project is attempting to disable the Ivy compiler. ' +
-      'Angular versions 12 and higher do not support the deprecated View Engine compiler for applications. ' +
-      'The Ivy compiler will be used to build this project. ' +
-      '\nFor additional information or if the build fails, please see https://angular.io/guide/ivy',
-  );
-
-  wco.tsConfig.options.enableIvy = true;
-}
-
 export function createIvyPlugin(
   wco: WebpackConfigOptions,
   aot: boolean,
   tsconfig: string,
 ): AngularWebpackPlugin {
-  if (aot) {
-    ensureIvy(wco);
-  }
-
   const { buildOptions } = wco;
   const optimize = buildOptions.optimization.scripts;
 

--- a/packages/ngtools/webpack/src/ivy/plugin.ts
+++ b/packages/ngtools/webpack/src/ivy/plugin.ts
@@ -454,7 +454,6 @@ export class AngularWebpackPlugin {
       this.pluginOptions.tsconfig,
       this.pluginOptions.compilerOptions,
     );
-    compilerOptions.enableIvy = true;
     compilerOptions.noEmitOnError = false;
     compilerOptions.suppressOutputPathCheck = true;
     compilerOptions.outDir = undefined;


### PR DESCRIPTION
This checks are no longer needed as `enableIvy` option is now meaningless to the compiler
