### PR TITLE
Revert "perf(@angular/cli): enable Node.js compile code cache when available

### DIFF
--- a/packages/angular/build/src/tools/angular/compilation/parallel-compilation.ts
+++ b/packages/angular/build/src/tools/angular/compilation/parallel-compilation.ts
@@ -8,7 +8,7 @@
 
 import type { CompilerOptions } from '@angular/compiler-cli';
 import type { PartialMessage } from 'esbuild';
-import { createRequire, getCompileCacheDir } from 'node:module';
+import { createRequire } from 'node:module';
 import { MessageChannel } from 'node:worker_threads';
 import Piscina from 'piscina';
 import type { SourceFile } from 'typescript';
@@ -41,11 +41,6 @@ export class ParallelCompilation extends AngularCompilation {
       useAtomics: !process.versions.webcontainer,
       filename: localRequire.resolve('./parallel-worker'),
       recordTiming: false,
-      env: {
-        ...process.env,
-        // Enable compile code caching if enabled for the main process (only exists on Node.js v22.8+)
-        'NODE_COMPILE_CACHE': getCompileCacheDir?.(),
-      },
     });
   }
 

--- a/packages/angular/build/src/tools/esbuild/javascript-transformer.ts
+++ b/packages/angular/build/src/tools/esbuild/javascript-transformer.ts
@@ -8,7 +8,6 @@
 
 import { createHash } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
-import { getCompileCacheDir } from 'node:module';
 import Piscina from 'piscina';
 import { Cache } from './cache';
 
@@ -63,11 +62,6 @@ export class JavaScriptTransformer {
       // Shutdown idle threads after 1 second of inactivity
       idleTimeout: 1000,
       recordTiming: false,
-      env: {
-        ...process.env,
-        // Enable compile code caching if enabled for the main process (only exists on Node.js v22.8+)
-        'NODE_COMPILE_CACHE': getCompileCacheDir?.(),
-      },
     });
 
     return this.#workerPool;

--- a/packages/angular/build/src/tools/sass/sass-service.ts
+++ b/packages/angular/build/src/tools/sass/sass-service.ts
@@ -7,7 +7,6 @@
  */
 
 import assert from 'node:assert';
-import { getCompileCacheDir } from 'node:module';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { MessageChannel } from 'node:worker_threads';
 import { Piscina } from 'piscina';
@@ -103,11 +102,6 @@ export class SassWorkerImplementation {
       // Shutdown idle threads after 1 second of inactivity
       idleTimeout: 1000,
       recordTiming: false,
-      env: {
-        ...process.env,
-        // Enable compile code caching if enabled for the main process (only exists on Node.js v22.8+)
-        'NODE_COMPILE_CACHE': getCompileCacheDir?.(),
-      },
     });
 
     return this.#workerPool;

--- a/packages/angular/build/src/typings.d.ts
+++ b/packages/angular/build/src/typings.d.ts
@@ -17,10 +17,3 @@
 declare module 'esbuild' {
   export * from 'esbuild-wasm';
 }
-
-/**
- * Augment the Node.js module builtin types to support the v22.8+ compile cache functions
- */
-declare module 'node:module' {
-  function getCompileCacheDir(): string | undefined;
-}

--- a/packages/angular/cli/bin/bootstrap.js
+++ b/packages/angular/cli/bin/bootstrap.js
@@ -18,12 +18,4 @@
  * range.
  */
 
-// Enable on-disk code caching if available (Node.js 22.8+)
-try {
-  const { enableCompileCache } = require('node:module');
-
-  enableCompileCache?.();
-} catch {}
-
-// Initialize the Angular CLI
-void import('../lib/init.js');
+import('../lib/init.js');


### PR DESCRIPTION

This reverts commit `ecc107d83bfdfd9d5dd1087e264892d60361625c`.

Passing a custom `process.env` to Piscina causes Bazel to fail, leading to path leaks and sandbox escapes.

As a result, `adev` builds encounter errors such as:
```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@angular/compiler-cli' imported from /home/runner/work/angular/angular/node_modules/@angular/build/src/utils/load-esm.js
```

Further investigation is needed to determine if this is a bug in Piscina or another underlying issue. For now, the change has been reverted to allow the FW repo to update to the latest version of the CLI packages.
