### PR TITLE
feat(@angular-devkit/build-angular): add support for `--no-browsers` in karma builder

### DIFF
--- a/goldens/public-api/angular_devkit/build_angular/index.md
+++ b/goldens/public-api/angular_devkit/build_angular/index.md
@@ -271,7 +271,7 @@ export interface FileReplacement {
 // @public
 export interface KarmaBuilderOptions {
     assets?: AssetPattern_3[];
-    browsers?: string;
+    browsers?: Browsers;
     codeCoverage?: boolean;
     codeCoverageExclude?: string[];
     exclude?: string[];

--- a/packages/angular_devkit/build_angular/src/builders/karma/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/index.ts
@@ -100,8 +100,10 @@ export function execute(
       karmaOptions.singleRun = singleRun;
 
       // Convert browsers from a string to an array
-      if (options.browsers) {
+      if (typeof options.browsers === 'string' && options.browsers) {
         karmaOptions.browsers = options.browsers.split(',');
+      } else if (options.browsers === false) {
+        karmaOptions.browsers = [];
       }
 
       if (options.reporters) {

--- a/packages/angular_devkit/build_angular/src/builders/karma/schema.json
+++ b/packages/angular_devkit/build_angular/src/builders/karma/schema.json
@@ -199,8 +199,18 @@
       "description": "Do not use the real path when resolving modules. If unset then will default to `true` if NodeJS option --preserve-symlinks is set."
     },
     "browsers": {
-      "type": "string",
-      "description": "Override which browsers tests are run against."
+      "description": "Override which browsers tests are run against. Set to `false` to not use any browser.",
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "A comma seperate list of browsers to run tests against."
+        },
+        {
+          "const": false,
+          "type": "boolean",
+          "description": "Does use run tests against a browser."
+        }
+      ]
     },
     "codeCoverage": {
       "type": "boolean",


### PR DESCRIPTION


This commit enables users to disable runnings tests against a browsers. This can be done by using the `--no-browsers` command line flag or setting `browsers` to `false` in the `angular.json`

Closes #26537
