### PR TITLE
build: remove `--silent` from `yarn` command

### DIFF
--- a/scripts/build-schema.mts
+++ b/scripts/build-schema.mts
@@ -13,7 +13,7 @@ import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const baseDir = resolve(`${__dirname}/..`);
-const bazelCmd = process.env.BAZEL ?? `yarn --silent bazel`;
+const bazelCmd = process.env.BAZEL ?? `yarn bazel`;
 const distRoot = join(baseDir, '/dist-schema/');
 
 function _clean() {


### PR DESCRIPTION
`--silent` is not a valid option for Yarn 4. This causes the build-schema script to fail.
