### PR TITLE
ci: transfer PR package artifact storage to GHA

### DIFF
--- a/.circleci/dynamic_config.yml
+++ b/.circleci/dynamic_config.yml
@@ -265,24 +265,6 @@ jobs:
           command: yarn admin snapshots --verbose
       - fail_fast
 
-  publish_artifacts:
-    executor: action-executor
-    resource_class: medium
-    environment:
-    steps:
-      - custom_attach_workspace
-      - run:
-          name: Create artifacts for packages
-          command: yarn ng-dev release build
-      - run:
-          name: Copy tarballs to folder
-          command: |
-            mkdir -p dist/artifacts/
-            cp dist/releases/*.tgz dist/artifacts/
-      - store_artifacts:
-          path: dist/artifacts/
-          destination: angular
-
   # Windows jobs
   e2e-cli-win:
     executor: windows-executor
@@ -399,8 +381,3 @@ workflows:
           requires:
             - setup
             - e2e-cli
-
-      - publish_artifacts:
-          <<: *only_pull_requests
-          requires:
-            - build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
         # it has been merged.
         if: github.event_name == 'pull_request'
         run: yarn ng-dev format changed --check ${{ github.event.pull_request.base.sha }}
+
   build:
     runs-on: ubuntu-latest
     steps:
@@ -62,8 +63,15 @@ jobs:
         uses: angular/dev-infra/github-actions/bazel/configure-remote@0109d498b0f6aae418ed4924a5e5c65695f0ac61
       - name: Install node modules
         run: yarn install --frozen-lockfile
-      - name: Build all buildable targets
-        run: yarn bazel build //...
+      - name: Build release targets
+        run: yarn ng-dev release build
+      - name: Store PR release packages
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: packages
+          path: dist/releases/*.tgz
+          retention-days: 14
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The newly introduce GHA CI build job has been augmented to build the release packages and, when run within a PR, upload the release packages at an artifact within the PR.