### PR TITLE
refactor: add warning when using `browser-esbuild`

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/builder-status-warnings.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/builder-status-warnings.ts
@@ -21,7 +21,15 @@ const UNSUPPORTED_OPTIONS: Array<keyof BrowserBuilderOptions> = [
   'webWorkerTsConfig',
 ];
 
-export function logBuilderStatusWarnings(options: BrowserBuilderOptions, context: BuilderContext) {
+export function logBuilderStatusWarnings(
+  options: BrowserBuilderOptions,
+  { logger }: BuilderContext,
+) {
+  logger.warn(
+    `The 'browser-esbuild' builder is a compatibility builder which will be removed in a future major ` +
+      `version in favor of the 'application' builder.`,
+  );
+
   // Validate supported options
   for (const unsupportedOption of UNSUPPORTED_OPTIONS) {
     const value = (options as unknown as BrowserBuilderOptions)[unsupportedOption];
@@ -41,12 +49,12 @@ export function logBuilderStatusWarnings(options: BrowserBuilderOptions, context
       unsupportedOption === 'resourcesOutputPath' ||
       unsupportedOption === 'deployUrl'
     ) {
-      context.logger.warn(
+      logger.warn(
         `The '${unsupportedOption}' option is not used by this builder and will be ignored.`,
       );
       continue;
     }
 
-    context.logger.warn(`The '${unsupportedOption}' option is not yet supported by this builder.`);
+    logger.warn(`The '${unsupportedOption}' option is not yet supported by this builder.`);
   }
 }

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
@@ -24,6 +24,7 @@ import { createAngularLocaleDataPlugin } from '../../tools/vite/i18n-locale-plug
 import { RenderOptions, renderPage } from '../../utils/server-rendering/render-page';
 import { getSupportedBrowsers } from '../../utils/supported-browsers';
 import { getIndexOutputFile } from '../../utils/webpack-browser-config';
+import { buildApplicationInternal } from '../application';
 import { buildEsbuildBrowser } from '../browser-esbuild';
 import { Schema as BrowserBuilderOptions } from '../browser-esbuild/schema';
 import { loadProxyConfiguration } from './load-proxy-config';
@@ -116,9 +117,15 @@ export async function* serveWithVite(
   let listeningAddress: AddressInfo | undefined;
   const generatedFiles = new Map<string, OutputFileRecord>();
   const assetFiles = new Map<string, string>();
+  const build =
+    builderName === '@angular-devkit/build-angular:application'
+      ? buildApplicationInternal
+      : buildEsbuildBrowser;
+
   // TODO: Switch this to an architect schedule call when infrastructure settings are supported
-  for await (const result of buildEsbuildBrowser(
-    browserOptions,
+  for await (const result of build(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    browserOptions as any,
     context,
     {
       write: false,


### PR DESCRIPTION
This commits add a warning when using the browser-esbuild builder which eventually will be removed in favor of the `application` builder.
