### PR TITLE
fix(@angular/ssr): return 302 when redirectTo is a function

### DIFF
--- a/packages/angular/ssr/src/routes/ng-routes.ts
+++ b/packages/angular/ssr/src/routes/ng-routes.ts
@@ -160,15 +160,20 @@ async function* handleRoute(options: {
         invokeGetPrerenderParams,
         includePrerenderFallbackRoutes,
       );
-    } else if (typeof redirectTo === 'string') {
+    } else if (redirectTo !== undefined) {
       if (metadata.status && !VALID_REDIRECT_RESPONSE_CODES.has(metadata.status)) {
         yield {
           error:
             `The '${metadata.status}' status code is not a valid redirect response code. ` +
             `Please use one of the following redirect response codes: ${[...VALID_REDIRECT_RESPONSE_CODES.values()].join(', ')}.`,
         };
+      } else if (typeof redirectTo === 'string') {
+        yield {
+          ...metadata,
+          redirectTo: resolveRedirectTo(metadata.route, redirectTo),
+        };
       } else {
-        yield { ...metadata, redirectTo: resolveRedirectTo(metadata.route, redirectTo) };
+        yield metadata;
       }
     } else {
       yield metadata;

--- a/packages/angular/ssr/test/app_spec.ts
+++ b/packages/angular/ssr/test/app_spec.ts
@@ -38,6 +38,11 @@ describe('AngularServerApp', () => {
         { path: 'redirect/relative', redirectTo: 'home' },
         { path: 'redirect/:param/relative', redirectTo: 'home' },
         { path: 'redirect/absolute', redirectTo: '/home' },
+        {
+          path: 'redirect-to-function',
+          redirectTo: () => 'home',
+          pathMatch: 'full',
+        },
       ],
       [
         {
@@ -106,25 +111,25 @@ describe('AngularServerApp', () => {
 
       it('should correctly handle top level redirects', async () => {
         const response = await app.handle(new Request('http://localhost/redirect'));
-        expect(response?.headers.get('location')).toContain('/home');
+        expect(response?.headers.get('location')).toBe('/home');
         expect(response?.status).toBe(302);
       });
 
       it('should correctly handle relative nested redirects', async () => {
         const response = await app.handle(new Request('http://localhost/redirect/relative'));
-        expect(response?.headers.get('location')).toContain('/redirect/home');
+        expect(response?.headers.get('location')).toBe('/redirect/home');
         expect(response?.status).toBe(302);
       });
 
       it('should correctly handle relative nested redirects with parameter', async () => {
         const response = await app.handle(new Request('http://localhost/redirect/param/relative'));
-        expect(response?.headers.get('location')).toContain('/redirect/param/home');
+        expect(response?.headers.get('location')).toBe('/redirect/param/home');
         expect(response?.status).toBe(302);
       });
 
       it('should correctly handle absolute nested redirects', async () => {
         const response = await app.handle(new Request('http://localhost/redirect/absolute'));
-        expect(response?.headers.get('location')).toContain('/home');
+        expect(response?.headers.get('location')).toBe('/home');
         expect(response?.status).toBe(302);
       });
 
@@ -251,6 +256,14 @@ describe('AngularServerApp', () => {
       it('should return null for a non-prerendered page', async () => {
         const response = await app.handle(new Request('http://localhost/unknown'));
         expect(response).toBeNull();
+      });
+    });
+
+    describe('SSR pages', () => {
+      it('returns a 302 status and redirects to the correct location when redirectTo is a function', async () => {
+        const response = await app.handle(new Request('http://localhost/redirect-to-function'));
+        expect(response?.headers.get('location')).toBe('/home');
+        expect(response?.status).toBe(302);
       });
     });
   });

--- a/packages/angular/ssr/test/routes/ng-routes_spec.ts
+++ b/packages/angular/ssr/test/routes/ng-routes_spec.ts
@@ -53,6 +53,16 @@ describe('extractRoutesAndCreateRouteTree', () => {
   });
 
   describe('route configuration validation', () => {
+    it('should error when a redirect uses an invalid status code', async () => {
+      setAngularAppTestingManifest(
+        [{ path: '', redirectTo: () => 'home', pathMatch: 'full' }],
+        [{ path: '', renderMode: RenderMode.Server, status: 404 }],
+      );
+
+      const { errors } = await extractRoutesAndCreateRouteTree({ url });
+      expect(errors[0]).toContain(`The '404' status code is not a valid redirect response code.`);
+    });
+
     it(`should error when a route starts with a '/'`, async () => {
       setAngularAppTestingManifest(
         [{ path: 'home', component: DummyComponent }],
@@ -88,7 +98,7 @@ describe('extractRoutesAndCreateRouteTree', () => {
       );
     });
 
-    it(`should not error when a catch-all route didn't match any Angular route.`, async () => {
+    it(`should not error when a catch-all route didn't match any Angular route`, async () => {
       setAngularAppTestingManifest(
         [{ path: 'home', component: DummyComponent }],
         [


### PR DESCRIPTION
Ensure the server returns a 302 status code and sets the correct 'Location' header when the redirectTo value is a function, aligning with expected HTTP redirect behavior.
