### PR TITLE
fix(@angular-devkit/build-angular): include sources in generated Sass source maps

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/styles.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/styles.ts
@@ -360,6 +360,7 @@ function getSassLoaderOptions(
           quietDeps: !verbose,
           verbose,
           syntax: indentedSyntax ? 'indented' : 'scss',
+          sourceMapIncludeSources: true,
         }),
       }
     : {


### PR DESCRIPTION


This commits enables `sourceMapIncludeSources` when using the modern Sass API so that sources are included in generated source map.

Closes #24394
