### PR TITLE
refactor(@angular-devkit/core): remove deprecated `fileBuffer` function in favor of `stringToFileBuffer`

### DIFF
--- a/goldens/public-api/angular_devkit/core/index.api.md
+++ b/goldens/public-api/angular_devkit/core/index.api.md
@@ -237,9 +237,6 @@ export class FileAlreadyExistException extends BaseException {
 // @public (undocumented)
 type FileBuffer = ArrayBuffer;
 
-// @public @deprecated (undocumented)
-const fileBuffer: TemplateTag<FileBuffer>;
-
 // @public (undocumented)
 type FileBufferLike = ArrayBufferLike;
 
@@ -1324,7 +1321,6 @@ declare namespace virtualFs {
         AliasHost,
         stringToFileBuffer,
         fileBufferToString,
-        fileBuffer,
         createSyncHost,
         SyncHostHandler,
         Empty,

--- a/packages/angular_devkit/core/src/virtual-fs/host/buffer.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/host/buffer.ts
@@ -7,7 +7,6 @@
  */
 
 import { TextDecoder, TextEncoder } from 'node:util';
-import { TemplateTag } from '../../utils/literals';
 import { FileBuffer } from './interface';
 
 export function stringToFileBuffer(str: string): FileBuffer {
@@ -21,8 +20,3 @@ export function fileBufferToString(fileBuffer: FileBuffer): string {
 
   return new TextDecoder('utf-8').decode(new Uint8Array(fileBuffer));
 }
-
-/** @deprecated use `stringToFileBuffer` instead. */
-export const fileBuffer: TemplateTag<FileBuffer> = (strings, ...values) => {
-  return stringToFileBuffer(String.raw(strings, ...values));
-};


### PR DESCRIPTION

BREAKING CHANGE: The deprecated `fileBuffer` function is no longer available. Update your code to use `stringToFileBuffer` instead to maintain compatibility.

**Note:** that this change does not affect application developers.
