### PR TITLE
fix(@angular/cli): add `schema.json` options to parsed command, also when a version is passed to `ng add <package>@<version>`

### DIFF
--- a/packages/angular/cli/src/commands/add/cli.ts
+++ b/packages/angular/cli/src/commands/add/cli.ts
@@ -346,7 +346,17 @@ export default class AddCommandModule
   }
 
   private async getCollectionName(): Promise<string> {
-    const [, collectionName] = this.context.args.positional;
+    let [, collectionName] = this.context.args.positional;
+
+    // The CLI argument may specify also a version, like `ng add @my/lib@13.0.0`,
+    // but here we need only the name of the package, like `@my/lib`
+    try {
+      const packageIdentifier = npa(collectionName);
+      collectionName = packageIdentifier.name ?? collectionName;
+    } catch (e) {
+      assertIsError(e);
+      this.context.logger.error(e.message);
+    }
 
     return collectionName;
   }


### PR DESCRIPTION
This commit fixes the method `AddCommandModule.getCollectionName()`, so it now returns only the package name, but remove the specified version (if present).

Previously, a `@<version>` specified in the const `collectionName` was causing a (silenced) error during the invocation of `workflow.engine.createCollection(collectionName)`, which lead to skipping eventually the invocation of the method `this.addSchemaOptionsToCommand()` in the try/catch block.

fixes https://github.com/angular/angular-cli/issues/27766

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] N/A Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/angular/angular-cli/issues/27766

## What is the new behavior?

<!-- Please describe the new behavior that. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
