### PR TITLE
fix(@schematics/angular): replace `@angular/platform-browser-dynamic` with `@angular/platform-browser`

### DIFF
--- a/packages/schematics/angular/application/files/module-files/src/main.ts.template
+++ b/packages/schematics/angular/application/files/module-files/src/main.ts.template
@@ -1,8 +1,8 @@
 <% if(!!viewEncapsulation) { %>import { ViewEncapsulation } from '@angular/core';
-<% }%>import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+<% }%>import { platformBrowser } from '@angular/platform-browser';
 import { AppModule } from './app/app.module';
 
-platformBrowserDynamic().bootstrapModule(AppModule, {
+platformBrowser().bootstrapModule(AppModule, {
   <% if(!experimentalZoneless) { %>ngZoneEventCoalescing: true,<% } %><% if(!!viewEncapsulation) { %>
   defaultEncapsulation: ViewEncapsulation.<%= viewEncapsulation %><% } %>
 })


### PR DESCRIPTION

The Angular CLI explicitly adds `@angular/compiler` as a polyfill when JIT mode is enabled which makes using  `@angular/platform-browser-dynamic` redundant and causes the compiler to be imported twice.

