### PR TITLE
ci: add initial Github Action lint workflow

### DIFF
--- a/.circleci/dynamic_config.yml
+++ b/.circleci/dynamic_config.yml
@@ -181,12 +181,6 @@ jobs:
           paths:
             - ~/.cache/yarn
 
-  lint:
-    executor: action-executor
-    steps:
-      - custom_attach_workspace
-      - run: yarn lint
-
   validate:
     executor: action-executor
     steps:
@@ -386,9 +380,6 @@ workflows:
     jobs:
       # Linux jobs
       - setup
-      - lint:
-          requires:
-            - setup
       - validate:
           requires:
             - setup

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,35 @@
+name: lint
+
+on:
+  pull_request:
+
+# Declare default permissions as read only.
+permissions:
+  contents: read
+
+jobs:
+  eslint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: yarn
+
+      - name: Install Dependencies
+        run: yarn install --frozen-lockfile --ignore-scripts
+
+      - name: Setup ESLint Caching
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        with:
+          path: .eslintcache
+          key: ${{ runner.os }}-${{ hashFiles('.eslintrc.json') }}-1
+
+      - name: Run ESLint
+        run: yarn lint --cache-strategy content


### PR DESCRIPTION
The eslint CI action has now been moved to a Github Action.
The check also now adds annotations to the PR code when eslint generates an error
or warning. Additionally, the eslint cache is saved and reused which provides improved
runtimes for the CI action.