### PR TITLE
refactor(@schematics/angular): remove explicit TypeScript lib option for new projects

### DIFF
--- a/packages/schematics/angular/workspace/files/tsconfig.json.template
+++ b/packages/schematics/angular/workspace/files/tsconfig.json.template
@@ -16,11 +16,7 @@
     "moduleResolution": "bundler",
     "importHelpers": true,
     "target": "ES2022",
-    "module": "ES2022",
-    "lib": [
-      "ES2022",
-      "dom"
-    ]
+    "module": "ES2022"
   },
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false<% if (strict) { %>,


### PR DESCRIPTION
Newly generated projects will now no longer have an explicit `lib` option defined within the TypeScript configuration for the workspace (`tsconfig.json`). This option will default to the `target` option value plus `DOM`. This combination is the same as the explicit value set in a new project. Removing the explicit option value will result in equivalent behavior without the need to duplicate the ES version in two places.