### PR TITLE
feat(@angular/cli): add builder info to list_projects MCP tool 

### DIFF
--- a/packages/angular/cli/src/commands/mcp/tools/projects.ts
+++ b/packages/angular/cli/src/commands/mcp/tools/projects.ts
@@ -34,6 +34,10 @@ const listProjectsOutputSchema = {
             .enum(['application', 'library'])
             .optional()
             .describe(`The type of the project, either 'application' or 'library'.`),
+          builder: z
+            .string()
+            .optional()
+            .describe('The primary builder for the project, typically from the "build" target.'),
           root: z
             .string()
             .describe('The root directory of the project, relative to the workspace root.'),
@@ -90,6 +94,7 @@ their types, and their locations.
 * Determining if a project is an \`application\` or a \`library\`.
 * Getting the \`selectorPrefix\` for a project before generating a new component to ensure it follows conventions.
 * Identifying the major version of the Angular framework for each workspace, which is crucial for monorepos.
+* Determining a project's primary function by inspecting its builder (e.g., '@angular-devkit/build-angular:browser' for an application).
 </Use Cases>
 <Operational Notes>
 * **Working Directory:** Shell commands for a project (like \`ng generate\`) **MUST**
@@ -253,6 +258,7 @@ async function loadAndParseWorkspace(
       projects.push({
         name,
         type: project.extensions['projectType'] as 'application' | 'library' | undefined,
+        builder: project.targets.get('build')?.builder,
         root: project.root,
         sourceRoot: project.sourceRoot ?? path.posix.join(project.root, 'src'),
         selectorPrefix: project.extensions['prefix'] as string,


### PR DESCRIPTION
The `list_projects` tool is enhanced to include the primary builder for each project, providing more specific metadata about its function.

The builder is extracted from the project's 'build' target and added as an optional 'builder' field to the output. This allows users and other tools to quickly determine a project's type (e.g., application, library) by inspecting its builder string.

The tool's description has also been updated to reflect this new capability.