### PR TITLE
ci: disable auto updates for `aspect_bazel_lib`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,7 @@
   "dependencyDashboard": true,
   "schedule": ["after 10:00pm every weekday", "before 4:00am every weekday", "every weekend"],
   "baseBranches": ["main"],
-  "ignoreDeps": ["@types/node", "rules_pkg", "sass", "less-loader"],
+  "ignoreDeps": ["@types/node", "aspect_bazel_lib", "rules_pkg", "sass", "less-loader"],
   "includePaths": [
     "WORKSPACE",
     "package.json",


### PR DESCRIPTION
Updates to `aspect_bazel_lib` currently breaks the build.
