### PR TITLE
fix(@angular-devkit/build-angular): default preserve symlinks to Node.js value for esbuild

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/options.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/options.ts
@@ -152,7 +152,8 @@ export async function normalizeOptions(
     crossOrigin,
     externalDependencies,
     poll,
-    preserveSymlinks,
+    // If not explicitly set, default to the Node.js process argument
+    preserveSymlinks: preserveSymlinks ?? process.execArgv.includes('--preserve-symlinks'),
     stylePreprocessorOptions,
     subresourceIntegrity,
     verbose,


### PR DESCRIPTION
When using the experimental esbuild-based browser application builder, the `preserveSymlinks` option will now default to the value of the Node.js `--preserve-symlinks` argument. This removes the need to manually specify the option in two places if executing the build manually with Node.js or via the `NODE_OPTIONS` environment variable. This behavior mimics that of the default Webpack-based builder.