### PR TITLE
fix(@angular/build): correct handling of response/request errors

### DIFF
--- a/packages/angular/build/src/utils/server-rendering/launch-server.ts
+++ b/packages/angular/build/src/utils/server-rendering/launch-server.ts
@@ -33,7 +33,7 @@ export async function launchServer(): Promise<URL> {
       // handle request
       if (isSsrNodeRequestHandler(reqHandler)) {
         await reqHandler(req, res, (e) => {
-          throw e;
+          throw e ?? new Error(`Unable to handle request: '${req.url}'.`);
         });
       } else {
         const webRes = await reqHandler(createWebRequestFromNodeRequest(req));

--- a/packages/angular/build/src/utils/server-rendering/prerender.ts
+++ b/packages/angular/build/src/utils/server-rendering/prerender.ts
@@ -113,7 +113,7 @@ export async function prerenderPages(
     outputMode,
   ).catch((err) => {
     return {
-      errors: [`An error occurred while extracting routes.\n\n${err.stack ?? err.message ?? err}`],
+      errors: [`An error occurred while extracting routes.\n\n${err.message ?? err.stack ?? err}`],
       serializedRouteTree: [],
       appShellRoute: undefined,
     };
@@ -258,7 +258,7 @@ async function renderPages(
         })
         .catch((err) => {
           errors.push(
-            `An error occurred while prerendering route '${route}'.\n\n${err.stack ?? err.message ?? err.code ?? err}`,
+            `An error occurred while prerendering route '${route}'.\n\n${err.message ?? err.stack ?? err.code ?? err}`,
           );
           void renderWorker.destroy();
         });
@@ -359,7 +359,7 @@ async function getAllRoutes(
 
     return {
       errors: [
-        `An error occurred while extracting routes.\n\n${err.stack ?? err.message ?? err.code ?? err}`,
+        `An error occurred while extracting routes.\n\n${err.message ?? err.stack ?? err.code ?? err}`,
       ],
       serializedRouteTree: [],
     };


### PR DESCRIPTION
Prior to this change, request errors were not handled correctly.

Closes #29884
