### PR TITLE
test: ensure esbuild and yarn E2E tests are executed

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/css-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/css-plugin.ts
@@ -71,7 +71,7 @@ export function createCssPlugin(options: CssPluginOptions): Plugin {
       const postcssProcessor = postcss();
       if (options.tailwindConfiguration) {
         const tailwind = await import(options.tailwindConfiguration.package);
-        postcssProcessor.use(tailwind({ config: options.tailwindConfiguration.file }));
+        postcssProcessor.use(tailwind.default({ config: options.tailwindConfiguration.file }));
       }
       if (!skipAutoprefixer) {
         postcssProcessor.use(autoprefixer);

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/options.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/options.ts
@@ -105,7 +105,8 @@ export async function normalizeOptions(
   let tailwindConfiguration: { file: string; package: string } | undefined;
   const tailwindConfigurationPath = findTailwindConfigurationFile(workspaceRoot, projectRoot);
   if (tailwindConfigurationPath) {
-    const resolver = createRequire(projectRoot);
+    // Create a node resolver at the project root as a directory
+    const resolver = createRequire(projectRoot + '/');
     try {
       tailwindConfiguration = {
         file: tailwindConfigurationPath,

--- a/tests/legacy-cli/e2e.bzl
+++ b/tests/legacy-cli/e2e.bzl
@@ -155,7 +155,7 @@ def _e2e_suite(name, runner, type, data, toolchain_name = "", toolchain = None):
         data = data,
         toolchain = toolchain,
         shard_count = TEST_SHARD_COUNT,
-        templated_args = [
+        templated_args = args + [
             "--glob=%s" % _to_glob(tests) if tests else "",
             "--ignore=%s" % _to_glob(ignore) if ignore else "",
         ],

--- a/tests/legacy-cli/e2e/tests/build/styles/tailwind-v2.ts
+++ b/tests/legacy-cli/e2e/tests/build/styles/tailwind-v2.ts
@@ -24,8 +24,14 @@ export default async function () {
   }
 
   // Tailwind directives should be unprocessed with missing package
-  await expectFileToMatch('dist/test-project/styles.css', '@tailwind base; @tailwind components;');
-  await expectFileToMatch('dist/test-project/main.js', '@tailwind base; @tailwind components;');
+  await expectFileToMatch(
+    'dist/test-project/styles.css',
+    /@tailwind base;\s+@tailwind components;/,
+  );
+  await expectFileToMatch(
+    'dist/test-project/main.js',
+    /@tailwind base;(?:\\n|\s*)@tailwind components;/,
+  );
 
   // Install Tailwind
   await installPackage('tailwindcss@2');
@@ -37,10 +43,13 @@ export default async function () {
   await expectFileToMatch('dist/test-project/styles.css', /::placeholder/);
   await expectFileToMatch('dist/test-project/main.js', /::placeholder/);
   await expectToFail(() =>
-    expectFileToMatch('dist/test-project/styles.css', '@tailwind base; @tailwind components;'),
+    expectFileToMatch('dist/test-project/styles.css', /@tailwind base;\s+@tailwind components;/),
   );
   await expectToFail(() =>
-    expectFileToMatch('dist/test-project/main.js', '@tailwind base; @tailwind components;'),
+    expectFileToMatch(
+      'dist/test-project/main.js',
+      /@tailwind base;(?:\\n|\s*)@tailwind components;/,
+    ),
   );
 
   // Remove configuration file
@@ -48,8 +57,14 @@ export default async function () {
 
   // Ensure Tailwind is disabled when no configuration file is present
   await ng('build', '--configuration=development');
-  await expectFileToMatch('dist/test-project/styles.css', '@tailwind base; @tailwind components;');
-  await expectFileToMatch('dist/test-project/main.js', '@tailwind base; @tailwind components;');
+  await expectFileToMatch(
+    'dist/test-project/styles.css',
+    /@tailwind base;\s+@tailwind components;/,
+  );
+  await expectFileToMatch(
+    'dist/test-project/main.js',
+    /@tailwind base;(?:\\n|\s*)@tailwind components;/,
+  );
 
   // Uninstall Tailwind
   await uninstallPackage('tailwindcss');

--- a/tests/legacy-cli/e2e/tests/build/styles/tailwind-v3-cjs.ts
+++ b/tests/legacy-cli/e2e/tests/build/styles/tailwind-v3-cjs.ts
@@ -29,7 +29,7 @@ export default async function () {
   // Check for Tailwind output
   await expectFileToMatch('dist/test-project/styles.css', /::placeholder/);
   await expectToFail(() =>
-    expectFileToMatch('dist/test-project/styles.css', '@tailwind base; @tailwind components;'),
+    expectFileToMatch('dist/test-project/styles.css', /@tailwind base;\s+@tailwind components;/),
   );
 
   // Uninstall Tailwind

--- a/tests/legacy-cli/e2e/tests/build/styles/tailwind-v3.ts
+++ b/tests/legacy-cli/e2e/tests/build/styles/tailwind-v3.ts
@@ -24,8 +24,14 @@ export default async function () {
   }
 
   // Tailwind directives should be unprocessed with missing package
-  await expectFileToMatch('dist/test-project/styles.css', '@tailwind base; @tailwind components;');
-  await expectFileToMatch('dist/test-project/main.js', '@tailwind base; @tailwind components;');
+  await expectFileToMatch(
+    'dist/test-project/styles.css',
+    /@tailwind base;\s+@tailwind components;/,
+  );
+  await expectFileToMatch(
+    'dist/test-project/main.js',
+    /@tailwind base;(?:\\n|\s*)@tailwind components;/,
+  );
 
   // Install Tailwind
   await installPackage('tailwindcss@3');
@@ -37,10 +43,13 @@ export default async function () {
   await expectFileToMatch('dist/test-project/styles.css', /::placeholder/);
   await expectFileToMatch('dist/test-project/main.js', /::placeholder/);
   await expectToFail(() =>
-    expectFileToMatch('dist/test-project/styles.css', '@tailwind base; @tailwind components;'),
+    expectFileToMatch('dist/test-project/styles.css', /@tailwind base;\s+@tailwind components;/),
   );
   await expectToFail(() =>
-    expectFileToMatch('dist/test-project/main.js', '@tailwind base; @tailwind components;'),
+    expectFileToMatch(
+      'dist/test-project/main.js',
+      /@tailwind base;(?:\\n|\s*)@tailwind components;/,
+    ),
   );
 
   // Remove configuration file
@@ -48,8 +57,14 @@ export default async function () {
 
   // Ensure Tailwind is disabled when no configuration file is present
   await ng('build', '--configuration=development');
-  await expectFileToMatch('dist/test-project/styles.css', '@tailwind base; @tailwind components;');
-  await expectFileToMatch('dist/test-project/main.js', '@tailwind base; @tailwind components;');
+  await expectFileToMatch(
+    'dist/test-project/styles.css',
+    /@tailwind base;\s+@tailwind components;/,
+  );
+  await expectFileToMatch(
+    'dist/test-project/main.js',
+    /@tailwind base;(?:\\n|\s*)@tailwind components;/,
+  );
 
   // Uninstall Tailwind
   await uninstallPackage('tailwindcss');


### PR DESCRIPTION
The additional arguments were previously not fully propagated within the bazel rules.