### PR TITLE
feat(@angular/build): add experimental vitest browser support to unit-testing

### DIFF
--- a/packages/angular/build/src/builders/unit-test/options.ts
+++ b/packages/angular/build/src/builders/unit-test/options.ts
@@ -36,7 +36,7 @@ export async function normalizeOptions(
   const buildTargetSpecifier = options.buildTarget ?? `::development`;
   const buildTarget = targetFromTargetString(buildTargetSpecifier, projectName, 'build');
 
-  const { codeCoverage, codeCoverageExclude, tsConfig, runner, reporters } = options;
+  const { codeCoverage, codeCoverageExclude, tsConfig, runner, reporters, browsers } = options;
 
   return {
     // Project/workspace information
@@ -53,6 +53,7 @@ export async function normalizeOptions(
     codeCoverageExclude,
     tsConfig,
     reporters,
+    browsers,
     // TODO: Implement watch support
     watch: false,
   };

--- a/packages/angular/build/src/builders/unit-test/schema.json
+++ b/packages/angular/build/src/builders/unit-test/schema.json
@@ -18,6 +18,14 @@
       "description": "The name of the test runner to use for test execution.",
       "enum": ["vitest"]
     },
+    "browsers": {
+      "description": "A list of browsers to use for test execution. If undefined, jsdom on Node.js will be used instead of a browser.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    },
     "include": {
       "type": "array",
       "items": {


### PR DESCRIPTION
The experimental `unit-test` builder now allows for enabling the experimental vitest browser testing support. A `browsers` option is now available that can list one or more browsers to use for test execution. If the `browsers` option is not specified (the default), then `jsdom` will be used to execute the tests without a browser. To use the browser support, either `playwright` or `webdriverio` must be installed within the project. On startup, the testing process will automatically attempt to discover the browser provider. The browser names present in the `browsers` option must be specified based on the installed provider. Each may have differing names for some browsers.