### PR TITLE
refactor(@angular/build): move `@angular-devkit/core` to a development dependency

### DIFF
--- a/.aspect/rules/external_repository_action_cache/npm_translate_lock_MzA5NzUwNzMx
+++ b/.aspect/rules/external_repository_action_cache/npm_translate_lock_MzA5NzUwNzMx
@@ -4,7 +4,7 @@
 .npmrc=-1406867100
 modules/testing/builder/package.json=-1196120648
 package.json=-888245585
-packages/angular/build/package.json=229129757
+packages/angular/build/package.json=1948684129
 packages/angular/cli/package.json=-1878910022
 packages/angular/pwa/package.json=1108903917
 packages/angular/ssr/package.json=1104313629
@@ -17,6 +17,6 @@ packages/angular_devkit/schematics/package.json=673943597
 packages/angular_devkit/schematics_cli/package.json=-1663529211
 packages/ngtools/webpack/package.json=1463215526
 packages/schematics/angular/package.json=251715148
-pnpm-lock.yaml=-1643167424
+pnpm-lock.yaml=967402942
 pnpm-workspace.yaml=-1847919625
 yarn.lock=1546758537

--- a/packages/angular/build/package.json
+++ b/packages/angular/build/package.json
@@ -19,7 +19,6 @@
   "builders": "builders.json",
   "dependencies": {
     "@ampproject/remapping": "2.3.0",
-    "@angular-devkit/core": "workspace:0.0.0-PLACEHOLDER",
     "@angular-devkit/architect": "workspace:0.0.0-EXPERIMENTAL-PLACEHOLDER",
     "@babel/core": "7.26.7",
     "@babel/helper-annotate-as-pure": "7.25.9",
@@ -49,7 +48,8 @@
     "lmdb": "3.2.2"
   },
   "devDependencies": {
-    "@angular/ssr": "workspace:*"
+    "@angular/ssr": "workspace:*",
+    "@angular-devkit/core": "workspace:*"
   },
   "peerDependencies": {
     "@angular/compiler": "0.0.0-ANGULAR-FW-PEER-DEP",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -547,9 +547,6 @@ importers:
       '@angular-devkit/architect':
         specifier: workspace:0.0.0-EXPERIMENTAL-PLACEHOLDER
         version: link:../../angular_devkit/architect
-      '@angular-devkit/core':
-        specifier: workspace:0.0.0-PLACEHOLDER
-        version: link:../../angular_devkit/core
       '@babel/core':
         specifier: 7.26.7
         version: 7.26.7
@@ -624,6 +621,9 @@ importers:
         specifier: 3.2.2
         version: 3.2.2
     devDependencies:
+      '@angular-devkit/core':
+        specifier: workspace:*
+        version: link:../../angular_devkit/core
       '@angular/ssr':
         specifier: workspace:*
         version: link:../ssr


### PR DESCRIPTION
The `@angular-devkit/core` package is not needed at runtime within the `@angular/build` package.