### PR TITLE
ci: ignore changes to `.yarn/releases`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,11 @@
   "labels": ["target: minor", "action: merge"],
   "timezone": "America/Tijuana",
   "postUpgradeTasks": {
-    "commands": ["yarn install --frozen-lockfile --non-interactive", "yarn bazel run @npm2//:sync"],
+    "commands": [
+      "git restore .yarn/releases/yarn-4.5.0.cjs",
+      "yarn install --frozen-lockfile --non-interactive",
+      "yarn bazel run @npm2//:sync"
+    ],
     "fileFilters": [".aspect/rules/external_repository_action_cache/**/*"],
     "executionMode": "branch"
   },


### PR DESCRIPTION
There is an unidentified issue causing the Yarn binary to be altered, resulting in packages not installing correctly and leading to failures in the process.
