### PR TITLE
fix(@angular-devkit/build-angular): Windows Node.js 20 prerendering failure

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/server-rendering/esm-in-memory-loader/loader-hooks.ts
+++ b/packages/angular_devkit/build_angular/src/utils/server-rendering/esm-in-memory-loader/loader-hooks.ts
@@ -71,7 +71,7 @@ export function resolve(
 export async function load(url: string, context: { format?: string | null }, nextLoad: Function) {
   const { format } = context;
 
-  // CommonJs modules require not transformations and are not in memory.
+  // CommonJs modules require no transformations and are not in memory.
   if (format !== 'commonjs' && isFileProtocol(url)) {
     const filePath = fileURLToPath(url);
     // Remove '/' or drive letter for Windows that was added in the above 'resolve'.

--- a/packages/angular_devkit/build_angular/src/utils/server-rendering/esm-in-memory-loader/loader-hooks.ts
+++ b/packages/angular_devkit/build_angular/src/utils/server-rendering/esm-in-memory-loader/loader-hooks.ts
@@ -69,7 +69,10 @@ export function resolve(
 }
 
 export async function load(url: string, context: { format?: string | null }, nextLoad: Function) {
-  if (isFileProtocol(url)) {
+  const { format } = context;
+
+  // CommonJs modules require not transformations and are not in memory.
+  if (format !== 'commonjs' && isFileProtocol(url)) {
     const filePath = fileURLToPath(url);
     // Remove '/' or drive letter for Windows that was added in the above 'resolve'.
     let source = outputFiles[relative('/', filePath)] ?? TRANSFORMED_FILES[filePath];
@@ -81,8 +84,6 @@ export async function load(url: string, context: { format?: string | null }, nex
     }
 
     if (source !== undefined) {
-      const { format } = context;
-
       return {
         format,
         shortCircuit: true,


### PR DESCRIPTION

On Node.js 20 prerendering failed on Windows with `An unhandled exception occurred: No handler function exported` error. This appears to be caused by transforming Piscina CJS bundles using the `JavaScriptTransformer`. interestingly, this does not effect other OS like Linux and Mac.
