### PR TITLE
fix(@angular-devkit/build-angular): ensure correct `.html` served with Vite dev-server

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
@@ -461,7 +461,8 @@ export async function setupServer(
     publicDir: false,
     esbuild: false,
     mode: 'development',
-    appType: 'mpa',
+    // We use custom as we do not rely on Vite's htmlFallbackMiddleware and indexHtmlMiddleware.
+    appType: 'custom',
     css: {
       devSourcemap: true,
     },

--- a/packages/angular_devkit/build_angular/src/tools/vite/angular-memory-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/tools/vite/angular-memory-plugin.ts
@@ -140,6 +140,23 @@ export function createAngularMemoryPlugin(options: AngularMemoryPluginOptions): 
           return;
         }
 
+        // HTML fallbacking
+        // This matches what happens in the vite html fallback middleware.
+        // ref: https://github.com/vitejs/vite/blob/main/packages/vite/src/node/server/middlewares/htmlFallback.ts#L9
+        const htmlAssetSourcePath =
+          pathname[pathname.length - 1] === '/'
+            ? // Trailing slash check for `index.html`.
+              assets.get(pathname + 'index.html')
+            : // Non-trailing slash check for fallback `.html`
+              assets.get(pathname + '.html');
+
+        if (htmlAssetSourcePath) {
+          req.url = `${server.config.base}@fs/${encodeURI(htmlAssetSourcePath)}`;
+          next();
+
+          return;
+        }
+
         // Resource files are handled directly.
         // Global stylesheets (CSS files) are currently considered resources to workaround
         // dev server sourcemap issues with stylesheets.


### PR DESCRIPTION

Prior to this commit, the Vite html fallback middleware failed to handle the in-memory assets generated by Angular CLI, resulting in incorrect fallback behavior. For instance, when an `index.html` existed as an asset under a specific path, the generated `index.html` would be served instead.

This fix addresses the issue, ensuring that the appropriate `.html` is served when using the Vite dev-server.

Closes #27044