### PR TITLE
feat(@angular-devkit/build-angular): support keyboard command shortcuts in application dev server

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
@@ -270,6 +270,22 @@ export async function* serveWithVite(
 
       // log connection information
       server.printUrls();
+
+      server.bindCLIShortcuts({
+        print: true,
+        customShortcuts: [
+          {
+            key: 'r',
+            description: 'force reload browser',
+            action(server) {
+              server.ws.send({
+                type: 'full-reload',
+                path: '*',
+              });
+            },
+          },
+        ],
+      });
     }
 
     // TODO: adjust output typings to reflect both development servers


### PR DESCRIPTION
When using the `application` or `browser-esbuild` builders with the `dev-server`, interactive key shortcuts are now available to use while the server is active. Once the build has successfully completed and the development server has initialized, typing a single letter key followed by enter will execute the associated action. These actions include forcing a browser full reload, clearing the console, or quitting. More actions may be added in the future.

The following actions are currently available:
```
  press r + enter to force reload browser
  press u + enter to show server url
  press o + enter to open in browser
  press c + enter to clear console
  press q + enter to quit
```

The `h` action is also available which will display the above list at runtime.