### PR TITLE
fix(@angular-devkit/schematics): replace template line endings with platform specific

### DIFF
--- a/packages/angular_devkit/schematics/src/rules/template.ts
+++ b/packages/angular_devkit/schematics/src/rules/template.ts
@@ -7,7 +7,7 @@
  */
 
 import { BaseException, normalize, template as templateImpl } from '@angular-devkit/core';
-import { TextDecoder } from 'util';
+import { EOL } from 'node:os';
 import { FileOperator, Rule } from '../engine/interface';
 import { FileEntry } from '../tree/interface';
 import { chain, composeFileOperators, forEach, when } from './base';
@@ -55,7 +55,7 @@ export function applyContentTemplate<T>(options: T): FileOperator {
     const { path, content } = entry;
 
     try {
-      const decodedContent = decoder.decode(content);
+      const decodedContent = decoder.decode(content).replace(/\r?\n/g, EOL);
 
       return {
         path,


### PR DESCRIPTION


Currently, when using `ng new` on Windows, users will get a number of `LF will be replaced by CRLF the next time Git touches it` warnings.

This commit, replaces the line endings in templates to be platform specific.

Closes #26764
