### PR TITLE
build: update framework and ng-packagr peer-deps

### DIFF
--- a/constants.bzl
+++ b/constants.bzl
@@ -5,8 +5,8 @@ RELEASE_ENGINES_YARN = ">= 1.13.0"
 
 NG_PACKAGR_VERSION = "^19.2.0-next.0"
 ANGULAR_FW_VERSION = "^19.2.0-next.0"
-ANGULAR_FW_PEER_DEP = "^19.0.0 || ^19.2.0-next.0"
-NG_PACKAGR_PEER_DEP = "^19.0.0 || ^19.2.0-next.0"
+ANGULAR_FW_PEER_DEP = "^19.2.0-next.0"
+NG_PACKAGR_PEER_DEP = "^19.2.0-next.0"
 
 SNAPSHOT_REPOS = {
     "@angular/cli": "angular/cli-builds",


### PR DESCRIPTION
```
Discovered errors when validating dependency ranges.
  - latest-versions: Invalid dependency range for "ng-packagr". Expected: ^19.2.0-next.0
  - latest-versions: Invalid dependency range for "@angular/core". Expected: ^19.2.0-next.0

Please fix these failures before publishing a new release.
These checks can be forcibly ignored by setting: SKIP_DEPENDENCY_RANGE_PRECHECK=1
```
