### PR TITLE
refactor(@angular/cli): avoid implicit undefined array defaults for `@angular/build` builders

### DIFF
--- a/goldens/public-api/angular_devkit/core/index.api.md
+++ b/goldens/public-api/angular_devkit/core/index.api.md
@@ -18,6 +18,9 @@ import { ValidateFunction } from 'ajv';
 // @public (undocumented)
 function addUndefinedDefaults(value: JsonValue, _pointer: JsonPointer, schema?: JsonSchema): JsonValue;
 
+// @public (undocumented)
+function addUndefinedObjectDefaults(value: JsonValue, _pointer: JsonPointer, schema?: JsonSchema): JsonValue;
+
 // @public
 class AliasHost<StatsT extends object = {}> extends ResolverHost<StatsT> {
     // (undocumented)
@@ -1297,6 +1300,7 @@ class TransformLogger extends Logger {
 
 declare namespace transforms {
     export {
+        addUndefinedObjectDefaults,
         addUndefinedDefaults
     }
 }

--- a/modules/testing/builder/src/builder-harness.ts
+++ b/modules/testing/builder/src/builder-harness.ts
@@ -104,7 +104,11 @@ export class BuilderHarness<T> {
       ...builderInfo,
     };
 
-    this.schemaRegistry.addPostTransform(json.schema.transforms.addUndefinedDefaults);
+    if (builderInfo?.builderName?.startsWith('@angular/build:')) {
+      this.schemaRegistry.addPostTransform(json.schema.transforms.addUndefinedObjectDefaults);
+    } else {
+      this.schemaRegistry.addPostTransform(json.schema.transforms.addUndefinedDefaults);
+    }
   }
 
   private resolvePath(path: string): string {

--- a/packages/angular/build/src/builders/application/tests/setup.ts
+++ b/packages/angular/build/src/builders/application/tests/setup.ts
@@ -13,7 +13,7 @@ import { Schema } from '../schema';
 export * from '../../../../../../../modules/testing/builder/src';
 
 export const APPLICATION_BUILDER_INFO = Object.freeze({
-  name: '@angular-devkit/build-angular:application',
+  name: '@angular/build:application',
   schemaPath: __dirname + '/../schema.json',
 });
 

--- a/packages/angular_devkit/core/src/json/schema/transforms.ts
+++ b/packages/angular_devkit/core/src/json/schema/transforms.ts
@@ -11,10 +11,27 @@ import { JsonPointer } from './interface';
 import { JsonSchema } from './schema';
 import { getTypesOfSchema } from './utility';
 
+export function addUndefinedObjectDefaults(
+  value: JsonValue,
+  _pointer: JsonPointer,
+  schema?: JsonSchema,
+): JsonValue {
+  return transformUndefined(value, _pointer, schema, true);
+}
+
 export function addUndefinedDefaults(
   value: JsonValue,
   _pointer: JsonPointer,
   schema?: JsonSchema,
+): JsonValue {
+  return transformUndefined(value, _pointer, schema, false);
+}
+
+function transformUndefined(
+  value: JsonValue,
+  _pointer: JsonPointer,
+  schema?: JsonSchema,
+  onlyObjects?: boolean,
 ): JsonValue {
   if (typeof schema === 'boolean' || schema === undefined) {
     return value;
@@ -45,7 +62,7 @@ export function addUndefinedDefaults(
     return value;
   }
 
-  if (type === 'array') {
+  if (!onlyObjects && type === 'array') {
     return value == undefined ? [] : value;
   }
 
@@ -94,7 +111,7 @@ export function addUndefinedDefaults(
           });
 
         if (adjustedSchema && isJsonObject(adjustedSchema)) {
-          newValue[propName] = addUndefinedDefaults(value, _pointer, adjustedSchema);
+          newValue[propName] = transformUndefined(value, _pointer, adjustedSchema, onlyObjects);
         }
       }
     }


### PR DESCRIPTION
Previously, all builder options that were of type array were set to a default empty array even if there was no explicit default defined within the schema. This can be problematic for options that have differing behavior based on their presence such as runtime calculated defaults. The implicit defaulting behavior was also not aligned with the generated schema types which resulted in additional type safety and initialization regardless. As a result, the implicit behavior was effectively redundant in most cases. Since this change could be breaking for third-party builders, the removal of this behavior is currently limited to the `@angular/build` package.