### PR TITLE
fix(@angular/build): avoid hashing development external component stylesheets

### DIFF
--- a/packages/angular/build/src/tools/esbuild/angular/component-stylesheets.ts
+++ b/packages/angular/build/src/tools/esbuild/angular/component-stylesheets.ts
@@ -48,6 +48,7 @@ export class ComponentStylesheetBundler {
           );
 
           buildOptions.entryPoints = { [externalId]: entry };
+          buildOptions.entryNames = '[name]';
           delete buildOptions.publicPath;
         } else {
           buildOptions.entryPoints = [entry];
@@ -88,6 +89,7 @@ export class ComponentStylesheetBundler {
         });
         if (externalId) {
           buildOptions.entryPoints = { [externalId]: `${namespace};${entry}` };
+          buildOptions.entryNames = '[name]';
           delete buildOptions.publicPath;
         } else {
           buildOptions.entryPoints = [`${namespace};${entry}`];


### PR DESCRIPTION
When using the development server with a production configuration or with bundle hashing enabled, the external stylesheet files used by the development server for hot replacement of component styles are no longer hashed. This ensures that the requests from the runtime served by the development server match the available generated component stylesheet files.