### PR TITLE
build: resolve issue with uncompiled `@angular/build/private` being included

### DIFF
--- a/packages/angular/build/BUILD.bazel
+++ b/packages/angular/build/BUILD.bazel
@@ -227,7 +227,7 @@ pkg_npm(
         ":README.md",
         ":build",
         ":license",
-        ":private",
+        "//packages/angular/build/private",
     ],
 )
 


### PR DESCRIPTION


Reference: https://github.com/angular/angular-build-builds/commit/3735297d21181b5885cf9a3625cb554c46efb8b3
