### PR TITLE
refactor(@angular/cli): allow opt-in Node.js compile cache for Bazel

### DIFF
--- a/packages/angular/cli/bin/bootstrap.js
+++ b/packages/angular/cli/bin/bootstrap.js
@@ -19,9 +19,9 @@
  */
 
 // Enable on-disk code caching if available (Node.js 22.8+)
-// Skip if running inside Bazel via a RUNFILES environment variable check. The cache does not work
-// well with Bazel's hermeticity requirements.
-if (!process.env['RUNFILES']) {
+// Skip if running inside Bazel via a RUNFILES environment variable check and no explicit cache
+// location defined. The default cache location does not work well with Bazel's hermeticity requirements.
+if (!process.env['RUNFILES'] || process.env['NODE_COMPILE_CACHE']) {
   try {
     const { enableCompileCache } = require('node:module');
 


### PR DESCRIPTION
When using the Angular CLI within Bazel, the Node.js compile cache can be enabled by setting the `NODE_COMPILE_CACHE` environment variable to a filesystem path.
This allows opt-in usage based on the Bazel execution environment.

Compile cache documentation:
https://nodejs.org/api/module.html#module-compile-cache