### PR TITLE
build: exclude `pnpm` and `dependenciesMeta` fields from published NPM packages

### DIFF
--- a/tools/package_json_release_filter.jq
+++ b/tools/package_json_release_filter.jq
@@ -16,7 +16,7 @@
 # Get the fields from root package.json that should override the project
 # package.json, i.e., every field except the following
 | ($root
-    | del(.bin, .description, .dependencies, .name, .main, .peerDependencies, .optionalDependencies, .typings, .version, .private, .workspaces, .resolutions, .scripts, .["ng-update"])
+    | del(.bin, .description, .dependencies, .name, .main, .peerDependencies, .optionalDependencies, .typings, .version, .private, .workspaces, .resolutions, .scripts, .["ng-update"], .pnpm, .dependenciesMeta)
 ) as $root_overrides
 
 # Use the project package.json as a base and override other fields from root


### PR DESCRIPTION


Currently, the `pnpm` and `dependenciesMeta` fields from the root `package.json` are inadvertently copied to the `package.json` of published packages.

For example, see: https://github.com/angular/angular-devkit-schematics-builds/blob/dc4d5e0d523e3449963fa8e6efa32aee3e194e0f/package.json#L42-L52
