### PR TITLE
test(@angular/cli): test all `ng add` in the esbuild pipeline

### DIFF
--- a/tests/legacy-cli/e2e.bzl
+++ b/tests/legacy-cli/e2e.bzl
@@ -36,7 +36,7 @@ ESBUILD_TESTS = [
     "tests/build/prod-build.js",
     "tests/build/relative-sourcemap.js",
     "tests/build/styles/**",
-    "tests/commands/add/add-pwa.js",
+    "tests/commands/add/**",
     "tests/i18n/extract-ivy*",
     "tests/ssr/**",
 ]


### PR DESCRIPTION
This commits adds the entire `tests/commands/add` directory to be tested with esbuild.
