### PR TITLE
test(@angular/cli): amend ng-add version specifier to not rely on latest tag

### DIFF
--- a/tests/legacy-cli/e2e/tests/commands/add/version-specifier.ts
+++ b/tests/legacy-cli/e2e/tests/commands/add/version-specifier.ts
@@ -1,4 +1,5 @@
 import { appendFile } from 'fs/promises';
+import { readNgVersion } from '../../../utils/version';
 import { expectFileToMatch, rimraf } from '../../../utils/fs';
 import { getActivePackageManager, uninstallPackage } from '../../../utils/packages';
 import { ng } from '../../../utils/process';
@@ -25,7 +26,7 @@ export default async function () {
     throw new Error('Installation was not skipped');
   }
 
-  const output2 = await ng('add', '@angular/localize@latest', '--skip-confirmation');
+  const output2 = await ng('add', `@angular/localize@${readNgVersion()}`, '--skip-confirmation');
   if (output2.stdout.includes('Skipping installation: Package already installed')) {
     throw new Error('Installation should not have been skipped');
   }


### PR DESCRIPTION

Replace tag specifier with version specifier as this causes breakages when a new major version is released.
