### PR TITLE
refactor: replace deprecated `logs` verdaccio setting

### DIFF
--- a/tests/legacy-cli/verdaccio.yaml
+++ b/tests/legacy-cli/verdaccio.yaml
@@ -41,7 +41,7 @@ packages:
     access: $all
     proxy: npmjs
 
-logs:
+log:
   type: stdout
   format: pretty
   level: warn

--- a/tests/legacy-cli/verdaccio_auth.yaml
+++ b/tests/legacy-cli/verdaccio_auth.yaml
@@ -23,7 +23,7 @@ packages:
     access: $authenticated
     proxy: local
 
-logs:
+log:
   type: stdout
   format: pretty
   level: warn


### PR DESCRIPTION
`logs` has been deprecated in favor of `log`
