### PR TITLE
build: use single Node.js toolchain to run unit tests

### DIFF
--- a/packages/angular/cli/BUILD.bazel
+++ b/packages/angular/cli/BUILD.bazel
@@ -6,7 +6,6 @@
 load("@npm//@bazel/jasmine:index.bzl", "jasmine_node_test")
 load("//tools:defaults.bzl", "pkg_npm", "ts_library")
 load("//tools:ng_cli_schema_generator.bzl", "cli_json_schema")
-load("//tools:toolchain_info.bzl", "TOOLCHAINS_NAMES", "TOOLCHAINS_VERSIONS")
 load("//tools:ts_json_schema.bzl", "ts_json_schema")
 
 licenses(["notice"])
@@ -146,18 +145,10 @@ ts_library(
     ],
 )
 
-[
-    jasmine_node_test(
-        name = "angular-cli_test_" + toolchain_name,
-        srcs = [":angular-cli_test_lib"],
-        tags = [toolchain_name],
-        toolchain = toolchain,
-    )
-    for toolchain_name, toolchain in zip(
-        TOOLCHAINS_NAMES,
-        TOOLCHAINS_VERSIONS,
-    )
-]
+jasmine_node_test(
+    name = "angular-cli_test",
+    srcs = [":angular-cli_test_lib"],
+)
 
 genrule(
     name = "license",

--- a/packages/angular/pwa/BUILD.bazel
+++ b/packages/angular/pwa/BUILD.bazel
@@ -6,7 +6,6 @@
 load("@npm//@bazel/jasmine:index.bzl", "jasmine_node_test")
 load("//tools:defaults.bzl", "pkg_npm", "ts_library")
 load("//tools:ts_json_schema.bzl", "ts_json_schema")
-load("//tools:toolchain_info.bzl", "TOOLCHAINS_NAMES", "TOOLCHAINS_VERSIONS")
 
 licenses(["notice"])
 
@@ -49,18 +48,10 @@ ts_library(
     ],
 )
 
-[
-    jasmine_node_test(
-        name = "pwa_test_" + toolchain_name,
-        srcs = [":pwa_test_lib"],
-        tags = [toolchain_name],
-        toolchain = toolchain,
-    )
-    for toolchain_name, toolchain in zip(
-        TOOLCHAINS_NAMES,
-        TOOLCHAINS_VERSIONS,
-    )
-]
+jasmine_node_test(
+    name = "pwa_test",
+    srcs = [":pwa_test_lib"],
+)
 
 genrule(
     name = "license",

--- a/packages/angular/ssr/schematics/BUILD.bazel
+++ b/packages/angular/ssr/schematics/BUILD.bazel
@@ -6,7 +6,6 @@
 load("@npm//@bazel/jasmine:index.bzl", "jasmine_node_test")
 load("//tools:defaults.bzl", "pkg_npm", "ts_library")
 load("//tools:ts_json_schema.bzl", "ts_json_schema")
-load("//tools:toolchain_info.bzl", "TOOLCHAINS_NAMES", "TOOLCHAINS_VERSIONS")
 
 licenses(["notice"])
 
@@ -86,23 +85,15 @@ ts_library(
     # @external_end
 )
 
-[
-    jasmine_node_test(
-        name = "ssr_schematics_test_" + toolchain_name,
-        srcs = [":ssr_schematics_test_lib"],
-        tags = [toolchain_name],
-        toolchain = toolchain,
-        deps = [
-            "@npm//jasmine",
-            "@npm//source-map",
-            "@npm//typescript",
-        ],
-    )
-    for toolchain_name, toolchain in zip(
-        TOOLCHAINS_NAMES,
-        TOOLCHAINS_VERSIONS,
-    )
-]
+jasmine_node_test(
+    name = "ssr_schematics_test",
+    srcs = [":ssr_schematics_test_lib"],
+    deps = [
+        "@npm//jasmine",
+        "@npm//source-map",
+        "@npm//typescript",
+    ],
+)
 
 # This package is intended to be combined into the main @angular/ssr package as a dep.
 pkg_npm(

--- a/packages/angular_devkit/architect/BUILD.bazel
+++ b/packages/angular_devkit/architect/BUILD.bazel
@@ -6,7 +6,6 @@
 load("@npm//@angular/build-tooling/bazel/api-golden:index.bzl", "api_golden_test_npm_package")
 load("@npm//@bazel/jasmine:index.bzl", "jasmine_node_test")
 load("//tools:defaults.bzl", "pkg_npm", "ts_library")
-load("//tools:toolchain_info.bzl", "TOOLCHAINS_NAMES", "TOOLCHAINS_VERSIONS")
 load("//tools:ts_json_schema.bzl", "ts_json_schema")
 
 licenses(["notice"])
@@ -86,18 +85,10 @@ ts_library(
     ],
 )
 
-[
-    jasmine_node_test(
-        name = "architect_test_" + toolchain_name,
-        srcs = [":architect_test_lib"],
-        tags = [toolchain_name],
-        toolchain = toolchain,
-    )
-    for toolchain_name, toolchain in zip(
-        TOOLCHAINS_NAMES,
-        TOOLCHAINS_VERSIONS,
-    )
-]
+jasmine_node_test(
+    name = "architect_test",
+    srcs = [":architect_test_lib"],
+)
 
 # @external_begin
 genrule(

--- a/packages/angular_devkit/architect/node/BUILD.bazel
+++ b/packages/angular_devkit/architect/node/BUILD.bazel
@@ -5,7 +5,6 @@
 
 load("@npm//@bazel/jasmine:index.bzl", "jasmine_node_test")
 load("//tools:defaults.bzl", "ts_library")
-load("//tools:toolchain_info.bzl", "TOOLCHAINS_NAMES", "TOOLCHAINS_VERSIONS")
 
 licenses(["notice"])
 
@@ -44,15 +43,7 @@ ts_library(
     ],
 )
 
-[
-    jasmine_node_test(
-        name = "node_test_" + toolchain_name,
-        srcs = [":node_test_lib"],
-        tags = [toolchain_name],
-        toolchain = toolchain,
-    )
-    for toolchain_name, toolchain in zip(
-        TOOLCHAINS_NAMES,
-        TOOLCHAINS_VERSIONS,
-    )
-]
+jasmine_node_test(
+    name = "node_test",
+    srcs = [":node_test_lib"],
+)

--- a/packages/angular_devkit/build_angular/BUILD.bazel
+++ b/packages/angular_devkit/build_angular/BUILD.bazel
@@ -6,7 +6,6 @@
 load("@npm//@bazel/jasmine:index.bzl", "jasmine_node_test")
 load("//tools:defaults.bzl", "pkg_npm", "ts_library")
 load("//tools:ts_json_schema.bzl", "ts_json_schema")
-load("//tools:toolchain_info.bzl", "TOOLCHAINS_NAMES", "TOOLCHAINS_VERSIONS")
 load("@npm//@angular/build-tooling/bazel/api-golden:index.bzl", "api_golden_test_npm_package")
 
 licenses(["notice"])
@@ -234,18 +233,10 @@ ts_library(
     ],
 )
 
-[
-    jasmine_node_test(
-        name = "build_angular_test_" + toolchain_name,
-        srcs = [":build_angular_test_lib"],
-        tags = [toolchain_name],
-        toolchain = toolchain,
-    )
-    for toolchain_name, toolchain in zip(
-        TOOLCHAINS_NAMES,
-        TOOLCHAINS_VERSIONS,
-    )
-]
+jasmine_node_test(
+    name = "build_angular_test",
+    srcs = [":build_angular_test_lib"],
+)
 
 genrule(
     name = "license",
@@ -426,26 +417,18 @@ LARGE_SPECS = {
 ]
 
 [
-    [
-        jasmine_node_test(
-            name = "build_angular_" + spec + "_test_" + toolchain_name,
-            size = LARGE_SPECS[spec].get("size", "medium"),
-            flaky = LARGE_SPECS[spec].get("flaky", False),
-            shard_count = LARGE_SPECS[spec].get("shards", 2),
-            # These tests are resource intensive and should not be over-parallized as they will
-            # compete for the resources of other parallel tests slowing everything down.
-            # Ask Bazel to allocate multiple CPUs for these tests with "cpu:n" tag.
-            tags = [
-                "cpu:2",
-                toolchain_name,
-            ] + LARGE_SPECS[spec].get("tags", []),
-            toolchain = toolchain,
-            deps = [":build_angular_" + spec + "_test_lib"],
-        )
-        for spec in LARGE_SPECS
-    ]
-    for toolchain_name, toolchain in zip(
-        TOOLCHAINS_NAMES,
-        TOOLCHAINS_VERSIONS,
+    jasmine_node_test(
+        name = "build_angular_" + spec + "_test",
+        size = LARGE_SPECS[spec].get("size", "medium"),
+        flaky = LARGE_SPECS[spec].get("flaky", False),
+        shard_count = LARGE_SPECS[spec].get("shards", 2),
+        # These tests are resource intensive and should not be over-parallized as they will
+        # compete for the resources of other parallel tests slowing everything down.
+        # Ask Bazel to allocate multiple CPUs for these tests with "cpu:n" tag.
+        tags = [
+            "cpu:2",
+        ] + LARGE_SPECS[spec].get("tags", []),
+        deps = [":build_angular_" + spec + "_test_lib"],
     )
+    for spec in LARGE_SPECS
 ]

--- a/packages/angular_devkit/build_webpack/BUILD.bazel
+++ b/packages/angular_devkit/build_webpack/BUILD.bazel
@@ -6,7 +6,6 @@
 load("@npm//@bazel/jasmine:index.bzl", "jasmine_node_test")
 load("//tools:defaults.bzl", "pkg_npm", "ts_library")
 load("//tools:ts_json_schema.bzl", "ts_json_schema")
-load("//tools:toolchain_info.bzl", "TOOLCHAINS_NAMES", "TOOLCHAINS_VERSIONS")
 load("@npm//@angular/build-tooling/bazel/api-golden:index.bzl", "api_golden_test_npm_package")
 
 licenses(["notice"])
@@ -33,8 +32,8 @@ ts_library(
             "src/**/*_spec.ts",
         ],
     ) + [
-        "//packages/angular_devkit/build_webpack:src/webpack/schema.ts",
         "//packages/angular_devkit/build_webpack:src/webpack-dev-server/schema.ts",
+        "//packages/angular_devkit/build_webpack:src/webpack/schema.ts",
     ],
     data = [
         "builders.json",
@@ -88,25 +87,17 @@ ts_library(
     ],
 )
 
-[
-    jasmine_node_test(
-        name = "build_webpack_test_" + toolchain_name,
-        srcs = [":build_webpack_test_lib"],
-        tags = [toolchain_name],
-        # Turns off nodejs require patches and turns on the linker, which sets up up node_modules
-        # so that standard node module resolution work.
-        templated_args = ["--nobazel_patch_module_resolver"],
-        toolchain = toolchain,
-        deps = [
-            "@npm//jasmine",
-            "@npm//source-map",
-        ],
-    )
-    for toolchain_name, toolchain in zip(
-        TOOLCHAINS_NAMES,
-        TOOLCHAINS_VERSIONS,
-    )
-]
+jasmine_node_test(
+    name = "build_webpack_test",
+    srcs = [":build_webpack_test_lib"],
+    # Turns off nodejs require patches and turns on the linker, which sets up up node_modules
+    # so that standard node module resolution work.
+    templated_args = ["--nobazel_patch_module_resolver"],
+    deps = [
+        "@npm//jasmine",
+        "@npm//source-map",
+    ],
+)
 
 genrule(
     name = "license",

--- a/packages/angular_devkit/core/BUILD.bazel
+++ b/packages/angular_devkit/core/BUILD.bazel
@@ -1,7 +1,6 @@
 load("@npm//@angular/build-tooling/bazel/api-golden:index.bzl", "api_golden_test_npm_package")
 load("@npm//@bazel/jasmine:index.bzl", "jasmine_node_test")
 load("//tools:defaults.bzl", "pkg_npm", "ts_library")
-load("//tools:toolchain_info.bzl", "TOOLCHAINS_NAMES", "TOOLCHAINS_VERSIONS")
 
 # Copyright Google Inc. All Rights Reserved.
 #
@@ -62,18 +61,10 @@ ts_library(
     ],
 )
 
-[
-    jasmine_node_test(
-        name = "core_test_" + toolchain_name,
-        srcs = [":core_test_lib"],
-        tags = [toolchain_name],
-        toolchain = toolchain,
-    )
-    for toolchain_name, toolchain in zip(
-        TOOLCHAINS_NAMES,
-        TOOLCHAINS_VERSIONS,
-    )
-]
+jasmine_node_test(
+    name = "core_test",
+    srcs = [":core_test_lib"],
+)
 
 genrule(
     name = "license",

--- a/packages/angular_devkit/core/node/BUILD.bazel
+++ b/packages/angular_devkit/core/node/BUILD.bazel
@@ -5,7 +5,6 @@
 
 load("@npm//@bazel/jasmine:index.bzl", "jasmine_node_test")
 load("//tools:defaults.bzl", "ts_library")
-load("//tools:toolchain_info.bzl", "TOOLCHAINS_NAMES", "TOOLCHAINS_VERSIONS")
 
 licenses(["notice"])
 
@@ -50,19 +49,11 @@ ts_library(
     ],
 )
 
-[
-    jasmine_node_test(
-        name = "node_test_" + toolchain_name,
-        srcs = [":node_test_lib"],
-        tags = [toolchain_name],
-        toolchain = toolchain,
-        deps = [
-            "@npm//chokidar",
-        ],
-    )
-    for toolchain_name, toolchain in zip(
-        TOOLCHAINS_NAMES,
-        TOOLCHAINS_VERSIONS,
-    )
-]
+jasmine_node_test(
+    name = "node_test",
+    srcs = [":node_test_lib"],
+    deps = [
+        "@npm//chokidar",
+    ],
+)
 # @external_end

--- a/packages/angular_devkit/schematics/BUILD.bazel
+++ b/packages/angular_devkit/schematics/BUILD.bazel
@@ -1,7 +1,6 @@
 load("@npm//@angular/build-tooling/bazel/api-golden:index.bzl", "api_golden_test_npm_package")
 load("@npm//@bazel/jasmine:index.bzl", "jasmine_node_test")
 load("//tools:defaults.bzl", "pkg_npm", "ts_library")
-load("//tools:toolchain_info.bzl", "TOOLCHAINS_NAMES", "TOOLCHAINS_VERSIONS")
 
 # Copyright Google Inc. All Rights Reserved.
 #
@@ -52,22 +51,14 @@ ts_library(
     ],
 )
 
-[
-    jasmine_node_test(
-        name = "schematics_test_" + toolchain_name,
-        srcs = [":schematics_test_lib"],
-        tags = [toolchain_name],
-        toolchain = toolchain,
-        deps = [
-            "@npm//jasmine",
-            "@npm//source-map",
-        ],
-    )
-    for toolchain_name, toolchain in zip(
-        TOOLCHAINS_NAMES,
-        TOOLCHAINS_VERSIONS,
-    )
-]
+jasmine_node_test(
+    name = "schematics_test",
+    srcs = [":schematics_test_lib"],
+    deps = [
+        "@npm//jasmine",
+        "@npm//source-map",
+    ],
+)
 
 genrule(
     name = "license",

--- a/packages/angular_devkit/schematics/tools/BUILD.bazel
+++ b/packages/angular_devkit/schematics/tools/BUILD.bazel
@@ -1,6 +1,5 @@
 load("@npm//@bazel/jasmine:index.bzl", "jasmine_node_test")
 load("//tools:defaults.bzl", "ts_library")
-load("//tools:toolchain_info.bzl", "TOOLCHAINS_NAMES", "TOOLCHAINS_VERSIONS")
 
 # Copyright Google Inc. All Rights Reserved.
 #
@@ -57,21 +56,12 @@ ts_library(
     ],
 )
 
-[
-    jasmine_node_test(
-        name = "tools_test_" + toolchain_name,
-        srcs = [":tools_test_lib"],
-        tags = [toolchain_name],
-        toolchain = toolchain,
-        deps = [
-            "@npm//jasmine",
-            "@npm//source-map",
-        ],
-    )
-    for toolchain_name, toolchain in zip(
-        TOOLCHAINS_NAMES,
-        TOOLCHAINS_VERSIONS,
-    )
-]
-
+jasmine_node_test(
+    name = "tools_test",
+    srcs = [":tools_test_lib"],
+    deps = [
+        "@npm//jasmine",
+        "@npm//source-map",
+    ],
+)
 # @external_end

--- a/packages/angular_devkit/schematics_cli/BUILD.bazel
+++ b/packages/angular_devkit/schematics_cli/BUILD.bazel
@@ -1,7 +1,6 @@
 load("@npm//@bazel/jasmine:index.bzl", "jasmine_node_test")
 load("//tools:defaults.bzl", "pkg_npm", "ts_library")
 load("//tools:ts_json_schema.bzl", "ts_json_schema")
-load("//tools:toolchain_info.bzl", "TOOLCHAINS_NAMES", "TOOLCHAINS_VERSIONS")
 
 # Copyright Google Inc. All Rights Reserved.
 #
@@ -74,18 +73,10 @@ ts_library(
     ],
 )
 
-[
-    jasmine_node_test(
-        name = "schematics_cli_test_" + toolchain_name,
-        srcs = [":schematics_cli_test_lib"],
-        tags = [toolchain_name],
-        toolchain = toolchain,
-    )
-    for toolchain_name, toolchain in zip(
-        TOOLCHAINS_NAMES,
-        TOOLCHAINS_VERSIONS,
-    )
-]
+jasmine_node_test(
+    name = "schematics_cli_test",
+    srcs = [":schematics_cli_test_lib"],
+)
 
 ts_json_schema(
     name = "blank_schema",

--- a/packages/ngtools/webpack/BUILD.bazel
+++ b/packages/ngtools/webpack/BUILD.bazel
@@ -5,7 +5,6 @@
 
 load("@npm//@bazel/jasmine:index.bzl", "jasmine_node_test")
 load("//tools:defaults.bzl", "pkg_npm", "ts_library")
-load("//tools:toolchain_info.bzl", "TOOLCHAINS_NAMES", "TOOLCHAINS_VERSIONS")
 load("@npm//@angular/build-tooling/bazel/api-golden:index.bzl", "api_golden_test_npm_package")
 
 licenses(["notice"])
@@ -55,23 +54,15 @@ ts_library(
     ],
 )
 
-[
-    jasmine_node_test(
-        name = "webpack_test_" + toolchain_name,
-        srcs = [":webpack_test_lib"],
-        tags = [toolchain_name],
-        toolchain = toolchain,
-        deps = [
-            "@npm//jasmine",
-            "@npm//source-map",
-            "@npm//tslib",
-        ],
-    )
-    for toolchain_name, toolchain in zip(
-        TOOLCHAINS_NAMES,
-        TOOLCHAINS_VERSIONS,
-    )
-]
+jasmine_node_test(
+    name = "webpack_test",
+    srcs = [":webpack_test_lib"],
+    deps = [
+        "@npm//jasmine",
+        "@npm//source-map",
+        "@npm//tslib",
+    ],
+)
 
 genrule(
     name = "license",

--- a/packages/schematics/angular/BUILD.bazel
+++ b/packages/schematics/angular/BUILD.bazel
@@ -6,7 +6,6 @@
 load("@npm//@bazel/jasmine:index.bzl", "jasmine_node_test")
 load("//tools:defaults.bzl", "pkg_npm", "ts_library")
 load("//tools:ts_json_schema.bzl", "ts_json_schema")
-load("//tools:toolchain_info.bzl", "TOOLCHAINS_NAMES", "TOOLCHAINS_VERSIONS")
 
 licenses(["notice"])
 
@@ -90,22 +89,14 @@ ts_library(
     ],
 )
 
-[
-    jasmine_node_test(
-        name = "no_typescript_runtime_dep_test_" + toolchain_name,
-        srcs = ["no_typescript_runtime_dep_spec.js"],
-        tags = [toolchain_name],
-        toolchain = toolchain,
-        deps = [
-            ":angular",
-            "@npm//jasmine",
-        ],
-    )
-    for toolchain_name, toolchain in zip(
-        TOOLCHAINS_NAMES,
-        TOOLCHAINS_VERSIONS,
-    )
-]
+jasmine_node_test(
+    name = "no_typescript_runtime_dep_test",
+    srcs = ["no_typescript_runtime_dep_spec.js"],
+    deps = [
+        ":angular",
+        "@npm//jasmine",
+    ],
+)
 
 ts_library(
     name = "angular_test_lib",
@@ -134,23 +125,15 @@ ts_library(
     # @external_end
 )
 
-[
-    jasmine_node_test(
-        name = "angular_test_" + toolchain_name,
-        srcs = [":angular_test_lib"],
-        tags = [toolchain_name],
-        toolchain = toolchain,
-        deps = [
-            "//packages/schematics/angular/third_party/github.com/Microsoft/TypeScript",
-            "@npm//jasmine",
-            "@npm//source-map",
-        ],
-    )
-    for toolchain_name, toolchain in zip(
-        TOOLCHAINS_NAMES,
-        TOOLCHAINS_VERSIONS,
-    )
-]
+jasmine_node_test(
+    name = "angular_test",
+    srcs = [":angular_test_lib"],
+    deps = [
+        "//packages/schematics/angular/third_party/github.com/Microsoft/TypeScript",
+        "@npm//jasmine",
+        "@npm//source-map",
+    ],
+)
 
 genrule(
     name = "license",


### PR DESCRIPTION
E2E tests are used to run tests on multiple platforms and node.js versions.
