### PR TITLE
build: update output target to ES2020

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -61,6 +61,12 @@ nodejs_register_toolchains(
     node_version = "18.10.0",
 )
 
+# Set the default nodejs toolchain to the latest supported major version
+nodejs_register_toolchains(
+    name = "nodejs",
+    node_version = "18.10.0",
+)
+
 load("@build_bazel_rules_nodejs//:index.bzl", "yarn_install")
 
 yarn_install(

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -36,7 +36,7 @@ def ts_library(
     if not devmode_module:
         devmode_module = "commonjs"
     if not devmode_target:
-        devmode_target = "es2018"
+        devmode_target = "es2020"
 
     _ts_library(
         name = name,
@@ -46,6 +46,7 @@ def ts_library(
         tsconfig = tsconfig,
         devmode_module = devmode_module,
         devmode_target = devmode_target,
+        prodmode_target = "es2020",
         # @external_end
         **kwargs
     )

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "outDir": "./dist",
     "skipLibCheck": true,
     "strict": true,
-    "target": "es2019",
+    "target": "es2020",
     "lib": ["es2020"],
     "rootDir": ".",
     "rootDirs": [".", "./dist-schema/"],


### PR DESCRIPTION
The minimum supported Node.js version is now v16.13. This version provides full support for ES2020 allowing the output code target to be increased. While Node.js v16.13 supports higher ECMAScript versions, a limitation of the bazel `ts_library` rule currently prevents increasing further at this time.