### PR TITLE
fix(@schematics/angular): add helper script to spawn SSR server from `dist`

### DIFF
--- a/packages/schematics/angular/ssr/index.ts
+++ b/packages/schematics/angular/ssr/index.ts
@@ -57,23 +57,28 @@ async function getOutputPath(
   return outputPath;
 }
 
-function addScriptsRule(options: SSROptions): Rule {
+function addScriptsRule({ project }: SSROptions, isUsingApplicationBuilder: boolean): Rule {
   return async (host) => {
     const pkgPath = '/package.json';
-    const buffer = host.read(pkgPath);
-    if (buffer === null) {
+    const pkg = host.readJson(pkgPath) as { scripts?: Record<string, string> } | null;
+    if (pkg === null) {
       throw new SchematicsException('Could not find package.json');
     }
 
-    const serverDist = await getOutputPath(host, options.project, 'server');
-    const pkg = JSON.parse(buffer.toString()) as { scripts?: Record<string, string> };
-    pkg.scripts = {
-      ...pkg.scripts,
-      'dev:ssr': `ng run ${options.project}:${SERVE_SSR_TARGET_NAME}`,
-      'serve:ssr': `node ${serverDist}/main.js`,
-      'build:ssr': `ng build && ng run ${options.project}:server`,
-      'prerender': `ng run ${options.project}:${PRERENDER_TARGET_NAME}`,
-    };
+    if (isUsingApplicationBuilder) {
+      const distPath = await getOutputPath(host, project, 'build');
+      pkg.scripts ??= {};
+      pkg.scripts[`serve:ssr:${project}`] = `node ${distPath}/server/server.mjs`;
+    } else {
+      const serverDist = await getOutputPath(host, project, 'server');
+      pkg.scripts = {
+        ...pkg.scripts,
+        'dev:ssr': `ng run ${project}:${SERVE_SSR_TARGET_NAME}`,
+        'serve:ssr': `node ${serverDist}/main.js`,
+        'build:ssr': `ng build && ng run ${project}:server`,
+        'prerender': `ng run ${project}:${PRERENDER_TARGET_NAME}`,
+      };
+    }
 
     host.overwrite(pkgPath, JSON.stringify(pkg, null, 2));
   };
@@ -278,11 +283,11 @@ export default function (options: SSROptions): Rule {
             updateApplicationBuilderTsConfigRule(options),
           ]
         : [
-            addScriptsRule(options),
             updateWebpackBuilderServerTsConfigRule(options),
             updateWebpackBuilderWorkspaceConfigRule(options),
           ]),
       addServerFile(options, isStandalone),
+      addScriptsRule(options, isUsingApplicationBuilder),
       addDependencies(),
     ]);
   };

--- a/packages/schematics/angular/ssr/index_spec.ts
+++ b/packages/schematics/angular/ssr/index_spec.ts
@@ -136,6 +136,13 @@ describe('SSR Schematic', () => {
           bootstrap,
       `);
     });
+
+    it('should add script section in package.json', async () => {
+      const tree = await schematicRunner.runSchematic('ssr', defaultOptions, appTree);
+      const { scripts } = tree.readJson('/package.json') as { scripts: Record<string, string> };
+
+      expect(scripts['serve:ssr:test-app']).toBe(`node dist/test-app/server/server.mjs`);
+    });
   });
 
   describe('Legacy browser builder', () => {


### PR DESCRIPTION


This commit adds a helper script in the `package.json` when running `ng add @angular/ssr` or `ng new --ssr` that can be used to spawn the SSR server.

Example of script:
```json
{
    "scripts": {
       "serve:ssr:my-app": "node dist/my-app/server/server.mjs"
    }
}
```

Closes #26315
