### PR TITLE
fix(@angular/build): also disable outputMode in vitest unit-tests

### DIFF
--- a/packages/angular/build/src/builders/unit-test/builder.ts
+++ b/packages/angular/build/src/builders/unit-test/builder.ts
@@ -122,6 +122,7 @@ export async function* execute(
     index: false,
     browser: undefined,
     server: undefined,
+    outputMode: undefined,
     localize: false,
     budgets: [],
     serviceWorker: false,


### PR DESCRIPTION
Application defined entry points (`browser`/`server`) are disabled when using the experimental unit-test builder. This allows the unit test files themselves to become the entry points for testing purposes. Previously, the `outputMode` option was not also disabled. This lead to errors if it was present in the build target configuration used for `unit-test` due to the `outputMode` option requiring the `server` option.

Closes #30410