### PR TITLE
fix(@angular/build): include `module` value check when adding custom conditions

### DIFF
--- a/packages/angular/build/src/tools/esbuild/angular/compiler-plugin.ts
+++ b/packages/angular/build/src/tools/esbuild/angular/compiler-plugin.ts
@@ -698,7 +698,10 @@ function createCompilerOptionsTransformer(
 
     // Synchronize custom resolve conditions.
     // Set if using the supported bundler resolution mode (bundler is the default in new projects)
-    if (compilerOptions.moduleResolution === 100 /* ModuleResolutionKind.Bundler */) {
+    if (
+      compilerOptions.moduleResolution === 100 /* ModuleResolutionKind.Bundler */ ||
+      compilerOptions.module === 200 /** ModuleKind.Preserve */
+    ) {
       compilerOptions.customConditions = customConditions;
     }
 


### PR DESCRIPTION

Previously, when setting `module: preserve`—which internally sets `moduleResolution` to `bundler` in TypeScript—custom conditions were not applied. This change ensures that custom conditions are also added when `module` is set to `preserve`.
