### PR TITLE
refactor(@angular-devkit/schematics): directly use magic-string in update recorder

### DIFF
--- a/packages/angular_devkit/schematics/src/tree/recorder.ts
+++ b/packages/angular_devkit/schematics/src/tree/recorder.ts
@@ -6,19 +6,34 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import MagicString from 'magic-string';
 import { ContentHasMutatedException } from '../exception/exception';
-import { UpdateBufferBase } from '../utility/update-buffer';
+import { IndexOutOfBoundException } from '../utility/update-buffer';
 import { FileEntry, UpdateRecorder } from './interface';
 
 export class UpdateRecorderBase implements UpdateRecorder {
   protected _path: string;
-  protected _original: Buffer;
-  protected _content: UpdateBufferBase;
+  protected content: MagicString;
 
-  constructor(entry: FileEntry) {
-    this._original = Buffer.from(entry.content);
-    this._content = UpdateBufferBase.create(entry.path, entry.content);
-    this._path = entry.path;
+  constructor(
+    private readonly data: Uint8Array,
+    path: string,
+    encoding = 'utf-8',
+    private readonly bom = false,
+  ) {
+    let text;
+    try {
+      text = new TextDecoder(encoding, { fatal: true, ignoreBOM: false }).decode(data);
+    } catch (e) {
+      if (e instanceof TypeError) {
+        throw new Error(`Failed to decode "${path}" as ${encoding} text.`);
+      }
+
+      throw e;
+    }
+
+    this._path = path;
+    this.content = new MagicString(text);
   }
 
   static createFromFileEntry(entry: FileEntry): UpdateRecorderBase {
@@ -28,62 +43,56 @@ export class UpdateRecorderBase implements UpdateRecorder {
 
     // Check if we're BOM.
     if (c0 == 0xef && c1 == 0xbb && c2 == 0xbf) {
-      return new UpdateRecorderBom(entry);
+      return new UpdateRecorderBase(entry.content, entry.path, 'utf-8', true);
     } else if (c0 === 0xff && c1 == 0xfe) {
-      return new UpdateRecorderBom(entry);
+      return new UpdateRecorderBase(entry.content, entry.path, 'utf-16le', true);
     } else if (c0 === 0xfe && c1 == 0xff) {
-      return new UpdateRecorderBom(entry);
+      return new UpdateRecorderBase(entry.content, entry.path, 'utf-16be', true);
     }
 
-    return new UpdateRecorderBase(entry);
+    return new UpdateRecorderBase(entry.content, entry.path);
   }
 
   get path() {
     return this._path;
   }
 
+  protected _assertIndex(index: number) {
+    if (index < 0 || index > this.content.original.length) {
+      throw new IndexOutOfBoundException(index, 0, this.content.original.length);
+    }
+  }
+
   // These just record changes.
   insertLeft(index: number, content: Buffer | string): UpdateRecorder {
-    this._content.insertLeft(index, typeof content == 'string' ? Buffer.from(content) : content);
+    this._assertIndex(index);
+    this.content.appendLeft(index, content.toString());
 
     return this;
   }
 
   insertRight(index: number, content: Buffer | string): UpdateRecorder {
-    this._content.insertRight(index, typeof content == 'string' ? Buffer.from(content) : content);
+    this._assertIndex(index);
+    this.content.appendRight(index, content.toString());
 
     return this;
   }
 
   remove(index: number, length: number): UpdateRecorder {
-    this._content.remove(index, length);
+    this._assertIndex(index);
+    this.content.remove(index, index + length);
 
     return this;
   }
 
   apply(content: Buffer): Buffer {
-    if (!content.equals(this._content.original)) {
+    if (!content.equals(this.data)) {
       throw new ContentHasMutatedException(this.path);
     }
 
-    return this._content.generate();
-  }
-}
+    // Schematics only support writing UTF-8 text
+    const result = Buffer.from((this.bom ? '\uFEFF' : '') + this.content.toString(), 'utf-8');
 
-export class UpdateRecorderBom extends UpdateRecorderBase {
-  constructor(entry: FileEntry, private _delta = 1) {
-    super(entry);
-  }
-
-  override insertLeft(index: number, content: Buffer | string) {
-    return super.insertLeft(index + this._delta, content);
-  }
-
-  override insertRight(index: number, content: Buffer | string) {
-    return super.insertRight(index + this._delta, content);
-  }
-
-  override remove(index: number, length: number) {
-    return super.remove(index + this._delta, length);
+    return result;
   }
 }

--- a/packages/angular_devkit/schematics/src/tree/recorder_spec.ts
+++ b/packages/angular_devkit/schematics/src/tree/recorder_spec.ts
@@ -8,14 +8,14 @@
 
 import { normalize } from '@angular-devkit/core';
 import { SimpleFileEntry } from './entry';
-import { UpdateRecorderBase, UpdateRecorderBom } from './recorder';
+import { UpdateRecorderBase } from './recorder';
 
 describe('UpdateRecorderBase', () => {
   it('works for simple files', () => {
     const buffer = Buffer.from('Hello World');
     const entry = new SimpleFileEntry(normalize('/some/path'), buffer);
 
-    const recorder = new UpdateRecorderBase(entry);
+    const recorder = UpdateRecorderBase.createFromFileEntry(entry);
     recorder.insertLeft(5, ' beautiful');
     const result = recorder.apply(buffer);
     expect(result.toString()).toBe('Hello beautiful World');
@@ -25,7 +25,7 @@ describe('UpdateRecorderBase', () => {
     const buffer = Buffer.from('Hello World');
     const entry = new SimpleFileEntry(normalize('/some/path'), buffer);
 
-    const recorder = new UpdateRecorderBase(entry);
+    const recorder = UpdateRecorderBase.createFromFileEntry(entry);
     recorder.insertRight(5, ' beautiful');
     const result = recorder.apply(buffer);
     expect(result.toString()).toBe('Hello beautiful World');
@@ -35,7 +35,7 @@ describe('UpdateRecorderBase', () => {
     const buffer = Buffer.from('Hello beautiful World');
     const entry = new SimpleFileEntry(normalize('/some/path'), buffer);
 
-    const recorder = new UpdateRecorderBase(entry);
+    const recorder = UpdateRecorderBase.createFromFileEntry(entry);
     recorder.remove(6, 9);
     recorder.insertRight(6, 'amazing');
     recorder.insertRight(15, ' and fantastic');
@@ -46,13 +46,11 @@ describe('UpdateRecorderBase', () => {
   it('can create the proper recorder', () => {
     const e = new SimpleFileEntry(normalize('/some/path'), Buffer.from('hello'));
     expect(UpdateRecorderBase.createFromFileEntry(e) instanceof UpdateRecorderBase).toBe(true);
-    expect(UpdateRecorderBase.createFromFileEntry(e) instanceof UpdateRecorderBom).toBe(false);
   });
 
   it('can create the proper recorder (bom)', () => {
     const eBom = new SimpleFileEntry(normalize('/some/path'), Buffer.from('\uFEFFhello'));
     expect(UpdateRecorderBase.createFromFileEntry(eBom) instanceof UpdateRecorderBase).toBe(true);
-    expect(UpdateRecorderBase.createFromFileEntry(eBom) instanceof UpdateRecorderBom).toBe(true);
   });
 
   it('supports empty files', () => {
@@ -71,7 +69,7 @@ describe('UpdateRecorderBom', () => {
     const buffer = Buffer.from('\uFEFFHello World');
     const entry = new SimpleFileEntry(normalize('/some/path'), buffer);
 
-    const recorder = new UpdateRecorderBom(entry);
+    const recorder = UpdateRecorderBase.createFromFileEntry(entry);
     recorder.insertLeft(5, ' beautiful');
     const result = recorder.apply(buffer);
     expect(result.toString()).toBe('\uFEFFHello beautiful World');


### PR DESCRIPTION
The schematics `UpdateRecorder` now uses the `magic-string` library directly instead of delegating to another class (`UpdateBuffer`) which now effectively only wraps the `magic-string`. This also allows for improved BOM handling and repeat conversion of strings to and from `Buffer` instances.