### PR TITLE
fix(@angular-devkit/build-angular): `baseHref` with trailing slash causes server not to be accessible without trailing slash

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/dev-server/tests/behavior/build-base-href_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/tests/behavior/build-base-href_spec.ts
@@ -1,0 +1,49 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { executeDevServer } from '../../index';
+import { executeOnceAndFetch } from '../execute-fetch';
+import { describeServeBuilder } from '../jasmine-helpers';
+import { BASE_OPTIONS, DEV_SERVER_BUILDER_INFO } from '../setup';
+
+describeServeBuilder(executeDevServer, DEV_SERVER_BUILDER_INFO, (harness, setupTarget) => {
+  describe('Behavior: "buildTarget baseHref"', () => {
+    beforeEach(async () => {
+      setupTarget(harness, {
+        baseHref: '/test/',
+      });
+
+      // Application code is not needed for these tests
+      await harness.writeFile('src/main.ts', 'console.log("foo");');
+    });
+
+    it('uses the baseHref defined in the "buildTarget" options as the serve path', async () => {
+      harness.useTarget('serve', {
+        ...BASE_OPTIONS,
+      });
+
+      const { result, response } = await executeOnceAndFetch(harness, '/test/main.js');
+
+      expect(result?.success).toBeTrue();
+      const baseUrl = new URL(`${result?.baseUrl}/`);
+      expect(baseUrl.pathname).toBe('/test/');
+      expect(await response?.text()).toContain('console.log');
+    });
+
+    it('serves the application from baseHref location without trailing slash', async () => {
+      harness.useTarget('serve', {
+        ...BASE_OPTIONS,
+      });
+
+      const { result, response } = await executeOnceAndFetch(harness, '/test');
+
+      expect(result?.success).toBeTrue();
+      expect(await response?.text()).toContain('<script src="main.js" type="module">');
+    });
+  });
+});

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
@@ -86,8 +86,11 @@ export async function* serveWithVite(
   // Set all packages as external to support Vite's prebundle caching
   browserOptions.externalPackages = serverOptions.cacheOptions.enabled;
 
-  if (serverOptions.servePath === undefined && browserOptions.baseHref !== undefined) {
-    serverOptions.servePath = browserOptions.baseHref;
+  const baseHref = browserOptions.baseHref;
+  if (serverOptions.servePath === undefined && baseHref !== undefined) {
+    // Remove trailing slash
+    serverOptions.servePath =
+      baseHref[baseHref.length - 1] === '/' ? baseHref.slice(0, -1) : baseHref;
   }
 
   // The development server currently only supports a single locale when localizing.
@@ -464,7 +467,7 @@ export async function setupServer(
     css: {
       devSourcemap: true,
     },
-    // Vite will normalize the `base` option by adding a leading and trailing forward slash.
+    // Vite will normalize the `base` option by adding a leading slash.
     base: serverOptions.servePath,
     resolve: {
       mainFields: ['es2020', 'browser', 'module', 'main'],


### PR DESCRIPTION

This commit fixes an issue were when using a `baseHref` with trailing slash, vite dev-server would have been only accessible via a URL with a trailing slash. As vite would redirect to an error page similar to the below;

```
The server is configured with a public base URL of /myapp/ - did you mean to visit [/myapp/](http://localhost:4200/myapp/) instead?
```

Closes: #26618
