### PR TITLE
fix(@schematics/angular): use same property order in standalone AppComponent

### DIFF
--- a/packages/schematics/angular/application/files/standalone-files/src/app/app.component.ts.template
+++ b/packages/schematics/angular/application/files/standalone-files/src/app/app.component.ts.template
@@ -4,7 +4,8 @@ import { RouterOutlet } from '@angular/router';<% } %>
 
 @Component({
   selector: '<%= selector %>',
-  standalone: true,<% if(inlineTemplate) { %>
+  standalone: true,
+  imports: [CommonModule<% if(routing) { %>, RouterOutlet<% } %>],<% if(inlineTemplate) { %>
   template: `
     <!--The content below is only a placeholder and can be replaced.-->
     <div style="text-align:center" class="content">
@@ -32,8 +33,7 @@ import { RouterOutlet } from '@angular/router';<% } %>
   `,<% } else { %>
   templateUrl: './app.component.html',<% } if(inlineStyle) { %>
   styles: [],<% } else { %>
-  styleUrls: ['./app.component.<%= style %>'], <% } %>
-  imports: [CommonModule<% if(routing) { %>, RouterOutlet<% } %>]
+  styleUrls: ['./app.component.<%= style %>']<% } %>
 })
 export class AppComponent {
   title = '<%= name %>';


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently, the standalone `app.component.ts` looks like:
```ts
@Component({
  selector: 'app-root',
  standalone: true,
  templateUrl: './app.component.html',
  styleUrls: ['./app.component.css'], 
  imports: [CommonModule]
})
```
whereas a generated component looks like:
```ts
@Component({
  selector: 'app-user',
  standalone: true,
  imports: [CommonModule],
  templateUrl: './user.component.html',
  styleUrls: ['./user.component.css']
})
```

Note that the imports are not always in the same place.

## What is the new behavior?

The imports are moved to a similar place than in other components.

Note that we could choose the other option (change it in the component template instead of app.component.ts),
but as `app.component.ts` is the most recent, I chose to update this one

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This can replace #24905
