### PR TITLE
perf(@angular-devkit/build-angular): only enable advanced optimizations with script optimizations

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/application/options.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/options.ts
@@ -284,7 +284,7 @@ export async function normalizeOptions(
 
   // Return all the normalized options
   return {
-    advancedOptimizations: !!aot,
+    advancedOptimizations: !!aot && optimizationOptions.scripts,
     allowedCommonJsDependencies,
     baseHref,
     cacheOptions,

--- a/packages/angular_devkit/build_angular/src/builders/application/tests/behavior/angular-aot-metadata_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/tests/behavior/angular-aot-metadata_spec.ts
@@ -14,6 +14,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
     it('should not emit any AOT class metadata functions', async () => {
       harness.useTarget('build', {
         ...BASE_OPTIONS,
+        optimization: true,
       });
 
       const { result } = await harness.executeOnce();
@@ -25,6 +26,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
     it('should not emit any AOT NgModule scope metadata functions', async () => {
       harness.useTarget('build', {
         ...BASE_OPTIONS,
+        optimization: true,
       });
 
       const { result } = await harness.executeOnce();

--- a/tests/legacy-cli/e2e/tests/build/prerender/error-with-sourcemaps.ts
+++ b/tests/legacy-cli/e2e/tests/build/prerender/error-with-sourcemaps.ts
@@ -44,5 +44,10 @@ export default async function () {
   const { message } = await expectToFail(() =>
     ng('build', '--configuration', 'development', '--prerender'),
   );
-  match(message, /window is not defined[.\s\S]*constructor \(.*app\.component\.ts\:\d+:\d+\)/);
+  match(
+    message,
+    // When babel is used it will add names to the sourcemap and `constructor` will be used in the stack trace.
+    // This will currently only happen if AOT and script optimizations are set which enables advanced optimizations.
+    /window is not defined[.\s\S]*(?:constructor|_AppComponent) \(.*app\.component\.ts\:\d+:\d+\)/,
+  );
 }


### PR DESCRIPTION
When using the `application` or `browser-esbuild` builders, the internal advanced optimizations can only be applied when in AOT mode. However, they were previously only checking the AOT mode and not whether the project was configured to use script optimizations. The advanced optimizations are now conditional on both AOT mode and the `optimization.scripts` option. This can greatly improve the performance of builds in development since the Babel related processing can be skipped for all TypeScript application code.