### PR TITLE
feat(@angular-devkit/build-angular): implement stats-json option for esbuild builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/experimental-warnings.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/experimental-warnings.ts
@@ -15,7 +15,6 @@ const UNSUPPORTED_OPTIONS: Array<keyof BrowserBuilderOptions> = [
   'extractLicenses',
   'progress',
   'scripts',
-  'statsJson',
 
   // * i18n support
   'localize',

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/options.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/options.ts
@@ -139,6 +139,7 @@ export async function normalizeOptions(
     inlineStyleLanguage = 'css',
     poll,
     preserveSymlinks,
+    statsJson,
     stylePreprocessorOptions,
     subresourceIntegrity,
     verbose,
@@ -153,6 +154,7 @@ export async function normalizeOptions(
     crossOrigin,
     externalDependencies,
     inlineStyleLanguage,
+    stats: !!statsJson,
     poll,
     // If not explicitly set, default to the Node.js process argument
     preserveSymlinks: preserveSymlinks ?? process.execArgv.includes('--preserve-symlinks'),

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/stylesheets.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/stylesheets.ts
@@ -34,6 +34,7 @@ export function createStylesheetBundleOptions(
     assetNames: options.outputNames?.media,
     logLevel: 'silent',
     minify: options.optimization,
+    metafile: true,
     sourcemap: options.sourcemap,
     outdir: options.workspaceRoot,
     write: false,
@@ -140,5 +141,6 @@ export async function bundleComponentStylesheet(
     map,
     path: outputPath,
     resourceFiles,
+    metafile: result.outputFiles && result.metafile,
   };
 }


### PR DESCRIPTION
When using the experimental esbuild-based browser application builder, the `--stats-json` option can now be used to create an esbuild metafile named `stats.json` in the output directory of the application. The metafile contents will contain information about the application JavaScript, global stylesheets, and the component stylesheets used by the Angular compiler. While the `--stats-json` option controls the output of the file onto the filesystem, the metafile data is internally always created to support the future integration of the bundle budget and console build stat output capabilities.
The metafile format follows the structure of the esbuild metafile format. Information regarding the file format can be found here: https://esbuild.github.io/api/#metafile