### PR TITLE
fix(@angular/build): improve error message when an unhandled exception occurs during prerendering

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/server/tests/behavior/build-errors_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/server/tests/behavior/build-errors_spec.ts
@@ -15,13 +15,14 @@ describeBuilder(execute, SERVER_BUILDER_INFO, (harness) => {
     it('emits errors', async () => {
       harness.useTarget('server', {
         ...BASE_OPTIONS,
-        watch: true,
       });
 
       // Generate an error
       await harness.appendToFile('src/main.server.ts', `const foo: = 'abc';`);
 
-      const { result, logs } = await harness.executeOnce();
+      const { result, logs } = await harness.executeOnce({
+        outputLogsOnFailure: false,
+      });
 
       expect(result?.success).toBeFalse();
       expect(logs).toContain(


### PR DESCRIPTION


This change enhances the error messaging when an unhandled exception occurs during the prerendering process. The updated error message provides more context and clarity.

**Previous Behavior**

```
ng b
An unhandled exception occurred: Some error!!!
See "/tmp/ng-S2ABKF/angular-errors.log" for further details.
```

**Updated Behavior:**
```
ng b
Browser bundles
Initial chunk files     | Names               |  Raw size | Estimated transfer size
main-AFPIPGGK.js        | main                | 218.00 kB |                59.48 kB
polyfills-Z2GOM3BN.js   | polyfills           |  35.82 kB |                11.80 kB
styles-5INURTSO.css     | styles              |   0 bytes |                 0 bytes

                        | Initial total       | 253.82 kB |                71.28 kB

Server bundles
Initial chunk files     | Names               |  Raw size
server.mjs              | server              |   1.11 MB |
chunk-HZL5H5M5.mjs      | -                   | 526.77 kB |
polyfills.server.mjs    | polyfills.server    | 269.91 kB |
chunk-GFWAPST7.mjs      | -                   |  19.16 kB |
chunk-5XUXGTUW.mjs      | -                   |   2.55 kB |
render-utils.server.mjs | render-utils.server |   1.46 kB |
main.server.mjs         | main.server         | 149 bytes |

Lazy chunk files        | Names               |  Raw size
chunk-7YC4RJ5P.mjs      | xhr2                |  12.08 kB |

Prerendered 1 static route.
Application bundle generation failed. [4.923 seconds]

✘ [ERROR] An error occurred while prerendering route '/'.

Error: Some error!!!
    at render (node_modules/@angular/build/src/utils/server-rendering/render-worker.js:20:20)
    at /angular-cli/abc/node_modules/piscina/dist/worker.js:146:32
```

Closes #28212
