### PR TITLE
fix(@angular-devkit/build-angular): watch symbolic links

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
@@ -334,7 +334,16 @@ export async function getCommonConfig(wco: WebpackConfigOptions): Promise<Config
     watch: buildOptions.watch,
     watchOptions: {
       poll,
+      // The below is needed as when preserveSymlinks is enabled we disable `resolve.symlinks`.
+      followSymlinks: buildOptions.preserveSymlinks,
       ignored: poll === undefined ? undefined : '**/node_modules/**',
+    },
+    snapshot: {
+      module: {
+        // Use hash of content instead of timestamp because the timestamp of the symlink will be used
+        // instead of the referenced files which causes changes in symlinks not to be picked up.
+        hash: buildOptions.preserveSymlinks,
+      },
     },
     performance: {
       hints: false,

--- a/tests/legacy-cli/e2e/tests/build/rebuild-symlink.ts
+++ b/tests/legacy-cli/e2e/tests/build/rebuild-symlink.ts
@@ -1,0 +1,31 @@
+import { symlink } from 'fs/promises';
+import { resolve } from 'path';
+import { appendToFile, expectFileToMatch, writeMultipleFiles } from '../../utils/fs';
+import { execAndWaitForOutputToMatch, waitForAnyProcessOutputToMatch } from '../../utils/process';
+import { updateJsonFile } from '../../utils/project';
+
+const buildReadyRegEx = /Build at: /;
+
+export default async function () {
+  await updateJsonFile('angular.json', (configJson) => {
+    configJson.projects['test-project'].architect.build.options.preserveSymlinks = true;
+  });
+
+  await writeMultipleFiles({
+    'src/link-source.ts': '// empty file',
+    'src/main.ts': `import './link-dest';`,
+  });
+
+  await symlink(resolve('src/link-source.ts'), resolve('src/link-dest.ts'));
+
+  await execAndWaitForOutputToMatch(
+    'ng',
+    ['build', '--watch', '--configuration=development'],
+    buildReadyRegEx,
+  );
+
+  // Trigger a rebuild
+  await appendToFile('src/link-source.ts', `console.log('foo-bar');`);
+  await waitForAnyProcessOutputToMatch(buildReadyRegEx);
+  await expectFileToMatch('dist/test-project/main.js', `console.log('foo-bar')`);
+}


### PR DESCRIPTION
This commit addresses an issue which caused symbolic links not to be watched properly.

Closes #23896
