### PR TITLE
ci: replace platform linux with windows 11

### DIFF
--- a/tests/legacy-cli/e2e/assets/protractor-saucelabs.conf.js
+++ b/tests/legacy-cli/e2e/assets/protractor-saucelabs.conf.js
@@ -22,19 +22,19 @@ exports.config = {
     {
       browserName: 'chrome',
       version: '132',
-      platform: 'Linux',
+      platform: 'Windows 11',
       tunnelIdentifier,
     },
     {
       browserName: 'chrome',
       version: '131',
-      platform: 'Linux',
+      platform: 'Windows 11',
       tunnelIdentifier,
     },
     {
       browserName: 'firefox',
       version: '134',
-      platform: 'Linux',
+      platform: 'Windows 11',
       tunnelIdentifier,
     },
     {


### PR DESCRIPTION
For some reason it seems all Linux tests are failing
```
[15:25:13] I/testLogger - [chrome 132 Linux #01] PID: 17353
[chrome 132 Linux #01] Specs: /tmp/angular-cli-e2e-HZAJ55/e2e-test/test-project/e2e/src/app.e2e-spec.ts
[chrome 132 Linux #01]
[chrome 132 Linux #01] [15:24:49] I/sauce - Using SauceLabs selenium server at https://ondemand.saucelabs.com:443/wd/hub
[chrome 132 Linux #01] Jasmine started
[chrome 132 Linux #01] [15:25:10] E/protractor - Could not find Angular on page http://localhost:2000/ : retries looking for angular exceeded
```
https://github.com/angular/angular-cli/actions/runs/12890037755/job/35938861009
