### PR TITLE
fix(@angular/build): remove duplicate prebundling warning

### DIFF
--- a/packages/angular/build/src/builders/dev-server/builder.ts
+++ b/packages/angular/build/src/builders/dev-server/builder.ts
@@ -56,13 +56,6 @@ export async function* execute(
 
   const { builderName, normalizedOptions } = await initialize(options, projectName, context);
 
-  // Warn if the initial options provided by the user enable prebundling but caching is disabled
-  if (options.prebundle && !normalizedOptions.cacheOptions.enabled) {
-    context.logger.warn(
-      `Prebundling has been configured but will not be used because caching has been disabled.`,
-    );
-  }
-
   yield* serveWithVite(
     normalizedOptions,
     builderName,


### PR DESCRIPTION
This warning is already displayed during the normalization of options. See: https://github.com/angular/angular-cli/blob/b5a86709b7c035c129f5a9d8f1f684169432195e/packages/angular/build/src/builders/dev-server/options.ts#L56
