### PR TITLE
fix(@angular/build): add `animate` to valid self-closing elements

### DIFF
--- a/packages/angular/build/src/utils/index-file/valid-self-closing-tags.ts
+++ b/packages/angular/build/src/utils/index-file/valid-self-closing-tags.ts
@@ -24,6 +24,7 @@ export const VALID_SELF_CLOSING_TAGS = new Set([
   'wbr',
 
   /** SVG tags */
+  'animate',
   'circle',
   'ellipse',
   'line',


### PR DESCRIPTION
The `<animate>` tag, used for SVG animations, was incorrectly treated as a non-self-closing tag by the Angular build process. This resulted in errors during the build, as the parser expected a closing `</animate>` tag even when unnecessary.

Closes #28502