### PR TITLE
fix(@angular-devkit/build-angular): experimental esbuild pipeline, add `es2015` to main fields for RxJS v6 compatibility

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/esbuild/application-code-bundle.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/application-code-bundle.ts
@@ -47,7 +47,11 @@ export function createCodeBundleOptions(
     assetNames: outputNames.media,
     target,
     supported: getFeatureSupport(target),
-    mainFields: ['es2020', 'browser', 'module', 'main'],
+    // Note: `es2015` is needed for RxJS v6. If not specified, `module` would
+    // match and the ES5 distribution would be bundled and ends up breaking at
+    // runtime with the RxJS testing library.
+    // More details: https://github.com/angular/angular-cli/issues/25405.
+    mainFields: ['es2020', 'es2015', 'browser', 'module', 'main'],
     conditions: ['es2020', 'es2015', 'module'],
     resolveExtensions: ['.ts', '.tsx', '.mjs', '.js'],
     metafile: true,


### PR DESCRIPTION
Currently, for RxJS v6, no conditions are available, and the ESBuild pipeline will select the
ES5 distribution based on the `module` main field. This is fine in most cases, but applications
could benefit from better optimization with the use of the ES2015 output + there are certain
code differences that currently would cause runtime breakages when e.g. `rxjs/testing` is used.

See: https://github.com/angular/angular-cli/issues/25405 for more details.

Fixes #25405.