### PR TITLE
refactor(@angular/build): provide a default for the application index option

### DIFF
--- a/goldens/public-api/angular/build/index.api.md
+++ b/goldens/public-api/angular/build/index.api.md
@@ -40,7 +40,7 @@ export type ApplicationBuilderOptions = {
     fileReplacements?: FileReplacement[];
     i18nDuplicateTranslation?: I18NTranslation;
     i18nMissingTranslation?: I18NTranslation;
-    index: IndexUnion;
+    index?: IndexUnion;
     inlineStyleLanguage?: InlineStyleLanguage;
     loader?: {
         [key: string]: any;

--- a/packages/angular/build/src/builders/application/options.ts
+++ b/packages/angular/build/src/builders/application/options.ts
@@ -332,11 +332,16 @@ export async function normalizeOptions(
   let indexHtmlOptions;
   // index can never have a value of `true` but in the schema it's of type `boolean`.
   if (typeof options.index !== 'boolean') {
+    let indexInput: string;
     let indexOutput: string;
     // The output file will be created within the configured output path
     if (typeof options.index === 'string') {
-      indexOutput = options.index;
+      indexInput = indexOutput = path.join(workspaceRoot, options.index);
+    } else if (typeof options.index === 'undefined') {
+      indexInput = path.join(projectSourceRoot, 'index.html');
+      indexOutput = 'index.html';
     } else {
+      indexInput = path.join(workspaceRoot, options.index.input);
       indexOutput = options.index.output || 'index.html';
     }
 
@@ -356,10 +361,7 @@ export async function normalizeOptions(
         : indexBaseName;
 
     indexHtmlOptions = {
-      input: path.join(
-        workspaceRoot,
-        typeof options.index === 'string' ? options.index : options.index.input,
-      ),
+      input: indexInput,
       output: indexOutput,
       insertionOrder: [
         ['polyfills', true],

--- a/packages/angular/build/src/builders/application/schema.json
+++ b/packages/angular/build/src/builders/application/schema.json
@@ -616,7 +616,7 @@
     }
   },
   "additionalProperties": false,
-  "required": ["index", "browser", "tsConfig"],
+  "required": ["browser", "tsConfig"],
   "definitions": {
     "assetPattern": {
       "oneOf": [

--- a/packages/angular/build/src/builders/application/tests/options/index_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/options/index_spec.ts
@@ -62,6 +62,23 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
         harness.expectFile('dist/browser/index.html').content.toContain('TEST_123');
       });
 
+      it('should use the the index.html file within the project source root when not present', async () => {
+        harness.useTarget('build', {
+          ...BASE_OPTIONS,
+          index: undefined,
+        });
+
+        await harness.writeFile(
+          'src/index.html',
+          '<html><head><title>TEST_123</title></head><body></body>',
+        );
+
+        const { result } = await harness.executeOnce();
+
+        expect(result?.success).toBe(true);
+        harness.expectFile('dist/browser/index.html').content.toContain('TEST_123');
+      });
+
       // TODO: Build needs to be fixed to not throw an unhandled exception for this case
       xit('should fail build when a string path to non-existent file', async () => {
         harness.useTarget('build', {


### PR DESCRIPTION
The application build system's `index` option is now considered optional. If not present, the value will be an `index.html` file within the configured project source root (`sourceRoot`). The default only applies to the short-form of the option. The object-based long-form continues to require explicit configuration of the input index HTML file. This change allows the removal of the `index` option from any project that uses the default generated value.