### PR TITLE
perf(@angular/build): enable dependency prebundling for server dependencies

### DIFF
--- a/packages/angular/build/src/builders/application/setup-bundling.ts
+++ b/packages/angular/build/src/builders/application/setup-bundling.ts
@@ -93,16 +93,7 @@ export function setupBundlerContexts(
       new BundlerContext(
         workspaceRoot,
         !!options.watch,
-        createServerCodeBundleOptions(
-          {
-            ...options,
-            // Disable external deps for server bundles.
-            // This is because it breaks Vite 'optimizeDeps' for SSR.
-            externalPackages: false,
-          },
-          nodeTargets,
-          codeBundleCache,
-        ),
+        createServerCodeBundleOptions(options, nodeTargets, codeBundleCache),
       ),
     );
 


### PR DESCRIPTION

With this commit, we introduce Vite dependencies prebundling for server bundles.

**Before:**
```
ng s
Browser bundles
Initial chunk files     | Names               |  Raw size
polyfills.js            | polyfills           |  90.87 kB
main.js                 | main                |  22.71 kB
styles.css              | styles              |  95 bytes

                        | Initial total       | 113.67 kB

Server bundles
Initial chunk files     | Names               |  Raw size
chunk-4EGJGG5L.mjs      | -                   |   1.80 MB
polyfills.server.mjs    | polyfills.server    | 573.58 kB
main.server.mjs         | main.server         | 224.03 kB
chunk-QDHZVCWX.mjs      | -                   |   2.57 kB
render-utils.server.mjs | render-utils.server | 423 bytes

Lazy chunk files        | Names               |  Raw size
chunk-XD2MYPRT.mjs      | xhr2                |  40.04 kB

Application bundle generation complete. [5.199 seconds]
```

**Now:**
```
ng s
Browser bundles
Initial chunk files     | Names               |  Raw size
polyfills.js            | polyfills           |  90.87 kB
main.js                 | main                |  22.71 kB
styles.css              | styles              |  95 bytes

                        | Initial total       | 113.67 kB

Server bundles
Initial chunk files     | Names               |  Raw size
polyfills.server.mjs    | polyfills.server    | 573.58 kB
main.server.mjs         | main.server         |  23.16 kB
render-utils.server.mjs | render-utils.server | 472 bytes

Application bundle generation complete. [2.880 seconds]
```
