### PR TITLE
refactor(@angular-devkit/build-angular): remove unused plugin from server polyfills

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/esbuild/application-code-bundle.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/application-code-bundle.ts
@@ -282,7 +282,6 @@ export function createServerPolyfillBundleOptions(
     return;
   }
 
-  const { workspaceRoot } = options;
   const buildOptions: BuildOptions = {
     ...polyfillBundleOptions,
     platform: 'node',
@@ -306,9 +305,6 @@ export function createServerPolyfillBundleOptions(
       'polyfills.server': namespace,
     },
   };
-
-  buildOptions.plugins ??= [];
-  buildOptions.plugins.push(createRxjsEsmResolutionPlugin());
 
   return () => buildOptions;
 }


### PR DESCRIPTION

RxJs is not imported in the server polyfills and thus we can safely remove this plugin.
