### PR TITLE
fix(@angular-devkit/build-angular): ignore .git folder in browser-esb…

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
@@ -655,6 +655,7 @@ export async function* buildEsbuildBrowserInternal(
       // Ignore all node modules directories to avoid excessive file watchers.
       // Package changes are handled below by watching manifest and lock files.
       '**/node_modules/**',
+      '**/.git/**',
     ],
   });
 

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
@@ -655,7 +655,7 @@ export async function* buildEsbuildBrowserInternal(
       // Ignore all node modules directories to avoid excessive file watchers.
       // Package changes are handled below by watching manifest and lock files.
       '**/node_modules/**',
-      '**/.git/**',
+      '**/.*/**',
     ],
   });
 


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

When running the builder in watch mode, and fetching the git repo that the project is contained in, any changes in the .git folder trigger a rebuild. This is especially annoying when the IDE that you use periodically fetches the repository, and the FETCH_HEAD file triggers the rebuild every time. 

Issue Number: N/A

## What is the new behavior?

With this change the .git folder will be ignored in the watcher

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

