### PR TITLE
fix(@schematics/angular): update library schematic to use `@angular-devkit/build-angular:ng-packagr`

### DIFF
--- a/packages/schematics/angular/library/index.ts
+++ b/packages/schematics/angular/library/index.ts
@@ -53,8 +53,8 @@ function addDependenciesToPackageJson() {
       },
       {
         type: NodeDependencyType.Dev,
-        name: '@angular/build',
-        version: latestVersions.AngularBuild,
+        name: '@angular-devkit/build-angular',
+        version: latestVersions.DevkitBuildAngular,
       },
       {
         type: NodeDependencyType.Dev,
@@ -91,7 +91,7 @@ function addLibToWorkspaceFile(
       prefix: options.prefix,
       targets: {
         build: {
-          builder: Builders.BuildNgPackagr,
+          builder: Builders.NgPackagr,
           defaultConfiguration: 'production',
           options: {
             project: `${projectRoot}/ng-package.json`,

--- a/packages/schematics/angular/library/index_spec.ts
+++ b/packages/schematics/angular/library/index_spec.ts
@@ -388,7 +388,9 @@ describe('Library Schematic', () => {
     const tree = await schematicRunner.runSchematic('library', defaultOptions, workspaceTree);
 
     const workspace = JSON.parse(tree.readContent('/angular.json'));
-    expect(workspace.projects.foo.architect.build.builder).toBe('@angular/build:ng-packagr');
+    expect(workspace.projects.foo.architect.build.builder).toBe(
+      '@angular-devkit/build-angular:ng-packagr',
+    );
   });
 
   describe('standalone=false', () => {


### PR DESCRIPTION

The library schematic currently relies on Karma, which requires `@angular-devkit/build-angular` to be installed. To address this, we now use the `ng-packagr` builder provided in this package.

Closes #29494

