### PR TITLE
fix(@angular-devkit/build-angular): downgrade copy-webpack-plugin to workaround Node.js support issue

### DIFF
--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -27,7 +27,7 @@
     "babel-loader": "9.1.3",
     "babel-plugin-istanbul": "6.1.1",
     "browserslist": "^4.21.5",
-    "copy-webpack-plugin": "12.0.2",
+    "copy-webpack-plugin": "11.0.0",
     "critters": "0.0.20",
     "css-loader": "6.10.0",
     "esbuild-wasm": "0.20.0",

--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,13 @@
   "dependencyDashboard": true,
   "schedule": ["after 10:00pm every weekday", "before 4:00am every weekday", "every weekend"],
   "baseBranches": ["main"],
-  "ignoreDeps": ["@types/node", "aspect_bazel_lib", "rules_pkg", "less-loader"],
+  "ignoreDeps": [
+    "@types/node",
+    "aspect_bazel_lib",
+    "rules_pkg",
+    "less-loader",
+    "copy-webpack-plugin"
+  ],
   "includePaths": [
     "WORKSPACE",
     "package.json",

--- a/yarn.lock
+++ b/yarn.lock
@@ -131,8 +131,7 @@
     tslib "^2.3.0"
 
 "@angular/bazel@https://github.com/angular/bazel-builds.git#55bd95c99e8fed8fbb2c2a5c052f6b25d0da849f":
-  version "17.3.0-next.0+sha-abf6371"
-  uid "55bd95c99e8fed8fbb2c2a5c052f6b25d0da849f"
+  version "17.3.0-next.0"
   resolved "https://github.com/angular/bazel-builds.git#55bd95c99e8fed8fbb2c2a5c052f6b25d0da849f"
   dependencies:
     "@microsoft/api-extractor" "^7.24.2"
@@ -149,7 +148,6 @@
 
 "@angular/build-tooling@https://github.com/angular/dev-infra-private-build-tooling-builds.git#7c4cf003cb4ac849986beaa243d7e85a893612f2":
   version "0.0.0-c83e99a12397014162531ca125c94549db55dd84"
-  uid "7c4cf003cb4ac849986beaa243d7e85a893612f2"
   resolved "https://github.com/angular/dev-infra-private-build-tooling-builds.git#7c4cf003cb4ac849986beaa243d7e85a893612f2"
   dependencies:
     "@angular-devkit/build-angular" "17.2.0-next.0"
@@ -317,7 +315,6 @@
 
 "@angular/ng-dev@https://github.com/angular/dev-infra-private-ng-dev-builds.git#c21f93acb618bcaeda52a8065e7b6c9242def182":
   version "0.0.0-c83e99a12397014162531ca125c94549db55dd84"
-  uid c21f93acb618bcaeda52a8065e7b6c9242def182
   resolved "https://github.com/angular/dev-infra-private-ng-dev-builds.git#c21f93acb618bcaeda52a8065e7b6c9242def182"
   dependencies:
     "@yarnpkg/lockfile" "^1.1.0"
@@ -6030,6 +6027,18 @@ copy-anything@^2.0.1:
   dependencies:
     is-what "^3.14.1"
 
+copy-webpack-plugin@11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/copy-webpack-plugin/-/copy-webpack-plugin-11.0.0.tgz#96d4dbdb5f73d02dd72d0528d1958721ab72e04a"
+  integrity sha512-fX2MWpamkW0hZxMEg0+mYnA40LTosOSa5TqZ9GYIBzyJa9C3QUaMPSE2xAi/buNr8u89SfD9wHSQVBzrRa/SOQ==
+  dependencies:
+    fast-glob "^3.2.11"
+    glob-parent "^6.0.1"
+    globby "^13.1.1"
+    normalize-path "^3.0.0"
+    schema-utils "^4.0.0"
+    serialize-javascript "^6.0.0"
+
 copy-webpack-plugin@12.0.2:
   version "12.0.2"
   resolved "https://registry.yarnpkg.com/copy-webpack-plugin/-/copy-webpack-plugin-12.0.2.tgz#935e57b8e6183c82f95bd937df658a59f6a2da28"
@@ -7138,7 +7147,7 @@ fast-fifo@^1.1.0, fast-fifo@^1.2.0:
   resolved "https://registry.yarnpkg.com/fast-fifo/-/fast-fifo-1.3.2.tgz#286e31de96eb96d38a97899815740ba2a4f3640c"
   integrity sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==
 
-fast-glob@3.3.2, fast-glob@^3.2.9, fast-glob@^3.3.1, fast-glob@^3.3.2:
+fast-glob@3.3.2, fast-glob@^3.2.11, fast-glob@^3.2.9, fast-glob@^3.3.0, fast-glob@^3.3.1, fast-glob@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.2.tgz#a904501e57cfdd2ffcded45e99a54fef55e46129"
   integrity sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==
@@ -7674,6 +7683,17 @@ globby@^11.0.1, globby@^11.1.0:
     ignore "^5.2.0"
     merge2 "^1.4.1"
     slash "^3.0.0"
+
+globby@^13.1.1:
+  version "13.2.2"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-13.2.2.tgz#63b90b1bf68619c2135475cbd4e71e66aa090592"
+  integrity sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==
+  dependencies:
+    dir-glob "^3.0.1"
+    fast-glob "^3.3.0"
+    ignore "^5.2.4"
+    merge2 "^1.4.1"
+    slash "^4.0.0"
 
 globby@^14.0.0:
   version "14.0.1"
@@ -11900,7 +11920,6 @@ sass@1.70.0, sass@^1.69.5:
 
 "sauce-connect-proxy@https://saucelabs.com/downloads/sc-4.9.1-linux.tar.gz":
   version "0.0.0"
-  uid "9310bc860f7870a1f872b11c4dc6073a1ad34e5e"
   resolved "https://saucelabs.com/downloads/sc-4.9.1-linux.tar.gz#9310bc860f7870a1f872b11c4dc6073a1ad34e5e"
 
 saucelabs@^1.5.0:
@@ -12033,7 +12052,7 @@ send@0.18.0, send@^0.18.0:
     range-parser "~1.2.1"
     statuses "2.0.1"
 
-serialize-javascript@^6.0.1, serialize-javascript@^6.0.2:
+serialize-javascript@^6.0.0, serialize-javascript@^6.0.1, serialize-javascript@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.2.tgz#defa1e055c83bf6d59ea805d8da862254eb6a6c2"
   integrity sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==
@@ -12193,6 +12212,11 @@ slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
+
+slash@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-4.0.0.tgz#2422372176c4c6c5addb5e2ada885af984b396a7"
+  integrity sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==
 
 slash@^5.1.0:
   version "5.1.0"


### PR DESCRIPTION
The `copy-webpack-plugin@12` package has a dependency on the `globby@14` package. The recently released `globby@14.0.1` uses the `merge-streams@2.1.0` package which requires a minimum Node.js version higher than the officially supported 18.13 for the Angular CLI. Due to both `globby` and `merge-streams` being transitive dependencies in end-user projects, the Angular CLI cannot directly control the package versions. However, `copy-webpack-plugin@11` uses `globby@13` which is not affected by the Node.js version problem. To workaround the Node.js compatibility problem, `copy-webpack-plugin` has been downgraded to version 11.0.0 which is the latest version in the 11 major for the package. The `copy-webpack-plugin` is only used with the Webpack-based builders when in watch mode. From a review of the commit history between 11.0.0 and 12.0.2 (latest at the time of this commit), it appears the only notable changes are several performance improvements and the major version update of `globby`.