### PR TITLE
refactor(@angular/ssr): handle promise-like results from `loadChildrenHelper`

### DIFF
--- a/packages/angular/ssr/src/routes/ng-routes.ts
+++ b/packages/angular/ssr/src/routes/ng-routes.ts
@@ -205,11 +205,13 @@ async function* handleRoute(options: {
           )
         : parentInjector;
 
-      const loadedChildRoutes = await loadChildrenHelper(
-        route,
-        compiler,
-        routeInjector,
-      ).toPromise();
+      // TODO(alanagius): replace all the below when FW 21.0.0-next.7 is out.
+      const loadChildrenHelperResult = loadChildrenHelper(route, compiler, routeInjector);
+      const loadedChildRoutes = await ('then' in loadChildrenHelperResult
+        ? (loadChildrenHelperResult as unknown as ReturnType<
+            typeof loadChildrenHelperResult.toPromise
+          >)
+        : loadChildrenHelperResult.toPromise());
 
       if (loadedChildRoutes) {
         const { routes: childRoutes, injector = routeInjector } = loadedChildRoutes;


### PR DESCRIPTION

The `loadChildrenHelper` function can return either an Observable or a Promise. This change ensures that we correctly handle both cases by checking if the return value is "thenable" before calling `.toPromise()`.

This provides compatibility with different versions of Angular framework that have different return types for `loadChildren`.

This is a temporary workaround and should be removed when Angular framework v21.0.0-next.7 is released.
