### PR TITLE
feat(@angular/build): add headless mode for vitest browser mode

### DIFF
--- a/packages/angular/build/src/builders/unit-test/builder.ts
+++ b/packages/angular/build/src/builders/unit-test/builder.ts
@@ -331,6 +331,15 @@ function findBrowserProvider(
   }
 }
 
+function normalizeBrowserName(browserName: string): string {
+  // Normalize browser names to match Vitest's expectations for headless but also supports karma's names
+  // e.g., 'ChromeHeadless' -> 'chrome', 'FirefoxHeadless'
+  // and 'Chrome' -> 'chrome', 'Firefox' -> 'firefox'.
+  const normalized = browserName.toLowerCase();
+
+  return normalized.replace(/headless$/, '');
+}
+
 function setupBrowserConfiguration(
   browsers: string[] | undefined,
   debug: boolean,
@@ -378,8 +387,10 @@ function setupBrowserConfiguration(
   const browser = {
     enabled: true,
     provider,
+    headless: browsers.some((name) => name.toLowerCase().includes('headless')),
+
     instances: browsers.map((browserName) => ({
-      browser: browserName,
+      browser: normalizeBrowserName(browserName),
     })),
   };
 

--- a/packages/angular/build/src/builders/unit-test/schema.json
+++ b/packages/angular/build/src/builders/unit-test/schema.json
@@ -19,7 +19,7 @@
       "enum": ["karma", "vitest"]
     },
     "browsers": {
-      "description": "A list of browsers to use for test execution. If undefined, jsdom on Node.js will be used instead of a browser.",
+      "description": "A list of browsers to use for test execution. If undefined, jsdom on Node.js will be used instead of a browser. For Vitest and Karma, browser names ending with 'Headless' (e.g., 'ChromeHeadless') will enable headless mode for that browser.",
       "type": "array",
       "items": {
         "type": "string"


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Headless mode is currently supported only for `karma` via `browsers: [ 'ChromeHeadless', 'FirefoxHeadless' ]`. However, it is not supported for Vitest browser mode. See [Headless](https://vitest.dev/guide/browser/#headless) for more information.

I considered two solutions for Vitest:

**Solution 1 (Committed / Implemented):**

This solution is compatible with how Karma handles headless mode, allowing for migration without configuration changes:

```json
"options": {
  "tsConfig": "tsconfig.spec.json",
  "buildTarget": "::development",
  "runner": "vitest",
  "browsers": ["ChromiumHeadless"]
}
```

**Solution 2:**

Introduce a new **headless** property in the schema. This approach is not compatible with Karma without a breaking API change:

```json
"options": {
  "tsConfig": "tsconfig.spec.json",
  "buildTarget": "::development",
  "runner": "vitest",
  "headless": true,
  "browsers": ["chromium"]
}
```

The issue with Solution 2 is that it is not compatible with Karma, which uses `'ChromiumHeadless'` / `'FirefoxHeadless'` to enable headless mode.

**Issue Number:** #30681

## What is the new behavior?

The builder can now convert the Karma headless configuration format to the Vitest format and activate headless mode accordingly.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


## Other information

**TODO**: If the solution makes sense, I will write the docs and tests for it

