### PR TITLE
build: improve retry exec logic

### DIFF
--- a/scripts/windows-testing/convert-symlinks.mjs
+++ b/scripts/windows-testing/convert-symlinks.mjs
@@ -133,7 +133,7 @@ try {
   // Re-link symlinks to work inside Windows.
   // This is done in batches to avoid flakiness due to WSL
   // See: https://github.com/microsoft/WSL/issues/8677.
-  const batchSize = 75;
+  const batchSize = 50;
   for (let i = 0; i < relinkFns.length; i += batchSize) {
     await Promise.all(relinkFns.slice(i, i + batchSize).map((fn) => fn()));
   }


### PR DESCRIPTION
Prior to this change, there was a flaw in its handling of the retry logic, specifically within the `setTimeout` block. The function had a recursive promise resolution problem and an incorrect handling of the rejected state.
