### PR TITLE
perf(@angular-devkit/build-angular): reduce TypeScript JSDoc parsing in application builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/esbuild/angular/angular-host.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/angular/angular-host.ts
@@ -48,6 +48,12 @@ export function createAngularCompilerHost(
 ): AngularCompilerHost {
   // Create TypeScript compiler host
   const host: AngularCompilerHost = ts.createIncrementalCompilerHost(compilerOptions);
+  // Set the parsing mode to the same as TS 5.3 default for tsc. This provides a parse
+  // performance improvement by skipping non-type related JSDoc parsing.
+  // NOTE: The check for this enum can be removed when TS 5.3 support is the minimum.
+  if (ts.JSDocParsingMode) {
+    host.jsDocParsingMode = ts.JSDocParsingMode.ParseForTypeErrors;
+  }
 
   // The AOT compiler currently requires this hook to allow for a transformResource hook.
   // Once the AOT compiler allows only a transformResource hook, this can be reevaluated.


### PR DESCRIPTION
TypeScript 5.3 provides a new programmatically accessible option on the compiler host object to control the amount of JSDoc parsing that the TypeScript parser will perform. The `tsc` command line tool now uses the `ParseForTypeErrors` value which only parses JSDoc comments that may affect type checking and is considered a good default for tools such as the Angular CLI. The Angular CLI will now attempt to use the `ParseForTypeErrors` value as well when available. Projects will need to use TypeScript 5.3+ for this option to be available. No behavior changes will occur on TypeScript 5.2 projects. This should not only provide a small improvement to build times but also a reduction in overall memory usage.