### PR TITLE
docs(@schematics/angular): update code scaffolding doc to with `ng generate --help`

### DIFF
--- a/modules/testing/builder/projects/hello-world-app/README.md
+++ b/modules/testing/builder/projects/hello-world-app/README.md
@@ -8,7 +8,7 @@ Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The app w
 
 ## Code scaffolding
 
-Run `ng generate component component-name` to generate a new component. You can also use `ng generate directive|pipe|service|class|guard|interface|enum|module`.
+Run `ng generate component component-name` to generate a new component. You can also use `ng generate --help` to see all the available schematics you can generate.
 
 ## Build
 

--- a/packages/schematics/angular/workspace/files/README.md.template
+++ b/packages/schematics/angular/workspace/files/README.md.template
@@ -8,7 +8,7 @@ Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The appli
 
 ## Code scaffolding
 
-Run `ng generate component component-name` to generate a new component. You can also use `ng generate directive|pipe|service|class|guard|interface|enum|module`.
+Run `ng generate component component-name` to generate a new component. You can also use `ng generate --help` to see all the available schematics you can generate.
 
 ## Build
 

--- a/tests/legacy-cli/e2e/assets/15.0-project/README.md
+++ b/tests/legacy-cli/e2e/assets/15.0-project/README.md
@@ -8,7 +8,7 @@ Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The appli
 
 ## Code scaffolding
 
-Run `ng generate component component-name` to generate a new component. You can also use `ng generate directive|pipe|service|class|guard|interface|enum|module`.
+Run `ng generate component component-name` to generate a new component. You can also use `ng generate --help` to see all the available schematics you can generate.
 
 ## Build
 

--- a/tests/legacy-cli/e2e/assets/18-ssr-project-webpack/README.md
+++ b/tests/legacy-cli/e2e/assets/18-ssr-project-webpack/README.md
@@ -8,7 +8,7 @@ Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The appli
 
 ## Code scaffolding
 
-Run `ng generate component component-name` to generate a new component. You can also use `ng generate directive|pipe|service|class|guard|interface|enum|module`.
+Run `ng generate component component-name` to generate a new component. You can also use `ng generate --help` to see all the available schematics you can generate.
 
 ## Build
 

--- a/tests/legacy-cli/e2e/assets/19-ssr-project-webpack/README.md
+++ b/tests/legacy-cli/e2e/assets/19-ssr-project-webpack/README.md
@@ -8,7 +8,7 @@ Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The appli
 
 ## Code scaffolding
 
-Run `ng generate component component-name` to generate a new component. You can also use `ng generate directive|pipe|service|class|guard|interface|enum|module`.
+Run `ng generate component component-name` to generate a new component. You can also use `ng generate --help` to see all the available schematics you can generate.
 
 ## Build
 


### PR DESCRIPTION


## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?
Improve the Code scaffolding section.
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
Code scaffolding section is updated a while ago and new commands associated with `ng generate` is not included. Only a subset of available schematics is documented in this section.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #28059 

## What is the new behavior?
This PR updates the code scaffolding section to inform users about the various commands available with `ng generate`, such as `ng generate component`.

Since the list of commands may evolve in the future, it's best to guide developers to use the `--help` option with `generate`. The documentation is now rewritten to highlight the use of `ng generate --help` for accessing the most up-to-date list of commands.
<!-- Please describe the new behavior that. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
