### PR TITLE
refactor(@schematics/angular): remove redundant `standalone: true` from templates

### DIFF
--- a/packages/schematics/angular/application/files/standalone-files/src/app/app.component.ts.template
+++ b/packages/schematics/angular/application/files/standalone-files/src/app/app.component.ts.template
@@ -3,7 +3,6 @@ import { RouterOutlet } from '@angular/router';<% } %>
 
 @Component({
   selector: '<%= selector %>',
-  standalone: true,
   imports: [<% if(routing) { %>RouterOutlet<% } %>],<% if(inlineTemplate) { %>
   template: `
     <h1>Welcome to {{title}}!</h1>

--- a/packages/schematics/angular/application/index_spec.ts
+++ b/packages/schematics/angular/application/index_spec.ts
@@ -558,11 +558,10 @@ describe('Application Schematic', () => {
 
   it('should create a standalone component', async () => {
     const options = { ...defaultOptions, standalone: true };
-
     const tree = await schematicRunner.runSchematic('application', options, workspaceTree);
-
     const component = tree.readContent('/projects/foo/src/app/app.component.ts');
-    expect(component).toMatch(/standalone: true/);
+
+    expect(component).not.toContain('standalone');
   });
 
   it('should create routing information by default', async () => {

--- a/packages/schematics/angular/component/files/__name@dasherize@if-flat__/__name@dasherize__.__type@dasherize__.ts.template
+++ b/packages/schematics/angular/component/files/__name@dasherize@if-flat__/__name@dasherize__.__type@dasherize__.ts.template
@@ -2,7 +2,6 @@ import { <% if(changeDetection !== 'Default') { %>ChangeDetectionStrategy, <% }%
 
 @Component({<% if(!skipSelector) {%>
   selector: '<%= selector %>',<%}%><% if(standalone) {%>
-  standalone: true,
   imports: [],<%} else { %>
   standalone: false,
   <% }%><% if(inlineTemplate) { %>

--- a/packages/schematics/angular/component/index_spec.ts
+++ b/packages/schematics/angular/component/index_spec.ts
@@ -350,7 +350,7 @@ describe('Component Schematic', () => {
     const componentContent = tree.readContent('/projects/bar/src/app/foo/foo.component.ts');
     expect(componentContent).toContain('class FooComponent');
     expect(moduleContent).not.toContain('FooComponent');
-    expect(componentContent).toContain('standalone: true');
+    expect(componentContent).not.toContain('standalone');
   });
 
   it('should declare standalone components in the `imports` of a test', async () => {

--- a/packages/schematics/angular/directive/files/__name@dasherize@if-flat__/__name@dasherize__.directive.ts.template
+++ b/packages/schematics/angular/directive/files/__name@dasherize@if-flat__/__name@dasherize__.directive.ts.template
@@ -1,8 +1,7 @@
 import { Directive } from '@angular/core';
 
 @Directive({
-  selector: '[<%= selector %>]'<% if(standalone) {%>,
-  standalone: true<%} else {%>,
+  selector: '[<%= selector %>]'<% if(!standalone) {%>,
   standalone: false<%}%>
 })
 export class <%= classify(name) %>Directive {

--- a/packages/schematics/angular/directive/index_spec.ts
+++ b/packages/schematics/angular/directive/index_spec.ts
@@ -107,7 +107,7 @@ describe('Directive Schematic', () => {
     const options = { ...defaultOptions, standalone: true };
     const tree = await schematicRunner.runSchematic('directive', options, appTree);
     const directiveContent = tree.readContent('/projects/bar/src/app/foo.directive.ts');
-    expect(directiveContent).toContain('standalone: true');
+    expect(directiveContent).not.toContain('standalone');
     expect(directiveContent).toContain('class FooDirective');
   });
 

--- a/packages/schematics/angular/library/index_spec.ts
+++ b/packages/schematics/angular/library/index_spec.ts
@@ -71,7 +71,7 @@ describe('Library Schematic', () => {
   it('should create a standalone component', async () => {
     const tree = await schematicRunner.runSchematic('library', defaultOptions, workspaceTree);
     const componentContent = tree.readContent('/projects/foo/src/lib/foo.component.ts');
-    expect(componentContent).toContain('standalone: true');
+    expect(componentContent).not.toContain('standalone');
   });
 
   describe('custom projectRoot', () => {

--- a/packages/schematics/angular/pipe/files/__name@dasherize@if-flat__/__name@dasherize__.pipe.ts.template
+++ b/packages/schematics/angular/pipe/files/__name@dasherize@if-flat__/__name@dasherize__.pipe.ts.template
@@ -1,8 +1,7 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({
-  name: '<%= camelize(name) %>'<% if(standalone) {%>,
-  standalone: true<%} else {%>,
+  name: '<%= camelize(name) %>'<% if(!standalone) {%>,
   standalone: false<%}%>
 })
 export class <%= classify(name) %>Pipe implements PipeTransform {

--- a/packages/schematics/angular/pipe/index_spec.ts
+++ b/packages/schematics/angular/pipe/index_spec.ts
@@ -156,7 +156,7 @@ describe('Pipe Schematic', () => {
       const tree = await schematicRunner.runSchematic('pipe', defaultOptions, appTree);
       const moduleContent = tree.readContent('/projects/bar/src/app/app.module.ts');
       const pipeContent = tree.readContent('/projects/bar/src/app/foo.pipe.ts');
-      expect(pipeContent).toContain('standalone: true');
+      expect(pipeContent).not.toContain('standalone');
       expect(pipeContent).toContain('class FooPipe');
       expect(moduleContent).not.toContain('FooPipe');
     });


### PR DESCRIPTION


This is no longer needed.
