### PR TITLE
refactor(@angular-devkit/build-angular): remove Sass module resolve workarounds

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/sass/worker.ts
+++ b/packages/angular_devkit/build_angular/src/tools/sass/worker.ts
@@ -93,7 +93,14 @@ parentPort.on('message', (message: RenderRequestMessage) => {
       const proxyImporter: FileImporter<'sync'> = {
         findFileUrl: (url, options) => {
           Atomics.store(importerSignal, 0, 0);
-          workerImporterPort.postMessage({ id, url, options });
+          workerImporterPort.postMessage({
+            id,
+            url,
+            options: {
+              ...options,
+              containingUrl: options.containingUrl ? fileURLToPath(options.containingUrl) : null,
+            },
+          });
           Atomics.wait(importerSignal, 0, 0);
 
           const result = receiveMessageOnPort(workerImporterPort)?.message as string | null;


### PR DESCRIPTION
The recent version of the Sass compiler (`dart-sass@1.68.0`) now provides additional information within an importer that allows more accurate resolution of node modules packages without several existing workarounds. Previously, the Sass files needed to be pre-processed to extract all `@import` and `@use` paths so that information regarding the containing Sass file could be used to fully resolve the paths. The Sass compiler now provides this information directly.