### PR TITLE
fix(@schematics/angular): use proper variable in functional guard spec

### DIFF
--- a/packages/schematics/angular/guard/type-files/__name@dasherize__.guard.spec.ts.template
+++ b/packages/schematics/angular/guard/type-files/__name@dasherize__.guard.spec.ts.template
@@ -13,6 +13,6 @@ describe('<%= camelize(name) %>Guard', () => {
   });
 
   it('should be created', () => {
-    expect(<%= camelize(name) %>Guard).toBeTruthy();
+    expect(executeGuard).toBeTruthy();
   });
 });


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

The current functional guard generates:

```ts
const executeGuard: CanActivateFn = ...

 it('should be created', () => {
    expect(fooGuard).toBeTruthy();
  });
```

with `fooGuard` the guard not run in injection context

## What is the new behavior?

```ts
const executeGuard: CanActivateFn = ...

 it('should be created', () => {
    expect(executeGuard).toBeTruthy();
  });
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
