### PR TITLE
refactor(@angular-devkit/build-angular): remove deployUrl from browser-esbuild builder-status-warnings

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/builder-status-warnings.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/builder-status-warnings.ts
@@ -39,11 +39,7 @@ export function logBuilderStatusWarnings(
       continue;
     }
 
-    if (
-      unsupportedOption === 'vendorChunk' ||
-      unsupportedOption === 'resourcesOutputPath' ||
-      unsupportedOption === 'deployUrl'
-    ) {
+    if (unsupportedOption === 'vendorChunk' || unsupportedOption === 'resourcesOutputPath') {
       logger.warn(
         `The '${unsupportedOption}' option is not used by this builder and will be ignored.`,
       );


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

The logBuilderStatusWarnings function of browser-esbuild builder checks if unsupportedOption is "deployUrl". However, deployUrl is not in the UNSUPPORTED_OPTIONS array.

Issue Number: N/A

## What is the new behavior?

The logBuilderStatusWarnings function of browser-esbuild builder does not check if unsupportedOption is "deployUrl".

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information
