### PR TITLE
fix(@angular/build): update critical CSS inlining to support `autoCsp`

### DIFF
--- a/packages/angular/build/src/builders/application/execute-build.ts
+++ b/packages/angular/build/src/builders/application/execute-build.ts
@@ -240,11 +240,6 @@ export async function executeBuild(
     );
   }
 
-  // Override auto-CSP settings if we are serving through Vite middleware.
-  if (context.builder.builderName === 'dev-server' && options.security) {
-    options.security.autoCsp = false;
-  }
-
   // Perform i18n translation inlining if enabled
   if (i18nOptions.shouldInline) {
     const result = await inlineI18n(metafile, options, executionResult, initialFiles);

--- a/packages/angular/build/src/builders/application/options.ts
+++ b/packages/angular/build/src/builders/application/options.ts
@@ -386,6 +386,15 @@ export async function normalizeOptions(
     }
   }
 
+  const autoCsp = options.security?.autoCsp;
+  const security = {
+    autoCsp: autoCsp
+      ? {
+          unsafeEval: autoCsp === true ? false : !!autoCsp.unsafeEval,
+        }
+      : undefined,
+  };
+
   // Initial options to keep
   const {
     allowedCommonJsDependencies,
@@ -415,7 +424,6 @@ export async function normalizeOptions(
     partialSSRBuild = false,
     externalRuntimeStyles,
     instrumentForCoverage,
-    security,
   } = options;
 
   // Return all the normalized options

--- a/packages/angular/build/src/builders/dev-server/vite-server.ts
+++ b/packages/angular/build/src/builders/dev-server/vite-server.ts
@@ -112,6 +112,11 @@ export async function* serveWithVite(
     browserOptions.ssr ||= true;
   }
 
+  // Disable auto CSP.
+  browserOptions.security = {
+    autoCsp: false,
+  };
+
   // Set all packages as external to support Vite's prebundle caching
   browserOptions.externalPackages = serverOptions.prebundle;
 

--- a/packages/angular/build/src/tools/esbuild/index-html-generator.ts
+++ b/packages/angular/build/src/tools/esbuild/index-html-generator.ts
@@ -80,15 +80,6 @@ export async function generateIndexHtml(
     throw new Error(`Output file does not exist: ${relativefilePath}`);
   };
 
-  // Read the Auto CSP options.
-  const autoCsp = buildOptions.security?.autoCsp;
-  const autoCspOptions =
-    autoCsp === true
-      ? { unsafeEval: false }
-      : autoCsp
-        ? { unsafeEval: !!autoCsp.unsafeEval }
-        : undefined;
-
   // Create an index HTML generator that reads from the in-memory output files
   const indexHtmlGenerator = new IndexHtmlGenerator({
     indexPath: indexHtmlOptions.input,
@@ -103,7 +94,7 @@ export async function generateIndexHtml(
       buildOptions.prerenderOptions ||
       buildOptions.appShellOptions
     ),
-    autoCsp: autoCspOptions,
+    autoCsp: buildOptions.security.autoCsp,
   });
 
   indexHtmlGenerator.readAsset = readAsset;

--- a/packages/angular/build/src/utils/index-file/auto-csp.ts
+++ b/packages/angular/build/src/utils/index-file/auto-csp.ts
@@ -98,7 +98,7 @@ export async function autoCsp(html: string, unsafeEval = false): Promise<string>
     scriptContent = [];
   }
 
-  rewriter.on('startTag', (tag, html) => {
+  rewriter.on('startTag', (tag) => {
     if (tag.tagName === 'script') {
       openedScriptTag = tag;
       const src = getScriptAttributeValue(tag, 'src');

--- a/packages/angular/build/src/utils/index-file/index-html-generator.ts
+++ b/packages/angular/build/src/utils/index-file/index-html-generator.ts
@@ -82,7 +82,7 @@ export class IndexHtmlGenerator {
 
     // CSR plugins
     if (options?.optimization?.styles?.inlineCritical) {
-      this.csrPlugins.push(inlineCriticalCssPlugin(this));
+      this.csrPlugins.push(inlineCriticalCssPlugin(this, !!options.autoCsp));
     }
 
     this.csrPlugins.push(addNoncePlugin());
@@ -197,11 +197,15 @@ function inlineFontsPlugin({ options }: IndexHtmlGenerator): IndexHtmlGeneratorP
   return async (html) => inlineFontsProcessor.process(html);
 }
 
-function inlineCriticalCssPlugin(generator: IndexHtmlGenerator): IndexHtmlGeneratorPlugin {
+function inlineCriticalCssPlugin(
+  generator: IndexHtmlGenerator,
+  autoCsp: boolean,
+): IndexHtmlGeneratorPlugin {
   const inlineCriticalCssProcessor = new InlineCriticalCssProcessor({
     minify: generator.options.optimization?.styles.minify,
     deployUrl: generator.options.deployUrl,
     readAsset: (filePath) => generator.readAsset(filePath),
+    autoCsp,
   });
 
   return async (html, options) =>

--- a/packages/angular/build/src/utils/index-file/inline-critical-css_spec.ts
+++ b/packages/angular/build/src/utils/index-file/inline-critical-css_spec.ts
@@ -106,6 +106,26 @@ describe('InlineCriticalCssProcessor', () => {
     expect(content).toContain('<style>body{margin:0}html{color:white}</style>');
   });
 
+  it(`should process the inline 'onload' handlers if a 'autoCsp' is true`, async () => {
+    const inlineCssProcessor = new InlineCriticalCssProcessor({
+      readAsset,
+      autoCsp: true,
+    });
+
+    const { content } = await inlineCssProcessor.process(getContent(''), {
+      outputPath: '/dist/',
+    });
+
+    expect(content).toContain(
+      '<link href="styles.css" rel="stylesheet" media="print" ngCspMedia="all">',
+    );
+    expect(tags.stripIndents`${content}`).toContain(tags.stripIndents`
+    <style>
+    body { margin: 0; }
+    html { color: white; }
+    </style>`);
+  });
+
   it('should process the inline `onload` handlers if a CSP nonce is specified', async () => {
     const inlineCssProcessor = new InlineCriticalCssProcessor({
       readAsset,


### PR DESCRIPTION

This update improves the handling of inlined critical CSS to align with `autoCsp`, ensuring compliance with Content Security Policy (CSP) directives. Previously, inlined styles could trigger CSP violations in certain configurations. With this fix, critical CSS is inlined in a way that maintains security while supporting `autoCsp`.  

Closes #29603

//cc @aaronshim