### PR TITLE
fix(@angular/cli): throw an error when executed in a google3-context

### DIFF
--- a/packages/angular/cli/bin/ng.js
+++ b/packages/angular/cli/bin/ng.js
@@ -11,6 +11,16 @@
 /* eslint-disable import/no-unassigned-import */
 'use strict';
 
+const path = require('path');
+
+// Error if the external CLI appears to be used inside a google3 context.
+if (process.cwd().split(path.sep).includes('google3')) {
+  console.error(
+    'This is the external Angular CLI, but you appear to be running in google3. There is a separate, internal version of the CLI which should be used instead. See http://go/angular/cli.',
+  );
+  process.exit();
+}
+
 // Provide a title to the process in `ps`.
 // Due to an obscure Mac bug, do not start this title with any symbol.
 try {


### PR DESCRIPTION
There is a separate, internal version of the Angular CLI which should be used instead. Running this version can lead to unintuitive and unexpected behavior. This commit intentionally does not include an opt-out because there is no supported use case for running the external CLI inside google3. If someone is broken by this and presents a compelling use case, we can reconsider and add an opt-out for this check.