### PR TITLE
fix(@angular/cli): register schematic aliases when providing collection name in `ng generate`

### DIFF
--- a/tests/legacy-cli/e2e/tests/generate/schematic-aliases.ts
+++ b/tests/legacy-cli/e2e/tests/generate/schematic-aliases.ts
@@ -1,0 +1,14 @@
+import { ng } from '../../utils/process';
+
+export default async function () {
+  const schematicNameVariation = [
+    'component',
+    'c',
+    '@schematics/angular:component',
+    '@schematics/angular:c',
+  ];
+
+  for (const schematic of schematicNameVariation) {
+    await ng('generate', schematic, 'comp-name', '--display-block', '--dry-run');
+  }
+}


### PR DESCRIPTION
Previously, schematic aliases were not registered when a collection name was provided to `ng generate`.  Example: `ng generate c` where `c` is an alias for `component` would work, but `ng generate @schematics/angular:c` would fail. This commits fixes the schematic registration to handle the latter case.

Closes #24518
