### PR TITLE
fix(@angular/build): do not consider internal Angular files as external imports

### DIFF
--- a/packages/angular/build/src/tools/esbuild/bundler-context.ts
+++ b/packages/angular/build/src/tools/esbuild/bundler-context.ts
@@ -366,6 +366,7 @@ export class BundlerContext {
         if (
           !external ||
           SERVER_GENERATED_EXTERNALS.has(path) ||
+          isInternalAngularFile(path) ||
           (kind !== 'import-statement' && kind !== 'dynamic-import' && kind !== 'require-call')
         ) {
           continue;


### PR DESCRIPTION
When using the `application` build system with i18n enabled, the development server may unintentionally attempt to optimize virtual internal files for the locale data. These virtual files are now excluded from the list of external imports.

Closes #30491