### PR TITLE
fix(@angular-devkit/build-angular): format esbuild error messages to include more information

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/plugins/javascript-optimizer-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/plugins/javascript-optimizer-plugin.ts
@@ -204,7 +204,15 @@ export class JavaScriptOptimizerPlugin {
                     options: optimizeOptions,
                   })
                   .then(
-                    ({ code, name, map }) => {
+                    async ({ code, name, map, errors }) => {
+                      if (errors?.length) {
+                        for (const error of errors) {
+                          addError(compilation, `Optimization error [${name}]: ${error}`);
+                        }
+
+                        return;
+                      }
+
                       const optimizedAsset = map
                         ? new SourceMapSource(code, name, map)
                         : new OriginalSource(code, name);


### PR DESCRIPTION


Prior to this change esbuild errors during the javascript optimization phase in the Webpack builder were not being formatting properly which caused meaningful information to be lost.

Closes #24457
