### PR TITLE
fix(@angular-devkit/build-angular): use all style language watch files in esbuild builder

### DIFF
--- a/tests/legacy-cli/e2e/tests/basic/rebuild.ts
+++ b/tests/legacy-cli/e2e/tests/basic/rebuild.ts
@@ -158,4 +158,19 @@ export default async function () {
       throw new Error('Expected component CSS to update.');
     }
   }
+
+  await Promise.all([
+    waitForAnyProcessOutputToMatch(validBundleRegEx),
+    writeMultipleFiles({
+      'src/styles.css': 'div { color: green; }',
+    }),
+  ]);
+
+  {
+    const response = await fetch(`http://localhost:${port}/styles.css`);
+    const body = await response.text();
+    if (!body.match(/color:\s?green/)) {
+      throw new Error('Expected component CSS to update.');
+    }
+  }
 }


### PR DESCRIPTION
A recent change to better support Tailwind CSS in watch mode unintentionally caused part of the watch files list for stylesheets to be ignored when Tailwind and/or autoprefixer were required to be executed. This resulted in rebuilds occurring but all stylesheet changes were not fully propagated to the development server. This has now been corrected.