### PR TITLE
build: update package output to use ES2022

### DIFF
--- a/packages/angular/ssr/src/inline-css-processor.ts
+++ b/packages/angular/ssr/src/inline-css-processor.ts
@@ -92,7 +92,7 @@ class CrittersExtended extends Critters {
   private documentNonces = new WeakMap<PartialDocument, string | null>();
 
   // Inherited from `Critters`, but not exposed in the typings.
-  protected embedLinkedStylesheet!: EmbedLinkedStylesheetFn;
+  protected declare embedLinkedStylesheet: EmbedLinkedStylesheetFn;
 
   constructor(
     readonly optionsExtended: InlineCriticalCssProcessorOptions & InlineCriticalCssProcessOptions,

--- a/packages/angular_devkit/build_angular/src/builders/prerender/utils.ts
+++ b/packages/angular_devkit/build_angular/src/builders/prerender/utils.ts
@@ -8,7 +8,7 @@
 
 import { BuilderContext } from '@angular-devkit/architect';
 import { BrowserBuilderOptions } from '@angular-devkit/build-angular';
-import { json } from '@angular-devkit/core';
+import { JsonObject, json } from '@angular-devkit/core';
 import * as fs from 'fs';
 import { parseAngularRoutes } from 'guess-parser';
 import * as path from 'path';
@@ -48,7 +48,7 @@ export async function getRoutes(
     } catch (e) {
       assertIsError(e);
 
-      logger.error('Unable to extract routes from application.', { ...e });
+      logger.error('Unable to extract routes from application.', { ...e } as unknown as JsonObject);
     }
   }
 

--- a/packages/angular_devkit/build_angular/src/utils/index-file/inline-critical-css.ts
+++ b/packages/angular_devkit/build_angular/src/utils/index-file/inline-critical-css.ts
@@ -88,7 +88,7 @@ class CrittersExtended extends Critters {
   private documentNonces = new WeakMap<PartialDocument, string | null>();
 
   // Inherited from `Critters`, but not exposed in the typings.
-  protected embedLinkedStylesheet!: EmbedLinkedStylesheetFn;
+  protected declare embedLinkedStylesheet: EmbedLinkedStylesheetFn;
 
   constructor(
     private readonly optionsExtended: InlineCriticalCssProcessorOptions &

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -73,7 +73,7 @@ def ts_library(
     if not devmode_module:
         devmode_module = "commonjs"
     if not devmode_target:
-        devmode_target = "es2020"
+        devmode_target = "es2022"
 
     _ts_library(
         name = name,
@@ -83,7 +83,7 @@ def ts_library(
         tsconfig = tsconfig,
         devmode_module = devmode_module,
         devmode_target = devmode_target,
-        prodmode_target = "es2020",
+        prodmode_target = "es2022",
         # @external_end
         **kwargs
     )

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,8 +11,8 @@
     "outDir": "./dist",
     "skipLibCheck": true,
     "strict": true,
-    "target": "es2020",
-    "lib": ["es2020"],
+    "target": "es2022",
+    "lib": ["es2022"],
     "rootDir": ".",
     "rootDirs": [".", "./dist-schema/bin/"],
     "paths": {


### PR DESCRIPTION
The JavaScript generated for the published packages is now using ES2022. This removes additional downleveling of code that was previously necessary to use newer features.
The minimum Node.js version of 18.13 provides support for the needed features. While this change does require a patch to `@bazel/concatjs` to allow the target to be set to `ES2022`, this patch is now already required by the migration of the universal repository into the CLI repository.