### PR TITLE
refactor: add "version" prop to schematics collection schema

### DIFF
--- a/packages/angular_devkit/schematics/collection-schema.json
+++ b/packages/angular_devkit/schematics/collection-schema.json
@@ -57,6 +57,10 @@
             "type": "boolean",
             "default": false,
             "description": "Whether or not this schematic can be called from an external schematic, or a tool. This implies hidden: true."
+          },
+          "version": {
+            "type": "string",
+            "description": "Used for an `ng update` migration schematic. Specifies in which version of the library the migration schematic will run when updating"
           }
         },
         "required": ["factory", "description"]


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- **N/A** Tests for the changes have been added (for bug fixes / features)
- **N/A** Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

[`collection-schema.json` file](https://github.com/angular/angular-cli/blob/18.2.10/packages/angular_devkit/schematics/collection-schema.json) is a schema to define a schematics collection JSON file.

However, it's missing the schematics' `version` property [used for `ng update` migration schematics](https://github.com/angular/angular-cli/blob/18.2.10/docs/specifications/update.md#library-developers).

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

Add the missing `version` property with a description. Optional as for rest of schematics it's not used AFAIK.

<!-- Please describe the new behavior that. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
