### PR TITLE
fix(@angular-devkit/build-angular): correctly align error/warning messages when spinner is active

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/spinner.ts
+++ b/packages/angular_devkit/build_angular/src/utils/spinner.ts
@@ -19,7 +19,7 @@ export class Spinner {
 
   constructor(text?: string) {
     this.spinner = ora({
-      text,
+      text: text === undefined ? undefined : text + '\n',
       // The below 2 options are needed because otherwise CTRL+C will be delayed
       // when the underlying process is sync.
       hideCursor: false,


### PR DESCRIPTION
When using the `application` builder with progress enabled (the default), the spinner text will now automatically contain a trailing newline. This ensures that any diagnostic messages are not awkwardly printed on the same line as the spinner.