### PR TITLE
refactor(@angular-devkit/build-angular): adds `protractor` builder which throws with a clear error message

### DIFF
--- a/packages/angular_devkit/build_angular/builders.json
+++ b/packages/angular_devkit/build_angular/builders.json
@@ -42,6 +42,11 @@
       "schema": "./src/builders/web-test-runner/schema.json",
       "description": "Run unit tests with Web Test Runner."
     },
+    "protractor": {
+      "implementation": "./src/builders/protractor-error",
+      "schema": "./src/builders/protractor/schema.json",
+      "description": "Throw an error that Protractor is end-of-life and no longer supported."
+    },
     "private-protractor": {
       "implementation": "./src/builders/protractor",
       "schema": "./src/builders/protractor/schema.json",

--- a/packages/angular_devkit/build_angular/src/builders/protractor-error/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/protractor-error/index.ts
@@ -1,0 +1,20 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { BuilderContext, createBuilder } from '@angular-devkit/architect';
+import { Schema as ProtractorBuilderOptions } from '../protractor/schema';
+
+export default createBuilder<ProtractorBuilderOptions>(
+  (_options: ProtractorBuilderOptions, context: BuilderContext) => {
+    context.logger.error(
+      'Protractor has reached end-of-life and is no longer supported. For additional information and alternatives, please see https://blog.angular.dev/protractor-deprecation-update-august-2023-2beac7402ce0.',
+    );
+
+    return { success: false };
+  },
+);

--- a/tests/legacy-cli/e2e/tests/protractor/test-fails.ts
+++ b/tests/legacy-cli/e2e/tests/protractor/test-fails.ts
@@ -1,0 +1,15 @@
+import { execAndCaptureError } from '../../utils/process';
+import { updateJsonFile } from '../../utils/project';
+
+export default async function () {
+  // Revert the `private-protractor` builder name back to the previous `protractor`.
+  await updateJsonFile('angular.json', (config) => {
+    config.projects['test-project'].architect['e2e'].builder =
+      '@angular-devkit/build-angular:protractor';
+  });
+
+  const error = await execAndCaptureError('ng', ['e2e']);
+  if (!error.message.includes('Protractor has reached end-of-life')) {
+    throw new Error(`Protractor did not fail with an appropriate message. Got:\n${error.message}`);
+  }
+}


### PR DESCRIPTION
This should help users who upgrade more easily discover that the builder has been removed and find the resources needed to migrate any existing tests.