### PR TITLE
fix(@angular-devkit/build-angular): transform async generator class methods for Zone.js support

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/javascript-transformer-worker.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/javascript-transformer-worker.ts
@@ -42,7 +42,7 @@ async function transformWithBabel({
 }: JavaScriptTransformRequest): Promise<string> {
   const forceAsyncTransformation =
     options.forceAsyncTransformation ??
-    (!/[\\/][_f]?esm2015[\\/]/.test(filename) && /async\s+function\s*\*/.test(data));
+    (!/[\\/][_f]?esm2015[\\/]/.test(filename) && /async(?:\s+function)?\s*\*/.test(data));
   const shouldLink = !options.skipLinker && (await requiresLinking(filename, data));
   const useInputSourcemap =
     options.sourcemap &&

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/javascript-transformer.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/javascript-transformer.ts
@@ -72,8 +72,8 @@ export class JavaScriptTransformer {
     let forceAsyncTransformation;
     if (skipLinker && !this.#commonOptions.advancedOptimizations) {
       // If the linker is being skipped and no optimizations are needed, only async transformation is left.
-      // This checks for async generator functions. All other async transformation is handled by esbuild.
-      forceAsyncTransformation = data.includes('async') && /async\s+function\s*\*/.test(data);
+      // This checks for async generator functions and class methods. All other async transformation is handled by esbuild.
+      forceAsyncTransformation = data.includes('async') && /async(?:\s+function)?\s*\*/.test(data);
 
       if (!forceAsyncTransformation) {
         return Buffer.from(data, 'utf-8');


### PR DESCRIPTION
When using the experimental esbuild-based browser application builder, async generator class methods will now be transformed to a downlevel form based on promise objects. This transformation is performed by babel and was previously (and still is) performed on async generator functions. This transformation is necessary to ensure Zone.js can hook async code via the Promise objects. Only async generator transformation is currently performed via babel as esbuild can handle all other native async syntax that requires transformation for Zone.js support.