### PR TITLE
build: remove `@types/browserslist`

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,6 @@
     "@rollup/plugin-node-resolve": "^13.0.5",
     "@types/babel__core": "7.20.5",
     "@types/browser-sync": "^2.27.0",
-    "@types/browserslist": "^4.15.0",
     "@types/express": "^4.16.0",
     "@types/http-proxy": "^1.17.4",
     "@types/ini": "^4.0.0",

--- a/packages/angular/build/BUILD.bazel
+++ b/packages/angular/build/BUILD.bazel
@@ -69,7 +69,6 @@ ts_library(
         "@npm//@babel/helper-split-export-declaration",
         "@npm//@inquirer/confirm",
         "@npm//@types/babel__core",
-        "@npm//@types/browserslist",
         "@npm//@types/less",
         "@npm//@types/node",
         "@npm//@types/picomatch",

--- a/packages/angular_devkit/build_angular/BUILD.bazel
+++ b/packages/angular_devkit/build_angular/BUILD.bazel
@@ -147,7 +147,6 @@ ts_library(
         "@npm//@discoveryjs/json-ext",
         "@npm//@types/babel__core",
         "@npm//@types/browser-sync",
-        "@npm//@types/browserslist",
         "@npm//@types/karma",
         "@npm//@types/less",
         "@npm//@types/loader-utils",

--- a/yarn.lock
+++ b/yarn.lock
@@ -674,7 +674,6 @@ __metadata:
     "@rollup/plugin-node-resolve": "npm:^13.0.5"
     "@types/babel__core": "npm:7.20.5"
     "@types/browser-sync": "npm:^2.27.0"
-    "@types/browserslist": "npm:^4.15.0"
     "@types/express": "npm:^4.16.0"
     "@types/http-proxy": "npm:^1.17.4"
     "@types/ini": "npm:^4.0.0"
@@ -5031,15 +5030,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/browserslist@npm:^4.15.0":
-  version: 4.15.0
-  resolution: "@types/browserslist@npm:4.15.0"
-  dependencies:
-    browserslist: "npm:*"
-  checksum: 10c0/00632450bde890898c1ef8f42a1b5790e91842a80e920e125a1cf9b9a8b52012a058a379e0496168b593a5477611bcb9e1ba387107f8eff7bdb209617aa108b6
-  languageName: node
-  linkType: hard
-
 "@types/co-body@npm:^6.1.0":
   version: 6.1.3
   resolution: "@types/co-body@npm:6.1.3"
@@ -7516,7 +7506,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browserslist@npm:*, browserslist@npm:^4.21.10, browserslist@npm:^4.21.5, browserslist@npm:^4.22.1, browserslist@npm:^4.22.2, browserslist@npm:^4.23.0":
+"browserslist@npm:^4.21.10, browserslist@npm:^4.21.5, browserslist@npm:^4.22.1, browserslist@npm:^4.22.2, browserslist@npm:^4.23.0":
   version: 4.23.1
   resolution: "browserslist@npm:4.23.1"
   dependencies:


### PR DESCRIPTION
`browserslist` now ships it's own typings
