### PR TITLE
feat(@angular-devkit/build-angular): add `deployUrl` to application builder

### DIFF
--- a/goldens/public-api/angular_devkit/build_angular/index.md
+++ b/goldens/public-api/angular_devkit/build_angular/index.md
@@ -36,6 +36,7 @@ export interface ApplicationBuilderOptions {
         [key: string]: string;
     };
     deleteOutputPath?: boolean;
+    deployUrl?: string;
     externalDependencies?: string[];
     extractLicenses?: boolean;
     fileReplacements?: FileReplacement_2[];
@@ -94,7 +95,6 @@ export interface BrowserBuilderOptions {
     commonChunk?: boolean;
     crossOrigin?: CrossOrigin;
     deleteOutputPath?: boolean;
-    // @deprecated
     deployUrl?: string;
     extractLicenses?: boolean;
     fileReplacements?: FileReplacement[];
@@ -351,7 +351,6 @@ export interface ServerBuilderOptions {
     assets?: AssetPattern_4[];
     buildOptimizer?: boolean;
     deleteOutputPath?: boolean;
-    // @deprecated
     deployUrl?: string;
     externalDependencies?: string[];
     extractLicenses?: boolean;

--- a/packages/angular_devkit/build_angular/src/builders/application/options.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/options.ts
@@ -65,11 +65,6 @@ interface InternalOptions {
    * This is only used by the development server which currently only supports a single locale per build.
    */
   forceI18nFlatOutput?: boolean;
-
-  /**
-   * Allows for usage of the deprecated `deployUrl` option with the compatibility builder `browser-esbuild`.
-   */
-  deployUrl?: string;
 }
 
 /** Full set of options for `application` builder. */
@@ -345,7 +340,7 @@ export async function normalizeOptions(
     i18nOptions,
     namedChunks,
     budgets: budgets?.length ? budgets : undefined,
-    publicPath: deployUrl ? deployUrl : undefined,
+    publicPath: deployUrl,
     plugins: extensions?.codePlugins?.length ? extensions?.codePlugins : undefined,
     loaderExtensions,
     jsonLogs: useJSONBuildLogs,

--- a/packages/angular_devkit/build_angular/src/builders/application/schema.json
+++ b/packages/angular_devkit/build_angular/src/builders/application/schema.json
@@ -33,6 +33,10 @@
       "type": "string",
       "description": "The full path for the TypeScript configuration file, relative to the current workspace."
     },
+    "deployUrl": {
+      "type": "string",
+      "description": "Customize the base path for the URLs of resources in 'index.html' and component stylesheets. This option is only necessary for specific deployment scenarios, such as with Angular Elements or when utilizing different CDN locations."
+    },
     "scripts": {
       "description": "Global scripts to be included in the build.",
       "type": "array",

--- a/packages/angular_devkit/build_angular/src/builders/application/tests/options/deploy-url_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/tests/options/deploy-url_spec.ts
@@ -6,10 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { buildEsbuildBrowser } from '../../index';
-import { BASE_OPTIONS, BROWSER_BUILDER_INFO, describeBuilder } from '../setup';
+import { buildApplication } from '../../index';
+import { APPLICATION_BUILDER_INFO, BASE_OPTIONS, describeBuilder } from '../setup';
 
-describeBuilder(buildEsbuildBrowser, BROWSER_BUILDER_INFO, (harness) => {
+describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
   describe('Option: "deployUrl"', () => {
     beforeEach(async () => {
       // Add a global stylesheet to test link elements
@@ -32,7 +32,7 @@ describeBuilder(buildEsbuildBrowser, BROWSER_BUILDER_INFO, (harness) => {
       const { result } = await harness.executeOnce();
       expect(result?.success).toBe(true);
       harness
-        .expectFile('dist/index.html')
+        .expectFile('dist/browser/index.html')
         .content.toEqual(
           `<html><head><base href="/"><link rel="stylesheet" href="deployUrl/styles.css"></head>` +
             `<body><app-root></app-root>` +
@@ -50,7 +50,7 @@ describeBuilder(buildEsbuildBrowser, BROWSER_BUILDER_INFO, (harness) => {
       const { result } = await harness.executeOnce();
       expect(result?.success).toBe(true);
       harness
-        .expectFile('dist/index.html')
+        .expectFile('dist/browser/index.html')
         .content.toEqual(
           `<html><head><base href="/"><link rel="stylesheet" href="https://example.com/some/path/styles.css"></head>` +
             `<body><app-root></app-root>` +
@@ -74,7 +74,7 @@ describeBuilder(buildEsbuildBrowser, BROWSER_BUILDER_INFO, (harness) => {
       expect(result?.success).toBeTrue();
 
       harness
-        .expectFile('dist/main.js')
+        .expectFile('dist/browser/main.js')
         .content.toContain('background-image: url("https://example.com/some/path/media/test.svg")');
     });
   });

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/schema.json
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/schema.json
@@ -277,8 +277,7 @@
     },
     "deployUrl": {
       "type": "string",
-      "description": "URL where files will be deployed.",
-      "x-deprecated": "Use \"baseHref\" option, \"APP_BASE_HREF\" DI token or a combination of both instead. For more information, see https://angular.io/guide/deployment#the-deploy-url."
+      "description": "Customize the base path for the URLs of resources in 'index.html' and component stylesheets. This option is only necessary for specific deployment scenarios, such as with Angular Elements or when utilizing different CDN locations."
     },
     "verbose": {
       "type": "boolean",

--- a/packages/angular_devkit/build_angular/src/builders/browser/schema.json
+++ b/packages/angular_devkit/build_angular/src/builders/browser/schema.json
@@ -270,8 +270,7 @@
     },
     "deployUrl": {
       "type": "string",
-      "description": "URL where files will be deployed.",
-      "x-deprecated": "Use \"baseHref\" option, \"APP_BASE_HREF\" DI token or a combination of both instead. For more information, see https://angular.io/guide/deployment#the-deploy-url."
+      "description": "Customize the base path for the URLs of resources in 'index.html' and component stylesheets. This option is only necessary for specific deployment scenarios, such as with Angular Elements or when utilizing different CDN locations."
     },
     "verbose": {
       "type": "boolean",

--- a/packages/angular_devkit/build_angular/src/builders/server/schema.json
+++ b/packages/angular_devkit/build_angular/src/builders/server/schema.json
@@ -121,8 +121,7 @@
     },
     "deployUrl": {
       "type": "string",
-      "description": "URL where files will be deployed.",
-      "x-deprecated": "Use \"baseHref\" browser builder option, \"APP_BASE_HREF\" DI token or a combination of both instead. For more information, see https://angular.io/guide/deployment#the-deploy-url."
+      "description": "Customize the base path for the URLs of resources in 'index.html' and component stylesheets. This option is only necessary for specific deployment scenarios, such as with Angular Elements or when utilizing different CDN locations."
     },
     "vendorChunk": {
       "type": "boolean",

--- a/packages/schematics/angular/migrations/update-17/use-application-builder.ts
+++ b/packages/schematics/angular/migrations/update-17/use-application-builder.ts
@@ -7,13 +7,7 @@
  */
 
 import { workspaces } from '@angular-devkit/core';
-import {
-  Rule,
-  SchematicContext,
-  SchematicsException,
-  chain,
-  externalSchematic,
-} from '@angular-devkit/schematics';
+import { Rule, SchematicsException, chain, externalSchematic } from '@angular-devkit/schematics';
 import { dirname, join } from 'node:path/posix';
 import { JSONFile } from '../../utility/json-file';
 import { TreeWorkspaceHost, allTargetOptions, getWorkspace } from '../../utility/workspace';
@@ -52,11 +46,6 @@ export default function (): Rule {
       const hasServerTarget = project.targets.has('server');
 
       for (const [, options] of allTargetOptions(buildTarget, false)) {
-        // Show warnings for using no longer supported options
-        if (usesNoLongerSupportedOptions(options, context, name)) {
-          continue;
-        }
-
         if (options['index'] === '') {
           options['index'] = false;
         }
@@ -102,7 +91,6 @@ export default function (): Rule {
         }
 
         // Delete removed options
-        delete options['deployUrl'];
         delete options['vendorChunk'];
         delete options['commonChunk'];
         delete options['resourcesOutputPath'];
@@ -203,20 +191,4 @@ export default function (): Rule {
 
     return chain(rules);
   };
-}
-
-function usesNoLongerSupportedOptions(
-  { deployUrl, resourcesOutputPath }: Record<string, unknown>,
-  context: SchematicContext,
-  projectName: string,
-): boolean {
-  let hasUsage = false;
-  if (typeof deployUrl === 'string') {
-    hasUsage = true;
-    context.logger.warn(
-      `Skipping migration for project "${projectName}". "deployUrl" option is not available in the application builder.`,
-    );
-  }
-
-  return hasUsage;
 }


### PR DESCRIPTION
This commit adds the deployUrl option ot the application builder.

Closes #26411
