### PR TITLE
fix(@angular/build): pass `preserveSymlinks` option to Karma esbuild builder

### DIFF
--- a/packages/angular/build/src/builders/karma/application_builder.ts
+++ b/packages/angular/build/src/builders/karma/application_builder.ts
@@ -405,6 +405,7 @@ async function initializeApplication(
     entryPoints,
     tsConfig: options.tsConfig,
     outputPath,
+    preserveSymlinks: options.preserveSymlinks,
     aot: options.aot,
     index: false,
     outputHashing: OutputHashing.None,


### PR DESCRIPTION

Ensure that several previously omitted options are correctly passed to the Karma esbuild builder, improving consistency and expected behavior.
