### PR TITLE
feat(@schematics/angular): add `guardType` as an alias of `implements` in guard schematic

### DIFF
--- a/packages/schematics/angular/guard/schema.json
+++ b/packages/schematics/angular/guard/schema.json
@@ -47,6 +47,7 @@
       "default": false
     },
     "implements": {
+      "alias": "guardType",
       "type": "array",
       "description": "Specifies which type of guard to create.",
       "uniqueItems": true,


### PR DESCRIPTION

`implements` option will be removed in future in favor of `guardType`. This is because the implements guard pattern is deprecated in version 15.1
