### PR TITLE
[17.0.x] fix(@angular-devkit/build-angular): cache loading of component resources in JIT mode

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/application/tests/behavior/rebuild-component_styles_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/tests/behavior/rebuild-component_styles_spec.ts
@@ -18,60 +18,67 @@ export const BUILD_TIMEOUT = 30_000;
 
 describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
   describe('Behavior: "Rebuilds when component stylesheets change"', () => {
-    it('updates component when imported sass changes', async () => {
-      harness.useTarget('build', {
-        ...BASE_OPTIONS,
-        watch: true,
+    for (const aot of [true, false]) {
+      it(`updates component when imported sass changes with ${aot ? 'AOT' : 'JIT'}`, async () => {
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          watch: true,
+          aot,
+        });
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          watch: true,
+        });
+
+        await harness.modifyFile('src/app/app.component.ts', (content) =>
+          content.replace('app.component.css', 'app.component.scss'),
+        );
+        await harness.writeFile('src/app/app.component.scss', "@import './a';");
+        await harness.writeFile('src/app/a.scss', '$primary: aqua;\\nh1 { color: $primary; }');
+
+        const builderAbort = new AbortController();
+        const buildCount = await harness
+          .execute({ signal: builderAbort.signal })
+          .pipe(
+            timeout(30000),
+            concatMap(async ({ result }, index) => {
+              expect(result?.success).toBe(true);
+
+              switch (index) {
+                case 0:
+                  harness.expectFile('dist/browser/main.js').content.toContain('color: aqua');
+                  harness.expectFile('dist/browser/main.js').content.not.toContain('color: blue');
+
+                  await harness.writeFile(
+                    'src/app/a.scss',
+                    '$primary: blue;\\nh1 { color: $primary; }',
+                  );
+                  break;
+                case 1:
+                  harness.expectFile('dist/browser/main.js').content.not.toContain('color: aqua');
+                  harness.expectFile('dist/browser/main.js').content.toContain('color: blue');
+
+                  await harness.writeFile(
+                    'src/app/a.scss',
+                    '$primary: green;\\nh1 { color: $primary; }',
+                  );
+                  break;
+                case 2:
+                  harness.expectFile('dist/browser/main.js').content.not.toContain('color: aqua');
+                  harness.expectFile('dist/browser/main.js').content.not.toContain('color: blue');
+                  harness.expectFile('dist/browser/main.js').content.toContain('color: green');
+
+                  // Test complete - abort watch mode
+                  builderAbort.abort();
+                  break;
+              }
+            }),
+            count(),
+          )
+          .toPromise();
+
+        expect(buildCount).toBe(3);
       });
-
-      await harness.modifyFile('src/app/app.component.ts', (content) =>
-        content.replace('app.component.css', 'app.component.scss'),
-      );
-      await harness.writeFile('src/app/app.component.scss', "@import './a';");
-      await harness.writeFile('src/app/a.scss', '$primary: aqua;\\nh1 { color: $primary; }');
-
-      const builderAbort = new AbortController();
-      const buildCount = await harness
-        .execute({ signal: builderAbort.signal })
-        .pipe(
-          timeout(30000),
-          concatMap(async ({ result }, index) => {
-            expect(result?.success).toBe(true);
-
-            switch (index) {
-              case 0:
-                harness.expectFile('dist/browser/main.js').content.toContain('color: aqua');
-                harness.expectFile('dist/browser/main.js').content.not.toContain('color: blue');
-
-                await harness.writeFile(
-                  'src/app/a.scss',
-                  '$primary: blue;\\nh1 { color: $primary; }',
-                );
-                break;
-              case 1:
-                harness.expectFile('dist/browser/main.js').content.not.toContain('color: aqua');
-                harness.expectFile('dist/browser/main.js').content.toContain('color: blue');
-
-                await harness.writeFile(
-                  'src/app/a.scss',
-                  '$primary: green;\\nh1 { color: $primary; }',
-                );
-                break;
-              case 2:
-                harness.expectFile('dist/browser/main.js').content.not.toContain('color: aqua');
-                harness.expectFile('dist/browser/main.js').content.not.toContain('color: blue');
-                harness.expectFile('dist/browser/main.js').content.toContain('color: green');
-
-                // Test complete - abort watch mode
-                builderAbort.abort();
-                break;
-            }
-          }),
-          count(),
-        )
-        .toPromise();
-
-      expect(buildCount).toBe(3);
-    });
+    }
   });
 });

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/angular/compiler-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/angular/compiler-plugin.ts
@@ -409,6 +409,7 @@ export function createCompilerPlugin(
           stylesheetBundler,
           additionalResults,
           styleOptions.inlineStyleLanguage,
+          pluginOptions.loadResultCache,
         );
       }
 


### PR DESCRIPTION
The load result caching capabilities of the Angular compiler plugin used within the `application` and `browser-esbuild` builders is now used for both stylesheet and template component resources when building in JIT mode. This limits the amount of file system access required during a rebuild in JIT mode and also more accurately captures the full set of watched files.

17.0.x variant of https://github.com/angular/angular-cli/pull/26636