### PR TITLE
build: mark server tests as flaky

### DIFF
--- a/packages/angular_devkit/build_angular/BUILD.bazel
+++ b/packages/angular_devkit/build_angular/BUILD.bazel
@@ -343,6 +343,7 @@ LARGE_SPECS = {
         "shards": 1,
     },
     "server": {
+        "flaky": True,
         "extra_deps": [
             "@npm//@angular/animations",
         ],


### PR DESCRIPTION
These server tests frequently fail due to timeouts. Despite efforts, the root cause has not yet been identified, so they are being marked as flaky to prevent blocking the pipeline while further investigation continues.
