### PR TITLE
fix(@angular/build): avoid extra tick in SSR dev-server builds

### DIFF
--- a/packages/angular/build/src/builders/dev-server/vite/index.ts
+++ b/packages/angular/build/src/builders/dev-server/vite/index.ts
@@ -436,6 +436,7 @@ export async function* serveWithVite(
         browserOptions.loader as EsbuildLoaderOption | undefined,
         {
           ...browserOptions.define,
+          'ngJitMode': browserOptions.aot ? 'false' : 'true',
           'ngHmrMode': browserOptions.templateUpdates ? 'true' : 'false',
         },
         extensions?.middleware,


### PR DESCRIPTION
In SSR applications, an unnecessary event loop tick during server startup could lead to an incorrect platform being initialized.

This change introduces an `ngJitMode` define, which is set to `false` during AOT builds. This allows for the JIT-specific code paths to not be followed, preventing the async operations that caused the extra tick. This ensures that the server platform is correctly and synchronously initialized.