### PR TITLE
refactor(@angular/build): use structured component stylesheet tracking for hot replacement

### DIFF
--- a/packages/angular/build/src/tools/vite/middlewares/index.ts
+++ b/packages/angular/build/src/tools/vite/middlewares/index.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-export { createAngularAssetsMiddleware } from './assets-middleware';
+export { type ComponentStyleRecord, createAngularAssetsMiddleware } from './assets-middleware';
 export { angularHtmlFallbackMiddleware } from './html-fallback-middleware';
 export { createAngularIndexHtmlMiddleware } from './index-html-middleware';
 export {

--- a/packages/angular/build/src/tools/vite/plugins/setup-middlewares-plugin.ts
+++ b/packages/angular/build/src/tools/vite/plugins/setup-middlewares-plugin.ts
@@ -9,6 +9,7 @@
 import type { Connect, Plugin } from 'vite';
 import { loadEsmModule } from '../../../utils/load-esm';
 import {
+  ComponentStyleRecord,
   angularHtmlFallbackMiddleware,
   createAngularAssetsMiddleware,
   createAngularComponentMiddleware,
@@ -49,7 +50,7 @@ interface AngularSetupMiddlewaresPluginOptions {
   assets: Map<string, string>;
   extensionMiddleware?: Connect.NextHandleFunction[];
   indexHtmlTransformer?: (content: string) => Promise<string>;
-  usedComponentStyles: Map<string, Set<string>>;
+  componentStyles: Map<string, ComponentStyleRecord>;
   templateUpdates: Map<string, string>;
   ssrMode: ServerSsrMode;
 }
@@ -78,7 +79,7 @@ export function createAngularSetupMiddlewaresPlugin(
         outputFiles,
         extensionMiddleware,
         assets,
-        usedComponentStyles,
+        componentStyles,
         templateUpdates,
         ssrMode,
       } = options;
@@ -91,7 +92,7 @@ export function createAngularSetupMiddlewaresPlugin(
           server,
           assets,
           outputFiles,
-          usedComponentStyles,
+          componentStyles,
           await createEncapsulateStyle(),
         ),
       );


### PR DESCRIPTION
When using the development server with the application builder, the internal state of any external component stylesheets is now more comprehensively tracked. This allows for more flexibility in both debugging potential problems as well as supporting additional stylesheet preprocessing steps including deferred component stylesheet processing.