### PR TITLE
fix(@angular/build): include full metadata for AOT unit-testing

### DIFF
--- a/packages/angular/build/src/tools/esbuild/angular/compiler-plugin.ts
+++ b/packages/angular/build/src/tools/esbuild/angular/compiler-plugin.ts
@@ -35,6 +35,13 @@ export interface CompilerPluginOptions {
   sourcemap: boolean | 'external';
   tsconfig: string;
   jit?: boolean;
+
+  /**
+   * Include class metadata and JIT information in built code.
+   * The Angular TestBed APIs require additional metadata for the Angular aspects of the application
+   * such as Components, Modules, Pipes, etc.
+   * TestBed may also leverage JIT capabilities during testing (e.g., overrideComponent).
+   */
   includeTestMetadata?: boolean;
 
   advancedOptimizations?: boolean;
@@ -89,7 +96,7 @@ export function createCompilerPlugin(
           sourcemap: !!pluginOptions.sourcemap,
           thirdPartySourcemaps: pluginOptions.thirdPartySourcemaps,
           advancedOptimizations: pluginOptions.advancedOptimizations,
-          jit: pluginOptions.jit,
+          jit: pluginOptions.jit || pluginOptions.includeTestMetadata,
         },
         maxWorkers,
         cacheStore?.createCache('jstransformer'),
@@ -718,6 +725,7 @@ function createCompilerOptionsTransformer(
       externalRuntimeStyles: pluginOptions.externalRuntimeStyles,
       _enableHmr: !!pluginOptions.templateUpdates,
       supportTestBed: !!pluginOptions.includeTestMetadata,
+      supportJitMode: !!pluginOptions.includeTestMetadata,
     };
   };
 }


### PR DESCRIPTION
Include class metadata and JIT information in code built for development and/or test usage. All non-optimized builds will now contain this metadata (`optimization.scripts` is false). The Angular TestBed APIs require additional metadata for the Angular aspects of the application such as Components, Modules, Pipes, etc.
TestBed may also leverage JIT capabilities during testing (e.g., `overrideComponent`). To support all these TestBed usage scenarios both the underlying `setClassMetadata` and `setNgModuleScope` class augmentation functions are now emitted when test metadata inclusion is enabled.