### PR TITLE
fix(@angular/cli): change update guide link to angular.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Angular is cross-platform, fast, scalable, has incredible tooling, and is loved 
 
 ## Upgrading
 
-Check out our [upgrade guide](https://update.angular.io/) to find out the best way to upgrade your project.
+Check out our [upgrade guide](https://update.angular.dev/) to find out the best way to upgrade your project.
 
 ## Contributing
 

--- a/packages/angular/build/src/utils/version.ts
+++ b/packages/angular/build/src/utils/version.ts
@@ -73,7 +73,7 @@ export function assertCompatibleAngularVersion(projectRoot: string): void | neve
     console.error(
       `This version of CLI is only compatible with Angular versions ${supportedAngularSemver},\n` +
         `but Angular version ${angularVersion} was found instead.\n` +
-        'Please visit the link below to find instructions on how to update Angular.\nhttps://update.angular.io/',
+        'Please visit the link below to find instructions on how to update Angular.\nhttps://update.angular.dev/',
     );
 
     process.exit(3);

--- a/packages/angular/cli/src/commands/update/cli.ts
+++ b/packages/angular/cli/src/commands/update/cli.ts
@@ -81,7 +81,7 @@ export default class UpdateCommandModule extends CommandModule<UpdateCommandArgs
   protected override shouldReportAnalytics = false;
 
   command = 'update [packages..]';
-  describe = 'Updates your workspace and its dependencies. See https://update.angular.io/.';
+  describe = 'Updates your workspace and its dependencies. See https://update.angular.dev/.';
   longDescriptionPath = join(__dirname, 'long-description.md');
 
   builder(localYargs: Argv): Argv<UpdateCommandArgs> {
@@ -716,7 +716,7 @@ export default class UpdateCommandModule extends CommandModule<UpdateCommandArgs
             // Example @angular/core skipped version 3, @angular/cli skipped versions 2-5.
             logger.error(
               `Updating multiple major versions of '${name}' at once is not supported. Please migrate each major version individually.\n` +
-                `For more information about the update process, see https://update.angular.io/.`,
+                `For more information about the update process, see https://update.angular.dev/.`,
             );
           } else {
             const nextMajorVersionFromCurrent = currentMajorVersion + 1;
@@ -725,7 +725,7 @@ export default class UpdateCommandModule extends CommandModule<UpdateCommandArgs
               `Updating multiple major versions of '${name}' at once is not supported. Please migrate each major version individually.\n` +
                 `Run 'ng update ${name}@${nextMajorVersionFromCurrent}' in your workspace directory ` +
                 `to update to latest '${nextMajorVersionFromCurrent}.x' version of '${name}'.\n\n` +
-                `For more information about the update process, see https://update.angular.io/?v=${currentMajorVersion}.0-${nextMajorVersionFromCurrent}.0`,
+                `For more information about the update process, see https://update.angular.dev/?v=${currentMajorVersion}.0-${nextMajorVersionFromCurrent}.0`,
             );
           }
 

--- a/packages/angular/cli/src/commands/update/long-description.md
+++ b/packages/angular/cli/src/commands/update/long-description.md
@@ -19,4 +19,4 @@ For example, use the following command to take the latest 10.x.x version and use
 ng update @angular/cli@^10 @angular/core@^10
 ```
 
-For detailed information and guidance on updating your application, see the interactive [Angular Update Guide](https://update.angular.io/).
+For detailed information and guidance on updating your application, see the interactive [Angular Update Guide](https://update.angular.dev/).

--- a/scripts/templates/readme.ejs
+++ b/scripts/templates/readme.ejs
@@ -106,7 +106,7 @@ Angular is cross-platform, fast, scalable, has incredible tooling, and is loved 
 
 ## Upgrading
 
-Check out our [upgrade guide](https://update.angular.io/) to find out the best way to upgrade your project.
+Check out our [upgrade guide](https://update.angular.dev/) to find out the best way to upgrade your project.
 
 ## Contributing
 


### PR DESCRIPTION
References to the Angular update guide now use the new angular.dev site.