### PR TITLE
fix(@angular-devkit/build-angular): correctly filter lazy global styles in esbuild builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
@@ -166,7 +166,7 @@ async function execute(
   }
 
   // Filter global stylesheet initial files. Currently all initial CSS files are from the global styles option.
-  if (options.globalScripts.length > 0) {
+  if (options.globalStyles.length > 0) {
     bundlingResult.initialFiles = bundlingResult.initialFiles.filter(
       ({ file, name }) =>
         !file.endsWith('.css') ||


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [X] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

Due to a typo in a conditional for the filtering of lazily defined global styles, global styles were unintentionally always initial if no global scripts were present in the application. This typo was causing the recently enabled styles E2E tests to fail.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

