### PR TITLE
[19.0.x] build: migrate `@angular/ssr` to `ts_project`

### DIFF
--- a/.aspect/rules/external_repository_action_cache/npm_translate_lock_MzA5NzUwNzMx
+++ b/.aspect/rules/external_repository_action_cache/npm_translate_lock_MzA5NzUwNzMx
@@ -2,7 +2,7 @@
 # Input hashes for repository rule npm_translate_lock(name = "npm2", pnpm_lock = "@//:pnpm-lock.yaml").
 # This file should be checked into version control along with the pnpm-lock.yaml file.
 .npmrc=-2023857461
-package.json=-1251203040
-pnpm-lock.yaml=2007346593
+package.json=-707512896
+pnpm-lock.yaml=-2119082430
 pnpm-workspace.yaml=1711114604
-yarn.lock=-279910630
+yarn.lock=1132326811

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -36,10 +36,19 @@ rules_js_tsconfig(
 )
 
 rules_js_tsconfig(
+    name = "build-tsconfig-angular",
+    src = "tsconfig-build-ng.json",
+    deps = [
+        "tsconfig.json",
+    ],
+)
+
+rules_js_tsconfig(
     name = "test-tsconfig",
     src = "tsconfig-test.json",
     deps = [
         "tsconfig.json",
+        "//:root_modules/@types/jasmine",
         "//:root_modules/@types/node",
     ],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -136,7 +136,7 @@ yarn_install(
     data = [
         "//:.yarn/releases/yarn-4.5.0.cjs",
         "//:.yarnrc.yml",
-        "//:patches/@angular+bazel+19.0.0-next.7.patch",
+        "//:patches/@angular+bazel+19.1.0-next.4.patch",
         "//:patches/@bazel+concatjs+5.8.1.patch",
         "//:patches/@bazel+jasmine+5.8.1.patch",
     ],
@@ -221,6 +221,6 @@ rules_ts_dependencies(
 
 http_file(
     name = "tsc_worker",
-    sha256 = "",
-    urls = ["https://raw.githubusercontent.com/devversion/rules_angular/a270a74d1e64577bddba96a5484c7c5d2c5d2770/dist/worker.mjs"],
+    sha256 = "5a5c46846ecda83e05b9da26f1672ad51c59bce08fed88419850d0e29c993b30",
+    urls = ["https://raw.githubusercontent.com/devversion/rules_angular/4b7532ba2b29078d005899cd15b415593d03cceb/dist/worker.mjs"],
 )

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@ampproject/remapping": "2.3.0",
     "@angular/animations": "19.0.0",
-    "@angular/bazel": "https://github.com/angular/bazel-builds.git#07617f0f8540d27f8895b1820a6f994e1e5b7277",
+    "@angular/bazel": "https://github.com/angular/bazel-builds.git#cfd7a06c2f972fcef59262995d232e2846b536a2",
     "@angular/build-tooling": "https://github.com/angular/dev-infra-private-build-tooling-builds.git#a35ad7f4e30ae1fc531517867efcae89cce5afa2",
     "@angular/cdk": "19.0.0-rc.3",
     "@angular/common": "19.0.0",

--- a/packages/angular/ssr/BUILD.bazel
+++ b/packages/angular/ssr/BUILD.bazel
@@ -1,12 +1,12 @@
 load("@npm//@angular/build-tooling/bazel/api-golden:index.bzl", "api_golden_test_npm_package")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
-load("//tools:defaults.bzl", "ng_package", "ts_library")
+load("//tools:defaults.bzl", "ng_package")
+load("//tools:interop.bzl", "ts_project")
 
 package(default_visibility = ["//visibility:public"])
 
-ts_library(
+ts_project(
     name = "ssr",
-    package_name = "@angular/ssr",
     srcs = glob(
         include = [
             "*.ts",
@@ -16,15 +16,23 @@ ts_library(
             "**/*_spec.ts",
         ],
     ),
+    args = [
+        "--lib",
+        "dom,es2020",
+    ],
+    data = [
+        "//packages/angular/ssr/third_party/beasties:beasties_bundled",
+    ],
     module_name = "@angular/ssr",
-    tsconfig = "//:tsconfig-build-ng",
+    source_map = True,
+    tsconfig = "//:build-tsconfig-angular",
     deps = [
-        "//packages/angular/ssr/third_party/beasties:bundled_beasties_lib",
-        "@npm//@angular/common",
-        "@npm//@angular/core",
-        "@npm//@angular/platform-server",
-        "@npm//@angular/router",
-        "@npm//tslib",
+        "//:root_modules/@angular/common",
+        "//:root_modules/@angular/core",
+        "//:root_modules/@angular/platform-server",
+        "//:root_modules/@angular/router",
+        "//:root_modules/tslib",
+        "//packages/angular/ssr/third_party/beasties:beasties_dts",
     ],
 )
 
@@ -33,7 +41,7 @@ ng_package(
     package_name = "@angular/ssr",
     srcs = [
         ":package.json",
-        "//packages/angular/ssr/third_party/beasties:bundled_beasties_lib",
+        "//packages/angular/ssr/third_party/beasties:beasties_bundled",
     ],
     externals = [
         "@angular/ssr",

--- a/packages/angular/ssr/node/BUILD.bazel
+++ b/packages/angular/ssr/node/BUILD.bazel
@@ -1,8 +1,8 @@
-load("//tools:defaults.bzl", "ts_library")
+load("//tools:interop.bzl", "ts_project")
 
 package(default_visibility = ["//visibility:public"])
 
-ts_library(
+ts_project(
     name = "node",
     srcs = glob(
         [
@@ -10,11 +10,17 @@ ts_library(
             "src/**/*.ts",
         ],
     ),
+    args = [
+        "--types",
+        "node",
+    ],
     module_name = "@angular/ssr/node",
+    source_map = True,
+    tsconfig = "//:build-tsconfig-angular",
     deps = [
-        "//packages/angular/ssr",
-        "@npm//@angular/core",
-        "@npm//@angular/platform-server",
-        "@npm//@types/node",
+        "//:root_modules/@angular/core",
+        "//:root_modules/@angular/platform-server",
+        "//:root_modules/@types/node",
+        "//packages/angular/ssr:ssr_rjs",
     ],
 )

--- a/packages/angular/ssr/node/test/BUILD.bazel
+++ b/packages/angular/ssr/node/test/BUILD.bazel
@@ -1,18 +1,30 @@
+load("@npm//@angular/build-tooling/bazel/spec-bundling:index.bzl", "spec_bundle")
 load("@npm//@bazel/jasmine:index.bzl", "jasmine_node_test")
-load("//tools:defaults.bzl", "ts_library")
+load("//tools:interop.bzl", "ts_project")
 
-ts_library(
+ts_project(
     name = "unit_test_lib",
     testonly = True,
     srcs = glob(["**/*_spec.ts"]),
     deps = [
-        "//packages/angular/ssr/node",
+        "//packages/angular/ssr/node:node_rjs",
+    ],
+)
+
+# TODO: Clean this up when this repo runs ESM consistently.
+spec_bundle(
+    name = "esm_tests_bundled",
+    downlevel_async_await = False,
+    platform = "node",
+    run_angular_linker = False,
+    deps = [
+        ":unit_test_lib",
     ],
 )
 
 jasmine_node_test(
     name = "test",
     deps = [
-        ":unit_test_lib",
+        ":esm_tests_bundled",
     ],
 )

--- a/packages/angular/ssr/schematics/BUILD.bazel
+++ b/packages/angular/ssr/schematics/BUILD.bazel
@@ -4,7 +4,8 @@
 # found in the LICENSE file at https://angular.dev/license
 
 load("@npm//@bazel/jasmine:index.bzl", "jasmine_node_test")
-load("//tools:defaults.bzl", "pkg_npm", "ts_library")
+load("//tools:defaults.bzl", "pkg_npm")
+load("//tools:interop.bzl", "ts_project")
 load("//tools:ts_json_schema.bzl", "ts_json_schema")
 
 licenses(["notice"])
@@ -44,9 +45,8 @@ filegroup(
     ),
 )
 
-ts_library(
+ts_project(
     name = "schematics",
-    package_name = "@angular/ssr/schematics",
     srcs = glob(
         include = ["**/*.ts"],
         exclude = [
@@ -59,13 +59,14 @@ ts_library(
         for (src, _) in ALL_SCHEMA_TARGETS
     ],
     data = [":schematics_assets"],
+    module_name = "@angular/ssr/schematics",
     deps = [
-        "//packages/angular_devkit/schematics",
-        "//packages/schematics/angular",
+        "//packages/angular_devkit/schematics:schematics_rjs",
+        "//packages/schematics/angular:angular_rjs",
     ],
 )
 
-ts_library(
+ts_project(
     name = "ssr_schematics_test_lib",
     testonly = True,
     srcs = glob(
@@ -77,12 +78,10 @@ ts_library(
             "node_modules/**",
         ],
     ),
-    # @external_begin
     deps = [
-        ":schematics",
-        "//packages/angular_devkit/schematics/testing",
+        ":schematics_rjs",
+        "//packages/angular_devkit/schematics/testing:testing_rjs",
     ],
-    # @external_end
 )
 
 jasmine_node_test(

--- a/packages/angular/ssr/test/BUILD.bazel
+++ b/packages/angular/ssr/test/BUILD.bazel
@@ -1,56 +1,35 @@
 load("@npm//@angular/build-tooling/bazel/spec-bundling:index.bzl", "spec_bundle")
 load("@npm//@bazel/jasmine:index.bzl", "jasmine_node_test")
-load("//tools:defaults.bzl", "ts_library")
+load("//tools:interop.bzl", "ts_project")
 
-ESM_TESTS = [
-    "app_spec.ts",
-    "app-engine_spec.ts",
-    "routes/router_spec.ts",
-    "routes/route-tree_spec.ts",
-    "routes/ng-routes_spec.ts",
-]
-
-ts_library(
+ts_project(
     name = "unit_test_lib",
     testonly = True,
     srcs = glob(
-        include = ["**/*_spec.ts"],
-        exclude = ESM_TESTS + ["npm_package/**"],
+        include = ["**/*.ts"],
     ),
     deps = [
-        "//packages/angular/ssr",
-    ],
-)
-
-ts_library(
-    name = "unit_test_with_esm_deps_lib",
-    testonly = True,
-    srcs = ESM_TESTS + ["testing-utils.ts"],
-    deps = [
-        "//packages/angular/ssr",
-        "@npm//@angular/common",
-        "@npm//@angular/compiler",
-        "@npm//@angular/core",
-        "@npm//@angular/platform-browser",
-        "@npm//@angular/platform-server",
-        "@npm//@angular/router",
+        "//:root_modules/@angular/common",
+        "//:root_modules/@angular/compiler",
+        "//:root_modules/@angular/core",
+        "//:root_modules/@angular/platform-browser",
+        "//:root_modules/@angular/platform-server",
+        "//:root_modules/@angular/router",
+        "//packages/angular/ssr:ssr_rjs",
     ],
 )
 
 spec_bundle(
-    name = "unit_test_with_esm_deps_lib_bundled",
+    name = "esm_tests_bundled",
     downlevel_async_await = False,
     platform = "node",
     run_angular_linker = False,
     deps = [
-        ":unit_test_with_esm_deps_lib",
+        ":unit_test_lib",
     ],
 )
 
 jasmine_node_test(
     name = "test",
-    deps = [
-        ":unit_test_lib",
-        ":unit_test_with_esm_deps_lib_bundled",
-    ],
+    deps = [":esm_tests_bundled"],
 )

--- a/packages/angular/ssr/test/npm_package/BUILD.bazel
+++ b/packages/angular/ssr/test/npm_package/BUILD.bazel
@@ -1,14 +1,14 @@
 load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@npm//@bazel/jasmine:index.bzl", "jasmine_node_test")
-load("//tools:defaults.bzl", "ts_library")
+load("//tools:interop.bzl", "ts_project")
 
-ts_library(
+ts_project(
     name = "unit_test_lib",
     testonly = True,
     srcs = glob(["**/*.ts"]),
     deps = [
-        "@npm//@bazel/runfiles",
+        "//:root_modules/@bazel/runfiles",
     ],
 )
 

--- a/packages/angular/ssr/third_party/beasties/BUILD.bazel
+++ b/packages/angular/ssr/third_party/beasties/BUILD.bazel
@@ -1,16 +1,25 @@
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@npm//@bazel/rollup:index.bzl", "rollup_bundle")
-load("//tools:defaults.bzl", "js_library")
 
 package(default_visibility = ["//visibility:public"])
 
 js_library(
-    name = "bundled_beasties_lib",
+    name = "beasties_dts",
     srcs = [
         "index.d.ts",
+    ],
+    deps = [
+        "//:root_modules/beasties",
+    ],
+)
+
+js_library(
+    name = "beasties_bundled",
+    srcs = [
         ":bundled_beasties_files",
     ],
     deps = [
-        "@npm//beasties",
+        "//:root_modules/beasties",
     ],
 )
 

--- a/patches/@angular+bazel+19.1.0-next.4.patch
+++ b/patches/@angular+bazel+19.1.0-next.4.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/@angular/bazel/src/ng_package/packager.mjs b/node_modules/@angular/bazel/src/ng_package/packager.mjs
-index 5c1f3a2c72e28a90b666c96b2fe9755cdafd5259..47034ceeb0b9ab9c1e9bee50239723a51d2e2e19 100755
+index 7184fd910a6ecaa817d5078a1fb17f78aee9113b..ef3e508cfa8f309ca298a21c0546bba60fae095c 100755
 --- a/node_modules/@angular/bazel/src/ng_package/packager.mjs
 +++ b/node_modules/@angular/bazel/src/ng_package/packager.mjs
 @@ -7,7 +7,7 @@

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,8 +20,8 @@ importers:
         specifier: 19.0.0
         version: 19.0.0(@angular/core@19.0.0)
       '@angular/bazel':
-        specifier: https://github.com/angular/bazel-builds.git#07617f0f8540d27f8895b1820a6f994e1e5b7277
-        version: github.com/angular/bazel-builds/07617f0f8540d27f8895b1820a6f994e1e5b7277(@angular/compiler-cli@19.0.0)(@bazel/concatjs@5.8.1)(@bazel/worker@5.8.1)(@rollup/plugin-commonjs@28.0.1)(@rollup/plugin-node-resolve@13.3.0)(@types/node@18.19.64)(rollup-plugin-sourcemaps@0.6.3)(rollup@4.26.0)(terser@5.36.0)(typescript@5.6.3)
+        specifier: https://github.com/angular/bazel-builds.git#cfd7a06c2f972fcef59262995d232e2846b536a2
+        version: github.com/angular/bazel-builds/cfd7a06c2f972fcef59262995d232e2846b536a2(@angular/compiler-cli@19.0.0)(@bazel/concatjs@5.8.1)(@bazel/worker@5.8.1)(@rollup/plugin-commonjs@28.0.1)(@rollup/plugin-node-resolve@13.3.0)(@types/node@18.19.64)(rollup-plugin-sourcemaps@0.6.3)(rollup@4.26.0)(terser@5.36.0)(typescript@5.6.3)
       '@angular/build-tooling':
         specifier: https://github.com/angular/dev-infra-private-build-tooling-builds.git#a35ad7f4e30ae1fc531517867efcae89cce5afa2
         version: github.com/angular/dev-infra-private-build-tooling-builds/a35ad7f4e30ae1fc531517867efcae89cce5afa2(@angular/compiler-cli@19.0.0)(@angular/compiler@19.0.0)(@angular/localize@19.0.0)(@angular/platform-server@19.0.0)(@angular/service-worker@19.0.0)(chokidar@4.0.1)(debug@4.3.7)(karma-chrome-launcher@3.2.0)(karma-firefox-launcher@2.1.3)(karma-jasmine@5.1.0)(karma-junit-reporter@2.0.1)(karma-requirejs@1.1.0)(karma-sourcemap-loader@0.4.0)(karma@6.4.4)(less@4.2.0)(postcss@8.4.49)(rxjs@7.8.1)(terser@5.36.0)(zone.js@0.15.0)
@@ -2087,7 +2087,6 @@ packages:
 
   /@bazel/typescript@5.8.1(typescript@5.6.3):
     resolution: {integrity: sha512-NAJ8WQHZL1WE1YmRoCrq/1hhG15Mvy/viWh6TkvFnBeEhNUiQUsA5GYyhU1ztnBIYW03nATO3vwhAEfO7Q0U5g==}
-    deprecated: No longer maintained, https://github.com/aspect-build/rules_ts is the recommended replacement
     hasBin: true
     peerDependencies:
       typescript: 5.6.3
@@ -12176,7 +12175,7 @@ packages:
   /puppeteer@18.2.1:
     resolution: {integrity: sha512-7+UhmYa7wxPh2oMRwA++k8UGVDxh3YdWFB52r9C3tM81T6BU7cuusUSxImz0GEYSOYUKk/YzIhkQ6+vc0gHbxQ==}
     engines: {node: '>=14.1.0'}
-    deprecated: < 22.8.2 is no longer supported
+    deprecated: < 19.4.0 is no longer supported
     dependencies:
       https-proxy-agent: 5.0.1(supports-color@10.0.0)
       progress: 2.0.3
@@ -14954,15 +14953,15 @@ packages:
     resolution: {integrity: sha512-9oxn0IIjbCZkJ67L+LkhYWRyAy7axphb3VgE2MBDlOqnmHMPWGYMxJxBYFueFq/JGY2GMwS0rU+UCLunEmy5UA==}
     dev: true
 
-  github.com/angular/bazel-builds/07617f0f8540d27f8895b1820a6f994e1e5b7277(@angular/compiler-cli@19.0.0)(@bazel/concatjs@5.8.1)(@bazel/worker@5.8.1)(@rollup/plugin-commonjs@28.0.1)(@rollup/plugin-node-resolve@13.3.0)(@types/node@18.19.64)(rollup-plugin-sourcemaps@0.6.3)(rollup@4.26.0)(terser@5.36.0)(typescript@5.6.3):
-    resolution: {tarball: https://codeload.github.com/angular/bazel-builds/tar.gz/07617f0f8540d27f8895b1820a6f994e1e5b7277}
-    id: github.com/angular/bazel-builds/07617f0f8540d27f8895b1820a6f994e1e5b7277
+  github.com/angular/bazel-builds/cfd7a06c2f972fcef59262995d232e2846b536a2(@angular/compiler-cli@19.0.0)(@bazel/concatjs@5.8.1)(@bazel/worker@5.8.1)(@rollup/plugin-commonjs@28.0.1)(@rollup/plugin-node-resolve@13.3.0)(@types/node@18.19.64)(rollup-plugin-sourcemaps@0.6.3)(rollup@4.26.0)(terser@5.36.0)(typescript@5.6.3):
+    resolution: {tarball: https://codeload.github.com/angular/bazel-builds/tar.gz/cfd7a06c2f972fcef59262995d232e2846b536a2}
+    id: github.com/angular/bazel-builds/cfd7a06c2f972fcef59262995d232e2846b536a2
     name: '@angular/bazel'
-    version: 19.0.0-next.7
+    version: 19.1.0-next.4
     engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0}
     hasBin: true
     peerDependencies:
-      '@angular/compiler-cli': 19.0.0-next.7+sha-00a79d0
+      '@angular/compiler-cli': 19.1.0-next.4+sha-b22677d
       '@bazel/concatjs': ^5.3.0
       '@bazel/worker': ^5.3.0
       '@rollup/plugin-commonjs': ^28.0.0

--- a/tsconfig-build-ng.json
+++ b/tsconfig-build-ng.json
@@ -8,7 +8,7 @@
   "compilerOptions": {
     "module": "esnext",
     "target": "es2022",
-    "lib": ["es2020", "dom"],
+    "lib": ["es2020"],
     // don't auto-discover @types/node, it results in a ///<reference in the .d.ts output
     "types": [],
     "sourceMap": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -65,15 +65,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@angular/bazel@https://github.com/angular/bazel-builds.git#07617f0f8540d27f8895b1820a6f994e1e5b7277":
-  version: 19.0.0-next.7+sha-00a79d0
-  resolution: "@angular/bazel@https://github.com/angular/bazel-builds.git#commit=07617f0f8540d27f8895b1820a6f994e1e5b7277"
+"@angular/bazel@https://github.com/angular/bazel-builds.git#cfd7a06c2f972fcef59262995d232e2846b536a2":
+  version: 19.1.0-next.4+sha-b22677d
+  resolution: "@angular/bazel@https://github.com/angular/bazel-builds.git#commit=cfd7a06c2f972fcef59262995d232e2846b536a2"
   dependencies:
     "@microsoft/api-extractor": "npm:^7.24.2"
     magic-string: "npm:^0.30.0"
     tslib: "npm:^2.3.0"
   peerDependencies:
-    "@angular/compiler-cli": 19.0.0-next.7+sha-00a79d0
+    "@angular/compiler-cli": 19.1.0-next.4+sha-b22677d
     "@bazel/concatjs": ^5.3.0
     "@bazel/worker": ^5.3.0
     "@rollup/plugin-commonjs": ^28.0.0
@@ -81,7 +81,7 @@ __metadata:
     rollup: ^2.56.3
     rollup-plugin-sourcemaps: ^0.6.3
     terser: ^5.9.0
-    typescript: ">=5.5 <5.7"
+    typescript: ">=5.5 <5.8"
   peerDependenciesMeta:
     terser:
       optional: true
@@ -90,7 +90,7 @@ __metadata:
     packager: ./src/ng_package/packager.mjs
     types_bundler: ./src/types_bundle/index.mjs
     xi18n: ./src/ngc-wrapped/extract_i18n.mjs
-  checksum: 10c0/18e8c7c6e70261f04756559cfbf6a1e099bbadef5f6206b04c28c5b4bd6e8178713e1361ae0edf21e888efdd90ea45d008374ef57b22ea31d0722566babae8e7
+  checksum: 10c0/8d1d1d9570ffa467282ad7c440600aa8f0f22194851b3e53fa02c859f4d7ea2577397c0b7474cbfad81cfe9e7c50832888ee5af5d65ebf49745d9c088c7366ef
   languageName: node
   linkType: hard
 
@@ -310,7 +310,7 @@ __metadata:
   dependencies:
     "@ampproject/remapping": "npm:2.3.0"
     "@angular/animations": "npm:19.0.0"
-    "@angular/bazel": "https://github.com/angular/bazel-builds.git#07617f0f8540d27f8895b1820a6f994e1e5b7277"
+    "@angular/bazel": "https://github.com/angular/bazel-builds.git#cfd7a06c2f972fcef59262995d232e2846b536a2"
     "@angular/build-tooling": "https://github.com/angular/dev-infra-private-build-tooling-builds.git#a35ad7f4e30ae1fc531517867efcae89cce5afa2"
     "@angular/cdk": "npm:19.0.0-rc.3"
     "@angular/common": "npm:19.0.0"


### PR DESCRIPTION
Migrates `@angular/ssr` to `ts_project`. Possible after various upstream fixes for `ng_package` and interop changes.

Patch of #29272 
