### PR TITLE
fix(@angular/build): correctly name entry points to match budgets

### DIFF
--- a/packages/angular/build/src/tools/esbuild/budget-stats.ts
+++ b/packages/angular/build/src/tools/esbuild/budget-stats.ts
@@ -7,9 +7,9 @@
  */
 
 import type { Metafile } from 'esbuild';
-import { basename } from 'node:path';
 import type { BudgetStats } from '../../utils/bundle-calculator';
 import type { InitialFileRecord } from './bundler-context';
+import { getEntryPointName } from './utils';
 
 /**
  * Generates a bundle budget calculator compatible stats object that provides
@@ -43,9 +43,7 @@ export function generateBudgetStats(
     let name = initialRecord?.name;
     if (name === undefined && entry.entryPoint) {
       // For non-initial lazy modules, convert the entry point file into a Webpack compatible name
-      name = basename(entry.entryPoint)
-        .replace(/\.[cm]?[jt]s$/, '')
-        .replace(/[\\/.]/g, '-');
+      name = getEntryPointName(entry.entryPoint);
     }
 
     stats.chunks.push({

--- a/packages/angular/build/src/tools/esbuild/utils.ts
+++ b/packages/angular/build/src/tools/esbuild/utils.ts
@@ -66,9 +66,7 @@ export function logBuildStats(
 
     let name = initial.get(file)?.name;
     if (name === undefined && output.entryPoint) {
-      name = basename(output.entryPoint)
-        .replace(/\.[cm]?[jt]s$/, '')
-        .replace(/[\\/.]/g, '-');
+      name = getEntryPointName(output.entryPoint);
     }
 
     const stat: BundleStats = {
@@ -495,4 +493,11 @@ export async function logMessages(
 export function isZonelessApp(polyfills: string[] | undefined): boolean {
   // TODO: Instead, we should rely on the presence of zone.js in the polyfills build metadata.
   return !polyfills?.some((p) => p === 'zone.js' || /\.[mc]?[jt]s$/.test(p));
+}
+
+export function getEntryPointName(entryPoint: string): string {
+  return basename(entryPoint)
+    .replace(/(.*:)/, '') // global:bundle.css  -> bundle.css
+    .replace(/\.[cm]?[jt]s$/, '')
+    .replace(/[\\/.]/g, '-');
 }


### PR DESCRIPTION


This commit addresses an issue where some lazy entry points were not name correctly to align with specified budgets.

Closes: #27936
