### PR TITLE
fix(@angular-devkit/build-angular): handle main field

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/karma/tests/behavior/fake-async_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/tests/behavior/fake-async_spec.ts
@@ -9,7 +9,7 @@
 import { execute } from '../../index';
 import { BASE_OPTIONS, KARMA_BUILDER_INFO, describeKarmaBuilder } from '../setup';
 
-describeKarmaBuilder(execute, KARMA_BUILDER_INFO, (harness, setupTarget, isApp) => {
+describeKarmaBuilder(execute, KARMA_BUILDER_INFO, (harness, setupTarget) => {
   describe('Behavior: "fakeAsync"', () => {
     beforeEach(async () => {
       await setupTarget(harness);

--- a/packages/angular_devkit/build_angular/src/builders/karma/tests/options/main_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/tests/options/main_spec.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { execute } from '../../index';
+import { BASE_OPTIONS, KARMA_BUILDER_INFO, describeKarmaBuilder } from '../setup';
+
+describeKarmaBuilder(execute, KARMA_BUILDER_INFO, (harness, setupTarget) => {
+  describe('Option: "main"', () => {
+    beforeEach(async () => {
+      await setupTarget(harness);
+    });
+
+    beforeEach(async () => {
+      await harness.writeFiles({
+        'src/magic.ts': `Object.assign(globalThis, {MAGIC_IS_REAL: true});`,
+        'src/magic.spec.ts': `
+            declare const MAGIC_IS_REAL: boolean;
+            describe('Magic', () => {
+              it('can be scientificially proven to be true', () => {
+                expect(typeof MAGIC_IS_REAL).toBe('boolean');
+              });
+            });`,
+      });
+      // Remove this test, we don't expect it to pass with our setup script.
+      await harness.removeFile('src/app/app.component.spec.ts');
+
+      // Add src/magic.ts to tsconfig.
+      interface TsConfig {
+        files: string[];
+      }
+      const tsConfig = JSON.parse(harness.readFile('src/tsconfig.spec.json')) as TsConfig;
+      tsConfig.files.push('magic.ts');
+      await harness.writeFile('src/tsconfig.spec.json', JSON.stringify(tsConfig));
+    });
+
+    it('uses custom setup file', async () => {
+      harness.useTarget('test', {
+        ...BASE_OPTIONS,
+        main: './src/magic.ts',
+      });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
+    });
+  });
+});


### PR DESCRIPTION
1. Move `init_test_bed.js` to the end of polyfills to ensure it always runs before any of the test chunks.
2. Add source maps to served files and only add `worker-*` and `chunk-*` files if there are any. This is meant to reduce the number of warnings Karma logs. In practice any non-trivial app should have _some_ `chunk-*` files for their test suite.
3. If `options.main` is provided, use that file instead of the default `init_test_bed.js`.
4. Add a new test that prevent future regressions with handling of the `main` option.