### PR TITLE
fix(@angular/build): warn when using both `isolatedModules` and `emitDecoratorMetadata`

### DIFF
--- a/packages/angular/build/src/tools/esbuild/angular/compiler-plugin.ts
+++ b/packages/angular/build/src/tools/esbuild/angular/compiler-plugin.ts
@@ -689,6 +689,20 @@ function createCompilerOptionsTransformer(
       });
     }
 
+    if (compilerOptions.isolatedModules && compilerOptions.emitDecoratorMetadata) {
+      setupWarnings?.push({
+        text: `TypeScript compiler option 'isolatedModules' may prevent the 'emitDecoratorMetadata' option from emitting all metadata.`,
+        location: null,
+        notes: [
+          {
+            text:
+              `The 'emitDecoratorMetadata' option is not required by Angular` +
+              'and can be removed if not explictly required by the project.',
+          },
+        ],
+      });
+    }
+
     // Synchronize custom resolve conditions.
     // Set if using the supported bundler resolution mode (bundler is the default in new projects)
     if (compilerOptions.moduleResolution === 100 /* ModuleResolutionKind.Bundler */) {


### PR DESCRIPTION
If both the `isolatedModules` and `emitDecoratorMetadata` Typescript options are enabled within a project, a warning will now be issued explaining that not all metadata may be emitting for each decorator. Isolated modules may not have access to non-local type information that would otherwise be needed for complete metadata emit.

The `emitDecoratorMetadata` option is not required by Angular and can cause runtime errors due to its underlying implementation when used with ES2015+ output. The option is only compatible with the experimental decorators and cannot be used with standard decorators. New Angular projects also do not enable this option. Removing the `emitDecoratorMetadata` option will remove the warning.  The majority of projects do not require the option and it may cease to function as standard decorators become more common.

Closes #28155