### PR TITLE
fix(@angular-devkit/build-angular): typo in allowedHosts warning for unsupported vite options

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/dev-server/builder.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/builder.ts
@@ -78,7 +78,7 @@ export function execute(
 
         if (options.allowedHosts?.length) {
           context.logger.warn(
-            `The "allowedHost" option will not be used because it is not supported by the "${builderName}" builder.`,
+            `The "allowedHosts" option will not be used because it is not supported by the "${builderName}" builder.`,
           );
         }
 


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

The warning mentions `allowedHost` instead of `allowedHosts`.

## What is the new behavior?

Warning is fixed

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
