### PR TITLE
refactor(@angular/build): automatically enable headless mode in CI for vitest

### DIFF
--- a/packages/angular/build/src/builders/unit-test/runners/vitest/browser-provider.ts
+++ b/packages/angular/build/src/builders/unit-test/runners/vitest/browser-provider.ts
@@ -83,15 +83,18 @@ export function setupBrowserConfiguration(
     return { errors };
   }
 
+  const isCI = !!process.env['CI'];
+  const headless = isCI || browsers.some((name) => name.toLowerCase().includes('headless'));
+
   const browser = {
     enabled: true,
     provider,
-    headless: browsers.some((name) => name.toLowerCase().includes('headless')),
-
+    headless,
+    ui: !headless,
     instances: browsers.map((browserName) => ({
       browser: normalizeBrowserName(browserName),
     })),
-  };
+  } satisfies import('vitest/node').BrowserConfigOptions;
 
   return { browser };
 }


### PR DESCRIPTION
The Vitest browser provider configuration is updated to be more intelligent in automated environments.

Previously, headless mode was only triggered if the browser name included headless. This change automatically enables headless mode when the `CI` environment variable is detected, which is standard practice for continuous integration pipelines.

Additionally, the `ui` property is now explicitly set to the inverse of the `headless` state, preventing the Vitest UI from attempting to render in a non-interactive environment. A `satisfies` clause has also been added to improve type safety against the Vitest configuration options.