### PR TITLE
refactor(@angular-devkit/core): don't use concrete type as interface

### DIFF
--- a/goldens/public-api/angular_devkit/core/index.api.md
+++ b/goldens/public-api/angular_devkit/core/index.api.md
@@ -554,11 +554,11 @@ function oneLine(strings: TemplateStringsArray, ...values: any[]): string;
 function parseJsonPointer(pointer: JsonPointer): string[];
 
 // @public (undocumented)
-export class PartiallyOrderedSet<T> implements Set<T> {
+export class PartiallyOrderedSet<T> {
     // (undocumented)
     [Symbol.iterator](): IterableIterator<T, undefined, unknown>;
     // (undocumented)
-    get [Symbol.toStringTag](): 'Set';
+    get [Symbol.toStringTag](): 'PartiallyOrderedSet';
     // (undocumented)
     add(item: T, deps?: Set<T> | T[]): this;
     // (undocumented)

--- a/packages/angular_devkit/core/src/utils/partially-ordered-set.ts
+++ b/packages/angular_devkit/core/src/utils/partially-ordered-set.ts
@@ -19,7 +19,7 @@ export class CircularDependencyFoundException extends BaseException {
   }
 }
 
-export class PartiallyOrderedSet<T> implements Set<T> {
+export class PartiallyOrderedSet<T> {
   private _items = new Map<T, Set<T>>();
 
   protected _checkCircularDependencies(item: T, deps: Set<T>): void {
@@ -161,7 +161,7 @@ export class PartiallyOrderedSet<T> implements Set<T> {
     return undefined;
   }
 
-  get [Symbol.toStringTag](): 'Set' {
-    return 'Set';
+  get [Symbol.toStringTag](): 'PartiallyOrderedSet' {
+    return 'PartiallyOrderedSet';
   }
 }


### PR DESCRIPTION
`Set` isn't a stable interface, it's a concrete type that changes over time (new spec versions may add methods, older ones may lack methods). There shouldn't be a huge downside to just declaring this class as "its own thing".

Follow-up to https://github.com/angular/angular-cli/pull/30208 which breaks on google3 import because the `Set` types are subtly different because of different TS configs.