### PR TITLE
ci: disable Renovate updates for all stamped versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -37,11 +37,7 @@
       "schedule": ["before 4:00am on the first day of the month"]
     },
     {
-      "matchCurrentVersion": "0.0.0-PLACEHOLDER",
-      "enabled": false
-    },
-    {
-      "matchCurrentVersion": "0.0.0-EXPERIMENTAL-PLACEHOLDER",
+      "matchCurrentVersion": "/0\\.0\\.0-/",
       "enabled": false
     },
     {


### PR DESCRIPTION
This will prevent updates to any version matching the pattern `/0\.0\.0-/`.
