### PR TITLE
fix(@angular-devkit/build-angular): serve assets

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/karma/tests/options/assets_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/tests/options/assets_spec.ts
@@ -74,8 +74,9 @@ describeKarmaBuilder(execute, KARMA_BUILDER_INFO, (harness, setupTarget) => {
                 declarations: [AppComponent]
               }));
 
-              it('should create the app', () => {
+              it('should create the app', async () => {
                 const fixture = TestBed.createComponent(AppComponent);
+                await fixture.whenStable();
                 const app = fixture.debugElement.componentInstance;
                 expect(app).toBeTruthy();
               });


### PR DESCRIPTION
Turns out the test for asset serving didn't actually test asset serving because of a missing `whenStable()` - it always succeeded, even with random filenames. This change adds a custom middleware to serve our static files since it seemed easier (and more predictable) than to try to map the `assets` concept to Karma's `files`+`proxy` logic.

One side effect of adding the middleware is that we don't actually need the Karma `files` anymore with the exception of any files that we'd want to include on page load. I don't touch that part here because it will be cleaner to change it when also addressing the naming collisions between spec files.

Fixes https://github.com/angular/angular-cli/issues/28754

~~P.S.: Currently the first commit is from a different PR (https://github.com/angular/angular-cli/pull/28794), I'm planning to rebase after landing it.~~