### PR TITLE
refactor(@angular/ssr): Convert crypto unavailable error to a soft error

### DIFF
--- a/packages/angular/ssr/src/app.ts
+++ b/packages/angular/ssr/src/app.ts
@@ -254,7 +254,17 @@ export class AngularServerApp {
         return this.assets.getServerAsset(fileName);
       });
 
-      if (isSsrMode) {
+      // TODO(alanagius): remove once Node.js version 18 is no longer supported.
+      if (isSsrMode && typeof crypto === 'undefined') {
+        // eslint-disable-next-line no-console
+        console.error(
+          `The global 'crypto' module is unavailable. ` +
+            `If you are running on Node.js, please ensure you are using version 20 or later, ` +
+            `which includes built-in support for the Web Crypto module.`,
+        );
+      }
+
+      if (isSsrMode && typeof crypto !== 'undefined') {
         // Only cache if we are running in SSR Mode.
         const cacheKey = await sha256(html);
         let htmlWithCriticalCss = this.criticalCssLRUCache.get(cacheKey);

--- a/packages/angular/ssr/src/utils/crypto.ts
+++ b/packages/angular/ssr/src/utils/crypto.ts
@@ -14,15 +14,6 @@
  * represented as a hexadecimal string.
  */
 export async function sha256(data: string): Promise<string> {
-  if (typeof crypto === 'undefined') {
-    // TODO(alanagius): remove once Node.js version 18 is no longer supported.
-    throw new Error(
-      `The global 'crypto' module is unavailable. ` +
-        `If you are running on Node.js, please ensure you are using version 20 or later, ` +
-        `which includes built-in support for the Web Crypto module.`,
-    );
-  }
-
   const encodedData = new TextEncoder().encode(data);
   const hashBuffer = await crypto.subtle.digest('SHA-256', encodedData);
   const hashParts: string[] = [];


### PR DESCRIPTION
This update changes the handling of the crypto unavailable error in the Angular SSR environment. Instead of throwing a hard error, which could interrupt the application flow, the error is now treated as a soft error
