### PR TITLE
refactor(@angular/ssr): remove duplicate `resetAngularServerApp` method

### DIFF
--- a/packages/angular/ssr/src/app.ts
+++ b/packages/angular/ssr/src/app.ts
@@ -90,14 +90,6 @@ export function getOrCreateAngularServerApp(): AngularServerApp {
 }
 
 /**
- * Resets the instance of `AngularServerApp` to undefined, effectively
- * clearing the reference. Use this to recreate the instance.
- */
-export function resetAngularServerApp(): void {
-  angularServerApp = undefined;
-}
-
-/**
  * Destroys the existing `AngularServerApp` instance, releasing associated resources and resetting the
  * reference to `undefined`.
  *


### PR DESCRIPTION
The `resetAngularServerApp` method was identical to `destroyAngularServerApp` and was mistakenly retained due to an incorrect merge. This commit removes the redundant method.
