### PR TITLE
Multiple asset fixes for Vite and the application builder in watch mode

### DIFF
--- a/packages/angular/build/src/builders/application/build-action.ts
+++ b/packages/angular/build/src/builders/application/build-action.ts
@@ -313,10 +313,10 @@ function* emitOutputResults(
     for (const { source, destination } of assetFiles) {
       removedAssetFiles.delete(source);
 
-      if (changes.modified.has(source)) {
-        incrementalResult.modified.push(destination);
-      } else if (!previousAssetsInfo.has(source)) {
+      if (!previousAssetsInfo.has(source)) {
         incrementalResult.added.push(destination);
+      } else if (changes.modified.has(source)) {
+        incrementalResult.modified.push(destination);
       } else {
         continue;
       }

--- a/packages/angular/build/src/tools/esbuild/bundler-execution-result.ts
+++ b/packages/angular/build/src/tools/esbuild/bundler-execution-result.ts
@@ -27,7 +27,8 @@ export interface RebuildState {
   componentStyleBundler: ComponentStylesheetBundler;
   codeBundleCache?: SourceFileCache;
   fileChanges: ChangedFiles;
-  previousOutputInfo: Map<string, { hash: string; type: BuildOutputFileType }>;
+  previousOutputInfo: ReadonlyMap<string, { hash: string; type: BuildOutputFileType }>;
+  previousAssetsInfo: ReadonlyMap<string, string>;
   templateUpdates?: Map<string, string>;
 }
 
@@ -172,12 +173,15 @@ export class ExecutionResult {
       previousOutputInfo: new Map(
         this.outputFiles.map(({ path, hash, type }) => [path, { hash, type }]),
       ),
+      previousAssetsInfo: new Map(
+        this.assetFiles.map(({ source, destination }) => [source, destination]),
+      ),
       templateUpdates: this.templateUpdates,
     };
   }
 
   findChangedFiles(
-    previousOutputHashes: Map<string, { hash: string; type: BuildOutputFileType }>,
+    previousOutputHashes: ReadonlyMap<string, { hash: string; type: BuildOutputFileType }>,
   ): Set<string> {
     const changed = new Set<string>();
     for (const file of this.outputFiles) {

--- a/packages/angular/build/src/tools/vite/plugins/setup-middlewares-plugin.ts
+++ b/packages/angular/build/src/tools/vite/plugins/setup-middlewares-plugin.ts
@@ -18,7 +18,7 @@ import {
   createAngularSsrExternalMiddleware,
   createAngularSsrInternalMiddleware,
 } from '../middlewares';
-import { AngularMemoryOutputFiles } from '../utils';
+import { AngularMemoryOutputFiles, AngularOutputAssets } from '../utils';
 
 export enum ServerSsrMode {
   /**
@@ -47,7 +47,7 @@ export enum ServerSsrMode {
 
 interface AngularSetupMiddlewaresPluginOptions {
   outputFiles: AngularMemoryOutputFiles;
-  assets: Map<string, string>;
+  assets: AngularOutputAssets;
   extensionMiddleware?: Connect.NextHandleFunction[];
   indexHtmlTransformer?: (content: string) => Promise<string>;
   componentStyles: Map<string, ComponentStyleRecord>;

--- a/packages/angular/build/src/tools/vite/utils.ts
+++ b/packages/angular/build/src/tools/vite/utils.ts
@@ -18,6 +18,8 @@ export type AngularMemoryOutputFiles = Map<
   { contents: Uint8Array; hash: string; servable: boolean }
 >;
 
+export type AngularOutputAssets = Map<string, { source: string }>;
+
 export function pathnameWithoutBasePath(url: string, basePath: string): string {
   const parsedUrl = new URL(url, 'http://localhost');
   const pathname = decodeURIComponent(parsedUrl.pathname);


### PR DESCRIPTION

**fix(@angular/build): trigger browser reload on asset changes with Vite dev server**

Ensures the Vite-based development server automatically reloads the browser when asset files are modified.

Closes #26141


**fix(@angular/build): remove deleted assets from output during watch mode**

This commit ensures that assets deleted from the source are also removed from the output directory while in watch mode. Previously, deleted assets could persist in the output folder, potentially causing inconsistencies or outdated files to be served. This fix improves the accuracy of the build output by maintaining synchronization between the source and the output directory during development.