### PR TITLE
fix(@schematics/angular): set explicit type in library schematic

### DIFF
--- a/packages/schematics/angular/library/index.ts
+++ b/packages/schematics/angular/library/index.ts
@@ -181,6 +181,10 @@ export default function (options: LibraryOptions): Rule {
         export: true,
         standalone: options.standalone,
         project: packageName,
+        // Explicitly set an empty `type` since it doesn't necessarily make sense in a library.
+        // This also ensures that the generated files are valid even if the `component` schematic
+        // inherits its `type` from the workspace.
+        type: '',
       }),
       (_tree: Tree, context: SchematicContext) => {
         if (!options.skipPackageJson && !options.skipInstall) {


### PR DESCRIPTION
Explicitly sets an empty `type` when the `library` calls into the `component` schematic for a few reasons:
1. The `type` for classes mostly makes sense in an application contenxt. E.g. libraries are unlikely to have guards.
2. The generated component is there primarily as an example and library authors are likely to either delete it or modify it to match their expected public API.
3. It ensures that the generated files remain correct if the `component` schematic ends up inheriting the `type` from the workspace.
