### PR TITLE
refactor(@angular/build): move Angular compilation creation to build execution

### DIFF
--- a/packages/angular/build/src/builders/application/execute-build.ts
+++ b/packages/angular/build/src/builders/application/execute-build.ts
@@ -7,6 +7,7 @@
  */
 
 import { BuilderContext } from '@angular-devkit/architect';
+import { createAngularCompilation } from '../../tools/angular/compilation';
 import { SourceFileCache } from '../../tools/esbuild/angular/source-file-cache';
 import { generateBudgetStats } from '../../tools/esbuild/budget-stats';
 import {
@@ -108,6 +109,8 @@ export async function executeBuild(
       target,
       codeBundleCache,
       componentStyleBundler,
+      // Create new reusable compilation for the appropriate mode based on the `jit` plugin option
+      await createAngularCompilation(!!options.jit, !options.serverEntryPoint),
       templateUpdates,
     );
 

--- a/packages/angular/build/src/builders/application/setup-bundling.ts
+++ b/packages/angular/build/src/builders/application/setup-bundling.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import { AngularCompilation } from '../../tools/angular/compilation';
 import { ComponentStylesheetBundler } from '../../tools/esbuild/angular/component-stylesheets';
 import { SourceFileCache } from '../../tools/esbuild/angular/source-file-cache';
 import {
@@ -34,6 +35,7 @@ export function setupBundlerContexts(
   target: string[],
   codeBundleCache: SourceFileCache,
   stylesheetBundler: ComponentStylesheetBundler,
+  angularCompilation: AngularCompilation,
   templateUpdates: Map<string, string> | undefined,
 ): {
   typescriptContexts: BundlerContext[];
@@ -61,6 +63,7 @@ export function setupBundlerContexts(
         target,
         codeBundleCache,
         stylesheetBundler,
+        angularCompilation,
         templateUpdates,
       ),
     ),

--- a/packages/angular/build/src/private.ts
+++ b/packages/angular/build/src/private.ts
@@ -13,6 +13,7 @@
  * their existence may change in any future version.
  */
 
+import { NoopCompilation, createAngularCompilation } from './tools/angular/compilation';
 import {
   CompilerPluginOptions,
   createCompilerPlugin as internalCreateCompilerPlugin,
@@ -38,11 +39,17 @@ export { createJitResourceTransformer } from './tools/angular/transformers/jit-r
 export { JavaScriptTransformer } from './tools/esbuild/javascript-transformer';
 
 export function createCompilerPlugin(
-  pluginOptions: CompilerPluginOptions,
+  pluginOptions: CompilerPluginOptions & {
+    browserOnlyBuild?: boolean;
+    noopTypeScriptCompilation?: boolean;
+  },
   styleOptions: BundleStylesheetOptions & { inlineStyleLanguage: string },
 ): import('esbuild').Plugin {
   return internalCreateCompilerPlugin(
     pluginOptions,
+    pluginOptions.noopTypeScriptCompilation
+      ? new NoopCompilation()
+      : () => createAngularCompilation(!!pluginOptions.jit, !!pluginOptions.browserOnlyBuild),
     new ComponentStylesheetBundler(
       styleOptions,
       styleOptions.inlineStyleLanguage,

--- a/packages/angular/build/src/tools/esbuild/application-code-bundle.ts
+++ b/packages/angular/build/src/tools/esbuild/application-code-bundle.ts
@@ -17,6 +17,7 @@ import {
   SERVER_APP_ENGINE_MANIFEST_FILENAME,
   SERVER_APP_MANIFEST_FILENAME,
 } from '../../utils/server-rendering/manifest';
+import { AngularCompilation, NoopCompilation } from '../angular/compilation';
 import { createCompilerPlugin } from './angular/compiler-plugin';
 import { ComponentStylesheetBundler } from './angular/component-stylesheets';
 import { SourceFileCache } from './angular/source-file-cache';
@@ -39,6 +40,7 @@ export function createBrowserCodeBundleOptions(
   target: string[],
   sourceFileCache: SourceFileCache,
   stylesheetBundler: ComponentStylesheetBundler,
+  angularCompilation: AngularCompilation,
   templateUpdates: Map<string, string> | undefined,
 ): BundlerOptionsFactory {
   return (loadCache) => {
@@ -73,6 +75,7 @@ export function createBrowserCodeBundleOptions(
         createCompilerPlugin(
           // JS/TS options
           pluginOptions,
+          angularCompilation,
           // Component stylesheet bundler
           stylesheetBundler,
         ),
@@ -135,7 +138,9 @@ export function createBrowserPolyfillBundleOptions(
     buildOptions.plugins.push(
       createCompilerPlugin(
         // JS/TS options
-        { ...pluginOptions, noopTypeScriptCompilation: true },
+        pluginOptions,
+        // Browser compilation handles the actual Angular code compilation
+        new NoopCompilation(),
         // Component stylesheet options are unused for polyfills but required by the plugin
         stylesheetBundler,
       ),
@@ -276,7 +281,9 @@ export function createServerMainCodeBundleOptions(
         createAngularLocalizeInitWarningPlugin(),
         createCompilerPlugin(
           // JS/TS options
-          { ...pluginOptions, noopTypeScriptCompilation: true },
+          pluginOptions,
+          // Browser compilation handles the actual Angular code compilation
+          new NoopCompilation(),
           // Component stylesheet bundler
           stylesheetBundler,
         ),
@@ -416,7 +423,9 @@ export function createSsrEntryCodeBundleOptions(
         createAngularLocalizeInitWarningPlugin(),
         createCompilerPlugin(
           // JS/TS options
-          { ...pluginOptions, noopTypeScriptCompilation: true },
+          pluginOptions,
+          // Browser compilation handles the actual Angular code compilation
+          new NoopCompilation(),
           // Component stylesheet bundler
           stylesheetBundler,
         ),

--- a/packages/angular/build/src/tools/esbuild/compiler-plugin-options.ts
+++ b/packages/angular/build/src/tools/esbuild/compiler-plugin-options.ts
@@ -31,7 +31,6 @@ export function createCompilerPluginOptions(
   const incremental = !!options.watch;
 
   return {
-    browserOnlyBuild: !options.serverEntryPoint,
     sourcemap: !!sourcemapOptions.scripts && (sourcemapOptions.hidden ? 'external' : true),
     thirdPartySourcemaps: sourcemapOptions.vendor,
     tsconfig,


### PR DESCRIPTION
The creation of the internal Angular compilation used by the internal esbuild plugin is now created within the main execution phase of the build process. This is causes no behavior changes but provides the infrastructure for several addition refactoring improvements including performance improvements of the HMR process. The private API for the `createCompilerPlugin` has kept its function signature and currently is not affected by this change.