### PR TITLE
refactor(@schematics/angular): fix typo in "expression" variable name inside "addSymbolToNgModuleMetadata" function

### DIFF
--- a/packages/schematics/angular/utility/ast-utils.ts
+++ b/packages/schematics/angular/utility/ast-utils.ts
@@ -411,7 +411,7 @@ export function addSymbolToNgModuleMetadata(
     return [];
   }
 
-  let expresssion: ts.Expression | ts.ArrayLiteralExpression;
+  let expression: ts.Expression | ts.ArrayLiteralExpression;
   const assignmentInit = assignment.initializer;
   const elements = assignmentInit.elements;
 
@@ -421,20 +421,20 @@ export function addSymbolToNgModuleMetadata(
       return [];
     }
 
-    expresssion = elements[elements.length - 1];
+    expression = elements[elements.length - 1];
   } else {
-    expresssion = assignmentInit;
+    expression = assignmentInit;
   }
 
   let toInsert: string;
-  let position = expresssion.getEnd();
-  if (ts.isArrayLiteralExpression(expresssion)) {
+  let position = expression.getEnd();
+  if (ts.isArrayLiteralExpression(expression)) {
     // We found the field but it's empty. Insert it just before the `]`.
     position--;
     toInsert = `\n${tags.indentBy(4)`${symbolName}`}\n  `;
   } else {
     // Get the indentation of the last element, if any.
-    const text = expresssion.getFullText(source);
+    const text = expression.getFullText(source);
     const matches = text.match(/^(\r?\n)(\s*)/);
     if (matches) {
       toInsert = `,${matches[1]}${tags.indentBy(matches[2].length)`${symbolName}`}`;


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

There is typo in `expresssion` variable name that is part of the `addSymbolToNgModuleMetadata` function from AST utils.

Issue Number: N/A

## What is the new behavior?

Variable name has been changed to `expression`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
