### PR TITLE
fix(@angular/build): address rxjs undefined issues during SSR prebundling

### DIFF
--- a/packages/angular/build/src/builders/dev-server/vite-server.ts
+++ b/packages/angular/build/src/builders/dev-server/vite-server.ts
@@ -25,7 +25,6 @@ import {
   BuildOutputFileType,
   type ExternalResultMetadata,
   JavaScriptTransformer,
-  createRxjsEsmResolutionPlugin,
   getFeatureSupport,
   getSupportedBrowsers,
   isZonelessApp,
@@ -658,10 +657,6 @@ function getDepOptimizationConfig({
       },
     },
   ];
-
-  if (ssr) {
-    plugins.unshift(createRxjsEsmResolutionPlugin() as ViteEsBuildPlugin);
-  }
 
   return {
     // Exclude any explicitly defined dependencies (currently build defined externals)


### PR DESCRIPTION


Replacing the paths to ESM in Vite can cause prebundling to fail in some cases, resulting in errors similar to the following:

```
12:55:12 PM [vite] Error when evaluating SSR module /chunk-CHB4JJIP.mjs:
|- TypeError: Cannot read properties of undefined (reading 'Subject')
    at eval (//src/app/shared/snackbar/snackbar.service.ts:2:25)
    at async instantiateModule (file:////node_modules/vite/dist/node/chunks/dep-BcXSligG.js:53408:5)

12:55:12 PM [vite] Error when evaluating SSR module /chunk-GQZ5BKXC.mjs:
|- TypeError: Cannot read properties of undefined (reading 'Subject')
    at eval (//src/app/shared/snackbar/snackbar.service.ts:2:25)
    at async instantiateModule (file:////node_modules/vite/dist/node/chunks/dep-BcXSligG.js:53408:5)
```

Closes: #27907
