### PR TITLE
fix(@angular/build): support template updates that also trigger global stylesheet changes

### DIFF
--- a/packages/angular/build/src/builders/dev-server/vite-server.ts
+++ b/packages/angular/build/src/builders/dev-server/vite-server.ts
@@ -589,7 +589,7 @@ function handleUpdate(
           type: 'update',
           updates,
         });
-        logger.info('HMR update sent to client(s).');
+        logger.info('Stylesheet update sent to client(s).');
 
         return;
       }


### PR DESCRIPTION
In some cases a change to a component template may cause changes to other aspects of the application. Tailwind, for instance, may cause changes to the global stylesheets when class usage is changed in a template. To support hot module replacement of the component template in these cases, stylesheet changes are now analyzed and separated during the update process. This allows both a hot update of the template and the global stylesheet during the rebuild instead of the previously required full page reload.

Closes #29440