### PR TITLE
fix(@angular-devkit/build-angular): support proxy configuration array-form in esbuild builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
@@ -20,7 +20,7 @@ import { buildEsbuildBrowserInternal } from '../browser-esbuild';
 import { JavaScriptTransformer } from '../browser-esbuild/javascript-transformer';
 import { BrowserEsbuildOptions } from '../browser-esbuild/options';
 import type { Schema as BrowserBuilderOptions } from '../browser-esbuild/schema';
-import { loadProxyConfiguration, normalizeProxyConfiguration } from './load-proxy-config';
+import { loadProxyConfiguration } from './load-proxy-config';
 import type { NormalizedDevServerOptions } from './options';
 import type { DevServerBuilderOutput } from './webpack-server';
 
@@ -196,10 +196,8 @@ export async function setupServer(
   const proxy = await loadProxyConfiguration(
     serverOptions.workspaceRoot,
     serverOptions.proxyConfig,
+    true,
   );
-  if (proxy) {
-    normalizeProxyConfiguration(proxy);
-  }
 
   const configuration: InlineConfig = {
     configFile: false,


### PR DESCRIPTION
When using the Webpack-based browser application builder with the development server, the proxy configuration can be in an array form when using the `proxyConfig` option. This is unfortunately not natively supported by the Vite development server used when building with the esbuild-based browser application builder. However, the array form can be transformed into the object form. This transformation allows for the array form of the proxy configuration to be used by both development server implementations.