### PR TITLE
fix(@angular-devkit/build-angular): correctly show initial files in stat table with esbuild builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/esbuild.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/esbuild.ts
@@ -103,13 +103,19 @@ export class BundlerContext {
       outputFile.path = relativeFilePath;
 
       if (entryPoint) {
-        // An entryPoint value indicates an initial file
-        initialFiles.push({
-          file: outputFile.path,
-          // The first part of the filename is the name of file (e.g., "polyfills" for "polyfills.7S5G3MDY.js")
-          name: basename(outputFile.path).split('.')[0],
-          extension: extname(outputFile.path),
-        });
+        // The first part of the filename is the name of file (e.g., "polyfills" for "polyfills.7S5G3MDY.js")
+        const name = basename(outputFile.path).split('.', 1)[0];
+
+        // Only entrypoints with an entry in the options are initial files.
+        // Dynamic imports also have an entryPoint value in the meta file.
+        if ((this.#esbuildOptions.entryPoints as Record<string, string>)?.[name]) {
+          // An entryPoint value indicates an initial file
+          initialFiles.push({
+            file: outputFile.path,
+            name,
+            extension: extname(outputFile.path),
+          });
+        }
       }
     }
 

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
@@ -765,7 +765,7 @@ function logBuildStats(context: BuilderContext, metafile: Metafile, initialFiles
 
     stats.push({
       initial: initial.has(file),
-      stats: [file, initial.get(file) ?? '', output.bytes, ''],
+      stats: [file, initial.get(file) ?? '-', output.bytes, ''],
     });
   }
 


### PR DESCRIPTION
When using the esbuild-based browser application builder, only actual initial files will be displayed in the initial files section. Previously, certain dynamically imported files could unintentionally be displayed in the stats output table as initial files. This was a display only error and had no effect on the files added to the index HTML file.