### PR TITLE
fix(@schematics/angular): use protected for class member

### DIFF
--- a/packages/schematics/angular/application/files/module-files/src/app/app.spec.ts.template
+++ b/packages/schematics/angular/application/files/module-files/src/app/app.spec.ts.template
@@ -22,12 +22,6 @@ describe('App', () => {
     expect(app).toBeTruthy();
   });
 
-  it(`should have as title '<%= name %>'`, () => {
-    const fixture = TestBed.createComponent(App);
-    const app = fixture.componentInstance;
-    expect(app.title).toEqual('<%= name %>');
-  });
-
   it('should render title', () => {
     const fixture = TestBed.createComponent(App);
     fixture.detectChanges();

--- a/packages/schematics/angular/application/files/module-files/src/app/app.ts.template
+++ b/packages/schematics/angular/application/files/module-files/src/app/app.ts.template
@@ -15,5 +15,5 @@ import { Component } from '@angular/core';
   styleUrl: './app.<%= style %>'<% } %>
 })
 export class App {
-  title = '<%= name %>';
+  protected title = '<%= name %>';
 }

--- a/packages/schematics/angular/application/files/standalone-files/src/app/app.spec.ts.template
+++ b/packages/schematics/angular/application/files/standalone-files/src/app/app.spec.ts.template
@@ -16,12 +16,6 @@ describe('App', () => {
     expect(app).toBeTruthy();
   });
 
-  it(`should have the '<%= name %>' title`, () => {
-    const fixture = TestBed.createComponent(App);
-    const app = fixture.componentInstance;
-    expect(app.title).toEqual('<%= name %>');
-  });
-
   it('should render title', () => {
     const fixture = TestBed.createComponent(App);
     fixture.detectChanges();

--- a/packages/schematics/angular/application/files/standalone-files/src/app/app.ts.template
+++ b/packages/schematics/angular/application/files/standalone-files/src/app/app.ts.template
@@ -16,5 +16,5 @@ import { RouterOutlet } from '@angular/router';<% } %>
   styleUrl: './app.<%= style %>'<% } %>
 })
 export class App {
-  title = '<%= name %>';
+  protected title = '<%= name %>';
 }


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the new behavior?

This follows the updated style guide recommendations.

https://next.angular.dev/style-guide#use-protected-on-class-members-that-are-only-used-by-a-components-template

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
