### PR TITLE
fix(@angular/build): include component test metadata in development builds

### DIFF
--- a/packages/angular/build/src/builders/application/tests/options/optimization-scripts_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/options/optimization-scripts_spec.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { buildApplication } from '../../index';
+import { APPLICATION_BUILDER_INFO, BASE_OPTIONS, describeBuilder } from '../setup';
+
+describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
+  describe('Option: "optimization.scripts"', () => {
+    it(`should include 'setClassMetadata' calls when false`, async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        optimization: {
+          scripts: false,
+        },
+      });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
+
+      harness.expectFile('dist/browser/main.js').content.toContain('setClassMetadata(');
+    });
+
+    it(`should not include 'setClassMetadata' calls when true`, async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        optimization: {
+          scripts: true,
+        },
+      });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
+
+      harness.expectFile('dist/browser/main.js').content.not.toContain('setClassMetadata(');
+    });
+  });
+});

--- a/packages/angular/build/src/tools/esbuild/angular/compiler-plugin.ts
+++ b/packages/angular/build/src/tools/esbuild/angular/compiler-plugin.ts
@@ -35,6 +35,7 @@ export interface CompilerPluginOptions {
   sourcemap: boolean | 'external';
   tsconfig: string;
   jit?: boolean;
+  includeTestMetadata?: boolean;
 
   advancedOptimizations?: boolean;
   thirdPartySourcemaps?: boolean;
@@ -292,7 +293,6 @@ export function createCompilerPlugin(
               pluginOptions,
               preserveSymlinks,
               build.initialOptions.conditions,
-              build.initialOptions.absWorkingDir,
             ),
           );
           shouldTsIgnoreJs = !initializationResult.compilerOptions.allowJs;
@@ -623,7 +623,6 @@ function createCompilerOptionsTransformer(
   pluginOptions: CompilerPluginOptions,
   preserveSymlinks: boolean | undefined,
   customConditions: string[] | undefined,
-  absWorkingDir: string | undefined,
 ): Parameters<AngularCompilation['initialize']>[2] {
   return (compilerOptions) => {
     // target of 9 is ES2022 (using the number avoids an expensive import of typescript just for an enum)
@@ -714,6 +713,7 @@ function createCompilerOptionsTransformer(
       preserveSymlinks,
       externalRuntimeStyles: pluginOptions.externalRuntimeStyles,
       _enableHmr: !!pluginOptions.templateUpdates,
+      supportTestBed: !!pluginOptions.includeTestMetadata,
     };
   };
 }

--- a/packages/angular/build/src/tools/esbuild/compiler-plugin-options.ts
+++ b/packages/angular/build/src/tools/esbuild/compiler-plugin-options.ts
@@ -27,6 +27,7 @@ export function createCompilerPluginOptions(
     jit,
     externalRuntimeStyles,
     instrumentForCoverage,
+    optimizationOptions,
   } = options;
   const incremental = !!options.watch;
 
@@ -43,5 +44,6 @@ export function createCompilerPluginOptions(
     externalRuntimeStyles,
     instrumentForCoverage,
     templateUpdates,
+    includeTestMetadata: !optimizationOptions.scripts,
   };
 }


### PR DESCRIPTION
To support the usage of AOT with unit tests, development builds of applications will now include injected calls to the internal Angular `setClassMetadata` function. These calls add metadata to each component that can be leveraged by the `TestBed` to override component information.