### PR TITLE
ci: setup bazel repository caching for windows jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Initialize environment
         uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@8ca74b8a897d28f4735043c745693a706ff5ca81
+      - name: Setup Bazel
+        uses: angular/dev-infra/github-actions/bazel/setup@8ca74b8a897d28f4735043c745693a706ff5ca81
       - name: Install node modules
         run: pnpm install --frozen-lockfile
       - name: Generate JSON schema types
@@ -109,6 +111,8 @@ jobs:
     steps:
       - name: Initialize environment
         uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@8ca74b8a897d28f4735043c745693a706ff5ca81
+      - name: Setup Bazel
+        uses: angular/dev-infra/github-actions/bazel/setup@8ca74b8a897d28f4735043c745693a706ff5ca81
       - name: Setup Bazel RBE
         uses: angular/dev-infra/github-actions/bazel/configure-remote@8ca74b8a897d28f4735043c745693a706ff5ca81
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -35,6 +35,8 @@ jobs:
     steps:
       - name: Initialize environment
         uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@8ca74b8a897d28f4735043c745693a706ff5ca81
+      - name: Setup Bazel
+        uses: angular/dev-infra/github-actions/bazel/setup@8ca74b8a897d28f4735043c745693a706ff5ca81
       - name: Setup ESLint Caching
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
@@ -131,6 +133,8 @@ jobs:
     steps:
       - name: Initialize environment
         uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@8ca74b8a897d28f4735043c745693a706ff5ca81
+      - name: Setup Bazel
+        uses: angular/dev-infra/github-actions/bazel/setup@8ca74b8a897d28f4735043c745693a706ff5ca81
       - name: Setup Bazel RBE
         uses: angular/dev-infra/github-actions/bazel/configure-remote@8ca74b8a897d28f4735043c745693a706ff5ca81
         with:


### PR DESCRIPTION
This should avoid extra downloads on every run, mitigating instabilities from e.g. GitHub downloads that are currently a bit unstable.
