### PR TITLE
ci: enable Renovate on non-base branches

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,18 +1,22 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "baseBranchPatterns": ["main", "20.2.x"],
   "extends": ["github>angular/dev-infra//renovate-presets/default.json5"],
   "ignorePaths": ["tests/legacy-cli/e2e/assets/**", "tests/schematics/update/packages/**"],
-  "ignoreDeps": ["io_bazel_rules_webtesting"],
-  "postUpgradeTasks": {
-    "commands": [
-      "git restore .npmrc",
-      "pnpm install --frozen-lockfile",
-      "pnpm bazel mod deps --lockfile_mode=update"
-    ],
-    "fileFilters": ["MODULE.bazel.lock"],
-    "executionMode": "branch"
-  },
   "packageRules": [
+    {
+      "matchBaseBranches": ["main"],
+      "addLabels": ["target: minor"]
+    },
+    {
+      "matchBaseBranches": ["!main"],
+      "addLabels": ["target: patch"]
+    },
+    {
+      "enabled": false,
+      "matchFileNames": ["tests/legacy-cli/e2e/ng-snapshot/package.json"],
+      "matchBaseBranches": ["!main"]
+    },
     {
       "matchFileNames": [
         "packages/angular_devkit/schematics_cli/blank/project-files/package.json",


### PR DESCRIPTION

This change allows Renovate to run on all branches, not just the base branch. Note that it will only update cross-repo, Bazel, and GitHub Actions dependencies on these branches.

The `postUpgradeTasks` has also been removed as it has been moved into the preset. See: https://github.com/angular/dev-infra/pull/2978