### PR TITLE
feat(@angular/ssr): redirect to preferred locale when accessing root route without a specified locale

### DIFF
--- a/packages/angular/ssr/src/i18n.ts
+++ b/packages/angular/ssr/src/i18n.ts
@@ -43,3 +43,160 @@ export function getPotentialLocaleIdFromUrl(url: URL, basePath: string): string 
   // Extract the potential locale id.
   return pathname.slice(start, end);
 }
+
+/**
+ * Parses the `Accept-Language` header and returns a list of locale preferences with their respective quality values.
+ *
+ * The `Accept-Language` header is typically a comma-separated list of locales, with optional quality values
+ * in the form of `q=<value>`. If no quality value is specified, a default quality of `1` is assumed.
+ * Special case: if the header is `*`, it returns the default locale with a quality of `1`.
+ *
+ * @param header - The value of the `Accept-Language` header, typically a comma-separated list of locales
+ *                  with optional quality values (e.g., `en-US;q=0.8,fr-FR;q=0.9`). If the header is `*`,
+ *                  it represents a wildcard for any language, returning the default locale.
+ *
+ * @returns A `ReadonlyMap` where the key is the locale (e.g., `en-US`, `fr-FR`), and the value is
+ *          the associated quality value (a number between 0 and 1). If no quality value is provided,
+ *          a default of `1` is used.
+ *
+ * @example
+ * ```js
+ * parseLanguageHeader('en-US;q=0.8,fr-FR;q=0.9')
+ * // returns new Map([['en-US', 0.8], ['fr-FR', 0.9]])
+
+ * parseLanguageHeader('*')
+ * // returns new Map([['*', 1]])
+ * ```
+ */
+function parseLanguageHeader(header: string): ReadonlyMap<string, number> {
+  if (header === '*') {
+    return new Map([['*', 1]]);
+  }
+
+  const parsedValues = header
+    .split(',')
+    .map((item) => {
+      const [locale, qualityValue] = item.split(';', 2).map((v) => v.trim());
+
+      let quality = qualityValue?.startsWith('q=') ? parseFloat(qualityValue.slice(2)) : undefined;
+      if (typeof quality !== 'number' || isNaN(quality) || quality < 0 || quality > 1) {
+        quality = 1; // Invalid quality value defaults to 1
+      }
+
+      return [locale, quality] as const;
+    })
+    .sort(([_localeA, qualityA], [_localeB, qualityB]) => qualityB - qualityA);
+
+  return new Map(parsedValues);
+}
+
+/**
+ * Gets the preferred locale based on the highest quality value from the provided `Accept-Language` header
+ * and the set of available locales.
+ *
+ * This function adheres to the HTTP `Accept-Language` header specification as defined in
+ * [RFC 7231](https://datatracker.ietf.org/doc/html/rfc7231#section-5.3.5), including:
+ * - Case-insensitive matching of language tags.
+ * - Quality value handling (e.g., `q=1`, `q=0.8`). If no quality value is provided, it defaults to `q=1`.
+ * - Prefix matching (e.g., `en` matching `en-US` or `en-GB`).
+ *
+ * @param header - The `Accept-Language` header string to parse and evaluate. It may contain multiple
+ *                 locales with optional quality values, for example: `'en-US;q=0.8,fr-FR;q=0.9'`.
+ * @param supportedLocales - An array of supported locales (e.g., `['en-US', 'fr-FR']`),
+ *                           representing the locales available in the application.
+ * @returns The best matching locale from the supported languages, or `undefined` if no match is found.
+ *
+ * @example
+ * ```js
+ * getPreferredLocale('en-US;q=0.8,fr-FR;q=0.9', ['en-US', 'fr-FR', 'de-DE'])
+ * // returns 'fr-FR'
+ *
+ * getPreferredLocale('en;q=0.9,fr-FR;q=0.8', ['en-US', 'fr-FR', 'de-DE'])
+ * // returns 'en-US'
+ *
+ * getPreferredLocale('es-ES;q=0.7', ['en-US', 'fr-FR', 'de-DE'])
+ * // returns undefined
+ * ```
+ */
+export function getPreferredLocale(
+  header: string,
+  supportedLocales: ReadonlyArray<string>,
+): string | undefined {
+  if (supportedLocales.length < 2) {
+    return supportedLocales[0];
+  }
+
+  const parsedLocales = parseLanguageHeader(header);
+
+  // Handle edge cases:
+  // - No preferred locales provided.
+  // - Only one supported locale.
+  // - Wildcard preference.
+  if (parsedLocales.size === 0 || (parsedLocales.size === 1 && parsedLocales.has('*'))) {
+    return supportedLocales[0];
+  }
+
+  // Create a map for case-insensitive lookup of supported locales.
+  // Keys are normalized (lowercase) locale values, values are original casing.
+  const normalizedSupportedLocales = new Map<string, string>();
+  for (const locale of supportedLocales) {
+    normalizedSupportedLocales.set(normalizeLocale(locale), locale);
+  }
+
+  // Iterate through parsed locales in descending order of quality.
+  let bestMatch: string | undefined;
+  const qualityZeroNormalizedLocales = new Set<string>();
+  for (const [locale, quality] of parsedLocales) {
+    const normalizedLocale = normalizeLocale(locale);
+    if (quality === 0) {
+      qualityZeroNormalizedLocales.add(normalizedLocale);
+      continue; // Skip locales with quality value of 0.
+    }
+
+    // Exact match found.
+    if (normalizedSupportedLocales.has(normalizedLocale)) {
+      return normalizedSupportedLocales.get(normalizedLocale);
+    }
+
+    // If an exact match is not found, try prefix matching (e.g., "en" matches "en-US").
+    // Store the first prefix match encountered, as it has the highest quality value.
+    if (bestMatch !== undefined) {
+      continue;
+    }
+
+    const [languagePrefix] = normalizedLocale.split('-', 1);
+    for (const supportedLocale of normalizedSupportedLocales.keys()) {
+      if (supportedLocale.startsWith(languagePrefix)) {
+        bestMatch = normalizedSupportedLocales.get(supportedLocale);
+        break; // No need to continue searching for this locale.
+      }
+    }
+  }
+
+  if (bestMatch !== undefined) {
+    return bestMatch;
+  }
+
+  // Return the first locale that is not quality zero.
+  for (const [normalizedLocale, locale] of normalizedSupportedLocales) {
+    if (!qualityZeroNormalizedLocales.has(normalizedLocale)) {
+      return locale;
+    }
+  }
+}
+
+/**
+ * Normalizes a locale string by converting it to lowercase.
+ *
+ * @param locale - The locale string to normalize.
+ * @returns The normalized locale string in lowercase.
+ *
+ * @example
+ * ```ts
+ * const normalized = normalizeLocale('EN-US');
+ * console.log(normalized); // Output: "en-us"
+ * ```
+ */
+function normalizeLocale(locale: string): string {
+  return locale.toLowerCase();
+}

--- a/packages/angular/ssr/src/manifest.ts
+++ b/packages/angular/ssr/src/manifest.ts
@@ -55,7 +55,7 @@ export interface AngularAppEngineManifest {
   /**
    * A readonly record of entry points for the server application.
    * Each entry consists of:
-   * - `key`: The base href for the entry point.
+   * - `key`: The url segment for the entry point.
    * - `value`: A function that returns a promise resolving to an object of type `EntryPointExports`.
    */
   readonly entryPoints: Readonly<Record<string, (() => Promise<EntryPointExports>) | undefined>>;
@@ -65,6 +65,14 @@ export interface AngularAppEngineManifest {
    * This is used to determine the root path of the application.
    */
   readonly basePath: string;
+
+  /**
+   * A readonly record mapping supported locales to their respective entry-point paths.
+   * Each entry consists of:
+   * - `key`: The locale identifier (e.g., 'en', 'fr').
+   * - `value`: The url segment associated with that locale.
+   */
+  readonly supportedLocales: Readonly<Record<string, string | undefined>>;
 }
 
 /**

--- a/packages/angular/ssr/test/i18n_spec.ts
+++ b/packages/angular/ssr/test/i18n_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import { getPotentialLocaleIdFromUrl } from '../src/i18n';
+import { getPotentialLocaleIdFromUrl, getPreferredLocale } from '../src/i18n';
 
 describe('getPotentialLocaleIdFromUrl', () => {
   it('should extract locale ID correctly when basePath is present', () => {
@@ -63,5 +63,108 @@ describe('getPotentialLocaleIdFromUrl', () => {
     const basePath = '/base';
     const localeId = getPotentialLocaleIdFromUrl(url, basePath);
     expect(localeId).toBe('en');
+  });
+});
+
+describe('getPreferredLocale', () => {
+  it('should return the exact match with the highest quality value', () => {
+    const header = 'en-GB;q=0.8,fr-FR;q=0.9';
+    const supportedLocales = ['en-GB', 'fr-FR', 'fr-BE'];
+    const result = getPreferredLocale(header, supportedLocales);
+    // Exact match for 'fr-FR' with the highest quality (0.9)
+    expect(result).toBe('fr-FR');
+  });
+
+  it('should return the best match when no exact match is found, using language prefixes', () => {
+    const header = 'en-GB;q=0.9,fr;q=0.8';
+    const supportedLocales = ['fr-FR', 'de-DE', 'en-US'];
+    const result = getPreferredLocale(header, supportedLocales);
+    // 'en-US' is the exact match with the highest quality (0.9)
+    expect(result).toBe('en-US');
+  });
+
+  it('should match based on language prefix when no exact match is found', () => {
+    const header = 'en-US;q=0.8,fr;q=0.9,en-GB;q=0.7';
+    const supportedLocales = ['en-GB', 'fr-FR', 'de-DE'];
+    const result = getPreferredLocale(header, supportedLocales);
+    // Best match is 'en-GB' based on exact match (0.8 for 'en-US')
+    expect(result).toBe('en-GB');
+  });
+
+  it('should return the first available locale when no exact match or prefix is found', () => {
+    const header = 'it-IT;q=0.8';
+    const supportedLocales = ['en-GB', 'fr-FR', 'de-DE'];
+    const result = getPreferredLocale(header, supportedLocales);
+    // The first locale in the supportedLocales set
+    expect(result).toBe('en-GB');
+  });
+
+  it('should return the first available locale when the header is empty', () => {
+    const header = '';
+    const supportedLocales = ['en-GB', 'fr-FR', 'de-DE'];
+    const result = getPreferredLocale(header, supportedLocales);
+    expect(result).toBe('en-GB'); // The first locale in the supportedLocales set
+  });
+
+  it('should return the first available locale when the header is just "*"', () => {
+    const header = '*';
+    const supportedLocales = ['en-GB', 'fr-FR', 'de-DE'];
+    const result = getPreferredLocale(header, supportedLocales);
+    // The first locale in the supportedLocales set
+    expect(result).toBe('en-GB');
+  });
+
+  it('should return the first available locale when no valid languages are in header', () => {
+    const header = 'xyz;q=0.5';
+    const supportedLocales = ['en-GB', 'fr-FR', 'de-DE'];
+    const result = getPreferredLocale(header, supportedLocales);
+    // No valid language, fallback to the first available locale
+    expect(result).toBe('en-GB');
+  });
+
+  it('should return the closest match when no valid languages in header', () => {
+    const header = 'en-XYZ;q=0.7,fr-XYZ;q=0.8';
+    const supportedLocales = ['en-GB', 'fr-FR', 'de-DE'];
+    const result = getPreferredLocale(header, supportedLocales);
+
+    // Since there is no exact match for 'en-XYZ' or 'fr-XYZ',
+    // the function should return 'fr-FR' as the closest match,
+    // as it shares the language prefix 'fr' with the 'fr-XYZ' in the header.
+    expect(result).toBe('fr-FR');
+  });
+
+  it('should ignore locales with quality 0 and choose the highest quality supported locale', () => {
+    const header = 'en-GB;q=0,fr;q=0.9';
+    const supportedLocales = ['en-GB', 'fr-FR', 'fr-BE'];
+    const result = getPreferredLocale(header, supportedLocales);
+    // 'en-GB' is ignored because quality is 0, so 'fr-FR' is chosen
+    expect(result).toBe('fr-FR');
+  });
+
+  it('should select the highest quality supported locale as fallback, ignoring those with quality 0', () => {
+    const header = 'en-GB;q=0';
+    const supportedLocales = ['en-GB', 'fr-FR', 'fr-BE'];
+    const result = getPreferredLocale(header, supportedLocales);
+    // 'en-GB' is ignored because quality is 0, so 'fr-FR' is chosen as the highest quality supported locale
+    expect(result).toBe('fr-FR');
+  });
+
+  it('should select the closest match based on quality before considering wildcard "*"', () => {
+    const header = 'fr-CH, fr;q=0.9, en;q=0.8, de;q=0.7, *;q=0.5';
+    const supportedLocales = ['it-IT', 'fr-FR', 'de-DE'];
+    const result = getPreferredLocale(header, supportedLocales);
+
+    // 'fr-FR' matches the 'fr' prefix with quality 0.9
+    expect(result).toBe('fr-FR');
+  });
+
+  it('should select the first available locale when only the wildcard "*" matches', () => {
+    const header = 'fr-CH, fr;q=0.9, *;q=0.5';
+    const supportedLocales = ['it-IT', 'de-DE'];
+    const result = getPreferredLocale(header, supportedLocales);
+
+    // Since 'fr-CH' and 'fr' do not match any supported locales,
+    // and '*' is present with quality 0.5, the first supported locale is chosen as a fallback.
+    expect(result).toBe('it-IT');
   });
 });


### PR DESCRIPTION
    
When users access the root route `/` without providing a locale, the application now redirects them to their preferred locale based on the `Accept-Language` header.
    
This enhancement leverages the user's browser preferences to determine the most appropriate locale, providing a seamless and personalized experience without requiring manual locale selection.
