### PR TITLE
fix(@angular-devkit/build-angular): remove browser-esbuild usage warning

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/builder-status-warnings.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/builder-status-warnings.ts
@@ -25,11 +25,6 @@ export function logBuilderStatusWarnings(
   options: BrowserBuilderOptions,
   { logger }: BuilderContext,
 ) {
-  logger.warn(
-    `The 'browser-esbuild' builder is a compatibility builder which will be removed in a future major ` +
-      `version in favor of the 'application' builder.`,
-  );
-
   // Validate supported options
   for (const unsupportedOption of UNSUPPORTED_OPTIONS) {
     const value = (options as unknown as BrowserBuilderOptions)[unsupportedOption];


### PR DESCRIPTION
To avoid potential confusion when updating to v17, the usage warning as been removed from the `browser-esbuild` builder. The `browser-esbuild` builder is considered stable and fully supported. This is in addition to the other stable builders: `browser` and `application`. The `browser-esbuild` builder provides similar behavior to the `browser` builder but with the performance improvements of the `application` builder. However, `browser-esbuild` does not have integrated SSR support and will not receive new/future `application` builder options and features.
For more details on these builders, please see: https://angular.io/guide/esbuild