### PR TITLE
fix(@angular-devkit/build-angular): avoid extra tick in SSR builds

### DIFF
--- a/packages/angular_devkit/build_angular/src/builders/server/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/server/index.ts
@@ -219,6 +219,7 @@ async function initialize(
           {
             plugins: [
               new webpack.DefinePlugin({
+                'ngJitMode': false,
                 'ngServerMode': true,
               }),
             ],


### PR DESCRIPTION
In SSR applications, an unnecessary event loop tick during server startup could lead to an incorrect platform being initialized.

This change introduces an `ngJitMode` define, which is set to `false` during AOT builds. This allows for the JIT-specific code paths to not be followed, preventing the async operations that caused the extra tick. This ensures that the server platform is correctly and synchronously initialized.
