### PR TITLE
test: re-enable WTR test

### DIFF
--- a/tests/legacy-cli/e2e/tests/web-test-runner/basic.ts
+++ b/tests/legacy-cli/e2e/tests/web-test-runner/basic.ts
@@ -2,9 +2,6 @@ import { noSilentNg } from '../../utils/process';
 import { applyWtrBuilder } from '../../utils/web-test-runner';
 
 export default async function () {
-  // Temporary disable this test until we fix it.
-  return;
-
   await applyWtrBuilder();
 
   const { stderr } = await noSilentNg('test');


### PR DESCRIPTION
This was disabled due to an issue with Puppeteer and Bazel which has been resolved by a simple version update.