### PR TITLE
refactor: use explicit coercion of exitCode to number.

### DIFF
--- a/scripts/devkit-admin.mts
+++ b/scripts/devkit-admin.mts
@@ -37,7 +37,7 @@ console.error = function (...args) {
 try {
   const script = await import(`./${scriptName}.mjs`);
   const exitCode = await script.default(args, cwd);
-  process.exitCode = exitCode || 0;
+  process.exitCode = typeof exitCode === 'number' ? exitCode : 0;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 } catch (err: any) {
   console.error(err.stack);


### PR DESCRIPTION
Implicit coercion to number was removed in node 20, see https://nodejs.org/api/deprecations.html#DEP0164
