### PR TITLE
refactor(@angular/build): improve readability of Vitest executor

### DIFF
--- a/packages/angular/build/BUILD.bazel
+++ b/packages/angular/build/BUILD.bazel
@@ -320,7 +320,7 @@ jasmine_test(
 
 jasmine_test(
     name = "unit-test_integration_tests",
-    size = "small",
+    size = "medium",
     data = [":unit-test_integration_test_lib"],
     shard_count = 5,
 )


### PR DESCRIPTION
The `initializeVitest` method within the Vitest test executor was overly large and handled multiple distinct responsibilities, including setup file preparation and Vite plugin configuration.

This change refactors the method by extracting these responsibilities into separate private methods: `prepareSetupFiles` and `createVitestPlugins`. This improves the overall readability, testability, and maintainability of the executor by better separating concerns without changing its behavior.