### PR TITLE
refactor(@angular/ssr): replace `Map` with `Record` in SSR manifest

### DIFF
--- a/packages/angular/ssr/src/app-engine.ts
+++ b/packages/angular/ssr/src/app-engine.ts
@@ -47,6 +47,11 @@ export class AngularAppEngine {
   private readonly manifest = getAngularAppEngineManifest();
 
   /**
+   * The number of entry points available in the server application's manifest.
+   */
+  private readonly entryPointsCount = Object.keys(this.manifest.entryPoints).length;
+
+  /**
    * A cache that holds entry points, keyed by their potential locale string.
    */
   private readonly entryPointsCache = new Map<string, Promise<EntryPointExports>>();
@@ -113,7 +118,7 @@ export class AngularAppEngine {
     }
 
     const { entryPoints } = this.manifest;
-    const entryPoint = entryPoints.get(potentialLocale);
+    const entryPoint = entryPoints[potentialLocale];
     if (!entryPoint) {
       return undefined;
     }
@@ -136,8 +141,8 @@ export class AngularAppEngine {
    * @returns A promise that resolves to the entry point exports or `undefined` if not found.
    */
   private getEntryPointExportsForUrl(url: URL): Promise<EntryPointExports> | undefined {
-    const { entryPoints, basePath } = this.manifest;
-    if (entryPoints.size === 1) {
+    const { basePath } = this.manifest;
+    if (this.entryPointsCount === 1) {
       return this.getEntryPointExports('');
     }
 

--- a/packages/angular/ssr/src/assets.ts
+++ b/packages/angular/ssr/src/assets.ts
@@ -27,7 +27,7 @@ export class ServerAssets {
    * @throws Error - Throws an error if the asset does not exist.
    */
   getServerAsset(path: string): ServerAsset {
-    const asset = this.manifest.assets.get(path);
+    const asset = this.manifest.assets[path];
     if (!asset) {
       throw new Error(`Server asset '${path}' does not exist.`);
     }
@@ -42,7 +42,7 @@ export class ServerAssets {
    * @returns A boolean indicating whether the asset exists.
    */
   hasServerAsset(path: string): boolean {
-    return this.manifest.assets.has(path);
+    return !!this.manifest.assets[path];
   }
 
   /**

--- a/packages/angular/ssr/src/manifest.ts
+++ b/packages/angular/ssr/src/manifest.ts
@@ -10,7 +10,7 @@ import type { SerializableRouteTreeNode } from './routes/route-tree';
 import { AngularBootstrap } from './utils/ng';
 
 /**
- * Represents of a server asset stored in the manifest.
+ * Represents a server asset stored in the manifest.
  */
 export interface ServerAsset {
   /**
@@ -53,12 +53,12 @@ export interface EntryPointExports {
  */
 export interface AngularAppEngineManifest {
   /**
-   * A map of entry points for the server application.
-   * Each entry in the map consists of:
+   * A readonly record of entry points for the server application.
+   * Each entry consists of:
    * - `key`: The base href for the entry point.
    * - `value`: A function that returns a promise resolving to an object of type `EntryPointExports`.
    */
-  readonly entryPoints: ReadonlyMap<string, () => Promise<EntryPointExports>>;
+  readonly entryPoints: Readonly<Record<string, (() => Promise<EntryPointExports>) | undefined>>;
 
   /**
    * The base path for the server application.
@@ -78,12 +78,12 @@ export interface AngularAppManifest {
   readonly baseHref: string;
 
   /**
-   * A map of assets required by the server application.
-   * Each entry in the map consists of:
+   * A readonly record of assets required by the server application.
+   * Each entry consists of:
    * - `key`: The path of the asset.
-   * - `value`: A function returning a promise that resolves to the file contents of the asset.
+   * - `value`: An object of type `ServerAsset`.
    */
-  readonly assets: ReadonlyMap<string, ServerAsset>;
+  readonly assets: Readonly<Record<string, ServerAsset | undefined>>;
 
   /**
    * The bootstrap mechanism for the server application.

--- a/packages/angular/ssr/test/assets_spec.ts
+++ b/packages/angular/ssr/test/assets_spec.ts
@@ -15,20 +15,18 @@ describe('ServerAsset', () => {
     assetManager = new ServerAssets({
       baseHref: '/',
       bootstrap: undefined as never,
-      assets: new Map(
-        Object.entries({
-          'index.server.html': {
-            text: async () => '<html>Index</html>',
-            size: 18,
-            hash: 'f799132d0a09e0fef93c68a12e443527700eb59e6f67fcb7854c3a60ff082fde',
-          },
-          'index.other.html': {
-            text: async () => '<html>Other</html>',
-            size: 18,
-            hash: '4a455a99366921d396f5d51c7253c4678764f5e9487f2c27baaa0f33553c8ce3',
-          },
-        }),
-      ),
+      assets: {
+        'index.server.html': {
+          text: async () => '<html>Index</html>',
+          size: 18,
+          hash: 'f799132d0a09e0fef93c68a12e443527700eb59e6f67fcb7854c3a60ff082fde',
+        },
+        'index.other.html': {
+          text: async () => '<html>Other</html>',
+          size: 18,
+          hash: '4a455a99366921d396f5d51c7253c4678764f5e9487f2c27baaa0f33553c8ce3',
+        },
+      },
     });
   });
 

--- a/packages/angular/ssr/test/testing-utils.ts
+++ b/packages/angular/ssr/test/testing-utils.ts
@@ -32,40 +32,38 @@ export function setAngularAppTestingManifest(
   setAngularAppManifest({
     inlineCriticalCss: false,
     baseHref,
-    assets: new Map(
-      Object.entries({
-        ...additionalServerAssets,
-        'index.server.html': {
-          size: 25,
-          hash: 'f799132d0a09e0fef93c68a12e443527700eb59e6f67fcb7854c3a60ff082fde',
-          text: async () => `<html>
-            <head>
-              <title>SSR page</title>
-              <base href="${baseHref}" />
-            </head>
-            <body>
-              <app-root></app-root>
-            </body>
-          </html>
-        `,
-        },
-        'index.csr.html': {
-          size: 25,
-          hash: 'f799132d0a09e0fef93c68a12e443527700eb59e6f67fcb7854c3a60ff082fde',
-          text: async () =>
-            `<html>
-            <head>
-              <title>CSR page</title>
-              <base href="${baseHref}" />
-            </head>
-            <body>
-              <app-root></app-root>
-            </body>
-          </html>
-        `,
-        },
-      }),
-    ),
+    assets: {
+      ...additionalServerAssets,
+      'index.server.html': {
+        size: 25,
+        hash: 'f799132d0a09e0fef93c68a12e443527700eb59e6f67fcb7854c3a60ff082fde',
+        text: async () => `<html>
+          <head>
+            <title>SSR page</title>
+            <base href="${baseHref}" />
+          </head>
+          <body>
+            <app-root></app-root>
+          </body>
+        </html>
+      `,
+      },
+      'index.csr.html': {
+        size: 25,
+        hash: 'f799132d0a09e0fef93c68a12e443527700eb59e6f67fcb7854c3a60ff082fde',
+        text: async () =>
+          `<html>
+          <head>
+            <title>CSR page</title>
+            <base href="${baseHref}" />
+          </head>
+          <body>
+            <app-root></app-root>
+          </body>
+        </html>
+      `,
+      },
+    },
     bootstrap: async () => () => {
       @Component({
         standalone: true,


### PR DESCRIPTION
Replaced `Map` with `Record` in SSR manifest to simplify structure and improve testing/setup.
