### PR TITLE
feat(@angular-devkit/build-angular): support using custom postcss configuration with application builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/application/options.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/options.ts
@@ -21,6 +21,7 @@ import { I18nOptions, createI18nOptions } from '../../utils/i18n-options';
 import { IndexHtmlTransform } from '../../utils/index-file/index-html-generator';
 import { normalizeCacheOptions } from '../../utils/normalize-cache';
 import { generateEntryPoints } from '../../utils/package-chunk-sort';
+import { loadPostcssConfiguration } from '../../utils/postcss-configuration';
 import { findTailwindConfigurationFile } from '../../utils/tailwind';
 import { getIndexInputFile, getIndexOutputFile } from '../../utils/webpack-browser-config';
 import {
@@ -190,6 +191,12 @@ export async function normalizeOptions(
     }
   }
 
+  const postcssConfiguration = await loadPostcssConfiguration(workspaceRoot, projectRoot);
+  // Skip tailwind configuration if postcss is customized
+  const tailwindConfiguration = postcssConfiguration
+    ? undefined
+    : await getTailwindConfig(workspaceRoot, projectRoot, context);
+
   const globalStyles: { name: string; files: string[]; initial: boolean }[] = [];
   if (options.styles?.length) {
     const { entryPoints: stylesheetEntrypoints, noInjectNames } = normalizeGlobalStyles(
@@ -329,7 +336,8 @@ export async function normalizeOptions(
     serviceWorker:
       typeof serviceWorker === 'string' ? path.join(workspaceRoot, serviceWorker) : undefined,
     indexHtmlOptions,
-    tailwindConfiguration: await getTailwindConfig(workspaceRoot, projectRoot, context),
+    tailwindConfiguration,
+    postcssConfiguration,
     i18nOptions,
     namedChunks,
     budgets: budgets?.length ? budgets : undefined,

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/compiler-plugin-options.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/compiler-plugin-options.ts
@@ -35,6 +35,7 @@ export function createCompilerPluginOptions(
     jit,
     cacheOptions,
     tailwindConfiguration,
+    postcssConfiguration,
     publicPath,
   } = options;
 
@@ -68,6 +69,7 @@ export function createCompilerPluginOptions(
       inlineStyleLanguage,
       preserveSymlinks,
       tailwindConfiguration,
+      postcssConfiguration,
       cacheOptions,
       publicPath,
     },

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/global-styles.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/global-styles.ts
@@ -27,6 +27,7 @@ export function createGlobalStylesBundleOptions(
     externalDependencies,
     stylePreprocessorOptions,
     tailwindConfiguration,
+    postcssConfiguration,
     cacheOptions,
     publicPath,
   } = options;
@@ -64,6 +65,7 @@ export function createGlobalStylesBundleOptions(
             },
         includePaths: stylePreprocessorOptions?.includePaths,
         tailwindConfiguration,
+        postcssConfiguration,
         cacheOptions,
         publicPath,
       },

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/stylesheets/bundle-options.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/stylesheets/bundle-options.ts
@@ -9,6 +9,7 @@
 import type { BuildOptions, Plugin } from 'esbuild';
 import path from 'node:path';
 import { NormalizedCachedOptions } from '../../../utils/normalize-cache';
+import { PostcssConfiguration } from '../../../utils/postcss-configuration';
 import { LoadResultCache } from '../load-result-cache';
 import { createCssInlineFontsPlugin } from './css-inline-fonts-plugin';
 import { CssStylesheetLanguage } from './css-language';
@@ -28,6 +29,7 @@ export interface BundleStylesheetOptions {
   externalDependencies?: string[];
   target: string[];
   tailwindConfiguration?: { file: string; package: string };
+  postcssConfiguration?: PostcssConfiguration;
   publicPath?: string;
   cacheOptions: NormalizedCachedOptions;
 }
@@ -48,6 +50,7 @@ export function createStylesheetBundleOptions(
       includePaths,
       inlineComponentData,
       tailwindConfiguration: options.tailwindConfiguration,
+      postcssConfiguration: options.postcssConfiguration,
     },
     cache,
   );

--- a/packages/angular_devkit/build_angular/src/utils/postcss-configuration.ts
+++ b/packages/angular_devkit/build_angular/src/utils/postcss-configuration.ts
@@ -1,0 +1,115 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { readFile, readdir } from 'node:fs/promises';
+import { join } from 'node:path';
+
+export interface PostcssConfiguration {
+  plugins: [name: string, options?: object][];
+}
+
+interface RawPostcssConfiguration {
+  plugins?: Record<string, object | boolean> | (string | [string, object])[];
+}
+
+const postcssConfigurationFiles: string[] = ['postcss.config.json', '.postcssrc.json'];
+
+interface SearchDirectory {
+  root: string;
+  files: Set<string>;
+}
+
+async function generateSearchDirectories(roots: string[]): Promise<SearchDirectory[]> {
+  return await Promise.all(
+    roots.map((root) =>
+      readdir(root, { withFileTypes: true }).then((entries) => ({
+        root,
+        files: new Set(entries.filter((entry) => entry.isFile()).map((entry) => entry.name)),
+      })),
+    ),
+  );
+}
+
+function findFile(
+  searchDirectories: SearchDirectory[],
+  potentialFiles: string[],
+): string | undefined {
+  for (const { root, files } of searchDirectories) {
+    for (const potential of potentialFiles) {
+      if (files.has(potential)) {
+        return join(root, potential);
+      }
+    }
+  }
+
+  return undefined;
+}
+
+async function readPostcssConfiguration(
+  configurationFile: string,
+): Promise<RawPostcssConfiguration> {
+  const data = await readFile(configurationFile, 'utf-8');
+  const config = JSON.parse(data) as RawPostcssConfiguration;
+
+  return config;
+}
+
+export async function loadPostcssConfiguration(
+  workspaceRoot: string,
+  projectRoot: string,
+): Promise<PostcssConfiguration | undefined> {
+  // A configuration file can exist in the project or workspace root
+  const searchDirectories = await generateSearchDirectories([projectRoot, workspaceRoot]);
+
+  const configPath = findFile(searchDirectories, postcssConfigurationFiles);
+  if (!configPath) {
+    return undefined;
+  }
+
+  const raw = await readPostcssConfiguration(configPath);
+
+  // If no plugins are defined, consider it equivalent to no configuration
+  if (!raw.plugins || typeof raw.plugins !== 'object') {
+    return undefined;
+  }
+
+  // Normalize plugin array form
+  if (Array.isArray(raw.plugins)) {
+    if (raw.plugins.length < 1) {
+      return undefined;
+    }
+
+    const config: PostcssConfiguration = { plugins: [] };
+    for (const element of raw.plugins) {
+      if (typeof element === 'string') {
+        config.plugins.push([element]);
+      } else {
+        config.plugins.push(element);
+      }
+    }
+
+    return config;
+  }
+
+  // Normalize plugin object map form
+  const entries = Object.entries(raw.plugins);
+  if (entries.length < 1) {
+    return undefined;
+  }
+
+  const config: PostcssConfiguration = { plugins: [] };
+  for (const [name, options] of entries) {
+    if (!options || typeof options !== 'object') {
+      continue;
+    }
+
+    config.plugins.push([name, options]);
+  }
+
+  return config;
+}


### PR DESCRIPTION
When using the `application` builder, the usage of a custom postcss configuration is now supported. The builder will automatically detect and use specific postcss configuration files if present in either the project root directory or the workspace root. Files present in the project root will have priority over a workspace root file. If using a custom postcss configuration file, the automatic tailwind integration will be disabled. To use both a custom postcss configuration and tailwind, the tailwind setup must be included in the custom postcss configuration file.

The configuration files must be JSON and named one of the following:
* `postcss.config.json`
* `.postcssrc.json`

A configuration file can use either an array form or an object form to setup plugins. An example of the array form:
```
{
    "plugins": [
        "tailwindcss",
        ["rtlcss", { "useCalc": true }]
    ]
}
```

The same in an object form:
```
{
    "plugins": {
        "tailwindcss": {},
        "rtlcss": { "useCalc": true }
    }
}
```

NOTE: Using a custom postcss configuration may result in reduced build and rebuild
performance. Postcss will be used to process all global and component stylesheets
when a custom configuration is present. Without a custom postcss configuration,
postcss is only used for a stylesheet when tailwind is enabled and the stylesheet
requires tailwind processing.

Closes #25411
Closes #26867