### PR TITLE
fix(@angular/cli): fix relative link to README not working on npm repo

### DIFF
--- a/packages/angular/build/README.md
+++ b/packages/angular/build/README.md
@@ -2,4 +2,4 @@
 
 The sources for this package are in the [Angular CLI](https://github.com/angular/angular-cli) repository. Please file issues and pull requests against that repository.
 
-Usage information and reference details can be found in repository [README](../../../README.md) file.
+Usage information and reference details can be found in repository [README](https://github.com/angular/angular-cli/blob/main/README.md) file.

--- a/packages/angular/cli/README.md
+++ b/packages/angular/cli/README.md
@@ -2,4 +2,4 @@
 
 The sources for this package are in the [Angular CLI](https://github.com/angular/angular-cli) repository. Please file issues and pull requests against that repository.
 
-Usage information and reference details can be found in repository [README](../../../README.md) file.
+Usage information and reference details can be found in repository [README](https://github.com/angular/angular-cli/blob/main/README.md) file.


### PR DESCRIPTION
The link to the README was relative, which caused it to break when viewed on the npm repository. The link has been updated to an absolute URL to ensure it works properly.

Closes #29489

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [ x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the new behavior that. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [ x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
