### PR TITLE
fix(@schematics/angular): noop workspace config migration when already executed

### DIFF
--- a/packages/schematics/angular/migrations/update-17/update-workspace-config.ts
+++ b/packages/schematics/angular/migrations/update-17/update-workspace-config.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { Rule, chain } from '@angular-devkit/schematics';
-import { removePackageJsonDependency } from '../../utility/dependencies';
+import { Rule } from '@angular-devkit/schematics';
 import { allTargetOptions, updateWorkspace } from '../../utility/workspace';
 import { Builders, ProjectType } from '../../utility/workspace-models';
 
@@ -22,8 +21,10 @@ export default function (): Rule {
       for (const [, target] of project.targets) {
         if (target.builder === Builders.ExtractI18n || target.builder === Builders.DevServer) {
           for (const [, options] of allTargetOptions(target, false)) {
-            options['buildTarget'] = options['browserTarget'];
-            delete options['browserTarget'];
+            if (options['browserTarget'] !== undefined) {
+              options['buildTarget'] = options['browserTarget'];
+              delete options['browserTarget'];
+            }
           }
         }
       }

--- a/packages/schematics/angular/migrations/update-17/update-workspace-config_spec.ts
+++ b/packages/schematics/angular/migrations/update-17/update-workspace-config_spec.ts
@@ -109,4 +109,27 @@ describe(`Migration to update 'angular.json'.`, () => {
     expect(browserTarget).toBe('app:build');
     expect(buildTarget).toBeUndefined();
   });
+
+  it(`should not remove 'buildTarget' when migration is ran multiple times`, async () => {
+    const runMigrationAndExpects = async (testTree: UnitTestTree) => {
+      const newTree = await schematicRunner.runSchematic(schematicName, {}, testTree);
+      const {
+        projects: { app },
+      } = JSON.parse(newTree.readContent('/angular.json'));
+
+      const { browserTarget, buildTarget } = app.architect['serve'].options;
+      expect(browserTarget).toBeUndefined();
+      expect(buildTarget).toBe('app:build:development');
+
+      const { browserTarget: browserTargetProd, buildTarget: buildTargetProd } =
+        app.architect['serve'].configurations['production'];
+      expect(browserTargetProd).toBeUndefined();
+      expect(buildTargetProd).toBe('app:build:production');
+
+      return newTree;
+    };
+
+    const newTree = await runMigrationAndExpects(tree);
+    await runMigrationAndExpects(newTree);
+  });
 });


### PR DESCRIPTION


Prior to this change there was a missing check that causes the migration to remove valid config when it was executed multiple times or on configs that do not contain the deprecated option.

Closes #26063
