### PR TITLE
fix(@angular/build): prevent server manifest generation when no server features are enabled

### DIFF
--- a/packages/angular/build/src/builders/application/execute-post-bundle.ts
+++ b/packages/angular/build/src/builders/application/execute-post-bundle.ts
@@ -66,7 +66,7 @@ export async function executePostBundleSteps(
   const {
     baseHref = '/',
     serviceWorker,
-    i18nOptions,
+    ssrOptions,
     indexHtmlOptions,
     optimizationOptions,
     sourcemapOptions,
@@ -113,7 +113,7 @@ export async function executePostBundleSteps(
 
   // Create server manifest
   const initialFilesPaths = new Set(initialFiles.keys());
-  if (serverEntryPoint) {
+  if (serverEntryPoint && (outputMode || prerenderOptions || appShellOptions || ssrOptions)) {
     const { manifestContent, serverAssetsChunks } = generateAngularServerAppManifest(
       additionalHtmlOutputFiles,
       outputFiles,


### PR DESCRIPTION


This change ensures that the server manifest is not generated if none of the server-related features are enabled.

Closes #29443