### PR TITLE
build: fix yarn ng-dev bin on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "build:bazel": "node ./bin/devkit-admin build-bazel",
     "build-tsc": "tsc -p tsconfig.json",
     "lint": "eslint --cache --max-warnings=0 \"**/*.ts\"",
-    "ng-dev": "cross-env TS_NODE_PROJECT=$PWD/.ng-dev/tsconfig.json TS_NODE_TRANSPILE_ONLY=1 node --no-warnings --loader ts-node/esm node_modules/@angular/ng-dev/bundles/cli.mjs",
+    "ng-dev": "cross-env TS_NODE_PROJECT=./.ng-dev/tsconfig.json TS_NODE_TRANSPILE_ONLY=1 node --no-warnings --loader ts-node/esm node_modules/@angular/ng-dev/bundles/cli.mjs",
     "templates": "node ./bin/devkit-admin templates",
     "validate": "node ./bin/devkit-admin validate",
     "postinstall": "yarn webdriver-update && yarn husky install",


### PR DESCRIPTION
This doesn't seem to work on windows (CI or Windows 11)? 🤷 