### PR TITLE
fix(@angular-devkit/build-angular): allow both script and module sourceTypes to be localized

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/process-bundle.ts
+++ b/packages/angular_devkit/build_angular/src/utils/process-bundle.ts
@@ -139,7 +139,7 @@ export async function inlineLocales(options: InlineOptions) {
     ast = parseSync(options.code, {
       babelrc: false,
       configFile: false,
-      sourceType: 'script',
+      sourceType: 'unambiguous',
       filename: options.filename,
     });
   } catch (error) {


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Localization fails to inline translations into module js files. This becomes an issue with module-federation builds.

Issue Number:  #23008

## What is the new behavior?

Allow locale to be inlined to both `script` and `module` files using `sourceType: 'unambiguous'`. https://babeljs.io/docs/en/options#sourcetype

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
