### PR TITLE
fix(@angular-devkit/build-angular): correctly display error messages that contain "at"

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/utils/stats.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/utils/stats.ts
@@ -397,7 +397,7 @@ export function statsErrorsToString(
       // See: https://github.com/webpack/webpack/issues/15980
       const message = statsConfig.errorStack
         ? error.message
-        : /[\s\S]+?(?=[\n\s]+at)/.exec(error.message)?.[0] ?? error.message;
+        : /[\s\S]+?(?=\n+\s+at\s)/.exec(error.message)?.[0] ?? error.message;
 
       if (!/^error/i.test(message)) {
         output += r('Error: ');


### PR DESCRIPTION


Previously, the regexp was incorrectly matching messages which contained "at" as part of the text.

Closes #23865
