### PR TITLE
fix(@angular-devkit/schematics): throw more relevant error when Rule returns invalid null value

### DIFF
--- a/packages/angular_devkit/schematics/src/rules/call.ts
+++ b/packages/angular_devkit/schematics/src/rules/call.ts
@@ -91,7 +91,7 @@ async function callRuleAsync(rule: Rule, tree: Tree, context: SchematicContext):
     result = await result.pipe(defaultIfEmpty(tree)).toPromise();
   }
 
-  if (TreeSymbol in result) {
+  if (result && TreeSymbol in result) {
     return result as Tree;
   }
 

--- a/packages/angular_devkit/schematics/src/rules/call_spec.ts
+++ b/packages/angular_devkit/schematics/src/rules/call_spec.ts
@@ -20,11 +20,11 @@ import {
   callSource,
 } from './call';
 
-const context: SchematicContext = ({
+const context: SchematicContext = {
   engine: null,
   debug: false,
   strategy: MergeStrategy.Default,
-} as {}) as SchematicContext;
+} as {} as SchematicContext;
 
 describe('callSource', () => {
   it('errors if undefined source', (done) => {
@@ -95,34 +95,20 @@ describe('callSource', () => {
 });
 
 describe('callRule', () => {
-  it('errors if invalid source object', (done) => {
-    const tree0 = observableOf(empty());
+  it('should throw InvalidRuleResultException when rule result is non-Tree object', async () => {
     const rule0: Rule = () => ({} as Tree);
 
-    callRule(rule0, tree0, context)
-      .toPromise()
-      .then(
-        () => done.fail(),
-        (err) => {
-          expect(err).toEqual(new InvalidRuleResultException({}));
-        },
-      )
-      .then(done, done.fail);
+    await expectAsync(callRule(rule0, empty(), context).toPromise()).toBeRejectedWithError(
+      InvalidRuleResultException,
+    );
   });
 
-  it('errors if Observable of invalid source object', (done) => {
-    const tree0 = observableOf(empty());
-    const rule0: Rule = () => observableOf({} as Tree);
+  it('should throw InvalidRuleResultException when rule result is null', async () => {
+    const rule0: Rule = () => null as unknown as Tree;
 
-    callRule(rule0, tree0, context)
-      .toPromise()
-      .then(
-        () => done.fail(),
-        (err) => {
-          expect(err).toEqual(new InvalidRuleResultException({}));
-        },
-      )
-      .then(done, done.fail);
+    await expectAsync(callRule(rule0, empty(), context).toPromise()).toBeRejectedWithError(
+      InvalidRuleResultException,
+    );
   });
 
   it('works with undefined result', (done) => {


### PR DESCRIPTION
A `null` value is not considered a valid return value for a schematics Rule. Previously, this
would accidently be treated the same as a void return due to incomplete result checking.
However, recent refactoring caused the `null` case to fail with a non-obvious error message when
it should have failed with the existing `InvalidRuleResultException`. Non-tree result objects
including `null` will now fail with `InvalidRuleResultException`.