### PR TITLE
build: bump versions for minor release

### DIFF
--- a/packages/angular/pwa/package.json
+++ b/packages/angular/pwa/package.json
@@ -17,7 +17,7 @@
     "parse5-html-rewriting-stream": "7.0.0"
   },
   "peerDependencies": {
-    "@angular/cli": "^16.0.0 || ^16.1.0-next.0"
+    "@angular/cli": "^16.1.0"
   },
   "peerDependenciesMeta": {
     "@angular/cli": {

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -75,14 +75,14 @@
     "esbuild": "0.17.19"
   },
   "peerDependencies": {
-    "@angular/compiler-cli": "^16.0.0 || ^16.1.0-next.0",
-    "@angular/localize": "^16.0.0 || ^16.1.0-next.0",
-    "@angular/platform-server": "^16.0.0 || ^16.1.0-next.0",
-    "@angular/service-worker": "^16.0.0 || ^16.1.0-next.0",
+    "@angular/compiler-cli": "^16.1.0",
+    "@angular/localize": "^16.1.0",
+    "@angular/platform-server": "^16.1.0",
+    "@angular/service-worker": "^16.1.0",
     "jest": "^29.5.0",
     "jest-environment-jsdom": "^29.5.0",
     "karma": "^6.3.0",
-    "ng-packagr": "^16.0.0 || ^16.1.0-next.0",
+    "ng-packagr": "^16.1.0",
     "protractor": "^7.0.0",
     "tailwindcss": "^2.0.0 || ^3.0.0",
     "typescript": ">=4.9.3 <5.2"

--- a/packages/ngtools/webpack/package.json
+++ b/packages/ngtools/webpack/package.json
@@ -22,14 +22,14 @@
   "homepage": "https://github.com/angular/angular-cli/tree/main/packages/ngtools/webpack",
   "dependencies": {},
   "peerDependencies": {
-    "@angular/compiler-cli": "^16.0.0 || ^16.1.0-next.0",
+    "@angular/compiler-cli": "^16.1.0",
     "typescript": ">=4.9.3 <5.2",
     "webpack": "^5.54.0"
   },
   "devDependencies": {
     "@angular-devkit/core": "0.0.0-PLACEHOLDER",
-    "@angular/compiler": "16.1.0-rc.0",
-    "@angular/compiler-cli": "16.1.0-rc.0",
+    "@angular/compiler": "16.1.0",
+    "@angular/compiler-cli": "16.1.0",
     "typescript": "5.1.3",
     "webpack": "5.86.0"
   }

--- a/packages/schematics/angular/utility/latest-versions.ts
+++ b/packages/schematics/angular/utility/latest-versions.ts
@@ -15,7 +15,7 @@ export const latestVersions: Record<string, string> & {
   ...require('./latest-versions/package.json')['dependencies'],
 
   // As Angular CLI works with same minor versions of Angular Framework, a tilde match for the current
-  Angular: '^16.1.0-next.0',
+  Angular: '^16.1.0',
 
   // Since @angular-devkit/build-angular and @schematics/angular are always
   // published together from the same monorepo, and they are both

--- a/packages/schematics/angular/utility/latest-versions/package.json
+++ b/packages/schematics/angular/utility/latest-versions/package.json
@@ -12,7 +12,7 @@
     "karma-jasmine-html-reporter": "~2.1.0",
     "karma-jasmine": "~5.1.0",
     "karma": "~6.4.0",
-    "ng-packagr": "^16.1.0-next.0",
+    "ng-packagr": "^16.1.0",
     "protractor": "~7.0.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",


### PR DESCRIPTION
(cherry picked from commit d4a2849010f5151bf7ad2bd390d1ec0a8b26a0f5)

Manual cherry pick of https://github.com/angular/angular-cli/pull/25373 because I accidentally targeted `minor` instead of `rc`.