### PR TITLE
feat(@schematics/angular): use zone eventCoalescing by default

### DIFF
--- a/packages/schematics/angular/application/files/module-files/src/main.ts.template
+++ b/packages/schematics/angular/application/files/module-files/src/main.ts.template
@@ -3,11 +3,8 @@
 
 import { AppModule } from './app/app.module';
 
-<% if(!!viewEncapsulation) { %>
 platformBrowserDynamic().bootstrapModule(AppModule, {
-  defaultEncapsulation: ViewEncapsulation.<%= viewEncapsulation %>
+  ngZoneEventCoalescing: true<% if(!!viewEncapsulation) { %>,
+  defaultEncapsulation: ViewEncapsulation.<%= viewEncapsulation %><% } %>
 })
-  .catch(err => console.error(err));<% } else { %>
-platformBrowserDynamic().bootstrapModule(AppModule)
   .catch(err => console.error(err));
-<% } %>

--- a/packages/schematics/angular/application/files/standalone-files/src/app/app.config.ts.template
+++ b/packages/schematics/angular/application/files/standalone-files/src/app/app.config.ts.template
@@ -1,8 +1,8 @@
-import { ApplicationConfig } from '@angular/core';<% if (routing) { %>
+import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';<% if (routing) { %>
 import { provideRouter } from '@angular/router';
 
 import { routes } from './app.routes';<% } %>
 
 export const appConfig: ApplicationConfig = {
-  providers: [<% if (routing) { %>provideRouter(routes)<% } %>]
+  providers: [provideZoneChangeDetection({eventCoalescing: true})<% if (routing) { %>, provideRouter(routes)<% } %>]
 };

--- a/packages/schematics/angular/application/index_spec.ts
+++ b/packages/schematics/angular/application/index_spec.ts
@@ -540,6 +540,14 @@ describe('Application Schematic', () => {
     expect(moduleFiles.length).toEqual(0);
   });
 
+  it('should enable zone event coalescing by default', async () => {
+    const options = { ...defaultOptions, standalone: true };
+
+    const tree = await schematicRunner.runSchematic('application', options, workspaceTree);
+    const appConfig = tree.readContent('/projects/foo/src/app/app.config.ts');
+    expect(appConfig).toContain('provideZoneChangeDetection({eventCoalescing: true})');
+  });
+
   it('should create a standalone component', async () => {
     const options = { ...defaultOptions, standalone: true };
 
@@ -575,6 +583,20 @@ describe('Application Schematic', () => {
   });
 
   describe('standalone=false', () => {
+    it('should add the ngZoneEventCoalescing option by default', async () => {
+      const tree = await schematicRunner.runSchematic(
+        'application',
+        {
+          ...defaultOptions,
+          standalone: false,
+        },
+        workspaceTree,
+      );
+
+      const content = tree.readContent('/projects/foo/src/main.ts');
+      expect(content).toContain('ngZoneEventCoalescing: true');
+    });
+
     it(`should set 'defaultEncapsulation' in main.ts when 'ViewEncapsulation' is provided`, async () => {
       const tree = await schematicRunner.runSchematic(
         'application',

--- a/packages/schematics/angular/server/index_spec.ts
+++ b/packages/schematics/angular/server/index_spec.ts
@@ -138,7 +138,7 @@ describe('Server Schematic', () => {
     it(`should add 'provideClientHydration' to the providers list`, async () => {
       const tree = await schematicRunner.runSchematic('server', defaultOptions, appTree);
       const contents = tree.readContent('/projects/bar/src/app/app.config.ts');
-      expect(contents).toContain(`providers: [provideClientHydration()]`);
+      expect(contents).toContain(`provideClientHydration()`);
     });
   });
 

--- a/packages/schematics/angular/service-worker/index_spec.ts
+++ b/packages/schematics/angular/service-worker/index_spec.ts
@@ -128,17 +128,19 @@ describe('Service Worker Schematic', () => {
     const tree = await schematicRunner.runSchematic('service-worker', defaultOptions, appTree);
     const content = tree.readContent('/projects/bar/src/app/app.config.ts');
     expect(tags.oneLine`${content}`).toContain(tags.oneLine`
-      providers: [provideServiceWorker('ngsw-worker.js', {
-        enabled: !isDevMode(),
-        registrationStrategy: 'registerWhenStable:30000'
-      })]
+        provideServiceWorker('ngsw-worker.js', {
+          enabled: !isDevMode(),
+          registrationStrategy: 'registerWhenStable:30000'
+        })  
     `);
   });
 
   it(`should import 'isDevMode' from '@angular/core'`, async () => {
     const tree = await schematicRunner.runSchematic('service-worker', defaultOptions, appTree);
     const content = tree.readContent('/projects/bar/src/app/app.config.ts');
-    expect(content).toContain(`import { ApplicationConfig, isDevMode } from '@angular/core';`);
+    expect(content).toContain(
+      `import { ApplicationConfig, provideZoneChangeDetection, isDevMode } from '@angular/core';`,
+    );
   });
 
   it(`should import 'provideServiceWorker' from '@angular/service-worker'`, async () => {

--- a/packages/schematics/angular/utility/standalone/rules_spec.ts
+++ b/packages/schematics/angular/utility/standalone/rules_spec.ts
@@ -93,12 +93,9 @@ describe('standalone utilities', () => {
 
       const content = readFile('app/app.config.ts');
 
-      assertContains(
-        content,
-        `import { ApplicationConfig, importProvidersFrom } from '@angular/core';`,
-      );
+      assertContains(content, `importProvidersFrom`);
       assertContains(content, `import { MyModule } from '@my/module';`);
-      assertContains(content, `providers: [importProvidersFrom(MyModule)]`);
+      assertContains(content, `importProvidersFrom(MyModule)`);
     });
 
     it('should add a root import to a standalone app whose app config does not have a providers array', async () => {
@@ -443,7 +440,10 @@ describe('standalone utilities', () => {
       const content = readFile('app/app.config.ts');
 
       assertContains(content, `import { provideModule } from '@my/module';`);
-      assertContains(content, `providers: [provideModule([])]`);
+      assertContains(
+        content,
+        `providers: [provideZoneChangeDetection({eventCoalescing:true}),provideModule([])]`,
+      );
     });
 
     it('should add a root provider to a standalone app when providers contain a trailing comma', async () => {


### PR DESCRIPTION
This commit enables eventCoalescing by default for standalone applications.
