### PR TITLE
perf(@angular-devkit/build-angular): conditionally add Angular compiler plugin to polyfills bundling

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/esbuild/application-code-bundle.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/application-code-bundle.ts
@@ -86,12 +86,7 @@ export function createBrowserPolyfillBundleOptions(
     return;
   }
 
-  const { outputNames } = options;
-  const { pluginOptions, styleOptions } = createCompilerPluginOptions(
-    options,
-    target,
-    sourceFileCache,
-  );
+  const { outputNames, polyfills } = options;
 
   const buildOptions: BuildOptions = {
     ...polyfillBundleOptions,
@@ -108,15 +103,24 @@ export function createBrowserPolyfillBundleOptions(
     },
   };
 
-  buildOptions.plugins ??= [];
-  buildOptions.plugins.push(
-    createCompilerPlugin(
-      // JS/TS options
-      { ...pluginOptions, noopTypeScriptCompilation: true },
-      // Component stylesheet options are unused for polyfills but required by the plugin
-      styleOptions,
-    ),
-  );
+  // Only add the Angular TypeScript compiler if TypeScript files are provided in the polyfills
+  const hasTypeScriptEntries = polyfills?.some((entry) => /\.[cm]?tsx?$/.test(entry));
+  if (hasTypeScriptEntries) {
+    buildOptions.plugins ??= [];
+    const { pluginOptions, styleOptions } = createCompilerPluginOptions(
+      options,
+      target,
+      sourceFileCache,
+    );
+    buildOptions.plugins.push(
+      createCompilerPlugin(
+        // JS/TS options
+        { ...pluginOptions, noopTypeScriptCompilation: true },
+        // Component stylesheet options are unused for polyfills but required by the plugin
+        styleOptions,
+      ),
+    );
+  }
 
   return buildOptions;
 }


### PR DESCRIPTION
When using the esbuild-based builders (`application`/`browser-esbuild`), the Angular compiler plugin is now only added to the polyfills bundler configuration if TypeScript files are found in the `polyfills` build option. This is not the case for a default project. The Angular compiler plugin is used to provide type-checking diagnostics for any TypeScript files present within the build. However, if there are no TypeScript files to process, there is no need to use it for the polyfills processing.