### PR TITLE
fix(@angular-devkit/build-angular): update sourcemaps when rebasing Sass url() functions in esbuild builder

### DIFF
--- a/packages/angular_devkit/build_angular/BUILD.bazel
+++ b/packages/angular_devkit/build_angular/BUILD.bazel
@@ -154,6 +154,7 @@ ts_library(
         "@npm//less-loader",
         "@npm//license-webpack-plugin",
         "@npm//loader-utils",
+        "@npm//magic-string",
         "@npm//mini-css-extract-plugin",
         "@npm//minimatch",
         "@npm//ng-packagr",

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -41,6 +41,7 @@
     "less-loader": "11.1.0",
     "license-webpack-plugin": "4.0.2",
     "loader-utils": "3.2.0",
+    "magic-string": "0.26.7",
     "mini-css-extract-plugin": "2.6.1",
     "minimatch": "5.1.0",
     "open": "8.4.0",

--- a/packages/angular_devkit/build_angular/src/sass/sass-service.ts
+++ b/packages/angular_devkit/build_angular/src/sass/sass-service.ts
@@ -145,7 +145,7 @@ export class SassWorkerImplementation {
 
       const callback: RenderCallback = (error, result) => {
         if (error) {
-          const url = error?.span.url as string | undefined;
+          const url = error.span?.url as string | undefined;
           if (url) {
             error.span.url = pathToFileURL(url);
           }


### PR DESCRIPTION
When using the experimental esbuild-based browser application builder with Sass and sourcemaps, the final sourcemap for an input Sass stylesheet will now contain the original content for any `url` functions that were rebased to support bundling. This required generating internal intermediate source maps for each imported stylesheet that was modified with rebased URLs and then merging these intermediate source maps with the final Sass generated source map. This process only occurs when stylesheet sourcemaps are enabled.