### PR TITLE
fix(@angular/build): normalize paths during module resolution in Vite

### DIFF
--- a/packages/angular/build/src/tools/vite/angular-memory-plugin.ts
+++ b/packages/angular/build/src/tools/vite/angular-memory-plugin.ts
@@ -55,7 +55,7 @@ export function createAngularMemoryPlugin(options: AngularMemoryPluginOptions): 
         return source;
       }
 
-      if (importer && source[0] === '.' && importer.startsWith(virtualProjectRoot)) {
+      if (importer && source[0] === '.' && normalizePath(importer).startsWith(virtualProjectRoot)) {
         // Remove query if present
         const [importerFile] = importer.split('?', 1);
 


### PR DESCRIPTION
Before this update, the importer path was not normalized, causing mismatches during SSR on Windows.
