### PR TITLE
build: use TypeScript 5.5 for new projects and tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "magic-string": "0.30.10",
     "mini-css-extract-plugin": "2.9.0",
     "mrmime": "2.0.0",
-    "ng-packagr": "18.0.0",
+    "ng-packagr": "18.1.0-next.0",
     "npm": "^10.8.1",
     "npm-package-arg": "11.0.2",
     "open": "10.1.0",

--- a/packages/angular_devkit/schematics_cli/blank/project-files/package.json
+++ b/packages/angular_devkit/schematics_cli/blank/project-files/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@angular-devkit/core": "^<%= coreVersion %>",
     "@angular-devkit/schematics": "^<%= schematicsVersion %>",
-    "typescript": "~5.4.2"
+    "typescript": "~5.5.2"
   },
   "devDependencies": {
     "@types/node": "^18.18.0",

--- a/packages/angular_devkit/schematics_cli/schematic/files/package.json
+++ b/packages/angular_devkit/schematics_cli/schematic/files/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@angular-devkit/core": "^<%= coreVersion %>",
     "@angular-devkit/schematics": "^<%= schematicsVersion %>",
-    "typescript": "~5.4.2"
+    "typescript": "~5.5.2"
   },
   "devDependencies": {
     "@types/node": "^18.18.0",

--- a/packages/schematics/angular/utility/latest-versions/package.json
+++ b/packages/schematics/angular/utility/latest-versions/package.json
@@ -17,13 +17,13 @@
     "karma-jasmine": "~5.1.0",
     "karma": "~6.4.0",
     "less": "^4.2.0",
-    "ng-packagr": "^18.0.0",
+    "ng-packagr": "^18.1.0-next.0",
     "postcss": "^8.4.38",
     "protractor": "~7.0.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "ts-node": "~10.9.0",
-    "typescript": "~5.4.2",
+    "typescript": "~5.5.2",
     "zone.js": "~0.14.3"
   }
 }

--- a/tests/legacy-cli/e2e/assets/18-ssr-project-webpack/package.json
+++ b/tests/legacy-cli/e2e/assets/18-ssr-project-webpack/package.json
@@ -14,25 +14,25 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/animations": "^18.0.0-next.0",
-    "@angular/common": "^18.0.0-next.0",
-    "@angular/compiler": "^18.0.0-next.0",
-    "@angular/core": "^18.0.0-next.0",
-    "@angular/forms": "^18.0.0-next.0",
-    "@angular/platform-browser": "^18.0.0-next.0",
-    "@angular/platform-browser-dynamic": "^18.0.0-next.0",
-    "@angular/platform-server": "^18.0.0-next.0",
-    "@angular/router": "^18.0.0-next.0",
-    "@angular/ssr": "^18.0.0-next.0",
+    "@angular/animations": "^18.1.0-next.3",
+    "@angular/common": "^18.1.0-next.3",
+    "@angular/compiler": "^18.1.0-next.3",
+    "@angular/core": "^18.1.0-next.3",
+    "@angular/forms": "^18.1.0-next.3",
+    "@angular/platform-browser": "^18.1.0-next.3",
+    "@angular/platform-browser-dynamic": "^18.1.0-next.3",
+    "@angular/platform-server": "^18.1.0-next.3",
+    "@angular/router": "^18.1.0-next.3",
+    "@angular/ssr": "^18.1.0-next.3",
     "express": "^4.18.2",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.14.3"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^18.0.0-next.0",
-    "@angular/cli": "^18.0.0-next.0",
-    "@angular/compiler-cli": "^18.0.0-next.0",
+    "@angular-devkit/build-angular": "^18.1.0-next.3",
+    "@angular/cli": "^18.1.0-next.3",
+    "@angular/compiler-cli": "^18.1.0-next.3",
     "@types/express": "^4.17.17",
     "@types/jasmine": "~4.3.0",
     "@types/mime": "^3.0.0",
@@ -43,6 +43,6 @@
     "karma-coverage": "~2.2.0",
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.1.0",
-    "typescript": "~5.4.2"
+    "typescript": "~5.5.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -747,7 +747,7 @@ __metadata:
     magic-string: "npm:0.30.10"
     mini-css-extract-plugin: "npm:2.9.0"
     mrmime: "npm:2.0.0"
-    ng-packagr: "npm:18.0.0"
+    ng-packagr: "npm:18.1.0-next.0"
     npm: "npm:^10.8.1"
     npm-package-arg: "npm:11.0.2"
     open: "npm:10.1.0"
@@ -13454,9 +13454,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ng-packagr@npm:18.0.0":
-  version: 18.0.0
-  resolution: "ng-packagr@npm:18.0.0"
+"ng-packagr@npm:18.1.0-next.0":
+  version: 18.1.0-next.0
+  resolution: "ng-packagr@npm:18.1.0-next.0"
   dependencies:
     "@rollup/plugin-json": "npm:^6.1.0"
     "@rollup/plugin-node-resolve": "npm:^15.2.3"
@@ -13482,10 +13482,10 @@ __metadata:
     rxjs: "npm:^7.8.1"
     sass: "npm:^1.69.5"
   peerDependencies:
-    "@angular/compiler-cli": ^18.0.0-next.0 || ^18.1.0-next.0
+    "@angular/compiler-cli": ^18.0.0 || ^18.1.0-next.0
     tailwindcss: ^2.0.0 || ^3.0.0
     tslib: ^2.3.0
-    typescript: ">=5.4 <5.5"
+    typescript: ">=5.4 <5.6"
   dependenciesMeta:
     rollup:
       optional: true
@@ -13494,7 +13494,7 @@ __metadata:
       optional: true
   bin:
     ng-packagr: cli/main.js
-  checksum: 10c0/7e8cb80f7a41c6735146aa9ad82fa6917051ff913965cd12f0a4a12421900ad410a8b9cd32109285112405ddeac99ddef75a093abe1d24afa8be7677da521f82
+  checksum: 10c0/d9daa88ef78798119fcfae556ca4265528485216a1a30c271b5575c5ee2d98c9e9d694ea7e550a206fa15b17083fa1107e70cbcdc0a406fd902858cbddf291e5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Now that https://github.com/angular/angular/pull/56358 is on track for 18.1, we can use TypeScript 5.5 for newly-created projects and in tests.