### PR TITLE
build: update tsconfig ECMAScript version to ES2023

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,8 +11,8 @@
     "isolatedModules": true,
     "skipLibCheck": true,
     "strict": true,
-    "target": "es2022",
-    "lib": ["es2022"],
+    "target": "es2023",
+    "lib": ["es2023"],
     "rootDir": ".",
     "rootDirs": [".", "./dist-schema/bin/"],
     "paths": {


### PR DESCRIPTION
With Node.js v20 now the minimum supported version for Angular v20, the ECMAScript version used with TypeScript can be increased to ES2023.