### PR TITLE
fix(@angular/build): skip prerendering when no routes are configured

### DIFF
--- a/packages/angular/ssr/src/routes/ng-routes.ts
+++ b/packages/angular/ssr/src/routes/ng-routes.ts
@@ -477,8 +477,6 @@ export async function getRoutesFromAngularRouterConfig(
           );
         }
       }
-    } else {
-      routesResults.push({ route: '', renderMode: RenderMode.Prerender });
     }
 
     return {


### PR DESCRIPTION
When no routes are specified, prerendering is unnecessary and can lead to unexpected behavior. This change ensures that prerendering is only performed when routes are properly configured.
