### PR TITLE
refactor(@angular/cli): separate MCP tool declaration assembly into helper function

### DIFF
--- a/packages/angular/cli/src/commands/mcp/tools/tool-registry.ts
+++ b/packages/angular/cli/src/commands/mcp/tools/tool-registry.ts
@@ -35,6 +35,9 @@ export interface McpToolDeclaration<TInput extends ZodRawShape, TOutput extends 
   isLocalOnly?: boolean;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type AnyMcpToolDeclaration = McpToolDeclaration<any, any>;
+
 export function declareTool<TInput extends ZodRawShape, TOutput extends ZodRawShape>(
   declaration: McpToolDeclaration<TInput, TOutput>,
 ): McpToolDeclaration<TInput, TOutput> {
@@ -44,8 +47,7 @@ export function declareTool<TInput extends ZodRawShape, TOutput extends ZodRawSh
 export async function registerTools(
   server: McpServer,
   context: McpToolContext,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  declarations: McpToolDeclaration<any, any>[],
+  declarations: AnyMcpToolDeclaration[],
 ): Promise<void> {
   for (const declaration of declarations) {
     if (declaration.shouldRegister && !(await declaration.shouldRegister(context))) {


### PR DESCRIPTION
The logic to assemble the list of active tools for the MCP server has been extracted into a new `assembleToolDeclarations` helper function. This improves the structure and readability of the `createMcpServer` function.

The tool lists have also been moved to module-level, `readonly` variables with JSDoc comments to improve clarity and prevent accidental modifications.