### PR TITLE
fix(@angular/ssr): properly handle baseHref with protocol

### DIFF
--- a/packages/angular/build/src/utils/server-rendering/prerender.ts
+++ b/packages/angular/build/src/utils/server-rendering/prerender.ts
@@ -228,12 +228,14 @@ async function renderPages(
   try {
     const renderingPromises: Promise<void>[] = [];
     const appShellRouteWithLeadingSlash = appShellRoute && addLeadingSlash(appShellRoute);
-    const baseHrefWithLeadingSlash = addLeadingSlash(baseHref);
+    const baseHrefPathnameWithLeadingSlash = new URL(baseHref, 'http://localhost').pathname;
 
     for (const { route, redirectTo } of serializableRouteTreeNode) {
       // Remove the base href from the file output path.
-      const routeWithoutBaseHref = addTrailingSlash(route).startsWith(baseHrefWithLeadingSlash)
-        ? addLeadingSlash(route.slice(baseHrefWithLeadingSlash.length))
+      const routeWithoutBaseHref = addTrailingSlash(route).startsWith(
+        baseHrefPathnameWithLeadingSlash,
+      )
+        ? addLeadingSlash(route.slice(baseHrefPathnameWithLeadingSlash.length))
         : route;
 
       const outPath = posix.join(removeLeadingSlash(routeWithoutBaseHref), 'index.html');

--- a/packages/angular/ssr/src/routes/ng-routes.ts
+++ b/packages/angular/ssr/src/routes/ng-routes.ts
@@ -615,13 +615,10 @@ export async function getRoutesFromAngularRouterConfig(
 
     const errors: string[] = [];
 
-    let baseHref =
+    const rawBaseHref =
       injector.get(APP_BASE_HREF, null, { optional: true }) ??
       injector.get(PlatformLocation).getBaseHrefFromDOM();
-
-    if (baseHref.startsWith('./')) {
-      baseHref = baseHref.slice(2);
-    }
+    const { pathname: baseHref } = new URL(rawBaseHref, 'http://localhost');
 
     const compiler = injector.get(Compiler);
     const serverRoutesConfig = injector.get(SERVER_ROUTES_CONFIG, null, { optional: true });

--- a/packages/angular/ssr/test/routes/ng-routes_spec.ts
+++ b/packages/angular/ssr/test/routes/ng-routes_spec.ts
@@ -576,6 +576,25 @@ describe('extractRoutesAndCreateRouteTree', () => {
     ]);
   });
 
+  it('handles a baseHref starting with a protocol', async () => {
+    setAngularAppTestingManifest(
+      [{ path: 'home', component: DummyComponent }],
+      [{ path: '**', renderMode: RenderMode.Server }],
+      /** baseHref*/ 'http://foo.com/example/',
+    );
+
+    const { routeTree, errors } = await extractRoutesAndCreateRouteTree({
+      url,
+      invokeGetPrerenderParams: true,
+      includePrerenderFallbackRoutes: true,
+    });
+
+    expect(errors).toHaveSize(0);
+    expect(routeTree.toObject()).toEqual([
+      { route: '/example/home', renderMode: RenderMode.Server },
+    ]);
+  });
+
   it('should not bootstrap the root component', async () => {
     @Component({
       standalone: true,


### PR DESCRIPTION
Enhances handling of `baseHref` when it includes a full URL with a protocol.

Closes #29590

