### PR TITLE
fix(@angular/cli): use correct path for MCP get_best_practices tool

### DIFF
--- a/packages/angular/cli/src/commands/mcp/tools/best-practices.ts
+++ b/packages/angular/cli/src/commands/mcp/tools/best-practices.ts
@@ -26,7 +26,7 @@ export const BEST_PRACTICES_TOOL = declareTool({
 
     return async () => {
       bestPracticesText ??= await readFile(
-        path.join(__dirname, '..', 'instructions', 'best-practices.md'),
+        path.join(__dirname, '..', 'resources', 'best-practices.md'),
         'utf-8',
       );
 

--- a/tests/legacy-cli/e2e/tests/mcp/best-practices.ts
+++ b/tests/legacy-cli/e2e/tests/mcp/best-practices.ts
@@ -1,0 +1,43 @@
+import { chdir } from 'node:process';
+import { exec, ProcessOutput, silentNpm } from '../../utils/process';
+import assert from 'node:assert/strict';
+
+const MCP_INSPECTOR_PACKAGE_NAME = '@modelcontextprotocol/inspector-cli';
+const MCP_INSPECTOR_PACKAGE_VERSION = '0.16.2';
+const MCP_INSPECTOR_COMMAND_NAME = 'mcp-inspector-cli';
+
+async function runInspector(...args: string[]): Promise<ProcessOutput> {
+  const result = await exec(
+    MCP_INSPECTOR_COMMAND_NAME,
+    '--cli',
+    'npx',
+    '--no',
+    '@angular/cli',
+    'mcp',
+    ...args,
+  );
+
+  return result;
+}
+
+export default async function () {
+  await silentNpm(
+    'install',
+    '--ignore-scripts',
+    '-g',
+    `${MCP_INSPECTOR_PACKAGE_NAME}@${MCP_INSPECTOR_PACKAGE_VERSION}`,
+  );
+
+  // Ensure `get_best_practices` returns the markdown content
+  const { stdout: stdoutInsideWorkspace } = await runInspector(
+    '--method',
+    'tools/call',
+    '--tool-name',
+    'get_best_practices',
+  );
+
+  assert.match(
+    stdoutInsideWorkspace,
+    /You are an expert in TypeScript, Angular, and scalable web application development./,
+  );
+}


### PR DESCRIPTION
The package internal path for the Angular best practices markdown file has been corrected to the new location following a previous refactoring.