### PR TITLE
fix(@schematics/angular): remove animations module from ng new app

### DIFF
--- a/packages/schematics/angular/workspace/files/package.json.template
+++ b/packages/schematics/angular/workspace/files/package.json.template
@@ -10,7 +10,6 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/animations": "<%= latestVersions.Angular %>",
     "@angular/common": "<%= latestVersions.Angular %>",
     "@angular/compiler": "<%= latestVersions.Angular %>",
     "@angular/core": "<%= latestVersions.Angular %>",


### PR DESCRIPTION
Previously the animations module was added to the `ng new` app, because `platform-server` was using it. That's no longer the case as of https://github.com/angular/angular/pull/59762 so these changes remove the dependency.
