### PR TITLE
fix(@angular/cli): handle packages with no version

### DIFF
--- a/packages/angular/cli/src/utilities/package-metadata.ts
+++ b/packages/angular/cli/src/utilities/package-metadata.ts
@@ -249,6 +249,11 @@ export async function fetchPackageMetadata(
     ...(registry ? { registry } : {}),
   });
 
+  if (!response.versions) {
+    // While pacote type declares that versions cannot be undefined this is not the case.
+    response.versions = {};
+  }
+
   // Normalize the response
   const metadata: PackageMetadata = {
     ...response,
@@ -312,6 +317,13 @@ export async function getNpmPackageJson(
     fullMetadata: true,
     ...npmrc,
     ...(registry ? { registry } : {}),
+  }).then((response) => {
+    // While pacote type declares that versions cannot be undefined this is not the case.
+    if (!response.versions) {
+      response.versions = {};
+    }
+
+    return response;
   });
 
   npmPackageJsonCache.set(packageName, response);


### PR DESCRIPTION
In some cases pacote will return undefined as `version` which resulted in `Cannot convert undefined or null to object`.

Closes #26337
