### PR TITLE
fix(@angular-devkit/build-angular): default to watching project root on Windows with application builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/environment-options.ts
+++ b/packages/angular_devkit/build_angular/src/utils/environment-options.ts
@@ -100,5 +100,9 @@ export const useLegacySass: boolean = (() => {
 const debugPerfVariable = process.env['NG_BUILD_DEBUG_PERF'];
 export const debugPerformance = isPresent(debugPerfVariable) && isEnabled(debugPerfVariable);
 
+// Default to true on Windows to workaround Visual Studio atomic file saving watch issues
 const watchRootVariable = process.env['NG_BUILD_WATCH_ROOT'];
-export const shouldWatchRoot = isPresent(watchRootVariable) && isEnabled(watchRootVariable);
+export const shouldWatchRoot =
+  process.platform === 'win32'
+    ? !isPresent(watchRootVariable) || !isDisabled(watchRootVariable)
+    : isPresent(watchRootVariable) && isEnabled(watchRootVariable);


### PR DESCRIPTION
When using the `application` or `browser-esbuild` builder in watch mode on Windows, the project root will now be watched by default. This provides a workaround for users of Visual Studio which uses a file save mechanism that causes the watch mode to not correctly trigger. By watching the entire project root, this problem is avoided. However, this may result in additional rebuilds due to changes of unrelated files in the project root.
This behavior can be disabled using the environment variable `NG_BUILD_WATCH_ROOT=0`. On non-Windows platforms, disabled is the default.