### PR TITLE
fix(@angular-devkit/build-angular): normalize Vite dev-server Windows asset paths

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
@@ -267,7 +267,7 @@ export async function setupServer(
             // Rewrite all build assets to a vite raw fs URL
             const assetSourcePath = assets.get(pathname);
             if (assetSourcePath !== undefined) {
-              req.url = `/@fs/${assetSourcePath}`;
+              req.url = `/@fs/${normalizePath(assetSourcePath)}`;
               next();
 
               return;


### PR DESCRIPTION
When using the esbuild-based browser application builder with the Vite-based development server on Windows, source asset paths were previously not normalized prior to being included in request URLs. This could result in invalid asset request URLs due to invalid path segment separators.