### PR TITLE
ci: disable auto-updates for `@types/express`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,7 @@
   "dependencyDashboard": true,
   "schedule": ["after 10:00pm every weekday", "before 4:00am every weekday", "every weekend"],
   "baseBranches": ["main"],
-  "ignoreDeps": ["@types/node", "build_bazel_rules_nodejs", "rules_pkg", "yarn"],
+  "ignoreDeps": ["@types/node", "@types/express", "build_bazel_rules_nodejs", "rules_pkg", "yarn"],
   "includePaths": [
     "WORKSPACE",
     "package.json",


### PR DESCRIPTION
Express version 5 is still in beta, but the types are incorrectly marked as the latest version.

