### PR TITLE
feat(@angular-devkit/build-angular): show estimated transfer size with esbuild builder

### DIFF
--- a/tests/legacy-cli/e2e/tests/basic/build.ts
+++ b/tests/legacy-cli/e2e/tests/basic/build.ts
@@ -4,21 +4,27 @@ import { ng } from '../../utils/process';
 
 export default async function () {
   // Development build
-  const { stdout } = await ng('build', '--configuration=development');
+  const { stdout: stdout1 } = await ng('build', '--configuration=development');
   await expectFileToMatch('dist/test-project/index.html', 'main.js');
 
-  if (stdout.includes('Estimated Transfer Size')) {
+  if (stdout1.includes('Estimated Transfer Size')) {
     throw new Error(
-      `Expected stdout not to contain 'Estimated Transfer Size' but it did.\n${stdout}`,
+      `Expected stdout not to contain 'Estimated Transfer Size' but it did.\n${stdout1}`,
     );
   }
 
   // Production build
-  await ng('build');
+  const { stdout: stdout2 } = await ng('build');
   if (getGlobalVariable('argv')['esbuild']) {
     // esbuild uses an 8 character hash
     await expectFileToMatch('dist/test-project/index.html', /main\.[a-zA-Z0-9]{8}\.js/);
   } else {
     await expectFileToMatch('dist/test-project/index.html', /main\.[a-zA-Z0-9]{16}\.js/);
+  }
+
+  if (!stdout2.includes('Estimated Transfer Size')) {
+    throw new Error(
+      `Expected stdout to contain 'Estimated Transfer Size' but it did not.\n${stdout2}`,
+    );
   }
 }

--- a/tests/legacy-cli/e2e/tests/build/progress-and-stats.ts
+++ b/tests/legacy-cli/e2e/tests/build/progress-and-stats.ts
@@ -2,11 +2,6 @@ import { getGlobalVariable } from '../../utils/env';
 import { ng } from '../../utils/process';
 
 export default async function () {
-  if (getGlobalVariable('argv')['esbuild']) {
-    // EXPERIMENTAL_ESBUILD: esbuild does not yet output build stats
-    return;
-  }
-
   const { stderr: stderrProgress, stdout } = await ng('build', '--progress');
   if (!stdout.includes('Initial Total')) {
     throw new Error(`Expected stdout to contain 'Initial Total' but it did not.\n${stdout}`);
@@ -18,11 +13,16 @@ export default async function () {
     );
   }
 
-  const logs: string[] = [
-    'Browser application bundle generation complete',
-    'Copying assets complete',
-    'Index html generation complete',
-  ];
+  let logs;
+  if (getGlobalVariable('argv')['esbuild']) {
+    logs = ['Application bundle generation complete.'];
+  } else {
+    logs = [
+      'Browser application bundle generation complete',
+      'Copying assets complete',
+      'Index html generation complete',
+    ];
+  }
 
   for (const log of logs) {
     if (!stderrProgress.includes(log)) {


### PR DESCRIPTION
When using the esbuild-based browser application builder, the console build stats output will now show the estimated transfer size of JavaScript and CSS files when optimizations are enabled. This provides similar behavior to the default Webpack-based builder.