### PR TITLE
fix(@schematics/angular): remove explicit `outputPath` option value from generated applications

### DIFF
--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -236,7 +236,6 @@ function addAppToWorkspaceFile(
         builder: Builders.BuildApplication,
         defaultConfiguration: 'production',
         options: {
-          outputPath: `dist/${folderName}`,
           index: `${sourceRoot}/index.html`,
           browser: `${sourceRoot}/main.ts`,
           polyfills: options.experimentalZoneless ? [] : ['zone.js'],

--- a/packages/schematics/angular/ssr/index.ts
+++ b/packages/schematics/angular/ssr/index.ts
@@ -81,12 +81,9 @@ async function getApplicationBuilderOutputPaths(
     throw new SchematicsException(`Cannot find 'options' for ${projectName} ${target} target.`);
   }
 
-  const { outputPath } = architectTarget.options;
-  if (outputPath === null || outputPath === undefined) {
-    throw new SchematicsException(
-      `outputPath for ${projectName} ${target} target is undefined or null.`,
-    );
-  }
+  let { outputPath } = architectTarget.options;
+  // Use default if not explicitly specified
+  outputPath ??= posix.join('dist', projectName);
 
   const defaultDirs = {
     server: DEFAULT_SERVER_DIR,

--- a/packages/schematics/angular/ssr/index_spec.ts
+++ b/packages/schematics/angular/ssr/index_spec.ts
@@ -118,7 +118,7 @@ describe('SSR Schematic', () => {
       const build = config.projects['test-app'].architect.build;
 
       build.options.outputPath = {
-        base: build.options.outputPath,
+        base: 'dist/test-app',
         browser: 'public',
         server: 'node-server',
       };
@@ -139,7 +139,7 @@ describe('SSR Schematic', () => {
       const build = config.projects['test-app'].architect.build;
 
       build.options.outputPath = {
-        base: build.options.outputPath,
+        base: 'dist/test-app',
         browser: '',
         server: 'node-server',
       };

--- a/tests/legacy-cli/e2e/tests/build/jit-ngmodule.ts
+++ b/tests/legacy-cli/e2e/tests/build/jit-ngmodule.ts
@@ -23,6 +23,7 @@ export default async function () {
         main: build.options.browser,
         browser: undefined,
         buildOptimizer: false,
+        outputPath: 'dist/test-project-two',
       };
 
       build.configurations.development = {

--- a/tests/legacy-cli/e2e/tests/build/rebuild-dot-dirname.ts
+++ b/tests/legacy-cli/e2e/tests/build/rebuild-dot-dirname.ts
@@ -33,6 +33,7 @@ export default async function () {
           ...build.options,
           main: build.options.browser,
           browser: undefined,
+          outputPath: 'dist/subdirectory-test-project',
         };
 
         build.configurations.development = {

--- a/tests/legacy-cli/e2e/tests/build/relative-sourcemap.ts
+++ b/tests/legacy-cli/e2e/tests/build/relative-sourcemap.ts
@@ -18,6 +18,7 @@ export default async function () {
         ...build.options,
         main: build.options.browser,
         browser: undefined,
+        outputPath: 'dist/secondary-project',
       };
 
       build.configurations.development = {


### PR DESCRIPTION
The `outputPath` option now defaults to `dist/<project_name>` for applications. This removes the need to explicitly set the option within a newly generated project. The value removal also reduces the overall size of the `angular.json` configuration for new projects. Existing projects are not modified by this change.