### PR TITLE
refactor(@angular/build): split SSR server assets into separate chunks

### DIFF
--- a/goldens/circular-deps/packages.json
+++ b/goldens/circular-deps/packages.json
@@ -7,7 +7,6 @@
     "packages/angular/build/src/tools/esbuild/angular/component-stylesheets.ts",
     "packages/angular/build/src/tools/esbuild/bundler-context.ts",
     "packages/angular/build/src/tools/esbuild/utils.ts",
-    "packages/angular/build/src/utils/server-rendering/manifest.ts",
     "packages/angular/build/src/tools/esbuild/bundler-execution-result.ts"
   ],
   [
@@ -17,16 +16,18 @@
   [
     "packages/angular/build/src/tools/esbuild/bundler-context.ts",
     "packages/angular/build/src/tools/esbuild/utils.ts",
-    "packages/angular/build/src/utils/server-rendering/manifest.ts"
+    "packages/angular/build/src/tools/esbuild/bundler-execution-result.ts"
   ],
   [
     "packages/angular/build/src/tools/esbuild/bundler-context.ts",
     "packages/angular/build/src/tools/esbuild/utils.ts",
-    "packages/angular/build/src/utils/server-rendering/manifest.ts",
-    "packages/angular/build/src/tools/esbuild/bundler-execution-result.ts"
+    "packages/angular/build/src/utils/server-rendering/manifest.ts"
   ],
   [
     "packages/angular/build/src/tools/esbuild/bundler-execution-result.ts",
+    "packages/angular/build/src/tools/esbuild/utils.ts"
+  ],
+  [
     "packages/angular/build/src/tools/esbuild/utils.ts",
     "packages/angular/build/src/utils/server-rendering/manifest.ts"
   ],

--- a/packages/angular/build/src/tools/vite/plugins/angular-memory-plugin.ts
+++ b/packages/angular/build/src/tools/vite/plugins/angular-memory-plugin.ts
@@ -8,7 +8,7 @@
 
 import assert from 'node:assert';
 import { readFile } from 'node:fs/promises';
-import { basename, dirname, join, relative } from 'node:path';
+import { dirname, join, relative } from 'node:path';
 import type { Plugin } from 'vite';
 import { loadEsmModule } from '../../../utils/load-esm';
 import { AngularMemoryOutputFiles } from '../utils';
@@ -24,8 +24,6 @@ export async function createAngularMemoryPlugin(
 ): Promise<Plugin> {
   const { virtualProjectRoot, outputFiles, external } = options;
   const { normalizePath } = await loadEsmModule<typeof import('vite')>('vite');
-  // See: https://github.com/vitejs/vite/blob/a34a73a3ad8feeacc98632c0f4c643b6820bbfda/packages/vite/src/node/server/pluginContainer.ts#L331-L334
-  const defaultImporter = join(virtualProjectRoot, 'index.html');
 
   return {
     name: 'vite:angular-memory',
@@ -40,16 +38,10 @@ export async function createAngularMemoryPlugin(
       }
 
       if (importer) {
-        let normalizedSource: string | undefined;
         if (source[0] === '.' && normalizePath(importer).startsWith(virtualProjectRoot)) {
           // Remove query if present
           const [importerFile] = importer.split('?', 1);
-          normalizedSource = join(dirname(relative(virtualProjectRoot, importerFile)), source);
-        } else if (source[0] === '/' && importer === defaultImporter) {
-          normalizedSource = basename(source);
-        }
-        if (normalizedSource) {
-          source = '/' + normalizePath(normalizedSource);
+          source = '/' + join(dirname(relative(virtualProjectRoot, importerFile)), source);
         }
       }
 

--- a/packages/angular/build/src/utils/server-rendering/manifest.ts
+++ b/packages/angular/build/src/utils/server-rendering/manifest.ts
@@ -124,16 +124,19 @@ export function generateAngularServerAppManifest(
     const extension = extname(file.path);
     if (extension === '.html' || (inlineCriticalCss && extension === '.css')) {
       const jsChunkFilePath = `assets-chunks/${file.path.replace(/[./]/g, '_')}.mjs`;
+      const escapedContent = escapeUnsafeChars(file.text);
+
       serverAssetsChunks.push(
         createOutputFile(
           jsChunkFilePath,
-          `export default \`${escapeUnsafeChars(file.text)}\`;`,
+          `export default \`${escapedContent}\`;`,
           BuildOutputFileType.ServerApplication,
         ),
       );
 
+      const contentLength = Buffer.byteLength(escapedContent);
       serverAssetsContent.push(
-        `['${file.path}', {size: ${file.size}, hash: '${file.hash}', text: () => import('./${jsChunkFilePath}').then(m => m.default)}]`,
+        `['${file.path}', {size: ${contentLength}, hash: '${file.hash}', text: () => import('./${jsChunkFilePath}').then(m => m.default)}]`,
       );
     }
   }


### PR DESCRIPTION
This commit refactors the build process for server-side rendering (SSR) by dividing server assets into separate, importable chunks rather than bundling them into a single output file

