### PR TITLE
feat(@angular-devkit/build-angular): implement progress option for esbuild builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/experimental-warnings.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/experimental-warnings.ts
@@ -11,7 +11,6 @@ import { Schema as BrowserBuilderOptions } from '../browser/schema';
 
 const UNSUPPORTED_OPTIONS: Array<keyof BrowserBuilderOptions> = [
   'budgets',
-  'progress',
 
   // * i18n support
   'localize',

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/options.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/options.ts
@@ -160,6 +160,7 @@ export async function normalizeOptions(
     subresourceIntegrity,
     verbose,
     watch,
+    progress,
   } = options;
 
   // Return all the normalized options
@@ -176,6 +177,7 @@ export async function normalizeOptions(
     stats: !!statsJson,
     polyfills: polyfills === undefined || Array.isArray(polyfills) ? polyfills : [polyfills],
     poll,
+    progress: progress ?? true,
     // If not explicitly set, default to the Node.js process argument
     preserveSymlinks: preserveSymlinks ?? process.execArgv.includes('--preserve-symlinks'),
     stylePreprocessorOptions,


### PR DESCRIPTION
When using the esbuild-based browser application builder, the `progress` option which is enabled by default will now show an activity spinner when building/rebuilding.