### PR TITLE
fix(@angular-devkit/build-angular): add `@angular/platform-server` as an optional peer dependency

### DIFF
--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -73,6 +73,7 @@
   "peerDependencies": {
     "@angular/compiler-cli": "^15.0.0-next",
     "@angular/localize": "^15.0.0-next",
+    "@angular/platform-server": "^15.0.0-next",
     "@angular/service-worker": "^15.0.0-next",
     "karma": "^6.3.0",
     "ng-packagr": "^15.0.0-next",
@@ -82,6 +83,9 @@
   },
   "peerDependenciesMeta": {
     "@angular/localize": {
+      "optional": true
+    },
+    "@angular/platform-server": {
       "optional": true
     },
     "@angular/service-worker": {


### PR DESCRIPTION

`@angular/platform-server` is now an optional peer dep due to the recent changes in https://github.com/angular/angular-cli/blob/1cd53d6be17d6199b6af74a5a1686b3cb8f52268/packages/angular_devkit/build_angular/src/builders/server/index.ts#L182