### PR TITLE
fix(@angular-devkit/build-angular): fail build on non bundling error when using the esbuild based builders

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/application/tests/options/bundle-budgets_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/tests/options/bundle-budgets_spec.ts
@@ -42,6 +42,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
       });
 
       const { result, logs } = await harness.executeOnce();
+      expect(result?.success).toBeFalse();
       expect(logs).toContain(
         jasmine.objectContaining<logging.LogEntry>({
           level: 'error',

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/bundler-execution-result.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/bundler-execution-result.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import type { Message } from 'esbuild';
+import type { Message, PartialMessage } from 'esbuild';
 import type { ChangedFiles } from '../../tools/esbuild/watcher';
 import type { SourceFileCache } from './angular/source-file-cache';
 import type { BuildOutputFile, BuildOutputFileType, BundlerContext } from './bundler-context';
@@ -30,7 +30,7 @@ export interface RebuildState {
 export class ExecutionResult {
   outputFiles: BuildOutputFile[] = [];
   assetFiles: BuildOutputAsset[] = [];
-  errors: Message[] = [];
+  errors: (Message | PartialMessage)[] = [];
   externalMetadata?: { implicit: string[]; explicit?: string[] };
 
   constructor(
@@ -46,7 +46,7 @@ export class ExecutionResult {
     this.assetFiles.push(...assets);
   }
 
-  addErrors(errors: Message[]): void {
+  addErrors(errors: (Message | PartialMessage)[]): void {
     this.errors.push(...errors);
   }
 

--- a/tests/legacy-cli/e2e/tests/build/bundle-budgets.ts
+++ b/tests/legacy-cli/e2e/tests/build/bundle-budgets.ts
@@ -5,14 +5,11 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import { getGlobalVariable } from '../../utils/env';
 import { ng } from '../../utils/process';
 import { updateJsonFile } from '../../utils/project';
 import { expectToFail } from '../../utils/utils';
 
 export default async function () {
-  const usingWebpack = !getGlobalVariable('argv')['esbuild'];
-
   // Error
   await updateJsonFile('angular.json', (json) => {
     json.projects['test-project'].architect.build.configurations.production.budgets = [
@@ -20,17 +17,9 @@ export default async function () {
     ];
   });
 
-  if (usingWebpack) {
-    const { message: errorMessage } = await expectToFail(() => ng('build'));
-    if (!/Error.+budget/i.test(errorMessage)) {
-      throw new Error('Budget error: all, max error.');
-    }
-  } else {
-    // Application builder does not generate an error exit code for budget failures
-    const { stderr } = await ng('build');
-    if (!/Error.+budget/i.test(stderr)) {
-      throw new Error('Budget error: all, max error.');
-    }
+  const { message: errorMessage } = await expectToFail(() => ng('build'));
+  if (!/Error.+budget/i.test(errorMessage)) {
+    throw new Error('Budget error: all, max error.');
   }
 
   // Warning


### PR DESCRIPTION

This change fixes an issue were non bundling related errors that happen during prerendering, index generation and bundle budget failures did not cause the build to terminate with an error.
