### PR TITLE
fix(@angular-devkit/build-angular): update vite to 4.5.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -204,7 +204,7 @@
     "typescript": "5.1.6",
     "verdaccio": "5.26.1",
     "verdaccio-auth-memory": "^10.0.0",
-    "vite": "4.5.3",
+    "vite": "4.5.5",
     "webpack": "5.94.0",
     "webpack-dev-middleware": "6.1.2",
     "webpack-dev-server": "4.15.1",

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -64,7 +64,7 @@
     "text-table": "0.2.0",
     "tree-kill": "1.2.2",
     "tslib": "2.6.1",
-    "vite": "4.5.3",
+    "vite": "4.5.5",
     "webpack": "5.94.0",
     "webpack-dev-middleware": "6.1.2",
     "webpack-dev-server": "4.15.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12362,10 +12362,10 @@ vite@4.4.3:
   optionalDependencies:
     fsevents "~2.3.2"
 
-vite@4.5.3:
-  version "4.5.3"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-4.5.3.tgz#d88a4529ea58bae97294c7e2e6f0eab39a50fb1a"
-  integrity sha512-kQL23kMeX92v3ph7IauVkXkikdDRsYMGTVl5KY2E9OY4ONLvkHf04MDTbnfo6NKxZiDLWzVpP5oTa8hQD8U3dg==
+vite@4.5.5:
+  version "4.5.5"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-4.5.5.tgz#639b9feca5c0a3bfe3c60cb630ef28bf219d742e"
+  integrity sha512-ifW3Lb2sMdX+WU91s3R0FyQlAyLxOzCSCP37ujw0+r5POeHPwe6udWVIElKQq8gk3t7b8rkmvqC6IHBpCff4GQ==
   dependencies:
     esbuild "^0.18.10"
     postcss "^8.4.27"


### PR DESCRIPTION

Includes a fix for CVE-2024-45812 / CVE-2024-45811

Closes angular#28435
