### PR TITLE
build: update dependencies for version 17.3.0

### DIFF
--- a/packages/angular/pwa/package.json
+++ b/packages/angular/pwa/package.json
@@ -17,7 +17,7 @@
     "parse5-html-rewriting-stream": "7.0.0"
   },
   "peerDependencies": {
-    "@angular/cli": "^17.0.0 || ^17.2.0-next.0"
+    "@angular/cli": "^17.0.0 || ^17.3.0-next.0"
   },
   "peerDependenciesMeta": {
     "@angular/cli": {

--- a/packages/angular/ssr/package.json
+++ b/packages/angular/ssr/package.json
@@ -17,8 +17,8 @@
     "tslib": "^2.3.0"
   },
   "peerDependencies": {
-    "@angular/common": "^17.0.0 || ^17.2.0-next.0",
-    "@angular/core": "^17.0.0 || ^17.2.0-next.0"
+    "@angular/common": "^17.0.0 || ^17.3.0-next.0",
+    "@angular/core": "^17.0.0 || ^17.3.0-next.0"
   },
   "schematics": "./schematics/collection.json",
   "repository": {

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -74,16 +74,16 @@
     "esbuild": "0.20.1"
   },
   "peerDependencies": {
-    "@angular/compiler-cli": "^17.0.0 || ^17.2.0-next.0",
-    "@angular/localize": "^17.0.0 || ^17.2.0-next.0",
-    "@angular/platform-server": "^17.0.0 || ^17.2.0-next.0",
-    "@angular/service-worker": "^17.0.0 || ^17.2.0-next.0",
+    "@angular/compiler-cli": "^17.0.0 || ^17.3.0-next.0",
+    "@angular/localize": "^17.0.0 || ^17.3.0-next.0",
+    "@angular/platform-server": "^17.0.0 || ^17.3.0-next.0",
+    "@angular/service-worker": "^17.0.0 || ^17.3.0-next.0",
     "@web/test-runner": "^0.18.0",
     "browser-sync": "^3.0.2",
     "jest": "^29.5.0",
     "jest-environment-jsdom": "^29.5.0",
     "karma": "^6.3.0",
-    "ng-packagr": "^17.0.0 || ^17.2.0-next.0",
+    "ng-packagr": "^17.0.0 || ^17.3.0-next.0",
     "protractor": "^7.0.0",
     "tailwindcss": "^2.0.0 || ^3.0.0",
     "typescript": ">=5.2 <5.5"

--- a/packages/ngtools/webpack/package.json
+++ b/packages/ngtools/webpack/package.json
@@ -22,7 +22,7 @@
   "homepage": "https://github.com/angular/angular-cli/tree/main/packages/ngtools/webpack",
   "dependencies": {},
   "peerDependencies": {
-    "@angular/compiler-cli": "^17.0.0 || ^17.2.0-next.0",
+    "@angular/compiler-cli": "^17.0.0 || ^17.3.0-next.0",
     "typescript": ">=5.2 <5.5",
     "webpack": "^5.54.0"
   },

--- a/packages/schematics/angular/utility/latest-versions.ts
+++ b/packages/schematics/angular/utility/latest-versions.ts
@@ -16,7 +16,7 @@ export const latestVersions: Record<string, string> & {
   ...require('./latest-versions/package.json')['dependencies'],
 
   // As Angular CLI works with same minor versions of Angular Framework, a tilde match for the current
-  Angular: '^17.2.0-next.0',
+  Angular: '^17.3.0-next.0',
 
   DevkitBuildAngular: '^0.0.0-PLACEHOLDER',
   AngularSSR: '^0.0.0-PLACEHOLDER',

--- a/packages/schematics/angular/utility/latest-versions/package.json
+++ b/packages/schematics/angular/utility/latest-versions/package.json
@@ -15,7 +15,7 @@
     "karma-jasmine-html-reporter": "~2.1.0",
     "karma-jasmine": "~5.1.0",
     "karma": "~6.4.0",
-    "ng-packagr": "^17.1.0-next.0",
+    "ng-packagr": "^17.3.0-next.0",
     "protractor": "~7.0.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",


### PR DESCRIPTION
The prerelease checks are failing due to incorrect dependencies

```
Discovered errors when validating dependency ranges.
  - @angular/pwa: Unexpected peer dependency range for "@angular/cli". Expected: ^17.0.0 || ^17.3.0-next.0
  - @angular/ssr: Unexpected peer dependency range for "@angular/common". Expected: ^17.0.0 || ^17.3.0-next.0
  - @angular/ssr: Unexpected peer dependency range for "@angular/core". Expected: ^17.0.0 || ^17.3.0-next.0
  - @angular-devkit/build-angular: Unexpected peer dependency range for "@angular/compiler-cli". Expected: ^17.0.0 || ^17.3.0-next.0
  - @angular-devkit/build-angular: Unexpected peer dependency range for "@angular/localize". Expected: ^17.0.0 || ^17.3.0-next.0
  - @angular-devkit/build-angular: Unexpected peer dependency range for "@angular/platform-server". Expected: ^17.0.0 || ^17.3.0-next.0
  - @angular-devkit/build-angular: Unexpected peer dependency range for "@angular/service-worker". Expected: ^17.0.0 || ^17.3.0-next.0
  - @angular-devkit/build-angular: Unexpected peer dependency range for "ng-packagr". Expected: ^17.0.0 || ^17.3.0-next.0
  - @ngtools/webpack: Unexpected peer dependency range for "@angular/compiler-cli". Expected: ^17.0.0 || ^17.3.0-next.0
  - latest-versions: Invalid dependency range for "ng-packagr". Expected: ^17.3.0-next.0
  - latest-versions: Invalid dependency range for "Angular". Expected: ^17.3.0-next.0
```
