### PR TITLE
ci: replace `bazel run @npm2//:sync` with `bazel sync --only=repo`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,7 @@
     "commands": [
       "git restore .yarn/releases/yarn-4.5.0.cjs pnpm-lock.yaml",
       "yarn install --immutable",
-      "yarn bazel run @npm2//:sync || true"
+      "yarn bazel sync --only=repo"
     ],
     "fileFilters": [".aspect/rules/external_repository_action_cache/**/*", "pnpm-lock.yaml"],
     "executionMode": "branch"


### PR DESCRIPTION
In certain scenarios, running `bazel run @npm2//:sync` does not reliably update the aspect lock files. For example:

```
# Update the version in package.json
$ yarn bazel run @npm2//:sync  # Lock file is updated
$ git restore .aspect
$ yarn bazel run @npm2//:sync  # Lock file is NOT updated
```

Switching to `bazel sync --only=repo` guarantees that the lock file is consistently updated.

More context: https://angular-team.slack.com/archives/C042EU9T5/p1739398554132249

