### PR TITLE
fix(@angular-devkit/build-angular): update dependency postcss to v8.4.31

### DIFF
--- a/package.json
+++ b/package.json
@@ -186,7 +186,7 @@
     "pidusage": "^3.0.0",
     "piscina": "3.2.0",
     "popper.js": "^1.14.1",
-    "postcss": "8.4.21",
+    "postcss": "8.4.31",
     "postcss-loader": "7.0.2",
     "prettier": "^2.0.0",
     "protractor": "~7.0.0",

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -48,7 +48,7 @@
     "ora": "5.4.1",
     "parse5-html-rewriting-stream": "7.0.0",
     "piscina": "3.2.0",
-    "postcss": "8.4.21",
+    "postcss": "8.4.31",
     "postcss-loader": "7.0.2",
     "resolve-url-loader": "5.0.0",
     "rxjs": "6.6.7",

--- a/tests/legacy-cli/e2e/tests/misc/npm-7.ts
+++ b/tests/legacy-cli/e2e/tests/misc/npm-7.ts
@@ -36,7 +36,7 @@ export default async function () {
 
   try {
     // Install version >=7.5.6
-    await npm('install', '--global', 'npm@>=7.5.6');
+    await npm('install', '--global', 'npm@8.0.0');
 
     // Ensure `ng update` does not show npm warning
     const { stderr: stderrUpdate1 } = await ng('update', ...extraArgs);

--- a/yarn.lock
+++ b/yarn.lock
@@ -8293,6 +8293,11 @@ nanoid@^3.3.4:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.4.tgz#730b67e3cd09e2deacf03c027c81c9d9dbc5e8ab"
   integrity sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==
 
+nanoid@^3.3.6:
+  version "3.3.6"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.6.tgz#443380c856d6e9f9824267d960b4236ad583ea4c"
+  integrity sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==
+
 natural-compare-lite@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz#17b09581988979fddafe0201e931ba933c96cbb4"
@@ -9324,6 +9329,15 @@ postcss@8.4.21, postcss@^8.2.14, postcss@^8.3.7, postcss@^8.4.16, postcss@^8.4.1
   integrity sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==
   dependencies:
     nanoid "^3.3.4"
+    picocolors "^1.0.0"
+    source-map-js "^1.0.2"
+
+postcss@8.4.31:
+  version "8.4.31"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.31.tgz#92b451050a9f914da6755af352bdc0192508656d"
+  integrity sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==
+  dependencies:
+    nanoid "^3.3.6"
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 


### PR DESCRIPTION
Addresses npm audit report of GHSA-7fh5-64p2-3v2j

Closes https://github.com/angular/angular-cli/issues/25944