### PR TITLE
fix(@schematics/angular): use fixture.whenStable() instead of fixture detectChanges() for zoneless apps

### DIFF
--- a/packages/schematics/angular/application/files/module-files/src/app/app__suffix__.spec.ts.template
+++ b/packages/schematics/angular/application/files/module-files/src/app/app__suffix__.spec.ts.template
@@ -20,9 +20,9 @@ describe('App', () => {
     expect(app).toBeTruthy();
   });
 
-  it('should render title', () => {
+  it('should render title', <% if(zoneless) { %> async <% } %>() => {
     const fixture = TestBed.createComponent(App);
-    fixture.detectChanges();
+    <%= zoneless ? 'await fixture.whenStable();' : 'fixture.detectChanges();' %>
     const compiled = fixture.nativeElement as HTMLElement;
     expect(compiled.querySelector('h1')?.textContent).toContain('Hello, <%= name %>');
   });

--- a/packages/schematics/angular/application/files/standalone-files/src/app/app__suffix__.spec.ts.template
+++ b/packages/schematics/angular/application/files/standalone-files/src/app/app__suffix__.spec.ts.template
@@ -14,9 +14,9 @@ describe('App', () => {
     expect(app).toBeTruthy();
   });
 
-  it('should render title', () => {
+  it('should render title', <% if(zoneless) { %> async <% } %>() => {
     const fixture = TestBed.createComponent(App);
-    fixture.detectChanges();
+    <%= zoneless ? 'await fixture.whenStable();' : 'fixture.detectChanges();' %>
     const compiled = fixture.nativeElement as HTMLElement;
     expect(compiled.querySelector('h1')?.textContent).toContain('Hello, <%= name %>');
   });

--- a/packages/schematics/angular/application/index_spec.ts
+++ b/packages/schematics/angular/application/index_spec.ts
@@ -831,6 +831,35 @@ describe('Application Schematic', () => {
     });
   });
 
+  it('should add fixture.whenStable() when zoneless application', async () => {
+    const tree = await schematicRunner.runSchematic(
+      'application',
+      {
+        ...defaultOptions,
+      },
+      workspaceTree,
+    );
+
+    const content = tree.readContent('/projects/foo/src/app/app.spec.ts');
+    expect(content).toContain('fixture.whenStable()');
+    expect(content).not.toContain('fixture.detectChanges()');
+  });
+
+  it('should not add fixture.whenStable() in initial spec files when its not zoneless application', async () => {
+    const tree = await schematicRunner.runSchematic(
+      'application',
+      {
+        ...defaultOptions,
+        zoneless: false,
+      },
+      workspaceTree,
+    );
+
+    const content = tree.readContent('/projects/foo/src/app/app.spec.ts');
+    expect(content).not.toContain('fixture.whenStable()');
+    expect(content).toContain('fixture.detectChanges()');
+  });
+
   it('should call the tailwind schematic when style is tailwind', async () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const options = { ...defaultOptions, style: 'tailwind' as any };

--- a/packages/schematics/angular/component/files/__name@dasherize@if-flat__/__name@dasherize__.__type@dasherize__.spec.ts.template
+++ b/packages/schematics/angular/component/files/__name@dasherize@if-flat__/__name@dasherize__.__type@dasherize__.spec.ts.template
@@ -14,7 +14,7 @@ describe('<%= classifiedName %>', () => {
 
     fixture = TestBed.createComponent(<%= classifiedName %>);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    <%= zoneless ? 'await fixture.whenStable();' : 'fixture.detectChanges();' %>
   });
 
   it('should create', () => {

--- a/packages/schematics/angular/component/index.ts
+++ b/packages/schematics/angular/component/index.ts
@@ -24,6 +24,7 @@ import { addDeclarationToNgModule } from '../utility/add-declaration-to-ng-modul
 import { findModuleFromOptions } from '../utility/find-module';
 import { parseName } from '../utility/parse-name';
 import { createProjectSchematic } from '../utility/project';
+import { isZonelessApp } from '../utility/project-targets';
 import { validateClassName, validateHtmlSelector } from '../utility/validation';
 import { buildDefaultPath } from '../utility/workspace';
 import { Schema as ComponentOptions, Style } from './schema';
@@ -59,6 +60,7 @@ export default createProjectSchematic<ComponentOptions>((options, { project, tre
     strings.classify(options.name) +
     (options.addTypeToClassName && options.type ? strings.classify(options.type) : '');
   validateClassName(classifiedName);
+  const zoneless = isZonelessApp(project);
 
   const skipStyleFile = options.inlineStyle || options.style === Style.None;
   const templateSource = apply(url('./files'), [
@@ -72,6 +74,7 @@ export default createProjectSchematic<ComponentOptions>((options, { project, tre
       ...options,
       // Add a new variable for the classified name, conditionally including the type
       classifiedName,
+      zoneless,
     }),
     !options.type
       ? forEach(((file) => {

--- a/packages/schematics/angular/component/index_spec.ts
+++ b/packages/schematics/angular/component/index_spec.ts
@@ -554,4 +554,38 @@ describe('Component Schematic', () => {
     const specContent = tree.readContent('/projects/bar/src/app/foo/foo.component.spec.ts');
     expect(specContent).toContain("import { FooComponent } from './foo.component';");
   });
+
+  it('should add fixture.whenStable() in spec file when zoneless and standalone apps', async () => {
+    const tree = await schematicRunner.runSchematic('component', { ...defaultOptions }, appTree);
+    const tsContent = tree.readContent('/projects/bar/src/app/foo/foo.component.spec.ts');
+
+    expect(tsContent).toContain('fixture.whenStable()');
+    expect(tsContent).not.toContain('fixture.detectChanges()');
+  });
+
+  describe('with zone.js application', () => {
+    const zoneAppOptions: ApplicationOptions = {
+      ...appOptions,
+      name: 'baz',
+      zoneless: false,
+    };
+
+    it('should add not fixture.whenStable() in spec file for standalone', async () => {
+      appTree = await schematicRunner.runSchematic(
+        'application',
+        { ...zoneAppOptions, standalone: true },
+        appTree,
+      );
+      const tree = await schematicRunner.runSchematic(
+        'component',
+        { ...defaultOptions, standalone: true, project: 'baz' },
+        appTree,
+      );
+
+      const tsContent = tree.readContent('/projects/baz/src/app/foo/foo.component.spec.ts');
+
+      expect(tsContent).not.toContain('fixture.whenStable()');
+      expect(tsContent).toContain('fixture.detectChanges()');
+    });
+  });
 });

--- a/packages/schematics/angular/utility/project-targets.ts
+++ b/packages/schematics/angular/utility/project-targets.ts
@@ -21,3 +21,15 @@ export function isUsingApplicationBuilder(project: ProjectDefinition): boolean {
 
   return isUsingApplicationBuilder;
 }
+
+export function isZonelessApp(project: ProjectDefinition): boolean {
+  const buildTarget = project.targets.get('build');
+  if (!buildTarget?.options?.polyfills) {
+    return true;
+  }
+
+  const polyfills = buildTarget.options.polyfills as string[] | string;
+  const polyfillsList = Array.isArray(polyfills) ? polyfills : [polyfills];
+
+  return !polyfillsList.includes('zone.js');
+}

--- a/tests/legacy-cli/e2e/tests/jest/no-zoneless.ts
+++ b/tests/legacy-cli/e2e/tests/jest/no-zoneless.ts
@@ -1,3 +1,4 @@
+import { replaceInFile } from '../../utils/fs';
 import { applyJestBuilder } from '../../utils/jest';
 import { installPackage, uninstallPackage } from '../../utils/packages';
 import { ng } from '../../utils/process';
@@ -8,8 +9,15 @@ export default async function (): Promise<void> {
     polyfills: ['zone.js', 'zone.js/testing'],
   });
 
+  await replaceInFile(
+    'src/app/app.spec.ts',
+    'await fixture.whenStable();',
+    'fixture.detectChanges();',
+  );
+
   try {
     await installPackage('zone.js');
+
     const { stderr } = await ng('test');
 
     if (!stderr.includes('Jest builder is currently EXPERIMENTAL')) {


### PR DESCRIPTION
Closes #31193

## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently, when we generate the app using add or generate command, for zoneless apps it uses `fixture.detectChanges()` whereas the docs says to use `fixture.whenStable()`

Issue Number: #31193

## What is the new behavior?

If we now create zoneless apps, when generate or add command, `fixture.whenStable()` will be used.

See #31193

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
