### PR TITLE
perf(@angular/build): cache translated i18n bundles for faster builds

### DIFF
--- a/packages/angular/build/src/builders/application/i18n.ts
+++ b/packages/angular/build/src/builders/application/i18n.ts
@@ -39,7 +39,7 @@ export async function inlineI18n(
   warnings: string[];
   prerenderedRoutes: PrerenderedRoutesRecord;
 }> {
-  const { i18nOptions, optimizationOptions, baseHref } = options;
+  const { i18nOptions, optimizationOptions, baseHref, cacheOptions } = options;
 
   // Create the multi-threaded inliner with common options and the files generated from the build.
   const inliner = new I18nInliner(
@@ -47,6 +47,7 @@ export async function inlineI18n(
       missingTranslation: i18nOptions.missingTranslationBehavior ?? 'warning',
       outputFiles: executionResult.outputFiles,
       shouldOptimize: optimizationOptions.scripts,
+      persistentCachePath: cacheOptions.enabled ? cacheOptions.path : undefined,
     },
     maxWorkers,
   );


### PR DESCRIPTION
When disk caching is enabled, translated i18n bundles are stored on disk, improving performance and speeding up both incremental and non-incremental builds.
