### PR TITLE
fix(@angular/build): check both potential build packages in Angular version check

### DIFF
--- a/packages/angular/build/src/utils/version.ts
+++ b/packages/angular/build/src/utils/version.ts
@@ -56,9 +56,17 @@ export function assertCompatibleAngularVersion(projectRoot: string): void | neve
     return;
   }
 
-  const supportedAngularSemver = projectRequire('@angular-devkit/build-angular/package.json')[
-    'peerDependencies'
-  ]['@angular/compiler-cli'];
+  let supportedAngularSemver;
+  try {
+    supportedAngularSemver = projectRequire('@angular/build/package.json')['peerDependencies'][
+      '@angular/compiler-cli'
+    ];
+  } catch {
+    supportedAngularSemver = projectRequire('@angular-devkit/build-angular/package.json')[
+      'peerDependencies'
+    ]['@angular/compiler-cli'];
+  }
+
   const angularVersion = new SemVer(angularPkgJson['version']);
 
   if (!satisfies(angularVersion, supportedAngularSemver, { includePrerelease: true })) {


### PR DESCRIPTION
The compatible Angular version check now supports getting the SemVer range of a compatible `@angular/compiler-cli` package from both this package and `@angular-devkit/build-angular` if present. This prevents a potential build error condition if `@angular-devkit/build-angular` is not present.