### PR TITLE
build: enforce frozen lockfile mode

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -16,6 +16,9 @@ test:debug --test_arg=--node_options=--inspect-brk --test_output=streamed --test
 # The below is useful to while using `fit` and `fdescribe` to avoid sharing and re-runs of failed flaky tests.
 test:no-sharding --flaky_test_attempts=1 --test_sharding_strategy=disabled
 
+# Frozen lockfile
+common --lockfile_mode=error
+
 ###############################
 # Filesystem interactions     #
 ###############################


### PR DESCRIPTION
This commit adds `lockfile_mode=error` to the `.bazelrc` file. This change ensures that any future builds will fail if the lock file is not up-to-date with the `BUILD.bazel` file, preventing inconsistencies and encouraging developers to commit updated lock files.
