### PR TITLE
fix(@angular/build): skip normalization of relative externals

### DIFF
--- a/packages/angular/build/src/builders/application/options.ts
+++ b/packages/angular/build/src/builders/application/options.ts
@@ -707,7 +707,14 @@ function normalizeExternals(value: string[] | undefined): string[] | undefined {
     return undefined;
   }
 
-  return [...new Set(value.map((d) => (d.endsWith('/*') ? d.slice(0, -2) : d)))];
+  return [
+    ...new Set(
+      value.map((d) =>
+        // remove "/*" wildcard in the end if provided string is not path-like
+        d.endsWith('/*') && !/^\.{0,2}\//.test(d) ? d.slice(0, -2) : d,
+      ),
+    ),
+  ];
 }
 
 async function findFrameworkVersion(projectRoot: string): Promise<string> {


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
In this PR https://github.com/angular/angular-cli/pull/29753 there was a regression that now prevents corrent handling of external local dependencies. In my case the configuration for the build target looks like this `"externalDependencies": ["/assets/js/*"]`. This ensures that all scripts in the given folder are marked as external. 

With the change in the PR mentioned above this no longer works. To bring back the old behavior I'm adding an extra condition to check whether provided dependency is indeed a package name or a relative/absolute path.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the new behavior that. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
