### PR TITLE
refactor(@schematics/angular): fix layout of pill button

### DIFF
--- a/packages/schematics/angular/application/files/common-files/src/app/app.html.template
+++ b/packages/schematics/angular/application/files/common-files/src/app/app.html.template
@@ -124,6 +124,7 @@
     line-height: 1.4rem;
     letter-spacing: -0.00875rem;
     text-decoration: none;
+    white-space: nowrap;
   }
 
   .pill:hover {


### PR DESCRIPTION
In the case of a long project name, the button would wrap. This commit prevents that.
