### PR TITLE
fix(@angular-devkit/build-angular): use preserveSymlinks option for tsconfigs in esbuild builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
@@ -393,6 +393,7 @@ function createCodeBundleOptions(
           externalDependencies,
           target,
           inlineStyleLanguage,
+          preserveSymlinks,
           browsers,
           tailwindConfiguration,
         },


### PR DESCRIPTION
When using the esbuild-based browser application builder, the tsconfig path will now be properly converted to the realpath when the `preserveSymlinks` option is disabled (the default). This ensures that TypeScript source files will be properly matched with the bundler's resolved paths when symlinks are used and the `preserveSymlinks` option is not enabled. This is needed to properly support the use of bazel with rules_js.