### PR TITLE
Revert "test: use `NPM_CONFIG_legacy_peer_deps` when testing prerelease versions of Angular material."

### DIFF
--- a/tests/legacy-cli/e2e/tests/commands/add/add-material.ts
+++ b/tests/legacy-cli/e2e/tests/commands/add/add-material.ts
@@ -1,31 +1,17 @@
 import { assertIsError } from '../../../utils/utils';
 import { expectFileToMatch, rimraf } from '../../../utils/fs';
 import { uninstallPackage } from '../../../utils/packages';
-import { execWithEnv } from '../../../utils/process';
+import { ng } from '../../../utils/process';
 import { isPrereleaseCli } from '../../../utils/project';
 
 export default async function () {
   // forcibly remove in case another test doesn't clean itself up
   await rimraf('node_modules/@angular/material');
 
-  const isPrerelease = await isPrereleaseCli();
-  const tag = isPrerelease ? '@next' : '';
-  const processEnv = {
-    ...process.env,
-    // `@angular/material` pre-release may not support the current version of `@angular/core` pre-release.
-    // due to the order of releases FW -> CLI -> Material
-    // In this case peer dependency ranges may not resolve causing npm 7+ to fail during tests.
-    'NPM_CONFIG_legacy_peer_deps': isPrerelease
-      ? 'true'
-      : process.env['NPM_CONFIG_legacy_peer_deps'],
-  };
+  const tag = (await isPrereleaseCli()) ? '@next' : '';
 
   try {
-    await execWithEnv(
-      'ng',
-      ['add', `@angular/material${tag}`, '--skip-confirmation', '--unknown'],
-      processEnv,
-    );
+    await ng('add', `@angular/material${tag}`, '--unknown', '--skip-confirmation');
   } catch (error) {
     assertIsError(error);
     if (!(error as Error).message.includes(`Unknown option: '--unknown'`)) {
@@ -33,12 +19,14 @@ export default async function () {
     }
   }
 
-  await execWithEnv(
-    'ng',
-    ['add', `@angular/material${tag}`, '--theme', 'custom', '--verbose', '--skip-confirmation'],
-    processEnv,
+  await ng(
+    'add',
+    `@angular/material${tag}`,
+    '--theme',
+    'custom',
+    '--verbose',
+    '--skip-confirmation',
   );
-
   await expectFileToMatch('package.json', /@angular\/material/);
 
   // Clean up existing cdk package


### PR DESCRIPTION


This reverts commit 04e7c25aad3644d0502f0ae30308ccabf4db43ea as it is no longer needed due to the recent changes done in the material packages to expand the peer dependency.
See: https://github.com/angular/components/commit/6afe888a1a1c840c371991051335c19b6a1bdf95
