### PR TITLE
docs: release notes for the v19.2.12 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+<a name="19.2.12"></a>
+
+# 19.2.12 (2025-05-14)
+
+### @angular/cli
+
+| Commit                                                                                              | Type | Description                                                 |
+| --------------------------------------------------------------------------------------------------- | ---- | ----------------------------------------------------------- |
+| [0098c38c6](https://github.com/angular/angular-cli/commit/0098c38c6d77310effa8c647e1bbfb32fb92afc5) | fix  | properly handle Node.js `require()` errors with ESM modules |
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="20.0.0-rc.0"></a>
 
 # 20.0.0-rc.0 (2025-05-07)


### PR DESCRIPTION
Cherry-picks the changelog from the "19.2.x" branch to the next branch (main).