### PR TITLE
fix(@angular/build): disable TypeScript `removeComments` option

### DIFF
--- a/packages/angular/build/src/tools/angular/compilation/angular-compilation.ts
+++ b/packages/angular/build/src/tools/angular/compilation/angular-compilation.ts
@@ -63,6 +63,9 @@ export abstract class AngularCompilation {
         enableResourceInlining: false,
         supportTestBed: false,
         supportJitMode: false,
+        // Disable removing of comments as TS is quite aggressive with these and can
+        // remove important annotations, such as /* @__PURE__ */ and comments like /* vite-ignore */.
+        removeComments: false,
       }),
     );
   }

--- a/packages/angular_devkit/build_angular/src/tools/webpack/plugins/typescript.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/plugins/typescript.ts
@@ -23,6 +23,9 @@ export function createIvyPlugin(
     sourceMap: buildOptions.sourceMap.scripts,
     declaration: false,
     declarationMap: false,
+    // Disable removing of comments as TS is quite aggressive with these and can
+    // remove important annotations, such as /* @__PURE__ */.
+    removeComments: false,
   };
 
   if (tsConfig.options.target === undefined || tsConfig.options.target < ScriptTarget.ES2022) {


### PR DESCRIPTION
Disables TypeScript's `removeComments` option to ensure important annotations like `/* @__PURE__ */` and `/* vite-ignore */` are preserved. TypeScript's comment removal can be too aggressive, potentially stripping out critical information needed by bundlers for dead code elimination. Non-essential comments will be handled by the bundler, so removing them in TypeScript isn't necessary and could lead to an increase in the final bundle size.

Closes #29470

