### PR TITLE
fix(@angular/build): allow explicitly disabling TypeScript incremental mode

### DIFF
--- a/packages/angular/build/src/builders/application/tests/behavior/typescript-incremental_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/behavior/typescript-incremental_spec.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { buildApplication } from '../../index';
+import { APPLICATION_BUILDER_INFO, BASE_OPTIONS, describeBuilder } from '../setup';
+
+describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
+  describe('Behavior: "TypeScript explicit incremental option usage"', () => {
+    it('should successfully build with incremental disabled', async () => {
+      // Disable tsconfig incremental option in tsconfig
+      await harness.modifyFile('tsconfig.json', (content) => {
+        const tsconfig = JSON.parse(content);
+        tsconfig.compilerOptions.incremental = false;
+
+        return JSON.stringify(tsconfig);
+      });
+
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+      });
+
+      const { result } = await harness.executeOnce();
+
+      expect(result?.success).toBe(true);
+    });
+  });
+});

--- a/packages/angular/build/src/tools/esbuild/angular/compiler-plugin.ts
+++ b/packages/angular/build/src/tools/esbuild/angular/compiler-plugin.ts
@@ -284,7 +284,7 @@ export function createCompilerPlugin(
             location: null,
             notes: [
               {
-                text: error instanceof Error ? error.stack ?? error.message : `${error}`,
+                text: error instanceof Error ? (error.stack ?? error.message) : `${error}`,
                 location: null,
               },
             ],
@@ -315,7 +315,7 @@ export function createCompilerPlugin(
             location: null,
             notes: [
               {
-                text: error instanceof Error ? error.stack ?? error.message : `${error}`,
+                text: error instanceof Error ? (error.stack ?? error.message) : `${error}`,
                 location: null,
               },
             ],
@@ -537,9 +537,12 @@ function createCompilerOptionsTransformer(
       compilerOptions.compilationMode = 'full';
     }
 
-    // Enable incremental compilation by default if caching is enabled
-    if (pluginOptions.sourceFileCache?.persistentCachePath) {
-      compilerOptions.incremental ??= true;
+    // Enable incremental compilation by default if caching is enabled and incremental is not explicitly disabled
+    if (
+      compilerOptions.incremental !== false &&
+      pluginOptions.sourceFileCache?.persistentCachePath
+    ) {
+      compilerOptions.incremental = true;
       // Set the build info file location to the configured cache directory
       compilerOptions.tsBuildInfoFile = path.join(
         pluginOptions.sourceFileCache?.persistentCachePath,


### PR DESCRIPTION
If the TypeScript `incremental` option is explicitly set to `false`, the `application` builder will no longer attempt to enable and use incremental compilation mode via stored TypeScript build file information. This prevents an potential build time error that would otherwise occur due to the `tsBuildInfoFile` option being set without the `incremental` option. Behavior remains the same if the option is not present or set to `true`.