### PR TITLE
refactor(@angular/build): remove deprecated signature usage

### DIFF
--- a/packages/angular/build/src/tools/angular/transformers/jit-bootstrap-transformer.ts
+++ b/packages/angular/build/src/tools/angular/transformers/jit-bootstrap-transformer.ts
@@ -32,7 +32,7 @@ export function replaceBootstrap(
             bootstrapImport = nodeFactory.createImportDeclaration(
               undefined,
               nodeFactory.createImportClause(
-                false,
+                undefined,
                 undefined,
                 nodeFactory.createNamespaceImport(bootstrapNamespace),
               ),

--- a/packages/angular/build/src/tools/angular/transformers/jit-resource-transformer.ts
+++ b/packages/angular/build/src/tools/angular/transformers/jit-resource-transformer.ts
@@ -254,7 +254,7 @@ function createResourceImport(
   resourceImportDeclarations.push(
     nodeFactory.createImportDeclaration(
       undefined,
-      nodeFactory.createImportClause(false, importName, undefined),
+      nodeFactory.createImportClause(undefined, importName, undefined),
       urlLiteral,
     ),
   );

--- a/packages/ngtools/webpack/src/ivy/transformation.ts
+++ b/packages/ngtools/webpack/src/ivy/transformation.ts
@@ -110,7 +110,7 @@ export function replaceBootstrap(
             bootstrapImport = nodeFactory.createImportDeclaration(
               undefined,
               nodeFactory.createImportClause(
-                false,
+                undefined,
                 undefined,
                 nodeFactory.createNamespaceImport(bootstrapNamespace),
               ),

--- a/packages/ngtools/webpack/src/transformers/replace_resources.ts
+++ b/packages/ngtools/webpack/src/transformers/replace_resources.ts
@@ -309,7 +309,7 @@ function createResourceImport(
     resourceImportDeclarations.push(
       nodeFactory.createImportDeclaration(
         undefined,
-        nodeFactory.createImportClause(false, importName, undefined),
+        nodeFactory.createImportClause(undefined, importName, undefined),
         urlLiteral,
       ),
     );


### PR DESCRIPTION
Fixes usages of a deprecated signature of `createImportClause`.
