### PR TITLE
fix(@angular/build): disable JS transformer persistent cache on web containers

### DIFF
--- a/packages/angular/build/src/tools/esbuild/angular/compiler-plugin.ts
+++ b/packages/angular/build/src/tools/esbuild/angular/compiler-plugin.ts
@@ -61,9 +61,10 @@ export function createCompilerPlugin(
       let setupWarnings: PartialMessage[] | undefined = [];
       const preserveSymlinks = build.initialOptions.preserveSymlinks;
 
-      // Initialize a worker pool for JavaScript transformations
+      // Initialize a worker pool for JavaScript transformations.
+      // Webcontainers currently do not support this persistent cache store.
       let cacheStore: import('../lmdb-cache-store').LmbdCacheStore | undefined;
-      if (pluginOptions.sourceFileCache?.persistentCachePath) {
+      if (pluginOptions.sourceFileCache?.persistentCachePath && !process.versions.webcontainer) {
         const { LmbdCacheStore } = await import('../lmdb-cache-store');
         cacheStore = new LmbdCacheStore(
           path.join(pluginOptions.sourceFileCache.persistentCachePath, 'angular-compiler.db'),


### PR DESCRIPTION
The backing store for the persistent caching of the JavaScript transformers is not currently supported on web containers. To allow other potential forms of caching, the JavaScript transformer caching is now selectively disabled when executed on a web container. This allows for development server prebundling to be used on web containers if needed.