### PR TITLE
fix(@angular-devkit/build-angular): ensure Sass load paths are resolved from workspace root

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/stylesheets.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/stylesheets.ts
@@ -46,7 +46,10 @@ export function createStylesheetBundleOptions(
     plugins: [
       createSassPlugin({
         sourcemap: !!options.sourcemap,
-        loadPaths: options.includePaths,
+        // Ensure Sass load paths are absolute based on the workspace root
+        loadPaths: options.includePaths?.map((includePath) =>
+          path.resolve(options.workspaceRoot, includePath),
+        ),
         inlineComponentData,
       }),
       createCssResourcePlugin(),


### PR DESCRIPTION
When using the esbuild-based browser application builder, the Sass compiler will attempt to resolve any relative load paths from the current working directory. However, the load paths from the `angular.json` file should always be relative to the location of the `angular.json` which is considered the workspace root. While the current working directory is typically also the workspace root, it is not required nor always the same. To resolve this potential mismatch, the load paths are now resolved from the workspace root prior to being passed to the Sass compiler.