### PR TITLE
refactor(@angular/build): remove unneeded babel import attributes syntax plugin

### DIFF
--- a/packages/angular/build/BUILD.bazel
+++ b/packages/angular/build/BUILD.bazel
@@ -81,7 +81,6 @@ ts_project(
         ":node_modules/@babel/core",
         ":node_modules/@babel/helper-annotate-as-pure",
         ":node_modules/@babel/helper-split-export-declaration",
-        ":node_modules/@babel/plugin-syntax-import-attributes",
         ":node_modules/@inquirer/confirm",
         ":node_modules/@vitejs/plugin-basic-ssl",
         ":node_modules/browserslist",

--- a/packages/angular/build/package.json
+++ b/packages/angular/build/package.json
@@ -23,7 +23,6 @@
     "@babel/core": "7.26.10",
     "@babel/helper-annotate-as-pure": "7.25.9",
     "@babel/helper-split-export-declaration": "7.24.7",
-    "@babel/plugin-syntax-import-attributes": "7.26.0",
     "@inquirer/confirm": "5.1.8",
     "@vitejs/plugin-basic-ssl": "2.0.0",
     "beasties": "0.2.0",

--- a/packages/angular/build/src/tools/esbuild/javascript-transformer-worker.ts
+++ b/packages/angular/build/src/tools/esbuild/javascript-transformer-worker.ts
@@ -61,9 +61,7 @@ async function transformWithBabel(
     options.sourcemap &&
     (!!options.thirdPartySourcemaps || !/[\\/]node_modules[\\/]/.test(filename));
 
-  // @ts-expect-error Import attribute syntax plugin does not currently have type definitions
-  const { default: importAttributePlugin } = await import('@babel/plugin-syntax-import-attributes');
-  const plugins: PluginItem[] = [importAttributePlugin];
+  const plugins: PluginItem[] = [];
 
   if (options.instrumentForCoverage) {
     const { default: coveragePlugin } = await import('../babel/plugins/add-code-coverage.js');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -355,9 +355,6 @@ importers:
       '@babel/helper-split-export-declaration':
         specifier: 7.24.7
         version: 7.24.7
-      '@babel/plugin-syntax-import-attributes':
-        specifier: 7.26.0
-        version: 7.26.0(@babel/core@7.26.10)
       '@inquirer/confirm':
         specifier: 5.1.8
         version: 5.1.8(@types/node@20.17.27)


### PR DESCRIPTION
As of babel v7.26.0, the separate `@babel/plugin-syntax-import-attributes` package is no longer needed. The ability to parse import attributes is included by default.