### PR TITLE
fix(@angular/build): ensure `com.chrome.devtools.json` is consistently served after initial run

### DIFF
--- a/packages/angular/build/src/tools/vite/middlewares/chrome-devtools-middleware.ts
+++ b/packages/angular/build/src/tools/vite/middlewares/chrome-devtools-middleware.ts
@@ -38,7 +38,8 @@ export function createChromeDevtoolsMiddleware(
     if (!devtoolsConfig) {
       // We store the UUID and re-use it to ensure Chrome does not repeatedly ask for permissions when restarting the dev server.
       try {
-        const devtoolsConfig = readFileSync(devtoolsConfigPath, 'utf-8');
+        devtoolsConfig = readFileSync(devtoolsConfigPath, 'utf-8');
+
         const devtoolsConfigJson: DevToolsJson = JSON.parse(devtoolsConfig);
         assert.equal(projectRoot, devtoolsConfigJson?.workspace.root);
       } catch {


### PR DESCRIPTION

Previously, `com.chrome.devtools.json` was generated and served correctly on the first run, but subsequent `ng serve` runs failed to serve the file unless the Angular cache was cleared. This change addresses the inconsistency.
