### PR TITLE
fix(@angular/build): exclude component styles from 'any' and 'all' budget calculations

### DIFF
--- a/packages/angular/build/src/utils/bundle-calculator.ts
+++ b/packages/angular/build/src/utils/bundle-calculator.ts
@@ -241,7 +241,7 @@ class AllScriptCalculator extends Calculator {
 class AllCalculator extends Calculator {
   calculate() {
     const size = this.assets
-      .filter((asset) => !asset.name.endsWith('.map'))
+      .filter((asset) => !asset.name.endsWith('.map') && !asset.componentStyle)
       .map((asset) => this.getAssetSize(asset))
       .reduce((total: number, size: number) => total + size, 0);
 
@@ -269,7 +269,7 @@ class AnyScriptCalculator extends Calculator {
 class AnyCalculator extends Calculator {
   calculate() {
     return this.assets
-      .filter((asset) => !asset.name.endsWith('.map'))
+      .filter((asset) => !asset.name.endsWith('.map') && !asset.componentStyle)
       .map((asset) => ({
         size: this.getAssetSize(asset),
         label: asset.name,


### PR DESCRIPTION

Previously, component styles were included in the 'any' and 'all' budgets, which could lead to incorrect budget violations. This update ensures that component styles are excluded from these budget calculations.

Closes #29609
