### PR TITLE
docs: replace `@note` with `@remarks`

### DIFF
--- a/packages/angular/build/src/tools/esbuild/server-bundle-metadata-plugin.ts
+++ b/packages/angular/build/src/tools/esbuild/server-bundle-metadata-plugin.ts
@@ -15,7 +15,7 @@ import type { Plugin } from 'esbuild';
  * @param options Optional configuration object.
  * - `ssrEntryBundle`: If `true`, marks the bundle as an SSR entry point.
  *
- * @note We can't rely on `platform: node` or `platform: neutral`, as the latter
+ * @remarks We can't rely on `platform: node` or `platform: neutral`, as the latter
  *       is used for non-SSR-related code too (e.g., global scripts).
  * @returns An esbuild plugin that injects SSR metadata into the build result's metafile.
  */

--- a/packages/angular/cli/src/analytics/analytics-parameters.mts
+++ b/packages/angular/cli/src/analytics/analytics-parameters.mts
@@ -41,7 +41,7 @@ export enum RequestParameter {
 
 /**
  * User scoped custom dimensions.
- * @notes
+ * @remarks
  * - User custom dimensions limit is 25.
  * - `up.*` string type.
  * - `upn.*` number type.
@@ -61,7 +61,7 @@ export enum UserCustomDimension {
 
 /**
  * Event scoped custom dimensions.
- * @notes
+ * @remarks
  * - Event custom dimensions limit is 50.
  * - `ep.*` string type.
  * - `epn.*` number type.
@@ -84,7 +84,7 @@ export enum EventCustomDimension {
 
 /**
  * Event scoped custom mertics.
- * @notes
+ * @remarks
  * - Event scoped custom mertics limit is 50.
  * - `ep.*` string type.
  * - `epn.*` number type.

--- a/packages/angular/cli/src/analytics/analytics-parameters.ts
+++ b/packages/angular/cli/src/analytics/analytics-parameters.ts
@@ -43,7 +43,7 @@ export enum RequestParameter {
 
 /**
  * User scoped custom dimensions.
- * @notes
+ * @remarks
  * - User custom dimensions limit is 25.
  * - `up.*` string type.
  * - `upn.*` number type.
@@ -63,7 +63,7 @@ export enum UserCustomDimension {
 
 /**
  * Event scoped custom dimensions.
- * @notes
+ * @remarks
  * - Event custom dimensions limit is 50.
  * - `ep.*` string type.
  * - `epn.*` number type.
@@ -86,7 +86,7 @@ export enum EventCustomDimension {
 
 /**
  * Event scoped custom mertics.
- * @notes
+ * @remarks
  * - Event scoped custom mertics limit is 50.
  * - `ep.*` string type.
  * - `epn.*` number type.

--- a/packages/angular/ssr/node/src/app-engine.ts
+++ b/packages/angular/ssr/node/src/app-engine.ts
@@ -15,7 +15,7 @@ import { createWebRequestFromNodeRequest } from './request';
  * Manages Angular server applications (including localized ones), handles rendering requests,
  * and optionally transforms index HTML before rendering.
  *
- * @note This class should be instantiated once and used as a singleton across the server-side
+ * @remarks This class should be instantiated once and used as a singleton across the server-side
  * application to ensure consistent handling of rendering requests and resource management.
  *
  * @developerPreview
@@ -31,7 +31,7 @@ export class AngularNodeAppEngine {
    * @param requestContext - Optional context for rendering, such as metadata associated with the request.
    * @returns A promise that resolves to the resulting HTTP response object, or `null` if no matching Angular route is found.
    *
-   * @note A request to `https://www.example.com/page/index.html` will serve or render the Angular route
+   * @remarks A request to `https://www.example.com/page/index.html` will serve or render the Angular route
    * corresponding to `https://www.example.com/page`.
    */
   async handle(request: IncomingMessage, requestContext?: unknown): Promise<Response | null> {

--- a/packages/angular/ssr/src/app-engine.ts
+++ b/packages/angular/ssr/src/app-engine.ts
@@ -17,7 +17,7 @@ import { stripIndexHtmlFromURL, stripTrailingSlash } from './utils/url';
  * Manages Angular server applications (including localized ones), handles rendering requests,
  * and optionally transforms index HTML before rendering.
  *
- * @note This class should be instantiated once and used as a singleton across the server-side
+ * @remarks This class should be instantiated once and used as a singleton across the server-side
  * application to ensure consistent handling of rendering requests and resource management.
  *
  * @developerPreview
@@ -60,7 +60,7 @@ export class AngularAppEngine {
    * @param requestContext - Optional context for rendering, such as metadata associated with the request.
    * @returns A promise that resolves to the resulting HTTP response object, or `null` if no matching Angular route is found.
    *
-   * @note A request to `https://www.example.com/page/index.html` will serve or render the Angular route
+   * @remarks A request to `https://www.example.com/page/index.html` will serve or render the Angular route
    * corresponding to `https://www.example.com/page`.
    */
   async handle(request: Request, requestContext?: unknown): Promise<Response | null> {

--- a/packages/angular/ssr/src/app.ts
+++ b/packages/angular/ssr/src/app.ts
@@ -114,7 +114,7 @@ export class AngularServerApp {
    * @param requestContext - Optional context for rendering, such as metadata associated with the request.
    * @returns A promise that resolves to the resulting HTTP response object, or `null` if no matching Angular route is found.
    *
-   * @note A request to `https://www.example.com/page/index.html` will serve or render the Angular route
+   * @remarks A request to `https://www.example.com/page/index.html` will serve or render the Angular route
    * corresponding to `https://www.example.com/page`.
    */
   async handle(request: Request, requestContext?: unknown): Promise<Response | null> {

--- a/packages/angular/ssr/src/manifest.ts
+++ b/packages/angular/ssr/src/manifest.ts
@@ -38,7 +38,7 @@ export interface EntryPointExports {
   /**
    * A reference to the function that creates an Angular server application instance.
    *
-   * @note The return type is `unknown` to prevent circular dependency issues.
+   * @remarks The return type is `unknown` to prevent circular dependency issues.
    */
   ɵgetOrCreateAngularServerApp: () => unknown;
 


### PR DESCRIPTION
Updated TSDoc comments by replacing @note with @remarks across the codebase. This aligns with TSDoc's preferred conventions, where @remarks is used for supplementary explanations and additional context.
