### PR TITLE
fix(@angular-devkit/build-angular): correctly copy `safety-worker.js` contents

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/service-worker.ts
+++ b/packages/angular_devkit/build_angular/src/utils/service-worker.ts
@@ -167,7 +167,7 @@ export async function augmentAppWithServiceWorkerCore(
 
     return inputputFileSystem === outputFileSystem
       ? // Native FS (Builder).
-        inputputFileSystem.copyFile(workerPath, resolvedDest, fsConstants.COPYFILE_FICLONE)
+        inputputFileSystem.copyFile(src, resolvedDest, fsConstants.COPYFILE_FICLONE)
       : // memfs (Webpack): Read the file from the input FS (disk) and write it to the output FS (memory).
         outputFileSystem.writeFile(resolvedDest, await inputputFileSystem.readFile(src));
   };


### PR DESCRIPTION

Previously, `safety-worker.js` and `worker-basic.min.js` contained incorrect data due to an incorrect path.

Closes #24678
