### PR TITLE
docs: release notes for the v19.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
-<a name="19.1.0-rc.0"></a>
+<a name="19.1.0"></a>
 
-# 19.1.0-rc.0 (2025-01-08)
+# 19.1.0 (2025-01-15)
+
+## Deprecations
+
+### @angular/build
+
+- The `baseHref` option under `i18n.locales` and `i18n.sourceLocale` in `angular.json` is deprecated in favor of `subPath`.
+
+  The `subPath` defines the URL segment for the locale, serving as both the HTML base HREF and the directory name for output. By default, if not specified, `subPath` will use the locale code.
 
 ### @schematics/angular
 
@@ -11,38 +19,48 @@
 
 ### @angular-devkit/architect
 
-| Commit                                                                                              | Type | Description                                      |
-| --------------------------------------------------------------------------------------------------- | ---- | ------------------------------------------------ |
-| [aa6bf07f3](https://github.com/angular/angular-cli/commit/aa6bf07f35fd0eab9e319ddedadafa06d027da47) | fix  | provide better error when builder is not defined |
+| Commit                                                                                              | Type | Description                                          |
+| --------------------------------------------------------------------------------------------------- | ---- | ---------------------------------------------------- |
+| [2b8a02bac](https://github.com/angular/angular-cli/commit/2b8a02bac098d4ac4f31b0e74bedfc739171e30b) | feat | require build schemas from modules                   |
+| [fe1ae6933](https://github.com/angular/angular-cli/commit/fe1ae6933998104c144b2c8854f362289c8d91c6) | fix  | avoid Node.js resolution for relative builder schema |
 
-### @angular-devkit/build-angular
+### @angular-devkit/core
 
-| Commit                                                                                              | Type | Description                       |
-| --------------------------------------------------------------------------------------------------- | ---- | --------------------------------- |
-| [916979c8a](https://github.com/angular/angular-cli/commit/916979c8a74a90788cf8c2379e08e05d48eb777e) | fix  | preserve css type for jasmine.css |
+| Commit                                                                                              | Type | Description                                                      |
+| --------------------------------------------------------------------------------------------------- | ---- | ---------------------------------------------------------------- |
+| [ce7c4e203](https://github.com/angular/angular-cli/commit/ce7c4e203d0312d21d4a3d1955f9c97bdf3e06d2) | fix  | handle Windows drive letter case insensitivity in path functions |
+
+### @angular-devkit/schematics
+
+| Commit                                                                                              | Type | Description                                                   |
+| --------------------------------------------------------------------------------------------------- | ---- | ------------------------------------------------------------- |
+| [2f55209dd](https://github.com/angular/angular-cli/commit/2f55209dd24602bdf8c27ef083f96b5f55166971) | fix  | update `Rule` type to support returning a `Promise` of `Tree` |
 
 ### @angular/build
 
-| Commit                                                                                              | Type | Description                                                             |
-| --------------------------------------------------------------------------------------------------- | ---- | ----------------------------------------------------------------------- |
-| [2c9d7368f](https://github.com/angular/angular-cli/commit/2c9d7368fc30f3488152e35ac468db5f2a9432f2) | feat | add ng-packagr builder to the package                                   |
-| [2f921219f](https://github.com/angular/angular-cli/commit/2f921219f99c846e04d699ba099928e5fbbd8629) | fix  | add asset tracking to application builder watch files                   |
-| [a5618693a](https://github.com/angular/angular-cli/commit/a5618693a12daf28fdfc1f791dd36889eeff6095) | fix  | do not mark Babel \_defineProperty helper function as pure              |
-| [ef3dc2ed0](https://github.com/angular/angular-cli/commit/ef3dc2ed02cd997ccb0cb7ab6ff563eec31c5d9e) | fix  | enable serving files with bundle-like names                             |
-| [e76800ce5](https://github.com/angular/angular-cli/commit/e76800ce54abf388fd8762fc7a298729fb58650f) | fix  | fix incorrect budget calculation                                        |
-| [a0b4ea23c](https://github.com/angular/angular-cli/commit/a0b4ea23c45ce048fcd9c8fa9d7ef74107a5d07d) | fix  | handle relative URLs when constructing new URLs during server fetch     |
-| [5cc62d4a3](https://github.com/angular/angular-cli/commit/5cc62d4a30d8353fc56aaa6dfb9c58e51cd092f5) | fix  | mitigate JS transformer worker execArgv errors                          |
-| [8639a3b6d](https://github.com/angular/angular-cli/commit/8639a3b6d981ddef84c0f4d70b6a941fc866b82b) | fix  | pass `define` option defined in application builder to Vite prebundling |
-| [48cae815c](https://github.com/angular/angular-cli/commit/48cae815cfd0124217c1b5bc8c92dfdb0b150101) | fix  | skip vite SSR warmup file configuration when SSR is disabled            |
-| [ba16ad6b5](https://github.com/angular/angular-cli/commit/ba16ad6b56e9a1ae0f380141bc1e1253a75fcf6b) | fix  | support incremental build file results in watch mode                    |
-| [bfe9ee36c](https://github.com/angular/angular-cli/commit/bfe9ee36cc4666deca60add57e793242d671b735) | fix  | warn when `@angular/localize/init` is imported directly                 |
+| Commit                                                                                              | Type | Description                                                        |
+| --------------------------------------------------------------------------------------------------- | ---- | ------------------------------------------------------------------ |
+| [2c9d7368f](https://github.com/angular/angular-cli/commit/2c9d7368fc30f3488152e35ac468db5f2a9432f2) | feat | add ng-packagr builder to the package                              |
+| [0a570c0c2](https://github.com/angular/angular-cli/commit/0a570c0c2e64c61ce9969975a21c0d9aac8d9f3b) | feat | add support for customizing URL segments with i18n                 |
+| [298b554a7](https://github.com/angular/angular-cli/commit/298b554a7a40465444b4c508e2250ecbf459ea47) | feat | enable component template hot replacement by default               |
+| [d350f357b](https://github.com/angular/angular-cli/commit/d350f357b2a74df828ec022e03754d59cc680848) | fix  | correctly validate locales `subPath`                               |
+| [8aa1ce608](https://github.com/angular/angular-cli/commit/8aa1ce60808c073634237d03045626d379a51183) | fix  | handle loaders correctly in SSR bundles for external packages      |
+| [3b7e6a8c6](https://github.com/angular/angular-cli/commit/3b7e6a8c6e2e018a85b437256040fd9c8161d537) | fix  | invalidate component template updates with dev-server SSR          |
+| [8fa682e57](https://github.com/angular/angular-cli/commit/8fa682e571dbba4bf249ceb3ca490c4ddd4d7fe5) | fix  | remove deleted assets from output during watch mode                |
+| [48cae815c](https://github.com/angular/angular-cli/commit/48cae815cfd0124217c1b5bc8c92dfdb0b150101) | fix  | skip vite SSR warmup file configuration when SSR is disabled       |
+| [ba16ad6b5](https://github.com/angular/angular-cli/commit/ba16ad6b56e9a1ae0f380141bc1e1253a75fcf6b) | fix  | support incremental build file results in watch mode               |
+| [955acef3d](https://github.com/angular/angular-cli/commit/955acef3d504ac924bd813f401fa9b49edbd337b) | fix  | trigger browser reload on asset changes with Vite dev server       |
+| [e74300a2c](https://github.com/angular/angular-cli/commit/e74300a2cbc666482992fa8d6dbfeef37f3a9db5) | fix  | use component updates for component style HMR                      |
+| [6a19c217e](https://github.com/angular/angular-cli/commit/6a19c217eaebf9c0bffba8482545efc375fd2a8a) | fix  | warn when using both `isolatedModules` and `emitDecoratorMetadata` |
 
 ### @angular/ssr
 
-| Commit                                                                                              | Type | Description                                                  |
-| --------------------------------------------------------------------------------------------------- | ---- | ------------------------------------------------------------ |
-| [3feecddbb](https://github.com/angular/angular-cli/commit/3feecddbba0d0559da10a45ad4040faf8e9d5198) | fix  | disable component boostrapping when running route extraction |
-| [6edb90883](https://github.com/angular/angular-cli/commit/6edb90883733040d77647cf24dea7f53b1b6ceaa) | fix  | throw error when using route matchers                        |
+| Commit                                                                                              | Type | Description                                                                       |
+| --------------------------------------------------------------------------------------------------- | ---- | --------------------------------------------------------------------------------- |
+| [8d7a51dfc](https://github.com/angular/angular-cli/commit/8d7a51dfc9658aa2f0f0c527435c05c2b10f34e5) | feat | add `modulepreload` for lazy-loaded routes                                        |
+| [41ece633b](https://github.com/angular/angular-cli/commit/41ece633b3d42ef110bf6085fe0783ab2a56efcd) | feat | redirect to preferred locale when accessing root route without a specified locale |
+| [3feecddbb](https://github.com/angular/angular-cli/commit/3feecddbba0d0559da10a45ad4040faf8e9d5198) | fix  | disable component boostrapping when running route extraction                      |
+| [6edb90883](https://github.com/angular/angular-cli/commit/6edb90883733040d77647cf24dea7f53b1b6ceaa) | fix  | throw error when using route matchers                                             |
 
 <!-- CHANGELOG SPLIT MARKER -->
 
@@ -77,39 +95,6 @@
 
 <!-- CHANGELOG SPLIT MARKER -->
 
-<a name="19.1.0-next.2"></a>
-
-# 19.1.0-next.2 (2024-12-18)
-
-### @angular-devkit/architect
-
-| Commit                                                                                              | Type | Description                                          |
-| --------------------------------------------------------------------------------------------------- | ---- | ---------------------------------------------------- |
-| [fe1ae6933](https://github.com/angular/angular-cli/commit/fe1ae6933998104c144b2c8854f362289c8d91c6) | fix  | avoid Node.js resolution for relative builder schema |
-
-### @angular-devkit/build-angular
-
-| Commit                                                                                              | Type | Description                    |
-| --------------------------------------------------------------------------------------------------- | ---- | ------------------------------ |
-| [a9a347014](https://github.com/angular/angular-cli/commit/a9a3470147aaf66ff4784a5b5c26c56d1051a5b3) | fix  | jasmine.clock with app builder |
-
-### @angular/build
-
-| Commit                                                                                              | Type | Description                                               |
-| --------------------------------------------------------------------------------------------------- | ---- | --------------------------------------------------------- |
-| [298b554a7](https://github.com/angular/angular-cli/commit/298b554a7a40465444b4c508e2250ecbf459ea47) | feat | enable component template hot replacement by default      |
-| [19bb2d480](https://github.com/angular/angular-cli/commit/19bb2d48097eaf8dcdbf584603210146b5f1b81e) | fix  | force HTTP/1.1 in dev-server SSR with SSL                 |
-| [3b7e6a8c6](https://github.com/angular/angular-cli/commit/3b7e6a8c6e2e018a85b437256040fd9c8161d537) | fix  | invalidate component template updates with dev-server SSR |
-
-### @angular/ssr
-
-| Commit                                                                                              | Type | Description                                                             |
-| --------------------------------------------------------------------------------------------------- | ---- | ----------------------------------------------------------------------- |
-| [1bf9381c8](https://github.com/angular/angular-cli/commit/1bf9381c8c580321c8a473da1735839ecaf5ad76) | fix  | correctly resolve pre-transform resources in Vite SSR without AppEngine |
-| [ad1d7d76f](https://github.com/angular/angular-cli/commit/ad1d7d76fc6b94b8f12841fcfb331e5fb098403e) | fix  | ensure correct `Location` header for redirects behind a proxy           |
-
-<!-- CHANGELOG SPLIT MARKER -->
-
 <a name="19.0.6"></a>
 
 # 19.0.6 (2024-12-18)
@@ -132,54 +117,6 @@
 | --------------------------------------------------------------------------------------------------- | ---- | ----------------------------------------------------------------------- |
 | [2f4df6b2b](https://github.com/angular/angular-cli/commit/2f4df6b2be458b3651df49f3bced923e8df4d547) | fix  | correctly resolve pre-transform resources in Vite SSR without AppEngine |
 | [0789a9e13](https://github.com/angular/angular-cli/commit/0789a9e133fed4edc29b108630b2cf91e157127e) | fix  | ensure correct `Location` header for redirects behind a proxy           |
-
-<!-- CHANGELOG SPLIT MARKER -->
-
-<a name="19.1.0-next.1"></a>
-
-# 19.1.0-next.1 (2024-12-12)
-
-## Deprecations
-
-### @angular/build
-
-- The `baseHref` option under `i18n.locales` and `i18n.sourceLocale` in `angular.json` is deprecated in favor of `subPath`.
-
-  The `subPath` defines the URL segment for the locale, serving as both the HTML base HREF and the directory name for output. By default, if not specified, `subPath` will use the locale code.
-
-### @angular-devkit/architect
-
-| Commit                                                                                              | Type | Description                        |
-| --------------------------------------------------------------------------------------------------- | ---- | ---------------------------------- |
-| [2b8a02bac](https://github.com/angular/angular-cli/commit/2b8a02bac098d4ac4f31b0e74bedfc739171e30b) | feat | require build schemas from modules |
-
-### @angular-devkit/build-angular
-
-| Commit                                                                                              | Type | Description                            |
-| --------------------------------------------------------------------------------------------------- | ---- | -------------------------------------- |
-| [fb41d182e](https://github.com/angular/angular-cli/commit/fb41d182ee9e50386b0412e07a8bacaaa8c7ce13) | fix  | fix webpack config transform for karma |
-| [9e2d3fbd1](https://github.com/angular/angular-cli/commit/9e2d3fbd1f5ce1eeca8a46d854aa45598e516d90) | fix  | handle windows spec collisions         |
-
-### @angular/build
-
-| Commit                                                                                              | Type | Description                                                                                                   |
-| --------------------------------------------------------------------------------------------------- | ---- | ------------------------------------------------------------------------------------------------------------- |
-| [0a570c0c2](https://github.com/angular/angular-cli/commit/0a570c0c2e64c61ce9969975a21c0d9aac8d9f3b) | feat | add support for customizing URL segments with i18n                                                            |
-| [210bf4e2b](https://github.com/angular/angular-cli/commit/210bf4e2b4eeac6cdda7e810752486b74c6c0876) | fix  | Fixing auto-csp edge cases where                                                                              |
-| [d811a7ffb](https://github.com/angular/angular-cli/commit/d811a7ffb0b6aad741e35025e218ea558590b0bb) | fix  | handle external `@angular/` packages during SSR ([#29094](https://github.com/angular/angular-cli/pull/29094)) |
-| [64f32c769](https://github.com/angular/angular-cli/commit/64f32c769f58b4e7306faf73fdae386a30f48a41) | fix  | provide component HMR update modules to dev-server SSR                                                        |
-| [c832bac9b](https://github.com/angular/angular-cli/commit/c832bac9b23cd7e8c354f4e2428c158b9bb45e47) | fix  | show error when Node.js built-ins are used during `ng serve`                                                  |
-| [887599822](https://github.com/angular/angular-cli/commit/88759982241ec2c30e00f62691347893d36bbfac) | fix  | use consistent path separators for template HMR identifiers                                                   |
-| [75998ebab](https://github.com/angular/angular-cli/commit/75998ebabb041f60aab40bf5a11979e8f3615537) | perf | reuse TS package.json cache when rebuilding                                                                   |
-
-### @angular/ssr
-
-| Commit                                                                                              | Type | Description                                                                       |
-| --------------------------------------------------------------------------------------------------- | ---- | --------------------------------------------------------------------------------- |
-| [8d7a51dfc](https://github.com/angular/angular-cli/commit/8d7a51dfc9658aa2f0f0c527435c05c2b10f34e5) | feat | add `modulepreload` for lazy-loaded routes                                        |
-| [41ece633b](https://github.com/angular/angular-cli/commit/41ece633b3d42ef110bf6085fe0783ab2a56efcd) | feat | redirect to preferred locale when accessing root route without a specified locale |
-| [d7214e961](https://github.com/angular/angular-cli/commit/d7214e9610588fe1dbd8ce30e51eaac14a038c56) | fix  | include `Content-Language` header when locale is set                              |
-| [10a5b8b6b](https://github.com/angular/angular-cli/commit/10a5b8b6b8ab1f1422adcb66e685af16b2c96549) | fix  | disable component bootstrapping during route extraction                           |
 
 <!-- CHANGELOG SPLIT MARKER -->
 
@@ -227,14 +164,6 @@
 | --------------------------------------------------------------------------------------------------- | ---- | ------------------------------------------------------------ |
 | [fc41f50b5](https://github.com/angular/angular-cli/commit/fc41f50b53bbffead017b420105eed5bd8573ac1) | fix  | show error when Node.js built-ins are used during `ng serve` |
 | [14451e275](https://github.com/angular/angular-cli/commit/14451e2754caff2c9800cca17e11ffa452575f09) | perf | reuse TS package.json cache when rebuilding                  |
-
-<!-- CHANGELOG SPLIT MARKER -->
-
-<a name="19.1.0-next.0"></a>
-
-# 19.1.0-next.0 (2024-12-04)
-
-Added support for TypeScript 5.7
 
 <!-- CHANGELOG SPLIT MARKER -->
 


### PR DESCRIPTION
Cherry-picks the changelog from the "19.1.x" branch to the next branch (main).