### PR TITLE
feat(@angular-devkit/core): update SchemaRegistry `compile` to return `Promise`

### DIFF
--- a/goldens/public-api/angular_devkit/core/index.md
+++ b/goldens/public-api/angular_devkit/core/index.md
@@ -172,9 +172,7 @@ class CoreSchemaRegistry implements SchemaRegistry {
     addPreTransform(visitor: JsonVisitor, deps?: JsonVisitor[]): void;
     // (undocumented)
     addSmartDefaultProvider<T>(source: string, provider: SmartDefaultProvider<T>): void;
-    compile(schema: JsonSchema): Observable<SchemaValidator>;
-    // @deprecated
-    flatten(schema: JsonObject): Observable<JsonObject>;
+    compile(schema: JsonSchema): Promise<SchemaValidator>;
     // (undocumented)
     registerUriHandler(handler: UriHandler): void;
     // (undocumented)
@@ -186,6 +184,7 @@ class CoreSchemaRegistry implements SchemaRegistry {
     usePromptProvider(provider: PromptProvider): void;
     // (undocumented)
     useXDeprecatedProvider(onUsage: (message: string) => void): void;
+    ɵflatten(schema: JsonObject): Promise<JsonObject>;
 }
 
 // @public (undocumented)
@@ -873,13 +872,13 @@ interface SchemaRegistry {
     // (undocumented)
     addSmartDefaultProvider<T>(source: string, provider: SmartDefaultProvider<T>): void;
     // (undocumented)
-    compile(schema: Object): Observable<SchemaValidator>;
-    // @deprecated (undocumented)
-    flatten(schema: JsonObject | string): Observable<JsonObject>;
+    compile(schema: Object): Promise<SchemaValidator>;
     // (undocumented)
     usePromptProvider(provider: PromptProvider): void;
     // (undocumented)
     useXDeprecatedProvider(onUsage: (message: string) => void): void;
+    // (undocumented)
+    ɵflatten(schema: JsonObject | string): Promise<JsonObject>;
 }
 
 // @public (undocumented)
@@ -894,7 +893,7 @@ class SchemaValidationException extends BaseException {
 // @public (undocumented)
 interface SchemaValidator {
     // (undocumented)
-    (data: JsonValue, options?: SchemaValidatorOptions): Observable<SchemaValidatorResult>;
+    (data: JsonValue, options?: SchemaValidatorOptions): Promise<SchemaValidatorResult>;
 }
 
 // @public (undocumented)

--- a/packages/angular/cli/src/command-builder/utilities/json-schema.ts
+++ b/packages/angular/cli/src/command-builder/utilities/json-schema.ts
@@ -197,7 +197,7 @@ export async function parseJsonSchemaToOptions(
     options.push(option);
   }
 
-  const flattenedSchema = await registry.flatten(schema).toPromise();
+  const flattenedSchema = await registry.ɵflatten(schema);
   json.schema.visitJsonSchema(flattenedSchema, visitor);
 
   // Sort by positional and name.

--- a/packages/angular/cli/src/utilities/config.ts
+++ b/packages/angular/cli/src/utilities/config.ts
@@ -253,9 +253,8 @@ export async function validateWorkspace(data: json.JsonObject, isGlobal: boolean
 
   const { formats } = await import('@angular-devkit/schematics');
   const registry = new json.schema.CoreSchemaRegistry(formats.standardFormats);
-  const validator = await registry.compile(schemaToValidate).toPromise();
-
-  const { success, errors } = await validator(data).toPromise();
+  const validator = await registry.compile(schemaToValidate);
+  const { success, errors } = await validator(data);
   if (!success) {
     throw new json.schema.SchemaValidationException(errors);
   }

--- a/packages/angular_devkit/build_angular/src/testing/builder-harness.ts
+++ b/packages/angular_devkit/build_angular/src/testing/builder-harness.ts
@@ -214,8 +214,8 @@ export class BuilderHarness<T> {
           }
         }
 
-        const validator = await this.schemaRegistry.compile(schema ?? true).toPromise();
-        const { data } = await validator(options).toPromise();
+        const validator = await this.schemaRegistry.compile(schema ?? true);
+        const { data } = await validator(options);
 
         return data as json.JsonObject;
       },
@@ -237,7 +237,7 @@ export class BuilderHarness<T> {
     const logs: logging.LogEntry[] = [];
     context.logger.subscribe((e) => logs.push(e));
 
-    return this.schemaRegistry.compile(this.builderInfo.optionSchema).pipe(
+    return observableFrom(this.schemaRegistry.compile(this.builderInfo.optionSchema)).pipe(
       mergeMap((validator) => validator(targetOptions)),
       map((validationResult) => validationResult.data),
       mergeMap((data) =>

--- a/packages/angular_devkit/core/src/json/schema/interface.ts
+++ b/packages/angular_devkit/core/src/json/schema/interface.ts
@@ -28,7 +28,7 @@ export interface SchemaValidatorOptions {
 }
 
 export interface SchemaValidator {
-  (data: JsonValue, options?: SchemaValidatorOptions): Observable<SchemaValidatorResult>;
+  (data: JsonValue, options?: SchemaValidatorOptions): Promise<SchemaValidatorResult>;
 }
 
 export type SchemaFormatter = Format;
@@ -72,13 +72,10 @@ export type PromptProvider = (
 ) => SubscribableOrPromise<{ [id: string]: JsonValue }>;
 
 export interface SchemaRegistry {
-  compile(schema: Object): Observable<SchemaValidator>;
-  /**
-   * @deprecated since 11.2 without replacement.
-   * Producing a flatten schema document does not in all cases produce a schema with identical behavior to the original.
-   * See: https://json-schema.org/draft/2019-09/json-schema-core.html#rfc.appendix.B.2
-   */
-  flatten(schema: JsonObject | string): Observable<JsonObject>;
+  compile(schema: Object): Promise<SchemaValidator>;
+
+  /** @private */
+  ɵflatten(schema: JsonObject | string): Promise<JsonObject>;
   addFormat(format: SchemaFormat): void;
   addSmartDefaultProvider<T>(source: string, provider: SmartDefaultProvider<T>): void;
   usePromptProvider(provider: PromptProvider): void;

--- a/packages/angular_devkit/core/src/json/schema/prompt_spec.ts
+++ b/packages/angular_devkit/core/src/json/schema/prompt_spec.ts
@@ -7,7 +7,6 @@
  */
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { map, mergeMap } from 'rxjs/operators';
 import { CoreSchemaRegistry } from './registry';
 
 describe('Prompt Provider', () => {
@@ -19,22 +18,17 @@ describe('Prompt Provider', () => {
       return { [definitions[0].id]: true };
     });
 
-    await registry
-      .compile({
-        properties: {
-          test: {
-            type: 'boolean',
-            'x-prompt': 'test-message',
-          },
+    const validator = await registry.compile({
+      properties: {
+        test: {
+          type: 'boolean',
+          'x-prompt': 'test-message',
         },
-      })
-      .pipe(
-        mergeMap((validator) => validator(data)),
-        map(() => {
-          expect(data.test).toBe(true);
-        }),
-      )
-      .toPromise();
+      },
+    });
+
+    await validator(data);
+    expect(data.test).toBe(true);
   });
 
   it('supports mixed schema references', async () => {
@@ -49,53 +43,48 @@ describe('Prompt Provider', () => {
       };
     });
 
-    await registry
-      .compile({
-        properties: {
-          bool: {
-            $ref: '#/definitions/example',
+    const validator = await registry.compile({
+      properties: {
+        bool: {
+          $ref: '#/definitions/example',
+        },
+        test: {
+          type: 'string',
+          enum: ['one', 'two', 'three'],
+          'x-prompt': {
+            type: 'list',
+            'message': 'other-message',
           },
-          test: {
-            type: 'string',
-            enum: ['one', 'two', 'three'],
-            'x-prompt': {
-              type: 'list',
-              'message': 'other-message',
-            },
-          },
-          obj: {
-            properties: {
-              deep: {
-                properties: {
-                  three: {
-                    $ref: '#/definitions/test3',
-                  },
+        },
+        obj: {
+          properties: {
+            deep: {
+              properties: {
+                three: {
+                  $ref: '#/definitions/test3',
                 },
               },
             },
           },
         },
-        definitions: {
-          example: {
-            type: 'boolean',
-            'x-prompt': 'example-message',
-          },
-          test3: {
-            type: 'string',
-            'x-prompt': 'test3-message',
-          },
+      },
+      definitions: {
+        example: {
+          type: 'boolean',
+          'x-prompt': 'example-message',
         },
-      })
-      .pipe(
-        mergeMap((validator) => validator(data)),
-        map((result) => {
-          expect(result.success).toBe(true);
-          expect(data.bool).toBe(true);
-          expect(data.test).toBe('two');
-          expect(data.obj.deep.three).toEqual('test3-answer');
-        }),
-      )
-      .toPromise();
+        test3: {
+          type: 'string',
+          'x-prompt': 'test3-message',
+        },
+      },
+    });
+
+    const result = await validator(data);
+    expect(result.success).toBe(true);
+    expect(data.bool).toBe(true);
+    expect(data.test).toBe('two');
+    expect(data.obj.deep.three).toEqual('test3-answer');
   });
 
   describe('with shorthand', () => {
@@ -110,17 +99,16 @@ describe('Prompt Provider', () => {
         return {};
       });
 
-      await registry
-        .compile({
-          properties: {
-            test: {
-              type: 'string',
-              'x-prompt': 'test-message',
-            },
+      const validator = await registry.compile({
+        properties: {
+          test: {
+            type: 'string',
+            'x-prompt': 'test-message',
           },
-        })
-        .pipe(mergeMap((validator) => validator(data)))
-        .toPromise();
+        },
+      });
+
+      await validator(data);
     });
 
     it('analyzes enums', async () => {
@@ -135,18 +123,16 @@ describe('Prompt Provider', () => {
         return {};
       });
 
-      await registry
-        .compile({
-          properties: {
-            test: {
-              type: 'string',
-              enum: ['one', 'two', 'three'],
-              'x-prompt': 'test-message',
-            },
+      const validator = await registry.compile({
+        properties: {
+          test: {
+            type: 'string',
+            enum: ['one', 'two', 'three'],
+            'x-prompt': 'test-message',
           },
-        })
-        .pipe(mergeMap((validator) => validator(data)))
-        .toPromise();
+        },
+      });
+      await validator(data);
     });
 
     it('analyzes boolean properties', async () => {
@@ -161,17 +147,15 @@ describe('Prompt Provider', () => {
         return {};
       });
 
-      await registry
-        .compile({
-          properties: {
-            test: {
-              type: 'boolean',
-              'x-prompt': 'test-message',
-            },
+      const validator = await registry.compile({
+        properties: {
+          test: {
+            type: 'boolean',
+            'x-prompt': 'test-message',
           },
-        })
-        .pipe(mergeMap((validator) => validator(data)))
-        .toPromise();
+        },
+      });
+      await validator(data);
     });
   });
 
@@ -187,19 +171,17 @@ describe('Prompt Provider', () => {
         return {};
       });
 
-      await registry
-        .compile({
-          properties: {
-            test: {
-              type: 'string',
-              'x-prompt': {
-                'message': 'test-message',
-              },
+      const validator = await registry.compile({
+        properties: {
+          test: {
+            type: 'string',
+            'x-prompt': {
+              'message': 'test-message',
             },
           },
-        })
-        .pipe(mergeMap((validator) => validator(data)))
-        .toPromise();
+        },
+      });
+      await validator(data);
     });
 
     it('analyzes enums WITH explicit list type', async () => {
@@ -214,21 +196,19 @@ describe('Prompt Provider', () => {
         return { [definitions[0].id]: 'one' };
       });
 
-      await registry
-        .compile({
-          properties: {
-            test: {
-              type: 'string',
-              enum: ['one', 'two', 'three'],
-              'x-prompt': {
-                'type': 'list',
-                'message': 'test-message',
-              },
+      const validator = await registry.compile({
+        properties: {
+          test: {
+            type: 'string',
+            enum: ['one', 'two', 'three'],
+            'x-prompt': {
+              'type': 'list',
+              'message': 'test-message',
             },
           },
-        })
-        .pipe(mergeMap((validator) => validator(data)))
-        .toPromise();
+        },
+      });
+      await validator(data);
     });
 
     it('analyzes list with true multiselect option and object items', async () => {
@@ -247,25 +227,23 @@ describe('Prompt Provider', () => {
         return { [definitions[0].id]: { 'value': 'one', 'label': 'one' } };
       });
 
-      await registry
-        .compile({
-          properties: {
-            test: {
-              type: 'array',
-              'x-prompt': {
-                'type': 'list',
-                'multiselect': true,
-                'items': [
-                  { 'value': 'one', 'label': 'one' },
-                  { 'value': 'two', 'label': 'two' },
-                ],
-                'message': 'test-message',
-              },
+      const validator = await registry.compile({
+        properties: {
+          test: {
+            type: 'array',
+            'x-prompt': {
+              'type': 'list',
+              'multiselect': true,
+              'items': [
+                { 'value': 'one', 'label': 'one' },
+                { 'value': 'two', 'label': 'two' },
+              ],
+              'message': 'test-message',
             },
           },
-        })
-        .pipe(mergeMap((validator) => validator(data)))
-        .toPromise();
+        },
+      });
+      await validator(data);
     });
 
     it('analyzes list with false multiselect option and object items', async () => {
@@ -284,25 +262,23 @@ describe('Prompt Provider', () => {
         return { [definitions[0].id]: { 'value': 'one', 'label': 'one' } };
       });
 
-      await registry
-        .compile({
-          properties: {
-            test: {
-              type: 'array',
-              'x-prompt': {
-                'type': 'list',
-                'multiselect': false,
-                'items': [
-                  { 'value': 'one', 'label': 'one' },
-                  { 'value': 'two', 'label': 'two' },
-                ],
-                'message': 'test-message',
-              },
+      const validator = await registry.compile({
+        properties: {
+          test: {
+            type: 'array',
+            'x-prompt': {
+              'type': 'list',
+              'multiselect': false,
+              'items': [
+                { 'value': 'one', 'label': 'one' },
+                { 'value': 'two', 'label': 'two' },
+              ],
+              'message': 'test-message',
             },
           },
-        })
-        .pipe(mergeMap((validator) => validator(data)))
-        .toPromise();
+        },
+      });
+      await validator(data);
     });
 
     it('analyzes list without multiselect option and object items', async () => {
@@ -321,24 +297,22 @@ describe('Prompt Provider', () => {
         return { [definitions[0].id]: { 'value': 'two', 'label': 'two' } };
       });
 
-      await registry
-        .compile({
-          properties: {
-            test: {
-              type: 'array',
-              'x-prompt': {
-                'type': 'list',
-                'items': [
-                  { 'value': 'one', 'label': 'one' },
-                  { 'value': 'two', 'label': 'two' },
-                ],
-                'message': 'test-message',
-              },
+      const validator = await registry.compile({
+        properties: {
+          test: {
+            type: 'array',
+            'x-prompt': {
+              'type': 'list',
+              'items': [
+                { 'value': 'one', 'label': 'one' },
+                { 'value': 'two', 'label': 'two' },
+              ],
+              'message': 'test-message',
             },
           },
-        })
-        .pipe(mergeMap((validator) => validator(data)))
-        .toPromise();
+        },
+      });
+      await validator(data);
     });
 
     it('analyzes enums WITHOUT explicit list type', async () => {
@@ -353,21 +327,18 @@ describe('Prompt Provider', () => {
 
         return {};
       });
-
-      await registry
-        .compile({
-          properties: {
-            test: {
-              type: 'string',
-              enum: ['one', 'two', 'three'],
-              'x-prompt': {
-                'message': 'test-message',
-              },
+      const validator = await registry.compile({
+        properties: {
+          test: {
+            type: 'string',
+            enum: ['one', 'two', 'three'],
+            'x-prompt': {
+              'message': 'test-message',
             },
           },
-        })
-        .pipe(mergeMap((validator) => validator(data)))
-        .toPromise();
+        },
+      });
+      await validator(data);
     });
 
     it('analyzes enums WITHOUT explicit list type and multiselect', async () => {
@@ -383,20 +354,18 @@ describe('Prompt Provider', () => {
         return {};
       });
 
-      await registry
-        .compile({
-          properties: {
-            test: {
-              type: 'array',
-              items: {
-                enum: ['one', 'two', 'three'],
-              },
-              'x-prompt': 'test-message',
+      const validator = await registry.compile({
+        properties: {
+          test: {
+            type: 'array',
+            items: {
+              enum: ['one', 'two', 'three'],
             },
+            'x-prompt': 'test-message',
           },
-        })
-        .pipe(mergeMap((validator) => validator(data)))
-        .toPromise();
+        },
+      });
+      await validator(data);
     });
 
     it('analyzes boolean properties', async () => {
@@ -411,19 +380,17 @@ describe('Prompt Provider', () => {
         return {};
       });
 
-      await registry
-        .compile({
-          properties: {
-            test: {
-              type: 'boolean',
-              'x-prompt': {
-                'message': 'test-message',
-              },
+      const validator = await registry.compile({
+        properties: {
+          test: {
+            type: 'boolean',
+            'x-prompt': {
+              'message': 'test-message',
             },
           },
-        })
-        .pipe(mergeMap((validator) => validator(data)))
-        .toPromise();
+        },
+      });
+      await validator(data);
     });
 
     it('allows prompt type override', async () => {
@@ -438,20 +405,18 @@ describe('Prompt Provider', () => {
         return {};
       });
 
-      await registry
-        .compile({
-          properties: {
-            test: {
-              type: 'boolean',
-              'x-prompt': {
-                'type': 'input',
-                'message': 'test-message',
-              },
+      const validator = await registry.compile({
+        properties: {
+          test: {
+            type: 'boolean',
+            'x-prompt': {
+              'type': 'input',
+              'message': 'test-message',
             },
           },
-        })
-        .pipe(mergeMap((validator) => validator(data)))
-        .toPromise();
+        },
+      });
+      await validator(data);
     });
   });
 });

--- a/packages/angular_devkit/core/src/json/schema/registry.ts
+++ b/packages/angular_devkit/core/src/json/schema/registry.ts
@@ -11,7 +11,6 @@ import ajvAddFormats from 'ajv-formats';
 import * as http from 'http';
 import * as https from 'https';
 import { Observable, from, isObservable } from 'rxjs';
-import { map } from 'rxjs/operators';
 import * as Url from 'url';
 import { BaseException } from '../../exception';
 import { PartiallyOrderedSet, deepCopy } from '../../utils';
@@ -221,19 +220,15 @@ export class CoreSchemaRegistry implements SchemaRegistry {
    * Flatten the Schema, resolving and replacing all the refs. Makes it into a synchronous schema
    * that is also easier to traverse. Does not cache the result.
    *
-   * @param schema The schema or URI to flatten.
-   * @returns An Observable of the flattened schema object.
-   * @deprecated since 11.2 without replacement.
    * Producing a flatten schema document does not in all cases produce a schema with identical behavior to the original.
    * See: https://json-schema.org/draft/2019-09/json-schema-core.html#rfc.appendix.B.2
+   *
+   * @param schema The schema or URI to flatten.
+   * @returns An Observable of the flattened schema object.
+   * @private since 11.2 without replacement.
    */
-  flatten(schema: JsonObject): Observable<JsonObject> {
-    return from(this._flatten(schema));
-  }
-
-  private async _flatten(schema: JsonObject): Promise<JsonObject> {
+  async ɵflatten(schema: JsonObject): Promise<JsonObject> {
     this._ajv.removeSchema(schema);
-
     this._currentCompilationSchemaInfo = undefined;
     const validate = await this._ajv.compileAsync(schema);
 
@@ -273,12 +268,11 @@ export class CoreSchemaRegistry implements SchemaRegistry {
    *
    * @param schema The schema to validate. If a string, will fetch the schema before compiling it
    * (using schema as a URI).
-   * @returns An Observable of the Validation function.
    */
-  compile(schema: JsonSchema): Observable<SchemaValidator> {
-    return from(this._compile(schema)).pipe(
-      map((validate) => (value, options) => from(validate(value, options))),
-    );
+  async compile(schema: JsonSchema): Promise<SchemaValidator> {
+    const validate = await this._compile(schema);
+
+    return (value, options) => validate(value, options);
   }
 
   private async _compile(

--- a/packages/angular_devkit/core/src/json/schema/transforms_spec.ts
+++ b/packages/angular_devkit/core/src/json/schema/transforms_spec.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { mergeMap } from 'rxjs/operators';
 import { CoreSchemaRegistry } from './registry';
 import { addUndefinedDefaults } from './transforms';
 
@@ -16,37 +15,36 @@ describe('addUndefinedDefaults', () => {
     registry.addPreTransform(addUndefinedDefaults);
     const data: any = {}; // eslint-disable-line @typescript-eslint/no-explicit-any
 
-    const result = await registry
-      .compile({
-        properties: {
-          bool: { type: 'boolean' },
-          str: { type: 'string', default: 'someString' },
-          obj: {
-            properties: {
-              num: { type: 'number' },
-              other: { type: 'number', default: 0 },
-            },
-          },
-          objAllOk: {
-            allOf: [{ type: 'object' }],
-          },
-          objAllBad: {
-            allOf: [{ type: 'object' }, { type: 'number' }],
-          },
-          objOne: {
-            oneOf: [{ type: 'object' }],
-          },
-          objNotOk: {
-            not: { not: { type: 'object' } },
-          },
-          objNotBad: {
-            type: 'object',
-            not: { type: 'object' },
+    const validator = await registry.compile({
+      properties: {
+        bool: { type: 'boolean' },
+        str: { type: 'string', default: 'someString' },
+        obj: {
+          properties: {
+            num: { type: 'number' },
+            other: { type: 'number', default: 0 },
           },
         },
-      })
-      .pipe(mergeMap((validator) => validator(data)))
-      .toPromise();
+        objAllOk: {
+          allOf: [{ type: 'object' }],
+        },
+        objAllBad: {
+          allOf: [{ type: 'object' }, { type: 'number' }],
+        },
+        objOne: {
+          oneOf: [{ type: 'object' }],
+        },
+        objNotOk: {
+          not: { not: { type: 'object' } },
+        },
+        objNotBad: {
+          type: 'object',
+          not: { type: 'object' },
+        },
+      },
+    });
+
+    const result = await validator(data);
 
     expect(result.success).toBeTrue();
     expect(data.bool).toBeUndefined();
@@ -72,20 +70,19 @@ describe('addUndefinedDefaults', () => {
       },
     };
 
-    const result = await registry
-      .compile({
-        properties: {
-          bool: { type: 'boolean', default: true },
-          str: { type: 'string', default: 'someString' },
-          obj: {
-            properties: {
-              num: { type: 'number', default: 0 },
-            },
+    const validator = await registry.compile({
+      properties: {
+        bool: { type: 'boolean', default: true },
+        str: { type: 'string', default: 'someString' },
+        obj: {
+          properties: {
+            num: { type: 'number', default: 0 },
           },
         },
-      })
-      .pipe(mergeMap((validator) => validator(data)))
-      .toPromise();
+      },
+    });
+
+    const result = await validator(data);
 
     expect(result.success).toBeTrue();
     expect(data.bool).toBeTrue();
@@ -108,7 +105,7 @@ describe('addUndefinedDefaults', () => {
       },
     };
 
-    const validator = registry.compile({
+    const validator = await registry.compile({
       properties: {
         bool: { type: 'boolean', default: true },
         obj: {
@@ -145,15 +142,13 @@ describe('addUndefinedDefaults', () => {
       },
     });
 
-    const result1 = await validator.pipe(mergeMap((validator) => validator(dataNoObj))).toPromise();
-
+    const result1 = await validator(dataNoObj);
     expect(result1.success).toBeTrue();
     expect(dataNoObj.bool).toBeTrue();
     expect(dataNoObj.obj).toBeTrue();
     expect(dataNoObj.noDefaultOneOf).toBeUndefined();
 
-    const result2 = await validator.pipe(mergeMap((validator) => validator(dataObj))).toPromise();
-
+    const result2 = await validator(dataObj);
     expect(result2.success).toBeTrue();
     expect(dataObj.bool).toBeTrue();
     expect(dataObj.obj.a).toBeFalse();
@@ -176,7 +171,7 @@ describe('addUndefinedDefaults', () => {
       },
     };
 
-    const validator = registry.compile({
+    const validator = await registry.compile({
       properties: {
         bool: { type: 'boolean', default: true },
         obj: {
@@ -204,14 +199,12 @@ describe('addUndefinedDefaults', () => {
       },
     });
 
-    const result1 = await validator.pipe(mergeMap((validator) => validator(dataNoObj))).toPromise();
-
+    const result1 = await validator(dataNoObj);
     expect(result1.success).toBeTrue();
     expect(dataNoObj.bool).toBeTrue();
     expect(dataNoObj.obj).toBeTrue();
 
-    const result2 = await validator.pipe(mergeMap((validator) => validator(dataObj))).toPromise();
-
+    const result2 = await validator(dataObj);
     expect(result2.success).toBeTrue();
     expect(dataObj.bool).toBeTrue();
     expect(dataObj.obj.a).toBeFalse();
@@ -228,7 +221,7 @@ describe('addUndefinedDefaults', () => {
       boolRef: true,
     };
 
-    const validator = registry.compile({
+    const validator = await registry.compile({
       definitions: {
         boolRef: {
           default: false,
@@ -246,12 +239,12 @@ describe('addUndefinedDefaults', () => {
       },
     });
 
-    const result1 = await validator.pipe(mergeMap((validator) => validator(dataNoObj))).toPromise();
+    const result1 = await validator(dataNoObj);
     expect(result1.success).toBeTrue();
     expect(dataNoObj['bool']).toBeFalse();
     expect(dataNoObj['boolRef']).toBeFalse();
 
-    const result2 = await validator.pipe(mergeMap((validator) => validator(dataObj))).toPromise();
+    const result2 = await validator(dataObj);
     expect(result2.success).toBeTrue();
     expect(dataObj['bool']).toBeFalse();
     expect(dataObj['boolRef']).toBeTrue();

--- a/packages/angular_devkit/schematics/src/formats/format-validator.ts
+++ b/packages/angular_devkit/schematics/src/formats/format-validator.ts
@@ -7,19 +7,19 @@
  */
 
 import { JsonObject, JsonValue, schema } from '@angular-devkit/core';
-import { Observable } from 'rxjs';
-import { mergeMap } from 'rxjs/operators';
 
-export function formatValidator(
+export async function formatValidator(
   data: JsonValue,
   dataSchema: JsonObject,
   formats: schema.SchemaFormat[],
-): Observable<schema.SchemaValidatorResult> {
+): Promise<schema.SchemaValidatorResult> {
   const registry = new schema.CoreSchemaRegistry();
 
   for (const format of formats) {
     registry.addFormat(format);
   }
 
-  return registry.compile(dataSchema).pipe(mergeMap((validator) => validator(data)));
+  const validator = await registry.compile(dataSchema);
+
+  return validator(data);
 }

--- a/packages/angular_devkit/schematics/src/formats/html-selector_spec.ts
+++ b/packages/angular_devkit/schematics/src/formats/html-selector_spec.ts
@@ -6,68 +6,57 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { map } from 'rxjs/operators';
 import { formatValidator } from './format-validator';
 import { htmlSelectorFormat } from './html-selector';
 
 describe('Schematics HTML selector format', () => {
-  it('accepts correct selectors', (done) => {
+  it('accepts correct selectors', async () => {
     const data = { selector: 'my-selector' };
     const dataSchema = {
       properties: { selector: { type: 'string', format: 'html-selector' } },
     };
 
-    formatValidator(data, dataSchema, [htmlSelectorFormat])
-      .pipe(map((result) => expect(result.success).toBe(true)))
-      .toPromise()
-      .then(done, done.fail);
+    const result = await formatValidator(data, dataSchema, [htmlSelectorFormat]);
+    expect(result.success).toBeTrue();
   });
 
-  it('rejects selectors starting with invalid characters', (done) => {
+  it('rejects selectors starting with invalid characters', async () => {
     const data = { selector: 'my-selector$' };
     const dataSchema = {
       properties: { selector: { type: 'string', format: 'html-selector' } },
     };
 
-    formatValidator(data, dataSchema, [htmlSelectorFormat])
-      .pipe(map((result) => expect(result.success).toBe(false)))
-      .toPromise()
-      .then(done, done.fail);
+    const result = await formatValidator(data, dataSchema, [htmlSelectorFormat]);
+    expect(result.success).toBeFalse();
   });
 
-  it('rejects selectors starting with number', (done) => {
+  it('rejects selectors starting with number', async () => {
     const data = { selector: '1selector' };
     const dataSchema = {
       properties: { selector: { type: 'string', format: 'html-selector' } },
     };
 
-    formatValidator(data, dataSchema, [htmlSelectorFormat])
-      .pipe(map((result) => expect(result.success).toBe(false)))
-      .toPromise()
-      .then(done, done.fail);
+    const result = await formatValidator(data, dataSchema, [htmlSelectorFormat]);
+    expect(result.success).toBeFalse();
   });
 
-  it('accepts selectors with non-letter after dash', (done) => {
+  it('accepts selectors with non-letter after dash', async () => {
     const data = { selector: 'my-1selector' };
     const dataSchema = {
       properties: { selector: { type: 'string', format: 'html-selector' } },
     };
 
-    formatValidator(data, dataSchema, [htmlSelectorFormat])
-      .pipe(map((result) => expect(result.success).toBe(true)))
-      .toPromise()
-      .then(done, done.fail);
+    const result = await formatValidator(data, dataSchema, [htmlSelectorFormat]);
+    expect(result.success).toBeTrue();
   });
 
-  it('accepts selectors with unicode', (done) => {
+  it('accepts selectors with unicode', async () => {
     const data = { selector: 'app-root😀' };
     const dataSchema = {
       properties: { selector: { type: 'string', format: 'html-selector' } },
     };
 
-    formatValidator(data, dataSchema, [htmlSelectorFormat])
-      .pipe(map((result) => expect(result.success).toBe(true)))
-      .toPromise()
-      .then(done, done.fail);
+    const result = await formatValidator(data, dataSchema, [htmlSelectorFormat]);
+    expect(result.success).toBeTrue();
   });
 });

--- a/packages/angular_devkit/schematics/src/formats/path_spec.ts
+++ b/packages/angular_devkit/schematics/src/formats/path_spec.ts
@@ -6,32 +6,27 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { map } from 'rxjs/operators';
 import { formatValidator } from './format-validator';
 import { pathFormat } from './path';
 
 describe('Schematics Path format', () => {
-  it('accepts correct Paths', (done) => {
+  it('accepts correct Paths', async () => {
     const data = { path: 'a/b/c' };
     const dataSchema = {
       properties: { path: { type: 'string', format: 'path' } },
     };
 
-    formatValidator(data, dataSchema, [pathFormat])
-      .pipe(map((result) => expect(result.success).toBe(true)))
-      .toPromise()
-      .then(done, done.fail);
+    const result = await formatValidator(data, dataSchema, [pathFormat]);
+    expect(result.success).toBeTrue();
   });
 
-  it('rejects Paths that are not normalized', (done) => {
+  it('rejects Paths that are not normalized', async () => {
     const data = { path: 'a/b/c/../' };
     const dataSchema = {
       properties: { path: { type: 'string', format: 'path' } },
     };
 
-    formatValidator(data, dataSchema, [pathFormat])
-      .pipe(map((result) => expect(result.success).toBe(false)))
-      .toPromise()
-      .then(done, done.fail);
+    const result = await formatValidator(data, dataSchema, [pathFormat]);
+    expect(result.success).toBeFalse();
   });
 });

--- a/packages/angular_devkit/schematics/tools/schema-option-transform.ts
+++ b/packages/angular_devkit/schematics/tools/schema-option-transform.ts
@@ -7,7 +7,7 @@
  */
 
 import { deepCopy, schema } from '@angular-devkit/core';
-import { Observable, of as observableOf } from 'rxjs';
+import { Observable, from, of as observableOf } from 'rxjs';
 import { first, map, mergeMap } from 'rxjs/operators';
 import { FileSystemSchematicContext, FileSystemSchematicDescription } from './description';
 
@@ -34,7 +34,7 @@ export function validateOptionsWithSchema(registry: schema.SchemaRegistry) {
 
     if (schematic.schema && schematic.schemaJson) {
       // Make a deep copy of options.
-      return registry.compile(schematic.schemaJson).pipe(
+      return from(registry.compile(schematic.schemaJson)).pipe(
         mergeMap((validator) => validator(options, { withPrompts })),
         first(),
         map((result) => {


### PR DESCRIPTION
Use promise based methods to reduce RXJS usage and boiler-platting.

BREAKING CHANGE: Several changes to the `SchemaRegistry`.
- `compile` method now returns a `Promise`.
- Deprecated `flatten` has been removed without replacement.