### PR TITLE
fix(@angular/build): handle empty module case to avoid TypeError

### DIFF
--- a/packages/angular/build/src/tools/vite/middlewares/ssr-middleware.ts
+++ b/packages/angular/build/src/tools/vite/middlewares/ssr-middleware.ts
@@ -40,6 +40,11 @@ export function createAngularSsrInternalMiddleware(
       const { writeResponseToNodeResponse, createWebRequestFromNodeRequest } =
         await loadEsmModule<typeof import('@angular/ssr/node')>('@angular/ssr/node');
 
+      // The following is necessary because accessing the module after invalidation may result in an empty module,
+      // which can trigger a `TypeError: ɵgetOrCreateAngularServerApp is not a function` error.
+      // TODO: look into why.
+      await server.ssrLoadModule('/main.server.mjs');
+
       const { ɵgetOrCreateAngularServerApp } = (await server.ssrLoadModule('/main.server.mjs')) as {
         ɵgetOrCreateAngularServerApp: typeof getOrCreateAngularServerApp;
       };


### PR DESCRIPTION
Ensure that accessing the module after invalidation doesn't result in an empty module, which causes a `TypeError: ɵgetOrCreateAngularServerApp is not a function`.

Closes #29458 and closes #29443