### PR TITLE
fix(@angular-devkit/build-angular): do not generate an `index.html` file in the browser directory when using SSR.

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/application/tests/behavior/index-preload-hints_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/tests/behavior/index-preload-hints_spec.ts
@@ -38,12 +38,10 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
       await harness.modifyFile('src/tsconfig.app.json', (content) => {
         const tsConfig = JSON.parse(content);
         tsConfig.files ??= [];
-        tsConfig.files.push('main.server.ts', 'server.ts');
+        tsConfig.files.push('main.server.ts');
 
         return JSON.stringify(tsConfig);
       });
-
-      await harness.writeFile('src/server.ts', `console.log('Hello!');`);
 
       harness.useTarget('build', {
         ...BASE_OPTIONS,
@@ -57,7 +55,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
       harness.expectFile('dist/server/main.server.mjs').toExist();
 
       harness
-        .expectFile('dist/browser/index.html')
+        .expectFile('dist/browser/index.csr.html')
         .content.not.toMatch(/<link rel="modulepreload" href="chunk-\.+\.mjs">/);
     });
   });

--- a/packages/angular_devkit/build_angular/src/builders/application/tests/behavior/rebuild-errors_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/tests/behavior/rebuild-errors_spec.ts
@@ -315,7 +315,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
       });
 
       const buildCount = await harness
-        .execute({ outputLogsOnFailure: true })
+        .execute({ outputLogsOnFailure: false })
         .pipe(
           timeout(BUILD_TIMEOUT),
           concatMap(async ({ result, logs }, index) => {

--- a/packages/angular_devkit/build_angular/src/builders/application/tests/options/index_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/tests/options/index_spec.ts
@@ -205,5 +205,27 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
       harness.expectFile('dist/browser/index.html').content.not.toContain('modulepreload');
       harness.expectFile('dist/browser/index.html').content.not.toContain('chunk-');
     });
+
+    it(`should generate 'index.csr.html' instead of 'index.html' by default when ssr is enabled.`, async () => {
+      await harness.modifyFile('src/tsconfig.app.json', (content) => {
+        const tsConfig = JSON.parse(content);
+        tsConfig.files ??= [];
+        tsConfig.files.push('main.server.ts');
+
+        return JSON.stringify(tsConfig);
+      });
+
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        server: 'src/main.server.ts',
+        ssr: true,
+      });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
+      harness.expectDirectory('dist/server').toExist();
+      harness.expectFile('dist/browser/index.csr.html').toExist();
+      harness.expectFile('dist/browser/index.html').toNotExist();
+    });
   });
 });

--- a/packages/schematics/angular/ssr/files/application-builder/server.ts.template
+++ b/packages/schematics/angular/ssr/files/application-builder/server.ts.template
@@ -20,12 +20,13 @@ export function app(): express.Express {
   // Example Express Rest API endpoints
   // server.get('/api/**', (req, res) => { });
   // Serve static files from /<%= browserDistDirectory %>
-  server.get('*.*', express.static(browserDistFolder, {
-    maxAge: '1y'
+  server.get('**', express.static(browserDistFolder, {
+    maxAge: '1y',
+    index: 'index.html',
   }));
 
   // All regular routes use the Angular engine
-  server.get('*', (req, res, next) => {
+  server.get('**', (req, res, next) => {
     const { protocol, originalUrl, baseUrl, headers } = req;
 
     commonEngine


### PR DESCRIPTION

BREAKING CHANGE: By default, the index.html file is no longer emitted in the browser directory when using the application builder with SSR. Instead, an index.csr.html file is emitted. This change is implemented because in many cases server and cloud providers incorrectly treat the index.html file as a statically generated page. If you still require the old behavior, you can use the `index` option to specify the `output` file name.

```json
"architect": {
  "build": {
    "builder": "@angular-devkit/build-angular:application",
    "options": {
      "outputPath": "dist/my-app",
      "index": {
        "input": "src/index.html",
        "output": "index.html"
      }
    }
  }
}
```
