### PR TITLE
build: remove template string helpers from validation scripts

### DIFF
--- a/scripts/validate-build-files.ts
+++ b/scripts/validate-build-files.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { logging, tags } from '@angular-devkit/core';
+import { logging } from '@angular-devkit/core';
 import { existsSync } from 'fs';
 import { join } from 'path';
 import { packages } from '../lib/packages';
@@ -24,10 +24,10 @@ export default async function (_options: {}, logger: logging.Logger) {
 
     // There should be at least one BUILD file next to each package.json.
     if (!existsSync(join(pkg.root, 'BUILD')) && !existsSync(join(pkg.root, 'BUILD.bazel'))) {
-      logger.error(tags.oneLine`
-        The package ${JSON.stringify(pkgName)} does not have a BUILD file associated to it. You
-        must either set an exception or make sure it can be built using Bazel.
-      `);
+      logger.error(
+        `The package ${JSON.stringify(pkgName)} does not have a BUILD file associated to it.\n` +
+          'You must either set an exception or make sure it can be built using Bazel.',
+      );
       error = true;
     }
   }

--- a/scripts/validate.ts
+++ b/scripts/validate.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { logging, tags } from '@angular-devkit/core';
+import { logging } from '@angular-devkit/core';
 import { execSync } from 'child_process';
 import templates from './templates';
 import validateBuildFiles from './validate-build-files';
@@ -28,10 +28,9 @@ export default async function (options: { verbose: boolean }, logger: logging.Lo
   const templateLogger = logger.createChild('templates');
   await templates({}, templateLogger);
   if (execSync(`git status --porcelain`).toString()) {
-    logger.error(tags.oneLine`
-      Running templates updated files... Please run "devkit-admin templates" before submitting
-      a PR.
-    `);
+    logger.error(
+      'Running templates updated files... Please run "devkit-admin templates" before submitting a PR.',
+    );
     if (!options.verbose) {
       process.exit(2);
     }


### PR DESCRIPTION
The helpers are unneeded and behavior can be reproduced with direct string usage.  Also, this removes a runtime dependency on the packages being validated.