### PR TITLE
fix(@ngtools/webpack): fix recursion in webpack resolve

### DIFF
--- a/packages/ngtools/webpack/src/paths-plugin.ts
+++ b/packages/ngtools/webpack/src/paths-plugin.ts
@@ -141,10 +141,16 @@ export class TypeScriptPathsPlugin {
             return;
           }
 
+          // Absolute requests are not mapped
+          if (path.isAbsolute(originalRequest)) {
+            callback();
+
+            return;
+          }
+
           switch (originalRequest[0]) {
             case '.':
-            case '/':
-              // Relative or absolute requests are not mapped
+              // Relative requests are not mapped
               callback();
 
               return;


### PR DESCRIPTION
fix a recursion in webpack resolve when resolving absolute paths on windows

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

When using wildcard in tsconfiig.json paths on windows webpack-dev-server fail with the following error
```
./node_modules/webpack-dev-server/client/socket.js:10:7-36 - Error: Module not found: Error: Recursion in resolving
Stack:
  resolve: (C:\Users\athor\OneDrive\Bureau\stackblitz-starters-6juerj\node_modules\webpack-dev-server\client) C:\Users\athor\OneDrive\Bureau\stackblitz-starters-6juerj\node_modules\webpack-dev-server\client\clients\WebSocketClient.js
  parsedResolve: (C:\Users\athor\OneDrive\Bureau\stackblitz-starters-6juerj\node_modules\webpack-dev-server\client) C:\Users\athor\OneDrive\Bureau\stackblitz-starters-6juerj\node_modules\webpack-dev-server\client\clients\WebSocketClient.js
  describedResolve: (C:\Users\athor\OneDrive\Bureau\stackblitz-starters-6juerj\node_modules\webpack-dev-server\client) C:\Users\athor\OneDrive\Bureau\stackblitz-starters-6juerj\node_modules\webpack-dev-server\client\clients\WebSocketClient.js

./node_modules/webpack-dev-server/client/socket.js - Error: Cannot read properties of undefined (reading 'module')
```

Issue can be reproduced with : https://stackblitz.com/edit/stackblitz-starters-9swkmh?file=tsconfig.json

Issue Number: N/A

## What is the new behavior?

With the fix the webpack-dev-server doesn't fail

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
