### PR TITLE
fix(@angular-devkit/build-angular): allow empty scripts to be optimized

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser/tests/options/scripts_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/tests/options/scripts_spec.ts
@@ -27,6 +27,27 @@ describeBuilder(buildWebpackBrowser, BROWSER_BUILDER_INFO, (harness) => {
       expect(result?.success).toBe(true);
     });
 
+    it('processes an empty script when optimizing', async () => {
+      await harness.writeFile('src/test-script-a.js', '');
+
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        optimization: {
+          scripts: true,
+        },
+        scripts: ['src/test-script-a.js'],
+      });
+
+      const { result } = await harness.executeOnce();
+
+      expect(result?.success).toBe(true);
+
+      harness.expectFile('dist/scripts.js').toExist();
+      harness
+        .expectFile('dist/index.html')
+        .content.toContain('<script src="scripts.js" defer></script>');
+    });
+
     describe('shorthand syntax', () => {
       it('processes a single script into a single output', async () => {
         await harness.writeFile('src/test-script-a.js', 'console.log("a");');

--- a/packages/angular_devkit/build_angular/src/webpack/plugins/javascript-optimizer-worker.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/plugins/javascript-optimizer-worker.ts
@@ -227,7 +227,7 @@ async function optimizeWithTerser(
     },
   );
 
-  if (!result.code) {
+  if (typeof result.code !== 'string') {
     throw new Error('Terser failed for unknown reason.');
   }
 


### PR DESCRIPTION
When using the internal JavaScript optimizer plugin for Webpack with an empty script file provided via the `scripts` option, the build would fail. This was because of a safety check that was checking whether the terser result was falsy. Since an empty string is considered falsy, the build considered the result to be an error. The safety check now will only trigger if the terser result is not a string value to avoid this case.

Fixes #24736