### PR TITLE
fix(@angular-devkit/build-angular): correctly re-point RXJS to ESM on Windows

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/esbuild/rxjs-esm-resolution-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/rxjs-esm-resolution-plugin.ts
@@ -39,7 +39,7 @@ export function createRxjsEsmResolutionPlugin(): Plugin {
           resolveDir,
         });
 
-        result.path = result.path.replace('/dist/cjs/', '/dist/esm/');
+        result.path = result.path.replace(/([\\/]dist[\\/])cjs([\\/])/, '$1esm$2');
 
         return result;
       });


### PR DESCRIPTION
Previously, the path matching and replacement did not consider non posix file systems like windows.

