### PR TITLE
fix(@angular-devkit/build-angular): `deleteOutputPath` when using `esbuild-builder`

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/application/tests/options/delete-output-path_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/tests/options/delete-output-path_spec.ts
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { buildApplication } from '../../index';
+import { APPLICATION_BUILDER_INFO, BASE_OPTIONS, describeBuilder } from '../setup';
+
+describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
+  describe('Option: "deleteOutputPath"', () => {
+    beforeEach(async () => {
+      // Application code is not needed for asset tests
+      await harness.writeFile('src/main.ts', 'console.log("TEST");');
+
+      // Add file in output
+      await harness.writeFile('dist/dummy.txt', '');
+    });
+
+    it(`should delete the output files when 'deleteOutputPath' is true`, async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        deleteOutputPath: true,
+      });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
+      harness.expectFile('dist/dummy.txt').toNotExist();
+    });
+
+    it(`should delete the output files when 'deleteOutputPath' is not set`, async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        deleteOutputPath: undefined,
+      });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
+      harness.expectFile('dist/dummy.txt').toNotExist();
+    });
+
+    it(`should not delete the output files when 'deleteOutputPath' is false`, async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        deleteOutputPath: false,
+      });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
+      harness.expectFile('dist/dummy.txt').toExist();
+    });
+  });
+});

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
@@ -14,6 +14,7 @@ import path from 'node:path';
 import { BuildOutputFile } from '../../tools/esbuild/bundler-context';
 import { BuildOutputAsset } from '../../tools/esbuild/bundler-execution-result';
 import { emitFilesToDisk } from '../../tools/esbuild/utils';
+import { deleteOutputDir } from '../../utils';
 import { buildApplicationInternal } from '../application';
 import { Schema as ApplicationBuilderOptions } from '../application/schema';
 import { logBuilderStatusWarnings } from './builder-status-warnings';
@@ -42,7 +43,12 @@ export async function* buildEsbuildBrowser(
   // Inform user of status of builder and options
   logBuilderStatusWarnings(userOptions, context);
   const normalizedOptions = normalizeOptions(userOptions);
-  const fullOutputPath = path.join(context.workspaceRoot, normalizedOptions.outputPath);
+  const { deleteOutputPath, outputPath } = normalizedOptions;
+  const fullOutputPath = path.join(context.workspaceRoot, outputPath);
+
+  if (deleteOutputPath && infrastructureSettings?.write !== false) {
+    await deleteOutputDir(context.workspaceRoot, outputPath);
+  }
 
   for await (const result of buildApplicationInternal(
     normalizedOptions,

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/tests/options/delete-output-path_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/tests/options/delete-output-path_spec.ts
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { buildEsbuildBrowser } from '../../index';
+import { BASE_OPTIONS, BROWSER_BUILDER_INFO, describeBuilder } from '../setup';
+
+describeBuilder(buildEsbuildBrowser, BROWSER_BUILDER_INFO, (harness) => {
+  describe('Option: "deleteOutputPath"', () => {
+    beforeEach(async () => {
+      // Application code is not needed for asset tests
+      await harness.writeFile('src/main.ts', 'console.log("TEST");');
+
+      // Add file in output
+      await harness.writeFile('dist/dummy.txt', '');
+    });
+
+    it(`should delete the output files when 'deleteOutputPath' is true`, async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        deleteOutputPath: true,
+      });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
+      harness.expectFile('dist/dummy.txt').toNotExist();
+    });
+
+    it(`should delete the output files when 'deleteOutputPath' is not set`, async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        deleteOutputPath: undefined,
+      });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
+      harness.expectFile('dist/dummy.txt').toNotExist();
+    });
+
+    it(`should not delete the output files when 'deleteOutputPath' is false`, async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        deleteOutputPath: false,
+      });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
+      harness.expectFile('dist/dummy.txt').toExist();
+    });
+  });
+});

--- a/packages/angular_devkit/build_angular/src/builders/browser/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/index.ts
@@ -107,7 +107,7 @@ async function initialize(
   }
 
   if (options.deleteOutputPath) {
-    deleteOutputDir(context.workspaceRoot, originalOutputPath);
+    await deleteOutputDir(context.workspaceRoot, originalOutputPath);
   }
 
   return { config: transformedConfig || config, projectRoot, projectSourceRoot, i18n };

--- a/packages/angular_devkit/build_angular/src/builders/server/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/server/index.ts
@@ -217,7 +217,7 @@ async function initialize(
     );
 
   if (options.deleteOutputPath) {
-    deleteOutputDir(context.workspaceRoot, originalOutputPath);
+    await deleteOutputDir(context.workspaceRoot, originalOutputPath);
   }
 
   const transformedConfig = (await webpackConfigurationTransform?.(config)) ?? config;

--- a/packages/angular_devkit/build_angular/src/utils/delete-output-dir.ts
+++ b/packages/angular_devkit/build_angular/src/utils/delete-output-dir.ts
@@ -6,13 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import * as fs from 'fs';
-import { join, resolve } from 'path';
+import { readdir, rm } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
 
 /**
  * Delete an output directory, but error out if it's the root of the project.
  */
-export function deleteOutputDir(root: string, outputPath: string): void {
+export async function deleteOutputDir(root: string, outputPath: string): Promise<void> {
   const resolvedOutputPath = resolve(root, outputPath);
   if (resolvedOutputPath === root) {
     throw new Error('Output path MUST not be project root directory!');
@@ -22,7 +22,7 @@ export function deleteOutputDir(root: string, outputPath: string): void {
   // directory is mounted or symlinked. Instead the contents are removed.
   let entries;
   try {
-    entries = fs.readdirSync(resolvedOutputPath);
+    entries = await readdir(resolvedOutputPath);
   } catch (error) {
     if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
       return;
@@ -31,6 +31,6 @@ export function deleteOutputDir(root: string, outputPath: string): void {
   }
 
   for (const entry of entries) {
-    fs.rmSync(join(resolvedOutputPath, entry), { force: true, recursive: true, maxRetries: 3 });
+    await rm(join(resolvedOutputPath, entry), { force: true, recursive: true, maxRetries: 3 });
   }
 }


### PR DESCRIPTION


Prior to this change the `deleteOutputPath` was not being used in the esbuild-builder.

Closes #26308
