### PR TITLE
build: disable inline sourcemap generation

### DIFF
--- a/tools/postinstall/patches/@bazel+concatjs+5.8.1.patch
+++ b/tools/postinstall/patches/@bazel+concatjs+5.8.1.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/@bazel/concatjs/internal/build_defs.bzl b/node_modules/@bazel/concatjs/internal/build_defs.bzl
-index 9e5cda6..851c8b7 100755
+index 9e5cda6..6c45196 100755
 --- a/node_modules/@bazel/concatjs/internal/build_defs.bzl
 +++ b/node_modules/@bazel/concatjs/internal/build_defs.bzl
 @@ -76,7 +76,7 @@ _TYPESCRIPT_TYPINGS = Label(
@@ -11,3 +11,19 @@ index 9e5cda6..851c8b7 100755
  _TYPESCRIPT_MODULE_KINDS = ["none", "commonjs", "amd", "umd", "system", "es2015", "esnext"]
  
  _DEVMODE_TARGET_DEFAULT = "es2015"
+diff --git a/node_modules/@bazel/concatjs/internal/common/tsconfig.bzl b/node_modules/@bazel/concatjs/internal/common/tsconfig.bzl
+index b01c999..ec3e4cc 100755
+--- a/node_modules/@bazel/concatjs/internal/common/tsconfig.bzl
++++ b/node_modules/@bazel/concatjs/internal/common/tsconfig.bzl
+@@ -278,11 +278,6 @@ def create_tsconfig(
+         "declarationDir": "/".join([workspace_path, outdir_path]),
+         "stripInternal": True,
+ 
+-        # Embed source maps and sources in .js outputs
+-        "inlineSourceMap": True,
+-        "inlineSources": True,
+-        # Implied by inlineSourceMap: True
+-        "sourceMap": False,
+     }
+ 
+     # "node_modules" still checked for backward compat for ng_module


### PR DESCRIPTION
The built packages that will be published on npm previously contained inlined sourcemaps for every JavaScript file. This caused a significant increase in the overall package size of over two times larger. This has a negative effect on developer experience especially the new project experience due to the increased time to download and setup a new project. The sourcemaps are also rarely used as debugging the CLI code itself is typically done with development builds. The generated code is also very close to the original source due to it being emitted as ES2022 code and with the eventual switch to ESM output this will become even closer.
As an example of the size difference, the `@angular/cli` compressed package size was reduced from ~352Kb to ~115Kb with this change.