### PR TITLE
build: remove labels from pull-requests config

### DIFF
--- a/.ng-dev/pull-request.mts
+++ b/.ng-dev/pull-request.mts
@@ -9,7 +9,4 @@ export const pullRequest: PullRequestConfig = {
     default: 'rebase',
     labels: [{ pattern: 'merge: squash commits', method: 'squash' }],
   },
-  mergeReadyLabel: 'action: merge',
-  caretakerNoteLabel: 'action: caretaker note',
-  commitMessageFixupLabel: 'merge: fix commit message',
 };


### PR DESCRIPTION
As part of the labels standardization across repos these options has been removed.
