### PR TITLE
refactor(@angular/cli): add structured output to examples MCP tool

### DIFF
--- a/packages/angular/cli/src/commands/mcp/tools/best-practices.ts
+++ b/packages/angular/cli/src/commands/mcp/tools/best-practices.ts
@@ -13,12 +13,21 @@ import { declareTool } from './tool-registry';
 export const BEST_PRACTICES_TOOL = declareTool({
   name: 'get_best_practices',
   title: 'Get Angular Coding Best Practices Guide',
-  description:
-    'You **MUST** use this tool to retrieve the Angular Best Practices Guide ' +
-    'before any interaction with Angular code (creating, analyzing, modifying). ' +
-    'It is mandatory to follow this guide to ensure all code adheres to ' +
-    'modern standards, including standalone components, typed forms, and ' +
-    'modern control flow. This is the first step for any Angular task.',
+  description: `
+<Purpose>
+Retrieves the official Angular Best Practices Guide. This guide contains the essential rules and conventions
+that **MUST** be followed for any task involving the creation, analysis, or modification of Angular code.
+</Purpose>
+<Use Cases>
+* As a mandatory first step before writing or modifying any Angular code to ensure adherence to modern standards.
+* To learn about key concepts like standalone components, typed forms, and modern control flow syntax (@if, @for, @switch).
+* To verify that existing code aligns with current Angular conventions before making changes.
+</Use Cases>
+<Operational Notes>
+* The content of this guide is non-negotiable and reflects the official, up-to-date standards for Angular development.
+* You **MUST** internalize and apply the principles from this guide in all subsequent Angular-related tasks.
+* Failure to adhere to these best practices will result in suboptimal and outdated code.
+</Operational Notes>`,
   isReadOnly: true,
   isLocalOnly: true,
   factory: () => {


### PR DESCRIPTION
The `find_examples` MCP tool is updated to frame it as a RAG (Retrieval-Augmented Generation) source, focusing on modern and recently updated Angular features.

The tool's description is rewritten to guide the AI on when to use this tool versus the documentation search. A structured output schema is also added to make the results more reliable, and the handler is updated to return data in the new format.