### PR TITLE
ci: disable fixup commit messages

### DIFF
--- a/.aspect/rules/external_repository_action_cache/npm_translate_lock_MzA5NzUwNzMx
+++ b/.aspect/rules/external_repository_action_cache/npm_translate_lock_MzA5NzUwNzMx
@@ -2,7 +2,7 @@
 # Input hashes for repository rule npm_translate_lock(name = "npm2", pnpm_lock = "@//:pnpm-lock.yaml").
 # This file should be checked into version control along with the pnpm-lock.yaml file.
 .npmrc=-2023857461
-package.json=-1152125274
-pnpm-lock.yaml=1180140498
+package.json=-162262807
+pnpm-lock.yaml=1313582615
 pnpm-workspace.yaml=1711114604
-yarn.lock=-1642396400
+yarn.lock=-1768014107

--- a/.ng-dev/commit-message.mjs
+++ b/.ng-dev/commit-message.mjs
@@ -9,6 +9,7 @@ export const commitMessage = {
   maxLineLength: Infinity,
   minBodyLength: 0,
   minBodyLengthTypeExcludes: ['docs'],
+  disallowFixup: true,
   // Note: When changing this logic, also change the `contributing.ejs` file.
   scopes: packages.map(({ name }) => name),
 };

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@angular/forms": "19.1.0-rc.0",
     "@angular/localize": "19.1.0-rc.0",
     "@angular/material": "19.1.0-rc.0",
-    "@angular/ng-dev": "https://github.com/angular/dev-infra-private-ng-dev-builds.git#5d1a3e42cd27a30b988a5d0e40fca332c7a10aa0",
+    "@angular/ng-dev": "https://github.com/angular/dev-infra-private-ng-dev-builds.git#2dde6a7f809c2928ab1c7b85afb7fec0c49beafc",
     "@angular/platform-browser": "19.1.0-rc.0",
     "@angular/platform-browser-dynamic": "19.1.0-rc.0",
     "@angular/platform-server": "19.1.0-rc.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,8 +50,8 @@ importers:
         specifier: 19.1.0-rc.0
         version: 19.1.0-rc.0(@angular/animations@19.1.0-rc.0)(@angular/cdk@19.1.0-rc.0)(@angular/common@19.1.0-rc.0)(@angular/core@19.1.0-rc.0)(@angular/forms@19.1.0-rc.0)(@angular/platform-browser@19.1.0-rc.0)(rxjs@7.8.1)
       '@angular/ng-dev':
-        specifier: https://github.com/angular/dev-infra-private-ng-dev-builds.git#5d1a3e42cd27a30b988a5d0e40fca332c7a10aa0
-        version: github.com/angular/dev-infra-private-ng-dev-builds/5d1a3e42cd27a30b988a5d0e40fca332c7a10aa0
+        specifier: https://github.com/angular/dev-infra-private-ng-dev-builds.git#2dde6a7f809c2928ab1c7b85afb7fec0c49beafc
+        version: github.com/angular/dev-infra-private-ng-dev-builds/2dde6a7f809c2928ab1c7b85afb7fec0c49beafc
       '@angular/platform-browser':
         specifier: 19.1.0-rc.0
         version: 19.1.0-rc.0(@angular/animations@19.1.0-rc.0)(@angular/common@19.1.0-rc.0)(@angular/core@19.1.0-rc.0)
@@ -14770,10 +14770,10 @@ packages:
       - zone.js
     dev: true
 
-  github.com/angular/dev-infra-private-ng-dev-builds/5d1a3e42cd27a30b988a5d0e40fca332c7a10aa0:
-    resolution: {tarball: https://codeload.github.com/angular/dev-infra-private-ng-dev-builds/tar.gz/5d1a3e42cd27a30b988a5d0e40fca332c7a10aa0}
+  github.com/angular/dev-infra-private-ng-dev-builds/2dde6a7f809c2928ab1c7b85afb7fec0c49beafc:
+    resolution: {tarball: https://codeload.github.com/angular/dev-infra-private-ng-dev-builds/tar.gz/2dde6a7f809c2928ab1c7b85afb7fec0c49beafc}
     name: '@angular/ng-dev'
-    version: 0.0.0-5b4b2a6258dece411626435f680d2818769f469a
+    version: 0.0.0-7863aba23429b9cdb432a63cb688dd4c61f51ce6
     hasBin: true
     dependencies:
       '@google-cloud/spanner': 7.17.1(supports-color@10.0.0)

--- a/yarn.lock
+++ b/yarn.lock
@@ -323,7 +323,7 @@ __metadata:
     "@angular/forms": "npm:19.1.0-rc.0"
     "@angular/localize": "npm:19.1.0-rc.0"
     "@angular/material": "npm:19.1.0-rc.0"
-    "@angular/ng-dev": "https://github.com/angular/dev-infra-private-ng-dev-builds.git#5d1a3e42cd27a30b988a5d0e40fca332c7a10aa0"
+    "@angular/ng-dev": "https://github.com/angular/dev-infra-private-ng-dev-builds.git#2dde6a7f809c2928ab1c7b85afb7fec0c49beafc"
     "@angular/platform-browser": "npm:19.1.0-rc.0"
     "@angular/platform-browser-dynamic": "npm:19.1.0-rc.0"
     "@angular/platform-server": "npm:19.1.0-rc.0"
@@ -536,9 +536,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@angular/ng-dev@https://github.com/angular/dev-infra-private-ng-dev-builds.git#5d1a3e42cd27a30b988a5d0e40fca332c7a10aa0":
-  version: 0.0.0-5b4b2a6258dece411626435f680d2818769f469a
-  resolution: "@angular/ng-dev@https://github.com/angular/dev-infra-private-ng-dev-builds.git#commit=5d1a3e42cd27a30b988a5d0e40fca332c7a10aa0"
+"@angular/ng-dev@https://github.com/angular/dev-infra-private-ng-dev-builds.git#2dde6a7f809c2928ab1c7b85afb7fec0c49beafc":
+  version: 0.0.0-7863aba23429b9cdb432a63cb688dd4c61f51ce6
+  resolution: "@angular/ng-dev@https://github.com/angular/dev-infra-private-ng-dev-builds.git#commit=2dde6a7f809c2928ab1c7b85afb7fec0c49beafc"
   dependencies:
     "@google-cloud/spanner": "npm:7.17.1"
     "@octokit/rest": "npm:21.1.0"
@@ -553,7 +553,7 @@ __metadata:
     yaml: "npm:2.7.0"
   bin:
     ng-dev: ./bundles/cli.mjs
-  checksum: 10c0/47d0904ebd62c680aa7c34e5c63059536ce2fa4b8d71671e373e4d089159b780da19a16711798b02c44ed1323b52c195140fd27df3b673b6577547cf3a8ac17e
+  checksum: 10c0/452de4595fae7e7a645b81cc0f5853617ae6a13ceb68d967e3fc15505848bc2a8955cc2b678d2254d83f148d9e47192d0013eac1defbba112e9313026f9291a8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixup commit messages are not permitted in this repository. This update modifies the `ng-dev` commit message validator configuration to prevent such commits.

