### PR TITLE
fix(@angular-devkit/build-angular): disable `deployUrl` when using vite dev-server

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
@@ -57,6 +57,9 @@ export async function* serveWithVite(
     serverOptions.buildTarget,
   )) as json.JsonObject & BrowserBuilderOptions;
 
+  // Deploy url is not used in the dev-server.
+  delete rawBrowserOptions.deployUrl;
+
   const browserOptions = (await context.validateOptions(
     {
       ...rawBrowserOptions,


### PR DESCRIPTION

Prior to this commit, the deployUrl was incorrectly being set when using vite dev-server.