### PR TITLE
ci: set `E2E_SHARD_TOTAL` as env variable

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -141,8 +141,9 @@ jobs:
           allow_windows_rbe: true
       - name: Run CLI E2E tests
         uses: ./.github/shared-actions/windows-bazel-test
-        with:
+        env:
           E2E_SHARD_TOTAL: 1
+        with:
           test_target_name: e2e_node22
           test_args: --esbuild --glob "tests/basic/{build,rebuild}.ts"
 


### PR DESCRIPTION
Whlist this defaults to 1 when not supplied, it's cleaner that this is 1. Also, this is not an action input.

