### PR TITLE
fix(@schematics/angular): use href property binding for links

### DIFF
--- a/packages/schematics/angular/application/files/common-files/src/app/app.component.html.template
+++ b/packages/schematics/angular/application/files/common-files/src/app/app.component.html.template
@@ -240,7 +240,7 @@
         ]; track item.title) {
           <a
             class="pill"
-            href="{{ item.link }}"
+            [href]="item.link"
             target="_blank"
             rel="noopener"
           >


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [ ] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

The default template uses interpolation instead of a property binding to set the the href value.

## What is the new behavior?

Use `[href]="item.title"`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
