### PR TITLE
fix(@angular/build): allow top-level await in zoneless applications

### DIFF
--- a/packages/angular/build/src/tools/esbuild/utils.ts
+++ b/packages/angular/build/src/tools/esbuild/utils.ts
@@ -180,8 +180,6 @@ export function getFeatureSupport(
     // will be used instead which provides a workaround for the performance issue.
     // For more details: https://bugs.chromium.org/p/v8/issues/detail?id=11536
     'object-rest-spread': false,
-    // Using top-level-await is not guaranteed to be safe with some code optimizations.
-    'top-level-await': false,
   };
 
   // Detect Safari browser versions that have a class field behavior bug


### PR DESCRIPTION
With the potential future introduction of features such as WASM/ES module integration and the experimental chunk optimizer, the need to restrict top-level await usage is no longer needed and a blocker for new features. As such, top-level await will now be available if an application has been configured to be zoneless.
Zoneless Angular is currently experimental and more details can be found here: https://angular.dev/guide/experimental/zoneless