### PR TITLE
fix(@angular-devkit/build-angular): pre-transform error when using vite with SSR

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/vite/angular-memory-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/tools/vite/angular-memory-plugin.ts
@@ -176,6 +176,7 @@ export function createAngularMemoryPlugin(options: AngularMemoryPluginOptions): 
         ) {
           const url = req.originalUrl;
           if (
+            !req.url ||
             // Skip if path is not defined.
             !url ||
             // Skip if path is like a file.
@@ -194,7 +195,7 @@ export function createAngularMemoryPlugin(options: AngularMemoryPluginOptions): 
             return;
           }
 
-          transformIndexHtmlAndAddHeaders(url, rawHtml, res, next, async (html) => {
+          transformIndexHtmlAndAddHeaders(req.url, rawHtml, res, next, async (html) => {
             const { content } = await renderPage({
               document: html,
               route: new URL(req.originalUrl ?? '/', server.resolvedUrls?.local[0]).toString(),


### PR DESCRIPTION

This commit fixes a regression which causes a pre-transform error when using vite with ssr. The `request.url` is now passed to the index transformer instead of `request.originalUrl`. This is because the `request.url` will have a value of the `index.html`.

Closes #26897