### PR TITLE
test: add `unrs-resolver` to known postinstall scripts

### DIFF
--- a/tests/legacy-cli/e2e/tests/misc/check-postinstalls.ts
+++ b/tests/legacy-cli/e2e/tests/misc/check-postinstalls.ts
@@ -7,6 +7,7 @@ const CURRENT_SCRIPT_PACKAGES: ReadonlySet<string> = new Set([
   'lmdb (install)',
   'msgpackr-extract (install)',
   'nice-napi (install)',
+  'unrs-resolver (postinstall)',
 ]);
 
 const POTENTIAL_SCRIPTS: ReadonlyArray<string> = ['preinstall', 'install', 'postinstall'];


### PR DESCRIPTION
See failure: https://github.com/angular/angular-cli/actions/runs/18489603907/job/52680140981
