### PR TITLE
fix: ignore custom Jest configuration file and warn if one is found

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/jest/jest.config.mjs
+++ b/packages/angular_devkit/build_angular/src/builders/jest/jest.config.mjs
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+// Empty config file, everything is specified via CLI options right now.
+// This file is used just so Jest doesn't accidentally inherit a custom user-specified Jest config.
+export default {};

--- a/tests/legacy-cli/e2e/tests/jest/custom-config.ts
+++ b/tests/legacy-cli/e2e/tests/jest/custom-config.ts
@@ -1,0 +1,53 @@
+import { deleteFile, writeFile } from '../../utils/fs';
+import { applyJestBuilder } from '../../utils/jest';
+import { ng } from '../../utils/process';
+import { updateJsonFile } from '../../utils/project';
+
+export default async function (): Promise<void> {
+  await applyJestBuilder();
+
+  {
+    // Users may incorrectly write a Jest config believing it to be used by Angular.
+    await writeFile(
+      'jest.config.mjs',
+      `
+  export default {
+    runner: 'does-not-exist',
+  };
+    `.trim(),
+    );
+
+    // Should not fail from the above (broken) configuration. Shouldn't use it at all.
+    const { stderr } = await ng('test');
+
+    // Should warn that a Jest configuration was found but not used.
+    if (!stderr.includes('A custom Jest config was found')) {
+      throw new Error(`No warning about custom Jest config:\nSTDERR:\n\n${stderr}`);
+    }
+    if (!stderr.includes('jest.config.mjs')) {
+      throw new Error(`Warning did not call out 'jest.config.mjs':\nSTDERR:\n\n${stderr}`);
+    }
+
+    await deleteFile('jest.config.mjs');
+  }
+
+  {
+    // Use `package.json` configuration instead of a `jest.config` file.
+    await updateJsonFile('package.json', (json) => {
+      json['jest'] = {
+        runner: 'does-not-exist',
+      };
+    });
+
+    // Should not fail from the above (broken) configuration. Shouldn't use it at all.
+    const { stderr } = await ng('test');
+
+    // Should warn that a Jest configuration was found but not used.
+    if (!stderr.includes('A custom Jest config was found')) {
+      throw new Error(`No warning about custom Jest config:\nSTDERR:\n\n${stderr}`);
+    }
+    if (!stderr.includes('package.json')) {
+      throw new Error(`Warning did not call out 'package.json':\nSTDERR:\n\n${stderr}`);
+    }
+  }
+}


### PR DESCRIPTION
Refs #25434.

Currently with Jest we're experimenting with whether or not Angular CLI can meet user needs without exposing the underlying configuration file. See https://github.com/angular/angular-cli/issues/25434#issuecomment-1610298235 for more context.

If hiding the Jest configuration is a challenge for you, please consider if an alternative approach _without_ hooking into the Jest config is reasonable. Otherwise please post your use case to https://github.com/angular/angular-cli/issues/25434 so we can evaluate the best path forward for this feature.

Jest was incorrectly picking up custom configurations, even though they exist outside Jest's root directory. This commit fixes that behavior so Jest does not see user configurations and does not apply them. Ideally we would throw an error if a Jest configuration is found to be more clear that it isn't doing what developers expect. However they may use a Jest config to run other projects in the same workspace outside of Angular CLI and we don't want to prevent that. A warning seems like the best trade off of notifying users that a custom config isn't supported while also not preventing unrelated Jest usage in the same workspace.

I've noticed a few issues where users were using a custom config either causing a problem or attempting to solve one. I want to be up front during the experimentation process what our current stance is for users playing around with Jest so we can collect feedback on how it impacts users earlier.