### PR TITLE
fix(@angular-devkit/build-angular): `Internal server error: Invalid URL` when using a non localhost IP

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/vite/angular-memory-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/tools/vite/angular-memory-plugin.ts
@@ -219,9 +219,12 @@ export function createAngularMemoryPlugin(options: AngularMemoryPluginOptions): 
           }
 
           transformIndexHtmlAndAddHeaders(req.url, rawHtml, res, next, async (html) => {
+            const resolvedUrls = server.resolvedUrls;
+            const baseUrl = resolvedUrls?.local[0] ?? resolvedUrls?.network[0];
+
             const { content } = await renderPage({
               document: html,
-              route: new URL(req.originalUrl ?? '/', server.resolvedUrls?.local[0]).toString(),
+              route: new URL(req.originalUrl ?? '/', baseUrl).toString(),
               serverContext: 'ssr',
               loadBundle: (uri: string) =>
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION


When using a non-localhost IP, Vite will correctly populate the `network` property of the `server.resolvedUrls` instead of `local`.

Example:
```
ng server --host=127.0.0.2
{ local: [], network: [ 'http://127.0.0.2:4200/' ] }
```

Closes #27327
