### PR TITLE
feat(@schematics/angular): add AGENTS.md support to ai-config schematic

### DIFF
--- a/packages/schematics/angular/ai-config/index.ts
+++ b/packages/schematics/angular/ai-config/index.ts
@@ -20,6 +20,10 @@ import {
 import { Schema as ConfigOptions, Tool } from './schema';
 
 const AI_TOOLS: { [key in Exclude<Tool, Tool.None>]: ContextFileInfo } = {
+  agents: {
+    rulesName: 'AGENTS.md',
+    directory: '.',
+  },
   gemini: {
     rulesName: 'GEMINI.md',
     directory: '.gemini',

--- a/packages/schematics/angular/ai-config/index_spec.ts
+++ b/packages/schematics/angular/ai-config/index_spec.ts
@@ -31,6 +31,11 @@ describe('Ai Config Schematic', () => {
     workspaceTree = await schematicRunner.runSchematic('workspace', workspaceOptions);
   });
 
+  it('should create an AGENTS.md file', async () => {
+    const tree = await runConfigSchematic([ConfigTool.Agents]);
+    expect(tree.exists('AGENTS.md')).toBeTruthy();
+  });
+
   it('should create a GEMINI.MD file', async () => {
     const tree = await runConfigSchematic([ConfigTool.Gemini]);
     expect(tree.exists('.gemini/GEMINI.md')).toBeTruthy();

--- a/packages/schematics/angular/ai-config/schema.json
+++ b/packages/schematics/angular/ai-config/schema.json
@@ -19,6 +19,10 @@
             "label": "None"
           },
           {
+            "value": "agents",
+            "label": "Agents.md      [ https://agents.md/                                               ]"
+          },
+          {
             "value": "claude",
             "label": "Claude         [ https://docs.anthropic.com/en/docs/claude-code/memory            ]"
           },
@@ -47,7 +51,7 @@
       "description": "Specifies which AI tools to generate configuration files for. These file are used to improve the outputs of AI tools by following the best practices.",
       "items": {
         "type": "string",
-        "enum": ["none", "gemini", "copilot", "claude", "cursor", "jetbrains", "windsurf"]
+        "enum": ["none", "gemini", "copilot", "claude", "cursor", "jetbrains", "windsurf", "agents"]
       }
     }
   }

--- a/packages/schematics/angular/ng-new/schema.json
+++ b/packages/schematics/angular/ng-new/schema.json
@@ -149,7 +149,7 @@
       "description": "Specifies which AI tools to generate configuration files for. These file are used to improve the outputs of AI tools by following the best practices.",
       "items": {
         "type": "string",
-        "enum": ["none", "gemini", "copilot", "claude", "cursor", "jetbrains", "windsurf"]
+        "enum": ["none", "gemini", "copilot", "claude", "cursor", "jetbrains", "windsurf", "agents"]
       }
     },
     "fileNameStyleGuide": {


### PR DESCRIPTION
This change introduces support for generating an `AGENTS.md` file via the `ng generate ai-config` schematic. The `AGENTS.md` standard is an emerging convention for providing instructions to AI agents that operate within a codebase.

By adding this option, users can easily create a root-level `AGENTS.md` file, helping to configure AI agents with project-specific guidelines and best practices.

The implementation includes:
- Updating the schematic's `schema.json` to include `agents` as a selectable tool.
- Extending the logic in `index.ts` to handle the creation and placement of the file.
- Adding a unit test to ensure the file is generated correctly.