### PR TITLE
fix(@schematics/angular): use @types/node v18

### DIFF
--- a/packages/angular_devkit/schematics_cli/blank/project-files/package.json
+++ b/packages/angular_devkit/schematics_cli/blank/project-files/package.json
@@ -18,7 +18,7 @@
     "typescript": "~5.2.2"
   },
   "devDependencies": {
-    "@types/node": "^16.11.7",
+    "@types/node": "^18.18.0",
     "@types/jasmine": "~4.3.0",
     "jasmine": "^5.0.0"
   }

--- a/packages/angular_devkit/schematics_cli/schematic/files/package.json
+++ b/packages/angular_devkit/schematics_cli/schematic/files/package.json
@@ -18,7 +18,7 @@
     "typescript": "~5.2.2"
   },
   "devDependencies": {
-    "@types/node": "^16.11.7",
+    "@types/node": "^18.18.0",
     "@types/jasmine": "~4.3.0",
     "jasmine": "~5.1.0"
   }

--- a/packages/schematics/angular/utility/latest-versions/package.json
+++ b/packages/schematics/angular/utility/latest-versions/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@types/express": "^4.17.17",
     "@types/jasmine": "~4.3.0",
-    "@types/node": "^16.11.7",
+    "@types/node": "^18.18.0",
     "express": "^4.18.2",
     "jasmine-core": "~5.1.0",
     "jasmine-spec-reporter": "~7.0.0",


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently, running a schematics that adds `@types/node` to a project, like `ng add @angular/ssr`, will add the v16 types. 

## What is the new behavior?

As nodejs v16 is now EOL, this PR updates the types to v18.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
