### PR TITLE
refactor: bump `@angular/pwa` peer dependency version for v16

### DIFF
--- a/packages/angular/pwa/package.json
+++ b/packages/angular/pwa/package.json
@@ -17,7 +17,7 @@
     "parse5-html-rewriting-stream": "7.0.0"
   },
   "peerDependencies": {
-    "@angular/cli": "^16.0.0-next.0"
+    "@angular/cli": "^16.0.0"
   },
   "peerDependenciesMeta": {
     "@angular/cli": {


### PR DESCRIPTION
Missed the `@angular/pwa` dep in a previous PR, need to bump this as well.