### PR TITLE
refactor(@angular-devkit/build-angular): remove deep import of `zone.js/node`

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/esbuild/application-code-bundle.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/application-code-bundle.ts
@@ -162,7 +162,7 @@ export function createServerCodeBundleOptions(
   const polyfills = [`import '@angular/platform-server/init';`];
 
   if (options.polyfills?.includes('zone.js')) {
-    polyfills.push(`import 'zone.js/fesm2015/zone-node.js';`);
+    polyfills.push(`import 'zone.js/node';`);
   }
 
   if (jit) {


### PR DESCRIPTION

This is no longer needed as `zone.js` now has proper package exports.
