### PR TITLE
refactor(@angular-devkit/build-angular): remove usage of terser constants in esbuild

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/esbuild/angular/compiler-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/angular/compiler-plugin.ts
@@ -114,22 +114,9 @@ export function createCompilerPlugin(
       // Initialize a worker pool for JavaScript transformations
       const javascriptTransformer = new JavaScriptTransformer(pluginOptions, maxWorkers);
 
-      // Setup defines based on the values provided by the Angular compiler-cli
-      const { GLOBAL_DEFS_FOR_TERSER_WITH_AOT } = await AngularCompilation.loadCompilerCli();
+      // Setup defines based on the values used by the Angular compiler-cli
       build.initialOptions.define ??= {};
-      for (const [key, value] of Object.entries(GLOBAL_DEFS_FOR_TERSER_WITH_AOT)) {
-        if (key in build.initialOptions.define) {
-          // Skip keys that have been manually provided
-          continue;
-        }
-        if (key === 'ngDevMode') {
-          // ngDevMode is already set based on the builder's script optimization option
-          continue;
-        }
-        // esbuild requires values to be a string (actual strings need to be quoted).
-        // In this case, all provided values are booleans.
-        build.initialOptions.define[key] = value.toString();
-      }
+      build.initialOptions.define['ngI18nClosureMode'] ??= 'false';
 
       // The in-memory cache of TypeScript file outputs will be used during the build in `onLoad` callbacks for TS files.
       // A string value indicates direct TS/NG output and a Uint8Array indicates fully transformed code.


### PR DESCRIPTION
The terser build time constant import from the `@angular/compiler-cli` package is no longer used in the esbuild-based builder. The constants present are already defined and conditionally added within the build configuration itself. This not only provides more flexibility but also removes the need to import the package early in the process. The import is also an expensive import due to it needing TypeScript and being ESM that needs to be dynamically imported via a function helper to work around current ESM/TypeScript/CommonJS limitations.