### PR TITLE
fix(@angular-devkit/build-angular): use correct type for `extraEntryPoints`

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/package-chunk-sort.ts
+++ b/packages/angular_devkit/build_angular/src/utils/package-chunk-sort.ts
@@ -18,7 +18,7 @@ export function generateEntryPoints(options: {
 }): EntryPointsType[] {
   // Add all styles/scripts, except lazy-loaded ones.
   const extraEntryPoints = (
-    extraEntryPoints: (ScriptElement | ScriptElement)[],
+    extraEntryPoints: (ScriptElement | StyleElement)[],
     defaultBundleName: string,
   ) => {
     const entryPoints = normalizeExtraEntryPoints(extraEntryPoints, defaultBundleName)


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

The type is incorrect

Issue Number: N/A

## What is the new behavior?

The type is correct

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
