### PR TITLE
docs: release notes for the v17.3.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+<a name="17.3.6"></a>
+
+# 17.3.6 (2024-04-25)
+
+### @angular-devkit/build-angular
+
+| Commit                                                                                              | Type | Description                                                  |
+| --------------------------------------------------------------------------------------------------- | ---- | ------------------------------------------------------------ |
+| [dcec59799](https://github.com/angular/angular-cli/commit/dcec59799faac66bf25043984c11944479efcf4d) | fix  | properly configure headers for media resources and HTML page |
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="18.0.0-next.3"></a>
 
 # 18.0.0-next.3 (2024-04-17)


### PR DESCRIPTION
Cherry-picks the changelog from the "17.3.x" branch to the next branch (main).