### PR TITLE
refactor: replace angular.io link with angular.dev

### DIFF
--- a/packages/angular/build/src/tools/esbuild/commonjs-checker.ts
+++ b/packages/angular/build/src/tools/esbuild/commonjs-checker.ts
@@ -169,7 +169,7 @@ function createCommonJSModuleError(request: string, importer: string): PartialMe
       {
         text:
           'CommonJS or AMD dependencies can cause optimization bailouts.\n' +
-          'For more information see: https://angular.io/guide/build#configuring-commonjs-dependencies',
+          'For more information see: https://angular.dev/tools/cli/build#configuring-commonjs-dependencies',
       },
     ],
   };

--- a/packages/angular_devkit/build_angular/src/tools/webpack/plugins/common-js-usage-warn-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/plugins/common-js-usage-warn-plugin.ts
@@ -91,7 +91,7 @@ export class CommonJsUsageWarnPlugin {
               const warning =
                 `${(issuer as NormalModule | null)?.userRequest} depends on '${rawRequest}'. ` +
                 'CommonJS or AMD dependencies can cause optimization bailouts.\n' +
-                'For more info see: https://angular.io/guide/build#configuring-commonjs-dependencies';
+                'For more info see: https://angular.dev/tools/cli/build#configuring-commonjs-dependencies';
 
               // Avoid showing the same warning multiple times when in 'watch' mode.
               if (!this.shownWarnings.has(warning)) {


### PR DESCRIPTION
This replaces https://angular.io/guide/build#configuring-commonjs-dependencies with https://angular.dev/tools/cli/build#configuring-commonjs-dependencies
