### PR TITLE
fix(@angular/build): handle postcss compilation errors gracefully

### DIFF
--- a/packages/angular/build/src/tools/esbuild/stylesheets/stylesheet-plugin-factory.ts
+++ b/packages/angular/build/src/tools/esbuild/stylesheets/stylesheet-plugin-factory.ts
@@ -12,6 +12,7 @@ import { readFile } from 'node:fs/promises';
 import { extname } from 'node:path';
 import type { Options } from 'sass';
 import { glob } from 'tinyglobby';
+import { assertIsError } from '../../../utils/error';
 import type { PostcssConfiguration } from '../../../utils/postcss-configuration';
 import { LoadResultCache, createCachedLoad } from '../load-result-cache';
 
@@ -422,8 +423,16 @@ async function compileString(
           },
         ],
       };
-    }
+    } else {
+      assertIsError(error);
 
-    throw error;
+      return {
+        errors: [
+          {
+            text: error.message,
+          },
+        ],
+      };
+    }
   }
 }


### PR DESCRIPTION
Improves error handling in the PostCSS compilation process to prevent crashes and allow recovery.

Closes #29789