### PR TITLE
fix(@angular/build): force HTTP/1.1 in dev-server SSR with SSL

### DIFF
--- a/packages/angular/build/src/builders/dev-server/vite-server.ts
+++ b/packages/angular/build/src/builders/dev-server/vite-server.ts
@@ -681,7 +681,15 @@ export async function setupServer(
       headers: serverOptions.headers,
       // Disable the websocket if live reload is disabled (false/undefined are the only valid values)
       ws: serverOptions.liveReload === false && serverOptions.hmr === false ? false : undefined,
-      proxy,
+      // When server-side rendering (SSR) is enabled togather with SSL and Express is being used,
+      // we must configure Vite to use HTTP/1.1.
+      // This is necessary because Express does not support HTTP/2.
+      // We achieve this by defining an empty proxy.
+      // See: https://github.com/vitejs/vite/blob/c4b532cc900bf988073583511f57bd581755d5e3/packages/vite/src/node/http.ts#L106
+      proxy:
+        serverOptions.ssl && ssrMode === ServerSsrMode.ExternalSsrMiddleware
+          ? (proxy ?? {})
+          : proxy,
       cors: {
         // Allow preflight requests to be proxied.
         preflightContinue: true,


### PR DESCRIPTION
When server-side rendering (SSR) is enabled with SSL and Express, Vite must use HTTP/1.1 because Express does not support HTTP/2. This is achieved by setting an empty proxy configuration.

Reference: https://github.com/vitejs/vite/blob/c4b532cc900bf988073583511f57bd581755d5e3/packages/vite/src/node/http.ts#L106

Closes #29142
