### PR TITLE
test: convert e2e_runner `ignore` to array

### DIFF
--- a/tests/legacy-cli/e2e_runner.ts
+++ b/tests/legacy-cli/e2e_runner.ts
@@ -51,9 +51,9 @@ const argv = yargsParser(process.argv.slice(2), {
     'verbose',
     'yarn',
   ],
-  string: ['devkit', 'glob', 'ignore', 'reuse', 'ng-tag', 'tmpdir', 'ng-version'],
+  string: ['devkit', 'glob', 'reuse', 'ng-tag', 'tmpdir', 'ng-version'],
   number: ['nb-shards', 'shard'],
-  array: ['package'],
+  array: ['package', 'ignore'],
   configuration: {
     'camel-case-expansion': false,
     'dot-notation': false,


### PR DESCRIPTION
Previously, the ignore was as a string, but this breaks with the last `fast-glob` update.

See: https://app.circleci.com/pipelines/github/angular/angular-cli/31919/workflows/7d68deac-000e-46ef-80f8-4dc259ef61fa/jobs/428958
