### PR TITLE
build: re-enable Material tests

### DIFF
--- a/tests/legacy-cli/e2e/tests/build/material.ts
+++ b/tests/legacy-cli/e2e/tests/build/material.ts
@@ -7,9 +7,6 @@ import { isPrereleaseCli, updateJsonFile } from '../../utils/project';
 const snapshots = require('../../ng-snapshot/package.json');
 
 export default async function () {
-  // TODO(crisbeto): temporarily disabled until Material is updated to TS 5.2
-  return;
-
   let tag = (await isPrereleaseCli()) ? '@next' : '';
   await ng('add', `@angular/material${tag}`, '--skip-confirmation');
 
@@ -46,10 +43,10 @@ export default async function () {
   // Ensure moment adapter works (uses unique importing mechanism for moment)
   // Issue: https://github.com/angular/angular-cli/issues/17320
   await replaceInFile(
-    'src/app/app.module.ts',
-    `import { AppComponent } from './app.component';`,
+    'src/app/app.config.ts',
+    `import { ApplicationConfig } from '@angular/core';`,
     `
-    import { AppComponent } from './app.component';
+    import { ApplicationConfig } from '@angular/core';
     import {
       MomentDateAdapter,
       MAT_MOMENT_DATE_FORMATS
@@ -63,10 +60,11 @@ export default async function () {
   );
 
   await replaceInFile(
-    'src/app/app.module.ts',
-    `providers: []`,
+    'src/app/app.config.ts',
+    `providers: [provideRouter(routes) ]`,
     `
     providers: [
+      provideRouter(routes),
       {
         provide: DateAdapter,
         useClass: MomentDateAdapter,

--- a/tests/legacy-cli/e2e/tests/commands/add/add-material.ts
+++ b/tests/legacy-cli/e2e/tests/commands/add/add-material.ts
@@ -5,9 +5,6 @@ import { ng } from '../../../utils/process';
 import { isPrereleaseCli } from '../../../utils/project';
 
 export default async function () {
-  // TODO(crisbeto): temporarily disabled until Material is updated to TS 5.2
-  return;
-
   // forcibly remove in case another test doesn't clean itself up
   await rimraf('node_modules/@angular/material');
 

--- a/tests/legacy-cli/e2e/tests/misc/invalid-schematic-dependencies.ts
+++ b/tests/legacy-cli/e2e/tests/misc/invalid-schematic-dependencies.ts
@@ -4,9 +4,6 @@ import { installPackage, uninstallPackage } from '../../utils/packages';
 import { isPrereleaseCli } from '../../utils/project';
 
 export default async function () {
-  // TODO(crisbeto): temporarily disabled until Material is updated to TS 5.2
-  return;
-
   // Must publish old version to local registry to allow install. This is especially important
   // for release commits as npm will try to request tooling packages that are not on the npm registry yet
   await publishOutdated('@schematics/angular@7');


### PR DESCRIPTION
Re-enables Material tests that had to be disabled during the TS 5.2 update.
