### PR TITLE
refactor(@angular/build): remove manual Node.js types for getCompileCacheDir

### DIFF
--- a/packages/angular/build/src/typings.d.ts
+++ b/packages/angular/build/src/typings.d.ts
@@ -17,10 +17,3 @@
 declare module 'esbuild' {
   export * from 'esbuild-wasm';
 }
-
-/**
- * Augment the Node.js module builtin types to support the v22.8+ compile cache functions
- */
-declare module 'node:module' {
-  function getCompileCacheDir(): string | undefined;
-}


### PR DESCRIPTION
The manual type declaration is no longer needed with newer versions of the Node.js types (`@types/node`).