### PR TITLE
ci: re-enable windows CI [main]

### DIFF
--- a/.github/shared-actions/windows-bazel-test/action.yml
+++ b/.github/shared-actions/windows-bazel-test/action.yml
@@ -18,16 +18,15 @@ runs:
   steps:
     - name: Initialize WSL
       id: init_wsl
-      uses: angular/dev-infra/github-actions/setup-wsl@7f2c99469dcf64fd466abf6cb53bede791d7599d
+      uses: angular/dev-infra/github-actions/setup-wsl@66a623888d17a9f2f9f4558fad5b07e78dde525e
       with:
         wsl_firewall_interface: 'vEthernet (WSL (Hyper-V firewall))'
 
-    - name: Installing pnpm (in WSL)
-      run: npm install -g pnpm@9
-      shell: wsl-bash {0}
-
     - name: Install node modules in WSL (re-using from previous install/cache restore)
       run: |
+        export NVM_DIR="$HOME/.nvm"
+        [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+
         cd ${{steps.init_wsl.outputs.repo_path}}
         pnpm install --frozen-lockfile
       shell: wsl-bash {0}
@@ -35,6 +34,9 @@ runs:
     - name: Build test binary for Windows (inside WSL)
       shell: wsl-bash {0}
       run: |
+        export NVM_DIR="$HOME/.nvm"
+        [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+
         cd ${{steps.init_wsl.outputs.repo_path}}
         pnpm bazel \
           build --config=e2e //tests/legacy-cli:${{inputs.test_target_name}} --platforms=tools:windows_x64
@@ -54,6 +56,9 @@ runs:
     - name: Convert symlinks for Windows host
       shell: wsl-bash {0}
       run: |
+        export NVM_DIR="$HOME/.nvm"
+        [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+
         cd ${{steps.init_wsl.outputs.repo_path}}
 
         runfiles_dir="/mnt/c/test/dist/bin/tests/legacy-cli/${{inputs.test_target_name}}_/${{inputs.test_target_name}}.bat.runfiles"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -127,24 +127,23 @@ jobs:
       - name: Run CLI E2E tests
         run: pnpm bazel test --test_env=E2E_SHARD_TOTAL=6 --test_env=E2E_SHARD_INDEX=${{ matrix.shard }} --config=e2e //tests/legacy-cli:e2e.${{ matrix.subset }}_node${{ matrix.node }}
 
-  # Temporarily disabled due to https://github.com/Vampire/setup-wsl/issues/76.
-  # e2e-windows-subset:
-  #   needs: build
-  #   runs-on: windows-2025
-  #   steps:
-  #     - name: Initialize environment
-  #       uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@59c46175bf3a8870c0c2ceb9de1eb741fd50d415
-  #     - name: Setup Bazel
-  #       uses: angular/dev-infra/github-actions/bazel/setup@59c46175bf3a8870c0c2ceb9de1eb741fd50d415
-  #     - name: Setup Bazel RBE
-  #       uses: angular/dev-infra/github-actions/bazel/configure-remote@59c46175bf3a8870c0c2ceb9de1eb741fd50d415
-  #       with:
-  #         allow_windows_rbe: true
-  #     - name: Run CLI E2E tests
-  #       uses: ./.github/shared-actions/windows-bazel-test
-  #       with:
-  #         test_target_name: e2e_node22
-  #         test_args: --esbuild --glob "tests/basic/{build,rebuild}.ts"
+  e2e-windows-subset:
+    needs: build
+    runs-on: windows-2025
+    steps:
+      - name: Initialize environment
+        uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@7f2c99469dcf64fd466abf6cb53bede791d7599d
+      - name: Setup Bazel
+        uses: angular/dev-infra/github-actions/bazel/setup@7f2c99469dcf64fd466abf6cb53bede791d7599d
+      - name: Setup Bazel RBE
+        uses: angular/dev-infra/github-actions/bazel/configure-remote@7f2c99469dcf64fd466abf6cb53bede791d7599d
+        with:
+          allow_windows_rbe: true
+      - name: Run CLI E2E tests
+        uses: ./.github/shared-actions/windows-bazel-test
+        with:
+          test_target_name: e2e_node22
+          test_args: --esbuild --glob "tests/basic/{build,rebuild}.ts"
 
   e2e-package-managers:
     needs: build

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -281,7 +281,7 @@ http_archive(
 
 git_repository(
     name = "rules_browsers",
-    commit = "56ef8007ea07cd1916429bca8bb523433b0e9cdc",
+    commit = "c9a70ad79258e2ffc498075623f9f974920a4025",
     remote = "https://github.com/devversion/rules_browsers.git",
 )
 


### PR DESCRIPTION


This commit fixes and re-enables windows CI. 

Upstream fixes:
- https://github.com/devversion/rules_browsers/pull/18
- https://github.com/angular/dev-infra/pull/2966