### PR TITLE
test(@angular/cli): add initial e2e test for MCP server tool registration

### DIFF
--- a/packages/angular/cli/src/commands/mcp/mcp-server.ts
+++ b/packages/angular/cli/src/commands/mcp/mcp-server.ts
@@ -59,8 +59,7 @@ export async function createMcpServer(
   registerBestPracticesTool(server);
 
   // If run outside an Angular workspace (e.g., globally) skip the workspace specific tools.
-  // Currently only the `list_projects` tool.
-  if (!context.workspace) {
+  if (context.workspace) {
     registerListProjectsTool(server, context);
   }
 

--- a/tests/legacy-cli/e2e/tests/mcp/registers-tools.ts
+++ b/tests/legacy-cli/e2e/tests/mcp/registers-tools.ts
@@ -1,0 +1,47 @@
+import { chdir } from 'process';
+import { exec, ProcessOutput, silentNpm } from '../../utils/process';
+import assert from 'node:assert/strict';
+
+const MCP_INSPECTOR_PACKAGE_NAME = '@modelcontextprotocol/inspector-cli';
+const MCP_INSPECTOR_PACKAGE_VERSION = '0.16.2';
+const MCP_INSPECTOR_COMMAND_NAME = 'mcp-inspector-cli';
+
+async function runInspector(...args: string[]): Promise<ProcessOutput> {
+  const result = await exec(
+    MCP_INSPECTOR_COMMAND_NAME,
+    '--cli',
+    'npx',
+    '--no',
+    '@angular/cli',
+    'mcp',
+    ...args,
+  );
+
+  return result;
+}
+
+export default async function () {
+  await silentNpm(
+    'install',
+    '--ignore-scripts',
+    '-g',
+    `${MCP_INSPECTOR_PACKAGE_NAME}@${MCP_INSPECTOR_PACKAGE_VERSION}`,
+  );
+
+  // Ensure 'list_projects' is registered when inside an Angular workspace
+  const { stdout: stdoutInsideWorkspace } = await runInspector('--method', 'tools/list');
+
+  assert.match(stdoutInsideWorkspace, /"list_projects"/);
+  assert.match(stdoutInsideWorkspace, /"get_best_practices"/);
+  assert.match(stdoutInsideWorkspace, /"search_documentation"/);
+
+  chdir('..');
+
+  const { stdout: stdoutOutsideWorkspace } = await runInspector('--method', 'tools/list');
+
+  assert.doesNotMatch(stdoutOutsideWorkspace, /"list_projects"/);
+  assert.match(stdoutOutsideWorkspace, /"get_best_practices"/);
+  assert.match(stdoutInsideWorkspace, /"search_documentation"/);
+
+  silentNpm('uninstall', '-g', MCP_INSPECTOR_PACKAGE_NAME);
+}


### PR DESCRIPTION
Introduces the first end-to-end test for the MCP server. The new test, `registers-tools.ts`, verifies that the MCP server correctly initializes and registers its default set of tools. This provides a foundation for more comprehensive e2e testing of the MCP server and its features.