### PR TITLE
ci: only download saucelabs connect utility when running tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -184,7 +184,6 @@
     "rxjs": "7.8.1",
     "sass": "1.77.4",
     "sass-loader": "14.2.1",
-    "sauce-connect-proxy": "https://saucelabs.com/downloads/sc-4.9.1-linux.tar.gz",
     "semver": "7.6.2",
     "shelljs": "^0.8.5",
     "source-map": "0.7.4",

--- a/scripts/saucelabs/start-tunnel.sh
+++ b/scripts/saucelabs/start-tunnel.sh
@@ -3,6 +3,14 @@
 set -x -u -e -o pipefail
 
 readonly currentDir=$(cd $(dirname $0); pwd)
+readonly connectVersion="sc-4.9.2-linux"
+readonly connectHash="2f8a3f87e1da4dc9a41bc45ec7c3a2ecdba4c72d72b7d0193f04ad66c5809104"
+
+echo "Downloading Sauce Connect"
+
+curl https://saucelabs.com/downloads/${connectVersion}.tar.gz -o ${currentDir}/${connectVersion}.tar.gz
+echo "${connectHash}  ${currentDir}/${connectVersion}.tar.gz" | shasum -a 256 -c
+tar -xzf ${currentDir}/${connectVersion}.tar.gz -C ${currentDir}
 
 # Command arguments that will be passed to sauce-connect. By default we disable SSL bumping for
 # all requests. This is because SSL bumping is not needed for our test setup and in order
@@ -29,4 +37,4 @@ fi
 
 echo "Starting Sauce Connect. Passed arguments: ${sauceArgs}"
 
-${currentDir}/../../node_modules/sauce-connect-proxy/bin/sc -u ${SAUCE_USERNAME} -k ${SAUCE_ACCESS_KEY} ${sauceArgs}
+${currentDir}/${connectVersion}/bin/sc -u ${SAUCE_USERNAME} -k ${SAUCE_ACCESS_KEY} ${sauceArgs}

--- a/yarn.lock
+++ b/yarn.lock
@@ -12483,10 +12483,6 @@ sass@1.77.4, sass@^1.69.5:
     immutable "^4.0.0"
     source-map-js ">=0.6.2 <2.0.0"
 
-"sauce-connect-proxy@https://saucelabs.com/downloads/sc-4.9.1-linux.tar.gz":
-  version "0.0.0"
-  resolved "https://saucelabs.com/downloads/sc-4.9.1-linux.tar.gz#9310bc860f7870a1f872b11c4dc6073a1ad34e5e"
-
 saucelabs@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/saucelabs/-/saucelabs-1.5.0.tgz#9405a73c360d449b232839919a86c396d379fd9d"


### PR DESCRIPTION
The saucelabs connect tunnel utility is now only downloaded when a saucelabs related test is executed. Previously it was part of the root `package.json` and downloaded whenever a package install was executed. The utility archive was also not an actual package which incidentally worked with npm but does not work with newer versions of yarn. A SHA256 check is also now performed prior to executing the utility to verify the expected file is present.