### PR TITLE
fix(@angular/build): allow tailwindcss 4.x as a peer dependency

### DIFF
--- a/packages/angular/build/package.json
+++ b/packages/angular/build/package.json
@@ -57,7 +57,7 @@
     "less": "^4.2.0",
     "ng-packagr": "^19.0.0",
     "postcss": "^8.4.0",
-    "tailwindcss": "^2.0.0 || ^3.0.0",
+    "tailwindcss": "^2.0.0 || ^3.0.0 || ^4.0.0",
     "typescript": ">=5.5 <5.8"
   },
   "peerDependenciesMeta": {

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -81,7 +81,7 @@
     "karma": "^6.3.0",
     "ng-packagr": "^19.0.0",
     "protractor": "^7.0.0",
-    "tailwindcss": "^2.0.0 || ^3.0.0",
+    "tailwindcss": "^2.0.0 || ^3.0.0 || ^4.0.0",
     "typescript": ">=5.5 <5.8"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
To support usage of the newly released Tailwind CSS 4.0.0, the peer dependency range has been update to include `^4.0.0`. This prevents potential installation warnings/error when using various package managers. Use of Tailwind CSS 4+ requires either the `application` (new project default) or `browser-esbuild` builder. Both of which support custom postcss configuration via a `.postcssrc.json` file.

For instructions on the setup of Tailwind CSS with Angular, please see the Tailwind CSS documentation here: https://tailwindcss.com/docs/installation/framework-guides/angular

(cherry picked from commit 694ef8e6e486ad66d19b831243193e0123a4b0b1)