### PR TITLE
fix(@angular/cli): respect registry in RC when running update through yarn

### DIFF
--- a/packages/angular/cli/src/utilities/package-metadata.ts
+++ b/packages/angular/cli/src/utilities/package-metadata.ts
@@ -139,6 +139,18 @@ function readOptions(
       continue;
     }
 
+    if (
+      normalizedName === 'registry' &&
+      rcOptions['registry'] &&
+      value === 'https://registry.yarnpkg.com' &&
+      process.env['npm_config_user_agent']?.includes('yarn')
+    ) {
+      // When running `ng update` using yarn (`yarn ng update`), yarn will set the `npm_config_registry` env variable to `https://registry.yarnpkg.com`
+      // even when an RC file is present with a different repository.
+      // This causes the registry specified in the RC to always be overridden with the below logic.
+      continue;
+    }
+
     normalizedName = normalizedName.replace(/(?!^)_/g, '-'); // don't replace _ at the start of the key.s
     envVariablesOptions[normalizedName] = value;
   }


### PR DESCRIPTION


This commit fixes an issue where when `ng update` was ran using `yarn` (`yarn ng update`) the registry was always being overridden to `https://registry.yarnpkg.com`.

This is because yarn will set the `npm_config_registry` env variable to `https://registry.yarnpkg.com` even when an RC file is present with a different repository.

reported by @JoostK and @SanderElias over slack.