### PR TITLE
fix(@angular-devkit/build-angular): prevent race condition in setting up sass worker pool

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/esbuild/stylesheets/sass-language.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/stylesheets/sass-language.ts
@@ -17,14 +17,20 @@ import type {
 import { StylesheetLanguage, StylesheetPluginOptions } from './stylesheet-plugin-factory';
 
 let sassWorkerPool: SassWorkerImplementation | undefined;
+let sassWorkerPoolPromise: Promise<SassWorkerImplementation> | undefined;
 
 function isSassException(error: unknown): error is Exception {
   return !!error && typeof error === 'object' && 'sassMessage' in error;
 }
 
 export function shutdownSassWorkerPool(): void {
-  sassWorkerPool?.close();
-  sassWorkerPool = undefined;
+  if (sassWorkerPool) {
+    sassWorkerPool.close();
+    sassWorkerPool = undefined;
+  } else if (sassWorkerPoolPromise) {
+    void sassWorkerPoolPromise.then(shutdownSassWorkerPool);
+  }
+  sassWorkerPoolPromise = undefined;
 }
 
 export const SassStylesheetLanguage = Object.freeze<StylesheetLanguage>({
@@ -77,8 +83,12 @@ async function compileString(
 ): Promise<OnLoadResult> {
   // Lazily load Sass when a Sass file is found
   if (sassWorkerPool === undefined) {
-    const sassService = await import('../../sass/sass-service');
-    sassWorkerPool = new sassService.SassWorkerImplementation(true);
+    if (sassWorkerPoolPromise === undefined) {
+      sassWorkerPoolPromise = import('../../sass/sass-service').then(
+        (sassService) => new sassService.SassWorkerImplementation(true),
+      );
+    }
+    sassWorkerPool = await sassWorkerPoolPromise;
   }
 
   const warnings: PartialMessage[] = [];


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Multiple calls to the `SassStylesheetLanguage`'s process function can lead to setting up multiple sass worker pools, only one of which is cleaned up after the esbuild application build.

The result is `ng build` hanging forever waiting for the workers to exit.

Issue Number: N/A

## What is the new behavior?

Prevent the race condition, thus setting up only one worker pool and allowing the process to exit gracefully.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
