### PR TITLE
fix(@schematics/angular): add missing property "buildTarget" to interface "ServeBuilderOptions"

### DIFF
--- a/packages/schematics/angular/utility/workspace-models.ts
+++ b/packages/schematics/angular/utility/workspace-models.ts
@@ -73,7 +73,13 @@ export interface BrowserBuilderOptions extends BrowserBuilderBaseOptions {
 }
 
 export interface ServeBuilderOptions {
+  /**
+   * @deprecated not used since version 17.0.0. Use the property "buildTarget" instead.
+   */
   browserTarget: string;
+
+  // TODO: make it required, when the deprecated property "browserTarget" is removed.
+  buildTarget?: string;
 }
 export interface LibraryBuilderOptions {
   tsConfig: string;


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The interface `ServeBuilderOptions` from `@schematics/angular/utility/workspace-model` is missing the property `buildTarget`

Issue Number: https://github.com/angular/angular-cli/issues/26693

## What is the new behavior?

<!-- Please describe the new behavior that. -->

The interface `ServeBuilderOptions` from `@schematics/angular/utility/workspace-model` now has the the property `buildTarget`. It's optional to avoid a breaking change, until the next major.

Note: I've left the obsolete `browserTarget` required property to avoid a breaking change. IMHO it's should be removed in the next major. But I marked the `browserTarget` property as `@deprecated`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
