### PR TITLE
fix(@angular/build): setup unit-test polyfills before TestBed init

### DIFF
--- a/packages/angular/build/src/builders/unit-test/builder.ts
+++ b/packages/angular/build/src/builders/unit-test/builder.ts
@@ -194,7 +194,7 @@ export async function* execute(
   // Add setup file entries for TestBed initialization and project polyfills
   const setupFiles = ['init-testbed.js'];
   if (buildTargetOptions?.polyfills?.length) {
-    setupFiles.push('polyfills.js');
+    setupFiles.unshift('polyfills.js');
   }
 
   try {


### PR DESCRIPTION
To ensure that Zone.js is fully setup and patched prior to the use of TestBed, the setup file order for the `vitest` runner of the `unit-test` builder has been swapped. This is particularly relevant for `fakeAsync` which has a module level statement that attempts to capture the `Zone` instance. If Zone.js is not setup at that point, fakeAsync will fail to function in tests.