### PR TITLE
fix(@angular/build): prevent errors with parameterized routes when `getPrerenderParams` is undefined

### DIFF
--- a/packages/angular/build/src/utils/server-rendering/routes-extractor-worker.ts
+++ b/packages/angular/build/src/utils/server-rendering/routes-extractor-worker.ts
@@ -38,7 +38,7 @@ async function extractRoutes(): Promise<RoutersExtractorWorkerResult> {
   const { routeTree, appShellRoute, errors } = await extractRoutesAndCreateRouteTree(
     serverURL,
     undefined /** manifest */,
-    true /** invokeGetPrerenderParams */,
+    outputMode !== undefined /** invokeGetPrerenderParams */,
     outputMode === OutputMode.Server /** includePrerenderFallbackRoutes */,
   );
 

--- a/tests/legacy-cli/e2e/tests/build/prerender/discover-routes-standalone.ts
+++ b/tests/legacy-cli/e2e/tests/build/prerender/discover-routes-standalone.ts
@@ -59,6 +59,10 @@ export default async function () {
       path: 'lazy-two',
       loadComponent: () => import('./lazy-two/lazy-two.component').then(c => c.LazyTwoComponent),
     },
+    {
+      path: ':param',
+      component: OneComponent,
+    },
   ];
   `,
   );


### PR DESCRIPTION


Ensure that parameterized routes do not cause errors when the `getPrerenderParams` function is undefined, specifically in cases where the routing API is not utilized.

Closes #28948
