### PR TITLE
fix(@angular/build): correctly remap Angular diagnostics

### DIFF
--- a/packages/angular/build/src/tools/esbuild/angular/diagnostics.ts
+++ b/packages/angular/build/src/tools/esbuild/angular/diagnostics.ts
@@ -75,9 +75,13 @@ export function convertTypeScriptDiagnostic(
 ): PartialMessage {
   let codePrefix = 'TS';
   let code = `${diagnostic.code}`;
-  if (diagnostic.source === 'ngtsc') {
+
+  // Custom ngtsc diagnostics are prefixed with -99 which isn't a valid TypeScript diagnostic code.
+  // Strip it and mark the diagnostic as coming from Angular. Note that we can't rely on
+  // `diagnostic.source`, because it isn't always produced. This is identical to:
+  // https://github.com/angular/angular/blob/main/packages/compiler-cli/src/ngtsc/diagnostics/src/util.ts
+  if (code.startsWith('-99')) {
     codePrefix = 'NG';
-    // Remove `-99` Angular prefix from diagnostic code
     code = code.slice(3);
   }
 


### PR DESCRIPTION
The esbuild builder has some logic that re-map diagnostics coming from the compiler, depending on their `source` and `code`. Currently this is incorrect, because it assumed that a value of `ngtsc` for `source` always means that the error is from the Angular compiler, but what it actually means is that it comes from an Angular template diagnostics. Furthermore, we can't rely on a `source` always being defined.

These changes align the logic to a similar one we already have in the compiler where we assume the diagnostic comes from Angular if it starts with `-99`.
