### PR TITLE
fix(@angular/cli): update regex to validate the project-name

### DIFF
--- a/packages/angular/cli/lib/config/workspace-schema.json
+++ b/packages/angular/cli/lib/config/workspace-schema.json
@@ -23,7 +23,7 @@
     "projects": {
       "type": "object",
       "patternProperties": {
-        "^(?:@[a-zA-Z0-9_-]+/)?[a-zA-Z0-9_-]+$": {
+        "^(?:@[a-zA-Z0-9._-]+/)?[a-zA-Z0-9._-]+$": {
           "$ref": "#/definitions/project"
         }
       },


### PR DESCRIPTION
fix(@angular/cli): update regex to validate the project-name

Ensure that the regex used for validating the project-name is updated to address any issues and enhance accuracy.

the existing regex for project-name validation was not validating the name with the dot(.) in application name.

Fixes #25704 

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #25704  

## What is the new behavior?

Project name can include the dot(.) in the name while creating the project but while validating the dot(.) was missing. I updated the pattern to accept dot(.) in projectName.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
