### PR TITLE
fix(@schematics/angular): add validation for component and directive …

### DIFF
--- a/packages/schematics/angular/component/index.ts
+++ b/packages/schematics/angular/component/index.ts
@@ -25,7 +25,7 @@ import {
 import { addDeclarationToNgModule } from '../utility/add-declaration-to-ng-module';
 import { findModuleFromOptions } from '../utility/find-module';
 import { parseName } from '../utility/parse-name';
-import { validateHtmlSelector } from '../utility/validation';
+import { validateClassName, validateHtmlSelector } from '../utility/validation';
 import { buildDefaultPath, getWorkspace } from '../utility/workspace';
 import { Schema as ComponentOptions, Style } from './schema';
 
@@ -62,6 +62,7 @@ export default function (options: ComponentOptions): Rule {
       options.selector || buildSelector(options, (project && project.prefix) || '');
 
     validateHtmlSelector(options.selector);
+    validateClassName(strings.classify(options.name));
 
     const skipStyleFile = options.inlineStyle || options.style === Style.None;
     const templateSource = apply(url('./files'), [

--- a/packages/schematics/angular/component/index_spec.ts
+++ b/packages/schematics/angular/component/index_spec.ts
@@ -157,6 +157,14 @@ describe('Component Schematic', () => {
     ).toBeRejectedWithError('Selector "app-1-one" is invalid.');
   });
 
+  it('should error when class name contains invalid characters', async () => {
+    const options = { ...defaultOptions, name: '404' };
+
+    await expectAsync(
+      schematicRunner.runSchematic('component', options, appTree),
+    ).toBeRejectedWithError('Class name "404" is invalid.');
+  });
+
   it('should allow dash in selector before a number', async () => {
     const options = { ...defaultOptions, name: 'one-1' };
 

--- a/packages/schematics/angular/directive/index.ts
+++ b/packages/schematics/angular/directive/index.ts
@@ -23,7 +23,7 @@ import {
 import { addDeclarationToNgModule } from '../utility/add-declaration-to-ng-module';
 import { findModuleFromOptions } from '../utility/find-module';
 import { parseName } from '../utility/parse-name';
-import { validateHtmlSelector } from '../utility/validation';
+import { validateClassName, validateHtmlSelector } from '../utility/validation';
 import { buildDefaultPath, getWorkspace } from '../utility/workspace';
 import { Schema as DirectiveOptions } from './schema';
 
@@ -58,6 +58,7 @@ export default function (options: DirectiveOptions): Rule {
     options.selector = options.selector || buildSelector(options, project.prefix || '');
 
     validateHtmlSelector(options.selector);
+    validateClassName(strings.classify(options.name));
 
     const templateSource = apply(url('./files'), [
       options.skipTests ? filter((path) => !path.endsWith('.spec.ts.template')) : noop(),

--- a/packages/schematics/angular/directive/index_spec.ts
+++ b/packages/schematics/angular/directive/index_spec.ts
@@ -111,6 +111,14 @@ describe('Directive Schematic', () => {
     expect(directiveContent).toContain('class FooDirective');
   });
 
+  it('should error when class name contains invalid characters', async () => {
+    const options = { ...defaultOptions, name: '404' };
+
+    await expectAsync(
+      schematicRunner.runSchematic('component', options, appTree),
+    ).toBeRejectedWithError('Class name "404" is invalid.');
+  });
+
   describe('standalone=false', () => {
     const defaultNonStandaloneOptions: DirectiveOptions = {
       ...defaultOptions,


### PR DESCRIPTION
fix(@schematics/angular): add validation for component and directive class name

class names for directives and components when they are created using `ng generate component <className>`
added tests for the changes made above

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #28548 

## What is the new behavior?

When a component or directive is created using an invalid character, such as a class name that begins with a number or a component or directive name that contains only a number, cli will throw an error.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
