### PR TITLE
[14.2.x] fix(@angular/cli): update direct semver dependencies to 7.5.3

### DIFF
--- a/.circleci/dynamic_config.yml
+++ b/.circleci/dynamic_config.yml
@@ -407,7 +407,7 @@ workflows:
 
       - e2e-tests:
           name: e2e-cli-<< matrix.subset >>
-          nodeversion: '14.15'
+          nodeversion: '14.19'
           matrix:
             parameters:
               subset: *all_e2e_subsets
@@ -424,7 +424,7 @@ workflows:
           matrix:
             alias: e2e-cli
             parameters:
-              nodeversion: ['14.15', '16.10']
+              nodeversion: ['14.19', '16.10']
               subset: *all_e2e_subsets
           requires:
             - build

--- a/package.json
+++ b/package.json
@@ -200,7 +200,7 @@
     "sass": "1.54.4",
     "sass-loader": "13.0.2",
     "sauce-connect-proxy": "https://saucelabs.com/downloads/sc-4.8.1-linux.tar.gz",
-    "semver": "7.3.7",
+    "semver": "7.5.3",
     "shelljs": "^0.8.5",
     "source-map": "0.7.4",
     "source-map-loader": "4.0.0",

--- a/packages/angular/cli/package.json
+++ b/packages/angular/cli/package.json
@@ -38,7 +38,7 @@
     "ora": "5.4.1",
     "pacote": "13.6.2",
     "resolve": "1.22.1",
-    "semver": "7.3.7",
+    "semver": "7.5.3",
     "symbol-observable": "4.0.0",
     "uuid": "8.3.2",
     "yargs": "17.5.1"

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -54,7 +54,7 @@
     "rxjs": "6.6.7",
     "sass": "1.54.4",
     "sass-loader": "13.0.2",
-    "semver": "7.3.7",
+    "semver": "7.5.3",
     "source-map-loader": "4.0.0",
     "source-map-support": "0.5.21",
     "stylus": "0.59.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9923,6 +9923,13 @@ semver@7.3.7, semver@^7.0.0, semver@^7.1.1, semver@^7.3.5, semver@^7.3.7, semver
   dependencies:
     lru-cache "^6.0.0"
 
+semver@7.5.3:
+  version "7.5.3"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.3.tgz#161ce8c2c6b4b3bdca6caadc9fa3317a4c4fe88e"
+  integrity sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==
+  dependencies:
+    lru-cache "^6.0.0"
+
 semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"


### PR DESCRIPTION
All direct usages of the `semver` package have been updated to address https://github.com/advisories/GHSA-c2qf-rxjj-qqgw. The `semver` package is only used as a development dependency and not included in built application code within generated projects. This update does not affect any transitive usages of `semver` and any such usages would need to be handled by relevant upstream packages.