### PR TITLE
build: reduce amount of dev tsconfig paths entries

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,22 +16,18 @@
     "rootDir": ".",
     "rootDirs": [".", "./dist-schema/bin/"],
     "paths": {
-      "@angular-devkit/core": ["./packages/angular_devkit/core/src/index"],
       "@angular-devkit/core/node": ["./packages/angular_devkit/core/node/index"],
       "@angular-devkit/core/node/testing": ["./packages/angular_devkit/core/node/testing/index"],
-      "@angular-devkit/schematics": ["./packages/angular_devkit/schematics/src/index"],
       "@angular-devkit/schematics/tasks": ["./packages/angular_devkit/schematics/tasks/index"],
       "@angular-devkit/schematics/tasks/node": [
         "./packages/angular_devkit/schematics/tasks/node/index"
       ],
       "@angular-devkit/schematics/tools": ["./packages/angular_devkit/schematics/tools/index"],
       "@angular-devkit/schematics/testing": ["./packages/angular_devkit/schematics/testing/index"],
-      "@angular-devkit/architect": ["./packages/angular_devkit/architect/src/index"],
       "@angular-devkit/architect/testing": ["./packages/angular_devkit/architect/testing/index"],
-      "@angular-devkit/build-angular": ["./packages/angular_devkit/build_angular/src/index"],
-      "@angular-devkit/build-webpack": ["./packages/angular_devkit/build_webpack/src/index"],
-      "@ngtools/webpack": ["./packages/ngtools/webpack/src/index"],
-      "@schematics/angular": ["./packages/schematics/angular/index"]
+      "@angular-devkit/*": ["./packages/angular_devkit/*/src"],
+      "@ngtools/webpack": ["./packages/ngtools/webpack/src"],
+      "@schematics/angular": ["./packages/schematics/angular"]
     },
     "plugins": [
       {


### PR DESCRIPTION
The use of wildcard entries with the tsconfig `paths` allows the root import of the `@angular-devkit/` packages to be reduced to a single entry.
