### PR TITLE
refactor(@angular/build): only load chunk optimizer if enabled

### DIFF
--- a/packages/angular/build/src/builders/application/execute-build.ts
+++ b/packages/angular/build/src/builders/application/execute-build.ts
@@ -31,7 +31,6 @@ import {
   generateAngularServerAppEngineManifest,
 } from '../../utils/server-rendering/manifest';
 import { getSupportedBrowsers } from '../../utils/supported-browsers';
-import { optimizeChunks } from './chunk-optimizer';
 import { executePostBundleSteps } from './execute-post-bundle';
 import { inlineI18n, loadActiveTranslations } from './i18n';
 import { NormalizedApplicationBuildOptions } from './options';
@@ -129,6 +128,7 @@ export async function executeBuild(
   }
 
   if (options.optimizationOptions.scripts && shouldOptimizeChunks) {
+    const { optimizeChunks } = await import('./chunk-optimizer');
     bundlingResult = await profileAsync('OPTIMIZE_CHUNKS', () =>
       optimizeChunks(
         bundlingResult,


### PR DESCRIPTION
The experimental chunk optimizer is now only imported if it is enabled via its environment variable (`NG_BUILD_OPTIMIZE_CHUNKS=1`). This prevents the loading of the rollup package as well as any transitive dependencies when these packages will not be used by the build.