### PR TITLE
fix(@angular/ssr): throw error when using route matchers

### DIFF
--- a/packages/angular/ssr/src/routes/ng-routes.ts
+++ b/packages/angular/ssr/src/routes/ng-routes.ts
@@ -144,8 +144,24 @@ async function* traverseRoutesConfig(options: {
 
   for (const route of routes) {
     try {
-      const { path = '', redirectTo, loadChildren, loadComponent, children, ɵentryName } = route;
+      const {
+        path = '',
+        matcher,
+        redirectTo,
+        loadChildren,
+        loadComponent,
+        children,
+        ɵentryName,
+      } = route;
       const currentRoutePath = joinUrlParts(parentRoute, path);
+
+      if (matcher) {
+        yield {
+          error: `The route '${stripLeadingSlash(currentRoutePath)}' uses a route matcher which is not supported.`,
+        };
+
+        continue;
+      }
 
       // Get route metadata from the server config route tree, if available
       let matchedMetaData: ServerConfigRouteTreeNodeMetadata | undefined;


### PR DESCRIPTION
Route matchers are not currently supported in Angular SSR. This commit ensures an error is issued when a route matcher is detected.
