### PR TITLE
refactor: change `JSONFile` to private instead of internal

### DIFF
--- a/packages/schematics/angular/utility/json-file.ts
+++ b/packages/schematics/angular/utility/json-file.ts
@@ -22,7 +22,7 @@ import {
 export type InsertionIndex = (properties: string[]) => number;
 export type JSONPath = (string | number)[];
 
-/** @internal */
+/** @private */
 export class JSONFile {
   content: string;
 


### PR DESCRIPTION
This is so that this can be used in the Universal repo which is not failing because the type is not available.

https://app.circleci.com/pipelines/github/angular/universal/4483/workflows/25535db2-4a9c-43b0-84a5-3a55071013c6/jobs/20263
