### PR TITLE
perf(@angular-devkit/build-angular): reduce build times for apps with  a large number of components when utilizing esbuild-based builders

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/esbuild/angular/compiler-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/angular/compiler-plugin.ts
@@ -420,8 +420,11 @@ export function createCompilerPlugin(
 
           // Combine additional metafiles with main metafile
           if (result.metafile && metafile) {
-            result.metafile.inputs = { ...result.metafile.inputs, ...metafile.inputs };
-            result.metafile.outputs = { ...result.metafile.outputs, ...metafile.outputs };
+            // Append the existing object, by appending to it we prevent unnecessary new objections creations with spread
+            // mitigating significant performance overhead for large apps.
+            // See: https://bugs.chromium.org/p/v8/issues/detail?id=11536
+            Object.assign(result.metafile.inputs, metafile.inputs);
+            Object.assign(result.metafile.outputs, metafile.outputs);
           }
         }
 

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/bundler-context.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/bundler-context.ts
@@ -18,7 +18,7 @@ import {
   context,
 } from 'esbuild';
 import assert from 'node:assert';
-import { basename, dirname, extname, join, relative } from 'node:path';
+import { basename, extname, join, relative } from 'node:path';
 import { LoadResultCache, MemoryLoadResultCache } from './load-result-cache';
 import { convertOutputFile } from './utils';
 

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/bundler-context.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/bundler-context.ts
@@ -136,8 +136,8 @@ export class BundlerContext {
 
       // Combine metafiles used for the stats option as well as bundle budgets and console output
       if (result.metafile) {
-        metafile.inputs = { ...metafile.inputs, ...result.metafile.inputs };
-        metafile.outputs = { ...metafile.outputs, ...result.metafile.outputs };
+        Object.assign(metafile.inputs, result.metafile.inputs);
+        Object.assign(metafile.outputs, result.metafile.outputs);
       }
 
       result.initialFiles.forEach((value, key) => initialFiles.set(key, value));


### PR DESCRIPTION
In this commit, we've optimized the build performance for applications containing a large number of components when using the esbuild-based builder. This optimization entails replacing the spread operator with `Object.assign` when appending to the result metadata in the Angular compiler plugin to avoid creating multiple copies of the object.

See: https://bugs.chromium.org/p/v8/issues/detail?id=11536

**Previous Performance**:
- Initial compilation: 37 seconds
- First incremental build: 20 seconds
- Second incremental build: 16 seconds

**Updated Performance**:
- Initial compilation: 24 seconds
- First incremental build: 6 seconds
- Second incremental build: 2 seconds

Closes #27280
