### PR TITLE
build: Preserve newlines when gathering stdout

### DIFF
--- a/scripts/build-schema.mts
+++ b/scripts/build-schema.mts
@@ -38,7 +38,7 @@ function _exec(cmd: string, captureStdout: boolean): Promise<string> {
     proc.stdout.on('data', (data) => {
       console.info(data.toString().trim());
       if (captureStdout) {
-        output += data.toString().trim();
+        output += data.toString();
       }
     });
     proc.stderr.on('data', (data) => console.info(data.toString().trim()));


### PR DESCRIPTION
If the chunk happens to end in a new line or other meaningful whitespace, stripping it can lead to two words (e.g. targets) being squished together and broken.

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [ ] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the new behavior that. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
