### PR TITLE
feat(@angular/build): introduce `outputMode` option to the application builder

### DIFF
--- a/goldens/circular-deps/packages.json
+++ b/goldens/circular-deps/packages.json
@@ -10,16 +10,18 @@
   [
     "packages/angular/build/src/tools/esbuild/bundler-context.ts",
     "packages/angular/build/src/tools/esbuild/utils.ts",
-    "packages/angular/build/src/tools/esbuild/bundler-execution-result.ts"
+    "packages/angular/build/src/utils/server-rendering/manifest.ts"
   ],
   [
     "packages/angular/build/src/tools/esbuild/bundler-context.ts",
     "packages/angular/build/src/tools/esbuild/utils.ts",
-    "packages/angular/build/src/utils/server-rendering/manifest.ts"
+    "packages/angular/build/src/utils/server-rendering/manifest.ts",
+    "packages/angular/build/src/tools/esbuild/bundler-execution-result.ts"
   ],
   [
     "packages/angular/build/src/tools/esbuild/bundler-execution-result.ts",
-    "packages/angular/build/src/tools/esbuild/utils.ts"
+    "packages/angular/build/src/tools/esbuild/utils.ts",
+    "packages/angular/build/src/utils/server-rendering/manifest.ts"
   ],
   [
     "packages/angular/cli/src/analytics/analytics-collector.ts",

--- a/goldens/public-api/angular/build/index.api.md
+++ b/goldens/public-api/angular/build/index.api.md
@@ -40,6 +40,7 @@ export interface ApplicationBuilderOptions {
     namedChunks?: boolean;
     optimization?: OptimizationUnion;
     outputHashing?: OutputHashing;
+    outputMode?: OutputMode;
     outputPath: OutputPathUnion;
     poll?: number;
     polyfills?: string[];
@@ -99,13 +100,15 @@ export interface BuildOutputFile extends OutputFile {
 // @public (undocumented)
 export enum BuildOutputFileType {
     // (undocumented)
-    Browser = 1,
+    Browser = 0,
     // (undocumented)
-    Media = 2,
+    Media = 1,
     // (undocumented)
     Root = 4,
     // (undocumented)
-    Server = 3
+    ServerApplication = 2,
+    // (undocumented)
+    ServerRoot = 3
 }
 
 // @public

--- a/packages/angular/build/src/builders/application/schema.json
+++ b/packages/angular/build/src/builders/application/schema.json
@@ -528,6 +528,11 @@
       "type": "boolean",
       "description": "Generates an application shell during build time.",
       "default": false
+    },
+    "outputMode": {
+      "type": "string",
+      "description": "Defines the build output target. 'static': Generates a static site for deployment on any static hosting service. 'server': Produces an application designed for deployment on a server that supports server-side rendering (SSR).",
+      "enum": ["static", "server"]
     }
   },
   "additionalProperties": false,

--- a/packages/angular/build/src/builders/application/tests/options/output-mode.ts
+++ b/packages/angular/build/src/builders/application/tests/options/output-mode.ts
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { buildApplication } from '../../index';
+import { OutputMode } from '../../schema';
+import { APPLICATION_BUILDER_INFO, BASE_OPTIONS, describeBuilder } from '../setup';
+
+describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
+  beforeEach(async () => {
+    await harness.modifyFile('src/tsconfig.app.json', (content) => {
+      const tsConfig = JSON.parse(content);
+      tsConfig.files ??= [];
+      tsConfig.files.push('main.server.ts', 'server.ts');
+
+      return JSON.stringify(tsConfig);
+    });
+
+    await harness.writeFile('src/server.ts', `console.log('Hello!');`);
+  });
+
+  describe('Option: "outputMode"', () => {
+    it(`should not emit 'server' directory when OutputMode is Static`, async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        outputMode: OutputMode.Static,
+        server: 'src/main.server.ts',
+        ssr: { entry: 'src/server.ts' },
+      });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
+
+      harness.expectDirectory('dist/server').toNotExist();
+    });
+
+    it(`should emit 'server' directory when OutputMode is Server`, async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        outputMode: OutputMode.Server,
+        server: 'src/main.server.ts',
+        ssr: { entry: 'src/server.ts' },
+      });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
+
+      harness.expectFile('dist/server/main.server.mjs').toExist();
+      harness.expectFile('dist/server/server.mjs').toExist();
+    });
+  });
+});

--- a/packages/angular/build/src/builders/dev-server/vite-server.ts
+++ b/packages/angular/build/src/builders/dev-server/vite-server.ts
@@ -11,7 +11,7 @@ import type { BuilderContext } from '@angular-devkit/architect';
 import type { Plugin } from 'esbuild';
 import assert from 'node:assert';
 import { readFile } from 'node:fs/promises';
-import { builtinModules } from 'node:module';
+import { builtinModules, isBuiltin } from 'node:module';
 import { join } from 'node:path';
 import type { Connect, DepOptimizationConfig, InlineConfig, ViteDevServer } from 'vite';
 import { createAngularMemoryPlugin } from '../../tools/vite/angular-memory-plugin';
@@ -93,20 +93,18 @@ export async function* serveWithVite(
     builderName,
   )) as unknown as ApplicationBuilderInternalOptions;
 
-  if (browserOptions.prerender || browserOptions.ssr) {
+  if (browserOptions.prerender) {
     // Disable prerendering if enabled and force SSR.
     // This is so instead of prerendering all the routes for every change, the page is "prerendered" when it is requested.
     browserOptions.prerender = false;
-
-    // Avoid bundling and processing the ssr entry-point as this is not used by the dev-server.
-    browserOptions.ssr = true;
-
-    // https://nodejs.org/api/process.html#processsetsourcemapsenabledval
-    process.setSourceMapsEnabled(true);
   }
 
   // Set all packages as external to support Vite's prebundle caching
   browserOptions.externalPackages = serverOptions.prebundle;
+
+  // Disable generating a full manifest with routes.
+  // This is done during runtime when using the dev-server.
+  browserOptions.disableFullServerManifestGeneration = true;
 
   // The development server currently only supports a single locale when localizing.
   // This matches the behavior of the Webpack-based development server but could be expanded in the future.
@@ -123,7 +121,14 @@ export async function* serveWithVite(
     browserOptions.forceI18nFlatOutput = true;
   }
 
-  const { vendor: thirdPartySourcemaps } = normalizeSourceMaps(browserOptions.sourceMap ?? false);
+  const { vendor: thirdPartySourcemaps, scripts: scriptsSourcemaps } = normalizeSourceMaps(
+    browserOptions.sourceMap ?? false,
+  );
+
+  if (scriptsSourcemaps && browserOptions.server) {
+    // https://nodejs.org/api/process.html#processsetsourcemapsenabledval
+    process.setSourceMapsEnabled(true);
+  }
 
   // Setup the prebundling transformer that will be shared across Vite prebundling requests
   const prebundleTransformer = new JavaScriptTransformer(
@@ -229,9 +234,9 @@ export async function* serveWithVite(
         'externalMetadata'
       ] as ExternalResultMetadata;
       const implicitServerFiltered = implicitServer.filter(
-        (m) => removeNodeJsBuiltinModules(m) && removeAbsoluteUrls(m),
+        (m) => !isBuiltin(m) && !isAbsoluteUrl(m),
       );
-      const implicitBrowserFiltered = implicitBrowser.filter(removeAbsoluteUrls);
+      const implicitBrowserFiltered = implicitBrowser.filter((m) => !isAbsoluteUrl(m));
 
       if (browserOptions.ssr && serverOptions.prebundle !== false) {
         const previousImplicitServer = new Set(externalMetadata.implicitServer);
@@ -249,7 +254,7 @@ export async function* serveWithVite(
       externalMetadata.implicitBrowser.length = 0;
 
       externalMetadata.explicitBrowser.push(...explicit);
-      externalMetadata.explicitServer.push(...explicit, ...nodeJsBuiltinModules);
+      externalMetadata.explicitServer.push(...explicit, ...builtinModules);
       externalMetadata.implicitServer.push(...implicitServerFiltered);
       externalMetadata.implicitBrowser.push(...implicitBrowserFiltered);
 
@@ -386,7 +391,7 @@ async function handleUpdate(
   for (const [file, record] of generatedFiles) {
     if (record.updated) {
       updatedFiles.push(file);
-      isServerFileUpdated ||= record.type === BuildOutputFileType.Server;
+      isServerFileUpdated ||= record.type === BuildOutputFileType.ServerApplication;
 
       const updatedModules = server.moduleGraph.getModulesByFile(
         normalizePath(join(server.config.root, file)),
@@ -744,14 +749,14 @@ function getDepOptimizationConfig({
   };
 }
 
-const nodeJsBuiltinModules = new Set(builtinModules);
-
-/** Remove any Node.js builtin modules to avoid Vite's prebundling from processing them as files. */
-function removeNodeJsBuiltinModules(value: string): boolean {
-  return !nodeJsBuiltinModules.has(value);
-}
-
-/** Remove any absolute URLs (http://, https://, //) to avoid Vite's prebundling from processing them as files. */
-function removeAbsoluteUrls(value: string): boolean {
-  return !/^(?:https?:)?\/\//.test(value);
+/**
+ * Checks if the given value is an absolute URL.
+ *
+ * This function helps in avoiding Vite's prebundling from processing absolute URLs (http://, https://, //) as files.
+ *
+ * @param value - The URL or path to check.
+ * @returns `true` if the value is not an absolute URL; otherwise, `false`.
+ */
+function isAbsoluteUrl(value: string): boolean {
+  return /^(?:https?:)?\/\//.test(value);
 }

--- a/packages/angular/build/src/builders/extract-i18n/application-extraction.ts
+++ b/packages/angular/build/src/builders/extract-i18n/application-extraction.ts
@@ -17,6 +17,7 @@ import type {
   ApplicationBuilderInternalOptions,
 } from '../application/options';
 import { ResultFile, ResultKind } from '../application/results';
+import { OutputMode } from '../application/schema';
 import type { NormalizedExtractI18nOptions } from './options';
 
 export async function extractMessages(
@@ -44,10 +45,8 @@ export async function extractMessages(
   buildOptions.budgets = undefined;
   buildOptions.index = false;
   buildOptions.serviceWorker = false;
-
-  buildOptions.ssr = false;
-  buildOptions.appShell = false;
-  buildOptions.prerender = false;
+  buildOptions.outputMode = OutputMode.Static;
+  buildOptions.server = undefined;
 
   // Build the application with the build options
   const builderResult = await first(buildApplicationInternal(buildOptions, context, extensions));

--- a/packages/angular/build/src/tools/esbuild/budget-stats.ts
+++ b/packages/angular/build/src/tools/esbuild/budget-stats.ts
@@ -39,7 +39,7 @@ export function generateBudgetStats(
     }
 
     // Exclude server bundles
-    if (type === BuildOutputFileType.Server) {
+    if (type === BuildOutputFileType.ServerApplication || type === BuildOutputFileType.ServerRoot) {
       continue;
     }
 

--- a/packages/angular/build/src/tools/esbuild/bundler-context.ts
+++ b/packages/angular/build/src/tools/esbuild/bundler-context.ts
@@ -47,10 +47,11 @@ export interface InitialFileRecord {
 }
 
 export enum BuildOutputFileType {
-  Browser = 1,
-  Media = 2,
-  Server = 3,
-  Root = 4,
+  Browser,
+  Media,
+  ServerApplication,
+  ServerRoot,
+  Root,
 }
 
 export interface BuildOutputFile extends OutputFile {
@@ -147,6 +148,7 @@ export class BundlerContext {
       }
 
       result.initialFiles.forEach((value, key) => initialFiles.set(key, value));
+
       outputFiles.push(...result.outputFiles);
       result.externalImports.browser?.forEach((value) => externalImportsBrowser.add(value));
       result.externalImports.server?.forEach((value) => externalImportsServer.add(value));
@@ -370,7 +372,10 @@ export class BundlerContext {
       if (!/\.([cm]?js|css|wasm)(\.map)?$/i.test(file.path)) {
         fileType = BuildOutputFileType.Media;
       } else if (this.#platformIsServer) {
-        fileType = BuildOutputFileType.Server;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        fileType = (result.metafile as any)['ng-ssr-entry-bundle']
+          ? BuildOutputFileType.ServerRoot
+          : BuildOutputFileType.ServerApplication;
       } else {
         fileType = BuildOutputFileType.Browser;
       }

--- a/packages/angular/build/src/tools/esbuild/bundler-execution-result.ts
+++ b/packages/angular/build/src/tools/esbuild/bundler-execution-result.ts
@@ -31,6 +31,8 @@ export interface ExternalResultMetadata {
   explicit: string[];
 }
 
+export type PrerenderedRoutesRecord = Record<string, { headers?: Record<string, string> }>;
+
 /**
  * Represents the result of a single builder execute call.
  */
@@ -38,7 +40,7 @@ export class ExecutionResult {
   outputFiles: BuildOutputFile[] = [];
   assetFiles: BuildOutputAsset[] = [];
   errors: (Message | PartialMessage)[] = [];
-  prerenderedRoutes: string[] = [];
+  prerenderedRoutes: PrerenderedRoutesRecord = {};
   warnings: (Message | PartialMessage)[] = [];
   logs: string[] = [];
   externalMetadata?: ExternalResultMetadata;
@@ -77,10 +79,16 @@ export class ExecutionResult {
     }
   }
 
-  addPrerenderedRoutes(routes: string[]): void {
-    this.prerenderedRoutes.push(...routes);
+  addPrerenderedRoutes(routes: PrerenderedRoutesRecord): void {
+    Object.assign(this.prerenderedRoutes, routes);
+
     // Sort the prerendered routes.
-    this.prerenderedRoutes.sort((a, b) => a.localeCompare(b));
+    const sortedObj: PrerenderedRoutesRecord = {};
+    for (const key of Object.keys(this.prerenderedRoutes).sort()) {
+      sortedObj[key] = this.prerenderedRoutes[key];
+    }
+
+    this.prerenderedRoutes = sortedObj;
   }
 
   addWarning(error: PartialMessage | string): void {

--- a/packages/angular/build/src/tools/esbuild/i18n-inliner.ts
+++ b/packages/angular/build/src/tools/esbuild/i18n-inliner.ts
@@ -44,7 +44,8 @@ export class I18nInliner {
     const files = new Map<string, Blob>();
     const pendingMaps = [];
     for (const file of options.outputFiles) {
-      if (file.type === BuildOutputFileType.Root) {
+      if (file.type === BuildOutputFileType.Root || file.type === BuildOutputFileType.ServerRoot) {
+        // Skip also the server entry-point.
         // Skip stats and similar files.
         continue;
       }

--- a/packages/angular/build/src/utils/server-rendering/models.ts
+++ b/packages/angular/build/src/utils/server-rendering/models.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import type { RenderMode, ɵextractRoutesAndCreateRouteTree } from '@angular/ssr';
+import { ESMInMemoryFileLoaderWorkerData } from './esm-in-memory-loader/loader-hooks';
+
+type Writeable<T extends readonly unknown[]> = T extends readonly (infer U)[] ? U[] : never;
+
+export interface RoutesExtractorWorkerData extends ESMInMemoryFileLoaderWorkerData {
+  assetFiles: Record</** Destination */ string, /** Source */ string>;
+}
+
+export type SerializableRouteTreeNode = ReturnType<
+  Awaited<ReturnType<typeof ɵextractRoutesAndCreateRouteTree>>['routeTree']['toObject']
+>;
+
+export type WritableSerializableRouteTreeNode = Writeable<SerializableRouteTreeNode>;
+
+export interface RoutersExtractorWorkerResult {
+  serializedRouteTree: SerializableRouteTreeNode;
+  errors: string[];
+}
+
+/**
+ * Local copy of `RenderMode` exported from `@angular/ssr`.
+ * This constant is needed to handle interop between CommonJS (CJS) and ES Modules (ESM) formats.
+ *
+ * It maps `RenderMode` enum values to their corresponding numeric identifiers.
+ */
+export const RouteRenderMode: Record<keyof typeof RenderMode, RenderMode> = {
+  AppShell: 0,
+  Server: 1,
+  Client: 2,
+  Prerender: 3,
+};

--- a/packages/angular/ssr/public_api.ts
+++ b/packages/angular/ssr/public_api.ts
@@ -12,7 +12,7 @@ export { AngularAppEngine } from './src/app-engine';
 
 export {
   type PrerenderFallback,
-  type RenderMode,
   type ServerRoute,
   provideServerRoutesConfig,
+  RenderMode,
 } from './src/routes/route-config';

--- a/packages/angular/ssr/src/app-engine.ts
+++ b/packages/angular/ssr/src/app-engine.ts
@@ -10,7 +10,7 @@ import type { AngularServerApp } from './app';
 import { Hooks } from './hooks';
 import { getPotentialLocaleIdFromUrl } from './i18n';
 import { EntryPointExports, getAngularAppEngineManifest } from './manifest';
-import { stripIndexHtmlFromURL } from './utils/url';
+import { stripIndexHtmlFromURL, stripTrailingSlash } from './utils/url';
 
 /**
  * Angular server application engine.
@@ -116,7 +116,7 @@ export class AngularAppEngine {
     }
 
     const { pathname } = stripIndexHtmlFromURL(new URL(request.url));
-    const headers = this.manifest.staticPathsHeaders.get(pathname);
+    const headers = this.manifest.staticPathsHeaders.get(stripTrailingSlash(pathname));
 
     return new Map(headers);
   }

--- a/packages/angular/ssr/src/manifest.ts
+++ b/packages/angular/ssr/src/manifest.ts
@@ -89,6 +89,12 @@ export interface AngularAppManifest {
    * It is used for route matching and navigation within the server application.
    */
   readonly routes?: SerializableRouteTreeNode;
+
+  /**
+   * An optional string representing the locale or language code to be used for
+   * the application, aiding with localization and rendering content specific to the locale.
+   */
+  readonly locale?: string;
 }
 
 /**

--- a/packages/angular/ssr/test/app_spec.ts
+++ b/packages/angular/ssr/test/app_spec.ts
@@ -114,7 +114,7 @@ describe('AngularServerApp', () => {
       expect(Object.fromEntries(headers)).toEqual({
         'cache-control': 'no-cache',
         'x-some-header': 'value',
-        'content-type': 'text/plain;charset=UTF-8',
+        'content-type': 'text/html;charset=UTF-8',
       });
     });
 
@@ -122,7 +122,7 @@ describe('AngularServerApp', () => {
       const response = await app.render(new Request('http://localhost/home'));
       const headers = response?.headers.entries() ?? [];
       expect(Object.fromEntries(headers)).toEqual({
-        'content-type': 'text/plain;charset=UTF-8', // default header
+        'content-type': 'text/html;charset=UTF-8', // default header
       });
     });
 

--- a/tests/legacy-cli/e2e.bzl
+++ b/tests/legacy-cli/e2e.bzl
@@ -42,6 +42,7 @@ ESBUILD_TESTS = [
 
 WEBPACK_IGNORE_TESTS = [
     "tests/vite/**",
+    "tests/server-rendering/server-routes-*",
     "tests/commands/serve/ssr-http-requests-assets.js",
     "tests/build/prerender/http-requests-assets.js",
     "tests/build/prerender/error-with-sourcemaps.js",

--- a/tests/legacy-cli/e2e/tests/build/prerender/discover-routes-standalone.ts
+++ b/tests/legacy-cli/e2e/tests/build/prerender/discover-routes-standalone.ts
@@ -111,15 +111,15 @@ export default async function () {
       // prerendered-routes.json file is only generated when using esbuild.
       const generatedRoutesStats = await readFile('dist/test-project/prerendered-routes.json');
       deepStrictEqual(JSON.parse(generatedRoutesStats), {
-        routes: [
-          '/',
-          '/lazy-one',
-          '/lazy-one/lazy-one-child',
-          '/lazy-two',
-          '/two',
-          '/two/two-child-one',
-          '/two/two-child-two',
-        ],
+        routes: {
+          '/': {},
+          '/lazy-one': {},
+          '/lazy-one/lazy-one-child': {},
+          '/lazy-two': {},
+          '/two': {},
+          '/two/two-child-one': {},
+          '/two/two-child-two': {},
+        },
       });
     }
   }

--- a/tests/legacy-cli/e2e/tests/i18n/setup.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/setup.ts
@@ -102,10 +102,11 @@ export async function setupI18nConfig() {
     `
     import { Component, Inject, LOCALE_ID } from '@angular/core';
     import { DatePipe } from '@angular/common';
+    import { RouterOutlet } from '@angular/router';
 
     @Component({
       selector: 'app-root',
-      imports: [DatePipe],
+      imports: [DatePipe, RouterOutlet],
       standalone: true,
       templateUrl: './app.component.html'
     })
@@ -124,6 +125,7 @@ export async function setupI18nConfig() {
     <p id="locale">{{ locale }}</p>
     <p id="date">{{ jan | date : 'LLLL' }}</p>
     <p id="plural" i18n>Updated {minutes, plural, =0 {just now} =1 {one minute ago} other {{{minutes}} minutes ago}}</p>
+    <router-outlet></router-outlet>
   `,
   );
 

--- a/tests/legacy-cli/e2e/tests/server-rendering/express-engine-ngmodule.ts
+++ b/tests/legacy-cli/e2e/tests/server-rendering/express-engine-ngmodule.ts
@@ -1,9 +1,9 @@
-import { getGlobalVariable } from '../../../utils/env';
-import { rimraf, writeMultipleFiles } from '../../../utils/fs';
-import { findFreePort } from '../../../utils/network';
-import { installWorkspacePackages } from '../../../utils/packages';
-import { execAndWaitForOutputToMatch, ng } from '../../../utils/process';
-import { updateJsonFile, useCIChrome, useCIDefaults, useSha } from '../../../utils/project';
+import { getGlobalVariable } from '../../utils/env';
+import { rimraf, writeMultipleFiles } from '../../utils/fs';
+import { findFreePort } from '../../utils/network';
+import { installWorkspacePackages } from '../../utils/packages';
+import { execAndWaitForOutputToMatch, ng } from '../../utils/process';
+import { updateJsonFile, useCIChrome, useCIDefaults, useSha } from '../../utils/project';
 
 export default async function () {
   // forcibly remove in case another test doesn't clean itself up

--- a/tests/legacy-cli/e2e/tests/server-rendering/express-engine-standalone.ts
+++ b/tests/legacy-cli/e2e/tests/server-rendering/express-engine-standalone.ts
@@ -1,20 +1,17 @@
-import { getGlobalVariable } from '../../../utils/env';
-import { rimraf, writeMultipleFiles } from '../../../utils/fs';
-import { findFreePort } from '../../../utils/network';
-import { installWorkspacePackages } from '../../../utils/packages';
-import { execAndWaitForOutputToMatch, ng } from '../../../utils/process';
-import { updateJsonFile, useSha } from '../../../utils/project';
+import { getGlobalVariable } from '../../utils/env';
+import { rimraf, writeMultipleFiles } from '../../utils/fs';
+import { findFreePort } from '../../utils/network';
+import { installWorkspacePackages } from '../../utils/packages';
+import { execAndWaitForOutputToMatch, ng } from '../../utils/process';
+import { updateJsonFile, useSha } from '../../utils/project';
 
 export default async function () {
-  const useWebpackBuilder = !getGlobalVariable('argv')['esbuild'];
-
   // forcibly remove in case another test doesn't clean itself up
   await rimraf('node_modules/@angular/ssr');
+
   await ng('add', '@angular/ssr', '--skip-confirmation', '--skip-install');
 
-  await useSha();
-  await installWorkspacePackages();
-
+  const useWebpackBuilder = !getGlobalVariable('argv')['esbuild'];
   if (!useWebpackBuilder) {
     // Disable prerendering
     await updateJsonFile('angular.json', (json) => {
@@ -22,6 +19,9 @@ export default async function () {
       build.configurations.production.prerender = false;
     });
   }
+
+  await useSha();
+  await installWorkspacePackages();
 
   await writeMultipleFiles({
     'src/app/app.component.css': `div { color: #000 }`,
@@ -34,18 +34,6 @@ export default async function () {
         bootstrapApplication(AppComponent, appConfig).catch((err) => console.error(err));
       };
       `,
-    'src/index.html': `
-      <!doctype html>
-      <html lang="en">
-      <head>
-        <meta charset="utf-8">
-        <base href="/">
-      </head>
-      <body>
-        <app-root ngCspNonce="{% nonce %}"></app-root>
-      </body>
-      </html>
-    `,
     'e2e/src/app.e2e-spec.ts':
       `
       import { browser, by, element } from 'protractor';
@@ -78,12 +66,12 @@ export default async function () {
           // Load the page without waiting for Angular since it is not bootstrapped automatically.
           await browser.driver.get(browser.baseUrl);
 
-          expect(
-            await element(by.css('style[ng-app-id="ng"]')).getText()
-          ).not.toBeNull();
+          const style = await browser.driver.findElement(by.css('style[ng-app-id="ng"]'));
+          expect(await style.getText()).not.toBeNull();
 
           // Test the contents from the server.
-          expect(await element(by.css('h1')).getText()).toMatch('Hello');
+          const serverDiv = await browser.driver.findElement(by.css('h1'));
+          expect(await serverDiv.getText()).toMatch('Hello');
 
           // Bootstrap the client side app.
           await browser.executeScript('doBootstrap()');
@@ -92,14 +80,12 @@ export default async function () {
           expect(await element(by.css('h1')).getText()).toMatch('Hello');
 
           // Make sure the server styles got replaced by client side ones.
-          expect(
-            await element(by.css('style[ng-app-id="ng"]')).isPresent()
-          ).toBeFalsy();
+          expect(await element(by.css('style[ng-app-id="ng"]')).isPresent()).toBeFalsy();
           expect(await element(by.css('style')).getText()).toMatch('');
 
           // Make sure there were no client side errors.
           await verifyNoBrowserErrors();
-        });` +
+        }); ` +
       // TODO(alanagius): enable the below tests once critical css inlining for SSR is supported with Vite.
       (useWebpackBuilder
         ? `
@@ -108,37 +94,20 @@ export default async function () {
           await browser.driver.get(browser.baseUrl);
 
           // Test the contents from the server.
-          const linkTag = await browser.driver.findElement(
-            by.css('link[rel="stylesheet"]')
-          );
-          expect(await linkTag.getAttribute('media')).toMatch('all');
-          expect(await linkTag.getAttribute('ngCspMedia')).toBeNull();
-          expect(await linkTag.getAttribute('onload')).toBeNull();
+          const styleTag = await browser.driver.findElement(by.css('link[rel="stylesheet"]'));
+          expect(await styleTag.getAttribute('media')).toMatch('all');
 
           // Make sure there were no client side errors.
           await verifyNoBrowserErrors();
         });`
         : '') +
       `
-        it('style tags all have a nonce attribute', async () => {
-          // Load the page without waiting for Angular since it is not bootstrapped automatically.
-          await browser.driver.get(browser.baseUrl);
-
-          // Test the contents from the server.
-          for (const s of await browser.driver.findElements(by.css('style'))) {
-            expect(await s.getAttribute('nonce')).toBe('{% nonce %}');
-          }
-
-          // Make sure there were no client side errors.
-          await verifyNoBrowserErrors();
-        });
       });
       `,
   });
 
   async function spawnServer(): Promise<number> {
     const port = await findFreePort();
-
     const runCommand = useWebpackBuilder ? 'serve:ssr' : 'serve:ssr:test-project';
 
     await execAndWaitForOutputToMatch(
@@ -154,10 +123,9 @@ export default async function () {
   }
 
   await ng('build');
-
   if (useWebpackBuilder) {
     // Build server code
-    await ng('run', 'test-project:server');
+    await ng('run', `test-project:server`);
   }
 
   const port = await spawnServer();

--- a/tests/legacy-cli/e2e/tests/server-rendering/server-routes-output-mode-server-i18n-base-href.ts
+++ b/tests/legacy-cli/e2e/tests/server-rendering/server-routes-output-mode-server-i18n-base-href.ts
@@ -1,0 +1,89 @@
+import { join } from 'node:path';
+import assert from 'node:assert';
+import { expectFileToMatch, writeFile } from '../../utils/fs';
+import { noSilentNg, silentNg } from '../../utils/process';
+import { setupProjectWithSSRAppEngine, spawnServer } from './setup';
+import { langTranslations, setupI18nConfig } from '../i18n/setup';
+
+export default async function () {
+  // Setup project
+  await setupI18nConfig();
+  await setupProjectWithSSRAppEngine();
+
+  // Add routes
+  await writeFile(
+    'src/app/app.routes.ts',
+    `
+  import { Routes } from '@angular/router';
+  import { HomeComponent } from './home/home.component';
+  import { SsrComponent } from './ssr/ssr.component';
+  import { SsgComponent } from './ssg/ssg.component';
+
+  export const routes: Routes = [
+    {
+      path: '',
+      component: HomeComponent,
+    },
+    {
+      path: 'ssg',
+      component: SsgComponent,
+    },
+    {
+      path: 'ssr',
+      component: SsrComponent,
+    },
+  ];
+  `,
+  );
+
+  // Add server routing
+  await writeFile(
+    'src/app/app.routes.server.ts',
+    `
+  import { RenderMode, ServerRoute } from '@angular/ssr';
+
+  export const routes: ServerRoute[] = [
+    {
+      path: '',
+      renderMode: RenderMode.Prerender,
+    },
+    {
+      path: 'ssg',
+      renderMode: RenderMode.Prerender,
+    },
+    {
+      path: '**',
+      renderMode: RenderMode.Server,
+    },
+  ];
+  `,
+  );
+
+  // Generate components for the above routes
+  const componentNames: string[] = ['home', 'ssg', 'csr', 'ssr'];
+  for (const componentName of componentNames) {
+    await silentNg('generate', 'component', componentName);
+  }
+
+  await noSilentNg('build', '--output-mode=server', '--base-href=/base/');
+
+  for (const { lang, outputPath } of langTranslations) {
+    await expectFileToMatch(join(outputPath, 'index.html'), `<p id="locale">${lang}</p>`);
+    await expectFileToMatch(join(outputPath, 'ssg/index.html'), `<p id="locale">${lang}</p>`);
+  }
+
+  // Tests responses
+  const port = await spawnServer();
+  const pathname = '/ssr';
+
+  for (const { lang } of langTranslations) {
+    const res = await fetch(`http://localhost:${port}/base/${lang}${pathname}`);
+    const text = await res.text();
+
+    assert.match(
+      text,
+      new RegExp(`<p id="locale">${lang}</p>`),
+      `Response for '${lang}${pathname}': '<p id="locale">${lang}</p>' was not matched in content.`,
+    );
+  }
+}

--- a/tests/legacy-cli/e2e/tests/server-rendering/server-routes-output-mode-server-i18n.ts
+++ b/tests/legacy-cli/e2e/tests/server-rendering/server-routes-output-mode-server-i18n.ts
@@ -1,0 +1,101 @@
+import { join } from 'node:path';
+import assert from 'node:assert';
+import { expectFileToMatch, writeFile } from '../../utils/fs';
+import { noSilentNg, silentNg } from '../../utils/process';
+import { setupProjectWithSSRAppEngine, spawnServer } from './setup';
+import { langTranslations, setupI18nConfig } from '../i18n/setup';
+
+export default async function () {
+  // Setup project
+  await setupI18nConfig();
+  await setupProjectWithSSRAppEngine();
+
+  // Add routes
+  await writeFile(
+    'src/app/app.routes.ts',
+    `
+  import { Routes } from '@angular/router';
+  import { HomeComponent } from './home/home.component';
+  import { SsrComponent } from './ssr/ssr.component';
+  import { SsgComponent } from './ssg/ssg.component';
+
+  export const routes: Routes = [
+    {
+      path: '',
+      component: HomeComponent,
+    },
+    {
+      path: 'ssg',
+      component: SsgComponent,
+    },
+    {
+      path: 'ssr',
+      component: SsrComponent,
+    },
+  ];
+  `,
+  );
+
+  // Add server routing
+  await writeFile(
+    'src/app/app.routes.server.ts',
+    `
+  import { RenderMode, ServerRoute } from '@angular/ssr';
+
+  export const routes: ServerRoute[] = [
+    {
+      path: '',
+      renderMode: RenderMode.Prerender,
+    },
+    {
+      path: 'ssg',
+      renderMode: RenderMode.Prerender,
+    },
+    {
+      path: '**',
+      renderMode: RenderMode.Server,
+    },
+  ];
+  `,
+  );
+
+  // Generate components for the above routes
+  const componentNames: string[] = ['home', 'ssg', 'ssr'];
+  for (const componentName of componentNames) {
+    await silentNg('generate', 'component', componentName);
+  }
+
+  await noSilentNg('build', '--output-mode=server');
+
+  const expects: Record<string, string> = {
+    'index.html': 'home works!',
+    'ssg/index.html': 'ssg works!',
+  };
+
+  for (const { lang, outputPath } of langTranslations) {
+    for (const [filePath, fileMatch] of Object.entries(expects)) {
+      await expectFileToMatch(join(outputPath, filePath), `<p id="locale">${lang}</p>`);
+      await expectFileToMatch(join(outputPath, filePath), fileMatch);
+    }
+  }
+
+  // Tests responses
+  const port = await spawnServer();
+  const pathname = '/ssr';
+
+  // We run the tests twice to ensure that the locale ID is set correctly.
+  for (const iteration of [1, 2]) {
+    for (const { lang, translation } of langTranslations) {
+      const res = await fetch(`http://localhost:${port}/${lang}${pathname}`);
+      const text = await res.text();
+
+      for (const match of [`<p id="date">${translation.date}</p>`, `<p id="locale">${lang}</p>`]) {
+        assert.match(
+          text,
+          new RegExp(match),
+          `Response for '${lang}${pathname}': '${match}' was not matched in content. Iteration: ${iteration}.`,
+        );
+      }
+    }
+  }
+}

--- a/tests/legacy-cli/e2e/tests/server-rendering/server-routes-output-mode-server.ts
+++ b/tests/legacy-cli/e2e/tests/server-rendering/server-routes-output-mode-server.ts
@@ -1,0 +1,179 @@
+import { join } from 'node:path';
+import { existsSync } from 'node:fs';
+import assert from 'node:assert';
+import { expectFileToMatch, writeFile } from '../../utils/fs';
+import { noSilentNg, silentNg } from '../../utils/process';
+import { setupProjectWithSSRAppEngine, spawnServer } from './setup';
+
+export default async function () {
+  // Setup project
+  await setupProjectWithSSRAppEngine();
+
+  // Add routes
+  await writeFile(
+    'src/app/app.routes.ts',
+    `
+  import { Routes } from '@angular/router';
+  import { HomeComponent } from './home/home.component';
+  import { CsrComponent } from './csr/csr.component';
+  import { SsrComponent } from './ssr/ssr.component';
+  import { SsgComponent } from './ssg/ssg.component';
+  import { AppShellComponent } from './app-shell/app-shell.component';
+  import { SsgWithParamsComponent } from './ssg-with-params/ssg-with-params.component';
+
+  export const routes: Routes = [
+    {
+      path: 'app-shell',
+      component: AppShellComponent
+    },
+    {
+      path: '',
+      component: HomeComponent,
+    },
+    {
+      path: 'ssg',
+      component: SsgComponent,
+    },
+    {
+      path: 'ssr',
+      component: SsrComponent,
+    },
+    {
+      path: 'csr',
+      component: CsrComponent,
+    },
+    {
+      path: 'redirect',
+      redirectTo: 'ssg'
+    },
+    {
+      path: 'ssg/:id',
+      component: SsgWithParamsComponent,
+    },
+  ];
+  `,
+  );
+
+  // Add server routing
+  await writeFile(
+    'src/app/app.routes.server.ts',
+    `
+  import { RenderMode, ServerRoute } from '@angular/ssr';
+
+  export const routes: ServerRoute[] = [
+    {
+      path: 'ssg/:id',
+      renderMode: RenderMode.Prerender,
+      headers: { 'x-custom': 'ssg-with-params' },
+      getPrerenderParams: async() => [{id: 'one'}, {id: 'two'}],
+    },
+    {
+      path: 'ssr',
+      renderMode: RenderMode.Server,
+      headers: { 'x-custom': 'ssr' },
+    },
+    {
+      path: 'csr',
+      renderMode: RenderMode.Client,
+      headers: { 'x-custom': 'csr' },
+    },
+    {
+      path: 'app-shell',
+      renderMode: RenderMode.AppShell,
+    },
+    {
+      path: '**',
+      renderMode: RenderMode.Prerender,
+      headers: { 'x-custom': 'ssg' },
+    },
+  ];
+  `,
+  );
+
+  // Generate components for the above routes
+  const componentNames: string[] = ['home', 'ssg', 'ssg-with-params', 'csr', 'ssr', 'app-shell'];
+
+  for (const componentName of componentNames) {
+    await silentNg('generate', 'component', componentName);
+  }
+
+  await noSilentNg('build', '--output-mode=server');
+
+  const expects: Record<string, string> = {
+    'index.html': 'home works!',
+    'ssg/index.html': 'ssg works!',
+    'ssg/one/index.html': 'ssg-with-params works!',
+    'ssg/two/index.html': 'ssg-with-params works!',
+  };
+
+  for (const [filePath, fileMatch] of Object.entries(expects)) {
+    await expectFileToMatch(join('dist/test-project/browser', filePath), fileMatch);
+  }
+
+  const filesDoNotExist: string[] = ['csr/index.html', 'ssr/index.html', 'redirect/index.html'];
+  for (const filePath of filesDoNotExist) {
+    const file = join('dist/test-project/browser', filePath);
+    assert.equal(existsSync(file), false, `Expected '${file}' to not exist.`);
+  }
+
+  // Tests responses
+  const responseExpects: Record<
+    string,
+    { headers: Record<string, string>; content: string; serverContext: string }
+  > = {
+    '/': {
+      content: 'home works',
+      serverContext: 'ng-server-context="ssg"',
+      headers: {
+        'x-custom': 'ssg',
+      },
+    },
+    '/ssg': {
+      content: 'ssg works!',
+      serverContext: 'ng-server-context="ssg"',
+      headers: {
+        'x-custom': 'ssg',
+      },
+    },
+    '/ssr': {
+      content: 'ssr works!',
+      serverContext: 'ng-server-context="ssr"',
+      headers: {
+        'x-custom': 'ssr',
+      },
+    },
+    '/csr': {
+      content: 'app-shell works',
+      serverContext: 'ng-server-context="app-shell"',
+      headers: {
+        'x-custom': 'csr',
+      },
+    },
+  };
+
+  const port = await spawnServer();
+  for (const [pathname, { content, headers, serverContext }] of Object.entries(responseExpects)) {
+    const res = await fetch(`http://localhost:${port}${pathname}`);
+    const text = await res.text();
+
+    assert.match(
+      text,
+      new RegExp(content),
+      `Response for '${pathname}': ${content} was not matched in content.`,
+    );
+
+    assert.match(
+      text,
+      new RegExp(serverContext),
+      `Response for '${pathname}': ${serverContext} was not matched in content.`,
+    );
+
+    for (const [name, value] of Object.entries(headers)) {
+      assert.equal(
+        res.headers.get(name),
+        value,
+        `Response for '${pathname}': ${name} header value did not match expected.`,
+      );
+    }
+  }
+}

--- a/tests/legacy-cli/e2e/tests/server-rendering/server-routes-output-mode-static.ts
+++ b/tests/legacy-cli/e2e/tests/server-rendering/server-routes-output-mode-static.ts
@@ -1,0 +1,103 @@
+import { join } from 'node:path';
+import { expectFileToMatch, replaceInFile, writeFile } from '../../utils/fs';
+import { noSilentNg, silentNg } from '../../utils/process';
+import { setupProjectWithSSRAppEngine } from './setup';
+import { existsSync } from 'node:fs';
+import { expectToFail } from '../../utils/utils';
+import assert from 'node:assert';
+
+export default async function () {
+  // Setup project
+  await setupProjectWithSSRAppEngine();
+
+  // Add routes
+  await writeFile(
+    'src/app/app.routes.ts',
+    `
+  import { Routes } from '@angular/router';
+  import { HomeComponent } from './home/home.component';
+  import { SsgComponent } from './ssg/ssg.component';
+  import { SsgWithParamsComponent } from './ssg-with-params/ssg-with-params.component';
+
+  export const routes: Routes = [
+    {
+      path: '',
+      component: HomeComponent,
+    },
+    {
+      path: 'ssg',
+      component: SsgComponent,
+    },
+    {
+      path: 'ssg-redirect',
+      redirectTo: 'ssg'
+    },
+    {
+      path: 'ssg/:id',
+      component: SsgWithParamsComponent,
+    },
+  ];
+  `,
+  );
+
+  // Add server routing
+  await writeFile(
+    'src/app/app.routes.server.ts',
+    `
+  import { RenderMode, ServerRoute } from '@angular/ssr';
+
+  export const routes: ServerRoute[] = [
+    {
+      path: 'ssg/:id',
+      renderMode: RenderMode.Prerender,
+      getPrerenderParams: async() => [{id: 'one'}, {id: 'two'}],
+    },
+    {
+      path: '**',
+      renderMode: RenderMode.Server,
+    },
+  ];
+  `,
+  );
+
+  // Generate components for the above routes
+  const componentNames: string[] = ['home', 'ssg', 'ssg-with-params'];
+
+  for (const componentName of componentNames) {
+    await silentNg('generate', 'component', componentName);
+  }
+
+  // Should error as above we set `RenderMode.Server`
+  const { message: errorMessage } = await expectToFail(() =>
+    noSilentNg('build', '--output-mode=static'),
+  );
+  assert.match(
+    errorMessage,
+    new RegExp(
+      `Route '/' is configured with server render mode, but the build 'outputMode' is set to 'static'.`,
+    ),
+  );
+
+  // Fix the error
+  await replaceInFile('src/app/app.routes.server.ts', 'RenderMode.Server', 'RenderMode.Prerender');
+  await noSilentNg('build', '--output-mode=static');
+
+  const expects: Record<string, string> = {
+    'index.html': 'home works!',
+    'ssg/index.html': 'ssg works!',
+    'ssg/one/index.html': 'ssg-with-params works!',
+    'ssg/two/index.html': 'ssg-with-params works!',
+    // When static redirects as generated as meta tags.
+    'ssg-redirect/index.html': '<meta http-equiv="refresh" content="0; url=/ssg">',
+  };
+
+  for (const [filePath, fileMatch] of Object.entries(expects)) {
+    await expectFileToMatch(join('dist/test-project/browser', filePath), fileMatch);
+  }
+
+  // Check that server directory does not exist
+  assert(
+    !existsSync('dist/test-project/server'),
+    'Server directory should not exist when output-mode is static',
+  );
+}

--- a/tests/legacy-cli/e2e/tests/server-rendering/setup.ts
+++ b/tests/legacy-cli/e2e/tests/server-rendering/setup.ts
@@ -1,0 +1,127 @@
+import { getGlobalVariable } from '../../utils/env';
+import { writeFile } from '../../utils/fs';
+import { findFreePort } from '../../utils/network';
+import { installWorkspacePackages, uninstallPackage } from '../../utils/packages';
+import { execAndWaitForOutputToMatch, ng } from '../../utils/process';
+import { updateJsonFile, useSha } from '../../utils/project';
+import assert from 'node:assert';
+
+export async function spawnServer(): Promise<number> {
+  const port = await findFreePort();
+  await execAndWaitForOutputToMatch(
+    'npm',
+    ['run', 'serve:ssr:test-project'],
+    /Node Express server listening on/,
+    {
+      'PORT': String(port),
+    },
+  );
+
+  return port;
+}
+
+export async function setupProjectWithSSRAppEngine(): Promise<void> {
+  assert(
+    getGlobalVariable('argv')['esbuild'],
+    'This test should not be called in the Webpack suite.',
+  );
+
+  // Forcibly remove in case another test doesn't clean itself up.
+  await uninstallPackage('@angular/ssr');
+  await ng('add', '@angular/ssr', '--skip-confirmation', '--skip-install');
+
+  await useSha();
+  await installWorkspacePackages();
+
+  // Add server config
+  await writeFile(
+    'src/app/app.config.server.ts',
+    `
+    import { mergeApplicationConfig, ApplicationConfig } from '@angular/core';
+    import { provideServerRendering } from '@angular/platform-server';
+    import { provideServerRoutesConfig } from '@angular/ssr';
+    import { routes } from './app.routes.server';
+    import { appConfig } from './app.config';
+
+    const serverConfig: ApplicationConfig = {
+      providers: [
+        provideServerRoutesConfig(routes),
+        provideServerRendering()
+      ]
+    };
+
+    export const config = mergeApplicationConfig(appConfig, serverConfig);
+  `,
+  );
+
+  // Update server.ts
+  await writeFile(
+    'server.ts',
+    `
+  import { AngularNodeAppEngine, writeResponseToNodeResponse } from '@angular/ssr/node';
+  import express from 'express';
+  import { fileURLToPath } from 'node:url';
+  import { dirname, resolve } from 'node:path';
+
+  // The Express app is exported so that it can be used by serverless Functions.
+  export function app(): express.Express {
+    const server = express();
+    const serverDistFolder = dirname(fileURLToPath(import.meta.url));
+    const browserDistFolder = resolve(serverDistFolder, '../browser');
+
+    const angularNodeAppEngine = new AngularNodeAppEngine();
+
+    server.set('view engine', 'html');
+    server.set('views', browserDistFolder);
+
+    server.get('**', express.static(browserDistFolder, {
+      maxAge: '1y',
+      index: 'index.html',
+      setHeaders: (res, path) => {
+        const headers = angularNodeAppEngine.getPrerenderHeaders(res.req);
+        for (const [key, value] of headers) {
+          res.setHeader(key, value);
+        }
+      }
+    }));
+
+    // All regular routes use the Angular engine
+    server.get('**', (req, res, next) => {
+      angularNodeAppEngine
+        .render(req)
+        .then((response) => {
+          if (response) {
+            return writeResponseToNodeResponse(response, res);
+          }
+
+          return next();
+        })
+        .catch((err) => next(err));
+    });
+
+    return server;
+  }
+
+  function run(): void {
+    const port = process.env['PORT'] || 4000;
+
+    // Start up the Node server
+    const server = app();
+    server.listen(port, () => {
+      console.log(\`Node Express server listening on http://localhost:\${port}\`);
+    });
+  }
+
+  run();
+`,
+  );
+
+  // Update angular.json
+  await updateJsonFile('angular.json', (workspaceJson) => {
+    const appArchitect = workspaceJson.projects['test-project'].architect;
+    const options = appArchitect.build.options;
+
+    delete options.prerender;
+    delete options.appShell;
+  });
+}


### PR DESCRIPTION
The `outputMode` option defines the build output target, offering two modes:
- `'static'`: Generates a static site suitable for deployment on any static hosting service. This mode can produce a fully client-side rendered (CSR) or static site generated (SSG) site. When SSG is enabled, redirects are handled using the `<meta>` tag.
- `'server'`: Produces an application designed for deployment on a server that supports server-side rendering (SSR) or a hybrid approach.

Additionally, the `outputMode` option determines whether the new API is used. If enabled, it bundles the `server.ts` as a separate entry point, preventing it from directly referencing `main.server.ts` and excluding it from localization.

This option will replace `appShell` and `prerendering` when server routing configuration is present.

closes https://github.com/angular/angular-cli/issues/27356
closes https://github.com/angular/angular-cli/issues/27403
closes https://github.com/angular/angular-cli/issues/25726
closes https://github.com/angular/angular-cli/issues/25718 
closes https://github.com/angular/angular-cli/issues/27196