### PR TITLE
feat(@angular-devkit/build-angular): apply global CSS updates without a live-reload when using `vite`

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
@@ -161,7 +161,7 @@ function handleUpdate(
     return;
   }
 
-  if (serverOptions.hmr) {
+  if (serverOptions.liveReload || serverOptions.hmr) {
     if (updatedFiles.every((f) => f.endsWith('.css'))) {
       const timestamp = Date.now();
       server.ws.send({


### PR DESCRIPTION

This commit changes the way that global style updates are applied when using `vite`.  When either live-reload or hmr are enabled the styles are replaced in placed (HMR style) without a live-reload.
