### PR TITLE
build: migrate `@angular/cli` to `ts_project`

### DIFF
--- a/packages/angular/cli/BUILD.bazel
+++ b/packages/angular/cli/BUILD.bazel
@@ -4,7 +4,8 @@
 # found in the LICENSE file at https://angular.dev/license
 
 load("@npm//@bazel/jasmine:index.bzl", "jasmine_node_test")
-load("//tools:defaults.bzl", "pkg_npm", "ts_library")
+load("//tools:defaults.bzl", "pkg_npm")
+load("//tools:interop.bzl", "ts_project")
 load("//tools:ng_cli_schema_generator.bzl", "cli_json_schema")
 load("//tools:ts_json_schema.bzl", "ts_json_schema")
 
@@ -12,9 +13,8 @@ licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
-ts_library(
+ts_project(
     name = "angular-cli",
-    package_name = "@angular/cli",
     srcs = glob(
         include = [
             "lib/**/*.ts",
@@ -24,11 +24,9 @@ ts_library(
             "**/*_spec.ts",
         ],
     ) + [
-        # @external_begin
         # These files are generated from the JSON schema
         "//packages/angular/cli:lib/config/workspace-schema.ts",
         "//packages/angular/cli:src/commands/update/schematic/schema.ts",
-        # @external_end
     ],
     data = glob(
         include = [
@@ -40,43 +38,42 @@ ts_library(
             "lib/config/workspace-schema.json",
         ],
     ) + [
-        # @external_begin
         "//packages/angular/cli:lib/config/schema.json",
-        # @external_end
     ],
-    module_name = "@angular/cli",
-    deps = [
-        "//packages/angular_devkit/architect",
-        "//packages/angular_devkit/architect/node",
-        "//packages/angular_devkit/core",
-        "//packages/angular_devkit/core/node",
+    interop_deps = [
         "//packages/angular_devkit/schematics",
         "//packages/angular_devkit/schematics/tasks",
         "//packages/angular_devkit/schematics/tools",
-        "@npm//@angular/core",
-        "@npm//@inquirer/prompts",
-        "@npm//@listr2/prompt-adapter-inquirer",
-        "@npm//@types/ini",
-        "@npm//@types/node",
-        "@npm//@types/npm-package-arg",
-        "@npm//@types/pacote",
-        "@npm//@types/resolve",
-        "@npm//@types/semver",
-        "@npm//@types/yargs",
-        "@npm//@types/yarnpkg__lockfile",
-        "@npm//@yarnpkg/lockfile",
-        "@npm//ini",
-        "@npm//jsonc-parser",
-        "@npm//listr2",
-        "@npm//npm-package-arg",
-        "@npm//npm-pick-manifest",
-        "@npm//pacote",
-        "@npm//semver",
-        "@npm//yargs",
+    ],
+    module_name = "@angular/cli",
+    deps = [
+        "//:root_modules/@angular/core",
+        "//:root_modules/@inquirer/prompts",
+        "//:root_modules/@listr2/prompt-adapter-inquirer",
+        "//:root_modules/@types/ini",
+        "//:root_modules/@types/node",
+        "//:root_modules/@types/npm-package-arg",
+        "//:root_modules/@types/pacote",
+        "//:root_modules/@types/resolve",
+        "//:root_modules/@types/semver",
+        "//:root_modules/@types/yargs",
+        "//:root_modules/@types/yarnpkg__lockfile",
+        "//:root_modules/@yarnpkg/lockfile",
+        "//:root_modules/ini",
+        "//:root_modules/jsonc-parser",
+        "//:root_modules/listr2",
+        "//:root_modules/npm-package-arg",
+        "//:root_modules/npm-pick-manifest",
+        "//:root_modules/pacote",
+        "//:root_modules/semver",
+        "//:root_modules/yargs",
+        "//packages/angular_devkit/architect:architect_rjs",
+        "//packages/angular_devkit/architect/node:node_rjs",
+        "//packages/angular_devkit/core:core_rjs",
+        "//packages/angular_devkit/core/node:node_rjs",
     ],
 )
 
-# @external_begin
 CLI_SCHEMA_DATA = [
     "//packages/angular/build:src/builders/application/schema.json",
     "//packages/angular/build:src/builders/dev-server/schema.json",
@@ -131,7 +128,7 @@ ts_json_schema(
     src = "src/commands/update/schematic/schema.json",
 )
 
-ts_library(
+ts_project(
     name = "angular-cli_test_lib",
     testonly = True,
     srcs = glob(
@@ -141,13 +138,15 @@ ts_library(
             "node_modules/**",
         ],
     ),
-    deps = [
-        ":angular-cli",
-        "//packages/angular_devkit/core",
+    interop_deps = [
         "//packages/angular_devkit/schematics",
         "//packages/angular_devkit/schematics/testing",
-        "@npm//@types/semver",
-        "@npm//@types/yargs",
+    ],
+    deps = [
+        ":angular-cli_rjs",
+        "//:root_modules/@types/semver",
+        "//:root_modules/@types/yargs",
+        "//packages/angular_devkit/core:core_rjs",
     ],
 )
 
@@ -182,4 +181,3 @@ pkg_npm(
         ":src/commands/update/schematic/schema.json",
     ],
 )
-# @external_end


### PR DESCRIPTION
The `@angular/cli` package has been migrated to the `rules_js` ts_project rule.