### PR TITLE
perf(@angular-devkit/build-angular): avoid transforming empty component stylesheets

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/esbuild/angular/angular-host.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/angular/angular-host.ts
@@ -68,6 +68,11 @@ export function createAngularCompilerHost(
       return null;
     }
 
+    // No transformation required if the resource is empty
+    if (data.trim().length === 0) {
+      return { content: '' };
+    }
+
     const result = await hostOptions.transformStylesheet(
       data,
       context.containingFile,


### PR DESCRIPTION
A stylesheet for a component that is empty or contains only whitespace will no longer be transformed and bundled during a build. Transforming the stylesheet was unnecessary work as an empty string would be returned as a result. While this may not be common in applications, it is a possibility. Both file and inline component stylesheets are affected by this change.