### PR TITLE
refactor(@angular/ssr): skip rendering root page during route extraction

### DIFF
--- a/packages/angular/ssr/src/routes/ng-routes.ts
+++ b/packages/angular/ssr/src/routes/ng-routes.ts
@@ -9,7 +9,7 @@
 import { APP_BASE_HREF, PlatformLocation } from '@angular/common';
 import { ApplicationRef, Compiler, Injector, runInInjectionContext, ɵConsole } from '@angular/core';
 import { INITIAL_CONFIG, platformServer } from '@angular/platform-server';
-import { Route, Router, ɵloadChildren as loadChildrenHelper } from '@angular/router';
+import { ROUTES, Route, Router, ɵloadChildren as loadChildrenHelper } from '@angular/router';
 import { ServerAssets } from '../assets';
 import { Console } from '../console';
 import { AngularAppManifest, getAngularAppManifest } from '../manifest';
@@ -24,6 +24,12 @@ import {
   ServerRoutesConfig,
 } from './route-config';
 import { RouteTree, RouteTreeNodeMetadata } from './route-tree';
+
+/**
+ * Constant representing the path for route extraction.
+ * This path is used during the route extraction process and does not affect the application's actual routing behavior.
+ */
+const EXTRACT_ROUTES_PATH = 'ng-routes-internal';
 
 /**
  * Regular expression to match segments preceded by a colon in a string.
@@ -407,7 +413,16 @@ export async function getRoutesFromAngularRouterConfig(
   const platformRef = platformServer([
     {
       provide: INITIAL_CONFIG,
-      useValue: { document, url: `${protocol}//${host}/` },
+      // The route below is intentionally configured with a non-existent path
+      // to prevent the root route from rendering during the route extraction process.
+      useValue: { document, url: `${protocol}//${host}/${EXTRACT_ROUTES_PATH}` },
+    },
+    {
+      provide: ROUTES,
+      multi: true,
+      // Adds an 'internal' route to extract routes.
+      // This route doesn't perform any action but ensures the use of a non-existent path to avoid route mismatch errors in Angular router.
+      useValue: [EXTRACT_ROUTES_PATH],
     },
     {
       provide: ɵConsole,


### PR DESCRIPTION
To prevent rendering the root route while extracting routes, a non-existent path (`/ng-extract-routes`) is intentionally used. This ensures unnecessary rendering during the route extraction process where now only the app component is rendered.