### PR TITLE
fix(@angular/build): reverts the test output location to its original

### DIFF
--- a/packages/angular/build/src/builders/karma/application_builder.ts
+++ b/packages/angular/build/src/builders/karma/application_builder.ts
@@ -8,7 +8,6 @@
 
 import type { BuilderContext, BuilderOutput } from '@angular-devkit/architect';
 import type { Config, ConfigOptions, FilePattern, InlinePluginDef, Server } from 'karma';
-import { randomUUID } from 'node:crypto';
 import * as fs from 'node:fs/promises';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import { createRequire } from 'node:module';
@@ -24,9 +23,9 @@ import { ApplicationBuilderInternalOptions } from '../application/options';
 import { Result, ResultFile, ResultKind } from '../application/results';
 import { OutputHashing } from '../application/schema';
 import { findTests, getTestEntrypoints } from './find-tests';
+import type { KarmaBuilderTransformsOptions } from './index';
 import { NormalizedKarmaBuilderOptions, normalizeOptions } from './options';
 import { Schema as KarmaBuilderOptions } from './schema';
-import type { KarmaBuilderTransformsOptions } from './index';
 
 const localResolve = createRequire(__filename).resolve;
 const isWindows = process.platform === 'win32';
@@ -383,7 +382,8 @@ async function initializeApplication(
 ): Promise<
   [typeof import('karma'), Config & ConfigOptions, BuildOptions, AsyncIterator<Result> | null]
 > {
-  const outputPath = path.join(context.workspaceRoot, 'dist/test-out', randomUUID());
+  const testOutput = '.angular/cache/test-out'; // Could be extended later to optionally allow for a randomUUID or a custom outputPath.
+  const outputPath = path.join(context.workspaceRoot, testOutput);
   const projectSourceRoot = await getProjectSourceRoot(context);
 
   const [karma, entryPoints] = await Promise.all([

--- a/packages/angular_devkit/build_angular/src/builders/jest/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/jest/index.ts
@@ -6,10 +6,9 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import { ResultKind, buildApplicationInternal } from '@angular/build/private';
 import { BuilderContext, BuilderOutput, createBuilder } from '@angular-devkit/architect';
+import { ResultKind, buildApplicationInternal } from '@angular/build/private';
 import { execFile as execFileCb } from 'node:child_process';
-import { randomUUID } from 'node:crypto';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { promisify } from 'node:util';
@@ -30,7 +29,10 @@ export default createBuilder(
     );
 
     const options = normalizeOptions(schema);
-    const testOut = path.join(context.workspaceRoot, 'dist/test-out', randomUUID()); // TODO(dgp1130): Hide in temp directory.
+    // Could be extended later to optionally allow for a randomUUID or a custom outputPath.
+    const testOutput = '.angular/cache/test-out';
+
+    const testOut = path.join(context.workspaceRoot, testOutput);
 
     // Verify Jest installation and get the path to it's binary.
     // We need to `node_modules/.bin/jest`, but there is no means to resolve that directly. Fortunately Jest's `package.json` exports the

--- a/packages/angular_devkit/build_angular/src/builders/web-test-runner/index.ts
+++ b/packages/angular_devkit/build_angular/src/builders/web-test-runner/index.ts
@@ -6,10 +6,9 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import { Result, ResultKind, buildApplicationInternal } from '@angular/build/private';
 import { BuilderContext, BuilderOutput, createBuilder } from '@angular-devkit/architect';
+import { Result, ResultKind, buildApplicationInternal } from '@angular/build/private';
 import type * as WebTestRunner from '@web/test-runner';
-import { randomUUID } from 'node:crypto';
 import fs from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import path from 'node:path';
@@ -43,8 +42,10 @@ export default createBuilder(
     }
 
     const options = normalizeOptions(schema);
+    // Could be extended later to optionally allow for a randomUUID or a custom outputPath.
+    const testOutput = '.angular/cache/test-out';
 
-    const testDir = path.join(ctx.workspaceRoot, 'dist/test-out', randomUUID());
+    const testDir = path.join(ctx.workspaceRoot, testOutput);
 
     // Parallelize startup work.
     const [testFiles] = await Promise.all([


### PR DESCRIPTION
Closes #30713

Reverts the test output location to its original and removes unique UUID folders. This reverts it back to `.angular/cache/test-out/` and does not append the `uuid()` to the folder. In the future this could be made optional and perhaps we could introduce a `output` override for the test options. 

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [X] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [X] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

The default (migrated) @angular/build:karma package would output test artifacts into `dist/test-out/<uuid>`, which would quickly build up folders and make it confusing as test results usually aren't a distributable. 

Issue Number: #30713

## What is the new behavior?

The default output directory has been reverted to `.angular/cache/test-out`. Comments have been put in place to prepare the idea to extend it to later allow for custom output directories. It was not clarified if Google itself are depending on this and might require this, so if this is the case let's quickly revisit it and see how we can expand the current solution.

## Does this PR introduce a breaking change?

- [X] Yes
- [ ] No

Although I'm not certain if it "breaks". The new @angular/build:karma seemed to have changed the default output and that was not considered a breaking change it seems? I have marked it as a breaking change for now.

## Other information
