### PR TITLE
Windows CI fixes

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -121,6 +121,20 @@ jobs:
       - name: Run CLI E2E tests
         run: yarn bazel test --define=E2E_SHARD_TOTAL=6 --define=E2E_SHARD_INDEX=${{ matrix.shard }} --config=e2e //tests/legacy-cli:e2e.${{ matrix.subset }}_node${{ matrix.node }}
 
+  e2e-windows-subset:
+    runs-on: windows-latest
+    steps:
+      - name: Initialize environment
+        uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@a3d0749c4d64959e85843fbeb54507e830be0f44
+      - name: Install node modules
+        run: yarn install --immutable
+      - name: Setup Bazel
+        uses: angular/dev-infra/github-actions/bazel/setup@a3d0749c4d64959e85843fbeb54507e830be0f44
+      - name: Setup Bazel RBE
+        uses: angular/dev-infra/github-actions/bazel/configure-remote@a3d0749c4d64959e85843fbeb54507e830be0f44
+      - name: Run CLI E2E tests
+        run: yarn bazel test --config=e2e //tests/legacy-cli:e2e_node22 --test_filter="tests/basic/{build,rebuild}.ts" --test_arg="--esbuild"
+
   e2e-package-managers:
     strategy:
       fail-fast: false

--- a/packages/angular/build/src/tools/esbuild/angular/source-file-cache.ts
+++ b/packages/angular/build/src/tools/esbuild/angular/source-file-cache.ts
@@ -36,6 +36,7 @@ export class SourceFileCache extends Map<string, ts.SourceFile> {
     for (let file of files) {
       file = path.normalize(file);
       invalid = this.loadResultCache.invalidate(file) || invalid;
+      invalid = extraWatchFiles.has(file) || invalid;
 
       // Normalize separators to allow matching TypeScript Host paths
       if (USING_WINDOWS) {
@@ -44,8 +45,6 @@ export class SourceFileCache extends Map<string, ts.SourceFile> {
 
       invalid = this.delete(file) || invalid;
       this.modifiedFiles.add(file);
-
-      invalid = extraWatchFiles.has(file) || invalid;
     }
 
     return invalid;

--- a/tests/legacy-cli/e2e/tests/basic/rebuild.ts
+++ b/tests/legacy-cli/e2e/tests/basic/rebuild.ts
@@ -6,7 +6,7 @@ import { ngServe } from '../../utils/project';
 
 export default async function () {
   const esbuild = getGlobalVariable('argv')['esbuild'];
-  const validBundleRegEx = esbuild ? /complete\./ : /Compiled successfully\./;
+  const validBundleRegEx = esbuild ? /sent to client/ : /Compiled successfully\./;
   const lazyBundleRegEx = esbuild ? /chunk-/ : /src_app_lazy_lazy_component_ts\.js/;
 
   // Disable component stylesheet HMR to support page reload based rebuild testing.


### PR DESCRIPTION
A fix for Windows CI as well as improvements to prevent flakes.
The Windows E2E build and rebuild tests are also now added to PRs to reduce main CI failure occurrences.