### PR TITLE
test: use Node test runner for E2E tests

### DIFF
--- a/tests/legacy-cli/e2e/tests/web-test-runner/basic.ts
+++ b/tests/legacy-cli/e2e/tests/web-test-runner/basic.ts
@@ -1,15 +1,11 @@
+import assert from 'node:assert';
 import { noSilentNg } from '../../utils/process';
 import { applyWtrBuilder } from '../../utils/web-test-runner';
 
 export default async function () {
-  // Temporary disable this test until we fix it.
-  return;
-
   await applyWtrBuilder();
 
   const { stderr } = await noSilentNg('test');
 
-  if (!stderr.includes('Web Test Runner builder is currently EXPERIMENTAL')) {
-    throw new Error(`No experimental notice in stderr.\nSTDERR:\n\n${stderr}`);
-  }
+  assert.match(stderr, /Web Test Runner builder is currently EXPERIMENTAL/);
 }

--- a/tests/legacy-cli/e2e/utils/invoke_default_export.ts
+++ b/tests/legacy-cli/e2e/utils/invoke_default_export.ts
@@ -1,0 +1,21 @@
+const script: string = process.argv[2];
+const moduleToExec = require(script);
+const defaultExport: () => Promise<void> | void =
+  typeof moduleToExec == 'function'
+    ? moduleToExec
+    : typeof moduleToExec.default == 'function'
+      ? moduleToExec.default
+      : () => {
+          throw new Error('Invalid module.');
+        };
+
+(async () => {
+  try {
+    await defaultExport();
+  } catch (e) {
+    console.error('Process error', e);
+    process.exitCode = -1;
+  } finally {
+    process.exit();
+  }
+})();

--- a/tests/legacy-cli/e2e/utils/process.ts
+++ b/tests/legacy-cli/e2e/utils/process.ts
@@ -390,13 +390,39 @@ export function silentGit(...args: string[]) {
 }
 
 /**
+ * Execute the given entry file using Node's built-in test runner.
+ *
+ * @see https://nodejs.org/api/test.html
+ */
+export async function launchTestProcess(entry: string): Promise<void> {
+  const testEntry = resolve(__dirname, 'test_process.js');
+  await launchProcess(testEntry, {
+    nodeOptions: ['--test'],
+    env: {
+      NG_TEST_ENTRY: entry,
+    },
+  });
+}
+
+/**
  * Launch the given entry in an child process isolated to the test environment.
  *
  * The test environment includes the local NPM registry, isolated NPM globals,
  * the PATH variable only referencing the local node_modules and local NPM
  * registry (not the test runner or standard global node_modules).
  */
-export async function launchTestProcess(entry: string, ...args: any[]): Promise<void> {
+export async function launchProcess(
+  entry: string,
+  {
+    args: inputArgs = [],
+    env: inputEnv = {},
+    nodeOptions = [],
+  }: {
+    args?: string[];
+    env?: Record<string, string>;
+    nodeOptions?: string[];
+  } = {},
+): Promise<void> {
   // NOTE: do NOT use the bazel TEST_TMPDIR. When sandboxing is not enabled the
   // TEST_TMPDIR is not sandboxed and has symlinks into the src dir in a
   // parent directory. Symlinks into the src dir will include package.json,
@@ -407,6 +433,8 @@ export async function launchTestProcess(entry: string, ...args: any[]): Promise<
 
   // Extract explicit environment variables for the test process.
   const env: NodeJS.ProcessEnv = {
+    ...inputEnv,
+
     TEMP,
     TMPDIR: TEMP,
     HOME: TEMP,
@@ -428,10 +456,10 @@ export async function launchTestProcess(entry: string, ...args: any[]): Promise<
     .filter((p) => p.startsWith(tempRoot) || p.startsWith(TEMP) || !p.includes('angular-cli'))
     .join(delimiter);
 
-  const testProcessArgs = [resolve(__dirname, 'test_process'), entry, ...args];
+  const args = [...nodeOptions, entry, ...inputArgs];
 
   return new Promise<void>((resolve, reject) => {
-    spawn(process.execPath, testProcessArgs, {
+    spawn(process.execPath, args, {
       stdio: 'inherit',
       env,
     })
@@ -441,10 +469,14 @@ export async function launchTestProcess(entry: string, ...args: any[]): Promise<
           return;
         }
 
-        reject(`Process error - "${testProcessArgs}`);
+        reject(
+          `Process error (code ${code}) - \`${process.execPath} ${args.map((arg) => `"${arg}"`).join(' ')}\``,
+        );
       })
       .on('error', (err) => {
-        reject(`Process exit error - "${testProcessArgs}]\n\n${err}`);
+        reject(
+          `Process exit error - \`${process.execPath} ${args.map((arg) => `"${arg}"`).join(' ')}]\n\n${err}\``,
+        );
       });
   });
 }

--- a/tests/legacy-cli/e2e/utils/test_process.ts
+++ b/tests/legacy-cli/e2e/utils/test_process.ts
@@ -1,4 +1,6 @@
-const testScript: string = process.argv[2];
+import { it } from 'node:test';
+
+const testScript: string = process.env['NG_TEST_ENTRY']!;
 const testModule = require(testScript);
 const testFunction: () => Promise<void> | void =
   typeof testModule == 'function'
@@ -9,13 +11,4 @@ const testFunction: () => Promise<void> | void =
           throw new Error('Invalid test module.');
         };
 
-(async () => {
-  try {
-    await testFunction();
-  } catch (e) {
-    console.error('Test Process error', e);
-    process.exitCode = -1;
-  } finally {
-    process.exit();
-  }
-})();
+it(testScript, testFunction);

--- a/tests/legacy-cli/e2e_runner.ts
+++ b/tests/legacy-cli/e2e_runner.ts
@@ -6,8 +6,8 @@ import * as path from 'path';
 import { getGlobalVariable, setGlobalVariable } from './e2e/utils/env';
 import { gitClean } from './e2e/utils/git';
 import { createNpmRegistry } from './e2e/utils/registry';
-import { launchTestProcess } from './e2e/utils/process';
-import { delimiter, dirname, join } from 'path';
+import { launchProcess, launchTestProcess } from './e2e/utils/process';
+import { delimiter, dirname, join, resolve } from 'path';
 import { findFreePort } from './e2e/utils/network';
 import { extractFile } from './e2e/utils/tar';
 import { realpathSync } from 'fs';
@@ -298,13 +298,15 @@ function runSetup(absoluteName: string): Promise<void> {
   return (typeof module === 'function' ? module : module.default)();
 }
 
+const invoker = resolve(__dirname, 'e2e/utils/invoke_default_export.js');
+
 /**
  * Run a file from the projects root directory in a subprocess via launchTestProcess().
  */
 function runInitializer(absoluteName: string): Promise<void> {
   process.chdir(getGlobalVariable('projects-root'));
 
-  return launchTestProcess(absoluteName);
+  return launchProcess(invoker, { args: [absoluteName] });
 }
 
 /**


### PR DESCRIPTION
This updates the E2E test runner to invoke test programs with `node --test`. This allows us to use the `assert` API for expressive assertions and print failures with more details.

Unfortunately, it seems that the test runner and the test file are actually executed as two separate processes. This means that we run `node --test` for _each_ test and print out N reports each containing exactly 1 test. This isn't ideal, but it's good enough for using assertions. We can also explore using `node --test` for the test runner just to print a single test report with all the tests listed. This might require running test code in process with the test runner.

`node --test` is a little awkward in that it seems to treat all arguments as file paths to test, meaning there's no easy way to pass arguments into the tests. Since we're actually invoking our own test runner, we need to pass through the actual file being tested, but this is not easy to do with `node --test`. I feel like `node --test test_runner.js -- file_under_test.js` _should_ work, but actually doesn't. Instead, I opted to pass the file through as an environment variable. It's inelegant, but good enough for now.

I also had to separate out running a _test_ from running an arbitrary process, which were previously using the same code path and conflicting with each other.

Example output for a test failure: https://gist.github.com/dgp1130/e795d5d540ec98de7aac02a363f56998