### PR TITLE
fix(@angular-devkit/build-angular): ensure service worker hashes index HTML file for application builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/application/execute-post-bundle.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/execute-post-bundle.ts
@@ -144,7 +144,8 @@ export async function executePostBundleSteps(
         workspaceRoot,
         serviceWorker,
         options.baseHref || '/',
-        outputFiles,
+        // Ensure additional files recently added are used
+        [...outputFiles, ...additionalOutputFiles],
         assetFiles,
       );
       additionalOutputFiles.push(


### PR DESCRIPTION
The generated HTML files for the application were previously not included in the hash calculations for the service worker. This has now been corrected and the index file for an application will not be included when service worker support is enabled via the `serviceWorker` option.