### PR TITLE
fix(@angular/ssr): rename `provideServerRoutesConfig` to `provideServerRouting`

### DIFF
--- a/goldens/public-api/angular/ssr/index.api.md
+++ b/goldens/public-api/angular/ssr/index.api.md
@@ -4,7 +4,10 @@
 
 ```ts
 
+import { DefaultExport } from '@angular/router';
 import { EnvironmentProviders } from '@angular/core';
+import { Provider } from '@angular/core';
+import { Type } from '@angular/core';
 
 // @public
 export class AngularAppEngine {
@@ -23,8 +26,11 @@ export enum PrerenderFallback {
     Server = 0
 }
 
-// @public
+// @public @deprecated
 export function provideServerRoutesConfig(routes: ServerRoute[], options?: ServerRoutesConfigOptions): EnvironmentProviders;
+
+// @public
+export function provideServerRouting(routes: ServerRoute[], ...features: ServerRoutesFeature<ServerRoutesFeatureKind>[]): EnvironmentProviders;
 
 // @public
 export enum RenderMode {
@@ -63,7 +69,7 @@ export interface ServerRoutePrerenderWithParams extends Omit<ServerRoutePrerende
     getPrerenderParams: () => Promise<Record<string, string>[]>;
 }
 
-// @public
+// @public @deprecated
 export interface ServerRoutesConfigOptions {
     appShellRoute?: string;
 }
@@ -72,6 +78,9 @@ export interface ServerRoutesConfigOptions {
 export interface ServerRouteServer extends ServerRouteCommon {
     renderMode: RenderMode.Server;
 }
+
+// @public
+export function withAppShell(component: Type<unknown> | (() => Promise<Type<unknown> | DefaultExport<Type<unknown>>>)): ServerRoutesFeature<ServerRoutesFeatureKind.AppShell>;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/angular/ssr/public_api.ts
+++ b/packages/angular/ssr/public_api.ts
@@ -16,6 +16,8 @@ export {
   type ServerRoute,
   type ServerRoutesConfigOptions,
   provideServerRoutesConfig,
+  provideServerRouting,
+  withAppShell,
   RenderMode,
   type ServerRouteClient,
   type ServerRoutePrerender,

--- a/packages/angular/ssr/test/testing-utils.ts
+++ b/packages/angular/ssr/test/testing-utils.ts
@@ -18,7 +18,7 @@ import { provideServerRendering } from '@angular/platform-server';
 import { RouterOutlet, Routes, provideRouter } from '@angular/router';
 import { destroyAngularServerApp } from '../src/app';
 import { ServerAsset, setAngularAppManifest } from '../src/manifest';
-import { ServerRoute, provideServerRoutesConfig } from '../src/routes/route-config';
+import { ServerRoute, provideServerRouting } from '../src/routes/route-config';
 
 @Component({
   standalone: true,
@@ -97,7 +97,7 @@ export function setAngularAppTestingManifest(
           provideServerRendering(),
           provideExperimentalZonelessChangeDetection(),
           provideRouter(routes),
-          provideServerRoutesConfig(serverRoutes),
+          provideServerRouting(serverRoutes),
           ...extraProviders,
         ],
       });

--- a/packages/schematics/angular/server/files/application-builder/ngmodule-src/app/app.module.server.ts.template
+++ b/packages/schematics/angular/server/files/application-builder/ngmodule-src/app/app.module.server.ts.template
@@ -1,13 +1,13 @@
 import { NgModule } from '@angular/core';
 import { ServerModule } from '@angular/platform-server';<% if(serverRouting) { %>
-import { provideServerRoutesConfig } from '@angular/ssr';<% } %>
+import { provideServerRouting } from '@angular/ssr';<% } %>
 import { AppComponent } from './app.component';
 import { AppModule } from './app.module';<% if(serverRouting) { %>
 import { serverRoutes } from './app.routes.server';<% } %>
 
 @NgModule({
   imports: [AppModule, ServerModule],<% if(serverRouting) { %>
-  providers: [provideServerRoutesConfig(serverRoutes)],<% } %>
+  providers: [provideServerRouting(serverRoutes)],<% } %>
   bootstrap: [AppComponent],
 })
 export class AppServerModule {}

--- a/packages/schematics/angular/server/files/application-builder/standalone-src/app/app.config.server.ts.template
+++ b/packages/schematics/angular/server/files/application-builder/standalone-src/app/app.config.server.ts.template
@@ -1,13 +1,13 @@
 import { mergeApplicationConfig, ApplicationConfig } from '@angular/core';
 import { provideServerRendering } from '@angular/platform-server';<% if(serverRouting) { %>
-import { provideServerRoutesConfig } from '@angular/ssr';<% } %>
+import { provideServerRouting } from '@angular/ssr';<% } %>
 import { appConfig } from './app.config';<% if(serverRouting) { %>
 import { serverRoutes } from './app.routes.server';<% } %>
 
 const serverConfig: ApplicationConfig = {
   providers: [
     provideServerRendering(),<% if(serverRouting) { %>
-    provideServerRoutesConfig(serverRoutes)<% } %>
+    provideServerRouting(serverRoutes)<% } %>
   ]
 };
 


### PR DESCRIPTION

This commit renames `provideServerRoutesConfig` to `provideServerRouting` and updates the second parameter to use the `ServerRoutes` features.

This change improves alignment with the framework's API conventions and the way features are integrated.

### Example Usage:
Before:
```typescript
provideServerRoutesConfig(serverRoutes, { appShellRoute: 'shell' })
```

After:
```typescript
provideServerRouting(serverRoutes, withAppShell(AppShellComponent))
```