### PR TITLE
refactor(@angular-devkit/build-angular): fully disable Vite internal file watching

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
@@ -449,10 +449,8 @@ export async function setupServer(
       open: serverOptions.open,
       headers: serverOptions.headers,
       proxy,
-      // Currently does not appear to be a way to disable file watching directly so ignore all files
-      watch: {
-        ignored: ['**/*'],
-      },
+      // File watching is handled by the build directly. `null` disables file watching for Vite.
+      watch: null,
       // This is needed when `externalDependencies` is used to prevent Vite load errors.
       // NOTE: If Vite adds direct support for externals, this can be removed.
       preTransformRequests: externalMetadata.explicit.length === 0,


### PR DESCRIPTION
With the Vite-based development server, the build pipeline itself watches for files and rebuilds the relevant parts of the application as needed. The Vite file watching is unneeded and was previously setup to ignore all files. This worked but was not ideal as chokidar was still initialized inside Vite. However, Vite now supports fully disabling the file watching by passing `null` for the Vite watch option value.