### PR TITLE
fix(@schematics/angular): trailing space in standalone decorator

### DIFF
--- a/packages/schematics/angular/application/files/standalone-files/src/app/app.component.ts.template
+++ b/packages/schematics/angular/application/files/standalone-files/src/app/app.component.ts.template
@@ -32,7 +32,7 @@ import { RouterOutlet } from '@angular/router';<% } %>
   `,<% } else { %>
   templateUrl: './app.component.html',<% } if(inlineStyle) { %>
   styles: [],<% } else { %>
-  styleUrls: ['./app.component.<%= style %>'], <% } %>
+  styleUrls: ['./app.component.<%= style %>'],<% } %>
   imports: [CommonModule<% if(routing) { %>, RouterOutlet<% } %>]
 })
 export class AppComponent {


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

The standalone `AppComponent` has a trailing space in the generated code for the decorator after `styleUrls` (whereas there are none after the other properties).

## What is the new behavior?

This removes the trailing space

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
