### PR TITLE
build: set `flaky_test_attempts` to `2` for E2E tests

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -94,6 +94,9 @@ build:e2e --workspace_status_command="yarn -s ng-dev release build-env-stamp --m
 build:e2e --stamp
 test:e2e --test_timeout=3600 --experimental_ui_max_stdouterr_bytes=2097152
 
+# Retry in the event of flakes
+test:e2e --flaky_test_attempts=2
+
 build:local --//:enable_package_json_tar_deps
 
 ###############################


### PR DESCRIPTION
By default Bazel, a single test attempt will be made for regular tests and three for tests marked explicitly as flaky by their rule (flaky=1 attribute)

This configures e2e tests to retry the test when it fails.
