### PR TITLE
fix(@angular/build): use date/time based output path for vitest unit-test

### DIFF
--- a/packages/angular/build/src/builders/unit-test/builder.ts
+++ b/packages/angular/build/src/builders/unit-test/builder.ts
@@ -113,7 +113,7 @@ export async function* execute(
     buildTargetOptions.polyfills.push('zone.js/testing');
   }
 
-  const outputPath = path.join(context.workspaceRoot, 'dist/test-out', randomUUID());
+  const outputPath = path.join(context.workspaceRoot, generateOutputPath());
   const buildOptions: ApplicationBuilderInternalOptions = {
     ...buildTargetOptions,
     watch: normalizedOptions.watch,
@@ -342,4 +342,11 @@ function setupBrowserConfiguration(
   };
 
   return { browser };
+}
+
+function generateOutputPath(): string {
+  const datePrefix = new Date().toISOString().replaceAll(/[-:.]/g, '');
+  const uuidSuffix = randomUUID().slice(0, 8);
+
+  return path.join('dist', 'test-out', `${datePrefix}-${uuidSuffix}`);
 }


### PR DESCRIPTION
The output directory name for the unit-test code when using the experimental `unit-test` builder with the `vitest` runner will now use a value based on the date and time of test execution instead of only a random UUID. This value improves the discoverability of a test execution when multiple have been performed.
