### PR TITLE
fix(@schematics/angular): replace `provideServerSupport` with `provideServerRendering`

### DIFF
--- a/packages/schematics/angular/universal/files/standalone-src/app/app.config.server.ts.template
+++ b/packages/schematics/angular/universal/files/standalone-src/app/app.config.server.ts.template
@@ -7,12 +7,12 @@
  */
 
 import { mergeApplicationConfig, ApplicationConfig } from '@angular/core';
-import { provideServerSupport } from '@angular/platform-server';
+import { provideServerRendering } from '@angular/platform-server';
 import { appConfig } from './app.config';
 
 const serverConfig: ApplicationConfig = {
   providers: [
-    provideServerSupport()
+    provideServerRendering()
   ]
 };
 


### PR DESCRIPTION

Update `provideServerSupport` with `provideServerRendering` as the former has been renamed.
