### PR TITLE
fix(@schematics/angular): use bracket notation for `process.env['pm_id']`

### DIFF
--- a/packages/schematics/angular/ssr/files/application-builder/server.ts.template
+++ b/packages/schematics/angular/ssr/files/application-builder/server.ts.template
@@ -51,7 +51,7 @@ app.use((req, res, next) => {
  * Start the server if this module is the main entry point, or it is ran via PM2.
  * The server listens on the port defined by the `PORT` environment variable, or defaults to 4000.
  */
-if (isMainModule(import.meta.url) || process.env.pm_id) {
+if (isMainModule(import.meta.url) || process.env['pm_id']) {
   const port = process.env['PORT'] || 4000;
   app.listen(port, (error) => {
     if (error) {


### PR DESCRIPTION

The property `pm_id` on `process.env` comes from an index signature, so it must be accessed with bracket notation (`['pm_id']`) to avoid TypeScript errors. This change corrects the access to `process.env['pm_id']` in the SSR server template.

`pm_id` is an environment variable that is set by PN2.

