### PR TITLE
refactor(@schematics/angular): remove unused local variables

### DIFF
--- a/packages/schematics/angular/environments/index_spec.ts
+++ b/packages/schematics/angular/environments/index_spec.ts
@@ -37,15 +37,12 @@ describe('Application Schematic', () => {
   };
 
   let applicationTree: UnitTestTree;
-  const messages: string[] = [];
-  schematicRunner.logger.subscribe((x) => messages.push(x.message));
 
   function runEnvironmentsSchematic(): Promise<UnitTestTree> {
     return schematicRunner.runSchematic('environments', defaultOptions, applicationTree);
   }
 
   beforeEach(async () => {
-    messages.length = 0;
     const workspaceTree = await schematicRunner.runSchematic('workspace', workspaceOptions);
     applicationTree = await schematicRunner.runSchematic(
       'application',


### PR DESCRIPTION
`messages` is unused from the spec and thus can be removed.
