### PR TITLE
fix(@schematics/angular): reset module `typeSeparator` when generating applications

### DIFF
--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -69,6 +69,7 @@ export default function (options: ApplicationOptions): Rule {
             routingScope: 'Root',
             path: sourceDir,
             project: options.name,
+            typeSeparator: undefined,
           }),
       schematic('component', {
         name: 'app',


### PR DESCRIPTION


The application schematic now invokes the module schematic with `typeSeparator` explicitly set to `undefined`. This ensures any legacy value from `angular.json` set by older versions of the Angular CLI is cleared during application generation and does not cause multiple files to be generated.

Closes #30497
