### PR TITLE
fix(@angular/build): maintain media output hashing with vitest unit-testing

### DIFF
--- a/packages/angular/build/src/builders/unit-test/runners/vitest/build-options.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/build-options.ts
@@ -46,6 +46,17 @@ function createTestBedInitVirtualFile(
   `;
 }
 
+function adjustOutputHashing(hashing?: OutputHashing): OutputHashing {
+  switch (hashing) {
+    case OutputHashing.All:
+    case OutputHashing.Media:
+      // Ensure media is continued to be hashed to avoid overwriting of output media files
+      return OutputHashing.Media;
+    default:
+      return OutputHashing.None;
+  }
+}
+
 export async function getVitestBuildOptions(
   options: NormalizedUnitTestBuilderOptions,
   baseBuildOptions: Partial<ApplicationBuilderInternalOptions>,
@@ -82,7 +93,7 @@ export async function getVitestBuildOptions(
     ssr: false,
     prerender: false,
     sourceMap: { scripts: true, vendor: false, styles: false },
-    outputHashing: OutputHashing.None,
+    outputHashing: adjustOutputHashing(baseBuildOptions.outputHashing),
     optimization: false,
     tsConfig,
     entryPoints,


### PR DESCRIPTION
To ensure that output media files do not overwrite each other if source media files use the same base file name but are contained in different directories, the output hashing option from the build target will now keep the `media` option enabled if configured.