### PR TITLE
build: clean up redundant `exclude` field from `tsconfig-build.json`

### DIFF
--- a/tsconfig-build.json
+++ b/tsconfig-build.json
@@ -2,26 +2,5 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "types": ["node"]
-  },
-  "exclude": [
-    "packages/angular_devkit/build_angular/src/bazel-babel.d.ts",
-    "bazel-out/**/*",
-    "dist/**/*",
-    "dist-schema/**",
-    "goldens/**/*",
-    "**/node_modules/**/*",
-    "**/third_party/**/*",
-    "packages/angular_devkit/schematics_cli/blank/*-files/**/*",
-    "packages/angular_devkit/schematics_cli/schematic/files/**/*",
-    "packages/angular_devkit/build_angular/src/*/tests/**/*",
-    "packages/angular_devkit/build_angular/src/builders/*/tests/**/*",
-    "packages/angular_devkit/build_angular/src/testing/**/*",
-    "packages/angular_devkit/*/test/**/*",
-    "packages/schematics/*/*/*files/**/*",
-    "tests/**/*",
-    "tools/**/*",
-    ".ng-dev/**/*",
-    "**/*_spec.ts",
-    "scripts/**/*.mts"
-  ]
+  }
 }


### PR DESCRIPTION
The exclude field has been removed from `tsconfig-build.json` as it is redundant. This configuration is used by Bazel, which already specifies the input files explicitly, making the exclude field unnecessary. This change simplifies the configuration without impacting the build process.