### PR TITLE
     fix(@angular/build): address prerendering in-memory ESM resolution in Node.js 22.2.0 and later

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -95,15 +95,15 @@ nodejs_register_toolchains(
     name = "node22",
     # The below can be removed once @rules_nodejs/nodejs is updated to latest which contains https://github.com/bazelbuild/rules_nodejs/pull/3701
     node_repositories = {
-        "22.0.0-darwin_arm64": ("node-v22.0.0-darwin-arm64.tar.gz", "node-v22.0.0-darwin-arm64", "ea96d349cfaa67aa87ceeaa3e5b52c9167f7ac302fd8d1ff162d0785e9dc0785"),
-        "22.0.0-darwin_amd64": ("node-v22.0.0-darwin-x64.tar.gz", "node-v22.0.0-darwin-x64", "422a3887ff5418f0a4552d89cf99346ab8ab51bb5d384660baa88b8444d2c111"),
-        "22.0.0-linux_arm64": ("node-v22.0.0-linux-arm64.tar.xz", "node-v22.0.0-linux-arm64", "83711d29cbe46375bdffab5419f3d831892e24294169272f6c39edc364556241"),
-        "22.0.0-linux_ppc64le": ("node-v22.0.0-linux-ppc64le.tar.xz", "node-v22.0.0-linux-ppc64le", "2b3fb8707a79243bfb3131312b86716ddc3855bce21bb168095b6b916798e5e9"),
-        "22.0.0-linux_s390x": ("node-v22.0.0-linux-s390x.tar.xz", "node-v22.0.0-linux-s390x", "89a8efeeb9f94ce9ea251b8109e079c14919f4c0dc2cbc9f545ec47ef0886737"),
-        "22.0.0-linux_amd64": ("node-v22.0.0-linux-x64.tar.xz", "node-v22.0.0-linux-x64", "9122e50f2642afd5f6078cafd1f52ede60fc464284384f05c18a04d13d07ae5a"),
-        "22.0.0-windows_amd64": ("node-v22.0.0-win-x64.zip", "node-v22.0.0-win-x64", "32d639b47d4c0a651ff8f8d7d41a454168a3d4045be37985f9a810cf8cef6174"),
+        "22.2.0-darwin_arm64": ("node-v22.2.0-darwin-arm64.tar.gz", "node-v22.2.0-darwin-arm64", "66dd98bd28d19603f2e5ab0aa0e07b64f8cad28bbc446bb44fb61cc3da62e685"),
+        "22.2.0-darwin_amd64": ("node-v22.2.0-darwin-x64.tar.gz", "node-v22.2.0-darwin-x64", "b3cd4ab4bb4ac7f9bd5c7603baf6bbdcf466c86bb6ca49abf5e221ab8fad7ceb"),
+        "22.2.0-linux_arm64": ("node-v22.2.0-linux-arm64.tar.xz", "node-v22.2.0-linux-arm64", "e3d580cb7738dd9a0f8672f684de86b621d8755a6cf349df8c01b8dd875b59ab"),
+        "22.2.0-linux_ppc64le": ("node-v22.2.0-linux-ppc64le.tar.xz", "node-v22.2.0-linux-ppc64le", "235dc30116f378d1ec326b49ad0ea08c3d84cc057238749e7ada6bb4307b1186"),
+        "22.2.0-linux_s390x": ("node-v22.2.0-linux-s390x.tar.xz", "node-v22.2.0-linux-s390x", "cb3cce70aeb29072aad450fd0b09130d34a36e38ad689f3bc4a6d72caade281f"),
+        "22.2.0-linux_amd64": ("node-v22.2.0-linux-x64.tar.xz", "node-v22.2.0-linux-x64", "3544eee9cb1414d6e9003efd56bc807ffb0f4445d2fc383e1df04c3e5e72c91b"),
+        "22.2.0-windows_amd64": ("node-v22.2.0-win-x64.zip", "node-v22.2.0-win-x64", "f83e956bd90c7f5066a7e96e9372839fcc263795525fa0c03cfdf4b43be9457f"),
     },
-    node_version = "22.0.0",
+    node_version = "22.2.0",
 )
 
 load("@build_bazel_rules_nodejs//:index.bzl", "yarn_install")

--- a/goldens/circular-deps/packages.json
+++ b/goldens/circular-deps/packages.json
@@ -17,6 +17,10 @@
     "packages/angular/build/src/tools/esbuild/utils.ts"
   ],
   [
+    "packages/angular/build/src/utils/server-rendering/prerender-child-process.ts",
+    "packages/angular/build/src/utils/server-rendering/prerender.ts"
+  ],
+  [
     "packages/angular/cli/src/analytics/analytics-collector.ts",
     "packages/angular/cli/src/command-builder/command-module.ts"
   ],

--- a/packages/angular/build/src/builders/application/execute-post-bundle.ts
+++ b/packages/angular/build/src/builders/application/execute-post-bundle.ts
@@ -126,7 +126,7 @@ export async function executePostBundleSteps(
 
     allErrors.push(...errors);
     allWarnings.push(...warnings);
-    prerenderedRoutes.push(...Array.from(generatedRoutes));
+    prerenderedRoutes.push(...generatedRoutes);
 
     for (const [path, content] of Object.entries(output)) {
       additionalHtmlOutputFiles.set(

--- a/packages/angular/build/src/utils/server-rendering/esm-in-memory-loader/register-hooks.ts
+++ b/packages/angular/build/src/utils/server-rendering/esm-in-memory-loader/register-hooks.ts
@@ -8,6 +8,26 @@
 
 import { register } from 'node:module';
 import { pathToFileURL } from 'node:url';
-import { workerData } from 'node:worker_threads';
+import { MessageChannel, workerData } from 'node:worker_threads';
+import { isLegacyESMLoaderImplementation } from './utils-lts-node';
 
-register('./loader-hooks.js', { parentURL: pathToFileURL(__filename), data: workerData });
+if (isLegacyESMLoaderImplementation && workerData) {
+  /** TODO: Remove when Node.js versions < 22.2 are no longer supported. */
+  register('./loader-hooks.js', {
+    parentURL: pathToFileURL(__filename),
+    data: workerData,
+  });
+} else {
+  const { port1, port2 } = new MessageChannel();
+
+  process.once('message', (msg) => {
+    port1.postMessage(msg);
+    port1.close();
+  });
+
+  register('./loader-hooks.js', {
+    parentURL: pathToFileURL(__filename),
+    data: { port: port2 },
+    transferList: [port2],
+  });
+}

--- a/packages/angular/build/src/utils/server-rendering/esm-in-memory-loader/utils-lts-node.ts
+++ b/packages/angular/build/src/utils/server-rendering/esm-in-memory-loader/utils-lts-node.ts
@@ -1,0 +1,12 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { lt } from 'semver';
+
+/** TODO: Remove when Node.js versions < 22.2 are no longer supported. */
+export const isLegacyESMLoaderImplementation = lt(process.version, '22.2.0');

--- a/packages/angular/build/src/utils/server-rendering/prerender-child-process.ts
+++ b/packages/angular/build/src/utils/server-rendering/prerender-child-process.ts
@@ -1,0 +1,348 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { readFile } from 'node:fs/promises';
+import { join, posix } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import Piscina from 'piscina';
+import { BuildOutputAsset } from '../../tools/esbuild/bundler-execution-result';
+import { isLegacyESMLoaderImplementation } from './esm-in-memory-loader/utils-lts-node';
+import { AppShellOptions, PrerenderOptions } from './prerender';
+import type { RenderResult, ServerContext } from './render-page';
+import type { RenderWorkerData } from './render-worker';
+import type {
+  RoutersExtractorWorkerResult,
+  RoutesExtractorWorkerData,
+} from './routes-extractor-worker';
+
+export interface ReadyMessage {
+  type: 'ready';
+  data: {
+    output: Record<string, string>;
+    warnings: string[];
+    errors: string[];
+    prerenderedRoutes: string[];
+  };
+}
+
+export interface ErrorMessage {
+  type: 'error';
+  data: {
+    name: string;
+    message: string;
+    stack: string;
+  };
+}
+
+export interface StartMessage {
+  type: 'start';
+  data: null;
+}
+
+export type ProcessMessages = ErrorMessage | ReadyMessage | StartMessage;
+
+export interface PrerenderPagesOptions {
+  appShellOptions: AppShellOptions;
+  prerenderOptions: PrerenderOptions;
+  assets: Readonly<BuildOutputAsset[]>;
+  document: string;
+  sourcemap: boolean;
+  inlineCriticalCss: boolean;
+  maxThreads: number;
+  verbose: boolean;
+  cssOutputFilesForWorker?: Record<string, string>;
+  /**
+   * Only defined when Node.js version is < 22.2.
+   * TODO: Remove when Node.js versions < 22.2 are no longer supported.
+   */
+  jsOutputFilesForWorker?: Record<string, string>;
+  /**
+   * Only defined when Node.js version is < 22.2.
+   * TODO: Remove when Node.js versions < 22.2 are no longer supported.
+   */
+  workspaceRoot?: string;
+}
+
+class RoutesSet extends Set<string> {
+  override add(value: string): this {
+    return super.add(addLeadingSlash(value));
+  }
+}
+
+async function prerenderPages({
+  appShellOptions,
+  prerenderOptions,
+  assets,
+  document,
+  sourcemap,
+  inlineCriticalCss,
+  maxThreads,
+  verbose,
+  workspaceRoot,
+  cssOutputFilesForWorker,
+  jsOutputFilesForWorker,
+}: PrerenderPagesOptions): Promise<{
+  output: Record<string, string>;
+  warnings: string[];
+  errors: string[];
+  prerenderedRoutes: string[];
+}> {
+  const warnings: string[] = [];
+  const errors: string[] = [];
+
+  const assetsReversed: Record</** Destination */ string, /** Source */ string> = {};
+  for (const { source, destination } of assets) {
+    assetsReversed[addLeadingSlash(destination.replace(/\\/g, posix.sep))] = source;
+  }
+
+  // Get routes to prerender
+  const { routes: allRoutes, warnings: routesWarnings } = await getAllRoutes(
+    assetsReversed,
+    document,
+    appShellOptions,
+    prerenderOptions,
+    sourcemap,
+    verbose,
+    jsOutputFilesForWorker,
+    workspaceRoot,
+  );
+
+  if (routesWarnings?.length) {
+    warnings.push(...routesWarnings);
+  }
+
+  if (allRoutes.length < 1) {
+    return {
+      errors,
+      warnings,
+      output: {},
+      prerenderedRoutes: allRoutes,
+    };
+  }
+
+  // Render routes
+  const {
+    warnings: renderingWarnings,
+    errors: renderingErrors,
+    output,
+  } = await renderPages(
+    sourcemap,
+    allRoutes,
+    maxThreads,
+    assetsReversed,
+    inlineCriticalCss,
+    document,
+    appShellOptions,
+    cssOutputFilesForWorker,
+    jsOutputFilesForWorker,
+    workspaceRoot,
+  );
+
+  errors.push(...renderingErrors);
+  warnings.push(...renderingWarnings);
+
+  return {
+    errors,
+    warnings,
+    output,
+    prerenderedRoutes: allRoutes,
+  };
+}
+
+async function renderPages(
+  sourcemap: boolean,
+  allRoutes: string[],
+  maxThreads: number,
+  assetFilesForWorker: Record<string, string>,
+  inlineCriticalCss: boolean,
+  document: string,
+  appShellOptions: AppShellOptions,
+  cssOutputFilesForWorker?: Record<string, string>,
+  /**
+   * Only defined when Node.js version is < 22.2.
+   * TODO: Remove when Node.js versions < 22.2 are no longer supported.
+   */
+  jsOutputFilesForWorker?: Record<string, string>,
+  /**
+   * Only defined when Node.js version is < 22.2.
+   * TODO: Remove when Node.js versions < 22.2 are no longer supported.
+   */
+  workspaceRoot?: string,
+): Promise<{
+  output: Record<string, string>;
+  warnings: string[];
+  errors: string[];
+}> {
+  const output: Record<string, string> = {};
+  const warnings: string[] = [];
+  const errors: string[] = [];
+  const execArgv: string[] = sourcemap
+    ? ['--enable-source-maps', ...process.execArgv]
+    : [...process.execArgv];
+
+  if (isLegacyESMLoaderImplementation) {
+    execArgv.push(
+      '--import',
+      // Loader cannot be an absolute path on Windows.
+      pathToFileURL(join(__dirname, 'esm-in-memory-loader/register-hooks.js')).href,
+    );
+  }
+
+  const renderWorker = new Piscina({
+    filename: join(__dirname, 'render-worker.js'),
+    maxThreads: Math.min(allRoutes.length, maxThreads),
+    workerData: {
+      assetFiles: assetFilesForWorker,
+      inlineCriticalCss,
+      document,
+      jsOutputFilesForWorker,
+      cssOutputFilesForWorker,
+      workspaceRoot,
+    } as RenderWorkerData,
+    execArgv,
+    recordTiming: false,
+  });
+
+  try {
+    const renderingPromises: Promise<void>[] = [];
+    const appShellRoute = appShellOptions.route && addLeadingSlash(appShellOptions.route);
+
+    for (const route of allRoutes) {
+      const isAppShellRoute = appShellRoute === route;
+      const serverContext: ServerContext = isAppShellRoute ? 'app-shell' : 'ssg';
+      const render: Promise<RenderResult> = renderWorker.run({ route, serverContext });
+      const renderResult: Promise<void> = render.then(({ content, warnings, errors }) => {
+        if (content !== undefined) {
+          const outPath = isAppShellRoute
+            ? 'index.html'
+            : posix.join(removeLeadingSlash(route), 'index.html');
+          output[outPath] = content;
+        }
+
+        if (warnings) {
+          warnings.push(...warnings);
+        }
+
+        if (errors) {
+          errors.push(...errors);
+        }
+      });
+
+      renderingPromises.push(renderResult);
+    }
+
+    await Promise.all(renderingPromises);
+  } finally {
+    void renderWorker.destroy();
+  }
+
+  return {
+    errors,
+    warnings,
+    output,
+  };
+}
+
+async function getAllRoutes(
+  assetFilesForWorker: Record<string, string>,
+  document: string,
+  appShellOptions: AppShellOptions,
+  prerenderOptions: PrerenderOptions,
+  sourcemap: boolean,
+  verbose: boolean,
+  /**
+   * Only defined when Node.js version is < 22.2.
+   * TODO: Remove when Node.js versions < 22.2 are no longer supported.
+   */
+  jsOutputFilesForWorker?: Record<string, string>,
+  /**
+   * Only defined when Node.js version is < 22.2.
+   * TODO: Remove when Node.js versions < 22.2 are no longer supported.
+   */
+  workspaceRoot?: string,
+): Promise<{ routes: string[]; warnings?: string[] }> {
+  const { routesFile, discoverRoutes } = prerenderOptions;
+  const routes = new RoutesSet();
+  const { route: appShellRoute } = appShellOptions;
+
+  if (appShellRoute !== undefined) {
+    routes.add(appShellRoute);
+  }
+
+  if (routesFile) {
+    const routesFromFile = (await readFile(routesFile, 'utf8')).split(/\r?\n/);
+    for (const route of routesFromFile) {
+      routes.add(route.trim());
+    }
+  }
+
+  if (!discoverRoutes) {
+    return { routes: Array.from(routes) };
+  }
+
+  const execArgv: string[] = sourcemap
+    ? ['--enable-source-maps', ...process.execArgv]
+    : [...process.execArgv];
+  if (isLegacyESMLoaderImplementation) {
+    execArgv.push(
+      '--import',
+      // Loader cannot be an absolute path on Windows.
+      pathToFileURL(join(__dirname, 'esm-in-memory-loader/register-hooks.js')).href,
+    );
+  }
+
+  const renderWorker = new Piscina({
+    filename: join(__dirname, 'routes-extractor-worker.js'),
+    maxThreads: 1,
+    workerData: {
+      assetFiles: assetFilesForWorker,
+      document,
+      verbose,
+      jsOutputFilesForWorker,
+      workspaceRoot,
+    } as RoutesExtractorWorkerData,
+    execArgv,
+    recordTiming: false,
+  });
+
+  const { routes: extractedRoutes, warnings }: RoutersExtractorWorkerResult = await renderWorker
+    .run({})
+    .finally(() => {
+      void renderWorker.destroy();
+    });
+
+  extractedRoutes.forEach((route) => routes.add(route));
+
+  return { routes: Array.from(routes), warnings };
+}
+
+function removeLeadingSlash(value: string): string {
+  return value.charAt(0) === '/' ? value.slice(1) : value;
+}
+
+function addLeadingSlash(value: string): string {
+  return value.charAt(0) === '/' ? value : '/' + value;
+}
+
+process
+  .once('message', (options: PrerenderPagesOptions) => {
+    prerenderPages(options)
+      .then((result) => {
+        process.send?.({
+          type: 'ready',
+          data: result,
+        } as ReadyMessage);
+      })
+      .catch((err) => {
+        process.send?.({
+          type: 'error',
+          data: { name: err.name, message: err.message, stack: err.stack },
+        } as ErrorMessage);
+      });
+  })
+  .send?.({ type: 'start', data: null } as StartMessage);

--- a/packages/angular/build/src/utils/server-rendering/prerender.ts
+++ b/packages/angular/build/src/utils/server-rendering/prerender.ts
@@ -6,29 +6,29 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { readFile } from 'node:fs/promises';
-import { extname, join, posix } from 'node:path';
+import { fork } from 'node:child_process';
+import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
-import Piscina from 'piscina';
 import { BuildOutputFile, BuildOutputFileType } from '../../tools/esbuild/bundler-context';
 import { BuildOutputAsset } from '../../tools/esbuild/bundler-execution-result';
-import type { RenderResult, ServerContext } from './render-page';
-import type { RenderWorkerData } from './render-worker';
+import { ESMInMemoryFileLoaderWorkerData } from './esm-in-memory-loader/loader-hooks';
+import { isLegacyESMLoaderImplementation } from './esm-in-memory-loader/utils-lts-node';
 import type {
-  RoutersExtractorWorkerResult,
-  RoutesExtractorWorkerData,
-} from './routes-extractor-worker';
+  PrerenderPagesOptions,
+  ProcessMessages,
+  ReadyMessage,
+} from './prerender-child-process';
 
-interface PrerenderOptions {
+export interface PrerenderOptions {
   routesFile?: string;
   discoverRoutes?: boolean;
 }
 
-interface AppShellOptions {
+export interface AppShellOptions {
   route?: string;
 }
 
-export async function prerenderPages(
+export function prerenderPages(
   workspaceRoot: string,
   appShellOptions: AppShellOptions = {},
   prerenderOptions: PrerenderOptions = {},
@@ -43,31 +43,37 @@ export async function prerenderPages(
   output: Record<string, string>;
   warnings: string[];
   errors: string[];
-  prerenderedRoutes: Set<string>;
+  prerenderedRoutes: string[];
 }> {
-  const outputFilesForWorker: Record<string, string> = {};
+  const cssOutputFilesForWorker: Record<string, string> = {};
+  const jsOutputFilesForWorker: Record<string, string> = {};
   const serverBundlesSourceMaps = new Map<string, string>();
-  const warnings: string[] = [];
-  const errors: string[] = [];
 
   for (const { text, path, type } of outputFiles) {
-    const fileExt = extname(path);
-    if (type === BuildOutputFileType.Server && fileExt === '.map') {
-      serverBundlesSourceMaps.set(path.slice(0, -4), text);
-    } else if (
-      type === BuildOutputFileType.Server || // Contains the server runnable application code
-      (type === BuildOutputFileType.Browser && fileExt === '.css') // Global styles for critical CSS inlining.
-    ) {
-      outputFilesForWorker[path] = text;
+    switch (type) {
+      case BuildOutputFileType.Browser:
+        if (path.endsWith('.css')) {
+          // Global styles for critical CSS inlining.
+          cssOutputFilesForWorker[path] = text;
+        }
+        break;
+      case BuildOutputFileType.Server:
+        if (path.endsWith('.map')) {
+          serverBundlesSourceMaps.set(path.slice(0, -4), text);
+        } else {
+          // Contains the server runnable application code
+          jsOutputFilesForWorker[path] = text;
+        }
+        break;
     }
   }
 
   // Inline sourcemap into JS file. This is needed to make Node.js resolve sourcemaps
   // when using `--enable-source-maps` when using in memory files.
   for (const [filePath, map] of serverBundlesSourceMaps) {
-    const jsContent = outputFilesForWorker[filePath];
+    const jsContent = jsOutputFilesForWorker[filePath];
     if (jsContent) {
-      outputFilesForWorker[filePath] =
+      jsOutputFilesForWorker[filePath] =
         jsContent +
         `\n//# sourceMappingURL=` +
         `data:application/json;base64,${Buffer.from(map).toString('base64')}`;
@@ -75,223 +81,64 @@ export async function prerenderPages(
   }
   serverBundlesSourceMaps.clear();
 
-  const assetsReversed: Record</** Destination */ string, /** Source */ string> = {};
-  for (const { source, destination } of assets) {
-    assetsReversed[addLeadingSlash(destination.replace(/\\/g, posix.sep))] = source;
-  }
-
-  // Get routes to prerender
-  const { routes: allRoutes, warnings: routesWarnings } = await getAllRoutes(
-    workspaceRoot,
-    outputFilesForWorker,
-    assetsReversed,
-    document,
-    appShellOptions,
-    prerenderOptions,
-    sourcemap,
-    verbose,
-  );
-
-  if (routesWarnings?.length) {
-    warnings.push(...routesWarnings);
-  }
-
-  if (allRoutes.size < 1) {
-    return {
-      errors,
-      warnings,
-      output: {},
-      prerenderedRoutes: allRoutes,
-    };
-  }
-
-  // Render routes
-  const {
-    warnings: renderingWarnings,
-    errors: renderingErrors,
-    output,
-  } = await renderPages(
-    sourcemap,
-    allRoutes,
-    maxThreads,
-    workspaceRoot,
-    outputFilesForWorker,
-    assetsReversed,
-    inlineCriticalCss,
-    document,
-    appShellOptions,
-  );
-
-  errors.push(...renderingErrors);
-  warnings.push(...renderingWarnings);
-
-  return {
-    errors,
-    warnings,
-    output,
-    prerenderedRoutes: allRoutes,
-  };
-}
-
-class RoutesSet extends Set<string> {
-  override add(value: string): this {
-    return super.add(addLeadingSlash(value));
-  }
-}
-
-async function renderPages(
-  sourcemap: boolean,
-  allRoutes: Set<string>,
-  maxThreads: number,
-  workspaceRoot: string,
-  outputFilesForWorker: Record<string, string>,
-  assetFilesForWorker: Record<string, string>,
-  inlineCriticalCss: boolean,
-  document: string,
-  appShellOptions: AppShellOptions,
-): Promise<{
-  output: Record<string, string>;
-  warnings: string[];
-  errors: string[];
-}> {
-  const output: Record<string, string> = {};
-  const warnings: string[] = [];
-  const errors: string[] = [];
-
-  const workerExecArgv = [
-    '--import',
-    // Loader cannot be an absolute path on Windows.
-    pathToFileURL(join(__dirname, 'esm-in-memory-loader/register-hooks.js')).href,
-  ];
-
-  if (sourcemap) {
-    workerExecArgv.push('--enable-source-maps');
-  }
-
-  const renderWorker = new Piscina({
-    filename: require.resolve('./render-worker'),
-    maxThreads: Math.min(allRoutes.size, maxThreads),
-    workerData: {
-      workspaceRoot,
-      outputFiles: outputFilesForWorker,
-      assetFiles: assetFilesForWorker,
-      inlineCriticalCss,
-      document,
-    } as RenderWorkerData,
-    execArgv: workerExecArgv,
-    recordTiming: false,
+  const childProcess = fork(join(__dirname, 'prerender-child-process.js'), {
+    execArgv: [
+      '--import',
+      // Loader cannot be an absolute path on Windows.
+      pathToFileURL(join(__dirname, 'esm-in-memory-loader/register-hooks.js')).href,
+    ],
   });
 
-  try {
-    const renderingPromises: Promise<void>[] = [];
-    const appShellRoute = appShellOptions.route && addLeadingSlash(appShellOptions.route);
+  // Send data to ESM loader worker.
+  const esmLoaderData: ESMInMemoryFileLoaderWorkerData = {
+    workspaceRoot,
+    jsOutputFilesForWorker,
+  };
+  childProcess.send(esmLoaderData);
 
-    for (const route of allRoutes) {
-      const isAppShellRoute = appShellRoute === route;
-      const serverContext: ServerContext = isAppShellRoute ? 'app-shell' : 'ssg';
-      const render: Promise<RenderResult> = renderWorker.run({ route, serverContext });
-      const renderResult: Promise<void> = render.then(({ content, warnings, errors }) => {
-        if (content !== undefined) {
-          const outPath = isAppShellRoute
-            ? 'index.html'
-            : posix.join(removeLeadingSlash(route), 'index.html');
-          output[outPath] = content;
-        }
+  return new Promise<ReadyMessage['data']>((resolve, reject) => {
+    childProcess
+      .once('error', reject)
+      .once('uncaughtException', reject)
+      .on('message', ({ type, data }: ProcessMessages) => {
+        switch (type) {
+          case 'start':
+            const prerenderPagesOptions: PrerenderPagesOptions = {
+              appShellOptions,
+              prerenderOptions,
+              assets,
+              document,
+              sourcemap,
+              inlineCriticalCss,
+              maxThreads,
+              verbose,
+              cssOutputFilesForWorker,
+              workspaceRoot,
+            };
 
-        if (warnings) {
-          warnings.push(...warnings);
-        }
+            // TODO: remove when Node.js version 22.2 is no longer supported.
+            if (isLegacyESMLoaderImplementation) {
+              prerenderPagesOptions.jsOutputFilesForWorker = jsOutputFilesForWorker;
+              prerenderPagesOptions.workspaceRoot = workspaceRoot;
+            }
+            childProcess.send(prerenderPagesOptions);
+            break;
+          case 'ready':
+            resolve(data);
+            break;
+          case 'error':
+            const { name, message, stack } = data;
+            const err = new Error(message);
+            err.name = name;
+            err.stack = stack;
 
-        if (errors) {
-          errors.push(...errors);
+            reject(err);
+            break;
+          default:
+            throw new Error(`Unhandled message type "${type}" from forked process.`);
         }
       });
-
-      renderingPromises.push(renderResult);
-    }
-
-    await Promise.all(renderingPromises);
-  } finally {
-    void renderWorker.destroy();
-  }
-
-  return {
-    errors,
-    warnings,
-    output,
-  };
-}
-
-async function getAllRoutes(
-  workspaceRoot: string,
-  outputFilesForWorker: Record<string, string>,
-  assetFilesForWorker: Record<string, string>,
-  document: string,
-  appShellOptions: AppShellOptions,
-  prerenderOptions: PrerenderOptions,
-  sourcemap: boolean,
-  verbose: boolean,
-): Promise<{ routes: Set<string>; warnings?: string[] }> {
-  const { routesFile, discoverRoutes } = prerenderOptions;
-  const routes = new RoutesSet();
-  const { route: appShellRoute } = appShellOptions;
-
-  if (appShellRoute !== undefined) {
-    routes.add(appShellRoute);
-  }
-
-  if (routesFile) {
-    const routesFromFile = (await readFile(routesFile, 'utf8')).split(/\r?\n/);
-    for (const route of routesFromFile) {
-      routes.add(route.trim());
-    }
-  }
-
-  if (!discoverRoutes) {
-    return { routes };
-  }
-
-  const workerExecArgv = [
-    '--import',
-    // Loader cannot be an absolute path on Windows.
-    pathToFileURL(join(__dirname, 'esm-in-memory-loader/register-hooks.js')).href,
-  ];
-
-  if (sourcemap) {
-    workerExecArgv.push('--enable-source-maps');
-  }
-
-  const renderWorker = new Piscina({
-    filename: require.resolve('./routes-extractor-worker'),
-    maxThreads: 1,
-    workerData: {
-      workspaceRoot,
-      outputFiles: outputFilesForWorker,
-      assetFiles: assetFilesForWorker,
-      document,
-      verbose,
-    } as RoutesExtractorWorkerData,
-    execArgv: workerExecArgv,
-    recordTiming: false,
+  }).finally(() => {
+    childProcess.kill();
   });
-
-  const { routes: extractedRoutes, warnings }: RoutersExtractorWorkerResult = await renderWorker
-    .run({})
-    .finally(() => {
-      void renderWorker.destroy();
-    });
-
-  for (const route of extractedRoutes) {
-    routes.add(route);
-  }
-
-  return { routes, warnings };
-}
-
-function addLeadingSlash(value: string): string {
-  return value.charAt(0) === '/' ? value : '/' + value;
-}
-
-function removeLeadingSlash(value: string): string {
-  return value.charAt(0) === '/' ? value.slice(1) : value;
 }

--- a/packages/angular/build/src/utils/server-rendering/render-worker.ts
+++ b/packages/angular/build/src/utils/server-rendering/render-worker.ts
@@ -7,14 +7,24 @@
  */
 
 import { workerData } from 'node:worker_threads';
-import type { ESMInMemoryFileLoaderWorkerData } from './esm-in-memory-loader/loader-hooks';
 import { patchFetchToLoadInMemoryAssets } from './fetch-patch';
 import { RenderResult, ServerContext, renderPage } from './render-page';
 
-export interface RenderWorkerData extends ESMInMemoryFileLoaderWorkerData {
+export interface RenderWorkerData {
   document: string;
   inlineCriticalCss?: boolean;
   assetFiles: Record</** Destination */ string, /** Source */ string>;
+  cssOutputFilesForWorker: Record<string, string>;
+  /**
+   * Only defined when Node.js version is < 22.2.
+   * TODO: Remove when Node.js versions < 22.2 are no longer supported.
+   */
+  jsOutputFilesForWorker: Record<string, string>;
+  /**
+   * Only defined when Node.js version is < 22.2.
+   * TODO: Remove when Node.js versions < 22.2 are no longer supported.
+   */
+  workspaceRoot: string;
 }
 
 export interface RenderOptions {
@@ -25,7 +35,11 @@ export interface RenderOptions {
 /**
  * This is passed as workerData when setting up the worker via the `piscina` package.
  */
-const { outputFiles, document, inlineCriticalCss } = workerData as RenderWorkerData;
+const {
+  cssOutputFilesForWorker: outputFiles,
+  document,
+  inlineCriticalCss,
+} = workerData as RenderWorkerData;
 
 /** Renders an application based on a provided options. */
 function render(options: RenderOptions): Promise<RenderResult> {

--- a/packages/angular/build/src/utils/server-rendering/routes-extractor-worker.ts
+++ b/packages/angular/build/src/utils/server-rendering/routes-extractor-worker.ts
@@ -7,14 +7,23 @@
  */
 
 import { workerData } from 'node:worker_threads';
-import type { ESMInMemoryFileLoaderWorkerData } from './esm-in-memory-loader/loader-hooks';
 import { patchFetchToLoadInMemoryAssets } from './fetch-patch';
 import { loadEsmModuleFromMemory } from './load-esm-from-memory';
 
-export interface RoutesExtractorWorkerData extends ESMInMemoryFileLoaderWorkerData {
+export interface RoutesExtractorWorkerData {
   document: string;
   verbose: boolean;
   assetFiles: Record</** Destination */ string, /** Source */ string>;
+  /**
+   * Only defined when Node.js version is < 22.2.
+   * TODO: Remove when Node.js versions < 22.2 are no longer supported.
+   */
+  jsOutputFilesForWorker: Record<string, string>;
+  /**
+   * Only defined when Node.js version is < 22.2.
+   * TODO: Remove when Node.js versions < 22.2 are no longer supported.
+   */
+  workspaceRoot: string;
 }
 
 export interface RoutersExtractorWorkerResult {


### PR DESCRIPTION
    
Node.js 22.2.0 introduced a breaking change affecting custom ESM resolution.
    
For more context, see: [Node.js issue #53097](https://github.com/nodejs/node/issues/53097)
    
Closes: #27674