### PR TITLE
[20.2.x] fix(@angular/build): maintain media output hashing with vitest unit-testing

### DIFF
--- a/packages/angular/build/src/builders/unit-test/builder.ts
+++ b/packages/angular/build/src/builders/unit-test/builder.ts
@@ -36,6 +36,17 @@ export type { UnitTestBuilderOptions };
 
 type VitestCoverageOption = Exclude<import('vitest/node').InlineConfig['coverage'], undefined>;
 
+function adjustOutputHashing(hashing?: OutputHashing): OutputHashing {
+  switch (hashing) {
+    case OutputHashing.All:
+    case OutputHashing.Media:
+      // Ensure media is continued to be hashed to avoid overwriting of output media files
+      return OutputHashing.Media;
+    default:
+      return OutputHashing.None;
+  }
+}
+
 /**
  * @experimental Direct usage of this function is considered experimental.
  */
@@ -135,7 +146,7 @@ export async function* execute(
     ssr: false,
     prerender: false,
     sourceMap: { scripts: true, vendor: false, styles: false },
-    outputHashing: OutputHashing.None,
+    outputHashing: adjustOutputHashing(buildTargetOptions.outputHashing),
     optimization: false,
     tsConfig: normalizedOptions.tsConfig,
     entryPoints,


### PR DESCRIPTION
To ensure that output media files do not overwrite each other if source media files use the same base file name but are contained in different directories, the output hashing option from the build target will now keep the `media` option enabled if configured.

(cherry picked from commit f806f6477af222907f1879181fb0f9839e889ea8)