### PR TITLE
feat(@angular-devkit/build-angular): add esbuild-based builder initial support for fileReplacements

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/experimental-warnings.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/experimental-warnings.ts
@@ -13,7 +13,6 @@ const UNSUPPORTED_OPTIONS: Array<keyof BrowserBuilderOptions> = [
   'allowedCommonJsDependencies',
   'budgets',
   'extractLicenses',
-  'fileReplacements',
   'progress',
   'scripts',
   'statsJson',

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
@@ -249,6 +249,17 @@ async function bundleCode(
   sourcemapOptions: SourceMapClass,
   tsconfig: string,
 ) {
+  let fileReplacements: Record<string, string> | undefined;
+  if (options.fileReplacements) {
+    for (const replacement of options.fileReplacements) {
+      fileReplacements ??= {};
+      fileReplacements[path.join(workspaceRoot, replacement.replace)] = path.join(
+        workspaceRoot,
+        replacement.with,
+      );
+    }
+  }
+
   return bundle({
     absWorkingDir: workspaceRoot,
     bundle: true,
@@ -288,6 +299,7 @@ async function bundleCode(
           thirdPartySourcemaps: sourcemapOptions.vendor,
           tsconfig,
           advancedOptimizations: options.buildOptimizer,
+          fileReplacements,
         },
         // Component stylesheet options
         {

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/schema.json
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/schema.json
@@ -461,38 +461,19 @@
       ]
     },
     "fileReplacement": {
-      "oneOf": [
-        {
-          "type": "object",
-          "properties": {
-            "src": {
-              "type": "string",
-              "pattern": "\\.(([cm]?j|t)sx?|json)$"
-            },
-            "replaceWith": {
-              "type": "string",
-              "pattern": "\\.(([cm]?j|t)sx?|json)$"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["src", "replaceWith"]
+      "type": "object",
+      "properties": {
+        "replace": {
+          "type": "string",
+          "pattern": "\\.(([cm]?j|t)sx?|json)$"
         },
-        {
-          "type": "object",
-          "properties": {
-            "replace": {
-              "type": "string",
-              "pattern": "\\.(([cm]?j|t)sx?|json)$"
-            },
-            "with": {
-              "type": "string",
-              "pattern": "\\.(([cm]?j|t)sx?|json)$"
-            }
-          },
-          "additionalProperties": false,
-          "required": ["replace", "with"]
+        "with": {
+          "type": "string",
+          "pattern": "\\.(([cm]?j|t)sx?|json)$"
         }
-      ]
+      },
+      "additionalProperties": false,
+      "required": ["replace", "with"]
     },
     "budget": {
       "type": "object",


### PR DESCRIPTION
Support for the `fileReplacements` option from the Webpack-based builder has now been integrated into the experimental esbuild-based browser application builder. The option will no longer be ignored during builds. Only the officially supported form of the option (`replace`/`with` fields) is implemented.