### PR TITLE
fix(@angular/cli): recommend optional application update migration during v19 update

### DIFF
--- a/packages/angular/cli/src/commands/update/cli.ts
+++ b/packages/angular/cli/src/commands/update/cli.ts
@@ -68,6 +68,7 @@ interface MigrationSchematicDescription
   extends SchematicDescription<FileSystemCollectionDescription, FileSystemSchematicDescription> {
   version?: string;
   optional?: boolean;
+  recommended?: boolean;
   documentation?: string;
 }
 
@@ -1138,6 +1139,7 @@ export default class UpdateCommandModule extends CommandModule<UpdateCommandArgs
         return {
           name: `[${colors.white(migration.name)}] ${title}${documentation ? ` (${documentation})` : ''}`,
           value: migration.name,
+          checked: migration.recommended,
         };
       }),
       null,

--- a/packages/angular/cli/src/utilities/prompt.ts
+++ b/packages/angular/cli/src/utilities/prompt.ts
@@ -54,7 +54,7 @@ export async function askQuestion(
 
 export async function askChoices(
   message: string,
-  choices: { name: string; value: string }[],
+  choices: { name: string; value: string; checked?: boolean }[],
   noTTYResponse: string[] | null,
 ): Promise<string[] | null> {
   if (!isTTY()) {

--- a/packages/schematics/angular/migrations/migration-collection.json
+++ b/packages/schematics/angular/migrations/migration-collection.json
@@ -5,6 +5,7 @@
       "factory": "./use-application-builder/migration",
       "description": "Migrate application projects to the new build system. Application projects that are using the '@angular-devkit/build-angular' package's 'browser' and/or 'browser-esbuild' builders will be migrated to use the new 'application' builder. You can read more about this, including known issues and limitations, here: https://angular.dev/tools/cli/build-system-migration",
       "optional": true,
+      "recommended": true,
       "documentation": "tools/cli/build-system-migration"
     },
     "update-workspace-config": {


### PR DESCRIPTION
The optional application builder migration will now default to enabled and recommended during the update process (`ng update`) for v19. The migration is still optional and can be unselected if preferred when updating.