### PR TITLE
feat(@schematics/angular): Update universal schematic to support standalone applications

### DIFF
--- a/packages/schematics/angular/universal/files/standalone-src/app/app.config.server.ts.template
+++ b/packages/schematics/angular/universal/files/standalone-src/app/app.config.server.ts.template
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { mergeApplicationConfig, ApplicationConfig } from '@angular/core';
+import { provideServerSupport } from '@angular/platform-server';
+import { appConfig } from './app.config';
+
+const serverConfig: ApplicationConfig = {
+  providers: [
+    provideServerSupport()
+  ]
+};
+
+export const config = mergeApplicationConfig(appConfig, serverConfig);

--- a/packages/schematics/angular/universal/files/standalone-src/main.server.ts.template
+++ b/packages/schematics/angular/universal/files/standalone-src/main.server.ts.template
@@ -1,0 +1,15 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { bootstrapApplication } from '@angular/platform-browser';
+import { AppComponent } from './app/app.component';
+import { config } from './app/app.config.server';
+
+const bootstrap = () => bootstrapApplication(AppComponent, config);
+
+export default bootstrap;

--- a/packages/schematics/angular/universal/index.ts
+++ b/packages/schematics/angular/universal/index.ts
@@ -17,6 +17,7 @@ import {
   chain,
   mergeWith,
   move,
+  noop,
   strings,
   url,
 } from '@angular-devkit/schematics';
@@ -27,6 +28,7 @@ import {
   getPackageJsonDependency,
 } from '../utility/dependencies';
 import { latestVersions } from '../utility/latest-versions';
+import { isStandaloneApp } from '../utility/ng-ast-utils';
 import { relativePathToWorkspaceRoot } from '../utility/paths';
 import { targetBuildNotFoundError } from '../utility/project-targets';
 import { getWorkspace, updateWorkspace } from '../utility/workspace';
@@ -133,7 +135,9 @@ export default function (options: UniversalOptions): Rule {
       context.addTask(new NodePackageInstallTask());
     }
 
-    const templateSource = apply(url('./files/src'), [
+    const isStandalone = isStandaloneApp(host, clientBuildOptions.main);
+
+    const templateSource = apply(url(isStandalone ? './files/standalone-src' : './files/src'), [
       applyTemplates({
         ...strings,
         ...options,

--- a/packages/schematics/angular/universal/index_spec.ts
+++ b/packages/schematics/angular/universal/index_spec.ts
@@ -188,4 +188,55 @@ describe('Universal Schematic', () => {
     };
     expect(compilerOptions.types).toContain('@angular/localize');
   });
+
+  describe('standalone application', () => {
+    let standaloneAppOptions;
+    let defaultStandaloneOptions: UniversalOptions;
+    beforeEach(async () => {
+      const standaloneAppName = 'baz';
+      standaloneAppOptions = {
+        ...appOptions,
+        name: standaloneAppName,
+        standalone: true,
+      };
+      defaultStandaloneOptions = {
+        project: standaloneAppName,
+      };
+      appTree = await schematicRunner.runSchematic('application', standaloneAppOptions, appTree);
+    });
+
+    it('should create not root module file', async () => {
+      const tree = await schematicRunner.runSchematic(
+        'universal',
+        defaultStandaloneOptions,
+        appTree,
+      );
+      const filePath = '/projects/baz/src/app/app.server.module.ts';
+      expect(tree.exists(filePath)).toEqual(false);
+    });
+
+    it('should create a main file', async () => {
+      const tree = await schematicRunner.runSchematic(
+        'universal',
+        defaultStandaloneOptions,
+        appTree,
+      );
+      const filePath = '/projects/baz/src/main.server.ts';
+      expect(tree.exists(filePath)).toEqual(true);
+      const contents = tree.readContent(filePath);
+      expect(contents).toContain(`bootstrapApplication(AppComponent, config)`);
+    });
+
+    it('should create server app config file', async () => {
+      const tree = await schematicRunner.runSchematic(
+        'universal',
+        defaultStandaloneOptions,
+        appTree,
+      );
+      const filePath = '/projects/baz/src/app/app.config.server.ts';
+      expect(tree.exists(filePath)).toEqual(true);
+      const contents = tree.readContent(filePath);
+      expect(contents).toContain(`const serverConfig: ApplicationConfig = {`);
+    });
+  });
 });

--- a/packages/schematics/angular/utility/ng-ast-utils.ts
+++ b/packages/schematics/angular/utility/ng-ast-utils.ts
@@ -9,6 +9,7 @@
 import { normalize } from '@angular-devkit/core';
 import { SchematicsException, Tree } from '@angular-devkit/schematics';
 import { dirname } from 'path';
+import { findBootstrapApplicationCall } from '../private/standalone';
 import * as ts from '../third_party/github.com/Microsoft/TypeScript/lib/typescript';
 import { findNode, getSourceNodes } from '../utility/ast-utils';
 
@@ -77,4 +78,16 @@ export function getAppModulePath(host: Tree, mainPath: string): string {
   const modulePath = normalize(`/${mainDir}/${moduleRelativePath}.ts`);
 
   return modulePath;
+}
+
+export function isStandaloneApp(host: Tree, mainPath: string): boolean {
+  const source = ts.createSourceFile(
+    mainPath,
+    host.readText(mainPath),
+    ts.ScriptTarget.Latest,
+    true,
+  );
+  const bootstrapCall = findBootstrapApplicationCall(source);
+
+  return bootstrapCall !== null;
 }


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently running universal schematic does not support standalone applications.

Issue Number: #23976

## What is the new behavior?

Running the universal schematic will add the necessary files and not attempt to update existing app modules files that do not exist in standalone applications.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This is a follow up to #24848 which introduced the standalone flag to application generation.