### PR TITLE
fix(@schematics/angular): use styleUrl

### DIFF
--- a/packages/schematics/angular/application/files/module-files/src/app/app.component.ts.template
+++ b/packages/schematics/angular/application/files/module-files/src/app/app.component.ts.template
@@ -11,7 +11,7 @@ import { Component } from '@angular/core';
   `,<% } else { %>
   templateUrl: './app.component.html',<% } if(inlineStyle) { %>
   styles: []<% } else { %>
-  styleUrls: ['./app.component.<%= style %>']<% } %>
+  styleUrl: './app.component.<%= style %>'<% } %>
 })
 export class AppComponent {
   title = '<%= name %>';

--- a/packages/schematics/angular/application/files/standalone-files/src/app/app.component.ts.template
+++ b/packages/schematics/angular/application/files/standalone-files/src/app/app.component.ts.template
@@ -15,7 +15,7 @@ import { RouterOutlet } from '@angular/router';<% } %>
   `,<% } else { %>
   templateUrl: './app.component.html',<% } if(inlineStyle) { %>
   styles: [],<% } else { %>
-  styleUrls: ['./app.component.<%= style %>']<% } %>
+  styleUrl: './app.component.<%= style %>'<% } %>
 })
 export class AppComponent {
   title = '<%= name %>';

--- a/tests/legacy-cli/e2e/tests/build/styles/include-paths.ts
+++ b/tests/legacy-cli/e2e/tests/build/styles/include-paths.ts
@@ -27,8 +27,8 @@ export default async function () {
 
   await replaceInFile(
     'src/app/app.component.ts',
-    `'./app.component.css\'`,
-    `'./app.component.scss', './app.component.less'`,
+    `styleUrl: './app.component.css\'`,
+    `styleUrls: ['./app.component.scss', './app.component.less']`,
   );
 
   await updateJsonFile('angular.json', (workspaceJson) => {


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

The `ng g c` schematic is already using `styleUrl`, but `app.component.ts` was still using `styleUrls`.

## What is the new behavior?

`app.component.ts` now uses `styleUrl` by default.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
