### PR TITLE
fix(@angular-devkit/build-angular): normalize workspace root path on Windows

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/application/options.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/options.ts
@@ -83,7 +83,7 @@ export async function normalizeOptions(
   options: ApplicationBuilderInternalOptions,
   plugins?: Plugin[],
 ) {
-  const workspaceRoot = context.workspaceRoot;
+  const workspaceRoot = normalizeDirectoryPath(context.workspaceRoot);
   const projectMetadata = await context.getProjectMetadata(projectName);
   const projectRoot = normalizeDirectoryPath(
     path.join(workspaceRoot, (projectMetadata.root as string | undefined) ?? ''),
@@ -396,14 +396,18 @@ function normalizeEntryPoints(
 
 /**
  * Normalize a directory path string.
- * Currently only removes a trailing slash if present.
+ * * Removes a trailing slash if present
+ * * Ensures all lower case on Windows
  * @param path A path string.
  * @returns A normalized path string.
  */
 function normalizeDirectoryPath(path: string): string {
+  if (process.platform === 'win32') {
+    path = path.toLowerCase();
+  }
   const last = path[path.length - 1];
   if (last === '/' || last === '\\') {
-    return path.slice(0, -1);
+    path = path.slice(0, -1);
   }
 
   return path;


### PR DESCRIPTION
The workspace root path obtain from the builder context may contain mixed casing on Windows. The workspace root path is used as the base for nearly all other paths within the build system. As a result path comparisons may fail in cases that the workspace root path does not have a consistent casing on Windows to other internal build system paths.