### PR TITLE
docs: release notes for the v17.3.10 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+<a name="17.3.10"></a>
+
+# 17.3.10 (2024-09-25)
+
+### @angular-devkit/build-angular
+
+| Commit                                                                                              | Type | Description          |
+| --------------------------------------------------------------------------------------------------- | ---- | -------------------- |
+| [30489d8fd](https://github.com/angular/angular-cli/commit/30489d8fd1cf738162d95333fe462eea58ba460f) | fix  | update vite to 4.1.8 |
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="19.0.0-next.7"></a>
 
 # 19.0.0-next.7 (2024-09-18)


### PR DESCRIPTION
Cherry-picks the changelog from the "17.3.x" branch to the next branch (main).