### PR TITLE
build: migrate `@angular-devkit/schematics` to `ts_project`

### DIFF
--- a/packages/angular_devkit/schematics/BUILD.bazel
+++ b/packages/angular_devkit/schematics/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@npm//@angular/build-tooling/bazel/api-golden:index.bzl", "api_golden_test_npm_package")
 load("@npm//@bazel/jasmine:index.bzl", "jasmine_node_test")
-load("//tools:defaults.bzl", "pkg_npm", "ts_library")
+load("//tools:defaults.bzl", "pkg_npm")
+load("//tools:interop.bzl", "ts_project")
 
 # Copyright Google Inc. All Rights Reserved.
 #
@@ -12,52 +13,49 @@ licenses(["notice"])
 
 # @angular-devkit/schematics
 
-ts_library(
+ts_project(
     name = "schematics",
-    package_name = "@angular-devkit/schematics",
     srcs = glob(
         include = ["src/**/*.ts"],
         exclude = [
             "src/**/*_spec.ts",
         ],
-    ),
+    ) + ["index.ts"],
     data = [
         "package.json",
     ],
-    module_name = "@angular-devkit/schematics",
-    module_root = "src/index.d.ts",
-    deps = [
+    interop_deps = [
         "//packages/angular_devkit/core",
         "//packages/angular_devkit/core/node",  # TODO: get rid of this for 6.0
-        "@npm//@types/node",
-        "@npm//jsonc-parser",
-        "@npm//magic-string",
-        "@npm//rxjs",
+    ],
+    module_name = "@angular-devkit/schematics",
+    deps = [
+        "//:root_modules/@types/node",
+        "//:root_modules/jsonc-parser",
+        "//:root_modules/magic-string",
+        "//:root_modules/rxjs",
     ],
 )
 
-# @external_begin
-
-ts_library(
+ts_project(
     name = "schematics_test_lib",
     testonly = True,
     srcs = glob(["src/**/*_spec.ts"]),
-    deps = [
-        ":schematics",
+    interop_deps = [
         "//packages/angular_devkit/core",
         "//packages/angular_devkit/core/node",
         "//packages/angular_devkit/schematics/testing",
-        "@npm//rxjs",
+    ],
+    deps = [
+        ":schematics_rjs",
+        "//:root_modules/@types/jasmine",
+        "//:root_modules/rxjs",
     ],
 )
 
 jasmine_node_test(
     name = "schematics_test",
-    srcs = [":schematics_test_lib"],
-    deps = [
-        "@npm//jasmine",
-        "@npm//source-map",
-    ],
+    deps = [":schematics_test_lib"],
 )
 
 genrule(
@@ -96,4 +94,3 @@ api_golden_test_npm_package(
     npm_package = "angular_cli/packages/angular_devkit/schematics/npm_package",
     types = ["@npm//@types/node"],
 )
-# @external_end

--- a/packages/angular_devkit/schematics/index.ts
+++ b/packages/angular_devkit/schematics/index.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+export * from './src/index';

--- a/packages/angular_devkit/schematics/tasks/BUILD.bazel
+++ b/packages/angular_devkit/schematics/tasks/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//tools:defaults.bzl", "ts_library")
+load("//tools:interop.bzl", "ts_project")
 
 # Copyright Google Inc. All Rights Reserved.
 #
@@ -8,7 +8,7 @@ licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
-ts_library(
+ts_project(
     name = "tasks",
     srcs = glob(
         include = ["**/*.ts"],
@@ -18,15 +18,15 @@ ts_library(
         ],
     ),
     data = ["package.json"],
-    module_name = "@angular-devkit/schematics/tasks",
-    module_root = "index.d.ts",
-    deps = [
+    interop_deps = [
         "//packages/angular_devkit/core",
         "//packages/angular_devkit/core/node",
         "//packages/angular_devkit/schematics",
-        "@npm//@types/node",
-        "@npm//ora",
-        "@npm//rxjs",
-        "@npm//typescript",
+    ],
+    module_name = "@angular-devkit/schematics/tasks",
+    deps = [
+        "//:root_modules/@types/node",
+        "//:root_modules/ora",
+        "//:root_modules/rxjs",
     ],
 )

--- a/packages/angular_devkit/schematics/tasks/node/BUILD.bazel
+++ b/packages/angular_devkit/schematics/tasks/node/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//tools:defaults.bzl", "ts_library")
+load("//tools:interop.bzl", "ts_project")
 
 # Copyright Google Inc. All Rights Reserved.
 #
@@ -8,7 +8,7 @@ licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
-ts_library(
+ts_project(
     name = "node",
     srcs = glob(
         include = ["**/*.ts"],
@@ -16,14 +16,15 @@ ts_library(
             "**/*_spec.ts",
         ],
     ),
-    module_name = "@angular-devkit/schematics/tasks/node",
-    module_root = "index.d.ts",
-    deps = [
+    interop_deps = [
         "//packages/angular_devkit/core",
         "//packages/angular_devkit/core/node",
         "//packages/angular_devkit/schematics",
         "//packages/angular_devkit/schematics/tasks",
-        "@npm//@types/node",
-        "@npm//rxjs",
+    ],
+    module_name = "@angular-devkit/schematics/tasks/node",
+    deps = [
+        "//:root_modules/@types/node",
+        "//:root_modules/rxjs",
     ],
 )

--- a/packages/angular_devkit/schematics/testing/BUILD.bazel
+++ b/packages/angular_devkit/schematics/testing/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//tools:defaults.bzl", "ts_library")
+load("//tools:interop.bzl", "ts_project")
 
 # Copyright Google Inc. All Rights Reserved.
 #
@@ -8,21 +8,20 @@ licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
-ts_library(
+ts_project(
     name = "testing",
     srcs = glob(
         include = ["**/*.ts"],
     ),
     data = ["package.json"],
-    module_name = "@angular-devkit/schematics/testing",
-    module_root = "index.d.ts",
-    deps = [
+    interop_deps = [
         "//packages/angular_devkit/core",
         "//packages/angular_devkit/schematics",
-        "//packages/angular_devkit/schematics/tasks",
         "//packages/angular_devkit/schematics/tasks/node",
         "//packages/angular_devkit/schematics/tools",
-        "@npm//@types/node",
-        "@npm//rxjs",
+    ],
+    module_name = "@angular-devkit/schematics/testing",
+    deps = [
+        "//:root_modules/rxjs",
     ],
 )

--- a/packages/angular_devkit/schematics/tools/BUILD.bazel
+++ b/packages/angular_devkit/schematics/tools/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@npm//@bazel/jasmine:index.bzl", "jasmine_node_test")
-load("//tools:defaults.bzl", "ts_library")
+load("//tools:interop.bzl", "ts_project")
 
 # Copyright Google Inc. All Rights Reserved.
 #
@@ -9,7 +9,7 @@ licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
-ts_library(
+ts_project(
     name = "tools",
     srcs = glob(
         include = ["**/*.ts"],
@@ -19,23 +19,22 @@ ts_library(
         ],
     ),
     data = ["package.json"],
-    module_name = "@angular-devkit/schematics/tools",
-    module_root = "index.d.ts",
-    deps = [
+    interop_deps = [
         "//packages/angular_devkit/core",
         "//packages/angular_devkit/core/node",
         "//packages/angular_devkit/schematics",
         "//packages/angular_devkit/schematics/tasks",
         "//packages/angular_devkit/schematics/tasks/node",
-        "@npm//@types/node",
-        "@npm//jsonc-parser",
-        "@npm//rxjs",
+    ],
+    module_name = "@angular-devkit/schematics/tools",
+    deps = [
+        "//:root_modules/@types/node",
+        "//:root_modules/jsonc-parser",
+        "//:root_modules/rxjs",
     ],
 )
 
-# @external_begin
-
-ts_library(
+ts_project(
     name = "tools_test_lib",
     testonly = True,
     srcs = glob(
@@ -44,24 +43,22 @@ ts_library(
             "test/**/*.ts",
         ],
     ),
-    deps = [
-        ":tools",
+    interop_deps = [
         "//packages/angular_devkit/core",
         "//packages/angular_devkit/core/node",
         "//packages/angular_devkit/schematics",
         "//packages/angular_devkit/schematics/tasks",
         "//packages/angular_devkit/schematics/testing",
         "//tests/angular_devkit/schematics/tools/file-system-engine-host:file_system_engine_host_test_lib",
-        "@npm//rxjs",
+    ],
+    deps = [
+        ":tools_rjs",
+        "//:root_modules/@types/jasmine",
+        "//:root_modules/rxjs",
     ],
 )
 
 jasmine_node_test(
     name = "tools_test",
-    srcs = [":tools_test_lib"],
-    deps = [
-        "@npm//jasmine",
-        "@npm//source-map",
-    ],
+    deps = [":tools_test_lib"],
 )
-# @external_end

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,18 +16,9 @@
     "rootDir": ".",
     "rootDirs": [".", "./dist-schema/bin/"],
     "paths": {
-      "@angular-devkit/core/node": ["./packages/angular_devkit/core/node/index"],
-      "@angular-devkit/core/node/testing": ["./packages/angular_devkit/core/node/testing/index"],
-      "@angular-devkit/schematics/tasks": ["./packages/angular_devkit/schematics/tasks/index"],
-      "@angular-devkit/schematics/tasks/node": [
-        "./packages/angular_devkit/schematics/tasks/node/index"
-      ],
-      "@angular-devkit/schematics/tools": ["./packages/angular_devkit/schematics/tools/index"],
-      "@angular-devkit/schematics/testing": ["./packages/angular_devkit/schematics/testing/index"],
-      "@angular-devkit/architect/*": ["./packages/angular_devkit/architect/*/index"],
       "@angular-devkit/build-webpack": ["./packages/angular_devkit/build_webpack"],
       "@angular-devkit/build-angular": ["./packages/angular_devkit/build_angular"],
-      "@angular-devkit/*": ["./packages/angular_devkit/*/src"],
+      "@angular-devkit/*": ["./packages/angular_devkit/*/index"],
       "@angular/ssr": ["./packages/angular/ssr"],
       "@angular/ssr/node": ["./packages/angular/ssr/node"],
       "@angular/*": ["./packages/angular/*/src"],


### PR DESCRIPTION
The `@angular-devkit/schematics` package has been migrated to the `rules_js` ts_project rule. The tsconfig path mappings for the `@angular-devkit` scope have also been cleaned up now that all the packages within this scope have been migrated.