### PR TITLE
test: add proper assertions to several E2E tests

### DIFF
--- a/tests/legacy-cli/e2e/tests/basic/aot.ts
+++ b/tests/legacy-cli/e2e/tests/basic/aot.ts
@@ -1,7 +1,12 @@
-import { expectFileToMatch } from '../../utils/fs';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
 import { ng } from '../../utils/process';
 
+/**
+ * AOT builds should contain generated component factories
+ */
 export default async function () {
   await ng('build', '--aot=true', '--configuration=development');
-  await expectFileToMatch('dist/test-project/browser/main.js', 'AppComponent_Factory');
+  const content = await readFile('dist/test-project/browser/main.js', 'utf-8');
+  assert.match(content, /AppComponent_Factory/);
 }

--- a/tests/legacy-cli/e2e/tests/basic/build.ts
+++ b/tests/legacy-cli/e2e/tests/basic/build.ts
@@ -1,30 +1,33 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
 import { getGlobalVariable } from '../../utils/env';
-import { expectFileToMatch } from '../../utils/fs';
 import { ng } from '../../utils/process';
+
+const OUTPUT_INDEX_PATH = 'dist/test-project/browser/index.html';
 
 export default async function () {
   // Development build
-  const { stdout: stdout1 } = await ng('build', '--configuration=development');
-  await expectFileToMatch('dist/test-project/browser/index.html', 'main.js');
+  const { stdout: stdoutDev } = await ng('build', '--configuration=development');
+  // Console output should not contain estimated transfer size information
+  assert.doesNotMatch(stdoutDev, /Estimated transfer size/);
+  // Output index HTML file should reference main JS file
+  const devIndexContent = await readFile(OUTPUT_INDEX_PATH, 'utf-8');
+  assert.match(devIndexContent, /main\.js/);
 
-  if (stdout1.includes('Estimated transfer size')) {
-    throw new Error(
-      `Expected stdout not to contain 'Estimated transfer size' but it did.\n${stdout1}`,
-    );
-  }
+  const usingApplicationBuilder = getGlobalVariable('argv')['esbuild'];
 
   // Production build
-  const { stdout: stdout2 } = await ng('build');
-  if (getGlobalVariable('argv')['esbuild']) {
-    // esbuild uses an 8 character hash and a dash as separator
-    await expectFileToMatch('dist/test-project/browser/index.html', /main-[a-zA-Z0-9]{8}\.js/);
-  } else {
-    await expectFileToMatch('dist/test-project/browser/index.html', /main\.[a-zA-Z0-9]{16}\.js/);
-  }
+  const { stdout: stdoutProd } = await ng('build');
+  // Console output should contain estimated transfer size information
+  assert.match(stdoutProd, /Estimated transfer size/);
+  // Output index HTML file should reference main JS file with hashing
+  const prodIndexContent = await readFile(OUTPUT_INDEX_PATH, 'utf-8');
 
-  if (!stdout2.includes('Estimated transfer size')) {
-    throw new Error(
-      `Expected stdout to contain 'Estimated transfer size' but it did not.\n${stdout2}`,
-    );
+  if (usingApplicationBuilder) {
+    // application builder uses an 8 character hash and a dash as a separator
+    assert.match(prodIndexContent, /main-[a-zA-Z0-9]{8}\.js/);
+  } else {
+    // browser builder uses a 16 character hash and a period as a separator
+    assert.match(prodIndexContent, /main\.[a-zA-Z0-9]{16}\.js/);
   }
 }

--- a/tests/legacy-cli/e2e/tests/basic/e2e.ts
+++ b/tests/legacy-cli/e2e/tests/basic/e2e.ts
@@ -1,9 +1,9 @@
+import assert from 'node:assert/strict';
 import { setTimeout } from 'node:timers/promises';
 import { silentNg } from '../../utils/process';
-import { expectToFail } from '../../utils/utils';
 
 export default async function () {
-  await expectToFail(() => silentNg('e2e', 'test-project', '--dev-server-target='));
+  assert.rejects(silentNg('e2e', 'test-project', '--dev-server-target='));
 
   // These should work.
   await silentNg('e2e', 'test-project');

--- a/tests/legacy-cli/e2e/tests/basic/run.ts
+++ b/tests/legacy-cli/e2e/tests/basic/run.ts
@@ -1,18 +1,28 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
 import { getGlobalVariable } from '../../utils/env';
-import { expectFileToMatch } from '../../utils/fs';
 import { silentNg } from '../../utils/process';
+
+const OUTPUT_INDEX_PATH = 'dist/test-project/browser/index.html';
 
 export default async function () {
   // Development build
   await silentNg('run', 'test-project:build:development');
-  await expectFileToMatch('dist/test-project/browser/index.html', 'main.js');
+  // Output index HTML file should reference main JS file
+  const devIndexContent = await readFile(OUTPUT_INDEX_PATH, 'utf-8');
+  assert.match(devIndexContent, /main\.js/);
+
+  const usingApplicationBuilder = getGlobalVariable('argv')['esbuild'];
 
   // Production build
   await silentNg('run', 'test-project:build');
-  if (getGlobalVariable('argv')['esbuild']) {
-    // esbuild uses an 8 character hash and a dash as separator
-    await expectFileToMatch('dist/test-project/browser/index.html', /main-[a-zA-Z0-9]{8}\.js/);
+  // Output index HTML file should reference main JS file with hashing
+  const prodIndexContent = await readFile(OUTPUT_INDEX_PATH, 'utf-8');
+  if (usingApplicationBuilder) {
+    // application builder uses an 8 character hash and a dash as a separator
+    assert.match(prodIndexContent, /main-[a-zA-Z0-9]{8}\.js/);
   } else {
-    await expectFileToMatch('dist/test-project/browser/index.html', /main\.[a-zA-Z0-9]{16}\.js/);
+    // browser builder uses a 16 character hash and a period as a separator
+    assert.match(prodIndexContent, /main\.[a-zA-Z0-9]{16}\.js/);
   }
 }


### PR DESCRIPTION
The aot, build, and command-scope E2E tests now use assertions from the Node.js `assert` builtin module. This reduces the amount of code within each test and improves the overall readability.