### PR TITLE
fix(@angular/build): replace deprecation of `i18n.baseHref` with a warning

### DIFF
--- a/packages/angular/build/src/builders/application/options.ts
+++ b/packages/angular/build/src/builders/application/options.ts
@@ -174,7 +174,7 @@ export async function normalizeOptions(
   const i18nOptions: I18nOptions & {
     duplicateTranslationBehavior?: I18NTranslation;
     missingTranslationBehavior?: I18NTranslation;
-  } = createI18nOptions(projectMetadata, options.localize, context.logger);
+  } = createI18nOptions(projectMetadata, options.localize, context.logger, !!options.ssr);
   i18nOptions.duplicateTranslationBehavior = options.i18nDuplicateTranslation;
   i18nOptions.missingTranslationBehavior = options.i18nMissingTranslation;
   if (options.forceI18nFlatOutput) {

--- a/packages/angular/build/src/utils/i18n-options.ts
+++ b/packages/angular/build/src/utils/i18n-options.ts
@@ -80,6 +80,7 @@ export function createI18nOptions(
   logger?: {
     warn(message: string): void;
   },
+  ssrEnabled?: boolean,
 ): I18nOptions {
   const { i18n: metadata = {} } = projectMetadata;
 
@@ -110,12 +111,14 @@ export function createI18nOptions(
 
     if (metadata.sourceLocale.baseHref !== undefined) {
       ensureString(metadata.sourceLocale.baseHref, 'i18n.sourceLocale.baseHref');
-      logger?.warn(
-        `The 'baseHref' field under 'i18n.sourceLocale' is deprecated and will be removed in future versions. ` +
-          `Please use 'subPath' instead.\nNote: 'subPath' defines the URL segment for the locale, acting ` +
-          `as both the HTML base HREF and the directory name for output.\nBy default, ` +
-          `if not specified, 'subPath' uses the locale code.`,
-      );
+      if (ssrEnabled) {
+        logger?.warn(
+          `'baseHref' in 'i18n.sourceLocale' may lead to undefined behavior when used with SSR. ` +
+            `Consider using 'subPath' instead.\n\n` +
+            `Note: 'subPath' specifies the URL segment for the locale, serving as both the HTML base HREF ` +
+            `and the output directory name.\nBy default, if not explicitly set, 'subPath' defaults to the locale code.`,
+        );
+      }
 
       rawSourceLocaleBaseHref = metadata.sourceLocale.baseHref;
     }
@@ -156,12 +159,15 @@ export function createI18nOptions(
 
         if ('baseHref' in options) {
           ensureString(options.baseHref, `i18n.locales.${locale}.baseHref`);
-          logger?.warn(
-            `The 'baseHref' field under 'i18n.locales.${locale}' is deprecated and will be removed in future versions. ` +
-              `Please use 'subPath' instead.\nNote: 'subPath' defines the URL segment for the locale, acting ` +
-              `as both the HTML base HREF and the directory name for output.\nBy default, ` +
-              `if not specified, 'subPath' uses the locale code.`,
-          );
+
+          if (ssrEnabled) {
+            logger?.warn(
+              `'baseHref' in 'i18n.locales.${locale}' may lead to undefined behavior when used with SSR. ` +
+                `Consider using 'subPath' instead.\n\n` +
+                `Note: 'subPath' specifies the URL segment for the locale, serving as both the HTML base HREF ` +
+                `and the output directory name.\nBy default, if not explicitly set, 'subPath' defaults to the locale code.`,
+            );
+          }
           baseHref = options.baseHref;
         }
 

--- a/packages/angular/cli/lib/config/workspace-schema.json
+++ b/packages/angular/cli/lib/config/workspace-schema.json
@@ -284,7 +284,6 @@
                     },
                     "baseHref": {
                       "type": "string",
-                      "deprecated": true,
                       "description": "Specifies the HTML base HREF for the locale. Defaults to the locale code if not provided."
                     },
                     "subPath": {
@@ -356,7 +355,6 @@
                         },
                         "baseHref": {
                           "type": "string",
-                          "deprecated": true,
                           "description": "Specifies the HTML base HREF for the locale. Defaults to the locale code if not provided."
                         },
                         "subPath": {


### PR DESCRIPTION
In certain scenarios, users build applications with the same `baseHref` when using i18n, primarily for deploying localized applications across multiple domains. To address this, we are removing the deprecation of `i18n.baseHref` and will revisit potential options as part of https://github.com/angular/angular-cli/issues/29111

Instead of deprecating `i18n.baseHref`, we now issue a warning when it is used with SSR, as this may lead to undefined behavior.

Closes #29396
