### PR TITLE
ci: adjust workflow permissions for OpenSSF Scorecard results publishing

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -16,10 +16,12 @@ jobs:
     name: Scorecards analysis
     runs-on: ubuntu-latest
     permissions:
-      # Needed to upload the results to code-scanning dashboard.
-      security-events: write
       actions: read
       contents: read
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Needed to publish results
+      id-token: write
 
     steps:
       - name: 'Checkout code'


### PR DESCRIPTION
Version 2 of the `openssf/scorecard-action` GitHub action requires the `id-token: write` permission to publish results.
