### PR TITLE
build: bump `@angular/ssr` framework versions

### DIFF
--- a/docs/process/release.md
+++ b/docs/process/release.md
@@ -72,6 +72,7 @@ manually updated:
 - [`@angular/pwa`](/packages/angular/pwa/package.json)
 - [`@angular-devkit/build-angular`](/packages/angular_devkit/build_angular/package.json)
 - [`@ngtools/webpack`](/packages/ngtools/webpack/package.json)
+- [`@angular/ssr`](/packages/angular/ssr/package.json)
 
 **DURING a minor OR major CLI release:**
 

--- a/packages/angular/ssr/package.json
+++ b/packages/angular/ssr/package.json
@@ -17,8 +17,8 @@
     "tslib": "^2.3.0"
   },
   "peerDependencies": {
-    "@angular/common": "^17.0.0 || ^17.3.0-next.0",
-    "@angular/core": "^17.0.0 || ^17.3.0-next.0"
+    "@angular/common": "^17.0.0",
+    "@angular/core": "^17.0.0"
   },
   "schematics": "./schematics/collection.json",
   "repository": {


### PR DESCRIPTION
Missed this in the previous PR.