### PR TITLE
Feat custom postcss plugin support

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/application/schema.json
+++ b/packages/angular_devkit/build_angular/src/builders/application/schema.json
@@ -104,6 +104,37 @@
         ]
       }
     },
+    "postcssPlugins": {
+      "description": "Postcss plugins to be included in the build.",
+      "type": "array",
+      "default": [],
+      "items": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "packageName": {
+                "type": "string",
+                "description": "Plugin package name."
+              },
+              "options": {
+                "type": "object",
+                "properties": {},
+                "description": "Plugin options.",
+                "additionalProperties": true,
+                "required": []
+              }
+            },
+            "additionalProperties": false,
+            "required": ["packageName"]
+          },
+          {
+            "type": "string",
+            "description": "Plugin package name."
+          }
+        ]
+      }
+    },
     "inlineStyleLanguage": {
       "description": "The stylesheet language to use for the application's inline component styles.",
       "type": "string",

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/schema.json
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/schema.json
@@ -109,6 +109,37 @@
         ]
       }
     },
+    "postcssPlugins": {
+      "description": "Postcss plugins to be included in the build.",
+      "type": "array",
+      "default": [],
+      "items": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "packageName": {
+                "type": "string",
+                "description": "Plugin package name."
+              },
+              "options": {
+                "type": "object",
+                "properties": {},
+                "description": "Plugin options.",
+                "additionalProperties": true,
+                "required": []
+              }
+            },
+            "additionalProperties": false,
+            "required": ["packageName"]
+          },
+          {
+            "type": "string",
+            "description": "Plugin package name."
+          }
+        ]
+      }
+    },
     "inlineStyleLanguage": {
       "description": "The stylesheet language to use for the application's inline component styles.",
       "type": "string",

--- a/packages/angular_devkit/build_angular/src/builders/browser/schema.json
+++ b/packages/angular_devkit/build_angular/src/builders/browser/schema.json
@@ -110,6 +110,37 @@
         ]
       }
     },
+    "postcssPlugins": {
+      "description": "Postcss plugins to be included in the build.",
+      "type": "array",
+      "default": [],
+      "items": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "packageName": {
+                "type": "string",
+                "description": "Plugin package name."
+              },
+              "options": {
+                "type": "object",
+                "properties": {},
+                "description": "Plugin options.",
+                "additionalProperties": true,
+                "required": []
+              }
+            },
+            "additionalProperties": false,
+            "required": ["packageName"]
+          },
+          {
+            "type": "string",
+            "description": "Plugin package name."
+          }
+        ]
+      }
+    },
     "inlineStyleLanguage": {
       "description": "The stylesheet language to use for the application's inline component styles.",
       "type": "string",

--- a/packages/angular_devkit/build_angular/src/builders/karma/schema.json
+++ b/packages/angular_devkit/build_angular/src/builders/karma/schema.json
@@ -114,6 +114,37 @@
         ]
       }
     },
+    "postcssPlugins": {
+      "description": "Postcss plugins to be included in the build.",
+      "type": "array",
+      "default": [],
+      "items": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "packageName": {
+                "type": "string",
+                "description": "Plugin package name."
+              },
+              "options": {
+                "type": "object",
+                "properties": {},
+                "description": "Plugin options.",
+                "additionalProperties": true,
+                "required": []
+              }
+            },
+            "additionalProperties": false,
+            "required": ["packageName"]
+          },
+          {
+            "type": "string",
+            "description": "Plugin package name."
+          }
+        ]
+      }
+    },
     "inlineStyleLanguage": {
       "description": "The stylesheet language to use for the application's inline component styles.",
       "type": "string",

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/bundler-context.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/bundler-context.ts
@@ -10,7 +10,6 @@ import {
   BuildContext,
   BuildFailure,
   BuildOptions,
-  BuildResult,
   Message,
   Metafile,
   OutputFile,
@@ -67,9 +66,7 @@ function isEsBuildFailure(value: unknown): value is BuildFailure {
 export class BundlerContext {
   #esbuildContext?: BuildContext<{ metafile: true; write: false }>;
   #esbuildOptions?: BuildOptions & { metafile: true; write: false };
-  #esbuildResult?: BundleContextResult;
   #optionsFactory: BundlerOptionsFactory<BuildOptions & { metafile: true; write: false }>;
-  #shouldCacheResult: boolean;
 
   #loadCache?: MemoryLoadResultCache;
   readonly watchFiles = new Set<string>();
@@ -80,8 +77,6 @@ export class BundlerContext {
     options: BuildOptions | BundlerOptionsFactory,
     private initialFilter?: (initial: Readonly<InitialFileRecord>) => boolean,
   ) {
-    // To cache the results an option factory is needed to capture the full set of dependencies
-    this.#shouldCacheResult = incremental && typeof options === 'function';
     this.#optionsFactory = (...args) => {
       const baseOptions = typeof options === 'function' ? options(...args) : options;
 
@@ -147,30 +142,12 @@ export class BundlerContext {
    * warnings and errors for the attempted build.
    */
   async bundle(): Promise<BundleContextResult> {
-    // Return existing result if present
-    if (this.#esbuildResult) {
-      return this.#esbuildResult;
-    }
-
-    const result = await this.#performBundle();
-    if (this.#shouldCacheResult) {
-      this.#esbuildResult = result;
-    }
-
-    return result;
-  }
-
-  async #performBundle() {
     // Create esbuild options if not present
     if (this.#esbuildOptions === undefined) {
       if (this.incremental) {
         this.#loadCache = new MemoryLoadResultCache();
       }
       this.#esbuildOptions = this.#optionsFactory(this.#loadCache);
-    }
-
-    if (this.incremental) {
-      this.watchFiles.clear();
     }
 
     let result;
@@ -190,8 +167,6 @@ export class BundlerContext {
     } catch (failure) {
       // Build failures will throw an exception which contains errors/warnings
       if (isEsBuildFailure(failure)) {
-        this.#addErrorsToWatch(failure);
-
         return failure;
       } else {
         throw failure;
@@ -202,6 +177,7 @@ export class BundlerContext {
     // While this should technically not be linked to incremental mode, incremental is only
     // currently enabled with watch mode where watch files are needed.
     if (this.incremental) {
+      this.watchFiles.clear();
       // Add input files except virtual angular files which do not exist on disk
       Object.keys(result.metafile.inputs)
         .filter((input) => !input.startsWith('angular:'))
@@ -218,8 +194,6 @@ export class BundlerContext {
 
     // Return if the build encountered any errors
     if (result.errors.length) {
-      this.#addErrorsToWatch(result);
-
       return {
         errors: result.errors,
         warnings: result.warnings,
@@ -307,28 +281,6 @@ export class BundlerContext {
     };
   }
 
-  #addErrorsToWatch(result: BuildFailure | BuildResult): void {
-    for (const error of result.errors) {
-      let file = error.location?.file;
-      if (file) {
-        this.watchFiles.add(join(this.workspaceRoot, file));
-      }
-      for (const note of error.notes) {
-        file = note.location?.file;
-        if (file) {
-          this.watchFiles.add(join(this.workspaceRoot, file));
-        }
-      }
-    }
-  }
-
-  /**
-   * Invalidate a stored bundler result based on the previous watch files
-   * and a list of changed files.
-   * The context must be created with incremental mode enabled for results
-   * to be stored.
-   * @returns True, if the result was invalidated; False, otherwise.
-   */
   invalidate(files: Iterable<string>): boolean {
     if (!this.incremental) {
       return false;
@@ -344,10 +296,6 @@ export class BundlerContext {
       invalid ||= this.watchFiles.has(file);
     }
 
-    if (invalid) {
-      this.#esbuildResult = undefined;
-    }
-
     return invalid;
   }
 
@@ -359,7 +307,6 @@ export class BundlerContext {
   async dispose(): Promise<void> {
     try {
       this.#esbuildOptions = undefined;
-      this.#esbuildResult = undefined;
       this.#loadCache = undefined;
       await this.#esbuildContext?.dispose();
     } finally {

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/javascript-transformer.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/javascript-transformer.ts
@@ -34,8 +34,6 @@ export class JavaScriptTransformer {
       filename: require.resolve('./javascript-transformer-worker'),
       minThreads: 1,
       maxThreads,
-      // Shutdown idle threads after 1 second of inactivity
-      idleTimeout: 1000,
     });
 
     // Extract options to ensure only the named options are serialized and sent to the worker

--- a/packages/angular_devkit/build_angular/src/tools/webpack/configs/styles.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/configs/styles.ts
@@ -101,6 +101,12 @@ export async function getStylesConfig(wco: WebpackConfigOptions): Promise<Config
     }
   }
 
+  for (const userPlugin of wco.buildOptions.postcssPlugins) {
+    if (typeof userPlugin === 'string') extraPostcssPlugins.push(require(userPlugin)({}));
+    else if (typeof userPlugin === 'object')
+      extraPostcssPlugins.push(require(<string>userPlugin.packageName)(<object>userPlugin.options));
+  }
+
   const autoprefixer: typeof import('autoprefixer') = require('autoprefixer');
 
   const postcssOptionsCreator = (inlineSourcemaps: boolean, extracted: boolean) => {

--- a/packages/angular_devkit/build_angular/src/utils/build-options.ts
+++ b/packages/angular_devkit/build_angular/src/utils/build-options.ts
@@ -20,6 +20,7 @@ import {
   ScriptElement,
   SourceMapClass,
   StyleElement,
+  PostcssPluginElement,
 } from '../builders/browser/schema';
 import { Schema as DevServerSchema } from '../builders/dev-server/schema';
 import { NormalizedCachedOptions } from './normalize-cache';
@@ -63,6 +64,7 @@ export interface BuildOptions {
   assets: AssetPatternClass[];
   scripts: ScriptElement[];
   styles: StyleElement[];
+  postcssPlugins: PostcssPluginElement[];
   stylePreprocessorOptions?: { includePaths: string[] };
   platform?: 'browser' | 'server';
   fileReplacements: NormalizedFileReplacement[];

--- a/packages/angular_devkit/build_angular/src/utils/normalize-builder-schema.ts
+++ b/packages/angular_devkit/build_angular/src/utils/normalize-builder-schema.ts
@@ -65,6 +65,7 @@ export function normalizeBrowserSchema(
     budgets: options.budgets || [],
     scripts: options.scripts || [],
     styles: options.styles || [],
+    postcssPlugins: options.postcssPlugins || [],
     stylePreprocessorOptions: {
       includePaths:
         (options.stylePreprocessorOptions && options.stylePreprocessorOptions.includePaths) || [],


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [ x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently users cannot include custom postcss plugins into the build process (easily at least)

## What is the new behavior?

With this PR, adding a postcss plugin will be as easy and seamless as

1) Installing the plugin package (e.g. npm install postcss-nested)
2) Adding package name to angular.json

    e.g.
        .
        .
        .
            "assets": [
              "src/favicon.ico",
              "src/assets"
            ],
            "styles": [
              "src/styles.scss"
            ],
            "postcssPlugins": [
              {
                "packageName": "postcss-nested",
                "options": {
                  "bubble": []
                }
              }
            ],
        .
        .
        .


## Does this PR introduce a breaking change?

- [ ] Yes
- [x ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Changes in files,

1) packages/angular_devkit/build_angular/src/tools/esbuild/bundler-context.ts
2) packages/angular_devkit/build_angular/src/tools/esbuild/javascript-transformer.ts

are not relevant to this commit. They are there as I reverted the last commit from main when I forked (due to that commit failing the automated tests)