### PR TITLE
refactor(@angular/build): use new HMR documentation URL for console message

### DIFF
--- a/packages/angular/build/src/builders/dev-server/tests/options/hmr_spec.ts
+++ b/packages/angular/build/src/builders/dev-server/tests/options/hmr_spec.ts
@@ -18,7 +18,7 @@ describeServeBuilder(executeDevServer, DEV_SERVER_BUILDER_INFO, (harness, setupT
       setupTarget(harness, {});
     });
 
-    it('shows message with opt out steps by default', async () => {
+    it('shows message with documentation by default', async () => {
       harness.useTarget('serve', {
         ...BASE_OPTIONS,
       });
@@ -33,12 +33,12 @@ describeServeBuilder(executeDevServer, DEV_SERVER_BUILDER_INFO, (harness, setupT
       );
       expect(logs).toContain(
         jasmine.objectContaining<logging.LogEntry>({
-          message: jasmine.stringMatching('--no-hmr'),
+          message: jasmine.stringMatching('angular.dev/hmr'),
         }),
       );
     });
 
-    it('shows message with opt out steps when explicitly enabled', async () => {
+    it('shows message with documentation when explicitly enabled', async () => {
       harness.useTarget('serve', {
         ...BASE_OPTIONS,
         hmr: true,
@@ -54,12 +54,12 @@ describeServeBuilder(executeDevServer, DEV_SERVER_BUILDER_INFO, (harness, setupT
       );
       expect(logs).toContain(
         jasmine.objectContaining<logging.LogEntry>({
-          message: jasmine.stringMatching('--no-hmr'),
+          message: jasmine.stringMatching('angular.dev/hmr'),
         }),
       );
     });
 
-    it('does not show enabled message with opt out steps when explicitly disabled', async () => {
+    it('does not show enabled message with documentation when explicitly disabled', async () => {
       harness.useTarget('serve', {
         ...BASE_OPTIONS,
         hmr: false,
@@ -75,7 +75,7 @@ describeServeBuilder(executeDevServer, DEV_SERVER_BUILDER_INFO, (harness, setupT
       );
       expect(logs).not.toContain(
         jasmine.objectContaining<logging.LogEntry>({
-          message: jasmine.stringMatching('--no-hmr'),
+          message: jasmine.stringMatching('angular.dev/hmr'),
         }),
       );
     });

--- a/packages/angular/build/src/builders/dev-server/vite-server.ts
+++ b/packages/angular/build/src/builders/dev-server/vite-server.ts
@@ -168,10 +168,7 @@ export async function* serveWithVite(
     browserOptions.aot && serverOptions.liveReload && serverOptions.hmr && useComponentTemplateHmr;
   if (browserOptions.templateUpdates) {
     context.logger.warn(
-      'Component HMR has been enabled.\n' +
-        'If you encounter application reload issues, you can manually reload the page to bypass HMR and/or disable this feature with the' +
-        ' `--no-hmr` command line option.\n' +
-        'Please consider reporting any issues you encounter here: https://github.com/angular/angular-cli/issues\n',
+      'Component HMR has been enabled, see https://angular.dev/hmr for more info.',
     );
   }
 


### PR DESCRIPTION
The https://angular.dev/hmr URL is now used in the HMR enabled console message for the development server. The message text has also been shortened as the information is available at the aforementioned documentation location.