### PR TITLE
Revert "ci: bump Angular dependencies to `16.0.0-rc.0`"

### DIFF
--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -74,12 +74,12 @@
     "esbuild": "0.17.16"
   },
   "peerDependencies": {
-    "@angular/compiler-cli": "^16.0.0-rc.0",
-    "@angular/localize": "^16.0.0-rc.0",
-    "@angular/platform-server": "^16.0.0-rc.0",
-    "@angular/service-worker": "^16.0.0-rc.0",
+    "@angular/compiler-cli": "^16.0.0-next.0",
+    "@angular/localize": "^16.0.0-next.0",
+    "@angular/platform-server": "^16.0.0-next.0",
+    "@angular/service-worker": "^16.0.0-next.0",
     "karma": "^6.3.0",
-    "ng-packagr": "^16.0.0-rc.0",
+    "ng-packagr": "^16.0.0-next.1",
     "protractor": "^7.0.0",
     "tailwindcss": "^2.0.0 || ^3.0.0",
     "typescript": ">=4.9.3 <5.1"

--- a/packages/ngtools/webpack/package.json
+++ b/packages/ngtools/webpack/package.json
@@ -22,14 +22,14 @@
   "homepage": "https://github.com/angular/angular-cli/tree/main/packages/ngtools/webpack",
   "dependencies": {},
   "peerDependencies": {
-    "@angular/compiler-cli": "^16.0.0-rc.0",
+    "@angular/compiler-cli": "^16.0.0-next.0",
     "typescript": ">=4.9.3 <5.1",
     "webpack": "^5.54.0"
   },
   "devDependencies": {
     "@angular-devkit/core": "0.0.0-PLACEHOLDER",
-    "@angular/compiler": "16.0.0-rc.0",
-    "@angular/compiler-cli": "16.0.0-rc.0",
+    "@angular/compiler": "16.0.0-next.7",
+    "@angular/compiler-cli": "16.0.0-next.7",
     "typescript": "~5.0.2",
     "webpack": "5.79.0"
   }

--- a/packages/schematics/angular/utility/latest-versions.ts
+++ b/packages/schematics/angular/utility/latest-versions.ts
@@ -15,7 +15,7 @@ export const latestVersions: Record<string, string> & {
   ...require('./latest-versions/package.json')['dependencies'],
 
   // As Angular CLI works with same minor versions of Angular Framework, a tilde match for the current
-  Angular: '^16.0.0-rc.0',
+  Angular: '^16.0.0-next.0',
 
   // Since @angular-devkit/build-angular and @schematics/angular are always
   // published together from the same monorepo, and they are both

--- a/packages/schematics/angular/utility/latest-versions/package.json
+++ b/packages/schematics/angular/utility/latest-versions/package.json
@@ -12,7 +12,7 @@
     "karma-jasmine-html-reporter": "~2.0.0",
     "karma-jasmine": "~5.1.0",
     "karma": "~6.4.0",
-    "ng-packagr": "^16.0.0-rc.0",
+    "ng-packagr": "^16.0.0-next.0",
     "protractor": "~7.0.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",


### PR DESCRIPTION
This reverts commit 290e06018d3934cf27a5734a60947dcd7b45fa58.

Release checks don't like being in an RC state and it's not strictly necessary since installing a `-next` package will install `-rc` because it alphabetically follows. This means generating applications with `-next` in the `package.json` will still pull the latest RC releases of Angular packages.