### PR TITLE
build: define typescript version via string in module.bazel file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,9 +71,7 @@ jobs:
       - name: Install node modules
         run: pnpm install --frozen-lockfile
       - name: Run module and package tests
-        run: pnpm bazel test //modules/... //packages/...
-        env:
-          ASPECT_RULES_JS_FROZEN_PNPM_LOCK: '1'
+        run: pnpm bazel test -- //... -//tests/legacy-cli/...
 
   e2e:
     needs: test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -101,9 +101,7 @@ jobs:
       - name: Install node modules
         run: pnpm install --frozen-lockfile
       - name: Run module and package tests
-        run: pnpm bazel test //modules/... //packages/...
-        env:
-          ASPECT_RULES_JS_FROZEN_PNPM_LOCK: '1'
+        run: pnpm bazel test -- //... -//tests/legacy-cli/...
 
   e2e:
     needs: build

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@aspect_rules_ts//ts:defs.bzl", rules_js_tsconfig = "ts_config")
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+load("@devinfra//bazel/validation:defs.bzl", "validate_ts_version_matching")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("//tools:defaults.bzl", "copy_to_bin")
 
@@ -101,4 +102,9 @@ config_setting(
     flag_values = {
         ":enable_snapshot_repo_deps": "true",
     },
+)
+
+validate_ts_version_matching(
+    module_lock_file = "MODULE.bazel.lock",
+    package_json = "package.json",
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -39,7 +39,7 @@ git_override(
 bazel_dep(name = "devinfra")
 git_override(
     module_name = "devinfra",
-    commit = "fc71b572acb06a4830ef5566edb05500f822b7ad",
+    commit = "7e2eefa1375195fa7616f78a76f538a188852067",
     remote = "https://github.com/angular/dev-infra.git",
 )
 
@@ -176,7 +176,7 @@ rules_ts_ext.deps(
     name = "angular_cli_npm_typescript",
     # Obtained by: curl --silent https://registry.npmjs.org/typescript/5.9.2 | jq -r '.dist.integrity'
     ts_integrity = "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-    ts_version_from = "//:package.json",
+    ts_version = "5.9.2",
 )
 use_repo(rules_ts_ext, **{"npm_typescript": "angular_cli_npm_typescript"})
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -534,10 +534,8 @@
     "@@aspect_rules_ts~//ts:extensions.bzl%ext": {
       "general": {
         "bzlTransitiveDigest": "9IJp6IlB/FMHFBJe4MX/DQM4zi3oArC8yqYE/+NyPwk=",
-        "usagesDigest": "ltWGqWW6sLMu/u31IwJqdHjhE4iS2Cto+bTSDdqQO0w=",
+        "usagesDigest": "1QffQgMsAO4zhe8vcwqME94TRDAlQADSJn4p/MOIYv4=",
         "recordedFileInputs": {
-          "@@//package.json": "ebb8e1336dcf13ba5ba14ed50f0a32c993ed2ba2e171e0c671329141f5993ccd",
-          "@@devinfra~//bazel/package.json": "f90ae656882e652c88b59c7b94880416dc4a90ef01e8763fd04e8c6f8c2bb6e6",
           "@@rules_browsers~//package.json": "45572077938c7a4916e4aaedf7db7ce8425854ab92f35348cff02a2134023bb8"
         },
         "recordedDirentsInputs": {},
@@ -547,8 +545,7 @@
             "bzlFile": "@@aspect_rules_ts~//ts/private:npm_repositories.bzl",
             "ruleClassName": "http_archive_version",
             "attributes": {
-              "version": "",
-              "version_from": "@@//:package.json",
+              "version": "5.9.2",
               "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
               "urls": [
                 "https://registry.npmjs.org/typescript/-/typescript-{}.tgz"
@@ -570,8 +567,7 @@
             "bzlFile": "@@aspect_rules_ts~//ts/private:npm_repositories.bzl",
             "ruleClassName": "http_archive_version",
             "attributes": {
-              "version": "",
-              "version_from": "@@devinfra~//bazel:package.json",
+              "version": "5.9.2",
               "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
               "urls": [
                 "https://registry.npmjs.org/typescript/-/typescript-{}.tgz"

--- a/tools/test/expected_package.json
+++ b/tools/test/expected_package.json
@@ -35,8 +35,8 @@
     }
   },
   "engines": {
-    "node": "^16.14.0 || >=18.10.0",
-    "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
-    "yarn": ">= 1.13.0"
+    "node": "0.0.0-ENGINES-NODE",
+    "npm": "0.0.0-ENGINES-NPM",
+    "yarn": "0.0.0-ENGINES-YARN"
   }
 }


### PR DESCRIPTION
Within our module.bazel file when describing the version of typescript to use for rules_ts, we use ts_version instead of ts_version_from to prevent our package.json file from being part of the set of files used to calculate the sha for the lock file.  Any unrelated change to the version of the typescript file would end up causing our lockfile to be out of date. This amount of churn has proven to be too much for our current setup. We instead now test to validate the versions defined in the package.json and MODULE.bazel files match.
