### PR TITLE
fix(@angular-devkit/build-angular): fix normalization of the application builder extensions

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/application/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/index.ts
@@ -165,11 +165,13 @@ export function buildApplication(
   context: BuilderContext,
   pluginsOrExtensions?: Plugin[] | ApplicationBuilderExtensions,
 ): AsyncIterable<ApplicationBuilderOutput> {
-  let extensions;
+  let extensions: ApplicationBuilderExtensions | undefined;
   if (pluginsOrExtensions && Array.isArray(pluginsOrExtensions)) {
     extensions = {
       codePlugins: pluginsOrExtensions,
     };
+  } else {
+    extensions = pluginsOrExtensions;
   }
 
   return buildApplicationInternal(options, context, undefined, extensions);


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [ ] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The `buildApplication` function normalizes the provided extensions incorrectly. When an object of the`ApplicationBuilderExtensions` type is provided with the esbuild plugin and/or the index HTML transformer function, the value is lost and the `buildApplicationInternal` function is invoked with `undefined`.

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the new behavior that. -->

The `buildApplication` function normalizes the provided extensions correctly. If an object of `ApplicationBuilderExtensions` type is provided, it is used as is.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
