### PR TITLE
build: update bazel commands to use pnpm

### DIFF
--- a/packages/angular/ssr/test/npm_package/BUILD.bazel
+++ b/packages/angular/ssr/test/npm_package/BUILD.bazel
@@ -37,7 +37,7 @@ diff_test(
     failure_message = """
 
     To accept the new golden file, execute:
-    yarn bazel run //packages/angular/ssr/test/npm_package:beasties_license_test.accept
+    pnpm bazel run //packages/angular/ssr/test/npm_package:beasties_license_test.accept
     """,
     file1 = ":THIRD_PARTY_LICENSES.txt.golden",
     file2 = ":beasties_license_file",
@@ -50,7 +50,7 @@ write_file(
         [
             "#!/usr/bin/env bash",
             "cd ${BUILD_WORKSPACE_DIRECTORY}",
-            "yarn bazel build //packages/angular/ssr:npm_package",
+            "pnpm bazel build //packages/angular/ssr:npm_package",
             "cp -fv dist/bin/packages/angular/ssr/npm_package/third_party/beasties/THIRD_PARTY_LICENSES.txt packages/angular/ssr/test/npm_package/THIRD_PARTY_LICENSES.txt.golden",
         ],
     is_executable = True,


### PR DESCRIPTION
`yarn` is no longer used.

