### PR TITLE
docs: release notes for the v16.1.7 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+<a name="16.1.7"></a>
+
+# 16.1.7 (2023-08-02)
+
+### @angular-devkit/build-angular
+
+| Commit                                                                                              | Type | Description                            |
+| --------------------------------------------------------------------------------------------------- | ---- | -------------------------------------- |
+| [1dab4ed87](https://github.com/angular/angular-cli/commit/1dab4ed8738b42d6b93298889caf1546b011706f) | fix  | hot update filename suffix with `.mjs` |
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="16.2.0-next.4"></a>
 
 # 16.2.0-next.4 (2023-07-26)


### PR DESCRIPTION
Cherry-picks the changelog from the "16.1.x" branch to the next branch (main).