### PR TITLE
feat(@angular-devkit/build-angular): support i18n with service worker and app-shell with esbuild builders

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/application/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/index.ts
@@ -43,20 +43,12 @@ export async function* buildApplicationInternal(
 
   const normalizedOptions = await normalizeOptions(context, projectName, options);
 
-  // Warn about prerender/ssr not yet supporting localize
-  if (
-    normalizedOptions.i18nOptions.shouldInline &&
-    (normalizedOptions.prerenderOptions ||
-      normalizedOptions.ssrOptions ||
-      normalizedOptions.appShellOptions)
-  ) {
+  // Warn about SSR not yet supporting localize
+  if (normalizedOptions.i18nOptions.shouldInline && normalizedOptions.ssrOptions) {
     context.logger.warn(
-      `Prerendering, App Shell, and SSR are not yet supported with the 'localize' option and will be disabled for this build.`,
+      `SSR is not yet supported with the 'localize' option and will be disabled for this build.`,
     );
-    normalizedOptions.prerenderOptions =
-      normalizedOptions.ssrOptions =
-      normalizedOptions.appShellOptions =
-        undefined;
+    normalizedOptions.ssrOptions = undefined;
   }
 
   yield* runEsBuildBuildAction(

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/i18n-inliner.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/i18n-inliner.ts
@@ -8,7 +8,7 @@
 
 import type { OutputFile } from 'esbuild';
 import Piscina from 'piscina';
-import { cloneOutputFile, createOutputFileFromData } from './utils';
+import { cloneOutputFile, createOutputFileFromText } from './utils';
 
 /**
  * A keyword used to indicate if a JavaScript file may require inlining of translations.
@@ -42,7 +42,7 @@ export class I18nInliner {
     const files = new Map<string, Blob>();
     const pendingMaps = [];
     for (const file of options.outputFiles) {
-      if (file.path.endsWith('.js')) {
+      if (file.path.endsWith('.js') || file.path.endsWith('.mjs')) {
         // Check if localizations are present
         const contentBuffer = Buffer.isBuffer(file.contents)
           ? file.contents
@@ -123,7 +123,7 @@ export class I18nInliner {
 
     // Convert raw results to output file objects and include all unmodified files
     return [
-      ...rawResults.flat().map(({ file, contents }) => createOutputFileFromData(file, contents)),
+      ...rawResults.flat().map(({ file, contents }) => createOutputFileFromText(file, contents)),
       ...this.#unmodifiedFiles.map((file) => cloneOutputFile(file)),
     ];
   }

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/utils.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/utils.ts
@@ -227,19 +227,16 @@ export function createOutputFileFromData(path: string, data: Uint8Array): Output
 }
 
 export function cloneOutputFile(file: OutputFile): OutputFile {
-  const path = file.path;
-  const data = file.contents;
-
   return {
-    path,
+    path: file.path,
     get text() {
-      return Buffer.from(data.buffer, data.byteOffset, data.byteLength).toString('utf-8');
+      return file.text;
     },
     get hash() {
-      return createHash('sha256').update(data).digest('hex');
+      return file.hash;
     },
     get contents() {
-      return data;
+      return file.contents;
     },
   };
 }


### PR DESCRIPTION
When using the esbuild-based application build system through the `application` builder, the `localize` option will now allow inlining project defined localizations when using the app shell, prerendering, and service worker features. Previously a warning was issued and these features were disabled when the `localize` option was enabled.