### PR TITLE
test: add `--disable-dev-shm-usage` to address `WebDriverError: unknown error: Chrome failed to start: crashed`

### DIFF
--- a/modules/testing/builder/projects/hello-world-app/protractor.conf.js
+++ b/modules/testing/builder/projects/hello-world-app/protractor.conf.js
@@ -18,7 +18,7 @@ exports.config = {
   capabilities: {
     browserName: 'chrome',
     chromeOptions: {
-      args: ['--headless', '--disable-gpu', '--window-size=800,600'],
+      args: ['--headless', '--no-sandbox', '--disable-gpu', '--disable-dev-shm-usage'],
       binary: require('puppeteer').executablePath(),
     },
   },


### PR DESCRIPTION


This fixes an issue where protractor integration tests are failing with

```
[07:38:37] I/direct - Using ChromeDriver directly...
[07:38:39] E/launcher - unknown error: Chrome failed to start: crashed.
  (unknown error: DevToolsActivePort file doesn't exist)
```
