### PR TITLE
build: address issue with snapshot publishing due incorrect property access

### DIFF
--- a/scripts/snapshots.mts
+++ b/scripts/snapshots.mts
@@ -74,7 +74,7 @@ async function _publishSnapshot(
   message: string,
   githubToken: string,
 ) {
-  const snapshotRepo = monorepoData[pkg.name]?.snapshotRepo;
+  const snapshotRepo = monorepoData.packages[pkg.name]?.snapshotRepo;
   if (!snapshotRepo) {
     console.warn(`Skipping ${pkg.name}.`);
 


### PR DESCRIPTION


This should fix the snpashot publishing which are currently being skipped.

```
    Skipping @angular/cli.
    Skipping @angular/create.
    Skipping @angular/pwa.
    Skipping @angular/ssr.
    Skipping @angular-devkit/architect.
    Skipping @angular-devkit/architect-cli.
    Skipping @angular-devkit/build-angular.
    Skipping @angular-devkit/build-webpack.
    Skipping @angular-devkit/core.
    Skipping @angular-devkit/schematics.
    Skipping @angular-devkit/schematics-cli.
    Skipping @ngtools/webpack.
    Skipping @schematics/angular.
```
