### PR TITLE
fix(@angular/cli): add `@angular/build` package to update group

### DIFF
--- a/packages/angular/cli/package.json
+++ b/packages/angular/cli/package.json
@@ -43,6 +43,7 @@
   "ng-update": {
     "migrations": "@schematics/angular/migrations/migration-collection.json",
     "packageGroup": {
+      "@angular/build": "0.0.0-PLACEHOLDER",
       "@angular/cli": "0.0.0-PLACEHOLDER",
       "@angular/ssr": "0.0.0-PLACEHOLDER",
       "@angular-devkit/architect": "0.0.0-EXPERIMENTAL-PLACEHOLDER",


### PR DESCRIPTION
The ng update package group list now contains the newly introduced `@angular/build` package which contains the esbuild/Vite-based build system. The group list ensures that all relevant direct project dependencies are update as group when `@angular/cli` itself is updated.