### PR TITLE
fix(@angular-devkit/build-angular): provide option to run build-optimizer on server bundles

### DIFF
--- a/goldens/public-api/angular_devkit/build_angular/index.md
+++ b/goldens/public-api/angular_devkit/build_angular/index.md
@@ -267,6 +267,7 @@ export interface ProtractorBuilderOptions {
 // @public (undocumented)
 export interface ServerBuilderOptions {
     assets?: AssetPattern_3[];
+    buildOptimizer?: boolean;
     deleteOutputPath?: boolean;
     // @deprecated
     deployUrl?: string;

--- a/packages/angular_devkit/build_angular/src/builders/server/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/server/index.ts
@@ -203,7 +203,6 @@ async function initialize(
     await generateI18nBrowserWebpackConfigFromContext(
       {
         ...adjustedOptions,
-        buildOptimizer: false,
         aot: true,
         platform: 'server',
       } as NormalizedBrowserBuilderSchema,

--- a/packages/angular_devkit/build_angular/src/builders/server/schema.json
+++ b/packages/angular_devkit/build_angular/src/builders/server/schema.json
@@ -189,6 +189,11 @@
       "description": "Extract all licenses in a separate file, in the case of production builds only.",
       "default": true
     },
+    "buildOptimizer": {
+      "type": "boolean",
+      "description": "Enables advanced build optimizations.",
+      "default": true
+    },
     "namedChunks": {
       "type": "boolean",
       "description": "Use file name for lazy loaded chunks.",

--- a/packages/schematics/angular/universal/index.ts
+++ b/packages/schematics/angular/universal/index.ts
@@ -46,6 +46,7 @@ function updateConfigFile(options: UniversalOptions, tsConfigDirectory: Path): R
       // One for the server which will be unhashed, and other on the client which will be hashed.
       const getServerOptions = (options: Record<string, JsonValue | undefined> = {}): {} => {
         return {
+          buildOptimizer: options?.buildOptimizer,
           outputHashing: options?.outputHashing === 'all' ? 'media' : options?.outputHashing,
           fileReplacements: options?.fileReplacements,
           optimization: options?.optimization === undefined ? undefined : !!options?.optimization,

--- a/tests/legacy-cli/e2e/tests/build/server/platform-server-build-optimizer.ts
+++ b/tests/legacy-cli/e2e/tests/build/server/platform-server-build-optimizer.ts
@@ -1,0 +1,62 @@
+import { normalize } from 'path';
+import { getGlobalVariable } from '../../../utils/env';
+import { expectFileToMatch, replaceInFile, writeFile } from '../../../utils/fs';
+import { installPackage } from '../../../utils/packages';
+import { exec, ng } from '../../../utils/process';
+import { updateJsonFile } from '../../../utils/project';
+
+const snapshots = require('../../../ng-snapshot/package.json');
+
+export default async function () {
+  await ng('generate', 'application', 'test-project-two', '--standalone', '--skip-install');
+  await ng('generate', 'universal', '--project', 'test-project-two');
+
+  const isSnapshotBuild = getGlobalVariable('argv')['ng-snapshots'];
+  if (isSnapshotBuild) {
+    const packagesToInstall: string[] = [];
+    await updateJsonFile('package.json', (packageJson) => {
+      const dependencies = packageJson['dependencies'];
+      // Iterate over all of the packages to update them to the snapshot version.
+      for (const [name, version] of Object.entries<string>(snapshots.dependencies)) {
+        if (name in dependencies && dependencies[name] !== version) {
+          packagesToInstall.push(version);
+        }
+      }
+    });
+
+    for (const pkg of packagesToInstall) {
+      await installPackage(pkg);
+    }
+  }
+
+  await writeFile(
+    './projects/test-project-two/server.ts',
+    `   import 'zone.js/node';
+        import * as fs from 'fs';
+        import { renderApplication } from '@angular/platform-server';
+        import bootstrap from './src/main.server';
+
+        renderApplication(bootstrap, {
+          url: '/',
+          document: '<app-root></app-root>'
+        }).then(html => {
+          fs.writeFileSync('dist/test-project-two/server/index.html', html);
+        })
+        `,
+  );
+
+  await replaceInFile(
+    './projects/test-project-two/tsconfig.server.json',
+    'src/main.server.ts',
+    'server.ts',
+  );
+  await replaceInFile('angular.json', 'src/main.server.ts', 'server.ts');
+
+  // works with build-optimizer
+  await ng('run', 'test-project-two:server', '--optimization', '--build-optimizer');
+  await exec(normalize('node'), 'dist/test-project-two/server/main.js');
+  await expectFileToMatch(
+    'dist/test-project-two/server/index.html',
+    /<p.*>Here are some links to help you get started:<\/p>/,
+  );
+}


### PR DESCRIPTION


This commit adds the option to run build-optimizer on the server bundles.

This is needed as in some cases, there can be restrictions on the size of server bundles that can be executed. One of these cases is CloudFlare workers
 which by default does not work with an `ng-new` application due to the size of the
 bundle mainly due to the retention of the `@angular/compiler`.

//cc @AndrewKushnir 
