### PR TITLE
refactor(@angular/build): include Angular compiler plugin in private API

### DIFF
--- a/packages/angular/build/src/private.ts
+++ b/packages/angular/build/src/private.ts
@@ -28,6 +28,7 @@ export { SassWorkerImplementation } from './tools/sass/sass-service';
 export { SourceFileCache } from './tools/esbuild/angular/source-file-cache';
 export { createJitResourceTransformer } from './tools/esbuild/angular/jit-resource-transformer';
 export { JavaScriptTransformer } from './tools/esbuild/javascript-transformer';
+export { createCompilerPlugin } from './tools/esbuild/angular/compiler-plugin';
 
 // Utilities
 export * from './utils/bundle-calculator';


### PR DESCRIPTION
Add `createCompilerPlugin` function to the private export of the package. Note that these are not considered part of the public API and are intended for use only with the `@angular-devkit/build-angular` package.