### PR TITLE
fix(@angular/build): serve build assets and styles in vitest

### DIFF
--- a/packages/angular/build/src/builders/unit-test/runners/vitest/plugins.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/plugins.ts
@@ -10,6 +10,7 @@ import assert from 'node:assert';
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 import type { VitestPlugin } from 'vitest/node';
+import { createBuildAssetsMiddleware } from '../../../../tools/vite/middlewares/assets-middleware';
 import { toPosixPath } from '../../../../utils/path';
 import type { ResultFile } from '../../../application/results';
 import type { NormalizedUnitTestBuilderOptions } from '../../options';
@@ -128,6 +129,11 @@ export function createVitestPlugins(
                     map: map ? JSON.parse(map) : undefined,
                   };
                 }
+              },
+              configureServer: (server) => {
+                server.middlewares.use(
+                  createBuildAssetsMiddleware(server.config.base, buildResultFiles),
+                );
               },
             },
             {


### PR DESCRIPTION
Adds a Vite middleware to the Vitest runner to serve assets and global stylesheets that are part of the build output.

Previously, when running component tests with Vitest, any referenced assets (such as images in an `<img>` tag) or component stylesheets would result in a 404 error because the Vite server was not configured to serve them.

This change introduces a middleware that intercepts requests for non-script files. It checks against the build's output files and serves the corresponding asset directly from memory or disk. This ensures that the test environment accurately reflects the assets available during a real build, allowing components to render correctly for testing.