### PR TITLE
fix(@angular-devkit/build-angular): update `loader-utils` to `3.2.1`

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
     "less-loader": "11.0.0",
     "license-checker": "^25.0.0",
     "license-webpack-plugin": "4.0.2",
-    "loader-utils": "3.2.0",
+    "loader-utils": "3.2.1",
     "magic-string": "0.26.2",
     "mini-css-extract-plugin": "2.6.1",
     "minimatch": "5.1.0",

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -38,7 +38,7 @@
     "less": "4.1.3",
     "less-loader": "11.0.0",
     "license-webpack-plugin": "4.0.2",
-    "loader-utils": "3.2.0",
+    "loader-utils": "3.2.1",
     "mini-css-extract-plugin": "2.6.1",
     "minimatch": "5.1.0",
     "open": "8.4.0",

--- a/tests/legacy-cli/e2e/tests/misc/npm-7.ts
+++ b/tests/legacy-cli/e2e/tests/misc/npm-7.ts
@@ -45,8 +45,8 @@ export default async function () {
   }
 
   try {
-    // Install version >=7.5.6
-    await npm('install', '--global', 'npm@>=7.5.6');
+    // Install version ^7.5.6
+    await npm('install', '--global', 'npm@^7.5.6');
 
     // Ensure `ng update` does not show npm warning
     const { stderr: stderrUpdate1 } = await ng('update', ...extraArgs);

--- a/tests/legacy-cli/e2e/tests/update/update-secure-registry.ts
+++ b/tests/legacy-cli/e2e/tests/update/update-secure-registry.ts
@@ -3,7 +3,6 @@ import { createNpmConfigForAuthentication } from '../../utils/registry';
 import { expectToFail } from '../../utils/utils';
 import { isPrereleaseCli } from '../../utils/project';
 import { getActivePackageManager } from '../../utils/packages';
-import assert from 'node:assert';
 
 export default async function () {
   // The environment variable has priority over the .npmrc
@@ -41,6 +40,8 @@ export default async function () {
     await createNpmConfigForAuthentication(true, true);
 
     const error = await expectToFail(() => exec('yarn', 'ng', 'update', ...extraArgs));
-    assert.match(error.message, /not allowed to access package/);
+    if (!/not allowed to access package/.test(error.message)) {
+      throw new Error('Error did not match not allowed to access package.');
+    }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7317,6 +7317,11 @@ loader-utils@3.2.0:
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-3.2.0.tgz#bcecc51a7898bee7473d4bc6b845b23af8304d4f"
   integrity sha512-HVl9ZqccQihZ7JM85dco1MvO9G+ONvxoGa9rkhzFsneGLKSUg1gJf9bWzhRhcvm2qChhWpebQhP44qxjKIUCaQ==
 
+loader-utils@3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-3.2.1.tgz#4fb104b599daafd82ef3e1a41fb9265f87e1f576"
+  integrity sha512-ZvFw1KWS3GVyYBYb7qkmRM/WwL2TQQBxgCK62rlvm4WpVQ23Nb4tYjApUlfjrEGvOs7KHEsmyUn75OHZrJMWPw==
+
 loader-utils@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.2.tgz#d6e3b4fb81870721ae4e0868ab11dd638368c129"


### PR DESCRIPTION
`loader-utils` is vulnerable to Regular Expression Denial of Service (ReDoS) via url variable.

See: https://github.com/advisories/GHSA-3rfm-jhwj-7488

Closes #24241
