### PR TITLE
test(@angular/cli): disable analytics gathering during CLI E2E

### DIFF
--- a/tests/legacy-cli/e2e/tests/misc/ask-analytics-command.ts
+++ b/tests/legacy-cli/e2e/tests/misc/ask-analytics-command.ts
@@ -1,9 +1,15 @@
 import { execWithEnv } from '../../utils/process';
+import { updateJsonFile } from '../../utils/project';
 import { mockHome } from '../../utils/utils';
 
 const ANALYTICS_PROMPT = /Would you like to share pseudonymous usage data/;
 
 export default async function () {
+  await updateJsonFile('angular.json', (workspaceJson) => {
+    // Delete analytics config to go back to unset stage.
+    delete workspaceJson.cli.analytics;
+  });
+
   // CLI should prompt for analytics permissions.
   await mockHome(async () => {
     const { stdout } = await execWithEnv(

--- a/tests/legacy-cli/e2e/utils/project.ts
+++ b/tests/legacy-cli/e2e/utils/project.ts
@@ -162,6 +162,10 @@ export function useSha() {
 
 export function useCIDefaults(projectName = 'test-project'): Promise<void> {
   return updateJsonFile('angular.json', (workspaceJson) => {
+    // Disable analytics gathering during CI runs.
+    workspaceJson.cli ??= {};
+    workspaceJson.cli.analytics = false;
+
     // Disable progress reporting on CI to reduce spam.
     const project = workspaceJson.projects[projectName];
     const appTargets = project.targets || project.architect;


### PR DESCRIPTION
Currently, analytics is enabled which causes a lot of noise in our analytics report.