### PR TITLE
refactor(@schematics/angular): remove deprecated appId option

### DIFF
--- a/packages/schematics/angular/app-shell/schema.json
+++ b/packages/schematics/angular/app-shell/schema.json
@@ -18,13 +18,6 @@
       "description": "Route path used to produce the application shell.",
       "default": "shell"
     },
-    "appId": {
-      "type": "string",
-      "format": "html-selector",
-      "description": "The application ID to use in withServerTransition().",
-      "default": "serverApp",
-      "x-deprecated": "This option is no longer used."
-    },
     "main": {
       "type": "string",
       "description": "The name of the main entry-point file.",

--- a/packages/schematics/angular/universal/schema.json
+++ b/packages/schematics/angular/universal/schema.json
@@ -13,13 +13,6 @@
         "$source": "projectName"
       }
     },
-    "appId": {
-      "type": "string",
-      "format": "html-selector",
-      "description": "The application identifier to use for transition.",
-      "default": "serverApp",
-      "x-deprecated": "This option is no longer used."
-    },
     "main": {
       "type": "string",
       "format": "path",


### PR DESCRIPTION
Remove deprecated unused options from schematics.

BREAKING CHANGE: App-shell and Universal schematics deprecated unused `appId` option has been removed.
