### PR TITLE
test: remove bundle budget from JIT production E2E test

### DIFF
--- a/tests/legacy-cli/e2e/tests/build/jit-prod.ts
+++ b/tests/legacy-cli/e2e/tests/build/jit-prod.ts
@@ -7,7 +7,12 @@ export default async function () {
   await updateJsonFile('angular.json', (configJson) => {
     const appArchitect = configJson.projects['test-project'].architect;
     appArchitect.build.configurations['production'].aot = false;
+
+    // JIT applications have significantly larger sizes
+    appArchitect.build.configurations['production'].budgets = [];
+
     if (!getGlobalVariable('argv')['esbuild']) {
+      // The build optimizer option does not exist with the application build system
       appArchitect.build.configurations['production'].buildOptimizer = false;
     }
   });


### PR DESCRIPTION
Applications built with JIT will be significantly larger due to both the need to bundle the Angular compiler and the extra metadata that must be retained for each Angular construct. The initial bundle budget in new applications is specified for an AOT application and may not pass if used with JIT.