### PR TITLE
refactor(@angular-devkit/build-angular): remove unneeded option type casting from several builders

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/app-shell/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/app-shell/index.ts
@@ -35,8 +35,7 @@ async function _renderUniversal(
 ): Promise<BrowserBuilderOutput> {
   // Get browser target options.
   const browserTarget = targetFromTargetString(options.browserTarget);
-  const rawBrowserOptions = (await context.getTargetOptions(browserTarget)) as JsonObject &
-    BrowserBuilderSchema;
+  const rawBrowserOptions = await context.getTargetOptions(browserTarget);
   const browserBuilderName = await context.getBuilderNameForTarget(browserTarget);
   const browserOptions = await context.validateOptions<JsonObject & BrowserBuilderSchema>(
     rawBrowserOptions,

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
@@ -39,6 +39,12 @@ interface OutputFileRecord {
   servable: boolean;
 }
 
+/**
+ * Build options that are also present on the dev server but are only passed
+ * to the build.
+ */
+const CONVENIENCE_BUILD_OPTIONS = ['watch', 'poll', 'verbose'] as const;
+
 // eslint-disable-next-line max-lines-per-function
 export async function* serveWithVite(
   serverOptions: NormalizedDevServerOptions,
@@ -53,22 +59,23 @@ export async function* serveWithVite(
   },
 ): AsyncIterableIterator<DevServerBuilderOutput> {
   // Get the browser configuration from the target name.
-  const rawBrowserOptions = (await context.getTargetOptions(
-    serverOptions.buildTarget,
-  )) as json.JsonObject & BrowserBuilderOptions;
+  const rawBrowserOptions = await context.getTargetOptions(serverOptions.buildTarget);
 
   // Deploy url is not used in the dev-server.
   delete rawBrowserOptions.deployUrl;
 
-  const browserOptions = (await context.validateOptions(
-    {
-      ...rawBrowserOptions,
-      watch: serverOptions.watch,
-      poll: serverOptions.poll,
-      verbose: serverOptions.verbose,
-    } as json.JsonObject & BrowserBuilderOptions,
+  // Copy convenience options to build
+  for (const optionName of CONVENIENCE_BUILD_OPTIONS) {
+    const optionValue = serverOptions[optionName];
+    if (optionValue !== undefined) {
+      rawBrowserOptions[optionName] = optionValue;
+    }
+  }
+
+  const browserOptions = await context.validateOptions<json.JsonObject & BrowserBuilderOptions>(
+    rawBrowserOptions,
     builderName,
-  )) as json.JsonObject & BrowserBuilderOptions;
+  );
 
   if (browserOptions.prerender || browserOptions.ssr) {
     // Disable prerendering if enabled and force SSR.

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/webpack-server.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/webpack-server.ts
@@ -85,9 +85,7 @@ export function serveWebpackBrowser(
     }
 
     // Get the browser configuration from the target name.
-    const rawBrowserOptions = (await context.getTargetOptions(
-      options.buildTarget,
-    )) as json.JsonObject & BrowserBuilderSchema;
+    const rawBrowserOptions = await context.getTargetOptions(options.buildTarget);
 
     if (rawBrowserOptions.outputHashing && rawBrowserOptions.outputHashing !== OutputHashing.None) {
       // Disable output hashing for dev build as this can cause memory leaks

--- a/packages/angular_devkit/build_angular/src/builders/prerender/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/prerender/index.ts
@@ -12,7 +12,6 @@ import {
   createBuilder,
   targetFromTargetString,
 } from '@angular-devkit/architect';
-import { json } from '@angular-devkit/core';
 import * as fs from 'fs';
 import { readFile } from 'node:fs/promises';
 import ora from 'ora';
@@ -30,7 +29,7 @@ import type { RenderOptions, RenderResult } from './render-worker';
 import { RoutesExtractorWorkerData } from './routes-extractor-worker';
 import { Schema } from './schema';
 
-type PrerenderBuilderOptions = Schema & json.JsonObject;
+type PrerenderBuilderOptions = Schema;
 type PrerenderBuilderOutput = BuilderOutput;
 
 class RoutesSet extends Set<string> {


### PR DESCRIPTION
Multiple cases where builder options were being cast to the `JsonObject` type have been removed. These casts are no longer needed and unnecessarily added complexity to the code.