### PR TITLE
feat(@schematics/angular): allow application migration to use new build package in projects where possible

### DIFF
--- a/packages/schematics/angular/migrations/use-application-builder/migration.ts
+++ b/packages/schematics/angular/migrations/use-application-builder/migration.ts
@@ -32,11 +32,6 @@ function* updateBuildTarget(
   buildTarget.builder = Builders.Application;
 
   for (const [, options] of allTargetOptions(buildTarget, false)) {
-    // Show warnings for using no longer supported options
-    if (usesNoLongerSupportedOptions(options, context, projectName)) {
-      continue;
-    }
-
     if (options['index'] === '') {
       options['index'] = false;
     }
@@ -82,7 +77,6 @@ function* updateBuildTarget(
     }
 
     // Delete removed options
-    delete options['deployUrl'];
     delete options['vendorChunk'];
     delete options['commonChunk'];
     delete options['resourcesOutputPath'];
@@ -346,20 +340,4 @@ export default function (): Rule {
       rootJson.modify(['compilerOptions', 'allowSyntheticDefaultImports'], undefined);
     }),
   ]);
-}
-
-function usesNoLongerSupportedOptions(
-  { deployUrl }: Record<string, unknown>,
-  context: SchematicContext,
-  projectName: string,
-): boolean {
-  let hasUsage = false;
-  if (typeof deployUrl === 'string') {
-    hasUsage = true;
-    context.logger.warn(
-      `Skipping migration for project "${projectName}". "deployUrl" option is not available in the application builder.`,
-    );
-  }
-
-  return hasUsage;
 }


### PR DESCRIPTION
When using the optional application build system migration, the newly
introduced `@angular/build` package which contains only the new build
system and no Webpack-related dependencies will be directly used when
possible. The migration will check for usage of any other builders from
the `@angular-devkit/build-angular` package. if none are present in the
`angular.json` file (excluding `dev-server` and `extract-i18n`), the
`@angular/build` package will be added as a dependency and used in the
`angular.json` file. The `@angular-devkit/build-angular` package will
then be removed as a dependency. Project usage of karma and/or protractor
will be the most common reasons this part of the migration will not be
performed.

Also includes a fix to the migration to no longer remove the now support deployUrl option.