### PR TITLE
test: use Node.js argument parser for E2E test runner

### DIFF
--- a/tests/legacy-cli/BUILD.bazel
+++ b/tests/legacy-cli/BUILD.bazel
@@ -15,10 +15,8 @@ ts_library(
         "//packages/angular_devkit/core",
         "//packages/angular_devkit/core/node",
         "//tests/legacy-cli/e2e/utils",
-        "@npm//@types/yargs-parser",
         "@npm//ansi-colors",
         "@npm//fast-glob",
-        "@npm//yargs-parser",
     ],
 )
 

--- a/tests/legacy-cli/e2e.bzl
+++ b/tests/legacy-cli/e2e.bzl
@@ -83,8 +83,8 @@ def e2e_suites(name, runner, data):
 
 def _e2e_tests(name, runner, **kwargs):
     # Always specify all the npm packages
-    args = kwargs.pop("templated_args", []) + ["--package"] + [
-        "$(rootpath %s)" % p
+    args = kwargs.pop("templated_args", []) + [
+        "--package $(rootpath %s)" % p
         for p in TESTED_PACKAGES
     ]
 

--- a/tests/legacy-cli/e2e/initialize/500-create-project.ts
+++ b/tests/legacy-cli/e2e/initialize/500-create-project.ts
@@ -1,5 +1,4 @@
 import { join } from 'path';
-import yargsParser from 'yargs-parser';
 import { getGlobalVariable } from '../utils/env';
 import { expectFileToExist } from '../utils/fs';
 import { gitClean } from '../utils/git';
@@ -8,13 +7,13 @@ import { ng } from '../utils/process';
 import { prepareProjectForE2e, updateJsonFile } from '../utils/project';
 
 export default async function () {
-  const argv = getGlobalVariable<yargsParser.Arguments>('argv');
+  const argv: Record<string, unknown> = getGlobalVariable('argv');
 
   if (argv.noproject) {
     return;
   }
 
-  if (argv.reuse) {
+  if (argv.reuse && typeof argv.reuse === 'string') {
     process.chdir(argv.reuse);
     await gitClean();
   } else {

--- a/tests/legacy-cli/e2e/initialize/BUILD.bazel
+++ b/tests/legacy-cli/e2e/initialize/BUILD.bazel
@@ -10,6 +10,5 @@ ts_library(
     visibility = ["//visibility:public"],
     deps = [
         "//tests/legacy-cli/e2e/utils",
-        "@npm//@types/yargs-parser",
     ],
 )

--- a/tests/legacy-cli/e2e/utils/BUILD.bazel
+++ b/tests/legacy-cli/e2e/utils/BUILD.bazel
@@ -11,7 +11,6 @@ ts_library(
     deps = [
         "@npm//@types/semver",
         "@npm//@types/tar",
-        "@npm//@types/yargs-parser",
         "@npm//ansi-colors",
         "@npm//fast-glob",
         "@npm//npm",

--- a/tests/legacy-cli/e2e/utils/project.ts
+++ b/tests/legacy-cli/e2e/utils/project.ts
@@ -1,7 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { prerelease, SemVer } from 'semver';
-import yargsParser from 'yargs-parser';
 import { getGlobalVariable } from './env';
 import { readFile, replaceInFile, writeFile } from './fs';
 import { gitCommit } from './git';
@@ -39,7 +38,7 @@ export async function ngServe(...args: string[]) {
 }
 
 export async function prepareProjectForE2e(name: string) {
-  const argv: yargsParser.Arguments = getGlobalVariable('argv');
+  const argv: Record<string, unknown> = getGlobalVariable('argv');
 
   await git('config', 'user.email', 'angular-core+e2e@google.com');
   await git('config', 'user.name', 'Angular CLI E2E');


### PR DESCRIPTION
The `node:util` builtin provides an argument parser that
can be leveraged for the E2E test runner that avoids the
need for additional third-party packages.