### PR TITLE
fix(@angular-devkit/build-angular): watch symlink when using `preserveSymlinks` option

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/application/build-action.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/build-action.ts
@@ -33,6 +33,7 @@ export async function* runEsBuildBuildAction(
     deleteOutputPath?: boolean;
     poll?: number;
     signal?: AbortSignal;
+    preserveSymlinks?: boolean;
   },
 ): AsyncIterable<(ExecutionResult['outputWithFiles'] | ExecutionResult['output']) & BuilderOutput> {
   const {
@@ -48,6 +49,7 @@ export async function* runEsBuildBuildAction(
     projectRoot,
     workspaceRoot,
     progress,
+    preserveSymlinks,
   } = options;
 
   if (deleteOutputPath && writeToFileSystem) {
@@ -79,6 +81,7 @@ export async function* runEsBuildBuildAction(
     watcher = createWatcher({
       polling: typeof poll === 'number',
       interval: poll,
+      followSymlinks: preserveSymlinks,
       ignored: [
         // Ignore the output and cache paths to avoid infinite rebuild cycles
         outputPath,

--- a/packages/angular_devkit/build_angular/src/builders/application/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/index.ts
@@ -72,6 +72,7 @@ export async function* buildApplicationInternal(
     },
     {
       watch: normalizedOptions.watch,
+      preserveSymlinks: normalizedOptions.preserveSymlinks,
       poll: normalizedOptions.poll,
       deleteOutputPath: normalizedOptions.deleteOutputPath,
       cacheOptions: normalizedOptions.cacheOptions,

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/watcher.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/watcher.ts
@@ -39,11 +39,13 @@ export function createWatcher(options?: {
   polling?: boolean;
   interval?: number;
   ignored?: string[];
+  followSymlinks?: boolean;
 }): BuildWatcher {
   const watcher = new FSWatcher({
     usePolling: options?.polling,
     interval: options?.interval,
     ignored: options?.ignored,
+    followSymlinks: options?.followSymlinks,
     disableGlobbing: true,
     ignoreInitial: true,
   });


### PR DESCRIPTION
When using the esbuild based builder symlinks are not watched when `preserveSymlinks` is enabled.

Closes #26585
