### PR TITLE
fix(@angular/build): resolve error with `extract-i18n` builder for libraries

### DIFF
--- a/packages/angular/build/src/builders/extract-i18n/builder.ts
+++ b/packages/angular/build/src/builders/extract-i18n/builder.ts
@@ -32,6 +32,18 @@ export async function execute(
     return { success: false };
   }
 
+  const { projectType } = (await context.getProjectMetadata(projectName)) as {
+    projectType?: string;
+  };
+  if (projectType !== 'application') {
+    context.logger.error(
+      `Tried to extract from ${projectName} with 'projectType' ${projectType}, which is not supported.` +
+        ` The 'extract-i18n' builder can only extract from applications.`,
+    );
+
+    return { success: false };
+  }
+
   // Check Angular version.
   assertCompatibleAngularVersion(context.workspaceRoot);
 

--- a/packages/angular_devkit/build_angular/src/builders/extract-i18n/builder.ts
+++ b/packages/angular_devkit/build_angular/src/builders/extract-i18n/builder.ts
@@ -35,6 +35,18 @@ export async function execute(
     return { success: false };
   }
 
+  const { projectType } = (await context.getProjectMetadata(projectName)) as {
+    projectType?: string;
+  };
+  if (projectType !== 'application') {
+    context.logger.error(
+      `Tried to extract from ${projectName} with 'projectType' ${projectType}, which is not supported.` +
+        ` The 'extract-i18n' builder can only extract from applications.`,
+    );
+
+    return { success: false };
+  }
+
   // Check Angular version.
   assertCompatibleAngularVersion(context.workspaceRoot);
 


### PR DESCRIPTION

The `extract-i18n` builder is only intended to be used with application projects.

Closes #28109
