### PR TITLE
build: enabled isolated modules TypeScript option

### DIFF
--- a/.yarn/patches/@bazel-concatjs-npm-5.8.1-1bf81df846.patch
+++ b/.yarn/patches/@bazel-concatjs-npm-5.8.1-1bf81df846.patch
@@ -12,13 +12,38 @@ index 9e5cda684f0456b61d1b6c0f9c56ae021594713f..6c45196bda5880531d32618dfca0dee4
  
  _DEVMODE_TARGET_DEFAULT = "es2015"
 diff --git a/internal/common/tsconfig.bzl b/internal/common/tsconfig.bzl
-index b01c999f5e02b388f51a508b0b608cf69db9b664..ec3e4ccb321fa230546e34c1c2ea87f7457fa108 100755
+index b01c999f5e02b388f51a508b0b608cf69db9b664..847c23fe4829d0c847e9b4bd1ad698e1ccea720e 100755
 --- a/internal/common/tsconfig.bzl
 +++ b/internal/common/tsconfig.bzl
-@@ -278,11 +278,6 @@ def create_tsconfig(
+@@ -211,9 +211,6 @@ def create_tsconfig(
+         # will convert that to goog.module syntax.
+         "module": "umd" if devmode_manifest or has_node_runtime else "esnext",
+ 
+-        # Has no effect in closure/ES2015 mode. Always true just for simplicity.
+-        "downlevelIteration": True,
+-
+         # Do not type-check the lib.*.d.ts.
+         # We think this shouldn't be necessary but haven't figured out why yet
+         # and builds are faster with the setting on.
+@@ -248,13 +245,6 @@ def create_tsconfig(
+         # "short name" mappings for npm packages, such as "@angular/core"
+         "paths": mapped_module_roots,
+ 
+-        # Inline const enums.
+-        "preserveConstEnums": False,
+-
+-        # permit `@Decorator` syntax and allow runtime reflection on their types.
+-        "experimentalDecorators": True,
+-        "emitDecoratorMetadata": True,
+-
+         # Interpret JSX as React calls (until someone asks for something different)
+         "jsx": "react",
+ 
+@@ -277,12 +267,6 @@ def create_tsconfig(
+         # always emit declaration files in the same location as outDir.
          "declarationDir": "/".join([workspace_path, outdir_path]),
          "stripInternal": True,
- 
+-
 -        # Embed source maps and sources in .js outputs
 -        "inlineSourceMap": True,
 -        "inlineSources": True,

--- a/modules/testing/builder/src/file-watching.ts
+++ b/modules/testing/builder/src/file-watching.ts
@@ -56,4 +56,4 @@ export class WatcherNotifier implements BuilderWatcherFactory {
   }
 }
 
-export { BuilderWatcherFactory };
+export type { BuilderWatcherFactory };

--- a/modules/testing/builder/src/index.ts
+++ b/modules/testing/builder/src/index.ts
@@ -8,8 +8,12 @@
 
 export {
   BuilderHarness,
-  BuilderHarnessExecutionOptions,
-  BuilderHarnessExecutionResult,
+  type BuilderHarnessExecutionOptions,
+  type BuilderHarnessExecutionResult,
 } from './builder-harness';
-export { HarnessFileMatchers, JasmineBuilderHarness, describeBuilder } from './jasmine-helpers';
+export {
+  type HarnessFileMatchers,
+  JasmineBuilderHarness,
+  describeBuilder,
+} from './jasmine-helpers';
 export * from './test-utils';

--- a/packages/angular/build/src/builders/application/index.ts
+++ b/packages/angular/build/src/builders/application/index.ts
@@ -22,7 +22,7 @@ import {
 } from './options';
 import { Schema as ApplicationBuilderOptions } from './schema';
 
-export { ApplicationBuilderOptions };
+export type { ApplicationBuilderOptions };
 
 export async function* buildApplicationInternal(
   options: ApplicationBuilderInternalOptions,

--- a/packages/angular/build/src/builders/dev-server/index.ts
+++ b/packages/angular/build/src/builders/dev-server/index.ts
@@ -8,10 +8,14 @@
 
 import { createBuilder } from '@angular-devkit/architect';
 import { execute } from './builder';
-import { DevServerBuilderOutput } from './output';
-import { Schema as DevServerBuilderOptions } from './schema';
+import type { DevServerBuilderOutput } from './output';
+import type { Schema as DevServerBuilderOptions } from './schema';
 
-export { DevServerBuilderOptions, DevServerBuilderOutput, execute as executeDevServerBuilder };
+export {
+  type DevServerBuilderOptions,
+  type DevServerBuilderOutput,
+  execute as executeDevServerBuilder,
+};
 export default createBuilder<DevServerBuilderOptions, DevServerBuilderOutput>(execute);
 
 // Temporary export to support specs

--- a/packages/angular/build/src/builders/dev-server/internal.ts
+++ b/packages/angular/build/src/builders/dev-server/internal.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-export { BuildOutputFile, BuildOutputFileType } from '@angular/build';
+export { type BuildOutputFile, BuildOutputFileType } from '@angular/build';
 export { createRxjsEsmResolutionPlugin } from '../../tools/esbuild/rxjs-esm-resolution-plugin';
 export { JavaScriptTransformer } from '../../tools/esbuild/javascript-transformer';
 export { getFeatureSupport, isZonelessApp } from '../../tools/esbuild/utils';
@@ -16,5 +16,5 @@ export { purgeStaleBuildCache } from '../../utils/purge-cache';
 export { getSupportedBrowsers } from '../../utils/supported-browsers';
 export { transformSupportedBrowsersToTargets } from '../../tools/esbuild/utils';
 export { buildApplicationInternal } from '../../builders/application';
-export { ApplicationBuilderInternalOptions } from '../../builders/application/options';
-export { ExternalResultMetadata } from '../../tools/esbuild/bundler-execution-result';
+export type { ApplicationBuilderInternalOptions } from '../../builders/application/options';
+export type { ExternalResultMetadata } from '../../tools/esbuild/bundler-execution-result';

--- a/packages/angular/build/src/index.ts
+++ b/packages/angular/build/src/index.ts
@@ -16,11 +16,11 @@ export type { BuildOutputAsset } from './tools/esbuild/bundler-execution-result'
 
 export {
   executeDevServerBuilder,
-  DevServerBuilderOptions,
-  DevServerBuilderOutput,
+  type DevServerBuilderOptions,
+  type DevServerBuilderOutput,
 } from './builders/dev-server';
 
 export {
   execute as executeExtractI18nBuilder,
-  ExtractI18nBuilderOptions,
+  type ExtractI18nBuilderOptions,
 } from './builders/extract-i18n';

--- a/packages/angular/build/src/private.ts
+++ b/packages/angular/build/src/private.ts
@@ -15,12 +15,12 @@
 
 // Builders
 export { buildApplicationInternal } from './builders/application';
-export { ApplicationBuilderInternalOptions } from './builders/application/options';
+export type { ApplicationBuilderInternalOptions } from './builders/application/options';
 export { serveWithVite } from './builders/dev-server/vite-server';
 
 // Tools
 export * from './tools/babel/plugins';
-export { ExternalResultMetadata } from './tools/esbuild/bundler-execution-result';
+export type { ExternalResultMetadata } from './tools/esbuild/bundler-execution-result';
 export { emitFilesToDisk } from './tools/esbuild/utils';
 export { transformSupportedBrowsersToTargets } from './tools/esbuild/utils';
 export { SassWorkerImplementation } from './tools/sass/sass-service';
@@ -34,7 +34,7 @@ export { createCompilerPlugin } from './tools/esbuild/angular/compiler-plugin';
 export * from './utils/bundle-calculator';
 export { checkPort } from './utils/check-port';
 export { deleteOutputDir } from './utils/delete-output-dir';
-export { I18nOptions, createI18nOptions, loadTranslations } from './utils/i18n-options';
+export { type I18nOptions, createI18nOptions, loadTranslations } from './utils/i18n-options';
 export {
   IndexHtmlGenerator,
   type IndexHtmlGeneratorOptions,
@@ -51,6 +51,6 @@ export { loadProxyConfiguration } from './utils/load-proxy-config';
 export { type TranslationLoader, createTranslationLoader } from './utils/load-translations';
 export { purgeStaleBuildCache } from './utils/purge-cache';
 export { augmentAppWithServiceWorker } from './utils/service-worker';
-export { BundleStats, generateBuildStatsTable } from './utils/stats-table';
+export { type BundleStats, generateBuildStatsTable } from './utils/stats-table';
 export { getSupportedBrowsers } from './utils/supported-browsers';
 export { assertCompatibleAngularVersion } from './utils/version';

--- a/packages/angular/build/src/utils/bundle-calculator.ts
+++ b/packages/angular/build/src/utils/bundle-calculator.ts
@@ -10,7 +10,7 @@ import { Budget as BudgetEntry, Type as BudgetType } from '../builders/applicati
 import { formatSize } from './format-bytes';
 
 // Re-export to avoid direct schema importing throughout code
-export { BudgetEntry, BudgetType };
+export { type BudgetEntry, BudgetType };
 
 interface Size {
   size: number;

--- a/packages/angular/ssr/public_api.ts
+++ b/packages/angular/ssr/public_api.ts
@@ -6,4 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-export { CommonEngine, CommonEngineRenderOptions, CommonEngineOptions } from './src/common-engine';
+export {
+  CommonEngine,
+  type CommonEngineRenderOptions,
+  type CommonEngineOptions,
+} from './src/common-engine';

--- a/packages/angular_devkit/architect/src/index.ts
+++ b/packages/angular_devkit/architect/src/index.ts
@@ -9,7 +9,7 @@
 import * as jobs from './jobs';
 
 export * from './api';
-export { Architect, ScheduleOptions } from './architect';
+export { Architect, type ScheduleOptions } from './architect';
 export { createBuilder } from './create-builder';
 
 export { jobs };

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/index.ts
@@ -11,7 +11,11 @@ import { createBuilder } from '@angular-devkit/architect';
 import { execute } from './builder';
 import { Schema as DevServerBuilderOptions } from './schema';
 
-export { DevServerBuilderOptions, DevServerBuilderOutput, execute as executeDevServerBuilder };
+export {
+  type DevServerBuilderOptions,
+  type DevServerBuilderOutput,
+  execute as executeDevServerBuilder,
+};
 export default createBuilder<DevServerBuilderOptions, DevServerBuilderOutput>(execute);
 
 // Temporary export to support specs

--- a/packages/angular_devkit/build_angular/src/builders/karma/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/index.ts
@@ -237,7 +237,7 @@ function getBuiltInKarmaConfig(
   };
 }
 
-export { KarmaBuilderOptions };
+export type { KarmaBuilderOptions };
 export default createBuilder<Record<string, string> & KarmaBuilderOptions>(execute);
 
 function getBuiltInMainFile(): string {

--- a/packages/angular_devkit/build_angular/src/builders/ng-packagr/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/ng-packagr/index.ts
@@ -63,5 +63,5 @@ export function execute(
   );
 }
 
-export { NgPackagrBuilderOptions };
+export type { NgPackagrBuilderOptions };
 export default createBuilder<Record<string, string> & NgPackagrBuilderOptions>(execute);

--- a/packages/angular_devkit/build_angular/src/builders/protractor/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/protractor/index.ts
@@ -82,7 +82,7 @@ async function updateWebdriver() {
   } as unknown as JSON);
 }
 
-export { ProtractorBuilderOptions };
+export type { ProtractorBuilderOptions };
 
 /**
  * @experimental Direct usage of this function is considered experimental.

--- a/packages/angular_devkit/build_angular/src/builders/server/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/server/index.ts
@@ -53,7 +53,7 @@ export type ServerBuilderOutput = BuilderOutput & {
   }[];
 };
 
-export { ServerBuilderOptions };
+export type { ServerBuilderOptions };
 
 /**
  * @experimental Direct usage of this function is considered experimental.

--- a/packages/angular_devkit/build_angular/src/index.ts
+++ b/packages/angular_devkit/build_angular/src/index.ts
@@ -8,61 +8,62 @@
 
 export * from './transforms';
 
-export {
+export { CrossOrigin, OutputHashing, Type } from './builders/browser/schema';
+export type {
   AssetPattern,
   AssetPatternClass as AssetPatternObject,
   Budget,
-  CrossOrigin,
   FileReplacement,
   OptimizationClass as OptimizationObject,
   OptimizationUnion,
-  OutputHashing,
   Schema as BrowserBuilderOptions,
   SourceMapClass as SourceMapObject,
   SourceMapUnion,
   StylePreprocessorOptions,
-  Type,
 } from './builders/browser/schema';
 
 export {
   buildWebpackBrowser as executeBrowserBuilder,
-  BrowserBuilderOutput,
+  type BrowserBuilderOutput,
 } from './builders/browser';
 
-export { buildApplication, ApplicationBuilderOptions } from '@angular/build';
+export { buildApplication, type ApplicationBuilderOptions } from '@angular/build';
 
 export {
   executeDevServerBuilder,
-  DevServerBuilderOptions,
-  DevServerBuilderOutput,
+  type DevServerBuilderOptions,
+  type DevServerBuilderOutput,
 } from './builders/dev-server';
 
 export {
   execute as executeExtractI18nBuilder,
-  ExtractI18nBuilderOptions,
+  type ExtractI18nBuilderOptions,
 } from './builders/extract-i18n';
 
 export {
   execute as executeKarmaBuilder,
-  KarmaBuilderOptions,
-  KarmaConfigOptions,
+  type KarmaBuilderOptions,
+  type KarmaConfigOptions,
 } from './builders/karma';
 
 export {
   execute as executeProtractorBuilder,
-  ProtractorBuilderOptions,
+  type ProtractorBuilderOptions,
 } from './builders/protractor';
 
 export {
   execute as executeServerBuilder,
-  ServerBuilderOptions,
-  ServerBuilderOutput,
+  type ServerBuilderOptions,
+  type ServerBuilderOutput,
 } from './builders/server';
 
 export {
   execute as executeSSRDevServerBuilder,
-  SSRDevServerBuilderOptions,
-  SSRDevServerBuilderOutput,
+  type SSRDevServerBuilderOptions,
+  type SSRDevServerBuilderOutput,
 } from './builders/ssr-dev-server';
 
-export { execute as executeNgPackagrBuilder, NgPackagrBuilderOptions } from './builders/ng-packagr';
+export {
+  execute as executeNgPackagrBuilder,
+  type NgPackagrBuilderOptions,
+} from './builders/ng-packagr';

--- a/packages/angular_devkit/build_angular/src/tools/webpack/plugins/index.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/plugins/index.ts
@@ -8,14 +8,14 @@
 
 // Exports the webpack plugins we use internally.
 export { AnyComponentStyleBudgetChecker } from './any-component-style-budget-checker';
-export { ScriptsWebpackPlugin, ScriptsWebpackPluginOptions } from './scripts-webpack-plugin';
+export { ScriptsWebpackPlugin, type ScriptsWebpackPluginOptions } from './scripts-webpack-plugin';
 export { SuppressExtractedTextChunksWebpackPlugin } from './suppress-entry-chunks-webpack-plugin';
-export { RemoveHashPlugin, RemoveHashPluginOptions } from './remove-hash-plugin';
+export { RemoveHashPlugin, type RemoveHashPluginOptions } from './remove-hash-plugin';
 export { DedupeModuleResolvePlugin } from './dedupe-module-resolve-plugin';
 export { CommonJsUsageWarnPlugin } from './common-js-usage-warn-plugin';
 export { JsonStatsPlugin } from './json-stats-plugin';
 export { JavaScriptOptimizerPlugin } from './javascript-optimizer-plugin';
 export {
   default as PostcssCliResources,
-  PostcssCliResourcesOptions,
+  type PostcssCliResourcesOptions,
 } from './postcss-cli-resources';

--- a/packages/angular_devkit/build_webpack/src/index.ts
+++ b/packages/angular_devkit/build_webpack/src/index.ts
@@ -8,4 +8,4 @@
 
 export * from './builders/webpack';
 export * from './builders/webpack-dev-server';
-export { EmittedFiles } from './utils';
+export type { EmittedFiles } from './utils';

--- a/packages/angular_devkit/core/src/virtual-fs/host/alias.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/host/alias.ts
@@ -58,7 +58,7 @@ import { ResolverHost } from './resolver';
 export class AliasHost<StatsT extends object = {}> extends ResolverHost<StatsT> {
   protected _aliases = new Map<Path, Path>();
 
-  protected _resolve(path: Path) {
+  protected _resolve(path: Path): Path {
     let maybeAlias = this._aliases.get(path);
     const sp = split(path);
     const remaining: PathFragment[] = [];

--- a/packages/angular_devkit/core/src/virtual-fs/host/memory.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/host/memory.ts
@@ -91,11 +91,11 @@ export class SimpleMemoryHost implements Host<{}> {
     this._cache.set(normalize('/'), this._newDirStats());
   }
 
-  protected _toAbsolute(path: Path) {
+  protected _toAbsolute(path: Path): Path {
     return isAbsolute(path) ? path : normalize('/' + path);
   }
 
-  protected _updateWatchers(path: Path, type: HostWatchEventType) {
+  protected _updateWatchers(path: Path, type: HostWatchEventType): void {
     const time = new Date();
     let currentPath = path;
     let parent: Path | null = null;

--- a/packages/angular_devkit/core/src/virtual-fs/host/pattern.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/host/pattern.ts
@@ -17,7 +17,7 @@ export type ReplacementFunction = (path: Path) => Path;
 export class PatternMatchingHost<StatsT extends object = {}> extends ResolverHost<StatsT> {
   protected _patterns = new Map<RegExp, ReplacementFunction>();
 
-  addPattern(pattern: string | string[], replacementFn: ReplacementFunction) {
+  addPattern(pattern: string | string[], replacementFn: ReplacementFunction): void {
     const patterns = Array.isArray(pattern) ? pattern : [pattern];
     for (const glob of patterns) {
       const { output } = parseGlob(glob);
@@ -25,7 +25,7 @@ export class PatternMatchingHost<StatsT extends object = {}> extends ResolverHos
     }
   }
 
-  protected _resolve(path: Path) {
+  protected _resolve(path: Path): Path {
     let newPath = path;
     this._patterns.forEach((fn, re) => {
       if (re.test(path)) {

--- a/packages/angular_devkit/core/src/virtual-fs/host/record.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/host/record.ts
@@ -400,19 +400,19 @@ export class CordHost extends SimpleMemoryHost {
     return null;
   }
 
-  willCreate(path: Path) {
+  willCreate(path: Path): boolean {
     return this._filesToCreate.has(path);
   }
-  willOverwrite(path: Path) {
+  willOverwrite(path: Path): boolean {
     return this._filesToOverwrite.has(path);
   }
-  willDelete(path: Path) {
+  willDelete(path: Path): boolean {
     return this._filesToDelete.has(path);
   }
-  willRename(path: Path) {
+  willRename(path: Path): boolean {
     return this._filesToRename.has(path);
   }
-  willRenameTo(path: Path, to: Path) {
+  willRenameTo(path: Path, to: Path): boolean {
     return this._filesToRename.get(path) === to;
   }
 }

--- a/packages/angular_devkit/core/src/virtual-fs/host/sync.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/host/sync.ts
@@ -64,7 +64,7 @@ export class SyncDelegateHost<T extends object = {}> {
   get capabilities(): HostCapabilities {
     return this._delegate.capabilities;
   }
-  get delegate() {
+  get delegate(): Host<T> {
     return this._delegate;
   }
 

--- a/packages/angular_devkit/core/src/virtual-fs/host/test.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/host/test.ts
@@ -48,7 +48,7 @@ export class TestHost extends SimpleMemoryHost {
   get records(): TestLogRecord[] {
     return [...this._records];
   }
-  clearRecords() {
+  clearRecords(): void {
     this._records = [];
   }
 
@@ -70,7 +70,7 @@ export class TestHost extends SimpleMemoryHost {
     return _visit(normalize('/'));
   }
 
-  get sync() {
+  get sync(): SyncDelegateHost<{}> {
     if (!this._sync) {
       this._sync = new SyncDelegateHost<{}>(this);
     }
@@ -78,7 +78,7 @@ export class TestHost extends SimpleMemoryHost {
     return this._sync;
   }
 
-  clone() {
+  clone(): TestHost {
     const newHost = new TestHost();
     newHost._cache = new Map(this._cache);
 
@@ -86,22 +86,22 @@ export class TestHost extends SimpleMemoryHost {
   }
 
   // Override parents functions to keep a record of all operators that were done.
-  protected override _write(path: Path, content: FileBuffer) {
+  protected override _write(path: Path, content: FileBuffer): void {
     this._records.push({ kind: 'write', path });
 
     return super._write(path, content);
   }
-  protected override _read(path: Path) {
+  protected override _read(path: Path): ArrayBuffer {
     this._records.push({ kind: 'read', path });
 
     return super._read(path);
   }
-  protected override _delete(path: Path) {
+  protected override _delete(path: Path): void {
     this._records.push({ kind: 'delete', path });
 
     return super._delete(path);
   }
-  protected override _rename(from: Path, to: Path) {
+  protected override _rename(from: Path, to: Path): void {
     this._records.push({ kind: 'rename', from, to });
 
     return super._rename(from, to);
@@ -111,17 +111,17 @@ export class TestHost extends SimpleMemoryHost {
 
     return super._list(path);
   }
-  protected override _exists(path: Path) {
+  protected override _exists(path: Path): boolean {
     this._records.push({ kind: 'exists', path });
 
     return super._exists(path);
   }
-  protected override _isDirectory(path: Path) {
+  protected override _isDirectory(path: Path): boolean {
     this._records.push({ kind: 'isDirectory', path });
 
     return super._isDirectory(path);
   }
-  protected override _isFile(path: Path) {
+  protected override _isFile(path: Path): boolean {
     this._records.push({ kind: 'isFile', path });
 
     return super._isFile(path);
@@ -137,7 +137,7 @@ export class TestHost extends SimpleMemoryHost {
     return super._watch(path, options);
   }
 
-  $write(path: string, content: string) {
+  $write(path: string, content: string): void {
     return super._write(normalize(path), stringToFileBuffer(content));
   }
 
@@ -149,15 +149,15 @@ export class TestHost extends SimpleMemoryHost {
     return super._list(normalize(path));
   }
 
-  $exists(path: string) {
+  $exists(path: string): boolean {
     return super._exists(normalize(path));
   }
 
-  $isDirectory(path: string) {
+  $isDirectory(path: string): boolean {
     return super._isDirectory(normalize(path));
   }
 
-  $isFile(path: string) {
+  $isFile(path: string): boolean {
     return super._isFile(normalize(path));
   }
 }

--- a/packages/angular_devkit/core/src/workspace/index.ts
+++ b/packages/angular_devkit/core/src/workspace/index.ts
@@ -7,5 +7,5 @@
  */
 
 export * from './definitions';
-export { WorkspaceHost, createWorkspaceHost } from './host';
+export { type WorkspaceHost, createWorkspaceHost } from './host';
 export { WorkspaceFormat, readWorkspace, writeWorkspace } from './core';

--- a/packages/angular_devkit/schematics/src/index.ts
+++ b/packages/angular_devkit/schematics/src/index.ts
@@ -29,7 +29,7 @@ export * from './rules/url';
 export * from './tree/delegate';
 export * from './tree/empty';
 export * from './tree/host-tree';
-export { UpdateRecorder } from './tree/interface';
+export type { UpdateRecorder } from './tree/interface';
 export * from './engine/schematic';
 export * from './sink/dryrun';
 export * from './sink/host';

--- a/packages/ngtools/webpack/src/index.ts
+++ b/packages/ngtools/webpack/src/index.ts
@@ -9,7 +9,7 @@
 export {
   AngularWebpackLoaderPath,
   AngularWebpackPlugin,
-  AngularWebpackPluginOptions,
+  type AngularWebpackPluginOptions,
   imageDomains,
   default,
 } from './ivy';

--- a/packages/ngtools/webpack/src/ivy/index.ts
+++ b/packages/ngtools/webpack/src/ivy/index.ts
@@ -7,6 +7,6 @@
  */
 
 export { angularWebpackLoader as default } from './loader';
-export { AngularWebpackPluginOptions, AngularWebpackPlugin, imageDomains } from './plugin';
+export { type AngularWebpackPluginOptions, AngularWebpackPlugin, imageDomains } from './plugin';
 
 export const AngularWebpackLoaderPath = __filename;

--- a/packages/schematics/angular/utility/index.ts
+++ b/packages/schematics/angular/utility/index.ts
@@ -8,9 +8,9 @@
 
 // Workspace related rules and types
 export {
-  ProjectDefinition,
-  TargetDefinition,
-  WorkspaceDefinition,
+  type ProjectDefinition,
+  type TargetDefinition,
+  type WorkspaceDefinition,
   getWorkspace as readWorkspace,
   updateWorkspace,
   writeWorkspace,

--- a/packages/schematics/angular/utility/standalone/index.ts
+++ b/packages/schematics/angular/utility/standalone/index.ts
@@ -7,4 +7,4 @@
  */
 
 export { addRootImport, addRootProvider } from './rules';
-export { PendingCode, CodeBlockCallback, type CodeBlock } from './code_block';
+export type { PendingCode, CodeBlockCallback, CodeBlock } from './code_block';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "experimentalDecorators": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitOverride": true,
+    "isolatedModules": true,
     "outDir": "./dist",
     "skipLibCheck": true,
     "strict": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2425,7 +2425,7 @@ __metadata:
 
 "@bazel/concatjs@patch:@bazel/concatjs@npm%3A5.8.1#~/.yarn/patches/@bazel-concatjs-npm-5.8.1-1bf81df846.patch":
   version: 5.8.1
-  resolution: "@bazel/concatjs@patch:@bazel/concatjs@npm%3A5.8.1#~/.yarn/patches/@bazel-concatjs-npm-5.8.1-1bf81df846.patch::version=5.8.1&hash=ed928c"
+  resolution: "@bazel/concatjs@patch:@bazel/concatjs@npm%3A5.8.1#~/.yarn/patches/@bazel-concatjs-npm-5.8.1-1bf81df846.patch::version=5.8.1&hash=6673ab"
   dependencies:
     protobufjs: "npm:6.8.8"
     source-map-support: "npm:0.5.9"
@@ -2440,7 +2440,7 @@ __metadata:
     karma-sourcemap-loader: ">=0.3.0"
   bin:
     tsc_wrapped: internal/tsc_wrapped/tsc_wrapped.js
-  checksum: 10c0/8c1c2b0912c72f3bd768d04fc612df5c5341969374fd4f285a5c3c222072c78f622c0d0d312e26cf6f3821b9ab82e70accfec2b141bc75931ab8ec4366f7a2eb
+  checksum: 10c0/644891b24514c83d9006f6a90abc0c4fc59816bdff56ed4fb4bd6c611ff4dc187c91dee112d98f1f694352b93691c97542aa04834fceabd44679540a5528a889
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The TypeScript `isolatedModules` option is now enabled for all TypeScript code within the repository. As a result, all packages will now be built with the option enabled. This does not affect projects created with the CLI and is only related to the building of the actual Angular CLI code. The `isolatedModules` option ensures that code can be emitted without the TypeScript typechecker and allows tools other than TypeScript to potentially be used. Code was updated to correct all errors after the option was enabled. Additionally, some early code fixes were done to add function and accessor return types to prepare for future `isolatedDeclarations` usage. More changes would be needed to consider turning on `isolatedDeclarations`, however.