### PR TITLE
fix: use default import for `express`

### DIFF
--- a/packages/schematics/angular/ssr/files/server-builder/server.ts.template
+++ b/packages/schematics/angular/ssr/files/server-builder/server.ts.template
@@ -2,7 +2,7 @@ import 'zone.js/node';
 
 import { APP_BASE_HREF } from '@angular/common';
 import { CommonEngine } from '@angular/ssr/node';
-import * as express from 'express';
+import express from 'express';
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import <% if (isStandalone) { %>bootstrap<% } else { %>AppServerModule<% } %> from './main.server';


### PR DESCRIPTION
Now that we're using `esModuleInterop`, a default import is required.