### PR TITLE
refactor: fix pipe type

### DIFF
--- a/packages/angular_devkit/schematics/src/rules/template.ts
+++ b/packages/angular_devkit/schematics/src/rules/template.ts
@@ -133,12 +133,13 @@ export function applyPathTemplate<T extends PathTemplateData>(
           if (!(pipe in data)) {
             throw new UnknownPipeException(pipe);
           }
-          if (typeof data[pipe] != 'function') {
+          const pipeFn = data[pipe];
+          if (typeof pipeFn != 'function') {
             throw new InvalidPipeException(pipe);
           }
 
           // Coerce to string.
-          return '' + data[pipe](acc);
+          return '' + pipeFn(acc);
         }, '' + replacement);
       }
 


### PR DESCRIPTION
An explicit cast was removed in https://github.com/angular/angular-cli/commit/fa9bce0e9ae5f28ae1d5c826bd218145a343c731#diff-29e41c6172a2d68db9886be9e933ed2b477732095313e104c52a725f887276cf which relies on [control flow narrowing](https://devblogs.microsoft.com/typescript/announcing-typescript-5-5/#control-flow-narrowing-for-constant-indexed-accesses) in TS 5.5. However, google3 is still on TS 5.4, so we can't fully depend on that feature. Using an intermediate variable makes the type narrowing work correctly even in TS 5.4.