### PR TITLE
fix(@angular/cli): remove `--to` option from being required when using `--from` in `ng update`

### DIFF
--- a/packages/angular/cli/src/commands/update/cli.ts
+++ b/packages/angular/cli/src/commands/update/cli.ts
@@ -102,7 +102,7 @@ export class UpdateCommandModule extends CommandModule<UpdateCommandArgs> {
           'Version from which to migrate from. ' +
           `Only available with a single package being updated, and only with 'migrate-only'.`,
         type: 'string',
-        implies: ['to', 'migrate-only'],
+        implies: ['migrate-only'],
         conflicts: ['name'],
       })
       .option('to', {


### PR DESCRIPTION


This change remove the requirement for the `to` option to be provided when using the `from` option in conjunction with `migrate-only`.

Closes #24510
