### PR TITLE
fix(@angular/build): mark InjectionToken as pure for improved treeshaking

### DIFF
--- a/packages/angular/build/src/tools/esbuild/javascript-transformer-worker.ts
+++ b/packages/angular/build/src/tools/esbuild/javascript-transformer-worker.ts
@@ -78,21 +78,19 @@ async function transformWithBabel(
   }
 
   if (options.advancedOptimizations) {
+    const { adjustStaticMembers, adjustTypeScriptEnums, elideAngularMetadata, markTopLevelPure } =
+      await import('../babel/plugins');
+
     const sideEffectFree = options.sideEffects === false;
     const safeAngularPackage =
       sideEffectFree && /[\\/]node_modules[\\/]@angular[\\/]/.test(filename);
 
-    const { adjustStaticMembers, adjustTypeScriptEnums, elideAngularMetadata, markTopLevelPure } =
-      await import('../babel/plugins');
-
-    if (safeAngularPackage) {
-      plugins.push(markTopLevelPure);
-    }
-
-    plugins.push(elideAngularMetadata, adjustTypeScriptEnums, [
-      adjustStaticMembers,
-      { wrapDecorators: sideEffectFree },
-    ]);
+    plugins.push(
+      [markTopLevelPure, { topLevelSafeMode: !safeAngularPackage }],
+      elideAngularMetadata,
+      adjustTypeScriptEnums,
+      [adjustStaticMembers, { wrapDecorators: sideEffectFree }],
+    );
   }
 
   // If no additional transformations are needed, return the data directly

--- a/packages/angular_devkit/build_angular/src/tools/babel/presets/application.ts
+++ b/packages/angular_devkit/build_angular/src/tools/babel/presets/application.ts
@@ -57,7 +57,7 @@ export interface ApplicationPresetOptions {
     inputSourceMap: unknown;
   };
   optimize?: {
-    pureTopLevel: boolean;
+    topLevelSafeMode: boolean;
     wrapDecorators: boolean;
   };
 
@@ -220,14 +220,12 @@ export default function (api: unknown, options: ApplicationPresetOptions) {
       elideAngularMetadata,
       markTopLevelPure,
     } = require('@angular/build/private');
-    if (options.optimize.pureTopLevel) {
-      plugins.push(markTopLevelPure);
-    }
-
-    plugins.push(elideAngularMetadata, adjustTypeScriptEnums, [
-      adjustStaticMembers,
-      { wrapDecorators: options.optimize.wrapDecorators },
-    ]);
+    plugins.push(
+      [markTopLevelPure, { topLevelSafeMode: options.optimize.topLevelSafeMode }],
+      elideAngularMetadata,
+      adjustTypeScriptEnums,
+      [adjustStaticMembers, { wrapDecorators: options.optimize.wrapDecorators }],
+    );
   }
 
   if (options.instrumentCode) {

--- a/packages/angular_devkit/build_angular/src/tools/babel/webpack-loader.ts
+++ b/packages/angular_devkit/build_angular/src/tools/babel/webpack-loader.ts
@@ -138,7 +138,7 @@ export default custom<ApplicationPresetOptions>(() => {
         customOptions.optimize = {
           // Angular packages provide additional tested side effects guarantees and can use
           // otherwise unsafe optimizations. (@angular/platform-server/init) however has side-effects.
-          pureTopLevel: AngularPackage && sideEffectFree,
+          topLevelSafeMode: !(AngularPackage && sideEffectFree),
           // JavaScript modules that are marked as side effect free are considered to have
           // no decorators that contain non-local effects.
           wrapDecorators: sideEffectFree,


### PR DESCRIPTION


`new InjectionToken(...)` is not considered pure by default by build tools, which prevents it from being tree-shaken when unused. This can lead to unused services being included in production bundles if they are provided as a default value for a token.

This change marks `new InjectionToken(...)` calls as pure. The `InjectionToken` constructor is side-effect free; its only purpose is to create a token for the dependency injection system. Marking it as pure is safe and  allows build tools like esbuild to tree-shake unused tokens and their dependencies.

Closes https://github.com/angular/angular-cli/issues/31270