### PR TITLE
feat(@angular-devkit/build-angular): support inline component Sass styles with esbuild builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/experimental-warnings.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/experimental-warnings.ts
@@ -23,11 +23,6 @@ const UNSUPPORTED_OPTIONS: Array<keyof BrowserBuilderOptions> = [
   // 'i18nDuplicateTranslation',
   // 'i18nMissingTranslation',
 
-  // * Stylesheet preprocessor support
-  'inlineStyleLanguage',
-  // The following option has no effect until preprocessors are supported
-  // 'stylePreprocessorOptions',
-
   // * Deprecated
   'deployUrl',
 
@@ -60,12 +55,13 @@ export function logExperimentalWarnings(options: BrowserBuilderOptions, context:
     if (typeof value === 'object' && Object.keys(value).length === 0) {
       continue;
     }
-    if (unsupportedOption === 'inlineStyleLanguage' && value === 'css') {
-      continue;
-    }
 
     context.logger.warn(
       `The '${unsupportedOption}' option is currently unsupported by this experimental builder and will be ignored.`,
     );
+  }
+
+  if (options.inlineStyleLanguage === 'less') {
+    context.logger.warn('The less stylesheet preprocessor is not currently supported.');
   }
 }

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
@@ -242,6 +242,7 @@ function createCodeBundleOptions(
     preserveSymlinks,
     stylePreprocessorOptions,
     advancedOptimizations,
+    inlineStyleLanguage,
   } = options;
 
   return {
@@ -292,6 +293,7 @@ function createCodeBundleOptions(
           includePaths: stylePreprocessorOptions?.includePaths,
           externalDependencies,
           target,
+          inlineStyleLanguage,
         },
       ),
     ],

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/options.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/options.ts
@@ -136,6 +136,7 @@ export async function normalizeOptions(
     buildOptimizer,
     crossOrigin,
     externalDependencies,
+    inlineStyleLanguage = 'css',
     poll,
     preserveSymlinks,
     stylePreprocessorOptions,
@@ -151,6 +152,7 @@ export async function normalizeOptions(
     cacheOptions,
     crossOrigin,
     externalDependencies,
+    inlineStyleLanguage,
     poll,
     // If not explicitly set, default to the Node.js process argument
     preserveSymlinks: preserveSymlinks ?? process.execArgv.includes('--preserve-symlinks'),


### PR DESCRIPTION
When using the experimental esbuild-based browser application builder, the `inlineStyleLanguage` option and the usage of inline Angular component styles that contain Sass are now supported. The `inlineStyleLanguage` option values of `css`, `sass`, and `scss` can be used and will behave as they would with the default Webpack-based builder. The less stylesheet preprocessor is not yet supported in general with the esbuild-based builder. However, when support is added for less, the `inlineStyleLanguage` option will also be able to be used with the `less` option value.