### PR TITLE
Initial experimental Jest support

### DIFF
--- a/packages/angular/cli/BUILD.bazel
+++ b/packages/angular/cli/BUILD.bazel
@@ -85,6 +85,7 @@ CLI_SCHEMA_DATA = [
     "//packages/angular_devkit/build_angular:src/builders/browser-esbuild/schema.json",
     "//packages/angular_devkit/build_angular:src/builders/dev-server/schema.json",
     "//packages/angular_devkit/build_angular:src/builders/extract-i18n/schema.json",
+    "//packages/angular_devkit/build_angular:src/builders/jest/schema.json",
     "//packages/angular_devkit/build_angular:src/builders/karma/schema.json",
     "//packages/angular_devkit/build_angular:src/builders/ng-packagr/schema.json",
     "//packages/angular_devkit/build_angular:src/builders/protractor/schema.json",

--- a/packages/angular/cli/lib/config/workspace-schema.json
+++ b/packages/angular/cli/lib/config/workspace-schema.json
@@ -360,6 +360,7 @@
                       "@angular-devkit/build-angular:dev-server",
                       "@angular-devkit/build-angular:extract-i18n",
                       "@angular-devkit/build-angular:karma",
+                      "@angular-devkit/build-angular:jest",
                       "@angular-devkit/build-angular:protractor",
                       "@angular-devkit/build-angular:server",
                       "@angular-devkit/build-angular:ng-packagr"
@@ -512,6 +513,28 @@
                   "type": "object",
                   "additionalProperties": {
                     "$ref": "../../../../angular_devkit/build_angular/src/builders/karma/schema.json"
+                  }
+                }
+              }
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "builder": {
+                  "const": "@angular-devkit/build-angular:jest"
+                },
+                "defaultConfiguration": {
+                  "type": "string",
+                  "description": "A default named configuration to use when a target configuration is not provided."
+                },
+                "options": {
+                  "$ref": "../../../../angular_devkit/build_angular/src/builders/jest/schema.json"
+                },
+                "configurations": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "$ref": "../../../../angular_devkit/build_angular/src/builders/jest/schema.json"
                   }
                 }
               }

--- a/packages/angular_devkit/build_angular/BUILD.bazel
+++ b/packages/angular_devkit/build_angular/BUILD.bazel
@@ -39,6 +39,11 @@ ts_json_schema(
 )
 
 ts_json_schema(
+    name = "jest_schema",
+    src = "src/builders/jest/schema.json",
+)
+
+ts_json_schema(
     name = "karma_schema",
     src = "src/builders/karma/schema.json",
 )
@@ -79,6 +84,7 @@ ts_library(
         "//packages/angular_devkit/build_angular:src/builders/browser/schema.ts",
         "//packages/angular_devkit/build_angular:src/builders/dev-server/schema.ts",
         "//packages/angular_devkit/build_angular:src/builders/extract-i18n/schema.ts",
+        "//packages/angular_devkit/build_angular:src/builders/jest/schema.ts",
         "//packages/angular_devkit/build_angular:src/builders/karma/schema.ts",
         "//packages/angular_devkit/build_angular:src/builders/ng-packagr/schema.ts",
         "//packages/angular_devkit/build_angular:src/builders/protractor/schema.ts",
@@ -267,7 +273,7 @@ ts_library(
             "src/**/tests/*.ts",
         ],
         exclude = [
-            "src/testing/**/*_spec.ts",
+            "src/**/*_spec.ts",
         ],
     ),
     data = glob(["test/**/*"]),
@@ -345,6 +351,12 @@ LARGE_SPECS = {
         "shards": 10,
         "extra_deps": [
             "@npm//buffer",
+        ],
+    },
+    "jest": {
+        "extra_deps": [
+            "@npm//glob",
+            "@npm//@types/glob",
         ],
     },
 }

--- a/packages/angular_devkit/build_angular/BUILD.bazel
+++ b/packages/angular_devkit/build_angular/BUILD.bazel
@@ -96,6 +96,7 @@ ts_library(
             "builders.json",
             "src/**/schema.json",
             "src/**/*.js",
+            "src/**/*.mjs",
             "src/**/*.html",
         ],
     ),

--- a/packages/angular_devkit/build_angular/builders.json
+++ b/packages/angular_devkit/build_angular/builders.json
@@ -26,6 +26,11 @@
       "schema": "./src/builders/extract-i18n/schema.json",
       "description": "Extract i18n strings from a browser application."
     },
+    "jest": {
+      "implementation": "./src/builders/jest",
+      "schema": "./src/builders/jest/schema.json",
+      "description": "Run unit tests using Jest."
+    },
     "karma": {
       "implementation": "./src/builders/karma",
       "schema": "./src/builders/karma/schema.json",

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -78,6 +78,8 @@
     "@angular/localize": "^16.0.0-next.0",
     "@angular/platform-server": "^16.0.0-next.0",
     "@angular/service-worker": "^16.0.0-next.0",
+    "jest": "^29.5.0",
+    "jest-environment-jsdom": "^29.5.0",
     "karma": "^6.3.0",
     "ng-packagr": "^16.0.0-next.1",
     "protractor": "^7.0.0",
@@ -92,6 +94,12 @@
       "optional": true
     },
     "@angular/service-worker": {
+      "optional": true
+    },
+    "jest": {
+      "optional": true
+    },
+    "jest-environment-jsdom": {
       "optional": true
     },
     "karma": {

--- a/packages/angular_devkit/build_angular/src/builders/jest/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/jest/index.ts
@@ -7,12 +7,18 @@
  */
 
 import { BuilderContext, BuilderOutput, createBuilder } from '@angular-devkit/architect';
+import { execFile as execFileCb } from 'child_process';
+import * as path from 'path';
+import { promisify } from 'util';
+import { colors } from '../../utils/color';
 import { buildEsbuildBrowserInternal } from '../browser-esbuild';
 import { BrowserEsbuildOptions } from '../browser-esbuild/options';
 import { OutputHashing } from '../browser-esbuild/schema';
 import { normalizeOptions } from './options';
 import { Schema as JestBuilderSchema } from './schema';
 import { findTestFiles } from './test-files';
+
+const execFile = promisify(execFileCb);
 
 /** Main execution function for the Jest builder. */
 export default createBuilder(
@@ -22,11 +28,35 @@ export default createBuilder(
     );
 
     const options = normalizeOptions(schema);
-    const testFiles = await findTestFiles(options, context.workspaceRoot);
     const testOut = 'dist/test-out'; // TODO(dgp1130): Hide in temp directory.
 
+    // Verify Jest installation and get the path to it's binary.
+    // We need to `node_modules/.bin/jest`, but there is no means to resolve that directly. Fortunately Jest's `package.json` exports the
+    // same file at `bin/jest`, so we can just resolve that instead.
+    const jest = resolveModule('jest/bin/jest');
+    if (!jest) {
+      return {
+        success: false,
+        // TODO(dgp1130): Display a more accurate message for non-NPM users.
+        error:
+          'Jest is not installed, most likely you need to run `npm install jest --save-dev` in your project.',
+      };
+    }
+
+    // Verify that JSDom is installed in the project.
+    const environment = resolveModule('jest-environment-jsdom');
+    if (!environment) {
+      return {
+        success: false,
+        // TODO(dgp1130): Display a more accurate message for non-NPM users.
+        error:
+          '`jest-environment-jsdom` is not installed. Install it with `npm install jest-environment-jsdom --save-dev`.',
+      };
+    }
+
     // Build all the test files.
-    return await build(context, {
+    const testFiles = await findTestFiles(options, context.workspaceRoot);
+    const buildResult = await build(context, {
       entryPoints: testFiles,
       tsConfig: options.tsConfig,
       polyfills: options.polyfills,
@@ -44,6 +74,53 @@ export default createBuilder(
         vendor: false,
       },
     });
+    if (!buildResult.success) {
+      return buildResult;
+    }
+
+    // Execute Jest on the built output directory.
+    const jestProc = execFile('node', [
+      '--experimental-vm-modules',
+      jest,
+
+      `--rootDir=${testOut}`,
+      '--testEnvironment=jsdom',
+
+      // TODO(dgp1130): Enable cache once we have a mechanism for properly clearing / disabling it.
+      '--no-cache',
+
+      // Run basically all files in the output directory, any excluded files were already dropped by the build.
+      `--testMatch=${path.join('<rootDir>', '**', '*.mjs')}`,
+
+      // Load polyfills before each test, and don't run them directly as a test.
+      `--setupFilesAfterEnv=${path.join('<rootDir>', 'polyfills.mjs')}`,
+      `--testPathIgnorePatterns=${path.join('<rootDir>', 'polyfills\\.mjs')}`,
+
+      // Skip shared chunks, as they are not entry points to tests.
+      `--testPathIgnorePatterns=${path.join('<rootDir>', 'chunk-.*\\.mjs')}`,
+
+      // Optionally enable color.
+      ...(colors.enabled ? ['--colors'] : []),
+    ]);
+
+    // Stream test output to the terminal.
+    jestProc.child.stdout?.on('data', (chunk) => {
+      context.logger.info(chunk);
+    });
+    jestProc.child.stderr?.on('data', (chunk) => {
+      // Write to stderr directly instead of `context.logger.error(chunk)` because the logger will overwrite Jest's coloring information.
+      process.stderr.write(chunk);
+    });
+
+    try {
+      await jestProc;
+    } catch (error) {
+      // No need to propagate error message, already piped to terminal output.
+      // TODO(dgp1130): Handle process spawning failures.
+      return { success: false };
+    }
+
+    return { success: true };
   },
 );
 
@@ -62,5 +139,14 @@ async function build(
       success: false,
       error: (err as Error).message,
     };
+  }
+}
+
+/** Safely resolves the given Node module string. */
+function resolveModule(module: string): string | undefined {
+  try {
+    return require.resolve(module);
+  } catch {
+    return undefined;
   }
 }

--- a/packages/angular_devkit/build_angular/src/builders/jest/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/jest/index.ts
@@ -1,0 +1,66 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { BuilderContext, BuilderOutput, createBuilder } from '@angular-devkit/architect';
+import { buildEsbuildBrowserInternal } from '../browser-esbuild';
+import { BrowserEsbuildOptions } from '../browser-esbuild/options';
+import { OutputHashing } from '../browser-esbuild/schema';
+import { normalizeOptions } from './options';
+import { Schema as JestBuilderSchema } from './schema';
+import { findTestFiles } from './test-files';
+
+/** Main execution function for the Jest builder. */
+export default createBuilder(
+  async (schema: JestBuilderSchema, context: BuilderContext): Promise<BuilderOutput> => {
+    context.logger.warn(
+      'NOTE: The Jest builder is currently EXPERIMENTAL and not ready for production use.',
+    );
+
+    const options = normalizeOptions(schema);
+    const testFiles = await findTestFiles(options, context.workspaceRoot);
+    const testOut = 'dist/test-out'; // TODO(dgp1130): Hide in temp directory.
+
+    // Build all the test files.
+    return await build(context, {
+      entryPoints: testFiles,
+      tsConfig: options.tsConfig,
+      polyfills: options.polyfills,
+      outputPath: testOut,
+      aot: false,
+      index: null,
+      outputHashing: OutputHashing.None,
+      outExtension: 'mjs', // Force native ESM.
+      commonChunk: false,
+      optimization: false,
+      buildOptimizer: false,
+      sourceMap: {
+        scripts: true,
+        styles: false,
+        vendor: false,
+      },
+    });
+  },
+);
+
+async function build(
+  context: BuilderContext,
+  options: BrowserEsbuildOptions,
+): Promise<BuilderOutput> {
+  try {
+    for await (const _ of buildEsbuildBrowserInternal(options, context)) {
+      // Nothing to do for each event, just wait for the whole build.
+    }
+
+    return { success: true };
+  } catch (err) {
+    return {
+      success: false,
+      error: (err as Error).message,
+    };
+  }
+}

--- a/packages/angular_devkit/build_angular/src/builders/jest/init-test-bed.mjs
+++ b/packages/angular_devkit/build_angular/src/builders/jest/init-test-bed.mjs
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+// TODO(dgp1130): These imports likely don't resolve in stricter package environments like `pnpm`, since they are resolved relative to
+// `@angular-devkit/build-angular` rather than the user's workspace. Should look into virtual modules to support those use cases.
+
+import { getTestBed } from '@angular/core/testing';
+import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
+
+getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), {
+  errorOnUnknownElements: true,
+  errorOnUnknownProperties: true,
+});

--- a/packages/angular_devkit/build_angular/src/builders/jest/jest-global.mjs
+++ b/packages/angular_devkit/build_angular/src/builders/jest/jest-global.mjs
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * @fileoverview Zone.js requires the `jest` global to be initialized in order to know that it must patch the environment to support Jest
+ * execution. When running ESM code, Jest does _not_ inject the global `jest` symbol, so Zone.js would not normally know it is running
+ * within Jest as users are supposed to import from `@jest/globals` or use `import.meta.jest`. Zone.js is not currently aware of this, so we
+ * manually set this global to get Zone.js to run correctly.
+ * 
+ * TODO(dgp1130): Update Zone.js to directly support Jest ESM executions so we can drop this.
+ */
+
+// eslint-disable-next-line no-undef
+globalThis.jest = import.meta.jest;

--- a/packages/angular_devkit/build_angular/src/builders/jest/options.ts
+++ b/packages/angular_devkit/build_angular/src/builders/jest/options.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { Schema as JestBuilderSchema } from './schema';
+
+/**
+ * Options supported for the Jest builder. The schema is an approximate
+ * representation of the options type, but this is a more precise version.
+ */
+export type JestBuilderOptions = JestBuilderSchema & {
+  include: string[];
+  exclude: string[];
+};
+
+/**
+ * Normalizes input options validated by the schema to a more precise and useful
+ * options type in {@link JestBuilderOptions}.
+ */
+export function normalizeOptions(schema: JestBuilderSchema): JestBuilderOptions {
+  return {
+    // Options with default values can't actually be null, even if the types say so.
+    /* eslint-disable @typescript-eslint/no-non-null-assertion */
+    include: schema.include!,
+    exclude: schema.exclude!,
+    /* eslint-enable @typescript-eslint/no-non-null-assertion */
+
+    ...schema,
+  };
+}

--- a/packages/angular_devkit/build_angular/src/builders/jest/schema.json
+++ b/packages/angular_devkit/build_angular/src/builders/jest/schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "title": "Jest browser schema for Build Facade.",
+  "description": "Jest target options",
+  "type": "object",
+  "properties": {
+    "include": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": ["**/*.spec.ts"],
+      "description": "Globs of files to include, relative to project root. \nThere are 2 special cases:\n - when a path to directory is provided, all spec files ending \".spec.@(ts|tsx)\" will be included\n - when a path to a file is provided, and a matching spec file exists it will be included instead."
+    },
+    "exclude": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": [],
+      "description": "Globs of files to exclude, relative to the project root."
+    },
+    "tsConfig": {
+      "type": "string",
+      "description": "The name of the TypeScript configuration file."
+    },
+    "polyfills": {
+      "description": "Polyfills to be included in the build.",
+      "oneOf": [
+        {
+          "type": "array",
+          "description": "A list of polyfills to include in the build. Can be a full path for a file, relative to the current workspace or module specifier. Example: 'zone.js'.",
+          "items": {
+            "type": "string",
+            "uniqueItems": true
+          },
+          "default": []
+        },
+        {
+          "type": "string",
+          "description": "The full path for the polyfills file, relative to the current workspace or a module specifier. Example: 'zone.js'."
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "required": ["tsConfig"]
+}

--- a/packages/angular_devkit/build_angular/src/builders/jest/schema.json
+++ b/packages/angular_devkit/build_angular/src/builders/jest/schema.json
@@ -10,7 +10,7 @@
         "type": "string"
       },
       "default": ["**/*.spec.ts"],
-      "description": "Globs of files to include, relative to project root. \nThere are 2 special cases:\n - when a path to directory is provided, all spec files ending \".spec.@(ts|tsx)\" will be included\n - when a path to a file is provided, and a matching spec file exists it will be included instead."
+      "description": "Globs of files to include, relative to project root."
     },
     "exclude": {
       "type": "array",

--- a/packages/angular_devkit/build_angular/src/builders/jest/test-files.ts
+++ b/packages/angular_devkit/build_angular/src/builders/jest/test-files.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { IOptions as GlobOptions, glob as globCb } from 'glob';
+import { promisify } from 'util';
+import { JestBuilderOptions } from './options';
+
+const globAsync = promisify(globCb);
+
+/**
+ * Finds all test files in the project.
+ *
+ * @param options The builder options describing where to find tests.
+ * @param workspaceRoot The path to the root directory of the workspace.
+ * @param glob A promisified implementation of the `glob` module. Only intended for
+ *     testing purposes.
+ * @returns A set of all test files in the project.
+ */
+export async function findTestFiles(
+  options: JestBuilderOptions,
+  workspaceRoot: string,
+  glob: typeof globAsync = globAsync,
+): Promise<Set<string>> {
+  const globOptions: GlobOptions = {
+    cwd: workspaceRoot,
+    ignore: ['node_modules/**'].concat(options.exclude),
+    strict: true, // Fail on an "unusual error" when reading the file system.
+    nobrace: true, // Do not expand `a{b,c}` to `ab,ac`.
+    noext: true, // Disable "extglob" patterns.
+    nodir: true, // Match only files, don't care about directories.
+  };
+
+  const included = await Promise.all(options.include.map((pattern) => glob(pattern, globOptions)));
+
+  // Flatten and deduplicate any files found in multiple include patterns.
+  return new Set(included.flat());
+}

--- a/packages/angular_devkit/build_angular/src/builders/jest/tests/options.ts
+++ b/packages/angular_devkit/build_angular/src/builders/jest/tests/options.ts
@@ -1,0 +1,16 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { JestBuilderOptions } from '../options';
+
+/** Default options to use for most tests. */
+export const BASE_OPTIONS = Object.freeze<JestBuilderOptions>({
+  include: ['**/*.spec.ts'],
+  exclude: [],
+  tsConfig: 'tsconfig.spec.json',
+});

--- a/packages/angular_devkit/build_angular/src/builders/jest/tests/test-files_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/jest/tests/test-files_spec.ts
@@ -1,0 +1,172 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { promises as fs } from 'fs';
+import { glob as globCb } from 'glob';
+import * as path from 'path';
+import { promisify } from 'util';
+import { findTestFiles } from '../test-files';
+import { BASE_OPTIONS } from './options';
+
+const realGlob = promisify(globCb);
+
+describe('test-files', () => {
+  describe('findTestFiles()', () => {
+    let tempDir!: string;
+
+    beforeEach(async () => {
+      tempDir = await fs.mkdtemp('angular-cli-jest-builder-test-files-');
+    });
+
+    afterEach(async () => {
+      await fs.rm(tempDir, { recursive: true });
+    });
+
+    it('returns all the test files in the project', async () => {
+      await fs.writeFile(path.join(tempDir, 'foo.spec.ts'), '');
+      await fs.mkdir(path.join(tempDir, 'nested'));
+      await fs.writeFile(path.join(tempDir, 'nested', 'bar.spec.ts'), '');
+
+      const testFiles = await findTestFiles(
+        {
+          ...BASE_OPTIONS,
+          include: ['**/*.spec.ts'],
+          exclude: [],
+        },
+        tempDir,
+      );
+
+      expect(testFiles).toEqual(new Set(['foo.spec.ts', path.join('nested', 'bar.spec.ts')]));
+    });
+
+    it('excludes `node_modules/` and files from input options', async () => {
+      await fs.writeFile(path.join(tempDir, 'foo.spec.ts'), '');
+      await fs.writeFile(path.join(tempDir, 'bar.ignored.spec.ts'), '');
+      await fs.mkdir(path.join(tempDir, 'node_modules', 'dep'), { recursive: true });
+      await fs.writeFile(path.join(tempDir, 'node_modules', 'dep', 'baz.spec.ts'), '');
+
+      const testFiles = await findTestFiles(
+        {
+          ...BASE_OPTIONS,
+          include: ['**/*.spec.ts'],
+          exclude: ['**/*.ignored.spec.ts'],
+        },
+        tempDir,
+      );
+
+      expect(testFiles).toEqual(new Set(['foo.spec.ts']));
+    });
+
+    it('finds files in multiple globs', async () => {
+      await fs.writeFile(path.join(tempDir, 'foo.spec.ts'), '');
+      await fs.writeFile(path.join(tempDir, 'bar.test.ts'), '');
+      await fs.writeFile(path.join(tempDir, 'foo.ignored.spec.ts'), '');
+      await fs.writeFile(path.join(tempDir, 'bar.ignored.test.ts'), '');
+
+      await fs.mkdir(path.join(tempDir, 'node_modules', 'dep'), { recursive: true });
+      await fs.writeFile(path.join(tempDir, 'node_modules', 'dep', 'baz.spec.ts'), '');
+      await fs.writeFile(path.join(tempDir, 'node_modules', 'dep', 'baz.test.ts'), '');
+
+      const testFiles = await findTestFiles(
+        {
+          ...BASE_OPTIONS,
+          include: ['**/*.spec.ts', '**/*.test.ts'],
+          // Exclude should be applied to all `glob()` executions.
+          exclude: ['**/*.ignored.*.ts'],
+        },
+        tempDir,
+      );
+
+      expect(testFiles).toEqual(new Set(['foo.spec.ts', 'bar.test.ts']));
+    });
+
+    it('is constrained to the workspace root', async () => {
+      await fs.mkdir(path.join(tempDir, 'nested'));
+      await fs.writeFile(path.join(tempDir, 'foo.spec.ts'), '');
+      await fs.writeFile(path.join(tempDir, 'nested', 'bar.spec.ts'), '');
+
+      const testFiles = await findTestFiles(
+        {
+          ...BASE_OPTIONS,
+          include: ['**/*.spec.ts'],
+        },
+        path.join(tempDir, 'nested'),
+      );
+
+      expect(testFiles).toEqual(new Set(['bar.spec.ts']));
+    });
+
+    it('throws if any `glob` invocation fails', async () => {
+      const err = new Error('Eww, I stepped in a glob.');
+      const glob = jasmine
+        .createSpy('glob', realGlob)
+        .and.returnValues(
+          Promise.resolve(['foo.spec.ts']),
+          Promise.reject(err),
+          Promise.resolve(['bar.test.ts']),
+        );
+
+      await expectAsync(
+        findTestFiles(
+          {
+            ...BASE_OPTIONS,
+            include: ['*.spec.ts', '*.stuff.ts', '*.test.ts'],
+          },
+          tempDir,
+          glob,
+        ),
+      ).toBeRejectedWith(err);
+    });
+
+    it('disables brace expansion', async () => {
+      await fs.writeFile(path.join(tempDir, 'foo.spec.ts'), '');
+      await fs.writeFile(path.join(tempDir, 'bar.spec.ts'), '');
+
+      const testFiles = await findTestFiles(
+        {
+          ...BASE_OPTIONS,
+          include: ['{foo,bar}.spec.ts'],
+        },
+        tempDir,
+      );
+
+      expect(testFiles).toEqual(new Set());
+    });
+
+    it('disables `extglob` features', async () => {
+      await fs.writeFile(path.join(tempDir, 'foo.spec.ts'), '');
+      await fs.writeFile(path.join(tempDir, 'bar.spec.ts'), '');
+
+      const testFiles = await findTestFiles(
+        {
+          ...BASE_OPTIONS,
+          include: ['+(foo|bar).spec.ts'],
+        },
+        tempDir,
+      );
+
+      expect(testFiles).toEqual(new Set());
+    });
+
+    it('ignores directories', async () => {
+      await fs.mkdir(path.join(tempDir, 'foo.spec.ts'));
+      await fs.mkdir(path.join(tempDir, 'bar.spec.ts'));
+      await fs.writeFile(path.join(tempDir, 'bar.spec.ts', 'baz.spec.ts'), '');
+
+      const testFiles = await findTestFiles(
+        {
+          ...BASE_OPTIONS,
+          include: ['**/*.spec.ts'],
+        },
+        tempDir,
+      );
+
+      expect(testFiles).toEqual(new Set([path.join('bar.spec.ts', 'baz.spec.ts')]));
+    });
+  });
+});

--- a/tests/legacy-cli/e2e/tests/jest/basic.ts
+++ b/tests/legacy-cli/e2e/tests/jest/basic.ts
@@ -1,0 +1,12 @@
+import { applyJestBuilder } from '../../utils/jest';
+import { ng } from '../../utils/process';
+
+export default async function (): Promise<void> {
+  await applyJestBuilder();
+
+  const { stderr } = await ng('test');
+
+  if (!stderr.includes('Jest builder is currently EXPERIMENTAL')) {
+    throw new Error(`No experimental notice in stderr.\nSTDERR:\n\n${stderr}`);
+  }
+}

--- a/tests/legacy-cli/e2e/utils/jest.ts
+++ b/tests/legacy-cli/e2e/utils/jest.ts
@@ -1,0 +1,29 @@
+import { silentNpm } from './process';
+import { updateJsonFile } from './project';
+
+/** Updates the `test` builder in the current workspace to use Jest with the given options. */
+export async function applyJestBuilder(
+  options: {} = {
+    tsConfig: 'tsconfig.spec.json',
+    polyfills: ['zone.js', 'zone.js/testing'],
+  },
+): Promise<void> {
+  await silentNpm('install', 'jest@29.5.0', 'jest-environment-jsdom@29.5.0', '--save-dev');
+
+  await updateJsonFile('angular.json', (json) => {
+    const projects = Object.values(json['projects']);
+    if (projects.length !== 1) {
+      throw new Error(
+        `Expected exactly one project but found ${projects.length} projects named ${Object.keys(
+          json['projects'],
+        ).join(', ')}`,
+      );
+    }
+    const project = projects[0]! as any;
+
+    // Update to Jest builder.
+    const test = project['architect']['test'];
+    test['builder'] = '@angular-devkit/build-angular:jest';
+    test['options'] = options;
+  });
+}


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [X] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Feature

## What is the new behavior?

This PR adds initial experimental [Jest](https://jestjs.io/) support. This is _experimental_ and not ready for production use yet. For now, it it sufficient to pass the tests generated by the `ng new` application and we will continue to expand on this design going forward.

Enable the Jest runner by updating the `test` builder in your `angular.json` to be:

```jsonc
{
  "projects": {
    "my-app": {
      "architect": {
        // ...
        "test": {
          "builder": "@angular-devkit/build-angular:jest"
        }
      }
    }
  }
}
```

The current approach is to pre-build application tests with the `browser-esbuild` Angular builder under the hood, and then run Jest on the JavaScript outputs. We'll continue to experiment with this architecture and others to see what the best path forward is in terms of performance, maintenance, and developer ergonomics.

## Does this PR introduce a breaking change?

- [X] No