### PR TITLE
refactor(@angular-devkit/build-angular): bundle polyfills independent of main code in application builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/application/execute-build.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/execute-build.ts
@@ -10,6 +10,7 @@ import { BuilderContext } from '@angular-devkit/architect';
 import { SourceFileCache } from '../../tools/esbuild/angular/source-file-cache';
 import {
   createBrowserCodeBundleOptions,
+  createBrowserPolyfillBundleOptions,
   createServerCodeBundleOptions,
 } from '../../tools/esbuild/application-code-bundle';
 import { generateBudgetStats } from '../../tools/esbuild/budget-stats';
@@ -80,6 +81,18 @@ export async function executeBuild(
       ),
     );
 
+    // Browser polyfills code
+    const polyfillBundleOptions = createBrowserPolyfillBundleOptions(
+      options,
+      target,
+      codeBundleCache,
+    );
+    if (polyfillBundleOptions) {
+      bundlerContexts.push(
+        new BundlerContext(workspaceRoot, !!options.watch, polyfillBundleOptions),
+      );
+    }
+
     // Global Stylesheets
     if (options.globalStyles.length > 0) {
       for (const initial of [true, false]) {
@@ -110,7 +123,7 @@ export async function executeBuild(
     }
 
     // Server application code
-    // Skip server build when non of the features are enabled.
+    // Skip server build when none of the features are enabled.
     if (serverEntryPoint && (prerenderOptions || appShellOptions || ssrOptions)) {
       const nodeTargets = getSupportedNodeTargets();
       bundlerContexts.push(


### PR DESCRIPTION
Any provided or required polyfills (the later mainly related to i18n) will now be bundled in a separate concurrent bundling action. This has several benefits including allowing different bundling options for the polyfills and minimizing rebundling of polyfills (which rarely change) in watch/serve mode. Along with this change, the polyfill bundling options have been adjusted to not externalize packages when in development server mode. This allows the zone.js globals to be more easily used as well as minimizing the need for Vite to process a typically unchanging output file.