### PR TITLE
feat(@schematics/angular): integrate `withEventReplay()` in `provideClientHydration` for new SSR apps

### DIFF
--- a/packages/schematics/angular/server/index.ts
+++ b/packages/schematics/angular/server/index.ts
@@ -9,7 +9,6 @@
 import { JsonValue, Path, basename, dirname, join, normalize } from '@angular-devkit/core';
 import {
   Rule,
-  SchematicContext,
   SchematicsException,
   Tree,
   apply,
@@ -222,7 +221,10 @@ export default function (options: ServerOptions): Rule {
       addRootProvider(
         options.project,
         ({ code, external }) =>
-          code`${external('provideClientHydration', '@angular/platform-browser')}()`,
+          code`${external('provideClientHydration', '@angular/platform-browser')}(${external(
+            'withEventReplay',
+            '@angular/platform-browser',
+          )}())`,
       ),
     ]);
   };

--- a/packages/schematics/angular/server/index_spec.ts
+++ b/packages/schematics/angular/server/index_spec.ts
@@ -95,7 +95,7 @@ describe('Server Schematic', () => {
     it(`should add 'provideClientHydration' to the providers list`, async () => {
       const tree = await schematicRunner.runSchematic('server', defaultOptions, appTree);
       const contents = tree.readContent('/projects/bar/src/app/app.module.ts');
-      expect(contents).toContain(`provideClientHydration()`);
+      expect(contents).toContain(`provideClientHydration(withEventReplay())`);
     });
   });
 
@@ -138,7 +138,7 @@ describe('Server Schematic', () => {
     it(`should add 'provideClientHydration' to the providers list`, async () => {
       const tree = await schematicRunner.runSchematic('server', defaultOptions, appTree);
       const contents = tree.readContent('/projects/bar/src/app/app.config.ts');
-      expect(contents).toContain(`provideClientHydration()`);
+      expect(contents).toContain(`provideClientHydration(withEventReplay())`);
     });
   });
 


### PR DESCRIPTION

Event Replay is now stable (see https://github.com/angular/angular/pull/57895). This commit adds `withEventReplay()` to the `provideClientHydration()` call in newly created Angular applications with SSR.
