### PR TITLE
perf(@angular-devkit/build-angular): minimize Angular diagnostics incremental analysis in esbuild-based builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/profiling.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/profiling.ts
@@ -21,7 +21,7 @@ export function logCumulativeDurations(): void {
 
   for (const [name, duration] of cumulativeDurations) {
     // eslint-disable-next-line no-console
-    console.log(`DURATION[${name}]: ${duration} seconds`);
+    console.log(`DURATION[${name}]: ${duration.toFixed(9)} seconds`);
   }
 }
 
@@ -32,7 +32,7 @@ function recordDuration(name: string, startTime: bigint, cumulative?: boolean): 
     cumulativeDurations.set(name, (cumulativeDurations.get(name) ?? 0) + duration);
   } else {
     // eslint-disable-next-line no-console
-    console.log(`DURATION[${name}]: ${duration} seconds`);
+    console.log(`DURATION[${name}]: ${duration.toFixed(9)} seconds`);
   }
 }
 


### PR DESCRIPTION
When using the experimental esbuild-based browser application builder, the Angular diagnostic analysis performed per rebuild is now reduced to only the affected files for that rebuild. A rebuild will now query the TypeScript compiler and the Angular compiler to determine the list of potentially affected files. The Angular compiler will then only be queried for diagnostics for this set of affected files instead of the entirety of the program.