### PR TITLE
fix(@angular-devkit/build-angular): watch all bundler provided inputs with esbuild builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/esbuild/angular/aot-compilation.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/angular/aot-compilation.ts
@@ -103,7 +103,10 @@ export class AotCompilation extends AngularCompilation {
     const referencedFiles = typeScriptProgram
       .getSourceFiles()
       .filter((sourceFile) => !angularCompiler.ignoreForEmit.has(sourceFile))
-      .map((sourceFile) => sourceFile.fileName);
+      .flatMap((sourceFile) => [
+        sourceFile.fileName,
+        ...angularCompiler.getResourceDependencies(sourceFile),
+      ]);
 
     return { affectedFiles, compilerOptions, referencedFiles };
   }

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/bundler-execution-result.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/bundler-execution-result.ts
@@ -49,7 +49,12 @@ export class ExecutionResult {
   }
 
   get watchFiles() {
-    return this.codeBundleCache?.referencedFiles ?? [];
+    const files = this.rebuildContexts.flatMap((context) => [...context.watchFiles]);
+    if (this.codeBundleCache?.referencedFiles) {
+      files.push(...this.codeBundleCache.referencedFiles);
+    }
+
+    return files;
   }
 
   createRebuildState(fileChanges: ChangedFiles): RebuildState {

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/watcher.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/watcher.ts
@@ -36,7 +36,9 @@ export function createWatcher(options?: {
   ignored?: string[];
 }): BuildWatcher {
   const watcher = new FSWatcher({
-    ...options,
+    usePolling: options?.polling,
+    interval: options?.interval,
+    ignored: options?.ignored,
     disableGlobbing: true,
     ignoreInitial: true,
   });


### PR DESCRIPTION
When using the esbuild-based browser application builder in watch mode (including `ng serve`), all input files provided by the bundler via the internal metafile information will now be watched and will trigger rebuilds if changed. This allows for files outside of the TypeScript compilation that are also outside of the project source root to be watched. This situation can be encountered in monorepo setups where library code is directly referenced within an application.