### PR TITLE
refactor(@angular-devkit/build-angular): disable Piscina timing information recording

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/app-shell/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/app-shell/index.ts
@@ -71,6 +71,7 @@ async function _renderUniversal(
     filename: require.resolve('./render-worker'),
     maxThreads: 1,
     workerData: { zonePackage },
+    recordTiming: false,
   });
 
   try {

--- a/packages/angular_devkit/build_angular/src/builders/prerender/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/prerender/index.ts
@@ -68,6 +68,7 @@ async function getRoutes(
         serverBundlePath,
         zonePackage: require.resolve('zone.js', { paths: [workspaceRoot] }),
       } as RoutesExtractorWorkerData,
+      recordTiming: false,
     });
 
     const extractedRoutes: string[] = await renderWorker
@@ -175,6 +176,7 @@ async function _renderUniversal(
     filename: path.join(__dirname, 'render-worker.js'),
     maxThreads: maxWorkers,
     workerData: { zonePackage },
+    recordTiming: false,
   });
 
   let routes: string[] | undefined;

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/angular/compilation/parallel-compilation.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/angular/compilation/parallel-compilation.ts
@@ -40,6 +40,7 @@ export class ParallelCompilation extends AngularCompilation {
       // is used when the Atomics based wait loop is enable.
       useAtomics: !process.versions.webcontainer,
       filename: localRequire.resolve('./parallel-worker'),
+      recordTiming: false,
     });
   }
 

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/i18n-inliner.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/i18n-inliner.ts
@@ -97,6 +97,7 @@ export class I18nInliner {
         shouldOptimize: options.shouldOptimize,
         files,
       },
+      recordTiming: false,
     });
   }
 

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/javascript-transformer.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/javascript-transformer.ts
@@ -61,6 +61,7 @@ export class JavaScriptTransformer {
       maxThreads: this.maxThreads,
       // Shutdown idle threads after 1 second of inactivity
       idleTimeout: 1000,
+      recordTiming: false,
     });
 
     return this.#workerPool;

--- a/packages/angular_devkit/build_angular/src/tools/webpack/plugins/javascript-optimizer-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/plugins/javascript-optimizer-plugin.ts
@@ -177,6 +177,7 @@ export class JavaScriptOptimizerPlugin {
           const workerPool = new Piscina({
             filename: workerPath,
             maxThreads: MAX_OPTIMIZE_WORKERS,
+            recordTiming: false,
           });
 
           // Enqueue script optimization tasks and update compilation assets as the tasks complete

--- a/packages/angular_devkit/build_angular/src/utils/action-executor.ts
+++ b/packages/angular_devkit/build_angular/src/utils/action-executor.ts
@@ -28,6 +28,7 @@ export class BundleActionExecutor {
       name: 'inlineLocales',
       workerData: this.workerOptions,
       maxThreads: maxWorkers,
+      recordTiming: false,
     });
 
     return this.workerPool;

--- a/packages/angular_devkit/build_angular/src/utils/server-rendering/prerender.ts
+++ b/packages/angular_devkit/build_angular/src/utils/server-rendering/prerender.ts
@@ -174,6 +174,7 @@ async function renderPages(
       document,
     } as RenderWorkerData,
     execArgv: workerExecArgv,
+    recordTiming: false,
   });
 
   try {
@@ -261,6 +262,7 @@ async function getAllRoutes(
       verbose,
     } as RoutesExtractorWorkerData,
     execArgv: workerExecArgv,
+    recordTiming: false,
   });
 
   const { routes: extractedRoutes, warnings }: RoutersExtractorWorkerResult = await renderWorker


### PR DESCRIPTION
The latest version of the worker pool package used by the build system (`Piscina`) now has an option to disable performance timing information. Since the build system does not currently use that information, disabling it avoids the extra overhead of histogram creation and usage. This information collection could potentially be enabled conditionally in the future if needed.