### PR TITLE
fix(@angular-devkit/build-angular): use a dot in chunk names

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/jest/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/jest/index.ts
@@ -109,7 +109,7 @@ export default createBuilder(
       `--testPathIgnorePatterns="<rootDir>/init-test-bed\\.mjs"`,
 
       // Skip shared chunks, as they are not entry points to tests.
-      `--testPathIgnorePatterns="<rootDir>/chunk-.*\\.mjs"`,
+      `--testPathIgnorePatterns="<rootDir>/chunk\\..*\\.mjs"`,
 
       // Optionally enable color.
       ...(colors.enabled ? ['--colors'] : []),

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/application-code-bundle.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/application-code-bundle.ts
@@ -263,7 +263,7 @@ function getEsBuildCommonOptions(options: NormalizedApplicationBuildOptions): Bu
     outExtension: outExtension ? { '.js': `.${outExtension}` } : undefined,
     sourcemap: sourcemapOptions.scripts && (sourcemapOptions.hidden ? 'external' : true),
     splitting: true,
-    chunkNames: 'chunk-[hash]',
+    chunkNames: 'chunk.[hash]',
     tsconfig,
     external: externalDependencies,
     write: false,

--- a/packages/angular_devkit/build_angular/src/utils/server-rendering/esm-in-memory-file-loader.ts
+++ b/packages/angular_devkit/build_angular/src/utils/server-rendering/esm-in-memory-file-loader.ts
@@ -25,7 +25,7 @@ export interface ESMInMemoryFileLoaderWorkerData {
 const { outputFiles, workspaceRoot } = workerData as ESMInMemoryFileLoaderWorkerData;
 
 const TRANSFORMED_FILES: Record<string, string> = {};
-const CHUNKS_REGEXP = /file:\/\/\/(main\.server|chunk-\w+)\.mjs/;
+const CHUNKS_REGEXP = /file:\/\/\/(main\.server|chunk\.\w+)\.mjs/;
 const WORKSPACE_ROOT_FILE = pathToFileURL(join(workspaceRoot, 'index.mjs')).href;
 
 const JAVASCRIPT_TRANSFORMER = new JavaScriptTransformer(

--- a/tests/legacy-cli/e2e/tests/basic/rebuild.ts
+++ b/tests/legacy-cli/e2e/tests/basic/rebuild.ts
@@ -7,7 +7,7 @@ import { ngServe } from '../../utils/project';
 export default async function () {
   const esbuild = getGlobalVariable('argv')['esbuild'];
   const validBundleRegEx = esbuild ? /complete\./ : /Compiled successfully\./;
-  const lazyBundleRegEx = esbuild ? /chunk-/ : /lazy_module_ts\.js/;
+  const lazyBundleRegEx = esbuild ? /chunk\./ : /lazy_module_ts\.js/;
 
   const port = await ngServe();
   // Add a lazy module.


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

The esbuild based builder generates chunks named `chunk-xxx.js`.

## What is the new behavior?

This updates the esbuild based builder to use `chunk.xxx.js` instead of `chunk-xxx.js` to be consistent with the other generated files (`main.xxx.js`, `polyfills.xxx.js`, etc).

<!-- Please describe the new behavior that. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
