### PR TITLE
refactor(@angular/build): avoid write file logic for internal application build action

### DIFF
--- a/packages/angular/build/src/builders/dev-server/builder.ts
+++ b/packages/angular/build/src/builders/dev-server/builder.ts
@@ -67,7 +67,7 @@ export async function* execute(
     normalizedOptions,
     builderName,
     (options, context, plugins) =>
-      buildApplicationInternal(options, context, { write: false }, { codePlugins: plugins }),
+      buildApplicationInternal(options, context, { codePlugins: plugins }),
     context,
     { indexHtml: extensions?.indexHtmlTransformer },
     extensions,

--- a/packages/angular/build/src/builders/extract-i18n/application-extraction.ts
+++ b/packages/angular/build/src/builders/extract-i18n/application-extraction.ts
@@ -49,9 +49,7 @@ export async function extractMessages(
   buildOptions.prerender = false;
 
   // Build the application with the build options
-  const builderResult = await first(
-    buildApplicationInternal(buildOptions, context, { write: false }, extensions),
-  );
+  const builderResult = await first(buildApplicationInternal(buildOptions, context, extensions));
 
   let success = false;
   if (!builderResult || builderResult.kind === ResultKind.Failure) {

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/index.ts
@@ -51,9 +51,6 @@ export async function* buildEsbuildBrowser(
   for await (const result of buildApplicationInternal(
     normalizedOptions,
     context,
-    {
-      write: false,
-    },
     plugins && { codePlugins: plugins },
   )) {
     // Write the file directly from this builder to maintain webpack output compatibility

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/builder.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/builder.ts
@@ -96,7 +96,7 @@ export function execute(
                 return builderName === '@angular-devkit/build-angular:browser-esbuild'
                   ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
                     buildEsbuildBrowser(options as any, context, { write: false }, codePlugins)
-                  : buildApplicationInternal(options, context, { write: false }, { codePlugins });
+                  : buildApplicationInternal(options, context, { codePlugins });
               },
               context,
               transforms,

--- a/packages/angular_devkit/build_angular/src/builders/jest/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/jest/index.ts
@@ -97,7 +97,6 @@ export default createBuilder(
           },
         },
         context,
-        { write: false },
       ),
     );
     if (buildResult.kind === ResultKind.Failure) {

--- a/packages/angular_devkit/build_angular/src/builders/web-test-runner/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/web-test-runner/index.ts
@@ -116,7 +116,6 @@ async function buildTests(
         polyfills,
       },
       ctx,
-      { write: false },
     ),
   );
 


### PR DESCRIPTION
The internal "buildApplicationInternal" function is only used by several consumers that require writing the output files to disk. One, `browser-esbuild`, directly writes to the disk. The two experimental unit test builders also have unique requirements and also directly write. This leaves only the main `application` builder that relies on the internal file writing functionality of `buildApplicationInternal`. To avoid unneeded logic for the other usages (`dev-server`, `extract-i18n`, unit testing, etc.), the disk writing logic is now elevated to the `application` build itself. The internal function will now always provide the output files within the result objects generated from a successful build. This also removes the need for the other usages to specify that files should not be written to disk.