### PR TITLE
[15.2.x] fix(@angular/cli): update direct semver dependencies to 7.5.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -197,7 +197,7 @@
     "sass": "1.58.1",
     "sass-loader": "13.2.0",
     "sauce-connect-proxy": "https://saucelabs.com/downloads/sc-4.8.1-linux.tar.gz",
-    "semver": "7.3.8",
+    "semver": "7.5.3",
     "shelljs": "^0.8.5",
     "source-map": "0.7.4",
     "source-map-loader": "4.0.1",

--- a/packages/angular/cli/package.json
+++ b/packages/angular/cli/package.json
@@ -37,7 +37,7 @@
     "ora": "5.4.1",
     "pacote": "15.1.0",
     "resolve": "1.22.1",
-    "semver": "7.3.8",
+    "semver": "7.5.3",
     "symbol-observable": "4.0.0",
     "yargs": "17.6.2"
   },

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -54,7 +54,7 @@
     "rxjs": "6.6.7",
     "sass": "1.58.1",
     "sass-loader": "13.2.0",
-    "semver": "7.3.8",
+    "semver": "7.5.3",
     "source-map-loader": "4.0.1",
     "source-map-support": "0.5.21",
     "terser": "5.16.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10163,6 +10163,13 @@ semver@7.3.8, semver@^7.0.0, semver@^7.1.1, semver@^7.3.5, semver@^7.3.7, semver
   dependencies:
     lru-cache "^6.0.0"
 
+semver@7.5.3:
+  version "7.5.3"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.3.tgz#161ce8c2c6b4b3bdca6caadc9fa3317a4c4fe88e"
+  integrity sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==
+  dependencies:
+    lru-cache "^6.0.0"
+
 semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"


### PR DESCRIPTION
All direct usages of the `semver` package have been updated to address https://github.com/advisories/GHSA-c2qf-rxjj-qqgw. The `semver` package is only used as a development dependency and not included in built application code within generated projects. This update does not affect any transitive usages of `semver` and any such usages would need to be handled by relevant upstream packages.