### PR TITLE
build: bump version constants to 20.2.0-next

### DIFF
--- a/constants.bzl
+++ b/constants.bzl
@@ -3,10 +3,10 @@ RELEASE_ENGINES_NODE = "^20.19.0 || ^22.12.0 || >=24.0.0"
 RELEASE_ENGINES_NPM = "^6.11.0 || ^7.5.6 || >=8.0.0"
 RELEASE_ENGINES_YARN = ">= 1.13.0"
 
-NG_PACKAGR_VERSION = "^20.1.0-next.0"
-ANGULAR_FW_VERSION = "^20.1.0-next.0"
-ANGULAR_FW_PEER_DEP = "^20.0.0 || ^20.1.0-next.0"
-NG_PACKAGR_PEER_DEP = "^20.0.0 || ^20.1.0-next.0"
+NG_PACKAGR_VERSION = "^20.2.0-next.0"
+ANGULAR_FW_VERSION = "^20.2.0-next.0"
+ANGULAR_FW_PEER_DEP = "^20.0.0 || ^20.2.0-next.0"
+NG_PACKAGR_PEER_DEP = "^20.0.0 || ^20.2.0-next.0"
 
 # Baseline widely-available date in `YYYY-MM-DD` format which defines Angular's
 # browser support. This date serves as the source of truth for the Angular CLI's


### PR DESCRIPTION
This is required to release `20.2.0-next.0`.