### PR TITLE
 build: minimize fakes in Windows for critters bundling

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -143,7 +143,7 @@ build:remote --host_platform=@npm//@angular/build-tooling/bazel/remote-execution
 build:remote --platforms=@npm//@angular/build-tooling/bazel/remote-execution:platform_with_network
 
 # Set remote caching settings
-build:remote --remote_accept_cached=true
+build:remote --remote_accept_cached=false
 
 # Force remote executions to consider the entire run as linux.
 # This is required for OSX cross-platform RBE.

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -104,7 +104,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [windows-latest]
         node: [22]
         subset: [npm, esbuild]
         shard: [0, 1, 2, 3, 4, 5]

--- a/packages/angular/ssr/third_party/critters/BUILD.bazel
+++ b/packages/angular/ssr/third_party/critters/BUILD.bazel
@@ -6,7 +6,11 @@ package(default_visibility = ["//visibility:public"])
 esbuild(
     name = "bundled_critters",
     config = ":esbuild_config",
-    entry_point = "@npm//:node_modules/critters/dist/critters.mjs",
+    # We should be able to use "@npm//:node_modules/critters/dist/critters.mjs" as entry_point and avoid having to create a file.
+    # But this causes a lot of flakes on Windows due to the linker.
+    # [link_node_modules.js] An error has been reported: [Error: ENOENT: no such file or directory,
+    # unlink 'C:\users\runneradmin\_bazel_runneradmin\whf6gbwo\execroot\angular_cli\node_modules']
+    entry_point = ":index.mjs",
     metafile = True,
     splitting = True,
     deps = [

--- a/packages/angular/ssr/third_party/critters/index.mjs
+++ b/packages/angular/ssr/third_party/critters/index.mjs
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export { default } from 'critters';


### PR DESCRIPTION

    
This commit addresses linker limitations on Windows, which are susceptible to race conditions when targets are built concurrently.

Example CI run: https://github.com/angular/angular-cli/actions/runs/10602179601/job/29383657763?pr=28302