### PR TITLE
Remove setClassDebugInfo calls

### DIFF
--- a/goldens/public-api/ngtools/webpack/index.md
+++ b/goldens/public-api/ngtools/webpack/index.md
@@ -35,6 +35,8 @@ export interface AngularWebpackPluginOptions {
     // (undocumented)
     emitNgModuleScope: boolean;
     // (undocumented)
+    emitSetClassDebugInfo?: boolean;
+    // (undocumented)
     fileReplacements: Record<string, string>;
     // (undocumented)
     inlineStyleFileExtension?: string;

--- a/packages/angular_devkit/build_angular/src/tools/babel/plugins/elide-angular-metadata.ts
+++ b/packages/angular_devkit/build_angular/src/tools/babel/plugins/elide-angular-metadata.ts
@@ -19,13 +19,18 @@ const SET_CLASS_METADATA_NAME = 'ɵsetClassMetadata';
 const SET_CLASS_METADATA_ASYNC_NAME = 'ɵsetClassMetadataAsync';
 
 /**
+ * Name of the function that sets debug information on classes.
+ */
+const SET_CLASS_DEBUG_INFO_NAME = 'ɵsetClassDebugInfo';
+
+/**
  * Provides one or more keywords that if found within the content of a source file indicate
  * that this plugin should be used with a source file.
  *
  * @returns An a string iterable containing one or more keywords.
  */
 export function getKeywords(): Iterable<string> {
-  return [SET_CLASS_METADATA_NAME, SET_CLASS_METADATA_ASYNC_NAME];
+  return [SET_CLASS_METADATA_NAME, SET_CLASS_METADATA_ASYNC_NAME, SET_CLASS_DEBUG_INFO_NAME];
 }
 
 /**
@@ -51,7 +56,8 @@ export default function (): PluginObj {
         if (
           calleeName !== undefined &&
           (isRemoveClassMetadataCall(calleeName, callArguments) ||
-            isRemoveClassmetadataAsyncCall(calleeName, callArguments))
+            isRemoveClassmetadataAsyncCall(calleeName, callArguments) ||
+            isSetClassDebugInfoCall(calleeName, callArguments))
         ) {
           // The metadata function is always emitted inside a function expression
           const parent = path.getFunctionParent();
@@ -95,6 +101,16 @@ function isRemoveClassmetadataAsyncCall(
     types.isIdentifier(args[0]) &&
     isInlineFunction(args[1]) &&
     isInlineFunction(args[2])
+  );
+}
+
+/** Determines if a function call is a call to `setClassDebugInfo`. */
+function isSetClassDebugInfoCall(name: string, args: types.CallExpression['arguments']): boolean {
+  return (
+    name === SET_CLASS_DEBUG_INFO_NAME &&
+    args.length === 2 &&
+    types.isIdentifier(args[0]) &&
+    types.isObjectExpression(args[1])
   );
 }
 

--- a/packages/angular_devkit/build_angular/src/tools/babel/plugins/elide-angular-metadata_spec.ts
+++ b/packages/angular_devkit/build_angular/src/tools/babel/plugins/elide-angular-metadata_spec.ts
@@ -186,4 +186,25 @@ describe('elide-angular-metadata Babel plugin', () => {
       `,
     }),
   );
+
+  it(
+    'elides arrow-function-based ɵsetClassMetadataAsync',
+    testCase({
+      input: `
+        import { Component } from '@angular/core';
+        class SomeClass {}
+        (() => {
+          (typeof ngDevMode === 'undefined' || ngDevMode) &&
+            i0.ɵsetClassDebugInfo(SomeClass, { className: 'SomeClass' });
+        })();
+      `,
+      expected: `
+        import { Component } from "@angular/core";
+        class SomeClass {}
+        (() => {
+          (typeof ngDevMode === "undefined" || ngDevMode) && void 0;
+        })();
+      `,
+    }),
+  );
 });

--- a/packages/ngtools/webpack/src/ivy/plugin.ts
+++ b/packages/ngtools/webpack/src/ivy/plugin.ts
@@ -49,6 +49,7 @@ export interface AngularWebpackPluginOptions {
   directTemplateLoading: boolean;
   emitClassMetadata: boolean;
   emitNgModuleScope: boolean;
+  emitSetClassDebugInfo?: boolean;
   jitMode: boolean;
   inlineStyleFileExtension?: string;
 }

--- a/packages/ngtools/webpack/src/ivy/transformation.ts
+++ b/packages/ngtools/webpack/src/ivy/transformation.ts
@@ -14,7 +14,11 @@ import { replaceResources } from '../transformers/replace_resources';
 
 export function createAotTransformers(
   builder: ts.BuilderProgram,
-  options: { emitClassMetadata?: boolean; emitNgModuleScope?: boolean },
+  options: {
+    emitClassMetadata?: boolean;
+    emitNgModuleScope?: boolean;
+    emitSetClassDebugInfo?: boolean;
+  },
   imageDomains: Set<string>,
 ): ts.CustomTransformers {
   const getTypeChecker = () => builder.getProgram().getTypeChecker();
@@ -25,10 +29,16 @@ export function createAotTransformers(
 
   const removeClassMetadata = !options.emitClassMetadata;
   const removeNgModuleScope = !options.emitNgModuleScope;
-  if (removeClassMetadata || removeNgModuleScope) {
+  const removeSetClassDebugInfo = !options.emitSetClassDebugInfo;
+  if (removeClassMetadata || removeNgModuleScope || removeSetClassDebugInfo) {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     transformers.before!.push(
-      removeIvyJitSupportCalls(removeClassMetadata, removeNgModuleScope, getTypeChecker),
+      removeIvyJitSupportCalls(
+        removeClassMetadata,
+        removeNgModuleScope,
+        removeSetClassDebugInfo,
+        getTypeChecker,
+      ),
     );
   }
 

--- a/packages/ngtools/webpack/src/transformers/remove-ivy-jit-support-calls.ts
+++ b/packages/ngtools/webpack/src/transformers/remove-ivy-jit-support-calls.ts
@@ -12,6 +12,7 @@ import { elideImports } from './elide_imports';
 export function removeIvyJitSupportCalls(
   classMetadata: boolean,
   ngModuleScope: boolean,
+  debugInfo: boolean,
   getTypeChecker: () => ts.TypeChecker,
 ): ts.TransformerFactory<ts.SourceFile> {
   return (context: ts.TransformationContext) => {
@@ -42,6 +43,16 @@ export function removeIvyJitSupportCalls(
 
             return undefined;
           }
+        }
+
+        if (
+          debugInfo &&
+          ts.isBinaryExpression(innerExpression) &&
+          isIvyPrivateCallExpression(innerExpression.right, 'ɵsetClassDebugInfo')
+        ) {
+          removedNodes.push(innerExpression);
+
+          return undefined;
         }
       }
 

--- a/packages/ngtools/webpack/src/transformers/remove-ivy-jit-support-calls_spec.ts
+++ b/packages/ngtools/webpack/src/transformers/remove-ivy-jit-support-calls_spec.ts
@@ -177,6 +177,16 @@ const inputAsyncArrowFn = tags.stripIndent`
       }); })();
 `;
 
+const inputDebugInfo = tags.stripIndent`
+  import { Component } from '@angular/core';
+  import * as i0 from "@angular/core";
+  export class TestCmp {
+  }
+  TestCmp.ɵfac = function TestCmp_Factory(t) { return new (t || TestCmp)(); };
+  TestCmp.ɵcmp = /*@__PURE__*/ i0.ɵɵdefineComponent({ type: TestCmp, selectors: [["test-cmp"]], decls: 0, vars: 0, template: function TestCmp_Template(rf, ctx) { }, encapsulation: 2 });
+  (() => { (typeof ngDevMode === "undefined" || ngDevMode) && i0.ɵsetClassDebugInfo(TestCmp, { className: "TestCmp" }); })();
+`;
+
 describe('@ngtools/webpack transformers', () => {
   describe('remove-ivy-dev-calls', () => {
     it('should allow removing only set class metadata with pure annotation', () => {
@@ -194,7 +204,7 @@ describe('@ngtools/webpack transformers', () => {
       `;
 
       const result = transform(input, (getTypeChecker) =>
-        removeIvyJitSupportCalls(true, false, getTypeChecker),
+        removeIvyJitSupportCalls(true, false, false, getTypeChecker),
       );
 
       expect(tags.oneLine`${result}`).toEqual(tags.oneLine`${output}`);
@@ -215,7 +225,7 @@ describe('@ngtools/webpack transformers', () => {
       `;
 
       const result = transform(inputNoPure, (getTypeChecker) =>
-        removeIvyJitSupportCalls(true, false, getTypeChecker),
+        removeIvyJitSupportCalls(true, false, false, getTypeChecker),
       );
 
       expect(tags.oneLine`${result}`).toEqual(tags.oneLine`${output}`);
@@ -248,7 +258,7 @@ describe('@ngtools/webpack transformers', () => {
       `;
 
       const result = transform(input, (getTypeChecker) =>
-        removeIvyJitSupportCalls(false, true, getTypeChecker),
+        removeIvyJitSupportCalls(false, true, false, getTypeChecker),
       );
 
       expect(tags.oneLine`${result}`).toEqual(tags.oneLine`${output}`);
@@ -281,7 +291,7 @@ describe('@ngtools/webpack transformers', () => {
       `;
 
       const result = transform(inputNoPure, (getTypeChecker) =>
-        removeIvyJitSupportCalls(false, true, getTypeChecker),
+        removeIvyJitSupportCalls(false, true, false, getTypeChecker),
       );
 
       expect(tags.oneLine`${result}`).toEqual(tags.oneLine`${output}`);
@@ -299,7 +309,7 @@ describe('@ngtools/webpack transformers', () => {
       `;
 
       const result = transform(input, (getTypeChecker) =>
-        removeIvyJitSupportCalls(true, true, getTypeChecker),
+        removeIvyJitSupportCalls(true, true, false, getTypeChecker),
       );
 
       expect(tags.oneLine`${result}`).toEqual(tags.oneLine`${output}`);
@@ -317,7 +327,7 @@ describe('@ngtools/webpack transformers', () => {
       `;
 
       const result = transform(inputNoPure, (getTypeChecker) =>
-        removeIvyJitSupportCalls(true, true, getTypeChecker),
+        removeIvyJitSupportCalls(true, true, false, getTypeChecker),
       );
 
       expect(tags.oneLine`${result}`).toEqual(tags.oneLine`${output}`);
@@ -325,7 +335,7 @@ describe('@ngtools/webpack transformers', () => {
 
     it('should allow removing neither set class metadata nor ng module scope with pure annotation', () => {
       const result = transform(input, (getTypeChecker) =>
-        removeIvyJitSupportCalls(false, false, getTypeChecker),
+        removeIvyJitSupportCalls(false, false, false, getTypeChecker),
       );
 
       expect(tags.oneLine`${result}`).toEqual(tags.oneLine`${input}`);
@@ -333,7 +343,7 @@ describe('@ngtools/webpack transformers', () => {
 
     it('should allow removing neither set class metadata nor ng module scope', () => {
       const result = transform(inputNoPure, (getTypeChecker) =>
-        removeIvyJitSupportCalls(false, false, getTypeChecker),
+        removeIvyJitSupportCalls(false, false, false, getTypeChecker),
       );
 
       expect(tags.oneLine`${result}`).toEqual(tags.oneLine`${inputNoPure}`);
@@ -364,7 +374,7 @@ describe('@ngtools/webpack transformers', () => {
       `;
 
       const result = transform(imports + input, (getTypeChecker) =>
-        removeIvyJitSupportCalls(true, true, getTypeChecker),
+        removeIvyJitSupportCalls(true, true, false, getTypeChecker),
       );
 
       expect(tags.oneLine`${result}`).toEqual(tags.oneLine`${output}`);
@@ -395,7 +405,7 @@ describe('@ngtools/webpack transformers', () => {
       `;
 
       const result = transform(imports + inputNoPure, (getTypeChecker) =>
-        removeIvyJitSupportCalls(true, true, getTypeChecker),
+        removeIvyJitSupportCalls(true, true, false, getTypeChecker),
       );
 
       expect(tags.oneLine`${result}`).toEqual(tags.oneLine`${output}`);
@@ -413,7 +423,7 @@ describe('@ngtools/webpack transformers', () => {
       `;
 
       const result = transform(inputArrowFnWithBody, (getTypeChecker) =>
-        removeIvyJitSupportCalls(true, true, getTypeChecker),
+        removeIvyJitSupportCalls(true, true, false, getTypeChecker),
       );
 
       expect(tags.oneLine`${result}`).toEqual(tags.oneLine`${output}`);
@@ -431,7 +441,7 @@ describe('@ngtools/webpack transformers', () => {
       `;
 
       const result = transform(inputArrowFnWithImplicitReturn, (getTypeChecker) =>
-        removeIvyJitSupportCalls(true, true, getTypeChecker),
+        removeIvyJitSupportCalls(true, true, false, getTypeChecker),
       );
 
       expect(tags.oneLine`${result}`).toEqual(tags.oneLine`${output}`);
@@ -446,7 +456,7 @@ describe('@ngtools/webpack transformers', () => {
       `;
 
       const result = transform(inputAsync, (getTypeChecker) =>
-        removeIvyJitSupportCalls(true, false, getTypeChecker),
+        removeIvyJitSupportCalls(true, false, false, getTypeChecker),
       );
 
       expect(tags.oneLine`${result}`).toEqual(tags.oneLine`${output}`);
@@ -461,7 +471,22 @@ describe('@ngtools/webpack transformers', () => {
       `;
 
       const result = transform(inputAsyncArrowFn, (getTypeChecker) =>
-        removeIvyJitSupportCalls(true, false, getTypeChecker),
+        removeIvyJitSupportCalls(true, false, false, getTypeChecker),
+      );
+
+      expect(tags.oneLine`${result}`).toEqual(tags.oneLine`${output}`);
+    });
+
+    it('should remove setClassDebugInfo calls', () => {
+      const output = tags.stripIndent`
+        import * as i0 from "@angular/core";
+        export class TestCmp { }
+        TestCmp.ɵfac = function TestCmp_Factory(t) { return new (t || TestCmp)(); };
+        TestCmp.ɵcmp = /*@__PURE__*/ i0.ɵɵdefineComponent({ type: TestCmp, selectors: [["test-cmp"]], decls: 0, vars: 0, template: function TestCmp_Template(rf, ctx) { }, encapsulation: 2 });
+      `;
+
+      const result = transform(inputDebugInfo, (getTypeChecker) =>
+        removeIvyJitSupportCalls(true, false, true, getTypeChecker),
       );
 
       expect(tags.oneLine`${result}`).toEqual(tags.oneLine`${output}`);


### PR DESCRIPTION
Includes a couple of commits that update the Babel and Webpack plugins to drop calls to the new `ɵsetClassDebugInfo` function which is only used in development mode.