### PR TITLE
fix(@angular/build): avoid internal karma request cache for assets

### DIFF
--- a/packages/angular/build/src/builders/karma/application_builder.ts
+++ b/packages/angular/build/src/builders/karma/application_builder.ts
@@ -86,7 +86,7 @@ class AngularAssetsMiddleware {
 
     switch (file.origin) {
       case 'disk':
-        this.serveFile(file.inputPath, undefined, res);
+        this.serveFile(file.inputPath, undefined, res, undefined, undefined, /* doNotCache */ true);
         break;
       case 'memory':
         // Include pathname to help with Content-Type headers.


### PR DESCRIPTION
The internal karma common middleware that handles requests converts the to be cached data into a string when stored. This can lead to invalid data when the cached string is then sent in a followup request if the original content was not intended to be a string. To avoid this  problem, asset files are now explicitly not cached by karma's middleware.
Ref: https://github.com/karma-runner/karma/blob/84f85e7016efc2266fa6b3465f494a3fa151c85c/lib/middleware/common.js#L72

Closes #30198