### PR TITLE
fix(@angular/build): properly rebase Sass url() values with leading interpolations

### DIFF
--- a/packages/angular/build/src/tools/sass/rebasing-importer.ts
+++ b/packages/angular/build/src/tools/sass/rebasing-importer.ts
@@ -83,7 +83,12 @@ abstract class UrlRebasingImporter implements Importer<'sync'> {
       }
 
       // Skip if root-relative, absolute or protocol relative url
-      if (/^((?:\w+:)?\/\/|data:|chrome:|#|\/)/.test(value)) {
+      if (/^((?:\w+:)?\/\/|data:|chrome:|\/)/.test(value)) {
+        continue;
+      }
+
+      // Skip if a fragment identifier but not a Sass interpolation
+      if (value[0] === '#' && value[1] !== '{') {
         continue;
       }
 


### PR DESCRIPTION
Previously, the Sass url() rebasing logic was skipping values that contained leading Sass interpolations. This was because an interpolation starts with the `#` character which in CSS indicates a fragment identifier and not a path. However, Sass special cases this scenario by checking if the next character is the `{` character and considers it an interpolation if present. The Angular rebasing logic will now match this behavior.

Fixes: #27621