### PR TITLE
refactor(@angular-devkit/architect): remove redundant internal job schema validation

### DIFF
--- a/packages/angular_devkit/architect/src/architect.ts
+++ b/packages/angular_devkit/architect/src/architect.ts
@@ -48,9 +48,6 @@ import {
 import { mergeOptions } from './options';
 import { scheduleByName, scheduleByTarget } from './schedule-by-name';
 
-const inputSchema = require('./input-schema.json');
-const outputSchema = require('./output-schema.json');
-
 function _createJobHandlerFromBuilderInfo(
   info: BuilderInfo,
   target: Target | undefined,
@@ -60,9 +57,9 @@ function _createJobHandlerFromBuilderInfo(
 ): Observable<BuilderJobHandler> {
   const jobDescription: BuilderDescription = {
     name: target ? `{${targetStringFromTarget(target)}}` : info.builderName,
-    argument: { type: 'object' },
-    input: inputSchema,
-    output: outputSchema,
+    argument: true,
+    input: true,
+    output: true,
     info,
   };
 
@@ -279,8 +276,6 @@ function _getTargetOptionsFactory(host: ArchitectHost) {
     },
     {
       name: '..getTargetOptions',
-      output: { type: 'object' },
-      argument: inputSchema.properties.target,
     },
   );
 }
@@ -298,10 +293,6 @@ function _getProjectMetadataFactory(host: ArchitectHost) {
     },
     {
       name: '..getProjectMetadata',
-      output: { type: 'object' },
-      argument: {
-        oneOf: [{ type: 'string' }, inputSchema.properties.target],
-      },
     },
   );
 }
@@ -318,8 +309,6 @@ function _getBuilderNameForTargetFactory(host: ArchitectHost) {
     },
     {
       name: '..getBuilderNameForTarget',
-      output: { type: 'string' },
-      argument: inputSchema.properties.target,
     },
   );
 }
@@ -344,11 +333,6 @@ function _validateOptionsFactory(host: ArchitectHost, registry: json.schema.Sche
     },
     {
       name: '..validateOptions',
-      output: { type: 'object' },
-      argument: {
-        type: 'array',
-        items: [{ type: 'string' }, { type: 'object' }],
-      },
     },
   );
 }

--- a/packages/angular_devkit/architect/src/jobs/simple-scheduler.ts
+++ b/packages/angular_devkit/architect/src/jobs/simple-scheduler.ts
@@ -155,11 +155,22 @@ export class SimpleScheduler<
           channels: handler.jobDescription.channels || {},
         };
 
+        const noopValidator = noopSchemaValidator();
+
         const handlerWithExtra = Object.assign(handler.bind(undefined), {
           jobDescription: description,
-          argumentV: this._schemaRegistry.compile(description.argument),
-          inputV: this._schemaRegistry.compile(description.input),
-          outputV: this._schemaRegistry.compile(description.output),
+          argumentV:
+            description.argument === true
+              ? noopValidator
+              : this._schemaRegistry.compile(description.argument),
+          inputV:
+            description.input === true
+              ? noopValidator
+              : this._schemaRegistry.compile(description.input),
+          outputV:
+            description.output === true
+              ? noopValidator
+              : this._schemaRegistry.compile(description.output),
         }) as JobHandlerWithExtra;
         this._internalJobDescriptionMap.set(name, handlerWithExtra);
 
@@ -545,4 +556,11 @@ export class SimpleScheduler<
 
     return this._createJob(name, argument, handler, inboundBus, outboundBus);
   }
+}
+
+async function noopSchemaValidator(): Promise<schema.SchemaValidator> {
+  return async (data: JsonValue) => ({
+    data,
+    success: true,
+  });
 }


### PR DESCRIPTION


Removed JSON schema-based validation for internal job arguments, inputs, and outputs in architect builder jobs. This validation applied to internal architect values.

Builder option validation remains unaffected. Eliminating this validation reduces overhead from costly RxJS operations, improving performance, especially for builders producing large outputs that were previously delayed by this processing.
