### PR TITLE
fix(@angular/build): use consistent path separators for template HMR identifiers

### DIFF
--- a/packages/angular/build/src/tools/angular/compilation/aot-compilation.ts
+++ b/packages/angular/build/src/tools/angular/compilation/aot-compilation.ts
@@ -155,6 +155,7 @@ export class AotCompilation extends AngularCompilation {
         if (relativePath.startsWith('..')) {
           relativePath = componentFilename;
         }
+        relativePath = relativePath.replaceAll('\\', '/');
         const updateId = encodeURIComponent(
           `${host.getCanonicalFileName(relativePath)}@${node.name?.text}`,
         );


### PR DESCRIPTION
To ensure that component HMR identifiers match correctly during an update, the path element of the identifier generated by the build system will now convert all windows path separators into POSIX separators. This provides matching behavior to the AOT compiler's identifier generation process.