### PR TITLE
fix(@angular/cli): properly handle Node.js `require()` errors with ESM modules

### DIFF
--- a/packages/angular/build/src/utils/load-proxy-config.ts
+++ b/packages/angular/build/src/utils/load-proxy-config.ts
@@ -67,7 +67,7 @@ export async function loadProxyConfiguration(
         break;
       } catch (e) {
         assertIsError(e);
-        if (e.code === 'ERR_REQUIRE_ESM') {
+        if (e.code === 'ERR_REQUIRE_ESM' || e.code === 'ERR_REQUIRE_ASYNC_MODULE') {
           // Load the ESM configuration file using the TypeScript dynamic import workaround.
           // Once TypeScript provides support for keeping the dynamic import this workaround can be
           // changed to a direct dynamic import.

--- a/packages/angular_devkit/architect/node/node-modules-architect-host.ts
+++ b/packages/angular_devkit/architect/node/node-modules-architect-host.ts
@@ -324,7 +324,10 @@ async function getBuilder(builderPath: string): Promise<any> {
       try {
         return localRequire(builderPath);
       } catch (e) {
-        if ((e as NodeJS.ErrnoException).code === 'ERR_REQUIRE_ESM') {
+        if (
+          (e as NodeJS.ErrnoException).code === 'ERR_REQUIRE_ESM' ||
+          (e as NodeJS.ErrnoException).code === 'ERR_REQUIRE_ASYNC_MODULE'
+        ) {
           // Load the ESM configuration file using the TypeScript dynamic import workaround.
           // Once TypeScript provides support for keeping the dynamic import this workaround can be
           // changed to a direct dynamic import.

--- a/packages/angular_devkit/build_angular/src/tools/webpack/configs/dev-server.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/configs/dev-server.ts
@@ -210,7 +210,7 @@ async function addProxyConfig(
         proxyConfiguration = require(proxyPath);
       } catch (e) {
         assertIsError(e);
-        if (e.code !== 'ERR_REQUIRE_ESM') {
+        if (e.code !== 'ERR_REQUIRE_ESM' && e.code !== 'ERR_REQUIRE_ASYNC_MODULE') {
           throw e;
         }
 

--- a/packages/angular_devkit/build_webpack/src/utils.ts
+++ b/packages/angular_devkit/build_webpack/src/utils.ts
@@ -90,7 +90,10 @@ export async function getWebpackConfig(configPath: string): Promise<Configuratio
       try {
         return require(configPath);
       } catch (e) {
-        if ((e as NodeJS.ErrnoException).code === 'ERR_REQUIRE_ESM') {
+        if (
+          (e as NodeJS.ErrnoException).code === 'ERR_REQUIRE_ESM' ||
+          (e as NodeJS.ErrnoException).code === 'ERR_REQUIRE_ASYNC_MODULE'
+        ) {
           // Load the ESM configuration file using the TypeScript dynamic import workaround.
           // Once TypeScript provides support for keeping the dynamic import this workaround can be
           // changed to a direct dynamic import.


### PR DESCRIPTION

Resolve `ERR_REQUIRE_ASYNC_MODULE` when attempting to `require()` ESM modules in a CommonJS context.

Closes #30286
