### PR TITLE
feat(@angular-devkit/build-angular): support basic web worker bundling with esbuild builders

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/esbuild/angular/web-worker-transformer.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/angular/web-worker-transformer.ts
@@ -97,7 +97,15 @@ export function createWorkerTransformer(
                     workerUrlNode.arguments,
                   ),
                 ),
-                node.arguments[1],
+                // Use the second Worker argument (options) if present.
+                // Otherwise create a default options object for module Workers.
+                node.arguments[1] ??
+                  nodeFactory.createObjectLiteralExpression([
+                    nodeFactory.createPropertyAssignment(
+                      'type',
+                      nodeFactory.createStringLiteral('module'),
+                    ),
+                  ]),
               ],
               node.arguments.hasTrailingComma,
             ),

--- a/tests/legacy-cli/e2e.bzl
+++ b/tests/legacy-cli/e2e.bzl
@@ -38,6 +38,7 @@ ESBUILD_TESTS = [
     "tests/build/relative-sourcemap.js",
     "tests/build/styles/**",
     "tests/build/prerender/**",
+    "tests/build/worker.js",
     "tests/commands/add/**",
     "tests/i18n/extract-ivy*",
 ]


### PR DESCRIPTION
When using the esbuild-based builders (`application`/`browser`), Web Workers that use the supported syntax will now be bundled. The bundling process currently uses an additional synchronous internal esbuild execution. The execution must be synchronous due to the usage within a TypeScript transformer. TypeScript's compilation process is fully synchronous. The bundling itself currently does not provide all the features of the Webpack-based builder. 
The following limitations are present in the current implementation but will be addressed in upcoming changes:
- Worker code is not type-checked
- Nested workers are not supported