### PR TITLE
fix(@angular/build): revert setup unit-test polyfills before TestBed init

### DIFF
--- a/packages/angular/build/src/builders/unit-test/builder.ts
+++ b/packages/angular/build/src/builders/unit-test/builder.ts
@@ -194,7 +194,7 @@ export async function* execute(
   // Add setup file entries for TestBed initialization and project polyfills
   const setupFiles = ['init-testbed.js'];
   if (buildTargetOptions?.polyfills?.length) {
-    setupFiles.unshift('polyfills.js');
+    setupFiles.push('polyfills.js');
   }
 
   try {


### PR DESCRIPTION
The previous change caused Zone.js related test failures when using vitest as a test runner.

This reverts commit 8b2ca7ae2617d0e6a1854693dbd24408a4cbe4fb.