### PR TITLE
fix(@angular/cli): improve JSON schema parsing for command options

### DIFF
--- a/packages/angular/build/src/builders/unit-test/schema.json
+++ b/packages/angular/build/src/builders/unit-test/schema.json
@@ -72,7 +72,16 @@
       "items": {
         "oneOf": [
           {
-            "$ref": "#/definitions/coverage-reporters"
+            "enum": [
+              "html",
+              "lcov",
+              "lcovonly",
+              "text",
+              "text-summary",
+              "cobertura",
+              "json",
+              "json-summary"
+            ]
           },
           {
             "type": "array",
@@ -80,7 +89,16 @@
             "maxItems": 2,
             "items": [
               {
-                "$ref": "#/definitions/coverage-reporters"
+                "enum": [
+                  "html",
+                  "lcov",
+                  "lcovonly",
+                  "text",
+                  "text-summary",
+                  "cobertura",
+                  "json",
+                  "json-summary"
+                ]
               },
               {
                 "type": "object"
@@ -98,10 +116,10 @@
           {
             "anyOf": [
               {
-                "$ref": "#/definitions/reporters-enum"
+                "type": "string"
               },
               {
-                "type": "string"
+                "enum": ["default", "verbose", "dots", "json", "junit", "tap", "tap-flat", "html"]
               }
             ]
           },
@@ -113,10 +131,19 @@
               {
                 "anyOf": [
                   {
-                    "$ref": "#/definitions/reporters-enum"
+                    "type": "string"
                   },
                   {
-                    "type": "string"
+                    "enum": [
+                      "default",
+                      "verbose",
+                      "dots",
+                      "json",
+                      "junit",
+                      "tap",
+                      "tap-flat",
+                      "html"
+                    ]
                   }
                 ]
               },
@@ -161,23 +188,5 @@
     }
   },
   "additionalProperties": false,
-  "required": ["buildTarget", "tsConfig", "runner"],
-  "definitions": {
-    "coverage-reporters": {
-      "enum": [
-        "html",
-        "lcov",
-        "lcovonly",
-        "text",
-        "text-summary",
-        "cobertura",
-        "json",
-        "json-summary"
-      ]
-    },
-    "reporters-enum": {
-      "type": "string",
-      "enum": ["default", "verbose", "dots", "json", "junit", "tap", "tap-flat", "html"]
-    }
-  }
+  "required": ["buildTarget", "tsConfig", "runner"]
 }


### PR DESCRIPTION
The JSON schema parsing for command options has been refactored to be more robust and handle more complex schemas. This includes better support for arrays, enums within 'oneOf' and 'anyOf'.

The schema definitions in packages/angular/build/src/builders/unit-test/schema.json have been removed as these are not resolved at this stage of schema processing.
