### PR TITLE
ci: ignore pnpm lock file update from renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -31,11 +31,8 @@
     "tests/legacy-cli/e2e/ng-snapshot/package.json",
     ".github/workflows/**/*.yml"
   ],
+  "ignorePaths": ["pnpm-lock.yaml"],
   "packageRules": [
-    {
-      "matchManagers": ["pnpm"],
-      "enabled": false
-    },
     {
       "matchPackageNames": ["quicktype-core"],
       "schedule": ["before 4:00am on the first day of the month"]


### PR DESCRIPTION
These files are updated by our tooling
