### PR TITLE
fix(@angular-devkit/build-angular): the request url "..." is outside of Vite serving allow list for all assets

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
@@ -220,7 +220,7 @@ export async function* serveWithVite(
     if (server) {
       // Update fs allow list to include any new assets from the build option.
       server.config.server.fs.allow = [
-        ...new Set(...server.config.server.fs.allow, ...assetFiles.values()),
+        ...new Set([...server.config.server.fs.allow, ...assetFiles.values()]),
       ];
 
       handleUpdate(normalizePath, generatedFiles, server, serverOptions, context.logger);


### PR DESCRIPTION


Vite's fs.allow was being populated incorrectly.

Closes #26624
