### PR TITLE
feat(@angular-devkit/build-angular): support JIT compilation with esbuild

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/angular/jit-compilation.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/angular/jit-compilation.ts
@@ -1,0 +1,133 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import assert from 'node:assert';
+import ts from 'typescript';
+import { AngularCompilation } from '../angular-compilation';
+import { AngularHostOptions, createAngularCompilerHost } from '../angular-host';
+import { profileSync } from '../profiling';
+import { createJitResourceTransformer } from './jit-resource-transformer';
+
+class JitCompilationState {
+  constructor(
+    public readonly typeScriptProgram: ts.EmitAndSemanticDiagnosticsBuilderProgram,
+    public readonly constructorParametersDownlevelTransform: ts.TransformerFactory<ts.SourceFile>,
+    public readonly replaceResourcesTransform: ts.TransformerFactory<ts.SourceFile>,
+  ) {}
+}
+
+export interface EmitFileResult {
+  content?: string;
+  map?: string;
+  dependencies: readonly string[];
+}
+export type FileEmitter = (file: string) => Promise<EmitFileResult | undefined>;
+
+export class JitCompilation {
+  #state?: JitCompilationState;
+
+  async initialize(
+    rootNames: string[],
+    compilerOptions: ts.CompilerOptions,
+    hostOptions: AngularHostOptions,
+    configurationDiagnostics?: ts.Diagnostic[],
+  ): Promise<{ affectedFiles: ReadonlySet<ts.SourceFile> }> {
+    // Dynamically load the Angular compiler CLI package
+    const { constructorParametersDownlevelTransform } = await AngularCompilation.loadCompilerCli();
+
+    // Create Angular compiler host
+    const host = createAngularCompilerHost(compilerOptions, hostOptions);
+
+    // Create the TypeScript Program
+    const typeScriptProgram = profileSync('TS_CREATE_PROGRAM', () =>
+      ts.createEmitAndSemanticDiagnosticsBuilderProgram(
+        rootNames,
+        compilerOptions,
+        host,
+        this.#state?.typeScriptProgram,
+        configurationDiagnostics,
+      ),
+    );
+
+    const affectedFiles = profileSync('TS_FIND_AFFECTED', () =>
+      findAffectedFiles(typeScriptProgram),
+    );
+
+    this.#state = new JitCompilationState(
+      typeScriptProgram,
+      constructorParametersDownlevelTransform(typeScriptProgram.getProgram()),
+      createJitResourceTransformer(() => typeScriptProgram.getProgram().getTypeChecker()),
+    );
+
+    return { affectedFiles };
+  }
+
+  *collectDiagnostics(): Iterable<ts.Diagnostic> {
+    assert(this.#state, 'Compilation must be initialized prior to collecting diagnostics.');
+    const { typeScriptProgram } = this.#state;
+
+    // Collect program level diagnostics
+    yield* typeScriptProgram.getConfigFileParsingDiagnostics();
+    yield* typeScriptProgram.getOptionsDiagnostics();
+    yield* typeScriptProgram.getGlobalDiagnostics();
+    yield* profileSync('NG_DIAGNOSTICS_SYNTACTIC', () =>
+      typeScriptProgram.getSyntacticDiagnostics(),
+    );
+    yield* profileSync('NG_DIAGNOSTICS_SEMANTIC', () => typeScriptProgram.getSemanticDiagnostics());
+  }
+
+  createFileEmitter(onAfterEmit?: (sourceFile: ts.SourceFile) => void): FileEmitter {
+    assert(this.#state, 'Compilation must be initialized prior to emitting files.');
+    const {
+      typeScriptProgram,
+      constructorParametersDownlevelTransform,
+      replaceResourcesTransform,
+    } = this.#state;
+
+    const transformers = {
+      before: [replaceResourcesTransform, constructorParametersDownlevelTransform],
+    };
+
+    return async (file: string) => {
+      const sourceFile = typeScriptProgram.getSourceFile(file);
+      if (!sourceFile) {
+        return undefined;
+      }
+
+      let content: string | undefined;
+      typeScriptProgram.emit(
+        sourceFile,
+        (filename, data) => {
+          if (/\.[cm]?js$/.test(filename)) {
+            content = data;
+          }
+        },
+        undefined /* cancellationToken */,
+        undefined /* emitOnlyDtsFiles */,
+        transformers,
+      );
+
+      onAfterEmit?.(sourceFile);
+
+      return { content, dependencies: [] };
+    };
+  }
+}
+
+function findAffectedFiles(
+  builder: ts.EmitAndSemanticDiagnosticsBuilderProgram,
+): Set<ts.SourceFile> {
+  const affectedFiles = new Set<ts.SourceFile>();
+
+  let result;
+  while ((result = builder.getSemanticDiagnosticsOfNextAffectedFile())) {
+    affectedFiles.add(result.affected as ts.SourceFile);
+  }
+
+  return affectedFiles;
+}

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/angular/jit-plugin-callbacks.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/angular/jit-plugin-callbacks.ts
@@ -1,0 +1,136 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import type { OutputFile, PluginBuild } from 'esbuild';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { BundleStylesheetOptions, bundleComponentStylesheet } from '../stylesheets';
+import {
+  JIT_NAMESPACE_REGEXP,
+  JIT_STYLE_NAMESPACE,
+  JIT_TEMPLATE_NAMESPACE,
+  parseJitUri,
+} from './uri';
+
+/**
+ * Loads/extracts the contents from a load callback Angular JIT entry.
+ * An Angular JIT entry represents either a file path for a component resource or base64
+ * encoded data for an inline component resource.
+ * @param entry The value that represents content to load.
+ * @param root The absolute path for the root of the build (typically the workspace root).
+ * @param skipRead If true, do not attempt to read the file; if false, read file content from disk.
+ * This option has no effect if the entry does not originate from a file. Defaults to false.
+ * @returns An object containing the absolute path of the contents and optionally the actual contents.
+ * For inline entries the contents will always be provided.
+ */
+async function loadEntry(
+  entry: string,
+  root: string,
+  skipRead?: boolean,
+): Promise<{ path: string; contents?: string }> {
+  if (entry.startsWith('file:')) {
+    const specifier = path.join(root, entry.slice(5));
+
+    return {
+      path: specifier,
+      contents: skipRead ? undefined : await readFile(specifier, 'utf-8'),
+    };
+  } else if (entry.startsWith('inline:')) {
+    const [importer, data] = entry.slice(7).split(';', 2);
+
+    return {
+      path: path.join(root, importer),
+      contents: Buffer.from(data, 'base64').toString(),
+    };
+  } else {
+    throw new Error('Invalid data for Angular JIT entry.');
+  }
+}
+
+/**
+ * Sets up esbuild resolve and load callbacks to support Angular JIT mode processing
+ * for both Component stylesheets and templates. These callbacks work alongside the JIT
+ * resource TypeScript transformer to convert and then bundle Component resources as
+ * static imports.
+ * @param build An esbuild {@link PluginBuild} instance used to add callbacks.
+ * @param styleOptions The options to use when bundling stylesheets.
+ * @param stylesheetResourceFiles An array where stylesheet resources will be added.
+ */
+export function setupJitPluginCallbacks(
+  build: PluginBuild,
+  styleOptions: BundleStylesheetOptions & { inlineStyleLanguage: string },
+  stylesheetResourceFiles: OutputFile[],
+): void {
+  const root = build.initialOptions.absWorkingDir ?? '';
+
+  // Add a resolve callback to capture and parse any JIT URIs that were added by the
+  // JIT resource TypeScript transformer.
+  // Resources originating from a file are resolved as relative from the containing file (importer).
+  build.onResolve({ filter: JIT_NAMESPACE_REGEXP }, (args) => {
+    const parsed = parseJitUri(args.path);
+    if (!parsed) {
+      return undefined;
+    }
+
+    const { namespace, origin, specifier } = parsed;
+
+    if (origin === 'file') {
+      return {
+        // Use a relative path to prevent fully resolved paths in the metafile (JSON stats file).
+        // This is only necessary for custom namespaces. esbuild will handle the file namespace.
+        path: 'file:' + path.relative(root, path.join(path.dirname(args.importer), specifier)),
+        namespace,
+      };
+    } else {
+      // Inline data may need the importer to resolve imports/references within the content
+      const importer = path.relative(root, args.importer);
+
+      return {
+        path: `inline:${importer};${specifier}`,
+        namespace,
+      };
+    }
+  });
+
+  // Add a load callback to handle Component stylesheets (both inline and external)
+  build.onLoad({ filter: /./, namespace: JIT_STYLE_NAMESPACE }, async (args) => {
+    // skipRead is used here because the stylesheet bundling will read a file stylesheet
+    // directly either via a preprocessor or esbuild itself.
+    const entry = await loadEntry(args.path, root, true /* skipRead */);
+
+    const { contents, resourceFiles, errors, warnings } = await bundleComponentStylesheet(
+      styleOptions.inlineStyleLanguage,
+      // The `data` parameter is only needed for a stylesheet if it was inline
+      entry.contents ?? '',
+      entry.path,
+      entry.contents !== undefined,
+      styleOptions,
+    );
+
+    stylesheetResourceFiles.push(...resourceFiles);
+
+    return {
+      errors,
+      warnings,
+      contents,
+      loader: 'text',
+    };
+  });
+
+  // Add a load callback to handle Component templates
+  // NOTE: While this callback supports both inline and external templates, the transformer
+  // currently only supports generating URIs for external templates.
+  build.onLoad({ filter: /./, namespace: JIT_TEMPLATE_NAMESPACE }, async (args) => {
+    const { contents } = await loadEntry(args.path, root);
+
+    return {
+      contents,
+      loader: 'text',
+    };
+  });
+}

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/angular/jit-resource-transformer.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/angular/jit-resource-transformer.ts
@@ -1,0 +1,292 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import ts from 'typescript';
+import { generateJitFileUri, generateJitInlineUri } from './uri';
+
+/**
+ * Creates a TypeScript Transformer to transform Angular Component resource references into
+ * static import statements. This transformer is used in Angular's JIT compilation mode to
+ * support processing of component resources. When in AOT mode, the Angular AOT compiler handles
+ * this processing and this transformer is not used.
+ * @param getTypeChecker A function that returns a TypeScript TypeChecker instance for the program.
+ * @returns A TypeScript transformer factory.
+ */
+export function createJitResourceTransformer(
+  getTypeChecker: () => ts.TypeChecker,
+): ts.TransformerFactory<ts.SourceFile> {
+  return (context: ts.TransformationContext) => {
+    const typeChecker = getTypeChecker();
+    const nodeFactory = context.factory;
+    const resourceImportDeclarations: ts.ImportDeclaration[] = [];
+
+    const visitNode: ts.Visitor = (node: ts.Node) => {
+      if (ts.isClassDeclaration(node)) {
+        const decorators = ts.getDecorators(node);
+
+        if (!decorators || decorators.length === 0) {
+          return node;
+        }
+
+        return nodeFactory.updateClassDeclaration(
+          node,
+          [
+            ...decorators.map((current) =>
+              visitDecorator(nodeFactory, current, typeChecker, resourceImportDeclarations),
+            ),
+            ...(ts.getModifiers(node) ?? []),
+          ],
+          node.name,
+          node.typeParameters,
+          node.heritageClauses,
+          node.members,
+        );
+      }
+
+      return ts.visitEachChild(node, visitNode, context);
+    };
+
+    return (sourceFile) => {
+      const updatedSourceFile = ts.visitEachChild(sourceFile, visitNode, context);
+
+      if (resourceImportDeclarations.length > 0) {
+        return nodeFactory.updateSourceFile(
+          updatedSourceFile,
+          ts.setTextRange(
+            nodeFactory.createNodeArray(
+              [...resourceImportDeclarations, ...updatedSourceFile.statements],
+              updatedSourceFile.statements.hasTrailingComma,
+            ),
+            updatedSourceFile.statements,
+          ),
+          updatedSourceFile.isDeclarationFile,
+          updatedSourceFile.referencedFiles,
+          updatedSourceFile.typeReferenceDirectives,
+          updatedSourceFile.hasNoDefaultLib,
+          updatedSourceFile.libReferenceDirectives,
+        );
+      } else {
+        return updatedSourceFile;
+      }
+    };
+  };
+}
+
+function visitDecorator(
+  nodeFactory: ts.NodeFactory,
+  node: ts.Decorator,
+  typeChecker: ts.TypeChecker,
+  resourceImportDeclarations: ts.ImportDeclaration[],
+): ts.Decorator {
+  const origin = getDecoratorOrigin(node, typeChecker);
+  if (!origin || origin.module !== '@angular/core' || origin.name !== 'Component') {
+    return node;
+  }
+
+  if (!ts.isCallExpression(node.expression)) {
+    return node;
+  }
+
+  const decoratorFactory = node.expression;
+  const args = decoratorFactory.arguments;
+  if (args.length !== 1 || !ts.isObjectLiteralExpression(args[0])) {
+    // Unsupported component metadata
+    return node;
+  }
+
+  const objectExpression = args[0] as ts.ObjectLiteralExpression;
+  const styleReplacements: ts.Expression[] = [];
+
+  // visit all properties
+  let properties = ts.visitNodes(objectExpression.properties, (node) =>
+    ts.isObjectLiteralElementLike(node)
+      ? visitComponentMetadata(nodeFactory, node, styleReplacements, resourceImportDeclarations)
+      : node,
+  );
+
+  // replace properties with updated properties
+  if (styleReplacements.length > 0) {
+    const styleProperty = nodeFactory.createPropertyAssignment(
+      nodeFactory.createIdentifier('styles'),
+      nodeFactory.createArrayLiteralExpression(styleReplacements),
+    );
+
+    properties = nodeFactory.createNodeArray([...properties, styleProperty]);
+  }
+
+  return nodeFactory.updateDecorator(
+    node,
+    nodeFactory.updateCallExpression(
+      decoratorFactory,
+      decoratorFactory.expression,
+      decoratorFactory.typeArguments,
+      [nodeFactory.updateObjectLiteralExpression(objectExpression, properties)],
+    ),
+  );
+}
+
+function visitComponentMetadata(
+  nodeFactory: ts.NodeFactory,
+  node: ts.ObjectLiteralElementLike,
+  styleReplacements: ts.Expression[],
+  resourceImportDeclarations: ts.ImportDeclaration[],
+): ts.ObjectLiteralElementLike | undefined {
+  if (!ts.isPropertyAssignment(node) || ts.isComputedPropertyName(node.name)) {
+    return node;
+  }
+
+  switch (node.name.text) {
+    case 'templateUrl':
+      // Only analyze string literals
+      if (
+        !ts.isStringLiteral(node.initializer) &&
+        !ts.isNoSubstitutionTemplateLiteral(node.initializer)
+      ) {
+        return node;
+      }
+
+      const url = node.initializer.text;
+      if (!url) {
+        return node;
+      }
+
+      return nodeFactory.updatePropertyAssignment(
+        node,
+        nodeFactory.createIdentifier('template'),
+        createResourceImport(
+          nodeFactory,
+          generateJitFileUri(url, 'template'),
+          resourceImportDeclarations,
+        ),
+      );
+    case 'styles':
+      if (!ts.isArrayLiteralExpression(node.initializer)) {
+        return node;
+      }
+
+      const inlineStyles = ts.visitNodes(node.initializer.elements, (node) => {
+        if (!ts.isStringLiteral(node) && !ts.isNoSubstitutionTemplateLiteral(node)) {
+          return node;
+        }
+
+        const contents = node.text;
+        if (!contents) {
+          // An empty inline style is equivalent to not having a style element
+          return undefined;
+        }
+
+        return createResourceImport(
+          nodeFactory,
+          generateJitInlineUri(contents, 'style'),
+          resourceImportDeclarations,
+        );
+      });
+
+      // Inline styles should be placed first
+      styleReplacements.unshift(...inlineStyles);
+
+      // The inline styles will be added afterwards in combination with any external styles
+      return undefined;
+    case 'styleUrls':
+      if (!ts.isArrayLiteralExpression(node.initializer)) {
+        return node;
+      }
+
+      const externalStyles = ts.visitNodes(node.initializer.elements, (node) => {
+        if (!ts.isStringLiteral(node) && !ts.isNoSubstitutionTemplateLiteral(node)) {
+          return node;
+        }
+
+        const url = node.text;
+        if (!url) {
+          return node;
+        }
+
+        return createResourceImport(
+          nodeFactory,
+          generateJitFileUri(url, 'style'),
+          resourceImportDeclarations,
+        );
+      });
+
+      // External styles are applied after any inline styles
+      styleReplacements.push(...externalStyles);
+
+      // The external styles will be added afterwards in combination with any inline styles
+      return undefined;
+    default:
+      // All other elements are passed through
+      return node;
+  }
+}
+
+function createResourceImport(
+  nodeFactory: ts.NodeFactory,
+  url: string,
+  resourceImportDeclarations: ts.ImportDeclaration[],
+): ts.Identifier {
+  const urlLiteral = nodeFactory.createStringLiteral(url);
+
+  const importName = nodeFactory.createIdentifier(
+    `__NG_CLI_RESOURCE__${resourceImportDeclarations.length}`,
+  );
+  resourceImportDeclarations.push(
+    nodeFactory.createImportDeclaration(
+      undefined,
+      nodeFactory.createImportClause(false, importName, undefined),
+      urlLiteral,
+    ),
+  );
+
+  return importName;
+}
+
+function getDecoratorOrigin(
+  decorator: ts.Decorator,
+  typeChecker: ts.TypeChecker,
+): { name: string; module: string } | null {
+  if (!ts.isCallExpression(decorator.expression)) {
+    return null;
+  }
+
+  let identifier: ts.Node;
+  let name = '';
+
+  if (ts.isPropertyAccessExpression(decorator.expression.expression)) {
+    identifier = decorator.expression.expression.expression;
+    name = decorator.expression.expression.name.text;
+  } else if (ts.isIdentifier(decorator.expression.expression)) {
+    identifier = decorator.expression.expression;
+  } else {
+    return null;
+  }
+
+  // NOTE: resolver.getReferencedImportDeclaration would work as well but is internal
+  const symbol = typeChecker.getSymbolAtLocation(identifier);
+  if (symbol && symbol.declarations && symbol.declarations.length > 0) {
+    const declaration = symbol.declarations[0];
+    let module: string;
+
+    if (ts.isImportSpecifier(declaration)) {
+      name = (declaration.propertyName || declaration.name).text;
+      module = (declaration.parent.parent.parent.moduleSpecifier as ts.StringLiteral).text;
+    } else if (ts.isNamespaceImport(declaration)) {
+      // Use the name from the decorator namespace property access
+      module = (declaration.parent.parent.moduleSpecifier as ts.StringLiteral).text;
+    } else if (ts.isImportClause(declaration)) {
+      name = (declaration.name as ts.Identifier).text;
+      module = (declaration.parent.moduleSpecifier as ts.StringLiteral).text;
+    } else {
+      return null;
+    }
+
+    return { name, module };
+  }
+
+  return null;
+}

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/angular/uri.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/angular/uri.ts
@@ -1,0 +1,78 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * A string value representing the base namespace for Angular JIT mode related imports.
+ */
+const JIT_BASE_NAMESPACE = 'angular:jit';
+
+/**
+ * A string value representing the namespace for Angular JIT mode related imports for
+ * Component styles. This namespace is used for both inline (`styles`) and external
+ * (`styleUrls`) styles.
+ */
+export const JIT_STYLE_NAMESPACE = `${JIT_BASE_NAMESPACE}:style` as const;
+
+/**
+ * A string value representing the namespace for Angular JIT mode related imports for
+ * Component templates. This namespace is currently only used for external (`templateUrl`)
+ * templates.
+ */
+export const JIT_TEMPLATE_NAMESPACE = `${JIT_BASE_NAMESPACE}:template` as const;
+
+/**
+ * A regular expression that can be used to match a Angular JIT mode namespace URI.
+ * It contains capture groups for the type (template/style), origin (file/inline), and specifier.
+ * The {@link parseJitUri} function can be used to parse and return an object representation of a JIT URI.
+ */
+export const JIT_NAMESPACE_REGEXP = new RegExp(
+  `^${JIT_BASE_NAMESPACE}:(template|style):(file|inline);(.*)$`,
+);
+
+/**
+ * Generates an Angular JIT mode namespace URI for a given file.
+ * @param file The path of the file to be included.
+ * @param type The type of the file (`style` or `template`).
+ * @returns A string containing the full JIT namespace URI.
+ */
+export function generateJitFileUri(file: string, type: 'style' | 'template') {
+  return `${JIT_BASE_NAMESPACE}:${type}:file;${file}`;
+}
+
+/**
+ * Generates an Angular JIT mode namespace URI for a given inline style or template.
+ * The provided content is base64 encoded and included in the URI.
+ * @param data The content to encode within the URI.
+ * @param type The type of the content (`style` or `template`).
+ * @returns A string containing the full JIT namespace URI.
+ */
+export function generateJitInlineUri(data: string | Uint8Array, type: 'style' | 'template') {
+  return `${JIT_BASE_NAMESPACE}:${type}:inline;${Buffer.from(data).toString('base64')}`;
+}
+
+/**
+ * Parses a string containing a JIT namespace URI.
+ * JIT namespace URIs are used to encode the information for an Angular component's stylesheets
+ * and templates when compiled in JIT mode.
+ * @param uri The URI to parse into its underlying components.
+ * @returns An object containing the namespace, type, origin, and specifier of the URI;
+ * `undefined` if not a JIT namespace URI.
+ */
+export function parseJitUri(uri: string) {
+  const matches = JIT_NAMESPACE_REGEXP.exec(uri);
+  if (!matches) {
+    return undefined;
+  }
+
+  return {
+    namespace: `${JIT_BASE_NAMESPACE}:${matches[1]}`,
+    type: matches[1] as 'style' | 'template',
+    origin: matches[2] as 'file' | 'inline',
+    specifier: matches[3],
+  };
+}

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
@@ -284,6 +284,7 @@ function createCodeBundleOptions(
     stylePreprocessorOptions,
     advancedOptimizations,
     inlineStyleLanguage,
+    jit,
   } = options;
 
   return {
@@ -318,6 +319,7 @@ function createCodeBundleOptions(
           sourcemap: !!sourcemapOptions.scripts,
           thirdPartySourcemaps: sourcemapOptions.vendor,
           tsconfig,
+          jit,
           advancedOptimizations,
           fileReplacements,
           sourceFileCache,
@@ -344,8 +346,7 @@ function createCodeBundleOptions(
       // Angular turns `ngDevMode` into an object for development debugging purposes when not defined
       // which a constant true value would break.
       ...(optimizationOptions.scripts ? { 'ngDevMode': 'false' } : undefined),
-      // Only AOT mode is supported currently
-      'ngJitMode': 'false',
+      'ngJitMode': jit ? 'true' : 'false',
     },
   };
 }
@@ -475,15 +476,6 @@ export async function* buildEsbuildBrowser(
   initialOptions: BrowserBuilderOptions,
   context: BuilderContext,
 ): AsyncIterable<BuilderOutput> {
-  // Only AOT is currently supported
-  if (initialOptions.aot !== true) {
-    context.logger.error(
-      'JIT mode is currently not supported by this experimental builder. AOT mode must be used.',
-    );
-
-    return;
-  }
-
   // Inform user of experimental status of builder and options
   logExperimentalWarnings(initialOptions, context);
 

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/javascript-transformer-worker.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/javascript-transformer-worker.ts
@@ -20,6 +20,7 @@ interface JavaScriptTransformRequest {
   advancedOptimizations: boolean;
   forceAsyncTransformation?: boolean;
   skipLinker: boolean;
+  jit: boolean;
 }
 
 export default async function transformJavaScript(
@@ -80,7 +81,7 @@ async function transformWithBabel({
         {
           angularLinker: linkerPluginCreator && {
             shouldLink,
-            jitMode: false,
+            jitMode: options.jit,
             linkerPluginCreator,
           },
           forceAsyncTransformation,

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/javascript-transformer.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/javascript-transformer.ts
@@ -15,6 +15,7 @@ export interface JavaScriptTransformerOptions {
   sourcemap: boolean;
   thirdPartySourcemaps?: boolean;
   advancedOptimizations?: boolean;
+  jit?: boolean;
 }
 
 /**
@@ -35,11 +36,17 @@ export class JavaScriptTransformer {
     });
 
     // Extract options to ensure only the named options are serialized and sent to the worker
-    const { sourcemap, thirdPartySourcemaps = false, advancedOptimizations = false } = options;
+    const {
+      sourcemap,
+      thirdPartySourcemaps = false,
+      advancedOptimizations = false,
+      jit = false,
+    } = options;
     this.#commonOptions = {
       sourcemap,
       thirdPartySourcemaps,
       advancedOptimizations,
+      jit,
     };
   }
 

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/options.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/options.ts
@@ -133,6 +133,7 @@ export async function normalizeOptions(
   // Initial options to keep
   const {
     allowedCommonJsDependencies,
+    aot,
     baseHref,
     buildOptimizer,
     crossOrigin,
@@ -158,6 +159,7 @@ export async function normalizeOptions(
     externalDependencies,
     extractLicenses,
     inlineStyleLanguage,
+    jit: !aot,
     stats: !!statsJson,
     poll,
     // If not explicitly set, default to the Node.js process argument

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/stylesheets.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/stylesheets.ts
@@ -12,6 +12,11 @@ import { createCssResourcePlugin } from './css-resource-plugin';
 import { BundlerContext } from './esbuild';
 import { createSassPlugin } from './sass-plugin';
 
+/**
+ * A counter for component styles used to generate unique build-time identifiers for each stylesheet.
+ */
+let componentStyleCounter = 0;
+
 export interface BundleStylesheetOptions {
   workspaceRoot: string;
   optimization: boolean;
@@ -73,7 +78,6 @@ export function createStylesheetBundleOptions(
  * @returns An object containing the output of the bundling operation.
  */
 export async function bundleComponentStylesheet(
-  identifier: string,
   language: string,
   data: string,
   filename: string,
@@ -81,7 +85,7 @@ export async function bundleComponentStylesheet(
   options: BundleStylesheetOptions,
 ) {
   const namespace = 'angular:styles/component';
-  const entry = [language, identifier, filename].join(';');
+  const entry = [language, componentStyleCounter++, filename].join(';');
 
   const buildOptions = createStylesheetBundleOptions(options, { [entry]: data });
   buildOptions.entryPoints = [`${namespace};${entry}`];


### PR DESCRIPTION
When using the experimental esbuild-based browser application builder, the `aot` build option can now be set to `false` to enable JIT compilation mode. The JIT mode compilation operates in a similar fashion to the Webpack-based builder in JIT mode. All external Component stylesheet and template references are converted to static import statements and then the content is bundled as text. All inline styles are also processed in this way as well to support inline style languages such as Sass. This approach also has the advantage of minimizing the processing necessary during rebuilds. In JIT watch mode, TypeScript code does not need to be reprocessed if only an external stylesheet or template is changed.