### PR TITLE
test(@angular/build): add unit tests for unit-test builder options

### DIFF
--- a/packages/angular/build/src/builders/unit-test/tests/options/browsers_spec.ts
+++ b/packages/angular/build/src/builders/unit-test/tests/options/browsers_spec.ts
@@ -1,0 +1,75 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { execute } from '../../index';
+import {
+  BASE_OPTIONS,
+  describeBuilder,
+  UNIT_TEST_BUILDER_INFO,
+  setupApplicationTarget,
+} from '../setup';
+
+describeBuilder(execute, UNIT_TEST_BUILDER_INFO, (harness) => {
+  xdescribe('Option: "browsers"', () => {
+    beforeEach(async () => {
+      setupApplicationTarget(harness);
+    });
+
+    it('should use jsdom when browsers is not provided', async () => {
+      harness.useTarget('test', {
+        ...BASE_OPTIONS,
+        browsers: undefined,
+      });
+
+      const { result, logs } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
+      expect(logs).toContain(
+        jasmine.objectContaining({ message: 'Using jsdom in Node.js for test execution.' }),
+      );
+    });
+
+    it('should fail when browsers is empty', async () => {
+      harness.useTarget('test', {
+        ...BASE_OPTIONS,
+        browsers: [],
+      });
+
+      await expectAsync(harness.executeOnce()).toBeRejectedWithError(
+        /must NOT have fewer than 1 items/,
+      );
+    });
+
+    it('should launch a browser when provided', async () => {
+      harness.useTarget('test', {
+        ...BASE_OPTIONS,
+        browsers: ['chrome'],
+      });
+
+      const { result, logs } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
+      expect(logs).toContain(
+        jasmine.objectContaining({ message: jasmine.stringMatching(/Starting browser "chrome"/) }),
+      );
+    });
+
+    it('should launch a browser in headless mode when specified', async () => {
+      harness.useTarget('test', {
+        ...BASE_OPTIONS,
+        browsers: ['chromeheadless'],
+      });
+
+      const { result, logs } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
+      expect(logs).toContain(
+        jasmine.objectContaining({
+          message: jasmine.stringMatching(/Starting browser "chrome" in headless mode/),
+        }),
+      );
+    });
+  });
+});

--- a/packages/angular/build/src/builders/unit-test/tests/options/build-target_spec.ts
+++ b/packages/angular/build/src/builders/unit-test/tests/options/build-target_spec.ts
@@ -1,0 +1,63 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { execute } from '../../index';
+import {
+  BASE_OPTIONS,
+  describeBuilder,
+  UNIT_TEST_BUILDER_INFO,
+  setupApplicationTarget,
+} from '../setup';
+
+describeBuilder(execute, UNIT_TEST_BUILDER_INFO, (harness) => {
+  xdescribe('Option: "buildTarget"', () => {
+    beforeEach(async () => {
+      setupApplicationTarget(harness);
+    });
+
+    it('should fail when buildTarget is not provided', async () => {
+      const { buildTarget, ...rest } = BASE_OPTIONS;
+      harness.useTarget('test', rest as any);
+
+      await expectAsync(harness.executeOnce()).toBeRejectedWithError(/"buildTarget" is required/);
+    });
+
+    it('should fail when buildTarget is empty', async () => {
+      harness.useTarget('test', {
+        ...BASE_OPTIONS,
+        buildTarget: '',
+      });
+
+      await expectAsync(harness.executeOnce()).toBeRejectedWithError(
+        /must match "\^\S+:\S+(:\S+)?\$"/,
+      );
+    });
+
+    it('should fail when buildTarget does not have a project name', async () => {
+      harness.useTarget('test', {
+        ...BASE_OPTIONS,
+        buildTarget: ':build',
+      });
+
+      await expectAsync(harness.executeOnce()).toBeRejectedWithError(
+        /must match "\^\S+:\S+(:\S+)?\$"/,
+      );
+    });
+
+    it('should fail when buildTarget does not have a target name', async () => {
+      harness.useTarget('test', {
+        ...BASE_OPTIONS,
+        buildTarget: 'app:',
+      });
+
+      await expectAsync(harness.executeOnce()).toBeRejectedWithError(
+        /must match "\^\S+:\S+(:\S+)?\$"/,
+      );
+    });
+  });
+});

--- a/packages/angular/build/src/builders/unit-test/tests/options/code-coverage-exclude_spec.ts
+++ b/packages/angular/build/src/builders/unit-test/tests/options/code-coverage-exclude_spec.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { execute } from '../../index';
+import {
+  BASE_OPTIONS,
+  describeBuilder,
+  UNIT_TEST_BUILDER_INFO,
+  setupApplicationTarget,
+} from '../setup';
+
+describeBuilder(execute, UNIT_TEST_BUILDER_INFO, (harness) => {
+  xdescribe('Option: "codeCoverageExclude"', () => {
+    beforeEach(async () => {
+      setupApplicationTarget(harness);
+      await harness.writeFiles({
+        'src/app/error.ts': `export const a = 1;`,
+      });
+    });
+
+    it('should not exclude any files from coverage when not provided', async () => {
+      harness.useTarget('test', {
+        ...BASE_OPTIONS,
+        codeCoverage: true,
+      });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
+      const summary = harness.readFile('coverage/coverage-summary.json');
+      expect(summary).toContain('"src/app/error.ts"');
+    });
+
+    it('should exclude files from coverage that match the glob pattern', async () => {
+      harness.useTarget('test', {
+        ...BASE_OPTIONS,
+        codeCoverage: true,
+        codeCoverageExclude: ['**/error.ts'],
+      });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
+      const summary = harness.readFile('coverage/coverage-summary.json');
+      expect(summary).not.toContain('"src/app/error.ts"');
+    });
+  });
+});

--- a/packages/angular/build/src/builders/unit-test/tests/options/code-coverage-reporters_spec.ts
+++ b/packages/angular/build/src/builders/unit-test/tests/options/code-coverage-reporters_spec.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { execute } from '../../index';
+import {
+  BASE_OPTIONS,
+  describeBuilder,
+  UNIT_TEST_BUILDER_INFO,
+  setupApplicationTarget,
+} from '../setup';
+
+describeBuilder(execute, UNIT_TEST_BUILDER_INFO, (harness) => {
+  xdescribe('Option: "codeCoverageReporters"', () => {
+    beforeEach(async () => {
+      setupApplicationTarget(harness);
+    });
+
+    it('should generate a json summary report when specified', async () => {
+      harness.useTarget('test', {
+        ...BASE_OPTIONS,
+        codeCoverage: true,
+        codeCoverageReporters: ['json-summary'] as any,
+      });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
+      expect(harness.hasFile('coverage/coverage-summary.json')).toBeTrue();
+    });
+
+    it('should generate multiple reports when specified', async () => {
+      harness.useTarget('test', {
+        ...BASE_OPTIONS,
+        codeCoverage: true,
+        codeCoverageReporters: ['json-summary', 'lcov'] as any,
+      });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
+      expect(harness.hasFile('coverage/coverage-summary.json')).toBeTrue();
+      expect(harness.hasFile('coverage/lcov.info')).toBeTrue();
+    });
+  });
+});

--- a/packages/angular/build/src/builders/unit-test/tests/options/code-coverage_spec.ts
+++ b/packages/angular/build/src/builders/unit-test/tests/options/code-coverage_spec.ts
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { execute } from '../../index';
+import {
+  BASE_OPTIONS,
+  describeBuilder,
+  UNIT_TEST_BUILDER_INFO,
+  setupApplicationTarget,
+} from '../setup';
+
+describeBuilder(execute, UNIT_TEST_BUILDER_INFO, (harness) => {
+  xdescribe('Option: "codeCoverage"', () => {
+    beforeEach(async () => {
+      setupApplicationTarget(harness);
+    });
+
+    it('should not generate a code coverage report when codeCoverage is false', async () => {
+      harness.useTarget('test', {
+        ...BASE_OPTIONS,
+        codeCoverage: false,
+      });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
+      expect(harness.hasFile('coverage/index.html')).toBeFalse();
+    });
+
+    it('should generate a code coverage report when codeCoverage is true', async () => {
+      harness.useTarget('test', {
+        ...BASE_OPTIONS,
+        codeCoverage: true,
+      });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
+      expect(harness.hasFile('coverage/index.html')).toBeTrue();
+    });
+  });
+});

--- a/packages/angular/build/src/builders/unit-test/tests/options/debug_spec.ts
+++ b/packages/angular/build/src/builders/unit-test/tests/options/debug_spec.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { execute } from '../../index';
+import {
+  BASE_OPTIONS,
+  describeBuilder,
+  UNIT_TEST_BUILDER_INFO,
+  setupApplicationTarget,
+} from '../setup';
+
+describeBuilder(execute, UNIT_TEST_BUILDER_INFO, (harness) => {
+  xdescribe('Option: "debug"', () => {
+    beforeEach(async () => {
+      setupApplicationTarget(harness);
+    });
+
+    it('should not enter debug mode when debug is false', async () => {
+      harness.useTarget('test', {
+        ...BASE_OPTIONS,
+        debug: false,
+      });
+
+      const { result, logs } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
+      expect(logs).not.toContain(
+        jasmine.objectContaining({ message: jasmine.stringMatching(/Node.js inspector/) }),
+      );
+    });
+
+    it('should enter debug mode when debug is true', async () => {
+      harness.useTarget('test', {
+        ...BASE_OPTIONS,
+        debug: true,
+      });
+
+      const { result, logs } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
+      expect(logs).toContain(
+        jasmine.objectContaining({
+          message: jasmine.stringMatching(/Node.js inspector is active/),
+        }),
+      );
+    });
+  });
+});

--- a/packages/angular/build/src/builders/unit-test/tests/options/providers-file_spec.ts
+++ b/packages/angular/build/src/builders/unit-test/tests/options/providers-file_spec.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { execute } from '../../index';
+import {
+  BASE_OPTIONS,
+  describeBuilder,
+  UNIT_TEST_BUILDER_INFO,
+  setupApplicationTarget,
+} from '../setup';
+
+describeBuilder(execute, UNIT_TEST_BUILDER_INFO, (harness) => {
+  xdescribe('Option: "providersFile"', () => {
+    beforeEach(async () => {
+      setupApplicationTarget(harness);
+    });
+
+    it('should fail when providersFile does not exist', async () => {
+      harness.useTarget('test', {
+        ...BASE_OPTIONS,
+        providersFile: 'src/my.providers.ts',
+      });
+
+      const { result, error } = await harness.executeOnce({ outputLogsOnFailure: false });
+      expect(result).toBeUndefined();
+      expect(error?.message).toMatch(
+        `The specified providers file "src/my.providers.ts" does not exist.`,
+      );
+    });
+
+    it('should use providers from the specified file', async () => {
+      await harness.writeFiles({
+        'src/my.providers.ts': `
+          import { importProvidersFrom } from '@angular/core';
+          import { CommonModule } from '@angular/common';
+          export default [importProvidersFrom(CommonModule)];
+        `,
+      });
+
+      harness.useTarget('test', {
+        ...BASE_OPTIONS,
+        providersFile: 'src/my.providers.ts',
+      });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
+    });
+  });
+});

--- a/packages/angular/build/src/builders/unit-test/tests/options/reporters_spec.ts
+++ b/packages/angular/build/src/builders/unit-test/tests/options/reporters_spec.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { execute } from '../../index';
+import {
+  BASE_OPTIONS,
+  describeBuilder,
+  UNIT_TEST_BUILDER_INFO,
+  setupApplicationTarget,
+} from '../setup';
+
+describeBuilder(execute, UNIT_TEST_BUILDER_INFO, (harness) => {
+  xdescribe('Option: "reporters"', () => {
+    beforeEach(async () => {
+      setupApplicationTarget(harness);
+    });
+
+    it('should use the default reporter when none is specified', async () => {
+      harness.useTarget('test', {
+        ...BASE_OPTIONS,
+      });
+
+      const { result, logs } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
+      expect(logs).toContain(
+        jasmine.objectContaining({ message: jasmine.stringMatching(/DefaultReporter/) }),
+      );
+    });
+
+    it('should use a custom reporter when specified', async () => {
+      harness.useTarget('test', {
+        ...BASE_OPTIONS,
+        reporters: ['json'],
+      });
+
+      const { result, logs } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
+      expect(logs).toContain(
+        jasmine.objectContaining({ message: jasmine.stringMatching(/JsonReporter/) }),
+      );
+    });
+  });
+});

--- a/packages/angular/build/src/builders/unit-test/tests/options/runner_spec.ts
+++ b/packages/angular/build/src/builders/unit-test/tests/options/runner_spec.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { execute } from '../../index';
+import {
+  BASE_OPTIONS,
+  describeBuilder,
+  UNIT_TEST_BUILDER_INFO,
+  setupApplicationTarget,
+} from '../setup';
+
+describeBuilder(execute, UNIT_TEST_BUILDER_INFO, (harness) => {
+  xdescribe('Option: "runner"', () => {
+    beforeEach(async () => {
+      setupApplicationTarget(harness);
+    });
+
+    it('should fail when runner is not provided', async () => {
+      const { runner, ...rest } = BASE_OPTIONS;
+      harness.useTarget('test', rest as any);
+
+      await expectAsync(harness.executeOnce()).toBeRejectedWithError(/"runner" is required/);
+    });
+
+    it('should fail when runner is invalid', async () => {
+      harness.useTarget('test', {
+        ...BASE_OPTIONS,
+        runner: 'invalid' as any,
+      });
+
+      await expectAsync(harness.executeOnce()).toBeRejectedWithError(
+        /must be one of the following values: "karma", "vitest"/,
+      );
+    });
+  });
+});

--- a/packages/angular/build/src/builders/unit-test/tests/options/setup-files_spec.ts
+++ b/packages/angular/build/src/builders/unit-test/tests/options/setup-files_spec.ts
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { execute } from '../../index';
+import {
+  BASE_OPTIONS,
+  describeBuilder,
+  UNIT_TEST_BUILDER_INFO,
+  setupApplicationTarget,
+} from '../setup';
+
+describeBuilder(execute, UNIT_TEST_BUILDER_INFO, (harness) => {
+  xdescribe('Option: "setupFiles"', () => {
+    beforeEach(async () => {
+      setupApplicationTarget(harness);
+    });
+
+    it('should fail when a setup file does not exist', async () => {
+      harness.useTarget('test', {
+        ...BASE_OPTIONS,
+        setupFiles: ['src/setup.ts'],
+      });
+
+      const { result, error } = await harness.executeOnce({ outputLogsOnFailure: false });
+      expect(result).toBeUndefined();
+      expect(error?.message).toMatch(`The specified setup file "src/setup.ts" does not exist.`);
+    });
+
+    it('should include the setup files', async () => {
+      await harness.writeFiles({
+        'src/setup.ts': `console.log('Hello from setup.ts');`,
+        'src/app/app.component.spec.ts': `
+        import { describe, expect, test } from 'vitest'
+        describe('AppComponent', () => {
+          test('should create the app', () => {
+            expect(true).toBe(true);
+          });
+        });`,
+      });
+
+      harness.useTarget('test', {
+        ...BASE_OPTIONS,
+        setupFiles: ['src/setup.ts'],
+      });
+
+      const { result, logs } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
+      expect(logs).toContain(jasmine.objectContaining({ message: 'Hello from setup.ts' }));
+    });
+  });
+});

--- a/packages/angular/build/src/builders/unit-test/tests/options/tsconfig_spec.ts
+++ b/packages/angular/build/src/builders/unit-test/tests/options/tsconfig_spec.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { execute } from '../../index';
+import {
+  BASE_OPTIONS,
+  describeBuilder,
+  UNIT_TEST_BUILDER_INFO,
+  setupApplicationTarget,
+} from '../setup';
+
+describeBuilder(execute, UNIT_TEST_BUILDER_INFO, (harness) => {
+  xdescribe('Option: "tsConfig"', () => {
+    beforeEach(async () => {
+      setupApplicationTarget(harness);
+    });
+
+    it('should fail when tsConfig is not provided', async () => {
+      const { tsConfig, ...rest } = BASE_OPTIONS;
+      harness.useTarget('test', rest as any);
+
+      await expectAsync(harness.executeOnce()).toBeRejectedWithError(/"tsConfig" is required/);
+    });
+
+    it('should fail when tsConfig is empty', async () => {
+      harness.useTarget('test', {
+        ...BASE_OPTIONS,
+        tsConfig: '',
+      });
+
+      await expectAsync(harness.executeOnce()).toBeRejectedWithError(
+        /must NOT have fewer than 1 characters/,
+      );
+    });
+
+    it('should fail when tsConfig does not exist', async () => {
+      harness.useTarget('test', {
+        ...BASE_OPTIONS,
+        tsConfig: 'src/tsconfig.spec.json',
+      });
+
+      const { result, error } = await harness.executeOnce({ outputLogsOnFailure: false });
+      expect(result).toBeUndefined();
+      expect(error?.message).toMatch(
+        `The specified tsConfig file "src/tsconfig.spec.json" does not exist.`,
+      );
+    });
+  });
+});

--- a/packages/angular/build/src/builders/unit-test/tests/options/watch_spec.ts
+++ b/packages/angular/build/src/builders/unit-test/tests/options/watch_spec.ts
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { execute } from '../../index';
+import {
+  BASE_OPTIONS,
+  describeBuilder,
+  UNIT_TEST_BUILDER_INFO,
+  setupApplicationTarget,
+} from '../setup';
+
+describeBuilder(execute, UNIT_TEST_BUILDER_INFO, (harness) => {
+  xdescribe('Option: "watch"', () => {
+    beforeEach(async () => {
+      setupApplicationTarget(harness);
+    });
+
+    it('should run tests once when watch is false', async () => {
+      harness.useTarget('test', {
+        ...BASE_OPTIONS,
+        watch: false,
+      });
+
+      const { result } = await harness.executeOnce();
+      expect(result?.success).toBeTrue();
+    });
+
+    it('should re-run tests when a file changes when watch is true', async () => {
+      harness.useTarget('test', {
+        ...BASE_OPTIONS,
+        watch: true,
+      });
+
+      await harness.executeWithCases([
+        async ({ result }) => {
+          expect(result?.success).toBeTrue();
+
+          await harness.writeFiles({
+            'src/app/app.component.spec.ts': `
+              import { describe, expect, test } from 'vitest'
+              describe('AppComponent', () => {
+                test('should create the app', () => {
+                  expect(true).toBe(false);
+                });
+              });`,
+          });
+        },
+        ({ result }) => {
+          expect(result?.success).toBeFalse();
+        },
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
Adds a suite of disabled unit tests for the options of the unit-test builder. These tests cover the functionality of each option and will be enabled in a future commit.