### PR TITLE
feat: allow configuration of the vite HMR server

### DIFF
--- a/packages/angular/build/src/builders/dev-server/schema.json
+++ b/packages/angular/build/src/builders/dev-server/schema.json
@@ -66,9 +66,39 @@
       "description": "The pathname where the application will be served."
     },
     "hmr": {
-      "type": "boolean",
-      "description": "Enable hot module replacement.",
-      "default": false
+      "description": "Disable or configure HMR connection",
+      "default": false,
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "protocol": {
+              "type": "string",
+              "description": "The WebSocket protocol used for the HMR connection: ws (WebSocket) or wss (WebSocket Secure)."
+            },
+            "host": {
+              "type": "string",
+              "description": "The IP addresses or domain the HMR server should listen on."
+            },
+            "port": {
+              "type": "number",
+              "description": "The port the HMR server should listen on."
+            },
+            "overlay": {
+              "type": "boolean",
+              "description": "Set to false to disable the server error overlay."
+            },
+            "clientPort": {
+              "type": "number",
+              "description": "An advanced option that overrides the port only on the client side, allowing you to serve the websocket on a different port than the client code looks for it on."
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "boolean"
+        }
+      ]
     },
     "watch": {
       "type": "boolean",

--- a/packages/angular/build/src/builders/dev-server/vite-server.ts
+++ b/packages/angular/build/src/builders/dev-server/vite-server.ts
@@ -218,7 +218,7 @@ export async function* serveWithVite(
         // TODO: Implement support -- application builder currently does not use
         break;
       case ResultKind.ComponentUpdate:
-        assert(serverOptions.hmr, 'Component updates are only supported with HMR enabled.');
+        assert(!!serverOptions.hmr, 'Component updates are only supported with HMR enabled.');
         // TODO: Implement support -- application builder currently does not use
         break;
       default:
@@ -430,7 +430,7 @@ async function handleUpdate(
     return;
   }
 
-  if (serverOptions.liveReload || serverOptions.hmr) {
+  if (serverOptions.liveReload || !!serverOptions.hmr) {
     if (updatedFiles.every((f) => f.endsWith('.css'))) {
       const timestamp = Date.now();
       server.hot.send({
@@ -613,6 +613,7 @@ export async function setupServer(
       open: serverOptions.open,
       headers: serverOptions.headers,
       proxy,
+      hmr: serverOptions.hmr,
       cors: {
         // Allow preflight requests to be proxied.
         preflightContinue: true,


### PR DESCRIPTION
Vite allows additional configuration options for the HMR server that let the user set the port, protocol and host etc. of the HMR server.



Configuring HMR server to run on a different port to the main application fixes the issue

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently it is impossible to configure the vite HMR server as this configuration option is not made available.

There is a bug in vite/browserstack which currently prevents running a local application using browserstack as the page will reload every ~50 seconds due to the websocket connection being lost. For some reason this only occurs when the application and the HMR are being served on the same port, resulting in the following error being thrown `client:529 WebSocket connection to 'ws://localhost:4200/' failed: Unrecognized frame opcode: 5`. 
On receiving this error vite triggers a reload https://github.com/vitejs/vite/blob/eb08f605ddadef99a5d68f55de143e3e47c91618/packages/vite/src/client/client.ts#L106-L108

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the new behavior that. -->

It is now possible to configure the hmr configuration in the angular.json making it possible to configure more advanced hmr settings (https://vitejs.dev/config/server-options.html#server-hmr).

A use case of this is that it allows a custom hmr config which bypasses the browserstack error seen above.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
