### PR TITLE
build: a couple of tweaks and fixes to `yarn admin create`.

### DIFF
--- a/scripts/devkit-admin.mts
+++ b/scripts/devkit-admin.mts
@@ -14,6 +14,9 @@ import yargsParser from 'yargs-parser';
 
 const args = yargsParser(process.argv.slice(2), {
   boolean: ['verbose'],
+  configuration: {
+    'camel-case-expansion': false,
+  },
 });
 const scriptName = args._.shift();
 


### PR DESCRIPTION
This update addresses an issue where an older version of the CLI tarball was mistakenly employed in creating a new application via `yarn admin create`.

Additionally, `yarn admin create` now accommodates extra options that can be utilized with `ng new`.

Example:
```
yarn admin create my-app --ssr
```
