### PR TITLE
ci: update `MODULE.bazel.lock` when updates packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,11 @@
   "extends": ["github>angular/dev-infra//renovate-presets/default.json5"],
   "ignorePaths": ["tests/legacy-cli/e2e/assets/**", "tests/schematics/update/packages/**"],
   "ignoreDeps": ["io_bazel_rules_webtesting"],
+  "postUpgradeTasks": {
+    "commands": ["git restore .npmrc", "pnpm install --frozen-lockfile", "pnpm bazel mod tidy"],
+    "fileFilters": ["MODULE.bazel.lock"],
+    "executionMode": "branch"
+  },
   "packageRules": [
     {
       "matchFileNames": [


### PR DESCRIPTION
Renovate does yet handle `MODULE.bazel.lock`. See: https://github.com/renovatebot/renovate/issues/25557

We do this as a workaround for that.
