### PR TITLE
perf(@angular-devkit/build-angular): only perform a server build when either prerendering, app-shell or ssr is enabled

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/application/execute-build.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/execute-build.ts
@@ -114,7 +114,8 @@ export async function executeBuild(
     }
 
     // Server application code
-    if (serverEntryPoint) {
+    // Skip server build when non of the features are enabled.
+    if (serverEntryPoint && (prerenderOptions || appShellOptions || ssrOptions)) {
       const nodeTargets = getSupportedNodeTargets();
       bundlerContexts.push(
         new BundlerContext(

--- a/packages/angular_devkit/build_angular/src/builders/application/tests/options/server_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/tests/options/server_spec.ts
@@ -24,6 +24,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
     it('uses a provided TypeScript file', async () => {
       harness.useTarget('build', {
         ...BASE_OPTIONS,
+        ssr: true,
         server: 'src/main.server.ts',
       });
 
@@ -36,6 +37,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
     it('does not write file to disk when "ssr" is "false"', async () => {
       harness.useTarget('build', {
         ...BASE_OPTIONS,
+        ssr: true,
         server: 'src/main.server.ts',
       });
 
@@ -50,6 +52,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
 
       harness.useTarget('build', {
         ...BASE_OPTIONS,
+        ssr: true,
         server: 'src/server.js',
       });
 
@@ -60,6 +63,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
     it('fails and shows an error when file does not exist', async () => {
       harness.useTarget('build', {
         ...BASE_OPTIONS,
+        ssr: true,
         server: 'src/missing.ts',
       });
 
@@ -91,6 +95,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
 
       harness.useTarget('build', {
         ...BASE_OPTIONS,
+        ssr: true,
         server: '/file.mjs',
       });
 


### PR DESCRIPTION


Prior to this change, a server build was performed when all the "server" features were disabled but the `server` fields was specified.
