### PR TITLE
fix(@angular-devkit/build-angular): ignore specs in node_modules when finding specs

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/karma/find-tests-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/find-tests-plugin.ts
@@ -132,6 +132,7 @@ async function findMatchingTests(
     root: projectSourceRoot,
     nomount: true,
     absolute: true,
+    ignore: ['**/node_modules/**'],
   });
 }
 


### PR DESCRIPTION
Some libraries ship spec in node_modules which might result errors such

```
./node_modules/comment-parser/tests/unit/spacer-description-joiner.spec.ts - Error: Module build failed (from ./node_modules/@ngtools/webpack/src/ivy/index.js):
Error: /Users/kkostadinov/Projects/material.angular.io/node_modules/comment-parser/tests/unit/spacer-description-joiner.spec.ts is missing from the TypeScript compilation. Please make sure it is in your tsconfig via the 'files' or 'include' property.
```

