### PR TITLE
docs(@angular/cli): update outdated statement about CLI accepting camelCase

### DIFF
--- a/packages/angular/cli/src/commands/build/long-description.md
+++ b/packages/angular/cli/src/commands/build/long-description.md
@@ -7,7 +7,7 @@ A "development" configuration is created by default when you use the CLI to crea
 
 The configuration options generally correspond to the command options.
 You can override individual configuration defaults by specifying the corresponding options on the command line.
-The command can accept option names given in either dash-case or camelCase.
+The command can accept option names given in dash-case.
 Note that in the configuration file, you must specify names in camelCase.
 
 Some additional options can only be set through the configuration file,


### PR DESCRIPTION

The Angular CLI does not accept camelCase args.
