### PR TITLE
refactor(@angular/build): allow forcing bundler context rebundle

### DIFF
--- a/packages/angular/build/src/tools/esbuild/bundler-context.ts
+++ b/packages/angular/build/src/tools/esbuild/bundler-context.ts
@@ -185,12 +185,13 @@ export class BundlerContext {
    * All builds use the `write` option with a value of `false` to allow for the output files
    * build result array to be populated.
    *
+   * @param force If true, always rebundle.
    * @returns If output files are generated, the full esbuild BuildResult; if not, the
    * warnings and errors for the attempted build.
    */
-  async bundle(): Promise<BundleContextResult> {
+  async bundle(force?: boolean): Promise<BundleContextResult> {
     // Return existing result if present
-    if (this.#esbuildResult) {
+    if (!force && this.#esbuildResult) {
       return this.#esbuildResult;
     }
 


### PR DESCRIPTION
A bundle call for a `BundlerContext` can now force a rebundling in cases where the cached version should not be used. This is currently not leveraged within the code but will be used for improvements to typescript based context rebuilds in the future.