### PR TITLE
fix(@angular/build): Exclude known `--import` from execArgv when spawning workers

### DIFF
--- a/packages/angular/build/src/tools/esbuild/javascript-transformer.ts
+++ b/packages/angular/build/src/tools/esbuild/javascript-transformer.ts
@@ -8,6 +8,7 @@
 
 import { createHash } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
+import { IMPORT_EXEC_ARGV } from '../../utils/server-rendering/esm-in-memory-loader/utils';
 import { WorkerPool } from '../../utils/worker-pool';
 import { Cache } from './cache';
 
@@ -59,7 +60,7 @@ export class JavaScriptTransformer {
       filename: require.resolve('./javascript-transformer-worker'),
       maxThreads: this.maxThreads,
       // Prevent passing `--import` (loader-hooks) from parent to child worker.
-      execArgv: [],
+      execArgv: process.execArgv.filter((v) => v !== IMPORT_EXEC_ARGV),
     });
 
     return this.#workerPool;

--- a/packages/angular/build/src/utils/server-rendering/esm-in-memory-loader/utils.ts
+++ b/packages/angular/build/src/utils/server-rendering/esm-in-memory-loader/utils.ts
@@ -1,0 +1,13 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+export const IMPORT_EXEC_ARGV =
+  '--import=' + pathToFileURL(join(__dirname, 'register-hooks.js')).href;

--- a/packages/angular/build/src/utils/server-rendering/prerender.ts
+++ b/packages/angular/build/src/utils/server-rendering/prerender.ts
@@ -7,8 +7,7 @@
  */
 
 import { readFile } from 'node:fs/promises';
-import { extname, join, posix } from 'node:path';
-import { pathToFileURL } from 'node:url';
+import { extname, posix } from 'node:path';
 import { NormalizedApplicationBuildOptions } from '../../builders/application/options';
 import { OutputMode } from '../../builders/application/schema';
 import { BuildOutputFile, BuildOutputFileType } from '../../tools/esbuild/bundler-context';
@@ -16,6 +15,7 @@ import { BuildOutputAsset } from '../../tools/esbuild/bundler-execution-result';
 import { assertIsError } from '../error';
 import { urlJoin } from '../url';
 import { WorkerPool } from '../worker-pool';
+import { IMPORT_EXEC_ARGV } from './esm-in-memory-loader/utils';
 import {
   RouteRenderMode,
   RoutersExtractorWorkerResult,
@@ -194,12 +194,7 @@ async function renderPages(
 }> {
   const output: PrerenderOutput = {};
   const errors: string[] = [];
-
-  const workerExecArgv = [
-    '--import',
-    // Loader cannot be an absolute path on Windows.
-    pathToFileURL(join(__dirname, 'esm-in-memory-loader/register-hooks.js')).href,
-  ];
+  const workerExecArgv = [IMPORT_EXEC_ARGV];
 
   if (sourcemap) {
     workerExecArgv.push('--enable-source-maps');
@@ -301,11 +296,7 @@ async function getAllRoutes(
     return { errors: [], serializedRouteTree: routes };
   }
 
-  const workerExecArgv = [
-    '--import',
-    // Loader cannot be an absolute path on Windows.
-    pathToFileURL(join(__dirname, 'esm-in-memory-loader/register-hooks.js')).href,
-  ];
+  const workerExecArgv = [IMPORT_EXEC_ARGV];
 
   if (sourcemap) {
     workerExecArgv.push('--enable-source-maps');


### PR DESCRIPTION

This change prevents Bazel compilation issues in the ADEV build process.
