### PR TITLE
feat(@angular-devkit/build-angular): add `ng-server-context` when using app-shell builder

### DIFF
--- a/packages/angular_devkit/build_angular/BUILD.bazel
+++ b/packages/angular_devkit/build_angular/BUILD.bazel
@@ -106,6 +106,7 @@ ts_library(
         "@npm//@angular/compiler-cli",
         "@npm//@angular/core",
         "@npm//@angular/localize",
+        "@npm//@angular/platform-server",
         "@npm//@angular/service-worker",
         "@npm//@babel/core",
         "@npm//@babel/generator",
@@ -282,9 +283,6 @@ ts_library(
 
 LARGE_SPECS = {
     "app-shell": {
-        "extra_deps": [
-            "@npm//@angular/platform-server",
-        ],
         "tags": [
             # TODO: node crashes with an internal error on node16
             "node16-broken",

--- a/packages/angular_devkit/build_angular/src/builders/app-shell/app-shell_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/app-shell/app-shell_spec.ts
@@ -140,7 +140,8 @@ describe('AppShell Builder', () => {
 
     const fileName = 'dist/index.html';
     const content = virtualFs.fileBufferToString(host.scopedSync().read(normalize(fileName)));
-    expect(content).toMatch(/Welcome to app!/);
+    expect(content).toMatch('Welcome to app');
+    expect(content).toMatch('ng-server-context="app-shell"');
   });
 
   it('works with route', async () => {


### PR DESCRIPTION
With this change we configure the app-shell builder to set the `ɵSERVER_CONTEXT` private provider.

FYI @AndrewKushnir 