### PR TITLE
fix(@schematics/angular): correct configure the `typeSeparator` in the library schematic

### DIFF
--- a/packages/schematics/angular/library/index.ts
+++ b/packages/schematics/angular/library/index.ts
@@ -188,6 +188,9 @@ export default function (options: LibraryOptions): Rule {
             flat: true,
             path: sourceDir,
             project: packageName,
+            // Explicitly set the `typeSeparator` this also ensures that the generated files are valid even if the `module` schematic
+            // inherits its `typeSeparator` from the workspace.
+            typeSeparator: '-',
           }),
       schematic('component', {
         name: options.name,


### PR DESCRIPTION


Prior to this the `typeSeparator` could have been inherited from the workspace setting which would cause the file references to be incorrect.

Closes #30886
