### PR TITLE
feat(@angular-devkit/build-angular): add aot to WTR schema

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/web-test-runner/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/web-test-runner/index.ts
@@ -100,7 +100,7 @@ async function buildTests(
         entryPoints,
         tsConfig: options.tsConfig,
         outputPath,
-        aot: false,
+        aot: options.aot,
         index: false,
         outputHashing: OutputHashing.None,
         optimization: false,

--- a/packages/angular_devkit/build_angular/src/builders/web-test-runner/schema.json
+++ b/packages/angular_devkit/build_angular/src/builders/web-test-runner/schema.json
@@ -249,6 +249,11 @@
     "webWorkerTsConfig": {
       "type": "string",
       "description": "TypeScript configuration for Web Worker modules."
+    },
+    "aot": {
+      "type": "boolean",
+      "description": "Run tests using Ahead of Time compilation.",
+      "default": false
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
For consistency, adds an `aot` option to WTR as well. This should mean that all test builders have the same option now.