### PR TITLE
fix(@schematics/angular): remove import from standalone test

### DIFF
--- a/packages/schematics/angular/application/files/standalone-files/src/app/app.component.spec.ts.template
+++ b/packages/schematics/angular/application/files/standalone-files/src/app/app.component.spec.ts.template
@@ -3,9 +3,7 @@ import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [AppComponent],
-    }).compileComponents();
+    await TestBed.configureTestingModule({}).compileComponents();
   });
 
   it('should create the app', () => {

--- a/packages/schematics/angular/component/files/__name@dasherize@if-flat__/__name@dasherize__.__type@dasherize__.spec.ts.template
+++ b/packages/schematics/angular/component/files/__name@dasherize@if-flat__/__name@dasherize__.__type@dasherize__.spec.ts.template
@@ -8,7 +8,7 @@ describe('<%= classify(name) %><%= classify(type) %>', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      <%= standalone ? 'imports' : 'declarations' %>: [ <%= classify(name) %><%= classify(type) %> ]
+      <% if(!standalone) { %>declarations: [<%= classify(name) %><%= classify(type) %>]<% } %>
     })
     .compileComponents();
 

--- a/packages/schematics/angular/component/index_spec.ts
+++ b/packages/schematics/angular/component/index_spec.ts
@@ -427,11 +427,11 @@ describe('Component Schematic', () => {
     expect(componentContent).toContain('imports: [CommonModule]');
   });
 
-  it('should declare standalone components in the `imports` of a test', async () => {
+  it('should not declare standalone components in the `imports` or `declarations` of a test', async () => {
     const options = { ...defaultOptions, standalone: true };
     const tree = await schematicRunner.runSchematic('component', options, appTree);
     const testContent = tree.readContent('/projects/bar/src/app/foo/foo.component.spec.ts');
-    expect(testContent).toContain('imports: [ FooComponent ]');
+    expect(testContent).not.toContain('imports');
     expect(testContent).not.toContain('declarations');
   });
 });


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

The generated test for a component imports the standalone component to test it,
whereas it should not be necessary.

## What is the new behavior?

The `imports` is no longer generated for component tests


<!-- Please describe the new behavior that. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
