### PR TITLE
build: add function type annotation for bazel win32 build support

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/esbuild/javascript-transformer-worker.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/javascript-transformer-worker.ts
@@ -25,7 +25,9 @@ interface JavaScriptTransformRequest {
 const textDecoder = new TextDecoder();
 const textEncoder = new TextEncoder();
 
-export default async function transformJavaScript(request: JavaScriptTransformRequest) {
+export default async function transformJavaScript(
+  request: JavaScriptTransformRequest,
+): Promise<unknown> {
   const { filename, data, ...options } = request;
   const textData = typeof data === 'string' ? data : textDecoder.decode(data);
 


### PR DESCRIPTION
Due to the file structure of Bazel Windows builds, type annotations are required in certain locations to successfully build the project. Function return type annotations are generally recommended anyway within the code.