### PR TITLE
feat(@angular-devkit/build-angular): allow customization of output locations

### DIFF
--- a/goldens/public-api/angular_devkit/build_angular/index.md
+++ b/goldens/public-api/angular_devkit/build_angular/index.md
@@ -46,7 +46,7 @@ export interface ApplicationBuilderOptions {
     namedChunks?: boolean;
     optimization?: OptimizationUnion_2;
     outputHashing?: OutputHashing_2;
-    outputPath: string;
+    outputPath: OutputPathUnion;
     poll?: number;
     polyfills?: string[];
     prerender?: PrerenderUnion;

--- a/packages/angular_devkit/build_angular/src/builders/application/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/index.ts
@@ -31,21 +31,47 @@ export async function* buildApplicationInternal(
   },
   extensions?: ApplicationBuilderExtensions,
 ): AsyncIterable<ApplicationBuilderOutput> {
+  const { workspaceRoot, logger, target } = context;
+
   // Check Angular version.
-  assertCompatibleAngularVersion(context.workspaceRoot);
+  assertCompatibleAngularVersion(workspaceRoot);
 
   // Purge old build disk cache.
   await purgeStaleBuildCache(context);
 
   // Determine project name from builder context target
-  const projectName = context.target?.project;
+  const projectName = target?.project;
   if (!projectName) {
-    context.logger.error(`The 'application' builder requires a target to be specified.`);
+    yield { success: false, error: `The 'application' builder requires a target to be specified.` };
 
     return;
   }
 
   const normalizedOptions = await normalizeOptions(context, projectName, options, extensions);
+  const writeToFileSystem = infrastructureSettings?.write ?? true;
+  const writeServerBundles =
+    writeToFileSystem && !!(normalizedOptions.ssrOptions && normalizedOptions.serverEntryPoint);
+
+  if (writeServerBundles) {
+    const { browser, server } = normalizedOptions.outputOptions;
+    if (browser === '') {
+      yield {
+        success: false,
+        error: `'outputPath.browser' cannot be configured to an empty string when SSR is enabled.`,
+      };
+
+      return;
+    }
+
+    if (browser === server) {
+      yield {
+        success: false,
+        error: `'outputPath.browser' and 'outputPath.server' cannot be configured to the same value.`,
+      };
+
+      return;
+    }
+  }
 
   // Setup an abort controller with a builder teardown if no signal is present
   let signal = context.signal;
@@ -58,14 +84,11 @@ export async function* buildApplicationInternal(
   yield* runEsBuildBuildAction(
     async (rebuildState) => {
       const startTime = process.hrtime.bigint();
-
       const result = await executeBuild(normalizedOptions, context, rebuildState);
 
       const buildTime = Number(process.hrtime.bigint() - startTime) / 10 ** 9;
       const status = result.errors.length > 0 ? 'failed' : 'complete';
-      context.logger.info(
-        `Application bundle generation ${status}. [${buildTime.toFixed(3)} seconds]`,
-      );
+      logger.info(`Application bundle generation ${status}. [${buildTime.toFixed(3)} seconds]`);
 
       return result;
     },
@@ -75,19 +98,18 @@ export async function* buildApplicationInternal(
       poll: normalizedOptions.poll,
       deleteOutputPath: normalizedOptions.deleteOutputPath,
       cacheOptions: normalizedOptions.cacheOptions,
-      outputPath: normalizedOptions.outputPath,
+      outputOptions: normalizedOptions.outputOptions,
       verbose: normalizedOptions.verbose,
       projectRoot: normalizedOptions.projectRoot,
       workspaceRoot: normalizedOptions.workspaceRoot,
       progress: normalizedOptions.progress,
-      writeToFileSystem: infrastructureSettings?.write,
+      writeToFileSystem,
       // For app-shell and SSG server files are not required by users.
       // Omit these when SSR is not enabled.
-      writeToFileSystemFilter:
-        normalizedOptions.ssrOptions && normalizedOptions.serverEntryPoint
-          ? undefined
-          : (file) => file.type !== BuildOutputFileType.Server,
-      logger: context.logger,
+      writeToFileSystemFilter: writeServerBundles
+        ? undefined
+        : (file) => file.type !== BuildOutputFileType.Server,
+      logger,
       signal,
     },
   );

--- a/packages/angular_devkit/build_angular/src/builders/application/schema.json
+++ b/packages/angular_devkit/build_angular/src/builders/application/schema.json
@@ -220,8 +220,41 @@
       "default": []
     },
     "outputPath": {
-      "type": "string",
-      "description": "The full path for the new output directory, relative to the current workspace."
+      "description": "Specify the output path relative to workspace root.",
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "base": {
+              "type": "string",
+              "description": "Specify the output path relative to workspace root."
+            },
+            "browser": {
+              "type": "string",
+              "pattern": "^[-\\w\\.]*$",
+              "default": "browser",
+              "description": "The output directory name of your browser build within the output path base. Defaults to 'browser'."
+            },
+            "server": {
+              "type": "string",
+              "pattern": "^[-\\w\\.]*$",
+              "default": "server",
+              "description": "The output directory name of your server build within the output path base. Defaults to 'server'."
+            },
+            "media": {
+              "type": "string",
+              "pattern": "^[-\\w\\.]+$",
+              "default": "media",
+              "description": "The output directory name of your media files within the output browser directory. Defaults to 'media'."
+            }
+          },
+          "required": ["base"],
+          "additionalProperties": false
+        },
+        {
+          "type": "string"
+        }
+      ]
     },
     "aot": {
       "type": "boolean",

--- a/packages/angular_devkit/build_angular/src/builders/application/tests/options/output-path_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/tests/options/output-path_spec.ts
@@ -1,0 +1,309 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { buildApplication } from '../../index';
+import { APPLICATION_BUILDER_INFO, BASE_OPTIONS, describeBuilder } from '../setup';
+
+describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
+  beforeEach(async () => {
+    // Add a media file
+    await harness.writeFile('src/styles.css', `h1 { background: url('./spectrum.png')}`);
+
+    // Enable SSR
+    await harness.modifyFile('src/tsconfig.app.json', (content) => {
+      const tsConfig = JSON.parse(content);
+      tsConfig.files ??= [];
+      tsConfig.files.push('main.server.ts', 'server.ts');
+
+      return JSON.stringify(tsConfig);
+    });
+
+    // Application code is not needed in this test
+    await harness.writeFile('src/main.server.ts', `console.log('Hello!');`);
+    await harness.writeFile('src/server.ts', `console.log('Hello!');`);
+    await harness.writeFile('src/main.ts', `console.log('Hello!');`);
+  });
+
+  describe('Option: "outputPath"', () => {
+    describe(`when option value is is a string`, () => {
+      beforeEach(() => {
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          polyfills: [],
+          outputPath: 'dist',
+          styles: ['src/styles.css'],
+          server: 'src/main.server.ts',
+          ssr: {
+            entry: 'src/server.ts',
+          },
+        });
+      });
+
+      it(`should emit browser bundles in 'browser' directory`, async () => {
+        const { result } = await harness.executeOnce();
+        expect(result?.success).toBeTrue();
+
+        harness.expectFile('dist/browser/main.js').toExist();
+      });
+
+      it(`should emit media files in 'browser/media' directory`, async () => {
+        const { result } = await harness.executeOnce();
+        expect(result?.success).toBeTrue();
+
+        harness.expectFile('dist/browser/media/spectrum.png').toExist();
+      });
+
+      it(`should emit server bundles in 'server' directory`, async () => {
+        const { result } = await harness.executeOnce();
+        expect(result?.success).toBeTrue();
+
+        harness.expectFile('dist/server/server.mjs').toExist();
+      });
+    });
+
+    describe(`when option value is an object`, () => {
+      describe(`'media' is set to 'resources'`, () => {
+        beforeEach(() => {
+          harness.useTarget('build', {
+            ...BASE_OPTIONS,
+            polyfills: [],
+            styles: ['src/styles.css'],
+            server: 'src/main.server.ts',
+            outputPath: {
+              base: 'dist',
+              media: 'resource',
+            },
+            ssr: {
+              entry: 'src/server.ts',
+            },
+          });
+        });
+
+        it(`should emit browser bundles in 'browser' directory`, async () => {
+          const { result } = await harness.executeOnce();
+          expect(result?.success).toBeTrue();
+
+          harness.expectFile('dist/browser/main.js').toExist();
+        });
+
+        it(`should emit media files in 'browser/resource' directory`, async () => {
+          const { result } = await harness.executeOnce();
+          expect(result?.success).toBeTrue();
+
+          harness.expectFile('dist/browser/resource/spectrum.png').toExist();
+        });
+
+        it(`should emit server bundles in 'server' directory`, async () => {
+          const { result } = await harness.executeOnce();
+          expect(result?.success).toBeTrue();
+
+          harness.expectFile('dist/server/server.mjs').toExist();
+        });
+      });
+
+      describe(`'server' is set to 'node-server'`, () => {
+        beforeEach(() => {
+          harness.useTarget('build', {
+            ...BASE_OPTIONS,
+            polyfills: [],
+            styles: ['src/styles.css'],
+            server: 'src/main.server.ts',
+            outputPath: {
+              base: 'dist',
+              server: 'node-server',
+            },
+            ssr: {
+              entry: 'src/server.ts',
+            },
+          });
+        });
+
+        it(`should emit browser bundles in 'browser' directory`, async () => {
+          const { result } = await harness.executeOnce();
+          expect(result?.success).toBeTrue();
+
+          harness.expectFile('dist/browser/main.js').toExist();
+        });
+
+        it(`should emit media files in 'browser/media' directory`, async () => {
+          const { result } = await harness.executeOnce();
+          expect(result?.success).toBeTrue();
+
+          harness.expectFile('dist/browser/media/spectrum.png').toExist();
+        });
+
+        it(`should emit server bundles in 'node-server' directory`, async () => {
+          const { result } = await harness.executeOnce();
+          expect(result?.success).toBeTrue();
+
+          harness.expectFile('dist/node-server/server.mjs').toExist();
+        });
+      });
+
+      describe(`'browser' is set to 'public'`, () => {
+        beforeEach(() => {
+          harness.useTarget('build', {
+            ...BASE_OPTIONS,
+            polyfills: [],
+            styles: ['src/styles.css'],
+            server: 'src/main.server.ts',
+            outputPath: {
+              base: 'dist',
+              browser: 'public',
+            },
+            ssr: {
+              entry: 'src/server.ts',
+            },
+          });
+        });
+
+        it(`should emit browser bundles in 'public' directory`, async () => {
+          const { result } = await harness.executeOnce();
+          expect(result?.success).toBeTrue();
+
+          harness.expectFile('dist/public/main.js').toExist();
+        });
+
+        it(`should emit media files in 'public/media' directory`, async () => {
+          const { result } = await harness.executeOnce();
+          expect(result?.success).toBeTrue();
+
+          harness.expectFile('dist/public/media/spectrum.png').toExist();
+        });
+
+        it(`should emit server bundles in 'server' directory`, async () => {
+          const { result } = await harness.executeOnce();
+          expect(result?.success).toBeTrue();
+
+          harness.expectFile('dist/server/server.mjs').toExist();
+        });
+      });
+
+      describe(`'browser' is set to ''`, () => {
+        it(`should emit browser bundles in '' directory`, async () => {
+          harness.useTarget('build', {
+            ...BASE_OPTIONS,
+            polyfills: [],
+            server: 'src/main.server.ts',
+            outputPath: {
+              base: 'dist',
+              browser: '',
+            },
+            ssr: false,
+          });
+
+          const { result } = await harness.executeOnce();
+          expect(result?.success).toBeTrue();
+
+          harness.expectFile('dist/main.js').toExist();
+        });
+
+        it(`should emit media files in 'media' directory`, async () => {
+          harness.useTarget('build', {
+            ...BASE_OPTIONS,
+            polyfills: [],
+            styles: ['src/styles.css'],
+            server: 'src/main.server.ts',
+            outputPath: {
+              base: 'dist',
+              browser: '',
+            },
+            ssr: false,
+          });
+
+          const { result } = await harness.executeOnce();
+          expect(result?.success).toBeTrue();
+
+          harness.expectFile('dist/media/spectrum.png').toExist();
+        });
+
+        it(`should error when ssr is enabled`, async () => {
+          harness.useTarget('build', {
+            ...BASE_OPTIONS,
+            polyfills: [],
+            server: 'src/main.server.ts',
+            outputPath: {
+              base: 'dist',
+              browser: '',
+            },
+            ssr: {
+              entry: 'src/server.ts',
+            },
+          });
+
+          const { result } = await harness.executeOnce();
+          expect(result?.success).toBeFalse();
+          expect(result?.error).toContain(
+            `'outputPath.browser' cannot be configured to an empty string when SSR is enabled`,
+          );
+        });
+      });
+
+      describe(`'server' is set ''`, () => {
+        beforeEach(() => {
+          harness.useTarget('build', {
+            ...BASE_OPTIONS,
+            polyfills: [],
+            styles: ['src/styles.css'],
+            server: 'src/main.server.ts',
+            outputPath: {
+              base: 'dist',
+              server: '',
+            },
+            ssr: {
+              entry: 'src/server.ts',
+            },
+          });
+        });
+
+        it(`should emit browser bundles in 'browser' directory`, async () => {
+          const { result } = await harness.executeOnce();
+          expect(result?.success).toBeTrue();
+
+          harness.expectFile('dist/browser/main.js').toExist();
+        });
+
+        it(`should emit media files in 'browser/media' directory`, async () => {
+          const { result } = await harness.executeOnce();
+          expect(result?.success).toBeTrue();
+
+          harness.expectFile('dist/browser/media/spectrum.png').toExist();
+        });
+
+        it(`should emit server bundles in '' directory`, async () => {
+          const { result } = await harness.executeOnce();
+          expect(result?.success).toBeTrue();
+
+          harness.expectFile('dist/server.mjs').toExist();
+        });
+      });
+
+      it(`should error when ssr is enabled and 'browser' and 'server' are identical`, async () => {
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          polyfills: [],
+          server: 'src/main.server.ts',
+          outputPath: {
+            base: 'dist',
+            browser: 'public',
+            server: 'public',
+          },
+          ssr: {
+            entry: 'src/server.ts',
+          },
+        });
+
+        const { result } = await harness.executeOnce();
+        expect(result?.success).toBeFalse();
+        expect(result?.error).toContain(
+          `'outputPath.browser' and 'outputPath.server' cannot be configured to the same value`,
+        );
+      });
+    });
+  });
+});

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/bundler-context.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/bundler-context.ts
@@ -17,6 +17,7 @@ import {
   build,
   context,
 } from 'esbuild';
+import assert from 'node:assert';
 import { basename, dirname, extname, join, relative } from 'node:path';
 import { LoadResultCache, MemoryLoadResultCache } from './load-result-cache';
 import { convertOutputFile } from './utils';
@@ -51,7 +52,6 @@ export enum BuildOutputFileType {
 
 export interface BuildOutputFile extends OutputFile {
   type: BuildOutputFileType;
-  fullOutputPath: string;
   clone: () => BuildOutputFile;
 }
 
@@ -325,10 +325,14 @@ export class BundlerContext {
       }
     }
 
-    const platformIsServer = this.#esbuildOptions?.platform === 'node';
+    assert(this.#esbuildOptions, 'esbuild options cannot be undefined.');
+
+    const { platform, assetNames = '' } = this.#esbuildOptions;
+    const platformIsServer = platform === 'node';
+    const mediaDirname = dirname(assetNames);
     const outputFiles = result.outputFiles.map((file) => {
       let fileType: BuildOutputFileType;
-      if (dirname(file.path) === 'media') {
+      if (dirname(file.path) === mediaDirname) {
         fileType = BuildOutputFileType.Media;
       } else {
         fileType = platformIsServer ? BuildOutputFileType.Server : BuildOutputFileType.Browser;


### PR DESCRIPTION
This update introduces the ability for users to define the locations for storing `media`, `browser`, and `server` files.

You can achieve this by utilizing the extended `outputPath` option.
```json
{
  "projects": {
    "my-app": {
      "architect": {
        "build": {
          "builder": "@angular-devkit/build-angular:application",
          "options": {
            "outputPath": {
              "base": "dist/my-app",
              "browser": "",
              "server": "node-server",
              "media": "resources"
            }
          }
        }
      }
    }
  }
}
```

While not recommended, choosing to set the `browser` option empty will result in files being output directly under the specified `base` path. It's important to note that this action will generate certain files like `stats.json` and `prerendered-routes.json` that aren't intended for deployment in this directory.

**Validation rules:**
- `browser` and `server` are relative to the configuration set in the `base` option.
- When SSR is enabled, `browser` cannot be set to an empty string, and cannot be the same as `server`.
- `media` is relative to the value specified in the `browser` option.
- `media` cannot be set to an empty string.
- `browser`, `media`, or `server` cannot contain slashes.

Closes: #26632 and closes: #26057