### PR TITLE
fix(@angular-devkit/build-angular): fix crash when Sass error occurs

### DIFF
--- a/packages/angular_devkit/build_angular/src/sass/worker.ts
+++ b/packages/angular_devkit/build_angular/src/sass/worker.ts
@@ -93,7 +93,18 @@ parentPort.on('message', ({ id, hasImporter, source, options }: RenderRequestMes
         id,
         error: {
           span: {
-            ...span,
+            text: span.text,
+            context: span.context,
+            end: {
+              column: span.end.column,
+              offset: span.end.offset,
+              line: span.end.line,
+            },
+            start: {
+              column: span.start.column,
+              offset: span.start.offset,
+              line: span.start.line,
+            },
             url: span.url ? fileURLToPath(span.url) : undefined,
           },
           message,


### PR DESCRIPTION
In some cases the build will crash when there is a Sass error due to the fact that the `span` property on the Error instance cannot be cloned.

```
  process.nextTick(() => { throw err; });
                           ^

DataCloneError: function StaticClosure() {
    } could not be cloned.
    at MessagePort.<anonymous> (/node_modules/@angular-devkit/build-angular/src/sass/worker.js:61:41)
```
