### PR TITLE
feat(@angular/build): support a default outputPath option for applications

### DIFF
--- a/goldens/public-api/angular/build/index.api.md
+++ b/goldens/public-api/angular/build/index.api.md
@@ -49,7 +49,7 @@ export type ApplicationBuilderOptions = {
     optimization?: OptimizationUnion;
     outputHashing?: OutputHashing;
     outputMode?: OutputMode;
-    outputPath: OutputPathUnion;
+    outputPath?: OutputPathUnion;
     poll?: number;
     polyfills?: string[];
     prerender?: PrerenderUnion;

--- a/packages/angular/build/src/builders/application/options.ts
+++ b/packages/angular/build/src/builders/application/options.ts
@@ -295,7 +295,7 @@ export async function normalizeOptions(
     };
   }
 
-  const outputPath = options.outputPath;
+  const outputPath = options.outputPath ?? path.join(workspaceRoot, 'dist', projectName);
   const outputOptions: NormalizedOutputOptions = {
     browser: 'browser',
     server: 'server',

--- a/packages/angular/build/src/builders/application/schema.json
+++ b/packages/angular/build/src/builders/application/schema.json
@@ -605,7 +605,7 @@
     }
   },
   "additionalProperties": false,
-  "required": ["outputPath", "index", "browser", "tsConfig"],
+  "required": ["index", "browser", "tsConfig"],
   "definitions": {
     "assetPattern": {
       "oneOf": [


### PR DESCRIPTION
The application builder will now use a default output path when the `outputPath` option is not specified either in the `angular.json` configuration or via the command line.  The default used will be `dist/<project_name>` and be relative to the workspace root. This value is the typical default for new projects. Projects may continue to customize the output path via the option if needed. Existing project behavior and configuration will not be changed.