### PR TITLE
refactor(@schematics/angular): correct several comment typos

### DIFF
--- a/packages/schematics/angular/private/standalone.ts
+++ b/packages/schematics/angular/private/standalone.ts
@@ -169,7 +169,7 @@ export function addModuleImportToStandaloneBootstrap(
  * @param functionName Name of the function that should be called.
  * @param importPath Path from which to import the function.
  * @param args Arguments to use when calling the function.
- * @returns The file path that the provider was added to.
+ * @return The file path that the provider was added to.
  * @deprecated Private utility that will be removed. Use `addRootImport` or `addRootProvider` from
  * `@schematics/angular/utility` instead.
  */

--- a/packages/schematics/angular/utility/standalone/code_block.ts
+++ b/packages/schematics/angular/utility/standalone/code_block.ts
@@ -20,7 +20,7 @@ export interface PendingCode {
   imports: PendingImports;
 }
 
-/** Map keeping track of imports and aliases under which they're referred to in an expresion. */
+/** Map keeping track of imports and aliases under which they're referred to in an expression. */
 type PendingImports = Map<string, Map<string, string>>;
 
 /** Counter used to generate unique IDs. */


### PR DESCRIPTION
There were several typos in the comments for the Angular schematics utilities.
