### PR TITLE
test(@angular-devkit/build-angular): port additional unit tests to esbuild builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/tests/options/extract-licenses_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/tests/options/extract-licenses_spec.ts
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { buildEsbuildBrowser } from '../../index';
+import { BASE_OPTIONS, BROWSER_BUILDER_INFO, describeBuilder } from '../setup';
+
+describeBuilder(buildEsbuildBrowser, BROWSER_BUILDER_INFO, (harness) => {
+  describe('Option: "extractLicenses"', () => {
+    it(`should generate '3rdpartylicenses.txt' when 'extractLicenses' is true`, async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        extractLicenses: true,
+      });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBe(true);
+      harness.expectFile('dist/3rdpartylicenses.txt').content.toContain('MIT');
+    });
+
+    it(`should not generate '3rdpartylicenses.txt' when 'extractLicenses' is false`, async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        extractLicenses: false,
+      });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBe(true);
+      harness.expectFile('dist/3rdpartylicenses.txt').toNotExist();
+    });
+
+    it(`should generate '3rdpartylicenses.txt' when 'extractLicenses' is not set`, async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+      });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBe(true);
+      harness.expectFile('dist/3rdpartylicenses.txt').content.toContain('MIT');
+    });
+  });
+});

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/tests/options/inline-critical_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/tests/options/inline-critical_spec.ts
@@ -1,0 +1,138 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { buildEsbuildBrowser } from '../../index';
+import { BASE_OPTIONS, BROWSER_BUILDER_INFO, describeBuilder } from '../setup';
+
+describeBuilder(buildEsbuildBrowser, BROWSER_BUILDER_INFO, (harness) => {
+  describe('Option: "inlineCritical"', () => {
+    beforeEach(async () => {
+      await harness.writeFile('src/styles.css', 'body { color: #000 }');
+    });
+
+    it(`should extract critical css when 'inlineCritical' is true`, async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        optimization: {
+          scripts: false,
+          styles: {
+            minify: true,
+            inlineCritical: true,
+          },
+          fonts: false,
+        },
+        styles: ['src/styles.css'],
+      });
+
+      const { result } = await harness.executeOnce();
+
+      expect(result?.success).toBe(true);
+      harness
+        .expectFile('dist/index.html')
+        .content.toContain(
+          `<link rel="stylesheet" href="styles.css" media="print" onload="this.media='all'">`,
+        );
+      harness.expectFile('dist/index.html').content.toContain(`body{color:#000}`);
+    });
+
+    it(`should extract critical css when 'optimization' is unset`, async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        styles: ['src/styles.css'],
+        optimization: undefined,
+      });
+
+      const { result } = await harness.executeOnce();
+
+      expect(result?.success).toBe(true);
+      harness
+        .expectFile('dist/index.html')
+        .content.toContain(
+          `<link rel="stylesheet" href="styles.css" media="print" onload="this.media='all'">`,
+        );
+      harness.expectFile('dist/index.html').content.toContain(`body{color:#000}`);
+    });
+
+    it(`should extract critical css when 'optimization' is true`, async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        styles: ['src/styles.css'],
+        optimization: true,
+      });
+
+      const { result } = await harness.executeOnce();
+
+      expect(result?.success).toBe(true);
+      harness
+        .expectFile('dist/index.html')
+        .content.toContain(
+          `<link rel="stylesheet" href="styles.css" media="print" onload="this.media='all'">`,
+        );
+      harness.expectFile('dist/index.html').content.toContain(`body{color:#000}`);
+    });
+
+    it(`should not extract critical css when 'optimization' is false`, async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        styles: ['src/styles.css'],
+        optimization: false,
+      });
+
+      const { result } = await harness.executeOnce();
+
+      expect(result?.success).toBe(true);
+      harness.expectFile('dist/index.html').content.not.toContain(`<style`);
+    });
+
+    it(`should not extract critical css when 'inlineCritical' is false`, async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        styles: ['src/styles.css'],
+        optimization: {
+          scripts: false,
+          styles: {
+            minify: false,
+            inlineCritical: false,
+          },
+          fonts: false,
+        },
+      });
+
+      const { result } = await harness.executeOnce();
+
+      expect(result?.success).toBe(true);
+      harness.expectFile('dist/index.html').content.not.toContain(`<style`);
+    });
+
+    it(`should extract critical css when using '@media all {}' and 'minify' is set to true`, async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        styles: ['src/styles.css'],
+        optimization: {
+          scripts: false,
+          styles: {
+            minify: true,
+            inlineCritical: true,
+          },
+          fonts: false,
+        },
+      });
+
+      await harness.writeFile('src/styles.css', '@media all { body { color: #000 } }');
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBe(true);
+      harness
+        .expectFile('dist/index.html')
+        .content.toContain(
+          `<link rel="stylesheet" href="styles.css" media="print" onload="this.media='all'">`,
+        );
+      harness.expectFile('dist/index.html').content.toContain(`body{color:#000}`);
+    });
+  });
+});

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/tests/options/main_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/tests/options/main_spec.ts
@@ -1,0 +1,63 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { buildEsbuildBrowser } from '../../index';
+import { BASE_OPTIONS, BROWSER_BUILDER_INFO, describeBuilder } from '../setup';
+
+describeBuilder(buildEsbuildBrowser, BROWSER_BUILDER_INFO, (harness) => {
+  describe('Option: "main"', () => {
+    it('uses a provided TypeScript file', async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        main: 'src/main.ts',
+      });
+
+      const { result } = await harness.executeOnce();
+
+      expect(result?.success).toBe(true);
+
+      harness.expectFile('dist/main.js').toExist();
+      harness.expectFile('dist/index.html').toExist();
+    });
+
+    it('uses a provided JavaScript file', async () => {
+      await harness.writeFile('src/main.js', `console.log('main');`);
+
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        main: 'src/main.js',
+      });
+
+      const { result } = await harness.executeOnce();
+
+      expect(result?.success).toBe(true);
+
+      harness.expectFile('dist/main.js').toExist();
+      harness.expectFile('dist/index.html').toExist();
+
+      harness.expectFile('dist/main.js').content.toContain('console.log("main")');
+    });
+
+    it('fails and shows an error when file does not exist', async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        main: 'src/missing.ts',
+      });
+
+      const { result, logs } = await harness.executeOnce({ outputLogsOnFailure: false });
+
+      expect(result?.success).toBe(false);
+      expect(logs).toContain(
+        jasmine.objectContaining({ message: jasmine.stringMatching('Could not resolve "') }),
+      );
+
+      harness.expectFile('dist/main.js').toNotExist();
+      harness.expectFile('dist/index.html').toNotExist();
+    });
+  });
+});

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/tests/options/styles_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/tests/options/styles_spec.ts
@@ -1,0 +1,441 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { buildEsbuildBrowser } from '../../index';
+import { BASE_OPTIONS, BROWSER_BUILDER_INFO, describeBuilder } from '../setup';
+
+describeBuilder(buildEsbuildBrowser, BROWSER_BUILDER_INFO, (harness) => {
+  describe('Option: "styles"', () => {
+    beforeEach(async () => {
+      // Application code is not needed for styles tests
+      await harness.writeFile('src/main.ts', 'console.log("TEST");');
+    });
+
+    it('supports an empty array value', async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        styles: [],
+      });
+
+      const { result } = await harness.executeOnce();
+
+      expect(result?.success).toBe(true);
+
+      harness.expectFile('dist/styles.css').toNotExist();
+    });
+
+    it('does not create an output styles file when option is not present', async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+      });
+
+      const { result } = await harness.executeOnce();
+
+      expect(result?.success).toBe(true);
+
+      harness.expectFile('dist/styles.css').toNotExist();
+    });
+
+    describe('shorthand syntax', () => {
+      it('processes a single style into a single output', async () => {
+        await harness.writeFile('src/test-style-a.css', '.test-a {color: red}');
+
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          styles: ['src/test-style-a.css'],
+        });
+
+        const { result } = await harness.executeOnce();
+
+        expect(result?.success).toBe(true);
+
+        harness.expectFile('dist/styles.css').content.toMatch(/\.test-a {\s*color: red;?\s*}/);
+        harness
+          .expectFile('dist/index.html')
+          .content.toContain('<link rel="stylesheet" href="styles.css">');
+      });
+
+      it('processes multiple styles into a single output', async () => {
+        await harness.writeFiles({
+          'src/test-style-a.css': '.test-a {color: red}',
+          'src/test-style-b.css': '.test-b {color: green}',
+        });
+
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          styles: ['src/test-style-a.css', 'src/test-style-b.css'],
+        });
+
+        const { result } = await harness.executeOnce();
+
+        expect(result?.success).toBe(true);
+
+        harness.expectFile('dist/styles.css').content.toMatch(/\.test-a {\s*color: red;?\s*}/);
+        harness.expectFile('dist/styles.css').content.toMatch(/\.test-b {\s*color: green;?\s*}/);
+        harness
+          .expectFile('dist/index.html')
+          .content.toContain('<link rel="stylesheet" href="styles.css">');
+      });
+
+      it('preserves order of multiple styles in single output', async () => {
+        await harness.writeFiles({
+          'src/test-style-a.css': '.test-a {color: red}',
+          'src/test-style-b.css': '.test-b {color: green}',
+          'src/test-style-c.css': '.test-c {color: blue}',
+          'src/test-style-d.css': '.test-d {color: yellow}',
+        });
+
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          styles: [
+            'src/test-style-c.css',
+            'src/test-style-d.css',
+            'src/test-style-b.css',
+            'src/test-style-a.css',
+          ],
+        });
+
+        const { result } = await harness.executeOnce();
+
+        expect(result?.success).toBe(true);
+
+        harness.expectFile('dist/styles.css').content.toMatch(
+          // eslint-disable-next-line max-len
+          /\.test-c {\s*color: blue;?\s*}[\s|\S]+\.test-d {\s*color: yellow;?\s*}[\s|\S]+\.test-b {\s*color: green;?\s*}[\s|\S]+\.test-a {\s*color: red;?\s*}/m,
+        );
+      });
+
+      it('fails and shows an error if style does not exist', async () => {
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          styles: ['src/test-style-a.css'],
+        });
+
+        const { result, logs } = await harness.executeOnce({ outputLogsOnFailure: false });
+
+        expect(result?.success).toBeFalse();
+        expect(logs).toContain(
+          jasmine.objectContaining({
+            level: 'error',
+            message: jasmine.stringMatching('Could not resolve "src/test-style-a.css"'),
+          }),
+        );
+
+        harness.expectFile('dist/styles.css').toNotExist();
+      });
+
+      // TODO: Re-enable once output logging is implemented for esbuild builder
+      xit('shows the output style as a chunk entry in the logging output', async () => {
+        await harness.writeFile('src/test-style-a.css', '.test-a {color: red}');
+
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          styles: ['src/test-style-a.css'],
+        });
+
+        const { result, logs } = await harness.executeOnce();
+
+        expect(result?.success).toBe(true);
+
+        expect(logs).toContain(
+          jasmine.objectContaining({ message: jasmine.stringMatching(/styles\.css.+\d+ bytes/) }),
+        );
+      });
+    });
+
+    describe('longhand syntax', () => {
+      it('processes a single style into a single output', async () => {
+        await harness.writeFile('src/test-style-a.css', '.test-a {color: red}');
+
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          styles: [{ input: 'src/test-style-a.css' }],
+        });
+
+        const { result } = await harness.executeOnce();
+
+        expect(result?.success).toBe(true);
+
+        harness.expectFile('dist/styles.css').content.toMatch(/\.test-a {\s*color: red;?\s*}/);
+        harness
+          .expectFile('dist/index.html')
+          .content.toContain('<link rel="stylesheet" href="styles.css">');
+      });
+
+      it('processes a single style into a single output named with bundleName', async () => {
+        await harness.writeFile('src/test-style-a.css', '.test-a {color: red}');
+
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          styles: [{ input: 'src/test-style-a.css', bundleName: 'extra' }],
+        });
+
+        const { result } = await harness.executeOnce();
+
+        expect(result?.success).toBe(true);
+
+        harness.expectFile('dist/extra.css').content.toMatch(/\.test-a {\s*color: red;?\s*}/);
+        harness
+          .expectFile('dist/index.html')
+          .content.toContain('<link rel="stylesheet" href="extra.css">');
+      });
+
+      it('uses default bundleName when bundleName is empty string', async () => {
+        await harness.writeFile('src/test-style-a.css', '.test-a {color: red}');
+
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          styles: [{ input: 'src/test-style-a.css', bundleName: '' }],
+        });
+
+        const { result } = await harness.executeOnce();
+
+        expect(result?.success).toBe(true);
+
+        harness.expectFile('dist/styles.css').content.toMatch(/\.test-a {\s*color: red;?\s*}/);
+        harness
+          .expectFile('dist/index.html')
+          .content.toContain('<link rel="stylesheet" href="styles.css">');
+      });
+
+      it('processes multiple styles with no bundleName into a single output', async () => {
+        await harness.writeFiles({
+          'src/test-style-a.css': '.test-a {color: red}',
+          'src/test-style-b.css': '.test-b {color: green}',
+        });
+
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          styles: [{ input: 'src/test-style-a.css' }, { input: 'src/test-style-b.css' }],
+        });
+
+        const { result } = await harness.executeOnce();
+
+        expect(result?.success).toBe(true);
+
+        harness.expectFile('dist/styles.css').content.toMatch(/\.test-a {\s*color: red;?\s*}/);
+        harness.expectFile('dist/styles.css').content.toMatch(/\.test-b {\s*color: green;?\s*}/);
+        harness
+          .expectFile('dist/index.html')
+          .content.toContain('<link rel="stylesheet" href="styles.css">');
+      });
+
+      it('processes multiple styles with same bundleName into a single output', async () => {
+        await harness.writeFiles({
+          'src/test-style-a.css': '.test-a {color: red}',
+          'src/test-style-b.css': '.test-b {color: green}',
+        });
+
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          styles: [
+            { input: 'src/test-style-a.css', bundleName: 'extra' },
+            { input: 'src/test-style-b.css', bundleName: 'extra' },
+          ],
+        });
+
+        const { result } = await harness.executeOnce();
+
+        expect(result?.success).toBe(true);
+
+        harness.expectFile('dist/extra.css').content.toMatch(/\.test-a {\s*color: red;?\s*}/);
+        harness.expectFile('dist/extra.css').content.toMatch(/\.test-b {\s*color: green;?\s*}/);
+        harness
+          .expectFile('dist/index.html')
+          .content.toContain('<link rel="stylesheet" href="extra.css">');
+      });
+
+      it('processes multiple styles with different bundleNames into separate outputs', async () => {
+        await harness.writeFiles({
+          'src/test-style-a.css': '.test-a {color: red}',
+          'src/test-style-b.css': '.test-b {color: green}',
+        });
+
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          styles: [
+            { input: 'src/test-style-a.css', bundleName: 'extra' },
+            { input: 'src/test-style-b.css', bundleName: 'other' },
+          ],
+        });
+
+        const { result } = await harness.executeOnce();
+
+        expect(result?.success).toBe(true);
+
+        harness.expectFile('dist/extra.css').content.toMatch(/\.test-a {\s*color: red;?\s*}/);
+        harness.expectFile('dist/other.css').content.toMatch(/\.test-b {\s*color: green;?\s*}/);
+        harness
+          .expectFile('dist/index.html')
+          .content.toContain('<link rel="stylesheet" href="extra.css">');
+        harness
+          .expectFile('dist/index.html')
+          .content.toContain('<link rel="stylesheet" href="other.css">');
+      });
+
+      it('preserves order of multiple styles in single output', async () => {
+        await harness.writeFiles({
+          'src/test-style-a.css': '.test-a {color: red}',
+          'src/test-style-b.css': '.test-b {color: green}',
+          'src/test-style-c.css': '.test-c {color: blue}',
+          'src/test-style-d.css': '.test-d {color: yellow}',
+        });
+
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          styles: [
+            { input: 'src/test-style-c.css' },
+            { input: 'src/test-style-d.css' },
+            { input: 'src/test-style-b.css' },
+            { input: 'src/test-style-a.css' },
+          ],
+        });
+
+        const { result } = await harness.executeOnce();
+
+        expect(result?.success).toBe(true);
+
+        harness.expectFile('dist/styles.css').content.toMatch(
+          // eslint-disable-next-line max-len
+          /\.test-c {\s*color: blue;?\s*}[\s|\S]+\.test-d {\s*color: yellow;?\s*}[\s|\S]+\.test-b {\s*color: green;?\s*}[\s|\S]+\.test-a {\s*color: red;?\s*}/,
+        );
+      });
+
+      it('preserves order of multiple styles with different bundleNames', async () => {
+        await harness.writeFiles({
+          'src/test-style-a.css': '.test-a {color: red}',
+          'src/test-style-b.css': '.test-b {color: green}',
+          'src/test-style-c.css': '.test-c {color: blue}',
+          'src/test-style-d.css': '.test-d {color: yellow}',
+        });
+
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          styles: [
+            { input: 'src/test-style-c.css', bundleName: 'other' },
+            { input: 'src/test-style-d.css', bundleName: 'extra' },
+            { input: 'src/test-style-b.css', bundleName: 'extra' },
+            { input: 'src/test-style-a.css', bundleName: 'other' },
+          ],
+        });
+
+        const { result } = await harness.executeOnce();
+
+        expect(result?.success).toBe(true);
+
+        harness
+          .expectFile('dist/other.css')
+          .content.toMatch(/\.test-c {\s*color: blue;?\s*}[\s|\S]+\.test-a {\s*color: red;?\s*}/);
+        harness
+          .expectFile('dist/extra.css')
+          .content.toMatch(
+            /\.test-d {\s*color: yellow;?\s*}[\s|\S]+\.test-b {\s*color: green;?\s*}/,
+          );
+        harness
+          .expectFile('dist/index.html')
+          .content.toMatch(
+            /<link rel="stylesheet" href="other.css">\s*<link rel="stylesheet" href="extra.css">/,
+          );
+      });
+
+      it('adds link element to index when inject is true', async () => {
+        await harness.writeFile('src/test-style-a.css', '.test-a {color: red}');
+
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          styles: [{ input: 'src/test-style-a.css', inject: true }],
+        });
+
+        const { result } = await harness.executeOnce();
+
+        expect(result?.success).toBe(true);
+
+        harness.expectFile('dist/styles.css').content.toMatch(/\.test-a {\s*color: red;?\s*}/);
+        harness
+          .expectFile('dist/index.html')
+          .content.toContain('<link rel="stylesheet" href="styles.css">');
+      });
+
+      it('does not add link element to index when inject is false', async () => {
+        await harness.writeFile('src/test-style-a.css', '.test-a {color: red}');
+
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          styles: [{ input: 'src/test-style-a.css', inject: false }],
+        });
+
+        const { result } = await harness.executeOnce();
+
+        expect(result?.success).toBe(true);
+
+        // `inject: false` causes the bundleName to be the input file name
+        harness
+          .expectFile('dist/test-style-a.css')
+          .content.toMatch(/\.test-a {\s*color: red;?\s*}/);
+        harness
+          .expectFile('dist/index.html')
+          .content.not.toContain('<link rel="stylesheet" href="test-style-a.css">');
+      });
+
+      it('does not add link element to index with bundleName when inject is false', async () => {
+        await harness.writeFile('src/test-style-a.css', '.test-a {color: red}');
+
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          styles: [{ input: 'src/test-style-a.css', bundleName: 'extra', inject: false }],
+        });
+
+        const { result } = await harness.executeOnce();
+
+        expect(result?.success).toBe(true);
+
+        harness.expectFile('dist/extra.css').content.toMatch(/\.test-a {\s*color: red;?\s*}/);
+
+        harness
+          .expectFile('dist/index.html')
+          .content.not.toContain('<link rel="stylesheet" href="extra.css">');
+      });
+
+      // TODO: Re-enable once output logging is implemented for esbuild builder
+      xit('shows the output style as a chunk entry in the logging output', async () => {
+        await harness.writeFile('src/test-style-a.css', '.test-a {color: red}');
+
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          styles: [{ input: 'src/test-style-a.css' }],
+        });
+
+        const { result, logs } = await harness.executeOnce();
+
+        expect(result?.success).toBe(true);
+
+        expect(logs).toContain(
+          jasmine.objectContaining({ message: jasmine.stringMatching(/styles\.css.+\d+ bytes/) }),
+        );
+      });
+
+      // TODO: Re-enable once output logging is implemented for esbuild builder
+      xit('shows the output style as a chunk entry with bundleName in the logging output', async () => {
+        await harness.writeFile('src/test-style-a.css', '.test-a {color: red}');
+
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          styles: [{ input: 'src/test-style-a.css', bundleName: 'extra' }],
+        });
+
+        const { result, logs } = await harness.executeOnce();
+
+        expect(result?.success).toBe(true);
+
+        expect(logs).toContain(
+          jasmine.objectContaining({ message: jasmine.stringMatching(/extra\.css.+\d+ bytes/) }),
+        );
+      });
+    });
+  });
+});

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/tests/options/subresource-integrity_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/tests/options/subresource-integrity_spec.ts
@@ -1,0 +1,70 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { logging } from '@angular-devkit/core';
+import { buildEsbuildBrowser } from '../../index';
+import { BASE_OPTIONS, BROWSER_BUILDER_INFO, describeBuilder } from '../setup';
+
+describeBuilder(buildEsbuildBrowser, BROWSER_BUILDER_INFO, (harness) => {
+  describe('Option: "subresourceIntegrity"', () => {
+    it(`does not add integrity attribute when not present`, async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+      });
+
+      const { result } = await harness.executeOnce();
+
+      expect(result?.success).toBe(true);
+      harness.expectFile('dist/index.html').content.not.toContain('integrity=');
+    });
+
+    it(`does not add integrity attribute when 'false'`, async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        subresourceIntegrity: false,
+      });
+
+      const { result } = await harness.executeOnce();
+
+      expect(result?.success).toBe(true);
+      harness.expectFile('dist/index.html').content.not.toContain('integrity=');
+    });
+
+    it(`does add integrity attribute when 'true'`, async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        subresourceIntegrity: true,
+      });
+
+      const { result } = await harness.executeOnce();
+
+      expect(result?.success).toBe(true);
+      harness.expectFile('dist/index.html').content.toMatch(/integrity="\w+-[A-Za-z0-9/+=]+"/);
+    });
+
+    it(`does not issue a warning when 'true' and 'scripts' is set.`, async () => {
+      await harness.writeFile('src/script.js', '');
+
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        subresourceIntegrity: true,
+        scripts: ['src/script.js'],
+      });
+
+      const { result, logs } = await harness.executeOnce();
+
+      expect(result?.success).toBe(true);
+      harness.expectFile('dist/index.html').content.toMatch(/integrity="\w+-[A-Za-z0-9/+=]+"/);
+      expect(logs).not.toContain(
+        jasmine.objectContaining<logging.LogEntry>({
+          message: jasmine.stringMatching(/subresource-integrity/),
+        }),
+      );
+    });
+  });
+});


### PR DESCRIPTION
The following unit tests have been ported over to test the experimental esbuild-based browser application builder:
* `extractLicenses` option
* `main` option
* `optimization.styles.inlineCritical` option
* `styles` option
* `subresourceIntegrity` option

Several individual tests involving file output logging have been temporarily disabled until build and file output logging has been implemented for the builder.