### PR TITLE
feat(@schematics/angular): mark `projectRoot` as non hidden option in application schematic

### DIFF
--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -247,7 +247,6 @@ export default function (options: ApplicationOptions): Rule {
 
     const workspace = await getWorkspace(host);
     const newProjectRoot = (workspace.extensions.newProjectRoot as string | undefined) || '';
-    const isRootApp = options.projectRoot !== undefined;
 
     // If scoped project (i.e. "@foo/bar"), convert dir to "foo/bar".
     let folderName = options.name.startsWith('@') ? options.name.slice(1) : options.name;
@@ -255,9 +254,11 @@ export default function (options: ApplicationOptions): Rule {
       folderName = strings.dasherize(folderName);
     }
 
-    const appDir = isRootApp
-      ? normalize(options.projectRoot || '')
-      : join(normalize(newProjectRoot), folderName);
+    const appDir =
+      options.projectRoot === undefined
+        ? join(normalize(newProjectRoot), folderName)
+        : normalize(options.projectRoot);
+
     const sourceDir = `${appDir}/src/app`;
 
     return chain([
@@ -270,7 +271,6 @@ export default function (options: ApplicationOptions): Rule {
             ...options,
             relativePathToWorkspaceRoot: relativePathToWorkspaceRoot(appDir),
             appName: options.name,
-            isRootApp,
             folderName,
           }),
           move(appDir),

--- a/packages/schematics/angular/application/schema.json
+++ b/packages/schematics/angular/application/schema.json
@@ -7,12 +7,11 @@
   "additionalProperties": false,
   "properties": {
     "projectRoot": {
-      "description": "The root directory of the new app.",
-      "type": "string",
-      "visible": false
+      "description": "The root directory of the new application.",
+      "type": "string"
     },
     "name": {
-      "description": "The name of the new app.",
+      "description": "The name of the new application.",
       "type": "string",
       "pattern": "^(?:@[a-zA-Z0-9-*~][a-zA-Z0-9-*._~]*/)?[a-zA-Z0-9-~][a-zA-Z0-9-._~]*$",
       "$default": {


### PR DESCRIPTION
This option is useful to create an application outside of the `newProjectRoot`.

Related to https://github.com/angular/angular-cli/pull/23994

