### PR TITLE
feat(@angular-devkit/schematics): add `runSchematic` and `runExternalSchematic` methods

### DIFF
--- a/goldens/public-api/angular_devkit/schematics/testing/index.md
+++ b/goldens/public-api/angular_devkit/schematics/testing/index.md
@@ -25,8 +25,12 @@ export class SchematicTestRunner {
     // (undocumented)
     registerCollection(collectionName: string, collectionPath: string): void;
     // (undocumented)
+    runExternalSchematic<SchematicSchemaT extends object>(collectionName: string, schematicName: string, opts?: SchematicSchemaT, tree?: Tree_2): Promise<UnitTestTree>;
+    // @deprecated (undocumented)
     runExternalSchematicAsync<SchematicSchemaT extends object>(collectionName: string, schematicName: string, opts?: SchematicSchemaT, tree?: Tree_2): Observable<UnitTestTree>;
     // (undocumented)
+    runSchematic<SchematicSchemaT extends object>(schematicName: string, opts?: SchematicSchemaT, tree?: Tree_2): Promise<UnitTestTree>;
+    // @deprecated (undocumented)
     runSchematicAsync<SchematicSchemaT extends object>(schematicName: string, opts?: SchematicSchemaT, tree?: Tree_2): Observable<UnitTestTree>;
     // (undocumented)
     get tasks(): TaskConfiguration[];

--- a/packages/angular/pwa/pwa/index_spec.ts
+++ b/packages/angular/pwa/pwa/index_spec.ts
@@ -39,18 +39,23 @@ describe('PWA Schematic', () => {
   };
 
   beforeEach(async () => {
-    appTree = await schematicRunner
-      .runExternalSchematicAsync('@schematics/angular', 'workspace', workspaceOptions)
-      .toPromise();
-    appTree = await schematicRunner
-      .runExternalSchematicAsync('@schematics/angular', 'application', appOptions, appTree)
-      .toPromise();
+    appTree = await schematicRunner.runExternalSchematic(
+      '@schematics/angular',
+      'workspace',
+      workspaceOptions,
+    );
+    appTree = await schematicRunner.runExternalSchematic(
+      '@schematics/angular',
+      'application',
+      appOptions,
+      appTree,
+    );
   });
 
   it('should run the service worker schematic', (done) => {
     schematicRunner
-      .runSchematicAsync('ng-add', defaultOptions, appTree)
-      .toPromise()
+      .runSchematic('ng-add', defaultOptions, appTree)
+
       .then((tree) => {
         const configText = tree.readContent('/angular.json');
         const config = JSON.parse(configText);
@@ -64,8 +69,8 @@ describe('PWA Schematic', () => {
     const dimensions = [72, 96, 128, 144, 152, 192, 384, 512];
     const iconPath = '/projects/bar/src/assets/icons/icon-';
     schematicRunner
-      .runSchematicAsync('ng-add', defaultOptions, appTree)
-      .toPromise()
+      .runSchematic('ng-add', defaultOptions, appTree)
+
       .then((tree) => {
         dimensions.forEach((d) => {
           const path = `${iconPath}${d}x${d}.png`;
@@ -77,8 +82,8 @@ describe('PWA Schematic', () => {
 
   it('should create a manifest file', (done) => {
     schematicRunner
-      .runSchematicAsync('ng-add', defaultOptions, appTree)
-      .toPromise()
+      .runSchematic('ng-add', defaultOptions, appTree)
+
       .then((tree) => {
         expect(tree.exists('/projects/bar/src/manifest.webmanifest')).toEqual(true);
         done();
@@ -87,8 +92,8 @@ describe('PWA Schematic', () => {
 
   it('should set the name & short_name in the manifest file', (done) => {
     schematicRunner
-      .runSchematicAsync('ng-add', defaultOptions, appTree)
-      .toPromise()
+      .runSchematic('ng-add', defaultOptions, appTree)
+
       .then((tree) => {
         const manifestText = tree.readContent('/projects/bar/src/manifest.webmanifest');
         const manifest = JSON.parse(manifestText);
@@ -102,8 +107,8 @@ describe('PWA Schematic', () => {
   it('should set the name & short_name in the manifest file when no title provided', (done) => {
     const options = { ...defaultOptions, title: undefined };
     schematicRunner
-      .runSchematicAsync('ng-add', options, appTree)
-      .toPromise()
+      .runSchematic('ng-add', options, appTree)
+
       .then((tree) => {
         const manifestText = tree.readContent('/projects/bar/src/manifest.webmanifest');
         const manifest = JSON.parse(manifestText);
@@ -116,8 +121,8 @@ describe('PWA Schematic', () => {
 
   it('should update the index file', (done) => {
     schematicRunner
-      .runSchematicAsync('ng-add', defaultOptions, appTree)
-      .toPromise()
+      .runSchematic('ng-add', defaultOptions, appTree)
+
       .then((tree) => {
         const content = tree.readContent('projects/bar/src/index.html');
 
@@ -135,8 +140,8 @@ describe('PWA Schematic', () => {
     index = index.replace('</body>', '<noscript>NO JAVASCRIPT</noscript></body>');
     appTree.overwrite('projects/bar/src/index.html', index);
     schematicRunner
-      .runSchematicAsync('ng-add', defaultOptions, appTree)
-      .toPromise()
+      .runSchematic('ng-add', defaultOptions, appTree)
+
       .then((tree) => {
         const content = tree.readContent('projects/bar/src/index.html');
 
@@ -152,8 +157,8 @@ describe('PWA Schematic', () => {
 
   it('should update the build and test assets configuration', (done) => {
     schematicRunner
-      .runSchematicAsync('ng-add', defaultOptions, appTree)
-      .toPromise()
+      .runSchematic('ng-add', defaultOptions, appTree)
+
       .then((tree) => {
         const configText = tree.readContent('/angular.json');
         const config = JSON.parse(configText);

--- a/packages/angular_devkit/build_angular/src/builders/karma/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/index.ts
@@ -176,7 +176,9 @@ export function execute(
           const karmaStart = karmaServer.start();
 
           // Cleanup, signal Karma to exit.
-          return () => karmaStart.then(() => karmaServer.stop());
+          return () => {
+            void karmaStart.then(() => karmaServer.stop());
+          };
         }),
     ),
     defaultIfEmpty({ success: false }),

--- a/packages/angular_devkit/schematics_cli/blank/schematic-files/src/__name@dasherize__/index_spec.ts
+++ b/packages/angular_devkit/schematics_cli/blank/schematic-files/src/__name@dasherize__/index_spec.ts
@@ -7,9 +7,7 @@ const collectionPath = path.join(__dirname, '../collection.json');
 describe('<%= dasherize(name) %>', () => {
   it('works', async () => {
     const runner = new SchematicTestRunner('schematics', collectionPath);
-    const tree = await runner
-      .runSchematicAsync('<%= dasherize(name) %>', {}, Tree.empty())
-      .toPromise();
+    const tree = await runner.runSchematic('<%= dasherize(name) %>', {}, Tree.empty());
 
     expect(tree.files).toEqual([]);
   });

--- a/packages/angular_devkit/schematics_cli/schematic/files/src/my-full-schematic/index_spec.ts
+++ b/packages/angular_devkit/schematics_cli/schematic/files/src/my-full-schematic/index_spec.ts
@@ -10,15 +10,13 @@ describe('my-full-schematic', () => {
     // We test that
     const runner = new SchematicTestRunner('schematics', collectionPath);
     await expectAsync(
-      runner.runSchematicAsync('my-full-schematic', {}, Tree.empty()).toPromise(),
+      runner.runSchematic('my-full-schematic', {}, Tree.empty())
     ).toBeRejected();
   });
 
   it('works', async () => {
     const runner = new SchematicTestRunner('schematics', collectionPath);
-    const tree = await runner
-      .runSchematicAsync('my-full-schematic', { name: 'str' }, Tree.empty())
-      .toPromise();
+    const tree = await runner.runSchematic('my-full-schematic', { name: 'str' }, Tree.empty());
 
     // Listing files
     expect(tree.files.sort()).toEqual(['/allo', '/hola', '/test1', '/test2']);

--- a/packages/angular_devkit/schematics_cli/schematic/files/src/my-other-schematic/index_spec.ts
+++ b/packages/angular_devkit/schematics_cli/schematic/files/src/my-other-schematic/index_spec.ts
@@ -7,7 +7,7 @@ const collectionPath = path.join(__dirname, '../collection.json');
 describe('my-other-schematic', () => {
   it('works', async () => {
     const runner = new SchematicTestRunner('schematics', collectionPath);
-    const tree = await runner.runSchematicAsync('my-other-schematic', {}, Tree.empty()).toPromise();
+    const tree = await runner.runSchematic('my-other-schematic', {}, Tree.empty());
 
     expect(tree.files.sort()).toEqual(['/allo', '/hola']);
   });

--- a/packages/angular_devkit/schematics_cli/schematic/files/src/my-schematic/index_spec.ts
+++ b/packages/angular_devkit/schematics_cli/schematic/files/src/my-schematic/index_spec.ts
@@ -7,7 +7,7 @@ const collectionPath = path.join(__dirname, '../collection.json');
 describe('my-schematic', () => {
   it('works', async () => {
     const runner = new SchematicTestRunner('schematics', collectionPath);
-    const tree = await runner.runSchematicAsync('my-schematic', {}, Tree.empty()).toPromise();
+    const tree = await runner.runSchematic('my-schematic', {}, Tree.empty());
 
     expect(tree.files).toEqual(['/hello']);
   });

--- a/packages/schematics/angular/app-shell/index_spec.ts
+++ b/packages/schematics/angular/app-shell/index_spec.ts
@@ -37,34 +37,30 @@ describe('App Shell Schematic', () => {
   let appTree: UnitTestTree;
 
   beforeEach(async () => {
-    appTree = await schematicRunner.runSchematicAsync('workspace', workspaceOptions).toPromise();
-    appTree = await schematicRunner
-      .runSchematicAsync('application', appOptions, appTree)
-      .toPromise();
+    appTree = await schematicRunner.runSchematic('workspace', workspaceOptions);
+    appTree = await schematicRunner.runSchematic('application', appOptions, appTree);
   });
 
   it('should ensure the client app has a router-outlet', async () => {
-    appTree = await schematicRunner.runSchematicAsync('workspace', workspaceOptions).toPromise();
-    appTree = await schematicRunner
-      .runSchematicAsync('application', { ...appOptions, routing: false }, appTree)
-      .toPromise();
+    appTree = await schematicRunner.runSchematic('workspace', workspaceOptions);
+    appTree = await schematicRunner.runSchematic(
+      'application',
+      { ...appOptions, routing: false },
+      appTree,
+    );
     await expectAsync(
-      schematicRunner.runSchematicAsync('app-shell', defaultOptions, appTree).toPromise(),
+      schematicRunner.runSchematic('app-shell', defaultOptions, appTree),
     ).toBeRejected();
   });
 
   it('should add a universal app', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('app-shell', defaultOptions, appTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('app-shell', defaultOptions, appTree);
     const filePath = '/projects/bar/src/app/app.server.module.ts';
     expect(tree.exists(filePath)).toEqual(true);
   });
 
   it('should add app shell configuration', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('app-shell', defaultOptions, appTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('app-shell', defaultOptions, appTree);
     const filePath = '/angular.json';
     const content = tree.readContent(filePath);
     const workspace = JSON.parse(content);
@@ -77,9 +73,7 @@ describe('App Shell Schematic', () => {
   });
 
   it('should add router module to client app module', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('app-shell', defaultOptions, appTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('app-shell', defaultOptions, appTree);
     const filePath = '/projects/bar/src/app/app.module.ts';
     const content = tree.readContent(filePath);
     expect(content).toMatch(/import { RouterModule } from '@angular\/router';/);
@@ -90,9 +84,7 @@ describe('App Shell Schematic', () => {
     updateRecorder.insertLeft(0, "import { RouterModule } from '@angular/router';");
     appTree.commitUpdate(updateRecorder);
 
-    const tree = await schematicRunner
-      .runSchematicAsync('app-shell', defaultOptions, appTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('app-shell', defaultOptions, appTree);
     const filePath = '/projects/bar/src/app/app.module.ts';
     const content = tree.readContent(filePath);
     expect(content).toMatch(/import { RouterModule } from '@angular\/router';/);
@@ -133,10 +125,7 @@ describe('App Shell Schematic', () => {
     it('should not re-add the router outlet (external template)', async () => {
       const htmlPath = '/projects/bar/src/app/app.component.html';
       appTree.overwrite(htmlPath, '<router-outlet></router-outlet>');
-      const tree = await schematicRunner
-        .runSchematicAsync('app-shell', defaultOptions, appTree)
-        .toPromise();
-
+      const tree = await schematicRunner.runSchematic('app-shell', defaultOptions, appTree);
       const content = tree.readContent(htmlPath);
       const matches = content.match(/<router-outlet><\/router-outlet>/g);
       const numMatches = matches ? matches.length : 0;
@@ -145,9 +134,7 @@ describe('App Shell Schematic', () => {
 
     it('should not re-add the router outlet (inline template)', async () => {
       makeInlineTemplate(appTree, '<router-outlet></router-outlet>');
-      const tree = await schematicRunner
-        .runSchematicAsync('app-shell', defaultOptions, appTree)
-        .toPromise();
+      const tree = await schematicRunner.runSchematic('app-shell', defaultOptions, appTree);
       const content = tree.readContent('/projects/bar/src/app/app.component.ts');
       const matches = content.match(/<router-outlet><\/router-outlet>/g);
       const numMatches = matches ? matches.length : 0;
@@ -156,43 +143,34 @@ describe('App Shell Schematic', () => {
   });
 
   it('should add router imports to server module', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('app-shell', defaultOptions, appTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('app-shell', defaultOptions, appTree);
     const filePath = '/projects/bar/src/app/app.server.module.ts';
     const content = tree.readContent(filePath);
     expect(content).toMatch(/import { Routes, RouterModule } from '@angular\/router';/);
   });
 
   it('should work after adding nguniversal', async () => {
-    let tree = await schematicRunner
-      .runSchematicAsync('universal', defaultOptions, appTree)
-      .toPromise();
-
+    let tree = await schematicRunner.runSchematic('universal', defaultOptions, appTree);
     // change main tsconfig to mimic ng add for nguniveral
     const workspace = JSON.parse(appTree.readContent('/angular.json'));
     workspace.projects.bar.architect.server.options.main = 'server.ts';
     appTree.overwrite('angular.json', JSON.stringify(workspace, undefined, 2));
 
-    tree = await schematicRunner.runSchematicAsync('app-shell', defaultOptions, tree).toPromise();
+    tree = await schematicRunner.runSchematic('app-shell', defaultOptions, tree);
     const filePath = '/projects/bar/src/app/app.server.module.ts';
     const content = tree.readContent(filePath);
     expect(content).toMatch(/import { Routes, RouterModule } from '@angular\/router';/);
   });
 
   it('should define a server route', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('app-shell', defaultOptions, appTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('app-shell', defaultOptions, appTree);
     const filePath = '/projects/bar/src/app/app.server.module.ts';
     const content = tree.readContent(filePath);
     expect(content).toMatch(/const routes: Routes = \[/);
   });
 
   it('should import RouterModule with forRoot', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('app-shell', defaultOptions, appTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('app-shell', defaultOptions, appTree);
     const filePath = '/projects/bar/src/app/app.server.module.ts';
     const content = tree.readContent(filePath);
     expect(content).toMatch(
@@ -202,9 +180,7 @@ describe('App Shell Schematic', () => {
   });
 
   it('should create the shell component', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('app-shell', defaultOptions, appTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('app-shell', defaultOptions, appTree);
     expect(tree.exists('/projects/bar/src/app/app-shell/app-shell.component.ts')).toBe(true);
     const content = tree.readContent('/projects/bar/src/app/app.server.module.ts');
     expect(content).toMatch(/app-shell\.component/);

--- a/packages/schematics/angular/application/index_spec.ts
+++ b/packages/schematics/angular/application/index_spec.ts
@@ -37,17 +37,14 @@ describe('Application Schematic', () => {
 
   let workspaceTree: UnitTestTree;
   beforeEach(async () => {
-    workspaceTree = await schematicRunner
-      .runSchematicAsync('workspace', workspaceOptions)
-      .toPromise();
+    workspaceTree = await schematicRunner.runSchematic('workspace', workspaceOptions);
   });
 
   it('should create all files of an application', async () => {
     const options = { ...defaultOptions };
 
-    const tree = await schematicRunner
-      .runSchematicAsync('application', options, workspaceTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('application', options, workspaceTree);
+
     const files = tree.files;
     expect(files).toEqual(
       jasmine.arrayContaining([
@@ -69,9 +66,8 @@ describe('Application Schematic', () => {
   it('should add the application to the workspace', async () => {
     const options = { ...defaultOptions };
 
-    const tree = await schematicRunner
-      .runSchematicAsync('application', options, workspaceTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('application', options, workspaceTree);
+
     const workspace = JSON.parse(tree.readContent('/angular.json'));
     expect(workspace.projects.foo).toBeDefined();
   });
@@ -79,9 +75,8 @@ describe('Application Schematic', () => {
   it('should set the prefix to app if none is set', async () => {
     const options = { ...defaultOptions };
 
-    const tree = await schematicRunner
-      .runSchematicAsync('application', options, workspaceTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('application', options, workspaceTree);
+
     const workspace = JSON.parse(tree.readContent('/angular.json'));
     expect(workspace.projects.foo.prefix).toEqual('app');
   });
@@ -89,9 +84,8 @@ describe('Application Schematic', () => {
   it('should set the prefix correctly', async () => {
     const options = { ...defaultOptions, prefix: 'pre' };
 
-    const tree = await schematicRunner
-      .runSchematicAsync('application', options, workspaceTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('application', options, workspaceTree);
+
     const workspace = JSON.parse(tree.readContent('/angular.json'));
     expect(workspace.projects.foo.prefix).toEqual('pre');
   });
@@ -99,9 +93,8 @@ describe('Application Schematic', () => {
   it('should handle the routing flag', async () => {
     const options = { ...defaultOptions, routing: true };
 
-    const tree = await schematicRunner
-      .runSchematicAsync('application', options, workspaceTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('application', options, workspaceTree);
+
     const files = tree.files;
     expect(files).toContain('/projects/foo/src/app/app.module.ts');
     expect(files).toContain('/projects/foo/src/app/app-routing.module.ts');
@@ -112,34 +105,31 @@ describe('Application Schematic', () => {
   });
 
   it('should import BrowserModule in the app module', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('application', defaultOptions, workspaceTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('application', defaultOptions, workspaceTree);
+
     const path = '/projects/foo/src/app/app.module.ts';
     const content = tree.readContent(path);
     expect(content).toMatch(/import { BrowserModule } from '@angular\/platform-browser';/);
   });
 
   it('should declare app component in the app module', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('application', defaultOptions, workspaceTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('application', defaultOptions, workspaceTree);
+
     const path = '/projects/foo/src/app/app.module.ts';
     const content = tree.readContent(path);
     expect(content).toMatch(/import { AppComponent } from '\.\/app\.component';/);
   });
 
   it(`should set 'defaultEncapsulation' in main.ts when 'ViewEncapsulation' is provided`, async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync(
-        'application',
-        {
-          ...defaultOptions,
-          viewEncapsulation: ViewEncapsulation.ShadowDom,
-        },
-        workspaceTree,
-      )
-      .toPromise();
+    const tree = await schematicRunner.runSchematic(
+      'application',
+      {
+        ...defaultOptions,
+        viewEncapsulation: ViewEncapsulation.ShadowDom,
+      },
+      workspaceTree,
+    );
+
     const path = '/projects/foo/src/main.ts';
     const content = tree.readContent(path);
     expect(content).toContain('defaultEncapsulation: ViewEncapsulation.ShadowDom');
@@ -147,27 +137,24 @@ describe('Application Schematic', () => {
   });
 
   it('should set the right paths in the tsconfig.app.json', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('application', defaultOptions, workspaceTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('application', defaultOptions, workspaceTree);
+
     const { files, extends: _extends } = readJsonFile(tree, '/projects/foo/tsconfig.app.json');
     expect(files).toEqual(['src/main.ts']);
     expect(_extends).toBe('../../tsconfig.json');
   });
 
   it('should set the right paths in the tsconfig.spec.json', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('application', defaultOptions, workspaceTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('application', defaultOptions, workspaceTree);
+
     const { extends: _extends } = readJsonFile(tree, '/projects/foo/tsconfig.spec.json');
     expect(_extends).toBe('../../tsconfig.json');
   });
 
   it('should set the skipTests flag for other schematics when using --skipTests=true', async () => {
     const options: ApplicationOptions = { ...defaultOptions, skipTests: true };
-    const tree = await schematicRunner
-      .runSchematicAsync('application', options, workspaceTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('application', options, workspaceTree);
+
     const config = JSON.parse(tree.readContent('/angular.json'));
     const schematics = config.projects.foo.schematics;
 
@@ -183,9 +170,8 @@ describe('Application Schematic', () => {
 
   it('minimal=true should not create e2e and test targets', async () => {
     const options = { ...defaultOptions, minimal: true };
-    const tree = await schematicRunner
-      .runSchematicAsync('application', options, workspaceTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('application', options, workspaceTree);
+
     const config = JSON.parse(tree.readContent('/angular.json'));
     const architect = config.projects.foo.architect;
     expect(architect.test).not.toBeDefined();
@@ -194,9 +180,8 @@ describe('Application Schematic', () => {
 
   it('minimal=true should configure the schematics options for components', async () => {
     const options = { ...defaultOptions, minimal: true };
-    const tree = await schematicRunner
-      .runSchematicAsync('application', options, workspaceTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('application', options, workspaceTree);
+
     const config = JSON.parse(tree.readContent('/angular.json'));
     const schematics = config.projects.foo.schematics;
     expect(schematics['@schematics/angular:component']).toEqual({
@@ -208,9 +193,8 @@ describe('Application Schematic', () => {
 
   it('minimal=true allows inlineStyle=false when configuring the schematics options for components', async () => {
     const options = { ...defaultOptions, minimal: true, inlineStyle: false };
-    const tree = await schematicRunner
-      .runSchematicAsync('application', options, workspaceTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('application', options, workspaceTree);
+
     const config = JSON.parse(tree.readContent('/angular.json'));
     const schematics = config.projects.foo.schematics;
     expect(schematics['@schematics/angular:component']).toEqual({
@@ -221,9 +205,8 @@ describe('Application Schematic', () => {
 
   it('minimal=true allows inlineTemplate=false when configuring the schematics options for components', async () => {
     const options = { ...defaultOptions, minimal: true, inlineTemplate: false };
-    const tree = await schematicRunner
-      .runSchematicAsync('application', options, workspaceTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('application', options, workspaceTree);
+
     const config = JSON.parse(tree.readContent('/angular.json'));
     const schematics = config.projects.foo.schematics;
     expect(schematics['@schematics/angular:component']).toEqual({
@@ -234,9 +217,8 @@ describe('Application Schematic', () => {
 
   it('should create correct files when using minimal', async () => {
     const options = { ...defaultOptions, minimal: true };
-    const tree = await schematicRunner
-      .runSchematicAsync('application', options, workspaceTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('application', options, workspaceTree);
+
     const files = tree.files;
     [
       '/projects/foo/tsconfig.spec.json',
@@ -260,9 +242,8 @@ describe('Application Schematic', () => {
 
   it('should create correct files when using minimal and inlineStyle=false', async () => {
     const options = { ...defaultOptions, minimal: true, inlineStyle: false };
-    const tree = await schematicRunner
-      .runSchematicAsync('application', options, workspaceTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('application', options, workspaceTree);
+
     const files = tree.files;
     [
       '/projects/foo/tsconfig.spec.json',
@@ -288,9 +269,8 @@ describe('Application Schematic', () => {
 
   it('should create correct files when using minimal and inlineTemplate=false', async () => {
     const options = { ...defaultOptions, minimal: true, inlineTemplate: false };
-    const tree = await schematicRunner
-      .runSchematicAsync('application', options, workspaceTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('application', options, workspaceTree);
+
     const files = tree.files;
     [
       '/projects/foo/tsconfig.spec.json',
@@ -316,9 +296,7 @@ describe('Application Schematic', () => {
 
   describe(`update package.json`, () => {
     it(`should add build-angular to devDependencies`, async () => {
-      const tree = await schematicRunner
-        .runSchematicAsync('application', defaultOptions, workspaceTree)
-        .toPromise();
+      const tree = await schematicRunner.runSchematic('application', defaultOptions, workspaceTree);
 
       const packageJson = JSON.parse(tree.readContent('package.json'));
       expect(packageJson.devDependencies['@angular-devkit/build-angular']).toEqual(
@@ -327,9 +305,8 @@ describe('Application Schematic', () => {
     });
 
     it('should use the latest known versions in package.json', async () => {
-      const tree = await schematicRunner
-        .runSchematicAsync('application', defaultOptions, workspaceTree)
-        .toPromise();
+      const tree = await schematicRunner.runSchematic('application', defaultOptions, workspaceTree);
+
       const pkg = JSON.parse(tree.readContent('/package.json'));
       expect(pkg.devDependencies['@angular/compiler-cli']).toEqual(latestVersions.Angular);
       expect(pkg.devDependencies['typescript']).toEqual(latestVersions['typescript']);
@@ -345,24 +322,21 @@ describe('Application Schematic', () => {
         ),
       );
 
-      const tree = await schematicRunner
-        .runSchematicAsync('application', defaultOptions, workspaceTree)
-        .toPromise();
+      const tree = await schematicRunner.runSchematic('application', defaultOptions, workspaceTree);
+
       const packageJson = JSON.parse(tree.readContent('package.json'));
       expect(packageJson.devDependencies.typescript).toEqual('~2.5.2');
     });
 
     it(`should not modify the file when --skipPackageJson`, async () => {
-      const tree = await schematicRunner
-        .runSchematicAsync(
-          'application',
-          {
-            name: 'foo',
-            skipPackageJson: true,
-          },
-          workspaceTree,
-        )
-        .toPromise();
+      const tree = await schematicRunner.runSchematic(
+        'application',
+        {
+          name: 'foo',
+          skipPackageJson: true,
+        },
+        workspaceTree,
+      );
 
       const packageJson = JSON.parse(tree.readContent('package.json'));
       expect(packageJson.devDependencies['@angular-devkit/build-angular']).toBeUndefined();
@@ -373,9 +347,8 @@ describe('Application Schematic', () => {
     it('should put app files in the right spot', async () => {
       const options = { ...defaultOptions, projectRoot: '' };
 
-      const tree = await schematicRunner
-        .runSchematicAsync('application', options, workspaceTree)
-        .toPromise();
+      const tree = await schematicRunner.runSchematic('application', options, workspaceTree);
+
       const files = tree.files;
       expect(files).toEqual(
         jasmine.arrayContaining([
@@ -397,9 +370,8 @@ describe('Application Schematic', () => {
     it('should set values in angular.json correctly', async () => {
       const options = { ...defaultOptions, projectRoot: '' };
 
-      const tree = await schematicRunner
-        .runSchematicAsync('application', options, workspaceTree)
-        .toPromise();
+      const tree = await schematicRunner.runSchematic('application', options, workspaceTree);
+
       const config = JSON.parse(tree.readContent('/angular.json'));
       const prj = config.projects.foo;
       expect(prj.root).toEqual('');
@@ -417,9 +389,8 @@ describe('Application Schematic', () => {
 
     it('should set values in angular.json correctly when using a style preprocessor', async () => {
       const options = { ...defaultOptions, projectRoot: '', style: Style.Sass };
-      const tree = await schematicRunner
-        .runSchematicAsync('application', options, workspaceTree)
-        .toPromise();
+      const tree = await schematicRunner.runSchematic('application', options, workspaceTree);
+
       const config = JSON.parse(tree.readContent('/angular.json'));
       const prj = config.projects.foo;
       const buildOpt = prj.architect.build.options;
@@ -431,9 +402,8 @@ describe('Application Schematic', () => {
 
     it('sets "inlineStyleLanguage" in angular.json when using a style preprocessor', async () => {
       const options = { ...defaultOptions, projectRoot: '', style: Style.Sass };
-      const tree = await schematicRunner
-        .runSchematicAsync('application', options, workspaceTree)
-        .toPromise();
+      const tree = await schematicRunner.runSchematic('application', options, workspaceTree);
+
       const config = JSON.parse(tree.readContent('/angular.json'));
       const prj = config.projects.foo;
 
@@ -446,9 +416,8 @@ describe('Application Schematic', () => {
 
     it('does not set "inlineStyleLanguage" in angular.json when not using a style preprocessor', async () => {
       const options = { ...defaultOptions, projectRoot: '' };
-      const tree = await schematicRunner
-        .runSchematicAsync('application', options, workspaceTree)
-        .toPromise();
+      const tree = await schematicRunner.runSchematic('application', options, workspaceTree);
+
       const config = JSON.parse(tree.readContent('/angular.json'));
       const prj = config.projects.foo;
 
@@ -461,9 +430,8 @@ describe('Application Schematic', () => {
 
     it('does not set "inlineStyleLanguage" in angular.json when using CSS styles', async () => {
       const options = { ...defaultOptions, projectRoot: '', style: Style.Css };
-      const tree = await schematicRunner
-        .runSchematicAsync('application', options, workspaceTree)
-        .toPromise();
+      const tree = await schematicRunner.runSchematic('application', options, workspaceTree);
+
       const config = JSON.parse(tree.readContent('/angular.json'));
       const prj = config.projects.foo;
 
@@ -476,9 +444,8 @@ describe('Application Schematic', () => {
 
     it('should set the relative tsconfig paths', async () => {
       const options = { ...defaultOptions, projectRoot: '' };
-      const tree = await schematicRunner
-        .runSchematicAsync('application', options, workspaceTree)
-        .toPromise();
+      const tree = await schematicRunner.runSchematic('application', options, workspaceTree);
+
       const appTsConfig = readJsonFile(tree, '/tsconfig.app.json');
       expect(appTsConfig.extends).toEqual('./tsconfig.json');
       const specTsConfig = readJsonFile(tree, '/tsconfig.spec.json');
@@ -486,14 +453,14 @@ describe('Application Schematic', () => {
     });
 
     it(`should create correct paths when 'newProjectRoot' is blank`, async () => {
-      const workspaceTree = await schematicRunner
-        .runSchematicAsync('workspace', { ...workspaceOptions, newProjectRoot: '' })
-        .toPromise();
+      const workspaceTree = await schematicRunner.runSchematic('workspace', {
+        ...workspaceOptions,
+        newProjectRoot: '',
+      });
 
       const options = { ...defaultOptions, projectRoot: undefined };
-      const tree = await schematicRunner
-        .runSchematicAsync('application', options, workspaceTree)
-        .toPromise();
+      const tree = await schematicRunner.runSchematic('application', options, workspaceTree);
+
       const config = JSON.parse(tree.readContent('/angular.json'));
       const project = config.projects.foo;
       expect(project.root).toEqual('foo');
@@ -512,45 +479,39 @@ describe('Application Schematic', () => {
 
   it(`should create kebab-case project folder names with camelCase project name`, async () => {
     const options: ApplicationOptions = { ...defaultOptions, name: 'myCool' };
-    const tree = await schematicRunner
-      .runSchematicAsync('application', options, workspaceTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('application', options, workspaceTree);
+
     const exists = tree.exists('/projects/my-cool/tsconfig.app.json');
     expect(exists).toBeTrue();
   });
 
   it(`should create scoped kebab-case project folder names with camelCase project name`, async () => {
     const options: ApplicationOptions = { ...defaultOptions, name: '@foo/myCool' };
-    const tree = await schematicRunner
-      .runSchematicAsync('application', options, workspaceTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('application', options, workspaceTree);
+
     const exists = tree.exists('/projects/foo/my-cool/tsconfig.app.json');
     expect(exists).toBeTrue();
   });
 
   it(`should create kebab-case project folder names with PascalCase project name`, async () => {
     const options: ApplicationOptions = { ...defaultOptions, name: 'MyCool' };
-    const tree = await schematicRunner
-      .runSchematicAsync('application', options, workspaceTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('application', options, workspaceTree);
+
     const exists = tree.exists('/projects/my-cool/tsconfig.app.json');
     expect(exists).toBeTrue();
   });
 
   it(`should create scoped kebab-case project folder names with PascalCase project name`, async () => {
     const options: ApplicationOptions = { ...defaultOptions, name: '@foo/MyCool' };
-    const tree = await schematicRunner
-      .runSchematicAsync('application', options, workspaceTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('application', options, workspaceTree);
+
     const exists = tree.exists('/projects/foo/my-cool/tsconfig.app.json');
     expect(exists).toBeTrue();
   });
 
   it('should support creating applications with `_` and `.` in name', async () => {
     const options = { ...defaultOptions, name: 'foo.bar_buz' };
-    const tree = await schematicRunner
-      .runSchematicAsync('application', options, workspaceTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('application', options, workspaceTree);
 
     expect(tree.exists('/projects/foo.bar_buz/tsconfig.app.json')).toBeTrue();
   });
@@ -558,9 +519,7 @@ describe('Application Schematic', () => {
   it('should support creating scoped application', async () => {
     const scopedName = '@myscope/myapp';
     const options = { ...defaultOptions, name: scopedName };
-    const tree = await schematicRunner
-      .runSchematicAsync('application', options, workspaceTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('application', options, workspaceTree);
 
     const cfg = JSON.parse(tree.readContent('/angular.json'));
     expect(cfg.projects['@myscope/myapp']).toBeDefined();

--- a/packages/schematics/angular/class/index_spec.ts
+++ b/packages/schematics/angular/class/index_spec.ts
@@ -39,16 +39,13 @@ describe('Class Schematic', () => {
   };
   let appTree: UnitTestTree;
   beforeEach(async () => {
-    appTree = await schematicRunner.runSchematicAsync('workspace', workspaceOptions).toPromise();
-    appTree = await schematicRunner
-      .runSchematicAsync('application', appOptions, appTree)
-      .toPromise();
+    appTree = await schematicRunner.runSchematic('workspace', workspaceOptions);
+    appTree = await schematicRunner.runSchematic('application', appOptions, appTree);
   });
 
   it('should create just the class file', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('class', defaultOptions, appTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('class', defaultOptions, appTree);
+
     expect(tree.files).toContain('/projects/bar/src/app/foo.ts');
     expect(tree.files).not.toContain('/projects/bar/src/app/foo.spec.ts');
   });
@@ -58,15 +55,14 @@ describe('Class Schematic', () => {
       ...defaultOptions,
       skipTests: false,
     };
-    const tree = await schematicRunner.runSchematicAsync('class', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('class', options, appTree);
     expect(tree.files).toContain('/projects/bar/src/app/foo.ts');
     expect(tree.files).toContain('/projects/bar/src/app/foo.spec.ts');
   });
 
   it('should create an class named "Foo"', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('class', defaultOptions, appTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('class', defaultOptions, appTree);
+
     const fileContent = tree.readContent('/projects/bar/src/app/foo.ts');
     expect(fileContent).toMatch(/export class Foo/);
   });
@@ -74,13 +70,13 @@ describe('Class Schematic', () => {
   it('should put type in the file name', async () => {
     const options = { ...defaultOptions, type: 'model' };
 
-    const tree = await schematicRunner.runSchematicAsync('class', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('class', options, appTree);
     expect(tree.files).toContain('/projects/bar/src/app/foo.model.ts');
   });
 
   it('should split the name to name & type with split on "."', async () => {
     const options = { ...defaultOptions, name: 'foo.model' };
-    const tree = await schematicRunner.runSchematicAsync('class', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('class', options, appTree);
     const classPath = '/projects/bar/src/app/foo.model.ts';
     const content = tree.readContent(classPath);
     expect(content).toMatch(/export class FooModel/);
@@ -88,7 +84,7 @@ describe('Class Schematic', () => {
 
   it('should respect the path option', async () => {
     const options = { ...defaultOptions, path: 'zzz' };
-    const tree = await schematicRunner.runSchematicAsync('class', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('class', options, appTree);
     expect(tree.files).toContain('/zzz/foo.ts');
   });
 
@@ -96,7 +92,7 @@ describe('Class Schematic', () => {
     const config = JSON.parse(appTree.readContent('/angular.json'));
     config.projects.bar.sourceRoot = 'projects/bar/custom';
     appTree.overwrite('/angular.json', JSON.stringify(config, null, 2));
-    appTree = await schematicRunner.runSchematicAsync('class', defaultOptions, appTree).toPromise();
+    appTree = await schematicRunner.runSchematic('class', defaultOptions, appTree);
     expect(appTree.files).toContain('/projects/bar/custom/app/foo.ts');
   });
 
@@ -105,7 +101,7 @@ describe('Class Schematic', () => {
       ...defaultOptions,
       skipTests: true,
     };
-    const tree = await schematicRunner.runSchematicAsync('class', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('class', options, appTree);
     expect(tree.files).toContain('/projects/bar/src/app/foo.ts');
     expect(tree.files).not.toContain('/projects/bar/src/app/foo.spec.ts');
   });
@@ -114,7 +110,7 @@ describe('Class Schematic', () => {
     const options = { ...defaultOptions, name: '1Clazz' };
 
     await expectAsync(
-      schematicRunner.runSchematicAsync('class', options, appTree).toPromise(),
+      schematicRunner.runSchematic('class', options, appTree),
     ).toBeRejectedWithError('Class name "1Clazz" is invalid.');
   });
 });

--- a/packages/schematics/angular/component/index_spec.ts
+++ b/packages/schematics/angular/component/index_spec.ts
@@ -49,15 +49,13 @@ describe('Component Schematic', () => {
   };
   let appTree: UnitTestTree;
   beforeEach(async () => {
-    appTree = await schematicRunner.runSchematicAsync('workspace', workspaceOptions).toPromise();
-    appTree = await schematicRunner
-      .runSchematicAsync('application', appOptions, appTree)
-      .toPromise();
+    appTree = await schematicRunner.runSchematic('workspace', workspaceOptions);
+    appTree = await schematicRunner.runSchematic('application', appOptions, appTree);
   });
 
   it('should create a component', async () => {
     const options = { ...defaultOptions };
-    const tree = await schematicRunner.runSchematicAsync('component', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('component', options, appTree);
     const files = tree.files;
     expect(files).toEqual(
       jasmine.arrayContaining([
@@ -75,7 +73,7 @@ describe('Component Schematic', () => {
   it('should set change detection to OnPush', async () => {
     const options = { ...defaultOptions, changeDetection: 'OnPush' };
 
-    const tree = await schematicRunner.runSchematicAsync('component', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('component', options, appTree);
     const tsContent = tree.readContent('/projects/bar/src/app/foo/foo.component.ts');
     expect(tsContent).toMatch(/changeDetection: ChangeDetectionStrategy.OnPush/);
   });
@@ -83,7 +81,7 @@ describe('Component Schematic', () => {
   it('should not set view encapsulation', async () => {
     const options = { ...defaultOptions };
 
-    const tree = await schematicRunner.runSchematicAsync('component', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('component', options, appTree);
     const tsContent = tree.readContent('/projects/bar/src/app/foo/foo.component.ts');
     expect(tsContent).not.toMatch(/encapsulation: ViewEncapsulation/);
   });
@@ -91,7 +89,7 @@ describe('Component Schematic', () => {
   it('should set view encapsulation to Emulated', async () => {
     const options = { ...defaultOptions, viewEncapsulation: 'Emulated' };
 
-    const tree = await schematicRunner.runSchematicAsync('component', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('component', options, appTree);
     const tsContent = tree.readContent('/projects/bar/src/app/foo/foo.component.ts');
     expect(tsContent).toMatch(/encapsulation: ViewEncapsulation.Emulated/);
   });
@@ -99,7 +97,7 @@ describe('Component Schematic', () => {
   it('should set view encapsulation to None', async () => {
     const options = { ...defaultOptions, viewEncapsulation: 'None' };
 
-    const tree = await schematicRunner.runSchematicAsync('component', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('component', options, appTree);
     const tsContent = tree.readContent('/projects/bar/src/app/foo/foo.component.ts');
     expect(tsContent).toMatch(/encapsulation: ViewEncapsulation.None/);
   });
@@ -107,7 +105,7 @@ describe('Component Schematic', () => {
   it('should create a flat component', async () => {
     const options = { ...defaultOptions, flat: true };
 
-    const tree = await schematicRunner.runSchematicAsync('component', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('component', options, appTree);
     const files = tree.files;
     expect(files).toEqual(
       jasmine.arrayContaining([
@@ -135,7 +133,7 @@ describe('Component Schematic', () => {
     `,
     );
 
-    const tree = await schematicRunner.runSchematicAsync('component', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('component', options, appTree);
     const fooModuleContent = tree.readContent(fooModule);
     expect(fooModuleContent).toMatch(/import { FooComponent } from '.\/foo.component'/);
   });
@@ -143,7 +141,7 @@ describe('Component Schematic', () => {
   it('should export the component', async () => {
     const options = { ...defaultOptions, export: true };
 
-    const tree = await schematicRunner.runSchematicAsync('component', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('component', options, appTree);
     const appModuleContent = tree.readContent('/projects/bar/src/app/app.module.ts');
     expect(appModuleContent).toMatch(/exports: \[\n(\s*) {2}FooComponent\n\1\]/);
   });
@@ -151,7 +149,7 @@ describe('Component Schematic', () => {
   it('should import into a specified module', async () => {
     const options = { ...defaultOptions, module: 'app.module.ts' };
 
-    const tree = await schematicRunner.runSchematicAsync('component', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('component', options, appTree);
     const appModule = tree.readContent('/projects/bar/src/app/app.module.ts');
 
     expect(appModule).toMatch(/import { FooComponent } from '.\/foo\/foo.component'/);
@@ -160,16 +158,14 @@ describe('Component Schematic', () => {
   it('should fail if specified module does not exist', async () => {
     const options = { ...defaultOptions, module: '/projects/bar/src/app.moduleXXX.ts' };
 
-    await expectAsync(
-      schematicRunner.runSchematicAsync('component', options, appTree).toPromise(),
-    ).toBeRejected();
+    await expectAsync(schematicRunner.runSchematic('component', options, appTree)).toBeRejected();
   });
 
   it('should handle upper case paths', async () => {
     const pathOption = 'projects/bar/src/app/SOME/UPPER/DIR';
     const options = { ...defaultOptions, path: pathOption };
 
-    const tree = await schematicRunner.runSchematicAsync('component', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('component', options, appTree);
     let files = tree.files;
     let root = `/${pathOption}/foo/foo.component`;
     expect(files).toEqual(
@@ -177,7 +173,7 @@ describe('Component Schematic', () => {
     );
 
     const options2 = { ...options, name: 'BAR' };
-    const tree2 = await schematicRunner.runSchematicAsync('component', options2, tree).toPromise();
+    const tree2 = await schematicRunner.runSchematic('component', options2, tree);
     files = tree2.files;
     root = `/${pathOption}/bar/bar.component`;
     expect(files).toEqual(
@@ -188,7 +184,7 @@ describe('Component Schematic', () => {
   it('should create a component in a sub-directory', async () => {
     const options = { ...defaultOptions, path: 'projects/bar/src/app/a/b/c' };
 
-    const tree = await schematicRunner.runSchematicAsync('component', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('component', options, appTree);
     const files = tree.files;
     const root = `/${options.path}/foo/foo.component`;
     expect(files).toEqual(
@@ -199,7 +195,7 @@ describe('Component Schematic', () => {
   it('should use the prefix', async () => {
     const options = { ...defaultOptions, prefix: 'pre' };
 
-    const tree = await schematicRunner.runSchematicAsync('component', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('component', options, appTree);
     const content = tree.readContent('/projects/bar/src/app/foo/foo.component.ts');
     expect(content).toMatch(/selector: 'pre-foo'/);
   });
@@ -208,14 +204,14 @@ describe('Component Schematic', () => {
     const options = { ...defaultOptions, name: '1-one' };
 
     await expectAsync(
-      schematicRunner.runSchematicAsync('component', options, appTree).toPromise(),
+      schematicRunner.runSchematic('component', options, appTree),
     ).toBeRejectedWithError('Selector "app-1-one" is invalid.');
   });
 
   it('should use the default project prefix if none is passed', async () => {
     const options = { ...defaultOptions, prefix: undefined };
 
-    const tree = await schematicRunner.runSchematicAsync('component', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('component', options, appTree);
     const content = tree.readContent('/projects/bar/src/app/foo/foo.component.ts');
     expect(content).toMatch(/selector: 'app-foo'/);
   });
@@ -223,14 +219,14 @@ describe('Component Schematic', () => {
   it('should use the supplied prefix if it is ""', async () => {
     const options = { ...defaultOptions, prefix: '' };
 
-    const tree = await schematicRunner.runSchematicAsync('component', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('component', options, appTree);
     const content = tree.readContent('/projects/bar/src/app/foo/foo.component.ts');
     expect(content).toMatch(/selector: 'foo'/);
   });
 
   it('should respect the inlineTemplate option', async () => {
     const options = { ...defaultOptions, inlineTemplate: true };
-    const tree = await schematicRunner.runSchematicAsync('component', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('component', options, appTree);
     const content = tree.readContent('/projects/bar/src/app/foo/foo.component.ts');
     expect(content).toMatch(/template: /);
     expect(content).not.toMatch(/templateUrl: /);
@@ -239,7 +235,7 @@ describe('Component Schematic', () => {
 
   it('should respect the inlineStyle option', async () => {
     const options = { ...defaultOptions, inlineStyle: true };
-    const tree = await schematicRunner.runSchematicAsync('component', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('component', options, appTree);
     const content = tree.readContent('/projects/bar/src/app/foo/foo.component.ts');
     expect(content).toMatch(/styles: \[/);
     expect(content).not.toMatch(/styleUrls: /);
@@ -248,35 +244,35 @@ describe('Component Schematic', () => {
 
   it('should respect the displayBlock option when inlineStyle is `false`', async () => {
     const options = { ...defaultOptions, displayBlock: true };
-    const tree = await schematicRunner.runSchematicAsync('component', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('component', options, appTree);
     const content = tree.readContent('/projects/bar/src/app/foo/foo.component.css');
     expect(content).toMatch(/:host {\r?\n {2}display: block;\r?\n}/);
   });
 
   it('should respect the displayBlock option when inlineStyle is `false` and use correct syntax for `scss`', async () => {
     const options = { ...defaultOptions, displayBlock: true, style: 'scss' };
-    const tree = await schematicRunner.runSchematicAsync('component', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('component', options, appTree);
     const content = tree.readContent('/projects/bar/src/app/foo/foo.component.scss');
     expect(content).toMatch(/:host {\r?\n {2}display: block;\r?\n}/);
   });
 
   it('should respect the displayBlock option when inlineStyle is `false` and use correct syntax for `sass', async () => {
     const options = { ...defaultOptions, displayBlock: true, style: 'sass' };
-    const tree = await schematicRunner.runSchematicAsync('component', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('component', options, appTree);
     const content = tree.readContent('/projects/bar/src/app/foo/foo.component.sass');
     expect(content).toMatch(/\\:host\r?\n {2}display: block;\r?\n/);
   });
 
   it('should respect the displayBlock option when inlineStyle is `true`', async () => {
     const options = { ...defaultOptions, displayBlock: true, inlineStyle: true };
-    const tree = await schematicRunner.runSchematicAsync('component', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('component', options, appTree);
     const content = tree.readContent('/projects/bar/src/app/foo/foo.component.ts');
     expect(content).toMatch(/:host {\r?\n(\s*)display: block;(\s*)}\r?\n/);
   });
 
   it('should respect the style option', async () => {
     const options = { ...defaultOptions, style: Style.Sass };
-    const tree = await schematicRunner.runSchematicAsync('component', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('component', options, appTree);
     const content = tree.readContent('/projects/bar/src/app/foo/foo.component.ts');
     expect(content).toMatch(/styleUrls: \['.\/foo.component.sass/);
     expect(tree.files).toContain('/projects/bar/src/app/foo/foo.component.sass');
@@ -285,7 +281,7 @@ describe('Component Schematic', () => {
 
   it('should respect the style=none option', async () => {
     const options = { ...defaultOptions, style: Style.None };
-    const tree = await schematicRunner.runSchematicAsync('component', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('component', options, appTree);
     const content = tree.readContent('/projects/bar/src/app/foo/foo.component.ts');
     expect(content).not.toMatch(/styleUrls: /);
     expect(tree.files).not.toContain('/projects/bar/src/app/foo/foo.component.css');
@@ -294,7 +290,7 @@ describe('Component Schematic', () => {
 
   it('should respect the type option', async () => {
     const options = { ...defaultOptions, type: 'Route' };
-    const tree = await schematicRunner.runSchematicAsync('component', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('component', options, appTree);
     const content = tree.readContent('/projects/bar/src/app/foo/foo.route.ts');
     const testContent = tree.readContent('/projects/bar/src/app/foo/foo.route.spec.ts');
     expect(content).toContain('export class FooRoute');
@@ -305,7 +301,7 @@ describe('Component Schematic', () => {
 
   it('should allow empty string in the type option', async () => {
     const options = { ...defaultOptions, type: '' };
-    const tree = await schematicRunner.runSchematicAsync('component', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('component', options, appTree);
     const content = tree.readContent('/projects/bar/src/app/foo/foo.ts');
     const testContent = tree.readContent('/projects/bar/src/app/foo/foo.spec.ts');
     expect(content).toContain('export class Foo');
@@ -319,7 +315,7 @@ describe('Component Schematic', () => {
     const routingModulePath = `/projects/bar/src/app/${routingFileName}`;
     const newTree = createAppModule(appTree, routingModulePath);
     const options = { ...defaultOptions, module: routingFileName };
-    const tree = await schematicRunner.runSchematicAsync('component', options, newTree).toPromise();
+    const tree = await schematicRunner.runSchematic('component', options, newTree);
     const content = tree.readContent(routingModulePath);
     expect(content).toMatch(/import { FooComponent } from '.\/foo\/foo.component/);
   });
@@ -327,7 +323,7 @@ describe('Component Schematic', () => {
   it('should handle a path in the name option', async () => {
     const options = { ...defaultOptions, name: 'dir/test-component' };
 
-    const tree = await schematicRunner.runSchematicAsync('component', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('component', options, appTree);
     const content = tree.readContent('/projects/bar/src/app/app.module.ts');
     expect(content).toMatch(
       /import { TestComponentComponent } from '\.\/dir\/test-component\/test-component.component'/,
@@ -335,12 +331,14 @@ describe('Component Schematic', () => {
   });
 
   it('should handle a path in the name and module options', async () => {
-    appTree = await schematicRunner
-      .runSchematicAsync('module', { name: 'admin/module', project: 'bar' }, appTree)
-      .toPromise();
+    appTree = await schematicRunner.runSchematic(
+      'module',
+      { name: 'admin/module', project: 'bar' },
+      appTree,
+    );
 
     const options = { ...defaultOptions, name: 'other/test-component', module: 'admin/module' };
-    appTree = await schematicRunner.runSchematicAsync('component', options, appTree).toPromise();
+    appTree = await schematicRunner.runSchematic('component', options, appTree);
 
     const content = appTree.readContent('/projects/bar/src/app/admin/module/module.module.ts');
     expect(content).toMatch(
@@ -350,14 +348,14 @@ describe('Component Schematic', () => {
 
   it('should create the right selector with a path in the name', async () => {
     const options = { ...defaultOptions, name: 'sub/test' };
-    appTree = await schematicRunner.runSchematicAsync('component', options, appTree).toPromise();
+    appTree = await schematicRunner.runSchematic('component', options, appTree);
     const content = appTree.readContent('/projects/bar/src/app/sub/test/test.component.ts');
     expect(content).toMatch(/selector: 'app-test'/);
   });
 
   it('should respect the skipSelector option', async () => {
     const options = { ...defaultOptions, name: 'sub/test', skipSelector: true };
-    appTree = await schematicRunner.runSchematicAsync('component', options, appTree).toPromise();
+    appTree = await schematicRunner.runSchematic('component', options, appTree);
     const content = appTree.readContent('/projects/bar/src/app/sub/test/test.component.ts');
     expect(content).not.toMatch(/selector: 'app-test'/);
   });
@@ -369,20 +367,19 @@ describe('Component Schematic', () => {
 
     // should fail without a module in that dir
     await expectAsync(
-      schematicRunner.runSchematicAsync('component', defaultOptions, appTree).toPromise(),
+      schematicRunner.runSchematic('component', defaultOptions, appTree),
     ).toBeRejected();
 
     // move the module
     appTree.rename('/projects/bar/src/app/app.module.ts', '/projects/bar/custom/app/app.module.ts');
-    appTree = await schematicRunner
-      .runSchematicAsync('component', defaultOptions, appTree)
-      .toPromise();
+    appTree = await schematicRunner.runSchematic('component', defaultOptions, appTree);
+
     expect(appTree.files).toContain('/projects/bar/custom/app/foo/foo.component.ts');
   });
 
   it('should respect the skipTests option', async () => {
     const options = { ...defaultOptions, skipTests: true };
-    const tree = await schematicRunner.runSchematicAsync('component', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('component', options, appTree);
     const files = tree.files;
 
     expect(files).toEqual(
@@ -397,7 +394,7 @@ describe('Component Schematic', () => {
 
   it('should respect templateUrl when style=none and changeDetection=OnPush', async () => {
     const options = { ...defaultOptions, style: Style.None, changeDetection: 'OnPush' };
-    const tree = await schematicRunner.runSchematicAsync('component', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('component', options, appTree);
     const content = tree.readContent('/projects/bar/src/app/foo/foo.component.ts');
     expect(content).not.toMatch(/styleUrls: /);
     expect(content).toMatch(/templateUrl: '.\/foo.component.html',\n/);
@@ -411,7 +408,7 @@ describe('Component Schematic', () => {
       changeDetection: 'OnPush',
       inlineTemplate: true,
     };
-    const tree = await schematicRunner.runSchematicAsync('component', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('component', options, appTree);
     const content = tree.readContent('/projects/bar/src/app/foo/foo.component.ts');
     expect(content).not.toMatch(/styleUrls: /);
     expect(content).toMatch(/template: `(\n(.|)*){3}\n\s*`,\n/);
@@ -420,7 +417,7 @@ describe('Component Schematic', () => {
 
   it('should create a standalone component', async () => {
     const options = { ...defaultOptions, standalone: true };
-    const tree = await schematicRunner.runSchematicAsync('component', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('component', options, appTree);
     const moduleContent = tree.readContent('/projects/bar/src/app/app.module.ts');
     const componentContent = tree.readContent('/projects/bar/src/app/foo/foo.component.ts');
     expect(componentContent).toContain('@angular/common');
@@ -432,7 +429,7 @@ describe('Component Schematic', () => {
 
   it('should declare standalone components in the `imports` of a test', async () => {
     const options = { ...defaultOptions, standalone: true };
-    const tree = await schematicRunner.runSchematicAsync('component', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('component', options, appTree);
     const testContent = tree.readContent('/projects/bar/src/app/foo/foo.component.spec.ts');
     expect(testContent).toContain('imports: [ FooComponent ]');
     expect(testContent).not.toContain('declarations');

--- a/packages/schematics/angular/directive/index_spec.ts
+++ b/packages/schematics/angular/directive/index_spec.ts
@@ -41,16 +41,14 @@ describe('Directive Schematic', () => {
   };
   let appTree: UnitTestTree;
   beforeEach(async () => {
-    appTree = await schematicRunner.runSchematicAsync('workspace', workspaceOptions).toPromise();
-    appTree = await schematicRunner
-      .runSchematicAsync('application', appOptions, appTree)
-      .toPromise();
+    appTree = await schematicRunner.runSchematic('workspace', workspaceOptions);
+    appTree = await schematicRunner.runSchematic('application', appOptions, appTree);
   });
 
   it('should create a directive', async () => {
     const options = { ...defaultOptions };
 
-    const tree = await schematicRunner.runSchematicAsync('directive', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('directive', options, appTree);
     const files = tree.files;
     expect(files).toContain('/projects/bar/src/app/foo.directive.spec.ts');
     expect(files).toContain('/projects/bar/src/app/foo.directive.ts');
@@ -62,7 +60,7 @@ describe('Directive Schematic', () => {
   it('should create respect the flat flag', async () => {
     const options = { ...defaultOptions, flat: false };
 
-    const tree = await schematicRunner.runSchematicAsync('directive', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('directive', options, appTree);
     const files = tree.files;
     expect(files).toContain('/projects/bar/src/app/foo/foo.directive.spec.ts');
     expect(files).toContain('/projects/bar/src/app/foo/foo.directive.ts');
@@ -84,7 +82,7 @@ describe('Directive Schematic', () => {
     `,
     );
 
-    const tree = await schematicRunner.runSchematicAsync('directive', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('directive', options, appTree);
     const fooModuleContent = tree.readContent(fooModule);
     expect(fooModuleContent).toMatch(/import { FooDirective } from '.\/foo.directive'/);
   });
@@ -92,7 +90,7 @@ describe('Directive Schematic', () => {
   it('should export the directive', async () => {
     const options = { ...defaultOptions, export: true };
 
-    const tree = await schematicRunner.runSchematicAsync('directive', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('directive', options, appTree);
     const appModuleContent = tree.readContent('/projects/bar/src/app/app.module.ts');
     expect(appModuleContent).toMatch(/exports: \[\n(\s*) {2}FooDirective\n\1\]/);
   });
@@ -100,7 +98,7 @@ describe('Directive Schematic', () => {
   it('should import into a specified module', async () => {
     const options = { ...defaultOptions, module: 'app.module.ts' };
 
-    const tree = await schematicRunner.runSchematicAsync('directive', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('directive', options, appTree);
     const appModule = tree.readContent('/projects/bar/src/app/app.module.ts');
 
     expect(appModule).toMatch(/import { FooDirective } from '.\/foo.directive'/);
@@ -109,22 +107,20 @@ describe('Directive Schematic', () => {
   it('should fail if specified module does not exist', async () => {
     const options = { ...defaultOptions, module: '/projects/bar/src/app/app.moduleXXX.ts' };
 
-    await expectAsync(
-      schematicRunner.runSchematicAsync('directive', options, appTree).toPromise(),
-    ).toBeRejected();
+    await expectAsync(schematicRunner.runSchematic('directive', options, appTree)).toBeRejected();
   });
 
   it('should converts dash-cased-name to a camelCasedSelector', async () => {
     const options = { ...defaultOptions, name: 'my-dir' };
 
-    const tree = await schematicRunner.runSchematicAsync('directive', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('directive', options, appTree);
     const content = tree.readContent('/projects/bar/src/app/my-dir.directive.ts');
     expect(content).toMatch(/selector: '\[appMyDir\]'/);
   });
 
   it('should create the right selector with a path in the name', async () => {
     const options = { ...defaultOptions, name: 'sub/test' };
-    appTree = await schematicRunner.runSchematicAsync('directive', options, appTree).toPromise();
+    appTree = await schematicRunner.runSchematic('directive', options, appTree);
 
     const content = appTree.readContent('/projects/bar/src/app/sub/test.directive.ts');
     expect(content).toMatch(/selector: '\[appTest\]'/);
@@ -132,7 +128,7 @@ describe('Directive Schematic', () => {
 
   it('should use the prefix', async () => {
     const options = { ...defaultOptions, prefix: 'pre' };
-    const tree = await schematicRunner.runSchematicAsync('directive', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('directive', options, appTree);
 
     const content = tree.readContent('/projects/bar/src/app/foo.directive.ts');
     expect(content).toMatch(/selector: '\[preFoo\]'/);
@@ -140,7 +136,7 @@ describe('Directive Schematic', () => {
 
   it('should use the default project prefix if none is passed', async () => {
     const options = { ...defaultOptions, prefix: undefined };
-    const tree = await schematicRunner.runSchematicAsync('directive', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('directive', options, appTree);
 
     const content = tree.readContent('/projects/bar/src/app/foo.directive.ts');
     expect(content).toMatch(/selector: '\[appFoo\]'/);
@@ -148,7 +144,7 @@ describe('Directive Schematic', () => {
 
   it('should use the supplied prefix if it is ""', async () => {
     const options = { ...defaultOptions, prefix: '' };
-    const tree = await schematicRunner.runSchematicAsync('directive', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('directive', options, appTree);
 
     const content = tree.readContent('/projects/bar/src/app/foo.directive.ts');
     expect(content).toMatch(/selector: '\[foo\]'/);
@@ -161,21 +157,20 @@ describe('Directive Schematic', () => {
 
     // should fail without a module in that dir
     await expectAsync(
-      schematicRunner.runSchematicAsync('directive', defaultOptions, appTree).toPromise(),
+      schematicRunner.runSchematic('directive', defaultOptions, appTree),
     ).toBeRejected();
 
     // move the module
     appTree.rename('/projects/bar/src/app/app.module.ts', '/projects/bar/custom/app/app.module.ts');
-    appTree = await schematicRunner
-      .runSchematicAsync('directive', defaultOptions, appTree)
-      .toPromise();
+    appTree = await schematicRunner.runSchematic('directive', defaultOptions, appTree);
+
     expect(appTree.files).toContain('/projects/bar/custom/app/foo.directive.ts');
   });
 
   it('should respect skipTests flag', async () => {
     const options = { ...defaultOptions, skipTests: true };
 
-    const tree = await schematicRunner.runSchematicAsync('directive', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('directive', options, appTree);
     const files = tree.files;
     expect(files).toContain('/projects/bar/src/app/foo.directive.ts');
     expect(files).not.toContain('/projects/bar/src/app/foo.directive.spec.ts');
@@ -183,7 +178,7 @@ describe('Directive Schematic', () => {
 
   it('should create a standalone directive', async () => {
     const options = { ...defaultOptions, standalone: true };
-    const tree = await schematicRunner.runSchematicAsync('directive', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('directive', options, appTree);
     const moduleContent = tree.readContent('/projects/bar/src/app/app.module.ts');
     const directiveContent = tree.readContent('/projects/bar/src/app/foo.directive.ts');
     expect(directiveContent).toContain('standalone: true');

--- a/packages/schematics/angular/e2e/index_spec.ts
+++ b/packages/schematics/angular/e2e/index_spec.ts
@@ -39,18 +39,18 @@ describe('Application Schematic', () => {
   let applicationTree: UnitTestTree;
 
   beforeEach(async () => {
-    const workspaceTree = await schematicRunner
-      .runSchematicAsync('workspace', workspaceOptions)
-      .toPromise();
-    applicationTree = await schematicRunner
-      .runSchematicAsync('application', defaultAppOptions, workspaceTree)
-      .toPromise();
+    const workspaceTree = await schematicRunner.runSchematic('workspace', workspaceOptions);
+
+    applicationTree = await schematicRunner.runSchematic(
+      'application',
+      defaultAppOptions,
+      workspaceTree,
+    );
   });
 
   it('should create all files of e2e in an application', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('e2e', defaultOptions, applicationTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('e2e', defaultOptions, applicationTree);
+
     const files = tree.files;
     expect(files).toEqual(
       jasmine.arrayContaining([
@@ -63,45 +63,40 @@ describe('Application Schematic', () => {
   });
 
   it('should set the rootSelector in the app.po.ts', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('e2e', defaultOptions, applicationTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('e2e', defaultOptions, applicationTree);
+
     const content = tree.readContent('/projects/foo/e2e/src/app.po.ts');
     expect(content).toMatch(/app-root/);
   });
 
   it('should set the rootSelector in the app.po.ts from the option', async () => {
     const options = { ...defaultOptions, rootSelector: 't-a-c-o' };
-    const tree = await schematicRunner
-      .runSchematicAsync('e2e', options, applicationTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('e2e', options, applicationTree);
+
     const content = tree.readContent('/projects/foo/e2e/src/app.po.ts');
     expect(content).toMatch(/t-a-c-o/);
   });
 
   it('should set the rootSelector in the app.po.ts from the option with emoji', async () => {
     const options = { ...defaultOptions, rootSelector: '🌮-🌯' };
-    const tree = await schematicRunner
-      .runSchematicAsync('e2e', options, applicationTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('e2e', options, applicationTree);
+
     const content = tree.readContent('/projects/foo/e2e/src/app.po.ts');
     expect(content).toMatch(/🌮-🌯/);
   });
 
   describe('workspace config', () => {
     it('should add e2e targets for the app', async () => {
-      const tree = await schematicRunner
-        .runSchematicAsync('e2e', defaultOptions, applicationTree)
-        .toPromise();
+      const tree = await schematicRunner.runSchematic('e2e', defaultOptions, applicationTree);
+
       const workspace = JSON.parse(tree.readContent('/angular.json'));
       const targets = workspace.projects.foo.architect;
       expect(targets.e2e).toBeDefined();
     });
 
     it('should set the e2e options', async () => {
-      const tree = await schematicRunner
-        .runSchematicAsync('e2e', defaultOptions, applicationTree)
-        .toPromise();
+      const tree = await schematicRunner.runSchematic('e2e', defaultOptions, applicationTree);
+
       const workspace = JSON.parse(tree.readContent('/angular.json'));
       const { options, configurations } = workspace.projects.foo.architect.e2e;
       expect(options.protractorConfig).toEqual('projects/foo/e2e/protractor.conf.js');
@@ -110,9 +105,8 @@ describe('Application Schematic', () => {
   });
 
   it('should add an e2e script in package.json', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('e2e', defaultOptions, applicationTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('e2e', defaultOptions, applicationTree);
+
     const pkg = JSON.parse(tree.readContent('/package.json'));
     expect(pkg.scripts['e2e']).toBe('ng e2e');
   });

--- a/packages/schematics/angular/enum/index_spec.ts
+++ b/packages/schematics/angular/enum/index_spec.ts
@@ -37,24 +37,20 @@ describe('Enum Schematic', () => {
   };
   let appTree: UnitTestTree;
   beforeEach(async () => {
-    appTree = await schematicRunner.runSchematicAsync('workspace', workspaceOptions).toPromise();
-    appTree = await schematicRunner
-      .runSchematicAsync('application', appOptions, appTree)
-      .toPromise();
+    appTree = await schematicRunner.runSchematic('workspace', workspaceOptions);
+    appTree = await schematicRunner.runSchematic('application', appOptions, appTree);
   });
 
   it('should create an enumeration', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('enum', defaultOptions, appTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('enum', defaultOptions, appTree);
+
     const files = tree.files;
     expect(files).toContain('/projects/bar/src/app/foo.ts');
   });
 
   it('should create an enumeration', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('enum', defaultOptions, appTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('enum', defaultOptions, appTree);
+
     const content = tree.readContent('/projects/bar/src/app/foo.ts');
     expect(content).toMatch('export enum Foo {');
   });
@@ -63,22 +59,22 @@ describe('Enum Schematic', () => {
     const config = JSON.parse(appTree.readContent('/angular.json'));
     config.projects.bar.sourceRoot = 'projects/bar/custom';
     appTree.overwrite('/angular.json', JSON.stringify(config, null, 2));
-    appTree = await schematicRunner.runSchematicAsync('enum', defaultOptions, appTree).toPromise();
+    appTree = await schematicRunner.runSchematic('enum', defaultOptions, appTree);
     expect(appTree.files).toContain('/projects/bar/custom/app/foo.ts');
   });
 
   it('should put type in the file name', async () => {
     const options = { ...defaultOptions, type: 'enum' };
 
-    const tree = await schematicRunner.runSchematicAsync('enum', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('enum', options, appTree);
     expect(tree.files).toContain('/projects/bar/src/app/foo.enum.ts');
   });
 
   it('should error when class name contains invalid characters', async () => {
     const options = { ...defaultOptions, name: '1Clazz' };
 
-    await expectAsync(
-      schematicRunner.runSchematicAsync('enum', options, appTree).toPromise(),
-    ).toBeRejectedWithError('Class name "1Clazz" is invalid.');
+    await expectAsync(schematicRunner.runSchematic('enum', options, appTree)).toBeRejectedWithError(
+      'Class name "1Clazz" is invalid.',
+    );
   });
 });

--- a/packages/schematics/angular/guard/index_spec.ts
+++ b/packages/schematics/angular/guard/index_spec.ts
@@ -39,16 +39,13 @@ describe('Guard Schematic', () => {
   };
   let appTree: UnitTestTree;
   beforeEach(async () => {
-    appTree = await schematicRunner.runSchematicAsync('workspace', workspaceOptions).toPromise();
-    appTree = await schematicRunner
-      .runSchematicAsync('application', appOptions, appTree)
-      .toPromise();
+    appTree = await schematicRunner.runSchematic('workspace', workspaceOptions);
+    appTree = await schematicRunner.runSchematic('application', appOptions, appTree);
   });
 
   it('should create a guard', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('guard', defaultOptions, appTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('guard', defaultOptions, appTree);
+
     const files = tree.files;
     expect(files).toContain('/projects/bar/src/app/foo.guard.spec.ts');
     expect(files).toContain('/projects/bar/src/app/foo.guard.ts');
@@ -57,7 +54,7 @@ describe('Guard Schematic', () => {
   it('should respect the skipTests flag', async () => {
     const options = { ...defaultOptions, skipTests: true };
 
-    const tree = await schematicRunner.runSchematicAsync('guard', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('guard', options, appTree);
     const files = tree.files;
     expect(files).not.toContain('/projects/bar/src/app/foo.guard.spec.ts');
     expect(files).toContain('/projects/bar/src/app/foo.guard.ts');
@@ -66,7 +63,7 @@ describe('Guard Schematic', () => {
   it('should respect the flat flag', async () => {
     const options = { ...defaultOptions, flat: false };
 
-    const tree = await schematicRunner.runSchematicAsync('guard', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('guard', options, appTree);
     const files = tree.files;
     expect(files).toContain('/projects/bar/src/app/foo/foo.guard.spec.ts');
     expect(files).toContain('/projects/bar/src/app/foo/foo.guard.ts');
@@ -76,13 +73,13 @@ describe('Guard Schematic', () => {
     const config = JSON.parse(appTree.readContent('/angular.json'));
     config.projects.bar.sourceRoot = 'projects/bar/custom';
     appTree.overwrite('/angular.json', JSON.stringify(config, null, 2));
-    appTree = await schematicRunner.runSchematicAsync('guard', defaultOptions, appTree).toPromise();
+    appTree = await schematicRunner.runSchematic('guard', defaultOptions, appTree);
     expect(appTree.files).toContain('/projects/bar/custom/app/foo.guard.ts');
   });
 
   it('should respect the implements value', async () => {
     const options = { ...defaultOptions, implements: ['CanActivate'] };
-    const tree = await schematicRunner.runSchematicAsync('guard', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('guard', options, appTree);
     const fileString = tree.readContent('/projects/bar/src/app/foo.guard.ts');
     expect(fileString).toContain('CanActivate');
     expect(fileString).toContain('canActivate');
@@ -94,7 +91,7 @@ describe('Guard Schematic', () => {
 
   it('should respect the functional guard value', async () => {
     const options = { ...defaultOptions, implements: ['CanActivate'], functional: true };
-    const tree = await schematicRunner.runSchematicAsync('guard', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('guard', options, appTree);
     const fileString = tree.readContent('/projects/bar/src/app/foo.guard.ts');
     expect(fileString).toContain('export const fooGuard: CanActivateFn = (route, state) => {');
     expect(fileString).not.toContain('CanActivateChild');
@@ -105,7 +102,7 @@ describe('Guard Schematic', () => {
 
   it('should generate a helper function to execute the guard in a test', async () => {
     const options = { ...defaultOptions, implements: ['CanActivate'], functional: true };
-    const tree = await schematicRunner.runSchematicAsync('guard', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('guard', options, appTree);
     const fileString = tree.readContent('/projects/bar/src/app/foo.guard.spec.ts');
     expect(fileString).toContain('const executeGuard: CanActivateFn = (...guardParameters) => ');
     expect(fileString).toContain(
@@ -115,7 +112,7 @@ describe('Guard Schematic', () => {
 
   it('should generate CanDeactivateFn with unknown functional guard', async () => {
     const options = { ...defaultOptions, implements: ['CanDeactivate'], functional: true };
-    const tree = await schematicRunner.runSchematicAsync('guard', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('guard', options, appTree);
     const fileString = tree.readContent('/projects/bar/src/app/foo.guard.ts');
     expect(fileString).toContain(
       'export const fooGuard: CanDeactivateFn<unknown> = ' +
@@ -126,7 +123,7 @@ describe('Guard Schematic', () => {
   it('should respect the implements values', async () => {
     const implementationOptions = ['CanActivate', 'CanLoad', 'CanActivateChild'];
     const options = { ...defaultOptions, implements: implementationOptions };
-    const tree = await schematicRunner.runSchematicAsync('guard', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('guard', options, appTree);
     const fileString = tree.readContent('/projects/bar/src/app/foo.guard.ts');
 
     // Should contain all implementations
@@ -140,7 +137,7 @@ describe('Guard Schematic', () => {
   it('should add correct imports based on CanLoad implementation', async () => {
     const implementationOptions = ['CanLoad'];
     const options = { ...defaultOptions, implements: implementationOptions };
-    const tree = await schematicRunner.runSchematicAsync('guard', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('guard', options, appTree);
     const fileString = tree.readContent('/projects/bar/src/app/foo.guard.ts');
     const expectedImports = `import { CanLoad, Route, UrlSegment, UrlTree } from '@angular/router';`;
 
@@ -150,7 +147,7 @@ describe('Guard Schematic', () => {
   it('should add correct imports based on CanMatch implementation', async () => {
     const implementationOptions = ['CanMatch'];
     const options = { ...defaultOptions, implements: implementationOptions };
-    const tree = await schematicRunner.runSchematicAsync('guard', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('guard', options, appTree);
     const fileString = tree.readContent('/projects/bar/src/app/foo.guard.ts');
     const expectedImports = `import { CanMatch, Route, UrlSegment, UrlTree } from '@angular/router';`;
 
@@ -159,7 +156,7 @@ describe('Guard Schematic', () => {
 
   it('should add correct imports based on canLoad functional guard', async () => {
     const options = { ...defaultOptions, implements: ['CanLoad'], functional: true };
-    const tree = await schematicRunner.runSchematicAsync('guard', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('guard', options, appTree);
     const fileString = tree.readContent('/projects/bar/src/app/foo.guard.ts');
     const expectedImports = `import { CanLoadFn } from '@angular/router';`;
 
@@ -169,7 +166,7 @@ describe('Guard Schematic', () => {
   it('should add correct imports based on CanActivate implementation', async () => {
     const implementationOptions = ['CanActivate'];
     const options = { ...defaultOptions, implements: implementationOptions };
-    const tree = await schematicRunner.runSchematicAsync('guard', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('guard', options, appTree);
     const fileString = tree.readContent('/projects/bar/src/app/foo.guard.ts');
     const expectedImports = `import { ActivatedRouteSnapshot, CanActivate, RouterStateSnapshot, UrlTree } from '@angular/router';`;
 
@@ -178,7 +175,7 @@ describe('Guard Schematic', () => {
 
   it('should add correct imports based on canActivate functional guard', async () => {
     const options = { ...defaultOptions, implements: ['CanActivate'], functional: true };
-    const tree = await schematicRunner.runSchematicAsync('guard', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('guard', options, appTree);
     const fileString = tree.readContent('/projects/bar/src/app/foo.guard.ts');
     const expectedImports = `import { CanActivateFn } from '@angular/router';`;
 
@@ -188,7 +185,7 @@ describe('Guard Schematic', () => {
   it('should add correct imports if multiple implementations was selected', async () => {
     const implementationOptions = ['CanActivate', 'CanLoad', 'CanActivateChild'];
     const options = { ...defaultOptions, implements: implementationOptions };
-    const tree = await schematicRunner.runSchematicAsync('guard', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('guard', options, appTree);
     const fileString = tree.readContent('/projects/bar/src/app/foo.guard.ts');
     const expectedImports =
       `import ` +

--- a/packages/schematics/angular/interceptor/index_spec.ts
+++ b/packages/schematics/angular/interceptor/index_spec.ts
@@ -37,18 +37,15 @@ describe('Interceptor Schematic', () => {
   };
   let appTree: UnitTestTree;
   beforeEach(async () => {
-    appTree = await schematicRunner.runSchematicAsync('workspace', workspaceOptions).toPromise();
-    appTree = await schematicRunner
-      .runSchematicAsync('application', appOptions, appTree)
-      .toPromise();
+    appTree = await schematicRunner.runSchematic('workspace', workspaceOptions);
+    appTree = await schematicRunner.runSchematic('application', appOptions, appTree);
   });
 
   it('should create an interceptor', async () => {
     const options = { ...defaultOptions };
 
-    const tree = await schematicRunner
-      .runSchematicAsync('interceptor', options, appTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('interceptor', options, appTree);
+
     const files = tree.files;
     expect(files).toContain('/projects/bar/src/app/foo/foo.interceptor.spec.ts');
     expect(files).toContain('/projects/bar/src/app/foo/foo.interceptor.ts');
@@ -57,9 +54,8 @@ describe('Interceptor Schematic', () => {
   it('should respect the skipTests flag', async () => {
     const options = { ...defaultOptions, skipTests: true };
 
-    const tree = await schematicRunner
-      .runSchematicAsync('interceptor', options, appTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('interceptor', options, appTree);
+
     const files = tree.files;
     expect(files).toContain('/projects/bar/src/app/foo/foo.interceptor.ts');
     expect(files).not.toContain('/projects/bar/src/app/foo/foo.interceptor.spec.ts');
@@ -69,16 +65,18 @@ describe('Interceptor Schematic', () => {
     const config = JSON.parse(appTree.readContent('/angular.json'));
     config.projects.bar.sourceRoot = 'projects/bar/custom';
     appTree.overwrite('/angular.json', JSON.stringify(config, null, 2));
-    appTree = await schematicRunner
-      .runSchematicAsync('interceptor', defaultOptions, appTree)
-      .toPromise();
+    appTree = await schematicRunner.runSchematic('interceptor', defaultOptions, appTree);
+
     expect(appTree.files).toContain('/projects/bar/custom/app/foo/foo.interceptor.ts');
   });
 
   it('should create a functional interceptor', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('interceptor', { ...defaultOptions, functional: true }, appTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic(
+      'interceptor',
+      { ...defaultOptions, functional: true },
+      appTree,
+    );
+
     const fileString = tree.readContent('/projects/bar/src/app/foo/foo.interceptor.ts');
     expect(fileString).toContain(
       'export const fooInterceptor: HttpInterceptorFn = (req, next) => {',
@@ -86,9 +84,12 @@ describe('Interceptor Schematic', () => {
   });
 
   it('should create a helper function to run a functional interceptor in a test', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('interceptor', { ...defaultOptions, functional: true }, appTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic(
+      'interceptor',
+      { ...defaultOptions, functional: true },
+      appTree,
+    );
+
     const fileString = tree.readContent('/projects/bar/src/app/foo/foo.interceptor.spec.ts');
     expect(fileString).toContain('const interceptor: HttpInterceptorFn = (req, next) => ');
     expect(fileString).toContain('TestBed.runInInjectionContext(() => fooInterceptor(req, next));');

--- a/packages/schematics/angular/interface/index_spec.ts
+++ b/packages/schematics/angular/interface/index_spec.ts
@@ -39,23 +39,17 @@ describe('Interface Schematic', () => {
   };
   let appTree: UnitTestTree;
   beforeEach(async () => {
-    appTree = await schematicRunner.runSchematicAsync('workspace', workspaceOptions).toPromise();
-    appTree = await schematicRunner
-      .runSchematicAsync('application', appOptions, appTree)
-      .toPromise();
+    appTree = await schematicRunner.runSchematic('workspace', workspaceOptions);
+    appTree = await schematicRunner.runSchematic('application', appOptions, appTree);
   });
 
   it('should create one file', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('interface', defaultOptions, appTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('interface', defaultOptions, appTree);
     expect(tree.files).toContain('/projects/bar/src/app/foo.ts');
   });
 
   it('should create an interface named "Foo"', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('interface', defaultOptions, appTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('interface', defaultOptions, appTree);
     const fileContent = tree.readContent('/projects/bar/src/app/foo.ts');
     expect(fileContent).toMatch(/export interface Foo/);
   });
@@ -63,7 +57,7 @@ describe('Interface Schematic', () => {
   it('should put type in the file name', async () => {
     const options = { ...defaultOptions, type: 'model' };
 
-    const tree = await schematicRunner.runSchematicAsync('interface', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('interface', options, appTree);
     expect(tree.files).toContain('/projects/bar/src/app/foo.model.ts');
   });
 
@@ -71,9 +65,7 @@ describe('Interface Schematic', () => {
     const config = JSON.parse(appTree.readContent('/angular.json'));
     config.projects.bar.sourceRoot = 'projects/bar/custom';
     appTree.overwrite('/angular.json', JSON.stringify(config, null, 2));
-    appTree = await schematicRunner
-      .runSchematicAsync('interface', defaultOptions, appTree)
-      .toPromise();
+    appTree = await schematicRunner.runSchematic('interface', defaultOptions, appTree);
     expect(appTree.files).toContain('/projects/bar/custom/app/foo.ts');
   });
 });

--- a/packages/schematics/angular/library/index_spec.ts
+++ b/packages/schematics/angular/library/index_spec.ts
@@ -40,15 +40,12 @@ describe('Library Schematic', () => {
 
   let workspaceTree: UnitTestTree;
   beforeEach(async () => {
-    workspaceTree = await schematicRunner
-      .runSchematicAsync('workspace', workspaceOptions)
-      .toPromise();
+    workspaceTree = await schematicRunner.runSchematic('workspace', workspaceOptions);
   });
 
   it('should create files', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('library', defaultOptions, workspaceTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('library', defaultOptions, workspaceTree);
+
     const files = tree.files;
     expect(files).toEqual(
       jasmine.arrayContaining([
@@ -78,9 +75,12 @@ describe('Library Schematic', () => {
     };
 
     it('should create files in /some/other/directory/bar', async () => {
-      const tree = await schematicRunner
-        .runSchematicAsync('library', customProjectRootOptions, workspaceTree)
-        .toPromise();
+      const tree = await schematicRunner.runSchematic(
+        'library',
+        customProjectRootOptions,
+        workspaceTree,
+      );
+
       const files = tree.files;
       expect(files).toEqual(
         jasmine.arrayContaining([
@@ -100,9 +100,11 @@ describe('Library Schematic', () => {
     });
 
     it(`should add library to workspace`, async () => {
-      const tree = await schematicRunner
-        .runSchematicAsync('library', customProjectRootOptions, workspaceTree)
-        .toPromise();
+      const tree = await schematicRunner.runSchematic(
+        'library',
+        customProjectRootOptions,
+        workspaceTree,
+      );
 
       const workspace = getJsonFileContent(tree, '/angular.json');
       expect(workspace.projects.foo).toBeDefined();
@@ -110,50 +112,44 @@ describe('Library Schematic', () => {
   });
 
   it('should create a package.json named "foo"', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('library', defaultOptions, workspaceTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('library', defaultOptions, workspaceTree);
+
     const fileContent = getFileContent(tree, '/projects/foo/package.json');
     expect(fileContent).toMatch(/"name": "foo"/);
   });
 
   it('should have the latest Angular major versions in package.json named "foo"', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('library', defaultOptions, workspaceTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('library', defaultOptions, workspaceTree);
+
     const fileContent = getJsonFileContent(tree, '/projects/foo/package.json');
     const angularVersion = latestVersions.Angular.replace('~', '').replace('^', '');
     expect(fileContent.peerDependencies['@angular/core']).toBe(`^${angularVersion}`);
   });
 
   it('should add sideEffects: false flag to package.json named "foo"', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('library', defaultOptions, workspaceTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('library', defaultOptions, workspaceTree);
+
     const fileContent = getFileContent(tree, '/projects/foo/package.json');
     expect(fileContent).toMatch(/"sideEffects": false/);
   });
 
   it('should create a README.md named "foo"', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('library', defaultOptions, workspaceTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('library', defaultOptions, workspaceTree);
+
     const fileContent = getFileContent(tree, '/projects/foo/README.md');
     expect(fileContent).toMatch(/# Foo/);
   });
 
   it('should create a tsconfig for library', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('library', defaultOptions, workspaceTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('library', defaultOptions, workspaceTree);
+
     const fileContent = getJsonFileContent(tree, '/projects/foo/tsconfig.lib.json');
     expect(fileContent).toBeDefined();
   });
 
   it('should create a ng-package.json with ngPackage conf', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('library', defaultOptions, workspaceTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('library', defaultOptions, workspaceTree);
+
     const fileContent = getJsonFileContent(tree, '/projects/foo/ng-package.json');
     expect(fileContent.lib).toBeDefined();
     expect(fileContent.lib.entryFile).toEqual('src/my-index.ts');
@@ -161,31 +157,26 @@ describe('Library Schematic', () => {
   });
 
   it('should use default value for baseDir and entryFile', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync(
-        'library',
-        {
-          name: 'foobar',
-        },
-        workspaceTree,
-      )
-      .toPromise();
+    const tree = await schematicRunner.runSchematic(
+      'library',
+      {
+        name: 'foobar',
+      },
+      workspaceTree,
+    );
+
     expect(tree.files).toContain('/projects/foobar/src/public-api.ts');
   });
 
   it(`should add library to workspace`, async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('library', defaultOptions, workspaceTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('library', defaultOptions, workspaceTree);
 
     const workspace = getJsonFileContent(tree, '/angular.json');
     expect(workspace.projects.foo).toBeDefined();
   });
 
   it('should set the prefix to lib if none is set', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('library', defaultOptions, workspaceTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('library', defaultOptions, workspaceTree);
 
     const workspace = JSON.parse(tree.readContent('/angular.json'));
     expect(workspace.projects.foo.prefix).toEqual('lib');
@@ -193,9 +184,7 @@ describe('Library Schematic', () => {
 
   it('should set the prefix correctly', async () => {
     const options = { ...defaultOptions, prefix: 'pre' };
-    const tree = await schematicRunner
-      .runSchematicAsync('library', options, workspaceTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('library', options, workspaceTree);
 
     const workspace = JSON.parse(tree.readContent('/angular.json'));
     expect(workspace.projects.foo.prefix).toEqual('pre');
@@ -203,9 +192,8 @@ describe('Library Schematic', () => {
 
   it('should handle a pascalCasedName', async () => {
     const options = { ...defaultOptions, name: 'pascalCasedName' };
-    const tree = await schematicRunner
-      .runSchematicAsync('library', options, workspaceTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('library', options, workspaceTree);
+
     const config = getJsonFileContent(tree, '/angular.json');
     const project = config.projects.pascalCasedName;
     expect(project).toBeDefined();
@@ -217,27 +205,23 @@ describe('Library Schematic', () => {
   });
 
   it('should export the component in the NgModule', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('library', defaultOptions, workspaceTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('library', defaultOptions, workspaceTree);
+
     const fileContent = getFileContent(tree, '/projects/foo/src/lib/foo.module.ts');
     expect(fileContent).toMatch(/exports: \[\n(\s*) {2}FooComponent\n\1\]/);
   });
 
   describe(`update package.json`, () => {
     it(`should add ng-packagr to devDependencies`, async () => {
-      const tree = await schematicRunner
-        .runSchematicAsync('library', defaultOptions, workspaceTree)
-        .toPromise();
+      const tree = await schematicRunner.runSchematic('library', defaultOptions, workspaceTree);
 
       const packageJson = getJsonFileContent(tree, 'package.json');
       expect(packageJson.devDependencies['ng-packagr']).toEqual(latestVersions['ng-packagr']);
     });
 
     it('should use the latest known versions in package.json', async () => {
-      const tree = await schematicRunner
-        .runSchematicAsync('library', defaultOptions, workspaceTree)
-        .toPromise();
+      const tree = await schematicRunner.runSchematic('library', defaultOptions, workspaceTree);
+
       const pkg = JSON.parse(tree.readContent('/package.json'));
       expect(pkg.devDependencies['@angular/compiler-cli']).toEqual(latestVersions.Angular);
       expect(pkg.devDependencies['typescript']).toEqual(latestVersions['typescript']);
@@ -253,24 +237,21 @@ describe('Library Schematic', () => {
         ),
       );
 
-      const tree = await schematicRunner
-        .runSchematicAsync('library', defaultOptions, workspaceTree)
-        .toPromise();
+      const tree = await schematicRunner.runSchematic('library', defaultOptions, workspaceTree);
+
       const packageJson = getJsonFileContent(tree, 'package.json');
       expect(packageJson.devDependencies.typescript).toEqual('~2.5.2');
     });
 
     it(`should not modify the file when --skipPackageJson`, async () => {
-      const tree = await schematicRunner
-        .runSchematicAsync(
-          'library',
-          {
-            name: 'foo',
-            skipPackageJson: true,
-          },
-          workspaceTree,
-        )
-        .toPromise();
+      const tree = await schematicRunner.runSchematic(
+        'library',
+        {
+          name: 'foo',
+          skipPackageJson: true,
+        },
+        workspaceTree,
+      );
 
       const packageJson = getJsonFileContent(tree, 'package.json');
       expect(packageJson.devDependencies['ng-packagr']).toBeUndefined();
@@ -280,9 +261,7 @@ describe('Library Schematic', () => {
 
   describe(`update tsconfig.json`, () => {
     it(`should add paths mapping to empty tsconfig`, async () => {
-      const tree = await schematicRunner
-        .runSchematicAsync('library', defaultOptions, workspaceTree)
-        .toPromise();
+      const tree = await schematicRunner.runSchematic('library', defaultOptions, workspaceTree);
 
       const tsConfigJson = getJsonFileContent(tree, 'tsconfig.json');
       expect(tsConfigJson.compilerOptions.paths['foo']).toEqual(['dist/foo']);
@@ -300,25 +279,21 @@ describe('Library Schematic', () => {
           },
         }),
       );
-      const tree = await schematicRunner
-        .runSchematicAsync('library', defaultOptions, workspaceTree)
-        .toPromise();
+      const tree = await schematicRunner.runSchematic('library', defaultOptions, workspaceTree);
 
       const tsConfigJson = getJsonFileContent(tree, 'tsconfig.json');
       expect(tsConfigJson.compilerOptions.paths['foo']).toEqual(['libs/*', 'dist/foo']);
     });
 
     it(`should not modify the file when --skipTsConfig`, async () => {
-      const tree = await schematicRunner
-        .runSchematicAsync(
-          'library',
-          {
-            name: 'foo',
-            skipTsConfig: true,
-          },
-          workspaceTree,
-        )
-        .toPromise();
+      const tree = await schematicRunner.runSchematic(
+        'library',
+        {
+          name: 'foo',
+          skipTsConfig: true,
+        },
+        workspaceTree,
+      );
 
       const tsConfigJson = getJsonFileContent(tree, 'tsconfig.json');
       expect(tsConfigJson.compilerOptions.paths).toBeUndefined();
@@ -326,23 +301,20 @@ describe('Library Schematic', () => {
   });
 
   it('should generate inside of a library', async () => {
-    let tree = await schematicRunner
-      .runSchematicAsync('library', defaultOptions, workspaceTree)
-      .toPromise();
+    let tree = await schematicRunner.runSchematic('library', defaultOptions, workspaceTree);
+
     const componentOptions: ComponentOptions = {
       name: 'comp',
       project: 'foo',
     };
-    tree = await schematicRunner.runSchematicAsync('component', componentOptions, tree).toPromise();
+    tree = await schematicRunner.runSchematic('component', componentOptions, tree);
     expect(tree.exists('/projects/foo/src/lib/comp/comp.component.ts')).toBe(true);
   });
 
   it(`should support creating scoped libraries`, async () => {
     const scopedName = '@myscope/mylib';
     const options = { ...defaultOptions, name: scopedName };
-    const tree = await schematicRunner
-      .runSchematicAsync('library', options, workspaceTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('library', options, workspaceTree);
 
     const pkgJsonPath = '/projects/myscope/mylib/package.json';
     expect(tree.files).toContain(pkgJsonPath);
@@ -367,9 +339,7 @@ describe('Library Schematic', () => {
     const expectedScopeName = '@my-scope/my-lib';
     const expectedFolderName = 'my-scope/my-lib';
     const options = { ...defaultOptions, name: scopedName };
-    const tree = await schematicRunner
-      .runSchematicAsync('library', options, workspaceTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('library', options, workspaceTree);
 
     const pkgJsonPath = '/projects/my-scope/my-lib/package.json';
     expect(tree.readContent(pkgJsonPath)).toContain(expectedScopeName);
@@ -385,12 +355,13 @@ describe('Library Schematic', () => {
   });
 
   it(`should create correct paths when 'newProjectRoot' is blank`, async () => {
-    const workspaceTree = await schematicRunner
-      .runSchematicAsync('workspace', { ...workspaceOptions, newProjectRoot: '' })
-      .toPromise();
-    const tree = await schematicRunner
-      .runSchematicAsync('library', defaultOptions, workspaceTree)
-      .toPromise();
+    const workspaceTree = await schematicRunner.runSchematic('workspace', {
+      ...workspaceOptions,
+      newProjectRoot: '',
+    });
+
+    const tree = await schematicRunner.runSchematic('library', defaultOptions, workspaceTree);
+
     const config = getJsonFileContent(tree, '/angular.json');
     const project = config.projects.foo;
     expect(project.root).toEqual('foo');
@@ -405,18 +376,14 @@ describe('Library Schematic', () => {
   });
 
   it(`should add 'development' configuration`, async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('library', defaultOptions, workspaceTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('library', defaultOptions, workspaceTree);
 
     const workspace = JSON.parse(tree.readContent('/angular.json'));
     expect(workspace.projects.foo.architect.build.configurations.development).toBeDefined();
   });
 
   it(`should add 'ng-packagr' builder`, async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('library', defaultOptions, workspaceTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('library', defaultOptions, workspaceTree);
 
     const workspace = JSON.parse(tree.readContent('/angular.json'));
     expect(workspace.projects.foo.architect.build.builder).toBe(

--- a/packages/schematics/angular/migrations/update-15/remove-browserslist-config_spec.ts
+++ b/packages/schematics/angular/migrations/update-15/remove-browserslist-config_spec.ts
@@ -29,7 +29,7 @@ describe('Migration to delete Browserslist configurations', () => {
       tree.create('/src/app/.browserslistrc', DEFAULT_BROWSERS.join('\n'));
       expect(tree.exists('/src/app/.browserslistrc')).toBeTrue();
 
-      const newTree = await schematicRunner.runSchematicAsync(schematicName, {}, tree).toPromise();
+      const newTree = await schematicRunner.runSchematic(schematicName, {}, tree);
       expect(newTree.exists('/src/app/.browserslistrc')).toBeFalse();
     });
 
@@ -37,7 +37,7 @@ describe('Migration to delete Browserslist configurations', () => {
       tree.create('/node_modules/browserslist', DEFAULT_BROWSERS.join('\n'));
       tree.create('/node_modules/.browserslistrc', DEFAULT_BROWSERS.join('\n'));
 
-      const newTree = await schematicRunner.runSchematicAsync(schematicName, {}, tree).toPromise();
+      const newTree = await schematicRunner.runSchematic(schematicName, {}, tree);
       expect(newTree.exists('/node_modules/browserslist')).toBeTrue();
       expect(newTree.exists('/node_modules/.browserslistrc')).toBeTrue();
     });
@@ -47,14 +47,14 @@ describe('Migration to delete Browserslist configurations', () => {
     it('should not delete "browserslist"', async () => {
       tree.create('/src/app/browserslist', 'last 1 Chrome version');
 
-      const newTree = await schematicRunner.runSchematicAsync(schematicName, {}, tree).toPromise();
+      const newTree = await schematicRunner.runSchematic(schematicName, {}, tree);
       expect(newTree.exists('/src/app/browserslist')).toBeTrue();
     });
 
     it('should not delete ".browserslistrc"', async () => {
       tree.create('/src/app/.browserslistrc', 'last 1 Chrome version');
 
-      const newTree = await schematicRunner.runSchematicAsync(schematicName, {}, tree).toPromise();
+      const newTree = await schematicRunner.runSchematic(schematicName, {}, tree);
       expect(newTree.exists('/src/app/.browserslistrc')).toBeTrue();
     });
 
@@ -62,7 +62,7 @@ describe('Migration to delete Browserslist configurations', () => {
       tree.create('/src/app/.browserslistrc', [...DEFAULT_BROWSERS, 'IE 10'].join('\n'));
       expect(tree.exists('/src/app/.browserslistrc')).toBeTrue();
 
-      const newTree = await schematicRunner.runSchematicAsync(schematicName, {}, tree).toPromise();
+      const newTree = await schematicRunner.runSchematic(schematicName, {}, tree);
       expect(newTree.exists('/src/app/.browserslistrc')).toBeFalse();
     });
 
@@ -77,7 +77,7 @@ describe('Migration to delete Browserslist configurations', () => {
       );
       expect(tree.exists('/src/app/.browserslistrc')).toBeTrue();
 
-      const newTree = await schematicRunner.runSchematicAsync(schematicName, {}, tree).toPromise();
+      const newTree = await schematicRunner.runSchematic(schematicName, {}, tree);
       expect(newTree.exists('/src/app/.browserslistrc')).toBeTrue();
     });
   });

--- a/packages/schematics/angular/migrations/update-15/remove-platform-server-exports_spec.ts
+++ b/packages/schematics/angular/migrations/update-15/remove-platform-server-exports_spec.ts
@@ -35,7 +35,7 @@ describe('Migration to delete platform-server exports', () => {
         `,
       );
 
-      const newTree = await schematicRunner.runSchematicAsync(schematicName, {}, tree).toPromise();
+      const newTree = await schematicRunner.runSchematic(schematicName, {}, tree);
       const content = newTree.readText(testTypeScriptFilePath);
       expect(content).not.toContain('@angular/platform-server');
       expect(content).toContain(`import { Path, join } from '@angular-devkit/core';`);
@@ -50,7 +50,7 @@ describe('Migration to delete platform-server exports', () => {
         `,
       );
 
-      const newTree = await schematicRunner.runSchematicAsync(schematicName, {}, tree).toPromise();
+      const newTree = await schematicRunner.runSchematic(schematicName, {}, tree);
       const content = newTree.readContent(testTypeScriptFilePath);
       expect(content).toContain(`import { Path, join } from '@angular-devkit/core';`);
       expect(content).toContain(`export { ServerModule } from '@angular/platform-server';`);
@@ -64,7 +64,7 @@ describe('Migration to delete platform-server exports', () => {
         `,
       );
 
-      const newTree = await schematicRunner.runSchematicAsync(schematicName, {}, tree).toPromise();
+      const newTree = await schematicRunner.runSchematic(schematicName, {}, tree);
       const content = newTree.readText(testTypeScriptFilePath);
       expect(content).toContain(`export { renderModule } from '@angular/core';`);
     });
@@ -77,7 +77,7 @@ describe('Migration to delete platform-server exports', () => {
         `,
       );
 
-      const newTree = await schematicRunner.runSchematicAsync(schematicName, {}, tree).toPromise();
+      const newTree = await schematicRunner.runSchematic(schematicName, {}, tree);
       const content = newTree.readText(testTypeScriptFilePath);
       expect(content).toContain(`import { renderModule } from '@angular/platform-server'`);
     });

--- a/packages/schematics/angular/migrations/update-15/update-karma-main-file_spec.ts
+++ b/packages/schematics/angular/migrations/update-15/update-karma-main-file_spec.ts
@@ -116,7 +116,7 @@ describe(`Migration to karma builder main file (test.ts)`, () => {
   });
 
   it(`should remove 'declare const require' and 'require.context' usages`, async () => {
-    const newTree = await schematicRunner.runSchematicAsync(schematicName, {}, tree).toPromise();
+    const newTree = await schematicRunner.runSchematic(schematicName, {}, tree);
     expect(newTree.readText('test.ts')).toBe(tags.stripIndents`
       import { getTestBed } from '@angular/core/testing';
       import {
@@ -133,7 +133,7 @@ describe(`Migration to karma builder main file (test.ts)`, () => {
   });
 
   it(`should remove multiple 'require.context' usages`, async () => {
-    const newTree = await schematicRunner.runSchematicAsync(schematicName, {}, tree).toPromise();
+    const newTree = await schematicRunner.runSchematic(schematicName, {}, tree);
     expect(newTree.readText('test-multiple-context.ts')).toBe(tags.stripIndents`
       import { getTestBed } from '@angular/core/testing';
       import {

--- a/packages/schematics/angular/migrations/update-15/update-typescript-target_spec.ts
+++ b/packages/schematics/angular/migrations/update-15/update-typescript-target_spec.ts
@@ -94,7 +94,7 @@ describe('Migration to update target and add useDefineForClassFields', () => {
   });
 
   it(`should update target and add useDefineForClassFields in workspace 'tsconfig.json'`, async () => {
-    const newTree = await schematicRunner.runSchematicAsync(schematicName, {}, tree).toPromise();
+    const newTree = await schematicRunner.runSchematic(schematicName, {}, tree);
     const compilerOptions = getCompilerOptionsValue(newTree, 'tsconfig.json');
     expect(compilerOptions).toEqual(
       jasmine.objectContaining({
@@ -105,7 +105,7 @@ describe('Migration to update target and add useDefineForClassFields', () => {
   });
 
   it(`should remove target value from tsconfig referenced in options and configuration`, async () => {
-    const newTree = await schematicRunner.runSchematicAsync(schematicName, {}, tree).toPromise();
+    const newTree = await schematicRunner.runSchematic(schematicName, {}, tree);
     {
       const compilerOptions = getCompilerOptionsValue(newTree, 'src/tsconfig.app.prod.json');
       expect(compilerOptions['target']).toBeUndefined();
@@ -119,7 +119,7 @@ describe('Migration to update target and add useDefineForClassFields', () => {
   });
 
   it('should add target and useDefineForClassFields when tsconfig is not extended', async () => {
-    const newTree = await schematicRunner.runSchematicAsync(schematicName, {}, tree).toPromise();
+    const newTree = await schematicRunner.runSchematic(schematicName, {}, tree);
     const compilerOptions = getCompilerOptionsValue(newTree, 'src/tsconfig.spec.json');
     expect(compilerOptions).toEqual(
       jasmine.objectContaining({
@@ -131,7 +131,7 @@ describe('Migration to update target and add useDefineForClassFields', () => {
 
   it('should not add useDefineForClassFields when tsconfig target is ES2022', async () => {
     createJsonFile(tree, 'tsconfig.json', { compilerOptions: { 'target': 'es2022' } });
-    const newTree = await schematicRunner.runSchematicAsync(schematicName, {}, tree).toPromise();
+    const newTree = await schematicRunner.runSchematic(schematicName, {}, tree);
 
     const compilerOptions = getCompilerOptionsValue(newTree, 'tsconfig.json');
     expect(compilerOptions).toEqual({ target: 'es2022' });
@@ -139,7 +139,7 @@ describe('Migration to update target and add useDefineForClassFields', () => {
 
   it('should not add useDefineForClassFields when tsconfig target is ESNEXT', async () => {
     createJsonFile(tree, 'tsconfig.json', { compilerOptions: { 'target': 'esnext' } });
-    const newTree = await schematicRunner.runSchematicAsync(schematicName, {}, tree).toPromise();
+    const newTree = await schematicRunner.runSchematic(schematicName, {}, tree);
 
     const compilerOptions = getCompilerOptionsValue(newTree, 'tsconfig.json');
     expect(compilerOptions).toEqual({ target: 'esnext' });

--- a/packages/schematics/angular/migrations/update-15/update-workspace-config_spec.ts
+++ b/packages/schematics/angular/migrations/update-15/update-workspace-config_spec.ts
@@ -78,7 +78,7 @@ describe(`Migration to update 'angular.json'. ${schematicName}`, () => {
   });
 
   it(`should remove 'bundleDependencies'`, async () => {
-    const newTree = await schematicRunner.runSchematicAsync(schematicName, {}, tree).toPromise();
+    const newTree = await schematicRunner.runSchematic(schematicName, {}, tree);
     const { options, configurations } = getServerTarget(newTree);
 
     expect(options.bundleDependencies).toBeUndefined();
@@ -88,7 +88,7 @@ describe(`Migration to update 'angular.json'. ${schematicName}`, () => {
   });
 
   it(`should add 'vendorChunk: true' to development configuration`, async () => {
-    const newTree = await schematicRunner.runSchematicAsync(schematicName, {}, tree).toPromise();
+    const newTree = await schematicRunner.runSchematic(schematicName, {}, tree);
     const { options, configurations } = getServerTarget(newTree);
 
     expect(options.bundleDependencies).toBeUndefined();

--- a/packages/schematics/angular/module/index_spec.ts
+++ b/packages/schematics/angular/module/index_spec.ts
@@ -39,16 +39,14 @@ describe('Module Schematic', () => {
   };
   let appTree: UnitTestTree;
   beforeEach(async () => {
-    appTree = await schematicRunner.runSchematicAsync('workspace', workspaceOptions).toPromise();
-    appTree = await schematicRunner
-      .runSchematicAsync('application', appOptions, appTree)
-      .toPromise();
+    appTree = await schematicRunner.runSchematic('workspace', workspaceOptions);
+    appTree = await schematicRunner.runSchematic('application', appOptions, appTree);
   });
 
   it('should create a module', async () => {
     const options = { ...defaultOptions };
 
-    const tree = await schematicRunner.runSchematicAsync('module', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('module', options, appTree);
     const files = tree.files;
     expect(files).toContain('/projects/bar/src/app/foo/foo.module.ts');
   });
@@ -56,7 +54,7 @@ describe('Module Schematic', () => {
   it('should import into another module', async () => {
     const options = { ...defaultOptions, module: 'app.module.ts' };
 
-    const tree = await schematicRunner.runSchematicAsync('module', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('module', options, appTree);
     const content = tree.readContent('/projects/bar/src/app/app.module.ts');
     expect(content).toMatch(/import { FooModule } from '.\/foo\/foo.module'/);
     expect(content).toMatch(/imports: \[[^\]]*FooModule[^\]]*\]/m);
@@ -65,7 +63,7 @@ describe('Module Schematic', () => {
   it('should import into another module when using flat', async () => {
     const options = { ...defaultOptions, flat: true, module: 'app.module.ts' };
 
-    const tree = await schematicRunner.runSchematicAsync('module', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('module', options, appTree);
     const content = tree.readContent('/projects/bar/src/app/app.module.ts');
     expect(content).toMatch(/import { FooModule } from '.\/foo.module'/);
     expect(content).toMatch(/imports: \[[^\]]*FooModule[^\]]*\]/m);
@@ -74,7 +72,7 @@ describe('Module Schematic', () => {
   it('should import into another module when using flat', async () => {
     const options = { ...defaultOptions, flat: true, module: 'app.module.ts' };
 
-    const tree = await schematicRunner.runSchematicAsync('module', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('module', options, appTree);
     const content = tree.readContent('/projects/bar/src/app/app.module.ts');
     expect(content).toMatch(/import { FooModule } from '.\/foo.module'/);
     expect(content).toMatch(/imports: \[[^\]]*FooModule[^\]]*\]/m);
@@ -83,29 +81,25 @@ describe('Module Schematic', () => {
   it('should import into another module (deep)', async () => {
     let tree = appTree;
 
-    tree = await schematicRunner
-      .runSchematicAsync(
-        'module',
-        {
-          ...defaultOptions,
-          path: 'projects/bar/src/app/sub1',
-          name: 'test1',
-        },
-        tree,
-      )
-      .toPromise();
-    tree = await schematicRunner
-      .runSchematicAsync(
-        'module',
-        {
-          ...defaultOptions,
-          path: 'projects/bar/src/app/sub2',
-          name: 'test2',
-          module: '../sub1/test1',
-        },
-        tree,
-      )
-      .toPromise();
+    tree = await schematicRunner.runSchematic(
+      'module',
+      {
+        ...defaultOptions,
+        path: 'projects/bar/src/app/sub1',
+        name: 'test1',
+      },
+      tree,
+    );
+    tree = await schematicRunner.runSchematic(
+      'module',
+      {
+        ...defaultOptions,
+        path: 'projects/bar/src/app/sub2',
+        name: 'test2',
+        module: '../sub1/test1',
+      },
+      tree,
+    );
 
     const content = tree.readContent('/projects/bar/src/app/sub1/test1/test1.module.ts');
     expect(content).toMatch(/import { Test2Module } from '..\/..\/sub2\/test2\/test2.module'/);
@@ -114,7 +108,7 @@ describe('Module Schematic', () => {
   it('should create a routing module', async () => {
     const options = { ...defaultOptions, routing: true };
 
-    const tree = await schematicRunner.runSchematicAsync('module', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('module', options, appTree);
     const files = tree.files;
     expect(files).toContain('/projects/bar/src/app/foo/foo.module.ts');
     expect(files).toContain('/projects/bar/src/app/foo/foo-routing.module.ts');
@@ -129,7 +123,7 @@ describe('Module Schematic', () => {
   it('should dasherize a name', async () => {
     const options = { ...defaultOptions, name: 'TwoWord' };
 
-    const tree = await schematicRunner.runSchematicAsync('module', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('module', options, appTree);
     const files = tree.files;
     expect(files).toContain('/projects/bar/src/app/two-word/two-word.module.ts');
   });
@@ -138,9 +132,7 @@ describe('Module Schematic', () => {
     const config = JSON.parse(appTree.readContent('/angular.json'));
     config.projects.bar.sourceRoot = 'projects/bar/custom';
     appTree.overwrite('/angular.json', JSON.stringify(config, null, 2));
-    appTree = await schematicRunner
-      .runSchematicAsync('module', defaultOptions, appTree)
-      .toPromise();
+    appTree = await schematicRunner.runSchematic('module', defaultOptions, appTree);
     expect(appTree.files).toContain('/projects/bar/custom/app/foo/foo.module.ts');
   });
 
@@ -152,7 +144,7 @@ describe('Module Schematic', () => {
     };
 
     it('should generate a lazy loaded module with a routing module', async () => {
-      const tree = await schematicRunner.runSchematicAsync('module', options, appTree).toPromise();
+      const tree = await schematicRunner.runSchematic('module', options, appTree);
       const files = tree.files;
 
       expect(files).toEqual(
@@ -204,7 +196,7 @@ describe('Module Schematic', () => {
       );
       appTree.delete('/projects/bar/src/app/app-routing.module.ts');
 
-      const tree = await schematicRunner.runSchematicAsync('module', options, appTree).toPromise();
+      const tree = await schematicRunner.runSchematic('module', options, appTree);
       const files = tree.files;
 
       expect(files).toContain('/projects/bar/src/app/foo/foo.module.ts');
@@ -226,9 +218,11 @@ describe('Module Schematic', () => {
     });
 
     it('should generate a lazy loaded module when "flat" flag is true', async () => {
-      const tree = await schematicRunner
-        .runSchematicAsync('module', { ...options, flat: true }, appTree)
-        .toPromise();
+      const tree = await schematicRunner.runSchematic(
+        'module',
+        { ...options, flat: true },
+        appTree,
+      );
       const files = tree.files;
 
       expect(files).toEqual(
@@ -250,31 +244,26 @@ describe('Module Schematic', () => {
     });
 
     it('should generate a lazy loaded module and add route in another parallel routing module', async () => {
-      await schematicRunner
-        .runSchematicAsync(
-          'module',
-          {
-            ...defaultOptions,
-            name: 'foo',
-            routing: true,
-          },
-          appTree,
-        )
-        .toPromise();
+      await schematicRunner.runSchematic(
+        'module',
+        {
+          ...defaultOptions,
+          name: 'foo',
+          routing: true,
+        },
+        appTree,
+      );
 
-      const tree = await schematicRunner
-        .runSchematicAsync(
-          'module',
-          {
-            ...defaultOptions,
-            name: 'bar',
-            module: 'foo',
-            route: 'new-route',
-          },
-          appTree,
-        )
-        .toPromise();
-
+      const tree = await schematicRunner.runSchematic(
+        'module',
+        {
+          ...defaultOptions,
+          name: 'bar',
+          module: 'foo',
+          route: 'new-route',
+        },
+        appTree,
+      );
       expect(tree.files).toEqual(
         jasmine.arrayContaining([
           '/projects/bar/src/app/foo/foo-routing.module.ts',
@@ -320,20 +309,17 @@ describe('Module Schematic', () => {
       `,
       );
 
-      const tree = await schematicRunner
-        .runSchematicAsync(
-          'module',
-          {
-            ...defaultOptions,
-            name: 'bar',
-            route: 'bar',
-            routing: true,
-            module: 'app.module.ts',
-          },
-          appTree,
-        )
-        .toPromise();
-
+      const tree = await schematicRunner.runSchematic(
+        'module',
+        {
+          ...defaultOptions,
+          name: 'bar',
+          route: 'bar',
+          routing: true,
+          module: 'app.module.ts',
+        },
+        appTree,
+      );
       const content = tree.readContent('/projects/bar/src/app/bar/bar.module.ts');
       expect(content).toContain('RouterModule.forChild(routes)');
       expect(content).not.toContain('BarRoutingModule');

--- a/packages/schematics/angular/ng-new/index_spec.ts
+++ b/packages/schematics/angular/ng-new/index_spec.ts
@@ -23,7 +23,7 @@ describe('Ng New Schematic', () => {
   it('should create files of a workspace', async () => {
     const options = { ...defaultOptions };
 
-    const tree = await schematicRunner.runSchematicAsync('ng-new', options).toPromise();
+    const tree = await schematicRunner.runSchematic('ng-new', options);
     const files = tree.files;
     expect(files).toContain('/bar/angular.json');
   });
@@ -31,7 +31,7 @@ describe('Ng New Schematic', () => {
   it('should create files of an application', async () => {
     const options = { ...defaultOptions };
 
-    const tree = await schematicRunner.runSchematicAsync('ng-new', options).toPromise();
+    const tree = await schematicRunner.runSchematic('ng-new', options);
     const files = tree.files;
     expect(files).toEqual(
       jasmine.arrayContaining([
@@ -45,7 +45,7 @@ describe('Ng New Schematic', () => {
   it('should should set the prefix in angular.json and in app.component.ts', async () => {
     const options = { ...defaultOptions, prefix: 'pre' };
 
-    const tree = await schematicRunner.runSchematicAsync('ng-new', options).toPromise();
+    const tree = await schematicRunner.runSchematic('ng-new', options);
     const content = tree.readContent('/bar/angular.json');
     expect(content).toMatch(/"prefix": "pre"/);
   });
@@ -56,7 +56,7 @@ describe('Ng New Schematic', () => {
       version: '6.0.0',
     };
 
-    const tree = await schematicRunner.runSchematicAsync('ng-new', options).toPromise();
+    const tree = await schematicRunner.runSchematic('ng-new', options);
     const moduleContent = tree.readContent('/foo/src/app/app.module.ts');
     expect(moduleContent).toMatch(/declarations:\s*\[\s*AppComponent\s*\]/m);
   });
@@ -64,7 +64,7 @@ describe('Ng New Schematic', () => {
   it('createApplication=false should create an empty workspace', async () => {
     const options = { ...defaultOptions, createApplication: false };
 
-    const tree = await schematicRunner.runSchematicAsync('ng-new', options).toPromise();
+    const tree = await schematicRunner.runSchematic('ng-new', options);
     const files = tree.files;
     expect(files).toContain('/bar/angular.json');
     expect(files).not.toContain('/bar/src');
@@ -73,15 +73,16 @@ describe('Ng New Schematic', () => {
   it('minimal=true should not create an e2e target', async () => {
     const options = { ...defaultOptions, minimal: true };
 
-    const tree = await schematicRunner.runSchematicAsync('ng-new', options).toPromise();
+    const tree = await schematicRunner.runSchematic('ng-new', options);
     const confContent = JSON.parse(tree.readContent('/bar/angular.json'));
     expect(confContent.projects.foo.e2e).toBeUndefined();
   });
 
   it('should add packageManager option in angular.json', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('ng-new', { ...defaultOptions, packageManager: 'npm' })
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('ng-new', {
+      ...defaultOptions,
+      packageManager: 'npm',
+    });
     const { cli } = JSON.parse(tree.readContent('/bar/angular.json'));
     expect(cli.packageManager).toBe('npm');
   });

--- a/packages/schematics/angular/resolver/index_spec.ts
+++ b/packages/schematics/angular/resolver/index_spec.ts
@@ -37,16 +37,12 @@ describe('resolver Schematic', () => {
   };
   let appTree: UnitTestTree;
   beforeEach(async () => {
-    appTree = await schematicRunner.runSchematicAsync('workspace', workspaceOptions).toPromise();
-    appTree = await schematicRunner
-      .runSchematicAsync('application', appOptions, appTree)
-      .toPromise();
+    appTree = await schematicRunner.runSchematic('workspace', workspaceOptions);
+    appTree = await schematicRunner.runSchematic('application', appOptions, appTree);
   });
 
   it('should create a resolver', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('resolver', defaultOptions, appTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('resolver', defaultOptions, appTree);
     const files = tree.files;
     expect(files).toContain('/projects/bar/src/app/foo.resolver.spec.ts');
     expect(files).toContain('/projects/bar/src/app/foo.resolver.ts');
@@ -55,7 +51,7 @@ describe('resolver Schematic', () => {
   it('should respect the skipTests flag', async () => {
     const options = { ...defaultOptions, skipTests: true };
 
-    const tree = await schematicRunner.runSchematicAsync('resolver', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('resolver', options, appTree);
     const files = tree.files;
     expect(files).not.toContain('/projects/bar/src/app/foo.resolver.spec.ts');
     expect(files).toContain('/projects/bar/src/app/foo.resolver.ts');
@@ -64,7 +60,7 @@ describe('resolver Schematic', () => {
   it('should respect the flat flag', async () => {
     const options = { ...defaultOptions, flat: false };
 
-    const tree = await schematicRunner.runSchematicAsync('resolver', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('resolver', options, appTree);
     const files = tree.files;
     expect(files).toContain('/projects/bar/src/app/foo/foo.resolver.spec.ts');
     expect(files).toContain('/projects/bar/src/app/foo/foo.resolver.ts');
@@ -74,16 +70,16 @@ describe('resolver Schematic', () => {
     const config = JSON.parse(appTree.readContent('/angular.json'));
     config.projects.bar.sourceRoot = 'projects/bar/custom';
     appTree.overwrite('/angular.json', JSON.stringify(config, null, 2));
-    appTree = await schematicRunner
-      .runSchematicAsync('resolver', defaultOptions, appTree)
-      .toPromise();
+    appTree = await schematicRunner.runSchematic('resolver', defaultOptions, appTree);
     expect(appTree.files).toContain('/projects/bar/custom/app/foo.resolver.ts');
   });
 
   it('should create a functional resolver', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('resolver', { ...defaultOptions, functional: true }, appTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic(
+      'resolver',
+      { ...defaultOptions, functional: true },
+      appTree,
+    );
     const fileString = tree.readContent('/projects/bar/src/app/foo.resolver.ts');
     expect(fileString).toContain(
       'export const fooResolver: ResolveFn<boolean> = (route, state) => {',
@@ -91,9 +87,11 @@ describe('resolver Schematic', () => {
   });
 
   it('should create a helper function to run a functional resolver in a test', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('resolver', { ...defaultOptions, functional: true }, appTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic(
+      'resolver',
+      { ...defaultOptions, functional: true },
+      appTree,
+    );
     const fileString = tree.readContent('/projects/bar/src/app/foo.resolver.spec.ts');
     expect(fileString).toContain(
       'const executeResolver: ResolveFn<boolean> = (...resolverParameters) => ',

--- a/packages/schematics/angular/service-worker/index_spec.ts
+++ b/packages/schematics/angular/service-worker/index_spec.ts
@@ -39,16 +39,12 @@ describe('Service Worker Schematic', () => {
   };
 
   beforeEach(async () => {
-    appTree = await schematicRunner.runSchematicAsync('workspace', workspaceOptions).toPromise();
-    appTree = await schematicRunner
-      .runSchematicAsync('application', appOptions, appTree)
-      .toPromise();
+    appTree = await schematicRunner.runSchematic('workspace', workspaceOptions);
+    appTree = await schematicRunner.runSchematic('application', appOptions, appTree);
   });
 
   it('should add `serviceWorker` option to build target', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('service-worker', defaultOptions, appTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('service-worker', defaultOptions, appTree);
     const configText = tree.readContent('/angular.json');
     const buildConfig = JSON.parse(configText).projects.bar.architect.build;
 
@@ -56,9 +52,7 @@ describe('Service Worker Schematic', () => {
   });
 
   it('should add the necessary dependency', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('service-worker', defaultOptions, appTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('service-worker', defaultOptions, appTree);
     const pkgText = tree.readContent('/package.json');
     const pkg = JSON.parse(pkgText);
     const version = pkg.dependencies['@angular/core'];
@@ -66,17 +60,13 @@ describe('Service Worker Schematic', () => {
   });
 
   it('should import ServiceWorkerModule', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('service-worker', defaultOptions, appTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('service-worker', defaultOptions, appTree);
     const pkgText = tree.readContent('/projects/bar/src/app/app.module.ts');
     expect(pkgText).toMatch(/import \{ ServiceWorkerModule \} from '@angular\/service-worker'/);
   });
 
   it('should add the SW import to the NgModule imports', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('service-worker', defaultOptions, appTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('service-worker', defaultOptions, appTree);
     const pkgText = tree.readContent('/projects/bar/src/app/app.module.ts');
     expect(pkgText).toMatch(
       new RegExp(
@@ -91,9 +81,7 @@ describe('Service Worker Schematic', () => {
   });
 
   it('should put the ngsw-config.json file in the project root', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('service-worker', defaultOptions, appTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('service-worker', defaultOptions, appTree);
     const path = '/projects/bar/ngsw-config.json';
     expect(tree.exists(path)).toEqual(true);
 
@@ -116,28 +104,28 @@ describe('Service Worker Schematic', () => {
       ...defaultOptions,
       project: name,
     };
-    const rootAppTree = await schematicRunner
-      .runSchematicAsync('application', rootAppOptions, appTree)
-      .toPromise();
-    const treeInRoot = await schematicRunner
-      .runSchematicAsync('service-worker', rootSWOptions, rootAppTree)
-      .toPromise();
+    const rootAppTree = await schematicRunner.runSchematic('application', rootAppOptions, appTree);
+    const treeInRoot = await schematicRunner.runSchematic(
+      'service-worker',
+      rootSWOptions,
+      rootAppTree,
+    );
     const pkgTextInRoot = treeInRoot.readContent('/ngsw-config.json');
     const configInRoot = JSON.parse(pkgTextInRoot);
     expect(configInRoot.$schema).toBe(`./${pathToNgswConfigSchema}`);
 
-    const treeNotInRoot = await schematicRunner
-      .runSchematicAsync('service-worker', defaultOptions, appTree)
-      .toPromise();
+    const treeNotInRoot = await schematicRunner.runSchematic(
+      'service-worker',
+      defaultOptions,
+      appTree,
+    );
     const pkgTextNotInRoot = treeNotInRoot.readContent('/projects/bar/ngsw-config.json');
     const configNotInRoot = JSON.parse(pkgTextNotInRoot);
     expect(configNotInRoot.$schema).toBe(`../../${pathToNgswConfigSchema}`);
   });
 
   it('should add root assets RegExp', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('service-worker', defaultOptions, appTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('service-worker', defaultOptions, appTree);
     const pkgText = tree.readContent('/projects/bar/ngsw-config.json');
     const config = JSON.parse(pkgText);
     expect(config.assetGroups[1].resources.files).toContain(
@@ -149,9 +137,7 @@ describe('Service Worker Schematic', () => {
     const config = JSON.parse(appTree.readContent('/angular.json'));
     config.projects.bar.architect.build.options.resourcesOutputPath = 'outDir';
     appTree.overwrite('/angular.json', JSON.stringify(config));
-    const tree = await schematicRunner
-      .runSchematicAsync('service-worker', defaultOptions, appTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('service-worker', defaultOptions, appTree);
     const pkgText = tree.readContent('/projects/bar/ngsw-config.json');
     const ngswConfig = JSON.parse(pkgText);
     expect(ngswConfig.assetGroups[1].resources.files).toContain(
@@ -171,12 +157,8 @@ describe('Service Worker Schematic', () => {
       project: name,
     };
 
-    let tree = await schematicRunner
-      .runSchematicAsync('application', rootAppOptions, appTree)
-      .toPromise();
-    tree = await schematicRunner
-      .runSchematicAsync('service-worker', rootSWOptions, tree)
-      .toPromise();
+    let tree = await schematicRunner.runSchematic('application', rootAppOptions, appTree);
+    tree = await schematicRunner.runSchematic('service-worker', rootSWOptions, tree);
     expect(tree.exists('/ngsw-config.json')).toBe(true);
 
     const { projects } = JSON.parse(tree.readContent('/angular.json'));

--- a/packages/schematics/angular/service/index_spec.ts
+++ b/packages/schematics/angular/service/index_spec.ts
@@ -37,16 +37,14 @@ describe('Service Schematic', () => {
   };
   let appTree: UnitTestTree;
   beforeEach(async () => {
-    appTree = await schematicRunner.runSchematicAsync('workspace', workspaceOptions).toPromise();
-    appTree = await schematicRunner
-      .runSchematicAsync('application', appOptions, appTree)
-      .toPromise();
+    appTree = await schematicRunner.runSchematic('workspace', workspaceOptions);
+    appTree = await schematicRunner.runSchematic('application', appOptions, appTree);
   });
 
   it('should create a service', async () => {
     const options = { ...defaultOptions };
 
-    const tree = await schematicRunner.runSchematicAsync('service', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('service', options, appTree);
     const files = tree.files;
     expect(files).toContain('/projects/bar/src/app/foo/foo.service.spec.ts');
     expect(files).toContain('/projects/bar/src/app/foo/foo.service.ts');
@@ -55,7 +53,7 @@ describe('Service Schematic', () => {
   it('service should be tree-shakeable', async () => {
     const options = { ...defaultOptions };
 
-    const tree = await schematicRunner.runSchematicAsync('service', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('service', options, appTree);
     const content = tree.readContent('/projects/bar/src/app/foo/foo.service.ts');
     expect(content).toMatch(/providedIn: 'root'/);
   });
@@ -63,7 +61,7 @@ describe('Service Schematic', () => {
   it('should respect the skipTests flag', async () => {
     const options = { ...defaultOptions, skipTests: true };
 
-    const tree = await schematicRunner.runSchematicAsync('service', options, appTree).toPromise();
+    const tree = await schematicRunner.runSchematic('service', options, appTree);
     const files = tree.files;
     expect(files).toContain('/projects/bar/src/app/foo/foo.service.ts');
     expect(files).not.toContain('/projects/bar/src/app/foo/foo.service.spec.ts');
@@ -73,9 +71,7 @@ describe('Service Schematic', () => {
     const config = JSON.parse(appTree.readContent('/angular.json'));
     config.projects.bar.sourceRoot = 'projects/bar/custom';
     appTree.overwrite('/angular.json', JSON.stringify(config, null, 2));
-    appTree = await schematicRunner
-      .runSchematicAsync('service', defaultOptions, appTree)
-      .toPromise();
+    appTree = await schematicRunner.runSchematic('service', defaultOptions, appTree);
     expect(appTree.files).toContain('/projects/bar/custom/app/foo/foo.service.ts');
   });
 });

--- a/packages/schematics/angular/universal/index_spec.ts
+++ b/packages/schematics/angular/universal/index_spec.ts
@@ -56,27 +56,23 @@ describe('Universal Schematic', () => {
   let appTree: UnitTestTree;
 
   beforeEach(async () => {
-    appTree = await schematicRunner.runSchematicAsync('workspace', workspaceOptions).toPromise();
-    appTree = await schematicRunner
-      .runSchematicAsync('application', initialWorkspaceAppOptions, appTree)
-      .toPromise();
-    appTree = await schematicRunner
-      .runSchematicAsync('application', appOptions, appTree)
-      .toPromise();
+    appTree = await schematicRunner.runSchematic('workspace', workspaceOptions);
+    appTree = await schematicRunner.runSchematic(
+      'application',
+      initialWorkspaceAppOptions,
+      appTree,
+    );
+    appTree = await schematicRunner.runSchematic('application', appOptions, appTree);
   });
 
   it('should create a root module file', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('universal', defaultOptions, appTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('universal', defaultOptions, appTree);
     const filePath = '/projects/bar/src/app/app.server.module.ts';
     expect(tree.exists(filePath)).toEqual(true);
   });
 
   it('should create a main file', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('universal', defaultOptions, appTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('universal', defaultOptions, appTree);
     const filePath = '/projects/bar/src/main.server.ts';
     expect(tree.exists(filePath)).toEqual(true);
     const contents = tree.readContent(filePath);
@@ -84,9 +80,11 @@ describe('Universal Schematic', () => {
   });
 
   it('should create a tsconfig file for the workspace project', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('universal', workspaceUniversalOptions, appTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic(
+      'universal',
+      workspaceUniversalOptions,
+      appTree,
+    );
     const filePath = '/tsconfig.server.json';
     expect(tree.exists(filePath)).toEqual(true);
     const contents = parseJson(tree.readContent(filePath).toString());
@@ -105,9 +103,7 @@ describe('Universal Schematic', () => {
   });
 
   it('should create a tsconfig file for a generated application', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('universal', defaultOptions, appTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('universal', defaultOptions, appTree);
     const filePath = '/projects/bar/tsconfig.server.json';
     expect(tree.exists(filePath)).toEqual(true);
     const contents = parseJson(tree.readContent(filePath).toString());
@@ -126,18 +122,14 @@ describe('Universal Schematic', () => {
   });
 
   it('should add dependency: @angular/platform-server', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('universal', defaultOptions, appTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('universal', defaultOptions, appTree);
     const filePath = '/package.json';
     const contents = tree.readContent(filePath);
     expect(contents).toMatch(/"@angular\/platform-server": "/);
   });
 
   it('should update workspace with a server target', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('universal', defaultOptions, appTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('universal', defaultOptions, appTree);
     const filePath = '/angular.json';
     const contents = tree.readContent(filePath);
     const config = JSON.parse(contents.toString());
@@ -151,9 +143,7 @@ describe('Universal Schematic', () => {
   });
 
   it('should update workspace with a build target outputPath', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('universal', defaultOptions, appTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('universal', defaultOptions, appTree);
     const filePath = '/angular.json';
     const contents = tree.readContent(filePath);
     const config = JSON.parse(contents.toString());
@@ -162,18 +152,14 @@ describe('Universal Schematic', () => {
   });
 
   it('should add a server transition to BrowserModule import', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('universal', defaultOptions, appTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('universal', defaultOptions, appTree);
     const filePath = '/projects/bar/src/app/app.module.ts';
     const contents = tree.readContent(filePath);
     expect(contents).toMatch(/BrowserModule\.withServerTransition\({ appId: 'serverApp' }\)/);
   });
 
   it('should wrap the bootstrap call in a DOMContentLoaded event handler', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('universal', defaultOptions, appTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('universal', defaultOptions, appTree);
     const filePath = '/projects/bar/src/main.ts';
     const contents = tree.readContent(filePath);
     expect(contents).toContain(`document.addEventListener('DOMContentLoaded', bootstrap);`);
@@ -197,15 +183,13 @@ describe('Universal Schematic', () => {
       `,
     );
 
-    const tree = await schematicRunner
-      .runSchematicAsync('universal', defaultOptions, appTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('universal', defaultOptions, appTree);
     const contents = tree.readContent(filePath);
     expect(contents).toContain(`document.addEventListener('DOMContentLoaded', bootstrap);`);
   });
 
   it('should install npm dependencies', async () => {
-    await schematicRunner.runSchematicAsync('universal', defaultOptions, appTree).toPromise();
+    await schematicRunner.runSchematic('universal', defaultOptions, appTree);
     expect(schematicRunner.tasks.length).toBe(1);
     expect(schematicRunner.tasks[0].name).toBe('node-package');
     expect((schematicRunner.tasks[0].options as { command: string }).command).toBe('install');
@@ -216,18 +200,13 @@ describe('Universal Schematic', () => {
     const appTsConfigContent = appTree.readContent(appTsConfigPath);
     appTree.overwrite(appTsConfigPath, '// comment in json file\n' + appTsConfigContent);
 
-    const tree = await schematicRunner
-      .runSchematicAsync('universal', defaultOptions, appTree)
-      .toPromise();
-
+    const tree = await schematicRunner.runSchematic('universal', defaultOptions, appTree);
     const filePath = '/projects/bar/tsconfig.server.json';
     expect(tree.exists(filePath)).toEqual(true);
   });
 
   it(`should not add import to '@angular/localize' as type in 'tsconfig.server.json' when it's not a dependency`, async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('universal', defaultOptions, appTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('universal', defaultOptions, appTree);
     const { compilerOptions } = tree.readJson('/projects/bar/tsconfig.server.json') as {
       compilerOptions: CompilerOptions;
     };
@@ -240,10 +219,7 @@ describe('Universal Schematic', () => {
       type: NodeDependencyType.Default,
       version: 'latest',
     });
-    const tree = await schematicRunner
-      .runSchematicAsync('universal', defaultOptions, appTree)
-      .toPromise();
-
+    const tree = await schematicRunner.runSchematic('universal', defaultOptions, appTree);
     const { compilerOptions } = tree.readJson('/projects/bar/tsconfig.server.json') as {
       compilerOptions: CompilerOptions;
     };

--- a/packages/schematics/angular/web-worker/index_spec.ts
+++ b/packages/schematics/angular/web-worker/index_spec.ts
@@ -41,24 +41,18 @@ describe('Web Worker Schematic', () => {
   };
 
   beforeEach(async () => {
-    appTree = await schematicRunner.runSchematicAsync('workspace', workspaceOptions).toPromise();
-    appTree = await schematicRunner
-      .runSchematicAsync('application', appOptions, appTree)
-      .toPromise();
+    appTree = await schematicRunner.runSchematic('workspace', workspaceOptions);
+    appTree = await schematicRunner.runSchematic('application', appOptions, appTree);
   });
 
   it('should put the worker file in the project root', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('web-worker', defaultOptions, appTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('web-worker', defaultOptions, appTree);
     const path = '/projects/bar/src/app/app.worker.ts';
     expect(tree.exists(path)).toEqual(true);
   });
 
   it('should put the tsconfig.worker.json file in the project root', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('web-worker', defaultOptions, appTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('web-worker', defaultOptions, appTree);
     const path = '/projects/bar/tsconfig.worker.json';
     expect(tree.exists(path)).toEqual(true);
 
@@ -67,9 +61,7 @@ describe('Web Worker Schematic', () => {
   });
 
   it('should add the webWorkerTsConfig option to workspace', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('web-worker', defaultOptions, appTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('web-worker', defaultOptions, appTree);
     const { projects } = JSON.parse(tree.readContent('/angular.json'));
     expect(projects.bar.architect.build.options.webWorkerTsConfig).toBe(
       'projects/bar/tsconfig.worker.json',
@@ -77,9 +69,7 @@ describe('Web Worker Schematic', () => {
   });
 
   it('should add snippet to sibling file', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('web-worker', defaultOptions, appTree)
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('web-worker', defaultOptions, appTree);
     const appComponent = tree.readContent('/projects/bar/src/app/app.component.ts');
     expect(appComponent).toContain(`new Worker(new URL('./${defaultOptions.name}.worker`);
     expect(appComponent).toContain('console.log(`page got message: ${data}`)');
@@ -89,13 +79,8 @@ describe('Web Worker Schematic', () => {
     const rootAppOptions = { ...appOptions, projectRoot: '', name: 'foo' };
     const workerOptions = { ...defaultOptions, project: 'foo' };
 
-    appTree = await schematicRunner
-      .runSchematicAsync('application', rootAppOptions, appTree)
-      .toPromise();
-    const tree = await schematicRunner
-      .runSchematicAsync('web-worker', workerOptions, appTree)
-      .toPromise();
-
+    appTree = await schematicRunner.runSchematic('application', rootAppOptions, appTree);
+    const tree = await schematicRunner.runSchematic('web-worker', workerOptions, appTree);
     const path = '/tsconfig.worker.json';
     expect(tree.exists(path)).toEqual(true);
 

--- a/packages/schematics/angular/workspace/index_spec.ts
+++ b/packages/schematics/angular/workspace/index_spec.ts
@@ -24,7 +24,7 @@ describe('Workspace Schematic', () => {
   it('should create all files of a workspace', async () => {
     const options = { ...defaultOptions };
 
-    const tree = await schematicRunner.runSchematicAsync('workspace', options).toPromise();
+    const tree = await schematicRunner.runSchematic('workspace', options);
     const files = tree.files;
     expect(files).toEqual(
       jasmine.arrayContaining([
@@ -42,19 +42,19 @@ describe('Workspace Schematic', () => {
   });
 
   it('should set the name in package.json', async () => {
-    const tree = await schematicRunner.runSchematicAsync('workspace', defaultOptions).toPromise();
+    const tree = await schematicRunner.runSchematic('workspace', defaultOptions);
     const pkg = JSON.parse(tree.readContent('/package.json'));
     expect(pkg.name).toEqual('foo');
   });
 
   it('should set the CLI version in package.json', async () => {
-    const tree = await schematicRunner.runSchematicAsync('workspace', defaultOptions).toPromise();
+    const tree = await schematicRunner.runSchematic('workspace', defaultOptions);
     const pkg = JSON.parse(tree.readContent('/package.json'));
     expect(pkg.devDependencies['@angular/cli']).toMatch('6.0.0');
   });
 
   it('should use the latest known versions in package.json', async () => {
-    const tree = await schematicRunner.runSchematicAsync('workspace', defaultOptions).toPromise();
+    const tree = await schematicRunner.runSchematic('workspace', defaultOptions);
     const pkg = JSON.parse(tree.readContent('/package.json'));
     expect(pkg.dependencies['@angular/core']).toEqual(latestVersions.Angular);
     expect(pkg.dependencies['rxjs']).toEqual(latestVersions['rxjs']);
@@ -63,9 +63,10 @@ describe('Workspace Schematic', () => {
   });
 
   it('should create correct files when using minimal', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('workspace', { ...defaultOptions, minimal: true })
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('workspace', {
+      ...defaultOptions,
+      minimal: true,
+    });
     const files = tree.files;
     expect(files).toEqual(
       jasmine.arrayContaining([
@@ -84,15 +85,16 @@ describe('Workspace Schematic', () => {
   });
 
   it('should set the `enableI18nLegacyMessageIdFormat` Angular compiler option', async () => {
-    const tree = await schematicRunner.runSchematicAsync('workspace', defaultOptions).toPromise();
+    const tree = await schematicRunner.runSchematic('workspace', defaultOptions);
     const { angularCompilerOptions } = parseJson(tree.readContent('tsconfig.json').toString());
     expect(angularCompilerOptions.enableI18nLegacyMessageIdFormat).toBe(false);
   });
 
   it('should not add strict compiler options when false', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('workspace', { ...defaultOptions, strict: false })
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('workspace', {
+      ...defaultOptions,
+      strict: false,
+    });
     const { compilerOptions, angularCompilerOptions } = parseJson(
       tree.readContent('tsconfig.json').toString(),
     );
@@ -103,9 +105,10 @@ describe('Workspace Schematic', () => {
   });
 
   it('should add strict compiler options when true', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('workspace', { ...defaultOptions, strict: true })
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('workspace', {
+      ...defaultOptions,
+      strict: true,
+    });
     const { compilerOptions, angularCompilerOptions } = parseJson(
       tree.readContent('tsconfig.json').toString(),
     );
@@ -114,9 +117,7 @@ describe('Workspace Schematic', () => {
   });
 
   it('should add vscode testing configuration', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('workspace', { ...defaultOptions })
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('workspace', { ...defaultOptions });
     const { configurations } = parseJson(tree.readContent('.vscode/launch.json').toString());
     expect(configurations).toContain(jasmine.objectContaining({ name: 'ng test' }));
     const { tasks } = parseJson(tree.readContent('.vscode/tasks.json').toString());
@@ -124,9 +125,10 @@ describe('Workspace Schematic', () => {
   });
 
   it('should not add vscode testing configuration when using minimal', async () => {
-    const tree = await schematicRunner
-      .runSchematicAsync('workspace', { ...defaultOptions, minimal: true })
-      .toPromise();
+    const tree = await schematicRunner.runSchematic('workspace', {
+      ...defaultOptions,
+      minimal: true,
+    });
     const { configurations } = parseJson(tree.readContent('.vscode/launch.json').toString());
     expect(configurations).not.toContain(jasmine.objectContaining({ name: 'ng test' }));
     const { tasks } = parseJson(tree.readContent('.vscode/tasks.json').toString());


### PR DESCRIPTION

These async methods are a replacement for the Observable based `runSchematicAsync` and `runExternalSchematicAsync` methods.

DEPRECATED:
The Observable based `SchematicTestRunner.runSchematicAsync` and `SchematicTestRunner.runExternalSchematicAsync` method have been deprecated in favor of the Promise based `SchematicTestRunner.runSchematic` and `SchematicTestRunner.runExternalSchematic`.
