### PR TITLE
refactor(@angular-devkit/build-angular): update esbuild builder option status messages

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/builder-status-warnings.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/builder-status-warnings.ts
@@ -25,20 +25,22 @@ const UNSUPPORTED_OPTIONS: Array<keyof BrowserBuilderOptions> = [
   // * Always enabled with esbuild
   // 'commonChunk',
 
-  // * Currently unsupported by esbuild
+  // * Unused by builder and will be removed in a future release
   'namedChunks',
   'vendorChunk',
+
+  // * Currently unsupported by esbuild
   'webWorkerTsConfig',
 ];
 
-export function logExperimentalWarnings(options: BrowserEsbuildOptions, context: BuilderContext) {
-  // Warn about experimental status of this builder
+export function logBuilderStatusWarnings(options: BrowserEsbuildOptions, context: BuilderContext) {
   context.logger.warn(
-    `The esbuild browser application builder ('browser-esbuild') is currently experimental.`,
+    `The esbuild-based browser application builder ('browser-esbuild') is currently in developer preview` +
+      ' and is not yet recommended for production use.' +
+      ' For additional information, please see https://angular.io/guide/esbuild',
   );
 
   // Validate supported options
-  // Currently only a subset of the Webpack-based browser builder options are supported.
   for (const unsupportedOption of UNSUPPORTED_OPTIONS) {
     const value = (options as unknown as BrowserBuilderOptions)[unsupportedOption];
 
@@ -52,8 +54,17 @@ export function logExperimentalWarnings(options: BrowserEsbuildOptions, context:
       continue;
     }
 
-    context.logger.warn(
-      `The '${unsupportedOption}' option is currently unsupported by this experimental builder and will be ignored.`,
-    );
+    if (
+      unsupportedOption === 'namedChunks' ||
+      unsupportedOption === 'vendorChunk' ||
+      unsupportedOption === 'deployUrl'
+    ) {
+      context.logger.warn(
+        `The '${unsupportedOption}' option is not used by this builder and will be ignored.`,
+      );
+      continue;
+    }
+
+    context.logger.warn(`The '${unsupportedOption}' option is not yet supported by this builder.`);
   }
 }

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
@@ -22,9 +22,9 @@ import { Spinner } from '../../utils/spinner';
 import { getSupportedBrowsers } from '../../utils/supported-browsers';
 import { BundleStats, generateBuildStatsTable } from '../../webpack/utils/stats';
 import { SourceFileCache, createCompilerPlugin } from './angular/compiler-plugin';
+import { logBuilderStatusWarnings } from './builder-status-warnings';
 import { checkCommonJSModules } from './commonjs-checker';
 import { BundlerContext, logMessages } from './esbuild';
-import { logExperimentalWarnings } from './experimental-warnings';
 import { createGlobalScriptsBundleOptions } from './global-scripts';
 import { extractLicenses } from './license-extractor';
 import { LoadResultCache } from './load-result-cache';
@@ -623,8 +623,8 @@ export async function* buildEsbuildBrowserInternal(
     assetFiles?: { source: string; destination: string }[];
   }
 > {
-  // Inform user of experimental status of builder and options
-  logExperimentalWarnings(userOptions, context);
+  // Inform user of status of builder and options
+  logBuilderStatusWarnings(userOptions, context);
 
   // Determine project name from builder context target
   const projectName = context.target?.project;


### PR DESCRIPTION
The status of the esbuild-based browser application builder has been changed to developer preview. Warning messages for unsupported options are now updated to reflect this change.
