### PR TITLE
fix(@angular/ssr): correctly set config URL

### DIFF
--- a/packages/schematics/angular/migrations/update-17/replace-nguniversal-engines.ts
+++ b/packages/schematics/angular/migrations/update-17/replace-nguniversal-engines.ts
@@ -127,13 +127,15 @@ export function app(): express.Express {
 
   // All regular routes use the Angular engine
   server.get('*', (req, res, next) => {
+    const { protocol, originalUrl, baseUrl, headers } = req;
+
     commonEngine
       .render({
         bootstrap,
         documentFilePath: indexHtml,
-        url: req.originalUrl,
+        url: \`\${protocol}://\${headers.host}\${originalUrl}\`,
         publicPath: distFolder,
-        providers: [{ provide: APP_BASE_HREF, useValue: req.baseUrl }],
+        providers: [{ provide: APP_BASE_HREF, useValue: baseUrl }],
       })
       .then((html) => res.send(html))
       .catch((err) => next(err));

--- a/packages/schematics/angular/ssr/files/application-builder/server.ts.template
+++ b/packages/schematics/angular/ssr/files/application-builder/server.ts.template
@@ -26,13 +26,15 @@ export function app(): express.Express {
 
   // All regular routes use the Angular engine
   server.get('*', (req, res, next) => {
+    const { protocol, originalUrl, baseUrl, headers } = req;
+
     commonEngine
       .render({
         <% if (isStandalone) { %>bootstrap<% } else { %>bootstrap: AppServerModule<% } %>,
         documentFilePath: indexHtml,
-        url: req.originalUrl,
+        url: `${protocol}://${headers.host}${originalUrl}`,
         publicPath: browserDistFolder,
-        providers: [{ provide: APP_BASE_HREF, useValue: req.baseUrl }],
+        providers: [{ provide: APP_BASE_HREF, useValue: baseUrl }],
       })
       .then((html) => res.send(html))
       .catch((err) => next(err));

--- a/packages/schematics/angular/ssr/files/server-builder/server.ts.template
+++ b/packages/schematics/angular/ssr/files/server-builder/server.ts.template
@@ -29,13 +29,15 @@ export function app(): express.Express {
 
   // All regular routes use the Angular engine
   server.get('*', (req, res, next) => {
+    const { protocol, originalUrl, baseUrl, headers } = req;
+
     commonEngine
       .render({
         <% if (isStandalone) { %>bootstrap<% } else { %>bootstrap: AppServerModule<% } %>,
         documentFilePath: indexHtml,
-        url: req.originalUrl,
+        url: `${protocol}://${headers.host}${originalUrl}`,
         publicPath: distFolder,
-        providers: [{ provide: APP_BASE_HREF, useValue: req.baseUrl }],
+        providers: [{ provide: APP_BASE_HREF, useValue: baseUrl }],
       })
       .then((html) => res.send(html))
       .catch((err) => next(err));


### PR DESCRIPTION
When calling `renderApplication` or `renderModule` the URL would be overridden to undefined as the `url` option was not provided as an option.
