### PR TITLE
docs: release notes for the v18.2.17 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+<a name="18.2.17"></a>
+
+# 18.2.17 (2025-04-02)
+
+### @angular/build
+
+| Commit                                                                                              | Type | Description                                    |
+| --------------------------------------------------------------------------------------------------- | ---- | ---------------------------------------------- |
+| [247ceff7f](https://github.com/angular/angular-cli/commit/247ceff7f7d71901f51dbab1c1a5235d59e45847) | fix  | update vite to 5.4.16 due to a security issues |
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="17.3.15"></a>
 
 # 17.3.15 (2025-04-02)


### PR DESCRIPTION
Cherry-picks the changelog from the "18.2.x" branch to the next branch (main).