### PR TITLE
docs: release notes for the v17.3.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+<a name="17.3.3"></a>
+
+# 17.3.3 (2024-04-02)
+
+### @schematics/angular
+
+| Commit                                                                                              | Type | Description                                                     |
+| --------------------------------------------------------------------------------------------------- | ---- | --------------------------------------------------------------- |
+| [a673baf5c](https://github.com/angular/angular-cli/commit/a673baf5ce385415ded23641a2dc5cdcae8f3f5c) | fix  | Revert "fix(@schematics/angular): rename SSR port env variable" |
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="18.0.0-next.1"></a>
 
 # 18.0.0-next.1 (2024-03-28)


### PR DESCRIPTION
Cherry-picks the changelog from the "17.3.x" branch to the next branch (main).