### PR TITLE
fix(@angular/build): exclude all entrypoints of a library from prebundling

### DIFF
--- a/packages/angular/build/src/builders/application/schema.json
+++ b/packages/angular/build/src/builders/application/schema.json
@@ -196,7 +196,7 @@
       "additionalProperties": false
     },
     "externalDependencies": {
-      "description": "Exclude the listed external dependencies from being bundled into the bundle. Instead, the created bundle relies on these dependencies to be available during runtime.",
+      "description": "Exclude the listed external dependencies from being bundled into the bundle. Instead, the created bundle relies on these dependencies to be available during runtime. Note: `@foo/bar` marks all paths within the `@foo/bar` package as external, including sub-paths like `@foo/bar/baz`.",
       "type": "array",
       "items": {
         "type": "string"

--- a/packages/angular/build/src/builders/dev-server/schema.json
+++ b/packages/angular/build/src/builders/dev-server/schema.json
@@ -115,7 +115,7 @@
           "type": "object",
           "properties": {
             "exclude": {
-              "description": "List of package imports that should not be prebundled by the development server. The packages will be bundled into the application code itself.",
+              "description": "List of package imports that should not be prebundled by the development server. The packages will be bundled into the application code itself. Note: specifying `@foo/bar` marks all paths within the `@foo/bar` package as excluded, including sub-paths like `@foo/bar/baz`.",
               "type": "array",
               "items": { "type": "string" }
             }

--- a/packages/angular/build/src/builders/dev-server/tests/behavior/build-external-dependencies_spec.ts
+++ b/packages/angular/build/src/builders/dev-server/tests/behavior/build-external-dependencies_spec.ts
@@ -48,7 +48,7 @@ describeServeBuilder(executeDevServer, DEV_SERVER_BUILDER_INFO, (harness, setupT
 
     it('respects import specifiers when using baseHref with trailing slash', async () => {
       setupTarget(harness, {
-        externalDependencies: ['rxjs', 'rxjs/operators'],
+        externalDependencies: ['rxjs'],
         baseHref: '/test/',
       });
 
@@ -67,7 +67,7 @@ describeServeBuilder(executeDevServer, DEV_SERVER_BUILDER_INFO, (harness, setupT
 
     it('respects import specifiers when using baseHref without trailing slash', async () => {
       setupTarget(harness, {
-        externalDependencies: ['rxjs', 'rxjs/operators'],
+        externalDependencies: ['rxjs/*'],
         baseHref: '/test',
       });
 

--- a/packages/angular/build/src/tools/esbuild/bundler-context.ts
+++ b/packages/angular/build/src/tools/esbuild/bundler-context.ts
@@ -359,17 +359,16 @@ export class BundlerContext {
     // Collect all external package names
     const externalImports = new Set<string>();
     for (const { imports } of Object.values(result.metafile.outputs)) {
-      for (const importData of imports) {
+      for (const { external, kind, path } of imports) {
         if (
-          !importData.external ||
-          SERVER_GENERATED_EXTERNALS.has(importData.path) ||
-          (importData.kind !== 'import-statement' &&
-            importData.kind !== 'dynamic-import' &&
-            importData.kind !== 'require-call')
+          !external ||
+          SERVER_GENERATED_EXTERNALS.has(path) ||
+          (kind !== 'import-statement' && kind !== 'dynamic-import' && kind !== 'require-call')
         ) {
           continue;
         }
-        externalImports.add(importData.path);
+
+        externalImports.add(path);
       }
     }
 

--- a/packages/angular/build/src/tools/esbuild/bundler-execution-result.ts
+++ b/packages/angular/build/src/tools/esbuild/bundler-execution-result.ts
@@ -127,9 +127,9 @@ export class ExecutionResult {
   setExternalMetadata(
     implicitBrowser: string[],
     implicitServer: string[],
-    explicit: string[] | undefined,
+    explicit: string[],
   ): void {
-    this.externalMetadata = { implicitBrowser, implicitServer, explicit: explicit ?? [] };
+    this.externalMetadata = { implicitBrowser, implicitServer, explicit };
   }
 
   get output() {

--- a/packages/angular/build/src/tools/vite/plugins/id-prefix-plugin.ts
+++ b/packages/angular/build/src/tools/vite/plugins/id-prefix-plugin.ts
@@ -27,7 +27,7 @@ export function createRemoveIdPrefixPlugin(externals: string[]): Plugin {
         return;
       }
 
-      const escapedExternals = externals.map(escapeRegexSpecialChars);
+      const escapedExternals = externals.map((e) => escapeRegexSpecialChars(e) + '(?:/.+)?');
       const prefixedExternalRegex = new RegExp(
         `${resolvedConfig.base}${VITE_ID_PREFIX}(${escapedExternals.join('|')})`,
         'g',


### PR DESCRIPTION

The configuration now ensures that when a package is listed for exclusion, all paths within that package including sub-paths like `@foo/bar/baz`  are marked as external and not prebundled by the development server.

For example, specifying `@foo/bar` in the exclude list will prevent the development server from bundling any files from the `@foo/bar` package, including its sub-paths such as `@foo/bar/baz`.

This aligns with esbuild external option behaviour https://esbuild.github.io/api/#external

Closes #29170

