### PR TITLE
fix(@angular-devkit/build-angular): filter explicit external dependencies for Vite prebundling

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/application/execute-build.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/execute-build.ts
@@ -178,12 +178,21 @@ export async function executeBuild(
 
   // Analyze external imports if external options are enabled
   if (options.externalPackages || bundlingResult.externalConfiguration) {
-    const { browser = new Set(), server = new Set() } = bundlingResult.externalImports;
-    // TODO: Filter externalImports to generate third argument to support wildcard externalConfiguration values
+    const {
+      externalConfiguration,
+      externalImports: { browser, server },
+    } = bundlingResult;
+    const implicitBrowser = browser ? [...browser] : [];
+    const implicitServer = server ? [...server] : [];
+    // TODO: Implement wildcard externalConfiguration filtering
     executionResult.setExternalMetadata(
-      [...browser],
-      [...server],
-      bundlingResult.externalConfiguration,
+      externalConfiguration
+        ? implicitBrowser.filter((value) => !externalConfiguration.includes(value))
+        : implicitBrowser,
+      externalConfiguration
+        ? implicitServer.filter((value) => !externalConfiguration.includes(value))
+        : implicitServer,
+      externalConfiguration,
     );
   }
 


### PR DESCRIPTION
To ensure that Vite does not unintentionally attempt to prebundle a module that was explicitly marked as external (typically via the `externalDependencies` build option), the full list of externalized imports is now filtered by the dependencies specified within the external configuration. Vite currently will include a module for prebundling if it is present in the include list even though it may also be present in the exclude list.

Closes #26730