### PR TITLE
build: update less-loader to v12.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
     "karma-jasmine-html-reporter": "~2.1.0",
     "karma-source-map-support": "1.4.0",
     "less": "4.2.0",
-    "less-loader": "11.1.0",
+    "less-loader": "12.2.0",
     "license-checker": "^25.0.0",
     "license-webpack-plugin": "4.0.2",
     "loader-utils": "3.2.1",

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -38,7 +38,7 @@
     "jsonc-parser": "3.2.1",
     "karma-source-map-support": "1.4.0",
     "less": "4.2.0",
-    "less-loader": "11.1.0",
+    "less-loader": "12.2.0",
     "license-webpack-plugin": "4.0.2",
     "loader-utils": "3.2.1",
     "magic-string": "0.30.8",

--- a/renovate.json
+++ b/renovate.json
@@ -12,13 +12,7 @@
   "dependencyDashboard": true,
   "schedule": ["after 10:00pm every weekday", "before 4:00am every weekday", "every weekend"],
   "baseBranches": ["main"],
-  "ignoreDeps": [
-    "@types/node",
-    "aspect_bazel_lib",
-    "rules_pkg",
-    "less-loader",
-    "copy-webpack-plugin"
-  ],
+  "ignoreDeps": ["@types/node", "aspect_bazel_lib", "rules_pkg", "copy-webpack-plugin"],
   "includePaths": [
     "WORKSPACE",
     "package.json",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9313,6 +9313,11 @@ less-loader@11.1.0:
   dependencies:
     klona "^2.0.4"
 
+less-loader@12.2.0:
+  version "12.2.0"
+  resolved "https://registry.yarnpkg.com/less-loader/-/less-loader-12.2.0.tgz#e1e94522f6abe9e064ef396c29a3151bc6c1b6cc"
+  integrity sha512-MYUxjSQSBUQmowc0l5nPieOYwMzGPUaTzB6inNW/bdPEG9zOL3eAAD1Qw5ZxSPk7we5dMojHwNODYMV1hq4EVg==
+
 less@4.2.0, less@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/less/-/less-4.2.0.tgz#cbefbfaa14a4cd388e2099b2b51f956e1465c450"


### PR DESCRIPTION
Also removes `less-loader` from the renovate update ignore list. The transitive dependency licensing issue has been resolved upstream.