### PR TITLE
fix(@angular-devkit/build-angular): disable runtime errors from being displayed in overlay

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/dev-server.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/dev-server.ts
@@ -318,6 +318,7 @@ function getWebSocketSettings(
       overlay: {
         errors: true,
         warnings: false,
+        runtimeErrors: false,
       },
     },
   };


### PR DESCRIPTION


By default now webpack-dev-server adds runtime errors in an overlay. See: https://github.com/webpack/webpack-dev-server/commit/aab01b3c4e4fb9ca9ae1c1bbc860a52a06026de6 this commit disables this functionality.

Closes #25151
