### PR TITLE
fix(@angular-devkit/build-angular): cache loading of component resources in JIT mode

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/esbuild/angular/compiler-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/angular/compiler-plugin.ts
@@ -409,6 +409,7 @@ export function createCompilerPlugin(
           stylesheetBundler,
           additionalResults,
           styleOptions.inlineStyleLanguage,
+          pluginOptions.loadResultCache,
         );
       }
 


### PR DESCRIPTION
The load result caching capabilities of the Angular compiler plugin used within the `application` and `browser-esbuild` builders is now used for both stylesheet and template component resources when building in JIT mode. This limits the amount of file system access required during a rebuild in JIT mode and also more accurately captures the full set of watched files.