### PR TITLE
fix(@angular-devkit/build-angular): ensure all build resources are served in esbuild dev server

### DIFF
--- a/package.json
+++ b/package.json
@@ -172,6 +172,7 @@
     "loader-utils": "3.2.1",
     "magic-string": "0.30.0",
     "mini-css-extract-plugin": "2.7.5",
+    "mrmime": "1.0.1",
     "ng-packagr": "16.0.0-next.2",
     "node-fetch": "^2.2.0",
     "npm": "^8.11.0",

--- a/packages/angular_devkit/build_angular/BUILD.bazel
+++ b/packages/angular_devkit/build_angular/BUILD.bazel
@@ -157,6 +157,7 @@ ts_library(
         "@npm//loader-utils",
         "@npm//magic-string",
         "@npm//mini-css-extract-plugin",
+        "@npm//mrmime",
         "@npm//ng-packagr",
         "@npm//open",
         "@npm//ora",

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -45,6 +45,7 @@
     "loader-utils": "3.2.1",
     "magic-string": "0.30.0",
     "mini-css-extract-plugin": "2.7.5",
+    "mrmime": "1.0.1",
     "open": "8.4.2",
     "ora": "5.4.1",
     "parse5-html-rewriting-stream": "7.0.0",

--- a/packages/angular_devkit/build_angular/src/utils/normalize-asset-patterns.ts
+++ b/packages/angular_devkit/build_angular/src/utils/normalize-asset-patterns.ts
@@ -67,6 +67,8 @@ export function normalizeAssetPatterns(
       const output = path.relative(resolvedSourceRoot, path.resolve(workspaceRoot, input));
 
       assetPattern = { glob, input, output };
+    } else {
+      assetPattern.output = path.join('.', assetPattern.output);
     }
 
     if (assetPattern.output.startsWith('..')) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8617,6 +8617,11 @@ mkdirp@^0.5.1, mkdirp@^0.5.5, mkdirp@~0.5.1:
   dependencies:
     minimist "^1.2.6"
 
+mrmime@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mrmime/-/mrmime-1.0.1.tgz#5f90c825fad4bdd41dc914eff5d1a8cfdaf24f27"
+  integrity sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"


### PR DESCRIPTION
Previously when using the esbuild-based browser application builder with the new dev server, resource files referenced via stylesheets may not have been served by the development server. The development server has now been adjusted to properly prioritize and serve files that were generated during the build process.
Global stylesheets are also currently considered resource files as well to workaround issues with development sourcemaps within the development server itself. Global stylesheets are already fully processed by the build system prior to being passed to the development server.