### PR TITLE
Remove Protractor Builder

### DIFF
--- a/modules/testing/builder/projects/hello-world-app/angular.json
+++ b/modules/testing/builder/projects/hello-world-app/angular.json
@@ -178,7 +178,7 @@
       "projectType": "application",
       "targets": {
         "e2e": {
-          "builder": "@angular-devkit/build-angular:protractor",
+          "builder": "@angular-devkit/build-angular:private-protractor",
           "options": {
             "protractorConfig": "protractor.conf.js",
             "devServerTarget": "app:serve",

--- a/packages/angular/cli/lib/config/workspace-schema.json
+++ b/packages/angular/cli/lib/config/workspace-schema.json
@@ -368,7 +368,6 @@
                       "@angular-devkit/build-angular:prerender",
                       "@angular-devkit/build-angular:jest",
                       "@angular-devkit/build-angular:web-test-runner",
-                      "@angular-devkit/build-angular:protractor",
                       "@angular-devkit/build-angular:server",
                       "@angular-devkit/build-angular:ssr-dev-server"
                     ]
@@ -652,28 +651,6 @@
                   "type": "object",
                   "additionalProperties": {
                     "$ref": "../../../../angular_devkit/build_angular/src/builders/web-test-runner/schema.json"
-                  }
-                }
-              }
-            },
-            {
-              "type": "object",
-              "additionalProperties": false,
-              "properties": {
-                "builder": {
-                  "const": "@angular-devkit/build-angular:protractor"
-                },
-                "defaultConfiguration": {
-                  "type": "string",
-                  "description": "A default named configuration to use when a target configuration is not provided."
-                },
-                "options": {
-                  "$ref": "../../../../angular_devkit/build_angular/src/builders/protractor/schema.json"
-                },
-                "configurations": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "$ref": "../../../../angular_devkit/build_angular/src/builders/protractor/schema.json"
                   }
                 }
               }

--- a/packages/angular_devkit/build_angular/builders.json
+++ b/packages/angular_devkit/build_angular/builders.json
@@ -42,10 +42,10 @@
       "schema": "./src/builders/web-test-runner/schema.json",
       "description": "Run unit tests with Web Test Runner."
     },
-    "protractor": {
+    "private-protractor": {
       "implementation": "./src/builders/protractor",
       "schema": "./src/builders/protractor/schema.json",
-      "description": "Run protractor over a dev server."
+      "description": "PRIVATE API - Do not use."
     },
     "server": {
       "implementation": "./src/builders/server",

--- a/packages/angular_devkit/core/src/workspace/json/test/angular.json
+++ b/packages/angular_devkit/core/src/workspace/json/test/angular.json
@@ -111,7 +111,7 @@
       "prefix": "",
       "architect": {
         "e2e": {
-          "builder": "@angular-devkit/build-angular:protractor",
+          "builder": "@angular-devkit/build-angular:private-protractor",
           "options": {
             "protractorConfig": "e2e/protractor.conf.js",
             "devServerTarget": "my-app:serve"

--- a/packages/angular_devkit/core/src/workspace/json/test/cases/AddProject2.json
+++ b/packages/angular_devkit/core/src/workspace/json/test/cases/AddProject2.json
@@ -111,7 +111,7 @@
       "prefix": "",
       "architect": {
         "e2e": {
-          "builder": "@angular-devkit/build-angular:protractor",
+          "builder": "@angular-devkit/build-angular:private-protractor",
           "options": {
             "protractorConfig": "e2e/protractor.conf.js",
             "devServerTarget": "my-app:serve"

--- a/packages/angular_devkit/core/src/workspace/json/test/cases/AddProject3.json
+++ b/packages/angular_devkit/core/src/workspace/json/test/cases/AddProject3.json
@@ -111,7 +111,7 @@
       "prefix": "",
       "architect": {
         "e2e": {
-          "builder": "@angular-devkit/build-angular:protractor",
+          "builder": "@angular-devkit/build-angular:private-protractor",
           "options": {
             "protractorConfig": "e2e/protractor.conf.js",
             "devServerTarget": "my-app:serve"

--- a/packages/angular_devkit/core/src/workspace/json/test/cases/ProjectAddTarget.json
+++ b/packages/angular_devkit/core/src/workspace/json/test/cases/ProjectAddTarget.json
@@ -114,7 +114,7 @@
       "prefix": "",
       "architect": {
         "e2e": {
-          "builder": "@angular-devkit/build-angular:protractor",
+          "builder": "@angular-devkit/build-angular:private-protractor",
           "options": {
             "protractorConfig": "e2e/protractor.conf.js",
             "devServerTarget": "my-app:serve"

--- a/packages/angular_devkit/core/src/workspace/json/test/cases/ProjectDeleteTarget.json
+++ b/packages/angular_devkit/core/src/workspace/json/test/cases/ProjectDeleteTarget.json
@@ -105,7 +105,7 @@
       "prefix": "",
       "architect": {
         "e2e": {
-          "builder": "@angular-devkit/build-angular:protractor",
+          "builder": "@angular-devkit/build-angular:private-protractor",
           "options": {
             "protractorConfig": "e2e/protractor.conf.js",
             "devServerTarget": "my-app:serve"

--- a/packages/angular_devkit/core/src/workspace/json/test/cases/ProjectModifyProperties.json
+++ b/packages/angular_devkit/core/src/workspace/json/test/cases/ProjectModifyProperties.json
@@ -111,7 +111,7 @@
       "prefix": "",
       "architect": {
         "e2e": {
-          "builder": "@angular-devkit/build-angular:protractor",
+          "builder": "@angular-devkit/build-angular:private-protractor",
           "options": {
             "protractorConfig": "e2e/protractor.conf.js",
             "devServerTarget": "my-app:serve"

--- a/packages/angular_devkit/core/src/workspace/json/test/cases/ProjectSetProperties.json
+++ b/packages/angular_devkit/core/src/workspace/json/test/cases/ProjectSetProperties.json
@@ -112,7 +112,7 @@
       "prefix": "",
       "architect": {
         "e2e": {
-          "builder": "@angular-devkit/build-angular:protractor",
+          "builder": "@angular-devkit/build-angular:private-protractor",
           "options": {
             "protractorConfig": "e2e/protractor.conf.js",
             "devServerTarget": "my-app:serve"

--- a/packages/schematics/angular/collection.json
+++ b/packages/schematics/angular/collection.json
@@ -23,10 +23,10 @@
       "schema": "./application/schema.json",
       "description": "Create an Angular application."
     },
-    "e2e": {
+    "private-e2e": {
       "factory": "./e2e",
       "schema": "./e2e/schema.json",
-      "description": "Create an Angular e2e application.",
+      "description": "PRIVATE API - Do not use.",
       "hidden": true
     },
     "class": {

--- a/packages/schematics/angular/e2e/index_spec.ts
+++ b/packages/schematics/angular/e2e/index_spec.ts
@@ -49,7 +49,7 @@ describe('Application Schematic', () => {
   });
 
   it('should create all files of e2e in an application', async () => {
-    const tree = await schematicRunner.runSchematic('e2e', defaultOptions, applicationTree);
+    const tree = await schematicRunner.runSchematic('private-e2e', defaultOptions, applicationTree);
 
     const files = tree.files;
     expect(files).toEqual(
@@ -64,7 +64,11 @@ describe('Application Schematic', () => {
 
   describe('workspace config', () => {
     it('should add e2e targets for the app', async () => {
-      const tree = await schematicRunner.runSchematic('e2e', defaultOptions, applicationTree);
+      const tree = await schematicRunner.runSchematic(
+        'private-e2e',
+        defaultOptions,
+        applicationTree,
+      );
 
       const workspace = JSON.parse(tree.readContent('/angular.json'));
       const targets = workspace.projects.foo.architect;
@@ -72,7 +76,11 @@ describe('Application Schematic', () => {
     });
 
     it('should set the e2e options', async () => {
-      const tree = await schematicRunner.runSchematic('e2e', defaultOptions, applicationTree);
+      const tree = await schematicRunner.runSchematic(
+        'private-e2e',
+        defaultOptions,
+        applicationTree,
+      );
 
       const workspace = JSON.parse(tree.readContent('/angular.json'));
       const { options, configurations } = workspace.projects.foo.architect.e2e;
@@ -82,7 +90,7 @@ describe('Application Schematic', () => {
   });
 
   it('should add an e2e script in package.json', async () => {
-    const tree = await schematicRunner.runSchematic('e2e', defaultOptions, applicationTree);
+    const tree = await schematicRunner.runSchematic('private-e2e', defaultOptions, applicationTree);
 
     const pkg = JSON.parse(tree.readContent('/package.json'));
     expect(pkg.scripts['e2e']).toBe('ng e2e');

--- a/packages/schematics/angular/utility/workspace-models.ts
+++ b/packages/schematics/angular/utility/workspace-models.ts
@@ -30,7 +30,7 @@ export enum Builders {
   NgPackagr = '@angular-devkit/build-angular:ng-packagr',
   DevServer = '@angular-devkit/build-angular:dev-server',
   ExtractI18n = '@angular-devkit/build-angular:extract-i18n',
-  Protractor = '@angular-devkit/build-angular:protractor',
+  Protractor = '@angular-devkit/build-angular:private-protractor',
   BuildApplication = '@angular/build:application',
 }
 

--- a/tests/legacy-cli/e2e/tests/build/jit-ngmodule.ts
+++ b/tests/legacy-cli/e2e/tests/build/jit-ngmodule.ts
@@ -4,7 +4,7 @@ import { updateJsonFile, useCIChrome, useCIDefaults } from '../../utils/project'
 
 export default async function () {
   await ng('generate', 'app', 'test-project-two', '--no-standalone', '--skip-install');
-  await ng('generate', 'e2e', '--related-app-name=test-project-two');
+  await ng('generate', 'private-e2e', '--related-app-name=test-project-two');
 
   // Setup testing to use CI Chrome.
   await useCIChrome('test-project-two', './projects/test-project-two/e2e');

--- a/tests/legacy-cli/e2e/tests/build/server-rendering/express-engine-ngmodule.ts
+++ b/tests/legacy-cli/e2e/tests/build/server-rendering/express-engine-ngmodule.ts
@@ -16,7 +16,7 @@ export default async function () {
   await rimraf('node_modules/@angular/ssr');
 
   await ng('generate', 'app', 'test-project-two', '--no-standalone', '--skip-install');
-  await ng('generate', 'e2e', '--related-app-name=test-project-two');
+  await ng('generate', 'private-e2e', '--related-app-name=test-project-two');
 
   // Setup testing to use CI Chrome.
   await useCIChrome('test-project-two', 'projects/test-project-two/e2e/');

--- a/tests/legacy-cli/e2e/tests/update/update.ts
+++ b/tests/legacy-cli/e2e/tests/update/update.ts
@@ -72,7 +72,7 @@ export default async function () {
   await ng('update', '@angular/cli', ...extraUpdateArgs);
 
   // Generate E2E setup
-  await ng('generate', 'e2e', '--related-app-name=fifteen-project');
+  await ng('generate', 'private-e2e', '--related-app-name=fifteen-project');
 
   // Setup testing to use CI Chrome.
   await useCIChrome('fifteen-project', './');

--- a/tests/legacy-cli/e2e/utils/project.ts
+++ b/tests/legacy-cli/e2e/utils/project.ts
@@ -51,7 +51,7 @@ export async function prepareProjectForE2e(name: string) {
 
   console.log(`Project ${name} created... Installing packages.`);
   await installWorkspacePackages();
-  await ng('generate', 'e2e', '--related-app-name', name);
+  await ng('generate', 'private-e2e', '--related-app-name', name);
 
   await useCIChrome(name, 'e2e');
   await useCIChrome(name, '');


### PR DESCRIPTION
This renames the Protractor builder and its `e2e` generator schematic to mark them private and remove them from Angular's public API. This will give us an opportunity to clean up internal usages and then remove the builder altogether in a future release. Since this rename makes Protractor non-public API, it may be completely deleted in a future patch release.

Protractor was [marked end-of-life in August 2023](https://protractortest.org/). Projects still relying on Protractor should consider migrating to another E2E testing framework, several support solid migration paths from Protractor.

Additional resources:
* https://angular.dev/tools/cli/end-to-end
* https://blog.angular.dev/the-state-of-end-to-end-testing-with-angular-d175f751cb9c