### PR TITLE
fix(@angular-devkit/build-angular): account for package.json exports fields with CSS import statements

### DIFF
--- a/package.json
+++ b/package.json
@@ -185,7 +185,6 @@
     "piscina": "3.2.0",
     "popper.js": "^1.14.1",
     "postcss": "8.4.18",
-    "postcss-import": "15.0.0",
     "postcss-loader": "7.0.1",
     "prettier": "^2.0.0",
     "protractor": "~7.0.0",

--- a/packages/angular_devkit/build_angular/BUILD.bazel
+++ b/packages/angular_devkit/build_angular/BUILD.bazel
@@ -162,7 +162,6 @@ ts_library(
         "@npm//parse5-html-rewriting-stream",
         "@npm//piscina",
         "@npm//postcss",
-        "@npm//postcss-import",
         "@npm//postcss-loader",
         "@npm//regenerator-runtime",
         "@npm//resolve-url-loader",

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -48,7 +48,6 @@
     "parse5-html-rewriting-stream": "6.0.1",
     "piscina": "3.2.0",
     "postcss": "8.4.18",
-    "postcss-import": "15.0.0",
     "postcss-loader": "7.0.1",
     "regenerator-runtime": "0.13.9",
     "resolve-url-loader": "5.0.0",

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/styles_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/styles_spec.ts
@@ -174,6 +174,7 @@ describe('Browser Builder styles', () => {
       };
 
       const overrides = {
+        aot: true,
         sourceMap: true,
         styles: [`src/styles.${ext}`],
       };
@@ -301,10 +302,13 @@ describe('Browser Builder styles', () => {
 
     const overrides = { optimization: false };
     const { files } = await browserBuild(architect, host, target, overrides);
-    expect(await files['styles.css']).toContain(tags.stripIndents`
+    const content = await files['styles.css'];
+    expect(content).toContain(tags.stripIndents`
       /* normal-comment */
       /*! important-comment */
-      section { -webkit-mask-composite: source-over; mask-composite: add; }
+      section { -webkit-mask-composite: source-over; mask-composite: add; }`);
+    // Check separately because Webpack may add source file comments inbetween the rules
+    expect(content).toContain(tags.stripIndents`
       /* normal-comment */
       /*! important-comment */
       div { -webkit-mask-composite: source-over; mask-composite: add; }`);

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/vendor-source-map_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/vendor-source-map_spec.ts
@@ -108,6 +108,7 @@ describe('Identifying third-party code in source maps', () => {
       './src/app/app.component.ts',
       './src/app/app.module.ts',
       './src/main.ts',
+      './src/app/app.component.css',
     ]);
 
     // Only some sources in the polyfills map are first-party.

--- a/packages/angular_devkit/build_angular/src/builders/server/tests/options/source-map_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/server/tests/options/source-map_spec.ts
@@ -11,7 +11,8 @@ import { BASE_OPTIONS, SERVER_BUILDER_INFO, describeBuilder } from '../setup';
 
 describeBuilder(execute, SERVER_BUILDER_INFO, (harness) => {
   describe('Option: "sourceMap"', () => {
-    const INLINE_SOURCEMAP_MARKER = '/*# sourceMappingURL=data:application/json;base64,';
+    const INLINE_SOURCEMAP_MARKER =
+      '/*# sourceMappingURL=data:application/json;charset=utf-8;base64,';
 
     beforeEach(async () => {
       await harness.writeFiles({

--- a/packages/ngtools/webpack/src/resource_loader.ts
+++ b/packages/ngtools/webpack/src/resource_loader.ts
@@ -6,9 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import assert from 'assert';
-import * as path from 'path';
-import * as vm from 'vm';
+import assert from 'node:assert';
+import { Buffer } from 'node:buffer';
+import * as path from 'node:path';
+import * as vm from 'node:vm';
 import type { Asset, Compilation } from 'webpack';
 import { addError } from './ivy/diagnostics';
 import { normalizePath } from './ivy/paths';
@@ -317,7 +318,13 @@ export class WebpackResourceLoader {
 
   private _evaluate(filename: string, source: string): string | null {
     // Evaluate code
-    const context: { resource?: string | { default?: string } } = {};
+
+    // css-loader requires the btoa function to exist to correctly generate inline sourcemaps
+    const context: { btoa: (input: string) => string; resource?: string | { default?: string } } = {
+      btoa(input) {
+        return Buffer.from(input).toString('base64');
+      },
+    };
 
     try {
       vm.runInNewContext(source, context, { filename });


### PR DESCRIPTION
The `postcss-imports` package was previously used to support `@import` within CSS files. Unfortunately, the package does not account for `package.json` exports fields. This prevents imports defined within that field from working when used within a build.  The `css-loader` package does provide this functionality and is now used to provide support for CSS `@import` instead of `postcss-imports`. This change does not affect preprocessors that provide their own import behavior.