### PR TITLE
refactor(@angular-devkit/schematics): initial isolated declarations type adjustments

### DIFF
--- a/goldens/public-api/angular_devkit/schematics/index.api.md
+++ b/goldens/public-api/angular_devkit/schematics/index.api.md
@@ -170,9 +170,9 @@ export type CollectionDescription<CollectionMetadataT extends object> = Collecti
 
 // @public (undocumented)
 export class CollectionImpl<CollectionT extends object, SchematicT extends object> implements Collection<CollectionT, SchematicT> {
-    constructor(_description: CollectionDescription<CollectionT>, _engine: SchematicEngine<CollectionT, SchematicT>, baseDescriptions?: Array<CollectionDescription<CollectionT>> | undefined);
+    constructor(_description: CollectionDescription<CollectionT>, _engine: SchematicEngine<CollectionT, SchematicT>, baseDescriptions?: CollectionDescription<CollectionT>[] | undefined);
     // (undocumented)
-    readonly baseDescriptions?: Array<CollectionDescription<CollectionT>> | undefined;
+    readonly baseDescriptions?: CollectionDescription<CollectionT>[] | undefined;
     // (undocumented)
     createSchematic(name: string, allowPrivate?: boolean): Schematic<CollectionT, SchematicT>;
     // (undocumented)

--- a/packages/angular_devkit/schematics/src/engine/engine.ts
+++ b/packages/angular_devkit/schematics/src/engine/engine.ts
@@ -87,7 +87,7 @@ export class CollectionImpl<CollectionT extends object, SchematicT extends objec
   constructor(
     private _description: CollectionDescription<CollectionT>,
     private _engine: SchematicEngine<CollectionT, SchematicT>,
-    public readonly baseDescriptions?: Array<CollectionDescription<CollectionT>>,
+    public readonly baseDescriptions?: CollectionDescription<CollectionT>[] | undefined,
   ) {}
 
   get description(): CollectionDescription<CollectionT> {
@@ -180,7 +180,7 @@ export class SchematicEngine<CollectionT extends object, SchematicT extends obje
 
   constructor(
     private _host: EngineHost<CollectionT, SchematicT>,
-    protected _workflow?: Workflow,
+    protected _workflow?: Workflow | undefined,
   ) {}
 
   get workflow(): Workflow | null {

--- a/packages/angular_devkit/schematics/src/rules/base.ts
+++ b/packages/angular_devkit/schematics/src/rules/base.ts
@@ -86,7 +86,7 @@ export function asSource(rule: Rule): Source {
   return (context) => callRule(rule, staticEmpty(), context);
 }
 
-export function branchAndMerge(rule: Rule, strategy = MergeStrategy.Default): Rule {
+export function branchAndMerge(rule: Rule, strategy: MergeStrategy = MergeStrategy.Default): Rule {
   return (tree, context) => {
     return callRule(rule, tree.branch(), context).pipe(
       map((branch) => tree.merge(branch, strategy || context.strategy)),

--- a/packages/angular_devkit/schematics/src/rules/template.ts
+++ b/packages/angular_devkit/schematics/src/rules/template.ts
@@ -12,7 +12,7 @@ import { FileOperator, Rule } from '../engine/interface';
 import { FileEntry } from '../tree/interface';
 import { chain, composeFileOperators, forEach, when } from './base';
 
-export const TEMPLATE_FILENAME_RE = /\.template$/;
+export const TEMPLATE_FILENAME_RE: RegExp = /\.template$/;
 
 export class OptionIsNotDefinedException extends BaseException {
   constructor(name: string) {

--- a/packages/angular_devkit/schematics/src/sink/dryrun.ts
+++ b/packages/angular_devkit/schematics/src/sink/dryrun.ts
@@ -44,9 +44,9 @@ export type DryRunEvent =
   | DryRunRenameEvent;
 
 export class DryRunSink extends HostSink {
-  protected _subject = new Subject<DryRunEvent>();
-  protected _fileDoesNotExistExceptionSet = new Set<string>();
-  protected _fileAlreadyExistExceptionSet = new Set<string>();
+  protected _subject: Subject<DryRunEvent> = new Subject();
+  protected _fileDoesNotExistExceptionSet: Set<string> = new Set();
+  protected _fileAlreadyExistExceptionSet: Set<string> = new Set();
 
   readonly reporter: Observable<DryRunEvent> = this._subject.asObservable();
 
@@ -72,7 +72,7 @@ export class DryRunSink extends HostSink {
     this._fileDoesNotExistExceptionSet.add(path);
   }
 
-  override _done() {
+  override _done(): Observable<void> {
     this._fileAlreadyExistExceptionSet.forEach((path) => {
       this._subject.next({
         kind: 'error',

--- a/packages/angular_devkit/schematics/src/sink/host.ts
+++ b/packages/angular_devkit/schematics/src/sink/host.ts
@@ -20,10 +20,10 @@ import { CreateFileAction } from '../tree/action';
 import { SimpleSinkBase } from './sink';
 
 export class HostSink extends SimpleSinkBase {
-  protected _filesToDelete = new Set<Path>();
-  protected _filesToRename = new Set<[Path, Path]>();
-  protected _filesToCreate = new Map<Path, Buffer>();
-  protected _filesToUpdate = new Map<Path, Buffer>();
+  protected _filesToDelete: Set<Path> = new Set();
+  protected _filesToRename: Set<[Path, Path]> = new Set();
+  protected _filesToCreate: Map<Path, Buffer<ArrayBufferLike>> = new Map();
+  protected _filesToUpdate: Map<Path, Buffer<ArrayBufferLike>> = new Map();
 
   constructor(
     protected _host: virtualFs.Host,

--- a/packages/angular_devkit/schematics/src/tree/recorder.ts
+++ b/packages/angular_devkit/schematics/src/tree/recorder.ts
@@ -12,7 +12,7 @@ import { ContentHasMutatedException } from '../exception/exception';
 import { FileEntry, UpdateRecorder } from './interface';
 
 export class IndexOutOfBoundException extends BaseException {
-  constructor(index: number, min: number, max = Infinity) {
+  constructor(index: number, min: number, max: number = Infinity) {
     super(`Index ${index} outside of range [${min}, ${max}].`);
   }
 }


### PR DESCRIPTION
Several type only changes have been made to the schematics code to support the eventual compilation of the package with TypeScript's `isolatedDeclarations` option. This is not yet comprehensive and more changes will be needed to fully support the option.