### PR TITLE
fix(@angular/ssr): ensure wildcard RenderMode is applied when no Angular routes are defined

### DIFF
--- a/packages/angular/ssr/src/routes/ng-routes.ts
+++ b/packages/angular/ssr/src/routes/ng-routes.ts
@@ -411,26 +411,26 @@ export async function getRoutesFromAngularRouterConfig(
       injector.get(APP_BASE_HREF, null, { optional: true }) ??
       injector.get(PlatformLocation).getBaseHrefFromDOM();
 
+    const compiler = injector.get(Compiler);
+
+    const serverRoutesConfig = injector.get(SERVER_ROUTES_CONFIG, null, { optional: true });
+    let serverConfigRouteTree: RouteTree<ServerConfigRouteTreeAdditionalMetadata> | undefined;
+
+    if (serverRoutesConfig) {
+      const result = buildServerConfigRouteTree(serverRoutesConfig);
+      serverConfigRouteTree = result.serverConfigRouteTree;
+      errors.push(...result.errors);
+    }
+
+    if (errors.length) {
+      return {
+        baseHref,
+        routes: routesResults,
+        errors,
+      };
+    }
+
     if (router.config.length) {
-      const compiler = injector.get(Compiler);
-
-      const serverRoutesConfig = injector.get(SERVER_ROUTES_CONFIG, null, { optional: true });
-      let serverConfigRouteTree: RouteTree<ServerConfigRouteTreeAdditionalMetadata> | undefined;
-
-      if (serverRoutesConfig) {
-        const result = buildServerConfigRouteTree(serverRoutesConfig);
-        serverConfigRouteTree = result.serverConfigRouteTree;
-        errors.push(...result.errors);
-      }
-
-      if (errors.length) {
-        return {
-          baseHref,
-          routes: routesResults,
-          errors,
-        };
-      }
-
       // Retrieve all routes from the Angular router configuration.
       const traverseRoutes = traverseRoutesConfig({
         routes: router.config,
@@ -478,7 +478,12 @@ export async function getRoutesFromAngularRouterConfig(
         }
       }
     } else {
-      routesResults.push({ route: '', renderMode: RenderMode.Prerender });
+      const renderMode = serverConfigRouteTree?.match('')?.renderMode ?? RenderMode.Prerender;
+
+      routesResults.push({
+        route: '',
+        renderMode,
+      });
     }
 
     return {

--- a/packages/angular/ssr/test/routes/ng-routes_spec.ts
+++ b/packages/angular/ssr/test/routes/ng-routes_spec.ts
@@ -361,4 +361,18 @@ describe('extractRoutesAndCreateRouteTree', () => {
       `Both 'home' and 'shell' routes have their 'renderMode' set to 'AppShell'.`,
     );
   });
+
+  it('should apply RenderMode matching the wildcard when no Angular routes are defined', async () => {
+    setAngularAppTestingManifest([], [{ path: '**', renderMode: RenderMode.Server }]);
+
+    const { errors, routeTree } = await extractRoutesAndCreateRouteTree(
+      url,
+      /** manifest */ undefined,
+      /** invokeGetPrerenderParams */ false,
+      /** includePrerenderFallbackRoutes */ false,
+    );
+
+    expect(errors).toHaveSize(0);
+    expect(routeTree.toObject()).toEqual([{ route: '/', renderMode: RenderMode.Server }]);
+  });
 });


### PR DESCRIPTION
This fix addresses a bug where, in the absence of defined Angular routes, the RenderMode was not correctly applied based on the wildcard setting.
