### PR TITLE
fix(@angular/cli): don't set a default for array options when length is 0

### DIFF
--- a/packages/angular/cli/src/command-builder/utilities/json-schema.ts
+++ b/packages/angular/cli/src/command-builder/utilities/json-schema.ts
@@ -206,7 +206,7 @@ export async function parseJsonSchemaToOptions(
           }
           break;
         case 'array':
-          if (Array.isArray(current.default)) {
+          if (Array.isArray(current.default) && current.default.length > 0) {
             defaultValue = current.default;
           }
           break;


### PR DESCRIPTION


This change prevents the CLI from setting a default value for array options that have a length of zero. Previously, this would result in an empty array being added  as a default, which isn't the intended behavior.
