### PR TITLE
Update next branch to reflect new release-train "v18.3.0-next.0".

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+<a name="18.2.0-rc.0"></a>
+
+# 18.2.0-rc.0 (2024-08-07)
+
+### @angular/build
+
+| Commit                                                                                              | Type | Description                                            |
+| --------------------------------------------------------------------------------------------------- | ---- | ------------------------------------------------------ |
+| [182ecbd18](https://github.com/angular/angular-cli/commit/182ecbd18817679b27441ffef2431f92910b592f) | fix  | allow explicitly disabling TypeScript incremental mode |
+| [34908a3fc](https://github.com/angular/angular-cli/commit/34908a3fcba304da6916b2113863751500268a8c) | fix  | lazy load Node.js inspector for dev server             |
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="18.1.4"></a>
 
 # 18.1.4 (2024-08-07)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@angular/devkit-repo",
-  "version": "18.2.0-next.3",
+  "version": "18.3.0-next.0",
   "private": true,
   "description": "Software Development Kit for Angular",
   "keywords": [


### PR DESCRIPTION
The previous "next" release-train has moved into the release-candidate phase. This PR updates the next branch to the subsequent release-train.

Also this PR cherry-picks the changelog for v18.2.0-rc.0 into the main branch so that the changelog is up to date.