### PR TITLE
feat(@angular-devkit/build-angular): add custom postcss plugin support

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/application/schema.json
+++ b/packages/angular_devkit/build_angular/src/builders/application/schema.json
@@ -104,6 +104,37 @@
         ]
       }
     },
+    "postcssPlugins": {
+      "description": "Postcss plugins to be included in the build.",
+      "type": "array",
+      "default": [],
+      "items": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "packageName": {
+                "type": "string",
+                "description": "Plugin package name."
+              },
+              "options": {
+                "type": "object",
+                "properties": {},
+                "description": "Plugin options.",
+                "additionalProperties": true,
+                "required": []
+              }
+            },
+            "additionalProperties": false,
+            "required": ["packageName", "options"]
+          },
+          {
+            "type": "string",
+            "description": "Plugin package name."
+          }
+        ]
+      }
+    },
     "inlineStyleLanguage": {
       "description": "The stylesheet language to use for the application's inline component styles.",
       "type": "string",

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/schema.json
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/schema.json
@@ -109,6 +109,37 @@
         ]
       }
     },
+    "postcssPlugins": {
+      "description": "Postcss plugins to be included in the build.",
+      "type": "array",
+      "default": [],
+      "items": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "packageName": {
+                "type": "string",
+                "description": "Plugin package name."
+              },
+              "options": {
+                "type": "object",
+                "properties": {},
+                "description": "Plugin options.",
+                "additionalProperties": true,
+                "required": []
+              }
+            },
+            "additionalProperties": false,
+            "required": ["packageName", "options"]
+          },
+          {
+            "type": "string",
+            "description": "Plugin package name."
+          }
+        ]
+      }
+    },
     "inlineStyleLanguage": {
       "description": "The stylesheet language to use for the application's inline component styles.",
       "type": "string",

--- a/packages/angular_devkit/build_angular/src/builders/browser/schema.json
+++ b/packages/angular_devkit/build_angular/src/builders/browser/schema.json
@@ -110,6 +110,37 @@
         ]
       }
     },
+    "postcssPlugins": {
+      "description": "Postcss plugins to be included in the build.",
+      "type": "array",
+      "default": [],
+      "items": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "packageName": {
+                "type": "string",
+                "description": "Plugin package name."
+              },
+              "options": {
+                "type": "object",
+                "properties": {},
+                "description": "Plugin options.",
+                "additionalProperties": true,
+                "required": []
+              }
+            },
+            "additionalProperties": false,
+            "required": ["packageName", "options"]
+          },
+          {
+            "type": "string",
+            "description": "Plugin package name."
+          }
+        ]
+      }
+    },
     "inlineStyleLanguage": {
       "description": "The stylesheet language to use for the application's inline component styles.",
       "type": "string",

--- a/packages/angular_devkit/build_angular/src/builders/karma/schema.json
+++ b/packages/angular_devkit/build_angular/src/builders/karma/schema.json
@@ -114,6 +114,37 @@
         ]
       }
     },
+    "postcssPlugins": {
+      "description": "Postcss plugins to be included in the build.",
+      "type": "array",
+      "default": [],
+      "items": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "packageName": {
+                "type": "string",
+                "description": "Plugin package name."
+              },
+              "options": {
+                "type": "object",
+                "properties": {},
+                "description": "Plugin options.",
+                "additionalProperties": true,
+                "required": []
+              }
+            },
+            "additionalProperties": false,
+            "required": ["packageName", "options"]
+          },
+          {
+            "type": "string",
+            "description": "Plugin package name."
+          }
+        ]
+      }
+    },
     "inlineStyleLanguage": {
       "description": "The stylesheet language to use for the application's inline component styles.",
       "type": "string",

--- a/packages/angular_devkit/build_angular/src/tools/webpack/configs/styles.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/configs/styles.ts
@@ -101,6 +101,29 @@ export async function getStylesConfig(wco: WebpackConfigOptions): Promise<Config
     }
   }
 
+  for (const userPlugin of wco.buildOptions.postcssPlugins) {
+    let packageName, packageOptions;
+    if (typeof userPlugin === 'string') packageName = userPlugin;
+    else if (typeof userPlugin === 'object') {
+      packageName = <string>userPlugin.packageName;
+      packageOptions = <object>userPlugin.options;
+    }
+
+    if (packageName) {
+      let packagePath;
+      try {
+        packagePath = require.resolve(packageName, { paths: [root] });
+      } catch {
+        logger.warn(`Couldn't resolve postcss plugin package "${packageName}". Skipping...`);
+      }
+      if (packagePath) {
+        extraPostcssPlugins.push(require(packagePath)(packageOptions ? packageOptions : {}));
+      }
+    } else {
+      logger.warn('Empty postcss plugin package name detected. Skipping...');
+    }
+  }
+
   const autoprefixer: typeof import('autoprefixer') = require('autoprefixer');
 
   const postcssOptionsCreator = (inlineSourcemaps: boolean, extracted: boolean) => {

--- a/packages/angular_devkit/build_angular/src/utils/build-options.ts
+++ b/packages/angular_devkit/build_angular/src/utils/build-options.ts
@@ -20,6 +20,7 @@ import {
   ScriptElement,
   SourceMapClass,
   StyleElement,
+  PostcssPluginElement,
 } from '../builders/browser/schema';
 import { Schema as DevServerSchema } from '../builders/dev-server/schema';
 import { NormalizedCachedOptions } from './normalize-cache';
@@ -63,6 +64,7 @@ export interface BuildOptions {
   assets: AssetPatternClass[];
   scripts: ScriptElement[];
   styles: StyleElement[];
+  postcssPlugins: PostcssPluginElement[];
   stylePreprocessorOptions?: { includePaths: string[] };
   platform?: 'browser' | 'server';
   fileReplacements: NormalizedFileReplacement[];

--- a/packages/angular_devkit/build_angular/src/utils/normalize-builder-schema.ts
+++ b/packages/angular_devkit/build_angular/src/utils/normalize-builder-schema.ts
@@ -65,6 +65,7 @@ export function normalizeBrowserSchema(
     budgets: options.budgets || [],
     scripts: options.scripts || [],
     styles: options.styles || [],
+    postcssPlugins: options.postcssPlugins || [],
     stylePreprocessorOptions: {
       includePaths:
         (options.stylePreprocessorOptions && options.stylePreprocessorOptions.includePaths) || [],


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [ x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently including user PostCSS plugins into the Angular build process is not easily accomplished. This PR intends to fix that.

## What is the new behavior?

This commit adds seamless custom PostCSS plugin inclusion to the Angular build process, with minimal changes to the angular-cli source.
Adding a postcss plugin is now as easy as,

1) Installing the plugin package (e.g. ```npm install postcss-nested```)
2) Adding the package name to ```angular.json``` ```postcssPlugins```

    e.g.
```
        .
        .
        .
        "styles": [
          "src/styles.scss"
        ],
        "postcssPlugins": [
          {
            "packageName": "postcss-nested",
            "options": {
              "bubble": []
            }
          }
        ],
        .
        .
        .
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [ x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
