### PR TITLE
fix(@angular/cli): fixes Yarn v2 support for registry configuration

### DIFF
--- a/packages/angular/cli/src/commands/add/cli.ts
+++ b/packages/angular/cli/src/commands/add/cli.ts
@@ -141,7 +141,10 @@ export default class AddCommandModule
 
     spinner.start('Determining package manager...');
     const usingYarn = packageManager.name === PackageManager.Yarn;
-    spinner.info(`Using package manager: ${colors.grey(packageManager.name)}`);
+    const packageManagerVersion = packageManager.version;
+    spinner.info(
+      `Using package manager: ${colors.grey(packageManager.name)} ${packageManagerVersion}`,
+    );
 
     if (
       packageIdentifier.name &&
@@ -155,6 +158,7 @@ export default class AddCommandModule
       let packageMetadata;
       try {
         packageMetadata = await fetchPackageMetadata(packageIdentifier.name, logger, {
+          packageManagerVersion,
           registry,
           usingYarn,
           verbose,
@@ -241,6 +245,7 @@ export default class AddCommandModule
     try {
       spinner.start('Loading package information from registry...');
       const manifest = await fetchPackageManifest(packageIdentifier.toString(), logger, {
+        packageManagerVersion,
         registry,
         verbose,
         usingYarn,

--- a/packages/angular/cli/src/commands/update/cli.ts
+++ b/packages/angular/cli/src/commands/update/cli.ts
@@ -601,13 +601,20 @@ export default class UpdateCommandModule extends CommandModule<UpdateCommandArgs
     options: Options<UpdateCommandArgs>,
     packages: PackageIdentifier[],
   ): Promise<number> {
-    const { logger } = this.context;
+    const { logger, packageManager } = this.context;
+    packageManager.ensureCompatibility();
 
     const logVerbose = (message: string) => {
       if (options.verbose) {
         logger.info(message);
       }
     };
+
+    const usingYarn = packageManager.name === PackageManager.Yarn;
+    const packageManagerVersion = packageManager.version;
+    logger.info(
+      `Using package manager: ${colors.grey(packageManager.name)} ${packageManagerVersion}`,
+    );
 
     const requests: {
       identifier: PackageIdentifier;
@@ -647,6 +654,8 @@ export default class UpdateCommandModule extends CommandModule<UpdateCommandArgs
         // Metadata requests are internally cached; multiple requests for same name
         // does not result in additional network traffic
         metadata = await fetchPackageMetadata(packageName, logger, {
+          packageManagerVersion: packageManagerVersion,
+          usingYarn: usingYarn,
           verbose: options.verbose,
         });
       } catch (e) {


### PR DESCRIPTION
Adds support for `yarnrc.yml` files so that users of Yarn v2+ who attempt to run `ng add` or `ng update` do not experience a bug where the incorrect registry file extension (.yarnrc) is selected.

Fixes #23448

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently repositories using Yarn v2 or higher do not use the correct registry configuration file format, which causes issues when running ng-cli commands that require access to private repositories. See:
[https://github.com/angular/angular-cli/issues/23448](https://github.com/angular/angular-cli/issues/23448)

Issue Number: 23448

## What is the new behavior?

The `ng add` and `ng update` commands check the correct file format (`yarnrc.yml`) for any repositories using Yarn version 2 or higher.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
