### PR TITLE
feat(@angular-devkit/build-angular): display build output table with esbuild

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/utils/stats.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/utils/stats.ts
@@ -76,7 +76,7 @@ function generateBundleStats(info: {
   };
 }
 
-function generateBuildStatsTable(
+export function generateBuildStatsTable(
   data: BundleStats[],
   colors: boolean,
   showTotalSize: boolean,


### PR DESCRIPTION
When using the experimental esbuild-based browser application builder, a build output table will now be displayed upon completion. The table is formatted to display output file information in a similar way to the default Webpack-based browser application builder. Estimated transfer size is currently not displayed but will be added in a future change.