### PR TITLE
fix(@angular-devkit/build-angular): emit root files when `localize` is enabled when using the esbuild based builders

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/application/i18n.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/i18n.ts
@@ -8,7 +8,7 @@
 
 import { BuilderContext } from '@angular-devkit/architect';
 import { join, posix } from 'node:path';
-import { InitialFileRecord } from '../../tools/esbuild/bundler-context';
+import { BuildOutputFileType, InitialFileRecord } from '../../tools/esbuild/bundler-context';
 import { ExecutionResult } from '../../tools/esbuild/bundler-execution-result';
 import { I18nInliner } from '../../tools/esbuild/i18n-inliner';
 import { maxWorkers } from '../../utils/environment-options';
@@ -108,8 +108,13 @@ export async function inlineI18n(
     await inliner.close();
   }
 
-  // Update the result with all localized files
-  executionResult.outputFiles = updatedOutputFiles;
+  // Update the result with all localized files.
+  executionResult.outputFiles = [
+    // Root files are not modified.
+    ...executionResult.outputFiles.filter(({ type }) => type === BuildOutputFileType.Root),
+    // Updated files for each locale.
+    ...updatedOutputFiles,
+  ];
 
   // Assets are only changed if not using the flat output option
   if (options.i18nOptions.flatOutput !== true) {

--- a/packages/angular_devkit/build_angular/src/builders/application/tests/options/extract-licenses_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/tests/options/extract-licenses_spec.ts
@@ -18,7 +18,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
       });
 
       const { result } = await harness.executeOnce();
-      expect(result?.success).toBe(true);
+      expect(result?.success).toBeTrue();
       harness.expectFile('dist/3rdpartylicenses.txt').content.toContain('MIT');
     });
 
@@ -29,7 +29,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
       });
 
       const { result } = await harness.executeOnce();
-      expect(result?.success).toBe(true);
+      expect(result?.success).toBeTrue();
       harness.expectFile('dist/3rdpartylicenses.txt').toNotExist();
     });
 
@@ -39,8 +39,21 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
       });
 
       const { result } = await harness.executeOnce();
-      expect(result?.success).toBe(true);
+      expect(result?.success).toBeTrue();
       harness.expectFile('dist/3rdpartylicenses.txt').content.toContain('MIT');
+    });
+
+    it(`should generate '3rdpartylicenses.txt' when 'extractLicenses' and 'localize' are true`, async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        localize: true,
+        extractLicenses: true,
+      });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
+      harness.expectFile('dist/3rdpartylicenses.txt').content.toContain('MIT');
+      harness.expectFile('dist/browser/en-US/main.js').toExist();
     });
   });
 });


### PR DESCRIPTION

This commit adds back the root files to the `outputFiles` when localize is enabled.

Closes #26386
