### PR TITLE
ci: add `ci-*` to GitHub actions config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
       - '[0-9]+.[0-9]+.x'
+
+      # Developers can make one-off pushes to `ci-*` branches to manually trigger full CI
+      # prior to opening a pull request.
+      - ci-*
   pull_request:
     types: [opened, synchronize, reopened]
 


### PR DESCRIPTION
This automatically runs full CI for any branch prefixed with `ci-`. This makes it easier to manually run CI prior to opening a pull request without having to update any files and make sure they aren't accidentally included in the final PR.