### PR TITLE
fix(@angular-devkit/build-angular): ensure secondary Angular compilations are unblocked on start errors

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/esbuild/angular/compiler-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/angular/compiler-plugin.ts
@@ -418,6 +418,9 @@ export function createCompilerPlugin(
       }
 
       build.onEnd((result) => {
+        // Ensure other compilations are unblocked if the main compilation throws during start
+        sharedTSCompilationState?.markAsReady();
+
         for (const { outputFiles, metafile } of additionalResults.values()) {
           // Add any additional output files to the main output files
           if (outputFiles?.length) {


### PR DESCRIPTION
When using the esbuild-based builders (`application`/`browser-esbuild`), the secondary Angular compilations will wait for the primary compilation to finish prior to bundling. This can potentially occur for polyfills that contain TypeScript files and the server code if enabled. However, if the Angular compilation throws an error during the start of the bundling process, the secondary compilations were never notified and instead would wait indefinitely. To avoid this situation, the compilations will now always be notified at the end of the compilation which will occur regardless. The build error that will be generated in these situations is currently not ideal and more verbose than needed but will provide information pertaining to the root cause.

Closes #26213