### PR TITLE
fix(@angular-devkit/build-angular): avoid native realpath in application builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/esbuild/angular/compiler-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/angular/compiler-plugin.ts
@@ -16,7 +16,7 @@ import type {
   PluginBuild,
 } from 'esbuild';
 import assert from 'node:assert';
-import { realpath } from 'node:fs/promises';
+import { realpathSync } from 'node:fs';
 import * as path from 'node:path';
 import { maxWorkers } from '../../../utils/environment-options';
 import { JavaScriptTransformer } from '../javascript-transformer';
@@ -61,8 +61,11 @@ export function createCompilerPlugin(
       if (!preserveSymlinks) {
         // Use the real path of the tsconfig if not preserving symlinks.
         // This ensures the TS source file paths are based on the real path of the configuration.
+        // NOTE: promises.realpath should not be used here since it uses realpath.native which
+        // can cause case conversion and other undesirable behavior on Windows systems.
+        // ref: https://github.com/nodejs/node/issues/7726
         try {
-          tsconfigPath = await realpath(tsconfigPath);
+          tsconfigPath = realpathSync(tsconfigPath);
         } catch {}
       }
 


### PR DESCRIPTION
When the `preserveSymlinks` option is false (the default), the tsconfig path was passed through realpath to ensure that the TypeScript source files were resolved correctly. However, the promise version of the Node.js API was previously used. This version used `realpath.native` internally but the native version has numerous behavior problems on Windows systems. This includes potential case conversion which can result in differing cases for files within the build system and in turn failed path comparison checks. The synchronous version is now used which has a JavaScript implementation that does not suffer from these problems.