### PR TITLE
fix(@angular-devkit/build-angular): warn if using partial mode with application builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/esbuild/angular/compiler-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/angular/compiler-plugin.ts
@@ -257,6 +257,15 @@ export function createCompilerPlugin(
             });
           }
 
+          if (compilerOptions.compilationMode === 'partial') {
+            setupWarnings?.push({
+              text: 'Angular partial compilation mode is not supported when building applications.',
+              location: null,
+              notes: [{ text: 'Full compilation mode will be used instead.' }],
+            });
+            compilerOptions.compilationMode = 'full';
+          }
+
           // Enable incremental compilation by default if caching is enabled
           if (pluginOptions.sourceFileCache?.persistentCachePath) {
             compilerOptions.incremental ??= true;


### PR DESCRIPTION
The Angular compiler's partial compilation mode is only intended for use when building libraries. If attempting to use the mode while building an application, the application would fail. A warning is now issued if partial mode is configured for the application and the mode is switched to full compilation mode to prevent the build from failing due to the option value.