### PR TITLE
fix(@schematics/angular): remove `downlevelIteration` from `tsconfig.json` for new workspaces

### DIFF
--- a/packages/schematics/angular/workspace/files/tsconfig.json.template
+++ b/packages/schematics/angular/workspace/files/tsconfig.json.template
@@ -12,7 +12,6 @@
     "esModuleInterop": true,
     "sourceMap": true,
     "declaration": false,
-    "downlevelIteration": true,
     "experimentalDecorators": true,
     "moduleResolution": "node",
     "importHelpers": true,


### PR DESCRIPTION

We no longer need `downlevelIteration` as ES5 is output is no longer supported by the CLI.
