### PR TITLE
feat(@schematics/angular): use TypeScript bundler module resolution for new projects

### DIFF
--- a/packages/schematics/angular/workspace/files/tsconfig.json.template
+++ b/packages/schematics/angular/workspace/files/tsconfig.json.template
@@ -14,7 +14,7 @@
     "sourceMap": true,
     "declaration": false,
     "experimentalDecorators": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "importHelpers": true,
     "target": "ES2022",
     "module": "ES2022",


### PR DESCRIPTION
The `bundler` TypeScript resolution mode is now the default for all newly created Angular CLI projects. This mode allows TypeScript to read and use any package.json `exports` and `imports` fields found within packages including the Angular workspace. Unlike the `node16` option value, this value does not require the use of file extensions for each import and does not require modification of all existing application code to use. The TypeScript language service also benefits from this option by allowing import auto-discovery to leverage any `exports` defined for a package. This is particularly useful for packages such as `@angular/material` which makes extensive use of secondary package exports.

Additional information regarding this resolution mode can be found here: https://www.typescriptlang.org/tsconfig#moduleResolution