### PR TITLE
build: update vendored TypeScript to final

### DIFF
--- a/packages/schematics/angular/third_party/github.com/Microsoft/TypeScript/BUILD.bazel
+++ b/packages/schematics/angular/third_party/github.com/Microsoft/TypeScript/BUILD.bazel
@@ -1,11 +1,11 @@
 load("//tools:defaults.bzl", "ts_library")
 
-# files fetched on 2024-02-28 from
-# https://github.com/microsoft/TypeScript/releases/tag/v5.4-rc
+# files fetched on 2024-03-11 from
+# https://github.com/microsoft/TypeScript/releases/tag/v5.4.2
 
 # Commands to download:
-# curl https://raw.githubusercontent.com/microsoft/TypeScript/v5.4-rc/lib/typescript.d.ts -o packages/schematics/angular/third_party/github.com/Microsoft/TypeScript/lib/typescript.d.ts
-# curl https://raw.githubusercontent.com/microsoft/TypeScript/v5.4-rc/lib/typescript.js -o packages/schematics/angular/third_party/github.com/Microsoft/TypeScript/lib/typescript.js
+# curl https://raw.githubusercontent.com/microsoft/TypeScript/v5.4.2/lib/typescript.d.ts -o packages/schematics/angular/third_party/github.com/Microsoft/TypeScript/lib/typescript.d.ts
+# curl https://raw.githubusercontent.com/microsoft/TypeScript/v5.4.2/lib/typescript.js -o packages/schematics/angular/third_party/github.com/Microsoft/TypeScript/lib/typescript.js
 
 licenses(["notice"])  # Apache 2.0
 


### PR DESCRIPTION
In an earlier commit TypeScript was updated to stable, but not the vendored version.