### PR TITLE
refactor(@angular/cli): import from `node:fs/promises` where appropriate

### DIFF
--- a/packages/angular/cli/lib/init.ts
+++ b/packages/angular/cli/lib/init.ts
@@ -8,7 +8,7 @@
 
 import 'symbol-observable';
 // symbol polyfill must go first
-import { promises as fs } from 'node:fs';
+import { readFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import * as path from 'node:path';
 import { SemVer, major } from 'semver';
@@ -62,7 +62,7 @@ let forceExit = false;
     let localVersion = cli.VERSION?.full;
     if (!localVersion) {
       try {
-        const localPackageJson = await fs.readFile(
+        const localPackageJson = await readFile(
           path.join(path.dirname(projectLocalCli), '../../package.json'),
           'utf-8',
         );

--- a/packages/angular/cli/src/commands/cache/clean/cli.ts
+++ b/packages/angular/cli/src/commands/cache/clean/cli.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import { promises as fs } from 'node:fs';
+import { rm } from 'node:fs/promises';
 import { Argv } from 'yargs';
 import {
   CommandModule,
@@ -28,7 +28,7 @@ export class CacheCleanModule extends CommandModule implements CommandModuleImpl
   run(): Promise<void> {
     const { path } = getCacheConfig(this.context.workspace);
 
-    return fs.rm(path, {
+    return rm(path, {
       force: true,
       recursive: true,
       maxRetries: 3,

--- a/packages/angular/cli/src/commands/cache/info/cli.ts
+++ b/packages/angular/cli/src/commands/cache/info/cli.ts
@@ -7,7 +7,7 @@
  */
 
 import { tags } from '@angular-devkit/core';
-import { promises as fs } from 'node:fs';
+import * as fs from 'node:fs/promises';
 import { join } from 'node:path';
 import { Argv } from 'yargs';
 import {

--- a/packages/angular/cli/src/utilities/completion.ts
+++ b/packages/angular/cli/src/utilities/completion.ts
@@ -8,7 +8,7 @@
 
 import { json, logging } from '@angular-devkit/core';
 import { execFile } from 'node:child_process';
-import { promises as fs } from 'node:fs';
+import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { env } from 'node:process';
 import { colors } from '../utilities/color';


### PR DESCRIPTION
Several usages of `import { promises as fs } from 'node:fs'` have been adjusted to import directly from `node:fs/promises`. This is consistent with the rest of the source code usage.