### PR TITLE
build: correctly set `@angular/build` version in snapshots

### DIFF
--- a/constants.bzl
+++ b/constants.bzl
@@ -6,6 +6,7 @@ RELEASE_ENGINES_YARN = ">= 1.13.0"
 SNAPSHOT_REPOS = {
     "@angular/cli": "angular/cli-builds",
     "@angular/pwa": "angular/angular-pwa-builds",
+    "@angular/build": "angular/angular-build-builds",
     "@angular/ssr": "angular/angular-ssr-builds",
     "@angular-devkit/architect": "angular/angular-devkit-architect-builds",
     "@angular-devkit/architect-cli": "angular/angular-devkit-architect-cli-builds",

--- a/tests/legacy-cli/e2e/utils/project.ts
+++ b/tests/legacy-cli/e2e/utils/project.ts
@@ -102,7 +102,7 @@ export async function useSha(): Promise<void> {
         .filter((name) => name.startsWith('@angular/'))
         .forEach((name) => {
           const pkgName = name.split(/\//)[1];
-          if (pkgName === 'cli' || pkgName === 'ssr') {
+          if (pkgName === 'cli' || pkgName === 'ssr' || pkgName === 'build') {
             return;
           }
 


### PR DESCRIPTION
Currently this is not being set correctly. Ex: https://github.com/angular/angular-devkit-build-angular-builds/blob/2760127ec678d422d352d8d02ebb85e16512a478/package.json#L10

