### PR TITLE
fix(@angular/build): allow vitest-based unit testing to use watch option

### DIFF
--- a/packages/angular/build/src/builders/unit-test/options.ts
+++ b/packages/angular/build/src/builders/unit-test/options.ts
@@ -32,7 +32,8 @@ export async function normalizeOptions(
   const buildTargetSpecifier = options.buildTarget ?? `::development`;
   const buildTarget = targetFromTargetString(buildTargetSpecifier, projectName, 'build');
 
-  const { codeCoverage, codeCoverageExclude, tsConfig, runner, reporters, browsers } = options;
+  const { codeCoverage, codeCoverageExclude, tsConfig, runner, reporters, browsers, watch } =
+    options;
 
   return {
     // Project/workspace information
@@ -50,8 +51,7 @@ export async function normalizeOptions(
     tsConfig,
     reporters,
     browsers,
-    // TODO: Implement watch support
-    watch: false,
+    watch,
   };
 }
 


### PR DESCRIPTION
When using the `application` build system with the experimental `unit-test` vitest support, the `watch` option will now be passed through to the underlying test runner. This allows vitest to be used for watch-based test development. Incremental test file updates from the build system are also enabled in watch mode as well to remove the need to rewrite all output files on a rebuild.