### PR TITLE
fix(@angular/build): include extracted routes in the manifest during prerendering

### DIFF
--- a/packages/angular/build/src/builders/application/execute-post-bundle.ts
+++ b/packages/angular/build/src/builders/application/execute-post-bundle.ts
@@ -184,7 +184,6 @@ export async function executePostBundleSteps(
     }
 
     const serializableRouteTreeNodeForManifest: WritableSerializableRouteTreeNode = [];
-
     for (const metadata of serializableRouteTreeNode) {
       serializableRouteTreeNodeForManifest.push(metadata);
 

--- a/packages/angular/build/src/utils/server-rendering/prerender.ts
+++ b/packages/angular/build/src/utils/server-rendering/prerender.ts
@@ -16,6 +16,7 @@ import { assertIsError } from '../error';
 import { urlJoin } from '../url';
 import { WorkerPool } from '../worker-pool';
 import { IMPORT_EXEC_ARGV } from './esm-in-memory-loader/utils';
+import { SERVER_APP_MANIFEST_FILENAME } from './manifest';
 import {
   RouteRenderMode,
   RoutersExtractorWorkerResult,
@@ -154,6 +155,16 @@ export async function prerenderPages(
       output: {},
       serializableRouteTreeNode,
     };
+  }
+
+  // Add the extracted routes to the manifest file.
+  // We could re-generate it from the start, but that would require a number of options to be passed down.
+  const manifest = outputFilesForWorker[SERVER_APP_MANIFEST_FILENAME];
+  if (manifest) {
+    outputFilesForWorker[SERVER_APP_MANIFEST_FILENAME] = manifest.replace(
+      'routes: undefined,',
+      `routes: ${JSON.stringify(serializableRouteTreeNodeForPrerender, undefined, 2)},`,
+    );
   }
 
   // Render routes

--- a/tests/legacy-cli/e2e/tests/build/server-rendering/server-routes-output-mode-static.ts
+++ b/tests/legacy-cli/e2e/tests/build/server-rendering/server-routes-output-mode-static.ts
@@ -101,11 +101,11 @@ export default async function () {
   await replaceInFile('src/app/app.routes.server.ts', 'RenderMode.Server', 'RenderMode.Prerender');
   await noSilentNg('build', '--output-mode=static');
 
-  const expects: Record<string, string> = {
-    'index.html': 'home works!',
-    'ssg/index.html': 'ssg works!',
-    'ssg/one/index.html': 'ssg-with-params works!',
-    'ssg/two/index.html': 'ssg-with-params works!',
+  const expects: Record<string, RegExp | string> = {
+    'index.html': /ng-server-context="ssg".+home works!/,
+    'ssg/index.html': /ng-server-context="ssg".+ssg works!/,
+    'ssg/one/index.html': /ng-server-context="ssg".+ssg-with-params works!/,
+    'ssg/two/index.html': /ng-server-context="ssg".+ssg-with-params works!/,
     // When static redirects as generated as meta tags.
     'ssg-redirect/index.html': '<meta http-equiv="refresh" content="0; url=/ssg">',
   };


### PR DESCRIPTION

This commit ensures that extracted routes are added to the manifest during prerendering. This guarantees a correct ng-server-context value for parameterized routes and provides a performance benefit by preventing route extraction from being repeated for every rendering worker.

Closes #29426
