### PR TITLE
fix(@schematics/angular): remove TypeScript target from universal schematic

### DIFF
--- a/packages/schematics/angular/universal/files/root/tsconfig.server.json.template
+++ b/packages/schematics/angular/universal/files/root/tsconfig.server.json.template
@@ -3,7 +3,6 @@
   "extends": "./<%= tsConfigExtends %>",
   "compilerOptions": {
     "outDir": "<%= relativePathToWorkspaceRoot %>/out-tsc/server",
-    "target": "es2019",
     "types": [
       "node"<% if (hasLocalizePackage) { %>,
       "@angular/localize"<% } %>

--- a/packages/schematics/angular/universal/index_spec.ts
+++ b/packages/schematics/angular/universal/index_spec.ts
@@ -94,7 +94,6 @@ describe('Universal Schematic', () => {
       extends: './tsconfig.app.json',
       compilerOptions: {
         outDir: './out-tsc/server',
-        target: 'es2019',
         types: ['node'],
       },
       files: ['src/main.server.ts'],
@@ -116,7 +115,6 @@ describe('Universal Schematic', () => {
       extends: './tsconfig.app.json',
       compilerOptions: {
         outDir: '../../out-tsc/server',
-        target: 'es2019',
         types: ['node'],
       },
       files: ['src/main.server.ts'],


### PR DESCRIPTION


This is no longer needed due to the recent changes in the CLI which always use ES2022.
