### PR TITLE
fix(@angular-devkit/build-angular): only add `@angular/platform-server/init` when package is installed.

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/server/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/server/index.ts
@@ -24,6 +24,7 @@ import {
   generateI18nBrowserWebpackConfigFromContext,
 } from '../../utils/webpack-browser-config';
 import { getCommonConfig, getStylesConfig } from '../../webpack/configs';
+import { isPlatformServerInstalled } from '../../webpack/utils/helpers';
 import { webpackStatsLogger } from '../../webpack/utils/stats';
 import { Schema as ServerBuilderOptions } from './schema';
 
@@ -175,23 +176,21 @@ async function initialize(
 function getPlatformServerExportsConfig(wco: BrowserWebpackConfigOptions): Partial<Configuration> {
   // Add `@angular/platform-server` exports.
   // This is needed so that DI tokens can be referenced and set at runtime outside of the bundle.
-  try {
-    // Only add `@angular/platform-server` exports when it is installed.
-    // In some cases this builder is used when `@angular/platform-server` is not installed.
-    // Example: when using `@nguniversal/common/clover` which does not need `@angular/platform-server`.
-    require.resolve('@angular/platform-server', { paths: [wco.root] });
-  } catch {
-    return {};
-  }
 
-  return {
-    module: {
-      rules: [
-        {
-          loader: require.resolve('./platform-server-exports-loader'),
-          include: [path.resolve(wco.root, wco.buildOptions.main)],
+  // Only add `@angular/platform-server` exports when it is installed.
+  // In some cases this builder is used when `@angular/platform-server` is not installed.
+  // Example: when using `@nguniversal/common/clover` which does not need `@angular/platform-server`.
+
+  return isPlatformServerInstalled(wco.root)
+    ? {
+        module: {
+          rules: [
+            {
+              loader: require.resolve('./platform-server-exports-loader'),
+              include: [path.resolve(wco.root, wco.buildOptions.main)],
+            },
+          ],
         },
-      ],
-    },
-  };
+      }
+    : {};
 }

--- a/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
@@ -42,6 +42,7 @@ import {
   getOutputHashFormat,
   getStatsOptions,
   globalScriptsByBundleName,
+  isPlatformServerInstalled,
 } from '../utils/helpers';
 
 const VENDORS_TEST = /[\\/]node_modules[\\/]/;
@@ -118,7 +119,7 @@ export async function getCommonConfig(wco: WebpackConfigOptions): Promise<Config
     // Fixes Critical dependency: the request of a dependency is an expression
     extraPlugins.push(new ContextReplacementPlugin(/@?hapi|express[\\/]/));
 
-    if (Array.isArray(entryPoints['main'])) {
+    if (isPlatformServerInstalled(wco.root) && Array.isArray(entryPoints['main'])) {
       // This import must come before any imports (direct or transitive) that rely on DOM built-ins being
       // available, such as `@angular/elements`.
       entryPoints['main'].unshift('@angular/platform-server/init');

--- a/packages/angular_devkit/build_angular/src/webpack/utils/helpers.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/utils/helpers.ts
@@ -8,7 +8,6 @@
 
 import type { ObjectPattern } from 'copy-webpack-plugin';
 import { createHash } from 'crypto';
-import { existsSync } from 'fs';
 import glob from 'glob';
 import * as path from 'path';
 import type { Configuration, WebpackOptionsNormalized } from 'webpack';
@@ -305,4 +304,18 @@ export function getStatsOptions(verbose = false): WebpackStatsOptions {
   return verbose
     ? { ...webpackOutputOptions, ...verboseWebpackOutputOptions }
     : webpackOutputOptions;
+}
+
+/**
+ * @param root the workspace root
+ * @returns `true` when `@angular/platform-server` is installed.
+ */
+export function isPlatformServerInstalled(root: string): boolean {
+  try {
+    require.resolve('@angular/platform-server', { paths: [root] });
+
+    return true;
+  } catch {
+    return false;
+  }
 }


### PR DESCRIPTION

This commit fixes an issue where `@angular/platform-server/init` was added as an entry-point during the server build even when this was not installed.

Closes #24188
