### PR TITLE
fix(@angular-devkit/build-angular): build optimizer support for non spec-compliant ES2022 class static properties

### DIFF
--- a/packages/angular_devkit/build_angular/src/babel/plugins/adjust-static-class-members_spec.ts
+++ b/packages/angular_devkit/build_angular/src/babel/plugins/adjust-static-class-members_spec.ts
@@ -669,6 +669,42 @@ describe('adjust-static-class-members Babel plugin', () => {
     });
   });
 
+  it('wraps class with Angular ɵfac static block (ES2022 + useDefineForClassFields: false)', () => {
+    testCase({
+      input: `
+        class CommonModule {
+          static { this.ɵfac = function CommonModule_Factory(t) { return new (t || CommonModule)(); }; }
+          static { this.ɵmod = ɵngcc0.ɵɵdefineNgModule({ type: CommonModule }); }
+        }
+      `,
+      expected: `
+        let CommonModule = /*#__PURE__*/ (() => {
+          class CommonModule {
+            static {
+              this.ɵfac = function CommonModule_Factory(t) {
+                return new (t || CommonModule)();
+              };
+            }
+            static {
+              this.ɵmod = ɵngcc0.ɵɵdefineNgModule({
+                type: CommonModule,
+              });
+            }
+          }
+          return CommonModule;
+        })();
+      `,
+    });
+  });
+
+  it('does not wrap class with side effect full static block (ES2022 + useDefineForClassFields: false)', () => {
+    testCaseNoChange(`
+        class CommonModule {
+          static { globalThis.bar = 1 }
+        }
+      `);
+  });
+
   it('wraps class with Angular ɵmod static field', () => {
     testCase({
       input: `


### PR DESCRIPTION

The build optimizer's static field pass will now additionally wrap classes that contain side effect free TypeScript ES2022 static class properties.

This is needed to update APF to ship ES2022, which have `useDefineForClassFields` set to `false`.
