### PR TITLE
fix(@angular/build): improve default coverage reporter handling for vitest

### DIFF
--- a/packages/angular/build/src/builders/unit-test/builder.ts
+++ b/packages/angular/build/src/builders/unit-test/builder.ts
@@ -232,9 +232,12 @@ export async function* execute(
           watch: normalizedOptions.watch,
           coverage: {
             enabled: !!normalizedOptions.codeCoverage,
-            reporter: normalizedOptions.codeCoverage?.reporters,
             excludeAfterRemap: true,
             exclude: normalizedOptions.codeCoverage?.exclude,
+            // Special handling for `reporter` due to an undefined value causing upstream failures
+            ...(normalizedOptions.codeCoverage?.reporters
+              ? { reporters: normalizedOptions.codeCoverage.reporters }
+              : {}),
           },
           ...debugOptions,
         },


### PR DESCRIPTION
When using the experimental `unit-test` builder with the `vitest` runner, the default handling for the coverage reporter option has been improved to avoid a potential upstream failure within Vitest. Vitest can crash if an explicit `undefined` value is present for the `coverage.reporter` option.