### PR TITLE
docs: release notes for the v13.3.10 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -209,6 +209,22 @@ Alan Agius and Charles Lyding
 
 <!-- CHANGELOG SPLIT MARKER -->
 
+<a name="13.3.10"></a>
+
+# 13.3.10 (2022-11-17)
+
+### @angular-devkit/build-angular
+
+| Commit                                                                                              | Type | Description                      |
+| --------------------------------------------------------------------------------------------------- | ---- | -------------------------------- |
+| [f298ebbd5](https://github.com/angular/angular-cli/commit/f298ebbd5f86077985d994662314379df92b6771) | fix  | update `loader-utils` to `3.2.1` |
+
+## Special Thanks
+
+Alan Agius
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="14.2.9"></a>
 
 # 14.2.9 (2022-11-09)


### PR DESCRIPTION
Cherry-picks the changelog from the "13.3.x" branch to the next branch (main).