### PR TITLE
feat(@angular-devkit/build-angular): provide option to allow automatically cleaning the terminal screen during rebuilds

### DIFF
--- a/goldens/public-api/angular_devkit/build_angular/index.md
+++ b/goldens/public-api/angular_devkit/build_angular/index.md
@@ -30,6 +30,7 @@ export interface ApplicationBuilderOptions {
     baseHref?: string;
     browser: string;
     budgets?: Budget_2[];
+    clearScreen?: boolean;
     crossOrigin?: CrossOrigin_2;
     deleteOutputPath?: boolean;
     externalDependencies?: string[];

--- a/packages/angular_devkit/build_angular/src/builders/application/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/index.ts
@@ -126,6 +126,7 @@ export async function* buildApplicationInternal(
       projectRoot: normalizedOptions.projectRoot,
       workspaceRoot: normalizedOptions.workspaceRoot,
       progress: normalizedOptions.progress,
+      clearScreen: normalizedOptions.clearScreen,
       writeToFileSystem,
       // For app-shell and SSG server files are not required by users.
       // Omit these when SSR is not enabled.

--- a/packages/angular_devkit/build_angular/src/builders/application/options.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/options.ts
@@ -294,6 +294,7 @@ export async function normalizeOptions(
     namedChunks,
     budgets,
     deployUrl,
+    clearScreen,
   } = options;
 
   // Return all the normalized options
@@ -348,6 +349,7 @@ export async function normalizeOptions(
     loaderExtensions,
     jsonLogs: useJSONBuildLogs,
     colors: colors.enabled,
+    clearScreen,
   };
 }
 

--- a/packages/angular_devkit/build_angular/src/builders/application/schema.json
+++ b/packages/angular_devkit/build_angular/src/builders/application/schema.json
@@ -133,6 +133,11 @@
       },
       "default": []
     },
+    "clearScreen": {
+      "type": "boolean",
+      "default": false,
+      "description": "Automatically clear the terminal screen during rebuilds."
+    },
     "optimization": {
       "description": "Enables optimization of the build output. Including minification of scripts and styles, tree-shaking, dead-code elimination, inlining of critical CSS and fonts inlining. For more information, see https://angular.io/guide/workspace-config#optimization-configuration.",
       "default": true,


### PR DESCRIPTION

When setting `"clearScreen": true` to the appliction builder during rebuilds the terminimal screen will be cleaned.

```json
{
  "projects": {
    "my-app": {
      "projectType": "application",
      "root": "",
      "sourceRoot": "src",
      "architect": {
        "build": {
          "builder": "@angular-devkit/build-angular:application",
          "options": {
            "clearScreen": true
          }
        }
      }
    }
  }
}
```

Closes #25699

