### PR TITLE
test: remove animations check from material build E2E test

### DIFF
--- a/tests/legacy-cli/e2e/tests/build/material.ts
+++ b/tests/legacy-cli/e2e/tests/build/material.ts
@@ -90,22 +90,4 @@ export default async function () {
   );
 
   await ng('e2e', '--configuration=production');
-
-  const usingApplicationBuilder = getGlobalVariable('argv')['esbuild'];
-  if (usingApplicationBuilder) {
-    // Test with chunk optimizations to reduce async animations chunk file count
-    await execWithEnv('ng', ['build'], {
-      ...process.env,
-      NG_BUILD_OPTIMIZE_CHUNKS: '1',
-    });
-    const distFiles = await readdir('dist/test-project/browser');
-    const jsCount = distFiles.filter((file) => file.endsWith('.js')).length;
-    // 3 = polyfills, main, and one lazy chunk
-    assert.equal(jsCount, 3);
-
-    await execWithEnv('ng', ['e2e', '--configuration=production'], {
-      ...process.env,
-      NG_BUILD_OPTIMIZE_CHUNKS: '1',
-    });
-  }
 }


### PR DESCRIPTION
The latest version of Angular material no longer adds `@angular/animations` to application code when using `ng add`.