### PR TITLE
fix(@angular-devkit/build-angular): ensure unique internal identifiers for inline stylesheet bundling

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/esbuild/angular/component-stylesheets.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/angular/component-stylesheets.ts
@@ -64,11 +64,10 @@ export class ComponentStylesheetBundler {
     // to the actual stylesheet file path.
     // TODO: Consider xxhash instead for hashing
     const id = createHash('sha256').update(data).digest('hex');
+    const entry = [language, id, filename].join(';');
 
-    const bundlerContext = this.#inlineContexts.getOrCreate(id, () => {
+    const bundlerContext = this.#inlineContexts.getOrCreate(entry, () => {
       const namespace = 'angular:styles/component';
-      const entry = [language, id, filename].join(';');
-
       const buildOptions = createStylesheetBundleOptions(this.options, this.cache, {
         [entry]: data,
       });


### PR DESCRIPTION
Within the application builder's template stylesheet processing, internal identifiers are used to track the incremental bundling status of each inline stylesheet. This identifier now consists of the stylesheet language, data, and containing file. This ensures that a tracking entry is maintained for each inline stylesheet and allows for the full cleanup and any incremental bundling resources at the end of the build.