### PR TITLE
fix(@angular-devkit/build-angular): several windows fixes to application builder prerendering

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/server-rendering/prerender.ts
+++ b/packages/angular_devkit/build_angular/src/utils/server-rendering/prerender.ts
@@ -8,7 +8,8 @@
 
 import { OutputFile } from 'esbuild';
 import { readFile } from 'node:fs/promises';
-import { extname, posix } from 'node:path';
+import { extname, join, posix } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import Piscina from 'piscina';
 import type { RenderResult, ServerContext } from './render-page';
 import type { WorkerData } from './render-worker';
@@ -73,7 +74,7 @@ export async function prerenderPages(
     execArgv: [
       '--no-warnings', // Suppress `ExperimentalWarning: Custom ESM Loaders is an experimental feature...`.
       '--loader',
-      require.resolve('./esm-in-memory-file-loader.js'),
+      pathToFileURL(join(__dirname, 'esm-in-memory-file-loader.js')).href, // Loader cannot be an absolute path on Windows.
     ],
   });
 


### PR DESCRIPTION


This commit fixes several Windows issues in the prerendering pipeline. Primarily due to path normalization and other Windows only constraints.
