### PR TITLE
fix(@schematics/angular): remove empty lines in main.ts

### DIFF
--- a/packages/schematics/angular/application/files/src/main.ts.template
+++ b/packages/schematics/angular/application/files/src/main.ts.template
@@ -1,5 +1,5 @@
-<% if(!!viewEncapsulation) { %>import { ViewEncapsulation } from '@angular/core';<% }%>
-import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+<% if(!!viewEncapsulation) { %>import { ViewEncapsulation } from '@angular/core';
+<% }%>import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 
 import { AppModule } from './app/app.module';
 
@@ -7,8 +7,7 @@ import { AppModule } from './app/app.module';
 platformBrowserDynamic().bootstrapModule(AppModule, {
   defaultEncapsulation: ViewEncapsulation.<%= viewEncapsulation %>
 })
-  .catch(err => console.error(err));
-<% } else { %>
+  .catch(err => console.error(err));<% } else { %>
 platformBrowserDynamic().bootstrapModule(AppModule)
   .catch(err => console.error(err));
 <% } %>


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
The recet removal of enableProdMode in 283b564d1de985f0af8c2fcb6192801a90baacda introduced unnecessary empty lines in main.ts

See https://github.com/cexbrayat/angular-cli-diff/blob/15.0.0-next.3/ponyracer/src/main.ts

## What is the new behavior?

main.ts is now:

```ts
import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';

import { AppModule } from './app/app.module';


platformBrowserDynamic().bootstrapModule(AppModule)
  .catch(err => console.error(err));

```

Note the removal of the extra lines

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
