### PR TITLE
build: preserve `peerDependenciesMeta` in snapshots

### DIFF
--- a/tools/snapshot_repo_filter.bzl
+++ b/tools/snapshot_repo_filter.bzl
@@ -6,14 +6,23 @@
 load("//:constants.bzl", "SNAPSHOT_REPOS")
 
 def _generate_snapshot_repo_filter():
-    filter = ""
-    for (i, pkg_name) in enumerate(SNAPSHOT_REPOS.keys()):
-        filter += "{sep}(..|objects|select(has(\"{pkg_name}\")))[\"{pkg_name}\"] |= \"github:{snapshot_repo}#BUILD_SCM_HASH-PLACEHOLDER\"\n".format(
-            sep = "| " if i > 0 else "",
-            pkg_name = pkg_name,
-            snapshot_repo = SNAPSHOT_REPOS[pkg_name],
+    individual_pkg_filters = []
+    for pkg_name, snapshot_repo in SNAPSHOT_REPOS.items():
+        individual_pkg_filters.append(
+            """
+            . as $root
+                | [paths(..)]
+                | [(.[] | select(
+                    contains(["{pkg_name}"]) and
+                    contains(["peerDependenciesMeta"]) != true))] as $paths
+                | $paths | reduce $paths[] as $path ($root; setpath($path; "github:{snapshot_repo}#BUILD_SCM_HASH-PLACEHOLDER")) | .
+            """.format(
+                pkg_name = pkg_name,
+                snapshot_repo = snapshot_repo,
+            ),
         )
-    return filter
+
+    return " | ".join(individual_pkg_filters)
 
 # jq filter that replaces package.json dependencies with snapshot repos
 SNAPSHOT_REPO_JQ_FILTER = _generate_snapshot_repo_filter()


### PR DESCRIPTION
Addresses an issue where publishing snapshot builds would replace the value with the package SHAs in `peerDependenciesMeta`.

See: https://github.com/angular/angular-build-builds/blob/d4d0f1ca0932bd4fe2df4cc2da10d132789dcd8f/package.json#L89
