### PR TITLE
fix(@angular-devkit/build-angular): change service worker errors to compilation errors

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/plugins/service-worker-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/plugins/service-worker-plugin.ts
@@ -20,8 +20,15 @@ export class ServiceWorkerPlugin {
   constructor(private readonly options: ServiceWorkerPluginOptions) {}
 
   apply(compiler: Compiler) {
-    compiler.hooks.done.tapPromise('angular-service-worker', async ({ compilation }) => {
+    compiler.hooks.done.tapPromise('angular-service-worker', async (stats) => {
+      if (stats.hasErrors()) {
+        // Don't generate a service worker if the compilation has errors.
+        // When there are errors some files will not be emitted which would cause other errors down the line such as readdir failures.
+        return;
+      }
+
       const { projectRoot, root, baseHref = '', ngswConfigPath } = this.options;
+      const { compilation } = stats;
       // We use the output path from the compilation instead of build options since during
       // localization the output path is modified to a temp directory.
       // See: https://github.com/angular/angular-cli/blob/7e64b1537d54fadb650559214fbb12707324cd75/packages/angular_devkit/build_angular/src/utils/i18n-options.ts#L251-L252
@@ -31,17 +38,25 @@ export class ServiceWorkerPlugin {
         throw new Error('Compilation output path cannot be empty.');
       }
 
-      await augmentAppWithServiceWorker(
-        projectRoot,
-        root,
-        outputPath,
-        baseHref,
-        ngswConfigPath,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (compiler.inputFileSystem as any).promises,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (compiler.outputFileSystem as any).promises,
-      );
+      try {
+        await augmentAppWithServiceWorker(
+          projectRoot,
+          root,
+          outputPath,
+          baseHref,
+          ngswConfigPath,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (compiler.inputFileSystem as any).promises,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (compiler.outputFileSystem as any).promises,
+        );
+      } catch (error) {
+        compilation.errors.push(
+          new compilation.compiler.webpack.WebpackError(
+            `Failed to generate service worker - ${error instanceof Error ? error.message : error}`,
+          ),
+        );
+      }
     });
   }
 }


### PR DESCRIPTION
Previously, when there was an error during a build that had service workers enabled, the dev-server crashed as the promise was rejected instead of emitting a compilation error.

With this change we update the logic so that any errors during the SW augmentation phase are changed to a compilation error and also update the logic so that when there are compilation errors we don't try to generate a SW.

See: https://github.com/angular/angular-cli/issues/23844#issuecomment-1236311405

