### PR TITLE
fix: wrong chokidar watcher option

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
@@ -679,7 +679,7 @@ export async function* buildEsbuildBrowserInternal(
   // Setup a watcher
   const { createWatcher } = await import('./watcher');
   const watcher = createWatcher({
-    polling: typeof userOptions.poll === 'number',
+    usePolling: typeof userOptions.poll === 'number',
     interval: userOptions.poll,
     ignored: [
       // Ignore the output and cache paths to avoid infinite rebuild cycles

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/watcher.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/watcher.ts
@@ -31,7 +31,7 @@ export interface BuildWatcher extends AsyncIterableIterator<ChangedFiles> {
 }
 
 export function createWatcher(options?: {
-  polling?: boolean;
+  usePolling?: boolean;
   interval?: number;
   ignored?: string[];
 }): BuildWatcher {


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
Instead of passing the correct argument 'usePolling' to the chokidar filewatcher, 'polling' is being passed. This prevents the dev server from starting in a network drive environment and results in the error message "unknown error watch."
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
Chokidar is being passed the corret argument 'usePolling'.
<!-- Please describe the new behavior that. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
