### PR TITLE
refactor(@angular-devkit/build-angular): emit affected files as a group in esbuild builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/angular/angular-compilation.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/angular/angular-compilation.ts
@@ -13,12 +13,10 @@ import { profileSync } from '../profiling';
 import type { AngularHostOptions } from './angular-host';
 
 export interface EmitFileResult {
-  content?: string;
-  map?: string;
-  dependencies: readonly string[];
+  filename: string;
+  contents: string;
+  dependencies?: readonly string[];
 }
-
-export type FileEmitter = (file: string) => Promise<EmitFileResult | undefined>;
 
 export abstract class AngularCompilation {
   static #angularCompilerCliModule?: typeof ng;
@@ -59,5 +57,5 @@ export abstract class AngularCompilation {
 
   abstract collectDiagnostics(): Iterable<ts.Diagnostic>;
 
-  abstract createFileEmitter(onAfterEmit?: (sourceFile: ts.SourceFile) => void): FileEmitter;
+  abstract emitAffectedFiles(): Iterable<EmitFileResult>;
 }


### PR DESCRIPTION
The internal emit strategy for the TypeScript/Angular compiler has been adjusted to prefill the memory cache during the initial phase of the build. Previously each file was emitted during the bundling process as requested by the bundler. This change has no immediate effect on the build process but enables future build performance improvements.