### PR TITLE
Update next branch to reflect new release-train "v16.2.0-next.0".

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+<a name="16.1.0-rc.0"></a>
+
+# 16.1.0-rc.0 (2023-06-07)
+
+### @schematics/angular
+
+| Commit                                                                                              | Type | Description                                                    |
+| --------------------------------------------------------------------------------------------------- | ---- | -------------------------------------------------------------- |
+| [b14b95990](https://github.com/angular/angular-cli/commit/b14b959901d5a670da0df45e082b8fd4c3392d14) | feat | add bootstrap-agnostic utilities for writing ng-add schematics |
+
+### @angular-devkit/build-angular
+
+| Commit                                                                                              | Type | Description                                                   |
+| --------------------------------------------------------------------------------------------------- | ---- | ------------------------------------------------------------- |
+| [772fe84ed](https://github.com/angular/angular-cli/commit/772fe84ed399ccc085893e645163b4b12c461d0e) | fix  | ignore .git folder in browser-esbuild watcher                 |
+| [7155cbe5b](https://github.com/angular/angular-cli/commit/7155cbe5b2991f986c0683d16a6fc4d9b411e47b) | fix  | ignore folders starting with a dot in browser-esbuild watcher |
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="16.0.5"></a>
 
 # 16.0.5 (2023-06-07)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@angular/devkit-repo",
-  "version": "16.1.0-next.2",
+  "version": "16.2.0-next.0",
   "private": true,
   "description": "Software Development Kit for Angular",
   "bin": {


### PR DESCRIPTION
The previous "next" release-train has moved into the release-candidate phase. This PR updates the next branch to the subsequent release-train.

Also this PR cherry-picks the changelog for v16.1.0-rc.0 into the main branch so that the changelog is up to date.