### PR TITLE
fix(@angular-devkit/build-angular): correctly emit AOT class metadata in development

### DIFF
--- a/packages/angular_devkit/build_angular/src/webpack/plugins/typescript.ts
+++ b/packages/angular_devkit/build_angular/src/webpack/plugins/typescript.ts
@@ -56,6 +56,7 @@ export function createIvyPlugin(
     compilerOptions,
     fileReplacements,
     jitMode: !aot,
+    emitClassMetadata: !optimize,
     emitNgModuleScope: !optimize,
     inlineStyleFileExtension: buildOptions.inlineStyleLanguage ?? 'css',
   });


### PR DESCRIPTION
When using the default Webpack-based builder, the AOT-generated class metadata was incorrectly removed in all cases. The metadata will now be present in development mode which in this case is signified by script optimizations being disabled.