### PR TITLE
test: ensure to use the correct version for `@angular/ssr` packages

### DIFF
--- a/packages/schematics/angular/migrations/update-17/replace-nguniversal-engines.ts
+++ b/packages/schematics/angular/migrations/update-17/replace-nguniversal-engines.ts
@@ -90,7 +90,7 @@ export default function (): Rule {
       removePackageJsonDependency(tree, '@nguniversal/express-engine');
       removePackageJsonDependency(tree, '@nguniversal/common');
     },
-    addDependency('@angular/ssr', latestVersions.Angular),
+    addDependency('@angular/ssr', latestVersions.AngularSSR),
   ]);
 }
 

--- a/packages/schematics/angular/ssr/index.ts
+++ b/packages/schematics/angular/ssr/index.ts
@@ -207,7 +207,7 @@ function updateWebpackBuilderServerTsConfigRule(options: SSROptions): Rule {
 
 function addDependencies(): Rule {
   return chain([
-    addDependency('@angular/ssr', '^0.0.0-PLACEHOLDER', {
+    addDependency('@angular/ssr', latestVersions.AngularSSR, {
       type: DependencyType.Default,
     }),
     addDependency('express', latestVersions['express'], {

--- a/packages/schematics/angular/utility/latest-versions.ts
+++ b/packages/schematics/angular/utility/latest-versions.ts
@@ -9,6 +9,7 @@
 export const latestVersions: Record<string, string> & {
   Angular: string;
   DevkitBuildAngular: string;
+  AngularSSR: string;
 } = {
   // We could have used TypeScripts' `resolveJsonModule` to make the `latestVersion` object typesafe,
   // but ts_library doesn't support JSON inputs.
@@ -17,8 +18,6 @@ export const latestVersions: Record<string, string> & {
   // As Angular CLI works with same minor versions of Angular Framework, a tilde match for the current
   Angular: '^17.0.0-next.0',
 
-  // Since @angular-devkit/build-angular and @schematics/angular are always
-  // published together from the same monorepo, and they are both
-  // non-experimental, they will always have the same version.
-  DevkitBuildAngular: '^' + require('../package.json')['version'],
+  DevkitBuildAngular: '^0.0.0-PLACEHOLDER',
+  AngularSSR: '^0.0.0-PLACEHOLDER',
 };


### PR DESCRIPTION
This commit fixes an issue that causes update tests to fail when we are in feature freeze
