### PR TITLE
refactor(@angular-devkit/build-angular): remove unneeded relative URL modification for public path

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/esbuild/application-code-bundle.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/application-code-bundle.ts
@@ -388,7 +388,6 @@ function getEsBuildCommonOptions(options: NormalizedApplicationBuildOptions): Bu
     },
     loader: loaderExtensions,
     footer,
-    publicPath: options.publicPath,
   };
 }
 

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/global-styles.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/global-styles.ts
@@ -29,7 +29,6 @@ export function createGlobalStylesBundleOptions(
     tailwindConfiguration,
     postcssConfiguration,
     cacheOptions,
-    publicPath,
   } = options;
 
   const namespace = 'angular:styles/global';
@@ -67,7 +66,6 @@ export function createGlobalStylesBundleOptions(
         tailwindConfiguration,
         postcssConfiguration,
         cacheOptions,
-        publicPath,
       },
       loadCache,
     );


### PR DESCRIPTION
Only the injected index HTML file references and component stylesheets require the modification of relative URLs with a public path when specified. Other usages are already resolved relative to their containing file location with the `application` builder.