### PR TITLE
fix(@angular/build): avoid deploy URL usage on absolute preload links

### DIFF
--- a/packages/angular/build/src/utils/index-file/augment-index-html_spec.ts
+++ b/packages/angular/build/src/utils/index-file/augment-index-html_spec.ts
@@ -398,6 +398,46 @@ describe('augment-index-html', () => {
       `);
   });
 
+  it(`should not add deploy URL to hints with an absolute URL`, async () => {
+    const { content, warnings } = await augmentIndexHtml({
+      ...indexGeneratorOptions,
+      deployUrl: 'https://localhost/',
+      hints: [{ mode: 'preload', url: 'http://example.com/y?b=2' }],
+    });
+
+    expect(warnings).toHaveSize(0);
+    expect(content).toEqual(oneLineHtml`
+        <html>
+          <head>
+            <base href="/">
+            <link rel="preload" href="http://example.com/y?b=2">
+          </head>
+          <body>
+          </body>
+        </html>
+      `);
+  });
+
+  it(`should not add deploy URL to hints with a root-relative URL`, async () => {
+    const { content, warnings } = await augmentIndexHtml({
+      ...indexGeneratorOptions,
+      deployUrl: 'https://example.com/',
+      hints: [{ mode: 'preload', url: '/y?b=2' }],
+    });
+
+    expect(warnings).toHaveSize(0);
+    expect(content).toEqual(oneLineHtml`
+        <html>
+          <head>
+            <base href="/">
+            <link rel="preload" href="/y?b=2">
+          </head>
+          <body>
+          </body>
+        </html>
+      `);
+  });
+
   it('should add `.mjs` script tags', async () => {
     const { content } = await augmentIndexHtml({
       ...indexGeneratorOptions,


### PR DESCRIPTION
The `deployUrl` option was unintentionally being prepended to preload links with absolute URLs within the generated index HTML for an appplication. This has now been corrected and absolute URLs will not be altered when a deploy URL is configured.

Closes: #29029