### PR TITLE
refactor(@angular-devkit/core): use picomatch for PatternMatchingHost glob support

### DIFF
--- a/packages/angular_devkit/core/BUILD.bazel
+++ b/packages/angular_devkit/core/BUILD.bazel
@@ -34,9 +34,11 @@ ts_library(
     module_root = "src/index.d.ts",
     deps = [
         "@npm//@types/node",
+        "@npm//@types/picomatch",
         "@npm//ajv",
         "@npm//ajv-formats",
         "@npm//jsonc-parser",
+        "@npm//picomatch",
         "@npm//rxjs",
         "@npm//source-map",
         # @node_module: typescript:es2015.proxy

--- a/packages/angular_devkit/core/package.json
+++ b/packages/angular_devkit/core/package.json
@@ -28,6 +28,7 @@
     "ajv-formats": "2.1.1",
     "ajv": "8.12.0",
     "jsonc-parser": "3.2.0",
+    "picomatch": "2.3.1",
     "rxjs": "7.8.1",
     "source-map": "0.7.4"
   },


### PR DESCRIPTION
The glob support in the `PatternMatchingHost` class now uses the capabilities of the `picomatch` package to convert glob strings into regular expressions. This removes custom string replacement code that previously was used. The `picomatch` package is already used by `@angular-devkit/build-angular` and is present in the repository but is a new dependency for the `@angular-devkit/core` package specifically.

Addresses https://github.com/angular/angular-cli/security/code-scanning/20 
Partially corrects #25731