### PR TITLE
fix(@angular-devkit/build-angular): alllow `OPTIONS` requests to be proxied when using `vite`

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
@@ -483,6 +483,10 @@ export async function setupServer(
       open: serverOptions.open,
       headers: serverOptions.headers,
       proxy,
+      cors: {
+        // Allow preflight requests to be proxied.
+        preflightContinue: true,
+      },
       // File watching is handled by the build directly. `null` disables file watching for Vite.
       watch: null,
       fs: {


### PR DESCRIPTION


This commit fixes an issue were `OPTIONS` requests were not being proxied when using Vite dev-server

Closes #26782
