### PR TITLE
fix(@angular-devkit/build-angular): normalize paths in loader cache with esbuild

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/esbuild/global-scripts.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/global-scripts.ts
@@ -89,15 +89,16 @@ export function createGlobalScriptsBundleOptions(
               let fileContent;
               try {
                 // Attempt to read as a relative path from the workspace root
-                fileContent = await readFile(path.join(workspaceRoot, filename), 'utf-8');
-                watchFiles.push(filename);
+                const fullPath = path.join(workspaceRoot, filename);
+                fileContent = await readFile(fullPath, 'utf-8');
+                watchFiles.push(fullPath);
               } catch (e) {
                 assertIsError(e);
                 if (e.code !== 'ENOENT') {
                   throw e;
                 }
 
-                // If not found attempt to resolve as a module specifier
+                // If not found, attempt to resolve as a module specifier
                 const resolveResult = await build.resolve(filename, {
                   kind: 'entry-point',
                   resolveDir: workspaceRoot,
@@ -114,7 +115,7 @@ export function createGlobalScriptsBundleOptions(
                   };
                 }
 
-                watchFiles.push(path.relative(resolveResult.path, workspaceRoot));
+                watchFiles.push(resolveResult.path);
                 fileContent = await readFile(resolveResult.path, 'utf-8');
               }
 

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/load-result-cache.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/load-result-cache.ts
@@ -7,6 +7,7 @@
  */
 
 import type { OnLoadResult, PluginBuild } from 'esbuild';
+import { normalize } from 'node:path';
 
 export interface LoadResultCache {
   get(path: string): OnLoadResult | undefined;
@@ -50,10 +51,12 @@ export class MemoryLoadResultCache implements LoadResultCache {
     this.#loadResults.set(path, result);
     if (result.watchFiles) {
       for (const watchFile of result.watchFiles) {
-        let affected = this.#fileDependencies.get(watchFile);
+        // Normalize the watch file path to ensure OS consistent paths
+        const normalizedWatchFile = normalize(watchFile);
+        let affected = this.#fileDependencies.get(normalizedWatchFile);
         if (affected === undefined) {
           affected = new Set();
-          this.#fileDependencies.set(watchFile, affected);
+          this.#fileDependencies.set(normalizedWatchFile, affected);
         }
         affected.add(path);
       }


### PR DESCRIPTION
When using the esbuild-based application builder, some plugins may return watch file lists that contain POSIX paths on Windows systems. This can cause the file watcher to not correctly invalidate files that need to be processed during a rebuild. All watch files are now normalized prior to being added to the in-memory cache to avoid this problem.