### PR TITLE
fix(@angular/build): ensure errors for missing component resources

### DIFF
--- a/packages/angular/build/src/builders/application/tests/behavior/component-stylesheets_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/behavior/component-stylesheets_spec.ts
@@ -44,5 +44,44 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
 
       harness.expectFile('dist/browser/main.js').content.not.toContain('variables');
     });
+
+    it('should generater an error for a missing stylesheet with AOT', async () => {
+      await harness.modifyFile('src/app/app.component.ts', (content) => {
+        return content.replace('./app.component.css', './not-present.css');
+      });
+
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+      });
+
+      const { result, logs } = await harness.executeOnce({ outputLogsOnFailure: false });
+      expect(result?.success).toBeFalse();
+      expect(logs).toContain(
+        jasmine.objectContaining({
+          level: 'error',
+          message: jasmine.stringContaining(`Could not find stylesheet file './not-present.css'`),
+        }),
+      );
+    });
+
+    it('should generater an error for a missing stylesheet with JIT', async () => {
+      await harness.modifyFile('src/app/app.component.ts', (content) => {
+        return content.replace('./app.component.css', './not-present.css');
+      });
+
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        aot: false,
+      });
+
+      const { result, logs } = await harness.executeOnce({ outputLogsOnFailure: false });
+      expect(result?.success).toBeFalse();
+      expect(logs).toContain(
+        jasmine.objectContaining({
+          level: 'error',
+          message: jasmine.stringContaining('Could not resolve'),
+        }),
+      );
+    });
   });
 });

--- a/packages/angular/build/src/builders/application/tests/behavior/component-templates_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/behavior/component-templates_spec.ts
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { buildApplication } from '../../index';
+import { APPLICATION_BUILDER_INFO, BASE_OPTIONS, describeBuilder } from '../setup';
+
+describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
+  describe('Behavior: "Component Templates"', () => {
+    it('should generater an error for a missing template', async () => {
+      await harness.modifyFile('src/app/app.component.ts', (content) => {
+        return content.replace('./app.component.html', './not-present.html');
+      });
+
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+      });
+
+      const { result, logs } = await harness.executeOnce({ outputLogsOnFailure: false });
+      expect(result?.success).toBeFalse();
+      expect(logs).toContain(
+        jasmine.objectContaining({
+          level: 'error',
+          message: jasmine.stringContaining(`Could not find template file './not-present.html'`),
+        }),
+      );
+    });
+  });
+});

--- a/packages/angular/build/src/tools/angular/angular-host.ts
+++ b/packages/angular/build/src/tools/angular/angular-host.ts
@@ -208,6 +208,9 @@ export function createAngularCompilerHost(
 
   host.resourceNameToFileName = function (resourceName, containingFile) {
     const resolvedPath = nodePath.join(nodePath.dirname(containingFile), resourceName);
+    if (!this.fileExists(resolvedPath)) {
+      return null;
+    }
 
     // All resource names that have template file extensions are assumed to be templates
     // TODO: Update compiler to provide the resource type to avoid extension matching here.


### PR DESCRIPTION
Compile time errors will now always be generated when an HTML template and/or CSS component stylesheet are not present on disk. The Angular compiler expects a return value of `null` from the `resourceNameToFileName` function to indicate that a resource path does not exist. JIT mode previously and continues to generate errors as expected.

Closes #29887