### PR TITLE
fix(@angular/build): drop support for TypeScript 5.8

### DIFF
--- a/packages/angular/build/package.json
+++ b/packages/angular/build/package.json
@@ -73,7 +73,7 @@
     "postcss": "^8.4.0",
     "tailwindcss": "^2.0.0 || ^3.0.0 || ^4.0.0",
     "tslib": "^2.3.0",
-    "typescript": ">=5.8 <6.0",
+    "typescript": ">=5.9 <6.0",
     "vitest": "^3.1.1"
   },
   "peerDependenciesMeta": {

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -87,7 +87,7 @@
     "ng-packagr": "0.0.0-NG-PACKAGR-PEER-DEP",
     "protractor": "^7.0.0",
     "tailwindcss": "^2.0.0 || ^3.0.0 || ^4.0.0",
-    "typescript": ">=5.8 <6.0"
+    "typescript": ">=5.9 <6.0"
   },
   "peerDependenciesMeta": {
     "@angular/core": {

--- a/packages/ngtools/webpack/package.json
+++ b/packages/ngtools/webpack/package.json
@@ -22,7 +22,7 @@
   "homepage": "https://github.com/angular/angular-cli/tree/main/packages/ngtools/webpack",
   "peerDependencies": {
     "@angular/compiler-cli": "0.0.0-ANGULAR-FW-PEER-DEP",
-    "typescript": ">=5.8 <6.0",
+    "typescript": ">=5.9 <6.0",
     "webpack": "^5.54.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Now that https://github.com/angular/angular/pull/63589 has landed, we can drop support for TypeScript 5.8.

BREAKING CHANGE:
* TypeScript versions older than 5.9 are no longer supported.
