### PR TITLE
Account for new compiler output in custom tranformers

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/babel/plugins/elide-angular-metadata.ts
+++ b/packages/angular_devkit/build_angular/src/tools/babel/plugins/elide-angular-metadata.ts
@@ -58,13 +58,13 @@ export default function (): PluginObj {
         }
 
         // The metadata function is always emitted inside a function expression
-        if (!path.getFunctionParent()?.isFunctionExpression()) {
-          return;
-        }
+        const parent = path.getFunctionParent();
 
-        // Replace the metadata function with `void 0` which is the equivalent return value
-        // of the metadata function.
-        path.replaceWith(path.scope.buildUndefinedNode());
+        if (parent && (parent.isFunctionExpression() || parent.isArrowFunctionExpression())) {
+          // Replace the metadata function with `void 0` which is the equivalent return value
+          // of the metadata function.
+          path.replaceWith(path.scope.buildUndefinedNode());
+        }
       },
     },
   };

--- a/packages/angular_devkit/build_angular/src/tools/babel/plugins/elide-angular-metadata.ts
+++ b/packages/angular_devkit/build_angular/src/tools/babel/plugins/elide-angular-metadata.ts
@@ -14,13 +14,18 @@ import { NodePath, PluginObj, types } from '@babel/core';
 const SET_CLASS_METADATA_NAME = 'ɵsetClassMetadata';
 
 /**
+ * Name of the asynchronous Angular class metadata function created by the Angular compiler.
+ */
+const SET_CLASS_METADATA_ASYNC_NAME = 'ɵsetClassMetadataAsync';
+
+/**
  * Provides one or more keywords that if found within the content of a source file indicate
  * that this plugin should be used with a source file.
  *
  * @returns An a string iterable containing one or more keywords.
  */
 export function getKeywords(): Iterable<string> {
-  return [SET_CLASS_METADATA_NAME];
+  return [SET_CLASS_METADATA_NAME, SET_CLASS_METADATA_ASYNC_NAME];
 }
 
 /**
@@ -33,6 +38,7 @@ export default function (): PluginObj {
     visitor: {
       CallExpression(path: NodePath<types.CallExpression>) {
         const callee = path.node.callee;
+        const callArguments = path.node.arguments;
 
         // The function being called must be the metadata function name
         let calleeName;
@@ -41,31 +47,58 @@ export default function (): PluginObj {
         } else if (types.isIdentifier(callee)) {
           calleeName = callee.name;
         }
-        if (calleeName !== SET_CLASS_METADATA_NAME) {
-          return;
-        }
 
-        // There must be four arguments that meet the following criteria:
-        // * First must be an identifier
-        // * Second must be an array literal
-        const callArguments = path.node.arguments;
         if (
-          callArguments.length !== 4 ||
-          !types.isIdentifier(callArguments[0]) ||
-          !types.isArrayExpression(callArguments[1])
+          calleeName !== undefined &&
+          (isRemoveClassMetadataCall(calleeName, callArguments) ||
+            isRemoveClassmetadataAsyncCall(calleeName, callArguments))
         ) {
-          return;
-        }
+          // The metadata function is always emitted inside a function expression
+          const parent = path.getFunctionParent();
 
-        // The metadata function is always emitted inside a function expression
-        const parent = path.getFunctionParent();
-
-        if (parent && (parent.isFunctionExpression() || parent.isArrowFunctionExpression())) {
-          // Replace the metadata function with `void 0` which is the equivalent return value
-          // of the metadata function.
-          path.replaceWith(path.scope.buildUndefinedNode());
+          if (parent && (parent.isFunctionExpression() || parent.isArrowFunctionExpression())) {
+            // Replace the metadata function with `void 0` which is the equivalent return value
+            // of the metadata function.
+            path.replaceWith(path.scope.buildUndefinedNode());
+          }
         }
       },
     },
   };
+}
+
+/** Determines if a function call is a call to `setClassMetadata`. */
+function isRemoveClassMetadataCall(name: string, args: types.CallExpression['arguments']): boolean {
+  // `setClassMetadata` calls have to meet the following criteria:
+  // * First must be an identifier
+  // * Second must be an array literal
+  return (
+    name === SET_CLASS_METADATA_NAME &&
+    args.length === 4 &&
+    types.isIdentifier(args[0]) &&
+    types.isArrayExpression(args[1])
+  );
+}
+
+/** Determines if a function call is a call to `setClassMetadataAsync`. */
+function isRemoveClassmetadataAsyncCall(
+  name: string,
+  args: types.CallExpression['arguments'],
+): boolean {
+  // `setClassMetadataAsync` calls have to meet the following criteria:
+  // * First argument must be an identifier.
+  // * Second argument must be an inline function.
+  // * Third argument must be an inline function.
+  return (
+    name === SET_CLASS_METADATA_ASYNC_NAME &&
+    args.length === 3 &&
+    types.isIdentifier(args[0]) &&
+    isInlineFunction(args[1]) &&
+    isInlineFunction(args[2])
+  );
+}
+
+/** Determines if a node is an inline function expression. */
+function isInlineFunction(node: types.Node): boolean {
+  return types.isFunctionExpression(node) || types.isArrowFunctionExpression(node);
 }

--- a/packages/angular_devkit/build_angular/src/tools/babel/plugins/elide-angular-metadata_spec.ts
+++ b/packages/angular_devkit/build_angular/src/tools/babel/plugins/elide-angular-metadata_spec.ts
@@ -102,4 +102,88 @@ describe('elide-angular-metadata Babel plugin', () => {
       `,
     }),
   );
+
+  it(
+    'elides pure annotated ɵsetClassMetadataAsync',
+    testCase({
+      input: `
+        import { Component } from '@angular/core';
+        export class SomeClass {}
+        /*@__PURE__*/ (function () {
+          i0.ɵsetClassMetadataAsync(SomeClass,
+            function () { return [import("./cmp-a").then(function (m) { return m.CmpA; })]; },
+            function (CmpA) { i0.ɵsetClassMetadata(SomeClass, [{
+                type: Component,
+                args: [{
+                        selector: 'test-cmp',
+                        standalone: true,
+                        imports: [CmpA, LocalDep],
+                        template: '{#defer}<cmp-a/>{/defer}',
+                    }]
+              }], null, null); });
+            })();
+      `,
+      expected: `
+        import { Component } from '@angular/core';
+        export class SomeClass {}
+        /*@__PURE__*/ (function () { void 0 })();
+      `,
+    }),
+  );
+
+  it(
+    'elides JIT mode protected ɵsetClassMetadataAsync',
+    testCase({
+      input: `
+        import { Component } from '@angular/core';
+        export class SomeClass {}
+        (function () {
+          (typeof ngJitMode === "undefined" || ngJitMode) && i0.ɵsetClassMetadataAsync(SomeClass,
+            function () { return [import("./cmp-a").then(function (m) { return m.CmpA; })]; },
+            function (CmpA) { i0.ɵsetClassMetadata(SomeClass, [{
+                type: Component,
+                args: [{
+                        selector: 'test-cmp',
+                        standalone: true,
+                        imports: [CmpA, LocalDep],
+                        template: '{#defer}<cmp-a/>{/defer}',
+                    }]
+              }], null, null); });
+            })();
+      `,
+      expected: `
+        import { Component } from '@angular/core';
+        export class SomeClass {}
+        (function () { (typeof ngJitMode === "undefined" || ngJitMode) && void 0 })();
+      `,
+    }),
+  );
+
+  it(
+    'elides arrow-function-based ɵsetClassMetadataAsync',
+    testCase({
+      input: `
+        import { Component } from '@angular/core';
+        export class SomeClass {}
+        /*@__PURE__*/ (() => {
+          i0.ɵsetClassMetadataAsync(SomeClass,
+            () => [import("./cmp-a").then(m => m.CmpA)],
+            (CmpA) => { i0.ɵsetClassMetadata(SomeClass, [{
+                type: Component,
+                args: [{
+                        selector: 'test-cmp',
+                        standalone: true,
+                        imports: [CmpA, LocalDep],
+                        template: '{#defer}<cmp-a/>{/defer}',
+                    }]
+              }], null, null); });
+            })();
+      `,
+      expected: `
+        import { Component } from '@angular/core';
+        export class SomeClass {}
+        /*@__PURE__*/ (() => { void 0 })();
+      `,
+    }),
+  );
 });

--- a/packages/angular_devkit/build_angular/src/tools/babel/plugins/elide-angular-metadata_spec.ts
+++ b/packages/angular_devkit/build_angular/src/tools/babel/plugins/elide-angular-metadata_spec.ts
@@ -79,4 +79,27 @@ describe('elide-angular-metadata Babel plugin', () => {
         (function () { (typeof ngJitMode === "undefined" || ngJitMode) && void 0 })();`,
     }),
   );
+
+  it(
+    'elides ɵsetClassMetadata inside an arrow-function-based IIFE',
+    testCase({
+      input: `
+        import { Component } from '@angular/core';
+        export class SomeClass {}
+        /*@__PURE__*/ (() => { i0.ɵsetClassMetadata(Clazz, [{
+            type: Component,
+            args: [{
+                    selector: 'app-lazy',
+                    template: 'very lazy',
+                    styles: []
+                }]
+        }], null, null); })();
+      `,
+      expected: `
+        import { Component } from '@angular/core';
+        export class SomeClass {}
+        /*@__PURE__*/ (() => { void 0 })();
+      `,
+    }),
+  );
 });

--- a/packages/angular_devkit/build_angular/src/tools/babel/plugins/pure-toplevel-functions.ts
+++ b/packages/angular_devkit/build_angular/src/tools/babel/plugins/pure-toplevel-functions.ts
@@ -47,7 +47,10 @@ export default function (): PluginObj {
         }
 
         const callee = path.node.callee;
-        if (types.isFunctionExpression(callee) && path.node.arguments.length !== 0) {
+        if (
+          (types.isFunctionExpression(callee) || types.isArrowFunctionExpression(callee)) &&
+          path.node.arguments.length !== 0
+        ) {
           return;
         }
         // Do not annotate TypeScript helpers emitted by the TypeScript compiler.

--- a/packages/angular_devkit/build_angular/src/tools/babel/plugins/pure-toplevel-functions_spec.ts
+++ b/packages/angular_devkit/build_angular/src/tools/babel/plugins/pure-toplevel-functions_spec.ts
@@ -66,9 +66,25 @@ describe('pure-toplevel-functions Babel plugin', () => {
   );
 
   it(
+    'annotates top-level arrow-function-based IIFE assignments with no arguments',
+    testCase({
+      input: 'var SomeClass = (() => { function SomeClass() { } return SomeClass; })();',
+      expected:
+        'var SomeClass = /*#__PURE__*/(() => { function SomeClass() { } return SomeClass; })();',
+    }),
+  );
+
+  it(
     'does not annotate top-level IIFE assignments with arguments',
     testCaseNoChange(
       'var SomeClass = (function () { function SomeClass() { } return SomeClass; })(abc);',
+    ),
+  );
+
+  it(
+    'does not annotate top-level arrow-function-based IIFE assignments with arguments',
+    testCaseNoChange(
+      'var SomeClass = (() => { function SomeClass() { } return SomeClass; })(abc);',
     ),
   );
 

--- a/packages/ngtools/webpack/src/transformers/remove-ivy-jit-support-calls.ts
+++ b/packages/ngtools/webpack/src/transformers/remove-ivy-jit-support-calls.ts
@@ -34,7 +34,10 @@ export function removeIvyJitSupportCalls(
           const expression = ts.isBinaryExpression(innerExpression)
             ? innerExpression.right
             : innerExpression;
-          if (isIvyPrivateCallExpression(expression, 'ɵsetClassMetadata')) {
+          if (
+            isIvyPrivateCallExpression(expression, 'ɵsetClassMetadata') ||
+            isIvyPrivateCallExpression(expression, 'ɵsetClassMetadataAsync')
+          ) {
             removedNodes.push(innerExpression);
 
             return undefined;
@@ -120,7 +123,7 @@ function isIvyPrivateCallExpression(expression: ts.Expression, name: string) {
     return false;
   }
 
-  if (propAccExpr.name.text != name) {
+  if (propAccExpr.name.text !== name) {
     return false;
   }
 

--- a/packages/ngtools/webpack/src/transformers/remove-ivy-jit-support-calls.ts
+++ b/packages/ngtools/webpack/src/transformers/remove-ivy-jit-support-calls.ts
@@ -18,24 +18,24 @@ export function removeIvyJitSupportCalls(
     const removedNodes: ts.Node[] = [];
 
     const visitNode: ts.Visitor = (node: ts.Node) => {
-      const innerStatement = ts.isExpressionStatement(node) && getIifeStatement(node);
-      if (innerStatement) {
+      const innerExpression = ts.isExpressionStatement(node) ? getIifeExpression(node) : null;
+      if (innerExpression) {
         if (
           ngModuleScope &&
-          ts.isBinaryExpression(innerStatement.expression) &&
-          isIvyPrivateCallExpression(innerStatement.expression.right, 'ɵɵsetNgModuleScope')
+          ts.isBinaryExpression(innerExpression) &&
+          isIvyPrivateCallExpression(innerExpression.right, 'ɵɵsetNgModuleScope')
         ) {
-          removedNodes.push(innerStatement);
+          removedNodes.push(innerExpression);
 
           return undefined;
         }
 
         if (classMetadata) {
-          const expression = ts.isBinaryExpression(innerStatement.expression)
-            ? innerStatement.expression.right
-            : innerStatement.expression;
+          const expression = ts.isBinaryExpression(innerExpression)
+            ? innerExpression.right
+            : innerExpression;
           if (isIvyPrivateCallExpression(expression, 'ɵsetClassMetadata')) {
-            removedNodes.push(innerStatement);
+            removedNodes.push(innerExpression);
 
             return undefined;
           }
@@ -75,7 +75,7 @@ export function removeIvyJitSupportCalls(
 }
 
 // Each Ivy private call expression is inside an IIFE
-function getIifeStatement(exprStmt: ts.ExpressionStatement): null | ts.ExpressionStatement {
+function getIifeExpression(exprStmt: ts.ExpressionStatement): null | ts.Expression {
   const expression = exprStmt.expression;
   if (!expression || !ts.isCallExpression(expression) || expression.arguments.length !== 0) {
     return null;
@@ -87,8 +87,12 @@ function getIifeStatement(exprStmt: ts.ExpressionStatement): null | ts.Expressio
   }
 
   const funExpr = parenExpr.expression.expression;
-  if (!ts.isFunctionExpression(funExpr)) {
+  if (!ts.isFunctionExpression(funExpr) && !ts.isArrowFunction(funExpr)) {
     return null;
+  }
+
+  if (!ts.isBlock(funExpr.body)) {
+    return funExpr.body;
   }
 
   const innerStmts = funExpr.body.statements;
@@ -101,7 +105,7 @@ function getIifeStatement(exprStmt: ts.ExpressionStatement): null | ts.Expressio
     return null;
   }
 
-  return innerExprStmt;
+  return innerExprStmt.expression;
 }
 
 function isIvyPrivateCallExpression(expression: ts.Expression, name: string) {

--- a/packages/ngtools/webpack/src/transformers/remove-ivy-jit-support-calls_spec.ts
+++ b/packages/ngtools/webpack/src/transformers/remove-ivy-jit-support-calls_spec.ts
@@ -137,6 +137,46 @@ const inputArrowFnWithImplicitReturn = tags.stripIndent`
       }], null, null))();
 `;
 
+const inputAsync = tags.stripIndent`
+  export class TestCmp {
+  }
+  TestCmp.ɵfac = function TestCmp_Factory(t) { return new (t || TestCmp)(); };
+  TestCmp.ɵcmp = i0.ɵɵdefineComponent({ type: TestCmp, selectors: [["test-cmp"]], standalone: true, features: [i0.ɵɵStandaloneFeature], decls: 3, vars: 0, template: function TestCmp_Template(rf, ctx) { }, encapsulation: 2 });
+  (function () {
+    (typeof ngJitMode === "undefined" || ngJitMode) && i0.ɵsetClassMetadataAsync(TestCmp,
+      function () { return [import("./cmp-a").then(function (m) { return m.CmpA; })]; },
+      function (CmpA) { i0.ɵsetClassMetadata(TestCmp, [{
+          type: Component,
+          args: [{
+            selector: 'test-cmp',
+            standalone: true,
+            imports: [CmpA],
+            template: '{#defer}<cmp-a />{/defer}',
+          }]
+      }], null, null); }); })();
+`;
+
+const inputAsyncArrowFn = tags.stripIndent`
+  export class TestCmp {
+  }
+  TestCmp.ɵfac = function TestCmp_Factory(t) { return new (t || TestCmp)(); };
+  TestCmp.ɵcmp = i0.ɵɵdefineComponent({ type: TestCmp, selectors: [["test-cmp"]], standalone: true, features: [i0.ɵɵStandaloneFeature], decls: 3, vars: 0, template: function TestCmp_Template(rf, ctx) { }, encapsulation: 2 });
+  (() => {
+    (typeof ngJitMode === "undefined" || ngJitMode) && i0.ɵsetClassMetadataAsync(TestCmp,
+      () => [import("./cmp-a").then((m) => m.CmpA)],
+      (CmpA) => {
+        i0.ɵsetClassMetadata(TestCmp, [{
+          type: Component,
+          args: [{
+            selector: 'test-cmp',
+            standalone: true,
+            imports: [CmpA],
+            template: '{#defer}<cmp-a />{/defer}',
+          }]
+        }], null, null);
+      }); })();
+`;
+
 describe('@ngtools/webpack transformers', () => {
   describe('remove-ivy-dev-calls', () => {
     it('should allow removing only set class metadata with pure annotation', () => {
@@ -392,6 +432,36 @@ describe('@ngtools/webpack transformers', () => {
 
       const result = transform(inputArrowFnWithImplicitReturn, (getTypeChecker) =>
         removeIvyJitSupportCalls(true, true, getTypeChecker),
+      );
+
+      expect(tags.oneLine`${result}`).toEqual(tags.oneLine`${output}`);
+    });
+
+    it('should remove setClassMetadataAsync calls', () => {
+      const output = tags.stripIndent`
+        export class TestCmp {
+        }
+        TestCmp.ɵfac = function TestCmp_Factory(t) { return new (t || TestCmp)(); };
+        TestCmp.ɵcmp = i0.ɵɵdefineComponent({ type: TestCmp, selectors: [["test-cmp"]], standalone: true, features: [i0.ɵɵStandaloneFeature], decls: 3, vars: 0, template: function TestCmp_Template(rf, ctx) { }, encapsulation: 2 });
+      `;
+
+      const result = transform(inputAsync, (getTypeChecker) =>
+        removeIvyJitSupportCalls(true, false, getTypeChecker),
+      );
+
+      expect(tags.oneLine`${result}`).toEqual(tags.oneLine`${output}`);
+    });
+
+    it('should remove arrow-function-based setClassMetadataAsync calls', () => {
+      const output = tags.stripIndent`
+        export class TestCmp {
+        }
+        TestCmp.ɵfac = function TestCmp_Factory(t) { return new (t || TestCmp)(); };
+        TestCmp.ɵcmp = i0.ɵɵdefineComponent({ type: TestCmp, selectors: [["test-cmp"]], standalone: true, features: [i0.ɵɵStandaloneFeature], decls: 3, vars: 0, template: function TestCmp_Template(rf, ctx) { }, encapsulation: 2 });
+      `;
+
+      const result = transform(inputAsyncArrowFn, (getTypeChecker) =>
+        removeIvyJitSupportCalls(true, false, getTypeChecker),
       );
 
       expect(tags.oneLine`${result}`).toEqual(tags.oneLine`${output}`);

--- a/packages/ngtools/webpack/src/transformers/remove-ivy-jit-support-calls_spec.ts
+++ b/packages/ngtools/webpack/src/transformers/remove-ivy-jit-support-calls_spec.ts
@@ -81,6 +81,62 @@ const inputNoPure = tags.stripIndent`
       }], null, null); })();
 `;
 
+const inputArrowFnWithBody = tags.stripIndent`
+  export class AppModule {
+  }
+  AppModule.ɵmod = i0.ɵɵdefineNgModule({ type: AppModule, bootstrap: [AppComponent] });
+  AppModule.ɵinj = i0.ɵɵdefineInjector({ factory: function AppModule_Factory(t) { return new (t || AppModule)(); }, providers: [], imports: [[
+              BrowserModule,
+              AppRoutingModule
+          ]] });
+  (() => { (typeof ngJitMode === "undefined" || ngJitMode) && i0.ɵɵsetNgModuleScope(AppModule, { declarations: [AppComponent,
+          ExampleComponent], imports: [BrowserModule,
+          AppRoutingModule] }); })();
+  (() => { i0.ɵsetClassMetadata(AppModule, [{
+          type: NgModule,
+          args: [{
+                  declarations: [
+                      AppComponent,
+                      ExampleComponent
+                  ],
+                  imports: [
+                      BrowserModule,
+                      AppRoutingModule
+                  ],
+                  providers: [],
+                  bootstrap: [AppComponent]
+              }]
+      }], null, null); })();
+`;
+
+const inputArrowFnWithImplicitReturn = tags.stripIndent`
+  export class AppModule {
+  }
+  AppModule.ɵmod = i0.ɵɵdefineNgModule({ type: AppModule, bootstrap: [AppComponent] });
+  AppModule.ɵinj = i0.ɵɵdefineInjector({ factory: function AppModule_Factory(t) { return new (t || AppModule)(); }, providers: [], imports: [[
+              BrowserModule,
+              AppRoutingModule
+          ]] });
+  (() => (typeof ngJitMode === "undefined" || ngJitMode) && i0.ɵɵsetNgModuleScope(AppModule, { declarations: [AppComponent,
+          ExampleComponent], imports: [BrowserModule,
+          AppRoutingModule] }))();
+  (() => i0.ɵsetClassMetadata(AppModule, [{
+          type: NgModule,
+          args: [{
+                  declarations: [
+                      AppComponent,
+                      ExampleComponent
+                  ],
+                  imports: [
+                      BrowserModule,
+                      AppRoutingModule
+                  ],
+                  providers: [],
+                  bootstrap: [AppComponent]
+              }]
+      }], null, null))();
+`;
+
 describe('@ngtools/webpack transformers', () => {
   describe('remove-ivy-dev-calls', () => {
     it('should allow removing only set class metadata with pure annotation', () => {
@@ -299,6 +355,42 @@ describe('@ngtools/webpack transformers', () => {
       `;
 
       const result = transform(imports + inputNoPure, (getTypeChecker) =>
+        removeIvyJitSupportCalls(true, true, getTypeChecker),
+      );
+
+      expect(tags.oneLine`${result}`).toEqual(tags.oneLine`${output}`);
+    });
+
+    it('should remove setClassMetadata and setNgModuleScope calls inside arrow-function-based IIFEs that have bodies', () => {
+      const output = tags.stripIndent`
+        export class AppModule {
+        }
+        AppModule.ɵmod = i0.ɵɵdefineNgModule({ type: AppModule, bootstrap: [AppComponent] });
+        AppModule.ɵinj = i0.ɵɵdefineInjector({ factory: function AppModule_Factory(t) { return new (t || AppModule)(); }, providers: [], imports: [[
+                    BrowserModule,
+                    AppRoutingModule
+                ]] });
+      `;
+
+      const result = transform(inputArrowFnWithBody, (getTypeChecker) =>
+        removeIvyJitSupportCalls(true, true, getTypeChecker),
+      );
+
+      expect(tags.oneLine`${result}`).toEqual(tags.oneLine`${output}`);
+    });
+
+    it('should remove setClassMetadata and setNgModuleScope calls inside arrow-function-based IIFEs that have an implicit return', () => {
+      const output = tags.stripIndent`
+        export class AppModule {
+        }
+        AppModule.ɵmod = i0.ɵɵdefineNgModule({ type: AppModule, bootstrap: [AppComponent] });
+        AppModule.ɵinj = i0.ɵɵdefineInjector({ factory: function AppModule_Factory(t) { return new (t || AppModule)(); }, providers: [], imports: [[
+                    BrowserModule,
+                    AppRoutingModule
+                ]] });
+      `;
+
+      const result = transform(inputArrowFnWithImplicitReturn, (getTypeChecker) =>
         removeIvyJitSupportCalls(true, true, getTypeChecker),
       );
 


### PR DESCRIPTION
There's some new output coming from the Angular compiler. These changes update the various custom transformers to account for it. It includes:
1. Emitting calls to `setClassMetadataAsync` instead of `setClassMetadata` for components that use the new `defer` block syntax.
2. Using arrow functions instead of function expressions for IIFEs. This isn't merged yet, but is being explored in https://github.com/angular/angular/pull/51637.