### PR TITLE
feat(@angular/cli): introduce `setup-gemini-cli` command with a Gemini CLI extension

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -16,3 +16,6 @@ dist/
 /tests/legacy-cli/e2e/assets/
 /tools/test/*.json
 pnpm-lock.yaml
+
+# This is a symbolic link.
+packages/angular/cli/src/commands/ai/setup-gemini-cli/extension/GEMINI.md

--- a/packages/angular/cli/src/commands/ai/cli.ts
+++ b/packages/angular/cli/src/commands/ai/cli.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { join } from 'node:path';
+import { Argv } from 'yargs';
+import {
+  CommandModule,
+  CommandModuleImplementation,
+  CommandScope,
+  Options,
+} from '../../command-builder/command-module';
+import {
+  addCommandModuleToYargs,
+  demandCommandFailureMessage,
+} from '../../command-builder/utilities/command';
+import SetupGeminiCliModule from './setup-gemini-cli/cli';
+
+export default class AiCommandModule extends CommandModule implements CommandModuleImplementation {
+  command = 'ai';
+  describe = 'Commands for artificial intelligence.';
+  longDescriptionPath = undefined;
+  override scope = CommandScope.Both;
+
+  builder(localYargs: Argv): Argv {
+    const subcommands = [SetupGeminiCliModule].sort();
+
+    for (const module of subcommands) {
+      addCommandModuleToYargs(module, this.context);
+    }
+
+    return localYargs.demandCommand(1, demandCommandFailureMessage).strict();
+  }
+
+  run(_options: Options<{}>): void {}
+}

--- a/packages/angular/cli/src/commands/ai/setup-gemini-cli/cli.ts
+++ b/packages/angular/cli/src/commands/ai/setup-gemini-cli/cli.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { cp, mkdir } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { Argv } from 'yargs';
+import {
+  CommandModule,
+  CommandModuleImplementation,
+  CommandScope,
+  Options,
+} from '../../../command-builder/command-module';
+
+export default class SetupGeminiCliModule
+  extends CommandModule
+  implements CommandModuleImplementation
+{
+  command = 'setup-gemini-cli';
+  describe = 'Sets up Gemini CLI with the official Angular extension.';
+  longDescriptionPath?: string | undefined;
+
+  override scope = CommandScope.Both;
+
+  builder(localYargs: Argv): Argv {
+    return localYargs.strict();
+  }
+
+  async run(_options: Options<{}>): Promise<void> {
+    const extensionDir = join(__dirname, './extension');
+    const extensionUserDir = join(homedir(), '.gemini', 'extensions', 'angular');
+
+    await mkdir(extensionUserDir, { recursive: true });
+    await cp(extensionDir, extensionUserDir, { recursive: true, dereference: true });
+
+    this.context.logger.info(`✅ Installed the Angular Gemini CLI extension.`);
+  }
+}

--- a/packages/angular/cli/src/commands/ai/setup-gemini-cli/extension/GEMINI.md
+++ b/packages/angular/cli/src/commands/ai/setup-gemini-cli/extension/GEMINI.md
@@ -1,0 +1,1 @@
+../../../mcp/instructions/best-practices.md

--- a/packages/angular/cli/src/commands/ai/setup-gemini-cli/extension/gemini-extension.json
+++ b/packages/angular/cli/src/commands/ai/setup-gemini-cli/extension/gemini-extension.json
@@ -1,0 +1,6 @@
+{
+  "name": "Angular",
+  "version": "0.0.0-PLACEHOLDER",
+  "mcpServers": {},
+  "contextFileName": "./GEMINI.md"
+}

--- a/packages/angular/cli/src/commands/command-config.ts
+++ b/packages/angular/cli/src/commands/command-config.ts
@@ -10,6 +10,7 @@ import { CommandModuleConstructor } from '../command-builder/utilities/command';
 
 export type CommandNames =
   | 'add'
+  | 'ai'
   | 'analytics'
   | 'build'
   | 'cache'
@@ -40,6 +41,9 @@ export const RootCommands: Record<
 > = {
   'add': {
     factory: () => import('./add/cli'),
+  },
+  'ai': {
+    factory: () => import('./ai/cli'),
   },
   'analytics': {
     factory: () => import('./analytics/cli'),

--- a/tests/legacy-cli/e2e/tests/commands/ai/setup-gemini-cli.ts
+++ b/tests/legacy-cli/e2e/tests/commands/ai/setup-gemini-cli.ts
@@ -1,0 +1,19 @@
+import { join } from 'node:path';
+import { expectFileNotToExist, expectFileToExist, expectFileToMatch } from '../../../utils/fs';
+import { ng } from '../../../utils/process';
+import assert from 'node:assert';
+
+export default async function () {
+  assert(process.env.HOME, 'Expected HOME directory to be set.');
+
+  const extensionDir = join(process.env.HOME, '.gemini', 'extensions', 'angular');
+  const geminiBestPracticesFile = join(extensionDir, 'GEMINI.md');
+
+  await expectFileNotToExist(extensionDir);
+  await expectFileNotToExist(geminiBestPracticesFile);
+  await ng('ai', 'setup-gemini-cli');
+
+  await expectFileToExist(extensionDir);
+  await expectFileToExist(geminiBestPracticesFile);
+  await expectFileToMatch(geminiBestPracticesFile, 'Angular Best Practices');
+}


### PR DESCRIPTION
Introduces `ng ai setup-gemini-cli` that will automatically install the "Angular Gemini CLI extension", wiring up Angular best practices and rules that improve code generation.

In the future we need to look further into:

* Documentation
* How we version the extension. I.e. could `ng update` help here?
* The extension could also wire up the MCP server from the CLI!