### PR TITLE
fix(@angular/build): provide karma stack trace sourcemap support

### DIFF
--- a/.aspect/rules/external_repository_action_cache/npm_translate_lock_MzA5NzUwNzMx
+++ b/.aspect/rules/external_repository_action_cache/npm_translate_lock_MzA5NzUwNzMx
@@ -4,7 +4,7 @@
 .npmrc=-1406867100
 modules/testing/builder/package.json=973445093
 package.json=2054604346
-packages/angular/build/package.json=-1460726595
+packages/angular/build/package.json=1250379839
 packages/angular/cli/package.json=-1917515334
 packages/angular/pwa/package.json=1108903917
 packages/angular/ssr/package.json=1856194341
@@ -17,6 +17,6 @@ packages/angular_devkit/schematics/package.json=673943597
 packages/angular_devkit/schematics_cli/package.json=-2026655035
 packages/ngtools/webpack/package.json=1021868664
 packages/schematics/angular/package.json=251715148
-pnpm-lock.yaml=-677899779
+pnpm-lock.yaml=-988408449
 pnpm-workspace.yaml=-1056556036
 yarn.lock=-535855759

--- a/packages/angular/build/BUILD.bazel
+++ b/packages/angular/build/BUILD.bazel
@@ -120,6 +120,7 @@ ts_project(
         "//:node_modules/rollup",
         "//:node_modules/sass",
         "//:node_modules/semver",
+        "//:node_modules/source-map-support",
         "//:node_modules/tslib",
         "//:node_modules/typescript",
         "//:node_modules/vite",

--- a/packages/angular/build/package.json
+++ b/packages/angular/build/package.json
@@ -41,6 +41,7 @@
     "rollup": "4.34.8",
     "sass": "1.85.0",
     "semver": "7.7.1",
+    "source-map-support": "0.5.21",
     "vite": "6.1.0",
     "watchpack": "2.4.2"
   },

--- a/packages/angular/build/src/builders/karma/application_builder.ts
+++ b/packages/angular/build/src/builders/karma/application_builder.ts
@@ -161,6 +161,13 @@ class AngularPolyfillsPlugin {
               f.type = 'module';
             }
           }
+
+          // Add browser sourcemap support as a classic script
+          files.unshift({
+            pattern: localResolve('source-map-support/browser-source-map-support.js'),
+            included: true,
+            watched: false,
+          });
         }, AngularPolyfillsPlugin),
       ],
     };
@@ -321,12 +328,13 @@ function normalizePolyfills(polyfills: string | string[] | undefined): [string[]
 
   const jasmineGlobalEntryPoint = localResolve('./polyfills/jasmine_global.js');
   const jasmineGlobalCleanupEntrypoint = localResolve('./polyfills/jasmine_global_cleanup.js');
+  const sourcemapEntrypoint = localResolve('./polyfills/init_sourcemaps.js');
 
   const zoneTestingEntryPoint = 'zone.js/testing';
   const polyfillsExludingZoneTesting = polyfills.filter((p) => p !== zoneTestingEntryPoint);
 
   return [
-    polyfillsExludingZoneTesting.concat([jasmineGlobalEntryPoint]),
+    polyfillsExludingZoneTesting.concat([jasmineGlobalEntryPoint, sourcemapEntrypoint]),
     polyfillsExludingZoneTesting.length === polyfills.length
       ? [jasmineGlobalCleanupEntrypoint]
       : [jasmineGlobalCleanupEntrypoint, zoneTestingEntryPoint],

--- a/packages/angular/build/src/builders/karma/polyfills/init_sourcemaps.js
+++ b/packages/angular/build/src/builders/karma/polyfills/init_sourcemaps.js
@@ -1,0 +1,10 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+// eslint-disable-next-line no-undef
+globalThis.sourceMapSupport?.install();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -606,6 +606,9 @@ importers:
       semver:
         specifier: 7.7.1
         version: 7.7.1
+      source-map-support:
+        specifier: 0.5.21
+        version: 0.5.21
       vite:
         specifier: 6.1.0
         version: 6.1.0(@types/node@18.19.76)(less@4.2.2)(sass@1.85.0)(terser@5.39.0)

--- a/tests/legacy-cli/e2e/tests/test/test-sourcemap.ts
+++ b/tests/legacy-cli/e2e/tests/test/test-sourcemap.ts
@@ -5,11 +5,6 @@ import { ng } from '../../utils/process';
 import { assertIsError } from '../../utils/utils';
 
 export default async function () {
-  if (getGlobalVariable('argv')['esbuild']) {
-    // TODO: enable once this is fixed when using the esbuild builder.
-    return;
-  }
-
   await writeFile(
     'src/app/app.component.spec.ts',
     `


### PR DESCRIPTION
When executing unit tests with `karma`, the stack traces within errors will now use any sourcemaps that were generated during the build process to provide source-based locations for the errors. Script sourcemaps must be enabled for this functionality.

Closes: #29129