### PR TITLE
ci: correctly store E2E test results and artifacts

### DIFF
--- a/.circleci/dynamic_config.yml
+++ b/.circleci/dynamic_config.yml
@@ -277,9 +277,9 @@ jobs:
           command: yarn bazel test --define=E2E_TEMP=/mnt/ramdisk/e2e --define=E2E_SHARD_TOTAL=${CIRCLE_NODE_TOTAL} --define=E2E_SHARD_INDEX=${CIRCLE_NODE_INDEX} --config=e2e //tests/legacy-cli:e2e<<# parameters.snapshots >>.snapshots<</ parameters.snapshots >>.<< parameters.subset >>_node<< parameters.nodeversion >>
           no_output_timeout: 40m
       - store_artifacts:
-          path: dist/testlogs/tests/legacy-cli/e2e.<<parameters.nodeversion>>.<< parameters.subset >>
+          path: dist/testlogs/tests/legacy-cli/e2e<<# parameters.snapshots >>.snapshots<</ parameters.snapshots >>.<< parameters.subset >>_node<< parameters.nodeversion >>
       - store_test_results:
-          path: dist/testlogs/tests/legacy-cli/e2e.<<parameters.nodeversion>>.<< parameters.subset >>
+          path: dist/testlogs/tests/legacy-cli/e2e<<# parameters.snapshots >>.snapshots<</ parameters.snapshots >>.<< parameters.subset >>_node<< parameters.nodeversion >>
       - fail_fast
 
   test-browsers:


### PR DESCRIPTION
The CircleCI commands to store the E2E test results and artifacts was outdated which caused nothing to be saved.