### PR TITLE
refactor(@angular-devkit/build-angular): remove vite deprecation warning

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
@@ -632,12 +632,12 @@ function getDepOptimizationConfig({
   }
 
   return {
-    // Only enable with caching since it causes prebundle dependencies to be cached
-    disabled,
     // Exclude any explicitly defined dependencies (currently build defined externals)
     exclude,
+    // NB: to disable the deps optimizer, set optimizeDeps.noDiscovery to true and optimizeDeps.include as undefined.
     // Include all implict dependencies from the external packages internal option
-    include,
+    include: disabled ? undefined : include,
+    noDiscovery: disabled,
     // Add an esbuild plugin to run the Angular linker on dependencies
     esbuildOptions: {
       // Set esbuild supported targets.


### PR DESCRIPTION
`optimizeDeps.disabled` has been deprecated in favor of `optimizeDeps.noDiscovery` to `true` and `optimizeDeps.include` to `undefined`

```
(!) Experimental ssr.optimizeDeps.disabled and deps pre-bundling during build were removed in Vite 5.1.
    To disable the deps optimizer, set ssr.optimizeDeps.noDiscovery to true and ssr.optimizeDeps.include as undefined or empty.
    Please remove ssr.optimizeDeps.disabled from your config.
```
