### PR TITLE
fix(@angular-devkit/build-angular): resolve correct outdir for esbuild

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/esbuild/application-code-bundle.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/application-code-bundle.ts
@@ -10,7 +10,7 @@ import type { BuildOptions } from 'esbuild';
 import assert from 'node:assert';
 import { createHash } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
-import { extname, join } from 'node:path';
+import { extname, join, resolve } from 'node:path';
 import type { NormalizedApplicationBuildOptions } from '../../builders/application/options';
 import { allowMangle } from '../../utils/environment-options';
 import { createCompilerPlugin } from './angular/compiler-plugin';
@@ -312,6 +312,7 @@ export function createServerPolyfillBundleOptions(
 function getEsBuildCommonOptions(options: NormalizedApplicationBuildOptions): BuildOptions {
   const {
     workspaceRoot,
+    outputPath,
     outExtension,
     optimizationOptions,
     sourcemapOptions,
@@ -352,7 +353,7 @@ function getEsBuildCommonOptions(options: NormalizedApplicationBuildOptions): Bu
     minifySyntax: optimizationOptions.scripts,
     minifyWhitespace: optimizationOptions.scripts,
     pure: ['forwardRef'],
-    outdir: workspaceRoot,
+    outdir: resolve(workspaceRoot, outputPath),
     outExtension: outExtension ? { '.js': `.${outExtension}` } : undefined,
     sourcemap: sourcemapOptions.scripts && (sourcemapOptions.hidden ? 'external' : true),
     splitting: true,


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Esbuild options `outdir` is currently using the `workspaceRoot` value instead of the `outputPath`, it is problematic for instance when we want to create a plugin where we need the actual outdir.  

Issue Number: N/A

## What is the new behavior?

Now esbuild build options are using the real output path of the application instead of the workspace root. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Before writing tests, I wanted to see if this change could be accepted.