### PR TITLE
fix(@angular-devkit/build-angular): respect i18nDuplicateTranslation …

### DIFF
--- a/goldens/public-api/angular/build/index.api.md
+++ b/goldens/public-api/angular/build/index.api.md
@@ -157,6 +157,7 @@ export function executeNgPackagrBuilder(options: NgPackagrBuilderOptions, contex
 export type ExtractI18nBuilderOptions = {
     buildTarget?: string;
     format?: Format;
+    i18nDuplicateTranslation?: I18NDuplicateTranslation;
     outFile?: string;
     outputPath?: string;
     progress?: boolean;

--- a/goldens/public-api/angular_devkit/build_angular/index.api.md
+++ b/goldens/public-api/angular_devkit/build_angular/index.api.md
@@ -191,6 +191,7 @@ export type ExecutionTransformer<T> = (input: T) => T | Promise<T>;
 export type ExtractI18nBuilderOptions = {
     buildTarget?: string;
     format?: Format;
+    i18nDuplicateTranslation?: I18NDuplicateTranslation;
     outFile?: string;
     outputPath?: string;
     progress?: boolean;

--- a/packages/angular/build/src/builders/extract-i18n/builder.ts
+++ b/packages/angular/build/src/builders/extract-i18n/builder.ts
@@ -90,16 +90,23 @@ export async function execute(
       return path.relative(from, to);
     },
   };
+  const duplicateTranslationBehavior = normalizedOptions.i18nOptions.duplicateTranslationBehavior;
   const diagnostics = checkDuplicateMessages(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     checkFileSystem as any,
     extractionResult.messages,
-    normalizedOptions.i18nOptions.i18nDuplicateTranslation || 'warning',
+    duplicateTranslationBehavior,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     extractionResult.basePath as any,
   );
-  if (diagnostics.messages.length > 0) {
-    context.logger.warn(diagnostics.formatDiagnostics(''));
+  if (diagnostics.messages.length > 0 && duplicateTranslationBehavior !== 'ignore') {
+    if (duplicateTranslationBehavior === 'error') {
+      context.logger.error(`Extraction Failed: ${diagnostics.formatDiagnostics('')}`);
+
+      return { success: false };
+    } else {
+      context.logger.warn(diagnostics.formatDiagnostics(''));
+    }
   }
 
   // Serialize all extracted messages

--- a/packages/angular/build/src/builders/extract-i18n/options.ts
+++ b/packages/angular/build/src/builders/extract-i18n/options.ts
@@ -6,10 +6,11 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import { type DiagnosticHandlingStrategy } from '@angular/localize/tools';
 import { BuilderContext, targetFromTargetString } from '@angular-devkit/architect';
 import { fail } from 'node:assert';
 import path from 'node:path';
-import { createI18nOptions } from '../../utils/i18n-options';
+import { type I18nOptions, createI18nOptions } from '../../utils/i18n-options';
 import { Schema as ExtractI18nOptions, Format } from './schema';
 
 export type NormalizedExtractI18nOptions = Awaited<ReturnType<typeof normalizeOptions>>;
@@ -36,7 +37,12 @@ export async function normalizeOptions(
   // Target specifier defaults to the current project's build target with no specified configuration
   const buildTargetSpecifier = options.buildTarget ?? ':';
   const buildTarget = targetFromTargetString(buildTargetSpecifier, projectName, 'build');
-  const i18nOptions = createI18nOptions(projectMetadata, /** inline */ false, context.logger);
+  const i18nOptions: I18nOptions & {
+    duplicateTranslationBehavior: DiagnosticHandlingStrategy;
+  } = {
+    ...createI18nOptions(projectMetadata, /** inline */ false, context.logger),
+    duplicateTranslationBehavior: options.i18nDuplicateTranslation || 'warning',
+  };
 
   // Normalize xliff format extensions
   let format = options.format;

--- a/packages/angular/build/src/builders/extract-i18n/schema.json
+++ b/packages/angular/build/src/builders/extract-i18n/schema.json
@@ -27,6 +27,11 @@
     "outFile": {
       "type": "string",
       "description": "Name of the file to output."
+    },
+    "i18nDuplicateTranslation": {
+      "type": "string",
+      "description": "How to handle duplicate translations.",
+      "enum": ["error", "warning", "ignore"]
     }
   },
   "additionalProperties": false

--- a/packages/angular/build/src/utils/i18n-options.ts
+++ b/packages/angular/build/src/utils/i18n-options.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import { DiagnosticHandlingStrategy } from '@angular/localize/tools';
 import path from 'node:path';
 import type { TranslationLoader } from './load-translations';
 
@@ -29,7 +28,6 @@ export interface I18nOptions {
   flatOutput?: boolean;
   readonly shouldInline: boolean;
   hasDefinedSourceLocale?: boolean;
-  i18nDuplicateTranslation?: DiagnosticHandlingStrategy;
 }
 
 function normalizeTranslationFileOption(

--- a/packages/angular_devkit/build_angular/src/builders/extract-i18n/builder.ts
+++ b/packages/angular_devkit/build_angular/src/builders/extract-i18n/builder.ts
@@ -110,16 +110,23 @@ export async function execute(
       return path.relative(from, to);
     },
   };
+  const duplicateTranslationBehavior = normalizedOptions.i18nOptions.duplicateTranslationBehavior;
   const diagnostics = checkDuplicateMessages(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     checkFileSystem as any,
     extractionResult.messages,
-    'warning',
+    duplicateTranslationBehavior,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     extractionResult.basePath as any,
   );
-  if (diagnostics.messages.length > 0) {
-    context.logger.warn(diagnostics.formatDiagnostics(''));
+  if (diagnostics.messages.length > 0 && duplicateTranslationBehavior !== 'ignore') {
+    if (duplicateTranslationBehavior === 'error') {
+      context.logger.error(`Extraction Failed: ${diagnostics.formatDiagnostics('')}`);
+
+      return { success: false };
+    } else {
+      context.logger.warn(diagnostics.formatDiagnostics(''));
+    }
   }
 
   // Serialize all extracted messages

--- a/packages/angular_devkit/build_angular/src/builders/extract-i18n/options.ts
+++ b/packages/angular_devkit/build_angular/src/builders/extract-i18n/options.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import { createI18nOptions } from '@angular/build/private';
+import { type I18nOptions, createI18nOptions } from '@angular/build/private';
+import { type DiagnosticHandlingStrategy } from '@angular/localize/tools';
 import { BuilderContext, targetFromTargetString } from '@angular-devkit/architect';
 import { fail } from 'node:assert';
 import path from 'node:path';
@@ -36,7 +37,12 @@ export async function normalizeOptions(
   // Target specifier defaults to the current project's build target with no specified configuration
   const buildTargetSpecifier = options.buildTarget ?? ':';
   const buildTarget = targetFromTargetString(buildTargetSpecifier, projectName, 'build');
-  const i18nOptions = createI18nOptions(projectMetadata, /** inline */ false, context.logger);
+  const i18nOptions: I18nOptions & {
+    duplicateTranslationBehavior: DiagnosticHandlingStrategy;
+  } = {
+    ...createI18nOptions(projectMetadata, /** inline */ false, context.logger),
+    duplicateTranslationBehavior: options.i18nDuplicateTranslation || 'warning',
+  };
 
   // Normalize xliff format extensions
   let format = options.format;

--- a/packages/angular_devkit/build_angular/src/builders/extract-i18n/schema.json
+++ b/packages/angular_devkit/build_angular/src/builders/extract-i18n/schema.json
@@ -27,6 +27,11 @@
     "outFile": {
       "type": "string",
       "description": "Name of the file to output."
+    },
+    "i18nDuplicateTranslation": {
+      "type": "string",
+      "description": "How to handle duplicate translations.",
+      "enum": ["error", "warning", "ignore"]
     }
   },
   "additionalProperties": false


### PR DESCRIPTION
…option when duplicates exist

Running the extract-i18n command will always log duplicate i18n message IDs as warnings, regardless of the value of the i18nDuplicateTranslation option. With this fix, command will log duplication errors and exit with code 1

Fixes #23635

Already merged to main #30306 

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the new behavior that. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
