### PR TITLE
build: setup `rules_esbuild` in preparation for `devinfra` update

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -256,3 +256,21 @@ register_toolchains(
     "@devinfra//bazel/git-toolchain:git_macos_arm64_toolchain",
     "@devinfra//bazel/git-toolchain:git_windows_toolchain",
 )
+
+http_archive(
+    name = "aspect_rules_esbuild",
+    sha256 = "550e33ddeb86a564b22b2c5d3f84748c6639b1b2b71fae66bf362c33392cbed8",
+    strip_prefix = "rules_esbuild-0.21.0",
+    url = "https://github.com/aspect-build/rules_esbuild/releases/download/v0.21.0/rules_esbuild-v0.21.0.tar.gz",
+)
+
+load("@aspect_rules_esbuild//esbuild:dependencies.bzl", "rules_esbuild_dependencies")
+
+rules_esbuild_dependencies()
+
+load("@aspect_rules_esbuild//esbuild:repositories.bzl", "LATEST_ESBUILD_VERSION", "esbuild_register_toolchains")
+
+esbuild_register_toolchains(
+    name = "esbuild",
+    esbuild_version = LATEST_ESBUILD_VERSION,
+)


### PR DESCRIPTION
The shared dev-infra repository will depend on `rules_esbuild` going forward, so we need to install it.

Unblocks https://github.com/angular/angular-cli/pull/29984