### PR TITLE
refactor(@angular/build): provide structured application builder result types

### DIFF
--- a/packages/angular/build/src/builders/application/execute-build.ts
+++ b/packages/angular/build/src/builders/application/execute-build.ts
@@ -156,6 +156,8 @@ export async function executeBuild(
   // Watch input index HTML file if configured
   if (options.indexHtmlOptions) {
     executionResult.extraWatchFiles.push(options.indexHtmlOptions.input);
+    executionResult.htmlIndexPath = options.indexHtmlOptions.output;
+    executionResult.htmlBaseHref = options.baseHref;
   }
 
   // Perform i18n translation inlining if enabled

--- a/packages/angular/build/src/builders/application/results.ts
+++ b/packages/angular/build/src/builders/application/results.ts
@@ -1,0 +1,74 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { BuildOutputFileType } from '../../tools/esbuild/bundler-context';
+
+export enum ResultKind {
+  Failure,
+  Full,
+  Incremental,
+  ComponentUpdate,
+}
+
+export type Result = FailureResult | FullResult | IncrementalResult | ComponentUpdateResult;
+
+export interface BaseResult {
+  kind: ResultKind;
+  warnings?: ResultMessage[];
+  duration?: number;
+  detail?: Record<string, unknown>;
+}
+
+export interface FailureResult extends BaseResult {
+  kind: ResultKind.Failure;
+  errors: ResultMessage[];
+}
+
+export interface FullResult extends BaseResult {
+  kind: ResultKind.Full;
+  files: Record<string, ResultFile>;
+}
+
+export interface IncrementalResult extends BaseResult {
+  kind: ResultKind.Incremental;
+  added: string[];
+  removed: string[];
+  modified: string[];
+  files: Record<string, ResultFile>;
+}
+
+export type ResultFile = DiskFile | MemoryFile;
+
+export interface BaseResultFile {
+  origin: 'memory' | 'disk';
+  type: BuildOutputFileType;
+}
+
+export interface DiskFile extends BaseResultFile {
+  origin: 'disk';
+  inputPath: string;
+}
+
+export interface MemoryFile extends BaseResultFile {
+  origin: 'memory';
+  hash: string;
+  contents: Uint8Array;
+}
+
+export interface ResultMessage {
+  text: string;
+  location?: { file: string; line: number; column: number } | null;
+  notes?: { text: string }[];
+}
+
+export interface ComponentUpdateResult extends BaseResult {
+  kind: ResultKind.ComponentUpdate;
+  id: string;
+  type: 'style' | 'template';
+  content: string;
+}

--- a/packages/angular/build/src/builders/application/tests/options/output-path_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/options/output-path_spec.ts
@@ -286,10 +286,14 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
             },
           });
 
-          const { result } = await harness.executeOnce();
+          const { result, logs } = await harness.executeOnce({ outputLogsOnFailure: false });
           expect(result?.success).toBeFalse();
-          expect(result?.error).toContain(
-            `'outputPath.browser' cannot be configured to an empty string when SSR is enabled`,
+          expect(logs).toContain(
+            jasmine.objectContaining({
+              message: jasmine.stringMatching(
+                `'outputPath.browser' cannot be configured to an empty string when SSR is enabled`,
+              ),
+            }),
           );
         });
       });
@@ -349,10 +353,14 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
           },
         });
 
-        const { result } = await harness.executeOnce();
+        const { result, logs } = await harness.executeOnce({ outputLogsOnFailure: false });
         expect(result?.success).toBeFalse();
-        expect(result?.error).toContain(
-          `'outputPath.browser' and 'outputPath.server' cannot be configured to the same value`,
+        expect(logs).toContain(
+          jasmine.objectContaining({
+            message: jasmine.stringMatching(
+              `'outputPath.browser' and 'outputPath.server' cannot be configured to the same value`,
+            ),
+          }),
         );
       });
     });

--- a/packages/angular/build/src/builders/extract-i18n/builder.ts
+++ b/packages/angular/build/src/builders/extract-i18n/builder.ts
@@ -64,9 +64,8 @@ export async function execute(
     extensions,
   );
 
-  // Return the builder result if it failed
-  if (!extractionResult.builderResult.success) {
-    return extractionResult.builderResult;
+  if (!extractionResult.success) {
+    return { success: false };
   }
 
   // Perform duplicate message checks

--- a/packages/angular/build/src/private.ts
+++ b/packages/angular/build/src/private.ts
@@ -16,6 +16,7 @@
 // Builders
 export { buildApplicationInternal } from './builders/application';
 export type { ApplicationBuilderInternalOptions } from './builders/application/options';
+export { type Result, type ResultFile, ResultKind } from './builders/application/results';
 export { serveWithVite } from './builders/dev-server/vite-server';
 
 // Tools

--- a/packages/angular/build/src/tools/esbuild/bundler-execution-result.ts
+++ b/packages/angular/build/src/tools/esbuild/bundler-execution-result.ts
@@ -43,6 +43,8 @@ export class ExecutionResult {
   logs: string[] = [];
   externalMetadata?: ExternalResultMetadata;
   extraWatchFiles: string[] = [];
+  htmlIndexPath?: string;
+  htmlBaseHref?: string;
 
   constructor(
     private rebuildContexts: BundlerContext[],

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/tests/options/assets_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/tests/options/assets_spec.ts
@@ -6,10 +6,10 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import { buildEsbuildBrowser } from '../../index';
+import { buildEsbuildBrowserArchitect } from '../../index';
 import { BASE_OPTIONS, BROWSER_BUILDER_INFO, describeBuilder } from '../setup';
 
-describeBuilder(buildEsbuildBrowser, BROWSER_BUILDER_INFO, (harness) => {
+describeBuilder(buildEsbuildBrowserArchitect, BROWSER_BUILDER_INFO, (harness) => {
   describe('Option: "assets"', () => {
     beforeEach(async () => {
       // Application code is not needed for asset tests

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/tests/options/delete-output-path_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/tests/options/delete-output-path_spec.ts
@@ -6,10 +6,10 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import { buildEsbuildBrowser } from '../../index';
+import { buildEsbuildBrowserArchitect } from '../../index';
 import { BASE_OPTIONS, BROWSER_BUILDER_INFO, describeBuilder } from '../setup';
 
-describeBuilder(buildEsbuildBrowser, BROWSER_BUILDER_INFO, (harness) => {
+describeBuilder(buildEsbuildBrowserArchitect, BROWSER_BUILDER_INFO, (harness) => {
   describe('Option: "deleteOutputPath"', () => {
     beforeEach(async () => {
       // Application code is not needed for asset tests

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/tests/options/deploy-url_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/tests/options/deploy-url_spec.ts
@@ -6,10 +6,10 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import { buildEsbuildBrowser } from '../../index';
+import { buildEsbuildBrowserArchitect } from '../../index';
 import { BASE_OPTIONS, BROWSER_BUILDER_INFO, describeBuilder } from '../setup';
 
-describeBuilder(buildEsbuildBrowser, BROWSER_BUILDER_INFO, (harness) => {
+describeBuilder(buildEsbuildBrowserArchitect, BROWSER_BUILDER_INFO, (harness) => {
   describe('Option: "deployUrl"', () => {
     beforeEach(async () => {
       // Add a global stylesheet to test link elements

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/tests/options/main_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/tests/options/main_spec.ts
@@ -6,10 +6,10 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import { buildEsbuildBrowser } from '../../index';
+import { buildEsbuildBrowserArchitect } from '../../index';
 import { BASE_OPTIONS, BROWSER_BUILDER_INFO, describeBuilder } from '../setup';
 
-describeBuilder(buildEsbuildBrowser, BROWSER_BUILDER_INFO, (harness) => {
+describeBuilder(buildEsbuildBrowserArchitect, BROWSER_BUILDER_INFO, (harness) => {
   describe('Option: "main"', () => {
     it('uses a provided TypeScript file', async () => {
       harness.useTarget('build', {

--- a/packages/angular_devkit/build_angular/src/builders/extract-i18n/application-extraction.ts
+++ b/packages/angular_devkit/build_angular/src/builders/extract-i18n/application-extraction.ts
@@ -8,12 +8,13 @@
 
 import {
   type ApplicationBuilderInternalOptions,
+  ResultFile,
+  ResultKind,
   buildApplicationInternal,
 } from '@angular/build/private';
 import type { ɵParsedMessage as LocalizeMessage } from '@angular/localize';
 import type { MessageExtractor } from '@angular/localize/tools';
-import type { BuilderContext, BuilderOutput } from '@angular-devkit/architect';
-import assert from 'node:assert';
+import type { BuilderContext } from '@angular-devkit/architect';
 import nodePath from 'node:path';
 import { buildEsbuildBrowser } from '../browser-esbuild';
 import type { NormalizedExtractI18nOptions } from './options';
@@ -24,7 +25,7 @@ export async function extractMessages(
   context: BuilderContext,
   extractorConstructor: typeof MessageExtractor,
 ): Promise<{
-  builderResult: BuilderOutput;
+  success: boolean;
   basePath: string;
   messages: LocalizeMessage[];
   useLegacyIds: boolean;
@@ -54,41 +55,21 @@ export async function extractMessages(
     build = buildEsbuildBrowser;
   }
 
-  // Build the application with the build options
-  let builderResult;
-  try {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    for await (const result of build(buildOptions as any, context, { write: false })) {
-      builderResult = result;
-      break;
-    }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const builderResult = await first(build(buildOptions as any, context, { write: false }));
 
-    assert(builderResult !== undefined, 'Application builder did not provide a result.');
-  } catch (err) {
-    builderResult = {
-      success: false,
-      error: (err as Error).message,
-    };
-  }
-
-  // Extract messages from each output JavaScript file.
-  // Output files are only present on a successful build.
-  if (builderResult.outputFiles) {
-    // Store the JS and JS map files for lookup during extraction
-    const files = new Map<string, string>();
-    for (const outputFile of builderResult.outputFiles) {
-      if (outputFile.path.endsWith('.js')) {
-        files.set(outputFile.path, outputFile.text);
-      } else if (outputFile.path.endsWith('.js.map')) {
-        files.set(outputFile.path, outputFile.text);
-      }
-    }
-
+  let success = false;
+  if (!builderResult || builderResult.kind === ResultKind.Failure) {
+    context.logger.error('Application build failed.');
+  } else if (builderResult.kind !== ResultKind.Full) {
+    context.logger.error('Application build did not provide a full output.');
+  } else {
     // Setup the localize message extractor based on the in-memory files
-    const extractor = setupLocalizeExtractor(extractorConstructor, files, context);
+    const extractor = setupLocalizeExtractor(extractorConstructor, builderResult.files, context);
 
-    // Attempt extraction of all output JS files
-    for (const filePath of files.keys()) {
+    // Extract messages from each output JavaScript file.
+    // Output files are only present on a successful build.
+    for (const filePath of Object.keys(builderResult.files)) {
       if (!filePath.endsWith('.js')) {
         continue;
       }
@@ -96,10 +77,12 @@ export async function extractMessages(
       const fileMessages = extractor.extractMessages(filePath);
       messages.push(...fileMessages);
     }
+
+    success = true;
   }
 
   return {
-    builderResult,
+    success,
     basePath: context.workspaceRoot,
     messages,
     // Legacy i18n identifiers are not supported with the new application builder
@@ -109,9 +92,10 @@ export async function extractMessages(
 
 function setupLocalizeExtractor(
   extractorConstructor: typeof MessageExtractor,
-  files: Map<string, string>,
+  files: Record<string, ResultFile>,
   context: BuilderContext,
 ): MessageExtractor {
+  const textDecoder = new TextDecoder();
   // Setup a virtual file system instance for the extractor
   // * MessageExtractor itself uses readFile, relative and resolve
   // * Internal SourceFileLoader (sourcemap support) uses dirname, exists, readFile, and resolve
@@ -120,7 +104,11 @@ function setupLocalizeExtractor(
       // Output files are stored as relative to the workspace root
       const requestedPath = nodePath.relative(context.workspaceRoot, path);
 
-      const content = files.get(requestedPath);
+      const file = files[requestedPath];
+      let content;
+      if (file?.origin === 'memory') {
+        content = textDecoder.decode(file.contents);
+      }
       if (content === undefined) {
         throw new Error('Unknown file requested: ' + requestedPath);
       }
@@ -137,7 +125,7 @@ function setupLocalizeExtractor(
       // Output files are stored as relative to the workspace root
       const requestedPath = nodePath.relative(context.workspaceRoot, path);
 
-      return files.has(requestedPath);
+      return files[requestedPath] !== undefined;
     },
     dirname(path: string): string {
       return nodePath.dirname(path);
@@ -170,4 +158,10 @@ function setupLocalizeExtractor(
   });
 
   return extractor;
+}
+
+async function first<T>(iterable: AsyncIterable<T>): Promise<T | undefined> {
+  for await (const value of iterable) {
+    return value;
+  }
 }

--- a/packages/angular_devkit/build_angular/src/builders/extract-i18n/builder.ts
+++ b/packages/angular_devkit/build_angular/src/builders/extract-i18n/builder.ts
@@ -70,6 +70,10 @@ export async function execute(
       context,
       localizeToolsModule.MessageExtractor,
     );
+
+    if (!extractionResult.success) {
+      return { success: false };
+    }
   } else {
     // Purge old build disk cache.
     // Other build systems handle stale cache purging directly.
@@ -77,11 +81,11 @@ export async function execute(
 
     const { extractMessages } = await import('./webpack-extraction');
     extractionResult = await extractMessages(normalizedOptions, builderName, context, transforms);
-  }
 
-  // Return the builder result if it failed
-  if (!extractionResult.builderResult.success) {
-    return extractionResult.builderResult;
+    // Return the builder result if it failed
+    if (!extractionResult.builderResult.success) {
+      return extractionResult.builderResult;
+    }
   }
 
   // Perform duplicate message checks

--- a/packages/angular_devkit/build_angular/src/builders/web-test-runner/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/web-test-runner/index.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import { buildApplicationInternal } from '@angular/build/private';
+import { Result, ResultKind, buildApplicationInternal } from '@angular/build/private';
 import { BuilderContext, BuilderOutput, createBuilder } from '@angular-devkit/architect';
 import type * as WebTestRunner from '@web/test-runner';
 import { promises as fs } from 'node:fs';
@@ -53,8 +53,8 @@ export default createBuilder(
 
     // Build the tests and abort on any build failure.
     const buildOutput = await buildTests(testFiles, testDir, options, ctx);
-    if (!buildOutput.success) {
-      return buildOutput;
+    if (buildOutput.kind === ResultKind.Failure) {
+      return { success: false };
     }
 
     // Run the built tests.
@@ -68,7 +68,7 @@ async function buildTests(
   outputPath: string,
   options: WtrBuilderOptions,
   ctx: BuilderContext,
-): Promise<BuilderOutput> {
+): Promise<Result> {
   const entryPoints = new Set([
     ...testFiles,
     'jasmine-core/lib/jasmine-core/jasmine.js',


### PR DESCRIPTION
The application builder now provides structured output types to its internal consumers. The architect builders themselves and the programmatic API is not changed. These output result types allow for the development server to receive additional information regarding the build and update the active browser appropriately. This functionality is not yet implemented but the additional result types provide the base infrastructure to enable future features. The result types also allow for reduced complexity inside other builders such as i18n extraction and the browser compatibility builder. The usage is not yet fully optimized and will be refined in future changes.