### PR TITLE
fix(@angular-devkit/build-angular): update dependency postcss to v8.4.31

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
     "picomatch": "2.3.1",
     "piscina": "4.0.0",
     "popper.js": "^1.14.1",
-    "postcss": "8.4.27",
+    "postcss": "8.4.31",
     "postcss-loader": "7.3.3",
     "prettier": "^3.0.0",
     "protractor": "~7.0.0",

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -51,7 +51,7 @@
     "parse5-html-rewriting-stream": "7.0.0",
     "picomatch": "2.3.1",
     "piscina": "4.0.0",
-    "postcss": "8.4.27",
+    "postcss": "8.4.31",
     "postcss-loader": "7.3.3",
     "resolve-url-loader": "5.0.0",
     "rxjs": "7.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10043,19 +10043,28 @@ postcss@8.4.26:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
-postcss@8.4.27, postcss@^8.4.26:
-  version "8.4.27"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.27.tgz#234d7e4b72e34ba5a92c29636734349e0d9c3057"
-  integrity sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ==
+postcss@8.4.31, postcss@^8.2.14, postcss@^8.4.16, postcss@^8.4.21, postcss@^8.4.23:
+  version "8.4.31"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.31.tgz#92b451050a9f914da6755af352bdc0192508656d"
+  integrity sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==
   dependencies:
     nanoid "^3.3.6"
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
-postcss@^8.2.14, postcss@^8.4.16, postcss@^8.4.21, postcss@^8.4.23, postcss@^8.4.25:
+postcss@^8.4.25:
   version "8.4.25"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.25.tgz#4a133f5e379eda7f61e906c3b1aaa9b81292726f"
   integrity sha512-7taJ/8t2av0Z+sQEvNzCkpDynl0tX3uJMCODi6nT3PfASC7dYCWV9aQ+uiCf+KBD4SEFcu+GvJdGdwzQ6OSjCw==
+  dependencies:
+    nanoid "^3.3.6"
+    picocolors "^1.0.0"
+    source-map-js "^1.0.2"
+
+postcss@^8.4.26:
+  version "8.4.27"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.27.tgz#234d7e4b72e34ba5a92c29636734349e0d9c3057"
+  integrity sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ==
   dependencies:
     nanoid "^3.3.6"
     picocolors "^1.0.0"


### PR DESCRIPTION
Addresses npm audit report of https://github.com/advisories/GHSA-7fh5-64p2-3v2j