### PR TITLE
fix(@angular-devkit/build-angular): actually disable Vite prebundling file discovery

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
@@ -368,7 +368,7 @@ export async function setupServer(
       // Exclude any provided dependencies (currently build defined externals)
       exclude: prebundleExclude,
       // Skip automatic file-based entry point discovery
-      include: [],
+      entries: [],
       // Add an esbuild plugin to run the Angular linker on dependencies
       esbuildOptions: {
         plugins: [


### PR DESCRIPTION
The `entries` option should be used instead of the `includes` option to disable the file entry based discovery for Vite's prebundling. This discovery is unneeded due to the built application files existing only in memory.