### PR TITLE
fix(@angular/ssr): initialize the DI tokens with `null` to avoid requiring them to be set to optional

### DIFF
--- a/goldens/public-api/angular/ssr/tokens/index.api.md
+++ b/goldens/public-api/angular/ssr/tokens/index.api.md
@@ -7,13 +7,13 @@
 import { InjectionToken } from '@angular/core';
 
 // @public
-export const REQUEST: InjectionToken<Request>;
+export const REQUEST: InjectionToken<Request | null>;
 
 // @public
 export const REQUEST_CONTEXT: InjectionToken<unknown>;
 
 // @public
-export const RESPONSE_INIT: InjectionToken<ResponseInit>;
+export const RESPONSE_INIT: InjectionToken<ResponseInit | null>;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/angular/ssr/tokens/src/tokens.ts
+++ b/packages/angular/ssr/tokens/src/tokens.ts
@@ -9,19 +9,62 @@
 import { InjectionToken } from '@angular/core';
 
 /**
- * Injection token for the current request.
+ * Injection token representing the current HTTP request object.
+ *
+ * Use this token to access the current request when handling server-side
+ * rendering (SSR).
+ *
+ * @remarks
+ * This token may be `null` in the following scenarios:
+ *
+ * * During the build processes.
+ * * When the application is rendered in the browser (client-side rendering).
+ * * When performing static site generation (SSG).
+ * * During route extraction in development (at the time of the request).
+ *
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/Request | `Request` on MDN}
+ *
  * @developerPreview
  */
-export const REQUEST = new InjectionToken<Request>('REQUEST');
+export const REQUEST = new InjectionToken<Request | null>('REQUEST', {
+  providedIn: 'platform',
+  factory: () => null,
+});
 
 /**
- * Injection token for the response initialization options.
+ * Injection token for response initialization options.
+ *
+ * Use this token to provide response options for configuring or initializing
+ * HTTP responses in server-side rendering or API endpoints.
+ *
+ * @remarks
+ * This token may be `null` in the following scenarios:
+ *
+ * * During the build processes.
+ * * When the application is rendered in the browser (client-side rendering).
+ * * When performing static site generation (SSG).
+ * * During route extraction in development (at the time of the request).
+ *
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/Response/Response | `ResponseInit` on MDN}
+ *
  * @developerPreview
  */
-export const RESPONSE_INIT = new InjectionToken<ResponseInit>('RESPONSE_INIT');
+export const RESPONSE_INIT = new InjectionToken<ResponseInit | null>('RESPONSE_INIT', {
+  providedIn: 'platform',
+  factory: () => null,
+});
 
 /**
  * Injection token for additional request context.
+ *
+ * Use this token to pass custom metadata or context related to the current request in server-side rendering.
+ *
+ * @remarks
+ * This token is only available during server-side rendering and will be `null` in other contexts.
+ *
  * @developerPreview
  */
-export const REQUEST_CONTEXT = new InjectionToken<unknown>('REQUEST_CONTEXT');
+export const REQUEST_CONTEXT = new InjectionToken<unknown>('REQUEST_CONTEXT', {
+  providedIn: 'platform',
+  factory: () => null,
+});


### PR DESCRIPTION


This commit initializes the `REQUEST`, `RESPONSE_INIT`, and `REQUEST_CONTEXT` DI tokens with `null` values by default.

Previously, these tokens lacked default values, which meant that developers had to explicitly mark them as optional when injecting them in constructors. This was necessary to avoid errors when these tokens were not provided, particularly in scenarios like client-side rendering or during development.

By initializing these tokens with `null`, we eliminate the need for developers to mark them as optional, simplifying the code and improving the developer experience.
