### PR TITLE
test(@angular-devkit/build-angular): enable additional build E2E tests for esbuild builder

### DIFF
--- a/tests/legacy-cli/e2e.bzl
+++ b/tests/legacy-cli/e2e.bzl
@@ -31,11 +31,10 @@ BROWSER_TESTS = ["tests/misc/browsers.js"]
 YARN_TESTS = ["tests/basic/**", "tests/update/**", "tests/commands/add/**"]
 ESBUILD_TESTS = [
     "tests/basic/**",
+    "tests/build/library/**",
     "tests/build/prod-build.js",
     "tests/build/relative-sourcemap.js",
-    "tests/build/styles/scss.js",
-    "tests/build/styles/include-paths.js",
-    "tests/build/styles/tailwind*.js",
+    "tests/build/styles/**",
     "tests/commands/add/add-pwa.js",
 ]
 


### PR DESCRIPTION
All the tests within the `build/library` and `build/styles` test directories will now be run for the esbuild-based builder E2E CI.
Also fixes an issue with relative Less imports.