### PR TITLE
fix(@angular/build): avoid race condition in sass importer

### DIFF
--- a/packages/angular/build/src/tools/sass/worker.ts
+++ b/packages/angular/build/src/tools/sass/worker.ts
@@ -106,6 +106,25 @@ export default async function renderSassStylesheet(
               containingUrl: containingUrl ? fileURLToPath(containingUrl) : null,
             },
           });
+          // Wait for the main thread to set the signal to 1 and notify, which tells
+          // us that a message can be received on the port.
+          // If the main thread is fast, the signal will already be set to 1, and no
+          // sleep/notify is necessary.
+          // However, there can be a race condition here:
+          // - the main thread sets the signal to 1, but does not get to the notify instruction yet
+          // - the worker does not pause because the signal is set to 1
+          // - the worker very soon enters this method again
+          // - this method sets the signal to 0 and sends the message
+          // - the signal is 0 and so the `Atomics.wait` call blocks
+          // - only now the main thread runs the `notify` from the first invocation, so the
+          //   worker continues.
+          // - but there is no message yet in the port, because the thread should not have been
+          //   waken up yet.
+          // To combat this, wait for a non-0 value _twice_.
+          // Almost every time, this immediately continues with "not-equal", because
+          // the signal is still set to 1, except during the race condition, when the second
+          // wait will wait for the correct notify.
+          Atomics.wait(importerChannel.signal, 0, 0);
           Atomics.wait(importerChannel.signal, 0, 0);
 
           const result = receiveMessageOnPort(importerChannel.port)?.message as string | null;


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #27167

Builds under load sometimes fail with "Can't find stylesheet to import" errors.

I was able to reproduce this error in my CI pipeline consistently, by running 4 `npx ng build` builds in parallel on an 8 core VPS. It also occurs sometimes during regular builds/`ng test`, especially when other concurrent jobs put load on the system.

By adding lots and lots of logging, I found the root cause, which is a race condition when the sass worker manages to call `findFileUrl` again in between `Atomics.store(..., 0, 1)` and `Atomics.notify(..., 0)` invocations - I left more details as a comment.

## What is the new behavior?

The race no longer causes failing builds. After being notified, the worker checks again that the signal is not set to 0, and waits for another `notify` if necessary, which will be the correct one.

<!-- Please describe the new behavior that. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
I verified that the second `Atomics.wait(..., 0, 0)` actually does something meaningful, by logging the return value. Under load, I observed two instances where the return value was `"ok"`, indicating that the signal was 0 at the time of the second `wait`, and the build would therefore have aborted without the change.
