### PR TITLE
test: add a standard decorator support E2E test

### DIFF
--- a/tests/legacy-cli/e2e/tests/build/ts-standard-decorators.ts
+++ b/tests/legacy-cli/e2e/tests/build/ts-standard-decorators.ts
@@ -1,0 +1,27 @@
+import { ng } from '../../utils/process';
+import { updateTsConfig } from '../../utils/project';
+
+export default async function () {
+  // Update project to disable experimental decorators
+  await updateTsConfig((json) => {
+    json['compilerOptions']['experimentalDecorators'] = false;
+  });
+
+  // Default production build
+  await ng('build');
+
+  // Production build with JIT
+  await ng('build', '--no-aot', '--no-build-optimizer');
+
+  // Default development build
+  await ng('build', '--configuration=development');
+
+  // Development build with JIT
+  await ng('build', '--configuration=development', '--no-aot');
+
+  // Unit tests (JIT only)
+  await ng('test', '--no-watch');
+
+  // E2E tests to ensure application functions in a browser
+  await ng('e2e');
+}


### PR DESCRIPTION
The added E2E test checks that it is possible to compile an application with experimental decorators disabled. The test also executes the unit tests inside a CLI generated project.

~~NOTE: This relies on the snapshot artifact build of `@angular/core` from FW PR: https://github.com/angular/angular/pull/49492~~ (merged)