### PR TITLE
build: update bazel aspect lib to 1.23.3

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -78,9 +78,9 @@ yarn_install(
 
 http_archive(
     name = "aspect_bazel_lib",
-    sha256 = "558d70e36425c317c70b19fb0f68241a3747bcf46561b5ffc19bed17527adbb3",
-    strip_prefix = "bazel-lib-1.20.0",
-    url = "https://github.com/aspect-build/bazel-lib/archive/v1.20.0.tar.gz",
+    sha256 = "79623d656aa23ad3fd4692ab99786c613cd36e49f5566469ed97bc9b4c655f03",
+    strip_prefix = "bazel-lib-1.23.3",
+    url = "https://github.com/aspect-build/bazel-lib/archive/v1.23.3.tar.gz",
 )
 
 load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies", "register_jq_toolchains")


### PR DESCRIPTION
Synchronizes the aspect bazel library used in patch with the main branch.