### PR TITLE
fix(@angular/build): resolve "Controller is already closed" error in Karma

### DIFF
--- a/goldens/public-api/angular/build/index.api.md
+++ b/goldens/public-api/angular/build/index.api.md
@@ -153,9 +153,7 @@ export function executeDevServerBuilder(options: DevServerBuilderOptions, contex
 export function executeExtractI18nBuilder(options: ExtractI18nBuilderOptions, context: BuilderContext, extensions?: ApplicationBuilderExtensions): Promise<BuilderOutput>;
 
 // @public
-export function executeKarmaBuilder(options: KarmaBuilderOptions, context: BuilderContext, transforms?: {
-    karmaOptions?: (options: KarmaConfigOptions) => KarmaConfigOptions;
-}): AsyncIterable<BuilderOutput>;
+export function executeKarmaBuilder(options: KarmaBuilderOptions, context: BuilderContext, transforms?: KarmaBuilderTransformsOptions): AsyncIterable<BuilderOutput>;
 
 // @public
 export function executeNgPackagrBuilder(options: NgPackagrBuilderOptions, context: BuilderContext): AsyncIterableIterator<BuilderOutput>;

--- a/packages/angular/build/src/builders/karma/application_builder.ts
+++ b/packages/angular/build/src/builders/karma/application_builder.ts
@@ -24,7 +24,7 @@ import { ApplicationBuilderInternalOptions } from '../application/options';
 import { Result, ResultFile, ResultKind } from '../application/results';
 import { OutputHashing } from '../application/schema';
 import { findTests, getTestEntrypoints } from './find-tests';
-import { Schema as KarmaBuilderOptions } from './schema';
+import { NormalizedKarmaBuilderOptions } from './options';
 
 const localResolve = createRequire(__filename).resolve;
 const isWindows = process.platform === 'win32';
@@ -275,7 +275,7 @@ function injectKarmaReporter(
 }
 
 export function execute(
-  options: KarmaBuilderOptions,
+  options: NormalizedKarmaBuilderOptions,
   context: BuilderContext,
   karmaOptions: ConfigOptions,
   transforms: {
@@ -359,14 +359,14 @@ function normalizePolyfills(polyfills: string | string[] | undefined): [string[]
 }
 
 async function collectEntrypoints(
-  options: KarmaBuilderOptions,
+  options: NormalizedKarmaBuilderOptions,
   context: BuilderContext,
   projectSourceRoot: string,
 ): Promise<Map<string, string>> {
   // Glob for files to test.
   const testFiles = await findTests(
-    options.include ?? [],
-    options.exclude ?? [],
+    options.include,
+    options.exclude,
     context.workspaceRoot,
     projectSourceRoot,
   );
@@ -376,7 +376,7 @@ async function collectEntrypoints(
 
 // eslint-disable-next-line max-lines-per-function
 async function initializeApplication(
-  options: KarmaBuilderOptions,
+  options: NormalizedKarmaBuilderOptions,
   context: BuilderContext,
   karmaOptions: ConfigOptions,
   transforms: {
@@ -435,7 +435,7 @@ async function initializeApplication(
     scripts: options.scripts,
     polyfills,
     webWorkerTsConfig: options.webWorkerTsConfig,
-    watch: options.watch ?? !karmaOptions.singleRun,
+    watch: options.watch,
     stylePreprocessorOptions: options.stylePreprocessorOptions,
     inlineStyleLanguage: options.inlineStyleLanguage,
     fileReplacements: options.fileReplacements,

--- a/packages/angular/build/src/builders/karma/index.ts
+++ b/packages/angular/build/src/builders/karma/index.ts
@@ -13,15 +13,12 @@ import {
   createBuilder,
 } from '@angular-devkit/architect';
 import type { ConfigOptions } from 'karma';
-import { createRequire } from 'node:module';
-import path from 'node:path';
-import { NormalizedKarmaBuilderOptions, normalizeOptions } from './options';
+
 import type { Schema as KarmaBuilderOptions } from './schema';
 
-export type KarmaConfigOptions = ConfigOptions & {
-  buildWebpack?: unknown;
-  configFile?: string;
-};
+export interface KarmaBuilderTransformsOptions {
+  karmaOptions?: (options: ConfigOptions) => ConfigOptions | Promise<ConfigOptions>;
+}
 
 /**
  * @experimental Direct usage of this function is considered experimental.
@@ -29,98 +26,11 @@ export type KarmaConfigOptions = ConfigOptions & {
 export async function* execute(
   options: KarmaBuilderOptions,
   context: BuilderContext,
-  transforms: {
-    // The karma options transform cannot be async without a refactor of the builder implementation
-    karmaOptions?: (options: KarmaConfigOptions) => KarmaConfigOptions;
-  } = {},
+  transforms?: KarmaBuilderTransformsOptions,
 ): AsyncIterable<BuilderOutput> {
   const { execute } = await import('./application_builder');
-  const normalizedOptions = normalizeOptions(options);
-  const karmaOptions = getBaseKarmaOptions(normalizedOptions, context);
 
-  yield* execute(normalizedOptions, context, karmaOptions, transforms);
-}
-
-function getBaseKarmaOptions(
-  options: NormalizedKarmaBuilderOptions,
-  context: BuilderContext,
-): KarmaConfigOptions {
-  const singleRun = !options.watch;
-
-  // Determine project name from builder context target
-  const projectName = context.target?.project;
-  if (!projectName) {
-    throw new Error(`The 'karma' builder requires a target to be specified.`);
-  }
-
-  const karmaOptions: KarmaConfigOptions = options.karmaConfig
-    ? {}
-    : getBuiltInKarmaConfig(context.workspaceRoot, projectName);
-
-  karmaOptions.singleRun = singleRun;
-
-  // Workaround https://github.com/angular/angular-cli/issues/28271, by clearing context by default
-  // for single run executions. Not clearing context for multi-run (watched) builds allows the
-  // Jasmine Spec Runner to be visible in the browser after test execution.
-  karmaOptions.client ??= {};
-  karmaOptions.client.clearContext ??= singleRun ?? false; // `singleRun` defaults to `false` per Karma docs.
-
-  // Convert browsers from a string to an array
-  if (options.browsers) {
-    karmaOptions.browsers = options.browsers;
-  }
-
-  if (options.reporters) {
-    karmaOptions.reporters = options.reporters;
-  }
-
-  return karmaOptions;
-}
-
-function getBuiltInKarmaConfig(
-  workspaceRoot: string,
-  projectName: string,
-): ConfigOptions & Record<string, unknown> {
-  let coverageFolderName = projectName.charAt(0) === '@' ? projectName.slice(1) : projectName;
-  coverageFolderName = coverageFolderName.toLowerCase();
-
-  const workspaceRootRequire = createRequire(workspaceRoot + '/');
-
-  // Any changes to the config here need to be synced to: packages/schematics/angular/config/files/karma.conf.js.template
-  return {
-    basePath: '',
-    rootUrl: '/',
-    frameworks: ['jasmine'],
-    plugins: [
-      'karma-jasmine',
-      'karma-chrome-launcher',
-      'karma-jasmine-html-reporter',
-      'karma-coverage',
-    ].map((p) => workspaceRootRequire(p)),
-    jasmineHtmlReporter: {
-      suppressAll: true, // removes the duplicated traces
-    },
-    coverageReporter: {
-      dir: path.join(workspaceRoot, 'coverage', coverageFolderName),
-      subdir: '.',
-      reporters: [{ type: 'html' }, { type: 'text-summary' }],
-    },
-    reporters: ['progress', 'kjhtml'],
-    browsers: ['Chrome'],
-    customLaunchers: {
-      // Chrome configured to run in a bazel sandbox.
-      // Disable the use of the gpu and `/dev/shm` because it causes Chrome to
-      // crash on some environments.
-      // See:
-      //   https://github.com/puppeteer/puppeteer/blob/v1.0.0/docs/troubleshooting.md#tips
-      //   https://stackoverflow.com/questions/50642308/webdriverexception-unknown-error-devtoolsactiveport-file-doesnt-exist-while-t
-      ChromeHeadlessNoSandbox: {
-        base: 'ChromeHeadless',
-        flags: ['--no-sandbox', '--headless', '--disable-gpu', '--disable-dev-shm-usage'],
-      },
-    },
-    restartOnFileChange: true,
-  };
+  yield* execute(options, context, transforms);
 }
 
 export type { KarmaBuilderOptions };

--- a/packages/angular/build/src/builders/karma/options.ts
+++ b/packages/angular/build/src/builders/karma/options.ts
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { Schema as KarmaBuilderOptions } from './schema';
+
+export type NormalizedKarmaBuilderOptions = Awaited<ReturnType<typeof normalizeOptions>>;
+
+export function normalizeOptions(options: KarmaBuilderOptions) {
+  const { watch = true, include = [], exclude = [], reporters = [], browsers, ...rest } = options;
+
+  let normalizedBrowsers: string[] | undefined;
+  if (typeof options.browsers === 'string' && options.browsers) {
+    normalizedBrowsers = options.browsers.split(',').map((browser) => browser.trim());
+  } else if (options.browsers === false) {
+    normalizedBrowsers = [];
+  }
+
+  // Split along commas to make it more natural, and remove empty strings.
+  const normalizedReporters = reporters
+    .reduce<string[]>((acc, curr) => acc.concat(curr.split(',')), [])
+    .filter((x) => !!x);
+
+  return {
+    reporters: normalizedReporters.length ? normalizedReporters : undefined,
+    browsers: normalizedBrowsers,
+    watch,
+    include,
+    exclude,
+    ...rest,
+  };
+}

--- a/packages/angular/build/src/builders/karma/schema.json
+++ b/packages/angular/build/src/builders/karma/schema.json
@@ -229,7 +229,7 @@
     },
     "watch": {
       "type": "boolean",
-      "description": "Run build when files change.",
+      "description": "Re-run tests when source files change.",
       "default": true
     },
     "poll": {

--- a/packages/angular/build/src/builders/karma/schema.json
+++ b/packages/angular/build/src/builders/karma/schema.json
@@ -229,7 +229,8 @@
     },
     "watch": {
       "type": "boolean",
-      "description": "Run build when files change."
+      "description": "Run build when files change.",
+      "default": true
     },
     "poll": {
       "type": "number",

--- a/packages/angular/build/src/builders/unit-test/schema.json
+++ b/packages/angular/build/src/builders/unit-test/schema.json
@@ -44,7 +44,7 @@
     },
     "watch": {
       "type": "boolean",
-      "description": "Run build when files change."
+      "description": "Re-run tests when source files change. Defaults to `true` in TTY environments and `false` otherwise."
     },
     "debug": {
       "type": "boolean",

--- a/packages/angular/build/src/private.ts
+++ b/packages/angular/build/src/private.ts
@@ -26,7 +26,6 @@ export { buildApplicationInternal } from './builders/application';
 export type { ApplicationBuilderInternalOptions } from './builders/application/options';
 export { type Result, type ResultFile, ResultKind } from './builders/application/results';
 export { serveWithVite } from './builders/dev-server/vite-server';
-export { execute as executeKarmaInternal } from './builders/karma/application_builder';
 
 // Tools
 export * from './tools/babel/plugins';


### PR DESCRIPTION
This issue stems from the `Some of your tests did a full page reload` error, which occurs because `karmaOptions.client.clearContext` is set to `true` when `singleRun` is `false`, even though Karma is running in watch mode. Previously, the `watch` flag was configured inconsistently across multiple locations, leading to misalignment.

Closes #30506