### PR TITLE
fix(@angular/build): lazy load Node.js inspector for dev server

### DIFF
--- a/packages/angular/build/src/builders/dev-server/vite-server.ts
+++ b/packages/angular/build/src/builders/dev-server/vite-server.ts
@@ -10,7 +10,6 @@ import type { BuilderContext } from '@angular-devkit/architect';
 import type { Plugin } from 'esbuild';
 import assert from 'node:assert';
 import { readFile } from 'node:fs/promises';
-import inspector from 'node:inspector';
 import { builtinModules } from 'node:module';
 import { join } from 'node:path';
 import type { Connect, DepOptimizationConfig, InlineConfig, ViteDevServer } from 'vite';
@@ -275,6 +274,7 @@ export async function* serveWithVite(
 
       if (browserOptions.ssr && serverOptions.inspect) {
         const { host, port } = serverOptions.inspect as { host?: string; port?: number };
+        const { default: inspector } = await import('node:inspector');
         inspector.open(port, host, true);
         context.addTeardown(() => inspector.close());
       }


### PR DESCRIPTION
The Node.js inspector will now only be imported if SSR is enabled and the `inspect` option is used. This prevents potential failures when a custom Node.js binary build is used that has not enabled inspector usage. While this is not common, loading the inspector on demand is a minimal change that also avoids loading code that will not be used for the majority of development server usage.

Closes #28172