### PR TITLE
build: update to TypeScript 5.5 stable

### DIFF
--- a/package.json
+++ b/package.json
@@ -197,7 +197,7 @@
     "tree-kill": "1.2.2",
     "ts-node": "^10.9.1",
     "tslib": "2.6.3",
-    "typescript": "5.5.1-rc",
+    "typescript": "5.5.2",
     "undici": "6.19.2",
     "verdaccio": "5.31.1",
     "verdaccio-auth-memory": "^10.0.0",

--- a/packages/ngtools/webpack/package.json
+++ b/packages/ngtools/webpack/package.json
@@ -29,7 +29,7 @@
     "@angular-devkit/core": "0.0.0-PLACEHOLDER",
     "@angular/compiler": "18.1.0-next.3",
     "@angular/compiler-cli": "18.1.0-next.3",
-    "typescript": "5.5.1-rc",
+    "typescript": "5.5.2",
     "webpack": "5.92.1"
   }
 }

--- a/packages/schematics/angular/third_party/github.com/Microsoft/TypeScript/BUILD.bazel
+++ b/packages/schematics/angular/third_party/github.com/Microsoft/TypeScript/BUILD.bazel
@@ -1,11 +1,11 @@
 load("//tools:defaults.bzl", "ts_library")
 
-# files fetched on 2024-06-11 from
-# https://github.com/microsoft/TypeScript/releases/tag/v5.5-rc
+# files fetched on 2024-07-02 from
+# https://github.com/microsoft/TypeScript/releases/tag/v5.5.2
 
 # Commands to download:
-# curl https://raw.githubusercontent.com/microsoft/TypeScript/v5.5-rc/lib/typescript.d.ts -o packages/schematics/angular/third_party/github.com/Microsoft/TypeScript/lib/typescript.d.ts
-# curl https://raw.githubusercontent.com/microsoft/TypeScript/v5.5-rc/lib/typescript.js -o packages/schematics/angular/third_party/github.com/Microsoft/TypeScript/lib/typescript.js
+# curl https://raw.githubusercontent.com/microsoft/TypeScript/v5.5.2/lib/typescript.d.ts -o packages/schematics/angular/third_party/github.com/Microsoft/TypeScript/lib/typescript.d.ts
+# curl https://raw.githubusercontent.com/microsoft/TypeScript/v5.5.2/lib/typescript.js -o packages/schematics/angular/third_party/github.com/Microsoft/TypeScript/lib/typescript.js
 
 licenses(["notice"])  # Apache 2.0
 

--- a/packages/schematics/angular/third_party/github.com/Microsoft/TypeScript/lib/typescript.d.ts
+++ b/packages/schematics/angular/third_party/github.com/Microsoft/TypeScript/lib/typescript.d.ts
@@ -6014,67 +6014,19 @@ declare namespace ts {
         isSourceFileFromExternalLibrary(file: SourceFile): boolean;
         isSourceFileDefaultLibrary(file: SourceFile): boolean;
         /**
-         * Calculates the final resolution mode for a given module reference node. This function only returns a result when module resolution
-         * settings allow differing resolution between ESM imports and CJS requires, or when a mode is explicitly provided via import attributes,
-         * which cause an `import` or `require` condition to be used during resolution regardless of module resolution settings. In absence of
-         * overriding attributes, and in modes that support differing resolution, the result indicates the syntax the usage would emit to JavaScript.
-         * Some examples:
-         *
-         * ```ts
-         * // tsc foo.mts --module nodenext
-         * import {} from "mod";
-         * // Result: ESNext - the import emits as ESM due to `impliedNodeFormat` set by .mts file extension
-         *
-         * // tsc foo.cts --module nodenext
-         * import {} from "mod";
-         * // Result: CommonJS - the import emits as CJS due to `impliedNodeFormat` set by .cts file extension
-         *
-         * // tsc foo.ts --module preserve --moduleResolution bundler
-         * import {} from "mod";
-         * // Result: ESNext - the import emits as ESM due to `--module preserve` and `--moduleResolution bundler`
-         * // supports conditional imports/exports
-         *
-         * // tsc foo.ts --module preserve --moduleResolution node10
-         * import {} from "mod";
-         * // Result: undefined - the import emits as ESM due to `--module preserve`, but `--moduleResolution node10`
-         * // does not support conditional imports/exports
-         *
-         * // tsc foo.ts --module commonjs --moduleResolution node10
-         * import type {} from "mod" with { "resolution-mode": "import" };
-         * // Result: ESNext - conditional imports/exports always supported with "resolution-mode" attribute
-         * ```
+         * Calculates the final resolution mode for a given module reference node. This is the resolution mode explicitly provided via import
+         * attributes, if present, or the syntax the usage would have if emitted to JavaScript. In `--module node16` or `nodenext`, this may
+         * depend on the file's `impliedNodeFormat`. In `--module preserve`, it depends only on the input syntax of the reference. In other
+         * `module` modes, when overriding import attributes are not provided, this function returns `undefined`, as the result would have no
+         * impact on module resolution, emit, or type checking.
          */
         getModeForUsageLocation(file: SourceFile, usage: StringLiteralLike): ResolutionMode;
         /**
-         * Calculates the final resolution mode for an import at some index within a file's `imports` list. This function only returns a result
-         * when module resolution settings allow differing resolution between ESM imports and CJS requires, or when a mode is explicitly provided
-         * via import attributes, which cause an `import` or `require` condition to be used during resolution regardless of module resolution
-         * settings. In absence of overriding attributes, and in modes that support differing resolution, the result indicates the syntax the
-         * usage would emit to JavaScript. Some examples:
-         *
-         * ```ts
-         * // tsc foo.mts --module nodenext
-         * import {} from "mod";
-         * // Result: ESNext - the import emits as ESM due to `impliedNodeFormat` set by .mts file extension
-         *
-         * // tsc foo.cts --module nodenext
-         * import {} from "mod";
-         * // Result: CommonJS - the import emits as CJS due to `impliedNodeFormat` set by .cts file extension
-         *
-         * // tsc foo.ts --module preserve --moduleResolution bundler
-         * import {} from "mod";
-         * // Result: ESNext - the import emits as ESM due to `--module preserve` and `--moduleResolution bundler`
-         * // supports conditional imports/exports
-         *
-         * // tsc foo.ts --module preserve --moduleResolution node10
-         * import {} from "mod";
-         * // Result: undefined - the import emits as ESM due to `--module preserve`, but `--moduleResolution node10`
-         * // does not support conditional imports/exports
-         *
-         * // tsc foo.ts --module commonjs --moduleResolution node10
-         * import type {} from "mod" with { "resolution-mode": "import" };
-         * // Result: ESNext - conditional imports/exports always supported with "resolution-mode" attribute
-         * ```
+         * Calculates the final resolution mode for an import at some index within a file's `imports` list. This is the resolution mode
+         * explicitly provided via import attributes, if present, or the syntax the usage would have if emitted to JavaScript. In
+         * `--module node16` or `nodenext`, this may depend on the file's `impliedNodeFormat`. In `--module preserve`, it depends only on the
+         * input syntax of the reference. In other `module` modes, when overriding import attributes are not provided, this function returns
+         * `undefined`, as the result would have no impact on module resolution, emit, or type checking.
          */
         getModeForResolutionAtIndex(file: SourceFile, index: number): ResolutionMode;
         getProjectReferences(): readonly ProjectReference[] | undefined;
@@ -9427,43 +9379,24 @@ declare namespace ts {
     function getModeForResolutionAtIndex(file: SourceFile, index: number, compilerOptions: CompilerOptions): ResolutionMode;
     /**
      * Use `program.getModeForUsageLocation`, which retrieves the correct `compilerOptions`, instead of this function whenever possible.
-     * Calculates the final resolution mode for a given module reference node. This function only returns a result when module resolution
-     * settings allow differing resolution between ESM imports and CJS requires, or when a mode is explicitly provided via import attributes,
-     * which cause an `import` or `require` condition to be used during resolution regardless of module resolution settings. In absence of
-     * overriding attributes, and in modes that support differing resolution, the result indicates the syntax the usage would emit to JavaScript.
-     * Some examples:
-     *
-     * ```ts
-     * // tsc foo.mts --module nodenext
-     * import {} from "mod";
-     * // Result: ESNext - the import emits as ESM due to `impliedNodeFormat` set by .mts file extension
-     *
-     * // tsc foo.cts --module nodenext
-     * import {} from "mod";
-     * // Result: CommonJS - the import emits as CJS due to `impliedNodeFormat` set by .cts file extension
-     *
-     * // tsc foo.ts --module preserve --moduleResolution bundler
-     * import {} from "mod";
-     * // Result: ESNext - the import emits as ESM due to `--module preserve` and `--moduleResolution bundler`
-     * // supports conditional imports/exports
-     *
-     * // tsc foo.ts --module preserve --moduleResolution node10
-     * import {} from "mod";
-     * // Result: undefined - the import emits as ESM due to `--module preserve`, but `--moduleResolution node10`
-     * // does not support conditional imports/exports
-     *
-     * // tsc foo.ts --module commonjs --moduleResolution node10
-     * import type {} from "mod" with { "resolution-mode": "import" };
-     * // Result: ESNext - conditional imports/exports always supported with "resolution-mode" attribute
-     * ```
-     *
+     * Calculates the final resolution mode for a given module reference node. This is the resolution mode explicitly provided via import
+     * attributes, if present, or the syntax the usage would have if emitted to JavaScript. In `--module node16` or `nodenext`, this may
+     * depend on the file's `impliedNodeFormat`. In `--module preserve`, it depends only on the input syntax of the reference. In other
+     * `module` modes, when overriding import attributes are not provided, this function returns `undefined`, as the result would have no
+     * impact on module resolution, emit, or type checking.
      * @param file The file the import or import-like reference is contained within
      * @param usage The module reference string
      * @param compilerOptions The compiler options for the program that owns the file. If the file belongs to a referenced project, the compiler options
      * should be the options of the referenced project, not the referencing project.
      * @returns The final resolution mode of the import
      */
-    function getModeForUsageLocation(file: SourceFile, usage: StringLiteralLike, compilerOptions: CompilerOptions): ResolutionMode;
+    function getModeForUsageLocation(
+        file: {
+            impliedNodeFormat?: ResolutionMode;
+        },
+        usage: StringLiteralLike,
+        compilerOptions: CompilerOptions,
+    ): ModuleKind.CommonJS | ModuleKind.ESNext | undefined;
     function getConfigFileParsingDiagnostics(configFileParseResult: ParsedCommandLine): readonly Diagnostic[];
     /**
      * A function for determining if a given file is esm or cjs format, assuming modern node module resolution rules, as configured by the

--- a/yarn.lock
+++ b/yarn.lock
@@ -779,7 +779,7 @@ __metadata:
     tree-kill: "npm:1.2.2"
     ts-node: "npm:^10.9.1"
     tslib: "npm:2.6.3"
-    typescript: "npm:5.5.1-rc"
+    typescript: "npm:5.5.2"
     undici: "npm:6.19.2"
     verdaccio: "npm:5.31.1"
     verdaccio-auth-memory: "npm:^10.0.0"
@@ -4229,7 +4229,7 @@ __metadata:
     "@angular-devkit/core": "npm:0.0.0-PLACEHOLDER"
     "@angular/compiler": "npm:18.1.0-next.3"
     "@angular/compiler-cli": "npm:18.1.0-next.3"
-    typescript: "npm:5.5.1-rc"
+    typescript: "npm:5.5.2"
     webpack: "npm:5.92.1"
   peerDependencies:
     "@angular/compiler-cli": ^18.0.0 || ^18.1.0-next.0
@@ -17655,13 +17655,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:5.5.1-rc":
-  version: 5.5.1-rc
-  resolution: "typescript@npm:5.5.1-rc"
+"typescript@npm:5.5.2":
+  version: 5.5.2
+  resolution: "typescript@npm:5.5.2"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/c098e0a2c90472003bf5e4cb9548f2298beb7930cfdf65d529a7ca6e688bbf5ee77d00184a9de18921e13022000120740ff56fb109976d09eb4c5202b4cd343b
+  checksum: 10c0/8ca39b27b5f9bd7f32db795045933ab5247897660627251e8254180b792a395bf061ea7231947d5d7ffa5cb4cc771970fd4ef543275f9b559f08c9325cccfce3
   languageName: node
   linkType: hard
 
@@ -17695,13 +17695,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A5.5.1-rc#optional!builtin<compat/typescript>":
-  version: 5.5.1-rc
-  resolution: "typescript@patch:typescript@npm%3A5.5.1-rc#optional!builtin<compat/typescript>::version=5.5.1-rc&hash=b45daf"
+"typescript@patch:typescript@npm%3A5.5.2#optional!builtin<compat/typescript>":
+  version: 5.5.2
+  resolution: "typescript@patch:typescript@npm%3A5.5.2#optional!builtin<compat/typescript>::version=5.5.2&hash=b45daf"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/2bdee8341050466230dfd9c2202981062bbf50644d40452e8d164b5e8daa85a53bffc60ebca21d3d984fe2b752c63fcca33a7ddac67acf0d609ccab5b34847e0
+  checksum: 10c0/6721ac8933a70c252d7b640b345792e103d881811ff660355617c1836526dbb71c2044e2e77a8823fb3570b469f33276875a4cab6d3c4de4ae7d7ee1c3074ae4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Updates the repo to the stable version of TypeScript 5.5. I'm holding off on updating the new projects to it due to https://github.com/angular/angular/pull/56358.