### PR TITLE
fix(@schematics/angular): remove karma config devkit package usages during application migration

### DIFF
--- a/packages/schematics/angular/migrations/use-application-builder/migration_spec.ts
+++ b/packages/schematics/angular/migrations/use-application-builder/migration_spec.ts
@@ -130,6 +130,103 @@ describe(`Migration to use the application builder`, () => {
     expect(builderMode).toBeUndefined();
   });
 
+  it(`should update file for 'karmaConfig' karma option (no require trailing comma)`, async () => {
+    addWorkspaceTarget(tree, 'test', {
+      'builder': Builders.Karma,
+      'options': {
+        'karmaConfig': './karma.conf.js',
+        'polyfills': ['zone.js', 'zone.js/testing'],
+        'tsConfig': 'projects/app-a/tsconfig.spec.json',
+      },
+    });
+    tree.create(
+      './karma.conf.js',
+      `
+        module.exports = function (config) {
+          config.set({
+            basePath: '',
+            frameworks: ['jasmine', '@angular-devkit/build-angular'],
+            plugins: [
+              require('karma-jasmine'),
+              require('karma-chrome-launcher'),
+              require('karma-jasmine-html-reporter'),
+              require('karma-coverage'),
+              require('@angular-devkit/build-angular/plugins/karma')
+            ]
+          });
+        };`,
+    );
+
+    const newTree = await schematicRunner.runSchematic(schematicName, {}, tree);
+    const {
+      projects: { app },
+    } = JSON.parse(newTree.readContent('/angular.json'));
+
+    const { karmaConfig } = app.architect['test'].options;
+    expect(karmaConfig).toBe('./karma.conf.js');
+
+    const karmaConfigText = newTree.readText('./karma.conf.js');
+    expect(karmaConfigText).not.toContain(`require('@angular-devkit/build-angular/plugins/karma')`);
+  });
+
+  it(`should update file for 'karmaConfig' karma option (require trailing comma)`, async () => {
+    addWorkspaceTarget(tree, 'test', {
+      'builder': Builders.Karma,
+      'options': {
+        'karmaConfig': './karma.conf.js',
+        'polyfills': ['zone.js', 'zone.js/testing'],
+        'tsConfig': 'projects/app-a/tsconfig.spec.json',
+      },
+    });
+    tree.create(
+      './karma.conf.js',
+      `
+        module.exports = function (config) {
+          config.set({
+            basePath: '',
+            frameworks: ['jasmine', '@angular-devkit/build-angular'],
+            plugins: [
+              require('karma-jasmine'),
+              require('karma-chrome-launcher'),
+              require('karma-jasmine-html-reporter'),
+              require('karma-coverage'),
+              require('@angular-devkit/build-angular/plugins/karma'),
+            ]
+          });
+        };`,
+    );
+
+    const newTree = await schematicRunner.runSchematic(schematicName, {}, tree);
+    const {
+      projects: { app },
+    } = JSON.parse(newTree.readContent('/angular.json'));
+
+    const { karmaConfig } = app.architect['test'].options;
+    expect(karmaConfig).toBe('./karma.conf.js');
+
+    const karmaConfigText = newTree.readText('./karma.conf.js');
+    expect(karmaConfigText).not.toContain(`require('@angular-devkit/build-angular/plugins/karma')`);
+  });
+
+  it(`should ignore missing file for 'karmaConfig' karma option`, async () => {
+    addWorkspaceTarget(tree, 'test', {
+      'builder': Builders.Karma,
+      'options': {
+        'karmaConfig': './karma.conf.js',
+        'polyfills': ['zone.js', 'zone.js/testing'],
+        'tsConfig': 'projects/app-a/tsconfig.spec.json',
+      },
+    });
+
+    const newTree = await schematicRunner.runSchematic(schematicName, {}, tree);
+    const {
+      projects: { app },
+    } = JSON.parse(newTree.readContent('/angular.json'));
+
+    const { karmaConfig } = app.architect['test'].options;
+    expect(karmaConfig).toBe('./karma.conf.js');
+  });
+
   it('should remove tilde prefix from CSS @import specifiers', async () => {
     // Replace outputPath
     tree.create(


### PR DESCRIPTION
When performing an `ng update` to Angular v20, the application migration will detect the usage of the `karma` builder's `karmaConfig` option and attempt to remove usages of the no longer needed `@angular-devkit/build-angular` karma framework and plugin usage. While the karma framework usage will be specifically ignored when using the `@angular/build:karma` builder, the plugin usage leverages a direct `require` within the configuration file. Regardless of the ability of the builder to ignore, neither usage is needed with `@angular/build:karma` and removing the code aligns with what would be generated by `ng generate config karma`.

Closes #30413