### PR TITLE
[FIX] Updated regex for the application name to not accept "."

### DIFF
--- a/packages/schematics/angular/application/schema.json
+++ b/packages/schematics/angular/application/schema.json
@@ -13,7 +13,7 @@
     "name": {
       "description": "The name of the new application.",
       "type": "string",
-      "pattern": "^(?:@[a-zA-Z0-9-*~][a-zA-Z0-9-*._~]*/)?[a-zA-Z0-9-~][a-zA-Z0-9-._~]*$",
+      "pattern": "^(?:@[a-zA-Z0-9-*~][a-zA-Z0-9-*_~]*/)?[a-zA-Z0-9-~][a-zA-Z0-9-_~]*$",
       "$default": {
         "$source": "argv",
         "index": 0


### PR DESCRIPTION
fix(@angular-cli): Updated the regex to invalidate the application name with "." in it. As the validation for project name doesn't accept "." in the name and thorows the error: "Data path "/projects" must NOT have additional properties(xyx.com)"

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #25704 

## What is the new behavior?

After the fix user creating new project will not be allowed to enter "." in the name of the application. i.e. xyz.com will get invalidated.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
