### PR TITLE
fix(@angular/build): enable unit-test reporters option

### DIFF
--- a/packages/angular/build/src/builders/unit-test/builder.ts
+++ b/packages/angular/build/src/builders/unit-test/builder.ts
@@ -190,6 +190,7 @@ export async function* execute(
         environment: browser ? 'node' : 'jsdom',
         watch: normalizedOptions.watch,
         browser,
+        reporters: normalizedOptions.reporters ?? ['default'],
         coverage: {
           enabled: normalizedOptions.codeCoverage,
           exclude: normalizedOptions.codeCoverageExclude,


### PR DESCRIPTION
The `unit-test` builder's `reporters` option will now pass through the values to the underlying unit-test runner. This allows customization of the reporters used when executing tests.
The `unit-test` builder is currently considered experimental.