### PR TITLE
fix(@angular/build): apply define option to JavaScript from scripts option

### DIFF
--- a/packages/angular/build/src/builders/application/tests/options/define_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/options/define_spec.ts
@@ -61,5 +61,22 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
       harness.expectFile('dist/browser/main.js').content.not.toContain('A_BOOLEAN');
       harness.expectFile('dist/browser/main.js').content.toContain('(true)');
     });
+
+    it('should replace a value in script code', async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        define: {
+          'A_BOOLEAN': 'true',
+        },
+        scripts: ['./src/script.js'],
+      });
+
+      await harness.writeFile('src/script.js', 'console.log(A_BOOLEAN);');
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBe(true);
+      harness.expectFile('dist/browser/scripts.js').content.not.toContain('A_BOOLEAN');
+      harness.expectFile('dist/browser/scripts.js').content.toContain('(true)');
+    });
   });
 });

--- a/packages/angular/build/src/tools/esbuild/global-scripts.ts
+++ b/packages/angular/build/src/tools/esbuild/global-scripts.ts
@@ -36,6 +36,7 @@ export function createGlobalScriptsBundleOptions(
     sourcemapOptions,
     jsonLogs,
     workspaceRoot,
+    define,
   } = options;
 
   const namespace = 'angular:script/global';
@@ -73,6 +74,7 @@ export function createGlobalScriptsBundleOptions(
       platform: 'neutral',
       target,
       preserveSymlinks,
+      define,
       plugins: [
         createSourcemapIgnorelistPlugin(),
         createVirtualModulePlugin({


### PR DESCRIPTION
The `define` option will now apply to JavaScript that is included in the output via the `scripts` option.  This allows the replacement of identifiers within any included scripts in addition to the already supported replacement within application code.

Closes #29002