### PR TITLE
refactor(@angular/build): define an internal ngHmrMode value

### DIFF
--- a/packages/angular/build/src/builders/dev-server/tests/behavior/component-updates_spec.ts
+++ b/packages/angular/build/src/builders/dev-server/tests/behavior/component-updates_spec.ts
@@ -47,5 +47,39 @@ describeServeBuilder(executeDevServer, DEV_SERVER_BUILDER_INFO, (harness, setupT
       expect(response?.headers.get('Cache-Control')).toEqual('no-cache');
       expect(output).toBe('');
     });
+
+    it('sets ngHmrMode define to true when HMR is enabled', async () => {
+      harness.useTarget('serve', {
+        ...BASE_OPTIONS,
+        hmr: true,
+      });
+
+      await harness.writeFile(
+        'src/main.ts',
+        'declare const ngHmrMode: boolean; console.log(`HMR=${ngHmrMode}`);',
+      );
+
+      const { result, content } = await executeOnceAndFetch(harness, 'main.js');
+
+      expect(result?.success).toBeTrue();
+      expect(content).toContain('HMR=${true}');
+    });
+
+    it('sets ngHmrMode define to false when HMR is disabled', async () => {
+      harness.useTarget('serve', {
+        ...BASE_OPTIONS,
+        hmr: false,
+      });
+
+      await harness.writeFile(
+        'src/main.ts',
+        'declare const ngHmrMode: boolean; console.log(`HMR=${ngHmrMode}`);',
+      );
+
+      const { result, content } = await executeOnceAndFetch(harness, 'main.js');
+
+      expect(result?.success).toBeTrue();
+      expect(content).toContain('HMR=${false}');
+    });
   });
 });

--- a/packages/angular/build/src/tools/esbuild/application-code-bundle.ts
+++ b/packages/angular/build/src/tools/esbuild/application-code-bundle.ts
@@ -600,6 +600,7 @@ function getEsBuildCommonOptions(options: NormalizedApplicationBuildOptions): Bu
       ...(optimizationOptions.scripts ? { 'ngDevMode': 'false' } : undefined),
       'ngJitMode': jit ? 'true' : 'false',
       'ngServerMode': 'false',
+      'ngHmrMode': options.templateUpdates ? 'true' : 'false',
     },
     loader: loaderExtensions,
     footer,


### PR DESCRIPTION
An `ngHmrMode` boolean value will now be defined within application bundles. The value is based on the development server's `hmr` option with `true` when HMR is enabled and `false` when disabled. For all application builds, the value will be `false`. `ngHmrMode` is similar in behavior to `ngServeMode` or `ngDevMode`. It will not be present in the output code unless referenced and in those cases only the final boolean value will be present if not optimized out of the final code.
The value is not considered part of the public API and may change in the future.