### PR TITLE
fix(@angular/build): provide vitest globals in unit-test builder

### DIFF
--- a/packages/angular/build/src/builders/unit-test/builder.ts
+++ b/packages/angular/build/src/builders/unit-test/builder.ts
@@ -223,6 +223,7 @@ export async function* execute(
       instance ??= await startVitest('test', undefined /* cliFilters */, undefined /* options */, {
         test: {
           root: outputPath,
+          globals: true,
           setupFiles,
           // Use `jsdom` if no browsers are explicitly configured.
           // `node` is effectively no "environment" and the default.


### PR DESCRIPTION
The experimental `unit-test` builder with the `vitest` runner now provides the test APIs also as globals. This increases the potential compatibility for existing karma/jasmine based tests. The initial unit tests within a newly generated application, for instance, now require no changes to execute with the new builder.