### PR TITLE
fix(@angular/build): coverage reporter option

### DIFF
--- a/packages/angular/build/src/builders/unit-test/builder.ts
+++ b/packages/angular/build/src/builders/unit-test/builder.ts
@@ -236,7 +236,7 @@ export async function* execute(
             exclude: normalizedOptions.codeCoverage?.exclude,
             // Special handling for `reporter` due to an undefined value causing upstream failures
             ...(normalizedOptions.codeCoverage?.reporters
-              ? { reporters: normalizedOptions.codeCoverage.reporters }
+              ? { reporter: normalizedOptions.codeCoverage.reporters }
               : {}),
           },
           ...debugOptions,


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

The `codeCoverageReporters` option has no effect.

## What is the new behavior?

The vitest coverage reporters option is `reporter` and not `reporters`, see https://vitest.dev/config/#coverage-reporter

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
