### PR TITLE
fix(@angular/ssr): resolve `bootstrap is not a function` error

### DIFF
--- a/packages/angular/ssr/src/routes/ng-routes.ts
+++ b/packages/angular/ssr/src/routes/ng-routes.ts
@@ -276,11 +276,8 @@ export async function extractRoutesAndCreateRouteTree(
 ): Promise<RouteTree> {
   const routeTree = new RouteTree();
   const document = await new ServerAssets(manifest).getIndexServerHtml();
-  const { baseHref, routes } = await getRoutesFromAngularRouterConfig(
-    await manifest.bootstrap(),
-    document,
-    url,
-  );
+  const bootstrap = await manifest.bootstrap();
+  const { baseHref, routes } = await getRoutesFromAngularRouterConfig(bootstrap, document, url);
 
   for (let { route, redirectTo } of routes) {
     route = joinUrlParts(baseHref, route);


### PR DESCRIPTION
In cases where the application is not zoneless and async/await is downleveled, an issue occurred where `await` was not being downleveled correctly. This led to the `bootstrap is not a function` error.

See: https://github.com/angular/angular/actions/runs/10817795242/job/30014914340?pr=57776
