### PR TITLE
perf(@angular-devkit/schematics): migrate to picospinner

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,11 +163,11 @@
     "npm-package-arg": "12.0.1",
     "npm-pick-manifest": "10.0.0",
     "open": "10.1.0",
-    "ora": "5.4.1",
     "pacote": "20.0.0",
     "parse5-html-rewriting-stream": "7.0.0",
     "patch-package": "^8.0.0",
     "picomatch": "4.0.2",
+    "picospinner": "2.0.0",
     "piscina": "4.8.0",
     "postcss": "8.4.49",
     "postcss-loader": "8.1.1",
@@ -222,5 +222,6 @@
   },
   "resolutions": {
     "typescript": "5.7.2"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/packages/angular_devkit/build_angular/BUILD.bazel
+++ b/packages/angular_devkit/build_angular/BUILD.bazel
@@ -181,7 +181,7 @@ ts_project(
         "//:root_modules/mini-css-extract-plugin",
         "//:root_modules/ng-packagr",
         "//:root_modules/open",
-        "//:root_modules/ora",
+        "//:root_modules/picospinner",
         "//:root_modules/piscina",
         "//:root_modules/postcss",
         "//:root_modules/postcss-loader",

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -41,7 +41,7 @@
     "loader-utils": "3.3.1",
     "mini-css-extract-plugin": "2.9.2",
     "open": "10.1.0",
-    "ora": "5.4.1",
+    "picospinner": "2.0.0",
     "picomatch": "4.0.2",
     "piscina": "4.8.0",
     "postcss": "8.4.49",

--- a/packages/angular_devkit/build_angular/src/builders/prerender/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/prerender/index.ts
@@ -15,7 +15,7 @@ import {
 } from '@angular-devkit/architect';
 import * as fs from 'fs';
 import { readFile } from 'node:fs/promises';
-import ora from 'ora';
+import { Spinner } from 'picospinner';
 import * as path from 'path';
 import Piscina from 'piscina';
 import { normalizeOptimization } from '../../utils';
@@ -198,7 +198,8 @@ async function _renderUniversal(
         context.workspaceRoot,
       );
 
-      const spinner = ora(`Prerendering ${routes.length} route(s) to ${outputPath}...`).start();
+      const spinner = new Spinner(`Prerendering ${routes.length} route(s) to ${outputPath}...`);
+      spinner.start();
 
       try {
         const results = (await Promise.all(
@@ -236,7 +237,8 @@ async function _renderUniversal(
       spinner.succeed(`Prerendering routes to ${outputPath} complete.`);
 
       if (browserOptions.serviceWorker) {
-        spinner.start('Generating service worker...');
+        spinner.setText('Generating service worker...');
+        spinner.start();
         try {
           await augmentAppWithServiceWorker(
             projectRoot,

--- a/packages/angular_devkit/build_angular/src/utils/spinner.ts
+++ b/packages/angular_devkit/build_angular/src/utils/spinner.ts
@@ -6,53 +6,51 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import ora from 'ora';
+import { Spinner as PicoSpinner } from 'picospinner';
 import { colors } from './color';
 import { isTTY } from './tty';
 
 export class Spinner {
-  private readonly spinner: ora.Ora;
+  private readonly spinner?: PicoSpinner;
 
   /** When false, only fail messages will be displayed. */
   enabled = true;
   readonly #isTTY = isTTY();
 
   constructor(text?: string) {
-    this.spinner = ora({
-      text: text === undefined ? undefined : text + '\n',
-      // The below 2 options are needed because otherwise CTRL+C will be delayed
-      // when the underlying process is sync.
-      hideCursor: false,
-      discardStdin: false,
-      isEnabled: this.#isTTY,
-    });
+    if (this.#isTTY) {
+      this.spinner = new PicoSpinner(text === undefined ? undefined : text + '\n');
+    }
   }
 
   set text(text: string) {
-    this.spinner.text = text;
+    this.spinner?.setText(text);
   }
 
   get isSpinning(): boolean {
-    return this.spinner.isSpinning || !this.#isTTY;
+    return this.spinner?.running || !this.#isTTY;
   }
 
   succeed(text?: string): void {
     if (this.enabled) {
-      this.spinner.succeed(text);
+      this.spinner?.succeed(text);
     }
   }
 
   fail(text?: string): void {
-    this.spinner.fail(text && colors.redBright(text));
+    this.spinner?.fail(text && colors.redBright(text));
   }
 
   stop(): void {
-    this.spinner.stop();
+    this.spinner?.stop();
   }
 
   start(text?: string): void {
     if (this.enabled) {
-      this.spinner.start(text);
+      if (text) {
+        this.text = text;
+      }
+      this.spinner?.start();
     }
   }
 }

--- a/packages/angular_devkit/schematics/package.json
+++ b/packages/angular_devkit/schematics/package.json
@@ -16,7 +16,7 @@
     "@angular-devkit/core": "0.0.0-PLACEHOLDER",
     "jsonc-parser": "3.3.1",
     "magic-string": "0.30.17",
-    "ora": "5.4.1",
+    "picospinner": "2.0.0",
     "rxjs": "7.8.1"
   }
 }

--- a/packages/angular_devkit/schematics/tasks/BUILD.bazel
+++ b/packages/angular_devkit/schematics/tasks/BUILD.bazel
@@ -25,7 +25,7 @@ ts_library(
         "//packages/angular_devkit/core/node",
         "//packages/angular_devkit/schematics",
         "@npm//@types/node",
-        "@npm//ora",
+        "@npm//picospinner",
         "@npm//rxjs",
         "@npm//typescript",
     ],

--- a/packages/angular_devkit/schematics/tasks/package-manager/executor.ts
+++ b/packages/angular_devkit/schematics/tasks/package-manager/executor.ts
@@ -8,7 +8,7 @@
 
 import { BaseException } from '@angular-devkit/core';
 import { SpawnOptions, spawn } from 'child_process';
-import ora from 'ora';
+import { Spinner } from 'picospinner';
 import * as path from 'path';
 import { Observable } from 'rxjs';
 import { TaskExecutor, UnsuccessfulWorkflowExecution } from '../../src';
@@ -128,11 +128,8 @@ export default function (
     }
 
     return new Observable((obs) => {
-      const spinner = ora({
-        text: `Installing packages (${taskPackageManagerName})...`,
-        // Workaround for https://github.com/sindresorhus/ora/issues/136.
-        discardStdin: process.platform != 'win32',
-      }).start();
+      const spinner = new Spinner(`Installing packages (${taskPackageManagerName})...`);
+      spinner.start();
       const childProcess = spawn(taskPackageManagerName, args, spawnOptions).on(
         'close',
         (code: number) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -379,9 +379,6 @@ importers:
       open:
         specifier: 10.1.0
         version: 10.1.0
-      ora:
-        specifier: 5.4.1
-        version: 5.4.1
       pacote:
         specifier: 20.0.0
         version: 20.0.0
@@ -394,6 +391,9 @@ importers:
       picomatch:
         specifier: 4.0.2
         version: 4.0.2
+      picospinner:
+        specifier: 2.0.0
+        version: 2.0.0
       piscina:
         specifier: 4.8.0
         version: 4.8.0
@@ -11692,6 +11692,11 @@ packages:
   /picomatch@4.0.2:
     resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
     engines: {node: '>=12'}
+    dev: true
+
+  /picospinner@2.0.0:
+    resolution: {integrity: sha512-bRX16jAx5sDlSAEKJ26hKloGU+w2DIkGw0qeUn87WkT8xircacGumNFHS0d/s51S9QbrtoEFwRSAvIvHNstfjA==}
+    engines: {node: '>=18.0.0'}
     dev: true
 
   /pify@2.3.0:

--- a/yarn.lock
+++ b/yarn.lock
@@ -430,11 +430,11 @@ __metadata:
     npm-package-arg: "npm:12.0.1"
     npm-pick-manifest: "npm:10.0.0"
     open: "npm:10.1.0"
-    ora: "npm:5.4.1"
     pacote: "npm:20.0.0"
     parse5-html-rewriting-stream: "npm:7.0.0"
     patch-package: "npm:^8.0.0"
     picomatch: "npm:4.0.2"
+    picospinner: "npm:2.0.0"
     piscina: "npm:4.8.0"
     postcss: "npm:8.4.49"
     postcss-loader: "npm:8.1.1"
@@ -14053,7 +14053,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ora@npm:5.4.1, ora@npm:^5.1.0":
+"ora@npm:^5.1.0":
   version: 5.4.1
   resolution: "ora@npm:5.4.1"
   dependencies:
@@ -14529,6 +14529,13 @@ __metadata:
   version: 2.3.1
   resolution: "picomatch@npm:2.3.1"
   checksum: 10c0/26c02b8d06f03206fc2ab8d16f19960f2ff9e81a658f831ecb656d8f17d9edc799e8364b1f4a7873e89d9702dff96204be0fa26fe4181f6843f040f819dac4be
+  languageName: node
+  linkType: hard
+
+"picospinner@npm:2.0.0":
+  version: 2.0.0
+  resolution: "picospinner@npm:2.0.0"
+  checksum: 10c0/f8e4cca484f093c2483e1bc9644e637c297b2f0b45de80a0697690bcde25540d413920abed6fea1d3ce1718518474a3d169ebae6101e0733bd31742cd7e85ee1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Migrates from `ora` to `picospinner` for CLI spinners.

This is a much lighter and faster package, giving us some gains in performance.

Note that most popular spinner libraries are _meant_ to ignore/clear output while they are running. So previous workarounds and notes around that will need to be re-discussed.

## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No