### PR TITLE
fix(@angular-devkit/build-angular): skip undefined files when generat…

### DIFF
--- a/packages/angular/build/src/tools/esbuild/budget-stats.ts
+++ b/packages/angular/build/src/tools/esbuild/budget-stats.ts
@@ -60,7 +60,10 @@ export function generateBudgetStats(
 
   // Add component styles from metafile
   // TODO: Provide this information directly from the AOT compiler
-  for (const entry of Object.values(metafile.outputs)) {
+  for (const [file, entry] of Object.entries(metafile.outputs)) {
+    if (!file.endsWith('.css')) {
+      continue;
+    }
     // 'ng-component' is set by the angular plugin's component stylesheet bundler
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const componentStyle: boolean = (entry as any)['ng-component'];


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

When the source maps are enabled, generated files are computed during the budget stats generation.

Issue Number: https://github.com/angular/angular-cli/issues/28036

## What is the new behavior?

The files that are `undefined` are now skipped.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
