### PR TITLE
fix(@angular/build): automatically resolve `.mjs` files when using Vite

### DIFF
--- a/packages/angular/build/src/builders/dev-server/vite-server.ts
+++ b/packages/angular/build/src/builders/dev-server/vite-server.ts
@@ -677,6 +677,7 @@ function getDepOptimizationConfig({
       supported: getFeatureSupport(target, zoneless),
       plugins,
       loader,
+      resolveExtensions: ['.mjs', '.js', '.cjs'],
     },
   };
 }

--- a/packages/angular/build/src/tools/esbuild/application-code-bundle.ts
+++ b/packages/angular/build/src/tools/esbuild/application-code-bundle.ts
@@ -360,7 +360,7 @@ function getEsBuildCommonOptions(options: NormalizedApplicationBuildOptions): Bu
     format: 'esm',
     assetNames: outputNames.media,
     conditions: ['es2020', 'es2015', 'module'],
-    resolveExtensions: ['.ts', '.tsx', '.mjs', '.js'],
+    resolveExtensions: ['.ts', '.tsx', '.mjs', '.js', '.cjs'],
     metafile: true,
     legalComments: options.extractLicenses ? 'none' : 'eof',
     logLevel: options.verbose && !jsonLogs ? 'debug' : 'silent',

--- a/packages/angular/build/src/tools/esbuild/global-scripts.ts
+++ b/packages/angular/build/src/tools/esbuild/global-scripts.ts
@@ -63,7 +63,7 @@ export function createGlobalScriptsBundleOptions(
       assetNames: outputNames.media,
       mainFields: ['script', 'browser', 'main'],
       conditions: ['script'],
-      resolveExtensions: ['.mjs', '.js'],
+      resolveExtensions: ['.mjs', '.js', '.cjs'],
       logLevel: options.verbose && !jsonLogs ? 'debug' : 'silent',
       metafile: true,
       minify: optimizationOptions.scripts,


### PR DESCRIPTION
Previously, ESM file resolution without extensions failed when using Vite, causing issues in module loading. This commit addresses the problem by automatically resolving `.mjs` files, aligning the behavior with the application builder and ensuring consistent module resolution across different build tools.

**NB**:  This is a workaround as valid ESM imports should always have an extension.

Closes #27841
