### PR TITLE
fix(@schematics/angular): add postcss dependency in application migration if needed

### DIFF
--- a/packages/schematics/angular/migrations/use-application-builder/migration_spec.ts
+++ b/packages/schematics/angular/migrations/use-application-builder/migration_spec.ts
@@ -278,11 +278,49 @@ describe(`Migration to use the application builder`, () => {
     expect(devDependencies['less']).toBeDefined();
   });
 
-  it('should not add "less" dependency when converting to "@angular/build" and a ".less" file is present', async () => {
+  it('should not add "less" dependency when converting to "@angular/build" and a ".less" file is not present', async () => {
     const newTree = await schematicRunner.runSchematic(schematicName, {}, tree);
 
     const { devDependencies } = JSON.parse(newTree.readContent('/package.json'));
 
     expect(devDependencies['less']).toBeUndefined();
+  });
+
+  it('should add "postcss" dependency when converting to "@angular/build" and postcss.config.json is present', async () => {
+    tree.create('postcss.config.json', '{}');
+
+    const newTree = await schematicRunner.runSchematic(schematicName, {}, tree);
+
+    const { devDependencies } = JSON.parse(newTree.readContent('/package.json'));
+
+    expect(devDependencies['postcss']).toBeDefined();
+  });
+
+  it('should add "postcss" dependency when converting to "@angular/build" and .postcssrc.json is present', async () => {
+    tree.create('.postcssrc.json', '{}');
+
+    const newTree = await schematicRunner.runSchematic(schematicName, {}, tree);
+
+    const { devDependencies } = JSON.parse(newTree.readContent('/package.json'));
+
+    expect(devDependencies['postcss']).toBeDefined();
+  });
+
+  it('should add "postcss" dependency when converting to "@angular/build" and .postcssrc.json is present in project', async () => {
+    tree.create('/project/app/.postcssrc.json', '{}');
+
+    const newTree = await schematicRunner.runSchematic(schematicName, {}, tree);
+
+    const { devDependencies } = JSON.parse(newTree.readContent('/package.json'));
+
+    expect(devDependencies['postcss']).toBeDefined();
+  });
+
+  it('should not add "postcss" dependency when converting to "@angular/build" and a Postcss configuration is not present', async () => {
+    const newTree = await schematicRunner.runSchematic(schematicName, {}, tree);
+
+    const { devDependencies } = JSON.parse(newTree.readContent('/package.json'));
+
+    expect(devDependencies['postcss']).toBeUndefined();
   });
 });

--- a/packages/schematics/angular/utility/latest-versions/package.json
+++ b/packages/schematics/angular/utility/latest-versions/package.json
@@ -18,6 +18,7 @@
     "karma": "~6.4.0",
     "less": "^4.2.0",
     "ng-packagr": "^18.0.0-next.0",
+    "postcss": "^8.4.38",
     "protractor": "~7.0.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",


### PR DESCRIPTION
The application migration schematic will now attempt to detect the usage of custom postcss plugins within a workspace and install the `postcss` dependency if required. This will only occur if the migration analysis allows for the conversion to use the `@angular/build` package instead of the `@angular-devkit/build-angular` package. Custom postcss configurations will be detected within the same locations as the build system itself which includes the workspace root and any project root for the `postcss.config.json` and `.postcssrc.json` files.