### PR TITLE
refactor(@schematics/angular): increase new application anyComponentSyle budget thresholds

### DIFF
--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -204,8 +204,8 @@ function addAppToWorkspaceFile(
       },
       {
         type: 'anyComponentStyle',
-        maximumWarning: '2kB',
-        maximumError: '4kB',
+        maximumWarning: '4kB',
+        maximumError: '8kB',
       },
     ];
   } else {


### PR DESCRIPTION
The 2kB/4kB warning/error thresholds for any component style within an application has now been increased to 4kB/8kB for warnings/errors respectively. This allows for more complex styles within a component while also reducing the likelihood of the budget rule being disabled or removed. The new limits still provide diagnostics for extreme size cases such as accidentally importing all Bootstrap or Material styles into an individual component. Such instances are a primary use case for the budget.