### PR TITLE
docs: release notes for the v20.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,34 +1,19 @@
-<a name="20.2.0-rc.1"></a>
+<a name="20.2.0"></a>
 
-# 20.2.0-rc.1 (2025-08-15)
-
-### @angular/cli
-
-| Commit                                                                                              | Type | Description                                      |
-| --------------------------------------------------------------------------------------------------- | ---- | ------------------------------------------------ |
-| [8ba6b0bcc](https://github.com/angular/angular-cli/commit/8ba6b0bcc8c8087875d14a0aefc6b7b52f39ce2a) | fix  | use correct path for MCP get_best_practices tool |
-
-### @schematics/angular
-
-| Commit                                                                                              | Type | Description                                                    |
-| --------------------------------------------------------------------------------------------------- | ---- | -------------------------------------------------------------- |
-| [ffe6fb916](https://github.com/angular/angular-cli/commit/ffe6fb916d496da1c6c20942f6e6b05a679b0f7d) | fix  | allow AI config prompt to be skipped without selecting a value |
-| [6a79f9a75](https://github.com/angular/angular-cli/commit/6a79f9a75cdcbb0761c4044066748f4eb788a57f) | fix  | zoneless is now stable                                         |
-
-<!-- CHANGELOG SPLIT MARKER -->
-
-<a name="20.2.0-rc.0"></a>
-
-# 20.2.0-rc.0 (2025-08-13)
+# 20.2.0 (2025-08-20)
 
 ### @angular/cli
 
-| Commit                                                                                              | Type | Description                                   |
-| --------------------------------------------------------------------------------------------------- | ---- | --------------------------------------------- |
-| [b4de9a1bf](https://github.com/angular/angular-cli/commit/b4de9a1bf50a35404fb79eb3f120faafd0ce825a) | feat | add --experimental-tool option to mcp command |
-| [755ba70fd](https://github.com/angular/angular-cli/commit/755ba70fd7ef38793d15797ba402020c375c3295) | feat | add --local-only option to mcp command        |
-| [59d7ef343](https://github.com/angular/angular-cli/commit/59d7ef343b6f1feea37a019935578c560d3d5e41) | feat | add --read-only option to mcp command         |
-| [4e92eb6f1](https://github.com/angular/angular-cli/commit/4e92eb6f17cb30259bc8e8d1979bbd9989bc5ad0) | feat | add modernize tool to the MCP server          |
+| Commit                                                                                              | Type | Description                                                           |
+| --------------------------------------------------------------------------------------------------- | ---- | --------------------------------------------------------------------- |
+| [b4de9a1bf](https://github.com/angular/angular-cli/commit/b4de9a1bf50a35404fb79eb3f120faafd0ce825a) | feat | add --experimental-tool option to mcp command                         |
+| [755ba70fd](https://github.com/angular/angular-cli/commit/755ba70fd7ef38793d15797ba402020c375c3295) | feat | add --local-only option to mcp command                                |
+| [59d7ef343](https://github.com/angular/angular-cli/commit/59d7ef343b6f1feea37a019935578c560d3d5e41) | feat | add --read-only option to mcp command                                 |
+| [4e92eb6f1](https://github.com/angular/angular-cli/commit/4e92eb6f17cb30259bc8e8d1979bbd9989bc5ad0) | feat | add modernize tool to the MCP server                                  |
+| [a3b25f675](https://github.com/angular/angular-cli/commit/a3b25f675283fdd8cc5689e3ec88f27aa1386390) | fix  | add choices to command line parser when type is array and has an enum |
+| [e19eee614](https://github.com/angular/angular-cli/commit/e19eee61404a9ca6268ebbc69f671a422d81df9b) | fix  | address Node.js deprecation DEP0190                                   |
+| [4ee6f327a](https://github.com/angular/angular-cli/commit/4ee6f327a206f8ff2ad5eeab43193df56b92b5e0) | fix  | apply default to array types                                          |
+| [8ba6b0bcc](https://github.com/angular/angular-cli/commit/8ba6b0bcc8c8087875d14a0aefc6b7b52f39ce2a) | fix  | use correct path for MCP get_best_practices tool                      |
 
 ### @schematics/angular
 
@@ -36,9 +21,22 @@
 | --------------------------------------------------------------------------------------------------- | ---- | ----------------------------------------------------------------------- |
 | [2e3cfd598](https://github.com/angular/angular-cli/commit/2e3cfd598c9366d0036a52cd18024317b33e6fca) | feat | add migration to remove default Karma configurations                    |
 | [d80dae276](https://github.com/angular/angular-cli/commit/d80dae276e9554c13e0c37640d0db8acafc9d48b) | feat | add schematics to generate ai context files.                            |
-| [6a78ef0ce](https://github.com/angular/angular-cli/commit/6a78ef0cec4875be76d9241499db67ddac6e14df) | fix  | add extra prettier config                                               |
-| [e46d9c54f](https://github.com/angular/angular-cli/commit/e46d9c54f07e32dc05e29a3533ce1bd063ff9f61) | fix  | correct configure the `typeSeparator` in the library schematic          |
+| [ffe6fb916](https://github.com/angular/angular-cli/commit/ffe6fb916d496da1c6c20942f6e6b05a679b0f7d) | fix  | allow AI config prompt to be skipped without selecting a value          |
+| [ae2802b7d](https://github.com/angular/angular-cli/commit/ae2802b7db358c5a3f0590feea212a768a710353) | fix  | improve AI config prompt wording                                        |
 | [b017f84fd](https://github.com/angular/angular-cli/commit/b017f84fdaf36bc0fcad2241846665c73b52b6d8) | fix  | improve coverage directory handling for Karma configuration comparisons |
+| [6a79f9a75](https://github.com/angular/angular-cli/commit/6a79f9a75cdcbb0761c4044066748f4eb788a57f) | fix  | zoneless is now stable                                                  |
+
+### @angular-devkit/schematics
+
+| Commit                                                                                              | Type | Description                         |
+| --------------------------------------------------------------------------------------------------- | ---- | ----------------------------------- |
+| [c43504d8d](https://github.com/angular/angular-cli/commit/c43504d8d96a4436ce71c23d957aec2d080106b8) | fix  | address Node.js deprecation DEP0190 |
+
+### @angular/build
+
+| Commit                                                                                              | Type | Description                               |
+| --------------------------------------------------------------------------------------------------- | ---- | ----------------------------------------- |
+| [fb06bb505](https://github.com/angular/angular-cli/commit/fb06bb5050e92eb4d0f95d7774552d0902163f6a) | feat | add headless mode for vitest browser mode |
 
 <!-- CHANGELOG SPLIT MARKER -->
 
@@ -55,18 +53,6 @@
 
 <!-- CHANGELOG SPLIT MARKER -->
 
-<a name="20.2.0-next.3"></a>
-
-# 20.2.0-next.3 (2025-08-08)
-
-### @angular/cli
-
-| Commit                                                                                              | Type | Description                                               |
-| --------------------------------------------------------------------------------------------------- | ---- | --------------------------------------------------------- |
-| [51d56f770](https://github.com/angular/angular-cli/commit/51d56f770714a015aa7621d53c4a1634e8a01cc8) | fix  | cache MCP best practices content and add tool annotations |
-
-<!-- CHANGELOG SPLIT MARKER -->
-
 <a name="20.1.5"></a>
 
 # 20.1.5 (2025-08-06)
@@ -76,24 +62,6 @@
 | Commit                                                                                              | Type | Description                                               |
 | --------------------------------------------------------------------------------------------------- | ---- | --------------------------------------------------------- |
 | [48ca04474](https://github.com/angular/angular-cli/commit/48ca044745f49bc7fc365a621827294f4cc82c50) | fix  | cache MCP best practices content and add tool annotations |
-
-<!-- CHANGELOG SPLIT MARKER -->
-
-<a name="20.2.0-next.2"></a>
-
-# 20.2.0-next.2 (2025-07-30)
-
-### @angular/cli
-
-| Commit                                                                                              | Type | Description                                            |
-| --------------------------------------------------------------------------------------------------- | ---- | ------------------------------------------------------ |
-| [193b39416](https://github.com/angular/angular-cli/commit/193b39416731fa439fea7da8c06d5d287df99bc1) | fix  | skip workspace-specific tools when outside a workspace |
-
-### @angular/build
-
-| Commit                                                                                              | Type | Description                                 |
-| --------------------------------------------------------------------------------------------------- | ---- | ------------------------------------------- |
-| [7a183730c](https://github.com/angular/angular-cli/commit/7a183730c77689fb9e63625f5ef20aef1cefb88b) | fix  | skip vite transformation of CSS-like assets |
 
 <!-- CHANGELOG SPLIT MARKER -->
 
@@ -127,30 +95,6 @@
 
 <!-- CHANGELOG SPLIT MARKER -->
 
-<a name="20.2.0-next.1"></a>
-
-# 20.2.0-next.1 (2025-07-23)
-
-### @angular/cli
-
-| Commit                                                                                              | Type | Description                                                       |
-| --------------------------------------------------------------------------------------------------- | ---- | ----------------------------------------------------------------- |
-| [fefa7a46f](https://github.com/angular/angular-cli/commit/fefa7a46f5733fd77852a61fddc3120b1bb4b202) | fix  | `define` option is being included multiple times in the JSON help |
-
-### @angular-devkit/core
-
-| Commit                                                                                              | Type | Description                                                                   |
-| --------------------------------------------------------------------------------------------------- | ---- | ----------------------------------------------------------------------------- |
-| [7595e1f88](https://github.com/angular/angular-cli/commit/7595e1f8887bafd344ec939e647e3fca8bbd98be) | fix  | use crypto.randomUUID instead of Date.now for unique string in tmp file names |
-
-### @angular/build
-
-| Commit                                                                                              | Type | Description                               |
-| --------------------------------------------------------------------------------------------------- | ---- | ----------------------------------------- |
-| [fb06bb505](https://github.com/angular/angular-cli/commit/fb06bb5050e92eb4d0f95d7774552d0902163f6a) | feat | add headless mode for vitest browser mode |
-
-<!-- CHANGELOG SPLIT MARKER -->
-
 <a name="20.1.2"></a>
 
 # 20.1.2 (2025-07-23)
@@ -166,12 +110,6 @@
 | Commit                                                                                              | Type | Description                                                                   |
 | --------------------------------------------------------------------------------------------------- | ---- | ----------------------------------------------------------------------------- |
 | [0d0040bdf](https://github.com/angular/angular-cli/commit/0d0040bdf58a82e18f7669363b6f149313524bfc) | fix  | use crypto.randomUUID instead of Date.now for unique string in tmp file names |
-
-<!-- CHANGELOG SPLIT MARKER -->
-
-<a name="20.2.0-next.0"></a>
-
-# 20.2.0-next.0 (2025-07-16)
 
 <!-- CHANGELOG SPLIT MARKER -->
 


### PR DESCRIPTION
Cherry-picks the changelog from the "20.2.x" branch to the next branch (main).