### PR TITLE
fix(@angular-devkit/build-angular): always enable `looseEnums` build optimizer rule

### DIFF
--- a/packages/angular_devkit/build_angular/src/babel/plugins/adjust-typescript-enums.ts
+++ b/packages/angular_devkit/build_angular/src/babel/plugins/adjust-typescript-enums.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { NodePath, PluginObj, PluginPass, types } from '@babel/core';
+import { NodePath, PluginObj, types } from '@babel/core';
 import annotateAsPure from '@babel/helper-annotate-as-pure';
 
 /**
@@ -27,10 +27,8 @@ export function getKeywords(): Iterable<string> {
 export default function (): PluginObj {
   return {
     visitor: {
-      VariableDeclaration(path: NodePath<types.VariableDeclaration>, state: PluginPass) {
+      VariableDeclaration(path: NodePath<types.VariableDeclaration>) {
         const { parentPath, node } = path;
-        const { loose } = state.opts as { loose: boolean };
-
         if (node.kind !== 'var' || node.declarations.length !== 1) {
           return;
         }
@@ -80,13 +78,8 @@ export default function (): PluginObj {
         const isEnumCalleeMatching =
           types.isIdentifier(enumCalleeParam) && enumCalleeParam.name === declarationId.name;
 
-        // Loose mode rewrites the enum to a shorter but less TypeScript-like form
-        // Note: We only can apply the `loose` mode transformation if the callee parameter matches
-        // with the declaration identifier name. This is necessary in case the the declaration id has
-        // been renamed to avoid collisions, as the loose transform would then break the enum assignments
-        // which rely on the differently-named callee identifier name.
         let enumAssignments: types.ExpressionStatement[] | undefined;
-        if (loose && isEnumCalleeMatching) {
+        if (isEnumCalleeMatching) {
           enumAssignments = [];
         }
 

--- a/packages/angular_devkit/build_angular/src/babel/plugins/adjust-typescript-enums_spec.ts
+++ b/packages/angular_devkit/build_angular/src/babel/plugins/adjust-typescript-enums_spec.ts
@@ -43,10 +43,9 @@ describe('adjust-typescript-enums Babel plugin', () => {
       `,
       expected: `
         var ChangeDetectionStrategy = /*#__PURE__*/ (() => {
-          (function (ChangeDetectionStrategy) {
-              ChangeDetectionStrategy[ChangeDetectionStrategy["OnPush"] = 0] = "OnPush";
-              ChangeDetectionStrategy[ChangeDetectionStrategy["Default"] = 1] = "Default";
-          })(ChangeDetectionStrategy || (ChangeDetectionStrategy = {}));
+          ChangeDetectionStrategy = ChangeDetectionStrategy || {};
+          ChangeDetectionStrategy[(ChangeDetectionStrategy["OnPush"] = 0)] = "OnPush";
+          ChangeDetectionStrategy[(ChangeDetectionStrategy["Default"] = 1)] = "Default";
           return ChangeDetectionStrategy;
         })();
       `,
@@ -64,10 +63,9 @@ describe('adjust-typescript-enums Babel plugin', () => {
       `,
       expected: `
         export var ChangeDetectionStrategy = /*#__PURE__*/ (() => {
-          (function (ChangeDetectionStrategy) {
-              ChangeDetectionStrategy[ChangeDetectionStrategy["OnPush"] = 0] = "OnPush";
-              ChangeDetectionStrategy[ChangeDetectionStrategy["Default"] = 1] = "Default";
-          })(ChangeDetectionStrategy || (ChangeDetectionStrategy = {}));
+          ChangeDetectionStrategy = ChangeDetectionStrategy || {};
+          ChangeDetectionStrategy[(ChangeDetectionStrategy["OnPush"] = 0)] = "OnPush";
+          ChangeDetectionStrategy[(ChangeDetectionStrategy["Default"] = 1)] = "Default";
           return ChangeDetectionStrategy;
         })();
       `,
@@ -85,10 +83,9 @@ describe('adjust-typescript-enums Babel plugin', () => {
       `,
       expected: `
         export var ChangeDetectionStrategy = /*#__PURE__*/ (() => {
-          (function (ChangeDetectionStrategy) {
-              ChangeDetectionStrategy[ChangeDetectionStrategy["OnPush"] = 5] = "OnPush";
-              ChangeDetectionStrategy[ChangeDetectionStrategy["Default"] = 8] = "Default";
-          })(ChangeDetectionStrategy || (ChangeDetectionStrategy = {}));
+          ChangeDetectionStrategy = ChangeDetectionStrategy || {};
+          ChangeDetectionStrategy[(ChangeDetectionStrategy["OnPush"] = 5)] = "OnPush";
+          ChangeDetectionStrategy[(ChangeDetectionStrategy["Default"] = 8)] = "Default";
           return ChangeDetectionStrategy;
         })();
       `,
@@ -98,20 +95,19 @@ describe('adjust-typescript-enums Babel plugin', () => {
   it('wraps string-based TypeScript enums', () => {
     testCase({
       input: `
-        var NotificationKind;
-        (function (NotificationKind) {
-            NotificationKind["NEXT"] = "N";
-            NotificationKind["ERROR"] = "E";
-            NotificationKind["COMPLETE"] = "C";
-        })(NotificationKind || (NotificationKind = {}));
+      var NotificationKind;
+      (function (NotificationKind) {
+          NotificationKind["NEXT"] = "N";
+          NotificationKind["ERROR"] = "E";
+          NotificationKind["COMPLETE"] = "C";
+      })(NotificationKind || (NotificationKind = {}));
       `,
       expected: `
         var NotificationKind = /*#__PURE__*/ (() => {
-          (function (NotificationKind) {
-              NotificationKind["NEXT"] = "N";
-              NotificationKind["ERROR"] = "E";
-              NotificationKind["COMPLETE"] = "C";
-          })(NotificationKind || (NotificationKind = {}));
+          NotificationKind = NotificationKind || {};
+          NotificationKind["NEXT"] = "N";
+          NotificationKind["ERROR"] = "E";
+          NotificationKind["COMPLETE"] = "C";
           return NotificationKind;
         })();
       `,
@@ -165,15 +161,14 @@ describe('adjust-typescript-enums Babel plugin', () => {
          * @deprecated use @angular/common/http instead
          */
         var RequestMethod = /*#__PURE__*/ (() => {
-          (function (RequestMethod) {
-              RequestMethod[RequestMethod["Get"] = 0] = "Get";
-              RequestMethod[RequestMethod["Post"] = 1] = "Post";
-              RequestMethod[RequestMethod["Put"] = 2] = "Put";
-              RequestMethod[RequestMethod["Delete"] = 3] = "Delete";
-              RequestMethod[RequestMethod["Options"] = 4] = "Options";
-              RequestMethod[RequestMethod["Head"] = 5] = "Head";
-              RequestMethod[RequestMethod["Patch"] = 6] = "Patch";
-          })(RequestMethod || (RequestMethod = {}));
+          RequestMethod = RequestMethod || {};
+          RequestMethod[(RequestMethod["Get"] = 0)] = "Get";
+          RequestMethod[(RequestMethod["Post"] = 1)] = "Post";
+          RequestMethod[(RequestMethod["Put"] = 2)] = "Put";
+          RequestMethod[(RequestMethod["Delete"] = 3)] = "Delete";
+          RequestMethod[(RequestMethod["Options"] = 4)] = "Options";
+          RequestMethod[(RequestMethod["Head"] = 5)] = "Head";
+          RequestMethod[(RequestMethod["Patch"] = 6)] = "Patch";
           return RequestMethod;
         })();
       `,

--- a/packages/angular_devkit/build_angular/src/babel/plugins/adjust-typescript-enums_spec.ts
+++ b/packages/angular_devkit/build_angular/src/babel/plugins/adjust-typescript-enums_spec.ts
@@ -12,19 +12,11 @@ import { default as adjustTypeScriptEnums } from './adjust-typescript-enums';
 // eslint-disable-next-line import/no-extraneous-dependencies
 const prettier = require('prettier');
 
-function testCase({
-  input,
-  expected,
-  options,
-}: {
-  input: string;
-  expected: string;
-  options?: { loose?: boolean };
-}): void {
+function testCase({ input, expected }: { input: string; expected: string }): void {
   const result = transform(input, {
     configFile: false,
     babelrc: false,
-    plugins: [[adjustTypeScriptEnums, options]],
+    plugins: [[adjustTypeScriptEnums]],
   });
   if (!result) {
     fail('Expected babel to return a transform result.');
@@ -211,7 +203,7 @@ describe('adjust-typescript-enums Babel plugin', () => {
     `);
   });
 
-  it('wraps TypeScript enums in loose mode', () => {
+  it('wraps TypeScript enums', () => {
     testCase({
       input: `
         var ChangeDetectionStrategy;
@@ -228,23 +220,19 @@ describe('adjust-typescript-enums Babel plugin', () => {
           return ChangeDetectionStrategy;
         })();
       `,
-      options: { loose: true },
     });
   });
 
-  it(
-    'should not wrap TypeScript enums in loose mode if the declaration identifier has been ' +
-      'renamed to avoid collisions',
-    () => {
-      testCase({
-        input: `
+  it('should not wrap TypeScript enums if the declaration identifier has been renamed to avoid collisions', () => {
+    testCase({
+      input: `
         var ChangeDetectionStrategy$1;
         (function (ChangeDetectionStrategy) {
             ChangeDetectionStrategy[ChangeDetectionStrategy["OnPush"] = 0] = "OnPush";
             ChangeDetectionStrategy[ChangeDetectionStrategy["Default"] = 1] = "Default";
         })(ChangeDetectionStrategy$1 || (ChangeDetectionStrategy$1 = {}));
       `,
-        expected: `
+      expected: `
         var ChangeDetectionStrategy$1 = /*#__PURE__*/ (() => {
           (function (ChangeDetectionStrategy) {
             ChangeDetectionStrategy[(ChangeDetectionStrategy["OnPush"] = 0)] = "OnPush";
@@ -253,8 +241,6 @@ describe('adjust-typescript-enums Babel plugin', () => {
           return ChangeDetectionStrategy$1;
         })();
       `,
-        options: { loose: true },
-      });
-    },
-  );
+    });
+  });
 });

--- a/packages/angular_devkit/build_angular/src/babel/presets/application.ts
+++ b/packages/angular_devkit/build_angular/src/babel/presets/application.ts
@@ -68,7 +68,6 @@ export interface ApplicationPresetOptions {
     inputSourceMap: unknown;
   };
   optimize?: {
-    looseEnums: boolean;
     pureTopLevel: boolean;
     wrapDecorators: boolean;
   };
@@ -245,10 +244,7 @@ export default function (api: unknown, options: ApplicationPresetOptions) {
 
     plugins.push(
       require('../plugins/elide-angular-metadata').default,
-      [
-        require('../plugins/adjust-typescript-enums').default,
-        { loose: options.optimize.looseEnums },
-      ],
+      [require('../plugins/adjust-typescript-enums').default, { loose: true }],
       [
         require('../plugins/adjust-static-class-members').default,
         { wrapDecorators: options.optimize.wrapDecorators },

--- a/packages/angular_devkit/build_angular/src/babel/webpack-loader.ts
+++ b/packages/angular_devkit/build_angular/src/babel/webpack-loader.ts
@@ -154,18 +154,15 @@ export default custom<ApplicationPresetOptions>(() => {
       }
 
       if (optimize) {
-        // @angular/platform-server/init entry-point has side-effects.
-        const safeAngularPackage =
-          /[\\/]node_modules[\\/]@angular[\\/]/.test(this.resourcePath) &&
-          !/@angular[\\/]platform-server[\\/]f?esm2022[\\/]init/.test(this.resourcePath);
+        const AngularPackage = /[\\/]node_modules[\\/]@angular[\\/]/.test(this.resourcePath);
+        const sideEffectFree = !!this._module?.factoryMeta?.sideEffectFree;
         customOptions.optimize = {
           // Angular packages provide additional tested side effects guarantees and can use
-          // otherwise unsafe optimizations.
-          looseEnums: safeAngularPackage,
-          pureTopLevel: safeAngularPackage,
+          // otherwise unsafe optimizations. (@angular/platform-server/init) however has side-effects.
+          pureTopLevel: AngularPackage && sideEffectFree,
           // JavaScript modules that are marked as side effect free are considered to have
           // no decorators that contain non-local effects.
-          wrapDecorators: !!this._module?.factoryMeta?.sideEffectFree,
+          wrapDecorators: sideEffectFree,
         };
 
         shouldProcess = true;

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/javascript-transformer-worker.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/javascript-transformer-worker.ts
@@ -86,7 +86,6 @@ async function transformWithBabel({
           },
           forceAsyncTransformation,
           optimize: options.advancedOptimizations && {
-            looseEnums: angularPackage,
             pureTopLevel: angularPackage,
           },
         },

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/javascript-transformer-worker.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/javascript-transformer-worker.ts
@@ -55,7 +55,10 @@ async function transformWithBabel({
     return useInputSourcemap ? data : data.replace(/^\/\/# sourceMappingURL=[^\r\n]*/gm, '');
   }
 
-  const angularPackage = /[\\/]node_modules[\\/]@angular[\\/]/.test(filename);
+  // @angular/platform-server/init entry-point has side-effects.
+  const safeAngularPackage =
+    /[\\/]node_modules[\\/]@angular[\\/]/.test(filename) &&
+    !/@angular[\\/]platform-server[\\/]f?esm2022[\\/]init/.test(filename);
 
   // Lazy load the linker plugin only when linking is required
   if (shouldLink) {
@@ -86,7 +89,7 @@ async function transformWithBabel({
           },
           forceAsyncTransformation,
           optimize: options.advancedOptimizations && {
-            pureTopLevel: angularPackage,
+            pureTopLevel: safeAngularPackage,
           },
         },
       ],


### PR DESCRIPTION


With this change TypeScript enums are always processing in "loose" mode. Previously, this was only done for `@angular/` packages.
