### PR TITLE
fix(@angular/build): add console note about development server raw file size

### DIFF
--- a/packages/angular/build/src/builders/dev-server/vite-server.ts
+++ b/packages/angular/build/src/builders/dev-server/vite-server.ts
@@ -241,6 +241,10 @@ export async function* serveWithVite(
         throw new Error('The builder requires a target.');
       }
 
+      context.logger.info(
+        'NOTE: Raw file sizes do not reflect development server per-request transformations.',
+      );
+
       const { root = '' } = await context.getProjectMetadata(projectName);
       const projectRoot = join(context.workspaceRoot, root as string);
       const browsers = getSupportedBrowsers(projectRoot, context.logger);


### PR DESCRIPTION
An informational note will now be shown upon development server startup to indicate that the raw file sizes shown in the console do not reflect any of the per-request transformations that may occur within the Vite-based development server. The raw file size and the size shown within the browser may differ as a result of these development workflow based transformations.