### PR TITLE
fix(@schematics/angular): remove animations module from ng new app

### DIFF
--- a/packages/schematics/angular/workspace/files/package.json.template
+++ b/packages/schematics/angular/workspace/files/package.json.template
@@ -10,7 +10,6 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/animations": "<%= latestVersions.Angular %>",
     "@angular/common": "<%= latestVersions.Angular %>",
     "@angular/compiler": "<%= latestVersions.Angular %>",
     "@angular/core": "<%= latestVersions.Angular %>",

--- a/tests/legacy-cli/e2e/tests/build/server-rendering/server-routes-output-mode-server-platform-neutral.ts
+++ b/tests/legacy-cli/e2e/tests/build/server-rendering/server-routes-output-mode-server-platform-neutral.ts
@@ -69,10 +69,6 @@ export default async function () {
         },
       ];
     `,
-    'src/app/app.config.ts': `
-      import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
-      ${(await readFile('src/app/app.config.ts', 'utf8')).replace('provideRouter(routes),', 'provideAnimationsAsync(), provideRouter(routes),')}
-    `,
     'src/server.ts': `
       import { AngularAppEngine, createRequestHandler } from '@angular/ssr';
       import { createApp, createRouter, toWebHandler, defineEventHandler, toWebRequest } from 'h3';


### PR DESCRIPTION
Previously the animations module was added to the `ng new` app, because `platform-server` was using it. That's no longer the case as of https://github.com/angular/angular/pull/59762 so these changes remove the dependency.
