### PR TITLE
fix(@angular/build): move lmdb to optionalDependencies

### DIFF
--- a/packages/angular/build/package.json
+++ b/packages/angular/build/package.json
@@ -33,7 +33,6 @@
     "https-proxy-agent": "7.0.5",
     "istanbul-lib-instrument": "6.0.3",
     "listr2": "8.2.5",
-    "lmdb": "3.1.3",
     "magic-string": "0.30.11",
     "mrmime": "2.0.0",
     "parse5-html-rewriting-stream": "7.0.0",
@@ -44,6 +43,9 @@
     "semver": "7.6.3",
     "vite": "5.4.8",
     "watchpack": "2.4.2"
+  },
+  "optionalDependencies": {
+    "lmdb": "3.1.3"
   },
   "peerDependencies": {
     "@angular/compiler": "^19.0.0-next.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -418,6 +418,9 @@ __metadata:
     postcss: ^8.4.0
     tailwindcss: ^2.0.0 || ^3.0.0
     typescript: ">=5.5 <5.7"
+  dependenciesMeta:
+    lmdb:
+      optional: true
   peerDependenciesMeta:
     "@angular/localize":
       optional: true


### PR DESCRIPTION
A warning mechanism has been implemented to notify users when lmdb is unavailable. On Windows ARM64 systems, however, installing this package with pnpm appears to cause installation failures.

See: https://github.com/angular/angular-cli/issues/27882#issuecomment-2395029997

Closes #27882
