### PR TITLE
fix(@angular-devkit/core): handle Windows drive letter case insensitivity in path functions

### DIFF
--- a/packages/angular_devkit/core/src/virtual-fs/path.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/path.ts
@@ -233,7 +233,7 @@ export function noCacheNormalize(path: string): Path {
   // Match absolute windows path.
   const original = path;
   if (path.match(/^[A-Z]:[/\\]/i)) {
-    path = '\\' + path[0] + '\\' + path.slice(3);
+    path = '\\' + path[0].toUpperCase() + '\\' + path.slice(3);
   }
 
   // We convert Windows paths as well here.

--- a/packages/angular_devkit/core/src/virtual-fs/path_spec.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/path_spec.ts
@@ -73,7 +73,7 @@ describe('path', () => {
     expect(normalize('\\a\\b\\c')).toBe('/a/b/c');
     expect(normalize('.\\a\\b\\c')).toBe('a/b/c');
     expect(normalize('C:\\a\\b\\c')).toBe('/C/a/b/c');
-    expect(normalize('c:\\a\\b\\c')).toBe('/c/a/b/c');
+    expect(normalize('c:\\a\\b\\c')).toBe('/C/a/b/c');
     expect(normalize('A:\\a\\b\\c')).toBe('/A/a/b/c');
     expect(() => normalize('A:\\..\\..')).toThrow(new InvalidPathException('A:\\..\\..'));
     expect(normalize('\\.\\a\\b\\c')).toBe('/a/b/c');
@@ -131,6 +131,7 @@ describe('path', () => {
       ['/src/app/sub1/test1', '/src/app/sub2/test2', '../../sub2/test2'],
       ['/', '/a/b/c', 'a/b/c'],
       ['/a/b/c', '/d', '../../../d'],
+      ['E:\\abc', 'e:\\abc\\def', 'def'],
     ];
 
     for (const [from, to, result] of tests) {
@@ -161,8 +162,8 @@ describe('path', () => {
   });
 
   it('asWindowsPath', () => {
-    expect(asWindowsPath(normalize('c:/'))).toBe('c:\\');
-    expect(asWindowsPath(normalize('c:/b/'))).toBe('c:\\b');
-    expect(asWindowsPath(normalize('c:/b/c'))).toBe('c:\\b\\c');
+    expect(asWindowsPath(normalize('c:/'))).toBe('C:\\');
+    expect(asWindowsPath(normalize('c:/b/'))).toBe('C:\\b');
+    expect(asWindowsPath(normalize('c:/b/c'))).toBe('C:\\b\\c');
   });
 });


### PR DESCRIPTION

This update ensures that path-related functions in account for the case-insensitivity of drive letters on Windows systems. By addressing this inconsistency, the functionality becomes more robust and aligned with Windows filesystem behavior.

Closes #27029
