### PR TITLE
build: avoid unnecessary re-evaluation of starlark code

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -50,7 +50,7 @@ test --incompatible_strict_action_env
 build --experimental_remote_merkle_tree_cache
 
 # Ensure that tags applied in BUILDs propagate to actions
-build --experimental_allow_tags_propagation
+common --experimental_allow_tags_propagation
 
 # Don't check if output files have been modified
 build --noexperimental_check_output_files


### PR DESCRIPTION
The experimental allow tags propagation flag is a `BuildLanguage` option and causes all Starlark code to be re-invoked. This causes a slow-down when switching between bazel query/ bazel build because the option is not set for `bazel query`.

We fix it by applying the option to all commands, using `common`.