### PR TITLE
fix(@angular-devkit/build-angular): ensure empty optimized Sass stylesheets stay empty

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/application/tests/behavior/component-stylesheets_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/tests/behavior/component-stylesheets_spec.ts
@@ -23,5 +23,26 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
       const { result } = await harness.executeOnce();
       expect(result?.success).toBeTrue();
     });
+
+    it('should maintain optimized empty Sass stylesheet when original has content', async () => {
+      await harness.modifyFile('src/app/app.component.ts', (content) => {
+        return content.replace('./app.component.css', './app.component.scss');
+      });
+      await harness.removeFile('src/app/app.component.css');
+      await harness.writeFile('src/app/app.component.scss', '@import "variables";');
+      await harness.writeFile('src/app/_variables.scss', '$value: blue;');
+
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        optimization: {
+          styles: true,
+        },
+      });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
+
+      harness.expectFile('dist/browser/main.js').content.not.toContain('variables');
+    });
   });
 });

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/angular/angular-host.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/angular/angular-host.ts
@@ -74,7 +74,7 @@ export function createAngularCompilerHost(
       context.resourceFile ?? undefined,
     );
 
-    return result ? { content: result } : null;
+    return typeof result === 'string' ? { content: result } : null;
   };
 
   // Allow the AOT compiler to request the set of changed templates and styles


### PR DESCRIPTION
When an optimized Sass stylesheet becomes an empty string the AOT Angular host adapter was previously treating this as a falsy value and using the original content of the stylesheet. Empty strings are now considered valid values and will be passed to the AOT compiler as such.

Closes: #26653