### PR TITLE
test: add `@parcel/watcher` to allowed postinstall checks

### DIFF
--- a/tests/legacy-cli/e2e/tests/misc/check-postinstalls.ts
+++ b/tests/legacy-cli/e2e/tests/misc/check-postinstalls.ts
@@ -2,6 +2,7 @@ import glob from 'fast-glob';
 import { readFile } from '../../utils/fs';
 
 const CURRENT_SCRIPT_PACKAGES: ReadonlySet<string> = new Set([
+  '@parcel/watcher (install)',
   'esbuild (postinstall)',
   'lmdb (install)',
   'msgpackr-extract (install)',


### PR DESCRIPTION
Included `@parcel/watcher` in the list of packages allowed in the postinstall checks test.
