### PR TITLE
fix(@angular/build): Address build issue in Node.js LTS versions with prerendering or SSR

### DIFF
--- a/packages/angular/build/src/tools/esbuild/javascript-transformer.ts
+++ b/packages/angular/build/src/tools/esbuild/javascript-transformer.ts
@@ -58,6 +58,8 @@ export class JavaScriptTransformer {
     this.#workerPool ??= new WorkerPool({
       filename: require.resolve('./javascript-transformer-worker'),
       maxThreads: this.maxThreads,
+      // Prevent passing `--import` (loader-hooks) from parent to child worker.
+      execArgv: [],
     });
 
     return this.#workerPool;


### PR DESCRIPTION


In Node.js 20, changes to ESM loader hooks result in the `--import` execArgv being passed from the parent to child workers.

This commit resolves the issue by setting an empty `execArgv` in the JavaScript transformer, preventing unintended propagation.

Closes #28683
