### PR TITLE
refactor(@angular/cli): use .html as template extension for mcp modernize tool

### DIFF
--- a/packages/angular/cli/src/commands/mcp/tools/modernize.ts
+++ b/packages/angular/cli/src/commands/mcp/tools/modernize.ts
@@ -136,7 +136,7 @@ export const MODERNIZE_TOOL = declareTool({
     '<Use Cases>\n' +
     '* After generating new code: Run this tool immediately after creating new Angular components, directives, ' +
     'or services to ensure they adhere to modern standards.\n' +
-    '* On existing code: Apply to existing TypeScript files (.ts) and Angular templates (.ng.html) to update ' +
+    '* On existing code: Apply to existing TypeScript files (.ts) and Angular templates (.html) to update ' +
     'them with the latest features, such as the new built-in control flow syntax.\n\n' +
     '* When the user asks for a specific transformation: When the transformation list is populated, ' +
     'these specific ones will be ran on the inputs.\n' +


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

`.ng.html` is not used unless `ngHtml` is set to true when generating a component. but the current style guide does not recommend to use `.ng.html`.

## What is the new behavior?

Uses `.html` instead.

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
