### PR TITLE
fix(@angular-devkit/build-angular): display warning when using `resourcesOutputPath` with esbuild builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/builder-status-warnings.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/builder-status-warnings.ts
@@ -27,6 +27,7 @@ const UNSUPPORTED_OPTIONS: Array<keyof BrowserBuilderOptions> = [
   // * Unused by builder and will be removed in a future release
   'namedChunks',
   'vendorChunk',
+  'resourcesOutputPath',
 
   // * Currently unsupported by esbuild
   'webWorkerTsConfig',


### PR DESCRIPTION


`resourcesOutputPath` option is not supported when using the esbuild based builder.

Closes #25658
