### PR TITLE
feat(@angular/cli): remove direct support for `cnpm`

### DIFF
--- a/packages/angular/cli/lib/config/workspace-schema.json
+++ b/packages/angular/cli/lib/config/workspace-schema.json
@@ -47,7 +47,7 @@
         "packageManager": {
           "description": "Specify which package manager tool to use.",
           "type": "string",
-          "enum": ["npm", "cnpm", "yarn", "pnpm", "bun"]
+          "enum": ["npm", "yarn", "pnpm", "bun"]
         },
         "warnings": {
           "description": "Control CLI specific console warnings",
@@ -101,7 +101,7 @@
         "packageManager": {
           "description": "Specify which package manager tool to use.",
           "type": "string",
-          "enum": ["npm", "cnpm", "yarn", "pnpm", "bun"]
+          "enum": ["npm", "yarn", "pnpm", "bun"]
         },
         "warnings": {
           "description": "Control CLI specific console warnings",

--- a/packages/angular/cli/src/commands/update/schematic/schema.json
+++ b/packages/angular/cli/src/commands/update/schematic/schema.json
@@ -57,7 +57,7 @@
       "description": "The preferred package manager configuration files to use for registry settings.",
       "type": "string",
       "default": "npm",
-      "enum": ["npm", "yarn", "cnpm", "pnpm", "bun"]
+      "enum": ["npm", "yarn", "pnpm", "bun"]
     }
   },
   "required": []

--- a/packages/angular/create/src/index.ts
+++ b/packages/angular/create/src/index.ts
@@ -17,7 +17,7 @@ const hasPackageManagerArg = args.some((a) => a.startsWith('--package-manager'))
 if (!hasPackageManagerArg) {
   // Ex: yarn/1.22.18 npm/? node/v16.15.1 linux x64
   const packageManager = process.env['npm_config_user_agent']?.split('/')[0];
-  if (packageManager && ['npm', 'pnpm', 'yarn', 'cnpm', 'bun'].includes(packageManager)) {
+  if (packageManager && ['npm', 'pnpm', 'yarn', 'bun'].includes(packageManager)) {
     args.push('--package-manager', packageManager);
   }
 }

--- a/packages/angular_devkit/core/src/json/schema/registry_spec.ts
+++ b/packages/angular_devkit/core/src/json/schema/registry_spec.ts
@@ -118,7 +118,7 @@ describe('CoreSchemaRegistry', () => {
 
     const validator = await registry.compile({
       properties: {
-        packageManager: { type: 'string', enum: ['npm', 'yarn', 'pnpm', 'cnpm'] },
+        packageManager: { type: 'string', enum: ['npm', 'yarn', 'pnpm'] },
       },
       additionalProperties: false,
     });
@@ -126,7 +126,7 @@ describe('CoreSchemaRegistry', () => {
     const result = await validator(data);
     expect(result.success).toBe(false);
     expect(new SchemaValidationException(result.errors).message).toContain(
-      `Data path "/packageManager" must be equal to one of the allowed values. Allowed values are: "npm", "yarn", "pnpm", "cnpm".`,
+      `Data path "/packageManager" must be equal to one of the allowed values. Allowed values are: "npm", "yarn", "pnpm".`,
     );
   });
 

--- a/packages/angular_devkit/schematics/tasks/package-manager/executor.ts
+++ b/packages/angular_devkit/schematics/tasks/package-manager/executor.ts
@@ -27,12 +27,6 @@ const packageManagers: { [name: string]: PackageManagerProfile } = {
       installPackage: 'install',
     },
   },
-  'cnpm': {
-    commands: {
-      installAll: 'install',
-      installPackage: 'install',
-    },
-  },
   'yarn': {
     commands: {
       installAll: 'install',

--- a/packages/angular_devkit/schematics_cli/blank/schema.json
+++ b/packages/angular_devkit/schematics_cli/blank/schema.json
@@ -15,7 +15,7 @@
     "packageManager": {
       "description": "The package manager used to install dependencies.",
       "type": "string",
-      "enum": ["npm", "yarn", "pnpm", "cnpm", "bun"],
+      "enum": ["npm", "yarn", "pnpm", "bun"],
       "default": "npm"
     },
     "author": {

--- a/packages/angular_devkit/schematics_cli/schematic/schema.json
+++ b/packages/angular_devkit/schematics_cli/schematic/schema.json
@@ -15,7 +15,7 @@
     "packageManager": {
       "description": "The package manager used to install dependencies.",
       "type": "string",
-      "enum": ["npm", "yarn", "pnpm", "cnpm", "bun"],
+      "enum": ["npm", "yarn", "pnpm", "bun"],
       "default": "npm"
     }
   },

--- a/packages/schematics/angular/ng-new/schema.json
+++ b/packages/schematics/angular/ng-new/schema.json
@@ -126,7 +126,7 @@
     "packageManager": {
       "description": "The package manager used to install dependencies.",
       "type": "string",
-      "enum": ["npm", "yarn", "pnpm", "cnpm", "bun"]
+      "enum": ["npm", "yarn", "pnpm", "bun"]
     },
     "standalone": {
       "description": "Creates an application based upon the standalone API, without NgModules.",

--- a/packages/schematics/angular/workspace/schema.json
+++ b/packages/schematics/angular/workspace/schema.json
@@ -40,7 +40,7 @@
     "packageManager": {
       "description": "The package manager to use for installing dependencies.",
       "type": "string",
-      "enum": ["npm", "yarn", "pnpm", "cnpm", "bun"]
+      "enum": ["npm", "yarn", "pnpm", "bun"]
     }
   },
   "required": ["name", "version"]

--- a/tests/angular_devkit/core/json/schema/serializers/schema_benchmark.json
+++ b/tests/angular_devkit/core/json/schema/serializers/schema_benchmark.json
@@ -547,7 +547,7 @@
     },
     "packageManager": {
       "description": "Specify which package manager tool to use.",
-      "enum": ["npm", "cnpm", "yarn", "default"],
+      "enum": ["npm", "yarn", "default"],
       "default": "default",
       "type": "string"
     },


### PR DESCRIPTION
This change removes the direct support for cnpm within the Angular CLI.

BREAKING CHANGE: The `ng` commands will no longer automatically detect and use `cnpm` as the package manager. As an alternative use the `.npmrc` file to ensure npm uses the cnpm registry.
