### PR TITLE
fix(@angular/build): add timestamp to bundle generation log

### DIFF
--- a/packages/angular/build/src/builders/application/index.ts
+++ b/packages/angular/build/src/builders/application/index.ts
@@ -109,7 +109,8 @@ export async function* buildApplicationInternal(
         const hasError = result.errors.length > 0;
 
         result.addLog(
-          `Application bundle generation ${hasError ? 'failed' : 'complete'}. [${buildTime.toFixed(3)} seconds]\n`,
+          `Application bundle generation ${hasError ? 'failed' : 'complete'}.` +
+            ` [${buildTime.toFixed(3)} seconds] - ${new Date().toISOString()}\n`,
         );
       }
 


### PR DESCRIPTION
Adds an ISO timestamp to the "Application bundle generation complete" message. This provides more precise information about when the build process finished, which can be useful for debugging and analyzing build performance.

Closes #30572