### PR TITLE
fix(@angular-devkit/build-angular): update `ssr` option definition

### DIFF
--- a/goldens/public-api/angular_devkit/build_angular/index.md
+++ b/goldens/public-api/angular_devkit/build_angular/index.md
@@ -47,7 +47,7 @@ export interface ApplicationBuilderOptions {
     server?: string;
     serviceWorker?: ServiceWorker_2;
     sourceMap?: SourceMapUnion_2;
-    ssr?: ServiceWorker_2;
+    ssr?: SsrUnion;
     statsJson?: boolean;
     stylePreprocessorOptions?: StylePreprocessorOptions_2;
     styles?: StyleElement_2[];

--- a/packages/angular_devkit/build_angular/src/builders/application/options.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/options.ts
@@ -210,9 +210,11 @@ export async function normalizeOptions(
   let ssrOptions;
   if (options.ssr === true) {
     ssrOptions = {};
-  } else if (typeof options.ssr === 'string') {
+  } else if (typeof options.ssr === 'object') {
+    const { entry } = options.ssr;
+
     ssrOptions = {
-      entry: path.join(workspaceRoot, options.ssr),
+      entry: entry && path.join(workspaceRoot, entry),
     };
   }
 

--- a/packages/angular_devkit/build_angular/src/builders/application/schema.json
+++ b/packages/angular_devkit/build_angular/src/builders/application/schema.json
@@ -447,8 +447,14 @@
           "description": "Enable the server bundles to be written to disk."
         },
         {
-          "type": "string",
-          "description": "The server entry-point that when executed will spawn the web server."
+          "type": "object",
+          "properties": {
+            "entry": {
+              "type": "string",
+              "description": "The server entry-point that when executed will spawn the web server."
+            }
+          },
+          "additionalProperties": false
         }
       ]
     },

--- a/packages/angular_devkit/build_angular/src/builders/application/tests/options/ssr_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/tests/options/ssr_spec.ts
@@ -27,7 +27,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
       harness.useTarget('build', {
         ...BASE_OPTIONS,
         server: 'src/main.server.ts',
-        ssr: 'src/server.ts',
+        ssr: { entry: 'src/server.ts' },
       });
 
       const { result } = await harness.executeOnce();
@@ -43,7 +43,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
       harness.useTarget('build', {
         ...BASE_OPTIONS,
         server: 'src/main.server.ts',
-        ssr: '/file.mjs',
+        ssr: { entry: '/file.mjs' },
       });
 
       const { result } = await harness.executeOnce();

--- a/packages/schematics/angular/ssr/index.ts
+++ b/packages/schematics/angular/ssr/index.ts
@@ -116,7 +116,9 @@ function updateApplicationBuilderWorkspaceConfigRule(
     buildTarget.options = {
       ...buildTarget.options,
       prerender: true,
-      ssr: join(normalize(projectRoot), 'server.ts'),
+      ssr: {
+        entry: join(normalize(projectRoot), 'server.ts'),
+      },
     };
   });
 }


### PR DESCRIPTION
This commits updates the `ssr` application builder option definition. The main change is that now the option does not accept the entry-point as a value. Instead it should be passed in the `entry` suboption.

Example
```json
"ssr": {
    "entry": "server.ts"
}
```

This change in this option is important to allow us in the future to add additional sub options. Like potentially a `platform` or `target`.
