### PR TITLE
fix(@angular-devkit/build-angular): support aot option for karma browser builder

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/karma/browser_builder.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/browser_builder.ts
@@ -131,7 +131,7 @@ async function initializeBrowser(
       budgets: undefined,
       optimization: false,
       buildOptimizer: false,
-      aot: false,
+      aot: options.aot,
       vendorChunk: true,
       namedChunks: true,
       extractLicenses: false,

--- a/packages/angular_devkit/build_angular/src/builders/karma/tests/options/aot_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/tests/options/aot_spec.ts
@@ -12,13 +12,13 @@ import { BuilderMode } from '../../schema';
 
 describeKarmaBuilder(execute, KARMA_BUILDER_INFO, (harness, setupTarget) => {
   describe('Option: "aot"', () => {
-    it('enables aot', async () => {
+    it('enables aot with application builder', async () => {
       await setupTarget(harness);
 
       await harness.writeFiles({
         'src/aot.spec.ts': `
           import { Component } from '@angular/core';
-          
+
           describe('Hello', () => {
             it('should *not* contain jit instructions', () => {
               @Component({
@@ -38,6 +38,38 @@ describeKarmaBuilder(execute, KARMA_BUILDER_INFO, (harness, setupTarget) => {
         /** Cf. {@link ../builder-mode_spec.ts} */
         polyfills: ['zone.js', '@angular/localize/init', 'zone.js/testing'],
         builderMode: BuilderMode.Application,
+      });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
+    });
+
+    it('enables aot with browser builder', async () => {
+      await setupTarget(harness);
+
+      await harness.writeFiles({
+        'src/aot.spec.ts': `
+          import { Component } from '@angular/core';
+
+          describe('Hello', () => {
+            it('should *not* contain jit instructions', () => {
+              @Component({
+                template: 'Hello',
+              })
+              class Hello {}
+
+              expect((Hello as any).ɵcmp.template.toString()).not.toContain('jit');
+            });
+          });
+`,
+      });
+
+      harness.useTarget('test', {
+        ...BASE_OPTIONS,
+        aot: true,
+        /** Cf. {@link ../builder-mode_spec.ts} */
+        polyfills: ['zone.js', '@angular/localize/init', 'zone.js/testing'],
+        builderMode: BuilderMode.Browser,
       });
 
       const { result } = await harness.executeOnce();


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

`aot: true` is supported by the karma builder, but only with the application builder, as the option is ignored with the browser builder.

## What is the new behavior?

The option is also used by the browser builder

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
