### PR TITLE
build: remove now unneeded platform-server package extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,11 +167,6 @@
         "peerDependencies": {
           "protobufjs": "*"
         }
-      },
-      "@angular/platform-server": {
-        "peerDependencies": {
-          "rxjs": "*"
-        }
       }
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   typescript: 5.8.3
   '@angular/build': workspace:*
 
-packageExtensionsChecksum: ea5f588691095a73da0f9364791a5f26
+packageExtensionsChecksum: d67b1f07b351844d00c57cbace376860
 
 importers:
 


### PR DESCRIPTION
The `@angular/platform-server` package has been updated to correctly include a peer dependency on `rxjs` and no longer requires a custom package extension defined.