### PR TITLE
fix(@angular-devkit/build-angular): provide actionable error message when server bundle is missing default export

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/prerender/routes-extractor-worker.ts
+++ b/packages/angular_devkit/build_angular/src/builders/prerender/routes-extractor-worker.ts
@@ -47,7 +47,7 @@ async function extract(): Promise<string[]> {
   const bootstrapAppFnOrModule = bootstrapAppFn || AppServerModule;
   assert(
     bootstrapAppFnOrModule,
-    `Neither an AppServerModule nor a bootstrapping function was exported from: ${serverBundlePath}.`,
+    `The file "${serverBundlePath}" does not have a default export for an AppServerModule or a bootstrapping function.`,
   );
 
   const routes: string[] = [];

--- a/packages/angular_devkit/build_angular/src/utils/server-rendering/render-page.ts
+++ b/packages/angular_devkit/build_angular/src/utils/server-rendering/render-page.ts
@@ -7,6 +7,7 @@
  */
 
 import type { ApplicationRef, StaticProvider } from '@angular/core';
+import assert from 'node:assert';
 import { basename } from 'node:path';
 import { loadEsmModule } from '../load-esm';
 import { MainServerBundleExports, RenderUtilsServerBundleExports } from './main-bundle-exports';
@@ -73,6 +74,10 @@ export async function renderPage({
   ];
 
   let html: string | undefined;
+  assert(
+    bootstrapAppFnOrModule,
+    'The file "./main.server.mjs" does not have a default export for an AppServerModule or a bootstrapping function.',
+  );
 
   if (isBootstrapFn(bootstrapAppFnOrModule)) {
     html = await renderApplication(bootstrapAppFnOrModule, {


### PR DESCRIPTION

This change improves the error message when the server bundle does not export a default export.

Closes #26922
