### PR TITLE
fix(@schematics/angular): avoid empty polyfill option for new zoneless application

### DIFF
--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -258,7 +258,7 @@ function addAppToWorkspaceFile(
         options: {
           index: `${sourceRoot}/index.html`,
           browser: `${sourceRoot}/main.ts`,
-          polyfills: options.zoneless ? [] : ['zone.js'],
+          polyfills: options.zoneless ? undefined : ['zone.js'],
           tsConfig: `${projectRoot}tsconfig.app.json`,
           inlineStyleLanguage,
           assets: [{ 'glob': '**/*', 'input': `${projectRoot}public` }],
@@ -297,7 +297,7 @@ function addAppToWorkspaceFile(
         : {
             builder: Builders.BuildKarma,
             options: {
-              polyfills: options.zoneless ? [] : ['zone.js', 'zone.js/testing'],
+              polyfills: options.zoneless ? undefined : ['zone.js', 'zone.js/testing'],
               tsConfig: `${projectRoot}tsconfig.spec.json`,
               inlineStyleLanguage,
               assets: [{ 'glob': '**/*', 'input': `${projectRoot}public` }],


### PR DESCRIPTION
To reduce the size of the initial `angular.json` for applications, newly generated zoneless applications will no longer contain an explicit empty `polyfills` option. The option can still be added and is available for use if needed by an application but the empty array value will no longer be present when generating a zoneless application.
This has no effect for applications using Zone.js (default).