### PR TITLE
fix(@angular/cli): handles not found packages for ng-update

### DIFF
--- a/packages/angular/cli/src/commands/update/schematic/index_spec.ts
+++ b/packages/angular/cli/src/commands/update/schematic/index_spec.ts
@@ -71,6 +71,28 @@ describe('@schematics/update', () => {
     );
   }, 45000);
 
+  it('ignores dependencies hosted on alternative/private NPM registries', async () => {
+    let newTree = new UnitTestTree(
+      new HostTree(
+        new virtualFs.test.TestHost({
+          '/package.json': `{
+        "name": "blah",
+        "dependencies": {
+          "@fortawesome/pro-thin-svg-icons": "^6.6.0",
+          "@nostr/tools": "npm:@jsr/nostr__tools@^2.10.3"
+        }
+      }`,
+          '/.npmrc': `@jsr:registry=https://npm.jsr.io`,
+        }),
+      ),
+    );
+
+    newTree = await schematicRunner.runSchematic('update', undefined, newTree);
+    const packageJson = JSON.parse(newTree.readContent('/package.json'));
+    expect(packageJson['dependencies']['@fortawesome/pro-thin-svg-icons']).toBe('^6.6.0');
+    expect(packageJson['dependencies']['@nostr/tools']).toBe('npm:@jsr/nostr__tools@^2.10.3');
+  }, 45000);
+
   it('should not error with yarn 2.0 protocols', async () => {
     let newTree = new UnitTestTree(
       new HostTree(

--- a/packages/angular/cli/src/utilities/package-metadata.ts
+++ b/packages/angular/cli/src/utilities/package-metadata.ts
@@ -317,14 +317,20 @@ export async function getNpmPackageJson(
     fullMetadata: true,
     ...npmrc,
     ...(registry ? { registry } : {}),
-  }).then((response) => {
-    // While pacote type declares that versions cannot be undefined this is not the case.
-    if (!response.versions) {
-      response.versions = {};
-    }
+  })
+    .then((response) => {
+      // While pacote type declares that versions cannot be undefined this is not the case.
+      if (!response.versions) {
+        response.versions = {};
+      }
 
-    return response;
-  });
+      return response;
+    })
+    .catch((err) => {
+      logger.warn(`Could not find ${packageName}`, { err });
+
+      return {} as Partial<NpmRepositoryPackageJson>;
+    });
 
   npmPackageJsonCache.set(packageName, response);
 


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #28834 

## What is the new behavior?

<!-- Please describe the new behavior that. -->
Packages in private or unknown repositories that cannot be found are skipped when trying to run `ng update`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
