### PR TITLE
fix(@angular-devkit/build-angular): allow SSR compilation to work with TS allowJs option

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/esbuild/angular/compiler-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/angular/compiler-plugin.ts
@@ -264,6 +264,7 @@ export function createCompilerPlugin(
 
         if (compilation instanceof NoopCompilation) {
           await sharedTSCompilationState.waitUntilReady;
+          hasCompilationErrors = false;
 
           return result;
         }


### PR DESCRIPTION
When using the `application` builder with SSR enabled and the `allowJs` TypeScript option, the build would previously generate warnings about undefined imports. This was caused by the recently introduced initialization error handling that was not accounting for the early exit of the SSR compiler plugin's `onStart` hook. This early exit prevent the error status checking from completing which resulted in the SSR plugin load hook assuming an error had occurred. This in turn caused JavaScript files that were not imported into TypeScript files to be returned as empty content to avoid the not found error message. To remedy this situation, the error status is now also set during the SSR early exit.