### PR TITLE
fix(@angular-devkit/build-angular): ensure proper display of build logs in the presence of warnings or errors

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/application/execute-build.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/execute-build.ts
@@ -185,7 +185,7 @@ export async function executeBuild(
   }
 
   if (!jsonLogs) {
-    context.logger.info(
+    executionResult.addLog(
       logBuildStats(
         metafile,
         initialFiles,

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/bundler-execution-result.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/bundler-execution-result.ts
@@ -40,6 +40,7 @@ export class ExecutionResult {
   errors: (Message | PartialMessage)[] = [];
   prerenderedRoutes: string[] = [];
   warnings: (Message | PartialMessage)[] = [];
+  logs: string[] = [];
   externalMetadata?: ExternalResultMetadata;
 
   constructor(
@@ -53,6 +54,10 @@ export class ExecutionResult {
 
   addAssets(assets: BuildOutputAsset[]): void {
     this.assetFiles.push(...assets);
+  }
+
+  addLog(value: string): void {
+    this.logs.push(value);
   }
 
   addError(error: PartialMessage | string): void {

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/utils.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/utils.ts
@@ -429,46 +429,53 @@ interface BuildManifest {
   prerenderedRoutes?: string[];
 }
 
+export async function createJsonBuildManifest(
+  result: ExecutionResult,
+  normalizedOptions: NormalizedApplicationBuildOptions,
+): Promise<string> {
+  const {
+    colors: color,
+    outputOptions: { base, server, browser },
+    ssrOptions,
+  } = normalizedOptions;
+
+  const { warnings, errors, prerenderedRoutes } = result;
+
+  const manifest: BuildManifest = {
+    errors: errors.length ? await formatMessages(errors, { kind: 'error', color }) : [],
+    warnings: warnings.length ? await formatMessages(warnings, { kind: 'warning', color }) : [],
+    outputPaths: {
+      root: pathToFileURL(base),
+      browser: pathToFileURL(join(base, browser)),
+      server: ssrOptions ? pathToFileURL(join(base, server)) : undefined,
+    },
+    prerenderedRoutes,
+  };
+
+  return JSON.stringify(manifest, undefined, 2);
+}
+
 export async function logMessages(
   logger: logging.LoggerApi,
   executionResult: ExecutionResult,
-  options: NormalizedApplicationBuildOptions,
+  color?: boolean,
+  jsonLogs?: boolean,
 ): Promise<void> {
-  const {
-    outputOptions: { base, server, browser },
-    ssrOptions,
-    jsonLogs,
-    colors: color,
-  } = options;
-  const { warnings, errors, prerenderedRoutes } = executionResult;
-  const warningMessages = warnings.length
-    ? await formatMessages(warnings, { kind: 'warning', color })
-    : [];
-  const errorMessages = errors.length ? await formatMessages(errors, { kind: 'error', color }) : [];
+  const { warnings, errors, logs } = executionResult;
+
+  if (logs.length) {
+    logger.info(logs.join('\n'));
+  }
 
   if (jsonLogs) {
-    // JSON format output
-    const manifest: BuildManifest = {
-      errors: errorMessages,
-      warnings: warningMessages,
-      outputPaths: {
-        root: pathToFileURL(base),
-        browser: pathToFileURL(join(base, browser)),
-        server: ssrOptions ? pathToFileURL(join(base, server)) : undefined,
-      },
-      prerenderedRoutes,
-    };
-
-    logger.info(JSON.stringify(manifest, undefined, 2));
-
     return;
   }
 
-  if (warningMessages.length) {
-    logger.warn(warningMessages.join('\n'));
+  if (warnings.length) {
+    logger.warn((await formatMessages(warnings, { kind: 'warning', color })).join('\n'));
   }
 
-  if (errorMessages.length) {
-    logger.error(errorMessages.join('\n'));
+  if (errors.length) {
+    logger.error((await formatMessages(errors, { kind: 'error', color })).join('\n'));
   }
 }


### PR DESCRIPTION

Previously, a race condition could occur due to the spinner, resulting in the deletion of the last printed log when warnings or errors were present. With this update, we ensure that logs are printed after the spinner has stopped.

Fixes #27233

