### PR TITLE
feat(@angular-devkit/build-angular): support incremental TypeScript semantic diagnostics in esbuild builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
@@ -98,6 +98,7 @@ async function execute(
     assets,
     serviceWorkerOptions,
     indexHtmlOptions,
+    cacheOptions,
   } = options;
 
   const browsers = getSupportedBrowsers(projectRoot, context.logger);
@@ -105,9 +106,9 @@ async function execute(
 
   // Reuse rebuild state or create new bundle contexts for code and global stylesheets
   let bundlerContexts = rebuildState?.rebuildContexts;
-  const codeBundleCache = options.watch
-    ? rebuildState?.codeBundleCache ?? new SourceFileCache()
-    : undefined;
+  const codeBundleCache =
+    rebuildState?.codeBundleCache ??
+    new SourceFileCache(cacheOptions.enabled ? cacheOptions.path : undefined);
   if (bundlerContexts === undefined) {
     bundlerContexts = [];
 

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/options.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/options.ts
@@ -7,7 +7,6 @@
  */
 
 import { BuilderContext } from '@angular-devkit/architect';
-import fs from 'node:fs';
 import { createRequire } from 'node:module';
 import path from 'node:path';
 import { normalizeAssetPatterns, normalizeOptimization, normalizeSourceMaps } from '../../utils';
@@ -64,7 +63,9 @@ export async function normalizeOptions(
     path.join(workspaceRoot, (projectMetadata.sourceRoot as string | undefined) ?? 'src'),
   );
 
+  // Gather persistent caching option and provide a project specific cache location
   const cacheOptions = normalizeCacheOptions(projectMetadata, workspaceRoot);
+  cacheOptions.path = path.join(cacheOptions.path, projectName);
 
   const entryPoints = normalizeEntryPoints(workspaceRoot, options.main, options.entryPoints);
   const tsconfig = path.join(workspaceRoot, options.tsConfig);


### PR DESCRIPTION
When using the esbuild-based browser application builder with CLI caching enabled, TypeScript's `incremental`
option will also be enabled by default. A TypeScript build information file will be written after each build and
an attempt to load and use the file will be made during compilation setup. Caching is enabled by default within
the CLI and can be controlled via the `ng cache` command. This is the first use of persistent caching for the
esbuild-based builder. If the TypeScript `incremental` option is manually set to `false`, the build system will
not alter the value. This can be used to disable the behavior, if preferred, by setting the option to `false` in
the application's configured `tsconfig` file.
NOTE: The build information only contains information regarding the TypeScript compilation itself and does not
contain information about the Angular AOT compilation. TypeScript does not have knowledge of the AOT compiler
and it therefore cannot include that information in its build information file. Angular AOT analysis is still
performed for each build.

Initial profiling indicates this provides a ~20% improvement to warm build times for a production build of a newly generated project.