### PR TITLE
fix(@schematics/angular): do not trigger NPM install when using `---skip-install` and `--ssr`

### DIFF
--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -101,6 +101,7 @@ export default function (options: ApplicationOptions): Rule {
       options.ssr
         ? schematic('ssr', {
             project: options.name,
+            skipInstall: true,
           })
         : noop(),
       options.skipPackageJson ? noop() : addDependenciesToPackageJson(options),

--- a/packages/schematics/angular/application/index_spec.ts
+++ b/packages/schematics/angular/application/index_spec.ts
@@ -105,6 +105,26 @@ describe('Application Schematic', () => {
     expect(_extends).toBe('../../tsconfig.json');
   });
 
+  it('should install npm dependencies when `skipInstall` is false', async () => {
+    await schematicRunner.runSchematic(
+      'application',
+      { ...defaultOptions, ssr: true, skipInstall: false },
+      workspaceTree,
+    );
+    expect(schematicRunner.tasks.length).toBe(1);
+    expect(schematicRunner.tasks[0].name).toBe('node-package');
+    expect((schematicRunner.tasks[0].options as { command: string }).command).toBe('install');
+  });
+
+  it('should not install npm dependencies when `skipInstall` is true', async () => {
+    await schematicRunner.runSchematic(
+      'application',
+      { ...defaultOptions, ssr: true, skipInstall: true },
+      workspaceTree,
+    );
+    expect(schematicRunner.tasks.length).toBe(0);
+  });
+
   it('should set the skipTests flag for other schematics when using --skipTests=true', async () => {
     const options: ApplicationOptions = { ...defaultOptions, skipTests: true };
     const tree = await schematicRunner.runSchematic('application', options, workspaceTree);

--- a/packages/schematics/angular/ssr/index.ts
+++ b/packages/schematics/angular/ssr/index.ts
@@ -22,7 +22,13 @@ import {
 } from '@angular-devkit/schematics';
 import { posix } from 'node:path';
 import { Schema as ServerOptions } from '../server/schema';
-import { DependencyType, addDependency, readWorkspace, updateWorkspace } from '../utility';
+import {
+  DependencyType,
+  InstallBehavior,
+  addDependency,
+  readWorkspace,
+  updateWorkspace,
+} from '../utility';
 import { JSONFile } from '../utility/json-file';
 import { latestVersions } from '../utility/latest-versions';
 import { isStandaloneApp } from '../utility/ng-ast-utils';
@@ -288,16 +294,21 @@ function updateWebpackBuilderServerTsConfigRule(options: SSROptions): Rule {
   };
 }
 
-function addDependencies(isUsingApplicationBuilder: boolean): Rule {
+function addDependencies({ skipInstall }: SSROptions, isUsingApplicationBuilder: boolean): Rule {
+  const install = skipInstall ? InstallBehavior.None : InstallBehavior.Auto;
+
   const rules: Rule[] = [
     addDependency('@angular/ssr', latestVersions.AngularSSR, {
       type: DependencyType.Default,
+      install,
     }),
     addDependency('express', latestVersions['express'], {
       type: DependencyType.Default,
+      install,
     }),
     addDependency('@types/express', latestVersions['@types/express'], {
       type: DependencyType.Dev,
+      install,
     }),
   ];
 
@@ -305,6 +316,7 @@ function addDependencies(isUsingApplicationBuilder: boolean): Rule {
     rules.push(
       addDependency('browser-sync', latestVersions['browser-sync'], {
         type: DependencyType.Dev,
+        install,
       }),
     );
   }
@@ -373,7 +385,7 @@ export default function (options: SSROptions): Rule {
           ]),
       addServerFile(options, isStandalone),
       addScriptsRule(options, isUsingApplicationBuilder),
-      addDependencies(isUsingApplicationBuilder),
+      addDependencies(options, isUsingApplicationBuilder),
     ]);
   };
 }


### PR DESCRIPTION

The `skipInstall` option was never passed to the ssr schematic, which caused NPM install to also be invoked when running `ng new --ssr`.

Closes #26727
