### PR TITLE
fix(@angular-devkit/build-angular): remove unintended files in esbuild output stats table

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
@@ -674,10 +674,20 @@ export default createBuilder(buildEsbuildBrowser);
 
 function logBuildStats(context: BuilderContext, metafile: Metafile) {
   const stats: BundleStats[] = [];
-  for (const [file, { bytes, entryPoint }] of Object.entries(metafile.outputs)) {
+  for (const [file, output] of Object.entries(metafile.outputs)) {
+    // Skip sourcemaps
+    if (file.endsWith('.map')) {
+      continue;
+    }
+    // Skip internal component resources
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    if ((output as any)['ng-component']) {
+      continue;
+    }
+
     stats.push({
-      initial: !!entryPoint,
-      stats: [file, '', bytes, ''],
+      initial: !!output.entryPoint,
+      stats: [file, '', output.bytes, ''],
     });
   }
 

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/stylesheets.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/stylesheets.ts
@@ -159,6 +159,18 @@ export async function bundleComponentStylesheet(
     }
   }
 
+  let metafile;
+  if (!result.errors) {
+    metafile = result.metafile;
+    // Remove entryPoint fields from outputs to prevent the internal component styles from being
+    // treated as initial files. Also mark the entry as a component resource for stat reporting.
+    Object.values(metafile.outputs).forEach((output) => {
+      delete output.entryPoint;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (output as any)['ng-component'] = true;
+    });
+  }
+
   return {
     errors: result.errors,
     warnings: result.warnings,
@@ -166,6 +178,6 @@ export async function bundleComponentStylesheet(
     map,
     path: outputPath,
     resourceFiles,
-    metafile: result.errors ? undefined : result.metafile,
+    metafile,
   };
 }


### PR DESCRIPTION
When using the esbuild-based browser application builder, the stat output table was incorrectly displaying source map files and internal component resource files such as inline stylesheets as initial entries.