### PR TITLE
fix(@angular-devkit/build-angular): normalize exclude path

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/karma/tests/options/exclude_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/tests/options/exclude_spec.ts
@@ -31,10 +31,29 @@ describeBuilder(execute, KARMA_BUILDER_INFO, (harness) => {
       expect(result?.success).toBeFalse();
     });
 
-    it(`should exclude spec that matches the 'exclude' pattern`, async () => {
+    it(`should exclude spec that matches the 'exclude' glob pattern`, async () => {
       harness.useTarget('test', {
         ...BASE_OPTIONS,
         exclude: ['**/error.spec.ts'],
+      });
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
+    });
+
+    it(`should exclude spec that matches the 'exclude' pattern with a relative project root`, async () => {
+      harness.useTarget('test', {
+        ...BASE_OPTIONS,
+        exclude: ['src/app/error.spec.ts'],
+      });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
+    });
+
+    it(`should exclude spec that matches the 'exclude' pattern prefixed with a slash`, async () => {
+      harness.useTarget('test', {
+        ...BASE_OPTIONS,
+        exclude: ['/src/app/error.spec.ts'],
       });
 
       const { result } = await harness.executeOnce();


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

The issue arises from passing `exclude` paths directly to the glob method, which can confuse users when they provide relative project roots or backslashes. This problem doesn't occur with `include` paths because those are automatically normalized. 

Issue Number: #26239

## What is the new behavior?

The `exclude` paths are now normalized for common user errors, such as the use of backslashes or relative project roots. This also unifies, to a certain extent, how `include` and `exclude` paths are transformed internally by the builder.

The remaining normalization steps for `include` are already informed to the developer, so now all the normalization for `include` & `exclude` are either unified or documented.
![image](https://github.com/angular/angular-cli/assets/24195616/9bf16231-07cd-49aa-a9be-e72c8ef00614)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
