### PR TITLE
fix(@schematics/angular): allow AI config prompt to be skipped without selecting a value

### DIFF
--- a/packages/schematics/angular/ai-config/schema.json
+++ b/packages/schematics/angular/ai-config/schema.json
@@ -12,7 +12,6 @@
       "default": "none",
       "x-prompt": "Which AI tools do you want to configure with Angular best practices? https://angular.dev/ai/develop-with-ai",
       "description": "Specifies which AI tools to generate configuration files for. These file are used to improve the outputs of AI tools by following the best practices.",
-      "minItems": 1,
       "items": {
         "type": "string",
         "enum": ["none", "gemini", "copilot", "claude", "cursor", "jetbrains", "windsurf"]
@@ -26,8 +25,7 @@
           "const": "none"
         }
       }
-    },
-    "required": ["tool"]
+    }
   },
   "then": {
     "properties": {


### PR DESCRIPTION

With this change, we allow the AI config prompt to be skipped by pressing "ENTER" without selecting "None" and it will default to "None".
