### PR TITLE
feat(@angular-devkit/build-angular): add `assets` option to server builder

### DIFF
--- a/goldens/public-api/angular_devkit/build_angular/index.md
+++ b/goldens/public-api/angular_devkit/build_angular/index.md
@@ -246,6 +246,7 @@ export interface ProtractorBuilderOptions {
 
 // @public (undocumented)
 export interface ServerBuilderOptions {
+    assets?: AssetPattern_3[];
     deleteOutputPath?: boolean;
     // @deprecated
     deployUrl?: string;

--- a/packages/angular_devkit/build_angular/src/builders/browser/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/index.ts
@@ -111,20 +111,6 @@ async function initialize(
       getStylesConfig(wco),
     ]);
 
-  // Validate asset option values if processed directly
-  if (options.assets?.length && !adjustedOptions.assets?.length) {
-    normalizeAssetPatterns(
-      options.assets,
-      context.workspaceRoot,
-      projectRoot,
-      projectSourceRoot,
-    ).forEach(({ output }) => {
-      if (output.startsWith('..')) {
-        throw new Error('An asset cannot be written to a location outside of the output path.');
-      }
-    });
-  }
-
   let transformedConfig;
   if (webpackConfigurationTransform) {
     transformedConfig = await webpackConfigurationTransform(config);

--- a/packages/angular_devkit/build_angular/src/builders/server/schema.json
+++ b/packages/angular_devkit/build_angular/src/builders/server/schema.json
@@ -4,6 +4,14 @@
   "title": "Universal Target",
   "type": "object",
   "properties": {
+    "assets": {
+      "type": "array",
+      "description": "List of static application assets.",
+      "default": [],
+      "items": {
+        "$ref": "#/definitions/assetPattern"
+      }
+    },
     "main": {
       "type": "string",
       "description": "The name of the main entry-point file."
@@ -207,6 +215,44 @@
   "additionalProperties": false,
   "required": ["outputPath", "main", "tsConfig"],
   "definitions": {
+    "assetPattern": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "followSymlinks": {
+              "type": "boolean",
+              "default": false,
+              "description": "Allow glob patterns to follow symlink directories. This allows subdirectories of the symlink to be searched."
+            },
+            "glob": {
+              "type": "string",
+              "description": "The pattern to match."
+            },
+            "input": {
+              "type": "string",
+              "description": "The input directory path in which to apply 'glob'. Defaults to the project root."
+            },
+            "ignore": {
+              "description": "An array of globs to ignore.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "output": {
+              "type": "string",
+              "description": "Absolute path within the output."
+            }
+          },
+          "additionalProperties": false,
+          "required": ["glob", "input", "output"]
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
     "fileReplacement": {
       "oneOf": [
         {

--- a/packages/angular_devkit/build_angular/src/builders/server/tests/options/assets_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/server/tests/options/assets_spec.ts
@@ -6,25 +6,25 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { buildWebpackBrowser } from '../../index';
-import { BASE_OPTIONS, BROWSER_BUILDER_INFO, describeBuilder } from '../setup';
+import { execute } from '../../index';
+import { BASE_OPTIONS, SERVER_BUILDER_INFO, describeBuilder } from '../setup';
 
-describeBuilder(buildWebpackBrowser, BROWSER_BUILDER_INFO, (harness) => {
+describeBuilder(execute, SERVER_BUILDER_INFO, (harness) => {
   describe('Option: "assets"', () => {
     beforeEach(async () => {
       // Application code is not needed for asset tests
-      await harness.writeFile('src/main.ts', '');
+      await harness.writeFile('src/main.server.ts', '');
     });
 
     it('supports an empty array value', async () => {
-      harness.useTarget('build', {
+      harness.useTarget('server', {
         ...BASE_OPTIONS,
         assets: [],
       });
 
       const { result } = await harness.executeOnce();
 
-      expect(result?.success).toBe(true);
+      expect(result?.success).toBeTrue();
     });
 
     it('supports mixing shorthand and longhand syntax', async () => {
@@ -32,14 +32,14 @@ describeBuilder(buildWebpackBrowser, BROWSER_BUILDER_INFO, (harness) => {
       await harness.writeFile('src/files/another.file', 'asset file');
       await harness.writeFile('src/extra.file', 'extra file');
 
-      harness.useTarget('build', {
+      harness.useTarget('server', {
         ...BASE_OPTIONS,
         assets: ['src/extra.file', { glob: '*', input: 'src/files', output: '.' }],
       });
 
       const { result } = await harness.executeOnce();
 
-      expect(result?.success).toBe(true);
+      expect(result?.success).toBeTrue();
 
       harness.expectFile('dist/extra.file').content.toBe('extra file');
       harness.expectFile('dist/test.svg').content.toBe('<svg></svg>');
@@ -50,14 +50,14 @@ describeBuilder(buildWebpackBrowser, BROWSER_BUILDER_INFO, (harness) => {
       it('copies a single asset', async () => {
         await harness.writeFile('src/test.svg', '<svg></svg>');
 
-        harness.useTarget('build', {
+        harness.useTarget('server', {
           ...BASE_OPTIONS,
           assets: ['src/test.svg'],
         });
 
         const { result } = await harness.executeOnce();
 
-        expect(result?.success).toBe(true);
+        expect(result?.success).toBeTrue();
 
         harness.expectFile('dist/test.svg').content.toBe('<svg></svg>');
       });
@@ -66,14 +66,14 @@ describeBuilder(buildWebpackBrowser, BROWSER_BUILDER_INFO, (harness) => {
         await harness.writeFile('src/test.svg', '<svg></svg>');
         await harness.writeFile('src/another.file', 'asset file');
 
-        harness.useTarget('build', {
+        harness.useTarget('server', {
           ...BASE_OPTIONS,
           assets: ['src/test.svg', 'src/another.file'],
         });
 
         const { result } = await harness.executeOnce();
 
-        expect(result?.success).toBe(true);
+        expect(result?.success).toBeTrue();
 
         harness.expectFile('dist/test.svg').content.toBe('<svg></svg>');
         harness.expectFile('dist/another.file').content.toBe('asset file');
@@ -82,42 +82,44 @@ describeBuilder(buildWebpackBrowser, BROWSER_BUILDER_INFO, (harness) => {
       it('copies an asset with directory and maintains directory in output', async () => {
         await harness.writeFile('src/subdirectory/test.svg', '<svg></svg>');
 
-        harness.useTarget('build', {
+        harness.useTarget('server', {
           ...BASE_OPTIONS,
           assets: ['src/subdirectory/test.svg'],
         });
 
         const { result } = await harness.executeOnce();
 
-        expect(result?.success).toBe(true);
+        expect(result?.success).toBeTrue();
 
         harness.expectFile('dist/subdirectory/test.svg').content.toBe('<svg></svg>');
       });
 
       it('does not fail if asset does not exist', async () => {
-        harness.useTarget('build', {
+        harness.useTarget('server', {
           ...BASE_OPTIONS,
           assets: ['src/test.svg'],
         });
 
         const { result } = await harness.executeOnce();
 
-        expect(result?.success).toBe(true);
+        expect(result?.success).toBeTrue();
 
         harness.expectFile('dist/test.svg').toNotExist();
       });
 
-      it('fail if asset path is not within project source root', async () => {
+      it('fails if output option is not within project output path', async () => {
         await harness.writeFile('test.svg', '<svg></svg>');
 
-        harness.useTarget('build', {
+        harness.useTarget('server', {
           ...BASE_OPTIONS,
-          assets: ['test.svg'],
+          assets: [{ glob: 'test.svg', input: 'src', output: '..' }],
         });
 
         const { result } = await harness.executeOnce();
 
-        expect(result?.error).toMatch('path must start with the project source root');
+        expect(result?.error).toMatch(
+          'An asset cannot be written to a location outside of the output path',
+        );
 
         harness.expectFile('dist/test.svg').toNotExist();
       });
@@ -127,14 +129,14 @@ describeBuilder(buildWebpackBrowser, BROWSER_BUILDER_INFO, (harness) => {
       it('copies a single asset', async () => {
         await harness.writeFile('src/test.svg', '<svg></svg>');
 
-        harness.useTarget('build', {
+        harness.useTarget('server', {
           ...BASE_OPTIONS,
           assets: [{ glob: 'test.svg', input: 'src', output: '.' }],
         });
 
         const { result } = await harness.executeOnce();
 
-        expect(result?.success).toBe(true);
+        expect(result?.success).toBeTrue();
 
         harness.expectFile('dist/test.svg').content.toBe('<svg></svg>');
       });
@@ -143,7 +145,7 @@ describeBuilder(buildWebpackBrowser, BROWSER_BUILDER_INFO, (harness) => {
         await harness.writeFile('src/test.svg', '<svg></svg>');
         await harness.writeFile('src/another.file', 'asset file');
 
-        harness.useTarget('build', {
+        harness.useTarget('server', {
           ...BASE_OPTIONS,
           assets: [
             { glob: 'test.svg', input: 'src', output: '.' },
@@ -153,7 +155,7 @@ describeBuilder(buildWebpackBrowser, BROWSER_BUILDER_INFO, (harness) => {
 
         const { result } = await harness.executeOnce();
 
-        expect(result?.success).toBe(true);
+        expect(result?.success).toBeTrue();
 
         harness.expectFile('dist/test.svg').content.toBe('<svg></svg>');
         harness.expectFile('dist/another.file').content.toBe('asset file');
@@ -163,14 +165,14 @@ describeBuilder(buildWebpackBrowser, BROWSER_BUILDER_INFO, (harness) => {
         await harness.writeFile('src/test.svg', '<svg></svg>');
         await harness.writeFile('src/another.file', 'asset file');
 
-        harness.useTarget('build', {
+        harness.useTarget('server', {
           ...BASE_OPTIONS,
           assets: [{ glob: '{test.svg,another.file}', input: 'src', output: '.' }],
         });
 
         const { result } = await harness.executeOnce();
 
-        expect(result?.success).toBe(true);
+        expect(result?.success).toBeTrue();
 
         harness.expectFile('dist/test.svg').content.toBe('<svg></svg>');
         harness.expectFile('dist/another.file').content.toBe('asset file');
@@ -180,14 +182,14 @@ describeBuilder(buildWebpackBrowser, BROWSER_BUILDER_INFO, (harness) => {
         await harness.writeFile('src/files/test.svg', '<svg></svg>');
         await harness.writeFile('src/files/another.file', 'asset file');
 
-        harness.useTarget('build', {
+        harness.useTarget('server', {
           ...BASE_OPTIONS,
           assets: [{ glob: '*', input: 'src/files', output: '.' }],
         });
 
         const { result } = await harness.executeOnce();
 
-        expect(result?.success).toBe(true);
+        expect(result?.success).toBeTrue();
 
         harness.expectFile('dist/test.svg').content.toBe('<svg></svg>');
         harness.expectFile('dist/another.file').content.toBe('asset file');
@@ -200,14 +202,14 @@ describeBuilder(buildWebpackBrowser, BROWSER_BUILDER_INFO, (harness) => {
           'src/files/nested/extra.file': 'extra file',
         });
 
-        harness.useTarget('build', {
+        harness.useTarget('server', {
           ...BASE_OPTIONS,
           assets: [{ glob: '**/*', input: 'src/files', output: '.' }],
         });
 
         const { result } = await harness.executeOnce();
 
-        expect(result?.success).toBe(true);
+        expect(result?.success).toBeTrue();
 
         harness.expectFile('dist/test.svg').content.toBe('<svg></svg>');
         harness.expectFile('dist/another.file').content.toBe('asset file');
@@ -217,14 +219,14 @@ describeBuilder(buildWebpackBrowser, BROWSER_BUILDER_INFO, (harness) => {
       it('automatically ignores "." prefixed files when using wildcard glob pattern', async () => {
         await harness.writeFile('src/files/.gitkeep', '');
 
-        harness.useTarget('build', {
+        harness.useTarget('server', {
           ...BASE_OPTIONS,
           assets: [{ glob: '*', input: 'src/files', output: '.' }],
         });
 
         const { result } = await harness.executeOnce();
 
-        expect(result?.success).toBe(true);
+        expect(result?.success).toBeTrue();
 
         harness.expectFile('dist/.gitkeep').toNotExist();
       });
@@ -236,14 +238,14 @@ describeBuilder(buildWebpackBrowser, BROWSER_BUILDER_INFO, (harness) => {
           'src/files/nested/extra.file': 'extra file',
         });
 
-        harness.useTarget('build', {
+        harness.useTarget('server', {
           ...BASE_OPTIONS,
           assets: [{ glob: '**/*', input: 'src/files', output: '.', ignore: ['another.file'] }],
         });
 
         const { result } = await harness.executeOnce();
 
-        expect(result?.success).toBe(true);
+        expect(result?.success).toBeTrue();
 
         harness.expectFile('dist/test.svg').content.toBe('<svg></svg>');
         harness.expectFile('dist/another.file').toNotExist();
@@ -257,14 +259,14 @@ describeBuilder(buildWebpackBrowser, BROWSER_BUILDER_INFO, (harness) => {
           'src/files/nested/extra.file': 'extra file',
         });
 
-        harness.useTarget('build', {
+        harness.useTarget('server', {
           ...BASE_OPTIONS,
           assets: [{ glob: '**/*', input: 'src/files', output: '.', ignore: ['**/*.file'] }],
         });
 
         const { result } = await harness.executeOnce();
 
-        expect(result?.success).toBe(true);
+        expect(result?.success).toBeTrue();
 
         harness.expectFile('dist/test.svg').content.toBe('<svg></svg>');
         harness.expectFile('dist/another.file').toNotExist();
@@ -274,27 +276,27 @@ describeBuilder(buildWebpackBrowser, BROWSER_BUILDER_INFO, (harness) => {
       it('copies an asset with directory and maintains directory in output', async () => {
         await harness.writeFile('src/subdirectory/test.svg', '<svg></svg>');
 
-        harness.useTarget('build', {
+        harness.useTarget('server', {
           ...BASE_OPTIONS,
           assets: [{ glob: 'subdirectory/test.svg', input: 'src', output: '.' }],
         });
 
         const { result } = await harness.executeOnce();
 
-        expect(result?.success).toBe(true);
+        expect(result?.success).toBeTrue();
 
         harness.expectFile('dist/subdirectory/test.svg').content.toBe('<svg></svg>');
       });
 
       it('does not fail if asset does not exist', async () => {
-        harness.useTarget('build', {
+        harness.useTarget('server', {
           ...BASE_OPTIONS,
           assets: [{ glob: 'test.svg', input: 'src', output: '.' }],
         });
 
         const { result } = await harness.executeOnce();
 
-        expect(result?.success).toBe(true);
+        expect(result?.success).toBeTrue();
 
         harness.expectFile('dist/test.svg').toNotExist();
       });
@@ -302,14 +304,14 @@ describeBuilder(buildWebpackBrowser, BROWSER_BUILDER_INFO, (harness) => {
       it('uses project output path when output option is empty string', async () => {
         await harness.writeFile('src/test.svg', '<svg></svg>');
 
-        harness.useTarget('build', {
+        harness.useTarget('server', {
           ...BASE_OPTIONS,
           assets: [{ glob: 'test.svg', input: 'src', output: '' }],
         });
 
         const { result } = await harness.executeOnce();
 
-        expect(result?.success).toBe(true);
+        expect(result?.success).toBeTrue();
 
         harness.expectFile('dist/test.svg').content.toBe('<svg></svg>');
       });
@@ -317,14 +319,14 @@ describeBuilder(buildWebpackBrowser, BROWSER_BUILDER_INFO, (harness) => {
       it('uses project output path when output option is "."', async () => {
         await harness.writeFile('src/test.svg', '<svg></svg>');
 
-        harness.useTarget('build', {
+        harness.useTarget('server', {
           ...BASE_OPTIONS,
           assets: [{ glob: 'test.svg', input: 'src', output: '.' }],
         });
 
         const { result } = await harness.executeOnce();
 
-        expect(result?.success).toBe(true);
+        expect(result?.success).toBeTrue();
 
         harness.expectFile('dist/test.svg').content.toBe('<svg></svg>');
       });
@@ -332,14 +334,14 @@ describeBuilder(buildWebpackBrowser, BROWSER_BUILDER_INFO, (harness) => {
       it('uses project output path when output option is "/"', async () => {
         await harness.writeFile('src/test.svg', '<svg></svg>');
 
-        harness.useTarget('build', {
+        harness.useTarget('server', {
           ...BASE_OPTIONS,
           assets: [{ glob: 'test.svg', input: 'src', output: '/' }],
         });
 
         const { result } = await harness.executeOnce();
 
-        expect(result?.success).toBe(true);
+        expect(result?.success).toBeTrue();
 
         harness.expectFile('dist/test.svg').content.toBe('<svg></svg>');
       });
@@ -347,14 +349,14 @@ describeBuilder(buildWebpackBrowser, BROWSER_BUILDER_INFO, (harness) => {
       it('creates a project output sub-path when output option path does not exist', async () => {
         await harness.writeFile('src/test.svg', '<svg></svg>');
 
-        harness.useTarget('build', {
+        harness.useTarget('server', {
           ...BASE_OPTIONS,
           assets: [{ glob: 'test.svg', input: 'src', output: 'subdirectory' }],
         });
 
         const { result } = await harness.executeOnce();
 
-        expect(result?.success).toBe(true);
+        expect(result?.success).toBeTrue();
 
         harness.expectFile('dist/subdirectory/test.svg').content.toBe('<svg></svg>');
       });
@@ -362,7 +364,7 @@ describeBuilder(buildWebpackBrowser, BROWSER_BUILDER_INFO, (harness) => {
       it('fails if output option is not within project output path', async () => {
         await harness.writeFile('test.svg', '<svg></svg>');
 
-        harness.useTarget('build', {
+        harness.useTarget('server', {
           ...BASE_OPTIONS,
           assets: [{ glob: 'test.svg', input: 'src', output: '..' }],
         });

--- a/packages/angular_devkit/build_angular/src/builders/server/tests/options/resources-output-path_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/server/tests/options/resources-output-path_spec.ts
@@ -35,10 +35,10 @@ describeBuilder(execute, SERVER_BUILDER_INFO, (harness) => {
 
       harness
         .expectFile('dist/main.js')
-        .content.toContain(`url(/assets/component-img-absolute.png)`);
+        .content.toContain(`url('/assets/component-img-absolute.png')`);
       harness
         .expectFile('dist/main.js')
-        .content.toContain(`url(out-assets/component-img-relative.png)`);
+        .content.toContain(`url('out-assets/component-img-relative.png')`);
 
       // Assets are not emitted during a server builds.
       harness.expectFile('dist/out-assets/component-img-relative.png').toNotExist();
@@ -54,8 +54,8 @@ describeBuilder(execute, SERVER_BUILDER_INFO, (harness) => {
 
       harness
         .expectFile('dist/main.js')
-        .content.toContain(`url(/assets/component-img-absolute.png)`);
-      harness.expectFile('dist/main.js').content.toContain(`url(component-img-relative.png)`);
+        .content.toContain(`url('/assets/component-img-absolute.png')`);
+      harness.expectFile('dist/main.js').content.toContain(`url('component-img-relative.png')`);
 
       // Assets are not emitted during a server builds.
       harness.expectFile('dist/component-img-relative.png').toNotExist();

--- a/packages/angular_devkit/build_angular/src/builders/server/tests/setup.ts
+++ b/packages/angular_devkit/build_angular/src/builders/server/tests/setup.ts
@@ -25,4 +25,7 @@ export const BASE_OPTIONS = Object.freeze<Schema>({
   progress: false,
   watch: false,
   outputPath: 'dist',
+
+  // Disable optimizations
+  optimization: false,
 });

--- a/packages/angular_devkit/build_angular/src/utils/normalize-asset-patterns.ts
+++ b/packages/angular_devkit/build_angular/src/utils/normalize-asset-patterns.ts
@@ -66,11 +66,13 @@ export function normalizeAssetPatterns(
       // Output directory for both is the relative path from source root to input.
       const output = path.relative(resolvedSourceRoot, path.resolve(workspaceRoot, input));
 
-      // Return the asset pattern in object format.
-      return { glob, input, output };
-    } else {
-      // It's already an AssetPatternObject, no need to convert.
-      return assetPattern;
+      assetPattern = { glob, input, output };
     }
+
+    if (assetPattern.output.startsWith('..')) {
+      throw new Error('An asset cannot be written to a location outside of the output path.');
+    }
+
+    return assetPattern;
   });
 }

--- a/packages/angular_devkit/build_angular/test/hello-world-app/src/tsconfig.server.json
+++ b/packages/angular_devkit/build_angular/test/hello-world-app/src/tsconfig.server.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.app.json",
   "compilerOptions": {
     "outDir": "../dist-server",
-    "target": "es2016",
     "baseUrl": "./",
     "types": ["@angular/localize"]
   },


### PR DESCRIPTION


This commits adds the `assets` option to the server builder. This can be useful to copy server specific assets such as config files.

Closes #24203
