### PR TITLE
fix(@angular/build): use global unit-test hooks during TestBed init

### DIFF
--- a/packages/angular/build/src/builders/unit-test/builder.ts
+++ b/packages/angular/build/src/builders/unit-test/builder.ts
@@ -145,7 +145,6 @@ export async function* execute(
         `import { NgModule } from '@angular/core';`,
         `import { getTestBed, ɵgetCleanupHook as getCleanupHook } from '@angular/core/testing';`,
         `import { BrowserTestingModule, platformBrowserTesting } from '@angular/platform-browser/testing';`,
-        `import { beforeEach, afterEach } from 'vitest';`,
         '',
         normalizedOptions.providersFile
           ? `import providers from './${path


### PR DESCRIPTION
To provide improved Zone.js support with the experimental `unit-test` builder using the `vitest` runner, the TestBed initialization now uses the global `beforeEach`/`afterEach` test hooks. The global hooks can be patched by Zone.js. The vitest globals are always available when using the `unit-test` builder.