### PR TITLE
fix(@angular/cli): process keeps running when analytics are enabled

### DIFF
--- a/packages/angular/cli/src/analytics/analytics-collector.ts
+++ b/packages/angular/cli/src/analytics/analytics-collector.ts
@@ -182,6 +182,9 @@ export class AnalyticsCollector {
           },
         },
         (response) => {
+          // The below is needed as otherwise the response will never close which will cause the CLI not to terminate.
+          response.on('data', () => {});
+
           if (response.statusCode !== 200 && response.statusCode !== 204) {
             reject(
               new Error(`Analytics reporting failed with status code: ${response.statusCode}.`),


### PR DESCRIPTION
In newer Node.js versions ng commands do not terminate properly when analytics are enabled.

This is because the request is never closed unless a `data` event listener is attached.

Closes #25034 and closes #25008
