### PR TITLE
refactor(@angular-devkit/build-angular): move bundler context setup into separate file

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/application/execute-build.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/execute-build.ts
@@ -13,11 +13,7 @@ import { BuildOutputFileType, BundlerContext } from '../../tools/esbuild/bundler
 import { ExecutionResult, RebuildState } from '../../tools/esbuild/bundler-execution-result';
 import { checkCommonJSModules } from '../../tools/esbuild/commonjs-checker';
 import { extractLicenses } from '../../tools/esbuild/license-extractor';
-import {
-  calculateEstimatedTransferSizes,
-  logBuildStats,
-  logMessages,
-} from '../../tools/esbuild/utils';
+import { calculateEstimatedTransferSizes, logBuildStats } from '../../tools/esbuild/utils';
 import { BudgetCalculatorResult, checkBudgets } from '../../utils/bundle-calculator';
 import { colors } from '../../utils/color';
 import { copyAssets } from '../../utils/copy-assets';
@@ -65,10 +61,8 @@ export async function executeBuild(
     rebuildState?.fileChanges.all,
   );
 
-  // Log all warnings and errors generated during bundling
-  await logMessages(context, bundlingResult);
-
   const executionResult = new ExecutionResult(bundlerContexts, codeBundleCache);
+  executionResult.addWarnings(bundlingResult.warnings);
 
   // Return if the bundling has errors
   if (bundlingResult.errors) {
@@ -188,15 +182,13 @@ export async function executeBuild(
   }
 
   logBuildStats(
-    context,
+    context.logger,
     metafile,
     initialFiles,
     budgetFailures,
     changedFiles,
     estimatedTransferSizes,
   );
-
-  await logMessages(context, executionResult);
 
   // Write metafile if stats option is enabled
   if (options.stats) {

--- a/packages/angular_devkit/build_angular/src/builders/application/setup-bundling.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/setup-bundling.ts
@@ -1,0 +1,130 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { SourceFileCache } from '../../tools/esbuild/angular/source-file-cache';
+import {
+  createBrowserCodeBundleOptions,
+  createBrowserPolyfillBundleOptions,
+  createServerCodeBundleOptions,
+  createServerPolyfillBundleOptions,
+} from '../../tools/esbuild/application-code-bundle';
+import { BundlerContext } from '../../tools/esbuild/bundler-context';
+import { createGlobalScriptsBundleOptions } from '../../tools/esbuild/global-scripts';
+import { createGlobalStylesBundleOptions } from '../../tools/esbuild/global-styles';
+import {
+  getSupportedNodeTargets,
+  transformSupportedBrowsersToTargets,
+} from '../../tools/esbuild/utils';
+import { NormalizedApplicationBuildOptions } from './options';
+
+/**
+ * Generates one or more BundlerContext instances based on the builder provided
+ * configuration.
+ * @param options The normalized application builder options to use.
+ * @param browsers An string array of browserslist browsers to support.
+ * @param codeBundleCache An instance of the TypeScript source file cache.
+ * @returns An array of BundlerContext objects.
+ */
+export function setupBundlerContexts(
+  options: NormalizedApplicationBuildOptions,
+  browsers: string[],
+  codeBundleCache: SourceFileCache,
+): BundlerContext[] {
+  const { appShellOptions, prerenderOptions, serverEntryPoint, ssrOptions, workspaceRoot } =
+    options;
+  const target = transformSupportedBrowsersToTargets(browsers);
+  const bundlerContexts = [];
+
+  // Browser application code
+  bundlerContexts.push(
+    new BundlerContext(
+      workspaceRoot,
+      !!options.watch,
+      createBrowserCodeBundleOptions(options, target, codeBundleCache),
+    ),
+  );
+
+  // Browser polyfills code
+  const browserPolyfillBundleOptions = createBrowserPolyfillBundleOptions(
+    options,
+    target,
+    codeBundleCache,
+  );
+  if (browserPolyfillBundleOptions) {
+    bundlerContexts.push(
+      new BundlerContext(workspaceRoot, !!options.watch, browserPolyfillBundleOptions),
+    );
+  }
+
+  // Global Stylesheets
+  if (options.globalStyles.length > 0) {
+    for (const initial of [true, false]) {
+      const bundleOptions = createGlobalStylesBundleOptions(options, target, initial);
+      if (bundleOptions) {
+        bundlerContexts.push(
+          new BundlerContext(workspaceRoot, !!options.watch, bundleOptions, () => initial),
+        );
+      }
+    }
+  }
+
+  // Global Scripts
+  if (options.globalScripts.length > 0) {
+    for (const initial of [true, false]) {
+      const bundleOptions = createGlobalScriptsBundleOptions(options, target, initial);
+      if (bundleOptions) {
+        bundlerContexts.push(
+          new BundlerContext(workspaceRoot, !!options.watch, bundleOptions, () => initial),
+        );
+      }
+    }
+  }
+
+  // Skip server build when none of the features are enabled.
+  if (serverEntryPoint && (prerenderOptions || appShellOptions || ssrOptions)) {
+    const nodeTargets = [...target, ...getSupportedNodeTargets()];
+    // Server application code
+    bundlerContexts.push(
+      new BundlerContext(
+        workspaceRoot,
+        !!options.watch,
+        createServerCodeBundleOptions(
+          {
+            ...options,
+            // Disable external deps for server bundles.
+            // This is because it breaks Vite 'optimizeDeps' for SSR.
+            externalPackages: false,
+          },
+          nodeTargets,
+          codeBundleCache,
+        ),
+        () => false,
+      ),
+    );
+
+    // Server polyfills code
+    const serverPolyfillBundleOptions = createServerPolyfillBundleOptions(
+      options,
+      nodeTargets,
+      codeBundleCache,
+    );
+
+    if (serverPolyfillBundleOptions) {
+      bundlerContexts.push(
+        new BundlerContext(
+          workspaceRoot,
+          !!options.watch,
+          serverPolyfillBundleOptions,
+          () => false,
+        ),
+      );
+    }
+  }
+
+  return bundlerContexts;
+}

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/utils.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/utils.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { BuilderContext } from '@angular-devkit/architect';
+import { logging } from '@angular-devkit/core';
 import { BuildOptions, Metafile, OutputFile, PartialMessage, formatMessages } from 'esbuild';
 import { createHash } from 'node:crypto';
 import { constants as fsConstants } from 'node:fs';
@@ -22,7 +22,7 @@ import { BuildOutputFile, BuildOutputFileType, InitialFileRecord } from './bundl
 import { BuildOutputAsset } from './bundler-execution-result';
 
 export function logBuildStats(
-  context: BuilderContext,
+  logger: logging.LoggerApi,
   metafile: Metafile,
   initial: Map<string, InitialFileRecord>,
   budgetFailures: BudgetCalculatorResult[] | undefined,
@@ -71,12 +71,12 @@ export function logBuildStats(
       budgetFailures,
     );
 
-    context.logger.info('\n' + tableText + '\n');
+    logger.info('\n' + tableText + '\n');
   } else if (changedFiles !== undefined) {
-    context.logger.info('\nNo output file changes.\n');
+    logger.info('\nNo output file changes.\n');
   }
   if (unchangedCount > 0) {
-    context.logger.info(`Unchanged output files: ${unchangedCount}`);
+    logger.info(`Unchanged output files: ${unchangedCount}`);
   }
 }
 
@@ -143,17 +143,17 @@ export async function withNoProgress<T>(text: string, action: () => T | Promise<
 }
 
 export async function logMessages(
-  context: BuilderContext,
+  logger: logging.LoggerApi,
   { errors, warnings }: { errors?: PartialMessage[]; warnings?: PartialMessage[] },
 ): Promise<void> {
   if (warnings?.length) {
     const warningMessages = await formatMessages(warnings, { kind: 'warning', color: true });
-    context.logger.warn(warningMessages.join('\n'));
+    logger.warn(warningMessages.join('\n'));
   }
 
   if (errors?.length) {
     const errorMessages = await formatMessages(errors, { kind: 'error', color: true });
-    context.logger.error(errorMessages.join('\n'));
+    logger.error(errorMessages.join('\n'));
   }
 }
 


### PR DESCRIPTION
To reduce the amount of code within the main `application` builder execution function, the bundler context setup has been moved into a separate file. This also reduces the amount of imports within the main execution function's module.