### PR TITLE
refactor: update test runner to use proxess.exit instead of treekill

### DIFF
--- a/tests/legacy-cli/e2e/utils/test_process.ts
+++ b/tests/legacy-cli/e2e/utils/test_process.ts
@@ -1,15 +1,13 @@
-import { killAllProcesses } from './process';
-
 const testScript: string = process.argv[2];
 const testModule = require(testScript);
 const testFunction: () => Promise<void> | void =
   typeof testModule == 'function'
     ? testModule
     : typeof testModule.default == 'function'
-    ? testModule.default
-    : () => {
-        throw new Error('Invalid test module.');
-      };
+      ? testModule.default
+      : () => {
+          throw new Error('Invalid test module.');
+        };
 
 (async () => {
   try {
@@ -18,6 +16,6 @@ const testFunction: () => Promise<void> | void =
     console.error('Test Process error', e);
     process.exitCode = -1;
   } finally {
-    await killAllProcesses();
+    process.exit();
   }
 })();


### PR DESCRIPTION
This fixes an issue on Linux CI that `ng serve` sub-process is not terminated properly when using tree-kill which causes the tests test process not to exit.

