### PR TITLE
refactor(@angular-devkit/build-angular): use high resolution time for esbuild builder completion time

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
@@ -69,7 +69,7 @@ async function execute(
   context: BuilderContext,
   rebuildState?: RebuildState,
 ): Promise<ExecutionResult> {
-  const startTime = Date.now();
+  const startTime = process.hrtime.bigint();
 
   const {
     projectRoot,
@@ -206,7 +206,8 @@ async function execute(
     }
   }
 
-  context.logger.info(`Complete. [${(Date.now() - startTime) / 1000} seconds]`);
+  const buildTime = Number(process.hrtime.bigint() - startTime) / 10 ** 9;
+  context.logger.info(`Complete. [${buildTime.toFixed(3)} seconds]`);
 
   return new ExecutionResult(true, codeResults.rebuild, codeBundleCache);
 }


### PR DESCRIPTION
Update the build time calculation for the experimental esbuild-based browser application builder to use the `process.hrtime` time source.  The high resolution time provides a more accurate time source and allows for nanosecond level timings if needed.  Currently the console output is rounded to the nearest millisecond. Future performance monitoring capabilities may leverage the more fine-grained values.