### PR TITLE
perf(@angular/cli): fix unnecessary esbuild rebuilds

### DIFF
--- a/packages/angular/build/src/tools/esbuild/bundler-context.ts
+++ b/packages/angular/build/src/tools/esbuild/bundler-context.ts
@@ -245,7 +245,7 @@ export class BundlerContext {
         // When incremental always add any files from the load result cache
         if (this.#loadCache) {
           for (const file of this.#loadCache.watchFiles) {
-            if (!isInternalAngularFile(file)) {
+            if (!isInternalAngularFileOrEsBuildDefine(file)) {
               // watch files are fully resolved paths
               this.watchFiles.add(file);
             }
@@ -260,7 +260,7 @@ export class BundlerContext {
     if (this.incremental) {
       // Add input files except virtual angular files which do not exist on disk
       for (const input of Object.keys(result.metafile.inputs)) {
-        if (!isInternalAngularFile(input)) {
+        if (!isInternalAngularFileOrEsBuildDefine(input)) {
           // input file paths are always relative to the workspace root
           this.watchFiles.add(join(this.workspaceRoot, input));
         }
@@ -417,12 +417,12 @@ export class BundlerContext {
   #addErrorsToWatch(result: BuildFailure | BuildResult): void {
     for (const error of result.errors) {
       let file = error.location?.file;
-      if (file && !isInternalAngularFile(file)) {
+      if (file && !isInternalAngularFileOrEsBuildDefine(file)) {
         this.watchFiles.add(join(this.workspaceRoot, file));
       }
       for (const note of error.notes) {
         file = note.location?.file;
-        if (file && !isInternalAngularFile(file)) {
+        if (file && !isInternalAngularFileOrEsBuildDefine(file)) {
           this.watchFiles.add(join(this.workspaceRoot, file));
         }
       }
@@ -475,6 +475,6 @@ export class BundlerContext {
   }
 }
 
-function isInternalAngularFile(file: string) {
-  return file.startsWith('angular:');
+function isInternalAngularFileOrEsBuildDefine(file: string) {
+  return file.startsWith('angular:') || file.startsWith('<define:');
 }


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

When using esbuild, Angular sets up a custom file watcher using esbuilds metafile inputs. Esbuild will generate <define:KEY> entries see https://esbuild.github.io/try/#YgAwLjI1LjMALS1kZWZpbmU6Rk9PPSd7fScgLS1tZXRhZmlsZSAtLWJ1bmRsZQBlAGVudHJ5LmpzAGNvbnNvbGUubG9nKEZPTyk. After the build is finished, the file watcher will notice that the <define:KEY> entries no longer exist on the file system and trigger a rebuild even though no files have changed.

Issue Number: N/A

## What is the new behavior?

No rebuilds are triggered since the file watcher is no longer tracking changes to <define:KEY> entries.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

There other conditions which may also trigger a rebuilds, because the file watcher is tracking all inputs from the metafile, which are not necessarily files. This [esbuild plugin example](https://esbuild.github.io/plugins/#using-plugins) will also trigger a rebuild because esbuild will add the `ns-env` namespace to the metafile inputs.
