### PR TITLE
Avoid `for await...of` with promise arrays

### DIFF
--- a/packages/angular_devkit/build_angular/src/utils/tailwind.ts
+++ b/packages/angular_devkit/build_angular/src/utils/tailwind.ts
@@ -28,7 +28,7 @@ export async function findTailwindConfigurationFile(
   );
 
   // A configuration file can exist in the project or workspace root
-  for await (const { root, files } of dirEntries) {
+  for (const { root, files } of await Promise.all(dirEntries)) {
     for (const potentialConfig of tailwindConfigFiles) {
       if (files.has(potentialConfig)) {
         return join(root, potentialConfig);

--- a/packages/angular_devkit/schematics/src/rules/base.ts
+++ b/packages/angular_devkit/schematics/src/rules/base.ts
@@ -35,8 +35,14 @@ export function empty(): Source {
 export function chain(rules: Iterable<Rule> | AsyncIterable<Rule>): Rule {
   return async (initialTree, context) => {
     let intermediateTree: Observable<Tree> | undefined;
-    for await (const rule of rules) {
-      intermediateTree = callRule(rule, intermediateTree ?? initialTree, context);
+    if (Symbol.asyncIterator in rules) {
+      for await (const rule of rules) {
+        intermediateTree = callRule(rule, intermediateTree ?? initialTree, context);
+      }
+    } else {
+      for (const rule of rules) {
+        intermediateTree = callRule(rule, intermediateTree ?? initialTree, context);
+      }
     }
 
     return () => intermediateTree;


### PR DESCRIPTION
The upcoming version of typescript Eslint rules will fail the `await-thenable`
rule for cases of for await...of that use promise arrays. This change
removes the usage to avoid lint failures during the version update.
Ref: https://typescript-eslint.io/rules/await-thenable/#async-iteration-for-awaitof-loops

Unblocks: #28534