### PR TITLE
fix(@schematics/angular): skip SSR routing prompt in webcontainer

### DIFF
--- a/packages/schematics/angular/ssr/index.ts
+++ b/packages/schematics/angular/ssr/index.ts
@@ -451,6 +451,12 @@ async function isServerRoutingEnabled(
     return serverRoutingDefault;
   }
 
+  // `inquirer` requires `async_hooks` which isn't supported by webcontainers, therefore we can't prompt in that context.
+  // See: https://github.com/SBoudrias/Inquirer.js/issues/1426
+  if (process.versions.webcontainer) {
+    return serverRoutingDefault;
+  }
+
   // Prompt the user if in an interactive terminal and no option was provided.
   return await prompt(
     'Would you like to use the Server Routing and App Engine APIs (Developer Preview) for this server application?',

--- a/packages/schematics/angular/ssr/index_spec.ts
+++ b/packages/schematics/angular/ssr/index_spec.ts
@@ -108,6 +108,7 @@ describe('SSR Schematic', () => {
 
     afterEach(() => {
       process.env['NG_FORCE_TTY'] = originalTty;
+      delete process.versions.webcontainer;
     });
 
     it('should add script section in package.json', async () => {
@@ -220,6 +221,22 @@ describe('SSR Schematic', () => {
       setPrompterForTestOnly(prompter);
 
       process.env['NG_FORCE_TTY'] = 'FALSE';
+      const tree = await schematicRunner.runSchematic(
+        'ssr',
+        { ...defaultOptions, serverRouting: undefined },
+        appTree,
+      );
+
+      expect(prompter).not.toHaveBeenCalled();
+
+      expect(tree.exists('/projects/test-app/src/app/app.routes.server.ts')).toBeFalse();
+    });
+
+    it('does not prompt when running in a web container', async () => {
+      const prompter = jasmine.createSpy<Prompt>('prompt').and.resolveTo(false);
+      setPrompterForTestOnly(prompter);
+
+      process.versions.webcontainer = 'abc123'; // Simulate webcontainer.
       const tree = await schematicRunner.runSchematic(
         'ssr',
         { ...defaultOptions, serverRouting: undefined },


### PR DESCRIPTION
Apparently `inquirer` requires `async_hooks` which isn't supported in webcontainers, therefore prompting the user fails. Instead we always fall back to the default option.

See: https://github.com/SBoudrias/Inquirer.js/issues/1426