### PR TITLE
fix(@schematics/angular): skip ssr migration when `@angular/ssr` is not a dependency

### DIFF
--- a/packages/schematics/angular/migrations/update-ssr-imports/migration.ts
+++ b/packages/schematics/angular/migrations/update-ssr-imports/migration.ts
@@ -8,6 +8,7 @@
 
 import { DirEntry, Rule, UpdateRecorder } from '@angular-devkit/schematics';
 import * as ts from '../../third_party/github.com/Microsoft/TypeScript/lib/typescript';
+import { getPackageJsonDependency } from '../../utility/dependencies';
 
 function* visit(directory: DirEntry): IterableIterator<ts.SourceFile> {
   for (const path of directory.subfiles) {
@@ -46,6 +47,10 @@ function* visit(directory: DirEntry): IterableIterator<ts.SourceFile> {
  */
 export default function (): Rule {
   return (tree) => {
+    if (!getPackageJsonDependency(tree, '@angular/ssr')) {
+      return;
+    }
+
     for (const sourceFile of visit(tree.root)) {
       let recorder: UpdateRecorder | undefined;
 

--- a/packages/schematics/angular/migrations/update-ssr-imports/migration_spec.ts
+++ b/packages/schematics/angular/migrations/update-ssr-imports/migration_spec.ts
@@ -19,6 +19,14 @@ describe('CommonEngine migration', () => {
   let tree: UnitTestTree;
   beforeEach(() => {
     tree = new UnitTestTree(new EmptyTree());
+    tree.create(
+      'package.json',
+      JSON.stringify({
+        dependencies: {
+          '@angular/ssr': '0.0.0',
+        },
+      }),
+    );
   });
 
   function runMigration(): Promise<UnitTestTree> {


### PR DESCRIPTION

This commit updates the `update-ssr-imports` migration to not run when the @angular/ssr` package is not listed as a dependency.

Closes #29560
