### PR TITLE
test: reduce karma test flakes by using `clearContext` that is set in the builder

### DIFF
--- a/modules/testing/builder/projects/hello-world-app/karma.conf.js
+++ b/modules/testing/builder/projects/hello-world-app/karma.conf.js
@@ -23,9 +23,6 @@ module.exports = function(config) {
       require('karma-coverage'),
       require('@angular-devkit/build-angular/plugins/karma'),
     ],
-    client: {
-      clearContext: false, // leave Jasmine Spec Runner output visible in browser
-    },
     jasmineHtmlReporter: {
       suppressAll: true // removes the duplicated traces
     },

--- a/packages/angular_devkit/build_angular/test/hello-world-lib/projects/lib/karma.conf.js
+++ b/packages/angular_devkit/build_angular/test/hello-world-lib/projects/lib/karma.conf.js
@@ -20,9 +20,6 @@ module.exports = function (config) {
       require('karma-coverage-istanbul-reporter'),
       require('@angular-devkit/build-angular/plugins/karma')
     ],
-    client: {
-      clearContext: false // leave Jasmine Spec Runner output visible in browser
-    },
     jasmineHtmlReporter: {
       suppressAll: true // removes the duplicated traces
     },


### PR DESCRIPTION


This is needed as a workaround for https://github.com/angular/angular-cli/issues/28271
