### PR TITLE
feat(@angular-devkit/build-angular): support dev-server package prebundling with esbuild builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
@@ -418,6 +418,46 @@ function createCodeBundleOptions(
     },
   };
 
+  if (options.externalPackages) {
+    // Add a plugin that marks any resolved path as external if it is within a node modules directory.
+    // This is used instead of the esbuild `packages` option to avoid marking bare specifiers that use
+    // tsconfig path mapping to resolve to a workspace relative path. This is common for monorepos that
+    // contain libraries that are built along with the application. These libraries should not be considered
+    // external even though the imports appear to be packages.
+    const EXTERNAL_PACKAGE_RESOLUTION = Symbol('EXTERNAL_PACKAGE_RESOLUTION');
+    buildOptions.plugins ??= [];
+    buildOptions.plugins.push({
+      name: 'angular-external-packages',
+      setup(build) {
+        build.onResolve({ filter: /./ }, async (args) => {
+          if (args.pluginData?.[EXTERNAL_PACKAGE_RESOLUTION]) {
+            return null;
+          }
+
+          const { importer, kind, resolveDir, namespace, pluginData = {} } = args;
+          pluginData[EXTERNAL_PACKAGE_RESOLUTION] = true;
+
+          const result = await build.resolve(args.path, {
+            importer,
+            kind,
+            namespace,
+            pluginData,
+            resolveDir,
+          });
+
+          if (result.path && /[\\/]node_modules[\\/]/.test(result.path)) {
+            return {
+              path: args.path,
+              external: true,
+            };
+          }
+
+          return result;
+        });
+      },
+    });
+  }
+
   const polyfills = options.polyfills ? [...options.polyfills] : [];
   if (jit) {
     polyfills.push('@angular/compiler');

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/options.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/options.ts
@@ -31,6 +31,12 @@ interface InternalOptions {
 
   /** File extension to use for the generated output files. */
   outExtension?: 'js' | 'mjs';
+
+  /**
+   * Indicates whether all node packages should be marked as external.
+   * Currently used by the dev-server to support prebundling.
+   */
+  externalPackages?: boolean;
 }
 
 /** Full set of options for `browser-esbuild` builder. */
@@ -180,6 +186,7 @@ export async function normalizeOptions(
     verbose,
     watch,
     progress,
+    externalPackages,
   } = options;
 
   // Return all the normalized options
@@ -197,6 +204,7 @@ export async function normalizeOptions(
     polyfills: polyfills === undefined || Array.isArray(polyfills) ? polyfills : [polyfills],
     poll,
     progress: progress ?? true,
+    externalPackages,
     // If not explicitly set, default to the Node.js process argument
     preserveSymlinks: preserveSymlinks ?? process.execArgv.includes('--preserve-symlinks'),
     stylePreprocessorOptions,


### PR DESCRIPTION
When using the development server with the esbuild-based browser application builder, the underlying
Vite server will now prebundle packages present in an application. During the prebundling process,
the Angular linker will also be invoked to ensure that APF packages are processed for AOT usage.
The Vite prebundling also provides automatic persistent caching of processed packages. This allows
reuse of processed packages across `ng serve` invocations. To support the use of prebundling at the
development server level, all packages are considered external from the build level. The first time
a package is used within an application there may be a short delay upon accessing the page as the
package is processed. Due to the persistent nature of the prebundling, the `ng cache` command is used
to control the use of the feature.