### PR TITLE
refactor(@angular-devkit/build-angular): reduce source map resolution…

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/sass/rebasing-importer.ts
+++ b/packages/angular_devkit/build_angular/src/tools/sass/rebasing-importer.ts
@@ -133,7 +133,7 @@ abstract class UrlRebasingImporter implements Importer<'sync'> {
       if (this.rebaseSourceMaps) {
         // Generate an intermediate source map for the rebasing changes
         const map = updatedContents.generateMap({
-          hires: true,
+          hires: 'boundary',
           includeContent: true,
           source: canonicalUrl.href,
         });


### PR DESCRIPTION
… to word boundary

magic-string 0.30.2 introduced [the `boundary` strategy][1] for its high-resolution source map mode, reducing the number of source map segments to align with word boundaries instead of having a segment per character.

[1]: https://github.com/Rich-Harris/magic-string/pull/255


---
Targeting major since magic-string has only been updated to 0.30.2 on the main branch, not the rc branch.