### PR TITLE
build: simplify unit test target names

### DIFF
--- a/modules/testing/builder/BUILD.bazel
+++ b/modules/testing/builder/BUILD.bazel
@@ -45,6 +45,6 @@ ts_project(
 )
 
 jasmine_test(
-    name = "unit_test",
+    name = "test",
     data = [":unit_test_lib"],
 )

--- a/packages/angular/cli/BUILD.bazel
+++ b/packages/angular/cli/BUILD.bazel
@@ -117,7 +117,7 @@ ts_project(
 )
 
 jasmine_test(
-    name = "angular-cli_test",
+    name = "test",
     data = [":angular-cli_test_lib"],
 )
 

--- a/packages/angular/pwa/BUILD.bazel
+++ b/packages/angular/pwa/BUILD.bazel
@@ -58,7 +58,7 @@ ts_project(
 )
 
 jasmine_test(
-    name = "pwa_test",
+    name = "test",
     data = [":pwa_test_lib"],
 )
 

--- a/packages/angular/ssr/schematics/BUILD.bazel
+++ b/packages/angular/ssr/schematics/BUILD.bazel
@@ -83,7 +83,7 @@ ts_project(
 )
 
 jasmine_test(
-    name = "ssr_schematics_test",
+    name = "test",
     data = [
         ":schematics_assets",
         ":ssr_schematics_test_lib",

--- a/packages/angular_devkit/architect/BUILD.bazel
+++ b/packages/angular_devkit/architect/BUILD.bazel
@@ -88,7 +88,7 @@ ts_project(
 )
 
 jasmine_test(
-    name = "architect_test",
+    name = "test",
     data = [":architect_test_lib"],
 )
 

--- a/packages/angular_devkit/architect/node/BUILD.bazel
+++ b/packages/angular_devkit/architect/node/BUILD.bazel
@@ -42,6 +42,6 @@ ts_project(
 )
 
 jasmine_test(
-    name = "node_test",
+    name = "test",
     data = [":node_test_lib"],
 )

--- a/packages/angular_devkit/build_angular/BUILD.bazel
+++ b/packages/angular_devkit/build_angular/BUILD.bazel
@@ -235,7 +235,7 @@ ts_project(
 )
 
 jasmine_test(
-    name = "build_angular_test",
+    name = "test",
     data = [":build_angular_test_lib"],
 )
 

--- a/packages/angular_devkit/core/BUILD.bazel
+++ b/packages/angular_devkit/core/BUILD.bazel
@@ -59,7 +59,7 @@ ts_project(
 )
 
 jasmine_test(
-    name = "core_test",
+    name = "test",
     data = [":core_test_lib"],
 )
 

--- a/packages/angular_devkit/core/node/BUILD.bazel
+++ b/packages/angular_devkit/core/node/BUILD.bazel
@@ -47,6 +47,6 @@ ts_project(
 )
 
 jasmine_test(
-    name = "node_test",
+    name = "test",
     data = [":node_test_lib"],
 )

--- a/packages/angular_devkit/schematics/BUILD.bazel
+++ b/packages/angular_devkit/schematics/BUILD.bazel
@@ -48,7 +48,7 @@ ts_project(
 )
 
 jasmine_test(
-    name = "schematics_test",
+    name = "test",
     data = [":schematics_test_lib"],
 )
 

--- a/packages/angular_devkit/schematics/tools/BUILD.bazel
+++ b/packages/angular_devkit/schematics/tools/BUILD.bazel
@@ -52,6 +52,6 @@ ts_project(
 )
 
 jasmine_test(
-    name = "tools_test",
+    name = "test",
     data = [":tools_test_lib"],
 )

--- a/packages/angular_devkit/schematics_cli/test/BUILD.bazel
+++ b/packages/angular_devkit/schematics_cli/test/BUILD.bazel
@@ -21,7 +21,7 @@ npm_link_package(
 )
 
 jasmine_test(
-    name = "schematics_cli_test",
+    name = "test",
     data = [
         ":schematics_cli_test_lib",
         # The npm package itself is needed for the test at runtime, so we

--- a/packages/ngtools/webpack/BUILD.bazel
+++ b/packages/ngtools/webpack/BUILD.bazel
@@ -56,7 +56,7 @@ ts_project(
 )
 
 jasmine_test(
-    name = "webpack_test",
+    name = "test",
     data = [
         ":webpack_test_lib",
         # Needed at runtime for runtime TS compilations performed by tests.

--- a/packages/schematics/angular/BUILD.bazel
+++ b/packages/schematics/angular/BUILD.bazel
@@ -138,7 +138,7 @@ ts_project(
 )
 
 jasmine_test(
-    name = "angular_test",
+    name = "test",
     data = [":angular_test_lib"],
 )
 

--- a/tools/baseline_browserslist/BUILD.bazel
+++ b/tools/baseline_browserslist/BUILD.bazel
@@ -32,7 +32,7 @@ ts_project(
 )
 
 jasmine_test(
-    name = "baseline_browserslist_test",
+    name = "test",
     data = [":baseline_browserslist_test_lib"],
 )
 


### PR DESCRIPTION
Renamed unit test targets for easier execution without needing to inspect build files.

