### PR TITLE
ci: run less jobs per executor for RBE

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -129,7 +129,7 @@ build:remote --define=EXECUTOR=remote
 build:remote --remote_cache=remotebuildexecution.googleapis.com
 build:remote --remote_executor=remotebuildexecution.googleapis.com
 build:remote --remote_timeout=600
-build:remote --jobs=150
+build:remote --jobs=10
 
 # Setup the toolchain and platform for the remote build execution. The platform
 # is provided by the shared dev-infra package and targets k8 remote containers.


### PR DESCRIPTION
Use less jobs per bazel run to reduce the rate at which we perform API calls for RBE
