### PR TITLE
fix(@angular/build): set `ngServerMode` during vite prebundling

### DIFF
--- a/packages/angular/build/src/builders/dev-server/vite-server.ts
+++ b/packages/angular/build/src/builders/dev-server/vite-server.ts
@@ -801,6 +801,9 @@ function getDepOptimizationConfig({
       supported: getFeatureSupport(target, zoneless),
       plugins,
       loader,
+      define: {
+        'ngServerMode': `${ssr}`,
+      },
       resolveExtensions: ['.mjs', '.js', '.cjs'],
     },
   };


### PR DESCRIPTION
This commit sets the `ngServerMode` in the prebundled deps.
