### PR TITLE
perf(@angular-devkit/build-angular): cache Sass in memory with esbuild watch mode

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/angular/jit-plugin-callbacks.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/angular/jit-plugin-callbacks.ts
@@ -9,6 +9,7 @@
 import type { OutputFile, PluginBuild } from 'esbuild';
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
+import { LoadResultCache } from '../load-result-cache';
 import { BundleStylesheetOptions, bundleComponentStylesheet } from '../stylesheets';
 import {
   JIT_NAMESPACE_REGEXP,
@@ -65,6 +66,7 @@ export function setupJitPluginCallbacks(
   build: PluginBuild,
   styleOptions: BundleStylesheetOptions & { inlineStyleLanguage: string },
   stylesheetResourceFiles: OutputFile[],
+  cache?: LoadResultCache,
 ): void {
   const root = build.initialOptions.absWorkingDir ?? '';
 
@@ -110,6 +112,7 @@ export function setupJitPluginCallbacks(
       entry.path,
       entry.contents !== undefined,
       styleOptions,
+      cache,
     );
 
     stylesheetResourceFiles.push(...resourceFiles);

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/load-result-cache.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/load-result-cache.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import type { OnLoadResult } from 'esbuild';
+
+export interface LoadResultCache {
+  get(path: string): OnLoadResult | undefined;
+  put(path: string, result: OnLoadResult): Promise<void>;
+}
+
+export class MemoryLoadResultCache implements LoadResultCache {
+  #loadResults = new Map<string, OnLoadResult>();
+  #fileDependencies = new Map<string, Set<string>>();
+
+  get(path: string): OnLoadResult | undefined {
+    return this.#loadResults.get(path);
+  }
+
+  async put(path: string, result: OnLoadResult): Promise<void> {
+    this.#loadResults.set(path, result);
+    if (result.watchFiles) {
+      for (const watchFile of result.watchFiles) {
+        let affected = this.#fileDependencies.get(watchFile);
+        if (affected === undefined) {
+          affected = new Set();
+          this.#fileDependencies.set(watchFile, affected);
+        }
+        affected.add(path);
+      }
+    }
+  }
+
+  invalidate(path: string): boolean {
+    const affected = this.#fileDependencies.get(path);
+    let found = false;
+
+    if (affected) {
+      affected.forEach((a) => (found ||= this.#loadResults.delete(a)));
+      this.#fileDependencies.delete(path);
+    }
+
+    found ||= this.#loadResults.delete(path);
+
+    return found;
+  }
+}


### PR DESCRIPTION
To improve rebuild performance when using Sass stylesheets with the esbuild-based browser application builder in watch mode, Sass stylesheets that are not affected by any file changes will now be cached and directly reused. This avoids performing potentially expensive Sass preprocessing on stylesheets that will not change within a rebuild.