### PR TITLE
refactor: add `ngServerMode` to Webpack SSR dev server

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/server/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/server/index.ts
@@ -212,7 +212,18 @@ async function initialize(
         wco.buildOptions.supportedBrowsers ??= [];
         wco.buildOptions.supportedBrowsers.push(...browserslist('maintained node versions'));
 
-        return [getPlatformServerExportsConfig(wco), getCommonConfig(wco), getStylesConfig(wco)];
+        return [
+          getPlatformServerExportsConfig(wco),
+          getCommonConfig(wco),
+          getStylesConfig(wco),
+          {
+            plugins: [
+              new webpack.DefinePlugin({
+                'ngServerMode': true,
+              }),
+            ],
+          },
+        ];
       },
     );
 


### PR DESCRIPTION
This was missed in the original addition of `ngServerMode` and incorrectly caused `withEventReplay` to run browser-specific code on the server and crash.