### PR TITLE
refactor(@angular-devkit/core): additional isolated declarations cleanup

### DIFF
--- a/goldens/public-api/angular_devkit/core/index.api.md
+++ b/goldens/public-api/angular_devkit/core/index.api.md
@@ -389,7 +389,7 @@ interface JsonVisitor {
 
 // @public (undocumented)
 class LevelCapLogger extends LevelTransformLogger {
-    constructor(name: string, parent: (Logger | null) | undefined, levelCap: LogLevel);
+    constructor(name: string, parent: Logger | null, levelCap: LogLevel);
     // (undocumented)
     readonly levelCap: LogLevel;
     // (undocumented)
@@ -406,7 +406,7 @@ class LevelCapLogger extends LevelTransformLogger {
 
 // @public (undocumented)
 class LevelTransformLogger extends Logger {
-    constructor(name: string, parent: (Logger | null) | undefined, levelTransform: (level: LogLevel) => LogLevel);
+    constructor(name: string, parent: Logger | null, levelTransform: (level: LogLevel) => LogLevel);
     // (undocumented)
     createChild(name: string): Logger;
     // (undocumented)
@@ -556,7 +556,7 @@ function parseJsonPointer(pointer: JsonPointer): string[];
 // @public (undocumented)
 export class PartiallyOrderedSet<T> implements Set<T> {
     // (undocumented)
-    [Symbol.iterator](): Generator<T, undefined, unknown>;
+    [Symbol.iterator](): IterableIterator<T, undefined, unknown>;
     // (undocumented)
     get [Symbol.toStringTag](): 'Set';
     // (undocumented)
@@ -941,29 +941,9 @@ class SimpleMemoryHost implements Host<{}> {
     // (undocumented)
     protected _list(path: Path): PathFragment[];
     // (undocumented)
-    protected _newDirStats(): {
-        inspect(): string;
-        isFile(): boolean;
-        isDirectory(): boolean;
-        size: number;
-        atime: Date;
-        ctime: Date;
-        mtime: Date;
-        birthtime: Date;
-        content: null;
-    };
+    protected _newDirStats(): Stats<SimpleMemoryHostStats>;
     // (undocumented)
-    protected _newFileStats(content: FileBuffer, oldStats?: Stats<SimpleMemoryHostStats>): {
-        inspect(): string;
-        isFile(): boolean;
-        isDirectory(): boolean;
-        size: number;
-        atime: Date;
-        ctime: Date;
-        mtime: Date;
-        birthtime: Date;
-        content: ArrayBuffer;
-    };
+    protected _newFileStats(content: FileBuffer, oldStats?: Stats<SimpleMemoryHostStats>): Stats<SimpleMemoryHostStats>;
     // (undocumented)
     read(path: Path): Observable<FileBuffer>;
     // (undocumented)
@@ -995,6 +975,8 @@ class SimpleMemoryHost implements Host<{}> {
 interface SimpleMemoryHostStats {
     // (undocumented)
     readonly content: FileBuffer | null;
+    // (undocumented)
+    inspect(): string;
 }
 
 // @public (undocumented)

--- a/packages/angular_devkit/core/src/logger/level.ts
+++ b/packages/angular_devkit/core/src/logger/level.ts
@@ -12,7 +12,7 @@ import { LogLevel, Logger } from './logger';
 export class LevelTransformLogger extends Logger {
   constructor(
     public override readonly name: string,
-    public override readonly parent: Logger | null = null,
+    public override readonly parent: Logger | null,
     public readonly levelTransform: (level: LogLevel) => LogLevel,
   ) {
     super(name, parent);
@@ -38,7 +38,7 @@ export class LevelCapLogger extends LevelTransformLogger {
 
   constructor(
     public override readonly name: string,
-    public override readonly parent: Logger | null = null,
+    public override readonly parent: Logger | null,
     public readonly levelCap: LogLevel,
   ) {
     super(name, parent, (level: LogLevel) => {

--- a/packages/angular_devkit/core/src/utils/partially-ordered-set.ts
+++ b/packages/angular_devkit/core/src/utils/partially-ordered-set.ts
@@ -22,7 +22,7 @@ export class CircularDependencyFoundException extends BaseException {
 export class PartiallyOrderedSet<T> implements Set<T> {
   private _items = new Map<T, Set<T>>();
 
-  protected _checkCircularDependencies(item: T, deps: Set<T>) {
+  protected _checkCircularDependencies(item: T, deps: Set<T>): void {
     if (deps.has(item)) {
       throw new CircularDependencyFoundException();
     }
@@ -30,13 +30,13 @@ export class PartiallyOrderedSet<T> implements Set<T> {
     deps.forEach((dep) => this._checkCircularDependencies(item, this._items.get(dep) || new Set()));
   }
 
-  clear() {
+  clear(): void {
     this._items.clear();
   }
-  has(item: T) {
+  has(item: T): boolean {
     return this._items.has(item);
   }
-  get size() {
+  get size(): number {
     return this._items.size;
   }
   forEach(
@@ -71,7 +71,7 @@ export class PartiallyOrderedSet<T> implements Set<T> {
     return this[Symbol.iterator]();
   }
 
-  add(item: T, deps: Set<T> | T[] = new Set()) {
+  add(item: T, deps: Set<T> | T[] = new Set()): this {
     if (Array.isArray(deps)) {
       deps = new Set(deps);
     }
@@ -119,7 +119,7 @@ export class PartiallyOrderedSet<T> implements Set<T> {
     return this;
   }
 
-  delete(item: T) {
+  delete(item: T): boolean {
     if (!this._items.has(item)) {
       return false;
     }
@@ -130,7 +130,7 @@ export class PartiallyOrderedSet<T> implements Set<T> {
     return this._items.delete(item);
   }
 
-  *[Symbol.iterator]() {
+  *[Symbol.iterator](): IterableIterator<T, undefined, unknown> {
     const copy: Map<T, Set<T>> = new Map(this._items);
 
     for (const [key, value] of copy.entries()) {

--- a/packages/angular_devkit/core/src/virtual-fs/host/memory.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/host/memory.ts
@@ -36,15 +36,16 @@ import {
 
 export interface SimpleMemoryHostStats {
   readonly content: FileBuffer | null;
+  inspect(): string;
 }
 
 export class SimpleMemoryHost implements Host<{}> {
-  protected _cache = new Map<Path, Stats<SimpleMemoryHostStats>>();
+  protected _cache: Map<Path, Stats<SimpleMemoryHostStats>> = new Map();
   private _watchers = new Map<Path, [HostWatchOptions, Subject<HostWatchEvent>][]>();
 
-  protected _newDirStats() {
+  protected _newDirStats(): Stats<SimpleMemoryHostStats> {
     return {
-      inspect() {
+      inspect(): string {
         return '<Directory>';
       },
 
@@ -64,7 +65,10 @@ export class SimpleMemoryHost implements Host<{}> {
       content: null,
     };
   }
-  protected _newFileStats(content: FileBuffer, oldStats?: Stats<SimpleMemoryHostStats>) {
+  protected _newFileStats(
+    content: FileBuffer,
+    oldStats?: Stats<SimpleMemoryHostStats>,
+  ): Stats<SimpleMemoryHostStats> {
     return {
       inspect() {
         return `<File size(${content.byteLength})>`;

--- a/packages/angular_devkit/core/src/virtual-fs/host/pattern.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/host/pattern.ts
@@ -15,7 +15,7 @@ export type ReplacementFunction = (path: Path) => Path;
 /**
  */
 export class PatternMatchingHost<StatsT extends object = {}> extends ResolverHost<StatsT> {
-  protected _patterns = new Map<RegExp, ReplacementFunction>();
+  protected _patterns: Map<RegExp, ReplacementFunction> = new Map();
 
   addPattern(pattern: string | string[], replacementFn: ReplacementFunction): void {
     const patterns = Array.isArray(pattern) ? pattern : [pattern];

--- a/packages/angular_devkit/core/src/virtual-fs/host/record.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/host/record.ts
@@ -68,11 +68,11 @@ export type CordHostRecord = CordHostCreate | CordHostOverwrite | CordHostRename
  * the create/overwrite records IIF the files does/doesn't already exist.
  */
 export class CordHost extends SimpleMemoryHost {
-  protected _filesToCreate = new Set<Path>();
-  protected _filesToRename = new Map<Path, Path>();
-  protected _filesToRenameRevert = new Map<Path, Path>();
-  protected _filesToDelete = new Set<Path>();
-  protected _filesToOverwrite = new Set<Path>();
+  protected _filesToCreate: Set<Path> = new Set();
+  protected _filesToRename: Map<Path, Path> = new Map();
+  protected _filesToRenameRevert: Map<Path, Path> = new Map();
+  protected _filesToDelete: Set<Path> = new Set();
+  protected _filesToOverwrite: Set<Path> = new Set();
 
   constructor(protected _back: ReadonlyHost) {
     super();

--- a/packages/angular_devkit/core/src/virtual-fs/path.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/path.ts
@@ -41,15 +41,13 @@ export type PathFragment = Path & {
 
 /**
  * The Separator for normalized path.
- * @type {Path}
  */
-export const NormalizedSep = '/' as Path;
+export const NormalizedSep: Path = '/' as Path;
 
 /**
  * The root of a normalized path.
- * @type {Path}
  */
-export const NormalizedRoot = NormalizedSep;
+export const NormalizedRoot: Path = NormalizedSep;
 
 /**
  * Split a path into multiple path fragments. Each fragments except the last one will end with
@@ -192,7 +190,7 @@ let normalizedCache = new Map<string, Path>();
  * Reset the cache. This is only useful for testing.
  * @private
  */
-export function resetNormalizeCache() {
+export function resetNormalizeCache(): void {
   normalizedCache = new Map<string, Path>();
 }
 

--- a/packages/angular_devkit/core/src/workspace/json/metadata.ts
+++ b/packages/angular_devkit/core/src/workspace/json/metadata.ts
@@ -35,7 +35,7 @@ function escapeKey(key: string): string | number {
 }
 
 export class JsonWorkspaceMetadata {
-  readonly changes = new Map<string, JsonChange>();
+  readonly changes: Map<string, JsonChange> = new Map();
 
   hasLegacyTargetsName = true;
 


### PR DESCRIPTION
To eventually support the use of the TypeScript `isolatedDeclarations` option, additional type adjustments have been made to code within the `@angular-devkit/core` package. While this is not yet comprehensive, it significantly reduces the amount of build errors with the `isolatedDeclarations` option enabled.