### PR TITLE
fix(@angular-devkit/build-angular): update http-proxy-middleware to v2.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "express": "4.18.3",
     "fast-glob": "3.3.2",
     "http-proxy": "^1.18.1",
-    "http-proxy-middleware": "2.0.7",
+    "http-proxy-middleware": "2.0.8",
     "https-proxy-agent": "7.0.4",
     "husky": "9.0.11",
     "ini": "4.1.2",

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -33,7 +33,7 @@
     "esbuild-wasm": "0.20.1",
     "fast-glob": "3.3.2",
     "https-proxy-agent": "7.0.4",
-    "http-proxy-middleware": "2.0.7",
+    "http-proxy-middleware": "2.0.8",
     "inquirer": "9.2.15",
     "jsonc-parser": "3.2.1",
     "karma-source-map-support": "1.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9144,10 +9144,10 @@ http-proxy-middleware@2.0.6, http-proxy-middleware@^2.0.3:
     is-plain-obj "^3.0.0"
     micromatch "^4.0.2"
 
-http-proxy-middleware@2.0.7:
-  version "2.0.7"
-  resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-2.0.7.tgz#915f236d92ae98ef48278a95dedf17e991936ec6"
-  integrity sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==
+http-proxy-middleware@2.0.8:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-2.0.8.tgz#0c3cc655df8213caa51a365f2b69aff377f7bfbf"
+  integrity sha512-/iazaeFPmL8KLA6QB7DFAU4O5j+9y/TA0D019MbLtPuFI56VK4BXFzM6j6QS9oGpScy8IIDH4S2LHv3zg/63Bw==
   dependencies:
     "@types/http-proxy" "^1.17.8"
     http-proxy "^1.18.1"


### PR DESCRIPTION


Addresses https://github.com/advisories/GHSA-4www-5p9h-95mh

