### PR TITLE
fix(@angular/build): set coverage report directory to coverage/project-name

### DIFF
--- a/packages/angular/build/src/builders/unit-test/runners/vitest/executor.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/executor.ts
@@ -20,7 +20,6 @@ import {
   ResultKind,
 } from '../../../application/results';
 import { NormalizedUnitTestBuilderOptions } from '../../options';
-import { findTests, getTestEntrypoints } from '../../test-discovery';
 import type { TestExecutor } from '../api';
 import { setupBrowserConfiguration } from './browser-provider';
 import { createVitestPlugins } from './plugins';
@@ -191,7 +190,7 @@ export class VitestExecutor implements TestExecutor {
         reporters: reporters ?? ['default'],
         outputFile,
         watch,
-        coverage: generateCoverageOption(codeCoverage),
+        coverage: generateCoverageOption(codeCoverage, this.projectName),
         ...debugOptions,
       },
       {
@@ -208,6 +207,7 @@ export class VitestExecutor implements TestExecutor {
 
 function generateCoverageOption(
   codeCoverage: NormalizedUnitTestBuilderOptions['codeCoverage'],
+  projectName: string,
 ): VitestCoverageOption {
   if (!codeCoverage) {
     return {
@@ -218,6 +218,7 @@ function generateCoverageOption(
   return {
     enabled: true,
     excludeAfterRemap: true,
+    reportsDirectory: toPosixPath(path.join('coverage', projectName)),
     // Special handling for `exclude`/`reporters` due to an undefined value causing upstream failures
     ...(codeCoverage.exclude ? { exclude: codeCoverage.exclude } : {}),
     ...(codeCoverage.reporters

--- a/packages/angular/build/src/builders/unit-test/tests/options/code-coverage-exclude_spec.ts
+++ b/packages/angular/build/src/builders/unit-test/tests/options/code-coverage-exclude_spec.ts
@@ -31,7 +31,7 @@ describeBuilder(execute, UNIT_TEST_BUILDER_INFO, (harness) => {
 
       const { result } = await harness.executeOnce();
       expect(result?.success).toBeTrue();
-      const summary = harness.readFile('coverage/coverage-final.json');
+      const summary = harness.readFile('coverage/test/coverage-final.json');
       expect(summary).toContain('src/app/error.ts"');
     });
 
@@ -44,7 +44,7 @@ describeBuilder(execute, UNIT_TEST_BUILDER_INFO, (harness) => {
 
       const { result } = await harness.executeOnce();
       expect(result?.success).toBeTrue();
-      const summary = harness.readFile('coverage/coverage-final.json');
+      const summary = harness.readFile('coverage/test/coverage-final.json');
       expect(summary).not.toContain('src/app/error.ts"');
     });
   });

--- a/packages/angular/build/src/builders/unit-test/tests/options/code-coverage-reporters_spec.ts
+++ b/packages/angular/build/src/builders/unit-test/tests/options/code-coverage-reporters_spec.ts
@@ -29,7 +29,7 @@ describeBuilder(execute, UNIT_TEST_BUILDER_INFO, (harness) => {
 
       const { result } = await harness.executeOnce();
       expect(result?.success).toBeTrue();
-      expect(harness.hasFile('coverage/coverage-summary.json')).toBeTrue();
+      expect(harness.hasFile('coverage/test/coverage-summary.json')).toBeTrue();
     });
 
     it('should generate multiple reports when specified', async () => {
@@ -41,8 +41,8 @@ describeBuilder(execute, UNIT_TEST_BUILDER_INFO, (harness) => {
 
       const { result } = await harness.executeOnce();
       expect(result?.success).toBeTrue();
-      expect(harness.hasFile('coverage/coverage-summary.json')).toBeTrue();
-      expect(harness.hasFile('coverage/lcov.info')).toBeTrue();
+      expect(harness.hasFile('coverage/test/coverage-summary.json')).toBeTrue();
+      expect(harness.hasFile('coverage/test/lcov.info')).toBeTrue();
     });
   });
 });

--- a/packages/angular/build/src/builders/unit-test/tests/options/code-coverage_spec.ts
+++ b/packages/angular/build/src/builders/unit-test/tests/options/code-coverage_spec.ts
@@ -28,7 +28,7 @@ describeBuilder(execute, UNIT_TEST_BUILDER_INFO, (harness) => {
 
       const { result } = await harness.executeOnce();
       expect(result?.success).toBeTrue();
-      expect(harness.hasFile('coverage/index.html')).toBeFalse();
+      expect(harness.hasFile('coverage/test/index.html')).toBeFalse();
     });
 
     it('should generate a code coverage report when codeCoverage is true', async () => {
@@ -39,7 +39,7 @@ describeBuilder(execute, UNIT_TEST_BUILDER_INFO, (harness) => {
 
       const { result } = await harness.executeOnce();
       expect(result?.success).toBeTrue();
-      expect(harness.hasFile('coverage/index.html')).toBeTrue();
+      expect(harness.hasFile('coverage/test/index.html')).toBeTrue();
     });
   });
 });

--- a/packages/angular/build/src/builders/unit-test/tests/setup.ts
+++ b/packages/angular/build/src/builders/unit-test/tests/setup.ts
@@ -11,7 +11,7 @@ import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { BuilderHarness } from '../../../../../../../modules/testing/builder/src';
 import {
-  ApplicationBuilderOptions as AppilicationSchema,
+  ApplicationBuilderOptions as ApplicationSchema,
   buildApplication,
 } from '../../../builders/application';
 import { Schema } from '../schema';
@@ -33,7 +33,7 @@ export const APPLICATION_BUILDER_INFO = Object.freeze({
  * Contains all required application builder fields.
  * Also disables progress reporting to minimize logging output.
  */
-export const APPLICATION_BASE_OPTIONS = Object.freeze<AppilicationSchema>({
+export const APPLICATION_BASE_OPTIONS = Object.freeze<ApplicationSchema>({
   index: 'src/index.html',
   browser: 'src/main.ts',
   outputPath: 'dist',
@@ -84,7 +84,7 @@ let applicationSchema: json.schema.JsonSchema | undefined;
  */
 export function setupApplicationTarget<T>(
   harness: BuilderHarness<T>,
-  extraOptions?: Partial<AppilicationSchema>,
+  extraOptions?: Partial<ApplicationSchema>,
 ): void {
   applicationSchema ??= JSON.parse(
     readFileSync(APPLICATION_BUILDER_INFO.schemaPath, 'utf8'),


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

The coverage report for the unit-test builder is generated in `coverage/` whereas the karma builder generates it in `coverage/project-name`.

## What is the new behavior?

The coverage report is generated in `coverage/project-name`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
