### PR TITLE
fix(@angular-devkit/build-angular): ensure css url() prefix warnings support Sass rebasing

### DIFF
--- a/packages/angular_devkit/build_angular/BUILD.bazel
+++ b/packages/angular_devkit/build_angular/BUILD.bazel
@@ -310,7 +310,7 @@ ts_library(
 
 LARGE_SPECS = {
     "application": {
-        "shards": 16,
+        "shards": 12,
         "size": "large",
         "flaky": True,
         "extra_deps": [

--- a/packages/angular_devkit/build_angular/src/tools/sass/rebasing-importer.ts
+++ b/packages/angular_devkit/build_angular/src/tools/sass/rebasing-importer.ts
@@ -94,8 +94,8 @@ abstract class UrlRebasingImporter implements Importer<'sync'> {
     // Rebase any URLs that are found
     let updatedContents;
     for (const { start, end, value } of findUrls(contents)) {
-      // Skip if value is empty or a Sass variable
-      if (value.length === 0 || value.startsWith('$')) {
+      // Skip if value is empty, a Sass variable, or Webpack-specific prefix
+      if (value.length === 0 || value[0] === '$' || value[0] === '~' || value[0] === '^') {
         continue;
       }
 


### PR DESCRIPTION
The stylesheet url() resource plugin will now correctly issue warnings for the usage of Webpack specific prefixes such as the tilde when used in an imported Sass file. Previously, these URLs would be rebased by the Sass processing step which would cause the tilde prefix to no longer be a prefix. This would then no longer be considered a warning due to the tilde no longer being the first character of the URL value. Additionally, a warning is also now issued for the previously unsupported but available caret prefix. Removing the caret prefix and adding the path to the `externalDependencies` build option should provide equivalent behavior.