### PR TITLE
fix(@angular/ssr): prevent route matcher error when SSR routing is not used

### DIFF
--- a/packages/angular/ssr/src/routes/ng-routes.ts
+++ b/packages/angular/ssr/src/routes/ng-routes.ts
@@ -155,17 +155,18 @@ async function* traverseRoutesConfig(options: {
       } = route;
       const currentRoutePath = joinUrlParts(parentRoute, path);
 
-      if (matcher) {
-        yield {
-          error: `The route '${stripLeadingSlash(currentRoutePath)}' uses a route matcher which is not supported.`,
-        };
-
-        continue;
-      }
-
       // Get route metadata from the server config route tree, if available
       let matchedMetaData: ServerConfigRouteTreeNodeMetadata | undefined;
       if (serverConfigRouteTree) {
+        if (matcher) {
+          // Only issue this error when SSR routing is used.
+          yield {
+            error: `The route '${stripLeadingSlash(currentRoutePath)}' uses a route matcher that is not supported.`,
+          };
+
+          continue;
+        }
+
         matchedMetaData = serverConfigRouteTree.match(currentRoutePath);
         if (!matchedMetaData) {
           yield {


### PR DESCRIPTION


Although route matchers are not supported with the SSR Routing API, they still function with the legacy `CommonEngine`. Therefore, no error should be issued in this case.

Closes #29420