### PR TITLE
build: remove unused ng_module rule

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -6,7 +6,6 @@ load("@aspect_rules_ts//ts:defs.bzl", rules_js_tsconfig = "ts_config")
 # found in the LICENSE file at https://angular.dev/license
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load("@build_bazel_rules_nodejs//:index.bzl", "copy_to_bin")
-load("@npm//@bazel/concatjs:index.bzl", "ts_config")
 load("@npm2//:defs.bzl", "npm_link_all_packages")
 
 package(default_visibility = ["//visibility:public"])
@@ -91,12 +90,4 @@ config_setting(
     flag_values = {
         ":enable_snapshot_repo_deps": "true",
     },
-)
-
-ts_config(
-    name = "tsconfig-build-ng",
-    src = "tsconfig-build-ng.json",
-    deps = [
-        ":tsconfig.json",
-    ],
 )

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -5,14 +5,13 @@ load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
 load("@aspect_bazel_lib//lib:jq.bzl", "jq")
 load("@aspect_bazel_lib//lib:utils.bzl", "to_label")
 load("@build_bazel_rules_nodejs//:index.bzl", _js_library = "js_library", _pkg_npm = "pkg_npm")
-load("@npm//@angular/bazel:index.bzl", _ng_module = "ng_module", _ng_package = "ng_package")
+load("@npm//@angular/bazel:index.bzl", _ng_package = "ng_package")
 load("@npm//@angular/build-tooling/bazel:extract_js_module_output.bzl", "extract_js_module_output")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("//tools:link_package_json_to_tarballs.bzl", "link_package_json_to_tarballs")
 load("//tools:snapshot_repo_filter.bzl", "SNAPSHOT_REPO_JQ_FILTER")
 load("//tools:substitutions.bzl", "NO_STAMP_PACKAGE_SUBSTITUTIONS", "NPM_PACKAGE_SUBSTITUTIONS")
 
-_DEFAULT_TSCONFIG_NG = "//:tsconfig-build-ng"
 _DEFAULT_TSCONFIG_TEST = "//:tsconfig-test.json"
 
 def _default_module_name(testonly):
@@ -176,45 +175,6 @@ def pkg_npm(name, pkg_deps = [], use_prodmode_output = False, **kwargs):
             strip_prefix = "./%s" % name,
             visibility = visibility,
         )
-
-def ng_module(name, tsconfig = None, entry_point = None, testonly = False, deps = [], module_name = None, package_name = None, **kwargs):
-    """Default values for ng_module"""
-    deps = deps + ["@npm//tslib"]
-    if testonly:
-        # Match the types[] in //packages:tsconfig-test.json
-        deps.append("@npm//@types/jasmine")
-        deps.append("@npm//@types/node")
-    if not tsconfig:
-        if testonly:
-            tsconfig = _DEFAULT_TSCONFIG_TEST
-        else:
-            tsconfig = _DEFAULT_TSCONFIG_NG
-
-    if not module_name:
-        module_name = _default_module_name(testonly)
-
-    # If no `package_name` is explicitly set, we use the default module name as package
-    # name, so that the target can be resolved within NodeJS executions, by activating
-    # the Bazel NodeJS linker. See: https://github.com/bazelbuild/rules_nodejs/pull/2799.
-    if not package_name:
-        package_name = _default_module_name(testonly)
-
-    if not entry_point:
-        entry_point = "public_api.ts"
-    _ng_module(
-        name = name,
-        flat_module_out_file = name,
-        tsconfig = tsconfig,
-        entry_point = entry_point,
-        testonly = testonly,
-        deps = deps,
-        # `module_name` is used for AMD module names within emitted JavaScript files.
-        module_name = module_name,
-        # `package_name` can be set to allow for the Bazel NodeJS linker to run. This
-        # allows for resolution of the given target within the `node_modules/`.
-        package_name = package_name,
-        **kwargs
-    )
 
 def ng_package(deps = [], **kwargs):
     _ng_package(


### PR DESCRIPTION
The ssr package uses ts_project directly now.