### PR TITLE
ci: enable e2e test runs on Node.js 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node: [20, 22]
+        node: [20, 22, 24]
         subset: [npm, esbuild]
         shard: [0, 1, 2, 3, 4, 5]
     runs-on: ${{ matrix.os }}

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -101,6 +101,20 @@ nodejs_register_toolchains(
     node_version = "22.11.0",
 )
 
+nodejs_register_toolchains(
+    name = "node24",
+    node_repositories = {
+        "24.0.0-darwin_arm64": ("node-v24.0.0-darwin-arm64.tar.gz", "node-v24.0.0-darwin-arm64", "194e2f3dd3ec8c2adcaa713ed40f44c5ca38467880e160974ceac1659be60121"),
+        "24.0.0-darwin_amd64": ("node-v24.0.0-darwin-x64.tar.gz", "node-v24.0.0-darwin-x64", "f716b3ce14a7e37a6cbf97c9de10d444d7da07ef833cd8da81dd944d111e6a4a"),
+        "24.0.0-linux_arm64": ("node-v24.0.0-linux-arm64.tar.xz", "node-v24.0.0-linux-arm64", "d40ec7ffe0b82b02dce94208c84351424099bd70fa3a42b65c46d95322305040"),
+        "24.0.0-linux_ppc64le": ("node-v24.0.0-linux-ppc64le.tar.xz", "node-v24.0.0-linux-ppc64le", "cfa0e8d51a2f9a446f1bfb81cdf4c7e95336ad622e2aa230e3fa1d093c63d77d"),
+        "24.0.0-linux_s390x": ("node-v24.0.0-linux-s390x.tar.xz", "node-v24.0.0-linux-s390x", "e37a04c7ee05416ec1234fd3255e05b6b81287eb0424a57441c8b69f0a155021"),
+        "24.0.0-linux_amd64": ("node-v24.0.0-linux-x64.tar.xz", "node-v24.0.0-linux-x64", "59b8af617dccd7f9f68cc8451b2aee1e86d6bd5cb92cd51dd6216a31b707efd7"),
+        "24.0.0-windows_amd64": ("node-v24.0.0-win-x64.zip", "node-v24.0.0-win-x64", "3d0fff80c87bb9a8d7f49f2f27832aa34a1477d137af46f5b14df5498be81304"),
+    },
+    node_version = "24.0.0",
+)
+
 load("@aspect_rules_js//js:toolchains.bzl", "rules_js_register_toolchains")
 
 rules_js_register_toolchains(

--- a/tools/toolchain_info.bzl
+++ b/tools/toolchain_info.bzl
@@ -5,6 +5,7 @@
 TOOLCHAINS_NAMES = [
     "node20",
     "node22",
+    "node24",
 ]
 
 # this is the list of toolchains that should be used and are registered with nodejs_register_toolchains in the WORKSPACE file
@@ -18,6 +19,11 @@ TOOLCHAINS_VERSIONS = [
         "@bazel_tools//src/conditions:linux_x86_64": "@node22_linux_amd64//:node_toolchain",
         "@bazel_tools//src/conditions:darwin": "@node22_darwin_amd64//:node_toolchain",
         "@bazel_tools//src/conditions:windows": "@node22_windows_amd64//:node_toolchain",
+    }),
+    select({
+        "@bazel_tools//src/conditions:linux_x86_64": "@node24_linux_amd64//:node_toolchain",
+        "@bazel_tools//src/conditions:darwin": "@node24_darwin_amd64//:node_toolchain",
+        "@bazel_tools//src/conditions:windows": "@node24_windows_amd64//:node_toolchain",
     }),
 ]
 


### PR DESCRIPTION
This update configures the CI pipeline to execute e2e tests using Node.js v24.