### PR TITLE
refactor(@angular-devkit/build-angular): prevent vite from resolving explicit external dependencies

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
@@ -391,6 +391,9 @@ export async function setupServer(
       watch: {
         ignored: ['**/*'],
       },
+      // This is needed when `externalDependencies` is used to prevent Vite load errors.
+      // NOTE: If Vite adds direct support for externals, this can be removed.
+      preTransformRequests: externalMetadata.explicit.length === 0,
     },
     ssr: {
       // Exclude any provided dependencies (currently build defined externals)
@@ -403,6 +406,13 @@ export async function setupServer(
         // Ensures plugin hooks run before built-in Vite hooks
         enforce: 'pre',
         async resolveId(source, importer) {
+          // Prevent vite from resolving an explicit external dependency (`externalDependencies` option)
+          if (externalMetadata.explicit.includes(source)) {
+            // This is still not ideal since Vite will still transform the import specifier to
+            // `/@id/${source}` but is currently closer to a raw external than a resolved file path.
+            return source;
+          }
+
           if (importer && source.startsWith('.')) {
             // Remove query if present
             const [importerFile] = importer.split('?', 1);


### PR DESCRIPTION
When using the Vite-based development server combined with the `externalDependencies` option, Vite will no longer attempt to resolve the explicitly marked externals. This is still not ideal since it Vite will still transform the import specifier to `/@id/${source}` but is currently closer to a raw external than a resolved file path. Further investigation with a possible feature request for Vite may be needed to achieve the desired outcome of an unresolved and untransformed external import specifier.