### PR TITLE
fix(@angular-devkit/build-angular): preserve css type for jasmine.css

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/karma/application_builder.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/application_builder.ts
@@ -156,7 +156,7 @@ class AngularPolyfillsPlugin {
               // page load. `type` won't affect them.
               continue;
             }
-            if ('js' === (f.type ?? 'js')) {
+            if (f.pattern.endsWith('.js') && 'js' === (f.type ?? 'js')) {
               f.type = 'module';
             }
           }


### PR DESCRIPTION
We should only force the type for files that we know are JavaScript. Otherwise we risk breaking the magic type detection done by Karma.

The previous code broke for `jasmine.css`.

Fixes https://github.com/angular/angular-cli/issues/29190