### PR TITLE
refactor: remove `keepNames` esbuild option for server builds

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/configs/common.ts
@@ -300,7 +300,6 @@ export async function getCommonConfig(wco: WebpackConfigOptions): Promise<Config
         sourcemap: scriptsSourceMap,
         supportedBrowsers: buildOptions.supportedBrowsers,
         keepIdentifierNames: !allowMangle || isPlatformServer,
-        keepNames: isPlatformServer,
         removeLicenses: buildOptions.extractLicenses,
         advanced: buildOptions.buildOptimizer,
       }),

--- a/packages/angular_devkit/build_angular/src/tools/webpack/plugins/javascript-optimizer-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/plugins/javascript-optimizer-plugin.ts
@@ -62,13 +62,6 @@ export interface JavaScriptOptimizerOptions {
   keepIdentifierNames: boolean;
 
   /**
-   * Enables the retention of original name of classes and functions.
-   *
-   * **Note**: this causes increase of bundle size as it causes dead-code elimination to not work fully.
-   */
-  keepNames: boolean;
-
-  /**
    * Enables the removal of all license comments from the output code.
    */
   removeLicenses?: boolean;
@@ -166,7 +159,6 @@ export class JavaScriptOptimizerPlugin {
           const optimizeOptions: OptimizeRequestOptions = {
             sourcemap: this.options.sourcemap,
             define,
-            keepNames: this.options.keepNames,
             keepIdentifierNames: this.options.keepIdentifierNames,
             target: this.targets,
             removeLicenses: this.options.removeLicenses,

--- a/packages/angular_devkit/build_angular/src/tools/webpack/plugins/javascript-optimizer-worker.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/plugins/javascript-optimizer-worker.ts
@@ -33,10 +33,6 @@ export interface OptimizeRequestOptions {
   keepIdentifierNames: boolean;
 
   /**
-   * Controls whether to retain the original name of classes and functions.
-   */
-  keepNames: boolean;
-  /**
    * Controls whether license text is removed from the output code.
    * Within the CLI, this option is linked to the license extraction functionality.
    */
@@ -167,11 +163,6 @@ async function optimizeWithEsbuild(
       sourcefile: name,
       sourcemap: options.sourcemap && 'external',
       define: options.define,
-      // This option should always be disabled for browser builds as we don't rely on `.name`
-      // and causes deadcode to be retained which makes `NG_BUILD_MANGLE` unusable to investigate tree-shaking issues.
-      // We enable `keepNames` only for server builds as Domino relies on `.name`.
-      // Once we no longer rely on Domino for SSR we should be able to remove this.
-      keepNames: options.keepNames,
       target: options.target,
     });
   } catch (error) {


### PR DESCRIPTION
This option is no longer needed due to the changes done in the forked version of Domino.
