### PR TITLE
build: add `repository` field to `@angular/ssr` package

### DIFF
--- a/packages/angular/ssr/package.json
+++ b/packages/angular/ssr/package.json
@@ -17,5 +17,9 @@
     "@angular/common": "^17.0.0 || ^17.0.0-next.0",
     "@angular/core": "^17.0.0 || ^17.0.0-next.0"
   },
-  "schematics": "./schematics/collection.json"
+  "schematics": "./schematics/collection.json",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/angular/angular-cli.git"
+  }
 }


### PR DESCRIPTION
This is necessary for Wombat publishing. Normally most packages have this generated at build time through `pkg_npm`, however we need to use `ng_package` in this case which does not do this by default.