### PR TITLE
feat(@angular/cli): log number of files update during `ng update`

### DIFF
--- a/packages/angular/cli/src/commands/update/cli.ts
+++ b/packages/angular/cli/src/commands/update/cli.ts
@@ -387,16 +387,29 @@ export class UpdateCommandModule extends CommandModule<UpdateCommandArgs> {
         logger.info('  ' + description.join('.\n  '));
       }
 
-      const result = await this.executeSchematic(
+      const { success, files } = await this.executeSchematic(
         workflow,
         migration.collection.name,
         migration.name,
       );
-      if (!result.success) {
+      if (!success) {
         return 1;
       }
 
-      logger.info('  Migration completed.');
+      let modifiedFilesText: string;
+      switch (files.size) {
+        case 0:
+          modifiedFilesText = 'No changes made';
+          break;
+        case 1:
+          modifiedFilesText = '1 file modified';
+          break;
+        default:
+          modifiedFilesText = `${files.size} files modified`;
+          break;
+      }
+
+      logger.info(`  Migration completed (${modifiedFilesText}).`);
 
       // Commit migration
       if (commit) {


### PR DESCRIPTION
This commit updates `ng update` to include the number of files updated when a migration is completed.

Closes #24488
