### PR TITLE
fix(@angular-devkit/build-angular): ensure Web Worker code file is replaced in esbuild builders

### DIFF
--- a/tests/legacy-cli/e2e/tests/build/worker.ts
+++ b/tests/legacy-cli/e2e/tests/build/worker.ts
@@ -10,6 +10,7 @@ import { readdir } from 'fs/promises';
 import { expectFileToExist, expectFileToMatch, replaceInFile, writeFile } from '../../utils/fs';
 import { ng } from '../../utils/process';
 import { getGlobalVariable } from '../../utils/env';
+import { expectToFail } from '../../utils/utils';
 
 export default async function () {
   const useWebpackBuilder = !getGlobalVariable('argv')['esbuild'];
@@ -33,6 +34,9 @@ export default async function () {
     const workerOutputFile = await getWorkerOutputFile(false);
     await expectFileToExist(`dist/test-project/browser/${workerOutputFile}`);
     await expectFileToMatch('dist/test-project/browser/main.js', workerOutputFile);
+    await expectToFail(() =>
+      expectFileToMatch('dist/test-project/browser/main.js', workerOutputFile + '.map'),
+    );
   }
 
   await ng('build', '--output-hashing=none');


### PR DESCRIPTION
The previous Web Worker bundling code for the esbuild-based builders assumed that the first output file was the JavaScript code for the worker. While this is typically the case, when sourcemaps are enabled it may not be. To ensure the code file is used as the replacement path for the Worker constructor, the output files are now searched for the code file.