### PR TITLE
ci: temporarily disable Windows CI for PRs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -127,23 +127,24 @@ jobs:
       - name: Run CLI E2E tests
         run: pnpm bazel test --test_env=E2E_SHARD_TOTAL=6 --test_env=E2E_SHARD_INDEX=${{ matrix.shard }} --config=e2e //tests/legacy-cli:e2e.${{ matrix.subset }}_node${{ matrix.node }}
 
-  e2e-windows-subset:
-    needs: build
-    runs-on: windows-2025
-    steps:
-      - name: Initialize environment
-        uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@59c46175bf3a8870c0c2ceb9de1eb741fd50d415
-      - name: Setup Bazel
-        uses: angular/dev-infra/github-actions/bazel/setup@59c46175bf3a8870c0c2ceb9de1eb741fd50d415
-      - name: Setup Bazel RBE
-        uses: angular/dev-infra/github-actions/bazel/configure-remote@59c46175bf3a8870c0c2ceb9de1eb741fd50d415
-        with:
-          allow_windows_rbe: true
-      - name: Run CLI E2E tests
-        uses: ./.github/shared-actions/windows-bazel-test
-        with:
-          test_target_name: e2e_node22
-          test_args: --esbuild --glob "tests/basic/{build,rebuild}.ts"
+  # Temporarily disabled due to https://github.com/Vampire/setup-wsl/issues/76.
+  # e2e-windows-subset:
+  #   needs: build
+  #   runs-on: windows-2025
+  #   steps:
+  #     - name: Initialize environment
+  #       uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@59c46175bf3a8870c0c2ceb9de1eb741fd50d415
+  #     - name: Setup Bazel
+  #       uses: angular/dev-infra/github-actions/bazel/setup@59c46175bf3a8870c0c2ceb9de1eb741fd50d415
+  #     - name: Setup Bazel RBE
+  #       uses: angular/dev-infra/github-actions/bazel/configure-remote@59c46175bf3a8870c0c2ceb9de1eb741fd50d415
+  #       with:
+  #         allow_windows_rbe: true
+  #     - name: Run CLI E2E tests
+  #       uses: ./.github/shared-actions/windows-bazel-test
+  #       with:
+  #         test_target_name: e2e_node22
+  #         test_args: --esbuild --glob "tests/basic/{build,rebuild}.ts"
 
   e2e-package-managers:
     needs: build


### PR DESCRIPTION
Currently seems to be broken due to https://github.com/Vampire/setup-wsl/issues/76. We're only disabling for PRs right now to unblock ongoing work, `main` will continue to fail until the root cause is addressed.