### PR TITLE
feat(@angular/build): support `.test.ts` files by default in unit test builder

### DIFF
--- a/packages/angular/build/src/builders/unit-test/schema.json
+++ b/packages/angular/build/src/builders/unit-test/schema.json
@@ -36,8 +36,8 @@
       "items": {
         "type": "string"
       },
-      "default": ["**/*.spec.ts"],
-      "description": "Specifies glob patterns of files to include for testing, relative to the project root. This option also has special handling for directory paths (includes all `.spec.ts` files within) and file paths (includes the corresponding `.spec` file if one exists)."
+      "default": ["**/*.spec.ts", "**/*.test.ts"],
+      "description": "Specifies glob patterns of files to include for testing, relative to the project root. This option also has special handling for directory paths (includes all test files within) and file paths (includes the corresponding test file if one exists)."
     },
     "exclude": {
       "type": "array",


### PR DESCRIPTION
The unit test discovery logic previously had hardcoded conventions for `.spec.ts` files. This made it inflexible for projects that use other common patterns, such as `.test.ts`.

This change introduces support for `.test.ts` files by default and refactors the discovery logic to be more flexible and maintainable.

Key changes:
- The `unit-test` builder schema now includes both `**/*.spec.ts` and `**/*.test.ts` in its default `include` globs.
- The internal test discovery logic in `test-discovery.ts` is refactored to use a configurable array of test file infixes (`.spec`, `.test`).
- This allows the smart-handling of static paths (e.g., `ng test --include src/app/app.component.ts`) to correctly resolve the corresponding test file for both conventions.
- JSDoc comments and variable names have been updated to improve clarity and reflect the new, more flexible approach.