### PR TITLE
build: improve debugging mode of e2e test runner

### DIFF
--- a/tests/legacy-cli/e2e_runner.ts
+++ b/tests/legacy-cli/e2e_runner.ts
@@ -257,10 +257,8 @@ Promise.all([findFreePort(), findFreePort(), findPackageTars()])
         console.log(`Current Directory: ${process.cwd()}`);
         console.log('Will loop forever while you debug... CTRL-C to quit.');
 
-        /* eslint-disable no-constant-condition */
-        while (1) {
-          // That's right!
-        }
+        // Wait forever until user explicitly cancels.
+        await new Promise(() => {});
       }
 
       process.exitCode = 1;


### PR DESCRIPTION
Currently the `while` loop may either be causing the process to be really stuck/hanging, or it somehow causes Node to exit.

This change makes the logic more robust and less CPU consuming.