### PR TITLE
feat(@schematics/angular): add --pure to ng generate pipe

### DIFF
--- a/packages/schematics/angular/pipe/files/__name@dasherize@if-flat__/__name@dasherize__.pipe.ts.template
+++ b/packages/schematics/angular/pipe/files/__name@dasherize@if-flat__/__name@dasherize__.pipe.ts.template
@@ -1,8 +1,9 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({
-  name: '<%= camelize(name) %>'<% if(standalone) {%>,
-  standalone: true<%}%>
+  name: '<%= camelize(name) %>' <% if(standalone) {%>,
+  standalone: true<%}%> <% if(pure) {%>,
+  pure: true<%}%>
 })
 export class <%= classify(name) %>Pipe implements PipeTransform {
 

--- a/packages/schematics/angular/pipe/index_spec.ts
+++ b/packages/schematics/angular/pipe/index_spec.ts
@@ -151,6 +151,13 @@ describe('Pipe Schematic', () => {
     expect(moduleContent).not.toContain('FooPipe');
   });
 
+  it('should create a pure pipe', async () => {
+    const options = { ...defaultOptions, pure: true };
+    const tree = await schematicRunner.runSchematic('pipe', options, appTree);
+    const pipeContent = tree.readContent('/projects/bar/src/app/foo.pipe.ts');
+    expect(pipeContent).toContain('pure: true');
+  });
+
   it('should error when class name contains invalid characters', async () => {
     const options = { ...defaultOptions, name: '1Clazz' };
 

--- a/packages/schematics/angular/pipe/schema.json
+++ b/packages/schematics/angular/pipe/schema.json
@@ -52,6 +52,11 @@
       "default": false,
       "x-user-analytics": "ep.ng_standalone"
     },
+    "pure": {
+      "description": "Whether the generated pipe is pure.",
+      "type": "boolean",
+      "default": false
+    },
     "module": {
       "type": "string",
       "description": "The declaring NgModule.",


### PR DESCRIPTION
Adds the `--pure` flag when generating pipe through `ng generate pipe`.

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [X] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Before this update, it was impossible to generate pure pipe with the `ng generate pipe` command

Issue Number: N/A

## What is the new behavior?

User can now generate pure pipe directly with CLI

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Other information
