### PR TITLE
Use compiler CLI private tooling export

### DIFF
--- a/packages/angular/build/src/tools/angular/compilation/jit-compilation.ts
+++ b/packages/angular/build/src/tools/angular/compilation/jit-compilation.ts
@@ -9,6 +9,7 @@
 import type ng from '@angular/compiler-cli';
 import assert from 'node:assert';
 import ts from 'typescript';
+import { loadEsmModule } from '../../../utils/load-esm';
 import { profileSync } from '../../esbuild/profiling';
 import { AngularHostOptions, createAngularCompilerHost } from '../angular-host';
 import { createJitResourceTransformer } from '../transformers/jit-resource-transformer';
@@ -38,7 +39,9 @@ export class JitCompilation extends AngularCompilation {
     referencedFiles: readonly string[];
   }> {
     // Dynamically load the Angular compiler CLI package
-    const { constructorParametersDownlevelTransform } = await AngularCompilation.loadCompilerCli();
+    const { constructorParametersDownlevelTransform } = await loadEsmModule<
+      typeof import('@angular/compiler-cli/private/tooling')
+    >('@angular/compiler-cli/private/tooling');
 
     // Load the compiler configuration and transform as needed
     const {

--- a/packages/angular_devkit/build_angular/src/tools/webpack/configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/configs/common.ts
@@ -83,11 +83,11 @@ export async function getCommonConfig(wco: WebpackConfigOptions): Promise<Config
   // Load ESM `@angular/compiler-cli` using the TypeScript dynamic import workaround.
   // Once TypeScript provides support for keeping the dynamic import this workaround can be
   // changed to a direct dynamic import.
-  const {
-    GLOBAL_DEFS_FOR_TERSER,
-    GLOBAL_DEFS_FOR_TERSER_WITH_AOT,
-    VERSION: NG_VERSION,
-  } = await loadEsmModule<typeof import('@angular/compiler-cli')>('@angular/compiler-cli');
+  const { VERSION: NG_VERSION } =
+    await loadEsmModule<typeof import('@angular/compiler-cli')>('@angular/compiler-cli');
+  const { GLOBAL_DEFS_FOR_TERSER, GLOBAL_DEFS_FOR_TERSER_WITH_AOT } = await loadEsmModule<
+    typeof import('@angular/compiler-cli/private/tooling')
+  >('@angular/compiler-cli/private/tooling');
 
   // determine hashing format
   const hashFormat = getOutputHashFormat(buildOptions.outputHashing);

--- a/packages/ngtools/webpack/src/ivy/plugin.ts
+++ b/packages/ngtools/webpack/src/ivy/plugin.ts
@@ -74,6 +74,7 @@ interface FileEmitHistoryItem {
 export class AngularWebpackPlugin {
   private readonly pluginOptions: AngularWebpackPluginOptions;
   private compilerCliModule?: typeof import('@angular/compiler-cli');
+  private compilerCliToolingModule?: typeof import('@angular/compiler-cli/private/tooling');
   private watchMode?: boolean;
   private ngtscNextProgram?: NgtscProgram;
   private builder?: ts.EmitAndSemanticDiagnosticsBuilderProgram;
@@ -105,6 +106,18 @@ export class AngularWebpackPlugin {
     assert.ok(this.compilerCliModule, `'@angular/compiler-cli' used prior to Webpack compilation.`);
 
     return this.compilerCliModule;
+  }
+
+  private get compilerCliTooling(): typeof import('@angular/compiler-cli/private/tooling') {
+    // The compilerCliToolingModule field is guaranteed to be defined during a compilation
+    // due to the `beforeCompile` hook. Usage of this property accessor prior to the
+    // hook execution is an implementation error.
+    assert.ok(
+      this.compilerCliToolingModule,
+      `'@angular/compiler-cli' used prior to Webpack compilation.`,
+    );
+
+    return this.compilerCliToolingModule;
   }
 
   get options(): AngularWebpackPluginOptions {
@@ -688,10 +701,6 @@ export class AngularWebpackPlugin {
   }
 
   private async initializeCompilerCli(): Promise<void> {
-    if (this.compilerCliModule) {
-      return;
-    }
-
     // This uses a dynamic import to load `@angular/compiler-cli` which may be ESM.
     // CommonJS code can load ESM code via a dynamic import. Unfortunately, TypeScript
     // will currently, unconditionally downlevel dynamic import into a require call.
@@ -699,7 +708,10 @@ export class AngularWebpackPlugin {
     // this, a Function constructor is used to prevent TypeScript from changing the dynamic import.
     // Once TypeScript provides support for keeping the dynamic import this workaround can
     // be dropped.
-    this.compilerCliModule = await new Function(`return import('@angular/compiler-cli');`)();
+    this.compilerCliModule ??= await new Function(`return import('@angular/compiler-cli');`)();
+    this.compilerCliToolingModule ??= await new Function(
+      `return import('@angular/compiler-cli/private/tooling');`,
+    )();
   }
 
   private async addFileEmitHistory(

--- a/packages/ngtools/webpack/src/ivy/transformation.ts
+++ b/packages/ngtools/webpack/src/ivy/transformation.ts
@@ -47,7 +47,7 @@ export function createAotTransformers(
 
 export function createJitTransformers(
   builder: ts.BuilderProgram,
-  compilerCli: typeof import('@angular/compiler-cli'),
+  compilerCli: typeof import('@angular/compiler-cli/private/tooling'),
   options: {
     inlineStyleFileExtension?: string;
   },


### PR DESCRIPTION
The `@angular/compiler-cli/private/tooling` package export is now used instead
of the main package export to allow cleanup of the compiler-cli package. This
secondary export has existed for several major versions.