### PR TITLE
Allow CJS dependencies by wildcard.

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/application/tests/options/allowed-common-js-dependencies_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/tests/options/allowed-common-js-dependencies_spec.ts
@@ -179,5 +179,30 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
         }),
       );
     });
+
+    it('should not show warning when all Common JS is allowed by wildcard (*)', async () => {
+      // Add a Common JS dependency
+      await harness.appendToFile(
+        'src/app/app.component.ts',
+        `
+        import 'buffer';
+      `,
+      );
+
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        allowedCommonJsDependencies: ['*'],
+        optimization: true,
+      });
+
+      const { result, logs } = await harness.executeOnce();
+
+      expect(result?.success).toBe(true);
+      expect(logs).not.toContain(
+        jasmine.objectContaining<logging.LogEntry>({
+          message: jasmine.stringMatching(/CommonJS or AMD dependencies/),
+        }),
+      );
+    });
   });
 });

--- a/packages/angular_devkit/build_angular/src/builders/browser/tests/options/allowed-common-js-dependencies_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/tests/options/allowed-common-js-dependencies_spec.ts
@@ -126,5 +126,30 @@ describeBuilder(buildWebpackBrowser, BROWSER_BUILDER_INFO, (harness) => {
         }),
       );
     });
+
+    it('should not show warning when all Common JS is allowed by wildcard (*)', async () => {
+      // Add a Common JS dependency
+      await harness.appendToFile(
+        'src/app/app.component.ts',
+        `
+        import 'bootstrap';
+        import 'zone.js';
+      `,
+      );
+
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        allowedCommonJsDependencies: ['*'],
+      });
+
+      const { result, logs } = await harness.executeOnce();
+
+      expect(result?.success).toBe(true);
+      expect(logs).not.toContain(
+        jasmine.objectContaining<logging.LogEntry>({
+          message: jasmine.stringMatching(/CommonJS or AMD dependencies/),
+        }),
+      );
+    });
   });
 });

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/commonjs-checker.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/commonjs-checker.ts
@@ -29,7 +29,7 @@ import type { Metafile, PartialMessage } from 'esbuild';
  */
 export function checkCommonJSModules(
   metafile: Metafile,
-  allowedCommonJsDependencies?: string[],
+  allowedCommonJsDependencies?: string[]
 ): PartialMessage[] {
   const messages: PartialMessage[] = [];
   const allowedRequests = new Set(allowedCommonJsDependencies);
@@ -83,7 +83,7 @@ export function checkCommonJSModules(
         const request = imported.original;
 
         let notAllowed = true;
-        if (allowedRequests.has(request)) {
+        if (allowedRequests.has('*') || allowedRequests.has(request)) {
           notAllowed = false;
         } else {
           // Check for deep imports of allowed requests


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Not sure where to find docs sources. Perhabs we don't need to update the docs in this case. Maybe add a sentence:
"Use wildcard '*' to allow all."

## PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe:

Just a minor change to extends the option `allowedCommonJsDependencies` to allow all CJS using `*` wildcard.

## What is the current behavior?

Closes #25784

## What is the new behavior?

You can now use `*` for `allowedCommonJsDependencies` to allow all without need to add each individual dependency.
But you can use this as before. No further changes. Just be able to use `*` on list. No more, no less.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

See the ref issue. I have simular issues with that. In a large project you cannot avoid using CJS/AMD. The developers should decide if allow all instead of adding each to the list which is exhausting and in a monorepo annoying.

It's a simple addition to the code at `packages/angular_devkit/build_angular/src/tools/esbuild/commonjs-checker.ts` checking for `allowedRequests.has('*')` too.

