### PR TITLE
fix(@angular-devkit/build-angular): add `required` modules as externals imports

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/esbuild/bundler-context.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/bundler-context.ts
@@ -331,7 +331,9 @@ export class BundlerContext {
       for (const importData of imports) {
         if (
           !importData.external ||
-          (importData.kind !== 'import-statement' && importData.kind !== 'dynamic-import')
+          (importData.kind !== 'import-statement' &&
+            importData.kind !== 'dynamic-import' &&
+            importData.kind !== 'require-call')
         ) {
           continue;
         }


### PR DESCRIPTION

Prior to this change any module which was used using `require` was not listed as an external.

Closes #26833