### PR TITLE
refactor: remove `forceConsistentCasingInFileNames` from tsconfig files

### DIFF
--- a/packages/schematics/angular/workspace/files/tsconfig.json.template
+++ b/packages/schematics/angular/workspace/files/tsconfig.json.template
@@ -3,7 +3,6 @@
   "compileOnSave": false,
   "compilerOptions": {
     "outDir": "./dist/out-tsc",<% if (strict) { %>
-    "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,
     "noPropertyAccessFromIndexSignature": true,

--- a/tests/legacy-cli/e2e/assets/15.0-project/tsconfig.json
+++ b/tests/legacy-cli/e2e/assets/15.0-project/tsconfig.json
@@ -4,7 +4,6 @@
   "compilerOptions": {
     "baseUrl": "./",
     "outDir": "./dist/out-tsc",
-    "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,
     "noPropertyAccessFromIndexSignature": true,

--- a/tests/legacy-cli/e2e/assets/17-ssr-project-webpack/tsconfig.json
+++ b/tests/legacy-cli/e2e/assets/17-ssr-project-webpack/tsconfig.json
@@ -4,7 +4,6 @@
   "compilerOptions": {
     "baseUrl": "./",
     "outDir": "./dist/out-tsc",
-    "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,
     "noPropertyAccessFromIndexSignature": true,


### PR DESCRIPTION
This option is enabled by default and hence it does not need to be specified.

See: https://www.typescriptlang.org/tsconfig#forceConsistentCasingInFileNames
