### PR TITLE
Update next branch to reflect new release-train "v18.2.0-next.0".

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+<a name="18.1.0-rc.0"></a>
+
+# 18.1.0-rc.0 (2024-06-26)
+
+### @angular/build
+
+| Commit                                                                                              | Type | Description                                          |
+| --------------------------------------------------------------------------------------------------- | ---- | ---------------------------------------------------- |
+| [3e359da8d](https://github.com/angular/angular-cli/commit/3e359da8dfdbfdb99be13f5c52a7e429c106d4ad) | fix  | address rxjs undefined issues during SSR prebundling |
+| [1e8fd70c6](https://github.com/angular/angular-cli/commit/1e8fd70c6f1bf2735474fcac0f109bd2bafa980e) | fix  | show JavaScript cache store initialization warning   |
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="18.0.6"></a>
 
 # 18.0.6 (2024-06-26)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@angular/devkit-repo",
-  "version": "18.1.0-next.3",
+  "version": "18.2.0-next.0",
   "private": true,
   "description": "Software Development Kit for Angular",
   "keywords": [


### PR DESCRIPTION
The previous "next" release-train has moved into the release-candidate phase. This PR updates the next branch to the subsequent release-train.

Also this PR cherry-picks the changelog for v18.1.0-rc.0 into the main branch so that the changelog is up to date.