### PR TITLE
fix(@angular-devkit/build-angular): display warning when `preserveWhitespaces` in set in the tsconfig provided to the server builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/server/tests/behavior/preserve_whitespaces_check_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/server/tests/behavior/preserve_whitespaces_check_spec.ts
@@ -1,0 +1,47 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { logging } from '@angular-devkit/core';
+import { execute } from '../../index';
+import { BASE_OPTIONS, SERVER_BUILDER_INFO, describeBuilder } from '../setup';
+
+describeBuilder(execute, SERVER_BUILDER_INFO, (harness) => {
+  describe('Behavior: "preserveWhitespaces warning"', () => {
+    it('should not show warning when "preserveWhitespaces" is not set.', async () => {
+      harness.useTarget('server', {
+        ...BASE_OPTIONS,
+      });
+
+      const { logs } = await harness.executeOnce();
+      expect(logs).not.toContain(
+        jasmine.objectContaining<logging.LogEntry>({
+          message: jasmine.stringMatching('"preserveWhitespaces" was set in'),
+        }),
+      );
+    });
+    it('should show warning when "preserveWhitespaces" is set.', async () => {
+      harness.useTarget('server', {
+        ...BASE_OPTIONS,
+      });
+
+      await harness.modifyFile('src/tsconfig.server.json', (content) => {
+        const tsconfig = JSON.parse(content);
+        (tsconfig.angularCompilerOptions ??= {}).preserveWhitespaces = false;
+
+        return JSON.stringify(tsconfig);
+      });
+
+      const { logs } = await harness.executeOnce();
+      expect(logs).toContain(
+        jasmine.objectContaining<logging.LogEntry>({
+          message: jasmine.stringMatching('"preserveWhitespaces" was set in'),
+        }),
+      );
+    });
+  });
+});


### PR DESCRIPTION


This commits add a check to display a warning when `preserveWhitespaces` is configured in `tsconfig.server.json`, as potentially this could cause issue with hydration.
