### PR TITLE
refactor(@angular-devkit/build-angular): remove piscina minThreads workaround

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/app-shell/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/app-shell/index.ts
@@ -123,9 +123,6 @@ async function _renderUniversal(
       }
     }
   } finally {
-    // Workaround piscina bug where a worker thread will be recreated after destroy to meet the minimum.
-    renderWorker.options.minThreads = 0;
-
     await renderWorker.destroy();
   }
 

--- a/packages/angular_devkit/build_angular/src/builders/prerender/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/prerender/index.ts
@@ -244,8 +244,6 @@ async function _renderUniversal(
       }
     }
   } finally {
-    // Workaround piscina bug where a worker thread will be recreated after destroy to meet the minimum.
-    worker.options.minThreads = 0;
     void worker.destroy();
   }
 

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/angular/compilation/parallel-compilation.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/angular/compilation/parallel-compilation.ts
@@ -135,9 +135,6 @@ export class ParallelCompilation extends AngularCompilation {
   }
 
   override close() {
-    // Workaround piscina bug where a worker thread will be recreated after destroy to meet the minimum.
-    this.#worker.options.minThreads = 0;
-
     return this.#worker.destroy();
   }
 }

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/i18n-inliner.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/i18n-inliner.ts
@@ -144,9 +144,6 @@ export class I18nInliner {
    * @returns A void promise that resolves when closing is complete.
    */
   close(): Promise<void> {
-    // Workaround piscina bug where a worker thread will be recreated after destroy to meet the minimum.
-    this.#workerPool.options.minThreads = 0;
-
     return this.#workerPool.destroy();
   }
 }

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/javascript-transformer.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/javascript-transformer.ts
@@ -143,9 +143,6 @@ export class JavaScriptTransformer {
     this.#pendingfileResults?.clear();
 
     if (this.#workerPool) {
-      // Workaround piscina bug where a worker thread will be recreated after destroy to meet the minimum.
-      this.#workerPool.options.minThreads = 0;
-
       try {
         await this.#workerPool.destroy();
       } finally {

--- a/packages/angular_devkit/build_angular/src/tools/webpack/plugins/javascript-optimizer-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/plugins/javascript-optimizer-plugin.ts
@@ -231,8 +231,6 @@ export class JavaScriptOptimizerPlugin {
 
             await Promise.all(tasks);
           } finally {
-            // Workaround piscina bug where a worker thread will be recreated after destroy to meet the minimum.
-            workerPool.options.minThreads = 0;
             void workerPool.destroy();
           }
 

--- a/packages/angular_devkit/build_angular/src/utils/action-executor.ts
+++ b/packages/angular_devkit/build_angular/src/utils/action-executor.ts
@@ -65,8 +65,6 @@ export class BundleActionExecutor {
 
   stop(): void {
     if (this.workerPool) {
-      // Workaround piscina bug where a worker thread will be recreated after destroy to meet the minimum.
-      this.workerPool.options.minThreads = 0;
       void this.workerPool.destroy();
     }
   }

--- a/packages/angular_devkit/build_angular/src/utils/server-rendering/prerender.ts
+++ b/packages/angular_devkit/build_angular/src/utils/server-rendering/prerender.ts
@@ -206,8 +206,6 @@ async function renderPages(
 
     await Promise.all(renderingPromises);
   } finally {
-    // Workaround piscina bug where a worker thread will be recreated after destroy to meet the minimum.
-    renderWorker.options.minThreads = 0;
     void renderWorker.destroy();
   }
 
@@ -268,8 +266,6 @@ async function getAllRoutes(
   const { routes: extractedRoutes, warnings }: RoutersExtractorWorkerResult = await renderWorker
     .run({})
     .finally(() => {
-      // Workaround piscina bug where a worker thread will be recreated after destroy to meet the minimum.
-      renderWorker.options.minThreads = 0;
       void renderWorker.destroy();
     });
 


### PR DESCRIPTION


This is no longer needed since 4.2.0
