### PR TITLE
test: attempt to reduce flakiness of Vite cache reuse test

### DIFF
--- a/tests/legacy-cli/e2e/tests/vite/reuse-dep-optimization-cache.ts
+++ b/tests/legacy-cli/e2e/tests/vite/reuse-dep-optimization-cache.ts
@@ -1,43 +1,43 @@
-import { setTimeout } from 'node:timers/promises';
 import assert from 'node:assert';
 import { findFreePort } from '../../utils/network';
-import { execAndWaitForOutputToMatch, killAllProcesses, ng } from '../../utils/process';
+import {
+  execAndWaitForOutputToMatch,
+  killAllProcesses,
+  ng,
+  waitForAnyProcessOutputToMatch,
+} from '../../utils/process';
 
 export default async function () {
   await ng('cache', 'clean');
   await ng('cache', 'on');
 
-  try {
-    const port = await findFreePort();
+  const port = await findFreePort();
 
-    // Make sure serve is consistent with build
-    await execAndWaitForOutputToMatch(
-      'ng',
-      ['serve', '--port', `${port}`],
-      /vite:deps Dependencies bundled/,
-      // Use CI:0 to force caching
-      { DEBUG: 'vite:deps', CI: '0' },
-    );
+  // Make sure serve is consistent with build
+  await execAndWaitForOutputToMatch(
+    'ng',
+    ['serve', '--port', `${port}`],
+    /Dependencies bundled/,
+    // Use CI:0 to force caching
+    { DEBUG: 'vite:deps', CI: '0' },
+  );
 
-    // Make request so that vite writes the cache.
-    const response = await fetch(`http://localhost:${port}/@vite/client`);
-    assert(response.ok, `Expected 'response.ok' to be 'true'.`);
+  // Make request so that vite writes the cache.
+  const response = await fetch(`http://localhost:${port}/main.js`);
+  assert(response.ok, `Expected 'response.ok' to be 'true'.`);
 
-    // Wait for vite to write to FS and stablize.
-    await setTimeout(2_000);
+  // Wait for vite to write to FS and stablize.
+  await waitForAnyProcessOutputToMatch(/dependencies optimized/, 5000);
 
-    // Terminate the dev-server
-    await killAllProcesses();
+  // Terminate the dev-server
+  await killAllProcesses();
 
-    // The Node.js specific module should not be found
-    await execAndWaitForOutputToMatch(
-      'ng',
-      ['serve', '--port=0'],
-      /vite:deps Hash is consistent\. Skipping/,
-      // Use CI:0 to force caching
-      { DEBUG: 'vite:deps', CI: '0' },
-    );
-  } finally {
-    await killAllProcesses();
-  }
+  // The Node.js specific module should not be found
+  await execAndWaitForOutputToMatch(
+    'ng',
+    ['serve', '--port=0'],
+    /Hash is consistent\. Skipping/,
+    // Use CI:0 to force caching
+    { DEBUG: 'vite:deps', CI: '0' },
+  );
 }


### PR DESCRIPTION
The test is changed to now wait for Vite to output that it has optimized the dependencies
after a request to the main application chunk. This removes the need to wait a specific
amount of time between steps. The `vite:deps` part of the console text check was also
removed to avoid any potential comparison problems with ansi color codes.
The final `killAllProcesses` is also removed since the test runner will always run that
function at the end of every test.