### PR TITLE
fix(@angular/cli): convert `before` option in `.npmrc` to Date

### DIFF
--- a/packages/angular/cli/src/utilities/package-metadata.ts
+++ b/packages/angular/cli/src/utilities/package-metadata.ts
@@ -212,6 +212,10 @@ function normalizeOptions(
           } catch {}
         }
         break;
+      case 'before':
+        options['before'] =
+          typeof substitutedValue === 'string' ? new Date(substitutedValue) : substitutedValue;
+        break;
       default:
         options[key] = substitutedValue;
         break;

--- a/tests/legacy-cli/e2e/tests/commands/add/npm-config.ts
+++ b/tests/legacy-cli/e2e/tests/commands/add/npm-config.ts
@@ -1,0 +1,8 @@
+import { writeFile } from '../../../utils/fs';
+import { ng } from '../../../utils/process';
+
+export default async function () {
+  // Works with before option
+  await writeFile('.npmrc', `before=${new Date().toISOString()}`);
+  await ng('add', '@angular/pwa', '--skip-confirmation');
+}


### PR DESCRIPTION
Previously, the `before` option in the npmrc was not converted properly to a date.

See: https://docs.npmjs.com/cli/v8/using-npm/config#before

Closes #24685
