### PR TITLE
refactor(@schematics/angular): use a project-based schematic helper to reduce boilerplate

### DIFF
--- a/packages/schematics/angular/directive/index.ts
+++ b/packages/schematics/angular/directive/index.ts
@@ -6,13 +6,14 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import { Rule, SchematicsException, Tree, chain, strings } from '@angular-devkit/schematics';
+import { Rule, chain, strings } from '@angular-devkit/schematics';
 import { addDeclarationToNgModule } from '../utility/add-declaration-to-ng-module';
 import { findModuleFromOptions } from '../utility/find-module';
 import { generateFromFiles } from '../utility/generate-from-files';
 import { parseName } from '../utility/parse-name';
+import { createProjectSchematic } from '../utility/project';
 import { validateClassName, validateHtmlSelector } from '../utility/validation';
-import { buildDefaultPath, getWorkspace } from '../utility/workspace';
+import { buildDefaultPath } from '../utility/workspace';
 import { Schema as DirectiveOptions } from './schema';
 
 function buildSelector(options: DirectiveOptions, projectPrefix: string) {
@@ -26,34 +27,26 @@ function buildSelector(options: DirectiveOptions, projectPrefix: string) {
   return strings.camelize(selector);
 }
 
-export default function (options: DirectiveOptions): Rule {
-  return async (host: Tree) => {
-    const workspace = await getWorkspace(host);
-    const project = workspace.projects.get(options.project);
-    if (!project) {
-      throw new SchematicsException(`Project "${options.project}" does not exist.`);
-    }
+export default createProjectSchematic<DirectiveOptions>((options, { project, tree }) => {
+  if (options.path === undefined) {
+    options.path = buildDefaultPath(project);
+  }
 
-    if (options.path === undefined) {
-      options.path = buildDefaultPath(project);
-    }
+  options.module = findModuleFromOptions(tree, options);
+  const parsedPath = parseName(options.path, options.name);
+  options.name = parsedPath.name;
+  options.path = parsedPath.path;
+  options.selector = options.selector || buildSelector(options, project.prefix || '');
 
-    options.module = findModuleFromOptions(host, options);
-    const parsedPath = parseName(options.path, options.name);
-    options.name = parsedPath.name;
-    options.path = parsedPath.path;
-    options.selector = options.selector || buildSelector(options, project.prefix || '');
+  validateHtmlSelector(options.selector);
+  validateClassName(strings.classify(options.name));
 
-    validateHtmlSelector(options.selector);
-    validateClassName(strings.classify(options.name));
+  return chain([
+    addDeclarationToNgModule({
+      type: 'directive',
 
-    return chain([
-      addDeclarationToNgModule({
-        type: 'directive',
-
-        ...options,
-      }),
-      generateFromFiles(options),
-    ]);
-  };
-}
+      ...options,
+    }),
+    generateFromFiles(options),
+  ]);
+});

--- a/packages/schematics/angular/pipe/index.ts
+++ b/packages/schematics/angular/pipe/index.ts
@@ -11,25 +11,24 @@ import { addDeclarationToNgModule } from '../utility/add-declaration-to-ng-modul
 import { findModuleFromOptions } from '../utility/find-module';
 import { generateFromFiles } from '../utility/generate-from-files';
 import { parseName } from '../utility/parse-name';
+import { createProjectSchematic } from '../utility/project';
 import { validateClassName } from '../utility/validation';
 import { createDefaultPath } from '../utility/workspace';
 import { Schema as PipeOptions } from './schema';
 
-export default function (options: PipeOptions): Rule {
-  return async (host: Tree) => {
-    options.path ??= await createDefaultPath(host, options.project);
-    options.module = findModuleFromOptions(host, options);
-    const parsedPath = parseName(options.path, options.name);
-    options.name = parsedPath.name;
-    options.path = parsedPath.path;
-    validateClassName(strings.classify(options.name));
+export default createProjectSchematic<PipeOptions>(async (options, { tree }) => {
+  options.path ??= await createDefaultPath(tree, options.project);
+  options.module = findModuleFromOptions(tree, options);
+  const parsedPath = parseName(options.path, options.name);
+  options.name = parsedPath.name;
+  options.path = parsedPath.path;
+  validateClassName(strings.classify(options.name));
 
-    return chain([
-      addDeclarationToNgModule({
-        type: 'pipe',
-        ...options,
-      }),
-      generateFromFiles(options),
-    ]);
-  };
-}
+  return chain([
+    addDeclarationToNgModule({
+      type: 'pipe',
+      ...options,
+    }),
+    generateFromFiles(options),
+  ]);
+});

--- a/packages/schematics/angular/service-worker/index.ts
+++ b/packages/schematics/angular/service-worker/index.ts
@@ -20,12 +20,13 @@ import {
   url,
 } from '@angular-devkit/schematics';
 import * as ts from '../third_party/github.com/Microsoft/TypeScript/lib/typescript';
-import { addDependency, addRootProvider, readWorkspace, writeWorkspace } from '../utility';
+import { addDependency, addRootProvider, writeWorkspace } from '../utility';
 import { addSymbolToNgModuleMetadata, insertImport } from '../utility/ast-utils';
 import { applyToUpdateRecorder } from '../utility/change';
 import { getDependency } from '../utility/dependency';
 import { getAppModulePath, isStandaloneApp } from '../utility/ng-ast-utils';
 import { relativePathToWorkspaceRoot } from '../utility/paths';
+import { createProjectSchematic } from '../utility/project';
 import { targetBuildNotFoundError } from '../utility/project-targets';
 import { findAppConfig } from '../utility/standalone/app_config';
 import { findBootstrapApplicationCall, getMainFilePath } from '../utility/standalone/util';
@@ -103,13 +104,8 @@ function getTsSourceFile(host: Tree, path: string): ts.SourceFile {
   return source;
 }
 
-export default function (options: ServiceWorkerOptions): Rule {
-  return async (host: Tree) => {
-    const workspace = await readWorkspace(host);
-    const project = workspace.projects.get(options.project);
-    if (!project) {
-      throw new SchematicsException(`Invalid project name (${options.project})`);
-    }
+export default createProjectSchematic<ServiceWorkerOptions>(
+  async (options, { project, workspace, tree }) => {
     if (project.extensions.projectType !== 'application') {
       throw new SchematicsException(`Service worker requires a project type of "application".`);
     }
@@ -119,7 +115,7 @@ export default function (options: ServiceWorkerOptions): Rule {
     }
 
     const buildOptions = buildTarget.options as Record<string, string | boolean>;
-    const browserEntryPoint = await getMainFilePath(host, options.project);
+    const browserEntryPoint = await getMainFilePath(tree, options.project);
     const ngswConfigPath = join(normalize(project.root), 'ngsw-config.json');
 
     if (
@@ -135,7 +131,7 @@ export default function (options: ServiceWorkerOptions): Rule {
       buildOptions.ngswConfigPath = ngswConfigPath;
     }
 
-    await writeWorkspace(host, workspace);
+    await writeWorkspace(tree, workspace);
 
     return chain([
       addDependencies(),
@@ -148,12 +144,12 @@ export default function (options: ServiceWorkerOptions): Rule {
           move(project.root),
         ]),
       ),
-      isStandaloneApp(host, browserEntryPoint)
+      isStandaloneApp(tree, browserEntryPoint)
         ? addProvideServiceWorker(options.project, browserEntryPoint)
         : updateAppModule(browserEntryPoint),
     ]);
-  };
-}
+  },
+);
 
 function addImport(host: Tree, filePath: string, symbolName: string, moduleName: string): void {
   const moduleSource = getTsSourceFile(host, filePath);

--- a/packages/schematics/angular/utility/project.ts
+++ b/packages/schematics/angular/utility/project.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { Rule, SchematicContext, SchematicsException, Tree } from '@angular-devkit/schematics';
+import { ProjectDefinition, WorkspaceDefinition, getWorkspace } from './workspace';
+
+/**
+ * Creates a schematic rule factory that provides project information to the given factory function.
+ * The project is determined from the `project` option. If the project is not found, an exception is
+ * thrown.
+ *
+ * @param factory The factory function that creates the schematic rule.
+ * @returns A schematic rule factory.
+ */
+export function createProjectSchematic<S extends { project: string }>(
+  factory: (
+    options: S,
+    projectContext: {
+      project: ProjectDefinition;
+      workspace: WorkspaceDefinition;
+      tree: Tree;
+      context: SchematicContext;
+    },
+  ) => Rule | Promise<Rule>,
+): (options: S) => Rule {
+  return (options) => async (tree, context) => {
+    const workspace = await getWorkspace(tree);
+    const project = workspace.projects.get(options.project);
+
+    if (!project) {
+      throw new SchematicsException(`Project "${options.project}" does not exist.`);
+    }
+
+    return factory(options, { project, workspace, tree, context });
+  };
+}

--- a/packages/schematics/angular/web-worker/index.ts
+++ b/packages/schematics/angular/web-worker/index.ts
@@ -23,7 +23,8 @@ import {
 } from '@angular-devkit/schematics';
 import { parseName } from '../utility/parse-name';
 import { relativePathToWorkspaceRoot } from '../utility/paths';
-import { buildDefaultPath, getWorkspace, updateWorkspace } from '../utility/workspace';
+import { createProjectSchematic } from '../utility/project';
+import { buildDefaultPath, updateWorkspace } from '../utility/workspace';
 import { Schema as WebWorkerOptions } from './schema';
 
 function addSnippet(options: WebWorkerOptions): Rule {
@@ -72,67 +73,54 @@ function addSnippet(options: WebWorkerOptions): Rule {
   };
 }
 
-export default function (options: WebWorkerOptions): Rule {
-  return async (host: Tree) => {
-    const workspace = await getWorkspace(host);
+export default createProjectSchematic<WebWorkerOptions>((options, { project }) => {
+  const projectType = project.extensions['projectType'];
+  if (projectType !== 'application') {
+    throw new SchematicsException(`Web Worker requires a project type of "application".`);
+  }
 
-    if (!options.project) {
-      throw new SchematicsException('Option "project" is required.');
-    }
+  if (options.path === undefined) {
+    options.path = buildDefaultPath(project);
+  }
+  const parsedPath = parseName(options.path, options.name);
+  options.name = parsedPath.name;
+  options.path = parsedPath.path;
 
-    const project = workspace.projects.get(options.project);
-    if (!project) {
-      throw new SchematicsException(`Invalid project name (${options.project})`);
-    }
+  const templateSourceWorkerCode = apply(url('./files/worker'), [
+    applyTemplates({ ...options, ...strings }),
+    move(parsedPath.path),
+  ]);
 
-    const projectType = project.extensions['projectType'];
-    if (projectType !== 'application') {
-      throw new SchematicsException(`Web Worker requires a project type of "application".`);
-    }
+  const root = project.root || '';
+  const templateSourceWorkerConfig = apply(url('./files/worker-tsconfig'), [
+    applyTemplates({
+      ...options,
+      relativePathToWorkspaceRoot: relativePathToWorkspaceRoot(root),
+    }),
+    move(root),
+  ]);
 
-    if (options.path === undefined) {
-      options.path = buildDefaultPath(project);
-    }
-    const parsedPath = parseName(options.path, options.name);
-    options.name = parsedPath.name;
-    options.path = parsedPath.path;
+  return chain([
+    // Add project configuration.
+    updateWorkspace((workspace) => {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const project = workspace.projects.get(options.project)!;
+      const buildTarget = project.targets.get('build');
+      const testTarget = project.targets.get('test');
+      if (!buildTarget) {
+        throw new Error(`Build target is not defined for this project.`);
+      }
 
-    const templateSourceWorkerCode = apply(url('./files/worker'), [
-      applyTemplates({ ...options, ...strings }),
-      move(parsedPath.path),
-    ]);
-
-    const root = project.root || '';
-    const templateSourceWorkerConfig = apply(url('./files/worker-tsconfig'), [
-      applyTemplates({
-        ...options,
-        relativePathToWorkspaceRoot: relativePathToWorkspaceRoot(root),
-      }),
-      move(root),
-    ]);
-
-    return chain([
-      // Add project configuration.
-      updateWorkspace((workspace) => {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const project = workspace.projects.get(options.project)!;
-        const buildTarget = project.targets.get('build');
-        const testTarget = project.targets.get('test');
-        if (!buildTarget) {
-          throw new Error(`Build target is not defined for this project.`);
-        }
-
-        const workerConfigPath = join(normalize(root), 'tsconfig.worker.json');
-        (buildTarget.options ??= {}).webWorkerTsConfig ??= workerConfigPath;
-        if (testTarget) {
-          (testTarget.options ??= {}).webWorkerTsConfig ??= workerConfigPath;
-        }
-      }),
-      // Create the worker in a sibling module.
-      options.snippet ? addSnippet(options) : noop(),
-      // Add the worker.
-      mergeWith(templateSourceWorkerCode),
-      mergeWith(templateSourceWorkerConfig),
-    ]);
-  };
-}
+      const workerConfigPath = join(normalize(root), 'tsconfig.worker.json');
+      (buildTarget.options ??= {}).webWorkerTsConfig ??= workerConfigPath;
+      if (testTarget) {
+        (testTarget.options ??= {}).webWorkerTsConfig ??= workerConfigPath;
+      }
+    }),
+    // Create the worker in a sibling module.
+    options.snippet ? addSnippet(options) : noop(),
+    // Add the worker.
+    mergeWith(templateSourceWorkerCode),
+    mergeWith(templateSourceWorkerConfig),
+  ]);
+});


### PR DESCRIPTION
Introduces a new `createProjectSchematic` helper to abstract the common logic of looking up a project within the workspace. This pattern was repeated across many schematics.

The following project-scoped schematics have been refactored to use the new helper:
- app-shell
- component
- config
- directive
- module
- pipe
- server
- service-worker
- ssr
- web-worker

This change simplifies the implementation of these schematics, reduces code duplication, and improves maintainability.

REVIEWER NOTE: Enable "Hide whitespace" option