### PR TITLE
fix(@angular/build): handle external `@angular/` packages during SSR

### DIFF
--- a/packages/angular/build/src/utils/server-rendering/esm-in-memory-loader/loader-hooks.ts
+++ b/packages/angular/build/src/utils/server-rendering/esm-in-memory-loader/loader-hooks.ts
@@ -14,6 +14,11 @@ import { fileURLToPath } from 'url';
 import { JavaScriptTransformer } from '../../../tools/esbuild/javascript-transformer';
 
 /**
+ * @note For some unknown reason, setting `globalThis.ngServerMode = true` does not work when using ESM loader hooks.
+ */
+const NG_SERVER_MODE_INIT_BYTES = new TextEncoder().encode('var ngServerMode=true;');
+
+/**
  * Node.js ESM loader to redirect imports to in memory files.
  * @see: https://nodejs.org/api/esm.html#loaders for more information about loaders.
  */
@@ -133,7 +138,12 @@ export async function load(url: string, context: { format?: string | null }, nex
   // need linking are ESM only.
   if (format === 'module' && isFileProtocol(url)) {
     const filePath = fileURLToPath(url);
-    const source = await javascriptTransformer.transformFile(filePath);
+    let source = await javascriptTransformer.transformFile(filePath);
+
+    if (filePath.includes('@angular/')) {
+      // Prepend 'var ngServerMode=true;' to the source.
+      source = new Uint8Array([...NG_SERVER_MODE_INIT_BYTES, ...source]);
+    }
 
     return {
       format,

--- a/packages/angular/build/src/utils/server-rendering/esm-in-memory-loader/loader-hooks.ts
+++ b/packages/angular/build/src/utils/server-rendering/esm-in-memory-loader/loader-hooks.ts
@@ -142,7 +142,7 @@ export async function load(url: string, context: { format?: string | null }, nex
 
     if (filePath.includes('@angular/')) {
       // Prepend 'var ngServerMode=true;' to the source.
-      source = new Uint8Array([...NG_SERVER_MODE_INIT_BYTES, ...source]);
+      source = Buffer.concat([NG_SERVER_MODE_INIT_BYTES, source]);
     }
 
     return {

--- a/tests/legacy-cli/e2e/tests/build/server-rendering/server-routes-output-mode-server-external-dependencies.ts
+++ b/tests/legacy-cli/e2e/tests/build/server-rendering/server-routes-output-mode-server-external-dependencies.ts
@@ -1,0 +1,32 @@
+import assert from 'node:assert';
+import { ng } from '../../../utils/process';
+import { installWorkspacePackages, uninstallPackage } from '../../../utils/packages';
+import { updateJsonFile, useSha } from '../../../utils/project';
+import { getGlobalVariable } from '../../../utils/env';
+
+export default async function () {
+  assert(
+    getGlobalVariable('argv')['esbuild'],
+    'This test should not be called in the Webpack suite.',
+  );
+
+  // Forcibly remove in case another test doesn't clean itself up.
+  await uninstallPackage('@angular/ssr');
+  await ng('add', '@angular/ssr', '--server-routing', '--skip-confirmation', '--skip-install');
+  await useSha();
+  await installWorkspacePackages();
+
+  await updateJsonFile('angular.json', (json) => {
+    const build = json['projects']['test-project']['architect']['build'];
+    build.options.externalDependencies = [
+      '@angular/platform-browser',
+      '@angular/core',
+      '@angular/router',
+      '@angular/common',
+      '@angular/common/http',
+      '@angular/platform-browser/animations',
+    ];
+  });
+
+  await ng('build');
+}


### PR DESCRIPTION
This commit introduces `ngServerMode` to ensure proper handling of external `@angular/` packages when they are used as externals during server-side rendering (SSR).

Closes: #29092
