### PR TITLE
test: update output regexp in i18n tests to account for change in filename

### DIFF
--- a/tests/legacy-cli/e2e/tests/i18n/ivy-localize-hashes.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/ivy-localize-hashes.ts
@@ -11,7 +11,7 @@ import { appendToFile } from '../../utils/fs';
 import { ng } from '../../utils/process';
 import { langTranslations, setupI18nConfig } from './setup';
 
-const OUTPUT_RE = /^(?<name>(?:main|vendor|\d+))\.(?<hash>[a-z0-9]+)\.js$/i;
+const OUTPUT_RE = /^(?<name>(?:main|vendor|\d+))(?:\.|-)(?<hash>[a-z0-9]+)\.js$/i;
 
 export default async function () {
   // Setup i18n tests and config.


### PR DESCRIPTION

This update the regexp to account for the change in https://github.com/angular/angular-cli/pull/25877. A filename that has the hash included will be `main.[hash]` in Webpack and `main-[hash]` when using esbuild.