### PR TITLE
build: update Angular peer dependencies to `^16.0.0`

### DIFF
--- a/packages/angular/pwa/package.json
+++ b/packages/angular/pwa/package.json
@@ -17,7 +17,7 @@
     "parse5-html-rewriting-stream": "7.0.0"
   },
   "peerDependencies": {
-    "@angular/cli": "^16.1.0"
+    "@angular/cli": "^16.0.0"
   },
   "peerDependenciesMeta": {
     "@angular/cli": {

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -75,14 +75,14 @@
     "esbuild": "0.17.19"
   },
   "peerDependencies": {
-    "@angular/compiler-cli": "^16.1.0",
-    "@angular/localize": "^16.1.0",
-    "@angular/platform-server": "^16.1.0",
-    "@angular/service-worker": "^16.1.0",
+    "@angular/compiler-cli": "^16.0.0",
+    "@angular/localize": "^16.0.0",
+    "@angular/platform-server": "^16.0.0",
+    "@angular/service-worker": "^16.0.0",
     "jest": "^29.5.0",
     "jest-environment-jsdom": "^29.5.0",
     "karma": "^6.3.0",
-    "ng-packagr": "^16.1.0",
+    "ng-packagr": "^16.0.0",
     "protractor": "^7.0.0",
     "tailwindcss": "^2.0.0 || ^3.0.0",
     "typescript": ">=4.9.3 <5.2"

--- a/packages/ngtools/webpack/package.json
+++ b/packages/ngtools/webpack/package.json
@@ -22,7 +22,7 @@
   "homepage": "https://github.com/angular/angular-cli/tree/main/packages/ngtools/webpack",
   "dependencies": {},
   "peerDependencies": {
-    "@angular/compiler-cli": "^16.1.0",
+    "@angular/compiler-cli": "^16.0.0",
     "typescript": ">=4.9.3 <5.2",
     "webpack": "^5.54.0"
   },

--- a/packages/schematics/angular/utility/latest-versions/package.json
+++ b/packages/schematics/angular/utility/latest-versions/package.json
@@ -12,7 +12,7 @@
     "karma-jasmine-html-reporter": "~2.1.0",
     "karma-jasmine": "~5.1.0",
     "karma": "~6.4.0",
-    "ng-packagr": "^16.1.0",
+    "ng-packagr": "^16.0.0",
     "protractor": "~7.0.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",


### PR DESCRIPTION
This is needed as the release check are failing due to incorrect peer deps.
