### PR TITLE
refactor: remove `process.cwd` from Web Test Runner builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/web-test-runner/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/web-test-runner/index.ts
@@ -46,9 +46,7 @@ export default createBuilder(
     // Parallelize startup work.
     const [testFiles] = await Promise.all([
       // Glob for files to test.
-      findTestFiles(options.include, options.exclude, ctx.workspaceRoot).then((files) =>
-        Array.from(files).map((file) => path.relative(process.cwd(), file)),
-      ),
+      findTestFiles(options.include, options.exclude, ctx.workspaceRoot),
       // Clean build output path.
       fs.rm(testDir, { recursive: true, force: true }),
     ]);
@@ -66,7 +64,7 @@ export default createBuilder(
 
 /** Build all the given test files and write the result to the given output path. */
 async function buildTests(
-  testFiles: string[],
+  testFiles: ReadonlySet<string>,
   outputPath: string,
   options: WtrBuilderOptions,
   ctx: BuilderContext,


### PR DESCRIPTION
Turns out this isn't needed for `application` builder to correctly resolve inputs. Not using `process.cwd` should make this builder a little less brittle for monorepo use cases or when running `ng test` inside a subdirectory.