### PR TITLE
refactor(@angular-devkit/build-angular): add experimental extension points to Vite-based dev server

### DIFF
--- a/goldens/public-api/angular_devkit/build_angular/index.md
+++ b/goldens/public-api/angular_devkit/build_angular/index.md
@@ -4,11 +4,14 @@
 
 ```ts
 
+/// <reference types="node" />
+
 import { BuilderContext } from '@angular-devkit/architect';
 import { BuilderOutput } from '@angular-devkit/architect';
 import type { ConfigOptions } from 'karma';
 import { Configuration } from 'webpack';
 import { DevServerBuildOutput } from '@angular-devkit/build-webpack';
+import type http from 'node:http';
 import { json } from '@angular-devkit/core';
 import { Observable } from 'rxjs';
 import { OutputFile } from 'esbuild';
@@ -204,7 +207,10 @@ export function executeDevServerBuilder(options: DevServerBuilderOptions, contex
     webpackConfiguration?: ExecutionTransformer<Configuration>;
     logging?: WebpackLoggingCallback;
     indexHtml?: IndexHtmlTransform;
-}, plugins?: Plugin_2[]): Observable<DevServerBuilderOutput>;
+}, extensions?: {
+    buildPlugins?: Plugin_2[];
+    middleware?: ((req: http.IncomingMessage, res: http.ServerResponse, next: (err?: unknown) => void) => void)[];
+}): Observable<DevServerBuilderOutput>;
 
 // @public
 export function executeExtractI18nBuilder(options: ExtractI18nBuilderOptions, context: BuilderContext, transforms?: {


### PR DESCRIPTION
When using the experimental programmatic API for the development server with an esbuild-based builder (`application`/`browser-esbuild`), express compatible middleware can now be added. Also, the index HTML transformer that previously only worked with the Webpack-based development server is also now enabled.
However, usage of these options may result in unexpected application output and/or build failures. They are also not officially supported and SemVer guarantees are not present. Stable and supported methods for build process extension are being evaluated for a future release.