### PR TITLE
fix(@angular-devkit/build-angular): handle regular expressions in proxy config when using Vite

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/dev-server/tests/options/proxy-config_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/tests/options/proxy-config_spec.ts
@@ -28,13 +28,10 @@ describeServeBuilder(executeDevServer, DEV_SERVER_BUILDER_INFO, (harness, setupT
         proxyConfig: 'proxy.config.json',
       });
 
-      const proxyServer = createProxyServer();
+      const proxyServer = await createProxyServer();
       try {
-        await new Promise<void>((resolve) => proxyServer.listen(0, '127.0.0.1', resolve));
-        const proxyAddress = proxyServer.address() as import('net').AddressInfo;
-
         await harness.writeFiles({
-          'proxy.config.json': `{ "/api/*": { "target": "http://127.0.0.1:${proxyAddress.port}" } }`,
+          'proxy.config.json': `{ "/api/*": { "target": "http://127.0.0.1:${proxyServer.address.port}" } }`,
         });
 
         const { result, response } = await executeOnceAndFetch(harness, '/api/test');
@@ -42,7 +39,7 @@ describeServeBuilder(executeDevServer, DEV_SERVER_BUILDER_INFO, (harness, setupT
         expect(result?.success).toBeTrue();
         expect(await response?.text()).toContain('TEST_API_RETURN');
       } finally {
-        await new Promise<void>((resolve) => proxyServer.close(() => resolve()));
+        await proxyServer.close();
       }
     });
 
@@ -52,15 +49,12 @@ describeServeBuilder(executeDevServer, DEV_SERVER_BUILDER_INFO, (harness, setupT
         proxyConfig: 'proxy.config.json',
       });
 
-      const proxyServer = createProxyServer();
+      const proxyServer = await createProxyServer();
       try {
-        await new Promise<void>((resolve) => proxyServer.listen(0, '127.0.0.1', resolve));
-        const proxyAddress = proxyServer.address() as import('net').AddressInfo;
-
         await harness.writeFiles({
           'proxy.config.json': `
             // JSON file with comments
-            { "/api/*": { "target": "http://127.0.0.1:${proxyAddress.port}" } }
+            { "/api/*": { "target": "http://127.0.0.1:${proxyServer.address.port}" } }
           `,
         });
 
@@ -69,7 +63,7 @@ describeServeBuilder(executeDevServer, DEV_SERVER_BUILDER_INFO, (harness, setupT
         expect(result?.success).toBeTrue();
         expect(await response?.text()).toContain('TEST_API_RETURN');
       } finally {
-        await new Promise<void>((resolve) => proxyServer.close(() => resolve()));
+        await proxyServer.close();
       }
     });
 
@@ -78,14 +72,10 @@ describeServeBuilder(executeDevServer, DEV_SERVER_BUILDER_INFO, (harness, setupT
         ...BASE_OPTIONS,
         proxyConfig: 'proxy.config.js',
       });
-
-      const proxyServer = createProxyServer();
+      const proxyServer = await createProxyServer();
       try {
-        await new Promise<void>((resolve) => proxyServer.listen(0, '127.0.0.1', resolve));
-        const proxyAddress = proxyServer.address() as import('net').AddressInfo;
-
         await harness.writeFiles({
-          'proxy.config.js': `module.exports = { "/api/*": { "target": "http://127.0.0.1:${proxyAddress.port}" } }`,
+          'proxy.config.js': `module.exports = { "/api/*": { "target": "http://127.0.0.1:${proxyServer.address.port}" } }`,
         });
 
         const { result, response } = await executeOnceAndFetch(harness, '/api/test');
@@ -93,7 +83,7 @@ describeServeBuilder(executeDevServer, DEV_SERVER_BUILDER_INFO, (harness, setupT
         expect(result?.success).toBeTrue();
         expect(await response?.text()).toContain('TEST_API_RETURN');
       } finally {
-        await new Promise<void>((resolve) => proxyServer.close(() => resolve()));
+        await proxyServer.close();
       }
     });
 
@@ -103,13 +93,10 @@ describeServeBuilder(executeDevServer, DEV_SERVER_BUILDER_INFO, (harness, setupT
         proxyConfig: 'proxy.config.js',
       });
 
-      const proxyServer = createProxyServer();
+      const proxyServer = await createProxyServer();
       try {
-        await new Promise<void>((resolve) => proxyServer.listen(0, '127.0.0.1', resolve));
-        const proxyAddress = proxyServer.address() as import('net').AddressInfo;
-
         await harness.writeFiles({
-          'proxy.config.js': `export default { "/api/*": { "target": "http://127.0.0.1:${proxyAddress.port}" } }`,
+          'proxy.config.js': `export default { "/api/*": { "target": "http://127.0.0.1:${proxyServer.address.port}" } }`,
           'package.json': '{ "type": "module" }',
         });
 
@@ -118,7 +105,7 @@ describeServeBuilder(executeDevServer, DEV_SERVER_BUILDER_INFO, (harness, setupT
         expect(result?.success).toBeTrue();
         expect(await response?.text()).toContain('TEST_API_RETURN');
       } finally {
-        await new Promise<void>((resolve) => proxyServer.close(() => resolve()));
+        await proxyServer.close();
       }
     });
 
@@ -128,10 +115,9 @@ describeServeBuilder(executeDevServer, DEV_SERVER_BUILDER_INFO, (harness, setupT
         proxyConfig: 'proxy.config.cjs',
       });
 
-      const proxyServer = createProxyServer();
+      const proxyServer = await createProxyServer();
       try {
-        await new Promise<void>((resolve) => proxyServer.listen(0, '127.0.0.1', resolve));
-        const proxyAddress = proxyServer.address() as import('net').AddressInfo;
+        const proxyAddress = proxyServer.address;
 
         await harness.writeFiles({
           'proxy.config.cjs': `module.exports = { "/api/*": { "target": "http://127.0.0.1:${proxyAddress.port}" } }`,
@@ -142,7 +128,7 @@ describeServeBuilder(executeDevServer, DEV_SERVER_BUILDER_INFO, (harness, setupT
         expect(result?.success).toBeTrue();
         expect(await response?.text()).toContain('TEST_API_RETURN');
       } finally {
-        await new Promise<void>((resolve) => proxyServer.close(() => resolve()));
+        await proxyServer.close();
       }
     });
 
@@ -152,13 +138,10 @@ describeServeBuilder(executeDevServer, DEV_SERVER_BUILDER_INFO, (harness, setupT
         proxyConfig: 'proxy.config.mjs',
       });
 
-      const proxyServer = createProxyServer();
+      const proxyServer = await createProxyServer();
       try {
-        await new Promise<void>((resolve) => proxyServer.listen(0, '127.0.0.1', resolve));
-        const proxyAddress = proxyServer.address() as import('net').AddressInfo;
-
         await harness.writeFiles({
-          'proxy.config.mjs': `export default { "/api/*": { "target": "http://127.0.0.1:${proxyAddress.port}" } }`,
+          'proxy.config.mjs': `export default { "/api/*": { "target": "http://127.0.0.1:${proxyServer.address.port}" } }`,
         });
 
         const { result, response } = await executeOnceAndFetch(harness, '/api/test');
@@ -166,7 +149,7 @@ describeServeBuilder(executeDevServer, DEV_SERVER_BUILDER_INFO, (harness, setupT
         expect(result?.success).toBeTrue();
         expect(await response?.text()).toContain('TEST_API_RETURN');
       } finally {
-        await new Promise<void>((resolve) => proxyServer.close(() => resolve()));
+        await proxyServer.close();
       }
     });
 
@@ -176,13 +159,10 @@ describeServeBuilder(executeDevServer, DEV_SERVER_BUILDER_INFO, (harness, setupT
         proxyConfig: 'proxy.config.json',
       });
 
-      const proxyServer = createProxyServer();
+      const proxyServer = await createProxyServer();
       try {
-        await new Promise<void>((resolve) => proxyServer.listen(0, '127.0.0.1', resolve));
-        const proxyAddress = proxyServer.address() as import('net').AddressInfo;
-
         await harness.writeFiles({
-          'proxy.config.json': `[ { "context": ["/api", "/abc"], "target": "http://127.0.0.1:${proxyAddress.port}" } ]`,
+          'proxy.config.json': `[ { "context": ["/api", "/abc"], "target": "http://127.0.0.1:${proxyServer.address.port}" } ]`,
         });
 
         const { result, response } = await executeOnceAndFetch(harness, '/api/test');
@@ -190,7 +170,7 @@ describeServeBuilder(executeDevServer, DEV_SERVER_BUILDER_INFO, (harness, setupT
         expect(result?.success).toBeTrue();
         expect(await response?.text()).toContain('TEST_API_RETURN');
       } finally {
-        await new Promise<void>((resolve) => proxyServer.close(() => resolve()));
+        await proxyServer.close();
       }
     });
 
@@ -255,14 +235,11 @@ function viteOnlyTests(harness: JasmineBuilderHarness<unknown>): void {
       proxyConfig: 'proxy.config.json',
     });
 
-    const proxyServer = createProxyServer();
+    const proxyServer = await createProxyServer();
     try {
-      await new Promise<void>((resolve) => proxyServer.listen(0, '127.0.0.1', resolve));
-      const proxyAddress = proxyServer.address() as import('net').AddressInfo;
-
       await harness.writeFiles({
         'proxy.config.json': `
-              { "^/api/.*": { "target": "http://127.0.0.1:${proxyAddress.port}" } }
+              { "^/api/.*": { "target": "http://127.0.0.1:${proxyServer.address.port}" } }
             `,
       });
 
@@ -271,7 +248,7 @@ function viteOnlyTests(harness: JasmineBuilderHarness<unknown>): void {
       expect(result?.success).toBeTrue();
       expect(await response?.text()).toContain('TEST_API_RETURN');
     } finally {
-      await new Promise<void>((resolve) => proxyServer.close(() => resolve()));
+      await proxyServer.close();
     }
   });
 
@@ -281,14 +258,11 @@ function viteOnlyTests(harness: JasmineBuilderHarness<unknown>): void {
       proxyConfig: 'proxy.config.json',
     });
 
-    const proxyServer = createProxyServer();
+    const proxyServer = await createProxyServer();
     try {
-      await new Promise<void>((resolve) => proxyServer.listen(0, '127.0.0.1', resolve));
-      const proxyAddress = proxyServer.address() as import('net').AddressInfo;
-
       await harness.writeFiles({
         'proxy.config.json': `
-              { "^\\/(?!something).*": { "target": "http://127.0.0.1:${proxyAddress.port}" } }
+              { "^\\/(?!something).*": { "target": "http://127.0.0.1:${proxyServer.address.port}" } }
             `,
       });
 
@@ -297,7 +271,7 @@ function viteOnlyTests(harness: JasmineBuilderHarness<unknown>): void {
       expect(result?.success).toBeTrue();
       expect(await response?.text()).toContain('TEST_API_RETURN');
     } finally {
-      await new Promise<void>((resolve) => proxyServer.close(() => resolve()));
+      await proxyServer.close();
     }
   });
 }
@@ -306,11 +280,9 @@ function viteOnlyTests(harness: JasmineBuilderHarness<unknown>): void {
  * Creates an HTTP Server used for proxy testing that provides a `/test` endpoint
  * that returns a 200 response with a body of `TEST_API_RETURN`. All other requests
  * will return a 404 response.
- *
- * @returns An HTTP Server instance.
  */
-function createProxyServer() {
-  return createServer((request, response) => {
+async function createProxyServer() {
+  const proxyServer = createServer((request, response) => {
     if (request.url?.endsWith('/test')) {
       response.writeHead(200);
       response.end('TEST_API_RETURN');
@@ -319,4 +291,11 @@ function createProxyServer() {
       response.end();
     }
   });
+
+  await new Promise<void>((resolve) => proxyServer.listen(0, '127.0.0.1', resolve));
+
+  return {
+    address: proxyServer.address() as import('net').AddressInfo,
+    close: () => new Promise<void>((resolve) => proxyServer.close(() => resolve())),
+  };
 }

--- a/packages/angular_devkit/build_angular/src/utils/load-proxy-config.ts
+++ b/packages/angular_devkit/build_angular/src/utils/load-proxy-config.ts
@@ -128,7 +128,7 @@ function normalizeProxyConfiguration(
 
   // TODO: Consider upstreaming glob support
   for (const key of Object.keys(normalizedProxy)) {
-    if (isDynamicPattern(key)) {
+    if (key[0] !== '^' && isDynamicPattern(key)) {
       const { output } = parseGlob(key);
       normalizedProxy[`^${output}$`] = normalizedProxy[key];
       delete normalizedProxy[key];


### PR DESCRIPTION


This commit enables proxies to have a RegExp as context when using Vite. See: https://vitejs.dev/config/server-options#server-proxy

Closes #26970
