### PR TITLE
fix(@angular-devkit/architect): default to failure if no builder result is provided

### DIFF
--- a/packages/angular_devkit/architect/src/create-builder.ts
+++ b/packages/angular_devkit/architect/src/create-builder.ts
@@ -8,7 +8,7 @@
 
 import { json, logging } from '@angular-devkit/core';
 import { Observable, Subscription, from, isObservable, of, throwError } from 'rxjs';
-import { mergeMap, tap } from 'rxjs/operators';
+import { defaultIfEmpty, mergeMap, tap } from 'rxjs/operators';
 import {
   BuilderContext,
   BuilderHandlerFn,
@@ -218,6 +218,7 @@ export function createBuilder<OptT = json.JsonObject, OutT extends BuilderOutput
         subscriptions.push(
           result
             .pipe(
+              defaultIfEmpty({ success: false } as unknown),
               tap(() => {
                 progress({ state: BuilderProgressState.Running, current: total }, context);
                 progress({ state: BuilderProgressState.Stopped }, context);


### PR DESCRIPTION
Currently, if an architect builder does not provide any results, the CLI will crash trying to access an error message property on the result. Instead architect will now provide a default failure result `{ success: false }` in the event that the builder exits prior to generating a result. Thrown errors continue to be propagated as before.