### PR TITLE
docs: release notes for the v18.2.18 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+<a name="18.2.18"></a>
+
+# 18.2.18 (2025-04-09)
+
+### @angular/build
+
+| Commit                                                                                              | Type | Description           |
+| --------------------------------------------------------------------------------------------------- | ---- | --------------------- |
+| [4245ca7b4](https://github.com/angular/angular-cli/commit/4245ca7b434e0aa859c805c459ce50238601b940) | fix  | update vite to 5.4.17 |
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="17.3.16"></a>
 
 # 17.3.16 (2025-04-09)


### PR DESCRIPTION
Cherry-picks the changelog from the "18.2.x" branch to the next branch (main).