### PR TITLE
ci: remove ci testing push trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,6 @@ on:
       - main
       - '[0-9]+.[0-9]+.x'
 
-      # Developers can make one-off pushes to `ci-*` branches to manually trigger full CI
-      # prior to opening a pull request.
-      - ci-*
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Remove ci testing pushing trigger as it no longer will work in the future and is unneccessary
