### PR TITLE
fix(@angular/build): add `$localize` polyfill when using zoneless

### DIFF
--- a/packages/angular/build/src/builders/application/tests/options/cross-origin_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/options/cross-origin_spec.ts
@@ -40,6 +40,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
         .content.toEqual(
           `<html><head><base href="/"><link rel="stylesheet" href="styles.css" crossorigin="use-credentials"></head>` +
             `<body><app-root></app-root>` +
+            `<script src="polyfills.js" type="module" crossorigin="use-credentials"></script>` +
             `<script src="main.js" type="module" crossorigin="use-credentials"></script></body></html>`,
         );
     });
@@ -59,6 +60,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
           `<html><head><base href="/">` +
             `<link rel="stylesheet" href="styles.css" crossorigin="anonymous"></head>` +
             `<body><app-root></app-root>` +
+            `<script src="polyfills.js" type="module" crossorigin="anonymous"></script>` +
             `<script src="main.js" type="module" crossorigin="anonymous"></script></body></html>`,
         );
     });
@@ -78,6 +80,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
           `<html><head><base href="/">` +
             `<link rel="stylesheet" href="styles.css"></head>` +
             `<body><app-root></app-root>` +
+            `<script src="polyfills.js" type="module"></script>` +
             `<script src="main.js" type="module"></script></body></html>`,
         );
     });
@@ -96,6 +99,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
           `<html><head><base href="/">` +
             `<link rel="stylesheet" href="styles.css"></head>` +
             `<body><app-root></app-root>` +
+            `<script src="polyfills.js" type="module"></script>` +
             `<script src="main.js" type="module"></script></body></html>`,
         );
     });

--- a/packages/angular/build/src/builders/application/tests/options/deploy-url_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/options/deploy-url_spec.ts
@@ -36,6 +36,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
         .content.toEqual(
           `<html><head><base href="/"><link rel="stylesheet" href="deployUrl/styles.css"></head>` +
             `<body><app-root></app-root>` +
+            `<script src="deployUrl/polyfills.js" type="module"></script>` +
             `<script src="deployUrl/main.js" type="module"></script></body></html>`,
         );
     });
@@ -54,6 +55,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
         .content.toEqual(
           `<html><head><base href="/"><link rel="stylesheet" href="https://example.com/some/path/styles.css"></head>` +
             `<body><app-root></app-root>` +
+            `<script src="https://example.com/some/path/polyfills.js" type="module"></script>` +
             `<script src="https://example.com/some/path/main.js" type="module"></script></body></html>`,
         );
     });

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/tests/options/deploy-url_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/tests/options/deploy-url_spec.ts
@@ -36,6 +36,7 @@ describeBuilder(buildEsbuildBrowser, BROWSER_BUILDER_INFO, (harness) => {
         .content.toEqual(
           `<html><head><base href="/"><link rel="stylesheet" href="deployUrl/styles.css"></head>` +
             `<body><app-root></app-root>` +
+            `<script src="deployUrl/polyfills.js" type="module"></script>` +
             `<script src="deployUrl/main.js" type="module"></script></body></html>`,
         );
     });
@@ -54,6 +55,7 @@ describeBuilder(buildEsbuildBrowser, BROWSER_BUILDER_INFO, (harness) => {
         .content.toEqual(
           `<html><head><base href="/"><link rel="stylesheet" href="https://example.com/some/path/styles.css"></head>` +
             `<body><app-root></app-root>` +
+            `<script src="https://example.com/some/path/polyfills.js" type="module"></script>` +
             `<script src="https://example.com/some/path/main.js" type="module"></script></body></html>`,
         );
     });

--- a/tests/legacy-cli/e2e/tests/i18n/extract-ivy.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/extract-ivy.ts
@@ -43,7 +43,8 @@ export default async function () {
   // Should not show any warnings when extracting
   const { stderr: message5 } = await ng('extract-i18n');
   if (message5.includes('WARNING')) {
-    throw new Error('Expected no warnings to be shown. STDERR:\n' + message5);
+    // TODO: enable once https://github.com/angular/angular/pull/56300 is released.
+    // throw new Error('Expected no warnings to be shown. STDERR:\n' + message5);
   }
 
   await expectFileToMatch('messages.xlf', 'Hello world');


### PR DESCRIPTION
This commit addresses an issue where the `@angular/localize/init` polyfill is not included when there are no polyfills specified in the `angular.json` file. However, this approach has a drawback: the localize polyfill will always be added if it is found in a monorepo, even if an application does not use i18n.

As a result, we will issue a warning to inform users about this behavior and encourage them to explicitly add it to their `polyfills` configuration.

The `ng add` schematic will also be updated to add the polyfill as in the builders config, see: https://github.com/angular/angular/pull/56300

Closes: #27786
