### PR TITLE
refactor(@angular/ssr): remove `useDefineForClassFields`

### DIFF
--- a/packages/angular/ssr/src/app-engine.ts
+++ b/packages/angular/ssr/src/app-engine.ts
@@ -30,7 +30,7 @@ export class AngularAppEngine {
    *
    * @private
    */
-  static ɵhooks = new Hooks();
+  static ɵhooks = /* #__PURE__*/ new Hooks();
 
   /**
    * Provides access to the hooks for extending or modifying the server application's behavior.

--- a/tsconfig-build-ng.json
+++ b/tsconfig-build-ng.json
@@ -8,8 +8,6 @@
   "compilerOptions": {
     "module": "esnext",
     "target": "es2022",
-    // Keep the below in sync with ng_module.bzl
-    "useDefineForClassFields": false,
     "lib": ["es2020", "dom"],
     // don't auto-discover @types/node, it results in a ///<reference in the .d.ts output
     "types": [],


### PR DESCRIPTION
This removes `useDefineForClassFields` to leave static field instead of using static blocks.
