### PR TITLE
fix(@schematics/angular): platform-browser-dynamic as dev dependency in standalone apps

### DIFF
--- a/packages/schematics/angular/ng-new/index.ts
+++ b/packages/schematics/angular/ng-new/index.ts
@@ -38,6 +38,7 @@ export default function (options: NgNewOptions): Rule {
     version: options.version,
     newProjectRoot: options.newProjectRoot,
     minimal: options.minimal,
+    standalone: options.standalone,
     strict: options.strict,
     packageManager: options.packageManager,
   };

--- a/packages/schematics/angular/ng-new/index_spec.ts
+++ b/packages/schematics/angular/ng-new/index_spec.ts
@@ -7,6 +7,7 @@
  */
 
 import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
+import { latestVersions } from '../utility/latest-versions';
 import { Schema as NgNewOptions } from './schema';
 
 describe('Ng New Schematic', () => {
@@ -55,6 +56,13 @@ describe('Ng New Schematic', () => {
       ]),
     );
     expect(files).not.toEqual(jasmine.arrayContaining(['/bar/src/app/app.module.ts']));
+
+    // @angular/platform-browser-dynamic is just a dev dependency in a standalone app
+    const pkg = JSON.parse(tree.readContent('/bar/package.json'));
+    expect(pkg.dependencies['@angular/platform-browser-dynamic']).toBeUndefined();
+    expect(pkg.devDependencies['@angular/platform-browser-dynamic']).toEqual(
+      latestVersions.Angular,
+    );
   });
 
   it('should should set the prefix in angular.json and in app.component.ts', async () => {

--- a/packages/schematics/angular/workspace/files/package.json.template
+++ b/packages/schematics/angular/workspace/files/package.json.template
@@ -15,8 +15,8 @@
     "@angular/compiler": "<%= latestVersions.Angular %>",
     "@angular/core": "<%= latestVersions.Angular %>",
     "@angular/forms": "<%= latestVersions.Angular %>",
-    "@angular/platform-browser": "<%= latestVersions.Angular %>",
-    "@angular/platform-browser-dynamic": "<%= latestVersions.Angular %>",
+    "@angular/platform-browser": "<%= latestVersions.Angular %>",<% if (!standalone) { %>
+    "@angular/platform-browser-dynamic": "<%= latestVersions.Angular %>",<% } %>
     "@angular/router": "<%= latestVersions.Angular %>",
     "rxjs": "<%= latestVersions['rxjs'] %>",
     "tslib": "<%= latestVersions['tslib'] %>",
@@ -24,7 +24,8 @@
   },
   "devDependencies": {
     "@angular/cli": "<%= '~' + version %>",
-    "@angular/compiler-cli": "<%= latestVersions.Angular %>",<% if (!minimal) { %>
+    "@angular/compiler-cli": "<%= latestVersions.Angular %>",<% if (standalone) { %>
+    "@angular/platform-browser-dynamic": "<%= latestVersions.Angular %>",<% } %><% if (!minimal) { %>
     "@types/jasmine": "<%= latestVersions['@types/jasmine'] %>",
     "jasmine-core": "<%= latestVersions['jasmine-core'] %>",
     "karma": "<%= latestVersions['karma'] %>",

--- a/packages/schematics/angular/workspace/index_spec.ts
+++ b/packages/schematics/angular/workspace/index_spec.ts
@@ -57,6 +57,7 @@ describe('Workspace Schematic', () => {
     const tree = await schematicRunner.runSchematic('workspace', defaultOptions);
     const pkg = JSON.parse(tree.readContent('/package.json'));
     expect(pkg.dependencies['@angular/core']).toEqual(latestVersions.Angular);
+    expect(pkg.dependencies['@angular/platform-browser-dynamic']).toEqual(latestVersions.Angular);
     expect(pkg.dependencies['rxjs']).toEqual(latestVersions['rxjs']);
     expect(pkg.dependencies['zone.js']).toEqual(latestVersions['zone.js']);
     expect(pkg.devDependencies['typescript']).toEqual(latestVersions['typescript']);
@@ -133,5 +134,17 @@ describe('Workspace Schematic', () => {
     expect(configurations).not.toContain(jasmine.objectContaining({ name: 'ng test' }));
     const { tasks } = parseJson(tree.readContent('.vscode/tasks.json').toString());
     expect(tasks).not.toContain(jasmine.objectContaining({ type: 'npm', script: 'test' }));
+  });
+
+  it('should not @angular/platform-browser-dynamic as a dev dependency when using standalone', async () => {
+    const tree = await schematicRunner.runSchematic('workspace', {
+      ...defaultOptions,
+      standalone: true,
+    });
+    const pkg = JSON.parse(tree.readContent('/package.json'));
+    expect(pkg.dependencies['@angular/platform-browser-dynamic']).toBeUndefined();
+    expect(pkg.devDependencies['@angular/platform-browser-dynamic']).toEqual(
+      latestVersions.Angular,
+    );
   });
 });

--- a/packages/schematics/angular/workspace/schema.json
+++ b/packages/schematics/angular/workspace/schema.json
@@ -32,6 +32,11 @@
       "type": "boolean",
       "default": false
     },
+    "standalone": {
+      "description": "Creates an application based upon the standalone API, without NgModules.",
+      "type": "boolean",
+      "default": false
+    },
     "strict": {
       "description": "Create a workspace with stricter type checking options. This setting helps improve maintainability and catch bugs ahead of time. For more information, see https://angular.io/strict",
       "type": "boolean",


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

The generated application with `--standalone` has `@angular/platform-browser-dynamic` as a dependency but does not use it. It is only useful for `ng test`

## What is the new behavior?

When using the `--standalone` flag, `@angular/platform-browser-dynamic` is added a dev dependency

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
