### PR TITLE
ci: disable auto updates for `io_bazel_rules_webtesting`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>angular/dev-infra//renovate-presets/default.json5"],
   "ignorePaths": ["tests/legacy-cli/e2e/assets/**", "tests/schematics/update/packages/**"],
-  "ignoreDeps": ["verdaccio"],
+  "ignoreDeps": ["io_bazel_rules_webtesting", "verdaccio"],
   "packageRules": [
     {
       "matchFileNames": [


### PR DESCRIPTION
This requires some changes due to the below error:

```
ERROR: error loading package '@@devinfra//bazel/browsers/chromium': Every .bzl file must have a corresponding package, but '@@io_bazel_rules_webtesting//web:web.bzl' does not have one. Please create a BUILD file in the same or any parent directory. Note that this BUILD file does not need to do anything except exist.
```

