### PR TITLE
fix(@angular/build): exclude unmodified files from logs with `--local…

### DIFF
--- a/packages/angular/build/src/builders/application/execute-build.ts
+++ b/packages/angular/build/src/builders/application/execute-build.ts
@@ -184,9 +184,6 @@ export async function executeBuild(
 
   executionResult.outputFiles.push(...outputFiles);
 
-  const changedFiles =
-    rebuildState && executionResult.findChangedFiles(rebuildState.previousOutputInfo);
-
   // Analyze files for bundle budget failures if present
   let budgetFailures: BudgetCalculatorResult[] | undefined;
   if (options.budgets) {
@@ -288,6 +285,8 @@ export async function executeBuild(
   }
 
   if (!jsonLogs) {
+    const changedFiles =
+      rebuildState && executionResult.findChangedFiles(rebuildState.previousOutputInfo);
     executionResult.addLog(
       logBuildStats(
         metafile,

--- a/packages/angular/build/src/tools/esbuild/utils.ts
+++ b/packages/angular/build/src/tools/esbuild/utils.ts
@@ -40,6 +40,11 @@ export function logBuildStats(
   ssrOutputEnabled?: boolean,
   verbose?: boolean,
 ): string {
+  // Remove the i18n subpath in case the build is using i18n.
+  // en-US/main.js -> main.js
+  const normalizedChangedFiles: Set<string> = new Set(
+    [...(changedFiles ?? [])].map((f) => basename(f)),
+  );
   const browserStats: BundleStats[] = [];
   const serverStats: BundleStats[] = [];
   let unchangedCount = 0;
@@ -52,7 +57,7 @@ export function logBuildStats(
     }
 
     // Show only changed files if a changed list is provided
-    if (changedFiles && !changedFiles.has(file)) {
+    if (normalizedChangedFiles.size && !normalizedChangedFiles.has(file)) {
       ++unchangedCount;
       continue;
     }


### PR DESCRIPTION
Ensures that only modified files are displayed in logs when using the `--localize` flag, preventing unnecessary noise.

Closes https://github.com/angular/angular-cli/issues/29586