### PR TITLE
fix(@angular-devkit/build-angular): account for package.json exports with Sass in esbuild builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/stylesheets.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/stylesheets.ts
@@ -27,10 +27,6 @@ async function bundleStylesheet(
   entry: Required<Pick<BuildOptions, 'stdin'> | Pick<BuildOptions, 'entryPoints'>>,
   options: BundleStylesheetOptions,
 ) {
-  const loadPaths = options.includePaths ?? [];
-  // Needed to resolve node packages.
-  loadPaths.push(path.join(options.workspaceRoot, 'node_modules'));
-
   // Execute esbuild
   const result = await bundle({
     ...entry,
@@ -50,7 +46,7 @@ async function bundleStylesheet(
     conditions: ['style', 'sass'],
     mainFields: ['style', 'sass'],
     plugins: [
-      createSassPlugin({ sourcemap: !!options.sourcemap, loadPaths }),
+      createSassPlugin({ sourcemap: !!options.sourcemap, loadPaths: options.includePaths }),
       createCssResourcePlugin(),
     ],
   });


### PR DESCRIPTION
When using the experimental esbuild-based browser application builder, Sass module imports will now resolve using esbuild's resolve methods. This allows for package.json exports and main fields to be recognized when resolving an import or use rules in Sass files (scss or sass file extensions).