### PR TITLE
fix(@angular/cli): only add --version option on default command

### DIFF
--- a/packages/angular/cli/src/command-builder/command-runner.ts
+++ b/packages/angular/cli/src/command-builder/command-runner.ts
@@ -91,6 +91,11 @@ export async function runCommand(args: string[], logger: logging.Logger): Promis
     usageInstance.help = () => jsonHelpUsage();
   }
 
+  // Add default command to support version option when no subcommand is specified
+  localYargs.command('*', false, (builder) =>
+    builder.version('version', 'Show Angular CLI version.', VERSION.full),
+  );
+
   await localYargs
     .scriptName('ng')
     // https://github.com/yargs/yargs/blob/main/docs/advanced.md#customizing-yargs-parser
@@ -123,7 +128,7 @@ export async function runCommand(args: string[], logger: logging.Logger): Promis
     .demandCommand(1, demandCommandFailureMessage)
     .recommendCommands()
     .middleware(normalizeOptionsMiddleware)
-    .version('version', 'Show Angular CLI version.', VERSION.full)
+    .version(false)
     .showHelpOnFail(false)
     .strict()
     .fail((msg, err) => {

--- a/tests/legacy-cli/e2e/tests/commands/help/help-json.ts
+++ b/tests/legacy-cli/e2e/tests/commands/help/help-json.ts
@@ -36,11 +36,6 @@ export default async function () {
         'description': 'If provided, a new value for the given configuration key.',
         'positional': 1,
       },
-      {
-        'name': 'version',
-        'type': 'boolean',
-        'description': 'Show Angular CLI version.',
-      },
     ],
   });
 


### PR DESCRIPTION
The newly added `--version` option was previously added to all subcommands which can result in a warning being shown if the subcommand was a builder or schematics that also happened to have a `version` option. To support the default `--version` option that displays the actual CLI version, the option is now only added when no subcommand is present. This prevents potential version option overlap.