### PR TITLE
build: set a mnemonic for template expand and file write

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -174,3 +174,7 @@ try-import .bazelrc.user
 # Enable runfiles even on Windows.
 # Architect resolves output files from data files, and this isn't possible without runfile support.
 build --enable_runfiles
+
+# TODO: Determine if this is a permanent solution or not.
+build --strategy=TemplateExpand=local
+build --strategy=FileWrite=local


### PR DESCRIPTION
Set the mnemonic to determine if it allows us to reduce the number of RBE queries executed
