### PR TITLE
fix(@angular/build): properly resolve transitive external dependencies in vite-dev-server

### DIFF
--- a/packages/angular/build/src/builders/dev-server/vite-server.ts
+++ b/packages/angular/build/src/builders/dev-server/vite-server.ts
@@ -347,8 +347,9 @@ export async function* serveWithVite(
       externalMetadata.implicitServer.length = 0;
       externalMetadata.implicitBrowser.length = 0;
 
-      externalMetadata.explicitBrowser.push(...explicit);
-      externalMetadata.explicitServer.push(...explicit, ...builtinModules);
+      const externalDeps = browserOptions.externalDependencies ?? [];
+      externalMetadata.explicitBrowser.push(...explicit, ...externalDeps);
+      externalMetadata.explicitServer.push(...explicit, ...externalDeps, ...builtinModules);
       externalMetadata.implicitServer.push(...implicitServerFiltered);
       externalMetadata.implicitBrowser.push(...implicitBrowserFiltered);
 


### PR DESCRIPTION


This fix ensures that transitive external dependencies are correctly recognized and excluded during development builds with the Vite dev server. Previously, some dependencies were mistakenly bundled.

Closes #30048