### PR TITLE
docs(@angular/cli): Add Puppeteer schematics to e2e command

### DIFF
--- a/packages/angular/cli/src/commands/e2e/cli.ts
+++ b/packages/angular/cli/src/commands/e2e/cli.ts
@@ -28,6 +28,10 @@ export default class E2eCommandModule
       name: 'WebdriverIO',
       value: '@wdio/schematics',
     },
+    {
+      name: 'Puppeteer',
+      value: '@puppeteer/ng-schematics',
+    },
   ];
 
   multiTarget = true;


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Running `ng e2e` suggests `Cypress`, `Nightwatch`, `WebdriverIO`. 

Issue Number: N/A

## What is the new behavior?

Running `ng e2e` suggests Puppeteer as an option to for e2e testing. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

Ref package: [@puppeteer/ng-schematics](https://www.npmjs.com/package/@puppeteer/ng-schematics)
Ref docs: [pptr.dev](https://pptr.dev/ng-schematics)
