### PR TITLE
ci: disable updating `build_bazel_rules_nodejs`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,7 @@
   "dependencyDashboard": true,
   "schedule": ["after 10:00pm every weekday", "before 4:00am every weekday", "every weekend"],
   "baseBranches": ["main"],
-  "ignoreDeps": ["@types/node", "rules_pkg", "copy-webpack-plugin"],
+  "ignoreDeps": ["@types/node", "build_bazel_rules_nodejs", "rules_pkg", "copy-webpack-plugin"],
   "includePaths": [
     "WORKSPACE",
     "package.json",


### PR DESCRIPTION
This commit disabled auto updating of `build_bazel_rules_nodejs` since this requires the new version of rulesjs
