### PR TITLE
refactor: replace `dirname(fileURLToPath(import.meta.url))` with `import.meta.dirname`

### DIFF
--- a/packages/schematics/angular/ssr/files/application-builder/server.ts.template
+++ b/packages/schematics/angular/ssr/files/application-builder/server.ts.template
@@ -5,11 +5,9 @@ import {
   writeResponseToNodeResponse,
 } from '@angular/ssr/node';
 import express from 'express';
-import { dirname, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
 
-const serverDistFolder = dirname(fileURLToPath(import.meta.url));
-const browserDistFolder = resolve(serverDistFolder, '../<%= browserDistDirectory %>');
+const browserDistFolder = join(import.meta.dirname, '../<%= browserDistDirectory %>');
 
 const app = express();
 const angularApp = new AngularNodeAppEngine();

--- a/packages/schematics/angular/ssr/index_spec.ts
+++ b/packages/schematics/angular/ssr/index_spec.ts
@@ -130,7 +130,7 @@ describe('SSR Schematic', () => {
       expect(scripts['serve:ssr:test-app']).toBe(`node dist/test-app/node-server/server.mjs`);
 
       const serverFileContent = tree.readContent('/projects/test-app/src/server.ts');
-      expect(serverFileContent).toContain(`resolve(serverDistFolder, '../public')`);
+      expect(serverFileContent).toContain(`join(import.meta.dirname, '../public')`);
     });
 
     it(`removes "outputPath.browser" when it's an empty string`, async () => {

--- a/scripts/build-packages-dist.mts
+++ b/scripts/build-packages-dist.mts
@@ -16,14 +16,13 @@ import { BuiltPackage } from '@angular/ng-dev';
 import { execSync } from 'node:child_process';
 import { chmodSync, copyFileSync, mkdirSync, rmSync } from 'node:fs';
 import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
 import sh from 'shelljs';
 
 /** Name of the Bazel tag that will be used to find release package targets. */
 const releaseTargetTag = 'release-package';
 
 /** Path to the project directory. */
-const projectDir = join(dirname(fileURLToPath(import.meta.url)), '../');
+const projectDir = join(import.meta.dirname, '../');
 
 /** Command that runs Bazel. */
 const bazelCmd = process.env.BAZEL || `pnpm -s bazel`;

--- a/scripts/build-schema.mts
+++ b/scripts/build-schema.mts
@@ -8,10 +8,9 @@
 
 import { spawn } from 'node:child_process';
 import { rm } from 'node:fs/promises';
-import { dirname, join, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join, resolve } from 'node:path';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
+const __dirname = import.meta.dirname;
 const baseDir = resolve(`${__dirname}/..`);
 const bazelCmd = process.env.BAZEL ?? `pnpm -s bazel`;
 const distRoot = join(baseDir, '/dist-schema/');

--- a/scripts/build.mts
+++ b/scripts/build.mts
@@ -9,10 +9,9 @@
 import { spawn } from 'node:child_process';
 import { COPYFILE_FICLONE } from 'node:constants';
 import fs from 'node:fs';
-import path, { dirname, join, relative, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { dirname, join, relative, resolve } from 'node:path';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const __dirname = import.meta.dirname;
 const baseDir = resolve(`${__dirname}/..`);
 const bazelCmd = process.env.BAZEL ?? `pnpm -s bazel`;
 const distRoot = join(baseDir, '/dist');

--- a/scripts/create.mts
+++ b/scripts/create.mts
@@ -10,7 +10,7 @@ import assert from 'node:assert';
 import * as child_process from 'node:child_process';
 import { copyFile, readFile, rm, writeFile } from 'node:fs/promises';
 import * as path from 'node:path';
-import { fileURLToPath, pathToFileURL } from 'node:url';
+import { pathToFileURL } from 'node:url';
 import build from './build.mjs';
 import { packages } from './packages.mjs';
 
@@ -18,7 +18,7 @@ export interface CreateOptions extends Record<string, unknown> {
   _: string[];
 }
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const __dirname = import.meta.dirname;
 
 async function _exec(command: string, args: string[], opts: { cwd?: string }) {
   const { status, error, stderr, stdout } = child_process.spawnSync(command, args, { ...opts });

--- a/scripts/devkit-admin.mts
+++ b/scripts/devkit-admin.mts
@@ -8,8 +8,7 @@
  */
 
 import colors from 'ansi-colors';
-import path, { dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import path from 'node:path';
 import yargsParser from 'yargs-parser';
 
 const args = yargsParser(process.argv.slice(2), {
@@ -21,7 +20,7 @@ const args = yargsParser(process.argv.slice(2), {
 const scriptName = args._.shift();
 
 const cwd = process.cwd();
-const scriptDir = dirname(fileURLToPath(import.meta.url));
+const scriptDir = import.meta.dirname;
 process.chdir(path.join(scriptDir, '..'));
 
 const originalConsole = { ...console };

--- a/scripts/json-help.mts
+++ b/scripts/json-help.mts
@@ -10,10 +10,9 @@ import { spawnSync } from 'node:child_process';
 import { promises as fs } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import create from './create.mjs';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const __dirname = import.meta.dirname;
 
 export async function createTemporaryProject(): Promise<string> {
   console.info('Creating temporary project...');

--- a/scripts/snapshots.mts
+++ b/scripts/snapshots.mts
@@ -10,12 +10,11 @@ import { execSync, spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import build from './build.mjs';
 import jsonHelp, { createTemporaryProject } from './json-help.mjs';
 import { PackageInfo, packages } from './packages.mjs';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const __dirname = import.meta.dirname;
 
 // Added to the README.md of the snapshot. This is markdown.
 const readmeHeaderFn = (name: string, snapshotRepo: string) => `

--- a/scripts/templates.mts
+++ b/scripts/templates.mts
@@ -9,10 +9,9 @@
 import lodash from 'lodash';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { releasePackages } from './packages.mjs';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const __dirname = import.meta.dirname;
 
 async function _runTemplate(inputPath: string, outputPath: string) {
   inputPath = path.resolve(__dirname, inputPath);

--- a/scripts/validate-user-analytics.mts
+++ b/scripts/validate-user-analytics.mts
@@ -11,14 +11,13 @@ import lodash from 'lodash';
 import assert from 'node:assert';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import {
   EventCustomDimension,
   EventCustomMetric,
   UserCustomDimension,
 } from '../packages/angular/cli/src/analytics/analytics-parameters.mjs';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const __dirname = import.meta.dirname;
 const userAnalyticsTable = lodash.template(
   fs.readFileSync(path.join(__dirname, './templates/user-analytics-table.ejs'), 'utf-8'),
 );

--- a/tests/legacy-cli/e2e/assets/ssr-project-webpack/package.json
+++ b/tests/legacy-cli/e2e/assets/ssr-project-webpack/package.json
@@ -35,7 +35,7 @@
     "@types/express": "^4.17.17",
     "@types/jasmine": "~4.3.0",
     "@types/mime": "^3.0.0",
-    "@types/node": "^18.18.0",
+    "@types/node": "^20.17.19",
     "jasmine-core": "~4.6.0",
     "karma": "~6.4.0",
     "karma-chrome-launcher": "~3.2.0",

--- a/tests/legacy-cli/e2e/tests/build/server-rendering/server-routes-output-mode-static-http-calls.ts
+++ b/tests/legacy-cli/e2e/tests/build/server-rendering/server-routes-output-mode-static-http-calls.ts
@@ -77,13 +77,11 @@ export default async function () {
     'src/server.ts': `
       import { AngularNodeAppEngine, writeResponseToNodeResponse, isMainModule, createNodeRequestHandler } from '@angular/ssr/node';
       import express from 'express';
-      import { fileURLToPath } from 'node:url';
-      import { dirname, resolve } from 'node:path';
+      import { join } from 'node:path';
 
       export function app(): express.Express {
         const server = express();
-        const serverDistFolder = dirname(fileURLToPath(import.meta.url));
-        const browserDistFolder = resolve(serverDistFolder, '../browser');
+        const browserDistFolder = join(import.meta.dirname, '../browser');
         const angularNodeAppEngine = new AngularNodeAppEngine();
 
         server.get('/api', (req, res) => res.json({ dataFromAPI: true }));

--- a/tests/legacy-cli/e2e/tests/vite/ssr-entry-express.ts
+++ b/tests/legacy-cli/e2e/tests/vite/ssr-entry-express.ts
@@ -39,13 +39,11 @@ export default async function () {
     'src/server.ts': `
       import { AngularNodeAppEngine, writeResponseToNodeResponse, isMainModule, createNodeRequestHandler } from '@angular/ssr/node';
       import express from 'express';
-      import { fileURLToPath } from 'node:url';
-      import { dirname, resolve } from 'node:path';
+      import { join } from 'node:path';
 
       export function app(): express.Express {
         const server = express();
-        const serverDistFolder = dirname(fileURLToPath(import.meta.url));
-        const browserDistFolder = resolve(serverDistFolder, '../browser');
+        const browserDistFolder = join(import.meta.dirname, '../browser');
         const angularNodeAppEngine = new AngularNodeAppEngine();
 
         server.use('/api/**', (req, res) => res.json({ hello: 'foo' }));

--- a/tests/legacy-cli/e2e/utils/project.ts
+++ b/tests/legacy-cli/e2e/utils/project.ts
@@ -212,14 +212,13 @@ export function updateServerFileForWebpack(filepath: string): Promise<void> {
     import { APP_BASE_HREF } from '@angular/common';
     import { CommonEngine } from '@angular/ssr/node';
     import express from 'express';
-    import { fileURLToPath } from 'node:url';
-    import { dirname, join, resolve } from 'node:path';
+    import { join, resolve } from 'node:path';
     import bootstrap from './main.server';
 
     // The Express app is exported so that it can be used by serverless Functions.
     export function app(): express.Express {
       const server = express();
-      const serverDistFolder = dirname(fileURLToPath(import.meta.url));
+      const serverDistFolder = import.meta.dirname;
       const browserDistFolder = resolve(serverDistFolder, '../browser');
       const indexHtml = join(serverDistFolder, 'index.server.html');
 


### PR DESCRIPTION


This change is possible because we no longer support Node.js versions earlier than 20.11.0

