### PR TITLE
refactor(@schematics/angular): more comprehensive empty type file name cleanup

### DIFF
--- a/packages/schematics/angular/utility/generate-from-files.ts
+++ b/packages/schematics/angular/utility/generate-from-files.ts
@@ -60,14 +60,17 @@ export function generateFromFiles(
         ...extraTemplateValues,
       }),
       !options.type
-        ? forEach(((file) => {
-            return file.path.includes('..')
-              ? {
-                  content: file.content,
-                  path: file.path.replace('..', '.'),
-                }
-              : file;
-          }) as FileOperator)
+        ? forEach((file) => {
+            let filePath: string = file.path;
+            while (filePath.includes('..')) {
+              filePath = filePath.replaceAll('..', '.');
+            }
+
+            return {
+              content: file.content,
+              path: filePath,
+            } as ReturnType<FileOperator>;
+          })
         : noop(),
       move(parsedPath.path + (options.flat ? '' : '/' + strings.dasherize(options.name))),
     ]);


### PR DESCRIPTION
The potential double periods within file name templates are now more completely removed in cases where there may be more than one set.