### PR TITLE
fix(@angular-devkit/build-angular): add support for vendor sourcemaps when using the dev-server

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
@@ -106,7 +106,7 @@ export async function* serveWithVite(
     // Always enable JIT linking to support applications built with and without AOT.
     // In a development environment the additional scope information does not
     // have a negative effect unlike production where final output size is relevant.
-    { sourcemap: true, jit: true },
+    { sourcemap: true, jit: true, thirdPartySourcemaps: true },
     1,
     true,
   );


### PR DESCRIPTION

Prior to this change the vendor sourcemaps were never generated when using vite prebundling.