### PR TITLE
refactor(@angular-devkit/build-angular): remove deprecated `outputPaths` and `outputPath` Builder output

### DIFF
--- a/goldens/public-api/angular_devkit/build_angular/index.md
+++ b/goldens/public-api/angular_devkit/build_angular/index.md
@@ -75,8 +75,6 @@ export interface BrowserBuilderOptions {
 export type BrowserBuilderOutput = BuilderOutput & {
     stats: BuildEventStats;
     baseOutputPath: string;
-    outputPaths: string[];
-    outputPath: string;
     outputs: {
         locale?: string;
         path: string;
@@ -279,7 +277,6 @@ export interface ServerBuilderOptions {
 // @public
 export type ServerBuilderOutput = BuilderOutput & {
     baseOutputPath: string;
-    outputPaths: string[];
     outputPath: string;
     outputs: {
         locale?: string;

--- a/packages/angular_devkit/build_angular/src/builders/browser/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/index.ts
@@ -65,17 +65,7 @@ import { Schema as BrowserBuilderSchema } from './schema';
  */
 export type BrowserBuilderOutput = BuilderOutput & {
   stats: BuildEventStats;
-
   baseOutputPath: string;
-  /**
-   * @deprecated in version 14. Use 'outputs' instead.
-   */
-  outputPaths: string[];
-  /**
-   * @deprecated in version 9. Use 'outputs' instead.
-   */
-  outputPath: string;
-
   outputs: {
     locale?: string;
     path: string;
@@ -413,8 +403,6 @@ export function buildWebpackBrowser(
                 ...event,
                 stats: generateBuildEventStats(webpackStats, options),
                 baseOutputPath,
-                outputPath: baseOutputPath,
-                outputPaths: (outputPaths && Array.from(outputPaths.values())) || [baseOutputPath],
                 outputs: (outputPaths &&
                   [...outputPaths.entries()].map(([locale, path]) => ({
                     locale,

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/allow-js_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/allow-js_spec.ts
@@ -39,7 +39,7 @@ describe('Browser Builder allow js', () => {
     expect(output.success).toBe(true);
 
     const content = virtualFs.fileBufferToString(
-      await lastValueFrom(host.read(join(normalize(output.outputPath), 'main.js'))),
+      await lastValueFrom(host.read(join(normalize(output.outputs[0].path), 'main.js'))),
     );
 
     expect(content).toContain('const a = 2');
@@ -66,7 +66,7 @@ describe('Browser Builder allow js', () => {
     expect(output.success).toBe(true);
 
     const content = virtualFs.fileBufferToString(
-      await lastValueFrom(host.read(join(normalize(output.outputPath), 'main.js'))),
+      await lastValueFrom(host.read(join(normalize(output.outputs[0].path), 'main.js'))),
     );
 
     expect(content).toContain('const a = 2');
@@ -94,7 +94,7 @@ describe('Browser Builder allow js', () => {
     await lastValueFrom(
       (run.output as Observable<BrowserBuilderOutput>).pipe(
         tap((output) => {
-          const path = relative(host.root(), join(normalize(output.outputPath), 'main.js'));
+          const path = relative(host.root(), join(normalize(output.outputs[0].path), 'main.js'));
           const content = virtualFs.fileBufferToString(host.scopedSync().read(path));
 
           switch (buildCount) {

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/base-href_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/base-href_spec.ts
@@ -33,7 +33,7 @@ describe('Browser Builder base href', () => {
     const output = (await run.result) as BrowserBuilderOutput;
 
     expect(output.success).toBe(true);
-    const fileName = join(normalize(output.outputPath), 'index.html');
+    const fileName = join(normalize(output.outputs[0].path), 'index.html');
     const content = virtualFs.fileBufferToString(await lastValueFrom(host.read(fileName)));
     expect(content).toMatch(/<base href="\/myUrl">/);
 
@@ -73,7 +73,7 @@ describe('Browser Builder base href', () => {
     const run = await architect.scheduleTarget(targetSpec, overrides);
     const output = (await run.result) as BrowserBuilderOutput;
     expect(output.success).toBe(true);
-    const fileName = join(normalize(output.outputPath), 'index.html');
+    const fileName = join(normalize(output.outputs[0].path), 'index.html');
     const content = virtualFs.fileBufferToString(
       await lastValueFrom(host.read(normalize(fileName))),
     );

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/build-optimizer_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/build-optimizer_spec.ts
@@ -44,7 +44,9 @@ describe('Browser Builder build optimizer', () => {
 
     expect(output.success).toBe(true);
 
-    const noBoStats = await lastValueFrom(host.stat(join(normalize(output.outputPath), 'main.js')));
+    const noBoStats = await lastValueFrom(
+      host.stat(join(normalize(output.outputs[0].path), 'main.js')),
+    );
     if (!noBoStats) {
       throw new Error('Main file has no stats');
     }
@@ -56,7 +58,7 @@ describe('Browser Builder build optimizer', () => {
     expect(boOutput.success).toBe(true);
 
     const boStats = await await lastValueFrom(
-      host.stat(join(normalize(output.outputPath), 'main.js')),
+      host.stat(join(normalize(output.outputs[0].path), 'main.js')),
     );
     if (!boStats) {
       throw new Error('Main file has no stats');

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/cross-origin_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/cross-origin_spec.ts
@@ -35,7 +35,7 @@ describe('Browser Builder crossOrigin', () => {
     const run = await architect.scheduleTarget(targetSpec, overrides);
     const output = (await run.result) as BrowserBuilderOutput;
     expect(output.success).toBe(true);
-    const fileName = join(normalize(output.outputPath), 'index.html');
+    const fileName = join(normalize(output.outputs[0].path), 'index.html');
     const content = virtualFs.fileBufferToString(
       await lastValueFrom(host.read(normalize(fileName))),
     );
@@ -55,7 +55,7 @@ describe('Browser Builder crossOrigin', () => {
     const run = await architect.scheduleTarget(targetSpec, overrides);
     const output = (await run.result) as BrowserBuilderOutput;
     expect(output.success).toBe(true);
-    const fileName = join(normalize(output.outputPath), 'index.html');
+    const fileName = join(normalize(output.outputs[0].path), 'index.html');
     const content = virtualFs.fileBufferToString(
       await lastValueFrom(host.read(normalize(fileName))),
     );
@@ -76,7 +76,7 @@ describe('Browser Builder crossOrigin', () => {
     const run = await architect.scheduleTarget(targetSpec, overrides);
     const output = (await run.result) as BrowserBuilderOutput;
     expect(output.success).toBe(true);
-    const fileName = join(normalize(output.outputPath), 'index.html');
+    const fileName = join(normalize(output.outputs[0].path), 'index.html');
     const content = virtualFs.fileBufferToString(
       await lastValueFrom(host.read(normalize(fileName))),
     );
@@ -103,7 +103,7 @@ describe('Browser Builder crossOrigin', () => {
     const output = (await run.result) as BrowserBuilderOutput;
     expect(output.success).toBe(true);
 
-    const fileName = join(normalize(output.outputPath), 'runtime.js');
+    const fileName = join(normalize(output.outputs[0].path), 'runtime.js');
     const content = virtualFs.fileBufferToString(
       await lastValueFrom(host.read(normalize(fileName))),
     );

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/deploy-url_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/deploy-url_spec.ts
@@ -36,8 +36,8 @@ describe('Browser Builder deploy url', () => {
     const run = await architect.scheduleTarget(targetSpec, overrides);
     const output = (await run.result) as BrowserBuilderOutput;
     expect(output.success).toBe(true);
-    expect(output.outputPath).not.toBeUndefined();
-    const outputPath = normalize(output.outputPath);
+    expect(output.outputs[0].path).not.toBeUndefined();
+    const outputPath = normalize(output.outputs[0].path);
 
     const fileName = join(outputPath, 'index.html');
     const runtimeFileName = join(outputPath, 'runtime.js');
@@ -52,7 +52,7 @@ describe('Browser Builder deploy url', () => {
 
     const run2 = await architect.scheduleTarget(targetSpec, overrides2);
     const output2 = (await run2.result) as BrowserBuilderOutput;
-    expect(output2.outputPath).toEqual(outputPath); // These should be the same.
+    expect(output2.outputs[0].path).toEqual(outputPath); // These should be the same.
 
     const content2 = virtualFs.fileBufferToString(
       await lastValueFrom(host.read(normalize(fileName))),

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/index_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/index_spec.ts
@@ -33,7 +33,7 @@ describe('Browser Builder index HTML processing', () => {
     const run = await architect.scheduleTarget(targetSpec);
     const output = (await run.result) as BrowserBuilderOutput;
     expect(output.success).toBe(true);
-    const fileName = join(normalize(output.outputPath), 'index.html');
+    const fileName = join(normalize(output.outputs[0].path), 'index.html');
     const content = virtualFs.fileBufferToString(
       await lastValueFrom(host.read(normalize(fileName))),
     );
@@ -58,7 +58,7 @@ describe('Browser Builder index HTML processing', () => {
     const run = await architect.scheduleTarget(targetSpec);
     const output = (await run.result) as BrowserBuilderOutput;
     expect(output.success).toBe(true);
-    const fileName = join(normalize(output.outputPath), 'index.html');
+    const fileName = join(normalize(output.outputs[0].path), 'index.html');
     const content = virtualFs.fileBufferToString(
       await lastValueFrom(host.read(normalize(fileName))),
     );
@@ -83,7 +83,7 @@ describe('Browser Builder index HTML processing', () => {
     const run = await architect.scheduleTarget(targetSpec);
     const output = (await run.result) as BrowserBuilderOutput;
     expect(output.success).toBe(true);
-    const fileName = join(normalize(output.outputPath), 'index.html');
+    const fileName = join(normalize(output.outputs[0].path), 'index.html');
     const content = virtualFs.fileBufferToString(
       await lastValueFrom(host.read(normalize(fileName))),
     );
@@ -107,7 +107,7 @@ describe('Browser Builder index HTML processing', () => {
     const run = await architect.scheduleTarget(targetSpec);
     const output = (await run.result) as BrowserBuilderOutput;
     expect(output.success).toBe(true);
-    const fileName = join(normalize(output.outputPath), 'index.html');
+    const fileName = join(normalize(output.outputs[0].path), 'index.html');
     const content = virtualFs.fileBufferToString(
       await lastValueFrom(host.read(normalize(fileName))),
     );

--- a/packages/angular_devkit/build_angular/src/builders/server/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/server/index.ts
@@ -46,15 +46,7 @@ import { Schema as ServerBuilderOptions } from './schema';
  */
 export type ServerBuilderOutput = BuilderOutput & {
   baseOutputPath: string;
-  /**
-   * @deprecated in version 14. Use 'outputs' instead.
-   */
-  outputPaths: string[];
-  /**
-   * @deprecated in version 9. Use 'outputs' instead.
-   */
   outputPath: string;
-
   outputs: {
     locale?: string;
     path: string;
@@ -172,8 +164,6 @@ export function execute(
       return {
         ...output,
         baseOutputPath,
-        outputPath: baseOutputPath,
-        outputPaths: outputPaths || [baseOutputPath],
         outputs: (outputPaths &&
           [...outputPaths.entries()].map(([locale, path]) => ({
             locale,


### PR DESCRIPTION


Remove the deprecated `outputPath` and `outputPaths` from the server and browser builder.

BREAKING CHANGE:

Deprecated `outputPath` and `outputPaths` from the server and browser builder have been removed from the builder output. Use `outputs` instead.

Note: this change does not effect application developers.
