### PR TITLE
ci: use static target: automation label in renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,14 +5,6 @@
   "ignorePaths": ["tests/legacy-cli/e2e/assets/**", "tests/schematics/update/packages/**"],
   "packageRules": [
     {
-      "matchBaseBranches": ["main"],
-      "addLabels": ["target: minor"]
-    },
-    {
-      "matchBaseBranches": ["!main"],
-      "addLabels": ["target: patch"]
-    },
-    {
       "enabled": false,
       "matchFileNames": ["tests/legacy-cli/e2e/ng-snapshot/package.json"],
       "matchBaseBranches": ["!main"]


### PR DESCRIPTION
The `target: automation` label is used by the Angular team to identify PRs that are created by automation. This is used to skip some checks that are not required for automated PRs.
