### PR TITLE
refactor(@angular-devkit/build-angular): use built-in async generator downleveling in esbuild

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/esbuild/javascript-transformer-worker.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/javascript-transformer-worker.ts
@@ -18,7 +18,6 @@ interface JavaScriptTransformRequest {
   sourcemap: boolean;
   thirdPartySourcemaps: boolean;
   advancedOptimizations: boolean;
-  forceAsyncTransformation?: boolean;
   skipLinker: boolean;
   jit: boolean;
 }
@@ -41,16 +40,13 @@ async function transformWithBabel({
   data,
   ...options
 }: JavaScriptTransformRequest): Promise<string> {
-  const forceAsyncTransformation =
-    options.forceAsyncTransformation ??
-    (!/[\\/][_f]?esm2015[\\/]/.test(filename) && /async(?:\s+function)?\s*\*/.test(data));
   const shouldLink = !options.skipLinker && (await requiresLinking(filename, data));
   const useInputSourcemap =
     options.sourcemap &&
     (!!options.thirdPartySourcemaps || !/[\\/]node_modules[\\/]/.test(filename));
 
   // If no additional transformations are needed, return the data directly
-  if (!forceAsyncTransformation && !options.advancedOptimizations && !shouldLink) {
+  if (!options.advancedOptimizations && !shouldLink) {
     // Strip sourcemaps if they should not be used
     return useInputSourcemap ? data : data.replace(/^\/\/# sourceMappingURL=[^\r\n]*/gm, '');
   }
@@ -87,7 +83,6 @@ async function transformWithBabel({
             jitMode: options.jit,
             linkerPluginCreator,
           },
-          forceAsyncTransformation,
           optimize: options.advancedOptimizations && {
             pureTopLevel: safeAngularPackage,
           },

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/utils.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/utils.ts
@@ -123,10 +123,7 @@ export async function logMessages(
 export function getFeatureSupport(target: string[]): BuildOptions['supported'] {
   const supported: Record<string, boolean> = {
     // Native async/await is not supported with Zone.js. Disabling support here will cause
-    // esbuild to downlevel async/await and for await...of to a Zone.js supported form. However, esbuild
-    // does not currently support downleveling async generators. Instead babel is used within the JS/TS
-    // loader to perform the downlevel transformation.
-    // NOTE: If esbuild adds support in the future, the babel support for async generators can be disabled.
+    // esbuild to downlevel async/await, async generators, and for await...of to a Zone.js supported form.
     'async-await': false,
     // V8 currently has a performance defect involving object spread operations that can cause signficant
     // degradation in runtime performance. By not supporting the language feature here, a downlevel form


### PR DESCRIPTION
As of esbuild v0.18.8, async generators can be downleveled when not supported. This improvement allows for the removal of the babel plugins to perform the async generator downleveling that were previously used. This can provide a performance benefit for cases of async generator usage in application and third-party library code.