### PR TITLE
fix(@angular-devkit/build-angular): provide Vite client code source map when loading

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/vite/angular-memory-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/tools/vite/angular-memory-plugin.ts
@@ -68,13 +68,16 @@ export function createAngularMemoryPlugin(options: AngularMemoryPluginOptions): 
         return join(virtualProjectRoot, source);
       }
     },
-    load(id) {
+    async load(id) {
       const [file] = id.split('?', 1);
       const relativeFile = '/' + normalizePath(relative(virtualProjectRoot, file));
       const codeContents = outputFiles.get(relativeFile)?.contents;
       if (codeContents === undefined) {
         if (relativeFile.endsWith('/node_modules/vite/dist/client/client.mjs')) {
-          return loadViteClientCode(file);
+          return {
+            code: await loadViteClientCode(file),
+            map: await readFile(file + '.map', 'utf-8'),
+          };
         }
 
         return;


### PR DESCRIPTION
The sourcemap for the Vite client code was previously not being loaded along with the actual code. This could lead to browser 404 console messages when debugging applications.

closes #27136