### PR TITLE
fix(@schematics/angular): do not generate standalone component when using `ng generate module`

### DIFF
--- a/packages/schematics/angular/module/index.ts
+++ b/packages/schematics/angular/module/index.ts
@@ -176,6 +176,7 @@ export default function (options: ModuleOptions): Rule {
       name: options.name,
       path: options.path,
       project: options.project,
+      standalone: false,
     };
 
     return chain([


### PR DESCRIPTION


Adjust the module schematic to always generate non standalone components.

Closes #26700
