### PR TITLE
refactor(@angular-devkit/core): add missing function return types

### DIFF
--- a/packages/angular_devkit/core/src/json/schema/registry.ts
+++ b/packages/angular_devkit/core/src/json/schema/registry.ts
@@ -173,7 +173,7 @@ export class CoreSchemaRegistry implements SchemaRegistry {
    * @param {JsonVisitor} visitor The visitor to transform every value.
    * @param {JsonVisitor[]} deps A list of other visitors to run before.
    */
-  addPreTransform(visitor: JsonVisitor, deps?: JsonVisitor[]) {
+  addPreTransform(visitor: JsonVisitor, deps?: JsonVisitor[]): void {
     this._pre.add(visitor, deps);
   }
 
@@ -184,7 +184,7 @@ export class CoreSchemaRegistry implements SchemaRegistry {
    * @param {JsonVisitor} visitor The visitor to transform every value.
    * @param {JsonVisitor[]} deps A list of other visitors to run before.
    */
-  addPostTransform(visitor: JsonVisitor, deps?: JsonVisitor[]) {
+  addPostTransform(visitor: JsonVisitor, deps?: JsonVisitor[]): void {
     this._post.add(visitor, deps);
   }
 
@@ -386,7 +386,7 @@ export class CoreSchemaRegistry implements SchemaRegistry {
     this._ajv.addFormat(format.name, format.formatter);
   }
 
-  addSmartDefaultProvider<T>(source: string, provider: SmartDefaultProvider<T>) {
+  addSmartDefaultProvider<T>(source: string, provider: SmartDefaultProvider<T>): void {
     if (this._sourceMap.has(source)) {
       throw new Error(source);
     }
@@ -424,11 +424,11 @@ export class CoreSchemaRegistry implements SchemaRegistry {
     }
   }
 
-  registerUriHandler(handler: UriHandler) {
+  registerUriHandler(handler: UriHandler): void {
     this._uriHandlers.add(handler);
   }
 
-  usePromptProvider(provider: PromptProvider) {
+  usePromptProvider(provider: PromptProvider): void {
     const isSetup = !!this._promptProvider;
 
     this._promptProvider = provider;

--- a/packages/angular_devkit/core/src/json/schema/visitor.ts
+++ b/packages/angular_devkit/core/src/json/schema/visitor.ts
@@ -155,7 +155,7 @@ export function visitJson<ContextT>(
   return _visitJsonRecursive(json, visitor, buildJsonPointer([]), schema, refResolver, context);
 }
 
-export function visitJsonSchema(schema: JsonSchema, visitor: JsonSchemaVisitor) {
+export function visitJsonSchema(schema: JsonSchema, visitor: JsonSchemaVisitor): void {
   if (schema === false || schema === true) {
     // Nothing to visit.
     return;

--- a/packages/angular_devkit/core/src/logger/logger.ts
+++ b/packages/angular_devkit/core/src/logger/logger.ts
@@ -101,11 +101,11 @@ export class Logger extends Observable<LogEntry> implements LoggerApi {
     };
   }
 
-  createChild(name: string) {
+  createChild(name: string): Logger {
     return new (this.constructor as typeof Logger)(name, this);
   }
 
-  complete() {
+  complete(): void {
     this._subject.complete();
   }
 
@@ -121,20 +121,20 @@ export class Logger extends Observable<LogEntry> implements LoggerApi {
     this._subject.next(entry);
   }
 
-  debug(message: string, metadata: JsonObject = {}) {
-    return this.log('debug', message, metadata);
+  debug(message: string, metadata: JsonObject = {}): void {
+    this.log('debug', message, metadata);
   }
-  info(message: string, metadata: JsonObject = {}) {
-    return this.log('info', message, metadata);
+  info(message: string, metadata: JsonObject = {}): void {
+    this.log('info', message, metadata);
   }
-  warn(message: string, metadata: JsonObject = {}) {
-    return this.log('warn', message, metadata);
+  warn(message: string, metadata: JsonObject = {}): void {
+    this.log('warn', message, metadata);
   }
-  error(message: string, metadata: JsonObject = {}) {
-    return this.log('error', message, metadata);
+  error(message: string, metadata: JsonObject = {}): void {
+    this.log('error', message, metadata);
   }
-  fatal(message: string, metadata: JsonObject = {}) {
-    return this.log('fatal', message, metadata);
+  fatal(message: string, metadata: JsonObject = {}): void {
+    this.log('fatal', message, metadata);
   }
 
   override toString() {

--- a/packages/angular_devkit/core/src/utils/priority-queue.ts
+++ b/packages/angular_devkit/core/src/utils/priority-queue.ts
@@ -12,11 +12,11 @@ export class PriorityQueue<T> {
 
   constructor(private _comparator: (x: T, y: T) => number) {}
 
-  clear() {
+  clear(): void {
     this._items = new Array<T>();
   }
 
-  push(item: T) {
+  push(item: T): void {
     const index = this._items.findIndex((existing) => this._comparator(item, existing) <= 0);
 
     if (index === -1) {

--- a/packages/angular_devkit/core/src/virtual-fs/host/alias.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/host/alias.ts
@@ -56,7 +56,7 @@ import { ResolverHost } from './resolver';
  *     .subscribe(x => expect(x).toBe(content2));
  */
 export class AliasHost<StatsT extends object = {}> extends ResolverHost<StatsT> {
-  protected _aliases = new Map<Path, Path>();
+  protected _aliases: Map<Path, Path> = new Map();
 
   protected _resolve(path: Path): Path {
     let maybeAlias = this._aliases.get(path);

--- a/packages/angular_devkit/core/src/virtual-fs/path.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/path.ts
@@ -120,7 +120,7 @@ export function join(p1: Path, ...others: string[]): Path {
 /**
  * Returns true if a path is absolute.
  */
-export function isAbsolute(p: Path) {
+export function isAbsolute(p: Path): boolean {
   return p.startsWith(NormalizedSep);
 }
 
@@ -166,7 +166,7 @@ export function relative(from: Path, to: Path): Path {
  * Returns a Path that is the resolution of p2, from p1. If p2 is absolute, it will return p2,
  * otherwise will join both p1 and p2.
  */
-export function resolve(p1: Path, p2: Path) {
+export function resolve(p1: Path, p2: Path): Path {
   if (isAbsolute(p2)) {
     return p2;
   } else {

--- a/packages/angular_devkit/core/src/workspace/json/metadata.ts
+++ b/packages/angular_devkit/core/src/workspace/json/metadata.ts
@@ -10,7 +10,7 @@ import { JSONPath, Node, findNodeAtLocation, getNodeValue } from 'jsonc-parser';
 import { JsonValue } from '../../json';
 import { ProjectDefinition, TargetDefinition, WorkspaceDefinition } from '../definitions';
 
-export const JsonWorkspaceSymbol = Symbol.for('@angular/core:workspace-json');
+export const JsonWorkspaceSymbol: unique symbol = Symbol.for('@angular/core:workspace-json');
 
 export interface JsonWorkspaceDefinition extends WorkspaceDefinition {
   [JsonWorkspaceSymbol]: JsonWorkspaceMetadata;


### PR DESCRIPTION
Adding explicit type information for function return types is needed to allow the `@angular-devkit/core` package to eventually be built with the `isolatedDeclarations` option.