### PR TITLE
refactor(@angular/build): update private exports for additional usage

### DIFF
--- a/packages/angular/build/src/private.ts
+++ b/packages/angular/build/src/private.ts
@@ -25,6 +25,10 @@ export { emitFilesToDisk } from './tools/esbuild/utils';
 export { transformSupportedBrowsersToTargets } from './tools/esbuild/utils';
 export { SassWorkerImplementation } from './tools/sass/sass-service';
 
+export { SourceFileCache } from './tools/esbuild/angular/source-file-cache';
+export { createJitResourceTransformer } from './tools/esbuild/angular/jit-resource-transformer';
+export { JavaScriptTransformer } from './tools/esbuild/javascript-transformer';
+
 // Utilities
 export * from './utils/bundle-calculator';
 export { checkPort } from './utils/check-port';


### PR DESCRIPTION
Add several additional APIs to the private export of the package. Note that these are not considered part of the public API and are intended for use only with the `@angular-devkit/build-angular` package.