### PR TITLE
fix(@angular/build): generate module preloads next to script elements in index HTML

### DIFF
--- a/packages/angular/build/src/utils/index-file/augment-index-html_spec.ts
+++ b/packages/angular/build/src/utils/index-file/augment-index-html_spec.ts
@@ -296,10 +296,10 @@ describe('augment-index-html', () => {
         <html>
           <head>
             <base href="/">
-            <link rel="modulepreload" href="x.js">
-            <link rel="modulepreload" href="y/z.js">
           </head>
           <body>
+            <link rel="modulepreload" href="x.js">
+            <link rel="modulepreload" href="y/z.js">
           </body>
         </html>
       `);
@@ -320,10 +320,10 @@ describe('augment-index-html', () => {
         <html>
           <head>
             <base href="/">
-            <link rel="modulepreload" href="x.js">
-            <link rel="modulepreload" href="y/z.js">
           </head>
           <body>
+            <link rel="modulepreload" href="x.js">
+            <link rel="modulepreload" href="y/z.js">
           </body>
         </html>
       `);


### PR DESCRIPTION
The `modulepreload` link elements for initial scripts are now generated next to the actual script elements that require the referenced preloaded scripts. This better represents the fetch priorities to the browser and also allows easier visual discovery of the relevant script related elements inside the index HTML.