### PR TITLE
ci: temporary disable updating esbuild

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,7 +23,15 @@
   "dependencyDashboard": true,
   "schedule": ["after 10:00pm every weekday", "before 4:00am every weekday", "every weekend"],
   "baseBranches": ["main"],
-  "ignoreDeps": ["@types/node", "@types/express", "build_bazel_rules_nodejs", "rules_pkg", "yarn"],
+  "ignoreDeps": [
+    "@types/node",
+    "@types/express",
+    "build_bazel_rules_nodejs",
+    "rules_pkg",
+    "yarn",
+    "esbuild",
+    "esbuild-wasm"
+  ],
   "includePaths": [
     "WORKSPACE",
     "package.json",


### PR DESCRIPTION
Versions 0.25.0 breaks sourcemaps, this requires further investigation and if it's possible to mitigate from our end.

