### PR TITLE
fix(@schematics/angular): migrate `provideServerRoutesConfig` to `provideServerRendering`

### DIFF
--- a/packages/schematics/angular/migrations/migration-collection.json
+++ b/packages/schematics/angular/migrations/migration-collection.json
@@ -8,7 +8,7 @@
     "replace-provide-server-routing": {
       "version": "20.0.0",
       "factory": "./replace-provide-server-routing/migration",
-      "description": "Migrate 'provideServerRendering' to use 'withRoutes' and remove 'provideServerRouting' from '@angular/ssr'."
+      "description": "Migrate 'provideServerRendering' to use 'withRoutes', and remove 'provideServerRouting' and 'provideServerRoutesConfig' from '@angular/ssr'."
     },
     "update-module-resolution": {
       "version": "20.0.0",

--- a/packages/schematics/angular/migrations/replace-provide-server-routing/migration.ts
+++ b/packages/schematics/angular/migrations/replace-provide-server-routing/migration.ts
@@ -16,7 +16,11 @@ function* visit(directory: DirEntry): IterableIterator<[fileName: string, conten
       const entry = directory.file(path);
       if (entry) {
         const content = entry.content;
-        if (content.includes('provideServerRouting') && content.includes('@angular/ssr')) {
+        if (
+          (content.includes('provideServerRouting') ||
+            content.includes('provideServerRoutesConfig')) &&
+          content.includes('@angular/ssr')
+        ) {
           // Only need to rename the import so we can just string replacements.
           yield [entry.path, content.toString()];
         }
@@ -63,7 +67,8 @@ export default function (): Rule {
               if (
                 ts.isCallExpression(el) &&
                 ts.isIdentifier(el.expression) &&
-                el.expression.text === 'provideServerRouting'
+                (el.expression.text === 'provideServerRouting' ||
+                  el.expression.text === 'provideServerRoutesConfig')
               ) {
                 const [withRouteVal, ...others] = el.arguments.map((arg) => arg.getText());
 
@@ -99,7 +104,7 @@ export default function (): Rule {
           const elements = namedBindings.elements;
           const updatedElements = elements
             .map((el) => el.getText())
-            .filter((x) => x !== 'provideServerRouting');
+            .filter((x) => x !== 'provideServerRouting' && x !== 'provideServerRoutesConfig');
 
           updatedElements.push('withRoutes');
 

--- a/packages/schematics/angular/migrations/replace-provide-server-routing/migration_spec.ts
+++ b/packages/schematics/angular/migrations/replace-provide-server-routing/migration_spec.ts
@@ -61,6 +61,30 @@ describe(`Migration to replace 'provideServerRouting' with 'provideServerRenderi
     expect(content).not.toContain(`provideServerRouting(serverRoutes)`);
   });
 
+  it('should remove "provideServerRoutesConfig" and update "provideServerRendering"', async () => {
+    tree.overwrite(
+      'src/app/app.config.ts',
+      `
+      import { ApplicationConfig } from '@angular/core';
+      import { provideServerRendering, provideServerRoutesConfig } from '@angular/ssr';
+      import { serverRoutes } from './app.routes';
+
+      const serverConfig: ApplicationConfig = {
+        providers: [
+          provideServerRendering(),
+          provideServerRoutesConfig(serverRoutes)
+        ]
+      };
+      `,
+    );
+
+    const newTree = await schematicRunner.runSchematic(schematicName, {}, tree);
+    const content = newTree.readContent('src/app/app.config.ts');
+
+    expect(content).toContain(`providers: [provideServerRendering(withRoutes(serverRoutes))]`);
+    expect(content).not.toContain(`provideServerRoutesConfig(serverRoutes)`);
+  });
+
   it('should correctly handle provideServerRouting with extra arguments', async () => {
     tree.overwrite(
       'src/app/app.config.ts',


### PR DESCRIPTION


Previously, `provideServerRoutesConfig` was not properly migrated to `provideServerRendering`. This change ensures the migration is handled correctly.
