### PR TITLE
docs: release notes for the v16.0.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+<a name="16.0.6"></a>
+
+# 16.0.6 (2023-06-13)
+
+### @angular-devkit/build-angular
+
+| Commit                                                                                              | Type | Description                                               |
+| --------------------------------------------------------------------------------------------------- | ---- | --------------------------------------------------------- |
+| [eebb54cbf](https://github.com/angular/angular-cli/commit/eebb54cbf4683b6113eb56dba17fab038318c918) | fix  | correctly handle sass imports                             |
+| [081b62539](https://github.com/angular/angular-cli/commit/081b62539b2562bff130343558bf4baafed7c36d) | fix  | support proxy configuration array-form in esbuild builder |
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="16.1.0-rc.0"></a>
 
 # 16.1.0-rc.0 (2023-06-07)


### PR DESCRIPTION
Cherry-picks the changelog from the "16.0.x" branch to the next branch (main).