### PR TITLE
feat(@angular-devkit/build-angular): initial tailwindcss support for CSS in esbuild builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
@@ -285,6 +285,7 @@ function createCodeBundleOptions(
     advancedOptimizations,
     inlineStyleLanguage,
     jit,
+    tailwindConfiguration,
   } = options;
 
   return {
@@ -339,6 +340,7 @@ function createCodeBundleOptions(
           target,
           inlineStyleLanguage,
           browsers,
+          tailwindConfiguration,
         },
       ),
     ],
@@ -417,6 +419,7 @@ function createGlobalStylesBundleOptions(
     preserveSymlinks,
     externalDependencies,
     stylePreprocessorOptions,
+    tailwindConfiguration,
   } = options;
 
   const buildOptions = createStylesheetBundleOptions({
@@ -429,6 +432,7 @@ function createGlobalStylesBundleOptions(
     outputNames,
     includePaths: stylePreprocessorOptions?.includePaths,
     browsers,
+    tailwindConfiguration,
   });
   buildOptions.legalComments = options.extractLicenses ? 'none' : 'eof';
 

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/stylesheets.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/stylesheets.ts
@@ -29,6 +29,7 @@ export interface BundleStylesheetOptions {
   externalDependencies?: string[];
   target: string[];
   browsers: string[];
+  tailwindConfiguration?: { file: string; package: string };
 }
 
 export function createStylesheetBundleOptions(
@@ -72,6 +73,7 @@ export function createStylesheetBundleOptions(
         sourcemap: !!options.sourcemap,
         inlineComponentData,
         browsers: options.browsers,
+        tailwindConfiguration: options.tailwindConfiguration,
       }),
       createCssResourcePlugin(),
     ],

--- a/tests/legacy-cli/e2e.bzl
+++ b/tests/legacy-cli/e2e.bzl
@@ -29,7 +29,15 @@ TEST_TAGS = ["no-remote-exec", "requires-network"]
 # Subset of tests for yarn/esbuild
 BROWSER_TESTS = ["tests/misc/browsers.js"]
 YARN_TESTS = ["tests/basic/**", "tests/update/**", "tests/commands/add/**"]
-ESBUILD_TESTS = ["tests/basic/**", "tests/build/prod-build.js", "tests/build/relative-sourcemap.js", "tests/build/styles/scss.js", "tests/build/styles/include-paths.js", "tests/commands/add/add-pwa.js"]
+ESBUILD_TESTS = [
+    "tests/basic/**",
+    "tests/build/prod-build.js",
+    "tests/build/relative-sourcemap.js",
+    "tests/build/styles/scss.js",
+    "tests/build/styles/include-paths.js",
+    "tests/build/styles/tailwind*.js",
+    "tests/commands/add/add-pwa.js",
+]
 
 # Tests excluded for esbuild
 ESBUILD_IGNORE_TESTS = [


### PR DESCRIPTION
When using the experimental esbuild-based browser application builder, CSS stylesheets will now be processed by tailwindcss if a tailwind configuration file is present and the `tailwindcss` package has been installed in the project. This provides equivalent behavior to the use of tailwind with the current default Webpack-based build system. Currently, only CSS stylesheets are processed. Preprocessor support including Sass and Less will be added in a future change.