### PR TITLE
refactor(@angular/build): show unexpected Sass import resolution errors

### DIFF
--- a/packages/angular/build/src/tools/sass/worker.ts
+++ b/packages/angular/build/src/tools/sass/worker.ts
@@ -15,7 +15,7 @@ import {
   Exception,
   FileImporter,
   SourceSpan,
-  StringOptionsWithImporter,
+  StringOptions,
   compileString,
 } from 'sass';
 import {
@@ -43,7 +43,7 @@ interface RenderRequestMessage {
   /**
    * The Sass options to provide to the `dart-sass` compile function.
    */
-  options: Omit<StringOptionsWithImporter<'sync'>, 'url'> & { url: string };
+  options: Omit<StringOptions<'sync'>, 'url'> & { url: string };
   /**
    * Indicates the request has a custom importer function on the main thread.
    */


### PR DESCRIPTION
When attempting to resolve a Sass import, failure to read the contents of a directory that is not caused by a non-existent directory will now cause an exception to be thrown. This prevents abnormal situations from being hidden during the build.

A deprecated Sass interface was also replaced and was a type only change.