### PR TITLE
fix(@schematics/angular): add `@angular/ssr` dependency only when `provideServerRendering` import has been updated

### DIFF
--- a/packages/schematics/angular/migrations/replace-provide-server-rendering-import/migration.ts
+++ b/packages/schematics/angular/migrations/replace-provide-server-rendering-import/migration.ts
@@ -39,12 +39,7 @@ function* visit(directory: DirEntry): IterableIterator<[fileName: string, conten
 
 export default function (): Rule {
   return async (tree) => {
-    addPackageJsonDependency(tree, {
-      name: '@angular/ssr',
-      version: latestVersions.AngularSSR,
-      type: NodeDependencyType.Default,
-      overwrite: false,
-    });
+    let angularSSRAdded = false;
 
     for (const [filePath, content] of visit(tree.root)) {
       let updatedContent = content;
@@ -104,6 +99,17 @@ export default function (): Rule {
 
       if (content !== updatedContent) {
         tree.overwrite(filePath, updatedContent);
+
+        if (!angularSSRAdded) {
+          addPackageJsonDependency(tree, {
+            name: '@angular/ssr',
+            version: latestVersions.AngularSSR,
+            type: NodeDependencyType.Default,
+            overwrite: false,
+          });
+
+          angularSSRAdded = true;
+        }
       }
     }
   };

--- a/packages/schematics/angular/migrations/replace-provide-server-rendering-import/migration_spec.ts
+++ b/packages/schematics/angular/migrations/replace-provide-server-rendering-import/migration_spec.ts
@@ -23,9 +23,7 @@ describe(`Migration to use the 'provideServerRendering' from '@angular/ssr'`, ()
     tree.create(
       '/package.json',
       JSON.stringify({
-        dependencies: {
-          '@angular/ssr': '0.0.0',
-        },
+        dependencies: {},
       }),
     );
   });
@@ -71,5 +69,23 @@ describe(`Migration to use the 'provideServerRendering' from '@angular/ssr'`, ()
       "import { provideServerRendering, provideServerRouting } from '@angular/ssr';",
     );
     expect(content.match(/@angular\/ssr/g) || []).toHaveSize(1);
+  });
+
+  it(`should add '@angular/ssr' when import has been changed`, async () => {
+    tree.create('test.ts', `import { provideServerRendering } from '@angular/platform-server';`);
+    const newTree = await schematicRunner.runSchematic(schematicName, {}, tree);
+    const { dependencies } = newTree.readJson('package.json') as {
+      dependencies: Record<string, string>;
+    };
+    expect(dependencies['@angular/ssr']).toBeDefined();
+  });
+
+  it(`should not add '@angular/ssr' dependency if no imports have been updated`, async () => {
+    tree.create('test.ts', `import { provideClientHydration } from '@angular/platform-browser';`);
+    const newTree = await schematicRunner.runSchematic(schematicName, {}, tree);
+    const { dependencies } = newTree.readJson('package.json') as {
+      dependencies: Record<string, string>;
+    };
+    expect(dependencies['@angular/ssr']).toBeUndefined();
   });
 });


### PR DESCRIPTION


Prior to this commit, the dependency was always added.
