### PR TITLE
perf(@angular/build): reuse TS package.json cache when rebuilding

### DIFF
--- a/packages/angular/build/src/tools/angular/compilation/jit-compilation.ts
+++ b/packages/angular/build/src/tools/angular/compilation/jit-compilation.ts
@@ -53,7 +53,7 @@ export class JitCompilation extends AngularCompilation {
       compilerOptionsTransformer?.(originalCompilerOptions) ?? originalCompilerOptions;
 
     // Create Angular compiler host
-    const host = createAngularCompilerHost(ts, compilerOptions, hostOptions);
+    const host = createAngularCompilerHost(ts, compilerOptions, hostOptions, undefined);
 
     // Create the TypeScript Program
     const typeScriptProgram = profileSync('TS_CREATE_PROGRAM', () =>


### PR DESCRIPTION
TypeScript 5.6 and higher added functionality that will search for a `package.json` file for source files that are part of the program (e.g., `.d.ts`) and within a node modules directory. This can be an expensive task especially considering the large amount of `.d.ts` files within packages. TypeScript supports using a cache of known `package.json` files to improve the performance of this task. The Angular CLI will now provide and reuse this cache across rebuilds during watch mode. This includes the use of `ng serve`.

The performance difference is most apparent for the Angular template diagnostic step of the build. Internally the Angular compiler creates a new template typechecking program which causes the `package.json` search process to occur. By leveraging the cache, this process becomes a series of cache hits. In the event that files are modified within the node modules directory, the cache is invalidated and the following rebuild may be longer as a result.

Previous:
```
DURATION[NG_DIAGNOSTICS_TOTAL]: 0.040498750s
DURATION[NG_DIAGNOSTICS_SYNTACTIC]: 0.000079378s [count: 265; avg: 0.000000300s; min: 0.000000166s; max: 0.000003042s]
DURATION[NG_DIAGNOSTICS_SEMANTIC]: 0.000095121s [count: 265; avg: 0.000000359s; min: 0.000000250s; max: 0.000004500s]
DURATION[NG_DIAGNOSTICS_TEMPLATE]: 0.040161625s [count: 1; avg: 0.040161625s; min: 0.040161625s; max: 0.040161625s]
```

Now:
```
DURATION[NG_DIAGNOSTICS_TOTAL]: 0.007495333s
DURATION[NG_DIAGNOSTICS_SYNTACTIC]: 0.000082327s [count: 265; avg: 0.000000311s; min: 0.000000208s; max: 0.000002750s]
DURATION[NG_DIAGNOSTICS_SEMANTIC]: 0.000109290s [count: 265; avg: 0.000000412s; min: 0.000000291s; max: 0.000003875s]
DURATION[NG_DIAGNOSTICS_TEMPLATE]: 0.007141042s [count: 1; avg: 0.007141042s; min: 0.007141042s; max: 0.007141042s]
```