### PR TITLE
fix(@angular/build): disable persistent disk caching inside webcontainers by default

### DIFF
--- a/packages/angular/build/src/utils/normalize-cache.ts
+++ b/packages/angular/build/src/utils/normalize-cache.ts
@@ -43,7 +43,12 @@ export function normalizeCacheOptions(
 ): NormalizedCachedOptions {
   const cacheMetadata = hasCacheMetadata(projectMetadata) ? projectMetadata.cli.cache : {};
 
-  const { enabled = true, environment = 'local', path = '.angular/cache' } = cacheMetadata;
+  const {
+    // Webcontainers do not currently benefit from persistent disk caching and can lead to increased browser memory usage
+    enabled = !process.versions.webcontainer,
+    environment = 'local',
+    path = '.angular/cache',
+  } = cacheMetadata;
   const isCI = process.env['CI'] === '1' || process.env['CI']?.toLowerCase() === 'true';
 
   let cacheEnabled = enabled;


### PR DESCRIPTION
When using the build system within a Web container, persistent disk caching is now disabled by default. Persistent disk caching does not provide a benefit for typical use cases and can cause increased browser memory usage when enabled.
