### PR TITLE
fix(@angular/cli): only set `DebugView` when `NG_DEBUG` is passed

### DIFF
--- a/packages/angular/cli/src/analytics/analytics-collector.ts
+++ b/packages/angular/cli/src/analytics/analytics-collector.ts
@@ -46,10 +46,11 @@ export class AnalyticsCollector {
       [RequestParameter.UserAgentArchitecture]: os.arch(),
       [RequestParameter.UserAgentPlatform]: os.platform(),
       [RequestParameter.UserAgentPlatformVersion]: os.version(),
-
-      // Set undefined to disable debug view.
-      [RequestParameter.DebugView]: ngDebug ? 1 : undefined,
     };
+
+    if (ngDebug) {
+      requestParameters[RequestParameter.DebugView] = 1;
+    }
 
     this.requestParameterStringified = querystring.stringify(requestParameters);
 


### PR DESCRIPTION
`querystring.stringify` will not remove undefined values.
