### PR TITLE
fix(@angular/build): resolve only ".wasm" files

### DIFF
--- a/packages/angular/build/src/tools/esbuild/wasm-plugin.ts
+++ b/packages/angular/build/src/tools/esbuild/wasm-plugin.ts
@@ -46,7 +46,7 @@ export function createWasmPlugin(options: WasmPluginOptions): Plugin {
   return {
     name: 'angular-wasm',
     setup(build): void {
-      build.onResolve({ filter: /.wasm$/ }, async (args) => {
+      build.onResolve({ filter: /\.wasm$/ }, async (args) => {
         // Skip if already resolving the WASM file to avoid infinite resolution
         if (args.pluginData?.[WASM_RESOLVE_SYMBOL]) {
           return;
@@ -94,7 +94,7 @@ export function createWasmPlugin(options: WasmPluginOptions): Plugin {
       });
 
       build.onLoad(
-        { filter: /.wasm$/, namespace: WASM_INIT_NAMESPACE },
+        { filter: /\.wasm$/, namespace: WASM_INIT_NAMESPACE },
         createCachedLoad(cache, async (args) => {
           // Ensure async mode is supported
           if (!allowAsync) {
@@ -194,7 +194,7 @@ export function createWasmPlugin(options: WasmPluginOptions): Plugin {
         }),
       );
 
-      build.onLoad({ filter: /.wasm$/, namespace: WASM_CONTENTS_NAMESPACE }, async (args) => {
+      build.onLoad({ filter: /\.wasm$/, namespace: WASM_CONTENTS_NAMESPACE }, async (args) => {
         const contents = args.pluginData.wasmContents ?? (await readFile(args.path));
 
         let loader: 'binary' | 'file' = 'file';


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently the wasm plugin introduced in v18.1.0 resolves not only `.wasm` imports, but any imports that end with `(any character)wasm`. It must be a typo in the wasm plugin regex `/.wasm$/` which should look like `/\.wasm$/`.

You can see it in this [example](https://stackblitz.com/edit/stackblitz-starters-jfbg7u?file=src%2Fmain.ts) by running `ng build`.
In the example above `matrix-js-sdk` depends on `@matrix-org/matrix-sdk-crypto-wasm` which is treated as a wasm import by the plugin which causes build error

```
The plugin "angular-compiler" didn't set a resolve directory for the file "angular:wasm:init:/home/projects/stackblitz-starters-nnuphq/node_modules/@matrix-org/matrix-sdk-crypto-wasm/pkg/index.js", so esbuild did not search for "./matrix_sdk_crypto_wasm_bg.wasm.js" on the file system.
```

## What is the new behavior?

<!-- Please describe the new behavior that. -->

Wasm plugin resolves only `.wasm` imports.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information