### PR TITLE
refactor(@schematics/angular): add getDependency and removeDependency utilities

### DIFF
--- a/packages/schematics/angular/library/index.ts
+++ b/packages/schematics/angular/library/index.ts
@@ -23,10 +23,11 @@ import {
 import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
 import { join } from 'node:path/posix';
 import {
-  NodeDependencyType,
-  addPackageJsonDependency,
-  getPackageJsonDependency,
-} from '../utility/dependencies';
+  DependencyType,
+  ExistingBehavior,
+  addDependency,
+  getDependency,
+} from '../utility/dependency';
 import { JSONFile } from '../utility/json-file';
 import { latestVersions } from '../utility/latest-versions';
 import { relativePathToWorkspaceRoot } from '../utility/paths';
@@ -62,38 +63,29 @@ function addTsProjectReference(...paths: string[]) {
   };
 }
 
-function addDependenciesToPackageJson() {
-  return (host: Tree) => {
-    [
-      {
-        type: NodeDependencyType.Dev,
-        name: '@angular/compiler-cli',
-        version: latestVersions.Angular,
-      },
-      {
-        type: NodeDependencyType.Dev,
-        name: '@angular/build',
-        version: latestVersions.AngularBuild,
-      },
-      {
-        type: NodeDependencyType.Dev,
-        name: 'ng-packagr',
-        version: latestVersions.NgPackagr,
-      },
-      {
-        type: NodeDependencyType.Default,
-        name: 'tslib',
-        version: latestVersions['tslib'],
-      },
-      {
-        type: NodeDependencyType.Dev,
-        name: 'typescript',
-        version: latestVersions['typescript'],
-      },
-    ].forEach((dependency) => addPackageJsonDependency(host, dependency));
-
-    return host;
-  };
+function addDependenciesToPackageJson(): Rule {
+  return chain([
+    addDependency('@angular/compiler-cli', latestVersions.Angular, {
+      type: DependencyType.Dev,
+      existing: ExistingBehavior.Skip,
+    }),
+    addDependency('@angular/build', latestVersions.AngularBuild, {
+      type: DependencyType.Dev,
+      existing: ExistingBehavior.Skip,
+    }),
+    addDependency('ng-packagr', latestVersions.NgPackagr, {
+      type: DependencyType.Dev,
+      existing: ExistingBehavior.Skip,
+    }),
+    addDependency('tslib', latestVersions['tslib'], {
+      type: DependencyType.Default,
+      existing: ExistingBehavior.Skip,
+    }),
+    addDependency('typescript', latestVersions['typescript'], {
+      type: DependencyType.Dev,
+      existing: ExistingBehavior.Skip,
+    }),
+  ]);
 }
 
 function addLibToWorkspaceFile(
@@ -177,7 +169,7 @@ export default function (options: LibraryOptions): Rule {
       move(libDir),
     ]);
 
-    const hasZoneDependency = getPackageJsonDependency(host, 'zone.js') !== null;
+    const hasZoneDependency = getDependency(host, 'zone.js') !== null;
 
     return chain([
       mergeWith(templateSource),

--- a/packages/schematics/angular/library/index.ts
+++ b/packages/schematics/angular/library/index.ts
@@ -35,6 +35,13 @@ import { getWorkspace, updateWorkspace } from '../utility/workspace';
 import { Builders, ProjectType } from '../utility/workspace-models';
 import { Schema as LibraryOptions } from './schema';
 
+const LIBRARY_DEV_DEPENDENCIES = [
+  { name: '@angular/compiler-cli', version: latestVersions.Angular },
+  { name: '@angular/build', version: latestVersions.AngularBuild },
+  { name: 'ng-packagr', version: latestVersions.NgPackagr },
+  { name: 'typescript', version: latestVersions['typescript'] },
+];
+
 function updateTsConfig(packageName: string, ...paths: string[]) {
   return (host: Tree) => {
     if (!host.exists('tsconfig.json')) {
@@ -65,24 +72,14 @@ function addTsProjectReference(...paths: string[]) {
 
 function addDependenciesToPackageJson(): Rule {
   return chain([
-    addDependency('@angular/compiler-cli', latestVersions.Angular, {
-      type: DependencyType.Dev,
-      existing: ExistingBehavior.Skip,
-    }),
-    addDependency('@angular/build', latestVersions.AngularBuild, {
-      type: DependencyType.Dev,
-      existing: ExistingBehavior.Skip,
-    }),
-    addDependency('ng-packagr', latestVersions.NgPackagr, {
-      type: DependencyType.Dev,
-      existing: ExistingBehavior.Skip,
-    }),
+    ...LIBRARY_DEV_DEPENDENCIES.map((dependency) =>
+      addDependency(dependency.name, dependency.version, {
+        type: DependencyType.Dev,
+        existing: ExistingBehavior.Skip,
+      }),
+    ),
     addDependency('tslib', latestVersions['tslib'], {
       type: DependencyType.Default,
-      existing: ExistingBehavior.Skip,
-    }),
-    addDependency('typescript', latestVersions['typescript'], {
-      type: DependencyType.Dev,
       existing: ExistingBehavior.Skip,
     }),
   ]);

--- a/packages/schematics/angular/migrations/replace-provide-server-rendering-import/migration.ts
+++ b/packages/schematics/angular/migrations/replace-provide-server-rendering-import/migration.ts
@@ -7,8 +7,8 @@
  */
 
 import { DirEntry, Rule } from '@angular-devkit/schematics';
-import * as ts from '../../third_party/github.com/Microsoft/TypeScript/lib/typescript';
-import { NodeDependencyType, addPackageJsonDependency } from '../../utility/dependencies';
+import ts from '../../third_party/github.com/Microsoft/TypeScript/lib/typescript';
+import { addDependency } from '../../utility/dependency';
 import { latestVersions } from '../../utility/latest-versions';
 
 function* visit(directory: DirEntry): IterableIterator<[fileName: string, contents: string]> {
@@ -39,7 +39,7 @@ function* visit(directory: DirEntry): IterableIterator<[fileName: string, conten
 
 export default function (): Rule {
   return async (tree) => {
-    let angularSSRAdded = false;
+    let rule: Rule | undefined;
 
     for (const [filePath, content] of visit(tree.root)) {
       let updatedContent = content;
@@ -100,17 +100,12 @@ export default function (): Rule {
       if (content !== updatedContent) {
         tree.overwrite(filePath, updatedContent);
 
-        if (!angularSSRAdded) {
-          addPackageJsonDependency(tree, {
-            name: '@angular/ssr',
-            version: latestVersions.AngularSSR,
-            type: NodeDependencyType.Default,
-            overwrite: false,
-          });
-
-          angularSSRAdded = true;
+        if (rule === undefined) {
+          rule = addDependency('@angular/ssr', latestVersions.AngularSSR);
         }
       }
     }
+
+    return rule;
   };
 }

--- a/packages/schematics/angular/migrations/use-application-builder/migration.ts
+++ b/packages/schematics/angular/migrations/use-application-builder/migration.ts
@@ -15,12 +15,11 @@ import {
   externalSchematic,
 } from '@angular-devkit/schematics';
 import { dirname, join } from 'node:path/posix';
-import { removePackageJsonDependency } from '../../utility/dependencies';
 import {
   DependencyType,
   ExistingBehavior,
-  InstallBehavior,
   addDependency,
+  removeDependency,
 } from '../../utility/dependency';
 import { JSONFile } from '../../utility/json-file';
 import { latestVersions } from '../../utility/latest-versions';
@@ -270,13 +269,10 @@ function updateProjects(tree: Tree, context: SchematicContext) {
       rules.push(
         addDependency('@angular/build', latestVersions.DevkitBuildAngular, {
           type: DependencyType.Dev,
-          // Always is set here since removePackageJsonDependency below does not automatically
-          // trigger the package manager execution.
-          install: InstallBehavior.Always,
           existing: ExistingBehavior.Replace,
         }),
+        removeDependency('@angular-devkit/build-angular'),
       );
-      removePackageJsonDependency(tree, '@angular-devkit/build-angular');
 
       // Add less dependency if any projects contain a Less stylesheet file.
       // This check does not consider Node.js packages due to the performance

--- a/packages/schematics/angular/service-worker/index.ts
+++ b/packages/schematics/angular/service-worker/index.ts
@@ -23,7 +23,7 @@ import * as ts from '../third_party/github.com/Microsoft/TypeScript/lib/typescri
 import { addDependency, addRootProvider, readWorkspace, writeWorkspace } from '../utility';
 import { addSymbolToNgModuleMetadata, insertImport } from '../utility/ast-utils';
 import { applyToUpdateRecorder } from '../utility/change';
-import { getPackageJsonDependency } from '../utility/dependencies';
+import { getDependency } from '../utility/dependency';
 import { getAppModulePath, isStandaloneApp } from '../utility/ng-ast-utils';
 import { relativePathToWorkspaceRoot } from '../utility/paths';
 import { targetBuildNotFoundError } from '../utility/project-targets';
@@ -34,7 +34,7 @@ import { Schema as ServiceWorkerOptions } from './schema';
 
 function addDependencies(): Rule {
   return (host: Tree) => {
-    const coreDep = getPackageJsonDependency(host, '@angular/core');
+    const coreDep = getDependency(host, '@angular/core');
     if (!coreDep) {
       throw new SchematicsException('Could not find "@angular/core" version.');
     }


### PR DESCRIPTION
Adds two new utility functions to the schematics dependency helper library:

- getDependency: Allows a schematic to query a package.json and check for the existence of a dependency, returning its version and type if found.
- removeDependency: Provides a schematic rule to safely remove a dependency from any of the dependency sections in a package.json.

Refactors several schematics (`application`, `library`, `service-worker`, and two migrations) to use the new, centralized dependency management utilities (`addDependency`, `removeDependency`, `getDependency`).