### PR TITLE
refactor(@angular-devkit/build-angular): convert `transformedContent` into a function

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/index-file/augment-index-html.ts
+++ b/packages/angular_devkit/build_angular/src/utils/index-file/augment-index-html.ts
@@ -183,7 +183,7 @@ export async function augmentIndexHtml(
       rewriter.emitEndTag(tag);
     });
 
-  const content = await transformedContent;
+  const content = await transformedContent();
 
   return {
     content:

--- a/packages/angular_devkit/build_angular/src/utils/index-file/html-rewriting-stream.ts
+++ b/packages/angular_devkit/build_angular/src/utils/index-file/html-rewriting-stream.ts
@@ -10,36 +10,44 @@ import { Readable, Writable } from 'stream';
 
 export async function htmlRewritingStream(content: string): Promise<{
   rewriter: import('parse5-html-rewriting-stream');
-  transformedContent: Promise<string>;
+  transformedContent: () => Promise<string>;
 }> {
   const chunks: Buffer[] = [];
   const rewriter = new (await import('parse5-html-rewriting-stream')).default();
 
   return {
     rewriter,
-    transformedContent: new Promise((resolve) => {
-      new Readable({
-        encoding: 'utf8',
-        read(): void {
-          this.push(Buffer.from(content));
-          this.push(null);
-        },
-      })
-        .pipe(rewriter)
-        .pipe(
-          new Writable({
-            write(chunk: string | Buffer, encoding: string | undefined, callback: Function): void {
-              chunks.push(
-                typeof chunk === 'string' ? Buffer.from(chunk, encoding as BufferEncoding) : chunk,
-              );
-              callback();
-            },
-            final(callback: (error?: Error) => void): void {
-              callback();
-              resolve(Buffer.concat(chunks).toString());
-            },
-          }),
-        );
-    }),
+    transformedContent: () => {
+      return new Promise((resolve) => {
+        new Readable({
+          encoding: 'utf8',
+          read(): void {
+            this.push(Buffer.from(content));
+            this.push(null);
+          },
+        })
+          .pipe(rewriter)
+          .pipe(
+            new Writable({
+              write(
+                chunk: string | Buffer,
+                encoding: string | undefined,
+                callback: Function,
+              ): void {
+                chunks.push(
+                  typeof chunk === 'string'
+                    ? Buffer.from(chunk, encoding as BufferEncoding)
+                    : chunk,
+                );
+                callback();
+              },
+              final(callback: (error?: Error) => void): void {
+                callback();
+                resolve(Buffer.concat(chunks).toString());
+              },
+            }),
+          );
+      });
+    },
   };
 }

--- a/packages/angular_devkit/build_angular/src/utils/index-file/inline-fonts.ts
+++ b/packages/angular_devkit/build_angular/src/utils/index-file/inline-fonts.ts
@@ -48,7 +48,8 @@ export class InlineFontsProcessor {
     const existingPreconnect = new Set<string>();
 
     // Collector link tags with href
-    const { rewriter: collectorStream } = await htmlRewritingStream(content);
+    const { rewriter: collectorStream, transformedContent: initCollectorStream } =
+      await htmlRewritingStream(content);
 
     collectorStream.on('startTag', (tag) => {
       const { tagName, attrs } = tag;
@@ -86,6 +87,11 @@ export class InlineFontsProcessor {
           return;
         }
       }
+    });
+
+    initCollectorStream().catch(() => {
+      // We don't really care about any errors here because it just initializes
+      // the rewriting stream, as we are waiting for `finish` below.
     });
 
     await new Promise((resolve) => collectorStream.on('finish', resolve));
@@ -151,7 +157,7 @@ export class InlineFontsProcessor {
       }
     });
 
-    return transformedContent;
+    return transformedContent();
   }
 
   private async getResponse(url: URL): Promise<string> {


### PR DESCRIPTION
This PR converts `transformedContent` into a function to give more control when the readable stream is initialized. There might be issues with late "subscribers" where events are added after the readable stream was initialized and the data was already pushed, e.g.

```ts
const { rewriter } = await htmlRewritingStream('<div />');

setTimeout(() => {
  rewriter.on('startTag', (tag) => {
    console.log(tag);
  });
})
```

This will not work and potentially wait indefinitely. I have ran into such issue with WebContainer on stackblitz.com.

With this change the stream now needs to be explicitily initialized:

```ts
const { rewriter, transformedContent } = await htmlRewritingStream('<div />');

setTimeout(() => {
  rewriter.on('startTag', (tag) => {
    console.log(tag);
  });
  
  // calling this function will create the readable stream
  transformedContent();
})
```

This will work as expected.

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No