### PR TITLE
ci: do not expand glob in shell

### DIFF
--- a/.github/shared-actions/windows-bazel-test/action.yml
+++ b/.github/shared-actions/windows-bazel-test/action.yml
@@ -6,12 +6,6 @@ inputs:
   test_target_name:
     description: E2E test target name.
     required: true
-  test_args:
-    description: |
-      Text representing the command line arguments that
-      should be passed to the e2e test runner.
-    required: false
-    default: ''
   e2e_temp_dir:
     description: 'The temporary directory path for E2E tests.'
     required: false
@@ -45,5 +39,4 @@ runs:
       run: |
         node ./scripts/windows-testing/parallel-executor.mjs \
           "./dist/bin/tests/legacy-cli/${{ inputs.test_target_name }}_/${{ inputs.test_target_name }}.bat.runfiles" \
-          ${{ inputs.test_target_name }} \
-          "${{ inputs.test_args }}"
+          ${{ inputs.test_target_name }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -171,9 +171,9 @@ jobs:
         uses: ./.github/shared-actions/windows-bazel-test
         with:
           test_target_name: e2e.esbuild_node22
-          test_args: --glob "tests/basic/{build,rebuild}.ts"
         env:
           E2E_SHARD_TOTAL: 1
+          TESTBRIDGE_TEST_ONLY: tests/basic/{build,rebuild}.ts
 
   e2e-package-managers:
     needs: build

--- a/scripts/windows-testing/parallel-executor.mjs
+++ b/scripts/windows-testing/parallel-executor.mjs
@@ -13,7 +13,7 @@ import { stripVTControlCharacters } from 'node:util';
 const initialStatusRegex = /Running (\d+) tests/;
 
 async function main() {
-  const [runfilesDir, targetName, testArgs] = process.argv.slice(2);
+  const [runfilesDir, targetName, ...testArgs] = process.argv.slice(2);
   const testEntrypoint = path.resolve(runfilesDir, '../', targetName);
   const testWorkingDir = path.resolve(runfilesDir, '_main');
   const tasks = [];
@@ -22,7 +22,7 @@ async function main() {
   tasks.push(
     spawnTest(
       'bash',
-      [testEntrypoint, ...testArgs.split(' ').filter((arg) => arg !== '')],
+      [testEntrypoint, ...testArgs],
       {
         cwd: testWorkingDir,
         env: {
@@ -35,6 +35,8 @@ async function main() {
           BAZEL_BINDIR: '.',
           // Needed to run the E2E in a different temp path.
           E2E_TEMP: process.env.E2E_TEMP,
+          // Using the `--glob` causes a bunch of issues due to path expansion in nested bash scripts.
+          TESTBRIDGE_TEST_ONLY: process.env.TESTBRIDGE_TEST_ONLY,
         },
       },
       (s) => (progress[0] = s),

--- a/tests/legacy-cli/e2e_runner.ts
+++ b/tests/legacy-cli/e2e_runner.ts
@@ -47,7 +47,7 @@ const parsed = parseArgs({
   options: {
     'debug': { type: 'boolean', default: !!process.env.BUILD_WORKSPACE_DIRECTORY },
     'esbuild': { type: 'boolean' },
-    'glob': { type: 'string', default: process.env.TESTBRIDGE_TEST_ONLY },
+    'glob': { type: 'string', default: 'tests/**/*.js' },
     'ignore': { type: 'string', multiple: true },
     'ng-snapshots': { type: 'boolean' },
     'ng-tag': { type: 'string' },
@@ -130,7 +130,7 @@ function lastLogger() {
 
 // Under bazel the compiled file (.js) and types (.d.ts) are available.
 const SRC_FILE_EXT_RE = /\.js$/;
-const testGlob = argv.glob?.replace(/\.ts$/, '.js') || `tests/**/*.js`;
+const testGlob = (process.env.TESTBRIDGE_TEST_ONLY ?? argv.glob).replace(/\.ts$/, '.js');
 
 const e2eRoot = path.join(__dirname, 'e2e');
 const allSetups = glob.sync(`setup/**/*.js`, { cwd: e2eRoot }).sort();


### PR DESCRIPTION

This ensures that the glob is expanded by the Node.js package as otherwise not all tests will be picked up. 