### PR TITLE
feat(editorconfig): support single quote setting in JetBrains IDEs

### DIFF
--- a/packages/schematics/angular/workspace/files/__dot__editorconfig.template
+++ b/packages/schematics/angular/workspace/files/__dot__editorconfig.template
@@ -10,6 +10,7 @@ trim_trailing_whitespace = true
 
 [*.ts]
 quote_type = single
+ij_typescript_use_double_quotes = false
 
 [*.md]
 max_line_length = off


### PR DESCRIPTION

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

The editorConfig generated by `ng new` specified `quote_type = single` for ts files. This is not a valid configuration option within editorConfig, instead editor could use it, but AFAIK no one utilizes this (https://github.com/editorconfig/editorconfig-vscode/issues/95). JetBrains IDEs have the option with the `ij_` prefix to set custom settings, and `ij_use_double_quote=false` will lead to autogenerated code (e.g. autoimports) to use single quotes

Issue Number: N/A

## What is the new behavior?

JetBrains IDEs will use single quotes by default

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

