### PR TITLE
fix(@angular-devkit/build-angular): ensure compilation errors propagate to all bundle actions

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/esbuild/angular/compiler-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/angular/compiler-plugin.ts
@@ -263,8 +263,7 @@ export function createCompilerPlugin(
         }
 
         if (compilation instanceof NoopCompilation) {
-          await sharedTSCompilationState.waitUntilReady;
-          hasCompilationErrors = false;
+          hasCompilationErrors = await sharedTSCompilationState.waitUntilReady;
 
           return result;
         }
@@ -318,7 +317,7 @@ export function createCompilerPlugin(
         // Reset the setup warnings so that they are only shown during the first build.
         setupWarnings = undefined;
 
-        sharedTSCompilationState.markAsReady();
+        sharedTSCompilationState.markAsReady(hasCompilationErrors);
 
         return result;
       });
@@ -409,7 +408,7 @@ export function createCompilerPlugin(
 
       build.onEnd((result) => {
         // Ensure other compilations are unblocked if the main compilation throws during start
-        sharedTSCompilationState?.markAsReady();
+        sharedTSCompilationState?.markAsReady(hasCompilationErrors);
 
         for (const { outputFiles, metafile } of additionalResults.values()) {
           // Add any additional output files to the main output files


### PR DESCRIPTION
If the TypeScript and/or Angular AOT compiler fails to initialize or emit files due to an error, the shared compilation state between the browser code bundle action and any additional bundle actions (polyfills, server, etc.) will now carry an error flag to ensure that the additional bundle actions bypass file emit. The file emit bypass is necessary in these cases to prevent an unintentional and misleading error about a file not being included in the compilation.