### PR TITLE
fix(@angular-devkit/build-angular): normalize paths in ssr sourcemaps to posix when using vite

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
@@ -546,7 +546,7 @@ export async function setupServer(
             );
 
             // Set the sourcemap root to the workspace root. This is needed since we set a virtual path as root.
-            remappedMap.sourceRoot = serverOptions.workspaceRoot + '/';
+            remappedMap.sourceRoot = normalizePath(serverOptions.workspaceRoot) + '/';
 
             return {
               ...result,


### PR DESCRIPTION


Path normalization that fixes a tests on windows

(cherry picked from commit 40c16760c42a8965cf6febe8226dc71ea920e3b3)
