### PR TITLE
refactor(@angular/build): use build output files directly in stats and budgets

### DIFF
--- a/packages/angular/build/src/builders/application/execute-build.ts
+++ b/packages/angular/build/src/builders/application/execute-build.ts
@@ -104,7 +104,7 @@ export async function executeBuild(
   // Analyze files for bundle budget failures if present
   let budgetFailures: BudgetCalculatorResult[] | undefined;
   if (options.budgets) {
-    const compatStats = generateBudgetStats(metafile, initialFiles);
+    const compatStats = generateBudgetStats(metafile, outputFiles, initialFiles);
     budgetFailures = [...checkBudgets(options.budgets, compatStats, true)];
     for (const { message, severity } of budgetFailures) {
       if (severity === 'error') {
@@ -191,6 +191,7 @@ export async function executeBuild(
     executionResult.addLog(
       logBuildStats(
         metafile,
+        outputFiles,
         initialFiles,
         budgetFailures,
         colors,


### PR DESCRIPTION
The bundle budget calculators and the console build stats output are now calculated directly from the build output file information instead of the esbuild metafile where possible. This provides a more generic method of accessing the information and can more accurately account for post-processing steps that may alter the output files. The metafile is still used for component style budgets and lazy chunk name information.