### PR TITLE
build: re-enable material e2e tests

### DIFF
--- a/tests/legacy-cli/e2e/tests/build/material.ts
+++ b/tests/legacy-cli/e2e/tests/build/material.ts
@@ -7,9 +7,6 @@ import { isPrereleaseCli, updateJsonFile } from '../../utils/project';
 const snapshots = require('../../ng-snapshot/package.json');
 
 export default async function () {
-  // TODO(crisbeto): temporarily disabled until Material is updated
-  return;
-
   let tag = (await isPrereleaseCli()) ? '@next' : '';
   await ng('add', `@angular/material${tag}`, '--skip-confirmation');
 

--- a/tests/legacy-cli/e2e/tests/commands/add/add-material.ts
+++ b/tests/legacy-cli/e2e/tests/commands/add/add-material.ts
@@ -5,9 +5,6 @@ import { ng } from '../../../utils/process';
 import { isPrereleaseCli } from '../../../utils/project';
 
 export default async function () {
-  // TODO(crisbeto): temporarily disabled until Material is updated
-  return;
-
   // forcibly remove in case another test doesn't clean itself up
   await rimraf('node_modules/@angular/material');
 

--- a/tests/legacy-cli/e2e/tests/misc/invalid-schematic-dependencies.ts
+++ b/tests/legacy-cli/e2e/tests/misc/invalid-schematic-dependencies.ts
@@ -4,9 +4,6 @@ import { installPackage, uninstallPackage } from '../../utils/packages';
 import { isPrereleaseCli } from '../../utils/project';
 
 export default async function () {
-  // TODO(crisbeto): temporarily disabled until Material is updated
-  return;
-
   // Must publish old version to local registry to allow install. This is especially important
   // for release commits as npm will try to request tooling packages that are not on the npm registry yet
   await publishOutdated('@schematics/angular@7');


### PR DESCRIPTION
The Material tests had to be disabled temporarily during the TS 4.9 update, because the peer dependency range didn't allow for `next` versions. Now that the range was expanded in https://github.com/angular/components/pull/26308, the tests should work again.