### PR TITLE
fix(@angular/build): exclude `@vitest/browser/context` from esbuild bundling

### DIFF
--- a/packages/angular/build/src/builders/unit-test/builder.ts
+++ b/packages/angular/build/src/builders/unit-test/builder.ts
@@ -138,7 +138,11 @@ export async function* execute(
     optimization: false,
     tsConfig: normalizedOptions.tsConfig,
     entryPoints,
-    externalDependencies: ['vitest', ...(buildTargetOptions.externalDependencies ?? [])],
+    externalDependencies: [
+      'vitest',
+      '@vitest/browser/context',
+      ...(buildTargetOptions.externalDependencies ?? []),
+    ],
   };
   extensions ??= {};
   extensions.codePlugins ??= [];


### PR DESCRIPTION


Bundling this module causes unit tests to fail with `@vitest/browser/context can be imported only inside the Browser Mode. Your test is running in browser pool. Make sure your regular tests are excluded from the "test.include" glob pattern.`, This is because `@vitest/browser/context` is a virtual mode in vite and the package on NPM is dummy that is used for static analysis.

Closes: #30677
