### PR TITLE
refactor(@angular/build): template style elements should always be CSS

### DIFF
--- a/packages/angular/build/src/tools/esbuild/angular/compiler-plugin.ts
+++ b/packages/angular/build/src/tools/esbuild/angular/compiler-plugin.ts
@@ -185,7 +185,8 @@ export function createCompilerPlugin(
               stylesheetResult = await stylesheetBundler.bundleInline(
                 data,
                 containingFile,
-                styleOptions.inlineStyleLanguage,
+                // Inline stylesheets from a template style element are always CSS
+                containingFile.endsWith('.html') ? 'css' : styleOptions.inlineStyleLanguage,
               );
             }
 


### PR DESCRIPTION
Now that style elements within templates are processed as inline component styles, the style contents should only be considered CSS. This ensures consistent behavior prior to when style elements were processed. It also ensures that the styles will function as expected in JIT mode where template styles cannot be preprocessed and must be written in a browser supported language.