### PR TITLE
refactor(@angular-devkit/build-angular): cache compiled load ESM file helper

### DIFF
--- a/packages/angular/cli/src/utilities/load-esm.ts
+++ b/packages/angular/cli/src/utilities/load-esm.ts
@@ -7,6 +7,11 @@
  */
 
 /**
+ * Lazily compiled dynamic import loader function.
+ */
+let load: (<T>(modulePath: string | URL) => Promise<T>) | undefined;
+
+/**
  * This uses a dynamic import to load a module which may be ESM.
  * CommonJS code can load ESM code via a dynamic import. Unfortunately, TypeScript
  * will currently, unconditionally downlevel dynamic import into a require call.
@@ -19,5 +24,10 @@
  * @returns A Promise that resolves to the dynamically imported module.
  */
 export function loadEsmModule<T>(modulePath: string | URL): Promise<T> {
-  return new Function('modulePath', `return import(modulePath);`)(modulePath) as Promise<T>;
+  load ??= new Function('modulePath', `return import(modulePath);`) as Exclude<
+    typeof load,
+    undefined
+  >;
+
+  return load(modulePath);
 }

--- a/packages/angular_devkit/build_angular/src/utils/load-esm.ts
+++ b/packages/angular_devkit/build_angular/src/utils/load-esm.ts
@@ -7,6 +7,11 @@
  */
 
 /**
+ * Lazily compiled dynamic import loader function.
+ */
+let load: (<T>(modulePath: string | URL) => Promise<T>) | undefined;
+
+/**
  * This uses a dynamic import to load a module which may be ESM.
  * CommonJS code can load ESM code via a dynamic import. Unfortunately, TypeScript
  * will currently, unconditionally downlevel dynamic import into a require call.
@@ -19,5 +24,10 @@
  * @returns A Promise that resolves to the dynamically imported module.
  */
 export function loadEsmModule<T>(modulePath: string | URL): Promise<T> {
-  return new Function('modulePath', `return import(modulePath);`)(modulePath) as Promise<T>;
+  load ??= new Function('modulePath', `return import(modulePath);`) as Exclude<
+    typeof load,
+    undefined
+  >;
+
+  return load(modulePath);
 }

--- a/packages/angular_devkit/schematics_cli/bin/schematics.ts
+++ b/packages/angular_devkit/schematics_cli/bin/schematics.ts
@@ -490,6 +490,11 @@ if (require.main === module) {
 }
 
 /**
+ * Lazily compiled dynamic import loader function.
+ */
+let load: (<T>(modulePath: string | URL) => Promise<T>) | undefined;
+
+/**
  * This uses a dynamic import to load a module which may be ESM.
  * CommonJS code can load ESM code via a dynamic import. Unfortunately, TypeScript
  * will currently, unconditionally downlevel dynamic import into a require call.
@@ -502,5 +507,10 @@ if (require.main === module) {
  * @returns A Promise that resolves to the dynamically imported module.
  */
 export function loadEsmModule<T>(modulePath: string | URL): Promise<T> {
-  return new Function('modulePath', `return import(modulePath);`)(modulePath) as Promise<T>;
+  load ??= new Function('modulePath', `return import(modulePath);`) as Exclude<
+    typeof load,
+    undefined
+  >;
+
+  return load(modulePath);
 }


### PR DESCRIPTION
The dynamically compiled ESM import helper is now cached to prevent the need to recompile the helper function everytime a load ESM helper call is made. This helper is currently used to workaround dynamic import limitations with the TypeScript compilation output. Once the build process is updated, it will no longer be required.