### PR TITLE
ng version updates

### DIFF
--- a/packages/angular/cli/src/command-builder/command-module.ts
+++ b/packages/angular/cli/src/command-builder/command-module.ts
@@ -176,8 +176,8 @@ export abstract class CommandModule<T extends {} = {}> implements CommandModuleI
 
     const userId = await getAnalyticsUserId(
       this.context,
-      // Don't prompt for `ng update` and `ng analytics` commands.
-      ['update', 'analytics'].includes(this.commandName),
+      // Don't prompt on `ng update`, 'ng version' or `ng analytics`.
+      ['version', 'update', 'analytics'].includes(this.commandName),
     );
 
     return userId ? new AnalyticsCollector(this.context, userId) : undefined;

--- a/packages/angular/cli/src/command-builder/command-runner.ts
+++ b/packages/angular/cli/src/command-builder/command-runner.ts
@@ -19,6 +19,7 @@ import { colors } from '../utilities/color';
 import { AngularWorkspace, getWorkspace } from '../utilities/config';
 import { assertIsError } from '../utilities/error';
 import { PackageManagerUtils } from '../utilities/package-manager';
+import { VERSION } from '../utilities/version';
 import { CommandContext, CommandModuleError } from './command-module';
 import {
   CommandModuleConstructor,
@@ -122,7 +123,7 @@ export async function runCommand(args: string[], logger: logging.Logger): Promis
     .demandCommand(1, demandCommandFailureMessage)
     .recommendCommands()
     .middleware(normalizeOptionsMiddleware)
-    .version(false)
+    .version('version', 'Show Angular CLI version.', VERSION.full)
     .showHelpOnFail(false)
     .strict()
     .fail((msg, err) => {

--- a/packages/angular/cli/src/utilities/completion.ts
+++ b/packages/angular/cli/src/utilities/completion.ts
@@ -130,8 +130,8 @@ async function shouldPromptForAutocompletionSetup(
     return forceAutocomplete;
   }
 
-  // Don't prompt on `ng update` or `ng completion`.
-  if (command === 'update' || command === 'completion') {
+  // Don't prompt on `ng update`, 'ng version' or `ng completion`.
+  if (['version', 'update', 'completion'].includes(command)) {
     return false;
   }
 

--- a/tests/legacy-cli/e2e/tests/commands/analytics/ask-analytics-command.ts
+++ b/tests/legacy-cli/e2e/tests/commands/analytics/ask-analytics-command.ts
@@ -8,7 +8,7 @@ export default async function () {
   await mockHome(async () => {
     const { stdout } = await execWithEnv(
       'ng',
-      ['version'],
+      ['config'],
       {
         ...process.env,
         NG_FORCE_TTY: '1',
@@ -24,7 +24,7 @@ export default async function () {
 
   // CLI should skip analytics prompt with `NG_CLI_ANALYTICS=false`.
   await mockHome(async () => {
-    const { stdout } = await execWithEnv('ng', ['version'], {
+    const { stdout } = await execWithEnv('ng', ['config'], {
       ...process.env,
       NG_FORCE_TTY: '1',
       NG_CLI_ANALYTICS: 'false',

--- a/tests/legacy-cli/e2e/tests/commands/completion/completion-prompt.ts
+++ b/tests/legacy-cli/e2e/tests/commands/completion/completion-prompt.ts
@@ -42,7 +42,7 @@ export default async function () {
 
     const { stdout } = await execWithEnv(
       'ng',
-      ['version'],
+      ['config'],
       {
         ...DEFAULT_ENV,
         SHELL: '/bin/bash',
@@ -74,7 +74,7 @@ export default async function () {
 
     const { stdout } = await execWithEnv(
       'ng',
-      ['version'],
+      ['config'],
       {
         ...DEFAULT_ENV,
         SHELL: '/bin/bash',
@@ -112,7 +112,7 @@ export default async function () {
 
     const { stdout: stdout1 } = await execWithEnv(
       'ng',
-      ['version'],
+      ['config'],
       {
         ...DEFAULT_ENV,
         SHELL: '/bin/bash',
@@ -136,7 +136,7 @@ export default async function () {
     // User modifies their configuration and removes `ng completion`.
     await fs.writeFile(bashrc, '# Some new commands...');
 
-    const { stdout: stdout2 } = await execWithEnv('ng', ['version'], {
+    const { stdout: stdout2 } = await execWithEnv('ng', ['config'], {
       ...DEFAULT_ENV,
       SHELL: '/bin/bash',
       HOME: home,
@@ -165,7 +165,7 @@ export default async function () {
 
     const { stdout: stdout1 } = await execWithEnv(
       'ng',
-      ['version'],
+      ['config'],
       {
         ...DEFAULT_ENV,
         SHELL: '/bin/bash',
@@ -178,7 +178,7 @@ export default async function () {
       throw new Error('First execution did not prompt for autocompletion setup.');
     }
 
-    const { stdout: stdout2 } = await execWithEnv('ng', ['version'], {
+    const { stdout: stdout2 } = await execWithEnv('ng', ['config'], {
       ...DEFAULT_ENV,
       SHELL: '/bin/bash',
       HOME: home,
@@ -211,7 +211,7 @@ export default async function () {
 
     const err = await execAndCaptureError(
       'ng',
-      ['version'],
+      ['config'],
       {
         ...DEFAULT_ENV,
         SHELL: '/bin/bash',
@@ -231,7 +231,7 @@ export default async function () {
 
     const { stdout: stdout2 } = await execWithEnv(
       'ng',
-      ['version'],
+      ['config'],
       {
         ...DEFAULT_ENV,
         SHELL: '/bin/bash',
@@ -283,7 +283,7 @@ export default async function () {
 
   // Does *not* prompt user for CI executions.
   {
-    const { stdout } = await execWithEnv('ng', ['version'], {
+    const { stdout } = await execWithEnv('ng', ['config'], {
       ...DEFAULT_ENV,
       CI: 'true',
       NG_FORCE_TTY: undefined,
@@ -296,7 +296,7 @@ export default async function () {
 
   // Does *not* prompt user for non-TTY executions.
   {
-    const { stdout } = await execWithEnv('ng', ['version'], {
+    const { stdout } = await execWithEnv('ng', ['config'], {
       ...DEFAULT_ENV,
       NG_FORCE_TTY: 'false',
     });
@@ -308,7 +308,7 @@ export default async function () {
 
   // Does *not* prompt user for executions without a `$HOME`.
   {
-    const { stdout } = await execWithEnv('ng', ['version'], {
+    const { stdout } = await execWithEnv('ng', ['config'], {
       ...DEFAULT_ENV,
       HOME: undefined,
     });
@@ -323,7 +323,7 @@ export default async function () {
 
   // Does *not* prompt user for executions without a `$SHELL`.
   {
-    const { stdout } = await execWithEnv('ng', ['version'], {
+    const { stdout } = await execWithEnv('ng', ['config'], {
       ...DEFAULT_ENV,
       SHELL: undefined,
     });
@@ -338,7 +338,7 @@ export default async function () {
 
   // Does *not* prompt user for executions from unknown shells.
   {
-    const { stdout } = await execWithEnv('ng', ['version'], {
+    const { stdout } = await execWithEnv('ng', ['config'], {
       ...DEFAULT_ENV,
       SHELL: '/usr/bin/unknown',
     });
@@ -364,7 +364,7 @@ source <(ng completion script)
     `.trim(),
     );
 
-    const { stdout } = await execWithEnv('ng', ['version'], {
+    const { stdout } = await execWithEnv('ng', ['config'], {
       ...DEFAULT_ENV,
       SHELL: '/bin/bash',
       HOME: home,
@@ -383,7 +383,7 @@ source <(ng completion script)
     const bashrc = path.join(home, '.bashrc');
     await fs.writeFile(bashrc, `# Other content...`);
 
-    await execAndWaitForOutputToMatch('ng', ['version'], AUTOCOMPLETION_PROMPT, {
+    await execAndWaitForOutputToMatch('ng', ['config'], AUTOCOMPLETION_PROMPT, {
       ...DEFAULT_ENV,
       SHELL: '/bin/bash',
       HOME: home,
@@ -411,7 +411,7 @@ source <(ng completion script)
       const localCliBinary = path.join(localCliDir, 'ng');
       const pathDirs = process.env['PATH']!.split(':');
       const pathEnvVar = [...pathDirs, localCliDir].join(':');
-      const { stdout } = await execWithEnv(localCliBinary, ['version'], {
+      const { stdout } = await execWithEnv(localCliBinary, ['config'], {
         ...DEFAULT_ENV,
         SHELL: '/bin/bash',
         HOME: home,
@@ -437,7 +437,7 @@ async function windowsTests(): Promise<void> {
     const bashrc = path.join(home, '.bashrc');
     await fs.writeFile(bashrc, `# Other content...`);
 
-    const { stdout } = await execWithEnv('ng', ['version'], { ...env });
+    const { stdout } = await execWithEnv('ng', ['config'], { ...env });
 
     if (AUTOCOMPLETION_PROMPT.test(stdout)) {
       throw new Error(

--- a/tests/legacy-cli/e2e/tests/commands/help/help-json.ts
+++ b/tests/legacy-cli/e2e/tests/commands/help/help-json.ts
@@ -36,6 +36,11 @@ export default async function () {
         'description': 'If provided, a new value for the given configuration key.',
         'positional': 1,
       },
+      {
+        'name': 'version',
+        'type': 'boolean',
+        'description': 'Show Angular CLI version.',
+      },
     ],
   });
 


### PR DESCRIPTION


**fix(@angular/cli): add `--version` option**

This commit introduces the `--version` option, which will display the Angular CLI version when using `ng --version`.

Closes #27668



**fix(@angular/cli): eliminate prompts during `ng version` command**

This update removes the analytics and completion prompts that appear when executing the `ng version` command, ensuring a smoother and uninterrupted user experience.

Closes #27668