### PR TITLE
ci: disable windows job on PRs

### DIFF
--- a/.circleci/dynamic_config.yml
+++ b/.circleci/dynamic_config.yml
@@ -462,7 +462,8 @@ workflows:
             - build
 
       # Windows jobs
-      - e2e-cli-win
+      - e2e-cli-win:
+          <<: *only_release_branches
 
       # Publish jobs
       - snapshot_publish:


### PR DESCRIPTION
Currently CLI's windows testing accounts for ~40% of all of our credit usage. This job is more of a sanity check and running only on release branches should suffice.
