### PR TITLE
fix(@angular-devkit/build-angular): Set chunk names explicitly

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/esbuild/application-code-bundle.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/application-code-bundle.ts
@@ -251,6 +251,7 @@ function getEsBuildCommonOptions(options: NormalizedApplicationBuildOptions): Bu
     outExtension: outExtension ? { '.js': `.${outExtension}` } : undefined,
     sourcemap: sourcemapOptions.scripts && (sourcemapOptions.hidden ? 'external' : true),
     splitting: true,
+    chunkNames: 'chunk-[hash]',
     tsconfig,
     external: externalDependencies,
     write: false,

--- a/tests/legacy-cli/e2e/tests/basic/rebuild.ts
+++ b/tests/legacy-cli/e2e/tests/basic/rebuild.ts
@@ -1,13 +1,13 @@
-import { waitForAnyProcessOutputToMatch, silentNg } from '../../utils/process';
-import { writeFile, writeMultipleFiles } from '../../utils/fs';
 import fetch from 'node-fetch';
-import { ngServe } from '../../utils/project';
 import { getGlobalVariable } from '../../utils/env';
+import { writeFile, writeMultipleFiles } from '../../utils/fs';
+import { silentNg, waitForAnyProcessOutputToMatch } from '../../utils/process';
+import { ngServe } from '../../utils/project';
 
 export default async function () {
   const esbuild = getGlobalVariable('argv')['esbuild'];
   const validBundleRegEx = esbuild ? /complete\./ : /Compiled successfully\./;
-  const lazyBundleRegEx = esbuild ? /lazy\.module/ : /lazy_module_ts\.js/;
+  const lazyBundleRegEx = esbuild ? /chunk-/ : /lazy_module_ts\.js/;
 
   const port = await ngServe();
   // Add a lazy module.
@@ -17,6 +17,7 @@ export default async function () {
   // We need to use Promise.all to ensure we are waiting for the rebuild just before we write
   // the file, otherwise rebuilds can be too fast and fail CI.
   // Count the bundles.
+  // Verify that a new chunk was created.
   await Promise.all([
     waitForAnyProcessOutputToMatch(lazyBundleRegEx),
     writeFile(


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, chunk names are determined by ESBuild. Some libraries may resolve to a name that is not in a format of `chunk.hash.mjs`. This causes Jest to run over the lib files and fail as it contains no test suite.

Fixes: #25189

## What is the new behavior?

The change sets chunk name pattern explicitly so that all `chunk`s are exluded by pattern from running tests over.

<!-- Please describe the new behavior that. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

I didn't figure out how this could be covered by tests. I did run a local build & installation and verified on a sample project that `@azure/msal-angular` no longer creates a "StandardController" file. Instead, it's named as `chunk...` and hence is excluded from tests.