### PR TITLE
refactor(@angular-devkit/build-angular): use `ɵloadChildren` helper from router package

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/esbuild/application-code-bundle.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/application-code-bundle.ts
@@ -110,7 +110,6 @@ export function createServerCodeBundleOptions(
   );
 
   const mainServerNamespace = 'angular:main-server';
-  const routeExtractorNamespace = 'angular:prerender-route-extractor';
   const ssrEntryNamespace = 'angular:ssr-entry';
 
   const entryPoints: Record<string, string> = {


### PR DESCRIPTION


This commit updates the routes extractor to use the newly exported private `ɵloadChildren` method from the router to executes a `route.loadChildren` callback and return an array of child routes.

See: https://github.com/angular/angular/pull/51818
