### PR TITLE
refactor(@angular/cli): use prompt helper functions in analytics and completion commands

### DIFF
--- a/packages/angular/cli/src/analytics/analytics.ts
+++ b/packages/angular/cli/src/analytics/analytics.ts
@@ -12,7 +12,7 @@ import type { CommandContext } from '../command-builder/command-module';
 import { colors } from '../utilities/color';
 import { getWorkspace } from '../utilities/config';
 import { analyticsDisabled } from '../utilities/environment-options';
-import { loadEsmModule } from '../utilities/load-esm';
+import { askConfirmation } from '../utilities/prompt';
 import { isTTY } from '../utilities/tty';
 
 /* eslint-disable no-console */
@@ -75,24 +75,19 @@ export async function promptAnalytics(
   }
 
   if (force || isTTY()) {
-    const { default: inquirer } = await loadEsmModule<typeof import('inquirer')>('inquirer');
-    const answers = await inquirer.prompt<{ analytics: boolean }>([
-      {
-        type: 'confirm',
-        name: 'analytics',
-        message: tags.stripIndents`
-           Would you like to share pseudonymous usage data about this project with the Angular Team
-           at Google under Google's Privacy Policy at https://policies.google.com/privacy. For more
-           details and how to change this setting, see https://angular.io/analytics.
+    const answer = await askConfirmation(
+      `
+Would you like to share pseudonymous usage data about this project with the Angular Team
+at Google under Google's Privacy Policy at https://policies.google.com/privacy. For more
+details and how to change this setting, see https://angular.io/analytics.
 
-         `,
-        default: false,
-      },
-    ]);
+  `,
+      false,
+    );
 
-    await setAnalyticsConfig(global, answers.analytics);
+    await setAnalyticsConfig(global, answer);
 
-    if (answers.analytics) {
+    if (answer) {
       console.log('');
       console.log(
         tags.stripIndent`

--- a/packages/angular/cli/src/utilities/completion.ts
+++ b/packages/angular/cli/src/utilities/completion.ts
@@ -16,7 +16,7 @@ import { getWorkspace } from '../utilities/config';
 import { forceAutocomplete } from '../utilities/environment-options';
 import { isTTY } from '../utilities/tty';
 import { assertIsError } from './error';
-import { loadEsmModule } from './load-esm';
+import { askConfirmation } from './prompt';
 
 /** Interface for the autocompletion configuration stored in the global workspace. */
 interface CompletionConfig {
@@ -179,24 +179,17 @@ async function shouldPromptForAutocompletionSetup(
 }
 
 async function promptForAutocompletion(): Promise<boolean> {
-  // Dynamically load `inquirer` so users don't have to pay the cost of parsing and executing it for
-  // the 99% of builds that *don't* prompt for autocompletion.
-  const { default: inquirer } = await loadEsmModule<typeof import('inquirer')>('inquirer');
-  const { autocomplete } = await inquirer.prompt<{ autocomplete: boolean }>([
-    {
-      name: 'autocomplete',
-      type: 'confirm',
-      message: `
+  const autocomplete = await askConfirmation(
+    `
 Would you like to enable autocompletion? This will set up your terminal so pressing TAB while typing
 Angular CLI commands will show possible options and autocomplete arguments. (Enabling autocompletion
 will modify configuration files in your home directory.)
-      `
-        .split('\n')
-        .join(' ')
-        .trim(),
-      default: true,
-    },
-  ]);
+        `
+      .split('\n')
+      .join(' ')
+      .trim(),
+    true,
+  );
 
   return autocomplete;
 }


### PR DESCRIPTION
Instead of manually invoking an underlying prompt library, the analytics and completion commands now use the helper utility functions present to handle console prompts.