### PR TITLE
feat(@schematics/angular): add sideEffects:false to library package.json

### DIFF
--- a/packages/schematics/angular/library/files/package.json.template
+++ b/packages/schematics/angular/library/files/package.json.template
@@ -7,5 +7,6 @@
   },
   "dependencies": {
     "tslib": "^<%= tsLibLatestVersion %>"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/schematics/angular/library/index_spec.ts
+++ b/packages/schematics/angular/library/index_spec.ts
@@ -126,6 +126,14 @@ describe('Library Schematic', () => {
     expect(fileContent.peerDependencies['@angular/core']).toBe(`^${angularVersion}`);
   });
 
+  it('should add sideEffects: false flag to package.json named "foo"', async () => {
+    const tree = await schematicRunner
+      .runSchematicAsync('library', defaultOptions, workspaceTree)
+      .toPromise();
+    const fileContent = getFileContent(tree, '/projects/foo/package.json');
+    expect(fileContent).toMatch(/"sideEffects": false/);
+  });
+
   it('should create a README.md named "foo"', async () => {
     const tree = await schematicRunner
       .runSchematicAsync('library', defaultOptions, workspaceTree)


### PR DESCRIPTION
## PR Checklist

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

This PR is related to #24122. It introduces the `sideEffects: false` flag to the `package.json` of libraries generated with `ng generate library`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
