### PR TITLE
fix(@angular/build): always generate a new hash for optimized chunk

### DIFF
--- a/packages/angular/build/src/builders/application/chunk-optimizer.ts
+++ b/packages/angular/build/src/builders/application/chunk-optimizer.ts
@@ -103,10 +103,7 @@ export async function optimizeChunks(
     const result = await bundle.generate({
       compact: true,
       sourcemap,
-      chunkFileNames(chunkInfo) {
-        // Do not add hash to file name if already present
-        return /-[a-zA-Z0-9]{8}$/.test(chunkInfo.name) ? '[name].js' : '[name]-[hash].js';
-      },
+      chunkFileNames: (chunkInfo) => `${chunkInfo.name.replace(/-[a-zA-Z0-9]{8}$/, '')}-[hash].js`,
     });
     optimizedOutput = result.output;
   } catch (e) {


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Rollup chunk optimizer preserves file name hashes from esbuild and doesn't add a new hash for these files 

Issue Number: [28569](https://github.com/angular/angular-cli/issues/28569)

## What is the new behavior?

Rollup chunk optimizer always adds a new hash to the filename. Hash from esbuild is removed

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
