### PR TITLE
refactor(@angular-devkit/build-angular): reduce complexity of bundle budget threshold regex

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/bundle-calculator.ts
+++ b/packages/angular_devkit/build_angular/src/utils/bundle-calculator.ts
@@ -290,7 +290,7 @@ class AnyComponentStyleCalculator extends Calculator {
  * Calculate the bytes given a string value.
  */
 function calculateBytes(input: string, baseline?: string, factor: 1 | -1 = 1): number {
-  const matches = input.match(/^\s*(\d+(?:\.\d+)?)\s*(%|(?:[mM]|[kK]|[gG])?[bB])?\s*$/);
+  const matches = input.trim().match(/^(\d+(?:\.\d+)?)[ \t]*(%|[kmg]?b)?$/i);
   if (!matches) {
     return NaN;
   }


### PR DESCRIPTION
The extra whitespace matching can be removed via a trim call prior to matching and casing can be handled by the `i` flag.