### PR TITLE
fix(@schematics/angular): correctly detect modules using new file extension format

### DIFF
--- a/packages/schematics/angular/component/index.ts
+++ b/packages/schematics/angular/component/index.ts
@@ -53,16 +53,7 @@ export default function (options: ComponentOptions): Rule {
       options.path = buildDefaultPath(project);
     }
 
-    try {
-      options.module = findModuleFromOptions(host, options);
-    } catch {
-      options.module = findModuleFromOptions(host, {
-        ...options,
-        moduleExt: '-module.ts',
-        routingModuleExt: '-routing-module.ts',
-      });
-    }
-
+    options.module = findModuleFromOptions(host, options);
     // Schematic templates require a defined type value
     options.type ??= '';
 

--- a/packages/schematics/angular/directive/index.ts
+++ b/packages/schematics/angular/directive/index.ts
@@ -38,15 +38,7 @@ export default function (options: DirectiveOptions): Rule {
       options.path = buildDefaultPath(project);
     }
 
-    try {
-      options.module = findModuleFromOptions(host, options);
-    } catch {
-      options.module = findModuleFromOptions(host, {
-        ...options,
-        moduleExt: '-module.ts',
-        routingModuleExt: '-routing-module.ts',
-      });
-    }
+    options.module = findModuleFromOptions(host, options);
     const parsedPath = parseName(options.path, options.name);
     options.name = parsedPath.name;
     options.path = parsedPath.path;

--- a/packages/schematics/angular/module/index.ts
+++ b/packages/schematics/angular/module/index.ts
@@ -27,7 +27,9 @@ import { addImportToModule, addRouteDeclarationToModule } from '../utility/ast-u
 import { InsertChange } from '../utility/change';
 import {
   MODULE_EXT,
+  MODULE_EXT_LEGACY,
   ROUTING_MODULE_EXT,
+  ROUTING_MODULE_EXT_LEGACY,
   buildRelativePath,
   findModuleFromOptions,
 } from '../utility/find-module';
@@ -114,11 +116,11 @@ function addRouteDeclarationToNgModule(
 
 function getRoutingModulePath(host: Tree, modulePath: string): string | undefined {
   const routingModulePath =
-    modulePath.endsWith(ROUTING_MODULE_EXT) || modulePath.endsWith('-routing-module.ts')
+    modulePath.endsWith(ROUTING_MODULE_EXT_LEGACY) || modulePath.endsWith(ROUTING_MODULE_EXT)
       ? modulePath
       : modulePath
-          .replace(MODULE_EXT, ROUTING_MODULE_EXT)
-          .replace('-module.ts', '-routing-module.ts');
+          .replace(MODULE_EXT_LEGACY, ROUTING_MODULE_EXT_LEGACY)
+          .replace(MODULE_EXT, ROUTING_MODULE_EXT);
 
   return host.exists(routingModulePath) ? routingModulePath : undefined;
 }
@@ -138,15 +140,7 @@ export default function (options: ModuleOptions): Rule {
     }
 
     if (options.module) {
-      try {
-        options.module = findModuleFromOptions(host, options);
-      } catch {
-        options.module = findModuleFromOptions(host, {
-          ...options,
-          moduleExt: '-module.ts',
-          routingModuleExt: '-routing-module.ts',
-        });
-      }
+      options.module = findModuleFromOptions(host, options);
     }
 
     let routingModulePath;

--- a/packages/schematics/angular/pipe/index.ts
+++ b/packages/schematics/angular/pipe/index.ts
@@ -18,16 +18,7 @@ import { Schema as PipeOptions } from './schema';
 export default function (options: PipeOptions): Rule {
   return async (host: Tree) => {
     options.path ??= await createDefaultPath(host, options.project);
-    try {
-      options.module = findModuleFromOptions(host, options);
-    } catch {
-      options.module = findModuleFromOptions(host, {
-        ...options,
-        moduleExt: '-module.ts',
-        routingModuleExt: '-routing-module.ts',
-      });
-    }
-
+    options.module = findModuleFromOptions(host, options);
     const parsedPath = parseName(options.path, options.name);
     options.name = parsedPath.name;
     options.path = parsedPath.path;

--- a/packages/schematics/angular/utility/find-module_spec.ts
+++ b/packages/schematics/angular/utility/find-module_spec.ts
@@ -143,6 +143,15 @@ describe('find-module', () => {
       expect(modPath).toEqual('/projects/my-proj/src/admin/foo.module.ts');
     });
 
+    it('should find a module in a sub dir when using the `-module` suffix', () => {
+      tree.create('/projects/my-proj/src/admin/foo-module.ts', '@NgModule');
+      options.name = 'other/test';
+      options.module = 'admin/foo';
+      options.path = '/projects/my-proj/src';
+      const modPath = findModuleFromOptions(tree, options) as string;
+      expect(modPath).toEqual('/projects/my-proj/src/admin/foo-module.ts');
+    });
+
     it('should find a module in a sub dir (2)', () => {
       tree.create('/projects/my-proj/src/admin/foo.module.ts', '@NgModule');
       options.name = 'admin/hello';


### PR DESCRIPTION

Previously, some internal methods failed to locate modules when using the `-module.ts` filename pattern instead of the legacy `.module.ts`. This update ensures proper detection with the new format.
