### PR TITLE
fix(@angular-devkit/build-angular): update `loader-utils` to `3.2.1`

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
     "less-loader": "10.2.0",
     "license-checker": "^25.0.0",
     "license-webpack-plugin": "4.0.2",
-    "loader-utils": "3.2.0",
+    "loader-utils": "3.2.1",
     "magic-string": "0.25.7",
     "mini-css-extract-plugin": "2.5.3",
     "minimatch": "3.0.5",

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -40,7 +40,7 @@
     "less": "4.1.2",
     "less-loader": "10.2.0",
     "license-webpack-plugin": "4.0.2",
-    "loader-utils": "3.2.0",
+    "loader-utils": "3.2.1",
     "mini-css-extract-plugin": "2.5.3",
     "minimatch": "3.0.5",
     "open": "8.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7322,6 +7322,11 @@ loader-utils@3.2.0:
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-3.2.0.tgz#bcecc51a7898bee7473d4bc6b845b23af8304d4f"
   integrity sha512-HVl9ZqccQihZ7JM85dco1MvO9G+ONvxoGa9rkhzFsneGLKSUg1gJf9bWzhRhcvm2qChhWpebQhP44qxjKIUCaQ==
 
+loader-utils@3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-3.2.1.tgz#4fb104b599daafd82ef3e1a41fb9265f87e1f576"
+  integrity sha512-ZvFw1KWS3GVyYBYb7qkmRM/WwL2TQQBxgCK62rlvm4WpVQ23Nb4tYjApUlfjrEGvOs7KHEsmyUn75OHZrJMWPw==
+
 loader-utils@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.0.tgz#c579b5e34cb34b1a74edc6c1fb36bfa371d5a613"


### PR DESCRIPTION
`loader-utils` is vulnerable to Regular Expression Denial of Service (ReDoS) via url variable.

See: https://github.com/advisories/GHSA-3rfm-jhwj-7488

Closes #24241
