### PR TITLE
fix(@schematics/angular): format template files to match Prettier conf

### DIFF
--- a/packages/schematics/angular/application/files/common-files/src/app/app.html.template
+++ b/packages/schematics/angular/application/files/common-files/src/app/app.html.template
@@ -36,9 +36,18 @@
 
     --pill-accent: var(--bright-blue);
 
-    font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-      Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
-      "Segoe UI Symbol";
+    font-family:
+      'Inter',
+      -apple-system,
+      BlinkMacSystemFont,
+      'Segoe UI',
+      Roboto,
+      Helvetica,
+      Arial,
+      sans-serif,
+      'Apple Color Emoji',
+      'Segoe UI Emoji',
+      'Segoe UI Symbol';
     box-sizing: border-box;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
@@ -51,9 +60,18 @@
     line-height: 100%;
     letter-spacing: -0.125rem;
     margin: 0;
-    font-family: "Inter Tight", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-      Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
-      "Segoe UI Symbol";
+    font-family:
+      'Inter Tight',
+      -apple-system,
+      BlinkMacSystemFont,
+      'Segoe UI',
+      Roboto,
+      Helvetica,
+      Arial,
+      sans-serif,
+      'Apple Color Emoji',
+      'Segoe UI Emoji',
+      'Segoe UI Symbol';
   }
 
   p {
@@ -214,14 +232,7 @@
             <stop offset=".707" stop-color="#FF41F8" stop-opacity=".5" />
             <stop offset="1" stop-color="#FF41F8" stop-opacity="0" />
           </radialGradient>
-          <linearGradient
-            id="b"
-            x1="0"
-            x2="982"
-            y1="192"
-            y2="192"
-            gradientUnits="userSpaceOnUse"
-          >
+          <linearGradient id="b" x1="0" x2="982" y1="192" y2="192" gradientUnits="userSpaceOnUse">
             <stop stop-color="#F0060B" />
             <stop offset="0" stop-color="#F0070C" />
             <stop offset=".526" stop-color="#CC26D5" />
@@ -236,20 +247,31 @@
     <div class="divider" role="separator" aria-label="Divider"></div>
     <div class="right-side">
       <div class="pill-group">
-        @for (item of [
-          { title: 'Explore the Docs', link: 'https://angular.dev' },
-          { title: 'Learn with Tutorials', link: 'https://angular.dev/tutorials' },
-          { title: 'Prompt and best practices for AI', link: 'https://angular.dev/ai/develop-with-ai'},
-          { title: 'CLI Docs', link: 'https://angular.dev/tools/cli' },
-          { title: 'Angular Language Service', link: 'https://angular.dev/tools/language-service' },
-          { title: 'Angular DevTools', link: 'https://angular.dev/tools/devtools' },
-        ]; track item.title) {
-          <a
-            class="pill"
-            [href]="item.link"
-            target="_blank"
-            rel="noopener"
-          >
+        @for (
+          item of [
+            { title: 'Explore the Docs', link: 'https://angular.dev' },
+            {
+              title:
+                'Learn
+        with Tutorials',
+              link: 'https://angular.dev/tutorials',
+            },
+            {
+              title:
+                'Prompt and best
+        practices for AI',
+              link: 'https://angular.dev/ai/develop-with-ai',
+            },
+            { title: 'CLI Docs', link: 'https://angular.dev/tools/cli' },
+            {
+              title: 'Angular Language Service',
+              link: 'https://angular.dev/tools/language-service',
+            },
+            { title: 'Angular DevTools', link: 'https://angular.dev/tools/devtools' },
+          ];
+          track item.title
+        ) {
+          <a class="pill" [href]="item.link" target="_blank" rel="noopener">
             <span>{{ item.title }}</span>
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -285,12 +307,7 @@
             />
           </svg>
         </a>
-        <a
-          href="https://twitter.com/angular"
-          aria-label="Twitter"
-          target="_blank"
-          rel="noopener"
-        >
+        <a href="https://twitter.com/angular" aria-label="Twitter" target="_blank" rel="noopener">
           <svg
             width="24"
             height="24"

--- a/packages/schematics/angular/application/files/common-files/src/index.html.template
+++ b/packages/schematics/angular/application/files/common-files/src/index.html.template
@@ -1,13 +1,13 @@
 <!doctype html>
 <html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title><%= utils.classify(name) %></title>
-  <base href="/">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="icon" type="image/x-icon" href="favicon.ico">
-</head>
-<body>
-  <<%= selector %>></<%= selector %>>
-</body>
+  <head>
+    <meta charset="utf-8" />
+    <title><%= utils.classify(name) %></title>
+    <base href="/" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" type="image/x-icon" href="favicon.ico" />
+  </head>
+  <body>
+    <<%= selector %>></<%= selector %>>
+  </body>
 </html>

--- a/packages/schematics/angular/application/files/standalone-files/src/app/app.config.ts.template
+++ b/packages/schematics/angular/application/files/standalone-files/src/app/app.config.ts.template
@@ -1,5 +1,9 @@
-import { ApplicationConfig, provideBrowserGlobalErrorListeners, <% if(!zoneless) { %>provideZoneChangeDetection<% } else { %>provideZonelessChangeDetection<% } %> } from '@angular/core';<% if (routing) { %>
-import { provideRouter } from '@angular/router';
+import {
+  ApplicationConfig,
+  provideBrowserGlobalErrorListeners,
+  <% if(!zoneless) { %>provideZoneChangeDetection<% } else { %>provideZonelessChangeDetection<% } %>,
+} from '@angular/core';
+<% if (routing) { %>import { provideRouter } from '@angular/router';
 
 import { routes } from './app.routes';<% } %>
 
@@ -7,6 +11,6 @@ export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
     <% if(zoneless) { %>provideZonelessChangeDetection()<% } else { %>provideZoneChangeDetection({ eventCoalescing: true })<% } %>,
-    <% if (routing) {%>provideRouter(routes)<% } %>
-  ]
+    <% if (routing) {%>provideRouter(routes)<% } %>,
+  ],
 };

--- a/packages/schematics/angular/application/files/standalone-files/src/app/app.ts.template
+++ b/packages/schematics/angular/application/files/standalone-files/src/app/app.ts.template
@@ -13,7 +13,7 @@ import { RouterOutlet } from '@angular/router';<% } %>
   `,<% } else { %>
   templateUrl: './app.html',<% } if(inlineStyle) { %>
   styles: [],<% } else { %>
-  styleUrl: './app.<%= style %>'<% } %>
+  styleUrl: './app.<%= style %>'<% } %>,
 })
 export class App {
   protected readonly title = signal('<%= name %>');

--- a/packages/schematics/angular/application/files/standalone-files/src/main.ts.template
+++ b/packages/schematics/angular/application/files/standalone-files/src/main.ts.template
@@ -2,5 +2,4 @@ import { bootstrapApplication } from '@angular/platform-browser';
 import { appConfig } from './app/app.config';
 import { App } from './app/app';
 
-bootstrapApplication(App, appConfig)
-  .catch((err) => console.error(err));
+bootstrapApplication(App, appConfig).catch((err) => console.error(err));


### PR DESCRIPTION
Applies consistent formatting to Angular schematic template files to prevent changes when Prettier is executed on freshly generated files. The templates now respect the formatting configuration defined in package.json.

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

When we format a file using Prettier on a freshly generated project, it reads the configuration in the package.json and formats the file. It would be nice if the templates were already formatted correctly to avoid unnecessary git changes.

Issue Number: N/A

Templates are formatted following the configuration set in package.json

<!-- Please describe the new behavior that. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
