### PR TITLE
refactor(@schematics/angular): consolidate `addDeclarationToNgModule`  logic

### DIFF
--- a/packages/schematics/angular/component/index.ts
+++ b/packages/schematics/angular/component/index.ts
@@ -22,78 +22,12 @@ import {
   strings,
   url,
 } from '@angular-devkit/schematics';
-import * as ts from '../third_party/github.com/Microsoft/TypeScript/lib/typescript';
-import { addDeclarationToModule, addExportToModule } from '../utility/ast-utils';
-import { InsertChange } from '../utility/change';
-import { buildRelativePath, findModuleFromOptions } from '../utility/find-module';
+import { addDeclarationToNgModule } from '../utility/add-declaration-to-ng-module';
+import { findModuleFromOptions } from '../utility/find-module';
 import { parseName } from '../utility/parse-name';
 import { validateHtmlSelector } from '../utility/validation';
 import { buildDefaultPath, getWorkspace } from '../utility/workspace';
 import { Schema as ComponentOptions, Style } from './schema';
-
-function readIntoSourceFile(host: Tree, modulePath: string): ts.SourceFile {
-  const sourceText = host.readText(modulePath);
-
-  return ts.createSourceFile(modulePath, sourceText, ts.ScriptTarget.Latest, true);
-}
-
-function addDeclarationToNgModule(options: ComponentOptions): Rule {
-  return (host: Tree) => {
-    if (options.skipImport || options.standalone || !options.module) {
-      return host;
-    }
-
-    options.type = options.type != null ? options.type : 'Component';
-
-    const modulePath = options.module;
-    const source = readIntoSourceFile(host, modulePath);
-
-    const componentPath =
-      `/${options.path}/` +
-      (options.flat ? '' : strings.dasherize(options.name) + '/') +
-      strings.dasherize(options.name) +
-      (options.type ? '.' : '') +
-      strings.dasherize(options.type);
-    const relativePath = buildRelativePath(modulePath, componentPath);
-    const classifiedName = strings.classify(options.name) + strings.classify(options.type);
-    const declarationChanges = addDeclarationToModule(
-      source,
-      modulePath,
-      classifiedName,
-      relativePath,
-    );
-
-    const declarationRecorder = host.beginUpdate(modulePath);
-    for (const change of declarationChanges) {
-      if (change instanceof InsertChange) {
-        declarationRecorder.insertLeft(change.pos, change.toAdd);
-      }
-    }
-    host.commitUpdate(declarationRecorder);
-
-    if (options.export) {
-      // Need to refresh the AST because we overwrote the file in the host.
-      const source = readIntoSourceFile(host, modulePath);
-
-      const exportRecorder = host.beginUpdate(modulePath);
-      const exportChanges = addExportToModule(
-        source,
-        modulePath,
-        strings.classify(options.name) + strings.classify(options.type),
-        relativePath,
-      );
-
-      for (const change of exportChanges) {
-        if (change instanceof InsertChange) {
-          exportRecorder.insertLeft(change.pos, change.toAdd);
-        }
-      }
-      host.commitUpdate(exportRecorder);
-    }
-
-    return host;
-  };
-}
 
 function buildSelector(options: ComponentOptions, projectPrefix: string) {
   let selector = strings.dasherize(options.name);
@@ -152,6 +86,12 @@ export default function (options: ComponentOptions): Rule {
       move(parsedPath.path),
     ]);
 
-    return chain([addDeclarationToNgModule(options), mergeWith(templateSource)]);
+    return chain([
+      addDeclarationToNgModule({
+        type: 'component',
+        ...options,
+      }),
+      mergeWith(templateSource),
+    ]);
   };
 }

--- a/packages/schematics/angular/directive/index.ts
+++ b/packages/schematics/angular/directive/index.ts
@@ -20,70 +20,12 @@ import {
   strings,
   url,
 } from '@angular-devkit/schematics';
-import * as ts from '../third_party/github.com/Microsoft/TypeScript/lib/typescript';
-import { addDeclarationToModule, addExportToModule } from '../utility/ast-utils';
-import { InsertChange } from '../utility/change';
-import { buildRelativePath, findModuleFromOptions } from '../utility/find-module';
+import { addDeclarationToNgModule } from '../utility/add-declaration-to-ng-module';
+import { findModuleFromOptions } from '../utility/find-module';
 import { parseName } from '../utility/parse-name';
 import { validateHtmlSelector } from '../utility/validation';
 import { buildDefaultPath, getWorkspace } from '../utility/workspace';
 import { Schema as DirectiveOptions } from './schema';
-
-function addDeclarationToNgModule(options: DirectiveOptions): Rule {
-  return (host: Tree) => {
-    if (options.skipImport || options.standalone || !options.module) {
-      return host;
-    }
-
-    const modulePath = options.module;
-    const sourceText = host.readText(modulePath);
-    const source = ts.createSourceFile(modulePath, sourceText, ts.ScriptTarget.Latest, true);
-
-    const directivePath =
-      `/${options.path}/` +
-      (options.flat ? '' : strings.dasherize(options.name) + '/') +
-      strings.dasherize(options.name) +
-      '.directive';
-    const relativePath = buildRelativePath(modulePath, directivePath);
-    const classifiedName = strings.classify(`${options.name}Directive`);
-    const declarationChanges = addDeclarationToModule(
-      source,
-      modulePath,
-      classifiedName,
-      relativePath,
-    );
-    const declarationRecorder = host.beginUpdate(modulePath);
-    for (const change of declarationChanges) {
-      if (change instanceof InsertChange) {
-        declarationRecorder.insertLeft(change.pos, change.toAdd);
-      }
-    }
-    host.commitUpdate(declarationRecorder);
-
-    if (options.export) {
-      // Need to refresh the AST because we overwrote the file in the host.
-      const sourceText = host.readText(modulePath);
-      const source = ts.createSourceFile(modulePath, sourceText, ts.ScriptTarget.Latest, true);
-
-      const exportRecorder = host.beginUpdate(modulePath);
-      const exportChanges = addExportToModule(
-        source,
-        modulePath,
-        strings.classify(`${options.name}Directive`),
-        relativePath,
-      );
-
-      for (const change of exportChanges) {
-        if (change instanceof InsertChange) {
-          exportRecorder.insertLeft(change.pos, change.toAdd);
-        }
-      }
-      host.commitUpdate(exportRecorder);
-    }
-
-    return host;
-  };
-}
 
 function buildSelector(options: DirectiveOptions, projectPrefix: string) {
   let selector = options.name;
@@ -127,6 +69,13 @@ export default function (options: DirectiveOptions): Rule {
       move(parsedPath.path),
     ]);
 
-    return chain([addDeclarationToNgModule(options), mergeWith(templateSource)]);
+    return chain([
+      addDeclarationToNgModule({
+        type: 'directive',
+
+        ...options,
+      }),
+      mergeWith(templateSource),
+    ]);
   };
 }

--- a/packages/schematics/angular/module/index.ts
+++ b/packages/schematics/angular/module/index.ts
@@ -47,7 +47,7 @@ function buildRelativeModulePath(options: ModuleOptions, modulePath: string): st
   return buildRelativePath(modulePath, importModulePath);
 }
 
-function addDeclarationToNgModule(options: ModuleOptions): Rule {
+function addImportToNgModule(options: ModuleOptions): Rule {
   return (host: Tree) => {
     if (!options.module) {
       return host;
@@ -179,7 +179,7 @@ export default function (options: ModuleOptions): Rule {
     };
 
     return chain([
-      !isLazyLoadedModuleGen ? addDeclarationToNgModule(options) : noop(),
+      !isLazyLoadedModuleGen ? addImportToNgModule(options) : noop(),
       addRouteDeclarationToNgModule(options, routingModulePath),
       mergeWith(templateSource),
       isLazyLoadedModuleGen ? schematic('component', componentOptions) : noop(),

--- a/packages/schematics/angular/pipe/index.ts
+++ b/packages/schematics/angular/pipe/index.ts
@@ -19,68 +19,12 @@ import {
   strings,
   url,
 } from '@angular-devkit/schematics';
-import * as ts from '../third_party/github.com/Microsoft/TypeScript/lib/typescript';
-import { addDeclarationToModule, addExportToModule } from '../utility/ast-utils';
-import { InsertChange } from '../utility/change';
-import { buildRelativePath, findModuleFromOptions } from '../utility/find-module';
+import { addDeclarationToNgModule } from '../utility/add-declaration-to-ng-module';
+import { findModuleFromOptions } from '../utility/find-module';
 import { parseName } from '../utility/parse-name';
 import { validateClassName } from '../utility/validation';
 import { createDefaultPath } from '../utility/workspace';
 import { Schema as PipeOptions } from './schema';
-
-function addDeclarationToNgModule(options: PipeOptions): Rule {
-  return (host: Tree) => {
-    if (options.skipImport || options.standalone || !options.module) {
-      return host;
-    }
-
-    const modulePath = options.module;
-    const sourceText = host.readText(modulePath);
-    const source = ts.createSourceFile(modulePath, sourceText, ts.ScriptTarget.Latest, true);
-
-    const pipePath =
-      `/${options.path}/` +
-      (options.flat ? '' : strings.dasherize(options.name) + '/') +
-      strings.dasherize(options.name) +
-      '.pipe';
-    const relativePath = buildRelativePath(modulePath, pipePath);
-    const changes = addDeclarationToModule(
-      source,
-      modulePath,
-      strings.classify(`${options.name}Pipe`),
-      relativePath,
-    );
-    const recorder = host.beginUpdate(modulePath);
-    for (const change of changes) {
-      if (change instanceof InsertChange) {
-        recorder.insertLeft(change.pos, change.toAdd);
-      }
-    }
-    host.commitUpdate(recorder);
-
-    if (options.export) {
-      const sourceText = host.readText(modulePath);
-      const source = ts.createSourceFile(modulePath, sourceText, ts.ScriptTarget.Latest, true);
-
-      const exportRecorder = host.beginUpdate(modulePath);
-      const exportChanges = addExportToModule(
-        source,
-        modulePath,
-        strings.classify(`${options.name}Pipe`),
-        relativePath,
-      );
-
-      for (const change of exportChanges) {
-        if (change instanceof InsertChange) {
-          exportRecorder.insertLeft(change.pos, change.toAdd);
-        }
-      }
-      host.commitUpdate(exportRecorder);
-    }
-
-    return host;
-  };
-}
 
 export default function (options: PipeOptions): Rule {
   return async (host: Tree) => {
@@ -102,6 +46,13 @@ export default function (options: PipeOptions): Rule {
       move(parsedPath.path),
     ]);
 
-    return chain([addDeclarationToNgModule(options), mergeWith(templateSource)]);
+    return chain([
+      addDeclarationToNgModule({
+        type: 'pipe',
+
+        ...options,
+      }),
+      mergeWith(templateSource),
+    ]);
   };
 }

--- a/packages/schematics/angular/utility/add-declaration-to-ng-module.ts
+++ b/packages/schematics/angular/utility/add-declaration-to-ng-module.ts
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { Rule, Tree, strings } from '@angular-devkit/schematics';
+import * as ts from '../third_party/github.com/Microsoft/TypeScript/lib/typescript';
+import { addDeclarationToModule, addSymbolToNgModuleMetadata } from './ast-utils';
+import { InsertChange } from './change';
+import { buildRelativePath } from './find-module';
+
+export interface DeclarationToNgModuleOptions {
+  module?: string;
+  path?: string;
+  name: string;
+  flat?: boolean;
+  export?: boolean;
+  type: string;
+  skipImport?: boolean;
+  standalone?: boolean;
+}
+
+export function addDeclarationToNgModule(options: DeclarationToNgModuleOptions): Rule {
+  return (host: Tree) => {
+    const modulePath = options.module;
+    if (options.skipImport || options.standalone || !modulePath) {
+      return host;
+    }
+
+    const sourceText = host.readText(modulePath);
+    const source = ts.createSourceFile(modulePath, sourceText, ts.ScriptTarget.Latest, true);
+
+    const filePath =
+      `/${options.path}/` +
+      (options.flat ? '' : strings.dasherize(options.name) + '/') +
+      strings.dasherize(options.name) +
+      (options.type ? '.' : '') +
+      strings.dasherize(options.type);
+
+    const importPath = buildRelativePath(modulePath, filePath);
+    const classifiedName = strings.classify(options.name) + strings.classify(options.type);
+    const changes = addDeclarationToModule(source, modulePath, classifiedName, importPath);
+
+    if (options.export) {
+      changes.push(...addSymbolToNgModuleMetadata(source, modulePath, 'exports', classifiedName));
+    }
+
+    const recorder = host.beginUpdate(modulePath);
+    for (const change of changes) {
+      if (change instanceof InsertChange) {
+        recorder.insertLeft(change.pos, change.toAdd);
+      }
+    }
+    host.commitUpdate(recorder);
+
+    return host;
+  };
+}


### PR DESCRIPTION

This commits extracts all `addDeclarationToNgModule` logic into a common util which is re-used across a number of schematics.
