### PR TITLE
fix(@angular-devkit/build-angular): disable parallel TS/NG compilation inside WebContainers

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/environment-options.ts
+++ b/packages/angular_devkit/build_angular/src/utils/environment-options.ts
@@ -78,8 +78,11 @@ export const allowMinify = debugOptimize.minify;
 const maxWorkersVariable = process.env['NG_BUILD_MAX_WORKERS'];
 export const maxWorkers = isPresent(maxWorkersVariable) ? +maxWorkersVariable : 4;
 
+// Default to enabled unless inside a Web Container which currently fails when transferring MessagePort objects
 const parallelTsVariable = process.env['NG_BUILD_PARALLEL_TS'];
-export const useParallelTs = !isPresent(parallelTsVariable) || !isDisabled(parallelTsVariable);
+export const useParallelTs = isPresent(parallelTsVariable)
+  ? !isDisabled(parallelTsVariable)
+  : !process.versions.webcontainer;
 
 const legacySassVariable = process.env['NG_BUILD_LEGACY_SASS'];
 export const useLegacySass: boolean = (() => {


### PR DESCRIPTION
When using the `application` or `browser-esbuild` builders, a parallel TS/NG compilation will be used by default via a Node.js Worker. However, when used inside a Web Container, the build will fail to initialize the compilation instance due to what appears to be a defect within Web containers involving the transfer/serialization of a MessageChannel's MessagePort objects. To avoid this problem, the parallel compilation is disabled by default when the build system detects it is being executed from within a Web Container. A parallel compilation can still be forced by using the `NG_BUILD_PARALLEL_TS=1` environment variable.