### PR TITLE
build: cleanup unneeded and/or default tsconfig options

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,7 @@
 /bazel-out/
 /dist-schema/
 /goldens/public-api
+/packages/angular_devkit/build_angular/src/babel-bazel.d.ts
 /packages/angular_devkit/build_angular/test/
 /packages/angular_devkit/build_webpack/test/
 /packages/angular_devkit/schematics_cli/blank/project-files/

--- a/.ng-dev/tsconfig.json
+++ b/.ng-dev/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "module": "Node16",
     "moduleResolution": "Node16",
-    "noEmit": true
+    "noEmit": true,
+    "types": []
   },
   "include": ["**/*.mts"],
   "exclude": []

--- a/scripts/json-help.ts
+++ b/scripts/json-help.ts
@@ -10,9 +10,9 @@ import { logging } from '@angular-devkit/core';
 import { spawnSync } from 'child_process';
 import { promises as fs } from 'fs';
 import * as os from 'os';
-import { JsonHelp } from 'packages/angular/cli/src/command-builder/utilities/json-help';
 import * as path from 'path';
 import { packages } from '../lib/packages';
+import { JsonHelp } from '../packages/angular/cli/src/command-builder/utilities/json-help';
 import create from './create';
 
 export async function createTemporaryProject(logger: logging.Logger): Promise<string> {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,18 +8,13 @@
     "experimentalDecorators": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitOverride": true,
-    "noUnusedParameters": false,
-    "noUnusedLocals": false,
     "outDir": "./dist",
-    "rootDir": ".",
     "skipLibCheck": true,
     "strict": true,
     "target": "es2019",
     "lib": ["es2020"],
-    "baseUrl": "",
-    "rootDirs": [".", "./dist-schema/", "./bazel-bin/"],
-    "typeRoots": ["./node_modules/@types"],
-    "types": ["node", "jasmine"],
+    "rootDir": ".",
+    "rootDirs": [".", "./dist-schema/"],
     "paths": {
       "@angular-devkit/core": ["./packages/angular_devkit/core/src/index"],
       "@angular-devkit/core/node": ["./packages/angular_devkit/core/node/index"],
@@ -50,8 +45,7 @@
     "suppressTsconfigOverrideWarnings": true
   },
   "exclude": [
-    "packages/angular_devkit/build_angular/src/bazel-babel.d.ts",
-    "bazel-out/**/*",
+    "packages/angular_devkit/build_angular/src/babel-bazel.d.ts",
     "dist/**/*",
     "dist-schema/**",
     "goldens/**/*",
@@ -60,9 +54,7 @@
     "packages/angular_devkit/schematics_cli/blank/*-files/**/*",
     "packages/angular_devkit/schematics_cli/schematic/files/**/*",
     "packages/angular_devkit/*/test/**/*",
-    "packages/schematics/*/*/*files/**/*",
     "tests/**/*",
-    "tools/**/*",
     ".ng-dev/**/*"
   ]
 }


### PR DESCRIPTION
General cleanup of the main repository `tsconfig.json` file that is used by the IDE and as a base for the build and test tsconfig files. This includes removal of options that contain default values and removal of no longer existing paths from several options. A project relative path in one of the development scripts was also fixed to use a relative path to be consist with all other paths.