### PR TITLE
fix(@angular/build): separate Vite cache by project

### DIFF
--- a/packages/angular/build/src/builders/dev-server/vite-server.ts
+++ b/packages/angular/build/src/builders/dev-server/vite-server.ts
@@ -574,7 +574,7 @@ export async function setupServer(
     join(serverOptions.workspaceRoot, `.angular/vite-root`, serverOptions.buildTarget.project),
   );
 
-  const cacheDir = join(serverOptions.cacheOptions.path, 'vite');
+  const cacheDir = join(serverOptions.cacheOptions.path, serverOptions.buildTarget.project, 'vite');
   const configuration: InlineConfig = {
     configFile: false,
     envFile: false,


### PR DESCRIPTION
Previously, Vite prebundled dependencies were stored in a shared directory across all projects, which caused the `_metadata.json` files to be overwritten. This resulted in undefined behavior, such as re-optimizing dependencies on each run when multiple projects were present in the workspace. Additionally, it introduced conflicts when running multiple `ng serve` processes simultaneously.

Closes #28536
