### PR TITLE
fix(@schematics/angular): enable opt-in for new `@angular/ssr` feature

### DIFF
--- a/packages/angular/ssr/schematics/ng-add/schema.json
+++ b/packages/angular/ssr/schematics/ng-add/schema.json
@@ -15,6 +15,10 @@
       "description": "Skip installing dependency packages.",
       "type": "boolean",
       "default": false
+    },
+    "serverRouting": {
+      "description": "Creates a server application using the Server Routing and App Engine APIs (Developer Preview).",
+      "type": "boolean"
     }
   },
   "required": ["project"],

--- a/packages/schematics/angular/app-shell/index_spec.ts
+++ b/packages/schematics/angular/app-shell/index_spec.ts
@@ -19,6 +19,7 @@ describe('App Shell Schematic', () => {
   );
   const defaultOptions: AppShellOptions = {
     project: 'bar',
+    serverRouting: true,
   };
 
   const workspaceOptions: WorkspaceOptions = {

--- a/packages/schematics/angular/app-shell/schema.json
+++ b/packages/schematics/angular/app-shell/schema.json
@@ -12,6 +12,11 @@
       "$default": {
         "$source": "projectName"
       }
+    },
+    "serverRouting": {
+      "description": "Creates a server application using the Server Routing API (Developer Preview).",
+      "type": "boolean",
+      "default": false
     }
   },
   "required": ["project"]

--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -101,6 +101,7 @@ export default function (options: ApplicationOptions): Rule {
       options.ssr
         ? schematic('ssr', {
             project: options.name,
+            serverRouting: options.serverRouting,
             skipInstall: true,
           })
         : noop(),

--- a/packages/schematics/angular/application/schema.json
+++ b/packages/schematics/angular/application/schema.json
@@ -118,6 +118,10 @@
       "default": false,
       "x-user-analytics": "ep.ng_ssr"
     },
+    "serverRouting": {
+      "description": "Creates a server application using the Server Routing and App Engine APIs (Developer Preview).",
+      "type": "boolean"
+    },
     "experimentalZoneless": {
       "description": "Create an application that does not utilize zone.js.",
       "type": "boolean",

--- a/packages/schematics/angular/ng-new/index.ts
+++ b/packages/schematics/angular/ng-new/index.ts
@@ -57,6 +57,7 @@ export default function (options: NgNewOptions): Rule {
     minimal: options.minimal,
     standalone: options.standalone,
     ssr: options.ssr,
+    serverRouting: options.serverRouting,
     experimentalZoneless: options.experimentalZoneless,
   };
 

--- a/packages/schematics/angular/ng-new/schema.json
+++ b/packages/schematics/angular/ng-new/schema.json
@@ -139,6 +139,10 @@
       "type": "boolean",
       "x-user-analytics": "ep.ng_ssr"
     },
+    "serverRouting": {
+      "description": "Creates a server application using the Server Routing and App Engine APIs (Developer Preview).",
+      "type": "boolean"
+    },
     "experimentalZoneless": {
       "description": "Create an application that does not utilize zone.js.",
       "type": "boolean",

--- a/packages/schematics/angular/server/files/application-builder/ngmodule-src/app/app.module.server.ts.template
+++ b/packages/schematics/angular/server/files/application-builder/ngmodule-src/app/app.module.server.ts.template
@@ -1,13 +1,13 @@
 import { NgModule } from '@angular/core';
-import { ServerModule } from '@angular/platform-server';
-import { provideServerRoutesConfig } from '@angular/ssr';
+import { ServerModule } from '@angular/platform-server';<% if(serverRouting) { %>
+import { provideServerRoutesConfig } from '@angular/ssr';<% } %>
 import { AppComponent } from './app.component';
-import { AppModule } from './app.module';
-import { serverRoutes } from './app.routes.server';
+import { AppModule } from './app.module';<% if(serverRouting) { %>
+import { serverRoutes } from './app.routes.server';<% } %>
 
 @NgModule({
-  imports: [AppModule, ServerModule],
-  providers: [provideServerRoutesConfig(serverRoutes)],
+  imports: [AppModule, ServerModule],<% if(serverRouting) { %>
+  providers: [provideServerRoutesConfig(serverRoutes)],<% } %>
   bootstrap: [AppComponent],
 })
 export class AppServerModule {}

--- a/packages/schematics/angular/server/files/application-builder/standalone-src/app/app.config.server.ts.template
+++ b/packages/schematics/angular/server/files/application-builder/standalone-src/app/app.config.server.ts.template
@@ -1,13 +1,13 @@
 import { mergeApplicationConfig, ApplicationConfig } from '@angular/core';
-import { provideServerRendering } from '@angular/platform-server';
-import { provideServerRoutesConfig } from '@angular/ssr';
-import { appConfig } from './app.config';
-import { serverRoutes } from './app.routes.server';
+import { provideServerRendering } from '@angular/platform-server';<% if(serverRouting) { %>
+import { provideServerRoutesConfig } from '@angular/ssr';<% } %>
+import { appConfig } from './app.config';<% if(serverRouting) { %>
+import { serverRoutes } from './app.routes.server';<% } %>
 
 const serverConfig: ApplicationConfig = {
   providers: [
-    provideServerRendering(),
-    provideServerRoutesConfig(serverRoutes)
+    provideServerRendering(),<% if(serverRouting) { %>
+    provideServerRoutesConfig(serverRoutes)<% } %>
   ]
 };
 

--- a/packages/schematics/angular/server/index.ts
+++ b/packages/schematics/angular/server/index.ts
@@ -14,9 +14,10 @@ import {
   apply,
   applyTemplates,
   chain,
+  filter,
   mergeWith,
   move,
-  renameTemplateFiles,
+  noop,
   strings,
   url,
 } from '@angular-devkit/schematics';
@@ -112,7 +113,9 @@ function updateConfigFileApplicationBuilder(options: ServerOptions): Rule {
       serverMainEntryName,
     );
 
-    buildTarget.options['outputMode'] = 'static';
+    if (options.serverRouting) {
+      buildTarget.options['outputMode'] = 'static';
+    }
   });
 }
 
@@ -191,6 +194,9 @@ export default function (options: ServerOptions): Rule {
     filesUrl += isStandalone ? 'standalone-src' : 'ngmodule-src';
 
     const templateSource = apply(url(filesUrl), [
+      options.serverRouting
+        ? noop()
+        : filter((path) => !path.endsWith('app.routes.server.ts.template')),
       applyTemplates({
         ...strings,
         ...options,

--- a/packages/schematics/angular/server/schema.json
+++ b/packages/schematics/angular/server/schema.json
@@ -17,6 +17,10 @@
       "description": "Do not install packages for dependencies.",
       "type": "boolean",
       "default": false
+    },
+    "serverRouting": {
+      "description": "Creates a server application using the Server Routing and App Engine APIs (Developer Preview).",
+      "type": "boolean"
     }
   },
   "required": ["project"]

--- a/packages/schematics/angular/ssr/files/application-builder-common-engine/server.ts.template
+++ b/packages/schematics/angular/ssr/files/application-builder-common-engine/server.ts.template
@@ -1,0 +1,65 @@
+import { APP_BASE_HREF } from '@angular/common';
+import { CommonEngine, isMainModule } from '@angular/ssr/node';
+import express from 'express';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import <% if (isStandalone) { %>bootstrap<% } else { %>AppServerModule<% } %> from './main.server';
+
+const serverDistFolder = dirname(fileURLToPath(import.meta.url));
+const browserDistFolder = resolve(serverDistFolder, '../<%= browserDistDirectory %>');
+const indexHtml = join(serverDistFolder, 'index.server.html');
+
+const app = express();
+const commonEngine = new CommonEngine();
+
+/**
+ * Example Express Rest API endpoints can be defined here.
+ * Uncomment and define endpoints as necessary.
+ *
+ * Example:
+ * ```ts
+ * app.get('/api/**', (req, res) => {
+ *   // Handle API request
+ * });
+ * ```
+ */
+
+/**
+ * Serve static files from /<%= browserDistDirectory %>
+ */
+app.get(
+  '**',
+  express.static(browserDistFolder, {
+    maxAge: '1y',
+    index: 'index.html'
+  }),
+);
+
+/**
+ * Handle all other requests by rendering the Angular application.
+ */
+app.get('**', (req, res, next) => {
+  const { protocol, originalUrl, baseUrl, headers } = req;
+
+  commonEngine
+    .render({
+      <% if (isStandalone) { %>bootstrap<% } else { %>bootstrap: AppServerModule<% } %>,
+      documentFilePath: indexHtml,
+      url: `${protocol}://${headers.host}${originalUrl}`,
+      publicPath: browserDistFolder,
+      providers: [{ provide: APP_BASE_HREF, useValue: baseUrl }],
+    })
+    .then((html) => res.send(html))
+    .catch((err) => next(err));
+});
+
+/**
+ * Start the server if this module is the main entry point.
+ * The server listens on the port defined by the `PORT` environment variable, or defaults to 4000.
+ */
+if (isMainModule(import.meta.url)) {
+  const port = process.env['PORT'] || 4000;
+  app.listen(port, () => {
+    console.log(`Node Express server listening on http://localhost:${port}`);
+  });
+}

--- a/packages/schematics/angular/ssr/index.ts
+++ b/packages/schematics/angular/ssr/index.ts
@@ -201,7 +201,8 @@ function updateApplicationBuilderWorkspaceConfigRule(
     buildTarget.options = {
       ...buildTarget.options,
       outputPath,
-      outputMode: 'server',
+      outputMode: options.serverRouting ? 'server' : undefined,
+      prerender: options.serverRouting ? undefined : true,
       ssr: {
         entry: join(normalize(projectSourceRoot), 'server.ts'),
       },
@@ -340,9 +341,12 @@ function addServerFile(
       ? (await getApplicationBuilderOutputPaths(host, projectName)).browser
       : await getLegacyOutputPaths(host, projectName, 'build');
 
+    const applicationBuilderFiles =
+      'application-builder' + (options.serverRouting ? '' : '-common-engine');
+
     return mergeWith(
       apply(
-        url(`./files/${isUsingApplicationBuilder ? 'application-builder' : 'server-builder'}`),
+        url(`./files/${isUsingApplicationBuilder ? applicationBuilderFiles : 'server-builder'}`),
         [
           applyTemplates({
             ...strings,

--- a/packages/schematics/angular/ssr/schema.json
+++ b/packages/schematics/angular/ssr/schema.json
@@ -15,6 +15,12 @@
       "description": "Skip installing dependency packages.",
       "type": "boolean",
       "default": false
+    },
+    "serverRouting": {
+      "description": "Creates a server application using the Server Routing and App Engine APIs (Developer Preview).",
+      "x-prompt": "Would you like to use the Server Routing and App Engine APIs (Developer Preview) for this server application?",
+      "type": "boolean",
+      "default": false
     }
   },
   "required": ["project"],

--- a/tests/legacy-cli/e2e/tests/build/prerender/discover-routes-ngmodule.ts
+++ b/tests/legacy-cli/e2e/tests/build/prerender/discover-routes-ngmodule.ts
@@ -39,6 +39,7 @@ export default async function () {
     projectName,
     '--skip-confirmation',
     '--skip-install',
+    '--server-routing',
   );
 
   await useSha();

--- a/tests/legacy-cli/e2e/tests/build/prerender/http-requests-assets.ts
+++ b/tests/legacy-cli/e2e/tests/build/prerender/http-requests-assets.ts
@@ -13,7 +13,7 @@ export default async function () {
 
   // Forcibly remove in case another test doesn't clean itself up.
   await rimraf('node_modules/@angular/ssr');
-  await ng('add', '@angular/ssr', '--skip-confirmation');
+  await ng('add', '@angular/ssr', '--server-routing', '--skip-confirmation');
   await useSha();
   await installWorkspacePackages();
 

--- a/tests/legacy-cli/e2e/tests/build/server-rendering/express-engine-csp-nonce.ts
+++ b/tests/legacy-cli/e2e/tests/build/server-rendering/express-engine-csp-nonce.ts
@@ -9,7 +9,7 @@ export default async function () {
   const useWebpackBuilder = !getGlobalVariable('argv')['esbuild'];
   // forcibly remove in case another test doesn't clean itself up
   await rimraf('node_modules/@angular/ssr');
-  await ng('add', '@angular/ssr', '--skip-confirmation', '--skip-install');
+  await ng('add', '@angular/ssr', '--server-routing', '--skip-confirmation', '--skip-install');
 
   await useSha();
   await installWorkspacePackages();

--- a/tests/legacy-cli/e2e/tests/build/server-rendering/express-engine-standalone.ts
+++ b/tests/legacy-cli/e2e/tests/build/server-rendering/express-engine-standalone.ts
@@ -8,7 +8,7 @@ import { updateJsonFile, updateServerFileForWebpack, useSha } from '../../../uti
 export default async function () {
   // forcibly remove in case another test doesn't clean itself up
   await rimraf('node_modules/@angular/ssr');
-  await ng('add', '@angular/ssr', '--skip-confirmation', '--skip-install');
+  await ng('add', '@angular/ssr', '--server-routing', '--skip-confirmation', '--skip-install');
 
   const useWebpackBuilder = !getGlobalVariable('argv')['esbuild'];
   if (!useWebpackBuilder) {

--- a/tests/legacy-cli/e2e/tests/build/server-rendering/server-routes-output-mode-server-i18n-base-href.ts
+++ b/tests/legacy-cli/e2e/tests/build/server-rendering/server-routes-output-mode-server-i18n-base-href.ts
@@ -19,7 +19,7 @@ export default async function () {
 
   // Forcibly remove in case another test doesn't clean itself up.
   await uninstallPackage('@angular/ssr');
-  await ng('add', '@angular/ssr', '--skip-confirmation', '--skip-install');
+  await ng('add', '@angular/ssr', '--server-routing', '--skip-confirmation', '--skip-install');
   await useSha();
   await installWorkspacePackages();
 

--- a/tests/legacy-cli/e2e/tests/build/server-rendering/server-routes-output-mode-server-i18n.ts
+++ b/tests/legacy-cli/e2e/tests/build/server-rendering/server-routes-output-mode-server-i18n.ts
@@ -19,7 +19,7 @@ export default async function () {
 
   // Forcibly remove in case another test doesn't clean itself up.
   await uninstallPackage('@angular/ssr');
-  await ng('add', '@angular/ssr', '--skip-confirmation', '--skip-install');
+  await ng('add', '@angular/ssr', '--server-routing', '--skip-confirmation', '--skip-install');
   await useSha();
   await installWorkspacePackages();
 

--- a/tests/legacy-cli/e2e/tests/build/server-rendering/server-routes-output-mode-server-platform-neutral.ts
+++ b/tests/legacy-cli/e2e/tests/build/server-rendering/server-routes-output-mode-server-platform-neutral.ts
@@ -20,7 +20,7 @@ export default async function () {
 
   // Forcibly remove in case another test doesn't clean itself up.
   await uninstallPackage('@angular/ssr');
-  await ng('add', '@angular/ssr', '--skip-confirmation', '--skip-install');
+  await ng('add', '@angular/ssr', '--server-routing', '--skip-confirmation', '--skip-install');
   await useSha();
   await installWorkspacePackages();
   await installPackage('h3@1');

--- a/tests/legacy-cli/e2e/tests/build/server-rendering/server-routes-output-mode-server.ts
+++ b/tests/legacy-cli/e2e/tests/build/server-rendering/server-routes-output-mode-server.ts
@@ -16,7 +16,7 @@ export default async function () {
 
   // Forcibly remove in case another test doesn't clean itself up.
   await uninstallPackage('@angular/ssr');
-  await ng('add', '@angular/ssr', '--skip-confirmation', '--skip-install');
+  await ng('add', '@angular/ssr', '--server-routing', '--skip-confirmation', '--skip-install');
   await useSha();
   await installWorkspacePackages();
 

--- a/tests/legacy-cli/e2e/tests/build/server-rendering/server-routes-output-mode-static-http-calls.ts
+++ b/tests/legacy-cli/e2e/tests/build/server-rendering/server-routes-output-mode-static-http-calls.ts
@@ -13,7 +13,7 @@ export default async function () {
 
   // Forcibly remove in case another test doesn't clean itself up.
   await uninstallPackage('@angular/ssr');
-  await ng('add', '@angular/ssr', '--skip-confirmation', '--skip-install');
+  await ng('add', '@angular/ssr', '--server-routing', '--skip-confirmation', '--skip-install');
   await useSha();
   await installWorkspacePackages();
 

--- a/tests/legacy-cli/e2e/tests/build/server-rendering/server-routes-output-mode-static.ts
+++ b/tests/legacy-cli/e2e/tests/build/server-rendering/server-routes-output-mode-static.ts
@@ -21,7 +21,7 @@ export default async function () {
 
   // Forcibly remove in case another test doesn't clean itself up.
   await uninstallPackage('@angular/ssr');
-  await ng('add', '@angular/ssr', '--skip-confirmation', '--skip-install');
+  await ng('add', '@angular/ssr', '--server-routing', '--skip-confirmation', '--skip-install');
   await useSha();
   await installWorkspacePackages();
 

--- a/tests/legacy-cli/e2e/tests/commands/serve/ssr-http-requests-assets.ts
+++ b/tests/legacy-cli/e2e/tests/commands/serve/ssr-http-requests-assets.ts
@@ -8,7 +8,7 @@ import { ngServe, useSha } from '../../../utils/project';
 export default async function () {
   // Forcibly remove in case another test doesn't clean itself up.
   await rimraf('node_modules/@angular/ssr');
-  await ng('add', '@angular/ssr', '--skip-confirmation');
+  await ng('add', '@angular/ssr', '--server-routing', '--skip-confirmation');
   await useSha();
   await installWorkspacePackages();
 

--- a/tests/legacy-cli/e2e/tests/vite/ssr-entry-express.ts
+++ b/tests/legacy-cli/e2e/tests/vite/ssr-entry-express.ts
@@ -14,7 +14,7 @@ export default async function () {
 
   // Forcibly remove in case another test doesn't clean itself up.
   await uninstallPackage('@angular/ssr');
-  await ng('add', '@angular/ssr', '--skip-confirmation', '--skip-install');
+  await ng('add', '@angular/ssr', '--server-routing', '--skip-confirmation', '--skip-install');
   await useSha();
   await installWorkspacePackages();
 

--- a/tests/legacy-cli/e2e/tests/vite/ssr-entry-fastify.ts
+++ b/tests/legacy-cli/e2e/tests/vite/ssr-entry-fastify.ts
@@ -14,7 +14,7 @@ export default async function () {
 
   // Forcibly remove in case another test doesn't clean itself up.
   await uninstallPackage('@angular/ssr');
-  await ng('add', '@angular/ssr', '--skip-confirmation', '--skip-install');
+  await ng('add', '@angular/ssr', '--server-routing', '--skip-confirmation', '--skip-install');
   await useSha();
   await installWorkspacePackages();
   await installPackage('fastify@5');

--- a/tests/legacy-cli/e2e/tests/vite/ssr-entry-h3.ts
+++ b/tests/legacy-cli/e2e/tests/vite/ssr-entry-h3.ts
@@ -14,7 +14,7 @@ export default async function () {
 
   // Forcibly remove in case another test doesn't clean itself up.
   await uninstallPackage('@angular/ssr');
-  await ng('add', '@angular/ssr', '--skip-confirmation', '--skip-install');
+  await ng('add', '@angular/ssr', '--server-routing', '--skip-confirmation', '--skip-install');
   await useSha();
   await installWorkspacePackages();
   await installPackage('h3@1');

--- a/tests/legacy-cli/e2e/tests/vite/ssr-entry-hono.ts
+++ b/tests/legacy-cli/e2e/tests/vite/ssr-entry-hono.ts
@@ -14,7 +14,7 @@ export default async function () {
 
   // Forcibly remove in case another test doesn't clean itself up.
   await uninstallPackage('@angular/ssr');
-  await ng('add', '@angular/ssr', '--skip-confirmation', '--skip-install');
+  await ng('add', '@angular/ssr', '--server-routing', '--skip-confirmation', '--skip-install');
   await useSha();
   await installWorkspacePackages();
   await installPackage('hono@4');

--- a/tests/legacy-cli/e2e/tests/vite/ssr-error-stack.ts
+++ b/tests/legacy-cli/e2e/tests/vite/ssr-error-stack.ts
@@ -7,7 +7,7 @@ import { installWorkspacePackages } from '../../utils/packages';
 export default async function () {
   // Forcibly remove in case another test doesn't clean itself up.
   await rimraf('node_modules/@angular/ssr');
-  await ng('add', '@angular/ssr', '--skip-confirmation');
+  await ng('add', '@angular/ssr', '--server-routing', '--skip-confirmation');
   await useSha();
   await installWorkspacePackages();
 


### PR DESCRIPTION
This commit updates several schematics to make the new `@angular/ssr` feature opt-in. Users can opt in by using the `--server-routing` option or by responding with `yes` to the prompt.
