### PR TITLE
fix(@schematics/angular): remove explicit index option from new applications

### DIFF
--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -256,7 +256,6 @@ function addAppToWorkspaceFile(
         builder: Builders.BuildApplication,
         defaultConfiguration: 'production',
         options: {
-          index: `${sourceRoot}/index.html`,
           browser: `${sourceRoot}/main.ts`,
           polyfills: options.zoneless ? undefined : ['zone.js'],
           tsConfig: `${projectRoot}tsconfig.app.json`,

--- a/packages/schematics/angular/application/index_spec.ts
+++ b/packages/schematics/angular/application/index_spec.ts
@@ -330,7 +330,7 @@ describe('Application Schematic', () => {
       const prj = config.projects.foo;
       expect(prj.root).toEqual('');
       const buildOpt = prj.architect.build.options;
-      expect(buildOpt.index).toEqual('src/index.html');
+      expect(buildOpt.index).toBeUndefined();
       expect(buildOpt.browser).toEqual('src/main.ts');
       expect(buildOpt.assets).toEqual([{ 'glob': '**/*', 'input': 'public' }]);
       expect(buildOpt.polyfills).toEqual(['zone.js']);
@@ -421,7 +421,6 @@ describe('Application Schematic', () => {
       const project = config.projects.foo;
       expect(project.root).toEqual('foo');
       const buildOpt = project.architect.build.options;
-      expect(buildOpt.index).toEqual('foo/src/index.html');
       expect(buildOpt.browser).toEqual('foo/src/main.ts');
       expect(buildOpt.polyfills).toEqual(['zone.js']);
       expect(buildOpt.tsConfig).toEqual('foo/tsconfig.app.json');

--- a/tests/legacy-cli/e2e/initialize/500-create-project.ts
+++ b/tests/legacy-cli/e2e/initialize/500-create-project.ts
@@ -35,6 +35,7 @@ export default async function () {
           main: build.options.browser,
           browser: undefined,
           outputPath: 'dist/test-project/browser',
+          index: 'src/index.html',
         };
 
         build.configurations.development = {

--- a/tests/legacy-cli/e2e/tests/build/jit-ngmodule.ts
+++ b/tests/legacy-cli/e2e/tests/build/jit-ngmodule.ts
@@ -24,6 +24,7 @@ export default async function () {
         browser: undefined,
         buildOptimizer: false,
         outputPath: 'dist/test-project-two',
+        index: 'src/index.html',
       };
 
       build.configurations.development = {

--- a/tests/legacy-cli/e2e/tests/build/prerender/discover-routes-ngmodule.ts
+++ b/tests/legacy-cli/e2e/tests/build/prerender/discover-routes-ngmodule.ts
@@ -19,6 +19,7 @@ export default async function () {
         ...build.options,
         main: build.options.browser,
         browser: undefined,
+        index: 'src/index.html',
       };
 
       build.configurations.development = {

--- a/tests/legacy-cli/e2e/tests/build/rebuild-dot-dirname.ts
+++ b/tests/legacy-cli/e2e/tests/build/rebuild-dot-dirname.ts
@@ -34,6 +34,7 @@ export default async function () {
           main: build.options.browser,
           browser: undefined,
           outputPath: 'dist/subdirectory-test-project',
+          index: 'src/index.html',
         };
 
         build.configurations.development = {

--- a/tests/legacy-cli/e2e/tests/build/relative-sourcemap.ts
+++ b/tests/legacy-cli/e2e/tests/build/relative-sourcemap.ts
@@ -19,6 +19,7 @@ export default async function () {
         main: build.options.browser,
         browser: undefined,
         outputPath: 'dist/secondary-project',
+        index: 'src/index.html',
       };
 
       build.configurations.development = {

--- a/tests/legacy-cli/e2e/tests/build/server-rendering/express-engine-ngmodule.ts
+++ b/tests/legacy-cli/e2e/tests/build/server-rendering/express-engine-ngmodule.ts
@@ -32,6 +32,7 @@ export default async function () {
         ...build.options,
         main: build.options.browser,
         browser: undefined,
+        index: 'src/index.html',
       };
 
       build.configurations.development = {


### PR DESCRIPTION
With the index option now defaulting to `<project_source_root>/index.html` for the `application` build system, the explicit value present in new applications is no longer required. This removal further reduces the size of the `angular.json` file for new projects.
