### PR TITLE
fix(@schematics/angular): remove explicit flag for host bindings

### DIFF
--- a/packages/schematics/angular/workspace/files/tsconfig.json.template
+++ b/packages/schematics/angular/workspace/files/tsconfig.json.template
@@ -19,7 +19,6 @@
     "enableI18nLegacyMessageIdFormat": false<% if (strict) { %>,
     "strictInjectionParameters": true,
     "strictInputAccessModifiers": true,
-    "typeCheckHostBindings": true,
     "strictTemplates": true<% } %>
   },
   "files": []


### PR DESCRIPTION
As of https://github.com/angular/angular/pull/63654 type checking of host bindings is enabled by default so we don't need the explicit flag anymore.
