### PR TITLE
fix(@angular/build): proxy karma request from `/` to `/base`

### DIFF
--- a/packages/angular/build/src/builders/karma/index.ts
+++ b/packages/angular/build/src/builders/karma/index.ts
@@ -99,6 +99,7 @@ function getBuiltInKarmaConfig(
   // Any changes to the config here need to be synced to: packages/schematics/angular/config/files/karma.conf.js.template
   return {
     basePath: '',
+    rootUrl: '/',
     frameworks: ['jasmine'],
     plugins: [
       'karma-jasmine',
@@ -106,6 +107,9 @@ function getBuiltInKarmaConfig(
       'karma-jasmine-html-reporter',
       'karma-coverage',
     ].map((p) => workspaceRootRequire(p)),
+    proxies: {
+      '/': '/base/',
+    },
     jasmineHtmlReporter: {
       suppressAll: true, // removes the duplicated traces
     },


### PR DESCRIPTION
This commit fixes an issue where Karma requests were not being correctly proxied, leading to 404 errors for assets and other files during test execution in Angular projects. The fix ensures that all Karma requests from the root (`/`) are correctly forwarded to the `/base` directory, where Karma serves the files.

Karma will always serve files from `/base`. This change aligns the testing environment with this fundamental behavior, resolving pathing issues and ensuring that tests can locate their dependencies reliably.

Closes #30627
