### PR TITLE
fix(@schematics/angular): generate new projects with ECMAScript standard class field behavior

### DIFF
--- a/modules/testing/builder/projects/hello-world-app/tsconfig.json
+++ b/modules/testing/builder/projects/hello-world-app/tsconfig.json
@@ -11,7 +11,6 @@
     "skipLibCheck": true,
     "target": "es2022",
     "module": "es2022",
-    "useDefineForClassFields": false,
     "lib": [
       "es2022",
       "dom"

--- a/packages/angular_devkit/build_angular/src/builders/browser/specs/lazy-module_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser/specs/lazy-module_spec.ts
@@ -65,7 +65,7 @@ describe('Browser Builder lazy modules', () => {
 
       const { files } = await browserBuild(architect, host, target, { aot: true });
       const data = await files['src_app_lazy_lazy_module_ts.js'];
-      expect(data).toContain('this.ɵmod');
+      expect(data).toContain('static ɵmod');
     });
   });
 

--- a/packages/schematics/angular/workspace/files/tsconfig.json.template
+++ b/packages/schematics/angular/workspace/files/tsconfig.json.template
@@ -17,7 +17,6 @@
     "importHelpers": true,
     "target": "ES2022",
     "module": "ES2022",
-    "useDefineForClassFields": false,
     "lib": [
       "ES2022",
       "dom"

--- a/tests/legacy-cli/e2e/tests/misc/safari-15-class-properties.ts
+++ b/tests/legacy-cli/e2e/tests/misc/safari-15-class-properties.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert';
 import { expectFileToExist, readFile, writeFile, replaceInFile } from '../../utils/fs';
 import { ng } from '../../utils/process';
 import { getGlobalVariable } from '../../utils/env';
+import { updateJsonFile } from '../../utils/project';
 
 const unexpectedStaticFieldErrorMessage =
   'Found unexpected static field. This indicates that the Safari <=v15 ' +
@@ -22,6 +23,10 @@ export default async function () {
 
       title = 'test-project';`,
   );
+
+  await updateJsonFile('tsconfig.json', (tsconfig) => {
+    tsconfig.compilerOptions.useDefineForClassFields = false;
+  });
 
   // Matches two types of static fields that indicate that the Safari bug
   // may still occur. With the workaround this should not appear in bundles.

--- a/tests/legacy-cli/e2e/tests/misc/third-party-decorators.ts
+++ b/tests/legacy-cli/e2e/tests/misc/third-party-decorators.ts
@@ -16,6 +16,10 @@ export default async function () {
   // This is especially common when testing snapshot builds for new prereleases.
   await installWorkspacePackages({ force: true });
 
+  await updateJsonFile('tsconfig.json', (tsconfig) => {
+    tsconfig.compilerOptions.useDefineForClassFields = false;
+  });
+
   // Create an app that uses ngrx decorators and has e2e tests.
   await writeMultipleFiles({
     './e2e/src/app.po.ts': `


### PR DESCRIPTION
Newly generated projects will now use ECMAScript standard class field behavior by default. If the legacy TypeScript behavior is required for a new project the `useDefineForClassFields` TypeScript option can be set to `false` within the application's `tsconfig`. This should be uncommon, and if needed, it is recommended to adjust code to match standard behavior where possible.