### PR TITLE
refactor(@angular/build): decouple test discovery from runner execution

### DIFF
--- a/packages/angular/build/src/builders/unit-test/builder.ts
+++ b/packages/angular/build/src/builders/unit-test/builder.ts
@@ -144,9 +144,8 @@ export async function* execute(
   const normalizedOptions = await normalizeOptions(context, projectName, options);
   const runner = await loadTestRunner(normalizedOptions.runnerName);
 
-  await using executor = await runner.createExecutor(context, normalizedOptions);
-
   if (runner.isStandalone) {
+    await using executor = await runner.createExecutor(context, normalizedOptions, undefined);
     yield* executor.execute({
       kind: ResultKind.Full,
       files: {},
@@ -174,9 +173,16 @@ export async function* execute(
   }
 
   // Get runner-specific build options from the hook
-  const { buildOptions: runnerBuildOptions, virtualFiles } = await runner.getBuildOptions(
+  const {
+    buildOptions: runnerBuildOptions,
+    virtualFiles,
+    testEntryPointMappings,
+  } = await runner.getBuildOptions(normalizedOptions, buildTargetOptions);
+
+  await using executor = await runner.createExecutor(
+    context,
     normalizedOptions,
-    buildTargetOptions,
+    testEntryPointMappings,
   );
 
   const finalExtensions = prepareBuildExtensions(

--- a/packages/angular/build/src/builders/unit-test/runners/api.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/api.ts
@@ -11,9 +11,27 @@ import type { ApplicationBuilderInternalOptions } from '../../application/option
 import type { FullResult, IncrementalResult } from '../../application/results';
 import type { NormalizedUnitTestBuilderOptions } from '../options';
 
+/**
+ * Represents the options for a test runner.
+ */
 export interface RunnerOptions {
+  /**
+   * Partial options for the application builder.
+   * These will be merged with the options from the build target.
+   */
   buildOptions: Partial<ApplicationBuilderInternalOptions>;
+
+  /**
+   * A record of virtual files to be added to the build.
+   * The key is the file path and the value is the file content.
+   */
   virtualFiles?: Record<string, string>;
+
+  /**
+   * A map of test entry points to their corresponding test files.
+   * This is used to avoid re-discovering the test files in the executor.
+   */
+  testEntryPointMappings?: Map<string, string>;
 }
 
 /**
@@ -51,10 +69,12 @@ export interface TestRunner {
    *
    * @param context The Architect builder context.
    * @param options The normalized unit test options.
+   * @param testEntryPointMappings A map of test entry points to their corresponding test files.
    * @returns A TestExecutor instance that will handle the test runs.
    */
   createExecutor(
     context: BuilderContext,
     options: NormalizedUnitTestBuilderOptions,
+    testEntryPointMappings: Map<string, string> | undefined,
   ): Promise<TestExecutor>;
 }

--- a/packages/angular/build/src/builders/unit-test/runners/vitest/build-options.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/build-options.ts
@@ -120,5 +120,6 @@ export async function getVitestBuildOptions(
     virtualFiles: {
       'angular:test-bed-init': testBedInitContents,
     },
+    testEntryPointMappings: entryPoints,
   };
 }

--- a/packages/angular/build/src/builders/unit-test/runners/vitest/index.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/index.ts
@@ -21,11 +21,11 @@ const VitestTestRunner: TestRunner = {
     return getVitestBuildOptions(options, baseBuildOptions);
   },
 
-  async createExecutor(context, options) {
+  async createExecutor(context, options, testEntryPointMappings) {
     const projectName = context.target?.project;
     assert(projectName, 'The builder requires a target.');
 
-    return new VitestExecutor(projectName, options);
+    return new VitestExecutor(projectName, options, testEntryPointMappings);
   },
 };
 


### PR DESCRIPTION
This commit refactors the unit test builder to centralize test file discovery, preventing redundant operations in the test runner's execution phase.

The `TestRunner` API has been updated to pass the test entry point mappings from the initial build options phase directly to the executor. This removes the need for the Vitest executor to re-discover tests, simplifying its logic and adhering to the DRY principle.

The JSDoc comments for the runner API have also been updated to reflect these changes.