### PR TITLE
fix(@schematics/angular): remove empty `scripts` option value from new applications

### DIFF
--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -244,7 +244,6 @@ function addAppToWorkspaceFile(
           inlineStyleLanguage,
           assets: [{ 'glob': '**/*', 'input': `${projectRoot}public` }],
           styles: [`${sourceRoot}/styles.${options.style}`],
-          scripts: [],
         },
         configurations: {
           production: {
@@ -284,7 +283,6 @@ function addAppToWorkspaceFile(
               inlineStyleLanguage,
               assets: [{ 'glob': '**/*', 'input': `${projectRoot}public` }],
               styles: [`${sourceRoot}/styles.${options.style}`],
-              scripts: [],
             },
           },
     },


### PR DESCRIPTION
The `scripts` option with an empty array value has been removed from newly generated applications including with `ng new`. This option is less commonly used and can be added if needed by a project. The removal reduces the total size of the generated `angular.json`.