### PR TITLE
fix(@angular/ssr): avoid preloading unnecessary dynamic bundles

### DIFF
--- a/packages/angular/build/src/utils/server-rendering/manifest.ts
+++ b/packages/angular/build/src/utils/server-rendering/manifest.ts
@@ -201,34 +201,22 @@ function generateLazyLoadedFilesMappings(
   metafile: Metafile,
   initialFiles: Set<string>,
   publicPath = '',
-): Record<string, FilesMapping[]> {
-  const entryPointToBundles: Record<string, FilesMapping[]> = {};
+): Record<string, string[]> {
+  const entryPointToBundles: Record<string, string[]> = {};
   for (const [fileName, { entryPoint, exports, imports }] of Object.entries(metafile.outputs)) {
     // Skip files that don't have an entryPoint, no exports, or are not .js
     if (!entryPoint || exports?.length < 1 || !fileName.endsWith('.js')) {
       continue;
     }
 
-    const importedPaths: FilesMapping[] = [
-      {
-        path: `${publicPath}${fileName}`,
-        dynamicImport: false,
-      },
-    ];
+    const importedPaths: string[] = [`${publicPath}${fileName}`];
 
     for (const { kind, external, path } of imports) {
-      if (
-        external ||
-        initialFiles.has(path) ||
-        (kind !== 'dynamic-import' && kind !== 'import-statement')
-      ) {
+      if (external || initialFiles.has(path) || kind !== 'import-statement') {
         continue;
       }
 
-      importedPaths.push({
-        path: `${publicPath}${path}`,
-        dynamicImport: kind === 'dynamic-import',
-      });
+      importedPaths.push(`${publicPath}${path}`);
     }
 
     entryPointToBundles[entryPoint] = importedPaths;

--- a/packages/angular/ssr/src/manifest.ts
+++ b/packages/angular/ssr/src/manifest.ts
@@ -123,21 +123,16 @@ export interface AngularAppManifest {
    * Maps entry-point names to their corresponding browser bundles and loading strategies.
    *
    * - **Key**: The entry-point name, typically the value of `ɵentryName`.
-   * - **Value**: An array of objects, each representing a browser bundle with:
-   *   - `path`: The filename or URL of the associated JavaScript bundle to preload.
-   *   - `dynamicImport`: A boolean indicating whether the bundle is loaded via a dynamic `import()`.
-   *     If `true`, the bundle is lazily loaded, impacting its preloading behavior.
+   * - **Value**: A readonly array of JavaScript bundle paths or `undefined` if no bundles are associated.
    *
    * ### Example
    * ```ts
    * {
-   *   'src/app/lazy/lazy.ts': [{ path: 'src/app/lazy/lazy.js', dynamicImport: true }]
+   *   'src/app/lazy/lazy.ts': ['src/app/lazy/lazy.js']
    * }
    * ```
    */
-  readonly entryPointToBrowserMapping?: Readonly<
-    Record<string, ReadonlyArray<{ path: string; dynamicImport: boolean }> | undefined>
-  >;
+  readonly entryPointToBrowserMapping?: Readonly<Record<string, readonly string[] | undefined>>;
 }
 
 /**

--- a/tests/legacy-cli/e2e/tests/build/server-rendering/server-routes-preload-links.ts
+++ b/tests/legacy-cli/e2e/tests/build/server-rendering/server-routes-preload-links.ts
@@ -143,17 +143,15 @@ const RESPONSE_EXPECTS: Record<
     matches: [
       /<link rel="modulepreload" href="(ssg\.routes-[a-zA-Z0-9]{8}\.js)">/,
       /<link rel="modulepreload" href="(ssg-one-[a-zA-Z0-9]{8}\.js)">/,
-      /<link rel="modulepreload" href="(cross-dep-[a-zA-Z0-9]{8}\.js)">/,
     ],
-    notMatches: [/home/, /ssr/, /csr/, /ssg-two/, /ssg\-component/],
+    notMatches: [/home/, /ssr/, /csr/, /ssg-two/, /ssg\-component/, /cross-dep-/],
   },
   '/ssg/two': {
     matches: [
       /<link rel="modulepreload" href="(ssg\.routes-[a-zA-Z0-9]{8}\.js)">/,
       /<link rel="modulepreload" href="(ssg-two-[a-zA-Z0-9]{8}\.js)">/,
-      /<link rel="modulepreload" href="(cross-dep-[a-zA-Z0-9]{8}\.js)">/,
     ],
-    notMatches: [/home/, /ssr/, /csr/, /ssg-one/, /ssg\-component/],
+    notMatches: [/home/, /ssr/, /csr/, /ssg-one/, /ssg\-component/, /cross-dep-/],
   },
   '/ssr': {
     matches: [/<link rel="modulepreload" href="(ssr-[a-zA-Z0-9]{8}\.js)">/],


### PR DESCRIPTION
This change to `@angular/ssr` prevents the preloading of dynamically imported bundles that aren't directly associated with routing.

Previously, Angular SSR might preload all dynamic bundles, even those not immediately required, such as deferred chunks within components.

Closes #30541