### PR TITLE
Revert "fix(@angular-devkit/build-angular): set public class fields as properties (#24849)"

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
@@ -415,13 +415,6 @@ export async function getCommonConfig(wco: WebpackConfigOptions): Promise<Config
             {
               loader: require.resolve('../../babel/webpack-loader'),
               options: {
-                assumptions: {
-                  // Use `setPublicClassFields: true` to avoid decrease bundle sizes
-                  // when targetting ES2022+ with `useDefineForClassFields: true`.
-                  // This is because ervery property of the class will otherwise be wrapped in a `_defineProperty`.
-                  // This is not needed for TypeScript as TS itself will emit the right declaration of class properties.
-                  setPublicClassFields: true,
-                },
                 cacheDirectory: (cache.enabled && path.join(cache.path, 'babel-webpack')) || false,
                 aot: buildOptions.aot,
                 optimize: buildOptions.buildOptimizer,


### PR DESCRIPTION

This reverts commit 04274afc15084ead2916e11055aa8f1d2f61951d.

Closes: #25161
