### PR TITLE
perf(@angular-devkit/build-angular): reduce rebuilt times when using the `scripts` option

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/plugins/scripts-webpack-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/plugins/scripts-webpack-plugin.ts
@@ -100,13 +100,17 @@ export class ScriptsWebpackPlugin {
       return;
     }
 
-    const resolver = compiler.resolverFactory.get('normal', {
-      preferRelative: true,
-      useSyncFileSystemCalls: true,
-      fileSystem: compiler.inputFileSystem,
-    });
-
     compiler.hooks.thisCompilation.tap(PLUGIN_NAME, (compilation) => {
+      // Use the resolver from the compilation instead of compiler.
+      // Using the latter will causes a lot of `DescriptionFileUtils.loadDescriptionFile` calls.
+      // See: https://github.com/angular/angular-cli/issues/24634#issuecomment-1425782668
+      const resolver = compilation.resolverFactory.get('normal', {
+        preferRelative: true,
+        useSyncFileSystemCalls: true,
+        // Caching must be disabled because it causes the resolver to become async after a rebuild.
+        cache: false,
+      });
+
       const scripts: string[] = [];
 
       for (const script of this.options.scripts) {


### PR DESCRIPTION
In some cases, using the `scripts` option caused a lot of `DescriptionFileUtils.loadDescriptionFile` calls which caused a bottleneck during build times.

The why to this is still unknown, but a workaround is to use the resolver from the Webpack compilation instead of the compiler.

Closes #24634

---

From @fearghalom
> On rebuilds, it knocked ~35secs off the time.

