### PR TITLE
fix(@angular/cli): allow ng add to find prerelease versions when CLI is prerelease

### DIFF
--- a/packages/angular/cli/src/commands/add/cli.ts
+++ b/packages/angular/cli/src/commands/add/cli.ts
@@ -34,6 +34,7 @@ import {
 import { askConfirmation } from '../../utilities/prompt';
 import { Spinner } from '../../utilities/spinner';
 import { isTTY } from '../../utilities/tty';
+import { VERSION } from '../../utilities/version';
 
 interface AddCommandArgs extends SchematicsCommandArgs {
   collection: string;
@@ -178,11 +179,15 @@ export class AddCommandModule
         );
       } else if (!latestManifest || (await this.hasMismatchedPeer(latestManifest))) {
         // 'latest' is invalid so search for most recent matching package
+
+        // Allow prelease versions if the CLI itself is a prerelease
+        const allowPrereleases = prerelease(VERSION.full);
+
         const versionExclusions = packageVersionExclusions[packageMetadata.name];
         const versionManifests = Object.values(packageMetadata.versions).filter(
           (value: PackageManifest) => {
             // Prerelease versions are not stable and should not be considered by default
-            if (prerelease(value.version)) {
+            if (!allowPrereleases && prerelease(value.version)) {
               return false;
             }
             // Deprecated versions should not be used or considered
@@ -198,7 +203,8 @@ export class AddCommandModule
           },
         );
 
-        versionManifests.sort((a, b) => compare(a.version, b.version, true));
+        // Sort in reverse SemVer order so that the newest compatible version is chosen
+        versionManifests.sort((a, b) => compare(b.version, a.version, true));
 
         let newIdentifier;
         for (const versionManifest of versionManifests) {

--- a/packages/angular/cli/src/commands/add/cli.ts
+++ b/packages/angular/cli/src/commands/add/cli.ts
@@ -50,6 +50,8 @@ interface AddCommandArgs extends SchematicsCommandArgs {
 const packageVersionExclusions: Record<string, string | undefined> = {
   // @angular/localize@9.x versions do not have peer dependencies setup
   '@angular/localize': '9.x',
+  // @angular/material@7.x versions have unbounded peer dependency ranges (>=7.0.0)
+  '@angular/material': '7.x',
 };
 
 export class AddCommandModule


### PR DESCRIPTION
When the CLI is a prerelease version, the `ng add` command will now consider the
use of prerelease versions of requested packages. Without this behavior, attempting
to install a package without a version specifier (e.g., `ng add @angular/material`)
will install an older stable version of the requested package instead of the expected
prerelease version compatible with the prerelease Angular project.