### PR TITLE
fix(@angular/build): enable serving files with bundle-like names

### DIFF
--- a/packages/angular/build/src/builders/dev-server/tests/behavior/build-assets_spec.ts
+++ b/packages/angular/build/src/builders/dev-server/tests/behavior/build-assets_spec.ts
@@ -141,5 +141,26 @@ describeServeBuilder(executeDevServer, DEV_SERVER_BUILDER_INFO, (harness, setupT
       expect(await response?.status).toBe(301);
       expect(await response?.headers.get('Location')).toBe('/login/');
     });
+
+    it('serves a JavaScript asset named as a bundle', async () => {
+      await harness.writeFile('public/test/main.js', javascriptFileContent);
+
+      setupTarget(harness, {
+        assets: [
+          {
+            glob: '**/*',
+            input: 'public',
+          },
+        ],
+      });
+
+      harness.useTarget('serve', {
+        ...BASE_OPTIONS,
+      });
+
+      const { result, response } = await executeOnceAndFetch(harness, 'test/main.js');
+      expect(result?.success).toBeTrue();
+      expect(await response?.text()).toContain(javascriptFileContent);
+    });
   });
 });

--- a/packages/angular/build/src/tools/vite/plugins/angular-memory-plugin.ts
+++ b/packages/angular/build/src/tools/vite/plugins/angular-memory-plugin.ts
@@ -22,6 +22,7 @@ interface AngularMemoryPluginOptions {
 }
 
 const ANGULAR_PREFIX = '/@ng/';
+const VITE_FS_PREFIX = '/@fs/';
 
 export async function createAngularMemoryPlugin(
   options: AngularMemoryPluginOptions,
@@ -34,6 +35,10 @@ export async function createAngularMemoryPlugin(
     // Ensures plugin hooks run before built-in Vite hooks
     enforce: 'pre',
     async resolveId(source, importer, { ssr }) {
+      if (source.startsWith(VITE_FS_PREFIX)) {
+        return;
+      }
+
       // For SSR with component HMR, pass through as a virtual module
       if (ssr && source.startsWith(ANGULAR_PREFIX)) {
         return '\0' + source;


### PR DESCRIPTION
Ensure files with names resembling bundles, such as `main.js`, can be served correctly. This resolves issues where specific filenames were mistakenly treated as generated bundles, preventing them from being accessed directly.

Closes #29232