### PR TITLE
build: refactor ng_package substitutions

### DIFF
--- a/packages/angular/ssr/BUILD.bazel
+++ b/packages/angular/ssr/BUILD.bazel
@@ -49,6 +49,12 @@ ng_package(
         "@angular/ssr/node",
         "../../third_party/beasties",
     ],
+    extra_substitutions = {
+        # Needed for ssr.d.ts file
+        "\\./third_party/beasties": "../third_party/beasties",
+        # Needed for the FESM file.
+        "\\./(.+)/packages/angular/ssr/third_party/beasties": "../third_party/beasties/index.js",
+    },
     nested_packages = [
         "//packages/angular/ssr/schematics:pkg",
         # Included directly as the generated types reference the types file in this location.

--- a/packages/angular/ssr/test/npm_package/package_spec.ts
+++ b/packages/angular/ssr/test/npm_package/package_spec.ts
@@ -25,10 +25,16 @@ const CRITTERS_ACTUAL_LICENSE_FILE_PATH = join(
 );
 
 describe('NPM Package Tests', () => {
-  it('should not include the contents of third_party/beasties/index.js in the FESM bundle', async () => {
+  it('should not include the contents of `third_party/beasties/index.js` in the FESM bundle', async () => {
     const fesmFilePath = join(ANGULAR_SSR_PACKAGE_PATH, 'fesm2022/ssr.mjs');
     const fesmContent = await readFile(fesmFilePath, 'utf-8');
     expect(fesmContent).toContain(`import Beasties from '../third_party/beasties/index.js'`);
+  });
+
+  it('should correctly reference `third_party/beasties` in the ssr types bundle', async () => {
+    const fesmFilePath = join(ANGULAR_SSR_PACKAGE_PATH, 'types/ssr.d.ts');
+    const fesmContent = await readFile(fesmFilePath, 'utf-8');
+    expect(fesmContent).toContain(`import Beasties from '../third_party/beasties'`);
   });
 
   describe('third_party/beasties/THIRD_PARTY_LICENSES.txt', () => {

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -45,13 +45,16 @@ def copy_to_bin(**kwargs):
 def js_binary(**kwargs):
     _js_binary(**kwargs)
 
-def ng_package(deps = [], **kwargs):
+def ng_package(deps = [], extra_substitutions = {}, **kwargs):
+    nostamp_subs = dict(substitutions["nostamp"], **extra_substitutions)
+    stamp_subs = dict(substitutions["stamp"], **extra_substitutions)
+
     _ng_package(
         deps = deps,
         license = "//:LICENSE",
         substitutions = select({
-            "//:stamp": substitutions["stamp"],
-            "//conditions:default": substitutions["nostamp"],
+            "//:stamp": stamp_subs,
+            "//conditions:default": nostamp_subs,
         }),
         **kwargs
     )

--- a/tools/substitutions.bzl
+++ b/tools/substitutions.bzl
@@ -24,8 +24,6 @@ _stamp_substitutions = {
     "0.0.0-NG-PACKAGR-PEER-DEP": NG_PACKAGR_PEER_DEP,
     "0.0.0-ANGULAR-FW-VERSION": ANGULAR_FW_VERSION,
     "0.0.0-ANGULAR-FW-PEER-DEP": ANGULAR_FW_PEER_DEP,
-    # The below is needed for @angular/ssr FESM file.
-    "\\./(.+)/packages/angular/ssr/third_party/beasties": "../third_party/beasties/index.js",
 }
 
 _no_stamp_substitutions = dict(_stamp_substitutions, **{


### PR DESCRIPTION
This refactoring moves the substitution for `@angular/ssr` and `beasties` from a global configuration to a local one within the `@angular/ssr` package definition.

This is achieved by introducing an `extra_substitutions` parameter to the `ng_package` function, allowing package-specific substitutions to be defined. This change improves modularity and removes hardcoded paths from the global substitution rules, making the build system cleaner and easier to maintain.

Additionally, this fixes an issue where the generated TypeScript definition files (.d.ts) for `@angular/ssr` had incorrect relative paths for the `beasties` dependency, causing type resolution failures in consuming projects. The new local substitution corrects these paths.

