### PR TITLE
refactor(@angular-devkit/build-angular): only write test related files in WTR builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/web-test-runner/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/web-test-runner/index.ts
@@ -9,7 +9,8 @@
 import { Result, ResultKind, buildApplicationInternal } from '@angular/build/private';
 import { BuilderContext, BuilderOutput, createBuilder } from '@angular-devkit/architect';
 import type * as WebTestRunner from '@web/test-runner';
-import { promises as fs } from 'node:fs';
+import { randomUUID } from 'node:crypto';
+import fs from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import path from 'node:path';
 import { findTestFiles } from '../../utils/test-files';
@@ -17,6 +18,7 @@ import { OutputHashing } from '../browser-esbuild/schema';
 import { logBuilderStatusWarnings } from './builder-status-warnings';
 import { WtrBuilderOptions, normalizeOptions } from './options';
 import { Schema } from './schema';
+import { writeTestFiles } from './write-test-files';
 
 export default createBuilder(
   async (schema: Schema, ctx: BuilderContext): Promise<BuilderOutput> => {
@@ -41,7 +43,8 @@ export default createBuilder(
     }
 
     const options = normalizeOptions(schema);
-    const testDir = 'dist/test-out';
+
+    const testDir = path.join(ctx.workspaceRoot, 'dist/test-out', randomUUID());
 
     // Parallelize startup work.
     const [testFiles] = await Promise.all([
@@ -55,10 +58,18 @@ export default createBuilder(
     const buildOutput = await buildTests(testFiles, testDir, options, ctx);
     if (buildOutput.kind === ResultKind.Failure) {
       return { success: false };
+    } else if (buildOutput.kind !== ResultKind.Full) {
+      return {
+        success: false,
+        error: 'A full build result is required from the application builder.',
+      };
     }
 
+    // Write test files
+    await writeTestFiles(buildOutput.files, testDir);
+
     // Run the built tests.
-    return await runTests(wtr, `${testDir}/browser`, options);
+    return await runTests(wtr, testDir, options);
   },
 );
 
@@ -105,6 +116,7 @@ async function buildTests(
         polyfills,
       },
       ctx,
+      { write: false },
     ),
   );
 

--- a/packages/angular_devkit/build_angular/src/builders/web-test-runner/write-test-files.ts
+++ b/packages/angular_devkit/build_angular/src/builders/web-test-runner/write-test-files.ts
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { BuildOutputFileType } from '@angular/build';
+import { ResultFile, emitFilesToDisk } from '@angular/build/private';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+export async function writeTestFiles(files: Record<string, ResultFile>, testDir: string) {
+  const directoryExists = new Set<string>();
+  // Writes the test related output files to disk and ensures the containing directories are present
+  await emitFilesToDisk(Object.entries(files), async ([filePath, file]) => {
+    if (file.type !== BuildOutputFileType.Browser && file.type !== BuildOutputFileType.Media) {
+      return;
+    }
+
+    const fullFilePath = path.join(testDir, filePath);
+
+    // Ensure output subdirectories exist
+    const fileBasePath = path.dirname(fullFilePath);
+    if (fileBasePath && !directoryExists.has(fileBasePath)) {
+      await fs.mkdir(fileBasePath, { recursive: true });
+      directoryExists.add(fileBasePath);
+    }
+
+    if (file.origin === 'memory') {
+      // Write file contents
+      await fs.writeFile(fullFilePath, file.contents);
+    } else {
+      // Copy file contents
+      await fs.copyFile(file.inputPath, fullFilePath, fs.constants.COPYFILE_FICLONE);
+    }
+  });
+}


### PR DESCRIPTION
With the structured build results available, the WTR builder can now more easily write only the needed files to a temporary location. This reduces the need to assume build directory output structure and reduces the amount of potential filesystem calls. The temporary files are also now written into a UUID subdirectory within the existing `dist/test-out` location. This allows for multiple projects to be tested concurrently without overwriting each other.
The Jest builder has also been updated with similar changes.