### PR TITLE
fix(@angular/cli): re-add `-d` alias for `--dry-run`

### DIFF
--- a/packages/angular/cli/src/command-builder/schematics-command-module.ts
+++ b/packages/angular/cli/src/command-builder/schematics-command-module.ts
@@ -64,6 +64,7 @@ export abstract class SchematicsCommandModule
       .option('dry-run', {
         describe: 'Run through and reports activity without writing out results.',
         type: 'boolean',
+        alias: ['d'],
         default: false,
       })
       .option('defaults', {


### PR DESCRIPTION
This got accidentally deleted during the transition to yargs.

Closes #26496
