### PR TITLE
fix(@angular-devkit/build-angular): correctly watch files when app is in a directory that starts with a dot

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/application/build-action.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/build-action.ts
@@ -86,7 +86,7 @@ export async function* runEsBuildBuildAction(
         // Ignore all node modules directories to avoid excessive file watchers.
         // Package changes are handled below by watching manifest and lock files.
         '**/node_modules/**',
-        '**/.*/**',
+        `${workspaceRoot.replace(/\\/g, '/')}/**/.*/**`,
       ],
     });
 

--- a/tests/legacy-cli/e2e/tests/build/poll.ts
+++ b/tests/legacy-cli/e2e/tests/build/poll.ts
@@ -1,8 +1,9 @@
+import { setTimeout } from 'node:timers/promises';
 import { getGlobalVariable } from '../../utils/env';
 import { appendToFile } from '../../utils/fs';
 import { waitForAnyProcessOutputToMatch } from '../../utils/process';
 import { ngServe } from '../../utils/project';
-import { expectToFail, wait } from '../../utils/utils';
+import { expectToFail } from '../../utils/utils';
 
 const webpackGoodRegEx = getGlobalVariable('argv')['esbuild']
   ? /Application bundle generation complete\./
@@ -13,7 +14,7 @@ export default async function () {
 
   // Wait before editing a file.
   // Editing too soon seems to trigger a rebuild and throw polling out of whack.
-  await wait(3000);
+  await setTimeout(3000);
   await appendToFile('src/main.ts', 'console.log(1);');
 
   // We have to wait poll time + rebuild build time for the regex match.

--- a/tests/legacy-cli/e2e/tests/build/rebuild-dot-dirname.ts
+++ b/tests/legacy-cli/e2e/tests/build/rebuild-dot-dirname.ts
@@ -1,0 +1,56 @@
+import { setTimeout } from 'node:timers/promises';
+import { getGlobalVariable } from '../../utils/env';
+import { appendToFile, createDir, rimraf } from '../../utils/fs';
+import { installWorkspacePackages } from '../../utils/packages';
+import { ng, waitForAnyProcessOutputToMatch } from '../../utils/process';
+import { ngServe, updateJsonFile, useSha } from '../../utils/project';
+
+const goodRegEx = getGlobalVariable('argv')['esbuild']
+  ? /Application bundle generation complete\./
+  : / Compiled successfully\./;
+
+export default async function () {
+  const originalCwd = process.cwd();
+  // Delete angular.json so that we can create a new app.
+  await rimraf('angular.json');
+  await createDir('./.subdirectory');
+
+  try {
+    process.chdir('./.subdirectory');
+
+    await ng('new', 'subdirectory-test-project', '--skip-install');
+    process.chdir('./subdirectory-test-project');
+
+    await useSha();
+    await installWorkspacePackages();
+
+    const useWebpackBuilder = !getGlobalVariable('argv')['esbuild'];
+    if (useWebpackBuilder) {
+      await updateJsonFile('angular.json', (json) => {
+        const build = json['projects']['subdirectory-test-project']['architect']['build'];
+        build.builder = '@angular-devkit/build-angular:browser';
+        build.options = {
+          ...build.options,
+          main: build.options.browser,
+          browser: undefined,
+        };
+
+        build.configurations.development = {
+          ...build.configurations.development,
+          vendorChunk: true,
+          namedChunks: true,
+          buildOptimizer: false,
+        };
+      });
+    }
+
+    await ngServe();
+
+    // Wait before editing a file.
+    await setTimeout(1000);
+    await appendToFile('src/main.ts', 'console.log(1);');
+    await waitForAnyProcessOutputToMatch(goodRegEx);
+  } finally {
+    process.chdir(originalCwd);
+  }
+}

--- a/tests/legacy-cli/e2e/utils/utils.ts
+++ b/tests/legacy-cli/e2e/utils/utils.ts
@@ -18,12 +18,6 @@ export function expectToFail(fn: () => Promise<any>, errorMessage?: string): Pro
   );
 }
 
-export function wait(msecs: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, msecs);
-  });
-}
-
 export async function mktempd(prefix: string, tempRoot?: string): Promise<string> {
   return realpath(await mkdtemp(path.join(tempRoot ?? tmpdir(), prefix)));
 }


### PR DESCRIPTION

This commit fixes an issue were previously, application files in a directory that starts with a dot were being ignored from watching.

Closes #26441