### PR TITLE
fix(@angular-devkit/build-angular): fix support of Safari TP versions

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/esbuild-targets.ts
+++ b/packages/angular_devkit/build_angular/src/utils/esbuild-targets.ts
@@ -38,7 +38,7 @@ export function transformSupportedBrowsersToTargets(supportedBrowsers: string[])
     [version] = version.split('-');
 
     if (esBuildSupportedBrowsers.has(browserName)) {
-      if (browserName === 'safari' && version === 'TP') {
+      if (browserName === 'safari' && version === 'tp') {
         // esbuild only supports numeric versions so `TP` is converted to a high number (999) since
         // a Technology Preview (TP) of Safari is assumed to support all currently known features.
         version = '999';


### PR DESCRIPTION
Fix issue-related to the support of Safari TP versions. This issue was accidentally introduced in angular/angular-cli@a0f9db8

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #24639 

## What is the new behavior?

You are getting an error when you try to build the project.

```
An unhandled exception occurred: Transform failed with 1 error:
error: Invalid version: "tp.0"
See "/private/var/folders/_1/g7z1fzm54sb_wrdyk00s32580000gn/T/ng-SQbgG6/angular-errors.log" for further details
```

<!-- Please describe the new behavior that. -->

The project was built successfully.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information