### PR TITLE
ci: partially move E2E tests to GHA

### DIFF
--- a/.circleci/dynamic_config.yml
+++ b/.circleci/dynamic_config.yml
@@ -322,31 +322,6 @@ workflows:
             - setup
 
       - e2e-tests:
-          name: e2e-cli-<< matrix.subset >>
-          nodeversion: *default_nodeversion_major
-          matrix:
-            parameters:
-              subset: *all_e2e_subsets
-          filters:
-            branches:
-              ignore:
-                - main
-                - /\d+\.\d+\.x/
-          requires:
-            - build
-
-      - e2e-tests:
-          name: e2e-cli-node-<<matrix.nodeversion>>-<< matrix.subset >>
-          matrix:
-            alias: e2e-cli
-            parameters:
-              nodeversion: *all_nodeversion_major
-              subset: *all_e2e_subsets
-          requires:
-            - build
-          <<: *only_release_branches
-
-      - e2e-tests:
           name: e2e-snapshots-<< matrix.subset >>
           nodeversion: *default_nodeversion_major
           matrix:
@@ -380,4 +355,4 @@ workflows:
           <<: *only_builds_branches
           requires:
             - setup
-            - e2e-cli
+            - e2e-cli-win

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,3 +100,28 @@ jobs:
       - if: matrix.version != env.defaultVersion
         name: Run tests for non-default node version
         run: yarn bazel test --test_tag_filters=node18,-node18-broken //packages/...
+
+  e2e:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node: [16, 18]
+        subset: [npm, yarn, esbuild]
+        shard: [0, 1, 2, 3]
+        exclude:
+          # Exclude Node.js v16 when running on a PR
+          - node: ${{ github.event_name != 'pull_request' && 'none' || '16' }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Initialize environment
+        uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@0109d498b0f6aae418ed4924a5e5c65695f0ac61
+        with:
+          fetch-depth: 1
+      - name: Install node modules
+        run: yarn install --frozen-lockfile
+      - name: Setup Bazel
+        uses: angular/dev-infra/github-actions/bazel/setup@0109d498b0f6aae418ed4924a5e5c65695f0ac61
+      - name: Setup Bazel RBE
+        uses: angular/dev-infra/github-actions/bazel/configure-remote@0109d498b0f6aae418ed4924a5e5c65695f0ac61
+      - name: Run CLI E2E tests
+        run: yarn bazel test --define=E2E_SHARD_TOTAL=4 --define=E2E_SHARD_INDEX=${{ matrix.shard }} --config=e2e //tests/legacy-cli:e2e.${{ matrix.subset }}_node${{ matrix.node }}


### PR DESCRIPTION
All E2E test runs are moved to Github Actions except:
* Windows E2E
* Snapshot E2E