### PR TITLE
build: downgrade sass version

### DIFF
--- a/package.json
+++ b/package.json
@@ -184,7 +184,7 @@
     "rollup": "4.20.0",
     "rollup-plugin-sourcemaps": "^0.6.0",
     "rxjs": "7.8.1",
-    "sass": "1.77.8",
+    "sass": "1.77.6",
     "sass-loader": "16.0.0",
     "semver": "7.6.3",
     "shelljs": "^0.8.5",

--- a/packages/angular/build/package.json
+++ b/packages/angular/build/package.json
@@ -39,7 +39,7 @@
     "picomatch": "4.0.2",
     "piscina": "4.6.1",
     "rollup": "4.20.0",
-    "sass": "1.77.8",
+    "sass": "1.77.6",
     "semver": "7.6.3",
     "vite": "5.4.0",
     "watchpack": "2.4.1"

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -53,7 +53,7 @@
     "postcss-loader": "8.1.1",
     "resolve-url-loader": "5.0.0",
     "rxjs": "7.8.1",
-    "sass": "1.77.8",
+    "sass": "1.77.6",
     "sass-loader": "16.0.0",
     "semver": "7.6.3",
     "source-map-loader": "5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -107,7 +107,7 @@ __metadata:
     postcss-loader: "npm:8.1.1"
     resolve-url-loader: "npm:5.0.0"
     rxjs: "npm:7.8.1"
-    sass: "npm:1.77.8"
+    sass: "npm:1.77.6"
     sass-loader: "npm:16.0.0"
     semver: "npm:7.6.3"
     source-map-loader: "npm:5.0.0"
@@ -399,7 +399,7 @@ __metadata:
     picomatch: "npm:4.0.2"
     piscina: "npm:4.6.1"
     rollup: "npm:4.20.0"
-    sass: "npm:1.77.8"
+    sass: "npm:1.77.6"
     semver: "npm:7.6.3"
     vite: "npm:5.4.0"
     watchpack: "npm:2.4.1"
@@ -788,7 +788,7 @@ __metadata:
     rollup: "npm:4.20.0"
     rollup-plugin-sourcemaps: "npm:^0.6.0"
     rxjs: "npm:7.8.1"
-    sass: "npm:1.77.8"
+    sass: "npm:1.77.6"
     sass-loader: "npm:16.0.0"
     semver: "npm:7.6.3"
     shelljs: "npm:^0.8.5"
@@ -15513,6 +15513,19 @@ __metadata:
     webpack:
       optional: true
   checksum: 10c0/0d2c2ee89a380ae19f1d024008c241afb747c254cf8e2163b281533c803a1cb3933236f0cfbb59a296fce864e4274e32a80c30dadd5b98618a362f0be8bac20f
+  languageName: node
+  linkType: hard
+
+"sass@npm:1.77.6":
+  version: 1.77.6
+  resolution: "sass@npm:1.77.6"
+  dependencies:
+    chokidar: "npm:>=3.0.0 <4.0.0"
+    immutable: "npm:^4.0.0"
+    source-map-js: "npm:>=0.6.2 <2.0.0"
+  bin:
+    sass: sass.js
+  checksum: 10c0/fe5a393c0aa29eda9f83c06be9b94788b61fe8bad0616ee6e3a25d21ab504f430d40c0064fdca89b02b8e426411ae6dcd906c91f2e48c263575c3d392b6daeb1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
In 18.2 the Sass version was updated to 1.77.7 which causes a lot of deprecation warnings for Material users (see https://github.com/angular/components/issues/29591). Resolving these warnings can break some apps so we want to delay it until v19.

These changes downgrade to a version that doesn't check for the deprecation.