### PR TITLE
refactor(@angular-devkit/build-angular): use Node.js builtin instead of custom removeColor helper

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/webpack/utils/stats.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/utils/stats.ts
@@ -10,11 +10,12 @@ import { WebpackLoggingCallback } from '@angular-devkit/build-webpack';
 import { logging } from '@angular-devkit/core';
 import assert from 'node:assert';
 import * as path from 'node:path';
+import { stripVTControlCharacters } from 'node:util';
 import { Configuration, StatsCompilation } from 'webpack';
 import { Schema as BrowserBuilderOptions } from '../../../builders/browser/schema';
 import { normalizeOptimization } from '../../../utils';
 import { BudgetCalculatorResult } from '../../../utils/bundle-calculator';
-import { colors as ansiColors, removeColor } from '../../../utils/color';
+import { colors as ansiColors } from '../../../utils/color';
 import { markAsyncChunksNonInitial } from './async-chunks';
 import { WebpackStatsOptions, getStatsOptions, normalizeExtraEntryPoints } from './helpers';
 
@@ -310,7 +311,7 @@ function generateTableText(bundleInfo: (string | number)[][], colors: boolean): 
       }
 
       const currentLongest = (longest[i] ??= 0);
-      const currentItemLength = removeColor(currentItem).length;
+      const currentItemLength = stripVTControlCharacters(currentItem).length;
       if (currentLongest < currentItemLength) {
         longest[i] = currentItemLength;
       }
@@ -330,7 +331,7 @@ function generateTableText(bundleInfo: (string | number)[][], colors: boolean): 
         continue;
       }
 
-      const currentItemLength = removeColor(currentItem).length;
+      const currentItemLength = stripVTControlCharacters(currentItem).length;
       const stringPad = ' '.repeat(longest[i] - currentItemLength);
       // Values in columns at index 2 and 3 (Raw and Estimated sizes) are always right aligned.
       item[i] = i >= 2 ? stringPad + currentItem : currentItem + stringPad;

--- a/packages/angular_devkit/build_angular/src/utils/color.ts
+++ b/packages/angular_devkit/build_angular/src/utils/color.ts
@@ -7,7 +7,7 @@
  */
 
 import * as ansiColors from 'ansi-colors';
-import { WriteStream } from 'tty';
+import { WriteStream } from 'node:tty';
 
 function supportColor(): boolean {
   if (process.env.FORCE_COLOR !== undefined) {
@@ -30,16 +30,10 @@ function supportColor(): boolean {
   }
 
   if (process.stdout instanceof WriteStream) {
-    return process.stdout.getColorDepth() > 1;
+    return process.stdout.hasColors();
   }
 
   return false;
-}
-
-export function removeColor(text: string): string {
-  // This has been created because when colors.enabled is false unstyle doesn't work
-  // see: https://github.com/doowb/ansi-colors/blob/a4794363369d7b4d1872d248fc43a12761640d8e/index.js#L38
-  return text.replace(ansiColors.ansiRegex, '');
 }
 
 // Create a separate instance to prevent unintended global changes to the color configuration


### PR DESCRIPTION
The Node.js `node:util` builtin contains a helper (`stripVTControlCharacters`) that can be used to remove ANSI color characters from a string. Usage removes the need for a custom helper within the package.