### PR TITLE
fix(@angular-devkit/build-angular): ensure correct web worker URL resolution in Vite dev server

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/esbuild/angular/compiler-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/angular/compiler-plugin.ts
@@ -222,8 +222,12 @@ export function createCompilerPlugin(
               file.path.endsWith('.js'),
             );
             assert(workerCodeFile, 'Web Worker bundled code file should always be present.');
+            const workerCodePath = path.relative(
+              build.initialOptions.outdir ?? '',
+              workerCodeFile.path,
+            );
 
-            return path.relative(build.initialOptions.outdir ?? '', workerCodeFile.path);
+            return workerCodePath.replaceAll('\\', '/');
           },
         };
 


### PR DESCRIPTION
When using the application builder with the development server, Web Worker URLs previously may have been incorrectly resolved. This caused Vite to consider the Web Worker URLs as outside the project root and generate a special file system URL. While this worked on Mac/Linux, it would fail on Windows. Since Vite does not appear to support resolve plugins for Web Workers, the virtual project root for the in-memory build has now been adjusted to allow the referencing file to have a path that resolves the Web Worker URL to a project relative location.