### PR TITLE
fix(@angular/ssr): handle nested redirects not explicitly defined in router config

### DIFF
--- a/packages/angular/ssr/src/routes/ng-routes.ts
+++ b/packages/angular/ssr/src/routes/ng-routes.ts
@@ -21,7 +21,7 @@ import { ServerAssets } from '../assets';
 import { Console } from '../console';
 import { AngularAppManifest, getAngularAppManifest } from '../manifest';
 import { AngularBootstrap, isNgModule } from '../utils/ng';
-import { joinUrlParts, stripLeadingSlash } from '../utils/url';
+import { addTrailingSlash, joinUrlParts, stripLeadingSlash } from '../utils/url';
 import {
   PrerenderFallback,
   RenderMode,
@@ -146,31 +146,36 @@ async function* traverseRoutesConfig(options: {
       const metadata: ServerConfigRouteTreeNodeMetadata = {
         renderMode: RenderMode.Prerender,
         ...matchedMetaData,
-        route: currentRoutePath,
+        // Match Angular router behavior
+        // ['one', 'two', ''] -> 'one/two/'
+        // ['one', 'two', 'three'] -> 'one/two/three'
+        route: path === '' ? addTrailingSlash(currentRoutePath) : currentRoutePath,
       };
 
       delete metadata.presentInClientRouter;
 
-      // Handle redirects
-      if (typeof redirectTo === 'string') {
-        const redirectToResolved = resolveRedirectTo(currentRoutePath, redirectTo);
+      if (metadata.renderMode === RenderMode.Prerender) {
+        // Handle SSG routes
+        yield* handleSSGRoute(
+          typeof redirectTo === 'string' ? redirectTo : undefined,
+          metadata,
+          parentInjector,
+          invokeGetPrerenderParams,
+          includePrerenderFallbackRoutes,
+        );
+      } else if (typeof redirectTo === 'string') {
+        // Handle redirects
         if (metadata.status && !VALID_REDIRECT_RESPONSE_CODES.has(metadata.status)) {
           yield {
             error:
               `The '${metadata.status}' status code is not a valid redirect response code. ` +
               `Please use one of the following redirect response codes: ${[...VALID_REDIRECT_RESPONSE_CODES.values()].join(', ')}.`,
           };
+
           continue;
         }
-        yield { ...metadata, redirectTo: redirectToResolved };
-      } else if (metadata.renderMode === RenderMode.Prerender) {
-        // Handle SSG routes
-        yield* handleSSGRoute(
-          metadata,
-          parentInjector,
-          invokeGetPrerenderParams,
-          includePrerenderFallbackRoutes,
-        );
+
+        yield { ...metadata, redirectTo: resolveRedirectTo(metadata.route, redirectTo) };
       } else {
         yield metadata;
       }
@@ -214,6 +219,7 @@ async function* traverseRoutesConfig(options: {
  * Handles SSG (Static Site Generation) routes by invoking `getPrerenderParams` and yielding
  * all parameterized paths, returning any errors encountered.
  *
+ * @param redirectTo - Optional path to redirect to, if specified.
  * @param metadata - The metadata associated with the route tree node.
  * @param parentInjector - The dependency injection container for the parent route.
  * @param invokeGetPrerenderParams - A flag indicating whether to invoke the `getPrerenderParams` function.
@@ -221,6 +227,7 @@ async function* traverseRoutesConfig(options: {
  * @returns An async iterable iterator that yields route tree node metadata for each SSG path or errors.
  */
 async function* handleSSGRoute(
+  redirectTo: string | undefined,
   metadata: ServerConfigRouteTreeNodeMetadata,
   parentInjector: Injector,
   invokeGetPrerenderParams: boolean,
@@ -237,6 +244,10 @@ async function* handleSSGRoute(
 
   if ('getPrerenderParams' in meta) {
     delete meta['getPrerenderParams'];
+  }
+
+  if (redirectTo !== undefined) {
+    meta.redirectTo = resolveRedirectTo(currentRoutePath, redirectTo);
   }
 
   if (!URL_PARAMETER_REGEXP.test(currentRoutePath)) {
@@ -279,7 +290,14 @@ async function* handleSSGRoute(
           return value;
         });
 
-        yield { ...meta, route: routeWithResolvedParams };
+        yield {
+          ...meta,
+          route: routeWithResolvedParams,
+          redirectTo:
+            redirectTo === undefined
+              ? undefined
+              : resolveRedirectTo(routeWithResolvedParams, redirectTo),
+        };
       }
     } catch (error) {
       yield { error: `${(error as Error).message}` };
@@ -319,7 +337,7 @@ function resolveRedirectTo(routePath: string, redirectTo: string): string {
   }
 
   // Resolve relative redirectTo based on the current route path.
-  const segments = routePath.split('/');
+  const segments = routePath.replace(URL_PARAMETER_REGEXP, '*').split('/');
   segments.pop(); // Remove the last segment to make it relative.
 
   return joinUrlParts(...segments, redirectTo);
@@ -456,7 +474,6 @@ export async function getRoutesFromAngularRouterConfig(
         includePrerenderFallbackRoutes,
       });
 
-      let seenAppShellRoute: string | undefined;
       for await (const result of traverseRoutes) {
         if ('error' in result) {
           errors.push(result.error);
@@ -546,8 +563,17 @@ export async function extractRoutesAndCreateRouteTree(
       metadata.redirectTo = joinUrlParts(baseHref, metadata.redirectTo);
     }
 
+    // Remove undefined fields
+    // Helps avoid unnecessary test updates
+    for (const [key, value] of Object.entries(metadata)) {
+      if (value === undefined) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        delete (metadata as any)[key];
+      }
+    }
+
     const fullRoute = joinUrlParts(baseHref, route);
-    routeTree.insert(fullRoute, metadata);
+    routeTree.insert(fullRoute.replace(URL_PARAMETER_REGEXP, '*'), metadata);
   }
 
   return {

--- a/packages/angular/ssr/src/utils/url.ts
+++ b/packages/angular/ssr/src/utils/url.ts
@@ -62,6 +62,23 @@ export function addLeadingSlash(url: string): string {
 }
 
 /**
+ * Adds a trailing slash to a URL if it does not already have one.
+ *
+ * @param url - The URL string to which the trailing slash will be added.
+ * @returns The URL string with a trailing slash.
+ *
+ * @example
+ * ```js
+ * addTrailingSlash('path'); // 'path/'
+ * addTrailingSlash('path/'); // 'path/'
+ * ```
+ */
+export function addTrailingSlash(url: string): string {
+  // Check if the URL already end with a slash
+  return url[url.length - 1] === '/' ? url : `${url}/`;
+}
+
+/**
  * Joins URL parts into a single URL string.
  *
  * This function takes multiple URL segments, normalizes them by removing leading
@@ -127,4 +144,55 @@ export function stripIndexHtmlFromURL(url: URL): URL {
   }
 
   return url;
+}
+
+/**
+ * Resolves `*` placeholders in a path template by mapping them to corresponding segments
+ * from a base path. This is useful for constructing paths dynamically based on a given base path.
+ *
+ * The function processes the `toPath` string, replacing each `*` placeholder with
+ * the corresponding segment from the `fromPath`. If the `toPath` contains no placeholders,
+ * it is returned as-is. Invalid `toPath` formats (not starting with `/`) will throw an error.
+ *
+ * @param toPath - A path template string that may contain `*` placeholders. Each `*` is replaced
+ * by the corresponding segment from the `fromPath`. Static paths (e.g., `/static/path`) are returned
+ * directly without placeholder replacement.
+ * @param fromPath - A base path string, split into segments, that provides values for
+ * replacing `*` placeholders in the `toPath`.
+ * @returns A resolved path string with `*` placeholders replaced by segments from the `fromPath`,
+ * or the `toPath` returned unchanged if it contains no placeholders.
+ *
+ * @throws If the `toPath` does not start with a `/`, indicating an invalid path format.
+ *
+ * @example
+ * ```typescript
+ * // Example with placeholders resolved
+ * const resolvedPath = buildPathWithParams('/*\/details', '/123/abc');
+ * console.log(resolvedPath); // Outputs: '/123/details'
+ *
+ * // Example with a static path
+ * const staticPath = buildPathWithParams('/static/path', '/base/unused');
+ * console.log(staticPath); // Outputs: '/static/path'
+ * ```
+ */
+export function buildPathWithParams(toPath: string, fromPath: string): string {
+  if (toPath[0] !== '/') {
+    throw new Error(`Invalid toPath: The string must start with a '/'. Received: '${toPath}'`);
+  }
+
+  if (fromPath[0] !== '/') {
+    throw new Error(`Invalid fromPath: The string must start with a '/'. Received: '${fromPath}'`);
+  }
+
+  if (!toPath.includes('/*')) {
+    return toPath;
+  }
+
+  const fromPathParts = fromPath.split('/');
+  const toPathParts = toPath.split('/');
+  const resolvedParts = toPathParts.map((part, index) =>
+    toPathParts[index] === '*' ? fromPathParts[index] : part,
+  );
+
+  return joinUrlParts(...resolvedParts);
 }

--- a/packages/angular/ssr/test/app_spec.ts
+++ b/packages/angular/ssr/test/app_spec.ts
@@ -38,6 +38,7 @@ describe('AngularServerApp', () => {
         { path: 'page-with-status', component: HomeComponent },
         { path: 'redirect', redirectTo: 'home' },
         { path: 'redirect/relative', redirectTo: 'home' },
+        { path: 'redirect/:param/relative', redirectTo: 'home' },
         { path: 'redirect/absolute', redirectTo: '/home' },
       ],
       [
@@ -114,6 +115,12 @@ describe('AngularServerApp', () => {
       it('should correctly handle relative nested redirects', async () => {
         const response = await app.handle(new Request('http://localhost/redirect/relative'));
         expect(response?.headers.get('location')).toContain('http://localhost/redirect/home');
+        expect(response?.status).toBe(302);
+      });
+
+      it('should correctly handle relative nested redirects with parameter', async () => {
+        const response = await app.handle(new Request('http://localhost/redirect/param/relative'));
+        expect(response?.headers.get('location')).toContain('http://localhost/redirect/param/home');
         expect(response?.status).toBe(302);
       });
 

--- a/packages/angular/ssr/test/routes/router_spec.ts
+++ b/packages/angular/ssr/test/routes/router_spec.ts
@@ -61,7 +61,7 @@ describe('ServerRouter', () => {
         status: 301,
       });
       expect(router.match(new URL('http://localhost/user/123'))).toEqual({
-        route: '/user/:id',
+        route: '/user/*',
         renderMode: RenderMode.Server,
       });
     });
@@ -95,7 +95,7 @@ describe('ServerRouter', () => {
         renderMode: RenderMode.Server,
       });
       expect(userMetadata).toEqual({
-        route: '/user/:id',
+        route: '/user/*',
         renderMode: RenderMode.Server,
       });
     });
@@ -116,7 +116,7 @@ describe('ServerRouter', () => {
         renderMode: RenderMode.Server,
       });
       expect(userMetadata).toEqual({
-        route: '/user/:id',
+        route: '/user/*',
         renderMode: RenderMode.Server,
       });
     });

--- a/packages/angular/ssr/test/utils/url_spec.ts
+++ b/packages/angular/ssr/test/utils/url_spec.ts
@@ -8,6 +8,8 @@
 
 import {
   addLeadingSlash,
+  addTrailingSlash,
+  buildPathWithParams,
   joinUrlParts,
   stripIndexHtmlFromURL,
   stripLeadingSlash,
@@ -53,10 +55,26 @@ describe('URL Utils', () => {
 
   describe('addLeadingSlash', () => {
     it('should add a leading slash to a URL without one', () => {
+      expect(addLeadingSlash('path')).toBe('/path');
       expect(addLeadingSlash('path/')).toBe('/path/');
     });
 
     it('should not modify URL if it already has a leading slash', () => {
+      expect(addLeadingSlash('/path/')).toBe('/path/');
+    });
+
+    it('should handle empty URL', () => {
+      expect(addLeadingSlash('')).toBe('/');
+    });
+  });
+
+  describe('addTrailingSlash', () => {
+    it('should add a trailing slash to a URL without one', () => {
+      expect(addTrailingSlash('path')).toBe('path/');
+      expect(addTrailingSlash('/path')).toBe('/path/');
+    });
+
+    it('should not modify URL if it already has a trailing slash', () => {
       expect(addLeadingSlash('/path/')).toBe('/path/');
     });
 
@@ -130,6 +148,37 @@ describe('URL Utils', () => {
       const url = new URL('https://www.example.com/page/index.html');
       const result = stripIndexHtmlFromURL(url);
       expect(result.href).toBe('https://www.example.com/page');
+    });
+  });
+
+  describe('buildPathWithParams', () => {
+    it('should return the same URL when there are no placeholders in the toPath', () => {
+      const fromPath = '/base/path';
+      const toPath = '/static/path';
+
+      const result = buildPathWithParams(toPath, fromPath);
+
+      // Since there are no placeholders, the URL remains the same.
+      expect(result.toString()).toBe('/static/path');
+    });
+
+    it('should replace placeholders with corresponding segments from the base URL path', () => {
+      const fromPath = '/base/path';
+      const toPath = '/*/*/details';
+
+      const result = buildPathWithParams(toPath, fromPath);
+
+      expect(result.toString()).toBe('/base/path/details');
+    });
+
+    it('should throw an error if the toPath does not start with "/"', () => {
+      const fromPath = '/base/path';
+      const toPath = 'details';
+
+      // This should throw an error because toPath doesn't start with "/"
+      expect(() => {
+        buildPathWithParams(toPath, fromPath);
+      }).toThrowError(`Invalid toPath: The string must start with a '/'. Received: 'details'`);
     });
   });
 });


### PR DESCRIPTION

This commit ensures proper handling of nested redirects that are implicitly structured but not explicitly defined in the router configuration.

Closes #28903
