### PR TITLE
fix(@angular/build): handle relative URLs when constructing new URLs during server fetch

### DIFF
--- a/packages/angular/build/src/utils/server-rendering/fetch-patch.ts
+++ b/packages/angular/build/src/utils/server-rendering/fetch-patch.ts
@@ -28,9 +28,9 @@ export function patchFetchToLoadInMemoryAssets(baseURL: URL): void {
     if (input instanceof URL) {
       url = input;
     } else if (typeof input === 'string') {
-      url = new URL(input);
+      url = new URL(input, baseURL);
     } else if (typeof input === 'object' && 'url' in input) {
-      url = new URL(input.url);
+      url = new URL(input.url, baseURL);
     } else {
       return originalFetch(input, init);
     }


### PR DESCRIPTION


Ensures proper handling of relative URLs to prevent errors in server-side fetch operations.

Closes #29236