### PR TITLE
test: suppress npm update warnings

### DIFF
--- a/tests/legacy-cli/e2e/setup/002-npm-sandbox.ts
+++ b/tests/legacy-cli/e2e/setup/002-npm-sandbox.ts
@@ -41,6 +41,11 @@ export default async function () {
   setGlobalVariable('npm-global', npmModulesPrefix);
   setGlobalVariable('yarn-global', yarnModulesPrefix);
 
+  // Disable all update/notification related npm/yarn features such as the NPM updater notifier.
+  // The NPM updater notifier may prevent the child process from closing until it timeouts after 3 minutes.
+  process.env.NO_UPDATE_NOTIFIER = '1';
+  process.env.NPM_CONFIG_UPDATE_NOTIFIER = 'false';
+
   console.log(`  Using "${npmModulesPrefix}" as e2e test global npm bin dir.`);
   console.log(`  Using "${yarnModulesPrefix}" as e2e test global yarn bin dir.`);
 }

--- a/tests/legacy-cli/e2e/tests/misc/npm-7.ts
+++ b/tests/legacy-cli/e2e/tests/misc/npm-7.ts
@@ -1,5 +1,4 @@
 import * as assert from 'assert';
-import { execSync } from 'child_process';
 import { valid as validSemVer } from 'semver';
 import { rimraf } from '../../utils/fs';
 import { getActivePackageManager } from '../../utils/packages';
@@ -21,16 +20,7 @@ export default async function () {
   }
 
   // Get current package manager version to restore after tests
-  const initialVersionText = execSync('npm --version', {
-    encoding: 'utf8',
-    stdio: ['ignore', 'pipe', 'ignore'],
-    env: {
-      ...process.env,
-      //  NPM updater notifier will prevent the child process from closing until it timeouts after 3 minutes.
-      NO_UPDATE_NOTIFIER: '1',
-      NPM_CONFIG_UPDATE_NOTIFIER: 'false',
-    },
-  }).trim();
+  const initialVersionText = (await npm('--version')).stdout.trim();
   const initialVersion = validSemVer(initialVersionText);
   assert.ok(
     initialVersion,

--- a/tests/legacy-cli/e2e/utils/process.ts
+++ b/tests/legacy-cli/e2e/utils/process.ts
@@ -16,7 +16,7 @@ interface ExecOptions {
   cwd?: string;
 }
 
-const NPM_CONFIG_RE = /^(npm_config_|yarn_)/i;
+const NPM_CONFIG_RE = /^(npm_config_|yarn_|no_update_notifier)/i;
 
 let _processes: child_process.ChildProcess[] = [];
 


### PR DESCRIPTION
Applying this to everything to reduce stdout spam. There's also the note about the 3 minute timeout although I don't think I've seen that myself.