### PR TITLE
refactor(@angular/build): remove outdated `allowedHosts` warning

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/dev-server/builder.ts
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/builder.ts
@@ -67,12 +67,6 @@ export function execute(
           );
         }
 
-        if (options.allowedHosts?.length) {
-          context.logger.warn(
-            `The "allowedHosts" option will not be used because it is not supported by the "${builderName}" builder.`,
-          );
-        }
-
         if (options.publicHost) {
           context.logger.warn(
             `The "publicHost" option will not be used because it is not supported by the "${builderName}" builder.`,


### PR DESCRIPTION
The warning is no longer accurate, as `allowedHosts` is now used in Vite.
