### PR TITLE
refactor(@angular-devkit/build-angular): ensure TS resolution cache with file replacements

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/esbuild/angular/angular-host.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/angular/angular-host.ts
@@ -77,7 +77,15 @@ export function createAngularCompilerHost(
 
   // Augment TypeScript Host for file replacements option
   if (hostOptions.fileReplacements) {
-    augmentHostWithReplacements(host, hostOptions.fileReplacements);
+    // Provide a resolution cache since overriding resolution prevents automatic creation
+    const resolutionCache = ts.createModuleResolutionCache(
+      host.getCurrentDirectory(),
+      host.getCanonicalFileName.bind(host),
+      compilerOptions,
+    );
+    host.getModuleResolutionCache = () => resolutionCache;
+
+    augmentHostWithReplacements(host, hostOptions.fileReplacements, resolutionCache);
   }
 
   // Augment TypeScript Host with source file caching if provided


### PR DESCRIPTION
When overriding module resolution on a TypeScript Host object, TypeScript will not automatically create a resolution cache for the Host. Within the application build system the TypeScript resolution is only overrided if file replacements are used. A resolution cache is now manually created and added to the TypeScript Host when file replacements are present.