### PR TITLE
test: disable WTR e2e test

### DIFF
--- a/tests/legacy-cli/e2e/tests/web-test-runner/basic.ts
+++ b/tests/legacy-cli/e2e/tests/web-test-runner/basic.ts
@@ -2,6 +2,9 @@ import { noSilentNg } from '../../utils/process';
 import { applyWtrBuilder } from '../../utils/web-test-runner';
 
 export default async function () {
+  // Temporary disabled due to failure.
+  return;
+
   await applyWtrBuilder();
 
   const { stderr } = await noSilentNg('test');


### PR DESCRIPTION
Temporary disable this test due to

```
Failed to launch local browser installed at /home/runner/.cache/bazel/_bazel_runner/f47b8283cc0f5922f9455b06771398a1/sandbox/processwrapper-sandbox/410/execroot/angular_cli/bazel-out/k8-fastbuild/bin/tests/legacy-cli/e2e.npm_node22.sh.runfiles/org_chromium_chromium_linux_x64/chrome-linux/chrome.
This could be because of a mismatch between the version of puppeteer and Chrome or Chromium.
Try updating either of them, or adjust the executablePath option to point to another browser installation. Use the --puppeteer flag to run tests with bundled compatible version of Chromium.

dist/test-out/c48222bb-ca34-455e-bc1b-122521e1e71e/app.component.spec.js:
```
