### PR TITLE
fix(@angular-devkit/build-angular): resolve absolute `output-path` when using esbuild based builders

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/application/options.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/options.ts
@@ -144,7 +144,7 @@ export async function normalizeOptions(
     media: 'media',
     ...(typeof outputPath === 'string' ? undefined : outputPath),
     base: normalizeDirectoryPath(
-      path.join(workspaceRoot, typeof outputPath === 'string' ? outputPath : outputPath.base),
+      path.resolve(workspaceRoot, typeof outputPath === 'string' ? outputPath : outputPath.base),
     ),
   };
 


### PR DESCRIPTION


Prior to this change using an absolute path as a `output-path` resulted in the path to be combined with the workspace root instead of resolved which caused the output to be emitted in the incorrect directory or error in Windows.

Closes #26935
