### PR TITLE
refactor(@angular/build): update `ensureWorkerPool` to do an early exit

### DIFF
--- a/packages/angular/build/src/tools/esbuild/javascript-transformer.ts
+++ b/packages/angular/build/src/tools/esbuild/javascript-transformer.ts
@@ -56,6 +56,10 @@ export class JavaScriptTransformer {
   }
 
   #ensureWorkerPool(): WorkerPool {
+    if (this.#workerPool) {
+      return this.#workerPool;
+    }
+
     const workerPoolOptions: WorkerPoolOptions = {
       filename: require.resolve('./javascript-transformer-worker'),
       maxThreads: this.maxThreads,
@@ -67,7 +71,7 @@ export class JavaScriptTransformer {
       workerPoolOptions.execArgv = filteredExecArgv;
     }
 
-    this.#workerPool ??= new WorkerPool(workerPoolOptions);
+    this.#workerPool = new WorkerPool(workerPoolOptions);
 
     return this.#workerPool;
   }


### PR DESCRIPTION
The avoid unnecessary logic to be executed for every call to `transformFile`.
