### PR TITLE
fix(@angular/build): prevent prerendering of catch-all routes

### DIFF
--- a/packages/angular/build/src/utils/server-rendering/prerender.ts
+++ b/packages/angular/build/src/utils/server-rendering/prerender.ts
@@ -121,6 +121,12 @@ export async function prerenderPages(
   const serializableRouteTreeNodeForPrerender: WritableSerializableRouteTreeNode = [];
   for (const metadata of serializableRouteTreeNode) {
     if (outputMode !== OutputMode.Static && metadata.redirectTo) {
+      // Skip redirects if output mode is not static.
+      continue;
+    }
+
+    if (metadata.route.includes('*')) {
+      // Skip catch all routes from prerender.
       continue;
     }
 
@@ -129,7 +135,6 @@ export async function prerenderPages(
       case RouteRenderMode.Prerender:
       case RouteRenderMode.AppShell:
         serializableRouteTreeNodeForPrerender.push(metadata);
-
         break;
       case RouteRenderMode.Server:
         if (outputMode === OutputMode.Static) {

--- a/tests/legacy-cli/e2e/tests/server-rendering/server-routes-output-mode-static.ts
+++ b/tests/legacy-cli/e2e/tests/server-rendering/server-routes-output-mode-static.ts
@@ -1,5 +1,5 @@
 import { join } from 'node:path';
-import { expectFileToMatch, replaceInFile, writeFile } from '../../utils/fs';
+import { expectFileNotToExist, expectFileToMatch, replaceInFile, writeFile } from '../../utils/fs';
 import { noSilentNg, silentNg } from '../../utils/process';
 import { setupProjectWithSSRAppEngine } from './setup';
 import { existsSync } from 'node:fs';
@@ -35,6 +35,10 @@ export default async function () {
     {
       path: 'ssg/:id',
       component: SsgWithParamsComponent,
+    },
+    {
+      path: '**',
+      component: HomeComponent,
     },
   ];
   `,
@@ -100,4 +104,7 @@ export default async function () {
     !existsSync('dist/test-project/server'),
     'Server directory should not exist when output-mode is static',
   );
+
+  // Should not prerender the catch all
+  await expectFileNotToExist(join('dist/test-project/browser/**/index.html'));
 }


### PR DESCRIPTION


Updated the build process to exclude catch-all routes from being prerendered. 