### PR TITLE
Revert "refactor: Make Logger.forEach compatible with both rxjs 6 and 7."

### DIFF
--- a/packages/angular_devkit/core/src/logger/logger.ts
+++ b/packages/angular_devkit/core/src/logger/logger.ts
@@ -164,7 +164,7 @@ export class Logger extends Observable<LogEntry> implements LoggerApi {
 
   override forEach(
     next: (value: LogEntry) => void,
-    promiseCtor: PromiseConstructorLike = Promise,
+    promiseCtor?: PromiseConstructorLike,
   ): Promise<void> {
     return this._observable.forEach(next, promiseCtor);
   }


### PR DESCRIPTION
Reverts angular/angular-cli#24136

No longer required as `noImplicitAny` has been enabled in G3.

//cc @gunan 