### PR TITLE
build: simplify unit test target names

### DIFF
--- a/.ng-dev/dx-perf-workflows.yml
+++ b/.ng-dev/dx-perf-workflows.yml
@@ -46,4 +46,4 @@ workflows:
     prepare:
       - bazel clean
     workflow:
-      - bazel test //packages/angular/build:unit_tests
+      - bazel test //packages/angular/build:test

--- a/packages/angular/build/BUILD.bazel
+++ b/packages/angular/build/BUILD.bazel
@@ -162,7 +162,7 @@ ts_project(
 )
 
 jasmine_test(
-    name = "unit_tests",
+    name = "test",
     data = [":unit_test_lib"],
 )
 


### PR DESCRIPTION
Renamed unit test targets for easier execution without needing to inspect build files.
