### PR TITLE
refactor(@angular-devkit/build-angular): move more esbuild option setup into normalize option helper

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/options.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/options.ts
@@ -15,6 +15,8 @@ import { getIndexInputFile, getIndexOutputFile } from '../../utils/webpack-brows
 import { normalizeGlobalStyles } from '../../webpack/utils/helpers';
 import { Schema as BrowserBuilderOptions, OutputHashing } from './schema';
 
+export type NormalizedBrowserOptions = Awaited<ReturnType<typeof normalizeOptions>>;
+
 /**
  * Normalize the user provided options by creating full paths for all path based options
  * and converting multi-form options into a single form that can be directly used
@@ -125,7 +127,28 @@ export async function normalizeOptions(
     };
   }
 
+  // Initial options to keep
+  const {
+    baseHref,
+    buildOptimizer,
+    crossOrigin,
+    externalDependencies,
+    preserveSymlinks,
+    stylePreprocessorOptions,
+    subresourceIntegrity,
+    verbose,
+  } = options;
+
+  // Return all the normalized options
   return {
+    advancedOptimizations: buildOptimizer,
+    baseHref,
+    crossOrigin,
+    externalDependencies,
+    preserveSymlinks,
+    stylePreprocessorOptions,
+    subresourceIntegrity,
+    verbose,
     workspaceRoot,
     entryPoints,
     optimizationOptions,

--- a/packages/angular_devkit/build_angular/src/utils/service-worker.ts
+++ b/packages/angular_devkit/build_angular/src/utils/service-worker.ts
@@ -93,6 +93,52 @@ export async function augmentAppWithServiceWorker(
     }
   }
 
+  return augmentAppWithServiceWorkerCore(
+    config,
+    outputPath,
+    baseHref,
+    inputputFileSystem,
+    outputFileSystem,
+  );
+}
+
+// This is currently used by the esbuild-based builder
+export async function augmentAppWithServiceWorkerEsbuild(
+  workspaceRoot: string,
+  configPath: string,
+  outputPath: string,
+  baseHref: string,
+): Promise<void> {
+  // Read the configuration file
+  let config: Config | undefined;
+  try {
+    const configurationData = await fsPromises.readFile(configPath, 'utf-8');
+    config = JSON.parse(configurationData) as Config;
+  } catch (error) {
+    assertIsError(error);
+    if (error.code === 'ENOENT') {
+      // TODO: Generate an error object that can be consumed by the esbuild-based builder
+      const message = `Service worker configuration file "${path.relative(
+        workspaceRoot,
+        configPath,
+      )}" could not be found.`;
+      throw new Error(message);
+    } else {
+      throw error;
+    }
+  }
+
+  // TODO: Return the output files and any errors/warnings
+  return augmentAppWithServiceWorkerCore(config, outputPath, baseHref);
+}
+
+export async function augmentAppWithServiceWorkerCore(
+  config: Config,
+  outputPath: string,
+  baseHref: string,
+  inputputFileSystem = fsPromises,
+  outputFileSystem = fsPromises,
+): Promise<void> {
   // Load ESM `@angular/service-worker/config` using the TypeScript dynamic import workaround.
   // Once TypeScript provides support for keeping the dynamic import this workaround can be
   // changed to a direct dynamic import.


### PR DESCRIPTION
The initial global stylesheet, file replacement, index HTML, and service worker option analysis and cleanup has now been moved into the `normalizeOptions` helper for the esbuild-based browser application builder. This better organizes the option related setup steps as well as reduces the amount of code in the main builder source file.