### PR TITLE
fix(@angular/cli): exclude `@angular/localize@<10.0.0` from ng add pa…

### DIFF
--- a/packages/angular/cli/src/commands/add/cli.ts
+++ b/packages/angular/cli/src/commands/add/cli.ts
@@ -49,7 +49,7 @@ interface AddCommandArgs extends SchematicsCommandArgs {
  * The key is a package name and the value is a SemVer range of versions to exclude.
  */
 const packageVersionExclusions: Record<string, string | Range> = {
-  // @angular/localize@9.x and earlier versions of @angular/localize@10.x prereleases do not have peer dependencies setup.
+  // @angular/localize@9.x and earlier versions as well as @angular/localize@10.0 prereleases do not have peer dependencies setup.
   '@angular/localize': '<10.0.0',
   // @angular/material@7.x versions have unbounded peer dependency ranges (>=7.0.0).
   '@angular/material': '7.x',

--- a/packages/angular/cli/src/commands/add/cli.ts
+++ b/packages/angular/cli/src/commands/add/cli.ts
@@ -11,7 +11,7 @@ import { NodePackageDoesNotSupportSchematics } from '@angular-devkit/schematics/
 import { createRequire } from 'module';
 import npa from 'npm-package-arg';
 import { dirname, join } from 'path';
-import { compare, intersects, prerelease, satisfies, valid } from 'semver';
+import { Range, compare, intersects, prerelease, satisfies, valid } from 'semver';
 import { Argv } from 'yargs';
 import { PackageManager } from '../../../lib/config/workspace-schema';
 import {
@@ -48,10 +48,10 @@ interface AddCommandArgs extends SchematicsCommandArgs {
  * when attempting to find a compatible version for a package.
  * The key is a package name and the value is a SemVer range of versions to exclude.
  */
-const packageVersionExclusions: Record<string, string | undefined> = {
-  // @angular/localize@9.x versions do not have peer dependencies setup
-  '@angular/localize': '9.x',
-  // @angular/material@7.x versions have unbounded peer dependency ranges (>=7.0.0)
+const packageVersionExclusions: Record<string, string | Range> = {
+  // @angular/localize@9.x and earlier versions of @angular/localize@10.x prereleases do not have peer dependencies setup.
+  '@angular/localize': '<10.0.0',
+  // @angular/material@7.x versions have unbounded peer dependency ranges (>=7.0.0).
   '@angular/material': '7.x',
 };
 
@@ -195,7 +195,10 @@ export class AddCommandModule
               return false;
             }
             // Excluded package versions should not be considered
-            if (versionExclusions && satisfies(value.version, versionExclusions)) {
+            if (
+              versionExclusions &&
+              satisfies(value.version, versionExclusions, { includePrerelease: true })
+            ) {
               return false;
             }
 


### PR DESCRIPTION
…ckage discovery

`@angular/localize@<10.0.0` has no peer dependencies. This can cause `ng add` to pick these versions of the package if the newer versions.

See: https://app.circleci.com/pipelines/github/angular/angular-cli/27402/workflows/faa64532-541a-4bea-b599-3c53afe42019/jobs/364822
```
Test Process error Error: Process exit error - "ng add @angular/localize --skip-confirmation": 1...

STDOUT:

STDERR:
npm version 7.4.0 detected. When using npm 7 with the Angular CLI, npm version 7.5.6 or higher is recommended.
- Determining package manager...
ℹ Using package manager: npm
- Searching for compatible package version...
✔ Found compatible package version: @angular/localize@10.0.0-next.7.
- Loading package information from registry...
✔ Package information loaded.
- Installing packages...
✔ Packages successfully installed.
NOT SUPPORTED: keyword "id", use "$id" for schema ID
```