### PR TITLE
feat(@angular-devkit/build-angular): support scripts option with esbuild builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/experimental-warnings.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/experimental-warnings.ts
@@ -12,7 +12,6 @@ import { Schema as BrowserBuilderOptions } from '../browser/schema';
 const UNSUPPORTED_OPTIONS: Array<keyof BrowserBuilderOptions> = [
   'budgets',
   'progress',
-  'scripts',
 
   // * i18n support
   'localize',

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/global-scripts.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/global-scripts.ts
@@ -1,0 +1,114 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import type { BuildOptions } from 'esbuild';
+import MagicString, { Bundle } from 'magic-string';
+import assert from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { NormalizedBrowserOptions } from './options';
+
+/**
+ * Create an esbuild 'build' options object for all global scripts defined in the user provied
+ * build options.
+ * @param options The builder's user-provider normalized options.
+ * @returns An esbuild BuildOptions object.
+ */
+export function createGlobalScriptsBundleOptions(options: NormalizedBrowserOptions): BuildOptions {
+  const {
+    globalScripts,
+    optimizationOptions,
+    outputNames,
+    preserveSymlinks,
+    sourcemapOptions,
+    workspaceRoot,
+  } = options;
+
+  const namespace = 'angular:script/global';
+  const entryPoints: Record<string, string> = {};
+  for (const { name } of globalScripts) {
+    entryPoints[name] = `${namespace}:${name}`;
+  }
+
+  return {
+    absWorkingDir: workspaceRoot,
+    bundle: false,
+    splitting: false,
+    entryPoints,
+    entryNames: outputNames.bundles,
+    assetNames: outputNames.media,
+    mainFields: ['script', 'browser', 'main'],
+    conditions: ['script'],
+    resolveExtensions: ['.mjs', '.js'],
+    logLevel: options.verbose ? 'debug' : 'silent',
+    metafile: true,
+    minify: optimizationOptions.scripts,
+    outdir: workspaceRoot,
+    sourcemap: sourcemapOptions.scripts && (sourcemapOptions.hidden ? 'external' : true),
+    write: false,
+    platform: 'neutral',
+    preserveSymlinks,
+    plugins: [
+      {
+        name: 'angular-global-scripts',
+        setup(build) {
+          build.onResolve({ filter: /^angular:script\/global:/ }, (args) => {
+            if (args.kind !== 'entry-point') {
+              return null;
+            }
+
+            return {
+              // Add the `js` extension here so that esbuild generates an output file with the extension
+              path: args.path.slice(namespace.length + 1) + '.js',
+              namespace,
+            };
+          });
+          // All references within a global script should be considered external. This maintains the runtime
+          // behavior of the script as if it were added directly to a script element for referenced imports.
+          build.onResolve({ filter: /./, namespace }, ({ path }) => {
+            return {
+              path,
+              external: true,
+            };
+          });
+          build.onLoad({ filter: /./, namespace }, async (args) => {
+            const files = globalScripts.find(({ name }) => name === args.path.slice(0, -3))?.files;
+            assert(files, `Invalid operation: global scripts name not found [${args.path}]`);
+
+            // Global scripts are concatenated using magic-string instead of bundled via esbuild.
+            const bundleContent = new Bundle();
+            for (const filename of files) {
+              const resolveResult = await build.resolve(filename, {
+                kind: 'entry-point',
+                resolveDir: workspaceRoot,
+              });
+
+              if (resolveResult.errors.length) {
+                // Remove resolution failure notes about marking as external since it doesn't apply
+                // to global scripts.
+                resolveResult.errors.forEach((error) => (error.notes = []));
+
+                return {
+                  errors: resolveResult.errors,
+                  warnings: resolveResult.warnings,
+                };
+              }
+
+              const fileContent = await readFile(resolveResult.path, 'utf-8');
+              bundleContent.addSource(new MagicString(fileContent, { filename }));
+            }
+
+            return {
+              contents: bundleContent.toString(),
+              loader: 'js',
+            };
+          });
+        },
+      },
+    ],
+  };
+}

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/options.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/options.ts
@@ -14,7 +14,7 @@ import { normalizeAssetPatterns, normalizeOptimization, normalizeSourceMaps } fr
 import { normalizeCacheOptions } from '../../utils/normalize-cache';
 import { generateEntryPoints } from '../../utils/package-chunk-sort';
 import { getIndexInputFile, getIndexOutputFile } from '../../utils/webpack-browser-config';
-import { normalizeGlobalStyles } from '../../webpack/utils/helpers';
+import { globalScriptsByBundleName, normalizeGlobalStyles } from '../../webpack/utils/helpers';
 import { Schema as BrowserBuilderOptions, OutputHashing } from './schema';
 
 export type NormalizedBrowserOptions = Awaited<ReturnType<typeof normalizeOptions>>;
@@ -85,6 +85,13 @@ export async function normalizeOptions(
     );
     for (const [name, files] of Object.entries(stylesheetEntrypoints)) {
       globalStyles.push({ name, files, initial: !noInjectNames.includes(name) });
+    }
+  }
+
+  const globalScripts: { name: string; files: string[]; initial: boolean }[] = [];
+  if (options.scripts?.length) {
+    for (const { bundleName, paths, inject } of globalScriptsByBundleName(options.scripts)) {
+      globalScripts.push({ name: bundleName, files: paths, initial: inject });
     }
   }
 
@@ -186,6 +193,7 @@ export async function normalizeOptions(
     outputNames,
     fileReplacements,
     globalStyles,
+    globalScripts,
     serviceWorkerOptions,
     indexHtmlOptions,
     tailwindConfiguration,

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/schema.json
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/schema.json
@@ -68,8 +68,7 @@
           },
           {
             "type": "string",
-            "description": "The file to include.",
-            "pattern": "\\.[cm]?jsx?$"
+            "description": "The JavaScript/TypeScript file or package containing the file to include."
           }
         ]
       }

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/tests/options/scripts_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/tests/options/scripts_spec.ts
@@ -1,0 +1,438 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { buildEsbuildBrowser } from '../../index';
+import { BASE_OPTIONS, BROWSER_BUILDER_INFO, describeBuilder } from '../setup';
+
+describeBuilder(buildEsbuildBrowser, BROWSER_BUILDER_INFO, (harness) => {
+  describe('Option: "scripts"', () => {
+    beforeEach(async () => {
+      // Application code is not needed for scripts tests
+      await harness.writeFile('src/main.ts', 'console.log("TESTING");');
+    });
+
+    it('supports an empty array value', async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        scripts: [],
+      });
+
+      const { result } = await harness.executeOnce();
+
+      expect(result?.success).toBe(true);
+    });
+
+    it('processes an empty script when optimizing', async () => {
+      await harness.writeFile('src/test-script-a.js', '');
+
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        optimization: {
+          scripts: true,
+        },
+        scripts: ['src/test-script-a.js'],
+      });
+
+      const { result } = await harness.executeOnce();
+
+      expect(result?.success).toBe(true);
+
+      harness.expectFile('dist/scripts.js').toExist();
+      harness
+        .expectFile('dist/index.html')
+        .content.toContain('<script src="scripts.js" defer></script>');
+    });
+
+    describe('shorthand syntax', () => {
+      it('processes a single script into a single output', async () => {
+        await harness.writeFile('src/test-script-a.js', 'console.log("a");');
+
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          scripts: ['src/test-script-a.js'],
+        });
+
+        const { result } = await harness.executeOnce();
+
+        expect(result?.success).toBe(true);
+
+        harness.expectFile('dist/scripts.js').content.toContain('console.log("a")');
+        harness
+          .expectFile('dist/index.html')
+          .content.toContain('<script src="scripts.js" defer></script>');
+      });
+
+      it('processes multiple scripts into a single output', async () => {
+        await harness.writeFile('src/test-script-a.js', 'console.log("a");');
+        await harness.writeFile('src/test-script-b.js', 'console.log("b");');
+
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          scripts: ['src/test-script-a.js', 'src/test-script-b.js'],
+        });
+
+        const { result } = await harness.executeOnce();
+
+        expect(result?.success).toBe(true);
+
+        harness.expectFile('dist/scripts.js').content.toContain('console.log("a")');
+        harness.expectFile('dist/scripts.js').content.toContain('console.log("b")');
+        harness
+          .expectFile('dist/index.html')
+          .content.toContain('<script src="scripts.js" defer></script>');
+      });
+
+      it('preserves order of multiple scripts in single output', async () => {
+        await harness.writeFile('src/test-script-a.js', 'console.log("a");');
+        await harness.writeFile('src/test-script-b.js', 'console.log("b");');
+        await harness.writeFile('src/test-script-c.js', 'console.log("c");');
+        await harness.writeFile('src/test-script-d.js', 'console.log("d");');
+
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          scripts: [
+            'src/test-script-c.js',
+            'src/test-script-d.js',
+            'src/test-script-b.js',
+            'src/test-script-a.js',
+          ],
+        });
+
+        const { result } = await harness.executeOnce();
+
+        expect(result?.success).toBe(true);
+
+        harness
+          .expectFile('dist/scripts.js')
+          .content.toMatch(
+            /console\.log\("c"\)[;\s]+console\.log\("d"\)[;\s]+console\.log\("b"\)[;\s]+console\.log\("a"\)/,
+          );
+      });
+
+      it('fails and shows an error if script does not exist', async () => {
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          scripts: ['src/test-script-a.js'],
+        });
+
+        const { result, logs } = await harness.executeOnce({ outputLogsOnFailure: false });
+
+        expect(result?.success).toBeFalse();
+        expect(logs).toContain(
+          jasmine.objectContaining({
+            level: 'error',
+            message: jasmine.stringMatching(`Could not resolve "src/test-script-a.js"`),
+          }),
+        );
+
+        harness.expectFile('dist/scripts.js').toNotExist();
+      });
+
+      it('shows the output script as a chunk entry in the logging output', async () => {
+        await harness.writeFile('src/test-script-a.js', 'console.log("a");');
+
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          scripts: ['src/test-script-a.js'],
+        });
+
+        const { result, logs } = await harness.executeOnce();
+
+        expect(result?.success).toBe(true);
+
+        expect(logs).toContain(
+          jasmine.objectContaining({ message: jasmine.stringMatching(/scripts\.js.+\d+ bytes/) }),
+        );
+      });
+    });
+
+    describe('longhand syntax', () => {
+      it('processes a single script into a single output', async () => {
+        await harness.writeFile('src/test-script-a.js', 'console.log("a");');
+
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          scripts: [{ input: 'src/test-script-a.js' }],
+        });
+
+        const { result } = await harness.executeOnce();
+
+        expect(result?.success).toBe(true);
+
+        harness.expectFile('dist/scripts.js').content.toContain('console.log("a")');
+        harness
+          .expectFile('dist/index.html')
+          .content.toContain('<script src="scripts.js" defer></script>');
+      });
+
+      it('processes a single script into a single output named with bundleName', async () => {
+        await harness.writeFile('src/test-script-a.js', 'console.log("a");');
+
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          scripts: [{ input: 'src/test-script-a.js', bundleName: 'extra' }],
+        });
+
+        const { result } = await harness.executeOnce();
+
+        expect(result?.success).toBe(true);
+
+        harness.expectFile('dist/extra.js').content.toContain('console.log("a")');
+        harness
+          .expectFile('dist/index.html')
+          .content.toContain('<script src="extra.js" defer></script>');
+      });
+
+      it('uses default bundleName when bundleName is empty string', async () => {
+        await harness.writeFile('src/test-script-a.js', 'console.log("a");');
+
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          scripts: [{ input: 'src/test-script-a.js', bundleName: '' }],
+        });
+
+        const { result } = await harness.executeOnce();
+
+        expect(result?.success).toBe(true);
+
+        harness.expectFile('dist/scripts.js').content.toContain('console.log("a")');
+        harness
+          .expectFile('dist/index.html')
+          .content.toContain('<script src="scripts.js" defer></script>');
+      });
+
+      it('processes multiple scripts with different bundleNames into separate outputs', async () => {
+        await harness.writeFiles({
+          'src/test-script-a.js': 'console.log("a");',
+          'src/test-script-b.js': 'console.log("b");',
+        });
+
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          scripts: [
+            { input: 'src/test-script-a.js', bundleName: 'extra' },
+            { input: 'src/test-script-b.js', bundleName: 'other' },
+          ],
+        });
+
+        const { result } = await harness.executeOnce();
+
+        expect(result?.success).toBe(true);
+
+        harness.expectFile('dist/extra.js').content.toContain('console.log("a")');
+        harness.expectFile('dist/other.js').content.toContain('console.log("b")');
+        harness
+          .expectFile('dist/index.html')
+          .content.toContain('<script src="extra.js" defer></script>');
+        harness
+          .expectFile('dist/index.html')
+          .content.toContain('<script src="other.js" defer></script>');
+      });
+
+      it('processes multiple scripts with no bundleName into a single output', async () => {
+        await harness.writeFiles({
+          'src/test-script-a.js': 'console.log("a");',
+          'src/test-script-b.js': 'console.log("b");',
+        });
+
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          scripts: [{ input: 'src/test-script-a.js' }, { input: 'src/test-script-b.js' }],
+        });
+
+        const { result } = await harness.executeOnce();
+
+        expect(result?.success).toBe(true);
+
+        harness.expectFile('dist/scripts.js').content.toContain('console.log("a")');
+        harness.expectFile('dist/scripts.js').content.toContain('console.log("b")');
+        harness
+          .expectFile('dist/index.html')
+          .content.toContain('<script src="scripts.js" defer></script>');
+      });
+
+      it('processes multiple scripts with same bundleName into a single output', async () => {
+        await harness.writeFiles({
+          'src/test-script-a.js': 'console.log("a");',
+          'src/test-script-b.js': 'console.log("b");',
+        });
+
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          scripts: [
+            { input: 'src/test-script-a.js', bundleName: 'extra' },
+            { input: 'src/test-script-b.js', bundleName: 'extra' },
+          ],
+        });
+
+        const { result } = await harness.executeOnce();
+
+        expect(result?.success).toBe(true);
+
+        harness.expectFile('dist/extra.js').content.toContain('console.log("a")');
+        harness.expectFile('dist/extra.js').content.toContain('console.log("b")');
+        harness
+          .expectFile('dist/index.html')
+          .content.toContain('<script src="extra.js" defer></script>');
+      });
+
+      it('preserves order of multiple scripts in single output', async () => {
+        await harness.writeFiles({
+          'src/test-script-a.js': 'console.log("a");',
+          'src/test-script-b.js': 'console.log("b");',
+          'src/test-script-c.js': 'console.log("c");',
+          'src/test-script-d.js': 'console.log("d");',
+        });
+
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          scripts: [
+            { input: 'src/test-script-c.js' },
+            { input: 'src/test-script-d.js' },
+            { input: 'src/test-script-b.js' },
+            { input: 'src/test-script-a.js' },
+          ],
+        });
+
+        const { result } = await harness.executeOnce();
+
+        expect(result?.success).toBe(true);
+
+        harness
+          .expectFile('dist/scripts.js')
+          .content.toMatch(
+            /console\.log\("c"\)[;\s]+console\.log\("d"\)[;\s]+console\.log\("b"\)[;\s]+console\.log\("a"\)/,
+          );
+      });
+
+      it('preserves order of multiple scripts with different bundleNames', async () => {
+        await harness.writeFiles({
+          'src/test-script-a.js': 'console.log("a");',
+          'src/test-script-b.js': 'console.log("b");',
+          'src/test-script-c.js': 'console.log("c");',
+          'src/test-script-d.js': 'console.log("d");',
+        });
+
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          scripts: [
+            { input: 'src/test-script-c.js', bundleName: 'other' },
+            { input: 'src/test-script-d.js', bundleName: 'extra' },
+            { input: 'src/test-script-b.js', bundleName: 'extra' },
+            { input: 'src/test-script-a.js', bundleName: 'other' },
+          ],
+        });
+
+        const { result } = await harness.executeOnce();
+
+        expect(result?.success).toBe(true);
+
+        harness
+          .expectFile('dist/other.js')
+          .content.toMatch(/console\.log\("c"\)[;\s]+console\.log\("a"\)/);
+        harness
+          .expectFile('dist/extra.js')
+          .content.toMatch(/console\.log\("d"\)[;\s]+console\.log\("b"\)/);
+        harness
+          .expectFile('dist/index.html')
+          .content.toMatch(
+            /<script src="other.js" defer><\/script>\s*<script src="extra.js" defer><\/script>/,
+          );
+      });
+
+      it('adds script element to index when inject is true', async () => {
+        await harness.writeFile('src/test-script-a.js', 'console.log("a");');
+
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          scripts: [{ input: 'src/test-script-a.js', inject: true }],
+        });
+
+        const { result } = await harness.executeOnce();
+
+        expect(result?.success).toBe(true);
+
+        harness.expectFile('dist/scripts.js').content.toContain('console.log("a")');
+        harness
+          .expectFile('dist/index.html')
+          .content.toContain('<script src="scripts.js" defer></script>');
+      });
+
+      it('does not add script element to index when inject is false', async () => {
+        await harness.writeFile('src/test-script-a.js', 'console.log("a");');
+
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          scripts: [{ input: 'src/test-script-a.js', inject: false }],
+        });
+
+        const { result } = await harness.executeOnce();
+
+        expect(result?.success).toBe(true);
+
+        // `inject: false` causes the bundleName to be the input file name
+        harness.expectFile('dist/test-script-a.js').content.toContain('console.log("a")');
+        harness
+          .expectFile('dist/index.html')
+          .content.not.toContain('<script src="test-script-a.js" defer></script>');
+      });
+
+      it('does not add script element to index with bundleName when inject is false', async () => {
+        await harness.writeFile('src/test-script-a.js', 'console.log("a");');
+
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          scripts: [{ input: 'src/test-script-a.js', bundleName: 'extra', inject: false }],
+        });
+
+        const { result } = await harness.executeOnce();
+
+        expect(result?.success).toBe(true);
+
+        harness.expectFile('dist/extra.js').content.toContain('console.log("a")');
+        harness
+          .expectFile('dist/index.html')
+          .content.not.toContain('<script src="extra.js" defer></script>');
+      });
+
+      it('shows the output script as a chunk entry in the logging output', async () => {
+        await harness.writeFile('src/test-script-a.js', 'console.log("a");');
+
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          scripts: [{ input: 'src/test-script-a.js' }],
+        });
+
+        const { result, logs } = await harness.executeOnce();
+
+        expect(result?.success).toBe(true);
+
+        expect(logs).toContain(
+          jasmine.objectContaining({ message: jasmine.stringMatching(/scripts\.js.+\d+ bytes/) }),
+        );
+      });
+
+      it('shows the output script as a chunk entry with bundleName in the logging output', async () => {
+        await harness.writeFile('src/test-script-a.js', 'console.log("a");');
+
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          scripts: [{ input: 'src/test-script-a.js', bundleName: 'extra' }],
+        });
+
+        const { result, logs } = await harness.executeOnce();
+
+        expect(result?.success).toBe(true);
+
+        expect(logs).toContain(
+          jasmine.objectContaining({ message: jasmine.stringMatching(/extra\.js.+\d+ bytes/) }),
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
When using the esbuild-based browser application builder, the `scripts` option will now provide equivalent functionality to the current default Webpack-based builder. The option provides full node resolution capabilities which allows both workspace relative paths and package paths with support for the `script` exports condition.