### PR TITLE
feat(@angular-devkit/build-angular): add wildcard option for `allowedCommonJsDependencies`

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/application/schema.json
+++ b/packages/angular_devkit/build_angular/src/builders/application/schema.json
@@ -406,7 +406,7 @@
       "enum": ["none", "anonymous", "use-credentials"]
     },
     "allowedCommonJsDependencies": {
-      "description": "A list of CommonJS packages that are allowed to be used without a build time warning.",
+      "description": "A list of CommonJS or AMD packages that are allowed to be used without a build time warning. Use `'*'` to allow all.",
       "type": "array",
       "items": {
         "type": "string"

--- a/packages/angular_devkit/build_angular/src/builders/application/tests/options/allowed-common-js-dependencies_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/tests/options/allowed-common-js-dependencies_spec.ts
@@ -77,6 +77,31 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
       );
     });
 
+    it('should not show warning when all dependencies are allowed by wildcard', async () => {
+      // Add a Common JS dependency
+      await harness.appendToFile(
+        'src/app/app.component.ts',
+        `
+        import 'buffer';
+      `,
+      );
+
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        allowedCommonJsDependencies: ['*'],
+        optimization: true,
+      });
+
+      const { result, logs } = await harness.executeOnce();
+
+      expect(result?.success).toBe(true);
+      expect(logs).not.toContain(
+        jasmine.objectContaining<logging.LogEntry>({
+          message: jasmine.stringMatching(/CommonJS or AMD dependencies/),
+        }),
+      );
+    });
+
     it('should not show warning when depending on zone.js', async () => {
       // Add a Common JS dependency
       await harness.appendToFile(

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/schema.json
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/schema.json
@@ -429,7 +429,7 @@
       "enum": ["none", "anonymous", "use-credentials"]
     },
     "allowedCommonJsDependencies": {
-      "description": "A list of CommonJS packages that are allowed to be used without a build time warning.",
+      "description": "A list of CommonJS or AMD packages that are allowed to be used without a build time warning. Use `'*'` to allow all.",
       "type": "array",
       "items": {
         "type": "string"

--- a/packages/angular_devkit/build_angular/src/builders/browser/schema.json
+++ b/packages/angular_devkit/build_angular/src/builders/browser/schema.json
@@ -417,7 +417,7 @@
       "enum": ["none", "anonymous", "use-credentials"]
     },
     "allowedCommonJsDependencies": {
-      "description": "A list of CommonJS packages that are allowed to be used without a build time warning.",
+      "description": "A list of CommonJS or AMD packages that are allowed to be used without a build time warning. Use `'*'` to allow all.",
       "type": "array",
       "items": {
         "type": "string"

--- a/packages/angular_devkit/build_angular/src/builders/browser/tests/options/allowed-common-js-dependencies_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/tests/options/allowed-common-js-dependencies_spec.ts
@@ -71,6 +71,31 @@ describeBuilder(buildWebpackBrowser, BROWSER_BUILDER_INFO, (harness) => {
       );
     });
 
+    it('should not show warning when all dependencies are allowed by wildcard', async () => {
+      // Add a Common JS dependency
+      await harness.appendToFile(
+        'src/app/app.component.ts',
+        `
+        import 'bootstrap';
+        import 'zone.js';
+      `,
+      );
+
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        allowedCommonJsDependencies: ['*'],
+      });
+
+      const { result, logs } = await harness.executeOnce();
+
+      expect(result?.success).toBe(true);
+      expect(logs).not.toContain(
+        jasmine.objectContaining<logging.LogEntry>({
+          message: jasmine.stringMatching(/CommonJS or AMD dependencies/),
+        }),
+      );
+    });
+
     it(`should not show warning when importing non global local data '@angular/common/locale/fr'`, async () => {
       await harness.appendToFile(
         'src/app/app.component.ts',

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/commonjs-checker.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/commonjs-checker.ts
@@ -17,7 +17,7 @@ import type { Metafile, PartialMessage } from 'esbuild';
  *
  * If any allowed dependencies are provided via the `allowedCommonJsDependencies`
  * parameter, both the direct import and any deep imports will be ignored and no
- * diagnostic will be generated.
+ * diagnostic will be generated. Use `'*'` as entry to skip the check.
  *
  * If a module has been issued a diagnostic message, then all descendant modules
  * will not be checked. This prevents a potential massive amount of inactionable
@@ -33,6 +33,10 @@ export function checkCommonJSModules(
 ): PartialMessage[] {
   const messages: PartialMessage[] = [];
   const allowedRequests = new Set(allowedCommonJsDependencies);
+
+  if (allowedRequests.has('*')) {
+    return messages;
+  }
 
   // Ignore Angular locale definitions which are currently UMD
   allowedRequests.add('@angular/common/locales');

--- a/packages/angular_devkit/build_angular/src/tools/webpack/plugins/common-js-usage-warn-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/plugins/common-js-usage-warn-plugin.ts
@@ -17,7 +17,7 @@ const CommonJsRequireDependency = require('webpack/lib/dependencies/CommonJsRequ
 const CommonJsSelfReferenceDependency = require('webpack/lib/dependencies/CommonJsSelfReferenceDependency');
 
 export interface CommonJsUsageWarnPluginOptions {
-  /** A list of CommonJS packages that are allowed to be used without a warning. */
+  /** A list of CommonJS or AMD packages that are allowed to be used without a warning. Use `'*'` to allow all. */
   allowedDependencies?: string[];
 }
 
@@ -30,6 +30,10 @@ export class CommonJsUsageWarnPlugin {
   }
 
   apply(compiler: Compiler) {
+    if (this.allowedDependencies.has('*')) {
+      return;
+    }
+
     compiler.hooks.compilation.tap('CommonJsUsageWarnPlugin', (compilation) => {
       compilation.hooks.finishModules.tap('CommonJsUsageWarnPlugin', (modules) => {
         const mainEntry = compilation.entries.get('main');


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)

## PR Type

- [x] Feature

## What is the current behavior?

The `allowedCommonJsDependencies` property suppresses warnings if CJS/AMD modules are used.
The developer can then search for alternative dependencies or expand this list. 
If there are many affected dependencies that the developer needs to use without alternatives, it’s a lot of effort to constantly maintain this list. It would be helpful if there is an option to allow all dependencies…

Closes #25784

## What is the new behavior?

The current behavior remains unchanged, but gives developers the option to allow all CJS/AMD dependencies by using asterisk (`*`) as entry in `allowedCommonJsDependencies` .

## Does this PR introduce a breaking change?

- [x] No

