### PR TITLE
fix(@schematics/angular): remove `declaration` and `sourceMap` from default tsconfig

### DIFF
--- a/packages/schematics/angular/workspace/files/tsconfig.json.template
+++ b/packages/schematics/angular/workspace/files/tsconfig.json.template
@@ -12,8 +12,6 @@
     "skipLibCheck": true,
     "isolatedModules": true,
     "esModuleInterop": true,
-    "sourceMap": true,
-    "declaration": false,
     "experimentalDecorators": true,
     "moduleResolution": "bundler",
     "importHelpers": true,


### PR DESCRIPTION
The `declaration` TypeScript option has been removed from the default generated `tsconfig` for new projects. This option was explicitly set to `false`. However, the default value for the option is already `false`. Also, the `sourceMap` option has been removed. Source map generation is controlled by the build options and not the TypeScript configuration.