### PR TITLE
refactor: replace `node` with `process.execPath`

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/jest/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/jest/index.ts
@@ -82,7 +82,7 @@ export default createBuilder(
     }
 
     // Execute Jest on the built output directory.
-    const jestProc = execFile('node', [
+    const jestProc = execFile(process.execPath, [
       '--experimental-vm-modules',
       jest,
 


### PR DESCRIPTION
This is ensure that the same node executable is used to spawn Jest
