### PR TITLE
fix(@schematics/angular): remove CommonModule import from standalone components

### DIFF
--- a/packages/schematics/angular/component/files/__name@dasherize@if-flat__/__name@dasherize__.__type@dasherize__.ts.template
+++ b/packages/schematics/angular/component/files/__name@dasherize@if-flat__/__name@dasherize__.__type@dasherize__.ts.template
@@ -1,10 +1,9 @@
-import { <% if(changeDetection !== 'Default') { %>ChangeDetectionStrategy, <% }%>Component<% if(!!viewEncapsulation) { %>, ViewEncapsulation<% }%> } from '@angular/core';<% if(standalone) {%>
-import { CommonModule } from '@angular/common';<% } %>
+import { <% if(changeDetection !== 'Default') { %>ChangeDetectionStrategy, <% }%>Component<% if(!!viewEncapsulation) { %>, ViewEncapsulation<% }%> } from '@angular/core';
 
 @Component({<% if(!skipSelector) {%>
   selector: '<%= selector %>',<%}%><% if(standalone) {%>
   standalone: true,
-  imports: [CommonModule],<%}%><% if(inlineTemplate) { %>
+  imports: [],<%}%><% if(inlineTemplate) { %>
   template: `
     <p>
       <%= dasherize(name) %> works!

--- a/packages/schematics/angular/component/index_spec.ts
+++ b/packages/schematics/angular/component/index_spec.ts
@@ -340,11 +340,9 @@ describe('Component Schematic', () => {
     const tree = await schematicRunner.runSchematic('component', options, appTree);
     const moduleContent = tree.readContent('/projects/bar/src/app/app.module.ts');
     const componentContent = tree.readContent('/projects/bar/src/app/foo/foo.component.ts');
-    expect(componentContent).toContain('@angular/common');
     expect(componentContent).toContain('class FooComponent');
     expect(moduleContent).not.toContain('FooComponent');
     expect(componentContent).toContain('standalone: true');
-    expect(componentContent).toContain('imports: [CommonModule]');
   });
 
   it('should declare standalone components in the `imports` of a test', async () => {


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [ ] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the new behavior?

`ng g c` no longer generates a component with the `CommonModule` import. This import is not useful if developers adopt the control flow syntax in their templates. Instead, developers are encouraged to import the individual directives/pipes if needed.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
