### PR TITLE
ci: fix `sauce-connect-proxy` version

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -11944,7 +11944,7 @@ sass@^1.69.5:
 
 "sauce-connect-proxy@https://saucelabs.com/downloads/sc-4.9.1-linux.tar.gz":
   version "0.0.0"
-  resolved "https://saucelabs.com/downloads/sc-4.8.1-linux.tar.gz#9c16682e4c9716734432789884f868212f95f563"
+  resolved "https://saucelabs.com/downloads/sc-4.9.1-linux.tar.gz#9310bc860f7870a1f872b11c4dc6073a1ad34e5e"
 
 saucelabs@^1.5.0:
   version "1.5.0"


### PR DESCRIPTION
Somehow the requested and resolved versions of `sauce-connect-proxy` got desynced and downgraded to 4.8.1 in 68dae539adfa12d6088f96ac5c9f224d9bb52e17. This reverts that change and bumps it back up to 4.9.1 which appears to fix Saucelabs CI.