### PR TITLE
BUILD: Changes to local repo's build system(path to npm_package_archive.tgz files)

### DIFF
--- a/tools/link_package_json_to_tarballs.bzl
+++ b/tools/link_package_json_to_tarballs.bzl
@@ -53,7 +53,7 @@ def link_package_json_to_tarballs(name, src, pkg_deps, out):
             name = "%s_%s_filter" % (name, i),
             srcs = srcs,
             cmd = """
-                TAR=$$(dirname $$({abs_path_sandbox} || {abs_path_nosandbox}))/npm_package_archive.tgz
+                TAR=$$({abs_path_sandbox} || {abs_path_nosandbox})/npm_package_archive.tgz
                 PKGNAME=$$(cat $(execpath {pkg_name}))
                 if [[ "$$TAR" != *bazel-out* ]]; then
                     echo "ERROR: package.json passed to substitute_tar_deps must be in the output tree. You can use copy_to_bin to copy a source file to the output tree."


### PR DESCRIPTION
Fixes the paths to npm_package_archive.tgz on local builds

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
I have followed the documentation steps mentioned in [Developer.md](https://github.com/angular/angular-cli/blob/main/docs/DEVELOPER.md). After running `yarn build --local` the package.json file for every scope(i.e. cli, build, pwa, etc..) have incorrect paths to npm_package_archive.tgz

Steps to reproduce
1. Clone the [angular cli repository](https://github.com/angular/angular-cli). 
2. Run `yarn build --local`
3. Open the dist folder and extract _angular_cli.tgz (Using this as an example you can look for any other tgz file in dist)
4. Open the `package.json` file
5. Look for `@angular-devkit/architect` (Using this as an example)
6. You will observe that the path to the file is something like: `<path>\packages\angular_devkit\npm_package_archive.tgz`
7. The same thing can be observerd in many places in this package.json file, and in other package.json files of other generated `<package>.tgz`



<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

Expected path(using `@angular-devkit/architect` as an example) should be `<path>/packages\angular_devkit\architect\npm_package_archive.tgz` 

<!-- Please describe the new behavior that. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No
- [x] Maybe(As it is chaning the package.json files for local builds)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

The problem seems to be in `link_package_json_to_tarballs.bzl` file where an unnecessary `dirname ` in line 56 is used ( this is resulting in `parent of parent dir` instead of just having `parent dir`). It is executing a statement like `(  dirname (<path>\packages\angular_devkit\architect)    )/npm_package_archive.tgz` which is resulting in TAR to have an incorrect value like `<path>\packages\angular_devkit\npm_package_archive.tgz`