### PR TITLE
refactor(@schematics/angular): remove empty space in app.config.ts.template

### DIFF
--- a/packages/schematics/angular/application/files/standalone-files/src/app/app.config.ts.template
+++ b/packages/schematics/angular/application/files/standalone-files/src/app/app.config.ts.template
@@ -4,5 +4,5 @@ import { provideRouter } from '@angular/router';
 import { routes } from './app.routes';<% } %>
 
 export const appConfig: ApplicationConfig = {
-  providers: [<% if (routing) { %>provideRouter(routes) <% } %>]
+  providers: [<% if (routing) { %>provideRouter(routes)<% } %>]
 };


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Code style update (formatting, local variables)


## What is the current behavior?
There's empty space after provideRouter();

<img width="539" alt="CleanShot 2023-09-15 at 15 04 20@2x" src="https://github.com/angular/angular-cli/assets/25394362/a41d6725-df02-4619-aff6-4c040de813cc">

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
No empty space
<img width="502" alt="CleanShot 2023-09-15 at 15 04 38@2x" src="https://github.com/angular/angular-cli/assets/25394362/ee876ab9-f9b4-44b6-9ae9-85519f134f0e">


<!-- Please describe the new behavior that. -->

## Does this PR introduce a breaking change?

- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
