### PR TITLE
fix(@schematics/angular): include `main.server.ts` in `tsconfig.files` when present

### DIFF
--- a/packages/schematics/angular/server/index.ts
+++ b/packages/schematics/angular/server/index.ts
@@ -119,6 +119,14 @@ function updateConfigFileApplicationBuilder(options: ServerOptions): Rule {
 function updateTsConfigFile(tsConfigPath: string): Rule {
   return (host: Tree) => {
     const json = new JSONFile(host, tsConfigPath);
+    // Skip adding the files entry if the server entry would already be included.
+    const include = json.get(['include']);
+    if (!Array.isArray(include) || !include.includes('src/**/*.ts')) {
+      const filesPath = ['files'];
+      const files = new Set((json.get(filesPath) as string[] | undefined) ?? []);
+      files.add('src/' + serverMainEntryName);
+      json.modify(filesPath, [...files]);
+    }
 
     const typePath = ['compilerOptions', 'types'];
     const types = new Set((json.get(typePath) as string[] | undefined) ?? []);


### PR DESCRIPTION


Add logic to automatically include `main.server.ts` in the `files` array of the tsconfig when present during schematic execution. This ensures backwards compatibility for applications generated prior to version 19.

Closes #30526
