### PR TITLE
feat(@angular-devkit/schematics-cli): add package manager option to blank schematic

### DIFF
--- a/packages/angular_devkit/schematics_cli/bin/schematics.ts
+++ b/packages/angular_devkit/schematics_cli/bin/schematics.ts
@@ -9,7 +9,7 @@
 
 // symbol polyfill must go first
 import 'symbol-observable';
-import type { JsonValue, logging, schema } from '@angular-devkit/core';
+import { JsonValue, logging, schema } from '@angular-devkit/core';
 import { ProcessOutput, createConsoleLogger } from '@angular-devkit/core/node';
 import { UnsuccessfulWorkflowExecution } from '@angular-devkit/schematics';
 import { NodeWorkflow } from '@angular-devkit/schematics/tools';
@@ -337,6 +337,8 @@ export async function main({
       error = false;
     }
   });
+
+  workflow.registry.addPostTransform(schema.transforms.addUndefinedDefaults);
 
   // Show usage of deprecated options
   workflow.registry.useXDeprecatedProvider((msg) => logger.warn(msg));

--- a/packages/angular_devkit/schematics_cli/blank/factory.ts
+++ b/packages/angular_devkit/schematics_cli/blank/factory.ts
@@ -90,7 +90,12 @@ export default function (options: Schema): Rule {
         move(options.name),
       ]);
 
-      context.addTask(new NodePackageInstallTask(options.name));
+      context.addTask(
+        new NodePackageInstallTask({
+          workingDirectory: options.name,
+          packageManager: options.packageManager,
+        }),
+      );
     }
 
     return chain([

--- a/packages/angular_devkit/schematics_cli/blank/schema.json
+++ b/packages/angular_devkit/schematics_cli/blank/schema.json
@@ -12,6 +12,12 @@
         "index": 0
       }
     },
+    "packageManager": {
+      "description": "The package manager used to install dependencies.",
+      "type": "string",
+      "enum": ["npm", "yarn", "pnpm", "cnpm", "bun"],
+      "default": "npm"
+    },
     "author": {
       "type": "string",
       "description": "Author for the new schematic."

--- a/packages/angular_devkit/schematics_cli/schematic/factory.ts
+++ b/packages/angular_devkit/schematics_cli/schematic/factory.ts
@@ -24,7 +24,12 @@ export default function (options: Schema): Rule {
   const coreVersion = require('@angular-devkit/core/package.json').version;
 
   return (_, context) => {
-    context.addTask(new NodePackageInstallTask(options.name));
+    context.addTask(
+      new NodePackageInstallTask({
+        workingDirectory: options.name,
+        packageManager: options.packageManager,
+      }),
+    );
 
     return mergeWith(
       apply(url('./files'), [

--- a/packages/angular_devkit/schematics_cli/schematic/schema.json
+++ b/packages/angular_devkit/schematics_cli/schematic/schema.json
@@ -11,6 +11,12 @@
     "author": {
       "type": "string",
       "description": "Author for the new schematic."
+    },
+    "packageManager": {
+      "description": "The package manager used to install dependencies.",
+      "type": "string",
+      "enum": ["npm", "yarn", "pnpm", "cnpm", "bun"],
+      "default": "npm"
     }
   },
   "required": ["name"]

--- a/tests/legacy-cli/e2e/tests/schematics_cli/basic.ts
+++ b/tests/legacy-cli/e2e/tests/schematics_cli/basic.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import { join } from 'node:path';
 import { getGlobalVariable } from '../../utils/env';
 import { exec, execAndWaitForOutputToMatch, silentNpm } from '../../utils/process';
 import { rimraf } from '../../utils/fs';
@@ -14,13 +14,13 @@ export default async function () {
   await exec(process.platform.startsWith('win') ? 'where' : 'which', 'schematics');
 
   const startCwd = process.cwd();
-  const schematicPath = path.join(startCwd, 'test-schematic');
+  const schematicPath = join(startCwd, 'test-schematic');
 
   try {
     // create blank schematic
     await exec('schematics', 'schematic', '--name', 'test-schematic');
 
-    process.chdir(path.join(startCwd, 'test-schematic'));
+    process.chdir(join(startCwd, 'test-schematic'));
     await execAndWaitForOutputToMatch(
       'schematics',
       ['.:', '--list-schematics'],
@@ -29,6 +29,9 @@ export default async function () {
   } finally {
     // restore path
     process.chdir(startCwd);
-    await rimraf(schematicPath);
+    await Promise.all([
+      rimraf(schematicPath),
+      silentNpm('uninstall', '-g', '@angular-devkit/schematics-cli'),
+    ]);
   }
 }

--- a/tests/legacy-cli/e2e/tests/schematics_cli/blank-test.ts
+++ b/tests/legacy-cli/e2e/tests/schematics_cli/blank-test.ts
@@ -1,5 +1,4 @@
-import * as fs from 'fs';
-import * as path from 'path';
+import { join } from 'node:path';
 import { getGlobalVariable } from '../../utils/env';
 import { exec, silentNpm } from '../../utils/process';
 import { rimraf } from '../../utils/fs';
@@ -15,7 +14,7 @@ export default async function () {
   await exec(process.platform.startsWith('win') ? 'where' : 'which', 'schematics');
 
   const startCwd = process.cwd();
-  const schematicPath = path.join(startCwd, 'test-schematic');
+  const schematicPath = join(startCwd, 'test-schematic');
 
   try {
     // create schematic
@@ -23,11 +22,13 @@ export default async function () {
 
     process.chdir(schematicPath);
 
-    await silentNpm('install');
     await silentNpm('test');
   } finally {
     // restore path
     process.chdir(startCwd);
-    await rimraf(schematicPath);
+    await Promise.all([
+      rimraf(schematicPath),
+      silentNpm('uninstall', '-g', '@angular-devkit/schematics-cli'),
+    ]);
   }
 }

--- a/tests/legacy-cli/e2e/tests/schematics_cli/schematic-test.ts
+++ b/tests/legacy-cli/e2e/tests/schematics_cli/schematic-test.ts
@@ -1,5 +1,4 @@
-import * as fs from 'fs';
-import * as path from 'path';
+import { join } from 'node:path';
 import { getGlobalVariable } from '../../utils/env';
 import { exec, silentNpm } from '../../utils/process';
 import { rimraf } from '../../utils/fs';
@@ -15,7 +14,7 @@ export default async function () {
   await exec(process.platform.startsWith('win') ? 'where' : 'which', 'schematics');
 
   const startCwd = process.cwd();
-  const schematicPath = path.join(startCwd, 'test-schematic');
+  const schematicPath = join(startCwd, 'test-schematic');
 
   try {
     // create schematic
@@ -23,11 +22,13 @@ export default async function () {
 
     process.chdir(schematicPath);
 
-    await silentNpm('install');
     await silentNpm('test');
   } finally {
     // restore path
     process.chdir(startCwd);
-    await rimraf(schematicPath);
+    await Promise.all([
+      rimraf(schematicPath),
+      silentNpm('uninstall', '-g', '@angular-devkit/schematics-cli'),
+    ]);
   }
 }


### PR DESCRIPTION
Allows users to specify the package manager (npm, yarn, etc.) when creating a new project using the `schematics blank` command. Resolves #27571.

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [ ] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the new behavior that. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
