### PR TITLE
refactor(@angular-devkit/build-angular): update Vite client code loading for v5

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/vite/angular-memory-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/tools/vite/angular-memory-plugin.ts
@@ -285,16 +285,17 @@ export function createAngularMemoryPlugin(options: AngularMemoryPluginOptions): 
  */
 async function loadViteClientCode(file: string) {
   const originalContents = await readFile(file, 'utf-8');
-  let contents = originalContents.replace('You can also disable this overlay by setting', '');
-  contents = contents.replace(
+  const firstUpdate = originalContents.replace('You can also disable this overlay by setting', '');
+  assert(originalContents !== firstUpdate, 'Failed to update Vite client error overlay text. (1)');
+
+  const secondUpdate = firstUpdate.replace(
     // eslint-disable-next-line max-len
-    '<code part="config-option-name">server.hmr.overlay</code> to <code part="config-option-value">false</code> in <code part="config-file-name">vite.config.js.</code>',
+    '<code part="config-option-name">server.hmr.overlay</code> to <code part="config-option-value">false</code> in <code part="config-file-name">${hmrConfigName}.</code>',
     '',
   );
+  assert(firstUpdate !== secondUpdate, 'Failed to update Vite client error overlay text. (2)');
 
-  assert(originalContents !== contents, 'Failed to update Vite client error overlay text.');
-
-  return contents;
+  return secondUpdate;
 }
 
 function pathnameWithoutBasePath(url: string, basePath: string): string {


### PR DESCRIPTION
Vite v5 updated the client code's error dialog text. This requires that the text replacement code also be updated to remove unactionable information from the error dialog.