### PR TITLE
refactor(@angular/cli): remove use of global require resolve

### DIFF
--- a/packages/angular/cli/lib/init.ts
+++ b/packages/angular/cli/lib/init.ts
@@ -9,6 +9,7 @@
 import 'symbol-observable';
 // symbol polyfill must go first
 import { promises as fs } from 'fs';
+import { createRequire } from 'module';
 import * as path from 'path';
 import { SemVer, major } from 'semver';
 import { colors } from '../src/utilities/color';
@@ -47,7 +48,8 @@ let forceExit = false;
   try {
     // No error implies a projectLocalCli, which will load whatever
     // version of ng-cli you have installed in a local package.json
-    const projectLocalCli = require.resolve('@angular/cli', { paths: [process.cwd()] });
+    const cwdRequire = createRequire(process.cwd() + '/');
+    const projectLocalCli = cwdRequire.resolve('@angular/cli');
     cli = await import(projectLocalCli);
 
     const globalVersion = new SemVer(VERSION.full);

--- a/packages/angular/cli/src/command-builder/utilities/schematic-engine-host.ts
+++ b/packages/angular/cli/src/command-builder/utilities/schematic-engine-host.ts
@@ -10,7 +10,7 @@ import { RuleFactory, SchematicsException, Tree } from '@angular-devkit/schemati
 import { FileSystemCollectionDesc, NodeModulesEngineHost } from '@angular-devkit/schematics/tools';
 import { readFileSync } from 'fs';
 import { parse as parseJson } from 'jsonc-parser';
-import nodeModule from 'module';
+import { createRequire } from 'module';
 import { dirname, resolve } from 'path';
 import { Script } from 'vm';
 import { assertIsError } from '../../utilities/error';
@@ -63,7 +63,8 @@ export class SchematicEngineHost extends NodeModulesEngineHost {
     // Mimic behavior of ExportStringRef class used in default behavior
     const fullPath = path[0] === '.' ? resolve(parentPath ?? process.cwd(), path) : path;
 
-    const schematicFile = require.resolve(fullPath, { paths: [parentPath] });
+    const referenceRequire = createRequire(__filename);
+    const schematicFile = referenceRequire.resolve(fullPath, { paths: [parentPath] });
 
     if (shouldWrapSchematic(schematicFile, !!collectionDescription?.encapsulation)) {
       const schematicPath = dirname(schematicFile);
@@ -128,8 +129,8 @@ function wrap(
   moduleCache: Map<string, unknown>,
   exportName?: string,
 ): () => unknown {
-  const hostRequire = nodeModule.createRequire(__filename);
-  const schematicRequire = nodeModule.createRequire(schematicFile);
+  const hostRequire = createRequire(__filename);
+  const schematicRequire = createRequire(schematicFile);
 
   const customRequire = function (id: string) {
     if (legacyModules[id]) {


### PR DESCRIPTION
The global require function is not present in Node.js ESM mode. To support the eventual transition of the `@angular/cli` package to ESM, usage of the `require.resolve` function has been converted to use locally created `require` functions via `createRequire` from the `module` builtin.