### PR TITLE
feat: drop support for TypeScript 4.6 and 4.7

### DIFF
--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -79,7 +79,7 @@
     "ng-packagr": "^15.0.0-next",
     "protractor": "^7.0.0",
     "tailwindcss": "^2.0.0 || ^3.0.0",
-    "typescript": ">=4.6.2 <4.9"
+    "typescript": "~4.8.2"
   },
   "peerDependenciesMeta": {
     "@angular/localize": {

--- a/packages/ngtools/webpack/package.json
+++ b/packages/ngtools/webpack/package.json
@@ -23,7 +23,7 @@
   "dependencies": {},
   "peerDependencies": {
     "@angular/compiler-cli": "^15.0.0-next",
-    "typescript": ">=4.6.2 <4.9",
+    "typescript": "~4.8.2",
     "webpack": "^5.54.0"
   },
   "devDependencies": {

--- a/packages/schematics/angular/utility/latest-versions/package.json
+++ b/packages/schematics/angular/utility/latest-versions/package.json
@@ -17,7 +17,7 @@
     "rxjs": "~7.5.0",
     "tslib": "^2.3.0",
     "ts-node": "~10.9.0",
-    "typescript": "~4.7.2",
+    "typescript": "~4.8.2",
     "zone.js": "~0.11.4"
   }
 }


### PR DESCRIPTION
This commit drops support for TypeScript 4.6 and 4.7

BREAKING CHANGE: TypeScript versions older than 4.8.2 are no longer supported.
