### PR TITLE
refactor(@angular/build): provide a pre-link resolution condition for APF

### DIFF
--- a/packages/angular/build/src/tools/esbuild/application-code-bundle.ts
+++ b/packages/angular/build/src/tools/esbuild/application-code-bundle.ts
@@ -547,6 +547,7 @@ function getEsBuildCommonOptions(options: NormalizedApplicationBuildOptions): Bu
     jsonLogs,
     i18nOptions,
     customConditions,
+    frameworkVersion,
   } = options;
 
   // Ensure unique hashes for i18n translation changes when using post-process inlining.
@@ -570,6 +571,14 @@ function getEsBuildCommonOptions(options: NormalizedApplicationBuildOptions): Bu
     'es2015',
     'es2020',
   ];
+  // The pre-linked code is not used with JIT for two reasons:
+  // 1) The pre-linked code may not have the metadata included that is required for JIT
+  // 2) The CLI is otherwise setup to use runtime linking for JIT to match the application template compilation
+  if (!jit) {
+    // The pre-linked package condition is based on the framework version.
+    // Currently this is specific to each patch version of the framework.
+    conditions.push('angular:linked-' + frameworkVersion);
+  }
 
   // Append custom conditions if present
   if (customConditions) {


### PR DESCRIPTION
To support future APF changes that may include pre-linked code specific to the Angular version used to create the package, an additional package resolution condition will now be automatically added to the build process for applications. A condition in the form of `angular:linked-<version>`, where `<version>` is the full package version of `@angular/core`, will now be present during application builds. This change in combination with APF changes will allow matching packages to avoid the linking step during a build. Non-version matching packages will continue to function and use the existing linking transformation process.