### PR TITLE
refactor(@angular-devkit/build-angular): consolidate result file writes in esbuild builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/copy-assets.ts
+++ b/packages/angular_devkit/build_angular/src/utils/copy-assets.ts
@@ -28,6 +28,8 @@ export async function copyAssets(
 ) {
   const defaultIgnore = ['.gitkeep', '**/.DS_Store', '**/Thumbs.db'];
 
+  const outputFiles: { source: string; destination: string }[] = [];
+
   for (const entry of entries) {
     const cwd = path.resolve(root, entry.input);
     const files = await globPromise(entry.glob, {
@@ -49,6 +51,9 @@ export async function copyAssets(
       }
 
       const filePath = entry.flatten ? path.basename(file) : file;
+
+      outputFiles.push({ source: src, destination: path.join(entry.output, filePath) });
+
       for (const base of basePaths) {
         const dest = path.join(base, entry.output, filePath);
         const dir = path.dirname(dest);
@@ -62,4 +67,6 @@ export async function copyAssets(
       }
     }
   }
+
+  return outputFiles;
 }


### PR DESCRIPTION
As a preparation step to allow for in-memory build outputs to support the development server, the output result files of the build are now written to the file system in one location. This includes the generated files from the bundling steps as well as any assets and service worker files.