### PR TITLE
fix(@angular/cli): correctly select package versions in descending order during `ng add`

### DIFF
--- a/packages/angular/cli/src/commands/add/cli.ts
+++ b/packages/angular/cli/src/commands/add/cli.ts
@@ -242,6 +242,7 @@ export default class AddCommandModule
                 versionManifest.version,
               );
               found = true;
+              break;
             }
 
             if (!found) {


### PR DESCRIPTION


When using the `ng add` command, the package version selection logic was not correctly selected based on the available versions in desc order. This could lead to selecting an unintended version of the package.

Closes: #28985