### PR TITLE
refactor(@angular-devkit/build-angular): workaround for piscina worker destroy recreation

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/app-shell/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/app-shell/index.ts
@@ -123,6 +123,9 @@ async function _renderUniversal(
       }
     }
   } finally {
+    // Workaround piscina bug where a worker thread will be recreated after destroy to meet the minimum.
+    renderWorker.options.minThreads = 0;
+
     await renderWorker.destroy();
   }
 

--- a/packages/angular_devkit/build_angular/src/builders/prerender/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/prerender/index.ts
@@ -244,6 +244,8 @@ async function _renderUniversal(
       }
     }
   } finally {
+    // Workaround piscina bug where a worker thread will be recreated after destroy to meet the minimum.
+    worker.options.minThreads = 0;
     void worker.destroy();
   }
 

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/i18n-inliner.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/i18n-inliner.ts
@@ -144,6 +144,9 @@ export class I18nInliner {
    * @returns A void promise that resolves when closing is complete.
    */
   close(): Promise<void> {
+    // Workaround piscina bug where a worker thread will be recreated after destroy to meet the minimum.
+    this.#workerPool.options.minThreads = 0;
+
     return this.#workerPool.destroy();
   }
 }

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/javascript-transformer.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/javascript-transformer.ts
@@ -32,6 +32,7 @@ export class JavaScriptTransformer {
   constructor(options: JavaScriptTransformerOptions, maxThreads?: number) {
     this.#workerPool = new Piscina({
       filename: require.resolve('./javascript-transformer-worker'),
+      minThreads: 1,
       maxThreads,
     });
 
@@ -102,6 +103,9 @@ export class JavaScriptTransformer {
    * @returns A void promise that resolves when closing is complete.
    */
   close(): Promise<void> {
+    // Workaround piscina bug where a worker thread will be recreated after destroy to meet the minimum.
+    this.#workerPool.options.minThreads = 0;
+
     return this.#workerPool.destroy();
   }
 }

--- a/packages/angular_devkit/build_angular/src/tools/webpack/plugins/javascript-optimizer-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/plugins/javascript-optimizer-plugin.ts
@@ -231,6 +231,8 @@ export class JavaScriptOptimizerPlugin {
 
             await Promise.all(tasks);
           } finally {
+            // Workaround piscina bug where a worker thread will be recreated after destroy to meet the minimum.
+            workerPool.options.minThreads = 0;
             void workerPool.destroy();
           }
 

--- a/packages/angular_devkit/build_angular/src/utils/action-executor.ts
+++ b/packages/angular_devkit/build_angular/src/utils/action-executor.ts
@@ -64,6 +64,10 @@ export class BundleActionExecutor {
   }
 
   stop(): void {
-    void this.workerPool?.destroy();
+    if (this.workerPool) {
+      // Workaround piscina bug where a worker thread will be recreated after destroy to meet the minimum.
+      this.workerPool.options.minThreads = 0;
+      void this.workerPool.destroy();
+    }
   }
 }

--- a/packages/angular_devkit/build_angular/src/utils/server-rendering/prerender.ts
+++ b/packages/angular_devkit/build_angular/src/utils/server-rendering/prerender.ts
@@ -144,6 +144,8 @@ export async function prerenderPages(
 
     await Promise.all(renderingPromises);
   } finally {
+    // Workaround piscina bug where a worker thread will be recreated after destroy to meet the minimum.
+    renderWorker.options.minThreads = 0;
     void renderWorker.destroy();
   }
 
@@ -208,7 +210,11 @@ async function getAllRoutes(
 
   const { routes: extractedRoutes, warnings }: RoutersExtractorWorkerResult = await renderWorker
     .run({})
-    .finally(() => void renderWorker.destroy());
+    .finally(() => {
+      // Workaround piscina bug where a worker thread will be recreated after destroy to meet the minimum.
+      renderWorker.options.minThreads = 0;
+      void renderWorker.destroy();
+    });
 
   for (const route of extractedRoutes) {
     routes.add(route);


### PR DESCRIPTION
When destroying a `piscina` package worker pool, the minimum workers must be set to 0 first to prevent the recreation of the minimum number of workers. These workers would then be cleaned up once the worker pool goes out of scope but the recreation and initialization of each worker is unneeded processing that should be avoided.