### PR TITLE
fix(@angular/cli): add `zone.js` to `ng version` output

### DIFF
--- a/packages/angular/cli/src/commands/version/cli.ts
+++ b/packages/angular/cli/src/commands/version/cli.ts
@@ -36,6 +36,7 @@ const PACKAGE_PATTERNS = [
   /^typescript$/,
   /^ng-packagr$/,
   /^webpack$/,
+  /^zone\.js$/,
 ];
 
 export default class VersionCommandModule


### PR DESCRIPTION
This commit add `zone.js` to the `ng version` command output.
