### PR TITLE
fix(@schematics/angular): replace vscode launch type from `pwa-chrome` to `chrome`

### DIFF
--- a/packages/schematics/angular/workspace/files/__dot__vscode/launch.json.template
+++ b/packages/schematics/angular/workspace/files/__dot__vscode/launch.json.template
@@ -4,7 +4,7 @@
   "configurations": [
     {
       "name": "ng serve",
-      "type": "pwa-chrome",
+      "type": "chrome",
       "request": "launch",
       "preLaunchTask": "npm: start",
       "url": "http://localhost:4200/"


### PR DESCRIPTION

The former is deprecated.
