### PR TITLE
refactor: Make Logger.forEach compatible with both rxjs 6 and 7.

### DIFF
--- a/packages/angular_devkit/core/src/logger/logger.ts
+++ b/packages/angular_devkit/core/src/logger/logger.ts
@@ -164,7 +164,7 @@ export class Logger extends Observable<LogEntry> implements LoggerApi {
 
   override forEach(
     next: (value: LogEntry) => void,
-    promiseCtor?: PromiseConstructorLike,
+    promiseCtor: PromiseConstructorLike = Promise,
   ): Promise<void> {
     return this._observable.forEach(next, promiseCtor);
   }


### PR DESCRIPTION
Some build environments build angular with rxjs 7, and see build failures due to this file.

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the new behavior that. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
