### PR TITLE
     perf(@angular-devkit/build-angular): cache polyfills virtual module result

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/esbuild/application-code-bundle.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/application-code-bundle.ts
@@ -76,7 +76,12 @@ export function createBrowserPolyfillBundleOptions(
   sourceFileCache?: SourceFileCache,
 ): BuildOptions | undefined {
   const namespace = 'angular:polyfills';
-  const polyfillBundleOptions = getEsBuildCommonPolyfillsOptions(options, namespace, true);
+  const polyfillBundleOptions = getEsBuildCommonPolyfillsOptions(
+    options,
+    namespace,
+    true,
+    sourceFileCache,
+  );
   if (!polyfillBundleOptions) {
     return;
   }
@@ -155,7 +160,7 @@ export function createServerCodeBundleOptions(
 
   const ssrEntryPoint = ssrOptions?.entry;
   if (ssrEntryPoint) {
-    entryPoints['server'] = ssrOptions?.entry;
+    entryPoints['server'] = ssrEntryPoint;
   }
 
   const buildOptions: BuildOptions = {
@@ -196,6 +201,7 @@ export function createServerCodeBundleOptions(
   buildOptions.plugins.push(
     createVirtualModulePlugin({
       namespace: mainServerNamespace,
+      cache: sourceFileCache?.loadResultCache,
       loadContent: async () => {
         const contents: string[] = [
           `export { ɵConsole } from '@angular/core';`,
@@ -265,6 +271,7 @@ export function createServerPolyfillBundleOptions(
     },
     namespace,
     false,
+    sourceFileCache,
   );
 
   if (!polyfillBundleOptions) {
@@ -394,6 +401,7 @@ function getEsBuildCommonPolyfillsOptions(
   options: NormalizedApplicationBuildOptions,
   namespace: string,
   tryToResolvePolyfillsAsRelative: boolean,
+  sourceFileCache: SourceFileCache | undefined,
 ): BuildOptions | undefined {
   const { jit, workspaceRoot, i18nOptions } = options;
   const buildOptions: BuildOptions = {
@@ -449,6 +457,7 @@ function getEsBuildCommonPolyfillsOptions(
   buildOptions.plugins?.push(
     createVirtualModulePlugin({
       namespace,
+      cache: sourceFileCache?.loadResultCache,
       loadContent: async (_, build) => {
         let hasLocalizePolyfill = false;
         let polyfillPaths = polyfills;

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/virtual-module-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/virtual-module-plugin.ts
@@ -7,6 +7,7 @@
  */
 
 import type { OnLoadArgs, Plugin, PluginBuild } from 'esbuild';
+import { LoadResultCache, createCachedLoad } from './load-result-cache';
 
 /**
  * Options for the createVirtualModulePlugin
@@ -26,6 +27,8 @@ export interface VirtualModulePluginOptions {
   ) => ReturnType<Parameters<PluginBuild['onLoad']>[1]>;
   /** Restrict to only entry points. Defaults to `true`. */
   entryPointOnly?: boolean;
+  /** Load results cache. */
+  cache?: LoadResultCache;
 }
 
 /**
@@ -39,6 +42,7 @@ export function createVirtualModulePlugin(options: VirtualModulePluginOptions): 
     external,
     transformPath: pathTransformer,
     loadContent,
+    cache,
     entryPointOnly = true,
   } = options;
 
@@ -65,7 +69,10 @@ export function createVirtualModulePlugin(options: VirtualModulePluginOptions): 
         });
       }
 
-      build.onLoad({ filter: /./, namespace }, (args) => loadContent(args, build));
+      build.onLoad(
+        { filter: /./, namespace },
+        createCachedLoad(cache, (args) => loadContent(args, build)),
+      );
     },
   };
 }


### PR DESCRIPTION
This commit adds caching to the polyfills virtual modules to avoid module resolutions on rebuilds which can take up to 3 seconds in some cases. Whilst these are done async, these can still slow down the build slightly due to IO limits.