### PR TITLE
fix(@angular-devkit/build-angular): improve file watching on Windows when using certain IDEs

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/environment-options.ts
+++ b/packages/angular_devkit/build_angular/src/utils/environment-options.ts
@@ -102,7 +102,4 @@ export const debugPerformance = isPresent(debugPerfVariable) && isEnabled(debugP
 
 // Default to true on Windows to workaround Visual Studio atomic file saving watch issues
 const watchRootVariable = process.env['NG_BUILD_WATCH_ROOT'];
-export const shouldWatchRoot =
-  process.platform === 'win32'
-    ? !isPresent(watchRootVariable) || !isDisabled(watchRootVariable)
-    : isPresent(watchRootVariable) && isEnabled(watchRootVariable);
+export const shouldWatchRoot = isPresent(watchRootVariable) && isEnabled(watchRootVariable);


### PR DESCRIPTION


This commit, fixes a file watching issue where file changes events are not triggered when using IDEs like Visual Studio (not VS Code).

The main changes to solve the issue are;

## Replace `watcher.on('all')` with `watcher.on('raw')`

Using `watcher.on('all')` does not capture some of events fired when using Visual studio and this does not happen all the time, but only after a file has been changed 3 or more times.


```
watcher.on('raw')
Change 1
rename | 'C:/../src/app/app.component.css'
rename | 'C:/../src/app/app.component.css'
change | 'C:/../src/app/app.component.css'

Change 2
rename | 'C:/../src/app/app.component.css'
rename | 'C:/../src/app/app.component.css'
change | 'C:/../src/app/app.component.css'

Change 3
rename | 'C:/../src/app/app.component.css'
rename | 'C:/../src/app/app.component.css'
change | 'C:/../src/app/app.component.css'

watcher.on('all')
Change 1
change | 'C:\\..\\src\\app\\app.component.css'

Change 2
unlink | 'C:\\..\\src\\app\\app.component.css'

Change 3
... (Nothing)
```

## Handle `rename` events
Some IDEs will fire a rename event instead of unlink/changed when a file is modified}

Closes #26437


---

**NB:** Confirmed with a user that was experiencing the issue, that this fix indeed solved the problem https://github.com/angular/angular-cli/issues/26437#issuecomment-1824350797