### PR TITLE
refactor(@schematics/angular): remove internal `linkCli` ng-new option

### DIFF
--- a/goldens/public-api/angular_devkit/schematics/tasks/index.md
+++ b/goldens/public-api/angular_devkit/schematics/tasks/index.md
@@ -27,7 +27,7 @@ export class NodePackageInstallTask implements TaskConfigurationGenerator<NodePa
     workingDirectory?: string;
 }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export class NodePackageLinkTask implements TaskConfigurationGenerator<NodePackageTaskOptions> {
     constructor(packageName?: string | undefined, workingDirectory?: string | undefined);
     // (undocumented)

--- a/packages/angular_devkit/schematics/tasks/package-manager/link-task.ts
+++ b/packages/angular_devkit/schematics/tasks/package-manager/link-task.ts
@@ -9,10 +9,16 @@
 import { TaskConfiguration, TaskConfigurationGenerator } from '../../src';
 import { NodePackageName, NodePackageTaskOptions } from './options';
 
+/**
+ * @deprecated since version 18. Create a custom task if required.
+ */
 export class NodePackageLinkTask implements TaskConfigurationGenerator<NodePackageTaskOptions> {
   quiet = true;
 
-  constructor(public packageName?: string, public workingDirectory?: string) {}
+  constructor(
+    public packageName?: string,
+    public workingDirectory?: string,
+  ) {}
 
   toConfiguration(): TaskConfiguration<NodePackageTaskOptions> {
     return {

--- a/packages/schematics/angular/ng-new/index.ts
+++ b/packages/schematics/angular/ng-new/index.ts
@@ -20,7 +20,6 @@ import {
 } from '@angular-devkit/schematics';
 import {
   NodePackageInstallTask,
-  NodePackageLinkTask,
   RepositoryInitializerTask,
 } from '@angular-devkit/schematics/tasks';
 import { Schema as ApplicationOptions } from '../application/schema';
@@ -77,12 +76,6 @@ export default function (options: NgNewOptions): Rule {
             packageManager: options.packageManager,
           }),
         );
-        if (options.linkCli) {
-          packageTask = context.addTask(
-            new NodePackageLinkTask('@angular/cli', options.directory),
-            [packageTask],
-          );
-        }
       }
       if (!options.skipGit) {
         const commit =

--- a/packages/schematics/angular/ng-new/schema.json
+++ b/packages/schematics/angular/ng-new/schema.json
@@ -24,12 +24,6 @@
       "type": "boolean",
       "default": false
     },
-    "linkCli": {
-      "description": "Link the CLI to the global version (internal development only).",
-      "type": "boolean",
-      "default": false,
-      "visible": false
-    },
     "skipGit": {
       "description": "Do not initialize a git repository.",
       "type": "boolean",


### PR DESCRIPTION
`yarn ng-dev misc build-and-link <path-to-local-project-root>` should be used instead.
