### PR TITLE
refactor(@angular-devkit/build-angular): use native path normalization for angular compiler caching

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/esbuild/angular/source-file-cache.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/angular/source-file-cache.ts
@@ -8,7 +8,6 @@
 
 import { platform } from 'node:os';
 import * as path from 'node:path';
-import { pathToFileURL } from 'node:url';
 import type ts from 'typescript';
 import { MemoryLoadResultCache } from '../load-result-cache';
 
@@ -17,7 +16,6 @@ const WINDOWS_SEP_REGEXP = new RegExp(`\\${path.win32.sep}`, 'g');
 
 export class SourceFileCache extends Map<string, ts.SourceFile> {
   readonly modifiedFiles = new Set<string>();
-  readonly babelFileCache = new Map<string, Uint8Array>();
   readonly typeScriptFileCache = new Map<string, string | Uint8Array>();
   readonly loadResultCache = new MemoryLoadResultCache();
 
@@ -32,8 +30,8 @@ export class SourceFileCache extends Map<string, ts.SourceFile> {
       this.modifiedFiles.clear();
     }
     for (let file of files) {
-      this.babelFileCache.delete(file);
-      this.typeScriptFileCache.delete(pathToFileURL(file).href);
+      file = path.normalize(file);
+      this.typeScriptFileCache.delete(file);
       this.loadResultCache.invalidate(file);
 
       // Normalize separators to allow matching TypeScript Host paths

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/load-result-cache.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/load-result-cache.ts
@@ -32,6 +32,11 @@ export function createCachedLoad(
 
       // Do not cache null or undefined
       if (result) {
+        // Ensure requested path is included if it was a resolved file
+        if (args.namespace === 'file') {
+          result.watchFiles ??= [];
+          result.watchFiles.push(args.path);
+        }
         await cache.put(loadCacheKey, result);
       }
     }
@@ -79,6 +84,8 @@ export class MemoryLoadResultCache implements LoadResultCache {
   }
 
   get watchFiles(): string[] {
-    return [...this.#loadResults.keys(), ...this.#fileDependencies.keys()];
+    // this.#loadResults.keys() is not included here because the keys
+    // are namespaced request paths and not disk-based file paths.
+    return [...this.#fileDependencies.keys()];
   }
 }


### PR DESCRIPTION
The path comparisons for the TypeScript emit file lookups now use the native path normalization functions. This removes the special handling previously used and better ensures that cache checks are valid. The separate babel cache Map has also been combined with the already present memory load cache within the Angular plugin. This removes the need for extra handling of another Map and allows it to use the common logic of the load cache. To support this usage, the load cache will also now automatically include the request path in the file dependencies if the request is from the `file` namespace. This removes the need to manually specify the request path file for each load result return value.