### PR TITLE
fix(@angular-devkit/build-angular): unpin and downgrade `browserslist`

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "babel-loader": "9.1.2",
     "babel-plugin-istanbul": "6.1.1",
     "bootstrap": "^4.0.0",
-    "browserslist": "4.21.8",
+    "browserslist": "^4.21.5",
     "buffer": "6.0.3",
     "cacache": "17.1.3",
     "chokidar": "3.5.3",

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -27,7 +27,7 @@
     "autoprefixer": "10.4.14",
     "babel-loader": "9.1.2",
     "babel-plugin-istanbul": "6.1.1",
-    "browserslist": "4.21.8",
+    "browserslist": "^4.21.5",
     "cacache": "17.1.3",
     "chokidar": "3.5.3",
     "copy-webpack-plugin": "11.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -126,7 +126,6 @@
 
 "@angular/build-tooling@https://github.com/angular/dev-infra-private-build-tooling-builds.git#27aea082d8662d61c5a087b320c23e38f9268bfa":
   version "0.0.0-2ec31a92100367a52100fca54d5e8c7c78cb149c"
-  uid "27aea082d8662d61c5a087b320c23e38f9268bfa"
   resolved "https://github.com/angular/dev-infra-private-build-tooling-builds.git#27aea082d8662d61c5a087b320c23e38f9268bfa"
   dependencies:
     "@angular-devkit/build-angular" "16.1.0-next.1"
@@ -308,7 +307,6 @@
 
 "@angular/ng-dev@https://github.com/angular/dev-infra-private-ng-dev-builds.git#2607227d897f609848248ffd6d611fa79b6a5593":
   version "0.0.0-2ec31a92100367a52100fca54d5e8c7c78cb149c"
-  uid "2607227d897f609848248ffd6d611fa79b6a5593"
   resolved "https://github.com/angular/dev-infra-private-ng-dev-builds.git#2607227d897f609848248ffd6d611fa79b6a5593"
   dependencies:
     "@yarnpkg/lockfile" "^1.1.0"
@@ -4844,16 +4842,6 @@ browserslist@4.21.5:
     node-releases "^2.0.8"
     update-browserslist-db "^1.0.10"
 
-browserslist@4.21.8:
-  version "4.21.8"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.21.8.tgz#db2498e1f4b80ed199c076248a094935860b6017"
-  integrity sha512-j+7xYe+v+q2Id9qbBeCI8WX5NmZSRe8es1+0xntD/+gaWXznP8tFEkv5IgSaHf5dS1YwVMbX/4W6m937mj+wQw==
-  dependencies:
-    caniuse-lite "^1.0.30001502"
-    electron-to-chromium "^1.4.428"
-    node-releases "^2.0.12"
-    update-browserslist-db "^1.0.11"
-
 browserstack@^1.5.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/browserstack/-/browserstack-1.6.1.tgz#e051f9733ec3b507659f395c7a4765a1b1e358b3"
@@ -5002,11 +4990,6 @@ caniuse-lite@^1.0.30001449, caniuse-lite@^1.0.30001464, caniuse-lite@^1.0.300014
   version "1.0.30001502"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001502.tgz#f7e4a76eb1d2d585340f773767be1fefc118dca8"
   integrity sha512-AZ+9tFXw1sS0o0jcpJQIXvFTOB/xGiQ4OQ2t98QX3NDn2EZTSRBC801gxrsGgViuq2ak/NLkNgSNEPtCr5lfKg==
-
-caniuse-lite@^1.0.30001502:
-  version "1.0.30001503"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001503.tgz#88b6ff1b2cf735f1f3361dc1a15b59f0561aa398"
-  integrity sha512-Sf9NiF+wZxPfzv8Z3iS0rXM1Do+iOy2Lxvib38glFX+08TCYYYGR5fRJXk4d77C4AYwhUjgYgMsMudbh2TqCKw==
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -5886,11 +5869,6 @@ electron-to-chromium@^1.4.284, electron-to-chromium@^1.4.411:
   version "1.4.427"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.427.tgz#67e8069f7a864fc092fe2e09f196e68af5cb88a1"
   integrity sha512-HK3r9l+Jm8dYAm1ctXEWIC+hV60zfcjS9UA5BDlYvnI5S7PU/yytjpvSrTNrSSRRkuu3tDyZhdkwIczh+0DWaw==
-
-electron-to-chromium@^1.4.428:
-  version "1.4.431"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.431.tgz#47990d6e43465d69aa1fbd0abdec43114946edd0"
-  integrity sha512-m232JTVmCawA2vG+1azVxhKZ9Sv1Q//xxNv5PkP5rWxGgQE8c3CiZFrh8Xnp+d1NmNxlu3QQrGIfdeW5TtXX5w==
 
 emoji-regex@^8.0.0:
   version "8.0.0"
@@ -10589,7 +10567,6 @@ sass@^1.55.0:
 
 "sauce-connect-proxy@https://saucelabs.com/downloads/sc-4.8.1-linux.tar.gz":
   version "0.0.0"
-  uid "9c16682e4c9716734432789884f868212f95f563"
   resolved "https://saucelabs.com/downloads/sc-4.8.1-linux.tar.gz#9c16682e4c9716734432789884f868212f95f563"
 
 saucelabs@^1.5.0:


### PR DESCRIPTION
This is in an effort to reduce errors like `"Unknown version 114 of edge (While processing: "base$0$0")"` which are caused by mismatching versions.

Closes #25377
