### PR TITLE
build: prevent rollup from bundling `@angular/ssr` in `@angular/ssr/node`

### DIFF
--- a/packages/angular/ssr/BUILD.bazel
+++ b/packages/angular/ssr/BUILD.bazel
@@ -37,7 +37,6 @@ ng_package(
     externals = [
         "@angular/ssr",
         "@angular/ssr/node",
-        "express",
         "../../third_party/critters",
     ],
     nested_packages = [

--- a/packages/angular/ssr/BUILD.bazel
+++ b/packages/angular/ssr/BUILD.bazel
@@ -35,7 +35,8 @@ ng_package(
         "//packages/angular/ssr/third_party/critters:bundled_critters_lib",
     ],
     externals = [
-        "tslib",
+        "@angular/ssr",
+        "@angular/ssr/node",
         "express",
         "../../third_party/critters",
     ],


### PR DESCRIPTION
This update addresses an issue on Windows where rollup attempts to bundle the `@angular/ssr`as part of the `@angular/ssr/node` FESM. Additionally, `tslib` is removed from externals as it is already configured internally within `ng_package`. See: https://github.com/angular/angular/blob/76b9e2b836d050e9196253ae56d45a65466d9f57/packages/bazel/src/ng_package/ng_package.bzl#L106