### PR TITLE
Output mode warning changed

### DIFF
--- a/packages/angular/build/src/builders/application/options.ts
+++ b/packages/angular/build/src/builders/application/options.ts
@@ -220,17 +220,17 @@ export async function normalizeOptions(
       options.ssr = false;
     }
 
-    if (options.prerender) {
+    if (options.prerender !== undefined) {
       context.logger.warn(
-        'The "prerender" option is no longer needed when "outputMode" is specified.',
+        'The "prerender" option is not considered when "outputMode" is specified.',
       );
-    } else {
-      options.prerender = !!options.server;
     }
 
-    if (options.appShell) {
+    options.prerender = !!options.server;
+
+    if (options.appShell !== undefined) {
       context.logger.warn(
-        'The "appShell" option is no longer needed when "outputMode" is specified.',
+        'The "appShell" option is not considered when "outputMode" is specified.',
       );
     }
   }

--- a/packages/angular/build/src/builders/application/schema.json
+++ b/packages/angular/build/src/builders/application/schema.json
@@ -536,7 +536,6 @@
     },
     "prerender": {
       "description": "Prerender (SSG) pages of your application during build time.",
-      "default": false,
       "oneOf": [
         {
           "type": "boolean",
@@ -586,8 +585,7 @@
     },
     "appShell": {
       "type": "boolean",
-      "description": "Generates an application shell during build time.",
-      "default": false
+      "description": "Generates an application shell during build time."
     },
     "outputMode": {
       "type": "string",

--- a/packages/angular/build/src/builders/application/schema.json
+++ b/packages/angular/build/src/builders/application/schema.json
@@ -18,7 +18,18 @@
     },
     "server": {
       "type": "string",
-      "description": "The full path for the server entry point to the application, relative to the current workspace."
+      "description": "The full path for the server entry point to the application, relative to the current workspace.",
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "The full path for the server entry point to the application, relative to the current workspace."
+        },
+        {
+          "const": false,
+          "type": "boolean",
+          "description": "Indicates that a server entry point is not provided."
+        }
+      ]
     },
     "polyfills": {
       "description": "A list of polyfills to include in the build. Can be a full path for a file, relative to the current workspace or module specifier. Example: 'zone.js'.",

--- a/packages/angular/build/src/builders/dev-server/vite-server.ts
+++ b/packages/angular/build/src/builders/dev-server/vite-server.ts
@@ -102,7 +102,7 @@ export async function* serveWithVite(
   if (browserOptions.prerender || (browserOptions.outputMode && browserOptions.server)) {
     // Disable prerendering if enabled and force SSR.
     // This is so instead of prerendering all the routes for every change, the page is "prerendered" when it is requested.
-    browserOptions.prerender = false;
+    browserOptions.prerender = undefined;
     browserOptions.ssr ||= true;
   }
 

--- a/packages/angular_devkit/build_angular/src/builders/extract-i18n/application-extraction.ts
+++ b/packages/angular_devkit/build_angular/src/builders/extract-i18n/application-extraction.ts
@@ -53,8 +53,9 @@ export async function extractMessages(
   buildOptions.serviceWorker = false;
   buildOptions.server = undefined;
   buildOptions.ssr = false;
-  buildOptions.appShell = false;
-  buildOptions.prerender = false;
+  buildOptions.appShell = undefined;
+  buildOptions.prerender = undefined;
+  buildOptions.outputMode = undefined;
 
   const builderResult = await first(buildApplicationInternal(buildOptions, context));
 


### PR DESCRIPTION
**fix(@angular/build): simplify disabling server features with `--no-server` via command line**

When `outputMode` is configured, `--prerender` and `--app-shell` become no-ops, making server feature disabling difficult without modifying the configuration.

This commit introduces the `--no-server` option, which can be used with `--output-mode static` to fully disable all server features.

```
ng build --output-mode static --no-server
```

 **fix(@angular/build): add warning when `--prerendering` or `--app-shell` are no-ops**
    
Both options are ineffective when used with `outputMode`, so a warning is now issued.