### PR TITLE
fix(@angular-devkit/build-angular): remove CJS usage warnings for inactionable packages

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/server-rendering/render-worker.ts
+++ b/packages/angular_devkit/build_angular/src/utils/server-rendering/render-worker.ts
@@ -28,7 +28,7 @@ export interface RenderOptions {
 const { outputFiles, document, inlineCriticalCss } = workerData as RenderWorkerData;
 
 /** Renders an application based on a provided options. */
-async function render(options: RenderOptions): Promise<RenderResult> {
+function render(options: RenderOptions): Promise<RenderResult> {
   return renderPage({
     ...options,
     outputFiles,


### PR DESCRIPTION


This commit add `critters` and `express` to the CJS allowed deps.
