### PR TITLE
Revert "build: temporarily block Webpack version updates"

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,7 @@
   "dependencyDashboard": true,
   "schedule": ["after 10:00pm every weekday", "before 4:00am every weekday", "every weekend"],
   "baseBranches": ["main"],
-  "ignoreDeps": ["@types/node", "rules_pkg", "less-loader", "webpack"],
+  "ignoreDeps": ["@types/node", "rules_pkg", "less-loader"],
   "includePaths": [
     "WORKSPACE",
     "package.json",


### PR DESCRIPTION
The issue appears to be related to esbuild/terser optimization and not webpack.

This reverts commit 78d1010967b21949688fa269f8a9ee7ae5fcd348.