### PR TITLE
ci: disable `less-loader` from being updated

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,7 @@
   "dependencyDashboard": true,
   "schedule": ["after 10:00pm every weekday", "before 4:00am every weekday", "every weekend"],
   "baseBranches": ["main"],
-  "ignoreDeps": ["@types/node", "rules_pkg"],
+  "ignoreDeps": ["@types/node", "rules_pkg", "less-loader"],
   "includePaths": [
     "WORKSPACE",
     "package.json",


### PR DESCRIPTION
`less-loader` depends on `v` which is licensed as `GPL-3.0`. This license is not allowed.

https://opensource.google/documentation/reference/thirdparty/licenses
