### PR TITLE
refactor(@angular/build): Pin the supported browsers in the default browserslist config

### DIFF
--- a/packages/angular/build/src/utils/supported-browsers.ts
+++ b/packages/angular/build/src/utils/supported-browsers.ts
@@ -12,13 +12,14 @@ export function getSupportedBrowsers(
   projectRoot: string,
   logger: { warn(message: string): void },
 ): string[] {
+  // This list should match the last 2 versions of the browsers we support at the release.
   browserslist.defaults = [
-    'last 2 Chrome versions',
-    'last 1 Firefox version',
-    'last 2 Edge major versions',
-    'last 2 Safari major versions',
-    'last 2 iOS major versions',
-    'last 2 Android major versions',
+    'Chrome >= 127',
+    'Edge >= 127',
+    'Firefox >= 129',
+    'Safari >= 16',
+    'ios >= 16',
+    'Android >= 127',
     'Firefox ESR',
   ];
 

--- a/packages/schematics/angular/config/files/.browserslistrc.template
+++ b/packages/schematics/angular/config/files/.browserslistrc.template
@@ -8,10 +8,10 @@
 # You can see what browsers were selected by your queries by running:
 #   npx browserslist
 
-last 2 Chrome versions
-last 1 Firefox version
-last 2 Edge major versions
-last 2 Safari major versions
-last 2 iOS major versions
-last 2 Android major versions
+Chrome >= 127
+Edge >= 127
+Firefox >= 129
+Safari >= 16
+ios >= 16
+Android >= 127 
 Firefox ESR


### PR DESCRIPTION
In order to deterministic list of supported browser for a given version, we now pin the versions in the browserlists config.

This could fix issue where like in #28707, a minor of Angular broke support for Safari 16, where is previously worked (because the definition of "last 2" got updated to drop Safari 16 with that bump). 

This would also address a demand on the fw side angular/angular#54195.
