### PR TITLE
feat(@angular-devkit/build-angular): enhance Sass rebasing importer for resources URL defined in variables and handling of external paths

### DIFF
--- a/packages/angular_devkit/build_angular/src/tools/esbuild/stylesheets/css-resource-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/tools/esbuild/stylesheets/css-resource-plugin.ts
@@ -32,42 +32,51 @@ export function createCssResourcePlugin(cache?: LoadResultCache): Plugin {
     name: 'angular-css-resource',
     setup(build: PluginBuild): void {
       build.onResolve({ filter: /.*/ }, async (args) => {
+        const { importer, path, kind, resolveDir, namespace, pluginData = {} } = args;
+
         // Only attempt to resolve url tokens which only exist inside CSS.
         // Also, skip this plugin if already attempting to resolve the url-token.
-        if (args.kind !== 'url-token' || args.pluginData?.[CSS_RESOURCE_RESOLUTION]) {
+        if (kind !== 'url-token' || pluginData[CSS_RESOURCE_RESOLUTION]) {
           return null;
+        }
+
+        let [containingDir, resourceUrl] = path.split('||file:', 2);
+        if (resourceUrl === undefined) {
+          // This can happen due to early exit checks in rebasing-importer
+          // logic such as when the url is an external URL.
+          resourceUrl = containingDir;
+          containingDir = '';
         }
 
         // If root-relative, absolute or protocol relative url, mark as external to leave the
         // path/URL in place.
-        if (/^((?:\w+:)?\/\/|data:|chrome:|#|\/)/.test(args.path)) {
+        if (/^((?:\w+:)?\/\/|data:|chrome:|#|\/)/.test(resourceUrl)) {
           return {
-            path: args.path,
+            path: resourceUrl,
             external: true,
           };
         }
 
-        const { importer, kind, resolveDir, namespace, pluginData = {} } = args;
         pluginData[CSS_RESOURCE_RESOLUTION] = true;
 
-        const result = await build.resolve(args.path, {
+        const result = await build.resolve(resourceUrl, {
           importer,
           kind,
           namespace,
           pluginData,
-          resolveDir,
+          resolveDir: join(resolveDir, containingDir),
         });
 
         if (result.errors.length) {
           const error = result.errors[0];
-          if (args.path[0] === '~') {
+          if (resourceUrl[0] === '~') {
             error.notes = [
               {
                 location: null,
                 text: 'You can remove the tilde and use a relative path to reference it, which should remove this error.',
               },
             ];
-          } else if (args.path[0] === '^') {
+          } else if (resourceUrl[0] === '^') {
             error.notes = [
               {
                 location: null,

--- a/packages/angular_devkit/build_angular/src/tools/sass/rebasing-importer.ts
+++ b/packages/angular_devkit/build_angular/src/tools/sass/rebasing-importer.ts
@@ -82,18 +82,15 @@ abstract class UrlRebasingImporter implements Importer<'sync'> {
         continue;
       }
 
-      // Skip if value is a Sass variable.
-      // Sass variable usage either starts with a `$` or contains a namespace and a `.$`
-      if (value[0] === '$' || /^\w+\.\$/.test(value)) {
-        continue;
-      }
-
       // Skip if root-relative, absolute or protocol relative url
       if (/^((?:\w+:)?\/\/|data:|chrome:|#|\/)/.test(value)) {
         continue;
       }
 
-      const rebasedPath = relative(this.entryDirectory, join(stylesheetDirectory, value));
+      // Sass variable usage either starts with a `$` or contains a namespace and a `.$`
+      const valueNormalized = value[0] === '$' || /^\w+\.\$/.test(value) ? `#{${value}}` : value;
+      const rebasedPath =
+        relative(this.entryDirectory, stylesheetDirectory) + '||file:' + valueNormalized;
 
       // Normalize path separators and escape characters
       // https://developer.mozilla.org/en-US/docs/Web/CSS/url#syntax


### PR DESCRIPTION


This commit introduces enhancements to the Sass rebasing importer, enabling it to resolve resources whose paths are stored in variables or namespaced variables. Also this addresses an issue where URL paths in Sass and SCSS files, flagged as external, were incorrectly rebased, leading to resolution errors.

Closes #27445 and closes #27007