### PR TITLE
fix(@angular/build): fully disable component style HMR in JIT mode

### DIFF
--- a/packages/angular/build/src/builders/application/options.ts
+++ b/packages/angular/build/src/builders/application/options.ts
@@ -381,7 +381,7 @@ export async function normalizeOptions(
   // Initial options to keep
   const {
     allowedCommonJsDependencies,
-    aot,
+    aot = true,
     baseHref,
     crossOrigin,
     externalDependencies,
@@ -469,7 +469,7 @@ export async function normalizeOptions(
     clearScreen,
     define,
     partialSSRBuild: usePartialSsrBuild || partialSSRBuild,
-    externalRuntimeStyles,
+    externalRuntimeStyles: aot && externalRuntimeStyles,
     instrumentForCoverage,
     security,
     templateUpdates: !!options.templateUpdates,


### PR DESCRIPTION
The component stylesheet HMR functionality requires build-time analysis of each component by the AOT compiler to provide the needed information to identify initial styles and detect individual changes to each style. Part of the style HMR rebuild logic was unintentionally enabled in JIT mode. The initial load of the application operated correctly but subsequent changes to file-based stylesheets were delayed by one rebuild cycle. To avoid this misalignment, all component stylesheet HMR functionality is now disabled when in JIT mode.