### PR TITLE
docs: release notes for the v19.2.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+<a name="19.2.3"></a>
+
+# 19.2.3 (2025-03-13)
+
+### @angular/build
+
+| Commit                                                                                              | Type | Description           |
+| --------------------------------------------------------------------------------------------------- | ---- | --------------------- |
+| [5a739820b](https://github.com/angular/angular-cli/commit/5a739820be5cc7cb25e159a1f2283db92e741f78) | fix  | update babel packages |
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="18.2.15"></a>
 
 # 18.2.15 (2025-03-13)


### PR DESCRIPTION
Cherry-picks the changelog from the "19.2.x" branch to the next branch (main).