### PR TITLE
fix(@angular-devkit/core): update logger `forEach` `promiseCtor` type

### DIFF
--- a/goldens/public-api/angular_devkit/core/index.md
+++ b/goldens/public-api/angular_devkit/core/index.md
@@ -459,7 +459,7 @@ class Logger extends Observable<LogEntry> implements LoggerApi {
     // (undocumented)
     fatal(message: string, metadata?: JsonObject): void;
     // (undocumented)
-    forEach(next: (value: LogEntry) => void, promiseCtor?: typeof Promise): Promise<void>;
+    forEach(next: (value: LogEntry) => void, promiseCtor?: PromiseConstructorLike): Promise<void>;
     // (undocumented)
     info(message: string, metadata?: JsonObject): void;
     // (undocumented)

--- a/packages/angular_devkit/core/src/logger/logger.ts
+++ b/packages/angular_devkit/core/src/logger/logger.ts
@@ -162,7 +162,10 @@ export class Logger extends Observable<LogEntry> implements LoggerApi {
     );
   }
 
-  override forEach(next: (value: LogEntry) => void, promiseCtor?: typeof Promise): Promise<void> {
+  override forEach(
+    next: (value: LogEntry) => void,
+    promiseCtor?: PromiseConstructorLike,
+  ): Promise<void> {
     return this._observable.forEach(next, promiseCtor);
   }
 }


### PR DESCRIPTION

`typeof Promise` and `PromiseConstructorLike` are not the same thing. This causes issues in G3 when `strictNullChecks` are being enabled using RXJS 7.

https://github.com/ReactiveX/rxjs/blob/afac3d574323333572987e043adcd0f8d4cff546/src/internal/Observable.ts#L311-L313

FYI @gunan