### PR TITLE
Fix MAIN CI

### DIFF
--- a/tests/legacy-cli/e2e/tests/basic/serve.ts
+++ b/tests/legacy-cli/e2e/tests/basic/serve.ts
@@ -1,3 +1,4 @@
+import { setTimeout } from 'node:timers/promises';
 import { killAllProcesses } from '../../utils/process';
 import { ngServe } from '../../utils/project';
 
@@ -5,6 +6,8 @@ export default async function () {
   // Serve works without HMR
   const noHmrPort = await ngServe('--no-hmr');
   await verifyResponse(noHmrPort);
+
+  await setTimeout(500);
   await killAllProcesses();
 
   // Serve works with HMR


### PR DESCRIPTION
This was causing `Error: The service was stopped: write EPIPE` which caused the test to fail on Node.js 18.