### PR TITLE
fix(@angular/cli): `ng e2e` and `ng lint` prompt requires to hit Enter twice to proceed on Windows

### DIFF
--- a/packages/angular/cli/src/command-builder/architect-base-command-module.ts
+++ b/packages/angular/cli/src/command-builder/architect-base-command-module.ts
@@ -12,9 +12,8 @@ import {
   WorkspaceNodeModulesArchitectHost,
 } from '@angular-devkit/architect/node';
 import { json } from '@angular-devkit/core';
-import { spawnSync } from 'child_process';
-import { existsSync } from 'fs';
-import { resolve } from 'path';
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { isPackageNameSafeForAnalytics } from '../analytics/analytics';
 import { EventCustomDimension, EventCustomMetric } from '../analytics/analytics-parameters';
 import { assertIsError } from '../utilities/error';
@@ -248,14 +247,14 @@ export abstract class ArchitectBaseCommandModule<T extends object>
       const packageToInstall = await this.getMissingTargetPackageToInstall(choices);
       if (packageToInstall) {
         // Example run: `ng add @angular-eslint/schematics`.
-        const binPath = resolve(__dirname, '../../bin/ng.js');
-        const { error } = spawnSync(process.execPath, [binPath, 'add', packageToInstall], {
-          stdio: 'inherit',
+        const AddCommandModule = (await import('../commands/add/cli')).default;
+        await new AddCommandModule(this.context).run({
+          interactive: true,
+          force: false,
+          dryRun: false,
+          defaults: false,
+          collection: packageToInstall,
         });
-
-        if (error) {
-          throw error;
-        }
       }
     } else {
       // Non TTY display error message.

--- a/packages/angular/cli/src/commands/add/cli.ts
+++ b/packages/angular/cli/src/commands/add/cli.ts
@@ -55,7 +55,7 @@ const packageVersionExclusions: Record<string, string | Range> = {
   '@angular/material': '7.x',
 };
 
-export default class AddCommadModule
+export default class AddCommandModule
   extends SchematicsCommandModule
   implements CommandModuleImplementation<AddCommandArgs>
 {


### PR DESCRIPTION


This fixes an issue where prompts in nested child processes on Windows require multiple keystrokes to proceed.

Closes #26724
