### PR TITLE
fix(@angular-devkit/build-angular): handle regular expressions in proxy config when using Vite

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/dev-server/tests/options/proxy-config_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/tests/options/proxy-config_spec.ts
@@ -7,12 +7,13 @@
  */
 
 import { createServer } from 'node:http';
+import { JasmineBuilderHarness } from '../../../../testing/jasmine-helpers';
 import { executeDevServer } from '../../index';
 import { executeOnceAndFetch } from '../execute-fetch';
 import { describeServeBuilder } from '../jasmine-helpers';
 import { BASE_OPTIONS, DEV_SERVER_BUILDER_INFO } from '../setup';
 
-describeServeBuilder(executeDevServer, DEV_SERVER_BUILDER_INFO, (harness, setupTarget) => {
+describeServeBuilder(executeDevServer, DEV_SERVER_BUILDER_INFO, (harness, setupTarget, isVite) => {
   describe('option: "proxyConfig"', () => {
     beforeEach(async () => {
       setupTarget(harness);
@@ -235,6 +236,15 @@ describeServeBuilder(executeDevServer, DEV_SERVER_BUILDER_INFO, (harness, setupT
         await proxyServer.close();
       }
     });
+
+    /**
+     * ****************************************************************************************************
+     * ********************************** Below only Vite specific tests **********************************
+     * ****************************************************************************************************
+     */
+    if (isVite) {
+      viteOnlyTests(harness);
+    }
   });
 });
 
@@ -260,4 +270,55 @@ async function createProxyServer() {
     address: proxyServer.address() as import('net').AddressInfo,
     close: () => new Promise<void>((resolve) => proxyServer.close(() => resolve())),
   };
+}
+
+/**
+ * Vite specific tests
+ */
+function viteOnlyTests(harness: JasmineBuilderHarness<unknown>): void {
+  it('proxies support regexp as context', async () => {
+    harness.useTarget('serve', {
+      ...BASE_OPTIONS,
+      proxyConfig: 'proxy.config.json',
+    });
+
+    const proxyServer = await createProxyServer();
+    try {
+      await harness.writeFiles({
+        'proxy.config.json': `
+              { "^/api/.*": { "target": "http://127.0.0.1:${proxyServer.address.port}" } }
+            `,
+      });
+
+      const { result, response } = await executeOnceAndFetch(harness, '/api/test');
+
+      expect(result?.success).toBeTrue();
+      expect(await response?.text()).toContain('TEST_API_RETURN');
+    } finally {
+      await proxyServer.close();
+    }
+  });
+
+  it('proxies support negated regexp as context', async () => {
+    harness.useTarget('serve', {
+      ...BASE_OPTIONS,
+      proxyConfig: 'proxy.config.json',
+    });
+
+    const proxyServer = await createProxyServer();
+    try {
+      await harness.writeFiles({
+        'proxy.config.json': `
+              { "^\\/(?!something).*": { "target": "http://127.0.0.1:${proxyServer.address.port}" } }
+            `,
+      });
+
+      const { result, response } = await executeOnceAndFetch(harness, '/api/test');
+
+      expect(result?.success).toBeTrue();
+      expect(await response?.text()).toContain('TEST_API_RETURN');
+    } finally {
+      await proxyServer.close();
+    }
+  });
 }

--- a/packages/angular_devkit/build_angular/src/utils/load-proxy-config.ts
+++ b/packages/angular_devkit/build_angular/src/utils/load-proxy-config.ts
@@ -128,7 +128,7 @@ function normalizeProxyConfiguration(
 
   // TODO: Consider upstreaming glob support
   for (const key of Object.keys(normalizedProxy)) {
-    if (isDynamicPattern(key)) {
+    if (key[0] !== '^' && isDynamicPattern(key)) {
       const pattern = makeRegExpFromGlob(key).source;
       normalizedProxy[pattern] = normalizedProxy[key];
       delete normalizedProxy[key];


### PR DESCRIPTION


This commit enables proxies to have a RegExp as context when using Vite. See: https://vitejs.dev/config/server-options#server-proxy

Closes #26970
