### PR TITLE
fix(@angular-devkit/build-angular): conditionally enable deprecated Less stylesheet JavaScript support

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/esbuild/stylesheets/bundle-options.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/stylesheets/bundle-options.ts
@@ -64,7 +64,7 @@ export function createStylesheetBundleOptions(
     preserveSymlinks: options.preserveSymlinks,
     external: options.externalDependencies,
     publicPath: options.publicPath,
-    conditions: ['style', 'sass'],
+    conditions: ['style', 'sass', 'less'],
     mainFields: ['style', 'sass'],
     plugins: [
       pluginFactory.create(SassStylesheetLanguage),


### PR DESCRIPTION
When a Less stylesheet is detected to require the deprecated `javascriptEnabled` Less option, the option is enabled for the stylesheet and a warning is issued to inform the user of the behavior change. The Less `javascriptEnabled` option has been deprecated and disabled by default since Less v3 (https://github.com/less/less.js/releases/tag/v3.0.0). When enabled, the `javascriptEnabled` option allows JavaScript within Less stylesheets to be executed at build time.

Less option reference: https://lesscss.org/usage/#less-options

This provides similar behavior to the default Webpack-based build system. However, the Webpack-based build system currently unconditionally enables the option.

Closes #25572