### PR TITLE
fix(@schematics/angular): improve coverage directory handling for Karma configuration comparisons

### DIFF
--- a/packages/schematics/angular/migrations/karma/karma-config-comparer.ts
+++ b/packages/schematics/angular/migrations/karma/karma-config-comparer.ts
@@ -120,9 +120,9 @@ export function hasDifferences(diff: KarmaConfigDiff): boolean {
  */
 export async function compareKarmaConfigToDefault(
   projectConfigContent: string,
-  projectRoot: string,
+  projectName: string,
+  karmaConfigPath: string,
   needDevkitPlugin: boolean,
-  karmaConfigPath?: string,
 ): Promise<KarmaConfigDiff>;
 
 /**
@@ -135,16 +135,16 @@ export async function compareKarmaConfigToDefault(
  */
 export async function compareKarmaConfigToDefault(
   projectAnalysis: KarmaConfigAnalysis,
-  projectRoot: string,
+  projectName: string,
+  karmaConfigPath: string,
   needDevkitPlugin: boolean,
-  karmaConfigPath?: string,
 ): Promise<KarmaConfigDiff>;
 
 export async function compareKarmaConfigToDefault(
   projectConfigOrAnalysis: string | KarmaConfigAnalysis,
-  projectRoot: string,
+  projectName: string,
+  karmaConfigPath: string,
   needDevkitPlugin: boolean,
-  karmaConfigPath?: string,
 ): Promise<KarmaConfigDiff> {
   const projectAnalysis =
     typeof projectConfigOrAnalysis === 'string'
@@ -152,8 +152,8 @@ export async function compareKarmaConfigToDefault(
       : projectConfigOrAnalysis;
 
   const defaultContent = await generateDefaultKarmaConfig(
-    relativePathToWorkspaceRoot(karmaConfigPath ? path.dirname(karmaConfigPath) : projectRoot),
-    path.basename(projectRoot),
+    relativePathToWorkspaceRoot(path.dirname(karmaConfigPath)),
+    projectName,
     needDevkitPlugin,
   );
   const defaultAnalysis = analyzeKarmaConfig(defaultContent);

--- a/packages/schematics/angular/migrations/karma/karma-config-comparer_spec.ts
+++ b/packages/schematics/angular/migrations/karma/karma-config-comparer_spec.ts
@@ -255,11 +255,11 @@ describe('Karma Config Comparer', () => {
     let defaultConfig: string;
 
     beforeAll(async () => {
-      defaultConfig = await generateDefaultKarmaConfig('..', 'test-project', true);
+      defaultConfig = await generateDefaultKarmaConfig('.', 'test-project', true);
     });
 
     it('should find no differences for the default config', async () => {
-      const diff = await compareKarmaConfigToDefault(defaultConfig, 'test-project', true);
+      const diff = await compareKarmaConfigToDefault(defaultConfig, 'test-project', '', true);
 
       expect(diff.isReliable).toBe(true);
       expect(diff.added.size).toBe(0);
@@ -272,7 +272,7 @@ describe('Karma Config Comparer', () => {
         .replace(`restartOnFileChange: true`, `restartOnFileChange: false`)
         .replace(`reporters: ['progress', 'kjhtml']`, `reporters: ['dots']`);
 
-      const diff = await compareKarmaConfigToDefault(modifiedConfig, 'test-project', true);
+      const diff = await compareKarmaConfigToDefault(modifiedConfig, 'test-project', '', true);
 
       expect(diff.isReliable).toBe(true);
       expect(diff.added.size).toBe(0);
@@ -288,15 +288,15 @@ describe('Karma Config Comparer', () => {
 
     it('should return an unreliable diff if the project config has unsupported values', async () => {
       const modifiedConfig = defaultConfig.replace(`browsers: ['Chrome']`, `browsers: myBrowsers`);
-      const diff = await compareKarmaConfigToDefault(modifiedConfig, 'test-project', true);
+      const diff = await compareKarmaConfigToDefault(modifiedConfig, 'test-project', '', true);
 
       expect(diff.isReliable).toBe(false);
       expect(diff.removed.has('browsers')).toBe(true);
     });
 
     it('should find no differences when devkit plugin is not needed', async () => {
-      const projectConfig = await generateDefaultKarmaConfig('..', 'test-project', false);
-      const diff = await compareKarmaConfigToDefault(projectConfig, 'test-project', false);
+      const projectConfig = await generateDefaultKarmaConfig('.', 'test-project', false);
+      const diff = await compareKarmaConfigToDefault(projectConfig, 'test-project', '', false);
 
       expect(diff.isReliable).toBe(true);
       expect(diff.added.size).toBe(0);

--- a/packages/schematics/angular/migrations/karma/migration.ts
+++ b/packages/schematics/angular/migrations/karma/migration.ts
@@ -16,7 +16,7 @@ function updateProjects(tree: Tree): Rule {
   return updateWorkspace(async (workspace) => {
     const removableKarmaConfigs = new Map<string, boolean>();
 
-    for (const [, project] of workspace.projects) {
+    for (const [projectName, project] of workspace.projects) {
       for (const [, target] of project.targets) {
         let needDevkitPlugin = false;
         switch (target.builder) {
@@ -46,9 +46,9 @@ function updateProjects(tree: Tree): Rule {
             } else {
               const diff = await compareKarmaConfigToDefault(
                 analysis,
-                project.root,
-                needDevkitPlugin,
+                projectName,
                 karmaConfig,
+                needDevkitPlugin,
               );
               isRemovable = !hasDifferences(diff) && diff.isReliable;
             }

--- a/packages/schematics/angular/migrations/karma/migration_spec.ts
+++ b/packages/schematics/angular/migrations/karma/migration_spec.ts
@@ -39,7 +39,7 @@ module.exports = function (config) {
       suppressAll: true // removes the duplicated traces
     },
     coverageReporter: {
-      dir: require('path').join(__dirname, './coverage/'),
+      dir: require('path').join(__dirname, './coverage/app'),
       subdir: '.',
       reporters: [
         { type: 'html' },
@@ -74,7 +74,7 @@ module.exports = function (config) {
       suppressAll: true
     },
     coverageReporter: {
-      dir: require('path').join(__dirname, './coverage/'),
+      dir: require('path').join(__dirname, './coverage/app'),
       subdir: '.',
       reporters: [
         { type: 'html' },
@@ -250,7 +250,7 @@ module.exports = function (config) {
       suppressAll: true
     },
     coverageReporter: {
-      dir: require('path').join(__dirname, './coverage/'),
+      dir: require('path').join(__dirname, './coverage/app'),
       subdir: '.',
       reporters: [
         { type: 'html' },
@@ -304,7 +304,7 @@ module.exports = function (config) {
       suppressAll: true
     },
     coverageReporter: {
-      dir: require('path').join(__dirname, './coverage/'),
+      dir: require('path').join(__dirname, './coverage/app'),
       subdir: '.',
       reporters: [
         { type: 'html' },
@@ -368,7 +368,7 @@ module.exports = function (config) {
       suppressAll: true
     },
     coverageReporter: {
-      dir: require('path').join(__dirname, '../coverage/'),
+      dir: require('path').join(__dirname, '../coverage/app'),
       subdir: '.',
       reporters: [
         { type: 'html' },
@@ -414,7 +414,7 @@ module.exports = function (config) {
       suppressAll: true
     },
     coverageReporter: {
-      dir: require('path').join(__dirname, './coverage/'),
+      dir: require('path').join(__dirname, './coverage/app'),
       subdir: '.',
       reporters: [
         { type: 'html' },


### PR DESCRIPTION
Analysis and comparison of coverage reporter directories has been improved. This provides more accurate removal of default configurations in favor of the built-in default configuration.