### PR TITLE
fix(@angular/build): disable glob directory expansion when finding tests

### DIFF
--- a/packages/angular/build/src/builders/unit-test/test-discovery.ts
+++ b/packages/angular/build/src/builders/unit-test/test-discovery.ts
@@ -54,6 +54,7 @@ export async function findTests(
     const globMatches = await glob(dynamicPatterns, {
       cwd: projectSourceRoot,
       absolute: true,
+      expandDirectories: false,
       ignore: ['**/node_modules/**', ...normalizedExcludes],
     });
 


### PR DESCRIPTION
When migrating the glob package to `tinyglobby` the `expandDirectories` option was left at its default value of `true`. This differs from the previous behavior and can inadvertently cause files that are not expected to be included to show up as tests.

Closes #31280