### PR TITLE
build: address pre-release validation failure

### DIFF
--- a/packages/schematics/angular/utility/latest-versions.ts
+++ b/packages/schematics/angular/utility/latest-versions.ts
@@ -6,17 +6,19 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+// We could have used TypeScripts' `resolveJsonModule` to make the `latestVersion` object typesafe,
+// but ts_library doesn't support JSON inputs.
+const dependencies = require('./latest-versions/package.json')['dependencies'];
+
 export const latestVersions: Record<string, string> & {
   Angular: string;
   DevkitBuildAngular: string;
   AngularSSR: string;
 } = {
-  // We could have used TypeScripts' `resolveJsonModule` to make the `latestVersion` object typesafe,
-  // but ts_library doesn't support JSON inputs.
-  ...require('./latest-versions/package.json')['dependencies'],
+  ...dependencies,
 
   // As Angular CLI works with same minor versions of Angular Framework, a tilde match for the current
-  Angular: '^17.3.0',
+  Angular: dependencies['@angular/core'],
 
   DevkitBuildAngular: '^0.0.0-PLACEHOLDER',
   AngularSSR: '^0.0.0-PLACEHOLDER',

--- a/packages/schematics/angular/utility/latest-versions/package.json
+++ b/packages/schematics/angular/utility/latest-versions/package.json
@@ -3,6 +3,7 @@
   "comment": "This file is needed so that dependencies are synced by Renovate.",
   "private": true,
   "dependencies": {
+    "@angular/core": "^17.3.0",
     "@types/express": "^4.17.17",
     "@types/jasmine": "~5.1.0",
     "@types/node": "^18.18.0",

--- a/scripts/release-checks/dependency-ranges/latest-versions-check.mts
+++ b/scripts/release-checks/dependency-ranges/latest-versions-check.mts
@@ -6,16 +6,17 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import { readFile } from 'node:fs/promises';
 import semver from 'semver';
 
 export async function checkSchematicsAngularLatestVersion(
   newVersion: semver.SemVer,
 ): Promise<string[]> {
-  const {
-    default: { latestVersions },
-  } = await import('../../../packages/schematics/angular/utility/latest-versions.js');
+  const { dependencies } = JSON.parse(
+    await readFile('./packages/schematics/angular/utility/latest-versions/package.json', 'utf-8'),
+  );
 
-  const keysToCheck = ['ng-packagr', 'Angular'];
+  const keysToCheck = ['ng-packagr', '@angular/core'];
   const { major, minor } = newVersion;
   const isPrerelease = !!newVersion.prerelease[0];
   const failures: string[] = [];
@@ -26,7 +27,7 @@ export async function checkSchematicsAngularLatestVersion(
   }
 
   for (const key of keysToCheck) {
-    if (latestVersions[key] !== expectedFwDep) {
+    if (dependencies[key] !== expectedFwDep) {
       failures.push(
         `latest-versions: Invalid dependency range for "${key}". Expected: ${expectedFwDep}`,
       );


### PR DESCRIPTION
Previously, the release process encountered an error due to ts-node's inability to transform `packages/schematics/angular/utility/latest-versions.ts`, resulting in the following error:

```
export const latestVersions: Record<string, string> & {
^^^^^^

SyntaxError: Unexpected token 'export'
    at internalCompileFunction (node:internal/vm:73:18)
    at wrapSafe (node:internal/modules/cjs/loader:1274:20)
    at Module._compile (node:internal/modules/cjs/loader:1320:27)
    at Module._extensions..js (node:internal/modules/cjs/loader:1414:10)
    at Module.load (node:internal/modules/cjs/loader:1197:32)
    at Module._load (node:internal/modules/cjs/loader:1013:12)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/translators:202:29)
    at ModuleJob.run (node:internal/modules/esm/module_job:195:25)
    at async ModuleLoader.import (node:internal/modules/esm/loader:336:24)
    at async checkSchematicsAngularLatestVersion (file:///usr/..../git/angular-cli/scripts/release-checks/dependency-ranges/latest-versions-check.mts:9:46)
```

To resolve this issue, we now utilize the `package.json` directly to retrieve dependency versions.

(cherry picked from commit 7682a7145f817241f6e4dc6036f1334b16efb235)
