### PR TITLE
build: migrate `@angular-devkit/build-webpack` to `ts_project`

### DIFF
--- a/packages/angular_devkit/build_webpack/BUILD.bazel
+++ b/packages/angular_devkit/build_webpack/BUILD.bazel
@@ -5,7 +5,8 @@
 
 load("@npm//@angular/build-tooling/bazel/api-golden:index.bzl", "api_golden_test_npm_package")
 load("@npm//@bazel/jasmine:index.bzl", "jasmine_node_test")
-load("//tools:defaults.bzl", "pkg_npm", "ts_library")
+load("//tools:defaults.bzl", "pkg_npm")
+load("//tools:interop.bzl", "ts_project")
 load("//tools:ts_json_schema.bzl", "ts_json_schema")
 
 licenses(["notice"])
@@ -22,14 +23,13 @@ ts_json_schema(
     src = "src/builders/webpack-dev-server/schema.json",
 )
 
-ts_library(
+ts_project(
     name = "build_webpack",
-    package_name = "@angular-devkit/build-webpack",
     srcs = glob(
         include = ["src/**/*.ts"],
         exclude = [
             "src/test-utils.ts",
-            "src/**/*_spec.ts",
+            "**/*_spec.ts",
         ],
     ) + [
         "index.ts",
@@ -42,18 +42,19 @@ ts_library(
         "src/builders/webpack-dev-server/schema.json",
         "src/builders/webpack/schema.json",
     ],
-    module_name = "@angular-devkit/build-webpack",
-    module_root = "src/index.d.ts",
-    deps = [
+    interop_deps = [
         "//packages/angular_devkit/architect",
-        "@npm//@types/node",
-        "@npm//rxjs",
-        "@npm//webpack",
-        "@npm//webpack-dev-server",
+    ],
+    module_name = "@angular-devkit/build-webpack",
+    deps = [
+        "//:root_modules/@types/node",
+        "//:root_modules/rxjs",
+        "//:root_modules/webpack",
+        "//:root_modules/webpack-dev-server",
     ],
 )
 
-ts_library(
+ts_project(
     name = "build_webpack_test_lib",
     testonly = True,
     srcs = glob(
@@ -66,34 +67,32 @@ ts_library(
             "test/**/*",
         ],
     ),
-    deps = [
-        ":build_webpack",
-        "//packages/angular_devkit/architect",
-        "//packages/angular_devkit/architect/node",
-        "//packages/angular_devkit/architect/testing",
+    interop_deps = [
         "//packages/angular_devkit/core",
         "//packages/angular_devkit/core/node",
         "//packages/ngtools/webpack",
-        "@npm//@angular/common",
-        "@npm//@angular/compiler",
-        "@npm//@angular/compiler-cli",
-        "@npm//@angular/core",
-        "@npm//@angular/platform-browser",
-        "@npm//@angular/platform-browser-dynamic",
-        "@npm//tslib",
-        "@npm//zone.js",
+        "//packages/angular_devkit/architect",
+        "//packages/angular_devkit/architect/node",
+        "//packages/angular_devkit/architect/testing",
+    ],
+    deps = [
+        ":build_webpack_rjs",
+        "//:root_modules/@types/jasmine",
     ],
 )
 
 jasmine_node_test(
     name = "build_webpack_test",
     srcs = [":build_webpack_test_lib"],
-    # Turns off nodejs require patches and turns on the linker, which sets up up node_modules
-    # so that standard node module resolution work.
-    templated_args = ["--nobazel_patch_module_resolver"],
-    deps = [
-        "@npm//jasmine",
-        "@npm//source-map",
+    data = [
+        "//:root_modules/@angular/common",
+        "//:root_modules/@angular/compiler",
+        "//:root_modules/@angular/compiler-cli",
+        "//:root_modules/@angular/core",
+        "//:root_modules/@angular/platform-browser",
+        "//:root_modules/@angular/platform-browser-dynamic",
+        "//:root_modules/tslib",
+        "//:root_modules/zone.js",
     ],
 )
 


### PR DESCRIPTION
The `@angular-devkit/build-webpack` package has been migrated to the `rules_js` ts_project rule.