### PR TITLE
Revert "build: update devinfra digest to 8ca74b8"

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -219,7 +219,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 git_repository(
     name = "devinfra",
-    commit = "8ca74b8a897d28f4735043c745693a706ff5ca81",
+    commit = "46b594244e02f9c26b67f22d1756bae31230e517",
     remote = "https://github.com/angular/dev-infra.git",
 )
 


### PR DESCRIPTION
This reverts commit 100571f03790bb5cf40a54b31b5f3cf902a2c46f.

The hope here is that it will address the spurious "module not found" issues we have seen.