### PR TITLE
fix(@angular/build): disable dev-server websocket when live reload is disabled

### DIFF
--- a/packages/angular/build/src/builders/dev-server/vite-server.ts
+++ b/packages/angular/build/src/builders/dev-server/vite-server.ts
@@ -612,6 +612,8 @@ export async function setupServer(
       host: serverOptions.host,
       open: serverOptions.open,
       headers: serverOptions.headers,
+      // Disable the websocket if live reload is disabled (false/undefined are the only valid values)
+      ws: serverOptions.liveReload === false ? false : undefined,
       proxy,
       cors: {
         // Allow preflight requests to be proxied.
@@ -671,6 +673,7 @@ export async function setupServer(
         virtualProjectRoot,
         outputFiles,
         external: externalMetadata.explicitBrowser,
+        skipViteClient: serverOptions.liveReload === false,
       }),
     ],
     // Browser only optimizeDeps. (This does not run for SSR dependencies).

--- a/packages/angular/build/src/tools/vite/plugins/angular-memory-plugin.ts
+++ b/packages/angular/build/src/tools/vite/plugins/angular-memory-plugin.ts
@@ -17,6 +17,7 @@ interface AngularMemoryPluginOptions {
   virtualProjectRoot: string;
   outputFiles: AngularMemoryOutputFiles;
   external?: string[];
+  skipViteClient?: boolean;
 }
 
 export async function createAngularMemoryPlugin(
@@ -63,9 +64,11 @@ export async function createAngularMemoryPlugin(
       const relativeFile = '/' + normalizePath(relative(virtualProjectRoot, file));
       const codeContents = outputFiles.get(relativeFile)?.contents;
       if (codeContents === undefined) {
-        return relativeFile.endsWith('/node_modules/vite/dist/client/client.mjs')
-          ? loadViteClientCode(file)
-          : undefined;
+        if (relativeFile.endsWith('/node_modules/vite/dist/client/client.mjs')) {
+          return options.skipViteClient ? '' : loadViteClientCode(file);
+        }
+
+        return undefined;
       }
 
       const code = Buffer.from(codeContents).toString('utf-8');


### PR DESCRIPTION
When live reload is disabled (`"liveReload": false`/`no-live-reload`) within the development server, the Vite websocket server will no longer be initialized. Additionally, the client code will not be loaded by the browser. This allows the development server to be used in test scenarios that would prefer to more fully represent the production fielded configuration such as E2E testing or other forms of browser-based testing.