### PR TITLE
test: update ssr test to use correct sha when testing `ng add @angular/ssr`

### DIFF
--- a/tests/legacy-cli/e2e/tests/ssr/express-engine-csp-nonce.ts
+++ b/tests/legacy-cli/e2e/tests/ssr/express-engine-csp-nonce.ts
@@ -1,12 +1,16 @@
 import { rimraf, writeMultipleFiles } from '../../utils/fs';
 import { findFreePort } from '../../utils/network';
+import { installWorkspacePackages } from '../../utils/packages';
 import { execAndWaitForOutputToMatch, killAllProcesses, ng } from '../../utils/process';
+import { useSha } from '../../utils/project';
 
 export default async function () {
   // forcibly remove in case another test doesn't clean itself up
   await rimraf('node_modules/@angular/ssr');
+  await ng('add', '@angular/ssr', '--skip-confirmation', '--skip-install');
 
-  await ng('add', '@angular/ssr', '--skip-confirmation');
+  await useSha();
+  await installWorkspacePackages();
 
   await writeMultipleFiles({
     'src/styles.css': `* { color: #000 }`,

--- a/tests/legacy-cli/e2e/tests/ssr/express-engine-ngmodule.ts
+++ b/tests/legacy-cli/e2e/tests/ssr/express-engine-ngmodule.ts
@@ -1,11 +1,16 @@
 import { rimraf, writeMultipleFiles } from '../../utils/fs';
 import { findFreePort } from '../../utils/network';
+import { installWorkspacePackages } from '../../utils/packages';
 import { execAndWaitForOutputToMatch, killAllProcesses, ng } from '../../utils/process';
+import { useSha } from '../../utils/project';
 
 export default async function () {
   // forcibly remove in case another test doesn't clean itself up
   await rimraf('node_modules/@angular/ssr');
-  await ng('add', '@angular/ssr', '--skip-confirmation');
+  await ng('add', '@angular/ssr', '--skip-confirmation', '--skip-install');
+
+  await useSha();
+  await installWorkspacePackages();
 
   await writeMultipleFiles({
     'src/styles.css': `* { color: #000 }`,

--- a/tests/legacy-cli/e2e/tests/ssr/express-engine-standalone.ts
+++ b/tests/legacy-cli/e2e/tests/ssr/express-engine-standalone.ts
@@ -1,20 +1,30 @@
 import { rimraf, writeMultipleFiles } from '../../utils/fs';
 import { findFreePort } from '../../utils/network';
+import { installWorkspacePackages } from '../../utils/packages';
 import { execAndWaitForOutputToMatch, killAllProcesses, ng } from '../../utils/process';
-import { useCIChrome, useCIDefaults } from '../../utils/project';
+import { useCIChrome, useCIDefaults, useSha } from '../../utils/project';
 
 export default async function () {
   // forcibly remove in case another test doesn't clean itself up
   await rimraf('node_modules/@angular/ssr');
 
   await ng('generate', 'app', 'test-project-two', '--standalone', '--skip-install');
-
   await ng('generate', 'e2e', '--related-app-name=test-project-two');
+
   // Setup testing to use CI Chrome.
   await useCIChrome('test-project-two', 'projects/test-project-two/e2e/');
   await useCIDefaults('test-project-two');
 
-  await ng('add', '@angular/ssr', '--skip-confirmation', '--project=test-project-two');
+  await ng(
+    'add',
+    '@angular/ssr',
+    '--skip-confirmation',
+    '--project=test-project-two',
+    '--skip-install',
+  );
+
+  await useSha();
+  await installWorkspacePackages();
 
   await writeMultipleFiles({
     'projects/test-project-two/src/styles.css': `* { color: #000 }`,


### PR DESCRIPTION

Before this change when running snapshot test, the schematic would add `@angular/platform-server` with the same version of `@angular/core`. This causing a problem when testing snapshots as the version is not a semver specifier but rather the path to the Github build repo.

With this change, we ensure that the correct SHA is used for platform-server when running snapshot tests.
