### PR TITLE
refactor(@angular-devkit/build-angular): use direct explicit external configuration for metadata

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/application/execute-build.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/execute-build.ts
@@ -177,10 +177,14 @@ export async function executeBuild(
   }
 
   // Analyze external imports if external options are enabled
-  if (options.externalPackages || options.externalDependencies?.length) {
+  if (options.externalPackages || bundlingResult.externalConfiguration) {
     const { browser = new Set(), server = new Set() } = bundlingResult.externalImports;
-    // TODO: Filter externalImports to generate second argument to support wildcard externalDependency values
-    executionResult.setExternalMetadata([...browser], [...server], options.externalDependencies);
+    // TODO: Filter externalImports to generate third argument to support wildcard externalConfiguration values
+    executionResult.setExternalMetadata(
+      [...browser],
+      [...server],
+      bundlingResult.externalConfiguration,
+    );
   }
 
   const { metafile, initialFiles, outputFiles } = bundlingResult;

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/bundler-context.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/bundler-context.ts
@@ -34,6 +34,7 @@ export type BundleContextResult =
         server?: Set<string>;
         browser?: Set<string>;
       };
+      externalConfiguration?: string[];
     };
 
 export interface InitialFileRecord {
@@ -124,6 +125,7 @@ export class BundlerContext {
     const externalImportsServer = new Set<string>();
 
     const outputFiles = [];
+    let externalConfiguration;
     for (const result of individualResults) {
       warnings.push(...result.warnings);
       if (result.errors) {
@@ -142,6 +144,13 @@ export class BundlerContext {
       outputFiles.push(...result.outputFiles);
       result.externalImports.browser?.forEach((value) => externalImportsBrowser.add(value));
       result.externalImports.server?.forEach((value) => externalImportsServer.add(value));
+
+      if (result.externalConfiguration) {
+        externalConfiguration ??= new Set<string>();
+        for (const value of result.externalConfiguration) {
+          externalConfiguration.add(value);
+        }
+      }
     }
 
     if (errors !== undefined) {
@@ -158,6 +167,7 @@ export class BundlerContext {
         browser: externalImportsBrowser,
         server: externalImportsServer,
       },
+      externalConfiguration: externalConfiguration ? [...externalConfiguration] : undefined,
     };
   }
 
@@ -349,6 +359,7 @@ export class BundlerContext {
       externalImports: {
         [platformIsServer ? 'server' : 'browser']: externalImports,
       },
+      externalConfiguration: this.#esbuildOptions.external,
       errors: undefined,
     };
   }


### PR DESCRIPTION
The metadata used by the development server to determine the prebundling and externalization behavior is now created using the external configurations of each bundling operation context directly instead of the higher level `externalDependencies` build option. This better captures the explicitly defined external values as each bundling operation configuration could contain additional values based on the needs and/or customization of each. This will have no current noticeable behavior change as the default behavior currently does not differ from the higher level option.