### PR TITLE
feat(@schematics/angular): enable error on unknown properties and elements in tests

### DIFF
--- a/packages/angular_devkit/build_angular/test/hello-world-app/src/test.ts
+++ b/packages/angular_devkit/build_angular/test/hello-world-app/src/test.ts
@@ -23,10 +23,10 @@ declare const require: {
 };
 
 // First, initialize the Angular testing environment.
-getTestBed().initTestEnvironment(
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting(),
-);
+getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), {
+  errorOnUnknownElements: true,
+  errorOnUnknownProperties: true
+});
 // Then we find all the tests.
 const context = require.context('./', true, /\.spec\.ts$/);
 // And load the modules.

--- a/packages/angular_devkit/build_angular/test/hello-world-lib/projects/lib/src/test.ts
+++ b/packages/angular_devkit/build_angular/test/hello-world-lib/projects/lib/src/test.ts
@@ -24,10 +24,10 @@ declare const require: {
 };
 
 // First, initialize the Angular testing environment.
-getTestBed().initTestEnvironment(
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting(),
-);
+getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), {
+  errorOnUnknownElements: true,
+  errorOnUnknownProperties: true
+});
 // Then we find all the tests.
 const context = require.context('./', true, /\.spec\.ts$/);
 // And load the modules.

--- a/packages/schematics/angular/application/files/src/test.ts.template
+++ b/packages/schematics/angular/application/files/src/test.ts.template
@@ -15,10 +15,10 @@ declare const require: {
 };
 
 // First, initialize the Angular testing environment.
-getTestBed().initTestEnvironment(
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting(),
-);
+getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), {
+  errorOnUnknownElements: true,
+  errorOnUnknownProperties: true
+});
 
 // Then we find all the tests.
 const context = require.context('./', true, /\.spec\.ts$/);

--- a/packages/schematics/angular/library/files/src/test.ts.template
+++ b/packages/schematics/angular/library/files/src/test.ts.template
@@ -16,10 +16,10 @@ declare const require: {
 };
 
 // First, initialize the Angular testing environment.
-getTestBed().initTestEnvironment(
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting(),
-);
+getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), {
+  errorOnUnknownElements: true,
+  errorOnUnknownProperties: true
+});
 
 // Then we find all the tests.
 const context = require.context('./', true, /\.spec\.ts$/);


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the new behavior?

These new options have been introduced in Angular v14. The commit enables the options in a new project, as we did when we introduced the `destroyAfterOption`, with the same long-term goal to have these options enabled by default.

This is similar to #21300 which was done in the past to add `destroyAfterOption: true` by default.

This was discussed with @AndrewKushnir (who wants to discuss it in the next team sync meeting) and the idea would be to change these options to true by default and add a migration to ease the transition in v16 or later.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
