### PR TITLE
fix(@angular-devkit/build-angular): only show changed output files in watch mode with esbuild

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/application/execute-build.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/execute-build.ts
@@ -256,7 +256,16 @@ export async function executeBuild(
   }
 
   printWarningsAndErrorsToConsole(context, warnings, errors);
-  logBuildStats(context, metafile, initialFiles, budgetFailures, estimatedTransferSizes);
+  const changedFiles =
+    rebuildState && executionResult.findChangedFiles(rebuildState.previousOutputHashes);
+  logBuildStats(
+    context,
+    metafile,
+    initialFiles,
+    budgetFailures,
+    changedFiles,
+    estimatedTransferSizes,
+  );
 
   // Write metafile if stats option is enabled
   if (options.stats) {

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/bundler-execution-result.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/bundler-execution-result.ts
@@ -21,6 +21,7 @@ export interface RebuildState {
   rebuildContexts: BundlerContext[];
   codeBundleCache?: SourceFileCache;
   fileChanges: ChangedFiles;
+  previousOutputHashes: Map<string, string>;
 }
 
 /**
@@ -91,7 +92,20 @@ export class ExecutionResult {
       rebuildContexts: this.rebuildContexts,
       codeBundleCache: this.codeBundleCache,
       fileChanges,
+      previousOutputHashes: new Map(this.outputFiles.map((file) => [file.path, file.hash])),
     };
+  }
+
+  findChangedFiles(previousOutputHashes: Map<string, string>): Set<string> {
+    const changed = new Set<string>();
+    for (const file of this.outputFiles) {
+      const previousHash = previousOutputHashes.get(file.path);
+      if (previousHash === undefined || previousHash !== file.hash) {
+        changed.add(file.path);
+      }
+    }
+
+    return changed;
   }
 
   async dispose(): Promise<void> {


### PR DESCRIPTION
Similar to how the Webpack-based `browser` builder only shows the output files that have changed during watch mode (including `ng serve`), the esbuild-based builders will now also only show changed files. For large applications, this can greatly reduce the amount of text shown in the console when actively developing in watch mode.