### PR TITLE
fix(@angular-devkit/schematics): add `bun` to known package managers

### DIFF
--- a/packages/angular_devkit/schematics/tasks/package-manager/executor.ts
+++ b/packages/angular_devkit/schematics/tasks/package-manager/executor.ts
@@ -36,6 +36,13 @@ const packageManagers: { [name: string]: PackageManagerProfile } = {
   },
   'yarn': {
     commands: {
+      installAll: 'install',
+      installPackage: 'add',
+    },
+  },
+  'bun': {
+    commands: {
+      installAll: 'install',
       installPackage: 'add',
     },
   },


### PR DESCRIPTION
Fixes an issue that causes `Unknown package manager "bun".` is thrown when running `NodePackageTask` executor
