### PR TITLE
refactor(@angular-devkit/build-angular): directly configure internal babel plugins for application builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/babel/plugins/index.ts
+++ b/packages/angular_devkit/build_angular/src/tools/babel/plugins/index.ts
@@ -1,0 +1,12 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export { default as adjustStaticMembers } from './adjust-static-class-members';
+export { default as adjustTypeScriptEnums } from './adjust-typescript-enums';
+export { default as elideAngularMetadata } from './elide-angular-metadata';
+export { default as markTopLevelPure } from './pure-toplevel-functions';


### PR DESCRIPTION
The linker and build optimizer related babel plugins are now directly imported when needed within the JavaScript transformer worker code. This lowers the number of transitive modules that must be loaded for each worker instance. It also removes the use of `require` from the initialization code which provides support for full ESM output in the future.