### PR TITLE
fix(@angular-devkit/build-angular): update the ECMA output warning message to be more actionable

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/compiler-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/compiler-plugin.ts
@@ -218,7 +218,8 @@ export function createCompilerPlugin(
         (setupWarnings ??= []).push({
           text:
             'TypeScript compiler options "target" and "useDefineForClassFields" are set to "ES2022" and ' +
-            '"false" respectively by the Angular CLI.',
+            '"false" respectively by the Angular CLI.\n' +
+            `NOTE: You can set the "target" to "ES2022" in the project's tsconfig to remove this warning.`,
           location: { file: pluginOptions.tsconfig },
           notes: [
             {

--- a/packages/angular_devkit/build_angular/src/webpack/plugins/typescript.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/plugins/typescript.ts
@@ -35,7 +35,8 @@ export function createIvyPlugin(
     wco.logger.warn(
       'TypeScript compiler options "target" and "useDefineForClassFields" are set to "ES2022" and ' +
         '"false" respectively by the Angular CLI. To control ECMA version and features use the Browerslist configuration. ' +
-        'For more information, see https://angular.io/guide/build#configuring-browser-compatibility',
+        'For more information, see https://angular.io/guide/build#configuring-browser-compatibility\n' +
+        `NOTE: You can set the "target" to "ES2022" in the project's tsconfig to remove this warning.`,
     );
   }
 


### PR DESCRIPTION


Update the `TypeScript compiler options "target" and "useDefineForClassFields" are set to "ES2022"` warning message to be more actionable.

Closes: #24697
