### PR TITLE
build: narrow down supported TypeScript versions

### DIFF
--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -86,7 +86,7 @@
     "ng-packagr": "^18.0.0-next.0",
     "protractor": "^7.0.0",
     "tailwindcss": "^2.0.0 || ^3.0.0",
-    "typescript": ">=5.2 <5.5"
+    "typescript": ">=5.4 <5.5"
   },
   "peerDependenciesMeta": {
     "@angular/localize": {

--- a/packages/ngtools/webpack/package.json
+++ b/packages/ngtools/webpack/package.json
@@ -23,7 +23,7 @@
   "dependencies": {},
   "peerDependencies": {
     "@angular/compiler-cli": "^18.0.0-next.0",
-    "typescript": ">=5.2 <5.5",
+    "typescript": ">=5.4 <5.5",
     "webpack": "^5.54.0"
   },
   "devDependencies": {

--- a/tests/legacy-cli/e2e/assets/18-ssr-project-webpack/package.json
+++ b/tests/legacy-cli/e2e/assets/18-ssr-project-webpack/package.json
@@ -42,6 +42,6 @@
     "karma-coverage": "~2.2.0",
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.1.0",
-    "typescript": "~5.3.2"
+    "typescript": "~5.4.2"
   }
 }


### PR DESCRIPTION
In https://github.com/angular/angular/pull/54961 the Angular compiler stopped supporting TypeScript versions older than 5.4. These changes narrow down the range for Tooling.