### PR TITLE
fix(@angular-devkit/build-angular): correct wrap ES2022 classes with static properties

### DIFF
--- a/packages/angular_devkit/build_angular/src/babel/plugins/adjust-static-class-members.ts
+++ b/packages/angular_devkit/build_angular/src/babel/plugins/adjust-static-class-members.ts
@@ -271,7 +271,7 @@ export default function (): PluginObj {
               if (
                 elementKey.isIdentifier() &&
                 (!elementValue.isExpression() ||
-                  canWrapProperty(elementKey.get('name'), elementValue))
+                  canWrapProperty(elementKey.node.name, elementValue))
               ) {
                 shouldWrap = true;
               } else {

--- a/packages/angular_devkit/build_angular/src/babel/plugins/adjust-static-class-members_spec.ts
+++ b/packages/angular_devkit/build_angular/src/babel/plugins/adjust-static-class-members_spec.ts
@@ -783,9 +783,9 @@ describe('adjust-static-class-members Babel plugin', () => {
         class CommonModule {
           static ɵfac = function CommonModule_Factory(t) { return new (t || CommonModule)(); };
           static ɵmod = /*@__PURE__*/ ɵngcc0.ɵɵdefineNgModule({ type: CommonModule });
-          static ɵinj = /*@__PURE__*/ ɵngcc0.ɵɵdefineInjector({ providers: [
-                  { provide: NgLocalization, useClass: NgLocaleLocalization },
-              ] });
+          static ɵinj = ɵngcc0.ɵɵdefineInjector({ providers: [
+            { provide: NgLocalization, useClass: NgLocaleLocalization },
+        ] });
         }
       `,
       expected: `
@@ -797,7 +797,7 @@ describe('adjust-static-class-members Babel plugin', () => {
             static ɵmod = /*@__PURE__*/ ɵngcc0.ɵɵdefineNgModule({
               type: CommonModule,
             });
-            static ɵinj = /*@__PURE__*/ ɵngcc0.ɵɵdefineInjector({
+            static ɵinj = ɵngcc0.ɵɵdefineInjector({
               providers: [
                 {
                   provide: NgLocalization,


### PR DESCRIPTION


Prior to this commit, we only wrapped classes with static properties that were marked with `/*@__PURE__*/` comment due to a bug in the `adjust-static-class-members` Babel plugin were we did not call the `Identifier` name text to the `canWrapProperty` function.
