### PR TITLE
refactor(@angular-devkit/build-angular): increase type safety in bundle-context

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/esbuild/bundler-context.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/bundler-context.ts
@@ -207,7 +207,7 @@ export class BundlerContext {
       this.watchFiles.clear();
     }
 
-    let result;
+    let result: BuildResult<{ metafile: true; write: false }>;
     try {
       if (this.#esbuildContext) {
         // Rebuild using the existing incremental build context


### PR DESCRIPTION

Currently the `result` variable will be set to `any` which caused a large part of this file not to be safely typed.
