### PR TITLE
perf(@angular-devkit/build-angular): only rebundle server polyfills on explicit changes

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/esbuild/application-code-bundle.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/application-code-bundle.ts
@@ -250,7 +250,7 @@ export function createServerPolyfillBundleOptions(
   options: NormalizedApplicationBuildOptions,
   target: string[],
   sourceFileCache?: SourceFileCache,
-): BuildOptions | undefined {
+): BundlerOptionsFactory | undefined {
   const polyfills: string[] = [];
   const zoneFlagsNamespace = 'angular:zone-flags/placeholder';
   const polyfillsFromConfig = new Set(options.polyfills);
@@ -329,7 +329,7 @@ export function createServerPolyfillBundleOptions(
 
   buildOptions.plugins.push(createRxjsEsmResolutionPlugin());
 
-  return buildOptions;
+  return () => buildOptions;
 }
 
 function getEsBuildCommonOptions(options: NormalizedApplicationBuildOptions): BuildOptions {


### PR DESCRIPTION


The newly introduced incremental bundler result caching is now used for server polyfills. This allows the bundling steps to be skipped in watch mode when no related files have been modified.
