### PR TITLE
fix(@angular/build): reduce the number of max workers to available CPUs minus one

### DIFF
--- a/packages/angular/build/src/utils/environment-options.ts
+++ b/packages/angular/build/src/utils/environment-options.ts
@@ -78,7 +78,7 @@ export const allowMinify = debugOptimize.minify;
 const maxWorkersVariable = process.env['NG_BUILD_MAX_WORKERS'];
 export const maxWorkers = isPresent(maxWorkersVariable)
   ? +maxWorkersVariable
-  : Math.min(4, availableParallelism());
+  : Math.min(4, Math.max(availableParallelism() - 1, 1));
 
 const parallelTsVariable = process.env['NG_BUILD_PARALLEL_TS'];
 export const useParallelTs = !isPresent(parallelTsVariable) || !isDisabled(parallelTsVariable);

--- a/packages/angular_devkit/build_angular/src/utils/environment-options.ts
+++ b/packages/angular_devkit/build_angular/src/utils/environment-options.ts
@@ -78,7 +78,7 @@ export const allowMinify = debugOptimize.minify;
 const maxWorkersVariable = process.env['NG_BUILD_MAX_WORKERS'];
 export const maxWorkers = isPresent(maxWorkersVariable)
   ? +maxWorkersVariable
-  : Math.min(4, availableParallelism());
+  : Math.min(4, Math.max(availableParallelism() - 1, 1));
 
 const parallelTsVariable = process.env['NG_BUILD_PARALLEL_TS'];
 export const useParallelTs = !isPresent(parallelTsVariable) || !isDisabled(parallelTsVariable);


### PR DESCRIPTION
This commit reduces the maximum number of workers to the available CPUs minus 1. This adjustment ensures that some resources are left for the main thread, preventing it from being starved of CPU cycles.

For more context see: https://github.com/angular/angular-cli/issues/27167#issuecomment-2199987874
