### PR TITLE
fix(@angular/ssr): improve handling of route mismatches between Angular server routes and Angular router

### DIFF
--- a/packages/angular/ssr/src/routes/route-tree.ts
+++ b/packages/angular/ssr/src/routes/route-tree.ts
@@ -207,7 +207,7 @@ export class RouteTree<AdditionalMetadata extends Record<string, unknown> = {}> 
    *
    * @param node - The current node to start the traversal from. Defaults to the root node of the tree.
    */
-  private *traverse(node = this.root): Generator<RouteTreeNodeMetadata & AdditionalMetadata> {
+  *traverse(node = this.root): Generator<RouteTreeNodeMetadata & AdditionalMetadata> {
     if (node.metadata) {
       yield node.metadata;
     }

--- a/packages/angular/ssr/test/routes/ng-routes_spec.ts
+++ b/packages/angular/ssr/test/routes/ng-routes_spec.ts
@@ -314,7 +314,7 @@ describe('extractRoutesAndCreateRouteTree', () => {
 
     expect(errors).toHaveSize(1);
     expect(errors[0]).toContain(
-      `The server route 'invalid' does not match any routes defined in the Angular routing configuration`,
+      `The 'invalid' server route does not match any routes defined in the Angular routing configuration`,
     );
   });
 
@@ -337,6 +337,28 @@ describe('extractRoutesAndCreateRouteTree', () => {
     expect(errors).toHaveSize(1);
     expect(errors[0]).toContain(
       `The 'invalid' route does not match any route defined in the server routing configuration`,
+    );
+  });
+
+  it(`should error when 'RenderMode.AppShell' is used on more than one route`, async () => {
+    setAngularAppTestingManifest(
+      [
+        { path: 'home', component: DummyComponent },
+        { path: 'shell', component: DummyComponent },
+      ],
+      [{ path: '**', renderMode: RenderMode.AppShell }],
+    );
+
+    const { errors } = await extractRoutesAndCreateRouteTree(
+      url,
+      /** manifest */ undefined,
+      /** invokeGetPrerenderParams */ false,
+      /** includePrerenderFallbackRoutes */ false,
+    );
+
+    expect(errors).toHaveSize(1);
+    expect(errors[0]).toContain(
+      `Both 'home' and 'shell' routes have their 'renderMode' set to 'AppShell'.`,
     );
   });
 });


### PR DESCRIPTION
fix(@angular/ssr): show error when multiple routes are set with `RenderMode.AppShell`**

This change introduces error handling to ensure that when multiple routes are configured with `RenderMode.AppShell`, an error message is displayed. This prevents misconfiguration and enhances clarity in route management.

---

**fix(@angular/ssr): improve handling of route mismatches between Angular server routes and Angular router**

This commit resolves an issue where routes defined in the Angular server routing configuration did not match those in the Angular router. Previously, discrepancies between these routes went unnoticed by users. With this update, appropriate error messages are now displayed when mismatches occur, enhancing the developer experience and facilitating easier troubleshooting.
