### PR TITLE
fix(@angular/build): always disable JSON stats with dev-server

### DIFF
--- a/packages/angular/build/src/builders/dev-server/vite-server.ts
+++ b/packages/angular/build/src/builders/dev-server/vite-server.ts
@@ -117,6 +117,16 @@ export async function* serveWithVite(
     autoCsp: false,
   };
 
+  // Disable JSON build stats.
+  // These are not accessible with the dev server and can cause HMR fallbacks.
+  if (browserOptions.statsJson === true) {
+    context.logger.warn(
+      'Build JSON statistics output (`statsJson` option) has been disabled.' +
+        ' The development server does not support this option.',
+    );
+  }
+  browserOptions.statsJson = false;
+
   // Set all packages as external to support Vite's prebundle caching
   browserOptions.externalPackages = serverOptions.prebundle;
 


### PR DESCRIPTION
When using the development server, the `statsJson` option will now unconditionally be disabled. The output JSON file is not accessible with the server and the analysis/generation of the JSON file may increase the rebuild time. Additionally, the JSON file changes during a rebuild may unexpectedly cause component HMR fallback to a full reload due to non-component file changes in the build output.