### PR TITLE
fix(@schematics/angular): remove browser field from generated angular.json

### DIFF
--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -295,7 +295,6 @@ function addAppToWorkspaceFile(options: ApplicationOptions, appDir: string): Rul
         builder: Builders.BuildApplication,
         defaultConfiguration: 'production',
         options: {
-          browser: `${sourceRoot}/main.ts`,
           polyfills: options.zoneless ? undefined : ['zone.js'],
           tsConfig: `${projectRoot}tsconfig.app.json`,
           inlineStyleLanguage,

--- a/packages/schematics/angular/application/index_spec.ts
+++ b/packages/schematics/angular/application/index_spec.ts
@@ -387,7 +387,6 @@ describe('Application Schematic', () => {
       expect(prj.root).toEqual('');
       const buildOpt = prj.architect.build.options;
       expect(buildOpt.index).toBeUndefined();
-      expect(buildOpt.browser).toEqual('src/main.ts');
       expect(buildOpt.assets).toEqual([{ 'glob': '**/*', 'input': 'public' }]);
       expect(buildOpt.polyfills).toBeUndefined();
       expect(buildOpt.tsConfig).toEqual('tsconfig.app.json');
@@ -477,7 +476,6 @@ describe('Application Schematic', () => {
       const project = config.projects.foo;
       expect(project.root).toEqual('foo');
       const buildOpt = project.architect.build.options;
-      expect(buildOpt.browser).toEqual('foo/src/main.ts');
       expect(buildOpt.polyfills).toBeUndefined();
       expect(buildOpt.tsConfig).toEqual('foo/tsconfig.app.json');
       expect(buildOpt.assets).toEqual([{ 'glob': '**/*', 'input': 'foo/public' }]);


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [ ] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

The browser field is now optional with a default value of 'src/main.ts' as of commit c560d440d. 

## What is the new behavior?

This remove the explicit browser field from the application schematic template since it's no longer needed.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
