### PR TITLE
fix(@angular-devkit/build-angular): handle windows spec collisions

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/karma/application_builder.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/application_builder.ts
@@ -26,7 +26,7 @@ import { Observable, Subscriber, catchError, defaultIfEmpty, from, of, switchMap
 import { Configuration } from 'webpack';
 import { ExecutionTransformer } from '../../transforms';
 import { OutputHashing } from '../browser-esbuild/schema';
-import { findTests } from './find-tests';
+import { findTests, getTestEntrypoints } from './find-tests';
 import { Schema as KarmaBuilderOptions } from './schema';
 
 interface BuildOptions extends ApplicationBuilderInternalOptions {
@@ -268,28 +268,7 @@ async function collectEntrypoints(
     projectSourceRoot,
   );
 
-  const seen = new Set<string>();
-
-  return new Map(
-    Array.from(testFiles, (testFile) => {
-      const relativePath = path
-        .relative(
-          testFile.startsWith(projectSourceRoot) ? projectSourceRoot : context.workspaceRoot,
-          testFile,
-        )
-        .replace(/^[./]+/, '_')
-        .replace(/\//g, '-');
-      let uniqueName = `spec-${path.basename(relativePath, path.extname(relativePath))}`;
-      let suffix = 2;
-      while (seen.has(uniqueName)) {
-        uniqueName = `${relativePath}-${suffix}`;
-        ++suffix;
-      }
-      seen.add(uniqueName);
-
-      return [uniqueName, testFile];
-    }),
-  );
+  return getTestEntrypoints(testFiles, { projectSourceRoot, workspaceRoot: context.workspaceRoot });
 }
 
 async function initializeApplication(

--- a/packages/angular_devkit/build_angular/src/builders/karma/find-tests_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/find-tests_spec.ts
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { getTestEntrypoints } from './find-tests';
+
+const UNIX_ENTRYPOINTS_OPTIONS = {
+  pathSeparator: '/',
+  workspaceRoot: '/my/workspace/root',
+  projectSourceRoot: '/my/workspace/root/src-root',
+};
+
+const WINDOWS_ENTRYPOINTS_OPTIONS = {
+  pathSeparator: '\\',
+  workspaceRoot: 'C:\\my\\workspace\\root',
+  projectSourceRoot: 'C:\\my\\workspace\\root\\src-root',
+};
+
+describe('getTestEntrypoints', () => {
+  for (const options of [UNIX_ENTRYPOINTS_OPTIONS, WINDOWS_ENTRYPOINTS_OPTIONS]) {
+    describe(`with path separator "${options.pathSeparator}"`, () => {
+      function joinWithSeparator(base: string, rel: string) {
+        return `${base}${options.pathSeparator}${rel.replace(/\//g, options.pathSeparator)}`;
+      }
+
+      function getEntrypoints(workspaceRelative: string[], sourceRootRelative: string[] = []) {
+        return getTestEntrypoints(
+          [
+            ...workspaceRelative.map((p) => joinWithSeparator(options.workspaceRoot, p)),
+            ...sourceRootRelative.map((p) => joinWithSeparator(options.projectSourceRoot, p)),
+          ],
+          options,
+        );
+      }
+
+      it('returns an empty map without test files', () => {
+        expect(getEntrypoints([])).toEqual(new Map());
+      });
+
+      it('strips workspace root and/or project source root', () => {
+        expect(getEntrypoints(['a/b.spec.js'], ['c/d.spec.js'])).toEqual(
+          new Map<string, string>([
+            ['spec-a-b.spec', joinWithSeparator(options.workspaceRoot, 'a/b.spec.js')],
+            ['spec-c-d.spec', joinWithSeparator(options.projectSourceRoot, 'c/d.spec.js')],
+          ]),
+        );
+      });
+
+      it('adds unique prefixes to distinguish between similar names', () => {
+        expect(getEntrypoints(['a/b/c/d.spec.js', 'a-b/c/d.spec.js'], ['a/b-c/d.spec.js'])).toEqual(
+          new Map<string, string>([
+            ['spec-a-b-c-d.spec', joinWithSeparator(options.workspaceRoot, 'a/b/c/d.spec.js')],
+            ['spec-a-b-c-d-2.spec', joinWithSeparator(options.workspaceRoot, 'a-b/c/d.spec.js')],
+            [
+              'spec-a-b-c-d-3.spec',
+              joinWithSeparator(options.projectSourceRoot, 'a/b-c/d.spec.js'),
+            ],
+          ]),
+        );
+      });
+    });
+  }
+});

--- a/packages/angular_devkit/build_angular/src/builders/karma/tests/behavior/specs_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/tests/behavior/specs_spec.ts
@@ -24,7 +24,9 @@ describeKarmaBuilder(execute, KARMA_BUILDER_INFO, (harness, setupTarget, isApp) 
 
       // src/app/app.component.spec.ts conflicts with this one:
       await harness.writeFiles({
-        [`src/app/a/${collidingBasename}`]: `/** Success! */`,
+        [`src/app/a/foo-bar/${collidingBasename}`]: `/** Success! */`,
+        [`src/app/a-foo/bar/${collidingBasename}`]: `/** Success! */`,
+        [`src/app/a-foo-bar/${collidingBasename}`]: `/** Success! */`,
         [`src/app/b/${collidingBasename}`]: `/** Success! */`,
       });
 
@@ -36,7 +38,9 @@ describeKarmaBuilder(execute, KARMA_BUILDER_INFO, (harness, setupTarget, isApp) 
         const bundleLog = logs.find((log) =>
           log.message.includes('Application bundle generation complete.'),
         );
-        expect(bundleLog?.message).toContain('spec-app-a-collision.spec.js');
+        expect(bundleLog?.message).toContain('spec-app-a-foo-bar-collision.spec.js');
+        expect(bundleLog?.message).toContain('spec-app-a-foo-bar-collision-2.spec.js');
+        expect(bundleLog?.message).toContain('spec-app-a-foo-bar-collision-3.spec.js');
         expect(bundleLog?.message).toContain('spec-app-b-collision.spec.js');
       }
     });


### PR DESCRIPTION
The previous logic didn't quite work when interacting with windows path. This PR does three things:

1. Move the logic to generate unique spec entrypoint names into its own function. This prepares for reusing it elsewhere (e.g. in WTR).
2. Add a more direct unit test for that logic.
3. Fix the logic so it works with Windows paths as well as unix paths.

As a drive-by fix, this also cleans up the deduped filenames so we get "foo-2.spec.js" instead of "foo.spec-2.js". The latter looked a bit confusing and it was just a tiiiiny regex to fix those names up. The index append shouldn't really come up in real code very often, so this is very much a tiny niche case.

Fixes https://github.com/angular/angular-cli/issues/28915