### PR TITLE
fix(@angular-devkit/build-angular): webpack config transform for karma

### DIFF
--- a/packages/angular_devkit/build_angular/BUILD.bazel
+++ b/packages/angular_devkit/build_angular/BUILD.bazel
@@ -321,6 +321,7 @@ LARGE_SPECS = {
             "@npm//karma-jasmine",
             "@npm//karma-jasmine-html-reporter",
             "@npm//puppeteer",
+            "@npm//webpack",
         ],
     },
     "protractor": {

--- a/packages/angular_devkit/build_angular/src/builders/karma/browser_builder.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/browser_builder.ts
@@ -34,7 +34,7 @@ export function execute(
     karmaOptions?: (options: KarmaConfigOptions) => KarmaConfigOptions;
   } = {},
 ): Observable<BuilderOutput> {
-  return from(initializeBrowser(options, context)).pipe(
+  return from(initializeBrowser(options, context, transforms.webpackConfiguration)).pipe(
     switchMap(async ([karma, webpackConfig]) => {
       const projectName = context.target?.project;
       if (!projectName) {

--- a/packages/angular_devkit/build_angular/src/builders/karma/tests/options/custom-loader_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/tests/options/custom-loader_spec.ts
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { Configuration } from 'webpack';
+
+import { execute } from '../../index';
+import { BASE_OPTIONS, KARMA_BUILDER_INFO, describeKarmaBuilder } from '../setup';
+import { ExecutionTransformer } from '../../../../transforms';
+
+describeKarmaBuilder(execute, KARMA_BUILDER_INFO, (harness, setupTarget, isApplicationBuilder) => {
+  describe('Option: Custom file loader', () => {
+    beforeEach(async () => {
+      if (isApplicationBuilder) {
+        pending('not implemented yet for application builder');
+      }
+      await setupTarget(harness);
+    });
+
+    beforeEach(async () => {
+      await harness.writeFiles({
+        'src/number-webpack-loader.js': `
+            module.exports = (source) => {
+              return 'export const DOUBLED = ' + (Number(source) * 2) + ';\\n';
+            };`,
+        'src/app/app.number': `42`,
+        'src/app/app.number.d.ts': `export const DOUBLED: number;`,
+        'src/app/app.component.spec.ts': `
+            import { DOUBLED } from './app.number';
+            describe('Custom webpack transform', () => {
+              it('generates expected export', () => {
+                expect(DOUBLED).toBe(84);
+              });
+            });`,
+      });
+    });
+
+    it('applies the webpack configuration transform', async () => {
+      harness.useTarget('test', {
+        ...BASE_OPTIONS,
+      });
+
+      const webpackConfiguration: ExecutionTransformer<Configuration> = (config: Configuration) => {
+        config.module ??= {};
+        config.module.rules ??= [];
+        config.module.rules.push({
+          test: /\.number$/,
+          loader: './src/number-webpack-loader.js',
+        });
+        return config;
+      };
+
+      const { result } = await harness.executeOnce({
+        additionalExecuteArguments: [
+          {
+            webpackConfiguration,
+          },
+        ],
+      });
+      expect(result?.success).toBeTrue();
+    });
+  });
+});


### PR DESCRIPTION
This PR is 10% passing an argument that got dropped during refactoring and 90% finding a way to test the behavior.

I'm making up a new concept for the harness (`additionalExecuteArguments`) which is pretty ugly but I couldn't think of a cleaner way of doing it. There might be a way to capture rest arguments of the `execute` function signature inside of the harness to make the cast go away. But I'm not 100% convinced that the more complicated types leaking throughout the harness code would really be worth it for this edge case.

See: https://github.com/angular/angular-cli/issues/29003