### PR TITLE
fix(@angular-devkit/build-angular): fix --watch regression in karma

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/karma/application_builder.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/application_builder.ts
@@ -123,7 +123,9 @@ export function execute(
     switchMap(
       ([karma, karmaConfig, buildOptions]) =>
         new Observable<BuilderOutput>((subscriber) => {
-          if (options.watch) {
+          // If `--watch` is explicitly enabled or if we are keeping the Karma
+          // process running, we should hook Karma into the build.
+          if (options.watch ?? !karmaConfig.singleRun) {
             injectKarmaReporter(context, buildOptions, karmaConfig, subscriber);
           }
 


### PR DESCRIPTION
Outside of single-run mode, the karma test provider was expected to watch for changes. In the application builder branch, we only handled the case of an explicit `--watch` though. This meant that the karma runner was kept running but didn't see any file changes.

Fixes https://github.com/angular/angular-cli/issues/28730