### PR TITLE
refactor(@angular-devkit/build-angular): allow JS transformer result reuse for application dev-server builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
@@ -109,6 +109,7 @@ export async function* serveWithVite(
     // have a negative effect unlike production where final output size is relevant.
     { sourcemap: true, jit: true },
     1,
+    true,
   );
 
   // Extract output index from options


### PR DESCRIPTION
The `JavaScriptTransformer` class that is responsible for Angular linking and several build optimization transformations can now be configured to track and reuse previous and pending transformation requests. This allows for cases where multiple consumers of the class will not cause repeat transformation actions. Pending results will be stored if the constructor option `reuseResults` is enabled. If two transformation requests are issued for the same file, the same underlying result will be provided to each. This behavior currently only applies to file transformation requests.