### PR TITLE
fix(@schematics/angular): add missing prettier config

### DIFF
--- a/packages/schematics/angular/workspace/files/package.json.template
+++ b/packages/schematics/angular/workspace/files/package.json.template
@@ -8,6 +8,16 @@
     "watch": "ng build --watch --configuration development"<% if (!minimal) { %>,
     "test": "ng test"<% } %>
   },
+  "prettier": {
+    "overrides": [
+      {
+        "files": "*.html",
+        "options": {
+          "parser": "angular"
+        }
+      }
+    ]
+  },
   "private": true,
   "dependencies": {
     "@angular/common": "<%= latestVersions.Angular %>",

--- a/packages/schematics/angular/workspace/index_spec.ts
+++ b/packages/schematics/angular/workspace/index_spec.ts
@@ -133,4 +133,10 @@ describe('Workspace Schematic', () => {
     const { tasks } = parseJson(tree.readContent('.vscode/tasks.json').toString());
     expect(tasks).not.toContain(jasmine.objectContaining({ type: 'npm', script: 'test' }));
   });
+
+  it('should include prettier config overrides for Angular templates', async () => {
+    const tree = await schematicRunner.runSchematic('workspace', defaultOptions);
+    const pkg = JSON.parse(tree.readContent('/package.json'));
+    expect(pkg.prettier).withContext('package.json#prettier is present').toBeTruthy();
+  });
 });


### PR DESCRIPTION
The current style guide no longer enforces the use of the template file extension `.component.html`. This means that prettier won't auto-detect the proper parser for these files anymore.

To ensure template formatting works out-of-the-box, we're adding a prettier config to newly created projects.

Fixes https://github.com/angular/angular-cli/issues/30548