### PR TITLE
refactor(@angular-devkit/build-angular): reduce usage of @angular-devkit/core types

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/application/build-action.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/build-action.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { BuilderOutput } from '@angular-devkit/architect';
-import type { logging } from '@angular-devkit/core';
+import { BuilderContext, BuilderOutput } from '@angular-devkit/architect';
 import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { BuildOutputFile } from '../../tools/esbuild/bundler-context';
@@ -44,7 +43,7 @@ export async function* runEsBuildBuildAction(
     workspaceRoot: string;
     projectRoot: string;
     outputOptions: NormalizedOutputOptions;
-    logger: logging.LoggerApi;
+    logger: BuilderContext['logger'];
     cacheOptions: NormalizedCachedOptions;
     writeToFileSystem: boolean;
     writeToFileSystemFilter: ((file: BuildOutputFile) => boolean) | undefined;

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
@@ -7,7 +7,7 @@
  */
 
 import type { BuilderContext } from '@angular-devkit/architect';
-import type { json, logging } from '@angular-devkit/core';
+import type { json } from '@angular-devkit/core';
 import type { Plugin } from 'esbuild';
 import assert from 'node:assert';
 import { readFile } from 'node:fs/promises';
@@ -314,7 +314,7 @@ function handleUpdate(
   generatedFiles: Map<string, OutputFileRecord>,
   server: ViteDevServer,
   serverOptions: NormalizedDevServerOptions,
-  logger: logging.LoggerApi,
+  logger: BuilderContext['logger'],
 ): void {
   const updatedFiles: string[] = [];
 

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/utils.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/utils.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { logging } from '@angular-devkit/core';
+import { BuilderContext } from '@angular-devkit/architect';
 import { BuildOptions, Metafile, OutputFile, formatMessages } from 'esbuild';
 import { createHash } from 'node:crypto';
 import { constants as fsConstants } from 'node:fs';
@@ -456,7 +456,7 @@ export async function createJsonBuildManifest(
 }
 
 export async function logMessages(
-  logger: logging.LoggerApi,
+  logger: BuilderContext['logger'],
   executionResult: ExecutionResult,
   color?: boolean,
   jsonLogs?: boolean,

--- a/packages/angular_devkit/build_angular/src/utils/normalize-asset-patterns.ts
+++ b/packages/angular_devkit/build_angular/src/utils/normalize-asset-patterns.ts
@@ -6,12 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { BaseException } from '@angular-devkit/core';
 import { statSync } from 'fs';
 import * as path from 'path';
 import { AssetPattern, AssetPatternClass } from '../builders/browser/schema';
 
-export class MissingAssetSourceRootException extends BaseException {
+export class MissingAssetSourceRootException extends Error {
   constructor(path: string) {
     super(`The ${path} asset path must start with the project source root.`);
   }

--- a/packages/angular_devkit/build_angular/src/utils/normalize-file-replacements.ts
+++ b/packages/angular_devkit/build_angular/src/utils/normalize-file-replacements.ts
@@ -6,12 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { BaseException } from '@angular-devkit/core';
 import { existsSync } from 'fs';
 import * as path from 'path';
 import { FileReplacement } from '../builders/browser/schema';
 
-export class MissingFileReplacementException extends BaseException {
+export class MissingFileReplacementException extends Error {
   constructor(path: string) {
     super(`The ${path} path in file replacements does not exist.`);
   }

--- a/packages/angular_devkit/build_angular/src/utils/supported-browsers.ts
+++ b/packages/angular_devkit/build_angular/src/utils/supported-browsers.ts
@@ -6,10 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { logging } from '@angular-devkit/core';
 import browserslist from 'browserslist';
 
-export function getSupportedBrowsers(projectRoot: string, logger: logging.LoggerApi): string[] {
+export function getSupportedBrowsers(
+  projectRoot: string,
+  logger: { warn(message: string): void },
+): string[] {
   browserslist.defaults = [
     'last 2 Chrome versions',
     'last 1 Firefox version',

--- a/packages/angular_devkit/build_angular/src/utils/webpack-browser-config.ts
+++ b/packages/angular_devkit/build_angular/src/utils/webpack-browser-config.ts
@@ -7,7 +7,6 @@
  */
 
 import { BuilderContext } from '@angular-devkit/architect';
-import { logging } from '@angular-devkit/core';
 import * as path from 'path';
 import { Configuration, javascript } from 'webpack';
 import { merge as webpackMerge } from 'webpack-merge';
@@ -34,7 +33,7 @@ export async function generateWebpackConfig(
   projectName: string,
   options: NormalizedBrowserBuilderSchema,
   webpackPartialGenerator: WebpackPartialGenerator,
-  logger: logging.LoggerApi,
+  logger: BuilderContext['logger'],
   extraBuildOptions: Partial<NormalizedBrowserBuilderSchema>,
 ): Promise<Configuration> {
   // Ensure Build Optimizer is only used with AOT.


### PR DESCRIPTION
Logging types are now based on the BuilderContext's type instead of the `@angular-devkit/core` type. This reduces the need to directly depend on this package while also allowing the builder logging type to diverge if needed.