### PR TITLE
fix(@schematics/angular): skip zone.js dependency for zoneless applications

### DIFF
--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -149,6 +149,14 @@ function addDependenciesToPackageJson(options: ApplicationOptions) {
       },
     ].forEach((dependency) => addPackageJsonDependency(host, dependency));
 
+    if (!options.zoneless) {
+      addPackageJsonDependency(host, {
+        type: NodeDependencyType.Default,
+        name: 'zone.js',
+        version: latestVersions['zone.js'],
+      });
+    }
+
     if (!options.skipInstall) {
       context.addTask(new NodePackageInstallTask());
     }

--- a/packages/schematics/angular/application/index_spec.ts
+++ b/packages/schematics/angular/application/index_spec.ts
@@ -268,6 +268,48 @@ describe('Application Schematic', () => {
       expect(pkg.devDependencies['typescript']).toEqual(latestVersions['typescript']);
     });
 
+    it('should include zone.js if "zoneless" option is false', async () => {
+      const tree = await schematicRunner.runSchematic(
+        'application',
+        {
+          ...defaultOptions,
+          zoneless: false,
+        },
+        workspaceTree,
+      );
+
+      const pkg = JSON.parse(tree.readContent('/package.json'));
+      expect(pkg.dependencies['zone.js']).toEqual(latestVersions['zone.js']);
+    });
+
+    it('should include zone.js if "zoneless" option is not present', async () => {
+      const tree = await schematicRunner.runSchematic(
+        'application',
+        {
+          ...defaultOptions,
+          zoneless: undefined,
+        },
+        workspaceTree,
+      );
+
+      const pkg = JSON.parse(tree.readContent('/package.json'));
+      expect(pkg.dependencies['zone.js']).toEqual(latestVersions['zone.js']);
+    });
+
+    it('should not include zone.js if "zoneless" option is true', async () => {
+      const tree = await schematicRunner.runSchematic(
+        'application',
+        {
+          ...defaultOptions,
+          zoneless: true,
+        },
+        workspaceTree,
+      );
+
+      const pkg = JSON.parse(tree.readContent('/package.json'));
+      expect(pkg.dependencies['zone.js']).toBeUndefined();
+    });
+
     it(`should not override existing users dependencies`, async () => {
       const oldPackageJson = workspaceTree.readContent('package.json');
       workspaceTree.overwrite(

--- a/packages/schematics/angular/library/index_spec.ts
+++ b/packages/schematics/angular/library/index_spec.ts
@@ -195,6 +195,13 @@ describe('Library Schematic', () => {
     expect(workspace.projects.foo.prefix).toEqual('pre');
   });
 
+  it(`should not add zone.js to test polyfills when no zone.js dependency`, async () => {
+    const tree = await schematicRunner.runSchematic('library', defaultOptions, workspaceTree);
+
+    const workspace = getJsonFileContent(tree, '/angular.json');
+    expect(workspace.projects.foo.architect.test.options.polyfills).toBeUndefined();
+  });
+
   it('should handle a pascalCasedName', async () => {
     const options = { ...defaultOptions, name: 'pascalCasedName' };
     const tree = await schematicRunner.runSchematic('library', options, workspaceTree);

--- a/packages/schematics/angular/workspace/files/package.json.template
+++ b/packages/schematics/angular/workspace/files/package.json.template
@@ -17,8 +17,7 @@
     "@angular/platform-browser": "<%= latestVersions.Angular %>",
     "@angular/router": "<%= latestVersions.Angular %>",
     "rxjs": "<%= latestVersions['rxjs'] %>",
-    "tslib": "<%= latestVersions['tslib'] %>",
-    "zone.js": "<%= latestVersions['zone.js'] %>"
+    "tslib": "<%= latestVersions['tslib'] %>"
   },
   "devDependencies": {
     "@angular/cli": "<%= '^' + version %>",

--- a/packages/schematics/angular/workspace/index_spec.ts
+++ b/packages/schematics/angular/workspace/index_spec.ts
@@ -58,7 +58,6 @@ describe('Workspace Schematic', () => {
     const pkg = JSON.parse(tree.readContent('/package.json'));
     expect(pkg.dependencies['@angular/core']).toEqual(latestVersions.Angular);
     expect(pkg.dependencies['rxjs']).toEqual(latestVersions['rxjs']);
-    expect(pkg.dependencies['zone.js']).toEqual(latestVersions['zone.js']);
     expect(pkg.devDependencies['typescript']).toEqual(latestVersions['typescript']);
   });
 


### PR DESCRIPTION
A newly generated application no longer adds the `zone.js` dependency to the workspace if the `zoneless` option is enabled.

Closes #30419