### PR TITLE
fix(@angular/build): exclude .angular from coverage instrumentation

### DIFF
--- a/packages/angular/build/src/builders/karma/coverage.ts
+++ b/packages/angular/build/src/builders/karma/coverage.ts
@@ -13,7 +13,7 @@ export function createInstrumentationFilter(includedBasePath: string, excludedPa
   return (request: string): boolean => {
     return (
       !excludedPaths.has(request) &&
-      !/\.(e2e|spec)\.tsx?$|[\\/]node_modules[\\/]/.test(request) &&
+      !/\.(e2e|spec)\.tsx?$|[\\/]node_modules[\\/]|[\\/]\.angular[\\/]/.test(request) &&
       request.startsWith(includedBasePath)
     );
   };


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Running `ng test --code-coverage` in a CLI project curently generates:

```
--------------------------------------------------|---------|----------|---------|---------|-------------------
File                                              | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
--------------------------------------------------|---------|----------|---------|---------|-------------------
All files                                         |   31.16 |       50 |      50 |   31.16 |                   
 .angular/cache/21.0.0-next.4/vitest-coverage/vite/deps |       0 |        0 |       0 |       0 |                   
  @angular_core.js                                |       0 |        0 |       0 |       0 | 1-497             
  chunk-WDMUDEB6.js                               |       0 |        0 |       0 |       0 | 1-51              
 src/app                                          |     100 |      100 |     100 |     100 |                   
  app.ts                                          |     100 |      100 |     100 |     100 |                   
 src/app/menu                                     |     100 |       75 |     100 |     100 |                   
  menu.ts                                         |     100 |       75 |     100 |     100 | 9                 
--------------------------------------------------|---------|----------|---------|---------|-------------------
```

## What is the new behavior?

The instrumentation filter now excludes files in the .angular directory in addition to node_modules.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
