### PR TITLE
test: correct misconfigured saucelabs platform/OS combination

### DIFF
--- a/tests/legacy-cli/e2e/assets/protractor-saucelabs.conf.js
+++ b/tests/legacy-cli/e2e/assets/protractor-saucelabs.conf.js
@@ -27,7 +27,7 @@ exports.config = {
     },
     {
       browserName: 'chrome',
-      platform: 'Linux',
+      platform: 'Windows 11',
       version: '116',
       tunnelIdentifier,
     },
@@ -40,7 +40,7 @@ exports.config = {
     {
       browserName: 'firefox',
       version: '102', // Latest Firefox ESR version as of Sep 2023
-      platform: 'Linux',
+      platform: 'Windows 11',
       tunnelIdentifier,
     },
     {


### PR DESCRIPTION
Using Linux in certain combinations on Saucelabs can lead to unsupported errors when initializing Saucelab environments prior to any actual testing.