### PR TITLE
fix(@angular/ssr): add validation to prevent use of `provideServerRoutesConfig` in browser context

### DIFF
--- a/packages/angular/ssr/src/global.d.ts
+++ b/packages/angular/ssr/src/global.d.ts
@@ -7,3 +7,15 @@
  */
 
 declare const ngDevMode: boolean | undefined;
+
+/**
+ * Indicates whether the application is operating in server-rendering mode.
+ *
+ * `ngServerMode` is a global flag set by Angular's server-side rendering mechanisms,
+ * typically configured by `provideServerRendering` and `platformServer` during runtime.
+ *
+ * @remarks
+ * - **Internal Angular Flag**: This is an *internal* Angular flag (not a public API), avoid relying on it in application code.
+ * - **Avoid Direct Use**: This variable is intended for runtime configuration; it should not be accessed directly in application code.
+ */
+declare const ngServerMode: boolean | undefined;

--- a/packages/angular/ssr/src/routes/route-config.ts
+++ b/packages/angular/ssr/src/routes/route-config.ts
@@ -169,6 +169,12 @@ export const SERVER_ROUTES_CONFIG = new InjectionToken<ServerRoute[]>('SERVER_RO
  * @developerPreview
  */
 export function provideServerRoutesConfig(routes: ServerRoute[]): EnvironmentProviders {
+  if (typeof ngServerMode === 'undefined' || !ngServerMode) {
+    throw new Error(
+      `The 'provideServerRoutesConfig' function should not be invoked within the browser portion of the application.`,
+    );
+  }
+
   return makeEnvironmentProviders([
     {
       provide: SERVER_ROUTES_CONFIG,


### PR DESCRIPTION

Introduced an error check to ensure that 'provideServerRoutesConfig' is not utilized in the browser part of the application. This helps avoid unintended behavior.
