### PR TITLE
refactor(@angular/cli): replace `VERSION` with Bazel-stamped version

### DIFF
--- a/packages/angular/cli/src/utilities/version.ts
+++ b/packages/angular/cli/src/utilities/version.ts
@@ -6,16 +6,13 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import { readFileSync } from 'fs';
-import { resolve } from 'path';
-
 // Same structure as used in framework packages
 class Version {
-  public readonly major: string;
-  public readonly minor: string;
-  public readonly patch: string;
+  readonly major: string;
+  readonly minor: string;
+  readonly patch: string;
 
-  constructor(public readonly full: string) {
+  constructor(readonly full: string) {
     const [major, minor, patch] = full.split('-', 1)[0].split('.', 3);
     this.major = major;
     this.minor = minor;
@@ -23,12 +20,4 @@ class Version {
   }
 }
 
-// TODO(bazel): Convert this to use build-time version stamping after flipping the build script to use bazel
-// export const VERSION = new Version('0.0.0-PLACEHOLDER');
-export const VERSION = new Version(
-  (
-    JSON.parse(readFileSync(resolve(__dirname, '../../package.json'), 'utf-8')) as {
-      version: string;
-    }
-  ).version,
-);
+export const VERSION = new Version('0.0.0-PLACEHOLDER');


### PR DESCRIPTION
Previously, the version was retrieved from the `package.json`. With this update, the version is now sourced using Bazel stamping.

