### PR TITLE
fix(@angular-devkit/build-angular): update dependency vite to v4.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -204,7 +204,7 @@
     "typescript": "5.1.6",
     "verdaccio": "5.26.1",
     "verdaccio-auth-memory": "^10.0.0",
-    "vite": "4.5.1",
+    "vite": "4.5.2",
     "webpack": "5.88.2",
     "webpack-dev-middleware": "6.1.1",
     "webpack-dev-server": "4.15.1",

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -64,7 +64,7 @@
     "text-table": "0.2.0",
     "tree-kill": "1.2.2",
     "tslib": "2.6.1",
-    "vite": "4.5.1",
+    "vite": "4.5.2",
     "webpack": "5.88.2",
     "webpack-dev-middleware": "6.1.1",
     "webpack-dev-server": "4.15.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12189,10 +12189,10 @@ vite@4.4.3:
   optionalDependencies:
     fsevents "~2.3.2"
 
-vite@4.5.1:
-  version "4.5.1"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-4.5.1.tgz#3370986e1ed5dbabbf35a6c2e1fb1e18555b968a"
-  integrity sha512-AXXFaAJ8yebyqzoNB9fu2pHoo/nWX+xZlaRwoeYUxEqBO+Zj4msE5G+BhGBll9lYEKv9Hfks52PAF2X7qDYXQA==
+vite@4.5.2:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-4.5.2.tgz#d6ea8610e099851dad8c7371599969e0f8b97e82"
+  integrity sha512-tBCZBNSBbHQkaGyhGCDUGqeo2ph8Fstyp6FMSvTtsXeZSPpSMGlviAOav2hxVTqFcx8Hj/twtWKsMJXNY0xI8w==
   dependencies:
     esbuild "^0.18.10"
     postcss "^8.4.27"


### PR DESCRIPTION
This commit updates vite to address https://github.com/advisories/GHSA-c24v-8rfc-w8vw

Closes #26916
