### PR TITLE
refactor(@angular-devkit/build-angular): use application builder for unknown builders in Vite dev server

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
@@ -142,9 +142,9 @@ export async function* serveWithVite(
   });
 
   const build =
-    builderName === '@angular-devkit/build-angular:application'
-      ? buildApplicationInternal
-      : buildEsbuildBrowser;
+    builderName === '@angular-devkit/build-angular:browser-esbuild'
+      ? buildEsbuildBrowser
+      : buildApplicationInternal;
 
   // TODO: Switch this to an architect schedule call when infrastructure settings are supported
   for await (const result of build(


### PR DESCRIPTION
The application builder logic will now be used when the Vite-based development server is used with a custom builder. This aligns with the programmatic export of application builder. This allows consistent behavior for custom builders that use both the application builder and dev server builder APIs. This should unblock custom dev server builder development for the application builder.