### PR TITLE
refactor(@ngtools/webpack): add return types to functions

### DIFF
--- a/packages/ngtools/webpack/src/benchmark.ts
+++ b/packages/ngtools/webpack/src/benchmark.ts
@@ -11,13 +11,13 @@
 // This should be false for commited code.
 const _benchmark = false;
 /* eslint-disable no-console */
-export function time(label: string) {
+export function time(label: string): void {
   if (_benchmark) {
     console.time(label);
   }
 }
 
-export function timeEnd(label: string) {
+export function timeEnd(label: string): void {
   if (_benchmark) {
     console.timeEnd(label);
   }

--- a/packages/ngtools/webpack/src/ivy/host.ts
+++ b/packages/ngtools/webpack/src/ivy/host.ts
@@ -21,7 +21,7 @@ export function augmentHostWithResources(
     directTemplateLoading?: boolean;
     inlineStyleFileExtension?: string;
   } = {},
-) {
+): void {
   const resourceHost = host as CompilerHost;
 
   resourceHost.readResource = function (fileName: string) {

--- a/packages/ngtools/webpack/src/ivy/loader.ts
+++ b/packages/ngtools/webpack/src/ivy/loader.ts
@@ -12,7 +12,11 @@ import { AngularPluginSymbol, FileEmitterCollection } from './symbol';
 
 const JS_FILE_REGEXP = /\.[cm]?js$/;
 
-export function angularWebpackLoader(this: LoaderContext<unknown>, content: string, map: string) {
+export function angularWebpackLoader(
+  this: LoaderContext<unknown>,
+  content: string,
+  map: string,
+): void {
   const callback = this.async();
   if (!callback) {
     throw new Error('Invalid webpack version');

--- a/packages/ngtools/webpack/src/loaders/inline-resource.ts
+++ b/packages/ngtools/webpack/src/loaders/inline-resource.ts
@@ -16,7 +16,7 @@ export interface CompilationWithInlineAngularResource extends Compilation {
   [InlineAngularResourceSymbol]: string;
 }
 
-export default function (this: LoaderContext<{ data?: string }>) {
+export default function (this: LoaderContext<{ data?: string }>): void {
   const callback = this.async();
   const { data } = this.getOptions();
 

--- a/packages/ngtools/webpack/src/resource_loader.ts
+++ b/packages/ngtools/webpack/src/resource_loader.ts
@@ -46,7 +46,7 @@ export class WebpackResourceLoader {
     }
   }
 
-  update(parentCompilation: Compilation, changedFiles?: Iterable<string>) {
+  update(parentCompilation: Compilation, changedFiles?: Iterable<string>): void {
     this._parentCompilation = parentCompilation;
 
     // Update resource cache and modified resources
@@ -82,23 +82,23 @@ export class WebpackResourceLoader {
     }
   }
 
-  clearParentCompilation() {
+  clearParentCompilation(): void {
     this._parentCompilation = undefined;
   }
 
-  getModifiedResourceFiles() {
+  getModifiedResourceFiles(): Set<string> {
     return this.modifiedResources;
   }
 
-  getResourceDependencies(filePath: string) {
+  getResourceDependencies(filePath: string): Iterable<string> {
     return this._fileDependencies.get(filePath) || [];
   }
 
-  getAffectedResources(file: string) {
+  getAffectedResources(file: string): Iterable<string> {
     return this._reverseDependencies.get(file) || [];
   }
 
-  setAffectedResources(file: string, resources: Iterable<string>) {
+  setAffectedResources(file: string, resources: Iterable<string>): void {
     this._reverseDependencies.set(file, new Set(resources));
   }
 

--- a/packages/ngtools/webpack/src/transformers/spec_helpers.ts
+++ b/packages/ngtools/webpack/src/transformers/spec_helpers.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import { basename } from 'path';
-import * as ts from 'typescript';
+import { basename } from 'node:path';
+import ts from 'typescript';
 
 // Test transform helpers.
 const basefileName = 'test-file.ts';
@@ -18,7 +18,10 @@ export function createTypescriptContext(
   useLibs = false,
   extraCompilerOptions: ts.CompilerOptions = {},
   jsxFile = false,
-) {
+): {
+  compilerHost: ts.CompilerHost;
+  program: ts.Program;
+} {
   const fileName = basefileName + (jsxFile ? 'x' : '');
   // Set compiler options.
   const compilerOptions: ts.CompilerOptions = {


### PR DESCRIPTION
Functions that are exported from files within the `@ngtools/webpack` package now contain return types. This improves code readability as well as being a requirement for eventual isolated declarations usage.