### PR TITLE
fix(@ngtools/webpack): disable TypeScript composite option with Angular compiler

### DIFF
--- a/packages/ngtools/webpack/src/ivy/plugin.ts
+++ b/packages/ngtools/webpack/src/ivy/plugin.ts
@@ -410,6 +410,7 @@ export class AngularWebpackPlugin {
       this.pluginOptions.tsconfig,
       this.pluginOptions.compilerOptions,
     );
+    compilerOptions.composite = false;
     compilerOptions.noEmitOnError = false;
     compilerOptions.suppressOutputPathCheck = true;
     compilerOptions.outDir = undefined;


### PR DESCRIPTION
The Angular compiler does not directly support the `composite` option within a referenced `tsconfig` file. If this option is enabled, the Angular compiler will crash due to the Angular compiler not leveraging the TypeScript BuilderProgram infrastructure. Since the Angular compiler is not aware of composite projects nor project references, the `composite` option is disabled when options are passed to the Angular compiler. This has no effect on non- Angular related usages of the `tsconfig`.