### PR TITLE
fix(@angular/cli): cache MCP best practices content and add tool annotations

### DIFF
--- a/packages/angular/cli/src/commands/mcp/tools/best-practices.ts
+++ b/packages/angular/cli/src/commands/mcp/tools/best-practices.ts
@@ -11,6 +11,8 @@ import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 
 export function registerBestPracticesTool(server: McpServer): void {
+  let bestPracticesText;
+
   server.registerTool(
     'get_best_practices',
     {
@@ -27,7 +29,7 @@ export function registerBestPracticesTool(server: McpServer): void {
       },
     },
     async () => {
-      const text = await readFile(
+      bestPracticesText ??= await readFile(
         path.join(__dirname, '..', 'instructions', 'best-practices.md'),
         'utf-8',
       );
@@ -36,7 +38,11 @@ export function registerBestPracticesTool(server: McpServer): void {
         content: [
           {
             type: 'text',
-            text,
+            text: bestPracticesText,
+            annotations: {
+              audience: ['assistant'],
+              priority: 0.9,
+            },
           },
         ],
       };


### PR DESCRIPTION
Caches the content of the best practices instructions to avoid redundant file reads on subsequent uses of the tool. This can provide a minor performance improvement in cases where the tool is used multiple times during a single CLI process.

Also, annotations have been added to the text to provide additional context for the assistant and allow for more tailored display of the information.