### PR TITLE
refactor(@angular-devkit/build-angular): allow internal Angular compilation control of diagnostic modes

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/esbuild/angular/compilation/index.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/angular/compilation/index.ts
@@ -6,6 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export { AngularCompilation } from './angular-compilation';
+export { AngularCompilation, DiagnosticModes } from './angular-compilation';
 export { createAngularCompilation } from './factory';
 export { NoopCompilation } from './noop-compilation';

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/angular/compilation/parallel-compilation.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/angular/compilation/parallel-compilation.ts
@@ -13,7 +13,7 @@ import { MessageChannel } from 'node:worker_threads';
 import Piscina from 'piscina';
 import type { SourceFile } from 'typescript';
 import type { AngularHostOptions } from '../angular-host';
-import { AngularCompilation, EmitFileResult } from './angular-compilation';
+import { AngularCompilation, DiagnosticModes, EmitFileResult } from './angular-compilation';
 
 /**
  * An Angular compilation which uses a Node.js Worker thread to load and execute
@@ -122,8 +122,10 @@ export class ParallelCompilation extends AngularCompilation {
     throw new Error('Not implemented in ParallelCompilation.');
   }
 
-  override diagnoseFiles(): Promise<{ errors?: PartialMessage[]; warnings?: PartialMessage[] }> {
-    return this.#worker.run(undefined, { name: 'diagnose' });
+  override diagnoseFiles(
+    modes = DiagnosticModes.All,
+  ): Promise<{ errors?: PartialMessage[]; warnings?: PartialMessage[] }> {
+    return this.#worker.run(modes, { name: 'diagnose' });
   }
 
   override emitAffectedFiles(): Promise<Iterable<EmitFileResult>> {

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/angular/compilation/parallel-worker.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/angular/compilation/parallel-worker.ts
@@ -11,7 +11,7 @@ import assert from 'node:assert';
 import { randomUUID } from 'node:crypto';
 import { type MessagePort, receiveMessageOnPort } from 'node:worker_threads';
 import { SourceFileCache } from '../source-file-cache';
-import type { AngularCompilation } from './angular-compilation';
+import type { AngularCompilation, DiagnosticModes } from './angular-compilation';
 import { AotCompilation } from './aot-compilation';
 import { JitCompilation } from './jit-compilation';
 
@@ -99,13 +99,13 @@ export async function initialize(request: InitRequest) {
   };
 }
 
-export async function diagnose(): Promise<{
+export async function diagnose(modes: DiagnosticModes): Promise<{
   errors?: PartialMessage[];
   warnings?: PartialMessage[];
 }> {
   assert(compilation);
 
-  const diagnostics = await compilation.diagnoseFiles();
+  const diagnostics = await compilation.diagnoseFiles(modes);
 
   return diagnostics;
 }

--- a/packages/angular_devkit/build_angular/src/utils/environment-options.ts
+++ b/packages/angular_devkit/build_angular/src/utils/environment-options.ts
@@ -102,3 +102,7 @@ export const debugPerformance = isPresent(debugPerfVariable) && isEnabled(debugP
 
 const watchRootVariable = process.env['NG_BUILD_WATCH_ROOT'];
 export const shouldWatchRoot = isPresent(watchRootVariable) && isEnabled(watchRootVariable);
+
+const typeCheckingVariable = process.env['NG_BUILD_TYPE_CHECK'];
+export const useTypeChecking =
+  !isPresent(typeCheckingVariable) || !isDisabled(typeCheckingVariable);


### PR DESCRIPTION
To support generate diagnostics in varying ways, the internal compilation classes now support a `modes` argument when diagnosing files during a build using the `application` builder. This is not exposed as an option at this time but can be experimented with a build using the `NG_BUILD_TYPE_CHECK` environment variable. This environment variable is not considered part of the public API and may be removed or altered in the future. Its current purpose is to allow profiling of the type checking diagnostics functionality of the build system.