### PR TITLE
fix(@angular-devkit/build-angular): update `webpack-dev-middleware` to `7.4.2`

### DIFF
--- a/package.json
+++ b/package.json
@@ -204,7 +204,7 @@
     "vite": "5.4.0",
     "watchpack": "2.4.1",
     "webpack": "5.94.0",
-    "webpack-dev-middleware": "7.3.0",
+    "webpack-dev-middleware": "7.4.2",
     "webpack-dev-server": "5.0.4",
     "webpack-merge": "6.0.1",
     "webpack-subresource-integrity": "5.1.0",

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -64,7 +64,7 @@
     "vite": "5.4.0",
     "watchpack": "2.4.1",
     "webpack": "5.94.0",
-    "webpack-dev-middleware": "7.3.0",
+    "webpack-dev-middleware": "7.4.2",
     "webpack-dev-server": "5.0.4",
     "webpack-merge": "6.0.1",
     "webpack-subresource-integrity": "5.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -119,7 +119,7 @@ __metadata:
     vite: "npm:5.4.0"
     watchpack: "npm:2.4.1"
     webpack: "npm:5.94.0"
-    webpack-dev-middleware: "npm:7.3.0"
+    webpack-dev-middleware: "npm:7.4.2"
     webpack-dev-server: "npm:5.0.4"
     webpack-merge: "npm:6.0.1"
     webpack-subresource-integrity: "npm:5.1.0"
@@ -808,7 +808,7 @@ __metadata:
     vite: "npm:5.4.0"
     watchpack: "npm:2.4.1"
     webpack: "npm:5.94.0"
-    webpack-dev-middleware: "npm:7.3.0"
+    webpack-dev-middleware: "npm:7.4.2"
     webpack-dev-server: "npm:5.0.4"
     webpack-merge: "npm:6.0.1"
     webpack-subresource-integrity: "npm:5.1.0"
@@ -17796,7 +17796,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack-dev-middleware@npm:7.3.0, webpack-dev-middleware@npm:^7.1.0":
+"webpack-dev-middleware@npm:7.4.2":
+  version: 7.4.2
+  resolution: "webpack-dev-middleware@npm:7.4.2"
+  dependencies:
+    colorette: "npm:^2.0.10"
+    memfs: "npm:^4.6.0"
+    mime-types: "npm:^2.1.31"
+    on-finished: "npm:^2.4.1"
+    range-parser: "npm:^1.2.1"
+    schema-utils: "npm:^4.0.0"
+  peerDependencies:
+    webpack: ^5.0.0
+  peerDependenciesMeta:
+    webpack:
+      optional: true
+  checksum: 10c0/2aa873ef57a7095d7fba09400737b6066adc3ded229fd6eba89a666f463c2614c68e01ae58f662c9cdd74f0c8da088523d972329bf4a054e470bc94feb8bcad0
+  languageName: node
+  linkType: hard
+
+"webpack-dev-middleware@npm:^7.1.0":
   version: 7.3.0
   resolution: "webpack-dev-middleware@npm:7.3.0"
   dependencies:


### PR DESCRIPTION

This update contains a fix for `Error: Cannot set headers after they are sent to the client`. See: https://github.com/webpack/webpack-dev-middleware/blob/master/CHANGELOG.md#742-2024-08-21

Closes #28331