### PR TITLE
fix(@angular/ssr): ensure compatibility for `Http2ServerResponse` type

### DIFF
--- a/goldens/public-api/angular/ssr/node/index.api.md
+++ b/goldens/public-api/angular/ssr/node/index.api.md
@@ -57,7 +57,7 @@ export function isMainModule(url: string): boolean;
 export type NodeRequestHandlerFunction = (req: IncomingMessage, res: ServerResponse, next: (err?: unknown) => void) => Promise<void> | void;
 
 // @public
-export function writeResponseToNodeResponse(source: Response, destination: ServerResponse | Http2ServerResponse<Http2ServerRequest>): Promise<void>;
+export function writeResponseToNodeResponse(source: Response, destination: ServerResponse | Http2ServerResponse): Promise<void>;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/angular/ssr/node/src/response.ts
+++ b/packages/angular/ssr/node/src/response.ts
@@ -7,7 +7,7 @@
  */
 
 import type { ServerResponse } from 'node:http';
-import type { Http2ServerRequest, Http2ServerResponse } from 'node:http2';
+import type { Http2ServerResponse } from 'node:http2';
 
 /**
  * Streams a web-standard `Response` into a Node.js `ServerResponse`
@@ -23,7 +23,7 @@ import type { Http2ServerRequest, Http2ServerResponse } from 'node:http2';
  */
 export async function writeResponseToNodeResponse(
   source: Response,
-  destination: ServerResponse | Http2ServerResponse<Http2ServerRequest>,
+  destination: ServerResponse | Http2ServerResponse,
 ): Promise<void> {
   const { status, headers, body } = source;
   destination.statusCode = status;

--- a/packages/angular/ssr/node/test/request_http2_spec.ts
+++ b/packages/angular/ssr/node/test/request_http2_spec.ts
@@ -32,7 +32,7 @@ describe('createWebRequestFromNodeRequest (HTTP/2)', () => {
   async function getNodeRequest(): Promise<Http2ServerRequest> {
     const { req, res } = await new Promise<{
       req: Http2ServerRequest;
-      res: Http2ServerResponse<Http2ServerRequest>;
+      res: Http2ServerResponse;
     }>((resolve) => {
       server.once('request', (req, res) => resolve({ req, res }));
     });


### PR DESCRIPTION
Updated the `Http2ServerResponse` interface to eliminate dependency on generics, ensuring compatibility across multiple versions of `@types/node`.

Closes #28965