### PR TITLE
refactor: replace custom promise-based setTimeout with native Node.js setTimeout

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/karma/tests/behavior/code-coverage_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/tests/behavior/code-coverage_spec.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import { setTimeout } from 'node:timers/promises';
 import { tags } from '@angular-devkit/core';
 import { last, tap } from 'rxjs';
-import { promisify } from 'util';
 import { execute } from '../../index';
 import { BASE_OPTIONS, KARMA_BUILDER_INFO, describeBuilder } from '../setup';
 
@@ -19,7 +19,6 @@ import { BASE_OPTIONS, KARMA_BUILDER_INFO, describeBuilder } from '../setup';
 // are subsequently written to disk. For more information, see
 // https://github.com/karma-runner/karma-coverage/blob/32acafa90ed621abd1df730edb44ae55a4009c2c/lib/reporter.js#L221
 
-const setTimeoutPromise = promisify(setTimeout);
 const coveragePath = 'coverage/lcov.info';
 
 describeBuilder(execute, KARMA_BUILDER_INFO, (harness) => {
@@ -36,7 +35,7 @@ describeBuilder(execute, KARMA_BUILDER_INFO, (harness) => {
       const { result } = await harness.executeOnce();
       expect(result?.success).toBeTrue();
 
-      await setTimeoutPromise(1000);
+      await setTimeout(1000);
       harness.expectFile(coveragePath).toExist();
     });
 
@@ -111,7 +110,7 @@ describeBuilder(execute, KARMA_BUILDER_INFO, (harness) => {
       const { result } = await harness.executeOnce();
       expect(result?.success).toBeTrue();
 
-      await setTimeoutPromise(1000);
+      await setTimeout(1000);
 
       harness
         .expectFile('coverage/app.component.ts.html')

--- a/packages/angular_devkit/build_angular/src/builders/karma/tests/options/code-coverage-exclude_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/tests/options/code-coverage-exclude_spec.ts
@@ -5,8 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.dev/license
  */
-
-import { promisify } from 'util';
+import { setTimeout } from 'node:timers/promises';
 import { execute } from '../../index';
 import { BASE_OPTIONS, KARMA_BUILDER_INFO, describeBuilder } from '../setup';
 
@@ -17,7 +16,6 @@ import { BASE_OPTIONS, KARMA_BUILDER_INFO, describeBuilder } from '../setup';
 // are subsequently written to disk. For more information, see
 // https://github.com/karma-runner/karma-coverage/blob/32acafa90ed621abd1df730edb44ae55a4009c2c/lib/reporter.js#L221
 
-const setTimeoutPromise = promisify(setTimeout);
 const coveragePath = 'coverage/lcov.info';
 
 describeBuilder(execute, KARMA_BUILDER_INFO, (harness) => {
@@ -33,7 +31,7 @@ describeBuilder(execute, KARMA_BUILDER_INFO, (harness) => {
 
       expect(result?.success).toBeTrue();
 
-      await setTimeoutPromise(1000);
+      await setTimeout(1000);
       harness.expectFile(coveragePath).content.not.toContain('app.component.ts');
     });
 
@@ -48,7 +46,7 @@ describeBuilder(execute, KARMA_BUILDER_INFO, (harness) => {
 
       expect(result?.success).toBeTrue();
 
-      await setTimeoutPromise(1000);
+      await setTimeout(1000);
       harness.expectFile(coveragePath).content.not.toContain('app.component.ts');
     });
 
@@ -62,7 +60,7 @@ describeBuilder(execute, KARMA_BUILDER_INFO, (harness) => {
 
       expect(result?.success).toBeTrue();
 
-      await setTimeoutPromise(1000);
+      await setTimeout(1000);
       harness.expectFile(coveragePath).content.toContain('app.component.ts');
     });
   });

--- a/packages/angular_devkit/build_angular/src/builders/karma/tests/options/code-coverage_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/tests/options/code-coverage_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import { promisify } from 'util';
+import { setTimeout } from 'node:timers/promises';
 import { execute } from '../../index';
 import { BASE_OPTIONS, KARMA_BUILDER_INFO, describeBuilder } from '../setup';
 
@@ -17,7 +17,6 @@ import { BASE_OPTIONS, KARMA_BUILDER_INFO, describeBuilder } from '../setup';
 // are subsequently written to disk. For more information, see
 // https://github.com/karma-runner/karma-coverage/blob/32acafa90ed621abd1df730edb44ae55a4009c2c/lib/reporter.js#L221
 
-const setTimeoutPromise = promisify(setTimeout);
 const coveragePath = 'coverage/lcov.info';
 
 describeBuilder(execute, KARMA_BUILDER_INFO, (harness) => {
@@ -31,7 +30,7 @@ describeBuilder(execute, KARMA_BUILDER_INFO, (harness) => {
       const { result } = await harness.executeOnce();
       expect(result?.success).toBeTrue();
 
-      await setTimeoutPromise(1000);
+      await setTimeout(1000);
       harness.expectFile(coveragePath).toExist();
     });
 
@@ -45,7 +44,7 @@ describeBuilder(execute, KARMA_BUILDER_INFO, (harness) => {
 
       expect(result?.success).toBeTrue();
 
-      await setTimeoutPromise(1000);
+      await setTimeout(1000);
       harness.expectFile(coveragePath).toNotExist();
     });
 
@@ -58,7 +57,7 @@ describeBuilder(execute, KARMA_BUILDER_INFO, (harness) => {
 
       expect(result?.success).toBeTrue();
 
-      await setTimeoutPromise(1000);
+      await setTimeout(1000);
       harness.expectFile(coveragePath).toNotExist();
     });
 
@@ -73,7 +72,7 @@ describeBuilder(execute, KARMA_BUILDER_INFO, (harness) => {
         './src/app/app.component.ts': `
           import { Component } from '@angular/core';
           import { title } from 'my-lib';
-  
+
           @Component({
             selector: 'app-root',
             templateUrl: './app.component.html',
@@ -105,7 +104,7 @@ describeBuilder(execute, KARMA_BUILDER_INFO, (harness) => {
       const { result } = await harness.executeOnce();
       expect(result?.success).toBeTrue();
 
-      await setTimeoutPromise(1000);
+      await setTimeout(1000);
       harness.expectFile(coveragePath).content.not.toContain('my-lib');
     });
   });


### PR DESCRIPTION


In this commit, the custom implementation of a promise-based setTimeout function has been replaced with the native Node.js setTimeout function, which now returns a promise.
