### PR TITLE
refactor(@angular-devkit/build-angular): format post-bundle diagnostic messages for esbuild builders

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/extract-i18n/application-extraction.ts
+++ b/packages/angular_devkit/build_angular/src/builders/extract-i18n/application-extraction.ts
@@ -37,6 +37,7 @@ export async function extractMessages(
   buildOptions.optimization = false;
   buildOptions.sourceMap = { scripts: true, vendor: true };
   buildOptions.localize = false;
+  buildOptions.budgets = undefined;
 
   let build;
   if (builderName === '@angular-devkit/build-angular:application') {

--- a/tests/legacy-cli/e2e/tests/i18n/extract-ivy.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/extract-ivy.ts
@@ -43,7 +43,7 @@ export default async function () {
   // Should not show any warnings when extracting
   const { stderr: message5 } = await ng('extract-i18n');
   if (message5.includes('WARNING')) {
-    throw new Error('Expected no warnings to be shown');
+    throw new Error('Expected no warnings to be shown. STDERR:\n' + message5);
   }
 
   await expectFileToMatch('messages.xlf', 'Hello world');


### PR DESCRIPTION
Any errors or warnings generated from post-bundling steps of the build will now be formatted and displayed in a similar manner to the bundling errors and warnings. This should be most noticeable with bundle budgets.