### PR TITLE
fix(@angular-devkit/build-angular): rollback terser to `5.29.2`

### DIFF
--- a/package.json
+++ b/package.json
@@ -192,7 +192,7 @@
     "source-map-support": "0.5.21",
     "symbol-observable": "4.0.0",
     "tar": "^6.1.6",
-    "terser": "5.31.1",
+    "terser": "5.29.2",
     "tree-kill": "1.2.2",
     "ts-node": "^10.9.1",
     "tslib": "2.6.3",

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -58,7 +58,7 @@
     "semver": "7.6.2",
     "source-map-loader": "5.0.0",
     "source-map-support": "0.5.21",
-    "terser": "5.31.1",
+    "terser": "5.29.2",
     "tree-kill": "1.2.2",
     "tslib": "2.6.3",
     "undici": "6.19.2",

--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,7 @@
   "dependencyDashboard": true,
   "schedule": ["after 10:00pm every weekday", "before 4:00am every weekday", "every weekend"],
   "baseBranches": ["main"],
-  "ignoreDeps": ["@types/node", "build_bazel_rules_nodejs", "rules_pkg", "yarn"],
+  "ignoreDeps": ["@types/node", "build_bazel_rules_nodejs", "terser", "rules_pkg", "yarn"],
   "includePaths": [
     "WORKSPACE",
     "package.json",

--- a/yarn.lock
+++ b/yarn.lock
@@ -122,7 +122,7 @@ __metadata:
     semver: "npm:7.6.2"
     source-map-loader: "npm:5.0.0"
     source-map-support: "npm:0.5.21"
-    terser: "npm:5.31.1"
+    terser: "npm:5.29.2"
     tree-kill: "npm:1.2.2"
     tslib: "npm:2.6.3"
     undici: "npm:6.19.2"
@@ -776,7 +776,7 @@ __metadata:
     source-map-support: "npm:0.5.21"
     symbol-observable: "npm:4.0.0"
     tar: "npm:^6.1.6"
-    terser: "npm:5.31.1"
+    terser: "npm:5.29.2"
     tree-kill: "npm:1.2.2"
     ts-node: "npm:^10.9.1"
     tslib: "npm:2.6.3"
@@ -17261,7 +17261,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"terser@npm:5.31.1, terser@npm:^5.26.0":
+"terser@npm:5.29.2":
+  version: 5.29.2
+  resolution: "terser@npm:5.29.2"
+  dependencies:
+    "@jridgewell/source-map": "npm:^0.3.3"
+    acorn: "npm:^8.8.2"
+    commander: "npm:^2.20.0"
+    source-map-support: "npm:~0.5.20"
+  bin:
+    terser: bin/terser
+  checksum: 10c0/a6f1e26725e3dc99943d7173a3fca8bee21418a3ff39f37053fecd6a988b5341432d535721642807e9c24604aff64410577e9aed3200d9345c89b176b0ba3d65
+  languageName: node
+  linkType: hard
+
+"terser@npm:^5.26.0":
   version: 5.31.1
   resolution: "terser@npm:5.31.1"
   dependencies:


### PR DESCRIPTION
More information in https://github.com/terser/terser/issues/1539

Closes #27866