### PR TITLE
Revert "build: change to local repo's build system(path to npm_package_archive.tgz files)"

### DIFF
--- a/tools/link_package_json_to_tarballs.bzl
+++ b/tools/link_package_json_to_tarballs.bzl
@@ -53,7 +53,7 @@ def link_package_json_to_tarballs(name, src, pkg_deps, out):
             name = "%s_%s_filter" % (name, i),
             srcs = srcs,
             cmd = """
-                TAR=$$({abs_path_sandbox} || {abs_path_nosandbox})/npm_package_archive.tgz
+                TAR=$$(dirname $$({abs_path_sandbox} || {abs_path_nosandbox}))/npm_package_archive.tgz
                 PKGNAME=$$(cat $(execpath {pkg_name}))
                 if [[ "$$TAR" != *bazel-out* ]]; then
                     echo "ERROR: package.json passed to substitute_tar_deps must be in the output tree. You can use copy_to_bin to copy a source file to the output tree."


### PR DESCRIPTION
This reverts commit eedeee2f4fc4f0cd3124611aa733d320847f5bd3.

Causes snapshot publishing failures: https://github.com/angular/angular-cli/actions/runs/10471282117/job/29006137399