### PR TITLE
ci: use `D:/` instead of `C:/` and sharding fixes

### DIFF
--- a/.github/shared-actions/windows-bazel-test/action.yml
+++ b/.github/shared-actions/windows-bazel-test/action.yml
@@ -49,9 +49,11 @@ runs:
       run: |
         cd ${{steps.init_wsl.outputs.repo_path}}
         tar -cf /tmp/test.tar.gz dist/bin/tests/legacy-cli/${{inputs.test_target_name}}_
-        mkdir /mnt/c/test
-        mv /tmp/test.tar.gz /mnt/c/test
-        (cd /mnt/c/test && tar -xf /mnt/c/test/test.tar.gz)
+        # Use D:/ for better performance see: https://github.com/actions/runner-images/issues/12744
+        mkdir /mnt/d/test
+        mkdir /mnt/d/tmp_dir
+        mv /tmp/test.tar.gz /mnt/d/test
+        (cd /mnt/d/test && tar -xf /mnt/d/test/test.tar.gz)
 
     - name: Convert symlinks for Windows host
       shell: wsl-bash {0}
@@ -61,7 +63,7 @@ runs:
 
         cd ${{steps.init_wsl.outputs.repo_path}}
 
-        runfiles_dir="/mnt/c/test/dist/bin/tests/legacy-cli/${{inputs.test_target_name}}_/${{inputs.test_target_name}}.bat.runfiles"
+        runfiles_dir="/mnt/d/test/dist/bin/tests/legacy-cli/${{inputs.test_target_name}}_/${{inputs.test_target_name}}.bat.runfiles"
 
         # Make WSL symlinks compatible on Windows native file system.
         node scripts/windows-testing/convert-symlinks.mjs $runfiles_dir "${{steps.init_wsl.outputs.cmd_path}}"
@@ -75,7 +77,9 @@ runs:
       shell: bash
       env:
         BAZEL_BINDIR: '.'
-      working-directory: "C:\\test"
+        # Use D:/ for better performance see: https://github.com/actions/runner-images/issues/12744
+        E2E_TEMP: 'D:\\tmp_dir'
+      working-directory: "D:\\test"
       run: |
         node "${{github.workspace}}\\scripts\\windows-testing\\parallel-executor.mjs" \
           $PWD/dist/bin/tests/legacy-cli/${{inputs.test_target_name}}_/${{inputs.test_target_name}}.bat.runfiles \

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -142,6 +142,7 @@ jobs:
       - name: Run CLI E2E tests
         uses: ./.github/shared-actions/windows-bazel-test
         with:
+          E2E_SHARD_TOTAL: 1
           test_target_name: e2e_node22
           test_args: --esbuild --glob "tests/basic/{build,rebuild}.ts"
 

--- a/scripts/windows-testing/parallel-executor.mjs
+++ b/scripts/windows-testing/parallel-executor.mjs
@@ -14,36 +14,32 @@ const initialStatusRegex = /Running (\d+) tests/;
 
 async function main() {
   const [runfilesDir, targetName, testArgs] = process.argv.slice(2);
-  const maxShards = 4;
-
   const testEntrypoint = path.resolve(runfilesDir, '../', targetName);
   const testWorkingDir = path.resolve(runfilesDir, '_main');
   const tasks = [];
   const progress = {};
 
-  for (let i = 0; i < maxShards; i++) {
-    tasks.push(
-      spawnTest(
-        'bash',
-        [testEntrypoint, ...testArgs.split(' ').filter((arg) => arg !== '')],
-        {
-          cwd: testWorkingDir,
-          env: {
-            // Try to construct a pretty hermetic environment, as within Bazel.
-            PATH: process.env.PATH,
-            TEST_TOTAL_SHARDS: maxShards,
-            TEST_SHARD_INDEX: i,
-            E2E_SHARD_TOTAL: process.env.E2E_SHARD_TOTAL,
-            E2E_SHARD_INDEX: process.env.E2E_SHARD_INDEX,
-            FORCE_COLOR: '3',
-            // Needed by `rules_js`
-            BAZEL_BINDIR: '.',
-          },
+  tasks.push(
+    spawnTest(
+      'bash',
+      [testEntrypoint, ...testArgs.split(' ').filter((arg) => arg !== '')],
+      {
+        cwd: testWorkingDir,
+        env: {
+          // Try to construct a pretty hermetic environment, as within Bazel.
+          PATH: process.env.PATH,
+          E2E_SHARD_TOTAL: process.env.E2E_SHARD_TOTAL,
+          E2E_SHARD_INDEX: process.env.E2E_SHARD_INDEX,
+          FORCE_COLOR: '3',
+          // Needed by `rules_js`
+          BAZEL_BINDIR: '.',
+          // Needed to run the E2E in a different temp path.
+          E2E_TEMP: process.env.E2E_TEMP,
         },
-        (s) => (progress[i] = s),
-      ),
-    );
-  }
+      },
+      (s) => (progress[0] = s),
+    ),
+  );
 
   const printUpdate = () => {
     console.error(`----`);


### PR DESCRIPTION

On Windows 2025, `D:/` was re-introduced again this week to improve performance https://github.com/actions/runner-images/issues/12744

Also, this change reduced the shards to 1 on PR workflow, additional we also fix an issue where in each shard we split the tests into another 4 shards which on Windows causes a lot of IO operations.

Difference:  `e2e_windows (windows-2025, 22, npm, 1)` from `48m 13s` to `20m 16s`