### PR TITLE
refactor(@angular-devkit/build-angular): update babel application preset with new plugin import location

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/babel/presets/application.ts
+++ b/packages/angular_devkit/build_angular/src/tools/babel/presets/application.ts
@@ -248,18 +248,20 @@ export default function (api: unknown, options: ApplicationPresetOptions) {
   }
 
   if (options.optimize) {
+    const {
+      adjustStaticMembers,
+      adjustTypeScriptEnums,
+      elideAngularMetadata,
+      markTopLevelPure,
+    } = require('../plugins');
     if (options.optimize.pureTopLevel) {
-      plugins.push(require('../plugins/pure-toplevel-functions').default);
+      plugins.push(markTopLevelPure);
     }
 
-    plugins.push(
-      require('../plugins/elide-angular-metadata').default,
-      [require('../plugins/adjust-typescript-enums').default, { loose: true }],
-      [
-        require('../plugins/adjust-static-class-members').default,
-        { wrapDecorators: options.optimize.wrapDecorators },
-      ],
-    );
+    plugins.push(elideAngularMetadata, adjustTypeScriptEnums, [
+      adjustStaticMembers,
+      { wrapDecorators: options.optimize.wrapDecorators },
+    ]);
   }
 
   if (options.instrumentCode) {


### PR DESCRIPTION
The babel application preset that is used with the Webpack-based build system now also uses the updated location for the build optimizer plugins. This also reduces the amount of require statements in the setup function for the preset.