### PR TITLE
fix(@angular-devkit/build-angular): load JavaScript bundles as modules in karma

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/plugins/karma/karma-context.html
+++ b/packages/angular_devkit/build_angular/src/webpack/plugins/karma/karma-context.html
@@ -30,14 +30,14 @@ Reloaded before every execution run.
       // All served files with the latest timestamps
       %MAPPINGS%
     </script>
-    <script src="_karma_webpack_/runtime.js" crossorigin="anonymous"></script>
-    <script src="_karma_webpack_/polyfills.js" crossorigin="anonymous"></script>
+    <script src="_karma_webpack_/runtime.js" crossorigin="anonymous" type="module"></script>
+    <script src="_karma_webpack_/polyfills.js" crossorigin="anonymous" type="module"></script>
     <!-- Dynamically replaced with <script> tags -->
     %SCRIPTS%
-    <script src="_karma_webpack_/scripts.js" crossorigin="anonymous"></script>
-    <script src="_karma_webpack_/vendor.js" crossorigin="anonymous"></script>
-    <script src="_karma_webpack_/main.js" crossorigin="anonymous"></script>
-    <script type="text/javascript">
+    <script src="_karma_webpack_/scripts.js" crossorigin="anonymous" defer></script>
+    <script src="_karma_webpack_/vendor.js" crossorigin="anonymous" type="module"></script>
+    <script src="_karma_webpack_/main.js" crossorigin="anonymous" type="module"></script>
+    <script type="module">
       window.__karma__.loaded();
     </script>
   </body>

--- a/packages/angular_devkit/build_angular/src/webpack/plugins/karma/karma-debug.html
+++ b/packages/angular_devkit/build_angular/src/webpack/plugins/karma/karma-debug.html
@@ -32,14 +32,14 @@ just for immediate execution, without reporting to Karma server.
       // All served files with the latest timestamps
       %MAPPINGS%
     </script>
-    <script src="_karma_webpack_/runtime.js" crossorigin="anonymous"></script>
-    <script src="_karma_webpack_/polyfills.js" crossorigin="anonymous"></script>
+    <script src="_karma_webpack_/runtime.js" crossorigin="anonymous" type="module"></script>
+    <script src="_karma_webpack_/polyfills.js" crossorigin="anonymous" type="module"></script>
     <!-- Dynamically replaced with <script> tags -->
     %SCRIPTS%
-    <script src="_karma_webpack_/scripts.js" crossorigin="anonymous"></script>
-    <script src="_karma_webpack_/vendor.js" crossorigin="anonymous"></script>
-    <script src="_karma_webpack_/main.js" crossorigin="anonymous"></script>
-    <script type="text/javascript">
+    <script src="_karma_webpack_/scripts.js" crossorigin="anonymous" defer></script>
+    <script src="_karma_webpack_/vendor.js" crossorigin="anonymous" type="module"></script>
+    <script src="_karma_webpack_/main.js" crossorigin="anonymous" type="module"></script>
+    <script type="module">
       window.__karma__.loaded();
     </script>
   </body>


### PR DESCRIPTION

With this change we load bundles as modules when using the Karma builder.
