### PR TITLE
refactor(@angular-devkit/core): remove single usage of const enum

### DIFF
--- a/goldens/public-api/angular_devkit/core/index.md
+++ b/goldens/public-api/angular_devkit/core/index.md
@@ -289,7 +289,7 @@ interface HostWatchEvent {
 }
 
 // @public (undocumented)
-const enum HostWatchEventType {
+enum HostWatchEventType {
     // (undocumented)
     Changed = 0,
     // (undocumented)

--- a/packages/angular_devkit/core/src/virtual-fs/host/interface.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/host/interface.ts
@@ -17,7 +17,7 @@ export interface HostWatchOptions {
   readonly recursive?: boolean;
 }
 
-export const enum HostWatchEventType {
+export enum HostWatchEventType {
   Changed = 0,
   Created = 1,
   Deleted = 2,


### PR DESCRIPTION
const enums complicate the potential use of the TypeScript isolatedModules option.