### PR TITLE
refactor(@angular/cli): provide a default extract-i18n target for applications

### DIFF
--- a/packages/angular/cli/src/commands/extract-i18n/cli.ts
+++ b/packages/angular/cli/src/commands/extract-i18n/cli.ts
@@ -6,6 +6,9 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import { workspaces } from '@angular-devkit/core';
+import { createRequire } from 'node:module';
+import { join } from 'node:path';
 import { ArchitectCommandModule } from '../../command-builder/architect-command-module';
 import { CommandModuleImplementation } from '../../command-builder/command-module';
 
@@ -17,4 +20,38 @@ export default class ExtractI18nCommandModule
   command = 'extract-i18n [project]';
   describe = 'Extracts i18n messages from source code.';
   longDescriptionPath?: string | undefined;
+
+  override async findDefaultBuilderName(
+    project: workspaces.ProjectDefinition,
+  ): Promise<string | undefined> {
+    // Only application type projects have a default i18n extraction target
+    if (project.extensions['projectType'] !== 'application') {
+      return;
+    }
+
+    const buildTarget = project.targets.get('build');
+    if (!buildTarget) {
+      // No default if there is no build target
+      return;
+    }
+
+    // Provide a default based on the defined builder for the 'build' target
+    switch (buildTarget.builder) {
+      case '@angular-devkit/build-angular:application':
+      case '@angular-devkit/build-angular:browser-esbuild':
+      case '@angular-devkit/build-angular:browser':
+        return '@angular-devkit/build-angular:extract-i18n';
+      case '@angular/build:application':
+        return '@angular/build:extract-i18n';
+    }
+
+    // For other builders, check for `@angular-devkit/build-angular` and use if found.
+    // This package is safer to use since it supports both application builder types.
+    try {
+      const projectRequire = createRequire(join(this.context.root, project.root) + '/');
+      projectRequire.resolve('@angular-devkit/build-angular');
+
+      return '@angular-devkit/build-angular:extract-i18n';
+    } catch {}
+  }
 }


### PR DESCRIPTION
The `extract-i18n` command will now use a default project target and builder name if the target entry is not explicitly defined. This allows the removal of additional configuration from an `angular.json` file. If the target is already present than it will take priority over any default builder behavior. Infrastructure is also now present to allow other architect commands to have similar functionality in the future.