### PR TITLE
fix(@schematics/angular): update `@angular/cli` version specifier to use `^`

### DIFF
--- a/packages/schematics/angular/workspace/files/package.json.template
+++ b/packages/schematics/angular/workspace/files/package.json.template
@@ -23,7 +23,7 @@
     "zone.js": "<%= latestVersions['zone.js'] %>"
   },
   "devDependencies": {
-    "@angular/cli": "<%= '~' + version %>",
+    "@angular/cli": "<%= '^' + version %>",
     "@angular/compiler-cli": "<%= latestVersions.Angular %>",<% if (!minimal) { %>
     "@types/jasmine": "<%= latestVersions['@types/jasmine'] %>",
     "jasmine-core": "<%= latestVersions['jasmine-core'] %>",


### PR DESCRIPTION


This is to match all other Angular framework and Angular devkit dependencies
