### PR TITLE
fix(@angular-devkit/build-angular): ensure watch file paths from TypeScript are normalized

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/esbuild/bundler-execution-result.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/bundler-execution-result.ts
@@ -7,6 +7,7 @@
  */
 
 import type { Message, PartialMessage } from 'esbuild';
+import { normalize } from 'node:path';
 import type { ChangedFiles } from '../../tools/esbuild/watcher';
 import type { SourceFileCache } from './angular/source-file-cache';
 import type { BuildOutputFile, BuildOutputFileType, BundlerContext } from './bundler-context';
@@ -88,11 +89,15 @@ export class ExecutionResult {
   }
 
   get watchFiles() {
+    // Bundler contexts internally normalize file dependencies
     const files = this.rebuildContexts.flatMap((context) => [...context.watchFiles]);
     if (this.codeBundleCache?.referencedFiles) {
-      files.push(...this.codeBundleCache.referencedFiles);
+      // These files originate from TS/NG and can have POSIX path separators even on Windows.
+      // To ensure path comparisons are valid, all these paths must be normalized.
+      files.push(...this.codeBundleCache.referencedFiles.map(normalize));
     }
     if (this.codeBundleCache?.loadResultCache) {
+      // Load result caches internally normalize file dependencies
       files.push(...this.codeBundleCache.loadResultCache.watchFiles);
     }
 


### PR DESCRIPTION
The TypeScript compiler converts all paths to use POSIX path separators. When on Windows, this can cause problems when comparing paths from other parts of the build system including the file watching provided by `chokidar`. The referenced files returned from the TypeScript compiler are now normalized to the native path format to mitigate this problem. This also avoids an issue where the same files but with differing path separators were included in the watch files list on Windows due to the bundler using native paths and TypeScript using converted paths.
