### PR TITLE
refactor(@angular-devkit/build-angular): use helper to setup esbuild plugin load caching

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/global-scripts.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/global-scripts.ts
@@ -12,7 +12,8 @@ import assert from 'node:assert';
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { assertIsError } from '../../utils/error';
-import { NormalizedBrowserOptions } from './options';
+import { LoadResultCache, createCachedLoad } from './load-result-cache';
+import type { NormalizedBrowserOptions } from './options';
 import { createSourcemapIngorelistPlugin } from './sourcemap-ignorelist-plugin';
 
 /**
@@ -24,6 +25,7 @@ import { createSourcemapIngorelistPlugin } from './sourcemap-ignorelist-plugin';
 export function createGlobalScriptsBundleOptions(
   options: NormalizedBrowserOptions,
   initial: boolean,
+  loadCache?: LoadResultCache,
 ): BuildOptions | undefined {
   const {
     globalScripts,
@@ -91,51 +93,60 @@ export function createGlobalScriptsBundleOptions(
               external: true,
             };
           });
-          build.onLoad({ filter: /./, namespace }, async (args) => {
-            const files = globalScripts.find(({ name }) => name === args.path.slice(0, -3))?.files;
-            assert(files, `Invalid operation: global scripts name not found [${args.path}]`);
+          build.onLoad(
+            { filter: /./, namespace },
+            createCachedLoad(loadCache, async (args) => {
+              const files = globalScripts.find(
+                ({ name }) => name === args.path.slice(0, -3),
+              )?.files;
+              assert(files, `Invalid operation: global scripts name not found [${args.path}]`);
 
-            // Global scripts are concatenated using magic-string instead of bundled via esbuild.
-            const bundleContent = new Bundle();
-            for (const filename of files) {
-              let fileContent;
-              try {
-                // Attempt to read as a relative path from the workspace root
-                fileContent = await readFile(path.join(workspaceRoot, filename), 'utf-8');
-              } catch (e) {
-                assertIsError(e);
-                if (e.code !== 'ENOENT') {
-                  throw e;
+              // Global scripts are concatenated using magic-string instead of bundled via esbuild.
+              const bundleContent = new Bundle();
+              const watchFiles = [];
+              for (const filename of files) {
+                let fileContent;
+                try {
+                  // Attempt to read as a relative path from the workspace root
+                  fileContent = await readFile(path.join(workspaceRoot, filename), 'utf-8');
+                  watchFiles.push(filename);
+                } catch (e) {
+                  assertIsError(e);
+                  if (e.code !== 'ENOENT') {
+                    throw e;
+                  }
+
+                  // If not found attempt to resolve as a module specifier
+                  const resolveResult = await build.resolve(filename, {
+                    kind: 'entry-point',
+                    resolveDir: workspaceRoot,
+                  });
+
+                  if (resolveResult.errors.length) {
+                    // Remove resolution failure notes about marking as external since it doesn't apply
+                    // to global scripts.
+                    resolveResult.errors.forEach((error) => (error.notes = []));
+
+                    return {
+                      errors: resolveResult.errors,
+                      warnings: resolveResult.warnings,
+                    };
+                  }
+
+                  watchFiles.push(path.relative(resolveResult.path, workspaceRoot));
+                  fileContent = await readFile(resolveResult.path, 'utf-8');
                 }
 
-                // If not found attempt to resolve as a module specifier
-                const resolveResult = await build.resolve(filename, {
-                  kind: 'entry-point',
-                  resolveDir: workspaceRoot,
-                });
-
-                if (resolveResult.errors.length) {
-                  // Remove resolution failure notes about marking as external since it doesn't apply
-                  // to global scripts.
-                  resolveResult.errors.forEach((error) => (error.notes = []));
-
-                  return {
-                    errors: resolveResult.errors,
-                    warnings: resolveResult.warnings,
-                  };
-                }
-
-                fileContent = await readFile(resolveResult.path, 'utf-8');
+                bundleContent.addSource(new MagicString(fileContent, { filename }));
               }
 
-              bundleContent.addSource(new MagicString(fileContent, { filename }));
-            }
-
-            return {
-              contents: bundleContent.toString(),
-              loader: 'js',
-            };
-          });
+              return {
+                contents: bundleContent.toString(),
+                loader: 'js',
+                watchFiles,
+              };
+            }),
+          );
         },
       },
     ],

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/load-result-cache.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/load-result-cache.ts
@@ -6,11 +6,36 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import type { OnLoadResult } from 'esbuild';
+import type { OnLoadResult, PluginBuild } from 'esbuild';
 
 export interface LoadResultCache {
   get(path: string): OnLoadResult | undefined;
   put(path: string, result: OnLoadResult): Promise<void>;
+}
+
+export function createCachedLoad(
+  cache: LoadResultCache | undefined,
+  callback: Parameters<PluginBuild['onLoad']>[1],
+): Parameters<PluginBuild['onLoad']>[1] {
+  if (cache === undefined) {
+    return callback;
+  }
+
+  return async (args) => {
+    const loadCacheKey = `${args.namespace}:${args.path}`;
+    let result: OnLoadResult | null | undefined = cache.get(loadCacheKey);
+
+    if (result === undefined) {
+      result = await callback(args);
+
+      // Do not cache null or undefined or results with errors
+      if (result && result.errors === undefined) {
+        await cache.put(loadCacheKey, result);
+      }
+    }
+
+    return result;
+  };
 }
 
 export class MemoryLoadResultCache implements LoadResultCache {

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/stylesheets/bundle-options.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/stylesheets/bundle-options.ts
@@ -7,6 +7,7 @@
  */
 
 import type { BuildOptions, OutputFile } from 'esbuild';
+import { createHash } from 'node:crypto';
 import path from 'node:path';
 import { BundlerContext } from '../esbuild';
 import { LoadResultCache } from '../load-result-cache';
@@ -108,7 +109,11 @@ export async function bundleComponentStylesheet(
   cache?: LoadResultCache,
 ) {
   const namespace = 'angular:styles/component';
-  const entry = [language, componentStyleCounter++, filename].join(';');
+  // Use a hash of the inline stylesheet content to ensure a consistent identifier. External stylesheets will resolve
+  // to the actual stylesheet file path.
+  // TODO: Consider xxhash instead for hashing
+  const id = inline ? createHash('sha256').update(data).digest('hex') : componentStyleCounter++;
+  const entry = [language, id, filename].join(';');
 
   const buildOptions = createStylesheetBundleOptions(options, cache, { [entry]: data });
   buildOptions.entryPoints = [`${namespace};${entry}`];

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/stylesheets/bundle-options.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/stylesheets/bundle-options.ts
@@ -70,18 +70,24 @@ export function createStylesheetBundleOptions(
         },
         cache,
       ),
-      createLessPlugin({
-        sourcemap: !!options.sourcemap,
-        includePaths,
-        inlineComponentData,
-      }),
-      createCssPlugin({
-        sourcemap: !!options.sourcemap,
-        inlineComponentData,
-        browsers: options.browsers,
-        tailwindConfiguration: options.tailwindConfiguration,
-      }),
-      createCssResourcePlugin(),
+      createLessPlugin(
+        {
+          sourcemap: !!options.sourcemap,
+          includePaths,
+          inlineComponentData,
+        },
+        cache,
+      ),
+      createCssPlugin(
+        {
+          sourcemap: !!options.sourcemap,
+          inlineComponentData,
+          browsers: options.browsers,
+          tailwindConfiguration: options.tailwindConfiguration,
+        },
+        cache,
+      ),
+      createCssResourcePlugin(cache),
     ],
   };
 }


### PR DESCRIPTION
Within the esbuild-based browser application builder, a helper function has been introduced
to streamline the use of the load result cache within the internal plugins. This removes
repeat code that would otherwise be needed.