### PR TITLE
ci: reduce bazel test shards for browser builder test

### DIFF
--- a/packages/angular_devkit/build_angular/BUILD.bazel
+++ b/packages/angular_devkit/build_angular/BUILD.bazel
@@ -352,7 +352,7 @@ LARGE_SPECS = {
     },
     "ng-packagr": {},
     "browser": {
-        "shards": 50,
+        "shards": 10,
         "size": "large",
         "flaky": True,
         "extra_deps": [

--- a/tests/legacy-cli/e2e/tests/build/ts-standard-decorators.ts
+++ b/tests/legacy-cli/e2e/tests/build/ts-standard-decorators.ts
@@ -1,5 +1,5 @@
 import { ng } from '../../utils/process';
-import { updateTsConfig } from '../../utils/project';
+import { updateJsonFile, updateTsConfig } from '../../utils/project';
 
 export default async function () {
   // Update project to disable experimental decorators
@@ -11,6 +11,11 @@ export default async function () {
   await ng('build');
 
   // Production build with JIT
+  await updateJsonFile('angular.json', (json) => {
+    // Remove bundle budgets to avoid a build error due to the expected increased output size
+    // of a JIT production build.
+    json.projects['test-project'].architect.build.configurations.production.budgets = [];
+  });
   await ng('build', '--no-aot', '--no-build-optimizer');
 
   // Default development build


### PR DESCRIPTION
Reduce the number of test shards for the browser builder from 50 to 10. 50 is more than needed and can cause excessive resource usage.
This fixes the OOM errors on CI for the test job.