### PR TITLE
fix(@angular/build): perform full reload for templates with `$localize` usage

### DIFF
--- a/packages/angular/build/src/tools/angular/compilation/aot-compilation.ts
+++ b/packages/angular/build/src/tools/angular/compilation/aot-compilation.ts
@@ -160,7 +160,11 @@ export class AotCompilation extends AngularCompilation {
           `${host.getCanonicalFileName(relativePath)}@${node.name?.text}`,
         );
         const updateText = angularCompiler.emitHmrUpdateModule(node);
-        if (updateText === null) {
+        // If compiler cannot generate an update for the component, prevent template updates.
+        // Also prevent template updates if $localize is directly present which also currently
+        // prevents a template update at runtime.
+        // TODO: Support localized template update modules and remove this check.
+        if (updateText === null || updateText.includes('$localize')) {
           // Build is needed if a template cannot be updated
           templateUpdates = undefined;
           break;


### PR DESCRIPTION
Component template updates that contain `$localize` usage currently may result in incorrect updates at runtime. To avoid this problem, any template update module that contains `$localize` will now perform a full rebuild. Support for component updates of these templates will be added in a future release.