### PR TITLE
refactor(@angular-devkit/build-angular): isolate typescript usage to compilation worker thread in application builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/esbuild/angular/compilation/noop-compilation.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/angular/compilation/noop-compilation.ts
@@ -7,7 +7,7 @@
  */
 
 import type ng from '@angular/compiler-cli';
-import ts from 'typescript';
+import type ts from 'typescript';
 import { AngularHostOptions } from '../angular-host';
 import { AngularCompilation } from './angular-compilation';
 

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/angular/compiler-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/angular/compiler-plugin.ts
@@ -19,7 +19,6 @@ import assert from 'node:assert';
 import { realpath } from 'node:fs/promises';
 import * as path from 'node:path';
 import { pathToFileURL } from 'node:url';
-import ts from 'typescript';
 import { maxWorkers } from '../../../utils/environment-options';
 import { JavaScriptTransformer } from '../javascript-transformer';
 import { LoadResultCache } from '../load-result-cache';
@@ -234,14 +233,12 @@ export function createCompilerPlugin(
           compilerOptions: { allowJs },
           referencedFiles,
         } = await compilation.initialize(tsconfigPath, hostOptions, (compilerOptions) => {
-          if (
-            compilerOptions.target === undefined ||
-            compilerOptions.target < ts.ScriptTarget.ES2022
-          ) {
+          // target of 9 is ES2022 (using the number avoids an expensive import of typescript just for an enum)
+          if (compilerOptions.target === undefined || compilerOptions.target < 9) {
             // If 'useDefineForClassFields' is already defined in the users project leave the value as is.
             // Otherwise fallback to false due to https://github.com/microsoft/TypeScript/issues/45995
             // which breaks the deprecated `@Effects` NGRX decorator and potentially other existing code as well.
-            compilerOptions.target = ts.ScriptTarget.ES2022;
+            compilerOptions.target = 9;
             compilerOptions.useDefineForClassFields ??= false;
 
             // Only add the warning on the initial build

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/angular/source-file-cache.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/angular/source-file-cache.ts
@@ -9,7 +9,7 @@
 import { platform } from 'node:os';
 import * as path from 'node:path';
 import { pathToFileURL } from 'node:url';
-import ts from 'typescript';
+import type ts from 'typescript';
 import { MemoryLoadResultCache } from '../load-result-cache';
 
 const USING_WINDOWS = platform() === 'win32';


### PR DESCRIPTION
To improve initialization type for the application builder, loading of the typescript package as been removed from the main thread. The parallel TS/NG compilation will instead load typescript during its worker thread startup. The typescript package is currently large and can take several hundred milliseconds to load.