### PR TITLE
perf(@angular/ssr): integrate ETags for prerendered pages

### DIFF
--- a/packages/angular/build/src/builders/application/execute-build.ts
+++ b/packages/angular/build/src/builders/application/execute-build.ts
@@ -7,7 +7,6 @@
  */
 
 import { BuilderContext } from '@angular-devkit/architect';
-import assert from 'node:assert';
 import { SourceFileCache } from '../../tools/esbuild/angular/source-file-cache';
 import { generateBudgetStats } from '../../tools/esbuild/budget-stats';
 import {
@@ -36,7 +35,6 @@ import { optimizeChunks } from './chunk-optimizer';
 import { executePostBundleSteps } from './execute-post-bundle';
 import { inlineI18n, loadActiveTranslations } from './i18n';
 import { NormalizedApplicationBuildOptions } from './options';
-import { OutputMode } from './schema';
 import { createComponentStyleBundler, setupBundlerContexts } from './setup-bundling';
 
 // eslint-disable-next-line max-lines-per-function
@@ -213,7 +211,7 @@ export async function executeBuild(
   if (serverEntryPoint) {
     executionResult.addOutputFile(
       SERVER_APP_ENGINE_MANIFEST_FILENAME,
-      generateAngularServerAppEngineManifest(i18nOptions, baseHref, undefined),
+      generateAngularServerAppEngineManifest(i18nOptions, baseHref),
       BuildOutputFileType.ServerRoot,
     );
   }
@@ -246,26 +244,11 @@ export async function executeBuild(
     executionResult.assetFiles.push(...result.additionalAssets);
   }
 
-  if (serverEntryPoint) {
-    const prerenderedRoutes = executionResult.prerenderedRoutes;
-
-    // Regenerate the manifest to append prerendered routes data. This is only needed if SSR is enabled.
-    if (outputMode === OutputMode.Server && Object.keys(prerenderedRoutes).length) {
-      const manifest = executionResult.outputFiles.find(
-        (f) => f.path === SERVER_APP_ENGINE_MANIFEST_FILENAME,
-      );
-      assert(manifest, `${SERVER_APP_ENGINE_MANIFEST_FILENAME} was not found in output files.`);
-      manifest.contents = new TextEncoder().encode(
-        generateAngularServerAppEngineManifest(i18nOptions, baseHref, prerenderedRoutes),
-      );
-    }
-
-    executionResult.addOutputFile(
-      'prerendered-routes.json',
-      JSON.stringify({ routes: prerenderedRoutes }, null, 2),
-      BuildOutputFileType.Root,
-    );
-  }
+  executionResult.addOutputFile(
+    'prerendered-routes.json',
+    JSON.stringify({ routes: executionResult.prerenderedRoutes }, null, 2),
+    BuildOutputFileType.Root,
+  );
 
   // Write metafile if stats option is enabled
   if (options.stats) {

--- a/packages/angular/ssr/src/assets.ts
+++ b/packages/angular/ssr/src/assets.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import { AngularAppManifest } from './manifest';
+import { AngularAppManifest, ServerAsset } from './manifest';
 
 /**
  * Manages server-side assets.
@@ -22,17 +22,17 @@ export class ServerAssets {
   /**
    * Retrieves the content of a server-side asset using its path.
    *
-   * @param path - The path to the server asset.
-   * @returns A promise that resolves to the asset content as a string.
-   * @throws Error If the asset path is not found in the manifest, an error is thrown.
+   * @param path - The path to the server asset within the manifest.
+   * @returns The server asset associated with the provided path, as a `ServerAsset` object.
+   * @throws Error - Throws an error if the asset does not exist.
    */
-  async getServerAsset(path: string): Promise<string> {
+  getServerAsset(path: string): ServerAsset {
     const asset = this.manifest.assets.get(path);
     if (!asset) {
       throw new Error(`Server asset '${path}' does not exist.`);
     }
 
-    return asset();
+    return asset;
   }
 
   /**
@@ -46,12 +46,12 @@ export class ServerAssets {
   }
 
   /**
-   * Retrieves and caches the content of 'index.server.html'.
+   * Retrieves the asset for 'index.server.html'.
    *
-   * @returns A promise that resolves to the content of 'index.server.html'.
-   * @throws Error If there is an issue retrieving the asset.
+   * @returns The `ServerAsset` object for 'index.server.html'.
+   * @throws Error - Throws an error if 'index.server.html' does not exist.
    */
-  getIndexServerHtml(): Promise<string> {
+  getIndexServerHtml(): ServerAsset {
     return this.getServerAsset('index.server.html');
   }
 }

--- a/packages/angular/ssr/src/manifest.ts
+++ b/packages/angular/ssr/src/manifest.ts
@@ -10,9 +10,26 @@ import type { SerializableRouteTreeNode } from './routes/route-tree';
 import { AngularBootstrap } from './utils/ng';
 
 /**
- * A function that returns a promise resolving to the file contents of the asset.
+ * Represents of a server asset stored in the manifest.
  */
-export type ServerAsset = () => Promise<string>;
+export interface ServerAsset {
+  /**
+   * Retrieves the text content of the asset.
+   *
+   * @returns A promise that resolves to the asset's content as a string.
+   */
+  text: () => Promise<string>;
+
+  /**
+   * A hash string representing the asset's content.
+   */
+  hash: string;
+
+  /**
+   * The size of the asset's content in bytes.
+   */
+  size: number;
+}
 
 /**
  * Represents the exports of an Angular server application entry point.

--- a/packages/angular/ssr/src/routes/ng-routes.ts
+++ b/packages/angular/ssr/src/routes/ng-routes.ts
@@ -516,7 +516,7 @@ export async function extractRoutesAndCreateRouteTree(
   includePrerenderFallbackRoutes = true,
 ): Promise<{ routeTree: RouteTree; errors: string[] }> {
   const routeTree = new RouteTree();
-  const document = await new ServerAssets(manifest).getIndexServerHtml();
+  const document = await new ServerAssets(manifest).getIndexServerHtml().text();
   const bootstrap = await manifest.bootstrap();
   const { baseHref, routes, errors } = await getRoutesFromAngularRouterConfig(
     bootstrap,

--- a/packages/angular/ssr/test/app_spec.ts
+++ b/packages/angular/ssr/test/app_spec.ts
@@ -72,17 +72,21 @@ describe('AngularServerApp', () => {
       ],
       undefined,
       {
-        'home-ssg/index.html': async () =>
-          `<html>
-            <head>
-              <title>SSG home page</title>
-              <base href="/" />
-            </head>
-            <body>
-              <app-root>Home SSG works</app-root>
-            </body>
-          </html>
-        `,
+        'home-ssg/index.html': {
+          text: async () =>
+            `<html>
+              <head>
+                <title>SSG home page</title>
+                <base href="/" />
+              </head>
+              <body>
+                <app-root>Home SSG works</app-root>
+              </body>
+            </html>
+          `,
+          size: 28,
+          hash: 'f799132d0a09e0fef93c68a12e443527700eb59e6f67fcb7854c3a60ff082fde',
+        },
       },
     );
 
@@ -183,7 +187,40 @@ describe('AngularServerApp', () => {
         const response = await app.handle(new Request('http://localhost/home-ssg'));
         const headers = response?.headers.entries() ?? [];
         expect(Object.fromEntries(headers)).toEqual({
-          'cache-control': 'max-age=31536000',
+          'etag': '"f799132d0a09e0fef93c68a12e443527700eb59e6f67fcb7854c3a60ff082fde"',
+          'content-length': '28',
+          'x-some-header': 'value',
+          'content-type': 'text/html;charset=UTF-8',
+        });
+      });
+
+      it('should return 304 Not Modified when ETag matches', async () => {
+        const url = 'http://localhost/home-ssg';
+
+        const initialResponse = await app.handle(new Request(url));
+        const etag = initialResponse?.headers.get('etag');
+
+        expect(etag).toBeDefined();
+
+        const conditionalResponse = await app.handle(
+          new Request(url, {
+            headers: {
+              'If-None-Match': etag as string,
+            },
+          }),
+        );
+
+        // Check that the response status is 304 Not Modified
+        expect(conditionalResponse?.status).toBe(304);
+        expect(await conditionalResponse?.text()).toBe('');
+      });
+
+      it('should return configured headers for pages with specific header settings', async () => {
+        const response = await app.handle(new Request('http://localhost/home-ssg'));
+        const headers = response?.headers.entries() ?? [];
+        expect(Object.fromEntries(headers)).toEqual({
+          'etag': '"f799132d0a09e0fef93c68a12e443527700eb59e6f67fcb7854c3a60ff082fde"',
+          'content-length': '28',
           'x-some-header': 'value',
           'content-type': 'text/html;charset=UTF-8',
         });

--- a/packages/angular/ssr/test/assets_spec.ts
+++ b/packages/angular/ssr/test/assets_spec.ts
@@ -16,26 +16,34 @@ describe('ServerAsset', () => {
       bootstrap: undefined as never,
       assets: new Map(
         Object.entries({
-          'index.server.html': async () => '<html>Index</html>',
-          'index.other.html': async () => '<html>Other</html>',
+          'index.server.html': {
+            text: async () => '<html>Index</html>',
+            size: 18,
+            hash: 'f799132d0a09e0fef93c68a12e443527700eb59e6f67fcb7854c3a60ff082fde',
+          },
+          'index.other.html': {
+            text: async () => '<html>Other</html>',
+            size: 18,
+            hash: '4a455a99366921d396f5d51c7253c4678764f5e9487f2c27baaa0f33553c8ce3',
+          },
         }),
       ),
     });
   });
 
   it('should retrieve and cache the content of index.server.html', async () => {
-    const content = await assetManager.getIndexServerHtml();
+    const content = await assetManager.getIndexServerHtml().text();
     expect(content).toBe('<html>Index</html>');
   });
 
-  it('should throw an error if the asset path does not exist', async () => {
-    await expectAsync(assetManager.getServerAsset('nonexistent.html')).toBeRejectedWithError(
+  it('should throw an error if the asset path does not exist', () => {
+    expect(() => assetManager.getServerAsset('nonexistent.html')).toThrowError(
       "Server asset 'nonexistent.html' does not exist.",
     );
   });
 
   it('should retrieve the content of index.other.html', async () => {
-    const content = await assetManager.getServerAsset('index.other.html');
-    expect(content).toBe('<html>Other</html>');
+    const asset = await assetManager.getServerAsset('index.other.html').text();
+    expect(asset).toBe('<html>Other</html>');
   });
 });

--- a/packages/angular/ssr/test/testing-utils.ts
+++ b/packages/angular/ssr/test/testing-utils.ts
@@ -10,7 +10,7 @@ import { Component, provideExperimentalZonelessChangeDetection } from '@angular/
 import { bootstrapApplication } from '@angular/platform-browser';
 import { provideServerRendering } from '@angular/platform-server';
 import { RouterOutlet, Routes, provideRouter } from '@angular/router';
-import { AngularAppManifest, ServerAsset, setAngularAppManifest } from '../src/manifest';
+import { ServerAsset, setAngularAppManifest } from '../src/manifest';
 import { ServerRoute, provideServerRoutesConfig } from '../src/routes/route-config';
 
 /**
@@ -34,8 +34,10 @@ export function setAngularAppTestingManifest(
     assets: new Map(
       Object.entries({
         ...additionalServerAssets,
-        'index.server.html': async () =>
-          `<html>
+        'index.server.html': {
+          size: 25,
+          hash: 'f799132d0a09e0fef93c68a12e443527700eb59e6f67fcb7854c3a60ff082fde',
+          text: async () => `<html>
             <head>
               <title>SSR page</title>
               <base href="/${baseHref}" />
@@ -45,8 +47,12 @@ export function setAngularAppTestingManifest(
             </body>
           </html>
         `,
-        'index.csr.html': async () =>
-          `<html>
+        },
+        'index.csr.html': {
+          size: 25,
+          hash: 'f799132d0a09e0fef93c68a12e443527700eb59e6f67fcb7854c3a60ff082fde',
+          text: async () =>
+            `<html>
             <head>
               <title>CSR page</title>
               <base href="/${baseHref}" />
@@ -56,6 +62,7 @@ export function setAngularAppTestingManifest(
             </body>
           </html>
         `,
+        },
       }),
     ),
     bootstrap: async () => () => {


### PR DESCRIPTION
When using the new developer preview API to serve prerendered pages, ETags are added automatically, enabling efficient caching and content validation for improved performance.