### PR TITLE
fix(@angular/build): set scripts option output as classic script for karma

### DIFF
--- a/packages/angular/build/src/builders/karma/application_builder.ts
+++ b/packages/angular/build/src/builders/karma/application_builder.ts
@@ -161,6 +161,11 @@ class AngularPolyfillsPlugin {
               // page load. `type` won't affect them.
               continue;
             }
+            if (f.pattern === 'scripts.js') {
+              // Don't consider "scripts" option files as module types.
+              // This should be expanded if custom scripts bundle names support is added.
+              continue;
+            }
             if (f.pattern.endsWith('.js') && 'js' === (f.type ?? 'js')) {
               f.type = 'module';
             }


### PR DESCRIPTION
When using the `karma` builder, the generated output JavaScript file was unintentionally being marked as a module type script. This prevent the output file from providing equivalent behavior to that of an actual build. The `scripts` option outputs should be considered classic scripts to the browser.

Closes #30534