### PR TITLE
perf(@angular-devkit/build-angular): do not inline sourcemap when using vite dev-server

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
@@ -228,13 +228,12 @@ export async function setupServer(
             return;
           }
 
-          const code = Buffer.from(codeContents).toString('utf-8');
           const mapContents = outputFiles.get(file + '.map')?.contents;
 
           return {
             // Remove source map URL comments from the code if a sourcemap is present.
             // Vite will inline and add an additional sourcemap URL for the sourcemap.
-            code: mapContents ? code.replace(/^\/\/# sourceMappingURL=[^\r\n]*/gm, '') : code,
+            code: Buffer.from(codeContents).toString('utf-8'),
             map: mapContents && Buffer.from(mapContents).toString('utf-8'),
           };
         },
@@ -262,7 +261,7 @@ export async function setupServer(
             // Resource files are handled directly.
             // Global stylesheets (CSS files) are currently considered resources to workaround
             // dev server sourcemap issues with stylesheets.
-            if (extension !== '.js' && extension !== '.html') {
+            if (extension !== '.html') {
               const outputFile = outputFiles.get(parsedUrl.pathname);
               if (outputFile) {
                 const mimeType = lookupMimeType(extension);


### PR DESCRIPTION

Vite inlines the source map as part of content (https://github.com/vitejs/vite/blob/ba62be40b4f46c98872fb10990b559fee88f4a29/packages/vite/src/node/server/send.ts#L59-L63) with no option to disable this behaviour. While this is improves performances when Vite is used without prebundling. When using prebundling this is causes an overhead as the response can grow drastically, in some cases over 50mb.

Closes #25012