### PR TITLE
fix(@schematics/angular): improve Sass format clarity for application style option

### DIFF
--- a/packages/schematics/angular/application/schema.json
+++ b/packages/schematics/angular/application/schema.json
@@ -59,18 +59,21 @@
         "message": "Which stylesheet format would you like to use?",
         "type": "list",
         "items": [
-          { "value": "css", "label": "CSS" },
+          {
+            "value": "css",
+            "label": "CSS             [ https://developer.mozilla.org/docs/Web/CSS                     ]"
+          },
           {
             "value": "scss",
-            "label": "SCSS   [ https://sass-lang.com/documentation/syntax#scss                ]"
+            "label": "Sass (SCSS)     [ https://sass-lang.com/documentation/syntax#scss                ]"
           },
           {
             "value": "sass",
-            "label": "Sass   [ https://sass-lang.com/documentation/syntax#the-indented-syntax ]"
+            "label": "Sass (Indented) [ https://sass-lang.com/documentation/syntax#the-indented-syntax ]"
           },
           {
             "value": "less",
-            "label": "Less   [ http://lesscss.org                                             ]"
+            "label": "Less            [ http://lesscss.org                                             ]"
           }
         ]
       },


### PR DESCRIPTION
The labels of the Sass preprocessor stylesheet option values have been updated for the `application` schematic's `style` option. The labels now provide greater clarity regarding the preprocessor tool used for both the SCSS (more common) and indented Sass syntaxes.

The new list selection prompt is now as follows:
```
? Which stylesheet format would you like to use? (Use arrow keys)
❯ CSS             [ https://developer.mozilla.org/docs/Web/CSS                     ]
  Sass (SCSS)     [ https://sass-lang.com/documentation/syntax#scss                ]
  Sass (Indented) [ https://sass-lang.com/documentation/syntax#the-indented-syntax ]
  Less            [ http://lesscss.org                                             ]
```