### PR TITLE
fix(@angular/ssr): prevent stream draining if `write` does not return a boolean

### DIFF
--- a/packages/angular/ssr/node/src/response.ts
+++ b/packages/angular/ssr/node/src/response.ts
@@ -76,7 +76,9 @@ export async function writeResponseToNodeResponse(
       }
 
       const canContinue = (destination as ServerResponse).write(value);
-      if (!canContinue) {
+      if (canContinue === false) {
+        // Explicitly check for `false`, as AWS may return `undefined` even though this is not valid.
+        // See: https://github.com/CodeGenieApp/serverless-express/issues/683
         await new Promise<void>((resolve) => destination.once('drain', resolve));
       }
     }


### PR DESCRIPTION


Implements a workaround for https://github.com/CodeGenieApp/serverless-express/issues/683

Closes #29801
