### PR TITLE
test: Add provideZoneChangeDetection to fakeAsync tests.

### DIFF
--- a/packages/angular/build/src/builders/karma/tests/behavior/fake-async_spec.ts
+++ b/packages/angular/build/src/builders/karma/tests/behavior/fake-async_spec.ts
@@ -35,12 +35,14 @@ describeKarmaBuilder(execute, KARMA_BUILDER_INFO, (harness, setupTarget) => {
               }
             }`,
         './src/app/app.component.spec.ts': `
+            import { provideZoneChangeDetection } from '@angular/core';
             import { TestBed, fakeAsync, tick } from '@angular/core/testing';
             import { By } from '@angular/platform-browser';
             import { AppComponent } from './app.component';
 
             describe('AppComponent', () => {
               beforeEach(() => TestBed.configureTestingModule({
+                providers: [provideZoneChangeDetection()],
                 declarations: [AppComponent]
               }));
 

--- a/packages/angular_devkit/build_angular/src/builders/karma/tests/behavior/fake-async_spec.ts
+++ b/packages/angular_devkit/build_angular/src/builders/karma/tests/behavior/fake-async_spec.ts
@@ -35,12 +35,14 @@ describeKarmaBuilder(execute, KARMA_BUILDER_INFO, (harness, setupTarget) => {
               }
             }`,
         './src/app/app.component.spec.ts': `
+            import { provideZoneChangeDetection } from '@angular/core';
             import { TestBed, fakeAsync, tick } from '@angular/core/testing';
             import { By } from '@angular/platform-browser';
             import { AppComponent } from './app.component';
 
             describe('AppComponent', () => {
               beforeEach(() => TestBed.configureTestingModule({
+                providers: [provideZoneChangeDetection()],
                 declarations: [AppComponent]
               }));
 


### PR DESCRIPTION
This commit adds `provideZoneChangeDetection()` to the `beforeEach` block in `fakeAsync_spec.ts` files to ensure proper zone change detection in tests