### PR TITLE
fix(@angular/build): use an empty array as default value for vitest exclude

### DIFF
--- a/packages/angular/build/src/builders/unit-test/builder.ts
+++ b/packages/angular/build/src/builders/unit-test/builder.ts
@@ -233,7 +233,7 @@ export async function* execute(
           coverage: {
             enabled: !!normalizedOptions.codeCoverage,
             excludeAfterRemap: true,
-            exclude: normalizedOptions.codeCoverage?.exclude,
+            exclude: normalizedOptions.codeCoverage?.exclude ?? [],
             // Special handling for `reporter` due to an undefined value causing upstream failures
             ...(normalizedOptions.codeCoverage?.reporters
               ? { reporters: normalizedOptions.codeCoverage.reporters }


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #30543

## What is the new behavior?

Avoids the error `resolved.coverage.exclude is not iterable` while running `ng test`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
