### PR TITLE
fix(@angular/build): ensure karma polyfills reporter factory returns a value

### DIFF
--- a/packages/angular/build/src/builders/karma/application_builder.ts
+++ b/packages/angular/build/src/builders/karma/application_builder.ts
@@ -187,6 +187,9 @@ class AngularPolyfillsPlugin {
             included: true,
             watched: false,
           });
+
+          // Karma needs a return value for a factory and Karma's multi-reporter expects an `adapters` array
+          return { adapters: [] };
         }, AngularPolyfillsPlugin),
       ],
     };


### PR DESCRIPTION
The factory function for the `reporter:angular--polyfills` Karma plugin did not return a value, which violates Karma's plugin contract. This could cause Karma to crash when multiple reporters were in use, particularly with tools that use Karma's multi-reporter functionality.

This change modifies the factory to return an object with an empty `adapters` array (`{ adapters: [] }`). This satisfies Karma's plugin requirements and ensures compatibility with the multi-reporter, preventing the crash.

Fixes #31039