### PR TITLE
feat(@schematics/angular): introduce initial jasmine-to-vitest unit test refactor schematic

### DIFF
--- a/packages/schematics/angular/BUILD.bazel
+++ b/packages/schematics/angular/BUILD.bazel
@@ -20,7 +20,10 @@ ALL_SCHEMA_TARGETS = [
         x.replace("/", "_").replace("-", "_").replace(".json", ""),
     )
     for x in glob(
-        include = ["*/schema.json"],
+        include = [
+            "*/schema.json",
+            "refactor/*/schema.json",
+        ],
         exclude = [
             # NB: we need to exclude the nested node_modules that is laid out by yarn workspaces
             "node_modules/**",
@@ -55,6 +58,7 @@ RUNTIME_ASSETS = [
         "*/type-files/**/*",
         "*/functional-files/**/*",
         "*/class-files/**/*",
+        "refactor/*/schema.json",
     ],
     exclude = [
         # NB: we need to exclude the nested node_modules that is laid out by yarn workspaces
@@ -123,6 +127,7 @@ ts_project(
         ":node_modules/jsonc-parser",
         "//:node_modules/@types/jasmine",
         "//:node_modules/@types/node",
+        "//:node_modules/prettier",
         "//packages/schematics/angular/third_party/github.com/Microsoft/TypeScript",
     ],
 )

--- a/packages/schematics/angular/collection.json
+++ b/packages/schematics/angular/collection.json
@@ -143,6 +143,12 @@
       "hidden": true,
       "private": true,
       "description": "[INTERNAL] Adds tailwind to a project. Intended for use for ng new/add."
+    },
+    "jasmine-to-vitest": {
+      "factory": "./refactor/jasmine-vitest",
+      "schema": "./refactor/jasmine-vitest/schema.json",
+      "description": "[EXPERIMENTAL] Refactors Jasmine tests to use Vitest APIs.",
+      "hidden": true
     }
   }
 }

--- a/packages/schematics/angular/refactor/jasmine-vitest/index.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/index.ts
@@ -1,0 +1,101 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import {
+  DirEntry,
+  Rule,
+  SchematicContext,
+  SchematicsException,
+  Tree,
+} from '@angular-devkit/schematics';
+import { ProjectDefinition, getWorkspace } from '../../utility/workspace';
+import { Schema } from './schema';
+import { transformJasmineToVitest } from './test-file-transformer';
+import { RefactorReporter } from './utils/refactor-reporter';
+
+async function getProjectRoot(tree: Tree, projectName: string | undefined): Promise<string> {
+  const workspace = await getWorkspace(tree);
+
+  let project: ProjectDefinition | undefined;
+  if (projectName) {
+    project = workspace.projects.get(projectName);
+    if (!project) {
+      throw new SchematicsException(`Project "${projectName}" not found.`);
+    }
+  } else {
+    if (workspace.projects.size === 1) {
+      project = workspace.projects.values().next().value;
+    } else {
+      const projectNames = Array.from(workspace.projects.keys());
+      throw new SchematicsException(
+        `Multiple projects found: [${projectNames.join(', ')}]. Please specify a project name.`,
+      );
+    }
+  }
+
+  if (!project) {
+    // This case should theoretically not be hit due to the checks above, but it's good for type safety.
+    throw new SchematicsException('Could not determine a project.');
+  }
+
+  return project.root;
+}
+
+const DIRECTORIES_TO_SKIP = new Set(['node_modules', '.git', 'dist', '.angular']);
+
+function findTestFiles(directory: DirEntry, fileSuffix: string): string[] {
+  const files: string[] = [];
+  const stack: DirEntry[] = [directory];
+
+  let current: DirEntry | undefined;
+  while ((current = stack.pop())) {
+    for (const path of current.subfiles) {
+      if (path.endsWith(fileSuffix)) {
+        files.push(current.path + '/' + path);
+      }
+    }
+
+    for (const path of current.subdirs) {
+      if (DIRECTORIES_TO_SKIP.has(path)) {
+        continue;
+      }
+      stack.push(current.dir(path));
+    }
+  }
+
+  return files;
+}
+
+export default function (options: Schema): Rule {
+  return async (tree: Tree, context: SchematicContext) => {
+    const reporter = new RefactorReporter(context.logger);
+    const projectRoot = await getProjectRoot(tree, options.project);
+    const fileSuffix = options.fileSuffix ?? '.spec.ts';
+
+    const files = findTestFiles(tree.getDir(projectRoot), fileSuffix);
+
+    if (files.length === 0) {
+      throw new SchematicsException(
+        `No files ending with '${fileSuffix}' found in project '${options.project}'.`,
+      );
+    }
+
+    for (const file of files) {
+      reporter.incrementScannedFiles();
+      const content = tree.readText(file);
+      const newContent = transformJasmineToVitest(file, content, reporter);
+
+      if (content !== newContent) {
+        tree.overwrite(file, newContent);
+        reporter.incrementTransformedFiles();
+      }
+    }
+
+    reporter.printSummary(options.verbose);
+  };
+}

--- a/packages/schematics/angular/refactor/jasmine-vitest/schema.json
+++ b/packages/schematics/angular/refactor/jasmine-vitest/schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "SchematicsAngularJasmineToVitest",
+  "title": "Angular Jasmine to Vitest Schematic",
+  "type": "object",
+  "description": "Refactors a Jasmine test file to use Vitest.",
+  "properties": {
+    "fileSuffix": {
+      "type": "string",
+      "description": "The file suffix to identify test files (e.g., '.spec.ts', '.test.ts').",
+      "default": ".spec.ts"
+    },
+    "project": {
+      "type": "string",
+      "description": "The name of the project where the tests should be refactored. If not specified, the CLI will determine the project from the current directory.",
+      "$default": {
+        "$source": "projectName"
+      }
+    },
+    "verbose": {
+      "type": "boolean",
+      "description": "Enable verbose logging to see detailed information about the transformations being applied.",
+      "default": false
+    }
+  }
+}

--- a/packages/schematics/angular/refactor/jasmine-vitest/test-file-transformer.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/test-file-transformer.ts
@@ -1,0 +1,80 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import ts from '../../third_party/github.com/Microsoft/TypeScript/lib/typescript';
+import {
+  transformDoneCallback,
+  transformFocusedAndSkippedTests,
+  transformPending,
+} from './transformers/jasmine-lifecycle';
+import { RefactorContext } from './utils/refactor-context';
+import { RefactorReporter } from './utils/refactor-reporter';
+
+/**
+ * Transforms a string of Jasmine test code to Vitest test code.
+ * This is the main entry point for the transformation.
+ * @param content The source code to transform.
+ * @param reporter The reporter to track TODOs.
+ * @returns The transformed code.
+ */
+export function transformJasmineToVitest(
+  filePath: string,
+  content: string,
+  reporter: RefactorReporter,
+): string {
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    content,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+
+  const transformer: ts.TransformerFactory<ts.SourceFile> = (context) => {
+    const refactorCtx: RefactorContext = {
+      sourceFile,
+      reporter,
+      tsContext: context,
+    };
+
+    const visitor: ts.Visitor = (node) => {
+      let transformedNode: ts.Node | readonly ts.Node[] = node;
+
+      // Transform the node itself based on its type
+      if (ts.isCallExpression(transformedNode)) {
+        const transformations = [
+          transformFocusedAndSkippedTests,
+          transformPending,
+          transformDoneCallback,
+        ];
+
+        for (const transformer of transformations) {
+          transformedNode = transformer(transformedNode, refactorCtx);
+        }
+      }
+
+      // Visit the children of the node to ensure they are transformed
+      if (Array.isArray(transformedNode)) {
+        return transformedNode.map((node) => ts.visitEachChild(node, visitor, context));
+      } else {
+        return ts.visitEachChild(transformedNode, visitor, context);
+      }
+    };
+
+    return (node) => ts.visitNode(node, visitor) as ts.SourceFile;
+  };
+
+  const result = ts.transform(sourceFile, [transformer]);
+  if (result.transformed[0] === sourceFile) {
+    return content;
+  }
+
+  const printer = ts.createPrinter();
+
+  return printer.printFile(result.transformed[0]);
+}

--- a/packages/schematics/angular/refactor/jasmine-vitest/transformers/jasmine-lifecycle.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/transformers/jasmine-lifecycle.ts
@@ -1,0 +1,433 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+/**
+ * @fileoverview This file contains transformers that convert Jasmine lifecycle functions
+ * and test setup/teardown patterns to their Vitest equivalents. This includes handling
+ * focused/skipped tests (fdescribe, fit, xdescribe, xit), pending tests, and asynchronous
+ * operations that use the `done` callback.
+ */
+
+import ts from '../../../third_party/github.com/Microsoft/TypeScript/lib/typescript';
+import { createPropertyAccess } from '../utils/ast-helpers';
+import { addTodoComment } from '../utils/comment-helpers';
+import { RefactorContext } from '../utils/refactor-context';
+
+const FOCUSED_SKIPPED_RENAMES = new Map<string, { newBase: string; newName: string }>([
+  ['fdescribe', { newBase: 'describe', newName: 'only' }],
+  ['fit', { newBase: 'it', newName: 'only' }],
+  ['xdescribe', { newBase: 'describe', newName: 'skip' }],
+  ['xit', { newBase: 'it', newName: 'skip' }],
+]);
+
+export function transformFocusedAndSkippedTests(
+  node: ts.Node,
+  { sourceFile, reporter }: RefactorContext,
+): ts.Node {
+  if (!ts.isCallExpression(node) || !ts.isIdentifier(node.expression)) {
+    return node;
+  }
+
+  const oldName = node.expression.text;
+  const rename = FOCUSED_SKIPPED_RENAMES.get(oldName);
+  if (rename) {
+    reporter.reportTransformation(
+      sourceFile,
+      node,
+      `Transformed \`${oldName}\` to \`${rename.newBase}.${rename.newName}\`.`,
+    );
+
+    const newPropAccess = createPropertyAccess(rename.newBase, rename.newName);
+
+    return ts.factory.updateCallExpression(node, newPropAccess, node.typeArguments, node.arguments);
+  }
+
+  return node;
+}
+
+export function transformPending(
+  node: ts.Node,
+  { sourceFile, reporter, tsContext }: RefactorContext,
+): ts.Node {
+  if (
+    !ts.isCallExpression(node) ||
+    !ts.isIdentifier(node.expression) ||
+    node.expression.text !== 'it'
+  ) {
+    return node;
+  }
+
+  const testFn = node.arguments[1];
+  if (!testFn || (!ts.isArrowFunction(testFn) && !ts.isFunctionExpression(testFn))) {
+    return node;
+  }
+
+  let hasPending = false;
+  const bodyTransformVisitor = (bodyNode: ts.Node): ts.Node | undefined => {
+    if (
+      ts.isExpressionStatement(bodyNode) &&
+      ts.isCallExpression(bodyNode.expression) &&
+      ts.isIdentifier(bodyNode.expression.expression) &&
+      bodyNode.expression.expression.text === 'pending'
+    ) {
+      hasPending = true;
+      const replacement = ts.factory.createEmptyStatement();
+      const originalText = bodyNode.getFullText().trim();
+
+      reporter.reportTransformation(
+        sourceFile,
+        bodyNode,
+        'Converted `pending()` to a skipped test (`it.skip`).',
+      );
+      reporter.recordTodo('pending');
+      addTodoComment(
+        replacement,
+        'The pending() function was converted to a skipped test (`it.skip`).',
+      );
+      ts.addSyntheticLeadingComment(
+        replacement,
+        ts.SyntaxKind.SingleLineCommentTrivia,
+        ` ${originalText}`,
+        true,
+      );
+
+      return replacement;
+    }
+
+    return ts.visitEachChild(bodyNode, bodyTransformVisitor, tsContext);
+  };
+
+  const newBody = ts.visitNode(testFn.body, bodyTransformVisitor) as ts.ConciseBody | undefined;
+
+  if (!hasPending) {
+    return node;
+  }
+
+  const newExpression = createPropertyAccess(node.expression, 'skip');
+  const newTestFn = ts.isArrowFunction(testFn)
+    ? ts.factory.updateArrowFunction(
+        testFn,
+        testFn.modifiers,
+        testFn.typeParameters,
+        testFn.parameters,
+        testFn.type,
+        testFn.equalsGreaterThanToken,
+        newBody ?? ts.factory.createBlock([]),
+      )
+    : ts.factory.updateFunctionExpression(
+        testFn,
+        testFn.modifiers,
+        testFn.asteriskToken,
+        testFn.name,
+        testFn.typeParameters,
+        testFn.parameters,
+        testFn.type,
+        (newBody as ts.Block) ?? ts.factory.createBlock([]),
+      );
+
+  const newArgs = [node.arguments[0], newTestFn, ...node.arguments.slice(2)];
+
+  return ts.factory.updateCallExpression(node, newExpression, node.typeArguments, newArgs);
+}
+
+function transformComplexDoneCallback(
+  node: ts.Node,
+  doneIdentifier: ts.Identifier,
+  refactorCtx: RefactorContext,
+): ts.Node | ts.Node[] | undefined {
+  const { sourceFile, reporter } = refactorCtx;
+  if (
+    !ts.isExpressionStatement(node) ||
+    !ts.isCallExpression(node.expression) ||
+    !ts.isPropertyAccessExpression(node.expression.expression)
+  ) {
+    return node;
+  }
+
+  const call = node.expression;
+  const pae = call.expression;
+
+  if (!ts.isPropertyAccessExpression(pae)) {
+    return node;
+  }
+
+  if (pae.name.text !== 'then' || call.arguments.length !== 1) {
+    return node;
+  }
+
+  const thenCallback = call.arguments[0];
+  if (!ts.isArrowFunction(thenCallback) && !ts.isFunctionExpression(thenCallback)) {
+    return node;
+  }
+
+  // Re-create the .then() call but with a modified callback that has `done()` removed.
+  const thenCallbackBody = ts.isBlock(thenCallback.body)
+    ? thenCallback.body
+    : ts.factory.createBlock([ts.factory.createExpressionStatement(thenCallback.body)]);
+
+  const newStatements = thenCallbackBody.statements.filter((stmt) => {
+    return (
+      !ts.isExpressionStatement(stmt) ||
+      !ts.isCallExpression(stmt.expression) ||
+      !ts.isIdentifier(stmt.expression.expression) ||
+      stmt.expression.expression.text !== doneIdentifier.text
+    );
+  });
+
+  if (newStatements.length === thenCallbackBody.statements.length) {
+    // No "done()" call was removed, so don't transform.
+    return node;
+  }
+
+  reporter.reportTransformation(
+    sourceFile,
+    node,
+    'Transformed promise `.then()` with `done()` to `await`.',
+  );
+
+  const newThenCallback = ts.isArrowFunction(thenCallback)
+    ? ts.factory.updateArrowFunction(
+        thenCallback,
+        thenCallback.modifiers,
+        thenCallback.typeParameters,
+        thenCallback.parameters,
+        thenCallback.type,
+        thenCallback.equalsGreaterThanToken,
+        ts.factory.updateBlock(thenCallbackBody, newStatements),
+      )
+    : ts.factory.updateFunctionExpression(
+        thenCallback,
+        thenCallback.modifiers,
+        thenCallback.asteriskToken,
+        thenCallback.name,
+        thenCallback.typeParameters,
+        thenCallback.parameters,
+        thenCallback.type,
+        ts.factory.updateBlock(thenCallbackBody, newStatements),
+      );
+
+  const newCall = ts.factory.updateCallExpression(call, call.expression, call.typeArguments, [
+    newThenCallback,
+  ]);
+
+  return ts.factory.createExpressionStatement(ts.factory.createAwaitExpression(newCall));
+}
+
+function transformPromiseBasedDone(
+  callExpr: ts.CallExpression,
+  doneIdentifier: ts.Identifier,
+  refactorCtx: RefactorContext,
+): ts.Node | undefined {
+  const { sourceFile, reporter } = refactorCtx;
+  if (
+    ts.isPropertyAccessExpression(callExpr.expression) &&
+    (callExpr.expression.name.text === 'then' || callExpr.expression.name.text === 'catch')
+  ) {
+    const promiseHandler = callExpr.arguments[0];
+    if (promiseHandler) {
+      let isDoneHandler = false;
+      // promise.then(done)
+      if (ts.isIdentifier(promiseHandler) && promiseHandler.text === doneIdentifier.text) {
+        isDoneHandler = true;
+      }
+      // promise.catch(done.fail)
+      if (
+        ts.isPropertyAccessExpression(promiseHandler) &&
+        ts.isIdentifier(promiseHandler.expression) &&
+        promiseHandler.expression.text === doneIdentifier.text &&
+        promiseHandler.name.text === 'fail'
+      ) {
+        isDoneHandler = true;
+      }
+      // promise.then(() => done())
+      if (ts.isArrowFunction(promiseHandler) && !promiseHandler.parameters.length) {
+        const body = promiseHandler.body;
+        if (
+          ts.isCallExpression(body) &&
+          ts.isIdentifier(body.expression) &&
+          body.expression.text === doneIdentifier.text
+        ) {
+          isDoneHandler = true;
+        }
+        if (ts.isBlock(body) && body.statements.length === 1) {
+          const stmt = body.statements[0];
+          if (
+            ts.isExpressionStatement(stmt) &&
+            ts.isCallExpression(stmt.expression) &&
+            ts.isIdentifier(stmt.expression.expression) &&
+            stmt.expression.expression.text === doneIdentifier.text
+          ) {
+            isDoneHandler = true;
+          }
+        }
+      }
+
+      if (isDoneHandler) {
+        reporter.reportTransformation(
+          sourceFile,
+          callExpr,
+          'Transformed promise `.then(done)` to `await`.',
+        );
+
+        return ts.factory.createExpressionStatement(
+          ts.factory.createAwaitExpression(callExpr.expression.expression),
+        );
+      }
+    }
+  }
+
+  return undefined;
+}
+
+export function transformDoneCallback(node: ts.Node, refactorCtx: RefactorContext): ts.Node {
+  const { sourceFile, reporter, tsContext } = refactorCtx;
+  if (
+    !ts.isCallExpression(node) ||
+    !ts.isIdentifier(node.expression) ||
+    !['it', 'beforeEach', 'afterEach', 'beforeAll', 'afterAll'].includes(node.expression.text)
+  ) {
+    return node;
+  }
+
+  const functionArg = node.arguments.find(
+    (arg) => ts.isArrowFunction(arg) || ts.isFunctionExpression(arg),
+  );
+
+  if (!functionArg || (!ts.isArrowFunction(functionArg) && !ts.isFunctionExpression(functionArg))) {
+    return node;
+  }
+
+  if (functionArg.parameters.length !== 1) {
+    return node;
+  }
+
+  const doneParam = functionArg.parameters[0];
+  if (!ts.isIdentifier(doneParam.name)) {
+    return node;
+  }
+  const doneIdentifier = doneParam.name;
+  let doneWasUsed = false;
+
+  const bodyVisitor = (bodyNode: ts.Node): ts.Node | ts.Node[] | undefined => {
+    const complexTransformed = transformComplexDoneCallback(bodyNode, doneIdentifier, refactorCtx);
+    if (complexTransformed !== bodyNode) {
+      doneWasUsed = true;
+
+      return complexTransformed;
+    }
+
+    if (ts.isExpressionStatement(bodyNode) && ts.isCallExpression(bodyNode.expression)) {
+      const callExpr = bodyNode.expression;
+
+      // Transform `done.fail('message')` to `throw new Error('message')`
+      if (
+        ts.isPropertyAccessExpression(callExpr.expression) &&
+        ts.isIdentifier(callExpr.expression.expression) &&
+        callExpr.expression.expression.text === doneIdentifier.text &&
+        callExpr.expression.name.text === 'fail'
+      ) {
+        doneWasUsed = true;
+        reporter.reportTransformation(
+          sourceFile,
+          bodyNode,
+          'Transformed `done.fail()` to `throw new Error()`.',
+        );
+        const errorArgs = callExpr.arguments.length > 0 ? [callExpr.arguments[0]] : [];
+
+        return ts.factory.createThrowStatement(
+          ts.factory.createNewExpression(
+            ts.factory.createIdentifier('Error'),
+            undefined,
+            errorArgs,
+          ),
+        );
+      }
+
+      // Transform `promise.then(done)` or `promise.catch(done.fail)` to `await promise`
+      const promiseTransformed = transformPromiseBasedDone(callExpr, doneIdentifier, refactorCtx);
+      if (promiseTransformed) {
+        doneWasUsed = true;
+
+        return promiseTransformed;
+      }
+
+      // Remove `done()`
+      if (
+        ts.isIdentifier(callExpr.expression) &&
+        callExpr.expression.text === doneIdentifier.text
+      ) {
+        doneWasUsed = true;
+
+        return ts.setTextRange(ts.factory.createEmptyStatement(), callExpr.expression);
+      }
+    }
+
+    return ts.visitEachChild(bodyNode, bodyVisitor, tsContext);
+  };
+
+  const newBody = ts.visitNode(functionArg.body, (node: ts.Node) => {
+    if (ts.isBlock(node)) {
+      const newStatements = node.statements.flatMap(
+        (stmt) => bodyVisitor(stmt) as ts.Statement | ts.Statement[] | undefined,
+      );
+
+      return ts.factory.updateBlock(
+        node,
+        newStatements.filter((s) => !!s),
+      );
+    }
+
+    return bodyVisitor(node);
+  });
+
+  if (!doneWasUsed) {
+    return node;
+  }
+
+  reporter.reportTransformation(
+    sourceFile,
+    node,
+    `Converted test with \`done\` callback to an \`async\` test.`,
+  );
+
+  const newModifiers = [
+    ts.factory.createModifier(ts.SyntaxKind.AsyncKeyword),
+    ...(ts.getModifiers(functionArg) ?? []).filter(
+      (mod) => mod.kind !== ts.SyntaxKind.AsyncKeyword,
+    ),
+  ];
+
+  let newFunction: ts.ArrowFunction | ts.FunctionExpression;
+  if (ts.isArrowFunction(functionArg)) {
+    newFunction = ts.factory.updateArrowFunction(
+      functionArg,
+      newModifiers,
+      functionArg.typeParameters,
+      [], // remove parameters
+      functionArg.type,
+      functionArg.equalsGreaterThanToken,
+      (newBody as ts.ConciseBody) ?? ts.factory.createBlock([]),
+    );
+  } else {
+    // isFunctionExpression
+    newFunction = ts.factory.updateFunctionExpression(
+      functionArg,
+      newModifiers,
+      functionArg.asteriskToken,
+      functionArg.name,
+      functionArg.typeParameters,
+      [], // remove parameters
+      functionArg.type,
+      (newBody as ts.Block) ?? ts.factory.createBlock([]),
+    );
+  }
+
+  const newArgs = node.arguments.map((arg) => (arg === functionArg ? newFunction : arg));
+
+  return ts.factory.updateCallExpression(node, node.expression, node.typeArguments, newArgs);
+}

--- a/packages/schematics/angular/refactor/jasmine-vitest/transformers/jasmine-lifecycle_spec.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/transformers/jasmine-lifecycle_spec.ts
@@ -1,0 +1,251 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { logging } from '@angular-devkit/core';
+import { format } from 'prettier';
+import { transformJasmineToVitest } from '../test-file-transformer';
+import { RefactorReporter } from '../utils/refactor-reporter';
+
+async function expectTransformation(input: string, expected: string): Promise<void> {
+  const logger = new logging.NullLogger();
+  const reporter = new RefactorReporter(logger);
+  const transformed = transformJasmineToVitest('spec.ts', input, reporter);
+  const formattedTransformed = await format(transformed, { parser: 'typescript' });
+  const formattedExpected = await format(expected, { parser: 'typescript' });
+
+  expect(formattedTransformed).toBe(formattedExpected);
+}
+
+describe('Jasmine to Vitest Transformer', () => {
+  describe('transformDoneCallback', () => {
+    const testCases = [
+      {
+        description: 'should transform an `it` block with a done callback to an async function',
+        input: `
+          it('should do something async', (done) => {
+            setTimeout(() => {
+              expect(true).toBe(true);
+              done();
+            }, 100);
+          });
+        `,
+        expected: `
+          it('should do something async', async () => {
+            setTimeout(() => {
+              expect(true).toBe(true);
+            }, 100);
+          });
+        `,
+      },
+      {
+        description: 'should transform a promise chain with a done callback to await',
+        input: `
+          beforeEach((done) => {
+            service.init().then(() => done());
+          });
+        `,
+        expected: `
+          beforeEach(async () => {
+            await service.init().then(() => {});
+          });
+        `,
+      },
+      {
+        description: 'should transform done.fail() to throw new Error()',
+        input: `
+          it('should fail', (done) => {
+            done.fail('it failed');
+          });
+        `,
+        expected: `
+          it('should fail', async () => {
+            throw new Error('it failed');
+          });
+        `,
+      },
+      {
+        description: 'should transform an `afterEach` block with a done callback',
+        input: 'afterEach((done) => { promise.then(done); });',
+        expected: 'afterEach(async () => { await promise; });',
+      },
+      {
+        description: 'should transform a test with a function(done) signature',
+        input: `
+          it('should work with a function expression', function(done) {
+            done();
+          });
+        `,
+        expected: `
+          it('should work with a function expression', async function() {});
+        `,
+      },
+      {
+        description: 'should transform done.fail() without a message',
+        input: `it('fails', (done) => { done.fail(); });`,
+        expected: `it('fails', async () => { throw new Error(); });`,
+      },
+      {
+        description: 'should handle promise rejections via catch',
+        input: `
+          it('should handle promise rejections via catch', (done) => {
+            myPromise.catch(done.fail);
+          });
+        `,
+        expected: `
+          it('should handle promise rejections via catch', async () => {
+            await myPromise;
+          });
+        `,
+      },
+      {
+        description: 'should work with a custom done name',
+        input: `
+          it('should work with a custom done name', (finish) => {
+            setTimeout(() => {
+              finish();
+            }, 100);
+          });
+        `,
+        expected: `
+          it('should work with a custom done name', async () => {
+            setTimeout(() => {
+            }, 100);
+          });
+        `,
+      },
+      {
+        description: 'should handle done in a finally block',
+        input: `
+          it('should handle done in a finally block', (done) => {
+            try {
+              // some logic
+            } finally {
+              done();
+            }
+          });
+        `,
+        expected: `
+          it('should handle done in a finally block', async () => {
+            try {
+              // some logic
+            } finally {}
+          });
+        `,
+      },
+      {
+        description: 'should not transform a function with a parameter that is not a done callback',
+        input: `
+          it('should not transform a function with a parameter that is not a done callback', (value) => {
+            expect(value).toBe(true);
+          });
+        `,
+        expected: `
+          it('should not transform a function with a parameter that is not a done callback', (value) => {
+            expect(value).toBe(true);
+          });
+        `,
+      },
+      {
+        description: 'should handle a .then() call with a multi-statement body',
+        input: `
+          it('should handle a complex then', (done) => {
+            let myValue = false;
+            myPromise.then(() => {
+              myValue = true;
+              done();
+            });
+          });
+        `,
+        expected: `
+          it('should handle a complex then', async () => {
+            let myValue = false;
+            await myPromise.then(() => {
+              myValue = true;
+            });
+          });
+        `,
+      },
+    ];
+
+    testCases.forEach(({ description, input, expected }) => {
+      it(description, async () => {
+        await expectTransformation(input, expected);
+      });
+    });
+  });
+
+  describe('transformPending', () => {
+    const testCases = [
+      {
+        description: 'should transform a test with pending() to it.skip()',
+        input: `
+          it('is a work in progress', () => {
+            pending('Not yet implemented');
+          });
+        `,
+        expected: `
+          it.skip('is a work in progress', () => {
+              // TODO: vitest-migration: The pending() function was converted to a skipped test (\`it.skip\`).
+              // pending('Not yet implemented');
+          });
+        `,
+      },
+      {
+        description: 'should transform a test with pending() using function keyword',
+        input: `
+          it('is a work in progress', function() {
+            pending('Not yet implemented');
+          });
+        `,
+        expected: `
+          it.skip('is a work in progress', function() {
+              // TODO: vitest-migration: The pending() function was converted to a skipped test (\`it.skip\`).
+              // pending('Not yet implemented');
+          });
+        `,
+      },
+    ];
+
+    testCases.forEach(({ description, input, expected }) => {
+      it(description, async () => {
+        await expectTransformation(input, expected);
+      });
+    });
+  });
+
+  describe('transformFocusedAndSkippedTests', () => {
+    const testCases = [
+      {
+        description: 'should transform fdescribe to describe.only',
+        input: `fdescribe('My Suite', () => {});`,
+        expected: `describe.only('My Suite', () => {});`,
+      },
+      {
+        description: 'should transform fit to it.only',
+        input: `fit('My Test', () => {});`,
+        expected: `it.only('My Test', () => {});`,
+      },
+      {
+        description: 'should transform xdescribe to describe.skip',
+        input: `xdescribe('My Suite', () => {});`,
+        expected: `describe.skip('My Suite', () => {});`,
+      },
+      {
+        description: 'should transform xit to it.skip',
+        input: `xit('My Test', () => {});`,
+        expected: `it.skip('My Test', () => {});`,
+      },
+    ];
+
+    testCases.forEach(({ description, input, expected }) => {
+      it(description, async () => {
+        await expectTransformation(input, expected);
+      });
+    });
+  });
+});

--- a/packages/schematics/angular/refactor/jasmine-vitest/utils/ast-helpers.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/utils/ast-helpers.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import ts from '../../../third_party/github.com/Microsoft/TypeScript/lib/typescript';
+
+export function createViCallExpression(
+  methodName: string,
+  args: readonly ts.Expression[] = [],
+  typeArgs: ts.TypeNode[] | undefined = undefined,
+): ts.CallExpression {
+  const callee = ts.factory.createPropertyAccessExpression(
+    ts.factory.createIdentifier('vi'),
+    methodName,
+  );
+
+  return ts.factory.createCallExpression(callee, typeArgs, args);
+}
+
+export function createExpectCallExpression(
+  args: ts.Expression[],
+  typeArgs: ts.TypeNode[] | undefined = undefined,
+): ts.CallExpression {
+  return ts.factory.createCallExpression(ts.factory.createIdentifier('expect'), typeArgs, args);
+}
+
+export function createPropertyAccess(
+  expressionOrIndentifierText: ts.Expression | string,
+  name: string | ts.MemberName,
+): ts.PropertyAccessExpression {
+  return ts.factory.createPropertyAccessExpression(
+    typeof expressionOrIndentifierText === 'string'
+      ? ts.factory.createIdentifier(expressionOrIndentifierText)
+      : expressionOrIndentifierText,
+    name,
+  );
+}

--- a/packages/schematics/angular/refactor/jasmine-vitest/utils/ast-validation.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/utils/ast-validation.ts
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+/**
+ * @fileoverview This file contains helper functions for validating the structure of
+ * TypeScript AST nodes, particularly for identifying specific patterns in Jasmine tests.
+ */
+
+import ts from '../../../third_party/github.com/Microsoft/TypeScript/lib/typescript';
+
+/**
+ * If a node is a `jasmine.method()` call, returns the method name.
+ * @param node The node to check.
+ * @returns The name of the method if it's a jasmine call, otherwise undefined.
+ */
+export function getJasmineMethodName(node: ts.Node): string | undefined {
+  if (!ts.isCallExpression(node) || !ts.isPropertyAccessExpression(node.expression)) {
+    return undefined;
+  }
+
+  const pae = node.expression;
+  if (!ts.isIdentifier(pae.expression) || pae.expression.text !== 'jasmine') {
+    return undefined;
+  }
+
+  return ts.isIdentifier(pae.name) ? pae.name.text : undefined;
+}
+
+/**
+ * Checks if a node is a call expression for a specific method on the `jasmine` object.
+ * @param node The node to check.
+ * @param methodName The name of the method on the `jasmine` object.
+ * @returns True if the node is a `jasmine.<methodName>()` call.
+ */
+export function isJasmineCallExpression(
+  node: ts.Node,
+  methodName: string,
+): node is ts.CallExpression {
+  return getJasmineMethodName(node) === methodName;
+}

--- a/packages/schematics/angular/refactor/jasmine-vitest/utils/comment-helpers.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/utils/comment-helpers.ts
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import ts from '../../../third_party/github.com/Microsoft/TypeScript/lib/typescript';
+
+export function addTodoComment(node: ts.Node, message: string) {
+  let statement: ts.Node = node;
+
+  // Attempt to find the containing statement
+  while (statement.parent && !ts.isBlock(statement.parent) && !ts.isSourceFile(statement.parent)) {
+    if (ts.isExpressionStatement(statement) || ts.isVariableStatement(statement)) {
+      break;
+    }
+    statement = statement.parent;
+  }
+
+  ts.addSyntheticLeadingComment(
+    statement,
+    ts.SyntaxKind.SingleLineCommentTrivia,
+    ` TODO: vitest-migration: ${message}`,
+    true,
+  );
+}

--- a/packages/schematics/angular/refactor/jasmine-vitest/utils/refactor-context.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/utils/refactor-context.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import ts from '../../../third_party/github.com/Microsoft/TypeScript/lib/typescript';
+import { RefactorReporter } from './refactor-reporter';
+
+/**
+ * A context object that provides access to shared utilities and state
+ * throughout the transformation process.
+ */
+export interface RefactorContext {
+  /** The root ts.SourceFile node of the file being transformed. */
+  readonly sourceFile: ts.SourceFile;
+
+  /** The reporter for logging changes and TODOs. */
+  readonly reporter: RefactorReporter;
+
+  /** The official context from the TypeScript Transformer API. */
+  readonly tsContext: ts.TransformationContext;
+}
+
+/**
+ * A generic transformer function that operates on a specific type of ts.Node.
+ * @template T The specific type of AST node this transformer works on (e.g., ts.CallExpression).
+ */
+export type NodeTransformer<T extends ts.Node> = (
+  node: T,
+  refactorCtx: RefactorContext,
+) => ts.Node | readonly ts.Node[];

--- a/packages/schematics/angular/refactor/jasmine-vitest/utils/refactor-reporter.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/utils/refactor-reporter.ts
@@ -1,0 +1,73 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { logging } from '@angular-devkit/core';
+import ts from '../../../third_party/github.com/Microsoft/TypeScript/lib/typescript';
+
+export class RefactorReporter {
+  private filesScanned = 0;
+  private filesTransformed = 0;
+  private readonly todos = new Map<string, number>();
+  private readonly verboseLogs = new Map<string, string[]>();
+
+  constructor(private logger: logging.LoggerApi) {}
+
+  incrementScannedFiles(): void {
+    this.filesScanned++;
+  }
+
+  incrementTransformedFiles(): void {
+    this.filesTransformed++;
+  }
+
+  recordTodo(category: string): void {
+    this.todos.set(category, (this.todos.get(category) ?? 0) + 1);
+  }
+
+  reportTransformation(sourceFile: ts.SourceFile, node: ts.Node, message: string): void {
+    const { line } = ts.getLineAndCharacterOfPosition(
+      sourceFile,
+      ts.getOriginalNode(node).getStart(),
+    );
+    const filePath = sourceFile.fileName;
+
+    let logs = this.verboseLogs.get(filePath);
+    if (!logs) {
+      logs = [];
+      this.verboseLogs.set(filePath, logs);
+    }
+    logs.push(`L${line + 1}: ${message}`);
+  }
+
+  printSummary(verbose = false): void {
+    if (verbose && this.verboseLogs.size > 0) {
+      this.logger.info('Detailed Transformation Log:');
+      for (const [filePath, logs] of this.verboseLogs) {
+        this.logger.info(`Processing: ${filePath}`);
+        logs.forEach((log) => this.logger.info(`  - ${log}`));
+      }
+      this.logger.info(''); // Add a blank line for separation
+    }
+
+    this.logger.info('Jasmine to Vitest Refactoring Summary:');
+    this.logger.info(`- ${this.filesScanned} test file(s) scanned.`);
+    this.logger.info(`- ${this.filesTransformed} file(s) transformed.`);
+    const filesSkipped = this.filesScanned - this.filesTransformed;
+    if (filesSkipped > 0) {
+      this.logger.info(`- ${filesSkipped} file(s) skipped (no changes needed).`);
+    }
+
+    if (this.todos.size > 0) {
+      const totalTodos = [...this.todos.values()].reduce((a, b) => a + b, 0);
+      this.logger.warn(`- ${totalTodos} TODO(s) added for manual review:`);
+      for (const [category, count] of this.todos) {
+        this.logger.warn(`  - ${count}x ${category}`);
+      }
+    }
+  }
+}

--- a/packages/schematics/angular/refactor/jasmine-vitest/utils/refactor-reporter_spec.ts
+++ b/packages/schematics/angular/refactor/jasmine-vitest/utils/refactor-reporter_spec.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { logging } from '@angular-devkit/core';
+import { RefactorReporter } from './refactor-reporter';
+
+describe('RefactorReporter', () => {
+  let logger: logging.LoggerApi;
+  let reporter: RefactorReporter;
+
+  beforeEach(() => {
+    logger = {
+      info: jasmine.createSpy('info'),
+      warn: jasmine.createSpy('warn'),
+    } as unknown as logging.LoggerApi;
+    reporter = new RefactorReporter(logger);
+  });
+
+  it('should correctly increment scanned and transformed files', () => {
+    reporter.incrementScannedFiles();
+    reporter.incrementScannedFiles();
+    reporter.incrementTransformedFiles();
+    reporter.printSummary();
+
+    expect(logger.info).toHaveBeenCalledWith('Jasmine to Vitest Refactoring Summary:');
+    expect(logger.info).toHaveBeenCalledWith('- 2 test file(s) scanned.');
+    expect(logger.info).toHaveBeenCalledWith('- 1 file(s) transformed.');
+    expect(logger.info).toHaveBeenCalledWith('- 1 file(s) skipped (no changes needed).');
+  });
+
+  it('should record and count todos by category', () => {
+    reporter.recordTodo('category-a');
+    reporter.recordTodo('category-b');
+    reporter.recordTodo('category-a');
+    reporter.printSummary();
+
+    expect(logger.warn).toHaveBeenCalledWith('- 3 TODO(s) added for manual review:');
+    expect(logger.warn).toHaveBeenCalledWith('  - 2x category-a');
+    expect(logger.warn).toHaveBeenCalledWith('  - 1x category-b');
+  });
+
+  it('should not print the todos section if none were recorded', () => {
+    reporter.printSummary();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
This commit introduces the base infrastructure for an experimental jasmine-to-vitest refactoring schematic and the initial set of transformers for lifecycle functions.

The base infrastructure includes the main schematic entry point, the AST transformer driver, and various utilities for AST manipulation, validation, and reporting.

The lifecycle transformers handle:
- fdescribe/fit -> describe.only/it.only
- xdescribe/xit -> describe.skip/it.skip
- pending() -> it.skip()
- Asynchronous tests using the 'done' callback are converted to 'async/await'.

Usage:
`ng generate jasmine-to-vitest [--project <project-name>]`