### PR TITLE
fix(@schematics/angular): support using default browser option when not present

### DIFF
--- a/packages/schematics/angular/environments/index_spec.ts
+++ b/packages/schematics/angular/environments/index_spec.ts
@@ -50,7 +50,7 @@ describe('Environments Schematic', () => {
     build.builder = Builders.Browser;
     build.options = {
       ...build.options,
-      main: build.options.browser,
+      main: 'projects/foo/src/main.ts',
       browser: undefined,
     };
 

--- a/packages/schematics/angular/server/index_spec.ts
+++ b/packages/schematics/angular/server/index_spec.ts
@@ -269,7 +269,7 @@ describe('Server Schematic', () => {
       build.builder = Builders.Browser;
       build.options = {
         ...build.options,
-        main: build.options.browser,
+        main: 'projects/bar/src/main.ts',
         browser: undefined,
       };
 

--- a/packages/schematics/angular/service-worker/index.ts
+++ b/packages/schematics/angular/service-worker/index.ts
@@ -28,7 +28,7 @@ import { getAppModulePath, isStandaloneApp } from '../utility/ng-ast-utils';
 import { relativePathToWorkspaceRoot } from '../utility/paths';
 import { targetBuildNotFoundError } from '../utility/project-targets';
 import { findAppConfig } from '../utility/standalone/app_config';
-import { findBootstrapApplicationCall } from '../utility/standalone/util';
+import { findBootstrapApplicationCall, getMainFilePath } from '../utility/standalone/util';
 import { Builders } from '../utility/workspace-models';
 import { Schema as ServiceWorkerOptions } from './schema';
 
@@ -119,20 +119,18 @@ export default function (options: ServiceWorkerOptions): Rule {
     }
 
     const buildOptions = buildTarget.options as Record<string, string | boolean>;
-    let browserEntryPoint: string | undefined;
+    const browserEntryPoint = await getMainFilePath(host, options.project);
     const ngswConfigPath = join(normalize(project.root), 'ngsw-config.json');
 
     if (
       buildTarget.builder === Builders.Application ||
       buildTarget.builder === Builders.BuildApplication
     ) {
-      browserEntryPoint = buildOptions.browser as string;
       const productionConf = buildTarget.configurations?.production;
       if (productionConf) {
         productionConf.serviceWorker = ngswConfigPath;
       }
     } else {
-      browserEntryPoint = buildOptions.main as string;
       buildOptions.serviceWorker = true;
       buildOptions.ngswConfigPath = ngswConfigPath;
     }

--- a/packages/schematics/angular/service-worker/index_spec.ts
+++ b/packages/schematics/angular/service-worker/index_spec.ts
@@ -203,7 +203,7 @@ describe('Service Worker Schematic', () => {
       build.builder = Builders.Browser;
       build.options = {
         ...build.options,
-        main: build.options.browser,
+        main: 'projects/bar/src/main.ts',
         browser: undefined,
       };
 

--- a/packages/schematics/angular/ssr/index_spec.ts
+++ b/packages/schematics/angular/ssr/index_spec.ts
@@ -182,7 +182,7 @@ describe('SSR Schematic', () => {
       build.builder = '@angular-devkit/build-angular:browser';
       build.options = {
         ...build.options,
-        main: build.options.browser,
+        main: 'projects/test-app/src/main.ts',
         browser: undefined,
       };
 


### PR DESCRIPTION
The Angular schematics that require knowledge of the main entry point of an application will now use the default value for the `application` builder. The default value as per the `application` build system is `<project_source_root>/main.ts`.