### PR TITLE
Revert "build: update dependency webpack-dev-middleware to v7"

### DIFF
--- a/package.json
+++ b/package.json
@@ -214,7 +214,7 @@
     "vite": "5.0.10",
     "watchpack": "2.4.0",
     "webpack": "5.89.0",
-    "webpack-dev-middleware": "7.0.0",
+    "webpack-dev-middleware": "6.1.1",
     "webpack-dev-server": "4.15.1",
     "webpack-merge": "5.10.0",
     "webpack-subresource-integrity": "5.1.0",

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -66,7 +66,7 @@
     "vite": "5.0.10",
     "watchpack": "2.4.0",
     "webpack": "5.89.0",
-    "webpack-dev-middleware": "7.0.0",
+    "webpack-dev-middleware": "6.1.1",
     "webpack-dev-server": "4.15.1",
     "webpack-merge": "5.10.0",
     "webpack-subresource-integrity": "5.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4327,11 +4327,6 @@ arg@^4.1.0:
   resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
   integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
-arg@^5.0.2:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/arg/-/arg-5.0.2.tgz#c81433cc427c92c4dcf4865142dbca6f15acd59c"
-  integrity sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==
-
 argparse@^1.0.7, argparse@~1.0.9:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
@@ -7243,11 +7238,6 @@ husky@8.0.3:
   resolved "https://registry.yarnpkg.com/husky/-/husky-8.0.3.tgz#4936d7212e46d1dea28fef29bb3a108872cd9184"
   integrity sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==
 
-hyperdyperid@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/hyperdyperid/-/hyperdyperid-1.2.0.tgz#59668d323ada92228d2a869d3e474d5a33b69e6b"
-  integrity sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==
-
 iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
@@ -7921,14 +7911,6 @@ json-buffer@3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.1.tgz#9338802a30d3b6605fbe0613e094008ca8c05a13"
   integrity sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==
-
-json-joy@^9.2.0:
-  version "9.9.1"
-  resolved "https://registry.yarnpkg.com/json-joy/-/json-joy-9.9.1.tgz#add8f8bdf4f7066894f5ec4817a5a43066a3757f"
-  integrity sha512-/d7th2nbQRBQ/nqTkBe6KjjvDciSwn9UICmndwk3Ed/Bk9AqkTRm4PnLVfXG4DKbT0rEY0nKnwE7NqZlqKE6kg==
-  dependencies:
-    arg "^5.0.2"
-    hyperdyperid "^1.2.0"
 
 json-parse-even-better-errors@^2.3.0, json-parse-even-better-errors@^2.3.1:
   version "2.3.1"
@@ -8665,14 +8647,6 @@ memfs@^3.4.12, memfs@^3.4.3:
   integrity sha512-EGowvkkgbMcIChjMTMkESFDbZeSh8xZ7kNSF0hAiAN4Jh6jgHCRS0Ga/+C8y6Au+oqpezRHCfPsmJ2+DwAgiwQ==
   dependencies:
     fs-monkey "^1.0.4"
-
-memfs@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/memfs/-/memfs-4.6.0.tgz#e812d438f73482a7110420d13d381c730b9a4de5"
-  integrity sha512-I6mhA1//KEZfKRQT9LujyW6lRbX7RkC24xKododIDO3AGShcaFAMKElv1yFGWX8fD4UaSiwasr3NeQ5TdtHY1A==
-  dependencies:
-    json-joy "^9.2.0"
-    thingies "^1.11.1"
 
 merge-descriptors@1.0.1:
   version "1.0.1"
@@ -11647,11 +11621,6 @@ text-table@0.2.0, text-table@^0.2.0, text-table@~0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==
 
-thingies@^1.11.1:
-  version "1.15.0"
-  resolved "https://registry.yarnpkg.com/thingies/-/thingies-1.15.0.tgz#bd186213bed5105b11eda0ce749fa475c5d4d6e3"
-  integrity sha512-ZSJlvEpD8QllYim0VSGlbAoob/iPrTWNlV/m8ltizMvMmzzU2gVJvHfH9ijLstyciWF70ZiQXqz+BCXWJq+ZQw==
-
 thread-stream@^0.15.1:
   version "0.15.2"
   resolved "https://registry.yarnpkg.com/thread-stream/-/thread-stream-0.15.2.tgz#fb95ad87d2f1e28f07116eb23d85aba3bc0425f4"
@@ -12355,17 +12324,6 @@ webpack-dev-middleware@6.1.1:
   dependencies:
     colorette "^2.0.10"
     memfs "^3.4.12"
-    mime-types "^2.1.31"
-    range-parser "^1.2.1"
-    schema-utils "^4.0.0"
-
-webpack-dev-middleware@7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-7.0.0.tgz#13595dc038a400e3ac9c76f0c9a8c75a59a7d4da"
-  integrity sha512-tZ5hqsWwww/8DislmrzXE3x+4f+v10H1z57mA2dWFrILb4i3xX+dPhTkcdR0DLyQztrhF2AUmO5nN085UYjd/Q==
-  dependencies:
-    colorette "^2.0.10"
-    memfs "^4.6.0"
     mime-types "^2.1.31"
     range-parser "^1.2.1"
     schema-utils "^4.0.0"


### PR DESCRIPTION
Reverts angular/angular-cli#26750

The original change breaks Windows bazel build. 

```
ERROR: D:/a/angular-cli/angular-cli/packages/angular_devkit/build_angular/BUILD.bazel:80:11: Compiling TypeScript (devmode) //packages/angular_devkit/build_angular:build_angular failed: missing input file 'external/npm/node_modules/json-joy/es2020/json-crdt/nodes/con/ConNode.d.ts', owner: '@npm//:node_modules/json-joy/es2020/json-crdt/nodes/con/ConNode.d.ts'
ERROR: D:/a/angular-cli/angular-cli/packages/angular_devkit/build_angular/BUILD.bazel:80:11: Compiling TypeScript (devmode) //packages/angular_devkit/build_angular:build_angular failed: missing input file 'external/npm/node_modules/json-joy/es6/json-crdt/nodes/con/ConNode.d.ts', owner: '@npm//:node_modules/json-joy/es6/json-crdt/nodes/con/ConNode.d.ts'
ERROR: D:/a/angular-cli/angular-cli/packages/angular_devkit/build_angular/BUILD.bazel:80:11: Compiling TypeScript (devmode) //packages/angular_devkit/build_angular:build_angular failed: missing input file 'external/npm/node_modules/json-joy/esm/json-crdt/nodes/con/ConNode.d.ts', owner: '@npm//:node_modules/json-joy/esm/json-crdt/nodes/con/ConNode.d.ts'
ERROR: D:/a/angular-cli/angular-cli/packages/angular_devkit/build_angular/BUILD.bazel:80:11: Compiling TypeScript (devmode) //packages/angular_devkit/build_angular:build_angular failed: missing input file 'external/npm/node_modules/json-joy/lib/json-crdt/nodes/con/ConNode.d.ts', owner: '@npm//:node_modules/json-joy/lib/json-crdt/nodes/con/ConNode.d.ts'
ERROR: D:/a/angular-cli/angular-cli/packages/angular_devkit/build_angular/BUILD.bazel:80:11: Compiling TypeScript (devmode) //packages/angular_devkit/build_angular:build_angular failed: missing input file 'external/npm/node_modules/json-joy/es2020/json-crdt/nodes/con/ConNode.js', owner: '@npm//:node_modules/json-joy/es2020/json-crdt/nodes/con/ConNode.js'
ERROR: D:/a/angular-cli/angular-cli/packages/angular_devkit/build_angular/BUILD.bazel:80:11: Compiling TypeScript (devmode) //packages/angular_devkit/build_angular:build_angular failed: missing input file 'external/npm/node_modules/json-joy/es6/json-crdt/nodes/con/ConNode.js', owner: '@npm//:node_modules/json-joy/es6/json-crdt/nodes/con/ConNode.js'
ERROR: D:/a/angular-cli/angular-cli/packages/angular_devkit/build_angular/BUILD.bazel:80:11: Compiling TypeScript (devmode) //packages/angular_devkit/build_angular:build_angular failed: missing input file 'external/npm/node_modules/json-joy/esm/json-crdt/nodes/con/ConNode.js', owner: '@npm//:node_modules/json-joy/esm/json-crdt/nodes/con/ConNode.js'
ERROR: D:/a/angular-cli/angular-cli/packages/angular_devkit/build_angular/BUILD.bazel:80:11: Compiling TypeScript (devmode) //packages/angular_devkit/build_angular:build_angular failed: missing input file 'external/npm/node_modules/json-joy/lib/json-crdt/nodes/con/ConNode.js', owner: '@npm//:node_modules/json-joy/lib/json-crdt/nodes/con/ConNode.js'
```