### PR TITLE
refactor(@angular/cli): exclude Cnpm from LOCKFILE_NAMES type

### DIFF
--- a/packages/angular/cli/src/utilities/package-manager.ts
+++ b/packages/angular/cli/src/utilities/package-manager.ts
@@ -18,7 +18,9 @@ import { memoize } from './memoize';
 /**
  * A map of package managers to their corresponding lockfile names.
  */
-const LOCKFILE_NAMES: Readonly<Record<PackageManager, string | readonly string[]>> = {
+const LOCKFILE_NAMES: Readonly<
+  Record<Exclude<PackageManager, PackageManager.Cnpm>, string | readonly string[]>
+> = {
   [PackageManager.Yarn]: 'yarn.lock',
   [PackageManager.Pnpm]: 'pnpm-lock.yaml',
   [PackageManager.Bun]: ['bun.lockb', 'bun.lock'],
@@ -289,7 +291,10 @@ export class PackageManagerUtils {
    * @param filesInRoot An array of file names in the root directory.
    * @returns True if the lockfile exists, false otherwise.
    */
-  private hasLockfile(packageManager: PackageManager, filesInRoot: string[]): boolean {
+  private hasLockfile(
+    packageManager: Exclude<PackageManager, PackageManager.Cnpm>,
+    filesInRoot: string[],
+  ): boolean {
     const lockfiles = LOCKFILE_NAMES[packageManager];
 
     return typeof lockfiles === 'string'


### PR DESCRIPTION
The `LOCKFILE_NAMES` constant in `packages/angular/cli/src/utilities/package-manager.ts` is updated to explicitly exclude `PackageManager.Cnpm` from its type definition. This refactors the type to accurately reflect the package managers supported by the lockfile detection logic.
