### PR TITLE
fix(@schematics/angular): skip spec project reference for minimal ng new

### DIFF
--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -56,7 +56,7 @@ export default function (options: ApplicationOptions): Rule {
     return chain([
       addAppToWorkspaceFile(options, appDir, folderName),
       addTsProjectReference('./' + join(normalize(appDir), 'tsconfig.app.json')),
-      options.skipTests
+      options.skipTests || options.minimal
         ? noop()
         : addTsProjectReference('./' + join(normalize(appDir), 'tsconfig.spec.json')),
       options.standalone

--- a/packages/schematics/angular/application/index_spec.ts
+++ b/packages/schematics/angular/application/index_spec.ts
@@ -138,6 +138,22 @@ describe('Application Schematic', () => {
     );
   });
 
+  it('should not add spec project reference in the root tsconfig.json with "minimal" enabled', async () => {
+    const tree = await schematicRunner.runSchematic(
+      'application',
+      { ...defaultOptions, minimal: true },
+      workspaceTree,
+    );
+
+    const { references } = readJsonFile(tree, '/tsconfig.json');
+    expect(references).toContain(
+      jasmine.objectContaining({ path: './projects/foo/tsconfig.app.json' }),
+    );
+    expect(references).not.toContain(
+      jasmine.objectContaining({ path: './projects/foo/tsconfig.spec.json' }),
+    );
+  });
+
   it('should install npm dependencies when `skipInstall` is false', async () => {
     await schematicRunner.runSchematic(
       'application',


### PR DESCRIPTION
When generating a new project with `ng new` and the `minimal` option, a Typescript project reference to a `tsconfig.spec.json` should not be present since that file is not created with a minimal project.

Closes #30181