### PR TITLE
refactor(@angular-devkit/schematics): add explicit return types to functions

### DIFF
--- a/packages/angular_devkit/schematics/src/engine/engine.ts
+++ b/packages/angular_devkit/schematics/src/engine/engine.ts
@@ -90,10 +90,10 @@ export class CollectionImpl<CollectionT extends object, SchematicT extends objec
     public readonly baseDescriptions?: Array<CollectionDescription<CollectionT>>,
   ) {}
 
-  get description() {
+  get description(): CollectionDescription<CollectionT> {
     return this._description;
   }
-  get name() {
+  get name(): string {
     return this.description.name || '<unknown>';
   }
 
@@ -183,10 +183,10 @@ export class SchematicEngine<CollectionT extends object, SchematicT extends obje
     protected _workflow?: Workflow,
   ) {}
 
-  get workflow() {
+  get workflow(): Workflow | null {
     return this._workflow || null;
   }
-  get defaultMergeStrategy() {
+  get defaultMergeStrategy(): MergeStrategy {
     return this._host.defaultMergeStrategy || MergeStrategy.Default;
   }
 

--- a/packages/angular_devkit/schematics/src/engine/schematic.ts
+++ b/packages/angular_devkit/schematics/src/engine/schematic.ts
@@ -41,10 +41,10 @@ export class SchematicImpl<CollectionT extends object, SchematicT extends object
     }
   }
 
-  get description() {
+  get description(): SchematicDescription<CollectionT, SchematicT> {
     return this._description;
   }
-  get collection() {
+  get collection(): Collection<CollectionT, SchematicT> {
     return this._collection;
   }
 

--- a/packages/angular_devkit/schematics/src/sink/host.ts
+++ b/packages/angular_devkit/schematics/src/sink/host.ts
@@ -86,7 +86,7 @@ export class HostSink extends SimpleSinkBase {
     return EMPTY;
   }
 
-  _done() {
+  _done(): Observable<void> {
     // Really commit everything to the actual filesystem.
     return concatObservables(
       observableFrom([...this._filesToDelete.values()]).pipe(

--- a/packages/angular_devkit/schematics/src/tree/action.ts
+++ b/packages/angular_devkit/schematics/src/tree/action.ts
@@ -27,7 +27,7 @@ let _id = 1;
 export class ActionList implements Iterable<Action> {
   private _actions: Action[] = [];
 
-  protected _action(action: Partial<Action>) {
+  protected _action(action: Partial<Action>): void {
     this._actions.push({
       ...(action as Action),
       id: _id++,
@@ -35,20 +35,20 @@ export class ActionList implements Iterable<Action> {
     });
   }
 
-  create(path: Path, content: Buffer) {
+  create(path: Path, content: Buffer): void {
     this._action({ kind: 'c', path, content });
   }
-  overwrite(path: Path, content: Buffer) {
+  overwrite(path: Path, content: Buffer): void {
     this._action({ kind: 'o', path, content });
   }
-  rename(path: Path, to: Path) {
+  rename(path: Path, to: Path): void {
     this._action({ kind: 'r', path, to });
   }
-  delete(path: Path) {
+  delete(path: Path): void {
     this._action({ kind: 'd', path });
   }
 
-  optimize() {
+  optimize(): void {
     const toCreate = new Map<Path, Buffer>();
     const toRename = new Map<Path, Path>();
     const toOverwrite = new Map<Path, Buffer>();
@@ -122,13 +122,13 @@ export class ActionList implements Iterable<Action> {
     });
   }
 
-  push(action: Action) {
+  push(action: Action): void {
     this._actions.push(action);
   }
-  get(i: number) {
+  get(i: number): Action {
     return this._actions[i];
   }
-  has(action: Action) {
+  has(action: Action): boolean {
     for (let i = 0; i < this._actions.length; i++) {
       const a = this._actions[i];
       if (a.id == action.id) {
@@ -144,10 +144,10 @@ export class ActionList implements Iterable<Action> {
   find(predicate: (value: Action) => boolean): Action | null {
     return this._actions.find(predicate) || null;
   }
-  forEach(fn: (value: Action, index: number, array: Action[]) => void, thisArg?: {}) {
+  forEach(fn: (value: Action, index: number, array: Action[]) => void, thisArg?: {}): void {
     this._actions.forEach(fn, thisArg);
   }
-  get length() {
+  get length(): number {
     return this._actions.length;
   }
   [Symbol.iterator](): IterableIterator<Action> {

--- a/packages/angular_devkit/schematics/src/tree/entry.ts
+++ b/packages/angular_devkit/schematics/src/tree/entry.ts
@@ -15,10 +15,10 @@ export class SimpleFileEntry implements FileEntry {
     private _content: Buffer,
   ) {}
 
-  get path() {
+  get path(): Path {
     return this._path;
   }
-  get content() {
+  get content(): Buffer {
     return this._content;
   }
 }
@@ -31,10 +31,10 @@ export class LazyFileEntry implements FileEntry {
     private _load: (path?: Path) => Buffer,
   ) {}
 
-  get path() {
+  get path(): Path {
     return this._path;
   }
-  get content() {
+  get content(): Buffer {
     return this._content || (this._content = this._load(this._path));
   }
 }

--- a/packages/angular_devkit/schematics/src/tree/host-tree.ts
+++ b/packages/angular_devkit/schematics/src/tree/host-tree.ts
@@ -107,7 +107,7 @@ export class HostTree implements Tree {
 
   private _dirCache = new Map<Path, HostDirEntry>();
 
-  [TreeSymbol]() {
+  [TreeSymbol](): this {
     return this;
   }
 
@@ -132,19 +132,19 @@ export class HostTree implements Tree {
     return normalize('/' + path);
   }
 
-  protected _willCreate(path: Path) {
+  protected _willCreate(path: Path): boolean {
     return this._record.willCreate(path);
   }
 
-  protected _willOverwrite(path: Path) {
+  protected _willOverwrite(path: Path): boolean {
     return this._record.willOverwrite(path);
   }
 
-  protected _willDelete(path: Path) {
+  protected _willDelete(path: Path): boolean {
     return this._record.willDelete(path);
   }
 
-  protected _willRename(path: Path) {
+  protected _willRename(path: Path): boolean {
     return this._record.willRename(path);
   }
 

--- a/packages/angular_devkit/schematics/src/tree/null.ts
+++ b/packages/angular_devkit/schematics/src/tree/null.ts
@@ -43,11 +43,11 @@ export class NullTreeDirEntry implements DirEntry {
     return null;
   }
 
-  visit() {}
+  visit(): void {}
 }
 
 export class NullTree implements Tree {
-  [TreeSymbol]() {
+  [TreeSymbol](): this {
     return this;
   }
 
@@ -74,10 +74,10 @@ export class NullTree implements Tree {
   get(_path: string) {
     return null;
   }
-  getDir(path: string) {
+  getDir(path: string): NullTreeDirEntry {
     return new NullTreeDirEntry(normalize('/' + path));
   }
-  visit() {}
+  visit(): void {}
 
   // Change content of host files.
   beginUpdate(path: string): never {

--- a/packages/angular_devkit/schematics/src/tree/recorder.ts
+++ b/packages/angular_devkit/schematics/src/tree/recorder.ts
@@ -59,11 +59,11 @@ export class UpdateRecorderBase implements UpdateRecorder {
     return new UpdateRecorderBase(entry.content, entry.path);
   }
 
-  get path() {
+  get path(): string {
     return this._path;
   }
 
-  protected _assertIndex(index: number) {
+  protected _assertIndex(index: number): void {
     if (index < 0 || index > this.content.original.length) {
       throw new IndexOutOfBoundException(index, 0, this.content.original.length);
     }

--- a/packages/angular_devkit/schematics/src/tree/scoped.ts
+++ b/packages/angular_devkit/schematics/src/tree/scoped.ts
@@ -197,7 +197,7 @@ export class ScopedTree implements Tree {
     return scopedActions;
   }
 
-  [TreeSymbol]() {
+  [TreeSymbol](): this {
     return this;
   }
 

--- a/packages/angular_devkit/schematics/src/tree/static.ts
+++ b/packages/angular_devkit/schematics/src/tree/static.ts
@@ -10,15 +10,19 @@ import { SchematicsException } from '../exception/exception';
 import { FilterHostTree, HostTree } from './host-tree';
 import { FilePredicate, MergeStrategy, Tree } from './interface';
 
-export function empty() {
+export function empty(): HostTree {
   return new HostTree();
 }
 
-export function branch(tree: Tree) {
+export function branch(tree: Tree): Tree {
   return tree.branch();
 }
 
-export function merge(tree: Tree, other: Tree, strategy: MergeStrategy = MergeStrategy.Default) {
+export function merge(
+  tree: Tree,
+  other: Tree,
+  strategy: MergeStrategy = MergeStrategy.Default,
+): Tree {
   tree.merge(other, strategy);
 
   return tree;


### PR DESCRIPTION
To support the eventual use of the TypeScript `isolatedDeclarations` option, explicit return types have been added to functions throughout the `@angular-devkit/schematics` package code.