### PR TITLE
build: remove dep on `io_bazel_rules_webtesting`

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,12 +12,6 @@ http_archive(
 )
 
 http_archive(
-    name = "io_bazel_rules_webtesting",
-    sha256 = "e9abb7658b6a129740c0b3ef6f5a2370864e102a5ba5ffca2cea565829ed825a",
-    urls = ["https://github.com/bazelbuild/rules_webtesting/releases/download/0.3.5/rules_webtesting.tar.gz"],
-)
-
-http_archive(
     name = "build_bazel_rules_nodejs",
     sha256 = "5dd1e5dea1322174c57d3ca7b899da381d516220793d0adef3ba03b9d23baa8e",
     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.8.3/rules_nodejs-5.8.3.tar.gz"],


### PR DESCRIPTION
This seems to be unused.
