### PR TITLE
feat(@angular-devkit/build-angular): add pre-rendering (SSG) and App-shell support generation to application builder     

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -58,7 +58,7 @@ nodejs_register_toolchains(
 
 nodejs_register_toolchains(
     name = "node18",
-    node_version = "18.10.0",
+    node_version = "18.13.0",
 )
 
 # Set the default nodejs toolchain to the latest supported major version

--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
     "eslint-plugin-import": "2.27.5",
     "express": "4.18.2",
     "fast-glob": "3.2.12",
+    "guess-parser": "0.4.22",
     "http-proxy": "^1.18.1",
     "https-proxy-agent": "5.0.1",
     "husky": "8.0.3",

--- a/packages/angular_devkit/build_angular/BUILD.bazel
+++ b/packages/angular_devkit/build_angular/BUILD.bazel
@@ -157,6 +157,7 @@ ts_library(
         "@npm//esbuild",
         "@npm//esbuild-wasm",
         "@npm//fast-glob",
+        "@npm//guess-parser",
         "@npm//https-proxy-agent",
         "@npm//inquirer",
         "@npm//jsonc-parser",
@@ -298,6 +299,10 @@ ts_library(
 LARGE_SPECS = {
     "application": {
         "shards": 10,
+        "tags": [
+            # TODO: This is broken as app-shell tests do not work in Node versions prior to 18.13 due to Zone.js and SafePromise.
+            "node16-broken",
+        ],
         "extra_deps": [
             "@npm//buffer",
         ],

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -34,6 +34,7 @@
     "css-loader": "6.8.1",
     "esbuild-wasm": "0.18.10",
     "fast-glob": "3.2.12",
+    "guess-parser": "0.4.22",
     "https-proxy-agent": "5.0.1",
     "inquirer": "8.2.4",
     "jsonc-parser": "3.2.0",

--- a/packages/angular_devkit/build_angular/src/builders/app-shell/render-worker.ts
+++ b/packages/angular_devkit/build_angular/src/builders/app-shell/render-worker.ts
@@ -78,7 +78,7 @@ async function render({ serverBundlePath, document, url }: RenderRequest): Promi
   ];
 
   // Render platform server module
-  if (bootstrapAppFn) {
+  if (isBootstrapFn(bootstrapAppFn)) {
     assert(renderApplication, `renderApplication was not exported from: ${serverBundlePath}.`);
 
     return renderApplication(bootstrapAppFn, {
@@ -99,6 +99,11 @@ async function render({ serverBundlePath, document, url }: RenderRequest): Promi
     url,
     extraProviders: platformProviders,
   });
+}
+
+function isBootstrapFn(value: unknown): value is () => Promise<ApplicationRef> {
+  // We can differentiate between a module and a bootstrap function by reading `cmp`:
+  return typeof value === 'function' && !('ɵmod' in value);
 }
 
 /**

--- a/packages/angular_devkit/build_angular/src/builders/application/options.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/options.ts
@@ -61,6 +61,7 @@ export type ApplicationBuilderInternalOptions = Omit<
  * @param options An object containing the options to use for the build.
  * @returns An object containing normalized options required to perform the build.
  */
+// eslint-disable-next-line max-lines-per-function
 export async function normalizeOptions(
   context: BuilderContext,
   projectName: string,
@@ -151,7 +152,8 @@ export async function normalizeOptions(
   }
 
   let indexHtmlOptions;
-  if (options.index) {
+  // index can never have a value of `true` but in the schema it's of type `boolean`.
+  if (typeof options.index !== 'boolean') {
     indexHtmlOptions = {
       input: path.join(workspaceRoot, getIndexInputFile(options.index)),
       // The output file will be created within the configured output path
@@ -169,6 +171,28 @@ export async function normalizeOptions(
     serverEntryPoint = path.join(workspaceRoot, options.server);
   } else if (options.server === '') {
     throw new Error('`server` option cannot be an empty string.');
+  }
+
+  let prerenderOptions;
+  if (options.prerender) {
+    const {
+      discoverRoutes = true,
+      routes = [],
+      routesFile = undefined,
+    } = options.prerender === true ? {} : options.prerender;
+
+    prerenderOptions = {
+      discoverRoutes,
+      routes,
+      routesFile: routesFile && path.join(workspaceRoot, routesFile),
+    };
+  }
+
+  let appShellOptions;
+  if (options.appShell) {
+    appShellOptions = {
+      route: 'shell',
+    };
   }
 
   // Initial options to keep
@@ -217,6 +241,8 @@ export async function normalizeOptions(
     stylePreprocessorOptions,
     subresourceIntegrity,
     serverEntryPoint,
+    prerenderOptions,
+    appShellOptions,
     verbose,
     watch,
     workspaceRoot,
@@ -232,7 +258,8 @@ export async function normalizeOptions(
     fileReplacements,
     globalStyles,
     globalScripts,
-    serviceWorker,
+    serviceWorker:
+      typeof serviceWorker === 'string' ? path.join(workspaceRoot, serviceWorker) : undefined,
     indexHtmlOptions,
     tailwindConfiguration,
   };

--- a/packages/angular_devkit/build_angular/src/builders/application/schema.json
+++ b/packages/angular_devkit/build_angular/src/builders/application/schema.json
@@ -353,6 +353,7 @@
         },
         {
           "const": false,
+          "type": "boolean",
           "description": "Does not generate a service worker configuration."
         }
       ]
@@ -384,6 +385,7 @@
         },
         {
           "const": false,
+          "type": "boolean",
           "description": "Does not generate an `index.html` file."
         }
       ]
@@ -418,6 +420,46 @@
         "type": "string"
       },
       "default": []
+    },
+    "prerender": {
+      "description": "Prerender (SSG) pages of your application during build time.",
+      "default": false,
+      "oneOf": [
+        {
+          "type": "boolean",
+          "description": "Enable prerending of pages of your application during build time."
+        },
+        {
+          "type": "object",
+          "properties": {
+            "routesFile": {
+              "type": "string",
+              "description": "The path to a file containing routes separated by newlines."
+            },
+            "routes": {
+              "type": "array",
+              "description": "The routes to render.",
+              "items": {
+                "minItems": 1,
+                "type": "string",
+                "uniqueItems": true
+              },
+              "default": []
+            },
+            "discoverRoutes": {
+              "type": "boolean",
+              "description": "Whether the builder should statically discover routes.",
+              "default": true
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "appShell": {
+      "type": "boolean",
+      "description": "Generates an application shell during build time.",
+      "default": false
     }
   },
   "additionalProperties": false,

--- a/packages/angular_devkit/build_angular/src/builders/application/tests/options/app-shell_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/tests/options/app-shell_spec.ts
@@ -1,0 +1,177 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { buildApplication } from '../../index';
+import { APPLICATION_BUILDER_INFO, BASE_OPTIONS, describeBuilder } from '../setup';
+
+const appShellRouteFiles: Record<string, string> = {
+  'src/styles.css': `p { color: #000 }`,
+  'src/app/app-shell/app-shell.component.ts': `
+    import { Component } from '@angular/core';
+
+    @Component({
+      selector: 'app-app-shell',
+      styles: ['div { color: #fff; }'],
+      template: '<p>app-shell works!</p>',
+    })
+    export class AppShellComponent {}`,
+  'src/main.server.ts': `
+    import { AppServerModule } from './app/app.module.server';
+    export default AppServerModule;
+  `,
+  'src/app/app.module.ts': `
+    import { BrowserModule } from '@angular/platform-browser';
+    import { NgModule } from '@angular/core';
+
+    import { AppRoutingModule } from './app-routing.module';
+    import { AppComponent } from './app.component';
+    import { RouterModule } from '@angular/router';
+
+    @NgModule({
+      declarations: [
+        AppComponent
+      ],
+      imports: [
+        BrowserModule,
+        AppRoutingModule,
+        RouterModule
+      ],
+      bootstrap: [AppComponent]
+    })
+    export class AppModule { }
+  `,
+  'src/app/app.module.server.ts': `
+    import { NgModule } from '@angular/core';
+    import { ServerModule } from '@angular/platform-server';
+
+    import { AppModule } from './app.module';
+    import { AppComponent } from './app.component';
+    import { Routes, RouterModule } from '@angular/router';
+    import { AppShellComponent } from './app-shell/app-shell.component';
+
+    const routes: Routes = [ { path: 'shell', component: AppShellComponent }];
+
+    @NgModule({
+      imports: [
+        AppModule,
+        ServerModule,
+        RouterModule.forRoot(routes),
+      ],
+      bootstrap: [AppComponent],
+      declarations: [AppShellComponent],
+    })
+    export class AppServerModule {}
+  `,
+  'src/main.ts': `
+    import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+    import { AppModule } from './app/app.module';
+
+    platformBrowserDynamic().bootstrapModule(AppModule).catch(err => console.log(err));
+  `,
+  'src/app/app-routing.module.ts': `
+    import { NgModule } from '@angular/core';
+    import { Routes, RouterModule } from '@angular/router';
+
+    const routes: Routes = [];
+
+    @NgModule({
+      imports: [RouterModule.forRoot(routes)],
+      exports: [RouterModule]
+    })
+    export class AppRoutingModule { }
+  `,
+  'src/app/app.component.html': `<router-outlet></router-outlet>`,
+};
+
+describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
+  beforeEach(async () => {
+    await harness.modifyFile('src/tsconfig.app.json', (content) => {
+      const tsConfig = JSON.parse(content);
+      tsConfig.files ??= [];
+      tsConfig.files.push('main.server.ts');
+
+      return JSON.stringify(tsConfig);
+    });
+
+    await harness.writeFiles(appShellRouteFiles);
+  });
+
+  describe('Option: "appShell"', () => {
+    it('renders the application shell', async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        server: 'src/main.server.ts',
+        appShell: true,
+      });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
+
+      harness.expectFile('dist/main.js').toExist();
+      const indexFileContent = harness.expectFile('dist/index.html').content;
+      indexFileContent.toContain('app-shell works!');
+      indexFileContent.toContain('ng-server-context="app-shell"');
+    });
+
+    it('critical CSS is inlined', async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        server: 'src/main.server.ts',
+        appShell: true,
+        styles: ['src/styles.css'],
+        optimization: {
+          styles: {
+            minify: true,
+            inlineCritical: true,
+          },
+        },
+      });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
+
+      const indexFileContent = harness.expectFile('dist/index.html').content;
+      indexFileContent.toContain('app-shell works!');
+      indexFileContent.toContain('p{color:#000}');
+      indexFileContent.toContain(
+        `<link rel="stylesheet" href="styles.css" media="print" onload="this.media='all'">`,
+      );
+    });
+
+    it('applies CSP nonce to critical CSS', async () => {
+      await harness.modifyFile('src/index.html', (content) =>
+        content.replace(/<app-root/g, '<app-root ngCspNonce="{% nonce %}" '),
+      );
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        server: 'src/main.server.ts',
+        appShell: true,
+        styles: ['src/styles.css'],
+        optimization: {
+          styles: {
+            minify: true,
+            inlineCritical: true,
+          },
+        },
+      });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
+
+      const indexFileContent = harness.expectFile('dist/index.html').content;
+      indexFileContent.toContain('app-shell works!');
+      indexFileContent.toContain('p{color:#000}');
+      indexFileContent.toContain(
+        `<link rel="stylesheet" href="styles.css" media="print" ngCspMedia="all">`,
+      );
+      indexFileContent.toContain('<style nonce="{% nonce %}">p{color:#000}');
+      indexFileContent.toContain('<style nonce="{% nonce %}" ng-app-id="ng">');
+      indexFileContent.toContain('<app-root ngcspnonce="{% nonce %}"');
+    });
+  });
+});

--- a/packages/angular_devkit/build_angular/src/builders/application/tests/options/server_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/tests/options/server_spec.ts
@@ -35,7 +35,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
     });
 
     it('uses a provided JavaScript file', async () => {
-      await harness.writeFile('src/server.js', `console.log('server');`);
+      await harness.writeFile('src/server.js', `console.log('server'); export default {};`);
 
       harness.useTarget('build', {
         ...BASE_OPTIONS,
@@ -45,7 +45,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
       const { result } = await harness.executeOnce();
       expect(result?.success).toBeTrue();
 
-      harness.expectFile('dist/server.mjs').content.toContain('console.log("server")');
+      harness.expectFile('dist/server.mjs').toExist();
     });
 
     it('fails and shows an error when file does not exist', async () => {
@@ -78,7 +78,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
     });
 
     it('resolves an absolute path as relative inside the workspace root', async () => {
-      await harness.writeFile('file.mjs', `console.log('Hello!');`);
+      await harness.writeFile('file.mjs', `console.log('Hello!'); export default {};`);
 
       harness.useTarget('build', {
         ...BASE_OPTIONS,

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/builder-status-warnings.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/builder-status-warnings.ts
@@ -7,7 +7,7 @@
  */
 
 import { BuilderContext } from '@angular-devkit/architect';
-import { Schema as BrowserBuilderOptions } from '../browser/schema';
+import { Schema as BrowserBuilderOptions } from './schema';
 
 const UNSUPPORTED_OPTIONS: Array<keyof BrowserBuilderOptions> = [
   'budgets',

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/schema.json
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/schema.json
@@ -400,6 +400,7 @@
         },
         {
           "const": false,
+          "type": "boolean",
           "description": "Does not generate an `index.html` file."
         }
       ]

--- a/packages/angular_devkit/build_angular/src/builders/jest/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/jest/index.ts
@@ -65,7 +65,7 @@ export default createBuilder(
       polyfills: options.polyfills ?? ['zone.js', 'zone.js/testing'],
       outputPath: testOut,
       aot: false,
-      index: null,
+      index: false,
       outputHashing: OutputHashing.None,
       outExtension: 'mjs', // Force native ESM.
       optimization: false,

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/application-code-bundle.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/application-code-bundle.ts
@@ -146,9 +146,13 @@ export function createServerCodeBundleOptions(
       createVirtualModulePlugin({
         namespace,
         loadContent: () => {
+          const mainServerEntryPoint = path
+            .relative(workspaceRoot, serverEntryPoint)
+            .replace(/\\/g, '/');
           const importAndExportDec: string[] = [
             `import '@angular/platform-server/init';`,
-            `import './${path.relative(workspaceRoot, serverEntryPoint).replace(/\\/g, '/')}';`,
+            `import moduleOrBootstrapFn from './${mainServerEntryPoint}';`,
+            `export default moduleOrBootstrapFn;`,
             `export { renderApplication, renderModule, ɵSERVER_CONTEXT } from '@angular/platform-server';`,
           ];
 

--- a/packages/angular_devkit/build_angular/src/utils/ssg/esm-in-memory-file-loader.ts
+++ b/packages/angular_devkit/build_angular/src/utils/ssg/esm-in-memory-file-loader.ts
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { workerData } from 'node:worker_threads';
+import { fileURLToPath } from 'url';
+
+/**
+ * Node.js ESM loader to redirect imports to in memory files.
+ * @see: https://nodejs.org/api/esm.html#loaders for more information about loaders.
+ */
+
+const { outputFiles } = workerData as {
+  outputFiles: Record<string, string>;
+};
+
+export function resolve(specifier: string, context: {}, nextResolve: Function) {
+  if (!isFileProtocol(specifier)) {
+    const normalizedSpecifier = specifier.replace(/^\.\//, '');
+    if (normalizedSpecifier in outputFiles) {
+      return {
+        format: 'module',
+        shortCircuit: true,
+        url: new URL(normalizedSpecifier, 'file:').href,
+      };
+    }
+  }
+
+  // Defer to the next hook in the chain, which would be the
+  // Node.js default resolve if this is the last user-specified loader.
+  return nextResolve(specifier);
+}
+
+export function load(url: string, context: { format?: string | null }, nextLoad: Function) {
+  if (isFileProtocol(url)) {
+    const source = outputFiles[fileURLToPath(url).slice(1)]; // Remove leading slash
+    if (source !== undefined) {
+      const { format } = context;
+
+      return {
+        format,
+        shortCircuit: true,
+        source,
+      };
+    }
+  }
+
+  // Let Node.js handle all other URLs.
+  return nextLoad(url);
+}
+
+function isFileProtocol(url: string): boolean {
+  return url.startsWith('file://');
+}

--- a/packages/angular_devkit/build_angular/src/utils/ssg/render-worker.ts
+++ b/packages/angular_devkit/build_angular/src/utils/ssg/render-worker.ts
@@ -1,0 +1,144 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import type { ApplicationRef, StaticProvider, Type } from '@angular/core';
+import type { renderApplication, renderModule, ɵSERVER_CONTEXT } from '@angular/platform-server';
+import assert from 'node:assert';
+import { basename } from 'node:path';
+import { workerData } from 'node:worker_threads';
+import { InlineCriticalCssProcessor } from '../index-file/inline-critical-css';
+import { loadEsmModule } from '../load-esm';
+
+export interface RenderOptions {
+  route: string;
+  serverContext: ServerContext;
+}
+
+export interface RenderResult {
+  errors?: string[];
+  warnings?: string[];
+  content?: string;
+}
+
+export type ServerContext = 'app-shell' | 'ssg';
+
+export interface WorkerData {
+  zonePackage: string;
+  outputFiles: Record<string, string>;
+  document: string;
+  inlineCriticalCss?: boolean;
+}
+
+interface BundleExports {
+  /** An internal token that allows providing extra information about the server context. */
+  ɵSERVER_CONTEXT?: typeof ɵSERVER_CONTEXT;
+
+  /** Render an NgModule application. */
+  renderModule?: typeof renderModule;
+
+  /** Method to render a standalone application. */
+  renderApplication?: typeof renderApplication;
+
+  /** Standalone application bootstrapping function. */
+  default?: (() => Promise<ApplicationRef>) | Type<unknown>;
+}
+
+/**
+ * The fully resolved path to the zone.js package that will be loaded during worker initialization.
+ * This is passed as workerData when setting up the worker via the `piscina` package.
+ */
+const { zonePackage, outputFiles, document, inlineCriticalCss } = workerData as WorkerData;
+
+/**
+ * Renders each route in routes and writes them to <outputPath>/<route>/index.html.
+ */
+async function render({ route, serverContext }: RenderOptions): Promise<RenderResult> {
+  const {
+    default: bootstrapAppFnOrModule,
+    ɵSERVER_CONTEXT,
+    renderModule,
+    renderApplication,
+  } = await loadEsmModule<BundleExports>('./server.mjs');
+
+  assert(ɵSERVER_CONTEXT, `ɵSERVER_CONTEXT was not exported.`);
+
+  const platformProviders: StaticProvider[] = [
+    {
+      provide: ɵSERVER_CONTEXT,
+      useValue: serverContext,
+    },
+  ];
+
+  let html: string | undefined;
+
+  if (isBootstrapFn(bootstrapAppFnOrModule)) {
+    assert(renderApplication, `renderApplication was not exported.`);
+    html = await renderApplication(bootstrapAppFnOrModule, {
+      document,
+      url: route,
+      platformProviders,
+    });
+  } else {
+    assert(renderModule, `renderModule was not exported.`);
+    assert(
+      bootstrapAppFnOrModule,
+      `Neither an AppServerModule nor a bootstrapping function was exported.`,
+    );
+
+    html = await renderModule(bootstrapAppFnOrModule, {
+      document,
+      url: route,
+      extraProviders: platformProviders,
+    });
+  }
+
+  if (inlineCriticalCss) {
+    const inlineCriticalCssProcessor = new InlineCriticalCssProcessor({
+      minify: false, // CSS has already been minified during the build.
+      readAsset: async (filePath) => {
+        filePath = basename(filePath);
+        const content = outputFiles[filePath];
+        if (content === undefined) {
+          throw new Error(`Output file does not exist: ${filePath}`);
+        }
+
+        return content;
+      },
+    });
+
+    return inlineCriticalCssProcessor.process(html, { outputPath: '' });
+  }
+
+  return {
+    content: html,
+  };
+}
+
+function isBootstrapFn(value: unknown): value is () => Promise<ApplicationRef> {
+  // We can differentiate between a module and a bootstrap function by reading `cmp`:
+  return typeof value === 'function' && !('ɵmod' in value);
+}
+
+/**
+ * Initializes the worker when it is first created by loading the Zone.js package
+ * into the worker instance.
+ *
+ * @returns A promise resolving to the render function of the worker.
+ */
+async function initialize() {
+  // Setup Zone.js
+  await import(zonePackage);
+
+  return render;
+}
+
+/**
+ * The default export will be the promise returned by the initialize function.
+ * This is awaited by piscina prior to using the Worker.
+ */
+export default initialize();

--- a/packages/angular_devkit/build_angular/src/utils/ssg/render.ts
+++ b/packages/angular_devkit/build_angular/src/utils/ssg/render.ts
@@ -1,0 +1,143 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { OutputFile } from 'esbuild';
+import { readFile } from 'node:fs/promises';
+import { extname, posix } from 'node:path';
+import Piscina from 'piscina';
+import type { RenderResult, ServerContext, WorkerData } from './render-worker';
+
+interface prerenderOptions {
+  routesFile?: string;
+  discoverRoutes?: boolean;
+  routes?: string[];
+}
+
+interface AppShellOptions {
+  route?: string;
+}
+
+export async function prerenderPages(
+  workspaceRoot: string,
+  tsConfigPath: string,
+  appShellOptions: AppShellOptions = {},
+  prerenderOptions: prerenderOptions = {},
+  outputFiles: Readonly<OutputFile[]>,
+  document: string,
+  inlineCriticalCss?: boolean,
+  maxThreads = 1,
+): Promise<{
+  output: Record<string, string>;
+  warnings: string[];
+  errors: string[];
+}> {
+  const allRoutes = await getAllRoutes(tsConfigPath, appShellOptions, prerenderOptions);
+  const outputFilesForWorker: Record<string, string> = {};
+
+  for (const { text, path } of outputFiles) {
+    switch (extname(path)) {
+      case '.mjs': // Contains the server runnable application code.
+      case '.css': // Global styles for critical CSS inlining.
+        outputFilesForWorker[path] = text;
+        break;
+    }
+  }
+
+  const renderWorker = new Piscina({
+    filename: require.resolve('./render-worker'),
+    maxThreads: Math.min(allRoutes.size, maxThreads),
+    workerData: {
+      zonePackage: require.resolve('zone.js', { paths: [workspaceRoot] }),
+      outputFiles: outputFilesForWorker,
+      inlineCriticalCss,
+      document,
+    } as WorkerData,
+    execArgv: [
+      '--no-warnings', // Suppress `ExperimentalWarning: Custom ESM Loaders is an experimental feature...`.
+      '--loader',
+      require.resolve('./esm-in-memory-file-loader.js'),
+    ],
+  });
+
+  const output: Record<string, string> = {};
+  const warnings: string[] = [];
+  const errors: string[] = [];
+
+  try {
+    const renderingPromises: Promise<void>[] = [];
+
+    for (const route of allRoutes) {
+      const isAppShellRoute = appShellOptions.route === route;
+      const serverContext: ServerContext = isAppShellRoute ? 'app-shell' : 'ssg';
+
+      const render: Promise<RenderResult> = renderWorker.run({ route, serverContext });
+      const renderResult: Promise<void> = render.then(({ content, warnings, errors }) => {
+        if (content !== undefined) {
+          const outPath = isAppShellRoute ? 'index.html' : posix.join(route, 'index.html');
+          output[outPath] = content;
+        }
+
+        if (warnings) {
+          warnings.push(...warnings);
+        }
+
+        if (errors) {
+          errors.push(...errors);
+        }
+      });
+
+      renderingPromises.push(renderResult);
+    }
+
+    await Promise.all(renderingPromises);
+  } finally {
+    void renderWorker.destroy();
+  }
+
+  return {
+    errors,
+    warnings,
+    output,
+  };
+}
+
+async function getAllRoutes(
+  tsConfigPath: string,
+  appShellOptions: AppShellOptions,
+  prerenderOptions: prerenderOptions,
+): Promise<Set<string>> {
+  const { routesFile, discoverRoutes, routes: existingRoutes } = prerenderOptions;
+  const routes = new Set(existingRoutes);
+
+  const { route: appShellRoute } = appShellOptions;
+  if (appShellRoute !== undefined) {
+    routes.add(appShellRoute);
+  }
+
+  if (routesFile) {
+    const routesFromFile = (await readFile(routesFile, 'utf8')).split(/\r?\n/);
+    for (let route of routesFromFile) {
+      route = route.trim();
+      if (route) {
+        routes.add(route);
+      }
+    }
+  }
+
+  if (discoverRoutes) {
+    const { parseAngularRoutes } = await import('guess-parser');
+    for (const { path } of parseAngularRoutes(tsConfigPath)) {
+      // Exclude dynamic routes as these cannot be pre-rendered.
+      if (!/[*:]/.test(path)) {
+        routes.add(path);
+      }
+    }
+  }
+
+  return routes;
+}

--- a/packages/angular_devkit/build_angular/test/hello-world-app/src/main.server.ts
+++ b/packages/angular_devkit/build_angular/test/hello-world-app/src/main.server.ts
@@ -6,4 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export { AppServerModule } from './app/app.module.server';
+import { AppServerModule } from './app/app.module.server';
+export default AppServerModule;
+export { AppServerModule};

--- a/yarn.lock
+++ b/yarn.lock
@@ -131,7 +131,6 @@
 
 "@angular/build-tooling@https://github.com/angular/dev-infra-private-build-tooling-builds.git#94903cc6c8023b776170ccce4746fd5624d65f2f":
   version "0.0.0-abd901f78e5c6f945c07e8886259f0c1c7e0383b"
-  uid "94903cc6c8023b776170ccce4746fd5624d65f2f"
   resolved "https://github.com/angular/dev-infra-private-build-tooling-builds.git#94903cc6c8023b776170ccce4746fd5624d65f2f"
   dependencies:
     "@angular-devkit/build-angular" "16.1.0"
@@ -292,7 +291,6 @@
 
 "@angular/ng-dev@https://github.com/angular/dev-infra-private-ng-dev-builds.git#af299940f1c6e16418e5a8627ac59564e52503d5":
   version "0.0.0-abd901f78e5c6f945c07e8886259f0c1c7e0383b"
-  uid af299940f1c6e16418e5a8627ac59564e52503d5
   resolved "https://github.com/angular/dev-infra-private-ng-dev-builds.git#af299940f1c6e16418e5a8627ac59564e52503d5"
   dependencies:
     "@yarnpkg/lockfile" "^1.1.0"
@@ -2913,6 +2911,11 @@
   resolved "https://registry.yarnpkg.com/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz#96116f2a912e0c02817345b3c10751069920d553"
   integrity sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==
 
+"@tootallnate/once@1":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
+  integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
+
 "@tootallnate/once@2":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
@@ -3839,6 +3842,16 @@
     "@webassemblyjs/ast" "1.11.6"
     "@xtuc/long" "4.2.2"
 
+"@wessberg/ts-evaluator@0.0.27":
+  version "0.0.27"
+  resolved "https://registry.yarnpkg.com/@wessberg/ts-evaluator/-/ts-evaluator-0.0.27.tgz#06e8b901d5e84f11199b9f84577c6426ae761767"
+  integrity sha512-7gOpVm3yYojUp/Yn7F4ZybJRxyqfMNf0LXK5KJiawbPfL0XTsJV+0mgrEDjOIR6Bi0OYk2Cyg4tjFu1r8MCZaA==
+  dependencies:
+    chalk "^4.1.0"
+    jsdom "^16.4.0"
+    object-path "^0.11.5"
+    tslib "^2.0.3"
+
 "@xmldom/xmldom@^0.8.5":
   version "0.8.8"
   resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.8.tgz#d0d11511cbc1de77e53342ad1546a4d487d6ea72"
@@ -3867,7 +3880,7 @@ JSONStream@1.3.5:
     jsonparse "^1.2.0"
     through ">=2.2.7 <3"
 
-abab@^2.0.6:
+abab@^2.0.3, abab@^2.0.5, abab@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.6.tgz#41b80f2c871d19686216b82309231cfd3cb3d291"
   integrity sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==
@@ -3892,6 +3905,14 @@ accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.8:
     mime-types "~2.1.34"
     negotiator "0.6.3"
 
+acorn-globals@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-6.0.0.tgz#46cdd39f0f8ff08a876619b55f5ac8a6dc770b45"
+  integrity sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==
+  dependencies:
+    acorn "^7.1.1"
+    acorn-walk "^7.1.1"
+
 acorn-import-assertions@^1.9.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz#507276249d684797c84e0734ef84860334cfb1ac"
@@ -3902,12 +3923,22 @@ acorn-jsx@^5.3.2:
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
+acorn-walk@^7.1.1:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
+  integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
+
 acorn-walk@^8.1.1:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
   integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
 
-acorn@^8.4.1, acorn@^8.7.1, acorn@^8.8.2, acorn@^8.9.0:
+acorn@^7.1.1:
+  version "7.4.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
+  integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
+
+acorn@^8.2.4, acorn@^8.4.1, acorn@^8.7.1, acorn@^8.8.2, acorn@^8.9.0:
   version "8.9.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.9.0.tgz#78a16e3b2bcc198c10822786fa6679e245db5b59"
   integrity sha512-jaVNAFBHNLXspO543WnNNPZFRtavh3skAkITqD0/2aeMkKZTN+254PyhwxFYrk3vQ1xfY+2wbesJMs/JC8/PwQ==
@@ -4448,6 +4479,11 @@ browser-or-node@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/browser-or-node/-/browser-or-node-2.1.1.tgz#738790b3a86a8fc020193fa581273fbe65eaea0f"
   integrity sha512-8CVjaLJGuSKMVTxJ2DpBl5XnlNDiT4cQFeuCJJrvJmts9YrTZDizTX7PjC2s6W4x+MBGZeEY6dGMrF04/6Hgqg==
+
+browser-process-hrtime@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz#3c9b4b7d782c8121e56f10106d84c0d0ffc94626"
+  integrity sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==
 
 browser-sync-client@^2.29.3:
   version "2.29.3"
@@ -5190,6 +5226,23 @@ cssesc@^3.0.0:
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
 
+cssom@^0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.4.4.tgz#5a66cf93d2d0b661d80bf6a44fb65f5c2e4e0a10"
+  integrity sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==
+
+cssom@~0.3.6:
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.8.tgz#9f1276f5b2b463f2114d3f2c75250af8c1a36f4a"
+  integrity sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==
+
+cssstyle@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-2.3.0.tgz#ff665a0ddbdc31864b09647f34163443d90b0852"
+  integrity sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==
+  dependencies:
+    cssom "~0.3.6"
+
 cuint@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/cuint/-/cuint-0.2.2.tgz#408086d409550c2631155619e9fa7bcadc3b991b"
@@ -5206,6 +5259,15 @@ dashdash@^1.12.0:
   integrity sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==
   dependencies:
     assert-plus "^1.0.0"
+
+data-urls@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-2.0.0.tgz#156485a72963a970f5d5821aaf642bef2bf2db9b"
+  integrity sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==
+  dependencies:
+    abab "^2.0.3"
+    whatwg-mimetype "^2.3.0"
+    whatwg-url "^8.0.0"
 
 date-format@^4.0.14:
   version "4.0.14"
@@ -5254,6 +5316,11 @@ decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==
+
+decimal.js@^10.2.1:
+  version "10.4.3"
+  resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.4.3.tgz#1044092884d245d1b7f65725fa4ad4c6f781cc23"
+  integrity sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==
 
 deep-is@^0.1.3:
   version "0.1.4"
@@ -5434,6 +5501,13 @@ domelementtype@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.3.0.tgz#5c45e8e869952626331d7aab326d01daf65d589d"
   integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
+
+domexception@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/domexception/-/domexception-2.0.1.tgz#fb44aefba793e1574b0af6aed2801d057529f304"
+  integrity sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==
+  dependencies:
+    webidl-conversions "^5.0.0"
 
 domhandler@^5.0.2, domhandler@^5.0.3:
   version "5.0.3"
@@ -5786,6 +5860,17 @@ escape-string-regexp@^4.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
+escodegen@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-2.1.0.tgz#ba93bbb7a43986d29d6041f99f5262da773e2e17"
+  integrity sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==
+  dependencies:
+    esprima "^4.0.1"
+    estraverse "^5.2.0"
+    esutils "^2.0.2"
+  optionalDependencies:
+    source-map "~0.6.1"
+
 eslint-config-prettier@8.8.0:
   version "8.8.0"
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz#bfda738d412adc917fd7b038857110efe98c9348"
@@ -5908,7 +5993,7 @@ espree@^9.5.2, espree@^9.6.0:
     acorn-jsx "^5.3.2"
     eslint-visitor-keys "^3.4.1"
 
-esprima@^4.0.0:
+esprima@^4.0.0, esprima@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
@@ -6611,6 +6696,13 @@ graphemer@^1.4.0:
   resolved "https://registry.yarnpkg.com/graphemer/-/graphemer-1.4.0.tgz#fb2f1d55e0e3a1849aeffc90c4fa0dd53a0e66c6"
   integrity sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==
 
+guess-parser@0.4.22:
+  version "0.4.22"
+  resolved "https://registry.yarnpkg.com/guess-parser/-/guess-parser-0.4.22.tgz#c26ab9e21b69bbc761960c5a1511476ae85428eb"
+  integrity sha512-KcUWZ5ACGaBM69SbqwVIuWGoSAgD+9iJnchR9j/IarVI1jHVeXv+bUXBIMeqVMSKt3zrn0Dgf9UpcOEpPBLbSg==
+  dependencies:
+    "@wessberg/ts-evaluator" "0.0.27"
+
 handle-thing@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-2.0.1.tgz#857f79ce359580c340d43081cc648970d0bb234e"
@@ -6742,6 +6834,13 @@ hpack.js@^2.1.6:
     readable-stream "^2.0.1"
     wbuf "^1.1.0"
 
+html-encoding-sniffer@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz#42a6dc4fd33f00281176e8b23759ca4e4fa185f3"
+  integrity sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==
+  dependencies:
+    whatwg-encoding "^1.0.5"
+
 html-entities@^2.3.2:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-2.4.0.tgz#edd0cee70402584c8c76cc2c0556db09d1f45061"
@@ -6797,6 +6896,15 @@ http-parser-js@>=0.5.1:
   version "0.5.8"
   resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.5.8.tgz#af23090d9ac4e24573de6f6aecc9d84a48bf20e3"
   integrity sha512-SGeBX54F94Wgu5RH3X5jsDtf4eHyRogWX1XGT3b4HuW3tQPM4AaBzoUji/4AAJNXCEOWZ5O0DgZmJw1947gD5Q==
+
+http-proxy-agent@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz#8a8c8ef7f5932ccf953c296ca8291b95aa74aa3a"
+  integrity sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==
+  dependencies:
+    "@tootallnate/once" "1"
+    agent-base "6"
+    debug "4"
 
 http-proxy-agent@^5.0.0:
   version "5.0.0"
@@ -7239,6 +7347,11 @@ is-plain-object@^2.0.4:
   dependencies:
     isobject "^3.0.1"
 
+is-potential-custom-element-name@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz#171ed6f19e3ac554394edf78caa05784a45bebb5"
+  integrity sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==
+
 is-promise@^2.1.0:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.2.2.tgz#39ab959ccbf9a774cf079f7b40c7a26f763135f1"
@@ -7509,6 +7622,39 @@ jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
   integrity sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==
+
+jsdom@^16.4.0:
+  version "16.7.0"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-16.7.0.tgz#918ae71965424b197c819f8183a754e18977b710"
+  integrity sha512-u9Smc2G1USStM+s/x1ru5Sxrl6mPYCbByG1U/hUmqaVsm4tbNyS7CicOSRyuGQYZhTu0h84qkZZQ/I+dzizSVw==
+  dependencies:
+    abab "^2.0.5"
+    acorn "^8.2.4"
+    acorn-globals "^6.0.0"
+    cssom "^0.4.4"
+    cssstyle "^2.3.0"
+    data-urls "^2.0.0"
+    decimal.js "^10.2.1"
+    domexception "^2.0.1"
+    escodegen "^2.0.0"
+    form-data "^3.0.0"
+    html-encoding-sniffer "^2.0.1"
+    http-proxy-agent "^4.0.1"
+    https-proxy-agent "^5.0.0"
+    is-potential-custom-element-name "^1.0.1"
+    nwsapi "^2.2.0"
+    parse5 "6.0.1"
+    saxes "^5.0.1"
+    symbol-tree "^3.2.4"
+    tough-cookie "^4.0.0"
+    w3c-hr-time "^1.0.2"
+    w3c-xmlserializer "^2.0.0"
+    webidl-conversions "^6.1.0"
+    whatwg-encoding "^1.0.5"
+    whatwg-mimetype "^2.3.0"
+    whatwg-url "^8.5.0"
+    ws "^7.4.6"
+    xml-name-validator "^3.0.0"
 
 jsesc@^2.5.1:
   version "2.5.2"
@@ -8016,7 +8162,7 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash@4, lodash@4.17.21, lodash@^4.17.10, lodash@^4.17.14, lodash@^4.17.21, lodash@~4.17.15:
+lodash@4, lodash@4.17.21, lodash@^4.17.10, lodash@^4.17.14, lodash@^4.17.21, lodash@^4.7.0, lodash@~4.17.15:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -8884,6 +9030,11 @@ nth-check@^2.0.1:
   dependencies:
     boolbase "^1.0.0"
 
+nwsapi@^2.2.0:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.5.tgz#a52744c61b3889dd44b0a158687add39b8d935e2"
+  integrity sha512-6xpotnECFy/og7tKSBVmUNft7J3jyXAka4XvG6AUhFWRz+Q/Ljus7znJAA3bxColfQLdS+XsjoodtJfCgeTEFQ==
+
 oauth-sign@~0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
@@ -8903,6 +9054,11 @@ object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
+
+object-path@^0.11.5:
+  version "0.11.8"
+  resolved "https://registry.yarnpkg.com/object-path/-/object-path-0.11.8.tgz#ed002c02bbdd0070b78a27455e8ae01fc14d4742"
+  integrity sha512-YJjNZrlXJFM42wTBn6zgOJVar9KFJvzx6sTWDte8sWZF//cnjl0BxHNpfZx+ZffXX63A9q0b1zsFiBX4g4X5KA==
 
 object.assign@^4.1.4:
   version "4.1.4"
@@ -9192,6 +9348,11 @@ parse5-sax-parser@^7.0.0:
   integrity sha512-5A+v2SNsq8T6/mG3ahcz8ZtQ0OUFTatxPbeidoMB7tkJSGDY3tdfl4MHovtLQHkEn5CGxijNWRQHhRQ6IRpXKg==
   dependencies:
     parse5 "^7.0.0"
+
+parse5@6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-6.0.1.tgz#e1a1c085c569b3dc08321184f19a39cc27f7c30b"
+  integrity sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==
 
 parse5@^7.0.0, parse5@^7.1.2:
   version "7.1.2"
@@ -9602,7 +9763,7 @@ prr@~1.0.1:
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
   integrity sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==
 
-psl@^1.1.28:
+psl@^1.1.28, psl@^1.1.33:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.9.0.tgz#d0df2a137f00794565fcaf3b2c00cd09f8d5a5a7"
   integrity sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==
@@ -9677,6 +9838,11 @@ qs@~6.5.2:
   version "6.5.3"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.3.tgz#3aeeffc91967ef6e35c0e488ef46fb296ab76aad"
   integrity sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==
+
+querystringify@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.2.0.tgz#3345941b4153cb9d082d8eee4cda2016a9aef7f6"
+  integrity sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==
 
 queue-microtask@^1.2.2:
   version "1.2.3"
@@ -10187,7 +10353,6 @@ sass@1.63.6, sass@^1.55.0:
 
 "sauce-connect-proxy@https://saucelabs.com/downloads/sc-4.9.1-linux.tar.gz":
   version "0.0.0"
-  uid "9310bc860f7870a1f872b11c4dc6073a1ad34e5e"
   resolved "https://saucelabs.com/downloads/sc-4.9.1-linux.tar.gz#9310bc860f7870a1f872b11c4dc6073a1ad34e5e"
 
 saucelabs@^1.5.0:
@@ -10201,6 +10366,13 @@ sax@>=0.6.0, sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
+
+saxes@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/saxes/-/saxes-5.0.1.tgz#eebab953fa3b7608dbe94e5dadb15c888fa6696d"
+  integrity sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==
+  dependencies:
+    xmlchars "^2.2.0"
 
 schema-utils@^3.1.1, schema-utils@^3.1.2, schema-utils@^3.2.0:
   version "3.3.0"
@@ -10914,6 +11086,11 @@ symbol-observable@4.0.0:
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-4.0.0.tgz#5b425f192279e87f2f9b937ac8540d1984b39205"
   integrity sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==
 
+symbol-tree@^3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
+  integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
+
 tapable@^2.1.1, tapable@^2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
@@ -11067,12 +11244,29 @@ toposort@^2.0.2:
   resolved "https://registry.yarnpkg.com/toposort/-/toposort-2.0.2.tgz#ae21768175d1559d48bef35420b2f4962f09c330"
   integrity sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==
 
+tough-cookie@^4.0.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.1.3.tgz#97b9adb0728b42280aa3d814b6b999b2ff0318bf"
+  integrity sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==
+  dependencies:
+    psl "^1.1.33"
+    punycode "^2.1.1"
+    universalify "^0.2.0"
+    url-parse "^1.5.3"
+
 tough-cookie@~2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
   integrity sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==
   dependencies:
     psl "^1.1.28"
+    punycode "^2.1.1"
+
+tr46@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-2.1.0.tgz#fa87aa81ca5d5941da8cbf1f9b749dc969a4e240"
+  integrity sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==
+  dependencies:
     punycode "^2.1.1"
 
 tr46@~0.0.3:
@@ -11134,7 +11328,7 @@ tslib@2.5.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.3.tgz#24944ba2d990940e6e982c4bea147aba80209913"
   integrity sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==
 
-tslib@2.6.0, tslib@^2.0.0, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.5.2:
+tslib@2.6.0, tslib@^2.0.0, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.5.2:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.0.tgz#b295854684dbda164e181d259a22cd779dcd7bc3"
   integrity sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==
@@ -11346,6 +11540,11 @@ universalify@^0.1.0:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
 
+universalify@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.2.0.tgz#6451760566fa857534745ab1dde952d1b1761be0"
+  integrity sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==
+
 unix-crypt-td-js@1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/unix-crypt-td-js/-/unix-crypt-td-js-1.1.4.tgz#4912dfad1c8aeb7d20fa0a39e4c31918c1d5d5dd"
@@ -11375,6 +11574,14 @@ urijs@^1.19.1:
   version "1.19.11"
   resolved "https://registry.yarnpkg.com/urijs/-/urijs-1.19.11.tgz#204b0d6b605ae80bea54bea39280cdb7c9f923cc"
   integrity sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==
+
+url-parse@^1.5.3:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.10.tgz#9d3c2f736c1d75dd3bd2be507dcc111f1e2ea9c1"
+  integrity sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==
+  dependencies:
+    querystringify "^2.1.1"
+    requires-port "^1.0.0"
 
 util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"
@@ -11554,6 +11761,20 @@ void-elements@^2.0.0:
   resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-2.0.1.tgz#c066afb582bb1cb4128d60ea92392e94d5e9dbec"
   integrity sha512-qZKX4RnBzH2ugr8Lxa7x+0V6XD9Sb/ouARtiasEQCHB1EVU4NXtmHsDDrx1dO4ne5fc3J6EW05BP1Dl0z0iung==
 
+w3c-hr-time@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz#0a89cdf5cc15822df9c360543676963e0cc308cd"
+  integrity sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==
+  dependencies:
+    browser-process-hrtime "^1.0.0"
+
+w3c-xmlserializer@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz#3e7104a05b75146cc60f564380b7f683acf1020a"
+  integrity sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==
+  dependencies:
+    xml-name-validator "^3.0.0"
+
 walk-up-path@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/walk-up-path/-/walk-up-path-1.0.0.tgz#d4745e893dd5fd0dbb58dd0a4c6a33d9c9fec53e"
@@ -11610,6 +11831,16 @@ webidl-conversions@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
   integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
+
+webidl-conversions@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-5.0.0.tgz#ae59c8a00b121543a2acc65c0434f57b0fc11aff"
+  integrity sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==
+
+webidl-conversions@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-6.1.0.tgz#9111b4d7ea80acd40f5270d666621afa78b69514"
+  integrity sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==
 
 webpack-dev-middleware@6.1.1:
   version "6.1.1"
@@ -11799,6 +12030,18 @@ websocket-extensions@>=0.1.1:
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.4.tgz#7f8473bc839dfd87608adb95d7eb075211578a42"
   integrity sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==
 
+whatwg-encoding@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz#5abacf777c32166a51d085d6b4f3e7d27113ddb0"
+  integrity sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==
+  dependencies:
+    iconv-lite "0.4.24"
+
+whatwg-mimetype@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"
+  integrity sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
+
 whatwg-url@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
@@ -11806,6 +12049,15 @@ whatwg-url@^5.0.0:
   dependencies:
     tr46 "~0.0.3"
     webidl-conversions "^3.0.0"
+
+whatwg-url@^8.0.0, whatwg-url@^8.5.0:
+  version "8.7.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-8.7.0.tgz#656a78e510ff8f3937bc0bcbe9f5c0ac35941b77"
+  integrity sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==
+  dependencies:
+    lodash "^4.7.0"
+    tr46 "^2.1.0"
+    webidl-conversions "^6.1.0"
 
 which-boxed-primitive@^1.0.2:
   version "1.0.2"
@@ -11923,6 +12175,11 @@ ws@>=8.13.0, ws@^8.13.0:
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.13.0.tgz#9a9fb92f93cf41512a0735c8f4dd09b8a1211cd0"
   integrity sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==
 
+ws@^7.4.6:
+  version "7.5.9"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.9.tgz#54fa7db29f4c7cec68b1ddd3a89de099942bb591"
+  integrity sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==
+
 ws@~8.11.0:
   version "8.11.0"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.11.0.tgz#6a0d36b8edfd9f96d8b25683db2f8d7de6e8e143"
@@ -11932,6 +12189,11 @@ xhr2@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/xhr2/-/xhr2-0.2.1.tgz#4e73adc4f9cfec9cbd2157f73efdce3a5f108a93"
   integrity sha512-sID0rrVCqkVNUn8t6xuv9+6FViXjUVXq8H5rWOH2rz9fDNQEd4g0EA2XlcEdJXRz5BMEn4O1pJFdT+z4YHhoWw==
+
+xml-name-validator@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
+  integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
 
 xml2js@^0.4.17:
   version "0.4.23"
@@ -11945,6 +12207,11 @@ xmlbuilder@~11.0.0:
   version "11.0.1"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
   integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
+
+xmlchars@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
+  integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
 xmlhttprequest-ssl@~2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This commit introduces experimental support to pre-render (SSG) and app-shell generation to the new application builder.
    
- `appShell`: option which can have a value of `true` or `false` has been added to support generating an app-shell.
- `prerender`: option which can have a value of `true`, `false` or an object with the below listed properties can be used to static render pages;
  - `routes`: Array of routes to render.
  - `discoverRoutes`: Whether the builder should statically discover routes.
  - `routesFile`: The path to a file containing routes separated by newlines.