### PR TITLE
fix(@schematics/angular): component spec with export default

### DIFF
--- a/packages/schematics/angular/component/files/__name@dasherize@if-flat__/__name@dasherize__.__type@dasherize__.spec.ts.template
+++ b/packages/schematics/angular/component/files/__name@dasherize@if-flat__/__name@dasherize__.__type@dasherize__.spec.ts.template
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { <%= classify(name) %><%= classify(type) %> } from './<%= dasherize(name) %><%= type ? '.' + dasherize(type): '' %>';
+import <% if(!exportDefault) { %>{ <% }%><%= classify(name) %><%= classify(type) %> <% if(!exportDefault) {%>} <% }%>from './<%= dasherize(name) %><%= type ? '.' + dasherize(type): '' %>';
 
 describe('<%= classify(name) %><%= classify(type) %>', () => {
   let component: <%= classify(name) %><%= classify(type) %>;

--- a/packages/schematics/angular/component/index_spec.ts
+++ b/packages/schematics/angular/component/index_spec.ts
@@ -511,6 +511,9 @@ describe('Component Schematic', () => {
     const tree = await schematicRunner.runSchematic('component', options, appTree);
     const tsContent = tree.readContent('/projects/bar/src/app/foo/foo.component.ts');
     expect(tsContent).toContain('export default class FooComponent');
+
+    const specContent = tree.readContent('/projects/bar/src/app/foo/foo.component.spec.ts');
+    expect(specContent).toContain("import FooComponent from './foo.component';");
   });
 
   it('should export the component as a named export when exportDefault is false', async () => {
@@ -519,5 +522,8 @@ describe('Component Schematic', () => {
     const tree = await schematicRunner.runSchematic('component', options, appTree);
     const tsContent = tree.readContent('/projects/bar/src/app/foo/foo.component.ts');
     expect(tsContent).toContain('export class FooComponent');
+
+    const specContent = tree.readContent('/projects/bar/src/app/foo/foo.component.spec.ts');
+    expect(specContent).toContain("import { FooComponent } from './foo.component';");
   });
 });


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

The generated spec was using the same import when it should be adapted if `exportDefault` is used:

```ts
import { UserComponent } from './user.component.ts`
```
## What is the new behavior?

It now produces:

```ts
import UserComponent from './user.component.ts`
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
