### PR TITLE
refactor(@angular-devkit/build-angular): remove unneeded package version from inline font cache key

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/index-file/inline-fonts.ts
+++ b/packages/angular_devkit/build_angular/src/utils/index-file/inline-fonts.ts
@@ -11,9 +11,7 @@ import { createHash } from 'node:crypto';
 import { readFile, rm, writeFile } from 'node:fs/promises';
 import * as https from 'node:https';
 import { join } from 'node:path';
-import { URL } from 'node:url';
 import { NormalizedCachedOptions } from '../normalize-cache';
-import { VERSION } from '../package-version';
 import { htmlRewritingStream } from './html-rewriting-stream';
 
 interface FontProviderDetails {
@@ -173,7 +171,7 @@ export class InlineFontsProcessor {
   private async getResponse(url: URL): Promise<string> {
     let cacheFile;
     if (this.cachePath) {
-      const key = createHash(CONTENT_HASH_ALGORITHM).update(`${VERSION}|${url}`).digest('hex');
+      const key = createHash(CONTENT_HASH_ALGORITHM).update(`${url}`).digest('hex');
       cacheFile = join(this.cachePath, key);
     }
 


### PR DESCRIPTION
Since the calculated cache path already contains the `@angular-devkit/build-angular` package version, the version is not needed within the cache key for each font URL. This removes the need to import the loaded version from the `package.json` in the font inline logic.