### PR TITLE
fix(@angular/ssr): export PrerenderFallback

### DIFF
--- a/packages/angular/ssr/public_api.ts
+++ b/packages/angular/ssr/public_api.ts
@@ -12,7 +12,7 @@ export { AngularAppEngine } from './src/app-engine';
 export { createRequestHandler, type RequestHandlerFunction } from './src/handler';
 
 export {
-  type PrerenderFallback,
+  PrerenderFallback,
   type ServerRoute,
   type ServerRoutesConfigOptions,
   provideServerRoutesConfig,


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Importing `PrerenderFallback` in a project throws at build time in rc.2 with:

```ts
✘ [ERROR] No matching export in "node_modules/@angular/ssr/fesm2022/ssr.mjs" for import "PrerenderFallback"

    src/app/app.routes.server.ts:1:9:
      1 │ import { PrerenderFallback, RenderMode, ServerRoute } from '@angula...
```

## What is the new behavior?

This exports `PrerenderFallback` the same way `RenderMode` is exported to fix the issue.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
