### PR TITLE
refactor(@angular/cli): use Node.js builtin ANSI escape removal helper

### DIFF
--- a/packages/angular/cli/lib/cli/index.ts
+++ b/packages/angular/cli/lib/cli/index.ts
@@ -7,10 +7,10 @@
  */
 
 import { logging } from '@angular-devkit/core';
-import { format } from 'util';
+import { format, stripVTControlCharacters } from 'node:util';
 import { CommandModuleError } from '../../src/command-builder/command-module';
 import { runCommand } from '../../src/command-builder/command-runner';
-import { colors, removeColor } from '../../src/utilities/color';
+import { colors } from '../../src/utilities/color';
 import { ngDebug } from '../../src/utilities/environment-options';
 import { writeErrorToLogFile } from '../../src/utilities/log-file';
 
@@ -51,7 +51,7 @@ export default async function (options: { cliArgs: string[] }) {
       return;
     }
 
-    const color = colors.enabled ? colorLevels[entry.level] : removeColor;
+    const color = colors.enabled ? colorLevels[entry.level] : stripVTControlCharacters;
     const message = color(entry.message);
 
     switch (entry.level) {

--- a/packages/angular/cli/src/utilities/color.ts
+++ b/packages/angular/cli/src/utilities/color.ts
@@ -36,12 +36,6 @@ function supportColor(): boolean {
   return false;
 }
 
-export function removeColor(text: string): string {
-  // This has been created because when colors.enabled is false unstyle doesn't work
-  // see: https://github.com/doowb/ansi-colors/blob/a4794363369d7b4d1872d248fc43a12761640d8e/index.js#L38
-  return text.replace(ansiColors.ansiRegex, '');
-}
-
 // Create a separate instance to prevent unintended global changes to the color configuration
 const colors = ansiColors.create();
 colors.enabled = supportColor();


### PR DESCRIPTION
Node.js contains a helper function within the `util` builtin that will remove any ANSI escape codes from a string. This removes the need for a custom utility function.