### PR TITLE
fix(@angular/build): prevent full page reload on HMR updates with SSR enabled

### DIFF
--- a/packages/angular/build/src/builders/application/build-action.ts
+++ b/packages/angular/build/src/builders/application/build-action.ts
@@ -295,7 +295,7 @@ function* emitOutputResults(
 
       if (needFile) {
         // Updates to non-JS files must signal an update with the dev server
-        if (!/(?:\.js|\.map)?$/.test(file.path)) {
+        if (!/(?:\.m?js|\.map)?$/.test(file.path)) {
           incrementalResult.background = false;
         }
 


### PR DESCRIPTION

This commit resolves an issue where HMR would incorrectly trigger a full page reload when used with SSR.

Closes #29372
