### PR TITLE
fix(@angular/build) allow component HMR for templates with i18n

### DIFF
--- a/packages/angular/build/src/builders/application/execute-build.ts
+++ b/packages/angular/build/src/builders/application/execute-build.ts
@@ -285,8 +285,10 @@ export async function executeBuild(
       i18nOptions.hasDefinedSourceLocale ? i18nOptions.sourceLocale : undefined,
     );
 
-    executionResult.addErrors(result.errors);
-    executionResult.addWarnings(result.warnings);
+    // Deduplicate and add errors and warnings
+    executionResult.addErrors([...new Set(result.errors)]);
+    executionResult.addWarnings([...new Set(result.warnings)]);
+
     executionResult.addPrerenderedRoutes(result.prerenderedRoutes);
     executionResult.outputFiles.push(...result.additionalOutputFiles);
     executionResult.assetFiles.push(...result.additionalAssets);

--- a/packages/angular/build/src/tools/angular/compilation/aot-compilation.ts
+++ b/packages/angular/build/src/tools/angular/compilation/aot-compilation.ts
@@ -161,10 +161,7 @@ export class AotCompilation extends AngularCompilation {
         );
         const updateText = angularCompiler.emitHmrUpdateModule(node);
         // If compiler cannot generate an update for the component, prevent template updates.
-        // Also prevent template updates if $localize is directly present which also currently
-        // prevents a template update at runtime.
-        // TODO: Support localized template update modules and remove this check.
-        if (updateText === null || updateText.includes('$localize')) {
+        if (updateText === null) {
           // Build is needed if a template cannot be updated
           templateUpdates = undefined;
           break;


### PR DESCRIPTION
When using the development server with the `application` build system and HMR has been enabled (default), component templates with i18n are now eligible to be hot reloaded. If translations exist within the template, they will also be translated assuming a matching translation is available. Changing the content of an i18n block may result in a missing translation warning/error. The development server continues to only support a single enabled locale.

Closes #29457