### PR TITLE
fix(@angular/build): disable Worker wait loop for Sass compilations in web containers

### DIFF
--- a/packages/angular/build/src/tools/sass/sass-service.ts
+++ b/packages/angular/build/src/tools/sass/sass-service.ts
@@ -95,6 +95,9 @@ export class SassWorkerImplementation {
       filename: require.resolve('./worker'),
       minThreads: 1,
       maxThreads: this.maxThreads,
+      // Web containers do not support transferable objects with receiveOnMessagePort which
+      // is used when the Atomics based wait loop is enable.
+      useAtomics: !process.versions.webcontainer,
       // Shutdown idle threads after 1 second of inactivity
       idleTimeout: 1000,
       recordTiming: false,


### PR DESCRIPTION


The Sass Worker by default uses an Atomics-based wait loop to improve performance while waiting for messages. This loop relies on the synchronous API `receiveMessageOnPort`. While this works well in Node.js, the web container execution environment does not currently support passing transferable objects via `receiveMessageOnPort`.

Closes: #27723
