### PR TITLE
refactor(@angular/build): remove experimental `buildApplication` overload

### DIFF
--- a/goldens/public-api/angular/build/index.api.md
+++ b/goldens/public-api/angular/build/index.api.md
@@ -10,6 +10,14 @@ import type http from 'node:http';
 import { OutputFile } from 'esbuild';
 import type { Plugin as Plugin_2 } from 'esbuild';
 
+// @public (undocumented)
+export interface ApplicationBuilderExtensions {
+    // (undocumented)
+    codePlugins?: Plugin_2[];
+    // (undocumented)
+    indexHtmlTransformer?: IndexHtmlTransform;
+}
+
 // @public
 export interface ApplicationBuilderOptions {
     allowedCommonJsDependencies?: string[];
@@ -73,9 +81,6 @@ export interface ApplicationBuilderOutput extends BuilderOutput {
     // (undocumented)
     outputFiles?: BuildOutputFile[];
 }
-
-// @public
-export function buildApplication(options: ApplicationBuilderOptions, context: BuilderContext, plugins?: Plugin_2[]): AsyncIterable<ApplicationBuilderOutput>;
 
 // @public
 export function buildApplication(options: ApplicationBuilderOptions, context: BuilderContext, extensions?: ApplicationBuilderExtensions): AsyncIterable<ApplicationBuilderOutput>;

--- a/packages/angular/build/src/builders/application/index.ts
+++ b/packages/angular/build/src/builders/application/index.ts
@@ -7,7 +7,6 @@
  */
 
 import { BuilderContext, BuilderOutput, createBuilder } from '@angular-devkit/architect';
-import type { Plugin } from 'esbuild';
 import assert from 'node:assert';
 import fs from 'node:fs/promises';
 import path from 'node:path';
@@ -142,26 +141,6 @@ export interface ApplicationBuilderOutput extends BuilderOutput {
  * Builds an application using the `application` builder with the provided
  * options.
  *
- * Usage of the `plugins` parameter is NOT supported and may cause unexpected
- * build output or build failures.
- *
- * @experimental Direct usage of this function is considered experimental.
- *
- * @param options The options defined by the builder's schema to use.
- * @param context An Architect builder context instance.
- * @param plugins An array of plugins to apply to the main code bundling.
- * @returns The build output results of the build.
- */
-export function buildApplication(
-  options: ApplicationBuilderOptions,
-  context: BuilderContext,
-  plugins?: Plugin[],
-): AsyncIterable<ApplicationBuilderOutput>;
-
-/**
- * Builds an application using the `application` builder with the provided
- * options.
- *
  * Usage of the `extensions` parameter is NOT supported and may cause unexpected
  * build output or build failures.
  *
@@ -172,26 +151,11 @@ export function buildApplication(
  * @param extensions An object contain extension points for the build.
  * @returns The build output results of the build.
  */
-export function buildApplication(
-  options: ApplicationBuilderOptions,
-  context: BuilderContext,
-  extensions?: ApplicationBuilderExtensions,
-): AsyncIterable<ApplicationBuilderOutput>;
-
 export async function* buildApplication(
   options: ApplicationBuilderOptions,
   context: BuilderContext,
-  pluginsOrExtensions?: Plugin[] | ApplicationBuilderExtensions,
+  extensions?: ApplicationBuilderExtensions,
 ): AsyncIterable<ApplicationBuilderOutput> {
-  let extensions: ApplicationBuilderExtensions | undefined;
-  if (pluginsOrExtensions && Array.isArray(pluginsOrExtensions)) {
-    extensions = {
-      codePlugins: pluginsOrExtensions,
-    };
-  } else {
-    extensions = pluginsOrExtensions;
-  }
-
   let initial = true;
   for await (const result of buildApplicationInternal(options, context, extensions)) {
     const outputOptions = result.detail?.['outputOptions'] as NormalizedOutputOptions | undefined;

--- a/packages/angular/build/src/index.ts
+++ b/packages/angular/build/src/index.ts
@@ -11,6 +11,7 @@ export {
   type ApplicationBuilderOptions,
   type ApplicationBuilderOutput,
 } from './builders/application';
+export type { ApplicationBuilderExtensions } from './builders/application/options';
 export { type BuildOutputFile, BuildOutputFileType } from './tools/esbuild/bundler-context';
 export type { BuildOutputAsset } from './tools/esbuild/bundler-execution-result';
 


### PR DESCRIPTION

An experimental overload of `buildApplication` has been removed.
