### PR TITLE
fix(@angular/build): correctly detect comma in Sass URL lexer

### DIFF
--- a/packages/angular/build/src/tools/sass/lexer.ts
+++ b/packages/angular/build/src/tools/sass/lexer.ts
@@ -55,7 +55,7 @@ export function* findUrls(
     if (pos > 0) {
       pos -= 2;
       next();
-      if (!isWhitespace(current) && current !== 0x0027 && current !== 0x003a) {
+      if (!isWhitespace(current) && current !== 0x002c && current !== 0x003a) {
         // Skip - not a url token
         pos += 3;
         continue;

--- a/packages/angular/build/src/tools/sass/lexer_spec.ts
+++ b/packages/angular/build/src/tools/sass/lexer_spec.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { findUrls } from './lexer';
+
+describe('Sass URL lexer', () => {
+  it('should find url immediately after a colon, comma, or whitespace', () => {
+    const input = `.c{property:url("first"),url("second"), url("third");}`;
+
+    const result = [...findUrls(input)];
+
+    expect(result).toEqual([
+      { start: 16, end: 23, value: 'first' },
+      { start: 29, end: 37, value: 'second' },
+      { start: 44, end: 51, value: 'third' },
+    ]);
+  });
+
+  it('should find full url with string containing url function', () => {
+    const input = `.c{property:url("url('abc')");}`;
+
+    const result = [...findUrls(input)];
+
+    expect(result).toEqual([{ start: 16, end: 28, value: `url('abc')` }]);
+  });
+});


### PR DESCRIPTION
The Sass rebasing lexer was incorrectly checking for a comma in certain cases previously. This has now been corrected and url usage that immediately follows a comma within a rule will now be extracted as expected.

Closes #28084