### PR TITLE
fix(@angular-devkit/schematics): `SchematicTestRunner.runExternalSchematic` fails with "The encoded data was not valid for encoding utf-8"

### DIFF
--- a/packages/angular_devkit/schematics/src/rules/template.ts
+++ b/packages/angular_devkit/schematics/src/rules/template.ts
@@ -62,7 +62,12 @@ export function applyContentTemplate<T>(options: T): FileOperator {
         content: Buffer.from(templateImpl(decodedContent, {})(options)),
       };
     } catch (e) {
-      if (e instanceof TypeError) {
+      // The second part should not be needed. But Jest does not support instanceof correctly.
+      // See: https://github.com/jestjs/jest/issues/2549
+      if (
+        e instanceof TypeError ||
+        (e as NodeJS.ErrnoException).code === 'ERR_ENCODING_INVALID_ENCODED_DATA'
+      ) {
         return entry;
       }
 

--- a/packages/angular_devkit/schematics/src/tree/host-tree.ts
+++ b/packages/angular_devkit/schematics/src/tree/host-tree.ts
@@ -304,7 +304,12 @@ export class HostTree implements Tree {
       // With the `fatal` option enabled, invalid data will throw a TypeError
       return decoder.decode(data);
     } catch (e) {
-      if (e instanceof TypeError) {
+      // The second part should not be needed. But Jest does not support instanceof correctly.
+      // See: https://github.com/jestjs/jest/issues/2549
+      if (
+        e instanceof TypeError ||
+        (e as NodeJS.ErrnoException).code === 'ERR_ENCODING_INVALID_ENCODED_DATA'
+      ) {
         throw new Error(`Failed to decode "${path}" as UTF-8 text.`);
       }
       throw e;


### PR DESCRIPTION


When using Jest `instanceof` does not work correctly. See: https://github.com/jestjs/jest/issues/2549

Closes: #27643
