### PR TITLE
fix(@angular/build): ensure `index.csr.html` is always generated when prerendering or SSR are enabled

### DIFF
--- a/packages/angular/build/src/builders/application/options.ts
+++ b/packages/angular/build/src/builders/application/options.ts
@@ -320,10 +320,16 @@ export async function normalizeOptions(
        * If SSR is activated, create a distinct entry file for the `index.html`.
        * This is necessary because numerous server/cloud providers automatically serve the `index.html` as a static file
        * if it exists (handling SSG).
+       *
        * For instance, accessing `foo.com/` would lead to `foo.com/index.html` being served instead of hitting the server.
+       *
+       * This approach can also be applied to service workers, where the `index.csr.html` is served instead of the prerendered `index.html`.
        */
       const indexBaseName = path.basename(options.index);
-      indexOutput = ssrOptions && indexBaseName === 'index.html' ? INDEX_HTML_CSR : indexBaseName;
+      indexOutput =
+        (ssrOptions || prerenderOptions) && indexBaseName === 'index.html'
+          ? INDEX_HTML_CSR
+          : indexBaseName;
     } else {
       indexOutput = options.index.output || 'index.html';
     }

--- a/tests/legacy-cli/e2e/tests/build/prerender/discover-routes-ngmodule.ts
+++ b/tests/legacy-cli/e2e/tests/build/prerender/discover-routes-ngmodule.ts
@@ -118,11 +118,19 @@ export default async function () {
     return;
   }
 
-  await ng('build', projectName, '--configuration=production', '--prerender');
+  await ng('build', projectName, '--configuration=production', '--prerender', '--no-ssr');
   await runExpects();
 
   // Test also JIT mode.
-  await ng('build', projectName, '--configuration=development', '--prerender', '--no-aot');
+  await ng(
+    'build',
+    projectName,
+    '--configuration=development',
+    '--prerender',
+    '--no-ssr',
+    '--no-aot',
+  );
+
   await runExpects();
 
   async function runExpects(): Promise<void> {
@@ -135,6 +143,10 @@ export default async function () {
       'lazy-one/lazy-one-child/index.html': 'lazy-one-child works!',
       'lazy-two/index.html': 'lazy-two works!',
     };
+
+    if (!useWebpackBuilder) {
+      expects['index.csr.html'] = '<app-root></app-root>';
+    }
 
     const distPath = 'dist/' + projectName + '/browser';
     for (const [filePath, fileMatch] of Object.entries(expects)) {


### PR DESCRIPTION


This commit addresses an issue where `index.csr.html` was not being generated when SSR was disabled and prerendering was enabled.

Closes #28580
