### PR TITLE
refactor(@angular-devkit/build-angular): remove direct import of i18n worker code

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/action-executor.ts
+++ b/packages/angular_devkit/build_angular/src/utils/action-executor.ts
@@ -7,9 +7,9 @@
  */
 
 import Piscina from 'piscina';
+import { InlineOptions } from './bundle-inline-options';
 import { maxWorkers } from './environment-options';
 import { I18nOptions } from './i18n-options';
-import { InlineOptions } from './process-bundle';
 
 const workerFile = require.resolve('./process-bundle');
 

--- a/packages/angular_devkit/build_angular/src/utils/bundle-inline-options.ts
+++ b/packages/angular_devkit/build_angular/src/utils/bundle-inline-options.ts
@@ -6,5 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-require('../../../../../lib/bootstrap-local');
-module.exports = require('./process-bundle.ts');
+export interface InlineOptions {
+  filename: string;
+  code: string;
+  map?: string;
+  outputPath: string;
+  missingTranslation?: 'warning' | 'error' | 'ignore';
+  setLocale?: boolean;
+}

--- a/packages/angular_devkit/build_angular/src/utils/i18n-inlining.ts
+++ b/packages/angular_devkit/build_angular/src/utils/i18n-inlining.ts
@@ -11,10 +11,10 @@ import { EmittedFiles } from '@angular-devkit/build-webpack';
 import * as fs from 'fs';
 import * as path from 'path';
 import { BundleActionExecutor } from './action-executor';
+import { InlineOptions } from './bundle-inline-options';
 import { copyAssets } from './copy-assets';
 import { assertIsError } from './error';
 import { I18nOptions } from './i18n-options';
-import { InlineOptions } from './process-bundle';
 import { Spinner } from './spinner';
 
 function emittedFilesToInlineOptions(

--- a/packages/angular_devkit/build_angular/src/utils/process-bundle.ts
+++ b/packages/angular_devkit/build_angular/src/utils/process-bundle.ts
@@ -20,6 +20,7 @@ import templateBuilder from '@babel/template';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import { workerData } from 'worker_threads';
+import { InlineOptions } from './bundle-inline-options';
 import { allowMinify, shouldBeautify } from './environment-options';
 import { assertIsError } from './error';
 import { I18nOptions } from './i18n-options';
@@ -65,7 +66,7 @@ async function loadLocalizeTools(): Promise<LocalizeUtilityModule> {
   return loadEsmModule('@angular/localize/tools');
 }
 
-export async function createI18nPlugins(
+async function createI18nPlugins(
   locale: string,
   translation: unknown | undefined,
   missingTranslation: 'error' | 'warning' | 'ignore',
@@ -99,15 +100,6 @@ export async function createI18nPlugins(
   }
 
   return { diagnostics, plugins };
-}
-
-export interface InlineOptions {
-  filename: string;
-  code: string;
-  map?: string;
-  outputPath: string;
-  missingTranslation?: 'warning' | 'error' | 'ignore';
-  setLocale?: boolean;
 }
 
 interface LocalizePosition {


### PR DESCRIPTION
The i18n inlining worker code was previously imported in several locations to allow reuse of the options object used to configure the worker. To prevent the worker code from being used outside of an actual worker, the options object definition is now located in a separate file and imported in both the worker and any other files that need to use the inlining options.
The unused worker bootstrap file was also removed since it was only need with the legacy unit testing setup which has been completely replaced.