### PR TITLE
fix(@angular-devkit/build-angular): automatically include known packages in vite prebundling

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/application/execute-build.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/execute-build.ts
@@ -168,6 +168,15 @@ export async function executeBuild(
     return executionResult;
   }
 
+  // Analyze external imports if external options are enabled
+  if (options.externalPackages || options.externalDependencies?.length) {
+    // TODO: Filter externalImports to generate second argument to support wildcard externalDependency values
+    executionResult.setExternalMetadata(
+      [...bundlingResult.externalImports],
+      options.externalDependencies,
+    );
+  }
+
   const { metafile, initialFiles, outputFiles } = bundlingResult;
 
   executionResult.outputFiles.push(...outputFiles);

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/bundler-execution-result.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/bundler-execution-result.ts
@@ -30,6 +30,7 @@ export class ExecutionResult {
   outputFiles: BuildOutputFile[] = [];
   assetFiles: BuildOutputAsset[] = [];
   errors: Message[] = [];
+  externalMetadata?: { implicit: string[]; explicit?: string[] };
 
   constructor(
     private rebuildContexts: BundlerContext[],
@@ -48,6 +49,16 @@ export class ExecutionResult {
     this.errors.push(...errors);
   }
 
+  /**
+   * Add external JavaScript import metadata to the result. This is currently used
+   * by the development server to optimize the prebundling process.
+   * @param implicit External dependencies due to the external packages option.
+   * @param explicit External dependencies due to explicit project configuration.
+   */
+  setExternalMetadata(implicit: string[], explicit: string[] | undefined) {
+    this.externalMetadata = { implicit, explicit };
+  }
+
   get output() {
     return {
       success: this.errors.length === 0,
@@ -60,6 +71,7 @@ export class ExecutionResult {
       outputFiles: this.outputFiles,
       assetFiles: this.assetFiles,
       errors: this.errors,
+      externalMetadata: this.externalMetadata,
     };
   }
 


### PR DESCRIPTION
When using the Vite-based development server, the application build step already contains the list of known packages that would need to be prebundled. This information can be passed to Vite directly to avoid Vite needing to perform discovery on every output file that will be requested. This also avoids the Vite server behavior where Vite forces a reload of the page when it discovers a new dependency. This behavior can result in lost state during lazy loading of a route.