### PR TITLE
docs: release notes for the v16.1.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+<a name="16.1.6"></a>
+
+# 16.1.6 (2023-07-26)
+
+### @angular-devkit/build-angular
+
+| Commit                                                                                              | Type | Description                                                 |
+| --------------------------------------------------------------------------------------------------- | ---- | ----------------------------------------------------------- |
+| [20816b57f](https://github.com/angular/angular-cli/commit/20816b57f16b0bcbd5b81f06f6f790e4485c1daa) | fix  | error during critical CSS inlining for external stylesheets |
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="16.2.0-next.3"></a>
 
 # 16.2.0-next.3 (2023-07-20)


### PR DESCRIPTION
Cherry-picks the changelog from the "16.1.x" branch to the next branch (main).