### PR TITLE
fix(@angular/build): support HTTP HEAD requests for virtual output files

### DIFF
--- a/packages/angular/build/src/tools/vite/middlewares/assets-middleware.ts
+++ b/packages/angular/build/src/tools/vite/middlewares/assets-middleware.ts
@@ -63,6 +63,12 @@ export function createAngularAssetsMiddleware(
       return;
     }
 
+    // Support HTTP HEAD requests for the virtual output files from the Angular build
+    if (req.method === 'HEAD' && outputFiles.get(pathname)?.servable) {
+      // While a GET will also generate content, the rest of the response is equivalent
+      req.method = 'GET';
+    }
+
     // Resource files are handled directly.
     // Global stylesheets (CSS files) are currently considered resources to workaround
     // dev server sourcemap issues with stylesheets.

--- a/tests/legacy-cli/e2e/tests/commands/serve/head-request.ts
+++ b/tests/legacy-cli/e2e/tests/commands/serve/head-request.ts
@@ -1,0 +1,25 @@
+import { ngServe } from '../../../utils/project';
+
+export default async function () {
+  const port = await ngServe();
+  // HTML
+  await checkHeadForUrl(`http://localhost:${port}/index.html`);
+  // Generated JS
+  await checkHeadForUrl(`http://localhost:${port}/main.js`);
+  // Generated CSS
+  await checkHeadForUrl(`http://localhost:${port}/styles.css`);
+  // Configured asset
+  await checkHeadForUrl(`http://localhost:${port}/favicon.ico`);
+}
+
+async function checkHeadForUrl(url: string): Promise<void> {
+  const result = await fetch(url, { method: 'HEAD' });
+  const content = await result.blob();
+
+  if (content.size !== 0) {
+    throw new Error(`Expected "size" to be "0" but got "${content.size}".`);
+  }
+  if (result.status !== 200) {
+    throw new Error(`Expected "status" to be "200" but got "${result.status}".`);
+  }
+}

--- a/tests/legacy-cli/e2e/tests/i18n/extract-ivy.ts
+++ b/tests/legacy-cli/e2e/tests/i18n/extract-ivy.ts
@@ -27,6 +27,9 @@ export default async function () {
   `,
   );
 
+  // Ensure localize package is not present initially
+  await uninstallPackage('@angular/localize');
+
   // Should fail if `@angular/localize` is missing
   const { message: message1 } = await expectToFail(() => ng('extract-i18n'));
   if (!message1.includes(`i18n extraction requires the '@angular/localize' package.`)) {


### PR DESCRIPTION
When using the development server, HTTP HEAD requests will now correctly respond for the virtual output files generated from the Angular build system.  Previously Vite only handled GET requests for the files. While HEAD requests are not common in development workflows, it can be needed in more complex cases with additional servers/proxies/etc. during development.
