### PR TITLE
[backport] fix(@angular/build): `Ctrl + C` not terminating dev-server with SSR

### DIFF
--- a/packages/angular/build/src/builders/dev-server/vite-server.ts
+++ b/packages/angular/build/src/builders/dev-server/vite-server.ts
@@ -96,6 +96,13 @@ export async function* serveWithVite(
 
     // https://nodejs.org/api/process.html#processsetsourcemapsenabledval
     process.setSourceMapsEnabled(true);
+
+    if (browserOptions.progress !== false) {
+      // This is a workaround for https://github.com/angular/angular-cli/issues/28336, which is caused by the interaction between `zone.js` and `listr2`.
+      process.once('SIGINT', () => {
+        process.kill(process.pid);
+      });
+    }
   }
 
   // Set all packages as external to support Vite's prebundle caching


### PR DESCRIPTION
Patch version of https://github.com/angular/angular-cli/pull/28604