### PR TITLE
fix(@angular/build): show error message when error stack is undefined

### DIFF
--- a/packages/angular/build/src/utils/server-rendering/prerender.ts
+++ b/packages/angular/build/src/utils/server-rendering/prerender.ts
@@ -334,7 +334,9 @@ async function getAllRoutes(
     assertIsError(err);
 
     return {
-      errors: [`An error occurred while extracting routes.\n\n${err.stack}`],
+      errors: [
+        `An error occurred while extracting routes.\n\n${err.stack ?? err.message ?? err.code ?? err}`,
+      ],
       serializedRouteTree: [],
     };
   } finally {


### PR DESCRIPTION
Handle cases where the error stack is missing by displaying a relevant message.

Closes #28590
