### PR TITLE
fix(@angular-devkit/build-angular): only generate `server` directory when SSR is  enabled

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/application/tests/options/ssr_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/tests/options/ssr_spec.ts
@@ -50,5 +50,47 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
       expect(result?.success).toBeTrue();
       harness.expectFile('dist/server/server.mjs').toExist();
     });
+
+    it(`should emit 'server' directory when 'ssr' is 'true'`, async () => {
+      await harness.writeFile('file.mjs', `console.log('Hello!');`);
+
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        server: 'src/main.server.ts',
+        ssr: true,
+      });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
+      harness.expectDirectory('dist/server').toExist();
+    });
+
+    it(`should not emit 'server' directory when 'ssr' is 'false'`, async () => {
+      await harness.writeFile('file.mjs', `console.log('Hello!');`);
+
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        server: 'src/main.server.ts',
+        ssr: false,
+      });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
+      harness.expectDirectory('dist/server').toNotExist();
+    });
+
+    it(`should not emit 'server' directory when 'ssr' is not set`, async () => {
+      await harness.writeFile('file.mjs', `console.log('Hello!');`);
+
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        server: 'src/main.server.ts',
+        ssr: undefined,
+      });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
+      harness.expectDirectory('dist/server').toNotExist();
+    });
   });
 });

--- a/packages/angular_devkit/build_angular/src/tools/esbuild/utils.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/utils.ts
@@ -217,7 +217,7 @@ export function getFeatureSupport(target: string[]): BuildOptions['supported'] {
 export async function writeResultFiles(
   outputFiles: BuildOutputFile[],
   assetFiles: BuildOutputAsset[] | undefined,
-  { base, browser, media, server }: NormalizedOutputOptions,
+  { base, browser, server }: NormalizedOutputOptions,
 ) {
   const directoryExists = new Set<string>();
   const ensureDirectoryExists = async (destPath: string) => {


### PR DESCRIPTION

Previously, the `server` directory was erroneously generated even in instances where SSG was enabled but SSR remained inactive.

