### PR TITLE
refactor: remove outdated namespace syntax usage

### DIFF
--- a/goldens/public-api/angular_devkit/architect/index.md
+++ b/goldens/public-api/angular_devkit/architect/index.md
@@ -358,6 +358,7 @@ class JobOutputSchemaValidationError extends schema.SchemaValidationException {
 
 declare namespace jobs {
     export {
+        strategy,
         isJobHandler,
         JobName,
         JobHandler,
@@ -403,8 +404,7 @@ declare namespace jobs {
         JobArgumentSchemaValidationError,
         JobInboundMessageSchemaValidationError,
         JobOutputSchemaValidationError,
-        SimpleScheduler,
-        strategy
+        SimpleScheduler
     }
 }
 export { jobs }
@@ -418,6 +418,12 @@ enum JobState {
     Started = "started"
 }
 
+// @public (undocumented)
+type JobStrategy<A extends JsonValue = JsonValue, I extends JsonValue = JsonValue, O extends JsonValue = JsonValue> = (handler: JobHandler<A, I, O>, options?: Partial<Readonly<JobDescription>>) => JobHandler<A, I, O>;
+
+// @public
+function memoize<A extends JsonValue = JsonValue, I extends JsonValue = JsonValue, O extends JsonValue = JsonValue>(replayMessages?: boolean): JobStrategy<A, I, O>;
+
 // @public
 interface RegisterJobOptions extends Partial<JobDescription> {
 }
@@ -426,6 +432,9 @@ interface RegisterJobOptions extends Partial<JobDescription> {
 interface Registry<MinimumArgumentValueT extends JsonValue = JsonValue, MinimumInputValueT extends JsonValue = JsonValue, MinimumOutputValueT extends JsonValue = JsonValue> {
     get<A extends MinimumArgumentValueT, I extends MinimumInputValueT, O extends MinimumOutputValueT>(name: JobName): Observable<JobHandler<A, I, O> | null>;
 }
+
+// @public
+function reuse<A extends JsonValue = JsonValue, I extends JsonValue = JsonValue, O extends JsonValue = JsonValue>(replayMessages?: boolean): JobStrategy<A, I, O>;
 
 // @public
 interface ScheduleJobOptions {
@@ -448,6 +457,9 @@ interface Scheduler<MinimumArgumentValueT extends JsonValue = JsonValue, Minimum
 
 // @public
 export function scheduleTargetAndForget(context: BuilderContext, target: Target, overrides?: json.JsonObject, scheduleOptions?: ScheduleOptions_2): Observable<BuilderOutput>;
+
+// @public
+function serialize<A extends JsonValue = JsonValue, I extends JsonValue = JsonValue, O extends JsonValue = JsonValue>(): JobStrategy<A, I, O>;
 
 // @public
 interface SimpleJobHandlerContext<A extends JsonValue, I extends JsonValue, O extends JsonValue> extends JobHandlerContext<A, I, O> {
@@ -490,13 +502,13 @@ class SimpleScheduler<MinimumArgumentT extends JsonValue = JsonValue, MinimumInp
     protected _schemaRegistry: schema.SchemaRegistry;
 }
 
-// @public (undocumented)
-namespace strategy {
-    // (undocumented)
-    type JobStrategy<A extends JsonValue = JsonValue, I extends JsonValue = JsonValue, O extends JsonValue = JsonValue> = (handler: JobHandler<A, I, O>, options?: Partial<Readonly<JobDescription>>) => JobHandler<A, I, O>;
-    function memoize<A extends JsonValue = JsonValue, I extends JsonValue = JsonValue, O extends JsonValue = JsonValue>(replayMessages?: boolean): JobStrategy<A, I, O>;
-    function reuse<A extends JsonValue = JsonValue, I extends JsonValue = JsonValue, O extends JsonValue = JsonValue>(replayMessages?: boolean): JobStrategy<A, I, O>;
-    function serialize<A extends JsonValue = JsonValue, I extends JsonValue = JsonValue, O extends JsonValue = JsonValue>(): JobStrategy<A, I, O>;
+declare namespace strategy {
+    export {
+        serialize,
+        reuse,
+        memoize,
+        JobStrategy
+    }
 }
 
 // @public (undocumented)

--- a/goldens/public-api/angular_devkit/core/index.md
+++ b/goldens/public-api/angular_devkit/core/index.md
@@ -1223,70 +1223,75 @@ interface TemplateTag<R = string> {
     (template: TemplateStringsArray, ...substitutions: any[]): R;
 }
 
-// @public (undocumented)
-namespace test {
-    // (undocumented)
-    class TestHost extends SimpleMemoryHost {
-        // (undocumented)
-        $exists(path: string): boolean;
-        // (undocumented)
-        $isDirectory(path: string): boolean;
-        // (undocumented)
-        $isFile(path: string): boolean;
-        // (undocumented)
-        $list(path: string): PathFragment[];
-        // (undocumented)
-        $read(path: string): string;
-        // (undocumented)
-        $write(path: string, content: string): void;
-        constructor(map?: {
-            [path: string]: string;
-        });
-        // (undocumented)
-        clearRecords(): void;
-        // (undocumented)
-        clone(): TestHost;
-        // (undocumented)
-        protected _delete(path: Path): void;
-        // (undocumented)
-        protected _exists(path: Path): boolean;
-        // (undocumented)
-        get files(): Path[];
-        // (undocumented)
-        protected _isDirectory(path: Path): boolean;
-        // (undocumented)
-        protected _isFile(path: Path): boolean;
-        // (undocumented)
-        protected _list(path: Path): PathFragment[];
-        // (undocumented)
-        protected _read(path: Path): ArrayBuffer;
-        // (undocumented)
-        get records(): TestLogRecord[];
-        // (undocumented)
-        protected _records: TestLogRecord[];
-        // (undocumented)
-        protected _rename(from: Path, to: Path): void;
-        // (undocumented)
-        protected _stat(path: Path): Stats<SimpleMemoryHostStats> | null;
-        // (undocumented)
-        get sync(): SyncDelegateHost<{}>;
-        // (undocumented)
-        protected _sync: SyncDelegateHost<{}> | null;
-        // (undocumented)
-        protected _watch(path: Path, options?: HostWatchOptions): Observable<HostWatchEvent>;
-        // (undocumented)
-        protected _write(path: Path, content: FileBuffer): void;
+declare namespace test {
+    export {
+        TestLogRecord,
+        TestHost
     }
-    // (undocumented)
-    type TestLogRecord = {
-        kind: 'write' | 'read' | 'delete' | 'list' | 'exists' | 'isDirectory' | 'isFile' | 'stat' | 'watch';
-        path: Path;
-    } | {
-        kind: 'rename';
-        from: Path;
-        to: Path;
-    };
 }
+
+// @public (undocumented)
+class TestHost extends SimpleMemoryHost {
+    // (undocumented)
+    $exists(path: string): boolean;
+    // (undocumented)
+    $isDirectory(path: string): boolean;
+    // (undocumented)
+    $isFile(path: string): boolean;
+    // (undocumented)
+    $list(path: string): PathFragment[];
+    // (undocumented)
+    $read(path: string): string;
+    // (undocumented)
+    $write(path: string, content: string): void;
+    constructor(map?: {
+        [path: string]: string;
+    });
+    // (undocumented)
+    clearRecords(): void;
+    // (undocumented)
+    clone(): TestHost;
+    // (undocumented)
+    protected _delete(path: Path): void;
+    // (undocumented)
+    protected _exists(path: Path): boolean;
+    // (undocumented)
+    get files(): Path[];
+    // (undocumented)
+    protected _isDirectory(path: Path): boolean;
+    // (undocumented)
+    protected _isFile(path: Path): boolean;
+    // (undocumented)
+    protected _list(path: Path): PathFragment[];
+    // (undocumented)
+    protected _read(path: Path): ArrayBuffer;
+    // (undocumented)
+    get records(): TestLogRecord[];
+    // (undocumented)
+    protected _records: TestLogRecord[];
+    // (undocumented)
+    protected _rename(from: Path, to: Path): void;
+    // (undocumented)
+    protected _stat(path: Path): Stats<SimpleMemoryHostStats> | null;
+    // (undocumented)
+    get sync(): SyncDelegateHost<{}>;
+    // (undocumented)
+    protected _sync: SyncDelegateHost<{}> | null;
+    // (undocumented)
+    protected _watch(path: Path, options?: HostWatchOptions): Observable<HostWatchEvent>;
+    // (undocumented)
+    protected _write(path: Path, content: FileBuffer): void;
+}
+
+// @public (undocumented)
+type TestLogRecord = {
+    kind: 'write' | 'read' | 'delete' | 'list' | 'exists' | 'isDirectory' | 'isFile' | 'stat' | 'watch';
+    path: Path;
+} | {
+    kind: 'rename';
+    from: Path;
+    to: Path;
+};
 
 // @public (undocumented)
 class TransformLogger extends Logger {
@@ -1315,6 +1320,7 @@ type UriHandler = (uri: string) => Observable<JsonObject> | Promise<JsonObject> 
 
 declare namespace virtualFs {
     export {
+        test,
         AliasHost,
         stringToFileBuffer,
         fileBufferToString,
@@ -1345,8 +1351,7 @@ declare namespace virtualFs {
         ScopedHost,
         SynchronousDelegateExpectedException,
         SyncDelegateHost,
-        ResolverHost,
-        test
+        ResolverHost
     }
 }
 export { virtualFs }

--- a/packages/angular_devkit/architect/src/jobs/index.ts
+++ b/packages/angular_devkit/architect/src/jobs/index.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import * as strategy from './strategy';
+
 export * from './api';
 export * from './create-job-handler';
 export * from './exception';
@@ -13,4 +15,4 @@ export * from './dispatcher';
 export * from './fallback-registry';
 export * from './simple-registry';
 export * from './simple-scheduler';
-export * from './strategy';
+export { strategy };

--- a/packages/angular_devkit/architect/src/jobs/strategy_spec.ts
+++ b/packages/angular_devkit/architect/src/jobs/strategy_spec.ts
@@ -11,7 +11,7 @@ import { JobState } from './api';
 import { createJobHandler } from './create-job-handler';
 import { SimpleJobRegistry } from './simple-registry';
 import { SimpleScheduler } from './simple-scheduler';
-import { strategy } from './strategy';
+import * as strategy from './strategy';
 
 const flush = promisify(setImmediate);
 

--- a/packages/angular_devkit/core/src/virtual-fs/host/index.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/host/index.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import * as test from './test';
+
 export * from './alias';
 export * from './buffer';
 export * from './create';
@@ -18,4 +20,4 @@ export * from './safe';
 export * from './scoped';
 export * from './sync';
 export * from './resolver';
-export * from './test';
+export { test };

--- a/packages/angular_devkit/core/src/virtual-fs/host/record_spec.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/host/record_spec.ts
@@ -10,7 +10,7 @@
 import { path } from '../path';
 import { stringToFileBuffer } from './buffer';
 import { CordHost } from './record';
-import { test } from './test';
+import * as test from './test';
 
 describe('CordHost', () => {
   const TestHost = test.TestHost;

--- a/packages/angular_devkit/core/src/virtual-fs/host/test.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/host/test.ts
@@ -13,154 +13,151 @@ import { FileBuffer, HostWatchEvent, HostWatchOptions, Stats } from './interface
 import { SimpleMemoryHost, SimpleMemoryHostStats } from './memory';
 import { SyncDelegateHost } from './sync';
 
-// eslint-disable-next-line @typescript-eslint/no-namespace
-export namespace test {
-  export type TestLogRecord =
-    | {
-        kind:
-          | 'write'
-          | 'read'
-          | 'delete'
-          | 'list'
-          | 'exists'
-          | 'isDirectory'
-          | 'isFile'
-          | 'stat'
-          | 'watch';
-        path: Path;
-      }
-    | {
-        kind: 'rename';
-        from: Path;
-        to: Path;
-      };
+export type TestLogRecord =
+  | {
+      kind:
+        | 'write'
+        | 'read'
+        | 'delete'
+        | 'list'
+        | 'exists'
+        | 'isDirectory'
+        | 'isFile'
+        | 'stat'
+        | 'watch';
+      path: Path;
+    }
+  | {
+      kind: 'rename';
+      from: Path;
+      to: Path;
+    };
 
-  export class TestHost extends SimpleMemoryHost {
-    protected _records: TestLogRecord[] = [];
-    protected _sync: SyncDelegateHost<{}> | null = null;
+export class TestHost extends SimpleMemoryHost {
+  protected _records: TestLogRecord[] = [];
+  protected _sync: SyncDelegateHost<{}> | null = null;
 
-    constructor(map: { [path: string]: string } = {}) {
-      super();
+  constructor(map: { [path: string]: string } = {}) {
+    super();
 
-      for (const filePath of Object.getOwnPropertyNames(map)) {
-        this._write(normalize(filePath), stringToFileBuffer(map[filePath]));
-      }
+    for (const filePath of Object.getOwnPropertyNames(map)) {
+      this._write(normalize(filePath), stringToFileBuffer(map[filePath]));
+    }
+  }
+
+  get records(): TestLogRecord[] {
+    return [...this._records];
+  }
+  clearRecords() {
+    this._records = [];
+  }
+
+  get files(): Path[] {
+    const sync = this.sync;
+    function _visit(p: Path): Path[] {
+      return sync
+        .list(p)
+        .map((fragment) => join(p, fragment))
+        .reduce((files, path) => {
+          if (sync.isDirectory(path)) {
+            return files.concat(_visit(path));
+          } else {
+            return files.concat(path);
+          }
+        }, [] as Path[]);
     }
 
-    get records(): TestLogRecord[] {
-      return [...this._records];
-    }
-    clearRecords() {
-      this._records = [];
-    }
+    return _visit(normalize('/'));
+  }
 
-    get files(): Path[] {
-      const sync = this.sync;
-      function _visit(p: Path): Path[] {
-        return sync
-          .list(p)
-          .map((fragment) => join(p, fragment))
-          .reduce((files, path) => {
-            if (sync.isDirectory(path)) {
-              return files.concat(_visit(path));
-            } else {
-              return files.concat(path);
-            }
-          }, [] as Path[]);
-      }
-
-      return _visit(normalize('/'));
+  get sync() {
+    if (!this._sync) {
+      this._sync = new SyncDelegateHost<{}>(this);
     }
 
-    get sync() {
-      if (!this._sync) {
-        this._sync = new SyncDelegateHost<{}>(this);
-      }
+    return this._sync;
+  }
 
-      return this._sync;
-    }
+  clone() {
+    const newHost = new TestHost();
+    newHost._cache = new Map(this._cache);
 
-    clone() {
-      const newHost = new TestHost();
-      newHost._cache = new Map(this._cache);
+    return newHost;
+  }
 
-      return newHost;
-    }
+  // Override parents functions to keep a record of all operators that were done.
+  protected override _write(path: Path, content: FileBuffer) {
+    this._records.push({ kind: 'write', path });
 
-    // Override parents functions to keep a record of all operators that were done.
-    protected override _write(path: Path, content: FileBuffer) {
-      this._records.push({ kind: 'write', path });
+    return super._write(path, content);
+  }
+  protected override _read(path: Path) {
+    this._records.push({ kind: 'read', path });
 
-      return super._write(path, content);
-    }
-    protected override _read(path: Path) {
-      this._records.push({ kind: 'read', path });
+    return super._read(path);
+  }
+  protected override _delete(path: Path) {
+    this._records.push({ kind: 'delete', path });
 
-      return super._read(path);
-    }
-    protected override _delete(path: Path) {
-      this._records.push({ kind: 'delete', path });
+    return super._delete(path);
+  }
+  protected override _rename(from: Path, to: Path) {
+    this._records.push({ kind: 'rename', from, to });
 
-      return super._delete(path);
-    }
-    protected override _rename(from: Path, to: Path) {
-      this._records.push({ kind: 'rename', from, to });
+    return super._rename(from, to);
+  }
+  protected override _list(path: Path): PathFragment[] {
+    this._records.push({ kind: 'list', path });
 
-      return super._rename(from, to);
-    }
-    protected override _list(path: Path): PathFragment[] {
-      this._records.push({ kind: 'list', path });
+    return super._list(path);
+  }
+  protected override _exists(path: Path) {
+    this._records.push({ kind: 'exists', path });
 
-      return super._list(path);
-    }
-    protected override _exists(path: Path) {
-      this._records.push({ kind: 'exists', path });
+    return super._exists(path);
+  }
+  protected override _isDirectory(path: Path) {
+    this._records.push({ kind: 'isDirectory', path });
 
-      return super._exists(path);
-    }
-    protected override _isDirectory(path: Path) {
-      this._records.push({ kind: 'isDirectory', path });
+    return super._isDirectory(path);
+  }
+  protected override _isFile(path: Path) {
+    this._records.push({ kind: 'isFile', path });
 
-      return super._isDirectory(path);
-    }
-    protected override _isFile(path: Path) {
-      this._records.push({ kind: 'isFile', path });
+    return super._isFile(path);
+  }
+  protected override _stat(path: Path): Stats<SimpleMemoryHostStats> | null {
+    this._records.push({ kind: 'stat', path });
 
-      return super._isFile(path);
-    }
-    protected override _stat(path: Path): Stats<SimpleMemoryHostStats> | null {
-      this._records.push({ kind: 'stat', path });
+    return super._stat(path);
+  }
+  protected override _watch(path: Path, options?: HostWatchOptions): Observable<HostWatchEvent> {
+    this._records.push({ kind: 'watch', path });
 
-      return super._stat(path);
-    }
-    protected override _watch(path: Path, options?: HostWatchOptions): Observable<HostWatchEvent> {
-      this._records.push({ kind: 'watch', path });
+    return super._watch(path, options);
+  }
 
-      return super._watch(path, options);
-    }
+  $write(path: string, content: string) {
+    return super._write(normalize(path), stringToFileBuffer(content));
+  }
 
-    $write(path: string, content: string) {
-      return super._write(normalize(path), stringToFileBuffer(content));
-    }
+  $read(path: string): string {
+    return fileBufferToString(super._read(normalize(path)));
+  }
 
-    $read(path: string): string {
-      return fileBufferToString(super._read(normalize(path)));
-    }
+  $list(path: string): PathFragment[] {
+    return super._list(normalize(path));
+  }
 
-    $list(path: string): PathFragment[] {
-      return super._list(normalize(path));
-    }
+  $exists(path: string) {
+    return super._exists(normalize(path));
+  }
 
-    $exists(path: string) {
-      return super._exists(normalize(path));
-    }
+  $isDirectory(path: string) {
+    return super._isDirectory(normalize(path));
+  }
 
-    $isDirectory(path: string) {
-      return super._isDirectory(normalize(path));
-    }
-
-    $isFile(path: string) {
-      return super._isFile(normalize(path));
-    }
+  $isFile(path: string) {
+    return super._isFile(normalize(path));
   }
 }

--- a/packages/angular_devkit/core/src/virtual-fs/host/test_spec.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/host/test_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { test } from './test';
+import * as test from './test';
 
 // Yes, we realize the irony of testing a test host.
 describe('TestHost', () => {

--- a/packages/angular_devkit/schematics/src/tree/interface.ts
+++ b/packages/angular_devkit/schematics/src/tree/interface.ts
@@ -127,12 +127,15 @@ export interface Tree {
   readonly actions: Action[];
 }
 
-// eslint-disable-next-line @typescript-eslint/no-namespace
-namespace Tree {
-  export function isTree(maybeTree: object): maybeTree is Tree {
-    return TreeSymbol in maybeTree;
-  }
+export interface TreeConstructor {
+  isTree(maybeTree: object): maybeTree is Tree;
 }
+
+export const Tree: TreeConstructor = Object.freeze({
+  isTree(maybeTree: object): maybeTree is Tree {
+    return TreeSymbol in maybeTree;
+  },
+});
 
 export interface UpdateRecorder {
   // These just record changes.


### PR DESCRIPTION
The `namespace` TypeScript usage within the CLI has been removed. This syntax is not recommended outside of type definition files.

Recommended to review with hide whitespace enabled.