### PR TITLE
fix(@angular/build): suppress asset missing warning for `/index.html` requests

### DIFF
--- a/packages/angular/build/src/tools/vite/middlewares/html-fallback-middleware.ts
+++ b/packages/angular/build/src/tools/vite/middlewares/html-fallback-middleware.ts
@@ -28,7 +28,10 @@ export function angularHtmlFallbackMiddleware(
 
   if (req.url) {
     const mimeType = lookupMimeTypeFromRequest(req.url);
-    if (mimeType === 'text/html' || mimeType === 'application/xhtml+xml') {
+    if (
+      (mimeType === 'text/html' || mimeType === 'application/xhtml+xml') &&
+      !/^\/index\.(?:csr\.)?html/.test(req.url)
+    ) {
       // eslint-disable-next-line no-console
       console.warn(
         `Request for HTML file "${req.url}" was received but no asset found. Asset may be missing from build.`,


### PR DESCRIPTION


Prevent incorrect warning display when the Service Worker requests `/index.html`.

