### PR TITLE
feat(@angular/build): support postcss js config

### DIFF
--- a/packages/angular/build/src/tools/esbuild/stylesheets/stylesheet-plugin-factory.ts
+++ b/packages/angular/build/src/tools/esbuild/stylesheets/stylesheet-plugin-factory.ts
@@ -206,13 +206,8 @@ export class StylesheetPluginFactory {
       if (!postcssProcessor) {
         postcss ??= (await import('postcss')).default;
         postcssProcessor = postcss();
-        for (const [pluginName, pluginOptions] of options.postcssConfiguration.plugins) {
-          const { default: plugin } = await import(pluginName);
-          if (typeof plugin !== 'function' || plugin.postcss !== true) {
-            throw new Error(`Attempted to load invalid Postcss plugin: "${pluginName}"`);
-          }
-
-          postcssProcessor.use(plugin(pluginOptions));
+        for (const plugin of options.postcssConfiguration.plugins) {
+          postcssProcessor.use(plugin);
         }
 
         postcssProcessors.set(postCssInstanceKey, new WeakRef(postcssProcessor));

--- a/packages/angular/build/src/utils/postcss-configuration.ts
+++ b/packages/angular/build/src/utils/postcss-configuration.ts
@@ -6,18 +6,19 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import { readFile, readdir } from 'node:fs/promises';
+import { readdir } from 'node:fs/promises';
 import { join } from 'node:path';
+import type { AcceptedPlugin } from 'postcss';
 
 export interface PostcssConfiguration {
-  plugins: [name: string, options?: object | string][];
+  plugins: AcceptedPlugin[];
 }
 
-interface RawPostcssConfiguration {
-  plugins?: Record<string, object | boolean | string> | (string | [string, object])[];
-}
-
-const postcssConfigurationFiles: string[] = ['postcss.config.json', '.postcssrc.json'];
+const postcssConfigurationFiles: string[] = [
+  'postcss.config.js',
+  'postcss.config.cjs',
+  'postcss.config.mjs',
+];
 const tailwindConfigFiles: string[] = [
   'tailwind.config.js',
   'tailwind.config.cjs',
@@ -62,15 +63,6 @@ export function findTailwindConfiguration(
   return findFile(searchDirectories, tailwindConfigFiles);
 }
 
-async function readPostcssConfiguration(
-  configurationFile: string,
-): Promise<RawPostcssConfiguration> {
-  const data = await readFile(configurationFile, 'utf-8');
-  const config = JSON.parse(data) as RawPostcssConfiguration;
-
-  return config;
-}
-
 export async function loadPostcssConfiguration(
   searchDirectories: SearchDirectory[],
 ): Promise<PostcssConfiguration | undefined> {
@@ -79,44 +71,11 @@ export async function loadPostcssConfiguration(
     return undefined;
   }
 
-  const raw = await readPostcssConfiguration(configPath);
+  const config = await import(configPath);
 
   // If no plugins are defined, consider it equivalent to no configuration
-  if (!raw.plugins || typeof raw.plugins !== 'object') {
+  if (!config.plugins || !Array.isArray(config.plugins)) {
     return undefined;
-  }
-
-  // Normalize plugin array form
-  if (Array.isArray(raw.plugins)) {
-    if (raw.plugins.length < 1) {
-      return undefined;
-    }
-
-    const config: PostcssConfiguration = { plugins: [] };
-    for (const element of raw.plugins) {
-      if (typeof element === 'string') {
-        config.plugins.push([element]);
-      } else {
-        config.plugins.push(element);
-      }
-    }
-
-    return config;
-  }
-
-  // Normalize plugin object map form
-  const entries = Object.entries(raw.plugins);
-  if (entries.length < 1) {
-    return undefined;
-  }
-
-  const config: PostcssConfiguration = { plugins: [] };
-  for (const [name, options] of entries) {
-    if (!options || (typeof options !== 'object' && typeof options !== 'string')) {
-      continue;
-    }
-
-    config.plugins.push([name, options]);
   }
 
   return config;


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
executor: `@angular-devkit/build-angular:dev-server`

Users can use customized postcss config, but `json` only, have a lot of limitions.

Issue Number: #27819

## What is the new behavior?

<!-- Please describe the new behavior that. -->
Users can use `js` config file(`.js`, `.cjs` and `.mjs`), it not only can handle all situations of `json` config, but also more powerful.

And the [`postcss` early migration guide](https://github.com/postcss/postcss-cli/wiki/Migrating-from-v2-to-v3#config-files) still recommend to use `js` as configuration file.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

Not support `json` configuration again. Try support `json` or `ts` will increase the complexity of code bases.

## Other information
