### PR TITLE
fix(@schematics/angular): add less dependency in application migration if needed

### DIFF
--- a/packages/schematics/angular/migrations/use-application-builder/migration_spec.ts
+++ b/packages/schematics/angular/migrations/use-application-builder/migration_spec.ts
@@ -267,4 +267,22 @@ describe(`Migration to use the application builder`, () => {
     const { stylePreprocessorOptions } = app.architect['build'].options;
     expect(stylePreprocessorOptions).toEqual({ includePaths: ['.'] });
   });
+
+  it('should add "less" dependency when converting to "@angular/build" and a ".less" file is present', async () => {
+    tree.create('/project/app/src/styles.less', '');
+
+    const newTree = await schematicRunner.runSchematic(schematicName, {}, tree);
+
+    const { devDependencies } = JSON.parse(newTree.readContent('/package.json'));
+
+    expect(devDependencies['less']).toBeDefined();
+  });
+
+  it('should not add "less" dependency when converting to "@angular/build" and a ".less" file is present', async () => {
+    const newTree = await schematicRunner.runSchematic(schematicName, {}, tree);
+
+    const { devDependencies } = JSON.parse(newTree.readContent('/package.json'));
+
+    expect(devDependencies['less']).toBeUndefined();
+  });
 });

--- a/packages/schematics/angular/utility/latest-versions/package.json
+++ b/packages/schematics/angular/utility/latest-versions/package.json
@@ -16,6 +16,7 @@
     "karma-jasmine-html-reporter": "~2.1.0",
     "karma-jasmine": "~5.1.0",
     "karma": "~6.4.0",
+    "less": "^4.2.0",
     "ng-packagr": "^18.0.0-next.0",
     "protractor": "~7.0.0",
     "rxjs": "~7.8.0",


### PR DESCRIPTION
The application migration schematic will now attempt to detect the usage of Less stylesheets within a workspace and install the `less` dependency if required. This will only occur if the migration analysis allows for the conversion to use the `@angular/build` package instead of the `@angular-devkit/build-angular` package. The Less usage detection may not detect Less stylesheets within Node.js packages and currently does not handle the case where a project only has inline Less stylesheets. More complex analysis may be added in the future. However, a build time error message will be presented with instructions to install `less` in these cases if the stylesheet preprocessor is required and not present.