### PR TITLE
fix(@angular-devkit/build-angular): downlevel class private methods when targeting Safari <=v15

### DIFF
--- a/packages/angular_devkit/build_angular/src/babel/presets/application.ts
+++ b/packages/angular_devkit/build_angular/src/babel/presets/application.ts
@@ -197,7 +197,10 @@ export default function (api: unknown, options: ApplicationPresetOptions) {
     // downlevel class properties by ensuring the class properties Babel plugin
     // is always included- regardless of the preset-env targets.
     if (options.supportedBrowsers.some((b) => safariClassFieldScopeBugBrowsers.has(b))) {
-      includePlugins.push('@babel/plugin-proposal-class-properties');
+      includePlugins.push(
+        '@babel/plugin-proposal-class-properties',
+        '@babel/plugin-proposal-private-methods',
+      );
     }
 
     presets.push([


### PR DESCRIPTION

This commits enables `@babel/plugin-proposal-private-methods` when targeting Safari <=v15 as this is needed to handle private class methods when using `@babel/plugin-proposal-class-properties`.

Closes #24411
