### PR TITLE
Revert "docs: remove `@latest` reference from `npm init` command"

### DIFF
--- a/packages/angular/create/README.md
+++ b/packages/angular/create/README.md
@@ -9,7 +9,7 @@ Scaffold an Angular CLI workspace without needing to install the Angular CLI glo
 ### npm
 
 ```
-npm init @angular [project-name] -- [...options]
+npm init @angular@latest [project-name] -- [...options]
 ```
 
 ### yarn


### PR DESCRIPTION
Reverts angular/angular-cli#23590 as the fix has landed in NPM v8.15.1

Closes #24341 