### PR TITLE
refactor: remove usages of deprecated version of `createImportDeclaration`

### DIFF
--- a/packages/ngtools/webpack/src/ivy/transformation.ts
+++ b/packages/ngtools/webpack/src/ivy/transformation.ts
@@ -97,7 +97,6 @@ export function replaceBootstrap(
             bootstrapNamespace = nodeFactory.createUniqueName('__NgCli_bootstrap_');
             bootstrapImport = nodeFactory.createImportDeclaration(
               undefined,
-              undefined,
               nodeFactory.createImportClause(
                 false,
                 undefined,

--- a/packages/ngtools/webpack/src/transformers/replace_resources.ts
+++ b/packages/ngtools/webpack/src/transformers/replace_resources.ts
@@ -326,7 +326,6 @@ function createResourceImport(
     resourceImportDeclarations.push(
       nodeFactory.createImportDeclaration(
         undefined,
-        undefined,
         nodeFactory.createImportClause(false, importName, undefined),
         urlLiteral,
       ),


### PR DESCRIPTION


The overload of `createImportDeclaration` with the `decorators` parameter is deprecated. This change removes the deprecated usage.
