### PR TITLE
refactor(@angular/cli): provide default serve target for applications

### DIFF
--- a/goldens/public-api/angular/build/index.api.md
+++ b/goldens/public-api/angular/build/index.api.md
@@ -109,7 +109,7 @@ export enum BuildOutputFileType {
 // @public
 export type DevServerBuilderOptions = {
     allowedHosts?: AllowedHosts;
-    buildTarget: string;
+    buildTarget?: string;
     headers?: {
         [key: string]: string;
     };

--- a/packages/angular/build/src/builders/dev-server/options.ts
+++ b/packages/angular/build/src/builders/dev-server/options.ts
@@ -36,8 +36,10 @@ export async function normalizeOptions(
 
   const cacheOptions = normalizeCacheOptions(projectMetadata, workspaceRoot);
 
-  // Target specifier defaults to the current project's build target using a development configuration
-  const buildTargetSpecifier = options.buildTarget ?? `::development`;
+  // Target specifier defaults to the current project's build target using the provided dev-server
+  // configuration if a configuration is present or the 'development' configuration if not.
+  const buildTargetSpecifier =
+    options.buildTarget ?? `::${context.target?.configuration || 'development'}`;
   const buildTarget = targetFromTargetString(buildTargetSpecifier, projectName, 'build');
 
   // Get the application builder options.

--- a/packages/angular/build/src/builders/dev-server/schema.json
+++ b/packages/angular/build/src/builders/dev-server/schema.json
@@ -127,5 +127,5 @@
     }
   },
   "additionalProperties": false,
-  "required": ["buildTarget"]
+  "required": []
 }

--- a/packages/angular/cli/src/commands/serve/cli.ts
+++ b/packages/angular/cli/src/commands/serve/cli.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import { workspaces } from '@angular-devkit/core';
 import { ArchitectCommandModule } from '../../command-builder/architect-command-module';
 import { CommandModuleImplementation } from '../../command-builder/command-module';
 import { RootCommands } from '../command-config';
@@ -19,4 +20,41 @@ export default class ServeCommandModule
   aliases = RootCommands['serve'].aliases;
   describe = 'Builds and serves your application, rebuilding on file changes.';
   longDescriptionPath?: string | undefined;
+
+  override async findDefaultBuilderName(
+    project: workspaces.ProjectDefinition,
+  ): Promise<string | undefined> {
+    // Only application type projects have a dev server target
+    if (project.extensions['projectType'] !== 'application') {
+      return;
+    }
+
+    const buildTarget = project.targets.get('build');
+    if (!buildTarget) {
+      // No default if there is no build target
+      return;
+    }
+
+    // Provide a default based on the defined builder for the 'build' target
+    switch (buildTarget.builder) {
+      case '@angular-devkit/build-angular:application':
+      case '@angular-devkit/build-angular:browser-esbuild':
+      case '@angular-devkit/build-angular:browser':
+        return '@angular-devkit/build-angular:dev-server';
+      case '@angular/build:application':
+        return '@angular/build:dev-server';
+    }
+
+    // For other builders, attempt to resolve a 'dev-server' builder from the 'build' target package name
+    const [buildPackageName] = buildTarget.builder.split(':', 1);
+    if (buildPackageName) {
+      try {
+        const qualifiedBuilderName = `${buildPackageName}:dev-server`;
+        await this.getArchitectHost().resolveBuilder(qualifiedBuilderName);
+
+        // Use builder if it resolves successfully
+        return qualifiedBuilderName;
+      } catch {}
+    }
+  }
 }

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/options.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/options.ts
@@ -36,8 +36,10 @@ export async function normalizeOptions(
 
   const cacheOptions = normalizeCacheOptions(projectMetadata, workspaceRoot);
 
-  // Target specifier defaults to the current project's build target using a development configuration
-  const buildTargetSpecifier = options.buildTarget ?? `::development`;
+  // Target specifier defaults to the current project's build target using the provided dev-server
+  // configuration if a configuration is present or the 'development' configuration if not.
+  const buildTargetSpecifier =
+    options.buildTarget ?? `::${context.target?.configuration || 'development'}`;
   const buildTarget = targetFromTargetString(buildTargetSpecifier, projectName, 'build');
 
   // Get the application builder options.

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/schema.json
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/schema.json
@@ -130,6 +130,5 @@
       ]
     }
   },
-  "additionalProperties": false,
-  "required": ["buildTarget"]
+  "additionalProperties": false
 }


### PR DESCRIPTION
The `serve` command will now use a default project target and builder name if the target entry is not explicitly defined. This allows the removal of additional configuration from an `angular.json` file. If the target is already present than it will take priority over any default builder behavior. The default logic will use the appropriate development server builder for officially supported packages (`@angular/build`/`@angular-devkit/build-angular`). The `dev-server` builder from these packages will currently assume a `development` configuration is present within the `build` target. The default behavior may be expanded in the future to support more arbitrary `build` target configurations. If there is third-party package usage within the `build` target, the CLI will attempt to discover a `dev-server` builder within the same package used by the `build` target. If none is found, no default will be added and the `serve` command will issue an error when no explicit target is present.