### PR TITLE
fix(@angular-devkit/build-angular): encode Sass package resolve directories in importer URLs

### DIFF
--- a/tests/legacy-cli/e2e/tests/build/styles/scss-partial-resolution.ts
+++ b/tests/legacy-cli/e2e/tests/build/styles/scss-partial-resolution.ts
@@ -12,10 +12,14 @@ export default async function () {
 
   await writeMultipleFiles({
     'src/styles.scss': `
-      @use '@material/button/button' as mat;
+      @use '@material/button/button';
+
+      @include button.core-styles;
     `,
     'src/app/app.component.scss': `
-      @use '@material/button/button' as mat;
+      @use '@material/button/button';
+
+      @include button.core-styles;
     `,
   });
 


### PR DESCRIPTION
When using the new developer preview application build system, Sass import/use usage that specifies a package is adjusted to contain the resolve directory to workaround Sass import plugin limitations. This resolve directory is now encoded to prevent the new specifier from looking like a URL with a scheme to the Sass compiler. This can occur on Windows when a drive letter is present (`C:\`).