### PR TITLE
fix(@angular-devkit/build-angular): display actionable error when a style does not exist in Karma builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/karma/tests/options/styles_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/tests/options/styles_spec.ts
@@ -16,7 +16,7 @@ describeBuilder(execute, KARMA_BUILDER_INFO, (harness) => {
         'src/styles.css': 'p {display: none}',
         'src/app/app.component.ts': `
           import { Component } from '@angular/core';
-  
+
           @Component({
             selector: 'app-root',
             template: '<p>Hello World</p>'
@@ -27,7 +27,7 @@ describeBuilder(execute, KARMA_BUILDER_INFO, (harness) => {
         'src/app/app.component.spec.ts': `
           import { TestBed } from '@angular/core/testing';
           import { AppComponent } from './app.component';
-  
+
           describe('AppComponent', () => {
             beforeEach(async () => {
               await TestBed.configureTestingModule({
@@ -38,7 +38,7 @@ describeBuilder(execute, KARMA_BUILDER_INFO, (harness) => {
                 ]
               }).compileComponents();
             });
-  
+
             it('should not contain text that is hidden via css', () => {
               const fixture = TestBed.createComponent(AppComponent);
               expect(fixture.nativeElement.innerText).not.toContain('Hello World');
@@ -128,6 +128,23 @@ describeBuilder(execute, KARMA_BUILDER_INFO, (harness) => {
 
       const { result } = await harness.executeOnce();
       expect(result?.success).toBeTrue();
+    });
+
+    it('fails and shows an error if style does not exist', async () => {
+      harness.useTarget('test', {
+        ...BASE_OPTIONS,
+        styles: ['src/test-style-a.css'],
+      });
+
+      const { result, logs } = await harness.executeOnce({ outputLogsOnFailure: false });
+
+      expect(result?.success).toBeFalse();
+      expect(logs).toContain(
+        jasmine.objectContaining({
+          level: 'error',
+          message: jasmine.stringMatching(`Can't resolve 'src/test-style-a.css'`),
+        }),
+      );
     });
   });
 });


### PR DESCRIPTION


Prior to this change the the error was not displayed correctly due to compilation being undefined.

Closes #24416