### PR TITLE
refactor(@angular/cli): update E2E command alias

### DIFF
--- a/packages/angular/cli/src/commands/command-config.ts
+++ b/packages/angular/cli/src/commands/command-config.ts
@@ -66,7 +66,7 @@ export const RootCommands: Record<
   },
   'e2e': {
     factory: () => import('./e2e/cli'),
-    aliases: ['e2e'],
+    aliases: ['e'],
   },
   'extract-i18n': {
     factory: () => import('./extract-i18n/cli'),


### PR DESCRIPTION
The mistake was introduced in a previous commit that introduced registration of lazy loading of commands.