### PR TITLE
docs: release notes for the v16.1.8 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+<a name="16.1.8"></a>
+
+# 16.1.8 (2023-08-04)
+
+| Commit                                                                                              | Type | Description            |
+| --------------------------------------------------------------------------------------------------- | ---- | ---------------------- |
+| [7a420d338](https://github.com/angular/angular-cli/commit/7a420d3382b21d24c73b722e849f01b0aacfb860) | fix  | build: update critters |
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="16.2.0-rc.1"></a>
 
 # 16.2.0-rc.1 (2023-08-04)


### PR DESCRIPTION
Cherry-picks the changelog from the "16.1.x" branch to the next branch (main).