### PR TITLE
Allow extending generated webpack config of karma builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/plugins/karma/karma.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/plugins/karma/karma.ts
@@ -12,6 +12,7 @@ import * as http from 'http';
 import * as path from 'path';
 import webpack from 'webpack';
 import webpackDevMiddleware from 'webpack-dev-middleware';
+import { merge as webpackMerge } from 'webpack-merge';
 
 import { statsErrorsToString } from '../../utils/stats';
 import { createConsoleLogger } from '@angular-devkit/core/node';
@@ -71,16 +72,23 @@ const init: any = (config: any, emitter: any) => {
   }
 
   // Add webpack config.
-  const webpackConfig = config.buildWebpack.webpackConfig;
-  const webpackMiddlewareConfig = {
+  let webpackConfig = config.buildWebpack.webpackConfig;
+  let webpackMiddlewareConfig = {
     // Hide webpack output because its noisy.
     stats: false,
     publicPath: `/${KARMA_APPLICATION_PATH}/`,
   };
 
-  // Use existing config if any.
-  config.webpack = { ...webpackConfig, ...config.webpack };
-  config.webpackMiddleware = { ...webpackMiddlewareConfig, ...config.webpackMiddleware };
+  // Merge with existing config, if any.
+  if (config.webpack) {
+    config.webpack = webpackConfig = webpackMerge(webpackConfig, config.webpack);
+  }
+  if (config.webpackMiddleware) {
+    config.webpackMiddleware = webpackMiddlewareConfig = webpackMerge(
+      webpackMiddlewareConfig,
+      config.webpackMiddleware,
+    );
+  }
 
   // Our custom context and debug files list the webpack bundles directly instead of using
   // the karma files array.


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

The `@angular-devkit/build-angular:karma` builder generates a webpack configuration, and runs webpack (and karma) with that configuration. Currently that configuration cannot be changed by the user, even if the user provides a webpack configuration in their karma config.

## What is the new behavior?

The user's webpack configuration is merged together with the generated configuration, using `webpack-merge`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This was previously possible, but the commit 04f5dfe5e2fc97bcf0641f1d2f8edfc59dae57b2 replaced  `Object.assign(webpackConfig, config.webpack)` with a spread operator, which means that `webpackConfig` was not changed anymore.

Since the generated configuration uses functions (and the user's configuration could as well), `webpack-merge` is used to merge the configurations. Since `webpack-merge` will throw an error when passing undefined values, the code first checks that a value to-be-merged exists.