### PR TITLE
refactor(@angular-devkit/build-angular): directly resolve asset files in application builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/application/execute-build.ts
+++ b/packages/angular_devkit/build_angular/src/builders/application/execute-build.ts
@@ -15,7 +15,7 @@ import { checkCommonJSModules } from '../../tools/esbuild/commonjs-checker';
 import { extractLicenses } from '../../tools/esbuild/license-extractor';
 import { calculateEstimatedTransferSizes, logBuildStats } from '../../tools/esbuild/utils';
 import { BudgetCalculatorResult, checkBudgets } from '../../utils/bundle-calculator';
-import { copyAssets } from '../../utils/copy-assets';
+import { resolveAssets } from '../../utils/resolve-assets';
 import { getSupportedBrowsers } from '../../utils/supported-browsers';
 import { executePostBundleSteps } from './execute-post-bundle';
 import { inlineI18n, loadActiveTranslations } from './i18n';
@@ -129,9 +129,7 @@ export async function executeBuild(
 
   // Copy assets
   if (assets) {
-    // The webpack copy assets helper is used with no base paths defined. This prevents the helper
-    // from directly writing to disk. This should eventually be replaced with a more optimized helper.
-    executionResult.addAssets(await copyAssets(assets, [], workspaceRoot));
+    executionResult.addAssets(await resolveAssets(assets, workspaceRoot));
   }
 
   // Extract and write licenses for used packages

--- a/packages/angular_devkit/build_angular/src/utils/resolve-assets.ts
+++ b/packages/angular_devkit/build_angular/src/utils/resolve-assets.ts
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import glob from 'fast-glob';
+import path from 'node:path';
+
+export async function resolveAssets(
+  entries: {
+    glob: string;
+    ignore?: string[];
+    input: string;
+    output: string;
+    flatten?: boolean;
+    followSymlinks?: boolean;
+  }[],
+  root: string,
+): Promise<{ source: string; destination: string }[]> {
+  const defaultIgnore = ['.gitkeep', '**/.DS_Store', '**/Thumbs.db'];
+
+  const outputFiles: { source: string; destination: string }[] = [];
+
+  for (const entry of entries) {
+    const cwd = path.resolve(root, entry.input);
+    const files = await glob(entry.glob, {
+      cwd,
+      dot: true,
+      ignore: entry.ignore ? defaultIgnore.concat(entry.ignore) : defaultIgnore,
+      followSymbolicLinks: entry.followSymlinks,
+    });
+
+    for (const file of files) {
+      const src = path.join(cwd, file);
+      const filePath = entry.flatten ? path.basename(file) : file;
+
+      outputFiles.push({ source: src, destination: path.join(entry.output, filePath) });
+    }
+  }
+
+  return outputFiles;
+}


### PR DESCRIPTION
Instead of previously attempting to reuse the Webpack-based copy assets helper function, the application builder will now only resolve all potential configured assets. This avoids depending on non-obvious parameter behavior to prevent the actual copying of the asset files.