### PR TITLE
feat(@schematics/angular): remove generation of  `BrowserModule.withServerTransition`

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/app-shell/app-shell_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/app-shell/app-shell_spec.ts
@@ -58,7 +58,7 @@ describe('AppShell Builder', () => {
           AppComponent
         ],
         imports: [
-          BrowserModule.withServerTransition({ appId: 'serverApp' }),
+          BrowserModule,
           AppRoutingModule,
           RouterModule
         ],
@@ -116,14 +116,6 @@ describe('AppShell Builder', () => {
   };
 
   it('works (basic)', async () => {
-    host.replaceInFile(
-      'src/app/app.module.ts',
-      / {4}BrowserModule/,
-      `
-      BrowserModule.withServerTransition({ appId: 'some-app' })
-    `,
-    );
-
     const run = await architect.scheduleTarget(target);
     const output = await run.result;
     await run.stop();

--- a/packages/schematics/angular/app-shell/schema.json
+++ b/packages/schematics/angular/app-shell/schema.json
@@ -22,7 +22,8 @@
       "type": "string",
       "format": "html-selector",
       "description": "The application ID to use in withServerTransition().",
-      "default": "serverApp"
+      "default": "serverApp",
+      "x-deprecated": "This option is no longer used."
     },
     "main": {
       "type": "string",

--- a/packages/schematics/angular/universal/index_spec.ts
+++ b/packages/schematics/angular/universal/index_spec.ts
@@ -151,46 +151,6 @@ describe('Universal Schematic', () => {
     expect(targets.build.options.outputPath).toEqual('dist/bar/browser');
   });
 
-  it('should add a server transition to BrowserModule import', async () => {
-    const tree = await schematicRunner.runSchematic('universal', defaultOptions, appTree);
-    const filePath = '/projects/bar/src/app/app.module.ts';
-    const contents = tree.readContent(filePath);
-    expect(contents).toMatch(/BrowserModule\.withServerTransition\({ appId: 'serverApp' }\)/);
-  });
-
-  it('should replace existing `withServerTransition` in BrowserModule import', async () => {
-    const filePath = '/projects/bar/src/app/app.module.ts';
-    appTree.overwrite(
-      filePath,
-      `
-      import { NgModule } from '@angular/core';
-      import { BrowserModule } from '@angular/platform-browser';
-
-      import { AppRoutingModule } from './app-routing.module';
-      import { AppComponent } from './app.component';
-
-      @NgModule({
-        declarations: [
-          AppComponent
-        ],
-        imports: [
-          BrowserModule.withServerTransition({ appId: 'foo' }),
-          AppRoutingModule
-        ],
-        providers: [],
-        bootstrap: [AppComponent]
-      })
-      export class AppModule { }
-    `,
-    );
-    const tree = await schematicRunner.runSchematic('universal', defaultOptions, appTree);
-    const contents = tree.readContent(filePath);
-    console.log(contents);
-
-    expect(contents).toContain(`BrowserModule.withServerTransition({ appId: 'serverApp' }),`);
-    expect(contents).not.toContain(`withServerTransition({ appId: 'foo' })`);
-  });
-
   it('should install npm dependencies', async () => {
     await schematicRunner.runSchematic('universal', defaultOptions, appTree);
     expect(schematicRunner.tasks.length).toBe(1);

--- a/packages/schematics/angular/universal/schema.json
+++ b/packages/schematics/angular/universal/schema.json
@@ -17,7 +17,8 @@
       "type": "string",
       "format": "html-selector",
       "description": "The application identifier to use for transition.",
-      "default": "serverApp"
+      "default": "serverApp",
+      "x-deprecated": "This option is no longer used."
     },
     "main": {
       "type": "string",

--- a/packages/schematics/angular/utility/ng-ast-utils.ts
+++ b/packages/schematics/angular/utility/ng-ast-utils.ts
@@ -46,7 +46,7 @@ export function findBootstrapModuleCall(host: Tree, mainPath: string): ts.CallEx
   return bootstrapCall;
 }
 
-export function findBootstrapModulePath(host: Tree, mainPath: string): string {
+function findBootstrapModulePath(host: Tree, mainPath: string): string {
   const bootstrapCall = findBootstrapModuleCall(host, mainPath);
   if (!bootstrapCall) {
     throw new SchematicsException('Bootstrap call not found');

--- a/tests/legacy-cli/e2e/tests/build/app-shell/app-shell-standalone.ts
+++ b/tests/legacy-cli/e2e/tests/build/app-shell/app-shell-standalone.ts
@@ -68,7 +68,7 @@ export default async function () {
 
       export default () => bootstrapApplication(AppComponent, {
         providers: [
-          importProvidersFrom(BrowserModule.withServerTransition({ appId: 'app' })),
+          importProvidersFrom(BrowserModule),
           importProvidersFrom(ServerModule),
           provideRouter([{ path: 'shell', component: AppShellComponent }]),
         ],


### PR DESCRIPTION


 This commit removes generation of `.withServerTransition` in the universal schematic as is deprecated.

 DEPRECATED: the `app-id` option in the app-shell and universal schematics has been deprecated without replacement. See: https://github.com/angular/angular/pull/49422 for more information about the rational of this change.
