### PR TITLE
refactor(@angular-devkit/build-angular): remove hardcoded Node.js version in application builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/application/execute-build.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/execute-build.ts
@@ -22,6 +22,7 @@ import { generateIndexHtml } from '../../tools/esbuild/index-html-generator';
 import { extractLicenses } from '../../tools/esbuild/license-extractor';
 import {
   calculateEstimatedTransferSizes,
+  getSupportedNodeTargets,
   logBuildStats,
   logMessages,
   transformSupportedBrowsersToTargets,
@@ -114,17 +115,12 @@ export async function executeBuild(
 
     // Server application code
     if (serverEntryPoint) {
+      const nodeTargets = getSupportedNodeTargets();
       bundlerContexts.push(
         new BundlerContext(
           workspaceRoot,
           !!options.watch,
-          createServerCodeBundleOptions(
-            options,
-            // NOTE: earlier versions of Node.js are not supported due to unsafe promise patching.
-            // See: https://github.com/angular/angular/pull/50552#issue-1737967592
-            [...target, 'node18.13'],
-            codeBundleCache,
-          ),
+          createServerCodeBundleOptions(options, [...target, ...nodeTargets], codeBundleCache),
           () => false,
         ),
       );

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/utils.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/utils.ts
@@ -14,6 +14,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { promisify } from 'node:util';
 import { brotliCompress } from 'node:zlib';
+import { coerce } from 'semver';
 import { Spinner } from '../../utils/spinner';
 import { BundleStats, generateBuildStatsTable } from '../webpack/utils/stats';
 import { InitialFileRecord } from './bundler-context';
@@ -289,4 +290,19 @@ export function transformSupportedBrowsersToTargets(supportedBrowsers: string[])
   }
 
   return transformed;
+}
+
+const SUPPORTED_NODE_VERSIONS = '0.0.0-ENGINES-NODE';
+
+/**
+ * Transform supported Node.js versions to esbuild target.
+ * @see https://esbuild.github.io/api/#target
+ */
+export function getSupportedNodeTargets(): string[] {
+  if (SUPPORTED_NODE_VERSIONS.charAt(0) === '0') {
+    // Unlike `pkg_npm`, `ts_library` which is used to run unit tests does not support substitutions.
+    return [];
+  }
+
+  return SUPPORTED_NODE_VERSIONS.split('||').map((v) => 'node' + coerce(v)?.version);
 }


### PR DESCRIPTION


This commit removed the hard coded Node.js version in application builder server config and instead passes the Angular CLI supported Node.js versions that are currently stamped using Bazel.