### PR TITLE
fix(@angular-devkit/build-angular): empty output directory instead of removing

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/output-path_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/output-path_spec.ts
@@ -21,7 +21,7 @@ describe('Browser Builder output path', () => {
   });
   afterEach(async () => host.restore().toPromise());
 
-  it('deletes output path', async () => {
+  it('deletes output path content', async () => {
     // Write a file to the output path to later verify it was deleted.
     await host
       .write(join(host.root(), 'dist/file.txt'), virtualFs.stringToFileBuffer('file'))
@@ -34,14 +34,14 @@ describe('Browser Builder output path', () => {
     const run = await architect.scheduleTarget(target);
     const output = await run.result;
     expect(output.success).toBe(false);
-    expect(await host.exists(join(host.root(), 'dist')).toPromise()).toBe(false);
+    expect(await host.exists(join(host.root(), 'dist/file.txt')).toPromise()).toBe(false);
     await run.stop();
   });
 
-  it('deletes output path and unlink symbolic link', async () => {
+  it('deletes output path content and unlink symbolic link', async () => {
     // Write a file to the output path to later verify it was deleted.
     host.writeMultipleFiles({
-      'src-link/dummy.txt': '',
+      'src-link/a.txt': '',
       'dist/file.txt': virtualFs.stringToFileBuffer('file'),
     });
 
@@ -63,8 +63,8 @@ describe('Browser Builder output path', () => {
     const output = await run.result;
     expect(output.success).toBe(false);
 
-    expect(await host.exists(join(host.root(), 'dist')).toPromise()).toBe(false);
-    expect(await host.exists(join(host.root(), 'src-link')).toPromise()).toBe(true);
+    expect(await host.exists(join(host.root(), 'dist/file.txt')).toPromise()).toBe(false);
+    expect(await host.exists(join(host.root(), 'src-link/a.txt')).toPromise()).toBe(true);
     await run.stop();
   });
 


### PR DESCRIPTION
When the `deleteOutputPath` option is enabled (default is enabled), the configured `outputPath` for the project was previously removed directly. This was problematic for cases such as when the path was mounted via a Docker setup. To alleviate these issues, the contents of the output path will now be removed instead. This maintains the existing output path directory itself but ensures an empty location to place the new build output.

Closes #26223