### PR TITLE
refactor(@angular-devkit/build-angular): remove implicit localize polyfill

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/karma/application_builder.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/application_builder.ts
@@ -12,7 +12,6 @@ import {
   ResultKind,
   buildApplicationInternal,
   emitFilesToDisk,
-  purgeStaleBuildCache,
 } from '@angular/build/private';
 import { BuilderContext, BuilderOutput } from '@angular-devkit/architect';
 import { randomUUID } from 'crypto';
@@ -22,7 +21,6 @@ import * as path from 'path';
 import { Observable, catchError, defaultIfEmpty, from, of, switchMap } from 'rxjs';
 import { Configuration } from 'webpack';
 import { ExecutionTransformer } from '../../transforms';
-import { readTsconfig } from '../../utils/read-tsconfig';
 import { OutputHashing } from '../browser-esbuild/schema';
 import { findTests } from './find-tests';
 import { Schema as KarmaBuilderOptions } from './schema';
@@ -108,18 +106,6 @@ async function collectEntrypoints(
   const [polyfills, hasZoneTesting] = extractZoneTesting(options.polyfills);
   if (hasZoneTesting) {
     entryPoints.add('zone.js/testing');
-  }
-
-  const tsConfigPath = path.resolve(context.workspaceRoot, options.tsConfig);
-  const tsConfig = await readTsconfig(tsConfigPath);
-
-  const localizePackageInitEntryPoint = '@angular/localize/init';
-  const hasLocalizeType = tsConfig.options.types?.some(
-    (t) => t === '@angular/localize' || t === localizePackageInitEntryPoint,
-  );
-
-  if (hasLocalizeType) {
-    polyfills.push(localizePackageInitEntryPoint);
   }
 
   return [entryPoints, polyfills];

--- a/packages/angular_devkit/build_angular/src/builders/karma/tests/behavior/code-coverage_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/tests/behavior/code-coverage_spec.ts
@@ -29,8 +29,8 @@ describeKarmaBuilder(execute, KARMA_BUILDER_INFO, (harness, setupTarget, isAppli
       });
     }
 
-    beforeEach(() => {
-      setupTarget(harness);
+    beforeEach(async () => {
+      await setupTarget(harness);
     });
 
     it('should generate coverage report when file was previously processed by Babel', async () => {

--- a/packages/angular_devkit/build_angular/src/builders/karma/tests/behavior/errors_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/tests/behavior/errors_spec.ts
@@ -11,8 +11,8 @@ import { BASE_OPTIONS, KARMA_BUILDER_INFO, describeKarmaBuilder } from '../setup
 
 describeKarmaBuilder(execute, KARMA_BUILDER_INFO, (harness, setupTarget) => {
   describe('Behavior: "Errors"', () => {
-    beforeEach(() => {
-      setupTarget(harness);
+    beforeEach(async () => {
+      await setupTarget(harness);
     });
 
     it('should fail when there is a TypeScript error', async () => {

--- a/packages/angular_devkit/build_angular/src/builders/karma/tests/behavior/module-cjs_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/tests/behavior/module-cjs_spec.ts
@@ -11,8 +11,8 @@ import { BASE_OPTIONS, KARMA_BUILDER_INFO, describeKarmaBuilder } from '../setup
 
 describeKarmaBuilder(execute, KARMA_BUILDER_INFO, (harness, setupTarget) => {
   describe('Behavior: "module commonjs"', () => {
-    beforeEach(() => {
-      setupTarget(harness);
+    beforeEach(async () => {
+      await setupTarget(harness);
     });
 
     it('should work when module is commonjs', async () => {

--- a/packages/angular_devkit/build_angular/src/builders/karma/tests/behavior/rebuilds_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/tests/behavior/rebuilds_spec.ts
@@ -18,8 +18,8 @@ describeKarmaBuilder(execute, KARMA_BUILDER_INFO, (harness, setupTarget, isAppli
       });
     }
 
-    beforeEach(() => {
-      setupTarget(harness);
+    beforeEach(async () => {
+      await setupTarget(harness);
     });
 
     it('recovers from compilation failures in watch mode', async () => {

--- a/packages/angular_devkit/build_angular/src/builders/karma/tests/options/assets_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/tests/options/assets_spec.ts
@@ -11,8 +11,8 @@ import { BASE_OPTIONS, KARMA_BUILDER_INFO, describeKarmaBuilder } from '../setup
 
 describeKarmaBuilder(execute, KARMA_BUILDER_INFO, (harness, setupTarget) => {
   describe('Option: "assets"', () => {
-    beforeEach(() => {
-      setupTarget(harness);
+    beforeEach(async () => {
+      await setupTarget(harness);
     });
 
     it('includes assets', async () => {

--- a/packages/angular_devkit/build_angular/src/builders/karma/tests/options/builder-mode_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/tests/options/builder-mode_spec.ts
@@ -14,13 +14,15 @@ const ESBUILD_LOG_TEXT = 'Application bundle generation complete.';
 
 describeKarmaBuilder(execute, KARMA_BUILDER_INFO, (harness, setupTarget, isApplicationTarget) => {
   describe('option: "builderMode"', () => {
-    beforeEach(() => {
-      setupTarget(harness);
+    beforeEach(async () => {
+      await setupTarget(harness);
     });
 
     it('"application" always uses esbuild', async () => {
       harness.useTarget('test', {
         ...BASE_OPTIONS,
+        // Must explicitly provide localize polyfill:
+        polyfills: ['zone.js', '@angular/localize/init', 'zone.js/testing'],
         builderMode: BuilderMode.Application,
       });
 

--- a/packages/angular_devkit/build_angular/src/builders/karma/tests/options/code-coverage-exclude_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/tests/options/code-coverage-exclude_spec.ts
@@ -26,8 +26,8 @@ describeKarmaBuilder(execute, KARMA_BUILDER_INFO, (harness, setupTarget, isAppli
       });
     }
 
-    beforeEach(() => {
-      setupTarget(harness);
+    beforeEach(async () => {
+      await setupTarget(harness);
     });
 
     it('should exclude file from coverage when set', async () => {

--- a/packages/angular_devkit/build_angular/src/builders/karma/tests/options/code-coverage_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/tests/options/code-coverage_spec.ts
@@ -27,8 +27,8 @@ describeKarmaBuilder(execute, KARMA_BUILDER_INFO, (harness, setupTarget, isAppli
       });
     }
 
-    beforeEach(() => {
-      setupTarget(harness);
+    beforeEach(async () => {
+      await setupTarget(harness);
     });
 
     it('should generate coverage report when option is set to true', async () => {

--- a/packages/angular_devkit/build_angular/src/builders/karma/tests/options/exclude_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/tests/options/exclude_spec.ts
@@ -11,8 +11,8 @@ import { BASE_OPTIONS, KARMA_BUILDER_INFO, describeKarmaBuilder } from '../setup
 
 describeKarmaBuilder(execute, KARMA_BUILDER_INFO, (harness, setupTarget) => {
   describe('Option: "exclude"', () => {
-    beforeEach(() => {
-      setupTarget(harness);
+    beforeEach(async () => {
+      await setupTarget(harness);
     });
 
     beforeEach(async () => {

--- a/packages/angular_devkit/build_angular/src/builders/karma/tests/options/include_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/tests/options/include_spec.ts
@@ -11,8 +11,8 @@ import { BASE_OPTIONS, KARMA_BUILDER_INFO, describeKarmaBuilder } from '../setup
 
 describeKarmaBuilder(execute, KARMA_BUILDER_INFO, (harness, setupTarget) => {
   describe('Option: "include"', () => {
-    beforeEach(() => {
-      setupTarget(harness);
+    beforeEach(async () => {
+      await setupTarget(harness);
     });
 
     it(`should fail when includes doesn't match any files`, async () => {

--- a/packages/angular_devkit/build_angular/src/builders/karma/tests/options/styles_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/tests/options/styles_spec.ts
@@ -11,8 +11,8 @@ import { BASE_OPTIONS, KARMA_BUILDER_INFO, describeKarmaBuilder } from '../setup
 
 describeKarmaBuilder(execute, KARMA_BUILDER_INFO, (harness, setupTarget) => {
   describe('Option: "styles"', () => {
-    beforeEach(() => {
-      setupTarget(harness);
+    beforeEach(async () => {
+      await setupTarget(harness);
     });
 
     it(`processes 'styles.css' styles`, async () => {

--- a/packages/angular_devkit/build_angular/src/builders/karma/tests/options/web-worker-tsconfig_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/tests/options/web-worker-tsconfig_spec.ts
@@ -11,8 +11,8 @@ import { BASE_OPTIONS, KARMA_BUILDER_INFO, describeKarmaBuilder } from '../setup
 
 describeKarmaBuilder(execute, KARMA_BUILDER_INFO, (harness, setupTarget, isApplicationBuilder) => {
   describe('Option: "webWorkerTsConfig"', () => {
-    beforeEach(() => {
-      setupTarget(harness);
+    beforeEach(async () => {
+      await setupTarget(harness);
     });
 
     beforeEach(async () => {

--- a/packages/angular_devkit/build_angular/src/builders/karma/tests/setup.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/tests/setup.ts
@@ -35,7 +35,7 @@ export const KARMA_BUILDER_INFO = Object.freeze({
  * Also disables progress reporting to minimize logging output.
  */
 export const BASE_OPTIONS = Object.freeze<Schema>({
-  polyfills: ['zone.js', 'zone.js/testing'],
+  polyfills: ['./src/polyfills', 'zone.js/testing'],
   tsConfig: 'src/tsconfig.spec.json',
   karmaConfig: 'karma.conf.js',
   browsers: 'ChromeHeadlessCI',
@@ -62,10 +62,10 @@ function getCachedSchema(options: { schemaPath: string }): json.schema.JsonSchem
  * @param harness The builder harness to use when setting up the browser builder target
  * @param extraOptions The additional options that should be used when executing the target.
  */
-export function setupBrowserTarget<T>(
+export async function setupBrowserTarget<T>(
   harness: BuilderHarness<T>,
   extraOptions?: Partial<BrowserSchema>,
-): void {
+): Promise<void> {
   const browserSchema = getCachedSchema(BROWSER_BUILDER_INFO);
 
   harness.withBuilderTarget(
@@ -117,10 +117,10 @@ export const APPLICATION_BUILDER_INFO = Object.freeze({
  * @param harness The builder harness to use when setting up the application builder target
  * @param extraOptions The additional options that should be used when executing the target.
  */
-export function setupApplicationTarget<T>(
+export async function setupApplicationTarget<T>(
   harness: BuilderHarness<T>,
   extraOptions?: Partial<ApplicationSchema>,
-): void {
+): Promise<void> {
   const applicationSchema = getCachedSchema(APPLICATION_BUILDER_INFO);
 
   harness.withBuilderTarget(
@@ -135,6 +135,9 @@ export function setupApplicationTarget<T>(
       optionSchema: applicationSchema,
     },
   );
+
+  // For application-builder based targets, the localize polyfill needs to be explicit.
+  await harness.appendToFile('src/polyfills.ts', `import '@angular/localize/init';`);
 }
 
 /** Runs the test against both an application- and a browser-builder context. */


### PR DESCRIPTION
In the v19 application builder, the localize polyfill should not be added implicitly.

See: https://github.com/angular/angular-cli/commit/d6a34034d7489c09753090642ade4c606cd98ece

### What Changes

1. Test: Reference `./src/polyfills.ts` in the base options so we have an easy way to inject the polyfill based on which builder is used.
2. Test: Make the `setupTarget` function async so we can write to the polyfills file as part of the setup.
3. Builder: Remove the code in the application-builder based Karma support to inject localize.