### PR TITLE
build: update Webpack to v5.101.0

### DIFF
--- a/goldens/public-api/angular_devkit/build_webpack/index.api.md
+++ b/goldens/public-api/angular_devkit/build_webpack/index.api.md
@@ -65,7 +65,7 @@ export type WebpackDevServerFactory = typeof WebpackDevServer;
 // @public (undocumented)
 export interface WebpackFactory {
     // (undocumented)
-    (config: webpack.Configuration): Observable<webpack.Compiler> | webpack.Compiler;
+    (config: webpack.Configuration): Observable<webpack.Compiler | null> | webpack.Compiler | null;
 }
 
 // @public (undocumented)

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -55,7 +55,7 @@
     "terser": "5.43.1",
     "tree-kill": "1.2.2",
     "tslib": "2.8.1",
-    "webpack": "5.100.2",
+    "webpack": "5.101.0",
     "webpack-dev-middleware": "7.4.2",
     "webpack-dev-server": "5.2.2",
     "webpack-merge": "6.0.1",

--- a/packages/angular_devkit/build_angular/src/tools/webpack/plugins/karma/karma.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/plugins/karma/karma.ts
@@ -18,6 +18,7 @@ import { createConsoleLogger } from '@angular-devkit/core/node';
 import { logging } from '@angular-devkit/core';
 import { BuildOptions } from '../../../../utils/build-options';
 import { normalizeSourceMaps } from '../../../../utils/index';
+import assert from 'node:assert';
 
 const KARMA_APPLICATION_PATH = '_karma_webpack_';
 
@@ -141,6 +142,8 @@ const init: any = (config: any, emitter: any) => {
     isBlocked = true;
     callback?.();
   }
+
+  assert(compiler, 'Webpack compiler factory did not return a compiler instance.');
 
   compiler.hooks.invalid.tap('karma', () => handler());
   compiler.hooks.watchRun.tapAsync('karma', (_: any, callback: () => void) => handler(callback));

--- a/packages/angular_devkit/build_webpack/package.json
+++ b/packages/angular_devkit/build_webpack/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@angular-devkit/core": "workspace:0.0.0-PLACEHOLDER",
     "@ngtools/webpack": "workspace:0.0.0-PLACEHOLDER",
-    "webpack": "5.100.2",
+    "webpack": "5.101.0",
     "webpack-dev-server": "5.2.2"
   },
   "peerDependencies": {

--- a/packages/angular_devkit/build_webpack/src/builders/webpack-dev-server/index.ts
+++ b/packages/angular_devkit/build_webpack/src/builders/webpack-dev-server/index.ts
@@ -7,6 +7,7 @@
  */
 
 import { Builder, BuilderContext, createBuilder } from '@angular-devkit/architect';
+import assert from 'node:assert';
 import { resolve as pathResolve } from 'node:path';
 import { Observable, from, isObservable, of, switchMap } from 'rxjs';
 import webpack from 'webpack';
@@ -72,6 +73,8 @@ export function runWebpackDevServer(
     switchMap(
       (webpackCompiler) =>
         new Observable<DevServerBuildOutput>((obs) => {
+          assert(webpackCompiler, 'Webpack compiler factory did not return a compiler instance.');
+
           const devServerConfig = options.devServerConfig || config.devServer || {};
           devServerConfig.host ??= 'localhost';
 

--- a/packages/angular_devkit/build_webpack/src/builders/webpack/index.ts
+++ b/packages/angular_devkit/build_webpack/src/builders/webpack/index.ts
@@ -7,6 +7,7 @@
  */
 
 import { Builder, BuilderContext, BuilderOutput, createBuilder } from '@angular-devkit/architect';
+import assert from 'node:assert';
 import { resolve as pathResolve } from 'node:path';
 import { Observable, from, isObservable, of, switchMap } from 'rxjs';
 import webpack from 'webpack';
@@ -19,7 +20,7 @@ export interface WebpackLoggingCallback {
   (stats: webpack.Stats, config: webpack.Configuration): void;
 }
 export interface WebpackFactory {
-  (config: webpack.Configuration): Observable<webpack.Compiler> | webpack.Compiler;
+  (config: webpack.Configuration): Observable<webpack.Compiler | null> | webpack.Compiler | null;
 }
 
 export type BuildResult = BuilderOutput & {
@@ -64,6 +65,8 @@ export function runWebpack(
     switchMap(
       (webpackCompiler) =>
         new Observable<BuildResult>((obs) => {
+          assert(webpackCompiler, 'Webpack compiler factory did not return a compiler instance.');
+
           const callback = (err?: Error | null, stats?: webpack.Stats) => {
             if (err) {
               return obs.error(err);

--- a/packages/ngtools/webpack/package.json
+++ b/packages/ngtools/webpack/package.json
@@ -30,6 +30,6 @@
     "@angular/compiler": "20.2.0-next.2",
     "@angular/compiler-cli": "20.2.0-next.2",
     "typescript": "5.8.3",
-    "webpack": "5.100.2"
+    "webpack": "5.101.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -643,16 +643,16 @@ importers:
         version: 10.4.21(postcss@8.5.6)
       babel-loader:
         specifier: 10.0.0
-        version: 10.0.0(@babel/core@7.28.0)(webpack@5.100.2(esbuild@0.25.8))
+        version: 10.0.0(@babel/core@7.28.0)(webpack@5.101.0(esbuild@0.25.8))
       browserslist:
         specifier: ^4.21.5
         version: 4.25.1
       copy-webpack-plugin:
         specifier: 13.0.0
-        version: 13.0.0(webpack@5.100.2(esbuild@0.25.8))
+        version: 13.0.0(webpack@5.101.0(esbuild@0.25.8))
       css-loader:
         specifier: 7.1.2
-        version: 7.1.2(webpack@5.100.2(esbuild@0.25.8))
+        version: 7.1.2(webpack@5.101.0(esbuild@0.25.8))
       esbuild-wasm:
         specifier: 0.25.8
         version: 0.25.8
@@ -676,16 +676,16 @@ importers:
         version: 4.4.0
       less-loader:
         specifier: 12.3.0
-        version: 12.3.0(less@4.4.0)(webpack@5.100.2(esbuild@0.25.8))
+        version: 12.3.0(less@4.4.0)(webpack@5.101.0(esbuild@0.25.8))
       license-webpack-plugin:
         specifier: 4.0.2
-        version: 4.0.2(webpack@5.100.2(esbuild@0.25.8))
+        version: 4.0.2(webpack@5.101.0(esbuild@0.25.8))
       loader-utils:
         specifier: 3.3.1
         version: 3.3.1
       mini-css-extract-plugin:
         specifier: 2.9.2
-        version: 2.9.2(webpack@5.100.2(esbuild@0.25.8))
+        version: 2.9.2(webpack@5.101.0(esbuild@0.25.8))
       open:
         specifier: 10.2.0
         version: 10.2.0
@@ -703,7 +703,7 @@ importers:
         version: 8.5.6
       postcss-loader:
         specifier: 8.1.1
-        version: 8.1.1(postcss@8.5.6)(typescript@5.9.1-rc)(webpack@5.100.2(esbuild@0.25.8))
+        version: 8.1.1(postcss@8.5.6)(typescript@5.9.1-rc)(webpack@5.101.0(esbuild@0.25.8))
       resolve-url-loader:
         specifier: 5.0.0
         version: 5.0.0
@@ -715,13 +715,13 @@ importers:
         version: 1.89.2
       sass-loader:
         specifier: 16.0.5
-        version: 16.0.5(sass@1.89.2)(webpack@5.100.2(esbuild@0.25.8))
+        version: 16.0.5(sass@1.89.2)(webpack@5.101.0(esbuild@0.25.8))
       semver:
         specifier: 7.7.2
         version: 7.7.2
       source-map-loader:
         specifier: 5.0.0
-        version: 5.0.0(webpack@5.100.2(esbuild@0.25.8))
+        version: 5.0.0(webpack@5.101.0(esbuild@0.25.8))
       source-map-support:
         specifier: 0.5.21
         version: 0.5.21
@@ -735,20 +735,20 @@ importers:
         specifier: 2.8.1
         version: 2.8.1
       webpack:
-        specifier: 5.100.2
-        version: 5.100.2(esbuild@0.25.8)
+        specifier: 5.101.0
+        version: 5.101.0(esbuild@0.25.8)
       webpack-dev-middleware:
         specifier: 7.4.2
-        version: 7.4.2(webpack@5.100.2(esbuild@0.25.8))
+        version: 7.4.2(webpack@5.101.0(esbuild@0.25.8))
       webpack-dev-server:
         specifier: 5.2.2
-        version: 5.2.2(webpack@5.100.2(esbuild@0.25.8))
+        version: 5.2.2(webpack@5.101.0(esbuild@0.25.8))
       webpack-merge:
         specifier: 6.0.1
         version: 6.0.1
       webpack-subresource-integrity:
         specifier: 5.1.0
-        version: 5.1.0(webpack@5.100.2(esbuild@0.25.8))
+        version: 5.1.0(webpack@5.101.0(esbuild@0.25.8))
     optionalDependencies:
       esbuild:
         specifier: 0.25.8
@@ -786,11 +786,11 @@ importers:
         specifier: workspace:0.0.0-PLACEHOLDER
         version: link:../../ngtools/webpack
       webpack:
-        specifier: 5.100.2
-        version: 5.100.2(esbuild@0.25.8)
+        specifier: 5.101.0
+        version: 5.101.0(esbuild@0.25.8)
       webpack-dev-server:
         specifier: 5.2.2
-        version: 5.2.2(webpack@5.100.2(esbuild@0.25.8))
+        version: 5.2.2(webpack@5.101.0(esbuild@0.25.8))
 
   packages/angular_devkit/core:
     dependencies:
@@ -868,8 +868,8 @@ importers:
         specifier: 5.9.1-rc
         version: 5.9.1-rc
       webpack:
-        specifier: 5.100.2
-        version: 5.100.2(esbuild@0.25.8)
+        specifier: 5.101.0
+        version: 5.101.0(esbuild@0.25.8)
 
   packages/schematics/angular:
     dependencies:
@@ -8200,8 +8200,8 @@ packages:
       html-webpack-plugin:
         optional: true
 
-  webpack@5.100.2:
-    resolution: {integrity: sha512-QaNKAvGCDRh3wW1dsDjeMdDXwZm2vqq3zn6Pvq4rHOEOGSaUMgOOjG2Y9ZbIGzpfkJk9ZYTHpDqgDfeBDcnLaw==}
+  webpack@5.101.0:
+    resolution: {integrity: sha512-B4t+nJqytPeuZlHuIKTbalhljIFXeNRqrUGAQgTGlfOl2lXXKXw+yZu6bicycP+PUlM44CxBjCFD6aciKFT3LQ==}
     engines: {node: '>=10.13.0'}
     hasBin: true
     peerDependencies:
@@ -11613,11 +11613,11 @@ snapshots:
 
   b4a@1.6.7: {}
 
-  babel-loader@10.0.0(@babel/core@7.28.0)(webpack@5.100.2(esbuild@0.25.8)):
+  babel-loader@10.0.0(@babel/core@7.28.0)(webpack@5.101.0(esbuild@0.25.8)):
     dependencies:
       '@babel/core': 7.28.0
       find-up: 5.0.0
-      webpack: 5.100.2(esbuild@0.25.8)
+      webpack: 5.101.0(esbuild@0.25.8)
 
   babel-plugin-polyfill-corejs2@0.4.14(@babel/core@7.28.0):
     dependencies:
@@ -12168,14 +12168,14 @@ snapshots:
     dependencies:
       is-what: 3.14.1
 
-  copy-webpack-plugin@13.0.0(webpack@5.100.2(esbuild@0.25.8)):
+  copy-webpack-plugin@13.0.0(webpack@5.101.0(esbuild@0.25.8)):
     dependencies:
       glob-parent: 6.0.2
       normalize-path: 3.0.0
       schema-utils: 4.3.2
       serialize-javascript: 6.0.2
       tinyglobby: 0.2.14
-      webpack: 5.100.2(esbuild@0.25.8)
+      webpack: 5.101.0(esbuild@0.25.8)
 
   core-js-compat@3.44.0:
     dependencies:
@@ -12219,7 +12219,7 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  css-loader@7.1.2(webpack@5.100.2(esbuild@0.25.8)):
+  css-loader@7.1.2(webpack@5.101.0(esbuild@0.25.8)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
       postcss: 8.5.6
@@ -12230,7 +12230,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.7.2
     optionalDependencies:
-      webpack: 5.100.2(esbuild@0.25.8)
+      webpack: 5.101.0(esbuild@0.25.8)
 
   css-select@6.0.0:
     dependencies:
@@ -14272,11 +14272,11 @@ snapshots:
       picocolors: 1.1.1
       shell-quote: 1.8.3
 
-  less-loader@12.3.0(less@4.4.0)(webpack@5.100.2(esbuild@0.25.8)):
+  less-loader@12.3.0(less@4.4.0)(webpack@5.101.0(esbuild@0.25.8)):
     dependencies:
       less: 4.4.0
     optionalDependencies:
-      webpack: 5.100.2(esbuild@0.25.8)
+      webpack: 5.101.0(esbuild@0.25.8)
 
   less@4.4.0:
     dependencies:
@@ -14297,11 +14297,11 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
-  license-webpack-plugin@4.0.2(webpack@5.100.2(esbuild@0.25.8)):
+  license-webpack-plugin@4.0.2(webpack@5.101.0(esbuild@0.25.8)):
     dependencies:
       webpack-sources: 3.3.3
     optionalDependencies:
-      webpack: 5.100.2(esbuild@0.25.8)
+      webpack: 5.101.0(esbuild@0.25.8)
 
   lie@3.3.0:
     dependencies:
@@ -14530,11 +14530,11 @@ snapshots:
 
   mimic-function@5.0.1: {}
 
-  mini-css-extract-plugin@2.9.2(webpack@5.100.2(esbuild@0.25.8)):
+  mini-css-extract-plugin@2.9.2(webpack@5.101.0(esbuild@0.25.8)):
     dependencies:
       schema-utils: 4.3.2
       tapable: 2.2.2
-      webpack: 5.100.2(esbuild@0.25.8)
+      webpack: 5.101.0(esbuild@0.25.8)
 
   minimalistic-assert@1.0.1: {}
 
@@ -15170,14 +15170,14 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-loader@8.1.1(postcss@8.5.6)(typescript@5.9.1-rc)(webpack@5.100.2(esbuild@0.25.8)):
+  postcss-loader@8.1.1(postcss@8.5.6)(typescript@5.9.1-rc)(webpack@5.101.0(esbuild@0.25.8)):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.9.1-rc)
       jiti: 1.21.7
       postcss: 8.5.6
       semver: 7.7.2
     optionalDependencies:
-      webpack: 5.100.2(esbuild@0.25.8)
+      webpack: 5.101.0(esbuild@0.25.8)
     transitivePeerDependencies:
       - typescript
 
@@ -15723,12 +15723,12 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sass-loader@16.0.5(sass@1.89.2)(webpack@5.100.2(esbuild@0.25.8)):
+  sass-loader@16.0.5(sass@1.89.2)(webpack@5.101.0(esbuild@0.25.8)):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
       sass: 1.89.2
-      webpack: 5.100.2(esbuild@0.25.8)
+      webpack: 5.101.0(esbuild@0.25.8)
 
   sass@1.89.2:
     dependencies:
@@ -16047,11 +16047,11 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  source-map-loader@5.0.0(webpack@5.100.2(esbuild@0.25.8)):
+  source-map-loader@5.0.0(webpack@5.101.0(esbuild@0.25.8)):
     dependencies:
       iconv-lite: 0.6.3
       source-map-js: 1.2.1
-      webpack: 5.100.2(esbuild@0.25.8)
+      webpack: 5.101.0(esbuild@0.25.8)
 
   source-map-support@0.4.18:
     dependencies:
@@ -16341,14 +16341,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  terser-webpack-plugin@5.3.14(esbuild@0.25.8)(webpack@5.100.2(esbuild@0.25.8)):
+  terser-webpack-plugin@5.3.14(esbuild@0.25.8)(webpack@5.101.0(esbuild@0.25.8)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.29
       jest-worker: 27.5.1
       schema-utils: 4.3.2
       serialize-javascript: 6.0.2
       terser: 5.43.1
-      webpack: 5.100.2(esbuild@0.25.8)
+      webpack: 5.101.0(esbuild@0.25.8)
     optionalDependencies:
       esbuild: 0.25.8
 
@@ -16861,7 +16861,7 @@ snapshots:
 
   webidl-conversions@7.0.0: {}
 
-  webpack-dev-middleware@7.4.2(webpack@5.100.2(esbuild@0.25.8)):
+  webpack-dev-middleware@7.4.2(webpack@5.101.0(esbuild@0.25.8)):
     dependencies:
       colorette: 2.0.20
       memfs: 4.24.0
@@ -16870,9 +16870,9 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.2
     optionalDependencies:
-      webpack: 5.100.2(esbuild@0.25.8)
+      webpack: 5.101.0(esbuild@0.25.8)
 
-  webpack-dev-server@5.2.2(webpack@5.100.2(esbuild@0.25.8)):
+  webpack-dev-server@5.2.2(webpack@5.101.0(esbuild@0.25.8)):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -16900,10 +16900,10 @@ snapshots:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 7.4.2(webpack@5.100.2(esbuild@0.25.8))
+      webpack-dev-middleware: 7.4.2(webpack@5.101.0(esbuild@0.25.8))
       ws: 8.18.3
     optionalDependencies:
-      webpack: 5.100.2(esbuild@0.25.8)
+      webpack: 5.101.0(esbuild@0.25.8)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -16918,12 +16918,12 @@ snapshots:
 
   webpack-sources@3.3.3: {}
 
-  webpack-subresource-integrity@5.1.0(webpack@5.100.2(esbuild@0.25.8)):
+  webpack-subresource-integrity@5.1.0(webpack@5.101.0(esbuild@0.25.8)):
     dependencies:
       typed-assert: 1.0.9
-      webpack: 5.100.2(esbuild@0.25.8)
+      webpack: 5.101.0(esbuild@0.25.8)
 
-  webpack@5.100.2(esbuild@0.25.8):
+  webpack@5.101.0(esbuild@0.25.8):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -16947,7 +16947,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.2
       tapable: 2.2.2
-      terser-webpack-plugin: 5.3.14(esbuild@0.25.8)(webpack@5.100.2(esbuild@0.25.8))
+      terser-webpack-plugin: 5.3.14(esbuild@0.25.8)(webpack@5.101.0(esbuild@0.25.8))
       watchpack: 2.4.4
       webpack-sources: 3.3.3
     transitivePeerDependencies:


### PR DESCRIPTION
Updates Webpack to version 5.101.0.
Also adds runtime assertions to ensure that a Webpack compiler instance is always created when expected.