### PR TITLE
fix(@angular/build): ensure accurate content length for server assets

### DIFF
--- a/packages/angular/build/src/utils/server-rendering/manifest.ts
+++ b/packages/angular/build/src/utils/server-rendering/manifest.ts
@@ -124,19 +124,16 @@ export function generateAngularServerAppManifest(
     const extension = extname(file.path);
     if (extension === '.html' || (inlineCriticalCss && extension === '.css')) {
       const jsChunkFilePath = `assets-chunks/${file.path.replace(/[./]/g, '_')}.mjs`;
-      const escapedContent = escapeUnsafeChars(file.text);
-
       serverAssetsChunks.push(
         createOutputFile(
           jsChunkFilePath,
-          `export default \`${escapedContent}\`;`,
+          `export default \`${escapeUnsafeChars(file.text)}\`;`,
           BuildOutputFileType.ServerApplication,
         ),
       );
 
-      const contentLength = Buffer.byteLength(escapedContent);
       serverAssetsContent.push(
-        `['${file.path}', {size: ${contentLength}, hash: '${file.hash}', text: () => import('./${jsChunkFilePath}').then(m => m.default)}]`,
+        `['${file.path}', {size: ${file.size}, hash: '${file.hash}', text: () => import('./${jsChunkFilePath}').then(m => m.default)}]`,
       );
     }
   }


### PR DESCRIPTION
Adjusts the server assets to use the original content length

Closes #28832