### PR TITLE
feat(@angular/build): allow control of source map sources content for application builds

### DIFF
--- a/packages/angular/build/src/builders/application/schema.json
+++ b/packages/angular/build/src/builders/application/schema.json
@@ -370,6 +370,11 @@
               "type": "boolean",
               "description": "Resolve vendor packages source maps.",
               "default": false
+            },
+            "sourcesContent": {
+              "type": "boolean",
+              "description": "Output original source content for files within the source map.",
+              "default": true
             }
           },
           "additionalProperties": false

--- a/packages/angular/build/src/builders/application/setup-bundling.ts
+++ b/packages/angular/build/src/builders/application/setup-bundling.ts
@@ -177,6 +177,7 @@ export function createComponentStyleBundler(
         // the same as being disabled. Disabling has the advantage of avoiding the overhead
         // of sourcemap processing.
         sourcemapOptions.styles && !sourcemapOptions.hidden ? 'linked' : false,
+      sourcesContent: sourcemapOptions.sourcesContent,
       outputNames,
       includePaths: stylePreprocessorOptions?.includePaths,
       // string[] | undefined' is not assignable to type '(Version | DeprecationOrId)[] | undefined'.

--- a/packages/angular/build/src/builders/application/tests/options/sourcemap_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/options/sourcemap_spec.ts
@@ -209,6 +209,82 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
       harness.expectFile('dist/browser/main.js.map').content.toContain('"x_google_ignoreList"');
     });
 
+    it(`should not include 'sourcesContent' field when 'sourcesContent' suboption is false`, async () => {
+      await harness.writeFile('src/styles.css', `div { flex: 1 }`);
+
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        styles: ['src/styles.css'],
+        sourceMap: { scripts: true, styles: true, sourcesContent: false },
+      });
+
+      const { result } = await harness.executeOnce();
+
+      expect(result?.success).toBeTrue();
+
+      harness.expectFile('dist/browser/main.js.map').content.not.toContain('"sourcesContent"');
+
+      harness.expectFile('dist/browser/styles.css.map').toExist();
+      harness.expectFile('dist/browser/styles.css.map').content.not.toContain('"sourcesContent"');
+    });
+
+    it(`should include 'sourcesContent' field when 'sourcesContent' suboption is true`, async () => {
+      await harness.writeFile('src/styles.css', `div { flex: 1 }`);
+
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        styles: ['src/styles.css'],
+        sourceMap: { scripts: true, styles: true, sourcesContent: true },
+      });
+
+      const { result } = await harness.executeOnce();
+
+      expect(result?.success).toBeTrue();
+
+      harness.expectFile('dist/browser/main.js.map').content.toContain('"sourcesContent"');
+
+      harness.expectFile('dist/browser/styles.css.map').toExist();
+      harness.expectFile('dist/browser/styles.css.map').content.toContain('"sourcesContent"');
+    });
+
+    it(`should include 'sourcesContent' field when 'sourcesContent' suboption is not present`, async () => {
+      await harness.writeFile('src/styles.css', `div { flex: 1 }`);
+
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        styles: ['src/styles.css'],
+        sourceMap: { scripts: true, styles: true },
+      });
+
+      const { result } = await harness.executeOnce();
+
+      expect(result?.success).toBeTrue();
+
+      harness.expectFile('dist/browser/main.js.map').content.toContain('"sourcesContent"');
+
+      harness.expectFile('dist/browser/styles.css.map').toExist();
+      harness.expectFile('dist/browser/styles.css.map').content.toContain('"sourcesContent"');
+    });
+
+    it(`should include 'sourcesContent' field when 'sourceMap' is true`, async () => {
+      await harness.writeFile('src/styles.css', `div { flex: 1 }`);
+
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        styles: ['src/styles.css'],
+        sourceMap: true,
+      });
+
+      const { result } = await harness.executeOnce();
+
+      expect(result?.success).toBeTrue();
+
+      harness.expectFile('dist/browser/main.js.map').content.toContain('"sourcesContent"');
+
+      harness.expectFile('dist/browser/styles.css.map').toExist();
+      harness.expectFile('dist/browser/styles.css.map').content.toContain('"sourcesContent"');
+    });
+
     it('should generate component sourcemaps when sourcemaps when true', async () => {
       await harness.writeFile('src/app/app.component.css', `* { color: red}`);
 

--- a/packages/angular/build/src/tools/esbuild/application-code-bundle.ts
+++ b/packages/angular/build/src/tools/esbuild/application-code-bundle.ts
@@ -586,6 +586,7 @@ function getEsBuildCommonOptions(options: NormalizedApplicationBuildOptions): Bu
     outdir: workspaceRoot,
     outExtension: outExtension ? { '.js': `.${outExtension}` } : undefined,
     sourcemap: sourcemapOptions.scripts && (sourcemapOptions.hidden ? 'external' : true),
+    sourcesContent: sourcemapOptions.sourcesContent,
     splitting: true,
     chunkNames: options.namedChunks ? '[name]-[hash]' : 'chunk-[hash]',
     tsconfig,

--- a/packages/angular/build/src/tools/esbuild/global-styles.ts
+++ b/packages/angular/build/src/tools/esbuild/global-styles.ts
@@ -53,6 +53,7 @@ export function createGlobalStylesBundleOptions(
         optimization: !!optimizationOptions.styles.minify,
         inlineFonts: !!optimizationOptions.fonts.inline,
         sourcemap: !!sourcemapOptions.styles && (sourcemapOptions.hidden ? 'external' : true),
+        sourcesContent: sourcemapOptions.sourcesContent,
         preserveSymlinks,
         target,
         externalDependencies,

--- a/packages/angular/build/src/tools/esbuild/stylesheets/bundle-options.ts
+++ b/packages/angular/build/src/tools/esbuild/stylesheets/bundle-options.ts
@@ -24,6 +24,7 @@ export interface BundleStylesheetOptions {
   inlineFonts: boolean;
   preserveSymlinks?: boolean;
   sourcemap: boolean | 'external' | 'inline' | 'linked';
+  sourcesContent?: boolean;
   outputNames: { bundles: string; media: string };
   includePaths?: string[];
   sass?: StylesheetPluginsass;
@@ -77,6 +78,7 @@ export function createStylesheetBundleOptions(
     minify: options.optimization,
     metafile: true,
     sourcemap: options.sourcemap,
+    sourcesContent: options.sourcesContent,
     outdir: options.workspaceRoot,
     write: false,
     platform: 'browser',

--- a/packages/angular/build/src/utils/normalize-source-maps.ts
+++ b/packages/angular/build/src/utils/normalize-source-maps.ts
@@ -13,11 +13,13 @@ export function normalizeSourceMaps(sourceMap: SourceMapUnion): SourceMapClass {
   const styles = typeof sourceMap === 'object' ? sourceMap.styles : sourceMap;
   const hidden = (typeof sourceMap === 'object' && sourceMap.hidden) || false;
   const vendor = (typeof sourceMap === 'object' && sourceMap.vendor) || false;
+  const sourcesContent = typeof sourceMap === 'object' ? sourceMap.sourcesContent : sourceMap;
 
   return {
     vendor,
     hidden,
     scripts,
     styles,
+    sourcesContent,
   };
 }


### PR DESCRIPTION
The `sourceMap` option now contains an additional sub-option named `sourcesContent` that allows the exclusion of original file content from generated source maps. This option affects both JavaScript and stylesheet source maps. The value of the `sourcesContent` option defaults to `true`.

Example usage to disable sources content:
```
    "sourceMap": {
        "scripts": true,
        "styles": true,
        "sourcesContent": false
    }
```

Closes #29551