### PR TITLE
fix(@angular-devkit/build-angular): avoid undefined module path for Sass imports in esbuild

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/sass-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/sass-plugin.ts
@@ -124,7 +124,11 @@ async function compileString(
 
               if (packageResult.path) {
                 return pathToFileURL(
-                  join(dirname(packageResult.path), !hasScope ? nameOrFirstPath : '', ...pathPart),
+                  join(
+                    dirname(packageResult.path),
+                    !hasScope && nameOrFirstPath ? nameOrFirstPath : '',
+                    ...pathPart,
+                  ),
                 );
               }
             }


### PR DESCRIPTION
When using Sass with the experimental esbuild-based browser application builder, bare imports without a path segment that were available via included paths but also happen to be a node module could cause an exception. An example of such an import would be `@import "globals";`. The deep import node module logic would previously attempt to join an undefined path segment to the resolved path for the `globals` package which would raise a argument type exception. This case has now been fixed by only joining if there is actually a path segment present such as `@import "globals/x"`. With this fix in place, the node module case can then continue and if no stylesheet is found, the include paths will then be searched.
