### PR TITLE
fix(@angular-devkit/build-angular): ensure i18n locale data is included in SSR application builds

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/esbuild/application-code-bundle.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/application-code-bundle.ts
@@ -308,6 +308,23 @@ export function createServerCodeBundleOptions(
 
   polyfills.push(`import '@angular/platform-server/init';`);
 
+  // Add Angular's global locale data if i18n options are present.
+  let needLocaleDataPlugin = false;
+  if (options.i18nOptions.shouldInline) {
+    // Add locale data for all active locales
+    for (const locale of options.i18nOptions.inlineLocales) {
+      polyfills.unshift(`import 'angular:locale/data:${locale}';`);
+    }
+    needLocaleDataPlugin = true;
+  } else if (options.i18nOptions.hasDefinedSourceLocale) {
+    // When not inlining and a source local is present, use the source locale data directly
+    polyfills.unshift(`import 'angular:locale/data:${options.i18nOptions.sourceLocale}';`);
+    needLocaleDataPlugin = true;
+  }
+  if (needLocaleDataPlugin) {
+    buildOptions.plugins.push(createAngularLocaleDataPlugin());
+  }
+
   buildOptions.plugins.push(
     createVirtualModulePlugin({
       namespace: mainServerNamespace,


### PR DESCRIPTION
When using the application builder to create server builds for SSR and/or prerendering with localization enabled, the locale data for each enabled locale is now properly included in the server output files. While browser builds contain this data in the polyfills output file, the server builds do not contain a polyfill output file, as a result, the locale data is added to the main server code instead. This is also the case for other polyfill-like code including zone.js.