### PR TITLE
fix(@angular/ssr): enable serving of prerendered pages in the App Engine

### DIFF
--- a/goldens/public-api/angular/ssr/index.api.md
+++ b/goldens/public-api/angular/ssr/index.api.md
@@ -8,8 +8,7 @@ import { EnvironmentProviders } from '@angular/core';
 
 // @public
 export class AngularAppEngine {
-    getPrerenderHeaders(request: Request): ReadonlyMap<string, string>;
-    render(request: Request, requestContext?: unknown): Promise<Response | null>;
+    handle(request: Request, requestContext?: unknown): Promise<Response | null>;
     static ɵhooks: Hooks;
 }
 

--- a/goldens/public-api/angular/ssr/node/index.api.md
+++ b/goldens/public-api/angular/ssr/node/index.api.md
@@ -12,8 +12,7 @@ import { Type } from '@angular/core';
 
 // @public
 export class AngularNodeAppEngine {
-    getPrerenderHeaders(request: IncomingMessage): ReadonlyMap<string, string>;
-    render(request: IncomingMessage, requestContext?: unknown): Promise<Response | null>;
+    handle(request: IncomingMessage, requestContext?: unknown): Promise<Response | null>;
 }
 
 // @public

--- a/packages/angular/build/src/builders/application/execute-post-bundle.ts
+++ b/packages/angular/build/src/builders/application/execute-post-bundle.ts
@@ -175,7 +175,8 @@ export async function executePostBundleSteps(
       switch (metadata.renderMode) {
         case RouteRenderMode.Prerender:
         case /* Legacy building mode */ undefined: {
-          if (!metadata.redirectTo || outputMode === OutputMode.Static) {
+          if (!metadata.redirectTo) {
+            serializableRouteTreeNodeForManifest.push(metadata);
             prerenderedRoutes[metadata.route] = { headers: metadata.headers };
           }
           break;

--- a/packages/angular/build/src/tools/vite/middlewares/ssr-middleware.ts
+++ b/packages/angular/build/src/tools/vite/middlewares/ssr-middleware.ts
@@ -59,7 +59,7 @@ export function createAngularSsrInternalMiddleware(
       const webReq = new Request(createWebRequestFromNodeRequest(req), {
         signal: AbortSignal.timeout(30_000),
       });
-      const webRes = await angularServerApp.render(webReq);
+      const webRes = await angularServerApp.handle(webReq);
       if (!webRes) {
         return next();
       }

--- a/packages/angular/build/src/utils/server-rendering/manifest.ts
+++ b/packages/angular/build/src/utils/server-rendering/manifest.ts
@@ -6,9 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import { extname } from 'node:path';
 import {
-  INDEX_HTML_CSR,
-  INDEX_HTML_SERVER,
   NormalizedApplicationBuildOptions,
   getLocaleBaseHref,
 } from '../../builders/application/options';
@@ -135,11 +134,8 @@ export function generateAngularServerAppManifest(
 ): string {
   const serverAssetsContent: string[] = [];
   for (const file of [...additionalHtmlOutputFiles.values(), ...outputFiles]) {
-    if (
-      file.path === INDEX_HTML_SERVER ||
-      file.path === INDEX_HTML_CSR ||
-      (inlineCriticalCss && file.path.endsWith('.css'))
-    ) {
+    const extension = extname(file.path);
+    if (extension === '.html' || (inlineCriticalCss && extension === '.css')) {
       serverAssetsContent.push(`['${file.path}', async () => \`${escapeUnsafeChars(file.text)}\`]`);
     }
   }

--- a/packages/angular/ssr/node/src/app-engine.ts
+++ b/packages/angular/ssr/node/src/app-engine.ts
@@ -24,49 +24,19 @@ export class AngularNodeAppEngine {
   private readonly angularAppEngine = new AngularAppEngine();
 
   /**
-   * Renders an HTTP response based on the incoming request using the Angular server application.
+   * Handles an incoming HTTP request by serving prerendered content, performing server-side rendering,
+   * or delivering a static file for client-side rendered routes based on the `RenderMode` setting.
    *
-   * The method processes the incoming request, determines the appropriate route, and prepares the
-   * rendering context to generate a response. If the request URL corresponds to a static file (excluding `/index.html`),
-   * the method returns `null`.
+   * @param request - The HTTP request to handle.
+   * @param requestContext - Optional context for rendering, such as metadata associated with the request.
+   * @returns A promise that resolves to the resulting HTTP response object, or `null` if no matching Angular route is found.
    *
-   * Example: A request to `https://www.example.com/page/index.html` will render the Angular route
-   * associated with `https://www.example.com/page`.
-   *
-   * @param request - The incoming HTTP request object to be rendered.
-   * @param requestContext - Optional additional context for the request, such as metadata or custom settings.
-   * @returns A promise that resolves to a `Response` object, or `null` if the request URL is for a static file
-   * (e.g., `./logo.png`) rather than an application route.
+   * @note A request to `https://www.example.com/page/index.html` will serve or render the Angular route
+   * corresponding to `https://www.example.com/page`.
    */
-  render(request: IncomingMessage, requestContext?: unknown): Promise<Response | null> {
-    return this.angularAppEngine.render(createWebRequestFromNodeRequest(request), requestContext);
-  }
+  async handle(request: IncomingMessage, requestContext?: unknown): Promise<Response | null> {
+    const webRequest = createWebRequestFromNodeRequest(request);
 
-  /**
-   * Retrieves HTTP headers for a request associated with statically generated (SSG) pages,
-   * based on the URL pathname.
-   *
-   * @param request - The incoming request object.
-   * @returns A `Map` containing the HTTP headers as key-value pairs.
-   * @note This function should be used exclusively for retrieving headers of SSG pages.
-   * @example
-   * ```typescript
-   * const angularAppEngine = new AngularNodeAppEngine();
-   *
-   * app.use(express.static('dist/browser', {
-   *   setHeaders: (res, path) => {
-   *     // Retrieve headers for the current request
-   *     const headers = angularAppEngine.getPrerenderHeaders(res.req);
-   *
-   *     // Apply the retrieved headers to the response
-   *     for (const [key, value] of headers) {
-   *       res.setHeader(key, value);
-   *     }
-   *   }
-     }));
-  * ```
-  */
-  getPrerenderHeaders(request: IncomingMessage): ReadonlyMap<string, string> {
-    return this.angularAppEngine.getPrerenderHeaders(createWebRequestFromNodeRequest(request));
+    return this.angularAppEngine.handle(webRequest, requestContext);
   }
 }

--- a/packages/angular/ssr/node/src/request.ts
+++ b/packages/angular/ssr/node/src/request.ts
@@ -56,7 +56,12 @@ function createRequestHeaders(nodeHeaders: IncomingHttpHeaders): Headers {
  * @returns A `URL` object representing the request URL.
  */
 function createRequestUrl(nodeRequest: IncomingMessage): URL {
-  const { headers, socket, url = '' } = nodeRequest;
+  const {
+    headers,
+    socket,
+    url = '',
+    originalUrl,
+  } = nodeRequest as IncomingMessage & { originalUrl?: string };
   const protocol =
     headers['x-forwarded-proto'] ?? ('encrypted' in socket && socket.encrypted ? 'https' : 'http');
   const hostname = headers['x-forwarded-host'] ?? headers.host ?? headers[':authority'];
@@ -71,5 +76,5 @@ function createRequestUrl(nodeRequest: IncomingMessage): URL {
     hostnameWithPort += `:${port}`;
   }
 
-  return new URL(url, `${protocol}://${hostnameWithPort}`);
+  return new URL(originalUrl ?? url, `${protocol}://${hostnameWithPort}`);
 }

--- a/packages/angular/ssr/src/assets.ts
+++ b/packages/angular/ssr/src/assets.ts
@@ -36,6 +36,16 @@ export class ServerAssets {
   }
 
   /**
+   * Checks if a specific server-side asset exists.
+   *
+   * @param path - The path to the server asset.
+   * @returns A boolean indicating whether the asset exists.
+   */
+  hasServerAsset(path: string): boolean {
+    return this.manifest.assets.has(path);
+  }
+
+  /**
    * Retrieves and caches the content of 'index.server.html'.
    *
    * @returns A promise that resolves to the content of 'index.server.html'.

--- a/packages/angular/ssr/src/manifest.ts
+++ b/packages/angular/ssr/src/manifest.ts
@@ -10,6 +10,11 @@ import type { SerializableRouteTreeNode } from './routes/route-tree';
 import { AngularBootstrap } from './utils/ng';
 
 /**
+ * A function that returns a promise resolving to the file contents of the asset.
+ */
+export type ServerAsset = () => Promise<string>;
+
+/**
  * Represents the exports of an Angular server application entry point.
  */
 export interface EntryPointExports {
@@ -43,19 +48,6 @@ export interface AngularAppEngineManifest {
    * This is used to determine the root path of the application.
    */
   readonly basePath: string;
-
-  /**
-   * A map that associates static paths with their corresponding HTTP headers.
-   * Each entry in the map consists of:
-   * - `key`: The static path as a string.
-   * - `value`: An array of tuples, where each tuple contains:
-   *   - `headerName`: The name of the HTTP header.
-   *   - `headerValue`: The value of the HTTP header.
-   */
-  readonly staticPathsHeaders: ReadonlyMap<
-    string,
-    readonly [headerName: string, headerValue: string][]
-  >;
 }
 
 /**
@@ -68,7 +60,7 @@ export interface AngularAppManifest {
    * - `key`: The path of the asset.
    * - `value`: A function returning a promise that resolves to the file contents of the asset.
    */
-  readonly assets: ReadonlyMap<string, () => Promise<string>>;
+  readonly assets: ReadonlyMap<string, ServerAsset>;
 
   /**
    * The bootstrap mechanism for the server application.

--- a/packages/angular/ssr/test/app-engine_spec.ts
+++ b/packages/angular/ssr/test/app-engine_spec.ts
@@ -53,15 +53,6 @@ describe('AngularAppEngine', () => {
           ]),
         ),
         basePath: '',
-        staticPathsHeaders: new Map([
-          [
-            '/about',
-            [
-              ['Cache-Control', 'no-cache'],
-              ['X-Some-Header', 'value'],
-            ],
-          ],
-        ]),
       });
 
       appEngine = new AngularAppEngine();
@@ -70,64 +61,38 @@ describe('AngularAppEngine', () => {
     describe('render', () => {
       it('should return null for requests to unknown pages', async () => {
         const request = new Request('https://example.com/unknown/page');
-        const response = await appEngine.render(request);
+        const response = await appEngine.handle(request);
         expect(response).toBeNull();
       });
 
       it('should return null for requests with unknown locales', async () => {
         const request = new Request('https://example.com/es/home');
-        const response = await appEngine.render(request);
+        const response = await appEngine.handle(request);
         expect(response).toBeNull();
       });
 
       it('should return a rendered page with correct locale', async () => {
         const request = new Request('https://example.com/it/home');
-        const response = await appEngine.render(request);
+        const response = await appEngine.handle(request);
         expect(await response?.text()).toContain('Home works IT');
       });
 
       it('should correctly render the content when the URL ends with "index.html" with correct locale', async () => {
         const request = new Request('https://example.com/it/home/index.html');
-        const response = await appEngine.render(request);
+        const response = await appEngine.handle(request);
         expect(await response?.text()).toContain('Home works IT');
       });
 
       it('should return null for requests to unknown pages in a locale', async () => {
         const request = new Request('https://example.com/it/unknown/page');
-        const response = await appEngine.render(request);
+        const response = await appEngine.handle(request);
         expect(response).toBeNull();
       });
 
       it('should return null for requests to file-like resources in a locale', async () => {
         const request = new Request('https://example.com/it/logo.png');
-        const response = await appEngine.render(request);
+        const response = await appEngine.handle(request);
         expect(response).toBeNull();
-      });
-    });
-
-    describe('getPrerenderHeaders', () => {
-      it('should return headers for a known path without index.html', () => {
-        const request = new Request('https://example.com/about');
-        const headers = appEngine.getPrerenderHeaders(request);
-        expect(Object.fromEntries(headers.entries())).toEqual({
-          'Cache-Control': 'no-cache',
-          'X-Some-Header': 'value',
-        });
-      });
-
-      it('should return headers for a known path with index.html', () => {
-        const request = new Request('https://example.com/about/index.html');
-        const headers = appEngine.getPrerenderHeaders(request);
-        expect(Object.fromEntries(headers.entries())).toEqual({
-          'Cache-Control': 'no-cache',
-          'X-Some-Header': 'value',
-        });
-      });
-
-      it('should return no headers for unknown paths', () => {
-        const request = new Request('https://example.com/unknown/path');
-        const headers = appEngine.getPrerenderHeaders(request);
-        expect(headers).toHaveSize(0);
       });
     });
   });
@@ -161,7 +126,6 @@ describe('AngularAppEngine', () => {
           ],
         ]),
         basePath: '',
-        staticPathsHeaders: new Map(),
       });
 
       appEngine = new AngularAppEngine();
@@ -169,25 +133,25 @@ describe('AngularAppEngine', () => {
 
     it('should return null for requests to file-like resources', async () => {
       const request = new Request('https://example.com/logo.png');
-      const response = await appEngine.render(request);
+      const response = await appEngine.handle(request);
       expect(response).toBeNull();
     });
 
     it('should return null for requests to unknown pages', async () => {
       const request = new Request('https://example.com/unknown/page');
-      const response = await appEngine.render(request);
+      const response = await appEngine.handle(request);
       expect(response).toBeNull();
     });
 
     it('should return a rendered page for known paths', async () => {
       const request = new Request('https://example.com/home');
-      const response = await appEngine.render(request);
+      const response = await appEngine.handle(request);
       expect(await response?.text()).toContain('Home works');
     });
 
     it('should correctly render the content when the URL ends with "index.html"', async () => {
       const request = new Request('https://example.com/home/index.html');
-      const response = await appEngine.render(request);
+      const response = await appEngine.handle(request);
       expect(await response?.text()).toContain('Home works');
     });
   });

--- a/packages/angular/ssr/test/app_spec.ts
+++ b/packages/angular/ssr/test/app_spec.ts
@@ -33,6 +33,7 @@ describe('AngularServerApp', () => {
       [
         { path: 'home', component: HomeComponent },
         { path: 'home-csr', component: HomeComponent },
+        { path: 'home-ssg', component: HomeComponent },
         { path: 'page-with-headers', component: HomeComponent },
         { path: 'page-with-status', component: HomeComponent },
         { path: 'redirect', redirectTo: 'home' },
@@ -43,6 +44,13 @@ describe('AngularServerApp', () => {
         {
           path: 'home-csr',
           renderMode: RenderMode.Client,
+        },
+        {
+          path: 'home-ssg',
+          renderMode: RenderMode.Prerender,
+          headers: {
+            'X-Some-Header': 'value',
+          },
         },
         {
           path: 'page-with-status',
@@ -62,86 +70,129 @@ describe('AngularServerApp', () => {
           renderMode: RenderMode.Server,
         },
       ],
+      undefined,
+      {
+        'home-ssg/index.html': async () =>
+          `<html>
+            <head>
+              <title>SSG home page</title>
+              <base href="/" />
+            </head>
+            <body>
+              <app-root>Home SSG works</app-root>
+            </body>
+          </html>
+        `,
+      },
     );
 
     app = new AngularServerApp();
   });
 
-  describe('render', () => {
-    it('should correctly render the content for the requested page', async () => {
-      const response = await app.render(new Request('http://localhost/home'));
-      expect(await response?.text()).toContain('Home works');
-    });
-
-    it(`should correctly render the content when the URL ends with 'index.html'`, async () => {
-      const response = await app.render(new Request('http://localhost/home/index.html'));
-      expect(await response?.text()).toContain('Home works');
-    });
-
-    it('should correctly handle top level redirects', async () => {
-      const response = await app.render(new Request('http://localhost/redirect'));
-      expect(response?.headers.get('location')).toContain('http://localhost/home');
-      expect(response?.status).toBe(302);
-    });
-
-    it('should correctly handle relative nested redirects', async () => {
-      const response = await app.render(new Request('http://localhost/redirect/relative'));
-      expect(response?.headers.get('location')).toContain('http://localhost/redirect/home');
-      expect(response?.status).toBe(302);
-    });
-
-    it('should correctly handle absolute nested redirects', async () => {
-      const response = await app.render(new Request('http://localhost/redirect/absolute'));
-      expect(response?.headers.get('location')).toContain('http://localhost/home');
-      expect(response?.status).toBe(302);
-    });
-
-    it('should handle request abortion gracefully', async () => {
-      const controller = new AbortController();
-      const request = new Request('http://localhost/home', { signal: controller.signal });
-
-      // Schedule the abortion of the request in the next microtask
-      queueMicrotask(() => {
-        controller.abort();
+  describe('handle', () => {
+    describe('CSR and SSG pages', () => {
+      it('should correctly render the content for the requested page', async () => {
+        const response = await app.handle(new Request('http://localhost/home'));
+        expect(await response?.text()).toContain('Home works');
       });
 
-      await expectAsync(app.render(request)).toBeRejectedWithError(/Request for: .+ was aborted/);
-    });
+      it(`should correctly render the content when the URL ends with 'index.html'`, async () => {
+        const response = await app.handle(new Request('http://localhost/home/index.html'));
+        expect(await response?.text()).toContain('Home works');
+      });
 
-    it('should return configured headers for pages with specific header settings', async () => {
-      const response = await app.render(new Request('http://localhost/page-with-headers'));
-      const headers = response?.headers.entries() ?? [];
-      expect(Object.fromEntries(headers)).toEqual({
-        'cache-control': 'no-cache',
-        'x-some-header': 'value',
-        'content-type': 'text/html;charset=UTF-8',
+      it('should correctly handle top level redirects', async () => {
+        const response = await app.handle(new Request('http://localhost/redirect'));
+        expect(response?.headers.get('location')).toContain('http://localhost/home');
+        expect(response?.status).toBe(302);
+      });
+
+      it('should correctly handle relative nested redirects', async () => {
+        const response = await app.handle(new Request('http://localhost/redirect/relative'));
+        expect(response?.headers.get('location')).toContain('http://localhost/redirect/home');
+        expect(response?.status).toBe(302);
+      });
+
+      it('should correctly handle absolute nested redirects', async () => {
+        const response = await app.handle(new Request('http://localhost/redirect/absolute'));
+        expect(response?.headers.get('location')).toContain('http://localhost/home');
+        expect(response?.status).toBe(302);
+      });
+
+      it('should handle request abortion gracefully', async () => {
+        const controller = new AbortController();
+        const request = new Request('http://localhost/home', { signal: controller.signal });
+
+        // Schedule the abortion of the request in the next microtask
+        queueMicrotask(() => {
+          controller.abort();
+        });
+
+        await expectAsync(app.handle(request)).toBeRejectedWithError(/Request for: .+ was aborted/);
+      });
+
+      it('should return configured headers for pages with specific header settings', async () => {
+        const response = await app.handle(new Request('http://localhost/page-with-headers'));
+        const headers = response?.headers.entries() ?? [];
+        expect(Object.fromEntries(headers)).toEqual({
+          'cache-control': 'no-cache',
+          'x-some-header': 'value',
+          'content-type': 'text/html;charset=UTF-8',
+        });
+      });
+
+      it('should return only default headers for pages without specific header configurations', async () => {
+        const response = await app.handle(new Request('http://localhost/home'));
+        const headers = response?.headers.entries() ?? [];
+        expect(Object.fromEntries(headers)).toEqual({
+          'content-type': 'text/html;charset=UTF-8', // default header
+        });
+      });
+
+      it('should return the configured status for pages with specific status settings', async () => {
+        const response = await app.handle(new Request('http://localhost/page-with-status'));
+        expect(response?.status).toBe(201);
+      });
+
+      it('should return static `index.csr.html` for routes with CSR rendering mode', async () => {
+        const response = await app.handle(new Request('http://localhost/home-csr'));
+        const content = await response?.text();
+
+        expect(content).toContain('<title>CSR page</title>');
+        expect(content).not.toContain('ng-server-context');
+      });
+
+      it('should include `ng-server-context="ssr"` for SSR rendering mode', async () => {
+        const response = await app.handle(new Request('http://localhost/home'));
+        expect(await response?.text()).toContain('ng-server-context="ssr"');
       });
     });
 
-    it('should return only default headers for pages without specific header configurations', async () => {
-      const response = await app.render(new Request('http://localhost/home'));
-      const headers = response?.headers.entries() ?? [];
-      expect(Object.fromEntries(headers)).toEqual({
-        'content-type': 'text/html;charset=UTF-8', // default header
+    describe('SSG pages', () => {
+      it('should correctly serve the content for the requested prerendered page', async () => {
+        const response = await app.handle(new Request('http://localhost/home-ssg'));
+        expect(await response?.text()).toContain('Home SSG works');
       });
-    });
 
-    it('should return the configured status for pages with specific status settings', async () => {
-      const response = await app.render(new Request('http://localhost/page-with-status'));
-      expect(response?.status).toBe(201);
-    });
+      it(`should correctly serve the content for the requested prerendered page when the URL ends with 'index.html'`, async () => {
+        const response = await app.handle(new Request('http://localhost/home-ssg/index.html'));
+        expect(await response?.text()).toContain('Home SSG works');
+      });
 
-    it('should return static `index.csr.html` for routes with CSR rendering mode', async () => {
-      const response = await app.render(new Request('http://localhost/home-csr'));
-      const content = await response?.text();
+      it('should return configured headers for pages with specific header settings', async () => {
+        const response = await app.handle(new Request('http://localhost/home-ssg'));
+        const headers = response?.headers.entries() ?? [];
+        expect(Object.fromEntries(headers)).toEqual({
+          'cache-control': 'max-age=31536000',
+          'x-some-header': 'value',
+          'content-type': 'text/html;charset=UTF-8',
+        });
+      });
 
-      expect(content).toContain('<title>CSR page</title>');
-      expect(content).not.toContain('ng-server-context');
-    });
-
-    it('should include `ng-server-context="ssr"` for SSR rendering mode', async () => {
-      const response = await app.render(new Request('http://localhost/home'));
-      expect(await response?.text()).toContain('ng-server-context="ssr"');
+      it('should return null for a non-prerendered page', async () => {
+        const response = await app.handle(new Request('http://localhost/unknown'));
+        expect(response).toBeNull();
+      });
     });
   });
 });

--- a/packages/angular/ssr/test/testing-utils.ts
+++ b/packages/angular/ssr/test/testing-utils.ts
@@ -10,7 +10,7 @@ import { Component, provideExperimentalZonelessChangeDetection } from '@angular/
 import { bootstrapApplication } from '@angular/platform-browser';
 import { provideServerRendering } from '@angular/platform-server';
 import { RouterOutlet, Routes, provideRouter } from '@angular/router';
-import { setAngularAppManifest } from '../src/manifest';
+import { AngularAppManifest, ServerAsset, setAngularAppManifest } from '../src/manifest';
 import { ServerRoute, provideServerRoutesConfig } from '../src/routes/route-config';
 
 /**
@@ -27,11 +27,13 @@ export function setAngularAppTestingManifest(
   routes: Routes,
   serverRoutes: ServerRoute[],
   baseHref = '',
+  additionalServerAssets: Record<string, ServerAsset> = {},
 ): void {
   setAngularAppManifest({
     inlineCriticalCss: false,
     assets: new Map(
       Object.entries({
+        ...additionalServerAssets,
         'index.server.html': async () =>
           `<html>
             <head>

--- a/packages/schematics/angular/ssr/files/application-builder/server.ts.template
+++ b/packages/schematics/angular/ssr/files/application-builder/server.ts.template
@@ -29,26 +29,20 @@ const angularApp = new AngularNodeAppEngine();
 /**
  * Serve static files from /<%= browserDistDirectory %>
  */
-app.get(
-  '**',
+app.use(
   express.static(browserDistFolder, {
     maxAge: '1y',
-    index: 'index.html',
-    setHeaders: (res) => {
-      const headers = angularApp.getPrerenderHeaders(res.req);
-      for (const [key, value] of headers) {
-        res.setHeader(key, value);
-      }
-    },
+    index: false,
+    redirect: false,
   }),
 );
 
 /**
  * Handle all other requests by rendering the Angular application.
  */
-app.get('**', (req, res, next) => {
+app.use('/**', (req, res, next) => {
   angularApp
-    .render(req)
+    .handle(req)
     .then((response) =>
       response ? writeResponseToNodeResponse(response, res) : next(),
     )

--- a/tests/legacy-cli/e2e/tests/build/server-rendering/server-routes-output-mode-server-platform-neutral.ts
+++ b/tests/legacy-cli/e2e/tests/build/server-rendering/server-routes-output-mode-server-platform-neutral.ts
@@ -78,7 +78,7 @@ export default async function () {
 
       router.use(
         '/**',
-        defineEventHandler((event) => angularAppEngine.render(toWebRequest(event))),
+        defineEventHandler((event) => angularAppEngine.handle(toWebRequest(event))),
       );
 
       app.use(router);

--- a/tests/legacy-cli/e2e/tests/build/server-rendering/server-routes-output-mode-static-http-calls.ts
+++ b/tests/legacy-cli/e2e/tests/build/server-rendering/server-routes-output-mode-static-http-calls.ts
@@ -94,7 +94,7 @@ export default async function () {
         }));
 
         server.get('**', (req, res, next) => {
-          angularNodeAppEngine.render(req)
+          angularNodeAppEngine.handle(req)
             .then((response) => response ? writeResponseToNodeResponse(response, res) : next())
             .catch(next);
         });

--- a/tests/legacy-cli/e2e/tests/vite/ssr-entry-express.ts
+++ b/tests/legacy-cli/e2e/tests/vite/ssr-entry-express.ts
@@ -63,7 +63,7 @@ export default async function () {
         }));
 
         server.get('**', (req, res, next) => {
-          angularNodeAppEngine.render(req)
+          angularNodeAppEngine.handle(req)
             .then((response) => response ? writeResponseToNodeResponse(response, res) : next())
             .catch(next);
         });

--- a/tests/legacy-cli/e2e/tests/vite/ssr-entry-fastify.ts
+++ b/tests/legacy-cli/e2e/tests/vite/ssr-entry-fastify.ts
@@ -54,7 +54,7 @@ export default async function () {
         server.get('/api/*', (req, reply) => reply.send({ hello: 'foo' }));
         server.get('*', async (req, reply) => {
           try {
-            const response = await angularNodeAppEngine.render(req.raw);
+            const response = await angularNodeAppEngine.handle(req.raw);
             if (response) {
               await writeResponseToNodeResponse(response, reply.raw);
             } else {

--- a/tests/legacy-cli/e2e/tests/vite/ssr-entry-h3.ts
+++ b/tests/legacy-cli/e2e/tests/vite/ssr-entry-h3.ts
@@ -60,7 +60,7 @@ export default async function () {
 
         router.use(
           '/**',
-          defineEventHandler((event) => angularAppEngine.render(toWebRequest(event))),
+          defineEventHandler((event) => angularAppEngine.handle(toWebRequest(event))),
         );
 
         server.use(router);

--- a/tests/legacy-cli/e2e/tests/vite/ssr-entry-hono.ts
+++ b/tests/legacy-cli/e2e/tests/vite/ssr-entry-hono.ts
@@ -54,7 +54,7 @@ export default async function () {
 
         server.get('/api/*', (c) => c.json({ hello: 'foo' }));
         server.get('/*', async (c) => {
-          const res = await angularAppEngine.render(c.req.raw);
+          const res = await angularAppEngine.handle(c.req.raw);
           return res || undefined
         });
 

--- a/tests/legacy-cli/e2e/utils/packages.ts
+++ b/tests/legacy-cli/e2e/utils/packages.ts
@@ -32,7 +32,7 @@ export async function installWorkspacePackages(options?: { force?: boolean }): P
   }
 }
 
-export async function installPackage(specifier: string, registry?: string): Promise<ProcessOutput> {
+export function installPackage(specifier: string, registry?: string): Promise<ProcessOutput> {
   const registryOption = registry ? [`--registry=${registry}`] : [];
   switch (getActivePackageManager()) {
     case 'npm':
@@ -46,16 +46,25 @@ export async function installPackage(specifier: string, registry?: string): Prom
   }
 }
 
-export async function uninstallPackage(name: string): Promise<ProcessOutput> {
-  switch (getActivePackageManager()) {
-    case 'npm':
-      return silentNpm('uninstall', name);
-    case 'yarn':
-      return silentYarn('remove', name);
-    case 'bun':
-      return silentBun('remove', name);
-    case 'pnpm':
-      return silentPnpm('remove', name);
+export async function uninstallPackage(name: string): Promise<void> {
+  try {
+    switch (getActivePackageManager()) {
+      case 'npm':
+        await silentNpm('uninstall', name);
+        break;
+      case 'yarn':
+        await silentYarn('remove', name);
+        break;
+      case 'bun':
+        await silentBun('remove', name);
+        break;
+      case 'pnpm':
+        await silentPnpm('remove', name);
+        break;
+    }
+  } catch (e) {
+    // Yarn throws an error when trying to remove a package that is not installed.
+    console.error(e);
   }
 }
 


### PR DESCRIPTION
This commit implements the capability for the App Engine to serve prerendered pages directly. Previously, we relied on frameworks like Express for this functionality, which resulted in inconsistent redirects for directories where in some cases a trailing slash was added to the route.

**Note:** This change applies only when using the new SSR APIs. When using the `CommonEngine`, a 3rd party static serve middleware is still required.
