### PR TITLE
test: disable new failing default typescript eslint rules to allow upgrading

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -103,7 +103,10 @@
     "@typescript-eslint/require-await": "off",
     "@typescript-eslint/restrict-plus-operands": "off",
     "@typescript-eslint/restrict-template-expressions": "off",
-    "@typescript-eslint/unbound-method": "off"
+    "@typescript-eslint/unbound-method": "off",
+    "@typescript-eslint/no-unsafe-enum-comparison": "off",
+    "@typescript-eslint/no-redundant-type-constituents": "off",
+    "@typescript-eslint/no-base-to-string": "off"
   },
   "overrides": [
     {


### PR DESCRIPTION
The latest major (v6) of the typescript eslint plugin contains several new rule defaults that currently cause errors in the repository code while linting. To facilitate an upgrade, these rules are now preemptively disabled. Once the update is complete, these rules can be evaluated for inclusion.

The rules are as follows:
   * @typescript-eslint/no-unsafe-enum-comparison
   * @typescript-eslint/no-redundant-type-constituents
   * @typescript-eslint/no-base-to-string

Unblocks #25522