### PR TITLE
fix(@angular-devkit/build-angular): handle HTTP requests to assets during SSG in dev-server

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
@@ -528,9 +528,11 @@ export async function setupServer(
               }
 
               transformIndexHtmlAndAddHeaders(url, rawHtml, res, next, async (html) => {
+                const protocol = serverOptions.ssl ? 'https' : 'http';
+                const route = `${protocol}://${req.headers.host}${req.originalUrl}`;
                 const { content } = await renderPage({
                   document: html,
-                  route: pathnameWithoutServePath(url, serverOptions),
+                  route,
                   serverContext: 'ssr',
                   loadBundle: (path: string) =>
                     // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
This commit fixes an issue were during SSG/SSR in the dev-server http requests to assets causes the page rendering to fail.

