### PR TITLE
fix(@angular/build): configure Vite CORS option

### DIFF
--- a/packages/angular/build/src/builders/dev-server/schema.json
+++ b/packages/angular/build/src/builders/dev-server/schema.json
@@ -37,12 +37,12 @@
       "description": "SSL certificate to use for serving HTTPS."
     },
     "allowedHosts": {
-      "description": "The hosts that can access the development server. This option sets the Vite option of the same name. For further details: https://vite.dev/config/server-options.html#server-allowedhosts",
+      "description": "The hosts that the development server will respond to. This option sets the Vite option of the same name. For further details: https://vite.dev/config/server-options.html#server-allowedhosts",
       "default": [],
       "oneOf": [
         {
           "type": "array",
-          "description": "List of hosts that are allowed to access the development server.",
+          "description": "A list of hosts that the development server will respond to.",
           "items": {
             "type": "string"
           }

--- a/packages/angular/build/src/builders/dev-server/vite-server.ts
+++ b/packages/angular/build/src/builders/dev-server/vite-server.ts
@@ -841,6 +841,9 @@ export async function setupServer(
           ? (proxy ?? {})
           : proxy,
       cors: {
+        // This will add the header `Access-Control-Allow-Origin: http://example.com`,
+        // where `http://example.com` is the requesting origin.
+        origin: true,
         // Allow preflight requests to be proxied.
         preflightContinue: true,
       },


### PR DESCRIPTION
Vite's `allowedHosts` option does not enable CORS; instead, it allows the dev server to respond to requests with a matching hostname (e.g., http://example.com/main.js). It only verifies that the request’s hostname is on the allowed list. However, this does not consider the `origin` in the case of a CORS request.

This commit updates Vite's configuration to enable CORS.

Closes #29549
