### PR TITLE
fix(@angular/cli): prevent bypassing select/checkbox prompts on validation failure

### DIFF
--- a/packages/angular/cli/src/command-builder/schematics-command-module.ts
+++ b/packages/angular/cli/src/command-builder/schematics-command-module.ts
@@ -197,6 +197,13 @@ export abstract class SchematicsCommandModule
                 definition.multiselect ? prompts.checkbox : prompts.select
               )({
                 message: definition.message,
+                validate: (values) => {
+                  if (!definition.validator) {
+                    return true;
+                  }
+
+                  return definition.validator(Object.values(values).map(({ value }) => value));
+                },
                 default: definition.default,
                 choices: definition.items?.map((item) =>
                   typeof item == 'string'

--- a/packages/angular_devkit/schematics_cli/bin/schematics.ts
+++ b/packages/angular_devkit/schematics_cli/bin/schematics.ts
@@ -96,6 +96,13 @@ function _createPromptProvider(): schema.PromptProvider {
           )({
             message: definition.message,
             default: definition.default,
+            validate: (values) => {
+              if (!definition.validator) {
+                return true;
+              }
+
+              return definition.validator(Object.values(values).map(({ value }) => value));
+            },
             choices: definition.items.map((item) =>
               typeof item == 'string'
                 ? {


### PR DESCRIPTION

Previously, when a select or checkbox prompt failed validation, it was bypassed, preventing users from correcting their input. This commit ensures that when validation fails, the prompts are re-displayed, allowing users to make the necessary corrections. This improves the user experience and helps avoid unintended selections.

Closes #28189