### PR TITLE
fix(@angular-devkit/build-angular): update locale setting snippet to use `globalThis`.

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/i18n-inlining.ts
+++ b/packages/angular_devkit/build_angular/src/utils/i18n-inlining.ts
@@ -42,7 +42,7 @@ function emittedFilesToInlineOptions(
       code: fs.readFileSync(originalPath, 'utf8'),
       outputPath,
       missingTranslation,
-      setLocale: emittedFile.name === 'main' || emittedFile.name === 'vendor',
+      setLocale: emittedFile.name === 'main',
     };
     originalFiles.push(originalPath);
 

--- a/packages/angular_devkit/build_angular/src/utils/process-bundle.ts
+++ b/packages/angular_devkit/build_angular/src/utils/process-bundle.ts
@@ -272,7 +272,7 @@ async function inlineLocalesDirect(ast: ParseResult, options: InlineOptions) {
 
     let outputSource: import('webpack').sources.Source = content;
     if (options.setLocale) {
-      const setLocaleText = `var $localize=Object.assign(void 0===$localize?{}:$localize,{locale:"${locale}"});\n`;
+      const setLocaleText = `globalThis.$localize=Object.assign(globalThis.$localize || {},{locale:"${locale}"});\n`;
 
       // If locale data is provided, load it and prepend to file
       let localeDataSource;


### PR DESCRIPTION

This commit changes how we set the `LOCALE_ID` when using the `localize` option

- We now include the locale setting snippet only in the main bundle.
- We use `globalThis` to set the the value globally and be accessible across module boundaries. This is important as in some causes such as when using MF `@angular/core` can be located in a bundles others than `main` and `vendor`.


FYI: @Coly010 