### PR TITLE
fix(@schematics/angular): directly resolve karma config template in migration

### DIFF
--- a/packages/schematics/angular/migrations/karma/karma-config-comparer.ts
+++ b/packages/schematics/angular/migrations/karma/karma-config-comparer.ts
@@ -41,7 +41,7 @@ export async function generateDefaultKarmaConfig(
   projectName: string,
   needDevkitPlugin: boolean,
 ): Promise<string> {
-  const templatePath = path.join(__dirname, '../../config/files/karma.conf.js.template');
+  const templatePath = require.resolve('../../config/files/karma.conf.js.template');
   let template = await readFile(templatePath, 'utf-8');
 
   // TODO: Replace this with the actual schematic templating logic.

--- a/packages/schematics/angular/migrations/migration-collection.json
+++ b/packages/schematics/angular/migrations/migration-collection.json
@@ -1,4 +1,5 @@
 {
+  "encapsulation": false,
   "schematics": {
     "use-application-builder": {
       "version": "21.0.0",


### PR DESCRIPTION
To attempt to workaround Windows pathing issues in the karma configuration migration, the default karma template is now resolved via `require.resolve`.