### PR TITLE
test: ensure atime and mtime are rounded consistently in tests

### DIFF
--- a/tests/legacy-cli/e2e/tests/build/assets.ts
+++ b/tests/legacy-cli/e2e/tests/build/assets.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
-import * as fs from 'node:fs';
-import { expectFileToExist, expectFileToMatch, writeFile } from '../../utils/fs';
+import { writeFile, stat, mkdir, symlink, utimes } from 'node:fs/promises';
+import { expectFileToExist, expectFileToMatch } from '../../utils/fs';
 import { ng } from '../../utils/process';
 import { updateJsonFile } from '../../utils/project';
 import { expectToFail } from '../../utils/utils';
@@ -9,13 +9,19 @@ import { getGlobalVariable } from '../../utils/env';
 const isNodeV22orHigher = Number(process.versions.node.split('.', 1)[0]) >= 22;
 
 export default async function () {
+  // Update the atime and mtime of the original file.
+  // Note: Node.js has different time precision, which may cause mtime-based tests to fail.
+  // Ensure both values are rounded to the same precision for consistency.
+  // Example:
+  // Original: '1742973507738.0234'
+  // Node.js CP: '1742973507737.999'
+  const { atime, mtime } = await stat('public/favicon.ico');
+  await utimes('public/favicon.ico', atime, mtime);
+
   await writeFile('public/.file', '');
   await writeFile('public/test.abc', 'hello world');
 
-  const originalStats = fs.statSync('public/favicon.ico', { bigint: true });
-
   await ng('build', '--configuration=development');
-
   await expectFileToExist('dist/test-project/browser/favicon.ico');
   await expectFileToExist('dist/test-project/browser/.file');
   await expectFileToMatch('dist/test-project/browser/test.abc', 'hello world');
@@ -23,7 +29,11 @@ export default async function () {
 
   // Timestamp preservation only supported with application build system on Node.js v22+
   if (isNodeV22orHigher && getGlobalVariable('argv')['esbuild']) {
-    const outputStats = fs.statSync('dist/test-project/browser/favicon.ico', { bigint: true });
+    const [originalStats, outputStats] = await Promise.all([
+      stat('public/favicon.ico'),
+      stat('dist/test-project/browser/favicon.ico'),
+    ]);
+
     assert.equal(
       originalStats.mtimeMs,
       outputStats.mtimeMs,
@@ -38,13 +48,17 @@ export default async function () {
       { glob: '**/*', input: 'public', followSymlinks: true },
     ];
   });
-  fs.mkdirSync('dirToSymlink/subdir1', { recursive: true });
-  fs.mkdirSync('dirToSymlink/subdir2/subsubdir1', { recursive: true });
-  fs.writeFileSync('dirToSymlink/a.txt', '');
-  fs.writeFileSync('dirToSymlink/subdir1/b.txt', '');
-  fs.writeFileSync('dirToSymlink/subdir2/c.txt', '');
-  fs.writeFileSync('dirToSymlink/subdir2/subsubdir1/d.txt', '');
-  fs.symlinkSync(process.cwd() + '/dirToSymlink', 'public/symlinkDir');
+
+  await mkdir('dirToSymlink/subdir1', { recursive: true });
+  await mkdir('dirToSymlink/subdir2/subsubdir1', { recursive: true });
+  await symlink(process.cwd() + '/dirToSymlink', 'public/symlinkDir');
+
+  await Promise.all([
+    writeFile('dirToSymlink/a.txt', ''),
+    writeFile('dirToSymlink/subdir1/b.txt', ''),
+    writeFile('dirToSymlink/subdir2/c.txt', ''),
+    writeFile('dirToSymlink/subdir2/subsubdir1/d.txt', ''),
+  ]);
 
   await ng('build', '--configuration=development');
 


### PR DESCRIPTION
Node.js handles time precision differently, which may cause mtime-based tests to fail.

This update ensures that atime and mtime values are rounded to the same precision,  preventing inconsistencies in file timestamp comparisons.
