### PR TITLE
fix(@schematics/angular): only overwrite JSON file if actually changed

### DIFF
--- a/packages/schematics/angular/utility/json-file.ts
+++ b/packages/schematics/angular/utility/json-file.ts
@@ -95,9 +95,16 @@ export class JSONFile {
       },
     });
 
-    this.content = applyEdits(this.content, edits);
-    this.host.overwrite(this.path, this.content);
-    this._jsonAst = undefined;
+    if (edits.length > 0) {
+      const editedContent = applyEdits(this.content, edits);
+
+      // Update the file content if it changed
+      if (editedContent !== this.content) {
+        this.content = editedContent;
+        this.host.overwrite(this.path, editedContent);
+        this._jsonAst = undefined;
+      }
+    }
   }
 
   remove(jsonPath: JSONPath): void {


### PR DESCRIPTION
The JSON file helper utility used within the Angular schematics now contains additional checks when attempting to modify a file to avoid overwriting a file if no actual changes will occur after a modify request.