### PR TITLE
fix(@angular-devkit/build-angular): ensure port 0 uses random port with Vite development server

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/dev-server/tests/options/port_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/tests/options/port_spec.ts
@@ -71,6 +71,11 @@ describeServeBuilder(
         expect(result?.success).toBeTrue();
         const port = getResultPort(result);
         expect(port).not.toBe('4200');
+        if (isViteRun) {
+          // Should not be default Vite port either
+          expect(port).not.toBe('5173');
+        }
+
         expect(port).toMatch(/\d{4,6}/);
         expect(await response?.text()).toContain('<title>');
 


### PR DESCRIPTION
Vite appears to consider a port value of `0` as a falsy value and use the default Vite port of `5173` when zero is used as a value for the development server port option. To workaround this issue, the port checker code now explicitly handles the zero value case and determines a random port as would be done automatically by the Webpack-based development server.