### PR TITLE
fix(@angular-devkit/build-angular): service-worker references non-existent named index output

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/application/execute-post-bundle.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/execute-post-bundle.ts
@@ -153,10 +153,12 @@ export async function executePostBundleSteps(
         workspaceRoot,
         serviceWorker,
         options.baseHref || '/',
+        options.indexHtmlOptions?.output,
         // Ensure additional files recently added are used
         [...outputFiles, ...additionalOutputFiles],
         assetFiles,
       );
+
       additionalOutputFiles.push(
         createOutputFileFromText(
           'ngsw.json',

--- a/packages/angular_devkit/build_angular/src/builders/application/options.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/options.ts
@@ -326,8 +326,12 @@ export async function normalizeOptions(
     fileReplacements,
     globalStyles,
     globalScripts,
-    serviceWorker:
-      typeof serviceWorker === 'string' ? path.join(workspaceRoot, serviceWorker) : undefined,
+    serviceWorker: serviceWorker
+      ? path.join(
+          workspaceRoot,
+          typeof serviceWorker === 'string' ? serviceWorker : 'src/ngsw-config.json',
+        )
+      : undefined,
     indexHtmlOptions,
     tailwindConfiguration,
     postcssConfiguration,

--- a/packages/angular_devkit/build_angular/src/builders/application/tests/options/service-worker_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/tests/options/service-worker_spec.ts
@@ -1,0 +1,92 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { buildApplication } from '../../index';
+import { APPLICATION_BUILDER_INFO, BASE_OPTIONS, describeBuilder } from '../setup';
+
+describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
+  describe('Option: "serviceWorker"', () => {
+    beforeEach(async () => {
+      const manifest = {
+        index: '/index.html',
+        assetGroups: [
+          {
+            name: 'app',
+            installMode: 'prefetch',
+            resources: {
+              files: ['/favicon.ico', '/index.html'],
+            },
+          },
+          {
+            name: 'assets',
+            installMode: 'lazy',
+            updateMode: 'prefetch',
+            resources: {
+              files: [
+                '/assets/**',
+                '/*.(svg|cur|jpg|jpeg|png|apng|webp|avif|gif|otf|ttf|woff|woff2)',
+              ],
+            },
+          },
+        ],
+      };
+
+      await harness.writeFile('src/ngsw-config.json', JSON.stringify(manifest));
+    });
+
+    it('should not generate SW config when option is unset', async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        serviceWorker: undefined,
+      });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
+      harness.expectFile('dist/browser/ngsw.json').toNotExist();
+    });
+
+    it('should not generate SW config when option is false', async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        serviceWorker: false,
+      });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
+      harness.expectFile('dist/browser/ngsw.json').toNotExist();
+    });
+
+    it('should generate SW config when option is true', async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        serviceWorker: true,
+      });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
+      harness.expectFile('dist/browser/ngsw.json').toExist();
+    });
+
+    it('should generate SW config referencing index output', async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        serviceWorker: true,
+        index: {
+          input: 'src/index.html',
+          output: 'index.csr.html',
+        },
+      });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBe(true);
+
+      const config = await harness.readFile('dist/browser/ngsw.json');
+      expect(JSON.parse(config)).toEqual(jasmine.objectContaining({ index: '/index.csr.html' }));
+    });
+  });
+});

--- a/packages/angular_devkit/build_angular/src/utils/service-worker.ts
+++ b/packages/angular_devkit/build_angular/src/utils/service-worker.ts
@@ -180,6 +180,7 @@ export async function augmentAppWithServiceWorkerEsbuild(
   workspaceRoot: string,
   configPath: string,
   baseHref: string,
+  indexHtml: string | undefined,
   outputFiles: BuildOutputFile[],
   assetFiles: BuildOutputAsset[],
 ): Promise<{ manifest: string; assetFiles: BuildOutputAsset[] }> {
@@ -188,6 +189,10 @@ export async function augmentAppWithServiceWorkerEsbuild(
   try {
     const configurationData = await fsPromises.readFile(configPath, 'utf-8');
     config = JSON.parse(configurationData) as Config;
+
+    if (indexHtml) {
+      config.index = indexHtml;
+    }
   } catch (error) {
     assertIsError(error);
     if (error.code === 'ENOENT') {


### PR DESCRIPTION

This commit addresses an issue where the service worker incorrectly referenced a non-existent `index.html` when utilizing the output index option. Additionally, it ensures proper resolution of the service worker configuration when the option value is set to `true`.

