### PR TITLE
test(@angular-devkit/build-angular): execute all basic E2E tests with esbuild builder

### DIFF
--- a/tests/legacy-cli/e2e.bzl
+++ b/tests/legacy-cli/e2e.bzl
@@ -41,10 +41,6 @@ ESBUILD_TESTS = [
 
 # Tests excluded for esbuild
 ESBUILD_IGNORE_TESTS = [
-    "tests/basic/environment.js",
-    "tests/basic/rebuild.js",
-    "tests/basic/serve.js",
-    "tests/basic/scripts-array.js",
 ]
 
 def _to_glob(patterns):

--- a/tests/legacy-cli/e2e/tests/basic/scripts-array.ts
+++ b/tests/legacy-cli/e2e/tests/basic/scripts-array.ts
@@ -1,3 +1,4 @@
+import { getGlobalVariable } from '../../utils/env';
 import { appendToFile, expectFileToMatch, writeMultipleFiles } from '../../utils/fs';
 import { ng } from '../../utils/process';
 import { updateJsonFile } from '../../utils/project';
@@ -50,15 +51,27 @@ export default async function () {
   await expectFileToMatch('dist/test-project/renamed-lazy-script.js', 'pre-rename-lazy-script');
 
   // index.html lists the right bundles
-  await expectFileToMatch(
-    'dist/test-project/index.html',
-    [
-      '<script src="runtime.js" type="module"></script>',
-      '<script src="polyfills.js" type="module"></script>',
-      '<script src="scripts.js" defer></script>',
-      '<script src="renamed-script.js" defer></script>',
-      '<script src="vendor.js" type="module"></script>',
-      '<script src="main.js" type="module"></script>',
-    ].join(''),
-  );
+  if (getGlobalVariable('argv')['esbuild']) {
+    await expectFileToMatch(
+      'dist/test-project/index.html',
+      [
+        '<script src="polyfills.js" type="module"></script>',
+        '<script src="scripts.js" defer></script>',
+        '<script src="renamed-script.js" defer></script>',
+        '<script src="main.js" type="module"></script>',
+      ].join(''),
+    );
+  } else {
+    await expectFileToMatch(
+      'dist/test-project/index.html',
+      [
+        '<script src="runtime.js" type="module"></script>',
+        '<script src="polyfills.js" type="module"></script>',
+        '<script src="scripts.js" defer></script>',
+        '<script src="renamed-script.js" defer></script>',
+        '<script src="vendor.js" type="module"></script>',
+        '<script src="main.js" type="module"></script>',
+      ].join(''),
+    );
+  }
 }

--- a/tests/legacy-cli/e2e/tests/basic/styles-array.ts
+++ b/tests/legacy-cli/e2e/tests/basic/styles-array.ts
@@ -1,4 +1,3 @@
-import { getGlobalVariable } from '../../utils/env';
 import { expectFileToMatch, writeMultipleFiles } from '../../utils/fs';
 import { ng } from '../../utils/process';
 import { updateJsonFile } from '../../utils/project';
@@ -39,13 +38,9 @@ export default async function () {
     '<link rel="stylesheet" href="styles.css"><link rel="stylesheet" href="renamed-style.css">',
   );
 
-  if (getGlobalVariable('argv')['esbuild']) {
-    // EXPERIMENTAL_ESBUILD: esbuild does not yet output build stats
-    return;
-  }
-
   // Non injected styles should be listed under lazy chunk files
-  if (!/Lazy Chunk Files.*\srenamed-lazy-style\.css/m.test(stdout)) {
+  if (!/Lazy Chunk Files[\s\S]+renamed-lazy-style\.css/m.test(stdout)) {
+    console.log(stdout);
     throw new Error(`Expected "renamed-lazy-style.css" to be listed under "Lazy Chunk Files".`);
   }
 }

--- a/tests/legacy-cli/e2e/utils/project.ts
+++ b/tests/legacy-cli/e2e/utils/project.ts
@@ -26,10 +26,13 @@ export function updateTsConfig(fn: (json: any) => any | void) {
 export async function ngServe(...args: string[]) {
   const port = await findFreePort();
 
+  const esbuild = getGlobalVariable('argv')['esbuild'];
+  const validBundleRegEx = esbuild ? /Complete\./ : /Compiled successfully\./;
+
   await execAndWaitForOutputToMatch(
     'ng',
     ['serve', '--port', String(port), ...args],
-    / Compiled successfully./,
+    validBundleRegEx,
   );
 
   return port;


### PR DESCRIPTION
With the increased feature parity of the esbuild-based browser application builder, all the basic E2E tests can now be executed against the builder. Several of the output checks were required to be updated to reflect the differences in console output, lazy chunk file naming, and less required initial files in the index HTML.