### PR TITLE
fix(@angular-devkit/build-angular): do not print `Angular is running in development mode.` in the server console when using dev-server

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
@@ -450,6 +450,14 @@ export async function setupServer(
               }
 
               transformIndexHtmlAndAddHeaders(url, rawHtml, res, next, async (html) => {
+                /* eslint-disable no-console */
+                const originalConsoleLog = console.log;
+                console.log = (...args) => {
+                  if (args[0] !== 'Angular is running in development mode.') {
+                    originalConsoleLog.apply(args);
+                  }
+                };
+
                 const { content } = await renderPage({
                   document: html,
                   route: pathnameWithoutServePath(url, serverOptions),
@@ -463,6 +471,9 @@ export async function setupServer(
                   // TODO: add support for critical css inlining.
                   inlineCriticalCss: false,
                 });
+
+                console.log = originalConsoleLog;
+                /* eslint-enable no-console */
 
                 return content;
               });


### PR DESCRIPTION


This commit disables logging `Angular is running in development mode.` when using SSR with vite dev-server. This to avoid polluting the server console with `Angular is running in development mode.` logs for each page load and reload.

Example:
```
ng s

Initial Chunk Files | Names         | Raw Size
main.js             | main          | 34.31 kB | 
polyfills.js        | polyfills     | 95 bytes | 
styles.css          | styles        | 95 bytes | 

                    | Initial Total | 34.49 kB

Application bundle generation complete. [5.205 seconds]

  ➜  Local:   http://localhost:4200/
Watch mode enabled. Watching for file changes...
Angular is running in development mode.
Angular is running in development mode.
Angular is running in development mode.
Angular is running in development mode.
Angular is running in development mode.
Angular is running in development mode.
```