### PR TITLE
perf(@angular-devkit/build-angular): avoid template diagnostics for declaration files in esbuild builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/compiler-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/compiler-plugin.ts
@@ -398,6 +398,11 @@ export function createCompilerPlugin(
               true,
             );
 
+            // Declaration files cannot have template diagnostics
+            if (sourceFile.isDeclarationFile) {
+              continue;
+            }
+
             // Only request Angular template diagnostics for affected files to avoid
             // overhead of template diagnostics for unchanged files.
             if (affectedFiles.has(sourceFile)) {


### PR DESCRIPTION
The experimental esbuild-based browser application builder will now avoid trying to query the Angular Compiler for template diagnostics when a TypeScript source file is a declaration file (`.d.ts`). This avoids the overhead of the in-memory diagnostics caching logic as well as any Angular Compiler logic to determine if the file has any template diagnostics.