### PR TITLE
refactor(@angular-devkit/architect): remove unneeded internal job input/output schema validation

### DIFF
--- a/packages/angular_devkit/architect/src/architect.ts
+++ b/packages/angular_devkit/architect/src/architect.ts
@@ -48,7 +48,6 @@ import {
 import { scheduleByName, scheduleByTarget } from './schedule-by-name';
 
 const inputSchema = require('./input-schema.json');
-const outputSchema = require('./output-schema.json');
 
 function _createJobHandlerFromBuilderInfo(
   info: BuilderInfo,
@@ -60,8 +59,8 @@ function _createJobHandlerFromBuilderInfo(
   const jobDescription: BuilderDescription = {
     name: target ? `{${targetStringFromTarget(target)}}` : info.builderName,
     argument: { type: 'object' },
-    input: inputSchema,
-    output: outputSchema,
+    input: true,
+    output: true,
     info,
   };
 


### PR DESCRIPTION
The internal job input and output value JSON schema-based validation has been removed for architect builder jobs. This validation was checking the internal architect jobs. However, these jobs and values are created by the internal implementation of architect and not by a builder's implementation. Actual builder option validation is unrelated to the validation change here. The JSON schema-based validation can be expensive and involves additional rxjs operator interaction within architect. Larger output results from a builder can be delayed significantly in some cases due to this unneeded validation.
