### PR TITLE
docs: release notes for the v18.2.15 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+<a name="18.2.15"></a>
+
+# 18.2.15 (2025-03-13)
+
+### @angular-devkit/build-angular
+
+| Commit                                                                                              | Type | Description           |
+| --------------------------------------------------------------------------------------------------- | ---- | --------------------- |
+| [255c8a50d](https://github.com/angular/angular-cli/commit/255c8a50d2214747c8121e963afcd96cbff39293) | fix  | update babel packages |
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="20.0.0-next.1"></a>
 
 # 20.0.0-next.1 (2025-03-13)


### PR DESCRIPTION
Cherry-picks the changelog from the "18.2.x" branch to the next branch (main).