### PR TITLE
fix(@angular/ssr): properly manage catch-all routes with base href

### DIFF
--- a/packages/angular/ssr/src/routes/ng-routes.ts
+++ b/packages/angular/ssr/src/routes/ng-routes.ts
@@ -583,13 +583,13 @@ export async function getRoutesFromAngularRouterConfig(
 
       if (serverConfigRouteTree) {
         for (const { route, presentInClientRouter } of serverConfigRouteTree.traverse()) {
-          if (presentInClientRouter || route === '**') {
+          if (presentInClientRouter || route.endsWith('/**')) {
             // Skip if matched or it's the catch-all route.
             continue;
           }
 
           errors.push(
-            `The '${route}' server route does not match any routes defined in the Angular ` +
+            `The '${stripLeadingSlash(route)}' server route does not match any routes defined in the Angular ` +
               `routing configuration (typically provided as a part of the 'provideRouter' call). ` +
               'Please make sure that the mentioned server route is present in the Angular routing configuration.',
           );

--- a/packages/angular/ssr/test/routes/route-tree_spec.ts
+++ b/packages/angular/ssr/test/routes/route-tree_spec.ts
@@ -150,7 +150,7 @@ describe('RouteTree', () => {
   describe('match', () => {
     it('should handle empty routes', () => {
       routeTree.insert('', { renderMode: RenderMode.Server });
-      expect(routeTree.match('')).toEqual({ route: '', renderMode: RenderMode.Server });
+      expect(routeTree.match('')).toEqual({ route: '/', renderMode: RenderMode.Server });
     });
 
     it('should insert and match basic routes', () => {
@@ -271,6 +271,14 @@ describe('RouteTree', () => {
       });
       expect(routeTree.match('/path/with/slashes')).toEqual({
         route: '/path/with/slashes',
+        renderMode: RenderMode.Server,
+      });
+    });
+
+    it('should correctly match catch-all segments with a prefix', () => {
+      routeTree.insert('/de/**', { renderMode: RenderMode.Server });
+      expect(routeTree.match('/de')).toEqual({
+        route: '/de/**',
         renderMode: RenderMode.Server,
       });
     });


### PR DESCRIPTION
This fix ensures that catch-all routes (e.g., wildcard routes like `**`) are handled correctly when a base href is configured in an Angular SSR application.

Closes #29397