### PR TITLE
fix(@angular-devkit/architect): provide better error when builder is not defined

### DIFF
--- a/packages/angular_devkit/architect/node/node-modules-architect-host.ts
+++ b/packages/angular_devkit/architect/node/node-modules-architect-host.ts
@@ -55,6 +55,10 @@ function findProjectTarget(
     throw new Error('Project target does not exist.');
   }
 
+  if (!targetDefinition.builder) {
+    throw new Error(`A builder is not set for target '${target}' in project '${project}'.`);
+  }
+
   return targetDefinition;
 }
 
@@ -74,9 +78,9 @@ export class WorkspaceNodeModulesArchitectHost implements ArchitectHost<NodeModu
     } else {
       this.workspaceHost = {
         async getBuilderName(project, target) {
-          const targetDefinition = findProjectTarget(workspaceOrHost, project, target);
+          const { builder } = findProjectTarget(workspaceOrHost, project, target);
 
-          return targetDefinition.builder;
+          return builder;
         },
         async getOptions(project, target, configuration) {
           const targetDefinition = findProjectTarget(workspaceOrHost, project, target);


### PR DESCRIPTION


When a builder is not defined a more actionable error message is now displayed.

Closes #29226