### PR TITLE
fix(@angular/build): disable Vite prebundling when script optimizations are enabled

### DIFF
--- a/goldens/circular-deps/packages.json
+++ b/goldens/circular-deps/packages.json
@@ -1,16 +1,20 @@
 [
   [
-    "packages/angular/build/src/tools/esbuild/bundler-context.ts",
-    "packages/angular/build/src/tools/esbuild/utils.ts"
+    "packages/angular_devkit/build_angular/src/builders/dev-server/builder.ts",
+    "packages/angular_devkit/build_angular/src/builders/dev-server/options.ts"
   ],
   [
-    "packages/angular/build/src/tools/esbuild/bundler-execution-result.ts",
+    "packages/angular/build/src/tools/esbuild/bundler-context.ts",
     "packages/angular/build/src/tools/esbuild/utils.ts"
   ],
   [
     "packages/angular/build/src/tools/esbuild/bundler-context.ts",
     "packages/angular/build/src/tools/esbuild/utils.ts",
     "packages/angular/build/src/tools/esbuild/bundler-execution-result.ts"
+  ],
+  [
+    "packages/angular/build/src/tools/esbuild/bundler-execution-result.ts",
+    "packages/angular/build/src/tools/esbuild/utils.ts"
   ],
   [
     "packages/angular/cli/src/analytics/analytics-collector.ts",

--- a/packages/angular/build/src/builders/dev-server/options.ts
+++ b/packages/angular/build/src/builders/dev-server/options.ts
@@ -8,7 +8,9 @@
 
 import { BuilderContext, targetFromTargetString } from '@angular-devkit/architect';
 import path from 'node:path';
+import { normalizeOptimization } from '../../utils';
 import { normalizeCacheOptions } from '../../utils/normalize-cache';
+import { ApplicationBuilderOptions } from '../application';
 import { Schema as DevServerOptions } from './schema';
 
 export type NormalizedDevServerOptions = Awaited<ReturnType<typeof normalizeOptions>>;
@@ -28,7 +30,7 @@ export async function normalizeOptions(
   projectName: string,
   options: DevServerOptions,
 ) {
-  const workspaceRoot = context.workspaceRoot;
+  const { workspaceRoot, logger } = context;
   const projectMetadata = await context.getProjectMetadata(projectName);
   const projectRoot = path.join(workspaceRoot, (projectMetadata.root as string | undefined) ?? '');
 
@@ -37,6 +39,29 @@ export async function normalizeOptions(
   // Target specifier defaults to the current project's build target using a development configuration
   const buildTargetSpecifier = options.buildTarget ?? `::development`;
   const buildTarget = targetFromTargetString(buildTargetSpecifier, projectName, 'build');
+
+  // Get the application builder options.
+  const browserBuilderName = await context.getBuilderNameForTarget(buildTarget);
+  const rawBuildOptions = await context.getTargetOptions(buildTarget);
+  const buildOptions = (await context.validateOptions(
+    rawBuildOptions,
+    browserBuilderName,
+  )) as unknown as ApplicationBuilderOptions;
+  const optimization = normalizeOptimization(buildOptions.optimization);
+
+  if (options.prebundle) {
+    if (!cacheOptions.enabled) {
+      // Warn if the initial options provided by the user enable prebundling but caching is disabled
+      logger.warn(
+        'Prebundling has been configured but will not be used because caching has been disabled.',
+      );
+    } else if (optimization.scripts) {
+      // Warn if the initial options provided by the user enable prebundling but script optimization is enabled.
+      logger.warn(
+        'Prebundling has been configured but will not be used because scripts optimization is enabled.',
+      );
+    }
+  }
 
   // Initial options to keep
   const {
@@ -78,6 +103,6 @@ export async function normalizeOptions(
     sslCert,
     sslKey,
     // Prebundling defaults to true but requires caching to function
-    prebundle: cacheOptions.enabled && (prebundle ?? true),
+    prebundle: cacheOptions.enabled && !optimization.scripts && prebundle,
   };
 }

--- a/packages/angular/build/src/builders/dev-server/schema.json
+++ b/packages/angular/build/src/builders/dev-server/schema.json
@@ -81,6 +81,7 @@
     },
     "prebundle": {
       "description": "Enable and control the Vite-based development server's prebundling capabilities. To enable prebundling, the Angular CLI cache must also be enabled.",
+      "default": true,
       "oneOf": [
         { "type": "boolean" },
         {

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/builder.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/builder.ts
@@ -67,13 +67,6 @@ export function execute(
           );
         }
 
-        // Warn if the initial options provided by the user enable prebundling but caching is disabled
-        if (options.prebundle && !normalizedOptions.cacheOptions.enabled) {
-          context.logger.warn(
-            `Prebundling has been configured but will not be used because caching has been disabled.`,
-          );
-        }
-
         if (options.allowedHosts?.length) {
           context.logger.warn(
             `The "allowedHosts" option will not be used because it is not supported by the "${builderName}" builder.`,
@@ -188,7 +181,7 @@ case.
   };
 }
 
-function isEsbuildBased(
+export function isEsbuildBased(
   builderName: string,
 ): builderName is
   | '@angular/build:application'


### PR DESCRIPTION
    
This change ensures that `ngDevMode` is replaced in node packages, aligning the behavior of the Vite server more closely with a production environment.
