### PR TITLE
fix(@angular/build): check inlineSourceMap option with isolated modules optimization

### DIFF
--- a/packages/angular/build/src/tools/angular/compilation/aot-compilation.ts
+++ b/packages/angular/build/src/tools/angular/compilation/aot-compilation.ts
@@ -204,7 +204,9 @@ export class AotCompilation extends AngularCompilation {
     const compilerOptions = typeScriptProgram.getCompilerOptions();
     const buildInfoFilename = compilerOptions.tsBuildInfoFile ?? '.tsbuildinfo';
     const useTypeScriptTranspilation =
-      !compilerOptions.isolatedModules || !!compilerOptions.sourceMap;
+      !compilerOptions.isolatedModules ||
+      !!compilerOptions.sourceMap ||
+      !!compilerOptions.inlineSourceMap;
 
     const emittedFiles = new Map<ts.SourceFile, EmitFileResult>();
     const writeFileCallback: ts.WriteFileCallback = (filename, contents, _a, _b, sourceFiles) => {

--- a/packages/angular/build/src/tools/angular/compilation/parallel-worker.ts
+++ b/packages/angular/build/src/tools/angular/compilation/parallel-worker.ts
@@ -94,11 +94,12 @@ export async function initialize(request: InitRequest) {
 
   return {
     referencedFiles,
-    // TODO: Expand? `allowJs`, `isolatedModules`, `sourceMap` are the only fields needed currently.
+    // TODO: Expand? `allowJs`, `isolatedModules`, `sourceMap`, `inlineSourceMap` are the only fields needed currently.
     compilerOptions: {
       allowJs: compilerOptions.allowJs,
       isolatedModules: compilerOptions.isolatedModules,
       sourceMap: compilerOptions.sourceMap,
+      inlineSourceMap: compilerOptions.inlineSourceMap,
     },
   };
 }

--- a/packages/angular/build/src/tools/esbuild/angular/compiler-plugin.ts
+++ b/packages/angular/build/src/tools/esbuild/angular/compiler-plugin.ts
@@ -275,7 +275,8 @@ export function createCompilerPlugin(
           // Typescript printing support for sourcemaps is not yet integrated.
           useTypeScriptTranspilation =
             !initializationResult.compilerOptions.isolatedModules ||
-            !!initializationResult.compilerOptions.sourceMap;
+            !!initializationResult.compilerOptions.sourceMap ||
+            !!initializationResult.compilerOptions.inlineSourceMap;
           referencedFiles = initializationResult.referencedFiles;
         } catch (error) {
           (result.errors ??= []).push({
@@ -562,6 +563,7 @@ function createCompilerOptionsTransformer(
       noEmitOnError: false,
       inlineSources: !!pluginOptions.sourcemap,
       inlineSourceMap: !!pluginOptions.sourcemap,
+      sourceMap: undefined,
       mapRoot: undefined,
       sourceRoot: undefined,
       preserveSymlinks,


### PR DESCRIPTION
The isolated modules transpilation option that was recently introduced is currently disabled when source maps are enabled. TypeScript has two mutually exclusive options that can be used to check for source map usage. Both of these options (`sourceMap` and `inlineSourceMap`) are now checked to determine if the direct transpilation optimization can be used.