### PR TITLE
fix(@angular-devkit/build-angular): emit error when using prerender and app-shell builders with application builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/app-shell/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/app-shell/index.ts
@@ -178,6 +178,16 @@ async function _appShellBuilder(
     serviceWorker: false,
     optimization: optimization as unknown as JsonObject,
   });
+
+  if (browserTargetRun.info.builderName === '@angular-devkit/build-angular:application') {
+    return {
+      success: false,
+      error:
+        '"@angular-devkit/build-angular:application" has built-in app-shell generation capabilities. ' +
+        'The "appShell" option should be used instead.',
+    };
+  }
+
   const serverTargetRun = await context.scheduleTarget(serverTarget, {
     watch: false,
   });

--- a/packages/angular_devkit/build_angular/src/builders/prerender/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/prerender/index.ts
@@ -106,6 +106,16 @@ async function _scheduleBuilds(
     serviceWorker: false,
     // todo: handle service worker augmentation
   });
+
+  if (browserTargetRun.info.builderName === '@angular-devkit/build-angular:application') {
+    return {
+      success: false,
+      error:
+        '"@angular-devkit/build-angular:application" has built-in prerendering capabilities. ' +
+        'The "prerender" option should be used instead.',
+    };
+  }
+
   const serverTargetRun = await context.scheduleTarget(serverTarget, {
     watch: false,
   });


### PR DESCRIPTION

The application builder has built-in prerendering and app-shell generation capabilities which makes using these builders redundant.
