### PR TITLE
fix(@angular-devkit/build-angular): avoid dev-server proxy rewrite normalization when invalid value

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/dev-server/load-proxy-config.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/load-proxy-config.ts
@@ -138,6 +138,7 @@ function normalizeProxyConfiguration(
   // Replace `pathRewrite` field with a `rewrite` function
   for (const proxyEntry of Object.values(normalizedProxy)) {
     if (
+      typeof proxyEntry === 'object' &&
       'pathRewrite' in proxyEntry &&
       proxyEntry.pathRewrite &&
       typeof proxyEntry.pathRewrite === 'object'


### PR DESCRIPTION
When normalizing the proxy configuration for the Vite-based development server, the `pathRewrite` logic will now be skipped if the proxy entry is not an object and therefore invalid. This situation can occur if the proxy configuration JSON contains invalid properties.

Closes #25978