### PR TITLE
build: minor cleanup of bazel build rules

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,3 +1,16 @@
 .git
 dist
 node_modules
+packages/angular/cli/node_modules
+packages/angular/create/node_modules
+packages/angular/pwa/node_modules
+packages/angular_devkit/architect/node_modules
+packages/angular_devkit/architect_cli/node_modules
+packages/angular_devkit/benchmark/node_modules
+packages/angular_devkit/build_angular/node_modules
+packages/angular_devkit/build_webpack/node_modules
+packages/angular_devkit/core/node_modules
+packages/angular_devkit/schematics/node_modules
+packages/angular_devkit/schematics_cli/node_modules
+packages/ngtools/webpack/node_modules
+packages/schematics/angular/node_modules

--- a/packages/angular/cli/BUILD.bazel
+++ b/packages/angular/cli/BUILD.bazel
@@ -17,11 +17,12 @@ ts_library(
     name = "angular-cli",
     package_name = "@angular/cli",
     srcs = glob(
-        include = ["**/*.ts"],
+        include = [
+            "lib/**/*.ts",
+            "src/**/*.ts",
+        ],
         exclude = [
             "**/*_spec.ts",
-            # NB: we need to exclude the nested node_modules that is laid out by yarn workspaces
-            "node_modules/**",
         ],
     ) + [
         # @external_begin
@@ -33,12 +34,10 @@ ts_library(
     data = glob(
         include = [
             "bin/**/*",
-            "**/*.json",
-            "**/*.md",
+            "src/**/*.md",
+            "src/**/*.json",
         ],
         exclude = [
-            # NB: we need to exclude the nested node_modules that is laid out by yarn workspaces
-            "node_modules/**",
             "lib/config/workspace-schema.json",
         ],
     ) + [

--- a/packages/angular/create/BUILD.bazel
+++ b/packages/angular/create/BUILD.bazel
@@ -10,13 +10,7 @@ licenses(["notice"])
 ts_library(
     name = "create",
     package_name = "@angular/create",
-    srcs = glob(
-        ["**/*.ts"],
-        exclude = [
-            # NB: we need to exclude the nested node_modules that is laid out by yarn workspaces
-            "node_modules/**",
-        ],
-    ),
+    srcs = ["src/index.ts"],
     deps = [
         "//packages/angular/cli:angular-cli",
         "@npm//@types/node",

--- a/packages/angular/pwa/BUILD.bazel
+++ b/packages/angular/pwa/BUILD.bazel
@@ -15,20 +15,8 @@ package(default_visibility = ["//visibility:public"])
 ts_library(
     name = "pwa",
     package_name = "@angular/pwa",
-    srcs = glob(
-        ["**/*.ts"],
-        # Currently, this library is used only with the rollup plugin.
-        # To make it simpler for downstream repositories to compile this, we
-        # neither provide compile-time deps as an `npm_install` rule, nor do we
-        # expect the downstream repository to install @types/webpack[-*]
-        # So we exclude files that depend on webpack typings.
-        exclude = [
-            "pwa/files/**/*",
-            "**/*_spec.ts",
-            # NB: we need to exclude the nested node_modules that is laid out by yarn workspaces
-            "node_modules/**",
-        ],
-    ) + [
+    srcs = [
+        "pwa/index.ts",
         "//packages/angular/pwa:pwa/schema.ts",
     ],
     data = glob(

--- a/packages/angular_devkit/benchmark/BUILD.bazel
+++ b/packages/angular_devkit/benchmark/BUILD.bazel
@@ -18,7 +18,6 @@ ts_library(
         include = ["src/**/*.ts"],
         exclude = [
             "src/**/*_spec.ts",
-            "src/**/*_benchmark.ts",
         ],
     ),
     module_name = "@angular-devkit/benchmark",

--- a/packages/angular_devkit/core/BUILD.bazel
+++ b/packages/angular_devkit/core/BUILD.bazel
@@ -20,7 +20,6 @@ ts_library(
         include = ["src/**/*.ts"],
         exclude = [
             "src/**/*_spec.ts",
-            "src/**/*_benchmark.ts",
         ],
     ),
     data = glob(

--- a/packages/angular_devkit/core/node/BUILD.bazel
+++ b/packages/angular_devkit/core/node/BUILD.bazel
@@ -18,7 +18,6 @@ ts_library(
         exclude = [
             "testing/**/*.ts",
             "**/*_spec.ts",
-            "**/*_benchmark.ts",
         ],
     ),
     data = ["package.json"],

--- a/packages/angular_devkit/core/node/testing/BUILD.bazel
+++ b/packages/angular_devkit/core/node/testing/BUILD.bazel
@@ -14,7 +14,6 @@ ts_library(
         include = ["**/*.ts"],
         exclude = [
             "**/*_spec.ts",
-            "**/*_benchmark.ts",
         ],
     ),
     module_name = "@angular-devkit/core/node/testing",

--- a/packages/angular_devkit/schematics/BUILD.bazel
+++ b/packages/angular_devkit/schematics/BUILD.bazel
@@ -20,16 +20,11 @@ ts_library(
         include = ["src/**/*.ts"],
         exclude = [
             "src/**/*_spec.ts",
-            "src/**/*_benchmark.ts",
         ],
     ),
-    data = glob(
-        include = ["**/*.json"],
-        exclude = [
-            # NB: we need to exclude the nested node_modules that is laid out by yarn workspaces
-            "node_modules/**",
-        ],
-    ),
+    data = [
+        "package.json",
+    ],
     module_name = "@angular-devkit/schematics",
     module_root = "src/index.d.ts",
     deps = [

--- a/packages/angular_devkit/schematics/tasks/BUILD.bazel
+++ b/packages/angular_devkit/schematics/tasks/BUILD.bazel
@@ -15,7 +15,6 @@ ts_library(
         exclude = [
             "node/**/*.ts",
             "**/*_spec.ts",
-            "**/*_benchmark.ts",
         ],
     ),
     data = ["package.json"],

--- a/packages/angular_devkit/schematics/tasks/node/BUILD.bazel
+++ b/packages/angular_devkit/schematics/tasks/node/BUILD.bazel
@@ -14,7 +14,6 @@ ts_library(
         include = ["**/*.ts"],
         exclude = [
             "**/*_spec.ts",
-            "**/*_benchmark.ts",
         ],
     ),
     module_name = "@angular-devkit/schematics/tasks/node",

--- a/packages/angular_devkit/schematics/tools/BUILD.bazel
+++ b/packages/angular_devkit/schematics/tools/BUILD.bazel
@@ -16,7 +16,6 @@ ts_library(
         include = ["**/*.ts"],
         exclude = [
             "**/*_spec.ts",
-            "**/*_benchmark.ts",
             "test/**/*.ts",
         ],
     ),

--- a/packages/ngtools/webpack/BUILD.bazel
+++ b/packages/ngtools/webpack/BUILD.bazel
@@ -24,12 +24,9 @@ ts_library(
             "src/**/*_spec_helpers.ts",
         ],
     ),
-    data = glob(
-        include = [
-            "src/type_checker_bootstrap.js",
-            "package.json",
-        ],
-    ),
+    data = [
+        "package.json",
+    ],
     module_name = "@ngtools/webpack",
     module_root = "src/index.d.ts",
     deps = [

--- a/packages/schematics/angular/BUILD.bazel
+++ b/packages/schematics/angular/BUILD.bazel
@@ -43,7 +43,6 @@ ts_library(
         include = ["**/*.ts"],
         exclude = [
             "**/*_spec.ts",
-            "**/*_benchmark.ts",
             # Also exclude templated files.
             "*/files/**/*.ts",
             "*/other-files/**/*.ts",


### PR DESCRIPTION
BUILD files for each package have had outdated glob excludes removed. Additionally, some src args have been reduced to a single file where possible. The root bazel ignore file has also been expanded to include all node module directories in each package. The ignore file does not appear to currently support globs so each path has been individually specified.