### PR TITLE
fix: replace aio links -> adev links

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -50,7 +50,7 @@
         " * Copyright Google LLC All Rights Reserved.",
         " *",
         " * Use of this source code is governed by an MIT-style license that can be",
-        " * found in the LICENSE file at https://angular.io/license",
+        " * found in the LICENSE file at https://angular.dev/license",
         " "
       ],
       2

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,7 +1,7 @@
 # Copyright Google Inc. All Rights Reserved.
 #
 # Use of this source code is governed by an MIT-style license that can be
-# found in the LICENSE file at https://angular.io/license
+# found in the LICENSE file at https://angular.dev/license
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load("@build_bazel_rules_nodejs//:index.bzl", "copy_to_bin")
 load("@npm//@bazel/concatjs:index.bzl", "ts_config")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4103,7 +4103,7 @@ Charles Lyding and Doug Parker
 
 ### @schematics/angular
 
-- `classlist.js` and `web-animations-js` are removed from application polyfills and uninstalled from the package. These were only needed for compatibility with Internet Explorer, which is no longer needed now that Angular only supports evergreen browsers. See: https://angular.io/guide/browser-support.
+- `classlist.js` and `web-animations-js` are removed from application polyfills and uninstalled from the package. These were only needed for compatibility with Internet Explorer, which is no longer needed now that Angular only supports evergreen browsers. See: https://angular.dev/reference/versions#browser-support.
 
 Add the following to the polyfills file for an app to re-add these packages:
 
@@ -11017,7 +11017,7 @@ The following options which were used to support the above syntax were removed w
 </h3>
 Critical CSS inlining is now enabled by default. If you wish to turn this off set `inlineCritical` to `false`.
 
-See: https://angular.io/guide/workspace-config#optimization-configuration
+See: https://angular.dev/reference/configs/workspace-config#optimization-configuration
 
 <h3>
     @angular-devkit/build-angular: drop support for zone.js 0.10 (<a href="https://github.com/angular/angular-cli/commit/f309516bcdcee711fc5693b5f14d6fef1cfa5dba">f309516</a>)
@@ -13613,7 +13613,7 @@ Alan Agius, Charles Lyding, Renovate Bot, Joey Perrott
 </h3>
 Critical CSS inlining is now enabled by default. If you wish to turn this off set `inlineCritical` to `false`.
 
-See: https://angular.io/guide/workspace-config#optimization-configuration
+See: https://angular.dev/reference/configs/workspace-config#optimization-configuration
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
   ·
   <a href="https://github.com/angular/angular-cli/issues">Submit an Issue</a>
   ·
-  <a href="https://blog.angular.dev/">Blog</a>
+  <a href="https://blog.angular.dev">Blog</a>
   <br>
   <br>
 </p>

--- a/modules/testing/builder/projects/hello-world-app/e2e/app.e2e-spec.ts
+++ b/modules/testing/builder/projects/hello-world-app/e2e/app.e2e-spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { AppPage } from './app.po';

--- a/modules/testing/builder/projects/hello-world-app/e2e/app.po.ts
+++ b/modules/testing/builder/projects/hello-world-app/e2e/app.po.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { browser, by, element } from 'protractor';

--- a/modules/testing/builder/projects/hello-world-app/karma.conf.js
+++ b/modules/testing/builder/projects/hello-world-app/karma.conf.js
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 // Karma configuration file, see link for more information

--- a/modules/testing/builder/projects/hello-world-app/protractor.conf.js
+++ b/modules/testing/builder/projects/hello-world-app/protractor.conf.js
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 // Protractor configuration file, see link for more information

--- a/modules/testing/builder/projects/hello-world-app/src/app/app.component.html
+++ b/modules/testing/builder/projects/hello-world-app/src/app/app.component.html
@@ -8,13 +8,13 @@
 <h2>Here are some links to help you start: </h2>
 <ul>
   <li>
-    <h2><a target="_blank" rel="noopener" href="https://angular.io/tutorial">Tour of Heroes</a></h2>
+    <h2><a target="_blank" rel="noopener" href="https://angular.dev/tutorials/learn-angular">Learn Angular</a></h2>
   </li>
   <li>
     <h2><a target="_blank" rel="noopener" href="https://github.com/angular/angular-cli/wiki">CLI Documentation</a></h2>
   </li>
   <li>
-    <h2><a target="_blank" rel="noopener" href="https://blog.angular.io/">Angular blog</a></h2>
+    <h2><a target="_blank" rel="noopener" href="https://blog.angular.dev">Angular blog</a></h2>
   </li>
 </ul>
 

--- a/modules/testing/builder/projects/hello-world-app/src/app/app.component.spec.ts
+++ b/modules/testing/builder/projects/hello-world-app/src/app/app.component.spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { TestBed } from '@angular/core/testing';

--- a/modules/testing/builder/projects/hello-world-app/src/app/app.component.ts
+++ b/modules/testing/builder/projects/hello-world-app/src/app/app.component.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Component } from '@angular/core';

--- a/modules/testing/builder/projects/hello-world-app/src/app/app.module.server.ts
+++ b/modules/testing/builder/projects/hello-world-app/src/app/app.module.server.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { NgModule } from '@angular/core';

--- a/modules/testing/builder/projects/hello-world-app/src/app/app.module.ts
+++ b/modules/testing/builder/projects/hello-world-app/src/app/app.module.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { BrowserModule } from '@angular/platform-browser';

--- a/modules/testing/builder/projects/hello-world-app/src/main.server.ts
+++ b/modules/testing/builder/projects/hello-world-app/src/main.server.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { AppServerModule } from './app/app.module.server';

--- a/modules/testing/builder/projects/hello-world-app/src/main.ts
+++ b/modules/testing/builder/projects/hello-world-app/src/main.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';

--- a/modules/testing/builder/projects/hello-world-app/src/polyfills.ts
+++ b/modules/testing/builder/projects/hello-world-app/src/polyfills.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 /**

--- a/modules/testing/builder/projects/hello-world-app/src/typings.d.ts
+++ b/modules/testing/builder/projects/hello-world-app/src/typings.d.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 /* SystemJS module definition */

--- a/modules/testing/builder/src/builder-harness.ts
+++ b/modules/testing/builder/src/builder-harness.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 /* eslint-disable import/no-extraneous-dependencies */

--- a/modules/testing/builder/src/builder-harness_spec.ts
+++ b/modules/testing/builder/src/builder-harness_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 /* eslint-disable import/no-extraneous-dependencies */

--- a/modules/testing/builder/src/file-watching.ts
+++ b/modules/testing/builder/src/file-watching.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 type BuilderWatcherCallback = (

--- a/modules/testing/builder/src/index.ts
+++ b/modules/testing/builder/src/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 export {

--- a/modules/testing/builder/src/jasmine-helpers.ts
+++ b/modules/testing/builder/src/jasmine-helpers.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { BuilderHandlerFn } from '@angular-devkit/architect';

--- a/modules/testing/builder/src/test-utils.ts
+++ b/modules/testing/builder/src/test-utils.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 /* eslint-disable import/no-extraneous-dependencies */

--- a/packages/angular/build/src/builders/application/build-action.ts
+++ b/packages/angular/build/src/builders/application/build-action.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { BuilderContext, BuilderOutput } from '@angular-devkit/architect';

--- a/packages/angular/build/src/builders/application/execute-build.ts
+++ b/packages/angular/build/src/builders/application/execute-build.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { BuilderContext } from '@angular-devkit/architect';

--- a/packages/angular/build/src/builders/application/execute-post-bundle.ts
+++ b/packages/angular/build/src/builders/application/execute-post-bundle.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import assert from 'node:assert';

--- a/packages/angular/build/src/builders/application/i18n.ts
+++ b/packages/angular/build/src/builders/application/i18n.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { BuilderContext } from '@angular-devkit/architect';

--- a/packages/angular/build/src/builders/application/index.ts
+++ b/packages/angular/build/src/builders/application/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { BuilderContext, BuilderOutput, createBuilder } from '@angular-devkit/architect';

--- a/packages/angular/build/src/builders/application/options.ts
+++ b/packages/angular/build/src/builders/application/options.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type { BuilderContext } from '@angular-devkit/architect';

--- a/packages/angular/build/src/builders/application/setup-bundling.ts
+++ b/packages/angular/build/src/builders/application/setup-bundling.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { SourceFileCache } from '../../tools/esbuild/angular/source-file-cache';

--- a/packages/angular/build/src/builders/application/tests/behavior/angular-aot-metadata_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/behavior/angular-aot-metadata_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { buildApplication } from '../../index';

--- a/packages/angular/build/src/builders/application/tests/behavior/browser-support_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/behavior/browser-support_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { buildApplication } from '../../index';

--- a/packages/angular/build/src/builders/application/tests/behavior/component-stylesheets_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/behavior/component-stylesheets_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { buildApplication } from '../../index';

--- a/packages/angular/build/src/builders/application/tests/behavior/index-preload-hints_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/behavior/index-preload-hints_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { buildApplication } from '../../index';

--- a/packages/angular/build/src/builders/application/tests/behavior/rebuild-component_styles_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/behavior/rebuild-component_styles_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { concatMap, count, take, timeout } from 'rxjs';

--- a/packages/angular/build/src/builders/application/tests/behavior/rebuild-errors_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/behavior/rebuild-errors_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { logging } from '@angular-devkit/core';

--- a/packages/angular/build/src/builders/application/tests/behavior/rebuild-general_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/behavior/rebuild-general_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { concatMap, count, take, timeout } from 'rxjs';

--- a/packages/angular/build/src/builders/application/tests/behavior/rebuild-global_styles_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/behavior/rebuild-global_styles_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { concatMap, count, take, timeout } from 'rxjs';

--- a/packages/angular/build/src/builders/application/tests/behavior/rebuild-index-html_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/behavior/rebuild-index-html_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { concatMap, count, take, timeout } from 'rxjs';

--- a/packages/angular/build/src/builders/application/tests/behavior/rebuild-web-workers_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/behavior/rebuild-web-workers_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { logging } from '@angular-devkit/core';

--- a/packages/angular/build/src/builders/application/tests/behavior/stylesheet-url-resolution_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/behavior/stylesheet-url-resolution_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { buildApplication } from '../../index';

--- a/packages/angular/build/src/builders/application/tests/behavior/stylesheet_autoprefixer_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/behavior/stylesheet_autoprefixer_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { buildApplication } from '../../index';

--- a/packages/angular/build/src/builders/application/tests/behavior/typescript-path-mapping_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/behavior/typescript-path-mapping_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { buildApplication } from '../../index';

--- a/packages/angular/build/src/builders/application/tests/behavior/typescript-rebuild-lazy_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/behavior/typescript-rebuild-lazy_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type { logging } from '@angular-devkit/core';

--- a/packages/angular/build/src/builders/application/tests/behavior/typescript-rebuild-touch-file_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/behavior/typescript-rebuild-touch-file_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { concatMap, count, take, timeout } from 'rxjs';

--- a/packages/angular/build/src/builders/application/tests/behavior/typescript-resolve-json_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/behavior/typescript-resolve-json_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { buildApplication } from '../../index';

--- a/packages/angular/build/src/builders/application/tests/behavior/web-workers-application_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/behavior/web-workers-application_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { buildApplication } from '../../index';

--- a/packages/angular/build/src/builders/application/tests/options/allowed-common-js-dependencies_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/options/allowed-common-js-dependencies_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { logging } from '@angular-devkit/core';

--- a/packages/angular/build/src/builders/application/tests/options/app-shell_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/options/app-shell_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { buildApplication } from '../../index';

--- a/packages/angular/build/src/builders/application/tests/options/assets_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/options/assets_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { buildApplication } from '../../index';

--- a/packages/angular/build/src/builders/application/tests/options/base-href_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/options/base-href_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { buildApplication } from '../../index';

--- a/packages/angular/build/src/builders/application/tests/options/browser_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/options/browser_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { buildApplication } from '../../index';

--- a/packages/angular/build/src/builders/application/tests/options/bundle-budgets_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/options/bundle-budgets_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { logging } from '@angular-devkit/core';

--- a/packages/angular/build/src/builders/application/tests/options/cross-origin_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/options/cross-origin_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { buildApplication } from '../../index';

--- a/packages/angular/build/src/builders/application/tests/options/define_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/options/define_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { buildApplication } from '../../index';

--- a/packages/angular/build/src/builders/application/tests/options/delete-output-path_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/options/delete-output-path_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { buildApplication } from '../../index';

--- a/packages/angular/build/src/builders/application/tests/options/deploy-url_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/options/deploy-url_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { buildApplication } from '../../index';

--- a/packages/angular/build/src/builders/application/tests/options/external-dependencies_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/options/external-dependencies_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { buildApplication } from '../../index';

--- a/packages/angular/build/src/builders/application/tests/options/extract-licenses_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/options/extract-licenses_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { buildApplication } from '../../index';

--- a/packages/angular/build/src/builders/application/tests/options/i18n-missing-translation_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/options/i18n-missing-translation_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { buildApplication } from '../../index';

--- a/packages/angular/build/src/builders/application/tests/options/index_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/options/index_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { buildApplication } from '../../index';

--- a/packages/angular/build/src/builders/application/tests/options/inline-style-language_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/options/inline-style-language_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { concatMap, count, take, timeout } from 'rxjs';

--- a/packages/angular/build/src/builders/application/tests/options/loader_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/options/loader_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { buildApplication } from '../../index';

--- a/packages/angular/build/src/builders/application/tests/options/named-chunks_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/options/named-chunks_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { buildApplication } from '../../index';

--- a/packages/angular/build/src/builders/application/tests/options/optimization-fonts-inline_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/options/optimization-fonts-inline_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { buildApplication } from '../../index';

--- a/packages/angular/build/src/builders/application/tests/options/optimization-inline-critical_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/options/optimization-inline-critical_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { buildApplication } from '../../index';

--- a/packages/angular/build/src/builders/application/tests/options/optimization-remove-special-comments_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/options/optimization-remove-special-comments_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { buildApplication } from '../../index';

--- a/packages/angular/build/src/builders/application/tests/options/output-hashing_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/options/output-hashing_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { buildApplication } from '../../index';

--- a/packages/angular/build/src/builders/application/tests/options/output-path_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/options/output-path_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { buildApplication } from '../../index';

--- a/packages/angular/build/src/builders/application/tests/options/polyfills_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/options/polyfills_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { buildApplication } from '../../index';

--- a/packages/angular/build/src/builders/application/tests/options/scripts_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/options/scripts_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { buildApplication } from '../../index';

--- a/packages/angular/build/src/builders/application/tests/options/server_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/options/server_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { buildApplication } from '../../index';

--- a/packages/angular/build/src/builders/application/tests/options/service-worker_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/options/service-worker_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { buildApplication } from '../../index';

--- a/packages/angular/build/src/builders/application/tests/options/sourcemap_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/options/sourcemap_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { buildApplication } from '../../index';

--- a/packages/angular/build/src/builders/application/tests/options/ssr_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/options/ssr_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { buildApplication } from '../../index';

--- a/packages/angular/build/src/builders/application/tests/options/styles_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/options/styles_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { buildApplication } from '../../index';

--- a/packages/angular/build/src/builders/application/tests/options/subresource-integrity_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/options/subresource-integrity_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { logging } from '@angular-devkit/core';

--- a/packages/angular/build/src/builders/application/tests/setup.ts
+++ b/packages/angular/build/src/builders/application/tests/setup.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Schema } from '../schema';

--- a/packages/angular/build/src/builders/dev-server/builder.ts
+++ b/packages/angular/build/src/builders/dev-server/builder.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type { BuilderContext } from '@angular-devkit/architect';

--- a/packages/angular/build/src/builders/dev-server/index.ts
+++ b/packages/angular/build/src/builders/dev-server/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { createBuilder } from '@angular-devkit/architect';

--- a/packages/angular/build/src/builders/dev-server/internal.ts
+++ b/packages/angular/build/src/builders/dev-server/internal.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 export { BuildOutputFile, BuildOutputFileType } from '@angular/build';

--- a/packages/angular/build/src/builders/dev-server/options.ts
+++ b/packages/angular/build/src/builders/dev-server/options.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { BuilderContext, targetFromTargetString } from '@angular-devkit/architect';

--- a/packages/angular/build/src/builders/dev-server/output.ts
+++ b/packages/angular/build/src/builders/dev-server/output.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { BuilderOutput } from '@angular-devkit/architect';

--- a/packages/angular/build/src/builders/dev-server/tests/behavior/build-assets_spec.ts
+++ b/packages/angular/build/src/builders/dev-server/tests/behavior/build-assets_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { executeDevServer } from '../../index';

--- a/packages/angular/build/src/builders/dev-server/tests/behavior/build-base-href_spec.ts
+++ b/packages/angular/build/src/builders/dev-server/tests/behavior/build-base-href_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { executeDevServer } from '../../index';

--- a/packages/angular/build/src/builders/dev-server/tests/behavior/build-budgets_spec.ts
+++ b/packages/angular/build/src/builders/dev-server/tests/behavior/build-budgets_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { BudgetType } from '../../../../utils/bundle-calculator';

--- a/packages/angular/build/src/builders/dev-server/tests/behavior/build-inline-critical-css_spec.ts
+++ b/packages/angular/build/src/builders/dev-server/tests/behavior/build-inline-critical-css_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { executeDevServer } from '../../index';

--- a/packages/angular/build/src/builders/dev-server/tests/behavior/build_localize_replaced_watch_spec.ts
+++ b/packages/angular/build/src/builders/dev-server/tests/behavior/build_localize_replaced_watch_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 /* eslint-disable max-len */

--- a/packages/angular/build/src/builders/dev-server/tests/behavior/build_translation_watch_spec.ts
+++ b/packages/angular/build/src/builders/dev-server/tests/behavior/build_translation_watch_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 /* eslint-disable max-len */

--- a/packages/angular/build/src/builders/dev-server/tests/behavior/serve-live-reload-proxies_spec.ts
+++ b/packages/angular/build/src/builders/dev-server/tests/behavior/serve-live-reload-proxies_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 /* eslint-disable import/no-extraneous-dependencies */

--- a/packages/angular/build/src/builders/dev-server/tests/behavior/serve_service-worker_spec.ts
+++ b/packages/angular/build/src/builders/dev-server/tests/behavior/serve_service-worker_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { concatMap, count, take, timeout } from 'rxjs';

--- a/packages/angular/build/src/builders/dev-server/tests/execute-fetch.ts
+++ b/packages/angular/build/src/builders/dev-server/tests/execute-fetch.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { lastValueFrom, mergeMap, take, timeout } from 'rxjs';

--- a/packages/angular/build/src/builders/dev-server/tests/jasmine-helpers.ts
+++ b/packages/angular/build/src/builders/dev-server/tests/jasmine-helpers.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { BuilderHandlerFn } from '@angular-devkit/architect';

--- a/packages/angular/build/src/builders/dev-server/tests/options/headers_spec.ts
+++ b/packages/angular/build/src/builders/dev-server/tests/options/headers_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { executeDevServer } from '../../index';

--- a/packages/angular/build/src/builders/dev-server/tests/options/port_spec.ts
+++ b/packages/angular/build/src/builders/dev-server/tests/options/port_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { URL } from 'url';

--- a/packages/angular/build/src/builders/dev-server/tests/options/prebundle_spec.ts
+++ b/packages/angular/build/src/builders/dev-server/tests/options/prebundle_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { executeDevServer } from '../../index';

--- a/packages/angular/build/src/builders/dev-server/tests/options/proxy-config_spec.ts
+++ b/packages/angular/build/src/builders/dev-server/tests/options/proxy-config_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { createServer } from 'node:http';

--- a/packages/angular/build/src/builders/dev-server/tests/options/serve-path_spec.ts
+++ b/packages/angular/build/src/builders/dev-server/tests/options/serve-path_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { URL } from 'url';

--- a/packages/angular/build/src/builders/dev-server/tests/options/watch_spec.ts
+++ b/packages/angular/build/src/builders/dev-server/tests/options/watch_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { TimeoutError, concatMap, count, take, timeout } from 'rxjs';

--- a/packages/angular/build/src/builders/dev-server/tests/setup.ts
+++ b/packages/angular/build/src/builders/dev-server/tests/setup.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { json } from '@angular-devkit/core';

--- a/packages/angular/build/src/builders/dev-server/vite-server.ts
+++ b/packages/angular/build/src/builders/dev-server/vite-server.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type { BuilderContext } from '@angular-devkit/architect';

--- a/packages/angular/build/src/builders/extract-i18n/application-extraction.ts
+++ b/packages/angular/build/src/builders/extract-i18n/application-extraction.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type { ɵParsedMessage as LocalizeMessage } from '@angular/localize';

--- a/packages/angular/build/src/builders/extract-i18n/builder.ts
+++ b/packages/angular/build/src/builders/extract-i18n/builder.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type { Diagnostics } from '@angular/localize/tools';

--- a/packages/angular/build/src/builders/extract-i18n/index.ts
+++ b/packages/angular/build/src/builders/extract-i18n/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { createBuilder } from '@angular-devkit/architect';

--- a/packages/angular/build/src/builders/extract-i18n/options.ts
+++ b/packages/angular/build/src/builders/extract-i18n/options.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { BuilderContext, targetFromTargetString } from '@angular-devkit/architect';

--- a/packages/angular/build/src/index.ts
+++ b/packages/angular/build/src/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 export {

--- a/packages/angular/build/src/private.ts
+++ b/packages/angular/build/src/private.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 /**

--- a/packages/angular/build/src/tools/babel/plugins/adjust-static-class-members.ts
+++ b/packages/angular/build/src/tools/babel/plugins/adjust-static-class-members.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { NodePath, PluginObj, PluginPass, types } from '@babel/core';

--- a/packages/angular/build/src/tools/babel/plugins/adjust-static-class-members_spec.ts
+++ b/packages/angular/build/src/tools/babel/plugins/adjust-static-class-members_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { transformSync } from '@babel/core';

--- a/packages/angular/build/src/tools/babel/plugins/adjust-typescript-enums.ts
+++ b/packages/angular/build/src/tools/babel/plugins/adjust-typescript-enums.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { NodePath, PluginObj, types } from '@babel/core';

--- a/packages/angular/build/src/tools/babel/plugins/adjust-typescript-enums_spec.ts
+++ b/packages/angular/build/src/tools/babel/plugins/adjust-typescript-enums_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { transformSync } from '@babel/core';

--- a/packages/angular/build/src/tools/babel/plugins/elide-angular-metadata.ts
+++ b/packages/angular/build/src/tools/babel/plugins/elide-angular-metadata.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type { NodePath, PluginObj } from '@babel/core';

--- a/packages/angular/build/src/tools/babel/plugins/elide-angular-metadata_spec.ts
+++ b/packages/angular/build/src/tools/babel/plugins/elide-angular-metadata_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { transformSync } from '@babel/core';

--- a/packages/angular/build/src/tools/babel/plugins/index.ts
+++ b/packages/angular/build/src/tools/babel/plugins/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 export { default as adjustStaticMembers } from './adjust-static-class-members';

--- a/packages/angular/build/src/tools/babel/plugins/pure-toplevel-functions.ts
+++ b/packages/angular/build/src/tools/babel/plugins/pure-toplevel-functions.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type { PluginObj } from '@babel/core';

--- a/packages/angular/build/src/tools/babel/plugins/pure-toplevel-functions_spec.ts
+++ b/packages/angular/build/src/tools/babel/plugins/pure-toplevel-functions_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { transformSync } from '@babel/core';

--- a/packages/angular/build/src/tools/babel/typings.d.ts
+++ b/packages/angular/build/src/tools/babel/typings.d.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 declare module '@babel/helper-annotate-as-pure' {

--- a/packages/angular/build/src/tools/esbuild/angular/angular-host.ts
+++ b/packages/angular/build/src/tools/esbuild/angular/angular-host.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type ng from '@angular/compiler-cli';

--- a/packages/angular/build/src/tools/esbuild/angular/compilation-state.ts
+++ b/packages/angular/build/src/tools/esbuild/angular/compilation-state.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 export class SharedTSCompilationState {

--- a/packages/angular/build/src/tools/esbuild/angular/compilation/angular-compilation.ts
+++ b/packages/angular/build/src/tools/esbuild/angular/compilation/angular-compilation.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type ng from '@angular/compiler-cli';

--- a/packages/angular/build/src/tools/esbuild/angular/compilation/aot-compilation.ts
+++ b/packages/angular/build/src/tools/esbuild/angular/compilation/aot-compilation.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type ng from '@angular/compiler-cli';

--- a/packages/angular/build/src/tools/esbuild/angular/compilation/factory.ts
+++ b/packages/angular/build/src/tools/esbuild/angular/compilation/factory.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { useParallelTs } from '../../../../utils/environment-options';

--- a/packages/angular/build/src/tools/esbuild/angular/compilation/index.ts
+++ b/packages/angular/build/src/tools/esbuild/angular/compilation/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 export { AngularCompilation, DiagnosticModes } from './angular-compilation';

--- a/packages/angular/build/src/tools/esbuild/angular/compilation/jit-bootstrap-transformer.ts
+++ b/packages/angular/build/src/tools/esbuild/angular/compilation/jit-bootstrap-transformer.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import ts from 'typescript';

--- a/packages/angular/build/src/tools/esbuild/angular/compilation/jit-compilation.ts
+++ b/packages/angular/build/src/tools/esbuild/angular/compilation/jit-compilation.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type ng from '@angular/compiler-cli';

--- a/packages/angular/build/src/tools/esbuild/angular/compilation/noop-compilation.ts
+++ b/packages/angular/build/src/tools/esbuild/angular/compilation/noop-compilation.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type ng from '@angular/compiler-cli';

--- a/packages/angular/build/src/tools/esbuild/angular/compilation/parallel-compilation.ts
+++ b/packages/angular/build/src/tools/esbuild/angular/compilation/parallel-compilation.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type { CompilerOptions } from '@angular/compiler-cli';

--- a/packages/angular/build/src/tools/esbuild/angular/compilation/parallel-worker.ts
+++ b/packages/angular/build/src/tools/esbuild/angular/compilation/parallel-worker.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type { PartialMessage } from 'esbuild';

--- a/packages/angular/build/src/tools/esbuild/angular/compiler-plugin.ts
+++ b/packages/angular/build/src/tools/esbuild/angular/compiler-plugin.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type {

--- a/packages/angular/build/src/tools/esbuild/angular/component-stylesheets.ts
+++ b/packages/angular/build/src/tools/esbuild/angular/component-stylesheets.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { OutputFile } from 'esbuild';

--- a/packages/angular/build/src/tools/esbuild/angular/diagnostics.ts
+++ b/packages/angular/build/src/tools/esbuild/angular/diagnostics.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type { PartialMessage, PartialNote } from 'esbuild';

--- a/packages/angular/build/src/tools/esbuild/angular/file-reference-tracker.ts
+++ b/packages/angular/build/src/tools/esbuild/angular/file-reference-tracker.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { normalize } from 'node:path';

--- a/packages/angular/build/src/tools/esbuild/angular/jit-plugin-callbacks.ts
+++ b/packages/angular/build/src/tools/esbuild/angular/jit-plugin-callbacks.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type { Metafile, OutputFile, PluginBuild } from 'esbuild';

--- a/packages/angular/build/src/tools/esbuild/angular/jit-resource-transformer.ts
+++ b/packages/angular/build/src/tools/esbuild/angular/jit-resource-transformer.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import ts from 'typescript';

--- a/packages/angular/build/src/tools/esbuild/angular/source-file-cache.ts
+++ b/packages/angular/build/src/tools/esbuild/angular/source-file-cache.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { platform } from 'node:os';

--- a/packages/angular/build/src/tools/esbuild/angular/uri.ts
+++ b/packages/angular/build/src/tools/esbuild/angular/uri.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 /**

--- a/packages/angular/build/src/tools/esbuild/angular/web-worker-transformer.ts
+++ b/packages/angular/build/src/tools/esbuild/angular/web-worker-transformer.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import ts from 'typescript';

--- a/packages/angular/build/src/tools/esbuild/application-code-bundle.ts
+++ b/packages/angular/build/src/tools/esbuild/application-code-bundle.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type { BuildOptions } from 'esbuild';

--- a/packages/angular/build/src/tools/esbuild/budget-stats.ts
+++ b/packages/angular/build/src/tools/esbuild/budget-stats.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type { Metafile } from 'esbuild';

--- a/packages/angular/build/src/tools/esbuild/bundler-context.ts
+++ b/packages/angular/build/src/tools/esbuild/bundler-context.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {

--- a/packages/angular/build/src/tools/esbuild/bundler-execution-result.ts
+++ b/packages/angular/build/src/tools/esbuild/bundler-execution-result.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type { Message, PartialMessage } from 'esbuild';

--- a/packages/angular/build/src/tools/esbuild/cache.ts
+++ b/packages/angular/build/src/tools/esbuild/cache.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 /**

--- a/packages/angular/build/src/tools/esbuild/commonjs-checker.ts
+++ b/packages/angular/build/src/tools/esbuild/commonjs-checker.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type { Metafile, PartialMessage } from 'esbuild';

--- a/packages/angular/build/src/tools/esbuild/compiler-plugin-options.ts
+++ b/packages/angular/build/src/tools/esbuild/compiler-plugin-options.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { NormalizedApplicationBuildOptions } from '../../builders/application/options';

--- a/packages/angular/build/src/tools/esbuild/external-packages-plugin.ts
+++ b/packages/angular/build/src/tools/esbuild/external-packages-plugin.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type { Plugin } from 'esbuild';

--- a/packages/angular/build/src/tools/esbuild/global-scripts.ts
+++ b/packages/angular/build/src/tools/esbuild/global-scripts.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import MagicString, { Bundle } from 'magic-string';

--- a/packages/angular/build/src/tools/esbuild/global-styles.ts
+++ b/packages/angular/build/src/tools/esbuild/global-styles.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import assert from 'node:assert';

--- a/packages/angular/build/src/tools/esbuild/i18n-inliner-worker.ts
+++ b/packages/angular/build/src/tools/esbuild/i18n-inliner-worker.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import remapping, { SourceMapInput } from '@ampproject/remapping';

--- a/packages/angular/build/src/tools/esbuild/i18n-inliner.ts
+++ b/packages/angular/build/src/tools/esbuild/i18n-inliner.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import assert from 'node:assert';

--- a/packages/angular/build/src/tools/esbuild/i18n-locale-plugin.ts
+++ b/packages/angular/build/src/tools/esbuild/i18n-locale-plugin.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type { Plugin } from 'esbuild';

--- a/packages/angular/build/src/tools/esbuild/index-html-generator.ts
+++ b/packages/angular/build/src/tools/esbuild/index-html-generator.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import assert from 'node:assert';

--- a/packages/angular/build/src/tools/esbuild/javascript-transformer-worker.ts
+++ b/packages/angular/build/src/tools/esbuild/javascript-transformer-worker.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { type PluginItem, transformAsync } from '@babel/core';

--- a/packages/angular/build/src/tools/esbuild/javascript-transformer.ts
+++ b/packages/angular/build/src/tools/esbuild/javascript-transformer.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { createHash } from 'node:crypto';

--- a/packages/angular/build/src/tools/esbuild/license-extractor.ts
+++ b/packages/angular/build/src/tools/esbuild/license-extractor.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type { Metafile } from 'esbuild';

--- a/packages/angular/build/src/tools/esbuild/lmdb-cache-store.ts
+++ b/packages/angular/build/src/tools/esbuild/lmdb-cache-store.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { RootDatabase, open } from 'lmdb';

--- a/packages/angular/build/src/tools/esbuild/load-result-cache.ts
+++ b/packages/angular/build/src/tools/esbuild/load-result-cache.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type { OnLoadResult, PluginBuild } from 'esbuild';

--- a/packages/angular/build/src/tools/esbuild/profiling.ts
+++ b/packages/angular/build/src/tools/esbuild/profiling.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { debugPerformance } from '../../utils/environment-options';

--- a/packages/angular/build/src/tools/esbuild/rxjs-esm-resolution-plugin.ts
+++ b/packages/angular/build/src/tools/esbuild/rxjs-esm-resolution-plugin.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type { Plugin } from 'esbuild';

--- a/packages/angular/build/src/tools/esbuild/sourcemap-ignorelist-plugin.ts
+++ b/packages/angular/build/src/tools/esbuild/sourcemap-ignorelist-plugin.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type { Plugin } from 'esbuild';

--- a/packages/angular/build/src/tools/esbuild/stylesheets/bundle-options.ts
+++ b/packages/angular/build/src/tools/esbuild/stylesheets/bundle-options.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type { BuildOptions, Plugin } from 'esbuild';

--- a/packages/angular/build/src/tools/esbuild/stylesheets/css-inline-fonts-plugin.ts
+++ b/packages/angular/build/src/tools/esbuild/stylesheets/css-inline-fonts-plugin.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type { Plugin, PluginBuild } from 'esbuild';

--- a/packages/angular/build/src/tools/esbuild/stylesheets/css-language.ts
+++ b/packages/angular/build/src/tools/esbuild/stylesheets/css-language.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { StylesheetLanguage } from './stylesheet-plugin-factory';

--- a/packages/angular/build/src/tools/esbuild/stylesheets/css-resource-plugin.ts
+++ b/packages/angular/build/src/tools/esbuild/stylesheets/css-resource-plugin.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type { Plugin, PluginBuild } from 'esbuild';

--- a/packages/angular/build/src/tools/esbuild/stylesheets/less-language.ts
+++ b/packages/angular/build/src/tools/esbuild/stylesheets/less-language.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type { Location, OnLoadResult, PluginBuild } from 'esbuild';

--- a/packages/angular/build/src/tools/esbuild/stylesheets/sass-language.ts
+++ b/packages/angular/build/src/tools/esbuild/stylesheets/sass-language.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type { OnLoadResult, PartialMessage, PartialNote, ResolveResult } from 'esbuild';

--- a/packages/angular/build/src/tools/esbuild/stylesheets/stylesheet-plugin-factory.ts
+++ b/packages/angular/build/src/tools/esbuild/stylesheets/stylesheet-plugin-factory.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type { OnLoadResult, Plugin, PluginBuild } from 'esbuild';

--- a/packages/angular/build/src/tools/esbuild/utils.ts
+++ b/packages/angular/build/src/tools/esbuild/utils.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { BuilderContext } from '@angular-devkit/architect';

--- a/packages/angular/build/src/tools/esbuild/virtual-module-plugin.ts
+++ b/packages/angular/build/src/tools/esbuild/virtual-module-plugin.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type { OnLoadArgs, Plugin, PluginBuild } from 'esbuild';

--- a/packages/angular/build/src/tools/esbuild/watcher.ts
+++ b/packages/angular/build/src/tools/esbuild/watcher.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import WatchPack from 'watchpack';

--- a/packages/angular/build/src/tools/sass/lexer.ts
+++ b/packages/angular/build/src/tools/sass/lexer.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 // TODO: Combine everything into a single pass lexer

--- a/packages/angular/build/src/tools/sass/rebasing-importer.ts
+++ b/packages/angular/build/src/tools/sass/rebasing-importer.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { RawSourceMap } from '@ampproject/remapping';

--- a/packages/angular/build/src/tools/sass/sass-service.ts
+++ b/packages/angular/build/src/tools/sass/sass-service.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import assert from 'node:assert';

--- a/packages/angular/build/src/tools/sass/worker.ts
+++ b/packages/angular/build/src/tools/sass/worker.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import mergeSourceMaps, { RawSourceMap } from '@ampproject/remapping';

--- a/packages/angular/build/src/tools/vite/angular-memory-plugin.ts
+++ b/packages/angular/build/src/tools/vite/angular-memory-plugin.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import remapping, { SourceMapInput } from '@ampproject/remapping';

--- a/packages/angular/build/src/tools/vite/i18n-locale-plugin.ts
+++ b/packages/angular/build/src/tools/vite/i18n-locale-plugin.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type { Plugin } from 'vite';

--- a/packages/angular/build/src/utils/bundle-calculator.ts
+++ b/packages/angular/build/src/utils/bundle-calculator.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Budget as BudgetEntry, Type as BudgetType } from '../builders/application/schema';

--- a/packages/angular/build/src/utils/bundle-calculator_spec.ts
+++ b/packages/angular/build/src/utils/bundle-calculator_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { BudgetEntry, BudgetType, ThresholdSeverity, checkBudgets } from './bundle-calculator';

--- a/packages/angular/build/src/utils/check-port.ts
+++ b/packages/angular/build/src/utils/check-port.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import assert from 'node:assert';

--- a/packages/angular/build/src/utils/color.ts
+++ b/packages/angular/build/src/utils/color.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import * as ansiColors from 'ansi-colors';

--- a/packages/angular/build/src/utils/delete-output-dir.ts
+++ b/packages/angular/build/src/utils/delete-output-dir.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { readdir, rm } from 'node:fs/promises';

--- a/packages/angular/build/src/utils/environment-options.ts
+++ b/packages/angular/build/src/utils/environment-options.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 function isDisabled(variable: string): boolean {

--- a/packages/angular/build/src/utils/error.ts
+++ b/packages/angular/build/src/utils/error.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import assert from 'assert';

--- a/packages/angular/build/src/utils/format-bytes.ts
+++ b/packages/angular/build/src/utils/format-bytes.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 export function formatSize(size: number): string {

--- a/packages/angular/build/src/utils/format-bytes_spec.ts
+++ b/packages/angular/build/src/utils/format-bytes_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { formatSize } from './format-bytes';

--- a/packages/angular/build/src/utils/i18n-options.ts
+++ b/packages/angular/build/src/utils/i18n-options.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import path from 'node:path';

--- a/packages/angular/build/src/utils/index-file/add-event-dispatch-contract.ts
+++ b/packages/angular/build/src/utils/index-file/add-event-dispatch-contract.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { readFile } from 'node:fs/promises';

--- a/packages/angular/build/src/utils/index-file/add-event-dispatch-contract_spec.ts
+++ b/packages/angular/build/src/utils/index-file/add-event-dispatch-contract_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { addEventDispatchContract } from './add-event-dispatch-contract';

--- a/packages/angular/build/src/utils/index-file/augment-index-html.ts
+++ b/packages/angular/build/src/utils/index-file/augment-index-html.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { createHash } from 'node:crypto';

--- a/packages/angular/build/src/utils/index-file/augment-index-html_spec.ts
+++ b/packages/angular/build/src/utils/index-file/augment-index-html_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { tags } from '@angular-devkit/core';

--- a/packages/angular/build/src/utils/index-file/html-rewriting-stream.ts
+++ b/packages/angular/build/src/utils/index-file/html-rewriting-stream.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Readable } from 'node:stream';

--- a/packages/angular/build/src/utils/index-file/index-html-generator.ts
+++ b/packages/angular/build/src/utils/index-file/index-html-generator.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { readFile } from 'node:fs/promises';

--- a/packages/angular/build/src/utils/index-file/inline-critical-css.ts
+++ b/packages/angular/build/src/utils/index-file/inline-critical-css.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import Critters from 'critters';

--- a/packages/angular/build/src/utils/index-file/inline-critical-css_spec.ts
+++ b/packages/angular/build/src/utils/index-file/inline-critical-css_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { tags } from '@angular-devkit/core';

--- a/packages/angular/build/src/utils/index-file/inline-fonts.ts
+++ b/packages/angular/build/src/utils/index-file/inline-fonts.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { HttpsProxyAgent } from 'https-proxy-agent';

--- a/packages/angular/build/src/utils/index-file/inline-fonts_spec.ts
+++ b/packages/angular/build/src/utils/index-file/inline-fonts_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { InlineFontsProcessor } from './inline-fonts';

--- a/packages/angular/build/src/utils/index-file/nonce.ts
+++ b/packages/angular/build/src/utils/index-file/nonce.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { htmlRewritingStream } from './html-rewriting-stream';

--- a/packages/angular/build/src/utils/index-file/nonce_spec.ts
+++ b/packages/angular/build/src/utils/index-file/nonce_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { addNonce } from './nonce';

--- a/packages/angular/build/src/utils/index-file/valid-self-closing-tags.ts
+++ b/packages/angular/build/src/utils/index-file/valid-self-closing-tags.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 /** A list of valid self closing HTML elements */

--- a/packages/angular/build/src/utils/index.ts
+++ b/packages/angular/build/src/utils/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 export * from './normalize-asset-patterns';

--- a/packages/angular/build/src/utils/load-esm.ts
+++ b/packages/angular/build/src/utils/load-esm.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 /**

--- a/packages/angular/build/src/utils/load-proxy-config.ts
+++ b/packages/angular/build/src/utils/load-proxy-config.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { isDynamicPattern } from 'fast-glob';

--- a/packages/angular/build/src/utils/load-translations.ts
+++ b/packages/angular/build/src/utils/load-translations.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type { Diagnostics } from '@angular/localize/tools';

--- a/packages/angular/build/src/utils/normalize-asset-patterns.ts
+++ b/packages/angular/build/src/utils/normalize-asset-patterns.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { statSync } from 'fs';

--- a/packages/angular/build/src/utils/normalize-cache.ts
+++ b/packages/angular/build/src/utils/normalize-cache.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { join, resolve } from 'node:path';

--- a/packages/angular/build/src/utils/normalize-optimization.ts
+++ b/packages/angular/build/src/utils/normalize-optimization.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {

--- a/packages/angular/build/src/utils/normalize-source-maps.ts
+++ b/packages/angular/build/src/utils/normalize-source-maps.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { SourceMapClass, SourceMapUnion } from '../builders/application/schema';

--- a/packages/angular/build/src/utils/postcss-configuration.ts
+++ b/packages/angular/build/src/utils/postcss-configuration.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { readFile, readdir } from 'node:fs/promises';

--- a/packages/angular/build/src/utils/purge-cache.ts
+++ b/packages/angular/build/src/utils/purge-cache.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { BuilderContext } from '@angular-devkit/architect';

--- a/packages/angular/build/src/utils/resolve-assets.ts
+++ b/packages/angular/build/src/utils/resolve-assets.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import glob from 'fast-glob';

--- a/packages/angular/build/src/utils/routes-extractor/BUILD.bazel
+++ b/packages/angular/build/src/utils/routes-extractor/BUILD.bazel
@@ -1,7 +1,7 @@
 # Copyright Google Inc. All Rights Reserved.
 #
 # Use of this source code is governed by an MIT-style license that can be
-# found in the LICENSE file at https://angular.io/license
+# found in the LICENSE file at https://angular.dev/license
 
 load("//tools:defaults.bzl", "ts_library")
 

--- a/packages/angular/build/src/utils/routes-extractor/extractor.ts
+++ b/packages/angular/build/src/utils/routes-extractor/extractor.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {

--- a/packages/angular/build/src/utils/server-rendering/esm-in-memory-loader/loader-hooks.ts
+++ b/packages/angular/build/src/utils/server-rendering/esm-in-memory-loader/loader-hooks.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import assert from 'node:assert';

--- a/packages/angular/build/src/utils/server-rendering/esm-in-memory-loader/register-hooks.ts
+++ b/packages/angular/build/src/utils/server-rendering/esm-in-memory-loader/register-hooks.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { register } from 'node:module';

--- a/packages/angular/build/src/utils/server-rendering/fetch-patch.ts
+++ b/packages/angular/build/src/utils/server-rendering/fetch-patch.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { lookup as lookupMimeType } from 'mrmime';

--- a/packages/angular/build/src/utils/server-rendering/load-esm-from-memory.ts
+++ b/packages/angular/build/src/utils/server-rendering/load-esm-from-memory.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { assertIsError } from '../error';

--- a/packages/angular/build/src/utils/server-rendering/main-bundle-exports.ts
+++ b/packages/angular/build/src/utils/server-rendering/main-bundle-exports.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type { ApplicationRef, Type, ɵConsole } from '@angular/core';

--- a/packages/angular/build/src/utils/server-rendering/prerender.ts
+++ b/packages/angular/build/src/utils/server-rendering/prerender.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { readFile } from 'node:fs/promises';

--- a/packages/angular/build/src/utils/server-rendering/render-page.ts
+++ b/packages/angular/build/src/utils/server-rendering/render-page.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type { ApplicationRef, StaticProvider } from '@angular/core';

--- a/packages/angular/build/src/utils/server-rendering/render-worker.ts
+++ b/packages/angular/build/src/utils/server-rendering/render-worker.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { workerData } from 'node:worker_threads';

--- a/packages/angular/build/src/utils/server-rendering/routes-extractor-worker.ts
+++ b/packages/angular/build/src/utils/server-rendering/routes-extractor-worker.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { workerData } from 'node:worker_threads';

--- a/packages/angular/build/src/utils/service-worker.ts
+++ b/packages/angular/build/src/utils/service-worker.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type { Config, Filesystem } from '@angular/service-worker/config';

--- a/packages/angular/build/src/utils/spinner.ts
+++ b/packages/angular/build/src/utils/spinner.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import ora from 'ora';

--- a/packages/angular/build/src/utils/stats-table.ts
+++ b/packages/angular/build/src/utils/stats-table.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { stripVTControlCharacters } from 'node:util';

--- a/packages/angular/build/src/utils/supported-browsers.ts
+++ b/packages/angular/build/src/utils/supported-browsers.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import browserslist from 'browserslist';

--- a/packages/angular/build/src/utils/tty.ts
+++ b/packages/angular/build/src/utils/tty.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 function _isTruthy(value: undefined | string): boolean {

--- a/packages/angular/build/src/utils/url.ts
+++ b/packages/angular/build/src/utils/url.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 export function urlJoin(...parts: string[]): string {

--- a/packages/angular/build/src/utils/version.ts
+++ b/packages/angular/build/src/utils/version.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 /* eslint-disable no-console */

--- a/packages/angular/cli/BUILD.bazel
+++ b/packages/angular/cli/BUILD.bazel
@@ -1,7 +1,7 @@
 # Copyright Google Inc. All Rights Reserved.
 #
 # Use of this source code is governed by an MIT-style license that can be
-# found in the LICENSE file at https://angular.io/license
+# found in the LICENSE file at https://angular.dev/license
 
 load("@npm//@bazel/jasmine:index.bzl", "jasmine_node_test")
 load("//tools:defaults.bzl", "pkg_npm", "ts_library")

--- a/packages/angular/cli/bin/bootstrap.js
+++ b/packages/angular/cli/bin/bootstrap.js
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 /**

--- a/packages/angular/cli/bin/ng.js
+++ b/packages/angular/cli/bin/ng.js
@@ -4,7 +4,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 /* eslint-disable no-console */

--- a/packages/angular/cli/lib/cli/index.ts
+++ b/packages/angular/cli/lib/cli/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { logging } from '@angular-devkit/core';

--- a/packages/angular/cli/lib/init.ts
+++ b/packages/angular/cli/lib/init.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import 'symbol-observable';

--- a/packages/angular/cli/src/analytics/analytics-collector.ts
+++ b/packages/angular/cli/src/analytics/analytics-collector.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { randomUUID } from 'crypto';
@@ -31,7 +31,10 @@ export class AnalyticsCollector {
   private readonly requestParameterStringified: string;
   private readonly userParameters: Record<UserCustomDimension, PrimitiveTypes | undefined>;
 
-  constructor(private context: CommandContext, userId: string) {
+  constructor(
+    private context: CommandContext,
+    userId: string,
+  ) {
     const requestParameters: Partial<Record<RequestParameter, PrimitiveTypes>> = {
       [RequestParameter.ProtocolVersion]: 2,
       [RequestParameter.ClientId]: userId,

--- a/packages/angular/cli/src/analytics/analytics-parameters.mts
+++ b/packages/angular/cli/src/analytics/analytics-parameters.mts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 /** This is a copy of analytics-parameters.ts and is needed for `yarn admin validate-user-analytics` due to ts-node. */

--- a/packages/angular/cli/src/analytics/analytics-parameters.ts
+++ b/packages/angular/cli/src/analytics/analytics-parameters.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 /** Any changes in this file needs to be done in the mts version. */

--- a/packages/angular/cli/src/analytics/analytics.ts
+++ b/packages/angular/cli/src/analytics/analytics.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { json, tags } from '@angular-devkit/core';

--- a/packages/angular/cli/src/command-builder/architect-base-command-module.ts
+++ b/packages/angular/cli/src/command-builder/architect-base-command-module.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Architect, Target } from '@angular-devkit/architect';

--- a/packages/angular/cli/src/command-builder/architect-command-module.ts
+++ b/packages/angular/cli/src/command-builder/architect-command-module.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Argv } from 'yargs';

--- a/packages/angular/cli/src/command-builder/command-module.ts
+++ b/packages/angular/cli/src/command-builder/command-module.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { logging, schema, strings } from '@angular-devkit/core';

--- a/packages/angular/cli/src/command-builder/command-runner.ts
+++ b/packages/angular/cli/src/command-builder/command-runner.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { logging } from '@angular-devkit/core';

--- a/packages/angular/cli/src/command-builder/schematics-command-module.ts
+++ b/packages/angular/cli/src/command-builder/schematics-command-module.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { normalize as devkitNormalize, schema } from '@angular-devkit/core';

--- a/packages/angular/cli/src/command-builder/utilities/command.ts
+++ b/packages/angular/cli/src/command-builder/utilities/command.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Argv } from 'yargs';

--- a/packages/angular/cli/src/command-builder/utilities/json-help.ts
+++ b/packages/angular/cli/src/command-builder/utilities/json-help.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import yargs from 'yargs';

--- a/packages/angular/cli/src/command-builder/utilities/json-schema.ts
+++ b/packages/angular/cli/src/command-builder/utilities/json-schema.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { json } from '@angular-devkit/core';
@@ -165,8 +165,8 @@ export async function parseJsonSchemaToOptions(
     const alias = json.isJsonArray(current.aliases)
       ? [...current.aliases].map((x) => '' + x)
       : current.alias
-      ? ['' + current.alias]
-      : [];
+        ? ['' + current.alias]
+        : [];
     const format = typeof current.format == 'string' ? current.format : undefined;
     const visible = current.visible === undefined || current.visible === true;
     const hidden = !!current.hidden || !visible;

--- a/packages/angular/cli/src/command-builder/utilities/normalize-options-middleware.ts
+++ b/packages/angular/cli/src/command-builder/utilities/normalize-options-middleware.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import * as yargs from 'yargs';

--- a/packages/angular/cli/src/command-builder/utilities/schematic-engine-host.ts
+++ b/packages/angular/cli/src/command-builder/utilities/schematic-engine-host.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { RuleFactory, SchematicsException, Tree } from '@angular-devkit/schematics';

--- a/packages/angular/cli/src/command-builder/utilities/schematic-workflow.ts
+++ b/packages/angular/cli/src/command-builder/utilities/schematic-workflow.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { logging } from '@angular-devkit/core';

--- a/packages/angular/cli/src/commands/add/cli.ts
+++ b/packages/angular/cli/src/commands/add/cli.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { NodePackageDoesNotSupportSchematics } from '@angular-devkit/schematics/tools';

--- a/packages/angular/cli/src/commands/analytics/cli.ts
+++ b/packages/angular/cli/src/commands/analytics/cli.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { join } from 'node:path';

--- a/packages/angular/cli/src/commands/analytics/info/cli.ts
+++ b/packages/angular/cli/src/commands/analytics/info/cli.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Argv } from 'yargs';

--- a/packages/angular/cli/src/commands/analytics/settings/cli.ts
+++ b/packages/angular/cli/src/commands/analytics/settings/cli.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Argv } from 'yargs';

--- a/packages/angular/cli/src/commands/build/cli.ts
+++ b/packages/angular/cli/src/commands/build/cli.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { join } from 'path';

--- a/packages/angular/cli/src/commands/cache/clean/cli.ts
+++ b/packages/angular/cli/src/commands/cache/clean/cli.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { promises as fs } from 'fs';

--- a/packages/angular/cli/src/commands/cache/cli.ts
+++ b/packages/angular/cli/src/commands/cache/cli.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { join } from 'path';

--- a/packages/angular/cli/src/commands/cache/info/cli.ts
+++ b/packages/angular/cli/src/commands/cache/info/cli.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { tags } from '@angular-devkit/core';

--- a/packages/angular/cli/src/commands/cache/settings/cli.ts
+++ b/packages/angular/cli/src/commands/cache/settings/cli.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Argv } from 'yargs';

--- a/packages/angular/cli/src/commands/cache/utilities.ts
+++ b/packages/angular/cli/src/commands/cache/utilities.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { isJsonObject } from '@angular-devkit/core';

--- a/packages/angular/cli/src/commands/command-config.ts
+++ b/packages/angular/cli/src/commands/command-config.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { CommandModuleConstructor } from '../command-builder/utilities/command';

--- a/packages/angular/cli/src/commands/completion/cli.ts
+++ b/packages/angular/cli/src/commands/completion/cli.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { join } from 'path';

--- a/packages/angular/cli/src/commands/config/cli.ts
+++ b/packages/angular/cli/src/commands/config/cli.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { JsonValue } from '@angular-devkit/core';

--- a/packages/angular/cli/src/commands/deploy/cli.ts
+++ b/packages/angular/cli/src/commands/deploy/cli.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { join } from 'node:path';

--- a/packages/angular/cli/src/commands/e2e/cli.ts
+++ b/packages/angular/cli/src/commands/e2e/cli.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { MissingTargetChoice } from '../../command-builder/architect-base-command-module';

--- a/packages/angular/cli/src/commands/extract-i18n/cli.ts
+++ b/packages/angular/cli/src/commands/extract-i18n/cli.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { ArchitectCommandModule } from '../../command-builder/architect-command-module';

--- a/packages/angular/cli/src/commands/generate/cli.ts
+++ b/packages/angular/cli/src/commands/generate/cli.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { strings } from '@angular-devkit/core';

--- a/packages/angular/cli/src/commands/lint/cli.ts
+++ b/packages/angular/cli/src/commands/lint/cli.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { join } from 'path';

--- a/packages/angular/cli/src/commands/make-this-awesome/cli.ts
+++ b/packages/angular/cli/src/commands/make-this-awesome/cli.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Argv } from 'yargs';

--- a/packages/angular/cli/src/commands/new/cli.ts
+++ b/packages/angular/cli/src/commands/new/cli.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { join } from 'node:path';

--- a/packages/angular/cli/src/commands/run/cli.ts
+++ b/packages/angular/cli/src/commands/run/cli.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Target } from '@angular-devkit/architect';

--- a/packages/angular/cli/src/commands/serve/cli.ts
+++ b/packages/angular/cli/src/commands/serve/cli.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { ArchitectCommandModule } from '../../command-builder/architect-command-module';

--- a/packages/angular/cli/src/commands/test/cli.ts
+++ b/packages/angular/cli/src/commands/test/cli.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { join } from 'path';

--- a/packages/angular/cli/src/commands/update/cli.ts
+++ b/packages/angular/cli/src/commands/update/cli.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { SchematicDescription, UnsuccessfulWorkflowExecution } from '@angular-devkit/schematics';

--- a/packages/angular/cli/src/commands/update/schematic/index.ts
+++ b/packages/angular/cli/src/commands/update/schematic/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { logging } from '@angular-devkit/core';

--- a/packages/angular/cli/src/commands/update/schematic/index_spec.ts
+++ b/packages/angular/cli/src/commands/update/schematic/index_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { normalize, virtualFs } from '@angular-devkit/core';

--- a/packages/angular/cli/src/commands/version/cli.ts
+++ b/packages/angular/cli/src/commands/version/cli.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import nodeModule from 'node:module';

--- a/packages/angular/cli/src/typings-bazel.d.ts
+++ b/packages/angular/cli/src/typings-bazel.d.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 /* eslint-disable import/no-extraneous-dependencies */

--- a/packages/angular/cli/src/typings.ts
+++ b/packages/angular/cli/src/typings.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 declare module 'npm-pick-manifest' {

--- a/packages/angular/cli/src/utilities/color.ts
+++ b/packages/angular/cli/src/utilities/color.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import * as ansiColors from 'ansi-colors';

--- a/packages/angular/cli/src/utilities/completion.ts
+++ b/packages/angular/cli/src/utilities/completion.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { json, logging } from '@angular-devkit/core';

--- a/packages/angular/cli/src/utilities/config.ts
+++ b/packages/angular/cli/src/utilities/config.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { json, workspaces } from '@angular-devkit/core';

--- a/packages/angular/cli/src/utilities/environment-options.ts
+++ b/packages/angular/cli/src/utilities/environment-options.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 function isPresent(variable: string | undefined): variable is string {

--- a/packages/angular/cli/src/utilities/eol.ts
+++ b/packages/angular/cli/src/utilities/eol.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { EOL } from 'node:os';

--- a/packages/angular/cli/src/utilities/error.ts
+++ b/packages/angular/cli/src/utilities/error.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import assert from 'assert';

--- a/packages/angular/cli/src/utilities/find-up.ts
+++ b/packages/angular/cli/src/utilities/find-up.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { existsSync } from 'fs';

--- a/packages/angular/cli/src/utilities/json-file.ts
+++ b/packages/angular/cli/src/utilities/json-file.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { JsonValue } from '@angular-devkit/core';

--- a/packages/angular/cli/src/utilities/load-esm.ts
+++ b/packages/angular/cli/src/utilities/load-esm.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 /**

--- a/packages/angular/cli/src/utilities/log-file.ts
+++ b/packages/angular/cli/src/utilities/log-file.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { appendFileSync, mkdtempSync, realpathSync } from 'fs';

--- a/packages/angular/cli/src/utilities/memoize.ts
+++ b/packages/angular/cli/src/utilities/memoize.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 /**

--- a/packages/angular/cli/src/utilities/memoize_spec.ts
+++ b/packages/angular/cli/src/utilities/memoize_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { memoize } from './memoize';

--- a/packages/angular/cli/src/utilities/package-manager.ts
+++ b/packages/angular/cli/src/utilities/package-manager.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { isJsonObject, json } from '@angular-devkit/core';

--- a/packages/angular/cli/src/utilities/package-metadata.ts
+++ b/packages/angular/cli/src/utilities/package-metadata.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { logging } from '@angular-devkit/core';

--- a/packages/angular/cli/src/utilities/package-tree.ts
+++ b/packages/angular/cli/src/utilities/package-tree.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import * as fs from 'fs';

--- a/packages/angular/cli/src/utilities/project.ts
+++ b/packages/angular/cli/src/utilities/project.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { normalize } from '@angular-devkit/core';

--- a/packages/angular/cli/src/utilities/prompt.ts
+++ b/packages/angular/cli/src/utilities/prompt.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type {

--- a/packages/angular/cli/src/utilities/spinner.ts
+++ b/packages/angular/cli/src/utilities/spinner.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import ora from 'ora';

--- a/packages/angular/cli/src/utilities/tty.ts
+++ b/packages/angular/cli/src/utilities/tty.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 function _isTruthy(value: undefined | string): boolean {

--- a/packages/angular/cli/src/utilities/version.ts
+++ b/packages/angular/cli/src/utilities/version.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { readFileSync } from 'fs';

--- a/packages/angular/create/BUILD.bazel
+++ b/packages/angular/create/BUILD.bazel
@@ -1,7 +1,7 @@
 # Copyright Google Inc. All Rights Reserved.
 #
 # Use of this source code is governed by an MIT-style license that can be
-# found in the LICENSE file at https://angular.io/license
+# found in the LICENSE file at https://angular.dev/license
 
 load("//tools:defaults.bzl", "pkg_npm", "ts_library")
 

--- a/packages/angular/create/README.md
+++ b/packages/angular/create/README.md
@@ -2,7 +2,7 @@
 
 ## Create an Angular CLI workspace
 
-Scaffold an Angular CLI workspace without needing to install the Angular CLI globally. All of the [ng new](https://angular.io/cli/new) options and features are supported.
+Scaffold an Angular CLI workspace without needing to install the Angular CLI globally. All of the [ng new](https://angular.dev/cli/new) options and features are supported.
 
 ## Usage
 

--- a/packages/angular/create/src/index.ts
+++ b/packages/angular/create/src/index.ts
@@ -4,7 +4,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { spawnSync } from 'child_process';

--- a/packages/angular/pwa/BUILD.bazel
+++ b/packages/angular/pwa/BUILD.bazel
@@ -1,7 +1,7 @@
 # Copyright Google Inc. All Rights Reserved.
 #
 # Use of this source code is governed by an MIT-style license that can be
-# found in the LICENSE file at https://angular.io/license
+# found in the LICENSE file at https://angular.dev/license
 
 load("@npm//@bazel/jasmine:index.bzl", "jasmine_node_test")
 load("//tools:defaults.bzl", "pkg_npm", "ts_library")

--- a/packages/angular/pwa/BUILD.bazel
+++ b/packages/angular/pwa/BUILD.bazel
@@ -18,10 +18,11 @@ ts_library(
         "pwa/index.ts",
         "//packages/angular/pwa:pwa/schema.ts",
     ],
-    data = glob(
+    data = [
+        "collection.json",
+        "pwa/schema.json",
+    ] + glob(
         include = [
-            "collection.json",
-            "pwa/schema.json",
             "pwa/files/**/*",
         ],
     ),

--- a/packages/angular/pwa/README.md
+++ b/packages/angular/pwa/README.md
@@ -1,8 +1,8 @@
 # `@angular/pwa`
 
-This is a [schematic](https://angular.io/guide/schematics) for adding
+This is a [schematic](https://angular.dev/tools/cli/schematics) for adding
 [Progressive Web App](https://web.dev/progressive-web-apps/) support to an Angular project. Run the
-schematic with the [Angular CLI](https://angular.io/cli):
+schematic with the [Angular CLI](https://angular.dev/tools/cli):
 
 ```shell
 ng add @angular/pwa --project <project-name>
@@ -19,5 +19,5 @@ Executing the command mentioned above will perform the following actions:
 1. Installs icon files to support the installed Progressive Web App (PWA).
 1. Creates the service worker configuration file called `ngsw-config.json`, specifying caching behaviors and other settings.
 
-See [Getting started with service workers](https://angular.io/guide/service-worker-getting-started)
+See [Getting started with service workers](https://angular.dev/ecosystem/service-workers/getting-started)
 for more information.

--- a/packages/angular/pwa/pwa/index.ts
+++ b/packages/angular/pwa/pwa/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {

--- a/packages/angular/pwa/pwa/index_spec.ts
+++ b/packages/angular/pwa/pwa/index_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';

--- a/packages/angular/ssr/README.md
+++ b/packages/angular/ssr/README.md
@@ -1,3 +1,3 @@
 # Angular SSR
 
-Read the dev guide [here](https://angular.io/guide/universal).
+Read the dev guide [here](https://angular.dev/guide/ssr).

--- a/packages/angular/ssr/index.ts
+++ b/packages/angular/ssr/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 export * from './public_api';

--- a/packages/angular/ssr/public_api.ts
+++ b/packages/angular/ssr/public_api.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 export { CommonEngine, CommonEngineRenderOptions, CommonEngineOptions } from './src/common-engine';

--- a/packages/angular/ssr/schematics/BUILD.bazel
+++ b/packages/angular/ssr/schematics/BUILD.bazel
@@ -1,7 +1,7 @@
 # Copyright Google Inc. All Rights Reserved.
 #
 # Use of this source code is governed by an MIT-style license that can be
-# found in the LICENSE file at https://angular.io/license
+# found in the LICENSE file at https://angular.dev/license
 
 load("@npm//@bazel/jasmine:index.bzl", "jasmine_node_test")
 load("//tools:defaults.bzl", "pkg_npm", "ts_library")

--- a/packages/angular/ssr/schematics/ng-add/index.ts
+++ b/packages/angular/ssr/schematics/ng-add/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { externalSchematic } from '@angular-devkit/schematics';

--- a/packages/angular/ssr/schematics/ng-add/index_spec.ts
+++ b/packages/angular/ssr/schematics/ng-add/index_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/angular/ssr/src/common-engine.ts
+++ b/packages/angular/ssr/src/common-engine.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { ApplicationRef, StaticProvider, Type } from '@angular/core';

--- a/packages/angular/ssr/src/inline-css-processor.ts
+++ b/packages/angular/ssr/src/inline-css-processor.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import Critters from 'critters';

--- a/packages/angular/ssr/src/peformance-profiler.ts
+++ b/packages/angular/ssr/src/peformance-profiler.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 const PERFORMANCE_MARK_PREFIX = '🅰️';

--- a/packages/angular_devkit/architect/BUILD.bazel
+++ b/packages/angular_devkit/architect/BUILD.bazel
@@ -1,7 +1,7 @@
 # Copyright Google Inc. All Rights Reserved.
 #
 # Use of this source code is governed by an MIT-style license that can be
-# found in the LICENSE file at https://angular.io/license
+# found in the LICENSE file at https://angular.dev/license
 
 load("@npm//@angular/build-tooling/bazel/api-golden:index.bzl", "api_golden_test_npm_package")
 load("@npm//@bazel/jasmine:index.bzl", "jasmine_node_test")

--- a/packages/angular_devkit/architect/builders/all-of.ts
+++ b/packages/angular_devkit/architect/builders/all-of.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { json } from '@angular-devkit/core';

--- a/packages/angular_devkit/architect/builders/concat.ts
+++ b/packages/angular_devkit/architect/builders/concat.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { json } from '@angular-devkit/core';

--- a/packages/angular_devkit/architect/builders/false.ts
+++ b/packages/angular_devkit/architect/builders/false.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { createBuilder } from '../src';

--- a/packages/angular_devkit/architect/builders/true.ts
+++ b/packages/angular_devkit/architect/builders/true.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { createBuilder } from '../src';

--- a/packages/angular_devkit/architect/node/BUILD.bazel
+++ b/packages/angular_devkit/architect/node/BUILD.bazel
@@ -1,7 +1,7 @@
 # Copyright Google Inc. All Rights Reserved.
 #
 # Use of this source code is governed by an MIT-style license that can be
-# found in the LICENSE file at https://angular.io/license
+# found in the LICENSE file at https://angular.dev/license
 
 load("@npm//@bazel/jasmine:index.bzl", "jasmine_node_test")
 load("//tools:defaults.bzl", "ts_library")

--- a/packages/angular_devkit/architect/node/index.ts
+++ b/packages/angular_devkit/architect/node/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import * as jobs from './jobs/job-registry';

--- a/packages/angular_devkit/architect/node/jobs/job-registry.ts
+++ b/packages/angular_devkit/architect/node/jobs/job-registry.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { jobs } from '@angular-devkit/architect';

--- a/packages/angular_devkit/architect/node/jobs/job-registry_spec.ts
+++ b/packages/angular_devkit/architect/node/jobs/job-registry_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { jobs } from '@angular-devkit/architect';

--- a/packages/angular_devkit/architect/node/node-modules-architect-host.ts
+++ b/packages/angular_devkit/architect/node/node-modules-architect-host.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { json, workspaces } from '@angular-devkit/core';

--- a/packages/angular_devkit/architect/src/api.ts
+++ b/packages/angular_devkit/architect/src/api.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { json, logging } from '@angular-devkit/core';

--- a/packages/angular_devkit/architect/src/api_spec.ts
+++ b/packages/angular_devkit/architect/src/api_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Target, targetFromTargetString, targetStringFromTarget } from './api';

--- a/packages/angular_devkit/architect/src/architect.ts
+++ b/packages/angular_devkit/architect/src/architect.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { json, logging } from '@angular-devkit/core';

--- a/packages/angular_devkit/architect/src/create-builder.ts
+++ b/packages/angular_devkit/architect/src/create-builder.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { json, logging } from '@angular-devkit/core';

--- a/packages/angular_devkit/architect/src/index.ts
+++ b/packages/angular_devkit/architect/src/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import * as jobs from './jobs';

--- a/packages/angular_devkit/architect/src/index_spec.ts
+++ b/packages/angular_devkit/architect/src/index_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { json, logging, schema } from '@angular-devkit/core';

--- a/packages/angular_devkit/architect/src/internal.ts
+++ b/packages/angular_devkit/architect/src/internal.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { json } from '@angular-devkit/core';

--- a/packages/angular_devkit/architect/src/jobs/api.ts
+++ b/packages/angular_devkit/architect/src/jobs/api.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { JsonObject, JsonValue, schema } from '@angular-devkit/core';
@@ -23,9 +23,10 @@ export interface JobHandler<
   InputT extends JsonValue,
   OutputT extends JsonValue,
 > {
-  (argument: ArgT, context: JobHandlerContext<ArgT, InputT, OutputT>): Observable<
-    JobOutboundMessage<OutputT>
-  >;
+  (
+    argument: ArgT,
+    context: JobHandlerContext<ArgT, InputT, OutputT>,
+  ): Observable<JobOutboundMessage<OutputT>>;
 
   jobDescription: Partial<JobDescription>;
 }

--- a/packages/angular_devkit/architect/src/jobs/create-job-handler.ts
+++ b/packages/angular_devkit/architect/src/jobs/create-job-handler.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { BaseException, JsonValue, isPromise, logging } from '@angular-devkit/core';

--- a/packages/angular_devkit/architect/src/jobs/dispatcher.ts
+++ b/packages/angular_devkit/architect/src/jobs/dispatcher.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { JsonValue } from '@angular-devkit/core';

--- a/packages/angular_devkit/architect/src/jobs/dispatcher_spec.ts
+++ b/packages/angular_devkit/architect/src/jobs/dispatcher_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { JsonValue } from '@angular-devkit/core';

--- a/packages/angular_devkit/architect/src/jobs/exception.ts
+++ b/packages/angular_devkit/architect/src/jobs/exception.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { BaseException } from '@angular-devkit/core';

--- a/packages/angular_devkit/architect/src/jobs/fallback-registry.ts
+++ b/packages/angular_devkit/architect/src/jobs/fallback-registry.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { JsonValue } from '@angular-devkit/core';

--- a/packages/angular_devkit/architect/src/jobs/index.ts
+++ b/packages/angular_devkit/architect/src/jobs/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import * as strategy from './strategy';

--- a/packages/angular_devkit/architect/src/jobs/simple-registry.ts
+++ b/packages/angular_devkit/architect/src/jobs/simple-registry.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { JsonValue, schema } from '@angular-devkit/core';

--- a/packages/angular_devkit/architect/src/jobs/simple-registry_spec.ts
+++ b/packages/angular_devkit/architect/src/jobs/simple-registry_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { lastValueFrom } from 'rxjs';

--- a/packages/angular_devkit/architect/src/jobs/simple-scheduler.ts
+++ b/packages/angular_devkit/architect/src/jobs/simple-scheduler.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { JsonValue, schema } from '@angular-devkit/core';

--- a/packages/angular_devkit/architect/src/jobs/simple-scheduler_spec.ts
+++ b/packages/angular_devkit/architect/src/jobs/simple-scheduler_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 /* eslint-disable @typescript-eslint/no-non-null-assertion */

--- a/packages/angular_devkit/architect/src/jobs/strategy.ts
+++ b/packages/angular_devkit/architect/src/jobs/strategy.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { JsonObject, JsonValue, isJsonObject } from '@angular-devkit/core';

--- a/packages/angular_devkit/architect/src/jobs/strategy_spec.ts
+++ b/packages/angular_devkit/architect/src/jobs/strategy_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { promisify } from 'util';

--- a/packages/angular_devkit/architect/src/jobs/types.ts
+++ b/packages/angular_devkit/architect/src/jobs/types.ts
@@ -3,16 +3,16 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 export type DeepReadonly<T> = T extends (infer R)[]
   ? DeepReadonlyArray<R>
   : T extends Function
-  ? T
-  : T extends object
-  ? DeepReadonlyObject<T>
-  : T;
+    ? T
+    : T extends object
+      ? DeepReadonlyObject<T>
+      : T;
 
 // This should be ReadonlyArray but it has implications.
 export type DeepReadonlyArray<T> = Array<DeepReadonly<T>>;

--- a/packages/angular_devkit/architect/src/schedule-by-name.ts
+++ b/packages/angular_devkit/architect/src/schedule-by-name.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { json, logging } from '@angular-devkit/core';
@@ -101,7 +101,7 @@ export async function scheduleByName(
           ...output,
           ...(options.target ? { target: options.target } : 0),
           info,
-        } as unknown as BuilderOutput),
+        }) as unknown as BuilderOutput,
     ),
     shareReplay(),
   );

--- a/packages/angular_devkit/architect/testing/BUILD.bazel
+++ b/packages/angular_devkit/architect/testing/BUILD.bazel
@@ -1,7 +1,7 @@
 # Copyright Google Inc. All Rights Reserved.
 #
 # Use of this source code is governed by an MIT-style license that can be
-# found in the LICENSE file at https://angular.io/license
+# found in the LICENSE file at https://angular.dev/license
 
 load("//tools:defaults.bzl", "ts_library")
 

--- a/packages/angular_devkit/architect/testing/index.ts
+++ b/packages/angular_devkit/architect/testing/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 export * from './testing-architect-host';

--- a/packages/angular_devkit/architect/testing/test-project-host.ts
+++ b/packages/angular_devkit/architect/testing/test-project-host.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {

--- a/packages/angular_devkit/architect/testing/testing-architect-host.ts
+++ b/packages/angular_devkit/architect/testing/testing-architect-host.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { json } from '@angular-devkit/core';

--- a/packages/angular_devkit/architect_cli/BUILD.bazel
+++ b/packages/angular_devkit/architect_cli/BUILD.bazel
@@ -3,7 +3,7 @@ load("//tools:defaults.bzl", "pkg_npm", "ts_library")
 # Copyright Google Inc. All Rights Reserved.
 #
 # Use of this source code is governed by an MIT-style license that can be
-# found in the LICENSE file at https://angular.io/license
+# found in the LICENSE file at https://angular.dev/license
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])

--- a/packages/angular_devkit/architect_cli/bin/architect.ts
+++ b/packages/angular_devkit/architect_cli/bin/architect.ts
@@ -4,7 +4,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Architect, BuilderInfo, BuilderProgressState, Target } from '@angular-devkit/architect';

--- a/packages/angular_devkit/architect_cli/src/progress.ts
+++ b/packages/angular_devkit/architect_cli/src/progress.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import ProgressBar from 'progress';
@@ -12,7 +12,10 @@ import * as readline from 'readline';
 export class MultiProgressBar<Key, T> {
   private _bars = new Map<Key, { data: T; bar: ProgressBar }>();
 
-  constructor(private _status: string, private _stream = process.stderr) {}
+  constructor(
+    private _status: string,
+    private _stream = process.stderr,
+  ) {}
   private _add(id: Key, data: T): { data: T; bar: ProgressBar } {
     const width = Math.min(80, this._stream.columns || 80);
     const value = {

--- a/packages/angular_devkit/build_angular/BUILD.bazel
+++ b/packages/angular_devkit/build_angular/BUILD.bazel
@@ -1,7 +1,7 @@
 # Copyright Google Inc. All Rights Reserved.
 #
 # Use of this source code is governed by an MIT-style license that can be
-# found in the LICENSE file at https://angular.io/license
+# found in the LICENSE file at https://angular.dev/license
 
 load("@npm//@angular/build-tooling/bazel/api-golden:index.bzl", "api_golden_test_npm_package")
 load("@npm//@bazel/jasmine:index.bzl", "jasmine_node_test")

--- a/packages/angular_devkit/build_angular/README.md
+++ b/packages/angular_devkit/build_angular/README.md
@@ -4,20 +4,20 @@ This package contains [Architect builders](/packages/angular_devkit/architect/RE
 
 ## Builders
 
-| Name            | Description                                                                                                                                                                                  |
-| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| application     | Build an Angular application targeting a browser and server environment using [esbuild](https://esbuild.github.io).                                                                          |
-| app-shell       | Build an Angular [App shell](https://angular.io/guide/app-shell).                                                                                                                            |
-| browser         | Build an Angular application targeting a browser environment using [Webpack](https://webpack.js.org).                                                                                        |
-| browser-esbuild | Build an Angular application targeting a browser environment using [esbuild](https://esbuild.github.io).                                                                                     |
-| dev-server      | A development server that provides live reloading.                                                                                                                                           |
-| extract-i18n    | Extract i18n messages from an Angular application.                                                                                                                                           |
-| karma           | Execute unit tests using [Karma](https://github.com/karma-runner/karma) test runner.                                                                                                         |
-| ng-packagr      | Build and package an Angular library in [Angular Package Format (APF)](https://angular.io/guide/angular-package-format) format using [ng-packagr](https://github.com/ng-packagr/ng-packagr). |
-| prerender       | [Prerender](https://angular.io/guide/prerendering) pages of your application. Prerendering is the process where a dynamic page is processed at build time generating static HTML.            |
-| server          | Build an Angular application targeting a [Node.js](https://nodejs.org) environment.                                                                                                          |
-| ssr-dev-server  | A development server which offers live reload during development, but uses server-side rendering.                                                                                            |
-| protractor      | **Deprecated** - Run end-to-end tests using [Protractor](https://www.protractortest.org/) framework.                                                                                         |
+| Name            | Description                                                                                                                                                                                             |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| application     | Build an Angular application targeting a browser and server environment using [esbuild](https://esbuild.github.io).                                                                                     |
+| app-shell       | Build an Angular [App shell](https://angular.dev/ecosystem/service-workers/app-shell).                                                                                                                  |
+| browser         | Build an Angular application targeting a browser environment using [Webpack](https://webpack.js.org).                                                                                                   |
+| browser-esbuild | Build an Angular application targeting a browser environment using [esbuild](https://esbuild.github.io).                                                                                                |
+| dev-server      | A development server that provides live reloading.                                                                                                                                                      |
+| extract-i18n    | Extract i18n messages from an Angular application.                                                                                                                                                      |
+| karma           | Execute unit tests using [Karma](https://github.com/karma-runner/karma) test runner.                                                                                                                    |
+| ng-packagr      | Build and package an Angular library in [Angular Package Format (APF)](https://angular.dev/tools/libraries/angular-package-format) format using [ng-packagr](https://github.com/ng-packagr/ng-packagr). |
+| prerender       | [Prerender](https://angular.dev/guide/prerendering) pages of your application. Prerendering is the process where a dynamic page is processed at build time generating static HTML.                      |
+| server          | Build an Angular application targeting a [Node.js](https://nodejs.org) environment.                                                                                                                     |
+| ssr-dev-server  | A development server which offers live reload during development, but uses server-side rendering.                                                                                                       |
+| protractor      | **Deprecated** - Run end-to-end tests using [Protractor](https://www.protractortest.org/) framework.                                                                                                    |
 
 ## Disclaimer
 

--- a/packages/angular_devkit/build_angular/plugins/karma.ts
+++ b/packages/angular_devkit/build_angular/plugins/karma.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 module.exports = require('../src/tools/webpack/plugins/karma/karma');

--- a/packages/angular_devkit/build_angular/src/babel-bazel.d.ts
+++ b/packages/angular_devkit/build_angular/src/babel-bazel.d.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 /* eslint-disable import/no-extraneous-dependencies */

--- a/packages/angular_devkit/build_angular/src/builders/app-shell/app-shell_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/app-shell/app-shell_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Architect } from '@angular-devkit/architect';

--- a/packages/angular_devkit/build_angular/src/builders/app-shell/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/app-shell/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { augmentAppWithServiceWorker } from '@angular/build/private';

--- a/packages/angular_devkit/build_angular/src/builders/app-shell/render-worker.ts
+++ b/packages/angular_devkit/build_angular/src/builders/app-shell/render-worker.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type { ApplicationRef, StaticProvider, Type } from '@angular/core';

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/builder-status-warnings.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/builder-status-warnings.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { BuilderContext } from '@angular-devkit/architect';

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type { ApplicationBuilderOptions, BuildOutputAsset, BuildOutputFile } from '@angular/build';

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/tests/options/assets_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/tests/options/assets_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { buildEsbuildBrowser } from '../../index';

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/tests/options/delete-output-path_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/tests/options/delete-output-path_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { buildEsbuildBrowser } from '../../index';

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/tests/options/deploy-url_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/tests/options/deploy-url_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { buildEsbuildBrowser } from '../../index';

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/tests/options/main_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/tests/options/main_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { buildEsbuildBrowser } from '../../index';

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/tests/setup.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/tests/setup.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Schema } from '../schema';

--- a/packages/angular_devkit/build_angular/src/builders/browser/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/allow-js_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/allow-js_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Architect } from '@angular-devkit/architect';

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/aot_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/aot_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Architect } from '@angular-devkit/architect';

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/base-href_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/base-href_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Architect } from '@angular-devkit/architect';

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/build-optimizer_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/build-optimizer_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Architect } from '@angular-devkit/architect';

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/cross-origin_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/cross-origin_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Architect } from '@angular-devkit/architect';

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/deploy-url_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/deploy-url_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Architect } from '@angular-devkit/architect';

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/errors_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/errors_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Architect } from '@angular-devkit/architect';

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/font-optimization_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/font-optimization_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Architect } from '@angular-devkit/architect';

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/index_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/index_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Architect } from '@angular-devkit/architect';

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/lazy-module_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/lazy-module_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Architect } from '@angular-devkit/architect';

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/no-entry-module_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/no-entry-module_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Architect } from '@angular-devkit/architect';

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/optimization-level_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/optimization-level_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Architect } from '@angular-devkit/architect';

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/output-path_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/output-path_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Architect } from '@angular-devkit/architect';

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/poll_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/poll_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Architect } from '@angular-devkit/architect';

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/rebuild_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/rebuild_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Architect } from '@angular-devkit/architect';

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/replacements_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/replacements_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Architect } from '@angular-devkit/architect';

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/resolve-json-module_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/resolve-json-module_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Architect } from '@angular-devkit/architect';

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/resources-output-path_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/resources-output-path_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Architect } from '@angular-devkit/architect';

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/scripts-array_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/scripts-array_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Architect } from '@angular-devkit/architect';

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/service-worker_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/service-worker_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Architect } from '@angular-devkit/architect';

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/source-map_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/source-map_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Architect } from '@angular-devkit/architect';

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/stats-json_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/stats-json_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Architect } from '@angular-devkit/architect';

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/styles_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/styles_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Architect } from '@angular-devkit/architect';

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/svg_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/svg_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Architect } from '@angular-devkit/architect';

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/tsconfig-paths_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/tsconfig-paths_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Architect } from '@angular-devkit/architect';

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/unused-files-warning_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/unused-files-warning_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Architect } from '@angular-devkit/architect';

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/vendor-chunk_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/vendor-chunk_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Architect } from '@angular-devkit/architect';

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/vendor-source-map_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/vendor-source-map_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Architect } from '@angular-devkit/architect';

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/web-worker_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/web-worker_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Architect } from '@angular-devkit/architect';

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/works_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/works_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { describeBuilder } from '../../../testing';

--- a/packages/angular_devkit/build_angular/src/builders/browser/tests/behavior/browser-support_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/tests/behavior/browser-support_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { buildWebpackBrowser } from '../../index';

--- a/packages/angular_devkit/build_angular/src/builders/browser/tests/behavior/index_watch_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/tests/behavior/index_watch_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { concatMap, count, take, timeout } from 'rxjs';

--- a/packages/angular_devkit/build_angular/src/builders/browser/tests/behavior/localize_watch_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/tests/behavior/localize_watch_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { concatMap, count, take, timeout } from 'rxjs';

--- a/packages/angular_devkit/build_angular/src/builders/browser/tests/behavior/rebuild-errors_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/tests/behavior/rebuild-errors_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { logging } from '@angular-devkit/core';

--- a/packages/angular_devkit/build_angular/src/builders/browser/tests/behavior/styles_unsupported_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/tests/behavior/styles_unsupported_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { logging } from '@angular-devkit/core';

--- a/packages/angular_devkit/build_angular/src/builders/browser/tests/options/allowed-common-js-dependencies_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/tests/options/allowed-common-js-dependencies_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { logging } from '@angular-devkit/core';

--- a/packages/angular_devkit/build_angular/src/builders/browser/tests/options/assets_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/tests/options/assets_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { buildWebpackBrowser } from '../../index';

--- a/packages/angular_devkit/build_angular/src/builders/browser/tests/options/bundle-budgets_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/tests/options/bundle-budgets_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { logging } from '@angular-devkit/core';

--- a/packages/angular_devkit/build_angular/src/builders/browser/tests/options/extract-licenses_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/tests/options/extract-licenses_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { buildWebpackBrowser } from '../../index';

--- a/packages/angular_devkit/build_angular/src/builders/browser/tests/options/inline-critical_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/tests/options/inline-critical_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { buildWebpackBrowser } from '../../index';

--- a/packages/angular_devkit/build_angular/src/builders/browser/tests/options/inline-style-language_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/tests/options/inline-style-language_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { concatMap, count, take, timeout } from 'rxjs';

--- a/packages/angular_devkit/build_angular/src/builders/browser/tests/options/main_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/tests/options/main_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { buildWebpackBrowser } from '../../index';

--- a/packages/angular_devkit/build_angular/src/builders/browser/tests/options/named-chunks_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/tests/options/named-chunks_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { buildWebpackBrowser } from '../../index';

--- a/packages/angular_devkit/build_angular/src/builders/browser/tests/options/output-hashing_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/tests/options/output-hashing_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { buildWebpackBrowser } from '../../index';

--- a/packages/angular_devkit/build_angular/src/builders/browser/tests/options/polyfills_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/tests/options/polyfills_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { buildWebpackBrowser } from '../../index';

--- a/packages/angular_devkit/build_angular/src/builders/browser/tests/options/scripts_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/tests/options/scripts_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { buildWebpackBrowser } from '../../index';

--- a/packages/angular_devkit/build_angular/src/builders/browser/tests/options/stats-json_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/tests/options/stats-json_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { buildWebpackBrowser } from '../../index';

--- a/packages/angular_devkit/build_angular/src/builders/browser/tests/options/styles_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/tests/options/styles_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { buildWebpackBrowser } from '../../index';

--- a/packages/angular_devkit/build_angular/src/builders/browser/tests/options/subresource-integrity_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/tests/options/subresource-integrity_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { logging } from '@angular-devkit/core';

--- a/packages/angular_devkit/build_angular/src/builders/browser/tests/options/tsconfig_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/tests/options/tsconfig_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { buildWebpackBrowser } from '../../index';

--- a/packages/angular_devkit/build_angular/src/builders/browser/tests/options/verbose_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/tests/options/verbose_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { logging } from '@angular-devkit/core';

--- a/packages/angular_devkit/build_angular/src/builders/browser/tests/options/watch_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/tests/options/watch_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { concatMap, count, take, timeout } from 'rxjs';

--- a/packages/angular_devkit/build_angular/src/builders/browser/tests/setup.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/tests/setup.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Schema } from '../schema';

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/builder.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/builder.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type { DevServerBuilderOutput } from '@angular/build';

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { DevServerBuilderOutput } from '@angular/build';

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/options.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/options.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { BuilderContext, targetFromTargetString } from '@angular-devkit/architect';

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/specs/hmr_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/specs/hmr_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Architect, BuilderRun } from '@angular-devkit/architect';

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/specs/index_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/specs/index_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { DevServerBuilderOutput } from '@angular-devkit/build-angular';

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/specs/ssl_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/specs/ssl_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Architect, BuilderRun } from '@angular-devkit/architect';

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/specs/works_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/specs/works_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Architect, BuilderRun } from '@angular-devkit/architect';

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/tests/behavior/build-assets_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/tests/behavior/build-assets_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { executeDevServer } from '../../index';

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/tests/behavior/build-base-href_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/tests/behavior/build-base-href_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { executeDevServer } from '../../index';

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/tests/behavior/build-budgets_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/tests/behavior/build-budgets_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Type as BudgetType } from '../../../..';

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/tests/behavior/build-deploy-url_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/tests/behavior/build-deploy-url_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { executeDevServer } from '../../index';

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/tests/behavior/build-inline-critical-css_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/tests/behavior/build-inline-critical-css_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { executeDevServer } from '../../index';

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/tests/behavior/build_localize_replaced_watch_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/tests/behavior/build_localize_replaced_watch_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 /* eslint-disable max-len */

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/tests/behavior/build_translation_watch_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/tests/behavior/build_translation_watch_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 /* eslint-disable max-len */

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/tests/behavior/serve-live-reload-proxies_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/tests/behavior/serve-live-reload-proxies_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 /* eslint-disable import/no-extraneous-dependencies */

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/tests/behavior/serve_service-worker_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/tests/behavior/serve_service-worker_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { concatMap, count, take, timeout } from 'rxjs';

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/tests/execute-fetch.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/tests/execute-fetch.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { lastValueFrom, mergeMap, take, timeout } from 'rxjs';

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/tests/jasmine-helpers.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/tests/jasmine-helpers.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { BuilderHandlerFn } from '@angular-devkit/architect';

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/tests/options/allowed-hosts_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/tests/options/allowed-hosts_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { executeDevServer } from '../../index';

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/tests/options/disable-host-check_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/tests/options/disable-host-check_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { executeDevServer } from '../../index';

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/tests/options/force-esbuild_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/tests/options/force-esbuild_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { executeDevServer } from '../../index';

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/tests/options/port_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/tests/options/port_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { URL } from 'url';

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/tests/options/prebundle_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/tests/options/prebundle_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { executeDevServer } from '../../index';

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/tests/options/proxy-config_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/tests/options/proxy-config_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { createServer } from 'node:http';

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/tests/options/public-host_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/tests/options/public-host_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { executeDevServer } from '../../index';

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/tests/options/serve-path_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/tests/options/serve-path_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { URL } from 'url';

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/tests/options/verbose_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/tests/options/verbose_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { executeDevServer } from '../../index';

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/tests/options/watch_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/tests/options/watch_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { TimeoutError, concatMap, count, take, timeout } from 'rxjs';

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/tests/setup.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/tests/setup.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { json } from '@angular-devkit/core';

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/webpack-server.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/webpack-server.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {

--- a/packages/angular_devkit/build_angular/src/builders/extract-i18n/application-extraction.ts
+++ b/packages/angular_devkit/build_angular/src/builders/extract-i18n/application-extraction.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {

--- a/packages/angular_devkit/build_angular/src/builders/extract-i18n/builder.ts
+++ b/packages/angular_devkit/build_angular/src/builders/extract-i18n/builder.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { assertCompatibleAngularVersion, purgeStaleBuildCache } from '@angular/build/private';

--- a/packages/angular_devkit/build_angular/src/builders/extract-i18n/empty-loader.ts
+++ b/packages/angular_devkit/build_angular/src/builders/extract-i18n/empty-loader.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 export default function () {

--- a/packages/angular_devkit/build_angular/src/builders/extract-i18n/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/extract-i18n/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { createBuilder } from '@angular-devkit/architect';

--- a/packages/angular_devkit/build_angular/src/builders/extract-i18n/ivy-extract-loader.ts
+++ b/packages/angular_devkit/build_angular/src/builders/extract-i18n/ivy-extract-loader.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import * as nodePath from 'path';
@@ -54,9 +54,8 @@ async function extract(
     // Load ESM `@angular/localize/tools` using the TypeScript dynamic import workaround.
     // Once TypeScript provides support for keeping the dynamic import this workaround can be
     // changed to a direct dynamic import.
-    const localizeToolsModule = await loadEsmModule<typeof import('@angular/localize/tools')>(
-      '@angular/localize/tools',
-    );
+    const localizeToolsModule =
+      await loadEsmModule<typeof import('@angular/localize/tools')>('@angular/localize/tools');
     MessageExtractor = localizeToolsModule.MessageExtractor;
   } catch {
     throw new Error(

--- a/packages/angular_devkit/build_angular/src/builders/extract-i18n/options.ts
+++ b/packages/angular_devkit/build_angular/src/builders/extract-i18n/options.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { createI18nOptions } from '@angular/build/private';

--- a/packages/angular_devkit/build_angular/src/builders/extract-i18n/webpack-extraction.ts
+++ b/packages/angular_devkit/build_angular/src/builders/extract-i18n/webpack-extraction.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type { ɵParsedMessage as LocalizeMessage } from '@angular/localize';

--- a/packages/angular_devkit/build_angular/src/builders/extract-i18n/works_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/extract-i18n/works_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Architect } from '@angular-devkit/architect';

--- a/packages/angular_devkit/build_angular/src/builders/jest/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/jest/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {

--- a/packages/angular_devkit/build_angular/src/builders/jest/init-test-bed.mjs
+++ b/packages/angular_devkit/build_angular/src/builders/jest/init-test-bed.mjs
@@ -3,14 +3,17 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 // TODO(dgp1130): These imports likely don't resolve in stricter package environments like `pnpm`, since they are resolved relative to
 // `@angular-devkit/build-angular` rather than the user's workspace. Should look into virtual modules to support those use cases.
 
 import { getTestBed } from '@angular/core/testing';
-import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting,
+} from '@angular/platform-browser-dynamic/testing';
 
 getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting(), {
   errorOnUnknownElements: true,

--- a/packages/angular_devkit/build_angular/src/builders/jest/jest-global.mjs
+++ b/packages/angular_devkit/build_angular/src/builders/jest/jest-global.mjs
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 /**
@@ -11,7 +11,7 @@
  * execution. When running ESM code, Jest does _not_ inject the global `jest` symbol, so Zone.js would not normally know it is running
  * within Jest as users are supposed to import from `@jest/globals` or use `import.meta.jest`. Zone.js is not currently aware of this, so we
  * manually set this global to get Zone.js to run correctly.
- * 
+ *
  * TODO(dgp1130): Update Zone.js to directly support Jest ESM executions so we can drop this.
  */
 

--- a/packages/angular_devkit/build_angular/src/builders/jest/jest.config.mjs
+++ b/packages/angular_devkit/build_angular/src/builders/jest/jest.config.mjs
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 // Empty config file, everything is specified via CLI options right now.

--- a/packages/angular_devkit/build_angular/src/builders/jest/options.ts
+++ b/packages/angular_devkit/build_angular/src/builders/jest/options.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Schema as JestBuilderSchema } from './schema';

--- a/packages/angular_devkit/build_angular/src/builders/jest/tests/options.ts
+++ b/packages/angular_devkit/build_angular/src/builders/jest/tests/options.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { JestBuilderOptions } from '../options';

--- a/packages/angular_devkit/build_angular/src/builders/karma/find-tests-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/find-tests-plugin.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import assert from 'assert';

--- a/packages/angular_devkit/build_angular/src/builders/karma/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { assertCompatibleAngularVersion, purgeStaleBuildCache } from '@angular/build/private';

--- a/packages/angular_devkit/build_angular/src/builders/karma/tests/behavior/code-coverage_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/tests/behavior/code-coverage_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { tags } from '@angular-devkit/core';

--- a/packages/angular_devkit/build_angular/src/builders/karma/tests/behavior/errors_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/tests/behavior/errors_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { execute } from '../../index';

--- a/packages/angular_devkit/build_angular/src/builders/karma/tests/behavior/module-cjs_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/tests/behavior/module-cjs_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { execute } from '../../index';

--- a/packages/angular_devkit/build_angular/src/builders/karma/tests/behavior/rebuilds_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/tests/behavior/rebuilds_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { concatMap, count, debounceTime, take, timeout } from 'rxjs';

--- a/packages/angular_devkit/build_angular/src/builders/karma/tests/options/assets_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/tests/options/assets_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { execute } from '../../index';

--- a/packages/angular_devkit/build_angular/src/builders/karma/tests/options/code-coverage-exclude_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/tests/options/code-coverage-exclude_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { promisify } from 'util';

--- a/packages/angular_devkit/build_angular/src/builders/karma/tests/options/code-coverage_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/tests/options/code-coverage_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { promisify } from 'util';

--- a/packages/angular_devkit/build_angular/src/builders/karma/tests/options/exclude_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/tests/options/exclude_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { execute } from '../../index';

--- a/packages/angular_devkit/build_angular/src/builders/karma/tests/options/include_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/tests/options/include_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { execute } from '../../index';

--- a/packages/angular_devkit/build_angular/src/builders/karma/tests/options/styles_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/tests/options/styles_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { execute } from '../../index';

--- a/packages/angular_devkit/build_angular/src/builders/karma/tests/options/web-worker-tsconfig_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/tests/options/web-worker-tsconfig_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { execute } from '../../index';

--- a/packages/angular_devkit/build_angular/src/builders/karma/tests/setup.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/tests/setup.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Schema } from '../schema';

--- a/packages/angular_devkit/build_angular/src/builders/ng-packagr/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/ng-packagr/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { purgeStaleBuildCache } from '@angular/build/private';

--- a/packages/angular_devkit/build_angular/src/builders/ng-packagr/works_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/ng-packagr/works_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Architect } from '@angular-devkit/architect';

--- a/packages/angular_devkit/build_angular/src/builders/prerender/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/prerender/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { augmentAppWithServiceWorker } from '@angular/build/private';

--- a/packages/angular_devkit/build_angular/src/builders/prerender/render-worker.ts
+++ b/packages/angular_devkit/build_angular/src/builders/prerender/render-worker.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type { ApplicationRef, StaticProvider, Type } from '@angular/core';

--- a/packages/angular_devkit/build_angular/src/builders/prerender/routes-extractor-worker.ts
+++ b/packages/angular_devkit/build_angular/src/builders/prerender/routes-extractor-worker.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type { ApplicationRef, Type } from '@angular/core';

--- a/packages/angular_devkit/build_angular/src/builders/prerender/works_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/prerender/works_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Architect } from '@angular-devkit/architect';

--- a/packages/angular_devkit/build_angular/src/builders/protractor/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/protractor/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {

--- a/packages/angular_devkit/build_angular/src/builders/protractor/works_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/protractor/works_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Architect } from '@angular-devkit/architect';

--- a/packages/angular_devkit/build_angular/src/builders/server/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/server/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { assertCompatibleAngularVersion, purgeStaleBuildCache } from '@angular/build/private';

--- a/packages/angular_devkit/build_angular/src/builders/server/platform-server-exports-loader.ts
+++ b/packages/angular_devkit/build_angular/src/builders/server/platform-server-exports-loader.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { readFileSync } from 'node:fs';

--- a/packages/angular_devkit/build_angular/src/builders/server/tests/behavior/build-errors_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/server/tests/behavior/build-errors_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { logging } from '@angular-devkit/core';

--- a/packages/angular_devkit/build_angular/src/builders/server/tests/behavior/preserve_whitespaces_check_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/server/tests/behavior/preserve_whitespaces_check_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { logging } from '@angular-devkit/core';

--- a/packages/angular_devkit/build_angular/src/builders/server/tests/behavior/web-workers_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/server/tests/behavior/web-workers_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { execute } from '../../index';

--- a/packages/angular_devkit/build_angular/src/builders/server/tests/options/assets_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/server/tests/options/assets_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { execute } from '../../index';

--- a/packages/angular_devkit/build_angular/src/builders/server/tests/options/external-dependencies_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/server/tests/options/external-dependencies_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { execute } from '../../index';

--- a/packages/angular_devkit/build_angular/src/builders/server/tests/options/extract-licenses_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/server/tests/options/extract-licenses_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { execute } from '../../index';

--- a/packages/angular_devkit/build_angular/src/builders/server/tests/options/resources-output-path_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/server/tests/options/resources-output-path_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { execute } from '../../index';

--- a/packages/angular_devkit/build_angular/src/builders/server/tests/options/source-map_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/server/tests/options/source-map_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { execute } from '../../index';

--- a/packages/angular_devkit/build_angular/src/builders/server/tests/setup.ts
+++ b/packages/angular_devkit/build_angular/src/builders/server/tests/setup.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Schema } from '../schema';

--- a/packages/angular_devkit/build_angular/src/builders/ssr-dev-server/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/ssr-dev-server/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { loadProxyConfiguration } from '@angular/build/private';

--- a/packages/angular_devkit/build_angular/src/builders/ssr-dev-server/specs/proxy_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/ssr-dev-server/specs/proxy_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Architect } from '@angular-devkit/architect';

--- a/packages/angular_devkit/build_angular/src/builders/ssr-dev-server/specs/ssl_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/ssr-dev-server/specs/ssl_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Architect } from '@angular-devkit/architect';

--- a/packages/angular_devkit/build_angular/src/builders/ssr-dev-server/specs/works_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/ssr-dev-server/specs/works_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Architect } from '@angular-devkit/architect';

--- a/packages/angular_devkit/build_angular/src/builders/ssr-dev-server/utils.ts
+++ b/packages/angular_devkit/build_angular/src/builders/ssr-dev-server/utils.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { SpawnOptions, spawn } from 'child_process';

--- a/packages/angular_devkit/build_angular/src/builders/web-test-runner/builder-status-warnings.ts
+++ b/packages/angular_devkit/build_angular/src/builders/web-test-runner/builder-status-warnings.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { BuilderContext } from '@angular-devkit/architect';

--- a/packages/angular_devkit/build_angular/src/builders/web-test-runner/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/web-test-runner/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { buildApplicationInternal } from '@angular/build/private';

--- a/packages/angular_devkit/build_angular/src/builders/web-test-runner/jasmine_runner.js
+++ b/packages/angular_devkit/build_angular/src/builders/web-test-runner/jasmine_runner.js
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { getTestBed } from '@angular/core/testing';

--- a/packages/angular_devkit/build_angular/src/builders/web-test-runner/options.ts
+++ b/packages/angular_devkit/build_angular/src/builders/web-test-runner/options.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Schema as WtrBuilderSchema } from './schema';

--- a/packages/angular_devkit/build_angular/src/builders/web-test-runner/options_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/web-test-runner/options_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { normalizeOptions } from './options';

--- a/packages/angular_devkit/build_angular/src/index.ts
+++ b/packages/angular_devkit/build_angular/src/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 export * from './transforms';

--- a/packages/angular_devkit/build_angular/src/testing/index.ts
+++ b/packages/angular_devkit/build_angular/src/testing/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 // TODO: Consider using package.json imports field instead of relative path

--- a/packages/angular_devkit/build_angular/src/testing/test-utils.ts
+++ b/packages/angular_devkit/build_angular/src/testing/test-utils.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 export * from '../../../../../modules/testing/builder/src';

--- a/packages/angular_devkit/build_angular/src/tools/babel/babel-loader.d.ts
+++ b/packages/angular_devkit/build_angular/src/tools/babel/babel-loader.d.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 declare module 'babel-loader' {

--- a/packages/angular_devkit/build_angular/src/tools/babel/presets/application.ts
+++ b/packages/angular_devkit/build_angular/src/tools/babel/presets/application.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type { ɵParsedTranslation } from '@angular/localize';

--- a/packages/angular_devkit/build_angular/src/tools/babel/webpack-loader.ts
+++ b/packages/angular_devkit/build_angular/src/tools/babel/webpack-loader.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { custom } from 'babel-loader';

--- a/packages/angular_devkit/build_angular/src/tools/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/configs/common.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { AngularWebpackLoaderPath } from '@ngtools/webpack';

--- a/packages/angular_devkit/build_angular/src/tools/webpack/configs/dev-server.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/configs/dev-server.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { logging, tags } from '@angular-devkit/core';

--- a/packages/angular_devkit/build_angular/src/tools/webpack/configs/index.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/configs/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 export * from './common';

--- a/packages/angular_devkit/build_angular/src/tools/webpack/configs/styles.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/configs/styles.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { SassWorkerImplementation } from '@angular/build/private';

--- a/packages/angular_devkit/build_angular/src/tools/webpack/plugins/any-component-style-budget-checker.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/plugins/any-component-style-budget-checker.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {

--- a/packages/angular_devkit/build_angular/src/tools/webpack/plugins/builder-watch-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/plugins/builder-watch-plugin.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Compiler } from 'webpack';

--- a/packages/angular_devkit/build_angular/src/tools/webpack/plugins/common-js-usage-warn-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/plugins/common-js-usage-warn-plugin.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { isAbsolute } from 'path';

--- a/packages/angular_devkit/build_angular/src/tools/webpack/plugins/css-optimizer-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/plugins/css-optimizer-plugin.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { transformSupportedBrowsersToTargets } from '@angular/build/private';

--- a/packages/angular_devkit/build_angular/src/tools/webpack/plugins/dedupe-module-resolve-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/plugins/dedupe-module-resolve-plugin.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Compiler } from 'webpack';

--- a/packages/angular_devkit/build_angular/src/tools/webpack/plugins/devtools-ignore-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/plugins/devtools-ignore-plugin.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Compilation, Compiler } from 'webpack';

--- a/packages/angular_devkit/build_angular/src/tools/webpack/plugins/esbuild-executor.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/plugins/esbuild-executor.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type {

--- a/packages/angular_devkit/build_angular/src/tools/webpack/plugins/hmr/hmr-accept.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/plugins/hmr/hmr-accept.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/angular_devkit/build_angular/src/tools/webpack/plugins/hmr/hmr-loader.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/plugins/hmr/hmr-loader.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { join } from 'path';

--- a/packages/angular_devkit/build_angular/src/tools/webpack/plugins/index-html-webpack-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/plugins/index-html-webpack-plugin.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {

--- a/packages/angular_devkit/build_angular/src/tools/webpack/plugins/index.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/plugins/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 // Exports the webpack plugins we use internally.

--- a/packages/angular_devkit/build_angular/src/tools/webpack/plugins/javascript-optimizer-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/plugins/javascript-optimizer-plugin.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { transformSupportedBrowsersToTargets } from '@angular/build/private';

--- a/packages/angular_devkit/build_angular/src/tools/webpack/plugins/javascript-optimizer-worker.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/plugins/javascript-optimizer-worker.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import remapping from '@ampproject/remapping';

--- a/packages/angular_devkit/build_angular/src/tools/webpack/plugins/json-stats-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/plugins/json-stats-plugin.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { createWriteStream, promises as fsPromises } from 'fs';

--- a/packages/angular_devkit/build_angular/src/tools/webpack/plugins/karma/karma.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/plugins/karma/karma.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 /* eslint-disable */

--- a/packages/angular_devkit/build_angular/src/tools/webpack/plugins/named-chunks-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/plugins/named-chunks-plugin.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { AsyncDependenciesBlock, Chunk, Compiler, Template, dependencies } from 'webpack';

--- a/packages/angular_devkit/build_angular/src/tools/webpack/plugins/occurrences-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/plugins/occurrences-plugin.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Compiler } from 'webpack';

--- a/packages/angular_devkit/build_angular/src/tools/webpack/plugins/postcss-cli-resources.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/plugins/postcss-cli-resources.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { interpolateName } from 'loader-utils';

--- a/packages/angular_devkit/build_angular/src/tools/webpack/plugins/progress-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/plugins/progress-plugin.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { ProgressPlugin as WebpackProgressPlugin } from 'webpack';

--- a/packages/angular_devkit/build_angular/src/tools/webpack/plugins/remove-hash-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/plugins/remove-hash-plugin.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Compiler } from 'webpack';

--- a/packages/angular_devkit/build_angular/src/tools/webpack/plugins/scripts-webpack-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/plugins/scripts-webpack-plugin.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { interpolateName } from 'loader-utils';

--- a/packages/angular_devkit/build_angular/src/tools/webpack/plugins/service-worker-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/plugins/service-worker-plugin.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { augmentAppWithServiceWorker } from '@angular/build/private';

--- a/packages/angular_devkit/build_angular/src/tools/webpack/plugins/styles-webpack-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/plugins/styles-webpack-plugin.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import assert from 'assert';

--- a/packages/angular_devkit/build_angular/src/tools/webpack/plugins/suppress-entry-chunks-webpack-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/plugins/suppress-entry-chunks-webpack-plugin.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 /**

--- a/packages/angular_devkit/build_angular/src/tools/webpack/plugins/transfer-size-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/plugins/transfer-size-plugin.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { promisify } from 'util';

--- a/packages/angular_devkit/build_angular/src/tools/webpack/plugins/typescript.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/plugins/typescript.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type { CompilerOptions } from '@angular/compiler-cli';

--- a/packages/angular_devkit/build_angular/src/tools/webpack/plugins/watch-files-logs-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/plugins/watch-files-logs-plugin.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type { Compiler } from 'webpack';

--- a/packages/angular_devkit/build_angular/src/tools/webpack/utils/async-chunks.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/utils/async-chunks.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { StatsChunk, StatsCompilation } from 'webpack';

--- a/packages/angular_devkit/build_angular/src/tools/webpack/utils/helpers.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/utils/helpers.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type { ObjectPattern } from 'copy-webpack-plugin';

--- a/packages/angular_devkit/build_angular/src/tools/webpack/utils/stats.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/utils/stats.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {

--- a/packages/angular_devkit/build_angular/src/transforms.ts
+++ b/packages/angular_devkit/build_angular/src/transforms.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 export type ExecutionTransformer<T> = (input: T) => T | Promise<T>;

--- a/packages/angular_devkit/build_angular/src/utils/action-executor.ts
+++ b/packages/angular_devkit/build_angular/src/utils/action-executor.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import Piscina from 'piscina';

--- a/packages/angular_devkit/build_angular/src/utils/build-options.ts
+++ b/packages/angular_devkit/build_angular/src/utils/build-options.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type { ParsedConfiguration } from '@angular/compiler-cli';

--- a/packages/angular_devkit/build_angular/src/utils/bundle-inline-options.ts
+++ b/packages/angular_devkit/build_angular/src/utils/bundle-inline-options.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 export interface InlineOptions {

--- a/packages/angular_devkit/build_angular/src/utils/color.ts
+++ b/packages/angular_devkit/build_angular/src/utils/color.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import * as ansiColors from 'ansi-colors';

--- a/packages/angular_devkit/build_angular/src/utils/copy-assets.ts
+++ b/packages/angular_devkit/build_angular/src/utils/copy-assets.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import glob from 'fast-glob';

--- a/packages/angular_devkit/build_angular/src/utils/default-progress.ts
+++ b/packages/angular_devkit/build_angular/src/utils/default-progress.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 export function defaultProgress(progress: boolean | undefined): boolean {

--- a/packages/angular_devkit/build_angular/src/utils/environment-options.ts
+++ b/packages/angular_devkit/build_angular/src/utils/environment-options.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 function isDisabled(variable: string): boolean {

--- a/packages/angular_devkit/build_angular/src/utils/error.ts
+++ b/packages/angular_devkit/build_angular/src/utils/error.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import assert from 'assert';

--- a/packages/angular_devkit/build_angular/src/utils/i18n-inlining.ts
+++ b/packages/angular_devkit/build_angular/src/utils/i18n-inlining.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { BuilderContext } from '@angular-devkit/architect';

--- a/packages/angular_devkit/build_angular/src/utils/i18n-webpack.ts
+++ b/packages/angular_devkit/build_angular/src/utils/i18n-webpack.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {

--- a/packages/angular_devkit/build_angular/src/utils/index.ts
+++ b/packages/angular_devkit/build_angular/src/utils/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 export * from './default-progress';

--- a/packages/angular_devkit/build_angular/src/utils/load-esm.ts
+++ b/packages/angular_devkit/build_angular/src/utils/load-esm.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 /**

--- a/packages/angular_devkit/build_angular/src/utils/normalize-asset-patterns.ts
+++ b/packages/angular_devkit/build_angular/src/utils/normalize-asset-patterns.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { statSync } from 'fs';

--- a/packages/angular_devkit/build_angular/src/utils/normalize-builder-schema.ts
+++ b/packages/angular_devkit/build_angular/src/utils/normalize-builder-schema.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { getSupportedBrowsers } from '@angular/build/private';

--- a/packages/angular_devkit/build_angular/src/utils/normalize-cache.ts
+++ b/packages/angular_devkit/build_angular/src/utils/normalize-cache.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { join, resolve } from 'node:path';

--- a/packages/angular_devkit/build_angular/src/utils/normalize-file-replacements.ts
+++ b/packages/angular_devkit/build_angular/src/utils/normalize-file-replacements.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { existsSync } from 'fs';

--- a/packages/angular_devkit/build_angular/src/utils/normalize-optimization.ts
+++ b/packages/angular_devkit/build_angular/src/utils/normalize-optimization.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {

--- a/packages/angular_devkit/build_angular/src/utils/normalize-polyfills.ts
+++ b/packages/angular_devkit/build_angular/src/utils/normalize-polyfills.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { existsSync } from 'fs';

--- a/packages/angular_devkit/build_angular/src/utils/normalize-source-maps.ts
+++ b/packages/angular_devkit/build_angular/src/utils/normalize-source-maps.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { SourceMapClass, SourceMapUnion } from '../builders/browser/schema';

--- a/packages/angular_devkit/build_angular/src/utils/output-paths.ts
+++ b/packages/angular_devkit/build_angular/src/utils/output-paths.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { existsSync, mkdirSync } from 'fs';

--- a/packages/angular_devkit/build_angular/src/utils/package-chunk-sort.ts
+++ b/packages/angular_devkit/build_angular/src/utils/package-chunk-sort.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { ScriptElement, StyleElement } from '../builders/browser/schema';

--- a/packages/angular_devkit/build_angular/src/utils/package-version.ts
+++ b/packages/angular_devkit/build_angular/src/utils/package-version.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 export const VERSION: string = require('../../package.json').version;

--- a/packages/angular_devkit/build_angular/src/utils/process-bundle.ts
+++ b/packages/angular_devkit/build_angular/src/utils/process-bundle.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import remapping from '@ampproject/remapping';

--- a/packages/angular_devkit/build_angular/src/utils/read-tsconfig.ts
+++ b/packages/angular_devkit/build_angular/src/utils/read-tsconfig.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type { ParsedConfiguration } from '@angular/compiler-cli';
@@ -26,9 +26,8 @@ export async function readTsconfig(
   // Load ESM `@angular/compiler-cli` using the TypeScript dynamic import workaround.
   // Once TypeScript provides support for keeping the dynamic import this workaround can be
   // changed to a direct dynamic import.
-  const { formatDiagnostics, readConfiguration } = await loadEsmModule<
-    typeof import('@angular/compiler-cli')
-  >('@angular/compiler-cli');
+  const { formatDiagnostics, readConfiguration } =
+    await loadEsmModule<typeof import('@angular/compiler-cli')>('@angular/compiler-cli');
 
   const configResult = readConfiguration(tsConfigFullPath);
   if (configResult.errors && configResult.errors.length) {

--- a/packages/angular_devkit/build_angular/src/utils/run-module-as-observable-fork.ts
+++ b/packages/angular_devkit/build_angular/src/utils/run-module-as-observable-fork.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { BuilderOutput } from '@angular-devkit/architect';
@@ -29,10 +29,10 @@ export function runModuleAsObservableFork(
       // Workaround for https://github.com/nodejs/node/issues/9435
       return !debugArgRegex.test(arg);
     });
-    const forkOptions: ForkOptions = ({
+    const forkOptions: ForkOptions = {
       cwd,
       execArgv,
-    } as {}) as ForkOptions;
+    } as {} as ForkOptions;
 
     // TODO: support passing in a logger to use as stdio streams
     // if (logger) {

--- a/packages/angular_devkit/build_angular/src/utils/run-module-worker.js
+++ b/packages/angular_devkit/build_angular/src/utils/run-module-worker.js
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 process.on('message', (message) => {
   // Only process messages with the hash in 'run-module-as-observable-fork.ts'.

--- a/packages/angular_devkit/build_angular/src/utils/spinner.ts
+++ b/packages/angular_devkit/build_angular/src/utils/spinner.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import ora from 'ora';

--- a/packages/angular_devkit/build_angular/src/utils/tailwind.ts
+++ b/packages/angular_devkit/build_angular/src/utils/tailwind.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { readdir } from 'node:fs/promises';

--- a/packages/angular_devkit/build_angular/src/utils/test-files.ts
+++ b/packages/angular_devkit/build_angular/src/utils/test-files.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import fastGlob, { Options as GlobOptions } from 'fast-glob';

--- a/packages/angular_devkit/build_angular/src/utils/test-files_spec.ts
+++ b/packages/angular_devkit/build_angular/src/utils/test-files_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/angular_devkit/build_angular/src/utils/tty.ts
+++ b/packages/angular_devkit/build_angular/src/utils/tty.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 function _isTruthy(value: undefined | string): boolean {

--- a/packages/angular_devkit/build_angular/src/utils/url.ts
+++ b/packages/angular_devkit/build_angular/src/utils/url.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 export function urlJoin(...parts: string[]): string {

--- a/packages/angular_devkit/build_angular/src/utils/url_spec.ts
+++ b/packages/angular_devkit/build_angular/src/utils/url_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { urlJoin } from './url';

--- a/packages/angular_devkit/build_angular/src/utils/webpack-browser-config.ts
+++ b/packages/angular_devkit/build_angular/src/utils/webpack-browser-config.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { BuilderContext } from '@angular-devkit/architect';

--- a/packages/angular_devkit/build_angular/src/utils/webpack-diagnostics.ts
+++ b/packages/angular_devkit/build_angular/src/utils/webpack-diagnostics.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type { Compilation } from 'webpack';

--- a/packages/angular_devkit/build_angular/test/hello-world-lib/projects/lib/karma.conf.js
+++ b/packages/angular_devkit/build_angular/test/hello-world-lib/projects/lib/karma.conf.js
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 // Karma configuration file, see link for more information

--- a/packages/angular_devkit/build_angular/test/hello-world-lib/projects/lib/src/lib/lib.component.spec.ts
+++ b/packages/angular_devkit/build_angular/test/hello-world-lib/projects/lib/src/lib/lib.component.spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';

--- a/packages/angular_devkit/build_angular/test/hello-world-lib/projects/lib/src/lib/lib.component.ts
+++ b/packages/angular_devkit/build_angular/test/hello-world-lib/projects/lib/src/lib/lib.component.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Component } from '@angular/core';

--- a/packages/angular_devkit/build_angular/test/hello-world-lib/projects/lib/src/lib/lib.module.ts
+++ b/packages/angular_devkit/build_angular/test/hello-world-lib/projects/lib/src/lib/lib.module.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { NgModule } from '@angular/core';

--- a/packages/angular_devkit/build_angular/test/hello-world-lib/projects/lib/src/lib/lib.service.spec.ts
+++ b/packages/angular_devkit/build_angular/test/hello-world-lib/projects/lib/src/lib/lib.service.spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { TestBed, inject } from '@angular/core/testing';

--- a/packages/angular_devkit/build_angular/test/hello-world-lib/projects/lib/src/lib/lib.service.ts
+++ b/packages/angular_devkit/build_angular/test/hello-world-lib/projects/lib/src/lib/lib.service.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Injectable } from '@angular/core';

--- a/packages/angular_devkit/build_angular/test/hello-world-lib/projects/lib/src/public-api.ts
+++ b/packages/angular_devkit/build_angular/test/hello-world-lib/projects/lib/src/public-api.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 /*

--- a/packages/angular_devkit/build_webpack/BUILD.bazel
+++ b/packages/angular_devkit/build_webpack/BUILD.bazel
@@ -1,12 +1,12 @@
 # Copyright Google Inc. All Rights Reserved.
 #
 # Use of this source code is governed by an MIT-style license that can be
-# found in the LICENSE file at https://angular.io/license
+# found in the LICENSE file at https://angular.dev/license
 
+load("@npm//@angular/build-tooling/bazel/api-golden:index.bzl", "api_golden_test_npm_package")
 load("@npm//@bazel/jasmine:index.bzl", "jasmine_node_test")
 load("//tools:defaults.bzl", "pkg_npm", "ts_library")
 load("//tools:ts_json_schema.bzl", "ts_json_schema")
-load("@npm//@angular/build-tooling/bazel/api-golden:index.bzl", "api_golden_test_npm_package")
 
 licenses(["notice"])
 

--- a/packages/angular_devkit/build_webpack/BUILD.bazel
+++ b/packages/angular_devkit/build_webpack/BUILD.bazel
@@ -57,7 +57,6 @@ ts_library(
     testonly = True,
     srcs = glob(
         include = [
-            "src/test-utils.ts",
             "src/**/*_spec.ts",
         ],
     ),

--- a/packages/angular_devkit/build_webpack/src/builders/webpack-dev-server/index.ts
+++ b/packages/angular_devkit/build_webpack/src/builders/webpack-dev-server/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { BuilderContext, createBuilder } from '@angular-devkit/architect';

--- a/packages/angular_devkit/build_webpack/src/builders/webpack-dev-server/index_spec.ts
+++ b/packages/angular_devkit/build_webpack/src/builders/webpack-dev-server/index_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Architect } from '@angular-devkit/architect';

--- a/packages/angular_devkit/build_webpack/src/builders/webpack/index.ts
+++ b/packages/angular_devkit/build_webpack/src/builders/webpack/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { BuilderContext, BuilderOutput, createBuilder } from '@angular-devkit/architect';

--- a/packages/angular_devkit/build_webpack/src/builders/webpack/index_spec.ts
+++ b/packages/angular_devkit/build_webpack/src/builders/webpack/index_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Architect } from '@angular-devkit/architect';

--- a/packages/angular_devkit/build_webpack/src/index.ts
+++ b/packages/angular_devkit/build_webpack/src/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 export * from './builders/webpack';

--- a/packages/angular_devkit/build_webpack/src/utils.ts
+++ b/packages/angular_devkit/build_webpack/src/utils.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { existsSync } from 'fs';

--- a/packages/angular_devkit/build_webpack/test/angular-app/src/app/app.component.html
+++ b/packages/angular_devkit/build_webpack/test/angular-app/src/app/app.component.html
@@ -10,7 +10,7 @@
 <h2>Here are some links to help you start:</h2>
 <ul>
   <li>
-    <h2><a target="_blank" rel="noopener" href="https://angular.io/tutorial">Tour of Heroes</a></h2>
+    <h2><a target="_blank" rel="noopener" href="https://angular.dev/tutorials/learn-angular">Learn Angular</a></h2>
   </li>
   <li>
     <h2>
@@ -20,7 +20,7 @@
     </h2>
   </li>
   <li>
-    <h2><a target="_blank" rel="noopener" href="https://blog.angular.io/">Angular blog</a></h2>
+    <h2><a target="_blank" rel="noopener" href="https://blog.angular.dev">Angular blog</a></h2>
   </li>
 </ul>
 

--- a/packages/angular_devkit/build_webpack/test/angular-app/src/app/app.component.spec.ts
+++ b/packages/angular_devkit/build_webpack/test/angular-app/src/app/app.component.spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { TestBed } from '@angular/core/testing';

--- a/packages/angular_devkit/build_webpack/test/angular-app/src/app/app.component.ts
+++ b/packages/angular_devkit/build_webpack/test/angular-app/src/app/app.component.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Component } from '@angular/core';

--- a/packages/angular_devkit/build_webpack/test/angular-app/src/app/app.module.ts
+++ b/packages/angular_devkit/build_webpack/test/angular-app/src/app/app.module.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { BrowserModule } from '@angular/platform-browser';

--- a/packages/angular_devkit/build_webpack/test/angular-app/src/main.ts
+++ b/packages/angular_devkit/build_webpack/test/angular-app/src/main.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';

--- a/packages/angular_devkit/build_webpack/test/angular-app/src/polyfills.ts
+++ b/packages/angular_devkit/build_webpack/test/angular-app/src/polyfills.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 /**

--- a/packages/angular_devkit/core/BUILD.bazel
+++ b/packages/angular_devkit/core/BUILD.bazel
@@ -5,7 +5,7 @@ load("//tools:defaults.bzl", "pkg_npm", "ts_library")
 # Copyright Google Inc. All Rights Reserved.
 #
 # Use of this source code is governed by an MIT-style license that can be
-# found in the LICENSE file at https://angular.io/license
+# found in the LICENSE file at https://angular.dev/license
 package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])

--- a/packages/angular_devkit/core/node/BUILD.bazel
+++ b/packages/angular_devkit/core/node/BUILD.bazel
@@ -1,7 +1,7 @@
 # Copyright Google Inc. All Rights Reserved.
 #
 # Use of this source code is governed by an MIT-style license that can be
-# found in the LICENSE file at https://angular.io/license
+# found in the LICENSE file at https://angular.dev/license
 
 load("@npm//@bazel/jasmine:index.bzl", "jasmine_node_test")
 load("//tools:defaults.bzl", "ts_library")

--- a/packages/angular_devkit/core/node/cli-logger.ts
+++ b/packages/angular_devkit/core/node/cli-logger.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { filter } from 'rxjs';

--- a/packages/angular_devkit/core/node/host.ts
+++ b/packages/angular_devkit/core/node/host.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {

--- a/packages/angular_devkit/core/node/host_spec.ts
+++ b/packages/angular_devkit/core/node/host_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 /* eslint-disable @typescript-eslint/no-non-null-assertion */

--- a/packages/angular_devkit/core/node/index.ts
+++ b/packages/angular_devkit/core/node/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 export * from './cli-logger';

--- a/packages/angular_devkit/core/node/testing/BUILD.bazel
+++ b/packages/angular_devkit/core/node/testing/BUILD.bazel
@@ -3,7 +3,7 @@ load("//tools:defaults.bzl", "ts_library")
 # Copyright Google Inc. All Rights Reserved.
 #
 # Use of this source code is governed by an MIT-style license that can be
-# found in the LICENSE file at https://angular.io/license
+# found in the LICENSE file at https://angular.dev/license
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])

--- a/packages/angular_devkit/core/node/testing/index.ts
+++ b/packages/angular_devkit/core/node/testing/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import * as fs from 'fs';

--- a/packages/angular_devkit/core/src/exception.ts
+++ b/packages/angular_devkit/core/src/exception.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 export class BaseException extends Error {

--- a/packages/angular_devkit/core/src/index.ts
+++ b/packages/angular_devkit/core/src/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import * as json from './json/index';

--- a/packages/angular_devkit/core/src/json/index.ts
+++ b/packages/angular_devkit/core/src/json/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import * as schema from './schema/index';

--- a/packages/angular_devkit/core/src/json/schema/index.ts
+++ b/packages/angular_devkit/core/src/json/schema/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import * as transforms from './transforms';

--- a/packages/angular_devkit/core/src/json/schema/interface.ts
+++ b/packages/angular_devkit/core/src/json/schema/interface.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { ErrorObject, Format } from 'ajv';
@@ -108,7 +108,10 @@ export interface JsonSchemaVisitor {
 }
 
 export interface JsonVisitor {
-  (value: JsonValue, pointer: JsonPointer, schema?: JsonObject, root?: JsonObject | JsonArray):
-    | Observable<JsonValue>
-    | JsonValue;
+  (
+    value: JsonValue,
+    pointer: JsonPointer,
+    schema?: JsonObject,
+    root?: JsonObject | JsonArray,
+  ): Observable<JsonValue> | JsonValue;
 }

--- a/packages/angular_devkit/core/src/json/schema/pointer.ts
+++ b/packages/angular_devkit/core/src/json/schema/pointer.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { JsonPointer } from './interface';

--- a/packages/angular_devkit/core/src/json/schema/prompt_spec.ts
+++ b/packages/angular_devkit/core/src/json/schema/prompt_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 /* eslint-disable @typescript-eslint/no-explicit-any */

--- a/packages/angular_devkit/core/src/json/schema/registry.ts
+++ b/packages/angular_devkit/core/src/json/schema/registry.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import Ajv, { SchemaObjCxt, ValidateFunction } from 'ajv';

--- a/packages/angular_devkit/core/src/json/schema/registry_spec.ts
+++ b/packages/angular_devkit/core/src/json/schema/registry_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 /* eslint-disable @typescript-eslint/no-explicit-any */

--- a/packages/angular_devkit/core/src/json/schema/schema.ts
+++ b/packages/angular_devkit/core/src/json/schema/schema.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { JsonObject, JsonValue, isJsonObject } from '../utils';

--- a/packages/angular_devkit/core/src/json/schema/transforms.ts
+++ b/packages/angular_devkit/core/src/json/schema/transforms.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { JsonObject, JsonValue, isJsonArray, isJsonObject } from '../utils';

--- a/packages/angular_devkit/core/src/json/schema/transforms_spec.ts
+++ b/packages/angular_devkit/core/src/json/schema/transforms_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { CoreSchemaRegistry } from './registry';

--- a/packages/angular_devkit/core/src/json/schema/utility.ts
+++ b/packages/angular_devkit/core/src/json/schema/utility.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { JsonObject, isJsonArray, isJsonObject } from '../utils';

--- a/packages/angular_devkit/core/src/json/schema/visitor.ts
+++ b/packages/angular_devkit/core/src/json/schema/visitor.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {

--- a/packages/angular_devkit/core/src/json/schema/visitor_spec.ts
+++ b/packages/angular_devkit/core/src/json/schema/visitor_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Observable, from } from 'rxjs';

--- a/packages/angular_devkit/core/src/json/utils.ts
+++ b/packages/angular_devkit/core/src/json/utils.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface

--- a/packages/angular_devkit/core/src/logger/indent.ts
+++ b/packages/angular_devkit/core/src/logger/indent.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { map } from 'rxjs';

--- a/packages/angular_devkit/core/src/logger/indent_spec.ts
+++ b/packages/angular_devkit/core/src/logger/indent_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 /* eslint-disable @typescript-eslint/no-explicit-any */

--- a/packages/angular_devkit/core/src/logger/index.ts
+++ b/packages/angular_devkit/core/src/logger/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 export * from './indent';

--- a/packages/angular_devkit/core/src/logger/level.ts
+++ b/packages/angular_devkit/core/src/logger/level.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { JsonObject } from '../json/utils';

--- a/packages/angular_devkit/core/src/logger/logger.ts
+++ b/packages/angular_devkit/core/src/logger/logger.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { EMPTY, Observable, Operator, PartialObserver, Subject, Subscription } from 'rxjs';
@@ -67,7 +67,10 @@ export class Logger extends Observable<LogEntry> implements LoggerApi {
     }
   }
 
-  constructor(public readonly name: string, public readonly parent: Logger | null = null) {
+  constructor(
+    public readonly name: string,
+    public readonly parent: Logger | null = null,
+  ) {
     super();
 
     const path: string[] = [];

--- a/packages/angular_devkit/core/src/logger/logger_spec.ts
+++ b/packages/angular_devkit/core/src/logger/logger_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 /* eslint-disable @typescript-eslint/no-explicit-any */

--- a/packages/angular_devkit/core/src/logger/null-logger.ts
+++ b/packages/angular_devkit/core/src/logger/null-logger.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { EMPTY } from 'rxjs';

--- a/packages/angular_devkit/core/src/logger/null-logger_spec.ts
+++ b/packages/angular_devkit/core/src/logger/null-logger_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { lastValueFrom, toArray } from 'rxjs';

--- a/packages/angular_devkit/core/src/logger/transform-logger.ts
+++ b/packages/angular_devkit/core/src/logger/transform-logger.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Observable } from 'rxjs';

--- a/packages/angular_devkit/core/src/logger/transform-logger_spec.ts
+++ b/packages/angular_devkit/core/src/logger/transform-logger_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 /* eslint-disable @typescript-eslint/no-explicit-any */

--- a/packages/angular_devkit/core/src/utils/index.ts
+++ b/packages/angular_devkit/core/src/utils/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import * as tags from './literals';

--- a/packages/angular_devkit/core/src/utils/lang.ts
+++ b/packages/angular_devkit/core/src/utils/lang.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 // Borrowed from @angular/core

--- a/packages/angular_devkit/core/src/utils/literals.ts
+++ b/packages/angular_devkit/core/src/utils/literals.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 export interface TemplateTag<R = string> {

--- a/packages/angular_devkit/core/src/utils/literals_spec.ts
+++ b/packages/angular_devkit/core/src/utils/literals_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { oneLine, stripIndent, stripIndents, trimNewlines } from './literals';

--- a/packages/angular_devkit/core/src/utils/object.ts
+++ b/packages/angular_devkit/core/src/utils/object.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 const copySymbol = Symbol();

--- a/packages/angular_devkit/core/src/utils/object_spec.ts
+++ b/packages/angular_devkit/core/src/utils/object_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -33,7 +33,11 @@ describe('object', () => {
 
     it('works with simple classes', () => {
       class Data {
-        constructor(private _x = 1, protected _y = 2, public _z = 3) {}
+        constructor(
+          private _x = 1,
+          protected _y = 2,
+          public _z = 3,
+        ) {}
       }
       const data = new Data();
       expect(deepCopy(data)).toEqual(data);

--- a/packages/angular_devkit/core/src/utils/partially-ordered-set.ts
+++ b/packages/angular_devkit/core/src/utils/partially-ordered-set.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { BaseException } from '../exception';

--- a/packages/angular_devkit/core/src/utils/partially-ordered-set_spec.ts
+++ b/packages/angular_devkit/core/src/utils/partially-ordered-set_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { PartiallyOrderedSet } from './partially-ordered-set';

--- a/packages/angular_devkit/core/src/utils/priority-queue.ts
+++ b/packages/angular_devkit/core/src/utils/priority-queue.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 /** Naive priority queue; not intended for large datasets */

--- a/packages/angular_devkit/core/src/utils/priority-queue_spec.ts
+++ b/packages/angular_devkit/core/src/utils/priority-queue_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { PriorityQueue } from './priority-queue';

--- a/packages/angular_devkit/core/src/utils/strings.ts
+++ b/packages/angular_devkit/core/src/utils/strings.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 const STRING_DASHERIZE_REGEXP = /[ _]/g;

--- a/packages/angular_devkit/core/src/utils/template.ts
+++ b/packages/angular_devkit/core/src/utils/template.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Position, SourceNode } from 'source-map';

--- a/packages/angular_devkit/core/src/virtual-fs/host/alias.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/host/alias.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { NormalizedRoot, Path, PathFragment, join, split } from '../path';

--- a/packages/angular_devkit/core/src/virtual-fs/host/alias_spec.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/host/alias_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { normalize } from '..';

--- a/packages/angular_devkit/core/src/virtual-fs/host/buffer.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/host/buffer.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { TextDecoder, TextEncoder } from 'node:util';

--- a/packages/angular_devkit/core/src/virtual-fs/host/create.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/host/create.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Observable } from 'rxjs';

--- a/packages/angular_devkit/core/src/virtual-fs/host/empty.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/host/empty.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Observable, of, throwError } from 'rxjs';

--- a/packages/angular_devkit/core/src/virtual-fs/host/index.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/host/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import * as test from './test';

--- a/packages/angular_devkit/core/src/virtual-fs/host/interface.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/host/interface.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Observable } from 'rxjs';

--- a/packages/angular_devkit/core/src/virtual-fs/host/memory.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/host/memory.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Observable, Subject } from 'rxjs';

--- a/packages/angular_devkit/core/src/virtual-fs/host/memory_spec.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/host/memory_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 /* eslint-disable @typescript-eslint/no-non-null-assertion */

--- a/packages/angular_devkit/core/src/virtual-fs/host/pattern.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/host/pattern.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { parse as parseGlob } from 'picomatch';

--- a/packages/angular_devkit/core/src/virtual-fs/host/pattern_spec.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/host/pattern_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { normalize } from '..';

--- a/packages/angular_devkit/core/src/virtual-fs/host/record.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/host/record.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {
@@ -156,7 +156,7 @@ export class CordHost extends SimpleMemoryHost {
           ({
             kind: 'delete',
             path,
-          } as CordHostRecord),
+          }) as CordHostRecord,
       ),
       ...[...this._filesToRename.entries()].map(
         ([from, to]) =>
@@ -164,7 +164,7 @@ export class CordHost extends SimpleMemoryHost {
             kind: 'rename',
             from,
             to,
-          } as CordHostRecord),
+          }) as CordHostRecord,
       ),
       ...[...this._filesToCreate.values()].map(
         (path) =>
@@ -172,7 +172,7 @@ export class CordHost extends SimpleMemoryHost {
             kind: 'create',
             path,
             content: this._read(path),
-          } as CordHostRecord),
+          }) as CordHostRecord,
       ),
       ...[...this._filesToOverwrite.values()].map(
         (path) =>
@@ -180,7 +180,7 @@ export class CordHost extends SimpleMemoryHost {
             kind: 'overwrite',
             path,
             content: this._read(path),
-          } as CordHostRecord),
+          }) as CordHostRecord,
       ),
     ];
   }
@@ -373,8 +373,8 @@ export class CordHost extends SimpleMemoryHost {
     return this._exists(path)
       ? of(true)
       : this.willDelete(path) || this.willRename(path)
-      ? of(false)
-      : this._back.exists(path);
+        ? of(false)
+        : this._back.exists(path);
   }
   override isDirectory(path: Path): Observable<boolean> {
     return this._exists(path) ? super.isDirectory(path) : this._back.isDirectory(path);
@@ -383,16 +383,16 @@ export class CordHost extends SimpleMemoryHost {
     return this._exists(path)
       ? super.isFile(path)
       : this.willDelete(path) || this.willRename(path)
-      ? of(false)
-      : this._back.isFile(path);
+        ? of(false)
+        : this._back.isFile(path);
   }
 
   override stat(path: Path): Observable<Stats | null> | null {
     return this._exists(path)
       ? super.stat(path)
       : this.willDelete(path) || this.willRename(path)
-      ? of(null)
-      : this._back.stat(path);
+        ? of(null)
+        : this._back.stat(path);
   }
 
   override watch(path: Path, options?: HostWatchOptions) {

--- a/packages/angular_devkit/core/src/virtual-fs/host/record_spec.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/host/record_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 /* eslint-disable @typescript-eslint/no-explicit-any */

--- a/packages/angular_devkit/core/src/virtual-fs/host/resolver.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/host/resolver.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Observable } from 'rxjs';

--- a/packages/angular_devkit/core/src/virtual-fs/host/safe.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/host/safe.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Observable, catchError, of } from 'rxjs';

--- a/packages/angular_devkit/core/src/virtual-fs/host/scoped.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/host/scoped.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { NormalizedRoot, Path, join } from '../path';
@@ -11,7 +11,10 @@ import { Host } from './interface';
 import { ResolverHost } from './resolver';
 
 export class ScopedHost<T extends object> extends ResolverHost<T> {
-  constructor(delegate: Host<T>, protected _root: Path = NormalizedRoot) {
+  constructor(
+    delegate: Host<T>,
+    protected _root: Path = NormalizedRoot,
+  ) {
     super(delegate);
   }
 

--- a/packages/angular_devkit/core/src/virtual-fs/host/sync.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/host/sync.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Observable } from 'rxjs';

--- a/packages/angular_devkit/core/src/virtual-fs/host/test.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/host/test.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Observable } from 'rxjs';

--- a/packages/angular_devkit/core/src/virtual-fs/host/test_spec.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/host/test_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import * as test from './test';

--- a/packages/angular_devkit/core/src/virtual-fs/index.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import * as virtualFs from './host/index';

--- a/packages/angular_devkit/core/src/virtual-fs/path.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/path.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { BaseException } from '../exception';

--- a/packages/angular_devkit/core/src/virtual-fs/path_spec.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/path_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {

--- a/packages/angular_devkit/core/src/workspace/core.ts
+++ b/packages/angular_devkit/core/src/workspace/core.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { basename, getSystemPath, join, normalize } from '../virtual-fs';

--- a/packages/angular_devkit/core/src/workspace/core_spec.ts
+++ b/packages/angular_devkit/core/src/workspace/core_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 /* eslint-disable @typescript-eslint/no-empty-function */

--- a/packages/angular_devkit/core/src/workspace/definitions.ts
+++ b/packages/angular_devkit/core/src/workspace/definitions.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { JsonValue } from '../json';
@@ -38,7 +38,10 @@ export type DefinitionCollectionListener<V extends object> = (
 class DefinitionCollection<V extends object> implements ReadonlyMap<string, V> {
   private _map: Map<string, V>;
 
-  constructor(initial?: Record<string, V>, private _listener?: DefinitionCollectionListener<V>) {
+  constructor(
+    initial?: Record<string, V>,
+    private _listener?: DefinitionCollectionListener<V>,
+  ) {
     this._map = new Map(initial && Object.entries(initial));
   }
 

--- a/packages/angular_devkit/core/src/workspace/definitions_spec.ts
+++ b/packages/angular_devkit/core/src/workspace/definitions_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {

--- a/packages/angular_devkit/core/src/workspace/host.ts
+++ b/packages/angular_devkit/core/src/workspace/host.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { lastValueFrom } from 'rxjs';

--- a/packages/angular_devkit/core/src/workspace/host_spec.ts
+++ b/packages/angular_devkit/core/src/workspace/host_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { test } from '../virtual-fs/host';

--- a/packages/angular_devkit/core/src/workspace/index.ts
+++ b/packages/angular_devkit/core/src/workspace/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 export * from './definitions';

--- a/packages/angular_devkit/core/src/workspace/json/metadata.ts
+++ b/packages/angular_devkit/core/src/workspace/json/metadata.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { JSONPath, Node, findNodeAtLocation, getNodeValue } from 'jsonc-parser';
@@ -39,7 +39,11 @@ export class JsonWorkspaceMetadata {
 
   hasLegacyTargetsName = true;
 
-  constructor(readonly filePath: string, private readonly ast: Node, readonly raw: string) {}
+  constructor(
+    readonly filePath: string,
+    private readonly ast: Node,
+    readonly raw: string,
+  ) {}
 
   get hasChanges(): boolean {
     return this.changes.size > 0;

--- a/packages/angular_devkit/core/src/workspace/json/reader.ts
+++ b/packages/angular_devkit/core/src/workspace/json/reader.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Node, findNodeAtLocation, getNodeValue, parseTree } from 'jsonc-parser';

--- a/packages/angular_devkit/core/src/workspace/json/reader_spec.ts
+++ b/packages/angular_devkit/core/src/workspace/json/reader_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 /* eslint-disable @typescript-eslint/no-non-null-assertion */

--- a/packages/angular_devkit/core/src/workspace/json/utilities.ts
+++ b/packages/angular_devkit/core/src/workspace/json/utilities.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { JsonArray, JsonObject, JsonValue, isJsonObject } from '../../json';

--- a/packages/angular_devkit/core/src/workspace/json/writer.ts
+++ b/packages/angular_devkit/core/src/workspace/json/writer.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { applyEdits, modify } from 'jsonc-parser';

--- a/packages/angular_devkit/core/src/workspace/json/writer_spec.ts
+++ b/packages/angular_devkit/core/src/workspace/json/writer_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { readFileSync } from 'fs';

--- a/packages/angular_devkit/schematics/BUILD.bazel
+++ b/packages/angular_devkit/schematics/BUILD.bazel
@@ -5,7 +5,7 @@ load("//tools:defaults.bzl", "pkg_npm", "ts_library")
 # Copyright Google Inc. All Rights Reserved.
 #
 # Use of this source code is governed by an MIT-style license that can be
-# found in the LICENSE file at https://angular.io/license
+# found in the LICENSE file at https://angular.dev/license
 package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])

--- a/packages/angular_devkit/schematics/src/engine/engine.ts
+++ b/packages/angular_devkit/schematics/src/engine/engine.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { BaseException, PriorityQueue, logging } from '@angular-devkit/core';
@@ -178,7 +178,10 @@ export class SchematicEngine<CollectionT extends object, SchematicT extends obje
   >();
   private _taskSchedulers = new Array<TaskScheduler>();
 
-  constructor(private _host: EngineHost<CollectionT, SchematicT>, protected _workflow?: Workflow) {}
+  constructor(
+    private _host: EngineHost<CollectionT, SchematicT>,
+    protected _workflow?: Workflow,
+  ) {}
 
   get workflow() {
     return this._workflow || null;

--- a/packages/angular_devkit/schematics/src/engine/index.ts
+++ b/packages/angular_devkit/schematics/src/engine/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 export * from './engine';

--- a/packages/angular_devkit/schematics/src/engine/interface.ts
+++ b/packages/angular_devkit/schematics/src/engine/interface.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { logging } from '@angular-devkit/core';

--- a/packages/angular_devkit/schematics/src/engine/schematic.ts
+++ b/packages/angular_devkit/schematics/src/engine/schematic.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { BaseException } from '@angular-devkit/core';

--- a/packages/angular_devkit/schematics/src/engine/schematic_spec.ts
+++ b/packages/angular_devkit/schematics/src/engine/schematic_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 /* eslint-disable @typescript-eslint/no-non-null-assertion */

--- a/packages/angular_devkit/schematics/src/exception/exception.ts
+++ b/packages/angular_devkit/schematics/src/exception/exception.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { BaseException } from '@angular-devkit/core';

--- a/packages/angular_devkit/schematics/src/formats/format-validator.ts
+++ b/packages/angular_devkit/schematics/src/formats/format-validator.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { JsonObject, JsonValue, schema } from '@angular-devkit/core';

--- a/packages/angular_devkit/schematics/src/formats/html-selector.ts
+++ b/packages/angular_devkit/schematics/src/formats/html-selector.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { schema } from '@angular-devkit/core';

--- a/packages/angular_devkit/schematics/src/formats/html-selector_spec.ts
+++ b/packages/angular_devkit/schematics/src/formats/html-selector_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { formatValidator } from './format-validator';

--- a/packages/angular_devkit/schematics/src/formats/index.ts
+++ b/packages/angular_devkit/schematics/src/formats/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { schema } from '@angular-devkit/core';

--- a/packages/angular_devkit/schematics/src/formats/path.ts
+++ b/packages/angular_devkit/schematics/src/formats/path.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { normalize, schema } from '@angular-devkit/core';

--- a/packages/angular_devkit/schematics/src/formats/path_spec.ts
+++ b/packages/angular_devkit/schematics/src/formats/path_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { formatValidator } from './format-validator';

--- a/packages/angular_devkit/schematics/src/index.ts
+++ b/packages/angular_devkit/schematics/src/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { strings } from '@angular-devkit/core';

--- a/packages/angular_devkit/schematics/src/rules/base.ts
+++ b/packages/angular_devkit/schematics/src/rules/base.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Observable, concat, map, mapTo, toArray } from 'rxjs';

--- a/packages/angular_devkit/schematics/src/rules/base_spec.ts
+++ b/packages/angular_devkit/schematics/src/rules/base_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 /* eslint-disable @typescript-eslint/no-non-null-assertion */

--- a/packages/angular_devkit/schematics/src/rules/call.ts
+++ b/packages/angular_devkit/schematics/src/rules/call.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { BaseException } from '@angular-devkit/core';

--- a/packages/angular_devkit/schematics/src/rules/call_spec.ts
+++ b/packages/angular_devkit/schematics/src/rules/call_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
@@ -42,7 +42,7 @@ describe('callSource', () => {
   });
 
   it('errors if invalid source object', (done) => {
-    const source0: Source = () => ({} as Tree);
+    const source0: Source = () => ({}) as Tree;
 
     callSource(source0, context)
       .toPromise()
@@ -96,7 +96,7 @@ describe('callSource', () => {
 
 describe('callRule', () => {
   it('should throw InvalidRuleResultException when rule result is non-Tree object', async () => {
-    const rule0: Rule = () => ({} as Tree);
+    const rule0: Rule = () => ({}) as Tree;
 
     await expectAsync(callRule(rule0, empty(), context).toPromise()).toBeRejectedWithError(
       InvalidRuleResultException,

--- a/packages/angular_devkit/schematics/src/rules/move.ts
+++ b/packages/angular_devkit/schematics/src/rules/move.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { join, normalize } from '@angular-devkit/core';

--- a/packages/angular_devkit/schematics/src/rules/move_spec.ts
+++ b/packages/angular_devkit/schematics/src/rules/move_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 /* eslint-disable @typescript-eslint/no-non-null-assertion */

--- a/packages/angular_devkit/schematics/src/rules/random.ts
+++ b/packages/angular_devkit/schematics/src/rules/random.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Source } from '../engine/interface';

--- a/packages/angular_devkit/schematics/src/rules/schematic.ts
+++ b/packages/angular_devkit/schematics/src/rules/schematic.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { last, map, of as observableOf } from 'rxjs';

--- a/packages/angular_devkit/schematics/src/rules/template.ts
+++ b/packages/angular_devkit/schematics/src/rules/template.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { BaseException, normalize, template as templateImpl } from '@angular-devkit/core';

--- a/packages/angular_devkit/schematics/src/rules/template_spec.ts
+++ b/packages/angular_devkit/schematics/src/rules/template_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 /* eslint-disable import/no-extraneous-dependencies */

--- a/packages/angular_devkit/schematics/src/rules/url.ts
+++ b/packages/angular_devkit/schematics/src/rules/url.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { parse } from 'url';

--- a/packages/angular_devkit/schematics/src/sink/dryrun.ts
+++ b/packages/angular_devkit/schematics/src/sink/dryrun.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { normalize, virtualFs } from '@angular-devkit/core';

--- a/packages/angular_devkit/schematics/src/sink/dryrun_spec.ts
+++ b/packages/angular_devkit/schematics/src/sink/dryrun_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Path, normalize, virtualFs } from '@angular-devkit/core';

--- a/packages/angular_devkit/schematics/src/sink/host.ts
+++ b/packages/angular_devkit/schematics/src/sink/host.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Path, virtualFs } from '@angular-devkit/core';
@@ -25,7 +25,10 @@ export class HostSink extends SimpleSinkBase {
   protected _filesToCreate = new Map<Path, Buffer>();
   protected _filesToUpdate = new Map<Path, Buffer>();
 
-  constructor(protected _host: virtualFs.Host, protected _force = false) {
+  constructor(
+    protected _host: virtualFs.Host,
+    protected _force = false,
+  ) {
     super();
   }
 

--- a/packages/angular_devkit/schematics/src/sink/host_spec.ts
+++ b/packages/angular_devkit/schematics/src/sink/host_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { normalize, virtualFs } from '@angular-devkit/core';

--- a/packages/angular_devkit/schematics/src/sink/sink.ts
+++ b/packages/angular_devkit/schematics/src/sink/sink.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {

--- a/packages/angular_devkit/schematics/src/tree/action.ts
+++ b/packages/angular_devkit/schematics/src/tree/action.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { BaseException, Path } from '@angular-devkit/core';

--- a/packages/angular_devkit/schematics/src/tree/action_spec.ts
+++ b/packages/angular_devkit/schematics/src/tree/action_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { normalize } from '@angular-devkit/core';

--- a/packages/angular_devkit/schematics/src/tree/common_spec.ts
+++ b/packages/angular_devkit/schematics/src/tree/common_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { normalize } from '@angular-devkit/core';

--- a/packages/angular_devkit/schematics/src/tree/delegate.ts
+++ b/packages/angular_devkit/schematics/src/tree/delegate.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { JsonValue } from '@angular-devkit/core';

--- a/packages/angular_devkit/schematics/src/tree/empty.ts
+++ b/packages/angular_devkit/schematics/src/tree/empty.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { HostTree } from './host-tree';

--- a/packages/angular_devkit/schematics/src/tree/entry.ts
+++ b/packages/angular_devkit/schematics/src/tree/entry.ts
@@ -3,14 +3,17 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Path } from '@angular-devkit/core';
 import { FileEntry } from './interface';
 
 export class SimpleFileEntry implements FileEntry {
-  constructor(private _path: Path, private _content: Buffer) {}
+  constructor(
+    private _path: Path,
+    private _content: Buffer,
+  ) {}
 
   get path() {
     return this._path;
@@ -23,7 +26,10 @@ export class SimpleFileEntry implements FileEntry {
 export class LazyFileEntry implements FileEntry {
   private _content: Buffer | null = null;
 
-  constructor(private _path: Path, private _load: (path?: Path) => Buffer) {}
+  constructor(
+    private _path: Path,
+    private _load: (path?: Path) => Buffer,
+  ) {}
 
   get path() {
     return this._path;

--- a/packages/angular_devkit/schematics/src/tree/host-tree.ts
+++ b/packages/angular_devkit/schematics/src/tree/host-tree.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {

--- a/packages/angular_devkit/schematics/src/tree/host-tree_spec.ts
+++ b/packages/angular_devkit/schematics/src/tree/host-tree_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { normalize, virtualFs } from '@angular-devkit/core';

--- a/packages/angular_devkit/schematics/src/tree/interface.ts
+++ b/packages/angular_devkit/schematics/src/tree/interface.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { JsonValue, Path, PathFragment } from '@angular-devkit/core';

--- a/packages/angular_devkit/schematics/src/tree/null.ts
+++ b/packages/angular_devkit/schematics/src/tree/null.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {

--- a/packages/angular_devkit/schematics/src/tree/recorder.ts
+++ b/packages/angular_devkit/schematics/src/tree/recorder.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { BaseException } from '@angular-devkit/core';

--- a/packages/angular_devkit/schematics/src/tree/recorder_spec.ts
+++ b/packages/angular_devkit/schematics/src/tree/recorder_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { normalize } from '@angular-devkit/core';

--- a/packages/angular_devkit/schematics/src/tree/scoped.ts
+++ b/packages/angular_devkit/schematics/src/tree/scoped.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {
@@ -28,7 +28,10 @@ import {
 } from './interface';
 
 class ScopedFileEntry implements FileEntry {
-  constructor(private _base: FileEntry, private scope: Path) {}
+  constructor(
+    private _base: FileEntry,
+    private scope: Path,
+  ) {}
 
   get path(): Path {
     return join(NormalizedRoot, relative(this.scope, this._base.path));
@@ -40,7 +43,10 @@ class ScopedFileEntry implements FileEntry {
 }
 
 class ScopedDirEntry implements DirEntry {
-  constructor(private _base: DirEntry, readonly scope: Path) {}
+  constructor(
+    private _base: DirEntry,
+    readonly scope: Path,
+  ) {}
 
   get parent(): DirEntry | null {
     if (!this._base.parent || this._base.path == this.scope) {
@@ -86,7 +92,10 @@ class ScopedDirEntry implements DirEntry {
 export class ScopedTree implements Tree {
   readonly _root: ScopedDirEntry;
 
-  constructor(private _base: Tree, scope: string) {
+  constructor(
+    private _base: Tree,
+    scope: string,
+  ) {
     const normalizedScope = normalize('/' + scope);
     this._root = new ScopedDirEntry(this._base.getDir(normalizedScope), normalizedScope);
   }

--- a/packages/angular_devkit/schematics/src/tree/scoped_spec.ts
+++ b/packages/angular_devkit/schematics/src/tree/scoped_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { UnitTestTree } from '../../testing';

--- a/packages/angular_devkit/schematics/src/tree/static.ts
+++ b/packages/angular_devkit/schematics/src/tree/static.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { SchematicsException } from '../exception/exception';

--- a/packages/angular_devkit/schematics/src/workflow/base.ts
+++ b/packages/angular_devkit/schematics/src/workflow/base.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { logging, schema, virtualFs } from '@angular-devkit/core';

--- a/packages/angular_devkit/schematics/src/workflow/index.ts
+++ b/packages/angular_devkit/schematics/src/workflow/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 export * from './base';

--- a/packages/angular_devkit/schematics/src/workflow/interface.ts
+++ b/packages/angular_devkit/schematics/src/workflow/interface.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { logging } from '@angular-devkit/core';

--- a/packages/angular_devkit/schematics/tasks/BUILD.bazel
+++ b/packages/angular_devkit/schematics/tasks/BUILD.bazel
@@ -3,7 +3,7 @@ load("//tools:defaults.bzl", "ts_library")
 # Copyright Google Inc. All Rights Reserved.
 #
 # Use of this source code is governed by an MIT-style license that can be
-# found in the LICENSE file at https://angular.io/license
+# found in the LICENSE file at https://angular.dev/license
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])

--- a/packages/angular_devkit/schematics/tasks/index.ts
+++ b/packages/angular_devkit/schematics/tasks/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 export { NodePackageInstallTask } from './package-manager/install-task';

--- a/packages/angular_devkit/schematics/tasks/node/BUILD.bazel
+++ b/packages/angular_devkit/schematics/tasks/node/BUILD.bazel
@@ -3,7 +3,7 @@ load("//tools:defaults.bzl", "ts_library")
 # Copyright Google Inc. All Rights Reserved.
 #
 # Use of this source code is governed by an MIT-style license that can be
-# found in the LICENSE file at https://angular.io/license
+# found in the LICENSE file at https://angular.dev/license
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])

--- a/packages/angular_devkit/schematics/tasks/node/index.ts
+++ b/packages/angular_devkit/schematics/tasks/node/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { TaskExecutor, TaskExecutorFactory } from '../../src';

--- a/packages/angular_devkit/schematics/tasks/package-manager/executor.ts
+++ b/packages/angular_devkit/schematics/tasks/package-manager/executor.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { BaseException } from '@angular-devkit/core';

--- a/packages/angular_devkit/schematics/tasks/package-manager/install-task.ts
+++ b/packages/angular_devkit/schematics/tasks/package-manager/install-task.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { TaskConfiguration, TaskConfigurationGenerator } from '../../src';

--- a/packages/angular_devkit/schematics/tasks/package-manager/link-task.ts
+++ b/packages/angular_devkit/schematics/tasks/package-manager/link-task.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { TaskConfiguration, TaskConfigurationGenerator } from '../../src';

--- a/packages/angular_devkit/schematics/tasks/package-manager/options.ts
+++ b/packages/angular_devkit/schematics/tasks/package-manager/options.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 export const NodePackageName = 'node-package';

--- a/packages/angular_devkit/schematics/tasks/repo-init/executor.ts
+++ b/packages/angular_devkit/schematics/tasks/repo-init/executor.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { tags } from '@angular-devkit/core';

--- a/packages/angular_devkit/schematics/tasks/repo-init/init-task.ts
+++ b/packages/angular_devkit/schematics/tasks/repo-init/init-task.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { TaskConfiguration, TaskConfigurationGenerator } from '../../src';
@@ -16,8 +16,12 @@ export interface CommitOptions {
 }
 
 export class RepositoryInitializerTask
-  implements TaskConfigurationGenerator<RepositoryInitializerTaskOptions> {
-  constructor(public workingDirectory?: string, public commitOptions?: CommitOptions) {}
+  implements TaskConfigurationGenerator<RepositoryInitializerTaskOptions>
+{
+  constructor(
+    public workingDirectory?: string,
+    public commitOptions?: CommitOptions,
+  ) {}
 
   toConfiguration(): TaskConfiguration<RepositoryInitializerTaskOptions> {
     return {

--- a/packages/angular_devkit/schematics/tasks/repo-init/options.ts
+++ b/packages/angular_devkit/schematics/tasks/repo-init/options.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 export const RepositoryInitializerName = 'repo-init';

--- a/packages/angular_devkit/schematics/tasks/run-schematic/executor.ts
+++ b/packages/angular_devkit/schematics/tasks/run-schematic/executor.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { SchematicContext, TaskExecutor } from '../../src';

--- a/packages/angular_devkit/schematics/tasks/run-schematic/options.ts
+++ b/packages/angular_devkit/schematics/tasks/run-schematic/options.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 export const RunSchematicName = 'run-schematic';

--- a/packages/angular_devkit/schematics/tasks/run-schematic/task.ts
+++ b/packages/angular_devkit/schematics/tasks/run-schematic/task.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { TaskConfiguration, TaskConfigurationGenerator } from '../../src';

--- a/packages/angular_devkit/schematics/testing/BUILD.bazel
+++ b/packages/angular_devkit/schematics/testing/BUILD.bazel
@@ -3,7 +3,7 @@ load("//tools:defaults.bzl", "ts_library")
 # Copyright Google Inc. All Rights Reserved.
 #
 # Use of this source code is governed by an MIT-style license that can be
-# found in the LICENSE file at https://angular.io/license
+# found in the LICENSE file at https://angular.dev/license
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])

--- a/packages/angular_devkit/schematics/testing/index.ts
+++ b/packages/angular_devkit/schematics/testing/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 export * from './schematic-test-runner';

--- a/packages/angular_devkit/schematics/testing/schematic-test-runner.ts
+++ b/packages/angular_devkit/schematics/testing/schematic-test-runner.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { logging, schema } from '@angular-devkit/core';

--- a/packages/angular_devkit/schematics/tools/BUILD.bazel
+++ b/packages/angular_devkit/schematics/tools/BUILD.bazel
@@ -4,7 +4,7 @@ load("//tools:defaults.bzl", "ts_library")
 # Copyright Google Inc. All Rights Reserved.
 #
 # Use of this source code is governed by an MIT-style license that can be
-# found in the LICENSE file at https://angular.io/license
+# found in the LICENSE file at https://angular.dev/license
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])

--- a/packages/angular_devkit/schematics/tools/description.ts
+++ b/packages/angular_devkit/schematics/tools/description.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { JsonObject } from '@angular-devkit/core';

--- a/packages/angular_devkit/schematics/tools/export-ref.ts
+++ b/packages/angular_devkit/schematics/tools/export-ref.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { dirname, resolve } from 'path';

--- a/packages/angular_devkit/schematics/tools/export-ref_spec.ts
+++ b/packages/angular_devkit/schematics/tools/export-ref_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import * as path from 'path';

--- a/packages/angular_devkit/schematics/tools/fallback-engine-host.ts
+++ b/packages/angular_devkit/schematics/tools/fallback-engine-host.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Observable, mergeMap, of as observableOf, throwError } from 'rxjs';

--- a/packages/angular_devkit/schematics/tools/file-system-engine-host-base.ts
+++ b/packages/angular_devkit/schematics/tools/file-system-engine-host-base.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { BaseException, JsonObject, normalize, virtualFs } from '@angular-devkit/core';

--- a/packages/angular_devkit/schematics/tools/file-system-engine-host.ts
+++ b/packages/angular_devkit/schematics/tools/file-system-engine-host.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { existsSync } from 'fs';

--- a/packages/angular_devkit/schematics/tools/file-system-engine-host_spec.ts
+++ b/packages/angular_devkit/schematics/tools/file-system-engine-host_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 /* eslint-disable @typescript-eslint/no-explicit-any, import/no-extraneous-dependencies */

--- a/packages/angular_devkit/schematics/tools/file-system-utility.ts
+++ b/packages/angular_devkit/schematics/tools/file-system-utility.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { JsonValue } from '@angular-devkit/core';

--- a/packages/angular_devkit/schematics/tools/index.ts
+++ b/packages/angular_devkit/schematics/tools/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 export * from './description';

--- a/packages/angular_devkit/schematics/tools/node-module-engine-host.ts
+++ b/packages/angular_devkit/schematics/tools/node-module-engine-host.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { BaseException } from '@angular-devkit/core';

--- a/packages/angular_devkit/schematics/tools/node-module-engine-host_spec.ts
+++ b/packages/angular_devkit/schematics/tools/node-module-engine-host_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { SchematicEngine } from '@angular-devkit/schematics';

--- a/packages/angular_devkit/schematics/tools/node-modules-test-engine-host.ts
+++ b/packages/angular_devkit/schematics/tools/node-modules-test-engine-host.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { TaskConfiguration, TaskConfigurationGenerator, TaskId } from '../src/engine';

--- a/packages/angular_devkit/schematics/tools/schema-option-transform.ts
+++ b/packages/angular_devkit/schematics/tools/schema-option-transform.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { deepCopy, schema } from '@angular-devkit/core';

--- a/packages/angular_devkit/schematics/tools/workflow/node-workflow.ts
+++ b/packages/angular_devkit/schematics/tools/workflow/node-workflow.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Path, getSystemPath, normalize, schema, virtualFs } from '@angular-devkit/core';

--- a/packages/angular_devkit/schematics/tools/workflow/node-workflow_spec.ts
+++ b/packages/angular_devkit/schematics/tools/workflow/node-workflow_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 /* eslint-disable import/no-extraneous-dependencies */

--- a/packages/angular_devkit/schematics_cli/BUILD.bazel
+++ b/packages/angular_devkit/schematics_cli/BUILD.bazel
@@ -5,7 +5,7 @@ load("//tools:ts_json_schema.bzl", "ts_json_schema")
 # Copyright Google Inc. All Rights Reserved.
 #
 # Use of this source code is governed by an MIT-style license that can be
-# found in the LICENSE file at https://angular.io/license
+# found in the LICENSE file at https://angular.dev/license
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])

--- a/packages/angular_devkit/schematics_cli/BUILD.bazel
+++ b/packages/angular_devkit/schematics_cli/BUILD.bazel
@@ -31,14 +31,15 @@ ts_library(
         "//packages/angular_devkit/schematics_cli:schematic/schema.ts",
         # @external_end
     ],
-    data = glob(
+    data = [
+        "blank/schema.json",
+        "collection.json",
+        "package.json",
+        "schematic/schema.json",
+    ] + glob(
         include = [
-            "collection.json",
-            "package.json",
-            "blank/schema.json",
             "blank/project-files/**/*",
             "blank/schematic-files/**/*",
-            "schematic/schema.json",
             "schematic/files/**/*",
         ],
     ),

--- a/packages/angular_devkit/schematics_cli/bin/schematics.ts
+++ b/packages/angular_devkit/schematics_cli/bin/schematics.ts
@@ -4,7 +4,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 // symbol polyfill must go first
@@ -410,9 +410,8 @@ const booleanArgs = [
   'interactive',
 ] as const;
 
-type ElementType<T extends ReadonlyArray<unknown>> = T extends ReadonlyArray<infer ElementType>
-  ? ElementType
-  : never;
+type ElementType<T extends ReadonlyArray<unknown>> =
+  T extends ReadonlyArray<infer ElementType> ? ElementType : never;
 
 interface Options {
   _: string[];

--- a/packages/angular_devkit/schematics_cli/bin/schematics_spec.ts
+++ b/packages/angular_devkit/schematics_cli/bin/schematics_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { main } from './schematics';

--- a/packages/angular_devkit/schematics_cli/blank/factory.ts
+++ b/packages/angular_devkit/schematics_cli/blank/factory.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { JsonObject, Path, isJsonObject, normalize, strings } from '@angular-devkit/core';

--- a/packages/angular_devkit/schematics_cli/schematic/factory.ts
+++ b/packages/angular_devkit/schematics_cli/schematic/factory.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { strings } from '@angular-devkit/core';

--- a/packages/ngtools/webpack/BUILD.bazel
+++ b/packages/ngtools/webpack/BUILD.bazel
@@ -1,11 +1,11 @@
 # Copyright Google Inc. All Rights Reserved.
 #
 # Use of this source code is governed by an MIT-style license that can be
-# found in the LICENSE file at https://angular.io/license
+# found in the LICENSE file at https://angular.dev/license
 
+load("@npm//@angular/build-tooling/bazel/api-golden:index.bzl", "api_golden_test_npm_package")
 load("@npm//@bazel/jasmine:index.bzl", "jasmine_node_test")
 load("//tools:defaults.bzl", "pkg_npm", "ts_library")
-load("@npm//@angular/build-tooling/bazel/api-golden:index.bzl", "api_golden_test_npm_package")
 
 licenses(["notice"])
 

--- a/packages/ngtools/webpack/README.md
+++ b/packages/ngtools/webpack/README.md
@@ -3,7 +3,7 @@
 Webpack 5.x plugin for the Angular Ahead-of-Time compiler. The plugin also supports Angular JIT mode.
 When this plugin is used outside of the Angular CLI, the Ivy linker will also be needed to support
 the usage of Angular libraries. An example configuration of the Babel-based Ivy linker is provided
-in the linker section. For additional information regarding the linker, please see: https://v13.angular.io/guide/creating-libraries#consuming-partial-ivy-code-outside-the-angular-cli
+in the linker section. For additional information regarding the linker, please see: https://angular.dev/tools/libraries/creating-libraries#consuming-partial-ivy-code-outside-the-angular-cli
 
 ## Usage
 

--- a/packages/ngtools/webpack/src/benchmark.ts
+++ b/packages/ngtools/webpack/src/benchmark.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 // Internal benchmark reporting flag.

--- a/packages/ngtools/webpack/src/index.ts
+++ b/packages/ngtools/webpack/src/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 export {

--- a/packages/ngtools/webpack/src/ivy/cache.ts
+++ b/packages/ngtools/webpack/src/ivy/cache.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import * as ts from 'typescript';

--- a/packages/ngtools/webpack/src/ivy/diagnostics.ts
+++ b/packages/ngtools/webpack/src/ivy/diagnostics.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Diagnostic, DiagnosticCategory } from 'typescript';

--- a/packages/ngtools/webpack/src/ivy/host.ts
+++ b/packages/ngtools/webpack/src/ivy/host.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 /* eslint-disable @typescript-eslint/unbound-method */

--- a/packages/ngtools/webpack/src/ivy/index.ts
+++ b/packages/ngtools/webpack/src/ivy/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 export { angularWebpackLoader as default } from './loader';

--- a/packages/ngtools/webpack/src/ivy/loader.ts
+++ b/packages/ngtools/webpack/src/ivy/loader.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import * as path from 'path';

--- a/packages/ngtools/webpack/src/ivy/paths.ts
+++ b/packages/ngtools/webpack/src/ivy/paths.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import * as nodePath from 'path';

--- a/packages/ngtools/webpack/src/ivy/plugin.ts
+++ b/packages/ngtools/webpack/src/ivy/plugin.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type { CompilerHost, CompilerOptions, NgtscProgram } from '@angular/compiler-cli';

--- a/packages/ngtools/webpack/src/ivy/symbol.ts
+++ b/packages/ngtools/webpack/src/ivy/symbol.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 export const AngularPluginSymbol = Symbol.for('@ngtools/webpack[angular-compiler]');

--- a/packages/ngtools/webpack/src/ivy/system.ts
+++ b/packages/ngtools/webpack/src/ivy/system.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import * as ts from 'typescript';

--- a/packages/ngtools/webpack/src/ivy/transformation.ts
+++ b/packages/ngtools/webpack/src/ivy/transformation.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import * as ts from 'typescript';

--- a/packages/ngtools/webpack/src/loaders/inline-resource.ts
+++ b/packages/ngtools/webpack/src/loaders/inline-resource.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import type { Compilation, LoaderContext } from 'webpack';

--- a/packages/ngtools/webpack/src/paths-plugin.ts
+++ b/packages/ngtools/webpack/src/paths-plugin.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import * as path from 'path';

--- a/packages/ngtools/webpack/src/resource_loader.ts
+++ b/packages/ngtools/webpack/src/resource_loader.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import assert from 'node:assert';

--- a/packages/ngtools/webpack/src/transformers/elide_imports.ts
+++ b/packages/ngtools/webpack/src/transformers/elide_imports.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import * as ts from 'typescript';

--- a/packages/ngtools/webpack/src/transformers/elide_imports_spec.ts
+++ b/packages/ngtools/webpack/src/transformers/elide_imports_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 /* eslint-disable max-len */

--- a/packages/ngtools/webpack/src/transformers/find_image_domains.ts
+++ b/packages/ngtools/webpack/src/transformers/find_image_domains.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import * as ts from 'typescript';

--- a/packages/ngtools/webpack/src/transformers/find_image_domains_spec.ts
+++ b/packages/ngtools/webpack/src/transformers/find_image_domains_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { tags } from '@angular-devkit/core';

--- a/packages/ngtools/webpack/src/transformers/index.ts
+++ b/packages/ngtools/webpack/src/transformers/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 export * from './elide_imports';

--- a/packages/ngtools/webpack/src/transformers/remove-ivy-jit-support-calls.ts
+++ b/packages/ngtools/webpack/src/transformers/remove-ivy-jit-support-calls.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import * as ts from 'typescript';

--- a/packages/ngtools/webpack/src/transformers/remove-ivy-jit-support-calls_spec.ts
+++ b/packages/ngtools/webpack/src/transformers/remove-ivy-jit-support-calls_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 /* eslint-disable max-len */

--- a/packages/ngtools/webpack/src/transformers/replace_resources.ts
+++ b/packages/ngtools/webpack/src/transformers/replace_resources.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import * as ts from 'typescript';

--- a/packages/ngtools/webpack/src/transformers/replace_resources_spec.ts
+++ b/packages/ngtools/webpack/src/transformers/replace_resources_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { tags } from '@angular-devkit/core';

--- a/packages/ngtools/webpack/src/transformers/spec_helpers.ts
+++ b/packages/ngtools/webpack/src/transformers/spec_helpers.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { basename } from 'path';

--- a/packages/schematics/angular/BUILD.bazel
+++ b/packages/schematics/angular/BUILD.bazel
@@ -1,7 +1,7 @@
 # Copyright Google Inc. All Rights Reserved.
 #
 # Use of this source code is governed by an MIT-style license that can be
-# found in the LICENSE file at https://angular.io/license
+# found in the LICENSE file at https://angular.dev/license
 
 load("@npm//@bazel/jasmine:index.bzl", "jasmine_node_test")
 load("//tools:defaults.bzl", "pkg_npm", "ts_library")

--- a/packages/schematics/angular/BUILD.bazel
+++ b/packages/schematics/angular/BUILD.bazel
@@ -58,12 +58,13 @@ ts_library(
         "//packages/schematics/angular:" + src.replace(".json", ".ts")
         for (src, _) in ALL_SCHEMA_TARGETS
     ],
-    data = glob(
+    data = [
+        "collection.json",
+        "migrations/migration-collection.json",
+        "package.json",
+        "utility/latest-versions/package.json",
+    ] + glob(
         include = [
-            "collection.json",
-            "package.json",
-            "utility/latest-versions/package.json",
-            "migrations/migration-collection.json",
             "*/schema.json",
             "*/files/**/*",
             "*/other-files/**/*",

--- a/packages/schematics/angular/app-shell/index.ts
+++ b/packages/schematics/angular/app-shell/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {

--- a/packages/schematics/angular/app-shell/index_spec.ts
+++ b/packages/schematics/angular/app-shell/index_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { tags } from '@angular-devkit/core';

--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { JsonObject, join, normalize } from '@angular-devkit/core';

--- a/packages/schematics/angular/application/index_spec.ts
+++ b/packages/schematics/angular/application/index_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';

--- a/packages/schematics/angular/class/index.ts
+++ b/packages/schematics/angular/class/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Rule } from '@angular-devkit/schematics';

--- a/packages/schematics/angular/class/index_spec.ts
+++ b/packages/schematics/angular/class/index_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';

--- a/packages/schematics/angular/component/index.ts
+++ b/packages/schematics/angular/component/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {

--- a/packages/schematics/angular/component/index_spec.ts
+++ b/packages/schematics/angular/component/index_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';

--- a/packages/schematics/angular/config/index.ts
+++ b/packages/schematics/angular/config/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {

--- a/packages/schematics/angular/config/index_spec.ts
+++ b/packages/schematics/angular/config/index_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';

--- a/packages/schematics/angular/directive/index.ts
+++ b/packages/schematics/angular/directive/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {

--- a/packages/schematics/angular/directive/index_spec.ts
+++ b/packages/schematics/angular/directive/index_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';

--- a/packages/schematics/angular/e2e/index.ts
+++ b/packages/schematics/angular/e2e/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {

--- a/packages/schematics/angular/e2e/index_spec.ts
+++ b/packages/schematics/angular/e2e/index_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';

--- a/packages/schematics/angular/enum/index.ts
+++ b/packages/schematics/angular/enum/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Rule } from '@angular-devkit/schematics';

--- a/packages/schematics/angular/enum/index_spec.ts
+++ b/packages/schematics/angular/enum/index_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';

--- a/packages/schematics/angular/environments/index.ts
+++ b/packages/schematics/angular/environments/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Rule, SchematicsException, chain } from '@angular-devkit/schematics';

--- a/packages/schematics/angular/environments/index_spec.ts
+++ b/packages/schematics/angular/environments/index_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';

--- a/packages/schematics/angular/guard/index.ts
+++ b/packages/schematics/angular/guard/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Rule, SchematicsException } from '@angular-devkit/schematics';

--- a/packages/schematics/angular/guard/index_spec.ts
+++ b/packages/schematics/angular/guard/index_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';

--- a/packages/schematics/angular/interceptor/index.ts
+++ b/packages/schematics/angular/interceptor/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Rule } from '@angular-devkit/schematics';

--- a/packages/schematics/angular/interceptor/index_spec.ts
+++ b/packages/schematics/angular/interceptor/index_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';

--- a/packages/schematics/angular/interface/index.ts
+++ b/packages/schematics/angular/interface/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Rule } from '@angular-devkit/schematics';

--- a/packages/schematics/angular/interface/index_spec.ts
+++ b/packages/schematics/angular/interface/index_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';

--- a/packages/schematics/angular/library/index.ts
+++ b/packages/schematics/angular/library/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {

--- a/packages/schematics/angular/library/index_spec.ts
+++ b/packages/schematics/angular/library/index_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';

--- a/packages/schematics/angular/migrations/use-application-builder/css-import-lexer.ts
+++ b/packages/schematics/angular/migrations/use-application-builder/css-import-lexer.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 /**

--- a/packages/schematics/angular/migrations/use-application-builder/migration.ts
+++ b/packages/schematics/angular/migrations/use-application-builder/migration.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {

--- a/packages/schematics/angular/migrations/use-application-builder/migration_spec.ts
+++ b/packages/schematics/angular/migrations/use-application-builder/migration_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { EmptyTree } from '@angular-devkit/schematics';

--- a/packages/schematics/angular/module/index.ts
+++ b/packages/schematics/angular/module/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {

--- a/packages/schematics/angular/module/index_spec.ts
+++ b/packages/schematics/angular/module/index_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';

--- a/packages/schematics/angular/ng-new/index.ts
+++ b/packages/schematics/angular/ng-new/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {

--- a/packages/schematics/angular/ng-new/index_spec.ts
+++ b/packages/schematics/angular/ng-new/index_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { SchematicTestRunner } from '@angular-devkit/schematics/testing';

--- a/packages/schematics/angular/ng-new/schema.json
+++ b/packages/schematics/angular/ng-new/schema.json
@@ -119,7 +119,7 @@
       "default": false
     },
     "strict": {
-      "description": "Creates a workspace with stricter type checking and stricter bundle budgets settings. This setting helps improve maintainability and catch bugs ahead of time. For more information, see https://angular.io/guide/strict-mode",
+      "description": "Creates a workspace with stricter type checking and stricter bundle budgets settings. This setting helps improve maintainability and catch bugs ahead of time. For more information, see https://angular.dev/tools/cli/template-typecheck#strict-mode",
       "type": "boolean",
       "default": true
     },

--- a/packages/schematics/angular/no_typescript_runtime_dep_spec.js
+++ b/packages/schematics/angular/no_typescript_runtime_dep_spec.js
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 const fs = require('fs');

--- a/packages/schematics/angular/pipe/index.ts
+++ b/packages/schematics/angular/pipe/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {

--- a/packages/schematics/angular/pipe/index_spec.ts
+++ b/packages/schematics/angular/pipe/index_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';

--- a/packages/schematics/angular/resolver/index.ts
+++ b/packages/schematics/angular/resolver/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Rule } from '@angular-devkit/schematics';

--- a/packages/schematics/angular/resolver/index_spec.ts
+++ b/packages/schematics/angular/resolver/index_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';

--- a/packages/schematics/angular/server/index.ts
+++ b/packages/schematics/angular/server/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { JsonValue, Path, basename, dirname, join, normalize } from '@angular-devkit/core';

--- a/packages/schematics/angular/server/index_spec.ts
+++ b/packages/schematics/angular/server/index_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';

--- a/packages/schematics/angular/service-worker/index.ts
+++ b/packages/schematics/angular/service-worker/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { join, normalize, tags } from '@angular-devkit/core';

--- a/packages/schematics/angular/service-worker/index_spec.ts
+++ b/packages/schematics/angular/service-worker/index_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { tags } from '@angular-devkit/core';

--- a/packages/schematics/angular/service/index.ts
+++ b/packages/schematics/angular/service/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Rule } from '@angular-devkit/schematics';

--- a/packages/schematics/angular/service/index_spec.ts
+++ b/packages/schematics/angular/service/index_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';

--- a/packages/schematics/angular/ssr/index.ts
+++ b/packages/schematics/angular/ssr/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { isJsonObject, join, normalize, strings } from '@angular-devkit/core';

--- a/packages/schematics/angular/ssr/index_spec.ts
+++ b/packages/schematics/angular/ssr/index_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { tags } from '@angular-devkit/core';

--- a/packages/schematics/angular/utility/add-declaration-to-ng-module.ts
+++ b/packages/schematics/angular/utility/add-declaration-to-ng-module.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Rule, Tree, strings } from '@angular-devkit/schematics';

--- a/packages/schematics/angular/utility/ast-utils.ts
+++ b/packages/schematics/angular/utility/ast-utils.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { tags } from '@angular-devkit/core';

--- a/packages/schematics/angular/utility/ast-utils_spec.ts
+++ b/packages/schematics/angular/utility/ast-utils_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { tags } from '@angular-devkit/core';

--- a/packages/schematics/angular/utility/change.ts
+++ b/packages/schematics/angular/utility/change.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { UpdateRecorder } from '@angular-devkit/schematics';
@@ -47,7 +47,11 @@ export class InsertChange implements Change {
   order: number;
   description: string;
 
-  constructor(public path: string, public pos: number, public toAdd: string) {
+  constructor(
+    public path: string,
+    public pos: number,
+    public toAdd: string,
+  ) {
     if (pos < 0) {
       throw new Error('Negative positions are invalid');
     }
@@ -75,7 +79,11 @@ export class RemoveChange implements Change {
   order: number;
   description: string;
 
-  constructor(public path: string, private pos: number, public toRemove: string) {
+  constructor(
+    public path: string,
+    private pos: number,
+    public toRemove: string,
+  ) {
     if (pos < 0) {
       throw new Error('Negative positions are invalid');
     }

--- a/packages/schematics/angular/utility/dependencies.ts
+++ b/packages/schematics/angular/utility/dependencies.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Tree } from '@angular-devkit/schematics';

--- a/packages/schematics/angular/utility/dependencies_spec.ts
+++ b/packages/schematics/angular/utility/dependencies_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { EmptyTree } from '@angular-devkit/schematics';

--- a/packages/schematics/angular/utility/dependency.ts
+++ b/packages/schematics/angular/utility/dependency.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Rule, SchematicContext } from '@angular-devkit/schematics';

--- a/packages/schematics/angular/utility/dependency_spec.ts
+++ b/packages/schematics/angular/utility/dependency_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {

--- a/packages/schematics/angular/utility/eol.ts
+++ b/packages/schematics/angular/utility/eol.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { EOL } from 'node:os';

--- a/packages/schematics/angular/utility/find-module.ts
+++ b/packages/schematics/angular/utility/find-module.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { NormalizedRoot, Path, dirname, join, normalize, relative } from '@angular-devkit/core';

--- a/packages/schematics/angular/utility/find-module_spec.ts
+++ b/packages/schematics/angular/utility/find-module_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { EmptyTree, Tree } from '@angular-devkit/schematics';

--- a/packages/schematics/angular/utility/generate-from-files.ts
+++ b/packages/schematics/angular/utility/generate-from-files.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {

--- a/packages/schematics/angular/utility/index.ts
+++ b/packages/schematics/angular/utility/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 // Workspace related rules and types

--- a/packages/schematics/angular/utility/json-file.ts
+++ b/packages/schematics/angular/utility/json-file.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { JsonValue } from '@angular-devkit/core';

--- a/packages/schematics/angular/utility/latest-versions.ts
+++ b/packages/schematics/angular/utility/latest-versions.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 // We could have used TypeScripts' `resolveJsonModule` to make the `latestVersion` object typesafe,

--- a/packages/schematics/angular/utility/ng-ast-utils.ts
+++ b/packages/schematics/angular/utility/ng-ast-utils.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { SchematicsException, Tree } from '@angular-devkit/schematics';

--- a/packages/schematics/angular/utility/parse-name.ts
+++ b/packages/schematics/angular/utility/parse-name.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Path, basename, dirname, join, normalize } from '@angular-devkit/core';

--- a/packages/schematics/angular/utility/parse-name_spec.ts
+++ b/packages/schematics/angular/utility/parse-name_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { parseName } from './parse-name';

--- a/packages/schematics/angular/utility/paths.ts
+++ b/packages/schematics/angular/utility/paths.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { join, relative } from 'node:path/posix';

--- a/packages/schematics/angular/utility/paths_spec.ts
+++ b/packages/schematics/angular/utility/paths_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { relativePathToWorkspaceRoot } from './paths';

--- a/packages/schematics/angular/utility/project-targets.ts
+++ b/packages/schematics/angular/utility/project-targets.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { SchematicsException } from '@angular-devkit/schematics';

--- a/packages/schematics/angular/utility/standalone/app_config.ts
+++ b/packages/schematics/angular/utility/standalone/app_config.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Tree } from '@angular-devkit/schematics';

--- a/packages/schematics/angular/utility/standalone/code_block.ts
+++ b/packages/schematics/angular/utility/standalone/code_block.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Rule, Tree } from '@angular-devkit/schematics';

--- a/packages/schematics/angular/utility/standalone/index.ts
+++ b/packages/schematics/angular/utility/standalone/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 export { addRootImport, addRootProvider } from './rules';

--- a/packages/schematics/angular/utility/standalone/rules.ts
+++ b/packages/schematics/angular/utility/standalone/rules.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { tags } from '@angular-devkit/core';

--- a/packages/schematics/angular/utility/standalone/rules_spec.ts
+++ b/packages/schematics/angular/utility/standalone/rules_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Rule, SchematicContext, Tree, callRule } from '@angular-devkit/schematics';

--- a/packages/schematics/angular/utility/standalone/util.ts
+++ b/packages/schematics/angular/utility/standalone/util.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { SchematicsException, Tree } from '@angular-devkit/schematics';

--- a/packages/schematics/angular/utility/test/create-app-module.ts
+++ b/packages/schematics/angular/utility/test/create-app-module.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { UnitTestTree } from '@angular-devkit/schematics/testing';

--- a/packages/schematics/angular/utility/test/get-file-content.ts
+++ b/packages/schematics/angular/utility/test/get-file-content.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Tree } from '@angular-devkit/schematics';

--- a/packages/schematics/angular/utility/test/index.ts
+++ b/packages/schematics/angular/utility/test/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 export * from './create-app-module';

--- a/packages/schematics/angular/utility/validation.ts
+++ b/packages/schematics/angular/utility/validation.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { SchematicsException } from '@angular-devkit/schematics';

--- a/packages/schematics/angular/utility/workspace-models.ts
+++ b/packages/schematics/angular/utility/workspace-models.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 export enum ProjectType {

--- a/packages/schematics/angular/utility/workspace.ts
+++ b/packages/schematics/angular/utility/workspace.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { json, workspaces } from '@angular-devkit/core';

--- a/packages/schematics/angular/utility/workspace_spec.ts
+++ b/packages/schematics/angular/utility/workspace_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { EmptyTree, Rule, SchematicContext, Tree, callRule } from '@angular-devkit/schematics';

--- a/packages/schematics/angular/web-worker/index.ts
+++ b/packages/schematics/angular/web-worker/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { join, normalize, tags } from '@angular-devkit/core';

--- a/packages/schematics/angular/web-worker/index_spec.ts
+++ b/packages/schematics/angular/web-worker/index_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';

--- a/packages/schematics/angular/workspace/index.ts
+++ b/packages/schematics/angular/workspace/index.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import {

--- a/packages/schematics/angular/workspace/index_spec.ts
+++ b/packages/schematics/angular/workspace/index_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { SchematicTestRunner } from '@angular-devkit/schematics/testing';

--- a/packages/schematics/angular/workspace/schema.json
+++ b/packages/schematics/angular/workspace/schema.json
@@ -33,7 +33,7 @@
       "default": false
     },
     "strict": {
-      "description": "Create a workspace with stricter type checking options. This setting helps improve maintainability and catch bugs ahead of time. For more information, see https://angular.io/strict",
+      "description": "Create a workspace with stricter type checking options. This setting helps improve maintainability and catch bugs ahead of time. For more information, see https://angular.dev/tools/cli/template-typecheck#strict-mode",
       "type": "boolean",
       "default": true
     },

--- a/scripts/build-packages-dist.mts
+++ b/scripts/build-packages-dist.mts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 /**

--- a/scripts/build-schema.mts
+++ b/scripts/build-schema.mts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { spawn } from 'node:child_process';

--- a/scripts/build.mts
+++ b/scripts/build.mts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { spawn } from 'node:child_process';

--- a/scripts/circular-deps-test.conf.mjs
+++ b/scripts/circular-deps-test.conf.mjs
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { statSync } from 'node:fs';

--- a/scripts/create.mts
+++ b/scripts/create.mts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import assert from 'node:assert';

--- a/scripts/devkit-admin.mts
+++ b/scripts/devkit-admin.mts
@@ -4,7 +4,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import colors from 'ansi-colors';

--- a/scripts/json-help.mts
+++ b/scripts/json-help.mts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { spawnSync } from 'child_process';

--- a/scripts/packages.mts
+++ b/scripts/packages.mts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import fastGlob from 'fast-glob';

--- a/scripts/release-checks/dependency-ranges/index.mts
+++ b/scripts/release-checks/dependency-ranges/index.mts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { Log, ReleasePrecheckError, bold } from '@angular/ng-dev';

--- a/scripts/release-checks/dependency-ranges/latest-versions-check.mts
+++ b/scripts/release-checks/dependency-ranges/latest-versions-check.mts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { readFile } from 'node:fs/promises';

--- a/scripts/release-checks/dependency-ranges/peer-deps-check.mts
+++ b/scripts/release-checks/dependency-ranges/peer-deps-check.mts
@@ -3,13 +3,12 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import semver from 'semver';
 
 /** Path to the current directory. */
-
 
 /** Describes a parsed `package.json` file. */
 export interface PackageJson {

--- a/scripts/snapshots.mts
+++ b/scripts/snapshots.mts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { execSync, spawnSync } from 'node:child_process';
@@ -161,7 +161,7 @@ export default async function (opts: SnapshotsOptions) {
 
   if (githubToken) {
     console.info('Setting up global git name.');
-    _exec('git', ['config', '--global', 'user.email', 'circleci@angular.io'], {});
+    _exec('git', ['config', '--global', 'user.email', 'circleci@angular.dev'], {});
     _exec('git', ['config', '--global', 'user.name', 'Angular Builds'], {});
     _exec('git', ['config', '--global', 'push.default', 'simple'], {});
   }

--- a/scripts/templates.mts
+++ b/scripts/templates.mts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import lodash from 'lodash';

--- a/scripts/templates/readme.ejs
+++ b/scripts/templates/readme.ejs
@@ -31,7 +31,7 @@
   ·
   <a href="https://github.com/angular/angular-cli/issues">Submit an Issue</a>
   ·
-  <a href="https://blog.angular.dev/">Blog</a>
+  <a href="https://blog.angular.dev">Blog</a>
   <br>
   <br>
 </p>

--- a/scripts/validate-user-analytics.mts
+++ b/scripts/validate-user-analytics.mts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import assert from 'assert';

--- a/scripts/validate.mts
+++ b/scripts/validate.mts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { execSync } from 'child_process';

--- a/tests/angular_devkit/architect/node/jobs/BUILD.bazel
+++ b/tests/angular_devkit/architect/node/jobs/BUILD.bazel
@@ -3,7 +3,7 @@ load("//tools:defaults.bzl", "ts_library")
 # Copyright Google Inc. All Rights Reserved.
 #
 # Use of this source code is governed by an MIT-style license that can be
-# found in the LICENSE file at https://angular.io/license
+# found in the LICENSE file at https://angular.dev/license
 package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])

--- a/tests/angular_devkit/architect/node/jobs/add.ts
+++ b/tests/angular_devkit/architect/node/jobs/add.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { jobs } from '@angular-devkit/architect';

--- a/tests/angular_devkit/core/json/schema/serializers/0.0.javascript_spec.ts
+++ b/tests/angular_devkit/core/json/schema/serializers/0.0.javascript_spec.ts
@@ -3,14 +3,13 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 // tslint:disable:no-any
 import { schema } from '@angular-devkit/core';
 
 const { serializers } = schema;
-
 
 export function works(registry: schema.JsonSchemaRegistry, schema: any) {
   const value = {
@@ -21,7 +20,7 @@ export function works(registry: schema.JsonSchemaRegistry, schema: any) {
 
   registry.addSchema('', schema);
 
-  const v = (new serializers.JavascriptSerializer()).serialize('', registry)(value);
+  const v = new serializers.JavascriptSerializer().serialize('', registry)(value);
 
   expect(v.firstName).toBe('Hans');
   expect(v.lastName).toBe('Larsen');
@@ -30,13 +29,13 @@ export function works(registry: schema.JsonSchemaRegistry, schema: any) {
   v.age = 10;
   expect(v.age).toBe(10);
 
-  expect(() => v.age = -1).toThrow();
-  expect(() => v.age = 'hello').toThrow();
-  expect(() => v.age = []).toThrow();
-  expect(() => v.age = undefined).not.toThrow();
+  expect(() => (v.age = -1)).toThrow();
+  expect(() => (v.age = 'hello')).toThrow();
+  expect(() => (v.age = [])).toThrow();
+  expect(() => (v.age = undefined)).not.toThrow();
 
-  expect(() => v.firstName = 0).toThrow();
-  expect(() => v.firstName = []).toThrow();
+  expect(() => (v.firstName = 0)).toThrow();
+  expect(() => (v.firstName = [])).toThrow();
   // This should throw as the value is required.
-  expect(() => v.firstName = undefined).toThrow();
+  expect(() => (v.firstName = undefined)).toThrow();
 }

--- a/tests/angular_devkit/core/json/schema/serializers/1.0.javascript_spec.ts
+++ b/tests/angular_devkit/core/json/schema/serializers/1.0.javascript_spec.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 // tslint:disable:no-any
@@ -11,14 +11,13 @@ import { schema } from '@angular-devkit/core';
 
 const { serializers } = schema;
 
-
 export function works(registry: schema.JsonSchemaRegistry, schema: any) {
   const value = {
     'requiredKey': 1,
   };
 
   registry.addSchema('', schema);
-  const v = (new serializers.JavascriptSerializer()).serialize('', registry)(value);
+  const v = new serializers.JavascriptSerializer().serialize('', registry)(value);
 
   expect(v.requiredKey).toBe(1);
   expect(() => delete v.requiredKey).toThrow();
@@ -40,16 +39,18 @@ export function works(registry: schema.JsonSchemaRegistry, schema: any) {
   expect(Object.keys(v.objectKey1)).toEqual(['stringKey', 'stringKeyDefault', 'objectKey']);
 }
 
-
 export function accessUndefined(registry: schema.JsonSchemaRegistry, schema: any) {
   const value = {
     'requiredKey': 1,
   };
 
   registry.addSchema('', schema);
-  const v = (new serializers.JavascriptSerializer({
+  const v = new serializers.JavascriptSerializer({
     allowAccessUndefinedObjects: true,
-  })).serialize('', registry)(value);
+  }).serialize(
+    '',
+    registry,
+  )(value);
 
   // Access an undefined property.
   v.objectKey1.stringKey = 'hello';

--- a/tests/angular_devkit/schematics/tools/file-system-engine-host/BUILD.bazel
+++ b/tests/angular_devkit/schematics/tools/file-system-engine-host/BUILD.bazel
@@ -3,7 +3,7 @@ load("//tools:defaults.bzl", "ts_library")
 # Copyright Google Inc. All Rights Reserved.
 #
 # Use of this source code is governed by an MIT-style license that can be
-# found in the LICENSE file at https://angular.io/license
+# found in the LICENSE file at https://angular.dev/license
 package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])

--- a/tests/angular_devkit/schematics/tools/file-system-engine-host/extra-properties/factory.ts
+++ b/tests/angular_devkit/schematics/tools/file-system-engine-host/extra-properties/factory.ts
@@ -3,18 +3,18 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 // tslint:disable-next-line:no-implicit-dependencies
 import { SchematicContext, Tree } from '@angular-devkit/schematics';
 
-export default function(options: {}) {
+export default function (options: {}) {
   return (tree: Tree, context: SchematicContext) => {
     // We pass information back to the test.
     tree.create(
-      (context.schematic.description as any).extra,  // tslint:disable-line:no-any
-      (context.schematic.collection.description as any).extra,  // tslint:disable-line:no-any
+      (context.schematic.description as any).extra, // tslint:disable-line:no-any
+      (context.schematic.collection.description as any).extra, // tslint:disable-line:no-any
     );
   };
 }

--- a/tests/angular_devkit/schematics/tools/file-system-engine-host/file-tasks/factory.ts
+++ b/tests/angular_devkit/schematics/tools/file-system-engine-host/file-tasks/factory.ts
@@ -3,13 +3,13 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 // tslint:disable-next-line:no-implicit-dependencies
 import { SchematicContext, Tree } from '@angular-devkit/schematics';
 
-export default function() {
+export default function () {
   return (_: Tree, context: SchematicContext) => {
     context.addTask({
       toConfiguration() {

--- a/tests/angular_devkit/schematics/tools/file-system-engine-host/null-factory.ts
+++ b/tests/angular_devkit/schematics/tools/file-system-engine-host/null-factory.ts
@@ -3,8 +3,8 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
-export default function() {
+export default function () {
   return () => {};
 }

--- a/tests/legacy-cli/e2e/assets/15.0-project/README.md
+++ b/tests/legacy-cli/e2e/assets/15.0-project/README.md
@@ -24,4 +24,4 @@ Run `ng e2e` to execute the end-to-end tests via a platform of your choice. To u
 
 ## Further help
 
-To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI Overview and Command Reference](https://angular.io/cli) page.
+To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI Overview](https://angular.dev/tools/cli) and [Command Reference](https://angular.dev/cli) pages.

--- a/tests/legacy-cli/e2e/assets/15.0-project/src/app/app.component.html
+++ b/tests/legacy-cli/e2e/assets/15.0-project/src/app/app.component.html
@@ -355,12 +355,12 @@
   <p>Here are some links to help you get started:</p>
 
   <div class="card-container">
-    <a class="card" target="_blank" rel="noopener" href="https://angular.io/tutorial">
+    <a class="card" target="_blank" rel="noopener" href="https://angular.dev/tutorials/learn-angular">
       <svg class="material-icons" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"/></svg>
       <span>Learn Angular</span>
       <svg class="material-icons" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"/></svg>    </a>
 
-    <a class="card" target="_blank" rel="noopener" href="https://angular.io/cli">
+    <a class="card" target="_blank" rel="noopener" href="https://angular.dev/tools/cli">
       <svg class="material-icons" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M9.4 16.6L4.8 12l4.6-4.6L8 6l-6 6 6 6 1.4-1.4zm5.2 0l4.6-4.6-4.6-4.6L16 6l6 6-6 6-1.4-1.4z"/></svg>
       <span>CLI Documentation</span>
       <svg class="material-icons" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"/></svg>
@@ -372,13 +372,13 @@
       <svg class="material-icons" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"/></svg>
     </a>
 
-    <a class="card" target="_blank" rel="noopener" href="https://blog.angular.io/">
+    <a class="card" target="_blank" rel="noopener" href="https://blog.angular.dev">
       <svg class="material-icons" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M13.5.67s.74 2.65.74 4.8c0 2.06-1.35 3.73-3.41 3.73-2.07 0-3.63-1.67-3.63-3.73l.03-.36C5.21 7.51 4 10.62 4 14c0 4.42 3.58 8 8 8s8-3.58 8-8C20 8.61 17.41 3.8 13.5.67zM11.71 19c-1.78 0-3.22-1.4-3.22-3.14 0-1.62 1.05-2.76 2.81-3.12 1.77-.36 3.6-1.21 4.62-2.58.39 1.29.59 2.65.59 4.04 0 2.65-2.15 4.8-4.8 4.8z"/></svg>
       <span>Angular Blog</span>
       <svg class="material-icons" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"/></svg>
     </a>
 
-    <a class="card" target="_blank" rel="noopener" href="https://angular.io/devtools/">
+    <a class="card" target="_blank" rel="noopener" href="https://angular.dev/tools/devtools">
       <svg class="material-icons" xmlns="http://www.w3.org/2000/svg" enable-background="new 0 0 24 24" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><g><rect fill="none" height="24" width="24"/></g><g><g><path d="M14.73,13.31C15.52,12.24,16,10.93,16,9.5C16,5.91,13.09,3,9.5,3S3,5.91,3,9.5C3,13.09,5.91,16,9.5,16 c1.43,0,2.74-0.48,3.81-1.27L19.59,21L21,19.59L14.73,13.31z M9.5,14C7.01,14,5,11.99,5,9.5S7.01,5,9.5,5S14,7.01,14,9.5 S11.99,14,9.5,14z"/><polygon points="10.29,8.44 9.5,6 8.71,8.44 6.25,8.44 8.26,10.03 7.49,12.5 9.5,10.97 11.51,12.5 10.74,10.03 12.75,8.44"/></g></g></svg>
       <span>Angular DevTools</span>
       <svg class="material-icons" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"/></svg>

--- a/tests/legacy-cli/e2e/assets/18-ssr-project-webpack/README.md
+++ b/tests/legacy-cli/e2e/assets/18-ssr-project-webpack/README.md
@@ -24,4 +24,4 @@ Run `ng e2e` to execute the end-to-end tests via a platform of your choice. To u
 
 ## Further help
 
-To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI Overview and Command Reference](https://angular.io/cli) page.
+To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI Overview](https://angular.dev/tools/cli) and [Command Reference](https://angular.dev/cli) pages.

--- a/tests/legacy-cli/e2e/assets/18-ssr-project-webpack/src/app/app.component.html
+++ b/tests/legacy-cli/e2e/assets/18-ssr-project-webpack/src/app/app.component.html
@@ -354,12 +354,12 @@
   <p>Here are some links to help you get started:</p>
 
   <div class="card-container">
-    <a class="card" target="_blank" rel="noopener" href="https://angular.io/tutorial">
+    <a class="card" target="_blank" rel="noopener" href="https://angular.dev/tutorials/learn-angular">
       <svg class="material-icons" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"/></svg>
       <span>Learn Angular</span>
       <svg class="material-icons" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"/></svg>    </a>
 
-    <a class="card" target="_blank" rel="noopener" href="https://angular.io/cli">
+    <a class="card" target="_blank" rel="noopener" href="https://angular.dev/tools/cli">
       <svg class="material-icons" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M9.4 16.6L4.8 12l4.6-4.6L8 6l-6 6 6 6 1.4-1.4zm5.2 0l4.6-4.6-4.6-4.6L16 6l6 6-6 6-1.4-1.4z"/></svg>
       <span>CLI Documentation</span>
       <svg class="material-icons" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"/></svg>
@@ -371,13 +371,13 @@
       <svg class="material-icons" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"/></svg>
     </a>
 
-    <a class="card" target="_blank" rel="noopener" href="https://blog.angular.io/">
+    <a class="card" target="_blank" rel="noopener" href="https://blog.angular.dev">
       <svg class="material-icons" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M13.5.67s.74 2.65.74 4.8c0 2.06-1.35 3.73-3.41 3.73-2.07 0-3.63-1.67-3.63-3.73l.03-.36C5.21 7.51 4 10.62 4 14c0 4.42 3.58 8 8 8s8-3.58 8-8C20 8.61 17.41 3.8 13.5.67zM11.71 19c-1.78 0-3.22-1.4-3.22-3.14 0-1.62 1.05-2.76 2.81-3.12 1.77-.36 3.6-1.21 4.62-2.58.39 1.29.59 2.65.59 4.04 0 2.65-2.15 4.8-4.8 4.8z"/></svg>
       <span>Angular Blog</span>
       <svg class="material-icons" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"/></svg>
     </a>
 
-    <a class="card" target="_blank" rel="noopener" href="https://angular.io/devtools/">
+    <a class="card" target="_blank" rel="noopener" href="https://angular.dev/tools/devtools">
       <svg class="material-icons" xmlns="http://www.w3.org/2000/svg" enable-background="new 0 0 24 24" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><g><rect fill="none" height="24" width="24"/></g><g><g><path d="M14.73,13.31C15.52,12.24,16,10.93,16,9.5C16,5.91,13.09,3,9.5,3S3,5.91,3,9.5C3,13.09,5.91,16,9.5,16 c1.43,0,2.74-0.48,3.81-1.27L19.59,21L21,19.59L14.73,13.31z M9.5,14C7.01,14,5,11.99,5,9.5S7.01,5,9.5,5S14,7.01,14,9.5 S11.99,14,9.5,14z"/><polygon points="10.29,8.44 9.5,6 8.71,8.44 6.25,8.44 8.26,10.03 7.49,12.5 9.5,10.97 11.51,12.5 10.74,10.03 12.75,8.44"/></g></g></svg>
       <span>Angular DevTools</span>
       <svg class="material-icons" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"/></svg>

--- a/tests/legacy-cli/e2e/tests/basic/standalone.ts
+++ b/tests/legacy-cli/e2e/tests/basic/standalone.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  *
  * @fileoverview
  * Tests the minimal conversion of a newly generated application

--- a/tests/legacy-cli/e2e/tests/build/bundle-budgets.ts
+++ b/tests/legacy-cli/e2e/tests/build/bundle-budgets.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 import { ng } from '../../utils/process';
 import { updateJsonFile } from '../../utils/project';

--- a/tests/legacy-cli/e2e/tests/build/lazy-load-syntax.ts
+++ b/tests/legacy-cli/e2e/tests/build/lazy-load-syntax.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 import { setTimeout } from 'node:timers/promises';
 import { replaceInFile, writeFile } from '../../utils/fs';

--- a/tests/legacy-cli/e2e/tests/build/library-with-demo-app.ts
+++ b/tests/legacy-cli/e2e/tests/build/library-with-demo-app.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { appendToFile, createDir, writeFile } from '../../utils/fs';

--- a/tests/legacy-cli/e2e/tests/build/worker.ts
+++ b/tests/legacy-cli/e2e/tests/build/worker.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { readdir } from 'fs/promises';

--- a/tests/legacy-cli/e2e/tests/i18n/ivy-localize-basehref-absolute.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/ivy-localize-basehref-absolute.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { expectFileToMatch } from '../../utils/fs';

--- a/tests/legacy-cli/e2e/tests/i18n/ivy-localize-basehref.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/ivy-localize-basehref.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { expectFileToMatch } from '../../utils/fs';

--- a/tests/legacy-cli/e2e/tests/i18n/ivy-localize-hashes.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/ivy-localize-hashes.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import * as fs from 'fs';

--- a/tests/legacy-cli/e2e/tests/i18n/ivy-localize-locale-data.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/ivy-localize-locale-data.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { ng } from '../../utils/process';

--- a/tests/legacy-cli/e2e/tests/i18n/ivy-localize-merging.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/ivy-localize-merging.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { ng } from '../../utils/process';

--- a/tests/legacy-cli/e2e/tests/i18n/ivy-localize-sourcelocale.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/ivy-localize-sourcelocale.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { getGlobalVariable } from '../../utils/env';

--- a/tests/legacy-cli/e2e/tests/misc/http-headers.ts
+++ b/tests/legacy-cli/e2e/tests/misc/http-headers.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { ng } from '../../utils/process';

--- a/tests/legacy-cli/e2e/tests/misc/trusted-types.ts
+++ b/tests/legacy-cli/e2e/tests/misc/trusted-types.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import { appendToFile, prependToFile, replaceInFile, writeFile } from '../../utils/fs';

--- a/tests/legacy-cli/e2e/utils/tar.ts
+++ b/tests/legacy-cli/e2e/utils/tar.ts
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 import fs from 'fs';

--- a/tests/schematics/update/packages/update-migrations/v1_5.js
+++ b/tests/schematics/update/packages/update-migrations/v1_5.js
@@ -3,11 +3,11 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
-exports.default = function() {
-    return function(tree) {
-        tree.create('/version1_5', '');
-    };
+exports.default = function () {
+  return function (tree) {
+    tree.create('/version1_5', '');
+  };
 };

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -1,7 +1,7 @@
 # Copyright Google Inc. All Rights Reserved.
 #
 # Use of this source code is governed by an MIT-style license that can be
-# found in the LICENSE file at https://angular.io/license
+# found in the LICENSE file at https://angular.dev/license
 # @external_begin
 load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
 

--- a/tools/link_package_json_to_tarballs.bzl
+++ b/tools/link_package_json_to_tarballs.bzl
@@ -1,7 +1,7 @@
 # Copyright Google Inc. All Rights Reserved.
 #
 # Use of this source code is governed by an MIT-style license that can be
-# found in the LICENSE file at https://angular.io/license
+# found in the LICENSE file at https://angular.dev/license
 load("@aspect_bazel_lib//lib:jq.bzl", "jq")
 load("@aspect_bazel_lib//lib:utils.bzl", "to_label")
 

--- a/tools/ng_cli_schema_generator.bzl
+++ b/tools/ng_cli_schema_generator.bzl
@@ -1,7 +1,7 @@
 # Copyright Google Inc. All Rights Reserved.
 #
 # Use of this source code is governed by an MIT-style license that can be
-# found in the LICENSE file at https://angular.io/license
+# found in the LICENSE file at https://angular.dev/license
 
 def _cli_json_schema_interface_impl(ctx):
     args = [

--- a/tools/ng_cli_schema_generator.js
+++ b/tools/ng_cli_schema_generator.js
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 const { readFileSync, writeFileSync, mkdirSync } = require('fs');

--- a/tools/package_json_release_filter.jq
+++ b/tools/package_json_release_filter.jq
@@ -1,7 +1,7 @@
 # Copyright Google Inc. All Rights Reserved.
 #
 # Use of this source code is governed by an MIT-style license that can be
-# found in the LICENSE file at https://angular.io/license
+# found in the LICENSE file at https://angular.dev/license
 #
 # This filter combines a subproject package.json with the root package.json
 # and performs substitutions to prepare it for release. It should be called

--- a/tools/quicktype_runner.js
+++ b/tools/quicktype_runner.js
@@ -3,7 +3,7 @@
  * Copyright Google LLC All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
+ * found in the LICENSE file at https://angular.dev/license
  */
 
 const fs = require('fs');

--- a/tools/snapshot_repo_filter.bzl
+++ b/tools/snapshot_repo_filter.bzl
@@ -1,7 +1,7 @@
 # Copyright Google Inc. All Rights Reserved.
 #
 # Use of this source code is governed by an MIT-style license that can be
-# found in the LICENSE file at https://angular.io/license
+# found in the LICENSE file at https://angular.dev/license
 
 load("//:constants.bzl", "SNAPSHOT_REPOS")
 

--- a/tools/ts_json_schema.bzl
+++ b/tools/ts_json_schema.bzl
@@ -1,7 +1,7 @@
 # Copyright Google Inc. All Rights Reserved.
 #
 # Use of this source code is governed by an MIT-style license that can be
-# found in the LICENSE file at https://angular.io/license
+# found in the LICENSE file at https://angular.dev/license
 
 def _ts_json_schema_interface_impl(ctx):
     args = [


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Various links throughout the codebase are still referencing angular.io 

Issue Number: N/A

## What is the new behavior?

Updated as many links as possible to point to the new locations on angular.dev. Specifically the following items were addressed:
- Update various guide and misc angular.io links
- Update all tutorial links
- Update all schematics links
- Update all security links
- Update all workspace config links
- Update all docs links
- Update all quick start links
- Update all blog links
- Update all cli links
- Update all optimization configuration links
- Update all browser support links
- Update all license file links

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
A few links could not be updated for the following reasons:

- `material.angular.io` these still appear to be valid for now
- `angular.io/config/tsconfig` there does not appear to be an equivalent resource on the angular.dev site