### PR TITLE
test: enable git core.longpaths option

### DIFF
--- a/.circleci/dynamic_config.yml
+++ b/.circleci/dynamic_config.yml
@@ -129,7 +129,6 @@ commands:
       - run: npm install -g yarn@1.22.10
       - run: node --version
       - run: yarn --version
-      - run: git config --global core.longpaths true
 
   setup_bazel_rbe:
     parameters:

--- a/tests/legacy-cli/e2e/utils/project.ts
+++ b/tests/legacy-cli/e2e/utils/project.ts
@@ -41,6 +41,7 @@ export async function prepareProjectForE2e(name: string) {
   await git('config', 'user.email', 'angular-core+e2e@google.com');
   await git('config', 'user.name', 'Angular CLI E2E');
   await git('config', 'commit.gpgSign', 'false');
+  await git('config', 'core.longpaths', 'true');
 
   if (argv['ng-snapshots'] || argv['ng-tag']) {
     await useSha();


### PR DESCRIPTION
If things like the temp dir, project root etc have long paths (such as custom paths passed on the cli, or bazel runfiles/temp directories) then this is required.