### PR TITLE
test: install specific npm version in npm version E2E test

### DIFF
--- a/tests/legacy-cli/e2e/tests/misc/npm-7.ts
+++ b/tests/legacy-cli/e2e/tests/misc/npm-7.ts
@@ -36,7 +36,7 @@ export default async function () {
 
   try {
     // Install version >=7.5.6
-    await npm('install', '--global', 'npm@>=7.5.6');
+    await npm('install', '--global', 'npm@8.0.0');
 
     // Ensure `ng update` does not show npm warning
     const { stderr: stderrUpdate1 } = await ng('update', ...extraArgs);


### PR DESCRIPTION
To avoid project installation errors when running the `npm-7` E2E test, the previous semver range of `>7.5.6` has been instead set to a fixed `8.0.0`. This ensures consistency within the test as now a known version of npm will be used.
This E2E test started failing recently due to the release of npm 10 which some packages do not support via the `engines` field. This situation in turn caused project install failures when the new version of npm was attempted to be installed in the test.