### PR TITLE
Renovate fixes

### DIFF
--- a/.aspect/rules/external_repository_action_cache/npm_translate_lock_MzA5NzUwNzMx
+++ b/.aspect/rules/external_repository_action_cache/npm_translate_lock_MzA5NzUwNzMx
@@ -2,7 +2,7 @@
 # Input hashes for repository rule npm_translate_lock(name = "npm2", pnpm_lock = "@//:pnpm-lock.yaml").
 # This file should be checked into version control along with the pnpm-lock.yaml file.
 .npmrc=-2023857461
-package.json=1044460161
-pnpm-lock.yaml=451366521
+package.json=1485890683
+pnpm-lock.yaml=-1807446371
 pnpm-workspace.yaml=1711114604
 yarn.lock=-892267542

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   },
   "engines": {
     "node": "^18.19.1 || ^20.11.1 || >=22.0.0",
-    "yarn": ">=1.21.1 <2",
     "npm": "Please use yarn instead of NPM to install dependencies"
   },
   "author": "Angular Authors",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2063,6 +2063,7 @@ packages:
 
   /@bazel/typescript@5.8.1(typescript@5.7.2):
     resolution: {integrity: sha512-NAJ8WQHZL1WE1YmRoCrq/1hhG15Mvy/viWh6TkvFnBeEhNUiQUsA5GYyhU1ztnBIYW03nATO3vwhAEfO7Q0U5g==}
+    deprecated: No longer maintained, https://github.com/aspect-build/rules_ts is the recommended replacement
     hasBin: true
     peerDependencies:
       typescript: 5.7.2

--- a/renovate.json
+++ b/renovate.json
@@ -31,7 +31,6 @@
     "tests/legacy-cli/e2e/ng-snapshot/package.json",
     ".github/workflows/**/*.yml"
   ],
-  "ignorePaths": ["pnpm-lock.yaml"],
   "packageRules": [
     {
       "matchPackageNames": ["quicktype-core"],

--- a/renovate.json
+++ b/renovate.json
@@ -38,6 +38,14 @@
       "schedule": ["before 4:00am on the first day of the month"]
     },
     {
+      "matchCurrentVersion": "0.0.0-PLACEHOLDER",
+      "enabled": false
+    },
+    {
+      "matchCurrentVersion": "0.0.0-EXPERIMENTAL-PLACEHOLDER",
+      "enabled": false
+    },
+    {
       "groupName": "angular",
       "matchDepNames": ["/^@angular/.*/", "/angular/dev-infra/"]
     },

--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,7 @@
     "commands": [
       "git restore .yarn/releases/yarn-4.5.0.cjs",
       "yarn install --frozen-lockfile --non-interactive",
+      "yarn bazel build //tools/...",
       "yarn bazel run @npm2//:sync"
     ],
     "fileFilters": [".aspect/rules/external_repository_action_cache/**/*", "pnpm-lock.yaml"],


### PR DESCRIPTION
**ci: remove `ignorePaths` paths for `pnpm-lock.yaml`**
This does not work as expected because the paths are expected to be package files.

**build: update `engines` field in `package.json`**
This commit removes the `yarn` engine field. The `packageManager` version was previously removed, causing Renovate to pick up an outdated Yarn version. Additionally, Yarn Berry does not use this field, rendering it unnecessary.

**build: workaround for `ERROR: An error occurred during the fetch of repository 'npm2'`**

In some cases `yarn bazel run @npm2//:sync` will fail in the first run see: https://github.com/aspect-build/rules_js/issues/1445 as a workaround we run a build before.

```
ERROR: An error occurred during the fetch of repository 'npm2':
   Traceback (most recent call last):
        File "/usr/local/google/home/alanagius/.cache/bazel/_bazel_alanagius/2fa837e4c5ce941f68b762e5f8e7dc4d/external/aspect_rules_js/npm/private/npm_translate_lock.bzl", line 112, column 21, in _npm_translate_lock_impl
                fail(msg)
Error in fail:

INFO: