### PR TITLE
ci: remove manually specifying GITHUB_TOKEN in scorecard action

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -32,7 +32,6 @@ jobs:
         with:
           results_file: results.sarif
           results_format: sarif
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
           publish_results: true
 
       # Upload the results as artifacts.


### PR DESCRIPTION
The `ossf/scorecard-action` action will automatically use the builtin GITHUB_TOKEN as needed.