### PR TITLE
refactor: reduce dependencies on `@angular-devkit/core`

### DIFF
--- a/goldens/public-api/angular/build/index.api.md
+++ b/goldens/public-api/angular/build/index.api.md
@@ -19,7 +19,7 @@ export interface ApplicationBuilderExtensions {
 }
 
 // @public
-export interface ApplicationBuilderOptions {
+export type ApplicationBuilderOptions = {
     allowedCommonJsDependencies?: string[];
     aot?: boolean;
     appShell?: boolean;
@@ -69,7 +69,7 @@ export interface ApplicationBuilderOptions {
     verbose?: boolean;
     watch?: boolean;
     webWorkerTsConfig?: string;
-}
+};
 
 // @public
 export function buildApplication(options: ApplicationBuilderOptions, context: BuilderContext, extensions?: ApplicationBuilderExtensions): AsyncIterable<BuilderOutput>;
@@ -107,7 +107,7 @@ export enum BuildOutputFileType {
 }
 
 // @public
-export interface DevServerBuilderOptions {
+export type DevServerBuilderOptions = {
     buildTarget: string;
     headers?: {
         [key: string]: string;
@@ -127,7 +127,7 @@ export interface DevServerBuilderOptions {
     sslKey?: string;
     verbose?: boolean;
     watch?: boolean;
-}
+};
 
 // @public
 export interface DevServerBuilderOutput extends BuilderOutput {
@@ -153,21 +153,21 @@ export function executeExtractI18nBuilder(options: ExtractI18nBuilderOptions, co
 export function executeNgPackagrBuilder(options: NgPackagrBuilderOptions, context: BuilderContext): AsyncIterableIterator<BuilderOutput>;
 
 // @public
-export interface ExtractI18nBuilderOptions {
+export type ExtractI18nBuilderOptions = {
     buildTarget?: string;
     format?: Format;
     outFile?: string;
     outputPath?: string;
     progress?: boolean;
-}
+};
 
 // @public
-export interface NgPackagrBuilderOptions {
+export type NgPackagrBuilderOptions = {
     poll?: number;
     project: string;
     tsConfig?: string;
     watch?: boolean;
-}
+};
 
 // (No @packageDocumentation comment for this package)
 

--- a/goldens/public-api/angular_devkit/build_angular/index.api.md
+++ b/goldens/public-api/angular_devkit/build_angular/index.api.md
@@ -13,7 +13,6 @@ import { Configuration } from 'webpack';
 import { DevServerBuilderOutput } from '@angular/build';
 import type http from 'node:http';
 import { IndexHtmlTransform } from '@angular/build/private';
-import { json } from '@angular-devkit/core';
 import { Observable } from 'rxjs';
 import type { Plugin as Plugin_2 } from 'esbuild';
 import webpack from 'webpack';
@@ -25,16 +24,16 @@ export { ApplicationBuilderOptions }
 export type AssetPattern = AssetPatternObject | string;
 
 // @public (undocumented)
-export interface AssetPatternObject {
+export type AssetPatternObject = {
     followSymlinks?: boolean;
     glob: string;
     ignore?: string[];
     input: string;
     output?: string;
-}
+};
 
 // @public
-export interface BrowserBuilderOptions {
+export type BrowserBuilderOptions = {
     allowedCommonJsDependencies?: string[];
     aot?: boolean;
     assets?: AssetPattern[];
@@ -75,7 +74,7 @@ export interface BrowserBuilderOptions {
     verbose?: boolean;
     watch?: boolean;
     webWorkerTsConfig?: string;
-}
+};
 
 // @public
 export type BrowserBuilderOutput = BuilderOutput & {
@@ -89,7 +88,7 @@ export type BrowserBuilderOutput = BuilderOutput & {
 };
 
 // @public (undocumented)
-export interface Budget {
+export type Budget = {
     baseline?: string;
     error?: string;
     maximumError?: string;
@@ -99,7 +98,7 @@ export interface Budget {
     name?: string;
     type: Type;
     warning?: string;
-}
+};
 
 export { buildApplication }
 
@@ -114,7 +113,7 @@ export enum CrossOrigin {
 }
 
 // @public
-export interface DevServerBuilderOptions {
+export type DevServerBuilderOptions = {
     allowedHosts?: string[];
     buildTarget: string;
     disableHostCheck?: boolean;
@@ -138,7 +137,7 @@ export interface DevServerBuilderOptions {
     sslKey?: string;
     verbose?: boolean;
     watch?: boolean;
-}
+};
 
 export { DevServerBuilderOutput }
 
@@ -189,28 +188,24 @@ export function executeSSRDevServerBuilder(options: SSRDevServerBuilderOptions, 
 export type ExecutionTransformer<T> = (input: T) => T | Promise<T>;
 
 // @public
-export interface ExtractI18nBuilderOptions {
+export type ExtractI18nBuilderOptions = {
     buildTarget?: string;
     format?: Format;
     outFile?: string;
     outputPath?: string;
     progress?: boolean;
-}
+};
 
 // @public (undocumented)
-export interface FileReplacement {
-    // (undocumented)
+export type FileReplacement = {
     replace?: string;
-    // (undocumented)
     replaceWith?: string;
-    // (undocumented)
     src?: string;
-    // (undocumented)
     with?: string;
-}
+};
 
 // @public
-export interface KarmaBuilderOptions {
+export type KarmaBuilderOptions = {
     assets?: AssetPattern_2[];
     browsers?: Browsers;
     builderMode?: BuilderMode;
@@ -234,7 +229,7 @@ export interface KarmaBuilderOptions {
     tsConfig: string;
     watch?: boolean;
     webWorkerTsConfig?: string;
-}
+};
 
 // @public (undocumented)
 export type KarmaConfigOptions = ConfigOptions & {
@@ -243,19 +238,19 @@ export type KarmaConfigOptions = ConfigOptions & {
 };
 
 // @public
-export interface NgPackagrBuilderOptions {
+export type NgPackagrBuilderOptions = {
     poll?: number;
     project: string;
     tsConfig?: string;
     watch?: boolean;
-}
+};
 
 // @public (undocumented)
-export interface OptimizationObject {
+export type OptimizationObject = {
     fonts?: FontsUnion;
     scripts?: boolean;
     styles?: StylesUnion;
-}
+};
 
 // @public
 export type OptimizationUnion = boolean | OptimizationObject;
@@ -273,7 +268,7 @@ export enum OutputHashing {
 }
 
 // @public
-export interface ProtractorBuilderOptions {
+export type ProtractorBuilderOptions = {
     baseUrl?: string;
     devServerTarget?: string;
     grep?: string;
@@ -284,10 +279,10 @@ export interface ProtractorBuilderOptions {
     specs?: string[];
     suite?: string;
     webdriverUpdate?: boolean;
-}
+};
 
 // @public (undocumented)
-export interface ServerBuilderOptions {
+export type ServerBuilderOptions = {
     assets?: AssetPattern_3[];
     buildOptimizer?: boolean;
     deleteOutputPath?: boolean;
@@ -315,7 +310,7 @@ export interface ServerBuilderOptions {
     vendorChunk?: boolean;
     verbose?: boolean;
     watch?: boolean;
-}
+};
 
 // @public
 export type ServerBuilderOutput = BuilderOutput & {
@@ -328,18 +323,18 @@ export type ServerBuilderOutput = BuilderOutput & {
 };
 
 // @public (undocumented)
-export interface SourceMapObject {
+export type SourceMapObject = {
     hidden?: boolean;
     scripts?: boolean;
     styles?: boolean;
     vendor?: boolean;
-}
+};
 
 // @public
 export type SourceMapUnion = boolean | SourceMapObject;
 
 // @public (undocumented)
-export type SSRDevServerBuilderOptions = Schema & json.JsonObject;
+export type SSRDevServerBuilderOptions = Schema;
 
 // @public (undocumented)
 export type SSRDevServerBuilderOutput = BuilderOutput & {
@@ -348,9 +343,9 @@ export type SSRDevServerBuilderOutput = BuilderOutput & {
 };
 
 // @public
-export interface StylePreprocessorOptions {
+export type StylePreprocessorOptions = {
     includePaths?: string[];
-}
+};
 
 // @public
 export enum Type {

--- a/packages/angular/build/src/builders/application/index.ts
+++ b/packages/angular/build/src/builders/application/index.ts
@@ -7,7 +7,6 @@
  */
 
 import { Builder, BuilderContext, BuilderOutput, createBuilder } from '@angular-devkit/architect';
-import { json } from '@angular-devkit/core';
 import assert from 'node:assert';
 import fs from 'node:fs/promises';
 import path from 'node:path';
@@ -260,7 +259,6 @@ function generateFullPath(
   return fullFilePath;
 }
 
-const builder: Builder<ApplicationBuilderOptions & json.JsonObject> =
-  createBuilder(buildApplication);
+const builder: Builder<ApplicationBuilderOptions> = createBuilder(buildApplication);
 
 export default builder;

--- a/packages/angular/build/src/builders/dev-server/index.ts
+++ b/packages/angular/build/src/builders/dev-server/index.ts
@@ -7,7 +7,6 @@
  */
 
 import { Builder, createBuilder } from '@angular-devkit/architect';
-import { json } from '@angular-devkit/core';
 import { execute } from './builder';
 import type { DevServerBuilderOutput } from './output';
 import type { Schema as DevServerBuilderOptions } from './schema';
@@ -17,7 +16,7 @@ export {
   type DevServerBuilderOutput,
   execute as executeDevServerBuilder,
 };
-const builder: Builder<DevServerBuilderOptions & json.JsonObject> = createBuilder<
+const builder: Builder<DevServerBuilderOptions> = createBuilder<
   DevServerBuilderOptions,
   DevServerBuilderOutput
 >(execute);

--- a/packages/angular/build/src/builders/extract-i18n/index.ts
+++ b/packages/angular/build/src/builders/extract-i18n/index.ts
@@ -7,13 +7,12 @@
  */
 
 import { Builder, createBuilder } from '@angular-devkit/architect';
-import { json } from '@angular-devkit/core';
 import { execute } from './builder';
 import type { Schema as ExtractI18nBuilderOptions } from './schema';
 
 export { ExtractI18nBuilderOptions, execute };
 
-const builder: Builder<ExtractI18nBuilderOptions & json.JsonObject> =
+const builder: Builder<ExtractI18nBuilderOptions> =
   createBuilder<ExtractI18nBuilderOptions>(execute);
 
 export default builder;

--- a/packages/angular/build/src/builders/ng-packagr/index.ts
+++ b/packages/angular/build/src/builders/ng-packagr/index.ts
@@ -7,13 +7,11 @@
  */
 
 import { Builder, createBuilder } from '@angular-devkit/architect';
-import { json } from '@angular-devkit/core';
 import { execute } from './builder';
 import type { Schema as NgPackagrBuilderOptions } from './schema';
 
 export { type NgPackagrBuilderOptions, execute };
 
-const builder: Builder<NgPackagrBuilderOptions & json.JsonObject> =
-  createBuilder<NgPackagrBuilderOptions>(execute);
+const builder: Builder<NgPackagrBuilderOptions> = createBuilder<NgPackagrBuilderOptions>(execute);
 
 export default builder;

--- a/packages/angular_devkit/build_angular/src/builders/dev-server/tests/jasmine-helpers.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/tests/jasmine-helpers.ts
@@ -15,8 +15,8 @@ import { setupApplicationTarget, setupBrowserTarget } from './setup';
 
 const optionSchemaCache = new Map<string, json.schema.JsonSchema>();
 
-export function describeServeBuilder<T>(
-  builderHandler: BuilderHandlerFn<T & json.JsonObject>,
+export function describeServeBuilder<T extends json.JsonObject>(
+  builderHandler: BuilderHandlerFn<T>,
   options: { name?: string; schemaPath: string },
   specDefinitions: ((
     harness: JasmineBuilderHarness<T>,

--- a/packages/angular_devkit/build_angular/src/builders/protractor/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/protractor/index.ts
@@ -12,7 +12,7 @@ import {
   createBuilder,
   targetFromTargetString,
 } from '@angular-devkit/architect';
-import { json, tags } from '@angular-devkit/core';
+import { tags } from '@angular-devkit/core';
 import { resolve } from 'path';
 import * as url from 'url';
 import { runModuleAsObservableFork } from '../../utils';
@@ -118,7 +118,7 @@ export async function execute(
       const overrides = {
         watch: false,
         liveReload: false,
-      } as DevServerBuilderOptions & json.JsonObject;
+      } as DevServerBuilderOptions;
 
       if (options.host !== undefined) {
         overrides.host = options.host;

--- a/packages/angular_devkit/build_angular/src/builders/ssr-dev-server/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/ssr-dev-server/index.ts
@@ -52,7 +52,7 @@ const IGNORED_STDOUT_MESSAGES = [
   'Angular is running in development mode. Call enableProdMode() to enable production mode.',
 ];
 
-export type SSRDevServerBuilderOptions = Schema & json.JsonObject;
+export type SSRDevServerBuilderOptions = Schema;
 export type SSRDevServerBuilderOutput = BuilderOutput & {
   baseUrl?: string;
   port?: string;

--- a/packages/angular_devkit/build_webpack/BUILD.bazel
+++ b/packages/angular_devkit/build_webpack/BUILD.bazel
@@ -48,7 +48,6 @@ ts_project(
     module_name = "@angular-devkit/build-webpack",
     deps = [
         ":node_modules/@angular-devkit/architect",
-        ":node_modules/@angular-devkit/core",
         "//:node_modules/@types/node",
         "//:node_modules/rxjs",
         "//:node_modules/webpack",

--- a/packages/angular_devkit/build_webpack/src/builders/webpack-dev-server/index.ts
+++ b/packages/angular_devkit/build_webpack/src/builders/webpack-dev-server/index.ts
@@ -7,7 +7,6 @@
  */
 
 import { Builder, BuilderContext, createBuilder } from '@angular-devkit/architect';
-import { json } from '@angular-devkit/core';
 import { resolve as pathResolve } from 'path';
 import { Observable, from, isObservable, of, switchMap } from 'rxjs';
 import webpack from 'webpack';
@@ -125,7 +124,7 @@ export function runWebpackDevServer(
   );
 }
 
-const builder: Builder<WebpackDevServerBuilderSchema & json.JsonObject> = createBuilder<
+const builder: Builder<WebpackDevServerBuilderSchema> = createBuilder<
   WebpackDevServerBuilderSchema,
   DevServerBuildOutput
 >((options, context) => {

--- a/packages/angular_devkit/build_webpack/src/builders/webpack/index.ts
+++ b/packages/angular_devkit/build_webpack/src/builders/webpack/index.ts
@@ -7,7 +7,6 @@
  */
 
 import { Builder, BuilderContext, BuilderOutput, createBuilder } from '@angular-devkit/architect';
-import { json } from '@angular-devkit/core';
 import { resolve as pathResolve } from 'path';
 import { Observable, from, isObservable, of, switchMap } from 'rxjs';
 import webpack from 'webpack';
@@ -121,13 +120,14 @@ export function runWebpack(
   );
 }
 
-const builder: Builder<WebpackBuilderSchema & json.JsonObject> =
-  createBuilder<WebpackBuilderSchema>((options, context) => {
+const builder: Builder<WebpackBuilderSchema> = createBuilder<WebpackBuilderSchema>(
+  (options, context) => {
     const configPath = pathResolve(context.workspaceRoot, options.webpackConfig);
 
     return from(getWebpackConfig(configPath)).pipe(
       switchMap((config) => runWebpack(config, context)),
     );
-  });
+  },
+);
 
 export default builder;

--- a/tools/quicktype_runner.js
+++ b/tools/quicktype_runner.js
@@ -126,6 +126,7 @@ async function generate(inPath) {
     inputData,
     alphabetizeProperties: true,
     rendererOptions: {
+      'prefer-types': 'true',
       'just-types': 'true',
       'explicit-unions': 'true',
       'acronym-style': 'camel',


### PR DESCRIPTION
By converting schemas from TypeScript `interfaces` to `types`, we can minimize the reliance on `json.JsonObject`. This approach avoids the error "Type 'Schema' does not satisfy the constraint 'JsonObject'" caused by the missing index signature for type 'string' in 'Schema'.