### PR TITLE
fix(@angular/build): keep background referenced HMR update chunks

### DIFF
--- a/packages/angular/build/src/builders/application/build-action.ts
+++ b/packages/angular/build/src/builders/application/build-action.ts
@@ -358,6 +358,15 @@ function* emitOutputResults(
     };
   }
 
+  // Do not remove stale files yet if there are template updates.
+  // Component chunk files may still be referenced in running browser code.
+  // Module evaluation time component updates will update any of these files.
+  // This typically occurs when a lazy component is changed that has not yet
+  // been accessed at runtime.
+  if (hasTemplateUpdates && incrementalResult.background) {
+    removedOutputFiles.clear();
+  }
+
   // Include the removed output and asset files
   incrementalResult.removed.push(
     ...Array.from(removedOutputFiles, ([file, { type }]) => ({


### PR DESCRIPTION
When HMR is enabled and a component update is sent to the development server, the following background incremental update will no longer remove the previous JavaScript chunk files for lazy routes. This allows the active and running application code within the browser to still access the lazy chunks referenced in the code. This is important for cases such as when a component in a lazy route (that has not yet been accessed) is modified. In this case, the component update is still processed if/when the lazy route is eventually accessed via the module-time evaluation of the component update code.

Closes #29507