### PR TITLE
fix(@angular/build): add timeout to route extraction

### DIFF
--- a/packages/angular/build/src/utils/server-rendering/routes-extractor-worker.ts
+++ b/packages/angular/build/src/utils/server-rendering/routes-extractor-worker.ts
@@ -35,12 +35,12 @@ async function extractRoutes(): Promise<RoutersExtractorWorkerResult> {
   const { ɵextractRoutesAndCreateRouteTree: extractRoutesAndCreateRouteTree } =
     await loadEsmModuleFromMemory('./main.server.mjs');
 
-  const { routeTree, appShellRoute, errors } = await extractRoutesAndCreateRouteTree(
-    serverURL,
-    undefined /** manifest */,
-    outputMode !== undefined /** invokeGetPrerenderParams */,
-    outputMode === OutputMode.Server /** includePrerenderFallbackRoutes */,
-  );
+  const { routeTree, appShellRoute, errors } = await extractRoutesAndCreateRouteTree({
+    url: serverURL,
+    invokeGetPrerenderParams: outputMode !== undefined,
+    includePrerenderFallbackRoutes: outputMode === OutputMode.Server,
+    signal: AbortSignal.timeout(30_000),
+  });
 
   return {
     errors,

--- a/packages/angular/ssr/src/routes/router.ts
+++ b/packages/angular/ssr/src/routes/router.ts
@@ -54,7 +54,7 @@ export class ServerRouter {
 
     // Create and store a new promise for the build process.
     // This prevents concurrent builds by re-using the same promise.
-    ServerRouter.#extractionPromise ??= extractRoutesAndCreateRouteTree(url, manifest)
+    ServerRouter.#extractionPromise ??= extractRoutesAndCreateRouteTree({ url, manifest })
       .then(({ routeTree, errors }) => {
         if (errors.length > 0) {
           throw new Error(

--- a/packages/angular/ssr/src/utils/promise.ts
+++ b/packages/angular/ssr/src/utils/promise.ts
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+/**
+ * Creates a promise that resolves with the result of the provided `promise` or rejects with an
+ * `AbortError` if the `AbortSignal` is triggered before the promise resolves.
+ *
+ * @param promise - The promise to monitor for completion.
+ * @param signal - An `AbortSignal` used to monitor for an abort event. If the signal is aborted,
+ *                 the returned promise will reject.
+ * @param errorMessagePrefix - A custom message prefix to include in the error message when the operation is aborted.
+ * @returns A promise that either resolves with the value of the provided `promise` or rejects with
+ *          an `AbortError` if the `AbortSignal` is triggered.
+ *
+ * @throws {AbortError} If the `AbortSignal` is triggered before the `promise` resolves.
+ */
+export function promiseWithAbort<T>(
+  promise: Promise<T>,
+  signal: AbortSignal,
+  errorMessagePrefix: string,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const abortHandler = () => {
+      reject(
+        new DOMException(`${errorMessagePrefix} was aborted.\n${signal.reason}`, 'AbortError'),
+      );
+    };
+
+    // Check for abort signal
+    if (signal.aborted) {
+      abortHandler();
+
+      return;
+    }
+
+    signal.addEventListener('abort', abortHandler, { once: true });
+
+    promise
+      .then(resolve)
+      .catch(reject)
+      .finally(() => {
+        signal.removeEventListener('abort', abortHandler);
+      });
+  });
+}

--- a/packages/angular/ssr/test/app_spec.ts
+++ b/packages/angular/ssr/test/app_spec.ts
@@ -139,7 +139,12 @@ describe('AngularServerApp', () => {
           controller.abort();
         });
 
-        await expectAsync(app.handle(request)).toBeRejectedWithError(/Request for: .+ was aborted/);
+        try {
+          await app.handle(request);
+          throw new Error('Should not be called.');
+        } catch (e) {
+          expect(e).toBeInstanceOf(DOMException);
+        }
       });
 
       it('should return configured headers for pages with specific header settings', async () => {

--- a/packages/angular/ssr/test/routes/ng-routes_spec.ts
+++ b/packages/angular/ssr/test/routes/ng-routes_spec.ts
@@ -41,7 +41,7 @@ describe('extractRoutesAndCreateRouteTree', () => {
       ],
     );
 
-    const { routeTree, errors } = await extractRoutesAndCreateRouteTree(url);
+    const { routeTree, errors } = await extractRoutesAndCreateRouteTree({ url });
     expect(errors).toHaveSize(0);
     expect(routeTree.toObject()).toEqual([
       { route: '/', renderMode: RenderMode.Server },
@@ -60,7 +60,7 @@ describe('extractRoutesAndCreateRouteTree', () => {
       ],
     );
 
-    const { errors } = await extractRoutesAndCreateRouteTree(url);
+    const { errors } = await extractRoutesAndCreateRouteTree({ url });
     expect(errors[0]).toContain(
       `Invalid '/invalid' route configuration: the path cannot start with a slash.`,
     );
@@ -85,7 +85,10 @@ describe('extractRoutesAndCreateRouteTree', () => {
         ],
       );
 
-      const { routeTree, errors } = await extractRoutesAndCreateRouteTree(url, undefined, true);
+      const { routeTree, errors } = await extractRoutesAndCreateRouteTree({
+        url,
+        invokeGetPrerenderParams: true,
+      });
       expect(errors).toHaveSize(0);
       expect(routeTree.toObject()).toEqual([
         { route: '/user/joe/role/admin', renderMode: RenderMode.Prerender },
@@ -119,7 +122,10 @@ describe('extractRoutesAndCreateRouteTree', () => {
         ],
       );
 
-      const { routeTree, errors } = await extractRoutesAndCreateRouteTree(url, undefined, true);
+      const { routeTree, errors } = await extractRoutesAndCreateRouteTree({
+        url,
+        invokeGetPrerenderParams: true,
+      });
       expect(errors).toHaveSize(0);
       expect(routeTree.toObject()).toEqual([
         { route: '/home', renderMode: RenderMode.Server },
@@ -154,7 +160,10 @@ describe('extractRoutesAndCreateRouteTree', () => {
         ],
       );
 
-      const { routeTree, errors } = await extractRoutesAndCreateRouteTree(url, undefined, true);
+      const { routeTree, errors } = await extractRoutesAndCreateRouteTree({
+        url,
+        invokeGetPrerenderParams: true,
+      });
       expect(errors).toHaveSize(0);
       expect(routeTree.toObject()).toEqual([
         { route: '/home', renderMode: RenderMode.Server },
@@ -201,12 +210,11 @@ describe('extractRoutesAndCreateRouteTree', () => {
         ],
       );
 
-      const { routeTree, errors } = await extractRoutesAndCreateRouteTree(
+      const { routeTree, errors } = await extractRoutesAndCreateRouteTree({
         url,
-        /** manifest */ undefined,
-        /** invokeGetPrerenderParams */ true,
-        /** includePrerenderFallbackRoutes */ true,
-      );
+        invokeGetPrerenderParams: true,
+        includePrerenderFallbackRoutes: true,
+      });
       expect(errors).toHaveSize(0);
       expect(routeTree.toObject()).toEqual([
         { route: '/', renderMode: RenderMode.Prerender, redirectTo: '/some' },
@@ -244,7 +252,7 @@ describe('extractRoutesAndCreateRouteTree', () => {
       [{ path: '**', renderMode: RenderMode.Server }],
     );
 
-    const { routeTree, errors } = await extractRoutesAndCreateRouteTree(url);
+    const { routeTree, errors } = await extractRoutesAndCreateRouteTree({ url });
     expect(errors).toHaveSize(0);
     expect(routeTree.toObject()).toEqual([
       { route: '/', renderMode: RenderMode.Server, redirectTo: '/some' },
@@ -274,7 +282,10 @@ describe('extractRoutesAndCreateRouteTree', () => {
       ],
     );
 
-    const { routeTree, errors } = await extractRoutesAndCreateRouteTree(url, undefined, false);
+    const { routeTree, errors } = await extractRoutesAndCreateRouteTree({
+      url,
+      invokeGetPrerenderParams: false,
+    });
     expect(errors).toHaveSize(0);
     expect(routeTree.toObject()).toEqual([
       { route: '/home', renderMode: RenderMode.Server },
@@ -304,12 +315,12 @@ describe('extractRoutesAndCreateRouteTree', () => {
       ],
     );
 
-    const { routeTree, errors } = await extractRoutesAndCreateRouteTree(
+    const { routeTree, errors } = await extractRoutesAndCreateRouteTree({
       url,
-      /** manifest */ undefined,
-      /** invokeGetPrerenderParams */ true,
-      /** includePrerenderFallbackRoutes */ false,
-    );
+
+      invokeGetPrerenderParams: true,
+      includePrerenderFallbackRoutes: false,
+    });
 
     expect(errors).toHaveSize(0);
     expect(routeTree.toObject()).toEqual([
@@ -344,12 +355,11 @@ describe('extractRoutesAndCreateRouteTree', () => {
       ],
     );
 
-    const { routeTree, errors } = await extractRoutesAndCreateRouteTree(
+    const { routeTree, errors } = await extractRoutesAndCreateRouteTree({
       url,
-      /** manifest */ undefined,
-      /** invokeGetPrerenderParams */ true,
-      /** includePrerenderFallbackRoutes */ true,
-    );
+      invokeGetPrerenderParams: true,
+      includePrerenderFallbackRoutes: true,
+    });
 
     expect(errors).toHaveSize(0);
     expect(routeTree.toObject()).toEqual([
@@ -372,12 +382,11 @@ describe('extractRoutesAndCreateRouteTree', () => {
       ],
     );
 
-    const { errors } = await extractRoutesAndCreateRouteTree(
+    const { errors } = await extractRoutesAndCreateRouteTree({
       url,
-      /** manifest */ undefined,
-      /** invokeGetPrerenderParams */ false,
-      /** includePrerenderFallbackRoutes */ false,
-    );
+      invokeGetPrerenderParams: false,
+      includePrerenderFallbackRoutes: false,
+    });
 
     expect(errors).toHaveSize(0);
   });
@@ -391,12 +400,11 @@ describe('extractRoutesAndCreateRouteTree', () => {
       ],
     );
 
-    const { errors } = await extractRoutesAndCreateRouteTree(
+    const { errors } = await extractRoutesAndCreateRouteTree({
       url,
-      /** manifest */ undefined,
-      /** invokeGetPrerenderParams */ false,
-      /** includePrerenderFallbackRoutes */ false,
-    );
+      invokeGetPrerenderParams: false,
+      includePrerenderFallbackRoutes: false,
+    });
 
     expect(errors).toHaveSize(1);
     expect(errors[0]).toContain(
@@ -413,12 +421,11 @@ describe('extractRoutesAndCreateRouteTree', () => {
       [{ path: 'home', renderMode: RenderMode.Server }],
     );
 
-    const { errors } = await extractRoutesAndCreateRouteTree(
+    const { errors } = await extractRoutesAndCreateRouteTree({
       url,
-      /** manifest */ undefined,
-      /** invokeGetPrerenderParams */ false,
-      /** includePrerenderFallbackRoutes */ false,
-    );
+      invokeGetPrerenderParams: false,
+      includePrerenderFallbackRoutes: false,
+    });
 
     expect(errors).toHaveSize(1);
     expect(errors[0]).toContain(
@@ -429,12 +436,11 @@ describe('extractRoutesAndCreateRouteTree', () => {
   it('should use wildcard configuration when no Angular routes are defined', async () => {
     setAngularAppTestingManifest([], [{ path: '**', renderMode: RenderMode.Server, status: 201 }]);
 
-    const { errors, routeTree } = await extractRoutesAndCreateRouteTree(
+    const { errors, routeTree } = await extractRoutesAndCreateRouteTree({
       url,
-      /** manifest */ undefined,
-      /** invokeGetPrerenderParams */ false,
-      /** includePrerenderFallbackRoutes */ false,
-    );
+      invokeGetPrerenderParams: false,
+      includePrerenderFallbackRoutes: false,
+    });
 
     expect(errors).toHaveSize(0);
     expect(routeTree.toObject()).toEqual([
@@ -449,12 +455,11 @@ describe('extractRoutesAndCreateRouteTree', () => {
       /** baseHref*/ './example',
     );
 
-    const { routeTree, errors } = await extractRoutesAndCreateRouteTree(
+    const { routeTree, errors } = await extractRoutesAndCreateRouteTree({
       url,
-      /** manifest */ undefined,
-      /** invokeGetPrerenderParams */ true,
-      /** includePrerenderFallbackRoutes */ true,
-    );
+      invokeGetPrerenderParams: true,
+      includePrerenderFallbackRoutes: true,
+    });
 
     expect(errors).toHaveSize(0);
     expect(routeTree.toObject()).toEqual([

--- a/packages/angular/ssr/test/utils/promise_spec.ts
+++ b/packages/angular/ssr/test/utils/promise_spec.ts
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { setTimeout } from 'node:timers/promises';
+import { promiseWithAbort } from '../../src/utils/promise';
+
+describe('promiseWithAbort', () => {
+  it('should reject with an AbortError when the signal is aborted', async () => {
+    const abortController = new AbortController();
+    const promise = promiseWithAbort(setTimeout(500), abortController.signal, 'Test operation');
+
+    queueMicrotask(() => {
+      abortController.abort('Test reason');
+    });
+
+    await expectAsync(promise).toBeRejectedWithError();
+  });
+
+  it('should not reject if the signal is not aborted', async () => {
+    const promise = promiseWithAbort(
+      setTimeout(100),
+      AbortSignal.timeout(10_000),
+      'Test operation',
+    );
+
+    // Wait briefly to ensure no rejection occurs
+    await setTimeout(20);
+
+    await expectAsync(promise).toBeResolved();
+  });
+});


### PR DESCRIPTION
This commit introduces a 30-second timeout for route extraction.
