### PR TITLE
refactor(@angular/build): make buildTarget optional in unit-test builder

### DIFF
--- a/goldens/public-api/angular/build/index.api.md
+++ b/goldens/public-api/angular/build/index.api.md
@@ -216,7 +216,7 @@ export type NgPackagrBuilderOptions = {
 // @public
 export type UnitTestBuilderOptions = {
     browsers?: string[];
-    buildTarget: string;
+    buildTarget?: string;
     coverage?: boolean;
     coverageAll?: boolean;
     coverageExclude?: string[];

--- a/packages/angular/build/src/builders/unit-test/schema.json
+++ b/packages/angular/build/src/builders/unit-test/schema.json
@@ -6,7 +6,7 @@
   "properties": {
     "buildTarget": {
       "type": "string",
-      "description": "Specifies the build target to use for the unit test build in the format `project:target[:configuration]`. You can also pass a comma-separated list of configurations. Example: `project:target:production,staging`.",
+      "description": "Specifies the build target to use for the unit test build in the format `project:target[:configuration]`. This defaults to the `build` target of the current project with the `development` configuration. You can also pass a comma-separated list of configurations. Example: `project:target:production,staging`.",
       "pattern": "^[^:\\s]*:[^:\\s]*(:[^\\s]+)?$"
     },
     "tsConfig": {
@@ -262,5 +262,5 @@
     }
   },
   "additionalProperties": false,
-  "required": ["buildTarget", "runner"]
+  "required": ["runner"]
 }


### PR DESCRIPTION
The `buildTarget` option in the `unit-test` builder is now optional to streamline the user configuration.

If the `buildTarget` option is not provided, the builder now defaults to using the `build` target with the `development` configuration for the current project. This change significantly reduces the boilerplate configuration needed in `angular.json` for most projects, as the builder can now infer the correct build settings by convention.

The builder's schema has been updated to reflect this change by removing `buildTarget` from the required properties and updating its description to document the new default behavior.