### PR TITLE
 feat(@schematics/angular): enable hydration when adding SSR, SSG or AppShell     

### DIFF
--- a/packages/angular/ssr/schematics/utility/utils.ts
+++ b/packages/angular/ssr/schematics/utility/utils.ts
@@ -9,7 +9,6 @@
 import { workspaces } from '@angular-devkit/core';
 import { SchematicsException, Tree } from '@angular-devkit/schematics';
 import { readWorkspace } from '@schematics/angular/utility';
-import * as ts from 'typescript';
 
 export async function getProject(
   host: Tree,
@@ -23,10 +22,6 @@ export async function getProject(
   }
 
   return project;
-}
-
-export function stripTsExtension(file: string): string {
-  return file.replace(/\.ts$/, '');
 }
 
 export async function getOutputPath(
@@ -49,107 +44,4 @@ export async function getOutputPath(
   }
 
   return outputPath;
-}
-
-export function findImport(
-  sourceFile: ts.SourceFile,
-  moduleName: string,
-  symbolName: string,
-): ts.NamedImports | null {
-  // Only look through the top-level imports.
-  for (const node of sourceFile.statements) {
-    if (
-      !ts.isImportDeclaration(node) ||
-      !ts.isStringLiteral(node.moduleSpecifier) ||
-      node.moduleSpecifier.text !== moduleName
-    ) {
-      continue;
-    }
-
-    const namedBindings = node.importClause && node.importClause.namedBindings;
-
-    if (!namedBindings || !ts.isNamedImports(namedBindings)) {
-      continue;
-    }
-
-    if (namedBindings.elements.some((element) => element.name.text === symbolName)) {
-      return namedBindings;
-    }
-  }
-
-  return null;
-}
-
-export type Import = {
-  name: string;
-  importModule: string;
-  node: ts.ImportDeclaration;
-};
-
-/** Gets import information about the specified identifier by using the Type checker. */
-export function getImportOfIdentifier(
-  typeChecker: ts.TypeChecker,
-  node: ts.Identifier,
-): Import | null {
-  const symbol = typeChecker.getSymbolAtLocation(node);
-
-  if (!symbol || !symbol.declarations?.length) {
-    return null;
-  }
-
-  const decl = symbol.declarations[0];
-
-  if (!ts.isImportSpecifier(decl)) {
-    return null;
-  }
-
-  const importDecl = decl.parent.parent.parent;
-
-  if (!ts.isStringLiteral(importDecl.moduleSpecifier)) {
-    return null;
-  }
-
-  return {
-    // Handles aliased imports: e.g. "import {Component as myComp} from ...";
-    name: decl.propertyName ? decl.propertyName.text : decl.name.text,
-    importModule: importDecl.moduleSpecifier.text,
-    node: importDecl,
-  };
-}
-
-export function addInitialNavigation(node: ts.CallExpression): ts.CallExpression {
-  const existingOptions = node.arguments[1] as ts.ObjectLiteralExpression | undefined;
-
-  // If the user has explicitly set initialNavigation, we respect that
-  if (
-    existingOptions &&
-    existingOptions.properties.some(
-      (exp) =>
-        ts.isPropertyAssignment(exp) &&
-        ts.isIdentifier(exp.name) &&
-        exp.name.text === 'initialNavigation',
-    )
-  ) {
-    return node;
-  }
-
-  const enabledLiteral = ts.factory.createStringLiteral('enabledBlocking');
-  // TypeScript will emit the Node with double quotes.
-  // In schematics we usually write code with a single quotes
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (enabledLiteral as any).singleQuote = true;
-
-  const initialNavigationProperty = ts.factory.createPropertyAssignment(
-    'initialNavigation',
-    enabledLiteral,
-  );
-  const routerOptions = existingOptions
-    ? ts.factory.updateObjectLiteralExpression(
-        existingOptions,
-        ts.factory.createNodeArray([...existingOptions.properties, initialNavigationProperty]),
-      )
-    : ts.factory.createObjectLiteralExpression([initialNavigationProperty], true);
-  const args = [node.arguments[0], routerOptions];
-
-  return ts.factory.createCallExpression(node.expression, node.typeArguments, args);
 }

--- a/packages/schematics/angular/server/index.ts
+++ b/packages/schematics/angular/server/index.ts
@@ -22,6 +22,7 @@ import {
 } from '@angular-devkit/schematics';
 import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
 import { posix } from 'node:path';
+import { addRootProvider } from '../utility';
 import {
   NodeDependencyType,
   addPackageJsonDependency,
@@ -220,6 +221,11 @@ export default function (options: ServerOptions): Rule {
             updateConfigFileBrowserBuilder(options, tsConfigDirectory),
           ]),
       addDependencies(),
+      addRootProvider(
+        options.project,
+        ({ code, external }) =>
+          code`${external('provideClientHydration', '@angular/platform-browser')}()`,
+      ),
     ]);
   };
 }

--- a/packages/schematics/angular/server/index_spec.ts
+++ b/packages/schematics/angular/server/index_spec.ts
@@ -91,6 +91,12 @@ describe('Server Schematic', () => {
       expect(contents.compilerOptions.types).toEqual(['node']);
       expect(contents.files).toEqual(['src/main.ts', 'src/main.server.ts']);
     });
+
+    it(`should add 'provideClientHydration' to the providers list`, async () => {
+      const tree = await schematicRunner.runSchematic('server', defaultOptions, appTree);
+      const contents = tree.readContent('/projects/bar/src/app/app.module.ts');
+      expect(contents).toContain(`provideClientHydration()`);
+    });
   });
 
   describe('standalone application', () => {
@@ -127,6 +133,12 @@ describe('Server Schematic', () => {
       expect(tree.exists(filePath)).toBeTrue();
       const contents = tree.readContent(filePath);
       expect(contents).toContain(`const serverConfig: ApplicationConfig = {`);
+    });
+
+    it(`should add 'provideClientHydration' to the providers list`, async () => {
+      const tree = await schematicRunner.runSchematic('server', defaultOptions, appTree);
+      const contents = tree.readContent('/projects/bar/src/app/app.config.ts');
+      expect(contents).toContain(`providers: [provideClientHydration()]`);
     });
   });
 


### PR DESCRIPTION
This commits updates the internal server schematic that is used by SSR and AppShell schematics to include `provideClientHydration` in the list of providers, which causes hydration to be enabled for application.
    
For more information about `provideClientHydration`, see: https://angular.io/api/platform-browser/provideClientHydration

FYI @AndrewKushnir 