### PR TITLE
fix(@angular/ssr):  include `Content-Language` header when locale is set

### DIFF
--- a/packages/angular/ssr/test/app-engine_spec.ts
+++ b/packages/angular/ssr/test/app-engine_spec.ts
@@ -60,6 +60,7 @@ function createEntryPoint(locale: string) {
         `,
         },
       },
+      locale,
     );
 
     return {
@@ -110,12 +111,14 @@ describe('AngularAppEngine', () => {
         const request = new Request('https://example.com/it/ssr/index.html');
         const response = await appEngine.handle(request);
         expect(await response?.text()).toContain('SSR works IT');
+        expect(response?.headers?.get('Content-Language')).toBe('it');
       });
 
       it('should return a serve prerendered page with correct locale', async () => {
         const request = new Request('https://example.com/it/ssg');
         const response = await appEngine.handle(request);
         expect(await response?.text()).toContain('SSG works IT');
+        expect(response?.headers?.get('Content-Language')).toBe('it');
       });
 
       it('should correctly serve the prerendered content when the URL ends with "index.html" with correct locale', async () => {

--- a/packages/angular/ssr/test/testing-utils.ts
+++ b/packages/angular/ssr/test/testing-utils.ts
@@ -21,14 +21,18 @@ import { ServerRoute, provideServerRoutesConfig } from '../src/routes/route-conf
  * Angular components and providers for testing purposes.
  *
  * @param routes - An array of route definitions to be used by the Angular Router.
- * @param serverRoutes - An array of ServerRoute definitions to be used for server-side rendering.
- * @param [baseHref='/'] - An optional base href to be used in the HTML template.
+ * @param serverRoutes - An array of server route definitions for server-side rendering.
+ * @param [baseHref='/'] - An optional base href for the HTML template (default is `/`).
+ * @param additionalServerAssets - A record of additional server assets to include,
+ *                                  where the keys are asset paths and the values are asset details.
+ * @param locale - An optional locale to configure for the application during testing.
  */
 export function setAngularAppTestingManifest(
   routes: Routes,
   serverRoutes: ServerRoute[],
   baseHref = '/',
   additionalServerAssets: Record<string, ServerAsset> = {},
+  locale?: string,
 ): void {
   destroyAngularServerApp();
 
@@ -43,6 +47,7 @@ export function setAngularAppTestingManifest(
   setAngularAppManifest({
     inlineCriticalCss: false,
     baseHref,
+    locale,
     assets: {
       ...additionalServerAssets,
       'index.server.html': {


### PR DESCRIPTION
The server now includes the `Content-Language` HTTP header in responses whenever a locale is explicitly set.
