### PR TITLE
fix(@schematics/angular): add `@angular/localize` as type when localize package is installed

### DIFF
--- a/packages/angular_devkit/build_angular/test/hello-world-app/src/tsconfig.app.json
+++ b/packages/angular_devkit/build_angular/test/hello-world-app/src/tsconfig.app.json
@@ -2,7 +2,7 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "outDir": "../out-tsc/app",
-    "types": ["@angular/localize/init"]
+    "types": ["@angular/localize"]
   },
   "files": [
     "main.ts",

--- a/packages/angular_devkit/build_angular/test/hello-world-app/src/tsconfig.server.json
+++ b/packages/angular_devkit/build_angular/test/hello-world-app/src/tsconfig.server.json
@@ -4,7 +4,7 @@
     "outDir": "../dist-server",
     "target": "es2016",
     "baseUrl": "./",
-    "types": ["@angular/localize/init"]
+    "types": ["@angular/localize"]
   },
   "files": [
     "main.server.ts"

--- a/packages/angular_devkit/build_angular/test/hello-world-app/src/tsconfig.spec.json
+++ b/packages/angular_devkit/build_angular/test/hello-world-app/src/tsconfig.spec.json
@@ -4,7 +4,7 @@
     "outDir": "../out-tsc/spec",
     "types": [
       "jasmine",
-      "@angular/localize/init"
+      "@angular/localize"
     ]
   },
   "files": [

--- a/packages/schematics/angular/universal/files/root/tsconfig.server.json.template
+++ b/packages/schematics/angular/universal/files/root/tsconfig.server.json.template
@@ -6,7 +6,7 @@
     "target": "es2019",
     "types": [
       "node"<% if (hasLocalizePackage) { %>,
-      "@angular/localize/init"<% } %>
+      "@angular/localize"<% } %>
     ]
   },
   "files": [

--- a/packages/schematics/angular/universal/index_spec.ts
+++ b/packages/schematics/angular/universal/index_spec.ts
@@ -233,7 +233,7 @@ describe('Universal Schematic', () => {
     const { compilerOptions } = tree.readJson('/projects/bar/tsconfig.server.json') as {
       compilerOptions: CompilerOptions;
     };
-    expect(compilerOptions.types).not.toContain('@angular/localize/init');
+    expect(compilerOptions.types).not.toContain('@angular/localize');
   });
 
   it(`should add import to '@angular/localize' as type in 'tsconfig.server.json' when it's a dependency`, async () => {
@@ -249,6 +249,6 @@ describe('Universal Schematic', () => {
     const { compilerOptions } = tree.readJson('/projects/bar/tsconfig.server.json') as {
       compilerOptions: CompilerOptions;
     };
-    expect(compilerOptions.types).toContain('@angular/localize/init');
+    expect(compilerOptions.types).toContain('@angular/localize');
   });
 });


### PR DESCRIPTION

The `@angular/localize` entrypoint now exposes the global `$localize` method type.

See: https://github.com/angular/angular/pull/47763

