### PR TITLE
fix(@angular/cli): correctly parse and resolve relative schematic collection names on Windows

### DIFF
--- a/packages/angular/cli/src/command-builder/schematics-command-module.ts
+++ b/packages/angular/cli/src/command-builder/schematics-command-module.ts
@@ -13,7 +13,7 @@ import {
   FileSystemSchematicDescription,
   NodeWorkflow,
 } from '@angular-devkit/schematics/tools';
-import { relative, resolve } from 'path';
+import { relative } from 'path';
 import { Argv } from 'yargs';
 import { isPackageNameSafeForAnalytics } from '../analytics/analytics';
 import { EventCustomDimension } from '../analytics/analytics-parameters';
@@ -277,12 +277,6 @@ export abstract class SchematicsCommandModule
 
   @memoize
   protected async getSchematicCollections(): Promise<Set<string>> {
-    // Resolve relative collections from the location of `angular.json`
-    const resolveRelativeCollection = (collectionName: string) =>
-      collectionName.charAt(0) === '.'
-        ? resolve(this.context.root, collectionName)
-        : collectionName;
-
     const getSchematicCollections = (
       configSection: Record<string, unknown> | undefined,
     ): Set<string> | undefined => {
@@ -292,7 +286,7 @@ export abstract class SchematicsCommandModule
 
       const { schematicCollections } = configSection;
       if (Array.isArray(schematicCollections)) {
-        return new Set(schematicCollections.map((c) => resolveRelativeCollection(c)));
+        return new Set(schematicCollections);
       }
 
       return undefined;
@@ -399,6 +393,10 @@ export abstract class SchematicsCommandModule
 
   private getResolvePaths(collectionName: string): string[] {
     const { workspace, root } = this.context;
+    if (collectionName[0] === '.') {
+      // Resolve relative collections from the location of `angular.json`
+      return [root];
+    }
 
     return workspace
       ? // Workspace


### PR DESCRIPTION


Previously, the logic incorrectly extracted the drive letter as the collection name when the schematic collection was specified as relative on Windows. This fix ensures that relative paths are parsed and resolved correctly, preventing the drive letter from being mistakenly treated as the collection name.

Closes #29559
