### PR TITLE
fix(@angular-devkit/build-angular): update dependency vite to v5.0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -212,7 +212,7 @@
     "undici": "6.2.1",
     "verdaccio": "5.29.0",
     "verdaccio-auth-memory": "^10.0.0",
-    "vite": "5.0.11",
+    "vite": "5.0.12",
     "watchpack": "2.4.0",
     "webpack": "5.89.0",
     "webpack-dev-middleware": "6.1.1",

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -63,7 +63,7 @@
     "tree-kill": "1.2.2",
     "tslib": "2.6.2",
     "undici": "6.2.1",
-    "vite": "5.0.11",
+    "vite": "5.0.12",
     "watchpack": "2.4.0",
     "webpack": "5.89.0",
     "webpack-dev-middleware": "6.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13479,10 +13479,10 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-vite@5.0.11:
-  version "5.0.11"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-5.0.11.tgz#31562e41e004cb68e1d51f5d2c641ab313b289e4"
-  integrity sha512-XBMnDjZcNAw/G1gEiskiM1v6yzM4GE5aMGvhWTlHAYYhxb7S3/V1s3m2LDHa8Vh6yIWYYB0iJwsEaS523c4oYA==
+vite@5.0.12:
+  version "5.0.12"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-5.0.12.tgz#8a2ffd4da36c132aec4adafe05d7adde38333c47"
+  integrity sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==
   dependencies:
     esbuild "^0.19.3"
     postcss "^8.4.32"


### PR DESCRIPTION
This commit updates vite to address https://github.com/advisories/GHSA-c24v-8rfc-w8vw

Closes https://github.com/angular/angular-cli/issues/26916