### PR TITLE
fix(@angular-devkit/build-angular): show diagnostic messages after build stats

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/esbuild/bundler-execution-result.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/bundler-execution-result.ts
@@ -38,6 +38,7 @@ export class ExecutionResult {
   outputFiles: BuildOutputFile[] = [];
   assetFiles: BuildOutputAsset[] = [];
   errors: (Message | PartialMessage)[] = [];
+  warnings: (Message | PartialMessage)[] = [];
   externalMetadata?: ExternalResultMetadata;
 
   constructor(
@@ -53,8 +54,32 @@ export class ExecutionResult {
     this.assetFiles.push(...assets);
   }
 
-  addErrors(errors: (Message | PartialMessage)[]): void {
-    this.errors.push(...errors);
+  addError(error: PartialMessage | string): void {
+    if (typeof error === 'string') {
+      this.errors.push({ text: error, location: null });
+    } else {
+      this.errors.push(error);
+    }
+  }
+
+  addErrors(errors: (PartialMessage | string)[]): void {
+    for (const error of errors) {
+      this.addError(error);
+    }
+  }
+
+  addWarning(error: PartialMessage | string): void {
+    if (typeof error === 'string') {
+      this.warnings.push({ text: error, location: null });
+    } else {
+      this.warnings.push(error);
+    }
+  }
+
+  addWarnings(errors: (PartialMessage | string)[]): void {
+    for (const error of errors) {
+      this.addWarning(error);
+    }
   }
 
   /**


### PR DESCRIPTION
To improve the readability and discoverability of any warnings or errors present during build, the diagnostic messages will be shown after the build stats are displayed. For large projects the amount of generated files previously could cause warnings to scroll off the screen and potentially be missed.

Closes #26514