### PR TITLE
build: remove tsetse rule exclusions

### DIFF
--- a/packages/angular/cli/src/commands/config/cli.ts
+++ b/packages/angular/cli/src/commands/config/cli.ts
@@ -185,7 +185,7 @@ function normalizeValue(value: string | undefined | boolean | number): JsonValue
     // and convert them into a numberic entities.
     // Example: 73b61974-182c-48e4-b4c6-30ddf08c5c98 -> 73.
     // These values should never contain comments, therefore using `JSON.parse` is safe.
-    return JSON.parse(valueString);
+    return JSON.parse(valueString) as JsonValue;
   } catch {
     return value;
   }

--- a/packages/angular/cli/src/commands/update/cli.ts
+++ b/packages/angular/cli/src/commands/update/cli.ts
@@ -1045,7 +1045,7 @@ export default class UpdateCommandModule extends CommandModule<UpdateCommandArgs
     if (existsSync(packageJsonPath)) {
       const content = await fs.readFile(packageJsonPath, 'utf-8');
       if (content) {
-        const { bin = {} } = JSON.parse(content);
+        const { bin = {} } = JSON.parse(content) as { bin: Record<string, string> };
         const binKeys = Object.keys(bin);
 
         if (binKeys.length) {

--- a/packages/angular/cli/src/utilities/package-tree.ts
+++ b/packages/angular/cli/src/utilities/package-tree.ts
@@ -44,7 +44,7 @@ export interface PackageTreeNode {
 
 export async function readPackageJson(packageJsonPath: string): Promise<PackageJson | undefined> {
   try {
-    return JSON.parse((await fs.promises.readFile(packageJsonPath)).toString());
+    return JSON.parse((await fs.promises.readFile(packageJsonPath)).toString()) as PackageJson;
   } catch {
     return undefined;
   }

--- a/packages/angular/cli/src/utilities/project.ts
+++ b/packages/angular/cli/src/utilities/project.ts
@@ -12,6 +12,11 @@ import * as os from 'os';
 import * as path from 'path';
 import { findUp } from './find-up';
 
+interface PackageDependencies {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+}
+
 export function findWorkspaceFile(currentDirectory = process.cwd()): string | null {
   const possibleConfigFiles = ['angular.json', '.angular.json'];
   const configFilePath = findUp(possibleConfigFiles, currentDirectory);
@@ -27,7 +32,7 @@ export function findWorkspaceFile(currentDirectory = process.cwd()): string | nu
 
     try {
       const packageJsonText = fs.readFileSync(packageJsonPath, 'utf-8');
-      const packageJson = JSON.parse(packageJsonText);
+      const packageJson = JSON.parse(packageJsonText) as PackageDependencies;
       if (!containsCliDep(packageJson)) {
         // No CLI dependency
         return null;
@@ -41,10 +46,7 @@ export function findWorkspaceFile(currentDirectory = process.cwd()): string | nu
   return configFilePath;
 }
 
-function containsCliDep(obj?: {
-  dependencies?: Record<string, string>;
-  devDependencies?: Record<string, string>;
-}): boolean {
+function containsCliDep(obj?: PackageDependencies): boolean {
   const pkgName = '@angular/cli';
   if (!obj) {
     return false;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,14 +31,7 @@
       "@angular/build/private": ["./packages/angular/build/src/private"],
       "@ngtools/webpack": ["./packages/ngtools/webpack/src"],
       "@schematics/angular": ["./packages/schematics/angular"]
-    },
-    "plugins": [
-      {
-        "name": "@bazel/tsetse",
-        // must-use-promises is handled by the eslint @typescript-eslint/no-floating-promises rule
-        "disabledRules": ["must-type-assert-json-parse", "must-use-promises"]
-      }
-    ]
+    }
   },
   "bazelOptions": {
     "suppressTsconfigOverrideWarnings": true


### PR DESCRIPTION
To remove the tsetse rule exclusions, several usages of `JSON.parse` that did not have type casting where adjusted to add types. This removed the need for the manual configuration within the tsconfig.