### PR TITLE
refactor(@angular-devkit/build-angular): use build version stamping for build cache path creation

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/normalize-cache.ts
+++ b/packages/angular_devkit/build_angular/src/utils/normalize-cache.ts
@@ -6,8 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { join, resolve } from 'path';
-import { VERSION } from './package-version';
+import { join, resolve } from 'node:path';
+
+/** Version placeholder is replaced during the build process with actual package version */
+const VERSION = '0.0.0-PLACEHOLDER';
 
 export interface NormalizedCachedOptions {
   /** Whether disk cache is enabled. */


### PR DESCRIPTION
The build process will automatically perform package version placeholder replacement within source files. This allows for the package version to be injected into the build cache path creation process as a constant. As the version is now a constant, there is no need to attempt runtime loading of the package metadata to retrieve the package version.