### PR TITLE
fix(@angular-devkit/build-angular): provide better error message when server option is required but missing

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/application/options.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/options.ts
@@ -221,7 +221,7 @@ export async function normalizeOptions(
   if (options.server) {
     serverEntryPoint = path.join(workspaceRoot, options.server);
   } else if (options.server === '') {
-    throw new Error('`server` option cannot be an empty string.');
+    throw new Error('The "server" option cannot be an empty string.');
   }
 
   let prerenderOptions;
@@ -251,6 +251,12 @@ export async function normalizeOptions(
     appShellOptions = {
       route: 'shell',
     };
+  }
+
+  if ((appShellOptions || ssrOptions || prerenderOptions) && !serverEntryPoint) {
+    throw new Error(
+      'The "server" option is required when enabling "ssr", "prerender" or "app-shell".',
+    );
   }
 
   // Initial options to keep

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/application-code-bundle.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/application-code-bundle.ts
@@ -154,15 +154,8 @@ export function createServerCodeBundleOptions(
   target: string[],
   sourceFileCache: SourceFileCache,
 ): BuildOptions {
-  const {
-    jit,
-    serverEntryPoint,
-    workspaceRoot,
-    ssrOptions,
-    watch,
-    externalPackages,
-    prerenderOptions,
-  } = options;
+  const { serverEntryPoint, workspaceRoot, ssrOptions, watch, externalPackages, prerenderOptions } =
+    options;
 
   assert(
     serverEntryPoint,


### PR DESCRIPTION


This improves the error message when the server entry-point is required but missing

Closes #27251
