### PR TITLE
fix(@angular/build): perform testing module cleanup when using Vitest

### DIFF
--- a/packages/angular/build/src/builders/unit-test/builder.ts
+++ b/packages/angular/build/src/builders/unit-test/builder.ts
@@ -124,8 +124,14 @@ export async function* execute(
     loadContent: async () => {
       const contents: string[] = [
         // Initialize the Angular testing environment
-        `import { getTestBed } from '@angular/core/testing';`,
+        `import { getTestBed, ɵgetCleanupHook as getCleanupHook } from '@angular/core/testing';`,
         `import { BrowserTestingModule, platformBrowserTesting } from '@angular/platform-browser/testing';`,
+        `import { beforeEach, afterEach } from 'vitest';`,
+        '',
+        // Same as https://github.com/angular/angular/blob/05a03d3f975771bb59c7eefd37c01fa127ee2229/packages/core/testing/src/test_hooks.ts#L21-L29
+        `beforeEach(getCleanupHook(false));`,
+        `afterEach(getCleanupHook(true));`,
+        '',
         `getTestBed().initTestEnvironment(BrowserTestingModule, platformBrowserTesting(), {`,
         `  errorOnUnknownElements: true,`,
         `  errorOnUnknownProperties: true,`,


### PR DESCRIPTION
Ensure proper cleanup of the Angular testing module when running tests with Vitest.

Closes: #30186

---

Blocked on https://github.com/angular/angular/pull/61017 being released on NPM