### PR TITLE
fix(@angular/build): allow a default application `browser` option

### DIFF
--- a/goldens/public-api/angular/build/index.api.md
+++ b/goldens/public-api/angular/build/index.api.md
@@ -25,7 +25,7 @@ export type ApplicationBuilderOptions = {
     appShell?: boolean;
     assets?: AssetPattern[];
     baseHref?: string;
-    browser: string;
+    browser?: string;
     budgets?: Budget[];
     clearScreen?: boolean;
     conditions?: string[];

--- a/packages/angular/build/src/builders/application/schema.json
+++ b/packages/angular/build/src/builders/application/schema.json
@@ -616,7 +616,7 @@
     }
   },
   "additionalProperties": false,
-  "required": ["browser", "tsConfig"],
+  "required": ["tsConfig"],
   "definitions": {
     "assetPattern": {
       "oneOf": [

--- a/packages/angular/build/src/builders/application/tests/options/browser_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/options/browser_spec.ts
@@ -42,6 +42,49 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
       harness.expectFile('dist/browser/main.js').content.toContain('console.log("main")');
     });
 
+    it('defaults to use `src/main.ts` if not present', async () => {
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        browser: undefined,
+      });
+
+      const { result } = await harness.executeOnce();
+
+      expect(result?.success).toBe(true);
+
+      harness.expectFile('dist/browser/main.js').toExist();
+      harness.expectFile('dist/browser/index.html').toExist();
+    });
+
+    it('uses project source root in default if `browser` not present', async () => {
+      harness.useProject('test', {
+        root: '.',
+        sourceRoot: 'source',
+        cli: {
+          cache: {
+            enabled: false,
+          },
+        },
+      });
+      harness.useTarget('build', {
+        ...BASE_OPTIONS,
+        browser: undefined,
+        index: false,
+      });
+
+      // Update app for a `source/main.ts` file based on the above changed `sourceRoot`
+      await harness.writeFile('source/main.ts', `console.log('main');`);
+      await harness.modifyFile('src/tsconfig.app.json', (content) =>
+        content.replace('main.ts', '../source/main.ts'),
+      );
+
+      const { result } = await harness.executeOnce();
+
+      expect(result?.success).toBe(true);
+
+      harness.expectFile('dist/browser/main.js').content.toContain('console.log("main")');
+    });
+
     it('fails and shows an error when file does not exist', async () => {
       harness.useTarget('build', {
         ...BASE_OPTIONS,


### PR DESCRIPTION
The application build system's `browser` option is now considered optional. If not present, the value will be an `main.ts` file within the configured project source root (`sourceRoot`). This change allows the removal of the `browser` option from any project that uses the default generated value.