### PR TITLE
refactor: disable Webpack `topLevelAwait`

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/configs/common.ts
@@ -436,6 +436,7 @@ export async function getCommonConfig(wco: WebpackConfigOptions): Promise<Config
       backCompat: false,
       syncWebAssembly: true,
       asyncWebAssembly: true,
+      topLevelAwait: false,
     },
     infrastructureLogging: {
       debug: verbose,


### PR DESCRIPTION
Webpack enabled top level await by default in version 5.83.0. (See: https://github.com/webpack/webpack/releases/tag/v5.83.0)

This commit restores the previous behaviour, as top level await is not supported due to Zone.js issues.
