### PR TITLE
refactor(@schematics/angular): spacing fixes after experimental zoneless introduction

### DIFF
--- a/packages/schematics/angular/application/files/module-files/src/app/app.component.spec.ts.template
+++ b/packages/schematics/angular/application/files/module-files/src/app/app.component.spec.ts.template
@@ -11,8 +11,8 @@ describe('AppComponent', () => {
       ],<% } %>
       declarations: [
         AppComponent
-      ],
-      <% if(experimentalZoneless) { %>providers: [provideExperimentalZonelessChangeDetection()]<% } %>
+      ],<% if(experimentalZoneless) { %>
+      providers: [provideExperimentalZonelessChangeDetection()]<% } %>
     }).compileComponents();
   });
 

--- a/packages/schematics/angular/application/files/standalone-files/src/app/app.component.spec.ts.template
+++ b/packages/schematics/angular/application/files/standalone-files/src/app/app.component.spec.ts.template
@@ -5,8 +5,8 @@ import { AppComponent } from './app.component';
 describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [AppComponent],
-      <% if(experimentalZoneless) { %>providers: [provideExperimentalZonelessChangeDetection()]<% } %>
+      imports: [AppComponent],<% if(experimentalZoneless) { %>
+      providers: [provideExperimentalZonelessChangeDetection()]<% } %>
     }).compileComponents();
   });
 

--- a/packages/schematics/angular/application/files/standalone-files/src/app/app.config.ts.template
+++ b/packages/schematics/angular/application/files/standalone-files/src/app/app.config.ts.template
@@ -4,7 +4,5 @@ import { provideRouter } from '@angular/router';
 import { routes } from './app.routes';<% } %>
 
 export const appConfig: ApplicationConfig = {
-  providers: [
-  <% if(experimentalZoneless) { %>provideExperimentalZonelessChangeDetection()<% } else { %>provideZoneChangeDetection({ eventCoalescing: true })<% } %><% if (routing) {%>, provideRouter(routes)<% } %>
-  ]
+  providers: [<% if(experimentalZoneless) { %>provideExperimentalZonelessChangeDetection()<% } else { %>provideZoneChangeDetection({ eventCoalescing: true })<% } %><% if (routing) {%>, provideRouter(routes)<% } %>]
 };


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

The experimental zoneless feature introduces some spacing issues in the generated code: see https://github.com/cexbrayat/angular-cli-diff/compare/19.0.0-next.10...19.0.0-next.11

## What is the new behavior?

THis hopefully fixes these issues

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
