### PR TITLE
Revert "ci: disable update of `quicktype-core`"

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,7 @@
   "dependencyDashboard": true,
   "schedule": ["after 10:00pm every weekday", "before 4:00am every weekday", "every weekend"],
   "baseBranches": ["main"],
-  "ignoreDeps": ["@types/node", "rules_pkg", "less-loader", "quicktype-core"],
+  "ignoreDeps": ["@types/node", "rules_pkg", "less-loader"],
   "includePaths": [
     "WORKSPACE",
     "package.json",


### PR DESCRIPTION
This reverts commit 5651d4056644134e5373ebed5c4e252db3087027 as quicktype issue has been resolved.

See: https://github.com/quicktype/quicktype/issues/2325
