### PR TITLE
feat(@angular/build): add dataurl, base64 loaders

### DIFF
--- a/packages/angular/build/src/builders/application/options.ts
+++ b/packages/angular/build/src/builders/application/options.ts
@@ -206,13 +206,22 @@ export async function normalizeOptions(
     }
   }
 
-  let loaderExtensions: Record<string, 'text' | 'binary' | 'file'> | undefined;
+  let loaderExtensions:
+    | Record<string, 'text' | 'binary' | 'file' | 'dataurl' | 'base64'>
+    | undefined;
   if (options.loader) {
     for (const [extension, value] of Object.entries(options.loader)) {
       if (extension[0] !== '.' || /\.[cm]?[jt]sx?$/.test(extension)) {
         continue;
       }
-      if (value !== 'text' && value !== 'binary' && value !== 'file' && value !== 'empty') {
+      if (
+        value !== 'text' &&
+        value !== 'binary' &&
+        value !== 'file' &&
+        value !== 'dataurl' &&
+        value !== 'base64' &&
+        value !== 'empty'
+      ) {
         continue;
       }
       loaderExtensions ??= {};

--- a/packages/angular/build/src/builders/application/schema.json
+++ b/packages/angular/build/src/builders/application/schema.json
@@ -279,10 +279,10 @@
       ]
     },
     "loader": {
-      "description": "Defines the type of loader to use with a specified file extension when used with a JavaScript `import`. `text` inlines the content as a string; `binary` inlines the content as a Uint8Array; `file` emits the file and provides the runtime location of the file; `empty` considers the content to be empty and not include it in bundles.",
+      "description": "Defines the type of loader to use with a specified file extension when used with a JavaScript `import`. `text` inlines the content as a string; `binary` inlines the content as a Uint8Array; `file` emits the file and provides the runtime location of the file; `dataurl` inlines the content as a data URL with best guess of MIME type; `base64` inlines the content as a Base64-encoded string; `empty` considers the content to be empty and not include it in bundles.",
       "type": "object",
       "patternProperties": {
-        "^\\.\\S+$": { "enum": ["text", "binary", "file", "empty"] }
+        "^\\.\\S+$": { "enum": ["text", "binary", "file", "dataurl", "base64", "empty"] }
       }
     },
     "define": {

--- a/packages/angular/build/src/builders/karma/schema.json
+++ b/packages/angular/build/src/builders/karma/schema.json
@@ -163,10 +163,10 @@
       "default": []
     },
     "loader": {
-      "description": "Defines the type of loader to use with a specified file extension when used with a JavaScript `import`. `text` inlines the content as a string; `binary` inlines the content as a Uint8Array; `file` emits the file and provides the runtime location of the file; `empty` considers the content to be empty and not include it in bundles.",
+      "description": "Defines the type of loader to use with a specified file extension when used with a JavaScript `import`. `text` inlines the content as a string; `binary` inlines the content as a Uint8Array; `file` emits the file and provides the runtime location of the file; `dataurl` inlines the content as a data URL with best guess of MIME type; `base64` inlines the content as a Base64-encoded string; `empty` considers the content to be empty and not include it in bundles.",
       "type": "object",
       "patternProperties": {
-        "^\\.\\S+$": { "enum": ["text", "binary", "file", "empty"] }
+        "^\\.\\S+$": { "enum": ["text", "binary", "file", "dataurl", "base64", "empty"] }
       }
     },
     "define": {

--- a/packages/angular/build/src/tools/esbuild/loader-import-attribute-plugin.ts
+++ b/packages/angular/build/src/tools/esbuild/loader-import-attribute-plugin.ts
@@ -9,7 +9,7 @@
 import type { Loader, Plugin } from 'esbuild';
 import { readFile } from 'node:fs/promises';
 
-const SUPPORTED_LOADERS: Loader[] = ['binary', 'file', 'text'];
+const SUPPORTED_LOADERS: Loader[] = ['base64', 'binary', 'dataurl', 'file', 'text'];
 
 export function createLoaderImportAttributePlugin(): Plugin {
   return {


### PR DESCRIPTION
This passes through the existing esbuild functionality to support dataurl and base64 loaders, in addition to the pre-existing text, binary, and file loaders.

Both the dataurl and base64 loaders return strings with the relevant content. There is no way to control whether the dataurl method uses base64 or plain text encoding, and no way to control the mime type it detects.

Fixes #30391

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently only the text/binary/file esbuild loaders are usable.

Issue Number: #30391

## What is the new behavior?

This adds the dataurl/base64 loaders as well.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

It wasn't clear to me how to cause the documentation at e.g. https://angular.dev/tools/cli/build-system-migration#file-extension-loader-customization to be updated. I updated the comments in schema.json.