### PR TITLE
fix(@angular/cli): record analytics for nested schematics

### DIFF
--- a/packages/angular/cli/src/command-builder/schematics-command-module.ts
+++ b/packages/angular/cli/src/command-builder/schematics-command-module.ts
@@ -143,27 +143,21 @@ export abstract class SchematicsCommandModule
       workingDir === '' ? undefined : workingDir,
     );
 
-    let shouldReportAnalytics = true;
     workflow.engineHost.registerOptionsTransform(async (schematic, options) => {
-      // Report analytics
-      if (shouldReportAnalytics) {
-        shouldReportAnalytics = false;
+      const {
+        collection: { name: collectionName },
+        name: schematicName,
+      } = schematic;
 
-        const {
-          collection: { name: collectionName },
-          name: schematicName,
-        } = schematic;
+      const analytics = isPackageNameSafeForAnalytics(collectionName)
+        ? await this.getAnalytics()
+        : undefined;
 
-        const analytics = isPackageNameSafeForAnalytics(collectionName)
-          ? await this.getAnalytics()
-          : undefined;
-
-        analytics?.reportSchematicRunEvent({
-          [EventCustomDimension.SchematicCollectionName]: collectionName,
-          [EventCustomDimension.SchematicName]: schematicName,
-          ...this.getAnalyticsParameters(options as unknown as {}),
-        });
-      }
+      analytics?.reportSchematicRunEvent({
+        [EventCustomDimension.SchematicCollectionName]: collectionName,
+        [EventCustomDimension.SchematicName]: schematicName,
+        ...this.getAnalyticsParameters(options as unknown as {}),
+      });
 
       return options;
     });


### PR DESCRIPTION
Prior to this commit, analytics were not recorded for nested schematics. This caused certain data to be incomplete. For example, when running `ng new` and selecting "yes" for SSR in the prompt, this choice was not recorded because the prompt exists within the `application` schematic.
