### PR TITLE
build: disable package install scripts by default

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,4 @@
 nodeLinker: node-modules
+enableScripts: false
 
 yarnPath: .yarn/releases/yarn-4.2.2.cjs

--- a/package.json
+++ b/package.json
@@ -210,6 +210,14 @@
     "yargs-parser": "21.1.1",
     "zone.js": "^0.14.0"
   },
+  "dependenciesMeta": {
+    "esbuild": {
+      "built": true
+    },
+    "puppeteer": {
+      "built": true
+    }
+  },
   "resolutions": {
     "@bazel/concatjs@npm:5.8.1": "patch:@bazel/concatjs@npm%3A5.8.1#~/.yarn/patches/@bazel-concatjs-npm-5.8.1-1bf81df846.patch"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -776,6 +776,11 @@ __metadata:
     yargs: "npm:17.7.2"
     yargs-parser: "npm:21.1.1"
     zone.js: "npm:^0.14.0"
+  dependenciesMeta:
+    esbuild:
+      built: true
+    puppeteer:
+      built: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Package installation will now disable postinstall scripts by default for the repository dependencies. The yarn `enableScripts` option is now set to `false`. This still allows workspace postinstall scripts to execute and the required dependency postinstall scripts are explicitly allowed (currently: esbuild & puppeteer).