### PR TITLE
perf(@angular-devkit/build-angular): only import esbuild watcher when in watch mode

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
@@ -32,7 +32,7 @@ import { NormalizedBrowserOptions, normalizeOptions } from './options';
 import { shutdownSassWorkerPool } from './sass-plugin';
 import { Schema as BrowserBuilderOptions } from './schema';
 import { createStylesheetBundleOptions } from './stylesheets';
-import { ChangedFiles, createWatcher } from './watcher';
+import type { ChangedFiles } from './watcher';
 
 interface RebuildState {
   codeRebuild?: BundlerContext;
@@ -678,6 +678,7 @@ export async function* buildEsbuildBrowser(
   }
 
   // Setup a watcher
+  const { createWatcher } = await import('./watcher');
   const watcher = createWatcher({
     polling: typeof userOptions.poll === 'number',
     interval: userOptions.poll,


### PR DESCRIPTION
When using the esbuild-based browser application builder, all the watch-related code is now only imported when the watch mode is enabled. This removes the need for Node.js to resolve and load code that will not be used.