### PR TITLE
fix(@angular/build): improve error handling in unit-test builder

### DIFF
--- a/packages/angular/build/src/builders/unit-test/tests/options/include_spec.ts
+++ b/packages/angular/build/src/builders/unit-test/tests/options/include_spec.ts
@@ -15,7 +15,7 @@ import {
 } from '../setup';
 
 describeBuilder(execute, UNIT_TEST_BUILDER_INFO, (harness) => {
-  xdescribe('Option: "include"', () => {
+  describe('Option: "include"', () => {
     beforeEach(async () => {
       setupApplicationTarget(harness);
     });
@@ -36,16 +36,8 @@ describeBuilder(execute, UNIT_TEST_BUILDER_INFO, (harness) => {
         input: ['src/app/app.component.spec.ts'],
       },
       {
-        test: 'relative path from workspace to file',
-        input: ['src/app/app.component.ts'],
-      },
-      {
         test: 'relative path from project root to spec',
         input: ['app/services/test.service.spec.ts'],
-      },
-      {
-        test: 'relative path from project root to file',
-        input: ['app/services/test.service.ts'],
       },
       {
         test: 'relative path from workspace to directory',
@@ -58,10 +50,6 @@ describeBuilder(execute, UNIT_TEST_BUILDER_INFO, (harness) => {
       {
         test: 'glob with spec suffix',
         input: ['**/*.pipe.spec.ts', '**/*.pipe.spec.ts', '**/*test.service.spec.ts'],
-      },
-      {
-        test: 'glob with forward slash and spec suffix',
-        input: ['/**/*test.service.spec.ts'],
       },
     ].forEach((options, index) => {
       it(`should work with ${options.test} (${index})`, async () => {


### PR DESCRIPTION
Previously, exceptions thrown within a test runner would cause the entire builder process to terminate. This resulted in a poor user experience, especially in watch mode, as the process would crash instead of reporting the error and waiting for changes.

This change introduces more granular `try-catch` blocks around the test runner's lifecycle. When a runner throws an exception, the error is now caught, logged with a descriptive message, and the builder emits a failed result without crashing.

To prevent logs from being spammed by a persistently failing runner, a circuit breaker has been added. If the test runner fails with an exception for 3 consecutive runs, the builder will pause testing and exit to prevent an endless error loop. This circuit breaker is specifically designed to only trip on runner exceptions, not on standard test failures, to avoid disrupting a normal TDD workflow.

Additionally, this commit re-enables and adjusts several related unit tests for the builder options to ensure they are passing and reflect the current behavior.