### PR TITLE
ci: enable `rules_js` interop mode for ng-dev release tool

### DIFF
--- a/.ng-dev/release.mjs
+++ b/.ng-dev/release.mjs
@@ -31,6 +31,8 @@ export const release = {
       '@angular-devkit/schematics-cli',
     ],
   },
+  // TODO: Remove after `rules_js` migration.
+  rulesJsInteropMode: true,
   publishRegistry: 'https://wombat-dressing-room.appspot.com',
   releasePrLabels: ['action: merge'],
 };


### PR DESCRIPTION
This ensures that the Bazel lock files are automatically updated.

See: https://github.com/angular/dev-infra/commit/289aa644e65a557bcb21adcf75ad60605a9c9859