### PR TITLE
fix(@angular-devkit/build-angular): improve parsing of error messages

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/utils/stats.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/utils/stats.ts
@@ -412,9 +412,9 @@ export function statsErrorsToString(
       // In most cases webpack will add stack traces to error messages.
       // This below cleans up the error from stacks.
       // See: https://github.com/webpack/webpack/issues/15980
-      const message = statsConfig.errorStack
-        ? error.message
-        : /[\s\S]+?(?=\n+\s+at\s)/.exec(error.message)?.[0] ?? error.message;
+      const index = error.message.search(/[\n\s]+at /);
+      const message =
+        statsConfig.errorStack || index === -1 ? error.message : error.message.substring(0, index);
 
       if (!/^error/i.test(message)) {
         output += r('Error: ');


### PR DESCRIPTION


Webpack errors can sometimes be several hundred of thousands of characters long as it may contain the entire bundle. This can cause a ReDoS. This change improves the way we parse and remove stack traces from error messages.

Closes #24771