### PR TITLE
fix(@angular-devkit/build-angular): watch all TypeScript referenced files in esbuild builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/angular/angular-compilation.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/angular/angular-compilation.ts
@@ -53,7 +53,11 @@ export abstract class AngularCompilation {
     tsconfig: string,
     hostOptions: AngularHostOptions,
     compilerOptionsTransformer?: (compilerOptions: ng.CompilerOptions) => ng.CompilerOptions,
-  ): Promise<{ affectedFiles: ReadonlySet<ts.SourceFile>; compilerOptions: ng.CompilerOptions }>;
+  ): Promise<{
+    affectedFiles: ReadonlySet<ts.SourceFile>;
+    compilerOptions: ng.CompilerOptions;
+    referencedFiles: readonly string[];
+  }>;
 
   abstract collectDiagnostics(): Iterable<ts.Diagnostic>;
 

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/angular/aot-compilation.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/angular/aot-compilation.ts
@@ -43,7 +43,11 @@ export class AotCompilation extends AngularCompilation {
     tsconfig: string,
     hostOptions: AngularHostOptions,
     compilerOptionsTransformer?: (compilerOptions: ng.CompilerOptions) => ng.CompilerOptions,
-  ): Promise<{ affectedFiles: ReadonlySet<ts.SourceFile>; compilerOptions: ng.CompilerOptions }> {
+  ): Promise<{
+    affectedFiles: ReadonlySet<ts.SourceFile>;
+    compilerOptions: ng.CompilerOptions;
+    referencedFiles: readonly string[];
+  }> {
     // Dynamically load the Angular compiler CLI package
     const { NgtscProgram, OptimizeFor } = await AngularCompilation.loadCompilerCli();
 
@@ -96,7 +100,12 @@ export class AotCompilation extends AngularCompilation {
       this.#state?.diagnosticCache,
     );
 
-    return { affectedFiles, compilerOptions };
+    const referencedFiles = typeScriptProgram
+      .getSourceFiles()
+      .filter((sourceFile) => !angularCompiler.ignoreForEmit.has(sourceFile))
+      .map((sourceFile) => sourceFile.fileName);
+
+    return { affectedFiles, compilerOptions, referencedFiles };
   }
 
   *collectDiagnostics(): Iterable<ts.Diagnostic> {

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/angular/compiler-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/angular/compiler-plugin.ts
@@ -45,6 +45,8 @@ export class SourceFileCache extends Map<string, ts.SourceFile> {
   readonly typeScriptFileCache = new Map<string, string | Uint8Array>();
   readonly loadResultCache = new MemoryLoadResultCache();
 
+  referencedFiles?: readonly string[];
+
   constructor(readonly persistentCachePath?: string) {
     super();
   }
@@ -185,6 +187,7 @@ export function createCompilerPlugin(
         // In watch mode, previous build state will be reused.
         const {
           compilerOptions: { allowJs },
+          referencedFiles,
         } = await compilation.initialize(tsconfigPath, hostOptions, (compilerOptions) => {
           if (
             compilerOptions.target === undefined ||
@@ -253,6 +256,11 @@ export function createCompilerPlugin(
             typeScriptFileCache.set(pathToFileURL(filename).href, contents);
           }
         });
+
+        // Store referenced files for updated file watching if enabled
+        if (pluginOptions.sourceFileCache) {
+          pluginOptions.sourceFileCache.referencedFiles = referencedFiles;
+        }
 
         // Reset the setup warnings so that they are only shown during the first build.
         setupWarnings = undefined;

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/angular/jit-compilation.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/angular/jit-compilation.ts
@@ -30,7 +30,11 @@ export class JitCompilation extends AngularCompilation {
     tsconfig: string,
     hostOptions: AngularHostOptions,
     compilerOptionsTransformer?: (compilerOptions: ng.CompilerOptions) => ng.CompilerOptions,
-  ): Promise<{ affectedFiles: ReadonlySet<ts.SourceFile>; compilerOptions: ng.CompilerOptions }> {
+  ): Promise<{
+    affectedFiles: ReadonlySet<ts.SourceFile>;
+    compilerOptions: ng.CompilerOptions;
+    referencedFiles: readonly string[];
+  }> {
     // Dynamically load the Angular compiler CLI package
     const { constructorParametersDownlevelTransform } = await AngularCompilation.loadCompilerCli();
 
@@ -68,7 +72,11 @@ export class JitCompilation extends AngularCompilation {
       createJitResourceTransformer(() => typeScriptProgram.getProgram().getTypeChecker()),
     );
 
-    return { affectedFiles, compilerOptions };
+    const referencedFiles = typeScriptProgram
+      .getSourceFiles()
+      .map((sourceFile) => sourceFile.fileName);
+
+    return { affectedFiles, compilerOptions, referencedFiles };
   }
 
   *collectDiagnostics(): Iterable<ts.Diagnostic> {

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/watcher.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/watcher.ts
@@ -25,8 +25,8 @@ export class ChangedFiles {
 }
 
 export interface BuildWatcher extends AsyncIterableIterator<ChangedFiles> {
-  add(paths: string | string[]): void;
-  remove(paths: string | string[]): void;
+  add(paths: string | readonly string[]): void;
+  remove(paths: string | readonly string[]): void;
   close(): Promise<void>;
 }
 


### PR DESCRIPTION
When using the esbuild-based browser application builder in watch mode, all files referenced by the TypeScript program are now watched in additional to files within the project root. This allows for more extensive monorepo setups to take advantage of watch mode as TypeScript files may exist in other library projects within the repository.