### PR TITLE
test: always use package manager force option in version add command E2E

### DIFF
--- a/tests/legacy-cli/e2e/tests/commands/add/version-specifier.ts
+++ b/tests/legacy-cli/e2e/tests/commands/add/version-specifier.ts
@@ -8,12 +8,11 @@ export default async function () {
   // forcibly remove in case another test doesn't clean itself up.
   await rimraf('node_modules/@angular/localize');
 
-  // If using npm, enable the force option to allow testing the output behavior of the
-  // `ng add` command itself and not the behavior of npm which may otherwise fail depending
-  // on the npm version in use and the version specifier supplied in each test.
-  if (getActivePackageManager() === 'npm') {
-    appendFile('.npmrc', '\nforce=true\n');
-  }
+  // Enable the force option to allow testing the output behavior of the
+  // `ng add` command itself and not the behavior of the package manager which may otherwise fail depending
+  // on the package manager version in use and the version specifier supplied in each test.
+  appendFile('.npmrc', '\nforce=true\n');
+  appendFile('.yarnrc', '\n--ignore-engines true\n');
 
   const tag = (await isPrereleaseCli()) ? '@next' : '';
 


### PR DESCRIPTION
The goal of the `commands/add/version-specifier` test is to check the behavior of the `ng add` command itself and not that of the package manager. To do so requires adding a package using a variety of different version specifiers. Some of which a package manager may consider incompatible with the hosting project. However, this is not relevant to the selection logic of the `ng add` command which should select the version as designed. To verify it does so within the Angular CLI, the installed version needs to be checked. As a result the package manager must install the package.