### PR TITLE
fix(@schematics/angular): add spaces around eventCoalescing option

### DIFF
--- a/packages/schematics/angular/application/files/standalone-files/src/app/app.config.ts.template
+++ b/packages/schematics/angular/application/files/standalone-files/src/app/app.config.ts.template
@@ -4,5 +4,5 @@ import { provideRouter } from '@angular/router';
 import { routes } from './app.routes';<% } %>
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideZoneChangeDetection({eventCoalescing: true})<% if (routing) { %>, provideRouter(routes)<% } %>]
+  providers: [provideZoneChangeDetection({ eventCoalescing: true })<% if (routing) { %>, provideRouter(routes)<% } %>]
 };

--- a/packages/schematics/angular/application/index_spec.ts
+++ b/packages/schematics/angular/application/index_spec.ts
@@ -545,7 +545,7 @@ describe('Application Schematic', () => {
 
     const tree = await schematicRunner.runSchematic('application', options, workspaceTree);
     const appConfig = tree.readContent('/projects/foo/src/app/app.config.ts');
-    expect(appConfig).toContain('provideZoneChangeDetection({eventCoalescing: true})');
+    expect(appConfig).toContain('provideZoneChangeDetection({ eventCoalescing: true })');
   });
 
   it('should create a standalone component', async () => {

--- a/packages/schematics/angular/utility/standalone/rules_spec.ts
+++ b/packages/schematics/angular/utility/standalone/rules_spec.ts
@@ -442,7 +442,7 @@ describe('standalone utilities', () => {
       assertContains(content, `import { provideModule } from '@my/module';`);
       assertContains(
         content,
-        `providers: [provideZoneChangeDetection({eventCoalescing:true}),provideModule([])]`,
+        `providers: [provideZoneChangeDetection({ eventCoalescing:true }),provideModule([])]`,
       );
     });
 


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

The usual coding style in the generated application is to have spaces in objects (see `server.ts.template` for example).
The new introduced `eventCoaslecing` option doesn't.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information
