### PR TITLE
fix(@angular-devkit/build-angular): update esbuild builder complete log

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
@@ -267,7 +267,7 @@ async function execute(
   logBuildStats(context, metafile, initialFiles);
 
   const buildTime = Number(process.hrtime.bigint() - startTime) / 10 ** 9;
-  context.logger.info(`Complete. [${buildTime.toFixed(3)} seconds]`);
+  context.logger.info(`Application bundle generation complete. [${buildTime.toFixed(3)} seconds]`);
 
   return executionResult;
 }

--- a/tests/legacy-cli/e2e/tests/basic/rebuild.ts
+++ b/tests/legacy-cli/e2e/tests/basic/rebuild.ts
@@ -6,7 +6,7 @@ import { getGlobalVariable } from '../../utils/env';
 
 export default async function () {
   const esbuild = getGlobalVariable('argv')['esbuild'];
-  const validBundleRegEx = esbuild ? /Complete\./ : /Compiled successfully\./;
+  const validBundleRegEx = esbuild ? /complete\./ : /Compiled successfully\./;
   const lazyBundleRegEx = esbuild ? /lazy\.module/ : /lazy_module_ts\.js/;
 
   const port = await ngServe();

--- a/tests/legacy-cli/e2e/utils/project.ts
+++ b/tests/legacy-cli/e2e/utils/project.ts
@@ -27,7 +27,7 @@ export async function ngServe(...args: string[]) {
   const port = await findFreePort();
 
   const esbuild = getGlobalVariable('argv')['esbuild'];
-  const validBundleRegEx = esbuild ? /Complete\./ : /Compiled successfully\./;
+  const validBundleRegEx = esbuild ? /complete\./ : /Compiled successfully\./;
 
   await execAndWaitForOutputToMatch(
     'ng',


### PR DESCRIPTION
The complete log has been updated to match the RegExp in https://github.com/angular/angular-cli/blob/c045c99667cec8a5986302d59eef3d326e3a53d2/packages/schematics/angular/workspace/files/__dot__vscode/tasks.json.template#L18 as otherwise vscode debugged will not work correctly when using vscode launcher to launch the dev-server.
