### PR TITLE
fix(@angular-devkit/build-angular): remove `@vitejs/plugin-basic-ssl` from dependencies

### DIFF
--- a/packages/angular_devkit/build_angular/BUILD.bazel
+++ b/packages/angular_devkit/build_angular/BUILD.bazel
@@ -154,7 +154,6 @@ ts_library(
         "@npm//@types/picomatch",
         "@npm//@types/semver",
         "@npm//@types/watchpack",
-        "@npm//@vitejs/plugin-basic-ssl",
         "@npm//@web/test-runner",
         "@npm//ajv",
         "@npm//ansi-colors",

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -22,7 +22,6 @@
     "@babel/runtime": "7.26.10",
     "@discoveryjs/json-ext": "0.6.1",
     "@ngtools/webpack": "0.0.0-PLACEHOLDER",
-    "@vitejs/plugin-basic-ssl": "1.1.0",
     "ansi-colors": "4.1.3",
     "autoprefixer": "10.4.20",
     "babel-loader": "9.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -75,7 +75,6 @@ __metadata:
     "@babel/runtime": "npm:7.26.10"
     "@discoveryjs/json-ext": "npm:0.6.1"
     "@ngtools/webpack": "npm:0.0.0-PLACEHOLDER"
-    "@vitejs/plugin-basic-ssl": "npm:1.1.0"
     ansi-colors: "npm:4.1.3"
     autoprefixer: "npm:10.4.20"
     babel-loader: "npm:9.1.3"


### PR DESCRIPTION

This dependency is not used in this package.

Closes #29921
