### PR TITLE
build: add `strict_deps` requirement for `ts_project`

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -262,3 +262,19 @@ http_archive(
 load("@aspect_rules_jasmine//jasmine:dependencies.bzl", "rules_jasmine_dependencies")
 
 rules_jasmine_dependencies()
+
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
+git_repository(
+    name = "devinfra",
+    commit = "0ad6a370f70638e785d6ef1f90dc6ede34684a47",
+    remote = "https://github.com/angular/dev-infra.git",
+)
+
+load("@devinfra//bazel:setup_dependencies_1.bzl", "setup_dependencies_1")
+
+setup_dependencies_1()
+
+load("@devinfra//bazel:setup_dependencies_2.bzl", "setup_dependencies_2")
+
+setup_dependencies_2()

--- a/packages/angular/build/BUILD.bazel
+++ b/packages/angular/build/BUILD.bazel
@@ -72,6 +72,8 @@ ts_project(
         "//packages/angular/build:src/builders/ng-packagr/schema.ts",
     ],
     data = RUNTIME_ASSETS,
+    # TODO: Fix strict_deps failure
+    ignore_strict_deps = True,
     module_name = "@angular/build",
     deps = [
         ":node_modules/@angular-devkit/architect",
@@ -135,6 +137,8 @@ ts_project(
         include = ["src/**/*_spec.ts"],
         exclude = ["src/builders/**/tests/**"],
     ),
+    # TODO: Fix strict_deps failure
+    ignore_strict_deps = True,
     deps = [
         ":build_rjs",
         "//:node_modules/@angular/compiler-cli",
@@ -155,6 +159,8 @@ ts_project(
     name = "application_integration_test_lib",
     testonly = True,
     srcs = glob(include = ["src/builders/application/tests/**/*.ts"]),
+    # TODO: Fix strict_deps failure
+    ignore_strict_deps = True,
     deps = [
         ":build_rjs",
         "//packages/angular/build/private:private_rjs",
@@ -181,6 +187,8 @@ ts_project(
     name = "dev-server_integration_test_lib",
     testonly = True,
     srcs = glob(include = ["src/builders/dev-server/tests/**/*.ts"]),
+    # TODO: Fix strict_deps failure
+    ignore_strict_deps = True,
     deps = [
         ":build_rjs",
         "//packages/angular/build/private:private_rjs",
@@ -213,6 +221,8 @@ ts_project(
     name = "karma_integration_test_lib",
     testonly = True,
     srcs = glob(include = ["src/builders/karma/tests/**/*.ts"]),
+    # TODO: Fix strict_deps failure
+    ignore_strict_deps = True,
     deps = [
         ":build_rjs",
         "//packages/angular/build/private:private_rjs",

--- a/packages/angular/cli/BUILD.bazel
+++ b/packages/angular/cli/BUILD.bazel
@@ -107,6 +107,8 @@ ts_project(
             "node_modules/**",
         ],
     ),
+    # TODO: Fix strict_deps failure
+    ignore_strict_deps = True,
     deps = [
         ":angular-cli_rjs",
         "//:node_modules/@types/semver",

--- a/packages/angular/pwa/BUILD.bazel
+++ b/packages/angular/pwa/BUILD.bazel
@@ -50,6 +50,8 @@ ts_project(
     name = "pwa_test_lib",
     testonly = True,
     srcs = glob(["pwa/**/*_spec.ts"]),
+    # TODO: Fix strict_deps failure
+    ignore_strict_deps = True,
     deps = [
         ":pwa_rjs",
         "//:node_modules/@types/jasmine",

--- a/packages/angular/ssr/node/BUILD.bazel
+++ b/packages/angular/ssr/node/BUILD.bazel
@@ -14,6 +14,8 @@ ts_project(
         "--types",
         "node",
     ],
+    # TODO: Fix strict_deps failure
+    ignore_strict_deps = True,
     module_name = "@angular/ssr/node",
     source_map = True,
     tsconfig = "//:build-tsconfig-esm",

--- a/packages/angular_devkit/architect/testing/BUILD.bazel
+++ b/packages/angular_devkit/architect/testing/BUILD.bazel
@@ -15,6 +15,8 @@ ts_project(
         include = ["**/*.ts"],
         exclude = ["**/*_spec.ts"],
     ),
+    # TODO: Fix strict_deps failure
+    ignore_strict_deps = True,
     module_name = "@angular-devkit/architect/testing",
     deps = [
         "//:node_modules/@types/node",

--- a/packages/angular_devkit/build_angular/BUILD.bazel
+++ b/packages/angular_devkit/build_angular/BUILD.bazel
@@ -127,6 +127,8 @@ ts_project(
         "//packages/angular_devkit/build_angular:src/builders/web-test-runner/schema.ts",
     ],
     data = RUNTIME_ASSETS,
+    # TODO: Fix strict_deps failure
+    ignore_strict_deps = True,
     module_name = "@angular-devkit/build-angular",
     deps = [
         ":node_modules/@angular-devkit/architect",
@@ -223,6 +225,8 @@ ts_project(
     data = [
         "//packages/angular_devkit/build_angular/test/hello-world-lib",
     ],
+    # TODO: Fix strict_deps failure
+    ignore_strict_deps = True,
     deps = [
         ":build_angular_rjs",
         ":build_angular_test_utils_rjs",
@@ -294,6 +298,8 @@ ts_project(
     data = [
         "//packages/angular_devkit/build_angular/test/hello-world-lib",
     ],
+    # TODO: Fix strict_deps failure
+    ignore_strict_deps = True,
     deps = [
         ":build_angular_rjs",
         "//:node_modules/@types/jasmine",
@@ -309,8 +315,13 @@ ts_project(
 )
 
 LARGE_SPECS = {
-    "app-shell": {},
+    "app-shell": {
+        # TODO: Fix strict_deps failure
+        "ignore_strict_deps": True,
+    },
     "dev-server": {
+        # TODO: Fix strict_deps failure
+        "ignore_strict_deps": True,
         "shards": 10,
         "size": "large",
         "flaky": True,
@@ -322,8 +333,13 @@ LARGE_SPECS = {
             "//:node_modules/undici",
         ],
     },
-    "extract-i18n": {},
+    "extract-i18n": {
+        # TODO: Fix strict_deps failure
+        "ignore_strict_deps": True,
+    },
     "karma": {
+        # TODO: Fix strict_deps failure
+        "ignore_strict_deps": True,
         "shards": 6,
         "size": "large",
         "flaky": True,
@@ -338,6 +354,8 @@ LARGE_SPECS = {
         ],
     },
     "protractor": {
+        # TODO: Fix strict_deps failure
+        "ignore_strict_deps": True,
         "extra_deps": [
             "//:node_modules/jasmine-spec-reporter",
             "//:node_modules/protractor",
@@ -350,13 +368,20 @@ LARGE_SPECS = {
         "shards": 1,
     },
     "server": {
+        # TODO: Fix strict_deps failure
+        "ignore_strict_deps": True,
         "size": "large",
         "extra_deps": [
             "//:node_modules/@angular/animations",
         ],
     },
-    "ng-packagr": {},
+    "ng-packagr": {
+        # TODO: Fix strict_deps failure
+        "ignore_strict_deps": True,
+    },
     "browser": {
+        # TODO: Fix strict_deps failure
+        "ignore_strict_deps": True,
         "shards": 10,
         "size": "large",
         "flaky": True,
@@ -365,9 +390,14 @@ LARGE_SPECS = {
             "//:node_modules/@angular/material",
         ],
     },
-    "prerender": {},
+    "prerender": {
+        # TODO: Fix strict_deps failure
+        "ignore_strict_deps": True,
+    },
     "browser-esbuild": {},
     "ssr-dev-server": {
+        # TODO: Fix strict_deps failure
+        "ignore_strict_deps": True,
         "extra_deps": [
             "//packages/angular/ssr/node:node_rjs",
             "//:node_modules/@types/browser-sync",
@@ -383,6 +413,7 @@ LARGE_SPECS = {
         name = "build_angular_" + spec + "_test_lib",
         testonly = True,
         srcs = glob(["src/builders/" + spec + "/**/*_spec.ts"]),
+        ignore_strict_deps = LARGE_SPECS[spec].get("ignore_strict_deps", False),
         deps = [
             # Dependencies needed to compile and run the specs themselves.
             ":build_angular_rjs",

--- a/packages/angular_devkit/schematics/BUILD.bazel
+++ b/packages/angular_devkit/schematics/BUILD.bazel
@@ -39,6 +39,8 @@ ts_project(
     name = "schematics_test_lib",
     testonly = True,
     srcs = glob(["src/**/*_spec.ts"]),
+    # TODO: Fix strict_deps failure
+    ignore_strict_deps = True,
     deps = [
         ":node_modules/@angular-devkit/core",
         ":schematics",

--- a/packages/angular_devkit/schematics/tasks/BUILD.bazel
+++ b/packages/angular_devkit/schematics/tasks/BUILD.bazel
@@ -18,6 +18,8 @@ ts_project(
         ],
     ),
     data = ["package.json"],
+    # TODO: Fix strict_deps failure
+    ignore_strict_deps = True,
     module_name = "@angular-devkit/schematics/tasks",
     deps = [
         "//:node_modules/@types/node",

--- a/packages/angular_devkit/schematics/testing/BUILD.bazel
+++ b/packages/angular_devkit/schematics/testing/BUILD.bazel
@@ -14,6 +14,8 @@ ts_project(
         include = ["**/*.ts"],
     ),
     data = ["package.json"],
+    # TODO: Fix strict_deps failure
+    ignore_strict_deps = True,
     module_name = "@angular-devkit/schematics/testing",
     deps = [
         "//:node_modules/rxjs",

--- a/packages/schematics/angular/BUILD.bazel
+++ b/packages/schematics/angular/BUILD.bazel
@@ -86,6 +86,8 @@ ts_project(
         for (src, _) in ALL_SCHEMA_TARGETS
     ],
     data = RUNTIME_ASSETS,
+    # TODO: Fix strict_deps failure
+    ignore_strict_deps = True,
     module_name = "@schematics/angular",
     deps = [
         ":node_modules/@angular-devkit/core",

--- a/tests/angular_devkit/schematics/tools/file-system-engine-host/BUILD.bazel
+++ b/tests/angular_devkit/schematics/tools/file-system-engine-host/BUILD.bazel
@@ -21,6 +21,8 @@ ts_project(
             "**/*.js",
         ],
     ),
+    # TODO: Fix strict_deps failure
+    ignore_strict_deps = True,
     deps = [
         "//:node_modules/@types/jasmine",
         "//:node_modules/@types/node",

--- a/tools/interop.bzl
+++ b/tools/interop.bzl
@@ -1,6 +1,7 @@
 load("@aspect_rules_js//js:providers.bzl", "JsInfo", "js_info")
 load("@aspect_rules_ts//ts:defs.bzl", _ts_project = "ts_project")
 load("@build_bazel_rules_nodejs//:providers.bzl", "DeclarationInfo", "JSEcmaScriptModuleInfo", "JSModuleInfo", "LinkablePackageInfo")
+load("@devinfra//bazel/ts_project:index.bzl", "strict_deps_test")
 
 def _ts_deps_interop_impl(ctx):
     types = []
@@ -104,6 +105,7 @@ def ts_project(
         tsconfig = None,
         testonly = False,
         visibility = None,
+        ignore_strict_deps = False,
         **kwargs):
     interop_deps = []
 
@@ -143,6 +145,13 @@ def ts_project(
         deps = [":%s_interop_deps" % name] + deps,
         **kwargs
     )
+
+    if not ignore_strict_deps:
+        strict_deps_test(
+            name = "%s_strict_deps_test" % name,
+            srcs = kwargs.get("srcs", []),
+            deps = deps,
+        )
 
     ts_project_module(
         name = name,


### PR DESCRIPTION
Setup requirement for `strict_deps` throughout repository to ensure that the only dependencies which are imported
are directly provided as dependencies within bazel.