### PR TITLE
fix(@angular-devkit/build-angular): disable Worker wait loop for TS/NG parallel compilation in web containers

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/esbuild/angular/compilation/parallel-compilation.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/angular/compilation/parallel-compilation.ts
@@ -36,6 +36,9 @@ export class ParallelCompilation extends AngularCompilation {
       minThreads: 1,
       maxThreads: 1,
       idleTimeout: Infinity,
+      // Web containers do not support transferable objects with receiveOnMessagePort which
+      // is used when the Atomics based wait loop is enable.
+      useAtomics: !process.versions.webcontainer,
       filename: localRequire.resolve('./parallel-worker'),
     });
   }

--- a/packages/angular_devkit/build_angular/src/utils/environment-options.ts
+++ b/packages/angular_devkit/build_angular/src/utils/environment-options.ts
@@ -78,11 +78,8 @@ export const allowMinify = debugOptimize.minify;
 const maxWorkersVariable = process.env['NG_BUILD_MAX_WORKERS'];
 export const maxWorkers = isPresent(maxWorkersVariable) ? +maxWorkersVariable : 4;
 
-// Default to enabled unless inside a Web Container which currently fails when transferring MessagePort objects
 const parallelTsVariable = process.env['NG_BUILD_PARALLEL_TS'];
-export const useParallelTs = isPresent(parallelTsVariable)
-  ? !isDisabled(parallelTsVariable)
-  : !process.versions.webcontainer;
+export const useParallelTs = !isPresent(parallelTsVariable) || !isDisabled(parallelTsVariable);
 
 const legacySassVariable = process.env['NG_BUILD_LEGACY_SASS'];
 export const useLegacySass: boolean = (() => {


### PR DESCRIPTION
When using the `application` builder, a parallel TS/NG compilation is used that is run inside a Node.js Worker.
This Worker by default uses an Atomics-based wait loop to improve performance while waiting for messages. This
loop relies on the synchronous API `receiveMessageOnPort`. While this works well in Node.js, the web container
execution environment does not currently support passing transferable objects via `receiveMessageOnPort`. Attempting
to do so will cause a serialization error and a failed application build. To avoid this problem, the wait loop
optimization is disabled when the web container execution environment is detected. This change is only needed
for the TS/NG compilation as no other parallel operation within the build system currently uses `receiveMessageOnPort`
with transferable objects.