### PR TITLE
fix(@angular-devkit/build-angular): add missing tailwind `@screen` directive in matcher

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/esbuild/stylesheets/stylesheet-plugin-factory.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/stylesheets/stylesheet-plugin-factory.ts
@@ -54,7 +54,15 @@ export interface StylesheetPluginOptions {
  *
  * Based on https://tailwindcss.com/docs/functions-and-directives
  */
-const TAILWIND_KEYWORDS = ['@tailwind', '@layer', '@apply', '@config', 'theme(', 'screen('];
+const TAILWIND_KEYWORDS = [
+  '@tailwind',
+  '@layer',
+  '@apply',
+  '@config',
+  'theme(',
+  'screen(',
+  '@screen', // Undocumented in version 3, see: https://github.com/tailwindlabs/tailwindcss/discussions/7516.
+];
 
 export interface StylesheetLanguage {
   name: string;


### PR DESCRIPTION


`@screen` is not documented in tailwind documentation as it is not a recommanded option, however it still works and they don't have plans to remove it.

https://github.com/tailwindlabs/tailwindcss/discussions/7516

Closes #26709
