### PR TITLE
Fix Web Test Runner e2e test on Windows

### DIFF
--- a/tests/legacy-cli/e2e.bzl
+++ b/tests/legacy-cli/e2e.bzl
@@ -103,6 +103,7 @@ def _e2e_tests(name, runner, **kwargs):
     # Chromium browser toolchain
     env.update({
         "CHROME_BIN": "$(CHROMIUM)",
+        "CHROME_PATH": "$(CHROMIUM)",
         "CHROMEDRIVER_BIN": "$(CHROMEDRIVER)",
     })
     toolchains = toolchains + ["@npm//@angular/build-tooling/bazel/browsers/chromium:toolchain_alias"]

--- a/tests/legacy-cli/e2e/utils/process.ts
+++ b/tests/legacy-cli/e2e/utils/process.ts
@@ -177,6 +177,7 @@ function extractCIEnv(): NodeJS.ProcessEnv {
         v === 'CI' ||
         v === 'CIRCLECI' ||
         v === 'CHROME_BIN' ||
+        v === 'CHROME_PATH' ||
         v === 'CHROMEDRIVER_BIN',
     )
     .reduce<NodeJS.ProcessEnv>((vars, n) => {

--- a/tests/legacy-cli/e2e/utils/web-test-runner.ts
+++ b/tests/legacy-cli/e2e/utils/web-test-runner.ts
@@ -3,11 +3,6 @@ import { updateJsonFile } from './project';
 
 /** Updates the `test` builder in the current workspace to use Web Test Runner with the given options. */
 export async function applyWtrBuilder(): Promise<void> {
-  // Does not load Chrome binary correctly on Windows.
-  if (process.platform.startsWith('win')) {
-    return;
-  }
-
   await silentNpm('install', '@web/test-runner', '--save-dev');
 
   await updateJsonFile('angular.json', (json) => {

--- a/tests/legacy-cli/e2e_runner.ts
+++ b/tests/legacy-cli/e2e_runner.ts
@@ -206,6 +206,7 @@ setGlobalVariable('package-manager', argv.yarn ? 'yarn' : 'npm');
 // Resolve from relative paths to absolute paths within the bazel runfiles tree
 // so subprocesses spawned in a different working directory can still find them.
 process.env.CHROME_BIN = path.resolve(process.env.CHROME_BIN!);
+process.env.CHROME_PATH = path.resolve(process.env.CHROME_PATH!);
 process.env.CHROMEDRIVER_BIN = path.resolve(process.env.CHROMEDRIVER_BIN!);
 
 Promise.all([findFreePort(), findFreePort(), findPackageTars()])


### PR DESCRIPTION
Needed to set `$CHROME_PATH` correctly for Web Test Runner / Chrome launcher to correctly find the the Chrome binary provided by Bazel.