### PR TITLE
fix(@angular-devkit/build-angular): prerender default view when no routes are defined

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/routes-extractor/extractor.ts
+++ b/packages/angular_devkit/build_angular/src/utils/routes-extractor/extractor.ts
@@ -117,10 +117,15 @@ export async function* extractRoutes(
 
     const injector = applicationRef.injector;
     const router = injector.get(Router);
-    const compiler = injector.get(Compiler);
 
-    // Extract all the routes from the config.
-    yield* getRoutesFromRouterConfig(router.config, compiler, injector);
+    if (router.config.length === 0) {
+      // In case there are no routes available
+      yield { route: '', success: true, redirect: false };
+    } else {
+      const compiler = injector.get(Compiler);
+      // Extract all the routes from the config.
+      yield* getRoutesFromRouterConfig(router.config, compiler, injector);
+    }
   } finally {
     platformRef.destroy();
   }


### PR DESCRIPTION

Prior to the commit, when no routes were defined the default view was not prerendering.

Closes #26317
