### PR TITLE
fix(@schematics/angular): remove extra space before async in spec templates

### DIFF
--- a/packages/schematics/angular/application/files/module-files/src/app/app__suffix__.spec.ts.template
+++ b/packages/schematics/angular/application/files/module-files/src/app/app__suffix__.spec.ts.template
@@ -20,7 +20,7 @@ describe('App', () => {
     expect(app).toBeTruthy();
   });
 
-  it('should render title', <% if(zoneless) { %> async <% } %>() => {
+  it('should render title', <% if(zoneless) { %>async <% } %>() => {
     const fixture = TestBed.createComponent(App);
     <%= zoneless ? 'await fixture.whenStable();' : 'fixture.detectChanges();' %>
     const compiled = fixture.nativeElement as HTMLElement;

--- a/packages/schematics/angular/application/files/standalone-files/src/app/app__suffix__.spec.ts.template
+++ b/packages/schematics/angular/application/files/standalone-files/src/app/app__suffix__.spec.ts.template
@@ -14,7 +14,7 @@ describe('App', () => {
     expect(app).toBeTruthy();
   });
 
-  it('should render title', <% if(zoneless) { %> async <% } %>() => {
+  it('should render title', <% if(zoneless) { %>async <% } %>() => {
     const fixture = TestBed.createComponent(App);
     <%= zoneless ? 'await fixture.whenStable();' : 'fixture.detectChanges();' %>
     const compiled = fixture.nativeElement as HTMLElement;


### PR DESCRIPTION
## PR Checklist

Please check to confirm your PR fulfills the following requirements:

<!-- Please check all that apply using "x". -->

- [x] The commit message follows our guidelines: https://github.com/angular/angular-cli/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

There are 2 spaces before async in generated specs https://github.com/cexbrayat/angular-cli-diff/compare/21.0.0-next.5...21.0.0-next.6

## What is the new behavior?

Removes the extra space

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
