### PR TITLE
build: re-enable latest version checks during release

### DIFF
--- a/scripts/release-checks/dependency-ranges/index.mts
+++ b/scripts/release-checks/dependency-ranges/index.mts
@@ -32,9 +32,8 @@ export async function assertValidDependencyRanges(
   }
 
   const failures: string[] = [
-    ...(await checkPeerDependencies(newVersion, allPackages)),
-    // TODO: Re-enable the following once the checks are performed against the stamped `.js` file instead of the source `.json` file.
-    // ...(await checkSchematicsAngularLatestVersion(newVersion)),
+    ...checkPeerDependencies(newVersion, allPackages),
+    ...checkSchematicsAngularLatestVersion(newVersion),
   ];
 
   if (failures.length !== 0) {

--- a/scripts/release-checks/dependency-ranges/peer-deps-check.mts
+++ b/scripts/release-checks/dependency-ranges/peer-deps-check.mts
@@ -16,12 +16,12 @@ export interface PackageJson {
   peerDependencies?: Record<string, string>;
 }
 
-export async function checkPeerDependencies(
+export function checkPeerDependencies(
   newVersion: semver.SemVer,
   allPackages: PackageJson[],
-): Promise<string[]> {
-  const { major, minor } = newVersion;
-  const isPrerelease = !!newVersion.prerelease[0];
+): string[] {
+  const { major, minor, prerelease } = newVersion;
+  const isPrerelease = !!prerelease[0];
   const isMajor = minor === 0;
 
   let expectedFwPeerDep = `^${major}.0.0`;
@@ -58,7 +58,7 @@ function checkPackage(pkgJson: PackageJson, expectedFwPeerDep: string): string[]
 
     if (range !== expectedFwPeerDep) {
       failures.push(
-        `${pkgJson.name}: Unexpected peer dependency range for "${depName}". Expected: ${expectedFwPeerDep}`,
+        `${pkgJson.name}: Unexpected peer dependency range for "${depName}". Expected: ${expectedFwPeerDep} but got: ${range}`,
       );
     }
   }


### PR DESCRIPTION
This commit restores the latest version checks, which are now fixed by using the stamped versions.
