### PR TITLE
fix(@angular/build): utilize bazel stamp instead of resolving peer dependency versions

### DIFF
--- a/packages/angular/build/BUILD.bazel
+++ b/packages/angular/build/BUILD.bazel
@@ -224,6 +224,7 @@ npm_package(
         "//packages/angular_devkit/architect:package.json",
     ],
     stamp_files = [
+        "src/utils/version.js",
         "src/tools/esbuild/utils.js",
         "src/utils/normalize-cache.js",
     ],

--- a/packages/angular/build/src/utils/version.ts
+++ b/packages/angular/build/src/utils/version.ts
@@ -56,17 +56,7 @@ export function assertCompatibleAngularVersion(projectRoot: string): void | neve
     return;
   }
 
-  let supportedAngularSemver;
-  try {
-    supportedAngularSemver = projectRequire('@angular/build/package.json')['peerDependencies'][
-      '@angular/compiler-cli'
-    ];
-  } catch {
-    supportedAngularSemver = projectRequire('@angular-devkit/build-angular/package.json')[
-      'peerDependencies'
-    ]['@angular/compiler-cli'];
-  }
-
+  const supportedAngularSemver = '0.0.0-ANGULAR-FW-PEER-DEP';
   const angularVersion = new SemVer(angularPkgJson['version']);
 
   if (!satisfies(angularVersion, supportedAngularSemver, { includePrerelease: true })) {


### PR DESCRIPTION

This update replaces the resolution of peer dependency versions with the use of the Bazel stamp for improved consistency and reliability.

Closes #29504
