### PR TITLE
I18n extract default build target

### DIFF
--- a/goldens/public-api/angular/build/index.md
+++ b/goldens/public-api/angular/build/index.md
@@ -152,7 +152,7 @@ export function executeExtractI18nBuilder(options: ExtractI18nBuilderOptions, co
 
 // @public
 export interface ExtractI18nBuilderOptions {
-    buildTarget: string;
+    buildTarget?: string;
     format?: Format;
     outFile?: string;
     outputPath?: string;

--- a/packages/angular/build/src/builders/extract-i18n/schema.json
+++ b/packages/angular/build/src/builders/extract-i18n/schema.json
@@ -29,6 +29,5 @@
       "description": "Name of the file to output."
     }
   },
-  "additionalProperties": false,
-  "required": ["buildTarget"]
+  "additionalProperties": false
 }

--- a/packages/angular_devkit/build_angular/src/builders/extract-i18n/schema.json
+++ b/packages/angular_devkit/build_angular/src/builders/extract-i18n/schema.json
@@ -35,6 +35,5 @@
       "description": "Name of the file to output."
     }
   },
-  "additionalProperties": false,
-  "anyOf": [{ "required": ["buildTarget"] }, { "required": ["browserTarget"] }]
+  "additionalProperties": false
 }

--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -273,9 +273,6 @@ function addAppToWorkspaceFile(
       },
       'extract-i18n': {
         builder: Builders.ExtractI18n,
-        options: {
-          buildTarget: `${options.name}:build`,
-        },
       },
       test: options.minimal
         ? undefined


### PR DESCRIPTION
The `extract-i18n` option schema has been updated to reflect that the
`buildTarget` option is not required. The option value will default
to the `build` target of the containing project. This removes the need
for an additional option and character count within the `angular.json`
file for the project.