### PR TITLE
fix(@angular-devkit/build-angular): use component style load result caching information for file watching

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/application/tests/behavior/rebuild-component_styles_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/tests/behavior/rebuild-component_styles_spec.ts
@@ -1,0 +1,77 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { concatMap, count, timeout } from 'rxjs';
+import { buildApplication } from '../../index';
+import { APPLICATION_BUILDER_INFO, BASE_OPTIONS, describeBuilder } from '../setup';
+
+/**
+ * Maximum time in milliseconds for single build/rebuild
+ * This accounts for CI variability.
+ */
+export const BUILD_TIMEOUT = 30_000;
+
+describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
+  describe('Behavior: "Rebuilds when component stylesheets change"', () => {
+    it('updates component when imported sass changes', async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        watch: true,
+      });
+
+      await harness.modifyFile('src/app/app.component.ts', (content) =>
+        content.replace('app.component.css', 'app.component.scss'),
+      );
+      await harness.writeFile('src/app/app.component.scss', "@import './a';");
+      await harness.writeFile('src/app/a.scss', '$primary: aqua;\\nh1 { color: $primary; }');
+
+      const builderAbort = new AbortController();
+      const buildCount = await harness
+        .execute({ signal: builderAbort.signal })
+        .pipe(
+          timeout(30000),
+          concatMap(async ({ result }, index) => {
+            expect(result?.success).toBe(true);
+
+            switch (index) {
+              case 0:
+                harness.expectFile('dist/browser/main.js').content.toContain('color: aqua');
+                harness.expectFile('dist/browser/main.js').content.not.toContain('color: blue');
+
+                await harness.writeFile(
+                  'src/app/a.scss',
+                  '$primary: blue;\\nh1 { color: $primary; }',
+                );
+                break;
+              case 1:
+                harness.expectFile('dist/browser/main.js').content.not.toContain('color: aqua');
+                harness.expectFile('dist/browser/main.js').content.toContain('color: blue');
+
+                await harness.writeFile(
+                  'src/app/a.scss',
+                  '$primary: green;\\nh1 { color: $primary; }',
+                );
+                break;
+              case 2:
+                harness.expectFile('dist/browser/main.js').content.not.toContain('color: aqua');
+                harness.expectFile('dist/browser/main.js').content.not.toContain('color: blue');
+                harness.expectFile('dist/browser/main.js').content.toContain('color: green');
+
+                // Test complete - abort watch mode
+                builderAbort.abort();
+                break;
+            }
+          }),
+          count(),
+        )
+        .toPromise();
+
+      expect(buildCount).toBe(3);
+    });
+  });
+});

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/angular/compiler-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/angular/compiler-plugin.ts
@@ -98,7 +98,6 @@ export function createCompilerPlugin(
       const stylesheetBundler = new ComponentStylesheetBundler(
         styleOptions,
         pluginOptions.incremental,
-        pluginOptions.loadResultCache,
       );
       let sharedTSCompilationState: SharedTSCompilationState | undefined;
 
@@ -131,6 +130,7 @@ export function createCompilerPlugin(
           // TODO: Differentiate between changed input files and stale output files
           modifiedFiles = referencedFileTracker.update(pluginOptions.sourceFileCache.modifiedFiles);
           pluginOptions.sourceFileCache.invalidate(modifiedFiles);
+          stylesheetBundler.invalidate(modifiedFiles);
         }
 
         if (

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/load-result-cache.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/load-result-cache.ts
@@ -12,6 +12,7 @@ import { normalize } from 'node:path';
 export interface LoadResultCache {
   get(path: string): OnLoadResult | undefined;
   put(path: string, result: OnLoadResult): Promise<void>;
+  readonly watchFiles: ReadonlyArray<string>;
 }
 
 export function createCachedLoad(
@@ -75,5 +76,9 @@ export class MemoryLoadResultCache implements LoadResultCache {
     found ||= this.#loadResults.delete(path);
 
     return found;
+  }
+
+  get watchFiles(): string[] {
+    return [...this.#loadResults.keys(), ...this.#fileDependencies.keys()];
   }
 }


### PR DESCRIPTION
When using the esbuild-based builders (`application`/`browser-esbuild`) in watch mode including `ng serve`, component stylesheets that used Sass and imported other stylesheets were previously no properly tracked. As a result, changes to the imported stylesheets would not invalidate the component and the rebuild would not contain the updated styles. The files used by the Sass (and Less) stylesheet processing are now correctly tracked in these cases.