### PR TITLE
test(@angular-devkit/build-angular): port several unit tests to esbuild builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/tests/behavior/browser-support_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/tests/behavior/browser-support_spec.ts
@@ -1,0 +1,116 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { buildEsbuildBrowser } from '../../index';
+import { BASE_OPTIONS, BROWSER_BUILDER_INFO, describeBuilder } from '../setup';
+
+describeBuilder(buildEsbuildBrowser, BROWSER_BUILDER_INFO, (harness) => {
+  describe('Behavior: "Browser support"', () => {
+    it('creates correct sourcemaps when downleveling async functions', async () => {
+      // Add a JavaScript file with async code
+      await harness.writeFile(
+        'src/async-test.js',
+        'async function testJs() { console.log("from-async-js-function"); }',
+      );
+
+      // Add an async function to the project as well as JavaScript file
+      // The type `Void123` is used as a unique identifier for the final sourcemap
+      // If sourcemaps are not properly propagated then it will not be in the final sourcemap
+      await harness.modifyFile(
+        'src/main.ts',
+        (content) =>
+          'import "./async-test";\n' +
+          content +
+          '\ntype Void123 = void;' +
+          `\nasync function testApp(): Promise<Void123> { console.log("from-async-app-function"); }`,
+      );
+
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        sourceMap: {
+          scripts: true,
+        },
+      });
+
+      const { result } = await harness.executeOnce();
+
+      expect(result?.success).toBe(true);
+      harness.expectFile('dist/main.js').content.not.toMatch(/\sasync\s+function\s/);
+      harness.expectFile('dist/main.js.map').content.toContain('Promise<Void123>');
+    });
+
+    it('downlevels async functions ', async () => {
+      // Add an async function to the project
+      await harness.writeFile(
+        'src/main.ts',
+        'async function test(): Promise<void> { console.log("from-async-function"); }\ntest();',
+      );
+
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+      });
+
+      const { result } = await harness.executeOnce();
+
+      expect(result?.success).toBe(true);
+      harness.expectFile('dist/main.js').content.not.toMatch(/\sasync\s/);
+      harness.expectFile('dist/main.js').content.toContain('"from-async-function"');
+    });
+
+    it('warns when IE is present in browserslist', async () => {
+      await harness.appendToFile(
+        '.browserslistrc',
+        `
+           IE 9
+           IE 11
+         `,
+      );
+
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+      });
+
+      const { result, logs } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
+
+      expect(logs).toContain(
+        jasmine.objectContaining({
+          level: 'warn',
+          message:
+            `One or more browsers which are configured in the project's Browserslist ` +
+            'configuration will be ignored as ES5 output is not supported by the Angular CLI.\n' +
+            'Ignored browsers: ie 11, ie 9',
+        }),
+      );
+    });
+
+    it('downlevels "for await...of"', async () => {
+      // Add an async function to the project
+      await harness.writeFile(
+        'src/main.ts',
+        `
+          (async () => {
+            for await (const o of [1, 2, 3]) {
+              console.log("for await...of");
+            }
+          })();
+          `,
+      );
+
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+      });
+
+      const { result } = await harness.executeOnce();
+
+      expect(result?.success).toBe(true);
+      harness.expectFile('dist/main.js').content.not.toMatch(/\sawait\s/);
+      harness.expectFile('dist/main.js').content.toContain('"for await...of"');
+    });
+  });
+});

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/tests/options/assets_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/tests/options/assets_spec.ts
@@ -1,0 +1,380 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { buildEsbuildBrowser } from '../../index';
+import { BASE_OPTIONS, BROWSER_BUILDER_INFO, describeBuilder } from '../setup';
+
+describeBuilder(buildEsbuildBrowser, BROWSER_BUILDER_INFO, (harness) => {
+  describe('Option: "assets"', () => {
+    beforeEach(async () => {
+      // Application code is not needed for asset tests
+      await harness.writeFile('src/main.ts', 'console.log("TEST");');
+    });
+
+    it('supports an empty array value', async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        assets: [],
+      });
+
+      const { result } = await harness.executeOnce();
+
+      expect(result?.success).toBe(true);
+    });
+
+    it('supports mixing shorthand and longhand syntax', async () => {
+      await harness.writeFile('src/files/test.svg', '<svg></svg>');
+      await harness.writeFile('src/files/another.file', 'asset file');
+      await harness.writeFile('src/extra.file', 'extra file');
+
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        assets: ['src/extra.file', { glob: '*', input: 'src/files', output: '.' }],
+      });
+
+      const { result } = await harness.executeOnce();
+
+      expect(result?.success).toBe(true);
+
+      harness.expectFile('dist/extra.file').content.toBe('extra file');
+      harness.expectFile('dist/test.svg').content.toBe('<svg></svg>');
+      harness.expectFile('dist/another.file').content.toBe('asset file');
+    });
+
+    describe('shorthand syntax', () => {
+      it('copies a single asset', async () => {
+        await harness.writeFile('src/test.svg', '<svg></svg>');
+
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          assets: ['src/test.svg'],
+        });
+
+        const { result } = await harness.executeOnce();
+
+        expect(result?.success).toBe(true);
+
+        harness.expectFile('dist/test.svg').content.toBe('<svg></svg>');
+      });
+
+      it('copies multiple assets', async () => {
+        await harness.writeFile('src/test.svg', '<svg></svg>');
+        await harness.writeFile('src/another.file', 'asset file');
+
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          assets: ['src/test.svg', 'src/another.file'],
+        });
+
+        const { result } = await harness.executeOnce();
+
+        expect(result?.success).toBe(true);
+
+        harness.expectFile('dist/test.svg').content.toBe('<svg></svg>');
+        harness.expectFile('dist/another.file').content.toBe('asset file');
+      });
+
+      it('copies an asset with directory and maintains directory in output', async () => {
+        await harness.writeFile('src/subdirectory/test.svg', '<svg></svg>');
+
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          assets: ['src/subdirectory/test.svg'],
+        });
+
+        const { result } = await harness.executeOnce();
+
+        expect(result?.success).toBe(true);
+
+        harness.expectFile('dist/subdirectory/test.svg').content.toBe('<svg></svg>');
+      });
+
+      it('does not fail if asset does not exist', async () => {
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          assets: ['src/test.svg'],
+        });
+
+        const { result } = await harness.executeOnce();
+
+        expect(result?.success).toBe(true);
+
+        harness.expectFile('dist/test.svg').toNotExist();
+      });
+
+      it('fail if asset path is not within project source root', async () => {
+        await harness.writeFile('test.svg', '<svg></svg>');
+
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          assets: ['test.svg'],
+        });
+
+        const { error } = await harness.executeOnce({ outputLogsOnException: false });
+
+        expect(error?.message).toMatch('path must start with the project source root');
+
+        harness.expectFile('dist/test.svg').toNotExist();
+      });
+    });
+
+    describe('longhand syntax', () => {
+      it('copies a single asset', async () => {
+        await harness.writeFile('src/test.svg', '<svg></svg>');
+
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          assets: [{ glob: 'test.svg', input: 'src', output: '.' }],
+        });
+
+        const { result } = await harness.executeOnce();
+
+        expect(result?.success).toBe(true);
+
+        harness.expectFile('dist/test.svg').content.toBe('<svg></svg>');
+      });
+
+      it('copies multiple assets as separate entries', async () => {
+        await harness.writeFile('src/test.svg', '<svg></svg>');
+        await harness.writeFile('src/another.file', 'asset file');
+
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          assets: [
+            { glob: 'test.svg', input: 'src', output: '.' },
+            { glob: 'another.file', input: 'src', output: '.' },
+          ],
+        });
+
+        const { result } = await harness.executeOnce();
+
+        expect(result?.success).toBe(true);
+
+        harness.expectFile('dist/test.svg').content.toBe('<svg></svg>');
+        harness.expectFile('dist/another.file').content.toBe('asset file');
+      });
+
+      it('copies multiple assets with a single entry glob pattern', async () => {
+        await harness.writeFile('src/test.svg', '<svg></svg>');
+        await harness.writeFile('src/another.file', 'asset file');
+
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          assets: [{ glob: '{test.svg,another.file}', input: 'src', output: '.' }],
+        });
+
+        const { result } = await harness.executeOnce();
+
+        expect(result?.success).toBe(true);
+
+        harness.expectFile('dist/test.svg').content.toBe('<svg></svg>');
+        harness.expectFile('dist/another.file').content.toBe('asset file');
+      });
+
+      it('copies multiple assets with a wildcard glob pattern', async () => {
+        await harness.writeFile('src/files/test.svg', '<svg></svg>');
+        await harness.writeFile('src/files/another.file', 'asset file');
+
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          assets: [{ glob: '*', input: 'src/files', output: '.' }],
+        });
+
+        const { result } = await harness.executeOnce();
+
+        expect(result?.success).toBe(true);
+
+        harness.expectFile('dist/test.svg').content.toBe('<svg></svg>');
+        harness.expectFile('dist/another.file').content.toBe('asset file');
+      });
+
+      it('copies multiple assets with a recursive wildcard glob pattern', async () => {
+        await harness.writeFiles({
+          'src/files/test.svg': '<svg></svg>',
+          'src/files/another.file': 'asset file',
+          'src/files/nested/extra.file': 'extra file',
+        });
+
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          assets: [{ glob: '**/*', input: 'src/files', output: '.' }],
+        });
+
+        const { result } = await harness.executeOnce();
+
+        expect(result?.success).toBe(true);
+
+        harness.expectFile('dist/test.svg').content.toBe('<svg></svg>');
+        harness.expectFile('dist/another.file').content.toBe('asset file');
+        harness.expectFile('dist/nested/extra.file').content.toBe('extra file');
+      });
+
+      it('automatically ignores "." prefixed files when using wildcard glob pattern', async () => {
+        await harness.writeFile('src/files/.gitkeep', '');
+
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          assets: [{ glob: '*', input: 'src/files', output: '.' }],
+        });
+
+        const { result } = await harness.executeOnce();
+
+        expect(result?.success).toBe(true);
+
+        harness.expectFile('dist/.gitkeep').toNotExist();
+      });
+
+      it('supports ignoring a specific file when using a glob pattern', async () => {
+        await harness.writeFiles({
+          'src/files/test.svg': '<svg></svg>',
+          'src/files/another.file': 'asset file',
+          'src/files/nested/extra.file': 'extra file',
+        });
+
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          assets: [{ glob: '**/*', input: 'src/files', output: '.', ignore: ['another.file'] }],
+        });
+
+        const { result } = await harness.executeOnce();
+
+        expect(result?.success).toBe(true);
+
+        harness.expectFile('dist/test.svg').content.toBe('<svg></svg>');
+        harness.expectFile('dist/another.file').toNotExist();
+        harness.expectFile('dist/nested/extra.file').content.toBe('extra file');
+      });
+
+      it('supports ignoring with a glob pattern when using a glob pattern', async () => {
+        await harness.writeFiles({
+          'src/files/test.svg': '<svg></svg>',
+          'src/files/another.file': 'asset file',
+          'src/files/nested/extra.file': 'extra file',
+        });
+
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          assets: [{ glob: '**/*', input: 'src/files', output: '.', ignore: ['**/*.file'] }],
+        });
+
+        const { result } = await harness.executeOnce();
+
+        expect(result?.success).toBe(true);
+
+        harness.expectFile('dist/test.svg').content.toBe('<svg></svg>');
+        harness.expectFile('dist/another.file').toNotExist();
+        harness.expectFile('dist/nested/extra.file').toNotExist();
+      });
+
+      it('copies an asset with directory and maintains directory in output', async () => {
+        await harness.writeFile('src/subdirectory/test.svg', '<svg></svg>');
+
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          assets: [{ glob: 'subdirectory/test.svg', input: 'src', output: '.' }],
+        });
+
+        const { result } = await harness.executeOnce();
+
+        expect(result?.success).toBe(true);
+
+        harness.expectFile('dist/subdirectory/test.svg').content.toBe('<svg></svg>');
+      });
+
+      it('does not fail if asset does not exist', async () => {
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          assets: [{ glob: 'test.svg', input: 'src', output: '.' }],
+        });
+
+        const { result } = await harness.executeOnce();
+
+        expect(result?.success).toBe(true);
+
+        harness.expectFile('dist/test.svg').toNotExist();
+      });
+
+      it('uses project output path when output option is empty string', async () => {
+        await harness.writeFile('src/test.svg', '<svg></svg>');
+
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          assets: [{ glob: 'test.svg', input: 'src', output: '' }],
+        });
+
+        const { result } = await harness.executeOnce();
+
+        expect(result?.success).toBe(true);
+
+        harness.expectFile('dist/test.svg').content.toBe('<svg></svg>');
+      });
+
+      it('uses project output path when output option is "."', async () => {
+        await harness.writeFile('src/test.svg', '<svg></svg>');
+
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          assets: [{ glob: 'test.svg', input: 'src', output: '.' }],
+        });
+
+        const { result } = await harness.executeOnce();
+
+        expect(result?.success).toBe(true);
+
+        harness.expectFile('dist/test.svg').content.toBe('<svg></svg>');
+      });
+
+      it('uses project output path when output option is "/"', async () => {
+        await harness.writeFile('src/test.svg', '<svg></svg>');
+
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          assets: [{ glob: 'test.svg', input: 'src', output: '/' }],
+        });
+
+        const { result } = await harness.executeOnce();
+
+        expect(result?.success).toBe(true);
+
+        harness.expectFile('dist/test.svg').content.toBe('<svg></svg>');
+      });
+
+      it('creates a project output sub-path when output option path does not exist', async () => {
+        await harness.writeFile('src/test.svg', '<svg></svg>');
+
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          assets: [{ glob: 'test.svg', input: 'src', output: 'subdirectory' }],
+        });
+
+        const { result } = await harness.executeOnce();
+
+        expect(result?.success).toBe(true);
+
+        harness.expectFile('dist/subdirectory/test.svg').content.toBe('<svg></svg>');
+      });
+
+      it('fails if output option is not within project output path', async () => {
+        await harness.writeFile('test.svg', '<svg></svg>');
+
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          assets: [{ glob: 'test.svg', input: 'src', output: '..' }],
+        });
+
+        const { error } = await harness.executeOnce({ outputLogsOnException: false });
+
+        expect(error?.message).toMatch(
+          'An asset cannot be written to a location outside of the output path',
+        );
+
+        harness.expectFile('dist/test.svg').toNotExist();
+      });
+    });
+  });
+});

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/tests/options/output-hashing_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/tests/options/output-hashing_spec.ts
@@ -1,0 +1,166 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { buildEsbuildBrowser } from '../../index';
+import { OutputHashing } from '../../schema';
+import { BASE_OPTIONS, BROWSER_BUILDER_INFO, describeBuilder } from '../setup';
+
+describeBuilder(buildEsbuildBrowser, BROWSER_BUILDER_INFO, (harness) => {
+  describe('Option: "outputHashing"', () => {
+    beforeEach(async () => {
+      // Application code is not needed for asset tests
+      await harness.writeFile('src/main.ts', 'console.log("TEST");');
+      await harness.writeFile('src/polyfills.ts', 'console.log("TEST-POLYFILLS");');
+    });
+
+    it('hashes all filenames when set to "all"', async () => {
+      await harness.writeFile('src/styles.css', `h1 { background: url('./spectrum.png')}`);
+
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        styles: ['src/styles.css'],
+        polyfills: 'src/polyfills.ts',
+        outputHashing: OutputHashing.All,
+      });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBe(true);
+
+      expect(harness.hasFileMatch('dist', /main\.[0-9A-Z]{8}\.js$/)).toBeTrue();
+      expect(harness.hasFileMatch('dist', /polyfills\.[0-9A-Z]{8}\.js$/)).toBeTrue();
+      expect(harness.hasFileMatch('dist', /styles\.[0-9A-Z]{8}\.css$/)).toBeTrue();
+      expect(harness.hasFileMatch('dist', /spectrum\.[0-9A-Z]{8}\.png$/)).toBeTrue();
+    });
+
+    it(`doesn't hash any filenames when not set`, async () => {
+      await harness.writeFile('src/styles.css', `h1 { background: url('./spectrum.png')}`);
+
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        polyfills: 'src/polyfills.ts',
+        styles: ['src/styles.css'],
+      });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBe(true);
+
+      expect(harness.hasFileMatch('dist', /main\.[0-9A-Z]{8}\.js$/)).toBeFalse();
+      expect(harness.hasFileMatch('dist', /polyfills\.[0-9A-Z]{8}\.js$/)).toBeFalse();
+      expect(harness.hasFileMatch('dist', /styles\.[0-9A-Z]{8}\.css$/)).toBeFalse();
+      expect(harness.hasFileMatch('dist', /spectrum\.[0-9A-Z]{8}\.png$/)).toBeFalse();
+    });
+
+    it(`doesn't hash any filenames when set to "none"`, async () => {
+      await harness.writeFile('src/styles.css', `h1 { background: url('./spectrum.png')}`);
+
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        styles: ['src/styles.css'],
+        polyfills: 'src/polyfills.ts',
+        outputHashing: OutputHashing.None,
+      });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBe(true);
+
+      expect(harness.hasFileMatch('dist', /main\.[0-9A-Z]{8}\.js$/)).toBeFalse();
+      expect(harness.hasFileMatch('dist', /polyfills\.[0-9A-Z]{8}\.js$/)).toBeFalse();
+      expect(harness.hasFileMatch('dist', /styles\.[0-9A-Z]{8}\.css$/)).toBeFalse();
+      expect(harness.hasFileMatch('dist', /spectrum\.[0-9A-Z]{8}\.png$/)).toBeFalse();
+    });
+
+    it(`hashes CSS resources filenames only when set to "media"`, async () => {
+      await harness.writeFile('src/styles.css', `h1 { background: url('./spectrum.png')}`);
+
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        styles: ['src/styles.css'],
+        polyfills: 'src/polyfills.ts',
+        outputHashing: OutputHashing.Media,
+      });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBe(true);
+
+      expect(harness.hasFileMatch('dist', /main\.[0-9A-Z]{8}\.js$/)).toBeFalse();
+      expect(harness.hasFileMatch('dist', /polyfills\.[0-9A-Z]{8}\.js$/)).toBeFalse();
+      expect(harness.hasFileMatch('dist', /styles\.[0-9A-Z]{8}\.css$/)).toBeFalse();
+      expect(harness.hasFileMatch('dist', /spectrum\.[0-9A-Z]{8}\.png$/)).toBeTrue();
+    });
+
+    it(`hashes bundles filenames only when set to "bundles"`, async () => {
+      await harness.writeFile('src/styles.css', `h1 { background: url('./spectrum.png')}`);
+
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        styles: ['src/styles.css'],
+        polyfills: 'src/polyfills.ts',
+        outputHashing: OutputHashing.Bundles,
+      });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBe(true);
+
+      expect(harness.hasFileMatch('dist', /main\.[0-9A-Z]{8}\.js$/)).toBeTrue();
+      expect(harness.hasFileMatch('dist', /polyfills\.[0-9A-Z]{8}\.js$/)).toBeTrue();
+      expect(harness.hasFileMatch('dist', /styles\.[0-9A-Z]{8}\.css$/)).toBeTrue();
+      expect(harness.hasFileMatch('dist', /spectrum\.[0-9A-Z]{8}\.png$/)).toBeFalse();
+    });
+
+    // TODO: Re-enable once implemented in the esbuild builder
+    xit('does not hash non injected styles', async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        outputHashing: OutputHashing.All,
+        sourceMap: true,
+        styles: [
+          {
+            input: 'src/styles.css',
+            inject: false,
+          },
+        ],
+      });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBe(true);
+
+      expect(harness.hasFileMatch('dist', /styles\.[0-9A-Z]{8}\.css$/)).toBeFalse();
+      expect(harness.hasFileMatch('dist', /styles\.[0-9A-Z]{8}\.css.map$/)).toBeFalse();
+      harness.expectFile('dist/styles.css').toExist();
+      harness.expectFile('dist/styles.css.map').toExist();
+    });
+
+    // TODO: Re-enable once implemented in the esbuild builder
+    xit('does not override different files which has the same filenames when hashing is "none"', async () => {
+      await harness.writeFiles({
+        'src/styles.css': `
+        h1 { background: url('./test.svg')}
+        h2 { background: url('./small/test.svg')}
+      `,
+        './src/test.svg': `<svg xmlns="http://www.w3.org/2000/svg">
+        <text x="20" y="20" font-size="20" fill="red">Hello World</text>
+      </svg>`,
+        './src/small/test.svg': `<svg xmlns="http://www.w3.org/2000/svg">
+        <text x="10" y="10" font-size="10" fill="red">Hello World</text>
+      </svg>`,
+      });
+
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        styles: ['src/styles.css'],
+        outputHashing: OutputHashing.None,
+      });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBe(true);
+
+      harness.expectFile('dist/test.svg').toExist();
+      harness.expectFile('dist/small-test.svg').toExist();
+    });
+  });
+});


### PR DESCRIPTION
The following unit tests have been ported over to test the experimental esbuild-based
browser application builder:

* `assets` option
* `outputHashing` option
* browser support behavior (`browserslist`)

Several small modifications were necessary to accommodate output file differences such
as no runtime chunk. Additionally, two tests are temporarily disabled for the `outputHashing`
tests pending implementation in the builder. These tests are the same stylesheet resource handling
file name test and no hashing of non-injected styles test.