### PR TITLE
fix(@schematics/angular): check both application builder packages in SSR schematic

### DIFF
--- a/packages/schematics/angular/ssr/index.ts
+++ b/packages/schematics/angular/ssr/index.ts
@@ -34,7 +34,7 @@ import { latestVersions } from '../utility/latest-versions';
 import { isStandaloneApp } from '../utility/ng-ast-utils';
 import { targetBuildNotFoundError } from '../utility/project-targets';
 import { getMainFilePath } from '../utility/standalone/util';
-import { getWorkspace } from '../utility/workspace';
+import { ProjectDefinition, getWorkspace } from '../utility/workspace';
 import { Builders } from '../utility/workspace-models';
 
 import { Schema as SSROptions } from './schema';
@@ -332,8 +332,7 @@ function addServerFile(options: ServerOptions, isStandalone: boolean): Rule {
     if (!project) {
       throw new SchematicsException(`Invalid project name (${projectName})`);
     }
-    const isUsingApplicationBuilder =
-      project?.targets?.get('build')?.builder === Builders.Application;
+    const isUsingApplicationBuilder = usingApplicationBuilder(project);
 
     const browserDistDirectory = isUsingApplicationBuilder
       ? (await getApplicationBuilderOutputPaths(host, projectName)).browser
@@ -366,8 +365,8 @@ export default function (options: SSROptions): Rule {
     if (!clientProject) {
       throw targetBuildNotFoundError();
     }
-    const isUsingApplicationBuilder =
-      clientProject.targets.get('build')?.builder === Builders.Application;
+
+    const isUsingApplicationBuilder = usingApplicationBuilder(clientProject);
 
     return chain([
       schematic('server', {
@@ -388,4 +387,12 @@ export default function (options: SSROptions): Rule {
       addDependencies(options, isUsingApplicationBuilder),
     ]);
   };
+}
+
+function usingApplicationBuilder(project: ProjectDefinition) {
+  const buildBuilder = project.targets.get('build')?.builder;
+  const isUsingApplicationBuilder =
+    buildBuilder === Builders.Application || buildBuilder === Builders.BuildApplication;
+
+  return isUsingApplicationBuilder;
 }

--- a/packages/schematics/angular/utility/standalone/util.ts
+++ b/packages/schematics/angular/utility/standalone/util.ts
@@ -29,7 +29,10 @@ export async function getMainFilePath(tree: Tree, projectName: string): Promise<
 
   const options = buildTarget.options as Record<string, string>;
 
-  return buildTarget.builder === Builders.Application ? options.browser : options.main;
+  return buildTarget.builder === Builders.Application ||
+    buildTarget.builder === Builders.BuildApplication
+    ? options.browser
+    : options.main;
 }
 
 /**

--- a/packages/schematics/angular/utility/workspace-models.ts
+++ b/packages/schematics/angular/utility/workspace-models.ts
@@ -31,6 +31,7 @@ export enum Builders {
   DevServer = '@angular-devkit/build-angular:dev-server',
   ExtractI18n = '@angular-devkit/build-angular:extract-i18n',
   Protractor = '@angular-devkit/build-angular:protractor',
+  BuildApplication = '@angular/build:application',
 }
 
 export interface FileReplacements {


### PR DESCRIPTION
The SSR schematic was previously only checking for the application build found within the `@angular-devkit/build-angular` package which is only an alias to the actual builder found in the `@angular/build` package. Both aliased and direct usages are now checked when executing the schematic.