### PR TITLE
build: disable eslint `await-thenable`

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,19 +1,23 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
 import { fixupConfigRules, fixupPluginRules } from '@eslint/compat';
+import { FlatCompat } from '@eslint/eslintrc';
+import js from '@eslint/js';
 import stylistic from '@stylistic/eslint-plugin';
 import typescriptEslint from '@typescript-eslint/eslint-plugin';
-import _import from 'eslint-plugin-import';
-import header from 'eslint-plugin-header';
-import globals from 'globals';
 import tsParser from '@typescript-eslint/parser';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-import js from '@eslint/js';
-import { FlatCompat } from '@eslint/eslintrc';
+import header from 'eslint-plugin-header';
+import _import from 'eslint-plugin-import';
+import globals from 'globals';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
 const compat = new FlatCompat({
-  baseDirectory: __dirname,
+  baseDirectory: import.meta.dirname,
   recommendedConfig: js.configs.recommended,
   allConfig: js.configs.all,
 });
@@ -185,6 +189,7 @@ export default [
         },
       ],
 
+      '@typescript-eslint/await-thenable': 'off',
       '@typescript-eslint/ban-types': 'off',
       '@typescript-eslint/no-implied-eval': 'off',
       '@typescript-eslint/no-var-requires': 'off',


### PR DESCRIPTION
This was recently introduced and there are a number of intentional parts that our code does not conform.
