### PR TITLE
 fix(@angular-devkit/build-angular): rewire sourcemap back to original source root

### DIFF
--- a/tests/legacy-cli/e2e.bzl
+++ b/tests/legacy-cli/e2e.bzl
@@ -38,6 +38,10 @@ ESBUILD_TESTS = [
     "tests/test/**",
 ]
 
+WEBPACK_IGNORE_TESTS = [
+    "tests/vite/**",
+]
+
 def _to_glob(patterns):
     if len(patterns) == 1:
         return patterns[0]
@@ -126,7 +130,7 @@ def _e2e_suite(name, runner, type, data, toolchain_name = "", toolchain = None):
     if type == "yarn":
         args.append("--yarn")
         tests = YARN_TESTS
-        ignore = BROWSER_TESTS
+        ignore = BROWSER_TESTS + WEBPACK_IGNORE_TESTS
     elif type == "esbuild":
         args.append("--esbuild")
         tests = ESBUILD_TESTS
@@ -137,7 +141,7 @@ def _e2e_suite(name, runner, type, data, toolchain_name = "", toolchain = None):
         ignore = None
     elif type == "npm":
         tests = None
-        ignore = BROWSER_TESTS
+        ignore = BROWSER_TESTS + WEBPACK_IGNORE_TESTS
 
     # Standard e2e tests
     _e2e_tests(

--- a/tests/legacy-cli/e2e/tests/vite/reuse-dep-optimization-cache.ts
+++ b/tests/legacy-cli/e2e/tests/vite/reuse-dep-optimization-cache.ts
@@ -2,14 +2,8 @@ import { setTimeout } from 'node:timers/promises';
 import assert from 'node:assert';
 import { findFreePort } from '../../utils/network';
 import { execAndWaitForOutputToMatch, killAllProcesses, ng } from '../../utils/process';
-import { getGlobalVariable } from '../../utils/env';
 
 export default async function () {
-  const useWebpackBuilder = !getGlobalVariable('argv')['esbuild'];
-  if (useWebpackBuilder) {
-    return;
-  }
-
   await ng('cache', 'clean');
   await ng('cache', 'on');
 

--- a/tests/legacy-cli/e2e/tests/vite/ssr-error-stack.ts
+++ b/tests/legacy-cli/e2e/tests/vite/ssr-error-stack.ts
@@ -1,0 +1,38 @@
+import { doesNotMatch, match } from 'node:assert';
+import { killAllProcesses, ng } from '../../utils/process';
+import { appendToFile, rimraf } from '../../utils/fs';
+import { ngServe, useSha } from '../../utils/project';
+import { installWorkspacePackages } from '../../utils/packages';
+
+export default async function () {
+  // Forcibly remove in case another test doesn't clean itself up.
+  await rimraf('node_modules/@angular/ssr');
+  await ng('add', '@angular/ssr', '--skip-confirmation');
+  await useSha();
+  await installWorkspacePackages();
+
+  try {
+    // Create Error.
+    await appendToFile(
+      'src/app/app.component.ts',
+      `
+      (() => {
+        throw new Error('something happened!');
+      })();
+      `,
+    );
+
+    const port = await ngServe();
+    const response = await fetch(`http://localhost:${port}/`);
+    const text = await response.text();
+
+    // The error is also sent in the browser, so we don't need to scrap the stderr.
+    match(
+      text,
+      /something happened.+at eval \(.+\/e2e-test[\\\/]test-project[\\\/]src[\\\/]app[\\\/]app\.component\.ts:\d+:\d+\)/,
+    );
+    doesNotMatch(text, /vite-root/);
+  } finally {
+    await killAllProcesses();
+  }
+}


### PR DESCRIPTION
Prior to this change, when a error occurs when using the SSR dev-server the stacktraces pointed back to the virtual root path.