### PR TITLE
feat(@ngtools/webpack): add automated preconnects for image domains

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/index.ts
@@ -8,6 +8,7 @@
 
 import { BuilderContext, BuilderOutput, createBuilder } from '@angular-devkit/architect';
 import { EmittedFiles, WebpackLoggingCallback, runWebpack } from '@angular-devkit/build-webpack';
+import { imageDomains } from '@ngtools/webpack';
 import * as fs from 'fs';
 import * as path from 'path';
 import { Observable, concatMap, from, map, switchMap } from 'rxjs';
@@ -310,6 +311,7 @@ export function buildWebpackBrowser(
                       optimization: normalizedOptimization,
                       crossOrigin: options.crossOrigin,
                       postTransform: transforms.indexHtml,
+                      imageDomains: Array.from(imageDomains),
                     });
 
                     let hasErrors = false;
@@ -412,7 +414,7 @@ export function buildWebpackBrowser(
                   path: baseOutputPath,
                   baseHref: options.baseHref,
                 },
-              } as BrowserBuilderOutput),
+              }) as BrowserBuilderOutput,
           ),
         );
       },

--- a/packages/angular_devkit/build_angular/src/utils/index-file/index-html-generator.ts
+++ b/packages/angular_devkit/build_angular/src/utils/index-file/index-html-generator.ts
@@ -40,6 +40,7 @@ export interface IndexHtmlGeneratorOptions {
   crossOrigin?: CrossOriginValue;
   optimization?: NormalizedOptimizationOptions;
   cache?: NormalizedCachedOptions;
+  imageDomains?: string[];
 }
 
 export type IndexHtmlTransform = (content: string) => Promise<string>;
@@ -112,7 +113,7 @@ export class IndexHtmlGenerator {
 }
 
 function augmentIndexHtmlPlugin(generator: IndexHtmlGenerator): IndexHtmlGeneratorPlugin {
-  const { deployUrl, crossOrigin, sri = false, entrypoints } = generator.options;
+  const { deployUrl, crossOrigin, sri = false, entrypoints, imageDomains } = generator.options;
 
   return async (html, options) => {
     const { lang, baseHref, outputPath = '', files, hints } = options;
@@ -126,6 +127,7 @@ function augmentIndexHtmlPlugin(generator: IndexHtmlGenerator): IndexHtmlGenerat
       lang,
       entrypoints,
       loadOutputFile: (filePath) => generator.readAsset(join(outputPath, filePath)),
+      imageDomains,
       files,
       hints,
     });

--- a/packages/ngtools/webpack/src/index.ts
+++ b/packages/ngtools/webpack/src/index.ts
@@ -10,5 +10,6 @@ export {
   AngularWebpackLoaderPath,
   AngularWebpackPlugin,
   AngularWebpackPluginOptions,
+  imageDomains,
   default,
 } from './ivy';

--- a/packages/ngtools/webpack/src/ivy/index.ts
+++ b/packages/ngtools/webpack/src/ivy/index.ts
@@ -7,6 +7,6 @@
  */
 
 export { angularWebpackLoader as default } from './loader';
-export { AngularWebpackPluginOptions, AngularWebpackPlugin } from './plugin';
+export { AngularWebpackPluginOptions, AngularWebpackPlugin, imageDomains } from './plugin';
 
 export const AngularWebpackLoaderPath = __filename;

--- a/packages/ngtools/webpack/src/ivy/plugin.ts
+++ b/packages/ngtools/webpack/src/ivy/plugin.ts
@@ -39,6 +39,8 @@ import { createAotTransformers, createJitTransformers, mergeTransformers } from 
  */
 const DIAGNOSTICS_AFFECTED_THRESHOLD = 1;
 
+export const imageDomains = new Set<string>();
+
 export interface AngularWebpackPluginOptions {
   tsconfig: string;
   compilerOptions?: CompilerOptions;
@@ -502,7 +504,7 @@ export class AngularWebpackPlugin {
       }
     }
 
-    const transformers = createAotTransformers(builder, this.pluginOptions);
+    const transformers = createAotTransformers(builder, this.pluginOptions, imageDomains);
 
     const getDependencies = (sourceFile: ts.SourceFile) => {
       const dependencies = [];

--- a/packages/ngtools/webpack/src/ivy/transformation.ts
+++ b/packages/ngtools/webpack/src/ivy/transformation.ts
@@ -8,16 +8,18 @@
 
 import * as ts from 'typescript';
 import { elideImports } from '../transformers/elide_imports';
+import { findImageDomains } from '../transformers/find_image_domains';
 import { removeIvyJitSupportCalls } from '../transformers/remove-ivy-jit-support-calls';
 import { replaceResources } from '../transformers/replace_resources';
 
 export function createAotTransformers(
   builder: ts.BuilderProgram,
   options: { emitClassMetadata?: boolean; emitNgModuleScope?: boolean },
+  imageDomains: Set<string>,
 ): ts.CustomTransformers {
   const getTypeChecker = () => builder.getProgram().getTypeChecker();
   const transformers: ts.CustomTransformers = {
-    before: [replaceBootstrap(getTypeChecker)],
+    before: [findImageDomains(imageDomains), replaceBootstrap(getTypeChecker)],
     after: [],
   };
 

--- a/packages/ngtools/webpack/src/transformers/find_image_domains.ts
+++ b/packages/ngtools/webpack/src/transformers/find_image_domains.ts
@@ -1,0 +1,126 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as ts from 'typescript';
+
+const TARGET_TEXT = '@NgModule';
+const BUILTIN_LOADERS = new Set([
+  'provideCloudflareLoader',
+  'provideCloudinaryLoader',
+  'provideImageKitLoader',
+  'provideImgixLoader',
+]);
+const URL_REGEX = /(https?:\/\/[^/]*)\//g;
+
+export function findImageDomains(imageDomains: Set<string>): ts.TransformerFactory<ts.SourceFile> {
+  return (context: ts.TransformationContext) => {
+    return (sourceFile: ts.SourceFile) => {
+      const isBuiltinImageLoader = (node: ts.CallExpression): Boolean => {
+        return BUILTIN_LOADERS.has(node.expression.getText());
+      };
+
+      const findDomainString = (node: ts.Node) => {
+        if (
+          ts.isStringLiteral(node) ||
+          ts.isTemplateHead(node) ||
+          ts.isTemplateMiddle(node) ||
+          ts.isTemplateTail(node)
+        ) {
+          const domain = node.text.match(URL_REGEX);
+          if (domain && domain[0]) {
+            imageDomains.add(domain[0]);
+
+            return node;
+          }
+        }
+        ts.visitEachChild(node, findDomainString, context);
+
+        return node;
+      };
+
+      function isImageProviderKey(property: ts.ObjectLiteralElementLike): boolean {
+        return (
+          ts.isPropertyAssignment(property) &&
+          property.name.getText() === 'provide' &&
+          property.initializer.getText() === 'IMAGE_LOADER'
+        );
+      }
+
+      function isImageProviderValue(property: ts.ObjectLiteralElementLike): boolean {
+        return ts.isPropertyAssignment(property) && property.name.getText() === 'useValue';
+      }
+
+      function checkForDomain(node: ts.ObjectLiteralExpression) {
+        if (node.properties.find(isImageProviderKey)) {
+          const value = node.properties.find(isImageProviderValue);
+          if (value && ts.isPropertyAssignment(value)) {
+            if (
+              ts.isArrowFunction(value.initializer) ||
+              ts.isFunctionExpression(value.initializer)
+            ) {
+              ts.visitEachChild(node, findDomainString, context);
+            }
+          }
+        }
+      }
+
+      function findImageLoaders(node: ts.Node) {
+        if (ts.isCallExpression(node)) {
+          if (isBuiltinImageLoader(node)) {
+            const firstArg = node.arguments[0];
+            if (ts.isStringLiteralLike(firstArg)) {
+              imageDomains.add(firstArg.text);
+            }
+          }
+        } else if (ts.isObjectLiteralExpression(node)) {
+          checkForDomain(node);
+        }
+
+        return node;
+      }
+
+      function findPropertyAssignment(node: ts.Node) {
+        if (ts.isPropertyAssignment(node)) {
+          if (ts.isIdentifier(node.name) && node.name.escapedText === 'providers') {
+            ts.visitEachChild(node.initializer, findImageLoaders, context);
+          }
+        }
+
+        return node;
+      }
+
+      function findPropertyDeclaration(node: ts.Node) {
+        if (
+          ts.isPropertyDeclaration(node) &&
+          ts.isIdentifier(node.name) &&
+          node.name.escapedText === 'ɵinj' &&
+          node.initializer &&
+          ts.isCallExpression(node.initializer) &&
+          node.initializer.arguments[0]
+        ) {
+          ts.visitEachChild(node.initializer.arguments[0], findPropertyAssignment, context);
+        }
+
+        return node;
+      }
+
+      // Continue traversal if node is ClassDeclaration and has name "AppModule"
+      function findClassDeclaration(node: ts.Node) {
+        if (ts.isClassDeclaration(node)) {
+          ts.visitEachChild(node, findPropertyDeclaration, context);
+        }
+
+        return node;
+      }
+
+      ts.visitEachChild(sourceFile, findClassDeclaration, context);
+
+      return sourceFile;
+    };
+  };
+}

--- a/packages/ngtools/webpack/src/transformers/find_image_domains_spec.ts
+++ b/packages/ngtools/webpack/src/transformers/find_image_domains_spec.ts
@@ -1,0 +1,179 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { tags } from '@angular-devkit/core';
+import * as ts from 'typescript';
+import { findImageDomains } from './find_image_domains';
+import { createTypescriptContext, transformTypescript } from './spec_helpers';
+
+function findDomains(
+  input: string,
+  importHelpers = true,
+  module: ts.ModuleKind = ts.ModuleKind.ES2020,
+) {
+  const { program, compilerHost } = createTypescriptContext(input, undefined, undefined, {
+    importHelpers,
+    module,
+  });
+  const domains = new Set<string>();
+  const transformer = findImageDomains(domains);
+
+  transformTypescript(input, [transformer], program, compilerHost);
+
+  return domains;
+}
+
+function inputTemplate(provider: string) {
+  /* eslint-disable max-len */
+  return tags.stripIndent`
+    export class AppModule {
+        static ɵfac = function AppModule_Factory(t) { return new (t || AppModule)(); };
+        static ɵmod = /*@__PURE__*/ i0.ɵɵdefineNgModule({ type: AppModule, bootstrap: [AppComponent] });
+        static ɵinj = /*@__PURE__*/ i0.ɵɵdefineInjector({ providers: [
+                ${provider}
+            ], imports: [BrowserModule] });
+    }
+    (function () { (typeof ngDevMode === "undefined" || ngDevMode) && i0.ɵsetClassMetadata(AppModule, [{
+            type: NgModule,
+            args: [{
+                    declarations: [
+                        AppComponent
+                    ],
+                    imports: [
+                        BrowserModule,
+                        NgOptimizedImage
+                    ],
+                    providers: [
+                        ${provider}
+                    ],
+                    bootstrap: [AppComponent]
+                }]
+        }], null, null); })();
+    (function () { (typeof ngJitMode === "undefined" || ngJitMode) && i0.ɵɵsetNgModuleScope(AppModule, { declarations: [AppComponent], imports: [BrowserModule,
+            NgOptimizedImage] }); })();
+    `;
+}
+
+describe('@ngtools/webpack transformers', () => {
+  describe('find_image_domains', () => {
+    it('should find a domain when a built-in loader is used with a string-literal-like argument', () => {
+      // Intentionally inconsistent use of quote styles in this data structure:
+      const builtInLoaders: Array<[string, string]> = [
+        ['provideCloudflareLoader("www.cloudflaredomain.com")', 'www.cloudflaredomain.com'],
+        [
+          "provideCloudinaryLoader('https://www.cloudinarydomain.net')",
+          'https://www.cloudinarydomain.net',
+        ],
+        ['provideImageKitLoader("www.imageKitdomain.com")', 'www.imageKitdomain.com'],
+        ['provideImgixLoader(`www.imgixdomain.com/images/`)', 'www.imgixdomain.com/images/'],
+      ];
+      for (const loader of builtInLoaders) {
+        const input = inputTemplate(loader[0]);
+        const result = Array.from(findDomains(input));
+        expect(result.length).toBe(1);
+        expect(result[0]).toBe(loader[1]);
+      }
+    });
+
+    it('should not find a domain when a built-in loader is used with a variable', () => {
+      const input = inputTemplate(`provideCloudflareLoader(myImageCDN)`);
+      const result = Array.from(findDomains(input));
+      expect(result.length).toBe(0);
+    });
+
+    it('should not find a domain when a built-in loader is used with an expression', () => {
+      const input = inputTemplate(
+        `provideCloudflareLoader("https://www." + (dev ? "dev." : "") + "cloudinarydomain.net")`,
+      );
+      const result = Array.from(findDomains(input));
+      expect(result.length).toBe(0);
+    });
+
+    it('should not find a domain when a built-in loader is used with a template literal', () => {
+      const input = inputTemplate(
+        'provideCloudflareLoader(`https://www.${dev ? "dev." : ""}cloudinarydomain.net`)',
+      );
+      const result = Array.from(findDomains(input));
+      expect(result.length).toBe(0);
+    });
+
+    it('should not find a domain in a function that is not a built-in loader', () => {
+      const input = inputTemplate('provideNotARealLoader("https://www.foo.com")');
+      const result = Array.from(findDomains(input));
+      expect(result.length).toBe(0);
+    });
+
+    it('should find a domain in a custom loader function with a template literal', () => {
+      const customLoader = tags.stripIndent`
+        {
+            provide: IMAGE_LOADER,
+            useValue: (config: ImageLoaderConfig) => {
+              return ${'`https://customLoaderTemplate.com/images?src=${config.src}&width=${config.width}`'};
+            },
+          },`;
+      const input = inputTemplate(customLoader);
+      const result = Array.from(findDomains(input));
+      expect(result.length).toBe(1);
+      expect(result[0]).toBe('https://customLoaderTemplate.com/');
+    });
+
+    it('should find a domain in a custom loader function with string concatenation', () => {
+      const customLoader = tags.stripIndent`
+        {
+            provide: IMAGE_LOADER,
+            useValue: (config: ImageLoaderConfig) => {
+              return "https://customLoaderString.com/images?src=" + config.src + "&width=" + config.width;
+            },
+          },`;
+      const input = inputTemplate(customLoader);
+      const result = Array.from(findDomains(input));
+      expect(result.length).toBe(1);
+      expect(result[0]).toBe('https://customLoaderString.com/');
+    });
+
+    it('should not find a domain if not an IMAGE_LOADER provider', () => {
+      const customLoader = tags.stripIndent`
+        {
+            provide: SOME_OTHER_PROVIDER,
+            useValue: (config: ImageLoaderConfig) => {
+              return "https://customLoaderString.com/images?src=" + config.src + "&width=" + config.width;
+            },
+          },`;
+      const input = inputTemplate(customLoader);
+      const result = Array.from(findDomains(input));
+      expect(result.length).toBe(0);
+    });
+
+    it('should find a domain when provider is alongside other providers', () => {
+      const customLoader = tags.stripIndent`
+            {
+                provide: SOME_OTHER_PROVIDER,
+                useValue: (config: ImageLoaderConfig) => {
+                return "https://notacustomloaderstring.com/images?src=" + config.src + "&width=" + config.width;
+                },
+            },
+            provideNotARealLoader("https://www.foo.com"),
+            {
+                provide: IMAGE_LOADER,
+                useValue: (config: ImageLoaderConfig) => {
+                    return ${'`https://customloadertemplate.com/images?src=${config.src}&width=${config.width}`'};
+                },
+            },
+            {
+                provide: YET_ANOTHER_PROVIDER,
+                useValue: (config: ImageLoaderConfig) => {
+                return ${'`https://notacustomloadertemplate.com/images?src=${config.src}&width=${config.width}`'};
+                },
+            },`;
+      const input = inputTemplate(customLoader);
+      const result = Array.from(findDomains(input));
+      expect(result.length).toBe(1);
+      expect(result[0]).toBe('https://customloadertemplate.com/');
+    });
+  });
+});


### PR DESCRIPTION
This PR adds new functionality to identify image domains used in [NgOptimizedImage](https://angular.io/api/common/NgOptimizedImage) loaders, and automatically add `link rel="preload"` tags to the index.html file for those domains, if the end-user isn't already managing their own preconnects. I designed this change with some substantial help from @alan-agius4 and @clydin. ATTN: @kara @AndrewKushnir 

### Technical details
How domains are identified:
Image domains are identified during the Typescript transformation process, where application Typescript files are already being traversed as an AST multiple times. This PR adds a new, non-modifying transformer, which conducts a narrow traversal of the AST to find image domains in the code. The traversal looks like this:
1) Starting at the root of the file, do a one-layer traversal, looking for a ClassDeclaration with name 'appModule'.
2) If found, look for the property assignment for `ɵinj`
3) If found, continue traversal to find the `providers` array
4) Visit all elements of the providers array and determine if they match one of two patterns:
  4a) Invocations of a [built-in CDN loader function](https://angular.io/guide/image-directive#built-in-loaders). The domain is extracted from the argument.
  4b) A manually-defined provider for IMAGE_LOADER with a [custom loader function](https://angular.io/guide/image-directive#custom-loaders). The function body is traversed and a regex is used on any string literals to find domain strings.

Found domains are added to a Set, which is exported from `@ngtools/webpack`, and imported cross-package into `packages/angular_devkit/build_angular/src/builders/browser/index.ts`. From there, the domains are used during index.html generation to add preload tags.

### Performance impacts
I've designed the changes in this PR so that they should have minimal effect on build times. The AST traversal is narrow in scope, and will quit early if it doesn't encounter the specific pattern it's looking for.

### Testing 
Unit tests are provided for both the new transform (`find_image_domains.ts`) and for the modifications to `augment-index-html.ts`. This feature really wants E2E testing (as it includes changes at both ends of the build process), but I couldn't find a good example of similar E2E tests for Ivy code in angular-cli. I'd be interested in feedback on this, and will be happy to add E2E tests with some guidance. 

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the new behavior?

<!-- Please describe the new behavior that. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

