### PR TITLE
Fix empty `styles` string and update component schematic to use single `styles` or `styleUrl` property

### DIFF
--- a/packages/ngtools/webpack/src/transformers/replace_resources.ts
+++ b/packages/ngtools/webpack/src/transformers/replace_resources.ts
@@ -236,6 +236,11 @@ function transformInlineStyleLiteral(
     return node;
   }
 
+  // Don't transform empty strings as PostCSS will choke on them. No work to do anyways.
+  if (node.text === '') {
+    return node;
+  }
+
   if (!isInlineStyle) {
     const url = getResourceUrl(node);
 

--- a/packages/schematics/angular/component/files/__name@dasherize@if-flat__/__name@dasherize__.__type@dasherize__.ts.template
+++ b/packages/schematics/angular/component/files/__name@dasherize@if-flat__/__name@dasherize__.__type@dasherize__.ts.template
@@ -11,14 +11,12 @@ import { CommonModule } from '@angular/common';<% } %>
     </p>
   `<% } else { %>
   templateUrl: './<%= dasherize(name) %><%= type ? '.' + dasherize(type): '' %>.html'<% } if(inlineStyle) { %>,
-  styles: [<% if(displayBlock){ %>
-    `
-      :host {
-        display: block;
-      }
-    `<% } %>
-  ]<% } else if (style !== 'none') { %>,
-  styleUrls: ['./<%= dasherize(name) %><%= type ? '.' + dasherize(type): '' %>.<%= style %>']<% } %><% if(!!viewEncapsulation) { %>,
+  styles: `<% if(displayBlock){ %>
+    :host {
+      display: block;
+    }
+  <% } %>`<% } else if (style !== 'none') { %>,
+  styleUrl: './<%= dasherize(name) %><%= type ? '.' + dasherize(type): '' %>.<%= style %>'<% } %><% if(!!viewEncapsulation) { %>,
   encapsulation: ViewEncapsulation.<%= viewEncapsulation %><% } if (changeDetection !== 'Default') { %>,
   changeDetection: ChangeDetectionStrategy.<%= changeDetection %><% } %>
 })

--- a/packages/schematics/angular/component/index_spec.ts
+++ b/packages/schematics/angular/component/index_spec.ts
@@ -210,8 +210,8 @@ describe('Component Schematic', () => {
     const options = { ...defaultOptions, inlineStyle: true };
     const tree = await schematicRunner.runSchematic('component', options, appTree);
     const content = tree.readContent('/projects/bar/src/app/foo/foo.component.ts');
-    expect(content).toMatch(/styles: \[/);
-    expect(content).not.toMatch(/styleUrls: /);
+    expect(content).toMatch(/styles: `/);
+    expect(content).not.toMatch(/styleUrl: /);
     expect(tree.files).not.toContain('/projects/bar/src/app/foo/foo.component.css');
   });
 
@@ -247,7 +247,7 @@ describe('Component Schematic', () => {
     const options = { ...defaultOptions, style: Style.Sass };
     const tree = await schematicRunner.runSchematic('component', options, appTree);
     const content = tree.readContent('/projects/bar/src/app/foo/foo.component.ts');
-    expect(content).toMatch(/styleUrls: \['.\/foo.component.sass/);
+    expect(content).toMatch(/styleUrl: '.\/foo.component.sass/);
     expect(tree.files).toContain('/projects/bar/src/app/foo/foo.component.sass');
     expect(tree.files).not.toContain('/projects/bar/src/app/foo/foo.component.css');
   });


### PR DESCRIPTION
An array is no longer required in v17 and we always generate a single style or style URL anyways, so we may as well drop the array.

This actually revealed a bug in the Webpack compilation where an empty `styles: ''` string would break PostCSS / the Webpack loader. Fixed this by just skipping resource inlining for an empty string, since there's no work to do anyways.