### PR TITLE
fix(@angular/build): correct Vitest coverage reporting for test files

### DIFF
--- a/packages/angular/build/BUILD.bazel
+++ b/packages/angular/build/BUILD.bazel
@@ -322,6 +322,7 @@ jasmine_test(
     name = "unit-test_integration_tests",
     size = "medium",
     data = [":unit-test_integration_test_lib"],
+    flaky = True,
     shard_count = 5,
 )
 

--- a/packages/angular/build/src/builders/karma/find-tests.ts
+++ b/packages/angular/build/src/builders/karma/find-tests.ts
@@ -30,12 +30,13 @@ export async function findTests(
 interface TestEntrypointsOptions {
   projectSourceRoot: string;
   workspaceRoot: string;
+  removeTestExtension?: boolean;
 }
 
 /** Generate unique bundle names for a set of test files. */
 export function getTestEntrypoints(
   testFiles: string[],
-  { projectSourceRoot, workspaceRoot }: TestEntrypointsOptions,
+  { projectSourceRoot, workspaceRoot, removeTestExtension }: TestEntrypointsOptions,
 ): Map<string, string> {
   const seen = new Set<string>();
 
@@ -46,7 +47,13 @@ export function getTestEntrypoints(
         .replace(/^[./\\]+/, '')
         // Replace any path separators with dashes.
         .replace(/[/\\]/g, '-');
-      const baseName = `spec-${basename(relativePath, extname(relativePath))}`;
+
+      let fileName = basename(relativePath, extname(relativePath));
+      if (removeTestExtension) {
+        fileName = fileName.replace(/\.(spec|test)$/, '');
+      }
+
+      const baseName = `spec-${fileName}`;
       let uniqueName = baseName;
       let suffix = 2;
       while (seen.has(uniqueName)) {

--- a/packages/angular/build/src/builders/karma/find-tests_spec.ts
+++ b/packages/angular/build/src/builders/karma/find-tests_spec.ts
@@ -62,6 +62,36 @@ describe('getTestEntrypoints', () => {
           ]),
         );
       });
+
+      describe('with removeTestExtension enabled', () => {
+        function getEntrypoints(workspaceRelative: string[], sourceRootRelative: string[] = []) {
+          return getTestEntrypoints(
+            [
+              ...workspaceRelative.map((p) => joinWithSeparator(options.workspaceRoot, p)),
+              ...sourceRootRelative.map((p) => joinWithSeparator(options.projectSourceRoot, p)),
+            ],
+            { ...options, removeTestExtension: true },
+          );
+        }
+
+        it('removes .spec extension', () => {
+          expect(getEntrypoints(['a/b.spec.js'], ['c/d.spec.js'])).toEqual(
+            new Map<string, string>([
+              ['spec-a-b', joinWithSeparator(options.workspaceRoot, 'a/b.spec.js')],
+              ['spec-c-d', joinWithSeparator(options.projectSourceRoot, 'c/d.spec.js')],
+            ]),
+          );
+        });
+
+        it('removes .test extension', () => {
+          expect(getEntrypoints(['a/b.test.js'], ['c/d.test.js'])).toEqual(
+            new Map<string, string>([
+              ['spec-a-b', joinWithSeparator(options.workspaceRoot, 'a/b.test.js')],
+              ['spec-c-d', joinWithSeparator(options.projectSourceRoot, 'c/d.test.js')],
+            ]),
+          );
+        });
+      });
     });
   }
 });

--- a/packages/angular/build/src/builders/unit-test/runners/vitest/build-options.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/build-options.ts
@@ -82,7 +82,11 @@ export async function getVitestBuildOptions(
     );
   }
 
-  const entryPoints = getTestEntrypoints(testFiles, { projectSourceRoot, workspaceRoot });
+  const entryPoints = getTestEntrypoints(testFiles, {
+    projectSourceRoot,
+    workspaceRoot,
+    removeTestExtension: true,
+  });
   entryPoints.set('init-testbed', 'angular:test-bed-init');
 
   const buildOptions: Partial<ApplicationBuilderInternalOptions> = {

--- a/packages/angular/build/src/builders/unit-test/schema.json
+++ b/packages/angular/build/src/builders/unit-test/schema.json
@@ -60,8 +60,7 @@
       "description": "Globs to exclude from code coverage.",
       "items": {
         "type": "string"
-      },
-      "default": []
+      }
     },
     "codeCoverageReporters": {
       "type": "array",

--- a/packages/angular/build/src/builders/unit-test/tests/options/watch_spec.ts
+++ b/packages/angular/build/src/builders/unit-test/tests/options/watch_spec.ts
@@ -15,7 +15,7 @@ import {
 } from '../setup';
 
 describeBuilder(execute, UNIT_TEST_BUILDER_INFO, (harness) => {
-  xdescribe('Option: "watch"', () => {
+  describe('Option: "watch"', () => {
     beforeEach(async () => {
       setupApplicationTarget(harness);
     });


### PR DESCRIPTION
Test coverage reporting within the Vitest runner was inaccurate because the test files themselves were being included in the coverage analysis. This was caused by how the in-memory provider directly loaded the test content.

This commit resolves the issue by introducing an intermediate virtual module for each test. The test entry point now only imports this module, which in turn contains the bundled test code. This extra layer of indirection prevents Vitest from including the test files in the coverage results, leading to an accurate analysis.

To support this change, the `getTestEntrypoints` function now removes the `.spec` or `.test` extension from bundle names, ensuring cleaner module identifiers. The Vitest runner has also been updated to better handle coverage exclusion options and resolve relative paths more reliably.

Closes #30511
Closes #30557