### PR TITLE
build: update peer deps check to support stable versions when cutting a major prerelease

### DIFF
--- a/scripts/release-checks/dependency-ranges/peer-deps-check.mts
+++ b/scripts/release-checks/dependency-ranges/peer-deps-check.mts
@@ -33,9 +33,9 @@ export async function checkPeerDependencies(
 
   let expectedFwPeerDep = `^${major}.0.0`;
   if (isMajor && isPrerelease) {
-    expectedFwPeerDep = `^${major}.0.0-next.0`;
+    expectedFwPeerDep += ` || ^${major}.0.0-next.0`;
   } else if (isPrerelease) {
-    expectedFwPeerDep = `^${major}.0.0 || ^${major}.${minor}.0-next.0`;
+    expectedFwPeerDep += ` || ^${major}.${minor}.0-next.0`;
   }
 
   const failures: string[] = [];


### PR DESCRIPTION


Prior, to this change when a new major prerelease the check did not allow `^17.0.0 || ^17.0.0-next.0`.
