### PR TITLE
fix(@angular/build): always provide Vite client helpers with development server

### DIFF
--- a/packages/angular/build/src/builders/dev-server/vite-server.ts
+++ b/packages/angular/build/src/builders/dev-server/vite-server.ts
@@ -854,7 +854,6 @@ export async function setupServer(
         outputFiles,
         templateUpdates,
         external: externalMetadata.explicitBrowser,
-        skipViteClient: serverOptions.liveReload === false && serverOptions.hmr === false,
       }),
     ],
     // Browser only optimizeDeps. (This does not run for SSR dependencies).


### PR DESCRIPTION
In addition to the WebSocket code, the Vite client module contains helper functions which may be injected into modules at request time. These helpers are required for certain behavior to function. Previously, when `--no-live-reload` was used, these helpers may not have been available which led to runtime errors. These runtime errors will no longer occur. However, the browser console will now log that the Vite client cannot connect to the development server WebSocket. This is expected in this case since live reload functionality was disabled and the server side is intentionally not available.

Closes #29556