### PR TITLE
fix(@angular-devkit/build-angular): update http-proxy-middleware to v3.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "express": "4.21.2",
     "fast-glob": "3.3.3",
     "http-proxy": "^1.18.1",
-    "http-proxy-middleware": "3.0.3",
+    "http-proxy-middleware": "3.0.5",
     "https-proxy-agent": "7.0.6",
     "husky": "9.1.7",
     "ini": "5.0.0",

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -31,7 +31,7 @@
     "css-loader": "7.1.2",
     "esbuild-wasm": "0.25.1",
     "fast-glob": "3.3.3",
-    "http-proxy-middleware": "3.0.3",
+    "http-proxy-middleware": "3.0.5",
     "istanbul-lib-instrument": "6.0.3",
     "jsonc-parser": "3.3.1",
     "karma-source-map-support": "1.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -279,8 +279,8 @@ importers:
         specifier: ^1.18.1
         version: 1.18.1(debug@4.4.0)
       http-proxy-middleware:
-        specifier: 3.0.3
-        version: 3.0.3
+        specifier: 3.0.5
+        version: 3.0.5
       https-proxy-agent:
         specifier: 7.0.6
         version: 7.0.6(supports-color@10.0.0)
@@ -831,8 +831,8 @@ importers:
         specifier: 3.3.3
         version: 3.3.3
       http-proxy-middleware:
-        specifier: 3.0.3
-        version: 3.0.3
+        specifier: 3.0.5
+        version: 3.0.5
       istanbul-lib-instrument:
         specifier: 6.0.3
         version: 6.0.3
@@ -5209,8 +5209,8 @@ packages:
       '@types/express':
         optional: true
 
-  http-proxy-middleware@3.0.3:
-    resolution: {integrity: sha512-usY0HG5nyDUwtqpiZdETNbmKtw3QQ1jwYFZ9wi5iHzX2BcILwQKtYDJPo7XHTsu5Z0B2Hj3W9NNnbd+AjFWjqg==}
+  http-proxy-middleware@3.0.5:
+    resolution: {integrity: sha512-GLZZm1X38BPY4lkXA01jhwxvDoOkkXqjgVyUzVxiEK4iuRu03PZoYHhHRwxnfhQMDuaxi3vVri0YgSro/1oWqg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   http-proxy@1.18.1:
@@ -13537,7 +13537,7 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  http-proxy-middleware@3.0.3:
+  http-proxy-middleware@3.0.5:
     dependencies:
       '@types/http-proxy': 1.17.16
       debug: 4.4.0(supports-color@10.0.0)


### PR DESCRIPTION

Addresses https://github.com/advisories/GHSA-4www-5p9h-95mh
