### PR TITLE
fix(@angular/build): handle undefined `less` stylesheet sourcemap values

### DIFF
--- a/packages/angular/build/src/tools/esbuild/stylesheets/less-language.ts
+++ b/packages/angular/build/src/tools/esbuild/stylesheets/less-language.ts
@@ -130,7 +130,9 @@ async function compileString(
     } as Less.Options);
 
     return {
-      contents: options.sourcemap ? `${css}\n${sourceMapToUrlComment(map)}` : css,
+      // There can be cases where `less` will return an undefined `map` even
+      // though the types do not specify this as a possibility.
+      contents: map ? `${css}\n${sourceMapToUrlComment(map)}` : css,
       loader: 'css',
       watchFiles: [filename, ...imports],
     };


### PR DESCRIPTION
There can be cases where the `less` stylesheet preprocessor will return an undefined value for a sourcemap even though sourcemaps have been enabled. A check is now performed to handle these cases to prevent potential crashes when processing `less` styles.