### PR TITLE
test: add `resolve/test/list-exports` to false positive in postinstall scripts check

### DIFF
--- a/tests/legacy-cli/e2e/tests/misc/check-postinstalls.ts
+++ b/tests/legacy-cli/e2e/tests/misc/check-postinstalls.ts
@@ -15,6 +15,7 @@ const POTENTIAL_SCRIPTS: ReadonlyArray<string> = ['preinstall', 'install', 'post
 const FALSE_POSITIVE_PATHS: ReadonlySet<string> = new Set([
   'jasmine-spec-reporter/examples/protractor/package.json',
   'resolve/test/resolver/multirepo/package.json',
+  'resolve/test/list-exports/packages/tests/fixtures/resolve-1/project/test/resolver/multirepo/package.json',
 ]);
 
 const INNER_NODE_MODULES_SEGMENT = '/node_modules/';


### PR DESCRIPTION


Added `resolve/test/list-exports/packages/tests/fixtures/resolve-1/project/test/resolver/multirepo/package.json as a false positive`
See: https://github.com/angular/angular-cli/actions/runs/12402554909/job/34638018185?pr=29134