### PR TITLE
refactor(@angular/build): directly bundle external component file-based style changes

### DIFF
--- a/packages/angular/build/src/tools/esbuild/angular/jit-plugin-callbacks.ts
+++ b/packages/angular/build/src/tools/esbuild/angular/jit-plugin-callbacks.ts
@@ -116,8 +116,16 @@ export function setupJitPluginCallbacks(
         stylesheetResult = await stylesheetBundler.bundleInline(entry.contents, entry.path);
       }
 
-      const { contents, outputFiles, errors, warnings, metafile, referencedFiles } =
-        stylesheetResult;
+      const { errors, warnings, referencedFiles } = stylesheetResult;
+      if (stylesheetResult.errors) {
+        return {
+          errors,
+          warnings,
+          watchFiles: referencedFiles && [...referencedFiles],
+        };
+      }
+
+      const { contents, outputFiles, metafile } = stylesheetResult;
 
       additionalResultFiles.set(entry.path, { outputFiles, metafile });
 


### PR DESCRIPTION
When using the development server with the application builder, file-based component styles will now be bundled during the main builder execution instead of within the application code bundling step. This allows for these styles to be processed independently from any code bundling steps and will support future changes that will allow the builder to completely skip code bundling if only file-based component stylesheets are changed.