### PR TITLE
refactor: bump `@angular/pwa` peer dep for `17.0.0-next`

### DIFF
--- a/packages/angular/pwa/package.json
+++ b/packages/angular/pwa/package.json
@@ -17,7 +17,7 @@
     "parse5-html-rewriting-stream": "7.0.0"
   },
   "peerDependencies": {
-    "@angular/cli": "^17.0.0"
+    "@angular/cli": "^17.0.0 || ^17.1.0-next.0"
   },
   "peerDependenciesMeta": {
     "@angular/cli": {


### PR DESCRIPTION
Missed this peer dependency and it's blocking next releases.