### PR TITLE
fix(@angular-devkit/build-angular): avoid build performance hit when using custom loader

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/esbuild/application-code-bundle.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/application-code-bundle.ts
@@ -65,9 +65,8 @@ export function createBrowserCodeBundleOptions(
   }
 
   if (options.externalPackages) {
-    // Package files affected by a customized loader should not be implicitly marked as external
+    // Package files affected by a customized plugin should not be implicitly marked as external
     if (
-      options.loaderExtensions ||
       options.plugins ||
       typeof options.externalPackages === 'object'
     ) {


### PR DESCRIPTION
loaders in esbuild aren't really custom code. You can only choose from the loaders that esbuild provides. So I doubt they require this `externalPackagesPlugin` which comes at a pretty steep cost of 1 second per 1500 `import` statements your project has on every build and watch rebuild.

fixes https://github.com/angular/angular-cli/issues/27116
followup to https://github.com/angular/angular-cli/pull/26923

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the new behavior that. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
