### PR TITLE
refactor(@angular-devkit/build-angular): allow NG_BUILD_MANGLE variable with esbuild builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/esbuild/application-code-bundle.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/application-code-bundle.ts
@@ -13,6 +13,7 @@ import { createExternalPackagesPlugin } from '../../tools/esbuild/external-packa
 import { createSourcemapIngorelistPlugin } from '../../tools/esbuild/sourcemap-ignorelist-plugin';
 import { getFeatureSupport } from '../../tools/esbuild/utils';
 import { createVirtualModulePlugin } from '../../tools/esbuild/virtual-module-plugin';
+import { allowMangle } from '../../utils/environment-options';
 
 export function createCodeBundleOptions(
   options: NormalizedBrowserOptions,
@@ -57,7 +58,9 @@ export function createCodeBundleOptions(
     metafile: true,
     legalComments: options.extractLicenses ? 'none' : 'eof',
     logLevel: options.verbose ? 'debug' : 'silent',
-    minify: optimizationOptions.scripts,
+    minifyIdentifiers: optimizationOptions.scripts && allowMangle,
+    minifySyntax: optimizationOptions.scripts,
+    minifyWhitespace: optimizationOptions.scripts,
     pure: ['forwardRef'],
     outdir: workspaceRoot,
     outExtension: outExtension ? { '.js': `.${outExtension}` } : undefined,


### PR DESCRIPTION
The development `NG_BUILD_MANGLE` environment variable is now supported when using the esbuild-based browser application builder. This environment variable is intended only for Angular CLI development and test purposes.

Closes: #25412