### PR TITLE
refactor(@angular-devkit/build-angular): add watch builder teardown to application builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/application/tests/behavior/rebuild-errors_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/tests/behavior/rebuild-errors_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import { logging } from '@angular-devkit/core';
-import { concatMap, count, timeout } from 'rxjs';
+import { concatMap, count, take, timeout } from 'rxjs';
 import { buildApplication } from '../../index';
 import { APPLICATION_BUILDER_INFO, BASE_OPTIONS, describeBuilder } from '../setup';
 
@@ -72,9 +72,8 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
       `,
       );
 
-      const builderAbort = new AbortController();
       const buildCount = await harness
-        .execute({ outputLogsOnFailure: false, signal: builderAbort.signal })
+        .execute({ outputLogsOnFailure: false })
         .pipe(
           timeout(BUILD_TIMEOUT),
           concatMap(async ({ result, logs }, index) => {
@@ -143,11 +142,10 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
                   }),
                 );
 
-                // Test complete - abort watch mode
-                builderAbort?.abort();
                 break;
             }
           }),
+          take(5),
           count(),
         )
         .toPromise();
@@ -161,9 +159,8 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
         watch: true,
       });
 
-      const builderAbort = new AbortController();
       const buildCount = await harness
-        .execute({ outputLogsOnFailure: false, signal: builderAbort.signal })
+        .execute({ outputLogsOnFailure: false })
         .pipe(
           timeout(BUILD_TIMEOUT),
           concatMap(async ({ logs }, index) => {
@@ -251,11 +248,10 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
                   }),
                 );
 
-                // Test complete - abort watch mode
-                builderAbort?.abort();
                 break;
             }
           }),
+          take(6),
           count(),
         )
         .toPromise();
@@ -270,9 +266,8 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
         aot: false,
       });
 
-      const builderAbort = new AbortController();
       const buildCount = await harness
-        .execute({ outputLogsOnFailure: false, signal: builderAbort.signal })
+        .execute({ outputLogsOnFailure: false })
         .pipe(
           timeout(BUILD_TIMEOUT),
           concatMap(async ({ result, logs }, index) => {
@@ -302,11 +297,10 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
                   .expectFile('dist/browser/main.js')
                   .content.toContain('p {\\n  color: green;\\n}');
 
-                // Test complete - abort watch mode
-                builderAbort?.abort();
                 break;
             }
           }),
+          take(3),
           count(),
         )
         .toPromise();
@@ -320,9 +314,8 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
         watch: true,
       });
 
-      const builderAbort = new AbortController();
       const buildCount = await harness
-        .execute({ outputLogsOnFailure: true, signal: builderAbort.signal })
+        .execute({ outputLogsOnFailure: true })
         .pipe(
           timeout(BUILD_TIMEOUT),
           concatMap(async ({ result, logs }, index) => {
@@ -365,11 +358,10 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
                 harness.expectFile('dist/browser/main.js').content.toContain('Hello, world!');
                 harness.expectFile('dist/browser/main.js').content.toContain('Guten Tag');
 
-                // Test complete - abort watch mode
-                builderAbort?.abort();
                 break;
             }
           }),
+          take(4),
           count(),
         )
         .toPromise();

--- a/packages/angular_devkit/build_angular/src/builders/application/tests/behavior/rebuild-web-workers_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/tests/behavior/rebuild-web-workers_spec.ts
@@ -55,9 +55,8 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
       `,
       );
 
-      const builderAbort = new AbortController();
       const buildCount = await harness
-        .execute({ outputLogsOnFailure: false, signal: builderAbort.signal })
+        .execute({ outputLogsOnFailure: false })
         .pipe(
           timeout(BUILD_TIMEOUT),
           concatMap(async ({ result, logs }, index) => {
@@ -125,11 +124,10 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
                   .expectFile('dist/browser/main.js')
                   .content.toMatch(REFERENCED_WORKER_REGEXP);
 
-                // Test complete - abort watch mode
-                builderAbort?.abort();
                 break;
             }
           }),
+          take(5),
           count(),
         )
         .toPromise();

--- a/packages/angular_devkit/build_angular/src/builders/application/tests/behavior/typescript-rebuild-lazy_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/tests/behavior/typescript-rebuild-lazy_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import type { logging } from '@angular-devkit/core';
-import { concatMap, count, firstValueFrom, timeout } from 'rxjs';
+import { concatMap, count, firstValueFrom, take, timeout } from 'rxjs';
 import { buildApplication } from '../../index';
 import { OutputHashing } from '../../schema';
 import { APPLICATION_BUILDER_INFO, BASE_OPTIONS, describeBuilder } from '../setup';
@@ -42,9 +42,8 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
         ssr: true,
       });
 
-      const builderAbort = new AbortController();
       const buildCount = await firstValueFrom(
-        harness.execute({ outputLogsOnFailure: false, signal: builderAbort.signal }).pipe(
+        harness.execute({ outputLogsOnFailure: false }).pipe(
           timeout(30_000),
           concatMap(async ({ result, logs }, index) => {
             switch (index) {
@@ -79,10 +78,10 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
               case 3:
                 expect(result?.success).toBeTrue();
 
-                builderAbort.abort();
                 break;
             }
           }),
+          take(4),
           count(),
         ),
       );

--- a/packages/angular_devkit/build_angular/src/builders/application/tests/options/inline-style-language_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/tests/options/inline-style-language_spec.ts
@@ -87,9 +87,8 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
             content.replace('__STYLE_MARKER__', '$primary: indianred;\\nh1 { color: $primary; }'),
           );
 
-          const builderAbort = new AbortController();
           const buildCount = await harness
-            .execute({ signal: builderAbort.signal })
+            .execute()
             .pipe(
               timeout(30000),
               concatMap(async ({ result }, index) => {
@@ -129,11 +128,10 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
                     harness.expectFile('dist/browser/main.js').content.not.toContain('color: aqua');
                     harness.expectFile('dist/browser/main.js').content.toContain('color: blue');
 
-                    // Test complete - abort watch mode
-                    builderAbort.abort();
                     break;
                 }
               }),
+              take(3),
               count(),
             )
             .toPromise();


### PR DESCRIPTION
An AbortController is now automatically linked to the `application` builder's teardown context if one has not been provided. This supports reduced overhead in the unit tests by eliminating the need to manually create and use an AbortController/AbortSignal in each test that uses watch mode. Relevant tests that were previously doing this have also been updated.