### PR TITLE
fix(@angular/cli): skip workspace-specific tools when outside a workspace

### DIFF
--- a/packages/angular/cli/src/commands/mcp/mcp-server.ts
+++ b/packages/angular/cli/src/commands/mcp/mcp-server.ts
@@ -54,7 +54,12 @@ export async function createMcpServer(
   );
 
   registerBestPracticesTool(server);
-  registerListProjectsTool(server, context);
+
+  // If run outside an Angular workspace (e.g., globally) skip the workspace specific tools.
+  // Currently only the `list_projects` tool.
+  if (!context.workspace) {
+    registerListProjectsTool(server, context);
+  }
 
   await registerDocSearchTool(server);
 


### PR DESCRIPTION
When the MCP server is initialized outside of an Angular workspace, workspace-specific tools such as  `list_projects` should not be registered as they will not function correctly.