### PR TITLE
perf(@angular-devkit/build-angular): skip Angular linker in JIT mode with esbuild

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/compiler-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/compiler-plugin.ts
@@ -399,7 +399,7 @@ export function createCompilerPlugin(
             // would need to be added to the key as well as a check for any change of content.
             let contents = pluginOptions.sourceFileCache?.babelFileCache.get(args.path);
             if (contents === undefined) {
-              contents = await javascriptTransformer.transformFile(args.path);
+              contents = await javascriptTransformer.transformFile(args.path, pluginOptions.jit);
               pluginOptions.sourceFileCache?.babelFileCache.set(args.path, contents);
             }
 

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/javascript-transformer.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/javascript-transformer.ts
@@ -54,13 +54,15 @@ export class JavaScriptTransformer {
    * Performs JavaScript transformations on a file from the filesystem.
    * If no transformations are required, the data for the original file will be returned.
    * @param filename The full path to the file.
+   * @param skipLinker If true, bypass all Angular linker processing; if false, attempt linking.
    * @returns A promise that resolves to a UTF-8 encoded Uint8Array containing the result.
    */
-  transformFile(filename: string): Promise<Uint8Array> {
+  transformFile(filename: string, skipLinker?: boolean): Promise<Uint8Array> {
     // Always send the request to a worker. Files are almost always from node modules which measn
     // they may need linking. The data is also not yet available to perform most transformation checks.
     return this.#workerPool.run({
       filename,
+      skipLinker,
       ...this.#commonOptions,
     });
   }


### PR DESCRIPTION
When using the esbuild-based browser application builder in JIT mode, the Angular linker will now be skipped. The runtime Angular compiler present in JIT applications will automatically link any needed code.