### PR TITLE
fix(@angular/build): allow direct bundling of TSX files with application builder

### DIFF
--- a/packages/angular/build/src/tools/esbuild/angular/compiler-plugin.ts
+++ b/packages/angular/build/src/tools/esbuild/angular/compiler-plugin.ts
@@ -8,6 +8,7 @@
 
 import type {
   BuildFailure,
+  Loader,
   Metafile,
   OnStartResult,
   OutputFile,
@@ -456,9 +457,21 @@ export function createCompilerPlugin(
           typeScriptFileCache.set(request, contents);
         }
 
+        let loader: Loader;
+        if (useTypeScriptTranspilation || isJS) {
+          // TypeScript has transpiled to JS or is already JS
+          loader = 'js';
+        } else if (request.at(-1) === 'x') {
+          // TSX and TS have different syntax rules. Only set if input is a TSX file.
+          loader = 'tsx';
+        } else {
+          // Otherwise, directly bundle TS
+          loader = 'ts';
+        }
+
         return {
           contents,
-          loader: useTypeScriptTranspilation || isJS ? 'js' : 'ts',
+          loader,
         };
       });
 


### PR DESCRIPTION
When using the application builder with `isolatedModules`, the bundler will directly handle TypeScript transpilation and bundling. Previously, any input TSX files were loaded by the bundler as TS files. This difference caused errors when attempting to process the files since the syntax differs between TSX and TS. The appropriate loader will now be used if the input file is TSX in this situation.

Closes #28640