### PR TITLE
fix(@angular/ssr): disable component bootstrapping during route extraction

### DIFF
--- a/packages/angular/ssr/test/routes/ng-routes_spec.ts
+++ b/packages/angular/ssr/test/routes/ng-routes_spec.ts
@@ -466,4 +466,33 @@ describe('extractRoutesAndCreateRouteTree', () => {
       { route: '/example/home', renderMode: RenderMode.Server },
     ]);
   });
+
+  it('should not bootstrap the root component', async () => {
+    @Component({
+      standalone: true,
+      selector: 'app-root',
+      template: '',
+    })
+    class RootComponent {
+      constructor() {
+        throw new Error('RootComponent should not be bootstrapped.');
+      }
+    }
+
+    setAngularAppTestingManifest(
+      [
+        { path: '', component: DummyComponent },
+        { path: 'home', component: DummyComponent },
+      ],
+      [{ path: '**', renderMode: RenderMode.Server }],
+      undefined,
+      undefined,
+      undefined,
+      RootComponent,
+    );
+
+    const { routeTree, errors } = await extractRoutesAndCreateRouteTree({ url });
+    expect(errors).toHaveSize(0);
+    expect(routeTree.toObject()).toHaveSize(2);
+  });
 });

--- a/packages/angular/ssr/test/testing-utils.ts
+++ b/packages/angular/ssr/test/testing-utils.ts
@@ -6,13 +6,21 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import { Component, provideExperimentalZonelessChangeDetection } from '@angular/core';
+import { Component, Type, provideExperimentalZonelessChangeDetection } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
 import { provideServerRendering } from '@angular/platform-server';
 import { RouterOutlet, Routes, provideRouter } from '@angular/router';
 import { destroyAngularServerApp } from '../src/app';
 import { ServerAsset, setAngularAppManifest } from '../src/manifest';
 import { ServerRoute, provideServerRoutesConfig } from '../src/routes/route-config';
+
+@Component({
+  standalone: true,
+  selector: 'app-root',
+  template: '<router-outlet />',
+  imports: [RouterOutlet],
+})
+class AppComponent {}
 
 /**
  * Configures the Angular application for testing by setting up the Angular app manifest,
@@ -26,6 +34,7 @@ import { ServerRoute, provideServerRoutesConfig } from '../src/routes/route-conf
  * @param additionalServerAssets - A record of additional server assets to include,
  *                                  where the keys are asset paths and the values are asset details.
  * @param locale - An optional locale to configure for the application during testing.
+ * @param rootComponent - The root Angular component to bootstrap the application.
  */
 export function setAngularAppTestingManifest(
   routes: Routes,
@@ -33,16 +42,9 @@ export function setAngularAppTestingManifest(
   baseHref = '/',
   additionalServerAssets: Record<string, ServerAsset> = {},
   locale?: string,
+  rootComponent: Type<unknown> = AppComponent,
 ): void {
   destroyAngularServerApp();
-
-  @Component({
-    standalone: true,
-    selector: 'app-root',
-    template: '<router-outlet />',
-    imports: [RouterOutlet],
-  })
-  class AppComponent {}
 
   setAngularAppManifest({
     inlineCriticalCss: false,
@@ -81,7 +83,7 @@ export function setAngularAppTestingManifest(
       },
     },
     bootstrap: async () => () => {
-      return bootstrapApplication(AppComponent, {
+      return bootstrapApplication(rootComponent, {
         providers: [
           provideServerRendering(),
           provideExperimentalZonelessChangeDetection(),


### PR DESCRIPTION


This commit disables component bootstrapping during route extraction to prevent invoking the AppComponent and its lifecycle hooks.

Closes #29085