### PR TITLE
build: add diagnose return type annotation for windows bazel builds

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/esbuild/angular/compilation/parallel-worker.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/angular/compilation/parallel-worker.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import type { PartialMessage } from 'esbuild';
 import assert from 'node:assert';
 import { randomUUID } from 'node:crypto';
 import { type MessagePort, receiveMessageOnPort } from 'node:worker_threads';
@@ -98,7 +99,10 @@ export async function initialize(request: InitRequest) {
   };
 }
 
-export async function diagnose() {
+export async function diagnose(): Promise<{
+  errors?: PartialMessage[];
+  warnings?: PartialMessage[];
+}> {
   assert(compilation);
 
   const diagnostics = await compilation.diagnoseFiles();


### PR DESCRIPTION
Due to the Windows Bazel directory structure, TypeScript can not safely infer the return type of the `diagnose` function in the parallel worker module. The return type should ideally be explicit regardless and so a return type is now provided for the function.
