### PR TITLE
fix(@angular/build): avoid pre-transform errors with Vite pre-bundling

### DIFF
--- a/packages/angular/build/src/builders/dev-server/tests/behavior/build-external-dependencies_spec.ts
+++ b/packages/angular/build/src/builders/dev-server/tests/behavior/build-external-dependencies_spec.ts
@@ -83,5 +83,21 @@ describeServeBuilder(executeDevServer, DEV_SERVER_BUILDER_INFO, (harness, setupT
       expect(text).toContain(`import { BehaviorSubject } from "rxjs";`);
       expect(text).toContain(`import { map } from "rxjs/operators";`);
     });
+
+    // TODO: Enable when Vite has a custom logger setup to redirect logging into the builder system
+    xit('does not show pre-transform errors in the console for external dependencies', async () => {
+      harness.useTarget('serve', {
+        ...BASE_OPTIONS,
+      });
+
+      const { result, logs } = await executeOnceAndFetch(harness, 'main.js');
+
+      expect(result?.success).toBeTrue();
+      expect(logs).not.toContain(
+        jasmine.objectContaining({
+          message: jasmine.stringMatching('Pre-transform error'),
+        }),
+      );
+    });
   });
 });

--- a/packages/angular/build/src/builders/dev-server/vite-server.ts
+++ b/packages/angular/build/src/builders/dev-server/vite-server.ts
@@ -768,6 +768,15 @@ export async function setupServer(
       mainFields: ['es2020', 'browser', 'module', 'main'],
       preserveSymlinks,
     },
+    dev: {
+      // This is needed when `externalDependencies` is used to prevent Vite load errors.
+      // NOTE: If Vite adds direct support for externals, this can be removed.
+      // NOTE: Vite breaks the resolution of browser modules in SSR
+      //       when accessing a url with two or more segments (e.g., 'foo/bar'),
+      //       as they are not re-based from the base href.
+      preTransformRequests:
+        externalMetadata.explicitBrowser.length === 0 && ssrMode === ServerSsrMode.NoSsr,
+    },
     server: {
       warmup: {
         ssrFiles,
@@ -806,13 +815,6 @@ export async function setupServer(
           ...[...assets.values()].map(({ source }) => source),
         ],
       },
-      // This is needed when `externalDependencies` is used to prevent Vite load errors.
-      // NOTE: If Vite adds direct support for externals, this can be removed.
-      // NOTE: Vite breaks the resolution of browser modules in SSR
-      //       when accessing a url with two or more segments (e.g., 'foo/bar'),
-      //       as they are not re-based from the base href.
-      preTransformRequests:
-        externalMetadata.explicitBrowser.length === 0 && ssrMode === ServerSsrMode.NoSsr,
     },
     ssr: {
       // Note: `true` and `/.*/` have different sematics. When true, the `external` option is ignored.


### PR DESCRIPTION
Vite 6.0 change the option location of the `preTransformRequests` to the `dev` section of the Vite configuration. While the previous `server` section option of the same name is still present, it currently does not change behavior when configured.