### PR TITLE
ci: configure codeql locally within the repo to allow for customization

### DIFF
--- a/.github/codeql/config.yml
+++ b/.github/codeql/config.yml
@@ -1,0 +1,8 @@
+name: 'Angular CLI CodeQL config'
+
+query-filters:
+  # TODO(josephperrott): reevaluate if these can be reenabled.
+  - exclude:
+      id: js/bad-code-sanitization
+  - exclude:
+      id: js/regex-injection

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,10 +15,6 @@ jobs:
       packages: read
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - language: javascript-typescript
-            build-mode: none
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -29,6 +25,7 @@ jobs:
         with:
           languages: javascript-typescript
           build-mode: none
+          config-file: .github/codeql/config.yml
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@86b04fb0e47484f7282357688f21d5d0e32175fe #v3.28.8
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,35 @@
+name: 'CodeQL'
+
+on:
+  push:
+    branches: ['main', '*.*.x']
+  schedule:
+    - cron: '39 9 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: 'ubuntu-latest'
+    permissions:
+      security-events: write
+      packages: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: javascript-typescript
+            build-mode: none
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@1a7989f3955e0c69f0e0ccc14aee54a387a0fd31 #v3.28.8
+        with:
+          languages: javascript-typescript
+          build-mode: none
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@86b04fb0e47484f7282357688f21d5d0e32175fe #v3.28.8
+        with:
+          category: '/language:javascript-typescript'


### PR DESCRIPTION
Moving to the configuration being in the repo allows us to specify which specific rules are run in analysis.
