### PR TITLE
fix(@angular-devkit/build-angular): use babel default export helper in build optimizer

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "@babel/core": "7.20.12",
     "@babel/generator": "7.20.14",
     "@babel/helper-annotate-as-pure": "7.18.6",
+    "@babel/helper-split-export-declaration": "7.18.6",
     "@babel/plugin-proposal-async-generator-functions": "7.20.7",
     "@babel/plugin-transform-async-to-generator": "7.20.7",
     "@babel/plugin-transform-runtime": "7.19.6",

--- a/packages/angular_devkit/build_angular/BUILD.bazel
+++ b/packages/angular_devkit/build_angular/BUILD.bazel
@@ -111,6 +111,7 @@ ts_library(
         "@npm//@babel/core",
         "@npm//@babel/generator",
         "@npm//@babel/helper-annotate-as-pure",
+        "@npm//@babel/helper-split-export-declaration",
         "@npm//@babel/plugin-proposal-async-generator-functions",
         "@npm//@babel/plugin-transform-async-to-generator",
         "@npm//@babel/plugin-transform-runtime",

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -13,6 +13,7 @@
     "@babel/core": "7.20.12",
     "@babel/generator": "7.20.14",
     "@babel/helper-annotate-as-pure": "7.18.6",
+    "@babel/helper-split-export-declaration": "7.18.6",
     "@babel/plugin-proposal-async-generator-functions": "7.20.7",
     "@babel/plugin-transform-async-to-generator": "7.20.7",
     "@babel/plugin-transform-runtime": "7.19.6",

--- a/packages/angular_devkit/build_angular/src/babel/plugins/adjust-static-class-members_spec.ts
+++ b/packages/angular_devkit/build_angular/src/babel/plugins/adjust-static-class-members_spec.ts
@@ -169,14 +169,27 @@ describe('adjust-static-class-members Babel plugin', () => {
   });
 
   it('does not wrap default exported class with no connected siblings', () => {
-    testCaseNoChange(`
-      export default class CustomComponentEffects {
-        constructor(_actions) {
-          this._actions = _actions;
-          this.doThis = this._actions;
+    // NOTE: This could technically have no changes but the default export splitting detection
+    // does not perform class property analysis currently.
+    testCase({
+      input: `
+        export default class CustomComponentEffects {
+          constructor(_actions) {
+            this._actions = _actions;
+            this.doThis = this._actions;
+          }
         }
-      }
-    `);
+      `,
+      expected: `
+        class CustomComponentEffects {
+          constructor(_actions) {
+            this._actions = _actions;
+            this.doThis = this._actions;
+          }
+        }
+        export { CustomComponentEffects as default };
+      `,
+    });
   });
 
   it('does wrap not default exported class with only side effect fields', () => {

--- a/packages/angular_devkit/build_angular/src/typings.d.ts
+++ b/packages/angular_devkit/build_angular/src/typings.d.ts
@@ -11,3 +11,11 @@ declare module '@babel/helper-annotate-as-pure' {
     pathOrNode: import('@babel/types').Node | { node: import('@babel/types').Node },
   ): void;
 }
+
+declare module '@babel/helper-split-export-declaration' {
+  export default function splitExportDeclaration(
+    exportDeclaration: import('@babel/traverse').NodePath<
+      import('@babel/types').ExportDefaultDeclaration
+    >,
+  ): void;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -581,7 +581,7 @@
   dependencies:
     "@babel/types" "^7.20.0"
 
-"@babel/helper-split-export-declaration@^7.18.6":
+"@babel/helper-split-export-declaration@7.18.6", "@babel/helper-split-export-declaration@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz#7367949bc75b20c6d5a5d4a97bba2824ae8ef075"
   integrity sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==


### PR DESCRIPTION
Within the build optimizer's static member optimization pass, a class that is directly default exported must be split into two statements: the class declaration and the default export. This is because the pass can wrap classes in a pure annotated IIFE which results in a variable declaration replacement and variable declarations can not be directly default exported. Previously, the pass did this splitting manually but this was causing later babel plugins to fail. In addition to updating the AST in this case, scoping information also needed to be updated. To support this, a babel helper package is now used that handles the details of the statement split operation.

Fixes #24688