### PR TITLE
refactor(@angular/ssr): add workaround for router `lastSuccessfulNavigation` breaking changing

### DIFF
--- a/packages/angular/ssr/src/utils/ng.ts
+++ b/packages/angular/ssr/src/utils/ng.ts
@@ -100,7 +100,15 @@ export async function renderAngular(
     const envInjector = applicationRef.injector;
     const routerIsProvided = !!envInjector.get(ActivatedRoute, null);
     const router = envInjector.get(Router);
-    const lastSuccessfulNavigation = router.lastSuccessfulNavigation;
+
+    // TODO(alanagius): Remove the below check when version 21.0.0-next.0 is on NPM
+    // Workaround for breaking change that landed on angular/angular main too early
+    // https://github.com/angular/angular/pull/63057
+    const lastSuccessfulNavigation =
+      typeof router.lastSuccessfulNavigation === 'function'
+        ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (router as any).lastSuccessfulNavigation()
+        : router.lastSuccessfulNavigation;
 
     if (!routerIsProvided) {
       hasNavigationError = false;


### PR DESCRIPTION


This workaround is needed to;
- Re-enable SSG in ADEV
- Re-enable SSR tests in angular/angular main
- Make cross-repo updates green again
