### PR TITLE
refactor(@angular-devkit/build-angular): remove babel core runtime imports from `elide-angular-metadata` build optimizer pass

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/babel/plugins/elide-angular-metadata.ts
+++ b/packages/angular_devkit/build_angular/src/tools/babel/plugins/elide-angular-metadata.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { NodePath, PluginObj, types } from '@babel/core';
+import type { NodePath, PluginObj } from '@babel/core';
 
 /**
  * The name of the Angular class metadata function created by the Angular compiler.
@@ -30,8 +30,18 @@ const SET_CLASS_DEBUG_INFO_NAME = 'ɵsetClassDebugInfo';
  * @returns An a string iterable containing one or more keywords.
  */
 export function getKeywords(): Iterable<string> {
-  return [SET_CLASS_METADATA_NAME, SET_CLASS_METADATA_ASYNC_NAME, SET_CLASS_DEBUG_INFO_NAME];
+  return Object.keys(angularMetadataFunctions);
 }
+
+/**
+ * An object map of function names and related value checks for discovery of Angular generated
+ * metadata calls.
+ */
+const angularMetadataFunctions: Record<string, (args: NodePath[]) => boolean> = {
+  [SET_CLASS_METADATA_NAME]: isSetClassMetadataCall,
+  [SET_CLASS_METADATA_ASYNC_NAME]: isSetClassMetadataAsyncCall,
+  [SET_CLASS_DEBUG_INFO_NAME]: isSetClassDebugInfoCall,
+};
 
 /**
  * A babel plugin factory function for eliding the Angular class metadata function (`ɵsetClassMetadata`).
@@ -41,23 +51,27 @@ export function getKeywords(): Iterable<string> {
 export default function (): PluginObj {
   return {
     visitor: {
-      CallExpression(path: NodePath<types.CallExpression>) {
-        const callee = path.node.callee;
-        const callArguments = path.node.arguments;
+      CallExpression(path) {
+        const callee = path.get('callee');
 
         // The function being called must be the metadata function name
         let calleeName;
-        if (types.isMemberExpression(callee) && types.isIdentifier(callee.property)) {
-          calleeName = callee.property.name;
-        } else if (types.isIdentifier(callee)) {
-          calleeName = callee.name;
+        if (callee.isMemberExpression()) {
+          const calleeProperty = callee.get('property');
+          if (calleeProperty.isIdentifier()) {
+            calleeName = calleeProperty.node.name;
+          }
+        } else if (callee.isIdentifier()) {
+          calleeName = callee.node.name;
+        }
+
+        if (!calleeName) {
+          return;
         }
 
         if (
-          calleeName !== undefined &&
-          (isRemoveClassMetadataCall(calleeName, callArguments) ||
-            isRemoveClassmetadataAsyncCall(calleeName, callArguments) ||
-            isSetClassDebugInfoCall(calleeName, callArguments))
+          Object.hasOwn(angularMetadataFunctions, calleeName) &&
+          angularMetadataFunctions[calleeName](path.get('arguments'))
         ) {
           // The metadata function is always emitted inside a function expression
           const parent = path.getFunctionParent();
@@ -74,47 +88,41 @@ export default function (): PluginObj {
 }
 
 /** Determines if a function call is a call to `setClassMetadata`. */
-function isRemoveClassMetadataCall(name: string, args: types.CallExpression['arguments']): boolean {
+function isSetClassMetadataCall(callArguments: NodePath[]): boolean {
   // `setClassMetadata` calls have to meet the following criteria:
   // * First must be an identifier
   // * Second must be an array literal
   return (
-    name === SET_CLASS_METADATA_NAME &&
-    args.length === 4 &&
-    types.isIdentifier(args[0]) &&
-    types.isArrayExpression(args[1])
+    callArguments.length === 4 &&
+    callArguments[0].isIdentifier() &&
+    callArguments[1].isArrayExpression()
   );
 }
 
 /** Determines if a function call is a call to `setClassMetadataAsync`. */
-function isRemoveClassmetadataAsyncCall(
-  name: string,
-  args: types.CallExpression['arguments'],
-): boolean {
+function isSetClassMetadataAsyncCall(callArguments: NodePath[]): boolean {
   // `setClassMetadataAsync` calls have to meet the following criteria:
   // * First argument must be an identifier.
   // * Second argument must be an inline function.
   // * Third argument must be an inline function.
   return (
-    name === SET_CLASS_METADATA_ASYNC_NAME &&
-    args.length === 3 &&
-    types.isIdentifier(args[0]) &&
-    isInlineFunction(args[1]) &&
-    isInlineFunction(args[2])
+    callArguments.length === 3 &&
+    callArguments[0].isIdentifier() &&
+    isInlineFunction(callArguments[1]) &&
+    isInlineFunction(callArguments[2])
   );
 }
 
 /** Determines if a function call is a call to `setClassDebugInfo`. */
-function isSetClassDebugInfoCall(name: string, args: types.CallExpression['arguments']): boolean {
+function isSetClassDebugInfoCall(callArguments: NodePath[]): boolean {
   return (
-    name === SET_CLASS_DEBUG_INFO_NAME &&
-    args.length === 2 &&
-    types.isIdentifier(args[0]) &&
-    types.isObjectExpression(args[1])
+    callArguments.length === 2 &&
+    callArguments[0].isIdentifier() &&
+    callArguments[1].isObjectExpression()
   );
 }
 
 /** Determines if a node is an inline function expression. */
-function isInlineFunction(node: types.Node): boolean {
-  return types.isFunctionExpression(node) || types.isArrowFunctionExpression(node);
+function isInlineFunction(path: NodePath): boolean {
+  return path.isFunctionExpression() || path.isArrowFunctionExpression();
 }


### PR DESCRIPTION
The `elide-angular-metadata` build optimization pass have been cleaned up and restructured to remove the need for a direct runtime dependency on `@babel/core`.