### PR TITLE
refactor(@angular-devkit/build-angular): add warnings for unsupported vite options

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/dev-server/builder.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/builder.ts
@@ -54,7 +54,7 @@ export function execute(
   // Determine project name from builder context target
   const projectName = context.target?.project;
   if (!projectName) {
-    context.logger.error(`The 'dev-server' builder requires a target to be specified.`);
+    context.logger.error(`The "dev-server" builder requires a target to be specified.`);
 
     return EMPTY;
   }
@@ -65,7 +65,7 @@ export function execute(
       if (isEsbuildBased(builderName)) {
         if (transforms?.logging || transforms?.webpackConfiguration) {
           throw new Error(
-            'The `application` and `browser-esbuild` builders do not support Webpack transforms.',
+            `The "application" and "browser-esbuild" builders do not support Webpack transforms.`,
           );
         }
 
@@ -73,6 +73,24 @@ export function execute(
         if (options.prebundle && !normalizedOptions.cacheOptions.enabled) {
           context.logger.warn(
             `Prebundling has been configured but will not be used because caching has been disabled.`,
+          );
+        }
+
+        if (options.allowedHosts?.length) {
+          context.logger.warn(
+            `The "allowedHost" option will not be used because it is not supported by the "${builderName}" builder.`,
+          );
+        }
+
+        if (options.publicHost) {
+          context.logger.warn(
+            `The "publicHost" option will not be used because it is not supported by the "${builderName}" builder.`,
+          );
+        }
+
+        if (options.disableHostCheck) {
+          context.logger.warn(
+            `The "disableHostCheck" option will not be used because it is not supported by the "${builderName}" builder.`,
           );
         }
 
@@ -91,11 +109,11 @@ export function execute(
       }
 
       if (extensions?.buildPlugins?.length) {
-        throw new Error('Only the `application` and `browser-esbuild` builders support plugins.');
+        throw new Error('Only the "application" and "browser-esbuild" builders support plugins.');
       }
       if (extensions?.middleware?.length) {
         throw new Error(
-          'Only the `application` and `browser-esbuild` builders support middleware.',
+          'Only the "application" and "browser-esbuild" builders support middleware.',
         );
       }
 

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/schema.json
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/schema.json
@@ -69,11 +69,11 @@
     },
     "publicHost": {
       "type": "string",
-      "description": "The URL that the browser client (or live-reload client, if enabled) should use to connect to the development server. Use for a complex dev server setup, such as one with reverse proxies."
+      "description": "The URL that the browser client (or live-reload client, if enabled) should use to connect to the development server. Use for a complex dev server setup, such as one with reverse proxies. This option has no effect when using the 'application' or other esbuild-based builders."
     },
     "allowedHosts": {
       "type": "array",
-      "description": "List of hosts that are allowed to access the dev server.",
+      "description": "List of hosts that are allowed to access the dev server. This option has no effect when using the 'application' or other esbuild-based builders.",
       "default": [],
       "items": {
         "type": "string"
@@ -85,7 +85,7 @@
     },
     "disableHostCheck": {
       "type": "boolean",
-      "description": "Don't verify connected clients are part of allowed hosts.",
+      "description": "Don't verify connected clients are part of allowed hosts. This option has no effect when using the 'application' or other esbuild-based builders.",
       "default": false
     },
     "hmr": {

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/tests/options/disable-host-check_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/tests/options/disable-host-check_spec.ts
@@ -17,7 +17,7 @@ describeServeBuilder(
   executeDevServer,
   DEV_SERVER_BUILDER_INFO,
   (harness, setupTarget, isViteRun) => {
-    // TODO(fix-vite): currently this is broken in vite.
+    // This option is not used when using vite.
     (isViteRun ? xdescribe : describe)('option: "disableHostCheck"', () => {
       beforeEach(async () => {
         setupTarget(harness);

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/tests/options/public-host_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/tests/options/public-host_spec.ts
@@ -17,7 +17,7 @@ describeServeBuilder(
   executeDevServer,
   DEV_SERVER_BUILDER_INFO,
   (harness, setupTarget, isViteRun) => {
-    // TODO(fix-vite): currently this is broken in vite.
+    // This option is not used when using vite.
     (isViteRun ? xdescribe : describe)('option: "publicHost"', () => {
       beforeEach(async () => {
         setupTarget(harness);

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
@@ -547,7 +547,6 @@ export async function setupServer(
         external: externalMetadata.explicit,
         indexHtmlTransformer,
         extensionMiddleware,
-        extraHeaders: serverOptions.headers,
         normalizePath,
       }),
     ],


### PR DESCRIPTION


This commit adds warnings when using unsupported dev-server options with vite.
