### PR TITLE
fix(@angular/build): use `sha256` instead of `sha-256` as hash algorithm name

### DIFF
--- a/packages/angular/build/src/tools/esbuild/angular/compiler-plugin.ts
+++ b/packages/angular/build/src/tools/esbuild/angular/compiler-plugin.ts
@@ -198,7 +198,7 @@ export function createCompilerPlugin(
                 // invalid the output and force a full page reload for HMR cases. The containing file and order
                 // of the style within the containing file is used.
                 pluginOptions.externalRuntimeStyles
-                  ? createHash('sha-256')
+                  ? createHash('sha256')
                       .update(containingFile)
                       .update((order ?? 0).toString())
                       .update(className ?? '')

--- a/packages/angular/build/src/tools/esbuild/wasm-plugin.ts
+++ b/packages/angular/build/src/tools/esbuild/wasm-plugin.ts
@@ -231,7 +231,7 @@ function generateInitHelper(streaming: boolean, wasmContents: Uint8Array) {
   let resultContents;
   if (streaming) {
     const fetchOptions = {
-      integrity: 'sha256-' + createHash('sha-256').update(wasmContents).digest('base64'),
+      integrity: 'sha256-' + createHash('sha256').update(wasmContents).digest('base64'),
     };
     const fetchContents = `fetch(new URL(wasmPath, import.meta.url), ${JSON.stringify(fetchOptions)})`;
     resultContents = `await WebAssembly.instantiateStreaming(${fetchContents}, imports)`;


### PR DESCRIPTION
Stackblitz appears to fail when attempting to use `crypto.createHash` with an algorithm value of `sha-256`. Since Node.js supports both the hyphenated and unhyphenated values, the later is now used to avoid issues when running on Stackblitz.