### PR TITLE
refactor(@angular-devkit/build-angular): disable SW and index generation during i18n extraction

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/extract-i18n/application-extraction.ts
+++ b/packages/angular_devkit/build_angular/src/builders/extract-i18n/application-extraction.ts
@@ -35,9 +35,11 @@ export async function extractMessages(
     builderName,
   )) as unknown as ApplicationBuilderInternalOptions;
   buildOptions.optimization = false;
-  buildOptions.sourceMap = { scripts: true, vendor: true };
+  buildOptions.sourceMap = { scripts: true, vendor: true, styles: false };
   buildOptions.localize = false;
   buildOptions.budgets = undefined;
+  buildOptions.index = false;
+  buildOptions.serviceWorker = false;
 
   let build;
   if (builderName === '@angular-devkit/build-angular:application') {


### PR DESCRIPTION

This commit disables index and service worker generation when using the i18n extraction together with the esbuild builders.

