### PR TITLE
refactor(@angular-devkit/build-angular): add experimental builder selector extension for dev-server

### DIFF
--- a/goldens/public-api/angular_devkit/build_angular/index.md
+++ b/goldens/public-api/angular_devkit/build_angular/index.md
@@ -212,6 +212,7 @@ export function executeDevServerBuilder(options: DevServerBuilderOptions, contex
 }, extensions?: {
     buildPlugins?: Plugin_2[];
     middleware?: ((req: http.IncomingMessage, res: http.ServerResponse, next: (err?: unknown) => void) => void)[];
+    builderSelector?: (info: BuilderSelectorInfo, logger: BuilderContext['logger']) => string;
 }): Observable<DevServerBuilderOutput>;
 
 // @public


### PR DESCRIPTION
When using the experimental programmatic API for the development server, the choice of builder used to execute the actual underlying build can now be chosen via a selector function extension option. The returned string value must be one of the first-party esbuild-based builders for the Vite-based development server to be used. All other returned values will cause the Webpack-based development server to be used. The Vite-based development server currently requires one of those builders to be used (either `@angular-devkit/build-angular:application` or `@angular-devkit/build-angular:browser-esbuild`).
