### PR TITLE
refactor(@angular-devkit/build-angular): configure AOT compiler to skip class metadata in esbuild

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/application/tests/behavior/angular-aot-metadata_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/tests/behavior/angular-aot-metadata_spec.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { buildApplication } from '../../index';
+import { APPLICATION_BUILDER_INFO, BASE_OPTIONS, describeBuilder } from '../setup';
+
+describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
+  describe('Behavior: "Angular metadata"', () => {
+    it('should not emit any AOT class metadata functions', async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+      });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBe(true);
+
+      harness.expectFile('dist/main.js').content.not.toContain('setClassMetadata');
+    });
+  });
+});

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/angular/angular-compilation.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/angular/angular-compilation.ts
@@ -45,6 +45,7 @@ export abstract class AngularCompilation {
         allowEmptyCodegenFiles: false,
         annotationsAs: 'decorators',
         enableResourceInlining: false,
+        supportTestBed: false,
       }),
     );
   }


### PR DESCRIPTION
The esbuild plugin used within the esbuild-based browser application builder will not use the newly introduced internal `supportTestBed` AOT compiler option to disable the emit of class metadata functions within the output code. This removes the need to perform an additional transformation of the AOT compiler generated code to immediately remove the class metadata. The class metadata is only needed when using TestBed with AOT generated code but testing infrastructure within the CLI only performs unit-testing in JIT mode. In the future event that AOT enabled unit-testing is supported, this compiler option can be enabled for test related builds.
