### PR TITLE
fix(@angular/ssr): correct route extraction and error handling

### DIFF
--- a/packages/angular/build/src/utils/server-rendering/prerender.ts
+++ b/packages/angular/build/src/utils/server-rendering/prerender.ts
@@ -15,8 +15,9 @@ import { BuildOutputAsset } from '../../tools/esbuild/bundler-execution-result';
 import { urlJoin } from '../url';
 import type { RenderWorkerData } from './render-worker';
 import type {
+  RoutersExtractorWorkerResult,
   RoutesExtractorWorkerData,
-  RoutersExtractorWorkerResult as SerializableRouteTreeNode,
+  SerializableRouteTreeNode,
 } from './routes-extractor-worker';
 
 interface PrerenderOptions {
@@ -298,14 +299,15 @@ async function getAllRoutes(
   });
 
   const errors: string[] = [];
-  const serializableRouteTreeNode: SerializableRouteTreeNode = await renderWorker
-    .run({})
-    .catch((err) => {
-      errors.push(`An error occurred while extracting routes.\n\n${err.stack}`);
-    })
-    .finally(() => {
-      void renderWorker.destroy();
-    });
+  const { serializedRouteTree: serializableRouteTreeNode }: RoutersExtractorWorkerResult =
+    await renderWorker
+      .run({})
+      .catch((err) => {
+        errors.push(`An error occurred while extracting routes.\n\n${err.stack}`);
+      })
+      .finally(() => {
+        void renderWorker.destroy();
+      });
 
   const skippedRedirects: string[] = [];
   const skippedOthers: string[] = [];

--- a/packages/angular/ssr/node/src/app-engine.ts
+++ b/packages/angular/ssr/node/src/app-engine.ts
@@ -59,7 +59,7 @@ export class AngularNodeAppEngine {
    *     const headers = angularAppEngine.getPrerenderHeaders(res.req);
    *
    *     // Apply the retrieved headers to the response
-   *     for (const { key, value } of headers) {
+   *     for (const [key, value] of headers) {
    *       res.setHeader(key, value);
    *     }
    *   }

--- a/packages/angular/ssr/src/routes/route-tree.ts
+++ b/packages/angular/ssr/src/routes/route-tree.ts
@@ -131,8 +131,7 @@ export class RouteTree<AdditionalMetadata extends Record<string, unknown> = {}> 
    */
   insert(route: string, metadata: RouteTreeNodeMetadataWithoutRoute & AdditionalMetadata): void {
     let node = this.root;
-    const normalizedRoute = stripTrailingSlash(route);
-    const segments = normalizedRoute.split('/');
+    const segments = this.getPathSegments(route);
 
     for (const segment of segments) {
       // Replace parameterized segments (e.g., :id) with a wildcard (*) for matching
@@ -150,7 +149,7 @@ export class RouteTree<AdditionalMetadata extends Record<string, unknown> = {}> 
     // At the leaf node, store the full route and its associated metadata
     node.metadata = {
       ...metadata,
-      route: normalizedRoute,
+      route: segments.join('/'),
     };
 
     node.insertionIndex = this.insertionIndexCounter++;
@@ -165,7 +164,7 @@ export class RouteTree<AdditionalMetadata extends Record<string, unknown> = {}> 
    * @returns The metadata of the best matching route or `undefined` if no match is found.
    */
   match(route: string): (RouteTreeNodeMetadata & AdditionalMetadata) | undefined {
-    const segments = stripTrailingSlash(route).split('/');
+    const segments = this.getPathSegments(route);
 
     return this.traverseBySegments(segments)?.metadata;
   }
@@ -216,6 +215,16 @@ export class RouteTree<AdditionalMetadata extends Record<string, unknown> = {}> 
     for (const childNode of node.children.values()) {
       yield* this.traverse(childNode);
     }
+  }
+
+  /**
+   * Extracts the path segments from a given route string.
+   *
+   * @param route - The route string from which to extract segments.
+   * @returns An array of path segments.
+   */
+  private getPathSegments(route: string): string[] {
+    return stripTrailingSlash(route).split('/');
   }
 
   /**

--- a/packages/angular/ssr/src/routes/router.ts
+++ b/packages/angular/ssr/src/routes/router.ts
@@ -55,7 +55,16 @@ export class ServerRouter {
     // Create and store a new promise for the build process.
     // This prevents concurrent builds by re-using the same promise.
     ServerRouter.#extractionPromise ??= extractRoutesAndCreateRouteTree(url, manifest)
-      .then((routeTree) => new ServerRouter(routeTree))
+      .then(({ routeTree, errors }) => {
+        if (errors.length > 0) {
+          throw new Error(
+            'Error(s) occurred while extracting routes:\n' +
+              errors.map((error) => `- ${error}`).join('\n'),
+          );
+        }
+
+        return new ServerRouter(routeTree);
+      })
       .finally(() => {
         ServerRouter.#extractionPromise = undefined;
       });

--- a/packages/angular/ssr/src/utils/url.ts
+++ b/packages/angular/ssr/src/utils/url.ts
@@ -16,11 +16,49 @@
  * ```js
  * stripTrailingSlash('path/'); // 'path'
  * stripTrailingSlash('/path');  // '/path'
+ * stripTrailingSlash('/'); // '/'
+ * stripTrailingSlash(''); // ''
  * ```
  */
 export function stripTrailingSlash(url: string): string {
   // Check if the last character of the URL is a slash
-  return url[url.length - 1] === '/' ? url.slice(0, -1) : url;
+  return url.length > 1 && url[url.length - 1] === '/' ? url.slice(0, -1) : url;
+}
+
+/**
+ * Removes the leading slash from a URL if it exists.
+ *
+ * @param url - The URL string from which to remove the leading slash.
+ * @returns The URL string without a leading slash.
+ *
+ * @example
+ * ```js
+ * stripLeadingSlash('/path'); // 'path'
+ * stripLeadingSlash('/path/');  // 'path/'
+ * stripLeadingSlash('/'); // '/'
+ * stripLeadingSlash(''); // ''
+ * ```
+ */
+export function stripLeadingSlash(url: string): string {
+  // Check if the first character of the URL is a slash
+  return url.length > 1 && url[0] === '/' ? url.slice(1) : url;
+}
+
+/**
+ * Adds a leading slash to a URL if it does not already have one.
+ *
+ * @param url - The URL string to which the leading slash will be added.
+ * @returns The URL string with a leading slash.
+ *
+ * @example
+ * ```js
+ * addLeadingSlash('path'); // '/path'
+ * addLeadingSlash('/path'); // '/path'
+ * ```
+ */
+export function addLeadingSlash(url: string): string {
+  // Check if the URL already starts with a slash
+  return url[0] === '/' ? url : `/${url}`;
 }
 
 /**
@@ -36,12 +74,11 @@ export function stripTrailingSlash(url: string): string {
  * ```js
  * joinUrlParts('path/', '/to/resource'); // '/path/to/resource'
  * joinUrlParts('/path/', 'to/resource'); // '/path/to/resource'
+ * joinUrlParts('', ''); // '/'
  * ```
  */
 export function joinUrlParts(...parts: string[]): string {
-  // Initialize an array with an empty string to always add a leading slash
-  const normalizeParts: string[] = [''];
-
+  const normalizeParts: string[] = [];
   for (const part of parts) {
     if (part === '') {
       // Skip any empty parts
@@ -60,7 +97,7 @@ export function joinUrlParts(...parts: string[]): string {
     }
   }
 
-  return normalizeParts.join('/');
+  return addLeadingSlash(normalizeParts.join('/'));
 }
 
 /**

--- a/packages/angular/ssr/test/app-engine_spec.ts
+++ b/packages/angular/ssr/test/app-engine_spec.ts
@@ -41,7 +41,7 @@ describe('AngularAppEngine', () => {
 
               setAngularAppTestingManifest(
                 [{ path: 'home', component: HomeComponent }],
-                [{ path: '/**', renderMode: RenderMode.Server }],
+                [{ path: '**', renderMode: RenderMode.Server }],
                 locale,
               );
 
@@ -150,7 +150,7 @@ describe('AngularAppEngine', () => {
 
               setAngularAppTestingManifest(
                 [{ path: 'home', component: HomeComponent }],
-                [{ path: '/**', renderMode: RenderMode.Server }],
+                [{ path: '**', renderMode: RenderMode.Server }],
               );
 
               return {

--- a/packages/angular/ssr/test/app_spec.ts
+++ b/packages/angular/ssr/test/app_spec.ts
@@ -41,16 +41,16 @@ describe('AngularServerApp', () => {
       ],
       [
         {
-          path: '/home-csr',
+          path: 'home-csr',
           renderMode: RenderMode.Client,
         },
         {
-          path: '/page-with-status',
+          path: 'page-with-status',
           renderMode: RenderMode.Server,
           status: 201,
         },
         {
-          path: '/page-with-headers',
+          path: 'page-with-headers',
           renderMode: RenderMode.Server,
           headers: {
             'Cache-Control': 'no-cache',
@@ -58,7 +58,7 @@ describe('AngularServerApp', () => {
           },
         },
         {
-          path: '/**',
+          path: '**',
           renderMode: RenderMode.Server,
         },
       ],

--- a/packages/angular/ssr/test/routes/router_spec.ts
+++ b/packages/angular/ssr/test/routes/router_spec.ts
@@ -37,8 +37,8 @@ describe('ServerRouter', () => {
         { path: 'user/:id', component: DummyComponent },
       ],
       [
-        { path: '/redirect', renderMode: RenderMode.Server, status: 301 },
-        { path: '/**', renderMode: RenderMode.Server },
+        { path: 'redirect', renderMode: RenderMode.Server, status: 301 },
+        { path: '**', renderMode: RenderMode.Server },
       ],
     );
 

--- a/packages/angular/ssr/test/utils/url_spec.ts
+++ b/packages/angular/ssr/test/utils/url_spec.ts
@@ -6,7 +6,13 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import { joinUrlParts, stripIndexHtmlFromURL, stripTrailingSlash } from '../../src/utils/url'; // Adjust the import path as needed
+import {
+  addLeadingSlash,
+  joinUrlParts,
+  stripIndexHtmlFromURL,
+  stripLeadingSlash,
+  stripTrailingSlash,
+} from '../../src/utils/url';
 
 describe('URL Utils', () => {
   describe('stripTrailingSlash', () => {
@@ -23,7 +29,39 @@ describe('URL Utils', () => {
     });
 
     it('should handle URL with only a trailing slash', () => {
-      expect(stripTrailingSlash('/')).toBe('');
+      expect(stripTrailingSlash('/')).toBe('/');
+    });
+  });
+
+  describe('stripLeadingSlash', () => {
+    it('should remove leading slash from URL', () => {
+      expect(stripLeadingSlash('/path/')).toBe('path/');
+    });
+
+    it('should not modify URL if no leading slash is present', () => {
+      expect(stripLeadingSlash('path/')).toBe('path/');
+    });
+
+    it('should handle empty URL', () => {
+      expect(stripLeadingSlash('')).toBe('');
+    });
+
+    it('should handle URL with only a leading slash', () => {
+      expect(stripLeadingSlash('/')).toBe('/');
+    });
+  });
+
+  describe('addLeadingSlash', () => {
+    it('should add a leading slash to a URL without one', () => {
+      expect(addLeadingSlash('path/')).toBe('/path/');
+    });
+
+    it('should not modify URL if it already has a leading slash', () => {
+      expect(addLeadingSlash('/path/')).toBe('/path/');
+    });
+
+    it('should handle empty URL', () => {
+      expect(addLeadingSlash('')).toBe('/');
     });
   });
 
@@ -38,6 +76,10 @@ describe('URL Utils', () => {
 
     it('should handle empty URL parts', () => {
       expect(joinUrlParts('', '', 'path', '', 'to/resource')).toBe('/path/to/resource');
+    });
+
+    it('should handle an all-empty URL parts', () => {
+      expect(joinUrlParts('', '')).toBe('/');
     });
   });
 


### PR DESCRIPTION


This commit introduces the following changes:
- Disallows paths starting with a slash to match Angular router behavior.
- Errors are now stored and displayed at a later stage, improving UX by avoiding unnecessary stack traces that are not useful in this context.