### PR TITLE
fix(@angular/cli): skip downloading temp CLI when running `ng update` without package names

### DIFF
--- a/packages/angular/cli/src/commands/update/cli.ts
+++ b/packages/angular/cli/src/commands/update/cli.ts
@@ -165,7 +165,8 @@ export class UpdateCommandModule extends CommandModule<UpdateCommandArgs> {
     packageManager.ensureCompatibility();
 
     // Check if the current installed CLI version is older than the latest compatible version.
-    if (!disableVersionCheck) {
+    // Skip when running `ng update` without a package name as this will not trigger an actual update.
+    if (!disableVersionCheck && options.packages?.length) {
       const cliVersionToInstall = await this.checkCLIVersion(
         options.packages,
         options.verbose,
@@ -882,7 +883,7 @@ export class UpdateCommandModule extends CommandModule<UpdateCommandArgs> {
    * @returns the version to install or null when there is no update to install.
    */
   private async checkCLIVersion(
-    packagesToUpdate: string[] | undefined,
+    packagesToUpdate: string[],
     verbose = false,
     next = false,
   ): Promise<string | null> {

--- a/packages/angular/cli/src/utilities/package-metadata.ts
+++ b/packages/angular/cli/src/utilities/package-metadata.ts
@@ -292,17 +292,10 @@ export async function getNpmPackageJson(
   const { usingYarn = false, verbose = false, registry } = options;
   ensureNpmrc(logger, usingYarn, verbose);
   const { packument } = await import('pacote');
-  const resultPromise = packument(packageName, {
+  const response = packument(packageName, {
     fullMetadata: true,
     ...npmrc,
     ...(registry ? { registry } : {}),
-  });
-
-  // TODO: find some way to test this
-  const response = resultPromise.catch((err) => {
-    logger.warn(err.message || err);
-
-    return { requestedName: packageName };
   });
 
   npmPackageJsonCache.set(packageName, response);


### PR DESCRIPTION


In the case when `ng update` is ran without a package name, an update is not be performed. In this case using the current installed version of the CLI is good enough.

Closes #24024
