### PR TITLE
feat(ssr): expose `writeResponseToNodeResponse` and `createWebRequestFromNodeRequest` in public API

### DIFF
--- a/goldens/public-api/angular/ssr/node/index.api.md
+++ b/goldens/public-api/angular/ssr/node/index.api.md
@@ -5,6 +5,8 @@
 ```ts
 
 import { ApplicationRef } from '@angular/core';
+import type { IncomingMessage } from 'node:http';
+import type { ServerResponse } from 'node:http';
 import { StaticProvider } from '@angular/core';
 import { Type } from '@angular/core';
 
@@ -34,6 +36,12 @@ export interface CommonEngineRenderOptions {
     // (undocumented)
     url?: string;
 }
+
+// @public
+export function createWebRequestFromNodeRequest(nodeRequest: IncomingMessage): Request;
+
+// @public
+export function writeResponseToNodeResponse(source: Response, destination: ServerResponse): Promise<void>;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/angular/ssr/node/public_api.ts
+++ b/packages/angular/ssr/node/public_api.ts
@@ -11,3 +11,6 @@ export {
   type CommonEngineRenderOptions,
   type CommonEngineOptions,
 } from './src/common-engine/common-engine';
+
+export { writeResponseToNodeResponse } from './src/response';
+export { createWebRequestFromNodeRequest } from './src/request';

--- a/packages/angular/ssr/node/src/request.ts
+++ b/packages/angular/ssr/node/src/request.ts
@@ -13,6 +13,7 @@ import type { IncomingHttpHeaders, IncomingMessage } from 'node:http';
  *
  * @param nodeRequest - The Node.js `IncomingMessage` object to convert.
  * @returns A Web Standard `Request` object.
+ * @developerPreview
  */
 export function createWebRequestFromNodeRequest(nodeRequest: IncomingMessage): Request {
   const { headers, method = 'GET' } = nodeRequest;

--- a/packages/angular/ssr/node/src/response.ts
+++ b/packages/angular/ssr/node/src/response.ts
@@ -14,6 +14,7 @@ import type { ServerResponse } from 'node:http';
  * @param source - The web-standard `Response` object to stream from.
  * @param destination - The Node.js `ServerResponse` object to stream into.
  * @returns A promise that resolves once the streaming operation is complete.
+ * @developerPreview
  */
 export async function writeResponseToNodeResponse(
   source: Response,


### PR DESCRIPTION

These additions enhance server-side rendering capabilities by providing more flexibility in handling web requests and responses within Node.js environments.
