### PR TITLE
perf(@angular/build): improve rebuild time for file loader usage with prebundling

### DIFF
--- a/packages/angular/build/src/builders/dev-server/vite-server.ts
+++ b/packages/angular/build/src/builders/dev-server/vite-server.ts
@@ -482,6 +482,15 @@ export async function setupServer(
     css: {
       devSourcemap: true,
     },
+    // Ensure custom 'file' loader build option entries are handled by Vite in application code that
+    // reference third-party libraries. Relative usage is handled directly by the build and not Vite.
+    // Only 'file' loader entries are currently supported directly by Vite.
+    assetsInclude:
+      prebundleLoaderExtensions &&
+      Object.entries(prebundleLoaderExtensions)
+        .filter(([, value]) => value === 'file')
+        // Create a file extension glob for each key
+        .map(([key]) => '*' + key),
     // Vite will normalize the `base` option by adding a leading slash.
     base: serverOptions.servePath,
     resolve: {

--- a/packages/angular/build/src/tools/esbuild/external-packages-plugin.ts
+++ b/packages/angular/build/src/tools/esbuild/external-packages-plugin.ts
@@ -24,8 +24,13 @@ export function createExternalPackagesPlugin(options?: { exclude?: string[] }): 
   return {
     name: 'angular-external-packages',
     setup(build) {
+      // Find all loader keys that are not using the 'file' loader.
+      // The 'file' loader is automatically handled by Vite and does not need exclusion.
       const loaderOptionKeys =
-        build.initialOptions.loader && Object.keys(build.initialOptions.loader);
+        build.initialOptions.loader &&
+        Object.entries(build.initialOptions.loader)
+          .filter(([, value]) => value !== 'file')
+          .map(([key]) => key);
 
       // Safe to use native packages external option if no loader options or exclusions present
       if (!exclusions && !loaderOptionKeys?.length) {


### PR DESCRIPTION
Rebuilds can now use the optimized external package execute path when using the `application` builder's `loader` option if only `file` type loaders are used. The Vite-based development server will now process any `file` type loader usage for third-party file references which removes the need for the build itself to handle the loader processing. This change only optimizes the case where only the `file` loader type is used. If any other loader types are present, the optimized execution path will not be used. Future further improvements may allow for all cases to use the optimized rebuild execution path.