### PR TITLE
feat(@schematics/angular): factor out logic from getRouterModuleDeclaration

### DIFF
--- a/packages/schematics/angular/utility/ast-utils.ts
+++ b/packages/schematics/angular/utility/ast-utils.ts
@@ -554,9 +554,15 @@ export function isImported(
 }
 
 /**
- * Returns the RouterModule declaration from NgModule metadata, if any.
+ * Returns the module declaration from NgModule metadata, by name, if exists.
+ * @param source the source object
+ * @param moduleName name of the module declaration to get
+ * @return module declaration
  */
-export function getRouterModuleDeclaration(source: ts.SourceFile): ts.Expression | undefined {
+export function getModuleDeclarationByName(
+  source: ts.SourceFile,
+  moduleName: string,
+): ts.Expression | undefined {
   const result = getDecoratorMetadata(source, 'NgModule', '@angular/core');
   const node = result[0];
   if (!node || !ts.isObjectLiteralExpression(node)) {
@@ -578,7 +584,14 @@ export function getRouterModuleDeclaration(source: ts.SourceFile): ts.Expression
 
   return arrLiteral.elements
     .filter((el) => el.kind === ts.SyntaxKind.CallExpression)
-    .find((el) => (el as ts.Identifier).getText().startsWith('RouterModule'));
+    .find((el) => (el as ts.Identifier).getText().startsWith(moduleName));
+}
+
+/**
+ * Returns the RouterModule declaration from NgModule metadata, if exists.
+ */
+export function getRouterModuleDeclaration(source: ts.SourceFile): ts.Expression | undefined {
+  return getModuleDeclarationByName(source, 'RouterModule');
 }
 
 /**


### PR DESCRIPTION

Can now get module declarations of modules other than RouterModule. This is useful for adding a custom declaration to module using schematics. Checking the spec files will show a use case for this new feature, now the getModuleDeclarationByName function can be used to get the module declaration of a custom module, in this case ngxsModule.

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [ x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x ] Tests for the changes have been added (for bug fixes / features)
- [x ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

The logic of getting module declaration was tied up in getRouterModuleDeclaration. This limits us from using that function to get other Modules.
On my personal project I am working on schematics that add new Ngxs States, including adding them to the NgxsModule in the NgModule.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
These modifications will allow me to use the angular schematics utility functions to assist me with my personal project.
<!-- Please describe the new behavior that. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
