### PR TITLE
fix(@angular-devkit/build-angular): use absolute watch paths for postcss dependency messages

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/esbuild/stylesheets/stylesheet-plugin-factory.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/stylesheets/stylesheet-plugin-factory.ts
@@ -260,7 +260,10 @@ async function compileString(
         typeof resultMessage['glob'] === 'string'
       ) {
         loadResult.watchFiles ??= [];
-        const dependencies = await glob(resultMessage['glob'], { cwd: resultMessage['dir'] });
+        const dependencies = await glob(resultMessage['glob'], {
+          absolute: true,
+          cwd: resultMessage['dir'],
+        });
         loadResult.watchFiles.push(...dependencies);
       }
     }


### PR DESCRIPTION
Postcss's directory dependency message can use a glob pattern to reflect that multiple files within a given directory should be watched. When calculated the complete file set, the paths must be absolute to ensure that the watch system correctly invalidates the stylesheet being processed.