### PR TITLE
refactor(@angular-devkit/build-angular): show build time on failures with application builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/application/execute-build.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/execute-build.ts
@@ -41,8 +41,6 @@ export async function executeBuild(
   context: BuilderContext,
   rebuildState?: RebuildState,
 ): Promise<ExecutionResult> {
-  const startTime = process.hrtime.bigint();
-
   const {
     projectRoot,
     workspaceRoot,
@@ -251,11 +249,8 @@ export async function executeBuild(
   }
 
   printWarningsAndErrorsToConsole(context, warnings, errors);
-
   logBuildStats(context, metafile, initialFiles, budgetFailures, estimatedTransferSizes);
 
-  const buildTime = Number(process.hrtime.bigint() - startTime) / 10 ** 9;
-  context.logger.info(`Application bundle generation complete. [${buildTime.toFixed(3)} seconds]`);
   // Write metafile if stats option is enabled
   if (options.stats) {
     executionResult.addOutputFile(


### PR DESCRIPTION
The build time is now shown when bundling fails. Previously only the errors were shown. This provides additional information that the build did indeed fail and how long it took to fail.
