### PR TITLE
refactor(@angular-devkit/architect): allow aliasing builder names in package builder manifest

### DIFF
--- a/packages/angular_devkit/architect/src/builders-schema.json
+++ b/packages/angular_devkit/architect/src/builders-schema.json
@@ -11,7 +11,15 @@
     "builders": {
       "type": "object",
       "additionalProperties": {
-        "$ref": "#/definitions/builder"
+        "oneOf": [
+          {
+            "$ref": "#/definitions/builder"
+          },
+          {
+            "type": "string",
+            "minLength": 1
+          }
+        ]
       }
     }
   },


### PR DESCRIPTION
A builder's manifest definition within a package (typically `builders.json`) can now contain a string value that will be used as a builder specifier when loading the named builder. This allows a builder name to be aliased to another builder. The other builder may also be in another package.
The build resolution logic has also been updated to remove use of the global `require` to support eventual direct ESM usage.