### PR TITLE
fix(@angular/build): skip vite SSR warmup file configuration when SSR is disabled

### DIFF
--- a/packages/angular/build/src/builders/dev-server/vite-server.ts
+++ b/packages/angular/build/src/builders/dev-server/vite-server.ts
@@ -670,6 +670,17 @@ export async function setupServer(
     join(serverOptions.workspaceRoot, `.angular/vite-root`, serverOptions.buildTarget.project),
   );
 
+  // Files used for SSR warmup.
+  let ssrFiles: string[] | undefined;
+  switch (ssrMode) {
+    case ServerSsrMode.InternalSsrMiddleware:
+      ssrFiles = ['./main.server.mjs'];
+      break;
+    case ServerSsrMode.ExternalSsrMiddleware:
+      ssrFiles = ['./main.server.mjs', './server.mjs'];
+      break;
+  }
+
   const cacheDir = join(serverOptions.cacheOptions.path, serverOptions.buildTarget.project, 'vite');
   const configuration: InlineConfig = {
     configFile: false,
@@ -701,7 +712,7 @@ export async function setupServer(
     },
     server: {
       warmup: {
-        ssrFiles: ['./main.server.mjs', './server.mjs'],
+        ssrFiles,
       },
       port: serverOptions.port,
       strictPort: true,


### PR DESCRIPTION

This change addresses recent updates in Vite that trigger pre-transform errors when SSR files (`/server.mjs`, `/main.server.mjs`) are missing. Skipping the configuration prevents unnecessary errors during the build process.

