### PR TITLE
fix(@angular/cli): clarify optional migration instructions during ng update

### DIFF
--- a/packages/angular/cli/src/commands/update/cli.ts
+++ b/packages/angular/cli/src/commands/update/cli.ts
@@ -1082,6 +1082,9 @@ export default class UpdateCommandModule extends CommandModule<UpdateCommandArgs
         numberOfMigrations > 1 ? 's' : ''
       } that can be executed.`,
     );
+    logger.info(
+      'Optional migrations may be skipped and executed after the update process if preferred.',
+    );
     logger.info(''); // Extra trailing newline.
 
     if (!isTTY()) {


### PR DESCRIPTION
The instructions for when optional migrations are present within an updated package have been adjusted. A sentence has been added to mention that optional migrations can be executed after the update process if preferred and can be skipped for now.