### PR TITLE
Update CSS/Sass import/use specifiers in application migration

### DIFF
--- a/packages/schematics/angular/migrations/update-17/css-import-lexer.ts
+++ b/packages/schematics/angular/migrations/update-17/css-import-lexer.ts
@@ -1,0 +1,129 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * Determines if a unicode code point is a CSS whitespace character.
+ * @param code The unicode code point to test.
+ * @returns true, if the code point is CSS whitespace; false, otherwise.
+ */
+function isWhitespace(code: number): boolean {
+  // Based on https://www.w3.org/TR/css-syntax-3/#whitespace
+  switch (code) {
+    case 0x0009: // tab
+    case 0x0020: // space
+    case 0x000a: // line feed
+    case 0x000c: // form feed
+    case 0x000d: // carriage return
+      return true;
+    default:
+      return false;
+  }
+}
+
+/**
+ * Scans a CSS or Sass file and locates all valid import/use directive values as defined by the
+ * syntax specification.
+ * @param contents A string containing a CSS or Sass file to scan.
+ * @returns An iterable that yields each CSS directive value found.
+ */
+export function* findImports(
+  contents: string,
+  sass: boolean,
+): Iterable<{ start: number; end: number; specifier: string; fromUse?: boolean }> {
+  yield* find(contents, '@import ');
+  if (sass) {
+    for (const result of find(contents, '@use ')) {
+      yield { ...result, fromUse: true };
+    }
+  }
+}
+
+/**
+ * Scans a CSS or Sass file and locates all valid function/directive values as defined by the
+ * syntax specification.
+ * @param contents A string containing a CSS or Sass file to scan.
+ * @param prefix The prefix to start a valid segment.
+ * @returns An iterable that yields each CSS url function value found.
+ */
+function* find(
+  contents: string,
+  prefix: string,
+): Iterable<{ start: number; end: number; specifier: string }> {
+  let pos = 0;
+  let width = 1;
+  let current = -1;
+  const next = () => {
+    pos += width;
+    current = contents.codePointAt(pos) ?? -1;
+    width = current > 0xffff ? 2 : 1;
+
+    return current;
+  };
+
+  // Based on https://www.w3.org/TR/css-syntax-3/#consume-ident-like-token
+  while ((pos = contents.indexOf(prefix, pos)) !== -1) {
+    // Set to position of the last character in prefix
+    pos += prefix.length - 1;
+    width = 1;
+
+    // Consume all leading whitespace
+    while (isWhitespace(next())) {
+      /* empty */
+    }
+
+    // Initialize URL state
+    const url = { start: pos, end: -1, specifier: '' };
+    let complete = false;
+
+    // If " or ', then consume the value as a string
+    if (current === 0x0022 || current === 0x0027) {
+      const ending = current;
+      // Based on https://www.w3.org/TR/css-syntax-3/#consume-string-token
+      while (!complete) {
+        switch (next()) {
+          case -1: // EOF
+            return;
+          case 0x000a: // line feed
+          case 0x000c: // form feed
+          case 0x000d: // carriage return
+            // Invalid
+            complete = true;
+            break;
+          case 0x005c: // \ -- character escape
+            // If not EOF or newline, add the character after the escape
+            switch (next()) {
+              case -1:
+                return;
+              case 0x000a: // line feed
+              case 0x000c: // form feed
+              case 0x000d: // carriage return
+                // Skip when inside a string
+                break;
+              default:
+                // TODO: Handle hex escape codes
+                url.specifier += String.fromCodePoint(current);
+                break;
+            }
+            break;
+          case ending:
+            // Full string position should include the quotes for replacement
+            url.end = pos + 1;
+            complete = true;
+            yield url;
+            break;
+          default:
+            url.specifier += String.fromCodePoint(current);
+            break;
+        }
+      }
+
+      next();
+      continue;
+    }
+  }
+}

--- a/packages/schematics/angular/migrations/update-17/use-application-builder.ts
+++ b/packages/schematics/angular/migrations/update-17/use-application-builder.ts
@@ -6,17 +6,154 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { workspaces } from '@angular-devkit/core';
-import { Rule, SchematicsException, chain, externalSchematic } from '@angular-devkit/schematics';
+import type { workspaces } from '@angular-devkit/core';
+import {
+  Rule,
+  SchematicContext,
+  SchematicsException,
+  Tree,
+  chain,
+  externalSchematic,
+} from '@angular-devkit/schematics';
 import { dirname, join } from 'node:path/posix';
 import { JSONFile } from '../../utility/json-file';
-import { TreeWorkspaceHost, allTargetOptions, getWorkspace } from '../../utility/workspace';
+import { allTargetOptions, updateWorkspace } from '../../utility/workspace';
 import { Builders, ProjectType } from '../../utility/workspace-models';
 
-export default function (): Rule {
-  return async (tree, context) => {
+function* updateBuildTarget(
+  projectName: string,
+  buildTarget: workspaces.TargetDefinition,
+  serverTarget: workspaces.TargetDefinition | undefined,
+  tree: Tree,
+  context: SchematicContext,
+): Iterable<Rule> {
+  // Update builder target and options
+  buildTarget.builder = Builders.Application;
+
+  for (const [, options] of allTargetOptions(buildTarget, false)) {
+    // Show warnings for using no longer supported options
+    if (usesNoLongerSupportedOptions(options, context, projectName)) {
+      continue;
+    }
+
+    if (options['index'] === '') {
+      options['index'] = false;
+    }
+
+    // Rename and transform options
+    options['browser'] = options['main'];
+    if (serverTarget && typeof options['browser'] === 'string') {
+      options['server'] = dirname(options['browser']) + '/main.server.ts';
+    }
+    options['serviceWorker'] = options['ngswConfigPath'] ?? options['serviceWorker'];
+
+    if (typeof options['polyfills'] === 'string') {
+      options['polyfills'] = [options['polyfills']];
+    }
+
+    let outputPath = options['outputPath'];
+    if (typeof outputPath === 'string') {
+      if (!/\/browser\/?$/.test(outputPath)) {
+        // TODO: add prompt.
+        context.logger.warn(
+          `The output location of the browser build has been updated from "${outputPath}" to ` +
+            `"${join(outputPath, 'browser')}". ` +
+            'You might need to adjust your deployment pipeline or, as an alternative, ' +
+            'set outputPath.browser to "" in order to maintain the previous functionality.',
+        );
+      } else {
+        outputPath = outputPath.replace(/\/browser\/?$/, '');
+      }
+
+      options['outputPath'] = {
+        base: outputPath,
+      };
+
+      if (typeof options['resourcesOutputPath'] === 'string') {
+        const media = options['resourcesOutputPath'].replaceAll('/', '');
+        if (media && media !== 'media') {
+          options['outputPath'] = {
+            base: outputPath,
+            media,
+          };
+        }
+      }
+    }
+
+    // Delete removed options
+    delete options['deployUrl'];
+    delete options['vendorChunk'];
+    delete options['commonChunk'];
+    delete options['resourcesOutputPath'];
+    delete options['buildOptimizer'];
+    delete options['main'];
+    delete options['ngswConfigPath'];
+  }
+
+  // Merge browser and server tsconfig
+  if (serverTarget) {
+    const browserTsConfig = buildTarget.options?.tsConfig;
+    const serverTsConfig = serverTarget.options?.tsConfig;
+
+    if (typeof browserTsConfig !== 'string') {
+      throw new SchematicsException(
+        `Cannot update project "${projectName}" to use the application builder` +
+          ` as the browser tsconfig cannot be located.`,
+      );
+    }
+
+    if (typeof serverTsConfig !== 'string') {
+      throw new SchematicsException(
+        `Cannot update project "${projectName}" to use the application builder` +
+          ` as the server tsconfig cannot be located.`,
+      );
+    }
+
+    const browserJson = new JSONFile(tree, browserTsConfig);
+    const serverJson = new JSONFile(tree, serverTsConfig);
+
+    const filesPath = ['files'];
+
+    const files = new Set([
+      ...((browserJson.get(filesPath) as string[] | undefined) ?? []),
+      ...((serverJson.get(filesPath) as string[] | undefined) ?? []),
+    ]);
+
+    // Server file will be added later by the means of the ssr schematic.
+    files.delete('server.ts');
+
+    browserJson.modify(filesPath, Array.from(files));
+
+    const typesPath = ['compilerOptions', 'types'];
+    browserJson.modify(
+      typesPath,
+      Array.from(
+        new Set([
+          ...((browserJson.get(typesPath) as string[] | undefined) ?? []),
+          ...((serverJson.get(typesPath) as string[] | undefined) ?? []),
+        ]),
+      ),
+    );
+
+    // Delete server tsconfig
+    yield deleteFile(serverTsConfig);
+  }
+
+  // Update server file
+  const ssrMainFile = serverTarget?.options?.['main'];
+  if (typeof ssrMainFile === 'string') {
+    yield deleteFile(ssrMainFile);
+
+    yield externalSchematic('@schematics/angular', 'ssr', {
+      project: projectName,
+      skipInstall: true,
+    });
+  }
+}
+
+function updateProjects(tree: Tree, context: SchematicContext) {
+  return updateWorkspace((workspace) => {
     const rules: Rule[] = [];
-    const workspace = await getWorkspace(tree);
 
     for (const [name, project] of workspace.projects) {
       if (project.extensions.projectType !== ProjectType.Application) {
@@ -41,137 +178,9 @@ export default function (): Rule {
         continue;
       }
 
-      // Update builder target and options
-      buildTarget.builder = Builders.Application;
-      const hasServerTarget = project.targets.has('server');
+      const serverTarget = project.targets.get('server');
 
-      for (const [, options] of allTargetOptions(buildTarget, false)) {
-        if (options['index'] === '') {
-          options['index'] = false;
-        }
-
-        // Rename and transform options
-        options['browser'] = options['main'];
-        if (hasServerTarget && typeof options['browser'] === 'string') {
-          options['server'] = dirname(options['browser']) + '/main.server.ts';
-        }
-        options['serviceWorker'] = options['ngswConfigPath'] ?? options['serviceWorker'];
-
-        if (typeof options['polyfills'] === 'string') {
-          options['polyfills'] = [options['polyfills']];
-        }
-
-        let outputPath = options['outputPath'];
-        if (typeof outputPath === 'string') {
-          if (!/\/browser\/?$/.test(outputPath)) {
-            // TODO: add prompt.
-            context.logger.warn(
-              `The output location of the browser build has been updated from "${outputPath}" to ` +
-                `"${join(outputPath, 'browser')}". ` +
-                'You might need to adjust your deployment pipeline or, as an alternative, ' +
-                'set outputPath.browser to "" in order to maintain the previous functionality.',
-            );
-          } else {
-            outputPath = outputPath.replace(/\/browser\/?$/, '');
-          }
-
-          options['outputPath'] = {
-            base: outputPath,
-          };
-
-          if (typeof options['resourcesOutputPath'] === 'string') {
-            const media = options['resourcesOutputPath'].replaceAll('/', '');
-            if (media && media !== 'media') {
-              options['outputPath'] = {
-                base: outputPath,
-                media: media,
-              };
-            }
-          }
-        }
-
-        // Delete removed options
-        delete options['vendorChunk'];
-        delete options['commonChunk'];
-        delete options['resourcesOutputPath'];
-        delete options['buildOptimizer'];
-        delete options['main'];
-        delete options['ngswConfigPath'];
-      }
-
-      // Merge browser and server tsconfig
-      if (hasServerTarget) {
-        const browserTsConfig = buildTarget?.options?.tsConfig;
-        const serverTsConfig = project.targets.get('server')?.options?.tsConfig;
-
-        if (typeof browserTsConfig !== 'string') {
-          throw new SchematicsException(
-            `Cannot update project "${name}" to use the application builder` +
-              ` as the browser tsconfig cannot be located.`,
-          );
-        }
-
-        if (typeof serverTsConfig !== 'string') {
-          throw new SchematicsException(
-            `Cannot update project "${name}" to use the application builder` +
-              ` as the server tsconfig cannot be located.`,
-          );
-        }
-
-        const browserJson = new JSONFile(tree, browserTsConfig);
-        const serverJson = new JSONFile(tree, serverTsConfig);
-
-        const filesPath = ['files'];
-
-        const files = new Set([
-          ...((browserJson.get(filesPath) as string[] | undefined) ?? []),
-          ...((serverJson.get(filesPath) as string[] | undefined) ?? []),
-        ]);
-
-        // Server file will be added later by the means of the ssr schematic.
-        files.delete('server.ts');
-
-        browserJson.modify(filesPath, Array.from(files));
-
-        const typesPath = ['compilerOptions', 'types'];
-        browserJson.modify(
-          typesPath,
-          Array.from(
-            new Set([
-              ...((browserJson.get(typesPath) as string[] | undefined) ?? []),
-              ...((serverJson.get(typesPath) as string[] | undefined) ?? []),
-            ]),
-          ),
-        );
-
-        // Delete server tsconfig
-        tree.delete(serverTsConfig);
-      }
-
-      // Update main tsconfig
-      const rootJson = new JSONFile(tree, 'tsconfig.json');
-      rootJson.modify(['compilerOptions', 'esModuleInterop'], true);
-      rootJson.modify(['compilerOptions', 'downlevelIteration'], undefined);
-      rootJson.modify(['compilerOptions', 'allowSyntheticDefaultImports'], undefined);
-
-      // Update server file
-      const ssrMainFile = project.targets.get('server')?.options?.['main'];
-      if (typeof ssrMainFile === 'string') {
-        tree.delete(ssrMainFile);
-
-        rules.push(
-          externalSchematic('@schematics/angular', 'ssr', {
-            project: name,
-            skipInstall: true,
-          }),
-        );
-      }
-
-      // Delete package.json helper scripts
-      const pkgJson = new JSONFile(tree, 'package.json');
-      ['build:ssr', 'dev:ssr', 'serve:ssr', 'prerender'].forEach((s) =>
-        pkgJson.remove(['scripts', s]),
-      );
+      rules.push(...updateBuildTarget(name, buildTarget, serverTarget, tree, context));
 
       // Delete all redundant targets
       for (const [key, target] of project.targets) {
@@ -186,9 +195,55 @@ export default function (): Rule {
       }
     }
 
-    // Save workspace changes
-    await workspaces.writeWorkspace(workspace, new TreeWorkspaceHost(tree));
-
     return chain(rules);
+  });
+}
+
+function deleteFile(path: string): Rule {
+  return (tree) => {
+    tree.delete(path);
   };
+}
+
+function updateJsonFile(path: string, updater: (json: JSONFile) => void): Rule {
+  return (tree) => {
+    updater(new JSONFile(tree, path));
+  };
+}
+
+/**
+ * Migration main entrypoint
+ */
+export default function (): Rule {
+  return chain([
+    updateProjects,
+    // Delete package.json helper scripts
+    updateJsonFile('package.json', (pkgJson) =>
+      ['build:ssr', 'dev:ssr', 'serve:ssr', 'prerender'].forEach((s) =>
+        pkgJson.remove(['scripts', s]),
+      ),
+    ),
+    // Update main tsconfig
+    updateJsonFile('tsconfig.json', (rootJson) => {
+      rootJson.modify(['compilerOptions', 'esModuleInterop'], true);
+      rootJson.modify(['compilerOptions', 'downlevelIteration'], undefined);
+      rootJson.modify(['compilerOptions', 'allowSyntheticDefaultImports'], undefined);
+    }),
+  ]);
+}
+
+function usesNoLongerSupportedOptions(
+  { deployUrl }: Record<string, unknown>,
+  context: SchematicContext,
+  projectName: string,
+): boolean {
+  let hasUsage = false;
+  if (typeof deployUrl === 'string') {
+    hasUsage = true;
+    context.logger.warn(
+      `Skipping migration for project "${projectName}". "deployUrl" option is not available in the application builder.`,
+    );
+  }
+
+  return hasUsage;
 }


### PR DESCRIPTION
When using the newly introduced migration to convert an application to use the new
esbuild-based `application` builder, CSS and Sass stylesheet will now have any import
and/or use specifiers adjusted to remove any Webpack builder specific prefixes. This includes
both the tilde and caret. Tilde usage is fully removed as package resolution is natively
supported. The caret is also removed and for each such specifier an external dependencies
entry is added to maintain existing behavior of keep the specifier unchanged.
Further, if any Sass imports are detected that assumed a workspace root path as a relative import
location then an entry is added to the `includePaths` array within the `stylePreprocessorOptions`
build option. This allows these import specifiers to continue to function.