### PR TITLE
build: remove `regenerator-runtime` from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -190,7 +190,6 @@
     "protractor": "~7.0.0",
     "puppeteer": "18.2.1",
     "quicktype-core": "6.0.69",
-    "regenerator-runtime": "0.13.10",
     "resolve-url-loader": "5.0.0",
     "rxjs": "6.6.7",
     "sass": "1.56.1",

--- a/packages/angular_devkit/build_angular/BUILD.bazel
+++ b/packages/angular_devkit/build_angular/BUILD.bazel
@@ -162,7 +162,6 @@ ts_library(
         "@npm//piscina",
         "@npm//postcss",
         "@npm//postcss-loader",
-        "@npm//regenerator-runtime",
         "@npm//resolve-url-loader",
         "@npm//rxjs",
         "@npm//sass",

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -49,7 +49,6 @@
     "piscina": "3.2.0",
     "postcss": "8.4.19",
     "postcss-loader": "7.0.1",
-    "regenerator-runtime": "0.13.10",
     "resolve-url-loader": "5.0.0",
     "rxjs": "6.6.7",
     "sass": "1.56.1",


### PR DESCRIPTION
This dependency is no longer needed since we no longer generate es5 output.
