### PR TITLE
test(@angular/build): add E2E test for Vitest snapshot functionality

### DIFF
--- a/tests/legacy-cli/e2e/tests/vitest/snapshot.ts
+++ b/tests/legacy-cli/e2e/tests/vitest/snapshot.ts
@@ -1,0 +1,69 @@
+import { ng } from '../../utils/process';
+import { appendToFile, replaceInFile, readFile } from '../../utils/fs';
+import { applyVitestBuilder } from '../../utils/vitest';
+import assert from 'node:assert/strict';
+
+export default async function () {
+  // Set up the test project to use the vitest runner
+  await applyVitestBuilder();
+
+  // Add snapshot assertions to the test file
+  await appendToFile(
+    'src/app/app.spec.ts',
+    `
+    it('should match file snapshot', () => {
+      const fixture = TestBed.createComponent(App);
+      const app = fixture.componentInstance;
+      expect((app as any).title()).toMatchSnapshot();
+    });
+
+    it('should match inline snapshot', () => {
+      const fixture = TestBed.createComponent(App);
+      const app = fixture.componentInstance;
+      expect((app as any).title()).toMatchInlineSnapshot();
+    });
+  `,
+  );
+
+  // First run: create snapshots
+  const { stdout: firstRunStdout } = await ng('test');
+  assert.match(
+    firstRunStdout,
+    /Snapshots\s+2 written/,
+    'Snapshots were not written on the first run.',
+  );
+
+  const specContent = await readFile('src/app/app.spec.ts');
+  assert.match(
+    specContent,
+    /toMatchInlineSnapshot\(`"test-project"`\)/,
+    'Inline snapshot was not written to the spec file.',
+  );
+
+  const snapshotContent = await readFile('src/app/__snapshots__/app.spec.ts.snap');
+  assert.match(
+    snapshotContent,
+    /exports\[`should match file snapshot 1`\] = `"test-project"`;/,
+    'File snapshot was not written to disk.',
+  );
+
+  // Second run: tests should pass with existing snapshots
+  await ng('test');
+
+  // Modify component to break snapshots
+  await replaceInFile('src/app/app.ts', 'test-project', 'Snapshot is broken!');
+
+  // Third run: tests should fail with snapshot mismatch
+  await assert.rejects(
+    () => ng('test'),
+    (err: any) => {
+      assert.match(
+        err.toString(),
+        /Snapshots\s+2 failed/,
+        'Expected snapshot mismatch error, but a different error occurred.',
+      );
+      return true;
+    },
+    'Snapshot mismatch did not cause the test to fail.',
+  );
+}

--- a/tests/legacy-cli/e2e/utils/vitest.ts
+++ b/tests/legacy-cli/e2e/utils/vitest.ts
@@ -25,4 +25,8 @@ export async function applyVitestBuilder(): Promise<void> {
       runner: 'vitest',
     };
   });
+
+  await updateJsonFile('tsconfig.spec.json', (tsconfig) => {
+    tsconfig['compilerOptions']['types'] = ['vitest/globals'];
+  });
 }


### PR DESCRIPTION
This commit introduces a new E2E test to validate snapshot testing with the Vitest runner. The test covers both file-based and inline snapshots.

The test follows this sequence:
1. Runs `ng test` to generate initial snapshots.
2. Runs `ng test` again to ensure tests pass against the existing snapshots.
3. Modifies the component to cause a mismatch.
4. Runs `ng test` a final time and asserts that the command fails with a snapshot error.

To support the new snapshot matchers (`toMatchSnapshot`, `toMatchInlineSnapshot`) in the test environment, the `vitest/globals` types are now added to the `tsconfig.spec.json` by the `applyVitestBuilder` helper.

Closes #30439