### PR TITLE
fix(@angular/build): support reading on-disk files during i18n extraction

### DIFF
--- a/packages/angular/build/src/builders/extract-i18n/application-extraction.ts
+++ b/packages/angular/build/src/builders/extract-i18n/application-extraction.ts
@@ -9,6 +9,7 @@
 import type { ɵParsedMessage as LocalizeMessage } from '@angular/localize';
 import type { MessageExtractor } from '@angular/localize/tools';
 import type { BuilderContext } from '@angular-devkit/architect';
+import { readFileSync } from 'node:fs';
 import nodePath from 'node:path';
 import { buildApplicationInternal } from '../application';
 import type {
@@ -101,6 +102,8 @@ function setupLocalizeExtractor(
       let content;
       if (file?.origin === 'memory') {
         content = textDecoder.decode(file.contents);
+      } else if (file?.origin === 'disk') {
+        content = readFileSync(file.inputPath, 'utf-8');
       }
       if (content === undefined) {
         throw new Error('Unknown file requested: ' + requestedPath);

--- a/packages/angular_devkit/build_angular/src/builders/extract-i18n/application-extraction.ts
+++ b/packages/angular_devkit/build_angular/src/builders/extract-i18n/application-extraction.ts
@@ -11,6 +11,7 @@ import { ResultFile, ResultKind, buildApplicationInternal } from '@angular/build
 import type { ɵParsedMessage as LocalizeMessage } from '@angular/localize';
 import type { MessageExtractor } from '@angular/localize/tools';
 import type { BuilderContext } from '@angular-devkit/architect';
+import { readFileSync } from 'node:fs';
 import nodePath from 'node:path';
 import { BrowserBuilderOptions, convertBrowserOptions } from '../browser-esbuild';
 import type { NormalizedExtractI18nOptions } from './options';
@@ -106,6 +107,8 @@ function setupLocalizeExtractor(
       let content;
       if (file?.origin === 'memory') {
         content = textDecoder.decode(file.contents);
+      } else if (file?.origin === 'disk') {
+        content = readFileSync(file.inputPath, 'utf-8');
       }
       if (content === undefined) {
         throw new Error('Unknown file requested: ' + requestedPath);


### PR DESCRIPTION
If an application has JavaScript files that are sourced directly from disk, the extraction would previously fail due to the i18n extractor only able to access the in-memory generated JavaScript files. The extractor can now access both memory and disk-based JavaScript files.