### PR TITLE
test(@angular/build): reset project metadata before each run

### DIFF
--- a/modules/testing/builder/src/builder-harness.ts
+++ b/modules/testing/builder/src/builder-harness.ts
@@ -115,6 +115,10 @@ export class BuilderHarness<T> {
     return join(getSystemPath(this.host.root()), path);
   }
 
+  resetProjectMetadata(): void {
+    this.projectMetadata = DEFAULT_PROJECT_METADATA;
+  }
+
   useProject(name: string, metadata: Record<string, unknown> = {}): this {
     if (!name) {
       throw new Error('Project name cannot be an empty string.');

--- a/modules/testing/builder/src/jasmine-helpers.ts
+++ b/modules/testing/builder/src/jasmine-helpers.ts
@@ -37,7 +37,11 @@ export function describeBuilder<T>(
   });
 
   describe(options.name || builderHandler.name, () => {
-    beforeEach(() => host.initialize().toPromise());
+    beforeEach(async () => {
+      harness.resetProjectMetadata();
+
+      await host.initialize().toPromise();
+    });
 
     afterEach(() => host.restore().toPromise());
 


### PR DESCRIPTION
Prevents test flakiness caused by `useProject` not cleaning up metadata between runs.
