### PR TITLE
feat(@angular/cli): overhaul `ng version` command output

### DIFF
--- a/packages/angular/cli/src/commands/version/version-info.ts
+++ b/packages/angular/cli/src/commands/version/version-info.ts
@@ -24,8 +24,6 @@ interface PartialPackageInfo {
  */
 export interface VersionInfo {
   ngCliVersion: string;
-  angularCoreVersion: string;
-  angularSameAsCore: string[];
   versions: Record<string, string>;
   unsupportedNodeVersion: boolean;
   nodeVersion: string;
@@ -90,30 +88,8 @@ export function gatherVersionInfo(context: {
     }
   }
 
-  const ngCliVersion = VERSION.full;
-  let angularCoreVersion = '';
-  const angularSameAsCore: string[] = [];
-
-  if (workspacePackage) {
-    // Filter all angular versions that are the same as core.
-    angularCoreVersion = versions['@angular/core'];
-    if (angularCoreVersion) {
-      for (const [name, version] of Object.entries(versions)) {
-        if (version === angularCoreVersion && name.startsWith('@angular/')) {
-          angularSameAsCore.push(name.replace(/^@angular\//, ''));
-          delete versions[name];
-        }
-      }
-
-      // Make sure we list them in alphabetical order.
-      angularSameAsCore.sort();
-    }
-  }
-
   return {
-    ngCliVersion,
-    angularCoreVersion,
-    angularSameAsCore,
+    ngCliVersion: VERSION.full,
     versions,
     unsupportedNodeVersion,
     nodeVersion: process.versions.node,


### PR DESCRIPTION
This commit completely revamps the `ng version` command's output for a more modern and readable experience.

The key improvements include:
- A single, unified table for all packages, removing the separate Angular section.
- A polished table format using box-drawing characters and consistent padding.
- An improved header section with aligned, bolded, and more formal labels.
- The use of color to highlight version numbers and other key information, improving scannability.
- Version lookup errors are now highlighted in red for better visibility.

The header generation logic is also refactored to be more maintainable by removing repeated label strings.