### PR TITLE
refactor(@angular/build): move postcss stylesheet processor to an optional peer dependency

### DIFF
--- a/packages/angular/build/package.json
+++ b/packages/angular/build/package.json
@@ -50,6 +50,7 @@
     "@angular/platform-server": "^18.0.0 || ^18.0.0-next.0",
     "@angular/service-worker": "^18.0.0 || ^18.0.0-next.0",
     "less": "^4.2.0",
+    "postcss": "^8.4.0",
     "tailwindcss": "^2.0.0 || ^3.0.0",
     "typescript": ">=5.4 <5.5"
   },
@@ -64,6 +65,9 @@
       "optional": true
     },
     "less": {
+      "optional": true
+    },
+    "postcss": {
       "optional": true
     },
     "tailwindcss": {


### PR DESCRIPTION
The Postcss stylesheet processor is now an optional peer dependency of the newly introduced `@angular/build` build system package. This change removes the need for the package to have a direct dependency on the `postcss` package and allows some version customization of the optional `postcss` package if needed. Postcss plugins (including Tailwind) are still fully supported but usage will now require installing the `postcss` package within the Angular workspace. An error with instructions to install the package will be generated during a build if the package is not present. This change only affects direct usage of the new `@angular/build` package. The `@angular-devkit/build-angular` package which is currently used for all existing projects will continue to contain and directly depend on the `postcss` package.

No changes are required for existing applications.