### PR TITLE
test: raise timeout of `//packages/ngtools/webpack:test`

### DIFF
--- a/packages/ngtools/webpack/BUILD.bazel
+++ b/packages/ngtools/webpack/BUILD.bazel
@@ -57,6 +57,7 @@ ts_project(
 
 jasmine_test(
     name = "test",
+    size = "medium",
     data = [
         ":webpack_test_lib",
         # Needed at runtime for runtime TS compilations performed by tests.


### PR DESCRIPTION
This seems to be timing out occasionally in CI.