### PR TITLE
fix(@angular/cli): prefer installed package as fallback when listing package groups

### DIFF
--- a/packages/angular/cli/src/commands/update/schematic/index.ts
+++ b/packages/angular/cli/src/commands/update/schematic/index.ts
@@ -471,19 +471,24 @@ function _usageMessage(
     )
     .map(({ name, info, version, tag, target }) => {
       // Look for packageGroup.
-      const packageGroup = target['ng-update']?.['packageGroup'];
+      const ngUpdate = target['ng-update'];
+      const packageGroup = ngUpdate?.['packageGroup'];
       if (packageGroup) {
         const packageGroupNames = Array.isArray(packageGroup)
           ? packageGroup
           : Object.keys(packageGroup);
+        const packageGroupName =
+          ngUpdate?.['packageGroupName'] || packageGroupNames.find((n) => infoMap.has(n));
 
-        const packageGroupName = target['ng-update']?.['packageGroupName'] || packageGroupNames[0];
         if (packageGroupName) {
           if (packageGroups.has(name)) {
             return null;
           }
 
-          packageGroupNames.forEach((x: string) => packageGroups.set(x, packageGroupName));
+          for (const groupName of packageGroupNames) {
+            packageGroups.set(groupName, packageGroupName);
+          }
+
           packageGroups.set(packageGroupName, packageGroupName);
           name = packageGroupName;
         }


### PR DESCRIPTION

Previously, the package group name defaulted to the first item in the list. This update prioritizes an installed package as the fallback instead.

Closes #29627
