### PR TITLE
fix(@angular-devkit/build-angular): allow vite to serve JavaScript and TypeScript assets

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/dev-server/tests/behavior/build-assets_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/tests/behavior/build-assets_spec.ts
@@ -12,9 +12,11 @@ import { describeServeBuilder } from '../jasmine-helpers';
 import { BASE_OPTIONS, DEV_SERVER_BUILDER_INFO } from '../setup';
 
 describeServeBuilder(executeDevServer, DEV_SERVER_BUILDER_INFO, (harness, setupTarget) => {
+  const javascriptFileContent =
+    "import {foo} from 'unresolved'; /* a comment */const foo = `bar`;\n\n\n";
+
   describe('Behavior: "browser builder assets"', () => {
     it('serves a project JavaScript asset unmodified', async () => {
-      const javascriptFileContent = '/* a comment */const foo = `bar`;\n\n\n';
       await harness.writeFile('src/extra.js', javascriptFileContent);
 
       setupTarget(harness, {
@@ -29,6 +31,26 @@ describeServeBuilder(executeDevServer, DEV_SERVER_BUILDER_INFO, (harness, setupT
       });
 
       const { result, response } = await executeOnceAndFetch(harness, 'extra.js');
+
+      expect(result?.success).toBeTrue();
+      expect(await response?.text()).toContain(javascriptFileContent);
+    });
+
+    it('serves a project TypeScript asset unmodified', async () => {
+      await harness.writeFile('src/extra.ts', javascriptFileContent);
+
+      setupTarget(harness, {
+        assets: ['src/extra.ts'],
+        optimization: {
+          scripts: true,
+        },
+      });
+
+      harness.useTarget('serve', {
+        ...BASE_OPTIONS,
+      });
+
+      const { result, response } = await executeOnceAndFetch(harness, 'extra.ts');
 
       expect(result?.success).toBeTrue();
       expect(await response?.text()).toContain(javascriptFileContent);

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
@@ -609,6 +609,11 @@ export async function setupServer(
             // Rewrite all build assets to a vite raw fs URL
             const assetSourcePath = assets.get(pathname);
             if (assetSourcePath !== undefined) {
+              // Workaround to disable Vite transformer middleware.
+              // See: https://github.com/vitejs/vite/blob/746a1daab0395f98f0afbdee8f364cb6cf2f3b3f/packages/vite/src/node/server/middlewares/transform.ts#L201 and
+              // https://github.com/vitejs/vite/blob/746a1daab0395f98f0afbdee8f364cb6cf2f3b3f/packages/vite/src/node/server/transformRequest.ts#L204-L206
+              req.headers.accept = 'text/html';
+
               // The encoding needs to match what happens in the vite static middleware.
               // ref: https://github.com/vitejs/vite/blob/d4f13bd81468961c8c926438e815ab6b1c82735e/packages/vite/src/node/server/middlewares/static.ts#L163
               req.url = `${server.config.base}@fs/${encodeURI(assetSourcePath)}`;


### PR DESCRIPTION


This commit fixes an issue which caused vite to transform JavaScript and TypeScript assets.

Closes #26641

