### PR TITLE
refactor(@angular/cli): remove dependency on `resolve`

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,6 @@
     "@types/pacote": "^11.1.3",
     "@types/picomatch": "^2.3.0",
     "@types/progress": "^2.0.3",
-    "@types/resolve": "^1.17.1",
     "@types/semver": "^7.3.12",
     "@types/shelljs": "^0.8.11",
     "@types/tar": "^6.1.2",

--- a/packages/angular/cli/BUILD.bazel
+++ b/packages/angular/cli/BUILD.bazel
@@ -59,7 +59,6 @@ ts_library(
         "@npm//@types/node",
         "@npm//@types/npm-package-arg",
         "@npm//@types/pacote",
-        "@npm//@types/resolve",
         "@npm//@types/semver",
         "@npm//@types/yargs",
         "@npm//@types/yarnpkg__lockfile",

--- a/packages/angular/cli/package.json
+++ b/packages/angular/cli/package.json
@@ -35,7 +35,6 @@
     "npm-pick-manifest": "9.0.1",
     "ora": "5.4.1",
     "pacote": "18.0.6",
-    "resolve": "1.22.8",
     "semver": "7.6.2",
     "symbol-observable": "4.0.0",
     "yargs": "17.7.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -522,7 +522,6 @@ __metadata:
     npm-pick-manifest: "npm:9.0.1"
     ora: "npm:5.4.1"
     pacote: "npm:18.0.6"
-    resolve: "npm:1.22.8"
     semver: "npm:7.6.2"
     symbol-observable: "npm:4.0.0"
     yargs: "npm:17.7.2"
@@ -671,7 +670,6 @@ __metadata:
     "@types/pacote": "npm:^11.1.3"
     "@types/picomatch": "npm:^2.3.0"
     "@types/progress": "npm:^2.0.3"
-    "@types/resolve": "npm:^1.17.1"
     "@types/semver": "npm:^7.3.12"
     "@types/shelljs": "npm:^0.8.11"
     "@types/tar": "npm:^6.1.2"
@@ -5960,13 +5958,6 @@ __metadata:
   version: 1.20.2
   resolution: "@types/resolve@npm:1.20.2"
   checksum: 10c0/c5b7e1770feb5ccfb6802f6ad82a7b0d50874c99331e0c9b259e415e55a38d7a86ad0901c57665d93f75938be2a6a0bc9aa06c9749192cadb2e4512800bbc6e6
-  languageName: node
-  linkType: hard
-
-"@types/resolve@npm:^1.17.1":
-  version: 1.20.6
-  resolution: "@types/resolve@npm:1.20.6"
-  checksum: 10c0/a9b0549d816ff2c353077365d865a33655a141d066d0f5a3ba6fd4b28bc2f4188a510079f7c1f715b3e7af505a27374adce2a5140a3ece2a059aab3d6e1a4244
   languageName: node
   linkType: hard
 
@@ -16067,7 +16058,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@npm:1.22.8, resolve@npm:^1.1.6, resolve@npm:^1.14.2, resolve@npm:^1.19.0, resolve@npm:^1.22.1, resolve@npm:^1.22.4, resolve@npm:~1.22.1, resolve@npm:~1.22.2":
+"resolve@npm:^1.1.6, resolve@npm:^1.14.2, resolve@npm:^1.19.0, resolve@npm:^1.22.1, resolve@npm:^1.22.4, resolve@npm:~1.22.1, resolve@npm:~1.22.2":
   version: 1.22.8
   resolution: "resolve@npm:1.22.8"
   dependencies:
@@ -16080,7 +16071,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@npm%3A1.22.8#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.1.6#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.14.2#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.19.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.4#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A~1.22.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A~1.22.2#optional!builtin<compat/resolve>":
+"resolve@patch:resolve@npm%3A^1.1.6#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.14.2#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.19.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.4#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A~1.22.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A~1.22.2#optional!builtin<compat/resolve>":
   version: 1.22.8
   resolution: "resolve@patch:resolve@npm%3A1.22.8#optional!builtin<compat/resolve>::version=1.22.8&hash=c3c19d"
   dependencies:


### PR DESCRIPTION

Instead of using the `resolve` npm package, we avoid populating `Module._pathCache` when resolving package JSON files.