### PR TITLE
test: update regexp in ssr-error-stack E2E test for Node.js 22 on Windows

### DIFF
--- a/tests/legacy-cli/e2e/tests/vite/ssr-error-stack.ts
+++ b/tests/legacy-cli/e2e/tests/vite/ssr-error-stack.ts
@@ -28,7 +28,7 @@ export default async function () {
   // The error is also sent in the browser, so we don't need to scrap the stderr.
   match(
     text,
-    /something happened.+at eval \(.+\/e2e-test[\\\/]test-project[\\\/]src[\\\/]app[\\\/]app\.component\.ts:\d+:\d+\)/,
+    /something happened.+at eval \(.+[\\/]+e2e-test[\\/]+test-project[\\/]+src[\\/]+app[\\/]+app\.component\.ts:\d+:\d+\)/,
   );
   doesNotMatch(text, /vite-root/);
 }


### PR DESCRIPTION
With Node.js 22 on Windows the stack traces may contain paths that have double backslash path segment separators.