### PR TITLE
fix(@angular/build): use Node.js available parallelism for default worker count

### DIFF
--- a/packages/angular/build/src/utils/environment-options.ts
+++ b/packages/angular/build/src/utils/environment-options.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import { availableParallelism } from 'node:os';
+
 function isDisabled(variable: string): boolean {
   return variable === '0' || variable.toLowerCase() === 'false';
 }
@@ -74,7 +76,9 @@ export const allowMinify = debugOptimize.minify;
  *
  */
 const maxWorkersVariable = process.env['NG_BUILD_MAX_WORKERS'];
-export const maxWorkers = isPresent(maxWorkersVariable) ? +maxWorkersVariable : 4;
+export const maxWorkers = isPresent(maxWorkersVariable)
+  ? +maxWorkersVariable
+  : Math.min(4, availableParallelism());
 
 const parallelTsVariable = process.env['NG_BUILD_PARALLEL_TS'];
 export const useParallelTs = !isPresent(parallelTsVariable) || !isDisabled(parallelTsVariable);

--- a/packages/angular_devkit/build_angular/src/utils/environment-options.ts
+++ b/packages/angular_devkit/build_angular/src/utils/environment-options.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import { availableParallelism } from 'node:os';
+
 function isDisabled(variable: string): boolean {
   return variable === '0' || variable.toLowerCase() === 'false';
 }
@@ -74,7 +76,9 @@ export const allowMinify = debugOptimize.minify;
  *
  */
 const maxWorkersVariable = process.env['NG_BUILD_MAX_WORKERS'];
-export const maxWorkers = isPresent(maxWorkersVariable) ? +maxWorkersVariable : 4;
+export const maxWorkers = isPresent(maxWorkersVariable)
+  ? +maxWorkersVariable
+  : Math.min(4, availableParallelism());
 
 const parallelTsVariable = process.env['NG_BUILD_PARALLEL_TS'];
 export const useParallelTs = !isPresent(parallelTsVariable) || !isDisabled(parallelTsVariable);


### PR DESCRIPTION
The Node.js `os.availableParallelism` API now provides more accurate values when used within containers such as many CI environments. This provides a better default when using resource limited CI setups. The value is still set to a maximum default of four. However, the `NG_BUILD_MAX_WORKERS` environment variable can be used to set the value to an explicit value if required.