### PR TITLE
fix(@schematics/angular): add type checking of host bindings to strict config

### DIFF
--- a/packages/schematics/angular/workspace/files/tsconfig.json.template
+++ b/packages/schematics/angular/workspace/files/tsconfig.json.template
@@ -20,6 +20,7 @@
     "enableI18nLegacyMessageIdFormat": false<% if (strict) { %>,
     "strictInjectionParameters": true,
     "strictInputAccessModifiers": true,
+    "typeCheckHostBindings": true,
     "strictTemplates": true<% } %>
   }
 }


### PR DESCRIPTION
Adds the `typeCheckHostBindings` flag when the user has opted into strict type checking.
