### PR TITLE
fix(@angular/build): `Ctrl + C` not terminating dev-server with SSR

### DIFF
--- a/packages/angular/build/src/builders/dev-server/vite-server.ts
+++ b/packages/angular/build/src/builders/dev-server/vite-server.ts
@@ -334,6 +334,13 @@ export async function* serveWithVite(
         ssrMode = ServerSsrMode.InternalSsrMiddleware;
       }
 
+      if (browserOptions.progress !== false && ssrMode !== ServerSsrMode.NoSsr) {
+        // This is a workaround for https://github.com/angular/angular-cli/issues/28336, which is caused by the interaction between `zone.js` and `listr2`.
+        process.once('SIGINT', () => {
+          process.kill(process.pid);
+        });
+      }
+
       // Setup server and start listening
       const serverConfiguration = await setupServer(
         serverOptions,


### PR DESCRIPTION
This commit provides a workaround for https://github.com/angular/angular-cli/issues/28336, which occurs due to the interaction between `zone.js` and `listr2`. The issue prevents proper termination of the development server using Ctrl + C when dev-server.

Closes: #28336