### PR TITLE
build: never use interop targets for ts compilations

### DIFF
--- a/packages/angular/build/BUILD.bazel
+++ b/packages/angular/build/BUILD.bazel
@@ -52,11 +52,6 @@ ts_project(
         "builders.json",
         "package.json",
     ],
-    interop_deps = [
-        "//packages/angular/ssr",
-        "//packages/angular/ssr/node",
-        "//packages/angular_devkit/architect",
-    ],
     module_name = "@angular/build",
     deps = [
         "//:root_modules/@ampproject/remapping",
@@ -101,6 +96,9 @@ ts_project(
         "//:root_modules/typescript",
         "//:root_modules/vite",
         "//:root_modules/watchpack",
+        "//packages/angular/ssr:ssr_rjs",
+        "//packages/angular/ssr/node:node_rjs",
+        "//packages/angular_devkit/architect:architect_rjs",
     ],
 )
 

--- a/packages/angular/cli/BUILD.bazel
+++ b/packages/angular/cli/BUILD.bazel
@@ -40,11 +40,6 @@ ts_project(
     ) + [
         "//packages/angular/cli:lib/config/schema.json",
     ],
-    interop_deps = [
-        "//packages/angular_devkit/schematics",
-        "//packages/angular_devkit/schematics/tasks",
-        "//packages/angular_devkit/schematics/tools",
-    ],
     module_name = "@angular/cli",
     deps = [
         "//:root_modules/@angular/core",
@@ -71,6 +66,9 @@ ts_project(
         "//packages/angular_devkit/architect/node:node_rjs",
         "//packages/angular_devkit/core:core_rjs",
         "//packages/angular_devkit/core/node:node_rjs",
+        "//packages/angular_devkit/schematics:schematics_rjs",
+        "//packages/angular_devkit/schematics/tasks:tasks_rjs",
+        "//packages/angular_devkit/schematics/tools:tools_rjs",
     ],
 )
 
@@ -138,15 +136,13 @@ ts_project(
             "node_modules/**",
         ],
     ),
-    interop_deps = [
-        "//packages/angular_devkit/schematics",
-        "//packages/angular_devkit/schematics/testing",
-    ],
     deps = [
         ":angular-cli_rjs",
         "//:root_modules/@types/semver",
         "//:root_modules/@types/yargs",
         "//packages/angular_devkit/core:core_rjs",
+        "//packages/angular_devkit/schematics:schematics_rjs",
+        "//packages/angular_devkit/schematics/testing:testing_rjs",
     ],
 )
 

--- a/packages/angular/pwa/BUILD.bazel
+++ b/packages/angular/pwa/BUILD.bazel
@@ -26,13 +26,11 @@ ts_project(
             "pwa/files/**/*",
         ],
     ),
-    interop_deps = [
-        "//packages/angular_devkit/schematics",
-    ],
     module_name = "@angular/pwa",
     deps = [
         "//:root_modules/@types/node",
         "//:root_modules/parse5-html-rewriting-stream",
+        "//packages/angular_devkit/schematics:schematics_rjs",
         "//packages/schematics/angular:angular_rjs",
     ],
 )
@@ -46,12 +44,10 @@ ts_project(
     name = "pwa_test_lib",
     testonly = True,
     srcs = glob(["pwa/**/*_spec.ts"]),
-    interop_deps = [
-        "//packages/angular_devkit/schematics/testing",
-    ],
     deps = [
         ":pwa_rjs",
         "//:root_modules/@types/jasmine",
+        "//packages/angular_devkit/schematics/testing:testing_rjs",
     ],
 )
 

--- a/packages/angular_devkit/architect/BUILD.bazel
+++ b/packages/angular_devkit/architect/BUILD.bazel
@@ -64,14 +64,12 @@ ts_project(
             "node_modules/**",
         ],
     ),
-    interop_deps = [
-        "//packages/angular_devkit/core",
-        "//packages/angular_devkit/core/node",
-    ],
     module_name = "@angular-devkit/architect",
     deps = [
         "//:root_modules/@types/node",
         "//:root_modules/rxjs",
+        "//packages/angular_devkit/core:core_rjs",
+        "//packages/angular_devkit/core/node:node_rjs",
     ],
 )
 
@@ -79,14 +77,12 @@ ts_project(
     name = "architect_test_lib",
     testonly = True,
     srcs = glob(["src/**/*_spec.ts"]),
-    interop_deps = [
-        "//packages/angular_devkit/core",
-    ],
     deps = [
         ":architect_rjs",
         "//:root_modules/@types/jasmine",
         "//:root_modules/rxjs",
         "//packages/angular_devkit/architect/testing:testing_rjs",
+        "//packages/angular_devkit/core:core_rjs",
     ],
 )
 

--- a/packages/angular_devkit/architect/node/BUILD.bazel
+++ b/packages/angular_devkit/architect/node/BUILD.bazel
@@ -16,15 +16,13 @@ ts_project(
         include = ["**/*.ts"],
         exclude = ["**/*_spec.ts"],
     ),
-    interop_deps = [
-        "//packages/angular_devkit/core",
-        "//packages/angular_devkit/core/node",
-    ],
     module_name = "@angular-devkit/architect/node",
     deps = [
         "//:root_modules/@types/node",
         "//:root_modules/rxjs",
         "//packages/angular_devkit/architect:architect_rjs",
+        "//packages/angular_devkit/core:core_rjs",
+        "//packages/angular_devkit/core/node:node_rjs",
     ],
 )
 
@@ -36,14 +34,12 @@ ts_project(
             "**/*_spec.ts",
         ],
     ),
-    interop_deps = [
-        "//tests/angular_devkit/architect/node/jobs:jobs_test_lib",
-    ],
     deps = [
         ":node_rjs",
         "//:root_modules/@types/jasmine",
         "//:root_modules/rxjs",
         "//packages/angular_devkit/architect:architect_rjs",
+        "//tests/angular_devkit/architect/node/jobs:jobs_test_lib_rjs",
     ],
 )
 

--- a/packages/angular_devkit/architect/testing/BUILD.bazel
+++ b/packages/angular_devkit/architect/testing/BUILD.bazel
@@ -15,14 +15,12 @@ ts_project(
         include = ["**/*.ts"],
         exclude = ["**/*_spec.ts"],
     ),
-    interop_deps = [
-        "//packages/angular_devkit/architect",
-        "//packages/angular_devkit/core",
-        "//packages/angular_devkit/core/node",
-    ],
     module_name = "@angular-devkit/architect/testing",
     deps = [
         "//:root_modules/@types/node",
         "//:root_modules/rxjs",
+        "//packages/angular_devkit/architect:architect_rjs",
+        "//packages/angular_devkit/core:core_rjs",
+        "//packages/angular_devkit/core/node:node_rjs",
     ],
 )

--- a/packages/angular_devkit/architect_cli/BUILD.bazel
+++ b/packages/angular_devkit/architect_cli/BUILD.bazel
@@ -14,10 +14,6 @@ ts_project(
     srcs = [
         "bin/architect.ts",
     ] + glob(["src/**/*.ts"]),
-    interop_deps = [
-        "//packages/angular_devkit/core",
-        "//packages/angular_devkit/core/node",
-    ],
     module_name = "@angular-devkit/architect-cli",
     deps = [
         "//:root_modules/@types/node",
@@ -26,6 +22,8 @@ ts_project(
         "//:root_modules/ansi-colors",
         "//packages/angular_devkit/architect:architect_rjs",
         "//packages/angular_devkit/architect/node:node_rjs",
+        "//packages/angular_devkit/core:core_rjs",
+        "//packages/angular_devkit/core/node:node_rjs",
     ],
 )
 

--- a/packages/angular_devkit/build_angular/BUILD.bazel
+++ b/packages/angular_devkit/build_angular/BUILD.bazel
@@ -119,13 +119,6 @@ ts_project(
         "builders.json",
         "package.json",
     ],
-    interop_deps = [
-        "//packages/angular/ssr",
-        "//packages/angular_devkit/build_webpack",
-        "//packages/angular_devkit/core",
-        "//packages/angular_devkit/core/node",
-        "//packages/ngtools/webpack",
-    ],
     module_name = "@angular-devkit/build-angular",
     deps = [
         "//:root_modules/@ampproject/remapping",
@@ -201,7 +194,12 @@ ts_project(
         "//:root_modules/webpack-subresource-integrity",
         "//packages/angular/build:build_rjs",
         "//packages/angular/build/private:private_rjs",
+        "//packages/angular/ssr:ssr_rjs",
         "//packages/angular_devkit/architect",
+        "//packages/angular_devkit/build_webpack:build_webpack_rjs",
+        "//packages/angular_devkit/core:core_rjs",
+        "//packages/angular_devkit/core/node:node_rjs",
+        "//packages/ngtools/webpack:webpack_rjs",
     ],
 )
 
@@ -217,9 +215,6 @@ ts_project(
         ],
     ),
     data = glob(["test/**/*"]),
-    interop_deps = [
-        "//packages/angular_devkit/core",
-    ],
     deps = [
         ":build_angular_rjs",
         ":build_angular_test_utils_rjs",
@@ -228,6 +223,7 @@ ts_project(
         "//:root_modules/typescript",
         "//:root_modules/webpack",
         "//packages/angular_devkit/architect/testing:testing_rjs",
+        "//packages/angular_devkit/core:core_rjs",
     ],
 )
 
@@ -285,19 +281,17 @@ ts_project(
         ],
     ),
     data = glob(["test/**/*"]),
-    interop_deps = [
-        "//modules/testing/builder",
-        "//packages/angular_devkit/core",
-        "//packages/angular_devkit/core/node",
-    ],
     deps = [
         ":build_angular_rjs",
         "//:root_modules/@types/jasmine",
+        "//modules/testing/builder:builder_rjs",
         "//packages/angular/build:build_rjs",
         "//packages/angular/build/private:private_rjs",
         "//packages/angular_devkit/architect:architect_rjs",
         "//packages/angular_devkit/architect/node:node_rjs",
         "//packages/angular_devkit/architect/testing:testing_rjs",
+        "//packages/angular_devkit/core:core_rjs",
+        "//packages/angular_devkit/core/node:node_rjs",
         "@npm//rxjs",
     ],
 )
@@ -308,10 +302,8 @@ LARGE_SPECS = {
         "shards": 10,
         "size": "large",
         "flaky": True,
-        "extra_interop_deps": [
-            "//packages/angular_devkit/build_webpack",
-        ],
         "extra_deps": [
+            "//packages/angular_devkit/build_webpack:build_webpack_rjs",
             "//:root_modules/@types/http-proxy",
             "//:root_modules/http-proxy",
             "//:root_modules/puppeteer",
@@ -364,10 +356,8 @@ LARGE_SPECS = {
     "prerender": {},
     "browser-esbuild": {},
     "ssr-dev-server": {
-        "extra_interop_deps": [
-            "//packages/angular/ssr/node",
-        ],
         "extra_deps": [
+            "//packages/angular/ssr/node:node_rjs",
             "//:root_modules/@types/browser-sync",
             "//:root_modules/browser-sync",
             "//:root_modules/express",
@@ -381,15 +371,12 @@ LARGE_SPECS = {
         name = "build_angular_" + spec + "_test_lib",
         testonly = True,
         srcs = glob(["src/builders/" + spec + "/**/*_spec.ts"]),
-        interop_deps = [
-            # Dependencies needed to compile and run the specs themselves.
-            "//packages/angular_devkit/core",
-            "//packages/angular_devkit/core/node",
-            "//modules/testing/builder",
-        ] + LARGE_SPECS[spec].get("extra_interop_deps", []),
         deps = [
             # Dependencies needed to compile and run the specs themselves.
             ":build_angular_rjs",
+            "//packages/angular_devkit/core:core_rjs",
+            "//packages/angular_devkit/core/node:node_rjs",
+            "//modules/testing/builder:builder_rjs",
             ":build_angular_test_utils_rjs",
             "//packages/angular/build:build_rjs",
             "//packages/angular/build/private:private_rjs",

--- a/packages/angular_devkit/build_webpack/BUILD.bazel
+++ b/packages/angular_devkit/build_webpack/BUILD.bazel
@@ -42,15 +42,13 @@ ts_project(
         "src/builders/webpack-dev-server/schema.json",
         "src/builders/webpack/schema.json",
     ],
-    interop_deps = [
-        "//packages/angular_devkit/architect",
-    ],
     module_name = "@angular-devkit/build-webpack",
     deps = [
         "//:root_modules/@types/node",
         "//:root_modules/rxjs",
         "//:root_modules/webpack",
         "//:root_modules/webpack-dev-server",
+        "//packages/angular_devkit/architect:architect_rjs",
     ],
 )
 
@@ -67,17 +65,15 @@ ts_project(
             "test/**/*",
         ],
     ),
-    interop_deps = [
-        "//packages/angular_devkit/core",
-        "//packages/angular_devkit/core/node",
-        "//packages/ngtools/webpack",
-        "//packages/angular_devkit/architect",
-        "//packages/angular_devkit/architect/node",
-        "//packages/angular_devkit/architect/testing",
-    ],
     deps = [
         ":build_webpack_rjs",
         "//:root_modules/@types/jasmine",
+        "//packages/angular_devkit/architect:architect_rjs",
+        "//packages/angular_devkit/architect/node:node_rjs",
+        "//packages/angular_devkit/architect/testing:testing_rjs",
+        "//packages/angular_devkit/core:core_rjs",
+        "//packages/angular_devkit/core/node:node_rjs",
+        "//packages/ngtools/webpack:webpack_rjs",
     ],
 )
 

--- a/packages/angular_devkit/schematics/BUILD.bazel
+++ b/packages/angular_devkit/schematics/BUILD.bazel
@@ -24,16 +24,14 @@ ts_project(
     data = [
         "package.json",
     ],
-    interop_deps = [
-        "//packages/angular_devkit/core",
-        "//packages/angular_devkit/core/node",  # TODO: get rid of this for 6.0
-    ],
     module_name = "@angular-devkit/schematics",
     deps = [
         "//:root_modules/@types/node",
         "//:root_modules/jsonc-parser",
         "//:root_modules/magic-string",
         "//:root_modules/rxjs",
+        "//packages/angular_devkit/core:core_rjs",
+        "//packages/angular_devkit/core/node:node_rjs",  # TODO: get rid of this for 6.0
     ],
 )
 
@@ -41,15 +39,13 @@ ts_project(
     name = "schematics_test_lib",
     testonly = True,
     srcs = glob(["src/**/*_spec.ts"]),
-    interop_deps = [
-        "//packages/angular_devkit/core",
-        "//packages/angular_devkit/core/node",
-        "//packages/angular_devkit/schematics/testing",
-    ],
     deps = [
-        ":schematics_rjs",
+        ":schematics",
         "//:root_modules/@types/jasmine",
         "//:root_modules/rxjs",
+        "//packages/angular_devkit/core:core_rjs",
+        "//packages/angular_devkit/core/node:node_rjs",
+        "//packages/angular_devkit/schematics/testing:testing_rjs",
     ],
 )
 

--- a/packages/angular_devkit/schematics/tasks/BUILD.bazel
+++ b/packages/angular_devkit/schematics/tasks/BUILD.bazel
@@ -18,15 +18,13 @@ ts_project(
         ],
     ),
     data = ["package.json"],
-    interop_deps = [
-        "//packages/angular_devkit/core",
-        "//packages/angular_devkit/core/node",
-        "//packages/angular_devkit/schematics",
-    ],
     module_name = "@angular-devkit/schematics/tasks",
     deps = [
         "//:root_modules/@types/node",
         "//:root_modules/ora",
         "//:root_modules/rxjs",
+        "//packages/angular_devkit/core:core_rjs",
+        "//packages/angular_devkit/core/node:node_rjs",
+        "//packages/angular_devkit/schematics:schematics_rjs",
     ],
 )

--- a/packages/angular_devkit/schematics/tasks/node/BUILD.bazel
+++ b/packages/angular_devkit/schematics/tasks/node/BUILD.bazel
@@ -16,15 +16,13 @@ ts_project(
             "**/*_spec.ts",
         ],
     ),
-    interop_deps = [
-        "//packages/angular_devkit/core",
-        "//packages/angular_devkit/core/node",
-        "//packages/angular_devkit/schematics",
-        "//packages/angular_devkit/schematics/tasks",
-    ],
     module_name = "@angular-devkit/schematics/tasks/node",
     deps = [
         "//:root_modules/@types/node",
         "//:root_modules/rxjs",
+        "//packages/angular_devkit/core:core_rjs",
+        "//packages/angular_devkit/core/node:node_rjs",
+        "//packages/angular_devkit/schematics:schematics_rjs",
+        "//packages/angular_devkit/schematics/tasks:tasks_rjs",
     ],
 )

--- a/packages/angular_devkit/schematics/testing/BUILD.bazel
+++ b/packages/angular_devkit/schematics/testing/BUILD.bazel
@@ -14,14 +14,12 @@ ts_project(
         include = ["**/*.ts"],
     ),
     data = ["package.json"],
-    interop_deps = [
-        "//packages/angular_devkit/core",
-        "//packages/angular_devkit/schematics",
-        "//packages/angular_devkit/schematics/tasks/node",
-        "//packages/angular_devkit/schematics/tools",
-    ],
     module_name = "@angular-devkit/schematics/testing",
     deps = [
         "//:root_modules/rxjs",
+        "//packages/angular_devkit/core:core_rjs",
+        "//packages/angular_devkit/schematics:schematics_rjs",
+        "//packages/angular_devkit/schematics/tasks/node:node_rjs",
+        "//packages/angular_devkit/schematics/tools:tools_rjs",
     ],
 )

--- a/packages/angular_devkit/schematics/tools/BUILD.bazel
+++ b/packages/angular_devkit/schematics/tools/BUILD.bazel
@@ -19,18 +19,16 @@ ts_project(
         ],
     ),
     data = ["package.json"],
-    interop_deps = [
-        "//packages/angular_devkit/core",
-        "//packages/angular_devkit/core/node",
-        "//packages/angular_devkit/schematics",
-        "//packages/angular_devkit/schematics/tasks",
-        "//packages/angular_devkit/schematics/tasks/node",
-    ],
     module_name = "@angular-devkit/schematics/tools",
     deps = [
         "//:root_modules/@types/node",
         "//:root_modules/jsonc-parser",
         "//:root_modules/rxjs",
+        "//packages/angular_devkit/core:core_rjs",
+        "//packages/angular_devkit/core/node:node_rjs",
+        "//packages/angular_devkit/schematics:schematics_rjs",
+        "//packages/angular_devkit/schematics/tasks:tasks_rjs",
+        "//packages/angular_devkit/schematics/tasks/node:node_rjs",
     ],
 )
 
@@ -43,18 +41,16 @@ ts_project(
             "test/**/*.ts",
         ],
     ),
-    interop_deps = [
-        "//packages/angular_devkit/core",
-        "//packages/angular_devkit/core/node",
-        "//packages/angular_devkit/schematics",
-        "//packages/angular_devkit/schematics/tasks",
-        "//packages/angular_devkit/schematics/testing",
-        "//tests/angular_devkit/schematics/tools/file-system-engine-host:file_system_engine_host_test_lib",
-    ],
     deps = [
         ":tools_rjs",
         "//:root_modules/@types/jasmine",
         "//:root_modules/rxjs",
+        "//packages/angular_devkit/core:core_rjs",
+        "//packages/angular_devkit/core/node:node_rjs",
+        "//packages/angular_devkit/schematics:schematics_rjs",
+        "//packages/angular_devkit/schematics/tasks:tasks_rjs",
+        "//packages/angular_devkit/schematics/testing:testing_rjs",
+        "//tests/angular_devkit/schematics/tools/file-system-engine-host:file_system_engine_host_test_lib_rjs",
     ],
 )
 

--- a/packages/angular_devkit/schematics_cli/BUILD.bazel
+++ b/packages/angular_devkit/schematics_cli/BUILD.bazel
@@ -41,11 +41,6 @@ ts_project(
             "schematic/files/**/*",
         ],
     ),
-    interop_deps = [
-        "//packages/angular_devkit/schematics",
-        "//packages/angular_devkit/schematics/tasks",
-        "//packages/angular_devkit/schematics/tools",
-    ],
     module_name = "@angular-devkit/schematics-cli",
     deps = [
         "//:root_modules/@inquirer/prompts",
@@ -56,6 +51,9 @@ ts_project(
         "//:root_modules/yargs-parser",
         "//packages/angular_devkit/core:core_rjs",
         "//packages/angular_devkit/core/node:node_rjs",
+        "//packages/angular_devkit/schematics:schematics_rjs",
+        "//packages/angular_devkit/schematics/tasks:tasks_rjs",
+        "//packages/angular_devkit/schematics/tools:tools_rjs",
     ],
 )
 

--- a/packages/ngtools/webpack/BUILD.bazel
+++ b/packages/ngtools/webpack/BUILD.bazel
@@ -46,14 +46,12 @@ ts_project(
             "src/**/*_spec_helpers.ts",
         ],
     ),
-    interop_deps = [
-        "//packages/angular_devkit/core",
-    ],
     deps = [
         ":webpack_rjs",
         "//:root_modules/@angular/compiler",
         "//:root_modules/@types/jasmine",
         "//:root_modules/typescript",
+        "//packages/angular_devkit/core:core_rjs",
     ],
 )
 

--- a/packages/schematics/angular/BUILD.bazel
+++ b/packages/schematics/angular/BUILD.bazel
@@ -78,10 +78,6 @@ ts_project(
             "node_modules/**",
         ],
     ),
-    interop_deps = [
-        "//packages/angular_devkit/schematics",
-        "//packages/angular_devkit/schematics/tasks",
-    ],
     module_name = "@schematics/angular",
     deps = [
         "//:root_modules/@inquirer/prompts",
@@ -89,6 +85,8 @@ ts_project(
         "//:root_modules/browserslist",
         "//:root_modules/jsonc-parser",
         "//packages/angular_devkit/core:core_rjs",
+        "//packages/angular_devkit/schematics:schematics_rjs",
+        "//packages/angular_devkit/schematics/tasks:tasks_rjs",
         "//packages/schematics/angular/third_party/github.com/Microsoft/TypeScript:TypeScript_rjs",
     ],
 )
@@ -115,17 +113,15 @@ ts_project(
             "node_modules/**",
         ],
     ),
-    interop_deps = [
-        "//packages/angular_devkit/schematics",
-        "//packages/angular_devkit/schematics/tasks",
-        "//packages/angular_devkit/schematics/testing",
-    ],
     deps = [
         ":angular_rjs",
         "//:root_modules/@types/jasmine",
         "//:root_modules/jsonc-parser",
         "//packages/angular_devkit/core:core_rjs",
         "//packages/angular_devkit/core/node/testing:testing_rjs",
+        "//packages/angular_devkit/schematics:schematics_rjs",
+        "//packages/angular_devkit/schematics/tasks:tasks_rjs",
+        "//packages/angular_devkit/schematics/testing:testing_rjs",
         "//packages/schematics/angular/third_party/github.com/Microsoft/TypeScript:TypeScript_rjs",
     ],
 )

--- a/tests/angular_devkit/schematics/tools/file-system-engine-host/BUILD.bazel
+++ b/tests/angular_devkit/schematics/tools/file-system-engine-host/BUILD.bazel
@@ -21,11 +21,9 @@ ts_project(
             "**/*.js",
         ],
     ),
-    interop_deps = [
-        "//packages/angular_devkit/schematics",
-    ],
     deps = [
         "//:root_modules/@types/jasmine",
         "//:root_modules/@types/node",
+        "//packages/angular_devkit/schematics:schematics_rjs",
     ],
 )

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -7,13 +7,11 @@ load("@aspect_bazel_lib//lib:utils.bzl", "to_label")
 load("@build_bazel_rules_nodejs//:index.bzl", _js_library = "js_library", _pkg_npm = "pkg_npm")
 load("@npm//@angular/bazel:index.bzl", _ng_module = "ng_module", _ng_package = "ng_package")
 load("@npm//@angular/build-tooling/bazel:extract_js_module_output.bzl", "extract_js_module_output")
-load("@npm//@bazel/concatjs:index.bzl", _ts_library = "ts_library")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("//:constants.bzl", "RELEASE_ENGINES_NODE", "RELEASE_ENGINES_NPM", "RELEASE_ENGINES_YARN")
 load("//tools:link_package_json_to_tarballs.bzl", "link_package_json_to_tarballs")
 load("//tools:snapshot_repo_filter.bzl", "SNAPSHOT_REPO_JQ_FILTER")
 
-_DEFAULT_TSCONFIG = "//:tsconfig-build.json"
 _DEFAULT_TSCONFIG_NG = "//:tsconfig-build-ng"
 _DEFAULT_TSCONFIG_TEST = "//:tsconfig-test.json"
 
@@ -52,43 +50,6 @@ def _default_module_name(testonly):
         return "@angular/" + pkg[len("packages/angular/"):]
 
     return None
-
-def ts_library(
-        name,
-        tsconfig = None,
-        testonly = False,
-        deps = [],
-        devmode_module = None,
-        devmode_target = None,
-        **kwargs):
-    """Default values for ts_library"""
-    if testonly:
-        # Match the types[] in //packages:tsconfig-test.json
-        deps.append("@npm//@types/jasmine")
-        deps.append("@npm//@types/node")
-    if not tsconfig:
-        if testonly:
-            tsconfig = _DEFAULT_TSCONFIG_TEST
-        else:
-            tsconfig = _DEFAULT_TSCONFIG
-
-    if not devmode_module:
-        devmode_module = "commonjs"
-    if not devmode_target:
-        devmode_target = "es2022"
-
-    _ts_library(
-        name = name,
-        testonly = testonly,
-        deps = deps,
-        # @external_begin
-        tsconfig = tsconfig,
-        devmode_module = devmode_module,
-        devmode_target = devmode_target,
-        prodmode_target = "es2022",
-        # @external_end
-        **kwargs
-    )
 
 js_library = _js_library
 

--- a/tools/interop.bzl
+++ b/tools/interop.bzl
@@ -97,7 +97,9 @@ ts_project_module = rule(
     },
 )
 
-def ts_project(name, module_name = None, interop_deps = [], deps = [], tsconfig = None, testonly = False, **kwargs):
+def ts_project(name, module_name = None, deps = [], tsconfig = None, testonly = False, **kwargs):
+    interop_deps = []
+
     # Pull in the `rules_nodejs` variants of dependencies we know are "hybrid". This
     # is necessary as we can't mix `npm/node_modules` from RNJS with the pnpm-style
     # symlink-dependent node modules. In addition, we need to extract `_rjs` interop
@@ -139,7 +141,7 @@ def ts_project(name, module_name = None, interop_deps = [], deps = [], tsconfig 
         dep = "%s_rjs" % name,
         # Forwarded dependencies for linker module mapping aspect.
         # RJS deps can also transitively pull in module mappings from their `interop_deps`.
-        deps = [] + interop_deps + deps,
+        deps = [] + ["%s_interop_deps" % name] + deps,
         module_name = module_name,
     )
 


### PR DESCRIPTION
* Removes `interop_deps` from the `ts_project` interop macro.
* Keeps `_rjs` suffix for now as we still need the interop targets for e.g. `jasmine_node_test` and the `rules_nodejs` linker.

In follow-ups we can remove the suffix, and interop layer.