### PR TITLE
build: temporarily block Webpack version updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,7 @@
   "dependencyDashboard": true,
   "schedule": ["after 10:00pm every weekday", "before 4:00am every weekday", "every weekend"],
   "baseBranches": ["main"],
-  "ignoreDeps": ["@types/node", "rules_pkg", "less-loader"],
+  "ignoreDeps": ["@types/node", "rules_pkg", "less-loader", "webpack"],
   "includePaths": [
     "WORKSPACE",
     "package.json",


### PR DESCRIPTION
Webpack 5.88.0+ currently causes failures during i18n builds and prevents CI from passing. This is causing a block on renovate from updating all minor dependencies. While an investigation into the problem is in progress, the Webpack version is now added to the Renovate ignore list to allow other dependencies updates to occur.