### PR TITLE
Several Vite-based development server internal refactoring changes

### DIFF
--- a/goldens/public-api/angular_devkit/build_angular/index.md
+++ b/goldens/public-api/angular_devkit/build_angular/index.md
@@ -12,7 +12,6 @@ import { BuilderContext } from '@angular-devkit/architect';
 import { BuilderOutput } from '@angular-devkit/architect';
 import type { ConfigOptions } from 'karma';
 import { Configuration } from 'webpack';
-import { DevServerBuildOutput } from '@angular-devkit/build-webpack';
 import type http from 'node:http';
 import { IndexHtmlTransform } from '@angular/build/private';
 import { json } from '@angular-devkit/core';
@@ -144,10 +143,14 @@ export interface DevServerBuilderOptions {
 }
 
 // @public
-export type DevServerBuilderOutput = DevServerBuildOutput & {
+export interface DevServerBuilderOutput extends BuilderOutput {
+    // (undocumented)
+    address?: string;
+    // (undocumented)
     baseUrl: string;
-    stats: BuildEventStats;
-};
+    // (undocumented)
+    port?: number;
+}
 
 // @public
 export function executeBrowserBuilder(options: BrowserBuilderOptions, context: BuilderContext, transforms?: {

--- a/packages/angular_devkit/build_angular/BUILD.bazel
+++ b/packages/angular_devkit/build_angular/BUILD.bazel
@@ -311,6 +311,7 @@ LARGE_SPECS = {
         "size": "large",
         "flaky": True,
         "extra_deps": [
+            "//packages/angular_devkit/build_webpack",
             "@npm//@types/http-proxy",
             "@npm//http-proxy",
             "@npm//puppeteer",

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/builder.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/builder.ts
@@ -14,8 +14,8 @@ import { EMPTY, Observable, defer, switchMap } from 'rxjs';
 import type { ExecutionTransformer } from '../../transforms';
 import { checkPort } from '../../utils/check-port';
 import { normalizeOptions } from './options';
+import type { DevServerBuilderOutput } from './output';
 import type { Schema as DevServerBuilderOptions } from './schema';
-import type { DevServerBuilderOutput } from './webpack-server';
 
 /**
  * A Builder that executes a development server based on the provided browser target option.

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/builder.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/builder.ts
@@ -6,13 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { type IndexHtmlTransform, purgeStaleBuildCache } from '@angular/build/private';
 import type { BuilderContext } from '@angular-devkit/architect';
 import type { Plugin } from 'esbuild';
 import type http from 'node:http';
 import { EMPTY, Observable, defer, switchMap } from 'rxjs';
 import type { ExecutionTransformer } from '../../transforms';
 import { checkPort } from '../../utils/check-port';
+import { type IndexHtmlTransform, purgeStaleBuildCache } from './internal';
 import { normalizeOptions } from './options';
 import type { DevServerBuilderOutput } from './output';
 import type { Schema as DevServerBuilderOptions } from './schema';

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/index.ts
@@ -8,8 +8,8 @@
 
 import { createBuilder } from '@angular-devkit/architect';
 import { execute } from './builder';
+import { DevServerBuilderOutput } from './output';
 import { Schema as DevServerBuilderOptions } from './schema';
-import { DevServerBuilderOutput } from './webpack-server';
 
 export { DevServerBuilderOptions, DevServerBuilderOutput, execute as executeDevServerBuilder };
 export default createBuilder<DevServerBuilderOptions, DevServerBuilderOutput>(execute);

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/internal.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/internal.ts
@@ -1,0 +1,22 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export { BuildOutputFile, BuildOutputFileType } from '@angular/build';
+export {
+  type ApplicationBuilderInternalOptions,
+  type ExternalResultMetadata,
+  JavaScriptTransformer,
+  buildApplicationInternal,
+  createRxjsEsmResolutionPlugin,
+  getFeatureSupport,
+  getSupportedBrowsers,
+  isZonelessApp,
+  transformSupportedBrowsersToTargets,
+  type IndexHtmlTransform,
+  purgeStaleBuildCache,
+} from '@angular/build/private';

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/output.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/output.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { BuilderOutput } from '@angular-devkit/architect';
+
+/**
+ * @experimental Direct usage of this type is considered experimental.
+ */
+export interface DevServerBuilderOutput extends BuilderOutput {
+  baseUrl: string;
+  port?: number;
+  address?: string;
+}

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/specs/works_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/specs/works_spec.ts
@@ -8,6 +8,7 @@
 
 import { Architect, BuilderRun } from '@angular-devkit/architect';
 import { DevServerBuilderOutput } from '@angular-devkit/build-angular';
+import { EmittedFiles } from '@angular-devkit/build-webpack';
 import { normalize, virtualFs } from '@angular-devkit/core';
 import { createArchitect, host } from '../../../testing/test-utils';
 
@@ -54,7 +55,7 @@ describe('Dev Server Builder', () => {
     const output = (await run.result) as DevServerBuilderOutput;
     expect(output.success).toBe(true);
     const hasSourceMaps =
-      output.emittedFiles && output.emittedFiles.some((f) => f.extension === '.map');
+      output.emittedFiles && output.emittedFiles.some((f: EmittedFiles) => f.extension === '.map');
     expect(hasSourceMaps).toBe(false, `Expected emitted files not to contain '.map' files.`);
   });
 

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
@@ -33,7 +33,7 @@ import { getIndexOutputFile } from '../../utils/webpack-browser-config';
 import { buildEsbuildBrowser } from '../browser-esbuild';
 import { Schema as BrowserBuilderOptions } from '../browser-esbuild/schema';
 import type { NormalizedDevServerOptions } from './options';
-import type { DevServerBuilderOutput } from './webpack-server';
+import type { DevServerBuilderOutput } from './output';
 
 interface OutputFileRecord {
   contents: Uint8Array;

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
@@ -6,18 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { BuildOutputFile, BuildOutputFileType } from '@angular/build';
-import {
-  type ApplicationBuilderInternalOptions,
-  type ExternalResultMetadata,
-  JavaScriptTransformer,
-  buildApplicationInternal,
-  createRxjsEsmResolutionPlugin,
-  getFeatureSupport,
-  getSupportedBrowsers,
-  isZonelessApp,
-  transformSupportedBrowsersToTargets,
-} from '@angular/build/private';
 import type { BuilderContext } from '@angular-devkit/architect';
 import type { json } from '@angular-devkit/core';
 import type { Plugin } from 'esbuild';
@@ -31,6 +19,19 @@ import { loadProxyConfiguration, normalizeSourceMaps } from '../../utils';
 import { loadEsmModule } from '../../utils/load-esm';
 import { buildEsbuildBrowser } from '../browser-esbuild';
 import { Schema as BrowserBuilderOptions } from '../browser-esbuild/schema';
+import {
+  type ApplicationBuilderInternalOptions,
+  type BuildOutputFile,
+  BuildOutputFileType,
+  type ExternalResultMetadata,
+  JavaScriptTransformer,
+  buildApplicationInternal,
+  createRxjsEsmResolutionPlugin,
+  getFeatureSupport,
+  getSupportedBrowsers,
+  isZonelessApp,
+  transformSupportedBrowsersToTargets,
+} from './internal';
 import type { NormalizedDevServerOptions } from './options';
 import type { DevServerBuilderOutput } from './output';
 

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/vite-server.ts
@@ -23,13 +23,12 @@ import type { json } from '@angular-devkit/core';
 import type { Plugin } from 'esbuild';
 import assert from 'node:assert';
 import { readFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { basename, join } from 'node:path';
 import type { Connect, DepOptimizationConfig, InlineConfig, ViteDevServer } from 'vite';
 import { createAngularMemoryPlugin } from '../../tools/vite/angular-memory-plugin';
 import { createAngularLocaleDataPlugin } from '../../tools/vite/i18n-locale-plugin';
 import { loadProxyConfiguration, normalizeSourceMaps } from '../../utils';
 import { loadEsmModule } from '../../utils/load-esm';
-import { getIndexOutputFile } from '../../utils/webpack-browser-config';
 import { buildEsbuildBrowser } from '../browser-esbuild';
 import { Schema as BrowserBuilderOptions } from '../browser-esbuild/schema';
 import type { NormalizedDevServerOptions } from './options';
@@ -131,8 +130,13 @@ export async function* serveWithVite(
 
   // Extract output index from options
   // TODO: Provide this info from the build results
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const htmlIndexPath = getIndexOutputFile(browserOptions.index as any);
+  let htmlIndexPath = 'index.html';
+  if (browserOptions.index && typeof browserOptions.index !== 'boolean') {
+    htmlIndexPath =
+      typeof browserOptions.index === 'string'
+        ? basename(browserOptions.index)
+        : browserOptions.index.output || 'index.html';
+  }
 
   // dynamically import Vite for ESM compatibility
   const { createServer, normalizePath } = await loadEsmModule<typeof import('vite')>('vite');


### PR DESCRIPTION
**refactor(@angular-devkit/build-angular): move Vite dev-server @angular/build imports into separate file**

To reduce the complexity of the move of the Vite-based dev-server builder
into the `@angular/build` package. The soon to be self-referencing imports
are now located in a separate file. Self-referencing imports are not well
supported inside the repository currently so this move allows the imports
to be adjusted in one location.

**refactor(@angular-devkit/build-angular): remove Webpack-specific index option helper from Vite-based dev-server**

The index output option helper from within the Webpack-based build system has been removed
from the Vite-based development server code to support separation of the builder. This
information will eventually be passed via the build system results and the direct option
access can then be removed completely.

**refactor(@angular-devkit/build-angular): use dev-server implementation neutral builder output result interface**

The dev-server builder will now only provide an interface with typed fields
for the combined set of common elements for the Webpack and Vite development
server implementations. Any additional builder specific runtime fields will
still be present and accessible.