### PR TITLE
fix(@angular-devkit/build-angular): avoid implicit CSS file extensions when resolving

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/esbuild/stylesheets/bundle-options.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/stylesheets/bundle-options.ts
@@ -84,6 +84,9 @@ export function createStylesheetBundleOptions(
     publicPath: options.publicPath,
     conditions: ['style', 'sass', 'less'],
     mainFields: ['style', 'sass'],
+    // Unlike JS, CSS does not have implicit file extensions in the general case.
+    // Preprocessor specific behavior is handled in each stylesheet language plugin.
+    resolveExtensions: [],
     plugins,
   };
 }


### PR DESCRIPTION
Unlike the non-ESM Node.js resolution for JS files, CSS does not have the concept of implicit file extensions. To avoid incorrectly resolving a file as CSS, stylesheet bundling no longer attempts to resolve implicit extensions. Preprocessors, such as Sass, contain logic internally that handles any specific resolution cases for their respective preprocessor and such behavior is unaffected.

Closes #27147