### PR TITLE
fix(@angular-devkit/build-angular): remove unused `@vitejs/plugin-basic-ssl` dependency

### DIFF
--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -22,7 +22,6 @@
     "@babel/runtime": "7.27.1",
     "@discoveryjs/json-ext": "0.6.3",
     "@ngtools/webpack": "workspace:0.0.0-PLACEHOLDER",
-    "@vitejs/plugin-basic-ssl": "2.0.0",
     "ansi-colors": "4.1.3",
     "autoprefixer": "10.4.21",
     "babel-loader": "10.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -629,9 +629,6 @@ importers:
       '@ngtools/webpack':
         specifier: workspace:0.0.0-PLACEHOLDER
         version: link:../../ngtools/webpack
-      '@vitejs/plugin-basic-ssl':
-        specifier: 2.0.0
-        version: 2.0.0(vite@6.3.5(@types/node@20.17.46)(jiti@1.21.7)(less@4.3.0)(sass@1.88.0)(terser@5.39.1)(yaml@2.7.1))
       ansi-colors:
         specifier: 4.1.3
         version: 4.1.3
@@ -6736,7 +6733,6 @@ packages:
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
     deprecated: |-
       You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
-
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qjobs@1.2.0:


### PR DESCRIPTION

This dependency is no longer needed.

Closes #30613

(cherry picked from commit f1d41b069db6cd3ab83561113567b8e5f4bf25d8)
