### PR TITLE
refactor(@angular/build): provide private factory API for internal compilation infrastructure

### DIFF
--- a/packages/angular/build/src/private.ts
+++ b/packages/angular/build/src/private.ts
@@ -58,6 +58,9 @@ export function createCompilerPlugin(
   );
 }
 
+export type { AngularCompilation } from './tools/angular/compilation';
+export { createAngularCompilation };
+
 // Utilities
 export * from './utils/bundle-calculator';
 export { checkPort } from './utils/check-port';

--- a/packages/angular/build/src/tools/angular/compilation/factory.ts
+++ b/packages/angular/build/src/tools/angular/compilation/factory.ts
@@ -20,8 +20,9 @@ import type { AngularCompilation } from './angular-compilation';
 export async function createAngularCompilation(
   jit: boolean,
   browserOnlyBuild: boolean,
+  parallel: boolean = useParallelTs,
 ): Promise<AngularCompilation> {
-  if (useParallelTs) {
+  if (parallel) {
     const { ParallelCompilation } = await import('./parallel-compilation');
 
     return new ParallelCompilation(jit, browserOnlyBuild);


### PR DESCRIPTION
The `createAngularCompilation` factory function is now available from the `private` entry point for the `@angular/build` package. All items exposed from this entry point are not subject to SemVer guarantees and may change between releases.