### PR TITLE
fix(@angular/cli): do not collect analytics when running in non TTY mode

### DIFF
--- a/packages/angular/cli/src/analytics/analytics.ts
+++ b/packages/angular/cli/src/analytics/analytics.ts
@@ -184,7 +184,7 @@ export async function getAnalyticsUserId(
     }
   }
 
-  return globalConfig || randomUUID();
+  return globalConfig;
 }
 
 function analyticsConfigValueToHumanFormat(value: unknown): 'enabled' | 'disabled' | 'not set' {

--- a/tests/legacy-cli/e2e/tests/commands/analytics/analytics-enable-disable.ts
+++ b/tests/legacy-cli/e2e/tests/commands/analytics/analytics-enable-disable.ts
@@ -1,0 +1,11 @@
+import assert from 'node:assert';
+import { readFile } from '../../../utils/fs';
+import { ng } from '../../../utils/process';
+
+export default async function () {
+  await ng('analytics', 'enable');
+  assert.ok(JSON.parse(await readFile('angular.json')).cli.analytics);
+
+  await ng('analytics', 'disable');
+  assert.strictEqual(JSON.parse(await readFile('angular.json')).cli.analytics, false);
+}

--- a/tests/legacy-cli/e2e/tests/commands/analytics/analytics-info.ts
+++ b/tests/legacy-cli/e2e/tests/commands/analytics/analytics-info.ts
@@ -1,0 +1,27 @@
+import { execAndWaitForOutputToMatch } from '../../../utils/process';
+import { updateJsonFile } from '../../../utils/project';
+
+export default async function () {
+  // Should be disabled by default.
+  await configureTest(undefined /** analytics */);
+  await execAndWaitForOutputToMatch('ng', ['analytics', 'info'], /Effective status: disabled/, {
+    NG_FORCE_TTY: '0', // Disable prompts
+  });
+
+  await configureTest('1dba0835-38a3-4957-bf34-9974e2df0df3' /** analytics */);
+  await execAndWaitForOutputToMatch('ng', ['analytics', 'info'], /Effective status: enabled/, {
+    NG_FORCE_TTY: '0', // Disable prompts
+  });
+
+  await configureTest(false /** analytics */);
+  await execAndWaitForOutputToMatch('ng', ['analytics', 'info'], /Effective status: disabled/, {
+    NG_FORCE_TTY: '0', // Disable prompts
+  });
+}
+
+async function configureTest(analytics: false | string | undefined): Promise<void> {
+  await updateJsonFile('angular.json', (config) => {
+    config.cli ??= {};
+    config.cli.analytics = analytics;
+  });
+}

--- a/tests/legacy-cli/e2e/tests/commands/analytics/ask-analytics-command.ts
+++ b/tests/legacy-cli/e2e/tests/commands/analytics/ask-analytics-command.ts
@@ -1,5 +1,5 @@
-import { execWithEnv } from '../../utils/process';
-import { mockHome } from '../../utils/utils';
+import { execWithEnv } from '../../../utils/process';
+import { mockHome } from '../../../utils/utils';
 
 const ANALYTICS_PROMPT = /Would you like to share pseudonymous usage data/;
 


### PR DESCRIPTION
Prior to this change we collected analytics when config was not present and the CLI was running in non TTY mode.

**Note**: this only effects `15.0.0-next.5` package.