### PR TITLE
docs(@angular/cli): update add long description to analytics command

### DIFF
--- a/packages/angular/cli/src/commands/analytics/cli.ts
+++ b/packages/angular/cli/src/commands/analytics/cli.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import { join } from 'node:path';
 import { Argv } from 'yargs';
 import {
   CommandModule,
@@ -25,9 +26,8 @@ import {
 
 export class AnalyticsCommandModule extends CommandModule implements CommandModuleImplementation {
   command = 'analytics';
-  describe =
-    'Configures the gathering of Angular CLI usage metrics. See https://angular.io/cli/usage-analytics-gathering';
-  longDescriptionPath?: string;
+  describe = 'Configures the gathering of Angular CLI usage metrics.';
+  longDescriptionPath = join(__dirname, 'long-description.md');
 
   builder(localYargs: Argv): Argv {
     const subcommands = [

--- a/packages/angular/cli/src/commands/analytics/long-description.md
+++ b/packages/angular/cli/src/commands/analytics/long-description.md
@@ -1,0 +1,20 @@
+You can help the Angular Team to prioritize features and improvements by permitting the Angular team to send command-line command usage statistics to Google.
+The Angular Team does not collect usage statistics unless you explicitly opt in. When installing the Angular CLI you are prompted to allow global collection of usage statistics.
+If you say no or skip the prompt, no data is collected.
+
+### What is collected?
+
+Usage analytics include the commands and selected flags for each execution.
+Usage analytics may include the following information:
+
+- Your operating system \(macOS, Linux distribution, Windows\) and its version.
+- Package manager name and version \(local version only\).
+- Node.js version \(local version only\).
+- Angular CLI version \(local version only\).
+- Command name that was run.
+- Workspace information, the number of application and library projects.
+- For schematics commands \(add, generate and new\), the schematic collection and name and a list of selected flags.
+- For build commands \(build, serve\), the builder name, the number and size of bundles \(initial and lazy\), compilation units, the time it took to build and rebuild, and basic Angular-specific API usage.
+
+Only Angular owned and developed schematics and builders are reported.
+Third-party schematics and builders do not send data to the Angular Team.

--- a/packages/angular/cli/src/commands/config/long-description.md
+++ b/packages/angular/cli/src/commands/config/long-description.md
@@ -10,4 +10,4 @@ while on the command line options can be given dash-case.
 
 For further details, see [Workspace Configuration](guide/workspace-config).
 
-For configuration of CLI usage analytics, see [Gathering an Viewing CLI Usage Analytics](cli/usage-analytics-gathering).
+For configuration of CLI usage analytics, see [ng analytics](cli/analytics).

--- a/tests/legacy-cli/e2e/tests/commands/help/help-json.ts
+++ b/tests/legacy-cli/e2e/tests/commands/help/help-json.ts
@@ -9,7 +9,7 @@ export default async function () {
       'Retrieves or sets Angular configuration values in the angular.json file for the workspace.',
     'longDescriptionRelativePath': '@angular/cli/src/commands/config/long-description.md',
     'longDescription':
-      'A workspace has a single CLI configuration file, `angular.json`, at the top level.\nThe `projects` object contains a configuration object for each project in the workspace.\n\nYou can edit the configuration directly in a code editor,\nor indirectly on the command line using this command.\n\nThe configurable property names match command option names,\nexcept that in the configuration file, all names must use camelCase,\nwhile on the command line options can be given dash-case.\n\nFor further details, see [Workspace Configuration](guide/workspace-config).\n\nFor configuration of CLI usage analytics, see [Gathering an Viewing CLI Usage Analytics](cli/usage-analytics-gathering).\n',
+      'A workspace has a single CLI configuration file, `angular.json`, at the top level.\nThe `projects` object contains a configuration object for each project in the workspace.\n\nYou can edit the configuration directly in a code editor,\nor indirectly on the command line using this command.\n\nThe configurable property names match command option names,\nexcept that in the configuration file, all names must use camelCase,\nwhile on the command line options can be given dash-case.\n\nFor further details, see [Workspace Configuration](guide/workspace-config).\n\nFor configuration of CLI usage analytics, see [ng analytics](cli/analytics).\n',
     'options': [
       {
         'name': 'global',


### PR DESCRIPTION
With this change we add a long description to analytics command with the information that is currently contain in https://angular.io/analytics which will be deleted at a later stage.

