### PR TITLE
fix(@angular-devkit/schematics-cli):  correctly transform numbers from prompts

### DIFF
--- a/packages/angular_devkit/schematics_cli/bin/schematics.ts
+++ b/packages/angular_devkit/schematics_cli/bin/schematics.ts
@@ -79,6 +79,32 @@ function _createPromptProvider(): schema.PromptProvider {
       const validator = definition.validator;
       if (validator) {
         question.validate = (input) => validator(input);
+
+        // Filter allows transformation of the value prior to validation
+        question.filter = async (input) => {
+          for (const type of definition.propertyTypes) {
+            let value;
+            switch (type) {
+              case 'string':
+                value = String(input);
+                break;
+              case 'integer':
+              case 'number':
+                value = Number(input);
+                break;
+              default:
+                value = input;
+                break;
+            }
+            // Can be a string if validation fails
+            const isValid = (await validator(value)) === true;
+            if (isValid) {
+              return value;
+            }
+          }
+
+          return input;
+        };
       }
 
       switch (definition.type) {


### PR DESCRIPTION


This commits ports the same logic from the `@angular/cli` (https://github.com/angular/angular-cli/blob/693d78b80de9e91bd5313353ea5c524742196e0a/packages/angular/cli/src/command-builder/schematics-command-module.ts#L183-L211) to correctly handle numbers in prompts.

Closes #24817
