### PR TITLE
fix(@angular/build): synchronize import/export conditions between bundler and TypeScript

### DIFF
--- a/modules/testing/builder/src/dev_prod_mode.ts
+++ b/modules/testing/builder/src/dev_prod_mode.ts
@@ -16,12 +16,14 @@ export async function setupConditionImport(harness: BuilderHarness<unknown>) {
   // Files that can be used as targets for the conditional import.
   await harness.writeFile('src/good.ts', `export const VALUE = 'good-value';`);
   await harness.writeFile('src/bad.ts', `export const VALUE = 'bad-value';`);
+  await harness.writeFile('src/wrong.ts', `export const VALUE = 1;`);
 
   // Simple application file that accesses conditional code.
   await harness.writeFile(
     'src/main.ts',
     `import {VALUE} from '#target';
 console.log(VALUE);
+console.log(VALUE.length);
 export default 42 as any;
 `,
   );
@@ -29,7 +31,7 @@ export default 42 as any;
   // Ensure that good/bad can be resolved from tsconfig.
   const tsconfig = JSON.parse(harness.readFile('src/tsconfig.app.json')) as TypeScriptConfig;
   tsconfig.compilerOptions.moduleResolution = 'bundler';
-  tsconfig.files.push('good.ts', 'bad.ts');
+  tsconfig.files.push('good.ts', 'bad.ts', 'wrong.ts');
   await harness.writeFile('src/tsconfig.app.json', JSON.stringify(tsconfig));
 }
 

--- a/packages/angular/build/src/builders/application/tests/behavior/build-conditions_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/behavior/build-conditions_spec.ts
@@ -91,5 +91,26 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
         });
       });
     }
+
+    it('fails type-checking when import contains differing type', async () => {
+      await setTargetMapping(harness, {
+        'development': './src/wrong.ts',
+        'default': './src/good.ts',
+      });
+
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        optimization: false,
+      });
+
+      const { result, logs } = await harness.executeOnce({ outputLogsOnFailure: false });
+
+      expect(result?.success).toBeFalse();
+      expect(logs).toContain(
+        jasmine.objectContaining({
+          message: jasmine.stringMatching('TS2339'),
+        }),
+      );
+    });
   });
 });


### PR DESCRIPTION
To improve type-checking and reduce hard to diagnose errors when using the new `production`/`development` conditions, the set of conditions used by the bundler are now also synchronized with those used by TypeScript. This helps ensure that type mismatches are avoided by type-checking against the actual file that will be bundled into the output.
