### PR TITLE
refactor(@angular/build): improve BuildOutputFile property access

### DIFF
--- a/goldens/public-api/angular/build/index.api.md
+++ b/goldens/public-api/angular/build/index.api.md
@@ -91,6 +91,8 @@ export interface BuildOutputFile extends OutputFile {
     // (undocumented)
     clone: () => BuildOutputFile;
     // (undocumented)
+    readonly size: number;
+    // (undocumented)
     type: BuildOutputFileType;
 }
 

--- a/packages/angular/build/src/builders/application/execute-post-bundle.ts
+++ b/packages/angular/build/src/builders/application/execute-post-bundle.ts
@@ -14,7 +14,7 @@ import {
 } from '../../tools/esbuild/bundler-context';
 import { BuildOutputAsset } from '../../tools/esbuild/bundler-execution-result';
 import { generateIndexHtml } from '../../tools/esbuild/index-html-generator';
-import { createOutputFileFromText } from '../../tools/esbuild/utils';
+import { createOutputFile } from '../../tools/esbuild/utils';
 import { maxWorkers } from '../../utils/environment-options';
 import { prerenderPages } from '../../utils/server-rendering/prerender';
 import { augmentAppWithServiceWorkerEsbuild } from '../../utils/service-worker';
@@ -84,14 +84,14 @@ export async function executePostBundleSteps(
 
     additionalHtmlOutputFiles.set(
       indexHtmlOptions.output,
-      createOutputFileFromText(indexHtmlOptions.output, csrContent, BuildOutputFileType.Browser),
+      createOutputFile(indexHtmlOptions.output, csrContent, BuildOutputFileType.Browser),
     );
 
     if (ssrContent) {
       const serverIndexHtmlFilename = 'index.server.html';
       additionalHtmlOutputFiles.set(
         serverIndexHtmlFilename,
-        createOutputFileFromText(serverIndexHtmlFilename, ssrContent, BuildOutputFileType.Server),
+        createOutputFile(serverIndexHtmlFilename, ssrContent, BuildOutputFileType.Server),
       );
 
       ssrIndexContent = ssrContent;
@@ -131,7 +131,7 @@ export async function executePostBundleSteps(
     for (const [path, content] of Object.entries(output)) {
       additionalHtmlOutputFiles.set(
         path,
-        createOutputFileFromText(path, content, BuildOutputFileType.Browser),
+        createOutputFile(path, content, BuildOutputFileType.Browser),
       );
     }
   }
@@ -153,11 +153,7 @@ export async function executePostBundleSteps(
       );
 
       additionalOutputFiles.push(
-        createOutputFileFromText(
-          'ngsw.json',
-          serviceWorkerResult.manifest,
-          BuildOutputFileType.Browser,
-        ),
+        createOutputFile('ngsw.json', serviceWorkerResult.manifest, BuildOutputFileType.Browser),
       );
       additionalAssets.push(...serviceWorkerResult.assetFiles);
     } catch (error) {

--- a/packages/angular/build/src/tools/esbuild/bundler-context.ts
+++ b/packages/angular/build/src/tools/esbuild/bundler-context.ts
@@ -55,6 +55,7 @@ export enum BuildOutputFileType {
 
 export interface BuildOutputFile extends OutputFile {
   type: BuildOutputFileType;
+  readonly size: number;
   clone: () => BuildOutputFile;
 }
 

--- a/packages/angular/build/src/tools/esbuild/bundler-execution-result.ts
+++ b/packages/angular/build/src/tools/esbuild/bundler-execution-result.ts
@@ -11,7 +11,7 @@ import { normalize } from 'node:path';
 import type { ChangedFiles } from '../../tools/esbuild/watcher';
 import type { SourceFileCache } from './angular/source-file-cache';
 import type { BuildOutputFile, BuildOutputFileType, BundlerContext } from './bundler-context';
-import { createOutputFileFromText } from './utils';
+import { createOutputFile } from './utils';
 
 export interface BuildOutputAsset {
   source: string;
@@ -49,8 +49,8 @@ export class ExecutionResult {
     private codeBundleCache?: SourceFileCache,
   ) {}
 
-  addOutputFile(path: string, content: string, type: BuildOutputFileType): void {
-    this.outputFiles.push(createOutputFileFromText(path, content, type));
+  addOutputFile(path: string, content: string | Uint8Array, type: BuildOutputFileType): void {
+    this.outputFiles.push(createOutputFile(path, content, type));
   }
 
   addAssets(assets: BuildOutputAsset[]): void {

--- a/packages/angular/build/src/tools/esbuild/i18n-inliner.ts
+++ b/packages/angular/build/src/tools/esbuild/i18n-inliner.ts
@@ -9,7 +9,7 @@
 import assert from 'node:assert';
 import Piscina from 'piscina';
 import { BuildOutputFile, BuildOutputFileType } from './bundler-context';
-import { createOutputFileFromText } from './utils';
+import { createOutputFile } from './utils';
 
 /**
  * A keyword used to indicate if a JavaScript file may require inlining of translations.
@@ -139,9 +139,9 @@ export class I18nInliner {
         const type = this.#fileToType.get(file);
         assert(type !== undefined, 'localized file should always have a type' + file);
 
-        const resultFiles = [createOutputFileFromText(file, code, type)];
+        const resultFiles = [createOutputFile(file, code, type)];
         if (map) {
-          resultFiles.push(createOutputFileFromText(file + '.map', map, type));
+          resultFiles.push(createOutputFile(file + '.map', map, type));
         }
 
         for (const message of messages) {


### PR DESCRIPTION
The `BuildOutputFile` type's helper functions have been adjusted to cache commonly accessed property values to avoid potentially expensive repeat processing. This includes encoding/decoding UTF-8 content and calculating hash values for the output file content. A size property has also been added to allow consumers to more directly determine the byte size of the output file. The size property is currently unused but will be leveraged in forthcoming updates to bundle budgets and console info logging.