### PR TITLE
fix(@angular-devkit/build-angular): percent encode asset URLs in development server for esbuild

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
@@ -255,7 +255,7 @@ export async function setupServer(
             // Parse the incoming request.
             // The base of the URL is unused but required to parse the URL.
             const parsedUrl = new URL(req.url, 'http://localhost');
-            let pathname = parsedUrl.pathname;
+            let pathname = decodeURIComponent(parsedUrl.pathname);
             if (serverOptions.servePath && pathname.startsWith(serverOptions.servePath)) {
               pathname = pathname.slice(serverOptions.servePath.length);
               if (pathname[0] !== '/') {
@@ -267,7 +267,7 @@ export async function setupServer(
             // Rewrite all build assets to a vite raw fs URL
             const assetSourcePath = assets.get(pathname);
             if (assetSourcePath !== undefined) {
-              req.url = `/@fs/${normalizePath(assetSourcePath)}`;
+              req.url = `/@fs/${encodeURIComponent(assetSourcePath)}`;
               next();
 
               return;


### PR DESCRIPTION
When using the esbuild-based browser application builder with the development server, configured application assets are served directly from disk. The URLs passed to Vite are now percent encoded to properly handle asset paths that may contain unsupported URL characters. This aligns with the static middleware within Vite: https://github.com/vitejs/vite/blob/3609e79dc1416073dc4775bb2fcf6a7398f169b3/packages/vite/src/node/server/middlewares/static.ts#L162

Closes #25238