### PR TITLE
fix(@angular-devkit/build-angular): do not perform advanced optimizations on `@angular/common/locales/global`

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/esbuild/javascript-transformer-worker.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/javascript-transformer-worker.ts
@@ -50,10 +50,11 @@ async function transformWithBabel({
     return useInputSourcemap ? data : data.replace(/^\/\/# sourceMappingURL=[^\r\n]*/gm, '');
   }
 
-  // @angular/platform-server/init entry-point has side-effects.
+  // `@angular/platform-server/init` and `@angular/common/locales/global` entry-points are side effectful.
   const safeAngularPackage =
     /[\\/]node_modules[\\/]@angular[\\/]/.test(filename) &&
-    !/@angular[\\/]platform-server[\\/]f?esm2022[\\/]init/.test(filename);
+    !/@angular[\\/]platform-server[\\/]f?esm2022[\\/]init/.test(filename) &&
+    !/@angular[\\/]common[\\/]locales[\\/]global/.test(filename);
 
   // Lazy load the linker plugin only when linking is required
   if (shouldLink) {


### PR DESCRIPTION


This entry-points are side effectual.
