### PR TITLE
ci: update CI `.bazelrc` to better support CI systems.

### DIFF
--- a/.circleci/bazel.common.rc
+++ b/.circleci/bazel.common.rc
@@ -4,8 +4,15 @@
 # Echo all the configuration settings and their source
 build --announce_rc
 
-# Don't be spammy in the logs
-build --noshow_progress
+# Print extra information for build failures to help with debugging.
+build --verbose_failures
+
+# Show progress so CI doesn't appear to be stuck, but rate limit to avoid
+# spamming the log.
+build --show_progress_rate_limit 5
+
+# Improve the UI for rendering to a CI log.
+build --curses yes --color yes --terminal_columns 140 --show_timestamps
 
 # Workaround https://github.com/bazelbuild/bazel/issues/3645
 # Bazel doesn't calculate the memory ceiling correctly when running under Docker.
@@ -19,3 +26,10 @@ build --verbose_failures=true
 
 # Retry in the event of flakes
 test --flaky_test_attempts=2
+
+# Run as many tests as possible so we capture all the failures.
+test --keep_going
+
+# Don't build targets not needed for tests. `build_test()` should be used if a
+# target should be verified as buildable on CI.
+test --build_tests_only


### PR DESCRIPTION
A number of small changes with comments here. The main one is that removing `--noshow_progress` will make Bazel print progress updates which tells Circle CI that test execution is still ongoing and avoids test failures due to lack of output.

The other notable trade-offs being made here are:
1. [`--keep_going`](https://bazel.build/docs/user-manual#keep-going) means `bazel test` will run all tests report all failures, which could be slower and noisier than reporting just the first failure but is more complete.
2. [`--build_tests_only`](https://bazel.build/docs/user-manual#build-tests-only) means only tests and binaries will be built, so any library targets not tested could have build errors hidden. Any such important targets should either be tested or use Skylib's `build_test()`.

The UI options mostly came from [this talk](https://www.youtube.com/watch?v=j332WfhNAFg).