### PR TITLE
fix(@angular-devkit/build-angular): skip checking CommonJS module descendants

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/esbuild/commonjs-checker.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/commonjs-checker.ts
@@ -104,11 +104,12 @@ export function checkCommonJSModules(
         }
 
         if (notAllowed) {
-          // Issue a diagnostic message and skip all descendants since they are also most
-          // likely not ESM but solved by addressing this import.
+          // Issue a diagnostic message for CommonJS module
           messages.push(createCommonJSModuleError(request, currentFile));
-          continue;
         }
+
+        // Skip all descendants since they are also most likely not ESM but solved by addressing this import
+        continue;
       }
 
       // Add the path so that its imports can be checked


### PR DESCRIPTION
When CommonJS module checking is enabled in the esbuild-based builders (`application`/`browser-esbuild`), the checker will now skip all descendants of a CommonJS module. Previously it would only skip them if the module was not allowed. This change now provides the same module checking behavior as the Webpack-based check. This makes the build behavior more consistent when migrating to the new build system.