### PR TITLE
feat(@angular-devkit/build-angular): support `~` path for `dev-server` ssl

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/dev-server/options.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/options.ts
@@ -7,6 +7,7 @@
  */
 
 import { BuilderContext, targetFromTargetString } from '@angular-devkit/architect';
+import os from 'node:os';
 import path from 'node:path';
 import { normalizeCacheOptions } from '../../utils/normalize-cache';
 import { normalizeOptimization } from '../../utils/normalize-optimization';
@@ -105,8 +106,8 @@ export async function normalizeOptions(
     servePath,
     publicHost,
     ssl,
-    sslCert,
-    sslKey,
+    ...(sslCert ? { sslCert: sslCert.replace(/^~/, os.homedir()) } : {}),
+    ...(sslKey ? { sslKey: sslKey.replace(/^~/, os.homedir()) } : {}),
     forceEsbuild,
     // Prebundling defaults to true but requires caching to function
     prebundle: cacheOptions.enabled && !optimization.scripts && (prebundle ?? true),


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When utilizing the `@angular-devkit/build-angular:dev-server` (serve) builder for local development of applications with SSL, it's not possible to set a default value in the project configuration using `~`. Instead, you must specify it through arguments, move it to the workspace, or wrap the Angular builder.

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the new behavior that. -->

This PR will manage the use of `~` for the `sslCert` and `sslKey` options.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
