### PR TITLE
fix(@angular/build): always clear dev-server error overlay on non-error result

### DIFF
--- a/packages/angular/build/src/builders/dev-server/vite-server.ts
+++ b/packages/angular/build/src/builders/dev-server/vite-server.ts
@@ -187,20 +187,31 @@ export async function* serveWithVite(
 
   // TODO: Switch this to an architect schedule call when infrastructure settings are supported
   for await (const result of builderAction(browserOptions, context, extensions?.buildPlugins)) {
+    if (result.kind === ResultKind.Failure) {
+      if (result.errors.length && server) {
+        hadError = true;
+        server.ws.send({
+          type: 'error',
+          err: {
+            message: result.errors[0].text,
+            stack: '',
+            loc: result.errors[0].location ?? undefined,
+          },
+        });
+      }
+      continue;
+    }
+    // Clear existing error overlay on successful result
+    if (hadError && server) {
+      hadError = false;
+      // Send an empty update to clear the error overlay
+      server.ws.send({
+        'type': 'update',
+        updates: [],
+      });
+    }
+
     switch (result.kind) {
-      case ResultKind.Failure:
-        if (result.errors.length && server) {
-          hadError = true;
-          server.ws.send({
-            type: 'error',
-            err: {
-              message: result.errors[0].text,
-              stack: '',
-              loc: result.errors[0].location ?? undefined,
-            },
-          });
-        }
-        continue;
       case ResultKind.Full:
         if (result.detail?.['htmlIndexPath']) {
           htmlIndexPath = result.detail['htmlIndexPath'] as string;
@@ -251,16 +262,6 @@ export async function* serveWithVite(
       default:
         context.logger.warn(`Unknown result kind [${(result as Result).kind}] provided by build.`);
         continue;
-    }
-
-    // Clear existing error overlay on successful result
-    if (hadError && server) {
-      hadError = false;
-      // Send an empty update to clear the error overlay
-      server.ws.send({
-        'type': 'update',
-        updates: [],
-      });
     }
 
     // To avoid disconnecting the array objects from the option, these arrays need to be mutated instead of replaced.


### PR DESCRIPTION
Now that additional result object types can be returned from the build system, the error overlay must be cleared on all non-error results. The introduction of component update results and eventual incremental results will now properly clear the error overlay after a successful build.