### PR TITLE
test(@angular/build): preserve zone change detection provider

### DIFF
--- a/tests/legacy-cli/e2e/tests/build/material.ts
+++ b/tests/legacy-cli/e2e/tests/build/material.ts
@@ -55,9 +55,9 @@ export default async function () {
   // Issue: https://github.com/angular/angular-cli/issues/17320
   await replaceInFile(
     'src/app/app.config.ts',
-    `import { ApplicationConfig } from '@angular/core';`,
+    `from '@angular/core';`,
     `
-    import { ApplicationConfig } from '@angular/core';
+    from '@angular/core';
     import {
       MomentDateAdapter,
       MAT_MOMENT_DATE_FORMATS
@@ -72,10 +72,8 @@ export default async function () {
 
   await replaceInFile(
     'src/app/app.config.ts',
-    `providers: [provideRouter(routes) ]`,
-    `
-    providers: [
-      provideRouter(routes),
+    `provideRouter(routes)`,
+    `provideRouter(routes),
       {
         provide: DateAdapter,
         useClass: MomentDateAdapter,
@@ -84,9 +82,7 @@ export default async function () {
       {
         provide: MAT_DATE_FORMATS,
         useValue: MAT_MOMENT_DATE_FORMATS
-      }
-    ]
-  `,
+      }`,
   );
 
   await ng('e2e', '--configuration=production');

--- a/tests/legacy-cli/e2e/tests/build/prerender/http-requests-assets.ts
+++ b/tests/legacy-cli/e2e/tests/build/prerender/http-requests-assets.ts
@@ -20,7 +20,7 @@ export default async function () {
   await writeMultipleFiles({
     // Add http client and route
     'src/app/app.config.ts': `
-      import { ApplicationConfig } from '@angular/core';
+      import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
       import { provideRouter } from '@angular/router';
 
       import {Home} from './home/home';
@@ -35,6 +35,7 @@ export default async function () {
           }]),
           provideClientHydration(),
           provideHttpClient(withFetch()),
+          provideZoneChangeDetection({ eventCoalescing: true }),
         ],
       };
     `,

--- a/tests/legacy-cli/e2e/tests/build/server-rendering/server-routes-output-mode-static-http-calls.ts
+++ b/tests/legacy-cli/e2e/tests/build/server-rendering/server-routes-output-mode-static-http-calls.ts
@@ -56,7 +56,7 @@ export default async function () {
     `,
     // Add http client and route
     'src/app/app.config.ts': `
-      import { ApplicationConfig } from '@angular/core';
+      import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
       import { provideRouter } from '@angular/router';
 
       import { Home } from './home/home';
@@ -71,6 +71,7 @@ export default async function () {
           }]),
           provideClientHydration(),
           provideHttpClient(withFetch()),
+          provideZoneChangeDetection({ eventCoalescing: true }),
         ],
       };
     `,

--- a/tests/legacy-cli/e2e/tests/commands/serve/ssr-http-requests-assets.ts
+++ b/tests/legacy-cli/e2e/tests/commands/serve/ssr-http-requests-assets.ts
@@ -24,7 +24,7 @@ export default async function () {
   await writeMultipleFiles({
     // Add http client and route
     'src/app/app.config.ts': `
-      import { ApplicationConfig } from '@angular/core';
+      import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
       import { provideRouter } from '@angular/router';
 
       import { Home } from './home/home';
@@ -39,6 +39,7 @@ export default async function () {
           }]),
           provideClientHydration(),
           provideHttpClient(withFetch()),
+          provideZoneChangeDetection({ eventCoalescing: true }),
         ],
       };
     `,


### PR DESCRIPTION
With the recent default flip, these tests are now unexpectedly getting a different zone behavior if they overwrite the app config.