### PR TITLE
ci: allow terser to be updated by renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,7 @@
   "dependencyDashboard": true,
   "schedule": ["after 10:00pm every weekday", "before 4:00am every weekday", "every weekend"],
   "baseBranches": ["main"],
-  "ignoreDeps": ["@types/node", "build_bazel_rules_nodejs", "terser", "rules_pkg", "yarn"],
+  "ignoreDeps": ["@types/node", "build_bazel_rules_nodejs", "rules_pkg", "yarn"],
   "includePaths": [
     "WORKSPACE",
     "package.json",


### PR DESCRIPTION
Issue https://github.com/terser/terser/issues/1539 has been fixed and released as part of `5.31.2`
