### PR TITLE
fix(@angular-devkit/build-angular): allow linker JIT support with prebundling with esbuild builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
@@ -376,7 +376,10 @@ export async function setupServer(
             name: 'angular-vite-optimize-deps',
             setup(build) {
               const transformer = new JavaScriptTransformer(
-                { sourcemap: !!build.initialOptions.sourcemap },
+                // Always enable JIT linking to support applications built with and without AOT.
+                // In a development environment the additional scope information does not
+                // have a negative effect unlike production where final output size is relevant.
+                { sourcemap: !!build.initialOptions.sourcemap, jit: true },
                 1,
               );
 


### PR DESCRIPTION
When using prebundling with the Vite-based development server, the angular linker will now correctly emit JIT module scope information. This information is required in JIT mode for NgModules to successfully be used in an application.