### PR TITLE
Update next branch to reflect new release-train "v16.3.0-next.0".

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+<a name="16.2.0-rc.0"></a>
+
+# 16.2.0-rc.0 (2023-08-02)
+
+### @angular-devkit/build-angular
+
+| Commit                                                                                              | Type | Description                            |
+| --------------------------------------------------------------------------------------------------- | ---- | -------------------------------------- |
+| [6539bb520](https://github.com/angular/angular-cli/commit/6539bb5200c924edbc62cc7be70072ecda84da1a) | fix  | hot update filename suffix with `.mjs` |
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="16.1.7"></a>
 
 # 16.1.7 (2023-08-02)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@angular/devkit-repo",
-  "version": "16.2.0-next.4",
+  "version": "16.3.0-next.0",
   "private": true,
   "description": "Software Development Kit for Angular",
   "bin": {


### PR DESCRIPTION
The previous "next" release-train has moved into the release-candidate phase. This PR updates the next branch to the subsequent release-train.

Also this PR cherry-picks the changelog for v16.2.0-rc.0 into the main branch so that the changelog is up to date.