### PR TITLE
 feat(@angular/build): utilize `ssr.entry` during prerendering to enable access to local API routes     

### DIFF
--- a/packages/angular/build/src/tools/vite/middlewares/ssr-middleware.ts
+++ b/packages/angular/build/src/tools/vite/middlewares/ssr-middleware.ts
@@ -8,13 +8,15 @@
 
 import type {
   AngularAppEngine as SSRAngularAppEngine,
-  createRequestHandler,
   ɵgetOrCreateAngularServerApp as getOrCreateAngularServerApp,
 } from '@angular/ssr';
-import type { createNodeRequestHandler } from '@angular/ssr/node';
 import type { ServerResponse } from 'node:http';
 import type { Connect, ViteDevServer } from 'vite';
 import { loadEsmModule } from '../../../utils/load-esm';
+import {
+  isSsrNodeRequestHandler,
+  isSsrRequestHandler,
+} from '../../../utils/server-rendering/utils';
 
 export function createAngularSsrInternalMiddleware(
   server: ViteDevServer,
@@ -135,14 +137,4 @@ export async function createAngularSsrExternalMiddleware(
       }
     })().catch(next);
   };
-}
-
-function isSsrNodeRequestHandler(
-  value: unknown,
-): value is ReturnType<typeof createNodeRequestHandler> {
-  return typeof value === 'function' && '__ng_node_request_handler__' in value;
-}
-
-function isSsrRequestHandler(value: unknown): value is ReturnType<typeof createRequestHandler> {
-  return typeof value === 'function' && '__ng_request_handler__' in value;
 }

--- a/packages/angular/build/src/utils/server-rendering/fetch-patch.ts
+++ b/packages/angular/build/src/utils/server-rendering/fetch-patch.ts
@@ -21,7 +21,7 @@ const { assetFiles } = workerData as {
 const assetsCache: Map<string, { headers: undefined | Record<string, string>; content: Buffer }> =
   new Map();
 
-export function patchFetchToLoadInMemoryAssets(): void {
+export function patchFetchToLoadInMemoryAssets(baseURL: URL): void {
   const originalFetch = globalThis.fetch;
   const patchedFetch: typeof fetch = async (input, init) => {
     let url: URL;
@@ -38,7 +38,7 @@ export function patchFetchToLoadInMemoryAssets(): void {
     const { hostname } = url;
     const pathname = decodeURIComponent(url.pathname);
 
-    if (hostname !== 'local-angular-prerender' || !assetFiles[pathname]) {
+    if (hostname !== baseURL.hostname || !assetFiles[pathname]) {
       // Only handle relative requests or files that are in assets.
       return originalFetch(input, init);
     }

--- a/packages/angular/build/src/utils/server-rendering/launch-server.ts
+++ b/packages/angular/build/src/utils/server-rendering/launch-server.ts
@@ -1,0 +1,64 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import assert from 'node:assert';
+import { createServer } from 'node:http';
+import { loadEsmModule } from '../load-esm';
+import { loadEsmModuleFromMemory } from './load-esm-from-memory';
+import { isSsrNodeRequestHandler, isSsrRequestHandler } from './utils';
+
+export const DEFAULT_URL = new URL('http://ng-localhost/');
+
+/**
+ * Launches a server that handles local requests.
+ *
+ * @returns A promise that resolves to the URL of the running server.
+ */
+export async function launchServer(): Promise<URL> {
+  const { default: handler } = await loadEsmModuleFromMemory('./server.mjs');
+  const { createWebRequestFromNodeRequest, writeResponseToNodeResponse } =
+    await loadEsmModule<typeof import('@angular/ssr/node')>('@angular/ssr/node');
+
+  if (!isSsrNodeRequestHandler(handler) && !isSsrRequestHandler(handler)) {
+    return DEFAULT_URL;
+  }
+
+  const server = createServer((req, res) => {
+    (async () => {
+      // handle request
+      if (isSsrNodeRequestHandler(handler)) {
+        await handler(req, res, (e) => {
+          throw e;
+        });
+      } else {
+        const webRes = await handler(createWebRequestFromNodeRequest(req));
+        if (webRes) {
+          await writeResponseToNodeResponse(webRes, res);
+        } else {
+          res.statusCode = 501;
+          res.end('Not Implemented.');
+        }
+      }
+    })().catch((e) => {
+      res.statusCode = 500;
+      res.end('Internal Server Error.');
+      // eslint-disable-next-line no-console
+      console.error(e);
+    });
+  });
+
+  server.unref();
+
+  await new Promise<void>((resolve) => server.listen(0, 'localhost', resolve));
+
+  const serverAddress = server.address();
+  assert(serverAddress, 'Server address should be defined.');
+  assert(typeof serverAddress !== 'string', 'Server address should not be a string.');
+
+  return new URL(`http://localhost:${serverAddress.port}/`);
+}

--- a/packages/angular/build/src/utils/server-rendering/load-esm-from-memory.ts
+++ b/packages/angular/build/src/utils/server-rendering/load-esm-from-memory.ts
@@ -20,9 +20,20 @@ interface MainServerBundleExports {
   ɵgetOrCreateAngularServerApp: typeof ɵgetOrCreateAngularServerApp;
 }
 
+/**
+ * Represents the exports available from the server bundle.
+ */
+interface ServerBundleExports {
+  default: unknown;
+}
+
 export function loadEsmModuleFromMemory(
   path: './main.server.mjs',
-): Promise<MainServerBundleExports> {
+): Promise<MainServerBundleExports>;
+export function loadEsmModuleFromMemory(path: './server.mjs'): Promise<ServerBundleExports>;
+export function loadEsmModuleFromMemory(
+  path: './main.server.mjs' | './server.mjs',
+): Promise<MainServerBundleExports | ServerBundleExports> {
   return loadEsmModule(new URL(path, 'memory://')).catch((e) => {
     assertIsError(e);
 

--- a/packages/angular/build/src/utils/server-rendering/prerender.ts
+++ b/packages/angular/build/src/utils/server-rendering/prerender.ts
@@ -165,6 +165,7 @@ export async function prerenderPages(
     outputFilesForWorker,
     assetsReversed,
     appShellOptions,
+    outputMode,
   );
 
   errors.push(...renderingErrors);
@@ -186,6 +187,7 @@ async function renderPages(
   outputFilesForWorker: Record<string, string>,
   assetFilesForWorker: Record<string, string>,
   appShellOptions: AppShellOptions | undefined,
+  outputMode: OutputMode | undefined,
 ): Promise<{
   output: PrerenderOutput;
   errors: string[];
@@ -210,6 +212,8 @@ async function renderPages(
       workspaceRoot,
       outputFiles: outputFilesForWorker,
       assetFiles: assetFilesForWorker,
+      outputMode,
+      hasSsrEntry: !!outputFilesForWorker['/server.mjs'],
     } as RenderWorkerData,
     execArgv: workerExecArgv,
   });
@@ -314,14 +318,16 @@ async function getAllRoutes(
       workspaceRoot,
       outputFiles: outputFilesForWorker,
       assetFiles: assetFilesForWorker,
+      outputMode,
+      hasSsrEntry: !!outputFilesForWorker['/server.mjs'],
     } as RoutesExtractorWorkerData,
     execArgv: workerExecArgv,
   });
 
   try {
-    const { serializedRouteTree, errors }: RoutersExtractorWorkerResult = await renderWorker.run({
-      outputMode,
-    });
+    const { serializedRouteTree, errors }: RoutersExtractorWorkerResult = await renderWorker.run(
+      {},
+    );
 
     return { errors, serializedRouteTree: [...routes, ...serializedRouteTree] };
   } catch (err) {

--- a/packages/angular/build/src/utils/server-rendering/render-worker.ts
+++ b/packages/angular/build/src/utils/server-rendering/render-worker.ts
@@ -6,17 +6,32 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import { workerData } from 'worker_threads';
+import type { OutputMode } from '../../builders/application/schema';
 import type { ESMInMemoryFileLoaderWorkerData } from './esm-in-memory-loader/loader-hooks';
 import { patchFetchToLoadInMemoryAssets } from './fetch-patch';
+import { DEFAULT_URL, launchServer } from './launch-server';
 import { loadEsmModuleFromMemory } from './load-esm-from-memory';
 
 export interface RenderWorkerData extends ESMInMemoryFileLoaderWorkerData {
   assetFiles: Record</** Destination */ string, /** Source */ string>;
+  outputMode: OutputMode | undefined;
+  hasSsrEntry: boolean;
 }
 
 export interface RenderOptions {
   url: string;
 }
+
+/**
+ * This is passed as workerData when setting up the worker via the `piscina` package.
+ */
+const { outputMode, hasSsrEntry } = workerData as {
+  outputMode: OutputMode | undefined;
+  hasSsrEntry: boolean;
+};
+
+let serverURL = DEFAULT_URL;
 
 /**
  * Renders each route in routes and writes them to <outputPath>/<route>/index.html.
@@ -26,15 +41,19 @@ async function renderPage({ url }: RenderOptions): Promise<string | null> {
     await loadEsmModuleFromMemory('./main.server.mjs');
   const angularServerApp = getOrCreateAngularServerApp();
   const response = await angularServerApp.renderStatic(
-    new URL(url, 'http://local-angular-prerender'),
+    new URL(url, serverURL),
     AbortSignal.timeout(30_000),
   );
 
   return response ? response.text() : null;
 }
 
-function initialize() {
-  patchFetchToLoadInMemoryAssets();
+async function initialize() {
+  if (outputMode !== undefined && hasSsrEntry) {
+    serverURL = await launchServer();
+  }
+
+  patchFetchToLoadInMemoryAssets(serverURL);
 
   return renderPage;
 }

--- a/packages/angular/build/src/utils/server-rendering/routes-extractor-worker.ts
+++ b/packages/angular/build/src/utils/server-rendering/routes-extractor-worker.ts
@@ -6,24 +6,35 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import { workerData } from 'worker_threads';
 import { OutputMode } from '../../builders/application/schema';
+import { ESMInMemoryFileLoaderWorkerData } from './esm-in-memory-loader/loader-hooks';
 import { patchFetchToLoadInMemoryAssets } from './fetch-patch';
+import { DEFAULT_URL, launchServer } from './launch-server';
 import { loadEsmModuleFromMemory } from './load-esm-from-memory';
 import { RoutersExtractorWorkerResult } from './models';
 
-export interface ExtractRoutesOptions {
-  outputMode?: OutputMode;
+export interface ExtractRoutesWorkerData extends ESMInMemoryFileLoaderWorkerData {
+  outputMode: OutputMode | undefined;
 }
 
+/**
+ * This is passed as workerData when setting up the worker via the `piscina` package.
+ */
+const { outputMode, hasSsrEntry } = workerData as {
+  outputMode: OutputMode | undefined;
+  hasSsrEntry: boolean;
+};
+
+let serverURL = DEFAULT_URL;
+
 /** Renders an application based on a provided options. */
-async function extractRoutes({
-  outputMode,
-}: ExtractRoutesOptions): Promise<RoutersExtractorWorkerResult> {
+async function extractRoutes(): Promise<RoutersExtractorWorkerResult> {
   const { ɵextractRoutesAndCreateRouteTree: extractRoutesAndCreateRouteTree } =
     await loadEsmModuleFromMemory('./main.server.mjs');
 
   const { routeTree, errors } = await extractRoutesAndCreateRouteTree(
-    new URL('http://local-angular-prerender/'),
+    serverURL,
     undefined /** manifest */,
     true /** invokeGetPrerenderParams */,
     outputMode === OutputMode.Server /** includePrerenderFallbackRoutes */,
@@ -35,8 +46,12 @@ async function extractRoutes({
   };
 }
 
-function initialize() {
-  patchFetchToLoadInMemoryAssets();
+async function initialize() {
+  if (outputMode !== undefined && hasSsrEntry) {
+    serverURL = await launchServer();
+  }
+
+  patchFetchToLoadInMemoryAssets(serverURL);
 
   return extractRoutes;
 }

--- a/packages/angular/build/src/utils/server-rendering/utils.ts
+++ b/packages/angular/build/src/utils/server-rendering/utils.ts
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import type { createRequestHandler } from '@angular/ssr';
+import type { createNodeRequestHandler } from '@angular/ssr/node';
+
+export function isSsrNodeRequestHandler(
+  value: unknown,
+): value is ReturnType<typeof createNodeRequestHandler> {
+  return typeof value === 'function' && '__ng_node_request_handler__' in value;
+}
+export function isSsrRequestHandler(
+  value: unknown,
+): value is ReturnType<typeof createRequestHandler> {
+  return typeof value === 'function' && '__ng_request_handler__' in value;
+}

--- a/tests/legacy-cli/e2e/tests/server-rendering/server-routes-output-mode-static-http-calls.ts
+++ b/tests/legacy-cli/e2e/tests/server-rendering/server-routes-output-mode-static-http-calls.ts
@@ -1,0 +1,126 @@
+import { match } from 'node:assert';
+import { readFile, writeMultipleFiles } from '../../utils/fs';
+import { noSilentNg, silentNg } from '../../utils/process';
+import { setupProjectWithSSRAppEngine } from './setup';
+
+export default async function () {
+  // Setup project
+  await setupProjectWithSSRAppEngine();
+
+  await writeMultipleFiles({
+    // Add asset
+    'public/media.json': JSON.stringify({ dataFromAssets: true }),
+    // Update component to do an HTTP call to asset and API.
+    'src/app/app.component.ts': `
+    import { Component, inject } from '@angular/core';
+    import { JsonPipe } from '@angular/common';
+    import { RouterOutlet } from '@angular/router';
+    import { HttpClient } from '@angular/common/http';
+
+    @Component({
+      selector: 'app-root',
+      standalone: true,
+      imports: [JsonPipe, RouterOutlet],
+      template: \`
+        <p>{{ assetsData | json }}</p>
+        <p>{{ apiData | json }}</p>
+        <router-outlet></router-outlet>
+      \`,
+    })
+    export class AppComponent {
+      assetsData: any;
+      apiData: any;
+
+      constructor() {
+        const http = inject(HttpClient);
+
+        http.get('/media.json').toPromise().then((d) => {
+          this.assetsData = d;
+        });
+
+        http.get('/api').toPromise().then((d) => {
+          this.apiData = d;
+        });
+      }
+    }
+    `,
+    // Add http client and route
+    'src/app/app.config.ts': `
+      import { ApplicationConfig } from '@angular/core';
+      import { provideRouter } from '@angular/router';
+
+      import { HomeComponent } from './home/home.component';
+      import { provideClientHydration } from '@angular/platform-browser';
+      import { provideHttpClient, withFetch } from '@angular/common/http';
+
+      export const appConfig: ApplicationConfig = {
+        providers: [
+          provideRouter([{
+            path: 'home',
+            component: HomeComponent,
+          }]),
+          provideClientHydration(),
+          provideHttpClient(withFetch()),
+        ],
+      };
+    `,
+    'src/app/app.routes.server.ts': `
+    import { RenderMode, ServerRoute } from '@angular/ssr';
+
+    export const routes: ServerRoute[] = [
+      {
+        path: '**',
+        renderMode: RenderMode.Prerender,
+      },
+    ];
+  `,
+    'server.ts': `
+      import { AngularNodeAppEngine, writeResponseToNodeResponse, isMainModule, createNodeRequestHandler } from '@angular/ssr/node';
+      import express from 'express';
+      import { fileURLToPath } from 'node:url';
+      import { dirname, resolve } from 'node:path';
+
+      export function app(): express.Express {
+        const server = express();
+        const serverDistFolder = dirname(fileURLToPath(import.meta.url));
+        const browserDistFolder = resolve(serverDistFolder, '../browser');
+        const angularNodeAppEngine = new AngularNodeAppEngine();
+
+        server.use('/api', (req, res) => res.json({ dataFromAPI: true }));
+
+        server.get('**', express.static(browserDistFolder, {
+          maxAge: '1y',
+          index: 'index.html'
+        }));
+
+        server.get('**', (req, res, next) => {
+          angularNodeAppEngine.render(req)
+            .then((response) => response ? writeResponseToNodeResponse(response, res) : next())
+            .catch(next);
+        });
+
+        return server;
+      }
+
+      const server = app();
+      if (isMainModule(import.meta.url)) {
+        const port = process.env['PORT'] || 4000;
+        server.listen(port, () => {
+          console.log(\`Node Express server listening on http://localhost:\${port}\`);
+        });
+      }
+
+      export default createNodeRequestHandler(server);
+    `,
+  });
+
+  await silentNg('generate', 'component', 'home');
+
+  // Fix the error
+  await noSilentNg('build', '--output-mode=static');
+
+  const contents = await readFile('dist/test-project/browser/home/index.html');
+  match(contents, /<p>{[\S\s]*"dataFromAssets":[\s\S]*true[\S\s]*}<\/p>/);
+  match(contents, /<p>{[\S\s]*"dataFromAPI":[\s\S]*true[\S\s]*}<\/p>/);
+  match(contents, /home works!/);
+}


### PR DESCRIPTION
The server.ts file is now utilized during prerendering, allowing access to locally defined API routes for improved data fetching and rendering.
