### PR TITLE
fix(@schematics/angular): prevent error when tsconfig file is missing in application builder migration

### DIFF
--- a/packages/schematics/angular/migrations/use-application-builder/migration.ts
+++ b/packages/schematics/angular/migrations/use-application-builder/migration.ts
@@ -460,8 +460,12 @@ function deleteFile(path: string): Rule {
 }
 
 function updateJsonFile(path: string, updater: (json: JSONFile) => void): Rule {
-  return (tree) => {
-    updater(new JSONFile(tree, path));
+  return (tree, ctx) => {
+    if (tree.exists(path)) {
+      updater(new JSONFile(tree, path));
+    } else {
+      ctx.logger.info(`Skipping updating '${path}' as it does not exist.`);
+    }
   };
 }
 


### PR DESCRIPTION

If the root tsconfig.json is missing we should not error.

Closes #29754
