### PR TITLE
build: adjust create project script to ensure all built packages are used

### DIFF
--- a/scripts/create.mts
+++ b/scripts/create.mts
@@ -84,12 +84,9 @@ export default async function (args: CreateOptions, cwd: string): Promise<number
   const packageJsonPath = path.join(projectName, 'package.json');
   const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf-8'));
 
-  if (!packageJson['dependencies']) {
-    packageJson['dependencies'] = {};
-  }
-  if (!packageJson['devDependencies']) {
-    packageJson['devDependencies'] = {};
-  }
+  packageJson['dependencies'] ??= {};
+  packageJson['devDependencies'] ??= {};
+  packageJson['overrides'] ??= {};
 
   // Set the dependencies to the new build we just used.
   for (const packageName of packages.map(({ name }) => name)) {
@@ -99,6 +96,8 @@ export default async function (args: CreateOptions, cwd: string): Promise<number
       packageJson['dependencies'][packageName] = tar;
     } else if (packageName in packageJson['devDependencies']) {
       packageJson['devDependencies'][packageName] = tar;
+    } else {
+      packageJson['overrides'][packageName] = tar;
     }
   }
 


### PR DESCRIPTION
The admin create script previously only updated the package.json dependencies for direct dependencies. This did not ensure that all built packages were used due to some built packages being used as transitive dependencies. The npm `overrides` field is now also used to ensure that these dependencies are also properly redirected to the built packages.