### PR TITLE
fix(@angular-devkit/build-angular): set public class fields as properties

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
@@ -411,6 +411,13 @@ export async function getCommonConfig(wco: WebpackConfigOptions): Promise<Config
             {
               loader: require.resolve('../../babel/webpack-loader'),
               options: {
+                assumptions: {
+                  // Use `setPublicClassFields: true` to avoid decrease bundle sizes
+                  // when targetting ES2022+ with `useDefineForClassFields: true`.
+                  // This is because ervery property of the class will otherwise be wrapped in a `_defineProperty`.
+                  // This is not needed for TypeScript as TS itself will emit the right decleration of class properties.
+                  setPublicClassFields: true,
+                },
                 cacheDirectory: (cache.enabled && path.join(cache.path, 'babel-webpack')) || false,
                 aot: buildOptions.aot,
                 optimize: buildOptions.buildOptimizer,

--- a/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
@@ -415,7 +415,7 @@ export async function getCommonConfig(wco: WebpackConfigOptions): Promise<Config
                   // Use `setPublicClassFields: true` to avoid decrease bundle sizes
                   // when targetting ES2022+ with `useDefineForClassFields: true`.
                   // This is because ervery property of the class will otherwise be wrapped in a `_defineProperty`.
-                  // This is not needed for TypeScript as TS itself will emit the right decleration of class properties.
+                  // This is not needed for TypeScript as TS itself will emit the right declaration of class properties.
                   setPublicClassFields: true,
                 },
                 cacheDirectory: (cache.enabled && path.join(cache.path, 'babel-webpack')) || false,


### PR DESCRIPTION

Configure Babel to use `setPublicClassFields: true`. As when shipping Angular packages without `"useDefineForClassFields": false` will increase the bundle size of an ng-new app by ~2Kb when `useDefineForClassFields`  is not false. due to the additional `_defineProperty`, which will be added on every class property.

See: https://babeljs.io/docs/babel-plugin-proposal-class-properties

