### PR TITLE
test: update browser compatibility test versions for v17

### DIFF
--- a/tests/legacy-cli/e2e/assets/protractor-saucelabs.conf.js
+++ b/tests/legacy-cli/e2e/assets/protractor-saucelabs.conf.js
@@ -17,47 +17,54 @@ exports.config = {
   allScriptsTimeout: 11000,
   specs: ['./src/**/*.e2e-spec.ts'],
 
+  // NOTE: https://saucelabs.com/products/platform-configurator can be used to determine configuration values
   multiCapabilities: [
     {
       browserName: 'chrome',
       platform: 'Windows 11',
-      version: '105',
+      version: '119',
+      tunnelIdentifier,
+    },
+    {
+      browserName: 'chrome',
+      platform: 'Linux',
+      version: '116',
       tunnelIdentifier,
     },
     {
       browserName: 'firefox',
-      version: '104',
+      version: '119',
       platform: 'Windows 11',
       tunnelIdentifier,
     },
     {
       browserName: 'firefox',
-      version: '91', // Latest Firefox ESR version
-      platform: 'Windows 11',
+      version: '102', // Latest Firefox ESR version as of Sep 2023
+      platform: 'Linux',
+      tunnelIdentifier,
+    },
+    {
+      browserName: 'safari',
+      platform: 'macOS 13',
+      version: '17',
       tunnelIdentifier,
     },
     {
       browserName: 'safari',
       platform: 'macOS 12',
-      version: '15',
-      tunnelIdentifier,
-    },
-    {
-      browserName: 'safari',
-      platform: 'macOS 11.00',
-      version: '14',
+      version: '16',
       tunnelIdentifier,
     },
     {
       browserName: 'MicrosoftEdge',
       platform: 'Windows 11',
-      version: '103',
+      version: '118',
       tunnelIdentifier,
     },
     {
       browserName: 'MicrosoftEdge',
       platform: 'Windows 11',
-      version: '104',
+      version: '115',
       tunnelIdentifier,
     },
   ],


### PR DESCRIPTION
The browser compatibility CI job contains a hardcoded set of browsers and platform combinations that should be updated for each major release. This update adjusts the versions for the Angular v17 release based on the support matrix at the time of release. Based on the release cadence of chrome-based browsers, the range was increased by 2 last versions to test a larger segment of the browser usage space.