### PR TITLE
fix(@angular/build): ensure full rebuild after initial error build in watch mode

### DIFF
--- a/packages/angular/build/src/builders/dev-server/tests/behavior/build-errors_spec.ts
+++ b/packages/angular/build/src/builders/dev-server/tests/behavior/build-errors_spec.ts
@@ -1,0 +1,66 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { concatMap, count, take, timeout } from 'rxjs';
+import { executeDevServer } from '../../index';
+import { describeServeBuilder } from '../jasmine-helpers';
+import { BASE_OPTIONS, BUILD_TIMEOUT, DEV_SERVER_BUILDER_INFO } from '../setup';
+import { logging } from '@angular-devkit/core';
+
+describeServeBuilder(executeDevServer, DEV_SERVER_BUILDER_INFO, (harness, setupTarget) => {
+  describe('Behavior: "Rebuild Error Detection"', () => {
+    beforeEach(() => {
+      setupTarget(harness);
+    });
+
+    it('Emits full build result with incremental enabled and initial build has errors', async () => {
+      harness.useTarget('serve', {
+        ...BASE_OPTIONS,
+        watch: true,
+      });
+
+      // Missing ending `>` on the div will cause an error
+      await harness.appendToFile('src/app/app.component.html', '<div>Hello, world!</div');
+
+      const buildCount = await harness
+        .execute({ outputLogsOnFailure: false })
+        .pipe(
+          timeout(BUILD_TIMEOUT),
+          concatMap(async ({ result, logs }, index) => {
+            switch (index) {
+              case 0:
+                expect(result?.success).toBeFalse();
+                debugger;
+                expect(logs).toContain(
+                  jasmine.objectContaining<logging.LogEntry>({
+                    message: jasmine.stringMatching('Unexpected character "EOF"'),
+                  }),
+                );
+
+                await harness.appendToFile('src/app/app.component.html', '>');
+
+                break;
+              case 1:
+                expect(result?.success).toBeTrue();
+                expect(logs).not.toContain(
+                  jasmine.objectContaining<logging.LogEntry>({
+                    message: jasmine.stringMatching('Unexpected character "EOF"'),
+                  }),
+                );
+                break;
+            }
+          }),
+          take(2),
+          count(),
+        )
+        .toPromise();
+
+      expect(buildCount).toBe(2);
+    });
+  });
+});

--- a/packages/angular/build/src/builders/dev-server/vite-server.ts
+++ b/packages/angular/build/src/builders/dev-server/vite-server.ts
@@ -213,6 +213,8 @@ export async function* serveWithVite(
           },
         });
       }
+
+      yield { baseUrl: '', success: false };
       continue;
     }
     // Clear existing error overlay on successful result

--- a/tests/legacy-cli/e2e/tests/build/jit-ngmodule.ts
+++ b/tests/legacy-cli/e2e/tests/build/jit-ngmodule.ts
@@ -32,6 +32,12 @@ export default async function () {
       };
     }
 
+    // Remove bundle budgets due to the increased size from JIT
+    build.configurations.production = {
+      ...build.configurations.production,
+      budgets: undefined,
+    };
+
     build.options.aot = false;
   });
   // Test it works


### PR DESCRIPTION
If an initial build of an application results in an error during watch mode (including `ng serve`), the following non-error rebuild will now always be a full build result. This ensures that all new files are available for later incremental build result updates.

Closes #29566