### PR TITLE
build: trim SHA used for snapshot tags

### DIFF
--- a/scripts/snapshots.mts
+++ b/scripts/snapshots.mts
@@ -125,7 +125,7 @@ async function _publishSnapshot(
   fs.writeFileSync(path.join(destPath, 'uniqueId'), '' + new Date());
 
   // Ensure we call git from within this repo
-  gitShaCache ??= _exec('git', ['log', '--format=%h', '-n1'], { cwd: __dirname });
+  gitShaCache ??= _exec('git', ['log', '--format=%h', '-n1'], { cwd: __dirname }).trim();
 
   // Commit and push.
   _exec('git', ['add', '.'], { cwd: destPath });


### PR DESCRIPTION
This should fix

```
fatal: 'c22bda9
' is not a valid tag name.
Command failed: git "tag", "c22bda9\n"
file:///home/runner/work/angular-cli/angular-cli/scripts/devkit-admin.mts:39
        console.error(err.stack);
```