### PR TITLE
build: update `ng-dev` to include latest pnpm release tool fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@angular/forms": "20.0.0-next.1",
     "@angular/localize": "20.0.0-next.1",
     "@angular/material": "20.0.0-next.0",
-    "@angular/ng-dev": "https://github.com/angular/dev-infra-private-ng-dev-builds.git#cab2b0de372f97ebb025e6aff24b9ef72f586666",
+    "@angular/ng-dev": "https://github.com/angular/dev-infra-private-ng-dev-builds.git#7d5826de6532be59189873725d3a6d61d4fdd941",
     "@angular/platform-browser": "20.0.0-next.1",
     "@angular/platform-browser-dynamic": "20.0.0-next.1",
     "@angular/platform-server": "20.0.0-next.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: 20.0.0-next.0
         version: 20.0.0-next.0(@angular/cdk@20.0.0-next.0(@angular/common@20.0.0-next.1(@angular/core@20.0.0-next.1)(rxjs@7.8.2))(@angular/core@20.0.0-next.1)(rxjs@7.8.2))(@angular/common@20.0.0-next.1(@angular/core@20.0.0-next.1)(rxjs@7.8.2))(@angular/core@20.0.0-next.1)(@angular/forms@20.0.0-next.1(@angular/common@20.0.0-next.1(@angular/core@20.0.0-next.1)(rxjs@7.8.2))(@angular/core@20.0.0-next.1)(@angular/platform-browser@20.0.0-next.1(@angular/animations@20.0.0-next.1(@angular/core@20.0.0-next.1))(@angular/common@20.0.0-next.1(@angular/core@20.0.0-next.1)(rxjs@7.8.2))(@angular/core@20.0.0-next.1))(rxjs@7.8.2))(@angular/platform-browser@20.0.0-next.1(@angular/animations@20.0.0-next.1(@angular/core@20.0.0-next.1))(@angular/common@20.0.0-next.1(@angular/core@20.0.0-next.1)(rxjs@7.8.2))(@angular/core@20.0.0-next.1))(rxjs@7.8.2)
       '@angular/ng-dev':
-        specifier: https://github.com/angular/dev-infra-private-ng-dev-builds.git#cab2b0de372f97ebb025e6aff24b9ef72f586666
-        version: https://codeload.github.com/angular/dev-infra-private-ng-dev-builds/tar.gz/cab2b0de372f97ebb025e6aff24b9ef72f586666(encoding@0.1.13)
+        specifier: https://github.com/angular/dev-infra-private-ng-dev-builds.git#7d5826de6532be59189873725d3a6d61d4fdd941
+        version: https://codeload.github.com/angular/dev-infra-private-ng-dev-builds/tar.gz/7d5826de6532be59189873725d3a6d61d4fdd941(encoding@0.1.13)
       '@angular/platform-browser':
         specifier: 20.0.0-next.1
         version: 20.0.0-next.1(@angular/animations@20.0.0-next.1(@angular/core@20.0.0-next.1))(@angular/common@20.0.0-next.1(@angular/core@20.0.0-next.1)(rxjs@7.8.2))(@angular/core@20.0.0-next.1)
@@ -1159,9 +1159,9 @@ packages:
       '@angular/platform-browser': ^20.0.0-0 || ^20.1.0-0 || ^20.2.0-0 || ^20.3.0-0 || ^21.0.0-0
       rxjs: ^6.5.3 || ^7.4.0
 
-  '@angular/ng-dev@https://codeload.github.com/angular/dev-infra-private-ng-dev-builds/tar.gz/cab2b0de372f97ebb025e6aff24b9ef72f586666':
-    resolution: {tarball: https://codeload.github.com/angular/dev-infra-private-ng-dev-builds/tar.gz/cab2b0de372f97ebb025e6aff24b9ef72f586666}
-    version: 0.0.0-f2a610b26cd7a451eddd50eb071dc495e3346a80
+  '@angular/ng-dev@https://codeload.github.com/angular/dev-infra-private-ng-dev-builds/tar.gz/7d5826de6532be59189873725d3a6d61d4fdd941':
+    resolution: {tarball: https://codeload.github.com/angular/dev-infra-private-ng-dev-builds/tar.gz/7d5826de6532be59189873725d3a6d61d4fdd941}
+    version: 0.0.0-471dc9772b769125f2d2bc81c6da025733dfbcae
     hasBin: true
 
   '@angular/platform-browser-dynamic@20.0.0-next.1':
@@ -8290,7 +8290,7 @@ snapshots:
       rxjs: 7.8.2
       tslib: 2.8.1
 
-  '@angular/ng-dev@https://codeload.github.com/angular/dev-infra-private-ng-dev-builds/tar.gz/cab2b0de372f97ebb025e6aff24b9ef72f586666(encoding@0.1.13)':
+  '@angular/ng-dev@https://codeload.github.com/angular/dev-infra-private-ng-dev-builds/tar.gz/7d5826de6532be59189873725d3a6d61d4fdd941(encoding@0.1.13)':
     dependencies:
       '@google-cloud/spanner': 7.19.0(encoding@0.1.13)(supports-color@10.0.0)
       '@octokit/rest': 21.1.1


### PR DESCRIPTION
The release tool did check for a `yarn.lock` file. This check was updated to also work with pnpm.