### PR TITLE
docs: release notes for the v19.1.9 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+<a name="19.1.9"></a>
+
+# 19.1.9 (2025-02-26)
+
+### @angular/build
+
+| Commit                                                                                              | Type | Description                               |
+| --------------------------------------------------------------------------------------------------- | ---- | ----------------------------------------- |
+| [2d361e9b0](https://github.com/angular/angular-cli/commit/2d361e9b0ae5409d7ab23f50b089da16497623c1) | fix  | always disable JSON stats with dev-server |
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="19.2.0-rc.0"></a>
 
 # 19.2.0-rc.0 (2025-02-19)


### PR DESCRIPTION
Cherry-picks the changelog from the "19.1.x" branch to the next branch (main).