### PR TITLE
docs: release notes for the v17.3.17 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+<a name="17.3.17"></a>
+
+# 17.3.17 (2025-04-30)
+
+### @angular-devkit/build-angular
+
+| Commit                                                                                              | Type | Description                            |
+| --------------------------------------------------------------------------------------------------- | ---- | -------------------------------------- |
+| [743d85bac](https://github.com/angular/angular-cli/commit/743d85bacce03bcc454574e0ffa9f243ff6631dd) | fix  | update http-proxy-middleware to v2.0.8 |
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="20.0.0-next.8"></a>
 
 # 20.0.0-next.8 (2025-04-23)


### PR DESCRIPTION
Cherry-picks the changelog from the "17.3.x" branch to the next branch (main).