### PR TITLE
Revert "refactor: use `platformBrowser` instead of `platformBrowserTesting`

### DIFF
--- a/packages/angular/build/src/builders/karma/polyfills/init_test_bed.js
+++ b/packages/angular/build/src/builders/karma/polyfills/init_test_bed.js
@@ -7,12 +7,10 @@
  */
 
 import { getTestBed } from '@angular/core/testing';
-import { platformBrowser } from '@angular/platform-browser';
-import { BrowserTestingModule } from '@angular/platform-browser/testing';
+import { BrowserTestingModule, platformBrowserTesting } from '@angular/platform-browser/testing';
 
-// TODO(alanagius): replace with `platformBrowserTesting` once https://github.com/angular/angular/pull/60480 is released.
 // Initialize the Angular testing environment.
-getTestBed().initTestEnvironment(BrowserTestingModule, platformBrowser(), {
+getTestBed().initTestEnvironment(BrowserTestingModule, platformBrowserTesting(), {
   errorOnUnknownElements: true,
   errorOnUnknownProperties: true,
 });

--- a/packages/angular_devkit/build_angular/src/builders/jest/init-test-bed.mjs
+++ b/packages/angular_devkit/build_angular/src/builders/jest/init-test-bed.mjs
@@ -10,11 +10,9 @@
 // `@angular-devkit/build-angular` rather than the user's workspace. Should look into virtual modules to support those use cases.
 
 import { getTestBed } from '@angular/core/testing';
-import { platformBrowser } from '@angular/platform-browser';
-import { BrowserTestingModule } from '@angular/platform-browser/testing';
+import { BrowserTestingModule, platformBrowserTesting } from '@angular/platform-browser/testing';
 
-// TODO(alanagius): replace with `platformBrowserTesting` once https://github.com/angular/angular/pull/60480 is released.
-getTestBed().initTestEnvironment(BrowserTestingModule, platformBrowser(), {
+getTestBed().initTestEnvironment(BrowserTestingModule, platformBrowserTesting(), {
   errorOnUnknownElements: true,
   errorOnUnknownProperties: true,
 });

--- a/packages/angular_devkit/build_angular/src/builders/karma/browser_builder.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/browser_builder.ts
@@ -153,12 +153,10 @@ function getBuiltInMainFile(): string {
   const content = Buffer.from(
     `
   import { getTestBed } from '@angular/core/testing';
-  import { platformBrowser } from '@angular/platform-browser';
   import { BrowserTestingModule, platformBrowserTesting } from '@angular/platform-browser/testing';
 
-  // TODO(alanagius): replace with \`platformBrowserTesting\` once https://github.com/angular/angular/pull/60480 is released.
   // Initialize the Angular testing environment.
-  getTestBed().initTestEnvironment(BrowserTestingModule, platformBrowser(), {
+  getTestBed().initTestEnvironment(BrowserTestingModule, platformBrowserTesting(), {
     errorOnUnknownElements: true,
     errorOnUnknownProperties: true
   });

--- a/packages/angular_devkit/build_angular/src/builders/web-test-runner/jasmine_runner.js
+++ b/packages/angular_devkit/build_angular/src/builders/web-test-runner/jasmine_runner.js
@@ -7,8 +7,7 @@
  */
 
 import { getTestBed } from '@angular/core/testing';
-import { platformBrowser } from '@angular/platform-browser';
-import { BrowserTestingModule } from '@angular/platform-browser/testing';
+import { BrowserTestingModule, platformBrowserTesting } from '@angular/platform-browser/testing';
 import {
   getConfig,
   sessionFailed,
@@ -65,8 +64,7 @@ export async function runJasmineTests(jasmineEnv) {
   jasmine.DEFAULT_TIMEOUT_INTERVAL = config.defaultTimeoutInterval;
 
   // Initialize `TestBed` automatically for users. This assumes we already evaluated `zone.js/testing`.
-  // TODO(alanagius): replace with `platformBrowserTesting` once https://github.com/angular/angular/pull/60480 is released.
-  getTestBed().initTestEnvironment(BrowserTestingModule, platformBrowser(), {
+  getTestBed().initTestEnvironment(BrowserTestingModule, platformBrowserTesting(), {
     errorOnUnknownElements: true,
     errorOnUnknownProperties: true,
   });


### PR DESCRIPTION
This reverts commit e5e51a22abe4c5c421ff984542fcc808b440b0fa.

This can now be reverted as `platformBrowserTesting` has been fixed.
