### PR TITLE
fix(@schematics/angular): remove `baseUrl` from `tsconfig.json`

### DIFF
--- a/packages/schematics/angular/library/index.ts
+++ b/packages/schematics/angular/library/index.ts
@@ -164,7 +164,7 @@ export default function (options: LibraryOptions): Rule {
       mergeWith(templateSource),
       addLibToWorkspaceFile(options, libDir, packageName),
       options.skipPackageJson ? noop() : addDependenciesToPackageJson(),
-      options.skipTsConfig ? noop() : updateTsConfig(packageName, distRoot),
+      options.skipTsConfig ? noop() : updateTsConfig(packageName, './' + distRoot),
       options.standalone
         ? noop()
         : schematic('module', {

--- a/packages/schematics/angular/library/index_spec.ts
+++ b/packages/schematics/angular/library/index_spec.ts
@@ -266,7 +266,7 @@ describe('Library Schematic', () => {
       const tree = await schematicRunner.runSchematic('library', defaultOptions, workspaceTree);
 
       const tsConfigJson = getJsonFileContent(tree, 'tsconfig.json');
-      expect(tsConfigJson.compilerOptions.paths['foo']).toEqual(['dist/foo']);
+      expect(tsConfigJson.compilerOptions.paths['foo']).toEqual(['./dist/foo']);
     });
 
     it(`should append to existing paths mappings`, async () => {
@@ -284,7 +284,7 @@ describe('Library Schematic', () => {
       const tree = await schematicRunner.runSchematic('library', defaultOptions, workspaceTree);
 
       const tsConfigJson = getJsonFileContent(tree, 'tsconfig.json');
-      expect(tsConfigJson.compilerOptions.paths['foo']).toEqual(['libs/*', 'dist/foo']);
+      expect(tsConfigJson.compilerOptions.paths['foo']).toEqual(['libs/*', './dist/foo']);
     });
 
     it(`should not modify the file when --skipTsConfig`, async () => {
@@ -333,7 +333,7 @@ describe('Library Schematic', () => {
     expect(cfg.projects['@myscope/mylib']).toBeDefined();
 
     const rootTsCfg = getJsonFileContent(tree, '/tsconfig.json');
-    expect(rootTsCfg.compilerOptions.paths['@myscope/mylib']).toEqual(['dist/myscope/mylib']);
+    expect(rootTsCfg.compilerOptions.paths['@myscope/mylib']).toEqual(['./dist/myscope/mylib']);
   });
 
   it(`should dasherize scoped libraries`, async () => {

--- a/packages/schematics/angular/workspace/files/tsconfig.json.template
+++ b/packages/schematics/angular/workspace/files/tsconfig.json.template
@@ -2,7 +2,6 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
-    "baseUrl": "./",
     "outDir": "./dist/out-tsc",<% if (strict) { %>
     "forceConsistentCasingInFileNames": true,
     "strict": true,

--- a/tests/legacy-cli/e2e/tests/build/library-with-demo-app.ts
+++ b/tests/legacy-cli/e2e/tests/build/library-with-demo-app.ts
@@ -17,7 +17,7 @@ export default async function () {
 
   // Scenario #1 where we use wildcard path mappings for secondary entry-points.
   await updateJsonFile('tsconfig.json', (json) => {
-    json.compilerOptions.paths = { 'mylib': ['dist/mylib'], 'mylib/*': ['dist/mylib/*'] };
+    json.compilerOptions.paths = { 'mylib': ['./dist/mylib'], 'mylib/*': ['./dist/mylib/*'] };
   });
 
   await appendToFile(
@@ -39,9 +39,9 @@ export default async function () {
   // Scenario #2 where we don't use wildcard path mappings.
   await updateJsonFile('tsconfig.json', (json) => {
     json.compilerOptions.paths = {
-      'mylib': ['dist/mylib'],
-      'mylib/secondary': ['dist/mylib/secondary'],
-      'mylib/another': ['dist/mylib/another'],
+      'mylib': ['./dist/mylib'],
+      'mylib/secondary': ['./dist/mylib/secondary'],
+      'mylib/another': ['./dist/mylib/another'],
     };
   });
 


### PR DESCRIPTION
The `baseUrl` is no longer needed since NGCC has been removed. This also enables better auto-import suggestions.

Closes #18834
