### PR TITLE
build: improve globbing of jasmine test files

### DIFF
--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -65,9 +65,10 @@ def jasmine_test(data = [], args = [], **kwargs):
         chdir = native.package_name(),
         args = [
             "--require=%s/node_modules/source-map-support/register.js" % relative_to_root,
-            "**/*spec.js",
-            "**/*spec.mjs",
-            "**/*spec.cjs",
+            # Escape so that the `js_binary` launcher triggers Bash expansion.
+            "'**/*+(.|_)spec.js'",
+            "'**/*+(.|_)spec.mjs'",
+            "'**/*+(.|_)spec.cjs'",
         ] + args,
         data = data + ["//:node_modules/source-map-support"],
         **kwargs


### PR DESCRIPTION
This doesn't seem to surface here, but in the framework and in the COMP repo, the glob wasn't catching all files because it wasn't escaped— so didn't actually get picked up by Jasmine, but was expanded by Bash.

This improves the rule and makes this logic more future-proof.