### PR TITLE
fix(@angular-devkit/build-angular): remove `type="text/css"` from `style` tag

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/index-file/inline-fonts.ts
+++ b/packages/angular_devkit/build_angular/src/utils/index-file/inline-fonts.ts
@@ -152,7 +152,7 @@ export class InlineFontsProcessor {
           if (hrefAttr) {
             const href = hrefAttr.value;
             const cssContent = hrefsContent.get(href);
-            rewriter.emitRaw(`<style type="text/css">${cssContent}</style>`);
+            rewriter.emitRaw(`<style>${cssContent}</style>`);
           } else {
             rewriter.emitStartTag(tag);
           }


### PR DESCRIPTION

`type="text/css"` is deprecated, for more info see: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/style#deprecated_attributes

Closes: #27471
