### PR TITLE
refactor(@angular/build): provide private component stylesheet bundling API for internal compilation infrastructure

### DIFF
--- a/packages/angular/build/src/private.ts
+++ b/packages/angular/build/src/private.ts
@@ -60,6 +60,7 @@ export function createCompilerPlugin(
 
 export type { AngularCompilation } from './tools/angular/compilation';
 export { createAngularCompilation };
+export { ComponentStylesheetBundler } from './tools/esbuild/angular/component-stylesheets';
 
 // Utilities
 export * from './utils/bundle-calculator';


### PR DESCRIPTION
The `ComponentStylesheetBundler` class is now available from the `private` entry point for the `@angular/build` package. All items exposed from this entry point are not subject to SemVer guarantees and may change between releases. Use with caution as breakage may occur when updating versions.