### PR TITLE
perf(@angular/cli): enable Node.js compile code cache when available

### DIFF
--- a/packages/angular/build/src/tools/angular/compilation/parallel-compilation.ts
+++ b/packages/angular/build/src/tools/angular/compilation/parallel-compilation.ts
@@ -8,7 +8,7 @@
 
 import type { CompilerOptions } from '@angular/compiler-cli';
 import type { PartialMessage } from 'esbuild';
-import { createRequire } from 'node:module';
+import { createRequire, getCompileCacheDir } from 'node:module';
 import { MessageChannel } from 'node:worker_threads';
 import Piscina from 'piscina';
 import type { SourceFile } from 'typescript';
@@ -41,6 +41,11 @@ export class ParallelCompilation extends AngularCompilation {
       useAtomics: !process.versions.webcontainer,
       filename: localRequire.resolve('./parallel-worker'),
       recordTiming: false,
+      env: {
+        ...process.env,
+        // Enable compile code caching if enabled for the main process (only exists on Node.js v22.8+)
+        'NODE_COMPILE_CACHE': getCompileCacheDir?.(),
+      },
     });
   }
 

--- a/packages/angular/build/src/tools/esbuild/javascript-transformer.ts
+++ b/packages/angular/build/src/tools/esbuild/javascript-transformer.ts
@@ -8,6 +8,7 @@
 
 import { createHash } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
+import { getCompileCacheDir } from 'node:module';
 import Piscina from 'piscina';
 import { Cache } from './cache';
 
@@ -62,6 +63,11 @@ export class JavaScriptTransformer {
       // Shutdown idle threads after 1 second of inactivity
       idleTimeout: 1000,
       recordTiming: false,
+      env: {
+        ...process.env,
+        // Enable compile code caching if enabled for the main process (only exists on Node.js v22.8+)
+        'NODE_COMPILE_CACHE': getCompileCacheDir?.(),
+      },
     });
 
     return this.#workerPool;

--- a/packages/angular/build/src/tools/sass/sass-service.ts
+++ b/packages/angular/build/src/tools/sass/sass-service.ts
@@ -7,6 +7,7 @@
  */
 
 import assert from 'node:assert';
+import { getCompileCacheDir } from 'node:module';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { MessageChannel } from 'node:worker_threads';
 import { Piscina } from 'piscina';
@@ -101,6 +102,11 @@ export class SassWorkerImplementation {
       // Shutdown idle threads after 1 second of inactivity
       idleTimeout: 1000,
       recordTiming: false,
+      env: {
+        ...process.env,
+        // Enable compile code caching if enabled for the main process (only exists on Node.js v22.8+)
+        'NODE_COMPILE_CACHE': getCompileCacheDir?.(),
+      },
     });
 
     return this.#workerPool;

--- a/packages/angular/build/src/typings.d.ts
+++ b/packages/angular/build/src/typings.d.ts
@@ -17,3 +17,10 @@
 declare module 'esbuild' {
   export * from 'esbuild-wasm';
 }
+
+/**
+ * Augment the Node.js module builtin types to support the v22.8+ compile cache functions
+ */
+declare module 'node:module' {
+  function getCompileCacheDir(): string | undefined;
+}

--- a/packages/angular/cli/bin/bootstrap.js
+++ b/packages/angular/cli/bin/bootstrap.js
@@ -18,4 +18,12 @@
  * range.
  */
 
-import('../lib/init.js');
+// Enable on-disk code caching if available (Node.js 22.8+)
+try {
+  const { enableCompileCache } = require('node:module');
+
+  enableCompileCache?.();
+} catch {}
+
+// Initialize the Angular CLI
+void import('../lib/init.js');


### PR DESCRIPTION
The Angular CLI will now enable the Node.js compile cache when available for use. Node.js v22.8 and higher currently provide support for this feature. The compile cache stores the v8 intermediate forms of JavaScript code for the Angular CLI itself. This provides a speed up to initialization on subsequent uses the Angular CLI. The Node.js cache is stored in a temporary directory in a globally accessible location so that all Node.js instances of a compatible version can share the cache. The code cache can be disabled if preferred via `NODE_DISABLE_COMPILE_CACHE=1`.

Based on initial profiling, this change provides an ~6% production build time improvement for a newly generated project once the cache is available.

```
Benchmark 1: NODE_DISABLE_COMPILE_CACHE=1 node ./node_modules/.bin/ng build
  Time (mean ± σ):      2.617 s ±  0.016 s    [User: 3.795 s, System: 1.284 s]
  Range (min … max):    2.597 s …  2.640 s    10 runs

Benchmark 2: node ./node_modules/.bin/ng build
  Time (mean ± σ):      2.475 s ±  0.017 s    [User: 3.555 s, System: 1.354 s]
  Range (min … max):    2.454 s …  2.510 s    10 runs

Summary
  node ./node_modules/.bin/ng build ran
    1.06 ± 0.01 times faster than NODE_DISABLE_COMPILE_CACHE=1 node ./node_modules/.bin/ng build
```