### PR TITLE
fix(@angular/build): support ESM PostCSS plugins

### DIFF
--- a/packages/angular/build/src/tools/esbuild/stylesheets/stylesheet-plugin-factory.ts
+++ b/packages/angular/build/src/tools/esbuild/stylesheets/stylesheet-plugin-factory.ts
@@ -225,9 +225,9 @@ export class StylesheetPluginFactory {
         postcssProcessor = postcss();
 
         const postCssPluginRequire = createRequire(dirname(configPath) + '/');
-
         for (const [pluginName, pluginOptions] of config.plugins) {
-          const plugin = postCssPluginRequire(pluginName);
+          const pluginMod = postCssPluginRequire(pluginName);
+          const plugin = pluginMod.__esModule ? pluginMod['default'] : pluginMod;
           if (typeof plugin !== 'function' || plugin.postcss !== true) {
             throw new Error(`Attempted to load invalid Postcss plugin: "${pluginName}"`);
           }

--- a/packages/angular_devkit/build_angular/src/tools/webpack/configs/styles.ts
+++ b/packages/angular_devkit/build_angular/src/tools/webpack/configs/styles.ts
@@ -87,7 +87,8 @@ export async function getStylesConfig(wco: WebpackConfigOptions): Promise<Config
     const postCssPluginRequire = createRequire(path.dirname(postcssConfig.configPath) + '/');
 
     for (const [pluginName, pluginOptions] of postcssConfig.config.plugins) {
-      const plugin = postCssPluginRequire(pluginName);
+      const pluginMod = postCssPluginRequire(pluginName);
+      const plugin = pluginMod.__esModule ? pluginMod['default'] : pluginMod;
       if (typeof plugin !== 'function' || plugin.postcss !== true) {
         throw new Error(`Attempted to load invalid Postcss plugin: "${pluginName}"`);
       }


### PR DESCRIPTION
This change updates the PostCSS plugin loader to support plugins distributed as ES modules. This allows modern PostCSS plugins authored in ESM to be used without import errors.
