### PR TITLE
feat(@schematics/angular): add option to export component as default

### DIFF
--- a/packages/schematics/angular/component/files/__name@dasherize@if-flat__/__name@dasherize__.__type@dasherize__.ts.template
+++ b/packages/schematics/angular/component/files/__name@dasherize@if-flat__/__name@dasherize__.__type@dasherize__.ts.template
@@ -19,6 +19,6 @@ import { <% if(changeDetection !== 'Default') { %>ChangeDetectionStrategy, <% }%
   encapsulation: ViewEncapsulation.<%= viewEncapsulation %><% } if (changeDetection !== 'Default') { %>,
   changeDetection: ChangeDetectionStrategy.<%= changeDetection %><% } %>
 })
-export class <%= classify(name) %><%= classify(type) %> {
+export <% if(exportDefault) {%>default <%}%>class <%= classify(name) %><%= classify(type) %> {
 
 }

--- a/packages/schematics/angular/component/index_spec.ts
+++ b/packages/schematics/angular/component/index_spec.ts
@@ -496,4 +496,20 @@ describe('Component Schematic', () => {
       await expectAsync(schematicRunner.runSchematic('component', options, appTree)).toBeRejected();
     });
   });
+
+  it('should export the component as default when exportDefault is true', async () => {
+    const options = { ...defaultOptions, exportDefault: true };
+
+    const tree = await schematicRunner.runSchematic('component', options, appTree);
+    const tsContent = tree.readContent('/projects/bar/src/app/foo/foo.component.ts');
+    expect(tsContent).toContain('export default class FooComponent');
+  });
+
+  it('should export the component as a named export when exportDefault is false', async () => {
+    const options = { ...defaultOptions, exportDefault: false };
+
+    const tree = await schematicRunner.runSchematic('component', options, appTree);
+    const tsContent = tree.readContent('/projects/bar/src/app/foo/foo.component.ts');
+    expect(tsContent).toContain('export class FooComponent');
+  });
 });

--- a/packages/schematics/angular/component/schema.json
+++ b/packages/schematics/angular/component/schema.json
@@ -130,6 +130,11 @@
       "type": "boolean",
       "default": false,
       "description": "The declaring NgModule exports this component."
+    },
+    "exportDefault": {
+      "type": "boolean",
+      "default": false,
+      "description": "Use default export for the component instead of a named export."
     }
   },
   "required": ["name", "project"]


### PR DESCRIPTION
added option for export class in default mode

Closes #25023

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [X] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #25023

## What is the new behavior?

added option for export class in default mode. Example `ng g c foo --export-default=true`. This option will generate a component with default keyword: ... export default class ...

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No