### PR TITLE
refactor(@angular/build): enable SSR when disabling Prerendering in Vite

### DIFF
--- a/packages/angular/build/src/builders/dev-server/vite-server.ts
+++ b/packages/angular/build/src/builders/dev-server/vite-server.ts
@@ -103,6 +103,7 @@ export async function* serveWithVite(
     // Disable prerendering if enabled and force SSR.
     // This is so instead of prerendering all the routes for every change, the page is "prerendered" when it is requested.
     browserOptions.prerender = false;
+    browserOptions.ssr ||= true;
   }
 
   // Set all packages as external to support Vite's prebundle caching

--- a/packages/angular/build/src/tools/vite/middlewares/ssr-middleware.ts
+++ b/packages/angular/build/src/tools/vite/middlewares/ssr-middleware.ts
@@ -32,6 +32,9 @@ export function createAngularSsrInternalMiddleware(
     }
 
     (async () => {
+      // Load the compiler because `@angular/ssr/node` depends on `@angular/` packages,
+      // which must be processed by the runtime linker, even if they are not used.
+      await loadEsmModule('@angular/compiler');
       const { writeResponseToNodeResponse, createWebRequestFromNodeRequest } =
         await loadEsmModule<typeof import('@angular/ssr/node')>('@angular/ssr/node');
 
@@ -73,6 +76,10 @@ export async function createAngularSsrExternalMiddleware(
   let angularSsrInternalMiddleware:
     | ReturnType<typeof createAngularSsrInternalMiddleware>
     | undefined;
+
+  // Load the compiler because `@angular/ssr/node` depends on `@angular/` packages,
+  // which must be processed by the runtime linker, even if they are not used.
+  await loadEsmModule('@angular/compiler');
 
   const { createWebRequestFromNodeRequest, writeResponseToNodeResponse } =
     await loadEsmModule<typeof import('@angular/ssr/node')>('@angular/ssr/node');


### PR DESCRIPTION
This commit activates ssr in the Vite when prerendering is disabled internally.

Closes #28523
