### PR TITLE
fix(@angular_devkit/build-angular): Allow relative paths in global scripts that don't start with "./" on Windows

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/global-scripts.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/global-scripts.ts
@@ -10,6 +10,7 @@ import type { BuildOptions } from 'esbuild';
 import MagicString, { Bundle } from 'magic-string';
 import assert from 'node:assert';
 import { readFile } from 'node:fs/promises';
+import { isAbsolute } from 'node:path';
 import { NormalizedBrowserOptions } from './options';
 import { createSourcemapIngorelistPlugin } from './sourcemap-ignorelist-plugin';
 
@@ -95,7 +96,12 @@ export function createGlobalScriptsBundleOptions(
 
             // Global scripts are concatenated using magic-string instead of bundled via esbuild.
             const bundleContent = new Bundle();
-            for (const filename of files) {
+            for (let filename of files) {
+
+              if (!isAbsolute(filename)) {
+                filename = "./" + filename;
+              }
+
               const resolveResult = await build.resolve(filename, {
                 kind: 'entry-point',
                 resolveDir: workspaceRoot,


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Defining global scripts in angular.json with relative paths fails on Windows when they don't start with "./" when using esbuild.

Issue Number: #25198

## What is the new behavior?

It no longer fails.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
I didn't add a test, because I don't know how to add tests for Windows only.