### PR TITLE
test: update webpack E2E test to use zone.js 0.13

### DIFF
--- a/tests/legacy-cli/e2e/assets/webpack/test-app/package.json
+++ b/tests/legacy-cli/e2e/assets/webpack/test-app/package.json
@@ -11,7 +11,7 @@
     "@angular/router": "^16.0.0-next",
     "@ngtools/webpack": "0.0.0",
     "rxjs": "^6.6.7",
-    "zone.js": "^0.11.4"
+    "zone.js": "^0.13.0"
   },
   "devDependencies": {
     "sass": "^1.32.8",


### PR DESCRIPTION
The latest next release of FW (16.0.0-next.2) now requires zone.js 0.13.