### PR TITLE
fix(@angular/build): disable TypeScript `composite` option with Angular compiler

### DIFF
--- a/packages/angular/build/src/tools/esbuild/angular/compiler-plugin.ts
+++ b/packages/angular/build/src/tools/esbuild/angular/compiler-plugin.ts
@@ -705,6 +705,7 @@ function createCompilerOptionsTransformer(
     return {
       ...compilerOptions,
       noEmitOnError: false,
+      composite: false,
       inlineSources: !!pluginOptions.sourcemap,
       inlineSourceMap: !!pluginOptions.sourcemap,
       sourceMap: undefined,


### PR DESCRIPTION
The Angular compiler does not directly support the `composite` option within a referenced `tsconfig` file. If this option is enabled, the Angular compiler will crash due to the Angular compiler not leveraging the TypeScript BuilderProgram infrastructure. Since the Angular compiler is not aware of composite projects nor project references, the `composite` option is disabled when options are passed to the Angular compiler. This has no effect on non- Angular related usages of the `tsconfig`.