### PR TITLE
build: update `.prettierignore` to remove incorrect exclude pattern

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -13,6 +13,5 @@
 /CONTRIBUTING.md
 .yarn/
 dist/
-third_party/github.com/
 /tests/legacy-cli/e2e/assets/
 /tools/test/*.json


### PR DESCRIPTION
The pattern `third_party/github.com/` does not match any files. It should be replaced with `/packages/schematics/angular/third_party/`, which is already included in the list.
