### PR TITLE
fix(@angular-devkit/build-angular): fix hanging terminal when `browser-sync` is not installed

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/ssr-dev-server/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/ssr-dev-server/index.ts
@@ -62,6 +62,20 @@ export function execute(
   options: SSRDevServerBuilderOptions,
   context: BuilderContext,
 ): Observable<SSRDevServerBuilderOutput> {
+  let browserSync: typeof import('browser-sync');
+  try {
+    browserSync = require('browser-sync');
+  } catch {
+    return of({
+      success: false,
+      error:
+        // eslint-disable-next-line max-len
+        'Required dependency `browser-sync` is not installed, most likely you need to run `npm install browser-sync --save-dev` in your project.',
+    });
+  }
+
+  const bsInstance = browserSync.create();
+
   const browserTarget = targetFromTargetString(options.browserTarget);
   const serverTarget = targetFromTargetString(options.serverTarget);
   const getBaseUrl = (bs: BrowserSyncInstance) =>
@@ -79,19 +93,6 @@ export function execute(
     progress: options.progress,
     verbose: options.verbose,
   } as json.JsonObject);
-
-  let browserSync: typeof import('browser-sync');
-  try {
-    browserSync = require('browser-sync');
-  } catch {
-    return of({
-      success: false,
-      error:
-        '"browser-sync" is not installed, most likely you need to run `npm install browser-sync --save-dev` in your project.',
-    });
-  }
-
-  const bsInstance = browserSync.create();
 
   context.logger.error(tags.stripIndents`
   ****************************************************************************************


### PR DESCRIPTION
Running the SSR dev server when `browser-sync` is not installed would print the error, but then build the browser and server targets, then hang and never return control to the user until they manually Ctrl+C. This change skips building at all if `browser-sync` is not installed, immediately returning control to the user.

This is a simple workaround, but there are two deeper bugs which would benefit from investigation:
1.  Figure out why NPM sometimes doesn't install `browser-sync`. It was happening inconsistently for me when running `ng add @angular/ssr`.
2.  Figure out why Architect does not cancel/await targets still executing when a builder completes.

I'm not sure if this fix should be backported to older versions, but we can worry about that after the v19 launch.