### PR TITLE
refactor(@angular-devkit/build-angular): preprocess Sass resolve cache entries in esbuild Sass plugin

### DIFF
--- a/packages/angular_devkit/build_angular/src/sass/worker.ts
+++ b/packages/angular_devkit/build_angular/src/sass/worker.ts
@@ -7,7 +7,6 @@
  */
 
 import mergeSourceMaps, { RawSourceMap } from '@ampproject/remapping';
-import { Dirent } from 'node:fs';
 import { dirname } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { MessagePort, parentPort, receiveMessageOnPort, workerData } from 'node:worker_threads';
@@ -19,6 +18,7 @@ import {
   compileString,
 } from 'sass';
 import {
+  DirectoryEntry,
   LoadPathsUrlRebasingImporter,
   ModuleUrlRebasingImporter,
   RelativeUrlRebasingImporter,
@@ -82,7 +82,7 @@ parentPort.on('message', (message: RenderRequestMessage) => {
       }[]
     | undefined;
   try {
-    const directoryCache = new Map<string, Dirent[]>();
+    const directoryCache = new Map<string, DirectoryEntry>();
     const rebaseSourceMaps = options.sourceMap ? new Map<string, RawSourceMap>() : undefined;
     if (hasImporter) {
       // When a custom importer function is present, the importer request must be proxied


### PR DESCRIPTION
When performing Sass import resolution within the experimental esbuild-based browser application builder, the directory cache entries will now be preprocessed during the first directory search operation. This will allow a more streamlined search operation on later resolution attempts for the same directory. The caching is still limited to sharing per render request but this change provides for cache entries that can more easily be serialized and shared between workers in the future.