### PR TITLE
fix(@angular-devkit/build-angular): use incremental component style bundling only in watch mode

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/esbuild/angular/compiler-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/angular/compiler-plugin.ts
@@ -47,6 +47,7 @@ export interface CompilerPluginOptions {
   fileReplacements?: Record<string, string>;
   sourceFileCache?: SourceFileCache;
   loadResultCache?: LoadResultCache;
+  incremental: boolean;
 }
 
 // eslint-disable-next-line max-lines-per-function
@@ -100,6 +101,7 @@ export function createCompilerPlugin(
       // Track incremental component stylesheet builds
       const stylesheetBundler = new ComponentStylesheetBundler(
         styleOptions,
+        pluginOptions.incremental,
         pluginOptions.loadResultCache,
       );
       let sharedTSCompilationState: SharedTSCompilationState | undefined;

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/angular/component-stylesheets.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/angular/component-stylesheets.ts
@@ -45,6 +45,7 @@ export class ComponentStylesheetBundler {
    */
   constructor(
     private readonly options: BundleStylesheetOptions,
+    private readonly incremental: boolean,
     private readonly cache?: LoadResultCache,
   ) {}
 
@@ -53,7 +54,7 @@ export class ComponentStylesheetBundler {
       const buildOptions = createStylesheetBundleOptions(this.options, this.cache);
       buildOptions.entryPoints = [entry];
 
-      return new BundlerContext(this.options.workspaceRoot, true, buildOptions);
+      return new BundlerContext(this.options.workspaceRoot, this.incremental, buildOptions);
     });
 
     return extractResult(await bundlerContext.bundle(), bundlerContext.watchFiles);
@@ -95,7 +96,7 @@ export class ComponentStylesheetBundler {
         },
       });
 
-      return new BundlerContext(this.options.workspaceRoot, true, buildOptions);
+      return new BundlerContext(this.options.workspaceRoot, this.incremental, buildOptions);
     });
 
     // Extract the result of the bundling from the output files

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/compiler-plugin-options.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/compiler-plugin-options.ts
@@ -47,6 +47,7 @@ export function createCompilerPluginOptions(
       fileReplacements,
       sourceFileCache,
       loadResultCache: sourceFileCache?.loadResultCache,
+      incremental: !!options.watch,
     },
     // Component stylesheet options
     styleOptions: {


### PR DESCRIPTION
Component style bundling when using the application builder will now only generate incremental contexts when in watch mode. During non-watch build, this incremental context information is not needed and unnecessarily increases memory usage during a build.