### PR TITLE
build: configure Bazel to ignore `packages/angular/build/node_modules`

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,6 +1,7 @@
 .git
 dist
 node_modules
+packages/angular/build/node_modules
 packages/angular/cli/node_modules
 packages/angular/create/node_modules
 packages/angular/pwa/node_modules


### PR DESCRIPTION
Although the `build` package is not present in this branch, the `node_modules` directory may persist when switching branches during a release, potentially causing the build to fail.
