### PR TITLE
test(@angular/build): add initial unit-test vitest runner E2E tests

### DIFF
--- a/tests/legacy-cli/e2e.bzl
+++ b/tests/legacy-cli/e2e.bzl
@@ -37,11 +37,13 @@ ESBUILD_TESTS = [
     "tests/commands/serve/ssr-http-requests-assets.js",
     "tests/i18n/**",
     "tests/vite/**",
+    "tests/vitest/**",
     "tests/test/**",
 ]
 
 WEBPACK_IGNORE_TESTS = [
     "tests/vite/**",
+    "tests/vitest/**",
     "tests/build/app-shell/**",
     "tests/i18n/ivy-localize-app-shell.js",
     "tests/i18n/ivy-localize-app-shell-service-worker.js",

--- a/tests/legacy-cli/e2e/tests/vitest/basic.ts
+++ b/tests/legacy-cli/e2e/tests/vitest/basic.ts
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict';
+import { applyVitestBuilder } from '../../utils/vitest';
+import { ng } from '../../utils/process';
+
+export default async function (): Promise<void> {
+  await applyVitestBuilder();
+
+  const { stderr } = await ng('test');
+
+  assert.match(
+    stderr,
+    /NOTE: The "unit-test" builder is currently EXPERIMENTAL/,
+    'Expected stderr to include the experimental notice.',
+  );
+}

--- a/tests/legacy-cli/e2e/tests/vitest/component.ts
+++ b/tests/legacy-cli/e2e/tests/vitest/component.ts
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict';
+import { applyVitestBuilder } from '../../utils/vitest';
+import { ng } from '../../utils/process';
+
+export default async function (): Promise<void> {
+  await applyVitestBuilder();
+  await ng('generate', 'component', 'my-comp');
+
+  const { stdout } = await ng('test');
+
+  assert.match(stdout, /2 passed/, 'Expected 2 tests to pass.');
+}

--- a/tests/legacy-cli/e2e/utils/vitest.ts
+++ b/tests/legacy-cli/e2e/utils/vitest.ts
@@ -1,0 +1,28 @@
+import { silentNpm } from './process';
+import { updateJsonFile } from './project';
+
+/** Updates the `test` builder in the current workspace to use Vitest. */
+export async function applyVitestBuilder(): Promise<void> {
+  await silentNpm('install', 'vitest@3.2.4', 'jsdom@26.1.0', '--save-dev');
+
+  await updateJsonFile('angular.json', (json) => {
+    const projects = Object.values(json['projects']);
+    if (projects.length !== 1) {
+      throw new Error(
+        `Expected exactly one project but found ${projects.length} projects named ${Object.keys(
+          json['projects'],
+        ).join(', ')}`,
+      );
+    }
+    const project = projects[0]! as any;
+
+    // Update to Vitest builder.
+    const test = project['architect']['test'];
+    test['builder'] = '@angular/build:unit-test';
+    test['options'] = {
+      tsConfig: test['options']['tsConfig'],
+      buildTarget: '::development',
+      runner: 'vitest',
+    };
+  });
+}


### PR DESCRIPTION
Two E2E tests have been added to test initial capabilities of the experimental unit-test builder with the vitest runner. This also ensures that the generated tests are compatible with both the karma/jasmine-based runner and the vitest runner.