### PR TITLE
refactor(@angular/cli): add a get best practices guide MCP tool

### DIFF
--- a/packages/angular/cli/src/commands/mcp/mcp-server.ts
+++ b/packages/angular/cli/src/commands/mcp/mcp-server.ts
@@ -12,6 +12,7 @@ import path from 'node:path';
 import { z } from 'zod';
 import type { AngularWorkspace } from '../../utilities/config';
 import { VERSION } from '../../utilities/version';
+import { registerBestPracticesTool } from './tools/best-practices';
 import { registerDocSearchTool } from './tools/doc-search';
 
 export async function createMcpServer(context: {
@@ -47,6 +48,8 @@ export async function createMcpServer(context: {
       return { contents: [{ uri: 'instructions://best-practices', text }] };
     },
   );
+
+  registerBestPracticesTool(server);
 
   server.registerTool(
     'list_projects',

--- a/packages/angular/cli/src/commands/mcp/tools/best-practices.ts
+++ b/packages/angular/cli/src/commands/mcp/tools/best-practices.ts
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+export function registerBestPracticesTool(server: McpServer): void {
+  server.registerTool(
+    'get_best_practices',
+    {
+      title: 'Get Angular Coding Best Practices Guide',
+      description:
+        'You **MUST** use this tool to retrieve the Angular Best Practices Guide ' +
+        'before any interaction with Angular code (creating, analyzing, modifying). ' +
+        'It is mandatory to follow this guide to ensure all code adheres to ' +
+        'modern standards, including standalone components, typed forms, and ' +
+        'modern control flow. This is the first step for any Angular task.',
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: false,
+      },
+    },
+    async () => {
+      const text = await readFile(
+        path.join(__dirname, '..', 'instructions', 'best-practices.md'),
+        'utf-8',
+      );
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text,
+          },
+        ],
+      };
+    },
+  );
+}


### PR DESCRIPTION
The Angular CLI's stdio-based MCP server now contains a tool to get an Angular best practices guide. This is in addition to a resource with the same content. The tool provides a description that strongly encourages the use of this tool and its content when performing Angular related tasks. This is useful in cases where MCP resource usage is not available or the resource would need to manually be added as context for specific use cases.