### PR TITLE
fix(@angular/ssr): ensure correct referer header handling in web request conversion

### DIFF
--- a/packages/angular/ssr/node/src/request.ts
+++ b/packages/angular/ssr/node/src/request.ts
@@ -33,12 +33,14 @@ export function createWebRequestFromNodeRequest(
 ): Request {
   const { headers, method = 'GET' } = nodeRequest;
   const withBody = method !== 'GET' && method !== 'HEAD';
+  const referrer = headers.referer && URL.canParse(headers.referer) ? headers.referer : undefined;
 
   return new Request(createRequestUrl(nodeRequest), {
     method,
     headers: createRequestHeaders(headers),
     body: withBody ? nodeRequest : undefined,
     duplex: withBody ? 'half' : undefined,
+    referrer,
   });
 }
 


### PR DESCRIPTION
The `Referer` header is classified as a forbidden header name within the Web Standard Fetch API. This means it cannot be manually set directly within the `headers` option, instead it must be set when constructing a `new Request()` object.

Closes #30581
