### PR TITLE
bugfix: provide i18nDuplicateTranslation config value to checkDuplicateMessages function

### DIFF
--- a/packages/angular/build/src/builders/extract-i18n/builder.ts
+++ b/packages/angular/build/src/builders/extract-i18n/builder.ts
@@ -94,7 +94,7 @@ export async function execute(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     checkFileSystem as any,
     extractionResult.messages,
-    'warning',
+    normalizedOptions.i18nOptions.i18nDuplicateTranslation || 'warning',
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     extractionResult.basePath as any,
   );

--- a/packages/angular/build/src/utils/i18n-options.ts
+++ b/packages/angular/build/src/utils/i18n-options.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import { DiagnosticHandlingStrategy } from '@angular/localize/tools';
 import path from 'node:path';
 import type { TranslationLoader } from './load-translations';
 
@@ -28,6 +29,7 @@ export interface I18nOptions {
   flatOutput?: boolean;
   readonly shouldInline: boolean;
   hasDefinedSourceLocale?: boolean;
+  i18nDuplicateTranslation?: DiagnosticHandlingStrategy;
 }
 
 function normalizeTranslationFileOption(


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Current behaviour is described inside this issue - https://github.com/angular/angular-cli/issues/23635

Issue Number: #23635

## What is the new behavior?

Now we can add different values according to the `i18nDuplicateTranslation` option https://github.com/angular/angular-cli/blob/d99e4ed49359632657cd170524673dd9f4e88b82/goldens/public-api/angular/build/index.api.md?plain=1#L40 and have corresponding output, not hardcoded `warning`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
