### PR TITLE
fix(@angular-devkit/build-angular): allow `mts` and `cts` file replac…

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/application/schema.json
+++ b/packages/angular_devkit/build_angular/src/builders/application/schema.json
@@ -572,11 +572,11 @@
       "properties": {
         "replace": {
           "type": "string",
-          "pattern": "\\.(([cm]?j|t)sx?|json)$"
+          "pattern": "\\.(([cm]?[jt])sx?|json)$"
         },
         "with": {
           "type": "string",
-          "pattern": "\\.(([cm]?j|t)sx?|json)$"
+          "pattern": "\\.(([cm]?[jt])sx?|json)$"
         }
       },
       "additionalProperties": false,

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/schema.json
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/schema.json
@@ -483,11 +483,11 @@
       "properties": {
         "replace": {
           "type": "string",
-          "pattern": "\\.(([cm]?j|t)sx?|json)$"
+          "pattern": "\\.(([cm]?[jt])sx?|json)$"
         },
         "with": {
           "type": "string",
-          "pattern": "\\.(([cm]?j|t)sx?|json)$"
+          "pattern": "\\.(([cm]?[jt])sx?|json)$"
         }
       },
       "additionalProperties": false,

--- a/packages/angular_devkit/build_angular/src/builders/browser/schema.json
+++ b/packages/angular_devkit/build_angular/src/builders/browser/schema.json
@@ -473,11 +473,11 @@
           "properties": {
             "src": {
               "type": "string",
-              "pattern": "\\.(([cm]?j|t)sx?|json)$"
+              "pattern": "\\.(([cm]?[jt])sx?|json)$"
             },
             "replaceWith": {
               "type": "string",
-              "pattern": "\\.(([cm]?j|t)sx?|json)$"
+              "pattern": "\\.(([cm]?[jt])sx?|json)$"
             }
           },
           "additionalProperties": false,
@@ -488,11 +488,11 @@
           "properties": {
             "replace": {
               "type": "string",
-              "pattern": "\\.(([cm]?j|t)sx?|json)$"
+              "pattern": "\\.(([cm]?[jt])sx?|json)$"
             },
             "with": {
               "type": "string",
-              "pattern": "\\.(([cm]?j|t)sx?|json)$"
+              "pattern": "\\.(([cm]?[jt])sx?|json)$"
             }
           },
           "additionalProperties": false,

--- a/packages/angular_devkit/build_angular/src/builders/server/schema.json
+++ b/packages/angular_devkit/build_angular/src/builders/server/schema.json
@@ -270,11 +270,11 @@
           "properties": {
             "src": {
               "type": "string",
-              "pattern": "\\.(([cm]?j|t)sx?|json)$"
+              "pattern": "\\.(([cm]?[jt])sx?|json)$"
             },
             "replaceWith": {
               "type": "string",
-              "pattern": "\\.(([cm]?j|t)sx?|json)$"
+              "pattern": "\\.(([cm]?[jt])sx?|json)$"
             }
           },
           "additionalProperties": false,
@@ -285,11 +285,11 @@
           "properties": {
             "replace": {
               "type": "string",
-              "pattern": "\\.(([cm]?j|t)sx?|json)$"
+              "pattern": "\\.(([cm]?[jt])sx?|json)$"
             },
             "with": {
               "type": "string",
-              "pattern": "\\.(([cm]?j|t)sx?|json)$"
+              "pattern": "\\.(([cm]?[jt])sx?|json)$"
             }
           },
           "additionalProperties": false,


### PR DESCRIPTION
…ement

Updates the `fileReplacement` pattern to allow `.mts` and `.cts` files. This enables support for TypeScript files with explicit ESM support.

Closes #27124

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Replacing `cts`, `ctsx`, `mts`, `mtsx` files is rejected by schema validation while these files are supported by the build script.

Issue Number: #27124

## What is the new behavior?

<!-- Please describe the new behavior that. -->

`.cts` and `.mts` files are allowed to be replaced.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
