### PR TITLE
fix(@angular-devkit/build-angular): avoid repeat error clear in vite development server

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
@@ -151,6 +151,7 @@ export async function* serveWithVite(
       }
       continue;
     } else if (hadError && server) {
+      hadError = false;
       // Send an empty update to clear the error overlay
       server.ws.send({
         'type': 'update',


### PR DESCRIPTION
In the Vite-based development server, an error overlay is requested if a build encounters an error. This error is then cleared when the error is corrected. However, the flag indicating that the error was cleared was not previously reset. This resulted in additional empty update commands being sent to the Vite client. While this has no visual effect, it is unneeded additional processing.