### PR TITLE
refactor(@angular/build): use `ngHmrMode` define for Vite prebundling

### DIFF
--- a/packages/angular/build/src/builders/dev-server/vite-server.ts
+++ b/packages/angular/build/src/builders/dev-server/vite-server.ts
@@ -439,7 +439,10 @@ export async function* serveWithVite(
         componentStyles,
         templateUpdates,
         browserOptions.loader as EsbuildLoaderOption | undefined,
-        browserOptions.define,
+        {
+          ...browserOptions.define,
+          'ngHmrMode': browserOptions.templateUpdates ? 'true' : 'false',
+        },
         extensions?.middleware,
         transformers?.indexHtml,
         thirdPartySourcemaps,


### PR DESCRIPTION
The internal `ngHmrMode` define value was previously available to application code and third-party modules that were not prebundled. To ensure that the value is propagated to all relevant code served by the development server, the `ngHmrMode` define is now used during the Vite prebundling phase. This allows any prebundled dependencies to also leverage the `ngHmrMode` value. The framework may, for instance, use the value to provide additional development time diagnostics.