### PR TITLE
test(@angular/cli): remove Safari 15 test

### DIFF
--- a/tests/legacy-cli/e2e/tests/misc/safari-15-class-properties.ts
+++ b/tests/legacy-cli/e2e/tests/misc/safari-15-class-properties.ts
@@ -28,13 +28,6 @@ export default async function () {
   //   - static #_ = this.ecmp = bla
   const staticIndicatorRegex = /static\s+(\{|#[_\d]+\s+=)/;
 
-  await ng('build', '--configuration=development');
-  await expectFileToExist('dist/test-project/main.js');
-  const mainContent = await readFile('dist/test-project/main.js');
-  // TODO: This default cause can be removed in the future when Safari v15
-  // is longer included in the default browserlist configuration of CLI apps.
-  assert.doesNotMatch(mainContent, staticIndicatorRegex, unexpectedStaticFieldErrorMessage);
-
   await writeFile('.browserslistrc', 'last 1 chrome version');
   await ng('build', '--configuration=development');
   await expectFileToExist('dist/test-project/main.js');


### PR DESCRIPTION
Safari v15 is longer included in the default browserlist configuration of CLI apps.
