### PR TITLE
refactor(@angular/cli): remove unneeded devkit core tag helper usage

### DIFF
--- a/packages/angular/cli/src/command-builder/utilities/schematic-workflow.ts
+++ b/packages/angular/cli/src/command-builder/utilities/schematic-workflow.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { logging, tags } from '@angular-devkit/core';
+import { logging } from '@angular-devkit/core';
 import { NodeWorkflow } from '@angular-devkit/schematics/tools';
 import { colors } from '../../utilities/color';
 
@@ -33,15 +33,11 @@ export function subscribeToWorkflow(
         logger.error(`ERROR! ${eventPath} ${desc}.`);
         break;
       case 'update':
-        logs.push(tags.oneLine`
-              ${colors.cyan('UPDATE')} ${eventPath} (${event.content.length} bytes)
-            `);
+        logs.push(`${colors.cyan('UPDATE')} ${eventPath} (${event.content.length} bytes)`);
         files.add(eventPath);
         break;
       case 'create':
-        logs.push(tags.oneLine`
-              ${colors.green('CREATE')} ${eventPath} (${event.content.length} bytes)
-            `);
+        logs.push(`${colors.green('CREATE')} ${eventPath} (${event.content.length} bytes)`);
         files.add(eventPath);
         break;
       case 'delete':

--- a/packages/angular/cli/src/commands/add/cli.ts
+++ b/packages/angular/cli/src/commands/add/cli.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { tags } from '@angular-devkit/core';
 import { NodePackageDoesNotSupportSchematics } from '@angular-devkit/schematics/tools';
 import { createRequire } from 'module';
 import npa from 'npm-package-arg';
@@ -397,10 +396,10 @@ export default class AddCommandModule
       });
     } catch (e) {
       if (e instanceof NodePackageDoesNotSupportSchematics) {
-        this.context.logger.error(tags.oneLine`
-          The package that you are trying to add does not support schematics. You can try using
-          a different version of the package or contact the package author to add ng-add support.
-        `);
+        this.context.logger.error(
+          'The package that you are trying to add does not support schematics.' +
+            'You can try using a different version of the package or contact the package author to add ng-add support.',
+        );
 
         return 1;
       }

--- a/packages/angular/cli/src/commands/update/schematic/index.ts
+++ b/packages/angular/cli/src/commands/update/schematic/index.ts
@@ -6,12 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { logging, tags } from '@angular-devkit/core';
+import { logging } from '@angular-devkit/core';
 import { Rule, SchematicContext, SchematicsException, Tree } from '@angular-devkit/schematics';
 import * as npa from 'npm-package-arg';
 import type { Manifest } from 'pacote';
 import * as semver from 'semver';
-import { assertIsError } from '../../../utilities/error';
 import {
   NgPackageManifestProperties,
   NpmRepositoryPackageJson,
@@ -249,9 +248,11 @@ function _validateUpdatePackages(
   });
 
   if (!force && peerErrors) {
-    throw new SchematicsException(tags.stripIndents`Incompatible peer dependencies found.
-      Peer dependency warnings when installing dependencies means that those dependencies might not work correctly together.
-      You can use the '--force' option to ignore incompatible peer dependencies and instead address these warnings later.`);
+    throw new SchematicsException(
+      'Incompatible peer dependencies found.\n' +
+        'Peer dependency warnings when installing dependencies means that those dependencies might not work correctly together.\n' +
+        `You can use the '--force' option to ignore incompatible peer dependencies and instead address these warnings later.`,
+    );
   }
 }
 


### PR DESCRIPTION
Direct string usage can be leveraged to remove the need for the helpers and reduce imports of `@angular-devkit/core`.