### PR TITLE
build: replace hardcoded Angular and ng-packagr peer dependencies with Bazel stamping

### DIFF
--- a/constants.bzl
+++ b/constants.bzl
@@ -3,6 +3,11 @@ RELEASE_ENGINES_NODE = "^18.19.1 || ^20.11.1 || >=22.0.0"
 RELEASE_ENGINES_NPM = "^6.11.0 || ^7.5.6 || >=8.0.0"
 RELEASE_ENGINES_YARN = ">= 1.13.0"
 
+NG_PACKAGR_VERSION = "^19.1.0-next.0"
+ANGULAR_FW_VERSION = "^19.1.0-next.0"
+ANGULAR_FW_PEER_DEP = "^19.0.0 || ^19.1.0-next.0"
+NG_PACKAGR_PEER_DEP = "^19.0.0 || ^19.1.0-next.0"
+
 SNAPSHOT_REPOS = {
     "@angular/cli": "angular/cli-builds",
     "@angular/pwa": "angular/angular-pwa-builds",

--- a/docs/process/release.md
+++ b/docs/process/release.md
@@ -69,24 +69,14 @@ Releasing is performed using Angular's unified release tooling. Each week, two r
 
 Once FW releases the actual minor/major release (for example: `13.0.0` or `13.1.0`), update dependencies with the following:
 
-1.  Run `sed -i -E "s, \|\| \^13\.1\.0-(next|rc)\.[0-9]+,,g" packages/**/package.json` with the release version to remove prerelease tags.
-    - No need to update `devDependencies` in the root `package.json`, Renovate will get them later.
-2.  Update [`latest-versions/package.json`](packages/schematics/angular/utility/latest-versions/package.json) so `@angular/core` and `ng-packagr` are using the release version (drop `-rc.0` / `-next.0`).
-    - This is the file used by `ng new` to determine versions in the generated `package.json` seen by developers.
-3.  Run `yarn -s bazel run @npm2//:sync` to update the pnpm lockfile.
+1.  Update [`constants.bzl`](../../constants.bzl) so `@angular/core` and `ng-packagr` are using the release version (drop `-next.0`).
 
-Merge the above two changes in a separate PR which lands _after_ FW releases (or else CI will fail) but _before_ the CLI
+Merge the above change in a separate PR which lands _after_ FW releases (or else CI will fail) but _before_ the CLI
 release PR. Releases are built before the PR is sent for review, so any changes after that point won't be included in the release.
-
-**AFTER a major CLI release:**
-
-Once a major release is complete, peer dependencies in the above files will need to be updated to "undo" the above change and add the
-prerelease version segment on `main`. For example, `"@angular/compiler-cli": "^13.0.0-next.0"` should become
-`"@angular/compiler-cli": "^13.0.0 || ^13.1.0-next.0"`. This should be done for all the peer deps in the above files.
 
 **AFTER a minor OR major CLI release:**
 
-`latest-versions.ts` also needs to be updated to use `-next.0` after a major or minor release. However this needs to happen _after_ FW
+`constants.bzl` also needs to be updated to use `-next.0` after a major or minor release. However this needs to happen _after_ FW
 publishes the initial `-next.0` release, which will happen 1 week after the major or minor release.
 
 ## Releasing the CLI

--- a/packages/angular/build/package.json
+++ b/packages/angular/build/package.json
@@ -48,14 +48,14 @@
     "lmdb": "3.2.2"
   },
   "peerDependencies": {
-    "@angular/compiler": "^19.0.0 || ^19.1.0-next.0",
-    "@angular/compiler-cli": "^19.0.0 || ^19.1.0-next.0",
-    "@angular/localize": "^19.0.0 || ^19.1.0-next.0",
-    "@angular/platform-server": "^19.0.0 || ^19.1.0-next.0",
-    "@angular/service-worker": "^19.0.0 || ^19.1.0-next.0",
+    "@angular/compiler": "0.0.0-ANGULAR-FW-PEER-DEP",
+    "@angular/compiler-cli": "0.0.0-ANGULAR-FW-PEER-DEP",
+    "@angular/localize": "0.0.0-ANGULAR-FW-PEER-DEP",
+    "@angular/platform-server": "0.0.0-ANGULAR-FW-PEER-DEP",
+    "@angular/service-worker": "0.0.0-ANGULAR-FW-PEER-DEP",
     "@angular/ssr": "^0.0.0-PLACEHOLDER",
     "less": "^4.2.0",
-    "ng-packagr": "^19.0.0 || ^19.1.0-next.0",
+    "ng-packagr": "0.0.0-NG-PACKAGR-PEER-DEP",
     "postcss": "^8.4.0",
     "tailwindcss": "^2.0.0 || ^3.0.0",
     "typescript": ">=5.5 <5.8"

--- a/packages/angular/pwa/package.json
+++ b/packages/angular/pwa/package.json
@@ -17,7 +17,7 @@
     "parse5-html-rewriting-stream": "7.0.0"
   },
   "peerDependencies": {
-    "@angular/cli": "^19.0.0 || ^19.1.0-next.0"
+    "@angular/cli": "0.0.0-ANGULAR-FW-PEER-DEP"
   },
   "peerDependenciesMeta": {
     "@angular/cli": {

--- a/packages/angular/ssr/package.json
+++ b/packages/angular/ssr/package.json
@@ -16,10 +16,10 @@
     "tslib": "^2.3.0"
   },
   "peerDependencies": {
-    "@angular/common": "^19.0.0 || ^19.1.0-next.0",
-    "@angular/core": "^19.0.0 || ^19.1.0-next.0",
-    "@angular/platform-server": "^19.0.0 || ^19.1.0-next.0",
-    "@angular/router": "^19.0.0 || ^19.1.0-next.0"
+    "@angular/common": "0.0.0-ANGULAR-FW-PEER-DEP",
+    "@angular/core": "0.0.0-ANGULAR-FW-PEER-DEP",
+    "@angular/platform-server": "0.0.0-ANGULAR-FW-PEER-DEP",
+    "@angular/router": "0.0.0-ANGULAR-FW-PEER-DEP"
   },
   "peerDependenciesMeta": {
     "@angular/platform-server": {

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -69,17 +69,17 @@
     "undici": "7.2.3"
   },
   "peerDependencies": {
-    "@angular/compiler-cli": "^19.0.0 || ^19.1.0-next.0",
-    "@angular/localize": "^19.0.0 || ^19.1.0-next.0",
-    "@angular/platform-server": "^19.0.0 || ^19.1.0-next.0",
-    "@angular/service-worker": "^19.0.0 || ^19.1.0-next.0",
+    "@angular/compiler-cli": "0.0.0-ANGULAR-FW-PEER-DEP",
+    "@angular/localize": "0.0.0-ANGULAR-FW-PEER-DEP",
+    "@angular/platform-server": "0.0.0-ANGULAR-FW-PEER-DEP",
+    "@angular/service-worker": "0.0.0-ANGULAR-FW-PEER-DEP",
     "@angular/ssr": "^0.0.0-PLACEHOLDER",
     "@web/test-runner": "^0.19.0",
     "browser-sync": "^3.0.2",
     "jest": "^29.5.0",
     "jest-environment-jsdom": "^29.5.0",
     "karma": "^6.3.0",
-    "ng-packagr": "^19.0.0 || ^19.1.0-next.0",
+    "ng-packagr": "0.0.0-NG-PACKAGR-PEER-DEP",
     "protractor": "^7.0.0",
     "tailwindcss": "^2.0.0 || ^3.0.0",
     "typescript": ">=5.5 <5.8"

--- a/packages/ngtools/webpack/package.json
+++ b/packages/ngtools/webpack/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/angular/angular-cli/tree/main/packages/ngtools/webpack",
   "peerDependencies": {
-    "@angular/compiler-cli": "^19.0.0 || ^19.1.0-next.0",
+    "@angular/compiler-cli": "0.0.0-ANGULAR-FW-PEER-DEP",
     "typescript": ">=5.5 <5.8",
     "webpack": "^5.54.0"
   },

--- a/packages/schematics/angular/library/index.ts
+++ b/packages/schematics/angular/library/index.ts
@@ -59,7 +59,7 @@ function addDependenciesToPackageJson() {
       {
         type: NodeDependencyType.Dev,
         name: 'ng-packagr',
-        version: latestVersions['ng-packagr'],
+        version: latestVersions.NgPackagr,
       },
       {
         type: NodeDependencyType.Default,

--- a/packages/schematics/angular/library/index_spec.ts
+++ b/packages/schematics/angular/library/index_spec.ts
@@ -218,7 +218,7 @@ describe('Library Schematic', () => {
       const tree = await schematicRunner.runSchematic('library', defaultOptions, workspaceTree);
 
       const packageJson = getJsonFileContent(tree, 'package.json');
-      expect(packageJson.devDependencies['ng-packagr']).toEqual(latestVersions['ng-packagr']);
+      expect(packageJson.devDependencies['ng-packagr']).toBeDefined();
     });
 
     it('should use the latest known versions in package.json', async () => {

--- a/packages/schematics/angular/utility/latest-versions.ts
+++ b/packages/schematics/angular/utility/latest-versions.ts
@@ -15,12 +15,13 @@ export const latestVersions: Record<string, string> & {
   DevkitBuildAngular: string;
   AngularBuild: string;
   AngularSSR: string;
+  NgPackagr: string;
 } = {
   ...dependencies,
 
   // As Angular CLI works with same minor versions of Angular Framework, a tilde match for the current
-  Angular: dependencies['@angular/core'],
-
+  Angular: '0.0.0-ANGULAR-FW-VERSION',
+  NgPackagr: '0.0.0-NG-PACKAGR-VERSION',
   DevkitBuildAngular: '^0.0.0-PLACEHOLDER',
   AngularBuild: '^0.0.0-PLACEHOLDER',
   AngularSSR: '^0.0.0-PLACEHOLDER',

--- a/packages/schematics/angular/utility/latest-versions/package.json
+++ b/packages/schematics/angular/utility/latest-versions/package.json
@@ -3,7 +3,6 @@
   "comment": "This file is needed so that dependencies are synced by Renovate.",
   "private": true,
   "dependencies": {
-    "@angular/core": "^19.1.0-next.0",
     "@types/express": "^4.17.17",
     "@types/jasmine": "~5.1.0",
     "@types/node": "^18.18.0",
@@ -17,7 +16,6 @@
     "karma-jasmine": "~5.1.0",
     "karma": "~6.4.0",
     "less": "^4.2.0",
-    "ng-packagr": "^19.1.0-next.0",
     "postcss": "^8.4.38",
     "protractor": "~7.0.0",
     "rxjs": "~7.8.0",

--- a/tools/substitutions.bzl
+++ b/tools/substitutions.bzl
@@ -1,4 +1,4 @@
-load("//:constants.bzl", "RELEASE_ENGINES_NODE", "RELEASE_ENGINES_NPM", "RELEASE_ENGINES_YARN")
+load("//:constants.bzl", "ANGULAR_FW_PEER_DEP", "ANGULAR_FW_VERSION", "NG_PACKAGR_PEER_DEP", "NG_PACKAGR_VERSION", "RELEASE_ENGINES_NODE", "RELEASE_ENGINES_NPM", "RELEASE_ENGINES_YARN")
 
 NPM_PACKAGE_SUBSTITUTIONS = {
     # Version of the local package being built, generated via the `--workspace_status_command` flag.
@@ -8,6 +8,10 @@ NPM_PACKAGE_SUBSTITUTIONS = {
     "0.0.0-ENGINES-NODE": RELEASE_ENGINES_NODE,
     "0.0.0-ENGINES-NPM": RELEASE_ENGINES_NPM,
     "0.0.0-ENGINES-YARN": RELEASE_ENGINES_YARN,
+    "0.0.0-NG-PACKAGR-VERSION": NG_PACKAGR_VERSION,
+    "0.0.0-NG-PACKAGR-PEER-DEP": NG_PACKAGR_PEER_DEP,
+    "0.0.0-ANGULAR-FW-VERSION": ANGULAR_FW_VERSION,
+    "0.0.0-ANGULAR-FW-PEER-DEP": ANGULAR_FW_PEER_DEP,
     # The below is needed for @angular/ssr FESM file.
     "\\./(.+)/packages/angular/ssr/third_party/beasties": "../third_party/beasties/index.js",
 }


### PR DESCRIPTION

Refactor the build configuration to use Bazel stamping for Angular and ng-packagr dependencies, eliminating the need for hardcoded peer dependencies.

