### PR TITLE
test: remove unneeded bazel tsetse configuration

### DIFF
--- a/tsconfig-test.json
+++ b/tsconfig-test.json
@@ -7,13 +7,6 @@
     // Istanbul (not Constantinople) as well, and applying both source maps to get the original
     // source in devtools.
     "inlineSources": true,
-    "types": ["node", "jasmine"],
-    "plugins": [
-      {
-        "name": "@bazel/tsetse",
-        // TODO: Cleanup tests and remove this rule disable
-        "disabledRules": ["must-type-assert-json-parse"]
-      }
-    ]
+    "types": ["node", "jasmine"]
   }
 }


### PR DESCRIPTION
Remove outdated `@bazel/tsetse` plugin configuration from test TS configuration. With the `rules_js` migration, `@bazel/tsetse` is no longer used.