### PR TITLE
refactor(@angular/cli): improve output format for `ng cache info` command

### DIFF
--- a/tests/legacy-cli/e2e/tests/commands/cache/cache-info.ts
+++ b/tests/legacy-cli/e2e/tests/commands/cache/cache-info.ts
@@ -7,59 +7,31 @@ export default async function () {
   try {
     // Should be enabled by default for local builds.
     await configureTest('0' /** envCI */);
-    await execAndWaitForOutputToMatch(
-      'ng',
-      ['cache', 'info'],
-      /Effective status on current machine: enabled/,
-    );
+    await execAndWaitForOutputToMatch('ng', ['cache', 'info'], /Effective Status\s*: Enabled/);
 
     // Should be disabled by default for CI builds.
     await configureTest('1' /** envCI */, { enabled: true });
-    await execAndWaitForOutputToMatch(
-      'ng',
-      ['cache', 'info'],
-      /Effective status on current machine: disabled/,
-    );
+    await execAndWaitForOutputToMatch('ng', ['cache', 'info'], /Effective Status\s*: Disabled/);
 
     // Should be enabled by when environment is local and env is not CI.
     await configureTest('0' /** envCI */, { environment: 'local' });
-    await execAndWaitForOutputToMatch(
-      'ng',
-      ['cache', 'info'],
-      /Effective status on current machine: enabled/,
-    );
+    await execAndWaitForOutputToMatch('ng', ['cache', 'info'], /Effective Status\s*: Enabled/);
 
     // Should be disabled by when environment is local and env is CI.
     await configureTest('1' /** envCI */, { environment: 'local' });
-    await execAndWaitForOutputToMatch(
-      'ng',
-      ['cache', 'info'],
-      /Effective status on current machine: disabled/,
-    );
+    await execAndWaitForOutputToMatch('ng', ['cache', 'info'], /Effective Status\s*: Disabled/);
 
     // Effective status should be enabled when 'environment' is set to 'all' or 'ci'.
     await configureTest('1' /** envCI */, { environment: 'all' });
-    await execAndWaitForOutputToMatch(
-      'ng',
-      ['cache', 'info'],
-      /Effective status on current machine: enabled/,
-    );
+    await execAndWaitForOutputToMatch('ng', ['cache', 'info'], /Effective Status\s*: Enabled/);
 
     // Effective status should be enabled when 'environment' is set to 'ci' and run is in ci
     await configureTest('1' /** envCI */, { environment: 'ci' });
-    await execAndWaitForOutputToMatch(
-      'ng',
-      ['cache', 'info'],
-      /Effective status on current machine: enabled/,
-    );
+    await execAndWaitForOutputToMatch('ng', ['cache', 'info'], /Effective Status\s*: Enabled/);
 
     // Effective status should be disabled when 'enabled' is set to false
     await configureTest('1' /** envCI */, { environment: 'all', enabled: false });
-    await execAndWaitForOutputToMatch(
-      'ng',
-      ['cache', 'info'],
-      /Effective status on current machine: disabled/,
-    );
+    await execAndWaitForOutputToMatch('ng', ['cache', 'info'], /Effective Status\s*: Disabled/);
   } finally {
     process.env['CI'] = originalCIValue;
   }


### PR DESCRIPTION
This commit refactors the output to be more user-friendly and consistent with other commands like `ng version`. It introduces a clean, aligned, two-column layout with colors to improve readability.

- Labels are now bolded for emphasis.
- Values are colored for clarity (cyan for general info, green/red for statuses).
- The layout is padded to ensure vertical alignment, making the information easier to scan.