### PR TITLE
fix(@angular-devkit/build-angular): normalize paths when invalidating stylesheet bundler

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/esbuild/angular/component-stylesheets.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/angular/component-stylesheets.ts
@@ -111,11 +111,13 @@ export class ComponentStylesheetBundler {
       return;
     }
 
+    const normalizedFiles = [...files].map(path.normalize);
+
     for (const bundler of this.#fileContexts.values()) {
-      bundler.invalidate(files);
+      bundler.invalidate(normalizedFiles);
     }
     for (const bundler of this.#inlineContexts.values()) {
-      bundler.invalidate(files);
+      bundler.invalidate(normalizedFiles);
     }
   }
 

--- a/tests/legacy-cli/e2e/tests/basic/rebuild.ts
+++ b/tests/legacy-cli/e2e/tests/basic/rebuild.ts
@@ -116,7 +116,7 @@ export default async function () {
     const response = await fetch(`http://localhost:${port}/styles.css`);
     const body = await response.text();
     if (!body.match(/color:\s?green/)) {
-      throw new Error('Expected component CSS to update.');
+      throw new Error('Expected global CSS to update.');
     }
   }
 }


### PR DESCRIPTION
To avoid incorrectly invalidating the stylesheet bundler within the application builder on Windows, the paths of changed files are now first normalized. This ensures that any changed files properly cause affected component stylesheets to be reprocessed.