### PR TITLE
fix(@angular-devkit/build-angular): remove unused `@vitejs/plugin-basic-ssl` dependency

### DIFF
--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -22,7 +22,6 @@
     "@babel/runtime": "7.27.6",
     "@discoveryjs/json-ext": "0.6.3",
     "@ngtools/webpack": "workspace:0.0.0-PLACEHOLDER",
-    "@vitejs/plugin-basic-ssl": "2.0.0",
     "ansi-colors": "4.1.3",
     "autoprefixer": "10.4.21",
     "babel-loader": "10.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -632,9 +632,6 @@ importers:
       '@ngtools/webpack':
         specifier: workspace:0.0.0-PLACEHOLDER
         version: link:../../ngtools/webpack
-      '@vitejs/plugin-basic-ssl':
-        specifier: 2.0.0
-        version: 2.0.0(vite@7.0.0(@types/node@20.19.1)(jiti@1.21.7)(less@4.3.0)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0))
       ansi-colors:
         specifier: 4.1.3
         version: 4.1.3


### PR DESCRIPTION


This dependency is no longer needed.

Closes #30613

