### PR TITLE
feat@angular-devkit/build-angular: allow TS config files for tailwindcss 

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/options.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/options.ts
@@ -207,7 +207,7 @@ function findTailwindConfigurationFile(
   // A configuration file can exist in the project or workspace root
   // The list of valid config files can be found:
   // https://github.com/tailwindlabs/tailwindcss/blob/8845d112fb62d79815b50b3bae80c317450b8b92/src/util/resolveConfigPath.js#L46-L52
-  const tailwindConfigFiles = ['tailwind.config.js', 'tailwind.config.cjs'];
+  const tailwindConfigFiles = ['tailwind.config.js', 'tailwind.config.cjs', 'tailwind.config.ts'];
   for (const basePath of [projectRoot, workspaceRoot]) {
     for (const configFile of tailwindConfigFiles) {
       // Project level configuration should always take precedence.


### PR DESCRIPTION
as mostly the filepath is passed around and handed off to tailwindcss, this might work

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [ x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

Issue Number: #24943 

## What is the new behavior?

The behavior is unchanged, only now one more value "tailwind.config.ts" is deemed valid to pass through to tailwindcss.
(see ./packages/angular_devkit/build_angular/src/builders/browser-esbuild/css-plugin.ts)

## Does this PR introduce a breaking change?

- [ ] Yes
- [ x] No


