### PR TITLE
ci: skip `e2e-snapshots` on non-main branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,7 @@ jobs:
 
   e2e-snapshots:
     needs: test
+    if: github.ref == 'refs/heads/main'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Snapshot updates occur only on the `main` branch, so running them on patch branches provides no benefit.
