### PR TITLE
refactor(@angular/build): add console message to dev server when component HMR is enabled

### DIFF
--- a/packages/angular/build/src/builders/dev-server/vite-server.ts
+++ b/packages/angular/build/src/builders/dev-server/vite-server.ts
@@ -151,6 +151,14 @@ export async function* serveWithVite(
   // This will also replace file-based/inline styles as code if external runtime styles are not enabled.
   browserOptions.templateUpdates =
     serverOptions.liveReload && serverOptions.hmr && useComponentTemplateHmr;
+  if (browserOptions.templateUpdates) {
+    context.logger.warn(
+      'Component HMR has been enabled.\n' +
+        'If you encounter application reload issues, you can manually reload the page to bypass HMR and/or disable this feature with the' +
+        ' `--no-hmr` command line option.\n' +
+        'Please consider reporting any issues you encounter here: https://github.com/angular/angular-cli/issues\n',
+    );
+  }
 
   browserOptions.incrementalResults = true;
 


### PR DESCRIPTION
An informational message has been added to the development server to ensure that users are aware that component HMR has been enabled and provide actionable steps in the event that an application reload may not behave as expected.