### PR TITLE
build: replace `@angular/build` version with archive in local builds

### DIFF
--- a/packages/angular_devkit/build_angular/BUILD.bazel
+++ b/packages/angular_devkit/build_angular/BUILD.bazel
@@ -251,6 +251,7 @@ genrule(
 pkg_npm(
     name = "npm_package",
     pkg_deps = [
+        "//packages/angular/build:package.json",
         "//packages/angular_devkit/architect:package.json",
         "//packages/angular_devkit/build_webpack:package.json",
         "//packages/angular_devkit/core:package.json",


### PR DESCRIPTION
When creating a local development build of the repository via `yarn build --local`, the package version for `@angular/build` within `@angular-devkit/build-angular` will now correctly be replaced with the path to the locally built archive of `@angular/build`.