### PR TITLE
fix(@angular-devkit/build-angular): print server builder errors and warnings

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/server/tests/behavior/build-errors_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/server/tests/behavior/build-errors_spec.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { logging } from '@angular-devkit/core';
+import { execute } from '../../index';
+import { BASE_OPTIONS, SERVER_BUILDER_INFO, describeBuilder } from '../setup';
+
+describeBuilder(execute, SERVER_BUILDER_INFO, (harness) => {
+  describe('Behavior: "Build Error"', () => {
+    it('emits errors', async () => {
+      harness.useTarget('server', {
+        ...BASE_OPTIONS,
+        watch: true,
+      });
+
+      // Generate an error
+      await harness.appendToFile('src/main.server.ts', `const foo: = 'abc';`);
+
+      const { result, logs } = await harness.executeOnce();
+
+      expect(result?.success).toBeFalse();
+      expect(logs).toContain(
+        jasmine.objectContaining<logging.LogEntry>({
+          message: jasmine.stringMatching(/TS1110:.*Type expected/),
+        }),
+      );
+    });
+  });
+});

--- a/packages/angular_devkit/build_angular/src/builders/server/tests/behavior/web-workers_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/server/tests/behavior/web-workers_spec.ts
@@ -12,14 +12,14 @@ import { BASE_OPTIONS, SERVER_BUILDER_INFO, describeBuilder } from '../setup';
 describeBuilder(execute, SERVER_BUILDER_INFO, (harness) => {
   describe('Behavior: "Errors"', () => {
     it('should not try to resolve web-workers', async () => {
-      harness.useTarget('test', {
+      harness.useTarget('server', {
         ...BASE_OPTIONS,
       });
 
       await harness.writeFiles({
         'src/app/app.worker.ts': `
           /// <reference lib="webworker" />
-  
+
           const foo: string = 'hello world';
           addEventListener('message', ({ data }) => {
             postMessage(foo);


### PR DESCRIPTION


Previously server builder errors and warnings were not being printed in the console correctly.

Closes #24612
