### PR TITLE
refactor(@ngtools/webpack): add types to exported module variables

### DIFF
--- a/packages/ngtools/webpack/src/ivy/index.ts
+++ b/packages/ngtools/webpack/src/ivy/index.ts
@@ -9,4 +9,4 @@
 export { angularWebpackLoader as default } from './loader';
 export { type AngularWebpackPluginOptions, AngularWebpackPlugin, imageDomains } from './plugin';
 
-export const AngularWebpackLoaderPath = __filename;
+export const AngularWebpackLoaderPath: string = __filename;

--- a/packages/ngtools/webpack/src/ivy/paths.ts
+++ b/packages/ngtools/webpack/src/ivy/paths.ts
@@ -34,7 +34,7 @@ function externalizeForWindows(path: string): string {
   return result;
 }
 
-export const externalizePath = (() => {
+export const externalizePath: typeof externalizeForWindows = (() => {
   if (process.platform !== 'win32') {
     return (path: string) => path;
   }

--- a/packages/ngtools/webpack/src/ivy/plugin.ts
+++ b/packages/ngtools/webpack/src/ivy/plugin.ts
@@ -39,7 +39,7 @@ import { createAotTransformers, createJitTransformers, mergeTransformers } from 
  */
 const DIAGNOSTICS_AFFECTED_THRESHOLD = 1;
 
-export const imageDomains = new Set<string>();
+export const imageDomains: Set<string> = new Set();
 
 export interface AngularWebpackPluginOptions {
   tsconfig: string;

--- a/packages/ngtools/webpack/src/ivy/symbol.ts
+++ b/packages/ngtools/webpack/src/ivy/symbol.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-export const AngularPluginSymbol = Symbol.for('@ngtools/webpack[angular-compiler]');
+export const AngularPluginSymbol: unique symbol = Symbol.for('@ngtools/webpack[angular-compiler]');
 
 export interface EmitFileResult {
   content?: string;

--- a/packages/ngtools/webpack/src/loaders/inline-resource.ts
+++ b/packages/ngtools/webpack/src/loaders/inline-resource.ts
@@ -8,9 +8,11 @@
 
 import type { Compilation, LoaderContext } from 'webpack';
 
-export const InlineAngularResourceLoaderPath = __filename;
+export const InlineAngularResourceLoaderPath: string = __filename;
 
-export const InlineAngularResourceSymbol = Symbol('@ngtools/webpack[angular-resource]');
+export const InlineAngularResourceSymbol: unique symbol = Symbol(
+  '@ngtools/webpack[angular-resource]',
+);
 
 export interface CompilationWithInlineAngularResource extends Compilation {
   [InlineAngularResourceSymbol]: string;


### PR DESCRIPTION
Adding explicit type information for a module's exported variables allows the `@ngtools/webpack` package to be built with the `isolatedDeclarations` option.