### PR TITLE
fix(@schematics/angular): remove EnvironmentInjector import in functional guard spec

### DIFF
--- a/packages/schematics/angular/guard/type-files/__name@dasherize__.guard.spec.ts.template
+++ b/packages/schematics/angular/guard/type-files/__name@dasherize__.guard.spec.ts.template
@@ -1,4 +1,3 @@
-import { EnvironmentInjector } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { <%= guardType %> } from '@angular/router';
 


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

It is unnecessary now that the spec uses `runInInjectionContext` 
The resolver spec does not have this issue as the import was missing in the spec in the first place.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
