### PR TITLE
fix(@angular/build): skip wildcard routes from being listed as prerendered routes

### DIFF
--- a/packages/angular/build/src/builders/application/execute-post-bundle.ts
+++ b/packages/angular/build/src/builders/application/execute-post-bundle.ts
@@ -181,7 +181,10 @@ export async function executePostBundleSteps(
         case /* Legacy building mode */ undefined: {
           if (!metadata.redirectTo) {
             serializableRouteTreeNodeForManifest.push(metadata);
-            prerenderedRoutes[metadata.route] = { headers: metadata.headers };
+
+            if (!metadata.route.includes('*')) {
+              prerenderedRoutes[metadata.route] = { headers: metadata.headers };
+            }
           }
           break;
         }


### PR DESCRIPTION

This fix ensures that the wildcard routes are not included in the prerendered list, improving the accuracy of prerendered route generation.