### PR TITLE
fix(@angular-devkit/build-angular): error when occurred while using `--force-esbuild` in `ng serve`

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
@@ -145,9 +145,9 @@ export async function* serveWithVite(
   });
 
   const build =
-    builderName === '@angular-devkit/build-angular:browser-esbuild'
-      ? buildEsbuildBrowser
-      : buildApplicationInternal;
+    builderName === '@angular-devkit/build-angular:application'
+      ? buildApplicationInternal
+      : buildEsbuildBrowser;
 
   // TODO: Switch this to an architect schedule call when infrastructure settings are supported
   for await (const result of build(


### PR DESCRIPTION


This fixes an issue were when using the `--force-esbuild` option the application builder was used instead of the browser-esbuild.

Closes #26605
