### PR TITLE
refactor(@angular/cli): remove non runnable migrations in mcp modernize tool

### DIFF
--- a/packages/angular/cli/src/commands/mcp/tools/modernize.ts
+++ b/packages/angular/cli/src/commands/mcp/tools/modernize.ts
@@ -30,12 +30,6 @@ const TRANSFORMATIONS: Array<Transformation> = [
     documentationUrl: 'https://angular.dev/reference/migrations/self-closing-tags',
   },
   {
-    name: 'test-bed-get',
-    description:
-      'Updates `TestBed.get` to the preferred and type-safe `TestBed.inject` in TypeScript test files.',
-    documentationUrl: 'https://angular.dev/guide/testing/dependency-injection',
-  },
-  {
     name: 'inject',
     description: 'Converts usages of constructor-based injection to the inject() function.',
     documentationUrl: 'https://angular.dev/reference/migrations/inject-function',
@@ -69,11 +63,6 @@ const TRANSFORMATIONS: Array<Transformation> = [
       '2. Run `ng g @angular/core:standalone` and select "Remove unnecessary NgModule classes"\n' +
       '3. Run `ng g @angular/core:standalone` and select "Bootstrap the project using standalone APIs"',
     documentationUrl: 'https://angular.dev/reference/migrations/standalone',
-  },
-  {
-    name: 'zoneless',
-    description: 'Migrates the application to be zoneless.',
-    documentationUrl: 'https://angular.dev/guide/zoneless',
   },
 ];
 

--- a/packages/angular/cli/src/commands/mcp/tools/modernize_spec.ts
+++ b/packages/angular/cli/src/commands/mcp/tools/modernize_spec.ts
@@ -35,16 +35,16 @@ describe('Modernize Tool', () => {
 
   it('should return instructions for multiple transformations', async () => {
     const instructions = await getInstructions({
-      transformations: ['self-closing-tags-migration', 'test-bed-get'],
+      transformations: ['self-closing-tags-migration', 'inject'],
     });
 
     const expectedInstructions = [
       'To run the self-closing-tags-migration migration, execute the following command: ' +
         '`ng generate @angular/core:self-closing-tags-migration`.\nFor more information, ' +
         'see https://angular.dev/reference/migrations/self-closing-tags.',
-      'To run the test-bed-get migration, execute the following command: ' +
-        '`ng generate @angular/core:test-bed-get`.\nFor more information, ' +
-        'see https://angular.dev/guide/testing/dependency-injection.',
+      'To run the inject migration, execute the following command: ' +
+        '`ng generate @angular/core:inject`.\nFor more information, ' +
+        'see https://angular.dev/reference/migrations/inject-function.',
     ];
 
     expect(instructions?.sort()).toEqual(expectedInstructions.sort());


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [ ] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

The `test-bed-get` migration is not runnable via `ng g @angular/core` and references a non-existing documentation page. `zoneless` does not exist for now (Angular v20.2.0-rc.0).

## What is the new behavior?

This removes the mentioned migrations

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
