### PR TITLE
refactor(@angular/build): add error as part of error notes

### DIFF
--- a/packages/angular/build/src/tools/esbuild/stylesheets/css-inline-fonts-plugin.ts
+++ b/packages/angular/build/src/tools/esbuild/stylesheets/css-inline-fonts-plugin.ts
@@ -65,7 +65,7 @@ export function createCssInlineFontsPlugin({
               errors: [
                 {
                   text: `Failed to inline external stylesheet '${args.path}'.`,
-                  detail: error,
+                  notes: error instanceof Error ? [{ text: error.toString() }] : undefined,
                 },
               ],
             };


### PR DESCRIPTION
This commit adds the error as part of the notes when an error occurs during font inlining.
