### PR TITLE
fix(@angular/build): relax constraints on external stylesheet component id

### DIFF
--- a/packages/angular/build/src/tools/vite/middlewares/assets-middleware.ts
+++ b/packages/angular/build/src/tools/vite/middlewares/assets-middleware.ts
@@ -88,7 +88,7 @@ export function createAngularAssetsMiddleware(
             // Shim the stylesheet if a component ID is provided
             if (componentId.length > 0) {
               // Validate component ID
-              if (/^[_.\-\p{Letter}\d]+-c\d{9}$/u.test(componentId)) {
+              if (/^[_.\-\p{Letter}\d]+-c\d+$/u.test(componentId)) {
                 loadEsmModule<typeof import('@angular/compiler')>('@angular/compiler')
                   .then((compilerModule) => {
                     const encapsulatedData = compilerModule.encapsulateStyle(


### PR DESCRIPTION
The number of digits in the component identifier that is generated at runtime can vary. The check for a valid identifier now accounts for this case.

Closes: #28656