### PR TITLE
fix(@angular-devkit/build-angular): file is missing from the TypeScript compilation with JIT

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/application/tests/behavior/typescript-rebuild-touch-file_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/tests/behavior/typescript-rebuild-touch-file_spec.ts
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { concatMap, count, take, timeout } from 'rxjs';
+import { buildApplication } from '../../index';
+import { APPLICATION_BUILDER_INFO, BASE_OPTIONS, describeBuilder } from '../setup';
+
+describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
+  describe('Behavior: "Rebuilds when touching file"', () => {
+    for (const aot of [true, false]) {
+      it(`Rebuild correctly when file is touched with ${aot ? 'AOT' : 'JIT'}`, async () => {
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          watch: true,
+          aot,
+        });
+
+        const buildCount = await harness
+          .execute({ outputLogsOnFailure: false })
+          .pipe(
+            timeout(30_000),
+            concatMap(async ({ result }, index) => {
+              switch (index) {
+                case 0:
+                  expect(result?.success).toBeTrue();
+                  // Touch a file without doing any changes.
+                  await harness.modifyFile('src/app/app.component.ts', (content) => content);
+                  break;
+                case 1:
+                  expect(result?.success).toBeTrue();
+                  await harness.removeFile('src/app/app.component.ts');
+                  break;
+                case 2:
+                  expect(result?.success).toBeFalse();
+                  break;
+              }
+            }),
+            take(3),
+            count(),
+          )
+          .toPromise();
+
+        expect(buildCount).toBe(3);
+      });
+    }
+  });
+});

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/angular/source-file-cache.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/angular/source-file-cache.ts
@@ -31,7 +31,6 @@ export class SourceFileCache extends Map<string, ts.SourceFile> {
     }
     for (let file of files) {
       file = path.normalize(file);
-      this.typeScriptFileCache.delete(file);
       this.loadResultCache.invalidate(file);
 
       // Normalize separators to allow matching TypeScript Host paths


### PR DESCRIPTION


Before this update, removing the modified file entry from `typeScriptFileCache` when a file was saved but unmodified created an issue. The TypeScript compiler didn't re-emit the file using `emitNextAffectedFile` because the file hashes remained unchanged. Consequently, this led to missing files in the esbuild compilation process.

In the current update, we no longer delete entries from typeScriptFileCache. This adjustment resolves the problem by ensuring the proper handling of file recompilation and prevents files from going missing during the esbuild compilation.

Closes #26635

