### PR TITLE
fix(@schematics/angular): drop composite in tsconfig

### DIFF
--- a/packages/schematics/angular/application/files/common-files/tsconfig.app.json.template
+++ b/packages/schematics/angular/application/files/common-files/tsconfig.app.json.template
@@ -3,7 +3,6 @@
 {
   "extends": "<%= relativePathToWorkspaceRoot %>/tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "outDir": "<%= relativePathToWorkspaceRoot %>/out-tsc/app",
     "types": []
   },

--- a/packages/schematics/angular/application/files/common-files/tsconfig.spec.json.template
+++ b/packages/schematics/angular/application/files/common-files/tsconfig.spec.json.template
@@ -3,7 +3,6 @@
 {
   "extends": "<%= relativePathToWorkspaceRoot %>/tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "outDir": "<%= relativePathToWorkspaceRoot %>/out-tsc/spec",
     "types": [
       "jasmine"


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Based on this [TS discussion](https://github.com/microsoft/TypeScript/issues/60465), `composite` is in fact not necessary, the TS docs are just misleading.

## What is the new behavior?

This removes `composite` from the configs, as it was recently done in create-vue (see  https://github.com/vuejs/create-vue/pull/635).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
