### PR TITLE
fix(@angular/build): provide direct debugging support for unit test builder

### DIFF
--- a/packages/angular/build/src/builders/unit-test/karma-bridge.ts
+++ b/packages/angular/build/src/builders/unit-test/karma-bridge.ts
@@ -15,6 +15,12 @@ export async function useKarmaBuilder(
   context: BuilderContext,
   unitTestOptions: NormalizedUnitTestOptions,
 ): Promise<AsyncIterable<BuilderOutput>> {
+  if (unitTestOptions.debug) {
+    context.logger.warn(
+      'The "karma" test runner does not support the "debug" option. The option will be ignored.',
+    );
+  }
+
   const buildTargetOptions = (await context.validateOptions(
     await context.getTargetOptions(unitTestOptions.buildTarget),
     await context.getBuilderNameForTarget(unitTestOptions.buildTarget),

--- a/packages/angular/build/src/builders/unit-test/options.ts
+++ b/packages/angular/build/src/builders/unit-test/options.ts
@@ -52,6 +52,7 @@ export async function normalizeOptions(
     reporters,
     browsers,
     watch,
+    debug: options.debug ?? false,
     providersFile: options.providersFile && path.join(workspaceRoot, options.providersFile),
   };
 }

--- a/packages/angular/build/src/builders/unit-test/schema.json
+++ b/packages/angular/build/src/builders/unit-test/schema.json
@@ -46,6 +46,11 @@
       "type": "boolean",
       "description": "Run build when files change."
     },
+    "debug": {
+      "type": "boolean",
+      "description": "Initialize the test runner to support using the Node Inspector for test debugging.",
+      "default": false
+    },
     "codeCoverage": {
       "type": "boolean",
       "description": "Output a code coverage report.",


### PR DESCRIPTION
When using the experimental `unit-test` builder with the `vitest` runner, a `debug` option is now available which configures the underlying runner to setup and use the Node Inspector to debug tests. This reduces the complexity to support debugging unit tests via a command execution of `ng test --debug`. This will cause the test process to initialize and then wait for a debugger to connect prior to executing the tests.