### PR TITLE
docs: release notes for the v17.3.8 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+<a name="17.3.8"></a>
+
+# 17.3.8 (2024-05-22)
+
+### @angular/cli
+
+| Commit                                                                                              | Type | Description                                              |
+| --------------------------------------------------------------------------------------------------- | ---- | -------------------------------------------------------- |
+| [3ada6eb52](https://github.com/angular/angular-cli/commit/3ada6eb5256631ca3a951525fc9814ad0447a41f) | fix  | clarify optional migration instructions during ng update |
+
+### @angular-devkit/schematics
+
+| Commit                                                                                              | Type | Description                                                                                               |
+| --------------------------------------------------------------------------------------------------- | ---- | --------------------------------------------------------------------------------------------------------- |
+| [4b6ba8df1](https://github.com/angular/angular-cli/commit/4b6ba8df1ab8f4801fba7ddc38812417e274d960) | fix  | `SchematicTestRunner.runExternalSchematic` fails with "The encoded data was not valid for encoding utf-8" |
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="18.0.0-rc.3"></a>
 
 # 18.0.0-rc.3 (2024-05-21)


### PR DESCRIPTION
Cherry-picks the changelog from the "17.3.x" branch to the next branch (main).