### PR TITLE
ci: disable `pnpm-lock.yaml` update via renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,7 +14,7 @@
       "yarn install --frozen-lockfile --non-interactive",
       "yarn bazel run @npm2//:sync"
     ],
-    "fileFilters": [".aspect/rules/external_repository_action_cache/**/*"],
+    "fileFilters": [".aspect/rules/external_repository_action_cache/**/*", "pnpm-lock.yaml"],
     "executionMode": "branch"
   },
   "lockFileMaintenance": {
@@ -32,6 +32,10 @@
     ".github/workflows/**/*.yml"
   ],
   "packageRules": [
+    {
+      "matchManagers": ["pnpm"],
+      "enabled": false
+    },
     {
       "matchPackageNames": ["quicktype-core"],
       "schedule": ["before 4:00am on the first day of the month"]


### PR DESCRIPTION
This commit tries to display `pnpm-lock.yaml` update using renovate and instead it uses `yarn bazel run @npm2//:sync`.
