### PR TITLE
refactor(ssr): use `ReadonlyMap` instead of `Readonly` mapped type

### DIFF
--- a/goldens/public-api/angular/ssr/index.api.md
+++ b/goldens/public-api/angular/ssr/index.api.md
@@ -6,7 +6,7 @@
 
 // @public
 export class AngularAppEngine {
-    getHeaders(request: Request): Readonly<Map<string, string>>;
+    getHeaders(request: Request): ReadonlyMap<string, string>;
     render(request: Request, requestContext?: unknown): Promise<Response | null>;
     static ɵhooks: Hooks;
 }

--- a/goldens/public-api/angular/ssr/node/index.api.md
+++ b/goldens/public-api/angular/ssr/node/index.api.md
@@ -12,7 +12,7 @@ import { Type } from '@angular/core';
 
 // @public
 export class AngularNodeAppEngine {
-    getHeaders(request: IncomingMessage): Readonly<Map<string, string>>;
+    getHeaders(request: IncomingMessage): ReadonlyMap<string, string>;
     render(request: IncomingMessage, requestContext?: unknown): Promise<Response | null>;
 }
 

--- a/packages/angular/ssr/node/src/app-engine.ts
+++ b/packages/angular/ssr/node/src/app-engine.ts
@@ -66,7 +66,7 @@ export class AngularNodeAppEngine {
      }));
   * ```
   */
-  getHeaders(request: IncomingMessage): Readonly<Map<string, string>> {
+  getHeaders(request: IncomingMessage): ReadonlyMap<string, string> {
     return this.angularAppEngine.getHeaders(createWebRequestFromNodeRequest(request));
   }
 }

--- a/packages/angular/ssr/src/app-engine.ts
+++ b/packages/angular/ssr/src/app-engine.ts
@@ -110,7 +110,7 @@ export class AngularAppEngine {
    * @returns A `Map` containing the HTTP headers as key-value pairs.
    * @note This function should be used exclusively for retrieving headers of SSG pages.
    */
-  getHeaders(request: Request): Readonly<Map<string, string>> {
+  getHeaders(request: Request): ReadonlyMap<string, string> {
     if (this.manifest.staticPathsHeaders.size === 0) {
       return new Map();
     }

--- a/packages/angular/ssr/src/manifest.ts
+++ b/packages/angular/ssr/src/manifest.ts
@@ -36,7 +36,7 @@ export interface AngularAppEngineManifest {
    * - `key`: The base href for the entry point.
    * - `value`: A function that returns a promise resolving to an object of type `EntryPointExports`.
    */
-  readonly entryPoints: Readonly<Map<string, () => Promise<EntryPointExports>>>;
+  readonly entryPoints: ReadonlyMap<string, () => Promise<EntryPointExports>>;
 
   /**
    * The base path for the server application.
@@ -52,8 +52,9 @@ export interface AngularAppEngineManifest {
    *   - `headerName`: The name of the HTTP header.
    *   - `headerValue`: The value of the HTTP header.
    */
-  readonly staticPathsHeaders: Readonly<
-    Map<string, readonly [headerName: string, headerValue: string][]>
+  readonly staticPathsHeaders: ReadonlyMap<
+    string,
+    readonly [headerName: string, headerValue: string][]
   >;
 }
 
@@ -67,7 +68,7 @@ export interface AngularAppManifest {
    * - `key`: The path of the asset.
    * - `value`: A function returning a promise that resolves to the file contents of the asset.
    */
-  readonly assets: Readonly<Map<string, () => Promise<string>>>;
+  readonly assets: ReadonlyMap<string, () => Promise<string>>;
 
   /**
    * The bootstrap mechanism for the server application.


### PR DESCRIPTION
The `Readonly` mapped type only introduces the `readonly` modifier for each property, but `Map` has mutating methods like `clear`, `delete` and `set` that would still remain usable. This commit switches those usages over to the `ReadonlyMap` type which doesn't have any of the mutating methods.
