### PR TITLE
fix(@angular/build): ensure SVG template URLs are considered templates with external stylesheets

### DIFF
--- a/packages/angular/build/src/tools/angular/angular-host.ts
+++ b/packages/angular/build/src/tools/angular/angular-host.ts
@@ -208,8 +208,9 @@ export function createAngularCompilerHost(
   host.resourceNameToFileName = function (resourceName, containingFile) {
     const resolvedPath = nodePath.join(nodePath.dirname(containingFile), resourceName);
 
-    // All resource names that have HTML file extensions are assumed to be templates
-    if (resourceName.endsWith('.html') || !hostOptions.externalStylesheets) {
+    // All resource names that have template file extensions are assumed to be templates
+    // TODO: Update compiler to provide the resource type to avoid extension matching here.
+    if (!hostOptions.externalStylesheets || hasTemplateExtension(resolvedPath)) {
       return resolvedPath;
     }
 
@@ -247,4 +248,17 @@ export function createAngularCompilerHost(
   }
 
   return host;
+}
+
+function hasTemplateExtension(file: string): boolean {
+  const extension = nodePath.extname(file).toLowerCase();
+
+  switch (extension) {
+    case '.htm':
+    case '.html':
+    case '.svg':
+      return true;
+  }
+
+  return false;
 }


### PR DESCRIPTION
When using the development server with the application builder (default for new projects), the external stylesheet functionality for component style hot replacement was incorrectly considering SVG files as stylesheet resources. This resulted in a build error when using SVG files as a template source. The file extension based checks have now been improved to account for this usage.