### PR TITLE
refactor(@angular/build): create component stylesheet bundler at start of build

### DIFF
--- a/goldens/circular-deps/packages.json
+++ b/goldens/circular-deps/packages.json
@@ -4,6 +4,13 @@
     "packages/angular_devkit/build_angular/src/builders/dev-server/options.ts"
   ],
   [
+    "packages/angular/build/src/tools/esbuild/angular/component-stylesheets.ts",
+    "packages/angular/build/src/tools/esbuild/bundler-context.ts",
+    "packages/angular/build/src/tools/esbuild/utils.ts",
+    "packages/angular/build/src/utils/server-rendering/manifest.ts",
+    "packages/angular/build/src/tools/esbuild/bundler-execution-result.ts"
+  ],
+  [
     "packages/angular/build/src/tools/esbuild/bundler-context.ts",
     "packages/angular/build/src/tools/esbuild/utils.ts"
   ],

--- a/packages/angular/build/src/tools/esbuild/angular/compiler-plugin.ts
+++ b/packages/angular/build/src/tools/esbuild/angular/compiler-plugin.ts
@@ -30,7 +30,6 @@ import {
 import { JavaScriptTransformer } from '../javascript-transformer';
 import { LoadResultCache, createCachedLoad } from '../load-result-cache';
 import { logCumulativeDurations, profileAsync, resetCumulativeDurations } from '../profiling';
-import { BundleStylesheetOptions } from '../stylesheets/bundle-options';
 import { SharedTSCompilationState, getSharedCompilationState } from './compilation-state';
 import { ComponentStylesheetBundler } from './component-stylesheets';
 import { FileReferenceTracker } from './file-reference-tracker';
@@ -57,7 +56,7 @@ export interface CompilerPluginOptions {
 // eslint-disable-next-line max-lines-per-function
 export function createCompilerPlugin(
   pluginOptions: CompilerPluginOptions,
-  styleOptions: BundleStylesheetOptions & { inlineStyleLanguage: string },
+  stylesheetBundler: ComponentStylesheetBundler,
 ): Plugin {
   return {
     name: 'angular-compiler',
@@ -128,12 +127,6 @@ export function createCompilerPlugin(
       // Determines if transpilation should be handle by TypeScript or esbuild
       let useTypeScriptTranspilation = true;
 
-      // Track incremental component stylesheet builds
-      const stylesheetBundler = new ComponentStylesheetBundler(
-        styleOptions,
-        styleOptions.inlineStyleLanguage,
-        pluginOptions.incremental,
-      );
       let sharedTSCompilationState: SharedTSCompilationState | undefined;
 
       // To fully invalidate files, track resource referenced files and their referencing source

--- a/packages/angular/build/src/tools/esbuild/angular/compiler-plugin.ts
+++ b/packages/angular/build/src/tools/esbuild/angular/compiler-plugin.ts
@@ -532,7 +532,6 @@ export function createCompilerPlugin(
 
       build.onDispose(() => {
         sharedTSCompilationState?.dispose();
-        void stylesheetBundler.dispose();
         void compilation.close?.();
         void cacheStore?.close();
       });

--- a/packages/angular/build/src/tools/esbuild/application-code-bundle.ts
+++ b/packages/angular/build/src/tools/esbuild/application-code-bundle.ts
@@ -18,6 +18,7 @@ import {
   SERVER_APP_MANIFEST_FILENAME,
 } from '../../utils/server-rendering/manifest';
 import { createCompilerPlugin } from './angular/compiler-plugin';
+import { ComponentStylesheetBundler } from './angular/component-stylesheets';
 import { SourceFileCache } from './angular/source-file-cache';
 import { BundlerOptionsFactory } from './bundler-context';
 import { createCompilerPluginOptions } from './compiler-plugin-options';
@@ -34,15 +35,12 @@ import { createWasmPlugin } from './wasm-plugin';
 export function createBrowserCodeBundleOptions(
   options: NormalizedApplicationBuildOptions,
   target: string[],
-  sourceFileCache?: SourceFileCache,
+  sourceFileCache: SourceFileCache,
+  stylesheetBundler: ComponentStylesheetBundler,
 ): BuildOptions {
   const { entryPoints, outputNames, polyfills } = options;
 
-  const { pluginOptions, stylesheetBundler } = createCompilerPluginOptions(
-    options,
-    target,
-    sourceFileCache,
-  );
+  const pluginOptions = createCompilerPluginOptions(options, sourceFileCache);
 
   const zoneless = isZonelessApp(polyfills);
 
@@ -100,7 +98,8 @@ export function createBrowserCodeBundleOptions(
 export function createBrowserPolyfillBundleOptions(
   options: NormalizedApplicationBuildOptions,
   target: string[],
-  sourceFileCache?: SourceFileCache,
+  sourceFileCache: SourceFileCache,
+  stylesheetBundler: ComponentStylesheetBundler,
 ): BuildOptions | BundlerOptionsFactory | undefined {
   const namespace = 'angular:polyfills';
   const polyfillBundleOptions = getEsBuildCommonPolyfillsOptions(
@@ -134,9 +133,9 @@ export function createBrowserPolyfillBundleOptions(
   // Only add the Angular TypeScript compiler if TypeScript files are provided in the polyfills
   if (hasTypeScriptEntries) {
     buildOptions.plugins ??= [];
-    const { pluginOptions, stylesheetBundler } = createCompilerPluginOptions(
+    const pluginOptions = createCompilerPluginOptions(
       options,
-      target,
+
       sourceFileCache,
     );
     buildOptions.plugins.push(
@@ -228,6 +227,7 @@ export function createServerMainCodeBundleOptions(
   options: NormalizedApplicationBuildOptions,
   target: string[],
   sourceFileCache: SourceFileCache,
+  stylesheetBundler: ComponentStylesheetBundler,
 ): BuildOptions {
   const {
     serverEntryPoint: mainServerEntryPoint,
@@ -243,11 +243,7 @@ export function createServerMainCodeBundleOptions(
     'createServerCodeBundleOptions should not be called without a defined serverEntryPoint.',
   );
 
-  const { pluginOptions, stylesheetBundler } = createCompilerPluginOptions(
-    options,
-    target,
-    sourceFileCache,
-  );
+  const pluginOptions = createCompilerPluginOptions(options, sourceFileCache);
 
   const mainServerNamespace = 'angular:main-server';
   const mainServerInjectPolyfillsNamespace = 'angular:main-server-inject-polyfills';
@@ -374,6 +370,7 @@ export function createSsrEntryCodeBundleOptions(
   options: NormalizedApplicationBuildOptions,
   target: string[],
   sourceFileCache: SourceFileCache,
+  stylesheetBundler: ComponentStylesheetBundler,
 ): BuildOptions {
   const { workspaceRoot, ssrOptions, externalPackages } = options;
   const serverEntryPoint = ssrOptions?.entry;
@@ -382,11 +379,7 @@ export function createSsrEntryCodeBundleOptions(
     'createSsrEntryCodeBundleOptions should not be called without a defined serverEntryPoint.',
   );
 
-  const { pluginOptions, stylesheetBundler } = createCompilerPluginOptions(
-    options,
-    target,
-    sourceFileCache,
-  );
+  const pluginOptions = createCompilerPluginOptions(options, sourceFileCache);
 
   const ssrEntryNamespace = 'angular:ssr-entry';
   const ssrInjectManifestNamespace = 'angular:ssr-entry-inject-manifest';

--- a/packages/angular/build/src/tools/esbuild/application-code-bundle.ts
+++ b/packages/angular/build/src/tools/esbuild/application-code-bundle.ts
@@ -38,7 +38,7 @@ export function createBrowserCodeBundleOptions(
 ): BuildOptions {
   const { entryPoints, outputNames, polyfills } = options;
 
-  const { pluginOptions, styleOptions } = createCompilerPluginOptions(
+  const { pluginOptions, stylesheetBundler } = createCompilerPluginOptions(
     options,
     target,
     sourceFileCache,
@@ -65,8 +65,8 @@ export function createBrowserCodeBundleOptions(
       createCompilerPlugin(
         // JS/TS options
         pluginOptions,
-        // Component stylesheet options
-        styleOptions,
+        // Component stylesheet bundler
+        stylesheetBundler,
       ),
     ],
   };
@@ -134,7 +134,7 @@ export function createBrowserPolyfillBundleOptions(
   // Only add the Angular TypeScript compiler if TypeScript files are provided in the polyfills
   if (hasTypeScriptEntries) {
     buildOptions.plugins ??= [];
-    const { pluginOptions, styleOptions } = createCompilerPluginOptions(
+    const { pluginOptions, stylesheetBundler } = createCompilerPluginOptions(
       options,
       target,
       sourceFileCache,
@@ -144,7 +144,7 @@ export function createBrowserPolyfillBundleOptions(
         // JS/TS options
         { ...pluginOptions, noopTypeScriptCompilation: true },
         // Component stylesheet options are unused for polyfills but required by the plugin
-        styleOptions,
+        stylesheetBundler,
       ),
     );
   }
@@ -243,7 +243,7 @@ export function createServerMainCodeBundleOptions(
     'createServerCodeBundleOptions should not be called without a defined serverEntryPoint.',
   );
 
-  const { pluginOptions, styleOptions } = createCompilerPluginOptions(
+  const { pluginOptions, stylesheetBundler } = createCompilerPluginOptions(
     options,
     target,
     sourceFileCache,
@@ -278,8 +278,8 @@ export function createServerMainCodeBundleOptions(
       createCompilerPlugin(
         // JS/TS options
         { ...pluginOptions, noopTypeScriptCompilation: true },
-        // Component stylesheet options
-        styleOptions,
+        // Component stylesheet bundler
+        stylesheetBundler,
       ),
     ],
   };
@@ -382,7 +382,7 @@ export function createSsrEntryCodeBundleOptions(
     'createSsrEntryCodeBundleOptions should not be called without a defined serverEntryPoint.',
   );
 
-  const { pluginOptions, styleOptions } = createCompilerPluginOptions(
+  const { pluginOptions, stylesheetBundler } = createCompilerPluginOptions(
     options,
     target,
     sourceFileCache,
@@ -411,8 +411,8 @@ export function createSsrEntryCodeBundleOptions(
       createCompilerPlugin(
         // JS/TS options
         { ...pluginOptions, noopTypeScriptCompilation: true },
-        // Component stylesheet options
-        styleOptions,
+        // Component stylesheet bundler
+        stylesheetBundler,
       ),
     ],
     inject,

--- a/packages/angular/build/src/tools/esbuild/bundler-execution-result.ts
+++ b/packages/angular/build/src/tools/esbuild/bundler-execution-result.ts
@@ -9,6 +9,7 @@
 import type { Message, PartialMessage } from 'esbuild';
 import { normalize } from 'node:path';
 import type { ChangedFiles } from '../../tools/esbuild/watcher';
+import type { ComponentStylesheetBundler } from './angular/component-stylesheets';
 import type { SourceFileCache } from './angular/source-file-cache';
 import type { BuildOutputFile, BuildOutputFileType, BundlerContext } from './bundler-context';
 import { createOutputFile } from './utils';
@@ -20,6 +21,7 @@ export interface BuildOutputAsset {
 
 export interface RebuildState {
   rebuildContexts: BundlerContext[];
+  componentStyleBundler: ComponentStylesheetBundler;
   codeBundleCache?: SourceFileCache;
   fileChanges: ChangedFiles;
   previousOutputHashes: Map<string, string>;
@@ -50,6 +52,7 @@ export class ExecutionResult {
 
   constructor(
     private rebuildContexts: BundlerContext[],
+    private componentStyleBundler: ComponentStylesheetBundler,
     private codeBundleCache?: SourceFileCache,
   ) {}
 
@@ -158,6 +161,7 @@ export class ExecutionResult {
     return {
       rebuildContexts: this.rebuildContexts,
       codeBundleCache: this.codeBundleCache,
+      componentStyleBundler: this.componentStyleBundler,
       fileChanges,
       previousOutputHashes: new Map(this.outputFiles.map((file) => [file.path, file.hash])),
     };
@@ -177,5 +181,6 @@ export class ExecutionResult {
 
   async dispose(): Promise<void> {
     await Promise.allSettled(this.rebuildContexts.map((context) => context.dispose()));
+    await this.componentStyleBundler.dispose();
   }
 }

--- a/packages/angular/build/src/tools/esbuild/compiler-plugin-options.ts
+++ b/packages/angular/build/src/tools/esbuild/compiler-plugin-options.ts
@@ -15,74 +15,30 @@ type CreateCompilerPluginParameters = Parameters<typeof createCompilerPlugin>;
 
 export function createCompilerPluginOptions(
   options: NormalizedApplicationBuildOptions,
-  target: string[],
   sourceFileCache?: SourceFileCache,
-): {
-  pluginOptions: CreateCompilerPluginParameters[0];
-  stylesheetBundler: ComponentStylesheetBundler;
-} {
+): CreateCompilerPluginParameters[0] {
   const {
-    workspaceRoot,
-    optimizationOptions,
     sourcemapOptions,
     tsconfig,
-    outputNames,
     fileReplacements,
-    externalDependencies,
-    preserveSymlinks,
-    stylePreprocessorOptions,
     advancedOptimizations,
-    inlineStyleLanguage,
     jit,
-    cacheOptions,
-    tailwindConfiguration,
-    postcssConfiguration,
-    publicPath,
     externalRuntimeStyles,
     instrumentForCoverage,
   } = options;
   const incremental = !!options.watch;
 
   return {
-    // JS/TS options
-    pluginOptions: {
-      sourcemap: !!sourcemapOptions.scripts && (sourcemapOptions.hidden ? 'external' : true),
-      thirdPartySourcemaps: sourcemapOptions.vendor,
-      tsconfig,
-      jit,
-      advancedOptimizations,
-      fileReplacements,
-      sourceFileCache,
-      loadResultCache: sourceFileCache?.loadResultCache,
-      incremental,
-      externalRuntimeStyles,
-      instrumentForCoverage,
-    },
-    stylesheetBundler: new ComponentStylesheetBundler(
-      {
-        workspaceRoot,
-        inlineFonts: !!optimizationOptions.fonts.inline,
-        optimization: !!optimizationOptions.styles.minify,
-        sourcemap:
-          // Hidden component stylesheet sourcemaps are inaccessible which is effectively
-          // the same as being disabled. Disabling has the advantage of avoiding the overhead
-          // of sourcemap processing.
-          sourcemapOptions.styles && !sourcemapOptions.hidden ? 'linked' : false,
-        outputNames,
-        includePaths: stylePreprocessorOptions?.includePaths,
-        // string[] | undefined' is not assignable to type '(Version | DeprecationOrId)[] | undefined'.
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        sass: stylePreprocessorOptions?.sass as any,
-        externalDependencies,
-        target,
-        preserveSymlinks,
-        tailwindConfiguration,
-        postcssConfiguration,
-        cacheOptions,
-        publicPath,
-      },
-      inlineStyleLanguage,
-      incremental,
-    ),
+    sourcemap: !!sourcemapOptions.scripts && (sourcemapOptions.hidden ? 'external' : true),
+    thirdPartySourcemaps: sourcemapOptions.vendor,
+    tsconfig,
+    jit,
+    advancedOptimizations,
+    fileReplacements,
+    sourceFileCache,
+    loadResultCache: sourceFileCache?.loadResultCache,
+    incremental,
+    externalRuntimeStyles,
+    instrumentForCoverage,
   };
 }

--- a/packages/angular/build/src/utils/server-rendering/manifest.ts
+++ b/packages/angular/build/src/utils/server-rendering/manifest.ts
@@ -13,7 +13,7 @@ import {
   getLocaleBaseHref,
 } from '../../builders/application/options';
 import type { BuildOutputFile } from '../../tools/esbuild/bundler-context';
-import { PrerenderedRoutesRecord } from '../../tools/esbuild/bundler-execution-result';
+import type { PrerenderedRoutesRecord } from '../../tools/esbuild/bundler-execution-result';
 
 export const SERVER_APP_MANIFEST_FILENAME = 'angular-app-manifest.mjs';
 export const SERVER_APP_ENGINE_MANIFEST_FILENAME = 'angular-app-engine-manifest.mjs';


### PR DESCRIPTION
**refactor(@angular/build): move component stylesheet bundler out of compiler plugin**

The component stylesheet bundler is now created during the setup of the Angular
compiler plugin options. This is an initial step to support more fine-grained
rebuild actions with the new component stylesheet development server support.

**refactor(@angular/build): create component stylesheet bundler at start of build**

The component stylesheet bundler is now created at the start of the build
and accessible prior to the bundling actions. This will provide support for
generating updated component styles and bypassing all code bundling when using
the development server and only component styles have been modified.