### PR TITLE
ci: disable `rules_pkg` updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,7 @@
   "dependencyDashboard": true,
   "schedule": ["after 10:00pm every weekday", "before 4:00am every weekday", "every weekend"],
   "baseBranches": ["main"],
-  "ignoreDeps": ["cacache", "@types/node"],
+  "ignoreDeps": ["cacache", "@types/node", "rules_pkg"],
   "includePaths": [
     "WORKSPACE",
     "package.json",


### PR DESCRIPTION
Currently version 0.9.0 causes e2e to fails due to incompatible changes https://github.com/bazelbuild/rules_pkg/releases/tag/0.9.0 until these issues are addressed in our build rules we disable this package from being updated.
