### PR TITLE
fix(@schematics/angular): respect skip-install for tailwind schematic

### DIFF
--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -147,6 +147,7 @@ export default function (options: ApplicationOptions): Rule {
       isTailwind
         ? schematic('tailwind', {
             project: options.name,
+            skipInstall: options.skipInstall,
           })
         : noop(),
     ]);

--- a/packages/schematics/angular/tailwind/index.ts
+++ b/packages/schematics/angular/tailwind/index.ts
@@ -22,6 +22,7 @@ import { join } from 'node:path/posix';
 import {
   DependencyType,
   ExistingBehavior,
+  InstallBehavior,
   ProjectDefinition,
   addDependency,
   updateWorkspace,
@@ -29,6 +30,7 @@ import {
 import { JSONFile } from '../utility/json-file';
 import { latestVersions } from '../utility/latest-versions';
 import { createProjectSchematic } from '../utility/project';
+import { Schema as TailwindOptions } from './schema';
 
 const TAILWIND_DEPENDENCIES = ['tailwindcss', '@tailwindcss/postcss', 'postcss'];
 const POSTCSS_CONFIG_FILES = ['.postcssrc.json', 'postcss.config.json'];
@@ -120,7 +122,7 @@ function managePostCssConfiguration(project: ProjectDefinition): Rule {
   };
 }
 
-export default createProjectSchematic((options, { project }) => {
+export default createProjectSchematic<TailwindOptions>((options, { project }) => {
   return chain([
     addTailwindStyles(options, project),
     managePostCssConfiguration(project),
@@ -128,6 +130,7 @@ export default createProjectSchematic((options, { project }) => {
       addDependency(name, latestVersions[name], {
         type: DependencyType.Dev,
         existing: ExistingBehavior.Skip,
+        install: options.skipInstall ? InstallBehavior.None : InstallBehavior.Auto,
       }),
     ),
   ]);

--- a/packages/schematics/angular/tailwind/schema.json
+++ b/packages/schematics/angular/tailwind/schema.json
@@ -9,6 +9,11 @@
       "$default": {
         "$source": "projectName"
       }
+    },
+    "skipInstall": {
+      "description": "Skip the automatic installation of packages. You will need to manually install the dependencies later.",
+      "type": "boolean",
+      "default": false
     }
   },
   "required": ["project"]


### PR DESCRIPTION
When generating a new application or using the application schematic with the `tailwind` style option, the `skipInstall` option was being ignored. This resulted in dependencies being installed even when `--skip-install` was specified.

This change ensures that the `skipInstall` option is correctly passed to and handled by the Tailwind schematic, preventing automatic package installation when requested.
