### PR TITLE
refactor(@angular-devkit/build-angular): remove disabling certificate validation when inlining fonts

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/index-file/inline-fonts.ts
+++ b/packages/angular_devkit/build_angular/src/utils/index-file/inline-fonts.ts
@@ -210,7 +210,6 @@ export class InlineFontsProcessor {
           url,
           {
             agent,
-            rejectUnauthorized: false,
             headers: {
               'user-agent':
                 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.121 Safari/537.36',


### PR DESCRIPTION


Disabling certificate validation is strongly discouraged and is not required for inling of fonts.

Addresses https://github.com/angular/angular-cli/security/code-scanning/29
Closes #25731
