### PR TITLE
fix(@angular-devkit/build-angular): ignore cache path when watching with esbuild builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
@@ -446,8 +446,8 @@ export async function* buildEsbuildBrowser(
   const watcher = createWatcher({
     polling: typeof initialOptions.poll === 'number',
     interval: initialOptions.poll,
-    // Ignore the output path to avoid infinite rebuild cycles
-    ignored: [normalizedOptions.outputPath],
+    // Ignore the output and cache paths to avoid infinite rebuild cycles
+    ignored: [normalizedOptions.outputPath, normalizedOptions.cacheOptions.basePath],
   });
 
   // Temporarily watch the entire project

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/options.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/options.ts
@@ -9,6 +9,7 @@
 import { BuilderContext } from '@angular-devkit/architect';
 import * as path from 'path';
 import { normalizeAssetPatterns, normalizeOptimization, normalizeSourceMaps } from '../../utils';
+import { normalizeCacheOptions } from '../../utils/normalize-cache';
 import { normalizePolyfills } from '../../utils/normalize-polyfills';
 import { generateEntryPoints } from '../../utils/package-chunk-sort';
 import { getIndexInputFile, getIndexOutputFile } from '../../utils/webpack-browser-config';
@@ -39,7 +40,9 @@ export async function normalizeOptions(
     workspaceRoot,
     (projectMetadata.sourceRoot as string | undefined) ?? 'src',
   );
-  // Normalize options
+
+  const cacheOptions = normalizeCacheOptions(projectMetadata, workspaceRoot);
+
   const mainEntryPoint = path.join(workspaceRoot, options.main);
 
   // Currently esbuild do not support multiple files per entry-point
@@ -145,6 +148,7 @@ export async function normalizeOptions(
   return {
     advancedOptimizations: buildOptimizer,
     baseHref,
+    cacheOptions,
     crossOrigin,
     externalDependencies,
     poll,


### PR DESCRIPTION
When using the experimental esbuild-based browser application builder in watch mode, the base cache path defined within the `angular.json` file will now be ignored when detecting file changes. While the builder currently does not persist cache to disk, it may in the future and other builders may currently be run in parallel.