### PR TITLE
build: migrate E2E tests to `ts_project`

### DIFF
--- a/tests/legacy-cli/BUILD.bazel
+++ b/tests/legacy-cli/BUILD.bazel
@@ -1,7 +1,7 @@
-load("//tools:defaults.bzl", "ts_library")
+load("//tools:interop.bzl", "ts_project")
 load(":e2e.bzl", "e2e_suites")
 
-ts_library(
+ts_project(
     name = "runner",
     testonly = True,
     srcs = [
@@ -12,11 +12,11 @@ ts_library(
         "verdaccio_auth.yaml",
     ],
     deps = [
-        "//packages/angular_devkit/core",
-        "//packages/angular_devkit/core/node",
-        "//tests/legacy-cli/e2e/utils",
-        "@npm//ansi-colors",
-        "@npm//fast-glob",
+        "//:root_modules/ansi-colors",
+        "//:root_modules/fast-glob",
+        "//packages/angular_devkit/core:core_rjs",
+        "//packages/angular_devkit/core/node:node_rjs",
+        "//tests/legacy-cli/e2e/utils:utils_rjs",
     ],
 )
 

--- a/tests/legacy-cli/e2e/initialize/BUILD.bazel
+++ b/tests/legacy-cli/e2e/initialize/BUILD.bazel
@@ -1,14 +1,15 @@
-load("//tools:defaults.bzl", "ts_library")
+load("//tools:interop.bzl", "ts_project")
 
-ts_library(
+package(default_visibility = ["//visibility:public"])
+
+ts_project(
     name = "initialize",
     testonly = True,
     srcs = glob(["**/*.ts"]),
     data = [
         "//:config-files",
     ],
-    visibility = ["//visibility:public"],
     deps = [
-        "//tests/legacy-cli/e2e/utils",
+        "//tests/legacy-cli/e2e/utils:utils_rjs",
     ],
 )

--- a/tests/legacy-cli/e2e/setup/BUILD.bazel
+++ b/tests/legacy-cli/e2e/setup/BUILD.bazel
@@ -1,11 +1,12 @@
-load("//tools:defaults.bzl", "ts_library")
+load("//tools:interop.bzl", "ts_project")
 
-ts_library(
+package(default_visibility = ["//visibility:public"])
+
+ts_project(
     name = "setup",
     testonly = True,
     srcs = glob(["**/*.ts"]),
-    visibility = ["//visibility:public"],
     deps = [
-        "//tests/legacy-cli/e2e/utils",
+        "//tests/legacy-cli/e2e/utils:utils_rjs",
     ],
 )

--- a/tests/legacy-cli/e2e/tests/BUILD.bazel
+++ b/tests/legacy-cli/e2e/tests/BUILD.bazel
@@ -1,19 +1,20 @@
-load("//tools:defaults.bzl", "ts_library")
+load("//tools:interop.bzl", "ts_project")
 
-ts_library(
+package(default_visibility = ["//visibility:public"])
+
+ts_project(
     name = "tests",
     testonly = True,
     srcs = glob(["**/*.ts"]),
     data = [
         "//tests/legacy-cli/e2e/ng-snapshot",
     ],
-    visibility = ["//visibility:public"],
     deps = [
-        "//tests/legacy-cli/e2e/utils",
-        "@npm//@types/express",
-        "@npm//@types/semver",
-        "@npm//express",
-        "@npm//fast-glob",
-        "@npm//semver",
+        "//:root_modules/@types/express",
+        "//:root_modules/@types/semver",
+        "//:root_modules/express",
+        "//:root_modules/fast-glob",
+        "//:root_modules/semver",
+        "//tests/legacy-cli/e2e/utils:utils_rjs",
     ],
 )

--- a/tests/legacy-cli/e2e/utils/BUILD.bazel
+++ b/tests/legacy-cli/e2e/utils/BUILD.bazel
@@ -1,24 +1,26 @@
-load("//tools:defaults.bzl", "ts_library")
+load("//tools:interop.bzl", "ts_project")
 
-ts_library(
+package(default_visibility = ["//visibility:public"])
+
+ts_project(
     name = "utils",
     testonly = True,
     srcs = glob(["**/*.ts"]),
     data = [
         "//tests/legacy-cli/e2e/ng-snapshot",
     ],
-    visibility = ["//visibility:public"],
     deps = [
-        "@npm//@types/semver",
-        "@npm//ansi-colors",
-        "@npm//fast-glob",
-        "@npm//npm",
-        "@npm//protractor",
-        "@npm//rxjs",
-        "@npm//semver",
-        "@npm//tar",
-        "@npm//tree-kill",
-        "@npm//verdaccio",
-        "@npm//verdaccio-auth-memory",
+        "//:root_modules/@types/jasmine",
+        "//:root_modules/@types/semver",
+        "//:root_modules/ansi-colors",
+        "//:root_modules/fast-glob",
+        "//:root_modules/npm",
+        "//:root_modules/protractor",
+        "//:root_modules/rxjs",
+        "//:root_modules/semver",
+        "//:root_modules/tar",
+        "//:root_modules/tree-kill",
+        "//:root_modules/verdaccio",
+        "//:root_modules/verdaccio-auth-memory",
     ],
 )

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -42,7 +42,6 @@
     "**/node_modules/**/*",
     "**/third_party/**/*",
     "packages/angular_devkit/schematics_cli/schematic/files/**/*",
-    "packages/angular_devkit/*/test/**/*",
-    "tests/**/*"
+    "packages/angular_devkit/*/test/**/*"
   ]
 }


### PR DESCRIPTION
The E2E tests have been migrated to the `rules_js` ts_project rule.