### PR TITLE
build: temporarily ignore renovate updates for @angular/build-tooling

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,7 +23,14 @@
   "dependencyDashboard": true,
   "schedule": ["after 10:00pm every weekday", "before 4:00am every weekday", "every weekend"],
   "baseBranches": ["main"],
-  "ignoreDeps": ["@types/node", "@types/express", "build_bazel_rules_nodejs", "rules_pkg", "yarn"],
+  "ignoreDeps": [
+    "@angular/build-tooling",
+    "@types/node",
+    "@types/express",
+    "build_bazel_rules_nodejs",
+    "rules_pkg",
+    "yarn"
+  ],
   "includePaths": [
     "WORKSPACE",
     "package.json",


### PR DESCRIPTION
The latest version of the DevInfra internal `@angular/build-tooling` package contains breaking changes that need to be addressed separately before the version can be updated.