### PR TITLE
fix(@angular-devkit/build-angular): retain symlinks to output platform directories on builds

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/application/build-action.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/build-action.ts
@@ -53,7 +53,7 @@ export async function* runEsBuildBuildAction(
   } = options;
 
   if (deleteOutputPath && writeToFileSystem) {
-    await deleteOutputDir(workspaceRoot, outputPath);
+    await deleteOutputDir(workspaceRoot, outputPath, ['browser', 'server']);
   }
 
   const withProgress: typeof withSpinner = progress ? withSpinner : withNoProgress;

--- a/packages/angular_devkit/build_angular/src/builders/application/tests/options/delete-output-path_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/tests/options/delete-output-path_spec.ts
@@ -15,8 +15,9 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
       // Application code is not needed for asset tests
       await harness.writeFile('src/main.ts', 'console.log("TEST");');
 
-      // Add file in output
-      await harness.writeFile('dist/dummy.txt', '');
+      // Add files in output
+      await harness.writeFile('dist/a.txt', 'A');
+      await harness.writeFile('dist/browser/b.txt', 'B');
     });
 
     it(`should delete the output files when 'deleteOutputPath' is true`, async () => {
@@ -27,7 +28,10 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
 
       const { result } = await harness.executeOnce();
       expect(result?.success).toBeTrue();
-      harness.expectFile('dist/dummy.txt').toNotExist();
+      harness.expectDirectory('dist').toExist();
+      harness.expectFile('dist/a.txt').toNotExist();
+      harness.expectDirectory('dist/browser').toExist();
+      harness.expectFile('dist/browser/b.txt').toNotExist();
     });
 
     it(`should delete the output files when 'deleteOutputPath' is not set`, async () => {
@@ -38,7 +42,10 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
 
       const { result } = await harness.executeOnce();
       expect(result?.success).toBeTrue();
-      harness.expectFile('dist/dummy.txt').toNotExist();
+      harness.expectDirectory('dist').toExist();
+      harness.expectFile('dist/a.txt').toNotExist();
+      harness.expectDirectory('dist/browser').toExist();
+      harness.expectFile('dist/browser/b.txt').toNotExist();
     });
 
     it(`should not delete the output files when 'deleteOutputPath' is false`, async () => {
@@ -49,7 +56,23 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
 
       const { result } = await harness.executeOnce();
       expect(result?.success).toBeTrue();
-      harness.expectFile('dist/dummy.txt').toExist();
+      harness.expectFile('dist/a.txt').toExist();
+      harness.expectFile('dist/browser/b.txt').toExist();
+    });
+
+    it(`should not delete empty only directories when 'deleteOutputPath' is true`, async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        deleteOutputPath: true,
+      });
+
+      // Add an error to prevent the build from writing files
+      await harness.writeFile('src/main.ts', 'INVALID_CODE');
+
+      const { result } = await harness.executeOnce({ outputLogsOnFailure: false });
+      expect(result?.success).toBeFalse();
+      harness.expectDirectory('dist').toExist();
+      harness.expectDirectory('dist/browser').toExist();
     });
   });
 });

--- a/packages/angular_devkit/build_angular/src/testing/builder-harness.ts
+++ b/packages/angular_devkit/build_angular/src/testing/builder-harness.ts
@@ -22,7 +22,7 @@ import {
 import { WorkspaceHost } from '@angular-devkit/architect/node';
 import { TestProjectHost } from '@angular-devkit/architect/testing';
 import { getSystemPath, json, logging } from '@angular-devkit/core';
-import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
 import fs from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import {
@@ -349,6 +349,12 @@ export class BuilderHarness<T> {
     const fullPath = this.resolvePath(path);
 
     return existsSync(fullPath);
+  }
+
+  hasDirectory(path: string): boolean {
+    const fullPath = this.resolvePath(path);
+
+    return statSync(fullPath, { throwIfNoEntry: false })?.isDirectory() ?? false;
   }
 
   hasFileMatch(directory: string, pattern: RegExp): boolean {

--- a/packages/angular_devkit/build_angular/src/testing/jasmine-helpers.ts
+++ b/packages/angular_devkit/build_angular/src/testing/jasmine-helpers.ts
@@ -42,6 +42,9 @@ export class JasmineBuilderHarness<T> extends BuilderHarness<T> {
   expectFile(path: string): HarnessFileMatchers {
     return expectFile(path, this);
   }
+  expectDirectory(path: string): HarnessDirectoryMatchers {
+    return expectDirectory(path, this);
+  }
 }
 
 export interface HarnessFileMatchers {
@@ -49,6 +52,11 @@ export interface HarnessFileMatchers {
   toNotExist(): boolean;
   readonly content: jasmine.ArrayLikeMatchers<string>;
   readonly size: jasmine.Matchers<number>;
+}
+
+export interface HarnessDirectoryMatchers {
+  toExist(): boolean;
+  toNotExist(): boolean;
 }
 
 /**
@@ -122,6 +130,26 @@ export function expectFile<T>(path: string, harness: BuilderHarness<T>): Harness
           `Expected file size but file does not exist: '${path}'`,
         );
       }
+    },
+  };
+}
+
+export function expectDirectory<T>(
+  path: string,
+  harness: BuilderHarness<T>,
+): HarnessDirectoryMatchers {
+  return {
+    toExist() {
+      const exists = harness.hasDirectory(path);
+      expect(exists).toBe(true, 'Expected directory to exist: ' + path);
+
+      return exists;
+    },
+    toNotExist() {
+      const exists = harness.hasDirectory(path);
+      expect(exists).toBe(false, 'Expected directory to not exist: ' + path);
+
+      return !exists;
     },
   };
 }


### PR DESCRIPTION
The `deleteOutputPath` option will now empty specific build artifact directories instead of
removing them completely. This allows for symlinking or mounting the directories via Docker.
This is similar to the current behavior of emptying the root output path to allow similar
actions. All previous files will still be removed when the `deleteOutputPath` option is enabled.
This is useful in situations were the browser output files may be symlinked onto another
location on disk that is setup as a development server, or a Docker configuration mounts the browser
and server output to different locations on the host machine.