### PR TITLE
fix(@angular-devkit/build-angular): allow `./` baseHref when using vite based server

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
@@ -87,7 +87,7 @@ export async function* serveWithVite(
   if (serverOptions.servePath === undefined && baseHref !== undefined) {
     // Remove trailing slash
     serverOptions.servePath =
-      baseHref[baseHref.length - 1] === '/' ? baseHref.slice(0, -1) : baseHref;
+      baseHref !== './' && baseHref[baseHref.length - 1] === '/' ? baseHref.slice(0, -1) : baseHref;
   }
 
   // The development server currently only supports a single locale when localizing.


### PR DESCRIPTION

Since this change https://github.com/angular/angular-cli/commit/4b3a965429bfaa6559693b2a3b69565455a75866 A warning is displayed when using `./` as a base href
```
(!) invalid "base" option: ".". The value can only be an absolute URL, "./", or an empty string.
```