### PR TITLE
build: migrate `@ngtools/webpack` to `ts_project`

### DIFF
--- a/packages/ngtools/webpack/BUILD.bazel
+++ b/packages/ngtools/webpack/BUILD.bazel
@@ -5,15 +5,15 @@
 
 load("@npm//@angular/build-tooling/bazel/api-golden:index.bzl", "api_golden_test_npm_package")
 load("@npm//@bazel/jasmine:index.bzl", "jasmine_node_test")
-load("//tools:defaults.bzl", "pkg_npm", "ts_library")
+load("//tools:defaults.bzl", "pkg_npm")
+load("//tools:interop.bzl", "ts_project")
 
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
-ts_library(
+ts_project(
     name = "webpack",
-    package_name = "@ngtools/webpack",
     srcs = glob(
         include = [
             "src/**/*.ts",
@@ -22,21 +22,22 @@ ts_library(
             "src/**/*_spec.ts",
             "src/**/*_spec_helpers.ts",
         ],
-    ),
+    ) + [
+        "index.ts",
+    ],
     data = [
         "package.json",
     ],
     module_name = "@ngtools/webpack",
-    module_root = "src/index.d.ts",
     deps = [
-        "@npm//@angular/compiler-cli",
-        "@npm//@types/node",
-        "@npm//typescript",
-        "@npm//webpack",
+        "//:root_modules/@angular/compiler-cli",
+        "//:root_modules/@types/node",
+        "//:root_modules/typescript",
+        "//:root_modules/webpack",
     ],
 )
 
-ts_library(
+ts_project(
     name = "webpack_test_lib",
     testonly = True,
     srcs = glob(
@@ -45,23 +46,20 @@ ts_library(
             "src/**/*_spec_helpers.ts",
         ],
     ),
-    deps = [
-        ":webpack",
+    interop_deps = [
         "//packages/angular_devkit/core",
-        "@npm//@angular/compiler",
-        "@npm//jasmine",
-        "@npm//typescript",
+    ],
+    deps = [
+        ":webpack_rjs",
+        "//:root_modules/@angular/compiler",
+        "//:root_modules/@types/jasmine",
+        "//:root_modules/typescript",
     ],
 )
 
 jasmine_node_test(
     name = "webpack_test",
     srcs = [":webpack_test_lib"],
-    deps = [
-        "@npm//jasmine",
-        "@npm//source-map",
-        "@npm//tslib",
-    ],
 )
 
 genrule(

--- a/packages/ngtools/webpack/index.ts
+++ b/packages/ngtools/webpack/index.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+export * from './src/index';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,7 +31,7 @@
       "@angular/ssr": ["./packages/angular/ssr"],
       "@angular/*": ["./packages/angular/*/src"],
       "@angular/build/private": ["./packages/angular/build/src/private"],
-      "@ngtools/webpack": ["./packages/ngtools/webpack/src"],
+      "@ngtools/webpack": ["./packages/ngtools/webpack/index"],
       "@schematics/angular": ["./packages/schematics/angular"]
     }
   },


### PR DESCRIPTION
The `@ngtools/webpack` package has been migrated to the `rules_js` ts_project rule.

Other than the `index.ts` addition, no code changes were needed.