### PR TITLE
feat(@angular-devkit/schematics): update `call`, `callRule` and `callSource` methods to promises

### DIFF
--- a/goldens/public-api/angular_devkit/schematics/index.md
+++ b/goldens/public-api/angular_devkit/schematics/index.md
@@ -139,10 +139,10 @@ interface BaseWorkflowOptions {
 export function branchAndMerge(rule: Rule, strategy?: MergeStrategy): Rule;
 
 // @public (undocumented)
-export function callRule(rule: Rule, input: Tree_2 | Observable<Tree_2>, context: SchematicContext): Observable<Tree_2>;
+export function callRule(rule: Rule, tree: Tree_2, context: SchematicContext): Promise<Tree_2>;
 
 // @public (undocumented)
-export function callSource(source: Source, context: SchematicContext): Observable<Tree_2>;
+export function callSource(source: Source, context: SchematicContext): Promise<Tree_2>;
 
 // @public
 export function chain(rules: Iterable<Rule> | AsyncIterable<Rule>): Rule;
@@ -720,7 +720,7 @@ interface RequiredWorkflowExecutionContext {
 }
 
 // @public (undocumented)
-export type Rule = (tree: Tree_2, context: SchematicContext) => Tree_2 | Observable<Tree_2> | Rule | Promise<void | Rule> | void;
+export type Rule = (tree: Tree_2, context: SchematicContext) => void | Rule | Tree_2 | Promise<void | Rule | Tree_2>;
 
 // @public
 export type RuleFactory<T extends object> = (options: T) => Rule;
@@ -728,7 +728,7 @@ export type RuleFactory<T extends object> = (options: T) => Rule;
 // @public
 export interface Schematic<CollectionMetadataT extends object, SchematicMetadataT extends object> {
     // (undocumented)
-    call<OptionT extends object>(options: OptionT, host: Observable<Tree_2>, parentContext?: Partial<TypedSchematicContext<CollectionMetadataT, SchematicMetadataT>>, executionOptions?: Partial<ExecutionOptions>): Observable<Tree_2>;
+    call<OptionT extends object>(options: OptionT, host: Tree_2, parentContext?: Partial<TypedSchematicContext<CollectionMetadataT, SchematicMetadataT>>, executionOptions?: Partial<ExecutionOptions>): Promise<Tree_2>;
     // (undocumented)
     readonly collection: Collection<CollectionMetadataT, SchematicMetadataT>;
     // (undocumented)
@@ -783,7 +783,7 @@ export class SchematicEngineConflictingException extends BaseException {
 export class SchematicImpl<CollectionT extends object, SchematicT extends object> implements Schematic<CollectionT, SchematicT> {
     constructor(_description: SchematicDescription<CollectionT, SchematicT>, _factory: RuleFactory<{}>, _collection: Collection<CollectionT, SchematicT>, _engine: Engine<CollectionT, SchematicT>);
     // (undocumented)
-    call<OptionT extends object>(options: OptionT, host: Observable<Tree_2>, parentContext?: Partial<TypedSchematicContext<CollectionT, SchematicT>>, executionOptions?: Partial<ExecutionOptions>): Observable<Tree_2>;
+    call<OptionT extends object>(options: OptionT, host: Tree_2, parentContext?: Partial<TypedSchematicContext<CollectionT, SchematicT>>, executionOptions?: Partial<ExecutionOptions>): Promise<Tree_2>;
     // (undocumented)
     get collection(): Collection<CollectionT, SchematicT>;
     // (undocumented)
@@ -843,7 +843,7 @@ export interface Sink {
 }
 
 // @public
-export type Source = (context: SchematicContext) => Tree_2 | Observable<Tree_2>;
+export type Source = (context: SchematicContext) => Tree_2 | Promise<Tree_2>;
 
 // @public
 export function source(tree: Tree_2): Source;

--- a/goldens/public-api/angular_devkit/schematics/testing/index.md
+++ b/goldens/public-api/angular_devkit/schematics/testing/index.md
@@ -17,7 +17,7 @@ import { Url } from 'url';
 export class SchematicTestRunner {
     constructor(_collectionName: string, collectionPath: string);
     // (undocumented)
-    callRule(rule: Rule, tree: Tree_2, parentContext?: Partial<SchematicContext>): Observable<Tree_2>;
+    callRule(rule: Rule, tree: Tree_2, parentContext?: Partial<SchematicContext>): Promise<Tree_2>;
     // (undocumented)
     get engine(): SchematicEngine<{}, {}>;
     // (undocumented)

--- a/packages/angular_devkit/schematics/src/engine/interface.ts
+++ b/packages/angular_devkit/schematics/src/engine/interface.ts
@@ -178,10 +178,10 @@ export interface Schematic<CollectionMetadataT extends object, SchematicMetadata
 
   call<OptionT extends object>(
     options: OptionT,
-    host: Observable<Tree>,
+    host: Tree,
     parentContext?: Partial<TypedSchematicContext<CollectionMetadataT, SchematicMetadataT>>,
     executionOptions?: Partial<ExecutionOptions>,
-  ): Observable<Tree>;
+  ): Promise<Tree>;
 }
 
 /**
@@ -232,8 +232,8 @@ export type AsyncFileOperator = (tree: FileEntry) => Observable<FileEntry | null
  * We obfuscate the context of Source and Rule because the schematic implementation should not
  * know which types is the schematic or collection metadata, as they are both tooling specific.
  */
-export type Source = (context: SchematicContext) => Tree | Observable<Tree>;
+export type Source = (context: SchematicContext) => Tree | Promise<Tree>;
 export type Rule = (
   tree: Tree,
   context: SchematicContext,
-) => Tree | Observable<Tree> | Rule | Promise<void | Rule> | void;
+) => void | Rule | Tree | Promise<void | Rule | Tree>;

--- a/packages/angular_devkit/schematics/src/engine/schematic_spec.ts
+++ b/packages/angular_devkit/schematics/src/engine/schematic_spec.ts
@@ -8,7 +8,7 @@
 
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { logging } from '@angular-devkit/core';
-import { lastValueFrom, of as observableOf } from 'rxjs';
+import { of as observableOf } from 'rxjs';
 import { chain } from '../rules/base';
 import { MergeStrategy, Tree } from '../tree/interface';
 import { branch, empty } from '../tree/static';
@@ -64,7 +64,8 @@ describe('Schematic', () => {
     };
 
     const schematic = new SchematicImpl(desc, desc.factory, null!, engine);
-    lastValueFrom(schematic.call({}, observableOf(empty())))
+    schematic
+      .call({}, empty())
       .then((x) => {
         expect(files(inner!)).toEqual([]);
         expect(files(x)).toEqual(['/a/b/c']);
@@ -82,12 +83,13 @@ describe('Schematic', () => {
       factory: () => (fem: Tree) => {
         inner = fem;
 
-        return observableOf(empty());
+        return empty();
       },
     };
 
     const schematic = new SchematicImpl(desc, desc.factory, null!, engine);
-    lastValueFrom(schematic.call({}, observableOf(empty())))
+    schematic
+      .call({}, empty())
       .then((x) => {
         expect(files(inner!)).toEqual([]);
         expect(files(x)).toEqual([]);
@@ -137,7 +139,8 @@ describe('Schematic', () => {
     };
 
     const schematic = new SchematicImpl(desc, desc.factory, null!, engine);
-    lastValueFrom(schematic.call({}, observableOf(empty())))
+    schematic
+      .call({}, empty())
       .then((_x) => {
         expect(chainCount).toBe(1);
         expect(oneCount).toBe(1);
@@ -159,7 +162,8 @@ describe('Schematic', () => {
     };
 
     const schematic = new SchematicImpl(desc, desc.factory, null!, engine);
-    lastValueFrom(schematic.call({}, observableOf(empty()), {}, { scope: 'base' }))
+    schematic
+      .call({}, empty(), {}, { scope: 'base' })
       .then((x) => {
         expect(files(x)).toEqual(['/base/a/b/c']);
       })

--- a/packages/angular_devkit/schematics/src/rules/call.ts
+++ b/packages/angular_devkit/schematics/src/rules/call.ts
@@ -7,7 +7,6 @@
  */
 
 import { BaseException } from '@angular-devkit/core';
-import { Observable, defaultIfEmpty, defer, isObservable, lastValueFrom, mergeMap } from 'rxjs';
 import { Rule, SchematicContext, Source } from '../engine/interface';
 import { Tree, TreeSymbol } from '../tree/interface';
 
@@ -46,35 +45,17 @@ export class InvalidSourceResultException extends BaseException {
   }
 }
 
-export function callSource(source: Source, context: SchematicContext): Observable<Tree> {
-  return defer(async () => {
-    let result: Tree | Observable<Tree> | undefined = source(context);
+export async function callSource(source: Source, context: SchematicContext): Promise<Tree> {
+  const result = await source(context);
 
-    if (isObservable(result)) {
-      result = await lastValueFrom(result.pipe(defaultIfEmpty(undefined)));
-    }
-
-    if (result && TreeSymbol in result) {
-      return result as Tree;
-    }
-
-    throw new InvalidSourceResultException(result);
-  });
-}
-
-export function callRule(
-  rule: Rule,
-  input: Tree | Observable<Tree>,
-  context: SchematicContext,
-): Observable<Tree> {
-  if (isObservable(input)) {
-    return input.pipe(mergeMap((inputTree) => callRuleAsync(rule, inputTree, context)));
-  } else {
-    return defer(() => callRuleAsync(rule, input, context));
+  if (result && TreeSymbol in result) {
+    return result;
   }
+
+  throw new InvalidSourceResultException(result);
 }
 
-async function callRuleAsync(rule: Rule, tree: Tree, context: SchematicContext): Promise<Tree> {
+export async function callRule(rule: Rule, tree: Tree, context: SchematicContext): Promise<Tree> {
   let result = await rule(tree, context);
 
   while (typeof result === 'function') {
@@ -84,10 +65,6 @@ async function callRuleAsync(rule: Rule, tree: Tree, context: SchematicContext):
 
   if (typeof result === 'undefined') {
     return tree;
-  }
-
-  if (isObservable(result)) {
-    result = await lastValueFrom(result.pipe(defaultIfEmpty(tree)));
   }
 
   if (result && TreeSymbol in result) {

--- a/packages/angular_devkit/schematics/src/rules/call_spec.ts
+++ b/packages/angular_devkit/schematics/src/rules/call_spec.ts
@@ -9,7 +9,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { MergeStrategy } from '@angular-devkit/schematics';
-import { of as observableOf } from 'rxjs';
 import { Rule, SchematicContext, Source } from '../engine/interface';
 import { Tree } from '../tree/interface';
 import { empty } from '../tree/static';
@@ -27,70 +26,41 @@ const context: SchematicContext = {
 } as {} as SchematicContext;
 
 describe('callSource', () => {
-  it('errors if undefined source', (done) => {
+  it('errors if undefined source', async () => {
     const source0: any = () => undefined;
-
-    callSource(source0, context)
-      .toPromise()
-      .then(
-        () => done.fail(),
-        (err) => {
-          expect(err).toEqual(new InvalidSourceResultException());
-        },
-      )
-      .then(done, done.fail);
+    await expectAsync(callSource(source0, context)).toBeRejectedWithError(
+      InvalidSourceResultException,
+    );
   });
 
-  it('errors if invalid source object', (done) => {
+  it('errors if invalid source object', async () => {
     const source0: Source = () => ({} as Tree);
-
-    callSource(source0, context)
-      .toPromise()
-      .then(
-        () => done.fail(),
-        (err) => {
-          expect(err).toEqual(new InvalidSourceResultException({}));
-        },
-      )
-      .then(done, done.fail);
+    await expectAsync(callSource(source0, context)).toBeRejectedWithError(
+      InvalidSourceResultException,
+    );
   });
 
-  it('errors if Observable of invalid source object', (done) => {
-    const source0: Source = () => observableOf({} as Tree);
-
-    callSource(source0, context)
-      .toPromise()
-      .then(
-        () => done.fail(),
-        (err) => {
-          expect(err).toEqual(new InvalidSourceResultException({}));
-        },
-      )
-      .then(done, done.fail);
+  it('errors if Observable of invalid source object', async () => {
+    const source0: Source = () => ({} as Tree);
+    await expectAsync(callSource(source0, context)).toBeRejectedWithError(
+      InvalidSourceResultException,
+    );
   });
 
-  it('works with a Tree', (done) => {
+  it('works with a Tree', async () => {
     const tree0 = empty();
     const source0: Source = () => tree0;
 
-    callSource(source0, context)
-      .toPromise()
-      .then((tree) => {
-        expect(tree).toBe(tree0);
-      })
-      .then(done, done.fail);
+    const tree = await callSource(source0, context);
+    expect(tree).toBe(tree0);
   });
 
-  it('works with an Observable', (done) => {
+  it('works with an Observable', async () => {
     const tree0 = empty();
-    const source0: Source = () => observableOf(tree0);
+    const source0: Source = () => tree0;
 
-    callSource(source0, context)
-      .toPromise()
-      .then((tree) => {
-        expect(tree).toBe(tree0);
-      })
-      .then(done, done.fail);
+    const tree = await callSource(source0, context);
+    expect(tree).toBe(tree0);
   });
 });
 
@@ -98,7 +68,7 @@ describe('callRule', () => {
   it('should throw InvalidRuleResultException when rule result is non-Tree object', async () => {
     const rule0: Rule = () => ({} as Tree);
 
-    await expectAsync(callRule(rule0, empty(), context).toPromise()).toBeRejectedWithError(
+    await expectAsync(callRule(rule0, empty(), context)).toBeRejectedWithError(
       InvalidRuleResultException,
     );
   });
@@ -106,44 +76,32 @@ describe('callRule', () => {
   it('should throw InvalidRuleResultException when rule result is null', async () => {
     const rule0: Rule = () => null as unknown as Tree;
 
-    await expectAsync(callRule(rule0, empty(), context).toPromise()).toBeRejectedWithError(
+    await expectAsync(callRule(rule0, empty(), context)).toBeRejectedWithError(
       InvalidRuleResultException,
     );
   });
 
-  it('works with undefined result', (done) => {
+  it('works with undefined result', async () => {
     const tree0 = empty();
     const rule0: Rule = () => undefined;
 
-    callRule(rule0, observableOf(tree0), context)
-      .toPromise()
-      .then((tree) => {
-        expect(tree).toBe(tree0);
-      })
-      .then(done, done.fail);
+    const tree = await callRule(rule0, tree0, context);
+    expect(tree).toBe(tree0);
   });
 
-  it('works with a Tree', (done) => {
+  it('works with a Tree', async () => {
     const tree0 = empty();
     const rule0: Rule = () => tree0;
 
-    callRule(rule0, observableOf(tree0), context)
-      .toPromise()
-      .then((tree) => {
-        expect(tree).toBe(tree0);
-      })
-      .then(done, done.fail);
+    const tree = await callRule(rule0, tree0, context);
+    expect(tree).toBe(tree0);
   });
 
-  it('works with an Observable', (done) => {
+  it('works with an Observable', async () => {
     const tree0 = empty();
-    const rule0: Rule = () => observableOf(tree0);
+    const rule0: Rule = () => tree0;
 
-    callRule(rule0, observableOf(tree0), context)
-      .toPromise()
-      .then((tree) => {
-        expect(tree).toBe(tree0);
-      })
-      .then(done, done.fail);
+    const tree = await callRule(rule0, tree0, context);
+    expect(tree).toBe(tree0);
   });
 });

--- a/packages/angular_devkit/schematics/src/rules/move_spec.ts
+++ b/packages/angular_devkit/schematics/src/rules/move_spec.ts
@@ -7,7 +7,6 @@
  */
 
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { lastValueFrom, of as observableOf } from 'rxjs';
 import { SchematicContext } from '../engine/interface';
 import { HostTree } from '../tree/host-tree';
 import { callRule } from './call';
@@ -16,80 +15,65 @@ import { move } from './move';
 const context: SchematicContext = null!;
 
 describe('move', () => {
-  it('works on moving the whole structure', (done) => {
+  it('works on moving the whole structure', async () => {
     const tree = new HostTree();
     tree.create('a/b/file1', 'hello world');
     tree.create('a/b/file2', 'hello world');
     tree.create('a/c/file3', 'hello world');
 
-    lastValueFrom(callRule(move('sub'), observableOf(tree), context))
-      .then((result) => {
-        expect(result.exists('sub/a/b/file1')).toBe(true);
-        expect(result.exists('sub/a/b/file2')).toBe(true);
-        expect(result.exists('sub/a/c/file3')).toBe(true);
-      })
-      .then(done, done.fail);
+    const result = await callRule(move('sub'), tree, context);
+    expect(result.exists('sub/a/b/file1')).toBe(true);
+    expect(result.exists('sub/a/b/file2')).toBe(true);
+    expect(result.exists('sub/a/c/file3')).toBe(true);
   });
 
-  it('works on moving a subdirectory structure', (done) => {
+  it('works on moving a subdirectory structure', async () => {
     const tree = new HostTree();
     tree.create('a/b/file1', 'hello world');
     tree.create('a/b/file2', 'hello world');
     tree.create('a/c/file3', 'hello world');
 
-    lastValueFrom(callRule(move('a/b', 'sub'), observableOf(tree), context))
-      .then((result) => {
-        expect(result.exists('sub/file1')).toBe(true);
-        expect(result.exists('sub/file2')).toBe(true);
-        expect(result.exists('a/c/file3')).toBe(true);
-      })
-      .then(done, done.fail);
+    const result = await callRule(move('a/b', 'sub'), tree, context);
+    expect(result.exists('sub/file1')).toBe(true);
+    expect(result.exists('sub/file2')).toBe(true);
+    expect(result.exists('a/c/file3')).toBe(true);
   });
 
-  it('works on moving a directory into a subdirectory of itself', (done) => {
+  it('works on moving a directory into a subdirectory of itself', async () => {
     const tree = new HostTree();
     tree.create('a/b/file1', 'hello world');
     tree.create('a/b/file2', 'hello world');
     tree.create('a/c/file3', 'hello world');
 
-    lastValueFrom(callRule(move('a/b', 'a/b/c'), observableOf(tree), context))
-      .then((result) => {
-        expect(result.exists('a/b/c/file1')).toBe(true);
-        expect(result.exists('a/b/c/file2')).toBe(true);
-        expect(result.exists('a/c/file3')).toBe(true);
-      })
-      .then(done, done.fail);
+    const result = await callRule(move('a/b', 'a/b/c'), tree, context);
+    expect(result.exists('a/b/c/file1')).toBe(true);
+    expect(result.exists('a/b/c/file2')).toBe(true);
+    expect(result.exists('a/c/file3')).toBe(true);
   });
 
-  it('works on moving a directory into a parent of itself', (done) => {
+  it('works on moving a directory into a parent of itself', async () => {
     const tree = new HostTree();
     tree.create('a/b/file1', 'hello world');
     tree.create('a/b/file2', 'hello world');
     tree.create('a/c/file3', 'hello world');
 
-    lastValueFrom(callRule(move('a/b', 'a'), observableOf(tree), context))
-      .then((result) => {
-        expect(result.exists('file1')).toBe(false);
-        expect(result.exists('file2')).toBe(false);
-        expect(result.exists('a/file1')).toBe(true);
-        expect(result.exists('a/file2')).toBe(true);
-        expect(result.exists('a/c/file3')).toBe(true);
-      })
-      .then(done, done.fail);
+    const result = await callRule(move('a/b', 'a'), tree, context);
+    expect(result.exists('file1')).toBe(false);
+    expect(result.exists('file2')).toBe(false);
+    expect(result.exists('a/file1')).toBe(true);
+    expect(result.exists('a/file2')).toBe(true);
+    expect(result.exists('a/c/file3')).toBe(true);
   });
 
-  it('becomes a noop with identical from and to', (done) => {
+  it('becomes a noop with identical from and to', async () => {
     const tree = new HostTree();
     tree.create('a/b/file1', 'hello world');
     tree.create('a/b/file2', 'hello world');
     tree.create('a/c/file3', 'hello world');
 
-    lastValueFrom(callRule(move(''), observableOf(tree), context))
-      .then((result) => {
-        expect(result.exists('a/b/file1')).toBe(true);
-        expect(result.exists('a/b/file2')).toBe(true);
-        expect(result.exists('a/c/file3')).toBe(true);
-      })
-      .then(done, done.fail);
+    const result = await callRule(move(''), tree, context);
+    expect(result.exists('a/b/file1')).toBe(true);
+    expect(result.exists('a/b/file2')).toBe(true);
+    expect(result.exists('a/c/file3')).toBe(true);
   });
 });

--- a/packages/angular_devkit/schematics/src/rules/template_spec.ts
+++ b/packages/angular_devkit/schematics/src/rules/template_spec.ts
@@ -9,7 +9,6 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import { normalize } from '@angular-devkit/core';
 import { UnitTestTree } from '@angular-devkit/schematics/testing';
-import { of as observableOf } from 'rxjs';
 import { SchematicContext } from '../engine/interface';
 import { HostTree } from '../tree/host-tree';
 import { FileEntry, MergeStrategy } from '../tree/interface';
@@ -174,7 +173,7 @@ describe('contentTemplate', () => {
 });
 
 describe('applyTemplateFiles', () => {
-  it('works with template files exclusively', (done) => {
+  it('works with template files exclusively', async () => {
     const tree = new UnitTestTree(new HostTree());
     tree.create('a/b/file1', 'hello world');
     tree.create('a/b/file2', 'hello world');
@@ -188,20 +187,16 @@ describe('applyTemplateFiles', () => {
     } as SchematicContext;
 
     // Rename all files that contain 'b' to 'hello'.
-    callRule(applyTemplates({ a: 'foo' }), observableOf(tree), context)
-      .toPromise()
-      .then(() => {
-        expect([...tree.files].sort()).toEqual([
-          '/a/b/file1',
-          '/a/b/file2',
-          '/a/b/file3',
-          '/a/b/file__norename__',
-          '/a/b/filefoo',
-          '/a/c/file4',
-        ]);
+    await callRule(applyTemplates({ a: 'foo' }), tree, context);
+    expect([...tree.files].sort()).toEqual([
+      '/a/b/file1',
+      '/a/b/file2',
+      '/a/b/file3',
+      '/a/b/file__norename__',
+      '/a/b/filefoo',
+      '/a/c/file4',
+    ]);
 
-        expect(tree.readContent('/a/b/file3')).toBe('hello 1 world');
-      })
-      .then(done, done.fail);
+    expect(tree.readContent('/a/b/file3')).toBe('hello 1 world');
   });
 });

--- a/packages/angular_devkit/schematics/testing/schematic-test-runner.ts
+++ b/packages/angular_devkit/schematics/testing/schematic-test-runner.ts
@@ -7,7 +7,7 @@
  */
 
 import { logging, schema } from '@angular-devkit/core';
-import { Observable, from, lastValueFrom, of as observableOf } from 'rxjs';
+import { Observable, from } from 'rxjs';
 import {
   Collection,
   DelegateTree,
@@ -83,10 +83,10 @@ export class SchematicTestRunner {
     tree?: Tree,
   ): Promise<UnitTestTree> {
     const schematic = this._collection.createSchematic(schematicName, true);
-    const host = observableOf(tree || new HostTree());
+    const host = tree || new HostTree();
     this._engineHost.clearTasks();
 
-    const newTree = await lastValueFrom(schematic.call(opts || {}, host, { logger: this._logger }));
+    const newTree = await schematic.call(opts || {}, host, { logger: this._logger });
 
     return new UnitTestTree(newTree);
   }
@@ -110,10 +110,10 @@ export class SchematicTestRunner {
   ): Promise<UnitTestTree> {
     const externalCollection = this._engine.createCollection(collectionName);
     const schematic = externalCollection.createSchematic(schematicName, true);
-    const host = observableOf(tree || new HostTree());
+    const host = tree || new HostTree();
     this._engineHost.clearTasks();
 
-    const newTree = await lastValueFrom(schematic.call(opts || {}, host, { logger: this._logger }));
+    const newTree = await schematic.call(opts || {}, host, { logger: this._logger });
 
     return new UnitTestTree(newTree);
   }
@@ -130,9 +130,9 @@ export class SchematicTestRunner {
     return from(this.runExternalSchematic(collectionName, schematicName, opts, tree));
   }
 
-  callRule(rule: Rule, tree: Tree, parentContext?: Partial<SchematicContext>): Observable<Tree> {
+  callRule(rule: Rule, tree: Tree, parentContext?: Partial<SchematicContext>): Promise<Tree> {
     const context = this._engine.createContext({} as Schematic<{}, {}>, parentContext);
 
-    return callRule(rule, observableOf(tree), context);
+    return callRule(rule, tree, context);
   }
 }

--- a/packages/angular_devkit/schematics/tools/file-system-engine-host_spec.ts
+++ b/packages/angular_devkit/schematics/tools/file-system-engine-host_spec.ts
@@ -11,7 +11,7 @@ import { normalize, virtualFs } from '@angular-devkit/core';
 import { HostSink, HostTree, SchematicEngine } from '@angular-devkit/schematics';
 import { FileSystemEngineHost } from '@angular-devkit/schematics/tools';
 import * as path from 'path';
-import { from, lastValueFrom, of as observableOf } from 'rxjs';
+import { from, lastValueFrom } from 'rxjs';
 
 describe('FileSystemEngineHost', () => {
   // We need to resolve a file that actually exists, and not just a folder.
@@ -305,7 +305,8 @@ describe('FileSystemEngineHost', () => {
     const collection = engine.createCollection('extra-properties');
     const schematic = collection.createSchematic('schematic1');
 
-    lastValueFrom(schematic.call({}, observableOf(new HostTree(host))))
+    schematic
+      .call({}, new HostTree(host))
       .then((tree) => {
         return lastValueFrom(new HostSink(host).commit(tree));
       })
@@ -344,10 +345,9 @@ describe('FileSystemEngineHost', () => {
     const collection = engine.createCollection('file-tasks');
     const schematic = collection.createSchematic('schematic-1');
 
-    lastValueFrom(schematic.call({}, observableOf(new HostTree(host))))
-      .then((tree) => {
-        return lastValueFrom(new HostSink(host).commit(tree));
-      })
+    schematic
+      .call({}, new HostTree(host))
+      .then((tree) => new HostSink(host).commit(tree).toPromise())
       .then(() => engine.executePostTasks().toPromise())
       .then(() => done.fail())
       .catch((reason) => {

--- a/packages/schematics/angular/utility/dependency_spec.ts
+++ b/packages/schematics/angular/utility/dependency_spec.ts
@@ -39,7 +39,7 @@ async function testRule(
     },
   };
 
-  await callRule(rule, tree, context as unknown as SchematicContext).toPromise();
+  await callRule(rule, tree, context as unknown as SchematicContext);
 
   return { tasks, logs };
 }

--- a/packages/schematics/angular/utility/workspace_spec.ts
+++ b/packages/schematics/angular/utility/workspace_spec.ts
@@ -19,7 +19,7 @@ const TEST_WORKSPACE_CONTENT = JSON.stringify({
 });
 
 async function testRule(rule: Rule, tree: Tree): Promise<void> {
-  await callRule(rule, tree, {} as unknown as SchematicContext).toPromise();
+  await callRule(rule, tree, {} as unknown as SchematicContext);
 }
 
 describe('readWorkspace', () => {


### PR DESCRIPTION

BREAKING CHANGE:
`call`, `callRule` and `callSource` methods now return a Promise instead of an Observable

Note: this does not effect application developers.

