### PR TITLE
refactor(ssr): remove `RenderMode.AppShell` in favor of new configuration option

### DIFF
--- a/goldens/public-api/angular/ssr/index.api.md
+++ b/goldens/public-api/angular/ssr/index.api.md
@@ -24,26 +24,20 @@ export enum PrerenderFallback {
 }
 
 // @public
-export function provideServerRoutesConfig(routes: ServerRoute[]): EnvironmentProviders;
+export function provideServerRoutesConfig(routes: ServerRoute[], options?: ServerRoutesConfigOptions): EnvironmentProviders;
 
 // @public
 export enum RenderMode {
-    AppShell = 0,
-    Client = 2,
-    Prerender = 3,
-    Server = 1
+    Client = 1,
+    Prerender = 2,
+    Server = 0
 }
 
 // @public
 export type RequestHandlerFunction = (request: Request) => Promise<Response | null> | null | Response;
 
 // @public
-export type ServerRoute = ServerRouteAppShell | ServerRouteClient | ServerRoutePrerender | ServerRoutePrerenderWithParams | ServerRouteServer;
-
-// @public
-export interface ServerRouteAppShell extends Omit<ServerRouteCommon, 'headers' | 'status'> {
-    renderMode: RenderMode.AppShell;
-}
+export type ServerRoute = ServerRouteClient | ServerRoutePrerender | ServerRoutePrerenderWithParams | ServerRouteServer;
 
 // @public
 export interface ServerRouteClient extends ServerRouteCommon {
@@ -67,6 +61,11 @@ export interface ServerRoutePrerender extends Omit<ServerRouteCommon, 'status'> 
 export interface ServerRoutePrerenderWithParams extends Omit<ServerRoutePrerender, 'fallback'> {
     fallback?: PrerenderFallback;
     getPrerenderParams: () => Promise<Record<string, string>[]>;
+}
+
+// @public
+export interface ServerRoutesConfigOptions {
+    appShellRoute?: string;
 }
 
 // @public

--- a/packages/angular/build/src/builders/application/tests/options/app-shell_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/options/app-shell_spec.ts
@@ -117,8 +117,6 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
       harness.expectFile('dist/browser/main.js').toExist();
       const indexFileContent = harness.expectFile('dist/browser/index.html').content;
       indexFileContent.toContain('app-shell works!');
-      // TODO(alanagius): enable once integration of routes in complete.
-      // indexFileContent.toContain('ng-server-context="app-shell"');
     });
 
     it('critical CSS is inlined', async () => {

--- a/packages/angular/build/src/utils/server-rendering/models.ts
+++ b/packages/angular/build/src/utils/server-rendering/models.ts
@@ -23,6 +23,7 @@ export type WritableSerializableRouteTreeNode = Writeable<SerializableRouteTreeN
 
 export interface RoutersExtractorWorkerResult {
   serializedRouteTree: SerializableRouteTreeNode;
+  appShellRoute?: string;
   errors: string[];
 }
 
@@ -33,8 +34,7 @@ export interface RoutersExtractorWorkerResult {
  * It maps `RenderMode` enum values to their corresponding numeric identifiers.
  */
 export const RouteRenderMode: Record<keyof typeof RenderMode, RenderMode> = {
-  AppShell: 0,
-  Server: 1,
-  Client: 2,
-  Prerender: 3,
+  Server: 0,
+  Client: 1,
+  Prerender: 2,
 };

--- a/packages/angular/build/src/utils/server-rendering/routes-extractor-worker.ts
+++ b/packages/angular/build/src/utils/server-rendering/routes-extractor-worker.ts
@@ -33,7 +33,7 @@ async function extractRoutes(): Promise<RoutersExtractorWorkerResult> {
   const { ɵextractRoutesAndCreateRouteTree: extractRoutesAndCreateRouteTree } =
     await loadEsmModuleFromMemory('./main.server.mjs');
 
-  const { routeTree, errors } = await extractRoutesAndCreateRouteTree(
+  const { routeTree, appShellRoute, errors } = await extractRoutesAndCreateRouteTree(
     serverURL,
     undefined /** manifest */,
     true /** invokeGetPrerenderParams */,
@@ -42,6 +42,7 @@ async function extractRoutes(): Promise<RoutersExtractorWorkerResult> {
 
   return {
     errors,
+    appShellRoute,
     serializedRouteTree: routeTree.toObject(),
   };
 }

--- a/packages/angular/ssr/public_api.ts
+++ b/packages/angular/ssr/public_api.ts
@@ -14,9 +14,9 @@ export { createRequestHandler, type RequestHandlerFunction } from './src/handler
 export {
   type PrerenderFallback,
   type ServerRoute,
+  type ServerRoutesConfigOptions,
   provideServerRoutesConfig,
   RenderMode,
-  type ServerRouteAppShell,
   type ServerRouteClient,
   type ServerRoutePrerender,
   type ServerRoutePrerenderWithParams,

--- a/packages/angular/ssr/test/routes/ng-routes_spec.ts
+++ b/packages/angular/ssr/test/routes/ng-routes_spec.ts
@@ -340,28 +340,6 @@ describe('extractRoutesAndCreateRouteTree', () => {
     );
   });
 
-  it(`should error when 'RenderMode.AppShell' is used on more than one route`, async () => {
-    setAngularAppTestingManifest(
-      [
-        { path: 'home', component: DummyComponent },
-        { path: 'shell', component: DummyComponent },
-      ],
-      [{ path: '**', renderMode: RenderMode.AppShell }],
-    );
-
-    const { errors } = await extractRoutesAndCreateRouteTree(
-      url,
-      /** manifest */ undefined,
-      /** invokeGetPrerenderParams */ false,
-      /** includePrerenderFallbackRoutes */ false,
-    );
-
-    expect(errors).toHaveSize(1);
-    expect(errors[0]).toContain(
-      `Both 'home' and 'shell' routes have their 'renderMode' set to 'AppShell'.`,
-    );
-  });
-
   it('should apply RenderMode matching the wildcard when no Angular routes are defined', async () => {
     setAngularAppTestingManifest([], [{ path: '**', renderMode: RenderMode.Server }]);
 

--- a/packages/angular_devkit/build_angular/src/builders/app-shell/app-shell_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/app-shell/app-shell_spec.ts
@@ -126,8 +126,6 @@ describe('AppShell Builder', () => {
     const fileName = 'dist/index.html';
     const content = virtualFs.fileBufferToString(host.scopedSync().read(normalize(fileName)));
     expect(content).toMatch('Welcome to app');
-    // TODO(alanagius): enable once integration of routes in complete.
-    // expect(content).toMatch('ng-server-context="app-shell"');
   });
 
   it('works with route', async () => {

--- a/packages/schematics/angular/app-shell/index_spec.ts
+++ b/packages/schematics/angular/app-shell/index_spec.ts
@@ -200,17 +200,12 @@ describe('App Shell Schematic', () => {
       expect(content).toMatch(/app-shell\.component/);
     });
 
-    it('should update the server routing configuration', async () => {
+    it(`should update the 'provideServerRoutesConfig' call to include 'appShellRoute`, async () => {
       const tree = await schematicRunner.runSchematic('app-shell', defaultOptions, appTree);
-      const content = tree.readContent('/projects/bar/src/app/app.routes.server.ts');
-      expect(tags.oneLine`${content}`).toContain(tags.oneLine`{
-        path: 'shell',
-        renderMode: RenderMode.AppShell
-      },
-      {
-        path: '**',
-        renderMode: RenderMode.Prerender
-      }`);
+      const content = tree.readContent('/projects/bar/src/app/app.config.server.ts');
+      expect(tags.oneLine`${content}`).toContain(
+        tags.oneLine`provideServerRoutesConfig(serverRoutes, { appShellRoute: 'shell' })`,
+      );
     });
 
     it('should define a server route', async () => {

--- a/tests/legacy-cli/e2e/tests/build/server-rendering/server-routes-output-mode-server.ts
+++ b/tests/legacy-cli/e2e/tests/build/server-rendering/server-routes-output-mode-server.ts
@@ -29,14 +29,9 @@ export default async function () {
   import { CsrComponent } from './csr/csr.component';
   import { SsrComponent } from './ssr/ssr.component';
   import { SsgComponent } from './ssg/ssg.component';
-  import { AppShellComponent } from './app-shell/app-shell.component';
   import { SsgWithParamsComponent } from './ssg-with-params/ssg-with-params.component';
 
   export const routes: Routes = [
-    {
-      path: 'app-shell',
-      component: AppShellComponent
-    },
     {
       path: '',
       component: HomeComponent,
@@ -89,10 +84,6 @@ export default async function () {
       headers: { 'x-custom': 'csr' },
     },
     {
-      path: 'app-shell',
-      renderMode: RenderMode.AppShell,
-    },
-    {
       path: '**',
       renderMode: RenderMode.Prerender,
       headers: { 'x-custom': 'ssg' },
@@ -102,11 +93,14 @@ export default async function () {
   );
 
   // Generate components for the above routes
-  const componentNames: string[] = ['home', 'ssg', 'ssg-with-params', 'csr', 'ssr', 'app-shell'];
+  const componentNames: string[] = ['home', 'ssg', 'ssg-with-params', 'csr', 'ssr'];
 
   for (const componentName of componentNames) {
     await silentNg('generate', 'component', componentName);
   }
+
+  // Generate app-shell
+  await ng('g', 'app-shell');
 
   await noSilentNg('build', '--output-mode=server');
 
@@ -155,7 +149,7 @@ export default async function () {
     },
     '/csr': {
       content: 'app-shell works',
-      serverContext: 'ng-server-context="app-shell"',
+      serverContext: 'ng-server-context="ssg"',
       headers: {
         'x-custom': 'csr',
       },


### PR DESCRIPTION

This commit removes the `RenderMode.AppShell` option. Instead, a new configuration parameter, `{ appShellRoute: 'shell' }`, is introduced to the `provideServerRoutesConfig` method.

```ts
provideServerRoutesConfig(serverRoutes, { appShellRoute: 'shell' })
```

