### PR TITLE
fix:@schematics/angular update browserslist config to include last 2 Android major versions

### DIFF
--- a/packages/angular/build/src/utils/supported-browsers.ts
+++ b/packages/angular/build/src/utils/supported-browsers.ts
@@ -18,6 +18,7 @@ export function getSupportedBrowsers(
     'last 2 Edge major versions',
     'last 2 Safari major versions',
     'last 2 iOS major versions',
+    'last 2 Android major versions',
     'Firefox ESR',
   ];
 

--- a/packages/schematics/angular/config/files/.browserslistrc.template
+++ b/packages/schematics/angular/config/files/.browserslistrc.template
@@ -13,4 +13,5 @@ last 1 Firefox version
 last 2 Edge major versions
 last 2 Safari major versions
 last 2 iOS major versions
+last 2 Android major versions
 Firefox ESR


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?
Adding a small change to the default browserslist
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
The command `ng g config browserslist` is not showing `last 2 Android major versions` in the `.browserslistrc` file. 
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #26834 

## What is the new behavior?
The command `ng g config browserslist` will start to show `last 2 Android major versions` in the `.browserslistrc` file. 
<!-- Please describe the new behavior that. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
