### PR TITLE
    fix(@angular-devkit/schematics): do not generate an UpdateBuffer for created and overridden files

### DIFF
--- a/goldens/public-api/angular_devkit/schematics/index.md
+++ b/goldens/public-api/angular_devkit/schematics/index.md
@@ -495,13 +495,13 @@ export class HostSink extends SimpleSinkBase {
     // (undocumented)
     _done(): Observable<void>;
     // (undocumented)
-    protected _filesToCreate: Map<Path, UpdateBufferBase>;
+    protected _filesToCreate: Map<Path, Buffer>;
     // (undocumented)
     protected _filesToDelete: Set<Path>;
     // (undocumented)
     protected _filesToRename: Set<[Path, Path]>;
     // (undocumented)
-    protected _filesToUpdate: Map<Path, UpdateBufferBase>;
+    protected _filesToUpdate: Map<Path, Buffer>;
     // (undocumented)
     protected _force: boolean;
     // (undocumented)

--- a/packages/angular/pwa/pwa/index.ts
+++ b/packages/angular/pwa/pwa/index.ts
@@ -167,12 +167,7 @@ export default function (options: PwaOptions): Rule {
     return chain([
       externalSchematic('@schematics/angular', 'service-worker', swOptions),
       mergeWith(apply(url('./files/root'), [template({ ...options }), move(sourcePath)])),
-      mergeWith(
-        apply(url('./files/assets'), [
-          template({ ...options }),
-          move(posix.join(sourcePath, 'assets')),
-        ]),
-      ),
+      mergeWith(apply(url('./files/assets'), [move(posix.join(sourcePath, 'assets'))])),
       ...[...indexFiles].map((path) => updateIndexFile(path)),
     ]);
   };

--- a/packages/angular_devkit/schematics/src/sink/dryrun.ts
+++ b/packages/angular_devkit/schematics/src/sink/dryrun.ts
@@ -117,10 +117,10 @@ export class DryRunSink extends HostSink {
         return;
       }
 
-      this._subject.next({ kind: 'create', path, content: content.generate() });
+      this._subject.next({ kind: 'create', path, content });
     });
     this._filesToUpdate.forEach((content, path) => {
-      this._subject.next({ kind: 'update', path, content: content.generate() });
+      this._subject.next({ kind: 'update', path, content });
     });
 
     this._subject.complete();

--- a/packages/angular_devkit/schematics/src/tree/recorder.ts
+++ b/packages/angular_devkit/schematics/src/tree/recorder.ts
@@ -17,7 +17,7 @@ export class UpdateRecorderBase implements UpdateRecorder {
 
   constructor(entry: FileEntry) {
     this._original = Buffer.from(entry.content);
-    this._content = UpdateBufferBase.create(entry.content);
+    this._content = UpdateBufferBase.create(entry.path, entry.content);
     this._path = entry.path;
   }
 


### PR DESCRIPTION

    
`UpdateBuffer` only supports UTF-8 encoded files, which causes schematics to emit corrupted binary like files such as images.

This commit also introduce an errors when the `UpdateRecorder` is used for non UTF-8 files.

Closes #25174
