### PR TITLE
refactor(@angular/cli): Improve zoneless migration prompts based on o…

### DIFF
--- a/packages/angular/cli/src/commands/mcp/tools/onpush-zoneless-migration/prompts.ts
+++ b/packages/angular/cli/src/commands/mcp/tools/onpush-zoneless-migration/prompts.ts
@@ -25,8 +25,12 @@ export function createProvideZonelessForTestsSetupPrompt(testFilePath: string): 
 
     In the main \`beforeEach\` block for the test suite (the one inside the top-level \`describe\`), add \`provideZonelessChangeDetection()\` to the providers array in \`TestBed.configureTestingModule\`.
 
+    *   If there is already an import from \`@angular/core\`, add \`provideZonelessChangeDetection\` to the existing import.
+    *   Otherwise, add a new import statement for \`provideZonelessChangeDetection\` from \`@angular/core\`.
+
     \`\`\`diff
-    + import { provideZonelessChangeDetection } from '@angular/core';
+    - import {{ SomeImport }} from '@angular/core';
+    + import {{ SomeImport, provideZonelessChangeDetection }} from '@angular/core';
       
       describe('MyComponent', () => {
    +    beforeEach(() => {
@@ -202,6 +206,9 @@ export async function createFixResponseForZoneTests(
 
       The following usages of \`provideZoneChangeDetection\` must be removed:
       ${locations.map((loc) => `- ${loc}`).join('\n')}
+
+      After removing \`provideZoneChangeDetection\`, the tests will likely fail. Use this guide to diagnose and fix the failures.
+
       ${testDebuggingGuideText(sourceFile.fileName)}
 
       ### Final Step
@@ -213,8 +220,6 @@ export async function createFixResponseForZoneTests(
 function testDebuggingGuideText(fileName: string) {
   return `
       ### Test Debugging Guide
-
-      After removing \`provideZoneChangeDetection\`, the tests will likely fail. Use this guide to diagnose and fix the failures.
 
       1.  **\`ExpressionChangedAfterItHasBeenCheckedError\`**:
         *   **Cause**: This error indicates that a value in a component's template was updated, but Angular was not notified to run change detection.


### PR DESCRIPTION
…bserved outcomes

After observing some results from the tool's prompts, I found some improvements:

* if there was an existing import from '@angular/core' LLMs sometimes chose to delete it and all preceding imports
* Moved the note about "remove provideZoneChangeDetection" to the specific prompt where it's relevant. This was being used in the final "non-actionable" prompts and resulted in LLMs choosing to delete 'provideZonelessChangeDetection' additions from previous iterations
