### PR TITLE
perf(@angular/ssr): prevent potential stampede in entry-points cache

### DIFF
--- a/packages/angular/ssr/src/app-engine.ts
+++ b/packages/angular/ssr/src/app-engine.ts
@@ -50,7 +50,7 @@ export class AngularAppEngine {
   /**
    * A cache that holds entry points, keyed by their potential locale string.
    */
-  private readonly entryPointsCache = new Map<string, EntryPointExports>();
+  private readonly entryPointsCache = new Map<string, Promise<EntryPointExports>>();
 
   /**
    * Renders a response for the given HTTP request using the server application.
@@ -110,9 +110,7 @@ export class AngularAppEngine {
    * @param potentialLocale - The locale string used to find the corresponding entry point.
    * @returns A promise that resolves to the entry point exports or `undefined` if not found.
    */
-  private async getEntryPointExports(
-    potentialLocale: string,
-  ): Promise<EntryPointExports | undefined> {
+  private getEntryPointExports(potentialLocale: string): Promise<EntryPointExports> | undefined {
     const cachedEntryPoint = this.entryPointsCache.get(potentialLocale);
     if (cachedEntryPoint) {
       return cachedEntryPoint;
@@ -124,7 +122,7 @@ export class AngularAppEngine {
       return undefined;
     }
 
-    const entryPointExports = await entryPoint();
+    const entryPointExports = entryPoint();
     this.entryPointsCache.set(potentialLocale, entryPointExports);
 
     return entryPointExports;
@@ -141,7 +139,7 @@ export class AngularAppEngine {
    * @param url - The URL of the request.
    * @returns A promise that resolves to the entry point exports or `undefined` if not found.
    */
-  private getEntryPointExportsForUrl(url: URL): Promise<EntryPointExports | undefined> {
+  private getEntryPointExportsForUrl(url: URL): Promise<EntryPointExports> | undefined {
     const { entryPoints, basePath } = this.manifest;
     if (entryPoints.size === 1) {
       return this.getEntryPointExports('');


### PR DESCRIPTION
If multiple concurrent requests hit `getEntryPointExports`, all of
them would previously see the cache miss for entry point. With this
change, only the first request will and the others can leverage the
cache.

This can be important when instances are added to a pool under high
traffic.

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the new behavior that. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
