### PR TITLE
fix(@angular-devkit/build-angular): hide loader paths in webpack warnings

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/utils/stats.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/utils/stats.ts
@@ -343,7 +343,17 @@ export function statsWarningsToString(
     if (typeof warning === 'string') {
       output += yb(`Warning: ${warning}\n\n`);
     } else {
-      const file = warning.file || warning.moduleName;
+      let file = warning.file || warning.moduleName;
+      // Clean up warning paths
+      // Ex: ./src/app/styles.scss.webpack[javascript/auto]!=!./node_modules/css-loader/dist/cjs.js....
+      // to ./src/app/styles.scss.webpack
+      if (file && !statsConfig.errorDetails) {
+        const webpackPathIndex = file.indexOf('.webpack[');
+        if (webpackPathIndex !== -1) {
+          file = file.substring(0, webpackPathIndex);
+        }
+      }
+
       if (file) {
         output += c(file);
         if (warning.loc) {


### PR DESCRIPTION


Similar to errors messages we now hide webpack paths in warnings to reduce clutter.

Before
```

./src/styles.scss.webpack[javascript/auto]!=!./node_modules/css-loader/dist/cjs.js??ruleSet[1].rules[6].rules[0].oneOf[0].use[1]!./node_modules/postcss-loader/dist/cjs.js??ruleSet[1].rules[6].rules[0].oneOf[0].use[2]!./node_modules/resolve-url-loader/index.js??ruleSet[1].rules[6].rules[1].use[0]!./node_modules/sass-loader/dist/cjs.js??ruleSet[1].rules[6].rules[1].use[1]!./src/styles.scss?ngGlobalStyle - Warning: Module Warning (from ./node_modules/sass-loader/dist/cjs.js):
Deprecation $weight: Passing a number without unit % (60) is deprecated.

To preserve current behavior: $weight * 1%

More info: https://sass-lang.com/d/function-units

@material/slider/_slider-theme.scss 77:5                                    @use
node_modules/@angular/material/slider/_slider-theme.scss 3:1                @use
node_modules/@angular/material/core/density/private/_all-density.scss 25:1  @forward
@angular/_index.scss 18:1                                                   @use
src/styles.scss 2:1                                                         root stylesheet
```

After
```

./src/styles.scss - Warning: Module Warning (from ./node_modules/sass-loader/dist/cjs.js):
Deprecation $weight: Passing a number without unit % (60) is deprecated.

To preserve current behavior: $weight * 1%

More info: https://sass-lang.com/d/function-units

@material/slider/_slider-theme.scss 77:5                                    @use
node_modules/@angular/material/slider/_slider-theme.scss 3:1                @use
node_modules/@angular/material/core/density/private/_all-density.scss 25:1  @forward
@angular/_index.scss 18:1                                                   @use
src/styles.scss 2:1                                                         root stylesheet
```