### PR TITLE
refactor(@angular/build): remove no longer correct type

### DIFF
--- a/goldens/public-api/angular/build/index.api.md
+++ b/goldens/public-api/angular/build/index.api.md
@@ -71,19 +71,8 @@ export interface ApplicationBuilderOptions {
     webWorkerTsConfig?: string;
 }
 
-// @public (undocumented)
-export interface ApplicationBuilderOutput extends BuilderOutput {
-    // (undocumented)
-    assetFiles?: {
-        source: string;
-        destination: string;
-    }[];
-    // (undocumented)
-    outputFiles?: BuildOutputFile[];
-}
-
 // @public
-export function buildApplication(options: ApplicationBuilderOptions, context: BuilderContext, extensions?: ApplicationBuilderExtensions): AsyncIterable<ApplicationBuilderOutput>;
+export function buildApplication(options: ApplicationBuilderOptions, context: BuilderContext, extensions?: ApplicationBuilderExtensions): AsyncIterable<BuilderOutput>;
 
 // @public (undocumented)
 export interface BuildOutputAsset {

--- a/packages/angular/build/src/builders/application/index.ts
+++ b/packages/angular/build/src/builders/application/index.ts
@@ -10,7 +10,7 @@ import { BuilderContext, BuilderOutput, createBuilder } from '@angular-devkit/ar
 import assert from 'node:assert';
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import { BuildOutputFile, BuildOutputFileType } from '../../tools/esbuild/bundler-context';
+import { BuildOutputFileType } from '../../tools/esbuild/bundler-context';
 import { createJsonBuildManifest, emitFilesToDisk } from '../../tools/esbuild/utils';
 import { colors as ansiColors } from '../../utils/color';
 import { deleteOutputDir } from '../../utils/delete-output-dir';
@@ -133,11 +133,6 @@ export async function* buildApplicationInternal(
   );
 }
 
-export interface ApplicationBuilderOutput extends BuilderOutput {
-  outputFiles?: BuildOutputFile[];
-  assetFiles?: { source: string; destination: string }[];
-}
-
 /**
  * Builds an application using the `application` builder with the provided
  * options.
@@ -156,7 +151,7 @@ export async function* buildApplication(
   options: ApplicationBuilderOptions,
   context: BuilderContext,
   extensions?: ApplicationBuilderExtensions,
-): AsyncIterable<ApplicationBuilderOutput> {
+): AsyncIterable<BuilderOutput> {
   let initial = true;
   const internalOptions = { ...options, incrementalResults: true };
   for await (const result of buildApplicationInternal(internalOptions, context, extensions)) {

--- a/packages/angular/build/src/index.ts
+++ b/packages/angular/build/src/index.ts
@@ -6,11 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-export {
-  buildApplication,
-  type ApplicationBuilderOptions,
-  type ApplicationBuilderOutput,
-} from './builders/application';
+export { buildApplication, type ApplicationBuilderOptions } from './builders/application';
 export type { ApplicationBuilderExtensions } from './builders/application/options';
 export { type BuildOutputFile, BuildOutputFileType } from './tools/esbuild/bundler-context';
 export type { BuildOutputAsset } from './tools/esbuild/bundler-execution-result';


### PR DESCRIPTION
`buildApplication` no longer yields the `outputFiles` and `assetFiles`.
