### PR TITLE
build: update dependency io_bazel_rules_webtesting to v0.4.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -13,8 +13,8 @@ http_archive(
 
 http_archive(
     name = "io_bazel_rules_webtesting",
-    sha256 = "e9abb7658b6a129740c0b3ef6f5a2370864e102a5ba5ffca2cea565829ed825a",
-    urls = ["https://github.com/bazelbuild/rules_webtesting/releases/download/0.3.5/rules_webtesting.tar.gz"],
+    sha256 = "ce50bd8186aa782f1315647da0b2be833a10fac07073f980b221f7f6b7b42f54",
+    urls = ["https://github.com/bazelbuild/rules_webtesting/releases/download/0.4.0/rules_webtesting-0.4.0.tar.gz"],
 )
 
 http_archive(


### PR DESCRIPTION
Forked off https://github.com/angular/angular-cli/pull/30465, as `@rules_webtesting` seems to have changed its URL format.