### PR TITLE
fix(@angular/cli): Suppress logBuildStats when budget errors present

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/application/execute-build.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/execute-build.ts
@@ -192,6 +192,7 @@ export async function executeBuild(
 
   // Analyze files for bundle budget failures if present
   let budgetFailures: BudgetCalculatorResult[] | undefined;
+  let hasBudgetErrors = false;
   if (options.budgets) {
     const compatStats = generateBudgetStats(metafile, initialFiles);
     budgetFailures = [...checkBudgets(options.budgets, compatStats, true)];
@@ -202,6 +203,7 @@ export async function executeBuild(
       const warnings = budgetFailures
         .filter((failure) => failure.severity !== 'error')
         .map(({ message }) => message);
+      hasBudgetErrors = errors.length > 0;
 
       await printWarningsAndErrorsToConsoleAndAddToResult(
         context,
@@ -285,14 +287,16 @@ export async function executeBuild(
     context.logger.info(colors.magenta(prerenderMsg) + '\n');
   }
 
-  logBuildStats(
-    context,
-    metafile,
-    initialFiles,
-    budgetFailures,
-    changedFiles,
-    estimatedTransferSizes,
-  );
+  if (!hasBudgetErrors) {
+    logBuildStats(
+      context,
+      metafile,
+      initialFiles,
+      budgetFailures,
+      changedFiles,
+      estimatedTransferSizes,
+    );
+  }
 
   // Write metafile if stats option is enabled
   if (options.stats) {


### PR DESCRIPTION
Fixes #26514

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently, even when there are budget errors found with the esbuild builders, the stats table is still shown, which can be misleading and make debugging issues difficult.

Issue Number: #26514 

## What is the new behavior?

When a bundle size budget error occurs, the CLI will not show the stats table.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
