### PR TITLE
test: remove unneeded kill-all-processes calls in E2E tests

### DIFF
--- a/tests/legacy-cli/e2e/tests/basic/serve.ts
+++ b/tests/legacy-cli/e2e/tests/basic/serve.ts
@@ -2,18 +2,14 @@ import { killAllProcesses } from '../../utils/process';
 import { ngServe } from '../../utils/project';
 
 export default async function () {
-  try {
-    // Serve works without HMR
-    const noHmrPort = await ngServe('--no-hmr');
-    await verifyResponse(noHmrPort);
-    await killAllProcesses();
+  // Serve works without HMR
+  const noHmrPort = await ngServe('--no-hmr');
+  await verifyResponse(noHmrPort);
+  await killAllProcesses();
 
-    // Serve works with HMR
-    const hmrPort = await ngServe('--hmr');
-    await verifyResponse(hmrPort);
-  } finally {
-    await killAllProcesses();
-  }
+  // Serve works with HMR
+  const hmrPort = await ngServe('--hmr');
+  await verifyResponse(hmrPort);
 }
 
 async function verifyResponse(port: number): Promise<void> {

--- a/tests/legacy-cli/e2e/tests/build/poll.ts
+++ b/tests/legacy-cli/e2e/tests/build/poll.ts
@@ -1,6 +1,6 @@
 import { getGlobalVariable } from '../../utils/env';
 import { appendToFile } from '../../utils/fs';
-import { killAllProcesses, waitForAnyProcessOutputToMatch } from '../../utils/process';
+import { waitForAnyProcessOutputToMatch } from '../../utils/process';
 import { ngServe } from '../../utils/project';
 import { expectToFail, wait } from '../../utils/utils';
 
@@ -9,24 +9,20 @@ const webpackGoodRegEx = getGlobalVariable('argv')['esbuild']
   : / Compiled successfully\./;
 
 export default async function () {
-  try {
-    await ngServe('--poll=10000');
+  await ngServe('--poll=10000');
 
-    // Wait before editing a file.
-    // Editing too soon seems to trigger a rebuild and throw polling out of whack.
-    await wait(3000);
-    await appendToFile('src/main.ts', 'console.log(1);');
+  // Wait before editing a file.
+  // Editing too soon seems to trigger a rebuild and throw polling out of whack.
+  await wait(3000);
+  await appendToFile('src/main.ts', 'console.log(1);');
 
-    // We have to wait poll time + rebuild build time for the regex match.
-    await waitForAnyProcessOutputToMatch(webpackGoodRegEx, 14000);
+  // We have to wait poll time + rebuild build time for the regex match.
+  await waitForAnyProcessOutputToMatch(webpackGoodRegEx, 14000);
 
-    // No rebuilds should occur for a while
-    await appendToFile('src/main.ts', 'console.log(1);');
-    await expectToFail(() => waitForAnyProcessOutputToMatch(webpackGoodRegEx, 7000));
+  // No rebuilds should occur for a while
+  await appendToFile('src/main.ts', 'console.log(1);');
+  await expectToFail(() => waitForAnyProcessOutputToMatch(webpackGoodRegEx, 7000));
 
-    // But a rebuild should happen roughly within the 10 second window.
-    await waitForAnyProcessOutputToMatch(webpackGoodRegEx, 7000);
-  } finally {
-    await killAllProcesses();
-  }
+  // But a rebuild should happen roughly within the 10 second window.
+  await waitForAnyProcessOutputToMatch(webpackGoodRegEx, 7000);
 }

--- a/tests/legacy-cli/e2e/tests/build/rebuild-deps-type-check.ts
+++ b/tests/legacy-cli/e2e/tests/build/rebuild-deps-type-check.ts
@@ -1,8 +1,4 @@
-import {
-  killAllProcesses,
-  waitForAnyProcessOutputToMatch,
-  execAndWaitForOutputToMatch,
-} from '../../utils/process';
+import { waitForAnyProcessOutputToMatch, execAndWaitForOutputToMatch } from '../../utils/process';
 import { writeFile, prependToFile, appendToFile } from '../../utils/fs';
 import { getGlobalVariable } from '../../utils/env';
 
@@ -129,6 +125,5 @@ export default function () {
           throw new Error('Expected no error but an error was shown.');
         }
       })
-      .finally(() => killAllProcesses())
   );
 }

--- a/tests/legacy-cli/e2e/tests/build/rebuild-replacements.ts
+++ b/tests/legacy-cli/e2e/tests/build/rebuild-replacements.ts
@@ -1,6 +1,6 @@
 import { getGlobalVariable } from '../../utils/env';
 import { appendToFile, createDir, writeMultipleFiles } from '../../utils/fs';
-import { killAllProcesses, waitForAnyProcessOutputToMatch } from '../../utils/process';
+import { waitForAnyProcessOutputToMatch } from '../../utils/process';
 import { ngServe, updateJsonFile } from '../../utils/project';
 
 const webpackGoodRegEx = getGlobalVariable('argv')['esbuild']
@@ -14,32 +14,28 @@ export default async function () {
 
   await createDir('src/environments');
 
-  try {
-    await writeMultipleFiles({
-      'src/environments/environment.ts': `export const env = 'dev';`,
-      'src/environments/environment.prod.ts': `export const env = 'prod';`,
-      'src/main.ts': `
+  await writeMultipleFiles({
+    'src/environments/environment.ts': `export const env = 'dev';`,
+    'src/environments/environment.prod.ts': `export const env = 'prod';`,
+    'src/main.ts': `
         import { env } from './environments/environment';
         console.log(env);
       `,
-    });
+  });
 
-    await updateJsonFile('angular.json', (workspaceJson) => {
-      const appArchitect = workspaceJson.projects['test-project'].architect;
-      appArchitect.build.configurations.production.fileReplacements = [
-        {
-          replace: 'src/environments/environment.ts',
-          with: 'src/environments/environment.prod.ts',
-        },
-      ];
-    });
+  await updateJsonFile('angular.json', (workspaceJson) => {
+    const appArchitect = workspaceJson.projects['test-project'].architect;
+    appArchitect.build.configurations.production.fileReplacements = [
+      {
+        replace: 'src/environments/environment.ts',
+        with: 'src/environments/environment.prod.ts',
+      },
+    ];
+  });
 
-    await ngServe('--configuration=production');
+  await ngServe('--configuration=production');
 
-    // Should trigger a rebuild.
-    await appendToFile('src/environments/environment.prod.ts', `console.log('PROD');`);
-    await waitForAnyProcessOutputToMatch(webpackGoodRegEx);
-  } finally {
-    await killAllProcesses();
-  }
+  // Should trigger a rebuild.
+  await appendToFile('src/environments/environment.prod.ts', `console.log('PROD');`);
+  await waitForAnyProcessOutputToMatch(webpackGoodRegEx);
 }

--- a/tests/legacy-cli/e2e/tests/build/rebuild-types.ts
+++ b/tests/legacy-cli/e2e/tests/build/rebuild-types.ts
@@ -1,8 +1,4 @@
-import {
-  killAllProcesses,
-  waitForAnyProcessOutputToMatch,
-  execAndWaitForOutputToMatch,
-} from '../../utils/process';
+import { waitForAnyProcessOutputToMatch, execAndWaitForOutputToMatch } from '../../utils/process';
 import { writeFile, prependToFile } from '../../utils/fs';
 import { getGlobalVariable } from '../../utils/env';
 
@@ -20,14 +16,10 @@ export default async function () {
   await writeFile('src/app/type.ts', `export type MyType = number;`);
   await prependToFile('src/app/app.component.ts', 'import { MyType } from "./type";\n');
 
-  try {
-    await execAndWaitForOutputToMatch('ng', ['serve'], successRe);
+  await execAndWaitForOutputToMatch('ng', ['serve'], successRe);
 
-    await Promise.all([
-      waitForAnyProcessOutputToMatch(successRe, 20000),
-      writeFile('src/app/type.ts', `export type MyType = string;`),
-    ]);
-  } finally {
-    await killAllProcesses();
-  }
+  await Promise.all([
+    waitForAnyProcessOutputToMatch(successRe, 20000),
+    writeFile('src/app/type.ts', `export type MyType = string;`),
+  ]);
 }

--- a/tests/legacy-cli/e2e/tests/build/ssr/express-engine-csp-nonce.ts
+++ b/tests/legacy-cli/e2e/tests/build/ssr/express-engine-csp-nonce.ts
@@ -2,7 +2,7 @@ import { getGlobalVariable } from '../../../utils/env';
 import { rimraf, writeMultipleFiles } from '../../../utils/fs';
 import { findFreePort } from '../../../utils/network';
 import { installWorkspacePackages } from '../../../utils/packages';
-import { execAndWaitForOutputToMatch, killAllProcesses, ng } from '../../../utils/process';
+import { execAndWaitForOutputToMatch, ng } from '../../../utils/process';
 import { updateJsonFile, useSha } from '../../../utils/project';
 
 export default async function () {
@@ -154,10 +154,6 @@ export default async function () {
     return port;
   }
 
-  try {
-    const port = await ngDevSsr();
-    await ng('e2e', `--base-url=http://localhost:${port}`, '--dev-server-target=');
-  } finally {
-    await killAllProcesses();
-  }
+  const port = await ngDevSsr();
+  await ng('e2e', `--base-url=http://localhost:${port}`, '--dev-server-target=');
 }

--- a/tests/legacy-cli/e2e/tests/build/ssr/express-engine-ngmodule.ts
+++ b/tests/legacy-cli/e2e/tests/build/ssr/express-engine-ngmodule.ts
@@ -2,7 +2,7 @@ import { getGlobalVariable } from '../../../utils/env';
 import { rimraf, writeMultipleFiles } from '../../../utils/fs';
 import { findFreePort } from '../../../utils/network';
 import { installWorkspacePackages } from '../../../utils/packages';
-import { execAndWaitForOutputToMatch, killAllProcesses, ng } from '../../../utils/process';
+import { execAndWaitForOutputToMatch, ng } from '../../../utils/process';
 import { updateJsonFile, useCIChrome, useCIDefaults, useSha } from '../../../utils/project';
 
 export default async function () {
@@ -158,15 +158,11 @@ export default async function () {
     return port;
   }
 
-  try {
-    const port = await ngDevSsr();
-    await ng(
-      'e2e',
-      'test-project-two',
-      `--base-url=http://localhost:${port}`,
-      '--dev-server-target=',
-    );
-  } finally {
-    await killAllProcesses();
-  }
+  const port = await ngDevSsr();
+  await ng(
+    'e2e',
+    'test-project-two',
+    `--base-url=http://localhost:${port}`,
+    '--dev-server-target=',
+  );
 }

--- a/tests/legacy-cli/e2e/tests/build/ssr/express-engine-standalone.ts
+++ b/tests/legacy-cli/e2e/tests/build/ssr/express-engine-standalone.ts
@@ -2,7 +2,7 @@ import { getGlobalVariable } from '../../../utils/env';
 import { rimraf, writeMultipleFiles } from '../../../utils/fs';
 import { findFreePort } from '../../../utils/network';
 import { installWorkspacePackages } from '../../../utils/packages';
-import { execAndWaitForOutputToMatch, killAllProcesses, ng } from '../../../utils/process';
+import { execAndWaitForOutputToMatch, ng } from '../../../utils/process';
 import { updateJsonFile, useSha } from '../../../utils/project';
 
 export default async function () {
@@ -123,10 +123,6 @@ export default async function () {
     return port;
   }
 
-  try {
-    const port = await ngDevSsr();
-    await ng('e2e', `--base-url=http://localhost:${port}`, '--dev-server-target=');
-  } finally {
-    await killAllProcesses();
-  }
+  const port = await ngDevSsr();
+  await ng('e2e', `--base-url=http://localhost:${port}`, '--dev-server-target=');
 }

--- a/tests/legacy-cli/e2e/tests/commands/e2e/e2e-and-serve.ts
+++ b/tests/legacy-cli/e2e/tests/commands/e2e/e2e-and-serve.ts
@@ -1,12 +1,8 @@
-import { killAllProcesses, silentNg } from '../../../utils/process';
+import { silentNg } from '../../../utils/process';
 import { ngServe } from '../../../utils/project';
 
 export default async function () {
-  try {
-    // Should run side-by-side with `ng serve`
-    await ngServe();
-    await silentNg('e2e');
-  } finally {
-    killAllProcesses();
-  }
+  // Should run side-by-side with `ng serve`
+  await ngServe();
+  await silentNg('e2e');
 }

--- a/tests/legacy-cli/e2e/tests/commands/serve/reload-shims.ts
+++ b/tests/legacy-cli/e2e/tests/commands/serve/reload-shims.ts
@@ -1,25 +1,21 @@
 import { prependToFile, writeFile } from '../../../utils/fs';
-import { execAndWaitForOutputToMatch, killAllProcesses } from '../../../utils/process';
+import { execAndWaitForOutputToMatch } from '../../../utils/process';
 
 export default async function () {
   // Simulate a JS library using a Node.js specific module
   await writeFile('src/node-usage.js', `const path = require('path');\n`);
   await prependToFile('src/main.ts', `import './node-usage';\n`);
 
-  try {
-    // Make sure serve is consistent with build
-    await execAndWaitForOutputToMatch(
-      'ng',
-      ['build'],
-      /Module not found: Error: Can't resolve 'path'/,
-    );
-    // The Node.js specific module should not be found
-    await execAndWaitForOutputToMatch(
-      'ng',
-      ['serve', '--port=0'],
-      /Module not found: Error: Can't resolve 'path'/,
-    );
-  } finally {
-    await killAllProcesses();
-  }
+  // Make sure serve is consistent with build
+  await execAndWaitForOutputToMatch(
+    'ng',
+    ['build'],
+    /Module not found: Error: Can't resolve 'path'/,
+  );
+  // The Node.js specific module should not be found
+  await execAndWaitForOutputToMatch(
+    'ng',
+    ['serve', '--port=0'],
+    /Module not found: Error: Can't resolve 'path'/,
+  );
 }

--- a/tests/legacy-cli/e2e/tests/commands/serve/serve-path.ts
+++ b/tests/legacy-cli/e2e/tests/commands/serve/serve-path.ts
@@ -1,5 +1,4 @@
 import * as assert from 'assert';
-import { killAllProcesses } from '../../../utils/process';
 import { ngServe } from '../../../utils/project';
 
 export default async function () {
@@ -17,6 +16,5 @@ export default async function () {
     .then(async (response) => {
       assert.strictEqual(response.status, 200);
       assert.match(await response.text(), /<app-root><\/app-root>/);
-    })
-    .finally(() => killAllProcesses());
+    });
 }

--- a/tests/legacy-cli/e2e/tests/misc/fallback.ts
+++ b/tests/legacy-cli/e2e/tests/misc/fallback.ts
@@ -31,6 +31,5 @@ export default function () {
         assert.strictEqual(response.status, 200);
         assert.match(await response.text(), /<app-root><\/app-root>/);
       })
-      .finally(() => killAllProcesses())
   );
 }

--- a/tests/legacy-cli/e2e/tests/misc/proxy-config.ts
+++ b/tests/legacy-cli/e2e/tests/misc/proxy-config.ts
@@ -2,7 +2,6 @@ import express from 'express';
 import * as http from 'http';
 
 import { writeFile } from '../../utils/fs';
-import { killAllProcesses } from '../../utils/process';
 import { ngServe } from '../../utils/project';
 import { AddressInfo } from 'net';
 import * as assert from 'assert';
@@ -38,8 +37,7 @@ export default function () {
       assert.strictEqual(response.status, 200);
       assert.match(await response.text(), /TEST_API_RETURN/);
     })
-    .finally(async () => {
-      await killAllProcesses();
+    .finally(() => {
       server.close();
     });
 }

--- a/tests/legacy-cli/e2e/tests/vite/ssr-error-stack.ts
+++ b/tests/legacy-cli/e2e/tests/vite/ssr-error-stack.ts
@@ -1,5 +1,5 @@
 import { doesNotMatch, match } from 'node:assert';
-import { killAllProcesses, ng } from '../../utils/process';
+import { ng } from '../../utils/process';
 import { appendToFile, rimraf } from '../../utils/fs';
 import { ngServe, useSha } from '../../utils/project';
 import { installWorkspacePackages } from '../../utils/packages';
@@ -11,28 +11,24 @@ export default async function () {
   await useSha();
   await installWorkspacePackages();
 
-  try {
-    // Create Error.
-    await appendToFile(
-      'src/app/app.component.ts',
-      `
+  // Create Error.
+  await appendToFile(
+    'src/app/app.component.ts',
+    `
       (() => {
         throw new Error('something happened!');
       })();
       `,
-    );
+  );
 
-    const port = await ngServe();
-    const response = await fetch(`http://localhost:${port}/`);
-    const text = await response.text();
+  const port = await ngServe();
+  const response = await fetch(`http://localhost:${port}/`);
+  const text = await response.text();
 
-    // The error is also sent in the browser, so we don't need to scrap the stderr.
-    match(
-      text,
-      /something happened.+at eval \(.+\/e2e-test[\\\/]test-project[\\\/]src[\\\/]app[\\\/]app\.component\.ts:\d+:\d+\)/,
-    );
-    doesNotMatch(text, /vite-root/);
-  } finally {
-    await killAllProcesses();
-  }
+  // The error is also sent in the browser, so we don't need to scrap the stderr.
+  match(
+    text,
+    /something happened.+at eval \(.+\/e2e-test[\\\/]test-project[\\\/]src[\\\/]app[\\\/]app\.component\.ts:\d+:\d+\)/,
+  );
+  doesNotMatch(text, /vite-root/);
 }


### PR DESCRIPTION
The E2E test runner will always perform the call after the completion of each E2E test. This removes the need to manually execute the helper function at the end of a test. All tests that did so have had the call removed from the end of the test. Some tests use the helper within the test and those calls have not been altered and remain.
REVIEW NOTE: Consider enabling "Hide whitespace"