### PR TITLE
fix(@angular/build): allow tailwindcss 4.x as a peer dependency

### DIFF
--- a/.aspect/rules/external_repository_action_cache/npm_translate_lock_MzA5NzUwNzMx
+++ b/.aspect/rules/external_repository_action_cache/npm_translate_lock_MzA5NzUwNzMx
@@ -4,13 +4,13 @@
 .npmrc=-1406867100
 modules/testing/builder/package.json=-1196120648
 package.json=-2061208187
-packages/angular/build/package.json=-1096831997
+packages/angular/build/package.json=229129757
 packages/angular/cli/package.json=-1878910022
 packages/angular/pwa/package.json=1108903917
 packages/angular/ssr/package.json=1104313629
 packages/angular_devkit/architect/package.json=-1496633956
 packages/angular_devkit/architect_cli/package.json=1551210941
-packages/angular_devkit/build_angular/package.json=1992694251
+packages/angular_devkit/build_angular/package.json=1732310149
 packages/angular_devkit/build_webpack/package.json=373950017
 packages/angular_devkit/core/package.json=339935828
 packages/angular_devkit/schematics/package.json=673943597

--- a/packages/angular/build/package.json
+++ b/packages/angular/build/package.json
@@ -61,7 +61,7 @@
     "less": "^4.2.0",
     "ng-packagr": "0.0.0-NG-PACKAGR-PEER-DEP",
     "postcss": "^8.4.0",
-    "tailwindcss": "^2.0.0 || ^3.0.0",
+    "tailwindcss": "^2.0.0 || ^3.0.0 || ^4.0.0",
     "typescript": ">=5.5 <5.8"
   },
   "peerDependenciesMeta": {

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -81,7 +81,7 @@
     "karma": "^6.3.0",
     "ng-packagr": "0.0.0-NG-PACKAGR-PEER-DEP",
     "protractor": "^7.0.0",
-    "tailwindcss": "^2.0.0 || ^3.0.0",
+    "tailwindcss": "^2.0.0 || ^3.0.0 || ^4.0.0",
     "typescript": ">=5.5 <5.8"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
To support usage of the newly released Tailwind CSS 4.0.0, the peer dependency range has been update to include `^4.0.0`. This prevents potential installation warnings/error when using various package managers. Use of Tailwind CSS 4+ requires either the `application` (new project default) or `browser-esbuild` builder. Both of which support custom postcss configuration via a `.postcssrc.json` file.

For instructions on the setup of Tailwind CSS with Angular, please see the Tailwind CSS documentation here: https://tailwindcss.com/docs/installation/framework-guides/angular