### PR TITLE
feat(@angular/ssr): add `isMainModule` function

### DIFF
--- a/goldens/public-api/angular/ssr/node/index.api.md
+++ b/goldens/public-api/angular/ssr/node/index.api.md
@@ -47,6 +47,9 @@ export interface CommonEngineRenderOptions {
 export function createWebRequestFromNodeRequest(nodeRequest: IncomingMessage): Request;
 
 // @public
+export function isMainModule(url: string): boolean;
+
+// @public
 export function writeResponseToNodeResponse(source: Response, destination: ServerResponse): Promise<void>;
 
 // (No @packageDocumentation comment for this package)

--- a/packages/angular/ssr/node/public_api.ts
+++ b/packages/angular/ssr/node/public_api.ts
@@ -16,3 +16,4 @@ export { AngularNodeAppEngine } from './src/app-engine';
 
 export { writeResponseToNodeResponse } from './src/response';
 export { createWebRequestFromNodeRequest } from './src/request';
+export { isMainModule } from './src/module';

--- a/packages/angular/ssr/node/src/module.ts
+++ b/packages/angular/ssr/node/src/module.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { argv } from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Determines whether the provided URL represents the main entry point module.
+ *
+ * This function checks if the provided URL corresponds to the main ESM module being executed directly.
+ * It's useful for conditionally executing code that should only run when a module is the entry point,
+ * such as starting a server or initializing an application.
+ *
+ * It performs two key checks:
+ * 1. Verifies if the URL starts with 'file:', ensuring it is a local file.
+ * 2. Compares the URL's resolved file path with the first command-line argument (`process.argv[1]`),
+ *    which points to the file being executed.
+ *
+ * @param url The URL of the module to check. This should typically be `import.meta.url`.
+ * @returns `true` if the provided URL represents the main entry point, otherwise `false`.
+ * @developerPreview
+ */
+export function isMainModule(url: string): boolean {
+  return url.startsWith('file:') && argv[1] === fileURLToPath(url);
+}


### PR DESCRIPTION
Adds a new function `isMainModule` that checks if the current module is the main entry point of the application.

This is useful to ensure that server listener handlers are only registered when the module is executed directly and not when it's imported as a dependency such as the dev-server. This prevents potential issues with multiple listeners being registered unintentionally.
