### PR TITLE
fix(@schematics/angular): allow dash in selector before a number

### DIFF
--- a/packages/schematics/angular/component/index_spec.ts
+++ b/packages/schematics/angular/component/index_spec.ts
@@ -208,6 +208,30 @@ describe('Component Schematic', () => {
     ).toBeRejectedWithError('Selector "app-1-one" is invalid.');
   });
 
+  it('should allow dash in selector before a number', async () => {
+    const options = { ...defaultOptions, name: 'one-1' };
+
+    const tree = await schematicRunner.runSchematic('component', options, appTree);
+    const content = tree.readContent('/projects/bar/src/app/one-1/one-1.component.ts');
+    expect(content).toMatch(/selector: 'app-one-1'/);
+  });
+
+  it('should allow dash in selector before a number and with a custom prefix', async () => {
+    const options = { ...defaultOptions, name: 'one-1', prefix: 'pre' };
+
+    const tree = await schematicRunner.runSchematic('component', options, appTree);
+    const content = tree.readContent('/projects/bar/src/app/one-1/one-1.component.ts');
+    expect(content).toMatch(/selector: 'pre-one-1'/);
+  });
+
+  it('should allow dash in selector before a number and without a prefix', async () => {
+    const options = { ...defaultOptions, name: 'one-2', selector: 'one-2' };
+
+    const tree = await schematicRunner.runSchematic('component', options, appTree);
+    const content = tree.readContent('/projects/bar/src/app/one-2/one-2.component.ts');
+    expect(content).toMatch(/selector: 'one-2'/);
+  });
+
   it('should use the default project prefix if none is passed', async () => {
     const options = { ...defaultOptions, prefix: undefined };
 

--- a/packages/schematics/angular/utility/validation.ts
+++ b/packages/schematics/angular/utility/validation.ts
@@ -10,7 +10,8 @@ import { SchematicsException } from '@angular-devkit/schematics';
 
 // Must start with a letter, and must contain only alphanumeric characters or dashes.
 // When adding a dash the segment after the dash must also start with a letter.
-export const htmlSelectorRe = /^[a-zA-Z][.0-9a-zA-Z]*(:?-[a-zA-Z][.0-9a-zA-Z]*)*$/;
+export const htmlSelectorRe =
+  /^[a-zA-Z][.0-9a-zA-Z]*((:?-[0-9]+)*|(:?-[a-zA-Z][.0-9a-zA-Z]*(:?-[0-9]+)*)*)$/;
 
 // See: https://github.com/tc39/proposal-regexp-unicode-property-escapes/blob/fe6d07fad74cd0192d154966baa1e95e7cda78a1/README.md#other-examples
 const ecmaIdentifierNameRegExp = /^(?:[$_\p{ID_Start}])(?:[$_\u200C\u200D\p{ID_Continue}])*$/u;


### PR DESCRIPTION
Closes #25164

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Does not allow dash in selector before a number. Which means, following command would throw error: -
`ng g c TodoItemTask-123`

Issue Number: https://github.com/angular/angular-cli/issues/25164

## What is the new behavior?

<!-- Please describe the new behavior that. -->
Command like this will work: -
`ng g c TodoItemTask-123`
![image](https://github.com/angular/angular-cli/assets/4236211/64a25ae5-3ea2-4cf4-9ae6-4f768b403ee2)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information