### PR TITLE
refactor(@schematics/angular): move `@angular/ssr` dependency to server schematic

### DIFF
--- a/packages/schematics/angular/server/index.ts
+++ b/packages/schematics/angular/server/index.ts
@@ -141,6 +141,10 @@ function addDependencies(skipInstall: boolean | undefined): Rule {
     const install = skipInstall ? InstallBehavior.None : InstallBehavior.Auto;
 
     return chain([
+      addDependency('@angular/ssr', latestVersions.AngularSSR, {
+        type: DependencyType.Default,
+        install,
+      }),
       addDependency('@angular/platform-server', coreDep.version, {
         type: DependencyType.Default,
         install,
@@ -154,7 +158,7 @@ function addDependencies(skipInstall: boolean | undefined): Rule {
 }
 
 export default function (options: ServerOptions): Rule {
-  return async (host: Tree, context: SchematicContext) => {
+  return async (host: Tree) => {
     const workspace = await getWorkspace(host);
     const clientProject = workspace.projects.get(options.project);
     if (clientProject?.extensions.projectType !== 'application') {

--- a/packages/schematics/angular/ssr/index.ts
+++ b/packages/schematics/angular/ssr/index.ts
@@ -298,10 +298,6 @@ function addDependencies({ skipInstall }: SSROptions, isUsingApplicationBuilder:
   const install = skipInstall ? InstallBehavior.None : InstallBehavior.Auto;
 
   const rules: Rule[] = [
-    addDependency('@angular/ssr', latestVersions.AngularSSR, {
-      type: DependencyType.Default,
-      install,
-    }),
     addDependency('express', latestVersions['express'], {
       type: DependencyType.Default,
       install,


### PR DESCRIPTION

This change is necessary as the `@angular/ssr` package is now required for all types of server-side rendering, including SSG and app-shell.

Context: https://github.com/angular/angular-cli/pull/28283