### PR TITLE
test: add bun and pnpm subsets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         node: [18, 20, 22]
-        subset: [npm, yarn, esbuild]
+        subset: [npm, yarn, pnpm, esbuild]
         shard: [0, 1, 2, 3, 4, 5]
         exclude:
           # Exclude Node.js v18 when running on a PR
@@ -87,6 +87,9 @@ jobs:
           # Skip yarn subset on Windows
           - os: windows-latest
             subset: yarn
+          # Skip pnpm subset on Windows
+          - os: windows-latest
+            subset: pnpm
           # Skip Node.js v18 tests on Windows
           - os: windows-latest
             node: 18
@@ -112,7 +115,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         node: [18]
-        subset: [npm, yarn, esbuild]
+        subset: [npm, yarn, pnpm, esbuild]
         shard: [0, 1, 2, 3, 4, 5]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -107,7 +107,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         node: [18, 20, 22]
-        subset: [npm, yarn, esbuild]
+        subset: [npm, yarn, pnpm, esbuild]
         shard: [0, 1, 2, 3, 4, 5]
         exclude:
           # Exclude Node.js v18 when running on a PR
@@ -119,6 +119,9 @@ jobs:
           # Skip yarn subset on Windows
           - os: windows-latest
             subset: yarn
+          # Skip pnpm subset on Windows
+          - os: windows-latest
+            subset: pnpm
           # Skip Node.js v18 tests on Windows
           - os: windows-latest
             node: 18
@@ -146,7 +149,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         node: [18]
-        subset: [npm, yarn, esbuild]
+        subset: [npm, yarn, pnpm, esbuild]
         shard: [0, 1, 2, 3, 4, 5]
     runs-on: ${{ matrix.os }}
     steps:

--- a/packages/angular/cli/src/commands/update/cli.ts
+++ b/packages/angular/cli/src/commands/update/cli.ts
@@ -80,6 +80,7 @@ const UPDATE_SCHEMATIC_COLLECTION = path.join(__dirname, 'schematic/collection.j
 export default class UpdateCommandModule extends CommandModule<UpdateCommandArgs> {
   override scope = CommandScope.In;
   protected override shouldReportAnalytics = false;
+  private readonly resolvePaths = [__dirname, this.context.root];
 
   command = 'update [packages..]';
   describe = 'Updates your workspace and its dependencies. See https://update.angular.dev/.';
@@ -251,7 +252,7 @@ export default class UpdateCommandModule extends CommandModule<UpdateCommandArgs
       packageManagerForce: this.packageManagerForce(options.verbose),
       // __dirname -> favor @schematics/update from this package
       // Otherwise, use packages from the active workspace (migrations)
-      resolvePaths: [__dirname, this.context.root],
+      resolvePaths: this.resolvePaths,
       schemaValidation: true,
       engineHostCreator: (options) => new SchematicEngineHost(options.resolvePaths),
     });
@@ -555,7 +556,7 @@ export default class UpdateCommandModule extends CommandModule<UpdateCommandArgs
       // This avoids issues with package hoisting.
       try {
         const packageRequire = createRequire(packagePath + '/');
-        migrations = packageRequire.resolve(migrations);
+        migrations = packageRequire.resolve(migrations, { paths: this.resolvePaths });
       } catch (e) {
         assertIsError(e);
         if (e.code === 'MODULE_NOT_FOUND') {

--- a/tests/legacy-cli/e2e.bzl
+++ b/tests/legacy-cli/e2e.bzl
@@ -28,7 +28,7 @@ TEST_TAGS = ["no-remote-exec", "requires-network"]
 
 # Subset of tests for yarn/esbuild
 BROWSER_TESTS = ["tests/misc/browsers.js"]
-YARN_TESTS = ["tests/basic/**", "tests/update/**", "tests/commands/add/**"]
+PACKAGE_MANAGER_SUBSET_TESTS = ["tests/basic/**", "tests/update/**", "tests/commands/add/**", "tests/misc/create-angular.js"]
 ESBUILD_TESTS = [
     "tests/basic/**",
     "tests/build/**",
@@ -72,6 +72,8 @@ def e2e_suites(name, runner, data):
         _e2e_tests(name + "_" + toolchain_name, runner, data = data, toolchain = toolchain, tags = ["manual"])
 
         _e2e_suite(name, runner, "npm", data, toolchain_name, toolchain)
+        _e2e_suite(name, runner, "bun", data, toolchain_name, toolchain)
+        _e2e_suite(name, runner, "pnpm", data, toolchain_name, toolchain)
         _e2e_suite(name, runner, "yarn", data, toolchain_name, toolchain)
         _e2e_suite(name, runner, "esbuild", data, toolchain_name, toolchain)
 
@@ -124,7 +126,7 @@ def _e2e_tests(name, runner, **kwargs):
 
 def _e2e_suite(name, runner, type, data, toolchain_name = "", toolchain = None):
     """
-    Setup a predefined test suite (yarn|esbuild|saucelabs|npm).
+    Setup a predefined test suite (yarn|pnpm|bun|esbuild|saucelabs|npm).
     """
     args = []
     tests = None
@@ -133,9 +135,10 @@ def _e2e_suite(name, runner, type, data, toolchain_name = "", toolchain = None):
     if toolchain_name:
         toolchain_name = "_" + toolchain_name
 
-    if type == "yarn":
-        args.append("--yarn")
-        tests = YARN_TESTS
+    if type == "yarn" or type == "bun" or type == "pnpm":
+        args.append("--package-manager=%s" % type)
+        args.append("--esbuild")
+        tests = PACKAGE_MANAGER_SUBSET_TESTS
         ignore = BROWSER_TESTS + WEBPACK_IGNORE_TESTS
     elif type == "esbuild":
         args.append("--esbuild")

--- a/tests/legacy-cli/e2e/initialize/300-log-environment.ts
+++ b/tests/legacy-cli/e2e/initialize/300-log-environment.ts
@@ -1,3 +1,4 @@
+import { getActivePackageManager } from '../utils/packages';
 import { exec, ng } from '../utils/process';
 
 export default async function () {
@@ -13,6 +14,6 @@ export default async function () {
     console.log(`  ${envName}: ${process.env[envName]!.replace(/[\n\r]+/g, '\n        ')}`);
   });
 
-  await exec('which', 'ng', 'yarn', 'npm', 'bun', 'pnpm');
+  await exec('which', 'ng', getActivePackageManager());
   await ng('version');
 }

--- a/tests/legacy-cli/e2e/initialize/300-log-environment.ts
+++ b/tests/legacy-cli/e2e/initialize/300-log-environment.ts
@@ -13,6 +13,6 @@ export default async function () {
     console.log(`  ${envName}: ${process.env[envName]!.replace(/[\n\r]+/g, '\n        ')}`);
   });
 
-  await exec('which', 'ng', 'yarn', 'npm');
+  await exec('which', 'ng', 'yarn', 'npm', 'bun', 'pnpm');
   await ng('version');
 }

--- a/tests/legacy-cli/e2e/setup/100-global-cli.ts
+++ b/tests/legacy-cli/e2e/setup/100-global-cli.ts
@@ -1,8 +1,10 @@
 import { getGlobalVariable } from '../utils/env';
 import { globalNpm } from '../utils/process';
 
-const NPM_VERSION = '7.24.0';
-const YARN_VERSION = '1.22.18';
+const NPM_VERSION = '7.24.0'; // TODO: update to latest and fix tests.
+const YARN_VERSION = '1.22.22';
+const PNPM_VERSION = '9.3.0';
+const BUN_VERSION = '1.1.13';
 
 export default async function () {
   const argv = getGlobalVariable('argv');
@@ -10,7 +12,7 @@ export default async function () {
     return;
   }
 
-  const testRegistry: string = getGlobalVariable('package-registry');
+  const testRegistry = getGlobalVariable('package-registry');
 
   // Install global Angular CLI being tested, npm+yarn used by e2e tests.
   await globalNpm([
@@ -18,7 +20,9 @@ export default async function () {
     '--global',
     `--registry=${testRegistry}`,
     '@angular/cli',
+    `bun@${BUN_VERSION}`,
     `npm@${NPM_VERSION}`,
     `yarn@${YARN_VERSION}`,
+    `pnpm@${PNPM_VERSION}`,
   ]);
 }

--- a/tests/legacy-cli/e2e/setup/100-global-cli.ts
+++ b/tests/legacy-cli/e2e/setup/100-global-cli.ts
@@ -1,10 +1,13 @@
 import { getGlobalVariable } from '../utils/env';
+import { getActivePackageManager } from '../utils/packages';
 import { globalNpm } from '../utils/process';
 
-const NPM_VERSION = '7.24.0'; // TODO: update to latest and fix tests.
-const YARN_VERSION = '1.22.22';
-const PNPM_VERSION = '9.3.0';
-const BUN_VERSION = '1.1.13';
+const PACKAGE_MANAGER_VERSION = {
+  'npm': '7.24.0', // TODO: update to latest and fix tests.
+  'yarn': '1.22.22',
+  'pnpm': '9.3.0',
+  'bun': '1.1.13',
+};
 
 export default async function () {
   const argv = getGlobalVariable('argv');
@@ -13,6 +16,7 @@ export default async function () {
   }
 
   const testRegistry = getGlobalVariable('package-registry');
+  const packageManager = getActivePackageManager();
 
   // Install global Angular CLI being tested, npm+yarn used by e2e tests.
   await globalNpm([
@@ -20,9 +24,6 @@ export default async function () {
     '--global',
     `--registry=${testRegistry}`,
     '@angular/cli',
-    `bun@${BUN_VERSION}`,
-    `npm@${NPM_VERSION}`,
-    `yarn@${YARN_VERSION}`,
-    `pnpm@${PNPM_VERSION}`,
+    `${packageManager}@${PACKAGE_MANAGER_VERSION[packageManager]}`,
   ]);
 }

--- a/tests/legacy-cli/e2e/tests/misc/create-angular.ts
+++ b/tests/legacy-cli/e2e/tests/misc/create-angular.ts
@@ -1,7 +1,7 @@
 import { join, resolve } from 'path';
 import { expectFileToExist, readFile, rimraf } from '../../utils/fs';
 import { getActivePackageManager } from '../../utils/packages';
-import { silentNpm, silentYarn } from '../../utils/process';
+import { silentBun, silentNpm, silentPnpm, silentYarn } from '../../utils/process';
 
 export default async function () {
   const currentDirectory = process.cwd();
@@ -20,6 +20,14 @@ export default async function () {
         break;
       case 'yarn':
         await silentYarn('create', '@angular', projectName, '--skip-install', '--style=scss');
+
+        break;
+      case 'bun':
+        await silentBun('create', '@angular', projectName, '--skip-install', '--style=scss');
+
+        break;
+      case 'pnpm':
+        await silentPnpm('create', '@angular', projectName, '--skip-install', '--style=scss');
 
         break;
       default:

--- a/tests/legacy-cli/e2e/tests/update/update.ts
+++ b/tests/legacy-cli/e2e/tests/update/update.ts
@@ -14,6 +14,9 @@ export default async function () {
     // older versions @angular/cli packages which would cause `npm install` during `ng update` to fail.
     restoreRegistry = await createProjectFromAsset('15.0-project', true);
 
+    // CLI project version
+    const cliMajorProjectVersion = 15;
+
     // If using npm, enable legacy peer deps mode to avoid defects in npm 7+'s peer dependency resolution
     // Example error where 11.2.14 satisfies the SemVer range ^11.0.0 but still fails:
     // npm ERR! Conflicting peer dependency: @angular/compiler-cli@11.2.14
@@ -24,12 +27,6 @@ export default async function () {
     if (getActivePackageManager() === 'npm') {
       await appendFile('.npmrc', '\nlegacy-peer-deps=true');
     }
-
-    // CLI project version
-    const { version: cliVersion } = JSON.parse(
-      await readFile('./node_modules/@angular/cli/package.json'),
-    );
-    const cliMajorProjectVersion = new SemVer(cliVersion).major;
 
     // CLI current version.
     const cliMajorVersion = getNgCLIVersion().major;

--- a/tests/legacy-cli/e2e/utils/packages.ts
+++ b/tests/legacy-cli/e2e/utils/packages.ts
@@ -1,5 +1,5 @@
 import { getGlobalVariable } from './env';
-import { ProcessOutput, silentNpm, silentYarn } from './process';
+import { ProcessOutput, silentBun, silentNpm, silentPnpm, silentYarn } from './process';
 
 export interface PkgInfo {
   readonly name: string;
@@ -7,13 +7,8 @@ export interface PkgInfo {
   readonly path: string;
 }
 
-export function getActivePackageManager(): 'npm' | 'yarn' {
-  const value = getGlobalVariable('package-manager');
-  if (value && value !== 'npm' && value !== 'yarn') {
-    throw new Error('Invalid package manager value: ' + value);
-  }
-
-  return value || 'npm';
+export function getActivePackageManager(): 'npm' | 'yarn' | 'bun' | 'pnpm' {
+  return getGlobalVariable('package-manager');
 }
 
 export async function installWorkspacePackages(options?: { force?: boolean }): Promise<void> {
@@ -26,7 +21,13 @@ export async function installWorkspacePackages(options?: { force?: boolean }): P
       await silentNpm(...npmArgs);
       break;
     case 'yarn':
-      await silentYarn();
+      await silentYarn('install');
+      break;
+    case 'pnpm':
+      await silentPnpm('install');
+      break;
+    case 'bun':
+      await silentBun('install');
       break;
   }
 }
@@ -38,6 +39,10 @@ export async function installPackage(specifier: string, registry?: string): Prom
       return silentNpm('install', specifier, ...registryOption);
     case 'yarn':
       return silentYarn('add', specifier, ...registryOption);
+    case 'bun':
+      return silentBun('add', specifier, ...registryOption);
+    case 'pnpm':
+      return silentPnpm('add', specifier, ...registryOption);
   }
 }
 
@@ -47,6 +52,10 @@ export async function uninstallPackage(name: string): Promise<ProcessOutput> {
       return silentNpm('uninstall', name);
     case 'yarn':
       return silentYarn('remove', name);
+    case 'bun':
+      return silentBun('remove', name);
+    case 'pnpm':
+      return silentPnpm('remove', name);
   }
 }
 

--- a/tests/legacy-cli/e2e/utils/process.ts
+++ b/tests/legacy-cli/e2e/utils/process.ts
@@ -359,6 +359,14 @@ export function silentYarn(...args: string[]) {
   return _exec({ silent: true }, 'yarn', args);
 }
 
+export function silentPnpm(...args: string[]) {
+  return _exec({ silent: true }, 'pnpm', args);
+}
+
+export function silentBun(...args: string[]) {
+  return _exec({ silent: true }, 'bun', args);
+}
+
 export function globalNpm(args: string[], env?: NodeJS.ProcessEnv) {
   if (!process.env.LEGACY_CLI_RUNNER) {
     throw new Error(
@@ -367,10 +375,6 @@ export function globalNpm(args: string[], env?: NodeJS.ProcessEnv) {
   }
 
   return _exec({ silent: true, env }, process.execPath, [require.resolve('npm'), ...args]);
-}
-
-export function npm(...args: string[]) {
-  return _exec({}, 'npm', args);
 }
 
 export function node(...args: string[]) {

--- a/tests/legacy-cli/e2e_runner.ts
+++ b/tests/legacy-cli/e2e_runner.ts
@@ -19,39 +19,30 @@ Error.stackTraceLimit = Infinity;
 
 /**
  * Here's a short description of those flags:
- *   --debug          If a test fails, block the thread so the temporary directory isn't deleted.
- *   --noproject      Skip creating a project or using one.
- *   --noglobal       Skip linking your local @angular/cli directory. Can save a few seconds.
- *   --nosilent       Never silence ng commands.
- *   --ng-tag=TAG     Use a specific tag for build snapshots. Similar to ng-snapshots but point to a
- *                    tag instead of using the latest `main`.
- *   --ng-snapshots   Install angular snapshot builds in the test project.
- *   --glob           Run tests matching this glob pattern (relative to tests/e2e/).
- *   --ignore         Ignore tests matching this glob pattern.
- *   --reuse=/path    Use a path instead of create a new project. That project should have been
- *                    created, and npm installed. Ideally you want a project created by a previous
- *                    run of e2e.
- *   --nb-shards      Total number of shards that this is part of. Default is 2 if --shard is
- *                    passed in.
- *   --shard          Index of this processes' shard.
- *   --tmpdir=path    Override temporary directory to use for new projects.
- *   --yarn           Use yarn as package manager.
- *   --package=path   An npm package to be published before running tests
+ *   --debug           If a test fails, block the thread so the temporary directory isn't deleted.
+ *   --noproject       Skip creating a project or using one.
+ *   --noglobal        Skip linking your local @angular/cli directory. Can save a few seconds.
+ *   --nosilent        Never silence ng commands.
+ *   --ng-tag=TAG      Use a specific tag for build snapshots. Similar to ng-snapshots but point to a
+ *                     tag instead of using the latest `main`.
+ *   --ng-snapshots    Install angular snapshot builds in the test project.
+ *   --glob            Run tests matching this glob pattern (relative to tests/e2e/).
+ *   --ignore          Ignore tests matching this glob pattern.
+ *   --reuse=/path     Use a path instead of create a new project. That project should have been
+ *                     created, and npm installed. Ideally you want a project created by a previous
+ *                     run of e2e.
+ *   --nb-shards       Total number of shards that this is part of. Default is 2 if --shard is
+ *                     passed in.
+ *   --shard           Index of this processes' shard.
+ *   --tmpdir=path     Override temporary directory to use for new projects.
+ *   --package-manager Package manager to use.
+ *   --package=path    An npm package to be published before running tests
  *
  * If unnamed flags are passed in, the list of tests will be filtered to include only those passed.
  */
 const argv = yargsParser(process.argv.slice(2), {
-  boolean: [
-    'debug',
-    'esbuild',
-    'ng-snapshots',
-    'noglobal',
-    'nosilent',
-    'noproject',
-    'verbose',
-    'yarn',
-  ],
-  string: ['devkit', 'glob', 'reuse', 'ng-tag', 'tmpdir', 'ng-version'],
+  boolean: ['debug', 'esbuild', 'ng-snapshots', 'noglobal', 'nosilent', 'noproject', 'verbose'],
+  string: ['devkit', 'glob', 'reuse', 'ng-tag', 'tmpdir', 'ng-version', 'package-manager'],
   number: ['nb-shards', 'shard'],
   array: ['package', 'ignore'],
   configuration: {
@@ -59,6 +50,7 @@ const argv = yargsParser(process.argv.slice(2), {
     'dot-notation': false,
   },
   default: {
+    'package-manager': 'npm',
     'package': ['./dist/_*.tgz'],
     'debug': !!process.env.BUILD_WORKSPACE_DIRECTORY,
     'glob': process.env.TESTBRIDGE_TEST_ONLY,
@@ -140,8 +132,8 @@ const allTests = glob
     // will be executed on the same shard.
     const fileName = path.basename(name);
     if (
-      (fileName.startsWith('yarn-') && !argv.yarn) ||
-      (fileName.startsWith('npm-') && argv.yarn)
+      (fileName.startsWith('yarn-') && argv['package-manager'] !== 'yarn') ||
+      (fileName.startsWith('npm-') && argv['package-manager'] !== 'npm')
     ) {
       return false;
     }
@@ -197,7 +189,7 @@ if (testsToRun.length == allTests.length) {
 console.log(['Tests:', ...testsToRun].join('\n '));
 
 setGlobalVariable('argv', argv);
-setGlobalVariable('package-manager', argv.yarn ? 'yarn' : 'npm');
+setGlobalVariable('package-manager', argv['package-manager']);
 
 // Use the chrome supplied by bazel or the puppeteer chrome and webdriver-manager driver outside.
 // This is needed by karma-chrome-launcher, protractor etc.


### PR DESCRIPTION
This commit adds PNPM and Bun package managers as subsets. However, Bun tests are currently disabled due to an issue where packages from the local registry are only partially extracted.