### PR TITLE
refactor(@angular-devkit/build-angular): update polyfills option in application builder to be only an array.

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/application/schema.json
+++ b/packages/angular_devkit/build_angular/src/builders/application/schema.json
@@ -21,22 +21,13 @@
       "description": "The full path for the server entry point to the application, relative to the current workspace."
     },
     "polyfills": {
-      "description": "Polyfills to be included in the build.",
-      "oneOf": [
-        {
-          "type": "array",
-          "description": "A list of polyfills to include in the build. Can be a full path for a file, relative to the current workspace or module specifier. Example: 'zone.js'.",
-          "items": {
-            "type": "string",
-            "uniqueItems": true
-          },
-          "default": []
-        },
-        {
-          "type": "string",
-          "description": "The full path for the polyfills file, relative to the current workspace or a module specifier. Example: 'zone.js'."
-        }
-      ]
+      "description": "A list of polyfills to include in the build. Can be a full path for a file, relative to the current workspace or module specifier. Example: 'zone.js'.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "uniqueItems": true
+      },
+      "default": []
     },
     "tsConfig": {
       "type": "string",

--- a/packages/angular_devkit/build_angular/src/builders/application/tests/options/output-hashing_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/tests/options/output-hashing_spec.ts
@@ -24,7 +24,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
       harness.useTarget('build', {
         ...BASE_OPTIONS,
         styles: ['src/styles.css'],
-        polyfills: 'src/polyfills.ts',
+        polyfills: ['src/polyfills.ts'],
         outputHashing: OutputHashing.All,
       });
 
@@ -42,7 +42,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
 
       harness.useTarget('build', {
         ...BASE_OPTIONS,
-        polyfills: 'src/polyfills.ts',
+        polyfills: ['src/polyfills.ts'],
         styles: ['src/styles.css'],
       });
 
@@ -61,7 +61,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
       harness.useTarget('build', {
         ...BASE_OPTIONS,
         styles: ['src/styles.css'],
-        polyfills: 'src/polyfills.ts',
+        polyfills: ['src/polyfills.ts'],
         outputHashing: OutputHashing.None,
       });
 
@@ -80,7 +80,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
       harness.useTarget('build', {
         ...BASE_OPTIONS,
         styles: ['src/styles.css'],
-        polyfills: 'src/polyfills.ts',
+        polyfills: ['src/polyfills.ts'],
         outputHashing: OutputHashing.Media,
       });
 
@@ -99,7 +99,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
       harness.useTarget('build', {
         ...BASE_OPTIONS,
         styles: ['src/styles.css'],
-        polyfills: 'src/polyfills.ts',
+        polyfills: ['src/polyfills.ts'],
         outputHashing: OutputHashing.Bundles,
       });
 

--- a/packages/angular_devkit/build_angular/src/builders/application/tests/options/polyfills_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/tests/options/polyfills_spec.ts
@@ -14,7 +14,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
     it('uses a provided TypeScript file', async () => {
       harness.useTarget('build', {
         ...BASE_OPTIONS,
-        polyfills: 'src/polyfills.ts',
+        polyfills: ['src/polyfills.ts'],
       });
 
       const { result } = await harness.executeOnce();
@@ -29,7 +29,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
 
       harness.useTarget('build', {
         ...BASE_OPTIONS,
-        polyfills: 'src/polyfills.js',
+        polyfills: ['src/polyfills.js'],
       });
 
       const { result } = await harness.executeOnce();
@@ -42,7 +42,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
     it('fails and shows an error when file does not exist', async () => {
       harness.useTarget('build', {
         ...BASE_OPTIONS,
-        polyfills: 'src/missing.ts',
+        polyfills: ['src/missing.ts'],
       });
 
       const { result, logs } = await harness.executeOnce({ outputLogsOnFailure: false });

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
@@ -41,11 +41,12 @@ export function buildEsbuildBrowser(
 }
 
 function normalizeOptions(options: BrowserBuilderOptions): ApplicationBuilderOptions {
-  const { main: browser, ngswConfigPath, serviceWorker, ...otherOptions } = options;
+  const { main: browser, ngswConfigPath, serviceWorker, polyfills, ...otherOptions } = options;
 
   return {
     browser,
     serviceWorker: serviceWorker ? ngswConfigPath : false,
+    polyfills: typeof polyfills === 'string' ? [polyfills] : polyfills,
     ...otherOptions,
   };
 }

--- a/packages/angular_devkit/build_angular/src/builders/jest/schema.json
+++ b/packages/angular_devkit/build_angular/src/builders/jest/schema.json
@@ -25,22 +25,13 @@
       "description": "The name of the TypeScript configuration file."
     },
     "polyfills": {
-      "description": "Polyfills to be included in the build.",
-      "oneOf": [
-        {
-          "type": "array",
-          "description": "A list of polyfills to include in the build. Can be a full path for a file, relative to the current workspace or module specifier. Example: 'zone.js'.",
-          "items": {
-            "type": "string",
-            "uniqueItems": true
-          },
-          "default": []
-        },
-        {
-          "type": "string",
-          "description": "The full path for the polyfills file, relative to the current workspace or a module specifier. Example: 'zone.js'."
-        }
-      ]
+      "type": "array",
+      "description": "A list of polyfills to include in the build. Can be a full path for a file, relative to the current workspace or module specifier. Example: 'zone.js'.",
+      "items": {
+        "type": "string",
+        "uniqueItems": true
+      },
+      "default": []
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION

This commit updates the polyfills options in application builder to support only an array of string as value.
