### PR TITLE
test: workaround npm cleanup for ng add tailwind E2E

### DIFF
--- a/tests/legacy-cli/e2e/tests/commands/add/add-tailwindcss.ts
+++ b/tests/legacy-cli/e2e/tests/commands/add/add-tailwindcss.ts
@@ -1,8 +1,15 @@
-import { expectFileToExist, expectFileToMatch } from '../../../utils/fs';
-import { uninstallPackage } from '../../../utils/packages';
+import { expectFileToExist, expectFileToMatch, rimraf } from '../../../utils/fs';
+import { getActivePackageManager, uninstallPackage } from '../../../utils/packages';
 import { ng } from '../../../utils/process';
 
 export default async function () {
+  // In case a previous test installed tailwindcss, clear it.
+  // (we don't clear node module directories between tests)
+  // npm does not appear to fully uninstall sometimes
+  if (getActivePackageManager() === 'npm') {
+    await rimraf('node_modules/tailwindcss');
+  }
+
   try {
     await ng('add', 'tailwindcss', '--skip-confirmation');
     await expectFileToExist('.postcssrc.json');


### PR DESCRIPTION
Add an explicit removal of previous `tailwindcss` at the start of the `commands/add/add-tailwindcss.ts` E2E test to workaround issues with npm not fully uninstalling the package from previous tests.