### PR TITLE
refactor(@angular-devkit/build-angular): reduce custom code in browser-esbuild implementation

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/tests/options/assets_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/tests/options/assets_spec.ts
@@ -6,10 +6,10 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import { buildEsbuildBrowserArchitect } from '../../index';
+import { buildEsbuildBrowser } from '../../index';
 import { BASE_OPTIONS, BROWSER_BUILDER_INFO, describeBuilder } from '../setup';
 
-describeBuilder(buildEsbuildBrowserArchitect, BROWSER_BUILDER_INFO, (harness) => {
+describeBuilder(buildEsbuildBrowser, BROWSER_BUILDER_INFO, (harness) => {
   describe('Option: "assets"', () => {
     beforeEach(async () => {
       // Application code is not needed for asset tests

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/tests/options/delete-output-path_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/tests/options/delete-output-path_spec.ts
@@ -6,10 +6,10 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import { buildEsbuildBrowserArchitect } from '../../index';
+import { buildEsbuildBrowser } from '../../index';
 import { BASE_OPTIONS, BROWSER_BUILDER_INFO, describeBuilder } from '../setup';
 
-describeBuilder(buildEsbuildBrowserArchitect, BROWSER_BUILDER_INFO, (harness) => {
+describeBuilder(buildEsbuildBrowser, BROWSER_BUILDER_INFO, (harness) => {
   describe('Option: "deleteOutputPath"', () => {
     beforeEach(async () => {
       // Application code is not needed for asset tests

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/tests/options/deploy-url_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/tests/options/deploy-url_spec.ts
@@ -6,10 +6,10 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import { buildEsbuildBrowserArchitect } from '../../index';
+import { buildEsbuildBrowser } from '../../index';
 import { BASE_OPTIONS, BROWSER_BUILDER_INFO, describeBuilder } from '../setup';
 
-describeBuilder(buildEsbuildBrowserArchitect, BROWSER_BUILDER_INFO, (harness) => {
+describeBuilder(buildEsbuildBrowser, BROWSER_BUILDER_INFO, (harness) => {
   describe('Option: "deployUrl"', () => {
     beforeEach(async () => {
       // Add a global stylesheet to test link elements

--- a/packages/angular_devkit/build_angular/src/builders/browser-esbuild/tests/options/main_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/browser-esbuild/tests/options/main_spec.ts
@@ -6,10 +6,10 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import { buildEsbuildBrowserArchitect } from '../../index';
+import { buildEsbuildBrowser } from '../../index';
 import { BASE_OPTIONS, BROWSER_BUILDER_INFO, describeBuilder } from '../setup';
 
-describeBuilder(buildEsbuildBrowserArchitect, BROWSER_BUILDER_INFO, (harness) => {
+describeBuilder(buildEsbuildBrowser, BROWSER_BUILDER_INFO, (harness) => {
   describe('Option: "main"', () => {
     it('uses a provided TypeScript file', async () => {
       harness.useTarget('build', {

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/builder.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/builder.ts
@@ -88,14 +88,16 @@ export function execute(
         return defer(() =>
           Promise.all([import('@angular/build/private'), import('../browser-esbuild')]),
         ).pipe(
-          switchMap(([{ serveWithVite, buildApplicationInternal }, { buildEsbuildBrowser }]) =>
+          switchMap(([{ serveWithVite, buildApplicationInternal }, { convertBrowserOptions }]) =>
             serveWithVite(
               normalizedOptions,
               builderName,
               (options, context, codePlugins) => {
                 return builderName === '@angular-devkit/build-angular:browser-esbuild'
                   ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                    buildEsbuildBrowser(options as any, context, { write: false }, codePlugins)
+                    buildApplicationInternal(convertBrowserOptions(options as any), context, {
+                      codePlugins,
+                    })
                   : buildApplicationInternal(options, context, { codePlugins });
               },
               context,


### PR DESCRIPTION
The implementation of the `browser-esbuild` builder is now a small wrapper around the `application` builder. The custom file writing code is no longer required with the availability of the additional output path options for `application` builder. This also allows the internal `browser-esbuild` programmatic interface to retain its architect-based signature.