### PR TITLE
feat(@angular-devkit/schematics-cli): auto detect package manager

### DIFF
--- a/packages/angular_devkit/schematics_cli/bin/schematics.ts
+++ b/packages/angular_devkit/schematics_cli/bin/schematics.ts
@@ -14,10 +14,10 @@ import { ProcessOutput, createConsoleLogger } from '@angular-devkit/core/node';
 import { UnsuccessfulWorkflowExecution } from '@angular-devkit/schematics';
 import { NodeWorkflow } from '@angular-devkit/schematics/tools';
 import * as ansiColors from 'ansi-colors';
-import * as inquirer from 'inquirer';
-import yargsParser, { camelCase, decamelize } from 'yargs-parser';
 import { existsSync } from 'fs';
+import * as inquirer from 'inquirer';
 import * as path from 'path';
+import yargsParser, { camelCase, decamelize } from 'yargs-parser';
 
 /**
  * Parse the name of schematic passed in argument, and return a {collection, schematic} named
@@ -145,6 +145,7 @@ function getPackageManagerName() {
   if (lockPath) {
     return LOCKS[path.basename(lockPath)];
   }
+
   return 'npm';
 }
 

--- a/packages/angular_devkit/schematics_cli/bin/schematics.ts
+++ b/packages/angular_devkit/schematics_cli/bin/schematics.ts
@@ -16,7 +16,7 @@ import { NodeWorkflow } from '@angular-devkit/schematics/tools';
 import * as ansiColors from 'ansi-colors';
 import * as inquirer from 'inquirer';
 import yargsParser, { camelCase, decamelize } from 'yargs-parser';
-import {existsSync} from 'fs'
+import { existsSync } from 'fs';
 import * as path from 'path';
 
 /**
@@ -134,18 +134,18 @@ function findUp(names: string | string[], from: string) {
 /**
  * return package manager' name by lock file
  */
- function getPackageManagerName() {
+function getPackageManagerName() {
   // order by check priority
   const LOCKS: Record<string, string> = {
     'package-lock.json': 'npm',
     'yarn.lock': 'yarn',
     'pnpm-lock.yaml': 'pnpm',
-  }
-  const lockPath = findUp(Object.keys(LOCKS), process.cwd())
+  };
+  const lockPath = findUp(Object.keys(LOCKS), process.cwd());
   if (lockPath) {
-    return LOCKS[path.basename(lockPath)]
+    return LOCKS[path.basename(lockPath)];
   }
-  return 'npm'
+  return 'npm';
 }
 
 // eslint-disable-next-line max-lines-per-function
@@ -195,7 +195,7 @@ export async function main({
     dryRun,
     resolvePaths: [process.cwd(), __dirname],
     schemaValidation: true,
-    packageManager: getPackageManagerName()
+    packageManager: getPackageManagerName(),
   });
 
   /** If the user wants to list schematics, we simply show all the schematic names. */


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
Can't specify packageManager when running a schematic
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
Detect packageManager by the lock file, and use the right package manager to install dependencies. Behave like `ng generate <schematic>`
<!-- Please describe the new behavior that. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
This PR originates from https://github.com/nestjs/nest-cli/issues/1115

As I look into the problem, first I wanted to fix it in [`@nestjs/schematics`](https://github.com/nestjs/schematics/blob/641e8d412d95f6de5393718e0d2e512493e62c45/src/lib/resource/resource.factory.ts#L195)

but then I checked Angular cli, and run the following command, it worked as excepted(using correct package manager).
```bash
ng new test --no-install
cd test
touch yarn.lock
ng g @nestjs/schematics:resource --name=users --no-dry-run --no-skip-import --language="ts" --source-root="src" --spec --no-flat
```

So I thought maybe it's better to fix it in `schematics-cli` to make it behave just like `angular-cli`.

I am a new contributor, plz let me know If I did anything wrong ;)