### PR TITLE
Update next branch to reflect new release-train "v19.3.0-next.0".

### DIFF
--- a/.aspect/rules/external_repository_action_cache/npm_translate_lock_MzA5NzUwNzMx
+++ b/.aspect/rules/external_repository_action_cache/npm_translate_lock_MzA5NzUwNzMx
@@ -3,7 +3,7 @@
 # This file should be checked into version control along with the pnpm-lock.yaml file.
 .npmrc=-1406867100
 modules/testing/builder/package.json=973445093
-package.json=-1311828140
+package.json=943428567
 packages/angular/build/package.json=1250379839
 packages/angular/cli/package.json=-1917515334
 packages/angular/pwa/package.json=1108903917

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,39 @@
+<a name="19.2.0-rc.0"></a>
+
+# 19.2.0-rc.0 (2025-02-19)
+
+### @angular/cli
+
+| Commit                                                                                              | Type | Description                                                                |
+| --------------------------------------------------------------------------------------------------- | ---- | -------------------------------------------------------------------------- |
+| [8c7c7ac69](https://github.com/angular/angular-cli/commit/8c7c7ac691e7f8b3e1585f863a6edbb46c4c31ad) | fix  | correctly parse and resolve relative schematic collection names on Windows |
+| [09f5006b5](https://github.com/angular/angular-cli/commit/09f5006b5ca208a4a9d3692223ca78f8c0226bc8) | fix  | prefer installed package as fallback when listing package groups           |
+
+### @schematics/angular
+
+| Commit                                                                                              | Type | Description                              |
+| --------------------------------------------------------------------------------------------------- | ---- | ---------------------------------------- |
+| [adf4ea5d4](https://github.com/angular/angular-cli/commit/adf4ea5d4ccb252132301111153619178c5bdabe) | fix  | remove animations module from ng new app |
+
+### @angular-devkit/build-angular
+
+| Commit                                                                                              | Type | Description                                   |
+| --------------------------------------------------------------------------------------------------- | ---- | --------------------------------------------- |
+| [a00a49a65](https://github.com/angular/angular-cli/commit/a00a49a65ae68e6e0f9856d8d0f4d9914031cd05) | feat | add aot to WTR schema                         |
+| [c0c1670a6](https://github.com/angular/angular-cli/commit/c0c1670a647638124f8d24363576a058ea45c1e4) | fix  | pass missing options to Karma esbuild builder |
+| [2bae1a9c0](https://github.com/angular/angular-cli/commit/2bae1a9c0c9eff8087b67c7890b87dc1c279c809) | fix  | support aot option for karma browser builder  |
+
+### @angular/build
+
+| Commit                                                                                              | Type | Description                                               |
+| --------------------------------------------------------------------------------------------------- | ---- | --------------------------------------------------------- |
+| [11fab9c7d](https://github.com/angular/angular-cli/commit/11fab9c7dde950e46b2a23d239bb9e29b20f5eff) | feat | add application builder karma testing to package          |
+| [a5fcf8044](https://github.com/angular/angular-cli/commit/a5fcf804428b835cd79bd8fad55c16e614c2be3a) | fix  | provide karma stack trace sourcemap support               |
+| [f92787947](https://github.com/angular/angular-cli/commit/f92787947f3c74900dbd1022bc91aa6ec1907358) | fix  | suppress asset missing warning for `/index.html` requests |
+| [e6deb82c6](https://github.com/angular/angular-cli/commit/e6deb82c6c46b48732c9f7c74eec3f1c8798b355) | fix  | update critical CSS inlining to support `autoCsp`         |
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="19.1.8"></a>
 
 # 19.1.8 (2025-02-19)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@angular/devkit-repo",
-  "version": "19.2.0-next.2",
+  "version": "19.3.0-next.0",
   "private": true,
   "description": "Software Development Kit for Angular",
   "keywords": [


### PR DESCRIPTION
The previous "next" release-train has moved into the release-candidate phase. This PR updates the next branch to the subsequent release-train.

Also this PR cherry-picks the changelog for v19.2.0-rc.0 into the main branch so that the changelog is up to date.