### PR TITLE
refactor(@angular/build): add internal support for generating template update functions

### DIFF
--- a/packages/angular/build/src/tools/angular/compilation/angular-compilation.ts
+++ b/packages/angular/build/src/tools/angular/compilation/angular-compilation.ts
@@ -76,6 +76,7 @@ export abstract class AngularCompilation {
     compilerOptions: ng.CompilerOptions;
     referencedFiles: readonly string[];
     externalStylesheets?: ReadonlyMap<string, string>;
+    templateUpdates?: ReadonlyMap<string, string>;
   }>;
 
   abstract emitAffectedFiles(): Iterable<EmitFileResult> | Promise<Iterable<EmitFileResult>>;


### PR DESCRIPTION
The internal AOT Angular compilation processing can now generate the newly introduced template update functions during development server rebuilds of template only file changes. These template update functions are not yet used but provide the infrastructure to enable template hot replacement in a future change.
