### PR TITLE
fix(@angular-devkit/build-angular): correct escaping of target warning text in esbuild builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/compiler-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/compiler-plugin.ts
@@ -235,8 +235,9 @@ export function createCompilerPlugin(
           location: { file: pluginOptions.tsconfig },
           notes: [
             {
-              text: `To control ECMA version and features use the Browerslist configuration. ' +
-              'For more information, see https://angular.io/guide/build#configuring-browser-compatibility'`,
+              text:
+                'To control ECMA version and features use the Browerslist configuration. ' +
+                'For more information, see https://angular.io/guide/build#configuring-browser-compatibility',
             },
           ],
         });


### PR DESCRIPTION
The warning text note for the TypeScript target was incorrectly escaped within a template literal which resulted in a badly formatted error message.