### PR TITLE
test: use valid theme for material schematic

### DIFF
--- a/tests/legacy-cli/e2e/tests/commands/add/add-material.ts
+++ b/tests/legacy-cli/e2e/tests/commands/add/add-material.ts
@@ -28,7 +28,7 @@ export default async function () {
     'add',
     `@angular/material${tag}`,
     '--theme',
-    'custom',
+    'azure-blue',
     '--verbose',
     '--skip-confirmation',
   );


### PR DESCRIPTION
The option "custom" isn't really meant to be a value pass via the `--theme` option. This broke our tests when it stopped being accepted properly by the schematic.