### PR TITLE
fix(@angular-devkit/build-angular): do not fail compilation when spec pattern does not match

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/karma/tests/options/include_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/tests/options/include_spec.ts
@@ -17,16 +17,8 @@ describeBuilder(execute, KARMA_BUILDER_INFO, (harness) => {
         include: ['abc.spec.ts', 'def.spec.ts'],
       });
 
-      const { result, logs } = await harness.executeOnce();
+      const { result } = await harness.executeOnce();
       expect(result?.success).toBeFalse();
-      expect(logs).toContain(
-        jasmine.objectContaining({
-          level: 'error',
-          message: jasmine.stringContaining(
-            'Specified patterns: "abc.spec.ts, def.spec.ts" did not match any spec files.',
-          ),
-        }),
-      );
     });
 
     [


### PR DESCRIPTION


Previously, we failed the compilation when the specified patterns did not match any spec file. This breaks the case were users configure Karma to not fail on empty test suit.

Closes #24644
