### PR TITLE
Improve existing project Tailwind CSS schematic integration

### DIFF
--- a/packages/schematics/angular/tailwind/index.ts
+++ b/packages/schematics/angular/tailwind/index.ts
@@ -17,42 +17,75 @@ import {
   strings,
   url,
 } from '@angular-devkit/schematics';
-import { DependencyType, ExistingBehavior, addDependency } from '../utility';
+import assert from 'node:assert';
+import { join } from 'node:path/posix';
+import {
+  DependencyType,
+  ExistingBehavior,
+  ProjectDefinition,
+  addDependency,
+  updateWorkspace,
+} from '../utility';
 import { latestVersions } from '../utility/latest-versions';
 import { createProjectSchematic } from '../utility/project';
 
 const TAILWIND_DEPENDENCIES = ['tailwindcss', '@tailwindcss/postcss', 'postcss'];
 
-function addTailwindImport(stylesheetPath: string): Rule {
-  return (tree) => {
-    let stylesheetText = '';
+function addTailwindStyles(options: { project: string }, project: ProjectDefinition): Rule {
+  return async (tree) => {
+    const buildTarget = project.targets.get('build');
 
-    if (tree.exists(stylesheetPath)) {
-      stylesheetText = tree.readText(stylesheetPath);
-      stylesheetText += '\n';
+    if (!buildTarget) {
+      throw new SchematicsException(`Project "${options.project}" does not have a build target.`);
     }
 
-    stylesheetText += '@import "tailwindcss";\n';
+    const styles = buildTarget.options?.['styles'] as (string | { input: string })[] | undefined;
 
-    tree.overwrite(stylesheetPath, stylesheetText);
+    let stylesheetPath: string | undefined;
+    if (styles) {
+      stylesheetPath = styles
+        .map((s) => (typeof s === 'string' ? s : s.input))
+        .find((p) => p.endsWith('.css'));
+    }
+
+    if (!stylesheetPath) {
+      const newStylesheetPath = join(project.sourceRoot ?? 'src', 'tailwind.css');
+      tree.create(newStylesheetPath, '@import "tailwindcss";\n');
+
+      return updateWorkspace((workspace) => {
+        const project = workspace.projects.get(options.project);
+        if (project) {
+          const buildTarget = project.targets.get('build');
+          assert(buildTarget, 'Build target should still be present');
+
+          // Update main styles
+          const buildOptions = buildTarget.options;
+          assert(buildOptions, 'Build options should still be present');
+          const existingStyles = (buildOptions['styles'] as (string | { input: string })[]) ?? [];
+          buildOptions['styles'] = [newStylesheetPath, ...existingStyles];
+
+          // Update configuration styles
+          if (buildTarget.configurations) {
+            for (const config of Object.values(buildTarget.configurations)) {
+              if (config && 'styles' in config) {
+                const existingStyles = (config['styles'] as (string | { input: string })[]) ?? [];
+                config['styles'] = [newStylesheetPath, ...existingStyles];
+              }
+            }
+          }
+        }
+      });
+    } else {
+      let stylesheetContent = tree.readText(stylesheetPath);
+      if (!stylesheetContent.includes('@import "tailwindcss";')) {
+        stylesheetContent += '\n@import "tailwindcss";\n';
+        tree.overwrite(stylesheetPath, stylesheetContent);
+      }
+    }
   };
 }
 
 export default createProjectSchematic((options, { project }) => {
-  const buildTarget = project.targets.get('build');
-
-  if (!buildTarget) {
-    throw new SchematicsException(`Project "${options.project}" does not have a build target.`);
-  }
-
-  const styles = buildTarget.options?.['styles'] as string[] | undefined;
-
-  if (!styles || styles.length === 0) {
-    throw new SchematicsException(`Project "${options.project}" does not have any global styles.`);
-  }
-
-  const stylesheetPath = styles[0];
-
   const templateSource = apply(url('./files'), [
     applyTemplates({
       ...strings,
@@ -62,7 +95,7 @@ export default createProjectSchematic((options, { project }) => {
   ]);
 
   return chain([
-    addTailwindImport(stylesheetPath),
+    addTailwindStyles(options, project),
     mergeWith(templateSource),
     ...TAILWIND_DEPENDENCIES.map((name) =>
       addDependency(name, latestVersions[name], {


### PR DESCRIPTION
The tailwind schematic's stylesheet injection logic has been updated to support a wider range of project configurations. Previously, it assumed a `styles.css` file was always present, which could cause issues in projects using CSS preprocessors like Sass/SCSS.
Instead of unconditionally creating a new `.postcssrc.json` file, the schematic now searches for `postcss.config.json` or `.postcssrc.json` in both the workspace and project roots. If an existing configuration file is found, it is updated with the required `@tailwindcss/postcss` plugin. A new configuration file is only created if one does not already exist.