### PR TITLE
refactor(@angular/build): add `NG_BUILD_PARTIAL_SSR` environment variable to disable prerendering and manifest generation

### DIFF
--- a/packages/angular/build/src/builders/application/execute-post-bundle.ts
+++ b/packages/angular/build/src/builders/application/execute-post-bundle.ts
@@ -70,7 +70,7 @@ export async function executePostBundleSteps(
     prerenderOptions,
     appShellOptions,
     workspaceRoot,
-    disableFullServerManifestGeneration,
+    partialSSRBuild,
   } = options;
 
   // Index HTML content without CSS inlining to be used for server rendering (AppShell, SSG and SSR).
@@ -125,7 +125,7 @@ export async function executePostBundleSteps(
   // Pre-render (SSG) and App-shell
   // If localization is enabled, prerendering is handled in the inlining process.
   if (
-    !disableFullServerManifestGeneration &&
+    !partialSSRBuild &&
     (prerenderOptions || appShellOptions || (outputMode && serverEntryPoint)) &&
     !allErrors.length
   ) {

--- a/packages/angular/build/src/builders/application/index.ts
+++ b/packages/angular/build/src/builders/application/index.ts
@@ -88,7 +88,7 @@ export async function* buildApplicationInternal(
 
   yield* runEsBuildBuildAction(
     async (rebuildState) => {
-      const { serverEntryPoint, jsonLogs, disableFullServerManifestGeneration } = normalizedOptions;
+      const { serverEntryPoint, jsonLogs, partialSSRBuild } = normalizedOptions;
 
       const startTime = process.hrtime.bigint();
       const result = await executeBuild(normalizedOptions, context, rebuildState);
@@ -96,7 +96,7 @@ export async function* buildApplicationInternal(
       if (jsonLogs) {
         result.addLog(await createJsonBuildManifest(result, normalizedOptions));
       } else {
-        if (serverEntryPoint && !disableFullServerManifestGeneration) {
+        if (serverEntryPoint && !partialSSRBuild) {
           const prerenderedRoutesLength = Object.keys(result.prerenderedRoutes).length;
           let prerenderMsg = `Prerendered ${prerenderedRoutesLength} static route`;
           prerenderMsg += prerenderedRoutesLength !== 1 ? 's.' : '.';

--- a/packages/angular/build/src/builders/application/options.ts
+++ b/packages/angular/build/src/builders/application/options.ts
@@ -14,7 +14,7 @@ import { createRequire } from 'node:module';
 import path from 'node:path';
 import { normalizeAssetPatterns, normalizeOptimization, normalizeSourceMaps } from '../../utils';
 import { supportColor } from '../../utils/color';
-import { useJSONBuildLogs } from '../../utils/environment-options';
+import { useJSONBuildLogs, usePartialSsrBuild } from '../../utils/environment-options';
 import { I18nOptions, createI18nOptions } from '../../utils/i18n-options';
 import { IndexHtmlTransform } from '../../utils/index-file/index-html-generator';
 import { normalizeCacheOptions } from '../../utils/normalize-cache';
@@ -82,14 +82,12 @@ interface InternalOptions {
   forceI18nFlatOutput?: boolean;
 
   /**
-   * When set to `true`, disables the generation of a full manifest with routes.
+   * When set to `true`, enables fast SSR in development mode by disabling the full manifest generation and prerendering.
    *
-   * This option is primarily used during development to improve performance,
-   * as the full manifest is generated at runtime when using the development server.
-   *
+   * This option is intended to optimize performance during development by skipping prerendering and route extraction when not required.
    * @default false
    */
-  disableFullServerManifestGeneration?: boolean;
+  partialSSRBuild?: boolean;
 
   /**
    * Enables the use of AOT compiler emitted external runtime styles.
@@ -382,7 +380,7 @@ export async function normalizeOptions(
     deployUrl,
     clearScreen,
     define,
-    disableFullServerManifestGeneration = false,
+    partialSSRBuild = false,
     externalRuntimeStyles,
   } = options;
 
@@ -444,7 +442,7 @@ export async function normalizeOptions(
     colors: supportColor(),
     clearScreen,
     define,
-    disableFullServerManifestGeneration,
+    partialSSRBuild: usePartialSsrBuild || partialSSRBuild,
     externalRuntimeStyles,
   };
 }

--- a/packages/angular/build/src/builders/dev-server/vite-server.ts
+++ b/packages/angular/build/src/builders/dev-server/vite-server.ts
@@ -110,7 +110,7 @@ export async function* serveWithVite(
 
   // Disable generating a full manifest with routes.
   // This is done during runtime when using the dev-server.
-  browserOptions.disableFullServerManifestGeneration = true;
+  browserOptions.partialSSRBuild = true;
 
   // The development server currently only supports a single locale when localizing.
   // This matches the behavior of the Webpack-based development server but could be expanded in the future.

--- a/packages/angular/build/src/utils/environment-options.ts
+++ b/packages/angular/build/src/utils/environment-options.ts
@@ -104,3 +104,7 @@ export const shouldOptimizeChunks =
 const hmrComponentStylesVariable = process.env['NG_HMR_CSTYLES'];
 export const useComponentStyleHmr =
   isPresent(hmrComponentStylesVariable) && isEnabled(hmrComponentStylesVariable);
+
+const partialSsrBuildVariable = process.env['NG_BUILD_PARTIAL_SSR'];
+export const usePartialSsrBuild =
+  isPresent(partialSsrBuildVariable) && isEnabled(partialSsrBuildVariable);


### PR DESCRIPTION


This change allows for forced disabling of prerendering and route extraction when using Vite with Angular CLI. In certain scenarios, such as when the application builder is invoked directly and not in watch mode (e.g. ADEV), an external configuration may be necessary.
