### PR TITLE
fix(@angular-devkit/build-angular): prevent optimization adding unsupported ECMASCript features

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/plugins/javascript-optimizer-worker.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/plugins/javascript-optimizer-worker.ts
@@ -190,8 +190,9 @@ async function optimizeWithTerser(
         passes: advanced ? 2 : 1,
         pure_getters: advanced,
       },
-      // terser only supports up to ES2020
-      ecma: 2020,
+      // Set to ES2015 to prevent higher level features from being introduced when browserslist
+      // contains older browsers. The build system requires browsers to support ES2015 at a minimum.
+      ecma: 2015,
       // esbuild in the first pass is used to minify identifiers instead of mangle here
       mangle: false,
       // esbuild in the first pass is used to minify function names


### PR DESCRIPTION
When optimization is enabled with the `@angular-devkit/build-angular:browser` builder, terser is used as a second phase optimizer. The terser configuration previously set its `ecma` option to `es2020` due to all officially supported browsers supporting the version. However, it is possible to add browsers to the browserslist configuration that are not officially supported that still may work but do not support es2020 syntax features. By setting the terser `ecma` option to `es2015`, terser will not turn existing syntax into newer syntax features that might be unsupported. Terser will also not downlevel any code based on this option.

Fixes #24347