### PR TITLE
build: add missing `pkg_deps` for `@angular/create`

### DIFF
--- a/packages/angular/create/BUILD.bazel
+++ b/packages/angular/create/BUILD.bazel
@@ -26,6 +26,9 @@ genrule(
 
 pkg_npm(
     name = "npm_package",
+    pkg_deps = [
+        "//packages/angular/cli:package.json",
+    ],
     tags = ["release-package"],
     visibility = ["//visibility:public"],
     deps = [


### PR DESCRIPTION
Included missing `@angular/cli` in `pkg_deps`.
