### PR TITLE
fix(@angular/cli): update schematics to use RouterModule when --routing flag is present

### DIFF
--- a/packages/schematics/angular/application/files/module-files/src/app/app.component.spec.ts.template
+++ b/packages/schematics/angular/application/files/module-files/src/app/app.component.spec.ts.template
@@ -1,12 +1,12 @@
 import { TestBed } from '@angular/core/testing';<% if (routing) { %>
-import { RouterTestingModule } from '@angular/router/testing';<% } %>
+import { RouterModule } from '@angular/router';<% } %>
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({<% if (routing) { %>
       imports: [
-        RouterTestingModule
+        RouterModule.forRoot([])
       ],<% } %>
       declarations: [
         AppComponent

--- a/tests/legacy-cli/e2e/assets/15.0-project/src/app/app.component.spec.ts
+++ b/tests/legacy-cli/e2e/assets/15.0-project/src/app/app.component.spec.ts
@@ -1,12 +1,12 @@
 import { TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
+import { RouterModule } from '@angular/router';
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [
-        RouterTestingModule
+        RouterModule.forRoot([])
       ],
       declarations: [
         AppComponent

--- a/tests/legacy-cli/e2e/assets/18-ssr-project-webpack/src/app/app.component.spec.ts
+++ b/tests/legacy-cli/e2e/assets/18-ssr-project-webpack/src/app/app.component.spec.ts
@@ -1,10 +1,10 @@
 import { TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
+import { RouterModule } from '@angular/router';
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
   beforeEach(() => TestBed.configureTestingModule({
-    imports: [RouterTestingModule],
+    imports: [RouterModule.forRoot([])],
     declarations: [AppComponent]
   }));
 


### PR DESCRIPTION
update schematics to use RouterModule instead of RouterTestingModule when generating a new project with the --routing flag

Fixes #27691

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Running `ng new --inline-style false --inline-template false --package-manager bun --routing --skip-git --standalone false --strict true --ssr false --style scss my-test-app` generates a new project with the `RouterTestingModule` which is deprecated

Issue Number: #27691 

## What is the new behavior?

Running `ng new --inline-style false --inline-template false --package-manager bun --routing --skip-git --standalone false --strict true --ssr false --style scss my-test-app` generates a new projects with the `RouterModule`
<!-- Please describe the new behavior that. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

NA