### PR TITLE
fix(@angular/cli): print error code when available on unexpected error occurred

### DIFF
--- a/packages/angular/cli/lib/cli/index.ts
+++ b/packages/angular/cli/lib/cli/index.ts
@@ -105,7 +105,11 @@ export default async function (options: { cliArgs: string[] }) {
     } else if (typeof err === 'number') {
       // Log nothing.
     } else {
-      logger.fatal(`An unexpected error occurred: ${err}`);
+      logger.fatal(
+        `An unexpected error occurred: ${
+          typeof err === 'object' && 'code' in err ? err.code : err
+        }`,
+      );
     }
 
     return 1;


### PR DESCRIPTION


In some cases, Node.js expection would only contain an error code, example `ERR_UNSUPPORTED_ESM_URL_SCHEME`. This caused `An unexpected error occurred: [object Object]` to be logged in the console.

Closes #26648
