### PR TITLE
fix(@angular-devkit/build-angular): provide an option to `exclude` specs in Karma builder

### DIFF
--- a/goldens/public-api/angular_devkit/build_angular/index.md
+++ b/goldens/public-api/angular_devkit/build_angular/index.md
@@ -176,6 +176,7 @@ export interface KarmaBuilderOptions {
     browsers?: string;
     codeCoverage?: boolean;
     codeCoverageExclude?: string[];
+    exclude?: string[];
     fileReplacements?: FileReplacement_2[];
     include?: string[];
     inlineStyleLanguage?: InlineStyleLanguage_2;

--- a/packages/angular_devkit/build_angular/src/builders/karma/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/index.ts
@@ -134,6 +134,7 @@ export function execute(
       webpackConfig.plugins.push(
         new FindTestsPlugin({
           include: options.include,
+          exclude: options.exclude,
           workspaceRoot: context.workspaceRoot,
           projectSourceRoot: path.join(context.workspaceRoot, sourceRoot),
         }),

--- a/packages/angular_devkit/build_angular/src/builders/karma/schema.json
+++ b/packages/angular_devkit/build_angular/src/builders/karma/schema.json
@@ -141,7 +141,15 @@
         "type": "string"
       },
       "default": ["**/*.spec.ts"],
-      "description": "Globs of files to include, relative to workspace or project root. \nThere are 2 special cases:\n - when a path to directory is provided, all spec files ending \".spec.@(ts|tsx)\" will be included\n - when a path to a file is provided, and a matching spec file exists it will be included instead."
+      "description": "Globs of files to include, relative to project root. \nThere are 2 special cases:\n - when a path to directory is provided, all spec files ending \".spec.@(ts|tsx)\" will be included\n - when a path to a file is provided, and a matching spec file exists it will be included instead."
+    },
+    "exclude": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": [],
+      "description": "Globs of files to exclude, relative to the project root."
     },
     "sourceMap": {
       "description": "Output source maps for scripts and styles. For more information, see https://angular.io/guide/workspace-config#source-map-configuration.",

--- a/packages/angular_devkit/build_angular/src/builders/karma/tests/options/exclude_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/tests/options/exclude_spec.ts
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { execute } from '../../index';
+import { BASE_OPTIONS, KARMA_BUILDER_INFO, describeBuilder } from '../setup';
+
+describeBuilder(execute, KARMA_BUILDER_INFO, (harness) => {
+  describe('Option: "exclude"', () => {
+    beforeEach(async () => {
+      await harness.writeFiles({
+        'src/app/error.spec.ts': `
+        describe('Error spec', () => {
+          it('should error', () => {
+            expect(false).toBe(true);
+          });
+        });`,
+      });
+    });
+
+    it(`should not exclude any spec when exclude is not supplied`, async () => {
+      harness.useTarget('test', {
+        ...BASE_OPTIONS,
+      });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBeFalse();
+    });
+
+    it(`should exclude spec that matches the 'exclude' pattern`, async () => {
+      harness.useTarget('test', {
+        ...BASE_OPTIONS,
+        exclude: ['**/error.spec.ts'],
+      });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
+    });
+  });
+});


### PR DESCRIPTION


With this change we add an `exclude` option to the Karma builder to provide a way to exclude certain specs from the compilation.

This is useful, when having integration, e2e and unit tests with the same suffix.

Closes #24472
