### PR TITLE
perf(@angular-devkit/build-angular): optimize server or browser only dependencies once

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/application/execute-build.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/execute-build.ts
@@ -169,11 +169,9 @@ export async function executeBuild(
 
   // Analyze external imports if external options are enabled
   if (options.externalPackages || options.externalDependencies?.length) {
+    const { browser = new Set(), server = new Set() } = bundlingResult.externalImports;
     // TODO: Filter externalImports to generate second argument to support wildcard externalDependency values
-    executionResult.setExternalMetadata(
-      [...bundlingResult.externalImports],
-      options.externalDependencies,
-    );
+    executionResult.setExternalMetadata([...browser], [...server], options.externalDependencies);
   }
 
   const { metafile, initialFiles, outputFiles } = bundlingResult;

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/bundler-execution-result.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/bundler-execution-result.ts
@@ -24,6 +24,12 @@ export interface RebuildState {
   previousOutputHashes: Map<string, string>;
 }
 
+export interface ExternalResultMetadata {
+  implicitBrowser: string[];
+  implicitServer: string[];
+  explicit: string[];
+}
+
 /**
  * Represents the result of a single builder execute call.
  */
@@ -31,7 +37,7 @@ export class ExecutionResult {
   outputFiles: BuildOutputFile[] = [];
   assetFiles: BuildOutputAsset[] = [];
   errors: (Message | PartialMessage)[] = [];
-  externalMetadata?: { implicit: string[]; explicit?: string[] };
+  externalMetadata?: ExternalResultMetadata;
 
   constructor(
     private rebuildContexts: BundlerContext[],
@@ -53,11 +59,16 @@ export class ExecutionResult {
   /**
    * Add external JavaScript import metadata to the result. This is currently used
    * by the development server to optimize the prebundling process.
-   * @param implicit External dependencies due to the external packages option.
+   * @param implicitBrowser External dependencies for the browser bundles due to the external packages option.
+   * @param implicitServer External dependencies for the server bundles due to the external packages option.
    * @param explicit External dependencies due to explicit project configuration.
    */
-  setExternalMetadata(implicit: string[], explicit: string[] | undefined) {
-    this.externalMetadata = { implicit, explicit };
+  setExternalMetadata(
+    implicitBrowser: string[],
+    implicitServer: string[],
+    explicit: string[] | undefined,
+  ): void {
+    this.externalMetadata = { implicitBrowser, implicitServer, explicit: explicit ?? [] };
   }
 
   get output() {


### PR DESCRIPTION

This commit splits the retrieval of external dependencies into two. Server imports and browser imports. This is so that we avoid vite from optimizing server or browser only dependencies twice.

This also fixes an issue were in some cases Vite would issue a warning like `Cannot optimize dependency: path, present in 'optimizeDeps.include'`. This was caused because of server only dependencies ended up trying to be optimized for a browser build.

