### PR TITLE
ci: add `BlueOak` license now that it is approved by legal

### DIFF
--- a/scripts/validate-licenses.ts
+++ b/scripts/validate-licenses.ts
@@ -33,6 +33,7 @@ const allowedLicenses = [
   'Apache-2.0',
   'Python-2.0',
   'Artistic-2.0',
+  'BlueOak-1.0.0',
 
   'BSD-2-Clause',
   'BSD-3-Clause',


### PR DESCRIPTION
https://skyvine.corp.google.com/issues/1044744690

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [X] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] CI related changes

## What is the current behavior?

We were not able to update to the latest `path-scurry` in transitive dependencies because the [Blue Oak](https://blueoakcouncil.org/license/1.0.0) license was not approved.

## What is the new behavior?

Blue Oak is now approved and can be used in dependencies.

## Does this PR introduce a breaking change?

- [X] No