### PR TITLE
test(@angular/build): enable i18n localize watch test for dev-server

### DIFF
--- a/packages/angular/build/src/builders/dev-server/tests/behavior/build_localize_replaced_watch_spec.ts
+++ b/packages/angular/build/src/builders/dev-server/tests/behavior/build_localize_replaced_watch_spec.ts
@@ -6,80 +6,70 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-/* eslint-disable max-len */
 import { concatMap, count, take, timeout } from 'rxjs';
-import { URL } from 'url';
 import { executeDevServer } from '../../index';
 import { describeServeBuilder } from '../jasmine-helpers';
 import { BASE_OPTIONS, BUILD_TIMEOUT, DEV_SERVER_BUILDER_INFO } from '../setup';
 
-describeServeBuilder(
-  executeDevServer,
-  DEV_SERVER_BUILDER_INFO,
-  (harness, setupTarget, isViteRun) => {
-    // TODO(fix-vite): currently this is broken in vite.
-    (isViteRun ? xdescribe : describe)(
-      'Behavior: "i18n $localize calls are replaced during watching"',
-      () => {
-        beforeEach(() => {
-          harness.useProject('test', {
-            root: '.',
-            sourceRoot: 'src',
-            cli: {
-              cache: {
-                enabled: false,
-              },
-            },
-            i18n: {
-              sourceLocale: {
-                'code': 'fr',
-              },
-            },
-          });
+describeServeBuilder(executeDevServer, DEV_SERVER_BUILDER_INFO, (harness, setupTarget) => {
+  describe('Behavior: "i18n $localize calls are replaced during watching"', () => {
+    beforeEach(() => {
+      harness.useProject('test', {
+        root: '.',
+        sourceRoot: 'src',
+        cli: {
+          cache: {
+            enabled: false,
+          },
+        },
+        i18n: {
+          sourceLocale: {
+            code: 'fr',
+          },
+        },
+      });
 
-          setupTarget(harness, { localize: ['fr'] });
-        });
+      setupTarget(harness, { localize: ['fr'] });
+    });
 
-        it('$localize are replaced in watch', async () => {
-          harness.useTarget('serve', {
-            ...BASE_OPTIONS,
-            watch: true,
-          });
+    it('$localize are replaced in watch', async () => {
+      harness.useTarget('serve', {
+        ...BASE_OPTIONS,
+        watch: true,
+      });
 
-          await harness.writeFile(
-            'src/app/app.component.html',
-            `
+      await harness.writeFile(
+        'src/app/app.component.html',
+        `
           <p id="hello" i18n="An introduction header for this sample">Hello {{ title }}! </p>
         `,
-          );
+      );
 
-          const buildCount = await harness
-            .execute()
-            .pipe(
-              timeout(BUILD_TIMEOUT * 2),
-              concatMap(async ({ result }, index) => {
-                expect(result?.success).toBe(true);
+      const buildCount = await harness
+        .execute()
+        .pipe(
+          timeout(BUILD_TIMEOUT * 2),
+          concatMap(async ({ result }, index) => {
+            expect(result?.success).toBe(true);
 
-                const response = await fetch(new URL('main.js', `${result?.baseUrl}`));
-                expect(await response?.text()).not.toContain('$localize`:');
+            const response = await fetch(new URL('main.js', `${result?.baseUrl}`));
+            expect(await response?.text()).not.toContain('$localize`:');
 
-                switch (index) {
-                  case 0: {
-                    await harness.modifyFile('src/app/app.component.html', (content) =>
-                      content.replace('introduction', 'intro'),
-                    );
-                    break;
-                  }
-                }
-              }),
-              take(2),
-              count(),
-            )
-            .toPromise();
+            switch (index) {
+              case 0: {
+                await harness.modifyFile('src/app/app.component.html', (content) =>
+                  content.replace('introduction', 'intro'),
+                );
+                break;
+              }
+            }
+          }),
+          take(2),
+          count(),
+        )
+        .toPromise();
 
-          expect(buildCount).toBe(2);
-        });
-      },
-    );
-  },
-);
+      expect(buildCount).toBe(2);
+    });
+  });
+});


### PR DESCRIPTION
The existing test for i18n `$localize` replacement during watch mode has been re-enabled.