### PR TITLE
test: prepare E2E tests for `@angular/build` project default

### DIFF
--- a/tests/legacy-cli/e2e/initialize/500-create-project.ts
+++ b/tests/legacy-cli/e2e/initialize/500-create-project.ts
@@ -43,6 +43,17 @@ export default async function () {
           namedChunks: true,
           buildOptimizer: false,
         };
+
+        const serve = json['projects']['test-project']['architect']['serve'];
+        serve.builder = '@angular-devkit/build-angular:dev-server';
+
+        const extract = json['projects']['test-project']['architect']['extract-i18n'];
+        if (extract) {
+          extract.builder = '@angular-devkit/build-angular:extract-i18n';
+        }
+
+        const test = json['projects']['test-project']['architect']['test'];
+        test.builder = '@angular-devkit/build-angular:karma';
       });
       await updateJsonFile('tsconfig.json', (tsconfig) => {
         delete tsconfig.compilerOptions.esModuleInterop;

--- a/tests/legacy-cli/e2e/tests/build/jit-ngmodule.ts
+++ b/tests/legacy-cli/e2e/tests/build/jit-ngmodule.ts
@@ -39,6 +39,9 @@ export default async function () {
     };
 
     build.options.aot = false;
+
+    const serve = json['projects']['test-project-two']['architect']['serve'];
+    serve.builder = '@angular-devkit/build-angular:dev-server';
   });
   // Test it works
   await ng('e2e', 'test-project-two', '--configuration=production');

--- a/tests/legacy-cli/e2e/tests/build/rebuild-dot-dirname.ts
+++ b/tests/legacy-cli/e2e/tests/build/rebuild-dot-dirname.ts
@@ -41,6 +41,9 @@ export default async function () {
           namedChunks: true,
           buildOptimizer: false,
         };
+
+        const serve = json['projects']['subdirectory-test-project']['architect']['serve'];
+        serve.builder = '@angular-devkit/build-angular:dev-server';
       });
     }
 

--- a/tests/legacy-cli/e2e/tests/commands/add/version-specifier.ts
+++ b/tests/legacy-cli/e2e/tests/commands/add/version-specifier.ts
@@ -15,7 +15,7 @@ export default async function () {
     await appendFile('.npmrc', '\nforce=true\n');
   }
 
-  const tag = (await isPrereleaseCli()) ? '@next' : '';
+  const tag = isPrereleaseCli() ? '@next' : '';
 
   await ng('add', `@angular/localize${tag}`, '--skip-confirmation');
   await expectFileToMatch('package.json', /@angular\/localize/);
@@ -30,13 +30,12 @@ export default async function () {
     throw new Error('Installation should not have been skipped');
   }
 
-  // v12.2.0 has a package.json engine field that supports Node.js v16+
-  const output3 = await ng('add', '@angular/localize@12.2.0', '--skip-confirmation');
+  const output3 = await ng('add', '@angular/localize@19.1.0', '--skip-confirmation');
   if (output3.stdout.includes('Skipping installation: Package already installed')) {
     throw new Error('Installation should not have been skipped');
   }
 
-  const output4 = await ng('add', '@angular/localize@12', '--skip-confirmation');
+  const output4 = await ng('add', '@angular/localize@19', '--skip-confirmation');
   if (!output4.stdout.includes('Skipping installation: Package already installed')) {
     throw new Error('Installation was not skipped');
   }

--- a/tests/legacy-cli/e2e/tests/test/test-environment.ts
+++ b/tests/legacy-cli/e2e/tests/test/test-environment.ts
@@ -33,8 +33,8 @@ export default function () {
             production: {
               fileReplacements: [
                 {
-                  src: 'src/environment.ts',
-                  replaceWith: 'src/environment.prod.ts',
+                  replace: 'src/environment.ts',
+                  with: 'src/environment.prod.ts',
                 },
               ],
             },


### PR DESCRIPTION
The E2E test setup and several of the individual E2E tests have been updated to be more robust for when the `@angular/build` package is used as the new default. The main changes involve ensuring that the Webpack- based `browser` builder testing uses the correct builders instead of the new `@angular/build` variants. This change also improves the reliability of some tests (e.g., `commands/add/version-specifier`) by not relying on outdated versions of Angular packages.