### PR TITLE
fix(@angular/build): fix tailwind css update on template hmr change

### DIFF
--- a/packages/angular/build/src/builders/application/build-action.ts
+++ b/packages/angular/build/src/builders/application/build-action.ts
@@ -223,7 +223,10 @@ async function emitOutputResult(
   }
 
   // Template updates only exist if no other changes have occurred
+  // To support Tailwind CSS the global styles.css build output is included in the update so it can be checked for changes
+  // as the file watcher is only capable of detecting changes to the raw styles.css file.
   if (templateUpdates?.size) {
+    const globalStyles = outputFiles.find((f) => f.path === 'styles.css');
     const updateResult: ComponentUpdateResult = {
       kind: ResultKind.ComponentUpdate,
       updates: Array.from(templateUpdates).map(([id, content]) => ({
@@ -231,6 +234,14 @@ async function emitOutputResult(
         id,
         content,
       })),
+      globalStyles: globalStyles
+        ? {
+            origin: 'memory',
+            hash: globalStyles.hash,
+            type: globalStyles.type,
+            contents: globalStyles.contents,
+          }
+        : undefined,
     };
 
     return updateResult;

--- a/packages/angular/build/src/builders/application/results.ts
+++ b/packages/angular/build/src/builders/application/results.ts
@@ -73,4 +73,5 @@ export interface ComponentUpdateResult extends BaseResult {
     type: 'style' | 'template';
     content: string;
   }[];
+  globalStyles?: MemoryFile;
 }


### PR DESCRIPTION
When adding tailwind classes to a template, the builder notifies Vite with a ComponentUpdate which reloads the template on the client with the new classes. However, if the global styles.css from the build output was changed due to a new class being added there. The client won't be served that new styles.css- until a Full Update or rebuild occurs. This commit is primarily a workaround until better support can be added for this scenario.

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Newly added tailwind classes won't render their styles when ComponentUpdate sent, as the styles.css is not being checked for changes.

## What is the new behavior?

On ComponentUpdate vite will also check the styles.css hash and if it is different send a `css-update` to the client to reload the global styles with the missing tailwind classes.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
