### PR TITLE
refactor(@angular/build): support external runtime component stylesheets in application builder

### DIFF
--- a/packages/angular/build/src/builders/application/options.ts
+++ b/packages/angular/build/src/builders/application/options.ts
@@ -90,6 +90,14 @@ interface InternalOptions {
    * @default false
    */
   disableFullServerManifestGeneration?: boolean;
+
+  /**
+   * Enables the use of AOT compiler emitted external runtime styles.
+   * External runtime styles use `link` elements instead of embedded style content in the output JavaScript.
+   * This option is only intended to be used with a development server that can process and serve component
+   * styles.
+   */
+  externalRuntimeStyles?: boolean;
 }
 
 /** Full set of options for `application` builder. */
@@ -375,6 +383,7 @@ export async function normalizeOptions(
     clearScreen,
     define,
     disableFullServerManifestGeneration = false,
+    externalRuntimeStyles,
   } = options;
 
   // Return all the normalized options
@@ -436,6 +445,7 @@ export async function normalizeOptions(
     clearScreen,
     define,
     disableFullServerManifestGeneration,
+    externalRuntimeStyles,
   };
 }
 

--- a/packages/angular/build/src/builders/dev-server/vite-server.ts
+++ b/packages/angular/build/src/builders/dev-server/vite-server.ts
@@ -18,6 +18,7 @@ import { createAngularMemoryPlugin } from '../../tools/vite/angular-memory-plugi
 import { createAngularLocaleDataPlugin } from '../../tools/vite/i18n-locale-plugin';
 import { createRemoveIdPrefixPlugin } from '../../tools/vite/id-prefix-plugin';
 import { loadProxyConfiguration, normalizeSourceMaps } from '../../utils';
+import { useComponentStyleHmr } from '../../utils/environment-options';
 import { loadEsmModule } from '../../utils/load-esm';
 import { Result, ResultFile, ResultKind } from '../application/results';
 import {
@@ -129,6 +130,9 @@ export async function* serveWithVite(
     // https://nodejs.org/api/process.html#processsetsourcemapsenabledval
     process.setSourceMapsEnabled(true);
   }
+
+  // TODO: Enable by default once full support across CLI and FW is integrated
+  browserOptions.externalRuntimeStyles = useComponentStyleHmr;
 
   // Setup the prebundling transformer that will be shared across Vite prebundling requests
   const prebundleTransformer = new JavaScriptTransformer(

--- a/packages/angular/build/src/tools/angular/angular-host.ts
+++ b/packages/angular/build/src/tools/angular/angular-host.ts
@@ -7,6 +7,7 @@
  */
 
 import type ng from '@angular/compiler-cli';
+import assert from 'node:assert';
 import { createHash } from 'node:crypto';
 import nodePath from 'node:path';
 import type ts from 'typescript';
@@ -18,6 +19,7 @@ export interface AngularHostOptions {
   fileReplacements?: Record<string, string>;
   sourceFileCache?: Map<string, ts.SourceFile>;
   modifiedFiles?: Set<string>;
+  externalStylesheets?: Map<string, string>;
   transformStylesheet(
     data: string,
     containingFile: string,
@@ -180,6 +182,11 @@ export function createAngularCompilerHost(
       return null;
     }
 
+    assert(
+      !context.resourceFile || !hostOptions.externalStylesheets?.has(context.resourceFile),
+      'External runtime stylesheets should not be transformed: ' + context.resourceFile,
+    );
+
     // No transformation required if the resource is empty
     if (data.trim().length === 0) {
       return { content: '' };
@@ -192,6 +199,24 @@ export function createAngularCompilerHost(
     );
 
     return typeof result === 'string' ? { content: result } : null;
+  };
+
+  host.resourceNameToFileName = function (resourceName, containingFile) {
+    const resolvedPath = nodePath.join(nodePath.dirname(containingFile), resourceName);
+
+    // All resource names that have HTML file extensions are assumed to be templates
+    if (resourceName.endsWith('.html') || !hostOptions.externalStylesheets) {
+      return resolvedPath;
+    }
+
+    // For external stylesheets, create a unique identifier and store the mapping
+    let externalId = hostOptions.externalStylesheets.get(resolvedPath);
+    if (externalId === undefined) {
+      externalId = createHash('sha256').update(resolvedPath).digest('hex');
+      hostOptions.externalStylesheets.set(resolvedPath, externalId);
+    }
+
+    return externalId + '.css';
   };
 
   // Allow the AOT compiler to request the set of changed templates and styles

--- a/packages/angular/build/src/tools/angular/angular-host.ts
+++ b/packages/angular/build/src/tools/angular/angular-host.ts
@@ -24,6 +24,7 @@ export interface AngularHostOptions {
     data: string,
     containingFile: string,
     stylesheetFile?: string,
+    order?: number,
   ): Promise<string | null>;
   processWebWorker(workerFile: string, containingFile: string): string;
 }
@@ -196,6 +197,9 @@ export function createAngularCompilerHost(
       data,
       context.containingFile,
       context.resourceFile ?? undefined,
+      // TODO: Remove once available in compiler-cli types
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (context as any).order,
     );
 
     return typeof result === 'string' ? { content: result } : null;

--- a/packages/angular/build/src/tools/angular/compilation/angular-compilation.ts
+++ b/packages/angular/build/src/tools/angular/compilation/angular-compilation.ts
@@ -75,6 +75,7 @@ export abstract class AngularCompilation {
     affectedFiles: ReadonlySet<ts.SourceFile>;
     compilerOptions: ng.CompilerOptions;
     referencedFiles: readonly string[];
+    externalStylesheets?: ReadonlyMap<string, string>;
   }>;
 
   abstract emitAffectedFiles(): Iterable<EmitFileResult> | Promise<Iterable<EmitFileResult>>;

--- a/packages/angular/build/src/tools/angular/compilation/aot-compilation.ts
+++ b/packages/angular/build/src/tools/angular/compilation/aot-compilation.ts
@@ -46,6 +46,7 @@ export class AotCompilation extends AngularCompilation {
     affectedFiles: ReadonlySet<ts.SourceFile>;
     compilerOptions: ng.CompilerOptions;
     referencedFiles: readonly string[];
+    externalStylesheets?: ReadonlyMap<string, string>;
   }> {
     // Dynamically load the Angular compiler CLI package
     const { NgtscProgram, OptimizeFor } = await AngularCompilation.loadCompilerCli();
@@ -58,6 +59,10 @@ export class AotCompilation extends AngularCompilation {
     } = await this.loadConfiguration(tsconfig);
     const compilerOptions =
       compilerOptionsTransformer?.(originalCompilerOptions) ?? originalCompilerOptions;
+
+    if (compilerOptions.externalRuntimeStyles) {
+      hostOptions.externalStylesheets ??= new Map();
+    }
 
     // Create Angular compiler host
     const host = createAngularCompilerHost(ts, compilerOptions, hostOptions);
@@ -121,7 +126,12 @@ export class AotCompilation extends AngularCompilation {
       this.#state?.diagnosticCache,
     );
 
-    return { affectedFiles, compilerOptions, referencedFiles };
+    return {
+      affectedFiles,
+      compilerOptions,
+      referencedFiles,
+      externalStylesheets: hostOptions.externalStylesheets,
+    };
   }
 
   *collectDiagnostics(modes: DiagnosticModes): Iterable<ts.Diagnostic> {

--- a/packages/angular/build/src/tools/angular/compilation/parallel-compilation.ts
+++ b/packages/angular/build/src/tools/angular/compilation/parallel-compilation.ts
@@ -47,6 +47,7 @@ export class ParallelCompilation extends AngularCompilation {
     affectedFiles: ReadonlySet<SourceFile>;
     compilerOptions: CompilerOptions;
     referencedFiles: readonly string[];
+    externalStylesheets?: ReadonlyMap<string, string>;
   }> {
     const stylesheetChannel = new MessageChannel();
     // The request identifier is required because Angular can issue multiple concurrent requests

--- a/packages/angular/build/src/tools/angular/compilation/parallel-worker.ts
+++ b/packages/angular/build/src/tools/angular/compilation/parallel-worker.ts
@@ -42,7 +42,7 @@ export async function initialize(request: InitRequest) {
     }
   });
 
-  const { compilerOptions, referencedFiles } = await compilation.initialize(
+  const { compilerOptions, referencedFiles, externalStylesheets } = await compilation.initialize(
     request.tsconfig,
     {
       fileReplacements: request.fileReplacements,
@@ -93,6 +93,7 @@ export async function initialize(request: InitRequest) {
   );
 
   return {
+    externalStylesheets,
     referencedFiles,
     // TODO: Expand? `allowJs`, `isolatedModules`, `sourceMap`, `inlineSourceMap` are the only fields needed currently.
     compilerOptions: {

--- a/packages/angular/build/src/tools/esbuild/cache.ts
+++ b/packages/angular/build/src/tools/esbuild/cache.ts
@@ -126,4 +126,12 @@ export class MemoryCache<V> extends Cache<V, Map<string, V>> {
   values() {
     return this.store.values();
   }
+
+  /**
+   * Provides all the keys/values currently present in the cache instance.
+   * @returns An iterable of all key/value pairs in the cache.
+   */
+  entries() {
+    return this.store.entries();
+  }
 }

--- a/packages/angular/build/src/tools/esbuild/compiler-plugin-options.ts
+++ b/packages/angular/build/src/tools/esbuild/compiler-plugin-options.ts
@@ -37,6 +37,7 @@ export function createCompilerPluginOptions(
     tailwindConfiguration,
     postcssConfiguration,
     publicPath,
+    externalRuntimeStyles,
   } = options;
 
   return {
@@ -51,6 +52,7 @@ export function createCompilerPluginOptions(
       sourceFileCache,
       loadResultCache: sourceFileCache?.loadResultCache,
       incremental: !!options.watch,
+      externalRuntimeStyles,
     },
     // Component stylesheet options
     styleOptions: {

--- a/packages/angular/build/src/utils/environment-options.ts
+++ b/packages/angular/build/src/utils/environment-options.ts
@@ -100,3 +100,7 @@ export const useJSONBuildLogs =
 const optimizeChunksVariable = process.env['NG_BUILD_OPTIMIZE_CHUNKS'];
 export const shouldOptimizeChunks =
   isPresent(optimizeChunksVariable) && isEnabled(optimizeChunksVariable);
+
+const hmrComponentStylesVariable = process.env['NG_HMR_CSTYLES'];
+export const useComponentStyleHmr =
+  isPresent(hmrComponentStylesVariable) && isEnabled(hmrComponentStylesVariable);


### PR DESCRIPTION
To support automatic component style HMR, `application` builder in development mode now provides support for generating external runtime component stylesheets. This capability leverages the upcoming support within the AOT -compiler to emit components that generate `link` elements instead of embedding the stylesheet contents for file-based styles (e.g., `styleUrl`). In combination with support within the development server to handle requests for component stylesheets, file-based component stylesheets will be able to be replaced without a full page reload.

The implementation leverages the AOT compiler option `externalRuntimeStyles` which uses the result of the resource handler's resolution and emits new external stylesheet metadata within the component output code. This new metadata works in concert with the Angular runtime to generate `link` elements which can then leverage existing global stylesheet HMR capabilities.

This capability is current disabled by default while all elements are integrated across the CLI and framework and can be controlled via the `NG_HMR_CSTYLES=1` environment variable. Once fully integrated the environment variable will unneeded.

This feature is only intended for use with the development server. Component styles within built code including production are not affected by this feature.

NOTE: Rebuild times have not yet been optimized. Future improvements will reduce the component stylesheet only rebuild time case.