### PR TITLE
refactor: remove `removeSpecialComments` from webpack based builder app-shell builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/app-shell/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/app-shell/index.ts
@@ -170,6 +170,8 @@ async function _appShellBuilder(
 
   const optimization = normalizeOptimization(browserOptions.optimization);
   optimization.styles.inlineCritical = false;
+  // Webpack based builders do not have the `removeSpecialComments` option.
+  delete optimization.styles.removeSpecialComments;
 
   const browserTargetRun = await context.scheduleTarget(browserTarget, {
     watch: false,


### PR DESCRIPTION
This option is not available in webpack based builders.