### PR TITLE
fix(@angular/cli): make `ng update` to keep newline at the end of package.json

### DIFF
--- a/packages/angular/cli/src/commands/update/schematic/index.ts
+++ b/packages/angular/cli/src/commands/update/schematic/index.ts
@@ -263,7 +263,7 @@ function _performUpdate(
   logger: logging.LoggerApi,
   migrateOnly: boolean,
 ): void {
-  const packageJsonContent = tree.read('/package.json');
+  const packageJsonContent = tree.read('/package.json')?.toString();
   if (!packageJsonContent) {
     throw new SchematicsException('Could not find a package.json. Are you in a Node project?');
   }
@@ -310,11 +310,12 @@ function _performUpdate(
       logger.warn(`Package ${name} was not found in dependencies.`);
     }
   });
-
-  const newContent = JSON.stringify(packageJson, null, 2);
-  if (packageJsonContent.toString() != newContent || migrateOnly) {
+  const eofMatches = packageJsonContent.match(/\r?\n$/);
+  const eof = eofMatches?.[0] ?? '';
+  const newContent = JSON.stringify(packageJson, null, 2) + eof;
+  if (packageJsonContent != newContent || migrateOnly) {
     if (!migrateOnly) {
-      tree.overwrite('/package.json', JSON.stringify(packageJson, null, 2));
+      tree.overwrite('/package.json', newContent);
     }
 
     const externalMigrations: {}[] = [];

--- a/packages/angular/cli/src/commands/update/schematic/index_spec.ts
+++ b/packages/angular/cli/src/commands/update/schematic/index_spec.ts
@@ -282,4 +282,57 @@ describe('@schematics/update', () => {
     expect(hasPeerdepMsg('typescript')).toBeTruthy();
     expect(hasPeerdepMsg('@angular/localize')).toBeFalsy();
   }, 45000);
+
+  it('does not remove newline at the end of package.json', async () => {
+    const newlineStyles = ['\n', '\r\n'];
+    for (const newline of newlineStyles) {
+      const packageJsonContent = `{
+        "name": "blah",
+        "dependencies": {
+          "@angular-devkit-tests/update-base": "1.0.0"
+        }
+      }${newline}`;
+      const inputTree = new UnitTestTree(
+        new HostTree(
+          new virtualFs.test.TestHost({
+            '/package.json': packageJsonContent,
+          }),
+        ),
+      );
+
+      const resultTree = await schematicRunner.runSchematic(
+        'update',
+        { packages: ['@angular-devkit-tests/update-base'] },
+        inputTree,
+      );
+
+      const resultTreeContent = resultTree.readContent('/package.json');
+      expect(resultTreeContent.endsWith(newline)).toBeTrue();
+    }
+  });
+
+  it('does not add a newline at the end of package.json', async () => {
+    const packageJsonContent = `{
+      "name": "blah",
+      "dependencies": {
+        "@angular-devkit-tests/update-base": "1.0.0"
+      }
+    }`;
+    const inputTree = new UnitTestTree(
+      new HostTree(
+        new virtualFs.test.TestHost({
+          '/package.json': packageJsonContent,
+        }),
+      ),
+    );
+
+    const resultTree = await schematicRunner.runSchematic(
+      'update',
+      { packages: ['@angular-devkit-tests/update-base'] },
+      inputTree,
+    );
+
+    const resultTreeContent = resultTree.readContent('/package.json');
+    expect(resultTreeContent.endsWith('}')).toBeTrue();
+  });
 });


### PR DESCRIPTION
As stated in https://github.com/angular/angular-cli/issues/11744, `ng update` command removed the newline at the end of the package.json file. This commit makes `ng update` to preserve newline, if it was present before running the command.

Fixes #11744

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #11744

## What is the new behavior?

<!-- Please describe the new behavior that. -->
`ng update` preserves the newline at the end of the package.json file

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
