### PR TITLE
perf(@angular-devkit/build-angular): disable ahead of time prerendering in vite dev-server

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
@@ -60,6 +60,14 @@ export async function* serveWithVite(
     } as json.JsonObject & BrowserBuilderOptions,
     builderName,
   )) as json.JsonObject & BrowserBuilderOptions;
+
+  if (browserOptions.prerender) {
+    // Disable prerendering if enabled and force SSR.
+    // This is so instead of prerendering all the routes for every change, the page is "prerendered" when it is requested.
+    browserOptions.ssr = true;
+    browserOptions.prerender = false;
+  }
+
   // Set all packages as external to support Vite's prebundle caching
   browserOptions.externalPackages = serverOptions.cacheOptions.enabled;
 


### PR DESCRIPTION


When using the devserver, instead of prerendering every page for every incremental change, we now perform a server rendering on the page during request time. This ensures that incremental build times are faster when prerending is enabled as we avoid rendering of pages that are never viewed.
