### PR TITLE
fix(@angular-devkit/build-angular): ensure TypeScript emits canonical paths

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/application/build-action.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/build-action.ts
@@ -115,7 +115,7 @@ export async function* runEsBuildBuildAction(
     watcher.add(packageWatchFiles.map((file) => path.join(workspaceRoot, file)));
 
     // Watch locations provided by the initial build result
-    watcher.add(result.watchFiles);
+    watcher.add([...result.watchFiles]);
   }
 
   // Output the first build results after setting up the watcher to ensure that any code executed

--- a/packages/angular_devkit/build_angular/src/builders/application/options.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/options.ts
@@ -83,7 +83,7 @@ export async function normalizeOptions(
   options: ApplicationBuilderInternalOptions,
   plugins?: Plugin[],
 ) {
-  const workspaceRoot = context.workspaceRoot;
+  const workspaceRoot = normalizeDirectoryPath(context.workspaceRoot);
   const projectMetadata = await context.getProjectMetadata(projectName);
   const projectRoot = normalizeDirectoryPath(
     path.join(workspaceRoot, (projectMetadata.root as string | undefined) ?? ''),
@@ -396,14 +396,18 @@ function normalizeEntryPoints(
 
 /**
  * Normalize a directory path string.
- * Currently only removes a trailing slash if present.
+ * * Removes a trailing slash if present
+ * * Ensures all lower case on Windows
  * @param path A path string.
  * @returns A normalized path string.
  */
 function normalizeDirectoryPath(path: string): string {
+  if (process.platform === 'win32') {
+    path = path.toLowerCase();
+  }
   const last = path[path.length - 1];
   if (last === '/' || last === '\\') {
-    return path.slice(0, -1);
+    path = path.slice(0, -1);
   }
 
   return path;

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/angular/compilation/aot-compilation.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/angular/compilation/aot-compilation.ts
@@ -112,7 +112,8 @@ export class AotCompilation extends AngularCompilation {
         }
 
         return [sourceFile.fileName, ...resourceDependencies];
-      });
+      })
+      .map((file) => host.getCanonicalFileName(file));
 
     this.#state = new AngularCompilationState(
       angularProgram,
@@ -208,7 +209,10 @@ export class AotCompilation extends AngularCompilation {
       }
 
       angularCompiler.incrementalCompilation.recordSuccessfulEmit(sourceFile);
-      emittedFiles.set(sourceFile, { filename: sourceFile.fileName, contents });
+      emittedFiles.set(sourceFile, {
+        filename: compilerHost.getCanonicalFileName(sourceFile.fileName),
+        contents,
+      });
     };
     const transformers = mergeTransformers(angularCompiler.prepareEmit().transformers, {
       before: [

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/angular/compilation/jit-compilation.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/angular/compilation/jit-compilation.ts
@@ -77,7 +77,7 @@ export class JitCompilation extends AngularCompilation {
 
     const referencedFiles = typeScriptProgram
       .getSourceFiles()
-      .map((sourceFile) => sourceFile.fileName);
+      .map((sourceFile) => host.getCanonicalFileName(sourceFile.fileName));
 
     return { affectedFiles, compilerOptions, referencedFiles };
   }
@@ -119,7 +119,10 @@ export class JitCompilation extends AngularCompilation {
 
       assert(sourceFiles?.length === 1, 'Invalid TypeScript program emit for ' + filename);
 
-      emittedFiles.push({ filename: sourceFiles[0].fileName, contents });
+      emittedFiles.push({
+        filename: compilerHost.getCanonicalFileName(sourceFiles[0].fileName),
+        contents,
+      });
     };
     const transformers = {
       before: [

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/bundler-execution-result.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/bundler-execution-result.ts
@@ -90,15 +90,19 @@ export class ExecutionResult {
 
   get watchFiles() {
     // Bundler contexts internally normalize file dependencies
-    const files = this.rebuildContexts.flatMap((context) => [...context.watchFiles]);
+    const files = new Set(this.rebuildContexts.flatMap((context) => [...context.watchFiles]));
     if (this.codeBundleCache?.referencedFiles) {
-      // These files originate from TS/NG and can have POSIX path separators even on Windows.
-      // To ensure path comparisons are valid, all these paths must be normalized.
-      files.push(...this.codeBundleCache.referencedFiles.map(normalize));
+      for (const file of this.codeBundleCache.referencedFiles) {
+        // These files originate from TS/NG and can have POSIX path separators even on Windows.
+        // To ensure path comparisons are valid, all these paths must be normalized.
+        files.add(normalize(file));
+      }
     }
     if (this.codeBundleCache?.loadResultCache) {
       // Load result caches internally normalize file dependencies
-      files.push(...this.codeBundleCache.loadResultCache.watchFiles);
+      for (const file of this.codeBundleCache.loadResultCache.watchFiles) {
+        files.add(file);
+      }
     }
 
     return files;


### PR DESCRIPTION
To avoid casing differences for paths on platforms that are case insensitive (such as Windows), all paths returned from the TypeScript/Angular compiler are not passed through TypeScript's path canonicalization helper. This ensures that the paths returned will have consistent casing. This is important for later comparison checks which may fail if the casing is inconsistent.