### PR TITLE
refactor(@angular/build): improve typescript bundling context rebuild checking

### DIFF
--- a/packages/angular/build/src/tools/esbuild/angular/component-stylesheets.ts
+++ b/packages/angular/build/src/tools/esbuild/angular/component-stylesheets.ts
@@ -86,6 +86,14 @@ export class ComponentStylesheetBundler {
     );
   }
 
+  bundleAllFiles(external: boolean, direct: boolean) {
+    return Promise.all(
+      Array.from(this.#fileContexts.entries()).map(([entry]) =>
+        this.bundleFile(entry, external, direct),
+      ),
+    );
+  }
+
   async bundleInline(
     data: string,
     filename: string,

--- a/packages/angular/build/src/tools/esbuild/application-code-bundle.ts
+++ b/packages/angular/build/src/tools/esbuild/application-code-bundle.ts
@@ -24,6 +24,7 @@ import { BundlerOptionsFactory } from './bundler-context';
 import { createCompilerPluginOptions } from './compiler-plugin-options';
 import { createExternalPackagesPlugin } from './external-packages-plugin';
 import { createAngularLocaleDataPlugin } from './i18n-locale-plugin';
+import type { LoadResultCache } from './load-result-cache';
 import { createLoaderImportAttributePlugin } from './loader-import-attribute-plugin';
 import { createRxjsEsmResolutionPlugin } from './rxjs-esm-resolution-plugin';
 import { createServerBundleMetadata } from './server-bundle-metadata-plugin';
@@ -106,7 +107,7 @@ export function createBrowserPolyfillBundleOptions(
     options,
     namespace,
     true,
-    sourceFileCache,
+    sourceFileCache.loadResultCache,
   );
   if (!polyfillBundleOptions) {
     return;
@@ -184,7 +185,7 @@ export function createServerPolyfillBundleOptions(
     },
     namespace,
     false,
-    sourceFileCache,
+    sourceFileCache?.loadResultCache,
   );
 
   if (!polyfillBundleOptions) {
@@ -602,7 +603,7 @@ function getEsBuildCommonPolyfillsOptions(
   options: NormalizedApplicationBuildOptions,
   namespace: string,
   tryToResolvePolyfillsAsRelative: boolean,
-  sourceFileCache: SourceFileCache | undefined,
+  loadResultCache: LoadResultCache | undefined,
 ): BuildOptions | undefined {
   const { jit, workspaceRoot, i18nOptions } = options;
   const buildOptions: BuildOptions = {
@@ -647,7 +648,7 @@ function getEsBuildCommonPolyfillsOptions(
   buildOptions.plugins?.push(
     createVirtualModulePlugin({
       namespace,
-      cache: sourceFileCache?.loadResultCache,
+      cache: loadResultCache,
       loadContent: async (_, build) => {
         let polyfillPaths = polyfills;
         let warnings: PartialMessage[] | undefined;


### PR DESCRIPTION
The TypeScript-based bundling contexts have now been separated from the other bundling contexts that may be present in an application build. The later of which include global styles, scripts, and non-TypeScript polyfills. This allows for the TypeScript bundling contexts to perform additional checks during a rebuild to determine if they actually need to be rebundled. The bundling context caching for the TypeScript contexts has not yet been enabled but these changes prepare for the switch to allow conditional rebundling on file changes.