### PR TITLE
refactor(@angular-devkit/build-angular): increase JS transformer worker pool idle timeout to 1 second

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/esbuild/javascript-transformer.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/javascript-transformer.ts
@@ -34,6 +34,8 @@ export class JavaScriptTransformer {
       filename: require.resolve('./javascript-transformer-worker'),
       minThreads: 1,
       maxThreads,
+      // Shutdown idle threads after 1 second of inactivity
+      idleTimeout: 1000,
     });
 
     // Extract options to ensure only the named options are serialized and sent to the worker


### PR DESCRIPTION
The idle timeout for threads in the JavaScript transformer worker pool for the esbuild-based builders (`application`/`browser-esbuild`) is now set at 1 second. This prevents the default of immediate shutdown of an idle worker from occurring. The immediate shutdown causes additional worker threads to be created due to the variable time between bundler requests for node module JavaScript files. The shutdown and subsequent recreation of the threads during the build causes unneeded extra processing that can now be avoided.