### PR TITLE
test: re-enable Angular material tests

### DIFF
--- a/tests/legacy-cli/e2e/tests/build/material.ts
+++ b/tests/legacy-cli/e2e/tests/build/material.ts
@@ -7,9 +7,6 @@ import { isPrereleaseCli, updateJsonFile } from '../../utils/project';
 const snapshots = require('../../ng-snapshot/package.json');
 
 export default async function () {
-  // TODO(alanagius): re-enable once material version 15.0.0-next is out.
-  return;
-
   let tag = (await isPrereleaseCli()) ? '@next' : '';
   await ng('add', `@angular/material${tag}`, '--skip-confirmation');
 

--- a/tests/legacy-cli/e2e/tests/commands/add/add-material.ts
+++ b/tests/legacy-cli/e2e/tests/commands/add/add-material.ts
@@ -5,34 +5,31 @@ import { ng } from '../../../utils/process';
 import { isPrereleaseCli } from '../../../utils/project';
 
 export default async function () {
-  // TODO(alanagius): re-enable material once version 15.0.0-next is out.
-  return;
+  // forcibly remove in case another test doesn't clean itself up
+  await rimraf('node_modules/@angular/material');
 
-  // // forcibly remove in case another test doesn't clean itself up
-  // await rimraf('node_modules/@angular/material');
+  const tag = (await isPrereleaseCli()) ? '@next' : '';
 
-  // const tag = (await isPrereleaseCli()) ? '@next' : '';
+  try {
+    await ng('add', `@angular/material${tag}`, '--unknown', '--skip-confirmation');
+  } catch (error) {
+    assertIsError(error);
+    if (!error.message.includes(`Unknown option: '--unknown'`)) {
+      throw error;
+    }
+  }
 
-  // try {
-  //   await ng('add', `@angular/material${tag}`, '--unknown', '--skip-confirmation');
-  // } catch (error) {
-  //   assertIsError(error);
-  //   if (!error.message.includes(`Unknown option: '--unknown'`)) {
-  //     throw error;
-  //   }
-  // }
+  await ng(
+    'add',
+    `@angular/material${tag}`,
+    '--theme',
+    'custom',
+    '--verbose',
+    '--skip-confirmation',
+  );
+  await expectFileToMatch('package.json', /@angular\/material/);
 
-  // await ng(
-  //   'add',
-  //   `@angular/material${tag}`,
-  //   '--theme',
-  //   'custom',
-  //   '--verbose',
-  //   '--skip-confirmation',
-  // );
-  // await expectFileToMatch('package.json', /@angular\/material/);
-
-  // // Clean up existing cdk package
-  // // Not doing so can cause adding material to fail if an incompatible cdk is present
-  // await uninstallPackage('@angular/cdk');
+  // Clean up existing cdk package
+  // Not doing so can cause adding material to fail if an incompatible cdk is present
+  await uninstallPackage('@angular/cdk');
 }

--- a/tests/legacy-cli/e2e/tests/misc/invalid-schematic-dependencies.ts
+++ b/tests/legacy-cli/e2e/tests/misc/invalid-schematic-dependencies.ts
@@ -4,9 +4,6 @@ import { installPackage, uninstallPackage } from '../../utils/packages';
 import { isPrereleaseCli } from '../../utils/project';
 
 export default async function () {
-  // TODO(alanagius): re-enable once material version 15.0.0-next is out.
-  return;
-
   // Must publish old version to local registry to allow install. This is especially important
   // for release commits as npm will try to request tooling packages that are not on the npm registry yet
   await publishOutdated('@schematics/angular@7');


### PR DESCRIPTION
Now that `@angular/material` has been released as `15.0.0-next` we can re-enable these tests.
