### PR TITLE
perf(@angular-devkit/build-angular): use Sass worker pool for Sass support in esbuild builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
@@ -23,6 +23,7 @@ import { SourceFileCache, createCompilerPlugin } from './compiler-plugin';
 import { bundle, logMessages } from './esbuild';
 import { logExperimentalWarnings } from './experimental-warnings';
 import { NormalizedBrowserOptions, normalizeOptions } from './options';
+import { shutdownSassWorkerPool } from './sass-plugin';
 import { Schema as BrowserBuilderOptions } from './schema';
 import { bundleStylesheetText } from './stylesheets';
 import { ChangedFiles, createWatcher } from './watcher';
@@ -437,6 +438,8 @@ export async function* buildEsbuildBrowser(
 
   // Finish if watch mode is not enabled
   if (!initialOptions.watch) {
+    shutdownSassWorkerPool();
+
     return;
   }
 
@@ -476,6 +479,7 @@ export async function* buildEsbuildBrowser(
     await watcher.close();
     // Cleanup incremental rebuild state
     result.dispose();
+    shutdownSassWorkerPool();
   }
 }
 


### PR DESCRIPTION
When using the experimental esbuild-based browser application builder, Sass stylesheets will now be processed using a worker pool that is currently also used by the default Webpack-based builder. This allows up to four stylesheets to be processed in parallel and keeps the main thread available for other build tasks. On projects with a large amount of Sass stylesheets, this change provided up to a 25% improvement in build times based on initial testing.