### PR TITLE
feat(@angular-devkit/build-angular): add initial support for bundle budgets to esbuild builders

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/application/options.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/options.ts
@@ -14,6 +14,7 @@ import {
   normalizeGlobalStyles,
 } from '../../tools/webpack/utils/helpers';
 import { normalizeAssetPatterns, normalizeOptimization, normalizeSourceMaps } from '../../utils';
+import { calculateThresholds } from '../../utils/bundle-calculator';
 import { I18nOptions, createI18nOptions } from '../../utils/i18n-options';
 import { normalizeCacheOptions } from '../../utils/normalize-cache';
 import { generateEntryPoints } from '../../utils/package-chunk-sort';
@@ -238,6 +239,7 @@ export async function normalizeOptions(
     externalPackages,
     deleteOutputPath,
     namedChunks,
+    budgets,
   } = options;
 
   // Return all the normalized options
@@ -286,6 +288,7 @@ export async function normalizeOptions(
     tailwindConfiguration,
     i18nOptions,
     namedChunks,
+    budgets: budgets?.length ? budgets : undefined,
   };
 }
 

--- a/packages/angular_devkit/build_angular/src/builders/application/tests/options/bundle-budgets_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/tests/options/bundle-budgets_spec.ts
@@ -1,0 +1,205 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { logging } from '@angular-devkit/core';
+import { lazyModuleFiles, lazyModuleFnImport } from '../../../../testing/test-utils';
+import { buildApplication } from '../../index';
+import { Type } from '../../schema';
+import { APPLICATION_BUILDER_INFO, BASE_OPTIONS, describeBuilder } from '../setup';
+
+describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
+  const CSS_EXTENSIONS = ['css', 'scss', 'less'];
+  const BUDGET_NOT_MET_REGEXP = /Budget .+ was not met by/;
+
+  describe('Option: "bundleBudgets"', () => {
+    it(`should not warn when size is below threshold`, async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        optimization: true,
+        budgets: [{ type: Type.All, maximumWarning: '100mb' }],
+      });
+
+      const { result, logs } = await harness.executeOnce();
+      expect(result?.success).toBe(true);
+      expect(logs).not.toContain(
+        jasmine.objectContaining<logging.LogEntry>({
+          level: 'warn',
+          message: jasmine.stringMatching(BUDGET_NOT_MET_REGEXP),
+        }),
+      );
+    });
+
+    it(`should error when size is above 'maximumError' threshold`, async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        optimization: true,
+        budgets: [{ type: Type.All, maximumError: '100b' }],
+      });
+
+      const { result, logs } = await harness.executeOnce();
+      expect(logs).toContain(
+        jasmine.objectContaining<logging.LogEntry>({
+          level: 'error',
+          message: jasmine.stringMatching(BUDGET_NOT_MET_REGEXP),
+        }),
+      );
+    });
+
+    it(`should warn when size is above 'maximumWarning' threshold`, async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        optimization: true,
+        budgets: [{ type: Type.All, maximumWarning: '100b' }],
+      });
+
+      const { result, logs } = await harness.executeOnce();
+      expect(result?.success).toBe(true);
+      expect(logs).toContain(
+        jasmine.objectContaining<logging.LogEntry>({
+          level: 'warn',
+          message: jasmine.stringMatching(BUDGET_NOT_MET_REGEXP),
+        }),
+      );
+    });
+
+    it(`should warn when lazy bundle is above 'maximumWarning' threshold`, async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        optimization: true,
+        budgets: [{ type: Type.Bundle, name: 'lazy-module', maximumWarning: '100b' }],
+      });
+
+      await harness.writeFiles(lazyModuleFiles);
+      await harness.writeFiles(lazyModuleFnImport);
+
+      const { result, logs } = await harness.executeOnce();
+      expect(result?.success).toBe(true);
+      expect(logs).toContain(
+        jasmine.objectContaining<logging.LogEntry>({
+          level: 'warn',
+          message: jasmine.stringMatching('lazy-module exceeded maximum budget'),
+        }),
+      );
+    });
+
+    CSS_EXTENSIONS.forEach((ext) => {
+      xit(`shows warnings for large component ${ext} when using 'anyComponentStyle' when AOT`, async () => {
+        const cssContent = `
+          .foo { color: white; padding: 1px; }
+          .buz { color: white; padding: 2px; }
+          .bar { color: white; padding: 3px; }
+        `;
+
+        await harness.writeFiles({
+          [`src/app/app.component.${ext}`]: cssContent,
+          [`src/assets/foo.${ext}`]: cssContent,
+          [`src/styles.${ext}`]: cssContent,
+        });
+
+        await harness.modifyFile('src/app/app.component.ts', (content) =>
+          content.replace('app.component.css', `app.component.${ext}`),
+        );
+
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          optimization: true,
+          aot: true,
+          styles: [`src/styles.${ext}`],
+          budgets: [{ type: Type.AnyComponentStyle, maximumWarning: '1b' }],
+        });
+
+        const { result, logs } = await harness.executeOnce();
+        expect(result?.success).toBe(true);
+        expect(logs).toContain(
+          jasmine.objectContaining<logging.LogEntry>({
+            level: 'warn',
+            message: jasmine.stringMatching(new RegExp(`Warning.+app.component.${ext}`)),
+          }),
+        );
+      });
+    });
+
+    describe(`should ignore '.map' files`, () => {
+      it(`when 'bundle' budget`, async () => {
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          sourceMap: true,
+          optimization: true,
+          extractLicenses: true,
+          budgets: [{ type: Type.Bundle, name: 'main', maximumError: '1mb' }],
+        });
+
+        const { result, logs } = await harness.executeOnce();
+        expect(result?.success).toBe(true);
+        expect(logs).not.toContain(
+          jasmine.objectContaining<logging.LogEntry>({
+            level: 'error',
+            message: jasmine.stringMatching(BUDGET_NOT_MET_REGEXP),
+          }),
+        );
+      });
+
+      it(`when 'intial' budget`, async () => {
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          sourceMap: true,
+          optimization: true,
+          extractLicenses: true,
+          budgets: [{ type: Type.Initial, name: 'main', maximumError: '1mb' }],
+        });
+
+        const { result, logs } = await harness.executeOnce();
+        expect(result?.success).toBe(true);
+        expect(logs).not.toContain(
+          jasmine.objectContaining<logging.LogEntry>({
+            level: 'error',
+            message: jasmine.stringMatching(BUDGET_NOT_MET_REGEXP),
+          }),
+        );
+      });
+
+      it(`when 'all' budget`, async () => {
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          sourceMap: true,
+          optimization: true,
+          extractLicenses: true,
+          budgets: [{ type: Type.All, maximumError: '1mb' }],
+        });
+
+        const { result, logs } = await harness.executeOnce();
+        expect(result?.success).toBe(true);
+        expect(logs).not.toContain(
+          jasmine.objectContaining<logging.LogEntry>({
+            level: 'error',
+            message: jasmine.stringMatching(BUDGET_NOT_MET_REGEXP),
+          }),
+        );
+      });
+
+      it(`when 'any' budget`, async () => {
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          sourceMap: true,
+          optimization: true,
+          extractLicenses: true,
+          budgets: [{ type: Type.Any, maximumError: '1mb' }],
+        });
+
+        const { result, logs } = await harness.executeOnce();
+        expect(result?.success).toBe(true);
+        expect(logs).not.toContain(
+          jasmine.objectContaining<logging.LogEntry>({
+            level: 'error',
+            message: jasmine.stringMatching(BUDGET_NOT_MET_REGEXP),
+          }),
+        );
+      });
+    });
+  });
+});

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/builder-status-warnings.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/builder-status-warnings.ts
@@ -10,8 +10,6 @@ import { BuilderContext } from '@angular-devkit/architect';
 import { Schema as BrowserBuilderOptions } from './schema';
 
 const UNSUPPORTED_OPTIONS: Array<keyof BrowserBuilderOptions> = [
-  'budgets',
-
   // * Deprecated
   'deployUrl',
 

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/budget-stats.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/budget-stats.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import type { Metafile } from 'esbuild';
+import { basename } from 'node:path';
+import type { BudgetStats } from '../../utils/bundle-calculator';
+import type { InitialFileRecord } from './bundler-context';
+
+/**
+ * Generates a bundle budget calculator compatible stats object that provides
+ * the necessary information for the Webpack-based bundle budget code to
+ * interoperate with the esbuild-based builders.
+ * @param metafile The esbuild metafile of a build to use.
+ * @param initialFiles The records of all initial files of a build.
+ * @returns A bundle budget compatible stats object.
+ */
+export function generateBudgetStats(
+  metafile: Metafile,
+  initialFiles: Map<string, InitialFileRecord>,
+): BudgetStats {
+  const stats: Required<BudgetStats> = {
+    chunks: [],
+    assets: [],
+  };
+
+  for (const [file, entry] of Object.entries(metafile.outputs)) {
+    if (!file.endsWith('.js') && !file.endsWith('.css')) {
+      continue;
+    }
+
+    const initialRecord = initialFiles.get(file);
+    let name = initialRecord?.name;
+    if (name === undefined && entry.entryPoint) {
+      // For non-initial lazy modules, convert the entry point file into a Webpack compatible name
+      name = basename(entry.entryPoint)
+        .replace(/\.[cm]?[jt]s$/, '')
+        .replace(/[\\/.]/g, '-');
+    }
+
+    stats.chunks.push({
+      files: [file],
+      initial: !!initialRecord,
+      names: name ? [name] : undefined,
+    });
+    stats.assets.push({ name: file, size: entry.bytes });
+  }
+
+  return stats;
+}


### PR DESCRIPTION
The bundle budget functionality (`budgets` option) is not available when using the esbuild-based builders (`browser-esbuild`/`application`). The existing option format from the Webpack-based builder can continue to be used. All budget types except `anyComponentStyle` are implemented. Any usage of the `anyComponentStyle` type will be ignored when calculating budget failures. This type will be implemented in a future change.