### PR TITLE
refactor(@angular/build): cleanup persistent JS transformer cache on plugin dispose

### DIFF
--- a/packages/angular/build/src/tools/esbuild/angular/compiler-plugin.ts
+++ b/packages/angular/build/src/tools/esbuild/angular/compiler-plugin.ts
@@ -63,10 +63,10 @@ export function createCompilerPlugin(
       const preserveSymlinks = build.initialOptions.preserveSymlinks;
 
       // Initialize a worker pool for JavaScript transformations
-      let cacheStore;
+      let cacheStore: LmbdCacheStore | undefined;
       if (pluginOptions.sourceFileCache?.persistentCachePath) {
         cacheStore = new LmbdCacheStore(
-          pluginOptions.sourceFileCache.persistentCachePath + '/angular-compiler.db',
+          path.join(pluginOptions.sourceFileCache.persistentCachePath, 'angular-compiler.db'),
         );
       }
       const javascriptTransformer = new JavaScriptTransformer(
@@ -446,6 +446,7 @@ export function createCompilerPlugin(
         sharedTSCompilationState?.dispose();
         void stylesheetBundler.dispose();
         void compilation.close?.();
+        void cacheStore?.close();
       });
 
       /**


### PR DESCRIPTION
Close and allow the persistent JS transformer cache to cleanup open lock files when the Angular compiler plugin is disposed. While this is not strictly necessary, it does help prevent extra cache lock files from being retained after build completion.