### PR TITLE
Update Prettier defaults to enforce single quotes and 100 character line width

### DIFF
--- a/packages/schematics/angular/workspace/files/package.json.template
+++ b/packages/schematics/angular/workspace/files/package.json.template
@@ -9,6 +9,8 @@
     "test": "ng test"<% } %>
   },
   "prettier": {
+    "singleQuote": true,
+    "printWidth": 100,
     "overrides": [
       {
         "files": "*.html",


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently, the prettier block in package.json does not fully align with Angular’s recommended defaults as defined in .editorconfig.
This can lead to inconsistent formatting across projects, as common preferences like "singleQuote": true and "printWidth": 100 are not enforced in Prettier, even though .editorconfig specifies similar rules.

Issue Number: #30744

## What is the new behavior?

The prettier block in package.json has been updated to include Angular’s recommended defaults (singleQuote: true, printWidth: 100), ensuring consistency between .editorconfig and Prettier formatting across all projects.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This change avoids manual intervention in minimal projects while preserving the intended HTML formatting benefits for standard projects.
