### PR TITLE
fix(@angular/build): only issue invalid i18n config error for duplicate `subPaths` with inlined locales

### DIFF
--- a/packages/angular/build/src/utils/i18n-options.ts
+++ b/packages/angular/build/src/utils/i18n-options.ts
@@ -193,8 +193,24 @@ export function createI18nOptions(
     }
   }
 
-  // Check that subPaths are unique.
-  const localesData = Object.entries(i18n.locales);
+  if (inline === true) {
+    i18n.inlineLocales.add(i18n.sourceLocale);
+    Object.keys(i18n.locales).forEach((locale) => i18n.inlineLocales.add(locale));
+  } else if (inline) {
+    for (const locale of inline) {
+      if (!i18n.locales[locale] && i18n.sourceLocale !== locale) {
+        throw new Error(`Requested locale '${locale}' is not defined for the project.`);
+      }
+
+      i18n.inlineLocales.add(locale);
+    }
+  }
+
+  // Check that subPaths are unique only the locales that we are inlining.
+  const localesData = Object.entries(i18n.locales).filter(([locale]) =>
+    i18n.inlineLocales.has(locale),
+  );
+
   for (let i = 0; i < localesData.length; i++) {
     const [localeA, { subPath: subPathA }] = localesData[i];
 
@@ -206,19 +222,6 @@ export function createI18nOptions(
           `Invalid i18n configuration: Locales '${localeA}' and '${localeB}' cannot have the same subPath: '${subPathB}'.`,
         );
       }
-    }
-  }
-
-  if (inline === true) {
-    i18n.inlineLocales.add(i18n.sourceLocale);
-    Object.keys(i18n.locales).forEach((locale) => i18n.inlineLocales.add(locale));
-  } else if (inline) {
-    for (const locale of inline) {
-      if (!i18n.locales[locale] && i18n.sourceLocale !== locale) {
-        throw new Error(`Requested locale '${locale}' is not defined for the project.`);
-      }
-
-      i18n.inlineLocales.add(locale);
     }
   }
 


### PR DESCRIPTION


The i18n configuration validation was incorrectly flagging errors for identical `subPaths` when both locales were not inlined within the same build. This was due to the validation not properly accounting for the inlining of locales.

This commit fixes this issue by ensuring that the validation only checks for duplicate `subPaths` when the locales are inlined.

Closes #29398