### PR TITLE
fix(@schematics/angular): relative tsconfig paths in references

### DIFF
--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -55,10 +55,10 @@ export default function (options: ApplicationOptions): Rule {
 
     return chain([
       addAppToWorkspaceFile(options, appDir, folderName),
-      addTsProjectReference(join(normalize(appDir), 'tsconfig.app.json')),
+      addTsProjectReference('./' + join(normalize(appDir), 'tsconfig.app.json')),
       options.skipTests
         ? noop()
-        : addTsProjectReference(join(normalize(appDir), 'tsconfig.spec.json')),
+        : addTsProjectReference('./' + join(normalize(appDir), 'tsconfig.spec.json')),
       options.standalone
         ? noop()
         : schematic('module', {

--- a/packages/schematics/angular/application/index_spec.ts
+++ b/packages/schematics/angular/application/index_spec.ts
@@ -115,10 +115,10 @@ describe('Application Schematic', () => {
 
     const { references } = readJsonFile(tree, '/tsconfig.json');
     expect(references).toContain(
-      jasmine.objectContaining({ path: 'projects/foo/tsconfig.app.json' }),
+      jasmine.objectContaining({ path: './projects/foo/tsconfig.app.json' }),
     );
     expect(references).toContain(
-      jasmine.objectContaining({ path: 'projects/foo/tsconfig.spec.json' }),
+      jasmine.objectContaining({ path: './projects/foo/tsconfig.spec.json' }),
     );
   });
 
@@ -131,10 +131,10 @@ describe('Application Schematic', () => {
 
     const { references } = readJsonFile(tree, '/tsconfig.json');
     expect(references).toContain(
-      jasmine.objectContaining({ path: 'projects/foo/tsconfig.app.json' }),
+      jasmine.objectContaining({ path: './projects/foo/tsconfig.app.json' }),
     );
     expect(references).not.toContain(
-      jasmine.objectContaining({ path: 'projects/foo/tsconfig.spec.json' }),
+      jasmine.objectContaining({ path: './projects/foo/tsconfig.spec.json' }),
     );
   });
 


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

We can't quickly navigate to the referenced paths as VSCode for example thinks they are modules (Failed tor resolve tsconfig.app.json as a module)

## What is the new behavior?

This makes them clickable for a quick navigation in IDEs

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
