### PR TITLE
fix(@angular-devkit/build-angular): process nested tailwind usage in application builder

### DIFF
--- a/tests/legacy-cli/e2e/tests/build/styles/tailwind-v3.ts
+++ b/tests/legacy-cli/e2e/tests/build/styles/tailwind-v3.ts
@@ -55,6 +55,29 @@ export default async function () {
     ),
   );
 
+  // Add Tailwind directives to an imported global style
+  await writeFile('src/tailwind.scss', '@tailwind base; @tailwind components;');
+  await writeFile('src/styles.css', '@import "./tailwind.scss";');
+
+  // Build should succeed and process Tailwind directives
+  await ng('build', '--configuration=development');
+
+  // Check for Tailwind output
+  await expectFileToMatch('dist/test-project/browser/styles.css', /::placeholder/);
+  await expectFileToMatch('dist/test-project/browser/main.js', /::placeholder/);
+  await expectToFail(() =>
+    expectFileToMatch(
+      'dist/test-project/browser/styles.css',
+      /@tailwind base;\s+@tailwind components;/,
+    ),
+  );
+  await expectToFail(() =>
+    expectFileToMatch(
+      'dist/test-project/browser/main.js',
+      /@tailwind base;(?:\\n|\s*)@tailwind components;/,
+    ),
+  );
+
   // Remove configuration file
   await deleteFile('tailwind.config.js');
 


### PR DESCRIPTION
When using the application builder with Tailwind directives not in a directly referenced Sass stylesheet, the Tailwind process was previously skipped. To avoid this problem, the Tailwind keyword checks are now performed on the result of any stylesheet language processing which will contain all the used stylesheet content.

Closes #26044