### PR TITLE
ci: update `matchCurrentVersion` RegExp

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -35,7 +35,7 @@
       "schedule": ["before 4:00am on the first day of the month"]
     },
     {
-      "matchCurrentVersion": "/0\\.0\\.0-/",
+      "matchCurrentVersion": "/^[~^]?0\\.0\\.0-/",
       "enabled": false
     },
     {


### PR DESCRIPTION
The previous regexp also matches `20.0.0-next` which causes Angular FW packages not to be updated.

