### PR TITLE
refactor(@schematics/angular): Remove zoneless prompt

### DIFF
--- a/packages/schematics/angular/application/schema.json
+++ b/packages/schematics/angular/application/schema.json
@@ -124,7 +124,6 @@
     },
     "zoneless": {
       "description": "Generate an application that does not use `zone.js`.",
-      "x-prompt": "Do you want to create a 'zoneless' application without zone.js?",
       "type": "boolean",
       "default": true
     },


### PR DESCRIPTION
Remove the zoneless prompt altogether in v21. Zoneless is the default experience.

fixes #30531
