### PR TITLE
test(@angular/build): use expectLog and expectNoLog helpers in tests

### DIFF
--- a/modules/testing/builder/src/index.ts
+++ b/modules/testing/builder/src/index.ts
@@ -15,5 +15,7 @@ export {
   type HarnessFileMatchers,
   JasmineBuilderHarness,
   describeBuilder,
+  expectLog,
+  expectNoLog,
 } from './jasmine-helpers';
 export * from './test-utils';

--- a/modules/testing/builder/src/jasmine-helpers.ts
+++ b/modules/testing/builder/src/jasmine-helpers.ts
@@ -7,7 +7,7 @@
  */
 
 import { BuilderHandlerFn } from '@angular-devkit/architect';
-import { json } from '@angular-devkit/core';
+import { json, logging } from '@angular-devkit/core';
 import { readFileSync } from 'node:fs';
 import { concatMap, count, debounceTime, firstValueFrom, take, timeout } from 'rxjs';
 import {
@@ -195,4 +195,26 @@ export function expectDirectory<T>(
       return !exists;
     },
   };
+}
+
+export function expectLog(logs: readonly logging.LogEntry[], message: string | RegExp) {
+  expect(logs).toContain(
+    jasmine.objectContaining({
+      message: jasmine.stringMatching(message),
+    }),
+  );
+}
+
+export function expectNoLog(
+  logs: readonly logging.LogEntry[],
+  message: string | RegExp,
+  failureMessage?: string,
+) {
+  expect(logs)
+    .withContext(failureMessage ?? '')
+    .not.toContain(
+      jasmine.objectContaining({
+        message: jasmine.stringMatching(message),
+      }),
+    );
 }

--- a/packages/angular/build/src/builders/application/tests/behavior/typescript-rebuild-lazy_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/behavior/typescript-rebuild-lazy_spec.ts
@@ -6,10 +6,9 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import type { logging } from '@angular-devkit/core';
 import { buildApplication } from '../../index';
 import { OutputHashing } from '../../schema';
-import { APPLICATION_BUILDER_INFO, BASE_OPTIONS, describeBuilder } from '../setup';
+import { APPLICATION_BUILDER_INFO, BASE_OPTIONS, describeBuilder, expectLog } from '../setup';
 
 describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
   beforeEach(async () => {
@@ -57,13 +56,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
           },
           async ({ result, logs }) => {
             expect(result?.success).toBeFalse();
-            expect(logs).toContain(
-              jasmine.objectContaining<logging.LogEntry>({
-                message: jasmine.stringMatching(
-                  `Type 'number' is not assignable to type 'string'.`,
-                ),
-              }),
-            );
+            expectLog(logs, `Type 'number' is not assignable to type 'string'.`);
 
             // Fix TS error
             await harness.writeFile('src/lazy.ts', `export const foo: string = "1";`);

--- a/packages/angular/build/src/builders/application/tests/options/allowed-common-js-dependencies_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/options/allowed-common-js-dependencies_spec.ts
@@ -6,9 +6,14 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import { logging } from '@angular-devkit/core';
 import { buildApplication } from '../../index';
-import { APPLICATION_BUILDER_INFO, BASE_OPTIONS, describeBuilder } from '../setup';
+import {
+  APPLICATION_BUILDER_INFO,
+  BASE_OPTIONS,
+  describeBuilder,
+  expectLog,
+  expectNoLog,
+} from '../setup';
 
 describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
   describe('Option: "allowedCommonJsDependencies"', () => {
@@ -30,22 +35,11 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
           const { result, logs } = await harness.executeOnce();
 
           expect(result?.success).toBe(true);
-          expect(logs).toContain(
-            jasmine.objectContaining<logging.LogEntry>({
-              message: jasmine.stringMatching(
-                /Module 'buffer' used by 'src\/app\/app\.component\.ts' is not ESM/,
-              ),
-            }),
-          );
-          expect(logs).toContain(
-            jasmine.objectContaining<logging.LogEntry>({
-              message: jasmine.stringMatching(/CommonJS or AMD dependencies/),
-            }),
-          );
-          expect(logs).not.toContain(
-            jasmine.objectContaining<logging.LogEntry>({
-              message: jasmine.stringMatching('base64-js'),
-            }),
+          expectLog(logs, /Module 'buffer' used by 'src\/app\/app\.component\.ts' is not ESM/);
+          expectLog(logs, /CommonJS or AMD dependencies/);
+          expectNoLog(
+            logs,
+            'base64-js',
             'Should not warn on transitive CommonJS packages which parent is also CommonJS.',
           );
         });
@@ -70,11 +64,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
       const { result, logs } = await harness.executeOnce();
 
       expect(result?.success).toBe(true);
-      expect(logs).not.toContain(
-        jasmine.objectContaining<logging.LogEntry>({
-          message: jasmine.stringMatching(/CommonJS or AMD dependencies/),
-        }),
-      );
+      expectNoLog(logs, /CommonJS or AMD dependencies/);
     });
 
     it('should not show warning when all dependencies are allowed by wildcard', async () => {
@@ -95,11 +85,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
       const { result, logs } = await harness.executeOnce();
 
       expect(result?.success).toBe(true);
-      expect(logs).not.toContain(
-        jasmine.objectContaining<logging.LogEntry>({
-          message: jasmine.stringMatching(/CommonJS or AMD dependencies/),
-        }),
-      );
+      expectNoLog(logs, /CommonJS or AMD dependencies/);
     });
 
     it('should not show warning when depending on zone.js', async () => {
@@ -120,11 +106,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
       const { result, logs } = await harness.executeOnce();
 
       expect(result?.success).toBe(true);
-      expect(logs).not.toContain(
-        jasmine.objectContaining<logging.LogEntry>({
-          message: jasmine.stringMatching(/CommonJS or AMD dependencies/),
-        }),
-      );
+      expectNoLog(logs, /CommonJS or AMD dependencies/);
     });
 
     it(`should not show warning when importing non global local data '@angular/common/locale/fr'`, async () => {
@@ -142,11 +124,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
       const { result, logs } = await harness.executeOnce();
 
       expect(result?.success).toBe(true);
-      expect(logs).not.toContain(
-        jasmine.objectContaining<logging.LogEntry>({
-          message: jasmine.stringMatching(/CommonJS or AMD dependencies/),
-        }),
-      );
+      expectNoLog(logs, /CommonJS or AMD dependencies/);
     });
 
     it('should not show warning in JIT for templateUrl and styleUrl when using paths', async () => {
@@ -178,11 +156,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
       const { result, logs } = await harness.executeOnce();
 
       expect(result?.success).toBe(true);
-      expect(logs).not.toContain(
-        jasmine.objectContaining<logging.LogEntry>({
-          message: jasmine.stringMatching(/CommonJS or AMD dependencies/),
-        }),
-      );
+      expectNoLog(logs, /CommonJS or AMD dependencies/);
     });
 
     it('should not show warning for relative imports', async () => {
@@ -198,11 +172,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
       const { result, logs } = await harness.executeOnce();
 
       expect(result?.success).toBe(true);
-      expect(logs).not.toContain(
-        jasmine.objectContaining<logging.LogEntry>({
-          message: jasmine.stringMatching(/CommonJS or AMD dependencies/),
-        }),
-      );
+      expectNoLog(logs, /CommonJS or AMD dependencies/);
     });
   });
 });

--- a/packages/angular/build/src/builders/application/tests/options/bundle-budgets_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/options/bundle-budgets_spec.ts
@@ -6,13 +6,14 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import { logging } from '@angular-devkit/core';
 import { buildApplication } from '../../index';
 import { Type } from '../../schema';
 import {
   APPLICATION_BUILDER_INFO,
   BASE_OPTIONS,
   describeBuilder,
+  expectLog,
+  expectNoLog,
   lazyModuleFiles,
   lazyModuleFnImport,
 } from '../setup';
@@ -31,12 +32,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
 
       const { result, logs } = await harness.executeOnce();
       expect(result?.success).toBe(true);
-      expect(logs).not.toContain(
-        jasmine.objectContaining<logging.LogEntry>({
-          level: 'warn',
-          message: jasmine.stringMatching(BUDGET_NOT_MET_REGEXP),
-        }),
-      );
+      expectNoLog(logs, BUDGET_NOT_MET_REGEXP);
     });
 
     it(`should error when size is above 'maximumError' threshold`, async () => {
@@ -48,12 +44,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
 
       const { result, logs } = await harness.executeOnce();
       expect(result?.success).toBeFalse();
-      expect(logs).toContain(
-        jasmine.objectContaining<logging.LogEntry>({
-          level: 'error',
-          message: jasmine.stringMatching(BUDGET_NOT_MET_REGEXP),
-        }),
-      );
+      expectLog(logs, BUDGET_NOT_MET_REGEXP);
     });
 
     it(`should warn when size is above 'maximumWarning' threshold`, async () => {
@@ -65,12 +56,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
 
       const { result, logs } = await harness.executeOnce();
       expect(result?.success).toBe(true);
-      expect(logs).toContain(
-        jasmine.objectContaining<logging.LogEntry>({
-          level: 'warn',
-          message: jasmine.stringMatching(BUDGET_NOT_MET_REGEXP),
-        }),
-      );
+      expectLog(logs, BUDGET_NOT_MET_REGEXP);
     });
 
     it(`should warn when lazy bundle is above 'maximumWarning' threshold`, async () => {
@@ -85,12 +71,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
 
       const { result, logs } = await harness.executeOnce();
       expect(result?.success).toBe(true);
-      expect(logs).toContain(
-        jasmine.objectContaining<logging.LogEntry>({
-          level: 'warn',
-          message: jasmine.stringMatching('lazy-module exceeded maximum budget'),
-        }),
-      );
+      expectLog(logs, 'lazy-module exceeded maximum budget');
     });
 
     it(`should not warn when non-injected style is not within the baseline threshold`, async () => {
@@ -118,12 +99,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
 
       const { result, logs } = await harness.executeOnce();
       expect(result?.success).toBeTrue();
-      expect(logs).not.toContain(
-        jasmine.objectContaining<logging.LogEntry>({
-          level: 'warn',
-          message: jasmine.stringMatching('lazy-styles failed to meet minimum budget'),
-        }),
-      );
+      expectNoLog(logs, 'lazy-styles failed to meet minimum budget');
     });
 
     CSS_EXTENSIONS.forEach((ext) => {
@@ -154,12 +130,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
 
         const { result, logs } = await harness.executeOnce();
         expect(result?.success).toBe(true);
-        expect(logs).toContain(
-          jasmine.objectContaining<logging.LogEntry>({
-            level: 'warn',
-            message: jasmine.stringMatching(new RegExp(`app.component.${ext}`)),
-          }),
-        );
+        expectLog(logs, new RegExp(`app.component.${ext}`));
       });
     });
 
@@ -175,12 +146,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
 
         const { result, logs } = await harness.executeOnce();
         expect(result?.success).toBe(true);
-        expect(logs).not.toContain(
-          jasmine.objectContaining<logging.LogEntry>({
-            level: 'error',
-            message: jasmine.stringMatching(BUDGET_NOT_MET_REGEXP),
-          }),
-        );
+        expectNoLog(logs, BUDGET_NOT_MET_REGEXP);
       });
 
       it(`when 'intial' budget`, async () => {
@@ -194,12 +160,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
 
         const { result, logs } = await harness.executeOnce();
         expect(result?.success).toBe(true);
-        expect(logs).not.toContain(
-          jasmine.objectContaining<logging.LogEntry>({
-            level: 'error',
-            message: jasmine.stringMatching(BUDGET_NOT_MET_REGEXP),
-          }),
-        );
+        expectNoLog(logs, BUDGET_NOT_MET_REGEXP);
       });
 
       it(`when 'all' budget`, async () => {
@@ -213,12 +174,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
 
         const { result, logs } = await harness.executeOnce();
         expect(result?.success).toBe(true);
-        expect(logs).not.toContain(
-          jasmine.objectContaining<logging.LogEntry>({
-            level: 'error',
-            message: jasmine.stringMatching(BUDGET_NOT_MET_REGEXP),
-          }),
-        );
+        expectNoLog(logs, BUDGET_NOT_MET_REGEXP);
       });
 
       it(`when 'any' budget`, async () => {
@@ -232,12 +188,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
 
         const { result, logs } = await harness.executeOnce();
         expect(result?.success).toBe(true);
-        expect(logs).not.toContain(
-          jasmine.objectContaining<logging.LogEntry>({
-            level: 'error',
-            message: jasmine.stringMatching(BUDGET_NOT_MET_REGEXP),
-          }),
-        );
+        expectNoLog(logs, BUDGET_NOT_MET_REGEXP);
       });
     });
   });

--- a/packages/angular/build/src/builders/application/tests/options/i18n-missing-translation_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/options/i18n-missing-translation_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import { buildApplication } from '../../index';
-import { APPLICATION_BUILDER_INFO, BASE_OPTIONS, describeBuilder } from '../setup';
+import { APPLICATION_BUILDER_INFO, BASE_OPTIONS, describeBuilder, expectNoLog } from '../setup';
 
 describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
   describe('Option: "i18nMissingTranslation"', () => {
@@ -131,11 +131,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
       const { result, logs } = await harness.executeOnce({ outputLogsOnFailure: false });
 
       expect(result?.success).toBeTrue();
-      expect(logs).not.toContain(
-        jasmine.objectContaining({
-          message: jasmine.stringMatching('No translation found for'),
-        }),
-      );
+      expectNoLog(logs, 'No translation found for');
     });
 
     it('should not error or warn when i18nMissingTranslation is set to error and all found', async () => {
@@ -158,11 +154,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
       const { result, logs } = await harness.executeOnce({ outputLogsOnFailure: false });
 
       expect(result?.success).toBeTrue();
-      expect(logs).not.toContain(
-        jasmine.objectContaining({
-          message: jasmine.stringMatching('No translation found for'),
-        }),
-      );
+      expectNoLog(logs, 'No translation found for');
     });
 
     it('should not error or warn when i18nMissingTranslation is set to warning and all found', async () => {
@@ -185,11 +177,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
       const { result, logs } = await harness.executeOnce({ outputLogsOnFailure: false });
 
       expect(result?.success).toBeTrue();
-      expect(logs).not.toContain(
-        jasmine.objectContaining({
-          message: jasmine.stringMatching('No translation found for'),
-        }),
-      );
+      expectNoLog(logs, 'No translation found for');
     });
   });
 });

--- a/packages/angular/build/src/builders/application/tests/options/scripts_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/options/scripts_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import { buildApplication } from '../../index';
-import { APPLICATION_BUILDER_INFO, BASE_OPTIONS, describeBuilder } from '../setup';
+import { APPLICATION_BUILDER_INFO, BASE_OPTIONS, describeBuilder, expectLog } from '../setup';
 
 describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
   describe('Option: "scripts"', () => {
@@ -145,9 +145,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
 
         expect(result?.success).toBe(true);
 
-        expect(logs).toContain(
-          jasmine.objectContaining({ message: jasmine.stringMatching(/scripts\.js.+\d+ bytes/) }),
-        );
+        expectLog(logs, /scripts\.js.+\d+ bytes/);
       });
     });
 
@@ -412,9 +410,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
 
         expect(result?.success).toBe(true);
 
-        expect(logs).toContain(
-          jasmine.objectContaining({ message: jasmine.stringMatching(/scripts\.js.+\d+ bytes/) }),
-        );
+        expectLog(logs, /scripts\.js.+\d+ bytes/);
       });
 
       it('shows the output script as a chunk entry with bundleName in the logging output', async () => {
@@ -429,9 +425,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
 
         expect(result?.success).toBe(true);
 
-        expect(logs).toContain(
-          jasmine.objectContaining({ message: jasmine.stringMatching(/extra\.js.+\d+ bytes/) }),
-        );
+        expectLog(logs, /extra\.js.+\d+ bytes/);
       });
     });
   });

--- a/packages/angular/build/src/builders/application/tests/options/style-preprocessor-options-sass_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/options/style-preprocessor-options-sass_spec.ts
@@ -7,8 +7,7 @@
  */
 
 import { buildApplication } from '../../index';
-import { APPLICATION_BUILDER_INFO, BASE_OPTIONS, describeBuilder } from '../setup';
-import { logging } from '@angular-devkit/core';
+import { APPLICATION_BUILDER_INFO, BASE_OPTIONS, describeBuilder, expectNoLog } from '../setup';
 
 describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
   describe('Option: "stylePreprocessorOptions.sass"', () => {
@@ -28,11 +27,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
       const { result, logs } = await harness.executeOnce({ outputLogsOnFailure: false });
 
       expect(result?.success).toBeFalse();
-      expect(logs).not.toContain(
-        jasmine.objectContaining<logging.LogEntry>({
-          message: jasmine.stringMatching('darken() is deprecated'),
-        }),
-      );
+      expectNoLog(logs, 'darken() is deprecated');
     });
 
     it('should succeed without `fatalDeprecations` despite using deprecated color functions', async () => {
@@ -79,11 +74,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
       });
 
       expect(result?.success).toBeFalse();
-      expect(logs).not.toContain(
-        jasmine.objectContaining<logging.LogEntry>({
-          message: jasmine.stringMatching('darken() is deprecated'),
-        }),
-      );
+      expectNoLog(logs, 'darken() is deprecated');
     });
   });
 });

--- a/packages/angular/build/src/builders/application/tests/options/styles_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/options/styles_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import { buildApplication } from '../../index';
-import { APPLICATION_BUILDER_INFO, BASE_OPTIONS, describeBuilder } from '../setup';
+import { APPLICATION_BUILDER_INFO, BASE_OPTIONS, describeBuilder, expectLog } from '../setup';
 
 describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
   describe('Option: "styles"', () => {
@@ -147,9 +147,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
 
         expect(result?.success).toBe(true);
 
-        expect(logs).toContain(
-          jasmine.objectContaining({ message: jasmine.stringMatching(/styles\.css.+\d+ bytes/) }),
-        );
+        expectLog(logs, /styles\.css.+\d+ bytes/);
       });
     });
 
@@ -440,9 +438,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
 
         expect(result?.success).toBe(true);
 
-        expect(logs).toContain(
-          jasmine.objectContaining({ message: jasmine.stringMatching(/styles\.css.+\d+ bytes/) }),
-        );
+        expectLog(logs, /styles\.css.+\d+ bytes/);
       });
 
       it('shows the output style as a chunk entry with bundleName in the logging output', async () => {
@@ -457,9 +453,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
 
         expect(result?.success).toBe(true);
 
-        expect(logs).toContain(
-          jasmine.objectContaining({ message: jasmine.stringMatching(/extra\.css.+\d+ bytes/) }),
-        );
+        expectLog(logs, /extra\.css.+\d+ bytes/);
       });
     });
   });

--- a/packages/angular/build/src/builders/application/tests/options/subresource-integrity_spec.ts
+++ b/packages/angular/build/src/builders/application/tests/options/subresource-integrity_spec.ts
@@ -6,9 +6,8 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import { logging } from '@angular-devkit/core';
 import { buildApplication } from '../../index';
-import { APPLICATION_BUILDER_INFO, BASE_OPTIONS, describeBuilder } from '../setup';
+import { APPLICATION_BUILDER_INFO, BASE_OPTIONS, describeBuilder, expectNoLog } from '../setup';
 
 describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
   describe('Option: "subresourceIntegrity"', () => {
@@ -64,11 +63,7 @@ describeBuilder(buildApplication, APPLICATION_BUILDER_INFO, (harness) => {
       harness
         .expectFile('dist/browser/index.html')
         .content.toMatch(/integrity="\w+-[A-Za-z0-9/+=]+"/);
-      expect(logs).not.toContain(
-        jasmine.objectContaining<logging.LogEntry>({
-          message: jasmine.stringMatching(/subresource-integrity/),
-        }),
-      );
+      expectNoLog(logs, /subresource-integrity/);
     });
   });
 });

--- a/packages/angular/build/src/builders/dev-server/tests/behavior/build-errors_spec.ts
+++ b/packages/angular/build/src/builders/dev-server/tests/behavior/build-errors_spec.ts
@@ -6,10 +6,9 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import { logging } from '@angular-devkit/core';
 import { executeDevServer } from '../../index';
 import { describeServeBuilder } from '../jasmine-helpers';
-import { BASE_OPTIONS, DEV_SERVER_BUILDER_INFO } from '../setup';
+import { BASE_OPTIONS, DEV_SERVER_BUILDER_INFO, expectLog, expectNoLog } from '../setup';
 
 describeServeBuilder(executeDevServer, DEV_SERVER_BUILDER_INFO, (harness, setupTarget) => {
   describe('Behavior: "Rebuild Error Detection"', () => {
@@ -31,21 +30,13 @@ describeServeBuilder(executeDevServer, DEV_SERVER_BUILDER_INFO, (harness, setupT
           async ({ result, logs }) => {
             expect(result?.success).toBeFalse();
             debugger;
-            expect(logs).toContain(
-              jasmine.objectContaining<logging.LogEntry>({
-                message: jasmine.stringMatching('Unexpected character "EOF"'),
-              }),
-            );
+            expectLog(logs, 'Unexpected character "EOF"');
 
             await harness.appendToFile('src/app/app.component.html', '>');
           },
           ({ result, logs }) => {
             expect(result?.success).toBeTrue();
-            expect(logs).not.toContain(
-              jasmine.objectContaining<logging.LogEntry>({
-                message: jasmine.stringMatching('Unexpected character "EOF"'),
-              }),
-            );
+            expectNoLog(logs, 'Unexpected character "EOF"');
           },
         ],
         { outputLogsOnFailure: false },

--- a/packages/angular/build/src/builders/unit-test/tests/options/browsers_spec.ts
+++ b/packages/angular/build/src/builders/unit-test/tests/options/browsers_spec.ts
@@ -12,6 +12,7 @@ import {
   describeBuilder,
   UNIT_TEST_BUILDER_INFO,
   setupApplicationTarget,
+  expectLog,
 } from '../setup';
 
 describeBuilder(execute, UNIT_TEST_BUILDER_INFO, (harness) => {
@@ -28,9 +29,7 @@ describeBuilder(execute, UNIT_TEST_BUILDER_INFO, (harness) => {
 
       const { result, logs } = await harness.executeOnce();
       expect(result?.success).toBeTrue();
-      expect(logs).toContain(
-        jasmine.objectContaining({ message: 'Using jsdom in Node.js for test execution.' }),
-      );
+      expectLog(logs, 'Using jsdom in Node.js for test execution.');
     });
 
     it('should fail when browsers is empty', async () => {
@@ -52,9 +51,7 @@ describeBuilder(execute, UNIT_TEST_BUILDER_INFO, (harness) => {
 
       const { result, logs } = await harness.executeOnce();
       expect(result?.success).toBeTrue();
-      expect(logs).toContain(
-        jasmine.objectContaining({ message: jasmine.stringMatching(/Starting browser "chrome"/) }),
-      );
+      expectLog(logs, /Starting browser "chrome"/);
     });
 
     it('should launch a browser in headless mode when specified', async () => {
@@ -65,11 +62,7 @@ describeBuilder(execute, UNIT_TEST_BUILDER_INFO, (harness) => {
 
       const { result, logs } = await harness.executeOnce();
       expect(result?.success).toBeTrue();
-      expect(logs).toContain(
-        jasmine.objectContaining({
-          message: jasmine.stringMatching(/Starting browser "chrome" in headless mode/),
-        }),
-      );
+      expectLog(logs, /Starting browser "chrome" in headless mode/);
     });
   });
 });

--- a/packages/angular/build/src/builders/unit-test/tests/options/debug_spec.ts
+++ b/packages/angular/build/src/builders/unit-test/tests/options/debug_spec.ts
@@ -12,6 +12,8 @@ import {
   describeBuilder,
   UNIT_TEST_BUILDER_INFO,
   setupApplicationTarget,
+  expectLog,
+  expectNoLog,
 } from '../setup';
 
 describeBuilder(execute, UNIT_TEST_BUILDER_INFO, (harness) => {
@@ -28,9 +30,7 @@ describeBuilder(execute, UNIT_TEST_BUILDER_INFO, (harness) => {
 
       const { result, logs } = await harness.executeOnce();
       expect(result?.success).toBeTrue();
-      expect(logs).not.toContain(
-        jasmine.objectContaining({ message: jasmine.stringMatching(/Node.js inspector/) }),
-      );
+      expectNoLog(logs, /Node.js inspector/);
     });
 
     it('should enter debug mode when debug is true', async () => {
@@ -41,11 +41,7 @@ describeBuilder(execute, UNIT_TEST_BUILDER_INFO, (harness) => {
 
       const { result, logs } = await harness.executeOnce();
       expect(result?.success).toBeTrue();
-      expect(logs).toContain(
-        jasmine.objectContaining({
-          message: jasmine.stringMatching(/Node.js inspector is active/),
-        }),
-      );
+      expectLog(logs, /Node.js inspector is active/);
     });
   });
 });

--- a/packages/angular/build/src/builders/unit-test/tests/options/setup-files_spec.ts
+++ b/packages/angular/build/src/builders/unit-test/tests/options/setup-files_spec.ts
@@ -12,6 +12,7 @@ import {
   describeBuilder,
   UNIT_TEST_BUILDER_INFO,
   setupApplicationTarget,
+  expectLog,
 } from '../setup';
 
 describeBuilder(execute, UNIT_TEST_BUILDER_INFO, (harness) => {
@@ -50,7 +51,7 @@ describeBuilder(execute, UNIT_TEST_BUILDER_INFO, (harness) => {
 
       const { result, logs } = await harness.executeOnce();
       expect(result?.success).toBeTrue();
-      expect(logs).toContain(jasmine.objectContaining({ message: 'Hello from setup.ts' }));
+      expectLog(logs, 'Hello from setup.ts');
     });
   });
 });


### PR DESCRIPTION
Introduces `expectLog` and `expectNoLog` jasmine helpers to simplify the assertions of logs in tests. This removes the need to use `jasmine.objectContaining` and `jasmine.stringMatching` for this purpose, making the tests more readable and less verbose.