### PR TITLE
fix(@schematics/angular): prevent accidental deletion of `main.ts` during application builder migration

### DIFF
--- a/packages/schematics/angular/migrations/use-application-builder/migration.ts
+++ b/packages/schematics/angular/migrations/use-application-builder/migration.ts
@@ -151,7 +151,10 @@ function* updateBuildTarget(
   // Update server file
   const ssrMainFile = serverTarget?.options?.['main'];
   if (typeof ssrMainFile === 'string') {
-    yield deleteFile(ssrMainFile);
+    // Do not delete the server main file if it's the same as the browser file.
+    if (buildTarget.options?.browser !== ssrMainFile) {
+      yield deleteFile(ssrMainFile);
+    }
 
     yield externalSchematic('@schematics/angular', 'ssr', {
       project: projectName,


### PR DESCRIPTION
In certain cases, misconfiguration of the server builder could cause the migration process to incorrectly delete `main.ts`. 

Closes: #29661
