### PR TITLE
feat(@angular-devkit/build-angular): add initial incremental code rebuilding to esbuild builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/options.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/options.ts
@@ -133,10 +133,12 @@ export async function normalizeOptions(
     buildOptimizer,
     crossOrigin,
     externalDependencies,
+    poll,
     preserveSymlinks,
     stylePreprocessorOptions,
     subresourceIntegrity,
     verbose,
+    watch,
   } = options;
 
   // Return all the normalized options
@@ -145,10 +147,12 @@ export async function normalizeOptions(
     baseHref,
     crossOrigin,
     externalDependencies,
+    poll,
     preserveSymlinks,
     stylePreprocessorOptions,
     subresourceIntegrity,
     verbose,
+    watch,
     workspaceRoot,
     entryPoints,
     optimizationOptions,


### PR DESCRIPTION
The experimental esbuild-based browser application builder will now support incremental JavaScript bundling when run in watch mode via the `watch` option. This initial implementation integrates the esbuild incremental rebuild functionality. TypeScript source file caching has also been added to improve the rebuild initialization time for the TypeScript and Angular compilation steps. This initial support is not yet fully optimized and additional work is planned to further improve the rebuild performance.