### PR TITLE
fix(@angular/build): ensure correct handling of `index.output` for SSR

### DIFF
--- a/packages/angular/build/src/builders/application/options.ts
+++ b/packages/angular/build/src/builders/application/options.ts
@@ -327,23 +327,25 @@ export async function normalizeOptions(
     let indexOutput: string;
     // The output file will be created within the configured output path
     if (typeof options.index === 'string') {
-      /**
-       * If SSR is activated, create a distinct entry file for the `index.html`.
-       * This is necessary because numerous server/cloud providers automatically serve the `index.html` as a static file
-       * if it exists (handling SSG).
-       *
-       * For instance, accessing `foo.com/` would lead to `foo.com/index.html` being served instead of hitting the server.
-       *
-       * This approach can also be applied to service workers, where the `index.csr.html` is served instead of the prerendered `index.html`.
-       */
-      const indexBaseName = path.basename(options.index);
-      indexOutput =
-        (ssrOptions || prerenderOptions) && indexBaseName === 'index.html'
-          ? INDEX_HTML_CSR
-          : indexBaseName;
+      indexOutput = options.index;
     } else {
       indexOutput = options.index.output || 'index.html';
     }
+
+    /**
+     * If SSR is activated, create a distinct entry file for the `index.html`.
+     * This is necessary because numerous server/cloud providers automatically serve the `index.html` as a static file
+     * if it exists (handling SSG).
+     *
+     * For instance, accessing `foo.com/` would lead to `foo.com/index.html` being served instead of hitting the server.
+     *
+     * This approach can also be applied to service workers, where the `index.csr.html` is served instead of the prerendered `index.html`.
+     */
+    const indexBaseName = path.basename(indexOutput);
+    indexOutput =
+      (ssrOptions || prerenderOptions) && indexBaseName === 'index.html'
+        ? INDEX_HTML_CSR
+        : indexBaseName;
 
     indexHtmlOptions = {
       input: path.join(

--- a/packages/angular/build/src/builders/application/tests/behavior/index-csr_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/behavior/index-csr_spec.ts
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { buildApplication } from '../../index';
+import { APPLICATION_BUILDER_INFO, BASE_OPTIONS, describeBuilder } from '../setup';
+
+describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
+  describe('Behavior: "index.csr.html"', () => {
+    beforeEach(async () => {
+      await harness.modifyFile('src/tsconfig.app.json', (content) => {
+        const tsConfig = JSON.parse(content);
+        tsConfig.files ??= [];
+        tsConfig.files.push('main.server.ts');
+
+        return JSON.stringify(tsConfig);
+      });
+    });
+
+    it(`should generate 'index.csr.html' instead of 'index.html' when ssr is enabled.`, async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        server: 'src/main.server.ts',
+        ssr: true,
+      });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
+      harness.expectDirectory('dist/server').toExist();
+      harness.expectFile('dist/browser/index.csr.html').toExist();
+      harness.expectFile('dist/browser/index.html').toNotExist();
+    });
+
+    it(`should generate 'index.csr.html' instead of 'index.html' when 'output' is 'index.html' and ssr is enabled.`, async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        index: {
+          input: 'src/index.html',
+          output: 'index.html',
+        },
+        server: 'src/main.server.ts',
+        ssr: true,
+      });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
+
+      harness.expectDirectory('dist/server').toExist();
+      harness.expectFile('dist/browser/index.csr.html').toExist();
+      harness.expectFile('dist/browser/index.html').toNotExist();
+    });
+  });
+});


### PR DESCRIPTION
Previously, the index file was not being renamed correctly when using server-side rendering (SSR).

Closes: #29012
