### PR TITLE
fix(@schematics/angular): rename SSR port env variable

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/ssr-dev-server/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/ssr-dev-server/index.ts
@@ -220,7 +220,7 @@ function startNodeServer(
 ): Observable<void> {
   const outputPath = serverOutput.outputPath as string;
   const path = join(outputPath, 'main.js');
-  const env = { ...process.env, PORT: '' + port };
+  const env = { ...process.env, SSR_PORT: '' + port, PORT: '' + port };
 
   const args = ['--enable-source-maps', `"${path}"`];
   if (inspectMode) {

--- a/packages/angular_devkit/build_angular/src/builders/ssr-dev-server/specs/proxy_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/ssr-dev-server/specs/proxy_spec.ts
@@ -58,7 +58,7 @@ describe('Serve SSR Builder', () => {
           return server;
         }
 
-        app().listen(process.env['PORT']);
+        app().listen(process.env['SSR_PORT']);
 
         export * from './app/app.module.server';
       `,

--- a/packages/angular_devkit/build_angular/src/builders/ssr-dev-server/specs/ssl_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/ssr-dev-server/specs/ssl_spec.ts
@@ -58,7 +58,7 @@ describe('Serve SSR Builder', () => {
           return server;
         }
 
-        app().listen(process.env['PORT']);
+        app().listen(process.env['SSR_PORT']);
 
         export * from './app/app.module.server';
       `,

--- a/packages/angular_devkit/build_angular/src/builders/ssr-dev-server/specs/works_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/ssr-dev-server/specs/works_spec.ts
@@ -57,7 +57,7 @@ describe('Serve SSR Builder', () => {
         return server;
       }
 
-      app().listen(process.env['PORT']);
+      app().listen(process.env['SSR_PORT']);
 
       export * from './app/app.module.server';
       `,

--- a/packages/schematics/angular/migrations/update-17/replace-nguniversal-engines.ts
+++ b/packages/schematics/angular/migrations/update-17/replace-nguniversal-engines.ts
@@ -199,7 +199,7 @@ export function app(): express.Express {
 }
 
 function run(): void {
-  const port = process.env['PORT'] || 4000;
+  const port = process.env['SSR_PORT'] || 4000;
 
   // Start up the Node server
   const server = app();

--- a/packages/schematics/angular/migrations/update-17/replace-nguniversal-engines_spec.ts
+++ b/packages/schematics/angular/migrations/update-17/replace-nguniversal-engines_spec.ts
@@ -128,7 +128,7 @@ export function app(): express.Express {
 }
 
 function run() {
-  const port = process.env.PORT || 4000;
+  const port = process.env.SSR_PORT || 4000;
 
   // Start up the Node server
   const server = app();

--- a/packages/schematics/angular/ssr/files/application-builder/server.ts.template
+++ b/packages/schematics/angular/ssr/files/application-builder/server.ts.template
@@ -44,7 +44,7 @@ export function app(): express.Express {
 }
 
 function run(): void {
-  const port = process.env['PORT'] || 4000;
+  const port = process.env['SSR_PORT'] || 4000;
 
   // Start up the Node server
   const server = app();

--- a/packages/schematics/angular/ssr/files/server-builder/server.ts.template
+++ b/packages/schematics/angular/ssr/files/server-builder/server.ts.template
@@ -47,7 +47,7 @@ export function app(): express.Express {
 }
 
 function run(): void {
-  const port = process.env['PORT'] || 4000;
+  const port = process.env['SSR_PORT'] || 4000;
 
   // Start up the Node server
   const server = app();

--- a/tests/legacy-cli/e2e/assets/18-ssr-project-webpack/server.ts
+++ b/tests/legacy-cli/e2e/assets/18-ssr-project-webpack/server.ts
@@ -47,7 +47,7 @@ export function app(): express.Express {
 }
 
 function run(): void {
-  const port = process.env['PORT'] || 4000;
+  const port = process.env['SSR_PORT'] || 4000;
 
   // Start up the Node server
   const server = app();


### PR DESCRIPTION
Rename SSR port env variable to SSR_PORT.

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

Rename the SSR port env variable to SSR_PORT.
It could help to resolve this firebase issue: https://github.com/firebase/firebase-tools/issues/6651#issuecomment-1881647322, cause PORT is reserved environment variable: https://firebase.google.com/docs/functions/config-env?gen=2nd#reserved-names.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
