### PR TITLE
test: disable `buildOptimizer` for server tests

### DIFF
--- a/packages/angular_devkit/build_angular/BUILD.bazel
+++ b/packages/angular_devkit/build_angular/BUILD.bazel
@@ -343,7 +343,6 @@ LARGE_SPECS = {
         "shards": 1,
     },
     "server": {
-        "flaky": True,
         "extra_deps": [
             "@npm//@angular/animations",
         ],

--- a/packages/angular_devkit/build_angular/src/builders/server/tests/setup.ts
+++ b/packages/angular_devkit/build_angular/src/builders/server/tests/setup.ts
@@ -28,4 +28,5 @@ export const BASE_OPTIONS = Object.freeze<Schema>({
 
   // Disable optimizations
   optimization: false,
+  buildOptimizer: false,
 });


### PR DESCRIPTION
Attempting to reduce flaky tests.

