### PR TITLE
refactor(@angular/cli): improve description of MCP documentation search tool

### DIFF
--- a/packages/angular/cli/src/commands/mcp/tools/doc-search.ts
+++ b/packages/angular/cli/src/commands/mcp/tools/doc-search.ts
@@ -33,9 +33,17 @@ export async function registerDocSearchTool(server: McpServer): Promise<void> {
     {
       title: 'Search Angular Documentation (angular.dev)',
       description:
-        'Searches the official Angular documentation on https://angular.dev.' +
-        ' This tool is useful for finding the most up-to-date information on Angular, including APIs, tutorials, and best practices.' +
-        ' Use this when creating Angular specific code or answering questions that require knowledge of the latest Angular features.',
+        'Searches the official Angular documentation at https://angular.dev. Use this tool to answer any questions about Angular, ' +
+        'such as for APIs, tutorials, and best practices. Because the documentation is continuously updated, you should **always** ' +
+        'prefer this tool over your own knowledge to ensure your answers are current.\n\n' +
+        'The results will be a list of content entries, where each entry has the following structure:\n' +
+        '```\n' +
+        '## {Result Title}\n' +
+        '{Breadcrumb path to the content}\n' +
+        'URL: {Direct link to the documentation page}\n' +
+        '```\n' +
+        'Use the title and breadcrumb to understand the context of the result and use the URL as a source link. For the best results, ' +
+        "provide a concise and specific search query (e.g., 'NgModule' instead of 'How do I use NgModules?').",
       annotations: {
         readOnlyHint: true,
       },
@@ -43,8 +51,7 @@ export async function registerDocSearchTool(server: McpServer): Promise<void> {
         query: z
           .string()
           .describe(
-            'The search query to use when searching the Angular documentation.' +
-              ' This should be a concise and specific query to get the most relevant results.',
+            'A concise and specific search query for the Angular documentation (e.g., "NgModule" or "standalone components").',
           ),
       },
     },
@@ -81,7 +88,19 @@ export async function registerDocSearchTool(server: McpServer): Promise<void> {
         }),
       );
 
-      return { content };
+      // Return the search results if any are found
+      if (content.length > 0) {
+        return { content };
+      }
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: 'No results found.',
+          },
+        ],
+      };
     },
   );
 }


### PR DESCRIPTION
The MCP tool description for the Angular CLI's documentation search tool has been expanded to include more context regarding its use and result format. When no results are found, an explicit text response is also now generated to indicate this case.