### PR TITLE
fix(@angular-devkit/core): use crypto.randomUUID instead of Date.now for unique string in tmp file names

### DIFF
--- a/packages/angular_devkit/core/node/testing/index.ts
+++ b/packages/angular_devkit/core/node/testing/index.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
+import * as crypto from 'node:crypto';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -20,7 +21,9 @@ export class TempScopedNodeJsSyncHost extends virtualFs.ScopedHost<fs.Stats> {
   protected override _root: Path;
 
   constructor() {
-    const root = normalize(path.join(os.tmpdir(), `devkit-host-${+Date.now()}-${process.pid}`));
+    const root = normalize(
+      path.join(os.tmpdir(), `devkit-host-${crypto.randomUUID()}-${process.pid}`),
+    );
     fs.mkdirSync(getSystemPath(root));
 
     super(new NodeJsSyncHost(), root);


### PR DESCRIPTION
Use crypto.randomUUID instead of Date.now for unique string in the tmpdir path name for a TempScopedNodeJsSyncHost to prevent naming conflicts. When performaning tests on a fast enough machine which rely on this class, two instances can be instantiated within one second and can cause failures because the path already exists that is attempted to be used. Using crypto.randomUUID should not run into this issue.