### PR TITLE
fix(@angular/cli): disable version check during auto completion

### DIFF
--- a/packages/angular/cli/lib/init.ts
+++ b/packages/angular/cli/lib/init.ts
@@ -88,7 +88,11 @@ let forceExit = false;
     }
 
     // When using the completion command, don't show the warning as otherwise this will break completion.
-    if (isGlobalGreater && rawCommandName !== 'completion') {
+    if (
+      isGlobalGreater &&
+      rawCommandName !== '--get-yargs-completions' &&
+      rawCommandName !== 'completion'
+    ) {
       // If using the update command and the global version is greater, use the newer update command
       // This allows improvements in update to be used in older versions that do not have bootstrapping
       if (


### PR DESCRIPTION
This causes sub broken DX

```
ng bui[TAB]Your global Angular CLI version (14.2.6) is greater than your local version (14.1.3). The local Angular CLI version is used.

To disable this warning use "ng config -g cli.warnings.versionMismatch false".
ld --conf[TAB]Your global Angular CLI version (14.2.6) is greater than your local version (14.1.3). The local Angular CLI version is used.

To disable this warning use "ng config -g cli.warnings.versionMismatch false".
iguration dev[TAB]Your global Angular CLI version (14.2.6) is greater than your local version (14.1.3). The local Angular CLI version is used.

To disable this warning use "ng config -g cli.warnings.versionMismatch false".
elopment
```

Closes #24133
