### PR TITLE
fix(@angular-devkit/build-angular): avoid attempted resolve of external CSS URLs with esbuild builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/css-resource-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/css-resource-plugin.ts
@@ -34,6 +34,15 @@ export function createCssResourcePlugin(): Plugin {
           return null;
         }
 
+        // If root-relative, absolute or protocol relative url, mark as external to leave the
+        // path/URL in place.
+        if (/^((?:\w+:)?\/\/|data:|chrome:|#|\/)/.test(args.path)) {
+          return {
+            path: args.path,
+            external: true,
+          };
+        }
+
         const { importer, kind, resolveDir, namespace, pluginData = {} } = args;
         pluginData[CSS_RESOURCE_RESOLUTION] = true;
 


### PR DESCRIPTION
When using the experimental esbuild-based browser application builder, `url()` functions within stylesheets will no longer cause a build failure due to an attempted local file resolution of URLs that do not represent on-disk resources. This includes absolute, protocol-relative, and root-relative URLs as well as SVG path identifiers.