### PR TITLE
refactor(@angular/build): use ETags for dev-server resource requests

### DIFF
--- a/packages/angular/build/src/tools/vite/middlewares/assets-middleware.ts
+++ b/packages/angular/build/src/tools/vite/middlewares/assets-middleware.ts
@@ -119,11 +119,21 @@ export function createAngularAssetsMiddleware(
           }
         }
 
+        // Avoid resending the content if it has not changed since last request
+        const etag = `W/"${outputFile.contents.byteLength}-${outputFile.hash}"`;
+        if (req.headers['if-none-match'] === etag) {
+          res.statusCode = 304;
+          res.end();
+
+          return;
+        }
+
         const mimeType = lookupMimeType(extension);
         if (mimeType) {
           res.setHeader('Content-Type', mimeType);
         }
         res.setHeader('Cache-Control', 'no-cache');
+        res.setHeader('ETag', etag);
         res.end(data);
 
         return;


### PR DESCRIPTION
When using the development server with the application build system, resource files managed by the build system will now using ETag headers to avoid resending content that has not changed since the last request. This includes such content as global stylesheet files, image/font files referenced in stylesheets, and other files managed by the bundler.