### PR TITLE
test: unlink symlink in ng add base E2E test

### DIFF
--- a/tests/legacy-cli/e2e/tests/commands/add/base.ts
+++ b/tests/legacy-cli/e2e/tests/commands/add/base.ts
@@ -1,5 +1,5 @@
 import { assetDir } from '../../../utils/assets';
-import { expectFileToExist, rimraf, symlinkFile } from '../../../utils/fs';
+import { deleteFile, expectFileToExist, symlinkFile } from '../../../utils/fs';
 import { ng } from '../../../utils/process';
 import { expectToFail } from '../../../utils/utils';
 
@@ -15,5 +15,5 @@ export default async function () {
   await expectToFail(() => ng('add', 'add-collection')); // File already exists.
 
   // Cleanup the package
-  await rimraf('node_modules/add-collection');
+  await deleteFile('node_modules/add-collection');
 }


### PR DESCRIPTION
Instead of attempting to delete all files within the directory, the created symlink can instead be removed on its own. This should prevent odd Windows failures in CI.