### PR TITLE
test(@angular-devkit/build-angular): add test to validate vite cache re-usage

### DIFF
--- a/tests/legacy-cli/e2e.bzl
+++ b/tests/legacy-cli/e2e.bzl
@@ -34,6 +34,7 @@ ESBUILD_TESTS = [
     "tests/commands/add/**",
     "tests/commands/e2e/**",
     "tests/i18n/**",
+    "tests/vite/**",
     "tests/test/**",
 ]
 

--- a/tests/legacy-cli/e2e/tests/vite/reuse-dep-optimization-cache.ts
+++ b/tests/legacy-cli/e2e/tests/vite/reuse-dep-optimization-cache.ts
@@ -1,0 +1,45 @@
+import assert from 'node:assert';
+import { findFreePort } from '../../utils/network';
+import { execAndWaitForOutputToMatch, killAllProcesses, ng } from '../../utils/process';
+import { getGlobalVariable } from '../../utils/env';
+
+export default async function () {
+  const useWebpackBuilder = !getGlobalVariable('argv')['esbuild'];
+  if (useWebpackBuilder) {
+    return;
+  }
+
+  await ng('cache', 'clean');
+  await ng('cache', 'on');
+
+  try {
+    const port = await findFreePort();
+
+    // Make sure serve is consistent with build
+    await execAndWaitForOutputToMatch(
+      'ng',
+      ['serve', '--port', `${port}`],
+      /vite:deps Dependencies bundled/,
+      // Use CI:0 to force caching
+      { DEBUG: 'vite:deps', CI: '0' },
+    );
+
+    // Make request so that vite writes the cache.
+    const response = await fetch(`http://localhost:${port}/@vite/client`);
+    assert(response.ok, `Expected 'response.ok' to be 'true'.`);
+
+    // Terminate the dev-server
+    await killAllProcesses();
+
+    // The Node.js specific module should not be found
+    await execAndWaitForOutputToMatch(
+      'ng',
+      ['serve', '--port=0'],
+      /vite:deps Hash is consistent\. Skipping/,
+      // Use CI:0 to force caching
+      { DEBUG: 'vite:deps', CI: '0' },
+    );
+  } finally {
+    await killAllProcesses();
+  }
+}


### PR DESCRIPTION

This commit adds a test to verify that vite uses the dep optimization cache

