### PR TITLE
fix(@angular/build): perform incremental background file updates with component updates

### DIFF
--- a/packages/angular/build/src/builders/application/results.ts
+++ b/packages/angular/build/src/builders/application/results.ts
@@ -36,6 +36,7 @@ export interface FullResult extends BaseResult {
 
 export interface IncrementalResult extends BaseResult {
   kind: ResultKind.Incremental;
+  background?: boolean;
   added: string[];
   removed: { path: string; type: BuildOutputFileType }[];
   modified: string[];


### PR DESCRIPTION
When HMR is enabled, a change to a lazy route component template may alter the names of lazy chunks. These lazy chunks must be updated within the development server so that any later non-HMR based update will have access to these chunks. To support this, the incremental results from the build process can now emit background file updates that will provide output file changes without triggering client updates.