### PR TITLE
fix(@schematics/angular): account for new block syntax in starter template

### DIFF
--- a/packages/schematics/angular/application/files/common-files/src/app/app.component.html.template
+++ b/packages/schematics/angular/application/files/common-files/src/app/app.component.html.template
@@ -427,8 +427,8 @@
   <!-- Terminal -->
   <div class="terminal" [ngSwitch]="selection.value">
       <pre *ngSwitchDefault>ng generate component xyz</pre>
-      <pre *ngSwitchCase="'material'">ng add @angular/material</pre>
-      <pre *ngSwitchCase="'pwa'">ng add @angular/pwa</pre>
+      <pre *ngSwitchCase="'material'">ng add &#64;angular/material</pre>
+      <pre *ngSwitchCase="'pwa'">ng add &#64;angular/pwa</pre>
       <pre *ngSwitchCase="'dependency'">ng add _____</pre>
       <pre *ngSwitchCase="'test'">ng test</pre>
       <pre *ngSwitchCase="'build'">ng build</pre>


### PR DESCRIPTION
Fixes that the starter template would've generated a compilation error in v17 after https://github.com/angular/angular/pull/51994 is released.