### PR TITLE
fix(@schematics/angular): enable TypeScript `skipLibCheck` in new workspace

### DIFF
--- a/packages/schematics/angular/workspace/files/tsconfig.json.template
+++ b/packages/schematics/angular/workspace/files/tsconfig.json.template
@@ -9,6 +9,7 @@
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,<% } %>
+    "skipLibCheck": true,
     "esModuleInterop": true,
     "sourceMap": true,
     "declaration": false,


### PR DESCRIPTION
This commit enables `skipLibCheck` in new workspaces which is now recommended by TypeScript.  When enabled, type checking of declaration files is skipped as rather than doing a full check of all `d.ts` files, TypeScript will type check the code you specifically refer to in your app’s source code.

See: https://www.typescriptlang.org/tsconfig#skipLibCheck


Note: this option is also enabled by default when running `tsc --init`

```
npx tsc --init               

Created a new tsconfig.json with: TS 
  target: es2016
  module: commonjs
  strict: true
  esModuleInterop: true
  skipLibCheck: true
  forceConsistentCasingInFileNames: true
```

Some more context: https://github.com/microsoft/TypeScript-Website/pull/970