### PR TITLE
fix(ngtools/webpack): let static scan to find image domains in standlone components

### DIFF
--- a/packages/ngtools/webpack/src/transformers/find_image_domains_spec.ts
+++ b/packages/ngtools/webpack/src/transformers/find_image_domains_spec.ts
@@ -28,7 +28,7 @@ function findDomains(
   return domains;
 }
 
-function inputTemplate(provider: string) {
+function inputTemplateAppModule(provider: string) {
   /* eslint-disable max-len */
   return tags.stripIndent`
     export class AppModule {
@@ -56,38 +56,107 @@ function inputTemplate(provider: string) {
         }], null, null); })();
     (function () { (typeof ngJitMode === "undefined" || ngJitMode) && i0.ɵɵsetNgModuleScope(AppModule, { declarations: [AppComponent], imports: [BrowserModule,
             NgOptimizedImage] }); })();
-    `;
+  `;
+}
+
+function inputTemplateComponent(provider: string) {
+  /* eslint-disable max-len */
+  return tags.stripIndent`
+    export class AppComponent {
+      title = 'angular-cli-testbed';
+      static ɵfac = function AppComponent_Factory(t) { return new (t || AppComponent)(); };
+      static ɵcmp = /*@__PURE__*/ i0.ɵɵdefineComponent({ type: AppComponent, selectors: [["app-root"]], standalone: true, features: [i0.ɵɵProvidersFeature([
+                  ${provider}
+              ]), i0.ɵɵStandaloneFeature], decls: 2, vars: 0, template: function AppComponent_Template(rf, ctx) { if (rf & 1) {
+              i0.ɵɵelementStart(0, "div");
+              i0.ɵɵtext(1, "Hello world");
+              i0.ɵɵelementEnd();
+          } } });
+    }
+    (function () { (typeof ngDevMode === "undefined" || ngDevMode) && i0.ɵsetClassMetadata(AppComponent, [{
+            type: Component,
+            args: [{ selector: 'app-root', imports: [NgOptimizedImage, NgSwitchCase, NgSwitchDefault, NgSwitch], standalone: true, providers: [
+                        ${provider}
+                    ], template: "<div>Hello world</div>\n\n" }]
+        }], null, null); })();
+  `;
+}
+
+function runSharedTests(template: (povider: string) => string) {
+  it('should find a domain when a built-in loader is used with a string-literal-like argument', () => {
+    // Intentionally inconsistent use of quote styles in this data structure:
+    const builtInLoaders: Array<[string, string]> = [
+      ['provideCloudflareLoader("www.cloudflaredomain.com")', 'www.cloudflaredomain.com'],
+      [
+        "provideCloudinaryLoader('https://www.cloudinarydomain.net')",
+        'https://www.cloudinarydomain.net',
+      ],
+      ['provideImageKitLoader("www.imageKitdomain.com")', 'www.imageKitdomain.com'],
+      ['provideImgixLoader(`www.imgixdomain.com/images/`)', 'www.imgixdomain.com/images/'],
+    ];
+    for (const loader of builtInLoaders) {
+      const input = template(loader[0]);
+      const result = Array.from(findDomains(input));
+      expect(result.length).toBe(1);
+      expect(result[0]).toBe(loader[1]);
+    }
+  });
+
+  it('should find a domain in a custom loader function with a template literal', () => {
+    const customLoader = tags.stripIndent`
+      {
+          provide: IMAGE_LOADER,
+          useValue: (config: ImageLoaderConfig) => {
+            return ${'`https://customLoaderTemplate.com/images?src=${config.src}&width=${config.width}`'};
+          },
+        },`;
+    const input = template(customLoader);
+    const result = Array.from(findDomains(input));
+    expect(result.length).toBe(1);
+    expect(result[0]).toBe('https://customLoaderTemplate.com/');
+  });
+
+  it('should find a domain when provider is alongside other providers', () => {
+    const customLoader = tags.stripIndent`
+          {
+              provide: SOME_OTHER_PROVIDER,
+              useValue: (config: ImageLoaderConfig) => {
+              return "https://notacustomloaderstring.com/images?src=" + config.src + "&width=" + config.width;
+              },
+          },
+          provideNotARealLoader("https://www.foo.com"),
+          {
+              provide: IMAGE_LOADER,
+              useValue: (config: ImageLoaderConfig) => {
+                  return ${'`https://customloadertemplate.com/images?src=${config.src}&width=${config.width}`'};
+              },
+          },
+          {
+              provide: YET_ANOTHER_PROVIDER,
+              useValue: (config: ImageLoaderConfig) => {
+              return ${'`https://notacustomloadertemplate.com/images?src=${config.src}&width=${config.width}`'};
+              },
+          },`;
+    const input = template(customLoader);
+    const result = Array.from(findDomains(input));
+    expect(result.length).toBe(1);
+    expect(result[0]).toBe('https://customloadertemplate.com/');
+  });
 }
 
 describe('@ngtools/webpack transformers', () => {
-  describe('find_image_domains', () => {
-    it('should find a domain when a built-in loader is used with a string-literal-like argument', () => {
-      // Intentionally inconsistent use of quote styles in this data structure:
-      const builtInLoaders: Array<[string, string]> = [
-        ['provideCloudflareLoader("www.cloudflaredomain.com")', 'www.cloudflaredomain.com'],
-        [
-          "provideCloudinaryLoader('https://www.cloudinarydomain.net')",
-          'https://www.cloudinarydomain.net',
-        ],
-        ['provideImageKitLoader("www.imageKitdomain.com")', 'www.imageKitdomain.com'],
-        ['provideImgixLoader(`www.imgixdomain.com/images/`)', 'www.imgixdomain.com/images/'],
-      ];
-      for (const loader of builtInLoaders) {
-        const input = inputTemplate(loader[0]);
-        const result = Array.from(findDomains(input));
-        expect(result.length).toBe(1);
-        expect(result[0]).toBe(loader[1]);
-      }
-    });
+  describe('find_image_domains (app module)', () => {
+    runSharedTests(inputTemplateAppModule);
+    runSharedTests(inputTemplateComponent);
 
     it('should not find a domain when a built-in loader is used with a variable', () => {
-      const input = inputTemplate(`provideCloudflareLoader(myImageCDN)`);
+      const input = inputTemplateAppModule(`provideCloudflareLoader(myImageCDN)`);
       const result = Array.from(findDomains(input));
       expect(result.length).toBe(0);
     });
 
     it('should not find a domain when a built-in loader is used with an expression', () => {
-      const input = inputTemplate(
+      const input = inputTemplateAppModule(
         `provideCloudflareLoader("https://www." + (dev ? "dev." : "") + "cloudinarydomain.net")`,
       );
       const result = Array.from(findDomains(input));
@@ -95,7 +164,7 @@ describe('@ngtools/webpack transformers', () => {
     });
 
     it('should not find a domain when a built-in loader is used with a template literal', () => {
-      const input = inputTemplate(
+      const input = inputTemplateAppModule(
         'provideCloudflareLoader(`https://www.${dev ? "dev." : ""}cloudinarydomain.net`)',
       );
       const result = Array.from(findDomains(input));
@@ -103,23 +172,9 @@ describe('@ngtools/webpack transformers', () => {
     });
 
     it('should not find a domain in a function that is not a built-in loader', () => {
-      const input = inputTemplate('provideNotARealLoader("https://www.foo.com")');
+      const input = inputTemplateAppModule('provideNotARealLoader("https://www.foo.com")');
       const result = Array.from(findDomains(input));
       expect(result.length).toBe(0);
-    });
-
-    it('should find a domain in a custom loader function with a template literal', () => {
-      const customLoader = tags.stripIndent`
-        {
-            provide: IMAGE_LOADER,
-            useValue: (config: ImageLoaderConfig) => {
-              return ${'`https://customLoaderTemplate.com/images?src=${config.src}&width=${config.width}`'};
-            },
-          },`;
-      const input = inputTemplate(customLoader);
-      const result = Array.from(findDomains(input));
-      expect(result.length).toBe(1);
-      expect(result[0]).toBe('https://customLoaderTemplate.com/');
     });
 
     it('should find a domain in a custom loader function with string concatenation', () => {
@@ -130,7 +185,7 @@ describe('@ngtools/webpack transformers', () => {
               return "https://customLoaderString.com/images?src=" + config.src + "&width=" + config.width;
             },
           },`;
-      const input = inputTemplate(customLoader);
+      const input = inputTemplateAppModule(customLoader);
       const result = Array.from(findDomains(input));
       expect(result.length).toBe(1);
       expect(result[0]).toBe('https://customLoaderString.com/');
@@ -144,36 +199,9 @@ describe('@ngtools/webpack transformers', () => {
               return "https://customLoaderString.com/images?src=" + config.src + "&width=" + config.width;
             },
           },`;
-      const input = inputTemplate(customLoader);
+      const input = inputTemplateAppModule(customLoader);
       const result = Array.from(findDomains(input));
       expect(result.length).toBe(0);
-    });
-
-    it('should find a domain when provider is alongside other providers', () => {
-      const customLoader = tags.stripIndent`
-            {
-                provide: SOME_OTHER_PROVIDER,
-                useValue: (config: ImageLoaderConfig) => {
-                return "https://notacustomloaderstring.com/images?src=" + config.src + "&width=" + config.width;
-                },
-            },
-            provideNotARealLoader("https://www.foo.com"),
-            {
-                provide: IMAGE_LOADER,
-                useValue: (config: ImageLoaderConfig) => {
-                    return ${'`https://customloadertemplate.com/images?src=${config.src}&width=${config.width}`'};
-                },
-            },
-            {
-                provide: YET_ANOTHER_PROVIDER,
-                useValue: (config: ImageLoaderConfig) => {
-                return ${'`https://notacustomloadertemplate.com/images?src=${config.src}&width=${config.width}`'};
-                },
-            },`;
-      const input = inputTemplate(customLoader);
-      const result = Array.from(findDomains(input));
-      expect(result.length).toBe(1);
-      expect(result[0]).toBe('https://customloadertemplate.com/');
     });
   });
 });


### PR DESCRIPTION
Currently, the static scanning done by the image domain scanner catches domains provided in files following the AppModule pattern, but misses domains when using the standalone component module. This PR adjusts the scan path to fix that. The actual logic governing the detection of domains and inserting them into the index.html file is unchanged, this fix simply tells the scanner to also look in one additional place in files.

Specifically, the new scanning route looks for the `static ɵinj = /*@__PURE__*/ i0.ɵɵdefineInjector(...)` invocation, which exists in post-transform standalone component files, and contains the providers.

As with the existing scanning, this new code path is very specific, looking at a constant number of nodes, and should not effect build time. CC: @clydin @AndrewKushnir @kara 