### PR TITLE
ci: create daily_run_workflow for 14.2.x branch

### DIFF
--- a/.circleci/dynamic_config.yml
+++ b/.circleci/dynamic_config.yml
@@ -385,6 +385,9 @@ jobs:
 workflows:
   version: 2
   default_workflow:
+    when:
+      not:
+        equal: [scheduled_pipeline, << pipeline.trigger_source >>]
     jobs:
       # Linux jobs
       - setup
@@ -483,5 +486,23 @@ workflows:
 
       - publish_artifacts:
           <<: *only_pull_requests
+          requires:
+            - build
+
+  daily_run_workflow:
+    when:
+      and:
+        - equal: [scheduled_pipeline, << pipeline.trigger_source >>]
+        - equal: ['14.2.x nightly run', << pipeline.schedule.name >>]
+    jobs:
+      - setup
+      - build:
+          requires:
+            - setup
+      - e2e-tests:
+          name: e2e-cli-nightly
+          requires:
+            - build
+      - test-browsers:
           requires:
             - build


### PR DESCRIPTION

This workflow is used by circle ci scheduled pipelines which is required to create a cron job when using dynamic configurations.

See: https://circleci.com/docs/scheduled-pipelines/?utm_source=google&utm_medium=sem&utm_campaign=sem-google-dg--emea-en-dsa-maxConv-auth-nb&utm_term=g_-_c__dsa_&utm_content=&gclid=Cj0KCQiA1NebBhDDARIsAANiDD2Ja2WCBYtxifWx9d8uD2bEZzDjtO4mB2aq7fEtvoUKZZ8GeQbeNtgaAoW5EALw_wcB and https://app.circleci.com/settings/project/github/angular/angular-cli/triggers?return-to=https%3A%2F%2Fapp.circleci.com%2Fpipelines%2Fgithub%2Fangular%2Fangular-cli&triggerSource=&scheduledTriggerId=8e3e6898-fd55-41b1-a3e8-85c52981d941&success=true
