### PR TITLE
fix(@angular-devkit/build-angular): pass listening port in result for esbuild dev server

### DIFF
--- a/goldens/public-api/angular_devkit/architect/index.md
+++ b/goldens/public-api/angular_devkit/architect/index.md
@@ -452,6 +452,8 @@ export function scheduleTargetAndForget(context: BuilderContext, target: Target,
 // @public
 interface SimpleJobHandlerContext<A extends JsonValue, I extends JsonValue, O extends JsonValue> extends JobHandlerContext<A, I, O> {
     // (undocumented)
+    addTeardown(teardown: () => Promise<void> | void): void;
+    // (undocumented)
     createChannel: (name: string) => Observer<JsonValue>;
     // (undocumented)
     input: Observable<I>;

--- a/packages/angular_devkit/architect/src/jobs/create-job-handler.ts
+++ b/packages/angular_devkit/architect/src/jobs/create-job-handler.ts
@@ -44,6 +44,7 @@ export interface SimpleJobHandlerContext<
 > extends JobHandlerContext<A, I, O> {
   createChannel: (name: string) => Observer<JsonValue>;
   input: Observable<I>;
+  addTeardown(teardown: () => Promise<void> | void): void;
 }
 
 /**
@@ -72,6 +73,8 @@ export function createJobHandler<A extends JsonValue, I extends JsonValue, O ext
     const inboundBus = context.inboundBus;
     const inputChannel = new Subject<I>();
     let subscription: Subscription;
+    const teardownLogics: Array<() => PromiseLike<void> | void> = [];
+    let tearingDown = false;
 
     return new Observable<JobOutboundMessage<O>>((subject) => {
       function complete() {
@@ -91,13 +94,22 @@ export function createJobHandler<A extends JsonValue, I extends JsonValue, O ext
             break;
 
           case JobInboundMessageKind.Stop:
-            // There's no way to cancel a promise or a synchronous function, but we do cancel
-            // observables where possible.
-            complete();
+            // Run teardown logic then complete.
+            tearingDown = true;
+            if (teardownLogics.length) {
+              Promise.all(teardownLogics.map((fn) => fn())).then(
+                () => complete(),
+                () => complete(),
+              );
+            } else {
+              complete();
+            }
             break;
 
           case JobInboundMessageKind.Input:
-            inputChannel.next(message.value);
+            if (!tearingDown) {
+              inputChannel.next(message.value);
+            }
             break;
         }
       });
@@ -108,6 +120,9 @@ export function createJobHandler<A extends JsonValue, I extends JsonValue, O ext
       const newContext: SimpleJobHandlerContext<A, I, O> = {
         ...context,
         input: inputChannel.asObservable(),
+        addTeardown(teardown: () => Promise<void> | void): void {
+          teardownLogics.push(teardown);
+        },
         createChannel(name: string) {
           if (channels.has(name)) {
             throw new ChannelAlreadyExistException(name);

--- a/packages/angular_devkit/build_angular/BUILD.bazel
+++ b/packages/angular_devkit/build_angular/BUILD.bazel
@@ -340,6 +340,7 @@ LARGE_SPECS = {
         ],
     },
     "browser-esbuild": {
+        "shards": 10,
         "extra_deps": [
             "@npm//buffer",
         ],

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
@@ -148,7 +148,14 @@ export async function* serveWithVite(
     yield { success: true, port: listeningAddress?.port } as unknown as DevServerBuilderOutput;
   }
 
-  await server?.close();
+  if (server) {
+    let deferred: () => void;
+    context.addTeardown(async () => {
+      await server?.close();
+      deferred?.();
+    });
+    await new Promise<void>((resolve) => (deferred = resolve));
+  }
 }
 
 async function setupServer(


### PR DESCRIPTION
The deprecated protractor builder requires that the result object from a development server provide the port used to access the application if the port is not the default (4200). The newly introduced esbuild development server will now provide the port when available.