### PR TITLE
refactor: add missing peer depedency on `@angular/core` and `tslib`

### DIFF
--- a/packages/angular/build/package.json
+++ b/packages/angular/build/package.json
@@ -57,6 +57,7 @@
     "rxjs": "7.8.2"
   },
   "peerDependencies": {
+    "@angular/core": "0.0.0-ANGULAR-FW-PEER-DEP",
     "@angular/compiler": "0.0.0-ANGULAR-FW-PEER-DEP",
     "@angular/compiler-cli": "0.0.0-ANGULAR-FW-PEER-DEP",
     "@angular/localize": "0.0.0-ANGULAR-FW-PEER-DEP",
@@ -69,9 +70,13 @@
     "ng-packagr": "0.0.0-NG-PACKAGR-PEER-DEP",
     "postcss": "^8.4.0",
     "tailwindcss": "^2.0.0 || ^3.0.0 || ^4.0.0",
+    "tslib": "^2.3.0",
     "typescript": ">=5.8 <5.9"
   },
   "peerDependenciesMeta": {
+    "@angular/core": {
+      "optional": true
+    },
     "@angular/localize": {
       "optional": true
     },

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -73,6 +73,7 @@
     "undici": "7.7.0"
   },
   "peerDependencies": {
+    "@angular/core": "0.0.0-ANGULAR-FW-PEER-DEP",
     "@angular/compiler-cli": "0.0.0-ANGULAR-FW-PEER-DEP",
     "@angular/localize": "0.0.0-ANGULAR-FW-PEER-DEP",
     "@angular/platform-browser": "0.0.0-ANGULAR-FW-PEER-DEP",
@@ -90,6 +91,9 @@
     "typescript": ">=5.8 <5.9"
   },
   "peerDependenciesMeta": {
+    "@angular/core": {
+      "optional": true
+    },
     "@angular/localize": {
       "optional": true
     },

--- a/tests/legacy-cli/e2e/tests/misc/dedupe-duplicate-modules.ts
+++ b/tests/legacy-cli/e2e/tests/misc/dedupe-duplicate-modules.ts
@@ -11,7 +11,7 @@ export default async function () {
     await updateJsonFile('package.json', (json) => {
       json.dependencies = {
         ...json.dependencies,
-        'tslib': '2.0.0',
+        'tslib': '^2.0.0',
         'tslib-1': 'npm:tslib@1.13.0',
         'tslib-1-copy': 'npm:tslib@1.13.0',
       };
@@ -56,7 +56,7 @@ export default async function () {
       throw new Error('Expected stderr to contain [DedupeModuleResolvePlugin] log for tslib.');
     }
 
-    await expectFileToMatch(outFile, './node_modules/tslib/tslib.es6.js');
+    await expectFileToMatch(outFile, './node_modules/tslib/tslib.es6.mjs');
   } finally {
     await rimraf('node_modules/tslib');
     await gitClean();


### PR DESCRIPTION
This is required  to support strict mode in pnpm.

Closes #30068