### PR TITLE
fix(@angular-devkit/build-angular): redirect `global` and `self` to `globalThis`

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/esbuild/application-code-bundle.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/application-code-bundle.ts
@@ -298,6 +298,12 @@ export function createServerPolyfillBundleOptions(
         // See: https://github.com/evanw/esbuild/issues/1921.
         `import { createRequire } from 'node:module';`,
         `globalThis['require'] ??= createRequire(import.meta.url);`,
+
+        // The below should not be needed but in some cases libraries
+        // do not correctly check if these are undefined.
+        // TODO: consider adding a warning when these are encountered.
+        `globalThis['global'] ??= globalThis;`,
+        `globalThis['self'] ??= globalThis;`,
       ].join('\n'),
     },
     target,


### PR DESCRIPTION

In some cases libraries do not correctly check if these if `global` and self are defined.
