### PR TITLE
test: update Safari 15 private property E2E for babel changes

### DIFF
--- a/tests/legacy-cli/e2e/tests/misc/safari-15-class-properties.ts
+++ b/tests/legacy-cli/e2e/tests/misc/safari-15-class-properties.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert';
 import { expectFileToExist, readFile, writeFile, replaceInFile } from '../../utils/fs';
 import { ng } from '../../utils/process';
+import { getGlobalVariable } from '../../utils/env';
 
 const unexpectedStaticFieldErrorMessage =
   'Found unexpected static field. This indicates that the Safari <=v15 ' +
@@ -55,9 +56,17 @@ export default async function () {
     unexpectedStaticFieldErrorMessage,
   );
 
-  assert.match(
-    mainContentSafari15Explicit,
-    /var _myPrivateMethod/,
-    'Expected private method to be downlevelled when Safari <=v15 is targeted',
-  );
+  if (getGlobalVariable('argv')['esbuild']) {
+    assert.match(
+      mainContentSafari15Explicit,
+      /var _myPrivateMethod/,
+      'Expected private method to be downlevelled when Safari <=v15 is targeted',
+    );
+  } else {
+    assert.match(
+      mainContentSafari15Explicit,
+      /_assertClassBrand/,
+      'Expected private method to be downlevelled when Safari <=v15 is targeted',
+    );
+  }
 }


### PR DESCRIPTION
Recent babel downlevelling changes for private properties require adjustments to the test expectations for the `misc/safari-15-class-properties` E2E test. This E2E test ensured that private class properties are downlevelled when Safari 15 is present in the supported browsers list to workaround Safari bugs that were present in these older versions of the browser.