### PR TITLE
ci: disable `yarn` auto update

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,13 @@
   "dependencyDashboard": true,
   "schedule": ["after 10:00pm every weekday", "before 4:00am every weekday", "every weekend"],
   "baseBranches": ["main"],
-  "ignoreDeps": ["@types/node", "build_bazel_rules_nodejs", "rules_pkg", "copy-webpack-plugin"],
+  "ignoreDeps": [
+    "@types/node",
+    "build_bazel_rules_nodejs",
+    "rules_pkg",
+    "copy-webpack-plugin",
+    "yarn"
+  ],
   "includePaths": [
     "WORKSPACE",
     "package.json",


### PR DESCRIPTION
Since the yarn version is specified in the Bazel setup, automatically updating the dependency is not feasible.
