### PR TITLE
ci: Disable PNPM cache on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,8 @@ jobs:
     steps:
       - name: Initialize environment
         uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@029d16b075db696b35d0d661d0fd3a0552a4b452
+        with:
+          disable-package-manager-cache: true
       - name: Setup Bazel
         uses: angular/dev-infra/github-actions/bazel/setup@029d16b075db696b35d0d661d0fd3a0552a4b452
       - name: Setup Bazel RBE

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -133,6 +133,8 @@ jobs:
     steps:
       - name: Initialize environment
         uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@029d16b075db696b35d0d661d0fd3a0552a4b452
+        with:
+          disable-package-manager-cache: true
       - name: Setup Bazel
         uses: angular/dev-infra/github-actions/bazel/setup@029d16b075db696b35d0d661d0fd3a0552a4b452
       - name: Setup Bazel RBE


### PR DESCRIPTION
Disabling the PNPM cache resolves an issue where pnpm install is being run inside WSL, causing the action to fail due to missing path.

See: https://github.com/angular/dev-infra/pull/2998
