### PR TITLE
fix(@angular-devkit/build-angular): handle basename collisions

### DIFF
--- a/packages/angular/build/src/builders/application/options.ts
+++ b/packages/angular/build/src/builders/application/options.ts
@@ -64,8 +64,10 @@ interface InternalOptions {
    * If given a relative path, it is resolved relative to the current workspace and will generate an output at the same relative location
    * in the output directory. If given an absolute path, the output will be generated in the root of the output directory with the same base
    * name.
+   *
+   * If provided a Map, the key is the name of the output bundle and the value is the entry point file.
    */
-  entryPoints?: Set<string>;
+  entryPoints?: Set<string> | Map<string, string>;
 
   /** File extension to use for the generated output files. */
   outExtension?: 'js' | 'mjs';
@@ -519,7 +521,7 @@ async function getTailwindConfig(
 function normalizeEntryPoints(
   workspaceRoot: string,
   browser: string | undefined,
-  entryPoints: Set<string> = new Set(),
+  entryPoints: Set<string> | Map<string, string> = new Set(),
 ): Record<string, string> {
   if (browser === '') {
     throw new Error('`browser` option cannot be an empty string.');
@@ -538,6 +540,16 @@ function normalizeEntryPoints(
   if (browser) {
     // Use `browser` alone.
     return { 'main': path.join(workspaceRoot, browser) };
+  } else if (entryPoints instanceof Map) {
+    return Object.fromEntries(
+      Array.from(entryPoints.entries(), ([name, entryPoint]) => {
+        // Get the full file path to a relative entry point input. Leave bare specifiers alone so they are resolved as modules.
+        const isRelativePath = entryPoint.startsWith('.');
+        const entryPointPath = isRelativePath ? path.join(workspaceRoot, entryPoint) : entryPoint;
+
+        return [name, entryPointPath];
+      }),
+    );
   } else {
     // Use `entryPoints` alone.
     const entryPointPaths: Record<string, string> = {};

--- a/packages/angular_devkit/build_angular/src/builders/karma/tests/behavior/specs_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/tests/behavior/specs_spec.ts
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { execute } from '../../index';
+import { BASE_OPTIONS, KARMA_BUILDER_INFO, describeKarmaBuilder } from '../setup';
+
+describeKarmaBuilder(execute, KARMA_BUILDER_INFO, (harness, setupTarget, isApp) => {
+  describe('Behavior: "Specs"', () => {
+    beforeEach(async () => {
+      await setupTarget(harness);
+    });
+
+    it('supports multiple spec files with same basename', async () => {
+      harness.useTarget('test', {
+        ...BASE_OPTIONS,
+      });
+
+      const collidingBasename = 'collision.spec.ts';
+
+      // src/app/app.component.spec.ts conflicts with this one:
+      await harness.writeFiles({
+        [`src/app/a/${collidingBasename}`]: `/** Success! */`,
+        [`src/app/b/${collidingBasename}`]: `/** Success! */`,
+      });
+
+      const { result, logs } = await harness.executeOnce();
+
+      expect(result?.success).toBeTrue();
+
+      if (isApp) {
+        const bundleLog = logs.find((log) =>
+          log.message.includes('Application bundle generation complete.'),
+        );
+        expect(bundleLog?.message).toContain('spec-app-a-collision.spec.js');
+        expect(bundleLog?.message).toContain('spec-app-b-collision.spec.js');
+      }
+    });
+  });
+});


### PR DESCRIPTION
Generates unique names for each test entry point and also creates a nice & consistent name for the main ("init test bed") chunk. All specs are now `spec-*.js` files.

Fixes https://github.com/angular/angular-cli/issues/28756

~~P.S.: Current based on https://github.com/angular/angular-cli/pull/28795, will rebase post-merge.~~