### PR TITLE
fix(@angular-devkit/build-angular): fix index option const value for browser-esbuild

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/schema.json
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/schema.json
@@ -399,7 +399,7 @@
           "required": ["input"]
         },
         {
-          "const": "false",
+          "const": false,
           "description": "Does not generate an `index.html` file."
         }
       ]


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The `index` option of the `browser-esbuild` builder is defined to accept one of a `string`, an `object`, or a const `"false"`. Note the const value it's not `false` but a string value. Because of that, there's no way to disable the index generation:

- If we set the option to `"false"` we get an error because it matches both the `string` and the const:
	```
	Error: Schema validation failed with the following errors:
    Data path "/index" must be object.
    Data path "/index" must match exactly one schema in oneOf.
    ```
- If we set the option to `false` we get an error because it doesn't match any of the possible definitions:
	```
	Error: Schema validation failed with the following errors:
    Data path "/index" must be string.
    Data path "/index" must be object.
    Data path "/index" must be equal to constant.
    Data path "/index" must match exactly one schema in oneOf.
    ```
- If we run the build with `ng build --no-index` (as one of the goals of the change https://github.com/angular/angular-cli/commit/0d4a40fd6eea6e60f5fc17ddb4ff74e58086669d) we get the same as the previous error:
    ```
	Error: Schema validation failed with the following errors:
    Data path "/index" must be string.
    Data path "/index" must be object.
    Data path "/index" must be equal to constant.
    Data path "/index" must match exactly one schema in oneOf.
    ```

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the new behavior that. -->

The `index` option of the `browser-esbuild` builder is defined to accept one of a `string`, and `object` or a const `false` (boolean). This allows users to set the option to `false` in their `angular.json` or to run the build with `--no-index`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
