### PR TITLE
refactor(@angular/cli): add MCP test support for custom code examples

### DIFF
--- a/packages/angular/cli/src/commands/mcp/mcp-server.ts
+++ b/packages/angular/cli/src/commands/mcp/mcp-server.ts
@@ -74,7 +74,7 @@ export async function createMcpServer(
           ' Registration of this tool has been skipped.',
       );
     } else {
-      registerFindExampleTool(server, path.join(__dirname, '../../../lib/code-examples.db'));
+      await registerFindExampleTool(server, path.join(__dirname, '../../../lib/code-examples.db'));
     }
   }
 


### PR DESCRIPTION
The experimental MCP server now supports an additional environment variable for test purposes that allows custom markdown code examples to be used with the `find_examples` tool. This uses the `NG_MCP_EXAMPLES_DIR` environment variable.