### PR TITLE
ci: remove daily CI run for v14.x

### DIFF
--- a/.circleci/dynamic_config.yml
+++ b/.circleci/dynamic_config.yml
@@ -488,21 +488,3 @@ workflows:
           <<: *only_pull_requests
           requires:
             - build
-
-  daily_run_workflow:
-    when:
-      and:
-        - equal: [scheduled_pipeline, << pipeline.trigger_source >>]
-        - equal: ['14.2.x nightly run', << pipeline.schedule.name >>]
-    jobs:
-      - setup
-      - build:
-          requires:
-            - setup
-      - e2e-tests:
-          name: e2e-cli-nightly
-          requires:
-            - build
-      - test-browsers:
-          requires:
-            - build


### PR DESCRIPTION
Angular v14 is EOL.