### PR TITLE
fix(@angular/build): provide component HMR update modules to dev-server SSR

### DIFF
--- a/packages/angular/build/src/builders/dev-server/vite-server.ts
+++ b/packages/angular/build/src/builders/dev-server/vite-server.ts
@@ -735,6 +735,7 @@ export async function setupServer(
       await createAngularMemoryPlugin({
         virtualProjectRoot,
         outputFiles,
+        templateUpdates,
         external: externalMetadata.explicitBrowser,
         skipViteClient: serverOptions.liveReload === false && serverOptions.hmr === false,
       }),


### PR DESCRIPTION
When using component HMR and SSR with the development server, the component update modules will now be available to the Vite server rendering.  This prevents console errors due to missing component update paths. Additionally, it allows the server rendering to use the latest component templates if those have been changed before a new rebuild has occurred.