### PR TITLE
docs(@angular-devkit/build-angular): update `forceEsbuild` option description

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/dev-server/schema.json
+++ b/packages/angular_devkit/build_angular/src/builders/dev-server/schema.json
@@ -108,7 +108,7 @@
     },
     "forceEsbuild": {
       "type": "boolean",
-      "description": "Force the development server to use the 'browser-esbuild' builder when building. This is a developer preview option for the esbuild-based build system.",
+      "description": "Force the development server to use the 'browser-esbuild' builder when building.",
       "default": false
     },
     "prebundle": {


### PR DESCRIPTION


Esbuild builder is stable and is no longer in developer preview.

