### PR TITLE
refactor(@angular-devkit/architect): use promise-based result property where possible

### DIFF
--- a/packages/angular_devkit/architect/node/jobs/job-registry_spec.ts
+++ b/packages/angular_devkit/architect/node/jobs/job-registry_spec.ts
@@ -18,6 +18,6 @@ describe('NodeModuleJobScheduler', () => {
     const scheduler = new jobs.SimpleScheduler(registry);
 
     const job = scheduler.schedule(path.join(root, 'add'), [1, 2, 3]);
-    expect(await job.output.toPromise()).toBe(6);
+    expect(await job.result).toBe(6);
   });
 });

--- a/packages/angular_devkit/architect/src/create-builder.ts
+++ b/packages/angular_devkit/architect/src/create-builder.ts
@@ -141,33 +141,31 @@ export function createBuilder<OptT = json.JsonObject, OutT extends BuilderOutput
             return run;
           },
           async getTargetOptions(target: Target) {
-            return scheduler
-              .schedule<Target, json.JsonValue, json.JsonObject>('..getTargetOptions', target)
-              .output.toPromise();
+            return scheduler.schedule<Target, json.JsonValue, json.JsonObject>(
+              '..getTargetOptions',
+              target,
+            ).result;
           },
           async getProjectMetadata(target: Target | string) {
-            return scheduler
-              .schedule<Target | string, json.JsonValue, json.JsonObject>(
-                '..getProjectMetadata',
-                target,
-              )
-              .output.toPromise();
+            return scheduler.schedule<Target | string, json.JsonValue, json.JsonObject>(
+              '..getProjectMetadata',
+              target,
+            ).result;
           },
           async getBuilderNameForTarget(target: Target) {
-            return scheduler
-              .schedule<Target, json.JsonValue, string>('..getBuilderNameForTarget', target)
-              .output.toPromise();
+            return scheduler.schedule<Target, json.JsonValue, string>(
+              '..getBuilderNameForTarget',
+              target,
+            ).result;
           },
           async validateOptions<T extends json.JsonObject = json.JsonObject>(
             options: json.JsonObject,
             builderName: string,
           ) {
-            return scheduler
-              .schedule<[string, json.JsonObject], json.JsonValue, T>('..validateOptions', [
-                builderName,
-                options,
-              ])
-              .output.toPromise();
+            return scheduler.schedule<[string, json.JsonObject], json.JsonValue, T>(
+              '..validateOptions',
+              [builderName, options],
+            ).result;
           },
           reportRunning() {
             switch (currentState) {

--- a/packages/angular_devkit/architect/src/index_spec.ts
+++ b/packages/angular_devkit/architect/src/index_spec.ts
@@ -325,7 +325,7 @@ describe('architect', () => {
     );
 
     const run = await architect.scheduleBuilder('package:getTargetOptions', {});
-    const output = await run.output.toPromise();
+    const output = await run.result;
     expect(output.success).toBe(true);
     expect(options).toEqual(goldenOptions);
     await run.stop();
@@ -339,7 +339,7 @@ describe('architect', () => {
 
     // But this should.
     try {
-      await run2.output.toPromise();
+      await run2.result;
       expect('THE ABOVE LINE SHOULD NOT ERROR').toBe('false');
     } catch {}
     await run2.stop();
@@ -369,7 +369,7 @@ describe('architect', () => {
     );
 
     const run = await architect.scheduleBuilder('package:do-it', {});
-    const output = await run.output.toPromise();
+    const output = await run.result;
     expect(output.success).toBe(true);
     expect(actualBuilderName).toEqual(builderName);
     await run.stop();
@@ -383,7 +383,7 @@ describe('architect', () => {
 
     // But this should.
     try {
-      await run2.output.toPromise();
+      await run2.result;
       expect('THE ABOVE LINE SHOULD NOT ERROR').toBe('false');
     } catch {}
     await run2.stop();
@@ -416,7 +416,7 @@ describe('architect', () => {
     );
 
     const run = await architect.scheduleBuilder('package:do-it', { p1: 'hello' });
-    const output = await run.output.toPromise();
+    const output = await run.result;
     expect(output.success).toBe(true);
     expect(actualOptions).toEqual({
       p0: 123,
@@ -427,7 +427,7 @@ describe('architect', () => {
     // Should also error.
     const run2 = await architect.scheduleBuilder('package:do-it', {});
 
-    await expectAsync(run2.output.toPromise()).toBeRejectedWith(
+    await expectAsync(run2.result).toBeRejectedWith(
       jasmine.objectContaining({ message: jasmine.stringMatching('p1') }),
     );
 

--- a/packages/angular_devkit/architect/src/jobs/api.ts
+++ b/packages/angular_devkit/architect/src/jobs/api.ts
@@ -324,6 +324,11 @@ export interface Job<
   readonly output: Observable<OutputT>;
 
   /**
+   * The first output of the job.
+   */
+  readonly result: Promise<OutputT>;
+
+  /**
    * The current state of the job.
    */
   readonly state: JobState;

--- a/packages/angular_devkit/architect/src/jobs/dispatcher_spec.ts
+++ b/packages/angular_devkit/architect/src/jobs/dispatcher_spec.ts
@@ -36,6 +36,6 @@ describe('createDispatcher', () => {
 
     dispatcher.setDefaultJob(add0 as JobHandler<JsonValue, JsonValue, number>);
     const sum = scheduler.schedule('add', [1, 2, 3, 4]);
-    expect(await sum.output.toPromise()).toBe(10);
+    expect(await sum.result).toBe(10);
   });
 });

--- a/packages/angular_devkit/architect/src/jobs/simple-scheduler.ts
+++ b/packages/angular_devkit/architect/src/jobs/simple-scheduler.ts
@@ -284,6 +284,7 @@ export class SimpleScheduler<
    * Create the job.
    * @private
    */
+  // eslint-disable-next-line max-lines-per-function
   private _createJob<A extends MinimumArgumentT, I extends MinimumInputT, O extends MinimumOutputT>(
     name: JobName,
     argument: A,
@@ -440,6 +441,9 @@ export class SimpleScheduler<
           }
         }),
       ),
+      get result() {
+        return output.pipe(first()).toPromise();
+      },
       output,
       getChannel<T extends JsonValue>(
         name: JobName,

--- a/packages/angular_devkit/architect/src/jobs/strategy_spec.ts
+++ b/packages/angular_devkit/architect/src/jobs/strategy_spec.ts
@@ -65,11 +65,11 @@ describe('strategy.serialize()', () => {
     expect(finished).toBe(0);
 
     await Promise.all([
-      job1.output.toPromise().then((s) => {
+      job1.result.then((s) => {
         expect(finished).toBe(1);
         expect(s).toBe(10);
       }),
-      job2.output.toPromise().then((s) => {
+      job2.result.then((s) => {
         expect(finished).toBe(2);
         expect(s).toBe(15);
       }),
@@ -142,11 +142,11 @@ describe('strategy.serialize()', () => {
     expect(finished).toBe(0);
 
     await Promise.all([
-      job1.output.toPromise().then((s) => {
+      job1.result.then((s) => {
         expect(finished).toBe(1);
         expect(s).toBe(10);
       }),
-      job2.output.toPromise().then((s) => {
+      job2.result.then((s) => {
         expect(finished).toBe(2);
         expect(s).toBe(115);
       }),
@@ -205,7 +205,7 @@ describe('strategy.reuse()', () => {
     expect(started).toBe(1); // job2 is reusing job1.
     expect(finished).toBe(0);
 
-    let result = await job1.output.toPromise();
+    let result = await job1.result;
     expect(result).toBe(10);
     expect(started).toBe(1);
     expect(finished).toBe(1);
@@ -223,7 +223,7 @@ describe('strategy.reuse()', () => {
     expect(started).toBe(2); // job4 is reusing job3.
     expect(finished).toBe(1);
 
-    result = await job3.output.toPromise();
+    result = await job3.result;
     expect(result).toBe(15);
     expect(started).toBe(2);
     expect(finished).toBe(2);
@@ -292,24 +292,24 @@ describe('strategy.memoize()', () => {
     expect(finished).toBe(0);
 
     await Promise.all([
-      job1.output.toPromise().then((s) => {
+      job1.result.then((s) => {
         // This is hard since job3 and job1 might finish out of order.
         expect(finished).toBeGreaterThanOrEqual(1);
         expect(s).toBe(10);
       }),
-      job2.output.toPromise().then((s) => {
+      job2.result.then((s) => {
         // This is hard since job3 and job1 might finish out of order.
         expect(finished).toBeGreaterThanOrEqual(1);
         expect(job1.state).toBe(JobState.Ended);
         expect(job2.state).toBe(JobState.Ended);
         expect(s).toBe(10);
       }),
-      job3.output.toPromise().then((s) => {
+      job3.result.then((s) => {
         // This is hard since job3 and job1 might finish out of order.
         expect(finished).toBeGreaterThanOrEqual(1);
         expect(s).toBe(15);
       }),
-      job4.output.toPromise().then((s) => {
+      job4.result.then((s) => {
         expect(job3.state).toBe(JobState.Ended);
         expect(job4.state).toBe(JobState.Ended);
         // This is hard since job3 and job1 might finish out of order.

--- a/packages/angular_devkit/architect_cli/bin/architect.ts
+++ b/packages/angular_devkit/architect_cli/bin/architect.ts
@@ -150,7 +150,7 @@ async function _executeTarget(
 
   // Wait for full completion of the builder.
   try {
-    const result = await run.output.toPromise();
+    const result = await run.result;
     if (result.success) {
       parentLogger.info(colors.green('SUCCESS'));
     } else {


### PR DESCRIPTION
This change adds a promise-based result property to the Job object which functions in a similar way to the BuilderRun object's result property. This allows for many of the Observable toPromise calls related to architect usage to be removed. As a result, many of the architect usage locations can now be more promise-based.