### PR TITLE
feat(@angular-devkit/architect): merge object options from CLI

### DIFF
--- a/packages/angular_devkit/architect/src/architect.ts
+++ b/packages/angular_devkit/architect/src/architect.ts
@@ -45,6 +45,7 @@ import {
   SimpleScheduler,
   createJobHandler,
 } from './jobs';
+import { mergeOptions } from './options';
 import { scheduleByName, scheduleByTarget } from './schedule-by-name';
 
 const inputSchema = require('./input-schema.json');
@@ -71,10 +72,7 @@ function _createJobHandlerFromBuilderInfo(
       concatMap(async (message) => {
         if (message.kind === JobInboundMessageKind.Input) {
           const v = message.value as BuilderInput;
-          const options = {
-            ...baseOptions,
-            ...v.options,
-          };
+          const options = mergeOptions(baseOptions, v.options);
 
           // Validate v against the options schema.
           const validation = await registry.compile(info.optionSchema);

--- a/packages/angular_devkit/architect/src/options.ts
+++ b/packages/angular_devkit/architect/src/options.ts
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { json } from '@angular-devkit/core';
+
+import { BuilderInput } from './api';
+
+type OverrideOptions = BuilderInput['options'];
+
+export function mergeOptions(
+  baseOptions: json.JsonObject,
+  overrideOptions: OverrideOptions,
+): json.JsonObject {
+  if (!overrideOptions) {
+    return { ...baseOptions };
+  }
+
+  const options = {
+    ...baseOptions,
+    ...overrideOptions,
+  };
+
+  // For object-object overrides, we merge one layer deep.
+  for (const key of Object.keys(overrideOptions)) {
+    const override = overrideOptions[key];
+    const base = baseOptions[key];
+
+    if (json.isJsonObject(base) && json.isJsonObject(override)) {
+      options[key] = { ...base, ...override };
+    }
+  }
+
+  return options;
+}

--- a/packages/angular_devkit/architect/src/options_spec.ts
+++ b/packages/angular_devkit/architect/src/options_spec.ts
@@ -1,0 +1,70 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { mergeOptions } from './options';
+
+describe('mergeOptions', () => {
+  it('overwrites literal values', () => {
+    expect(
+      mergeOptions(
+        {
+          onlyBase: 'base',
+          a: 'foo',
+          b: 42,
+          c: true,
+        },
+        {
+          onlyOverride: 'override',
+          a: 'bar',
+          b: 43,
+          c: false,
+        },
+      ),
+    ).toEqual({
+      onlyBase: 'base',
+      a: 'bar',
+      b: 43,
+      c: false,
+      onlyOverride: 'override',
+    });
+  });
+
+  it('merges object values one layer deep', () => {
+    expect(
+      mergeOptions(
+        {
+          obj: {
+            nested: {
+              fromBase: true,
+            },
+            fromBase: true,
+            overridden: false,
+          },
+        },
+        {
+          obj: {
+            nested: {
+              fromOverride: true,
+            },
+            overridden: true,
+            fromOverride: true,
+          },
+        },
+      ),
+    ).toEqual({
+      obj: {
+        nested: {
+          fromOverride: true,
+        },
+        fromBase: true,
+        overridden: true,
+        fromOverride: true,
+      },
+    });
+  });
+});


### PR DESCRIPTION
We recently introduced the ability to pass object values from the command line (#28362). @clydin noticed that the initial behavior didn't work well for `--define`: It completely replaced all values even if just one of multiple defines is specified.

This updates the architect to support merging of object options. If both the base option (e.g. from `angular.json`) and the override (e.g. from a CLI `--flag`) are objects, the objects are merged.

See: https://github.com/angular/angular-cli/pull/28362

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [ ] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

With multiple `define`s in `angular.json`, passing any define via the `--define` flag will ignore all existing defines.

## What is the new behavior?

<!-- Please describe the new behavior that. -->

Only defines specified via the `--define` flag will be replaced. All others retain the value specified in `angular.json`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
