### PR TITLE
refactor(@angular/build): move less stylesheet preprocessor to an optional peer dependency

### DIFF
--- a/packages/angular/build/package.json
+++ b/packages/angular/build/package.json
@@ -30,7 +30,6 @@
     "fast-glob": "3.3.2",
     "https-proxy-agent": "7.0.4",
     "inquirer": "9.2.19",
-    "less": "4.2.0",
     "magic-string": "0.30.10",
     "mrmime": "2.0.0",
     "ora": "5.4.1",
@@ -48,6 +47,7 @@
     "@angular/localize": "^18.0.0 || ^18.0.0-next.0",
     "@angular/platform-server": "^18.0.0 || ^18.0.0-next.0",
     "@angular/service-worker": "^18.0.0 || ^18.0.0-next.0",
+    "less": "^4.2.0",
     "tailwindcss": "^2.0.0 || ^3.0.0",
     "typescript": ">=5.4 <5.5"
   },
@@ -59,6 +59,9 @@
       "optional": true
     },
     "@angular/service-worker": {
+      "optional": true
+    },
+    "less": {
       "optional": true
     },
     "tailwindcss": {

--- a/packages/angular/build/src/tools/esbuild/stylesheets/less-language.ts
+++ b/packages/angular/build/src/tools/esbuild/stylesheets/less-language.ts
@@ -49,7 +49,26 @@ async function compileString(
   resolver: PluginBuild['resolve'],
   unsafeInlineJavaScript: boolean,
 ): Promise<OnLoadResult> {
-  const less = (lessPreprocessor ??= (await import('less')).default);
+  try {
+    lessPreprocessor ??= (await import('less')).default;
+  } catch {
+    return {
+      errors: [
+        {
+          text: 'Unable to load the "less" stylesheet preprocessor.',
+          location: null,
+          notes: [
+            {
+              text:
+                'Ensure that the "less" Node.js package is installed within the project. ' +
+                "If not present, installation via the project's package manager should resolve the error.",
+            },
+          ],
+        },
+      ],
+    };
+  }
+  const less = lessPreprocessor;
 
   const resolverPlugin: Less.Plugin = {
     install({ FileManager }, pluginManager): void {


### PR DESCRIPTION
The Less stylesheet preprocessor is now an optional peer dependency of the newly introduced `@angular/build` build system package. Less stylesheet usage is currently estimated at less than 10% of projects with analytics enabled. Less stylesheets are still fully supported but usage will now require installing the `less` package within the Angular workspace. An error with instructions to install the package will be generated during a build if the package is not present. This change only affects direct usage of the new `@angular/build` package. The `@angular-devkit/build-angular` package which is currently used for all existing projects will continue to contain and directly depend on the `less` package.

No changes are required for existing applications.