### PR TITLE
fix(@angular/build): read WASM file from script location on Node.js

### DIFF
--- a/packages/angular/build/src/tools/esbuild/wasm-plugin.ts
+++ b/packages/angular/build/src/tools/esbuild/wasm-plugin.ts
@@ -123,7 +123,8 @@ export function createWasmPlugin(options: WasmPluginOptions): Plugin {
           // Read from the file system when on Node.js (SSR) and not inline
           if (!inlineWasm && build.initialOptions.platform === 'node') {
             initContents += 'import { readFile } from "node:fs/promises";\n';
-            initContents += 'const wasmData = await readFile(wasmPath);\n';
+            initContents +=
+              'const wasmData = await readFile(new URL(wasmPath, import.meta.url));\n';
           }
 
           // Create initialization function


### PR DESCRIPTION
When using a WASM file on Node.js via SSR/SSG/etc. the path for the `readFile` call will now be based on the location of the script using the WASM file instead of the current working directory.
This change also adds a general Node.js WASM E2E test via prerendering.
