### PR TITLE
refactor(@angular/cli): use non-experimental decorators for internal memoize

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,6 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "noEmitOnError": true,
-    "experimentalDecorators": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitOverride": true,
     "isolatedModules": true,


### PR DESCRIPTION
With standard decorator support now available for use, the memoize decorator has been updated to be a standard decorator instead of the TypeScript experimental decorator. This change also removes the only usage of decorators within the Angular CLI code itself. This change does not affect application code.