### PR TITLE
fix(@angular-devkit/build-angular): clear context in Karma by default for single run executions

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/karma/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/index.ts
@@ -99,6 +99,12 @@ export function execute(
 
       karmaOptions.singleRun = singleRun;
 
+      // Workaround https://github.com/angular/angular-cli/issues/28271, by clearing context by default
+      // for single run executions. Not clearing context for multi-run (watched) builds allows the
+      // Jasmine Spec Runner to be visible in the browser after test execution.
+      karmaOptions.client ??= {};
+      karmaOptions.client.clearContext ??= singleRun ?? false; // `singleRun` defaults to `false` per Karma docs.
+
       // Convert browsers from a string to an array
       if (options.browsers) {
         karmaOptions.browsers = options.browsers.split(',');
@@ -207,9 +213,6 @@ function getBuiltInKarmaConfig(
       'karma-coverage',
       '@angular-devkit/build-angular/plugins/karma',
     ].map((p) => workspaceRootRequire(p)),
-    client: {
-      clearContext: false, // leave Jasmine Spec Runner output visible in browser
-    },
     jasmineHtmlReporter: {
       suppressAll: true, // removes the duplicated traces
     },

--- a/packages/schematics/angular/config/files/karma.conf.js.template
+++ b/packages/schematics/angular/config/files/karma.conf.js.template
@@ -19,7 +19,6 @@ module.exports = function (config) {
         // for example, you can disable the random execution with `random: false`
         // or set a specific seed with `seed: 4321`
       },
-      clearContext: false // leave Jasmine Spec Runner output visible in browser
     },
     jasmineHtmlReporter: {
       suppressAll: true // removes the duplicated traces


### PR DESCRIPTION
This works around https://github.com/angular/angular-cli/issues/28271.

(cherry picked from commit 3ee21631f481b2e72be2390b5a2cac74824efbb5)

This is an LTS patch of #28315 to v16.