### PR TITLE
fix: Fix capitalization for YouTube

### DIFF
--- a/packages/schematics/angular/application/files/common-files/src/app/app.component.html.template
+++ b/packages/schematics/angular/application/files/common-files/src/app/app.component.html.template
@@ -300,7 +300,7 @@
         </a>
         <a
           href="https://www.youtube.com/channel/UCbn1OgGei-DV7aSRo_HaAiw"
-          aria-label="Youtube"
+          aria-label="YouTube"
           target="_blank"
           rel="noopener"
         >
@@ -310,7 +310,7 @@
             viewBox="0 0 29 20"
             fill="none"
             xmlns="http://www.w3.org/2000/svg"
-            alt="Youtube"
+            alt="YouTube"
           >
             <path
               fill-rule="evenodd"


### PR DESCRIPTION
The word should be [YouTube](https://youtube.com), not Youtube (the letter t should be uppercase after the word You), also made the same mistake in [this file](https://github.com/angular/schematics-angular-builds/blob/0a750495dfcd00c5cd9101219835996116ad46c7/application/files/common-files/src/app/app.component.html.template#L313)

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe: Fix capitalization for [YouTube](https://youtube.com)

## What is the current behavior?
YouTube has current capitalization, but Youtube is wrong capitalization.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
Fix capitalization mistake
<!-- Please describe the new behavior that. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
