### PR TITLE
build: update saucelabs connect version

### DIFF
--- a/package.json
+++ b/package.json
@@ -198,7 +198,7 @@
     "rxjs": "6.6.7",
     "sass": "1.54.4",
     "sass-loader": "13.0.2",
-    "sauce-connect-proxy": "https://saucelabs.com/downloads/sc-4.7.1-linux.tar.gz",
+    "sauce-connect-proxy": "https://saucelabs.com/downloads/sc-4.8.1-linux.tar.gz",
     "semver": "7.3.7",
     "shelljs": "^0.8.5",
     "source-map": "0.7.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9799,9 +9799,9 @@ sass@1.54.4, sass@^1.49.9:
     immutable "^4.0.0"
     source-map-js ">=0.6.2 <2.0.0"
 
-"sauce-connect-proxy@https://saucelabs.com/downloads/sc-4.7.1-linux.tar.gz":
+"sauce-connect-proxy@https://saucelabs.com/downloads/sc-4.8.1-linux.tar.gz":
   version "0.0.0"
-  resolved "https://saucelabs.com/downloads/sc-4.7.1-linux.tar.gz#e5d7f82ad98251a653d1b0537f1103e49eda5e11"
+  resolved "https://saucelabs.com/downloads/sc-4.8.1-linux.tar.gz#9c16682e4c9716734432789884f868212f95f563"
 
 saucelabs@^1.5.0:
   version "1.5.0"


### PR DESCRIPTION
Update to saucelabs connect 4.8.1

(cherry picked from commit 82649bc6c27d5b9c9f07d5c877a61da8a7d1e61b)

Cherry pick of https://github.com/angular/angular-cli/pull/23909.