### PR TITLE
fix(@angular/build): do not mark Babel _defineProperty helper function as pure

### DIFF
--- a/packages/angular/build/src/tools/babel/plugins/pure-toplevel-functions.ts
+++ b/packages/angular/build/src/tools/babel/plugins/pure-toplevel-functions.ts
@@ -32,6 +32,18 @@ function isTslibHelperName(name: string): boolean {
   return tslibHelpers.has(originalName);
 }
 
+const babelHelpers = new Set<string>(['_defineProperty']);
+
+/**
+ * Determinates whether an identifier name matches one of the Babel helper function names.
+ *
+ * @param name The identifier name to check.
+ * @returns True, if the name matches a Babel helper name; otherwise, false.
+ */
+function isBabelHelperName(name: string): boolean {
+  return babelHelpers.has(name);
+}
+
 /**
  * A babel plugin factory function for adding the PURE annotation to top-level new and call expressions.
  *
@@ -53,9 +65,12 @@ export default function (): PluginObj {
         ) {
           return;
         }
-        // Do not annotate TypeScript helpers emitted by the TypeScript compiler.
-        // TypeScript helpers are intended to cause side effects.
-        if (callee.isIdentifier() && isTslibHelperName(callee.node.name)) {
+        // Do not annotate TypeScript helpers emitted by the TypeScript compiler or Babel helpers.
+        // They are intended to cause side effects.
+        if (
+          callee.isIdentifier() &&
+          (isTslibHelperName(callee.node.name) || isBabelHelperName(callee.node.name))
+        ) {
           return;
         }
 

--- a/packages/angular/build/src/tools/babel/plugins/pure-toplevel-functions_spec.ts
+++ b/packages/angular/build/src/tools/babel/plugins/pure-toplevel-functions_spec.ts
@@ -131,6 +131,18 @@ describe('pure-toplevel-functions Babel plugin', () => {
   );
 
   it(
+    'does not annotate _defineProperty function',
+    testCaseNoChange(`
+      class LanguageState {}
+      _defineProperty(
+        LanguageState,
+        'property',
+        'value'
+      );
+    `),
+  );
+
+  it(
     'does not annotate object literal methods',
     testCaseNoChange(`
       const literal = {


### PR DESCRIPTION
Fixes #29145

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [ ] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

_defineProperty is marked as pure and then tree shaken when targeting Safari < 15 or Chrome < 84 which breaks the application.

Issue Number: #29145

## What is the new behavior?

_defineProperty is not marked as pure

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
