### PR TITLE
build: use more shards for application builder tests

### DIFF
--- a/packages/angular/build/BUILD.bazel
+++ b/packages/angular/build/BUILD.bazel
@@ -294,7 +294,7 @@ jasmine_test(
     size = "large",
     data = [":application_integration_test_lib"],
     flaky = True,
-    shard_count = 10,
+    shard_count = 20,
 )
 
 jasmine_test(


### PR DESCRIPTION
We've added more tests (yay!) but at least when running on RBE, this seems to have made things less stable.

I've tried to run the tests a few times with `--config=remote --nocache_test_results` and this appears to make them pass consistently. There may be a more perfect integer but x2 should give us stable CI again (at least for this issue).