### PR TITLE
refactor(@angular/build): Remove unnecessary `onLoad` from `createCssResourcePlugin`

### DIFF
--- a/packages/angular/build/src/tools/esbuild/stylesheets/bundle-options.ts
+++ b/packages/angular/build/src/tools/esbuild/stylesheets/bundle-options.ts
@@ -59,7 +59,7 @@ export function createStylesheetBundleOptions(
     pluginFactory.create(SassStylesheetLanguage),
     pluginFactory.create(LessStylesheetLanguage),
     pluginFactory.create(CssStylesheetLanguage),
-    createCssResourcePlugin(cache),
+    createCssResourcePlugin(),
   ];
 
   if (options.inlineFonts) {


### PR DESCRIPTION

This commit eliminates the redundant `onLoad` handling from the `createCssResourcePlugin`, allowing esbuild to manage the file reads directly.
