### PR TITLE
perf(@angular/build): use direct transpilation with isolated modules

### DIFF
--- a/packages/angular/build/src/builders/application/tests/behavior/typescript-isolated-modules_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/behavior/typescript-isolated-modules_spec.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { buildApplication } from '../../index';
+import { APPLICATION_BUILDER_INFO, BASE_OPTIONS, describeBuilder } from '../setup';
+
+describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
+  describe('Behavior: "TypeScript isolated modules direct transpilation"', () => {
+    it('should successfully build with isolated modules enabled and disabled optimizations', async () => {
+      // Enable tsconfig isolatedModules option in tsconfig
+      await harness.modifyFile('tsconfig.json', (content) => {
+        const tsconfig = JSON.parse(content);
+        tsconfig.compilerOptions.isolatedModules = true;
+
+        return JSON.stringify(tsconfig);
+      });
+
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+      });
+
+      const { result } = await harness.executeOnce();
+
+      expect(result?.success).toBe(true);
+    });
+
+    it('should successfully build with isolated modules enabled and enabled optimizations', async () => {
+      // Enable tsconfig isolatedModules option in tsconfig
+      await harness.modifyFile('tsconfig.json', (content) => {
+        const tsconfig = JSON.parse(content);
+        tsconfig.compilerOptions.isolatedModules = true;
+
+        return JSON.stringify(tsconfig);
+      });
+
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        optimization: true,
+      });
+
+      const { result } = await harness.executeOnce();
+
+      expect(result?.success).toBe(true);
+    });
+  });
+});

--- a/packages/angular/build/src/tools/esbuild/angular/compilation/parallel-worker.ts
+++ b/packages/angular/build/src/tools/esbuild/angular/compilation/parallel-worker.ts
@@ -94,8 +94,12 @@ export async function initialize(request: InitRequest) {
 
   return {
     referencedFiles,
-    // TODO: Expand? `allowJs` is the only field needed currently.
-    compilerOptions: { allowJs: compilerOptions.allowJs },
+    // TODO: Expand? `allowJs`, `isolatedModules`, `sourceMap` are the only fields needed currently.
+    compilerOptions: {
+      allowJs: compilerOptions.allowJs,
+      isolatedModules: compilerOptions.isolatedModules,
+      sourceMap: compilerOptions.sourceMap,
+    },
   };
 }
 


### PR DESCRIPTION
When using the application builder and the TypeScript `isolatedModules` option is enabled and script sourcemaps are disabled, TypeScript code will be transpiled via the bundler instead of the current behavior of using TypeScript. The use of the `isolatedModules` option ensures that TypeScript code can be safely transpiled without the need for the type-checker. This mode of operation has several advantages. The bundler (esbuild in this case) will know have knowledge of the TypeScript code constructs, such as enums, and can optimize the output code based on that knowledge including inlining both const and regular enums where possible. Additionally, this allows for the removal of the babel-based optimization passes for all TypeScript code. These passes are still present for all JavaScript code such as from third-party libraries/packages. These advantages lead to an improvement in build time, especially in production configurations. To ensure optimal output code size in this setup, the `useDefineForClassFields` TypeScript option should either be removed or set to `true` which enables ECMAScript standard compliant behavior.

Initial testing reduced a warm production build of a newly generated project from ~2.3 seconds to ~2.0 seconds.