### PR TITLE
fix(@angular/cli): remove Node.js 16 from supported checks

### DIFF
--- a/packages/angular/cli/src/commands/version/cli.ts
+++ b/packages/angular/cli/src/commands/version/cli.ts
@@ -23,7 +23,7 @@ interface PartialPackageInfo {
 /**
  * Major versions of Node.js that are officially supported by Angular.
  */
-const SUPPORTED_NODE_MAJORS = [16, 18];
+const SUPPORTED_NODE_MAJORS = [18];
 
 const PACKAGE_PATTERNS = [
   /^@angular\/.*/,


### PR DESCRIPTION
Node.js support was removed, but it appears that this got through the cracks.
