### PR TITLE
fix(@angular/build): correctly handle  `false` value in server option

### DIFF
--- a/goldens/public-api/angular/build/index.api.md
+++ b/goldens/public-api/angular/build/index.api.md
@@ -57,8 +57,8 @@ export type ApplicationBuilderOptions = {
     progress?: boolean;
     scripts?: ScriptElement[];
     security?: Security;
-    server?: string;
-    serviceWorker?: ServiceWorker_2;
+    server?: Serv;
+    serviceWorker?: Serv;
     sourceMap?: SourceMapUnion;
     ssr?: SsrUnion;
     statsJson?: boolean;

--- a/packages/angular/build/src/builders/application/options.ts
+++ b/packages/angular/build/src/builders/application/options.ts
@@ -259,10 +259,12 @@ export async function normalizeOptions(
     : await getTailwindConfig(searchDirectories, workspaceRoot, context);
 
   let serverEntryPoint: string | undefined;
-  if (options.server) {
+  if (typeof options.server === 'string') {
+    if (options.server === '') {
+      throw new Error('The "server" option cannot be an empty string.');
+    }
+
     serverEntryPoint = path.join(workspaceRoot, options.server);
-  } else if (options.server === '') {
-    throw new Error('The "server" option cannot be an empty string.');
   }
 
   let prerenderOptions;

--- a/packages/angular/build/src/builders/application/schema.json
+++ b/packages/angular/build/src/builders/application/schema.json
@@ -17,7 +17,6 @@
       "description": "The full path for the browser entry point to the application, relative to the current workspace."
     },
     "server": {
-      "type": "string",
       "description": "The full path for the server entry point to the application, relative to the current workspace.",
       "oneOf": [
         {


### PR DESCRIPTION
The schema included a top-level `type`, preventing this option from functioning correctly.

Closes: #29969

