### PR TITLE
fix(@angular-devkit/build-angular): handle updates of an `npm link` library from another workspace when `preserveSymlinks` is `true`

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/application/build-action.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/build-action.ts
@@ -76,21 +76,27 @@ export async function* runEsBuildBuildAction(
       logger.info('Watch mode enabled. Watching for file changes...');
     }
 
+    const ignored: string[] = [
+      // Ignore the output and cache paths to avoid infinite rebuild cycles
+      outputPath,
+      cacheOptions.basePath,
+      `${workspaceRoot.replace(/\\/g, '/')}/**/.*/**`,
+    ];
+
+    if (!preserveSymlinks) {
+      // Ignore all node modules directories to avoid excessive file watchers.
+      // Package changes are handled below by watching manifest and lock files.
+      // NOTE: this is not enable when preserveSymlinks is true as this would break `npm link` usages.
+      ignored.push('**/node_modules/**');
+    }
+
     // Setup a watcher
     const { createWatcher } = await import('../../tools/esbuild/watcher');
     watcher = createWatcher({
       polling: typeof poll === 'number',
       interval: poll,
       followSymlinks: preserveSymlinks,
-      ignored: [
-        // Ignore the output and cache paths to avoid infinite rebuild cycles
-        outputPath,
-        cacheOptions.basePath,
-        // Ignore all node modules directories to avoid excessive file watchers.
-        // Package changes are handled below by watching manifest and lock files.
-        '**/node_modules/**',
-        `${workspaceRoot.replace(/\\/g, '/')}/**/.*/**`,
-      ],
+      ignored,
     });
 
     // Setup abort support


### PR DESCRIPTION


Prior to this change, watching of an `npm link` of a library in another workspace when `preserveSymlinks` was set to `true` was not being picked up as `node_modules` files were always ignored.

Closes #25753
