### PR TITLE
fix(@angular/build): pass `define` option defined in application builder to Vite prebundling

### DIFF
--- a/packages/angular/build/src/builders/dev-server/vite-server.ts
+++ b/packages/angular/build/src/builders/dev-server/vite-server.ts
@@ -422,6 +422,7 @@ export async function* serveWithVite(
         componentStyles,
         templateUpdates,
         browserOptions.loader as EsbuildLoaderOption | undefined,
+        browserOptions.define,
         extensions?.middleware,
         transformers?.indexHtml,
         thirdPartySourcemaps,
@@ -653,6 +654,7 @@ export async function setupServer(
   componentStyles: Map<string, ComponentStyleRecord>,
   templateUpdates: Map<string, string>,
   prebundleLoaderExtensions: EsbuildLoaderOption | undefined,
+  define: ApplicationBuilderInternalOptions['define'],
   extensionMiddleware?: Connect.NextHandleFunction[],
   indexHtmlTransformer?: (content: string) => Promise<string>,
   thirdPartySourcemaps = false,
@@ -754,6 +756,7 @@ export async function setupServer(
         target,
         loader: prebundleLoaderExtensions,
         thirdPartySourcemaps,
+        define,
       }),
     },
     plugins: [
@@ -791,6 +794,7 @@ export async function setupServer(
       zoneless,
       loader: prebundleLoaderExtensions,
       thirdPartySourcemaps,
+      define,
     }),
   };
 

--- a/packages/angular/build/src/tools/vite/utils.ts
+++ b/packages/angular/build/src/tools/vite/utils.ts
@@ -57,6 +57,7 @@ export function getDepOptimizationConfig({
   ssr,
   loader,
   thirdPartySourcemaps,
+  define = {},
 }: {
   disabled: boolean;
   exclude: string[];
@@ -67,6 +68,7 @@ export function getDepOptimizationConfig({
   zoneless: boolean;
   loader?: EsbuildLoaderOption;
   thirdPartySourcemaps: boolean;
+  define: Record<string, string> | undefined;
 }): DepOptimizationConfig {
   const plugins: ViteEsBuildPlugin[] = [
     {
@@ -99,6 +101,7 @@ export function getDepOptimizationConfig({
       plugins,
       loader,
       define: {
+        ...define,
         'ngServerMode': `${ssr}`,
       },
       resolveExtensions: ['.mjs', '.js', '.cjs'],


### PR DESCRIPTION
This update ensures that the `define` option is correctly passed to Vite during the prebundling phase of the application builder, improving compatibility and optimization of the build process.

Closes #29278
