### PR TITLE
refactor(@angular-devkit/build-angular): configure AOT compiler to skip NgModule scope metadata emit in esbuild

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/application/tests/behavior/angular-aot-metadata_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/tests/behavior/angular-aot-metadata_spec.ts
@@ -21,5 +21,16 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
 
       harness.expectFile('dist/main.js').content.not.toContain('setClassMetadata');
     });
+
+    it('should not emit any AOT NgModule scope metadata functions', async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+      });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBe(true);
+
+      harness.expectFile('dist/main.js').content.not.toContain('setNgModuleScope');
+    });
   });
 });

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/angular/compilation/angular-compilation.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/angular/compilation/angular-compilation.ts
@@ -46,6 +46,7 @@ export abstract class AngularCompilation {
         annotationsAs: 'decorators',
         enableResourceInlining: false,
         supportTestBed: false,
+        supportJitMode: false,
       }),
     );
   }


### PR DESCRIPTION
The esbuild plugin used within the esbuild-based browser application builder will now use the newly introduced internal `supportJitMode` AOT compiler option to disable the emit of NgModule scope metadata functions within the output code. This removes the need to perform an additional transformation of the AOT compiler generated code to immediately remove the metadata. The Angular CLI neither previously nor currently supports hybrid AOT/JIT mode. In the future if this support situation changes, additional behavior may be added control the internal `supportJitMode` option.