### PR TITLE
feat(@schematics/angular): generate functional interceptors by default

### DIFF
--- a/packages/schematics/angular/interceptor/schema.json
+++ b/packages/schematics/angular/interceptor/schema.json
@@ -44,7 +44,7 @@
     "functional": {
       "type": "boolean",
       "description": "Creates the interceptor as a `HttpInterceptorFn`.",
-      "default": false
+      "default": true
     }
   },
   "required": ["name", "project"]


### PR DESCRIPTION
This commit updates the interceptor schematic to generate function intererceptors by default.

BREAKING CHANGE: `ng g interceptor` now generate a functional interceptor by default. or guard by default. To generate a class-based interceptor the `--no-functional` command flag should be used.
