### PR TITLE
fix(@schematics/angular): add missing semicolon in functional guard/resolver/interceptor

### DIFF
--- a/packages/schematics/angular/guard/type-files/__name@dasherize__.guard.ts.template
+++ b/packages/schematics/angular/guard/type-files/__name@dasherize__.guard.ts.template
@@ -6,4 +6,4 @@ export const <%= camelize(name) %>Guard: <%= guardType %><% if (guardType === 'C
   %><% if (guardType === 'CanActivateChildFn') { %>(childRoute, state)<% }
   %><% if (guardType === 'CanDeactivateFn') { %>(component, currentRoute, currentState, nextState)<% } %> => {
   return true;
-}
+};

--- a/packages/schematics/angular/interceptor/functional-files/__name@dasherize@if-flat__/__name@dasherize__.interceptor.ts.template
+++ b/packages/schematics/angular/interceptor/functional-files/__name@dasherize@if-flat__/__name@dasherize__.interceptor.ts.template
@@ -2,4 +2,4 @@ import { HttpInterceptorFn } from '@angular/common/http';
 
 export const <%= camelize(name) %>Interceptor: HttpInterceptorFn = (req, next) => {
   return next(req);
-}
+};

--- a/packages/schematics/angular/resolver/functional-files/__name@dasherize__.resolver.ts.template
+++ b/packages/schematics/angular/resolver/functional-files/__name@dasherize__.resolver.ts.template
@@ -2,4 +2,4 @@ import { ResolveFn } from '@angular/router';
 
 export const <%= camelize(name) %>Resolver: ResolveFn<boolean> = (route, state) => {
   return true;
-}
+};


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

The new functional entities are constants, and there is no semicolon at the end of their declaration

## What is the new behavior?

Maybe that was a deliberate choice, but we usually have semicolons in the generated code from the CLI

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
